### PR TITLE
Fix UI glitch with webkit hi-res rendering for #482

### DIFF
--- a/server/webapp/WEB-INF/rails.new/app/assets/stylesheets/module.scss
+++ b/server/webapp/WEB-INF/rails.new/app/assets/stylesheets/module.scss
@@ -2925,6 +2925,7 @@ li.task_property {
     width: inherit;
     margin: 0;
     height: 30px;
+    position: static;
 }
 
 .vsm-entity.material .more {

--- a/server/webapp/stylesheets/module.css
+++ b/server/webapp/stylesheets/module.css
@@ -2925,6 +2925,7 @@ li.task_property {
     width: inherit;
     margin: 0;
     height: 30px;
+    position: static;
 }
 
 .vsm-entity.material .more {


### PR DESCRIPTION
These changes should fix material circle is not properly rendering when shown in chrome in high resolution machines - MBP Retina.
