### PR TITLE
Remove unnecessary logging from test environment

### DIFF
--- a/server/webapp/WEB-INF/rails.new/config/environments/test.rb
+++ b/server/webapp/WEB-INF/rails.new/config/environments/test.rb
@@ -41,7 +41,7 @@ Go::Application.configure do
   # Print deprecation notices to the stderr.
   # config.active_support.deprecation = :stderr
 
-  config.logger = ::Logger.new(STDOUT)
+  config.logger = nil
 end
 
 # Override load_context of Spring for rspec.


### PR DESCRIPTION
Goes from

```
I, [2014-12-11T23:10:06.247000 #85843]  INFO -- : Processing by Admin::JobsController#edit as HTML
I, [2014-12-11T23:10:06.252000 #85843]  INFO -- :   Parameters: {"stage_parent"=>"pipelines", "current_tab"=>"settings", "pipeline_name"=>"pipeline-name", "stage_name"=>"stage-name", "job_name"=>"job-1"}
I, [2014-12-11T23:10:06.610000 #85843]  INFO -- :   Rendered shared/_form_required_message.html.erb (65.0ms)
I, [2014-12-11T23:10:06.627000 #85843]  INFO -- :   Rendered shared/_convert_tool_tips.html.erb (6.0ms)
I, [2014-12-11T23:10:06.627000 #85843]  INFO -- :   Rendered admin/jobs/_job_basic_settings.html.erb (211.0ms)
I, [2014-12-11T23:10:06.661000 #85843]  INFO -- :   Rendered admin/shared/_form_submit.html.erb (12.0ms)
I, [2014-12-11T23:10:06.671000 #85843]  INFO -- :   Rendered admin/jobs/settings.html.erb within layouts/pipelines/job (320.0ms)
I, [2014-12-11T23:10:06.733000 #85843]  INFO -- :   Rendered shared/_head.html.erb (29.0ms)
I, [2014-12-11T23:10:06.878000 #85843]  INFO -- :   Rendered server/_counts.html.erb (9.0ms)
I, [2014-12-11T23:10:06.893000 #85843]  INFO -- :   Rendered server/_messages_body.html.erb (8.0ms)
I, [2014-12-11T23:10:06.907000 #85843]  INFO -- :   Rendered shared/_error_messaging_counter.html.erb (54.0ms)
I, [2014-12-11T23:10:06.925000 #85843]  INFO -- :   Rendered shared/_go_license_about_to_expire.html.erb (11.0ms)
I, [2014-12-11T23:10:06.926000 #85843]  INFO -- :   Rendered shared/_application_nav.html.erb (135.0ms)
I, [2014-12-11T23:10:06.927000 #85843]  INFO -- :   Rendered shared/_header.html.erb (183.0ms)
I, [2014-12-11T23:10:06.942000 #85843]  INFO -- :   Rendered shared/_flash_message.html.erb (8.0ms)
I, [2014-12-11T23:10:06.963000 #85843]  INFO -- :   Rendered shared/_config_save_actions.html.erb (8.0ms)
I, [2014-12-11T23:10:07.056000 #85843]  INFO -- :   Rendered shared/_pause_control.html.erb (40.0ms)
I, [2014-12-11T23:10:07.073000 #85843]  INFO -- :   Rendered shared/_pause_info.html.erb (6.0ms)
I, [2014-12-11T23:10:07.077000 #85843]  INFO -- :   Rendered shared/_pause_info_and_control.html.erb (76.0ms)
I, [2014-12-11T23:10:07.078000 #85843]  INFO -- :   Rendered layouts/pipelines/_breadcrumb_top.html.erb (96.0ms)
I, [2014-12-11T23:10:07.179000 #85843]  INFO -- :   Rendered admin/shared/_pipeline_tree.html.erb (90.0ms)
I, [2014-12-11T23:10:07.280000 #85843]  INFO -- :   Rendered admin/jobs/_job_navigation.html.erb (57.0ms)
I, [2014-12-11T23:10:07.294000 #85843]  INFO -- :   Rendered admin/shared/_dirty_form.html.erb (5.0ms)
I, [2014-12-11T23:10:07.336000 #85843]  INFO -- :   Rendered shared/_footer.html.erb (36.0ms)
I, [2014-12-11T23:10:07.350000 #85843]  INFO -- : Completed 200 OK in 1097ms (Views: 1052.0ms)
.I, [2014-12-11T23:10:07.581000 #85843]  INFO -- : Processing by Admin::JobsController#edit as HTML
I, [2014-12-11T23:10:07.582000 #85843]  INFO -- :   Parameters: {"stage_parent"=>"pipelines", "current_tab"=>"artifacts", "pipeline_name"=>"pipeline-name", "stage_name"=>"stage-name", "job_name"=>"job-1"}
I, [2014-12-11T23:10:07.790000 #85843]  INFO -- :   Rendered admin/jobs/_artifact_plans.html.erb (121.0ms)
I, [2014-12-11T23:10:07.805000 #85843]  INFO -- :   Rendered shared/_convert_tool_tips.html.erb (11.0ms)
I, [2014-12-11T23:10:07.832000 #85843]  INFO -- :   Rendered admin/shared/_form_submit.html.erb (13.0ms)
I, [2014-12-11T23:10:07.867000 #85843]  INFO -- :   Rendered shared/_head.html.erb (19.0ms)
I, [2014-12-11T23:10:07.892000 #85843]  INFO -- :   Rendered server/_counts.html.erb (2.0ms)
I, [2014-12-11T23:10:07.899000 #85843]  INFO -- :   Rendered server/_messages_body.html.erb (3.0ms)
I, [2014-12-11T23:10:07.903000 #85843]  INFO -- :   Rendered shared/_error_messaging_counter.html.erb (14.0ms)
I, [2014-12-11T23:10:07.905000 #85843]  INFO -- :   Rendered shared/_go_license_about_to_expire.html.erb (0.0ms)
I, [2014-12-11T23:10:07.906000 #85843]  INFO -- :   Rendered shared/_application_nav.html.erb (33.0ms)
I, [2014-12-11T23:10:07.906000 #85843]  INFO -- :   Rendered shared/_header.html.erb (35.0ms)
I, [2014-12-11T23:10:07.912000 #85843]  INFO -- :   Rendered shared/_flash_message.html.erb (4.0ms)
I, [2014-12-11T23:10:07.915000 #85843]  INFO -- :   Rendered shared/_config_save_actions.html.erb (2.0ms)
I, [2014-12-11T23:10:07.976000 #85843]  INFO -- :   Rendered shared/_pause_control.html.erb (41.0ms)
I, [2014-12-11T23:10:07.981000 #85843]  INFO -- :   Rendered shared/_pause_info.html.erb (3.0ms)
I, [2014-12-11T23:10:07.984000 #85843]  INFO -- :   Rendered shared/_pause_info_and_control.html.erb (59.0ms)
I, [2014-12-11T23:10:07.994000 #85843]  INFO -- :   Rendered layouts/pipelines/_breadcrumb_top.html.erb (78.0ms)
I, [2014-12-11T23:10:08.050000 #85843]  INFO -- :   Rendered admin/shared/_pipeline_tree.html.erb (53.0ms)
I, [2014-12-11T23:10:08.117000 #85843]  INFO -- :   Rendered admin/jobs/_job_navigation.html.erb (56.0ms)
I, [2014-12-11T23:10:08.123000 #85843]  INFO -- :   Rendered admin/shared/_dirty_form.html.erb (3.0ms)
I, [2014-12-11T23:10:08.267000 #85843]  INFO -- :   Rendered shared/_footer.html.erb (102.0ms)
I, [2014-12-11T23:10:08.290000 #85843]  INFO -- : Completed 200 OK in 703ms (Views: 697.0ms)
.I, [2014-12-11T23:10:09.128000 #85843]  INFO -- : Processing by Admin::JobsController#edit as HTML
I, [2014-12-11T23:10:09.131000 #85843]  INFO -- :   Parameters: {"stage_parent"=>"pipelines", "current_tab"=>"artifacts", "pipeline_name"=>"pipeline-name", "stage_name"=>"stage-name", "job_name"=>"job-1"}
I, [2014-12-11T23:10:09.218000 #85843]  INFO -- :   Rendered admin/jobs/_artifact_plans.html.erb (44.0ms)
I, [2014-12-11T23:10:09.232000 #85843]  INFO -- :   Rendered shared/_convert_tool_tips.html.erb (1.0ms)
I, [2014-12-11T23:10:09.260000 #85843]  INFO -- :   Rendered admin/shared/_form_submit.html.erb (11.0ms)
I, [2014-12-11T23:10:09.359000 #85843]  INFO -- :   Rendered shared/_head.html.erb (48.0ms)
I, [2014-12-11T23:10:09.469000 #85843]  INFO -- :   Rendered server/_counts.html.erb (3.0ms)
I, [2014-12-11T23:10:09.476000 #85843]  INFO -- :   Rendered server/_messages_body.html.erb (3.0ms)
I, [2014-12-11T23:10:09.481000 #85843]  INFO -- :   Rendered shared/_error_messaging_counter.html.erb (22.0ms)
I, [2014-12-11T23:10:09.539000 #85843]  INFO -- :   Rendered shared/_go_license_about_to_expire.html.erb (11.0ms)
I, [2014-12-11T23:10:09.544000 #85843]  INFO -- :   Rendered shared/_application_nav.html.erb (167.0ms)
I, [2014-12-11T23:10:09.545000 #85843]  INFO -- :   Rendered shared/_header.html.erb (182.0ms)
I, [2014-12-11T23:10:09.549000 #85843]  INFO -- :   Rendered shared/_flash_message.html.erb (2.0ms)
I, [2014-12-11T23:10:09.552000 #85843]  INFO -- :   Rendered shared/_config_save_actions.html.erb (0.0ms)
I, [2014-12-11T23:10:09.596000 #85843]  INFO -- :   Rendered shared/_pause_control.html.erb (25.0ms)
I, [2014-12-11T23:10:09.605000 #85843]  INFO -- :   Rendered shared/_pause_info.html.erb (6.0ms)
I, [2014-12-11T23:10:09.606000 #85843]  INFO -- :   Rendered shared/_pause_info_and_control.html.erb (37.0ms)
I, [2014-12-11T23:10:09.607000 #85843]  INFO -- :   Rendered layouts/pipelines/_breadcrumb_top.html.erb (52.0ms)
I, [2014-12-11T23:10:09.658000 #85843]  INFO -- :   Rendered admin/shared/_pipeline_tree.html.erb (49.0ms)
I, [2014-12-11T23:10:09.738000 #85843]  INFO -- :   Rendered admin/jobs/_job_navigation.html.erb (57.0ms)
I, [2014-12-11T23:10:09.743000 #85843]  INFO -- :   Rendered admin/shared/_dirty_form.html.erb (2.0ms)
I, [2014-12-11T23:10:09.779000 #85843]  INFO -- :   Rendered shared/_footer.html.erb (34.0ms)
I, [2014-12-11T23:10:09.802000 #85843]  INFO -- : Completed 200 OK in 665ms (Views: 657.0ms)
....................I, [2014-12-11T23:10:12.487000 #85843]  INFO -- : Processing by Admin::TasksController#create as HTML
I, [2014-12-11T23:10:12.488000 #85843]  INFO -- :   Parameters: {"config_md5"=>"abcd1234", "task"=>{"Url"=>"http://foo"}, "pipeline_name"=>"pipeline.name", "stage_name"=>"stage.name", "job_name"=>"job.1", "type"=>"pluggable_task_curl_plugin", "stage_parent"=>"pipelines", "current_tab"=>"tasks"}
I, [2014-12-11T23:10:13.010000 #85843]  INFO -- : Completed 200 OK in 521ms (Views: 25.0ms)
.I, [2014-12-11T23:10:13.164000 #85843]  INFO -- : Processing by Admin::TasksController#create as HTML
I, [2014-12-11T23:10:13.165000 #85843]  INFO -- :   Parameters: {"config_md5"=>"1234abcd", "task"=>{"Url"=>"http://foo"}, "pipeline_name"=>"pipeline.name", "stage_name"=>"stage.name", "job_name"=>"job.1", "type"=>"pluggable_task_curl_plugin", "stage_parent"=>"pipelines", "current_tab"=>"tasks"}
I, [2014-12-11T23:10:13.311000 #85843]  INFO -- : Completed 400 Bad Request in 139ms (Views: 60.0ms)
.I, [2014-12-11T23:10:13.828000 #85843]  INFO -- : Processing by Admin::TasksController#destroy as HTML
I, [2014-12-11T23:10:13.830000 #85843]  INFO -- :   Parameters: {"config_md5"=>"abcd1234", "pipeline_name"=>"pipeline.name", "stage_name"=>"stage.name", "job_name"=>"job.1", "task_index"=>"0", "stage_parent"=>"pipelines", "current_tab"=>"tasks"}
(snip)
```

