### PR TITLE
Logs are missing in console-log tab (when renaming a job that is currently running)

### DIFF
--- a/server/src/com/thoughtworks/go/server/controller/ArtifactsController.java
+++ b/server/src/com/thoughtworks/go/server/controller/ArtifactsController.java
@@ -249,6 +249,8 @@ public class ArtifactsController {
             return new ModelAndView(new ConsoleOutView(consoleOut.calculateNextStart(), consoleOut.output()));
         } catch (FileNotFoundException e) {
             return new ModelAndView(new ConsoleOutView(0, ""));
+        } catch (Exception e) {
+            return buildNotFound(pipelineName, counterOrLabel, stageName, stageCounter, buildName);
         }
     }
 

--- a/server/test/integration/com/thoughtworks/go/server/controller/ArtifactsControllerIntegrationTest.java
+++ b/server/test/integration/com/thoughtworks/go/server/controller/ArtifactsControllerIntegrationTest.java
@@ -191,7 +191,7 @@ public class ArtifactsControllerIntegrationTest {
         assertValidContentAndStatus(mav, SC_NOT_FOUND, "Job " + pipelineName + "/latest/stage/1/build2 not found.");
     }
 
-    //2779 
+    //2779
     @Test
     @Ignore
     public void shouldUpdateLastHeardTimeFromAgentForPut() throws Exception {
@@ -447,6 +447,18 @@ public class ArtifactsControllerIntegrationTest {
     }
 
     @Test
+    public void testConsoleOutShouldReturn404WhenJobIsNotFound() throws Exception {
+        prepareConsoleOut("");
+        Stage firstStage = pipeline.getFirstStage();
+        int startLineNumber = 0;
+        ModelAndView view = artifactsController.consoleout("snafu", "snafu", "snafu", "build", String.valueOf(firstStage.getCounter()), startLineNumber);
+
+        assertThat(view.getView().getContentType(), is(RESPONSE_CHARSET));
+        assertThat(view.getView(), is(instanceOf((ResponseCodeView.class))));
+        assertThat(((ResponseCodeView) view.getView()).getContent(), containsString("Job snafu/snafu/snafu/1/build not found."));
+    }
+
+    @Test
     public void shouldSaveChecksumFileInTheCruiseOutputFolder() throws Exception {
         File fooFile = createFile(artifactsRoot, "/tmp/foobar.html");
         FileUtils.writeStringToFile(fooFile, "FooBarBaz...");
@@ -456,7 +468,7 @@ public class ArtifactsControllerIntegrationTest {
         MockMultipartFile checksumMultipart = new MockMultipartFile("file_checksum", new FileInputStream(checksumFile));
         StubMultipartHttpServletRequest multipartRequest = new StubMultipartHttpServletRequest(request, artifactMultipart, checksumMultipart);
         postFileWithChecksum("baz/foobar.html", multipartRequest);
-        
+
         assertThat(file(artifactsRoot, "baz/foobar.html"), exists());
         File uploadedChecksumFile = file(artifactsRoot, "cruise-output/md5.checksum");
         assertThat(uploadedChecksumFile, exists());
@@ -472,7 +484,7 @@ public class ArtifactsControllerIntegrationTest {
         MockMultipartFile artifactMultipart = new MockMultipartFile("file", new FileInputStream(fooFile));
         MockMultipartFile checksumMultipart = new MockMultipartFile("file_checksum", new FileInputStream(checksumFile));
         StubMultipartHttpServletRequest multipartRequest = new StubMultipartHttpServletRequest(request, artifactMultipart, checksumMultipart);
-        
+
         postFileWithChecksum("baz/foobar.html", multipartRequest);
 
         assertThat(file(artifactsRoot, "baz/foobar.html"), exists());

--- a/server/webapp/WEB-INF/rails.new/app/assets/javascripts/build_output_observer.js
+++ b/server/webapp/WEB-INF/rails.new/app/assets/javascripts/build_output_observer.js
@@ -60,12 +60,19 @@ BuildOutputObserver.prototype = {
                 onSuccess: function(transport, next_start_as_json) {
                     if (next_start_as_json) {
                         _this.start_line_number = next_start_as_json[0];
-                        var build_output = transport.responseText;
-                        _this.is_output_empty = _this.chosen_update_of_live_output.call(_this, build_output);
+                        _this.is_output_empty = _this.chosen_update_of_live_output.call(_this, transport.responseText);
                     } else {
                         _this.is_output_empty = true;
                     }
+                },
+              onFailure: function(response){
+                if (404 === response.status){
+                  _this.is_output_empty = _this.chosen_update_of_live_output.call(_this, response.responseText);
+                } else {
+                  var message = "There was an error contacting the server. The HTTP status was " + response.status + ".";
+                  _this.is_output_empty = _this.chosen_update_of_live_output.call(_this, message);
                 }
+              }
             });
         }
     },


### PR DESCRIPTION
The controller was not handling a job not found and instead throwing a 500.
We now gracefully handle this error both on the server and on the browser and display a better error message.

Fixes #1221