### PR TITLE
Couple of fixes with console log page.

### DIFF
--- a/server/webapp/WEB-INF/rails.new/app/assets/javascripts/console_log_tailing.js
+++ b/server/webapp/WEB-INF/rails.new/app/assets/javascripts/console_log_tailing.js
@@ -33,21 +33,16 @@
     });
 
     var globalBackToTopButton      = $('#back_to_top'),
-        topActionBar               = $('.console-action-bar'),
-        bottomActionBar            = $('.console-footer-action-bar'),
         historySidebarContainer    = $('.sidebar_history'),
         historySidebarHandle       = $('.sidebar-handle'),
-        historySidebarHandleHeight = $('.sidebar-handle').outerHeight(true),
+        historySidebarHandleHeight = historySidebarHandle.outerHeight(true),
         historySidebar             = $('#build_history_holder'),
         sidebarPin                 = $('.sidebar-pin'),
         sidebarTop                 = historySidebar.offset().top,
+        consoleTab                 = $('#tab-content-of-console'),
+        failuresTab                = $('#tab-content-of-failures'),
         sidebarBottom              = sidebarTop + historySidebar.get(0).getBoundingClientRect().height
       ;
-
-    // pin the console action bar on top
-    topActionBar.scrollToFixed({marginTop: 90, zIndex: 100});
-    // and the other action bar to bottom
-    bottomActionBar.scrollToFixed({bottom: 0, limit: bottomActionBar.offset().top, zIndex: 100});
 
     $(window).on('scroll resize', function (evt) {
       var delta                 = 5;
@@ -57,15 +52,43 @@
     });
 
     // hide the global "back to top" link, because the one on the console log goes well with the console log
