### PR TITLE
#724 - Proper STARTLS support for email notifications

### DIFF
--- a/server/src/com/thoughtworks/go/config/GoSmtpMailSender.java
+++ b/server/src/com/thoughtworks/go/config/GoSmtpMailSender.java
@@ -140,13 +140,13 @@ public class GoSmtpMailSender implements GoMailSender {
             props.put("mail.smtp.timeout", DEFAULT_TIMEOUT);
         }
 
-        if (tls) {
-            props.put("mail.transport.protocol", "smtps");
-
-        } else {
-            props.put("mail.transport.protocol", "smtp");
+        if (System.getProperties().containsKey("mail.smtp.starttls.enable")) {
+            props.put("mail.smtp.starttls.enable", "true");
         }
-//        props.put("mail.debug", "true");
+
+        String mailProtocol = tls ? "smtps" : "smtp";
+        props.put("mail.transport.protocol", mailProtocol);
+
         return props;
     }
 

--- a/server/src/com/thoughtworks/go/config/MailSession.java
+++ b/server/src/com/thoughtworks/go/config/MailSession.java
@@ -1,0 +1,91 @@
+/*************************GO-LICENSE-START*********************************
+ * Copyright 2014 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *************************GO-LICENSE-END***********************************/
+
+package com.thoughtworks.go.config;
+
+import javax.mail.*;
+import javax.mail.internet.InternetAddress;
+import javax.mail.internet.MimeMessage;
+import java.util.Date;
+import java.util.Properties;
+
+import static javax.mail.Message.RecipientType.TO;
+
+/* This class is a wrapper over javax.mail.Session, which has been marked "final", making
+ * it nearly impossible to test, especially since it is created statically.
+ *
+ * The getInstance method in this class can be setup to return a mock or stub of
+ * an instance of this class, and tests can be written against users of the session. */
+public class MailSession {
+    public static MailSession fakeSessionJustForTestsSinceSessionClassIsFinal = null;
+    private Session session;
+
+    public static MailSession getInstance() {
+        if (fakeSessionJustForTestsSinceSessionClassIsFinal != null) {
+            return fakeSessionJustForTestsSinceSessionClassIsFinal;
+        }
+        return new MailSession();
+    }
+
+    public MailSession createWith(Properties props, String username, String password) {
+        this.session = createSession(props, username, password);
+        return this;
+    }
+
+    public Transport getTransport() throws NoSuchProviderException {
+        return session.getTransport();
+    }
+
+    public MimeMessage createMessage(String from, String to, String subject, String body)
+            throws MessagingException {
+        MimeMessage msg = new MimeMessage(session);
+        msg.setFrom(new InternetAddress(from));
+        msg.setRecipients(TO, to);
+        msg.setSubject(subject);
+        msg.setContent(msg, "text/plain");
+        msg.setSentDate(new Date());
+        msg.setText(body);
+        msg.setSender(new InternetAddress(from));
+        msg.setReplyTo(new InternetAddress[]{new InternetAddress(from)});
+        return msg;
+    }
+
+    private Session createSession(Properties props, String username, String password) {
+        Session session;
+        if (username == null || password == null || username.equals("") || password.equals("")) {
+            session = Session.getInstance(props);
+        } else {
+            props.put("mail.smtp.auth", "true");
+            props.put("mail.smtps.auth", "true");
+            session = Session.getInstance(props, new SMTPAuthenticator(username, password));
+        }
+        return session;
+    }
+
+    private final class SMTPAuthenticator extends Authenticator {
+        private final String username;
+        private final String password;
+
+        public SMTPAuthenticator(String username, String password) {
+            this.username = username;
+            this.password = password;
+        }
+
+        protected PasswordAuthentication getPasswordAuthentication() {
+            return new PasswordAuthentication(username, password);
+        }
+    }
+}

--- a/server/test/unit/com/thoughtworks/go/config/GoSmtpMailSenderTest.java
+++ b/server/test/unit/com/thoughtworks/go/config/GoSmtpMailSenderTest.java
@@ -18,36 +18,171 @@ package com.thoughtworks.go.config;
 
 import com.thoughtworks.go.domain.materials.ValidationBean;
 import com.thoughtworks.go.security.GoCipher;
+import com.thoughtworks.go.util.GoConstants;
 import org.bouncycastle.crypto.InvalidCipherTextException;
+import org.junit.After;
 import org.junit.Test;
 import org.junit.internal.runners.JUnit4ClassRunner;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+
