### PR TITLE
#371 - Fix dashboard JSON - can administer and locking

### DIFF
--- a/server/webapp/WEB-INF/rails.new/app/views/pipelines/dashboard.json.erb
+++ b/server/webapp/WEB-INF/rails.new/app/views/pipelines/dashboard.json.erb
@@ -8,10 +8,12 @@
     "pipelines": [
       <%- pipeline_group.getPipelineModels().each_with_index do |pipeline_model, pipeline_index| -%>
       <%- is_last_pipeline = pipeline_index == pipeline_group.getPipelineModels().count - 1 -%>
+      <%- latest_instance = pipeline_model.getLatestPipelineInstance -%>
       {
         "name": <%== pipeline_model.getName().to_json %>,
         "can_administer": <%== pipeline_model.canAdminister().to_json %>,
         "settings_path": <%== pipeline_edit_path(:pipeline_name => pipeline_model.getName(), :current_tab => "general").to_json %>,
+        "is_locked": <%== ((not latest_instance.nil?) and latest_instance.isCurrentlyLocked).to_json %>,
 
         <%-# ====== ====== EVERY CURRENTLY RUNNING INSTANCE OF THIS PIPELINE ====== ====== -%>
         "instances": [
@@ -55,8 +57,8 @@
 
 
         <%-# ====== ====== PREVIOUS RUN INFO (TO SHOW WHETHER THIS STAGE FAILED BEFORE ...) ====== ====== -%>
-        <%- if pipeline_model.getLatestPipelineInstance().isAnyStageActive() -%>
-        <%- active_stage = pipeline_model.getLatestPipelineInstance().activeStage() -%>
+        <%- if ((not latest_instance.nil?) and latest_instance.isAnyStageActive()) -%>
+        <%- active_stage = latest_instance.activeStage() -%>
         <%- if active_stage.hasPreviousStage() -%>
         "previous_instance": { <%# TODO: Handle previously blurb. %>
           "result": <%== active_stage.getPreviousStage().getResult().to_s.to_json %>,
@@ -71,6 +73,12 @@
         <%- is_paused = pipeline_model.getPausedInfo().isPaused() -%>
         "available_operations": [
         <%- if pipeline_model.canOperate() -%>
+          <%- if ((not latest_instance.nil?) and latest_instance.isCurrentlyLocked and latest_instance.canUnlock) -%>
+          {
+            "operation": "unlock",
+            "operation_path": <%== api_pipeline_action_path(:pipeline_name => pipeline_model.getName(), :action => "releaseLock").to_json %>
+          },
+          <%- end -%>
           {
             "operation": "trigger",
             "operation_path": <%== api_pipeline_action_path(:pipeline_name => pipeline_model.getName(), :action => "schedule").to_json %>


### PR DESCRIPTION
1. The ability of a user to administer a pipeline is indicated in the JSON now.
2. The pipeline settings path is now at the pipeline level, rather than the instance level.
3. Pipeline unlock operation is now shown at the appropriate times (pipeline is locked, and can be unlocked).

The top part of the JSON looks like this:

```
[
  {
    "name": "pipeline_group_name",

    "pipelines": [
      {
        "name": "pipeline_name",
        "can_administer": true,
        "settings_path": "/go/admin/pipelines/pipeline_name/general",
        "is_locked": true,

        "instances": [
              ...
```

The unlock operation looks like this:

```
   ...
        "available_operations": [
          {
            "operation": "unlock",
            "operation_path": "/go/api/pipelines/pipeline_name/releaseLock"
          },
          {
            "operation": "trigger",
            "operation_path": "/go/api/pipelines/pipeline_name/schedule"
          },
   ...
```
