### PR TITLE
Use label tag helper for auto update checkbox

### DIFF
--- a/server/webapp/WEB-INF/rails.new/app/views/admin/materials/pluggable_scm/_form.html.erb
+++ b/server/webapp/WEB-INF/rails.new/app/views/admin/materials/pluggable_scm/_form.html.erb
@@ -38,7 +38,7 @@
 
                         <div class="form_item_block checkbox_row material_options">
                             <%= f.check_box(com.thoughtworks.go.domain.scm.SCM::AUTO_UPDATE, {:include_blank => true, :class => "form_input"}, "true") -%>
-                            <label for="material_<%= com.thoughtworks.go.domain.scm.SCM::AUTO_UPDATE -%>"><%= l.string('SHOULD_AUTO_UPDATE') -%></label>
+                            <%= f.label(com.thoughtworks.go.domain.scm.SCM::AUTO_UPDATE, l.string('SHOULD_AUTO_UPDATE')) %>
                             <%= error_message_on(scm_config, com.thoughtworks.go.domain.scm.SCM::AUTO_UPDATE, :css_class => "form_error") %>
                         </div>
 

--- a/server/webapp/WEB-INF/rails.new/app/views/admin/materials/shared/_options.html.erb
+++ b/server/webapp/WEB-INF/rails.new/app/views/admin/materials/shared/_options.html.erb
@@ -1,5 +1,5 @@
 <div class="form_item_block checkbox_row material_options">
     <%= scope[:form].check_box(com.thoughtworks.go.config.materials.ScmMaterialConfig::AUTO_UPDATE, {:include_blank => true, :class => "form_input"}, "true") -%>
-    <label for="material_<%= com.thoughtworks.go.config.materials.ScmMaterialConfig::AUTO_UPDATE -%>"><%= l.string('SHOULD_AUTO_UPDATE') -%></label>
+    <%= scope[:form].label(com.thoughtworks.go.config.materials.ScmMaterialConfig::AUTO_UPDATE, l.string('SHOULD_AUTO_UPDATE')) %>
     <%= error_message_on(scope[:form].object, com.thoughtworks.go.config.materials.ScmMaterialConfig::AUTO_UPDATE, :css_class => "form_error") %>
 </div>


### PR DESCRIPTION
When using the label tag directly it didn't work in the create new
pipeline view. You had to explicitly click the checkbox instead of the label.

<img width="308" alt="add_pipeline_-_go" src="https://cloud.githubusercontent.com/assets/18167/9134398/45ad1890-3d36-11e5-90df-a9cc900be4bf.png">

The old code did work in the materials tab of an already created pipeline though, and it works now as well from my manual testing.

There's [another location](https://github.com/gocd/gocd/blob/master/server/webapp/WEB-INF/rails.new/app/views/admin/materials/pluggable_scm/_form.html.erb#L41) that uses a `<label>` tag manually, but I couldn't figure out which page was using that code so I've left it alone for now. 

I did a search through the code and at a cursory glance it seemed to me like the other uses of the label tag without using the Rails helpers were fine.