### PR TITLE
More appropriate runlevel start and stop priority in chkconfig init scri...

### DIFF
--- a/installers/agent/release/init.cruise-agent
+++ b/installers/agent/release/init.cruise-agent
@@ -15,14 +15,14 @@
 # limitations under the License.
 #*************************GO-LICENSE-END**********************************
 
-# chkconfig: 2345 90 90
+# chkconfig: 345 90 10
 # description: Go Agent
 ### BEGIN INIT INFO
 # Provides: go-agent
 # Required-Start: $network $remote_fs
 # Required-Stop: $network $remote_fs
-# Default-Start: 2 3 4 5
-# Default-Stop: 0 1 6
+# Default-Start: 3 4 5
+# Default-Stop: 0 1 2 6
 # Description: Start the Go Agent
 ### END INIT INFO
 

--- a/installers/server/release/init.cruise-server
+++ b/installers/server/release/init.cruise-server
@@ -15,14 +15,14 @@
 # limitations under the License.
 #*************************GO-LICENSE-END**********************************
 
-# chkconfig: 2345 90 90
+# chkconfig: 345 90 10
 # description: Go Server
 ### BEGIN INIT INFO
 # Provides: go-server
 # Required-Start: $network $remote_fs
 # Required-Stop: $network $remote_fs
-# Default-Start: 2 3 4 5
-# Default-Stop: 0 1 6
+# Default-Start: 3 4 5
+# Default-Stop: 0 1 2 6
 # Description: Start the Go Server
 ### END INIT INFO
 


### PR DESCRIPTION
To my understanding more appropriate runlevel for starting the service is 3 when most network services start.

The other change is related to stop priority. From the results of my searching the stop priority is decreasing. Low numbers stops earlier.

I haven't been able to test that those changes correctly generate the right init script after the package is deployed. I currenlty don't know how to test this process. 
