### PR TITLE
Change command error stream prefix to STDERR.

### DIFF
--- a/common/src/com/thoughtworks/go/util/command/CommandLine.java
+++ b/common/src/com/thoughtworks/go/util/command/CommandLine.java
@@ -121,7 +121,7 @@ public class CommandLine {
     private String encoding;
     public static final long NO_TIMEOUT = -1;
     private final String ERROR_STREAM_PREFIX_FOR_SCRIPTS = "";
-    private final String ERROR_STREAM_PREFIX_FOR_CMDS = "ERROR: ";
+    private final String ERROR_STREAM_PREFIX_FOR_CMDS = "STDERR: ";
 
     private CommandLine(String executable) {
         this.executable = executable;

--- a/common/test/com/thoughtworks/go/domain/materials/perforce/P4CommandTestBase.java
+++ b/common/test/com/thoughtworks/go/domain/materials/perforce/P4CommandTestBase.java
@@ -62,7 +62,7 @@ public abstract class P4CommandTestBase extends PerforceFixture {
         }
         catch(Exception e) {
             assertThat(e, is(instanceOf(RuntimeException.class)));
-            assertThat(e.getMessage(), containsString("ERROR: //client/... - no such file(s)"));
+            assertThat(e.getMessage(), containsString("STDERR: //client/... - no such file(s)"));
         }
     }
 

--- a/common/test/com/thoughtworks/go/util/command/CommandLineTest.java
+++ b/common/test/com/thoughtworks/go/util/command/CommandLineTest.java
@@ -405,4 +405,14 @@ public class CommandLineTest {
         String[] commandLineArgs = command.getCommandLine();
         assertThat(commandLineArgs[0], is(file));
     }
+
+    @Test
+    public void shouldPrefixStderrOutput() {
+        CommandLine line = CommandLine.createCommandLine("rmdir").withArg("/a/directory/that/does/not/exist");
+        InMemoryStreamConsumer output = new InMemoryStreamConsumer();
+        ProcessWrapper processWrapper = line.execute(output, new EnvironmentVariableContext(), null);
+        processWrapper.waitForExit();
+
+        assertThat(output.getAllOutput(), containsString("STDERR: "));
+    }
 }


### PR DESCRIPTION
Currently output written to stderr by a process shows up in the console
log with the prefix "ERROR: ". This can cause the user to interpret all
messages written to stderr as errors and many are just informational.
This change will help users make this distinction.

This is a personal pull request and not associated with Pivotal.
