### PR TITLE
Updated plugin "getting started" URL if Javadoc

### DIFF
--- a/plugin-infra/go-plugin-api/src/com/thoughtworks/go/plugin/api/annotation/Extension.java
+++ b/plugin-infra/go-plugin-api/src/com/thoughtworks/go/plugin/api/annotation/Extension.java
@@ -33,7 +33,7 @@ import java.lang.annotation.Target;
  * Please refer to the Go Plugin documentation for more details on how to use
  * this annotation.
  *
- * @see <a href="http://www.go.cd/documentation/user/current/extension_points/go_plugins_basics.html" target="_blank">Go Plugin Documentation</a>
+ * @see <a href="http://www.go.cd/documentation/developer/writing_go_plugins/go_plugins_basics.html" target="_blank">Go Plugin Documentation</a>
  *
  * @author Go Team
  */

--- a/plugin-infra/go-plugin-api/src/com/thoughtworks/go/plugin/api/annotation/Load.java
+++ b/plugin-infra/go-plugin-api/src/com/thoughtworks/go/plugin/api/annotation/Load.java
@@ -38,7 +38,7 @@ import java.lang.annotation.Target;
  *
  * Please refer to the Go Plugin documentation for more details.
  *
- * @see <a href="http://www.go.cd/documentation/user/current/extension_points/go_plugins_basics.html" target="_blank">Go Plugin Documentation</a>
+ * @see <a href="http://www.go.cd/documentation/developer/writing_go_plugins/go_plugins_basics.html" target="_blank">Go Plugin Documentation</a>
  * @see com.thoughtworks.go.plugin.api.info.PluginContext
  * @see Load
  *

--- a/plugin-infra/go-plugin-api/src/com/thoughtworks/go/plugin/api/annotation/UnLoad.java
+++ b/plugin-infra/go-plugin-api/src/com/thoughtworks/go/plugin/api/annotation/UnLoad.java
@@ -41,7 +41,7 @@ import java.lang.annotation.Target;
  *
  * Please refer to the Go Plugin documentation for more details.
  *
- * @see <a href="http://www.go.cd/documentation/user/current/extension_points/go_plugins_basics.html" target="_blank">Go Plugin Documentation</a>
+ * @see <a href="http://www.go.cd/documentation/developer/writing_go_plugins/go_plugins_basics.html" target="_blank">Go Plugin Documentation</a>
  * @see com.thoughtworks.go.plugin.api.info.PluginContext
  * @see Load
  *

--- a/plugin-infra/go-plugin-api/src/com/thoughtworks/go/plugin/api/info/PluginDescriptor.java
+++ b/plugin-infra/go-plugin-api/src/com/thoughtworks/go/plugin/api/info/PluginDescriptor.java
@@ -22,7 +22,7 @@ import java.util.List;
 /**
  * Descriptor represent the plugin descriptor XML file.
  *
- * @see <a href="http://www.go.cd/documentation/user/current/extension_points/go_plugins_basics.html" target="_blank">Go Plugin Documentation</a>
+ * @see <a href="http://www.go.cd/documentation/developer/writing_go_plugins/go_plugins_basics.html" target="_blank">Go Plugin Documentation</a>
  *
  * @author Go Team
  */

--- a/plugin-infra/go-plugin-api/src/com/thoughtworks/go/plugin/api/logging/Logger.java
+++ b/plugin-infra/go-plugin-api/src/com/thoughtworks/go/plugin/api/logging/Logger.java
@@ -21,7 +21,7 @@ import com.thoughtworks.go.plugin.internal.api.LoggingService;
 import java.lang.reflect.Field;
 
 /**
- * Logger for use by the plugin developers.
+ * Logger for use by plugin developers.
  *
  * @author Go Team
  * @see <a href="http://www.go.cd/documentation/developer/writing_go_plugins/go_plugins_basics.html" target="_blank">Go Plugin Documentation</a>
@@ -151,7 +151,7 @@ public class Logger {
      * Messages to be logged in error mode.
      *
      * @param message a string containing the message to be logged.
-     * @param throwable a string containing the message to be logged.
+     * @param throwable
      */
     public void error(String message, Throwable throwable) {
         if (loggingService == null) {

--- a/plugin-infra/go-plugin-api/src/com/thoughtworks/go/plugin/api/logging/Logger.java
+++ b/plugin-infra/go-plugin-api/src/com/thoughtworks/go/plugin/api/logging/Logger.java
@@ -24,7 +24,7 @@ import java.lang.reflect.Field;
  * Logger for use by the plugin developers.
  *
  * @author Go Team
- * @see <a href="http://www.go.cd/documentation/user/current/extension_points/go_plugins_basics.html" target="_blank">Go Plugin Documentation</a>
+ * @see <a href="http://www.go.cd/documentation/developer/writing_go_plugins/go_plugins_basics.html" target="_blank">Go Plugin Documentation</a>
  */
 public class Logger {
     private String pluginId;


### PR DESCRIPTION
Debatable whether the URL belongs in the Javadoc, but I have updated it to point to a non-404 page.