to this:

```
.............................................................................................................................................................................................................................................................../Users/derekhammer/Projects/gocd/server/webapp/WEB-INF/rails.new/app/controllers/admin/tasks_controller.rb:92 warning: ambiguous Java methods found, using remove(int)
................................................................F...............................................................................................................................................................................................................................................An expectation of :registry was set on nil. Called from /Users/derekhammer/Projects/gocd/server/webapp/WEB-INF/rails.new/spec/controllers/admin/templates_controller_spec.rb:23:in `(root)'. Use allow_message_expectations_on_nil to disable warnings.
.An expectation of :registry was set on nil. Called from /Users/derekhammer/Projects/gocd/server/webapp/WEB-INF/rails.new/spec/controllers/admin/templates_controller_spec.rb:23:in `(root)'. Use allow_message_expectations_on_nil to disable warnings.
.An expectation of :registry was set on nil. Called from /Users/derekhammer/Projects/gocd/server/webapp/WEB-INF/rails.new/spec/controllers/admin/templates_controller_spec.rb:23:in `(root)'. Use allow_message_expectations_on_nil to disable warnings.
.An expectation of :registry was set on nil. Called from /Users/derekhammer/Projects/gocd/server/webapp/WEB-INF/rails.new/spec/controllers/admin/templates_controller_spec.rb:23:in `(root)'. Use allow_message_expectations_on_nil to disable warnings.
.An expectation of :registry was set on nil. Called from /Users/derekhammer/Projects/gocd/server/webapp/WEB-INF/rails.new/spec/controllers/admin/templates_controller_spec.rb:23:in `(root)'. Use allow_message_expectations_on_nil to disable warnings.
.An expectation of :registry was set on nil. Called from /Users/derekhammer/Projects/gocd/server/webapp/WEB-INF/rails.new/spec/controllers/admin/templates_controller_spec.rb:23:in `(root)'. Use allow_message_expectations_on_nil to disable warnings.
.An expectation of :registry was set on nil. Called from /Users/derekhammer/Projects/gocd/server/webapp/WEB-INF/rails.new/spec/controllers/admin/templates_controller_spec.rb:23:in `(root)'. Use allow_message_expectations_on_nil to disable warnings.
.An expectation of :registry was set on nil. Called from /Users/derekhammer/Projects/gocd/server/webapp/WEB-INF/rails.new/spec/controllers/admin/templates_controller_spec.rb:23:in `(root)'. Use allow_message_expectations_on_nil to disable warnings.
.An expectation of :registry was set on nil. Called from /Users/derekhammer/Projects/gocd/server/webapp/WEB-INF/rails.new/spec/controllers/admin/templates_controller_spec.rb:23:in `(root)'. Use allow_message_expectations_on_nil to disable warnings.
.An expectation of :registry was set on nil. Called from /Users/derekhammer/Projects/gocd/server/webapp/WEB-INF/rails.new/spec/controllers/admin/templates_controller_spec.rb:23:in `(root)'. Use allow_message_expectations_on_nil to disable warnings.
.An expectation of :registry was set on nil. Called from /Users/derekhammer/Projects/gocd/server/webapp/WEB-INF/rails.new/spec/controllers/admin/templates_controller_spec.rb:23:in `(root)'. Use allow_message_expectations_on_nil to disable warnings.
.An expectation of :registry was set on nil. Called from /Users/derekhammer/Projects/gocd/server/webapp/WEB-INF/rails.new/spec/controllers/admin/templates_controller_spec.rb:23:in `(root)'. Use allow_message_expectations_on_nil to disable warnings.
.An expectation of :registry was set on nil. Called from /Users/derekhammer/Projects/gocd/server/webapp/WEB-INF/rails.new/spec/controllers/admin/templates_controller_spec.rb:23:in `(root)'. Use allow_message_expectations_on_nil to disable warnings.
.An expectation of :registry was set on nil. Called from /Users/derekhammer/Projects/gocd/server/webapp/WEB-INF/rails.new/spec/controllers/admin/templates_controller_spec.rb:23:in `(root)'. Use allow_message_expectations_on_nil to disable warnings.
.An expectation of :registry was set on nil. Called from /Users/derekhammer/Projects/gocd/server/webapp/WEB-INF/rails.new/spec/controllers/admin/templates_controller_spec.rb:23:in `(root)'. Use allow_message_expectations_on_nil to disable warnings.
.An expectation of :registry was set on nil. Called from /Users/derekhammer/Projects/gocd/server/webapp/WEB-INF/rails.new/spec/controllers/admin/templates_controller_spec.rb:23:in `(root)'. Use allow_message_expectations_on_nil to disable warnings.
.An expectation of :registry was set on nil. Called from /Users/derekhammer/Projects/gocd/server/webapp/WEB-INF/rails.new/spec/controllers/admin/templates_controller_spec.rb:23:in `(root)'. Use allow_message_expectations_on_nil to disable warnings.
.An expectation of :registry was set on nil. Called from /Users/derekhammer/Projects/gocd/server/webapp/WEB-INF/rails.new/spec/controllers/admin/templates_controller_spec.rb:23:in `(root)'. Use allow_message_expectations_on_nil to disable warnings.
.An expectation of :registry was set on nil. Called from /Users/derekhammer/Projects/gocd/server/webapp/WEB-INF/rails.new/spec/controllers/admin/templates_controller_spec.rb:23:in `(root)'. Use allow_message_expectations_on_nil to disable warnings.
.An expectation of :registry was set on nil. Called from /Users/derekhammer/Projects/gocd/server/webapp/WEB-INF/rails.new/spec/controllers/admin/templates_controller_spec.rb:23:in `(root)'. Use allow_message_expectations_on_nil to disable warnings.
.An expectation of :registry was set on nil. Called from /Users/derekhammer/Projects/gocd/server/webapp/WEB-INF/rails.new/spec/controllers/admin/templates_controller_spec.rb:23:in `(root)'. Use allow_message_expectations_on_nil to disable warnings.
.An expectation of :registry was set on nil. Called from /Users/derekhammer/Projects/gocd/server/webapp/WEB-INF/rails.new/spec/controllers/admin/templates_controller_spec.rb:23:in `(root)'. Use allow_message_expectations_on_nil to disable warnings.
.An expectation of :registry was set on nil. Called from /Users/derekhammer/Projects/gocd/server/webapp/WEB-INF/rails.new/spec/controllers/admin/templates_controller_spec.rb:23:in `(root)'. Use allow_message_expectations_on_nil to disable warnings.
.An expectation of :registry was set on nil. Called from /Users/derekhammer/Projects/gocd/server/webapp/WEB-INF/rails.new/spec/controllers/admin/templates_controller_spec.rb:23:in `(root)'. Use allow_message_expectations_on_nil to disable warnings.
..............................................
```

Still not perfect, but much cleaner
