### PR TITLE
Improve the "perceived" performance of `/go/api/support` call.

### DIFF
--- a/server/webapp/WEB-INF/rails.new/app/controllers/api/server_controller.rb
+++ b/server/webapp/WEB-INF/rails.new/app/controllers/api/server_controller.rb
@@ -25,10 +25,12 @@ class Api::ServerController < Api::ApiController
 
   def capture_support_info
     information = server_status_service.captureServerInfo(current_user, result = HttpLocalizedOperationResult.new)
-    if !result.isSuccessful()
-      render_localized_operation_result result && return
+
+    if result.isSuccessful()
+      render text: information, layout: false
+    else
+      render_localized_operation_result(result)
     end
 
-    send_data information, disposition: "inline", stream: false, type: "text"
   end
 end


### PR DESCRIPTION
On large go servers that have network latency, the `/go/api/support`
api call takes forever to render when the server has a lot content to render.

Currently the text output is rendered with the following headers -

```
Content-Disposition:inline
Content-Transfer-Encoding:binary
Content-Type:text
```

The fix is to simply use `render text: plain_text` that does the "right thing" and
compresses better because of the correct content type.

New headers -

```
Content-Encoding:gzip
Content-Type:text/plain; charset=UTF-8
```