### PR TITLE
#718 - Fixed bug

### DIFF
--- a/config/config-api/src/com/thoughtworks/go/config/pluggabletask/PluggableTask.java
+++ b/config/config-api/src/com/thoughtworks/go/config/pluggabletask/PluggableTask.java
@@ -111,6 +111,7 @@ public class PluggableTask extends AbstractTask {
             List<? extends Property> propertyDefinitions = preference.getConfig().list();
             for (Property propertyDefinition : propertyDefinitions) {
                 ConfigurationProperty configuredProperty = configuration.getProperty(propertyDefinition.getKey());
+                if(configuredProperty == null) continue;
                 taskProperties.add(new TaskProperty(propertyDefinition.getOption(Property.DISPLAY_NAME), configuredProperty.getDisplayValue(), configuredProperty.getConfigKeyName()));
             }
             return taskProperties;

--- a/config/config-api/test/com/thoughtworks/go/config/pluggabletask/PluggableTaskTest.java
+++ b/config/config-api/test/com/thoughtworks/go/config/pluggabletask/PluggableTaskTest.java
@@ -158,6 +158,33 @@ public class PluggableTaskTest {
         assertProperty(propertiesForDisplay.get(2), "Key 3", "****", "key3");
     }
 
+    @Test
+    public void shouldGetOnlyConfiguredPropertiesIfACertainPropertyDefinedByPluginIsNotConfiguredByUser() throws Exception {
+        Task taskDetails = mock(Task.class);
+        TaskConfig taskConfig = new TaskConfig();
+        addProperty(taskConfig, "KEY2", "Key 2", 1);
+        addProperty(taskConfig, "KEY1", "Key 1", 0);
+        addProperty(taskConfig, "KEY3", "Key 3", 2);
+        when(taskDetails.config()).thenReturn(taskConfig);
+        when(taskDetails.view()).thenReturn(mock(TaskView.class));
+
+        String pluginId = "plugin_with_all_details";
+        PluggableTaskConfigStore.store().setPreferenceFor(pluginId, new TaskPreference(taskDetails));
+
+        Configuration configuration = new Configuration(
+                ConfigurationPropertyMother.create("KEY1", false, "value1"),
+                ConfigurationPropertyMother.create("KEY2", false, "value2")
+        );
+
+        PluggableTask task = new PluggableTask("abc", new PluginConfiguration(pluginId, "1"), configuration);
+
+        List<TaskProperty> propertiesForDisplay = task.getPropertiesForDisplay();
+
+        assertThat(propertiesForDisplay.size(), is(2));
+        assertProperty(propertiesForDisplay.get(0), "Key 1", "value1", "key1");
+        assertProperty(propertiesForDisplay.get(1), "Key 2", "value2", "key2");
+    }
+
     private void addProperty(TaskConfig taskConfig, String key, String displayName, int displayOrder) {
         TaskConfigProperty property = taskConfig.addProperty(key);
         property.with(Property.DISPLAY_NAME, displayName);

--- a/plugin-infra/sample-plugins/pom.xml
+++ b/plugin-infra/sample-plugins/pom.xml
@@ -50,6 +50,7 @@
     <modules>
         <module>curl-plugin</module>
         <module>descriptor-hash-plugin</module>
+        <module>curl-plugin-old-api-based</module>
     </modules>
 
     <build>


### PR DESCRIPTION
If a task property is manually deleted from config.xml, the tasks listing page threw null pointer exception. Such properties would not show up on the listing.
