### PR TITLE
#000 - Ruby string -> Java string in view cache.

### DIFF
--- a/server/webapp/WEB-INF/rails.new/lib/go_cache_store.rb
+++ b/server/webapp/WEB-INF/rails.new/lib/go_cache_store.rb
@@ -19,6 +19,14 @@ class GoCacheStore < ActiveSupport::Cache::Store
     cache.get(*key(name, options))
   end
 
+  def write(name, value, options = nil)
+    if name.start_with? "view_" and value.is_a? String
+      super(name, value.to_java(:string), options)
+      return
+    end
+    super(name, value, options)
+  end
+
   def write_entry(name, value, options = nil)
     cache.put(*(key(name, options) << value))
   end

--- a/server/webapp/WEB-INF/rails.new/spec/lib/go_cache_store_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/lib/go_cache_store_spec.rb
@@ -87,5 +87,35 @@ describe GoCacheStore do
     @store.clear
     expect(@go_cache.get("key")).to eq nil
   end
+
+  it "should convert Ruby strings into Java strings for view fragments (name starting with view_)" do
+    @store.write("view_a", "value")
+
+    expect(@store.fetch("view_a").is_a? java.lang.String).to be_true
+    expect(@store.fetch("view_a")).to eq(java.lang.String.new("value"))
+
+    expect(@go_cache.get("view_a").value.is_a? java.lang.String).to be_true
+    expect(@go_cache.get("view_a").value).to eq(java.lang.String.new("value"))
+  end
+
+  it "should NOT convert objects which are not Ruby strings into Java string for view fragments (name starting with view_)" do
+    @store.write("view_a", ["ABC", "DEF"])
+
+    expect(@store.fetch("view_a").is_a? java.lang.String).to be_false
+    expect(@store.fetch("view_a")).to eq(["ABC", "DEF"])
+
+    expect(@go_cache.get("view_a").value.is_a? java.lang.String).to be_false
+    expect(@go_cache.get("view_a").value).to eq(["ABC", "DEF"])
+  end
+
+  it "should NOT convert Ruby strings into Java strings for non-view-fragments (name NOT starting with view_)" do
+    @store.write("notview_a", "value")
+
+    expect(@store.fetch("notview_a").is_a? java.lang.String).to be_false
+    expect(@store.fetch("notview_a")).to eq("value")
+
+    expect(@go_cache.get("notview_a").value.is_a? java.lang.String).to be_false
+    expect(@go_cache.get("notview_a").value).to eq("value")
+  end
 end
 


### PR DESCRIPTION
When fragment caching is used, as mentioned in the Rails guide
http://guides.rubyonrails.org/caching_with_rails.html#fragment-caching,
the actual fragment is cached as a Ruby String. In JRuby, this means
that the RubyString class (http://jruby.org/apidocs/org/jruby/RubyString.html)
is used.

When a RubyString class is used in a long-lived cache, it has
potentially bad consequences. In this case, because of JRuby string
copy-on-write semantics, some of these strings had 3MB of memory stored
for a string as small as 6000 characters (because RubyString uses
ByteList, which had a big byte array as a buffer, which it indexes into.

When the Go fragment cache tried to cache 500 pipelines, each taking
about 3MB to cache (instead of about the usual 6 to 10 KB), the memory
usage went through the roof.

This commit brings back the old JRuby and Rails way of using
java.lang.String for the fragment cache, instead of using RubyString.
Just for fragment caches.
