### PR TITLE
Gracefully handle cases where ambiguous environment variable definition is flagged as an error (#1630, #1417)

### DIFF
--- a/config/config-api/test/com/thoughtworks/go/config/EnvironmentVariableConfigTest.java
+++ b/config/config-api/test/com/thoughtworks/go/config/EnvironmentVariableConfigTest.java
@@ -16,11 +16,6 @@
 
 package com.thoughtworks.go.config;
 
-import java.lang.reflect.Method;
-import java.util.HashMap;
-import java.util.Map;
-import javax.annotation.PostConstruct;
-
 import com.thoughtworks.go.domain.ConfigErrors;
 import com.thoughtworks.go.security.GoCipher;
 import com.thoughtworks.go.util.command.EnvironmentVariableContext;
@@ -30,15 +25,19 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import javax.annotation.PostConstruct;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNot.not;
 import static org.hamcrest.core.IsNull.nullValue;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.anyString;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 public class EnvironmentVariableConfigTest {
 
@@ -299,7 +298,7 @@ public class EnvironmentVariableConfigTest {
         config2.addError("name", "errrr");
         assertThat(config1.equals(config2), is(true));
     }
-    
+
     private HashMap getAttributeMap(String value, final String secure, String isChanged) {
         HashMap attrs;
         attrs = new HashMap();
@@ -308,5 +307,20 @@ public class EnvironmentVariableConfigTest {
         attrs.put(EnvironmentVariableConfig.SECURE, secure);
         attrs.put(EnvironmentVariableConfig.ISCHANGED, isChanged);
         return attrs;
+    }
+
+    @Test
+    public void shouldDeserializeWithErrorFlagIfAnEncryptedVarialeHasBothClearTextAndCipherText() throws Exception {
+        EnvironmentVariableConfig variable = new EnvironmentVariableConfig();
+        variable.deserialize("PASSWORD", "clearText", true, "c!ph3rt3xt");
+        assertThat(variable.errors().getAllOn("value"), is(Arrays.asList("You may only specify `value` or `encrypted_value`, not both!")));
+        assertThat(variable.errors().getAllOn("encryptedValue"), is(Arrays.asList("You may only specify `value` or `encrypted_value`, not both!")));
+    }
+
+    @Test
+    public void shouldDeserializeWithNoErrorFlagIfAnEncryptedVarialeHasEitherClearTextOrCipherText() throws Exception {
+        EnvironmentVariableConfig variable = new EnvironmentVariableConfig();
+        variable.deserialize("PASSWORD", "clearText", true, null);
+        assertTrue(variable.errors().isEmpty());
     }
 }

--- a/server/webapp/WEB-INF/rails.new/app/presenters/api_v1/config/environment_variable_representer.rb
+++ b/server/webapp/WEB-INF/rails.new/app/presenters/api_v1/config/environment_variable_representer.rb
@@ -19,13 +19,11 @@ module ApiV1
     class EnvironmentVariableRepresenter < ApiV1::BaseRepresenter
       alias_method :environment_variable, :represented
 
-      property :isSecure, as: :secure
-      property :name
-      property :value, skip_nil: true, exec_context: :decorator
-      property :encrypted_value, skip_nil: true, exec_context: :decorator
-      property :errors, decorator: ApiV1::Config::ErrorRepresenter, skip_parse: true, skip_render: lambda { |object, options| object.empty? }
-
-      delegate :value=, :encrypted_value=, to: :environment_variable
+      property :isSecure, as: :secure, writable: false
+      property :name, writable: false
+      property :value, skip_nil: true, writable: false, exec_context: :decorator
+      property :encrypted_value, skip_nil: true, writable: false, exec_context: :decorator
+      property :errors, exec_context: :decorator, decorator: ApiV1::Config::ErrorRepresenter, skip_parse: true, skip_render: lambda { |object, options| object.empty? }
 
       def value
         environment_variable.getValueForDisplay() if environment_variable.isPlain
@@ -33,6 +31,31 @@ module ApiV1
 
       def encrypted_value
         environment_variable.getValueForDisplay() if environment_variable.isSecure
+      end
+
+      def from_hash(data, options={})
+        data = data.with_indifferent_access
+        environment_variable.deserialize(data[:name], data[:value], data[:secure].to_bool, data[:encrypted_value])
+        environment_variable
+      end
+
+      private
+
+      def errors
+        mapped_errors = {}
+        environment_variable.errors.each do |key, value|
+          mapped_errors[matching_error_key(key)] = value
+        end
+        mapped_errors
+      end
+
+      def error_keys
+        { 'encryptedValue' => 'encrypted_value' }
+      end
+
+      def matching_error_key key
+        return error_keys[key] if error_keys[key]
+        key
       end
 
     end

--- a/server/webapp/WEB-INF/rails.new/lib/extensions/to_bool_ext.rb
+++ b/server/webapp/WEB-INF/rails.new/lib/extensions/to_bool_ext.rb
@@ -1,0 +1,21 @@
+class Object
+  def to_bool
+    if self.blank? || self =~ /^false$/i
+      return false
+    end
+
+    !!(self =~ /^true$/i)
+  end
+end
+
+class TrueClass
+  def to_bool
+    self
+  end
+end
+
+class FalseClass
+  def to_bool
+    self
+  end
+end


### PR DESCRIPTION
When users submit both `value` and `encrypted_value` for a `secure` variable,
the input will be considered as ambiguous and flagged as such

```json
{
  "secure": true,
  "name": "PASSWORD",
  "value": "clearText"
  "encrypted_value", "c!ph3rt3xt"
}
```