### PR TITLE
#540 - Fix VSM actions button position.

### DIFF
--- a/server/webapp/WEB-INF/rails.new/app/assets/stylesheets/module.scss
+++ b/server/webapp/WEB-INF/rails.new/app/assets/stylesheets/module.scss
@@ -2914,6 +2914,7 @@ li.task_property {
     height: 110px;
     width: 110px;
     overflow: hidden;
+    z-index: 1;
 }
 
 .vsm-entity.material .icon {
@@ -2928,7 +2929,6 @@ li.task_property {
     width: inherit;
     margin: 0;
     height: 30px;
-    position: static;
 }
 
 .vsm-entity.material .more {

--- a/server/webapp/stylesheets/module.css
+++ b/server/webapp/stylesheets/module.css
@@ -2911,6 +2911,7 @@ li.task_property {
     height: 110px;
     width: 110px;
     overflow: hidden;
+    z-index: 1;
 }
 
 .vsm-entity.material .icon {
@@ -2925,7 +2926,6 @@ li.task_property {
     width: inherit;
     margin: 0;
     height: 30px;
-    position: static;
 }
 
 .vsm-entity.material .more {


### PR DESCRIPTION
For #540, this should fix issues 2 and 3, across all resolutions and all cases (that I know of), and the issue of #482. This switches back to absolute positioning, which is the right thing to do here (since the position is really the same, regardless of the other items around it).

The z-index change is a bit of a hack for what looks like a Chrome bug (manifested as #482). If you reduce the height of the browser window, then you'll see that the action bar comes above the material's (circular) element, without this z-index change. This doesn't happen in Firefox.
