### PR TITLE
#130 - Make rspec exit after successful run.

### DIFF
--- a/server/run_rspec_tests_use_new_rails.rake
+++ b/server/run_rspec_tests_use_new_rails.rake
@@ -102,13 +102,13 @@ task "spec" => RAILS_DEPENDENCIES do
   rm_rf SPEC_SERVER_DIR
   reports_dir = File.join(File.dirname(__FILE__), 'target', 'reports', 'spec')
   puts "reports directory: " + reports_dir
-  str = 'rspec' +
+  str = File.join(File.dirname(__FILE__), '..', 'tools', 'bin', 'go.rspec') +
           ' --require rspec-extra-formatters' +
           ' --format progress' +
           ' --format TapFormatter -o ' + reports_dir + '/spec_full_report' +
           ' --format JUnitFormatter -o ' + reports_dir + '/spec_full_report.xml' +
           ' spec '
-  str=str+ "--pattern "+ ENV['spec_module']+'/**/*_spec.rb' if ENV.has_key? 'spec_module'
+  str = str + "--pattern " + ENV['spec_module'] +'/**/*_spec.rb' if ENV.has_key? 'spec_module'
   execute_under_rails(str)
 end
 

--- a/server/webapp/WEB-INF/rails.new/spec/spec_helper.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/spec_helper.rb
@@ -8,27 +8,7 @@ require 'rspec/autorun'
 # in spec/support/ and its subdirectories.
 Dir[Rails.root.join("spec/support/**/*.rb")].each { |f| require f }
 
-# Checks for pending migrations before tests are run.
-# If you are not using ActiveRecord, you can remove this line.
-ActiveRecord::Migration.check_pending! if defined?(ActiveRecord::Migration)
-
 RSpec.configure do |config|
-  # ## Mock Framework
-  #
-  # If you prefer to use mocha, flexmock or RR, uncomment the appropriate line:
-  #
-  # config.mock_with :mocha
-  # config.mock_with :flexmock
-  # config.mock_with :rr
-
-  # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
-  # config.fixture_path = "#{::Rails.root}/spec/fixtures"
-
-  # If you're not using ActiveRecord, or you'd prefer not to run each of your
-  # examples within a transaction, remove the following line or assign false
-  # instead of true.
-  # config.use_transactional_fixtures = true
-
   # If true, the base class of anonymous controllers will be inferred
   # automatically. This will be the default behavior in future versions of
   # rspec-rails.
@@ -39,4 +19,10 @@ RSpec.configure do |config|
   # the seed, which is printed after each run.
   #     --seed 1234
   config.order = "random"
+end
+
+def current_user
+  @user ||= com.thoughtworks.go.server.domain.Username.new(CaseInsensitiveString.new("some-user"), "display name")
+  @controller.stub(:current_user).and_return(@user)
+  @user
 end

--- a/tools/bin/go.rspec
+++ b/tools/bin/go.rspec
@@ -1,0 +1,26 @@
+#!/usr/bin/env jruby
+require 'rubygems'
+
+version = ">= 0"
+
+if ARGV.first
+  str = ARGV.first
+  str = str.dup.force_encoding("BINARY") if str.respond_to? :force_encoding
+  if str =~ /\A_(.*)_\z/
+    version = $1
+    ARGV.shift
+  end
+end
+
+gem 'rspec-core', version
+
+# Because of how Spring application is started from within RSpec, the
+# process will not finish, if all RSpec tests pass. Look at code in
+# rspec-core-2.14.5/lib/rspec/core/runner.rb#self.autorun to understand
+# why.
+
+require 'rspec/core'
+RSpec::Core::Runner.disable_autorun!
+
+load Gem.bin_path('rspec-core', 'rspec', version)
+exit RSpec::Core::Runner.run ARGV


### PR DESCRIPTION
For the tests, we load the Spring application context, which starts
activemq, ehcache, h2, etc. which start daemon threads, which do not
allow rspec to finish (and exit) once the tests are done (when run
using autorun).

Explicitly exit with the status code.
