### PR TITLE
#1223 - rake task to execute jasmine tests platform independently from both unix-based and windows machines

### DIFF
--- a/server/prepare_go_server_webapp.rake
+++ b/server/prepare_go_server_webapp.rake
@@ -182,6 +182,12 @@ task :precompile_assets do
   end
 end
 
+task :jasmine_tests do
+  cd rails_root do
+    sh_with_environment("#{ruby_executable} -S ./bin/rake jasmine:ci", {'RAILS_ENV' => 'test', 'REPORTERS' => 'console,junit', 'CLASSPATH' => classpath})
+  end
+end
+
 # inline partials
 RAILS_DIR = "rails.new"
 RAILS_ROOT = "target/webapp/WEB-INF/" + RAILS_DIR


### PR DESCRIPTION
Completely forgot that this needs to be run from windows machines as well. Task task should run from both linux and windows machine.