### PR TITLE
Also remove ignored files when cleaning a git working dir

### DIFF
--- a/common/src/com/thoughtworks/go/domain/materials/git/GitCommand.java
+++ b/common/src/com/thoughtworks/go/domain/materials/git/GitCommand.java
@@ -188,7 +188,7 @@ public class GitCommand extends SCMCommand {
     }
 
     private void cleanUnversionedFiles(File workingDir) {
-        String[] args = new String[]{"clean", "-dff"};
+        String[] args = new String[]{"clean", "-dffx"};
         CommandLine gitCmd = git().withArgs(args).withWorkingDir(workingDir);
         runOrBomb(gitCmd);
     }


### PR DESCRIPTION
If `git clean` is used without -x, all files that are listed in .gitignore survive the cleaning.

This has bitten me hard when trying to let gocd build cURL, which uses an ignored build subdirectory. Some remnants of old builds that survived the cleaning led to a subtly broken library.