### PR TITLE
Upgrade `ansi_up` from 1.1.3 up to `1.3.0`

### DIFF
--- a/server/webapp/WEB-INF/rails.new/app/assets/javascripts/lib/ansi_up.js
+++ b/server/webapp/WEB-INF/rails.new/app/assets/javascripts/lib/ansi_up.js
@@ -1,5 +1,5 @@
 // ansi_up.js
-// version : 1.1.3
+// version : 1.3.0
 // author : Dru Nelson
 // license : MIT
 // http://github.com/drudru/ansi_up
@@ -7,7 +7,7 @@
 (function (Date, undefined) {
 
     var ansi_up,
-        VERSION = "1.1.3",
+        VERSION = "1.3.0",
 
         // check for nodeJS
         hasModule = (typeof module !== 'undefined'),
@@ -34,12 +34,53 @@
             { color: "85, 255, 255",   'class': "ansi-bright-cyan"    },
             { color: "255, 255, 255",  'class': "ansi-bright-white"   }
           ]
-        ];
+        ],
+
+        // 256 Colors Palette
+        PALETTE_COLORS;
 
     function Ansi_Up() {
-      this.fg = this.bg = null;
+      this.fg = this.bg = this.fg_truecolor = this.bg_truecolor = null;
       this.bright = 0;
     }
