### PR TITLE
#000 - Fix agents table sanitization.

### DIFF
--- a/server/webapp/WEB-INF/rails.new/app/helpers/agents_helper.rb
+++ b/server/webapp/WEB-INF/rails.new/app/helpers/agents_helper.rb
@@ -27,7 +27,7 @@ module AgentsHelper
   end
 
   def cell_with_title value, klass, title = value
-    "<td class='#{klass}' title='#{title}'><span>#{value}</span></td>"
+    "<td class='#{ERB::Util.h(klass)}' title='#{ERB::Util.h(title)}'><span>#{ERB::Util.h(value)}</span></td>".html_safe
   end
 
   def to_display_name(status)


### PR DESCRIPTION
Values in the table can come from unauthorized agents, while they wait to be
accepted and enabled (they remain in 'Pending state'). The values they send
during that time should not be considered safe.
