### PR TITLE
Fixed issue with the way query params were handled in agents page

### DIFF
--- a/server/jsunit/tests/micro_content_on_agents_test_rails_new.html
+++ b/server/jsunit/tests/micro_content_on_agents_test_rails_new.html
@@ -380,6 +380,9 @@ function test_should_call_after_close_callback_handler() {
                     <p><a class='' href='http://www.go.cd/documentation/user/current/navigation/agents_page.html#filtering-agents' target='_blank'>More...</a></p>
                 </div>
             </div>
+            <input id='autoRefresh' name='autoRefresh' type='hidden'/>
+            <input id='column' name='column' type='hidden'/>
+            <input id='order' name='order' type='hidden'/>
             <input id='filter_text' name='filter' placeholder='tag: value' type='text'/>
             <button class='submit primary' type='submit'>Filter</button>
             <a class='link_as_button' href='/agents?filter=' id='clear_filter'>Clear</a></form>

--- a/server/webapp/WEB-INF/rails.new/app/controllers/agents_controller.rb
+++ b/server/webapp/WEB-INF/rails.new/app/controllers/agents_controller.rb
@@ -63,7 +63,7 @@ class AgentsController < ApplicationController
   def edit_agents
     result = bulk_edit
     session[LISTING_MESSAGE_KEY] = FlashMessageModel.new(result.message(), result.canContinue() ? 'success' : 'error')
-    redirect_to action: "index"
+    redirect_to action: "index", filter: params[:filter], order: params[:order], column: params[:column]
   end
 
   private
@@ -86,10 +86,6 @@ class AgentsController < ApplicationController
     com.thoughtworks.go.server.ui.SortOrder.orderFor(params[:order] || default)
   end
 
-  helper_method :default_url_options
-  def default_url_options(options = nil)
-    super.reverse_merge(params.only(:filter, :order, :column).symbolize_keys)
-  end
 
   def set_tab_name
     @current_tab_name = "agents"

--- a/server/webapp/WEB-INF/rails.new/app/views/agents/_agent_filter.html.erb
+++ b/server/webapp/WEB-INF/rails.new/app/views/agents/_agent_filter.html.erb
@@ -18,14 +18,15 @@
                 <p><%==l.string("FILTERS_HELP_LINK")%></p>
             </div>
         </div>
-        <%- default_url_options.each do |key, val| -%>
-           <%- unless key.to_sym == :filter -%>
-              <%= hidden_field_tag key, val -%>
-           <%- end -%>
-        <%- end -%>
+
+
+        <%= hidden_field_tag :autoRefresh, params[:autoRefresh] -%>
+        <%= hidden_field_tag :column, params[:column] -%>
+        <%= hidden_field_tag :order, params[:order] -%>
+
         <%= text_field_tag :filter, params[:filter], :placeholder => "tag: value", :id => "filter_text" -%>
         <button type="submit" class="submit primary"><%= l.string("FILTER") -%></button>
-        <%= link_to l.string("CLEAR"), agents_path(:filter => ''), :id => "clear_filter", :class => "link_as_button" -%>
+        <%= link_to l.string("CLEAR"), agents_path(:filter => '', :column => params[:column], :order => params[:order]), :id => "clear_filter", :class => "link_as_button" -%>
     <%= end_form_tag %>
 </div>
 

--- a/server/webapp/WEB-INF/rails.new/app/views/agents/index.html.erb
+++ b/server/webapp/WEB-INF/rails.new/app/views/agents/index.html.erb
@@ -5,7 +5,7 @@
 
     <% if has_operate_permission_for_agents? %>
     <div class="edit_panel" id="dd_ajax_float" style='float:right;'>
-        <%= form_tag(edit_agents_path(:column => params[:column], :order => params[:order]), :id => 'agents_form') -%>
+        <%= form_tag(edit_agents_path(:filter => params[:filter], :column => params[:column], :order => params[:order]), :id => 'agents_form') -%>
         <input id="agent_edit_operation" type="hidden" name="operation" />
 
         <div style="display: none" id="actual_agent_selectors">

--- a/server/webapp/WEB-INF/rails.new/spec/controllers/agents_controller_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/controllers/agents_controller_spec.rb
@@ -138,8 +138,8 @@ describe AgentsController do
       controller.should_receive(:bulk_edit).and_return(bulk_edit_result)
       bulk_edit_result.stub(:message).and_return("successfuly managed to edit")
       bulk_edit_result.stub(:canContinue).and_return(false)
-      get :edit_agents, :column => "foo", :order => "bar"
-      expect(response).to redirect_to("/agents?column=foo&order=bar")
+      get :edit_agents, :column => "foo", :order => "bar", :filter => "criteria"
+      expect(response).to redirect_to("/agents?column=foo&filter=criteria&order=bar")
     end
   end
 

--- a/server/webapp/WEB-INF/rails.new/spec/views/agents/index_html_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/views/agents/index_html_spec.rb
@@ -49,7 +49,15 @@ describe "/agents/index.html.erb" do
     allow(view).to receive(:has_view_or_operate_permission_on_pipeline?).and_return(true)
     allow(view).to receive(:is_user_an_admin?).and_return(true)
     stub_context_path(view)
-    allow(view).to receive(:default_url_options).and_return({})
+  end
+
+  it "should have form with submit path including all params" do
+    allow(view).to receive(:has_operate_permission_for_agents?).and_return(true)
+    in_params(:column => "status", :order => "DESC", :filter => "foobar")
+
+    render
+    page = Capybara::Node::Simple.new(response.body)
+    expect(page).to have_xpath("//form[@id='agents_form' and @action='/agents/edit_agents?column=status&filter=foobar&order=DESC']")
   end
 
   describe "agents page has filtering capability" do
@@ -60,16 +68,16 @@ describe "/agents/index.html.erb" do
     end
 
     it "should have filter textbox" do
-      allow(view).to receive(:default_url_options).and_return({:order => 'ASC', :column => 'status', :autoRefresh => 'false'})
-      render
+      in_params(:column => "status", :order => "ASC", :filter => "foo:bar, moo:boo", :autoRefresh => false)
 
+      render
       Capybara.string(response.body).find("div.filter_agents").tap do |div|
         expect(div).to have_selector("input[type='text'][name='filter'][value='foo:bar, moo:boo']")
         expect(div).to have_selector("input[type='hidden'][name='column'][value='status']")
         expect(div).to have_selector("input[type='hidden'][name='order'][value='ASC']")
         expect(div).to have_selector("input[type='hidden'][name='autoRefresh'][value='false']")
         expect(div).to have_selector("button[type='submit']")
-        expect(div).to have_selector("a[href='/agents?filter='][id='clear_filter']", "Clear")
+        expect(div).to have_selector("a[href='/agents?column=status&filter=&order=ASC'][id='clear_filter']", "Clear")
       end
     end
 


### PR DESCRIPTION
default_url_options was overridden in agents_controller causing any redirects from this page to contain query params for column and order. This lead to a blank page being displayed when navigating to user summary page from here.
All get and post paths used in this page have been fixed to pass along the necessary params