### PR TITLE
minor changes to authentication end-point

### DIFF
--- a/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/authentication/JsonMessageHandler1_0.java
+++ b/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/authentication/JsonMessageHandler1_0.java
@@ -61,7 +61,14 @@ public class JsonMessageHandler1_0 implements JsonMessageHandler {
             return null;
         }
 
-        User user = toUser(map);
+        Map userMap;
+        try {
+            userMap = (Map) map.get("user");
+        } catch (Exception e) {
+            throw new RuntimeException("User should be returned as a map");
+        }
+
+        User user = toUser(userMap);
         return user;
     }
 

--- a/plugin-infra/go-plugin-access/test/com/thoughtworks/go/plugin/access/authentication/JsonMessageHandler1_0Test.java
+++ b/plugin-infra/go-plugin-access/test/com/thoughtworks/go/plugin/access/authentication/JsonMessageHandler1_0Test.java
@@ -57,13 +57,13 @@ public class JsonMessageHandler1_0Test {
 
     @Test
     public void shouldHandleResponseMessageForAuthenticateUser() throws Exception {
-        User user = messageHandler.responseMessageForAuthenticateUser("{\"username\":\"username\",\"display-name\":\"display-name\",\"email-id\":\"test@test.com\"}");
+        User user = messageHandler.responseMessageForAuthenticateUser("{\"user\":{\"username\":\"username\",\"display-name\":\"display-name\",\"email-id\":\"test@test.com\"}}");
         assertThat(user, is(new User("username", "display-name", "test@test.com")));
     }
 
     @Test
     public void shouldHandleMissingDataInResponseMessageForAuthenticateUser() throws Exception {
-        User user = messageHandler.responseMessageForAuthenticateUser("{\"username\":\"username\"}");
+        User user = messageHandler.responseMessageForAuthenticateUser("{\"user\":{\"username\":\"username\"}}");
         assertThat(user, is(new User("username", null, null)));
     }
 
@@ -110,10 +110,11 @@ public class JsonMessageHandler1_0Test {
     @Test
     public void shouldValidateIncorrectJsonForAuthenticateUser() {
         assertThat(errorMessageForAuthenticateUser("[]"), is("User should be returned as a map"));
-        assertThat(errorMessageForAuthenticateUser("{\"username\":true}"), is("User 'username' should be of type string"));
-        assertThat(errorMessageForAuthenticateUser("{\"username\":\"\"}"), is("User 'username' cannot be empty"));
-        assertThat(errorMessageForAuthenticateUser("{\"username\":\"name\",\"display-name\":true}"), is("User 'display-name' should be of type string"));
-        assertThat(errorMessageForAuthenticateUser("{\"username\":\"name\",\"display-name\":\"display\",\"email-id\":true}"), is("User 'email-id' should be of type string"));
+        assertThat(errorMessageForAuthenticateUser("{\"user\":[]}"), is("User should be returned as a map"));
+        assertThat(errorMessageForAuthenticateUser("{\"user\":{\"username\":true}}"), is("User 'username' should be of type string"));
+        assertThat(errorMessageForAuthenticateUser("{\"user\":{\"username\":\"\"}}"), is("User 'username' cannot be empty"));
+        assertThat(errorMessageForAuthenticateUser("{\"user\":{\"username\":\"name\",\"display-name\":true}}"), is("User 'display-name' should be of type string"));
+        assertThat(errorMessageForAuthenticateUser("{\"user\":{\"username\":\"name\",\"display-name\":\"display\",\"email-id\":true}}"), is("User 'email-id' should be of type string"));
     }
 
     @Test

--- a/server/src/com/thoughtworks/go/server/plugin/controller/PluginController.java
+++ b/server/src/com/thoughtworks/go/server/plugin/controller/PluginController.java
@@ -45,7 +45,7 @@ public class PluginController {
         this.pluginManager = pluginManager;
     }
 
-    @RequestMapping(value = "/{pluginId}/{requestName}", method = RequestMethod.GET)
+    @RequestMapping(value = "/{pluginId}/{requestName}", method = {RequestMethod.GET, RequestMethod.POST, RequestMethod.PUT, RequestMethod.DELETE})
     public ModelAndView handlePluginInteractRequest(
             @PathVariable String pluginId,
             @PathVariable String requestName,

--- a/server/src/com/thoughtworks/go/server/plugin/controller/PluginController.java
+++ b/server/src/com/thoughtworks/go/server/plugin/controller/PluginController.java
@@ -31,6 +31,7 @@ import org.springframework.web.servlet.View;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -52,6 +53,7 @@ public class PluginController {
             HttpServletRequest request) {
         DefaultGoPluginApiRequest apiRequest = new DefaultGoPluginApiRequest(null, null, requestName);
         apiRequest.setRequestParams(getParameterMap(request));
+        addRequestHeaders(request, apiRequest);
 
         try {
             GoPluginApiResponse response = pluginManager.submitTo(pluginId, apiRequest);
@@ -84,6 +86,15 @@ public class PluginController {
             }
         }
         return pluginParameterMap;
+    }
+
+    private void addRequestHeaders(HttpServletRequest request, DefaultGoPluginApiRequest apiRequest) {
+        Enumeration headerNames = request.getHeaderNames();
+        while (headerNames.hasMoreElements()) {
+            String header = (String) headerNames.nextElement();
+            String value = request.getHeader(header);
+            apiRequest.addRequestHeader(header, value);
+        }
     }
 
     private ModelAndView renderPluginResponse(final GoPluginApiResponse response) {


### PR DESCRIPTION
* add web request - request headers to go plugin api request
* allow post, put & delete web requests to be delegated to plugin
* change json authenticate-user of authentication extension & authenticate request processor from `{"username":"username","display-name":"display-name","email-id":"email-id"}` to `{"user":{"username":"username","display-name":"display-name","email-id":"email-id"}}`