### PR TITLE
Setup agent hostname when auto-registering (#124)

### DIFF
--- a/agent/src/com/thoughtworks/go/agent/service/SslInfrastructureService.java
+++ b/agent/src/com/thoughtworks/go/agent/service/SslInfrastructureService.java
@@ -199,6 +199,7 @@ public class SslInfrastructureService {
             postMethod.addParameter("agentAutoRegisterKey", agentAutoRegisterProperties.getAgentAutoRegisterKey());
             postMethod.addParameter("agentAutoRegisterResources", agentAutoRegisterProperties.getAgentAutoRegisterResources());
             postMethod.addParameter("agentAutoRegisterEnvironments", agentAutoRegisterProperties.getAgentAutoRegisterEnvironments());
+            postMethod.addParameter("agentAutoRegisterHostname", agentAutoRegisterProperties.getAgentAutoRegisterHostname());
             try {
                 httpClient.executeMethod(postMethod);
                 InputStream is = postMethod.getResponseBodyAsStream();

--- a/agent/test/functional/com/thoughtworks/go/agent/service/RemoteRegistrationRequesterTest.java
+++ b/agent/test/functional/com/thoughtworks/go/agent/service/RemoteRegistrationRequesterTest.java
@@ -59,7 +59,13 @@ public class RemoteRegistrationRequesterTest {
         String url = "http://cruise.com/go";
         HttpClient httpClient = Mockito.mock(HttpClient.class);
         final DefaultAgentRegistry defaultAgentRegistry = new DefaultAgentRegistry();
-        remoteRegistryRequester(url, httpClient, defaultAgentRegistry).requestRegistration("cruise.com", new AgentRegistrationPropertiesReader(new Properties()));
+        Properties properties = new Properties();
+        properties.put(AgentRegistrationPropertiesReader.AGENT_AUTO_REGISTER_KEY, "t0ps3cret");
+        properties.put(AgentRegistrationPropertiesReader.AGENT_AUTO_REGISTER_RESOURCES, "linux, java");
+        properties.put(AgentRegistrationPropertiesReader.AGENT_AUTO_REGISTER_ENVIRONMENTS, "uat, staging");
+        properties.put(AgentRegistrationPropertiesReader.AGENT_AUTO_REGISTER_HOSTNAME, "agent01.example.com");
+
+        remoteRegistryRequester(url, httpClient, defaultAgentRegistry).requestRegistration("cruise.com", new AgentRegistrationPropertiesReader(properties));
         verify(httpClient).executeMethod(argThat(hasAllParams(defaultAgentRegistry.uuid())));
     }
 
@@ -72,9 +78,10 @@ public class RemoteRegistrationRequesterTest {
                 String workingDir = SystemUtil.currentWorkingDirectory();
                 assertThat(postMethod.getParameter("location").getValue(),is(workingDir));
                 assertThat(postMethod.getParameter("operating_system").getValue(),is("minix"));
-                assertThat(postMethod.getParameter("agentAutoRegisterKey").getValue(),is(""));
-                assertThat(postMethod.getParameter("agentAutoRegisterResources").getValue(),is(""));
-                assertThat(postMethod.getParameter("agentAutoRegisterEnvironments").getValue(),is(""));
+                assertThat(postMethod.getParameter("agentAutoRegisterKey").getValue(),is("t0ps3cret"));
+                assertThat(postMethod.getParameter("agentAutoRegisterResources").getValue(),is("linux, java"));
+                assertThat(postMethod.getParameter("agentAutoRegisterEnvironments").getValue(),is("uat, staging"));
+                assertThat(postMethod.getParameter("agentAutoRegisterHostname").getValue(),is("agent01.example.com"));
                 return true;
             }
 

--- a/common/src/com/thoughtworks/go/config/AgentRegistrationPropertiesReader.java
+++ b/common/src/com/thoughtworks/go/config/AgentRegistrationPropertiesReader.java
@@ -28,6 +28,7 @@ public class AgentRegistrationPropertiesReader {
     public static final String AGENT_AUTO_REGISTER_KEY = "agent.auto.register.key";
     public static final String AGENT_AUTO_REGISTER_RESOURCES = "agent.auto.register.resources";
     public static final String AGENT_AUTO_REGISTER_ENVIRONMENTS = "agent.auto.register.environments";
+    public static final String AGENT_AUTO_REGISTER_HOSTNAME = "agent.auto.register.hostname";
 
     private Properties agentAutoRegisterProperties;
 
@@ -65,6 +66,10 @@ public class AgentRegistrationPropertiesReader {
 
     public String getAgentAutoRegisterEnvironments() {
         return agentAutoRegisterProperties.getProperty(AGENT_AUTO_REGISTER_ENVIRONMENTS, "");
+    }
+
+    public String getAgentAutoRegisterHostname() {
+        return agentAutoRegisterProperties.getProperty(AGENT_AUTO_REGISTER_HOSTNAME, "");
     }
 
 }

--- a/common/test/unit/com/thoughtworks/go/config/AgentRegistrationPropertiesReaderTest.java
+++ b/common/test/unit/com/thoughtworks/go/config/AgentRegistrationPropertiesReaderTest.java
@@ -34,6 +34,7 @@ public class AgentRegistrationPropertiesReaderTest {
         properties.put(AgentRegistrationPropertiesReader.AGENT_AUTO_REGISTER_KEY, "foo");
         properties.put(AgentRegistrationPropertiesReader.AGENT_AUTO_REGISTER_RESOURCES, "foo, zoo");
         properties.put(AgentRegistrationPropertiesReader.AGENT_AUTO_REGISTER_ENVIRONMENTS, "foo, bar");
+        properties.put(AgentRegistrationPropertiesReader.AGENT_AUTO_REGISTER_HOSTNAME, "agent01.example.com");
     }
 
     @Test
@@ -42,6 +43,7 @@ public class AgentRegistrationPropertiesReaderTest {
         assertThat(reader.getAgentAutoRegisterKey(), is("foo"));
         assertThat(reader.getAgentAutoRegisterResources(), is("foo, zoo"));
         assertThat(reader.getAgentAutoRegisterEnvironments(), is("foo, bar"));
+        assertThat(reader.getAgentAutoRegisterHostname(), is("agent01.example.com"));
     }
 
     @Test
@@ -51,5 +53,6 @@ public class AgentRegistrationPropertiesReaderTest {
         assertThat(reader.getAgentAutoRegisterKey().isEmpty(), is(true));
         assertThat(reader.getAgentAutoRegisterResources().isEmpty(), is(true));
         assertThat(reader.getAgentAutoRegisterEnvironments().isEmpty(), is(true));
+        assertThat(reader.getAgentAutoRegisterHostname().isEmpty(), is(true));
     }
 }

--- a/server/test/unit/com/thoughtworks/go/server/controller/AgentRegistrationControllerTest.java
+++ b/server/test/unit/com/thoughtworks/go/server/controller/AgentRegistrationControllerTest.java
@@ -83,7 +83,7 @@ public class AgentRegistrationControllerTest {
         when(goConfigService.hasAgent("blahAgent-uuid")).thenReturn(false);
         ServerConfig serverConfig = new ServerConfig("artifacts", new SecurityConfig(), 10, 20, "1", null);
         when(goConfigService.serverConfig()).thenReturn(serverConfig);
-        controller.agentRequest("blahAgent-host", "blahAgent-uuid", "blah-location", "34567", "osx", "", "", "", request);
+        controller.agentRequest("blahAgent-host", "blahAgent-uuid", "blah-location", "34567", "osx", "", "", "", "", request);
         verify(agentService).requestRegistration(AgentRuntimeInfo.fromServer(new AgentConfig("blahAgent-uuid", "blahAgent-host", request.getRemoteAddr()), false, "blah-location", 34567L, "osx"));
     }
 
@@ -94,9 +94,22 @@ public class AgentRegistrationControllerTest {
         ServerConfig serverConfig = new ServerConfig("artifacts", new SecurityConfig(), 10, 20, "1", "someKey");
         when(goConfigService.serverConfig()).thenReturn(serverConfig);
 
-        controller.agentRequest("host", uuid, "location", "233232", "osx", "someKey", "", "", request);
+        controller.agentRequest("host", uuid, "location", "233232", "osx", "someKey", "", "", "", request);
 
         verify(agentService).requestRegistration(AgentRuntimeInfo.fromServer(new AgentConfig(uuid, "host", request.getRemoteAddr()), false, "location", 233232L, "osx"));
+        verify(goConfigService).updateConfig(any(UpdateConfigCommand.class));
+    }
+
+    @Test
+    public void shouldAutoRegisterAgentWithHostnameFromAutoRegisterProperties() throws Exception {
+        String uuid = "uuid";
+        when(goConfigService.hasAgent(uuid)).thenReturn(false);
+        ServerConfig serverConfig = new ServerConfig("artifacts", new SecurityConfig(), 10, 20, "1", "someKey");
+        when(goConfigService.serverConfig()).thenReturn(serverConfig);
+
+        controller.agentRequest("host", uuid, "location", "233232", "osx", "someKey", "", "", "autoregister-hostname", request);
+
+        verify(agentService).requestRegistration(AgentRuntimeInfo.fromServer(new AgentConfig(uuid, "autoregister-hostname", request.getRemoteAddr()), false, "location", 233232L, "osx"));
         verify(goConfigService).updateConfig(any(UpdateConfigCommand.class));
     }
 
@@ -107,7 +120,7 @@ public class AgentRegistrationControllerTest {
         ServerConfig serverConfig = new ServerConfig("artifacts", new SecurityConfig(), 10, 20, "1", "");
         when(goConfigService.serverConfig()).thenReturn(serverConfig);
 
-        controller.agentRequest("host", uuid, "location", "233232", "osx", "", "", "", request);
+        controller.agentRequest("host", uuid, "location", "233232", "osx", "", "", "", "", request);
 
         verify(agentService).requestRegistration(AgentRuntimeInfo.fromServer(new AgentConfig(uuid, "host", request.getRemoteAddr()), false, "location", 233232L, "osx"));
         verify(goConfigService, never()).updateConfig(any(UpdateConfigCommand.class));


### PR DESCRIPTION
* Add a new property `agent.auto.register.hostname` to supply a hostname when registering a hostname
* The registration controller will use the above preferred hostname if autoregisteration key matches, else falls back to the old mechanism