### PR TITLE
Fix startup scripts

### DIFF
--- a/installers/agent/release/agent.sh
+++ b/installers/agent/release/agent.sh
@@ -118,8 +118,8 @@ if [ "$JAVA_HOME" == "" ]; then
 fi
 
 if [ "$DAEMON" == "Y" ]; then
-    exec nohup $CMD >>$LOG_FILE 2>&1 &
-    echo $! >$PID_FILE
+    eval exec nohup "$CMD" >>"$LOG_FILE" 2>&1 &
+    echo $! >"$PID_FILE"
 else
-    exec $CMD
+    eval exec "$CMD"
 fi

--- a/installers/agent/release/agent.sh
+++ b/installers/agent/release/agent.sh
@@ -101,6 +101,9 @@ AGENT_STARTUP_ARGS="-Dcruise.console.publish.interval=10 -Xms$AGENT_MEM -Xmx$AGE
 if [ "$TMPDIR" != "" ]; then
     AGENT_STARTUP_ARGS="$AGENT_STARTUP_ARGS -Djava.io.tmpdir=$TMPDIR"
 fi
+if [ "$USE_URANDOM" != "false" ] && [ -e "/dev/urandom" ]; then
+    AGENT_STARTUP_ARGS="$AGENT_STARTUP_ARGS -Djava.security.egd=file:/dev/./urandom"
+fi
 export AGENT_STARTUP_ARGS
 export LOG_DIR
 export LOG_FILE

--- a/installers/agent/release/agent.sh
+++ b/installers/agent/release/agent.sh
@@ -46,7 +46,7 @@ else
     AGENT_WORK_DIR=$AGENT_DIR
 fi
 
-if [ ! -d ${AGENT_WORK_DIR} ]; then
+if [ ! -d "${AGENT_WORK_DIR}" ]; then
     echo Agent working directory ${AGENT_WORK_DIR} does not exist
     exit 2
 fi
@@ -61,10 +61,7 @@ else
     LOG_DIR=$AGENT_WORK_DIR
 fi
 
-
-
 LOG_FILE=$LOG_DIR/${SERVICE_NAME}-bootstrapper.log
-
 
 if [ "$PID_FILE" ]; then
     echo "[`date`] Use PID_FILE: $PID_FILE"
@@ -110,9 +107,9 @@ export LOG_FILE
 
 CMD="$JAVA_HOME/bin/java -jar \"$AGENT_DIR/agent-bootstrapper.jar\" $GO_SERVER $GO_SERVER_PORT"
 
-echo "[`date`] Starting Go Agent Bootstrapper with command: $CMD" >>$LOG_FILE
-echo "[`date`] Starting Go Agent Bootstrapper in directory: $AGENT_WORK_DIR" >>$LOG_FILE
-echo "[`date`] AGENT_STARTUP_ARGS=$AGENT_STARTUP_ARGS" >>$LOG_FILE
+echo "[`date`] Starting Go Agent Bootstrapper with command: $CMD" >>"$LOG_FILE"
+echo "[`date`] Starting Go Agent Bootstrapper in directory: $AGENT_WORK_DIR" >>"$LOG_FILE"
+echo "[`date`] AGENT_STARTUP_ARGS=$AGENT_STARTUP_ARGS" >>"$LOG_FILE"
 cd "$AGENT_WORK_DIR"
 
 if [ "$JAVA_HOME" == "" ]; then

--- a/installers/server/release/server.sh
+++ b/installers/server/release/server.sh
@@ -141,4 +141,3 @@ if [ "$DAEMON" == "Y" ]; then
 else
     exec $CMD
 fi
-

--- a/installers/server/release/server.sh
+++ b/installers/server/release/server.sh
@@ -121,6 +121,9 @@ SERVER_STARTUP_ARGS+=("-Dcruise.server.port=$GO_SERVER_PORT -Dcruise.server.ssl.
 if [ "$TMPDIR" != "" ]; then
     SERVER_STARTUP_ARGS+=("-Djava.io.tmpdir=$TMPDIR")
 fi
+if [ "$USE_URANDOM" != "false" ] && [ -e "/dev/urandom" ]; then
+    SERVER_STARTUP_ARGS+=("-Djava.security.egd=file:/dev/./urandom")
+fi
 CMD="$JAVA_HOME/bin/java ${SERVER_STARTUP_ARGS[@]} -jar $SERVER_DIR/go.jar"
 
 echo "Starting Go Server with command: $CMD" >>$LOG_FILE


### PR DESCRIPTION
Commit messages should be descriptive. This should be easy to verify.

Functional tests should be changed to use these scripts, and not their own.

Fixes #1460.