### PR TITLE
#57 - Handling windows file system path as a part hgurlargument.defaultRemoteUrl

### DIFF
--- a/common/test/com/thoughtworks/go/util/command/HgUrlArgumentTest.java
+++ b/common/test/com/thoughtworks/go/util/command/HgUrlArgumentTest.java
@@ -57,5 +57,9 @@ public class HgUrlArgumentTest {
     public void shouldNotModifyFileURIS() throws Exception {
         assertThat(new HgUrlArgument("file://junk").defaultRemoteUrl(), is("file://junk"));
     }
+    @Test
+    public void shouldNotModifyWindowsFileSystemPath() throws Exception {
+        assertThat(new HgUrlArgument("c:\\foobar").defaultRemoteUrl(), is("c:\\foobar"));
+    }
 
 }

--- a/config/config-api/src/com/thoughtworks/go/util/command/HgUrlArgument.java
+++ b/config/config-api/src/com/thoughtworks/go/util/command/HgUrlArgument.java
@@ -53,7 +53,7 @@ public class HgUrlArgument extends UrlArgument {
                 return uri.toString();
             }
         } catch (URISyntaxException e) {
-            throw new RuntimeException(e);
+            return sanitizedUrl;
         }
         return sanitizedUrl;
     }


### PR DESCRIPTION
This fixes failing materials tests under common and server on windows -> https://build.go.cd/go/pipelines/build-windows/264/build-non-server-windows/1