### PR TITLE
#1000 - Allow special chars is pipeline label format.

### DIFF
--- a/common/test/unit/com/thoughtworks/go/domain/PipelineLabelTest.java
+++ b/common/test/unit/com/thoughtworks/go/domain/PipelineLabelTest.java
@@ -233,18 +233,33 @@ public class PipelineLabelTest {
     }
 
     @Test
+    public void canNotMatchWithTruncationWhenMaterialNameHasAColon() throws Exception {
+        final String[][] expectedGroups = { { "git:one", "7" } };
+        String res = assertLabelGroupsMatchingAndReplace("release-${git:one[:7]}", expectedGroups);
+        assertThat(res, is("release-${git:one[:7]}"));
+    }
+
+    @Test
     public void shouldReplaceTheTemplateWithSpecialCharacters() throws Exception {
         ensureLabelIsReplaced("SVNMaterial");
         ensureLabelIsReplaced("SVN-Material");
         ensureLabelIsReplaced("SVN_Material");
         ensureLabelIsReplaced("SVN!Material");
-        ensureLabelIsReplaced("SVN*MATERIAL");
-        ensureLabelIsReplaced("SVN**__##Material_1023_WithNumbers");
-        ensureLabelIsReplaced("SVN_Material-_!!_**");
+        ensureLabelIsReplaced("SVN__##Material_1023_WithNumbers");
+        ensureLabelIsReplaced("SVN_Material-_!!_");
         ensureLabelIsReplaced("svn_Material'WithQuote");
+        ensureLabelIsReplaced("SVN_Material.With.Period");
+        ensureLabelIsReplaced("SVN_Material#With#Hash");
+        ensureLabelIsReplaced("SVN_Material:With:Colon");
+        ensureLabelIsReplaced("SVN_Material~With~Tilde");
 
+        ensureLabelIsNOTReplaced("SVN*MATERIAL");
         ensureLabelIsNOTReplaced("SVN+Material");
         ensureLabelIsNOTReplaced("SVN^Material");
+        ensureLabelIsNOTReplaced("SVN_Material(With)Parentheses");
+        ensureLabelIsNOTReplaced("SVN_Material{With}Braces");
+        ensureLabelIsNOTReplaced("SVN**Material");
+        ensureLabelIsNOTReplaced("SVN\\Material_With_Backslash");
     }
 
     @BeforeClass

--- a/config/config-api/src/com/thoughtworks/go/domain/label/PipelineLabel.java
+++ b/config/config-api/src/com/thoughtworks/go/domain/label/PipelineLabel.java
@@ -42,7 +42,7 @@ public class PipelineLabel implements Serializable {
         return label;
     }
 
-    public static final Pattern PATTERN = Pattern.compile("(?i)\\$\\{([a-zA-Z0-9_\\-\\.!~*'()#]+)(\\[:(\\d+)\\])?\\}");
+    public static final Pattern PATTERN = Pattern.compile("(?i)\\$\\{([a-zA-Z0-9_\\-\\.!~'#:]+)(\\[:(\\d+)\\])?\\}");
 
     private String replaceRevisionsInLabel(Map<CaseInsensitiveString, String> materialRevisions) {
         final Matcher matcher = PATTERN.matcher(this.label);

--- a/config/config-api/src/com/thoughtworks/go/domain/label/PipelineLabel.java
+++ b/config/config-api/src/com/thoughtworks/go/domain/label/PipelineLabel.java
@@ -42,7 +42,7 @@ public class PipelineLabel implements Serializable {
         return label;
     }
 
-    public static final Pattern PATTERN = Pattern.compile("(?i)\\$\\{([\\w\\.]+)(\\[:(\\d+)\\])?\\}");
+    public static final Pattern PATTERN = Pattern.compile("(?i)\\$\\{([a-zA-Z0-9_\\-\\.!~*'()#]+)(\\[:(\\d+)\\])?\\}");
 
     private String replaceRevisionsInLabel(Map<CaseInsensitiveString, String> materialRevisions) {
         final Matcher matcher = PATTERN.matcher(this.label);


### PR DESCRIPTION
Use parts of the regex from the [XSD](https://github.com/gocd/gocd/blob/1ff8eed679b4bbfc13f4790630c4b6c7004e02c1/config/config-server/resources/cruise-config.xsd#L715), when replacing the variables in the label, so that special characters can be used.

Fixes #1000.