### PR TITLE
Revert "The entirety of JUnit XML files is skipped if they are minified (#1132)"

### DIFF
--- a/common/test-resources/unit/data/MinifiedJunitReport.xml
+++ b/common/test-resources/unit/data/MinifiedJunitReport.xml
@@ -1,1 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?><testsuite errors="0" failures="0" name="HelloWorldTestSuite" skips="0" tests="2" time="0.004"><testcase classname="HelloWorldTest" name="test_hello" time="0.0033"/><testcase classname="HelloWorldTest" name="test_world" time="0.0002"/></testsuite>

--- a/common/test/unit/com/thoughtworks/go/domain/UnitTestReportGeneratorTest.java
+++ b/common/test/unit/com/thoughtworks/go/domain/UnitTestReportGeneratorTest.java
@@ -261,24 +261,6 @@ public class UnitTestReportGeneratorTest {
         restoreConsoleOutput();
     }
 
-    @Test
-    public void shouldGenerateReportForMinifiedJUnitReport() throws IOException, ArtifactPublishingException {
-        context.checking(new Expectations() {
-            {
-                one(publisher).upload(with(any(File.class)), with(any(String.class)));
-                one(publisher).setProperty(new Property(TOTAL_TEST_COUNT, "2"));
-                one(publisher).setProperty(new Property(FAILED_TEST_COUNT, "0"));
-                one(publisher).setProperty(new Property(IGNORED_TEST_COUNT, "0"));
-                one(publisher).setProperty(new Property(TEST_TIME, "0.004"));
-            }
-        });
-
-
-        copyAndClose(source("MinifiedJunitReport.xml"), target("MinifiedJunitReport.xml"));
-
-        generator.generate(testFolder.listFiles());
-    }
-
     private OutputStream target(String targetFile) throws FileNotFoundException {
         return new FileOutputStream(testFolder.getAbsolutePath() + FileUtil.fileseparator() + targetFile);
     }

--- a/config/config-api/src/com/thoughtworks/go/domain/UnitTestReportGenerator.java
+++ b/config/config-api/src/com/thoughtworks/go/domain/UnitTestReportGenerator.java
@@ -16,10 +16,12 @@
 
 package com.thoughtworks.go.domain;
 
+import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
+import java.io.FileReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -35,13 +37,10 @@ import javax.xml.xpath.XPathFactory;
 
 import com.thoughtworks.go.util.FileUtil;
 import com.thoughtworks.go.util.TestFileUtil;
-import com.thoughtworks.go.util.XmlUtils;
 import com.thoughtworks.go.util.XpathUtils;
 import com.thoughtworks.go.work.GoPublisher;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
-import org.jdom.Document;
-import org.jdom.JDOMException;
 
 public class UnitTestReportGenerator implements TestReportGenerator {
     private final File folderToUpload;
@@ -152,12 +151,18 @@ public class UnitTestReportGenerator implements TestReportGenerator {
     }
 
     private void pumpFileContent(File file, PrintStream out) throws IOException {
+        BufferedReader bufferedReader = null;
         try {
-            String content = FileUtil.readToEnd(file).trim().replaceFirst("^\\W+<", "<");
-            final Document document = XmlUtils.buildXmlDocument(content);
-            XmlUtils.writeXml(document.getRootElement(), out);
-        } catch (JDOMException e) {
-            publisher.consumeLine(MessageFormat.format("The file {0} could not be parsed as XML document: {1}", file.getName(), e.getMessage()));
+            bufferedReader = new BufferedReader(new FileReader(file));
+            String line = bufferedReader.readLine();
+            if (!line.contains("<?xml")) { // skip prolog
+                out.println(line);
+            }
+            while ((line = bufferedReader.readLine()) != null) {
+                out.println(line);
+            }
+        } finally {
+            IOUtils.closeQuietly(bufferedReader);
         }
     }
 


### PR DESCRIPTION
Reverts gocd/gocd#1685— seems like a failure on windows https://build.go.cd/go/tab/build/detail/build-windows/611/build-non-server-windows/2/common-split-runInstance-4

/cc @xli 