### PR TITLE
Making core server SQL cross compatible #1406

### DIFF
--- a/addon-api/database/src/com/thoughtworks/go/database/QueryExtensions.java
+++ b/addon-api/database/src/com/thoughtworks/go/database/QueryExtensions.java
@@ -22,4 +22,6 @@ public interface QueryExtensions {
     String queryFromInclusiveModificationsForPipelineRange(String pipelineName, Integer fromCounter, Integer toCounter);
 
     String queryRelevantToLookedUpDependencyMap(List<Long> pipelineIds);
+    
+    String retrievePipelineTimeline();
 }

--- a/server/src/com/thoughtworks/go/server/database/H2Database.java
+++ b/server/src/com/thoughtworks/go/server/database/H2Database.java
@@ -252,6 +252,16 @@ public class H2Database implements Database {
                         + ")"
                         + "SELECT id, name, lookedUpId FROM link";
             }
+            
+            @Override
+            public String retrievePipelineTimeline() {
+                return "SELECT CAST(p.name AS VARCHAR), p.id AS p_id, p.counter, m.modifiedtime, "
+                        + " (SELECT CAST(materials.fingerprint AS VARCHAR) FROM materials WHERE id = m.materialId), naturalOrder, m.revision, pmr.folder, pmr.toRevisionId AS mod_id, pmr.Id as pmrid "
+                        + "FROM pipelines p, pipelinematerialrevisions pmr, modifications m "
+                        + "WHERE p.id = pmr.pipelineid "
+                        + "AND pmr.torevisionid = m.id "
+                        + "AND p.id > ?";
+            }
         };
     }
 }

--- a/server/src/com/thoughtworks/go/server/persistence/MaterialRepository.java
+++ b/server/src/com/thoughtworks/go/server/persistence/MaterialRepository.java
@@ -141,11 +141,11 @@ public class MaterialRepository extends HibernateDaoSupport {
             return new ArrayList<Long>();
         }
 
-        String minMaxQuery = " SELECT mod.materialId as materialId, min(mod.id) as min, max(mod.id) as max"
-                + " FROM modifications mod "
-                + "     INNER JOIN pipelineMaterialRevisions pmr ON (mod.id >= pmr.actualFromRevisionId AND mod.id <= pmr.toRevisionId) AND mod.materialId = pmr.materialId "
+        String minMaxQuery = " SELECT mods1.materialId as materialId, min(mods1.id) as min, max(mods1.id) as max"
+                + " FROM modifications mods1 "
+                + "     INNER JOIN pipelineMaterialRevisions pmr ON (mods1.id >= pmr.actualFromRevisionId AND mods1.id <= pmr.toRevisionId) AND mods1.materialId = pmr.materialId "
                 + " WHERE pmr.pipelineId IN (:ids) "
