### PR TITLE
#1012 The ReaderState enums are static. 

### DIFF
--- a/config/config-api/src/com/thoughtworks/go/config/preprocessor/ParamStateMachine.java
+++ b/config/config-api/src/com/thoughtworks/go/config/preprocessor/ParamStateMachine.java
@@ -34,8 +34,11 @@ public class ParamStateMachine {
         IN_PATTERN {
             ReaderState interpret(char ch, ParamHandler paramsHandler) {
                 if (ch == CHAR_CURL_CLOSE) {
-                    paramsHandler.handlePatternFound(pattern);
-                    pattern.setLength(0);
+                    try {
+                        paramsHandler.handlePatternFound(pattern);
+                    } finally {
+                        pattern.setLength(0);
+                    }
                     return NOT_IN_PATTERN;
                 } else {
                     pattern.append(ch);

--- a/config/config-api/test/com/thoughtworks/go/config/preprocessor/ParamStateMachineTest.java
+++ b/config/config-api/test/com/thoughtworks/go/config/preprocessor/ParamStateMachineTest.java
@@ -1,0 +1,42 @@
+package com.thoughtworks.go.config.preprocessor;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.*;
+
+public class ParamStateMachineTest {
+
+    private ParamHandler handler;
+
+    @Before
+    public void setUp() throws Exception {
+        handler = mock(ParamHandler.class);
+    }
+
+    @Test
+    public void shouldClearPatternWhenFound() throws Exception {
+        ParamStateMachine stateMachine = new ParamStateMachine();
+        stateMachine.process("#{pattern}", handler);
+
+        assertThat(ParamStateMachine.ReaderState.IN_PATTERN.pattern.length(), is(0));
+        verify(handler).handlePatternFound(any(StringBuilder.class));
+    }
+
+    @Test
+    public void shouldClearPatternWhenParameterCannotBeResolved() throws Exception {
+        ParamStateMachine stateMachine = new ParamStateMachine();
+        doThrow(new IllegalStateException()).when(handler).handlePatternFound(any(StringBuilder.class));
+
+        try {
+            stateMachine.process("#{pattern}", handler);
+        } catch (Exception e) {
+            //Ignore to assert on the pattern
+        }
+        assertThat(ParamStateMachine.ReaderState.IN_PATTERN.pattern.length(), is(0));
+        verify(handler).handlePatternFound(any(StringBuilder.class));
+    }
+}


### PR DESCRIPTION
We are not cleaning up the pattern when there's an exception in parameters substitution. This causes the pattern to remain in the string builder resulting in an endless append cycle.