### PR TITLE
#000 - Fix Java 6/Java 7 message in Win installer.

### DIFF
--- a/installers/agent/win/JavaHome.ini
+++ b/installers/agent/win/JavaHome.ini
@@ -17,7 +17,7 @@ Left=5
 Right=-5
 Top=30
 Bottom=40
-Text=" Use your own Java (Open/Oracle/Sun JRE 6 or above)"
+Text=" Use your own Java (Open/Oracle/Sun JRE 7 or above)"
 Flags=NOTIFY
 
 

--- a/installers/server/win/JavaHome.ini
+++ b/installers/server/win/JavaHome.ini
@@ -17,7 +17,7 @@ Left=5
 Right=-5
 Top=30
 Bottom=40
-Text=" Use your own Java (Open/Oracle/Sun JRE 6 or above)"
+Text=" Use your own Java (Open/Oracle/Sun JRE 7 or above)"
 Flags=NOTIFY
 
 


### PR DESCRIPTION
It should say "Use JRE 7" now, not "Use JRE 6".