### PR TITLE
Make Keystore password configurable by ENV

### DIFF
--- a/server/src/com/thoughtworks/go/server/GoServer.java
+++ b/server/src/com/thoughtworks/go/server/GoServer.java
@@ -76,7 +76,9 @@ public class GoServer {
 
     AppServer configureServer() throws Exception {
         Constructor<?> constructor = Class.forName(systemEnvironment.get(SystemEnvironment.APP_SERVER)).getConstructor(SystemEnvironment.class, String.class, SSLSocketFactory.class);
-        AppServer server = ((AppServer) constructor.newInstance(systemEnvironment, password, sslSocketFactory));
+        String value = System.getenv("KEYSTORE_PASSWORD");
+        String pass = (value != null)?value:password;
+        AppServer server = ((AppServer) constructor.newInstance(systemEnvironment, pass, sslSocketFactory));
         server.configure();
         server.addExtraJarsToClasspath(getExtraJarsToBeAddedToClasspath());
         server.setCookieExpirePeriod(twoWeeks());


### PR DESCRIPTION
Before creating the AppServer instance, it checks for the environment variable KEYSTORE_PASSWORD. If there is a password found, it uses that, if not (backwards compatible) it uses the hardcoded value stored 'password'. This should allow folks to change the password on the keystore for security sake where needed, just add the environment variable to /etc/default/go-server (or the Windows equivalent) - while maintaining compatibility with those who are fine with the historic hardcoded value.