### PR TITLE
Change git clean step to remove ignored files.

### DIFF
--- a/common/src/com/thoughtworks/go/domain/materials/git/GitCommand.java
+++ b/common/src/com/thoughtworks/go/domain/materials/git/GitCommand.java
@@ -188,7 +188,7 @@ public class GitCommand extends SCMCommand {
     }
 
     private void cleanUnversionedFiles(File workingDir) {
-        String[] args = new String[]{"clean", "-dff"};
+        String[] args = new String[]{"clean", "-dffx"};
         CommandLine gitCmd = git().withArgs(args).withWorkingDir(workingDir);
         runOrBomb(gitCmd);
     }


### PR DESCRIPTION
The man page for git-clean says: "Don't use the standard ignore rules read from
.gitignore (per directory) and $GIT_DIR/info/exclude, but do still use the
ignore rules given with -e options. This allows removing all untracked files,
including build products."

Without this option, files from previous builds are persisted across runs. This can mask issues that aren't discovered until someone clones the repository fresh (or runs `git clean -fxd` locally).