### PR TITLE
Changed session tracking mode to cookie only

### DIFF
--- a/server/test/integration/com/thoughtworks/go/server/web/WebappSessionConfigIntegrationTest.java
+++ b/server/test/integration/com/thoughtworks/go/server/web/WebappSessionConfigIntegrationTest.java
@@ -1,0 +1,67 @@
+/*************************GO-LICENSE-START*********************************
+ * Copyright 2015 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *************************GO-LICENSE-END***********************************/
+
+package com.thoughtworks.go.server.web;
+
+import org.apache.commons.io.FileUtils;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.webapp.WebAppContext;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import javax.servlet.SessionTrackingMode;
+import java.io.File;
+import java.io.IOException;
+import java.util.Set;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+
+public class WebappSessionConfigIntegrationTest {
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+    private File webapp;
+
+    @Before
+    public void setup() throws IOException {
+        webapp = temporaryFolder.newFolder();
+        File webInf = new File(webapp, "WEB-INF");
+        webInf.mkdirs();
+        File webXmlForTest = new File(webInf, "web.xml");
+        File srcWebXMlFile = new File(WebappSessionConfigIntegrationTest.class.getResource("/WEB-INF/web.xml").getFile());
+        FileUtils.copyFile(srcWebXMlFile, webXmlForTest);
+    }
+
+    @Test
+    public void shouldSetSessionTrackingModeToCookieOnly() throws Exception {
+        Server server = new Server(1234);
+        WebAppContext webAppContext = new WebAppContext();
+        webAppContext.setWar(webapp.getAbsolutePath());
+        webAppContext.setContextPath("/");
+        server.setHandler(webAppContext);
+        try {
+            server.start();
+            Set<SessionTrackingMode> effectiveSessionTrackingModes = ((WebAppContext) server.getHandlers()[0]).getServletContext().getEffectiveSessionTrackingModes();
+            assertThat(effectiveSessionTrackingModes.size(), is(1));
+            assertThat(effectiveSessionTrackingModes.contains(SessionTrackingMode.COOKIE), is(true));
+        } finally {
+            server.stop();
+        }
+    }
+}

--- a/server/webapp/WEB-INF/web.xml
+++ b/server/webapp/WEB-INF/web.xml
@@ -14,11 +14,11 @@
  * limitations under the License.
  *************************GO-LICENSE-END******************************* -->
 
-<web-app xmlns="http://java.sun.com/xml/ns/j2ee"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://java.sun.com/xml/ns/j2ee http://java.sun.com/xml/ns/j2ee/web-app_2_4.xsd"
-         version="2.4">
-
+<web-app xmlns="http://java.sun.com/xml/ns/javaee"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
+        metadata-complete="true"
+        version="3.0">
 
     <context-param>
         <param-name>contextConfigLocation</param-name>
@@ -297,5 +297,6 @@
     <!-- Do not timeout idle/stale sessions for 14 days: 60 * 24 * 14 minutes. -->
     <session-config>
         <session-timeout>20160</session-timeout>
+        <tracking-mode>COOKIE</tracking-mode>
     </session-config>
 </web-app>

--- a/server/webapp/WEB-INF/webdefault-jetty6.xml
+++ b/server/webapp/WEB-INF/webdefault-jetty6.xml
@@ -14,10 +14,11 @@
  * limitations under the License.
  *************************GO-LICENSE-END******************************* -->
 
-<web-app xmlns="http://java.sun.com/xml/ns/j2ee"
+<web-app xmlns="http://java.sun.com/xml/ns/javaee"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://java.sun.com/xml/ns/j2ee http://java.sun.com/xml/ns/j2ee/web-app_2_4.xsd"
-         version="2.4">
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
+         metadata-complete="true"
+         version="3.0">
 
     <context-param>
         <param-name>org.mortbay.jetty.servlet.MaxAge</param-name>

--- a/server/webapp/WEB-INF/webdefault.xml
+++ b/server/webapp/WEB-INF/webdefault.xml
@@ -14,10 +14,11 @@
  * limitations under the License.
  *************************GO-LICENSE-END******************************* -->
 
-<web-app xmlns="http://java.sun.com/xml/ns/j2ee"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://java.sun.com/xml/ns/j2ee http://java.sun.com/xml/ns/j2ee/web-app_2_4.xsd"
-         version="2.4">
+<web-app xmlns="http://java.sun.com/xml/ns/javaee"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
+        metadata-complete="true"
+        version="3.0">
 
     <context-param>
         <param-name>org.eclipse.jetty.servlet.MaxAge</param-name>


### PR DESCRIPTION
By default jetty sets it to url and cookie (http://www.eclipse.org/jetty/documentation/9.2.8.v20150217/session-management.html#session-tracking-modes)
Also, updated the xsd version used by the web xml files

Fixes #1185 and [this](https://groups.google.com/forum/#!topic/go-cd/xU8aPOYGBSs/discussion) issue reported on mailing lists.