### PR TITLE
Handle UnknownHostException in SystemUtilTest

### DIFF
--- a/base/test/com/thoughtworks/go/util/SystemUtilTest.java
+++ b/base/test/com/thoughtworks/go/util/SystemUtilTest.java
@@ -32,7 +32,15 @@ public class SystemUtilTest {
 
     @Test
     public void shouldDetermineIfAddressIsLocal() throws UnknownHostException {
-        InetAddress local = InetAddress.getLocalHost();
+        InetAddress local;
+
+        try {
+            local = InetAddress.getLocalHost();
+        }
+        catch (UnknownHostException e) {
+            local = InetAddress.getByName("localhost");
+        }
+
         assertThat("Localhost (" + local.getHostName() + ") should be a local address.", SystemUtil.isLocalhost(local.getHostAddress()), is(true));
     }
 


### PR DESCRIPTION
- If the host system's local hostname is not resolvable, a UnknownHostException is thrown in the
  shouldDetermineIfAddressIsLocal test. This caused the test run to stop. This change resolves the
  IP using localhost in the event of an UnknownHostException.
