### PR TITLE
When a resource is visible to users, but they cannot perform an action on it, render 401, instead of 404.

### DIFF
--- a/server/webapp/WEB-INF/rails.new/app/controllers/api/agents_controller.rb
+++ b/server/webapp/WEB-INF/rails.new/app/controllers/api/agents_controller.rb
@@ -16,9 +16,10 @@
 
 class Api::AgentsController < Api::ApiController
   include AgentBulkEditor
+  include ApiV1::AuthenticationHelper
 
-  before_action :check_user
-  before_action :check_admin_user, except: [:index, :show, :job_run_history]
+  before_action :check_user_and_404
+  before_action :check_admin_user_and_401, except: [:index, :show, :job_run_history]
 
   JobHistoryColumns = com.thoughtworks.go.server.service.JobInstanceService::JobHistoryColumns
 

--- a/server/webapp/WEB-INF/rails.new/app/controllers/api/api_controller.rb
+++ b/server/webapp/WEB-INF/rails.new/app/controllers/api/api_controller.rb
@@ -16,6 +16,4 @@
 
 class Api::ApiController < ApplicationController
   skip_before_filter :verify_authenticity_token
-
-  include ApiV1::AuthenticationHelper
 end

--- a/server/webapp/WEB-INF/rails.new/app/controllers/api_v1/agents_controller.rb
+++ b/server/webapp/WEB-INF/rails.new/app/controllers/api_v1/agents_controller.rb
@@ -17,8 +17,8 @@
 module ApiV1
   class AgentsController < ApiV1::BaseController
 
-    before_action :check_user
-    before_action :check_admin_user, except: [:index, :show]
+    before_action :check_user_and_404
+    before_action :check_admin_user_and_401, except: [:index, :show]
 
     before_action :load_agent, only: [:show, :edit, :update, :destroy, :enable, :disable]
 

--- a/server/webapp/WEB-INF/rails.new/app/helpers/api_v1/authentication_helper.rb
+++ b/server/webapp/WEB-INF/rails.new/app/helpers/api_v1/authentication_helper.rb
@@ -16,7 +16,7 @@
 
 module ApiV1
   module AuthenticationHelper
-    def check_user
+    def check_user_and_404
       return unless security_service.isSecurityEnabled()
       if current_user.try(:isAnonymous)
         Rails.logger.info("User '#{current_user.getUsername}' attempted to perform an unauthorized action!")
@@ -24,10 +24,10 @@ module ApiV1
       end
     end
 
-    def check_admin_user
+    def check_admin_user_and_401
       unless security_service.isUserAdmin(current_user)
         Rails.logger.info("User '#{current_user.getUsername}' attempted to perform an unauthorized action!")
-        render_not_found_error
+        render_unauthorized_error
       end
     end
 
@@ -39,6 +39,10 @@ module ApiV1
 
     def render_not_found_error
       render :json_hal_v1 => { :message => 'Either the resource you requested was not found, or you are not authorized to perform this action.' }, :status => 404
+    end
+
+    def render_unauthorized_error
+      render :json_hal_v1 => { :message => 'You are not authorized to perform this action.' }, :status => 401
     end
 
   end

--- a/server/webapp/WEB-INF/rails.new/spec/support/api_spec_helper.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/support/api_spec_helper.rb
@@ -73,6 +73,96 @@ class UrlBuilder
 end
 
 
+class ReachedControllerError < StandardError
+end
+
+RSpec::Matchers.define :allow_action do |verb, expected_action, params={}, headers={}|
+  match do |controller|
+    @reached_controller = false
+    controller.stub(expected_action).and_raise(ReachedControllerError)
+    begin
+      send("#{verb}_with_api_header", expected_action, params, headers)
+    rescue => ReachedControllerError
+      # ignore
+      @reached_controller = true
+    rescue => e
+      @reached_controller = false
+      @exception          = e
+    end
+
+    @reached_controller && !@exception
+  end
+
+  failure_message_for_should do |controller|
+    messages = []
+    if !@reached_controller
+      messages << "expected `#{controller}` to reach action #{verb.to_s.upcase} :#{expected_action.to_sym}, but did not."
+    end
+
+    if @exception
+      messages << "An exception was raised #{exception.message}."
+    end
+
+    messages.join("\n")
+  end
+end
+
+RSpec::Matchers.define :disallow_action do |verb, expected_action, params={}, headers={}|
+  chain :with do |expected_status, expected_message|
+    @status_matcher  = RSpec::Matchers::BuiltIn::Eq.new(expected_status)
+    @message_matcher = RSpec::Matchers::BuiltIn::Eq.new(expected_message)
+  end
+
+  match do |controller|
+    @reached_controller = false
+    controller.stub(expected_action).and_raise(ReachedControllerError)
+    begin
+      send("#{verb}_with_api_header", expected_action, params, headers)
+    rescue => ReachedControllerError
+      # ignore
+      @reached_controller = true
+    rescue => e
+      @reached_controller = false
+      @exception          = e
+    end
+
+    failed = @reached_controller || @exception
+
+    if @status_matcher && !@status_matcher.matches?(response.status)
+      failed = true
+      @failed_with_bad_status = true
+    end
+
+    if @message_matcher && !@message_matcher.matches?(JSON.parse(response.body)['message'])
+      failed = true
+      @failed_with_bad_message = true
+    end
+
+    !failed
+  end
+
+  failure_message_for_should do |controller|
+    messages = []
+    if @reached_controller
+      messages << "expected `#{controller}` to not reach action #{verb.to_s.upcase} :#{expected_action.to_sym}."
+    end
+
+    if @exception
+      messages << "An exception was raised #{exception.message}."
+    end
+
+    if @failed_with_bad_status
+      messages << @status_matcher.failure_message_for_should
+    end
+
+    if @failed_with_bad_message
+      messages << @message_matcher.failure_message_for_should
+    end
+
+    messages.join("\n")
+  end
+end
+
 RSpec::Matchers.define :have_api_message_response do |expected_status, expected_message|
 
   failure_message_for_should do |response|


### PR DESCRIPTION
Also migrate the tests to a nicer dsl to test security filters.