### PR TITLE
Set javac source and target to java 7 compatibility, pending decision about java 8.

### DIFF
--- a/buildfile
+++ b/buildfile
@@ -61,7 +61,7 @@ repositories.remote << "http://repo1.maven.org/maven2/"
 
 desc "Go - ThoughtWorks Studios"
 define "cruise" do |project|
-  compile.options[:other] = %w[-encoding UTF-8 -target 1.6 -source 1.6]
+  compile.options[:other] = %w[-encoding UTF-8 -target 1.7 -source 1.7]
   TMP_DIR = test.options[:properties]['java.io.tmpdir'] = _('target/temp')
   mkpath TMP_DIR
 

--- a/installers/server/osx/Info.plist
+++ b/installers/server/osx/Info.plist
@@ -48,8 +48,6 @@
         <dict>
             <key>ClassPath</key>
             <string>$APP_PACKAGE/go.jar</string>
-            <key>JVMVersion</key>
-            <string>1.6+</string>
             <key>MainClass</key>
             <string>com.thoughtworks.go.server.util.GoMacLauncher</string>
             <key>Properties</key>

--- a/plugin-infra/sample-plugins/curl-plugin-old-api-based/pom.xml
+++ b/plugin-infra/sample-plugins/curl-plugin-old-api-based/pom.xml
@@ -60,8 +60,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.1</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>1.7</source>
+                    <target>1.7</target>
                 </configuration>
             </plugin>
 

--- a/plugin-infra/sample-plugins/curl-plugin/pom.xml
+++ b/plugin-infra/sample-plugins/curl-plugin/pom.xml
@@ -65,8 +65,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.1</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>1.7</source>
+                    <target>1.7</target>
                 </configuration>
             </plugin>
 

--- a/plugin-infra/sample-plugins/descriptor-hash-plugin/pom.xml
+++ b/plugin-infra/sample-plugins/descriptor-hash-plugin/pom.xml
@@ -68,8 +68,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.1</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>1.7</source>
+                    <target>1.7</target>
                 </configuration>
             </plugin>
 

--- a/pom.xml
+++ b/pom.xml
@@ -35,8 +35,8 @@
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>3.3</version>
                     <configuration>
-                        <source>1.6</source>
-                        <target>1.6</target>
+                        <source>1.7</source>
+                        <target>1.7</target>
                         <useIncrementalCompilation>false</useIncrementalCompilation>
                     </configuration>
                 </plugin>


### PR DESCRIPTION
Although official support for java 6 was dropped last year, we continued to compile
for java 6.