### PR TITLE
Fixing race condition on console log create and display of empty console creation on rerun jobs

### DIFF
--- a/server/src/com/thoughtworks/go/domain/activity/ConsoleLogArtifactHandler.java
+++ b/server/src/com/thoughtworks/go/domain/activity/ConsoleLogArtifactHandler.java
@@ -36,7 +36,12 @@ public class ConsoleLogArtifactHandler implements JobStatusListener {
 
     @Override
     public void jobStatusChanged(JobInstance job) {
-        if (job.getState().isCompleted()) {
+        /*
+            We are checking for jobs which are a copy because the completion event is fired for a job that's a part
+            of a stage which have rerun jobs. The read fix is to not raise this event for those jobs.
+            TODO: Do not fire completed event for jobs that do not run in the stage.
+         */
+        if (!job.isCopy() && job.isCompleted()) {
             try {
                 JobIdentifier identifier = job.getIdentifier();
                 consoleService.moveConsoleArtifacts(identifier);

--- a/server/src/com/thoughtworks/go/server/service/ConsoleService.java
+++ b/server/src/com/thoughtworks/go/server/service/ConsoleService.java
@@ -173,7 +173,10 @@ public class ConsoleService {
     public void moveConsoleArtifacts(LocatableEntity locatableEntity) {
         try {
             File from = chooser.temporaryConsoleFile(locatableEntity);
-            from.createNewFile(); // Job cancellation skips temporary file creation. Force create one if it does not exist.
+
+            // Job cancellation skips temporary file creation. Force create one if it does not exist.
+            FileUtils.touch(from);
+
             File to = chooser.findArtifact(locatableEntity, getConsoleOutputFolderAndFileName());
             FileUtils.moveFile(from, to);
         } catch (IOException e) {

--- a/server/test/unit/com/thoughtworks/go/domain/activity/ConsoleLogArtifactHandlerTest.java
+++ b/server/test/unit/com/thoughtworks/go/domain/activity/ConsoleLogArtifactHandlerTest.java
@@ -24,20 +24,31 @@ public class ConsoleLogArtifactHandlerTest {
     }
 
     @Test
-    public void shouldMoveConsoleArtifactWhenJobCompletes() throws Exception {
+    public void shouldMoveConsoleArtifactWhenJobThatIsRunOrRerunCompletes() throws Exception {
+        completedJobInstance.setOriginalJobId(null);
         handler.jobStatusChanged(completedJobInstance);
         verify(consoleService).moveConsoleArtifacts(completedJobInstance.getIdentifier());
     }
 
     @Test
-    public void shouldMoveConsoleArtifactOnlyWhenJobCompletes() throws Exception {
+    public void shouldNotMoveConsoleArtifactWhenJobCompletedIsWasNotActuallyRunWhenAnotherJobInItsStageWasRerun() throws Exception {
+        completedJobInstance.setOriginalJobId(1L);
+        handler.jobStatusChanged(completedJobInstance);
+        verify(consoleService, never()).moveConsoleArtifacts(buildingJobInstance.getIdentifier());
+    }
+
+    @Test
+    public void shouldNotMoveConsoleArtifactWhenJobIsACopyIsNotYetCompleted() throws Exception {
+        completedJobInstance.setOriginalJobId(1L);
         handler.jobStatusChanged(buildingJobInstance);
         verify(consoleService, never()).moveConsoleArtifacts(buildingJobInstance.getIdentifier());
     }
 
     @Test
-    public void shouldReportJobAsCompletedOnConsoleOnlyWhenStatusIsCompleted() throws Exception {
+    public void shouldNotMoveConsoleArtifactWhenJobIsNotYetCompleted() throws Exception {
+        completedJobInstance.setOriginalJobId(null);
         handler.jobStatusChanged(buildingJobInstance);
-        verify(consoleService, never()).appendToConsoleLog(buildingJobInstance.getIdentifier(), "[go] Job Completed pipeline/label-1/stage/1/job");
+        verify(consoleService, never()).moveConsoleArtifacts(buildingJobInstance.getIdentifier());
     }
+
 }


### PR DESCRIPTION
Build failure as seen here

https://build.go.cd/go/tab/build/detail/regression_with_jetty_6/11/twist/2/firefox-split-runInstance-19#tab-twist