### PR TITLE
Write stdout and stderr to a file that is different from `/var/log/go-{agent,server}/go-{server,agent-bootstrapper}.log`

### DIFF
--- a/installers/agent/release/agent.sh
+++ b/installers/agent/release/agent.sh
@@ -61,7 +61,7 @@ else
     LOG_DIR=$AGENT_WORK_DIR
 fi
 
-LOG_FILE=$LOG_DIR/${SERVICE_NAME}-bootstrapper.log
+STDOUT_LOG_FILE=$LOG_DIR/${SERVICE_NAME}-bootstrapper.out.log
 
 if [ "$PID_FILE" ]; then
     echo "[`date`] Use PID_FILE: $PID_FILE"
@@ -107,9 +107,9 @@ export LOG_FILE
 
 CMD="$JAVA_HOME/bin/java -jar \"$AGENT_DIR/agent-bootstrapper.jar\" $GO_SERVER $GO_SERVER_PORT"
 
-echo "[`date`] Starting Go Agent Bootstrapper with command: $CMD" >>"$LOG_FILE"
-echo "[`date`] Starting Go Agent Bootstrapper in directory: $AGENT_WORK_DIR" >>"$LOG_FILE"
-echo "[`date`] AGENT_STARTUP_ARGS=$AGENT_STARTUP_ARGS" >>"$LOG_FILE"
+echo "[`date`] Starting Go Agent Bootstrapper with command: $CMD" >>"$STDOUT_LOG_FILE"
+echo "[`date`] Starting Go Agent Bootstrapper in directory: $AGENT_WORK_DIR" >>"$STDOUT_LOG_FILE"
+echo "[`date`] AGENT_STARTUP_ARGS=$AGENT_STARTUP_ARGS" >>"$STDOUT_LOG_FILE"
 cd "$AGENT_WORK_DIR"
 
 if [ "$JAVA_HOME" == "" ]; then
@@ -118,7 +118,7 @@ if [ "$JAVA_HOME" == "" ]; then
 fi
 
 if [ "$DAEMON" == "Y" ]; then
-    eval exec nohup "$CMD" >>"$LOG_FILE" 2>&1 &
+    eval exec nohup "$CMD" >>"$STDOUT_LOG_FILE" 2>&1 &
     echo $! >"$PID_FILE"
 else
     eval exec "$CMD"

--- a/installers/server/release/server.sh
+++ b/installers/server/release/server.sh
@@ -38,9 +38,9 @@ SERVER_DIR=`(cd "$CWD" && pwd)`
 [ ! -z "$YOURKIT_DISBALE_TRACING" ] || YOURKIT_DISBALE_TRACING=""
 
 if [ -d /var/log/go-server ]; then
-    LOG_FILE=/var/log/go-server/go-server.log
+    STDOUT_LOG_FILE=/var/log/go-server/go-server.out.log
 else
-    LOG_FILE=go-server.log
+    STDOUT_LOG_FILE=go-server.out.log
 fi
 
 if [ "$PID_FILE" ]; then
@@ -126,8 +126,8 @@ if [ "$USE_URANDOM" != "false" ] && [ -e "/dev/urandom" ]; then
 fi
 CMD="$JAVA_HOME/bin/java ${SERVER_STARTUP_ARGS[@]} -jar $SERVER_DIR/go.jar"
 
-echo "Starting Go Server with command: $CMD" >>$LOG_FILE
-echo "Starting Go Server in directory: $GO_WORK_DIR" >>$LOG_FILE
+echo "Starting Go Server with command: $CMD" >> $STDOUT_LOG_FILE
+echo "Starting Go Server in directory: $GO_WORK_DIR" >> $STDOUT_LOG_FILE
 cd "$SERVER_WORK_DIR"
 
 if [ "$JAVA_HOME" == "" ]; then
@@ -136,7 +136,7 @@ if [ "$JAVA_HOME" == "" ]; then
 fi
 
 if [ "$DAEMON" == "Y" ]; then
-    exec nohup $CMD >>$LOG_FILE 2>&1 &
+    exec nohup $CMD >> $STDOUT_LOG_FILE 2>&1 &
     echo $! >$PID_FILE
 else
     exec $CMD


### PR DESCRIPTION
Fixes #1275