### PR TITLE
Start services at runlevel 2 on Debian-like systems.

### DIFF
--- a/installers/agent/release/init.cruise-agent
+++ b/installers/agent/release/init.cruise-agent
@@ -22,8 +22,8 @@
 # Provides: go-agent
 # Required-Start: $network $remote_fs
 # Required-Stop: $network $remote_fs
-# Default-Start: 3 4 5
-# Default-Stop: 0 1 2 6
+# Default-Start: 2 3 4 5
+# Default-Stop: 0 1 6
 # Description: Start the Go Agent
 ### END INIT INFO
 SERVICE_NAME=${0##*/}

--- a/installers/server/release/init.cruise-server
+++ b/installers/server/release/init.cruise-server
@@ -21,8 +21,8 @@
 # Provides: go-server
 # Required-Start: $network $remote_fs
 # Required-Stop: $network $remote_fs
-# Default-Start: 3 4 5
-# Default-Stop: 0 1 2 6
+# Default-Start: 2 3 4 5
+# Default-Stop: 0 1 6
 # Description: Start the Go Server
 ### END INIT INFO
 


### PR DESCRIPTION
While trying to automate the deployment of Go using Puppet on a Debian 7 (Wheezy) server, I found that the init script would always be marked as disabled by Puppet, even when specifically marked as enabled, and the service would not start on boot without manual intervention:

```
root@localhost:~# puppet resource service go-server enable=true
Notice: /Service[go-server]/enable: enable changed 'false' to 'true'
service { 'go-server':
  ensure => 'running',
  enable => 'false',
}
```

I tracked this down to commit 1efeb1b, as part of PR #669, which altered the default runlevels for the ini-script so it would be enabled on runlevels to 3-5 and disabled on runlevel 2 on all systems.

This is fine for Redhat-like systems (as they boot to runlevel 3 by default) but will prevent any Debian-like system from enabling the service (as they boot to runlevel 2 by default).

This patch updates the init-script metadata on Debian-like systems to include runlevel 2 by default. 