### PR TITLE
#000 Removed/Upgraded libs that's pulling older versions of xerces

### DIFF
--- a/app-server/pom.xml
+++ b/app-server/pom.xml
@@ -177,30 +177,6 @@
             <version>${project.parent.version}</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>com.tlb</groupId>
-            <artifactId>tlb-java</artifactId>
-            <version>0.3.2-90-g6df47e3</version>
-            <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>commons-io</groupId>
-                    <artifactId>commons-io</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>commons-codec</groupId>
-                    <artifactId>commons-codec</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>log4j</groupId>
-                    <artifactId>log4j</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>xalan</groupId>
-                    <artifactId>xalan</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
     </dependencies>
 
     <build>

--- a/config/config-api/pom.xml
+++ b/config/config-api/pom.xml
@@ -92,7 +92,7 @@
         <dependency>
             <groupId>jaxen</groupId>
             <artifactId>jaxen</artifactId>
-            <version>1.1</version>
+            <version>1.1.6</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/jetty6/pom.xml
+++ b/jetty6/pom.xml
@@ -206,30 +206,6 @@
             <version>${project.parent.version}</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>com.tlb</groupId>
-            <artifactId>tlb-java</artifactId>
-            <version>0.3.2-90-g6df47e3</version>
-            <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>commons-io</groupId>
-                    <artifactId>commons-io</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>commons-codec</groupId>
-                    <artifactId>commons-codec</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>log4j</groupId>
-                    <artifactId>log4j</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>xalan</groupId>
-                    <artifactId>xalan</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
     </dependencies>
 
     <build>

--- a/jetty9/pom.xml
+++ b/jetty9/pom.xml
@@ -198,30 +198,6 @@
             <version>${project.parent.version}</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>com.tlb</groupId>
-            <artifactId>tlb-java</artifactId>
-            <version>0.3.2-90-g6df47e3</version>
-            <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>commons-io</groupId>
-                    <artifactId>commons-io</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>commons-codec</groupId>
-                    <artifactId>commons-codec</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>log4j</groupId>
-                    <artifactId>log4j</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>xalan</groupId>
-                    <artifactId>xalan</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
     </dependencies>
 
     <build>

--- a/plugin-infra/go-plugin-access/test/com/thoughtworks/go/plugin/access/pluggabletask/TaskExtensionTest.java
+++ b/plugin-infra/go-plugin-access/test/com/thoughtworks/go/plugin/access/pluggabletask/TaskExtensionTest.java
@@ -28,9 +28,9 @@ import org.junit.Before;
 import org.junit.Test;
 
 import static junit.framework.Assert.assertTrue;
-import static junitx.framework.Assert.fail;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
 import static org.mockito.Mockito.*;
 
 public class TaskExtensionTest {

--- a/server/test/common/com/thoughtworks/go/server/dao/DatabaseAccessHelper.java
+++ b/server/test/common/com/thoughtworks/go/server/dao/DatabaseAccessHelper.java
@@ -58,6 +58,7 @@ import com.thoughtworks.go.util.TimeProvider;
 import org.apache.log4j.Logger;
 import org.dbunit.DataSourceDatabaseTester;
 import org.dbunit.IDatabaseTester;
+import org.dbunit.database.AmbiguousTableNameException;
 import org.dbunit.dataset.DefaultDataSet;
 import org.dbunit.dataset.DefaultTable;
 import org.dbunit.operation.DatabaseOperation;
@@ -100,7 +101,7 @@ public class DatabaseAccessHelper extends HibernateDaoSupport {
     private InstanceFactory instanceFactory;
 
     @Deprecated // Should not be creating a new spring context for every test
-    public DatabaseAccessHelper() {
+    public DatabaseAccessHelper() throws AmbiguousTableNameException {
         ClassPathXmlApplicationContext context = createDataContext();
         dataSource = (DataSource) context.getBean("dataSource");
         initialize(dataSource);
@@ -120,7 +121,7 @@ public class DatabaseAccessHelper extends HibernateDaoSupport {
     }
 
     @Deprecated //use Autowired version
-    public DatabaseAccessHelper(DataSource dataSource) {
+    public DatabaseAccessHelper(DataSource dataSource) throws AmbiguousTableNameException {
         this.dataSource = dataSource;
         initialize(dataSource);
     }
@@ -138,7 +139,7 @@ public class DatabaseAccessHelper extends HibernateDaoSupport {
                                 TransactionTemplate transactionTemplate,
                                 TransactionSynchronizationManager transactionSynchronizationManager,
                                 GoCache goCache,
-                                PipelineService pipelineService, InstanceFactory instanceFactory) {
+                                PipelineService pipelineService, InstanceFactory instanceFactory) throws AmbiguousTableNameException {
         this.dataSource = dataSource;
         this.sqlMapClient = sqlMapClient;
         this.stageDao = stageDao;
@@ -156,7 +157,7 @@ public class DatabaseAccessHelper extends HibernateDaoSupport {
         initialize(dataSource);
     }
 
-    private void initialize(DataSource dataSource) {
+    private void initialize(DataSource dataSource) throws AmbiguousTableNameException {
         databaseTester = new DataSourceDatabaseTester(dataSource);
         databaseTester.setSetUpOperation(DatabaseOperation.CLEAN_INSERT);
         databaseTester.setTearDownOperation(DatabaseOperation.DELETE_ALL);

--- a/test-utils/pom.xml
+++ b/test-utils/pom.xml
@@ -266,7 +266,7 @@
 		<dependency>
 			<groupId>org.dbunit</groupId>
 			<artifactId>dbunit</artifactId>
-			<version>2.3.0</version>
+			<version>2.5.1</version>
 			<exclusions>
 				<exclusion>
 					<groupId>commons-lang</groupId>


### PR DESCRIPTION
This to fix the problem of 
```
WARNING:  'org.apache.xerces.jaxp.SAXParserImpl: Property 'http://javax.xml.XMLConstants/property/accessExternalDTD' is not recognized.'
Warning:  org.apache.xerces.parsers.SAXParser: Property 'http://javax.xml.XMLConstants/property/accessExternalDTD' is not recognized.
Warning:  org.apache.xerces.parsers.SAXParser: Property 'http://www.oracle.com/xml/jaxp/properties/entityExpansionLimit' is not recognized.
Warning:  org.apache.xerces.jaxp.SAXParserImpl$JAXPSAXParser: Property 'http://www.oracle.com/xml/jaxp/properties/entityExpansionLimit' is not recognized.
```

These warnings are printed when you have xerces on the classpath. A newer version of the JDK(8) does not fix this. The only solution is to get rid of xerces  (which now comes bundled with the idk) as a transitive dependency. 

This pull request fix it only on some modules.

Apache shindig (used on our app) hard wires the xerces dependency and modules referring shindig will still print this error. For a long term solution we should upgrade the version of Apache shindig.