### PR TITLE
Send elastic agent properties from `autoregister.properties` as part of `AgentRuntimeInfo` as part of the ping call to the server.

### DIFF
--- a/agent/pom.xml
+++ b/agent/pom.xml
@@ -58,12 +58,6 @@
             <version>1.47</version>
         </dependency>
 
-        <dependency>
-            <groupId>commons-configuration</groupId>
-            <artifactId>commons-configuration</artifactId>
-            <version>1.10</version>
-        </dependency>
-
         <!-- test dependencies -->
         <dependency>
             <groupId>com.thoughtworks.go</groupId>

--- a/agent/src/com/thoughtworks/go/agent/service/SslInfrastructureService.java
+++ b/agent/src/com/thoughtworks/go/agent/service/SslInfrastructureService.java
@@ -17,6 +17,7 @@
 
 package com.thoughtworks.go.agent.service;
 
+import com.thoughtworks.go.config.AgentAutoRegistrationProperties;
 import com.thoughtworks.go.config.AgentRegistry;
 import com.thoughtworks.go.config.GuidService;
 import com.thoughtworks.go.security.AuthSSLProtocolSocketFactory;

--- a/agent/src/com/thoughtworks/go/agent/service/SslInfrastructureService.java
+++ b/agent/src/com/thoughtworks/go/agent/service/SslInfrastructureService.java
@@ -87,12 +87,12 @@ public class SslInfrastructureService {
         }
     }
 
