### PR TITLE
Small change: OSX installer build: Show message on zip failure.

### DIFF
--- a/tasks/buildr_extensions.rake
+++ b/tasks/buildr_extensions.rake
@@ -436,7 +436,8 @@ module OSXPackageHelper
       cp File.join("..", "..", "..", "..", "build", "osx", "JavaApplicationStub64"), java_application_stub_64_file
       chmod 0755, java_application_stub_64_file
 
-      `zip -q -r -9 #{go_pkg_name_with_release_revision}-osx.zip "#{pkg_dir}"`
+      system("zip -q -r -9 #{go_pkg_name_with_release_revision}-osx.zip \"#{pkg_dir}\"") || \
+        (STDERR.puts "Failed to zip the OSX installer from #{pkg_dir}"; exit 1)
       rm_rf pkg_dir
     end
   end


### PR DESCRIPTION
Small change: Show a message if zipping the installer fails. If not, the error shows at some later point in the build, leading to confusion.