### PR TITLE
Update UrlUtil.java

### DIFF
--- a/common/src/com/thoughtworks/go/util/UrlUtil.java
+++ b/common/src/com/thoughtworks/go/util/UrlUtil.java
@@ -119,7 +119,9 @@ public class UrlUtil {
             String[] split = query.split(QUERY_SEPERATOR);
             for (String queryFrag : split) {
                 String[] queryFragmentSplit = queryFrag.split(QUERY_KEY_VAL_SEPERATOR);
-                parsed.add(new QueryTuple(queryFragmentSplit[0], decode(queryFragmentSplit[1])));
+                if (queryFragmentSplit.length == 2) {
+                    parsed.add(new QueryTuple(queryFragmentSplit[0], decode(queryFragmentSplit[1])));
+                }
             }
             return parsed;
         }


### PR DESCRIPTION
Check length of queryFragmentSplit before access it.

2015-12-10 16:08:41,264 FATAL [qtp2121744517-17] Rails:? -
Java::JavaLang::ArrayIndexOutOfBoundsException (1):
  com.thoughtworks.go.util.UrlUtil$QueryTuple.parse(com/thoughtworks/go/util/UrlUtil.java:122)
  com.thoughtworks.go.util.UrlUtil.urlWithQuery(com/thoughtworks/go/util/UrlUtil.java:57)
  java.lang.reflect.Method.invoke(java/lang/reflect/Method.java:497)
  