### PR TITLE
#000 - Remove Java 6 dependency from deb installers.

### DIFF
--- a/installers/agent/deb/control.go-agent
+++ b/installers/agent/deb/control.go-agent
@@ -3,7 +3,7 @@ Section: base
 Priority: optional
 Version: @VERSION@-@RELEASE@
 Architecture: all
-Pre-Depends: java6-runtime | java6-runtime-headless | java7-runtime-headless
+Pre-Depends: java7-runtime-headless
 Maintainer: The Go Team <studios@thoughtworks.com>
 Conflicts: cruise-agent
 Replaces: cruise-agent

--- a/installers/server/deb/control.go-server
+++ b/installers/server/deb/control.go-server
@@ -6,7 +6,7 @@ Section: base
 Priority: optional
 Version: @VERSION@-@RELEASE@
 Architecture: all
-Pre-Depends: java6-runtime | java6-runtime-headless | java7-runtime-headless, unzip
+Pre-Depends: java7-runtime-headless, unzip
 Maintainer: The Go Team <studios@thoughtworks.com>
 Installed-Size: 409600
 Description: Go Server Component


### PR DESCRIPTION
It needs Java 7 now. Verified after building installers.