### PR TITLE
Fix #304 Git commit emails appear escaped (sometimes)

### DIFF
--- a/server/webapp/WEB-INF/rails.new/app/views/shared/_modification_for_table.html.erb
+++ b/server/webapp/WEB-INF/rails.new/app/views/shared/_modification_for_table.html.erb
@@ -1,6 +1,6 @@
 <tr class="change <%= scope[:changed_css] -%>" id="<%= scope[:id] %>">
     <td class="modified_by">
-        <%= smart_word_breaker(h(scope[:modification].getUserDisplayName())) -%><br/><%= smart_word_breaker(scope[:modification].getModifiedTime().iso8601) -%>
+        <%= h(scope[:modification].getUserDisplayName()) -%><br/><%= smart_word_breaker(scope[:modification].getModifiedTime().iso8601) -%>
     </td>
     <td class="comment">
         <%= render_comment(scope[:modification], scope[:pipeline_name]) %>

--- a/server/webapp/WEB-INF/rails/app/views/shared/_modification_for_table.html.erb
+++ b/server/webapp/WEB-INF/rails/app/views/shared/_modification_for_table.html.erb
@@ -1,6 +1,6 @@
 <tr class="change <%= scope[:changed_css] -%>" id="<%= scope[:id] %>">
     <td class="modified_by">
-        <%= smart_word_breaker(h(scope[:modification].getUserDisplayName())) -%><br/><%= smart_word_breaker(scope[:modification].getModifiedTime().iso8601) -%>
+        <%= h(scope[:modification].getUserDisplayName()) -%><br/><%= smart_word_breaker(scope[:modification].getModifiedTime().iso8601) -%>
     </td>
     <td class="comment">
         <%= render_comment(scope[:modification], scope[:pipeline_name]) %>


### PR DESCRIPTION
The build cause popup works fine without `smart_word_breaker` since data is wrapped in a `<td>`. Is there a valid case where smart_word_breaker is needed?
