### PR TITLE
Various changes to the agents API -

### DIFF
--- a/base/src/com/thoughtworks/go/util/TriState.java
+++ b/base/src/com/thoughtworks/go/util/TriState.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2015 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.util;
+
+// an object that represents a ruby like truthy
+public abstract class TriState {
+    public static TriState UNSET = new TriState() {
+        @Override
+        public boolean isFalse() {
+            return false;
+        }
+
+        @Override
+        public boolean isTrue() {
+            return false;
+        }
+    };
+
+    public static TriState TRUE = new TriState() {
+        @Override
+        public boolean isFalse() {
+            return false;
+        }
+
+        @Override
+        public boolean isTruthy() {
+            return true;
+        }
+    };
+
+    public static TriState FALSE = new TriState() {
+
+    };
+
+    private TriState() {
+
+    }
+
+    public boolean isTruthy() {
+        return false;
+    }
+
+    public boolean isFalsy() {
+        return !isTruthy();
+    }
+
+
+    public boolean isFalse() {
+        return true;
+    }
+
+    public boolean isTrue() {
+        return !isFalse();
+    }
+
+    public static TriState from(String booleanLike) {
+        if (booleanLike == null) {
+            return UNSET;
+        }
+        if (booleanLike.toLowerCase().equals("false")) {
+            return FALSE;
+        }
+        if (booleanLike.toLowerCase().equals("true")) {
+            return TRUE;
+        }
+        return UNSET;
+    }
+}

--- a/base/test/com/thoughtworks/go/util/TriStateTest.java
+++ b/base/test/com/thoughtworks/go/util/TriStateTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2015 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.util;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class TriStateTest {
+
+    @Test
+    public void testTrueShouldBeTruthy() throws Exception {
+        TriState triState = TriState.from("tRuE");
+        assertTrue(triState.isTrue());
+        assertTrue(triState.isTruthy());
+        assertFalse(triState.isFalsy());
+        assertFalse(triState.isFalse());
+    }
+
+    @Test
+    public void testFalseShouldBeTruthy() throws Exception {
+        TriState triState = TriState.from("FaLsE");
+        assertTrue(triState.isFalsy());
+        assertTrue(triState.isFalse());
+        assertFalse(triState.isTrue());
+        assertFalse(triState.isTruthy());
+    }
+
+
+    @Test
+    public void testUnsetShouldBeTruthy() throws Exception {
+        TriState triState = TriState.from(null);
+        assertTrue(triState.isFalsy());
+        assertFalse(triState.isFalse());
+        assertFalse(triState.isTrue());
+        assertFalse(triState.isTruthy());
+    }
+
+}

--- a/server/src/com/thoughtworks/go/config/GoConfigFileDao.java
+++ b/server/src/com/thoughtworks/go/config/GoConfigFileDao.java
@@ -26,6 +26,7 @@ import com.thoughtworks.go.metrics.domain.probes.ProbeType;
 import com.thoughtworks.go.metrics.service.MetricsProbeService;
 import com.thoughtworks.go.presentation.TriStateSelection;
 import com.thoughtworks.go.util.ExceptionUtils;
+import com.thoughtworks.go.util.TriState;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -123,12 +124,12 @@ public class GoConfigFileDao {
         }
     }
 
