### PR TITLE
Fix for Users API where login_name has special characters #1650

### DIFF
--- a/server/test/integration/com/thoughtworks/go/server/web/UrlRewriterIntegrationTest.java
+++ b/server/test/integration/com/thoughtworks/go/server/web/UrlRewriterIntegrationTest.java
@@ -261,6 +261,9 @@ public class UrlRewriterIntegrationTest {
 
     @DataPoint public static ResponseAssertion RAILS_INTERNAL_API = new ResponseAssertion("http://127.1.1.1:" + HTTP +"/go/api/config/internal/pluggable_task/indix.s3fetch", "http://127.1.1.1:" + HTTP + "/go/rails/api/config/internal/pluggable_task/indix.s3fetch", METHOD.GET);
 
+    @DataPoint public static ResponseAssertion USERS_INDEX_API = new ResponseAssertion("http://127.1.1.1:" + HTTP +"/go/api/users", "http://127.1.1.1:" + HTTP + "/go/rails/api/users", METHOD.GET);
+    @DataPoint public static ResponseAssertion USERS_SHOW_API = new ResponseAssertion("http://127.1.1.1:" + HTTP +"/go/api/users/some.one", "http://127.1.1.1:" + HTTP + "/go/rails/api/users/some.one", METHOD.GET);
+
     public static String enc(String str) {
         try {
             return URLEncoder.encode(str, "UTF-8");

--- a/server/webapp/WEB-INF/rails.new/config/routes.rb
+++ b/server/webapp/WEB-INF/rails.new/config/routes.rb
@@ -220,7 +220,7 @@ Go::Application.routes.draw do
     api_version(:module => 'ApiV1', header: {name: 'Accept', value: 'application/vnd.go.cd.v1+json'}) do
       resources :backups, only: [:create]
 
-      resources :users, param: :login_name, only: [:create, :index, :show, :destroy], constraints: { login_name: USER_NAME_FORMAT } do
+      resources :users, param: :login_name, only: [:create, :index, :show, :destroy], :format => false, constraints: { login_name: /(.*?)/ } do
         patch :update, on: :member
       end
 

--- a/server/webapp/WEB-INF/urlrewrite.xml
+++ b/server/webapp/WEB-INF/urlrewrite.xml
@@ -134,6 +134,21 @@
         <set name="rails_bound">true</set>
     </rule>
 
+    <!-- Rule for Rails Users API should be above the generic rule 'Rails API' -->
+    <rule>
+        <name>Rails Users Index and Delete API</name>
+        <from>^/api/users$</from>
+        <to last="true">/rails/api/users</to>
+        <set name="rails_bound">true</set>
+    </rule>
+
+    <rule>
+        <name>Rails Users Show and Delete API</name>
+        <from>^/api/users/(.*)$</from>
+        <to last="true">/rails/api/users/${escape:$1}</to>
+        <set name="rails_bound">true</set>
+    </rule>
+
     <rule>
         <name>Rails API</name>
         <from>^/(api/(?!admin/config).*)$</from>


### PR DESCRIPTION
Verified the following scenarios 
?foo?bar?
.foo.bar.
/foo/baz/
*foo*baz*
foo!foo
?foo&bar
+foo@bar&q+
;foo;bar;
"foo"bar"
foo#bar#
>foo<bar<
@foo<bar<
foo?bar<
(foo~*bar+&)
foo+bar