### PR TITLE
#466 - Make behaviour of appliesTo and matchStage same.

### DIFF
--- a/common/src/com/thoughtworks/go/domain/NotificationFilter.java
+++ b/common/src/com/thoughtworks/go/domain/NotificationFilter.java
@@ -76,14 +76,7 @@ public class NotificationFilter extends PersistentObject {
     }
 
     public boolean matchStage(StageConfigIdentifier stageIdentifier, StageEvent event) {
-        boolean anyPipelineAndStage = this.pipelineName.equals(GoConstants.ANY_PIPELINE) && this.stageName.equals(GoConstants.ANY_STAGE);
-        if (anyPipelineAndStage && this.event.include(event)) {
-            return true;
-        }
-
-        return stageIdentifier.getPipelineName().equals(pipelineName) &&
-               (stageIdentifier.getStageName().equals(stageName) || stageName.equals(GoConstants.ANY_STAGE)) &&
-               this.event.include(event);
+        return this.event.include(event) && appliesTo(stageIdentifier.getPipelineName(), stageIdentifier.getStageName());
     }
 
     public boolean appliesTo(String pipelineName, String stageName) {

--- a/common/test/com/thoughtworks/go/domain/NotificationFilterTest.java
+++ b/common/test/com/thoughtworks/go/domain/NotificationFilterTest.java
@@ -86,6 +86,14 @@ public class NotificationFilterTest {
     }
 
     @Test
+    public void specificStageShouldMatchWithinAnyPipeline() {
+        NotificationFilter filter = new NotificationFilter(GoConstants.ANY_PIPELINE, "dev", StageEvent.Breaks, false);
+        assertThat(filter.matchStage(new StageConfigIdentifier("cruise1", "dev"), StageEvent.Breaks), is(true));
+        assertThat(filter.matchStage(new StageConfigIdentifier("cruise2", "dev"), StageEvent.Breaks), is(true));
+        assertThat(filter.matchStage(new StageConfigIdentifier("cruise2", "not-dev"), StageEvent.Breaks), is(false));
+    }
+
+    @Test
     public void anyPipelineAndAnyStageShouldAlwaysApply() {
         NotificationFilter filter = new NotificationFilter(GoConstants.ANY_PIPELINE, GoConstants.ANY_STAGE, StageEvent.Breaks, false);
         assertThat(filter.appliesTo("cruise2", "dev"), is(true));
@@ -107,5 +115,13 @@ public class NotificationFilterTest {
     public void shouldNotApplyIfStageDiffers() {
         NotificationFilter filter = new NotificationFilter("cruise2", "devo", StageEvent.Breaks, false);
         assertThat(filter.appliesTo("cruise2", "dev"), is(false));
+    }
+
+    @Test
+    public void specificStageShouldApplyToAnyPipeline() {
+        NotificationFilter filter = new NotificationFilter(GoConstants.ANY_PIPELINE, "dev", StageEvent.Breaks, false);
+        assertThat(filter.appliesTo("cruise1", "dev"), is(true));
+        assertThat(filter.appliesTo("cruise2", "dev"), is(true));
+        assertThat(filter.appliesTo("cruise2", "not-dev"), is(false));
     }
 }


### PR DESCRIPTION
Based on conversation [here](https://github.com/gocd/gocd/pull/466#issuecomment-54858718) and [here](https://github.com/gocd/gocd/pull/466#issuecomment-54869963), making stageMatches and appliesTo almost the same, except that stageMatches checks the event type as well.
