### PR TITLE
#216 - Fixing class names lengths so that the filename does not overflow 143 characters.

### DIFF
--- a/plugin-infra/go-plugin-infra/test/com/thoughtworks/go/plugin/activation/DefaultGoPluginActivatorIntegrationTest.java
+++ b/plugin-infra/go-plugin-infra/test/com/thoughtworks/go/plugin/activation/DefaultGoPluginActivatorIntegrationTest.java
@@ -218,11 +218,11 @@ public class DefaultGoPluginActivatorIntegrationTest {
         }
 
         File bundleWithActivator = createBundleWithActivator(BUNDLE_DIR_WHICH_HAS_PROPER_ACTIVATOR, PluginAwareExtensionOuterClass.class,
-                PluginAwareExtensionOuterClass.PluginAwareExtensionNestedClass.class,
-                PluginAwareExtensionOuterClass.PluginAwareExtensionInnerClass.class,
-                PluginAwareExtensionOuterClass.PluginAwareExtensionInnerClass.PluginAwareExtensionSecondLevelInnerClass.class,
-                PluginAwareExtensionOuterClass.PluginAwareExtensionInnerClass.PluginAwareExtensionSecondLevelInnerClass.PluginAwareExtensionThirdLevelInnerClass.class,
-                PluginAwareExtensionOuterClass.PluginAwareExtensionInnerClass.PluginAwareExtensionSecondLevelSiblingInnerClassWhichDoesNotHaveADefaultConstructor.class);
+                PluginAwareExtensionOuterClass.NestedClass.class,
+                PluginAwareExtensionOuterClass.InnerClass.class,
+                PluginAwareExtensionOuterClass.InnerClass.SecondLevelInnerClass.class,
+                PluginAwareExtensionOuterClass.InnerClass.SecondLevelInnerClass.PluginAwareExtensionThirdLevelInnerClass.class,
+                PluginAwareExtensionOuterClass.InnerClass.SecondLevelSiblingInnerClassNoDefaultConstructor.class);
         BundleContext installedBundledContext = bundleContext(installBundleFoundInDirectory(bundleWithActivator));
 
         ServiceReference<?>[] references = installedBundledContext.getServiceReferences(PluginDescriptorAware.class.getName(), null);
@@ -230,9 +230,9 @@ public class DefaultGoPluginActivatorIntegrationTest {
 
         assertEquals(Arrays.toString(services), 4, services.length);
         assertEquals(PluginAwareExtensionOuterClass.class.getName(), services[0]);
-        assertEquals(PluginAwareExtensionOuterClass.PluginAwareExtensionInnerClass.class.getName(), services[1]);
-        assertEquals(PluginAwareExtensionOuterClass.PluginAwareExtensionInnerClass.PluginAwareExtensionSecondLevelInnerClass.PluginAwareExtensionThirdLevelInnerClass.class.getName(), services[2]);
-        assertEquals(PluginAwareExtensionOuterClass.PluginAwareExtensionNestedClass.class.getName(), services[3]);
+        assertEquals(PluginAwareExtensionOuterClass.InnerClass.class.getName(), services[1]);
+        assertEquals(PluginAwareExtensionOuterClass.InnerClass.SecondLevelInnerClass.PluginAwareExtensionThirdLevelInnerClass.class.getName(), services[2]);
+        assertEquals(PluginAwareExtensionOuterClass.NestedClass.class.getName(), services[3]);
     }
 
     @Test

--- a/plugin-infra/go-plugin-infra/test/com/thoughtworks/go/plugin/activation/test/PluginAwareExtensionOuterClass.java
+++ b/plugin-infra/go-plugin-infra/test/com/thoughtworks/go/plugin/activation/test/PluginAwareExtensionOuterClass.java
@@ -28,7 +28,7 @@ public class PluginAwareExtensionOuterClass implements PluginDescriptorAware {
     }
 
     @Extension
-    public static class PluginAwareExtensionNestedClass implements PluginDescriptorAware {
+    public static class NestedClass implements PluginDescriptorAware {
 
         @Override
         public void setPluginDescriptor(PluginDescriptor descriptor) {
@@ -37,14 +37,14 @@ public class PluginAwareExtensionOuterClass implements PluginDescriptorAware {
     }
 
     @Extension
-    public class PluginAwareExtensionInnerClass implements PluginDescriptorAware {
+    public class InnerClass implements PluginDescriptorAware {
 
         @Override
         public void setPluginDescriptor(PluginDescriptor descriptor) {
             throw new UnsupportedOperationException();
         }
 
-        public class PluginAwareExtensionSecondLevelInnerClass {
+        public class SecondLevelInnerClass {
 
             @Extension
             public class PluginAwareExtensionThirdLevelInnerClass implements PluginDescriptorAware {
@@ -57,12 +57,12 @@ public class PluginAwareExtensionOuterClass implements PluginDescriptorAware {
 
         }
 
-        public class PluginAwareExtensionSecondLevelSiblingInnerClassWhichDoesNotHaveADefaultConstructor {
-            public PluginAwareExtensionSecondLevelSiblingInnerClassWhichDoesNotHaveADefaultConstructor(int x) {
+        public class SecondLevelSiblingInnerClassNoDefaultConstructor {
+            public SecondLevelSiblingInnerClassNoDefaultConstructor(int x) {
             }
 
             @Extension
-            public class PluginAwareExtensionThirdLevelInnerClassWhichHasInvalidParent implements PluginDescriptorAware {
+            public class ThirdLevelInnerClassWithInvalidParent implements PluginDescriptorAware {
 
                 @Override
                 public void setPluginDescriptor(PluginDescriptor descriptor) {


### PR DESCRIPTION
This is because of a limitation in ecryptfs on Ubuntu which does not allow filename with more than 143 characters. Link to the issue on launchpad is on issue #216.
