### PR TITLE
Switching flow for assets:precompile in case of Windows

### DIFF
--- a/server/prepare_go_server_webapp.rake
+++ b/server/prepare_go_server_webapp.rake
@@ -204,8 +204,17 @@ end
 
 task :precompile_assets do
   ruby = File.expand_path('../../tools/bin', __FILE__) + (Gem.win_platform? ? '/go.jruby.bat' : '/go.jruby')
-  classpath = File.read("target/server-test-dependencies")
-  sh "cd #{File.join("webapp/WEB-INF/rails.new")} && CLASSPATH=#{classpath} RAILS_ENV=production #{ruby} -S rake assets:clobber assets:precompile"
+  if Gem.win_platform?
+    server_test_dependency_file_path = File.join("target", "server-test-dependencies")
+    system <<END
+    cd #{File.join("webapp/WEB-INF/rails.new")};
+    set /p CLASSPATH=<#{server_test_dependency_file_path};
+    RAILS_ENV=production #{ruby} -S rake assets:clobber assets:precompile;
+END
+  else
+    classpath = File.read("target/server-test-dependencies")
+    sh "cd #{File.join("webapp/WEB-INF/rails.new")} && CLASSPATH=#{classpath} RAILS_ENV=production #{ruby} -S rake assets:clobber assets:precompile"
+  end
 end
 
 task :create_all_js_rails2 do


### PR DESCRIPTION
Because of the character limitation on Windows Command Line, the existing CLASSPATH assignment was failing. The commandline was exceeding 17000 characters while the limit is ~8000. Spilting the commands into multiple line and echoing the CLASSPATH value from a file rather than having it as part of the command line.
