### PR TITLE
#000 - Fix inline ERB partials.

### DIFF
--- a/server/prepare_go_server_webapp.rake
+++ b/server/prepare_go_server_webapp.rake
@@ -352,7 +352,7 @@ def inline_partials dir = RAILS_INTERPOLATED_VIEWS
 end
 
 def erb_ruby call
-  return call.scan(/\A<%=\s*(.+?)\s*-?%>\Z/m).flatten[0]
+  return call.scan(/\A<%==*\s*(.+?)\s*-?%>\Z/m).flatten[0]
 end
 
 def args_of_fn fn_name, call
@@ -377,7 +377,7 @@ def locals_hash call
 end
 
 def inline_partial_render_calls file, depth
-  inline_render_calls(File.read(file), file, /<%=\s*render\s*\:partial.*?%>/m, depth)
+  inline_render_calls(File.read(file), file, /<%==*\s*render[\s(]*\:partial.*?%>/m, depth)
 end
 
 def inline_render_calls buffer, file, scanned_by, depth
@@ -411,7 +411,7 @@ def actual_partial_path partial_path
 end
 
 def inline_json_render_calls buffer, file, depth
-  buffer = inline_render_calls(buffer, file, /<%=\s*render_json\s*\:partial.*?%>/m, depth) do |sub_buffer|
+  buffer = inline_render_calls(buffer, file, /<%==*\s*render_json[\s(]*\:partial.*?%>/m, depth) do |sub_buffer|
     placeholder_map = {}
     sub_buffer.scan(/<%.*?%>/m).flatten.each do |match_ruby|
       key = SecureRandom.uuid


### PR DESCRIPTION
Fix the inline of partials done in the package step of Go (where render :partial => abc gets inlined into the place it is called.

Previously patterns of this format were supported:
<%= render :partial => ... %>
<%= render_json :partial => ... %>

Fixes are:
1. Handle 'render(:partial => ...)'.
2. Handle 'render_json(:partial => ...)'.
3. Handle '<%== render_json(:partial => ...)' since it is used by ERB of Rails 4.
