### PR TITLE
#na - removing licensing code also ended up removing an authenticatio…

### DIFF
--- a/server/src/com/thoughtworks/go/server/security/providers/GoAuthenticationProvider.java
+++ b/server/src/com/thoughtworks/go/server/security/providers/GoAuthenticationProvider.java
@@ -1,0 +1,53 @@
+/*************************GO-LICENSE-START*********************************
+ * Copyright 2015 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *************************GO-LICENSE-END***********************************/
+
+package com.thoughtworks.go.server.security.providers;
+
+import com.thoughtworks.go.server.service.UserService;
+import com.thoughtworks.go.server.util.UserHelper;
+import org.springframework.security.Authentication;
+import org.springframework.security.AuthenticationException;
+import org.springframework.security.providers.AuthenticationProvider;
+
+/**
+ * @understands Creates user records in db on successful authentication
+ */
+public class GoAuthenticationProvider implements AuthenticationProvider {
+    private final UserService userService;
+    private AuthenticationProvider provider;
+
+    public GoAuthenticationProvider(UserService userService, AuthenticationProvider provider) {
+        this.userService = userService;
+        this.provider = provider;
+    }
+
+    public Authentication authenticate(Authentication authentication) throws AuthenticationException {
+        Authentication auth = provider.authenticate(authentication);
+        if (auth != null) {
+            userService.addUserIfDoesNotExist(UserHelper.getUserName(auth));
+        }
+        return auth;
+    }
+
+    public boolean supports(Class authentication) {
+        return provider.supports(authentication);
+    }
+
+    public GoAuthenticationProvider setProvider(AuthenticationProvider provider) {
+        this.provider = provider;
+        return this;
+    }
+}

--- a/server/src/com/thoughtworks/go/server/security/providers/GoAuthenticationProviderFactory.java
+++ b/server/src/com/thoughtworks/go/server/security/providers/GoAuthenticationProviderFactory.java
@@ -1,0 +1,40 @@
+/*************************GO-LICENSE-START*********************************
+ * Copyright 2015 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *************************GO-LICENSE-END***********************************/
+
+package com.thoughtworks.go.server.security.providers;
+
+import com.thoughtworks.go.server.service.UserService;
+import org.springframework.beans.factory.FactoryBean;
+
+public class GoAuthenticationProviderFactory implements FactoryBean {
+    private final UserService userService;
+
+    public GoAuthenticationProviderFactory(UserService userService) {
+        this.userService = userService;
+    }
+
+    public Object getObject() throws Exception {
+        return new GoAuthenticationProvider(userService, null);
+    }
+
+    public Class getObjectType() {
+        return GoAuthenticationProvider.class;
+    }
+
+    public boolean isSingleton() {
+        return false;
+    }
+}

--- a/server/test/unit/com/thoughtworks/go/server/security/providers/GoAuthenticationProviderFactoryTest.java
+++ b/server/test/unit/com/thoughtworks/go/server/security/providers/GoAuthenticationProviderFactoryTest.java
@@ -1,0 +1,63 @@
+/*************************GO-LICENSE-START*********************************
+ * Copyright 2015 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *************************GO-LICENSE-END***********************************/
+
+package com.thoughtworks.go.server.security.providers;
+
+import com.thoughtworks.go.server.security.GoAuthority;
+import com.thoughtworks.go.server.service.UserService;
+import com.thoughtworks.go.server.util.UserHelper;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.security.GrantedAuthority;
+import org.springframework.security.providers.AuthenticationProvider;
+import org.springframework.security.providers.UsernamePasswordAuthenticationToken;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.*;
+
+public class GoAuthenticationProviderFactoryTest {
+    private UserService userService;
+    private GoAuthenticationProviderFactory factory;
+
+    @Before public void setUp() throws Exception {
+        userService = mock(UserService.class);
+        factory = new GoAuthenticationProviderFactory(userService);
+    }
+
+    @Test
+    public void shouldCreateLicenseEnforcementProviderWithUserServicePassedIn() throws Exception {
+        GoAuthenticationProvider licenseEnforcementProvider = (GoAuthenticationProvider) factory.getObject();
+        AuthenticationProvider underlyingProvider = mock(AuthenticationProvider.class);
+        licenseEnforcementProvider.setProvider(underlyingProvider);
+        UsernamePasswordAuthenticationToken auth = new UsernamePasswordAuthenticationToken("foo", "bar");
+        UsernamePasswordAuthenticationToken resultantAuthorization = new UsernamePasswordAuthenticationToken(
+                new org.springframework.security.userdetails.User("foo-user", "pass", true, true, true, true, new GrantedAuthority[]{GoAuthority.ROLE_USER.asAuthority()}), "bar");
+        when(underlyingProvider.authenticate(auth)).thenReturn(resultantAuthorization);
+        licenseEnforcementProvider.authenticate(auth);
+        verify(userService).addUserIfDoesNotExist(UserHelper.getUserName(resultantAuthorization));
+    }
+
+    @Test
+    public void shouldReturnUserLicenseEnforcementClass() throws Exception {
+        assertTrue(factory.getObjectType() == GoAuthenticationProvider.class);
+    }
+    
+    @Test
+    public void shouldCreateNewInstancesEveryTime() throws Exception {
+        assertFalse(factory.isSingleton());
+    }
+}

