### PR TITLE
WIP - demonstration of JSON over HTTP agent

### DIFF
--- a/agent/src/com/thoughtworks/go/agent/AgentController.java
+++ b/agent/src/com/thoughtworks/go/agent/AgentController.java
@@ -65,7 +65,7 @@ public class AgentController {
     private TaskExtension taskExtension;
 
     @Autowired
-    public AgentController(BuildRepositoryRemote server, GoArtifactsManipulator manipulator, SslInfrastructureService sslInfrastructureService, AgentRegistry agentRegistry,
+    public AgentController(BuildRepositoryRemote server, BuildRepositoryHttpRemote remoteServer, GoArtifactsManipulator manipulator, SslInfrastructureService sslInfrastructureService, AgentRegistry agentRegistry,
                            AgentUpgradeService agentUpgradeService, SubprocessLogger subprocessLogger, SystemEnvironment systemEnvironment,
                            PluginManager pluginManager, TaskExtension taskExtension) {
         this.agentUpgradeService = agentUpgradeService;

--- a/agent/src/com/thoughtworks/go/agent/BuildRepositoryHttpRemote.java
+++ b/agent/src/com/thoughtworks/go/agent/BuildRepositoryHttpRemote.java
@@ -1,0 +1,65 @@
+/*************************GO-LICENSE-START*********************************
+ * Copyright 2014 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *************************GO-LICENSE-END***********************************/
+
+package com.thoughtworks.go.agent;
+
+import com.thoughtworks.go.domain.JobIdentifier;
+import com.thoughtworks.go.domain.JobResult;
+import com.thoughtworks.go.domain.JobState;
+import com.thoughtworks.go.remote.AgentIdentifier;
+import com.thoughtworks.go.remote.AgentInstruction;
+import com.thoughtworks.go.remote.BuildRepositoryRemote;
+import com.thoughtworks.go.remote.work.Work;
+import com.thoughtworks.go.server.service.AgentRuntimeInfo;
+import org.springframework.stereotype.Component;
+
+@Component
+public class BuildRepositoryHttpRemote implements BuildRepositoryRemote {
+    @Override
+    public AgentInstruction ping(AgentRuntimeInfo info) {
+        return null;
+    }
+
+    @Override
+    public Work getWork(AgentRuntimeInfo runtimeInfo) {
+        return null;
+    }
+
+    @Override
+    public void reportCurrentStatus(AgentRuntimeInfo agentRuntimeInfo, JobIdentifier jobIdentifier, JobState jobState) {
+
+    }
+
+    @Override
+    public void reportCompleting(AgentRuntimeInfo agentRuntimeInfo, JobIdentifier jobIdentifier, JobResult result) {
+
+    }
+
+    @Override
+    public void reportCompleted(AgentRuntimeInfo agentRuntimeInfo, JobIdentifier jobIdentifier, JobResult result) {
+
+    }
+
+    @Override
+    public boolean isIgnored(JobIdentifier jobIdentifier) {
+        return false;
+    }
+
+    @Override
+    public String getCookie(AgentIdentifier identifier, String location) {
+        return null;
+    }
+}

--- a/server/webapp/WEB-INF/rails.new/Gemfile.lock
+++ b/server/webapp/WEB-INF/rails.new/Gemfile.lock
@@ -103,6 +103,7 @@ GEM
 
 PLATFORMS
   java
+  ruby
 
 DEPENDENCIES
   dynamic_form

--- a/server/webapp/WEB-INF/rails.new/app/controllers/api/agents_controller.rb
+++ b/server/webapp/WEB-INF/rails.new/app/controllers/api/agents_controller.rb
@@ -44,6 +44,12 @@ class Api::AgentsController < Api::ApiController
     render text: bulk_edit.message()
   end
 
+  def work
+    identifier = AgentIdentifier.new(params[:hostname], params[:ip_address], params[:uuid])
+    work = build_repository_message_producer.getWork(AgentRuntimeInfo.fromAgent(identifier))
+    render json: work
+  end
+
   def job_run_history
     offset = params[:offset].to_i
     page_size = 10

--- a/server/webapp/WEB-INF/rails.new/config/routes.rb
+++ b/server/webapp/WEB-INF/rails.new/config/routes.rb
@@ -251,6 +251,7 @@ Go::Application.routes.draw do
 
       #agents api's
       get 'agents' => 'agents#index', format: 'json', as: :agents_information
+      get 'agents/:uuid/work' => 'agents#work', format: 'json'
       post 'agents/edit_agents' => 'agents#edit_agents', as: :api_disable_agent
       post 'agents/:uuid/:action' => 'agents#%{action}', constraints: {action: /enable|disable|delete/}, as: :agent_action
 

--- a/server/webapp/WEB-INF/rails.new/spec/controllers/api/agents_controller_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/controllers/api/agents_controller_spec.rb
@@ -19,6 +19,7 @@ require File.expand_path(File.dirname(__FILE__) + '/../../spec_helper')
 describe Api::AgentsController do
   before do
     controller.stub(:agent_service).and_return(@agent_service = double('agent-service'))
+    controller.stub(:build_repository_message_producer).and_return(@build_repository = double('build-repository'))
     controller.stub(:job_instance_service).and_return(@job_instance_service = double('job instance service'))
     controller.stub(:current_user).and_return(@user = Object.new)
   end
@@ -143,6 +144,13 @@ describe Api::AgentsController do
     it "should show error if no agents are selected" do
       post :edit_agents, :operation => 'Enable', :selected => [], :no_layout => true
       expect(response.body).to eq("No agents were selected. Please select at least one agent and try again.")
+    end
+  end
+
+  describe :work do
+    it 'should get some work' do
+      get :work, hostname: 'my-host', ip_address: '255.0.0.1', uuid: 'random-uuid'
+      expect(response.body).to eq({})
     end
   end
 


### PR DESCRIPTION
This is a work in progress. I'm submitting the PR to kick off a discussion before I go too far down this road.

My goal is to have the go-agent talk JSON over HTTP instead of Java Serialization over HTTP (basically JMI). This would enable us to
* Have a far more flexible and decouple architecture for the agent
* Encourage different implementations of a go agent (including building in a system level language like golang so we need no dependencies on our hosts and can start them super-fast without needed to boot a JVM)

These are big wins and this is the groundwork for that.