### PR TITLE
Check SCM connection throws incorrect error on pipeline creation wizard  (#1660)

### DIFF
--- a/server/webapp/WEB-INF/rails.new/app/controllers/api_v1/material_test_controller.rb
+++ b/server/webapp/WEB-INF/rails.new/app/controllers/api_v1/material_test_controller.rb
@@ -28,7 +28,7 @@ module ApiV1
     def test
       material_config = ApiV1::Config::Materials::MaterialRepresenter.new(ApiV1::Config::Materials::MaterialRepresenter.get_material_type(params[:type]).new).from_hash(params)
 
-      perform_param_expansion(material_config) if params[:pipeline_name]
+      perform_param_expansion(material_config) unless params[:pipeline_name].blank?
 
       material = MaterialConfigConverter.new.toMaterial(material_config)
       if material.respond_to?(:checkConnection)

--- a/server/webapp/WEB-INF/rails.new/spec/controllers/api_v1/material_test_controller_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/controllers/api_v1/material_test_controller_spec.rb
@@ -96,6 +96,23 @@ describe ApiV1::MaterialTestController do
 
         expect(response).to have_api_message_response(200, 'Connection OK.')
       end
+
+      it 'does not perform parameter expansion if pipeline_name param is blank' do
+        com.thoughtworks.go.config.materials.git.GitMaterial.
+          any_instance.
+          should_receive(:checkConnection).with(ApiV1::MaterialTestController.check_connection_execution_context).
+          and_return(com.thoughtworks.go.domain.materials.ValidationBean.valid)
+
+        post_with_api_header :test, {
+          type:          'git',
+          pipeline_name: '',
+          attributes:    {
+            url: 'https://example.com/git/FooBarWidgets.git'
+          }
+        }
+
+        expect(response).to have_api_message_response(200, 'Connection OK.')
+      end
     end
   end
 end


### PR DESCRIPTION
If the pipeline_name parameter submitted is blank, then don't attempt to lookup that pipeline and throw a 404.