### PR TITLE
Fix for oauth clients page

### DIFF
--- a/server/webapp/WEB-INF/rails.new/app/controllers/application_controller.rb
+++ b/server/webapp/WEB-INF/rails.new/app/controllers/application_controller.rb
@@ -31,6 +31,7 @@ class ApplicationController < ActionController::Base
 
   LOCAL_ONLY_ACTIONS = Hash.new([]).merge("api/server" => ["info"])
 
+  helper Oauth2Provider::ApplicationHelper
 
   if Rails.env.development?
     before_filter do |controller|


### PR DESCRIPTION
Explicitly using oauth engine helpers as it is in isolated_namespace,
this is required to use main_app route helpers in the oauth pages.