### PR TITLE
Replacing Deprecated `SecurityService#hasViewPermissionForPipeline(String, String)`

### DIFF
--- a/common/src/com/thoughtworks/go/domain/User.java
+++ b/common/src/com/thoughtworks/go/domain/User.java
@@ -102,6 +102,9 @@ public class  User extends PersistentObject {
         this.name = StringUtils.trim(name);
     }
 
+    public Username getUsername() {
+        return Username.valueOf(name);
+    }
     /**
      * only used by ibatis
      *

--- a/common/src/com/thoughtworks/go/server/domain/Username.java
+++ b/common/src/com/thoughtworks/go/server/domain/Username.java
@@ -88,4 +88,8 @@ public class Username implements Serializable {
         result = 31 * result + (username != null ? username.hashCode() : 0);
         return result;
     }
+
+    public static Username valueOf(String username) {
+        return new Username(new CaseInsensitiveString(username));
+    }
 }

--- a/server/src/com/thoughtworks/go/server/service/JobInstanceService.java
+++ b/server/src/com/thoughtworks/go/server/service/JobInstanceService.java
@@ -32,6 +32,7 @@ import com.thoughtworks.go.plugin.infra.PluginManager;
 import com.thoughtworks.go.plugin.infra.plugininfo.GoPluginDescriptor;
 import com.thoughtworks.go.server.dao.JobInstanceDao;
 import com.thoughtworks.go.server.domain.JobStatusListener;
+import com.thoughtworks.go.server.domain.Username;
 import com.thoughtworks.go.server.messaging.JobResultMessage;
 import com.thoughtworks.go.server.messaging.JobResultTopic;
 import com.thoughtworks.go.server.service.result.OperationResult;
@@ -104,7 +105,7 @@ public class JobInstanceService implements JobPlanLoader {
 			result.notFound("Not Found", "Pipeline not found", HealthStateType.general(HealthStateScope.GLOBAL));
 			return null;
 		}
-		if (!securityService.hasViewPermissionForPipeline(username, pipelineName)) {
+		if (!securityService.hasViewPermissionForPipeline(Username.valueOf(username), pipelineName)) {
 			result.unauthorized("Unauthorized", NOT_AUTHORIZED_TO_VIEW_PIPELINE, HealthStateType.general(HealthStateScope.forPipeline(pipelineName)));
 			return null;
 		}

--- a/server/src/com/thoughtworks/go/server/service/MaterialService.java
+++ b/server/src/com/thoughtworks/go/server/service/MaterialService.java
@@ -89,7 +89,7 @@ public class MaterialService {
     }
 
     public List<MatchedRevision> searchRevisions(String pipelineName, String fingerprint, String searchString, Username username, LocalizedOperationResult result) {
-        if (!securityService.hasViewPermissionForPipeline(CaseInsensitiveString.str(username.getUsername()), pipelineName)) {
+        if (!securityService.hasViewPermissionForPipeline(username, pipelineName)) {
             result.unauthorized(LocalizedMessage.cannotViewPipeline(pipelineName), HealthStateType.general(HealthStateScope.forPipeline(pipelineName)));
             return new ArrayList<MatchedRevision>();
         }

--- a/server/src/com/thoughtworks/go/server/service/PipelineHistoryService.java
+++ b/server/src/com/thoughtworks/go/server/service/PipelineHistoryService.java
@@ -140,7 +140,7 @@ public class PipelineHistoryService implements PipelineInstanceLoader {
 			result.notFound("Not Found", "Pipeline " + pipelineName + " not found", HealthStateType.general(HealthStateScope.GLOBAL));
 			return null;
 		}
-		if (!securityService.hasViewPermissionForPipeline(username, pipelineName)) {
+		if (!securityService.hasViewPermissionForPipeline(Username.valueOf(username), pipelineName)) {
 			result.unauthorized("Unauthorized", NOT_AUTHORIZED_TO_VIEW_PIPELINE, HealthStateType.general(HealthStateScope.forPipeline(pipelineName)));
 			return null;
 		}
@@ -166,7 +166,7 @@ public class PipelineHistoryService implements PipelineInstanceLoader {
 			result.notFound("Not Found", "Pipeline not found", HealthStateType.general(HealthStateScope.GLOBAL));
 			return null;
 		}
-		if (!securityService.hasViewPermissionForPipeline(username, pipelineName)) {
+		if (!securityService.hasViewPermissionForPipeline(Username.valueOf(username), pipelineName)) {
 			result.unauthorized("Unauthorized", NOT_AUTHORIZED_TO_VIEW_PIPELINE, HealthStateType.general(HealthStateScope.forPipeline(pipelineName)));
 			return null;
 		}

--- a/server/src/com/thoughtworks/go/server/service/SecurityService.java
+++ b/server/src/com/thoughtworks/go/server/service/SecurityService.java
@@ -39,18 +39,11 @@ public class SecurityService {
     }
 
     public boolean hasViewPermissionForPipeline(Username username, String pipelineName) {
-        return hasViewPermissionForPipeline(CaseInsensitiveString.str(username.getUsername()), pipelineName);
-    }
-
-    /**
-     * @deprecated use hasViewPermissionForPipeline(Username username, String pipelineName) instead
-     */
-    public boolean hasViewPermissionForPipeline(String username, String pipelineName) {
         String groupName = goConfigService.findGroupNameByPipeline(new CaseInsensitiveString(pipelineName));
         if (groupName == null) {
             return true;
         }
-        return hasViewPermissionForGroup(username, groupName);
+        return hasViewPermissionForGroup(CaseInsensitiveString.str(username.getUsername()), groupName);
     }
 
     public boolean hasViewPermissionForGroup(String userName, String pipelineGroupName) {
@@ -150,7 +143,7 @@ public class SecurityService {
     }
 
     public boolean hasViewOrOperatePermissionForPipeline(Username username, String pipelineName) {
-        return hasViewPermissionForPipeline(CaseInsensitiveString.str(username.getUsername()), pipelineName) ||
+        return hasViewPermissionForPipeline(username, pipelineName) ||
                 hasOperatePermissionForPipeline(username.getUsername(), pipelineName);
     }
 

--- a/server/src/com/thoughtworks/go/server/service/StageService.java
+++ b/server/src/com/thoughtworks/go/server/service/StageService.java
@@ -412,7 +412,7 @@ public class StageService implements StageRunFinder, StageFinder {
 			result.notFound("Not Found", "Pipeline not found", HealthStateType.general(HealthStateScope.GLOBAL));
 			return null;
 		}
-		if (!securityService.hasViewPermissionForPipeline(username, pipelineName)) {
+		if (!securityService.hasViewPermissionForPipeline(Username.valueOf(username), pipelineName)) {
 			result.unauthorized("Unauthorized", NOT_AUTHORIZED_TO_VIEW_PIPELINE, HealthStateType.general(HealthStateScope.forPipeline(pipelineName)));
 			return null;
 		}

--- a/server/src/com/thoughtworks/go/server/service/StageService.java
+++ b/server/src/com/thoughtworks/go/server/service/StageService.java
@@ -129,7 +129,7 @@ public class StageService implements StageRunFinder, StageFinder {
             result.notFound("Not Found", "Pipeline not found", HealthStateType.general(HealthStateScope.GLOBAL));
             return null;
         }
-        if (!securityService.hasViewPermissionForPipeline(username, pipelineName)) {
+        if (!securityService.hasViewPermissionForPipeline(Username.valueOf(username), pipelineName)) {
             result.unauthorized("Unauthorized", NOT_AUTHORIZED_TO_VIEW_PIPELINE, HealthStateType.general(HealthStateScope.forPipeline(pipelineName)));
             return null;
         }
@@ -142,7 +142,7 @@ public class StageService implements StageRunFinder, StageFinder {
     }
 
     public StageSummaryModel findStageSummaryByIdentifier(StageIdentifier stageId, Username username, LocalizedOperationResult result) {
-        if (!securityService.hasViewPermissionForPipeline(CaseInsensitiveString.str(username.getUsername()), stageId.getPipelineName())) {
+        if (!securityService.hasViewPermissionForPipeline(username, stageId.getPipelineName())) {
             result.unauthorized(LocalizedMessage.cannotViewPipeline(stageId.getPipelineName()), HealthStateType.general(HealthStateScope.forPipeline(stageId.getPipelineName())));
             return null;
         }

--- a/server/src/com/thoughtworks/go/server/service/UserService.java
+++ b/server/src/com/thoughtworks/go/server/service/UserService.java
@@ -413,7 +413,7 @@ public class UserService {
         return users.filter(new Filter<User>() {
             public boolean matches(User user) {
                 return user.hasSubscribedFor(identifier.getPipelineName(), identifier.getStageName()) &&
-                        securityService.hasViewPermissionForPipeline(user.getName(), identifier.getPipelineName());
+                        securityService.hasViewPermissionForPipeline(user.getUsername(), identifier.getPipelineName());
             }
         });
     }

--- a/server/src/com/thoughtworks/go/server/web/AuthorizationInterceptor.java
+++ b/server/src/com/thoughtworks/go/server/web/AuthorizationInterceptor.java
@@ -21,6 +21,7 @@ import javax.servlet.http.HttpServletResponse;
 import static javax.servlet.http.HttpServletResponse.SC_UNAUTHORIZED;
 
 import com.thoughtworks.go.config.CaseInsensitiveString;
+import com.thoughtworks.go.server.domain.Username;
 import com.thoughtworks.go.server.service.SecurityService;
 import com.thoughtworks.go.server.util.UserHelper;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -45,9 +46,10 @@ public class AuthorizationInterceptor implements HandlerInterceptor {
 
         String pipelineName = request.getParameter("pipelineName");
         if (pipelineName != null) {
-            String userName = CaseInsensitiveString.str(UserHelper.getUserName().getUsername());
+            Username username = UserHelper.getUserName();
+            String name = CaseInsensitiveString.str(username.getUsername());
             if (request.getMethod().equalsIgnoreCase("get")) {
-                if (!securityService.hasViewPermissionForPipeline(userName, pipelineName)) {
+                if (!securityService.hasViewPermissionForPipeline(username, pipelineName)) {
                     response.sendError(SC_UNAUTHORIZED);
                     return false;
                 }
@@ -58,17 +60,17 @@ public class AuthorizationInterceptor implements HandlerInterceptor {
                 
                 String stageName = request.getParameter("stageName");
                 if (stageName != null) {
-                    if (!securityService.hasOperatePermissionForStage(pipelineName, stageName, userName)) {
+                    if (!securityService.hasOperatePermissionForStage(pipelineName, stageName, name)) {
                         response.sendError(SC_UNAUTHORIZED);
                         return false;
                     }
                 } else {
                     if (isForcePipelineRequest(request)) {
-                        if (!securityService.hasOperatePermissionForFirstStage(pipelineName, userName)) {
+                        if (!securityService.hasOperatePermissionForFirstStage(pipelineName, name)) {
                             response.sendError(SC_UNAUTHORIZED);
                             return false;
                         }
-                    } else if (!securityService.hasOperatePermissionForPipeline(new CaseInsensitiveString(userName), pipelineName)) {
+                    } else if (!securityService.hasOperatePermissionForPipeline(username.getUsername(), pipelineName)) {
                         response.sendError(SC_UNAUTHORIZED);
                         return false;
                     }

--- a/server/test/integration/com/thoughtworks/go/server/service/JobInstanceServiceTest.java
+++ b/server/test/integration/com/thoughtworks/go/server/service/JobInstanceServiceTest.java
@@ -30,6 +30,7 @@ import com.thoughtworks.go.plugin.infra.PluginManager;
 import com.thoughtworks.go.server.dao.JobInstanceDao;
 import com.thoughtworks.go.server.dao.StageDao;
 import com.thoughtworks.go.server.domain.JobStatusListener;
+import com.thoughtworks.go.server.domain.Username;
 import com.thoughtworks.go.server.messaging.JobResultMessage;
 import com.thoughtworks.go.server.messaging.JobResultTopic;
 import com.thoughtworks.go.server.service.result.HttpOperationResult;
@@ -302,7 +303,7 @@ public class JobInstanceServiceTest {
 	public void shouldDelegateToDAO_findJobHistoryPage() {
 		when(cruiseConfig.hasPipelineNamed(new CaseInsensitiveString("pipeline"))).thenReturn(true);
 		when(goConfigService.currentCruiseConfig()).thenReturn(cruiseConfig);
-		when(securityService.hasViewPermissionForPipeline("looser", "pipeline")).thenReturn(true);
+		when(securityService.hasViewPermissionForPipeline(Username.valueOf("looser"), "pipeline")).thenReturn(true);
 
 		final JobInstanceService jobService = new JobInstanceService(jobInstanceDao, buildPropertiesService, topic, jobStatusCache,
 				transactionTemplate, transactionSynchronizationManager, null, null, goConfigService, securityService, pluginManager);
@@ -317,7 +318,7 @@ public class JobInstanceServiceTest {
 	public void shouldPopulateErrorWhenPipelineNotFound_findJobHistoryPage() {
 		when(cruiseConfig.hasPipelineNamed(new CaseInsensitiveString("pipeline"))).thenReturn(false);
 		when(goConfigService.currentCruiseConfig()).thenReturn(cruiseConfig);
-		when(securityService.hasViewPermissionForPipeline("looser", "pipeline")).thenReturn(true);
+		when(securityService.hasViewPermissionForPipeline(Username.valueOf("looser"), "pipeline")).thenReturn(true);
 
 		final JobInstanceService jobService = new JobInstanceService(jobInstanceDao, buildPropertiesService, topic, jobStatusCache,
 				transactionTemplate, transactionSynchronizationManager, null, null, goConfigService, securityService, pluginManager);
@@ -334,7 +335,7 @@ public class JobInstanceServiceTest {
 	public void shouldPopulateErrorWhenUnauthorized_findJobHistoryPage() {
 		when(cruiseConfig.hasPipelineNamed(new CaseInsensitiveString("pipeline"))).thenReturn(true);
 		when(goConfigService.currentCruiseConfig()).thenReturn(cruiseConfig);
-		when(securityService.hasViewPermissionForPipeline("looser", "pipeline")).thenReturn(false);
+		when(securityService.hasViewPermissionForPipeline(Username.valueOf("looser"), "pipeline")).thenReturn(false);
 
 		final JobInstanceService jobService = new JobInstanceService(jobInstanceDao, buildPropertiesService, topic, jobStatusCache,
 				transactionTemplate, transactionSynchronizationManager, null, null, goConfigService, securityService, pluginManager);

--- a/server/test/integration/com/thoughtworks/go/server/service/SecurityServiceIntegrationTest.java
+++ b/server/test/integration/com/thoughtworks/go/server/service/SecurityServiceIntegrationTest.java
@@ -90,7 +90,7 @@ public class SecurityServiceIntegrationTest {
         assertThat(securityService.hasViewPermissionForGroup(PIPELINE_ADMIN, GROUP_NAME), is(true));
         assertThat(securityService.hasOperatePermissionForGroup(new CaseInsensitiveString(PIPELINE_ADMIN), GROUP_NAME), is(true));
         assertThat(securityService.hasOperatePermissionForPipeline(new CaseInsensitiveString(PIPELINE_ADMIN), PIPELINE_NAME), is(true));
-        assertThat(securityService.hasViewPermissionForPipeline(PIPELINE_ADMIN, PIPELINE_NAME), is(true));
+        assertThat(securityService.hasViewPermissionForPipeline(Username.valueOf(PIPELINE_ADMIN), PIPELINE_NAME), is(true));
         assertThat(securityService.hasViewPermissionForPipeline(new Username(new CaseInsensitiveString(PIPELINE_ADMIN)), PIPELINE_NAME), is(true));
         assertThat(securityService.hasOperatePermissionForStage(PIPELINE_NAME, STAGE_NAME, PIPELINE_ADMIN), is(true));
     }
@@ -103,13 +103,13 @@ public class SecurityServiceIntegrationTest {
         assertThat(securityService.hasViewPermissionForGroup(viewOnly, GROUP_NAME), is(true));
         assertThat(securityService.hasOperatePermissionForGroup(new CaseInsensitiveString(viewOnly), GROUP_NAME), is(false));
         assertThat(securityService.hasOperatePermissionForPipeline(new CaseInsensitiveString(viewOnly), PIPELINE_NAME), is(false));
-        assertThat(securityService.hasViewPermissionForPipeline(viewOnly, PIPELINE_NAME), is(true));
+        assertThat(securityService.hasViewPermissionForPipeline(Username.valueOf(viewOnly), PIPELINE_NAME), is(true));
         assertThat(securityService.hasOperatePermissionForStage(PIPELINE_NAME, STAGE_NAME, viewOnly), is(false));
 
         assertThat(securityService.hasViewPermissionForGroup(viewOnly, GROUP_NAME), is(true));
         assertThat(securityService.hasOperatePermissionForGroup(new CaseInsensitiveString(viewOnly), GROUP_NAME), is(false));
         assertThat(securityService.hasOperatePermissionForPipeline(new CaseInsensitiveString(viewOnly), PIPELINE_NAME), is(false));
-        assertThat(securityService.hasViewPermissionForPipeline(viewOnly, PIPELINE_NAME), is(true));
+        assertThat(securityService.hasViewPermissionForPipeline(Username.valueOf(viewOnly), PIPELINE_NAME), is(true));
         assertThat(securityService.hasOperatePermissionForStage(PIPELINE_NAME, STAGE_NAME, viewOnly), is(false));
     }
 
@@ -172,7 +172,7 @@ public class SecurityServiceIntegrationTest {
 
     @Test
     public void shouldNotCheckViewPermissionIfPipelineDoesNotExist() {
-        assertThat(securityService.hasViewPermissionForPipeline(VIEWER, "noSuchAPipeline"), is(true));
+        assertThat(securityService.hasViewPermissionForPipeline(Username.valueOf(VIEWER), "noSuchAPipeline"), is(true));
     }
 
     @Test

--- a/server/test/unit/com/thoughtworks/go/server/domain/UsernameTest.java
+++ b/server/test/unit/com/thoughtworks/go/server/domain/UsernameTest.java
@@ -38,4 +38,11 @@ public class UsernameTest {
         assertThat("dyang should be display name.", username1.getDisplayName(), is("dyang"));
     }
 
+    @Test
+    public void shouldAllowBuildingUsernameFromString() {
+        Username one = new Username(new CaseInsensitiveString("myusername"));
+        Username two = Username.valueOf("myusername");
+        assertThat(one, is(two));
+    }
+
 }

--- a/server/test/unit/com/thoughtworks/go/server/service/MaterialServiceTest.java
+++ b/server/test/unit/com/thoughtworks/go/server/service/MaterialServiceTest.java
@@ -112,7 +112,7 @@ public class MaterialServiceTest {
 
     @Test
     public void shouldNotBeAuthorizedToViewAPipeline() {
-        when(securityService.hasViewPermissionForPipeline("pavan", "pipeline")).thenReturn(false);
+        when(securityService.hasViewPermissionForPipeline(Username.valueOf("pavan"), "pipeline")).thenReturn(false);
         LocalizedOperationResult operationResult = mock(LocalizedOperationResult.class);
         materialService.searchRevisions("pipeline", "sha", "search-string", new Username(new CaseInsensitiveString("pavan")), operationResult);
         verify(operationResult).unauthorized(LocalizedMessage.cannotViewPipeline("pipeline"), HealthStateType.general(HealthStateScope.forPipeline("pipeline")));
@@ -120,7 +120,7 @@ public class MaterialServiceTest {
 
     @Test
     public void shouldReturnTheRevisionsThatMatchTheGivenSearchString() {
-        when(securityService.hasViewPermissionForPipeline("pavan", "pipeline")).thenReturn(true);
+        when(securityService.hasViewPermissionForPipeline(Username.valueOf("pavan"), "pipeline")).thenReturn(true);
         LocalizedOperationResult operationResult = mock(LocalizedOperationResult.class);
         MaterialConfig materialConfig = mock(MaterialConfig.class);
         when(goConfigService.materialForPipelineWithFingerprint("pipeline", "sha")).thenReturn(materialConfig);
@@ -132,7 +132,7 @@ public class MaterialServiceTest {
 
     @Test
     public void shouldReturnNotFoundIfTheMaterialDoesNotBelongToTheGivenPipeline() {
-        when(securityService.hasViewPermissionForPipeline("pavan", "pipeline")).thenReturn(true);
+        when(securityService.hasViewPermissionForPipeline(Username.valueOf("pavan"), "pipeline")).thenReturn(true);
         LocalizedOperationResult operationResult = mock(LocalizedOperationResult.class);
 
         when(goConfigService.materialForPipelineWithFingerprint("pipeline", "sha")).thenThrow(new RuntimeException("Not found"));

--- a/server/test/unit/com/thoughtworks/go/server/service/MaterialServiceTest.java
+++ b/server/test/unit/com/thoughtworks/go/server/service/MaterialServiceTest.java
@@ -112,32 +112,35 @@ public class MaterialServiceTest {
 
     @Test
     public void shouldNotBeAuthorizedToViewAPipeline() {
-        when(securityService.hasViewPermissionForPipeline(Username.valueOf("pavan"), "pipeline")).thenReturn(false);
+        Username pavan = Username.valueOf("pavan");
+        when(securityService.hasViewPermissionForPipeline(pavan, "pipeline")).thenReturn(false);
         LocalizedOperationResult operationResult = mock(LocalizedOperationResult.class);
-        materialService.searchRevisions("pipeline", "sha", "search-string", new Username(new CaseInsensitiveString("pavan")), operationResult);
+        materialService.searchRevisions("pipeline", "sha", "search-string", pavan, operationResult);
         verify(operationResult).unauthorized(LocalizedMessage.cannotViewPipeline("pipeline"), HealthStateType.general(HealthStateScope.forPipeline("pipeline")));
     }
 
     @Test
     public void shouldReturnTheRevisionsThatMatchTheGivenSearchString() {
-        when(securityService.hasViewPermissionForPipeline(Username.valueOf("pavan"), "pipeline")).thenReturn(true);
+        Username pavan = Username.valueOf("pavan");
+        when(securityService.hasViewPermissionForPipeline(pavan, "pipeline")).thenReturn(true);
         LocalizedOperationResult operationResult = mock(LocalizedOperationResult.class);
         MaterialConfig materialConfig = mock(MaterialConfig.class);
         when(goConfigService.materialForPipelineWithFingerprint("pipeline", "sha")).thenReturn(materialConfig);
 
         List<MatchedRevision> expected = asList(new MatchedRevision("23", "revision", "revision", "user", new DateTime(2009, 10, 10, 12, 0, 0, 0).toDate(), "comment"));
         when(materialRepository.findRevisionsMatching(materialConfig, "23")).thenReturn(expected);
-        assertThat(materialService.searchRevisions("pipeline", "sha", "23", new Username(new CaseInsensitiveString("pavan")), operationResult), is(expected));
+        assertThat(materialService.searchRevisions("pipeline", "sha", "23", pavan, operationResult), is(expected));
     }
 
     @Test
     public void shouldReturnNotFoundIfTheMaterialDoesNotBelongToTheGivenPipeline() {
-        when(securityService.hasViewPermissionForPipeline(Username.valueOf("pavan"), "pipeline")).thenReturn(true);
+        Username pavan = Username.valueOf("pavan");
+        when(securityService.hasViewPermissionForPipeline(pavan, "pipeline")).thenReturn(true);
         LocalizedOperationResult operationResult = mock(LocalizedOperationResult.class);
 
         when(goConfigService.materialForPipelineWithFingerprint("pipeline", "sha")).thenThrow(new RuntimeException("Not found"));
 
-        materialService.searchRevisions("pipeline", "sha", "23", new Username(new CaseInsensitiveString("pavan")), operationResult);
+        materialService.searchRevisions("pipeline", "sha", "23", pavan, operationResult);
         verify(operationResult).notFound(LocalizedMessage.materialWithFingerPrintNotFound("pipeline", "sha"), HealthStateType.general(HealthStateScope.forPipeline("pipeline")));
     }
 

--- a/server/test/unit/com/thoughtworks/go/server/service/PipelineHistoryServiceTest.java
+++ b/server/test/unit/com/thoughtworks/go/server/service/PipelineHistoryServiceTest.java
@@ -813,7 +813,7 @@ public class PipelineHistoryServiceTest {
         PipelinePauseInfo pipelinePauseInfo = new PipelinePauseInfo(true,"pausing pipeline for some-reason", "some-one");
 		when(cruiseConfig.getPipelineConfigByName(new CaseInsensitiveString("pipeline-name"))).thenReturn(pipelineConfig);
 		when(goConfigService.currentCruiseConfig()).thenReturn(cruiseConfig);
-		when(securityService.hasViewPermissionForPipeline("user-name", "pipeline-name")).thenReturn(true);
+		when(securityService.hasViewPermissionForPipeline(Username.valueOf("user-name"), "pipeline-name")).thenReturn(true);
 		when(pipelinePauseService.pipelinePauseInfo("pipeline-name")).thenReturn(pipelinePauseInfo);
 		when(pipelineLockService.isLocked("pipeline-name")).thenReturn(true);
 		when(schedulingCheckerService.canManuallyTrigger(eq(pipelineConfig), eq("user-name"), any(ServerHealthStateOperationResult.class))).thenReturn(true);
@@ -846,7 +846,7 @@ public class PipelineHistoryServiceTest {
 		PipelineConfig pipelineConfig = new PipelineConfig();
 		when(cruiseConfig.getPipelineConfigByName(new CaseInsensitiveString("pipeline-name"))).thenReturn(pipelineConfig);
 		when(goConfigService.currentCruiseConfig()).thenReturn(cruiseConfig);
-		when(securityService.hasViewPermissionForPipeline("user-name", "pipeline-name")).thenReturn(false);
+		when(securityService.hasViewPermissionForPipeline(Username.valueOf("user-name"), "pipeline-name")).thenReturn(false);
 
 		HttpOperationResult result = new HttpOperationResult();
 		PipelineStatusModel pipelineStatus = pipelineHistoryService.getPipelineStatus("pipeline-name", "user-name", result);
@@ -879,8 +879,8 @@ public class PipelineHistoryServiceTest {
 		when(cruiseConfig.hasPipelineNamed(new CaseInsensitiveString(pipelineName))).thenReturn(true);
 		when(goConfigService.currentCruiseConfig()).thenReturn(cruiseConfig);
 
-		when(securityService.hasViewPermissionForPipeline(noAccessUserName, pipelineName)).thenReturn(false);
-		when(securityService.hasViewPermissionForPipeline(withAccessUserName, pipelineName)).thenReturn(true);
+		when(securityService.hasViewPermissionForPipeline(Username.valueOf(noAccessUserName), pipelineName)).thenReturn(false);
+		when(securityService.hasViewPermissionForPipeline(Username.valueOf(withAccessUserName), pipelineName)).thenReturn(true);
 
 		when(pipelineDao.loadHistory(pipelineName, 10, 0)).thenReturn(PipelineInstanceModels.createPipelineInstanceModels());
 

--- a/server/test/unit/com/thoughtworks/go/server/service/StageServiceTest.java
+++ b/server/test/unit/com/thoughtworks/go/server/service/StageServiceTest.java
@@ -558,7 +558,7 @@ public class StageServiceTest {
 	public void shouldDelegateToDAO_findDetailedStageHistoryByOffset() {
 		when(cruiseConfig.hasPipelineNamed(new CaseInsensitiveString("pipeline"))).thenReturn(true);
 		when(goConfigService.currentCruiseConfig()).thenReturn(cruiseConfig);
-		when(securityService.hasViewPermissionForPipeline("looser", "pipeline")).thenReturn(true);
+		when(securityService.hasViewPermissionForPipeline(Username.valueOf("looser"), "pipeline")).thenReturn(true);
 
 		final StageService stageService = new StageService(stageDao, jobInstanceService, mock(StageStatusTopic.class), mock(StageStatusCache.class), securityService, pipelineDao,
 		                changesetService, goConfigService, transactionTemplate, transactionSynchronizationManager, goCache);
@@ -573,7 +573,7 @@ public class StageServiceTest {
 	public void shouldPopulateErrorWhenPipelineNotFound_findDetailedStageHistoryByOffset() {
 		when(cruiseConfig.hasPipelineNamed(new CaseInsensitiveString("pipeline"))).thenReturn(false);
 		when(goConfigService.currentCruiseConfig()).thenReturn(cruiseConfig);
-		when(securityService.hasViewPermissionForPipeline("looser", "pipeline")).thenReturn(true);
+		when(securityService.hasViewPermissionForPipeline(Username.valueOf("looser"), "pipeline")).thenReturn(true);
 
 		final StageService stageService = new StageService(stageDao, jobInstanceService, mock(StageStatusTopic.class), mock(StageStatusCache.class), securityService, pipelineDao,
 		                changesetService, goConfigService, transactionTemplate, transactionSynchronizationManager, goCache);
@@ -590,7 +590,7 @@ public class StageServiceTest {
 	public void shouldPopulateErrorWhenUnauthorized_findDetailedStageHistoryByOffset() {
 		when(cruiseConfig.hasPipelineNamed(new CaseInsensitiveString("pipeline"))).thenReturn(true);
 		when(goConfigService.currentCruiseConfig()).thenReturn(cruiseConfig);
-		when(securityService.hasViewPermissionForPipeline("looser", "pipeline")).thenReturn(false);
+		when(securityService.hasViewPermissionForPipeline(Username.valueOf("looser"), "pipeline")).thenReturn(false);
 
 		final StageService stageService = new StageService(stageDao, jobInstanceService, mock(StageStatusTopic.class), mock(StageStatusCache.class), securityService, pipelineDao,
 		                changesetService, goConfigService, transactionTemplate, transactionSynchronizationManager, goCache);
@@ -607,7 +607,7 @@ public class StageServiceTest {
     public void shouldPopulateErrorWhenPipelineNotFound_findStageWithIdentifier() {
         when(cruiseConfig.hasPipelineNamed(new CaseInsensitiveString("pipeline"))).thenReturn(false);
         when(goConfigService.currentCruiseConfig()).thenReturn(cruiseConfig);
-        when(securityService.hasViewPermissionForPipeline("looser", "pipeline")).thenReturn(true);
+        when(securityService.hasViewPermissionForPipeline(Username.valueOf("looser"), "pipeline")).thenReturn(true);
 
         final StageService stageService = new StageService(stageDao, jobInstanceService, mock(StageStatusTopic.class), mock(StageStatusCache.class), securityService, pipelineDao,
                 changesetService, goConfigService, transactionTemplate, transactionSynchronizationManager, goCache);
@@ -623,7 +623,7 @@ public class StageServiceTest {
     public void shouldPopulateErrorWhenUnauthorized_findStageWithIdentifier() {
         when(cruiseConfig.hasPipelineNamed(new CaseInsensitiveString("pipeline"))).thenReturn(true);
         when(goConfigService.currentCruiseConfig()).thenReturn(cruiseConfig);
-        when(securityService.hasViewPermissionForPipeline("looser", "pipeline")).thenReturn(false);
+        when(securityService.hasViewPermissionForPipeline(Username.valueOf("looser"), "pipeline")).thenReturn(false);
 
         final StageService stageService = new StageService(stageDao, jobInstanceService, mock(StageStatusTopic.class), mock(StageStatusCache.class), securityService, pipelineDao,
                 changesetService, goConfigService, transactionTemplate, transactionSynchronizationManager, goCache);

--- a/server/test/unit/com/thoughtworks/go/server/service/StageServiceTest.java
+++ b/server/test/unit/com/thoughtworks/go/server/service/StageServiceTest.java
@@ -231,7 +231,7 @@ public class StageServiceTest {
 
     private SecurityService alwaysAllow() {
         SecurityService securityService = mock(SecurityService.class);
-        when(securityService.hasViewPermissionForPipeline(eq(CaseInsensitiveString.str(ALWAYS_ALLOW_USER.getUsername())), any(String.class))).thenReturn(true);
+        when(securityService.hasViewPermissionForPipeline(eq(ALWAYS_ALLOW_USER), any(String.class))).thenReturn(true);
         return securityService;
     }
 
@@ -266,7 +266,7 @@ public class StageServiceTest {
     @Test
     public void findStageSummaryByIdentifierShouldRespondWith401WhenUserDoesNotHavePermissionToViewThePipeline() throws Exception {
         SecurityService securityService = mock(SecurityService.class);
-        when(securityService.hasViewPermissionForPipeline(CaseInsensitiveString.str(ALWAYS_ALLOW_USER.getUsername()), "pipeline_name")).thenReturn(false);
+        when(securityService.hasViewPermissionForPipeline(ALWAYS_ALLOW_USER, "pipeline_name")).thenReturn(false);
         TransactionSynchronizationManager transactionSynchronizationManager = mock(TransactionSynchronizationManager.class);
         StageService service = new StageService(stageDao, null, null, null, securityService, null, changesetService, goConfigService, transactionTemplate, transactionSynchronizationManager,
                 goCache);
@@ -281,7 +281,7 @@ public class StageServiceTest {
     @Test
     public void findStageSummaryByIdentifierShouldRespondWith404WhenNoStagesFound() throws Exception {
         SecurityService securityService = mock(SecurityService.class);
-        when(securityService.hasViewPermissionForPipeline(CaseInsensitiveString.str(ALWAYS_ALLOW_USER.getUsername()), "pipeline_does_not_exist")).thenReturn(true);
+        when(securityService.hasViewPermissionForPipeline(ALWAYS_ALLOW_USER, "pipeline_does_not_exist")).thenReturn(true);
         TransactionSynchronizationManager transactionSynchronizationManager = mock(TransactionSynchronizationManager.class);
         StageService service = new StageService(stageDao, null, null, null, securityService, null, changesetService, goConfigService, transactionTemplate, transactionSynchronizationManager,
                 goCache);
@@ -299,7 +299,7 @@ public class StageServiceTest {
     @Test
     public void findStageSummaryByIdentifierShouldRespondWith404WhenStagesHavingGivenCounterIsNotFound() throws Exception {
         SecurityService securityService = mock(SecurityService.class);
-        when(securityService.hasViewPermissionForPipeline(CaseInsensitiveString.str(ALWAYS_ALLOW_USER.getUsername()), "dev")).thenReturn(true);
+        when(securityService.hasViewPermissionForPipeline(ALWAYS_ALLOW_USER, "dev")).thenReturn(true);
         TransactionSynchronizationManager transactionSynchronizationManager = mock(TransactionSynchronizationManager.class);
         StageService service = new StageService(stageDao, null, null, null, securityService, null, changesetService, goConfigService, transactionTemplate, transactionSynchronizationManager,
                 goCache);

--- a/server/test/unit/com/thoughtworks/go/server/service/UserServiceTest.java
+++ b/server/test/unit/com/thoughtworks/go/server/service/UserServiceTest.java
@@ -491,8 +491,8 @@ public class UserServiceTest {
         quux.addNotificationFilter(new NotificationFilter("p2", "s2", StageEvent.Passes, true));
 
         when(userDao.findNotificationSubscribingUsers()).thenReturn(new Users(Arrays.asList(foo, bar, quux)));
-        when(securityService.hasViewPermissionForPipeline(foo.getName(), "p1")).thenReturn(true);
-        when(securityService.hasViewPermissionForPipeline(bar.getName(), "p1")).thenReturn(false);
+        when(securityService.hasViewPermissionForPipeline(foo.getUsername(), "p1")).thenReturn(true);
+        when(securityService.hasViewPermissionForPipeline(bar.getUsername(), "p1")).thenReturn(false);
         assertThat(userService.findValidSubscribers(new StageConfigIdentifier("p1", "s1")), contains(foo));
     }
 
@@ -504,8 +504,8 @@ public class UserServiceTest {
         bar.addNotificationFilter(new NotificationFilter(GoConstants.ANY_PIPELINE, GoConstants.ANY_STAGE, StageEvent.Passes, true));
 
         when(userDao.findNotificationSubscribingUsers()).thenReturn(new Users(Arrays.asList(foo, bar)));
-        when(securityService.hasViewPermissionForPipeline(foo.getName(), "p1")).thenReturn(true);
-        when(securityService.hasViewPermissionForPipeline(bar.getName(), "p1")).thenReturn(false);
+        when(securityService.hasViewPermissionForPipeline(foo.getUsername(), "p1")).thenReturn(true);
+        when(securityService.hasViewPermissionForPipeline(bar.getUsername(), "p1")).thenReturn(false);
         assertThat(userService.findValidSubscribers(new StageConfigIdentifier("p1", "s1")), contains(foo));
     }
 

--- a/server/test/unit/com/thoughtworks/go/server/web/AuthorizationInterceptorTest.java
+++ b/server/test/unit/com/thoughtworks/go/server/web/AuthorizationInterceptorTest.java
@@ -110,7 +110,7 @@ public class AuthorizationInterceptorTest {
     private void assumeUserHasViewPermission() {
         context.checking(new Expectations() {
             {
-                one(securityService).hasViewPermissionForPipeline(CaseInsensitiveString.str(ANONYMOUS.getUsername()), "cruise");
+                one(securityService).hasViewPermissionForPipeline(ANONYMOUS, "cruise");
                 will(returnValue(true));
             }
         });

--- a/server/webapp/WEB-INF/rails.new/app/helpers/api_v1/authentication_helper.rb
+++ b/server/webapp/WEB-INF/rails.new/app/helpers/api_v1/authentication_helper.rb
@@ -26,7 +26,7 @@ module ApiV1
 
     def check_user_can_see_pipeline
       return unless security_service.isSecurityEnabled()
-      unless security_service.hasViewPermissionForPipeline(string_username, params[:pipeline_name])
+      unless security_service.hasViewPermissionForPipeline(current_user, params[:pipeline_name])
         Rails.logger.info("User '#{current_user.getUsername}' attempted to perform an unauthorized action!")
         render_unauthorized_error
       end

--- a/server/webapp/WEB-INF/rails.new/spec/support/api_spec_helper.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/support/api_spec_helper.rb
@@ -44,11 +44,11 @@ module ApiSpecHelper
   end
 
   def allow_current_user_to_access_pipeline(pipeline_name)
-    @security_service.stub(:hasViewPermissionForPipeline).with(controller.string_username, pipeline_name).and_return(true)
+    @security_service.stub(:hasViewPermissionForPipeline).with(controller.current_user, pipeline_name).and_return(true)
   end
 
   def allow_current_user_to_not_access_pipeline(pipeline_name)
-    @security_service.stub(:hasViewPermissionForPipeline).with(controller.string_username, pipeline_name).and_return(false)
+    @security_service.stub(:hasViewPermissionForPipeline).with(controller.current_user, pipeline_name).and_return(false)
   end
 
   def disable_security


### PR DESCRIPTION
Replacing the deprecated `hasViewPermissionForPipeline(String, String)` method with the suggested `hasViewPermissionForPipeline(Username, String)` from `SecurityService`