-    private static class UpdateAgentHostname implements UpdateConfigCommand, UserAware {
+    public static class UpdateAgentHostname implements UpdateConfigCommand, UserAware {
         private final String uuid;
         private final String hostname;
         private final String userName;
 
-        private UpdateAgentHostname(String uuid, String hostname, String userName) {
+        public UpdateAgentHostname(String uuid, String hostname, String userName) {
             this.uuid = uuid;
             this.hostname = hostname;
             this.userName = userName;
@@ -148,19 +149,6 @@ public class GoConfigFileDao {
 
     public void updateAgentIp(final String uuid, final String ipAddress, String userName) {
         updateConfig(new UpdateAgentIp(uuid, ipAddress, userName));
-    }
-
-    public void updateAgentAttributes(final String uuid, String userName, final String hostname, String resources) {
-        CompositeConfigCommand command = new CompositeConfigCommand();
-
-        if (hostname != null) {
-            command.addCommand(new UpdateAgentHostname(uuid, hostname, userName));
-        }
-        if (resources != null) {
-            command.addCommand(new UpdateResourcesCommand(uuid, new Resources(resources)));
-        }
-
-        updateConfig(command);
     }
 
     public CruiseConfig loadForEditing() {

--- a/server/src/com/thoughtworks/go/server/service/AgentConfigService.java
+++ b/server/src/com/thoughtworks/go/server/service/AgentConfigService.java
@@ -22,6 +22,8 @@ import com.thoughtworks.go.config.Agents;
 import com.thoughtworks.go.domain.AgentInstance;
 import com.thoughtworks.go.listener.AgentChangeListener;
 import com.thoughtworks.go.presentation.TriStateSelection;
+import com.thoughtworks.go.server.domain.AgentInstances;
+import com.thoughtworks.go.util.TriState;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -61,8 +63,8 @@ public class AgentConfigService {
         goConfigService.updateAgentIpByUuid(uuid, ipAdress, userName);
     }
 
-    public void updateAgentAttributes(String uuid, String userName, String hostname, String resources) {
-        goConfigService.updateAgentAttributes(uuid, userName, hostname, resources);
+    public void updateAgentAttributes(String uuid, String userName, String hostname, String resources, TriState enable, AgentInstances agentInstances) {
+        goConfigService.updateAgentAttributes(uuid, userName, hostname, resources, enable, agentInstances);
     }
 
     public void saveOrUpdateAgent(AgentInstance agentInstance) {

--- a/server/src/com/thoughtworks/go/server/service/AgentService.java
+++ b/server/src/com/thoughtworks/go/server/service/AgentService.java
@@ -38,6 +38,7 @@ import com.thoughtworks.go.serverhealth.HealthStateType;
 import com.thoughtworks.go.serverhealth.ServerHealthService;
 import com.thoughtworks.go.serverhealth.ServerHealthState;
 import com.thoughtworks.go.util.SystemEnvironment;
+import com.thoughtworks.go.util.TriState;
 import com.thoughtworks.go.utils.Timeout;
 import org.apache.log4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -167,7 +168,7 @@ public class AgentService {
         return true;
     }
 
-    public void updateAgentAttributes(Username username, HttpOperationResult result, String uuid, String newHostname, String resources) {
+    public void updateAgentAttributes(Username username, HttpOperationResult result, String uuid, String newHostname, String resources, TriState enable) {
         if (!hasOperatePermission(username, result)) {
             return;
         }
@@ -178,7 +179,7 @@ public class AgentService {
         }
 
         try {
-            agentConfigService.updateAgentAttributes(uuid, username.getUsername().toString(), newHostname, resources);
+            agentConfigService.updateAgentAttributes(uuid, username.getUsername().toString(), newHostname, resources, enable, agentInstances);
             result.ok(String.format("Updated agent with uuid %s.", uuid));
         } catch (Exception e) {
             if (e.getCause() instanceof GoConfigInvalidException) {
@@ -187,7 +188,6 @@ public class AgentService {
                 result.internalServerError("Updating agents failed: " + e.getMessage(), HealthStateType.general(HealthStateScope.GLOBAL));
             }
         }
-
     }
 
     public void enableAgents(Username username, OperationResult operationResult, List<String> uuids) {

--- a/server/webapp/WEB-INF/rails.new/app/controllers/api_v1/agents_controller.rb
+++ b/server/webapp/WEB-INF/rails.new/app/controllers/api_v1/agents_controller.rb
@@ -35,7 +35,7 @@ module ApiV1
                   else
                     params[:resources]
                   end
-      agent_service.updateAgentAttributes(current_user, result, params[:uuid], params[:hostname], resources)
+      agent_service.updateAgentAttributes(current_user, result, params[:uuid], params[:hostname], resources, TriState.from(params[:enabled].to_s))
 
       if result.isSuccess
         load_agent
@@ -43,31 +43,6 @@ module ApiV1
       else
         render_http_operation_result(result)
       end
-    end
-
-    def enable
-      result = HttpOperationResult.new
-      agent_service.enableAgents(current_user, result, [params[:uuid]])
-
-      if result.isSuccess
-        load_agent
-        render json_hal_v1: agent_presenter.to_hash(url_builder: self)
-      else
-        render_http_operation_result(result)
-      end
-    end
-
-    def disable
-      result = HttpOperationResult.new
-      agent_service.disableAgents(current_user, result, [params[:uuid]])
-
-      if result.isSuccess
-        load_agent
-        render json_hal_v1: agent_presenter.to_hash(url_builder: self)
-      else
-        render_http_operation_result(result)
-      end
-
     end
 
     def destroy

--- a/server/webapp/WEB-INF/rails.new/app/presenters/api_v1/agent_representer.rb
+++ b/server/webapp/WEB-INF/rails.new/app/presenters/api_v1/agent_representer.rb
@@ -22,14 +22,6 @@ module ApiV1
       opts[:url_builder].apiv1_agent_url(agent.getUuid())
     end
 
-    link :enable do |opts|
-      opts[:url_builder].enable_apiv1_agent_url(agent.getUuid())
-    end
-
-    link :disable do |opts|
-      opts[:url_builder].disable_apiv1_agent_url(agent.getUuid())
-    end
-
     link :doc do |opts|
       'http://www.go.cd/documentation/user/current/api/v1/agents.html'
     end
@@ -39,12 +31,12 @@ module ApiV1
     end
 
     property :getUuid, as: :uuid
-    property :getHostname, as: :agent_name
+    property :getHostname, as: :hostname
     property :getIpAddress, as: :ip_address
     property :isEnabled, as: :enabled
     property :getLocation, as: :sandbox
     property :get_status_for_display, as: :status
-    property :getOperatingSystem, as: :os
+    property :getOperatingSystem, as: :operating_system
     property :free_space, exec_context: :decorator
     property :getResources, as: :resources
     property :getEnvironments, as: :environments

--- a/server/webapp/WEB-INF/rails.new/config/routes.rb
+++ b/server/webapp/WEB-INF/rails.new/config/routes.rb
@@ -218,9 +218,8 @@ Go::Application.routes.draw do
 
   scope :api, as: :apiv1 do
     api_version(:module => 'ApiV1', header: {name: 'Accept', value: 'application/vnd.go.cd.v1+json'}) do
-      resources :agents, param: :uuid, except: [:new, :create, :edit] do
-        put :enable, on: :member
-        put :disable, on: :member
+      resources :agents, param: :uuid, except: [:new, :create, :edit, :update] do
+        patch :update, on: :member
       end
     end
   end

--- a/server/webapp/WEB-INF/rails.new/lib/java_imports.rb
+++ b/server/webapp/WEB-INF/rails.new/lib/java_imports.rb
@@ -158,6 +158,7 @@ module JavaImports
   java_import com.thoughtworks.go.util.SystemEnvironment unless defined? SystemEnvironment
   java_import com.thoughtworks.go.util.SystemUtil unless defined? SystemUtil
   java_import com.thoughtworks.go.util.TimeConverter unless defined? TimeConverter
+  java_import com.thoughtworks.go.util.TriState unless defined? TriState
   #java_import com.thoughtworks.go.domain.config.Admin unless defined? com.thoughtworks.go.domain.config.Admin
   java_import java.lang.System unless defined? System
   java_import java.util.HashMap unless defined? HashMap

--- a/server/webapp/WEB-INF/rails.new/spec/presenters/api_v1/agent_representer_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/presenters/api_v1/agent_representer_spec.rb
@@ -21,7 +21,7 @@ describe ApiV1::AgentRepresenter do
 
   it 'renders an agent with hal representation' do
     presenter   = ApiV1::AgentRepresenter.new(idle_agent(
-                                                hostname:         'Agent01',
+                                                hostname:         'agent01.example.com',
                                                 location:         '/var/lib/go-server',
                                                 uuid:             'some-uuid',
                                                 space:            10.gigabytes,
@@ -32,11 +32,9 @@ describe ApiV1::AgentRepresenter do
                                               ))
     actual_json = JSON.parse(presenter.to_json(url_builder: UrlBuilder.new))
 
-    expect(actual_json).to have_links(:self, :enable, :disable, :find, :doc)
+    expect(actual_json).to have_links(:self, :find, :doc)
     expect(actual_json).to have_link(:self).with_url('http://test.host/api/agents/some-uuid')
     expect(actual_json).to have_link(:find).with_url('http://test.host/api/agents/:uuid')
-    expect(actual_json).to have_link(:enable).with_url('http://test.host/api/agents/some-uuid/enable')
-    expect(actual_json).to have_link(:disable).with_url('http://test.host/api/agents/some-uuid/disable')
     expect(actual_json).to have_link(:doc).with_url('http://www.go.cd/documentation/user/current/api/v1/agents.html')
 
     actual_json.delete('_links')
@@ -45,16 +43,16 @@ describe ApiV1::AgentRepresenter do
 
   def agent_hash
     {
-      uuid:          'some-uuid',
-      agent_name:    'Agent01',
-      ip_address:    '127.0.0.1',
-      enabled:       true,
-      sandbox:       '/var/lib/go-server',
-      status:        'Idle',
-      os:            'Linux',
-      free_space:    10.gigabytes,
-      resources:     ['firefox', 'linux'],
-      environments:  ['load_test', 'uat']
+      uuid:             'some-uuid',
+      hostname:         'agent01.example.com',
+      ip_address:       '127.0.0.1',
+      enabled:          true,
+      sandbox:          '/var/lib/go-server',
+      status:           'Idle',
+      operating_system: 'Linux',
+      free_space:       10.gigabytes,
+      resources:        ['firefox', 'linux'],
+      environments:     ['load_test', 'uat']
     }.as_json
   end
 

--- a/server/webapp/WEB-INF/rails.new/spec/presenters/api_v1/agents_representer_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/presenters/api_v1/agents_representer_spec.rb
@@ -21,7 +21,7 @@ describe ApiV1::AgentsRepresenter do
 
   it 'renders all agents with hal representation' do
     presenter   = ApiV1::AgentsRepresenter.new([idle_agent(
-                                                  hostname:         'Agent01',
+                                                  hostname:         'agent01.example.com',
                                                   location:         '/var/lib/go-server',
                                                   uuid:             'some-uuid',
                                                   space:            10.gigabytes,
@@ -40,16 +40,16 @@ describe ApiV1::AgentsRepresenter do
 
   def agent_hash
     {
-      uuid:          'some-uuid',
-      agent_name:    'Agent01',
-      ip_address:    '127.0.0.1',
-      enabled:       true,
-      sandbox:       '/var/lib/go-server',
-      status:        'Idle',
-      os:            'Linux',
-      free_space:    10.gigabytes,
-      resources:     ['firefox', 'linux'],
-      environments:  ['load_test', 'uat']
+      uuid:             'some-uuid',
+      hostname:         'agent01.example.com',
+      ip_address:       '127.0.0.1',
+      enabled:          true,
+      sandbox:          '/var/lib/go-server',
+      status:           'Idle',
+      operating_system: 'Linux',
+      free_space:       10.gigabytes,
+      resources:        ['firefox', 'linux'],
+      environments:     ['load_test', 'uat']
     }.as_json
   end
 

--- a/server/webapp/WEB-INF/rails.new/spec/support/api_spec_helper.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/support/api_spec_helper.rb
@@ -15,7 +15,7 @@
 ##########################GO-LICENSE-END##################################
 
 module ApiSpecHelper
-  [:get, :post, :put, :delete, :head].each do |http_verb|
+  [:get, :post, :put, :delete, :head, :patch].each do |http_verb|
     class_eval(<<-EOS, __FILE__, __LINE__)
       def #{http_verb}_with_api_header(path, params={}, headers={})
         #{http_verb} path, params, {'Accept' => 'application/vnd.go.cd.v1+json'}.merge(headers)


### PR DESCRIPTION
* Use `PATCH` instead of `PUT` to update an agent properties.
* Fold an agent's `enable` and `disable` into the `update` call.
    When users do not specify a value for enabled,
    treat it as unset, and don't update the enabled flag (TriState)
* Rename some attributes
  * `agent_name` => `hostname`
  * `os` => `operating_system`