+
+    Ansi_Up.prototype.setup_palette = function() {
+      PALETTE_COLORS = [];
+      // Index 0..15 : System color
+      (function() {
+        var i, j;
+        for (i = 0; i < 2; ++i) {
+          for (j = 0; j < 8; ++j) {
+            PALETTE_COLORS.push(ANSI_COLORS[i][j]['color']);
+          }
+        }
+      })();
+
+      // Index 16..231 : RGB 6x6x6
+      // https://gist.github.com/jasonm23/2868981#file-xterm-256color-yaml
+      (function() {
+        var levels = [0, 95, 135, 175, 215, 255];
+        var format = function (r, g, b) { return levels[r] + ', ' + levels[g] + ', ' + levels[b] };
+        var r, g, b;
+        for (r = 0; r < 6; ++r) {
+          for (g = 0; g < 6; ++g) {
+            for (b = 0; b < 6; ++b) {
+              PALETTE_COLORS.push(format.call(this, r, g, b));
+            }
+          }
+        }
+      })();
+
+      // Index 232..255 : Grayscale
+      (function() {
+        var level = 8;
+        var format = function(level) { return level + ', ' + level + ', ' + level };
+        var i;
+        for (i = 0; i < 24; ++i, level += 10) {
+          PALETTE_COLORS.push(format.call(this, level));
+        }
+      })();
+    };
 
     Ansi_Up.prototype.escape_for_html = function (txt) {
       return txt.replace(/[&<>]/gm, function(str) {
@@ -56,24 +97,29 @@
     };
 
     Ansi_Up.prototype.ansi_to_html = function (txt, options) {
-
-      var data4 = txt.split(/\033\[/);
-
-      var first = data4.shift(); // the first chunk is not the result of the split
-
-      var self = this;
-      var data5 = data4.map(function (chunk) {
-        return self.process_chunk(chunk, options);
-      });
-
-      data5.unshift(first);
-
-      var escaped_data = data5.join('');
-
-      return escaped_data;
+      return this.process(txt, options, true);
     };
 
-    Ansi_Up.prototype.process_chunk = function (text, options) {
+    Ansi_Up.prototype.ansi_to_text = function (txt) {
+      var options = {};
+      return this.process(txt, options, false);
+    };
+
+    Ansi_Up.prototype.process = function (txt, options, markup) {
+      var self = this;
+      var raw_text_chunks = txt.split(/\033\[/);
+      var first_chunk = raw_text_chunks.shift(); // the first chunk is not the result of the split
+
+      var color_chunks = raw_text_chunks.map(function (chunk) {
+        return self.process_chunk(chunk, options, markup);
+      });
+
+      color_chunks.unshift(first_chunk);
+
+      return color_chunks.join('');
+    };
+
+    Ansi_Up.prototype.process_chunk = function (text, options, markup) {
 
       // Are we using classes or styles?
       options = typeof options == 'undefined' ? {} : options;
@@ -82,21 +128,38 @@
 
       // Each 'chunk' is the text after the CSI (ESC + '[') and before the next CSI/EOF.
       //
-      // This regex matches two groups within a chunk.
-      // The first group matches all of the number+semicolon command sequences
-      // before the 'm' character. These are the graphics or SGR commands.
-      // The second group is the text (including newlines) that is colored by
-      // the first group's commands.
-      var matches = text.match(/([\d;]*)m([\s\S]*)/m);
+      // This regex matches four groups within a chunk.
+      //
+      // The first and third groups match code type.
+      // We supported only SGR command. It has empty first group and 'm' in third.
+      //
+      // The second group matches all of the number+semicolon command sequences
+      // before the 'm' (or other trailing) character.
+      // These are the graphics or SGR commands.
+      //
+      // The last group is the text (including newlines) that is colored by
+      // the other group's commands.
+      var matches = text.match(/^([!\x3c-\x3f]*)([\d;]*)([\x20-\x2c]*[\x40-\x7e])([\s\S]*)/m);
 
       if (!matches) return text;
 
-      var orig_txt = matches[2];
-      var nums = matches[1].split(';');
+      var orig_txt = matches[4];
+      var nums = matches[2].split(';');
+
+      // We currently support only "SGR" (Select Graphic Rendition)
+      // Simply ignore if not a SGR command.
+      if (matches[1] !== '' || matches[3] !== 'm') {
+        return orig_txt;
+      }
+
+      if (!markup) {
+        return orig_txt;
+      }
 
       var self = this;
-      nums.map(function (num_str) {
 
+      while (nums.length > 0) {
+        var num_str = nums.shift();
         var num = parseInt(num_str);
 
         if (isNaN(num) || num === 0) {
@@ -104,6 +167,10 @@
           self.bright = 0;
         } else if (num === 1) {
           self.bright = 1;
+        } else if (num == 39) {
+          self.fg = null;
+        } else if (num == 49) {
+          self.bg = null;
         } else if ((num >= 30) && (num < 38)) {
           self.fg = ANSI_COLORS[self.bright][(num % 10)][key];
         } else if ((num >= 90) && (num < 98)) {
@@ -112,16 +179,86 @@
           self.bg = ANSI_COLORS[0][(num % 10)][key];
         } else if ((num >= 100) && (num < 108)) {
           self.bg = ANSI_COLORS[1][(num % 10)][key];
+        } else if (num === 38 || num === 48) { // extend color (38=fg, 48=bg)
+          (function() {
+            var is_foreground = (num === 38);
+            if (nums.length >= 1) {
+              var mode = nums.shift();
+              if (mode === '5' && nums.length >= 1) { // palette color
+                var palette_index = parseInt(nums.shift());
+                if (palette_index >= 0 && palette_index <= 255) {
+                  if (!use_classes) {
+                    if (!PALETTE_COLORS) {
+                      self.setup_palette.call(self);
+                    }
+                    if (is_foreground) {
+                      self.fg = PALETTE_COLORS[palette_index];
+                    } else {
+                      self.bg = PALETTE_COLORS[palette_index];
+                    }
+                  } else {
+                    var klass = (palette_index >= 16)
+                          ? ('ansi-palette-' + palette_index)
+                          : ANSI_COLORS[palette_index > 7 ? 1 : 0][palette_index % 8]['class'];
+                    if (is_foreground) {
+                      self.fg = klass;
+                    } else {
+                      self.bg = klass;
+                    }
+                  }
+                }
+              } else if(mode === '2' && nums.length >= 3) { // true color
+                var r = parseInt(nums.shift());
+                var g = parseInt(nums.shift());
+                var b = parseInt(nums.shift());
+                if ((r >= 0 && r <= 255) && (g >= 0 && g <= 255) && (b >= 0 && b <= 255)) {
+                  var color = r + ', ' + g + ', ' + b;
+                  if (!use_classes) {
+                    if (is_foreground) {
+                      self.fg = color;
+                    } else {
+                      self.bg = color;
+                    }
+                  } else {
+                    if (is_foreground) {
+                      self.fg = 'ansi-truecolor';
+                      self.fg_truecolor = color;
+                    } else {
+                      self.bg = 'ansi-truecolor';
+                      self.bg_truecolor = color;
+                    }
+                  }
+                }
+              }
+            }
+          })();
         }
-      });
+      }
 
       if ((self.fg === null) && (self.bg === null)) {
         return orig_txt;
       } else {
-        var styles = classes = [];
+        var styles = [];
+        var classes = [];
+        var data = {};
+        var render_data = function (data) {
+          var fragments = [];
+          var key;
+          for (key in data) {
+            if (data.hasOwnProperty(key)) {
+              fragments.push('data-' + key + '="' + this.escape_for_html(data[key]) + '"');
+            }
+          }
+          return fragments.length > 0 ? ' ' + fragments.join(' ') : '';
+        };
+
         if (self.fg) {
           if (use_classes) {
             classes.push(self.fg + "-fg");
+            if (self.fg_truecolor !== null) {
+              data['ansi-truecolor-fg'] = self.fg_truecolor;
+              self.fg_truecolor = null;
+            }
           } else {
             styles.push("color:rgb(" + self.fg + ")");
           }
@@ -129,14 +266,18 @@
         if (self.bg) {
           if (use_classes) {
             classes.push(self.bg + "-bg");
+            if (self.bg_truecolor !== null) {
+              data['ansi-truecolor-bg'] = self.bg_truecolor;
+              self.bg_truecolor = null;
+            }
           } else {
             styles.push("background-color:rgb(" + self.bg + ")");
           }
         }
         if (use_classes) {
-          return "<span class=\"" + classes.join(' ') + "\">" + orig_txt + "</span>";
+          return '<span class="' + classes.join(' ') + '"' + render_data.call(self, data) + '>' + orig_txt + '</span>';
         } else {
-          return "<span style=\"" + styles.join(';') + "\">"  + orig_txt + "</span>";
+          return '<span style="' + styles.join(';') + '"' + render_data.call(self, data) + '>' + orig_txt + '</span>';
         }
       }
     };
@@ -157,6 +298,11 @@
       ansi_to_html: function (txt, options) {
         var a2h = new Ansi_Up();
         return a2h.ansi_to_html(txt, options);
+      },
+
+      ansi_to_text: function (txt) {
+        var a2h = new Ansi_Up();
+        return a2h.ansi_to_text(txt);
       },
 
       ansi_to_html_obj: function () {


### PR DESCRIPTION
Changelog available here - https://github.com/drudru/ansi_up/compare/v1.1.3...v1.3.0

Relevant updates from changelog -

* Add support for true color
* Add support to reset bg and fg with 39 and 49 code
* Ignore unsupported CSI