-    function hideGlobalBackToTopButton() {
-      var consoleTab = $('#tab-content-of-console');
-      globalBackToTopButton.toggleClass('back_to_top', !consoleTab.is(':visible'));
+    function maybeHideGlobalBackToTopButton() {
+      var hideGlobalBackToTopButton = false,
+          topActionBar,
+          bottomActionBar;
+
+      if (consoleTab.is(':visible')) {
+        hideGlobalBackToTopButton = true;
+        if (!consoleTab.data('enable-scroll-to-fixed')) {
+          consoleTab.data('enable-scroll-to-fixed', true);
+          topActionBar    = consoleTab.find('.console-action-bar');
+          bottomActionBar = consoleTab.find('.console-footer-action-bar');
+        }
+      }
+
+      if (failuresTab.is(':visible')) {
+        hideGlobalBackToTopButton = true;
+        if (!failuresTab.data('enable-scroll-to-fixed')) {
+          failuresTab.data('enable-scroll-to-fixed', true);
+          topActionBar    = failuresTab.find('.console-action-bar');
+          bottomActionBar = failuresTab.find('.console-footer-action-bar');
+        }
+      }
+
+      if (topActionBar && bottomActionBar && topActionBar.length === 1 && bottomActionBar.length === 1) {
+        // pin the console action bar on top
+        topActionBar.scrollToFixed({marginTop: 90, zIndex: 100});
+        // and the other action bar to bottom
+        bottomActionBar.scrollToFixed({bottom: 0, limit: bottomActionBar.offset().top, zIndex: 100});
+      }
+
+      globalBackToTopButton.toggleClass('back_to_top', !hideGlobalBackToTopButton);
     }
 
-    hideGlobalBackToTopButton();
+    maybeHideGlobalBackToTopButton();
 
     $('.sub_tabs_container a').on('click', function () {
-      hideGlobalBackToTopButton();
+      window.setTimeout(maybeHideGlobalBackToTopButton, 50);
     });
 
     var currentPinned = localStorage && localStorage.getItem('job-detail-sidebar-collapsed') === 'true';

--- a/server/webapp/WEB-INF/rails.new/app/assets/stylesheets/css/build_detail.scss
+++ b/server/webapp/WEB-INF/rails.new/app/assets/stylesheets/css/build_detail.scss
@@ -277,7 +277,7 @@ div.build_detail_container_content {
 }
 
 .ansi-color-toggle-true {
-  margin-top: -10px;
+  margin-top: -10px !important;
 }
 
 .ansi-color-toggle-false .buildoutput_pre {
@@ -304,7 +304,7 @@ div.build_detail_container_content {
   border: none;
 }
 
-#tab-content-of-console {
+.console-area {
   background-color: #333;
 }
 
@@ -377,7 +377,7 @@ div.build_detail_container_content {
     padding: 0px 15px 15px 15px;
   }
   .back-to-top-in-console {
-    padding-right: 70px; // push aside because of the red "server error messages"
+    padding-right: 170px; // push aside because of the red "server error messages"
   }
 }
 
@@ -764,8 +764,6 @@ a.collapse-all {
 
 .job_details_content {
   margin-right: 20px;
-  overflow: hidden;
-  overflow-y: scroll;
 }
 
 @mixin apply-transition() {

--- a/server/webapp/WEB-INF/vm/build_detail/_build_output_raw.vm
+++ b/server/webapp/WEB-INF/vm/build_detail/_build_output_raw.vm
@@ -1,0 +1,20 @@
+<div class="console-area">
+#if($color_logs_feature_toggle_key)
+<div class="console-action-bar">
+    <div>
+        <a class='change-theme' href="javascript:void(0);">Change theme</a>
+        <a href="$req.getContextPath()/files/${presenter.consoleoutLocator}">Raw output</a>
+        <a class="auto-scroll" title="Scroll to bottom">&nbsp;<span class="scroll-help-text">Scroll to end of logs</span><span class="scroll-dot"></span></a>
+    </div>
+</div>
+<pre class="buildoutput_pre #if(!$color_logs_feature_toggle_key) white-theme #end"></pre>
+<div class="console-footer-action-bar">
+    <div>
+        <a href="javascript:(0)" class="back-to-top-in-console">Back to top</a>
+    </div>
+</div>
+#end
+#if($presenter.isCompleted())
+<div class="widget" id="build-output-console-warnning" style="display: none;">No console output.</div>
+#end
+</div>

--- a/server/webapp/WEB-INF/vm/build_detail/_buildoutput.vm
+++ b/server/webapp/WEB-INF/vm/build_detail/_buildoutput.vm
@@ -15,22 +15,5 @@
  *************************GO-LICENSE-END***********************************#
 
 <div id="tab-content-of-console" class="ansi-color-toggle-$color_logs_feature_toggle_key" $buildoutput_extra_attrs>
-    #if($color_logs_feature_toggle_key)
-        <div class="console-action-bar">
-            <div>
-                <a class='change-theme' href="javascript:void(0);">Change theme</a>
-                <a href="$req.getContextPath()/files/${presenter.consoleoutLocator}">Raw output</a>
-                <a class="auto-scroll" title="Scroll to bottom">&nbsp;<span class="scroll-help-text">Scroll to end of logs</span><span class="scroll-dot"></span></a>
-            </div>
-        </div>
-        <pre class="buildoutput_pre #if(!$color_logs_feature_toggle_key) white-theme #end"></pre>
-        <div class="console-footer-action-bar">
-            <div>
-                <a href="javascript:(0)" class="back-to-top-in-console">Back to top</a>
-            </div>
-        </div>
-    #end
-    #if($presenter.isCompleted())
-        <div class="widget" id="build-output-console-warnning" style="display: none;">No console output.</div>
-    #end
+    #parse("build_detail/_build_output_raw.vm")
 </div>

--- a/server/webapp/WEB-INF/vm/build_detail/_failures.vm
+++ b/server/webapp/WEB-INF/vm/build_detail/_failures.vm
@@ -14,11 +14,11 @@
  * limitations under the License.
  *************************GO-LICENSE-END***********************************#
 
-<div id="tab-content-of-failures" class="widget"  $errors_extra_attrs>
+<div id="tab-content-of-failures" class="widget ansi-color-toggle-$color_logs_feature_toggle_key" $errors_extra_attrs >
 <div>
     #if (!$presenter.hasBuildError() && !$presenter.hasFailedTests() && !$presenter.hasStacktrace() && !$presenter.hasServerFailure())
         #if ($presenter.isFailed())
-            #parse("build_detail/_buildoutput.vm")
+            #parse("build_detail/_build_output_raw.vm")
         #else
             #if ($presenter.hasTests())
                 No failures

--- a/server/webapp/WEB-INF/vm/build_detail/build_detail_page.vm
+++ b/server/webapp/WEB-INF/vm/build_detail/build_detail_page.vm
@@ -117,17 +117,13 @@
                                     <div class="clear"></div>
 
                                     #set($buildoutput_extra_attrs="")
-                                    <span class='console_tab_content_container'>
-                                        #parse("build_detail/_buildoutput.vm")
-                                    </span>
+                                    #parse("build_detail/_buildoutput.vm")
 
                                     #set($tests_extra_attrs="style='display:none'")
                                     #parse("build_detail/_tests.vm")
 
                                     #set($errors_extra_attrs="style='display:none'")
-                                    <span class='failures_tab_content_container'>
-                                        #parse("build_detail/_failures.vm")
-                                    </span>
+                                    #parse("build_detail/_failures.vm")
 
                                     #set($artifacts_extra_attrs="style='display:none'")
                                     #parse("build_detail/_artifacts.vm")


### PR DESCRIPTION
* When switching between tabs, the event handler that switches tabs is
  before the one that hides the back to top button. Since we're using
  the end result of the first callback to determine the result of the
  second, this does not work as expected.
* Also scrolling up from the very bottom of the log when live tailing is
  turned on does not disable "scroll to bottom" feature because the
  scroll event handlers were only installed when the autoscroll button
  was clicked.