### PR TITLE
#1004 - Fix Maven dependency issue.

### DIFF
--- a/app-server/pom.xml
+++ b/app-server/pom.xml
@@ -31,6 +31,10 @@
         <relativePath>../</relativePath>
     </parent>
 
+    <properties>
+      <main.dir>${project.basedir}/..</main.dir>
+      <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
 
     <dependencies>
         <dependency>

--- a/jetty6/pom.xml
+++ b/jetty6/pom.xml
@@ -33,6 +33,8 @@
 
     <properties>
         <jetty.version>6.1.23</jetty.version>
+        <main.dir>${project.basedir}/..</main.dir>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <dependencies>

--- a/jetty9/pom.xml
+++ b/jetty9/pom.xml
@@ -33,6 +33,8 @@
 
     <properties>
         <jetty.version>9.2.3.v20140905</jetty.version>
+        <main.dir>${project.basedir}/..</main.dir>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
On a clean build (with no Maven cache - ~/.m2), the build fails because the local-maven-repo is not found (inside app-server/). Fix this, by setting main.dir in app-server's pom.xml.

Fixes #1004.