### PR TITLE
NA - fan-in debug url

### DIFF
--- a/server/src/com/thoughtworks/go/server/service/PipelineService.java
+++ b/server/src/com/thoughtworks/go/server/service/PipelineService.java
@@ -49,7 +49,6 @@ import java.util.Queue;
 
 @Service
 public class PipelineService implements UpstreamPipelineResolver {
-
     private static final Logger LOGGER = Logger.getLogger(PipelineService.class);
 
     private TransactionTemplate transactionTemplate;

--- a/server/src/com/thoughtworks/go/server/service/PipelineService.java
+++ b/server/src/com/thoughtworks/go/server/service/PipelineService.java
@@ -16,9 +16,13 @@
 
 package com.thoughtworks.go.server.service;
 
+import com.google.gson.ExclusionStrategy;
+import com.google.gson.FieldAttributes;
+import com.google.gson.GsonBuilder;
 import com.thoughtworks.go.config.CaseInsensitiveString;
 import com.thoughtworks.go.config.CruiseConfig;
 import com.thoughtworks.go.config.PipelineConfig;
+import com.thoughtworks.go.config.materials.Materials;
 import com.thoughtworks.go.config.materials.dependency.DependencyMaterial;
 import com.thoughtworks.go.domain.*;
 import com.thoughtworks.go.domain.buildcause.BuildCause;
@@ -28,6 +32,8 @@ import com.thoughtworks.go.server.dao.PipelineSqlMapDao;
 import com.thoughtworks.go.server.domain.PipelineConfigDependencyGraph;
 import com.thoughtworks.go.server.domain.PipelineTimeline;
 import com.thoughtworks.go.server.persistence.MaterialRepository;
+import com.thoughtworks.go.server.service.dd.DependencyFanInNode;
+import com.thoughtworks.go.server.service.dd.FanInEventListener;
 import com.thoughtworks.go.server.service.dd.FanInGraph;
 import com.thoughtworks.go.server.transaction.TransactionTemplate;
 import com.thoughtworks.go.util.SystemEnvironment;
@@ -230,6 +236,46 @@ public class PipelineService implements UpstreamPipelineResolver {
         final MaterialRevisions computedRevisions = fanInGraph.computeRevisions(actualRevisions, pipelineTimeline);
         fillUpNonOverridableRevisions(actualRevisions, computedRevisions);
         return restoreOriginalMaterialConfigAndMaterialOrderUsingFingerprint(actualRevisions, computedRevisions);
+    }
+
+    // This is for debugging purposes
+    public String getRevisionsBasedOnDependenciesForDebug(CaseInsensitiveString pipelineName, final Integer targetIterationCount) {
+        CruiseConfig cruiseConfig = goConfigService.getCurrentConfig();
+        FanInGraph fanInGraph = new FanInGraph(cruiseConfig, pipelineName, materialRepository, pipelineDao, systemEnvironment, materialConfigConverter);
+        final String[] iterationData = {null};
+        fanInGraph.setFanInEventListener(new FanInEventListener() {
+            @Override
+            public void iterationComplete(int iterationCount, List<DependencyFanInNode> dependencyFanInNodes) {
+                if (iterationCount == targetIterationCount) {
+                    iterationData[0] = new GsonBuilder().setExclusionStrategies(getGsonExclusionStrategy()).create().toJson(dependencyFanInNodes);
+                }
+            }
+        });
+        PipelineConfig pipelineConfig = goConfigService.pipelineConfigNamed(pipelineName);
+        Materials materials = materialConfigConverter.toMaterials(pipelineConfig.materialConfigs());
+        MaterialRevisions actualRevisions = new MaterialRevisions();
+        for (Material material : materials) {
+            actualRevisions.addAll(materialRepository.findLatestModification(material));
+        }
+        MaterialRevisions materialRevisions = fanInGraph.computeRevisions(actualRevisions, pipelineTimeline);
+        if (iterationData[0] == null) {
+            iterationData[0] = new GsonBuilder().setExclusionStrategies(getGsonExclusionStrategy()).create().toJson(materialRevisions);
+        }
+        return iterationData[0];
+    }
+
+    private ExclusionStrategy getGsonExclusionStrategy() {
+        return new ExclusionStrategy() {
+            @Override
+            public boolean shouldSkipField(FieldAttributes f) {
+                return f.getName().equals("materialConfig") || f.getName().equals("parents") || f.getName().equals("children");
+            }
+
+            @Override
+            public boolean shouldSkipClass(Class<?> clazz) {
+                return false;
+            }
+        };
     }
 
     //This whole method is repeated for reporting and it does not use actual revisions for determining final revisions

--- a/server/src/com/thoughtworks/go/server/service/dd/FanInEventListener.java
+++ b/server/src/com/thoughtworks/go/server/service/dd/FanInEventListener.java
@@ -1,0 +1,23 @@
+/*************************GO-LICENSE-START*********************************
+ * Copyright 2014 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *************************GO-LICENSE-END***********************************/
+
+package com.thoughtworks.go.server.service.dd;
+
+import java.util.List;
+
+public interface FanInEventListener {
+    void iterationComplete(int iterationCount, List<DependencyFanInNode> dependencyFanInNodes);
+}

--- a/server/src/com/thoughtworks/go/server/service/dd/FanInGraph.java
+++ b/server/src/com/thoughtworks/go/server/service/dd/FanInGraph.java
@@ -81,12 +81,12 @@ public class FanInGraph {
 
     private void buildGraph(PipelineConfig target) {
         nodes.add(this.root);
-        final HashSet<String> scmMaterials = new HashSet<String>();
+        final Set<String> scmMaterials = new HashSet<String>();
         buildRestOfTheGraph(this.root, target, scmMaterials);
         dependencyMaterialFingerprintMap.put((DependencyMaterialConfig) this.root.materialConfig, scmMaterials);
     }
 
-    private void buildRestOfTheGraph(DependencyFanInNode root, PipelineConfig target, HashSet<String> scmMaterialSet) {
+    private void buildRestOfTheGraph(DependencyFanInNode root, PipelineConfig target, Set<String> scmMaterialSet) {
         for (MaterialConfig material : target.materialConfigs()) {
             FanInNode node = createNode(material);
             root.children.add(node);
@@ -101,16 +101,15 @@ public class FanInGraph {
         }
     }
 
-    private void handleScmMaterial(HashSet<String> scmMaterialSet, MaterialConfig material) {
+    private void handleScmMaterial(Set<String> scmMaterialSet, MaterialConfig material) {
         final String fingerprint = material.getFingerprint();
         scmMaterialSet.add(fingerprint);
         fingerprintScmMaterialMap.put(fingerprint, material);
     }
 
-    private void handleDependencyMaterial(HashSet<String> scmMaterialSet, DependencyMaterialConfig depMaterial, DependencyFanInNode node) {
-        final HashSet<String> scmMaterialFingerprintSet = new HashSet<String>();
+    private void handleDependencyMaterial(Set<String> scmMaterialSet, DependencyMaterialConfig depMaterial, DependencyFanInNode node) {
+        final Set<String> scmMaterialFingerprintSet = new HashSet<String>();
         buildRestOfTheGraph(node, cruiseConfig.pipelineConfigByName(depMaterial.getPipelineName()), scmMaterialFingerprintSet);
-        scmMaterialFingerprintSet.addAll(scmMaterialFingerprintSet);
         dependencyMaterialFingerprintMap.put(depMaterial, scmMaterialFingerprintSet);
         scmMaterialSet.addAll(scmMaterialFingerprintSet);
     }
@@ -160,7 +159,6 @@ public class FanInGraph {
     }
 
     public MaterialRevisions computeRevisions(MaterialRevisions actualRevisions, PipelineTimeline pipelineTimeline) {
-
         assertAllDirectDependenciesArePresentInInput(actualRevisions, pipelineName);
 
         Pair<List<RootFanInNode>, List<DependencyFanInNode>> scmAndDepMaterialsChildren = getScmAndDepMaterialsChildren();

--- a/server/webapp/WEB-INF/rails.new/app/controllers/api/fanin_trace_controller.rb
+++ b/server/webapp/WEB-INF/rails.new/app/controllers/api/fanin_trace_controller.rb
@@ -20,13 +20,20 @@ class Api::FaninTraceController < Api::ApiController
     pipeline_name = params[:name]
     reporting_fanin_graph = ReportingFanInGraph.new(cruise_config, pipeline_name, pipeline_sql_map_dao)
     @str = reporting_fanin_graph.computeRevisions(pipeline_service.getPipelineTimeline())
-    render text: "<pre>" + @str + "</pre>"
+    render text: @str
+  end
+
+  def fanin_debug
+    pipeline_name = params[:name]
+    index = params[:index].to_i
+    data = pipeline_service.getRevisionsBasedOnDependenciesForDebug(CaseInsensitiveString.new(pipeline_name), index)
+    render json: data
   end
 
   def fanin
     cruise_config = go_config_service.getCurrentConfig()
     pipeline_name = params[:name]
-    output = "<pre>" + "\n"
+    output = ""
     revisions = pipeline_service.getRevisionsBasedOnDependenciesForReporting(cruise_config, CaseInsensitiveString.new(pipeline_name))
     render text: "No Fan-In" and return unless revisions
     revisions.each do |rev|
@@ -42,7 +49,7 @@ class Api::FaninTraceController < Api::ApiController
       end
       output = output + "---\n\n"
     end
-    output = output + "</pre>"
+    output = output
     render text: output
   end
 end

--- a/server/webapp/WEB-INF/rails.new/config/routes.rb
+++ b/server/webapp/WEB-INF/rails.new/config/routes.rb
@@ -286,6 +286,7 @@ Go::Application.routes.draw do
       defaults :format => 'text' do
         get 'support' => 'server#capture_support_info'
         get 'fanin_trace/:name' => 'fanin_trace#fanin_trace', constraints: {name: PIPELINE_NAME_FORMAT}
+        get 'fanin_debug/:name/(:index)' => 'fanin_trace#fanin_debug', constraints: {name: PIPELINE_NAME_FORMAT}, defaults: {:offset => '0'}
         get 'fanin/:name' => 'fanin_trace#fanin', constraints: {name: PIPELINE_NAME_FORMAT}
       end
 


### PR DESCRIPTION
Introduced route - `<go-server>/go/api/fanin_debug/<pipeline-name>/<iteration>` which provides JSON response containing all upstream dependencies with values of their SCM revisions pegged at selected iteration