### PR TITLE
Svn externals relative root fix

### DIFF
--- a/common/src/com/thoughtworks/go/domain/materials/svn/SvnCommand.java
+++ b/common/src/com/thoughtworks/go/domain/materials/svn/SvnCommand.java
@@ -302,6 +302,7 @@ public class SvnCommand extends SCMCommand implements Subversion {
     static class SvnInfo {
         private String path = "";
         private String encodedUrl = "";
+        private String root = "";
         private static final String ENCODING = "UTF-8";
 
 
@@ -324,6 +325,7 @@ public class SvnCommand extends SCMCommand implements Subversion {
             String encodedPath = StringUtils.replace(encodedUrl, root, "");
 
             this.path = URLDecoder.decode(encodedPath, ENCODING);
+            this.root = root;
             this.encodedUrl = encodedUrl;
         }
 
@@ -334,5 +336,7 @@ public class SvnCommand extends SCMCommand implements Subversion {
         public String getUrl() {
             return encodedUrl;
         }
+
+        public String getRoot() { return root; }
     }
 }

--- a/common/src/com/thoughtworks/go/domain/materials/svn/SvnCommand.java
+++ b/common/src/com/thoughtworks/go/domain/materials/svn/SvnCommand.java
@@ -99,10 +99,12 @@ public class SvnCommand extends SCMCommand implements Subversion {
                 .withArg(repositoryUrl);
         ConsoleResult result = executeCommand(svnExternalCommand);
         String svnExternalConsoleOut = result.outputAsString();
-        String repoUrl = remoteInfo(new SAXBuilder(false)).getUrl();
+        SvnInfo remoteInfo = remoteInfo(new SAXBuilder(false));
+        String repoUrl = remoteInfo.getUrl();
+        String repoRoot = remoteInfo.getRoot();
         List<SvnExternal> svnExternalList = null;
         try {
-            svnExternalList = new SvnExternalParser().parse(svnExternalConsoleOut, repoUrl);
+            svnExternalList = new SvnExternalParser().parse(svnExternalConsoleOut, repoUrl, repoRoot);
         } catch (RuntimeException e) {
             throw (RuntimeException) result.smudgedException(e);
         }

--- a/common/src/com/thoughtworks/go/domain/materials/svn/SvnExternalParser.java
+++ b/common/src/com/thoughtworks/go/domain/materials/svn/SvnExternalParser.java
@@ -143,6 +143,10 @@ public class SvnExternalParser {
             }
         }
 
+        protected String replaceRootRelativePathWithAbsoluteFor(String external, String repoUrl) {
+            return external.replace("^", repoUrl);
+        }
+
         protected abstract Pattern pattern();
 
         protected abstract String root(Matcher matcher, SvnExternalParser.SvnExternalRoot svnExternalRoot);
@@ -169,6 +173,13 @@ public class SvnExternalParser {
             return matcher.group(1);
         }
 
+        @Override
+        public boolean match(String external, String repoUrl, List<SvnExternal> results, SvnExternalRoot svnExternalRoot) {
+            external = replaceRootRelativePathWithAbsoluteFor(external, repoUrl);
+
+            return super.match(external, repoUrl, results, svnExternalRoot);
+        }
+
         protected String externalDir(Matcher matcher) {
             return matcher.group(5);
         }
@@ -190,6 +201,13 @@ public class SvnExternalParser {
 
         protected String root(Matcher matcher, SvnExternalRoot svnExternalRoot) {
             return svnExternalRoot.getRoot();
+        }
+
+        @Override
+        public boolean match(String external, String repoUrl, List<SvnExternal> results, SvnExternalRoot svnExternalRoot) {
+            external = replaceRootRelativePathWithAbsoluteFor(external, repoUrl);
+
+            return super.match(external, repoUrl, results, svnExternalRoot);
         }
 
         protected String externalDir(Matcher matcher) {

--- a/common/src/com/thoughtworks/go/domain/materials/svn/SvnExternalParser.java
+++ b/common/src/com/thoughtworks/go/domain/materials/svn/SvnExternalParser.java
@@ -144,7 +144,9 @@ public class SvnExternalParser {
         }
 
         protected String replaceRootRelativePathWithAbsoluteFor(String external, String repoUrl) {
-            return external.replace("^", repoUrl);
+            final Pattern CARET_AT_START_OF_BOUNDARY = Pattern.compile("(?<!/)\\^/");
+            Matcher matcher = CARET_AT_START_OF_BOUNDARY.matcher(external);
+            return matcher.replaceAll(repoUrl + "/");
         }
 
         protected abstract Pattern pattern();

--- a/common/src/com/thoughtworks/go/domain/materials/svn/SvnExternalParser.java
+++ b/common/src/com/thoughtworks/go/domain/materials/svn/SvnExternalParser.java
@@ -38,19 +38,19 @@ public class SvnExternalParser {
         return StringUtils.isBlank(root) ? externalDir : root + "/" + externalDir;
     }
 
-    public List<SvnExternal> parse(String externals, String repoUrl) {
+    public List<SvnExternal> parse(String externals, String repoUrl, String repoRoot) {
         List<SvnExternal> results = new ArrayList<SvnExternal>();
         for (String externalSection : externals.split("\n\n")) {
-            parseSection(externalSection, repoUrl, results);
+            parseSection(externalSection, repoUrl, repoRoot, results);
         }
         return results;
     }
 
-    private void parseSection(String externalSection, String repoUrl, List<SvnExternal> results) {
+    private void parseSection(String externalSection, String repoUrl, String repoRoot, List<SvnExternal> results) {
         SvnExternalRoot svnExternalRoot = new SvnExternalRoot();
         for (String external : externalSection.split("\n")) {
             for (SvnExternalMatcher matcher : matchers) {
-                if (matcher.match(external, repoUrl, results, svnExternalRoot)) {
+                if (matcher.match(external, repoUrl, repoRoot, results, svnExternalRoot)) {
                     break;
                 }
             }
@@ -73,8 +73,8 @@ public class SvnExternalParser {
     }
 
     private interface SvnExternalMatcher {
-        boolean match(String external, String repoUrl, List<SvnExternal> results,
-                      SvnExternalParser.SvnExternalRoot svnExternalRoot);
+        boolean match(String external, String repoUrl, String repoRoot, List<SvnExternal> results,
+                      SvnExternalRoot svnExternalRoot);
     }
 
     private class Svn14WithRootMatcher extends BaseSvnExternalMatcher {
@@ -126,7 +126,7 @@ public class SvnExternalParser {
     }
 
     private abstract class BaseSvnExternalMatcher implements SvnExternalMatcher {
-        public boolean match(String external, String repoUrl, List<SvnExternal> results, SvnExternalRoot svnExternalRoot) {
+        public boolean match(String external, String repoUrl, String repoRoot, List<SvnExternal> results, SvnExternalRoot svnExternalRoot) {
             Matcher matcher = pattern().matcher(external);
             try {
                 if (matcher.matches()) {
@@ -174,10 +174,10 @@ public class SvnExternalParser {
         }
 
         @Override
-        public boolean match(String external, String repoUrl, List<SvnExternal> results, SvnExternalRoot svnExternalRoot) {
-            external = replaceRootRelativePathWithAbsoluteFor(external, repoUrl);
+        public boolean match(String external, String repoUrl, String repoRoot, List<SvnExternal> results, SvnExternalRoot svnExternalRoot) {
+            external = replaceRootRelativePathWithAbsoluteFor(external, repoRoot);
 
-            return super.match(external, repoUrl, results, svnExternalRoot);
+            return super.match(external, repoUrl, repoRoot, results, svnExternalRoot);
         }
 
         protected String externalDir(Matcher matcher) {
@@ -204,10 +204,10 @@ public class SvnExternalParser {
         }
 
         @Override
-        public boolean match(String external, String repoUrl, List<SvnExternal> results, SvnExternalRoot svnExternalRoot) {
-            external = replaceRootRelativePathWithAbsoluteFor(external, repoUrl);
+        public boolean match(String external, String repoUrl, String repoRoot, List<SvnExternal> results, SvnExternalRoot svnExternalRoot) {
+            external = replaceRootRelativePathWithAbsoluteFor(external, repoRoot);
 
-            return super.match(external, repoUrl, results, svnExternalRoot);
+            return super.match(external, repoUrl, repoRoot, results, svnExternalRoot);
         }
 
         protected String externalDir(Matcher matcher) {

--- a/common/src/com/thoughtworks/go/domain/materials/svn/SvnExternalParser.java
+++ b/common/src/com/thoughtworks/go/domain/materials/svn/SvnExternalParser.java
@@ -30,8 +30,8 @@ public class SvnExternalParser {
     public SvnExternalParser() {
         matchers.add(new Svn14WithRootMatcher());
         matchers.add(new Svn14NoRootMatcher());
-        matchers.add(new Svn15WithRootMatcher());
-        matchers.add(new Svn15NoRootMatcher());
+        matchers.add(new Svn15AndAboveWithRootMatcher());
+        matchers.add(new Svn15AndAboveNoRootMatcher());
     }
 
     private static String combine(String root, String externalDir) {
@@ -164,7 +164,7 @@ public class SvnExternalParser {
         return StringUtils.strip(StringUtils.remove(absoluteRoot, repoUrl), "/");
     }
 
-    private class Svn15WithRootMatcher extends BaseSvnExternalMatcher {
+    private class Svn15AndAboveWithRootMatcher extends BaseSvnExternalMatcher {
         private Pattern SVN_15_ROOT_PATTERN = Pattern.compile("(\\S+) - (-r\\s*\\d)?\\s*(\\S+:(//|\\\\)+.*)\\s+(\\S+)\\s*");
 
         protected Pattern pattern() {
@@ -195,7 +195,7 @@ public class SvnExternalParser {
         }
     }
 
-    private class Svn15NoRootMatcher extends BaseSvnExternalMatcher {
+    private class Svn15AndAboveNoRootMatcher extends BaseSvnExternalMatcher {
         private Pattern SVN_15_SAMEFOLER_PATTERN = Pattern.compile("\\s*(-r\\s*\\d)?\\s*(\\S+:(//|\\\\)+\\S+)\\s+(\\S+)\\s*");
         protected Pattern pattern() {
             return SVN_15_SAMEFOLER_PATTERN;

--- a/common/src/com/thoughtworks/go/domain/materials/svn/SvnExternalParser.java
+++ b/common/src/com/thoughtworks/go/domain/materials/svn/SvnExternalParser.java
@@ -144,7 +144,7 @@ public class SvnExternalParser {
         }
 
         protected String replaceRootRelativePathWithAbsoluteFor(String external, String repoUrl) {
-            final Pattern CARET_AT_START_OF_BOUNDARY = Pattern.compile("(?<!/)\\^/");
+            final Pattern CARET_AT_START_OF_BOUNDARY = Pattern.compile("(?<![/\\w])\\^/");
             Matcher matcher = CARET_AT_START_OF_BOUNDARY.matcher(external);
             return matcher.replaceAll(repoUrl + "/");
         }

--- a/common/test/unit/com/thoughtworks/go/domain/materials/svn/SvnCommandTest.java
+++ b/common/test/unit/com/thoughtworks/go/domain/materials/svn/SvnCommandTest.java
@@ -307,9 +307,9 @@ public class SvnCommandTest {
                 + "   kind=\"dir\"\n"
                 + "   path=\"someotherline\"\n"
                 + "   revision=\"36788\">\n"
-                + "<url>http://svn.somewhere.com/someotherline</url>\n"
+                + "<url>http://svn.somewhere.com/svn/someotherline</url>\n"
                 + "<repository>\n"
-                + "<root>http://svn.somewhere.com/someotherline</root>\n"
+                + "<root>http://svn.somewhere.com/svn</root>\n"
                 + "<uuid>f6689194-972b-e749-89bf-11ebdadc4dc5</uuid>\n"
                 + "</repository>\n"
                 + "<commit\n"
@@ -321,9 +321,10 @@ public class SvnCommandTest {
                 + "</info>";
         SvnCommand.SvnInfo svnInfo = new SvnCommand.SvnInfo();
         svnInfo.parse(output, new SAXBuilder(false));
-        assertThat(svnInfo.getPath(), is(""));
+        assertThat(svnInfo.getPath(), is("/someotherline"));
         assertThat(svnInfo.getUrl(),
-                is("http://svn.somewhere.com/someotherline"));
+                is("http://svn.somewhere.com/svn/someotherline"));
+        assertThat(svnInfo.getRoot(), is("http://svn.somewhere.com/svn"));
     }
 
     @Test

--- a/common/test/unit/com/thoughtworks/go/domain/materials/svn/SvnExternalParserTest.java
+++ b/common/test/unit/com/thoughtworks/go/domain/materials/svn/SvnExternalParserTest.java
@@ -209,11 +209,12 @@ public class SvnExternalParserTest {
     @Test
     public void shouldLeaveCaretsUntouchedUnlessAtFront() {
         String svnExternals = "http://10.18.3.171:8080/svn/externalstest - http://10.18.3.171:8080/svn/^/repo1/trunk lib/repo1\n" +
+                "http://10.18.3.171:8080/svn/a^/repo1/trunk lib/repo1\n" +
                 "http://10.18.3.171:8080/svn/^/repo2/trunk repo2\n";
 
         List<SvnExternal> externals = new SvnExternalParser().parse(svnExternals, "http://10.18.3.171:8080/svn/externalstest", "http://10.18.3.171:8080/svn");
-        assertThat(externals.size(), is(2));
+        assertThat(externals.size(), is(3));
         assertThat(externals.get(0), is(new SvnExternal("lib/repo1", "http://10.18.3.171:8080/svn/^/repo1/trunk")));
-        assertThat(externals.get(1), is(new SvnExternal("repo2", "http://10.18.3.171:8080/svn/^/repo2/trunk")));
+        assertThat(externals.get(2), is(new SvnExternal("repo2", "http://10.18.3.171:8080/svn/^/repo2/trunk")));
     }
 }

--- a/common/test/unit/com/thoughtworks/go/domain/materials/svn/SvnExternalParserTest.java
+++ b/common/test/unit/com/thoughtworks/go/domain/materials/svn/SvnExternalParserTest.java
@@ -194,7 +194,7 @@ public class SvnExternalParserTest {
     }
 
     @Test
-    public void shouldParseSvnExternalsWithRootRelativePathsForSvn15() {
+    public void shouldParseSvnExternalsWithRootSvn15AndAboveWithRootMatcherRelativePathsForSvn15() {
         String svnExternals = "http://10.18.3.171:8080/svn/externalstest - ^/repo1/trunk lib/repo1\n" +
                 "^/repo2/trunk repo2\n" +
                 "^/repo3/trunk app/repo3\n" +
@@ -204,5 +204,16 @@ public class SvnExternalParserTest {
         assertThat(externals.size(), is(4));
         assertThat(externals.get(0), is(new SvnExternal("lib/repo1", "http://10.18.3.171:8080/svn/repo1/trunk")));
         assertThat(externals.get(3), is(new SvnExternal("app/repo4", "http://10.18.3.171:8080/svn/repo4/trunk")));
+    }
+
+    @Test
+    public void shouldLeaveCaretsUntouchedUnlessAtFront() {
+        String svnExternals = "http://10.18.3.171:8080/svn/externalstest - http://10.18.3.171:8080/svn/^/repo1/trunk lib/repo1\n" +
+                "http://10.18.3.171:8080/svn/^/repo2/trunk repo2\n";
+
+        List<SvnExternal> externals = new SvnExternalParser().parse(svnExternals, "http://10.18.3.171:8080/svn/externalstest", "http://10.18.3.171:8080/svn");
+        assertThat(externals.size(), is(2));
+        assertThat(externals.get(0), is(new SvnExternal("lib/repo1", "http://10.18.3.171:8080/svn/^/repo1/trunk")));
+        assertThat(externals.get(1), is(new SvnExternal("repo2", "http://10.18.3.171:8080/svn/^/repo2/trunk")));
     }
 }

--- a/common/test/unit/com/thoughtworks/go/domain/materials/svn/SvnExternalParserTest.java
+++ b/common/test/unit/com/thoughtworks/go/domain/materials/svn/SvnExternalParserTest.java
@@ -192,4 +192,17 @@ public class SvnExternalParserTest {
                 is(new SvnExternal("lib/externals-2", "http://10.18.3.171:8080/svn/CSharpProject/trunk/")));
         assertThat(externals.get(1), is(new SvnExternal("lib/externals-6", "svn://10.18.3.171:8080/svn/CSharpProject/trunk/")));
     }
+
+    @Test
+    public void shouldParseSvnExternalsWithRootRelativePathsForSvn15() {
+        String svnExternals = "http://10.18.3.171:8080/svn/externalstest - ^/repo1/trunk lib/repo1\n" +
+                "^/repo2/trunk repo2\n" +
+                "^/repo3/trunk app/repo3\n" +
+                "^/repo4/trunk app/repo4";
+
+        List<SvnExternal> externals = new SvnExternalParser().parse(svnExternals, "http://10.18.3.171:8080/svn");
+        assertThat(externals.size(), is(4));
+        assertThat(externals.get(0), is(new SvnExternal("externalstest/lib/repo1", "http://10.18.3.171:8080/svn/repo1/trunk")));
+        assertThat(externals.get(3), is(new SvnExternal("externalstest/app/repo4", "http://10.18.3.171:8080/svn/repo4/trunk")));
+    }
 }

--- a/common/test/unit/com/thoughtworks/go/domain/materials/svn/SvnExternalParserTest.java
+++ b/common/test/unit/com/thoughtworks/go/domain/materials/svn/SvnExternalParserTest.java
@@ -29,7 +29,7 @@ public class SvnExternalParserTest {
     public void shouldParseOneLineSvnExternalOnCurrentFolderForSvn14() {
         String svnExternals = "http://10.18.3.171:8080/svn/connect4/trunk - CSharp http://10.18.3.171:8080/svn/CSharpProject/trunk\n";
 
-        List<SvnExternal> externals = new SvnExternalParser().parse(svnExternals, "http://10.18.3.171:8080/svn/connect4/trunk");
+        List<SvnExternal> externals = new SvnExternalParser().parse(svnExternals, "http://10.18.3.171:8080/svn/connect4/trunk", "http://10.18.3.171:8080/svn");
         assertThat(externals.get(0),
                 is(new SvnExternal("CSharp", "http://10.18.3.171:8080/svn/CSharpProject/trunk")));
     }
@@ -38,7 +38,7 @@ public class SvnExternalParserTest {
     public void shouldParseOneLineSvnExternalOnMultipleLevelFolderForSvn14() {
         String svnExternals = "http://10.18.3.171:8080/svn/connect4/trunk/dir1/dir2 - externals-2 http://10.18.3.171:8080/svn/CSharpProject/trunk/\n";
 
-        List<SvnExternal> externals = new SvnExternalParser().parse(svnExternals, "http://10.18.3.171:8080/svn/connect4/trunk");
+        List<SvnExternal> externals = new SvnExternalParser().parse(svnExternals, "http://10.18.3.171:8080/svn/connect4/trunk", "http://10.18.3.171:8080/svn");
         assertThat(externals.get(0),
                 is(new SvnExternal("dir1/dir2/externals-2", "http://10.18.3.171:8080/svn/CSharpProject/trunk/")));
     }
@@ -48,7 +48,7 @@ public class SvnExternalParserTest {
         String svnExternals = "http://10.18.3.171:8080/svn/connect4/trunk - externals-2 http://10.18.3.171:8080/svn/CSharpProject/trunk/\n" +
                 "dir1 http://10.18.3.171:8080/svn/CSharpProject/trunk";
 
-        List<SvnExternal> externals = new SvnExternalParser().parse(svnExternals, "http://10.18.3.171:8080/svn/connect4/trunk");
+        List<SvnExternal> externals = new SvnExternalParser().parse(svnExternals, "http://10.18.3.171:8080/svn/connect4/trunk", "http://10.18.3.171:8080/svn");
         assertThat(externals.get(0),
                 is(new SvnExternal("externals-2", "http://10.18.3.171:8080/svn/CSharpProject/trunk/")));
         assertThat(externals.get(1),
@@ -63,7 +63,7 @@ public class SvnExternalParserTest {
                 "http://10.18.3.171:8080/svn/connect4/trunk/dir2 - externals-2 http://10.18.3.171:8080/svn/CSharpProject/trunk\n" +
                 "dir3 http://10.18.3.171:8080/svn/CSharpProject/trunk\n";
 
-        List<SvnExternal> externals = new SvnExternalParser().parse(svnExternals, "http://10.18.3.171:8080/svn/connect4/trunk");
+        List<SvnExternal> externals = new SvnExternalParser().parse(svnExternals, "http://10.18.3.171:8080/svn/connect4/trunk", "http://10.18.3.171:8080/svn");
         assertThat(externals.get(0),
                 is(new SvnExternal("externals-2", "http://10.18.3.171:8080/svn/CSharpProject/trunk")));
         assertThat(externals.get(1),
@@ -78,7 +78,7 @@ public class SvnExternalParserTest {
     public void shouldParseOneLineSvnExternalOnCurrentFolderForSvn15() {
         String svnExternals = "http://10.18.3.171:8080/svn/connect4/trunk - http://10.18.3.171:8080/svn/CSharpProject/trunk externals-2 \n";
 
-        List<SvnExternal> externals = new SvnExternalParser().parse(svnExternals, "http://10.18.3.171:8080/svn/connect4/trunk");
+        List<SvnExternal> externals = new SvnExternalParser().parse(svnExternals, "http://10.18.3.171:8080/svn/connect4/trunk", "http://10.18.3.171:8080/svn");
         assertThat(externals.get(0),
                 is(new SvnExternal("externals-2", "http://10.18.3.171:8080/svn/CSharpProject/trunk")));
     }
@@ -87,7 +87,7 @@ public class SvnExternalParserTest {
     public void shouldParseOneLineSvnExternalOnMultipleLevelFolderForSvn15() {
         String svnExternals = "http://10.18.3.171:8080/svn/connect4/trunk/dir1/dir2 - http://10.18.3.171:8080/svn/CSharpProject/trunk externals-2 \n";
 
-        List<SvnExternal> externals = new SvnExternalParser().parse(svnExternals, "http://10.18.3.171:8080/svn/connect4/trunk");
+        List<SvnExternal> externals = new SvnExternalParser().parse(svnExternals, "http://10.18.3.171:8080/svn/connect4/trunk", "http://10.18.3.171:8080/svn");
         assertThat(externals.get(0),
                 is(new SvnExternal("dir1/dir2/externals-2", "http://10.18.3.171:8080/svn/CSharpProject/trunk")));
     }
@@ -97,7 +97,7 @@ public class SvnExternalParserTest {
         String svnExternals = "http://10.18.3.171:8080/svn/connect4/trunk - http://10.18.3.171:8080/svn/CSharpProject/trunk/ externals-2 \n" +
                 "http://10.18.3.171:8080/svn/CSharpProject/trunk dir1 ";
 
-        List<SvnExternal> externals = new SvnExternalParser().parse(svnExternals, "http://10.18.3.171:8080/svn/connect4/trunk");
+        List<SvnExternal> externals = new SvnExternalParser().parse(svnExternals, "http://10.18.3.171:8080/svn/connect4/trunk", "http://10.18.3.171:8080/svn");
         assertThat(externals.get(0),
                 is(new SvnExternal("externals-2", "http://10.18.3.171:8080/svn/CSharpProject/trunk/")));
         assertThat(externals.get(1),
@@ -112,7 +112,7 @@ public class SvnExternalParserTest {
                 "http://10.18.3.171:8080/svn/connect4/trunk/dir2 - svn://10.18.3.171:8080/svn/CSharpProject/trunk externals-2 \n" +
                 "svn://10.18.3.171:8080/svn/CSharpProject/trunk dir3 \n";
 
-        List<SvnExternal> externals = new SvnExternalParser().parse(svnExternals, "http://10.18.3.171:8080/svn/connect4/trunk");
+        List<SvnExternal> externals = new SvnExternalParser().parse(svnExternals, "http://10.18.3.171:8080/svn/connect4/trunk", "http://10.18.3.171:8080/svn");
         assertThat(externals.get(0),
                 is(new SvnExternal("externals-2", "http://10.18.3.171:8080/svn/CSharpProject/trunk")));
         assertThat(externals.get(1),
@@ -127,7 +127,7 @@ public class SvnExternalParserTest {
     public void shouldSupportFileProtocal() throws Exception {
         String svnExternals = "file:///tmp/repo/project/trunk - end2end file:///tmp/testSvnRepo-1246619674077/end2end";
 
-        List<SvnExternal> externals = new SvnExternalParser().parse(svnExternals, "file:///tmp/repo/project");
+        List<SvnExternal> externals = new SvnExternalParser().parse(svnExternals, "file:///tmp/repo/project", "http://10.18.3.171:8080/svn");
         assertThat(externals.get(0),
                 is(new SvnExternal("trunk/end2end", "file:///tmp/testSvnRepo-1246619674077/end2end")));
     }
@@ -136,7 +136,7 @@ public class SvnExternalParserTest {
     public void shouldSupportUrlWithEncodedSpaces() throws Exception {
         String svnExternals = "file:///C:/Program%20Files/trunk - end2end file:///C:/Program%20Files/testSvnRepo-1246619674077/end2end";
 
-        List<SvnExternal> externals = new SvnExternalParser().parse(svnExternals, "file:///C:/Program%20Files");
+        List<SvnExternal> externals = new SvnExternalParser().parse(svnExternals, "file:///C:/Program%20Files", "http://10.18.3.171:8080/svn");
         assertThat(externals.get(0),
                 is(new SvnExternal("trunk/end2end", "file:///C:/Program%20Files/testSvnRepo-1246619674077/end2end")));
     }
@@ -148,7 +148,7 @@ public class SvnExternalParserTest {
                 + "http://10.18.3.171:8080/svn/connect4/trunk - svn://10.18.3.171:8080/svn/CSharpProject/trunk/ externals-6\n"
                 + "externals-x svn://10.18.3.171:8080/svn/CSharpProject/trunk/\n";
 
-        List<SvnExternal> externals = new SvnExternalParser().parse(svnExternals, "http://10.18.3.171:8080/svn/connect4/trunk");
+        List<SvnExternal> externals = new SvnExternalParser().parse(svnExternals, "http://10.18.3.171:8080/svn/connect4/trunk", "http://10.18.3.171:8080/svn");
         assertThat(externals.get(0),
                 is(new SvnExternal("lib/externals-2", "http://10.18.3.171:8080/svn/CSharpProject/trunk/")));
         assertThat(externals.get(1), is(new SvnExternal("externals-6", "svn://10.18.3.171:8080/svn/CSharpProject/trunk/")));
@@ -163,7 +163,7 @@ public class SvnExternalParserTest {
                 + "  externals-x     svn://10.18.3.171:8080/svn/CSharpProject/trunk/\n"
                 + " svn://10.18.3.171:8080/svn/CSharpProject/trunk/    externals-y\n";
 
-        List<SvnExternal> externals = new SvnExternalParser().parse(svnExternals, "http://10.18.3.171:8080/svn/connect4/trunk");
+        List<SvnExternal> externals = new SvnExternalParser().parse(svnExternals, "http://10.18.3.171:8080/svn/connect4/trunk", "http://10.18.3.171:8080/svn");
         assertThat(externals.get(0),
                 is(new SvnExternal("lib/externals-2", "http://10.18.3.171:8080/svn/CSharpProject/trunk/")));
         assertThat(externals.get(1), is(new SvnExternal("externals-6", "svn://10.18.3.171:8080/svn/CSharpProject/trunk/")));
@@ -176,7 +176,7 @@ public class SvnExternalParserTest {
         String svnExternals = "http://10.18.3.171:8080/svn/connect4/trunk/lib - externals-2 -r 2 http://10.18.3.171:8080/svn/CSharpProject/trunk/   \n"
                 + "externals-6  -r3 svn://10.18.3.171:8080/svn/CSharpProject/trunk/ \n";
 
-        List<SvnExternal> externals = new SvnExternalParser().parse(svnExternals, "http://10.18.3.171:8080/svn/connect4/trunk");
+        List<SvnExternal> externals = new SvnExternalParser().parse(svnExternals, "http://10.18.3.171:8080/svn/connect4/trunk", "http://10.18.3.171:8080/svn");
         assertThat(externals.get(0),
                 is(new SvnExternal("lib/externals-2", "http://10.18.3.171:8080/svn/CSharpProject/trunk/")));
         assertThat(externals.get(1), is(new SvnExternal("lib/externals-6", "svn://10.18.3.171:8080/svn/CSharpProject/trunk/")));
@@ -187,7 +187,7 @@ public class SvnExternalParserTest {
         String svnExternals = "http://10.18.3.171:8080/svn/connect4/trunk/lib - -r 2 http://10.18.3.171:8080/svn/CSharpProject/trunk/  externals-2 \n"
                 + "-r3 svn://10.18.3.171:8080/svn/CSharpProject/trunk/ externals-6\n";
 
-        List<SvnExternal> externals = new SvnExternalParser().parse(svnExternals, "http://10.18.3.171:8080/svn/connect4/trunk");
+        List<SvnExternal> externals = new SvnExternalParser().parse(svnExternals, "http://10.18.3.171:8080/svn/connect4/trunk", "http://10.18.3.171:8080/svn");
         assertThat(externals.get(0),
                 is(new SvnExternal("lib/externals-2", "http://10.18.3.171:8080/svn/CSharpProject/trunk/")));
         assertThat(externals.get(1), is(new SvnExternal("lib/externals-6", "svn://10.18.3.171:8080/svn/CSharpProject/trunk/")));
@@ -200,9 +200,9 @@ public class SvnExternalParserTest {
                 "^/repo3/trunk app/repo3\n" +
                 "^/repo4/trunk app/repo4";
 
-        List<SvnExternal> externals = new SvnExternalParser().parse(svnExternals, "http://10.18.3.171:8080/svn");
+        List<SvnExternal> externals = new SvnExternalParser().parse(svnExternals, "http://10.18.3.171:8080/svn/externalstest", "http://10.18.3.171:8080/svn");
         assertThat(externals.size(), is(4));
-        assertThat(externals.get(0), is(new SvnExternal("externalstest/lib/repo1", "http://10.18.3.171:8080/svn/repo1/trunk")));
-        assertThat(externals.get(3), is(new SvnExternal("externalstest/app/repo4", "http://10.18.3.171:8080/svn/repo4/trunk")));
+        assertThat(externals.get(0), is(new SvnExternal("lib/repo1", "http://10.18.3.171:8080/svn/repo1/trunk")));
+        assertThat(externals.get(3), is(new SvnExternal("app/repo4", "http://10.18.3.171:8080/svn/repo4/trunk")));
     }
 }


### PR DESCRIPTION
As described in #1039 we have a file structure created by pulling multiple repositories together with SVN externals. We had an issue with builds not triggering when changes were made to the external repositories, only the root.

After looking through the code that parses SVN externals, my hunch was that it wasn't parsing the relative root '^' character in the URLs. I made a failing test using the output from running PROPGET and found the parser returned no repositories.

The code attached basically does a substitution on the '^' character with the root path, so it just goes through the regular parser logic. I've only added it to the 1.5 version of the parsers as that was when it was introduced.

I think there is probably scope for doing some refactoring in the area in general, but given how niche my problem is it didn't seem worthwhile.