### PR TITLE
#469, #506 - Fix session timeout properly.

### DIFF
--- a/server/webapp/WEB-INF/web.xml
+++ b/server/webapp/WEB-INF/web.xml
@@ -260,4 +260,9 @@
         <extension>svg</extension>
         <mime-type>image/svg+xml</mime-type>
     </mime-mapping>
+
+    <!-- Do not timeout idle/stale sessions for 14 days: 60 * 24 * 14 minutes. -->
+    <session-config>
+        <session-timeout>20160</session-timeout>
+    </session-config>
 </web-app>

--- a/server/webapp/WEB-INF/webdefault.xml
+++ b/server/webapp/WEB-INF/webdefault.xml
@@ -170,10 +170,5 @@
         <servlet-name>default</servlet-name>
         <url-pattern>/help/*</url-pattern>
     </servlet-mapping>
-
-    <!-- Do not timeout idle/stale sessions for 14 days: 60 * 24 * 14 minutes. -->
-    <session-config>
-        <session-timeout>20160</session-timeout>
-    </session-config>
 </web-app>
 


### PR DESCRIPTION
Proper fix for issue #469. Earlier "fix" was #506. It was wrong.

Sorry. I had mentioned on the [thread]() that the change should be on web.xml. But, in #506, I changed webdefault.xml by mistake. Jetty's internal web.xml overrides whatever is defined in webdefault.xml. However, the webapp's web.xml is used towards the end and can override Jetty's web.xml.
