### PR TITLE
#130 - Fix script tag. Fixes many issues.

### DIFF
--- a/server/webapp/WEB-INF/vm/shared/_header.vm
+++ b/server/webapp/WEB-INF/vm/shared/_header.vm
@@ -63,7 +63,7 @@
 
     #end
     #if ($useCompressJS || $useNewRails)
-        <script src="$req.getContextPath()/$concatenatedJavascriptFilePath" type="text/javascript">
+        <script src="$req.getContextPath()/$concatenatedJavascriptFilePath" type="text/javascript"></script>
     #else
         <script src="$req.getContextPath()/javascripts/lib/jquery-1.7.2.js?#include("admin/admin_version.txt.vm")" type="text/javascript"></script>
         <script src="$req.getContextPath()/javascripts/lib/bootstrap-2.3.2.min.js?#include("admin/admin_version.txt.vm")" type="text/javascript"></script>


### PR DESCRIPTION
Because of the script tag not being closed, the next script, which was
the one which set contextPath (var contextPath = ...) was not getting
executed. Was causing many pages to fail rendering.
