### PR TITLE
Solaris build script fixes

### DIFF
--- a/tasks/buildr_extensions.rake
+++ b/tasks/buildr_extensions.rake
@@ -275,7 +275,7 @@ module SolarisPackageHelper
 
       ["#{package}.sh", "go-#{package}"].each do |file_name|
         sol_pkg_file = sol_pkg_file(name_with_version, file_name)
-        puts "CHMOD 777 for file #{sol_pkg_file}"
+        puts "CHMOD 0755 for file #{sol_pkg_file}"
         FileUtils.chmod 0755, sol_pkg_file
       end
 


### PR DESCRIPTION
Made them use ruby/rake APIs rather than using `sh` for everything.
