### PR TITLE
fixes for bugs on #1417 - #1630

### DIFF
--- a/common/test/unit/com/thoughtworks/go/domain/JobConfigTest.java
+++ b/common/test/unit/com/thoughtworks/go/domain/JobConfigTest.java
@@ -192,7 +192,7 @@ public class JobConfigTest {
     @Test
     public void shouldValidateEmptyAndNullResources()
     {
-        PipelineConfig pipelineConfig=PipelineConfigMother.CreatePipelineConfigWithJobConfigs("pipeline1");
+        PipelineConfig pipelineConfig=PipelineConfigMother.createPipelineConfigWithJobConfigs("pipeline1");
         JobConfig jobConfig = JobConfigMother.createJobConfigWithJobNameAndEmptyResources();
         ValidationContext validationContext=mock(ValidationContext.class);
         when(validationContext.getPipeline()).thenReturn(pipelineConfig);

--- a/config/config-api/src/com/thoughtworks/go/config/EnvironmentVariableConfig.java
+++ b/config/config-api/src/com/thoughtworks/go/config/EnvironmentVariableConfig.java
@@ -110,9 +110,6 @@ public class EnvironmentVariableConfig extends PersistentObject implements Seria
         if (isSecure != that.isSecure) {
             return false;
         }
-        if (configErrors != null ? !configErrors.equals(that.configErrors) : that.configErrors != null) {
-            return false;
-        }
         if (encryptedValue != null ? !encryptedValue.equals(that.encryptedValue) : that.encryptedValue != null) {
             return false;
         }

--- a/config/config-api/src/com/thoughtworks/go/config/SecurityConfig.java
+++ b/config/config-api/src/com/thoughtworks/go/config/SecurityConfig.java
@@ -176,9 +176,6 @@ public class SecurityConfig implements Validatable {
         if (adminsConfig != null ? !adminsConfig.equals(that.adminsConfig) : that.adminsConfig != null) {
             return false;
         }
-        if (errors != null ? !errors.equals(that.errors) : that.errors != null) {
-            return false;
-        }
         if (ldapConfig != null ? !ldapConfig.equals(that.ldapConfig) : that.ldapConfig != null) {
             return false;
         }
@@ -200,7 +197,6 @@ public class SecurityConfig implements Validatable {
         result = 31 * result + (adminsConfig != null ? adminsConfig.hashCode() : 0);
         result = 31 * result + (anonymous ? 1 : 0);
         result = 31 * result + (allowOnlyKnownUsersToLogin ? 1 : 0);
-        result = 31 * result + (errors != null ? errors.hashCode() : 0);
         return result;
     }
 

--- a/config/config-api/src/com/thoughtworks/go/config/server/security/ldap/BaseConfig.java
+++ b/config/config-api/src/com/thoughtworks/go/config/server/security/ldap/BaseConfig.java
@@ -71,10 +71,7 @@ public class BaseConfig implements Validatable {
         }
 
         BaseConfig that = (BaseConfig) o;
-
-        if (errors != null ? !errors.equals(that.errors) : that.errors != null) {
-            return false;
-        }
+        
         if (value != null ? !value.equals(that.value) : that.value != null) {
             return false;
         }
@@ -84,8 +81,6 @@ public class BaseConfig implements Validatable {
 
     @Override
     public int hashCode() {
-        int result = errors != null ? errors.hashCode() : 0;
-        result = 31 * result + (value != null ? value.hashCode() : 0);
-        return result;
+        return value != null ? value.hashCode() : 0;
     }
 }

--- a/config/config-api/test/com/thoughtworks/go/config/EnvironmentVariableConfigTest.java
+++ b/config/config-api/test/com/thoughtworks/go/config/EnvironmentVariableConfigTest.java
@@ -291,6 +291,14 @@ public class EnvironmentVariableConfigTest {
         assertThat(copy.getEncryptedValue(), is(secureEnvironmentVariable.getEncryptedValue()));
         assertThat(copy.isSecure(), is(secureEnvironmentVariable.isSecure()));
     }
+
+    @Test
+    public void shouldNotConsiderErrorsForEqualsCheck(){
+        EnvironmentVariableConfig config1 = new EnvironmentVariableConfig("name", "value");
+        EnvironmentVariableConfig config2 = new EnvironmentVariableConfig("name", "value");
+        config2.addError("name", "errrr");
+        assertThat(config1.equals(config2), is(true));
+    }
     
     private HashMap getAttributeMap(String value, final String secure, String isChanged) {
         HashMap attrs;

--- a/config/config-api/test/com/thoughtworks/go/helper/PipelineConfigMother.java
+++ b/config/config-api/test/com/thoughtworks/go/helper/PipelineConfigMother.java
@@ -66,7 +66,7 @@ public class PipelineConfigMother {
     public static PipelineConfig pipelineConfig(String name, MaterialConfigs materialConfigs) {
         return pipelineConfig(name, materialConfigs, new JobConfigs());
     }
-    public static PipelineConfig CreatePipelineConfigWithJobConfigs(String name) {
+    public static PipelineConfig createPipelineConfigWithJobConfigs(String name) {
         return pipelineConfig(name, new MaterialConfigs(),new JobConfigs(JobConfigMother.createJobConfigWithJobNameAndEmptyResources()));
     }
 

--- a/server/webapp/WEB-INF/rails.new/app/presenters/api_v1/config/materials/pluggable_scm_material_representer.rb
+++ b/server/webapp/WEB-INF/rails.new/app/presenters/api_v1/config/materials/pluggable_scm_material_representer.rb
@@ -21,15 +21,10 @@ module ApiV1
                 alias_method :material_config, :represented
 
                 property :scm_id, as: :ref
-                property :filter, exec_context: :decorator, decorator: ApiV1::Config::Materials::FilterRepresenter, class:com.thoughtworks.go.config.materials.Filter
-
-                def filter
-                    material_config.filter
-                end
-
-                def filter=(value)
-                    material_config.setFilter(value)
-                end
+                property :filter,
+                         decorator:  ApiV1::Config::Materials::FilterRepresenter,
+                         class:      com.thoughtworks.go.config.materials.Filter,
+                         skip_parse: SkipParseOnBlank
             end
         end
     end

--- a/server/webapp/WEB-INF/rails.new/spec/presenters/api_v1/config/materials/material_representer_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/presenters/api_v1/config/materials/material_representer_spec.rb
@@ -74,6 +74,46 @@ describe ApiV1::Config::Materials::MaterialRepresenter do
       expect(deserialized_object).to eq(expected)
     end
 
+    it "should serialize pluggable scm material" do
+
+      presenter   = ApiV1::Config::Materials::MaterialRepresenter.prepare(PluggableSCMMaterialConfig.new("23a28171-3d5a-4912-9f36-d4e1536281b0"))
+      actual_json = presenter.to_hash(url_builder: UrlBuilder.new)
+      expect(actual_json).to eq(scm_material_basic_hash)
+    end
+
+    it "should deserialize pluggable scm material" do
+      presenter           = ApiV1::Config::Materials::MaterialRepresenter.new(PluggableSCMMaterialConfig.new)
+      deserialized_object = presenter.from_hash({
+                                                    type: "plugin",
+                                                    attributes: {
+                                                      ref: "23a28171-3d5a-4912-9f36-d4e1536281b0",
+                                                      filter: {
+                                                        ignore: [
+                                                          "doc/**/*",
+                                                          "foo/**/*"
+                                                        ]
+                                                      }
+                                                    }
+                                                })
+      expect(deserialized_object.name.to_s).to eq("")
+      expect(deserialized_object.getScmId).to eq("23a28171-3d5a-4912-9f36-d4e1536281b0")
+      expect(deserialized_object.filter.getStringForDisplay).to eq("doc/**/*,foo/**/*")
+    end
+
+    it "should deserialize pluggable scm material with null filter" do
+      presenter           = ApiV1::Config::Materials::MaterialRepresenter.new(PluggableSCMMaterialConfig.new)
+      deserialized_object = presenter.from_hash({
+                                                    type: "plugin",
+                                                    attributes: {
+                                                      ref: "23a28171-3d5a-4912-9f36-d4e1536281b0",
+                                                      filter: nil
+                                                    }
+                                                })
+      expect(deserialized_object.name.to_s).to eq("")
+      expect(deserialized_object.getScmId).to eq("23a28171-3d5a-4912-9f36-d4e1536281b0")
+      expect(ReflectionUtil::getField(deserialized_object, "filter")).to be_nil
+    end
+
     def material_hash
       {
         type:       'git',
@@ -102,6 +142,16 @@ describe ApiV1::Config::Materials::MaterialRepresenter do
           auto_update:      true,
           branch:           "master",
           submodule_folder: nil
+        }
+      }
+    end
+
+    def scm_material_basic_hash
+      {
+        type: "plugin",
+        attributes: {
+          ref: "23a28171-3d5a-4912-9f36-d4e1536281b0",
+          filter: nil
         }
       }
     end


### PR DESCRIPTION
Also, equals method should not consider configErrors object. That causes the validation error to not get rendered.