### PR TITLE
Add startup banner to Development Server

### DIFF
--- a/development-utility/development-server/src/com/thoughtworks/go/server/DevelopmentServer.java
+++ b/development-utility/development-server/src/com/thoughtworks/go/server/DevelopmentServer.java
@@ -66,6 +66,14 @@ public class DevelopmentServer {
         systemEnvironment.setProperty(GoConstants.USE_COMPRESSED_JAVASCRIPT, Boolean.toString(false));
         try {
             server.startServer();
+
+            String hostName = systemEnvironment.getListenHost();
+            if(hostName == null){
+                hostName = "localhost";
+            }
+
+            System.out.println("Go server dashboard started on http://" + hostName + ":" + systemEnvironment.getServerPort());
+            System.out.println("* credentials: \"admin\" / \"badger\"");
         } catch (Exception e) {
             System.err.println("Failed to start Go server. Exception:");
             e.printStackTrace();


### PR DESCRIPTION
It helps newcomers to know how to access the Go Dashboard.

Could not find where the default credentials comes from. Would be good to refactor and build the string getting the value from the same place.
