### PR TITLE
#000 - Stop ehcache call home.

### DIFF
--- a/server/src/com/thoughtworks/go/server/cache/GoCacheFactory.java
+++ b/server/src/com/thoughtworks/go/server/cache/GoCacheFactory.java
@@ -33,6 +33,10 @@ public class GoCacheFactory {
     private EhCacheFactoryBean factoryBean;
     private Boolean clearOnFlush = true;
 
+    static {
+        System.setProperty("net.sf.ehcache.skipUpdateCheck", "true");
+    }
+
     public GoCacheFactory(TransactionSynchronizationManager transactionSynchronizationManager) {
         this.transactionSynchronizationManager = transactionSynchronizationManager;
         factoryBean = new EhCacheFactoryBean();


### PR DESCRIPTION
ehcache calls home by default. Setting updateCheck="false" doesn't work, since it is
initialized in applicationContext-dataLocalAccess.xml, for Hibernate, without using
ehcache.xml

[Here's](http://terracotta.org/documentation/3.7.4/enterprise-ehcache/configuration-guide#via-ehcachexml) some info about updateCheck flag.