### PR TITLE
#130 - Fix 'trigger with options' material search.

### DIFF
--- a/server/webapp/WEB-INF/rails.new/app/controllers/pipelines_controller.rb
+++ b/server/webapp/WEB-INF/rails.new/app/controllers/pipelines_controller.rb
@@ -17,6 +17,7 @@
 class PipelinesController < ApplicationController
   include ApplicationHelper
   layout "application", :except => ["show", "material_search", "show_for_trigger"]
+  protect_from_forgery :except => [:material_search]
 
   def build_cause
     result = HttpOperationResult.new
@@ -53,6 +54,7 @@ class PipelinesController < ApplicationController
       return
     end
     @material_type = go_config_service.materialForPipelineWithFingerprint(params[:pipeline_name], params[:fingerprint]).getType
+    render layout: false
   end
 
   def select_pipelines

--- a/server/webapp/WEB-INF/rails.new/spec/controllers/pipelines_controller_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/controllers/pipelines_controller_spec.rb
@@ -223,6 +223,7 @@ describe PipelinesController do
     get :material_search, :pipeline_name => 'pipeline', :fingerprint => 'sha', :search => 'search'
 
     expect(response).to be_success
+    expect(response).to render_template(:layout => false)
     expect(assigns[:matched_revisions]).to eq(revisions)
     expect(assigns[:material_type]).to eq("PackageMaterial")
   end
@@ -236,6 +237,7 @@ describe PipelinesController do
     post :material_search, :pipeline_name => 'pipeline', :fingerprint => 'sha', :search => 'search'
 
     expect(response).to be_success
+    expect(response).to render_template(:layout => false)
     expect(assigns[:matched_revisions]).to eq(revisions)
     expect(assigns[:material_type]).to eq("PackageMaterial")
   end


### PR DESCRIPTION
- Was failing because of CSRF protection. This shouldn't even be using
  POST. Should use GET. But, that involves too much change right now.
  Since the dashboard might be rewritten soon, leaving it as POST and
  disabling CSRF protection for only that method (which is not making
  any POST-like changes anyway).
