### PR TITLE
Additional fixes for #973 - Read only mode.

### DIFF
--- a/server/src/com/thoughtworks/go/server/security/ModeAwareFilter.java
+++ b/server/src/com/thoughtworks/go/server/security/ModeAwareFilter.java
@@ -53,14 +53,15 @@ public class ModeAwareFilter implements Filter {
 
     private boolean shouldBlockRequest(HttpServletRequest servletRequest) {
         if (systemEnvironment.isServerActive()) return false;
-        if (isGetRequest(servletRequest)) return false;
+        if (isReadOnlyRequest(servletRequest)) return false;
         if ((systemEnvironment.getWebappContextPath() + "/auth/security_check").equals(servletRequest.getRequestURI()))
             return false;
         return true;
     }
 
-    private boolean isGetRequest(HttpServletRequest servletRequest) {
-        return RequestMethod.GET.name().equalsIgnoreCase(servletRequest.getMethod());
+    private boolean isReadOnlyRequest(HttpServletRequest servletRequest) {
+        return RequestMethod.GET.name().equalsIgnoreCase(servletRequest.getMethod()) ||
+                RequestMethod.HEAD.name().equalsIgnoreCase(servletRequest.getMethod());
     }
 
     @Override

--- a/server/test/unit/com/thoughtworks/go/server/security/ModeAwareFilterTest.java
+++ b/server/test/unit/com/thoughtworks/go/server/security/ModeAwareFilterTest.java
@@ -64,13 +64,14 @@ public class ModeAwareFilterTest {
     }
 
     @Test
-    public void shouldNotBlockGetRequestWhenInPassiveState() throws Exception {
-        when(request.getMethod()).thenReturn("get");
+    public void shouldNotBlockGetOrHeadRequestWhenInPassiveState() throws Exception {
+        when(request.getMethod()).thenReturn("get").thenReturn("head");
         when(systemEnvironment.isServerActive()).thenReturn(false);
 
         filter.doFilter(request, response, filterChain);
+        filter.doFilter(request, response, filterChain);
 
-        verify(filterChain).doFilter(request, response);
+        verify(filterChain, times(2)).doFilter(request, response);
     }
 
     @Test


### PR DESCRIPTION
This will ensure that in addition to GET requests,
HEAD requests are treated as "read only" and will
pass through (not get filtered) to the application.

