### PR TITLE
#996 - Added listener to generate PluginsList.

### DIFF
--- a/base/src/com/thoughtworks/go/util/SystemEnvironment.java
+++ b/base/src/com/thoughtworks/go/util/SystemEnvironment.java
@@ -617,6 +617,10 @@ public class SystemEnvironment implements Serializable, ConfigDirProvider {
         return new File(get(PLUGIN_EXTERNAL_PROVIDED_PATH)).getAbsolutePath();
     }
 
+    public String getBundledPluginAbsolutePath() {
+        return new File(get(PLUGIN_BUNDLE_PATH)).getAbsolutePath();
+    }
+
     public <T> void reset(GoSystemProperty<T> systemProperty) {
         System.clearProperty(systemProperty.propertyName());
         if (systemProperty instanceof CachedProperty) {

--- a/plugin-infra/go-plugin-access/pom.xml
+++ b/plugin-infra/go-plugin-access/pom.xml
@@ -42,18 +42,6 @@
             <artifactId>go-plugin-infra</artifactId>
             <version>1.0</version>
         </dependency>
-        <dependency>
-            <groupId>com.google.code.gson</groupId>
-            <artifactId>gson</artifactId>
-            <version>2.2.3</version>
-        </dependency>
-
-
-        <dependency>
-            <groupId>com.google.code.gson</groupId>
-            <artifactId>gson</artifactId>
-            <version>2.2.3</version>
-        </dependency>
 
         <!-- test dependencies -->
         <dependency>

--- a/plugin-infra/go-plugin-infra/pom.xml
+++ b/plugin-infra/go-plugin-infra/pom.xml
@@ -72,11 +72,17 @@
             </exclusions>
         </dependency>
 
-		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-log4j12</artifactId>
-			<version>1.7.2</version>
-		</dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+            <version>1.7.2</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>2.2.3</version>
+        </dependency>
 
         <!-- test dependencies -->
         <dependency>

--- a/plugin-infra/go-plugin-infra/pom.xml
+++ b/plugin-infra/go-plugin-infra/pom.xml
@@ -44,6 +44,11 @@
         </dependency>
         <dependency>
             <groupId>com.thoughtworks.go</groupId>
+            <artifactId>util</artifactId>
+            <version>1.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.thoughtworks.go</groupId>
             <artifactId>go-plugin-activator</artifactId>
             <version>1.0</version>
         </dependency>

--- a/plugin-infra/go-plugin-infra/resources/applicationContext-plugin-infra.xml
+++ b/plugin-infra/go-plugin-infra/resources/applicationContext-plugin-infra.xml
@@ -37,7 +37,9 @@
     <bean id="defaultGoApplicationAccessor" class="com.thoughtworks.go.plugin.infra.DefaultGoApplicationAccessor" />
 
     <bean id="PluginsZipUpdater" class="com.thoughtworks.go.plugin.infra.listeners.PluginsZipUpdater"/>
+    <bean id="PluginsListListener" class="com.thoughtworks.go.plugin.infra.listeners.PluginsListListener"/>
     <bean id="pluginsZip"  class="com.thoughtworks.go.plugin.infra.commons.PluginsZip"/>
+    <bean id="pluginsList"  class="com.thoughtworks.go.plugin.infra.commons.PluginsList"/>
     <bean id="zipUtil" class="com.thoughtworks.go.util.ZipUtil"/>
     <bean id="systemEnvironment" class="com.thoughtworks.go.util.SystemEnvironment"/>
 </beans>

--- a/plugin-infra/go-plugin-infra/src/com/thoughtworks/go/plugin/infra/DefaultPluginManager.java
+++ b/plugin-infra/go-plugin-infra/src/com/thoughtworks/go/plugin/infra/DefaultPluginManager.java
@@ -24,8 +24,9 @@ import com.thoughtworks.go.plugin.api.request.GoPluginApiRequest;
 import com.thoughtworks.go.plugin.api.response.GoPluginApiResponse;
 import com.thoughtworks.go.plugin.infra.commons.PluginUploadResponse;
 import com.thoughtworks.go.plugin.infra.listeners.DefaultPluginJarChangeListener;
-import com.thoughtworks.go.plugin.infra.monitor.DefaultPluginJarLocationMonitor;
+import com.thoughtworks.go.plugin.infra.listeners.PluginsListListener;
 import com.thoughtworks.go.plugin.infra.listeners.PluginsZipUpdater;
+import com.thoughtworks.go.plugin.infra.monitor.DefaultPluginJarLocationMonitor;
 import com.thoughtworks.go.plugin.infra.plugininfo.DefaultPluginRegistry;
 import com.thoughtworks.go.plugin.infra.plugininfo.GoPluginDescriptor;
 import com.thoughtworks.go.util.FileUtil;
@@ -60,16 +61,19 @@ public class DefaultPluginManager implements PluginManager {
     private PluginWriter pluginWriter;
     private PluginValidator pluginValidator;
     private PluginsZipUpdater pluginsZipUpdater;
+    private PluginsListListener pluginsListListener;
 
     @Autowired
     public DefaultPluginManager(DefaultPluginJarLocationMonitor monitor, DefaultPluginRegistry registry, GoPluginOSGiFramework goPluginOSGiFramework,
-                                DefaultPluginJarChangeListener defaultPluginJarChangeListener, GoApplicationAccessor goApplicationAccessor, PluginWriter pluginWriter, PluginValidator pluginValidator, SystemEnvironment systemEnvironment, PluginsZipUpdater pluginsZipUpdater) {
+                                DefaultPluginJarChangeListener defaultPluginJarChangeListener, GoApplicationAccessor goApplicationAccessor, PluginWriter pluginWriter,
+                                PluginValidator pluginValidator, SystemEnvironment systemEnvironment, PluginsZipUpdater pluginsZipUpdater, PluginsListListener pluginsListListener) {
         this.monitor = monitor;
         this.registry = registry;
         this.defaultPluginJarChangeListener = defaultPluginJarChangeListener;
         this.goApplicationAccessor = goApplicationAccessor;
         this.systemEnvironment = systemEnvironment;
         this.pluginsZipUpdater = pluginsZipUpdater;
+        this.pluginsListListener = pluginsListListener;
         bundleLocation = bundlePath();
         this.goPluginOSGiFramework = goPluginOSGiFramework;
         this.pluginWriter = pluginWriter;
@@ -80,7 +84,6 @@ public class DefaultPluginManager implements PluginManager {
     public List<GoPluginDescriptor> plugins() {
         return registry.plugins();
     }
-
 
     public PluginUploadResponse addPlugin(File uploadedPlugin, String filename) {
         if (!pluginValidator.namecheckForJar(filename)) {
@@ -139,6 +142,7 @@ public class DefaultPluginManager implements PluginManager {
     @Override
     public void registerPluginsFolderChangeListener() {
         monitor.addPluginsFolderChangeListener(pluginsZipUpdater);
+        monitor.addPluginsFolderChangeListener(pluginsListListener);
     }
 
     @Override

--- a/plugin-infra/go-plugin-infra/src/com/thoughtworks/go/plugin/infra/commons/PluginsList.java
+++ b/plugin-infra/go-plugin-infra/src/com/thoughtworks/go/plugin/infra/commons/PluginsList.java
@@ -1,0 +1,91 @@
+/*************************GO-LICENSE-START*********************************
+ * Copyright 2015 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *************************GO-LICENSE-END***********************************/
+
+package com.thoughtworks.go.plugin.infra.commons;
+
+import com.google.gson.Gson;
+import com.thoughtworks.go.util.SystemEnvironment;
+import org.apache.commons.io.comparator.NameFileComparator;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static com.thoughtworks.go.util.FileDigester.md5DigestOfFile;
+
+@Component
+public class PluginsList {
+    private static final org.apache.log4j.Logger LOG = org.apache.log4j.Logger.getLogger(PluginsList.class);
+    private String pluginsJSON;
+
+    private SystemEnvironment systemEnvironment;
+    private final Map<String, String> bundledPluginsMap;
+    private final Map<String, String> externalPluginsMap;
+
+    @Autowired
+    public PluginsList(SystemEnvironment systemEnvironment) {
+        this.systemEnvironment = systemEnvironment;
+        bundledPluginsMap = new LinkedHashMap<String, String>();
+        externalPluginsMap = new LinkedHashMap<String, String>();
+    }
+
+    public void updatePluginsList() {
+        try {
+            File bundledPlugins = new File(systemEnvironment.get(SystemEnvironment.PLUGIN_GO_PROVIDED_PATH));
+            fillDetailsOfPluginsInDirectory(bundledPlugins, bundledPluginsMap);
+
+            File externalPlugins = new File(systemEnvironment.get(SystemEnvironment.PLUGIN_EXTERNAL_PROVIDED_PATH));
+            fillDetailsOfPluginsInDirectory(externalPlugins, externalPluginsMap);
+
+            clearPluginsJSON();
+        } catch (Exception e) {
+            LOG.warn("Error occurred while generating plugin map.", e);
+        }
+    }
+
+    void fillDetailsOfPluginsInDirectory(File directory, Map<String, String> pluginsMap) throws Exception {
+        pluginsMap.clear();
+        File[] pluginJars = directory.exists() ? directory.listFiles() : null;
+        if (pluginJars != null && pluginJars.length != 0) {
+            Arrays.sort(pluginJars, NameFileComparator.NAME_COMPARATOR);
+            for (File pluginJar : pluginJars) {
+                pluginsMap.put(pluginJar.getName(), md5DigestOfFile(pluginJar));
+            }
+        }
+    }
+
+    public String getPluginsJSON() throws IOException {
+        if (pluginsJSON == null) {
+            createPluginsJSON();
+        }
+        return pluginsJSON;
+    }
+
+    private void createPluginsJSON() throws IOException {
+        Map<String, Map<String, String>> allPluginsMap = new LinkedHashMap<String, Map<String, String>>();
+        allPluginsMap.put("bundled", bundledPluginsMap);
+        allPluginsMap.put("external", externalPluginsMap);
+        pluginsJSON = new Gson().toJson(allPluginsMap);
+    }
+
+    private void clearPluginsJSON() {
+        pluginsJSON = null;
+    }
+}

--- a/plugin-infra/go-plugin-infra/src/com/thoughtworks/go/plugin/infra/commons/PluginsList.java
+++ b/plugin-infra/go-plugin-infra/src/com/thoughtworks/go/plugin/infra/commons/PluginsList.java
@@ -52,8 +52,8 @@ public class PluginsList {
 
     public void update() {
         try {
-            bundled.initialize(new File(systemEnvironment.get(SystemEnvironment.PLUGIN_GO_PROVIDED_PATH)));
-            external.initialize(new File(systemEnvironment.get(SystemEnvironment.PLUGIN_EXTERNAL_PROVIDED_PATH)));
+            bundled.initialize(new File(systemEnvironment.getBundledPluginAbsolutePath()));
+            external.initialize(new File(systemEnvironment.getExternalPluginAbsolutePath()));
             clearPluginsJSON();
         } catch (Exception e) {
             LOG.warn("Error occurred while generating plugin map.", e);

--- a/plugin-infra/go-plugin-infra/src/com/thoughtworks/go/plugin/infra/commons/PluginsList.java
+++ b/plugin-infra/go-plugin-infra/src/com/thoughtworks/go/plugin/infra/commons/PluginsList.java
@@ -36,14 +36,12 @@ public class PluginsList {
     private String pluginsJSON;
 
     private SystemEnvironment systemEnvironment;
-    private final Map<String, String> bundledPluginsMap;
-    private final Map<String, String> externalPluginsMap;
+    private final Map<String, String> bundledPluginsMap = new LinkedHashMap<String, String>();
+    private final Map<String, String> externalPluginsMap = new LinkedHashMap<String, String>();
 
     @Autowired
     public PluginsList(SystemEnvironment systemEnvironment) {
         this.systemEnvironment = systemEnvironment;
-        bundledPluginsMap = new LinkedHashMap<String, String>();
-        externalPluginsMap = new LinkedHashMap<String, String>();
     }
 
     public void updatePluginsList() {
@@ -71,14 +69,14 @@ public class PluginsList {
         }
     }
 
-    public String getPluginsJSON() throws IOException {
+    public String getPluginsJSON() {
         if (pluginsJSON == null) {
             createPluginsJSON();
         }
         return pluginsJSON;
     }
 
-    private void createPluginsJSON() throws IOException {
+    private void createPluginsJSON() {
         Map<String, Map<String, String>> allPluginsMap = new LinkedHashMap<String, Map<String, String>>();
         allPluginsMap.put("bundled", bundledPluginsMap);
         allPluginsMap.put("external", externalPluginsMap);

--- a/plugin-infra/go-plugin-infra/src/com/thoughtworks/go/plugin/infra/listeners/PluginsListListener.java
+++ b/plugin-infra/go-plugin-infra/src/com/thoughtworks/go/plugin/infra/listeners/PluginsListListener.java
@@ -32,6 +32,6 @@ public class PluginsListListener implements PluginsFolderChangeListener {
 
     @Override
     public void handle() {
-        pluginsList.updatePluginsList();
+        pluginsList.update();
     }
 }

--- a/plugin-infra/go-plugin-infra/src/com/thoughtworks/go/plugin/infra/listeners/PluginsListListener.java
+++ b/plugin-infra/go-plugin-infra/src/com/thoughtworks/go/plugin/infra/listeners/PluginsListListener.java
@@ -1,0 +1,37 @@
+/*************************GO-LICENSE-START*********************************
+ * Copyright 2015 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *************************GO-LICENSE-END***********************************/
+
+package com.thoughtworks.go.plugin.infra.listeners;
+
+import com.thoughtworks.go.plugin.infra.commons.PluginsList;
+import com.thoughtworks.go.plugin.infra.monitor.PluginsFolderChangeListener;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class PluginsListListener implements PluginsFolderChangeListener {
+    private PluginsList pluginsList;
+
+    @Autowired
+    public PluginsListListener(PluginsList pluginsList) {
+        this.pluginsList = pluginsList;
+    }
+
+    @Override
+    public void handle() {
+        pluginsList.updatePluginsList();
+    }
+}

--- a/plugin-infra/go-plugin-infra/src/com/thoughtworks/go/plugin/infra/monitor/DefaultPluginJarLocationMonitor.java
+++ b/plugin-infra/go-plugin-infra/src/com/thoughtworks/go/plugin/infra/monitor/DefaultPluginJarLocationMonitor.java
@@ -341,10 +341,10 @@ public class DefaultPluginJarLocationMonitor implements PluginJarLocationMonitor
 
                     try {
                         new Closure() {
-                    public void execute(Object o) {
-                        ((PluginsFolderChangeListener) o).handle();
-                    }
-                }.execute(changeListener);
+                            public void execute(Object o) {
+                                ((PluginsFolderChangeListener) o).handle();
+                            }
+                        }.execute(changeListener);
                     } catch (Exception e) {
                         LOGGER.warn("Plugin listener failed", e);
                     }

--- a/plugin-infra/go-plugin-infra/test/com/thoughtworks/go/plugin/infra/DefaultPluginManagerTest.java
+++ b/plugin-infra/go-plugin-infra/test/com/thoughtworks/go/plugin/infra/DefaultPluginManagerTest.java
@@ -23,6 +23,7 @@ import com.thoughtworks.go.plugin.api.request.GoPluginApiRequest;
 import com.thoughtworks.go.plugin.api.response.GoPluginApiResponse;
 import com.thoughtworks.go.plugin.infra.commons.PluginUploadResponse;
 import com.thoughtworks.go.plugin.infra.listeners.DefaultPluginJarChangeListener;
+import com.thoughtworks.go.plugin.infra.listeners.PluginsListListener;
 import com.thoughtworks.go.plugin.infra.listeners.PluginsZipUpdater;
 import com.thoughtworks.go.plugin.infra.monitor.DefaultPluginJarLocationMonitor;
 import com.thoughtworks.go.plugin.infra.plugininfo.DefaultPluginRegistry;
@@ -36,6 +37,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InOrder;
+import org.mockito.Mock;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.osgi.framework.Bundle;
@@ -53,40 +55,45 @@ import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.Matchers.isEmptyString;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
+import static org.mockito.MockitoAnnotations.initMocks;
 
 public class DefaultPluginManagerTest {
     private static final String TEST_PLUGIN_BUNDLE_PATH = "test-bundles-dir";
+    private static final File NON_JAR_FILE = new File("ice-cream-photo.jpg");
+    private static final File NEW_JAR_FILE = new File("a-fancy-hipster-plugin.jar");
+
+    @Mock
+    private DefaultPluginJarLocationMonitor monitor;
+    @Mock
+    private DefaultPluginRegistry registry;
+    @Mock
+    private GoPluginOSGiFramework goPluginOSGiFramework;
+    @Mock
+    private DefaultPluginJarChangeListener jarChangeListener;
+    @Mock
+    private SystemEnvironment systemEnvironment;
+    @Mock
+    private GoApplicationAccessor applicationAccessor;
+    @Mock
+    private PluginWriter pluginWriter;
+    @Mock
+    private PluginValidator pluginValidator;
+    @Mock
+    private PluginsZipUpdater pluginsZipUpdater;
+    @Mock
+    private PluginsListListener pluginsListListener;
+
     private File BUNDLE_DIR;
     private File PLUGIN_EXTERNAL_DIR;
-    private DefaultPluginJarLocationMonitor monitor;
-    private DefaultPluginRegistry registry;
-    private GoPluginOSGiFramework goPluginOSGiFramework;
-    private DefaultPluginJarChangeListener jarChangeListener;
-    private SystemEnvironment systemEnvironment;
-    private GoApplicationAccessor applicationAccessor;
-    private PluginWriter pluginWriter;
-    private PluginValidator pluginValidator;
-    private static final File NON_JAR_FILE = new File("ice-cream-photo.jpg");
-    public static final File NEW_JAR_FILE = new File("a-fancy-hipster-plugin.jar");
-    private PluginsZipUpdater pluginsZipUpdater;
 
     @Before
     public void setUp() throws Exception {
-        BUNDLE_DIR = new File(TEST_PLUGIN_BUNDLE_PATH);
+        initMocks(this);
 
+        BUNDLE_DIR = new File(TEST_PLUGIN_BUNDLE_PATH);
         String pluginExternalDirName = "./tmp-external-DPJLMT" + new Random().nextInt();
         PLUGIN_EXTERNAL_DIR = new File(pluginExternalDirName);
         PLUGIN_EXTERNAL_DIR.mkdirs();
-
-        monitor = mock(DefaultPluginJarLocationMonitor.class);
-        registry = mock(DefaultPluginRegistry.class);
-        goPluginOSGiFramework = mock(GoPluginOSGiFramework.class);
-        jarChangeListener = mock(DefaultPluginJarChangeListener.class);
-        systemEnvironment = mock(SystemEnvironment.class);
-        applicationAccessor = mock(GoApplicationAccessor.class);
-        pluginWriter = mock(PluginWriter.class);
-        pluginValidator = mock(PluginValidator.class);
-        pluginsZipUpdater = mock(PluginsZipUpdater.class);
 
         when(systemEnvironment.get(PLUGIN_BUNDLE_PATH)).thenReturn(TEST_PLUGIN_BUNDLE_PATH);
         when(systemEnvironment.get(PLUGIN_FRAMEWORK_ENABLED)).thenReturn(Boolean.TRUE);
@@ -103,7 +110,7 @@ public class DefaultPluginManagerTest {
     @Test
     public void shouldProceedToPluginWriterWithValidJarFile() throws Exception {
         NEW_JAR_FILE.createNewFile();
-        DefaultPluginManager defaultPluginManager = new DefaultPluginManager(monitor, registry, goPluginOSGiFramework, jarChangeListener, null, pluginWriter, pluginValidator, systemEnvironment, pluginsZipUpdater);
+        DefaultPluginManager defaultPluginManager = new DefaultPluginManager(monitor, registry, goPluginOSGiFramework, jarChangeListener, null, pluginWriter, pluginValidator, systemEnvironment, pluginsZipUpdater, pluginsListListener);
         when(pluginValidator.namecheckForJar(NEW_JAR_FILE.getName())).thenReturn(true);
 
         defaultPluginManager.addPlugin(NEW_JAR_FILE, NEW_JAR_FILE.getName());
@@ -119,7 +126,7 @@ public class DefaultPluginManagerTest {
     @Test
     public void shouldReturnTheResponseReturnedByPluginWriterWithValidJarFile() throws Exception {
         NEW_JAR_FILE.createNewFile();
-        DefaultPluginManager defaultPluginManager = new DefaultPluginManager(monitor, registry, goPluginOSGiFramework, jarChangeListener, null, pluginWriter, pluginValidator, systemEnvironment, pluginsZipUpdater);
+        DefaultPluginManager defaultPluginManager = new DefaultPluginManager(monitor, registry, goPluginOSGiFramework, jarChangeListener, null, pluginWriter, pluginValidator, systemEnvironment, pluginsZipUpdater, pluginsListListener);
         when(pluginValidator.namecheckForJar(NEW_JAR_FILE.getName())).thenReturn(true);
         PluginUploadResponse expectedResponse = PluginUploadResponse.create(true, "successful!", null);
         when(pluginWriter.addPlugin(NEW_JAR_FILE, NEW_JAR_FILE.getName())).thenReturn(expectedResponse);
@@ -132,7 +139,7 @@ public class DefaultPluginManagerTest {
     @Test
     public void shouldReturnResponseWithErrorsWithInvalidJarFile() throws Exception {
         NON_JAR_FILE.createNewFile();
-        DefaultPluginManager defaultPluginManager = new DefaultPluginManager(monitor, registry, goPluginOSGiFramework, jarChangeListener, null, pluginWriter, pluginValidator, systemEnvironment, pluginsZipUpdater);
+        DefaultPluginManager defaultPluginManager = new DefaultPluginManager(monitor, registry, goPluginOSGiFramework, jarChangeListener, null, pluginWriter, pluginValidator, systemEnvironment, pluginsZipUpdater, pluginsListListener);
         when(pluginValidator.namecheckForJar(NON_JAR_FILE.getName())).thenReturn(false);
 
         PluginUploadResponse response = defaultPluginManager.addPlugin(NON_JAR_FILE, "not a jar");
@@ -148,14 +155,14 @@ public class DefaultPluginManagerTest {
         String pluginJarFile = "descriptor-aware-test-plugin.should.be.deleted.jar";
         copyPluginToTheDirectory(BUNDLE_DIR, pluginJarFile);
 
-        new DefaultPluginManager(monitor, registry, goPluginOSGiFramework, jarChangeListener, null, pluginWriter, pluginValidator,systemEnvironment, pluginsZipUpdater).startInfrastructure();
+        new DefaultPluginManager(monitor, registry, goPluginOSGiFramework, jarChangeListener, null, pluginWriter, pluginValidator, systemEnvironment, pluginsZipUpdater, pluginsListListener).startInfrastructure();
 
         assertThat(BUNDLE_DIR.exists(), is(false));
     }
 
     @Test
     public void shouldStartOSGiFrameworkBeforeStartingMonitor() throws Exception {
-        new DefaultPluginManager(monitor, registry, goPluginOSGiFramework, jarChangeListener, null, pluginWriter, pluginValidator, systemEnvironment, pluginsZipUpdater).startInfrastructure();
+        new DefaultPluginManager(monitor, registry, goPluginOSGiFramework, jarChangeListener, null, pluginWriter, pluginValidator, systemEnvironment, pluginsZipUpdater, pluginsListListener).startInfrastructure();
         InOrder inOrder = inOrder(goPluginOSGiFramework, monitor);
 
         inOrder.verify(goPluginOSGiFramework).start();
@@ -166,7 +173,7 @@ public class DefaultPluginManagerTest {
     public void shouldNotStartPluginFrameworkIfPluginsAreDisabled() throws Exception {
         when(systemEnvironment.get(PLUGIN_FRAMEWORK_ENABLED)).thenReturn(Boolean.FALSE);
 
-        new DefaultPluginManager(monitor, registry, goPluginOSGiFramework, jarChangeListener, null, pluginWriter, pluginValidator, systemEnvironment, pluginsZipUpdater);
+        new DefaultPluginManager(monitor, registry, goPluginOSGiFramework, jarChangeListener, null, pluginWriter, pluginValidator, systemEnvironment, pluginsZipUpdater, pluginsListListener);
 
         verifyZeroInteractions(goPluginOSGiFramework);
         verifyZeroInteractions(monitor);
@@ -174,7 +181,7 @@ public class DefaultPluginManagerTest {
 
     @Test
     public void shouldAllowRunningAnActionOnAllRegisteredImplementations() throws Exception {
-        PluginManager pluginManager = new DefaultPluginManager(monitor, registry, goPluginOSGiFramework, jarChangeListener, null, pluginWriter, pluginValidator, systemEnvironment, pluginsZipUpdater);
+        PluginManager pluginManager = new DefaultPluginManager(monitor, registry, goPluginOSGiFramework, jarChangeListener, null, pluginWriter, pluginValidator, systemEnvironment, pluginsZipUpdater, pluginsListListener);
 
         Action action = mock(Action.class);
         pluginManager.doOnAll(SomeInterface.class, action);
@@ -184,7 +191,7 @@ public class DefaultPluginManagerTest {
 
     @Test
     public void shouldAllowRunningAnActionOnASpecificPlugin() throws Exception {
-        PluginManager pluginManager = new DefaultPluginManager(monitor, registry, goPluginOSGiFramework, jarChangeListener, null, pluginWriter, pluginValidator, systemEnvironment, pluginsZipUpdater);
+        PluginManager pluginManager = new DefaultPluginManager(monitor, registry, goPluginOSGiFramework, jarChangeListener, null, pluginWriter, pluginValidator, systemEnvironment, pluginsZipUpdater, pluginsListListener);
 
         Action action = mock(Action.class);
         String pluginId = "test-plugin-id";
@@ -196,7 +203,7 @@ public class DefaultPluginManagerTest {
     @Test
     public void shouldAllowRegistrationOfPluginChangeListenersForGivenServiceReferences() throws Exception {
         GoPlugginOSGiFrameworkStub frameworkStub = new GoPlugginOSGiFrameworkStub();
-        PluginManager pluginManager = new DefaultPluginManager(monitor, registry, frameworkStub, jarChangeListener, null, pluginWriter, pluginValidator, systemEnvironment, pluginsZipUpdater);
+        PluginManager pluginManager = new DefaultPluginManager(monitor, registry, frameworkStub, jarChangeListener, null, pluginWriter, pluginValidator, systemEnvironment, pluginsZipUpdater, pluginsListListener);
 
         Action action = mock(Action.class);
         String pluginId1 = "test-plugin-id-1";
@@ -235,7 +242,7 @@ public class DefaultPluginManagerTest {
 
     @Test
     public void shouldAllowRunningAnActionOnASpecificPluginIfReferenceExists() throws Exception {
-        PluginManager pluginManager = new DefaultPluginManager(monitor, registry, goPluginOSGiFramework, jarChangeListener, null, pluginWriter, pluginValidator, systemEnvironment, pluginsZipUpdater);
+        PluginManager pluginManager = new DefaultPluginManager(monitor, registry, goPluginOSGiFramework, jarChangeListener, null, pluginWriter, pluginValidator, systemEnvironment, pluginsZipUpdater, pluginsListListener);
 
         Action action = mock(Action.class);
         String pluginId1 = "test-plugin-id-1";
@@ -253,7 +260,7 @@ public class DefaultPluginManagerTest {
 
     @Test
     public void shouldAllowRunningAnActionOnAllRegisteredImplementationsWithExceptionHandling() throws Exception {
-        PluginManager pluginManager = new DefaultPluginManager(monitor, registry, goPluginOSGiFramework, jarChangeListener, null, pluginWriter, pluginValidator, systemEnvironment, pluginsZipUpdater);
+        PluginManager pluginManager = new DefaultPluginManager(monitor, registry, goPluginOSGiFramework, jarChangeListener, null, pluginWriter, pluginValidator, systemEnvironment, pluginsZipUpdater, pluginsListListener);
 
         Action action = mock(Action.class);
         ExceptionHandler exceptionHandler = mock(ExceptionHandler.class);
@@ -264,7 +271,7 @@ public class DefaultPluginManagerTest {
 
     @Test
     public void shouldAllowRunningAnActionOnRegisteredImplementationOfSpecifiedPlugin() {
-        PluginManager pluginManager = new DefaultPluginManager(monitor, registry, goPluginOSGiFramework, jarChangeListener, null, pluginWriter, pluginValidator, systemEnvironment, pluginsZipUpdater);
+        PluginManager pluginManager = new DefaultPluginManager(monitor, registry, goPluginOSGiFramework, jarChangeListener, null, pluginWriter, pluginValidator, systemEnvironment, pluginsZipUpdater, pluginsListListener);
         ActionWithReturn action = mock(ActionWithReturn.class);
         pluginManager.doOn(SomeInterface.class, "plugin-id", action);
 
@@ -273,7 +280,7 @@ public class DefaultPluginManagerTest {
 
     @Test
     public void shouldGetPluginDescriptorForGivenPluginIdCorrectly() throws Exception {
-        DefaultPluginManager pluginManager = new DefaultPluginManager(monitor, registry, goPluginOSGiFramework, jarChangeListener, null, pluginWriter, pluginValidator, systemEnvironment, pluginsZipUpdater);
+        DefaultPluginManager pluginManager = new DefaultPluginManager(monitor, registry, goPluginOSGiFramework, jarChangeListener, null, pluginWriter, pluginValidator, systemEnvironment, pluginsZipUpdater, pluginsListListener);
         GoPluginDescriptor pluginDescriptorForP1 = new GoPluginDescriptor("p1", "1.0", null, null, null, true);
         when(registry.getPlugin("valid-plugin")).thenReturn(pluginDescriptorForP1);
         when(registry.getPlugin("invalid-plugin")).thenReturn(null);
@@ -297,7 +304,7 @@ public class DefaultPluginManagerTest {
             }
         }).when(goPluginOSGiFramework).doOn(eq(GoPlugin.class), eq("plugin-id"), any(ActionWithReturn.class));
 
-        DefaultPluginManager pluginManager = new DefaultPluginManager(monitor, registry, goPluginOSGiFramework, jarChangeListener, applicationAccessor, pluginWriter, pluginValidator, systemEnvironment, pluginsZipUpdater);
+        DefaultPluginManager pluginManager = new DefaultPluginManager(monitor, registry, goPluginOSGiFramework, jarChangeListener, applicationAccessor, pluginWriter, pluginValidator, systemEnvironment, pluginsZipUpdater, pluginsListListener);
         GoPluginApiResponse actualResponse = pluginManager.submitTo("plugin-id", request);
 
         assertThat(actualResponse, is(expectedResponse));
@@ -322,7 +329,7 @@ public class DefaultPluginManagerTest {
         when(goPlugin.pluginIdentifier()).thenReturn(pluginIdentifier).thenReturn(anotherPluginIdentifier);
 
 
-        DefaultPluginManager pluginManager = new DefaultPluginManager(monitor, registry, goPluginOSGiFramework, jarChangeListener, applicationAccessor, pluginWriter, pluginValidator, systemEnvironment, pluginsZipUpdater);
+        DefaultPluginManager pluginManager = new DefaultPluginManager(monitor, registry, goPluginOSGiFramework, jarChangeListener, applicationAccessor, pluginWriter, pluginValidator, systemEnvironment, pluginsZipUpdater, pluginsListListener);
         List<GoPluginIdentifier> pluginIdentifiers = pluginManager.allPluginsOfType("extension-type");
         assertThat(pluginIdentifiers.size(), is(1));
         assertThat(pluginIdentifiers.get(0), is(pluginIdentifier));
@@ -332,7 +339,7 @@ public class DefaultPluginManagerTest {
     public void shouldCheckIfReferenceCanBeFoundForServiceClassAndPluginId() throws Exception {
         String pluginId = "plugin-id";
         when(goPluginOSGiFramework.hasReferenceFor(GoPlugin.class, pluginId)).thenReturn(true);
-        DefaultPluginManager pluginManager = new DefaultPluginManager(monitor, registry, goPluginOSGiFramework, jarChangeListener, applicationAccessor, pluginWriter, pluginValidator, systemEnvironment, pluginsZipUpdater);
+        DefaultPluginManager pluginManager = new DefaultPluginManager(monitor, registry, goPluginOSGiFramework, jarChangeListener, applicationAccessor, pluginWriter, pluginValidator, systemEnvironment, pluginsZipUpdater, pluginsListListener);
         assertThat(pluginManager.hasReferenceFor(GoPlugin.class, pluginId), is(true));
     }
 
@@ -353,7 +360,7 @@ public class DefaultPluginManagerTest {
         }).when(goPluginOSGiFramework).doOn(eq(GoPlugin.class), eq(pluginId), any(ActionWithReturn.class));
         when(goPlugin.pluginIdentifier()).thenReturn(pluginIdentifier);
 
-        DefaultPluginManager pluginManager = new DefaultPluginManager(monitor, registry, goPluginOSGiFramework, jarChangeListener, applicationAccessor, pluginWriter, pluginValidator, systemEnvironment, pluginsZipUpdater);
+        DefaultPluginManager pluginManager = new DefaultPluginManager(monitor, registry, goPluginOSGiFramework, jarChangeListener, applicationAccessor, pluginWriter, pluginValidator, systemEnvironment, pluginsZipUpdater, pluginsListListener);
         assertTrue(pluginManager.isPluginOfType("sample-extension", pluginId));
     }
 
@@ -362,7 +369,7 @@ public class DefaultPluginManagerTest {
         final String pluginThatDoesNotImplement = "plugin-that-does-not-implement";
         when(goPluginOSGiFramework.hasReferenceFor(GoPlugin.class, pluginThatDoesNotImplement)).thenReturn(false);
 
-        DefaultPluginManager pluginManager = new DefaultPluginManager(monitor, registry, goPluginOSGiFramework, jarChangeListener, applicationAccessor, pluginWriter, pluginValidator, systemEnvironment, pluginsZipUpdater);
+        DefaultPluginManager pluginManager = new DefaultPluginManager(monitor, registry, goPluginOSGiFramework, jarChangeListener, applicationAccessor, pluginWriter, pluginValidator, systemEnvironment, pluginsZipUpdater, pluginsListListener);
         assertFalse(pluginManager.isPluginOfType("extension-type", pluginThatDoesNotImplement));
         verify(goPluginOSGiFramework).hasReferenceFor(GoPlugin.class, pluginThatDoesNotImplement);
         verify(goPluginOSGiFramework, never()).doOn(eq(GoPlugin.class), eq(pluginThatDoesNotImplement), any(ActionWithReturn.class));
@@ -386,7 +393,7 @@ public class DefaultPluginManagerTest {
         }).when(goPluginOSGiFramework).doOn(eq(GoPlugin.class), eq(pluginThatDoesNotImplement), any(ActionWithReturn.class));
         when(goPlugin.pluginIdentifier()).thenReturn(pluginIdentifier);
 
-        DefaultPluginManager pluginManager = new DefaultPluginManager(monitor, registry, goPluginOSGiFramework, jarChangeListener, applicationAccessor, pluginWriter, pluginValidator, systemEnvironment, pluginsZipUpdater);
+        DefaultPluginManager pluginManager = new DefaultPluginManager(monitor, registry, goPluginOSGiFramework, jarChangeListener, applicationAccessor, pluginWriter, pluginValidator, systemEnvironment, pluginsZipUpdater, pluginsListListener);
         assertFalse(pluginManager.isPluginOfType("extension-type", pluginThatDoesNotImplement));
         verify(goPluginOSGiFramework).doOn(eq(GoPlugin.class), eq(pluginThatDoesNotImplement), any(ActionWithReturn.class));
     }
@@ -398,7 +405,7 @@ public class DefaultPluginManagerTest {
         GoPlugginOSGiFrameworkStub osGiFrameworkStub = new GoPlugginOSGiFrameworkStub(goPlugin);
         osGiFrameworkStub.addHasReferenceFor(GoPlugin.class, pluginId, true);
         when(goPlugin.pluginIdentifier()).thenReturn(new GoPluginIdentifier("sample-extension", asList("1.0", "2.0")));
-        DefaultPluginManager pluginManager = new DefaultPluginManager(monitor, registry, osGiFrameworkStub, jarChangeListener, applicationAccessor, pluginWriter, pluginValidator, systemEnvironment, pluginsZipUpdater);
+        DefaultPluginManager pluginManager = new DefaultPluginManager(monitor, registry, osGiFrameworkStub, jarChangeListener, applicationAccessor, pluginWriter, pluginValidator, systemEnvironment, pluginsZipUpdater, pluginsListListener);
         assertThat(pluginManager.resolveExtensionVersion(pluginId, asList("1.0", "2.0", "3.0")), is("2.0"));
 
     }
@@ -410,7 +417,7 @@ public class DefaultPluginManagerTest {
         GoPlugginOSGiFrameworkStub osGiFrameworkStub = new GoPlugginOSGiFrameworkStub(goPlugin);
         osGiFrameworkStub.addHasReferenceFor(GoPlugin.class, pluginId, true);
         when(goPlugin.pluginIdentifier()).thenReturn(new GoPluginIdentifier("sample-extension", asList("1.0", "2.0")));
-        DefaultPluginManager pluginManager = new DefaultPluginManager(monitor, registry, osGiFrameworkStub, jarChangeListener, applicationAccessor, pluginWriter, pluginValidator, systemEnvironment, pluginsZipUpdater);
+        DefaultPluginManager pluginManager = new DefaultPluginManager(monitor, registry, osGiFrameworkStub, jarChangeListener, applicationAccessor, pluginWriter, pluginValidator, systemEnvironment, pluginsZipUpdater, pluginsListListener);
         try {
             pluginManager.resolveExtensionVersion(pluginId, asList("3.0", "4.0"));
             fail("should have thrown exception for not finding matching extension version");
@@ -421,7 +428,7 @@ public class DefaultPluginManagerTest {
 
     @Test
     public void shouldAddPluginChangeListener() throws Exception {
-        DefaultPluginManager pluginManager = new DefaultPluginManager(monitor, registry, mock(GoPluginOSGiFramework.class), jarChangeListener, applicationAccessor, pluginWriter, pluginValidator, systemEnvironment, pluginsZipUpdater);
+        DefaultPluginManager pluginManager = new DefaultPluginManager(monitor, registry, mock(GoPluginOSGiFramework.class), jarChangeListener, applicationAccessor, pluginWriter, pluginValidator, systemEnvironment, pluginsZipUpdater, pluginsListListener);
         pluginManager.startInfrastructure();
 
         InOrder inOrder = inOrder(monitor);

--- a/plugin-infra/go-plugin-infra/test/com/thoughtworks/go/plugin/infra/DefaultPluginManagerTest.java
+++ b/plugin-infra/go-plugin-infra/test/com/thoughtworks/go/plugin/infra/DefaultPluginManagerTest.java
@@ -436,6 +436,17 @@ public class DefaultPluginManagerTest {
         inOrder.verify(monitor).addPluginJarChangeListener(jarChangeListener);
     }
 
+    @Test
+    public void shouldAddPluginsFolderChangeListener() throws Exception {
+        DefaultPluginManager pluginManager = new DefaultPluginManager(monitor, registry, mock(GoPluginOSGiFramework.class), jarChangeListener, applicationAccessor, pluginWriter, pluginValidator, systemEnvironment, pluginsZipUpdater, pluginsListListener);
+        pluginManager.registerPluginsFolderChangeListener();
+
+        InOrder inOrder = inOrder(monitor);
+
+        inOrder.verify(monitor).addPluginsFolderChangeListener(pluginsZipUpdater);
+        inOrder.verify(monitor).addPluginsFolderChangeListener(pluginsListListener);
+    }
+
     @After
     public void tearDown() throws Exception {
         FileUtils.deleteQuietly(BUNDLE_DIR);

--- a/plugin-infra/go-plugin-infra/test/com/thoughtworks/go/plugin/infra/commons/PluginsListTest.java
+++ b/plugin-infra/go-plugin-infra/test/com/thoughtworks/go/plugin/infra/commons/PluginsListTest.java
@@ -1,0 +1,119 @@
+/*************************GO-LICENSE-START*********************************
+ * Copyright 2015 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *************************GO-LICENSE-END***********************************/
+
+package com.thoughtworks.go.plugin.infra.commons;
+
+import com.thoughtworks.go.util.ReflectionUtil;
+import com.thoughtworks.go.util.SystemEnvironment;
+import org.apache.commons.io.FileUtils;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.mockito.Mock;
+
+import java.io.File;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static com.thoughtworks.go.util.SystemEnvironment.PLUGIN_EXTERNAL_PROVIDED_PATH;
+import static com.thoughtworks.go.util.SystemEnvironment.PLUGIN_GO_PROVIDED_PATH;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+public class PluginsListTest {
+    @Mock
+    private SystemEnvironment systemEnvironment;
+    private PluginsList pluginsList;
+    private File bundledPluginsDir;
+    private File externalPluginsDir;
+
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    @Before
+    public void setUp() throws Exception {
+        initMocks(this);
+        temporaryFolder.create();
+        bundledPluginsDir = temporaryFolder.newFolder("bundled");
+        externalPluginsDir = temporaryFolder.newFolder("external");
+
+        File bundledYumPlugin = new File(bundledPluginsDir, "yum.jar");
+        File externalPlugin1 = new File(externalPluginsDir, "external1.jar");
+        File externalPlugin2 = new File(externalPluginsDir, "external2.jar");
+        File externalPlugin3 = new File(externalPluginsDir, "external3.jar");
+        FileUtils.writeStringToFile(bundledYumPlugin, bundledYumPlugin.getName());
+        FileUtils.writeStringToFile(externalPlugin1, externalPlugin1.getName());
+        FileUtils.writeStringToFile(externalPlugin2, externalPlugin2.getName());
+        FileUtils.writeStringToFile(externalPlugin3, externalPlugin3.getName());
+
+        when(systemEnvironment.get(PLUGIN_GO_PROVIDED_PATH)).thenReturn(bundledPluginsDir.getAbsolutePath());
+        when(systemEnvironment.get(PLUGIN_EXTERNAL_PROVIDED_PATH)).thenReturn(externalPluginsDir.getAbsolutePath());
+
+        pluginsList = new PluginsList(systemEnvironment);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        temporaryFolder.delete();
+    }
+
+    @Test
+    public void shouldPopulateJarDetails() throws Exception {
+        final Map<String, String> bundledPluginsMap = new LinkedHashMap<String, String>();
+        pluginsList.fillDetailsOfPluginsInDirectory(bundledPluginsDir, bundledPluginsMap);
+
+        assertThat(bundledPluginsMap.size(), is(1));
+        assertThat(bundledPluginsMap.get("yum.jar"), is("LAVBbwaDykricDnAP57klg=="));
+
+        final Map<String, String> externalPluginsMap = new LinkedHashMap<String, String>();
+        pluginsList.fillDetailsOfPluginsInDirectory(externalPluginsDir, externalPluginsMap);
+
+        assertThat(externalPluginsMap.size(), is(3));
+        assertThat(externalPluginsMap.get("external1.jar"), is("+yWDK4+tYQtfqyh3tmT95A=="));
+        assertThat(externalPluginsMap.get("external2.jar"), is("DS/Oa0vv5URteXfzSU7mvQ=="));
+        assertThat(externalPluginsMap.get("external3.jar"), is("OQV644wsBJgbtQWR+L3UXA=="));
+    }
+
+    @Test
+    public void shouldRemoveOlderEntriesInPluginsMap() throws Exception {
+        final Map<String, String> bundledPluginsMap = new LinkedHashMap<String, String>();
+        pluginsList.fillDetailsOfPluginsInDirectory(bundledPluginsDir, bundledPluginsMap);
+
+        assertThat(bundledPluginsMap.size(), is(1));
+        assertThat(bundledPluginsMap.get("yum.jar"), is("LAVBbwaDykricDnAP57klg=="));
+
+        File bundledYumPlugin = new File(bundledPluginsDir, "yum.jar");
+        FileUtils.deleteQuietly(bundledYumPlugin);
+
+        pluginsList.fillDetailsOfPluginsInDirectory(bundledPluginsDir, bundledPluginsMap);
+        assertThat(bundledPluginsMap.isEmpty(), is(true));
+    }
+
+    @Test
+    public void shouldGetPluginsJSON() throws Exception {
+        pluginsList.updatePluginsList();
+        assertThat(ReflectionUtil.getField(pluginsList, "pluginsJSON"), is(nullValue()));
+
+        String allPluginsJSON = pluginsList.getPluginsJSON();
+
+        assertThat(ReflectionUtil.getField(pluginsList, "pluginsJSON"), is(notNullValue()));
+        assertThat(allPluginsJSON, is("{\"bundled\":{\"yum.jar\":\"LAVBbwaDykricDnAP57klg\\u003d\\u003d\"},\"external\":{\"external1.jar\":\"+yWDK4+tYQtfqyh3tmT95A\\u003d\\u003d\",\"external2.jar\":\"DS/Oa0vv5URteXfzSU7mvQ\\u003d\\u003d\",\"external3.jar\":\"OQV644wsBJgbtQWR+L3UXA\\u003d\\u003d\"}}"));
+    }
+}

--- a/plugin-infra/go-plugin-infra/test/com/thoughtworks/go/plugin/infra/commons/PluginsListTest.java
+++ b/plugin-infra/go-plugin-infra/test/com/thoughtworks/go/plugin/infra/commons/PluginsListTest.java
@@ -62,8 +62,8 @@ public class PluginsListTest {
         FileUtils.writeStringToFile(externalPlugin2, externalPlugin2.getName());
         FileUtils.writeStringToFile(externalPlugin3, externalPlugin3.getName());
 
-        when(systemEnvironment.get(PLUGIN_GO_PROVIDED_PATH)).thenReturn(bundledPluginsDir.getAbsolutePath());
-        when(systemEnvironment.get(PLUGIN_EXTERNAL_PROVIDED_PATH)).thenReturn(externalPluginsDir.getAbsolutePath());
+        when(systemEnvironment.getBundledPluginAbsolutePath()).thenReturn(bundledPluginsDir.getAbsolutePath());
+        when(systemEnvironment.getExternalPluginAbsolutePath()).thenReturn(externalPluginsDir.getAbsolutePath());
 
         pluginsList = new PluginsList(systemEnvironment);
     }

--- a/plugin-infra/go-plugin-infra/test/com/thoughtworks/go/plugin/infra/listeners/PluginsListListenerTest.java
+++ b/plugin-infra/go-plugin-infra/test/com/thoughtworks/go/plugin/infra/listeners/PluginsListListenerTest.java
@@ -1,0 +1,29 @@
+package com.thoughtworks.go.plugin.infra.listeners;
+
+import com.thoughtworks.go.plugin.infra.commons.PluginsList;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+public class PluginsListListenerTest {
+    @Mock
+    private PluginsList pluginsList;
+    private PluginsListListener pluginsListListener;
+
+    @Before
+    public void setUp() throws Exception {
+        initMocks(this);
+        pluginsListListener = new PluginsListListener(pluginsList);
+    }
+
+    @Test
+    public void shouldUpdatePluginListOnHandle() throws Exception {
+        pluginsListListener.handle();
+
+        verify(pluginsList, times(1)).updatePluginsList();
+    }
+}

--- a/plugin-infra/go-plugin-infra/test/com/thoughtworks/go/plugin/infra/listeners/PluginsListListenerTest.java
+++ b/plugin-infra/go-plugin-infra/test/com/thoughtworks/go/plugin/infra/listeners/PluginsListListenerTest.java
@@ -5,7 +5,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.MockitoAnnotations.initMocks;
 
@@ -24,6 +23,6 @@ public class PluginsListListenerTest {
     public void shouldUpdatePluginListOnHandle() throws Exception {
         pluginsListListener.handle();
 
-        verify(pluginsList, times(1)).updatePluginsList();
+        verify(pluginsList).updatePluginsList();
     }
 }

--- a/plugin-infra/go-plugin-infra/test/com/thoughtworks/go/plugin/infra/listeners/PluginsListListenerTest.java
+++ b/plugin-infra/go-plugin-infra/test/com/thoughtworks/go/plugin/infra/listeners/PluginsListListenerTest.java
@@ -23,6 +23,6 @@ public class PluginsListListenerTest {
     public void shouldUpdatePluginListOnHandle() throws Exception {
         pluginsListListener.handle();
 
-        verify(pluginsList).updatePluginsList();
+        verify(pluginsList).update();
     }
 }


### PR DESCRIPTION
* A map is created for bundled and external plugins which is then used to create a JSON for all the plugins. This JSON will be passed to the agents which will compare with it's own local JSON contents. If there is any change, viz addition (new entry), deletion (entry no longer exists) or update (the md5 of the plugin entry changed), that particular plugin should be downloaded.