### PR TITLE
Add missing javadoc required by Java 8

### DIFF
--- a/plugin-infra/go-plugin-api/src/com/thoughtworks/go/plugin/api/config/Option.java
+++ b/plugin-infra/go-plugin-api/src/com/thoughtworks/go/plugin/api/config/Option.java
@@ -18,7 +18,7 @@ package com.thoughtworks.go.plugin.api.config;
 
 /**
  * Option could be used to specify metadata for a Property.
- * @param <T>
+ * @param <T> type for the option value
  */
 public class Option<T> {
     private String name;
@@ -55,6 +55,7 @@ public class Option<T> {
 
     /**
      * Checks if this option has same name as the provided option
+     * @param <T> type for the option value
      * @param option the option for which name equality has to be checked
      * @return true if name matches
      */

--- a/plugin-infra/go-plugin-api/src/com/thoughtworks/go/plugin/api/material/packagerepository/PackageRevision.java
+++ b/plugin-infra/go-plugin-api/src/com/thoughtworks/go/plugin/api/material/packagerepository/PackageRevision.java
@@ -115,6 +115,7 @@ public class PackageRevision {
 
     /**
      * Gets additional data related to package revision for given key
+     * @param key for additional data
      * @return additional data related to package revision for given key
      */
     public String getDataFor(String key) {

--- a/plugin-infra/go-plugin-api/src/com/thoughtworks/go/plugin/api/task/Console.java
+++ b/plugin-infra/go-plugin-api/src/com/thoughtworks/go/plugin/api/task/Console.java
@@ -32,10 +32,10 @@ public interface Console {
 
     /**
      * Setup the console to read the input stream as standard error.
-     * <p/>
+     * <p></p>
      * This is used to connect the output of a process, to the build log. This is usually used as:
      * console.readErrorOf(process.getErrorStream());
-     * <p/>
+     * <p></p>
      * where the "process" object is of type {@link java.lang.Process}.
      *
      * @param in The input stream to read as standard error.
@@ -44,10 +44,10 @@ public interface Console {
 
     /**
      * Setup the console to read the input stream as standard output.
-     * <p/>
+     * <p></p>
      * This is used to connect the output of a process, to the build log. This is usually used as:
      * console.readOutputOf(process.getInputStream());
-     * <p/>
+     * <p></p>
      * where the "process" object is of type {@link java.lang.Process}.
      *
      * @param in The input stream to read as standard output.

--- a/plugin-infra/go-plugin-api/src/com/thoughtworks/go/plugin/api/task/EnvironmentVariables.java
+++ b/plugin-infra/go-plugin-api/src/com/thoughtworks/go/plugin/api/task/EnvironmentVariables.java
@@ -29,6 +29,7 @@ public interface EnvironmentVariables {
 
     /**
      * Write the environment variables to a {@link com.thoughtworks.go.plugin.api.task.Console}.
+     * @param console to write
      */
     void writeTo(Console console);
 

--- a/plugin-infra/go-plugin-api/src/com/thoughtworks/go/plugin/api/task/TaskConfig.java
+++ b/plugin-infra/go-plugin-api/src/com/thoughtworks/go/plugin/api/task/TaskConfig.java
@@ -40,7 +40,10 @@ public class TaskConfig extends Configuration {
     }
 
     /**
-     * The value of the specified property, or null if not found.
+     * Retrieves the value of a property.
+     * @param propertyName Name of the property (or key) in the configuration.
+     *
+     * @return the value of the specified property, or null if not found.
      */
     public String getValue(String propertyName) {
         Property property = super.get(propertyName);

--- a/plugin-infra/go-plugin-api/src/com/thoughtworks/go/plugin/api/task/TaskExecutionContext.java
+++ b/plugin-infra/go-plugin-api/src/com/thoughtworks/go/plugin/api/task/TaskExecutionContext.java
@@ -23,17 +23,20 @@ package com.thoughtworks.go.plugin.api.task;
 public interface TaskExecutionContext {
     /**
      * The environment variables that this task should run with.
+     * @return the environment variables that this task should run with.
      */
     EnvironmentVariables environment();
 
     /**
      * This Console instance will be setup such that any messages written to it will show
      * up in the build log.
+     * @return the console instance that any messages will be written to
      */
     Console console();
 
     /**
      * Working directory to be used by the task.
+     * @return the working directory to be used by the task.
      */
     String workingDir();
 }

--- a/plugin-infra/go-plugin-api/src/com/thoughtworks/go/plugin/api/task/TaskView.java
+++ b/plugin-infra/go-plugin-api/src/com/thoughtworks/go/plugin/api/task/TaskView.java
@@ -23,11 +23,15 @@ public interface TaskView {
     /**
      * Specifies the display value of this task plugin. This value is used in the job UI's task dropdown
      * as well as in the title of the task definition dialog box.
+     *
+     * @return display value for the task plugin
      */
     String displayValue();
 
     /**
      * The template for the task configuration, written using Angular.js templating language.
+     *
+     * @return Angular.js template for the task configuration
      */
     String template();
 }


### PR DESCRIPTION
JDK 8 introduces `doclint` to validate the javadoc comments. This commit adds missing javadoc entries (required by `doclint`) and fixes a few violations. [Disabling doclint](http://blog.joda.org/2014/02/turning-off-doclint-in-jdk-8-javadoc.html) could be an alternative to this, but it was pretty easy to fix the violations.

Fixes #138

More info: http://openjdk.java.net/jeps/172
