### PR TITLE
#000 - Fix Shine failure details popup.

### DIFF
--- a/server/webapp/WEB-INF/rails.new/app/helpers/failures_helper.rb
+++ b/server/webapp/WEB-INF/rails.new/app/helpers/failures_helper.rb
@@ -35,6 +35,7 @@ LINK
 
   def failure_details_path job_id, suite_name, test_name
     failure_details_internal_path(:pipeline_name => job_id.getPipelineName(), :pipeline_counter => job_id.getPipelineCounter(), :stage_name => job_id.getStageName(),
-                                  :stage_counter => job_id.getStageCounter(), :job_name => job_id.getBuildName(), :suite_name => enc(suite_name), :test_name => enc(test_name))
+                                  :stage_counter => job_id.getStageCounter(), :job_name => job_id.getBuildName(),
+                                  :suite_name => CGI.escape(enc(suite_name)), :test_name => CGI.escape(enc(test_name)))
   end
 end

--- a/server/webapp/WEB-INF/rails.new/spec/helpers/failures_helper_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/helpers/failures_helper_spec.rb
@@ -45,10 +45,8 @@ describe FailuresHelper do
     end
 
     it "should render anchor and js for failed_test details" do
-      job_id = JobIdentifier.new("foo", 12, "label-1020", "bar", "34", "baz")
-      failure_details_link(job_id, "suite", "test").should == <<VAR
-<a href='#{failure_details_path(job_id, "suite", "test")}' id="for_fbh_failure_details_foo/12/bar/34/baz_suite_test" class="fbh_failure_detail_button" title='View failure details'>[Trace]</a>
-VAR
+      job_id = JobIdentifier.new("pipeline1", 1234, "pip-label-1", "defaultStage", "5678", "defaultJob")
+      failure_details_link(job_id, "cruise.testing.JUnit", "a").should == %Q{<a href='/failures/pipeline1/1234/defaultStage/5678/defaultJob/Y3J1aXNlLnRlc3RpbmcuSlVuaXQ%253D%250A/YQ%253D%253D%250A' id="for_fbh_failure_details_pipeline1/1234/defaultStage/5678/defaultJob_cruise.testing.JUnit_a" class="fbh_failure_detail_button" title='View failure details'>[Trace]</a>\n}
     end
   end
 end

--- a/server/webapp/WEB-INF/rails/spec/helpers/failures_helper_spec.rb
+++ b/server/webapp/WEB-INF/rails/spec/helpers/failures_helper_spec.rb
@@ -45,10 +45,8 @@ describe FailuresHelper do
     end
 
     it "should render anchor and js for failed_test details" do
-      job_id = JobIdentifier.new("foo", 12, "label-1020", "bar", "34", "baz")
-      failure_details_link(job_id, "suite", "test").should == <<VAR
-<a href='#{failure_details_path(job_id, "suite", "test")}' id="for_fbh_failure_details_foo/12/bar/34/baz_suite_test" class="fbh_failure_detail_button" title='View failure details'>[Trace]</a>
-VAR
+      job_id = JobIdentifier.new("pipeline1", 1234, "pip-label-1", "defaultStage", "5678", "defaultJob")
+      failure_details_link(job_id, "cruise.testing.JUnit", "a").should == %Q{<a href='/failures/pipeline1/1234/defaultStage/5678/defaultJob/Y3J1aXNlLnRlc3RpbmcuSlVuaXQ%253D%250A/YQ%253D%253D%250A' id="for_fbh_failure_details_pipeline1/1234/defaultStage/5678/defaultJob_cruise.testing.JUnit_a" class="fbh_failure_detail_button" title='View failure details'>[Trace]</a>\n}
     end
   end
 end


### PR DESCRIPTION
- The "[Trace]" link in the Shine "Tests" tab was not working since the URL was not escaped properly. Fix that.
- Also, now it has a proper test, which catches this issue.
