### PR TITLE
#297 - Fix action button alignment.

### DIFF
--- a/server/webapp/WEB-INF/rails.new/app/assets/stylesheets/css_sass/gadgets/dropdowns.scss
+++ b/server/webapp/WEB-INF/rails.new/app/assets/stylesheets/css_sass/gadgets/dropdowns.scss
@@ -91,6 +91,7 @@
 }
 .enhanced_dropdown .add_panel button.primary {
     margin-left: 10px;
+    margin-right: 10px;
     width: 100px;
 }
 *+html .enhanced_dropdown .add_panel .new_field{

--- a/server/webapp/sass/gadgets/dropdowns.scss
+++ b/server/webapp/sass/gadgets/dropdowns.scss
@@ -91,6 +91,7 @@
 }
 .enhanced_dropdown .add_panel button.primary {
     margin-left: 10px;
+    margin-right: 10px;
     width: 100px;
 }
 *+html .enhanced_dropdown .add_panel .new_field{


### PR DESCRIPTION
[This is related to #297 and #638.]

For resources dropdown and user summary dropdown, the 'Apply' or 'Add' buttons did not have enough margin and were looking bad.

[I don't know how to make this images smaller, without doing it locally]
#### Agents dropdown:

**Before**

![1_agent_resources_before](https://cloud.githubusercontent.com/assets/172235/4593642/c19db316-5087-11e4-9489-ddc70db09842.png)

**After**

![2_agent_resources_after](https://cloud.githubusercontent.com/assets/172235/4593651/d2a00984-5087-11e4-9809-c75bf6bfce61.png)
#### User summary - roles dropdown:

**Before**

![4_usersummary_roles_after](https://cloud.githubusercontent.com/assets/172235/4593656/d963fb7c-5087-11e4-80ea-6037b80a4f23.png)

**After**

![3_usersummary_roles_before](https://cloud.githubusercontent.com/assets/172235/4593645/c902c358-5087-11e4-836e-a47facb904dc.png)
