### PR TITLE
Use /bin/bash for Solaris installer. sh fails.

### DIFF
--- a/tools/bin/go.jruby
+++ b/tools/bin/go.jruby
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #*************************GO-LICENSE-START********************************
 # Copyright 2014 ThoughtWorks, Inc.
 #


### PR DESCRIPTION
Solaris installer generation script fails with /bin/sh. Use /bin/bash instead. It works.