--- a/server/test/unit/com/thoughtworks/go/server/security/providers/GoAuthenticationProviderTest.java
+++ b/server/test/unit/com/thoughtworks/go/server/security/providers/GoAuthenticationProviderTest.java
@@ -1,0 +1,71 @@
+/*************************GO-LICENSE-START*********************************
+ * Copyright 2015 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *************************GO-LICENSE-END***********************************/
+
+package com.thoughtworks.go.server.security.providers;
+
+import com.thoughtworks.go.server.security.GoAuthority;
+import com.thoughtworks.go.server.service.UserService;
+import com.thoughtworks.go.server.util.UserHelper;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.security.Authentication;
+import org.springframework.security.GrantedAuthority;
+import org.springframework.security.providers.AuthenticationProvider;
+import org.springframework.security.providers.UsernamePasswordAuthenticationToken;
+import org.springframework.security.userdetails.User;
+
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsNull.nullValue;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.*;
+
+public class GoAuthenticationProviderTest {
+    private UserService userService;
+    private GoAuthenticationProvider enforcementProvider;
+    private UsernamePasswordAuthenticationToken auth;
+    private Authentication resultantAuthorization;
+    private AuthenticationProvider underlyingProvider;
+
+    @Before public void setUp() throws Exception {
+        userService = mock(UserService.class);
+        underlyingProvider = mock(AuthenticationProvider.class);
+        enforcementProvider = new GoAuthenticationProvider(userService, underlyingProvider);
+        auth = new UsernamePasswordAuthenticationToken(new User("user", "pass", true, true, true, true, new GrantedAuthority[] {}), "credentials");
+        resultantAuthorization = new UsernamePasswordAuthenticationToken(new User("user-authenticated", "pass", true, true, true, true,
+                new GrantedAuthority[]{GoAuthority.ROLE_GROUP_SUPERVISOR.asAuthority()}), "credentials");
+        when(underlyingProvider.authenticate(auth)).thenReturn(resultantAuthorization);
+    }
+
+    @After
+    public void tearDown() {
+        verifyNoMoreInteractions(userService);
+    }
+
+    @Test
+    public void shouldEnforceLicenseLimit() throws Exception {
+        Authentication authentication = enforcementProvider.authenticate(auth);
+        assertThat(authentication, is(resultantAuthorization));
+        verify(userService).addUserIfDoesNotExist(UserHelper.getUserName(resultantAuthorization));
+    }
+
+    @Test
+    public void shouldNotFailWhenUnderlyingProviderDoesNotAuthenticate() throws Exception {
+        when(underlyingProvider.authenticate(auth)).thenReturn(null);
+        Authentication authentication = enforcementProvider.authenticate(auth);
+        assertThat(authentication, is(nullValue()));
+    }
+}

--- a/server/webapp/WEB-INF/applicationContext-acegi-security.xml
+++ b/server/webapp/WEB-INF/applicationContext-acegi-security.xml
@@ -96,16 +96,34 @@
         </constructor-arg>
      </bean>
 
+    <bean id="goAuthenticationProviderFactory" class="com.thoughtworks.go.server.security.providers.GoAuthenticationProviderFactory">
+        <constructor-arg index="0">
+            <bean class="com.thoughtworks.go.server.service.UserService" autowire="autodetect"/>
+        </constructor-arg>
+    </bean>
+
     <bean id="goAuthenticationManager" class="org.springframework.security.providers.ProviderManager">
         <property name="providers">
             <list>
-                <bean class="com.thoughtworks.go.server.security.providers.OauthAuthenticationProvider" autowire="autodetect"/>
-                <bean class="com.thoughtworks.go.server.security.providers.FileAuthenticationProvider"
-                      autowire="autodetect"/>
-                <bean class="com.thoughtworks.go.server.security.providers.PluginAuthenticationProvider"
-                      autowire="autodetect"/>
-                <bean class="org.springframework.security.providers.anonymous.AnonymousAuthenticationProvider"
-                      p:key="anonymousKey"/>
+                <bean factory-bean="goAuthenticationProviderFactory" factory-method="setProvider">
+                    <constructor-arg index="0">
+                        <bean class="com.thoughtworks.go.server.security.providers.OauthAuthenticationProvider" autowire="autodetect"/>
+                    </constructor-arg>
+                </bean>
+                <bean factory-bean="goAuthenticationProviderFactory" factory-method="setProvider">
+                    <constructor-arg index="0">
+                        <bean class="com.thoughtworks.go.server.security.providers.FileAuthenticationProvider" autowire="autodetect"/>
+                    </constructor-arg>
+                </bean>
+                <bean factory-bean="goAuthenticationProviderFactory" factory-method="setProvider">
+                    <constructor-arg index="0" ref="ldapAuthProvider"/>
+                </bean>
+                <bean factory-bean="goAuthenticationProviderFactory" factory-method="setProvider">
+                    <constructor-arg index="0">
+                        <bean class="com.thoughtworks.go.server.security.providers.PluginAuthenticationProvider" autowire="autodetect"/>
+                    </constructor-arg>
+                </bean>
+                <bean class="org.springframework.security.providers.anonymous.AnonymousAuthenticationProvider" p:key="anonymousKey"/>
             </list>
         </property>
     </bean>


### PR DESCRIPTION
…n provider (wrongly named as UserLicenseEnforcementProvider) which was responsible for creating user records in db. Bringing it back.

This basically leads to no user records being inserted to db so a bunch of things fail in the app.