### PR TITLE
Turn off the single page app by default.

### DIFF
--- a/server/resources/available.toggles
+++ b/server/resources/available.toggles
@@ -10,6 +10,11 @@
          "key": "plugin_upload_feature_toggle_key",
          "description": "Enables uploading a plugin, directly from Go's plugins tab. Default: off.",
          "value": false
+      },
+      {
+         "key": "pipeline_config_single_page_app_key",
+         "description": "Enables the pipeline config single page application. Default: off.",
+         "value": false
       }
    ]
 }

--- a/server/src/com/thoughtworks/go/server/service/support/toggle/Toggles.java
+++ b/server/src/com/thoughtworks/go/server/service/support/toggle/Toggles.java
@@ -18,6 +18,7 @@ package com.thoughtworks.go.server.service.support.toggle;
 public class Toggles {
     public static String PIPELINE_COMMENT_FEATURE_TOGGLE_KEY = "pipeline_comment_feature_toggle_key";
     public static String PLUGIN_UPLOAD_FEATURE_TOGGLE_KEY = "plugin_upload_feature_toggle_key";
+    public static String PIPELINE_CONFIG_SINGLE_PAGE_APP = "pipeline_config_single_page_app_key";
 
     private static FeatureToggleService service;
 

--- a/server/webapp/WEB-INF/rails.new/app/controllers/admin/pipeline_configs_controller.rb
+++ b/server/webapp/WEB-INF/rails.new/app/controllers/admin/pipeline_configs_controller.rb
@@ -19,6 +19,7 @@ module Admin
     include ApiV1::AuthenticationHelper
 
     layout 'pipeline_configs'
+    before_action :check_feature_toggle
     before_action :check_admin_user_and_401
     before_action :load_pipeline
 
@@ -57,6 +58,12 @@ module Admin
     end
 
     helper_method :plugin_templates
+
+    def check_feature_toggle
+      unless Toggles.isToggleOn(Toggles.PIPELINE_CONFIG_SINGLE_PAGE_APP)
+        render :text => 'This feature is not enabled!'
+      end
+    end
 
   end
 


### PR DESCRIPTION
Allow the feature toggle `pipeline_config_single_page_app_key` to turn it on if needed.