### PR TITLE
Serve assets with gzip (#1060)

### DIFF
--- a/jetty9/src/com/thoughtworks/go/server/AssetsContextHandler.java
+++ b/jetty9/src/com/thoughtworks/go/server/AssetsContextHandler.java
@@ -1,4 +1,4 @@
-/*************************GO-LICENSE-START*********************************
+/*
  * Copyright 2015 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,16 +12,17 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *************************GO-LICENSE-END***********************************/
+ *
+ */
 
 package com.thoughtworks.go.server;
 
 import com.thoughtworks.go.util.SystemEnvironment;
-import org.eclipse.jetty.server.HttpConnection;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.handler.AbstractHandler;
 import org.eclipse.jetty.server.handler.ContextHandler;
 import org.eclipse.jetty.server.handler.ResourceHandler;
+import org.eclipse.jetty.servlets.gzip.GzipHandler;
 import org.eclipse.jetty.webapp.WebAppContext;
 
 import javax.servlet.ServletException;
@@ -37,7 +38,11 @@ public class AssetsContextHandler extends ContextHandler {
         super(systemEnvironment.getWebappContextPath() + "/assets");
         this.systemEnvironment = systemEnvironment;
         handler = new AssetsHandler();
-        setHandler(handler);
+
+        GzipHandler gzipHandler = new GzipHandler();
+        gzipHandler.setMimeTypes("text/html,text/plain,text/xml,application/xhtml+xml,text/css,application/javascript,image/svg+xml,application/vnd.go.cd.v1+json,application/json");
+        gzipHandler.setHandler(handler);
+        setHandler(gzipHandler);
     }
 
     public void init(WebAppContext webAppContext) throws IOException {
@@ -55,6 +60,7 @@ public class AssetsContextHandler extends ContextHandler {
 
         private AssetsHandler() {
             resourceHandler.setCacheControl("max-age=31536000,public");
+            resourceHandler.setEtags(false);
         }
 
         public void handle(String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response) throws IOException, ServletException {

--- a/jetty9/test/unit/com/thoughtworks/go/server/AssetsContextHandlerTest.java
+++ b/jetty9/test/unit/com/thoughtworks/go/server/AssetsContextHandlerTest.java
@@ -1,4 +1,4 @@
-/*************************GO-LICENSE-START*********************************
+/*
  * Copyright 2015 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,8 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *************************GO-LICENSE-END***********************************/
+ *
+ */
 
 package com.thoughtworks.go.server;
 
@@ -20,6 +21,7 @@ import com.thoughtworks.go.util.OperatingSystem;
 import com.thoughtworks.go.util.ReflectionUtil;
 import com.thoughtworks.go.util.SystemEnvironment;
 import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.handler.HandlerWrapper;
 import org.eclipse.jetty.server.handler.ResourceHandler;
 import org.eclipse.jetty.util.resource.Resource;
 import org.eclipse.jetty.webapp.WebAppContext;
@@ -60,8 +62,8 @@ public class AssetsContextHandlerTest {
     @Test
     public void shouldSetHeadersAndBaseDirectory() throws IOException {
         assertThat(handler.getContextPath(), is("/go/assets"));
-        assertThat(handler.getHandler() instanceof AssetsContextHandler.AssetsHandler, is(true));
-        AssetsContextHandler.AssetsHandler assetsHandler = (AssetsContextHandler.AssetsHandler) handler.getHandler();
+        assertThat(((HandlerWrapper) handler.getHandler()).getHandler() instanceof AssetsContextHandler.AssetsHandler, is(true));
+        AssetsContextHandler.AssetsHandler assetsHandler = (AssetsContextHandler.AssetsHandler) ((HandlerWrapper) handler.getHandler()).getHandler();
         ResourceHandler resourceHandler = (ResourceHandler) ReflectionUtil.getField(assetsHandler, "resourceHandler");
         assertThat(resourceHandler.getCacheControl(), is("max-age=31536000,public"));
         assertThat(resourceHandler.getResourceBase(), isSameFileAs(new File("WEB-INF/rails.root/public/assets").toURI().toString()));
@@ -75,7 +77,7 @@ public class AssetsContextHandlerTest {
         HttpServletResponse response = mock(HttpServletResponse.class);
         Request baseRequest = mock(Request.class);
         ResourceHandler resourceHandler = mock(ResourceHandler.class);
-        ReflectionUtil.setField(handler.getHandler(), "resourceHandler", resourceHandler);
+        handler.setHandler(resourceHandler);
 
         handler.getHandler().handle(target, baseRequest, request, response);
         verify(resourceHandler).handle(target, baseRequest, request, response);
@@ -90,7 +92,7 @@ public class AssetsContextHandlerTest {
         HttpServletResponse response = mock(HttpServletResponse.class);
         Request baseRequest = mock(Request.class);
         ResourceHandler resourceHandler = mock(ResourceHandler.class);
-        ReflectionUtil.setField(handler.getHandler(), "resourceHandler", resourceHandler);
+        ReflectionUtil.setField(((HandlerWrapper) handler.getHandler()).getHandler(), "resourceHandler", resourceHandler);
 
         handler.getHandler().handle(target, baseRequest, request, response);
         verify(resourceHandler, never()).handle(any(String.class), any(Request.class), any(HttpServletRequest.class), any(HttpServletResponse.class));


### PR DESCRIPTION
Each of the top level assets is over 1MB each. This can take a long time
over a slow link. So send them using gzip compression when the client
requests it.

Jetty6 does not have an equivalent of jetty9's GzipHandler, so skip the
impl on jetty6.