### PR TITLE
Remove confusion when creating `ArtifactPlan` instances.

### DIFF
--- a/common/test/unit/com/thoughtworks/go/domain/ArtifactPlanTest.java
+++ b/common/test/unit/com/thoughtworks/go/domain/ArtifactPlanTest.java
@@ -1,5 +1,5 @@
-/*************************GO-LICENSE-START*********************************
- * Copyright 2014 ThoughtWorks, Inc.
+/*
+ * Copyright 2015 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *************************GO-LICENSE-END***********************************/
+ */
 
 package com.thoughtworks.go.domain;
 
@@ -58,7 +58,7 @@ public class ArtifactPlanTest {
 
     @Test public void shouldPublishArtifacts() throws Exception {
         final DefaultGoPublisher publisher = context.mock(DefaultGoPublisher.class);
-        final ArtifactPlan artifactPlan = new ArtifactPlan(ArtifactType.file, "src", "dest");
+        final ArtifactPlan artifactPlan = new ArtifactPlan("src", "dest");
         context.checking(new Expectations() {
             {
                 one(publisher).upload(new File(testFolder, "src"), "dest");
@@ -71,74 +71,74 @@ public class ArtifactPlanTest {
 
     @Test
     public void shouldNormalizePath() throws Exception {
-        ArtifactPlan artifactPlan = new ArtifactPlan(ArtifactType.file, "folder\\src", "folder\\dest");
+        ArtifactPlan artifactPlan = new ArtifactPlan("folder\\src", "folder\\dest");
         assertThat(artifactPlan.getSrc(), is("folder/src"));
         assertThat(artifactPlan.getDest(), is("folder/dest"));
     }
 
     @Test
     public void shouldProvideAppendFilePathToDest() {
-        ArtifactPlan artifactPlan = new ArtifactPlan(ArtifactType.file, "test/**/*/a.log", "logs");
+        ArtifactPlan artifactPlan = new ArtifactPlan("test/**/*/a.log", "logs");
         assertThat(artifactPlan.destURL(new File("pipelines/pipelineA"),
                 new File("pipelines/pipelineA/test/a/b/a.log")), is("logs/a/b"));
     }
 
     @Test
     public void shouldProvideAppendFilePathToDestWhenUsingDoubleStart() {
-        ArtifactPlan artifactPlan = new ArtifactPlan(ArtifactType.file, "**/*/a.log", "logs");
+        ArtifactPlan artifactPlan = new ArtifactPlan("**/*/a.log", "logs");
         assertThat(artifactPlan.destURL(new File("pipelines/pipelineA"),
                 new File("pipelines/pipelineA/test/a/b/a.log")), is("logs/test/a/b"));
     }
 
     @Test
     public void shouldProvideAppendFilePathToDestWhenPathProvidedAreSame() {
-        ArtifactPlan artifactPlan = new ArtifactPlan(ArtifactType.file, "test/a/b/a.log", "logs");
+        ArtifactPlan artifactPlan = new ArtifactPlan("test/a/b/a.log", "logs");
         assertThat(artifactPlan.destURL(new File("pipelines/pipelineA"),
                 new File("pipelines/pipelineA/test/b/a.log")), is("logs"));
     }
 
     @Test
     public void shouldProvideAppendFilePathToDestWhenUsingSingleStarToMatchFile() {
-        ArtifactPlan artifactPlan = new ArtifactPlan(ArtifactType.file, "test/a/b/*.log", "logs");
+        ArtifactPlan artifactPlan = new ArtifactPlan("test/a/b/*.log", "logs");
         assertThat(artifactPlan.destURL(new File("pipelines/pipelineA"),
                 new File("pipelines/pipelineA/test/a/b/a.log")), is("logs"));
     }
 
     @Test
     public void shouldProvideAppendFilePathToDestWhenPathMatchingAtTheRoot() {
-        ArtifactPlan artifactPlan = new ArtifactPlan(ArtifactType.file, "*.jar", "logs");
+        ArtifactPlan artifactPlan = new ArtifactPlan("*.jar", "logs");
         assertThat(artifactPlan.destURL(new File("pipelines/pipelineA"),
                 new File("pipelines/pipelineA/a.jar")), is("logs"));
     }
 
     @Test
     public void shouldTrimThePath() {
-        assertThat(new ArtifactPlan(ArtifactType.file, "pkg   ", "logs "),
-                is(new ArtifactPlan(ArtifactType.file, "pkg", "logs")));
+        assertThat(new ArtifactPlan("pkg   ", "logs "),
+                is(new ArtifactPlan("pkg", "logs")));
     }
 
     @Test
     public void shouldGiveTheEffectiveDestinationPath() {
-        assertThat(new ArtifactPlan(ArtifactType.file, "foo/bar", "").effectiveDestinationPath(), is("bar"));
-        assertThat(new ArtifactPlan(ArtifactType.file, "foo/bar", "blah/foo").effectiveDestinationPath(), is("blah/foo/bar"));
-        assertThat(new ArtifactPlan(ArtifactType.file, "foo/bar.xml", "").effectiveDestinationPath(), is("bar.xml"));
-        assertThat(new ArtifactPlan(ArtifactType.file, "foo/bar/blah.xml", "boo/baz").effectiveDestinationPath(), is("boo/baz/blah.xml"));
-        assertThat(new ArtifactPlan(ArtifactType.file, "foo/**/*blah.xml", "boo/baz").effectiveDestinationPath(), is("boo/baz/*blah.xml"));
-        assertThat(new ArtifactPlan(ArtifactType.file, "foo/**/*.xml", "boo/baz").effectiveDestinationPath(), is("boo/baz/*.xml"));
-        assertThat(new ArtifactPlan(ArtifactType.file, "foo/**/*", "boo/baz").effectiveDestinationPath(), is("boo/baz/*"));
-        assertThat(new ArtifactPlan(ArtifactType.file, "foo/**/*", "boo\\baz").effectiveDestinationPath(), is("boo/baz/*"));
+        assertThat(new ArtifactPlan("foo/bar", "").effectiveDestinationPath(), is("bar"));
+        assertThat(new ArtifactPlan("foo/bar", "blah/foo").effectiveDestinationPath(), is("blah/foo/bar"));
+        assertThat(new ArtifactPlan("foo/bar.xml", "").effectiveDestinationPath(), is("bar.xml"));
+        assertThat(new ArtifactPlan("foo/bar/blah.xml", "boo/baz").effectiveDestinationPath(), is("boo/baz/blah.xml"));
+        assertThat(new ArtifactPlan("foo/**/*blah.xml", "boo/baz").effectiveDestinationPath(), is("boo/baz/*blah.xml"));
+        assertThat(new ArtifactPlan("foo/**/*.xml", "boo/baz").effectiveDestinationPath(), is("boo/baz/*.xml"));
+        assertThat(new ArtifactPlan("foo/**/*", "boo/baz").effectiveDestinationPath(), is("boo/baz/*"));
+        assertThat(new ArtifactPlan("foo/**/*", "boo\\baz").effectiveDestinationPath(), is("boo/baz/*"));
     }
 
     @Test
     public void validate_shouldFailIfSourceIsEmpty() {
-        ArtifactPlan artifactPlan = new ArtifactPlan(ArtifactType.file, "", "bar");
+        ArtifactPlan artifactPlan = new ArtifactPlan("", "bar");
         artifactPlan.validate(ValidationContext.forChain(new JobConfig("jobname")));
         assertThat(artifactPlan.errors().on(ArtifactPlan.SRC), is("Job 'jobname' has an aritfact with an empty source"));
     }
 
     @Test
    public void validate_shouldFailIfDestDoesNotMatchAFilePattern() {
-        ArtifactPlan artifactPlan = new ArtifactPlan(ArtifactType.file, "foo/bar", "..");
+        ArtifactPlan artifactPlan = new ArtifactPlan("foo/bar", "..");
         artifactPlan.validate(null);
         assertThat(artifactPlan.errors().on(ArtifactPlan.DEST), is("Invalid destination path. Destination path should match the pattern ([^. ].+[^. ])|([^. ][^. ])|([^. ])"));
     }
@@ -150,13 +150,13 @@ public class ArtifactPlanTest {
         artifactPlan.validate(null);
         assertThat(artifactPlan.errors().isEmpty(), is(true));
     }
-    
+
     @Test
     public void shouldErrorOutWhenDuplicateArtifactPlansExists() {
         List<ArtifactPlan> plans = new ArrayList<ArtifactPlan>();
-        ArtifactPlan existingPlan = new ArtifactPlan(ArtifactType.file, "src", "dest");
+        ArtifactPlan existingPlan = new ArtifactPlan("src", "dest");
         plans.add(existingPlan);
-        ArtifactPlan artifactPlan = new ArtifactPlan(ArtifactType.file, "src", "dest");
+        ArtifactPlan artifactPlan = new ArtifactPlan("src", "dest");
 
         artifactPlan.validateUniqueness(plans);
 
@@ -170,7 +170,7 @@ public class ArtifactPlanTest {
 
     @Test
     public void shouldBeAbleToCreateACopyOfItself() throws Exception {
-        ArtifactPlan existingPlan = new ArtifactPlan(ArtifactType.file, "src1", "dest1");
+        ArtifactPlan existingPlan = new ArtifactPlan("src1", "dest1");
         existingPlan.setId(2);
         existingPlan.setBuildId(10);
         existingPlan.addError("abc", "def");

--- a/common/test/unit/com/thoughtworks/go/domain/ArtifactPlansTest.java
+++ b/common/test/unit/com/thoughtworks/go/domain/ArtifactPlansTest.java
@@ -1,5 +1,5 @@
-/*************************GO-LICENSE-START*********************************
- * Copyright 2014 ThoughtWorks, Inc.
+/*
+ * Copyright 2015 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *************************GO-LICENSE-END***********************************/
+ */
 
 package com.thoughtworks.go.domain;
 
@@ -35,8 +35,8 @@ public class ArtifactPlansTest {
     public void shouldAddDuplicatedArtifactSoThatValidationKicksIn() throws Exception {
         final ArtifactPlans artifactPlans = new ArtifactPlans();
         assertThat(artifactPlans.size(), is(0));
-        artifactPlans.add(new ArtifactPlan(ArtifactType.file, "src", "dest"));
-        artifactPlans.add(new ArtifactPlan(ArtifactType.file, "src", "dest"));
+        artifactPlans.add(new ArtifactPlan("src", "dest"));
+        artifactPlans.add(new ArtifactPlan("src", "dest"));
         assertThat(artifactPlans.size(), is(2));
     }
 
@@ -63,7 +63,7 @@ public class ArtifactPlansTest {
         plan.setSrc("blah");
         plan.setDest("something");
         assertThat((TestArtifactPlan) artifactPlans.get(0), is(plan));
-        assertThat(artifactPlans.get(1), is(new ArtifactPlan(ArtifactType.file, "blah2", "something2")));
+        assertThat(artifactPlans.get(1), is(new ArtifactPlan("blah2", "something2")));
     }
 
     @Test
@@ -95,18 +95,16 @@ public class ArtifactPlansTest {
         plan.setSrc("blah");
         plan.setDest("something");
         assertThat((TestArtifactPlan) artifactPlans.get(0), is(plan));
-        assertThat(artifactPlans.get(1), is(new ArtifactPlan(ArtifactType.file, "blah2", "something2")));
+        assertThat(artifactPlans.get(1), is(new ArtifactPlan("blah2", "something2")));
     }
 
     @Test
     public void shouldClearAllArtifactsWhenTheMapIsNull() {
         ArtifactPlans artifactPlans = new ArtifactPlans();
-        artifactPlans.add(new ArtifactPlan(ArtifactType.file, "src", "dest"));
+        artifactPlans.add(new ArtifactPlan("src", "dest"));
 
         artifactPlans.setConfigAttributes(null);
 
         assertThat(artifactPlans.size(), is(0));
     }
-
-
 }

--- a/common/test/unit/com/thoughtworks/go/domain/DefaultJobPlanTest.java
+++ b/common/test/unit/com/thoughtworks/go/domain/DefaultJobPlanTest.java
@@ -1,5 +1,5 @@
-/*************************GO-LICENSE-START*********************************
- * Copyright 2014 ThoughtWorks, Inc.
+/*
+ * Copyright 2015 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *************************GO-LICENSE-END***********************************/
+ */
 
 package com.thoughtworks.go.domain;
 
@@ -21,12 +21,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
-import com.thoughtworks.go.config.ArtifactPlan;
-import com.thoughtworks.go.config.ArtifactPlans;
-import com.thoughtworks.go.config.ArtifactPropertiesGenerators;
-import com.thoughtworks.go.config.EnvironmentVariablesConfig;
-import com.thoughtworks.go.config.Resource;
-import com.thoughtworks.go.config.Resources;
+import com.thoughtworks.go.config.*;
 import com.thoughtworks.go.util.FileUtil;
 import com.thoughtworks.go.util.TestFileUtil;
 import com.thoughtworks.go.util.command.EnvironmentVariableContext;
@@ -107,8 +102,8 @@ public class DefaultJobPlanTest {
         ArtifactPlans artifactPlans = new ArtifactPlans();
         DefaultJobPlan plan = new DefaultJobPlan(new Resources(), artifactPlans, new ArtifactPropertiesGenerators(), -1,
                 null);
-        artifactPlans.add(new ArtifactPlan(ArtifactType.unit, "test1", "test"));
-        artifactPlans.add(new ArtifactPlan(ArtifactType.unit, "test2", "test"));
+        artifactPlans.add(new TestArtifactPlan("test1", "test"));
+        artifactPlans.add(new TestArtifactPlan("test2", "test"));
 
         final File firstTestFolder = prepareTestFolder(workingFolder, "test1");
         final File secondTestFolder = prepareTestFolder(workingFolder, "test2");
@@ -127,8 +122,8 @@ public class DefaultJobPlanTest {
         ArtifactPlans artifactPlans = new ArtifactPlans();
         DefaultJobPlan plan = new DefaultJobPlan(new Resources(), artifactPlans, new ArtifactPropertiesGenerators(), -1,
                 null);
-        artifactPlans.add(new ArtifactPlan(ArtifactType.unit, "test1", "test"));
-        artifactPlans.add(new ArtifactPlan(ArtifactType.unit, "test2", "test"));
+        artifactPlans.add(new TestArtifactPlan("test1", "test"));
+        artifactPlans.add(new TestArtifactPlan("test2", "test"));
 
         prepareTestFolder(workingFolder, "test1");
         prepareTestFolder(workingFolder, "test2");
@@ -146,11 +141,11 @@ public class DefaultJobPlanTest {
         ArtifactPlans artifactPlans = new ArtifactPlans();
         final File src1 = TestFileUtil.createTestFolder(workingFolder, "src1");
         TestFileUtil.createTestFile(src1, "test.txt");
-        artifactPlans.add(new ArtifactPlan(ArtifactType.file, src1.getName(), "dest"));
+        artifactPlans.add(new ArtifactPlan(src1.getName(), "dest"));
         final File src2 = TestFileUtil.createTestFolder(workingFolder, "src2");
         TestFileUtil.createTestFile(src1, "test.txt");
 
-        artifactPlans.add(new ArtifactPlan(ArtifactType.file, src2.getName(), "test"));
+        artifactPlans.add(new ArtifactPlan(src2.getName(), "test"));
         StubGoPublisher publisher = new StubGoPublisher();
         DefaultJobPlan plan = new DefaultJobPlan(new Resources(), artifactPlans, new ArtifactPropertiesGenerators(), -1,
                 null);
@@ -174,7 +169,7 @@ public class DefaultJobPlanTest {
         final File testFile1 = TestFileUtil.createTestFile(src1, "test1.txt");
         final File testFile2 = TestFileUtil.createTestFile(src1, "test2.txt");
         final File testFile3 = TestFileUtil.createTestFile(src1, "readme.pdf");
-        artifactPlans.add(new ArtifactPlan(ArtifactType.file, src1.getName() + "/*", "dest"));
+        artifactPlans.add(new ArtifactPlan(src1.getName() + "/*", "dest"));
         StubGoPublisher publisher = new StubGoPublisher();
 
         DefaultJobPlan plan = new DefaultJobPlan(new Resources(), artifactPlans, new ArtifactPropertiesGenerators(), -1,

--- a/common/test/unit/com/thoughtworks/go/domain/TestArtifactPlanTest.java
+++ b/common/test/unit/com/thoughtworks/go/domain/TestArtifactPlanTest.java
@@ -1,5 +1,5 @@
-/*************************GO-LICENSE-START*********************************
- * Copyright 2014 ThoughtWorks, Inc.
+/*
+ * Copyright 2015 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *************************GO-LICENSE-END***********************************/
+ */
 
 package com.thoughtworks.go.domain;
 
@@ -62,7 +62,7 @@ public class TestArtifactPlanTest {
     @Test
     public void shouldNotThrowExceptionIfFolderNotFound() throws Exception {
         final TestArtifactPlan compositeTestArtifact = new TestArtifactPlan(
-                new ArtifactPlan(ArtifactType.unit, "some_random_path_that_does_not_exist",
+                new TestArtifactPlan("some_random_path_that_does_not_exist",
                         "testoutput"));
         compositeTestArtifact.publish(mockArtifactPublisher, rootPath);
         verify(mockArtifactPublisher).consumeLineWithPrefix("The Directory target/test/some_random_path_that_does_not_exist specified as a test artifact was not found. Please check your configuration");
@@ -73,7 +73,7 @@ public class TestArtifactPlanTest {
         final File nonFolderFileThatExists = TestFileUtil.createTestFile(TestFileUtil.createTempFolder("tempFolder"),
                 "nonFolderFileThatExists");
         final TestArtifactPlan compositeTestArtifact = new TestArtifactPlan(
-                new ArtifactPlan(ArtifactType.unit, nonFolderFileThatExists.getPath(),
+                new TestArtifactPlan(nonFolderFileThatExists.getPath(),
                         "testoutput"));
 
         compositeTestArtifact.publish(mockArtifactPublisher, rootPath);
@@ -82,7 +82,7 @@ public class TestArtifactPlanTest {
 
     @Test
     public void shouldSupportGlobPatternsInSourcePath() {
-        ArtifactPlan artifactPlan = new ArtifactPlan(ArtifactType.file,  "**/*/a.log", "logs");
+        ArtifactPlan artifactPlan = new ArtifactPlan( "**/*/a.log", "logs");
         TestArtifactPlan testArtifactPlan = new TestArtifactPlan(artifactPlan);
 
         File first = new File("target/test/report/a.log");

--- a/common/test/unit/com/thoughtworks/go/remote/work/BuildWorkArtifactUploadingTest.java
+++ b/common/test/unit/com/thoughtworks/go/remote/work/BuildWorkArtifactUploadingTest.java
@@ -1,5 +1,5 @@
-/*************************GO-LICENSE-START*********************************
- * Copyright 2014 ThoughtWorks, Inc.
+/*
+ * Copyright 2015 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *************************GO-LICENSE-END***********************************/
+ */
 
 package com.thoughtworks.go.remote.work;
 
@@ -102,7 +102,7 @@ public class BuildWorkArtifactUploadingTest {
     @Test
     public void shouldUploadEachMatchedFile() throws Exception {
         ArtifactPlans artifactPlans = new ArtifactPlans();
-        artifactPlans.add(new ArtifactPlan(ArtifactType.file, "**/*.png", "mypic"));
+        artifactPlans.add(new ArtifactPlan("**/*.png", "mypic"));
 
         BuildAssignment buildAssigment = createAssignment(artifactPlans, new String[]{"logs/pic/fail.png", "logs/pic/pass.png", "README"});
 
@@ -121,7 +121,7 @@ public class BuildWorkArtifactUploadingTest {
     @Test
     public void shouldUploadMatchedFolder() throws Exception {
         ArtifactPlans artifactPlans = new ArtifactPlans();
-        artifactPlans.add(new ArtifactPlan(ArtifactType.file, "**/*", "mypic"));
+        artifactPlans.add(new ArtifactPlan("**/*", "mypic"));
 
         BuildAssignment buildAssigment = createAssignment(artifactPlans,
                 new String[]{"logs/pic/fail.png", "logs/pic/pass.png", "README"});
@@ -145,7 +145,7 @@ public class BuildWorkArtifactUploadingTest {
     @Test
     public void shouldNotUploadFileContainingFolderAgain() throws Exception {
         ArtifactPlans artifactPlans = new ArtifactPlans();
-        artifactPlans.add(new ArtifactPlan(ArtifactType.file, "logs/pic/*.png", "mypic"));
+        artifactPlans.add(new ArtifactPlan("logs/pic/*.png", "mypic"));
 
         BuildAssignment buildAssigment = createAssignment(artifactPlans,
                 new String[]{"logs/pic/fail.png", "logs/pic/pass.png", "README"});
@@ -167,11 +167,11 @@ public class BuildWorkArtifactUploadingTest {
     @Test
     public void shouldUploadFolderWhenMatchedWithWildCards() throws Exception {
         ArtifactPlans artifactPlans = new ArtifactPlans();
-        artifactPlans.add(new ArtifactPlan(ArtifactType.file, "logs/pic-*", "mypic"));
+        artifactPlans.add(new ArtifactPlan("logs/pic-*", "mypic"));
 
         BuildAssignment buildAssigment = createAssignment(artifactPlans,
                 new String[]{"logs/pic-1/fail.png", "logs/pic-1/pass.png", "logs/pic-2/cancel.png", "logs/pic-2/complete.png", "README"});
-    
+
         BuildWork work = new BuildWork(buildAssigment);
         GoArtifactsManipulatorStub manipulator = new GoArtifactsManipulatorStub();
 
@@ -193,7 +193,7 @@ public class BuildWorkArtifactUploadingTest {
     @Test
     public void shouldUploadFolderWhenDirectMatch() throws Exception {
         ArtifactPlans artifactPlans = new ArtifactPlans();
-        artifactPlans.add(new ArtifactPlan(ArtifactType.file, "logs/pic-1", "mypic"));
+        artifactPlans.add(new ArtifactPlan("logs/pic-1", "mypic"));
 
         BuildAssignment buildAssigment = createAssignment(artifactPlans,
                 new String[]{"logs/pic-1/fail.png", "logs/pic-1/pass.png", "logs/pic-2/cancel.png", "logs/pic-2/complete.png", "README"});
@@ -213,7 +213,7 @@ public class BuildWorkArtifactUploadingTest {
     @Test
     public void shouldUploadFolderWhenTrimedPathDirectMatch() throws Exception {
         ArtifactPlans artifactPlans = new ArtifactPlans();
-        artifactPlans.add(new ArtifactPlan(ArtifactType.file, "logs/pic-1 ", "mypic"));
+        artifactPlans.add(new ArtifactPlan("logs/pic-1 ", "mypic"));
 
         BuildAssignment buildAssigment = createAssignment(artifactPlans,
                 new String[]{"logs/pic-1/fail.png", "logs/pic-1/pass.png", "logs/pic-2/cancel.png", "logs/pic-2/complete.png", "README"});
@@ -233,7 +233,7 @@ public class BuildWorkArtifactUploadingTest {
     @Test
     public void shouldFailBuildWhenNothingMatched() throws Exception {
         ArtifactPlans artifactPlans = new ArtifactPlans();
-        artifactPlans.add(new ArtifactPlan(ArtifactType.file, "logs/picture", "mypic"));
+        artifactPlans.add(new ArtifactPlan("logs/picture", "mypic"));
 
         BuildAssignment buildAssigment = createAssignment(artifactPlans,
                 new String[]{"logs/pic-1/fail.png", "logs/pic-1/pass.png", "logs/pic-2/cancel.png", "logs/pic-2/complete.png", "README"});
@@ -257,7 +257,7 @@ public class BuildWorkArtifactUploadingTest {
     @Test
     public void shouldFailBuildWhenSourceDirectoryDoesNotExist() throws Exception {
         ArtifactPlans artifactPlans = new ArtifactPlans();
-        artifactPlans.add(new ArtifactPlan(ArtifactType.file, "not-Exist-Folder", "mypic"));
+        artifactPlans.add(new ArtifactPlan("not-Exist-Folder", "mypic"));
 
         BuildAssignment buildAssigment = createAssignment(artifactPlans,
                 new String[]{"logs/pic-1/fail.png", "logs/pic-1/pass.png", "logs/pic-2/cancel.png", "logs/pic-2/complete.png", "README"});
@@ -281,7 +281,7 @@ public class BuildWorkArtifactUploadingTest {
     @Test
     public void shouldFailBuildWhenNothingMatchedUsingMatcherStartDotStart() throws Exception {
         ArtifactPlans artifactPlans = new ArtifactPlans();
-        artifactPlans.add(new ArtifactPlan(ArtifactType.file, "target/pkg/*.*", "MYDEST"));
+        artifactPlans.add(new ArtifactPlan("target/pkg/*.*", "MYDEST"));
 
         BuildAssignment buildAssigment = createAssignment(artifactPlans, new String[]{"target/pkg/"});
 
@@ -305,7 +305,7 @@ public class BuildWorkArtifactUploadingTest {
     @Test
     public void shouldReportUploadFailuresWhenTheyHappen() throws Exception {
         ArtifactPlans artifactPlans = new ArtifactPlans();
-        artifactPlans.add(new ArtifactPlan(ArtifactType.file, "**/*.png", "mypic"));
+        artifactPlans.add(new ArtifactPlan("**/*.png", "mypic"));
 
         BuildAssignment buildAssigment = createAssignment(artifactPlans,
                 new String[]{"logs/pic/pass.png", "logs/pic-1/pass.png"});

--- a/config/config-api/src/com/thoughtworks/go/config/ArtifactPlan.java
+++ b/config/config-api/src/com/thoughtworks/go/config/ArtifactPlan.java
@@ -1,5 +1,5 @@
-/*************************GO-LICENSE-START*********************************
- * Copyright 2014 ThoughtWorks, Inc.
+/*
+ * Copyright 2015 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *************************GO-LICENSE-END***********************************/
+ */
 
 package com.thoughtworks.go.config;
 
@@ -26,6 +26,7 @@ import java.io.File;
 import java.text.MessageFormat;
 import java.util.List;
 
+import static com.thoughtworks.go.util.ExceptionUtils.bomb;
 import static com.thoughtworks.go.util.FileUtil.normalizePath;
 import static com.thoughtworks.go.util.FileUtil.subtractPath;
 import static com.thoughtworks.go.util.SelectorUtils.rtrimStandardrizedWildcardTokens;
@@ -51,7 +52,7 @@ public class ArtifactPlan extends PersistentObject implements Artifact {
     public ArtifactPlan() {
     }
 
-    public ArtifactPlan(ArtifactType artifactType, String source, String destination) {
+    protected ArtifactPlan(ArtifactType artifactType, String source, String destination) {
         setSrc(source);
         setDest(destination);
         this.artifactType = artifactType;
@@ -60,6 +61,10 @@ public class ArtifactPlan extends PersistentObject implements Artifact {
     public ArtifactPlan(ArtifactPlan other) {
         this(other.artifactType, other.src, other.dest);
         this.errors = other.errors;
+    }
+
+    public ArtifactPlan(String src, String dest) {
+        this(ArtifactType.file, src, dest);
     }
 
     public File getSource(File rootPath) {
@@ -135,12 +140,12 @@ public class ArtifactPlan extends PersistentObject implements Artifact {
         return artifactType;
     }
 
-    public String getArtifactTypeValue() {
-        return ARTIFACT_PLAN_DISPLAY_NAME;
+    protected void setArtifactType(ArtifactType artifactType) {
+        this.artifactType = artifactType;
     }
 
-    public void setArtifactType(ArtifactType artifactType) {
-        this.artifactType = artifactType;
+    public String getArtifactTypeValue() {
+        return ARTIFACT_PLAN_DISPLAY_NAME;
     }
 
     public String destURL(File rootPath, File file) {
@@ -199,5 +204,15 @@ public class ArtifactPlan extends PersistentObject implements Artifact {
     private void addUniquenessViolationError() {
         addError(SRC, "Duplicate artifacts defined.");
         addError(DEST, "Duplicate artifacts defined.");
+    }
+
+    public static ArtifactPlan create(ArtifactType artifactType, String src, String dest) {
+        if (artifactType == ArtifactType.file) {
+            return new ArtifactPlan(src, dest);
+        } else if (artifactType == ArtifactType.unit) {
+            return new TestArtifactPlan(src, dest);
+        } else {
+            throw bomb("ArtifactType not specified");
+        }
     }
 }

--- a/config/config-api/src/com/thoughtworks/go/config/ArtifactPlans.java
+++ b/config/config-api/src/com/thoughtworks/go/config/ArtifactPlans.java
@@ -1,5 +1,5 @@
-/*************************GO-LICENSE-START*********************************
- * Copyright 2014 ThoughtWorks, Inc.
+/*
+ * Copyright 2015 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,18 +12,17 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *************************GO-LICENSE-END***********************************/
+ */
 
 package com.thoughtworks.go.config;
+
+import com.thoughtworks.go.domain.Artifact;
+import com.thoughtworks.go.domain.BaseCollection;
+import com.thoughtworks.go.domain.ConfigErrors;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-
-import com.thoughtworks.go.domain.Artifact;
-import com.thoughtworks.go.domain.ArtifactType;
-import com.thoughtworks.go.domain.BaseCollection;
-import com.thoughtworks.go.domain.ConfigErrors;
 
 @ConfigTag("artifacts")
 @ConfigCollection(Artifact.class)
@@ -42,7 +41,7 @@ public class ArtifactPlans extends BaseCollection<ArtifactPlan> implements Valid
     }
 
     private void validateUniqueness() {
-        List<ArtifactPlan> plans = new ArrayList<ArtifactPlan>();
+        List<ArtifactPlan> plans = new ArrayList<>();
         for (ArtifactPlan artifactPlan : this) {
             artifactPlan.validateUniqueness(plans);
         }
@@ -69,18 +68,13 @@ public class ArtifactPlans extends BaseCollection<ArtifactPlan> implements Valid
                 continue;
             }
             String type = (String) attrMap.get("artifactTypeValue");
+
             if (TestArtifactPlan.TEST_PLAN_DISPLAY_NAME.equals(type)) {
-                TestArtifactPlan plan = new TestArtifactPlan();
-                plan.setSrc(source);
-                plan.setDest(destination);
-                this.add(plan);
+                this.add(new TestArtifactPlan(source, destination));
             } else {
-                this.add(artifactPlan(attrMap));
+                this.add(new ArtifactPlan(source, destination));
             }
         }
     }
 
-    private ArtifactPlan artifactPlan(Map attrMap) {
-        return new ArtifactPlan(ArtifactType.file, (String) attrMap.get(ArtifactPlan.SRC), (String) attrMap.get(ArtifactPlan.DEST));
-    }
 }

--- a/config/config-api/src/com/thoughtworks/go/config/TestArtifactPlan.java
+++ b/config/config-api/src/com/thoughtworks/go/config/TestArtifactPlan.java
@@ -1,5 +1,5 @@
-/*************************GO-LICENSE-START*********************************
- * Copyright 2014 ThoughtWorks, Inc.
+/*
+ * Copyright 2015 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *************************GO-LICENSE-END***********************************/
+ */
 
 package com.thoughtworks.go.config;
 
@@ -46,6 +46,10 @@ public class TestArtifactPlan extends ArtifactPlan {
         this();
         add(plan);
         setDest(TEST_OUTPUT_FOLDER);
+    }
+
+    public TestArtifactPlan(String src, String dest) {
+        super(ArtifactType.unit, src, dest);
     }
 
     public void add(ArtifactPlan plan) {
@@ -95,7 +99,7 @@ public class TestArtifactPlan extends ArtifactPlan {
                 testResultSource.mkdirs();
                 UnitTestReportGenerator generator = new UnitTestReportGenerator(publisher, testResultSource);
                 generator.generate(allFiles.toArray(new File[allFiles.size()]));
-                publisher.upload(testResultSource, "testoutput");                
+                publisher.upload(testResultSource, "testoutput");
             } finally {
                 if (tempFolder!=null) {
                     FileUtil.deleteFolder(tempFolder);

--- a/config/config-api/test/com/thoughtworks/go/helper/StageConfigMother.java
+++ b/config/config-api/test/com/thoughtworks/go/helper/StageConfigMother.java
@@ -1,5 +1,5 @@
-/*************************GO-LICENSE-START*********************************
- * Copyright 2014 ThoughtWorks, Inc.
+/*
+ * Copyright 2015 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,27 +12,14 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *************************GO-LICENSE-END***********************************/
+ */
 
 package com.thoughtworks.go.helper;
 
 import java.util.Arrays;
 import java.util.HashMap;
 
-import com.thoughtworks.go.config.AdminRole;
-import com.thoughtworks.go.config.AdminUser;
-import com.thoughtworks.go.config.AntTask;
-import com.thoughtworks.go.config.Approval;
-import com.thoughtworks.go.config.ArtifactPlan;
-import com.thoughtworks.go.config.ArtifactPlans;
-import com.thoughtworks.go.config.AuthConfig;
-import com.thoughtworks.go.config.CaseInsensitiveString;
-import com.thoughtworks.go.config.ExecTask;
-import com.thoughtworks.go.config.JobConfig;
-import com.thoughtworks.go.config.JobConfigs;
-import com.thoughtworks.go.config.Resource;
-import com.thoughtworks.go.config.Resources;
-import com.thoughtworks.go.config.StageConfig;
+import com.thoughtworks.go.config.*;
 import com.thoughtworks.go.domain.ArtifactType;
 import com.thoughtworks.go.util.ReflectionUtil;
 
@@ -49,10 +36,10 @@ public class StageConfigMother {
 
     public static StageConfig twoBuildPlansWithResourcesAndMaterials(String stageName) {
         JobConfig windoze = new JobConfig(
-                new CaseInsensitiveString("WinBuild"), new Resources(new Resource("Windows"), new Resource(".NET")), new ArtifactPlans(Arrays.asList(new ArtifactPlan(ArtifactType.unit, "junit", "junit")))
+                new CaseInsensitiveString("WinBuild"), new Resources(new Resource("Windows"), new Resource(".NET")), new ArtifactPlans(Arrays.<ArtifactPlan>asList(new TestArtifactPlan("junit", "junit")))
         );
         JobConfig linux = new JobConfig(
-                new CaseInsensitiveString("NixBuild"), new Resources(new Resource("Linux"), new Resource("java")), new ArtifactPlans(Arrays.asList(new ArtifactPlan(ArtifactType.unit, "junit", "junit")))
+                new CaseInsensitiveString("NixBuild"), new Resources(new Resource("Linux"), new Resource("java")), new ArtifactPlans(Arrays.<ArtifactPlan>asList(new TestArtifactPlan("junit", "junit")))
         );
         JobConfigs jobConfigs = new JobConfigs(windoze, linux);
         return stageConfig(stageName, jobConfigs);
@@ -105,7 +92,7 @@ public class StageConfigMother {
 
     public static StageConfig stageConfigWithArtifact(String stageName, String jobName , ArtifactType artifactType){
         ArtifactPlans artifactPlansWithTests = new ArtifactPlans();
-        artifactPlansWithTests.add(new ArtifactPlan(artifactType, "src", "dest"));
+        artifactPlansWithTests.add(ArtifactPlan.create(artifactType, "src", "dest"));
         JobConfig job1 = new JobConfig(new CaseInsensitiveString(jobName), new Resources("abc"), artifactPlansWithTests);
         StageConfig stage = new StageConfig(new CaseInsensitiveString(stageName), new JobConfigs(job1));
         return stage;

--- a/server/test/integration/com/thoughtworks/go/server/dao/JobInstanceSqlMapDaoTest.java
+++ b/server/test/integration/com/thoughtworks/go/server/dao/JobInstanceSqlMapDaoTest.java
@@ -1,5 +1,5 @@
-/*************************GO-LICENSE-START*********************************
- * Copyright 2014 ThoughtWorks, Inc.
+/*
+ * Copyright 2015 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *************************GO-LICENSE-END***********************************/
+ */
 
 package com.thoughtworks.go.server.dao;
 
@@ -995,8 +995,8 @@ public class JobInstanceSqlMapDaoTest {
 
     private ArtifactPlans artifactPlans() {
         ArtifactPlans artifactPlans = new ArtifactPlans();
-        artifactPlans.add(new ArtifactPlan(ArtifactType.file, "src", "dest"));
-        artifactPlans.add(new ArtifactPlan(ArtifactType.file, "src1", "dest2"));
+        artifactPlans.add(new ArtifactPlan("src", "dest"));
+        artifactPlans.add(new ArtifactPlan("src1", "dest2"));
         return artifactPlans;
     }
 }

--- a/server/test/integration/com/thoughtworks/go/server/persistence/ArtifactPlanRepositoryIntegrationTest.java
+++ b/server/test/integration/com/thoughtworks/go/server/persistence/ArtifactPlanRepositoryIntegrationTest.java
@@ -1,5 +1,5 @@
-/*************************GO-LICENSE-START*********************************
- * Copyright 2014 ThoughtWorks, Inc.
+/*
+ * Copyright 2015 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *************************GO-LICENSE-END***********************************/
+ */
 
 package com.thoughtworks.go.server.persistence;
 
@@ -84,7 +84,7 @@ public class ArtifactPlanRepositoryIntegrationTest {
     public void shouldSaveArtifactPlan() {
         // Arrange
         JobInstance jobInstance = jobInstanceDao.save(stageId, new JobInstance(JOB_NAME));
-        ArtifactPlan artifactPlan = new ArtifactPlan(ArtifactType.file, "src", "dest");
+        ArtifactPlan artifactPlan = new ArtifactPlan("src", "dest");
         artifactPlan.setBuildId(jobInstance.getId());
 
         // Act
@@ -98,7 +98,7 @@ public class ArtifactPlanRepositoryIntegrationTest {
     public void shouldLoadSavedArtifactPlan() {
         // Arrange
         JobInstance jobInstance = jobInstanceDao.save(stageId, new JobInstance(JOB_NAME));
-        ArtifactPlan savedArtifactPlan = new ArtifactPlan(ArtifactType.file, "src", "dest");
+        ArtifactPlan savedArtifactPlan = new ArtifactPlan("src", "dest");
         savedArtifactPlan.setBuildId(jobInstance.getId());
         artifactPlanRepository.save(savedArtifactPlan);
 
@@ -114,7 +114,7 @@ public class ArtifactPlanRepositoryIntegrationTest {
     public void shouldLoadSavedArtifactPlanWithTypeUnit() {
         // Arrange
         JobInstance jobInstance = jobInstanceDao.save(stageId, new JobInstance(JOB_NAME));
-        ArtifactPlan savedArtifactPlan = new ArtifactPlan(ArtifactType.unit, "src", "dest");
+        ArtifactPlan savedArtifactPlan = new TestArtifactPlan("src", "dest");
         savedArtifactPlan.setBuildId(jobInstance.getId());
         artifactPlanRepository.save(savedArtifactPlan);
 
@@ -148,7 +148,7 @@ public class ArtifactPlanRepositoryIntegrationTest {
         // Arrange
         JobInstance firstJobInstance = jobInstanceDao.save(stageId, new JobInstance(JOB_NAME + "1"));
         JobInstance secondJobInstance = jobInstanceDao.save(stageId, new JobInstance(JOB_NAME + "2"));
-        ArtifactPlan artifactPlan = new ArtifactPlan(ArtifactType.file, "src", "dest");
+        ArtifactPlan artifactPlan = new ArtifactPlan("src", "dest");
 
         // Act
         ArtifactPlan artifactPlanOfFirstJob = artifactPlanRepository.saveCopyOf(firstJobInstance.getId(), artifactPlan);

--- a/server/test/integration/com/thoughtworks/go/server/service/JobInstanceServiceIntegrationTest.java
+++ b/server/test/integration/com/thoughtworks/go/server/service/JobInstanceServiceIntegrationTest.java
@@ -1,5 +1,5 @@
-/*************************GO-LICENSE-START*********************************
- * Copyright 2014 ThoughtWorks, Inc.
+/*
+ * Copyright 2015 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *************************GO-LICENSE-END***********************************/
+ */
 
 package com.thoughtworks.go.server.service;
 
@@ -331,7 +331,7 @@ public class JobInstanceServiceIntegrationTest {
     @Test
     public void shouldSet_BelongsToKnownPipeline_FlagOnEachJob_pipelineForWhichIsStillPresentInConfig() {
         String agentUuid = "special_uuid";
-        
+
         configHelper.addPipeline("existingPipeline", "existingStage");
 
         Long existingStage = stageWithId("existingPipeline", "existingStage");
@@ -471,7 +471,7 @@ public class JobInstanceServiceIntegrationTest {
         jobConfig.setRunInstanceCount(2);
         jobConfig.addResource("blah");
         jobConfig.getProperties().add(new ArtifactPropertiesGenerator("prop1", "props.xml", "//somepath"));
-        jobConfig.artifactPlans().add(new ArtifactPlan(ArtifactType.file, "src1", "dest1"));
+        jobConfig.artifactPlans().add(new ArtifactPlan("src1", "dest1"));
         configHelper.addPipeline("go", "dev");
 
         scheduleHelper.schedule(pipelineConfig, BuildCause.createWithModifications(modifyOneFile(pipelineConfig), ""), DEFAULT_APPROVED_BY);
@@ -508,7 +508,7 @@ public class JobInstanceServiceIntegrationTest {
         jobConfig.setRunOnAllAgents(true);
         jobConfig.addResource("blah");
         jobConfig.getProperties().add(new ArtifactPropertiesGenerator("prop1", "props.xml", "//somepath"));
-        jobConfig.artifactPlans().add(new ArtifactPlan(ArtifactType.file, "src1", "dest1"));
+        jobConfig.artifactPlans().add(new ArtifactPlan("src1", "dest1"));
         configHelper.addPipeline("go", "dev");
 
         DefaultSchedulingContext schedulingContext = new DefaultSchedulingContext("anyone", new Agents(localAgentWithResources("blah"), localAgentWithResources("blah")));

--- a/server/test/integration/com/thoughtworks/go/server/service/RescheduleJobTest.java
+++ b/server/test/integration/com/thoughtworks/go/server/service/RescheduleJobTest.java
@@ -1,5 +1,5 @@
-/*************************GO-LICENSE-START*********************************
- * Copyright 2014 ThoughtWorks, Inc.
+/*
+ * Copyright 2015 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *************************GO-LICENSE-END***********************************/
+ */
 
 package com.thoughtworks.go.server.service;
 
@@ -139,7 +139,7 @@ public class RescheduleJobTest {
         dbHelper.cancelStage(stage);
 
         Resources resources = new Resources(new Resource("r1"), new Resource("r2"));
-        ArtifactPlans artifactPlans = new ArtifactPlans(Arrays.asList(new ArtifactPlan(ArtifactType.file, "s1", "d1"), new ArtifactPlan(ArtifactType.file, "s2", "d2")));
+        ArtifactPlans artifactPlans = new ArtifactPlans(Arrays.asList(new ArtifactPlan("s1", "d1"), new ArtifactPlan("s2", "d2")));
         ArtifactPropertiesGenerators artifactPropertiesGenerators = new ArtifactPropertiesGenerators(new ArtifactPropertiesGenerator("n1", "s1", "x1"), new ArtifactPropertiesGenerator("n2", "s2", "x2"));
         configHelper.addAssociatedEntitiesForAJob(PIPELINE_NAME, STAGE_NAME, JOB_NAME, resources, artifactPlans, artifactPropertiesGenerators);
 
@@ -201,7 +201,7 @@ public class RescheduleJobTest {
     public void rescheduleShouldNotDuplicateResourcesEtc() throws Exception {
         JobInstance job = scheduledJob();
         JobPlan oldPlan = loadJobPlan(job);
-        
+
         scheduleService.rescheduleJob(job);
 
         JobPlan newPlan = dbHelper.getBuildInstanceDao().orderedScheduledBuilds().get(0);

--- a/server/webapp/WEB-INF/rails.new/spec/controllers/admin/jobs_controller_view_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/controllers/admin/jobs_controller_view_spec.rb
@@ -30,8 +30,8 @@ describe Admin::JobsController, "view" do
       @cruise_config = BasicCruiseConfig.new()
       cruise_config_mother = GoConfigMother.new
       @pipeline = cruise_config_mother.addPipeline(@cruise_config, "pipeline-name", "stage-name", ["job-1", "job-2"].to_java(java.lang.String))
-      @artifact1 = ArtifactPlan.new(ArtifactType.file, 'src', 'dest')
-      @artifact2 = ArtifactPlan.new(ArtifactType.file, 'src2', 'dest2')
+      @artifact1 = ArtifactPlan.new('src', 'dest')
+      @artifact2 = ArtifactPlan.new('src2', 'dest2')
       @pipeline.get(0).getJobs().get(0).artifactPlans().add(@artifact1)
       @pipeline.get(0).getJobs().get(0).artifactPlans().add(@artifact2)
 

--- a/server/webapp/WEB-INF/rails.new/spec/views/api/jobs/index_xml_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/views/api/jobs/index_xml_spec.rb
@@ -23,9 +23,9 @@ describe "/api/jobs" do
     @properties.add(com.thoughtworks.go.domain.Property.new("foo", "value_of_property_foo"))
 
     @plans = ArtifactPlans.new
-    @plans.add(ArtifactPlan.new(ArtifactType::file, "artifact", "blahartifact/path"))
-    @plans.add(ArtifactPlan.new(ArtifactType::file, "logs/log-artifact", "log-path"))
-    @plans.add(ArtifactPlan.new(ArtifactType::unit, "test.xml", ""))
+    @plans.add(ArtifactPlan.new("artifact", "blahartifact/path"))
+    @plans.add(ArtifactPlan.new("logs/log-artifact", "log-path"))
+    @plans.add(TestArtifactPlan.new("test.xml", ""))
 
     @resources = Resources.new("linux, teapot")
 
@@ -120,9 +120,9 @@ describe "/api/jobs" do
       properties.add(com.thoughtworks.go.domain.Property.new("prop<er\"ty", "val<ue_of_prop\"erty_foo"))
 
       plans = ArtifactPlans.new
-      plans.add(ArtifactPlan.new(ArtifactType::file, "artifact", "blah<artif\"act/path"))
-      plans.add(ArtifactPlan.new(ArtifactType::file, "logs/log-arti\"fact", "log-path"))
-      plans.add(ArtifactPlan.new(ArtifactType::unit, "te<s\"t.xml", ""))
+      plans.add(ArtifactPlan.new("artifact", "blah<artif\"act/path"))
+      plans.add(ArtifactPlan.new("logs/log-arti\"fact", "log-path"))
+      plans.add(TestArtifactPlan.new("te<s\"t.xml", ""))
 
       variables = EnvironmentVariablesConfig.new
       variables.add("VARIA<BLE_NA\"ME", "varia<ble-val\"ue")

--- a/server/webapp/WEB-INF/rails.new/spec/views/config_view/templates/_job_view_html_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/views/config_view/templates/_job_view_html_spec.rb
@@ -164,10 +164,8 @@ describe "config_view/templates/_job_view.html.erb" do
 
   it "should render artifacts tab for a job" do
     artifact_plans = ArtifactPlans.new()
-    artifact_plans.add(ArtifactPlan.new(ArtifactType.unit, "build-result", "build-output"))
-    test_artifact = TestArtifactPlan.new()
-    test_artifact.setSrc('test-result')
-    test_artifact.setDest('test-output')
+    artifact_plans.add(ArtifactPlan.new("build-result", "build-output"))
+    test_artifact = TestArtifactPlan.new('test-result', 'test-output')
     artifact_plans.add(test_artifact)
     job = JobConfig.new(CaseInsensitiveString.new("jobName"), Resources.new(), artifact_plans)
     job.addTask(ant_task)


### PR DESCRIPTION
Meat of the changes in `ArtifactPlan` and `TestArtifactPlan`. The rest
of it is supplimental changes to adapt to the change in their interfaces.

ArtifactPlan has a configurable `artifactType` instance. It was therefore
possible to create an instance of `ArtifactPlan` with `artifactType` set to
`ArtifactType.unit` - this was not only confusing, but incorrect since the
behavior of both artifact types is different.

This PR changes that by ensuring that the `artifactType` instance cannot
be set by clients that create an instance of `ArtifactPlan`.