### PR TITLE
include java_import into helpers

### DIFF
--- a/server/webapp/WEB-INF/rails.new/app/helpers/application_helper.rb
+++ b/server/webapp/WEB-INF/rails.new/app/helpers/application_helper.rb
@@ -18,6 +18,7 @@
 module ApplicationHelper
   include Services
   include RailsLocalizer
+  include JavaImports
   include PrototypeHelper
 
   GO_MESSAGE_KEYS = [:error, :notice, :success]

--- a/server/webapp/WEB-INF/rails.new/lib/java_imports.rb
+++ b/server/webapp/WEB-INF/rails.new/lib/java_imports.rb
@@ -122,7 +122,6 @@ module JavaImports
   java_import com.thoughtworks.go.presentation.pipelinehistory.StageInstanceModels unless defined? StageInstanceModels
   java_import com.thoughtworks.go.presentation.pipelinehistory.StageInstanceModel unless defined? StageInstanceModel
   java_import com.thoughtworks.go.presentation.TriStateSelection unless defined? TriStateSelection
-  java_import com.thoughtworks.go.presentation.TriStateSelection unless defined? TriStateSelection
   java_import com.thoughtworks.go.presentation.UserModel unless defined? UserModel
   java_import com.thoughtworks.go.presentation.UserSearchModel unless defined? UserSearchModel
   java_import com.thoughtworks.go.presentation.UserSourceType unless defined? UserSourceType


### PR DESCRIPTION
was found as part of testing of undocumented agent API for editing environment & resource. @jyotisingh found the fix.
