### PR TITLE
#1007 - The plugins bundled location was wrong due to which the PluginsL...

### DIFF
--- a/base/src/com/thoughtworks/go/util/SystemEnvironment.java
+++ b/base/src/com/thoughtworks/go/util/SystemEnvironment.java
@@ -618,7 +618,7 @@ public class SystemEnvironment implements Serializable, ConfigDirProvider {
     }
 
     public String getBundledPluginAbsolutePath() {
-        return new File(get(PLUGIN_BUNDLE_PATH)).getAbsolutePath();
+        return new File(get(PLUGIN_GO_PROVIDED_PATH)).getAbsolutePath();
     }
 
     public <T> void reset(GoSystemProperty<T> systemProperty) {


### PR DESCRIPTION
...ist was throwing the error while calculating the md5.