### PR TITLE
The entirety of JUnit XML files is skipped if they are minified (#1132)

### DIFF
--- a/common/test-resources/unit/data/MinifiedJunitReport.xml
+++ b/common/test-resources/unit/data/MinifiedJunitReport.xml
@@ -1,0 +1,1 @@
+<?xml version="1.0" encoding="utf-8"?><testsuite errors="0" failures="0" name="HelloWorldTestSuite" skips="0" tests="2" time="0.004"><testcase classname="HelloWorldTest" name="test_hello" time="0.0033"/><testcase classname="HelloWorldTest" name="test_world" time="0.0002"/></testsuite>

--- a/common/test/unit/com/thoughtworks/go/domain/UnitTestReportGeneratorTest.java
+++ b/common/test/unit/com/thoughtworks/go/domain/UnitTestReportGeneratorTest.java
@@ -261,6 +261,24 @@ public class UnitTestReportGeneratorTest {
         restoreConsoleOutput();
     }
 
+    @Test
+    public void shouldGenerateReportForMinifiedJUnitReport() throws IOException, ArtifactPublishingException {
+        context.checking(new Expectations() {
+            {
+                one(publisher).upload(with(any(File.class)), with(any(String.class)));
+                one(publisher).setProperty(new Property(TOTAL_TEST_COUNT, "2"));
+                one(publisher).setProperty(new Property(FAILED_TEST_COUNT, "0"));
+                one(publisher).setProperty(new Property(IGNORED_TEST_COUNT, "0"));
+                one(publisher).setProperty(new Property(TEST_TIME, "0.004"));
+            }
+        });
+
+
+        copyAndClose(source("MinifiedJunitReport.xml"), target("MinifiedJunitReport.xml"));
+
+        generator.generate(testFolder.listFiles());
+    }
+
     private OutputStream target(String targetFile) throws FileNotFoundException {
         return new FileOutputStream(testFolder.getAbsolutePath() + FileUtil.fileseparator() + targetFile);
     }


### PR DESCRIPTION
* Changed to use BOMInputStream from commons-io to ignore BOM in test report xml file.
* Use Jdom to parse out unit test report xml file instead of using regex expression, when merging all test files
* Output message when a test report xml file can't be parsed as XML document

(This reverts commit 84f1458363eccb3efc205da90f3bf58b69e24a9b.)