### PR TITLE
#675 - Fix a failing rspec spec in pipeline whitelist PR.

### DIFF
--- a/server/jsunit/tests/pipelines_selector_test_rails_new.html
+++ b/server/jsunit/tests/pipelines_selector_test_rails_new.html
@@ -150,6 +150,10 @@
                 <div id='select_text'>Select:</div>
                 <a  class='link_as_button' href='javascript:void(0);' id='select_all_pipelines'>All</a>
                 <a  class='link_as_button' href='javascript:void(0);' id='select_no_pipelines'>None</a>
+                <div id="show_new_pipelines_container">
+                    <input id="show_new_pipelines" type="checkbox" name="show_new_pipelines" checked='checked'/>
+                    <label id="show_new_pipelines_label" for="show_new_pipelines">Show newly created pipelines</label>
+                </div>
             </div>
             <div id='pipelines_selector_pipelines' class='scrollable_panel'>
                 <div id='selector_group_group-1' class='selector_group'>


### PR DESCRIPTION
Needed for pipeline whitelist PR. It fails two specs. One in spec/views/pipelines/_pipelines_selector_pipelines_html_spec.rb (fixed by this commit) and another in spec/views/pipelines/_pipelines_selector_html_spec.rb.

For that one, line 53 of the spec needs to be changed from:

```
expect(response).to have_selector("div.select_all_none_panel div#show_new_pipelines_container label#show_new_pipelines_label[for='show_new_pipelines']", text: "Show New Pipelines")
```

to 

```
expect(response).to have_selector("div.select_all_none_panel div#show_new_pipelines_container label#show_new_pipelines_label[for='show_new_pipelines']", text: "Show newly created pipelines")
```
