### PR TITLE
Switch to using jetty6 by default since the version of jetty9 (9.2.3.v20140905) that is currently being used appears to be leaking something.

### DIFF
--- a/base/src/com/thoughtworks/go/util/SystemEnvironment.java
+++ b/base/src/com/thoughtworks/go/util/SystemEnvironment.java
@@ -154,7 +154,8 @@ public class SystemEnvironment implements Serializable, ConfigDirProvider {
     public static GoSystemProperty<String> JETTY_XML_FILE_NAME = new GoStringSystemProperty("jetty.xml.file.name", JETTY_XML);
 
     public static final String JETTY9 = "com.thoughtworks.go.server.Jetty9Server";
-    public static GoSystemProperty<String> APP_SERVER = new CachedProperty<String>(new GoStringSystemProperty("app.server", JETTY9));
+    public static final String JETTY6 = "com.thoughtworks.go.server.Jetty6Server";
+    public static GoSystemProperty<String> APP_SERVER = new CachedProperty<String>(new GoStringSystemProperty("app.server", JETTY6));
     public static GoSystemProperty<String> GO_SERVER_STATE = new GoStringSystemProperty("go.server.state", "active");
     public static GoSystemProperty<String> GO_LANDING_PAGE = new GoStringSystemProperty("go.landing.page", "/pipelines");
 

--- a/common/test/unit/com/thoughtworks/go/util/SystemEnvironmentTest.java
+++ b/common/test/unit/com/thoughtworks/go/util/SystemEnvironmentTest.java
@@ -419,13 +419,13 @@ public class SystemEnvironmentTest {
     }
 
     @Test
-    public void shouldUseJetty9ByDefault() {
+    public void shouldUseJetty6ByDefault() {
         SystemEnvironment systemEnvironment = new SystemEnvironment();
-        assertThat(systemEnvironment.get(SystemEnvironment.APP_SERVER), is(SystemEnvironment.JETTY9));
-        assertThat(systemEnvironment.usingJetty9(), is(true));
-
-        systemEnvironment.set(SystemEnvironment.APP_SERVER, "JETTY6");
+        assertThat(systemEnvironment.get(SystemEnvironment.APP_SERVER), is(SystemEnvironment.JETTY6));
         assertThat(systemEnvironment.usingJetty9(), is(false));
+
+        systemEnvironment.set(SystemEnvironment.APP_SERVER, SystemEnvironment.JETTY9);
+        assertThat(systemEnvironment.usingJetty9(), is(true));
     }
 
     @Test


### PR DESCRIPTION
We're still investigating the root cause of this.