### PR TITLE
#103 - Fix agent plugin cleanup

### DIFF
--- a/agent/src/com/thoughtworks/go/agent/AgentPluginsInitializer.java
+++ b/agent/src/com/thoughtworks/go/agent/AgentPluginsInitializer.java
@@ -21,6 +21,7 @@ import com.thoughtworks.go.plugin.infra.PluginManager;
 import com.thoughtworks.go.plugin.infra.monitor.DefaultPluginJarLocationMonitor;
 import com.thoughtworks.go.util.SystemEnvironment;
 import com.thoughtworks.go.util.ZipUtil;
+import org.apache.commons.io.FileUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -54,6 +55,10 @@ public class AgentPluginsInitializer implements ApplicationListener<ContextRefre
         try {
             File agentPluginsZip = new File(DownloadableFile.AGENT_PLUGINS.getLocalFileName());
             File pluginsFolder = new File(systemEnvironment.get(SystemEnvironment.AGENT_PLUGINS_PATH));
+
+            if (pluginsFolder.exists()) {
+                FileUtils.forceDelete(pluginsFolder);
+            }
             zipUtil.unzip(agentPluginsZip, pluginsFolder);
             defaultPluginJarLocationMonitor.initialize();
             pluginManager.startPluginInfrastructure();

--- a/agent/src/com/thoughtworks/go/agent/AgentPluginsInitializer.java
+++ b/agent/src/com/thoughtworks/go/agent/AgentPluginsInitializer.java
@@ -16,20 +16,20 @@
 
 package com.thoughtworks.go.agent;
 
-import java.io.File;
-import java.io.IOException;
-
 import com.thoughtworks.go.agent.launcher.DownloadableFile;
-import com.thoughtworks.go.util.SystemEnvironment;
-import com.thoughtworks.go.util.ZipUtil;
 import com.thoughtworks.go.plugin.infra.PluginManager;
 import com.thoughtworks.go.plugin.infra.monitor.DefaultPluginJarLocationMonitor;
+import com.thoughtworks.go.util.SystemEnvironment;
+import com.thoughtworks.go.util.ZipUtil;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationListener;
 import org.springframework.context.event.ContextRefreshedEvent;
 import org.springframework.stereotype.Component;
+
+import java.io.File;
+import java.io.IOException;
 
 @Component
 public class AgentPluginsInitializer implements ApplicationListener<ContextRefreshedEvent> {
@@ -38,19 +38,22 @@ public class AgentPluginsInitializer implements ApplicationListener<ContextRefre
 
     private final DefaultPluginJarLocationMonitor defaultPluginJarLocationMonitor;
     private ZipUtil zipUtil;
+    private SystemEnvironment systemEnvironment;
 
     @Autowired
-    public AgentPluginsInitializer(PluginManager pluginManager, DefaultPluginJarLocationMonitor defaultPluginJarLocationMonitor, ZipUtil zipUtil) {
+    public AgentPluginsInitializer(PluginManager pluginManager, DefaultPluginJarLocationMonitor defaultPluginJarLocationMonitor,
+                                   ZipUtil zipUtil, SystemEnvironment systemEnvironment) {
         this.pluginManager = pluginManager;
         this.defaultPluginJarLocationMonitor = defaultPluginJarLocationMonitor;
         this.zipUtil = zipUtil;
+        this.systemEnvironment = systemEnvironment;
     }
 
     @Override
     public void onApplicationEvent(ContextRefreshedEvent contextRefreshedEvent) {
         try {
             File agentPluginsZip = new File(DownloadableFile.AGENT_PLUGINS.getLocalFileName());
-            File pluginsFolder = new File(SystemEnvironment.PLUGINS_PATH);
+            File pluginsFolder = new File(systemEnvironment.get(SystemEnvironment.AGENT_PLUGINS_PATH));
             zipUtil.unzip(agentPluginsZip, pluginsFolder);
             defaultPluginJarLocationMonitor.initialize();
             pluginManager.startPluginInfrastructure();

--- a/agent/test/unit/com/thoughtworks/go/agent/AgentPluginsInitializerIntegrationTest.java
+++ b/agent/test/unit/com/thoughtworks/go/agent/AgentPluginsInitializerIntegrationTest.java
@@ -1,0 +1,5 @@
+package com.thoughtworks.go.agent;
+
+public class AgentPluginsInitializerIntegrationTest {
+
+}

--- a/agent/test/unit/com/thoughtworks/go/agent/AgentPluginsInitializerIntegrationTest.java
+++ b/agent/test/unit/com/thoughtworks/go/agent/AgentPluginsInitializerIntegrationTest.java
@@ -1,5 +1,156 @@
 package com.thoughtworks.go.agent;
 
-public class AgentPluginsInitializerIntegrationTest {
+import com.thoughtworks.go.plugin.infra.PluginManager;
+import com.thoughtworks.go.plugin.infra.monitor.DefaultPluginJarLocationMonitor;
+import com.thoughtworks.go.util.*;
+import org.apache.commons.io.FileUtils;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
 
+import java.io.File;
+import java.io.IOException;
+
+import static com.thoughtworks.go.agent.launcher.DownloadableFile.AGENT_PLUGINS;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+/* Some parts are mocked, as in AgentPluginsInitializerTest, but the file system (through ZipUtil) is not. */
+public class AgentPluginsInitializerIntegrationTest {
+    @Mock private PluginManager pluginManager;
+    @Mock private DefaultPluginJarLocationMonitor pluginJarLocationMonitor;
+    @Mock private SystemEnvironment systemEnvironment;
+
+    private File directoryForUnzippedPlugins;
+    private AgentPluginsInitializer agentPluginsInitializer;
+
+    @Before
+    public void setUp() throws Exception {
+        initMocks(this);
+        agentPluginsInitializer = new AgentPluginsInitializer(pluginManager, pluginJarLocationMonitor, new ZipUtil(), systemEnvironment);
+
+        directoryForUnzippedPlugins = setupUnzippedPluginsDirectoryStructure();
+        when(systemEnvironment.get(SystemEnvironment.AGENT_PLUGINS_PATH)).thenReturn(directoryForUnzippedPlugins.getAbsolutePath());
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        cleanupAgentPluginsFile();
+        TestFileUtil.cleanTempFiles();
+    }
+
+    @Test
+    public void shouldRemoveExistingBundledPluginsBeforeInitializingNewPlugins() throws Exception {
+        File existingBundledPlugin = new File(directoryForUnzippedPlugins, "bundled/existing-plugin-1.jar");
+
+        setupAgentsPluginFile().withBundledPlugin("new-plugin-1.jar", "SOME-PLUGIN-CONTENT").done();
+        FileUtils.writeStringToFile(existingBundledPlugin, "OLD-CONTENT");
+
+        agentPluginsInitializer.onApplicationEvent(null);
+
+        assertThat(existingBundledPlugin.exists(), is(false));
+        assertThat(new File(directoryForUnzippedPlugins, "bundled/new-plugin-1.jar").exists(), is(true));
+    }
+
+    @Test
+    public void shouldReplaceExistingBundledPluginsWithNewPluginsOfSameName() throws Exception {
+        File bundledPlugin = new File(directoryForUnzippedPlugins, "bundled/plugin-1.jar");
+
+        setupAgentsPluginFile().withBundledPlugin("plugin-1.jar", "SOME-NEW-CONTENT").done();
+        FileUtils.writeStringToFile(bundledPlugin, "OLD-CONTENT");
+
+        agentPluginsInitializer.onApplicationEvent(null);
+
+        assertThat(bundledPlugin.exists(), is(true));
+        assertThat(FileUtils.readFileToString(bundledPlugin), is("SOME-NEW-CONTENT"));
+    }
+
+    @Test
+    public void shouldRemoveExistingExternalPluginsBeforeInitializingNewPlugins() throws Exception {
+        File existingExternalPlugin = new File(directoryForUnzippedPlugins, "external/existing-plugin-1.jar");
+
+        setupAgentsPluginFile().withExternalPlugin("new-plugin-1.jar", "SOME-PLUGIN-CONTENT").done();
+        FileUtils.writeStringToFile(existingExternalPlugin, "OLD-CONTENT");
+
+        agentPluginsInitializer.onApplicationEvent(null);
+
+        assertThat(existingExternalPlugin.exists(), is(false));
+        assertThat(new File(directoryForUnzippedPlugins, "external/new-plugin-1.jar").exists(), is(true));
+    }
+
+    @Test
+    public void shouldReplaceExistingExternalPluginsWithNewPluginsOfSameName() throws Exception {
+        File externalPlugin = new File(directoryForUnzippedPlugins, "external/plugin-1.jar");
+
+        setupAgentsPluginFile().withExternalPlugin("plugin-1.jar", "SOME-NEW-CONTENT").done();
+        FileUtils.writeStringToFile(externalPlugin, "OLD-CONTENT");
+
+        agentPluginsInitializer.onApplicationEvent(null);
+
+        assertThat(externalPlugin.exists(), is(true));
+        assertThat(FileUtils.readFileToString(externalPlugin), is("SOME-NEW-CONTENT"));
+    }
+
+    @Test
+    public void shouldRemoveAnExistingPluginWhenItHasBeenRemovedFromTheServerSide() throws Exception {
+        File existingExternalPlugin = new File(directoryForUnzippedPlugins, "external/plugin-1.jar");
+
+        setupAgentsPluginFile().done();
+        FileUtils.writeStringToFile(existingExternalPlugin, "OLD-CONTENT");
+
+        agentPluginsInitializer.onApplicationEvent(null);
+
+        assertThat(existingExternalPlugin.exists(), is(false));
+    }
+
+    private File setupUnzippedPluginsDirectoryStructure() throws IOException {
+        File dir = TestFileUtil.createTempFolder("unzipped-plugins");
+        FileUtils.forceMkdir(new File(dir, "bundled"));
+        FileUtils.forceMkdir(new File(dir, "external"));
+        return dir;
+    }
+
+    private SetupOfAgentPluginsFile setupAgentsPluginFile() throws IOException {
+        return new SetupOfAgentPluginsFile(new File(AGENT_PLUGINS.getLocalFileName()));
+    }
+
+    private void cleanupAgentPluginsFile() throws IOException {
+        File pluginsFile = new File(AGENT_PLUGINS.getLocalFileName());
+        if (pluginsFile.exists()) {
+            FileUtils.forceDelete(pluginsFile);
+        }
+    }
+
+    private class SetupOfAgentPluginsFile {
+        private final File bundledPluginsDir;
+        private final File externalPluginsDir;
+        private final ZipUtil zipUtil;
+        private File pluginsZipFile;
+
+        public SetupOfAgentPluginsFile(File pluginsZipFile) {
+            this.pluginsZipFile = pluginsZipFile;
+            this.bundledPluginsDir = TestFileUtil.createTempFolder("bundled");
+            this.externalPluginsDir = TestFileUtil.createTempFolder("external");
+            this.zipUtil = new ZipUtil();
+        }
+
+        public SetupOfAgentPluginsFile withBundledPlugin(String pluginFileName, String pluginFileContent) throws IOException {
+            FileUtils.writeStringToFile(new File(bundledPluginsDir, pluginFileName), pluginFileContent);
+            return this;
+        }
+
+        public SetupOfAgentPluginsFile withExternalPlugin(String pluginFileName, String pluginFileContent) throws IOException {
+            FileUtils.writeStringToFile(new File(externalPluginsDir, pluginFileName), pluginFileContent);
+            return this;
+        }
+
+        public File done() throws IOException {
+            ZipBuilder zipBuilder = zipUtil.zipContentsOfMultipleFolders(pluginsZipFile, true);
+            zipBuilder.add("bundled", bundledPluginsDir).add("external", externalPluginsDir).done();
+            return pluginsZipFile;
+        }
+    }
 }

--- a/agent/test/unit/com/thoughtworks/go/agent/AgentPluginsInitializerTest.java
+++ b/agent/test/unit/com/thoughtworks/go/agent/AgentPluginsInitializerTest.java
@@ -16,37 +16,36 @@
 
 package com.thoughtworks.go.agent;
 
-import java.io.File;
-import java.io.IOException;
-
 import com.thoughtworks.go.agent.launcher.DownloadableFile;
-import com.thoughtworks.go.util.SystemEnvironment;
-import com.thoughtworks.go.util.ZipUtil;
 import com.thoughtworks.go.plugin.infra.PluginManager;
 import com.thoughtworks.go.plugin.infra.monitor.DefaultPluginJarLocationMonitor;
+import com.thoughtworks.go.util.SystemEnvironment;
+import com.thoughtworks.go.util.ZipUtil;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.InOrder;
+import org.mockito.Mock;
+
+import java.io.File;
+import java.io.IOException;
 
 import static org.junit.Assert.fail;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.inOrder;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
+import static org.mockito.MockitoAnnotations.initMocks;
 
 public class AgentPluginsInitializerTest {
+    @Mock private ZipUtil zipUtil;
+    @Mock private PluginManager pluginManager;
+    @Mock private DefaultPluginJarLocationMonitor pluginJarLocationMonitor;
+    @Mock private SystemEnvironment systemEnvironment;
 
-    private ZipUtil zipUtil;
-    private PluginManager pluginManager;
     private AgentPluginsInitializer agentPluginsInitializer;
-    private DefaultPluginJarLocationMonitor pluginJarLocationMonitor;
 
     @Before
     public void setUp() throws Exception {
-        zipUtil = mock(ZipUtil.class);
-        pluginManager = mock(PluginManager.class);
-        pluginJarLocationMonitor = mock(DefaultPluginJarLocationMonitor.class);
-        agentPluginsInitializer = new AgentPluginsInitializer(pluginManager, pluginJarLocationMonitor, zipUtil);
+        initMocks(this);
+        agentPluginsInitializer = new AgentPluginsInitializer(pluginManager, pluginJarLocationMonitor, zipUtil, systemEnvironment);
+        when(systemEnvironment.get(SystemEnvironment.AGENT_PLUGINS_PATH)).thenReturn(SystemEnvironment.PLUGINS_PATH);
     }
 
     @Test
@@ -84,6 +83,4 @@ public class AgentPluginsInitializerTest {
             fail("should have handled IOException");
         }
     }
-
-
 }

--- a/base/src/com/thoughtworks/go/util/SystemEnvironment.java
+++ b/base/src/com/thoughtworks/go/util/SystemEnvironment.java
@@ -129,6 +129,7 @@ public class SystemEnvironment implements Serializable, ConfigDirProvider {
             new GoStringSystemProperty("default.command.snippets.zip.location", "/defaultFiles/defaultCommandSnippets.zip"));
     public static GoSystemProperty<String> DEFAULT_PLUGINS_ZIP = new CachedProperty<String>(
             new GoStringSystemProperty("default.plugins.zip.location", "/defaultFiles/plugins.zip"));
+    public static final GoSystemProperty<String> AGENT_PLUGINS_PATH = new CachedProperty<String>(new GoStringSystemProperty("agent.plugins.path", PLUGINS_PATH));
     public static GoSystemProperty<String> VERSION_FILE_IN_DEFAULT_COMMAND_REPOSITORY = new CachedProperty<String>(new GoStringSystemProperty("version.file.in.command.repository", "version.txt"));
     public static GoSystemProperty<Integer> COMMAND_REPOSITORY_CACHE_TIME_IN_SECONDS = new CachedProperty<Integer>(new GoIntSystemProperty("command.repo.cache.timeout.in.secs", 30 * 60));
     public static GoSystemProperty<String> COMMAND_REPOSITORY_DIRECTORY = new CachedProperty<String>(new GoStringSystemProperty("command.repo.dir", DB_BASE_DIR + "command_repository"));


### PR DESCRIPTION
This fixes the symptom, but not the real root issue. The symptom is that plugins removed on the server-side were not properly removed from the agent-side. The code in this PR fixes that.

However, there needs to be more intelligence in the way newer plugins are introduced to both the server and agent sides. Not just a full copy of all the plugins sent every time. That will remove the need for the agent to restart itself, when new plugins are installed.