### PR TITLE
Updating JGit version to 3.6.2.201501210735-r

### DIFF
--- a/config/config-server/pom.xml
+++ b/config/config-server/pom.xml
@@ -51,7 +51,7 @@
         <dependency>
             <groupId>org.eclipse.jgit</groupId>
             <artifactId>org.eclipse.jgit</artifactId>
-            <version>2.0.0.201206130900-r</version>
+            <version>3.6.2.201501210735-r</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
All file permissions are not preserved after cloning from Git using GoCD (with JGit). This behavior has since been fixed in JGit v3.6.2.201501210735-r, according to https://bugs.eclipse.org/bugs/show_bug.cgi?id=424395, and so this pull request is to update the JGit version used by GoCD.