### PR TITLE
#795 - Move cctray init to end.

### DIFF
--- a/server/src/com/thoughtworks/go/server/dao/PipelineSqlMapDao.java
+++ b/server/src/com/thoughtworks/go/server/dao/PipelineSqlMapDao.java
@@ -31,6 +31,7 @@ import com.thoughtworks.go.presentation.pipelinehistory.PipelineInstanceModel;
 import com.thoughtworks.go.presentation.pipelinehistory.PipelineInstanceModels;
 import com.thoughtworks.go.server.cache.GoCache;
 import com.thoughtworks.go.server.domain.StageStatusListener;
+import com.thoughtworks.go.server.initializers.Initializer;
 import com.thoughtworks.go.server.persistence.MaterialRepository;
 import com.thoughtworks.go.server.transaction.SqlMapClientDaoSupport;
 import com.thoughtworks.go.server.transaction.TransactionSynchronizationManager;
@@ -56,7 +57,7 @@ import static com.thoughtworks.go.util.IBatisUtil.arguments;
 
 @SuppressWarnings({"ALL"})
 @Component
-public class PipelineSqlMapDao extends SqlMapClientDaoSupport implements PipelineDao, StageStatusListener {
+public class PipelineSqlMapDao extends SqlMapClientDaoSupport implements Initializer, PipelineDao, StageStatusListener {
     private static final Logger LOGGER = Logger.getLogger(PipelineSqlMapDao.class);
     private StageDao stageDao;
     private MaterialRepository materialRepository;
@@ -87,14 +88,15 @@ public class PipelineSqlMapDao extends SqlMapClientDaoSupport implements Pipelin
 
     }
 
-    public void initialize() throws Exception {
+    @Override
+    public void initialize() {
         try {
             LOGGER.info("Loading active pipelines into memory.");
             cacheActivePipelines();
             LOGGER.info("Done loading active pipelines into memory.");
         } catch (Exception e) {
             LOGGER.fatal(e.getMessage(), e);
-            throw e;
+            throw new RuntimeException(e);
         }
     }
 

--- a/server/src/com/thoughtworks/go/server/initializers/ApplicationInitializer.java
+++ b/server/src/com/thoughtworks/go/server/initializers/ApplicationInitializer.java
@@ -111,7 +111,6 @@ public class ApplicationInitializer implements ApplicationListener<ContextRefres
             materialUpdateService.initialize();
             pipelineScheduler.initialize();
             removeAdminPermissionFilter.initialize();
-            ccTrayActivityListener.initialize();
 
             pipelineTimeline.updateTimelineOnInit();
             pipelineSqlMapDao.initialize();
@@ -123,6 +122,7 @@ public class ApplicationInitializer implements ApplicationListener<ContextRefres
             goDiskSpaceMonitor.initialize();
             backupService.initialize();
             railsAssetsService.initialize();
+            ccTrayActivityListener.initialize();
 
             // initialize static accessors
             Toggles.initializeWith(featureToggleService);

--- a/server/test/unit/com/thoughtworks/go/server/initializers/ApplicationInitializerTest.java
+++ b/server/test/unit/com/thoughtworks/go/server/initializers/ApplicationInitializerTest.java
@@ -99,8 +99,8 @@ public class ApplicationInitializerTest {
     }
 
     @Test
-    public void shouldInitializeCcTrayActivityListenerAfterGoConfigServiceIsInitialize() throws Exception {
-        verifyOrder(goConfigService, ccTrayActivityListener);
+    public void shouldInitializeCcTrayActivityListenerAfterGoConfigServiceAndPipelineSqlMapDaoAreInitialized() throws Exception {
+        verifyOrder(goConfigService, pipelineSqlMapDao, ccTrayActivityListener);
     }
 
     private void verifyOrder(Initializer... initializers) {


### PR DESCRIPTION
CCTray initialization was conflicting with pipelineSqlMapDao initialization, because pipelineSqlMapDao
was loading from DB, into cache, without synchronization. Since cctray initialize is asynchronous, it
finished, and tried to use the cache, while it was being loaded, causing a concurrent modification
exception. So, this change moves the cctray init to the end of the application initializers.

The exception was:
```
2015-02-26 16:57:04,650  INFO [main] PipelineSqlMapDao:92 - Loading active pipelines into memory.
2015-02-26 16:57:04,651  INFO [main] PipelineSqlMapDao:388 - Retriving Active Pipelines from Database...
2015-02-26 16:57:04,695  INFO [Thread-69] PipelineSqlMapDao:429 - Loading pipeline history to cache...Started
2015-02-26 16:57:04,698  INFO [main] MaterialRepository:254 - Loading PMRs,Remaining 6 Pipelines (Total: 6)...
2015-02-26 16:57:04,699  INFO [Thread-69] PipelineSqlMapDao:433 - Loading pipeline history to cache...Done
2015-02-26 16:57:04,700  INFO [Thread-68] PipelineSqlMapDao:420 - Loading Active Pipelines to cache...Started
2015-02-26 16:57:04,700  INFO [Thread-68] PipelineSqlMapDao:423 - Loading Active Pipelines to cache...Done
2015-02-26 16:57:04,755  INFO [main] MaterialRepository:340 - Loading modifications, Remaining 9 PMRs(Total: 9)...
2015-02-26 16:57:04,781  WARN [CCTray-Queue-Processor] CcTrayActivityListener:111 - Failed to handle action in CCTray queue
java.util.ConcurrentModificationException
	at java.util.ArrayList$Itr.checkForComodification(ArrayList.java:782)
	at java.util.ArrayList$Itr.next(ArrayList.java:754)
	at com.thoughtworks.go.server.persistence.MaterialRepository.findMaterialRevisionsForPipeline(MaterialRepository.java:236)
	at com.thoughtworks.go.domain.cctray.CcTrayBreakersCalculator.calculateFor(CcTrayBreakersCalculator.java:47)
	at com.thoughtworks.go.domain.cctray.CcTrayStageStatusChangeHandler.statusesOfStageAndItsJobsFor(CcTrayStageStatusChangeHandler.java:55)
	at com.thoughtworks.go.domain.cctray.CcTrayStageStatusLoader.getStatusesForStageAndJobsOf(CcTrayStageStatusLoader.java:54)
	at com.thoughtworks.go.domain.cctray.CcTrayConfigChangeHandler.findStageAndStatusesFromDB(CcTrayConfigChangeHandler.java:96)
	at com.thoughtworks.go.domain.cctray.CcTrayConfigChangeHandler.access$500(CcTrayConfigChangeHandler.java:32)
	at com.thoughtworks.go.domain.cctray.CcTrayConfigChangeHandler$1.findExistingStatuses(CcTrayConfigChangeHandler.java:72)
	at com.thoughtworks.go.domain.cctray.CcTrayConfigChangeHandler$1.visit(CcTrayConfigChangeHandler.java:59)
	at com.thoughtworks.go.domain.PipelineGroups.accept(PipelineGroups.java:116)
	at com.thoughtworks.go.config.CruiseConfig.accept(CruiseConfig.java:439)
	at com.thoughtworks.go.domain.cctray.CcTrayConfigChangeHandler.findAllProjectStatusesForStagesAndJobsIn(CcTrayConfigChangeHandler.java:52)
	at com.thoughtworks.go.domain.cctray.CcTrayConfigChangeHandler.call(CcTrayConfigChangeHandler.java:45)
	at com.thoughtworks.go.domain.cctray.CcTrayActivityListener$3.call(CcTrayActivityListener.java:94)
	at com.thoughtworks.go.domain.cctray.CcTrayActivityListener$4.run(CcTrayActivityListener.java:109)
2015-02-26 16:57:04,785  INFO [main] PipelineSqlMapDao:94 - Done loading active pipelines into memory.
2015-02-26 16:57:04,874  INFO [main] ConsoleActivityMonitor:66 - Found '0' building jobs. Added them with '2015-02-26T16:57:04.787+05:30' as the last heard time
2015-02-26 16:57:04,946  INFO [main] RailsAssetsService:66 - Found rails assets manifest file named manifest-6430544aee0542be41ba921ec27cb2b8.json 
2015-02-26 16:57:04,986  INFO [main] RailsAssetsService:70 - Successfully read rails assets manifest file located at /var/lib/go-server/work/Jetty_0_0_0_0_8153_cruise.war__go__.mt8b37/webapp/WEB-INF/rails.new/public/assets/manifest-6430544aee0542be41ba921ec27cb2b8.json
```