### PR TITLE
#1058 Move console artifacts on complete only of the job is not a copy

### DIFF
--- a/server/src/com/thoughtworks/go/domain/activity/ConsoleLogArtifactHandler.java
+++ b/server/src/com/thoughtworks/go/domain/activity/ConsoleLogArtifactHandler.java
@@ -36,7 +36,12 @@ public class ConsoleLogArtifactHandler implements JobStatusListener {
 
     @Override
     public void jobStatusChanged(JobInstance job) {
-        if (job.getState().isCompleted()) {
+        /*
+            We are checking for jobs which are a copy because the completion event is fired for a job that's a part
+            of a stage which have rerun jobs. The read fix is to not raise this event for those jobs.
+            TODO: Do not fire completed event for jobs that do not run in the stage.
+         */
+        if (!job.isCopy() && job.isCompleted()) {
             try {
                 JobIdentifier identifier = job.getIdentifier();
                 consoleService.moveConsoleArtifacts(identifier);

--- a/server/test/unit/com/thoughtworks/go/domain/activity/ConsoleLogArtifactHandlerTest.java
+++ b/server/test/unit/com/thoughtworks/go/domain/activity/ConsoleLogArtifactHandlerTest.java
@@ -24,20 +24,31 @@ public class ConsoleLogArtifactHandlerTest {
     }
 
     @Test
-    public void shouldMoveConsoleArtifactWhenJobCompletes() throws Exception {
+    public void shouldMoveConsoleArtifactWhenJobThatIsRunOrRerunCompletes() throws Exception {
+        completedJobInstance.setOriginalJobId(null);
         handler.jobStatusChanged(completedJobInstance);
         verify(consoleService).moveConsoleArtifacts(completedJobInstance.getIdentifier());
     }
 
     @Test
-    public void shouldMoveConsoleArtifactOnlyWhenJobCompletes() throws Exception {
+    public void shouldNotMoveConsoleArtifactWhenJobCompletedIsWasNotActuallyRunWhenAnotherJobInItsStageWasRerun() throws Exception {
+        completedJobInstance.setOriginalJobId(1L);
+        handler.jobStatusChanged(completedJobInstance);
+        verify(consoleService, never()).moveConsoleArtifacts(buildingJobInstance.getIdentifier());
+    }
+
+    @Test
+    public void shouldNotMoveConsoleArtifactWhenJobIsACopyIsNotYetCompleted() throws Exception {
+        completedJobInstance.setOriginalJobId(1L);
         handler.jobStatusChanged(buildingJobInstance);
         verify(consoleService, never()).moveConsoleArtifacts(buildingJobInstance.getIdentifier());
     }
 
     @Test
-    public void shouldReportJobAsCompletedOnConsoleOnlyWhenStatusIsCompleted() throws Exception {
+    public void shouldNotMoveConsoleArtifactWhenJobIsNotYetCompleted() throws Exception {
+        completedJobInstance.setOriginalJobId(null);
         handler.jobStatusChanged(buildingJobInstance);
-        verify(consoleService, never()).appendToConsoleLog(buildingJobInstance.getIdentifier(), "[go] Job Completed pipeline/label-1/stage/1/job");
+        verify(consoleService, never()).moveConsoleArtifacts(buildingJobInstance.getIdentifier());
     }
+
 }


### PR DESCRIPTION
The todo on the code has more information about a better way to apply this fix.
This is a temporary in case we can slot something for a 15.1 release.