### PR TITLE
#1249 Refactor validateAllScmRevisionsAreSameWithinAFingerprint with linear complexity

### DIFF
--- a/server/src/com/thoughtworks/go/server/service/dd/DependencyFanInNode.java
+++ b/server/src/com/thoughtworks/go/server/service/dd/DependencyFanInNode.java
@@ -18,6 +18,7 @@ package com.thoughtworks.go.server.service.dd;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -36,7 +37,6 @@ import com.thoughtworks.go.server.domain.PipelineTimeline;
 import com.thoughtworks.go.server.service.NoCompatibleUpstreamRevisionsException;
 import com.thoughtworks.go.util.Pair;
 import org.apache.commons.collections.CollectionUtils;
-import org.apache.commons.collections.Predicate;
 import org.apache.log4j.Logger;
 
 import static com.thoughtworks.go.server.service.dd.DependencyFanInNode.RevisionAlteration.ALL_OPTIONS_EXHAUSTED;
@@ -180,19 +180,14 @@ public class DependencyFanInNode extends FanInNode {
         if (pIdScmPair == null) {
             return false;
         }
+        Map<FaninScmMaterial, PipelineTimelineEntry.Revision> versionsByMaterial = new HashMap<FaninScmMaterial, PipelineTimelineEntry.Revision>();
         List<FaninScmMaterial> scmMaterialList = pIdScmPair.last();
         for (final FaninScmMaterial scmMaterial : scmMaterialList) {
-            Collection<FaninScmMaterial> scmMaterialOfSameFingerprint = CollectionUtils.select(scmMaterialList, new Predicate() {
-                @Override
-                public boolean evaluate(Object o) {
-                    return scmMaterial.equals(o);
-                }
-            });
-
-            for (FaninScmMaterial faninScmMaterial : scmMaterialOfSameFingerprint) {
-                if (!faninScmMaterial.revision.equals(scmMaterial.revision)) {
-                    return false;
-                }
+            PipelineTimelineEntry.Revision revision = versionsByMaterial.get(scmMaterial);
+            if (revision == null) {
+                versionsByMaterial.put(scmMaterial, scmMaterial.revision);
+            } else if (!revision.equals(scmMaterial.revision)) {
+                return false;
             }
         }
         return true;


### PR DESCRIPTION
Normally we would do TDD on new features. However, as we didn't want to introduce a time based performance test, we decided to rely on regression testing with this change to ensure we haven't broken any existing functionality. We've been testing this patch with our local go-server for the past 2 weeks and have had no issues.

As a proof of concept, we used the following method placed within DependencyFanInNode.java
```
    public static void main(String[] args) {
        List<FaninScmMaterial> scmMaterials = new ArrayList<FaninScmMaterial>();
        for (int i = 0; i < 100000; i++) {
            scmMaterials.add(new FaninScmMaterial("a", new PipelineTimelineEntry.Revision(null, null, null, 1)));
        }
        Pair<StageIdentifier, List<FaninScmMaterial>> pair = new Pair<StageIdentifier, List<FaninScmMaterial>>(null, scmMaterials);

        long start = System.currentTimeMillis();
        validateAllScmRevisionsAreSameWithinAFingerprint(pair);
        long end = System.currentTimeMillis();

        long duration = end - start;
        System.out.println("Duration: " + duration + " millisec");
    }
```

Running this function on our machine before patching took: 120805 millisec
Running this function on our machine after patching took: 21 millisec

If you want to see more information about the issue, including yourkit analysis, please see #1249.

Let us know if you require any further information.

ctorpe [at] tyro.com
dmcniven [at] tyro.com