### PR TITLE
feature: email notification for all stages of a pipeline.

### DIFF
--- a/base/src/com/thoughtworks/go/util/GoConstants.java
+++ b/base/src/com/thoughtworks/go/util/GoConstants.java
@@ -88,4 +88,5 @@ public class GoConstants {
     public static final String AGENT_PLUGINS_MD5 = "agent.plugins.md5";
     public static final String GIVEN_AGENT_LAUNCHER_JAR_MD5 = "agent.launcher.md5";
     public static final String AGENT_LAUNCHER_VERSION = "agent.launcher.version";
+    public static final String ALL_STAGES = "[All Stages]";
 }

--- a/common/src/com/thoughtworks/go/domain/NotificationFilter.java
+++ b/common/src/com/thoughtworks/go/domain/NotificationFilter.java
@@ -16,6 +16,8 @@
 
 package com.thoughtworks.go.domain;
 
+import com.thoughtworks.go.util.GoConstants;
+
 public class NotificationFilter extends PersistentObject {
     private String pipelineName;
     private String stageName;
@@ -75,7 +77,7 @@ public class NotificationFilter extends PersistentObject {
 
     public boolean matchStage(StageConfigIdentifier stageIdentifier, StageEvent event) {
         return stageIdentifier.getPipelineName().equals(pipelineName) &&
-                stageIdentifier.getStageName().equals(stageName) &&
+                (stageIdentifier.getStageName().equals(stageName) || stageName.equals(GoConstants.ALL_STAGES)) &&
                 this.event.include(event);
     }
 

--- a/common/src/com/thoughtworks/go/domain/User.java
+++ b/common/src/com/thoughtworks/go/domain/User.java
@@ -290,12 +290,4 @@ public class  User extends PersistentObject {
         });
         notificationFilters.removeAll(toBeDeleted);
     }
-
-    public boolean hasSubscribedFor(String pipelineName, String stageName) {
-        for (NotificationFilter notificationFilter : notificationFilters) {
-            if (notificationFilter.getPipelineName().equals(pipelineName) && notificationFilter.getStageName().equals(stageName))
-                return true;
-        }
-        return false;
-    }
 }

--- a/common/test/com/thoughtworks/go/domain/NotificationFilterTest.java
+++ b/common/test/com/thoughtworks/go/domain/NotificationFilterTest.java
@@ -16,6 +16,7 @@
 
 package com.thoughtworks.go.domain;
 
+import com.thoughtworks.go.util.GoConstants;
 import org.junit.Test;
 import static org.junit.Assert.assertThat;
 import static org.hamcrest.core.Is.is;
@@ -47,6 +48,18 @@ public class NotificationFilterTest {
     }
 
     @Test
+    public void shouldMatchForAllStageAllEvent() {
+        NotificationFilter filter = new NotificationFilter("cruise", GoConstants.ALL_STAGES, StageEvent.All, false);
+        assertThat(filter.matchStage(new StageConfigIdentifier("cruise", "dev"), StageEvent.All), is(true));
+    }
+
+    @Test
+    public void shouldMatchForAllStageBroken() {
+        NotificationFilter filter = new NotificationFilter("cruise", GoConstants.ALL_STAGES, StageEvent.Fails, false);
+        assertThat(filter.matchStage(new StageConfigIdentifier("cruise", "dev"), StageEvent.Fails), is(true));
+    }
+
+    @Test
     public void shouldNotMatchStageWithDifferentName() {
         NotificationFilter filter = new NotificationFilter("cruise", "xyz", StageEvent.All, false);
         assertThat(filter.matchStage(new StageConfigIdentifier("cruise", "dev"), StageEvent.All), is(false));
@@ -65,4 +78,6 @@ public class NotificationFilterTest {
                 new NotificationFilter("cruise", "dev", StageEvent.Fixed, true)), is(true));
 
     }
+
+
 }

--- a/server/src/com/thoughtworks/go/server/controller/MyGoController.java
+++ b/server/src/com/thoughtworks/go/server/controller/MyGoController.java
@@ -40,6 +40,7 @@ import com.thoughtworks.go.server.service.UserService;
 import com.thoughtworks.go.server.ui.controller.Redirection;
 import com.thoughtworks.go.server.util.UserHelper;
 import com.thoughtworks.go.server.web.JsonView;
