### PR TITLE
Remove @Deprecated PipelineInstanceGroupModel#getConfig()

### DIFF
--- a/server/src/com/thoughtworks/go/server/presentation/PipelineHistoryGroupingUtil.java
+++ b/server/src/com/thoughtworks/go/server/presentation/PipelineHistoryGroupingUtil.java
@@ -38,7 +38,7 @@ public class PipelineHistoryGroupingUtil {
     private PipelineInstanceGroupModel createGroupFor(PipelineInstanceModel pipelineInstanceModel) {
         PipelineInstanceGroupModel group = new PipelineInstanceGroupModel();
         group.getPipelineInstances().add(pipelineInstanceModel);
-        group.getConfig().addAll(pipelineInstanceModel.getStageHistory());
+        group.getStages().addAll(pipelineInstanceModel.getStageHistory());
         return group;
     }
 

--- a/server/src/com/thoughtworks/go/server/presentation/models/PipelineHistoryJsonPresentationModel.java
+++ b/server/src/com/thoughtworks/go/server/presentation/models/PipelineHistoryJsonPresentationModel.java
@@ -127,8 +127,7 @@ public class PipelineHistoryJsonPresentationModel implements JsonAware {
         JsonList jsonList = new JsonList();
         for (PipelineInstanceGroupModel group : pipelineHistoryGroups) {
             JsonMap jsonMap = new JsonMap();
-            BaseCollection<StageConfigurationModel> groupConfig = group.getConfig();
-            Json configJson = configAsJson(groupConfig);
+            Json configJson = configAsJson(group.getStages());
             jsonMap.put("config", configJson);
             jsonMap.put("history", historyAsJson(group.getPipelineInstances()));
             jsonList.add(jsonMap);
@@ -136,9 +135,9 @@ public class PipelineHistoryJsonPresentationModel implements JsonAware {
         return jsonList;
     }
 
-    private Json configAsJson(BaseCollection<StageConfigurationModel> config) {
+    private Json configAsJson(Iterable<StageConfigurationModel> stages) {
         JsonList jsonList = new JsonList();
-        for (StageConfigurationModel stageInfo : config) {
+        for (StageConfigurationModel stageInfo : stages) {
             JsonMap jsonMap = new JsonMap();
             jsonMap.put("name", stageInfo.getName());
             jsonMap.put("isAutoApproved", String.valueOf(stageInfo.isAutoApproved()));

--- a/server/src/com/thoughtworks/go/server/presentation/models/PipelineInstanceGroupModel.java
+++ b/server/src/com/thoughtworks/go/server/presentation/models/PipelineInstanceGroupModel.java
@@ -47,11 +47,6 @@ public class PipelineInstanceGroupModel {
         pipelineInstances = PipelineInstanceModels.createPipelineInstanceModels();
     }
 
-    @Deprecated
-    public StageConfigurationModels getConfig() {
-        return config;
-    }
-
     public Collection<StageConfigurationModel> getStages() {
         return config;
     }

--- a/server/src/com/thoughtworks/go/server/presentation/models/PipelineInstanceGroupModel.java
+++ b/server/src/com/thoughtworks/go/server/presentation/models/PipelineInstanceGroupModel.java
@@ -26,7 +26,7 @@ import com.thoughtworks.go.presentation.pipelinehistory.PipelineInstanceModels;
 import com.thoughtworks.go.presentation.pipelinehistory.StageInstanceModels;
 
 public class PipelineInstanceGroupModel {
-    private StageConfigurationModels config;
+    private StageConfigurationModels stages;
     private PipelineInstanceModels pipelineInstances;
     private Map<String, StageIdentifier> latestStages;
 
@@ -42,13 +42,13 @@ public class PipelineInstanceGroupModel {
         this(new StageConfigurationModels());
     }
 
-    public PipelineInstanceGroupModel(StageConfigurationModels config) {
-        this.config = config;
+    public PipelineInstanceGroupModel(StageConfigurationModels stages) {
+        this.stages = stages;
         pipelineInstances = PipelineInstanceModels.createPipelineInstanceModels();
     }
 
     public Collection<StageConfigurationModel> getStages() {
-        return config;
+        return stages;
     }
 
     public PipelineInstanceModels getPipelineInstances() {
@@ -57,11 +57,11 @@ public class PipelineInstanceGroupModel {
 
     public boolean hasSameStagesAs(PipelineInstanceModel pipelineInstanceModel) {
         StageInstanceModels stageHistory = pipelineInstanceModel.getStageHistory();
-        if (config.size() != stageHistory.size()) {
+        if (stages.size() != stageHistory.size()) {
             return false;
         }
-        for (int i = 0; i < config.size(); i++) {
-            if (!equals(config.get(i), stageHistory.get(i))) {
+        for (int i = 0; i < stages.size(); i++) {
+            if (!equals(stages.get(i), stageHistory.get(i))) {
                 return false;
             }
         }
@@ -69,7 +69,7 @@ public class PipelineInstanceGroupModel {
     }
 
     public boolean match(PipelineConfig pipelineConfig) {
-        return config.match(pipelineConfig);
+        return stages.match(pipelineConfig);
     }
 
     private boolean equals(StageConfigurationModel obj1, StageConfigurationModel obj2) {

--- a/server/test/unit/com/thoughtworks/go/server/presentation/models/PipelineHistoryGroupTest.java
+++ b/server/test/unit/com/thoughtworks/go/server/presentation/models/PipelineHistoryGroupTest.java
@@ -39,7 +39,7 @@ public class PipelineHistoryGroupTest {
     @Test
     public void shouldMatchSpecifiedItem() throws Exception {
         PipelineInstanceGroupModel group = new PipelineInstanceGroupModel();
-        group.getConfig().addAll(asList(new SimpleInfo("stage1", true), new SimpleInfo("stage2", false)));
+        group.getStages().addAll(asList(new SimpleInfo("stage1", true), new SimpleInfo("stage2", false)));
         PipelineInstanceModel pipelineInstanceModel = PipelineHistoryItemMother.custom(
                 StageHistoryItemMother.custom("stage1", true), StageHistoryItemMother.custom("stage2", false));
         assertThat(group.hasSameStagesAs(pipelineInstanceModel), is(true));
@@ -48,7 +48,7 @@ public class PipelineHistoryGroupTest {
     @Test
     public void shouldNotMatchSpecifiedItemIfNameNotMatched() throws Exception {
         PipelineInstanceGroupModel group = new PipelineInstanceGroupModel();
-        group.getConfig().addAll(asList(new SimpleInfo("stage1", true), new SimpleInfo("stage2", false)));
+        group.getStages().addAll(asList(new SimpleInfo("stage1", true), new SimpleInfo("stage2", false)));
         PipelineInstanceModel pipelineInstanceModel = PipelineHistoryItemMother.custom(
                 StageHistoryItemMother.custom("stage1", true), StageHistoryItemMother.custom("stage3", false));
         assertThat(group.hasSameStagesAs(pipelineInstanceModel), is(false));
@@ -57,7 +57,7 @@ public class PipelineHistoryGroupTest {
     @Test
     public void shouldNotMatchSpecifiedItemIfApprovalTypeNotMatched() throws Exception {
         PipelineInstanceGroupModel group = new PipelineInstanceGroupModel();
-        group.getConfig().addAll(asList(new SimpleInfo("stage1", true), new SimpleInfo("stage2", false)));
+        group.getStages().addAll(asList(new SimpleInfo("stage1", true), new SimpleInfo("stage2", false)));
         PipelineInstanceModel pipelineInstanceModel = PipelineHistoryItemMother.custom(
                 StageHistoryItemMother.custom("stage1", true), StageHistoryItemMother.custom("stage2", true));
         assertThat(group.hasSameStagesAs(pipelineInstanceModel), is(false));
@@ -66,7 +66,7 @@ public class PipelineHistoryGroupTest {
     @Test
     public void shouldNotMatchSpecifiedItemIfSizeNotMatched() throws Exception {
         PipelineInstanceGroupModel group = new PipelineInstanceGroupModel();
-        group.getConfig().addAll(asList(new SimpleInfo("stage1", true), new SimpleInfo("stage2", false)));
+        group.getStages().addAll(asList(new SimpleInfo("stage1", true), new SimpleInfo("stage2", false)));
         PipelineInstanceModel pipelineInstanceModel = PipelineHistoryItemMother.custom(
                 StageHistoryItemMother.custom("stage1", true), StageHistoryItemMother.custom("stage2", false),
                 StageHistoryItemMother.custom("stage3", false));


### PR DESCRIPTION
* Switch callers over to getStages(), which returns the same object
* Rename PipelineInstanceGroupModel's `config` -> `stages` for consistency with the getter