### PR TITLE
#315 - The pipeline label gets resolved.

### DIFF
--- a/common/src/com/thoughtworks/go/domain/MaterialRevision.java
+++ b/common/src/com/thoughtworks/go/domain/MaterialRevision.java
@@ -317,6 +317,4 @@ public class MaterialRevision implements Serializable {
         }
         return cardNumbers;
     }
-
-
 }

--- a/server/src/com/thoughtworks/go/server/service/dd/FanInGraph.java
+++ b/server/src/com/thoughtworks/go/server/service/dd/FanInGraph.java
@@ -407,5 +407,4 @@ public class FanInGraph {
         }
         return updatedRevisions;
     }
-
 }


### PR DESCRIPTION
- If a dependency material P1 ({material-P1}) was referred to by current pipeline P0 (with label ${material-P1}) and an upstream material pipeline P2 ({material-P2}, Triangle Dependency), and the order of materials was such that the resolution of material-P2 for the current pipeline happened before the resolution of material-P1, the name of material-P1 for pipeline P0 got changed and the resolution for the current pipeline label failed.
- The material name was getting changed during fan-in resolution. This fix restores the computed material config to actual material config after fan-in graph is generated.
