### PR TITLE
#469 - Keep session alive for 2 weeks.

### DIFF
--- a/server/webapp/WEB-INF/webdefault.xml
+++ b/server/webapp/WEB-INF/webdefault.xml
@@ -171,5 +171,9 @@
         <url-pattern>/help/*</url-pattern>
     </servlet-mapping>
 
+    <!-- Do not timeout idle/stale sessions for 14 days: 60 * 24 * 14 minutes. -->
+    <session-config>
+        <session-timeout>20160</session-timeout>
+    </session-config>
 </web-app>
 


### PR DESCRIPTION
Should not time out idle sessions in 30 minutes. See discussion at:
https://groups.google.com/forum/#!topic/go-cd/Ta6zdTPjlkM
