### PR TITLE
15.3 - Improve perf logging

### DIFF
--- a/jetty6/src/com/thoughtworks/go/server/util/Jetty6Response.java
+++ b/jetty6/src/com/thoughtworks/go/server/util/Jetty6Response.java
@@ -18,6 +18,8 @@ package com.thoughtworks.go.server.util;
 
 import org.mortbay.jetty.Response;
 
+import javax.servlet.ServletResponseWrapper;
+
 public class Jetty6Response implements ServletResponse {
     private javax.servlet.ServletResponse servletResponse;
 
@@ -27,11 +29,19 @@ public class Jetty6Response implements ServletResponse {
 
     @Override
     public int getStatus() {
-        return ((Response) servletResponse).getStatus();
+        return response().getStatus();
     }
 
     @Override
     public long getContentCount() {
-        return ((Response) servletResponse).getContentCount();
+        return response().getContentCount();
+    }
+
+    /* Handle single-level of wrapping in response (usually for gzip filtered responses). */
+    private Response response() {
+        if (servletResponse instanceof ServletResponseWrapper) {
+            return (Response) ((ServletResponseWrapper) servletResponse).getResponse();
+        }
+        return (Response) servletResponse;
     }
 }

--- a/jetty6/test/unit/com/thoughtworks/go/server/util/Jetty6ResponseTest.java
+++ b/jetty6/test/unit/com/thoughtworks/go/server/util/Jetty6ResponseTest.java
@@ -20,6 +20,8 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mortbay.jetty.Response;
 
+import javax.servlet.ServletResponseWrapper;
+
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.mock;
@@ -44,6 +46,15 @@ public class Jetty6ResponseTest {
     @Test
     public void shouldGetResponseContentCount() {
         when(response.getContentCount()).thenReturn(2000l);
+        assertThat(jetty6Response.getContentCount(), is(2000l));
+    }
+
+    @Test
+    public void shouldHandleWrappedResponse() throws Exception {
+        ServletResponseWrapper wrappedResponse = mock(ServletResponseWrapper.class);
+        when(wrappedResponse.getResponse()).thenReturn(response);
+        when(response.getContentCount()).thenReturn(2000l);
+
         assertThat(jetty6Response.getContentCount(), is(2000l));
     }
 }

--- a/jetty9/src/com/thoughtworks/go/server/util/Jetty9Response.java
+++ b/jetty9/src/com/thoughtworks/go/server/util/Jetty9Response.java
@@ -18,21 +18,30 @@ package com.thoughtworks.go.server.util;
 
 import org.eclipse.jetty.server.Response;
 
+import javax.servlet.ServletResponseWrapper;
+
 public class Jetty9Response implements ServletResponse {
     private javax.servlet.ServletResponse servletResponse;
 
     public Jetty9Response(javax.servlet.ServletResponse servletResponse) {
-
         this.servletResponse = servletResponse;
     }
 
     @Override
     public int getStatus() {
-        return ((Response) servletResponse).getStatus();
+        return response().getStatus();
     }
 
     @Override
     public long getContentCount() {
-        return ((Response) servletResponse).getContentCount();
+        return response().getContentCount();
+    }
+
+    /* Handle single-level of wrapping in response (usually for gzip filtered responses). */
+    private Response response() {
+        if (servletResponse instanceof ServletResponseWrapper) {
+            return (Response) ((ServletResponseWrapper) servletResponse).getResponse();
+        }
+        return (Response) servletResponse;
     }
 }

--- a/jetty9/test/unit/com/thoughtworks/go/server/util/Jetty9ResponseTest.java
+++ b/jetty9/test/unit/com/thoughtworks/go/server/util/Jetty9ResponseTest.java
@@ -20,8 +20,10 @@ import org.eclipse.jetty.server.Response;
 import org.junit.Before;
 import org.junit.Test;
 
+import javax.servlet.ServletResponseWrapper;
+
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -44,6 +46,15 @@ public class Jetty9ResponseTest {
     @Test
     public void shouldGetResponseContentCount() {
         when(response.getContentCount()).thenReturn(2000l);
+        assertThat(jetty9Response.getContentCount(), is(2000l));
+    }
+
+    @Test
+    public void shouldHandleWrappedResponse() throws Exception {
+        ServletResponseWrapper wrappedResponse = mock(ServletResponseWrapper.class);
+        when(wrappedResponse.getResponse()).thenReturn(response);
+        when(response.getContentCount()).thenReturn(2000l);
+
         assertThat(jetty9Response.getContentCount(), is(2000l));
     }
 }

--- a/server/src/com/thoughtworks/go/server/perf/AgentCommunicationPerformanceLogger.java
+++ b/server/src/com/thoughtworks/go/server/perf/AgentCommunicationPerformanceLogger.java
@@ -1,0 +1,27 @@
+package com.thoughtworks.go.server.perf;
+
+import com.thoughtworks.go.domain.JobIdentifier;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class AgentCommunicationPerformanceLogger {
+    private PerformanceLogger performanceLogger;
+
+    @Autowired
+    public AgentCommunicationPerformanceLogger(PerformanceLogger performanceLogger) {
+        this.performanceLogger = performanceLogger;
+    }
+
+    public void logPing(String agentUUID, long startTime, long endTime) {
+        performanceLogger.log("AGENT-PING {} {} {}", agentUUID, startTime, endTime);
+    }
+
+    public void logReporting(String agentUUID, JobIdentifier jobIdentifier, String thingBeingReported, long startTime, long endTime) {
+        performanceLogger.log("AGENT-REPORT {} {} {} {} {} {}", agentUUID, thingBeingReported, startTime, endTime, jobIdentifier);
+    }
+
+    public void logIsIgnoredCheck(JobIdentifier jobIdentifier, long startTime, long endTime) {
+        performanceLogger.log("AGENT-IGN-CHECK {} {} {}", startTime, endTime, jobIdentifier);
+    }
+}

--- a/server/src/com/thoughtworks/go/server/perf/PerformanceLogger.java
+++ b/server/src/com/thoughtworks/go/server/perf/PerformanceLogger.java
@@ -23,9 +23,18 @@ import org.springframework.stereotype.Component;
 @Component
 public class PerformanceLogger {
     private static final Logger LOGGER = LoggerFactory.getLogger("PerformanceLogger");
+    private final boolean isDebuggingTurnedOn;
+
+    public PerformanceLogger() {
+        isDebuggingTurnedOn = LOGGER.isDebugEnabled();
+    }
 
     public void log(String format, Object... arguments) {
         LOGGER.debug(format, arguments);
+    }
+
+    public boolean isLoggingTurnedOn() {
+        return isDebuggingTurnedOn;
     }
 }
 

--- a/server/src/com/thoughtworks/go/server/perf/PerformanceLogger.java
+++ b/server/src/com/thoughtworks/go/server/perf/PerformanceLogger.java
@@ -46,5 +46,5 @@ log4j.appender.PerformanceLoggerAppender.File=go-perf.log
 log4j.appender.PerformanceLoggerAppender.MaxFileSize=10240KB
 log4j.appender.PerformanceLoggerAppender.MaxBackupIndex=50
 log4j.appender.PerformanceLoggerAppender.layout=org.apache.log4j.PatternLayout
-log4j.appender.PerformanceLoggerAppender.layout.conversionPattern=%d{ISO8601} |%t| %m%n
+log4j.appender.PerformanceLoggerAppender.layout.conversionPattern=%d{yyyy-MM-dd HH:mm:ss,SSSZ} |%t| %m%n
 */

--- a/server/src/com/thoughtworks/go/server/perf/SchedulingPerformanceLogger.java
+++ b/server/src/com/thoughtworks/go/server/perf/SchedulingPerformanceLogger.java
@@ -79,7 +79,7 @@ public class SchedulingPerformanceLogger {
         performanceLogger.log("SCH-TO-BE-SCHEDULED-QUEUE-PUT {} {}", trackingId, pipelineName);
     }
 
-    public void scheduledPipeline(String pipelineName, int toBeScheduledQueueSize, long schedulePipelineStartTime, long schedulePipelineEndTime) {
-        performanceLogger.log("SCH-SCHEDULED {} {} {} {}", pipelineName, toBeScheduledQueueSize, schedulePipelineStartTime, schedulePipelineEndTime);
+    public void scheduledPipeline(Long trackingId, String pipelineName, int toBeScheduledQueueSize, long schedulePipelineStartTime, long schedulePipelineEndTime) {
+        performanceLogger.log("SCH-SCHEDULED {} {} {} {} {}", trackingId, pipelineName, toBeScheduledQueueSize, schedulePipelineStartTime, schedulePipelineEndTime);
     }
 }

--- a/server/src/com/thoughtworks/go/server/perf/WebRequestPerformanceLogger.java
+++ b/server/src/com/thoughtworks/go/server/perf/WebRequestPerformanceLogger.java
@@ -5,14 +5,20 @@ import org.springframework.stereotype.Component;
 
 @Component
 public class WebRequestPerformanceLogger {
+    private final boolean shouldLog;
     private PerformanceLogger performanceLogger;
 
     @Autowired
     public WebRequestPerformanceLogger(PerformanceLogger performanceLogger) {
         this.performanceLogger = performanceLogger;
+        this.shouldLog = performanceLogger.isLoggingTurnedOn();
     }
 
-    public void logRequest(String uri, String requestor, int status, long contentCount, long amountOfTimeItTookInMilliseconds) {
-        performanceLogger.log("WEB-REQUEST {} {} {} {} {}", status, uri, requestor, contentCount, amountOfTimeItTookInMilliseconds);
+    public void logRequest(String uri, String requestor, int status, long contentCount, long requestStartTime, long requestEndTime) {
+        performanceLogger.log("WEB-REQUEST {} {} {} {} {} {}", status, uri, requestor, contentCount, requestStartTime, requestEndTime);
+    }
+
+    public boolean isLoggingTurnedOn() {
+        return shouldLog;
     }
 }

--- a/server/src/com/thoughtworks/go/server/perf/WebRequestPerformanceLogger.java
+++ b/server/src/com/thoughtworks/go/server/perf/WebRequestPerformanceLogger.java
@@ -5,13 +5,11 @@ import org.springframework.stereotype.Component;
 
 @Component
 public class WebRequestPerformanceLogger {
-    private final boolean shouldLog;
     private PerformanceLogger performanceLogger;
 
     @Autowired
     public WebRequestPerformanceLogger(PerformanceLogger performanceLogger) {
         this.performanceLogger = performanceLogger;
-        this.shouldLog = performanceLogger.isLoggingTurnedOn();
     }
 
     public void logRequest(String uri, String requestor, int status, long contentCount, long requestStartTime, long requestEndTime) {
@@ -19,6 +17,6 @@ public class WebRequestPerformanceLogger {
     }
 
     public boolean isLoggingTurnedOn() {
-        return shouldLog;
+        return performanceLogger.isLoggingTurnedOn();
     }
 }

--- a/server/src/com/thoughtworks/go/server/perf/WorkAssignmentPerformanceLogger.java
+++ b/server/src/com/thoughtworks/go/server/perf/WorkAssignmentPerformanceLogger.java
@@ -35,16 +35,16 @@ public class WorkAssignmentPerformanceLogger {
 
     public void retrievedWorkForAgent(AgentRuntimeInfo agentRuntimeInfo, Work work, long retrieveWorkStartTime, long retrieveWorkEndTime) {
         if (work == null || !(work instanceof BuildWork)) {
-            performanceLogger.log("WORK-NOWORK {} {} {}", agentRuntimeInfo.getIdentifier().getUuid(), retrieveWorkStartTime, retrieveWorkEndTime);
+            performanceLogger.log("WORK-NOWORK {} {} {} {}", agentRuntimeInfo.getUUId(), retrieveWorkStartTime, retrieveWorkEndTime, "NOJOB");
             return;
         }
         BuildWork buildWork = (BuildWork) work;
 
-        performanceLogger.log("WORK-RETRIEVED {} {} {} {}", agentRuntimeInfo.getIdentifier().getUuid(), buildWork.identifierForLogging(), retrieveWorkStartTime, retrieveWorkEndTime);
+        performanceLogger.log("WORK-RETRIEVED {} {} {} {}", agentRuntimeInfo.getUUId(), retrieveWorkStartTime, retrieveWorkEndTime, buildWork.identifierForLogging());
     }
 
     public void agentReportedCompletion(AgentRuntimeInfo agentRuntimeInfo, JobIdentifier jobIdentifier, long reportCompletionStartTime, long reportCompletionEndTime) {
-        performanceLogger.log("WORK-COMPLETED {} {} {} {}", agentRuntimeInfo.getIdentifier().getUuid(), jobIdentifier, reportCompletionStartTime, reportCompletionEndTime);
+        performanceLogger.log("WORK-COMPLETED {} {} {} {}", agentRuntimeInfo.getUUId(), reportCompletionStartTime, reportCompletionEndTime, jobIdentifier);
     }
 
     public void assignedWorkToAgent(Work work, AgentIdentifier agentIdentifier, long assignWorkStartTime, long assignWorkEndTime) {
@@ -53,6 +53,6 @@ public class WorkAssignmentPerformanceLogger {
         }
         BuildWork buildWork = (BuildWork) work;
 
-        performanceLogger.log("WORK-ASSIGNED {} {} {} {}", agentIdentifier.getUuid(), buildWork.identifierForLogging(), assignWorkStartTime, assignWorkEndTime);
+        performanceLogger.log("WORK-ASSIGNED {} {} {} {}", agentIdentifier.getUuid(), assignWorkStartTime, assignWorkEndTime, buildWork.identifierForLogging());
     }
 }

--- a/server/src/com/thoughtworks/go/server/scheduling/BuildCauseProducerService.java
+++ b/server/src/com/thoughtworks/go/server/scheduling/BuildCauseProducerService.java
@@ -29,27 +29,10 @@ import com.thoughtworks.go.domain.buildcause.BuildCause;
 import com.thoughtworks.go.domain.materials.Material;
 import com.thoughtworks.go.domain.materials.MaterialConfig;
 import com.thoughtworks.go.server.domain.Username;
-import com.thoughtworks.go.server.materials.MaterialChecker;
-import com.thoughtworks.go.server.materials.MaterialUpdateCompletedMessage;
-import com.thoughtworks.go.server.materials.MaterialUpdateFailedMessage;
-import com.thoughtworks.go.server.materials.MaterialUpdateService;
-import com.thoughtworks.go.server.materials.MaterialUpdateStatusListener;
-import com.thoughtworks.go.server.materials.MaterialUpdateStatusNotifier;
-import com.thoughtworks.go.server.materials.SpecificMaterialRevisionFactory;
+import com.thoughtworks.go.server.materials.*;
 import com.thoughtworks.go.server.perf.SchedulingPerformanceLogger;
 import com.thoughtworks.go.server.persistence.MaterialRepository;
-import com.thoughtworks.go.server.service.AutoBuild;
-import com.thoughtworks.go.server.service.BuildType;
-import com.thoughtworks.go.server.service.GoConfigService;
-import com.thoughtworks.go.server.service.ManualBuild;
 import com.thoughtworks.go.server.service.*;
-import com.thoughtworks.go.server.service.MaterialExpansionService;
-import com.thoughtworks.go.server.service.NoCompatibleUpstreamRevisionsException;
-import com.thoughtworks.go.server.service.NoModificationsPresentForDependentMaterialException;
-import com.thoughtworks.go.server.service.PipelineScheduleQueue;
-import com.thoughtworks.go.server.service.PipelineService;
-import com.thoughtworks.go.server.service.SchedulingCheckerService;
-import com.thoughtworks.go.server.service.TimedBuild;
 import com.thoughtworks.go.server.service.result.OperationResult;
 import com.thoughtworks.go.server.service.result.ServerHealthStateOperationResult;
 import com.thoughtworks.go.serverhealth.HealthStateScope;
@@ -60,6 +43,9 @@ import com.thoughtworks.go.util.SystemEnvironment;
 import org.apache.log4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+
+import java.util.HashMap;
+import java.util.concurrent.ConcurrentHashMap;
 
 import static java.lang.String.format;
 
@@ -212,7 +198,7 @@ public class BuildCauseProducerService {
                 buildCause.addOverriddenVariables(scheduleOptions.getVariables());
                 updateChangedRevisions(pipelineConfig.name(), buildCause);
                 if (materialConfigurationChanged || buildType.isValidBuildCause(pipelineConfig, buildCause)) {
-                    pipelineScheduleQueue.schedule(pipelineName, buildCause);
+                    pipelineScheduleQueue.schedule(pipelineName, buildCause, trackingId);
 
                     schedulingPerformanceLogger.sendingPipelineToTheToBeScheduledQueue(trackingId, pipelineName);
                     if (LOGGER.isDebugEnabled()) {

--- a/server/src/com/thoughtworks/go/server/security/PerformanceLoggingFilter.java
+++ b/server/src/com/thoughtworks/go/server/security/PerformanceLoggingFilter.java
@@ -31,7 +31,7 @@ import java.io.IOException;
 public class PerformanceLoggingFilter implements Filter {
     private static final Log LOGGER = LogFactory.getLog(PerformanceLoggingFilter.class);
     private final boolean usingJetty9;
-    private boolean logRequestTimings;
+    private final boolean logRequestTimings;
     private WebRequestPerformanceLogger webRequestPerformanceLogger;
 
     public PerformanceLoggingFilter(WebRequestPerformanceLogger webRequestPerformanceLogger) {
@@ -45,12 +45,12 @@ public class PerformanceLoggingFilter implements Filter {
     }
 
     public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain) throws IOException, ServletException {
-        long start = System.currentTimeMillis();
+        long startTime = System.currentTimeMillis();
         try {
             filterChain.doFilter(servletRequest, servletResponse);
         } finally {
-            if (logRequestTimings) {
-                long amountOfTimeItTookInMilliseconds = System.currentTimeMillis() - start;
+            if (webRequestPerformanceLogger.isLoggingTurnedOn()) {
+                long endTime = System.currentTimeMillis();
                 String requestURI = ((HttpServletRequest) servletRequest).getRequestURI();
                 String requestor = servletRequest.getRemoteAddr();
 
@@ -58,8 +58,7 @@ public class PerformanceLoggingFilter implements Filter {
                 int status = response.getStatus();
                 long contentCount = response.getContentCount();
 
-                webRequestPerformanceLogger.logRequest(requestURI, requestor, status, contentCount, amountOfTimeItTookInMilliseconds);
-                LOGGER.warn(requestURI + " took: " + amountOfTimeItTookInMilliseconds + " ms");
+                webRequestPerformanceLogger.logRequest(requestURI, requestor, status, contentCount, startTime, endTime);
             }
         }
     }

--- a/server/test/integration/com/thoughtworks/go/server/scheduling/ScheduleHelper.java
+++ b/server/test/integration/com/thoughtworks/go/server/scheduling/ScheduleHelper.java
@@ -34,6 +34,7 @@ import com.thoughtworks.go.server.service.*;
 import com.thoughtworks.go.server.service.result.ServerHealthStateOperationResult;
 import com.thoughtworks.go.server.transaction.TransactionTemplate;
 import com.thoughtworks.go.serverhealth.ServerHealthState;
+import com.thoughtworks.go.util.Pair;
 import com.thoughtworks.go.util.TimeProvider;
 import com.thoughtworks.go.utils.Timeout;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -112,9 +113,9 @@ public class ScheduleHelper {
         return result.getServerHealthState();
     }
 
-    public Map<String, BuildCause> waitForAnyScheduled(int seconds) {
+    public Map<String, Pair<Long, BuildCause>> waitForAnyScheduled(int seconds) {
         int count = 0;
-        Map<String, BuildCause> afterLoad = pipelineScheduleQueue.toBeScheduled();
+        Map<String, Pair<Long, BuildCause>> afterLoad = pipelineScheduleQueue.toBeScheduled();
         while (afterLoad.isEmpty()) {
             try {
                 Thread.sleep(1000);

--- a/server/test/integration/com/thoughtworks/go/server/service/BuildCauseProducerServiceIntegrationHgTest.java
+++ b/server/test/integration/com/thoughtworks/go/server/service/BuildCauseProducerServiceIntegrationHgTest.java
@@ -16,11 +16,6 @@
 
 package com.thoughtworks.go.server.service;
 
-import java.io.File;
-import java.sql.SQLException;
-import java.util.List;
-import java.util.Map;
-
 import com.thoughtworks.go.config.GoConfigFileDao;
 import com.thoughtworks.go.config.PipelineConfig;
 import com.thoughtworks.go.config.materials.Filter;
@@ -33,12 +28,12 @@ import com.thoughtworks.go.domain.buildcause.BuildCause;
 import com.thoughtworks.go.domain.materials.Modification;
 import com.thoughtworks.go.domain.materials.svn.Subversion;
 import com.thoughtworks.go.helper.*;
-import com.thoughtworks.go.helper.PipelineMother;
 import com.thoughtworks.go.server.dao.DatabaseAccessHelper;
 import com.thoughtworks.go.server.dao.PipelineDao;
 import com.thoughtworks.go.server.scheduling.ScheduleHelper;
-import com.thoughtworks.go.util.GoConfigFileHelper;
 import com.thoughtworks.go.util.FileUtil;
+import com.thoughtworks.go.util.GoConfigFileHelper;
+import com.thoughtworks.go.util.Pair;
 import com.thoughtworks.go.util.TestFileUtil;
 import com.thoughtworks.go.util.command.InMemoryStreamConsumer;
 import org.apache.commons.io.FileUtils;
@@ -49,6 +44,11 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import java.io.File;
+import java.sql.SQLException;
+import java.util.List;
+import java.util.Map;
 
 import static com.thoughtworks.go.util.command.ProcessOutputStreamConsumer.inMemoryConsumer;
 import static org.hamcrest.core.Is.is;
@@ -118,11 +118,11 @@ public class BuildCauseProducerServiceIntegrationHgTest {
                 "helper/topics/upgrading_go.xml",
                 "helper/topics/whats_new_in_go.xml");
 
-        Map<String, BuildCause> beforeLoad = pipelineScheduleQueue.toBeScheduled();
+        Map<String, Pair<Long, BuildCause>> beforeLoad = pipelineScheduleQueue.toBeScheduled();
 
         scheduleHelper.autoSchedulePipelinesWithRealMaterials();
 
-        Map<String, BuildCause> afterLoad = pipelineScheduleQueue.toBeScheduled();
+        Map<String, Pair<Long, BuildCause>> afterLoad = pipelineScheduleQueue.toBeScheduled();
         assertThat(afterLoad.size(), is(beforeLoad.size()));
 
     }

--- a/server/test/integration/com/thoughtworks/go/server/service/BuildCauseProducerServiceIntegrationSvnTest.java
+++ b/server/test/integration/com/thoughtworks/go/server/service/BuildCauseProducerServiceIntegrationSvnTest.java
@@ -16,9 +16,6 @@
 
 package com.thoughtworks.go.server.service;
 
-import java.io.File;
-import java.sql.SQLException;
-
 import com.thoughtworks.go.config.CaseInsensitiveString;
 import com.thoughtworks.go.config.GoConfigFileDao;
 import com.thoughtworks.go.config.PipelineConfig;
@@ -30,17 +27,13 @@ import com.thoughtworks.go.domain.Pipeline;
 import com.thoughtworks.go.domain.buildcause.BuildCause;
 import com.thoughtworks.go.domain.materials.Material;
 import com.thoughtworks.go.domain.materials.svn.Subversion;
-import com.thoughtworks.go.helper.MaterialsMother;
-import com.thoughtworks.go.helper.PipelineMother;
-import com.thoughtworks.go.helper.SvnTestRepo;
-import com.thoughtworks.go.helper.SvnTestRepoWithExternal;
-import com.thoughtworks.go.helper.TestRepo;
+import com.thoughtworks.go.helper.*;
 import com.thoughtworks.go.server.dao.DatabaseAccessHelper;
 import com.thoughtworks.go.server.materials.MaterialDatabaseUpdater;
 import com.thoughtworks.go.server.scheduling.BuildCauseProducerService;
 import com.thoughtworks.go.server.service.result.ServerHealthStateOperationResult;
-import com.thoughtworks.go.util.GoConfigFileHelper;
 import com.thoughtworks.go.util.FileUtil;
+import com.thoughtworks.go.util.GoConfigFileHelper;
 import com.thoughtworks.go.util.TestFileUtil;
 import org.apache.commons.io.FileUtils;
 import org.junit.After;
@@ -50,6 +43,9 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import java.io.File;
+import java.sql.SQLException;
 
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
@@ -119,7 +115,7 @@ public class BuildCauseProducerServiceIntegrationSvnTest {
 
         assertThat(result.canContinue(), is(true));
 
-        BuildCause mingleBuildCause = pipelineScheduleQueue.toBeScheduled().get(CaseInsensitiveString.str(mingleConfig.name()));
+        BuildCause mingleBuildCause = pipelineScheduleQueue.toBeScheduled().get(CaseInsensitiveString.str(mingleConfig.name())).last();
 
         MaterialRevisions materialRevisions = mingleBuildCause.getMaterialRevisions();
         assertThat(materialRevisions.getRevisions().size(), is(1));
@@ -142,7 +138,7 @@ public class BuildCauseProducerServiceIntegrationSvnTest {
 
         assertThat(result.canContinue(), is(true));
 
-        BuildCause mingleBuildCause = pipelineScheduleQueue.toBeScheduled().get(CaseInsensitiveString.str(mingleConfig.name()));
+        BuildCause mingleBuildCause = pipelineScheduleQueue.toBeScheduled().get(CaseInsensitiveString.str(mingleConfig.name())).last();
 
         MaterialRevisions materialRevisions = mingleBuildCause.getMaterialRevisions();
         assertThat(materialRevisions.getRevisions().size(), is(2));

--- a/server/test/integration/com/thoughtworks/go/server/service/BuildCauseProducerServiceIntegrationTimerTest.java
+++ b/server/test/integration/com/thoughtworks/go/server/service/BuildCauseProducerServiceIntegrationTimerTest.java
@@ -16,8 +16,6 @@
 
 package com.thoughtworks.go.server.service;
 
-import java.util.Date;
-
 import com.rits.cloning.Cloner;
 import com.thoughtworks.go.config.GoConfigFileDao;
 import com.thoughtworks.go.config.materials.git.GitMaterial;
@@ -46,6 +44,8 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import java.util.Date;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
@@ -112,7 +112,7 @@ public class BuildCauseProducerServiceIntegrationTimerTest {
         buildCauseProducerService.timerSchedulePipeline(p1.config, new ServerHealthStateOperationResult());
 
         assertThat(piplineScheduleQueue.toBeScheduled().size(), is(1));
-        assertThat(piplineScheduleQueue.toBeScheduled().get(pipelineName).getMaterialRevisions(), isSameMaterialRevisionsAs(u.mrs(u.mr(git1, false, "g12"))));
+        assertThat(piplineScheduleQueue.toBeScheduled().get(pipelineName).last().getMaterialRevisions(), isSameMaterialRevisionsAs(u.mrs(u.mr(git1, false, "g12"))));
     }
 
     @Test
@@ -132,9 +132,9 @@ public class BuildCauseProducerServiceIntegrationTimerTest {
         buildCauseProducerService.timerSchedulePipeline(p1.config, new ServerHealthStateOperationResult());
 
         assertThat(piplineScheduleQueue.toBeScheduled().size(), is(1));
-        assertThat(piplineScheduleQueue.toBeScheduled().get(pipelineName).getMaterialRevisions(), isSameMaterialRevisionsAs(u.mrs(u.mr(git1, true, "g11"), u.mr(up1, true, up1_1))));
+        assertThat(piplineScheduleQueue.toBeScheduled().get(pipelineName).last().getMaterialRevisions(), isSameMaterialRevisionsAs(u.mrs(u.mr(git1, true, "g11"), u.mr(up1, true, up1_1))));
 
-        BuildCause buildCause = piplineScheduleQueue.toBeScheduled().get(pipelineName);
+        BuildCause buildCause = piplineScheduleQueue.toBeScheduled().get(pipelineName).last();
         String up1_2 = u.runAndPassWithGivenMDUTimestampAndRevisionStrings(up1, u.d(i++), "g11");
         piplineScheduleQueue.finishSchedule(pipelineName, buildCause, buildCause);
 
@@ -142,7 +142,7 @@ public class BuildCauseProducerServiceIntegrationTimerTest {
         buildCauseProducerService.timerSchedulePipeline(p1.config, new ServerHealthStateOperationResult());
 
         assertThat(piplineScheduleQueue.toBeScheduled().size(), is(1));
-        assertThat(piplineScheduleQueue.toBeScheduled().get(pipelineName).getMaterialRevisions(), is(u.mrs(u.mr(git1, false, "g11"), u.mr(up1, false, up1_2))));
+        assertThat(piplineScheduleQueue.toBeScheduled().get(pipelineName).last().getMaterialRevisions(), is(u.mrs(u.mr(git1, false, "g11"), u.mr(up1, false, up1_2))));
         assertThat(logFixture.contains(Level.INFO, "Skipping scheduling of timer-triggered pipeline 'p1' as it has previously run with the latest material(s)."), is(false));
     }
 
@@ -162,9 +162,9 @@ public class BuildCauseProducerServiceIntegrationTimerTest {
         buildCauseProducerService.timerSchedulePipeline(p1.config, new ServerHealthStateOperationResult());
 
         assertThat(piplineScheduleQueue.toBeScheduled().size(), is(1));
-        assertThat(piplineScheduleQueue.toBeScheduled().get(pipelineName).getMaterialRevisions(), isSameMaterialRevisionsAs(u.mrs(u.mr(git1, true, "g11"), u.mr(git2, true, "g21"))));
+        assertThat(piplineScheduleQueue.toBeScheduled().get(pipelineName).last().getMaterialRevisions(), isSameMaterialRevisionsAs(u.mrs(u.mr(git1, true, "g11"), u.mr(git2, true, "g21"))));
 
-        BuildCause buildCause = piplineScheduleQueue.toBeScheduled().get(pipelineName);
+        BuildCause buildCause = piplineScheduleQueue.toBeScheduled().get(pipelineName).last();
         piplineScheduleQueue.finishSchedule(pipelineName, buildCause, buildCause);
 
         // Timer time comes around again. Will NOT rerun since the new flag (runOnlyOnNewMaterials) is ON.
@@ -194,9 +194,9 @@ public class BuildCauseProducerServiceIntegrationTimerTest {
         buildCauseProducerService.timerSchedulePipeline(p2.config, new ServerHealthStateOperationResult());
 
         assertThat(piplineScheduleQueue.toBeScheduled().size(), is(1));
-        assertThat(piplineScheduleQueue.toBeScheduled().get(pipelineName).getMaterialRevisions(), isSameMaterialRevisionsAs(u.mrs(u.mr(git1, true, "g11"), u.mr(git2, true, "g21"), u.mr(p1, true, p1_1))));
+        assertThat(piplineScheduleQueue.toBeScheduled().get(pipelineName).last().getMaterialRevisions(), isSameMaterialRevisionsAs(u.mrs(u.mr(git1, true, "g11"), u.mr(git2, true, "g21"), u.mr(p1, true, p1_1))));
 
-        BuildCause buildCause = piplineScheduleQueue.toBeScheduled().get(pipelineName);
+        BuildCause buildCause = piplineScheduleQueue.toBeScheduled().get(pipelineName).last();
         u.runAndPassWithGivenMDUTimestampAndRevisionStrings(p2, u.d(i++), "g11", "g21", p1_1);
         piplineScheduleQueue.finishSchedule(pipelineName, buildCause, buildCause);
 
@@ -207,7 +207,7 @@ public class BuildCauseProducerServiceIntegrationTimerTest {
         buildCauseProducerService.timerSchedulePipeline(p2.config, new ServerHealthStateOperationResult());
 
         assertThat(piplineScheduleQueue.toBeScheduled().size(), is(1));
-        assertThat(piplineScheduleQueue.toBeScheduled().get(pipelineName).getMaterialRevisions(), isSameMaterialRevisionsAs(u.mrs(u.mr(git1, false, "g11"), u.mr(git2, true, "g22"), u.mr(p1, true, p1_2))));
+        assertThat(piplineScheduleQueue.toBeScheduled().get(pipelineName).last().getMaterialRevisions(), isSameMaterialRevisionsAs(u.mrs(u.mr(git1, false, "g11"), u.mr(git2, true, "g22"), u.mr(p1, true, p1_2))));
         assertThat(logFixture.contains(Level.INFO, "Skipping scheduling of timer-triggered pipeline 'p1' as it has previously run with the latest material(s)."), is(false));
     }
 

--- a/server/test/integration/com/thoughtworks/go/server/service/MultipleMaterialsWithFilterTest.java
+++ b/server/test/integration/com/thoughtworks/go/server/service/MultipleMaterialsWithFilterTest.java
@@ -98,7 +98,7 @@ public class MultipleMaterialsWithFilterTest {
         fixture.checkInToFirstMaterial("a.doc");
         fixture.checkInToSecondMaterial("b.java");
         buildCauseProducerService.autoSchedulePipeline(fixture.pipelineName, new ServerHealthStateOperationResult(), 12345);
-        BuildCause buildCause = pipelineScheduleQueue.toBeScheduled().get(fixture.pipelineName);
+        BuildCause buildCause = pipelineScheduleQueue.toBeScheduled().get(fixture.pipelineName).last();
         assertThat(buildCause, instanceOf(BuildCause.class));
 
         MaterialRevisions actual = buildCause.getMaterialRevisions();

--- a/server/test/integration/com/thoughtworks/go/server/service/PipelineScheduleServiceTest.java
+++ b/server/test/integration/com/thoughtworks/go/server/service/PipelineScheduleServiceTest.java
@@ -396,8 +396,8 @@ public class PipelineScheduleServiceTest {
 
     @Test
     public void shouldConsumeAllBuildCausesInServerHealth() throws Exception {
-        pipelineScheduleQueue.schedule("mingle", BuildCause.createManualForced(modifyOneFile(mingleConfig), Username.ANONYMOUS));
-        pipelineScheduleQueue.schedule("evolve", BuildCause.createManualForced(modifyOneFile(evolveConfig), Username.ANONYMOUS));
+        pipelineScheduleQueue.schedule("mingle", BuildCause.createManualForced(modifyOneFile(mingleConfig), Username.ANONYMOUS), -1L);
+        pipelineScheduleQueue.schedule("evolve", BuildCause.createManualForced(modifyOneFile(evolveConfig), Username.ANONYMOUS), -1L);
 
         scheduleService.autoSchedulePipelinesFromRequestBuffer();
         assertThat(pipelineScheduleQueue.toBeScheduled().size(), is(0));

--- a/server/test/integration/com/thoughtworks/go/server/service/PipelineSchedulerIntegrationTest.java
+++ b/server/test/integration/com/thoughtworks/go/server/service/PipelineSchedulerIntegrationTest.java
@@ -16,24 +16,7 @@
 
 package com.thoughtworks.go.server.service;
 
-import com.thoughtworks.go.helper.PipelineMother;
-import com.thoughtworks.go.server.dao.PipelineDao;
-import com.thoughtworks.go.server.scheduling.ScheduleHelper;
-import com.thoughtworks.go.server.scheduling.ScheduleOptions;
-import com.thoughtworks.go.util.GoConfigFileHelper;
-import com.thoughtworks.go.util.GoConstants;
-import junit.framework.Assert;
-
-import java.io.IOException;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-
-import com.thoughtworks.go.config.CaseInsensitiveString;
-import com.thoughtworks.go.config.GoConfigFileDao;
-import com.thoughtworks.go.config.EnvironmentVariablesConfig;
-import com.thoughtworks.go.config.PipelineConfig;
-import com.thoughtworks.go.config.StageConfig;
+import com.thoughtworks.go.config.*;
 import com.thoughtworks.go.domain.DefaultSchedulingContext;
 import com.thoughtworks.go.domain.JobInstance;
 import com.thoughtworks.go.domain.Pipeline;
@@ -41,28 +24,36 @@ import com.thoughtworks.go.domain.PipelinePauseInfo;
 import com.thoughtworks.go.domain.buildcause.BuildCause;
 import com.thoughtworks.go.domain.materials.svn.Subversion;
 import com.thoughtworks.go.domain.materials.svn.SvnCommand;
+import com.thoughtworks.go.helper.PipelineMother;
 import com.thoughtworks.go.helper.SvnTestRepo;
 import com.thoughtworks.go.helper.TestRepo;
 import com.thoughtworks.go.server.cache.GoCache;
 import com.thoughtworks.go.server.dao.DatabaseAccessHelper;
+import com.thoughtworks.go.server.dao.PipelineDao;
 import com.thoughtworks.go.server.domain.Username;
+import com.thoughtworks.go.server.scheduling.ScheduleHelper;
+import com.thoughtworks.go.server.scheduling.ScheduleOptions;
 import com.thoughtworks.go.server.service.result.HttpOperationResult;
 import com.thoughtworks.go.serverhealth.HealthStateScope;
 import com.thoughtworks.go.serverhealth.HealthStateType;
 import com.thoughtworks.go.serverhealth.ServerHealthService;
 import com.thoughtworks.go.serverhealth.ServerHealthState;
+import com.thoughtworks.go.util.GoConfigFileHelper;
+import com.thoughtworks.go.util.GoConstants;
 import com.thoughtworks.go.util.TimeProvider;
 import com.thoughtworks.go.utils.Assertions;
 import com.thoughtworks.go.utils.Timeout;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import junit.framework.Assert;
+import org.junit.*;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
 
 import static com.thoughtworks.go.helper.ModificationsMother.modifySomeFiles;
 import static com.thoughtworks.go.matchers.RegexMatcher.matches;
@@ -151,7 +142,7 @@ public class PipelineSchedulerIntegrationTest {
                 return serverHealthService.filterByScope(HealthStateScope.forPipeline(PIPELINE_MINGLE)).size() == 0;
             }
         });
-        BuildCause buildCause = pipelineScheduleQueue.toBeScheduled().get(PIPELINE_MINGLE);
+        BuildCause buildCause = pipelineScheduleQueue.toBeScheduled().get(PIPELINE_MINGLE).last();
 
         EnvironmentVariablesConfig overriddenVariables = buildCause.getVariables();
         assertThat(overriddenVariables, is(env("KEY", "value")));

--- a/server/test/integration/com/thoughtworks/go/server/service/ScheduleServiceCachedIntegrationTest.java
+++ b/server/test/integration/com/thoughtworks/go/server/service/ScheduleServiceCachedIntegrationTest.java
@@ -196,7 +196,7 @@ public class ScheduleServiceCachedIntegrationTest {
     private Pipeline tryToScheduleAPipeline() {
         BuildCause buildCause = BuildCause.createWithModifications(modifyOneFile(preCondition.pipelineConfig()), "");
         dbHelper.saveMaterials(buildCause.getMaterialRevisions());
-        pipelineScheduleQueue.schedule(preCondition.pipelineName, buildCause);
+        pipelineScheduleQueue.schedule(preCondition.pipelineName, buildCause, -1L);
         scheduleService.autoSchedulePipelinesFromRequestBuffer();
         return pipelineService.mostRecentFullPipelineByName(preCondition.pipelineName);
     }

--- a/server/test/integration/com/thoughtworks/go/server/service/ScheduleServiceIntegrationTest.java
+++ b/server/test/integration/com/thoughtworks/go/server/service/ScheduleServiceIntegrationTest.java
@@ -427,7 +427,7 @@ public class ScheduleServiceIntegrationTest {
         BuildCause buildCause = ModificationsMother.modifySomeFiles(pipelineConfig);
         dbHelper.saveMaterials(buildCause.getMaterialRevisions());
         String pipelineName = pipelineConfig.name().toString();
-        pipelineScheduleQueue.schedule(pipelineName, buildCause);
+        pipelineScheduleQueue.schedule(pipelineName, buildCause, -1L);
         scheduleService.autoSchedulePipelinesFromRequestBuffer();
         Pipeline pipeline = pipelineDao.findPipelineByNameAndCounter(pipelineName, counter);
         pipeline = pipelineDao.loadAssociations(pipeline, pipelineName);

--- a/server/test/integration/com/thoughtworks/go/server/service/ScheduleServiceRunOnAllAgentIntegrationTest.java
+++ b/server/test/integration/com/thoughtworks/go/server/service/ScheduleServiceRunOnAllAgentIntegrationTest.java
@@ -131,7 +131,7 @@ public class ScheduleServiceRunOnAllAgentIntegrationTest {
 
     @Test
     public void shouldUpdateServerHealthWhenSchedulePipelineFails() throws Exception {
-        pipelineScheduleQueue.schedule("blahPipeline", saveMaterials(modifySomeFiles(goConfigService.pipelineConfigNamed(new CaseInsensitiveString("blahPipeline")))));
+        pipelineScheduleQueue.schedule("blahPipeline", saveMaterials(modifySomeFiles(goConfigService.pipelineConfigNamed(new CaseInsensitiveString("blahPipeline")))), -1L);
         scheduleService.autoSchedulePipelinesFromRequestBuffer();
         List<ServerHealthState> stateList = serverHealthService.filterByScope(HealthStateScope.forStage("blahPipeline", "blahStage"));
         assertThat(stateList.size(), is(1));

--- a/server/test/integration/com/thoughtworks/go/server/service/SchedulingCheckerServiceIntegrationTest.java
+++ b/server/test/integration/com/thoughtworks/go/server/service/SchedulingCheckerServiceIntegrationTest.java
@@ -136,7 +136,7 @@ public class SchedulingCheckerServiceIntegrationTest {
     public void shouldFailCheckingWhenPipelineNotYetScheduledButInScheduleQueue() throws Exception {
         String pipelineName = "blahPipeline";
         PipelineConfig pipelineConfig = configFileHelper.addPipelineWithGroup("group2", pipelineName, "stage", "job");
-        pipelineScheduleQueue.schedule(pipelineName, BuildCause.createManualForced());
+        pipelineScheduleQueue.schedule(pipelineName, BuildCause.createManualForced(), -1L);
         HttpOperationResult operationResult = new HttpOperationResult();
         assertThat(schedulingChecker.canManuallyTrigger(pipelineConfig, "blahUser", operationResult), is(false));
         assertThat(operationResult.canContinue(), is(false));
@@ -148,7 +148,7 @@ public class SchedulingCheckerServiceIntegrationTest {
         String pipelineName = "blahPipeline";
         configFileHelper.addPipelineWithGroup("group2", pipelineName, "stage", "job");
 
-        pipelineScheduleQueue.schedule(pipelineName, BuildCause.createWithEmptyModifications());
+        pipelineScheduleQueue.schedule(pipelineName, BuildCause.createWithEmptyModifications(), -1L);
         assertThat(schedulingChecker.canManuallyTrigger(pipelineName, new Username(new CaseInsensitiveString("blahUser"))), is(true));
     }
 

--- a/server/test/unit/com/thoughtworks/go/remote/BuildRepositoryRemoteImplTest.java
+++ b/server/test/unit/com/thoughtworks/go/remote/BuildRepositoryRemoteImplTest.java
@@ -16,17 +16,10 @@
 
 package com.thoughtworks.go.remote;
 
-import java.util.Arrays;
-import java.util.List;
-
-import com.thoughtworks.go.domain.AgentInstance;
-import com.thoughtworks.go.domain.AgentStatus;
-import com.thoughtworks.go.domain.JobIdentifier;
-import com.thoughtworks.go.domain.JobResult;
-import com.thoughtworks.go.domain.JobState;
-import com.thoughtworks.go.domain.StageIdentifier;
+import com.thoughtworks.go.domain.*;
 import com.thoughtworks.go.server.messaging.JobStatusMessage;
 import com.thoughtworks.go.server.messaging.JobStatusTopic;
+import com.thoughtworks.go.server.perf.AgentCommunicationPerformanceLogger;
 import com.thoughtworks.go.server.service.AgentRuntimeInfo;
 import com.thoughtworks.go.server.service.AgentService;
 import com.thoughtworks.go.server.service.BuildRepositoryService;
@@ -39,15 +32,15 @@ import org.junit.Before;
 import org.junit.Test;
 import org.springframework.remoting.RemoteAccessException;
 
+import java.util.Arrays;
+import java.util.List;
+
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.sameInstance;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 public class BuildRepositoryRemoteImplTest {
     private BuildRepositoryService repositoryService;
@@ -62,7 +55,7 @@ public class BuildRepositoryRemoteImplTest {
         repositoryService = mock(BuildRepositoryService.class);
         agentService = mock(AgentService.class);
         jobStatusTopic = mock(JobStatusTopic.class);
-        buildRepository = new BuildRepositoryRemoteImpl(repositoryService, agentService, jobStatusTopic);
+        buildRepository = new BuildRepositoryRemoteImpl(repositoryService, agentService, jobStatusTopic, mock(AgentCommunicationPerformanceLogger.class));
         logFixture = LogFixture.startListening(Level.TRACE);
         info = AgentRuntimeInfo.fromAgent(new AgentIdentifier("host", "192.168.1.1", "uuid"), "cookie", null);
     }

--- a/server/test/unit/com/thoughtworks/go/server/scheduling/BuildCauseProducerServiceTest.java
+++ b/server/test/unit/com/thoughtworks/go/server/scheduling/BuildCauseProducerServiceTest.java
@@ -343,7 +343,7 @@ public class BuildCauseProducerServiceTest {
                 new ScheduleOptions(Collections.singletonMap(dependencyMaterial.getPipelineUniqueFingerprint(), "upstream-pipeline/2/stage/1"),
                         stringStringHashMap, new HashMap<String, String>()), new ServerHealthStateOperationResult(), 12345);
 
-        verify(pipelineScheduleQueue).schedule(eq("pipeline"), argThat(containsRevisions(new MaterialRevision(svnMaterial, svnModifications), specificMaterialRevision)));
+        verify(pipelineScheduleQueue).schedule(eq("pipeline"), argThat(containsRevisions(new MaterialRevision(svnMaterial, svnModifications), specificMaterialRevision)), -1L);
     }
 
     @Test


### PR DESCRIPTION
* Better logging of scheduling subsystem. Using trackingID to corelate across threads.
* Agent communication is now logged.
* Web request logging now works even for gzipped content.
* Job identifiers at the end (in final log statements) to help parsing.