### PR TITLE
close input stream openned in FileUtil#readToEnd(File file)

### DIFF
--- a/base/src/com/thoughtworks/go/util/FileUtil.java
+++ b/base/src/com/thoughtworks/go/util/FileUtil.java
@@ -78,7 +78,11 @@ public class FileUtil {
 
     public static String readToEnd(File file) throws IOException {
         FileInputStream input = new FileInputStream(file);
-        return readToEnd(input);
+        try {
+            return readToEnd(input);
+        } finally {
+            IOUtils.closeQuietly(input);
+        }
     }
 
     public static String readToEnd(InputStream input) throws IOException {


### PR DESCRIPTION
Part of #1697, I forgot to close an input stream.
FileUtil#readToEnd(File file) method had same problem, because the way I used FileUtil#readToEnd(InputStream input) was copied from FileUtil#readToEnd(File file) method.
