### PR TITLE
Improve the interop betwen jetty 6 and 9.

### DIFF
--- a/app-server/src/com/thoughtworks/go/server/util/ServletHelper.java
+++ b/app-server/src/com/thoughtworks/go/server/util/ServletHelper.java
@@ -23,8 +23,6 @@ public abstract class ServletHelper {
 
     public abstract ServletResponse getResponse(javax.servlet.ServletResponse servletResponse);
 
-    public abstract String encodeString(String string);
-
     private static ServletHelper instance;
 
     public static void init(Boolean usingJetty9) {

--- a/development-utility/development-server-with-jetty6/src/com/thoughtworks/go/server/DevelopmentServerWithJetty6.java
+++ b/development-utility/development-server-with-jetty6/src/com/thoughtworks/go/server/DevelopmentServerWithJetty6.java
@@ -29,8 +29,7 @@ import com.thoughtworks.go.util.SystemEnvironment;
 public class DevelopmentServerWithJetty6 {
     public static void main(String[] args) throws Exception {
         SystemEnvironment systemEnvironment = new SystemEnvironment();
-        systemEnvironment.set(SystemEnvironment.APP_SERVER, Jetty6Server.class.getCanonicalName());
-        systemEnvironment.set(SystemEnvironment.JETTY_XML_FILE_NAME, "jetty6.xml");
+        systemEnvironment.set(SystemEnvironment.APP_SERVER, SystemEnvironment.JETTY6);
         DevelopmentServer.main(args);
     }
 }

--- a/development-utility/development-server/src/com/thoughtworks/go/server/DevelopmentServer.java
+++ b/development-utility/development-server/src/com/thoughtworks/go/server/DevelopmentServer.java
@@ -44,6 +44,12 @@ public class DevelopmentServer {
 
         copyActivatorJarToClassPath();
         SystemEnvironment systemEnvironment = new SystemEnvironment();
+
+        String chosenAppServer = System.getProperty(SystemEnvironment.APP_SERVER.propertyName());
+        if (chosenAppServer == null || chosenAppServer.trim().isEmpty()) {
+            systemEnvironment.set(SystemEnvironment.APP_SERVER, SystemEnvironment.JETTY9);
+        }
+
         systemEnvironment.setProperty(SystemEnvironment.PARENT_LOADER_PRIORITY, "true");
         systemEnvironment.setProperty(SystemEnvironment.CRUISE_SERVER_WAR_PROPERTY, webApp.getAbsolutePath());
 

--- a/jetty6/src/com/thoughtworks/go/server/util/Jetty6ServletHelper.java
+++ b/jetty6/src/com/thoughtworks/go/server/util/Jetty6ServletHelper.java
@@ -16,8 +16,6 @@
 
 package com.thoughtworks.go.server.util;
 
-import org.mortbay.util.UrlEncoded;
-
 //Do not delete. Invoked using reflection
 public class Jetty6ServletHelper extends ServletHelper {
     @Override
@@ -28,11 +26,6 @@ public class Jetty6ServletHelper extends ServletHelper {
     @Override
     public ServletResponse getResponse(javax.servlet.ServletResponse servletResponse) {
         return new Jetty6Response(servletResponse);
-    }
-
-    @Override
-    public String encodeString(String string) {
-        return UrlEncoded.encodeString(string);
     }
 
 }

--- a/jetty9/src/com/thoughtworks/go/server/util/Jetty9ServletHelper.java
+++ b/jetty9/src/com/thoughtworks/go/server/util/Jetty9ServletHelper.java
@@ -16,10 +16,6 @@
 
 package com.thoughtworks.go.server.util;
 
-import org.eclipse.jetty.util.UrlEncoded;
-
-import java.net.URLEncoder;
-
 //Do not delete. Invoked using reflection
 public class Jetty9ServletHelper extends ServletHelper {
     @Override
@@ -32,9 +28,5 @@ public class Jetty9ServletHelper extends ServletHelper {
         return new Jetty9Response(servletResponse);
     }
 
-    @Override
-    public String encodeString(String string) {
-        return UrlEncoded.encodeString(string);
-    }
 }
 

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -580,6 +580,12 @@
         </dependency>
         <dependency>
             <groupId>com.thoughtworks.go</groupId>
+            <artifactId>jetty6</artifactId>
+            <version>1.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.thoughtworks.go</groupId>
             <artifactId>jetty9</artifactId>
             <version>1.0</version>
             <scope>test</scope>

--- a/server/src/com/thoughtworks/go/server/GoServer.java
+++ b/server/src/com/thoughtworks/go/server/GoServer.java
@@ -75,11 +75,6 @@ public class GoServer {
     }
 
     AppServer configureServer() throws Exception {
-        String chosenAppServer = System.getProperty(SystemEnvironment.APP_SERVER.propertyName());
-        if (chosenAppServer == null || chosenAppServer.trim().isEmpty()) {
-            systemEnvironment.set(SystemEnvironment.APP_SERVER, SystemEnvironment.JETTY6);
-        }
-
         Constructor<?> constructor = Class.forName(systemEnvironment.get(SystemEnvironment.APP_SERVER)).getConstructor(SystemEnvironment.class, String.class, SSLSocketFactory.class);
         AppServer server = ((AppServer) constructor.newInstance(systemEnvironment, password, sslSocketFactory));
         server.configure();

--- a/server/src/com/thoughtworks/go/server/web/RedirectDuringBackup.java
+++ b/server/src/com/thoughtworks/go/server/web/RedirectDuringBackup.java
@@ -21,6 +21,8 @@ import com.thoughtworks.go.server.util.ServletRequest;
 import org.springframework.web.context.support.WebApplicationContextUtils;
 
 import javax.servlet.http.HttpServletRequest;
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
 
 /**
  * @understands redirecting all requests to a service unavailable page when the server is being backed up.
@@ -30,17 +32,21 @@ public class RedirectDuringBackup {
     static final String BACKUP_IN_PROGRESS = "backupInProgress";
     private static final String REFERER = "Referer";
 
-    public void setServerBackupFlag(HttpServletRequest req) {
+    public void setServerBackupFlag(HttpServletRequest req) throws UnsupportedEncodingException {
         ServletHelper servletHelper = ServletHelper.getInstance();
         BackupStatusProvider backupStatusProvider = getBackupStatusProvider(req);
         boolean backingUp = backupStatusProvider.isBackingUp();
         req.setAttribute(BACKUP_IN_PROGRESS, String.valueOf(backingUp));
 
         if (backingUp) {
-            req.setAttribute("redirected_from", servletHelper.encodeString(getRedirectUri(req, servletHelper)));
-            req.setAttribute("backup_started_at", servletHelper.encodeString(backupStatusProvider.backupRunningSinceISO8601()));
-            req.setAttribute("backup_started_by", servletHelper.encodeString(backupStatusProvider.backupStartedBy()));
+            req.setAttribute("redirected_from", urlEncode(getRedirectUri(req, servletHelper)));
+            req.setAttribute("backup_started_at", urlEncode(backupStatusProvider.backupRunningSinceISO8601()));
+            req.setAttribute("backup_started_by", urlEncode(backupStatusProvider.backupStartedBy()));
         }
+    }
+
+    private String urlEncode(String string) throws UnsupportedEncodingException {
+        return URLEncoder.encode(string, "UTF-8");
     }
 
     private String getRedirectUri(HttpServletRequest req, ServletHelper servletHelper) {

--- a/server/test/unit/com/thoughtworks/go/server/web/RedirectDuringBackupTest.java
+++ b/server/test/unit/com/thoughtworks/go/server/web/RedirectDuringBackupTest.java
@@ -17,8 +17,6 @@
 package com.thoughtworks.go.server.web;
 
 import com.thoughtworks.go.server.util.ServletHelper;
-import com.thoughtworks.go.server.util.ServletRequest;
-import com.thoughtworks.go.server.util.ServletResponse;
 import org.eclipse.jetty.http.HttpMethod;
 import org.eclipse.jetty.http.HttpURI;
 import org.eclipse.jetty.server.HttpChannel;
@@ -62,7 +60,7 @@ public class RedirectDuringBackupTest {
     }
 
     @Test
-    public void shouldNotRedirectWhenBackupIsNotBeingTaken() {
+    public void shouldNotRedirectWhenBackupIsNotBeingTaken() throws Exception {
         when(provider.isBackingUp()).thenReturn(false);
         Request request = request(HttpMethod.GET, "", "/go/agents");
 


### PR DESCRIPTION
* DevelopmentServer will run with jetty9, use DevelopmentServerWithJetty6 to run with jetty6.
* Reduce the API footprint of ServletHelper's method that performed url encoding.