### PR TITLE
#869 - Fix build

### DIFF
--- a/server/webapp/WEB-INF/rails.new/app/assets/javascripts/build_output_observer.js
+++ b/server/webapp/WEB-INF/rails.new/app/assets/javascripts/build_output_observer.js
@@ -68,14 +68,15 @@ BuildOutputObserver.prototype = {
     },
     _update_live_output: function (build_output) {
         var is_output_empty = !build_output;
-        if (!is_output_empty) {
+        var buildoutputPreElement = $('buildoutput_pre');
+        if (!is_output_empty && buildoutputPreElement) {
             var escapedOutPut = build_output.escapeHTML();
             if (Prototype.Browser.IE) {
                 // Fix for the IE not wrap /r in pre bug
                 escapedOutPut = '<br/>' + escapedOutPut.replace(/\n/ig, '<br\/>');
-            }
-            if($('buildoutput_pre')){
-                $('buildoutput_pre').insert({bottom: escapedOutPut});
+                buildoutputPreElement.innerHTML += escapedOutPut;
+            } else {
+                buildoutputPreElement.insert({bottom: escapedOutPut})
             }
         }
         return is_output_empty;


### PR DESCRIPTION
IE 9 does not support 'createContextualFragment'. So, need to use innerHTML += for IE.

This failed a [build](https://build.go.cd/go/tab/build/detail/build-windows/271/build-non-server-windows/1/jsunit-win). So, I'm going to accept this fix myself, to fix the build. I've tested this with IE 9, IE 10 and IE Edge. And, the test runs with IE 9, I think. So, this fix should fix the build.