### PR TITLE
#768 - Add feature toggle for plugin upload form.

### DIFF
--- a/server/resources/available.toggles
+++ b/server/resources/available.toggles
@@ -3,7 +3,12 @@
    "toggles": [
       {
          "key": "pipeline_comment_feature_toggle_key",
-         "description": "Toggle for Pipeline Comment feature",
+         "description": "Enables commenting on a pipeline run, in the pipeline history view. See more at: http://www.go.cd/documentation/user/current/beta/comment_on_pipeline_run.html. Default: off.",
+         "value": false
+      },
+      {
+         "key": "plugin_upload_feature_toggle_key",
+         "description": "Enables uploading a plugin, directly from Go's plugins tab. Default: off.",
          "value": false
       }
    ]

--- a/server/src/com/thoughtworks/go/server/service/support/toggle/Toggles.java
+++ b/server/src/com/thoughtworks/go/server/service/support/toggle/Toggles.java
@@ -2,6 +2,7 @@ package com.thoughtworks.go.server.service.support.toggle;
 
 public class Toggles {
     public static String PIPELINE_COMMENT_FEATURE_TOGGLE_KEY = "pipeline_comment_feature_toggle_key";
+    public static String PLUGIN_UPLOAD_FEATURE_TOGGLE_KEY = "plugin_upload_feature_toggle_key";
 
     private static FeatureToggleService service;
 

--- a/server/webapp/WEB-INF/rails.new/app/controllers/admin/plugins/plugins_controller.rb
+++ b/server/webapp/WEB-INF/rails.new/app/controllers/admin/plugins/plugins_controller.rb
@@ -23,9 +23,11 @@ class Admin::Plugins::PluginsController < AdminController
                               .collect { |descriptor| GoPluginDescriptorModel::convertToDescriptorWithAllValues descriptor }
                               .sort { |plugin1, plugin2| plugin1.about().name().downcase <=> plugin2.about().name().downcase }
     @external_plugin_location = system_environment.getExternalPluginAbsolutePath()
+    @upload_feature_enabled = Toggles.isToggleOn(Toggles.PLUGIN_UPLOAD_FEATURE_TOGGLE_KEY)
   end
 
   def upload
+    render :status => 403, :text => "Feature is not enabled" and return unless Toggles.isToggleOn(Toggles.PLUGIN_UPLOAD_FEATURE_TOGGLE_KEY)
     if params[:plugin].nil?
       respond_to do |format|
         format.html { flash[:error] = "Please select a file to upload." and redirect_to action: "index" }

--- a/server/webapp/WEB-INF/rails.new/app/views/admin/plugins/plugins/index.html.erb
+++ b/server/webapp/WEB-INF/rails.new/app/views/admin/plugins/plugins/index.html.erb
@@ -5,6 +5,7 @@
         <div class="information"><%= l.string("NO_PLUGINS_FOUND") -%><%= @external_plugin_location -%></div>
     <% end %>
 
+    <% if @upload_feature_enabled %>
     <h2 class="legend"><%= l.string("UPLOAD_PLUGIN") %></h2>
     <div id="upload-plugin">
         <div class="fieldset">
@@ -16,6 +17,7 @@
             </div>
         </div>
     </div>
+    <% end %>
 
     <h2><%= l.string("INSTALLED_PLUGINS") %></h2>
     <ul class="plugins">

--- a/server/webapp/WEB-INF/rails.new/lib/java_imports.rb
+++ b/server/webapp/WEB-INF/rails.new/lib/java_imports.rb
@@ -222,4 +222,5 @@ module JavaImports
   java_import com.thoughtworks.go.presentation.MissingPluggableTaskViewModel unless defined? MissingPluggableTaskViewModel
   java_import com.thoughtworks.go.config.pluggabletask.PluggableTask unless defined? PluggableTask
   java_import com.thoughtworks.go.plugin.access.pluggabletask.PluggableTaskConfigStore unless defined? PluggableTaskConfigStore
+  java_import com.thoughtworks.go.server.service.support.toggle.Toggles unless defined? Toggles
 end

--- a/server/webapp/WEB-INF/rails.new/spec/views/admin/plugins/plugins/index_html_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/views/admin/plugins/plugins/index_html_spec.rb
@@ -26,12 +26,24 @@ end
 describe "admin/plugins/plugins/index.html.erb" do
 
   it "should have a form to upload plugins" do
+    assign(:upload_feature_enabled, true)
     assign(:plugin_descriptors, [valid_descriptor("1")])
 
     render
 
     plugin_upload = Capybara.string(response.body).find('div#plugins-listing')
     expect(plugin_upload).to have_selector("form")
+  end
+
+  it "should hide the upload plugins form when the Toggles.PLUGIN_UPLOAD_FEATURE_TOGGLE_KEY is off" do
+    assign(:upload_feature_enabled, false)
+    assign(:plugin_descriptors, [])
+
+    render
+
+    expect(response).to_not have_selector('div#plugins-listing div#upload-plugin')
+    expect(response).to_not have_selector('div#plugins-listing form')
+    expect("This test should fail when the toggle is removed. So, access the toggle: #{Toggles.PLUGIN_UPLOAD_FEATURE_TOGGLE_KEY}").to_not be_nil
   end
 
   it "should list a set of plugins" do


### PR DESCRIPTION
To turn this on, you need to do this:

```
curl -d 'toggle_value=on' 'http://go_server/go/api/admin/feature_toggles/plugin_upload_feature_toggle_key'
```

When the Go server has authentication turned on, use with the --user option, like this:

```
curl --user username:password -d 'toggle_value=on' ...
```
