### PR TITLE
#869 - append changes to build log element, rather than replace html

### DIFF
--- a/server/webapp/WEB-INF/rails.new/app/assets/javascripts/build_output_observer.js
+++ b/server/webapp/WEB-INF/rails.new/app/assets/javascripts/build_output_observer.js
@@ -75,7 +75,7 @@ BuildOutputObserver.prototype = {
                 escapedOutPut = '<br/>' + escapedOutPut.replace(/\n/ig, '<br\/>');
             }
             if($('buildoutput_pre')){
-                $('buildoutput_pre').innerHTML += escapedOutPut;
+                $('buildoutput_pre').insert({bottom: escapedOutPut});
             }
         }
         return is_output_empty;


### PR DESCRIPTION
Fixes #869.

Use prototypejs functionality to append to the bottom of the existing element, rather than replacing entire innerhtml.

No new tests added - this is covered by existing tests (which I couldn't figure out how to run).