### PR TITLE
Fix for relative root paths in SVN 1.5+ externals

### DIFF
--- a/common/src/com/thoughtworks/go/domain/materials/svn/SvnExternalParser.java
+++ b/common/src/com/thoughtworks/go/domain/materials/svn/SvnExternalParser.java
@@ -143,6 +143,10 @@ public class SvnExternalParser {
             }
         }
 
+        protected String replaceRootRelativePathWithAbsoluteFor(String external, String repoUrl) {
+            return external.replace("^", repoUrl);
+        }
+
         protected abstract Pattern pattern();
 
         protected abstract String root(Matcher matcher, SvnExternalParser.SvnExternalRoot svnExternalRoot);
@@ -169,6 +173,13 @@ public class SvnExternalParser {
             return matcher.group(1);
         }
 
+        @Override
+        public boolean match(String external, String repoUrl, List<SvnExternal> results, SvnExternalRoot svnExternalRoot) {
+            external = replaceRootRelativePathWithAbsoluteFor(external, repoUrl);
+
+            return super.match(external, repoUrl, results, svnExternalRoot);
+        }
+
         protected String externalDir(Matcher matcher) {
             return matcher.group(5);
         }
@@ -190,6 +201,13 @@ public class SvnExternalParser {
 
         protected String root(Matcher matcher, SvnExternalRoot svnExternalRoot) {
             return svnExternalRoot.getRoot();
+        }
+
+        @Override
+        public boolean match(String external, String repoUrl, List<SvnExternal> results, SvnExternalRoot svnExternalRoot) {
+            external = replaceRootRelativePathWithAbsoluteFor(external, repoUrl);
+
+            return super.match(external, repoUrl, results, svnExternalRoot);
         }
 
         protected String externalDir(Matcher matcher) {

--- a/common/test/unit/com/thoughtworks/go/domain/materials/svn/SvnExternalParserTest.java
+++ b/common/test/unit/com/thoughtworks/go/domain/materials/svn/SvnExternalParserTest.java
@@ -192,4 +192,17 @@ public class SvnExternalParserTest {
                 is(new SvnExternal("lib/externals-2", "http://10.18.3.171:8080/svn/CSharpProject/trunk/")));
         assertThat(externals.get(1), is(new SvnExternal("lib/externals-6", "svn://10.18.3.171:8080/svn/CSharpProject/trunk/")));
     }
+
+    @Test
+    public void shouldParseSvnExternalsWithRootRelativePathsForSvn15() {
+        String svnExternals = "http://10.18.3.171:8080/svn/externalstest - ^/repo1/trunk lib/repo1\n" +
+                "^/repo2/trunk repo2\n" +
+                "^/repo3/trunk app/repo3\n" +
+                "^/repo4/trunk app/repo4";
+
+        List<SvnExternal> externals = new SvnExternalParser().parse(svnExternals, "http://10.18.3.171:8080/svn");
+        assertThat(externals.size(), is(4));
+        assertThat(externals.get(0), is(new SvnExternal("externalstest/lib/repo1", "http://10.18.3.171:8080/svn/repo1/trunk")));
+        assertThat(externals.get(3), is(new SvnExternal("externalstest/app/repo4", "http://10.18.3.171:8080/svn/repo4/trunk")));
+    }
 }


### PR DESCRIPTION
As described in #1039 we have a file structure created by pulling multiple repositories together with SVN externals. We had an issue with builds not triggering when changes were made to the external repositories, only the root.

After looking through the code that parses SVN externals, my hunch was that it wasn't parsing the relative root '^' character in the URLs. I made a failing test using the output from running PROPGET and found the parser returned no repositories.

The code attached basically does a substitution on the '^' character with the root path, so it just goes through the regular parser logic. I've only added it to the 1.5 version of the parsers as that was when it was introduced.