### PR TITLE
#480 - Making the ERBRenderer issue not happen on dev.

### DIFF
--- a/server/webapp/WEB-INF/rails.new/config/application.rb
+++ b/server/webapp/WEB-INF/rails.new/config/application.rb
@@ -34,7 +34,9 @@ module Go
         match '*url', via: :all, to: 'application#unresolved'
       end
     end
+
     config.assets.enabled = true
     config.serve_static_assets = true
+    config.fail_if_unable_to_register_renderer = true
   end
 end

--- a/server/webapp/WEB-INF/rails.new/config/environments/development.rb
+++ b/server/webapp/WEB-INF/rails.new/config/environments/development.rb
@@ -27,4 +27,5 @@ Go::Application.configure do
   config.assets.raise_runtime_errors=true
 
   config.java_services_cache = :ServiceCache
+  config.fail_if_unable_to_register_renderer = false
 end

--- a/server/webapp/WEB-INF/rails.new/config/environments/production.rb
+++ b/server/webapp/WEB-INF/rails.new/config/environments/production.rb
@@ -78,4 +78,5 @@ Go::Application.configure do
   config.log_formatter = ::Logger::Formatter.new
 
   config.java_services_cache = :ServiceCache
+  config.fail_if_unable_to_register_renderer = true
 end

--- a/server/webapp/WEB-INF/rails.new/config/environments/test.rb
+++ b/server/webapp/WEB-INF/rails.new/config/environments/test.rb
@@ -31,6 +31,7 @@ Go::Application.configure do
   config.action_controller.allow_forgery_protection = false
 
   config.java_services_cache = :TestServiceCache
+  config.fail_if_unable_to_register_renderer = true
 
   # Tell Action Mailer not to deliver emails to the real world.
   # The :test delivery method accumulates sent emails in the

--- a/server/webapp/WEB-INF/rails.new/lib/spring.rb
+++ b/server/webapp/WEB-INF/rails.new/lib/spring.rb
@@ -36,7 +36,12 @@ class Spring
       MUTEX.synchronize do
         if (!@context)
           @context =  load_context
-          self.bean("viewRenderingService").registerRenderer(com.thoughtworks.go.plugins.presentation.Renderer.ERB, ErbRenderer.new) if @context
+          begin
+            self.bean("viewRenderingService").registerRenderer(com.thoughtworks.go.plugins.presentation.Renderer.ERB, ErbRenderer.new) if @context
+          rescue => e
+            raise $! if Rails.configuration.fail_if_unable_to_register_renderer
+            puts "WARNING: Failed to register renderer. Continuing, though: #{e}"
+          end
         end
       end
     end


### PR DESCRIPTION
The issue is described here: https://github.com/gocd/gocd/issues/480. Making
it not happen on the development server.
