### PR TITLE
#130 - Fix POST => GET for old Rails.

### DIFF
--- a/server/webapp/WEB-INF/rails/config/routes.rb
+++ b/server/webapp/WEB-INF/rails/config/routes.rb
@@ -68,7 +68,7 @@ ActionController::Routing::Routes.draw do |map|
     no_layout.api_disable_agent 'api/agents/edit_agents', :action => 'edit_agents', :controller => 'api/agents', :conditions => {:method => :post}
     no_layout.agent_action "api/agents/:uuid/:action", :controller => 'api/agents', :requirements => {:action => /enable|disable|delete/}, :conditions => {:method => :post}
 
-    no_layout.pipeline_material_search "pipelines/material_search", :controller => 'pipelines', :action => 'material_search', :conditions => {:method => :post}
+    no_layout.pipeline_material_search "pipelines/material_search", :controller => 'pipelines', :action => 'material_search', :conditions => {:method => :get}
     no_layout.pipeline_show_with_option "pipelines/show_for_trigger", :controller => 'pipelines', :action => 'show_for_trigger', :conditions => {:method => :post}
     no_layout.environment_new "environments/new", :controller => 'environments', :action => 'new', :conditions => {:method => :get}
     no_layout.environment_create "environments/create", :controller => 'environments', :action => 'create', :conditions => {:method => :post}

--- a/server/webapp/WEB-INF/rails/spec/controllers/pipelines_controller_spec.rb
+++ b/server/webapp/WEB-INF/rails/spec/controllers/pipelines_controller_spec.rb
@@ -183,7 +183,7 @@ describe PipelinesController do
   end
 
   it "should resolve post to /pipelines/material_search as a call" do
-    params_from(:post, "/pipelines/material_search").should == {:controller => 'pipelines', :action => 'material_search', :no_layout => true}
+    params_from(:get, "/pipelines/material_search").should == {:controller => 'pipelines', :action => 'material_search', :no_layout => true}
   end
 
   it "should show error message if the user is not authorized to view the pipeline" do


### PR DESCRIPTION
Since Javascript is common between the two Rails versions, changing the Javascript to use GET means that both Rails apps need to be changed.
