### PR TITLE
Change min value to 0 on graphs tab.

### DIFF
--- a/server/webapp/WEB-INF/rails.new/app/views/shared/_stage_details_chart.html.erb
+++ b/server/webapp/WEB-INF/rails.new/app/views/shared/_stage_details_chart.html.erb
@@ -60,6 +60,7 @@
                 }
             },
             xAxis: {
+                min:0,
                 allowDecimals : false,
                 maxZoom: 40,
                 title: {


### PR DESCRIPTION
Given that build numbers monotonically increment and cannot be negative it is desirable to have the graph start at 0 for the x-axis.