### PR TITLE
Adding a z-index to pipeline-history build cause popup.

### DIFF
--- a/server/webapp/WEB-INF/rails.new/app/assets/stylesheets/css/pipeline-history.scss
+++ b/server/webapp/WEB-INF/rails.new/app/assets/stylesheets/css/pipeline-history.scss
@@ -346,6 +346,7 @@ new-pipeline-history .popup table tbody td {
 .popup-open .popup
 {
     display: block;
+    z-index: 5000;
 }
 
 .popup-closed .popup


### PR DESCRIPTION
The popup was going under the header when we have only 1 instance of pipeline run with more than 2 materials in the build-cause popup. I'm assuming that the bottom limit was the footer and hence the popup was moved up. Adding a z-index:5000 makes this popup appear over the header.
