### PR TITLE
#718 - Fix acceptance test failing due to wrong merge.

### DIFF
--- a/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/PluginRequestHelper.java
+++ b/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/PluginRequestHelper.java
@@ -33,7 +33,7 @@ public class PluginRequestHelper {
             if (DefaultGoApiResponse.SUCCESS_RESPONSE_CODE == response.responseCode()) {
                 return pluginInteractionCallback.onSuccess(response.responseBody(), resolvedExtensionVersion);
             }
-            throw new RuntimeException(format("Unsuccessful response code from plugin '%s' with body '%s'", response.responseCode(), response.responseBody()));
+            throw new RuntimeException(format("Unsuccessful response from plugin, response code '%s' and response body '%s'", response.responseCode(), response.responseBody()));
         } catch (Exception e) {
             throw new RuntimeException(format("Exception while interacting with plugin id '%s', extension '%s', request '%s'. Reason, [%s]", pluginId, extensionName, requestName, e.getMessage()), e);
         }


### PR DESCRIPTION
There was a small mistake in 29e3b456e507eabfed856a3212cc16f5ee96da55, where it did not correctly
merge changes from 118794c4b73c6cca50004d01dbb9ea59a742837d. Acceptance tests failed because of
this.
