### PR TITLE
#297 - Fix transparent resource dropdown.

### DIFF
--- a/server/webapp/WEB-INF/rails.new/app/assets/stylesheets/css_sass/gadgets/dropdowns.scss
+++ b/server/webapp/WEB-INF/rails.new/app/assets/stylesheets/css_sass/gadgets/dropdowns.scss
@@ -54,11 +54,10 @@
  * ==INTERACTIONS
  */
 
-.enhanced_dropdown{
-    overflow: hidden;
+.enhanced_dropdown {
     max-height: 30em;
-
 }
+
 .enhanced_dropdown .scrollable_panel {
     max-height: 17em;
     overflow-x: hidden;

--- a/server/webapp/sass/gadgets/dropdowns.scss
+++ b/server/webapp/sass/gadgets/dropdowns.scss
@@ -55,10 +55,9 @@
  */
 
 .enhanced_dropdown{
-    overflow: hidden;
     max-height: 30em;
-
 }
+
 .enhanced_dropdown .scrollable_panel {
     max-height: 17em;
     overflow-x: hidden;


### PR DESCRIPTION
The value of the CSS attribute "overflow" [was set to "visible"](https://github.com/gocd/gocd/blob/master/server/webapp/sass/gadgets/dropdowns.scss#L28) (the
correct value) for the enhanced_dropdown class. Then, in the same file
(dropdowns.scss), the value was changed to "hidden", which is the wrong
value.

Chrome behaved differently from Firefox in this case (unknown reason).
