### PR TITLE
#000 - Fix JSUnit tests when run under IE 9.

### DIFF
--- a/server/jsunit/tests/jsUnitTestSuite.html
+++ b/server/jsunit/tests/jsUnitTestSuite.html
@@ -99,6 +99,7 @@
             result.addTestPage("tests/pipelines_selector_test_rails_new.html");
             result.addTestPage("tests/pipeline_dashboard_test_rails_new.html");
             result.addTestPage("tests/pipeline_deploy_test_rails_new.html");
+            result.addTestPage("tests/server_configuration_test.html");
             if(!isBrowserIE()) {
                 result.addTestPage("tests/micro_content_on_agents_test_rails_new.html");
             }

--- a/server/webapp/WEB-INF/rails.new/spec/javascripts/helpers/test_helper.js
+++ b/server/webapp/WEB-INF/rails.new/spec/javascripts/helpers/test_helper.js
@@ -55,7 +55,6 @@ var MockXHR = Class.create({
         return this.headers[name];
     },
     setRequestHeader: function(name, value){
-        console.log("Got header: " + name + " " + value);
         this.headersSentInRequest[name] = value;
     },
     open: function(method, url, asynchronous){

--- a/server/webapp/javascripts/test_helper.js
+++ b/server/webapp/javascripts/test_helper.js
@@ -55,7 +55,6 @@ var MockXHR = Class.create({
         return this.headers[name];
     },
     setRequestHeader: function(name, value){
-        console.log("Got header: " + name + " " + value);
         this.headersSentInRequest[name] = value;
     },
     open: function(method, url, asynchronous){


### PR DESCRIPTION
- There was a console.log line which caused IE to fail the specs.
- Also, add a test which was missing, back to the suite. That was
  server_configuration_test.html.
