### PR TITLE
#980 Jetty 6 deletes the work directory on exit. 

### DIFF
--- a/server/src/com/thoughtworks/go/server/view/artifacts/ArtifactDirectoryChooser.java
+++ b/server/src/com/thoughtworks/go/server/view/artifacts/ArtifactDirectoryChooser.java
@@ -75,7 +75,7 @@ public class ArtifactDirectoryChooser {
     }
 
     public File temporaryConsoleFile(LocatableEntity locatableEntity) {
-        return new File("work/local", format("%s.log", DigestUtils.md5Hex(locatableEntity.entityLocator())));
+        return new File("data/console", format("%s.log", DigestUtils.md5Hex(locatableEntity.entityLocator())));
     }
 
 }

--- a/server/test/unit/com/thoughtworks/go/server/view/artifacts/ArtifactDirectoryChooserTest.java
+++ b/server/test/unit/com/thoughtworks/go/server/view/artifacts/ArtifactDirectoryChooserTest.java
@@ -129,6 +129,6 @@ public class ArtifactDirectoryChooserTest {
     public void shouldFetchATemporaryConsoleOutLocation() throws Exception {
         File consoleFile = chooser.temporaryConsoleFile(new JobIdentifier("cruise", 1, "1.1", "dev", "2", "linux-firefox", null));
         String filePathSeparator = System.getProperty("file.separator");
-        assertThat(consoleFile.getPath(), is(String.format("work%slocal%sd0132b209429f7dc5b9ffffe87b02a7c.log", filePathSeparator, filePathSeparator)));
+        assertThat(consoleFile.getPath(), is(String.format("data%sconsole%sd0132b209429f7dc5b9ffffe87b02a7c.log", filePathSeparator, filePathSeparator)));
     }
 }


### PR DESCRIPTION
Jetty 9 does not. Since we'll be switching between jetty 9 and jetty 6 for atleast another release it's safer to move this out of work to a top level dir and migrate jetty's work folder or temp folder under that in the next release.