### PR TITLE
#000 - Trying to fix flaky UserSqlMapDaoCachingTest

### DIFF
--- a/server/test/integration/com/thoughtworks/go/server/dao/UserSqlMapDaoCachingTest.java
+++ b/server/test/integration/com/thoughtworks/go/server/dao/UserSqlMapDaoCachingTest.java
@@ -172,7 +172,7 @@ public class UserSqlMapDaoCachingTest {
 
     @Test(timeout = 60000)
     public void enabledUserCacheShouldBeThreadSafe() throws Exception {
-        ThreadSafetyChecker threadSafetyChecker = new ThreadSafetyChecker(5000);
+        ThreadSafetyChecker threadSafetyChecker = new ThreadSafetyChecker(10000);
 
         threadSafetyChecker.addOperation(new ThreadSafetyChecker.Operation() {
             @Override


### PR DESCRIPTION
changed assertion for one of the tests so that the values are not hardcoded
A bunch of tests used to fail because of thread-level timeout happening in enabledUserCacheShouldBeThreadSafe.
For now increased the timeout so the tests pass. Added a stop watch to record the operation times to see which operation takes long.