### PR TITLE
#000 - Properly hide ActiveRecord warning.

### DIFF
--- a/server/webapp/WEB-INF/rails.new/config/environment.rb
+++ b/server/webapp/WEB-INF/rails.new/config/environment.rb
@@ -1,9 +1,9 @@
-# Load the Rails application.
-require File.expand_path('../application', __FILE__)
-
 # Adding below ENVs because engine-routes need them
 ENV['ADMIN_OAUTH_URL_PREFIX'] = "admin"
 ENV['LOAD_OAUTH_SILENTLY'] = "yes"
+
+# Load the Rails application.
+require File.expand_path('../application', __FILE__)
 
 # Initialize the Rails application.
 Go::Application.initialize!


### PR DESCRIPTION
Was showing up because LOAD_OAUTH_SILENTLY was set after model_base.rb was loaded.

The warning shown was:

```
********************************************************************************
*** Activerecord is not defined! Using InMemoryDatasource, which will not persist across application restarts!! ***
********************************************************************************
```

It was misleading.