### PR TITLE
Fix/properly detect init script name when in rc x.d

### DIFF
--- a/installers/agent/release/init.cruise-agent
+++ b/installers/agent/release/init.cruise-agent
@@ -28,6 +28,9 @@
 ### END INIT INFO
 SERVICE_NAME=${0##*/}
 
+# Strips initV leading chars if the script is located in rcX.d (automatically executed on runlevel change)
+INIT_DIR=${0%/*}; echo ${INIT_DIR##*/} | grep -e '^rc[0-9]\.d$' >/dev/null && SERVICE_NAME=$(echo "${SERVICE_NAME}" | sed 's/^[SK][0-9][0-9]//');
+
 PID_FILE="/var/run/go-agent/${SERVICE_NAME}.pid"
 CUR_USER=`whoami`
 


### PR DESCRIPTION
Fix a bug that prevents the agents to be automatically started at boot and stopped at shutdown/restart.

A SystemV init script is linked in /etc/rcX.d/ , where X is the runlevel, with its name being prepended with the letter S or K and a two-digit number, if the service has to be respectively started or stopped at this runlevel.

The extracted service name containing these systemV-specific characters didn't match the actual service name. They are now therefore removed if the script is run from one of the /etc/rcX.d/ directories.