### PR TITLE
Workaround for specs to pass.

### DIFF
--- a/server/webapp/WEB-INF/rails.new/spec/controllers/api/server_controller_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/controllers/api/server_controller_spec.rb
@@ -20,7 +20,7 @@ describe Api::ServerController do
 
   before :each do
     controller.stub(:populate_health_messages) do
-      stub_server_health_messages
+      stub_server_health_messages_for_controllers
     end
     @system_environment = double('system_environment')
     @go_config_service = double('go_config_service')
@@ -42,11 +42,11 @@ describe Api::ServerController do
 
       get :info, {:format => "xml", :no_layout => true}
 
-      assigns[:base_url].should == :base_url
-      assigns[:base_ssl_url].should == :base_ssl_url
-      assigns[:artifacts_dir].should =~ /artifacts$/
-      assigns[:shine_db_path].should =~ /shineDb$/
-      assigns[:config_dir].should =~ /config$/
+      expect(assigns[:base_url]).to eq(:base_url)
+      expect(assigns[:base_ssl_url]).to eq(:base_ssl_url)
+      expect(assigns[:artifacts_dir]).to match(/artifacts$/)
+      expect(assigns[:shine_db_path]).to  match(/shineDb$/)
+      expect(assigns[:config_dir]).to match(/config$/)
     end
 
     it "should return 401 if request is not from localhost" do

--- a/server/webapp/WEB-INF/rails.new/spec/spec_helper.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/spec_helper.rb
@@ -55,7 +55,12 @@ include JavaSpecImports
 def java_date_utc(year, month, day, hour, minute, second)
   org.joda.time.DateTime.new(year, month, day, hour, minute, second, 0, org.joda.time.DateTimeZone::UTC).toDate()
 end
+
 def stub_server_health_messages
+  assign(:current_server_health_states, com.thoughtworks.go.serverhealth.ServerHealthStates.new)
+end
+
+def stub_server_health_messages_for_controllers
   assigns[:current_server_health_states] = com.thoughtworks.go.serverhealth.ServerHealthStates.new
 end
 


### PR DESCRIPTION
assign(key, value) not accessible in controller_specs. Created another method for controller_specs to do use the old assigns[]. This is a temporary workaround.
