### PR TITLE
Update Apache commons-io to version 2.4.

### DIFF
--- a/base/pom.xml
+++ b/base/pom.xml
@@ -42,7 +42,7 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>1.4</version>
+            <version>${commons.io.version}</version>
         </dependency>
 
         <dependency>

--- a/plugin-infra/sample-plugins/curl-plugin/pom.xml
+++ b/plugin-infra/sample-plugins/curl-plugin/pom.xml
@@ -39,7 +39,7 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>1.4</version>
+            <version>2.4</version>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,7 @@
         <spring.version>3.1.3.RELEASE</spring.version>
         <spring-security.version>2.0.3</spring-security.version>
         <jetty.version>6.1.23</jetty.version>
+        <commons.io.version>2.4</commons.io.version>
 
         <jmock.version>2.4.0</jmock.version>
         <pax-exam.version>3.0.0.M4</pax-exam.version>

--- a/server-launcher/pom.xml
+++ b/server-launcher/pom.xml
@@ -84,7 +84,7 @@
 		<dependency>
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
-			<version>1.4</version>
+			<version>${commons.io.version}</version>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
Version 2.4 is able to clean up circular symlinks.

See https://github.com/gocd/gocd/issues/360#issuecomment-50403790

Signed-off-by: Aravind SV arvind.sv@gmail.com