+import javax.mail.Address;
+import javax.mail.Transport;
+import javax.mail.internet.MimeMessage;
+import java.util.Properties;
 
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNot.not;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.*;
 
 @RunWith(JUnit4ClassRunner.class)
 public class GoSmtpMailSenderTest {
+    private static final String SMTP_CONNECTIONTIMEOUT_PROPERTY = "mail.smtp.connectiontimeout";
+    private static final String SMTP_TIMEOUT_PROPERTY = "mail.smtp.timeout";
+    public static final String MAIL_FROM_PROPERTY = "mail.from";
+    public static final String MAIL_TRANSPORT_PROTOCOL_PROPERTY = "mail.transport.protocol";
+    private static final String MAIL_SMTP_STARTTLS_PROPERTY = "mail.smtp.starttls.enable";
 
     private final String hostName = "smtp.company.test";
+    private final String from = "from.cruise.test@gmail.com";
+    private final String to = "cruise.test.admin@gmail.com";
+    private final String subject = "Subject";
+    private final String body = "Body";
+    private final int port = 25;
+    private final String username = "cruise2";
+    private final String password = "password123";
+
+    @After
+    public void tearDown() throws Exception {
+        FakeMailSession.tearDown();
+    }
 
     @Test
     public void testShouldNotSendOutTestEmailToAdminstrator() {
-        GoSmtpMailSender sender = new GoSmtpMailSender(hostName, 465, "cruise.test.admin@gmail.com",
-                "password123", true,
-                "from.cruise.test@gmail.com", "cruise.test.admin@gmail.com");
-        ValidationBean bean = sender.send("Subject", "Body", "cruise.test.admin@gmail.com");
+        GoSmtpMailSender sender = new GoSmtpMailSender(hostName, 465, to, password, true, from, to);
+        ValidationBean bean = sender.send(subject, body, to);
 
         assertThat(bean, is(not(ValidationBean.valid())));
     }
-    
+
     @Test
     public void shouldNotSendTestEmailToSmtpServerIfTlsConfiguredIncorrect() {
-        GoSmtpMailSender sender = new GoSmtpMailSender(hostName, 25, "cruise2", "password123", true, "from.cruise.test@gmail.com", "cruise.test.admin@gmail.com");
-        ValidationBean bean = sender.send("Subject", "Body", "cruise.test.admin@gmail.com");
+        GoSmtpMailSender sender = new GoSmtpMailSender(hostName, 25, username, password, true, from, to);
+        ValidationBean bean = sender.send(subject, body, to);
 
         assertThat(bean, is(not(ValidationBean.valid())));
+    }
+
+    @Test
+    public void shouldSendAMailWhenValidationSucceeds() throws Exception {
+        FakeMailSession mailSession = FakeMailSession.setupFor(username, password, from, to, subject, body);
+
+        GoSmtpMailSender sender = new GoSmtpMailSender(hostName, port, username, password, true, from, to);
+        ValidationBean bean = sender.send(subject, body, to);
+
+        assertThat(bean, is(ValidationBean.valid()));
+        mailSession.verifyThatConnectionWasMadeTo(hostName, port, username, password);
+        mailSession.verifyMessageWasSent();
+        mailSession.verifyTransportWasClosed();
+    }
+
+    @Test
+    public void shouldSetMailFromProperty() throws Exception {
+        FakeMailSession mailSession = FakeMailSession.setupFor(username, password, from, to, subject, body);
+
+        GoSmtpMailSender sender = new GoSmtpMailSender(hostName, port, username, password, true, from, to);
+        ValidationBean bean = sender.send(subject, body, to);
+
+        assertThat(bean, is(ValidationBean.valid()));
+        mailSession.verifyMessageWasSent();
+        mailSession.verifyProperty(MAIL_FROM_PROPERTY, from);
+    }
+
+    @Test
+    public void shouldSetDefaultMailTimeoutPropertiesWhenNoOverridingValuesAreProvided() throws Exception {
+        FakeMailSession mailSession = FakeMailSession.setupFor(username, password, from, to, subject, body);
+
+        GoSmtpMailSender sender = new GoSmtpMailSender(hostName, port, username, password, true, from, to);
+        ValidationBean bean = sender.send(subject, body, to);
+
+        assertThat(bean, is(ValidationBean.valid()));
+        mailSession.verifyMessageWasSent();
+        mailSession.verifyProperty(SMTP_CONNECTIONTIMEOUT_PROPERTY, GoConstants.DEFAULT_TIMEOUT);
+        mailSession.verifyProperty(SMTP_TIMEOUT_PROPERTY, GoConstants.DEFAULT_TIMEOUT);
+    }
+
+    @Test
+    public void shouldNotOverrideSMTPConnectionTimeoutPropertyIfItIsSetAtSystemLevel() throws Exception {
+        FakeMailSession mailSession = FakeMailSession.setupFor(username, password, from, to, subject, body);
+
+        GoSmtpMailSender sender = new GoSmtpMailSender(hostName, port, username, password, true, from, to);
+        sendMailWithPropertySetTo(sender, SMTP_CONNECTIONTIMEOUT_PROPERTY, "12345");
+
+        mailSession.verifyMessageWasSent();
+        mailSession.verifyPropertyDoesNotExist(SMTP_CONNECTIONTIMEOUT_PROPERTY);
+        mailSession.verifyProperty(SMTP_TIMEOUT_PROPERTY, GoConstants.DEFAULT_TIMEOUT);
+    }
+
+    @Test
+    public void shouldNotOverrideSMTPTimeoutPropertyIfItIsSetAtSystemLevel() throws Exception {
+        FakeMailSession mailSession = FakeMailSession.setupFor(username, password, from, to, subject, body);
+
+        GoSmtpMailSender sender = new GoSmtpMailSender(hostName, port, username, password, true, from, to);
+        sendMailWithPropertySetTo(sender, SMTP_TIMEOUT_PROPERTY, "12345");
+
+        mailSession.verifyMessageWasSent();
+        mailSession.verifyProperty(SMTP_CONNECTIONTIMEOUT_PROPERTY, GoConstants.DEFAULT_TIMEOUT);
+        mailSession.verifyPropertyDoesNotExist(SMTP_TIMEOUT_PROPERTY);
+    }
+
+    @Test
+    public void shouldSetProtocolToSMTPSWhenSMTPSIsEnabled() throws Exception {
+        FakeMailSession mailSession = FakeMailSession.setupFor(username, password, from, to, subject, body);
+
+        boolean isSMTPSEnabled = true;
+        GoSmtpMailSender sender = new GoSmtpMailSender(hostName, port, username, password, isSMTPSEnabled, from, to);
+        ValidationBean bean = sender.send(subject, body, to);
+
+        assertThat(bean, is(ValidationBean.valid()));
+        mailSession.verifyMessageWasSent();
+        mailSession.verifyProperty(MAIL_TRANSPORT_PROTOCOL_PROPERTY, "smtps");
+    }
+
+    @Test
+    public void shouldSetProtocolToSMTPWhenSMTPSIsDisabled() throws Exception {
+        FakeMailSession mailSession = FakeMailSession.setupFor(username, password, from, to, subject, body);
+
+        boolean isSMTPSEnabled = false;
+        GoSmtpMailSender sender = new GoSmtpMailSender(hostName, port, username, password, isSMTPSEnabled, from, to);
+        ValidationBean bean = sender.send(subject, body, to);
+
+        assertThat(bean, is(ValidationBean.valid()));
+        mailSession.verifyMessageWasSent();
+        mailSession.verifyProperty(MAIL_TRANSPORT_PROTOCOL_PROPERTY, "smtp");
+    }
+
+    @Test
+    public void shouldEnableSMTPS_With_StartTLS_WhenThePropertyIsSet() throws Exception {
+        FakeMailSession mailSession = FakeMailSession.setupFor(username, password, from, to, subject, body);
+
+        GoSmtpMailSender sender = new GoSmtpMailSender(hostName, port, username, password, false, from, to);
+        sendMailWithPropertySetTo(sender, MAIL_SMTP_STARTTLS_PROPERTY, "any-non-null-value");
+
+        mailSession.verifyMessageWasSent();
+        mailSession.verifyProperty(MAIL_SMTP_STARTTLS_PROPERTY, "true");
+    }
+
+    @Test
+    public void shouldNotEnableSMTPS_With_StartTLS_WhenThePropertyIsNotSet() throws Exception {
+        FakeMailSession mailSession = FakeMailSession.setupFor(username, password, from, to, subject, body);
+
+        GoSmtpMailSender sender = new GoSmtpMailSender(hostName, port, username, password, false, from, to);
+        sendMailWithPropertySetTo(sender, MAIL_SMTP_STARTTLS_PROPERTY, null);
+
+        mailSession.verifyMessageWasSent();
+        mailSession.verifyPropertyDoesNotExist(MAIL_SMTP_STARTTLS_PROPERTY);
     }
 
     @Test
@@ -75,4 +210,79 @@ public class GoSmtpMailSenderTest {
         assertThat((BackgroundMailSender) sender, is(new BackgroundMailSender(new GoSmtpMailSender(hostName, 25, "smtpuser", "encrypted_password", true, "cruise@me.com", "jez@me.com"))));
     }
 
+    private void sendMailWithPropertySetTo(GoSmtpMailSender sender, String property, String value) {
+        String oldValue = System.getProperty(property);
+
+        if (value == null) {
+            System.clearProperty(property);
+        } else {
+            System.setProperty(property, value);
+        }
+
+        try {
+            sender.send(subject, body, to);
+        } finally {
+            if (oldValue == null) {
+                System.clearProperty(property);
+            } else {
+                System.setProperty(property, oldValue);
+            }
+        }
+    }
+
+    private static class FakeMailSession {
+        private Transport transport = mock(Transport.class);
+        private MimeMessage message = mock(MimeMessage.class);
+        private MailSession session = mock(MailSession.class);
+
+        public static void tearDown() {
+            MailSession.fakeSessionJustForTestsSinceSessionClassIsFinal = null;
+        }
+
+        public static FakeMailSession setupFor(String username, String password, String from, String to, String subject, String body) throws Exception {
+            return new FakeMailSession(username, password, from, to, subject, body);
+        }
+
+        public FakeMailSession(String username, String password, String from, String to, String subject, String body) throws Exception {
+            MailSession.fakeSessionJustForTestsSinceSessionClassIsFinal = session;
+
+            when(session.getTransport()).thenReturn(transport);
+            when(session.createWith(any(Properties.class), eq(username), eq(password))).thenReturn(session);
+            when(session.createMessage(from, to, subject, body)).thenReturn(message);
+        }
+
+        public void verifyMessageWasSent() throws Exception {
+            verify(transport).sendMessage(eq(message), any(Address[].class));
+        }
+
+        public void verifyThatConnectionWasMadeTo(String hostName, int port, String username, String password) throws Exception {
+            verify(transport).connect(hostName, port, username, password);
+        }
+
+        public void verifyProperty(String expectedProperty, Object expectedValueOfProperty) {
+            Properties properties = getPropertiesUsedInSession();
+            if (!expectedValueOfProperty.equals(properties.get(expectedProperty))) {
+                fail("Could not find property: " + expectedProperty + " with value: " + expectedValueOfProperty + ". Properties found were: " + properties);
+            }
+        }
+
+        public void verifyPropertyDoesNotExist(String propertyWhichShouldNotExist) {
+            Properties properties = getPropertiesUsedInSession();
+
+            if (properties.containsKey(propertyWhichShouldNotExist)) {
+                fail("Did not expect to find property: " + propertyWhichShouldNotExist + ". Found it in properties list: " + properties);
+            }
+        }
+
+        private Properties getPropertiesUsedInSession() {
+            ArgumentCaptor<Properties> propertyCaptor = ArgumentCaptor.forClass(Properties.class);
+            verify(session).createWith(propertyCaptor.capture(), any(String.class), any(String.class));
+
+            return propertyCaptor.getValue();
+        }
+
+        public void verifyTransportWasClosed() throws Exception {
+            verify(transport).close();
+        }
+    }
 }

