### PR TITLE
Modified StageXmlViewModel to expose duration property via API xml format

### DIFF
--- a/server/src/com/thoughtworks/go/server/domain/xml/StageXmlViewModel.java
+++ b/server/src/com/thoughtworks/go/server/domain/xml/StageXmlViewModel.java
@@ -64,7 +64,7 @@ public class StageXmlViewModel implements XmlRepresentable {
 
         root.addElement("approvedBy").addCDATA(stage.getApprovedBy());
 
-        root.addElement("duration").addText(stage.getDuration().duration(RunDuration.PERIOD_FORMATTER));
+        root.addElement("duration").addText(getStageDurationForXml(stage));
 
         Element jobs = root.addElement("jobs");
         for (JobInstance jobInstance : stage.getJobInstances()) {
@@ -76,5 +76,13 @@ public class StageXmlViewModel implements XmlRepresentable {
 
     public String httpUrl(String baseUrl) {
         return httpUrlFor(baseUrl, stage.getId());
+    }
+
+    public String getStageDurationForXml(Stage stage) {
+        try {
+            return stage.getDuration().duration(RunDuration.PERIOD_FORMATTER);
+        } catch (NullPointerException e) {
+            return "N/A";
+        }
     }
 }

--- a/server/src/com/thoughtworks/go/server/domain/xml/StageXmlViewModel.java
+++ b/server/src/com/thoughtworks/go/server/domain/xml/StageXmlViewModel.java
@@ -17,6 +17,7 @@
 package com.thoughtworks.go.server.domain.xml;
 
 import com.thoughtworks.go.domain.JobInstance;
+import com.thoughtworks.go.domain.RunDuration;
 import com.thoughtworks.go.domain.Stage;
 import com.thoughtworks.go.domain.StageIdentifier;
 import com.thoughtworks.go.domain.XmlRepresentable;
@@ -62,6 +63,8 @@ public class StageXmlViewModel implements XmlRepresentable {
         root.addElement("state").addText(stage.status());
 
         root.addElement("approvedBy").addCDATA(stage.getApprovedBy());
+
+        root.addElement("duration").addText(stage.getDuration().duration(RunDuration.PERIOD_FORMATTER));
 
         Element jobs = root.addElement("jobs");
         for (JobInstance jobInstance : stage.getJobInstances()) {

--- a/server/webapp/WEB-INF/rails.new/spec/views/api/stages/index_xml_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/views/api/stages/index_xml_spec.rb
@@ -25,6 +25,7 @@ describe "/api/stages" do
     @stage.setApprovedBy("blahUser")
     @stage.setPipelineId(100)
     @stage_id = @stage.getIdentifier()
+    @stage_duration = @stage.getDuration().toString()
     @context = XmlWriterContext.new("http://localhost:8153/go", nil, nil, nil, nil)
     assign(:doc, StageXmlViewModel.new(@stage).toXml(@context))
     allow(view).to receive(:api_pipeline_instance_url) do |options|
@@ -45,6 +46,7 @@ describe "/api/stages" do
     expect(stage.xpath("state").text).to eq("Completed")
     expect(stage.xpath("state").text).to eq("Completed")
     expect(stage.xpath("approvedBy").text).to eq("blahUser")
+    expect(stage.xpath("duration").text).to eq(@stage_duration)
 
     jobs = stage.xpath("jobs/job")
     expect(jobs.count).to eq(1)


### PR DESCRIPTION
Simple change to expose stage duration via XML feed in the API:
GET /go/api/stages/:stage_id.xml

The duration property is the same as is shown in the UI.