### PR TITLE
Add a small note about CLA

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,3 +2,8 @@
 
 We encourage you to contribute to Go. For information on contributing to this project, please see our <a href="http://www.go.cd/contribute/">contributor's guide</a>.
 A lot of useful information like links to user documentation, design documentation, mailing lists etc can be found in the <a href="http://www.go.cd/community/resources.html">resources</a> section.
+
+## Contributing Code?
+
+Signing the [Contributor License Agreement (CLA)](http://www.go.cd/contribute/cla.html) is required before any of your code or pull-requests are accepted.
+


### PR DESCRIPTION
so users don't have to click through to the contributors guide and then to another page.