--- a/server/test/unit/com/thoughtworks/go/config/GoSmtpMailSenderTest.java
+++ b/server/test/unit/com/thoughtworks/go/config/GoSmtpMailSenderTest.java
@@ -273,15 +273,15 @@ public class GoSmtpMailSenderTest {
             }
         }
 
+        public void verifyTransportWasClosed() throws Exception {
+            verify(transport).close();
+        }
+
         private Properties getPropertiesUsedInSession() {
             ArgumentCaptor<Properties> propertyCaptor = ArgumentCaptor.forClass(Properties.class);
             verify(session).createWith(propertyCaptor.capture(), any(String.class), any(String.class));
 
             return propertyCaptor.getValue();
-        }
-
-        public void verifyTransportWasClosed() throws Exception {
-            verify(transport).close();
         }
     }
 }

--- a/server/test/unit/com/thoughtworks/go/config/GoSmtpMailSenderTest.java
+++ b/server/test/unit/com/thoughtworks/go/config/GoSmtpMailSenderTest.java
@@ -89,7 +89,7 @@ public class GoSmtpMailSenderTest {
     }
 
     @Test
-    public void shouldSetMailFromProperty() throws Exception {
+    public void shouldSet_MailFrom_Property() throws Exception {
         FakeMailSession mailSession = FakeMailSession.setupFor(username, password, from, to, subject, body);
 
         GoSmtpMailSender sender = new GoSmtpMailSender(hostName, port, username, password, true, from, to);
@@ -268,7 +268,6 @@ public class GoSmtpMailSenderTest {
 
         public void verifyPropertyDoesNotExist(String propertyWhichShouldNotExist) {
             Properties properties = getPropertiesUsedInSession();
-
             if (properties.containsKey(propertyWhichShouldNotExist)) {
                 fail("Did not expect to find property: " + propertyWhichShouldNotExist + ". Found it in properties list: " + properties);
             }


### PR DESCRIPTION
Fixes #724. STARTLS can be enabled by setting the system property ```mail.smtp.starttls.enable``` to any value. Need to update documentation and change message in UI from "Use TLS" to "Use SMTPS". Will do as a part of #723.