### PR TITLE
#496 - Remove usage of a temp file for /api/support.

### DIFF
--- a/server/src/com/thoughtworks/go/server/service/support/ServerStatusService.java
+++ b/server/src/com/thoughtworks/go/server/service/support/ServerStatusService.java
@@ -21,12 +21,10 @@ import com.thoughtworks.go.server.domain.Username;
 import com.thoughtworks.go.server.service.SecurityService;
 import com.thoughtworks.go.server.service.result.LocalizedOperationResult;
 import com.thoughtworks.go.serverhealth.HealthStateType;
-import org.apache.commons.io.FileUtils;
 import org.apache.log4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
-import java.io.File;
 import java.io.IOException;
 import java.util.*;
 
@@ -55,10 +53,6 @@ public class ServerStatusService {
             return null;
         }
         return serverInfo();
-    }
-
-    private void populateServerInfo(File serverInfoFile) throws IOException {
-        FileUtils.writeStringToFile(serverInfoFile, serverInfo());
     }
 
     private String serverInfo() {

--- a/server/src/com/thoughtworks/go/server/service/support/ServerStatusService.java
+++ b/server/src/com/thoughtworks/go/server/service/support/ServerStatusService.java
@@ -16,15 +16,6 @@
 
 package com.thoughtworks.go.server.service.support;
 
-import java.io.File;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.Date;
-import java.util.List;
-
 import com.thoughtworks.go.i18n.LocalizedMessage;
 import com.thoughtworks.go.server.domain.Username;
 import com.thoughtworks.go.server.service.SecurityService;
@@ -34,6 +25,10 @@ import org.apache.commons.io.FileUtils;
 import org.apache.log4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.*;
 
 @Component
 public class ServerStatusService {
@@ -54,14 +49,12 @@ public class ServerStatusService {
         });
     }
 
-    public File captureServerInfo(Username username, LocalizedOperationResult result) throws IOException {
+    public String captureServerInfo(Username username, LocalizedOperationResult result) throws IOException {
         if (!securityService.isUserAdmin(username)) {
             result.unauthorized(LocalizedMessage.string("UNAUTHORIZED_TO_ADMINISTER"), HealthStateType.unauthorised());
             return null;
         }
-        File serverInfoFile = File.createTempFile("serverinfo", "txt");
-        populateServerInfo(serverInfoFile);
-        return serverInfoFile;
+        return serverInfo();
     }
 
     private void populateServerInfo(File serverInfoFile) throws IOException {

--- a/server/webapp/WEB-INF/rails.new/app/controllers/api/server_controller.rb
+++ b/server/webapp/WEB-INF/rails.new/app/controllers/api/server_controller.rb
@@ -24,11 +24,11 @@ class Api::ServerController < Api::ApiController
   end
 
   def capture_support_info
-    file = server_status_service.captureServerInfo(current_user, result = HttpLocalizedOperationResult.new)
+    information = server_status_service.captureServerInfo(current_user, result = HttpLocalizedOperationResult.new)
     if !result.isSuccessful()
-      render_localized_operation_result result
-    else
-      send_file file.getAbsolutePath(), :disposition => "inline", :stream => false, :type => "text"
+      render_localized_operation_result result and return
     end
+
+    send_data information, :disposition => "inline", :stream => false, :type => "text"
   end
 end

--- a/server/webapp/WEB-INF/rails.new/app/controllers/api/server_controller.rb
+++ b/server/webapp/WEB-INF/rails.new/app/controllers/api/server_controller.rb
@@ -26,9 +26,9 @@ class Api::ServerController < Api::ApiController
   def capture_support_info
     information = server_status_service.captureServerInfo(current_user, result = HttpLocalizedOperationResult.new)
     if !result.isSuccessful()
-      render_localized_operation_result result and return
+      render_localized_operation_result result && return
     end
 
-    send_data information, :disposition => "inline", :stream => false, :type => "text"
+    send_data information, disposition: "inline", stream: false, type: "text"
   end
 end


### PR DESCRIPTION
/api/support used to create a new temporary file every time, and leave it around. Removing that. Not using a file any more.