### PR TITLE
Fixing broken tests because of rollback to jetty6 is proving to be too  cumbersome (thanks to maven)

### DIFF
--- a/base/src/com/thoughtworks/go/util/SystemEnvironment.java
+++ b/base/src/com/thoughtworks/go/util/SystemEnvironment.java
@@ -153,6 +153,7 @@ public class SystemEnvironment implements Serializable, ConfigDirProvider {
     public static GoSystemProperty<Boolean> SHOULD_VALIDATE_XML_AGAINST_DTD = new GoBooleanSystemProperty("validate.xml.against.dtd", false);
     public static GoSystemProperty<String> JETTY_XML_FILE_NAME = new GoStringSystemProperty("jetty.xml.file.name", JETTY_XML);
 
+    public static final String JETTY6 = "com.thoughtworks.go.server.Jetty6Server";
     public static final String JETTY9 = "com.thoughtworks.go.server.Jetty9Server";
     public static GoSystemProperty<String> APP_SERVER = new CachedProperty<String>(new GoStringSystemProperty("app.server", JETTY9));
     public static GoSystemProperty<String> GO_SERVER_STATE = new GoStringSystemProperty("go.server.state", "active");

--- a/base/src/com/thoughtworks/go/util/SystemEnvironment.java
+++ b/base/src/com/thoughtworks/go/util/SystemEnvironment.java
@@ -154,8 +154,7 @@ public class SystemEnvironment implements Serializable, ConfigDirProvider {
     public static GoSystemProperty<String> JETTY_XML_FILE_NAME = new GoStringSystemProperty("jetty.xml.file.name", JETTY_XML);
 
     public static final String JETTY9 = "com.thoughtworks.go.server.Jetty9Server";
-    public static final String JETTY6 = "com.thoughtworks.go.server.Jetty6Server";
-    public static GoSystemProperty<String> APP_SERVER = new CachedProperty<String>(new GoStringSystemProperty("app.server", JETTY6));
+    public static GoSystemProperty<String> APP_SERVER = new CachedProperty<String>(new GoStringSystemProperty("app.server", JETTY9));
     public static GoSystemProperty<String> GO_SERVER_STATE = new GoStringSystemProperty("go.server.state", "active");
     public static GoSystemProperty<String> GO_LANDING_PAGE = new GoStringSystemProperty("go.landing.page", "/pipelines");
 

--- a/common/test/unit/com/thoughtworks/go/util/SystemEnvironmentTest.java
+++ b/common/test/unit/com/thoughtworks/go/util/SystemEnvironmentTest.java
@@ -419,13 +419,13 @@ public class SystemEnvironmentTest {
     }
 
     @Test
-    public void shouldUseJetty6ByDefault() {
+    public void shouldUseJetty9ByDefault() {
         SystemEnvironment systemEnvironment = new SystemEnvironment();
-        assertThat(systemEnvironment.get(SystemEnvironment.APP_SERVER), is(SystemEnvironment.JETTY6));
-        assertThat(systemEnvironment.usingJetty9(), is(false));
-
-        systemEnvironment.set(SystemEnvironment.APP_SERVER, SystemEnvironment.JETTY9);
+        assertThat(systemEnvironment.get(SystemEnvironment.APP_SERVER), is(SystemEnvironment.JETTY9));
         assertThat(systemEnvironment.usingJetty9(), is(true));
+
+        systemEnvironment.set(SystemEnvironment.APP_SERVER, "JETTY6");
+        assertThat(systemEnvironment.usingJetty9(), is(false));
     }
 
     @Test

--- a/common/test/unit/com/thoughtworks/go/util/SystemEnvironmentTest.java
+++ b/common/test/unit/com/thoughtworks/go/util/SystemEnvironmentTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -421,15 +421,11 @@ public class SystemEnvironmentTest {
     @Test
     public void shouldUseJetty6ByDefault() {
         SystemEnvironment systemEnvironment = new SystemEnvironment();
-        try {
-            assertThat(systemEnvironment.get(SystemEnvironment.APP_SERVER), is(SystemEnvironment.JETTY6));
-            assertThat(systemEnvironment.usingJetty9(), is(false));
+        assertThat(systemEnvironment.get(SystemEnvironment.APP_SERVER), is(SystemEnvironment.JETTY6));
+        assertThat(systemEnvironment.usingJetty9(), is(false));
 
-            systemEnvironment.set(SystemEnvironment.APP_SERVER, SystemEnvironment.JETTY9);
-            assertThat(systemEnvironment.usingJetty9(), is(true));
-        } finally {
-            systemEnvironment.set(SystemEnvironment.APP_SERVER, SystemEnvironment.JETTY6);
-        }
+        systemEnvironment.set(SystemEnvironment.APP_SERVER, SystemEnvironment.JETTY9);
+        assertThat(systemEnvironment.usingJetty9(), is(true));
     }
 
     @Test

--- a/development-utility/development-server/src/com/thoughtworks/go/server/DevelopmentServer.java
+++ b/development-utility/development-server/src/com/thoughtworks/go/server/DevelopmentServer.java
@@ -44,7 +44,6 @@ public class DevelopmentServer {
 
         copyActivatorJarToClassPath();
         SystemEnvironment systemEnvironment = new SystemEnvironment();
-        systemEnvironment.set(SystemEnvironment.APP_SERVER, Jetty9Server.class.getCanonicalName());
         systemEnvironment.setProperty(SystemEnvironment.PARENT_LOADER_PRIORITY, "true");
         systemEnvironment.setProperty(SystemEnvironment.CRUISE_SERVER_WAR_PROPERTY, webApp.getAbsolutePath());
 

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -580,7 +580,7 @@
         </dependency>
         <dependency>
             <groupId>com.thoughtworks.go</groupId>
-            <artifactId>jetty6</artifactId>
+            <artifactId>jetty9</artifactId>
             <version>1.0</version>
             <scope>test</scope>
         </dependency>

--- a/server/src/com/thoughtworks/go/server/GoServer.java
+++ b/server/src/com/thoughtworks/go/server/GoServer.java
@@ -16,6 +16,7 @@
 
 package com.thoughtworks.go.server;
 
+import com.thoughtworks.go.util.StringUtil;
 import com.thoughtworks.go.util.SubprocessLogger;
 import com.thoughtworks.go.util.SystemEnvironment;
 import com.thoughtworks.go.util.validators.*;
@@ -75,7 +76,9 @@ public class GoServer {
     }
 
     AppServer configureServer() throws Exception {
-        this.systemEnvironment.set(SystemEnvironment.APP_SERVER, SystemEnvironment.JETTY6);
+        if(StringUtil.isBlank(System.getProperty(SystemEnvironment.APP_SERVER.propertyName()))){
+            systemEnvironment.set(SystemEnvironment.APP_SERVER, SystemEnvironment.JETTY6);
+        }
         Constructor<?> constructor = Class.forName(systemEnvironment.get(SystemEnvironment.APP_SERVER)).getConstructor(SystemEnvironment.class, String.class, SSLSocketFactory.class);
         AppServer server = ((AppServer) constructor.newInstance(systemEnvironment, password, sslSocketFactory));
         server.configure();

--- a/server/src/com/thoughtworks/go/server/GoServer.java
+++ b/server/src/com/thoughtworks/go/server/GoServer.java
@@ -75,6 +75,7 @@ public class GoServer {
     }
 
     AppServer configureServer() throws Exception {
+        this.systemEnvironment.set(SystemEnvironment.APP_SERVER, SystemEnvironment.JETTY6);
         Constructor<?> constructor = Class.forName(systemEnvironment.get(SystemEnvironment.APP_SERVER)).getConstructor(SystemEnvironment.class, String.class, SSLSocketFactory.class);
         AppServer server = ((AppServer) constructor.newInstance(systemEnvironment, password, sslSocketFactory));
         server.configure();


### PR DESCRIPTION
This fix will just force the default server to be jetty6 on bootup.

Also the `app.server` flag will do nothing as things currently stand; this
won't necessarily cause any harm because we know that jetty9 has other issues.