### PR TITLE
Change init.d script to redirect the output of start_daemon calls.

### DIFF
--- a/installers/agent/release/init.cruise-agent
+++ b/installers/agent/release/init.cruise-agent
@@ -68,9 +68,9 @@ start_go_agent() {
 
     if [ "$JAVA_HOME" != "" ]; then
         if [ "${CUR_USER}" == "root" ]; then
-            start_daemon /bin/su - go -c /usr/share/go-agent/agent.sh
+            start_daemon /bin/su - go -c /usr/share/go-agent/agent.sh >/dev/null 2>&1
         else
-            start_daemon /usr/share/go-agent/agent.sh
+            start_daemon /usr/share/go-agent/agent.sh >/dev/null 2>&1
         fi
     else
         log_failure_msg "Starting up of Go Agent requires JAVA_HOME to be set in /etc/default/go-agent. Please set JAVA_HOME to proceed."

--- a/installers/server/release/init.cruise-server
+++ b/installers/server/release/init.cruise-server
@@ -68,9 +68,9 @@ start_go_server() {
 
     if [ "$JAVA_HOME" != "" ]; then
         if [ "${CUR_USER}" == "root" ]; then
-            start_daemon /bin/su - go -c /usr/share/go-server/server.sh
+            start_daemon /bin/su - go -c /usr/share/go-server/server.sh >/dev/null 2>&1
         else
-            start_daemon /usr/share/go-server/server.sh
+            start_daemon /usr/share/go-server/server.sh >/dev/null 2>&1
         fi
     else
         log_failure_msg "Starting up of Go Server requires JAVA_HOME to be set in /etc/default/go-server. Please set JAVA_HOME to proceed."


### PR DESCRIPTION
Currently the absence of this redirection causes configuration
management tools such as Saltstack to hang on service start, as the
process waits infintely for the file descriptors to close.
Tested with init.d script on Ubuntu 14.04.

closes #846