-                + " GROUP BY mod.materialId";
+                + " GROUP BY mods1.materialId";
 
         SQLQuery query = session.createSQLQuery("SELECT mods.id "
                 + " FROM modifications mods"
@@ -171,16 +171,16 @@ public class MaterialRepository extends HibernateDaoSupport {
                 }
                 Map<PipelineId, Set<Long>> relevantToLookedUpMap = relevantToLookedUpDependencyMap(session, pipelineIds);
 
-                SQLQuery query = session.createSQLQuery("SELECT mod.*, pmr.pipelineId as pmrPipelineId, p.name as pmrPipelineName, m.type as materialType, m.fingerprint as fingerprint"
-                        + " FROM modifications mod "
-                        + "     INNER JOIN pipelineMaterialRevisions pmr ON (mod.id >= pmr.fromRevisionId AND mod.id <= pmr.toRevisionId) AND mod.materialId = pmr.materialId "
+                SQLQuery query = session.createSQLQuery("SELECT mods.*, pmr.pipelineId as pmrPipelineId, p.name as pmrPipelineName, m.type as materialType, m.fingerprint as fingerprint"
+                        + " FROM modifications mods "
+                        + "     INNER JOIN pipelineMaterialRevisions pmr ON (mods.id >= pmr.fromRevisionId AND mods.id <= pmr.toRevisionId) AND mods.materialId = pmr.materialId "
                         + "     INNER JOIN pipelines p ON pmr.pipelineId = p.id"
-                        + "     INNER JOIN materials m ON mod.materialId = m.id"
+                        + "     INNER JOIN materials m ON mods.materialId = m.id"
                         + " WHERE pmr.pipelineId IN (:ids)");
 
                 @SuppressWarnings({"unchecked"})
                 List<Object[]> allModifications = query.
-                        addEntity("mod", Modification.class).
+                        addEntity("mods", Modification.class).
                         addScalar("pmrPipelineId", new LongType()).
                         addScalar("pmrPipelineName", new StringType()).
                         addScalar("materialType", new StringType()).

--- a/server/src/com/thoughtworks/go/server/persistence/PipelineRepository.java
+++ b/server/src/com/thoughtworks/go/server/persistence/PipelineRepository.java
@@ -16,6 +16,8 @@
 
 package com.thoughtworks.go.server.persistence;
 
+import com.thoughtworks.go.database.Database;
+import com.thoughtworks.go.database.QueryExtensions;
 import java.math.BigInteger;
 import java.sql.SQLException;
 import java.util.ArrayList;
@@ -49,12 +51,14 @@ import org.springframework.stereotype.Component;
 public class PipelineRepository extends HibernateDaoSupport {
     private static final Logger LOGGER = Logger.getLogger(PipelineRepository.class);
     private final SystemEnvironment systemEnvironment;
+    private final QueryExtensions queryExtensions;
     private GoCache goCache;
 
     @Autowired
-    public PipelineRepository(SessionFactory sessionFactory, GoCache goCache, SystemEnvironment systemEnvironment) {
+    public PipelineRepository(SessionFactory sessionFactory, GoCache goCache, SystemEnvironment systemEnvironment, Database databaseStrategy) {
         this.goCache = goCache;
         this.systemEnvironment = systemEnvironment;
+        this.queryExtensions = databaseStrategy.getQueryExtensions();
         setSessionFactory(sessionFactory);
     }
 
@@ -108,13 +112,7 @@ public class PipelineRepository extends HibernateDaoSupport {
             }
 
             private List<Object[]> retrieveTimeline(Session session, PipelineTimeline pipelineTimeline) {
-                String sql = "SELECT CAST(p.name AS VARCHAR), p.id AS p_id, p.counter, m.modifiedtime, "
-                        + " (SELECT CAST(materials.fingerprint AS VARCHAR) FROM materials WHERE id = m.materialId), naturalOrder, m.revision, pmr.folder, pmr.toRevisionId AS mod_id, pmr.Id as pmrid "
-                        + "FROM pipelines p, pipelinematerialrevisions pmr, modifications m "
-                        + "WHERE p.id = pmr.pipelineid "
-                        + "AND pmr.torevisionid = m.id "
-                        + "AND p.id > ?";
-                SQLQuery query = session.createSQLQuery(sql);
+                SQLQuery query = session.createSQLQuery(queryExtensions.retrievePipelineTimeline());
                 query.setLong(0, pipelineTimeline.maximumId());
 
                 List<Object[]> matches = loadTimeline(query);

--- a/server/test/unit/com/thoughtworks/go/server/persistence/PipelineRepositoryTest.java
+++ b/server/test/unit/com/thoughtworks/go/server/persistence/PipelineRepositoryTest.java
@@ -17,11 +17,13 @@
 package com.thoughtworks.go.server.persistence;
 
 
+import com.thoughtworks.go.database.QueryExtensions;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
 
 import com.thoughtworks.go.server.cache.GoCache;
+import com.thoughtworks.go.server.database.DatabaseStrategy;
 import com.thoughtworks.go.server.domain.user.PipelineSelections;
 import com.thoughtworks.go.util.SystemEnvironment;
 import org.hibernate.SessionFactory;
@@ -40,6 +42,8 @@ public class PipelineRepositoryTest {
     private HibernateTemplate hibernateTemplate;
     private PipelineRepository pipelineRepository;
     private SystemEnvironment systemEnvironment;
+    private DatabaseStrategy databaseStrategy;
+    private QueryExtensions queryExtensions;
 
     @Before
     public void setup() {
@@ -47,7 +51,10 @@ public class PipelineRepositoryTest {
         hibernateTemplate = mock(HibernateTemplate.class);
         goCache = mock(GoCache.class);
         systemEnvironment = mock(SystemEnvironment.class);
-        pipelineRepository = new PipelineRepository(sessionFactory, goCache,systemEnvironment);
+        databaseStrategy = mock(DatabaseStrategy.class);
+        queryExtensions = mock(QueryExtensions.class);
+        when(databaseStrategy.getQueryExtensions()).thenReturn(queryExtensions);
+        pipelineRepository = new PipelineRepository(sessionFactory, goCache,systemEnvironment, databaseStrategy);
         pipelineRepository.setHibernateTemplate(hibernateTemplate);
     }
 

--- a/server/test/unit/com/thoughtworks/go/server/persistence/PipelineRepositoryTest.java
+++ b/server/test/unit/com/thoughtworks/go/server/persistence/PipelineRepositoryTest.java
@@ -43,7 +43,6 @@ public class PipelineRepositoryTest {
     private PipelineRepository pipelineRepository;
     private SystemEnvironment systemEnvironment;
     private DatabaseStrategy databaseStrategy;
-    private QueryExtensions queryExtensions;
 
     @Before
     public void setup() {
@@ -52,8 +51,6 @@ public class PipelineRepositoryTest {
         goCache = mock(GoCache.class);
         systemEnvironment = mock(SystemEnvironment.class);
         databaseStrategy = mock(DatabaseStrategy.class);
-        queryExtensions = mock(QueryExtensions.class);
-        when(databaseStrategy.getQueryExtensions()).thenReturn(queryExtensions);
         pipelineRepository = new PipelineRepository(sessionFactory, goCache,systemEnvironment, databaseStrategy);
         pipelineRepository.setHibernateTemplate(hibernateTemplate);
     }


### PR DESCRIPTION
* Changing the alias 'mod' as it is a reserved word for MySQL
* Adding retrieveTimeline query to the QueryExtensions interface so it can be override for different DBs
* Adding the QueryExtensions interface to PipelineRepository to remove the embedded SQL