### PR TITLE
Adding verbosity to Exception message while loading DatabaseProvider.

### DIFF
--- a/server/src/com/thoughtworks/go/server/database/DatabaseStrategy.java
+++ b/server/src/com/thoughtworks/go/server/database/DatabaseStrategy.java
@@ -85,7 +85,7 @@ public class DatabaseStrategy implements Database {
             Constructor<?> constructor = Class.forName(databaseProvider).getConstructor(SystemEnvironment.class);
             return ((Database) constructor.newInstance(systemEnvironment));
         } catch (Exception e) {
-            throw new RuntimeException("could not locate database provider:" + databaseProvider);
+            throw new RuntimeException(String.format("Failed loading database provider [%s]", databaseProvider), e);
         }
     }
 

--- a/server/test/unit/com/thoughtworks/go/server/database/DatabaseStrategyTest.java
+++ b/server/test/unit/com/thoughtworks/go/server/database/DatabaseStrategyTest.java
@@ -22,10 +22,11 @@ import com.thoughtworks.go.util.SystemEnvironment;
 import org.junit.Before;
 import org.junit.Test;
 
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.*;
 
 public class DatabaseStrategyTest {
 
@@ -81,6 +82,19 @@ public class DatabaseStrategyTest {
     public void shouldGetQueryExtensions() throws SQLException {
         databaseStrategy.getQueryExtensions();
         assertThat(database.getQueryExtensions, is(true));
+    }
+
+    @Test
+    public void shouldThrowUpWhenFailedToLoadDatabaseProvider() throws Exception {
+        when(systemEnvironment.getDatabaseProvider()).thenReturn("some.random.provider");
+        try {
+            new DatabaseStrategy(systemEnvironment);
+            fail("Should have thrown exception");
+        } catch (RuntimeException e) {
+            assertThat(e.getMessage(), is("Failed loading database provider [some.random.provider]"));
+            assertThat(e.getCause(), is(instanceOf(ClassNotFoundException.class)));
+            assertThat(e.getCause().getMessage(), is("some.random.provider"));
+        }
     }
 }
 


### PR DESCRIPTION
Actual exception wasn't being forwared in the new exception throw. This meant that inner exceptions were getting swallowed at this point and every error, either Class Load exception or Configuration exception were indicated by the same exception string. As a fix, passing along 'e' to the new exception.
