### PR TITLE
Config repo gc - modified behavior - #1567

### DIFF
--- a/base/src/com/thoughtworks/go/util/SystemEnvironment.java
+++ b/base/src/com/thoughtworks/go/util/SystemEnvironment.java
@@ -167,8 +167,8 @@ public class SystemEnvironment implements Serializable, ConfigDirProvider {
     public static GoSystemProperty<String[]> GO_SSL_EXCLUDE_PROTOCOLS = new GoStringArraySystemProperty("go.ssl.protocols.exclude", null);
     public static GoSystemProperty<Boolean> GO_SSL_RENEGOTIATION_ALLOWED = new GoBooleanSystemProperty("go.ssl.renegotiation.allowed", true);
     public static GoSystemProperty<Boolean> GO_CONFIG_REPO_GC_AGGRESSIVE = new GoBooleanSystemProperty("go.config.repo.gc.aggressive", true);
-    public static GoSystemProperty<Long> GO_CONFIG_REPO_GC_WARNING_THRESHOLD = new GoLongSystemProperty("go.config.repo.gc.warning.threshold", 10000L);
-    public static GoSystemProperty<Boolean> GO_CONFIG_REPO_AUTO_GC = new GoBooleanSystemProperty("go.config.repo.gc.auto", false);
+    public static GoSystemProperty<Long> GO_CONFIG_REPO_GC_LOOSE_OBJECT_WARNING_THRESHOLD = new GoLongSystemProperty("go.config.repo.gc.warning.looseobject.threshold", 10000L);
+    public static GoSystemProperty<Boolean> GO_CONFIG_REPO_PERIODIC_GC = new GoBooleanSystemProperty("go.config.repo.gc.periodic", false);
 
 
     private volatile static Integer agentConnectionTimeout;

--- a/base/src/com/thoughtworks/go/util/SystemEnvironment.java
+++ b/base/src/com/thoughtworks/go/util/SystemEnvironment.java
@@ -166,7 +166,9 @@ public class SystemEnvironment implements Serializable, ConfigDirProvider {
     public static GoSystemProperty<String[]> GO_SSL_INCLUDE_PROTOCOLS = new GoStringArraySystemProperty("go.ssl.protocols.include", null);
     public static GoSystemProperty<String[]> GO_SSL_EXCLUDE_PROTOCOLS = new GoStringArraySystemProperty("go.ssl.protocols.exclude", null);
     public static GoSystemProperty<Boolean> GO_SSL_RENEGOTIATION_ALLOWED = new GoBooleanSystemProperty("go.ssl.renegotiation.allowed", true);
-    public static GoSystemProperty<Boolean> GO_CONFIG_REPO_GC_AGGRESSIVE = new GoBooleanSystemProperty("go.config.repo.gc.aggressive", false);
+    public static GoSystemProperty<Boolean> GO_CONFIG_REPO_GC_AGGRESSIVE = new GoBooleanSystemProperty("go.config.repo.gc.aggressive", true);
+    public static GoSystemProperty<Long> GO_CONFIG_REPO_GC_WARNING_THRESHOLD = new GoLongSystemProperty("go.config.repo.gc.warning.threshold", 10000L);
+    public static GoSystemProperty<Boolean> GO_CONFIG_REPO_AUTO_GC = new GoBooleanSystemProperty("go.config.repo.gc.auto", false);
 
 
     private volatile static Integer agentConnectionTimeout;

--- a/common/src/com/thoughtworks/go/serverhealth/HealthStateScope.java
+++ b/common/src/com/thoughtworks/go/serverhealth/HealthStateScope.java
@@ -67,6 +67,9 @@ public class HealthStateScope implements Comparable<HealthStateScope> {
     public static HealthStateScope forMaterialConfigUpdate(MaterialConfig materialConfig) {
         return new HealthStateScope(ScopeType.MATERIAL_UPDATE, materialConfig.getFingerprint());
     }
+    public static HealthStateScope forConfigRepo(String operation) {
+        return new HealthStateScope(ScopeType.CONFIG_REPO, operation);
+    }
 
     public boolean isSame(String scope) {
         return StringUtils.endsWithIgnoreCase(this.scope, scope);
@@ -147,6 +150,7 @@ public class HealthStateScope implements Comparable<HealthStateScope> {
     enum ScopeType {
 
         GLOBAL,
+        CONFIG_REPO,
         GROUP{
             public boolean isRemovedFromConfig(CruiseConfig cruiseConfig, String group){
                 return !cruiseConfig.hasPipelineGroup(group);

--- a/common/test/unit/com/thoughtworks/go/util/SystemEnvironmentTest.java
+++ b/common/test/unit/com/thoughtworks/go/util/SystemEnvironmentTest.java
@@ -1,18 +1,18 @@
-/*************************GO-LICENSE-START*********************************
- * Copyright 2014 ThoughtWorks, Inc.
+/*
+ * Copyright 2015 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *************************GO-LICENSE-END***********************************/
+ */
 
 package com.thoughtworks.go.util;
 
@@ -479,5 +479,15 @@ public class SystemEnvironmentTest {
         assertThat(systemEnvironment.get(property), is(defaultValue));
         System.setProperty(propertyName, " ");
         assertThat(systemEnvironment.get(property), is(defaultValue));
+    }
+
+    @Test
+    public void shouldSetConfigRepoGCToBeAggressiveByDefault(){
+        assertThat(new SystemEnvironment().get(SystemEnvironment.GO_CONFIG_REPO_GC_AGGRESSIVE), is(true));
+    }
+
+    @Test
+    public void shouldTurnOffAutoGCByDefault(){
+        assertThat(new SystemEnvironment().get(SystemEnvironment.GO_CONFIG_REPO_AUTO_GC), is(false));
     }
 }

--- a/common/test/unit/com/thoughtworks/go/util/SystemEnvironmentTest.java
+++ b/common/test/unit/com/thoughtworks/go/util/SystemEnvironmentTest.java
@@ -487,7 +487,7 @@ public class SystemEnvironmentTest {
     }
 
     @Test
-    public void shouldTurnOffAutoGCByDefault(){
-        assertThat(new SystemEnvironment().get(SystemEnvironment.GO_CONFIG_REPO_AUTO_GC), is(false));
+    public void shouldTurnOffPeriodicGCByDefault(){
+        assertThat(new SystemEnvironment().get(SystemEnvironment.GO_CONFIG_REPO_PERIODIC_GC), is(false));
     }
 }

--- a/config/config-server/pom.xml
+++ b/config/config-server/pom.xml
@@ -45,6 +45,11 @@
             <artifactId>metrics</artifactId>
             <version>${project.parent.version}</version>
         </dependency>
+        <dependency>
+            <groupId>com.thoughtworks.go</groupId>
+            <artifactId>common</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
 
         <dependency>
             <groupId>org.eclipse.jgit</groupId>

--- a/config/config-server/src/com/thoughtworks/go/service/ConfigRepository.java
+++ b/config/config-server/src/com/thoughtworks/go/service/ConfigRepository.java
@@ -1,18 +1,18 @@
-/*************************GO-LICENSE-START*********************************
+/*
  * Copyright 2015 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *************************GO-LICENSE-END***********************************/
+ */
 
 package com.thoughtworks.go.service;
 
@@ -396,6 +396,9 @@ public class ConfigRepository {
     }
 
     public void garbageCollect() throws Exception {
+        if (!systemEnvironment.get(SystemEnvironment.GO_CONFIG_REPO_AUTO_GC)){
+            return;
+        }
         doLocked(new VoidThrowingFn<Exception>() {
             public void run() throws Exception {
                 try {
@@ -406,6 +409,14 @@ public class ConfigRepository {
                     LOGGER.error("Could not perform GC", e);
                     throw e;
                 }
+            }
+        });
+    }
+
+    public long getLooseObjectCount() throws Exception {
+        return doLocked(new ThrowingFn<Long, GitAPIException>() {
+            public Long call() throws GitAPIException {
+                return (Long) git.gc().getStatistics().get("numberOfLooseObjects");
             }
         });
     }

--- a/config/config-server/src/com/thoughtworks/go/service/ConfigRepository.java
+++ b/config/config-server/src/com/thoughtworks/go/service/ConfigRepository.java
@@ -396,7 +396,7 @@ public class ConfigRepository {
     }
 
     public void garbageCollect() throws Exception {
-        if (!systemEnvironment.get(SystemEnvironment.GO_CONFIG_REPO_AUTO_GC)){
+        if (!systemEnvironment.get(SystemEnvironment.GO_CONFIG_REPO_PERIODIC_GC)){
             return;
         }
         doLocked(new VoidThrowingFn<Exception>() {

--- a/config/config-server/src/com/thoughtworks/go/service/ConfigRepositoryGCWarningService.java
+++ b/config/config-server/src/com/thoughtworks/go/service/ConfigRepositoryGCWarningService.java
@@ -43,7 +43,7 @@ public class ConfigRepositoryGCWarningService {
 
     public void checkRepoAndAddWarningIfRequired() {
         try {
-            if (configRepository.getLooseObjectCount() >= systemEnvironment.get(SystemEnvironment.GO_CONFIG_REPO_GC_WARNING_THRESHOLD)) {
+            if (configRepository.getLooseObjectCount() >= systemEnvironment.get(SystemEnvironment.GO_CONFIG_REPO_GC_LOOSE_OBJECT_WARNING_THRESHOLD)) {
                 String message = "Action required: Run 'git gc' on config.git repo";
                 String description = "Number of loose objects in your Configuration repository(config.git) has grown beyond " +
                         "the configured threshold. As the size of config repo increases, the config save operations tend to slow down " +

--- a/config/config-server/src/com/thoughtworks/go/service/ConfigRepositoryGCWarningService.java
+++ b/config/config-server/src/com/thoughtworks/go/service/ConfigRepositoryGCWarningService.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2015 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.service;
+
+import com.thoughtworks.go.serverhealth.HealthStateScope;
+import com.thoughtworks.go.serverhealth.HealthStateType;
+import com.thoughtworks.go.serverhealth.ServerHealthService;
+import com.thoughtworks.go.serverhealth.ServerHealthState;
+import com.thoughtworks.go.util.SystemEnvironment;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ConfigRepositoryGCWarningService {
+    private final ConfigRepository configRepository;
+    private final ServerHealthService serverHealthService;
+    private final SystemEnvironment systemEnvironment;
+    private static final String SCOPE = "GC";
+    private static final Logger LOGGER = LoggerFactory.getLogger(ConfigRepositoryGCWarningService.class.getName());
+
+    @Autowired
+    public ConfigRepositoryGCWarningService(ConfigRepository configRepository, ServerHealthService serverHealthService, SystemEnvironment systemEnvironment) {
+        this.configRepository = configRepository;
+        this.serverHealthService = serverHealthService;
+        this.systemEnvironment = systemEnvironment;
+    }
+
+    public void checkRepoAndAddWarningIfRequired() {
+        try {
+            if (configRepository.getLooseObjectCount() >= systemEnvironment.get(SystemEnvironment.GO_CONFIG_REPO_GC_WARNING_THRESHOLD)) {
+                String message = "Action required: Run 'git gc' on config.git repo";
+                String description = "Number of loose objects in your Configuration repository(config.git) has grown beyond " +
+                        "the configured threshold. As the size of config repo increases, the config save operations tend to slow down " +
+                        "drastically. It is recommended that you run 'git gc' from " +
+                        "'&lt;go server installation directory&gt;/db/config.git/' to address this problem. Go can do this " +
+                        "automatically on a periodic basis if you enable automatic GC. <a target='_blank' href='http://www.go.cd/documentation/user/current/advanced_usage/config_repo.html'>read more...</a>";
+
+                serverHealthService.update(ServerHealthState.warning(message, description, HealthStateType.general(HealthStateScope.forConfigRepo(SCOPE))));
+                LOGGER.warn("{}:{}", message, description);
+            } else {
+                serverHealthService.removeByScope(HealthStateScope.forConfigRepo(SCOPE));
+
+            }
+        } catch (Exception e) {
+            LOGGER.error(e.getMessage(), e);
+        }
+    }
+}

--- a/config/config-server/test/com/thoughtworks/go/service/ConfigRepositoryGCWarningServiceTest.java
+++ b/config/config-server/test/com/thoughtworks/go/service/ConfigRepositoryGCWarningServiceTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2015 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.service;
+
+import com.thoughtworks.go.serverhealth.*;
+import com.thoughtworks.go.util.SystemEnvironment;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class ConfigRepositoryGCWarningServiceTest {
+
+    private ConfigRepository configRepository;
+    private ServerHealthService serverHealthService;
+    private SystemEnvironment systemEnvironment;
+    private ConfigRepositoryGCWarningService service;
+
+    @Before
+    public void setUp() throws Exception {
+        configRepository = mock(ConfigRepository.class);
+        serverHealthService = new ServerHealthService();
+        systemEnvironment = mock(SystemEnvironment.class);
+        service = new ConfigRepositoryGCWarningService(configRepository, serverHealthService, systemEnvironment);
+    }
+
+    @Test
+    public void shouldAddWarningWhenConfigRepoLooseObjectCountGoesBeyondTheConfiguredThreshold() throws Exception {
+        when(systemEnvironment.get(SystemEnvironment.GO_CONFIG_REPO_GC_WARNING_THRESHOLD)).thenReturn(10L);
+        when(configRepository.getLooseObjectCount()).thenReturn(20L);
+
+        service.checkRepoAndAddWarningIfRequired();
+        List<ServerHealthState> healthStates = serverHealthService.filterByScope(HealthStateScope.forConfigRepo("GC"));
+        String message = "Action required: Run 'git gc' on config.git repo";
+        String description = "Number of loose objects in your Configuration repository(config.git) has grown beyond " +
+                "the configured threshold. As the size of config repo increases, the config save operations tend to slow down " +
+                "drastically. It is recommended that you run 'git gc' from " +
+                "'&lt;go server installation directory&gt;/db/config.git/' to address this problem. Go can do this " +
+                "automatically on a periodic basis if you enable automatic GC. <a target='_blank' href='http://www.go.cd/documentation/user/current/advanced_usage/config_repo.html'>read more...</a>";
+
+        assertThat(healthStates.get(0).getDescription(), is(description));
+        assertThat(healthStates.get(0).getLogLevel(), is(HealthStateLevel.WARNING));
+        assertThat(healthStates.get(0).getMessage(), is(message));
+    }
+
+    @Test
+    public void shouldNotAddWarningWhenConfigRepoLooseObjectCountIsBelowTheConfiguredThreshold() throws Exception {
+        when(systemEnvironment.get(SystemEnvironment.GO_CONFIG_REPO_GC_WARNING_THRESHOLD)).thenReturn(10L);
+        when(configRepository.getLooseObjectCount()).thenReturn(1L);
+
+        service.checkRepoAndAddWarningIfRequired();
+        List<ServerHealthState> healthStates = serverHealthService.filterByScope(HealthStateScope.forConfigRepo("GC"));
+        assertThat(healthStates.isEmpty(), is(true));
+    }
+
+    @Test
+    public void shouldRemoteExistingWarningAboutGCIfLooseObjectCountGoesBelowTheSetThreshold() throws Exception {
+        serverHealthService.update(ServerHealthState.warning("message", "description", HealthStateType.general(HealthStateScope.forConfigRepo("GC"))));
+        assertThat(serverHealthService.filterByScope(HealthStateScope.forConfigRepo("GC")).isEmpty(), is(false));
+
+        when(systemEnvironment.get(SystemEnvironment.GO_CONFIG_REPO_GC_WARNING_THRESHOLD)).thenReturn(10L);
+        when(configRepository.getLooseObjectCount()).thenReturn(1L);
+
+        service.checkRepoAndAddWarningIfRequired();
+        assertThat(serverHealthService.filterByScope(HealthStateScope.forConfigRepo("GC")).isEmpty(), is(true));
+    }
+
+}

--- a/config/config-server/test/com/thoughtworks/go/service/ConfigRepositoryGCWarningServiceTest.java
+++ b/config/config-server/test/com/thoughtworks/go/service/ConfigRepositoryGCWarningServiceTest.java
@@ -45,7 +45,7 @@ public class ConfigRepositoryGCWarningServiceTest {
 
     @Test
     public void shouldAddWarningWhenConfigRepoLooseObjectCountGoesBeyondTheConfiguredThreshold() throws Exception {
-        when(systemEnvironment.get(SystemEnvironment.GO_CONFIG_REPO_GC_WARNING_THRESHOLD)).thenReturn(10L);
+        when(systemEnvironment.get(SystemEnvironment.GO_CONFIG_REPO_GC_LOOSE_OBJECT_WARNING_THRESHOLD)).thenReturn(10L);
         when(configRepository.getLooseObjectCount()).thenReturn(20L);
 
         service.checkRepoAndAddWarningIfRequired();
@@ -64,7 +64,7 @@ public class ConfigRepositoryGCWarningServiceTest {
 
     @Test
     public void shouldNotAddWarningWhenConfigRepoLooseObjectCountIsBelowTheConfiguredThreshold() throws Exception {
-        when(systemEnvironment.get(SystemEnvironment.GO_CONFIG_REPO_GC_WARNING_THRESHOLD)).thenReturn(10L);
+        when(systemEnvironment.get(SystemEnvironment.GO_CONFIG_REPO_GC_LOOSE_OBJECT_WARNING_THRESHOLD)).thenReturn(10L);
         when(configRepository.getLooseObjectCount()).thenReturn(1L);
 
         service.checkRepoAndAddWarningIfRequired();
@@ -77,7 +77,7 @@ public class ConfigRepositoryGCWarningServiceTest {
         serverHealthService.update(ServerHealthState.warning("message", "description", HealthStateType.general(HealthStateScope.forConfigRepo("GC"))));
         assertThat(serverHealthService.filterByScope(HealthStateScope.forConfigRepo("GC")).isEmpty(), is(false));
 
-        when(systemEnvironment.get(SystemEnvironment.GO_CONFIG_REPO_GC_WARNING_THRESHOLD)).thenReturn(10L);
+        when(systemEnvironment.get(SystemEnvironment.GO_CONFIG_REPO_GC_LOOSE_OBJECT_WARNING_THRESHOLD)).thenReturn(10L);
         when(configRepository.getLooseObjectCount()).thenReturn(1L);
 
         service.checkRepoAndAddWarningIfRequired();

--- a/config/config-server/test/com/thoughtworks/go/service/ConfigRepositoryTest.java
+++ b/config/config-server/test/com/thoughtworks/go/service/ConfigRepositoryTest.java
@@ -60,7 +60,7 @@ public class ConfigRepositoryTest {
         systemEnvironment = mock(SystemEnvironment.class);
         when(systemEnvironment.getConfigRepoDir()).thenReturn(configRepoDir);
         when(systemEnvironment.get(SystemEnvironment.GO_CONFIG_REPO_GC_AGGRESSIVE)).thenReturn(true);
-        when(systemEnvironment.get(SystemEnvironment.GO_CONFIG_REPO_AUTO_GC)).thenReturn(true);
+        when(systemEnvironment.get(SystemEnvironment.GO_CONFIG_REPO_PERIODIC_GC)).thenReturn(true);
         configRepo = new ConfigRepository(systemEnvironment);
         configRepo.initialize();
     }
@@ -381,8 +381,8 @@ public class ConfigRepositoryTest {
     }
 
     @Test
-    public void shouldNotPerformGCWhenAutoGCIsTurnedOff() throws Exception {
-        when(systemEnvironment.get(SystemEnvironment.GO_CONFIG_REPO_AUTO_GC)).thenReturn(false);
+    public void shouldNotPerformGCWhenPeriodicGCIsTurnedOff() throws Exception {
+        when(systemEnvironment.get(SystemEnvironment.GO_CONFIG_REPO_PERIODIC_GC)).thenReturn(false);
         configRepo.checkin(goConfigRevision("v1", "md5-1"));
         Long numberOfLooseObjectsOld = (Long) configRepo.git().gc().getStatistics().get("sizeOfLooseObjects");
         configRepo.garbageCollect();

--- a/config/config-server/test/com/thoughtworks/go/service/ConfigRepositoryTest.java
+++ b/config/config-server/test/com/thoughtworks/go/service/ConfigRepositoryTest.java
@@ -1,18 +1,18 @@
-/*************************GO-LICENSE-START*********************************
- * Copyright 2014 ThoughtWorks, Inc.
+/*
+ * Copyright 2015 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *************************GO-LICENSE-END***********************************/
+ */
 
 package com.thoughtworks.go.service;
 
@@ -21,27 +21,21 @@ import com.thoughtworks.go.config.exceptions.ConfigFileHasChangedException;
 import com.thoughtworks.go.config.exceptions.ConfigMergeException;
 import com.thoughtworks.go.domain.GoConfigRevision;
 import com.thoughtworks.go.helper.ConfigFileFixture;
-import com.thoughtworks.go.util.FileUtil;
 import com.thoughtworks.go.util.SystemEnvironment;
 import com.thoughtworks.go.util.TimeProvider;
-import org.apache.commons.io.FileUtils;
-import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.ListBranchCommand;
 import org.eclipse.jgit.api.errors.GitAPIException;
 import org.eclipse.jgit.lib.Ref;
-import org.eclipse.jgit.lib.Repository;
-import org.eclipse.jgit.lib.RepositoryBuilder;
 import org.eclipse.jgit.revwalk.RevCommit;
-import org.eclipse.jgit.storage.file.FileRepositoryBuilder;
-import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
 import java.io.IOException;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Properties;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.not;
@@ -50,22 +44,25 @@ import static org.hamcrest.core.IsNull.notNullValue;
 import static org.hamcrest.core.IsNull.nullValue;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class ConfigRepositoryTest {
     private ConfigRepository configRepo;
-    private SystemEnvironment env;
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+    private SystemEnvironment systemEnvironment;
 
     @Before
     public void setUp() throws IOException {
-        env = new SystemEnvironment();
-        FileUtils.deleteQuietly(env.getConfigRepoDir());
-        configRepo = new ConfigRepository(env);
+        File configRepoDir = this.temporaryFolder.newFolder();
+        System.out.println("configRepoDir.getAbsolutePath() = " + configRepoDir.getAbsolutePath());
+        systemEnvironment = mock(SystemEnvironment.class);
+        when(systemEnvironment.getConfigRepoDir()).thenReturn(configRepoDir);
+        when(systemEnvironment.get(SystemEnvironment.GO_CONFIG_REPO_GC_AGGRESSIVE)).thenReturn(true);
+        when(systemEnvironment.get(SystemEnvironment.GO_CONFIG_REPO_AUTO_GC)).thenReturn(true);
+        configRepo = new ConfigRepository(systemEnvironment);
         configRepo.initialize();
-    }
-
-    @After
-    public void tearDown() {
-        FileUtils.deleteQuietly(env.getConfigRepoDir());
     }
 
     @Test
@@ -76,26 +73,26 @@ public class ConfigRepositoryTest {
         assertThat(configRepo.getRevision("md5-v2").getContent(), is("v1 v2"));
     }
 
-	@Test
-	public void shouldGetCommitsCorrectly() throws Exception {
-		configRepo.checkin(new GoConfigRevision("v1", "md5-v1", "user-name", "100.3.9", new TimeProvider()));
-		configRepo.checkin(new GoConfigRevision("v2", "md5-v2", "user-name", "100.3.9", new TimeProvider()));
-		configRepo.checkin(new GoConfigRevision("v3", "md5-v3", "user-name", "100.3.9", new TimeProvider()));
-		configRepo.checkin(new GoConfigRevision("v4", "md5-v4", "user-name", "100.3.9", new TimeProvider()));
+    @Test
+    public void shouldGetCommitsCorrectly() throws Exception {
+        configRepo.checkin(new GoConfigRevision("v1", "md5-v1", "user-name", "100.3.9", new TimeProvider()));
+        configRepo.checkin(new GoConfigRevision("v2", "md5-v2", "user-name", "100.3.9", new TimeProvider()));
+        configRepo.checkin(new GoConfigRevision("v3", "md5-v3", "user-name", "100.3.9", new TimeProvider()));
+        configRepo.checkin(new GoConfigRevision("v4", "md5-v4", "user-name", "100.3.9", new TimeProvider()));
 
-		GoConfigRevisions goConfigRevisions = configRepo.getCommits(3, 0);
+        GoConfigRevisions goConfigRevisions = configRepo.getCommits(3, 0);
 
-		assertThat(goConfigRevisions.size(), is(3));
-		assertThat(goConfigRevisions.get(0).getContent(), is(nullValue()));
-		assertThat(goConfigRevisions.get(0).getMd5(), is("md5-v4"));
-		assertThat(goConfigRevisions.get(1).getMd5(), is("md5-v3"));
-		assertThat(goConfigRevisions.get(2).getMd5(), is("md5-v2"));
+        assertThat(goConfigRevisions.size(), is(3));
+        assertThat(goConfigRevisions.get(0).getContent(), is(nullValue()));
+        assertThat(goConfigRevisions.get(0).getMd5(), is("md5-v4"));
+        assertThat(goConfigRevisions.get(1).getMd5(), is("md5-v3"));
+        assertThat(goConfigRevisions.get(2).getMd5(), is("md5-v2"));
 
-		goConfigRevisions = configRepo.getCommits(3, 3);
+        goConfigRevisions = configRepo.getCommits(3, 3);
 
-		assertThat(goConfigRevisions.size(), is(1));
-		assertThat(goConfigRevisions.get(0).getMd5(), is("md5-v1"));
-	}
+        assertThat(goConfigRevisions.size(), is(1));
+        assertThat(goConfigRevisions.get(0).getMd5(), is("md5-v1"));
+    }
 
     @Test
     public void shouldFailWhenDoesNotFindARev() throws Exception {
@@ -198,30 +195,30 @@ public class ConfigRepositoryTest {
         assertThat(actual, containsString(configChangesLine3));
     }
 
-	@Test
-	public void shouldShowDiffForAnyTwoCommitSHAs() throws Exception {
-		configRepo.checkin(goConfigRevision(ConfigFileFixture.configWithPipeline(ConfigFileFixture.SIMPLE_PIPELINE, 33), "md5-1"));
-		configRepo.checkin(new GoConfigRevision(ConfigFileFixture.configWithPipeline(ConfigFileFixture.SIMPLE_PIPELINE, 60), "md5-2", "user-2", "13.2", new TimeProvider()));
-		configRepo.checkin(new GoConfigRevision(ConfigFileFixture.configWithPipeline(ConfigFileFixture.SIMPLE_PIPELINE, 55), "md5-3", "user-2", "13.2", new TimeProvider()));
+    @Test
+    public void shouldShowDiffForAnyTwoCommitSHAs() throws Exception {
+        configRepo.checkin(goConfigRevision(ConfigFileFixture.configWithPipeline(ConfigFileFixture.SIMPLE_PIPELINE, 33), "md5-1"));
+        configRepo.checkin(new GoConfigRevision(ConfigFileFixture.configWithPipeline(ConfigFileFixture.SIMPLE_PIPELINE, 60), "md5-2", "user-2", "13.2", new TimeProvider()));
+        configRepo.checkin(new GoConfigRevision(ConfigFileFixture.configWithPipeline(ConfigFileFixture.SIMPLE_PIPELINE, 55), "md5-3", "user-2", "13.2", new TimeProvider()));
 
-		GoConfigRevisions commits = configRepo.getCommits(10, 0);
-		String firstCommitSHA = commits.get(2).getCommitSHA();
-		String secondCommitSHA = commits.get(1).getCommitSHA();
-		String thirdCommitSHA = commits.get(0).getCommitSHA();
+        GoConfigRevisions commits = configRepo.getCommits(10, 0);
+        String firstCommitSHA = commits.get(2).getCommitSHA();
+        String secondCommitSHA = commits.get(1).getCommitSHA();
+        String thirdCommitSHA = commits.get(0).getCommitSHA();
 
-		String configChangesLine1 = "-<cruise schemaVersion='33'>";
-		String configChangesLine2 = "+<cruise schemaVersion='60'>";
-		String configChangesLine3 = "+<cruise schemaVersion='55'>";
+        String configChangesLine1 = "-<cruise schemaVersion='33'>";
+        String configChangesLine2 = "+<cruise schemaVersion='60'>";
+        String configChangesLine3 = "+<cruise schemaVersion='55'>";
 
-		String actual = configRepo.configChangesForCommits(secondCommitSHA, firstCommitSHA);
+        String actual = configRepo.configChangesForCommits(secondCommitSHA, firstCommitSHA);
 
-		assertThat(actual, containsString(configChangesLine1));
-		assertThat(actual, containsString(configChangesLine2));
+        assertThat(actual, containsString(configChangesLine1));
+        assertThat(actual, containsString(configChangesLine2));
 
-		actual = configRepo.configChangesForCommits(thirdCommitSHA, firstCommitSHA);
-		assertThat(actual, containsString(configChangesLine1));
-		assertThat(actual, containsString(configChangesLine3));
-	}
+        actual = configRepo.configChangesForCommits(thirdCommitSHA, firstCommitSHA);
+        assertThat(actual, containsString(configChangesLine1));
+        assertThat(actual, containsString(configChangesLine3));
+    }
 
     @Test
     public void shouldRemoveUnwantedDataFromDiff() throws Exception {
@@ -329,7 +326,7 @@ public class ConfigRepositoryTest {
         assertThat(mergedConfig, is("1st\nsecond\nthird\n"));
         List<Ref> branches = getAllBranches();
         assertThat(branches.size(), is(1));
-        assertThat(branches.get(0).getName().endsWith("master"),is(true));
+        assertThat(branches.get(0).getName().endsWith("master"), is(true));
         assertThat(configRepo.getCurrentRevCommit(), is(currentRevCommitOnMaster));
     }
 
@@ -353,7 +350,7 @@ public class ConfigRepositoryTest {
         configRepo.git().checkout().setName(ConfigRepository.BRANCH_AT_REVISION).call();
         assertThat(configRepo.git().getRepository().getBranch(), is(ConfigRepository.BRANCH_AT_REVISION));
 
-        new ConfigRepository(new SystemEnvironment()).initialize();
+        new ConfigRepository(systemEnvironment).initialize();
 
         assertThat(configRepo.git().getRepository().getBranch(), is("master"));
         assertThat(configRepo.git().branchList().call().size(), is(1));
@@ -383,6 +380,24 @@ public class ConfigRepositoryTest {
         assertThat(numberOfLooseObjects, is(0l));
     }
 
+    @Test
+    public void shouldNotPerformGCWhenAutoGCIsTurnedOff() throws Exception {
+        when(systemEnvironment.get(SystemEnvironment.GO_CONFIG_REPO_AUTO_GC)).thenReturn(false);
+        configRepo.checkin(goConfigRevision("v1", "md5-1"));
+        Long numberOfLooseObjectsOld = (Long) configRepo.git().gc().getStatistics().get("sizeOfLooseObjects");
+        configRepo.garbageCollect();
+        Long numberOfLooseObjectsNow = (Long) configRepo.git().gc().getStatistics().get("sizeOfLooseObjects");
+        assertThat(numberOfLooseObjectsNow, is(numberOfLooseObjectsOld));
+    }
+
+    @Test
+    public void shouldGetLooseObjectCount() throws Exception {
+        configRepo.checkin(goConfigRevision("v1", "md5-1"));
+        Long numberOfLooseObjects = (Long) configRepo.git().gc().getStatistics().get("numberOfLooseObjects");
+        assertThat(configRepo.getLooseObjectCount(), is(numberOfLooseObjects));
+    }
+
+
     private GoConfigRevision goConfigRevision(String fileContent, String md5) {
         return new GoConfigRevision(fileContent, md5, "user-1", "13.2", new TimeProvider());
     }
@@ -400,7 +415,7 @@ public class ConfigRepositoryTest {
     Ref getBranch(String branchName) throws GitAPIException {
         List<Ref> branches = getAllBranches();
         for (Ref branch : branches) {
-            if(branch.getName().endsWith(branchName)) {
+            if (branch.getName().endsWith(branchName)) {
                 return branch;
             }
         }

--- a/development-utility/development-server/src/com/thoughtworks/go/server/DevelopmentServer.java
+++ b/development-utility/development-server/src/com/thoughtworks/go/server/DevelopmentServer.java
@@ -56,6 +56,7 @@ public class DevelopmentServer {
 
         systemEnvironment.set(SystemEnvironment.DEFAULT_PLUGINS_ZIP, "/plugins.zip");
         systemEnvironment.setProperty(GoConstants.I18N_CACHE_LIFE, "0"); //0 means reload when stale
+        setupAutoGC(systemEnvironment);
         File pluginsDist = new File("../tw-go-plugins/dist/");
         if (!pluginsDist.exists()) {
             pluginsDist.mkdirs();
@@ -77,6 +78,14 @@ public class DevelopmentServer {
             System.err.println("Failed to start Go server. Exception:");
             e.printStackTrace();
         }
+    }
+
+    private static void setupAutoGC(SystemEnvironment systemEnvironment) {
+        systemEnvironment.set(SystemEnvironment.GO_CONFIG_REPO_GC_WARNING_THRESHOLD, 1L);
+        systemEnvironment.set(SystemEnvironment.GO_CONFIG_REPO_AUTO_GC, true);
+        systemEnvironment.set(SystemEnvironment.GO_CONFIG_REPO_GC_AGGRESSIVE, true);
+        systemEnvironment.setProperty("go.config.repo.gc.cron", "0 0/1 * 1/1 * ?");
+        systemEnvironment.setProperty("go.config.repo.gc.check.interval", "5000");
     }
 
     private static void copyDbFiles() throws IOException {

--- a/development-utility/development-server/src/com/thoughtworks/go/server/DevelopmentServer.java
+++ b/development-utility/development-server/src/com/thoughtworks/go/server/DevelopmentServer.java
@@ -17,10 +17,8 @@
 package com.thoughtworks.go.server;
 
 import com.thoughtworks.go.util.GoConstants;
-import com.thoughtworks.go.util.OperatingSystem;
 import com.thoughtworks.go.util.SystemEnvironment;
 import com.thoughtworks.go.util.ZipUtil;
-import com.thoughtworks.go.util.command.ProcessRunner;
 import org.apache.commons.io.FileUtils;
 
 import java.io.File;
@@ -56,7 +54,7 @@ public class DevelopmentServer {
 
         systemEnvironment.set(SystemEnvironment.DEFAULT_PLUGINS_ZIP, "/plugins.zip");
         systemEnvironment.setProperty(GoConstants.I18N_CACHE_LIFE, "0"); //0 means reload when stale
-        setupAutoGC(systemEnvironment);
+        setupPeriodicGC(systemEnvironment);
         File pluginsDist = new File("../tw-go-plugins/dist/");
         if (!pluginsDist.exists()) {
             pluginsDist.mkdirs();
@@ -80,9 +78,9 @@ public class DevelopmentServer {
         }
     }
 
-    private static void setupAutoGC(SystemEnvironment systemEnvironment) {
-        systemEnvironment.set(SystemEnvironment.GO_CONFIG_REPO_GC_WARNING_THRESHOLD, 1L);
-        systemEnvironment.set(SystemEnvironment.GO_CONFIG_REPO_AUTO_GC, true);
+    private static void setupPeriodicGC(SystemEnvironment systemEnvironment) {
+        systemEnvironment.set(SystemEnvironment.GO_CONFIG_REPO_GC_LOOSE_OBJECT_WARNING_THRESHOLD, 1L);
+        systemEnvironment.set(SystemEnvironment.GO_CONFIG_REPO_PERIODIC_GC, true);
         systemEnvironment.set(SystemEnvironment.GO_CONFIG_REPO_GC_AGGRESSIVE, true);
         systemEnvironment.setProperty("go.config.repo.gc.cron", "0 0/1 * 1/1 * ?");
         systemEnvironment.setProperty("go.config.repo.gc.check.interval", "5000");

--- a/installers/server/release/server.sh
+++ b/installers/server/release/server.sh
@@ -112,21 +112,53 @@ fi
 if [ ! -z $SERVER_LISTEN_HOST ]; then
     GO_SERVER_SYSTEM_PROPERTIES="$GO_SERVER_SYSTEM_PROPERTIES -Dcruise.listen.host=$SERVER_LISTEN_HOST"
 fi
-SERVER_STARTUP_ARGS+=("-server $YOURKIT")
-SERVER_STARTUP_ARGS+=("-Xms$SERVER_MEM -Xmx$SERVER_MAX_MEM -XX:PermSize=$SERVER_MIN_PERM_GEN -XX:MaxPermSize=$SERVER_MAX_PERM_GEN")
-SERVER_STARTUP_ARGS+=("$JVM_DEBUG $GC_LOG $GO_SERVER_SYSTEM_PROPERTIES")
-SERVER_STARTUP_ARGS+=("-Duser.language=en -Djruby.rack.request.size.threshold.bytes=30000000")
-SERVER_STARTUP_ARGS+=("-Duser.country=US -Dcruise.config.dir=$GO_CONFIG_DIR -Dcruise.config.file=$GO_CONFIG_DIR/cruise-config.xml")
-SERVER_STARTUP_ARGS+=("-Dcruise.server.port=$GO_SERVER_PORT -Dcruise.server.ssl.port=$GO_SERVER_SSL_PORT")
+SERVER_STARTUP_ARGS+=("-server")
+if [ "$YOURKIT" != "" ]; then
+   GO_SERVER_SYSTEM_PROPERTIES="$GO_SERVER_SYSTEM_PROPERTIES $YOURKIT"
+fi
+SERVER_STARTUP_ARGS+=("-Xms$SERVER_MEM")
+SERVER_STARTUP_ARGS+=("-Xmx$SERVER_MAX_MEM")
+SERVER_STARTUP_ARGS+=("-XX:PermSize=$SERVER_MIN_PERM_GEN")
+SERVER_STARTUP_ARGS+=("-XX:MaxPermSize=$SERVER_MAX_PERM_GEN")
+if [ "$JVM_DEBUG" != "" ]; then
+   GO_SERVER_SYSTEM_PROPERTIES="$GO_SERVER_SYSTEM_PROPERTIES $JVM_DEBUG"
+fi
+if [ "$GC_LOG" != "" ]; then
+   GO_SERVER_SYSTEM_PROPERTIES="$GO_SERVER_SYSTEM_PROPERTIES $GC_LOG"
+fi
+SERVER_STARTUP_ARGS+=("-Duser.language=en")
+SERVER_STARTUP_ARGS+=("-Djruby.rack.request.size.threshold.bytes=30000000")
+SERVER_STARTUP_ARGS+=("-Duser.country=US")
+SERVER_STARTUP_ARGS+=("-Dcruise.config.dir=$GO_CONFIG_DIR")
+SERVER_STARTUP_ARGS+=("-Dcruise.config.file=$GO_CONFIG_DIR/cruise-config.xml")
+SERVER_STARTUP_ARGS+=("-Dcruise.server.port=$GO_SERVER_PORT")
+SERVER_STARTUP_ARGS+=("-Dcruise.server.ssl.port=$GO_SERVER_SSL_PORT")
+
+if [ "$GO_CONFIG_REPO_GC_CRON" != "" ]; then
+    SERVER_STARTUP_ARGS+=("-Dgo.config.repo.gc.cron=$GO_CONFIG_REPO_GC_CRON")
+fi
+
 if [ "$TMPDIR" != "" ]; then
     SERVER_STARTUP_ARGS+=("-Djava.io.tmpdir=$TMPDIR")
 fi
+
 if [ "$USE_URANDOM" != "false" ] && [ -e "/dev/urandom" ]; then
     SERVER_STARTUP_ARGS+=("-Djava.security.egd=file:/dev/./urandom")
 fi
-CMD="$JAVA_HOME/bin/java ${SERVER_STARTUP_ARGS[@]} -jar $SERVER_DIR/go.jar"
 
-echo "Starting Go Server with command: $CMD" >> $STDOUT_LOG_FILE
+if [ "$GO_SERVER_SYSTEM_PROPERTIES" != "" ]; then
+    IFS=' ' read -r -a properties <<< "$GO_SERVER_SYSTEM_PROPERTIES"
+    for property in "${properties[@]}"
+    do
+        SERVER_STARTUP_ARGS+=("$property")
+    done
+fi
+
+CMD+=("$JAVA_HOME/bin/java")
+CMD+=("${SERVER_STARTUP_ARGS[@]}")
+CMD+=("-jar")
+CMD+=("$SERVER_DIR/go.jar")
+echo "Starting Go Server with command: ${CMD[@]}" >> $STDOUT_LOG_FILE
 echo "Starting Go Server in directory: $GO_WORK_DIR" >> $STDOUT_LOG_FILE
 cd "$SERVER_WORK_DIR"
 
@@ -134,10 +166,10 @@ if [ "$JAVA_HOME" == "" ]; then
     echo "Please set JAVA_HOME to proceed."
     exit 1
 fi
-
 if [ "$DAEMON" == "Y" ]; then
-    exec nohup $CMD >> $STDOUT_LOG_FILE 2>&1 &
+    exec nohup "${CMD[@]}" >> $STDOUT_LOG_FILE 2>&1 &
     echo $! >$PID_FILE
 else
-    exec $CMD
+    exec "${CMD[@]}"
 fi
+

--- a/server/properties/src/cruise.properties
+++ b/server/properties/src/cruise.properties
@@ -26,7 +26,8 @@ cruise.cancel.hung.jobs.interval=30000
 cruise.reschedule.hung.builds.interval=300000
 cruise.build.assignment.service.interval=5000
 cruise.config.refresh.interval=5000
-go.config.repo.gc.cron=0 0 1 * * ?
+go.config.repo.gc.cron=0 0 7 ? * SUN
+go.config.repo.gc.check.interval=28800000
 cruise.disk.space.check.interval=5000
 cruise.agent.service.refresh.interval=5000
 

--- a/server/webapp/WEB-INF/spring-cruise-remoting-servlet.xml
+++ b/server/webapp/WEB-INF/spring-cruise-remoting-servlet.xml
@@ -31,6 +31,7 @@
 
     <task:scheduled-tasks>
         <task:scheduled ref="configRepository" method="garbageCollect" cron="${go.config.repo.gc.cron}"/>
+        <task:scheduled ref="configRepositoryGCWarningService" method="checkRepoAndAddWarningIfRequired" fixed-delay="${go.config.repo.gc.check.interval}"/>
     </task:scheduled-tasks>
 
     <bean name="/remoteBuildRepository" class="org.springframework.remoting.httpinvoker.HttpInvokerServiceExporter"


### PR DESCRIPTION
Auto GC is turned off by default. Can be turned on using `-Dgo.config.repo.gc.auto=Y`

A warning is displayed when loose-object count exceeds the threshold (defaults to 10000), can be configured using `-Dgo.config.repo.gc.warning.threshold=10`. This check is performed every 8 hours, can be overridden using `-Dgo.config.repo.gc.check.interval=5000`

Warning message provides documenation link to enable auto GC

Auto GC is aggressive by default, can be turned off using `-Dgo.config.repo.gc.aggressive=N`. This runs on a weekly basis instead of daily.

GC cron expression can be overridden for linux based installation by adding an entry such as below in /etc/default/go-server `GO_CONFIG_REPO_GC_CRON="0 0/1 * 1/1 * ?"`