### PR TITLE
#1041 & #400 - Jetty xml fix

### DIFF
--- a/jetty6/src/com/thoughtworks/go/server/Jetty6Server.java
+++ b/jetty6/src/com/thoughtworks/go/server/Jetty6Server.java
@@ -60,6 +60,7 @@ public class Jetty6Server extends AppServer {
 
     Jetty6Server(SystemEnvironment systemEnvironment, String password, SSLSocketFactory sslSocketFactory, Server server, GoJetty6CipherSuite goJetty6CipherSuite, Jetty6GoWebXmlConfiguration configuration) {
         super(systemEnvironment, password, sslSocketFactory);
+        systemEnvironment.set(SystemEnvironment.JETTY_XML_FILE_NAME, "jetty6.xml");
         this.server = server;
         this.goCipherSuite = goJetty6CipherSuite;
         this.configuration = configuration;
@@ -120,7 +121,7 @@ public class Jetty6Server extends AppServer {
     }
 
     private void performCustomConfiguration() throws Exception {
-        File jettyConfig = new File(systemEnvironment.getConfigDir(), "jetty6.xml");
+        File jettyConfig = systemEnvironment.getJettyConfigFile();
         if (jettyConfig.exists()) {
             LOG.info("Configuring Jetty using " + jettyConfig.getAbsolutePath());
             FileInputStream serverConfiguration = new FileInputStream(jettyConfig);

--- a/jetty6/test/unit/com/thoughtworks/go/server/Jetty6ServerTest.java
+++ b/jetty6/test/unit/com/thoughtworks/go/server/Jetty6ServerTest.java
@@ -40,6 +40,7 @@ import org.mortbay.jetty.webapp.WebXmlConfiguration;
 import org.mortbay.management.MBeanContainer;
 
 import javax.net.ssl.SSLSocketFactory;
+import java.io.File;
 import java.util.Arrays;
 import java.util.List;
 
@@ -82,6 +83,7 @@ public class Jetty6ServerTest {
         when(systemEnvironment.getParentLoaderPriority()).thenReturn(false);
         when(systemEnvironment.get(SystemEnvironment.RESPONSE_BUFFER_SIZE)).thenReturn(1000);
         when(systemEnvironment.get(SystemEnvironment.IDLE_TIMEOUT)).thenReturn(2000);
+        when(systemEnvironment.getJettyConfigFile()).thenReturn(new File("foo"));
 
         sslSocketFactory = mock(SSLSocketFactory.class);
         when(sslSocketFactory.getSupportedCipherSuites()).thenReturn(new String[]{});

--- a/jetty9/pom.xml
+++ b/jetty9/pom.xml
@@ -261,6 +261,11 @@
 
     <build>
         <sourceDirectory>src</sourceDirectory>
+        <testResources>
+            <testResource>
+                <directory>test-resources</directory>
+            </testResource>
+        </testResources>
         <plugins>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>

--- a/jetty9/src/com/thoughtworks/go/server/Jetty9Server.java
+++ b/jetty9/src/com/thoughtworks/go/server/Jetty9Server.java
@@ -28,7 +28,9 @@ import org.eclipse.jetty.jmx.MBeanContainer;
 import org.eclipse.jetty.server.Connector;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Server;
-import org.eclipse.jetty.server.handler.*;
+import org.eclipse.jetty.server.handler.AbstractHandler;
+import org.eclipse.jetty.server.handler.ContextHandler;
+import org.eclipse.jetty.server.handler.HandlerCollection;
 import org.eclipse.jetty.servlet.ServletHolder;
 import org.eclipse.jetty.webapp.JettyWebXmlConfiguration;
 import org.eclipse.jetty.webapp.WebAppContext;
@@ -49,7 +51,7 @@ import java.lang.management.ManagementFactory;
 import static java.text.MessageFormat.format;
 
 public class Jetty9Server extends AppServer {
-    private static final String JETTY_XML_LOCATION_IN_JAR = "/defaultFiles/config";
+    protected static String JETTY_XML_LOCATION_IN_JAR = "/defaultFiles/config";
     private static final String JETTY_XML = "jetty.xml";
     private static final String JETTY_VERSION = "jetty-v9.2.3";
     private Server server;
@@ -182,13 +184,13 @@ public class Jetty9Server extends AppServer {
     }
 
     private void replaceFileWithPackagedOne(File jettyConfig) {
-        File destinationFile = new File(systemEnvironment.getConfigDir(), jettyConfig.getName());
-        InputStream inputStream = getClass().getResourceAsStream(JETTY_XML_LOCATION_IN_JAR + "/" + jettyConfig.getName());
+        InputStream inputStream = null;
         try {
+            inputStream  = getClass().getResourceAsStream(JETTY_XML_LOCATION_IN_JAR + "/" + jettyConfig.getName());
             if (inputStream == null) {
                 throw new RuntimeException(format("Resource {0}/{1} does not exist in the classpath", JETTY_XML_LOCATION_IN_JAR, jettyConfig.getName()));
             }
-            FileUtil.writeToFile(inputStream, destinationFile);
+            FileUtil.writeToFile(inputStream, systemEnvironment.getJettyConfigFile());
         } catch (IOException e) {
             throw new RuntimeException(e);
         } finally {

--- a/jetty9/src/com/thoughtworks/go/server/Jetty9Server.java
+++ b/jetty9/src/com/thoughtworks/go/server/Jetty9Server.java
@@ -182,13 +182,11 @@ public class Jetty9Server extends AppServer {
     }
 
     private void replaceFileWithPackagedOne(File jettyConfig) {
-        String srcDir = JETTY_XML_LOCATION_IN_JAR;
-        String fileName = jettyConfig.getName();
-        File destinationFile = new File(systemEnvironment.getConfigDir(), fileName);
-        InputStream inputStream = getClass().getResourceAsStream(srcDir + "/" + fileName);
+        File destinationFile = new File(systemEnvironment.getConfigDir(), jettyConfig.getName());
+        InputStream inputStream = getClass().getResourceAsStream(JETTY_XML_LOCATION_IN_JAR + "/" + jettyConfig.getName());
         try {
             if (inputStream == null) {
-                throw new RuntimeException(format("Resource {0}/{1} does not exist in the classpath", srcDir, fileName));
+                throw new RuntimeException(format("Resource {0}/{1} does not exist in the classpath", JETTY_XML_LOCATION_IN_JAR, jettyConfig.getName()));
             }
             FileUtil.writeToFile(inputStream, destinationFile);
         } catch (IOException e) {

--- a/jetty9/src/com/thoughtworks/go/server/Jetty9Server.java
+++ b/jetty9/src/com/thoughtworks/go/server/Jetty9Server.java
@@ -19,17 +19,17 @@ package com.thoughtworks.go.server;
 import com.thoughtworks.go.server.util.GoCipherSuite;
 import com.thoughtworks.go.server.util.GoPlainSocketConnector;
 import com.thoughtworks.go.server.util.GoSslSocketConnector;
+import com.thoughtworks.go.util.FileUtil;
 import com.thoughtworks.go.util.GoConstants;
 import com.thoughtworks.go.util.SystemEnvironment;
+import org.apache.commons.io.IOUtils;
 import org.apache.log4j.Logger;
 import org.eclipse.jetty.jmx.MBeanContainer;
 import org.eclipse.jetty.server.Connector;
-import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.handler.*;
 import org.eclipse.jetty.servlet.ServletHolder;
-import org.eclipse.jetty.util.component.Container;
 import org.eclipse.jetty.webapp.JettyWebXmlConfiguration;
 import org.eclipse.jetty.webapp.WebAppContext;
 import org.eclipse.jetty.webapp.WebInfConfiguration;
@@ -43,11 +43,10 @@ import javax.servlet.ServletException;
 import javax.servlet.UnavailableException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.PrintWriter;
+import java.io.*;
 import java.lang.management.ManagementFactory;
+
+import static java.text.MessageFormat.format;
 
 public class Jetty9Server extends AppServer {
     private Server server;
@@ -59,8 +58,9 @@ public class Jetty9Server extends AppServer {
         this(systemEnvironment, password, sslSocketFactory, new Server());
     }
 
-    Jetty9Server(SystemEnvironment systemEnvironment, String password, SSLSocketFactory sslSocketFactory, Server server){
+    Jetty9Server(SystemEnvironment systemEnvironment, String password, SSLSocketFactory sslSocketFactory, Server server) {
         super(systemEnvironment, password, sslSocketFactory);
+        systemEnvironment.set(SystemEnvironment.JETTY_XML_FILE_NAME, "jetty.xml");
         this.server = server;
         goCipherSuite = new GoCipherSuite(sslSocketFactory);
     }
@@ -158,9 +158,9 @@ public class Jetty9Server extends AppServer {
 
 
     private void performCustomConfiguration() throws Exception {
-        File jettyConfig = new File(systemEnvironment.getConfigDir(), "jetty.xml");
-
+        File jettyConfig = systemEnvironment.getJettyConfigFile();
         if (jettyConfig.exists()) {
+            replaceJettyXmlIfItBelongsToADifferentVersion(jettyConfig);
             LOG.info("Configuring Jetty using " + jettyConfig.getAbsolutePath());
             FileInputStream serverConfiguration = new FileInputStream(jettyConfig);
             XmlConfiguration configuration = new XmlConfiguration(serverConfiguration);
@@ -172,6 +172,29 @@ public class Jetty9Server extends AppServer {
             LOG.info(message);
         }
     }
+
+    protected void replaceJettyXmlIfItBelongsToADifferentVersion(File jettyConfig) throws IOException {
+        if (FileUtil.readContentFromFile(jettyConfig).contains("jetty-v9.2.3")) return;
+        replaceFileWithPackagedOne(jettyConfig);
+    }
+
+    private void replaceFileWithPackagedOne(File jettyConfig) {
+        String srcDir = "/defaultFiles/config";
+        String fileName = jettyConfig.getName();
+        File destinationFile = new File(systemEnvironment.getConfigDir(), fileName);
+        InputStream inputStream = getClass().getResourceAsStream(srcDir + "/" + fileName);
+        try {
+            if (inputStream == null) {
+                throw new RuntimeException(format("Resource {0}/{1} does not exist in the classpath", srcDir, fileName));
+            }
+            FileUtil.writeToFile(inputStream, destinationFile);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        } finally {
+            IOUtils.closeQuietly(inputStream);
+        }
+    }
+
 
     private void addResourceHandler(HandlerCollection handlers, WebAppContext webAppContext) throws IOException {
         if (!systemEnvironment.useCompressedJs()) return;

--- a/jetty9/src/com/thoughtworks/go/server/Jetty9Server.java
+++ b/jetty9/src/com/thoughtworks/go/server/Jetty9Server.java
@@ -49,6 +49,9 @@ import java.lang.management.ManagementFactory;
 import static java.text.MessageFormat.format;
 
 public class Jetty9Server extends AppServer {
+    private static final String JETTY_XML_LOCATION_IN_JAR = "/defaultFiles/config";
+    private static final String JETTY_XML = "jetty.xml";
+    private static final String JETTY_VERSION = "jetty-v9.2.3";
     private Server server;
     private WebAppContext webAppContext;
     private static final Logger LOG = Logger.getLogger(Jetty9Server.class);
@@ -60,7 +63,7 @@ public class Jetty9Server extends AppServer {
 
     Jetty9Server(SystemEnvironment systemEnvironment, String password, SSLSocketFactory sslSocketFactory, Server server) {
         super(systemEnvironment, password, sslSocketFactory);
-        systemEnvironment.set(SystemEnvironment.JETTY_XML_FILE_NAME, "jetty.xml");
+        systemEnvironment.set(SystemEnvironment.JETTY_XML_FILE_NAME, JETTY_XML);
         this.server = server;
         goCipherSuite = new GoCipherSuite(sslSocketFactory);
     }
@@ -174,12 +177,12 @@ public class Jetty9Server extends AppServer {
     }
 
     protected void replaceJettyXmlIfItBelongsToADifferentVersion(File jettyConfig) throws IOException {
-        if (FileUtil.readContentFromFile(jettyConfig).contains("jetty-v9.2.3")) return;
+        if (FileUtil.readContentFromFile(jettyConfig).contains(JETTY_VERSION)) return;
         replaceFileWithPackagedOne(jettyConfig);
     }
 
     private void replaceFileWithPackagedOne(File jettyConfig) {
-        String srcDir = "/defaultFiles/config";
+        String srcDir = JETTY_XML_LOCATION_IN_JAR;
         String fileName = jettyConfig.getName();
         File destinationFile = new File(systemEnvironment.getConfigDir(), fileName);
         InputStream inputStream = getClass().getResourceAsStream(srcDir + "/" + fileName);

--- a/jetty9/test-resources/com/thoughtworks/go/server/config/jetty.xml
+++ b/jetty9/test-resources/com/thoughtworks/go/server/config/jetty.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0"?>
+<!-- *************************GO-LICENSE-START******************************
+ * Copyright 2015 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *************************GO-LICENSE-END******************************* -->
+
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure.dtd">
+
+<Configure id="Server" class="org.eclipse.jetty.server.Server">
+    <!--Do not remove/modify the below line containing jetty version, else all your changes to this file will be reverted.-->
+    <!--jetty-v9.2.3-->
+    <!-- =========================================================== -->
+    <!-- Server Thread Pool                                          -->
+    <!-- =========================================================== -->
+    <Get name="ThreadPool">
+        <Set name="minThreads">20</Set>
+        <Set name="maxThreads">300</Set>
+        <!-- New Jetty QTP does not have these two properties below.
+        <Set name="lowThreads">10</Set>
+        <Set name="SpawnOrShrinkAt">2</Set>
+        -->
+    </Get>
+    <Call name="setAttribute">
+        <Arg>org.eclipse.jetty.server.Request.maxFormContentSize</Arg>
+        <Arg>30000000</Arg>
+    </Call>
+
+    <!--<Call name="addBean">-->
+    <!--<Arg>-->
+    <!--<New class="org.eclipse.jetty.server.LowResourceMonitor">-->
+    <!--<Arg><Ref id="Server"/></Arg>-->
+    <!--<Set name="period"><Property name="lowresources.period" default="1000"/></Set>-->
+    <!--<Set name="lowResourcesIdleTimeout"><Property name="lowresources.lowResourcesIdleTimeout" default="1000"/></Set>-->
+    <!--<Set name="monitorThreads"><Property name="lowresources.monitorThreads" default="true"/></Set>-->
+    <!--<Set name="maxConnections"><Property name="lowresources.maxConnections" default="0"/></Set>-->
+    <!--<Set name="maxMemory"><Property name="lowresources.maxMemory" default="0"/></Set>-->
+    <!--<Set name="maxLowResourcesTime"><Property name="lowresources.maxLowResourcesTime" default="5000"/></Set>-->
+    <!--</New>-->
+    <!--</Arg>-->
+    <!--</Call>-->
+
+
+    <!-- =========================================================== -->
+    <!-- Logging                                                     -->
+    <!-- =========================================================== -->
+    <!-- Note: Please create the weblogs directory if not exist -->
+    <!--
+    <Get name="handler">
+        <Call name="addHandler">
+            <Arg>
+                <New class="org.eclipse.jetty.server.handler.RequestLogHandler">
+                    <Set name="requestLog">
+                        <New class="org.eclipse.jetty.server.NCSARequestLog">
+                            <Arg><SystemProperty name="jetty.logs" default="./weblogs"/>/jetty-yyyy_mm_dd.request.log</Arg>
+                            <Set name="filenameDateFormat">yyyy_MM_dd</Set>
+                            <Set name="retainDays">7</Set>
+                            <Set name="append">true</Set>
+                            <Set name="extended">false</Set>
+                            <Set name="logCookies">false</Set>
+                            <Set name="logLatency">false</Set>
+                        </New>
+                    </Set>
+                </New>
+            </Arg>
+        </Call>
+    </Get>
+    -->
+</Configure>

--- a/jetty9/test/unit/com/thoughtworks/go/server/Jetty9ServerTest.java
+++ b/jetty9/test/unit/com/thoughtworks/go/server/Jetty9ServerTest.java
@@ -69,6 +69,7 @@ public class Jetty9ServerTest {
         when(systemEnvironment.get(SystemEnvironment.RESPONSE_BUFFER_SIZE)).thenReturn(1000);
         when(systemEnvironment.get(SystemEnvironment.IDLE_TIMEOUT)).thenReturn(2000);
         when(systemEnvironment.configDir()).thenReturn(configDir = temporaryFolder.newFile());
+        when(systemEnvironment.getJettyConfigFile()).thenReturn(new File("foo"));
 
         sslSocketFactory = mock(SSLSocketFactory.class);
         when(sslSocketFactory.getSupportedCipherSuites()).thenReturn(new String[]{});

--- a/server/config/jetty.xml
+++ b/server/config/jetty.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!-- *************************GO-LICENSE-START******************************
- * Copyright 2014 ThoughtWorks, Inc.
+ * Copyright 2015 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@
 <!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
-
+    <!--jetty-v9.2.3-->
     <!-- =========================================================== -->
     <!-- Server Thread Pool                                          -->
     <!-- =========================================================== -->

--- a/server/config/jetty.xml
+++ b/server/config/jetty.xml
@@ -18,6 +18,7 @@
 <!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
+    <!--Do not remove/modify the below line containing jetty version, else all your changes to this file will be reverted.-->
     <!--jetty-v9.2.3-->
     <!-- =========================================================== -->
     <!-- Server Thread Pool                                          -->

--- a/server/config/jetty.xml
+++ b/server/config/jetty.xml
@@ -35,6 +35,21 @@
         <Arg>30000000</Arg>
     </Call>
 
+    <!--<Call name="addBean">-->
+        <!--<Arg>-->
+            <!--<New class="org.eclipse.jetty.server.LowResourceMonitor">-->
+                <!--<Arg><Ref id="Server"/></Arg>-->
+                <!--<Set name="period"><Property name="lowresources.period" default="1000"/></Set>-->
+                <!--<Set name="lowResourcesIdleTimeout"><Property name="lowresources.lowResourcesIdleTimeout" default="1000"/></Set>-->
+                <!--<Set name="monitorThreads"><Property name="lowresources.monitorThreads" default="true"/></Set>-->
+                <!--<Set name="maxConnections"><Property name="lowresources.maxConnections" default="0"/></Set>-->
+                <!--<Set name="maxMemory"><Property name="lowresources.maxMemory" default="0"/></Set>-->
+                <!--<Set name="maxLowResourcesTime"><Property name="lowresources.maxLowResourcesTime" default="5000"/></Set>-->
+            <!--</New>-->
+        <!--</Arg>-->
+    <!--</Call>-->
+
+
     <!-- =========================================================== -->
     <!-- Logging                                                     -->
     <!-- =========================================================== -->

--- a/server/src/com/thoughtworks/go/server/GoServer.java
+++ b/server/src/com/thoughtworks/go/server/GoServer.java
@@ -142,8 +142,8 @@ public class GoServer {
         validators.add(FileValidator.configFile("cruise-config.xml", systemEnvironment));
         validators.add(FileValidator.configFile("config.properties", systemEnvironment));
         validators.add(FileValidator.configFileAlwaysOverwrite("cruise-config.xsd", systemEnvironment));
-		validators.add(FileValidator.configFileAlwaysOverwrite("jetty.xml", systemEnvironment));
-		validators.add(FileValidator.configFileAlwaysOverwrite("jetty6.xml", systemEnvironment));
+		validators.add(FileValidator.configFile("jetty.xml", systemEnvironment));
+		validators.add(FileValidator.configFile("jetty6.xml", systemEnvironment));
         validators.add(new JettyWorkDirValidator());
         validators.add(new DatabaseValidator());
         validators.add(new LoggingValidator(systemEnvironment));


### PR DESCRIPTION
* the file was being replaced every time Go server starts up. It now checks for the version number in jetty.xml and replaces only if there is a mismatch.

* added LowResourceMonitor which is commented out right now, need to figure out the properties values after performance runs