-    public void registerIfNecessary() throws Exception {
+    public void registerIfNecessary(AgentAutoRegistrationProperties agentAutoRegistrationProperties) throws Exception {
         registered = keyStoreManager.hasCertificates(CHAIN_ALIAS, AGENT_CERTIFICATE_FILE,
                 AGENT_STORE_PASSWORD) && GuidService.guidPresent();
         if (!registered) {
             LOGGER.info("[Agent Registration] Starting to register agent");
-            register();
+            register(agentAutoRegistrationProperties);
             createSslInfrastructure();
             registered = true;
             LOGGER.info("[Agent Registration] Successfully registered agent");
@@ -103,11 +103,10 @@ public class SslInfrastructureService {
         return registered;
     }
 
-    private void register() throws Exception {
+    private void register(AgentAutoRegistrationProperties agentAutoRegistrationProperties) throws Exception {
         String hostName = SystemUtil.getLocalhostNameOrRandomNameIfNotFound();
         Registration keyEntry = null;
         while (keyEntry == null || keyEntry.getChain().length == 0) {
-            AgentAutoRegistrationProperties agentAutoRegistrationProperties = new AgentAutoRegistrationProperties(new File("config", "autoregister.properties"));
             try {
                 keyEntry = remoteRegistrationRequester.requestRegistration(hostName, agentAutoRegistrationProperties);
             } catch (Exception e) {

--- a/agent/test/functional/com/thoughtworks/go/agent/service/RemoteRegistrationRequesterTest.java
+++ b/agent/test/functional/com/thoughtworks/go/agent/service/RemoteRegistrationRequesterTest.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Properties;
 
+import com.thoughtworks.go.config.AgentAutoRegistrationProperties;
 import com.thoughtworks.go.config.DefaultAgentRegistry;
 import com.thoughtworks.go.security.Registration;
 import com.thoughtworks.go.util.SystemEnvironment;

--- a/agent/test/functional/com/thoughtworks/go/agent/service/SslInfrastructureServiceTest.java
+++ b/agent/test/functional/com/thoughtworks/go/agent/service/SslInfrastructureServiceTest.java
@@ -20,6 +20,7 @@ package com.thoughtworks.go.agent.service;
 import java.io.IOException;
 
 import com.thoughtworks.go.agent.testhelpers.AgentCertificateMother;
+import com.thoughtworks.go.config.AgentAutoRegistrationProperties;
 import com.thoughtworks.go.config.AgentRegistry;
 import com.thoughtworks.go.config.GuidService;
 import com.thoughtworks.go.security.AuthSSLProtocolSocketFactory;

--- a/agent/test/functional/com/thoughtworks/go/agent/service/SslInfrastructureServiceTest.java
+++ b/agent/test/functional/com/thoughtworks/go/agent/service/SslInfrastructureServiceTest.java
@@ -17,6 +17,7 @@
 
 package com.thoughtworks.go.agent.service;
 
+import java.io.File;
 import java.io.IOException;
 
 import com.thoughtworks.go.agent.testhelpers.AgentCertificateMother;
@@ -36,7 +37,9 @@ import org.jmock.Mockery;
 import org.jmock.integration.junit4.JMock;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 
 import static com.thoughtworks.go.util.TestUtils.exists;
@@ -51,6 +54,8 @@ public class SslInfrastructureServiceTest {
     private SslInfrastructureService sslInfrastructureService;
     private boolean remoteCalled;
     private HttpConnectionManagerParams httpConnectionManagerParams = new HttpConnectionManagerParams();
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
 
     @Before
     public void setup() throws Exception {
@@ -72,17 +77,20 @@ public class SslInfrastructureServiceTest {
 
     @Test
     public void shouldInvalidateKeystore() throws Exception {
+        folder.create();
+        File configFile = folder.newFile();
+
         shouldCreateSslInfrastucture();
 
-        sslInfrastructureService.registerIfNecessary();
+        sslInfrastructureService.registerIfNecessary(new AgentAutoRegistrationProperties(configFile));
         assertThat(SslInfrastructureService.AGENT_CERTIFICATE_FILE, exists());
         assertRemoteCalled();
 
-        sslInfrastructureService.registerIfNecessary();
+        sslInfrastructureService.registerIfNecessary(new AgentAutoRegistrationProperties(configFile));
         assertRemoteNotCalled();
 
         sslInfrastructureService.invalidateAgentCertificate();
-        sslInfrastructureService.registerIfNecessary();
+        sslInfrastructureService.registerIfNecessary(new AgentAutoRegistrationProperties(configFile));
         assertRemoteCalled();
     }
 

--- a/agent/test/unit/com/thoughtworks/go/agent/AgentControllerTest.java
+++ b/agent/test/unit/com/thoughtworks/go/agent/AgentControllerTest.java
@@ -18,6 +18,7 @@ package com.thoughtworks.go.agent;
 
 import com.thoughtworks.go.agent.service.AgentUpgradeService;
 import com.thoughtworks.go.agent.service.SslInfrastructureService;
+import com.thoughtworks.go.config.AgentAutoRegistrationProperties;
 import com.thoughtworks.go.config.AgentRegistry;
 import com.thoughtworks.go.config.GuidService;
 import com.thoughtworks.go.plugin.access.packagematerial.PackageAsRepositoryExtension;
@@ -36,10 +37,13 @@ import com.thoughtworks.go.util.SystemUtil;
 import com.thoughtworks.go.util.command.EnvironmentVariableContext;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import org.mockito.InOrder;
 import org.mockito.Mock;
 
+import java.io.File;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
 
@@ -82,6 +86,8 @@ public class AgentControllerTest {
     private String agentUuid = "uuid";
     private AgentIdentifier agentIdentifier;
     private AgentController agentController;
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
 
     @Before
     public void setUp() throws Exception {
@@ -194,10 +200,12 @@ public class AgentControllerTest {
 
     @Test
     public void shouldUpgradeAgentBeforeAgentRegistration() throws Exception {
+        File configFile = folder.newFile();
+
         agentController = new AgentController(loopServer, artifactsManipulator, sslInfrastructureService, agentRegistry, agentUpgradeService, subprocessLogger, systemEnvironment,pluginManager, packageAsRepositoryExtension, scmExtension, taskExtension);
         InOrder inOrder = inOrder(agentUpgradeService, sslInfrastructureService);
         agentController.loop();
         inOrder.verify(agentUpgradeService).checkForUpgrade();
-        inOrder.verify(sslInfrastructureService).registerIfNecessary();
+        inOrder.verify(sslInfrastructureService).registerIfNecessary(agentController.getAgentAutoRegistrationProperties());
     }
 }

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -101,6 +101,12 @@
             <scope>provided</scope>
         </dependency>
 
+        <dependency>
+            <groupId>commons-configuration</groupId>
+            <artifactId>commons-configuration</artifactId>
+            <version>1.10</version>
+        </dependency>
+
         <!-- test dependencies -->
         <dependency>
             <groupId>com.thoughtworks.go</groupId>

--- a/common/src/com/thoughtworks/go/config/AgentAutoRegistrationProperties.java
+++ b/common/src/com/thoughtworks/go/config/AgentAutoRegistrationProperties.java
@@ -33,6 +33,8 @@ public class AgentAutoRegistrationProperties {
     public static final String AGENT_AUTO_REGISTER_RESOURCES = "agent.auto.register.resources";
     public static final String AGENT_AUTO_REGISTER_ENVIRONMENTS = "agent.auto.register.environments";
     public static final String AGENT_AUTO_REGISTER_HOSTNAME = "agent.auto.register.hostname";
+    public static final String AGENT_AUTO_REGISTER_ELASTIC_PLUGIN_ID = "agent.auto.register.elasticAgent.pluginId";
+    public static final String AGENT_AUTO_REGISTER_ELASTIC_AGENT_ID = "agent.auto.register.elasticAgent.agentId";
 
     private final File configFile;
     private final Properties properties;
@@ -41,7 +43,7 @@ public class AgentAutoRegistrationProperties {
         this(config, new Properties());
     }
 
-    AgentAutoRegistrationProperties(File config, Properties properties) {
+    public AgentAutoRegistrationProperties(File config, Properties properties) {
         this.configFile = config;
         this.properties = properties;
     }
@@ -51,19 +53,27 @@ public class AgentAutoRegistrationProperties {
     }
 
     public String agentAutoRegisterKey() {
-        return getProperty(AGENT_AUTO_REGISTER_KEY);
+        return getProperty(AGENT_AUTO_REGISTER_KEY, "");
     }
 
     public String agentAutoRegisterResources() {
-        return getProperty(AGENT_AUTO_REGISTER_RESOURCES);
+        return getProperty(AGENT_AUTO_REGISTER_RESOURCES, "");
     }
 
     public String agentAutoRegisterEnvironments() {
-        return getProperty(AGENT_AUTO_REGISTER_ENVIRONMENTS);
+        return getProperty(AGENT_AUTO_REGISTER_ENVIRONMENTS, "");
+    }
+
+    public String getAgentAutoRegisterElasticPluginId() {
+        return getProperty(AGENT_AUTO_REGISTER_ELASTIC_PLUGIN_ID, null);
+    }
+
+    public String getAgentAutoRegisterElasticAgentId() {
+        return getProperty(AGENT_AUTO_REGISTER_ELASTIC_AGENT_ID, null);
     }
 
     public String agentAutoRegisterHostname() {
-        return getProperty(AGENT_AUTO_REGISTER_HOSTNAME);
+        return getProperty(AGENT_AUTO_REGISTER_HOSTNAME, "");
     }
 
     public void scrubRegistrationProperties() {
@@ -83,8 +93,8 @@ public class AgentAutoRegistrationProperties {
         }
     }
 
-    private String getProperty(String property) {
-        return properties().getProperty(property, "");
+    private String getProperty(String property, String defaultValue) {
+        return properties().getProperty(property, defaultValue);
     }
 
     private Properties properties() {

--- a/common/src/com/thoughtworks/go/config/AgentAutoRegistrationProperties.java
+++ b/common/src/com/thoughtworks/go/config/AgentAutoRegistrationProperties.java
@@ -15,7 +15,7 @@
  *
  */
 
-package com.thoughtworks.go.agent.service;
+package com.thoughtworks.go.config;
 
 import org.apache.commons.configuration.ConfigurationException;
 import org.apache.commons.configuration.PropertiesConfiguration;
@@ -26,7 +26,7 @@ import org.apache.log4j.Logger;
 import java.io.*;
 import java.util.Properties;
 
-class AgentAutoRegistrationProperties {
+public class AgentAutoRegistrationProperties {
     private static final Logger LOG = Logger.getLogger(AgentAutoRegistrationProperties.class);
 
     public static final String AGENT_AUTO_REGISTER_KEY = "agent.auto.register.key";
@@ -41,7 +41,7 @@ class AgentAutoRegistrationProperties {
         this(config, new Properties());
     }
 
-    public AgentAutoRegistrationProperties(File config, Properties properties) {
+    AgentAutoRegistrationProperties(File config, Properties properties) {
         this.configFile = config;
         this.properties = properties;
     }
@@ -51,19 +51,19 @@ class AgentAutoRegistrationProperties {
     }
 
     public String agentAutoRegisterKey() {
-        return properties().getProperty(AGENT_AUTO_REGISTER_KEY, "");
+        return getProperty(AGENT_AUTO_REGISTER_KEY);
     }
 
     public String agentAutoRegisterResources() {
-        return properties().getProperty(AGENT_AUTO_REGISTER_RESOURCES, "");
+        return getProperty(AGENT_AUTO_REGISTER_RESOURCES);
     }
 
     public String agentAutoRegisterEnvironments() {
-        return properties().getProperty(AGENT_AUTO_REGISTER_ENVIRONMENTS, "");
+        return getProperty(AGENT_AUTO_REGISTER_ENVIRONMENTS);
     }
 
     public String agentAutoRegisterHostname() {
-        return properties().getProperty(AGENT_AUTO_REGISTER_HOSTNAME, "");
+        return getProperty(AGENT_AUTO_REGISTER_HOSTNAME);
     }
 
     public void scrubRegistrationProperties() {
@@ -77,20 +77,30 @@ class AgentAutoRegistrationProperties {
             layout.setLineSeparator("\n");
             layout.load(reader());
             layout.save(new FileWriter(this.configFile));
+            loadProperties();
         } catch (ConfigurationException | IOException e) {
             LOG.warn("[Agent Auto Registration] Unable to scrub registration key.", e);
         }
     }
 
+    private String getProperty(String property) {
+        return properties().getProperty(property, "");
+    }
+
     private Properties properties() {
         if (this.properties.isEmpty()) {
-            try {
-                this.properties.load(reader());
-            } catch (IOException e) {
-                LOG.debug("[Agent Auto Registration] Unable to load agent auto register properties file. This agent will not auto-register.", e);
-            }
+            loadProperties();
         }
         return this.properties;
+    }
+
+    private void loadProperties() {
+        try {
+            this.properties.clear();
+            this.properties.load(reader());
+        } catch (IOException e) {
+            LOG.debug("[Agent Auto Registration] Unable to load agent auto register properties file. This agent will not auto-register.", e);
+        }
     }
 
     private StringReader reader() throws IOException {

--- a/common/src/com/thoughtworks/go/domain/AgentInstance.java
+++ b/common/src/com/thoughtworks/go/domain/AgentInstance.java
@@ -27,6 +27,7 @@ import com.thoughtworks.go.security.X509CertificateGenerator;
 import com.thoughtworks.go.server.domain.AgentInstances;
 import com.thoughtworks.go.server.service.AgentBuildingInfo;
 import com.thoughtworks.go.server.service.AgentRuntimeInfo;
+import com.thoughtworks.go.server.service.ElasticAgentRuntimeInfo;
 import com.thoughtworks.go.util.StringUtil;
 import com.thoughtworks.go.util.SystemEnvironment;
 import com.thoughtworks.go.util.TimeProvider;
@@ -342,6 +343,10 @@ public class AgentInstance implements Comparable<AgentInstance> {
     public boolean needsUpgrade() {
         if(isMissing()) return false;
         return StringUtil.isBlank(agentRuntimeInfo.getAgentLauncherVersion());
+    }
+
+    public ElasticAgentRuntimeInfo getElasticAgentRuntimeInfo(){
+        return agentRuntimeInfo.getElasticAgentRuntimeInfo();
     }
 
     public static enum AgentType {

--- a/common/src/com/thoughtworks/go/server/service/AgentRuntimeInfo.java
+++ b/common/src/com/thoughtworks/go/server/service/AgentRuntimeInfo.java
@@ -19,6 +19,7 @@ package com.thoughtworks.go.server.service;
 import java.io.File;
 import java.io.Serializable;
 
+import com.thoughtworks.go.config.AgentAutoRegistrationProperties;
 import com.thoughtworks.go.config.AgentConfig;
 import com.thoughtworks.go.domain.AgentConfigStatus;
 import com.thoughtworks.go.domain.AgentRuntimeStatus;
@@ -44,6 +45,7 @@ public class AgentRuntimeInfo implements Serializable {
     private volatile String operatingSystemName;
     private volatile String cookie;
     private volatile String agentLauncherVersion;
+    private volatile ElasticAgentRuntimeInfo elasticAgentRuntimeInfo;
 
     private AgentRuntimeInfo(AgentIdentifier identifier, AgentStatus status, String location, String cookie) {
         this(identifier, status, location, cookie, null);
@@ -100,6 +102,10 @@ public class AgentRuntimeInfo implements Serializable {
     private void refresh() {
         refreshUsableSpace();
         refreshOperatingSystem();
+    }
+
+    public void refreshElasticAgentProperties(AgentAutoRegistrationProperties refreshElasticAgentProperties) {
+        this.elasticAgentRuntimeInfo = ElasticAgentRuntimeInfo.createFrom(refreshElasticAgentProperties);
     }
 
     private void refreshOperatingSystem() {
@@ -306,6 +312,7 @@ public class AgentRuntimeInfo implements Serializable {
         if (newRuntimeInfo.isCancelled()) {
             this.setRuntimeStatus(AgentRuntimeStatus.Cancelled, null);
         }
+        this.elasticAgentRuntimeInfo = newRuntimeInfo.getElasticAgentRuntimeInfo();
         this.location = newRuntimeInfo.getLocation();
         this.usableSpace = newRuntimeInfo.getUsableSpace();
         this.operatingSystemName = newRuntimeInfo.getOperatingSystem();
@@ -318,5 +325,13 @@ public class AgentRuntimeInfo implements Serializable {
 
     public void setAgentLauncherVersion(String agentLauncherVersion) {
         this.agentLauncherVersion = agentLauncherVersion;
+    }
+
+    public ElasticAgentRuntimeInfo getElasticAgentRuntimeInfo() {
+        return elasticAgentRuntimeInfo;
+    }
+
+    public void setElasticAgentRuntimeInfo(ElasticAgentRuntimeInfo elasticAgentRuntimeInfo) {
+        this.elasticAgentRuntimeInfo = elasticAgentRuntimeInfo;
     }
 }

--- a/common/src/com/thoughtworks/go/server/service/ElasticAgentRuntimeInfo.java
+++ b/common/src/com/thoughtworks/go/server/service/ElasticAgentRuntimeInfo.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2015 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.thoughtworks.go.server.service;
+
+import com.thoughtworks.go.config.AgentAutoRegistrationProperties;
+
+import java.io.Serializable;
+
+import static org.apache.commons.lang.StringUtils.isBlank;
+
+public class ElasticAgentRuntimeInfo implements Serializable {
+
+    private volatile String agentId;
+    private volatile String pluginId;
+
+    public ElasticAgentRuntimeInfo(String elasticAgentId, String pluginId) {
+        this.agentId = elasticAgentId;
+        this.pluginId = pluginId;
+    }
+
+    public static ElasticAgentRuntimeInfo createFrom(AgentAutoRegistrationProperties properties) {
+        if (properties != null && properties.exist() && !isBlank(properties.getAgentAutoRegisterElasticPluginId())) {
+            return new ElasticAgentRuntimeInfo(properties.getAgentAutoRegisterElasticAgentId(), properties.getAgentAutoRegisterElasticPluginId());
+        }
+        return null;
+    }
+
+    public String getAgentId() {
+        return agentId;
+    }
+
+    public String getPluginId() {
+        return pluginId;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        ElasticAgentRuntimeInfo that = (ElasticAgentRuntimeInfo) o;
+
+        if (agentId != null ? !agentId.equals(that.agentId) : that.agentId != null) return false;
+        return !(pluginId != null ? !pluginId.equals(that.pluginId) : that.pluginId != null);
+
+    }
+
+    @Override
+    public int hashCode() {
+        int result = agentId != null ? agentId.hashCode() : 0;
+        result = 31 * result + (pluginId != null ? pluginId.hashCode() : 0);
+        return result;
+    }
+}

--- a/common/src/com/thoughtworks/go/server/service/ElasticAgentRuntimeInfo.java
+++ b/common/src/com/thoughtworks/go/server/service/ElasticAgentRuntimeInfo.java
@@ -18,6 +18,7 @@
 package com.thoughtworks.go.server.service;
 
 import com.thoughtworks.go.config.AgentAutoRegistrationProperties;
+import org.apache.commons.lang.builder.ToStringBuilder;
 
 import java.io.Serializable;
 
@@ -65,5 +66,10 @@ public class ElasticAgentRuntimeInfo implements Serializable {
         int result = agentId != null ? agentId.hashCode() : 0;
         result = 31 * result + (pluginId != null ? pluginId.hashCode() : 0);
         return result;
+    }
+
+    @Override
+    public String toString() {
+        return ToStringBuilder.reflectionToString(this);
     }
 }

--- a/common/test/unit/com/thoughtworks/go/config/AgentAutoRegistrationPropertiesTest.java
+++ b/common/test/unit/com/thoughtworks/go/config/AgentAutoRegistrationPropertiesTest.java
@@ -15,7 +15,7 @@
  *
  */
 
-package com.thoughtworks.go.agent.service;
+package com.thoughtworks.go.config;
 
 import org.apache.commons.io.FileUtils;
 import org.junit.Before;

--- a/server/src/com/thoughtworks/go/server/ui/AgentViewModel.java
+++ b/server/src/com/thoughtworks/go/server/ui/AgentViewModel.java
@@ -23,6 +23,7 @@ import com.thoughtworks.go.domain.AgentInstance;
 import com.thoughtworks.go.domain.AgentStatus;
 import com.thoughtworks.go.domain.DiskSpace;
 import com.thoughtworks.go.domain.IpAddress;
+import com.thoughtworks.go.server.service.ElasticAgentRuntimeInfo;
 import com.thoughtworks.go.util.comparator.AlphaAsciiComparator;
 import info.aduna.text.NumericStringComparator;
 import org.apache.commons.lang.StringUtils;
@@ -222,6 +223,10 @@ public class AgentViewModel implements Comparable<AgentViewModel>{
         int result = agentInstance != null ? agentInstance.hashCode() : 0;
         result = 31 * result + (environments != null ? environments.hashCode() : 0);
         return result;
+    }
+
+    public ElasticAgentRuntimeInfo getElasticAgentRuntimeInfo(){
+        return this.agentInstance.getElasticAgentRuntimeInfo();
     }
 
     public boolean needsUpgrade() {

--- a/server/webapp/WEB-INF/rails.new/app/presenters/api_v1/agent_representer.rb
+++ b/server/webapp/WEB-INF/rails.new/app/presenters/api_v1/agent_representer.rb
@@ -38,6 +38,7 @@ module ApiV1
     property :getStatusForDisplay, as: :status
     property :getOperatingSystem, as: :operating_system
     property :free_space, exec_context: :decorator
+    property :elastic, exec_context: :decorator
     property :resources, exec_context: :decorator
     property :environments, exec_context: :decorator
 
@@ -54,6 +55,15 @@ module ApiV1
         agent.freeDiskSpace().space
       else
         'unknown'
+      end
+    end
+
+    def elastic
+      if elastic_runtime_info = agent.getElasticAgentRuntimeInfo
+        {
+          agent_id:  elastic_runtime_info.getAgentId,
+          plugin_id: elastic_runtime_info.getPluginId
+        }
       end
     end
   end

--- a/server/webapp/WEB-INF/rails.new/spec/presenters/api_v1/agent_representer_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/presenters/api_v1/agent_representer_spec.rb
@@ -51,6 +51,7 @@ describe ApiV1::AgentRepresenter do
       status:           'Idle',
       operating_system: 'Linux',
       free_space:       10.gigabytes,
+      elastic:          false,
       resources:        ['firefox', 'linux'],
       environments:     ['load_test', 'uat']
     }


### PR DESCRIPTION
Part of #1082