### PR TITLE
#1007 - Renaming of file withought changing the content ensures plugin d...

### DIFF
--- a/base/src/com/thoughtworks/go/util/FileDigester.java
+++ b/base/src/com/thoughtworks/go/util/FileDigester.java
@@ -80,7 +80,7 @@ public class FileDigester {
             if (file.isDirectory())
                 md5.append(md5DigestOfFolderContent(file));
             else
-                md5.append(md5DigestOfFile(file));
+                md5.append(file.getName() + md5DigestOfFile(file));
         }
         return md5DigestOfStream(new ByteArrayInputStream(md5.toString().getBytes(CharEncoding.UTF_8)));
     }

--- a/base/test/com/thoughtworks/go/util/FileDigesterTest.java
+++ b/base/test/com/thoughtworks/go/util/FileDigesterTest.java
@@ -26,6 +26,7 @@ import java.io.File;
 import java.io.IOException;
 
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
@@ -57,15 +58,25 @@ public class FileDigesterTest {
         assertThat("md5 should not be empty", digest1.length() > 0, is(true));
         temporaryFolder.delete();
         temporaryFolder.create();
-        String digest2 = FileDigester.md5DigestOfFolderContent(createFolderWithSampleData("test2", 3));
+        String digest2 = FileDigester.md5DigestOfFolderContent(createFolderWithSampleData("test1", 3));
         assertThat(digest1, is(digest2));
+    }
+
+    @Test
+    public void shouldReturnDifferentMd5ForSameFileContentButDifferentFileName() throws Exception {
+        String digest1 = FileDigester.md5DigestOfFolderContent(createFolderWithSampleData("test1", 1));
+        assertThat("md5 should not be empty", digest1.length() > 0, is(true));
+        temporaryFolder.delete();
+        temporaryFolder.create();
+        String digest2 = FileDigester.md5DigestOfFolderContent(createFolderWithSampleData("test2", 1));
+        assertThat(digest1, not(digest2));
     }
 
     @Test
     public void shouldReturnConsistentMd5BySortingTheFileList() throws Exception {
         String digest1 = FileDigester.md5DigestOfFolderContent(createFolderWithSampleData("test", 3));
         assertThat("md5 should not be empty", digest1.length() > 0, is(true));
-        assertThat(digest1, is("SCRRYY4W1zLuiA++CSuy6A=="));
+        assertThat(digest1, is("qGpmuFY5fs+Ap0jLQTWeXQ=="));
     }
 
     @Test


### PR DESCRIPTION
...ownload on agent.

* Earlier the plugin download on agent did not acknowledge the plugin name change if there was no change in the file content.
* The md5 computation now acknowleges the file name change. Now even if the file content remains same and file name changes, the md5 of folder changes and hence the plugin change is acknowledged.