+import com.thoughtworks.go.util.GoConstants;
 import com.thoughtworks.go.util.json.JsonMap;
 import org.apache.commons.lang.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -183,7 +184,9 @@ public class MyGoController {
     }
 
     private List<PipelineViewModel.StageViewModel> getStagesModelsFor(PipelineConfig pipelineConfig) {
-        List<PipelineViewModel.StageViewModel> stageModels = new ArrayList<PipelineViewModel.StageViewModel>();
+        List<PipelineViewModel.StageViewModel> stageModels = new ArrayList<PipelineViewModel.StageViewModel>() {{
+            add(new PipelineViewModel.StageViewModel(GoConstants.ALL_STAGES));
+        }};
         for (StageConfig stageConfig : pipelineConfig) {
             stageModels.add(new PipelineViewModel.StageViewModel(CaseInsensitiveString.str(stageConfig.name())));
         }

--- a/server/src/com/thoughtworks/go/server/service/UserService.java
+++ b/server/src/com/thoughtworks/go/server/service/UserService.java
@@ -402,8 +402,7 @@ public class UserService {
         Users users = userDao.findNotificationSubscribingUsers();
         return users.filter(new Filter<User>() {
             public boolean matches(User user) {
-                return user.hasSubscribedFor(identifier.getPipelineName(), identifier.getStageName()) &&
-                        securityService.hasViewPermissionForPipeline(user.getName(), identifier.getPipelineName());
+                return securityService.hasViewPermissionForPipeline(user.getName(), identifier.getPipelineName());
             }
         });
     }

--- a/server/test/unit/com/thoughtworks/go/server/controller/MyGoControllerTest.java
+++ b/server/test/unit/com/thoughtworks/go/server/controller/MyGoControllerTest.java
@@ -31,6 +31,7 @@ import com.thoughtworks.go.i18n.Localizer;
 import com.thoughtworks.go.server.domain.Username;
 import com.thoughtworks.go.server.service.SecurityService;
 import com.thoughtworks.go.server.service.UserService;
+import com.thoughtworks.go.util.GoConstants;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -82,9 +83,9 @@ public class MyGoControllerTest {
         assertThat((Localizer) modelAndView.getModel().get("l"), is(localizer));
 
         assertThat((String) modelAndView.getModel().get("pipelines"),
-                is("[{\"name\":\"pipeline1-1\",\"stages\":[{\"stageName\":\"stage1-1\"},{\"stageName\":\"stage1-2\"}]},"
-                        + "{\"name\":\"PIPELINE2-1\",\"stages\":[{\"stageName\":\"stage2-1\"}]},"
-                        + "{\"name\":\"pipeline3-1\",\"stages\":[{\"stageName\":\"stage3-1\"}]}]"));
+                is("[{\"name\":\"pipeline1-1\",\"stages\":[{\"stageName\":\"" + GoConstants.ALL_STAGES + "\"},{\"stageName\":\"stage1-1\"},{\"stageName\":\"stage1-2\"}]},"
+                        + "{\"name\":\"PIPELINE2-1\",\"stages\":[{\"stageName\":\"" + GoConstants.ALL_STAGES + "\"},{\"stageName\":\"stage2-1\"}]},"
+                        + "{\"name\":\"pipeline3-1\",\"stages\":[{\"stageName\":\"" + GoConstants.ALL_STAGES + "\"},{\"stageName\":\"stage3-1\"}]}]"));
     }
 
     private class MyGoControllerWithMockedUser extends MyGoController {

--- a/util/pom.xml
+++ b/util/pom.xml
@@ -26,7 +26,7 @@
 
     <parent>
         <groupId>com.thoughtworks.go</groupId>
-        <artifactId>gocd</artifactId>
+        <artifactId>main</artifactId>
         <version>1.0</version>
         <relativePath>../</relativePath>
     </parent>


### PR DESCRIPTION
This pull request allows users to add email notifications for all stages of any given pipeline.
At present one needs add notification or every stage of a given pipeline, this pull request eases this by allowing user to add a notification on all-stages of any pipeline. 

It tries to do this by introducing a new label called [ALL STAGES], returning it as part of the stages list when viewed via MyController. We've also updated the test cases and found the feature changes to work as expected to when tested locally. 

The choice for label "[ALL STAGES]" made sense to use, because its descriptive enough for the purpose and users are prohibited to create any pipelines or stages with starting with special characters.
