### PR TITLE
Run git submodule sync between git submodule init and update.

### DIFF
--- a/common/test/com/thoughtworks/go/domain/materials/git/GitCommandTest.java
+++ b/common/test/com/thoughtworks/go/domain/materials/git/GitCommandTest.java
@@ -445,6 +445,24 @@ public class GitCommandTest {
         clonedCopy.fetchAndReset(outputStreamConsumer, new StringRevision("HEAD"));
     }
 
+    @Test
+    public void shouldAllowSubmoduleUrlstoChange() throws Exception {
+        InMemoryStreamConsumer outputStreamConsumer = inMemoryConsumer();
+        GitSubmoduleRepos submoduleRepos = new GitSubmoduleRepos();
+        String submoduleDirectoryName = "local-submodule";
+        File cloneDirectory = createTempWorkingDirectory();
+
+        File remoteSubmoduleLocation = submoduleRepos.addSubmodule(SUBMODULE, submoduleDirectoryName);
+
+        GitCommand clonedCopy = new GitCommand(null, cloneDirectory, GitMaterialConfig.DEFAULT_BRANCH, false);
+        clonedCopy.cloneFrom(outputStreamConsumer, submoduleRepos.mainRepo().getUrl());
+        clonedCopy.fetchAndResetToHead(outputStreamConsumer);
+
+        submoduleRepos.changeSubmoduleUrl(submoduleDirectoryName);
+
+        clonedCopy.fetchAndResetToHead(outputStreamConsumer);
+    }
+
     private List<File> allFilesIn(File directory, String prefixOfFiles) {
         return new ArrayList<File>(FileUtils.listFiles(directory, andFileFilter(fileFileFilter(), prefixFileFilter(prefixOfFiles)), null));
     }

--- a/common/test/com/thoughtworks/go/helper/GitSubmoduleRepos.java
+++ b/common/test/com/thoughtworks/go/helper/GitSubmoduleRepos.java
@@ -21,6 +21,7 @@ import com.thoughtworks.go.config.materials.git.GitMaterialConfig;
 import com.thoughtworks.go.domain.materials.Modification;
 import com.thoughtworks.go.domain.materials.TestSubprocessExecutionContext;
 import com.thoughtworks.go.domain.materials.git.GitCommand;
+import com.thoughtworks.go.domain.materials.mercurial.StringRevision;
 import com.thoughtworks.go.util.TestFileUtil;
 import org.apache.commons.io.FileUtils;
 
@@ -136,5 +137,19 @@ public class GitSubmoduleRepos extends TestRepo {
 
     @Override public GitMaterial material() {
         return new GitMaterial(remoteRepoDir.getAbsolutePath());
+    }
+
+    public void changeSubmoduleUrl(String submoduleName) throws Exception {
+        File newSubmodule = createRepo("new-submodule");
+        addAndCommitNewFile(newSubmodule, "new", "make a commit");
+
+        git(remoteRepoDir).changeSubmoduleUrl(submoduleName, newSubmodule.getAbsolutePath());
+        git(remoteRepoDir).submoduleSync();
+
+        git(new File(remoteRepoDir, "local-submodule")).fetch(inMemoryConsumer());
+        git(new File(remoteRepoDir, "local-submodule")).resetHard(inMemoryConsumer(), new StringRevision("origin/master"));
+        git(remoteRepoDir).add(new File(".gitmodules"));
+        git(remoteRepoDir).add(new File("local-submodule"));
+        git(remoteRepoDir).commit("change submodule url");
     }
 }


### PR DESCRIPTION
This is a fix for #548. Currently when git submodule urls change, both
server and agents are unable to get materials and must be manually
fixed.
