### PR TITLE
Go on IE Intranet

### DIFF
--- a/server/webapp/WEB-INF/rails.new/app/views/layouts/admin.html.erb
+++ b/server/webapp/WEB-INF/rails.new/app/views/layouts/admin.html.erb
@@ -11,7 +11,6 @@
 <!--<![endif]-->
 
 <head>
-    <meta http-equiv="X-UA-Compatible" content="IE=9">
     <%- @current_tab_name = "admin" -%>
     <%- @view_title = @view_title || "Administration" -%>
     <%= render :partial => "shared/head" %>

--- a/server/webapp/WEB-INF/rails.new/app/views/shared/_head.html.erb
+++ b/server/webapp/WEB-INF/rails.new/app/views/shared/_head.html.erb
@@ -1,3 +1,4 @@
+<meta http-equiv="X-UA-COMPATIBLE" content="IE=edge,chrome=1">
 <title>
     <%= @view_title %> - Go
 </title>

--- a/server/webapp/WEB-INF/vm/shared/_header.vm
+++ b/server/webapp/WEB-INF/vm/shared/_header.vm
@@ -14,8 +14,7 @@
  * limitations under the License.
  *************************GO-LICENSE-END***********************************#
 
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
-        "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<!DOCTYPE html>
 <!--[if lt IE 7]> <html lang="en" class="no-js ie6 oldie"> <![endif]-->
 <!--[if IE 7]> <html lang="en" class="no-js ie7 oldie"> <![endif]-->
 <!--[if IE 8]> <html lang="en" class="no-js ie8 oldie"> <![endif]-->
@@ -24,6 +23,7 @@
 <!--<![endif]-->
 
 <head>
+    <meta http-equiv="X-UA-COMPATIBLE" content="IE=edge,chrome=1">
     <meta http-equiv="content-type" content="text/html; charset=UTF-8"/>
 
     <link href="$req.getContextPath()/$concatenatedCruiseIconFilePath?#include("admin/admin_version.txt.vm")" rel="shortcut icon" />


### PR DESCRIPTION
When the GoCD server is hosted internally, IE treats it as an intranet site by
default. Being an intranet site, it is automatically rendered in IE7
compatibility mode, which causes a few problems:

* pipelines dashboard doesn't line up as in Chrome and Firefox
* console log in job details page does not show line breaks, making it very
  difficult to read

By providing the X-UA-COMPATIBLE meta tag, IE shows the site in standards mode
and everything looks very similar to Chrome and Firefox.

## Screenshots

### Before
![pipelines-before](https://cloud.githubusercontent.com/assets/230004/10404583/909a3be8-6e88-11e5-8f17-beeddff984e0.png)
![job-console-before](https://cloud.githubusercontent.com/assets/230004/10404586/93457650-6e88-11e5-993f-0f09f3586f25.png)

### After
![pipelines-after](https://cloud.githubusercontent.com/assets/230004/10404595/95aec644-6e88-11e5-8be9-492fd879153a.png)
![job-console-after](https://cloud.githubusercontent.com/assets/230004/10404589/945f5862-6e88-11e5-96b1-507884840e7a.png)

## Reproducing

I grabbed the Windows 7 IE 11 VM from https://dev.modern.ie/tools/vms/mac/ and
added go to the list of intranet sites through Settings -> Internet Options ->
Security Tab -> Highlight Local Intranet -> Sites -> Advanced -> Add 