### PR TITLE
#890 - Make win installer logging optional

### DIFF
--- a/build/windows-installer-base.nsi
+++ b/build/windows-installer-base.nsi
@@ -62,6 +62,26 @@ UninstallIcon $%GO_ICON%
 XPStyle on
 
 ;--------------------------------
+; Make logging conditional. Inspiration: http://nsis.sourceforge.net/Logging:Enable_Logs_Quickly
+; NSIS has to be *compiled* with logging enabled. This flag allows logging to be disabled
+; during installer creation, so that the default nsis package in debian can be used to create
+; and installer, which does not create an install.log file.
+!define LogSet "!insertmacro LogSetMacro"
+!macro LogSetMacro SETTING
+  !if "$%DISABLE_LOGGING%" != "true"
+    LogSet ${SETTING}
+  !endif
+!macroend
+
+!define LogText "!insertmacro LogTextMacro"
+!macro LogTextMacro INPUT_TEXT
+  !if "$%DISABLE_LOGGING%" != "true"
+    LogText $INPUT_TEXT
+  !endif
+!macroend
+;--------------------------------
+
+;--------------------------------
 Function .onInit
     ; Check if go is already installed - if it exists no errors is set
     ClearErrors
@@ -71,7 +91,7 @@ Function .onInit
     IfSilent TURN_ON_LOGGING TURN_OFF_LOGGING
       TURN_ON_LOGGING:
                   SetOutPath $INSTDIR
-                  LogSet on
+                  ${LogSet} on
       TURN_OFF_LOGGING:
 
    ; If we get an error then the key does not exist and we're doing a clean install
@@ -83,7 +103,7 @@ Function .onInit
         issame:
             IfSilent IsSameSilentLabel IsSameNonSilentLabel
 	        IsSameSilentLabel:
-	            LogText "Go $%NAME% $%VERSION% is already installed."
+	            ${LogText} "Go $%NAME% $%VERSION% is already installed."
                 Goto IsSameDone
             IsSameNonSilentLabel:
                 MessageBox MB_OK "Go $%NAME% $%VERSION% is already installed."
@@ -94,7 +114,7 @@ Function .onInit
         isnewer:
             IfSilent IsNewerSilentLabel IsNewerNonSilentLabel
             IsNewerSilentLabel:
-                LogText "Go $%NAME% upgraded from $2 to $%VERSION%"
+                ${LogText} "Go $%NAME% upgraded from $2 to $%VERSION%"
                 Goto upgrade
             IsNewerNonSilentLabel:
                 MessageBox MB_YESNO "This will upgrade Go $%NAME% from $2 to $%VERSION%.$\r$\nMake sure you have backups before doing this!$\r$\nDo you want to continue?" IDYES upgrade IDNO dontupgrade
@@ -102,7 +122,7 @@ Function .onInit
         isolder:
             IfSilent IsOlderSilentLabel IsOlderNonSilentLabel
             IsOlderSilentLabel:
-                LogText "Go $%NAME% $2 is installed, and you are trying to install an older version ($%VERSION%).This is not supported."
+                ${LogText} "Go $%NAME% $2 is installed, and you are trying to install an older version ($%VERSION%).This is not supported."
                 Goto IsOlderDone
             IsOlderNonSilentLabel:
                 MessageBox MB_OK "Go $%NAME% $2 is installed, and you are trying to install an older version ($%VERSION%).$\r$\nThis is not supported."
@@ -132,7 +152,7 @@ Function .onInit
         isCruise:
             IfSilent IsCruiseSilentLabel IsCruiseNonSilentLabel
             IsCruiseSilentLabel:
-                LogText "Go $%NAME% upgrade from $2 to $%VERSION%"
+                ${LogText} "Go $%NAME% upgrade from $2 to $%VERSION%"
                 Goto upgradeToGo
             IsCruiseNonSilentLabel:
                 MessageBox MB_YESNO "This will upgrade Go $%NAME% from $2 to $%VERSION%.$\r$\nMake sure you have backups before doing this!$\r$\nDo you want to continue?" IDYES upgradeToGo IDNO dontupgradeToGo
@@ -276,7 +296,7 @@ Section "Install"
     done:
     SetOverWrite on
     ; Uncomment line below to enable NSIS logging
-    LogSet on
+    ${LogSet} on
 
     SetOutPath $INSTDIR\$%JAVA%
     File /r $%JAVASRC%\*.*

--- a/installers/agent/win/go-agent.nsi
+++ b/installers/agent/win/go-agent.nsi
@@ -69,9 +69,9 @@ Function CustomInstallBits
     ClearErrors
     ExecWait 'net start "Go Agent"'
     IfErrors 0 +3
-        LogText "Error starting Go Agent Windows Service. Check if service is disabled."
+        ${LogText} "Error starting Go Agent Windows Service. Check if service is disabled."
         Goto DONE
-    LogText "Successfully started Go Agent"
+    ${LogText} "Successfully started Go Agent"
     DONE:
 FunctionEnd
 

--- a/tasks/buildr_extensions.rake
+++ b/tasks/buildr_extensions.rake
@@ -383,6 +383,7 @@ module WinPackageHelper
   def win_build depend_on, package, package_name, windows_name, windows_java
     task :exe => depend_on do
       cp win_pkg_src(package, 'cruisewrapper.exe'), win_pkg_content_dir(package_name)
+      disable_logging_value = ENV['DISABLE_WIN_INSTALLER_LOGGING'] || "false"
       Buildr.ant('win') do |win|
         win.get :src => ENV['WINDOWS_JRE_LOCATION'], :dest => "#{_(:target)}/jre-7u9-windows-i586.tar.gz"
         win.gunzip :src => "#{_(:target)}/jre-7u9-windows-i586.tar.gz"
@@ -403,6 +404,7 @@ module WinPackageHelper
           exec.env :key => "REGVER", :value => "#{VERSION_NUMBER}#{padded_release_revision}".gsub(/\./, '')
           exec.env :key => "JAVA", :value => windows_java
           exec.env :key => "JAVASRC", :value => windows_dir_file("jre1.7.0_09")
+          exec.env :key => "DISABLE_LOGGING", :value => disable_logging_value
           exec.arg :line => "-NOCD #{win_pkg_src(package, package_name + '.nsi')}"
         end
       end


### PR DESCRIPTION
Installer logging is now optional, controllable while building the installer. It defaults to the old behavior of logging turned on (which means it still needs the modified NSIS package). However, it can be turned off by setting the environment variable: DISABLE_WIN_INSTALLER_LOGGING=true, while building the installer.