### PR TITLE
Trim commands in ExecTasks.

### DIFF
--- a/config/config-api/src/com/thoughtworks/go/config/ExecTask.java
+++ b/config/config-api/src/com/thoughtworks/go/config/ExecTask.java
@@ -60,7 +60,7 @@ public class ExecTask extends AbstractTask implements CommandTask {
     }
 
     public ExecTask(String command, String args, Arguments argList) {
-        this.command = command;
+        setCommand(command);
         this.args = args;
         this.argList = argList;
     }
@@ -71,13 +71,13 @@ public class ExecTask extends AbstractTask implements CommandTask {
     }
 
     private ExecTask(String command, String workingDir) {
-        this.command = command;
+        setCommand(command);
         this.workingDirectory = workingDir;
     }
 
     protected void setTaskConfigAttributes(Map attributeMap) {
         if (attributeMap.containsKey(COMMAND)) {
-            command = (String) attributeMap.get(COMMAND);
+            setCommand((String) attributeMap.get(COMMAND));
         }
         if (attributeMap.containsKey(ARG_LIST_STRING)) {
             clearCurrentArgsAndArgList();
@@ -100,6 +100,10 @@ public class ExecTask extends AbstractTask implements CommandTask {
             final String newWorkingDir = (String) attributeMap.get(WORKING_DIR);
             workingDirectory = StringUtil.isBlank(newWorkingDir) ? null : newWorkingDir;
         }
+    }
+
+    private void setCommand(String cmd) {
+        command = (cmd != null ? cmd.trim() : cmd);
     }
 
     private void clearCurrentArgsAndArgList() {

--- a/config/config-api/test/com/thoughtworks/go/config/ExecTaskTest.java
+++ b/config/config-api/test/com/thoughtworks/go/config/ExecTaskTest.java
@@ -116,6 +116,13 @@ public class ExecTaskTest {
     }
 
     @Test
+    public void shouldTrimTheCommandAttribute() throws Exception {
+        ExecTask exec = new ExecTask();
+        exec.setConfigAttributes(m(ExecTask.COMMAND, "  ls  "));
+        assertThat(exec.command(), is("ls"));
+    }
+
+    @Test
     public void shouldNotSetAttributesWhenKeysNotPresentInAttributeMap() throws Exception {
         ExecTask exec = new ExecTask();
         exec.setConfigAttributes(m(ExecTask.COMMAND, "ls", ExecTask.ARGS, "-la", ExecTask.WORKING_DIR, "my_dir"));


### PR DESCRIPTION
Trailing or leading whitespaces in commands
cause them to fail. For example "ls  " is an
invalid command.
