### PR TITLE
Updates the build script to point to the working jruby.

### DIFF
--- a/bn
+++ b/bn
@@ -23,5 +23,5 @@ fi
 export TF_CLC_HOME=$project_root/tfs-tool
 unset GEM_HOME
 unset GEM_PATH
-$(dirname $0)/tools/jruby-1.7.3/bin/jruby -J-Xmx2048m -S buildr $*
+$(dirname $0)/tools/jruby/bin/jruby -J-Xmx2048m -S buildr $*
 

--- a/bn.cmd
+++ b/bn.cmd
@@ -1,2 +1,2 @@
-%~dp0\tools\jruby-1.7.3\bin\jruby.bat -S buildr %*
+%~dp0\tools\jruby\bin\jruby.bat -S buildr %*
 


### PR DESCRIPTION
I was trying to follow the instructions to [manually set up a development environment](https://github.com/gocd/documentation/blob/master/3/3.1.md#312-setting-it-up-manually) on Mac OS X and the command `./bn clean` failed consistently with:

> Could not find i18n-0.6.1 in any of the sources
> Run `bundle install` to install missing gems.

It looks like `./tools/jruby-1.7.3` has some missing gems, so I found another jruby installation under `./tools/jruby` folder and it just worked.
