### PR TITLE
Output working directory in console output and when polling fails.

### DIFF
--- a/common/src/com/thoughtworks/go/domain/materials/git/GitCommand.java
+++ b/common/src/com/thoughtworks/go/domain/materials/git/GitCommand.java
@@ -79,7 +79,7 @@ public class GitCommand extends SCMCommand {
                 fetchAndResetToHead(outputStreamConsumer);
             }
         } catch (Exception e) {
-            throw new RuntimeException(outputStreamConsumer.getStdError(), e);
+            throw new RuntimeException(String.format("Working directory: %s\n%s", workingDir, outputStreamConsumer.getStdError()), e);
         }
 
         CommandLine gitCmd = git().withArg("log").withArgs(args).withWorkingDir(workingDir);
@@ -119,6 +119,7 @@ public class GitCommand extends SCMCommand {
 
 
     public void fetchAndReset(ProcessOutputStreamConsumer outputStreamConsumer, Revision revision) {
+        outputStreamConsumer.stdOutput(String.format("[GIT] Fetch and reset in working directory %s", workingDir));
         cleanAllUnversionedFiles(outputStreamConsumer);
         removeSubmoduleSectionsFromGitConfig(outputStreamConsumer);
         fetch(outputStreamConsumer);


### PR DESCRIPTION
When the git commands that update a material fail, this makes it easy to
find the flyweight directory on the server for debugging.
