### PR TITLE
#000 - Fix Rails specs.

### DIFF
--- a/server/webapp/WEB-INF/rails.new/spec/views/environments/edit_variables_html_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/views/environments/edit_variables_html_spec.rb
@@ -44,8 +44,8 @@ describe "environments/edit_variables.html.erb" do
   # Capybara does not understand how to search for an input tag *inside* a textarea.
   it "should have a template for newly added environment variables" do
     textarea_tag = 'textarea id="environment_variables_template"'
-    name_input = 'input class=".*environment_variable_name" id="environment_variables__name"'
-    value_input = 'input class="form_input environment_variable_value" id="environment_variables__valueForDisplay"'
+    name_input = 'input class=".*environment_variable_name" name="environment\[variables\]\[\]\[name\]"'
+    value_input = 'input class="form_input environment_variable_value" name="environment\[variables\]\[\]\[valueForDisplay\]"'
 
     expect(response.body).to match Regexp.new("#{textarea_tag}.*\n.*#{name_input}.*\n.*#{value_input}")
   end


### PR DESCRIPTION
- Since the omit_id_generation functionality was brought back as a part of commits
  d6aa580268cb3763e0367563d9776fa20f53233b and c4936a2532373d8e8ac9583263a76fcf56a1696c,
  the ID was not generated for environment variables edit scenario. The spec was asserting
  against the ID. Removed it. Now, it does an assertion against the name of the input
  element.
