### PR TITLE
Trim whitespace characters when loading agent GUID

### DIFF
--- a/common/src/com/thoughtworks/go/config/GuidService.java
+++ b/common/src/com/thoughtworks/go/config/GuidService.java
@@ -40,7 +40,7 @@ public class GuidService {
 
     public static String loadGuid() {
         try {
-            return FileUtils.readFileToString(AGENT_GUID_FILE);
+            return FileUtils.readFileToString(AGENT_GUID_FILE).trim();
         } catch (IOException ioe) {
             throw bomb("Couldn't load GUID from filesystem", ioe);
         }

--- a/common/test/unit/com/thoughtworks/go/config/GuidServiceTest.java
+++ b/common/test/unit/com/thoughtworks/go/config/GuidServiceTest.java
@@ -1,0 +1,21 @@
+package com.thoughtworks.go.config;
+
+import org.junit.After;
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+public class GuidServiceTest {
+
+    @After
+    public void tearDown() {
+        GuidService.deleteGuid();
+    }
+
+    @Test
+    public void shouldStripExtraWhitespaceFromGuidStringOnLoad() throws Exception {
+        GuidService.storeGuid(" \tuuid\n ");
+        assertThat(GuidService.loadGuid(), is("uuid"));
+    }
+}


### PR DESCRIPTION
This correlates to an earlier bug report by me, #874, and this is my try at fixing that fairly minor issue.

I'm not a Java developer so I've basically muddled this together by looking at other tests, so I hope this'll fit with the Go style. :)