### PR TITLE
#130 - Force use of correct Java session store.

### DIFF
--- a/server/webapp/WEB-INF/rails.new/config/initializers/session_store.rb
+++ b/server/webapp/WEB-INF/rails.new/config/initializers/session_store.rb
@@ -15,4 +15,7 @@
 ##########################GO-LICENSE-END##################################
 
 # Use the same session store as Java. This is what makes us see the authentication context from Spring for example.
-Go::Application.config.session_store :java_servlet_store
+if defined?($servlet_context)
+  require 'action_controller/session/java_servlet_store'
+  Go::Application.config.session_store :java_servlet_store
+end


### PR DESCRIPTION
Rails specs fail without this change. This change loads the java_servlet_store found in jruby-rack.

Also, this makes the session_store.rb almost the same as the one found in the older Rails codebase.
