### PR TITLE
#1332 fix - close open files in partial config xml loader

### DIFF
--- a/config/config-server/src/com/thoughtworks/go/config/parts/XmlPartialConfigProvider.java
+++ b/config/config-server/src/com/thoughtworks/go/config/parts/XmlPartialConfigProvider.java
@@ -20,6 +20,7 @@ import com.thoughtworks.go.config.remote.PartialConfig;
 import com.thoughtworks.go.domain.WildcardScanner;
 import com.thoughtworks.go.domain.config.Configuration;
 import com.thoughtworks.go.domain.config.ConfigurationProperty;
+import org.apache.log4j.Logger;
 import org.jdom.input.JDOMParseException;
 
 import java.io.File;
@@ -27,6 +28,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 
 public class XmlPartialConfigProvider implements PartialConfigProvider {
+    private static final Logger LOGGER = Logger.getLogger(XmlPartialConfigProvider.class);
 
     private final String defaultPatter = "**/*.gocd.xml";
 
@@ -103,8 +105,9 @@ public class XmlPartialConfigProvider implements PartialConfigProvider {
     }
 
     public PartialConfig parseFile(File file) {
+        FileInputStream inputStream = null;
         try {
-            final FileInputStream inputStream = new FileInputStream(file);
+            inputStream = new FileInputStream(file);
             return loader.fromXmlPartial(inputStream, PartialConfig.class);
         }
         catch (JDOMParseException jdomex)
@@ -118,6 +121,15 @@ public class XmlPartialConfigProvider implements PartialConfigProvider {
         catch (Exception ex)
         {
             throw new RuntimeException("Failed to parse xml file in configuration repository",ex);
+        }
+        finally {
+            if (inputStream != null) {
+                try {
+                    inputStream.close();
+                } catch (IOException e) {
+                    LOGGER.error("Failed to close file: " + file, e);
+                }
+            }
         }
     }
 }

--- a/config/config-server/test/com/thoughtworks/go/config/parts/PartialConfigHelper.java
+++ b/config/config-server/test/com/thoughtworks/go/config/parts/PartialConfigHelper.java
@@ -18,10 +18,7 @@ package com.thoughtworks.go.config.parts;
 import com.thoughtworks.go.config.*;
 import com.thoughtworks.go.config.remote.PartialConfig;
 import com.thoughtworks.go.util.FileUtil;
-import com.thoughtworks.go.util.TempFiles;
-import com.thoughtworks.go.util.TestFileUtil;
 
-import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
 
@@ -39,28 +36,35 @@ public class PartialConfigHelper {
         this.directory = directory;
     }
 
-    public File addFileWithPipeline(String relativePath,PipelineConfig pipelineConfig) throws Exception
+    public File addFileWithPipeline(String relativePath, PipelineConfig pipelineConfig) throws Exception
     {
         PartialConfig partialConfig = new PartialConfig();
         partialConfig.getGroups().addPipeline(PipelineConfigs.DEFAULT_GROUP,pipelineConfig);
         return this.addFileWithPartialConfig(relativePath,partialConfig);
-
     }
 
-    public File addFileWithPartialConfig(String relativePath,PartialConfig partialConfig) throws Exception
+    public File addFileWithPartialConfig(String relativePath, PartialConfig partialConfig) throws Exception
     {
         File dest = new File(directory,relativePath);
         FileUtil.createParentFolderIfNotExist(dest);
-        FileOutputStream output = new FileOutputStream(dest);
 
         BasicCruiseConfig cruiseConfig = new BasicCruiseConfig();
         cruiseConfig.setGroup(partialConfig.getGroups());
         cruiseConfig.setEnvironments(partialConfig.getEnvironments());
 
-        writer.write(cruiseConfig, output, true);
+        FileOutputStream output = null;
+        try {
+            output = new FileOutputStream(dest);
+            writer.write(cruiseConfig, output, true);
+        } finally {
+            if (output != null) {
+                output.close();
+            }
+        }
         return dest;
     }
-    public File writeFileWithContent(String relativePath,String content) throws Exception
+
+    public File writeFileWithContent(String relativePath, String content) throws Exception
     {
         File dest = new File(directory,relativePath);
         FileUtil.createParentFolderIfNotExist(dest);

--- a/config/config-server/test/com/thoughtworks/go/config/parts/XmlPartialConfigProviderTest.java
+++ b/config/config-server/test/com/thoughtworks/go/config/parts/XmlPartialConfigProviderTest.java
@@ -30,6 +30,8 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
 
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertArrayEquals;
@@ -65,8 +67,8 @@ public class XmlPartialConfigProviderTest {
     }
 
     @After
-    public void tearDown() {
-        FileUtil.deleteFolder(baseFolder);
+    public void tearDown() throws IOException {
+        FileUtil.deleteDirectoryNoisily(baseFolder);
     }
 
     @Test
@@ -172,11 +174,8 @@ public class XmlPartialConfigProviderTest {
 
         File[] matchingFiles = xmlPartialProvider.getFiles(tmpFolder, mock(PartialConfigLoadContext.class));
 
-        File[] expected = new File[3];
-        expected[0] = file1;
-        expected[1] = file3;
-        expected[2] = file4;
-        assertArrayEquals(expected,matchingFiles);
+        File[] expected = new File[] {file1, file3, file4};
+        assertArrayEquals("Matched files are: " + Arrays.asList(matchingFiles).toString(), expected, matchingFiles);
     }
 
     @Test


### PR DESCRIPTION
I checked other writes and reads to files config repo files.
This is your diff + the logging in case of `parseFile`.