### PR TITLE
Do not close the stdout/error streams of the go server process

### DIFF
--- a/server/src/com/thoughtworks/go/server/util/GoMacLauncher.java
+++ b/server/src/com/thoughtworks/go/server/util/GoMacLauncher.java
@@ -101,10 +101,13 @@ public class GoMacLauncher extends JFrame {
         try {
             setUpApplicationSupport();
 
-            final Process server = Runtime.getRuntime().exec(args, null, new File(APPLICATION_SUPPORT_PATHNAME));
-            server.getErrorStream().close();
-            server.getInputStream().close();
+            ProcessBuilder processBuilder = new ProcessBuilder(args);
+            processBuilder.directory(new File(APPLICATION_SUPPORT_PATHNAME));
+            processBuilder.redirectErrorStream(true);
+            processBuilder.redirectOutput(ProcessBuilder.Redirect.appendTo(new File(APPLICATION_SUPPORT_PATHNAME, "go-server.log")));
+            final Process server = processBuilder.start();
             server.getOutputStream().close();
+
             Thread shutdownHook = new Thread(new Shutdown(server));
             Runtime.getRuntime().addShutdownHook(shutdownHook);
 


### PR DESCRIPTION
Do not close the stdout/error streams of the go server process that the mac launcher executes.

When runnong the mac launcher on jdk8 - this seems to cause the
child process (the go.jar process) to crash out because it writes to stdout.

This fix will perform the equivalent of `java -jar go.jar 2>&1 > go-server.log`