### PR TITLE
Do not check for execjs runtime during server boot

### DIFF
--- a/server/webapp/WEB-INF/init.rb
+++ b/server/webapp/WEB-INF/init.rb
@@ -1,5 +1,4 @@
 # This file is sourced by jruby-rack and is used to perform initialization of the jruby environment
-
 # because jruby-rack does not respect GEM_HOME/GEM_PATH set in web.xml
 if $servlet_context
   ENV['GEM_HOME']       = $servlet_context.getRealPath('/WEB-INF/rails.new/vendor/bundle/jruby/1.9')
@@ -10,4 +9,8 @@ else
 end
 
 ENV['RAILS_ENV']      ||= (ENV['RACK_ENV'] || 'production')
-ENV['BUNDLE_WITHOUT'] = 'development:test:assets' if ENV['RAILS_ENV'] == 'production'
+
+if ENV['RAILS_ENV'] == 'production'
+  ENV['EXECJS_RUNTIME'] = 'Disabled'
+  ENV['BUNDLE_WITHOUT'] = 'development:test:assets'
+end


### PR DESCRIPTION
execjs runtime check is required only in development mode. 
This flag prevents the check on production mode or server boot.

