### PR TITLE
Use an instance of the class instead of the class itself (#1654)

### DIFF
--- a/server/webapp/WEB-INF/rails.new/app/controllers/api_v1/material_test_controller.rb
+++ b/server/webapp/WEB-INF/rails.new/app/controllers/api_v1/material_test_controller.rb
@@ -23,7 +23,7 @@ module ApiV1
     before_action :check_user_and_401
 
     cattr_accessor :check_connection_execution_context
-    self.check_connection_execution_context = CheckConnectionSubprocessExecutionContext
+    self.check_connection_execution_context = CheckConnectionSubprocessExecutionContext.new
 
     def test
       material_config = ApiV1::Config::Materials::MaterialRepresenter.new(ApiV1::Config::Materials::MaterialRepresenter.get_material_type(params[:type]).new).from_hash(params)


### PR DESCRIPTION
Not quite sure how JRuby was coercing a type to an instance of the type.