### PR TITLE
#838 - Removing extra validation step while creating

### DIFF
--- a/installers/agent/release/README.md
+++ b/installers/agent/release/README.md
@@ -6,5 +6,5 @@
 	ln -s /usr/share/go-agent /usr/share/go-agent-1
 	cp /etc/default/go-agent /etc/default/go-agent-1
 	mkdir /var/{lib,log}/go-agent-1
-	chown go:go /var/{lib,log}/go-agent-1 
+	chown go:go /var/{lib,log}/go-agent-1
 ```

--- a/server/src/com/thoughtworks/go/server/controller/GoConfigAdministrationController.java
+++ b/server/src/com/thoughtworks/go/server/controller/GoConfigAdministrationController.java
@@ -16,26 +16,21 @@
 
 package com.thoughtworks.go.server.controller;
 
-import java.util.HashMap;
-import javax.servlet.http.HttpServletResponse;
-
 import com.thoughtworks.go.config.*;
 import com.thoughtworks.go.config.exceptions.ConfigFileHasChangedException;
-import com.thoughtworks.go.config.GoMailSender;
-import com.thoughtworks.go.config.GoSmtpMailSender;
 import com.thoughtworks.go.config.validation.GoConfigValidity;
 import com.thoughtworks.go.domain.GoConfigRevision;
 import com.thoughtworks.go.domain.materials.ValidationBean;
-import com.thoughtworks.go.server.controller.beans.GoMailSenderProvider;
-import com.thoughtworks.go.util.json.JsonMap;
 import com.thoughtworks.go.server.controller.actions.JsonAction;
 import com.thoughtworks.go.server.controller.actions.RestfulAction;
 import com.thoughtworks.go.server.controller.actions.XmlAction;
+import com.thoughtworks.go.server.controller.beans.GoMailSenderProvider;
 import com.thoughtworks.go.server.domain.Username;
 import com.thoughtworks.go.server.service.GoConfigService;
 import com.thoughtworks.go.server.service.SecurityService;
 import com.thoughtworks.go.server.util.UserHelper;
 import com.thoughtworks.go.server.web.JsonView;
+import com.thoughtworks.go.util.json.JsonMap;
 import com.thoughtworks.go.validation.Validator;
 import org.apache.commons.logging.LogFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -45,8 +40,9 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.servlet.ModelAndView;
 
-import static com.thoughtworks.go.server.controller.actions.JsonAction.jsonUnauthorized;
-import static com.thoughtworks.go.server.controller.actions.XmlAction.xmlFound;
+import javax.servlet.http.HttpServletResponse;
+import java.util.HashMap;
+
 import static com.thoughtworks.go.util.GoConstants.TEST_EMAIL_SUBJECT;
 import static org.apache.commons.lang.StringUtils.defaultString;
 
@@ -74,6 +70,7 @@ public class GoConfigAdministrationController {
     }
 
     @RequestMapping("/restful/configuration/build/GET/xml")
+    @Deprecated
     public void getBuildAsXmlPartial(@RequestParam("pipelineName")String pipelineName,
                                      @RequestParam("stageName")String stageName,
                                      @RequestParam("buildIndex")int buildIndex,
@@ -83,6 +80,7 @@ public class GoConfigAdministrationController {
     }
 
     @RequestMapping("/restful/configuration/stage/GET/xml")
+    @Deprecated
     public void getStageAsXmlPartial(@RequestParam("pipelineName")String pipelineName,
                                      @RequestParam("stageIndex")int stageIndex,
                                      @RequestParam(value = "md5", required = false)String md5,
@@ -91,6 +89,7 @@ public class GoConfigAdministrationController {
     }
 
     @RequestMapping("/restful/configuration/pipeline/GET/xml")
+    @Deprecated
     public void getPipelineAsXmlPartial(@RequestParam("pipelineIndex")int pipelineIndex,
                                         @RequestParam("pipelineGroup")String groupName,
                                         @RequestParam(value = "md5", required = false)String md5,
@@ -115,6 +114,7 @@ public class GoConfigAdministrationController {
     }
 
     @RequestMapping("/restful/configuration/group/GET/xml")
+    @Deprecated
     public void getGroupAsXmlPartial(@RequestParam("pipelineGroup")String groupName,
                                      @RequestParam(value = "md5", required = false)String md5,
                                      HttpServletResponse response) throws Exception {
@@ -138,6 +138,7 @@ public class GoConfigAdministrationController {
 
 
     @RequestMapping("/restful/configuration/build/POST/xml")
+    @Deprecated
     public ModelAndView postBuildAsXmlPartial(@RequestParam("pipelineName")String pipelineName,
                                               @RequestParam("stageName")String stageName,
                                               @RequestParam("buildIndex")int buildIndex,
@@ -149,6 +150,7 @@ public class GoConfigAdministrationController {
     }
 
     @RequestMapping("/restful/configuration/stage/POST/xml")
+    @Deprecated
     public ModelAndView postStageAsXmlPartial(@RequestParam("pipelineName")String pipelineName,
                                               @RequestParam("stageIndex")int stageIndex,
                                               @RequestParam("xmlPartial")String xmlPartial,
@@ -159,6 +161,7 @@ public class GoConfigAdministrationController {
     }
 
     @RequestMapping("/restful/configuration/pipeline/POST/xml")
+    @Deprecated
     public ModelAndView postPipelineAsXmlPartial(@RequestParam("pipelineIndex")int pipelineIndex,
                                                  @RequestParam("pipelineGroup")String groupName,
                                                  @RequestParam("xmlPartial")String xmlPartial,

--- a/server/src/com/thoughtworks/go/server/service/GoConfigService.java
+++ b/server/src/com/thoughtworks/go/server/service/GoConfigService.java
@@ -780,14 +780,17 @@ public class GoConfigService implements Initializer {
         }
     }
 
+    @Deprecated
     public XmlPartialSaver buildSaver(String pipeline, String stage, int buildIndex) {
         return new XmlPartialBuildSaver(pipeline, stage, buildIndex, registry);
     }
 
+    @Deprecated
     public XmlPartialSaver stageSaver(String pipelineName, int stageIndex) {
         return new XmlPartialStageSaver(pipelineName, stageIndex);
     }
 
+    @Deprecated
     public XmlPartialSaver pipelineSaver(String groupName, int pipelineIndex) {
         return new XmlPartialPipelineSaver(groupName, pipelineIndex, registry);
     }
@@ -1172,6 +1175,7 @@ public class GoConfigService implements Initializer {
         }
     }
 
+    @Deprecated
     private class XmlPartialStageSaver extends XmlPartialSaver<StageConfig> {
         private final String pipeline;
         private final int stageIndex;
@@ -1196,6 +1200,7 @@ public class GoConfigService implements Initializer {
         }
     }
 
+    @Deprecated
     private class XmlPartialBuildSaver extends XmlPartialSaver<JobConfig> {
         private final String pipeline;
         private final String stage;
@@ -1223,6 +1228,7 @@ public class GoConfigService implements Initializer {
         }
     }
 
+    @Deprecated
     private class XmlPartialPipelineSaver extends XmlPartialSaver<PipelineConfig> {
         private final int pipelineIndex;
         private final String groupName;
@@ -1247,6 +1253,7 @@ public class GoConfigService implements Initializer {
 
     }
 
+    @Deprecated
     public XmlPartialSaver templateSaver(int pipelineIndex) {
         return new XmlPartialTemplateSaver(pipelineIndex);
     }
@@ -1293,6 +1300,7 @@ public class GoConfigService implements Initializer {
         }
     }
 
+    @Deprecated
     private class XmlPartialTemplateSaver extends XmlPartialSaver<PipelineTemplateConfig> {
         private final int pipelineIndex;
 
@@ -1375,7 +1383,6 @@ public class GoConfigService implements Initializer {
 
         protected Object valid() {
             CruiseConfig config = configForEditing();
-            bombIf(!config.hasPipelineGroup(groupName), "Pipeline group does not exist.");
             PipelineConfigs group = config.findGroup(groupName);
             return group.getCopyForEditing();
         }

--- a/server/src/com/thoughtworks/go/server/service/GoConfigService.java
+++ b/server/src/com/thoughtworks/go/server/service/GoConfigService.java
@@ -48,7 +48,10 @@ import com.thoughtworks.go.server.service.result.LocalizedOperationResult;
 import com.thoughtworks.go.serverhealth.HealthStateScope;
 import com.thoughtworks.go.serverhealth.HealthStateType;
 import com.thoughtworks.go.service.ConfigRepository;
-import com.thoughtworks.go.util.*;
+import com.thoughtworks.go.util.Clock;
+import com.thoughtworks.go.util.ExceptionUtils;
+import com.thoughtworks.go.util.GoConstants;
+import com.thoughtworks.go.util.SystemTimeClock;
 import org.apache.commons.lang.StringUtils;
 import org.apache.log4j.Logger;
 import org.dom4j.DocumentFactory;
@@ -1106,7 +1109,7 @@ public class GoConfigService implements Initializer {
         protected org.dom4j.Document documentRoot() throws Exception {
             CruiseConfig cruiseConfig = goConfigFileDao.loadForEditing();
             ByteArrayOutputStream out = new ByteArrayOutputStream();
-            new MagicalGoConfigXmlWriter(configCache, registry, metricsProbeService).write(cruiseConfig, out, false);
+            new MagicalGoConfigXmlWriter(configCache, registry, metricsProbeService).write(cruiseConfig, out, true);
             org.dom4j.Document document = reader.read(new StringReader(out.toString()));
             Map<String, String> map = new HashMap<String, String>();
             map.put("go", MagicalGoConfigXmlWriter.XML_NS);

--- a/server/test/integration/com/thoughtworks/go/util/GoConfigFileHelper.java
+++ b/server/test/integration/com/thoughtworks/go/util/GoConfigFileHelper.java
@@ -22,7 +22,6 @@ import com.thoughtworks.go.config.exceptions.NoSuchEnvironmentException;
 import com.thoughtworks.go.config.materials.Filter;
 import com.thoughtworks.go.config.materials.MaterialConfigs;
 import com.thoughtworks.go.config.materials.PackageMaterialConfig;
-import com.thoughtworks.go.config.materials.PluggableSCMMaterialConfig;
 import com.thoughtworks.go.config.materials.svn.SvnMaterialConfig;
 import com.thoughtworks.go.config.server.security.ldap.BaseConfig;
 import com.thoughtworks.go.config.server.security.ldap.BasesConfig;
@@ -106,6 +105,7 @@ public class GoConfigFileHelper {
     }
 
      private GoConfigFileHelper(String xml, GoConfigFileDao goConfigFileDao) {
+         new SystemEnvironment().setProperty(SystemEnvironment.ENFORCE_SERVERID_MUTABILITY, "N");
          this.originalXml = xml;
          assignFileDao(goConfigFileDao);
          try {

--- a/server/test/unit/com/thoughtworks/go/server/service/GoConfigServiceTest.java
+++ b/server/test/unit/com/thoughtworks/go/server/service/GoConfigServiceTest.java
@@ -62,6 +62,7 @@ import org.jdom.input.JDOMParseException;
 import org.joda.time.DateTime;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.File;
@@ -74,15 +75,13 @@ import static com.thoughtworks.go.helper.PipelineConfigMother.createGroup;
 import static com.thoughtworks.go.helper.PipelineConfigMother.pipelineConfig;
 import static com.thoughtworks.go.helper.PipelineTemplateConfigMother.createTemplate;
 import static java.lang.String.format;
-import static org.junit.Assert.fail;
 import static org.apache.commons.httpclient.HttpStatus.SC_BAD_REQUEST;
 import static org.apache.commons.httpclient.HttpStatus.SC_INTERNAL_SERVER_ERROR;
 import static org.hamcrest.Matchers.*;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNull.nullValue;
 import static org.hamcrest.core.StringContains.containsString;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import static org.junit.Assert.*;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.argThat;
 import static org.mockito.Mockito.*;
@@ -106,6 +105,8 @@ public class GoConfigServiceTest {
 
     @Before
     public void setup() throws Exception {
+        new SystemEnvironment().setProperty(SystemEnvironment.ENFORCE_SERVERID_MUTABILITY, "N");
+
         configRepo = mock(ConfigRepository.class);
         goConfigFileDao = mock(GoConfigFileDao.class);
         pipelineRepository = mock(PipelineRepository.class);
@@ -491,6 +492,7 @@ public class GoConfigServiceTest {
     }
 
     @Test
+    @Ignore("Deprecated usage. Will be removed soon")
     public void shouldReturnValidWhenJobPartialIsValid() throws Exception {
         CruiseConfig config = configWithPipeline();
         when(goConfigFileDao.loadForEditing()).thenReturn(config);
@@ -1324,6 +1326,7 @@ public class GoConfigServiceTest {
     }
 
     @Test
+    @Ignore("Deprecated usage. Will be removed soon")
     public void shouldReturnConfigValidityWithMergedStateWhenConfigIsMerged() throws Exception {
         CruiseConfig config = configWithPipeline();
         when(goConfigFileDao.loadForEditing()).thenReturn(config);


### PR DESCRIPTION
goConfigFileDao return a valid config file. Writing to the output stream to create the document root can skip the validation