### PR TITLE
#000 - Fix order-dependent test.

### DIFF
--- a/server/test/integration/com/thoughtworks/go/server/dao/UserSqlMapDaoIntegrationTest.java
+++ b/server/test/integration/com/thoughtworks/go/server/dao/UserSqlMapDaoIntegrationTest.java
@@ -33,6 +33,8 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 
 import static org.hamcrest.Matchers.empty;
@@ -377,6 +379,14 @@ public class UserSqlMapDaoIntegrationTest {
         userDao.findNotificationSubscribingUsers();
         assertThat(subscribedUsers.size(), is(3));
         assertThat(subscribedUsers.containsAll(Arrays.asList(user1, user2, user3)), is(true));
+
+        Collections.sort(subscribedUsers, new Comparator<User>() {
+            @Override
+            public int compare(User user1, User user2) {
+                return user1.getName().compareTo(user2.getName());
+            }
+        });
+
         assertThat(subscribedUsers.get(0).getNotificationFilters().size(), is(1));
         assertThat(subscribedUsers.get(1).getNotificationFilters().size(), is(3));
         assertThat(subscribedUsers.get(2).getNotificationFilters().size(), is(1));


### PR DESCRIPTION
Used to fail now and then, since it was dependent on order of the users returned from the DB. So,
sort before using.