### PR TITLE
Gracefully handle cases where ambiguous scm password definition is flagged as an error (#1630, #1417)

### DIFF
--- a/config/config-api/src/com/thoughtworks/go/config/materials/perforce/P4MaterialConfig.java
+++ b/config/config-api/src/com/thoughtworks/go/config/materials/perforce/P4MaterialConfig.java
@@ -32,6 +32,7 @@ import java.util.Map;
 
 import static com.thoughtworks.go.util.ExceptionUtils.bomb;
 import static com.thoughtworks.go.util.ExceptionUtils.bombIfNull;
+import static org.apache.commons.lang.StringUtils.isNotEmpty;
 
 @ConfigTag(value = "p4", label = "Perforce")
 public class P4MaterialConfig extends ScmMaterialConfig implements ParamsAttributeAware, PasswordEncrypter, PasswordAwareMaterial {
@@ -180,6 +181,11 @@ public class P4MaterialConfig extends ScmMaterialConfig implements ParamsAttribu
         resetPassword(password);
     }
 
+    public void setCleartextPassword(String password) {
+        this.password = password;
+    }
+
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -227,6 +233,10 @@ public class P4MaterialConfig extends ScmMaterialConfig implements ParamsAttribu
         }
         if (StringUtil.isBlank(getServerAndPort())) {
             errors.add(SERVER_AND_PORT, "P4 port cannot be empty.");
+        }
+        if (isNotEmpty(this.password) && isNotEmpty(this.encryptedPassword)){
+            addError("password", "You may only specify `password` or `encrypted_password`, not both!");
+            addError("encryptedPassword", "You may only specify `password` or `encrypted_password`, not both!");
         }
     }
 

--- a/config/config-api/src/com/thoughtworks/go/config/materials/svn/SvnMaterialConfig.java
+++ b/config/config-api/src/com/thoughtworks/go/config/materials/svn/SvnMaterialConfig.java
@@ -16,15 +16,7 @@
 
 package com.thoughtworks.go.config.materials.svn;
 
-import java.util.Map;
-import javax.annotation.PostConstruct;
-
-import com.thoughtworks.go.config.CaseInsensitiveString;
-import com.thoughtworks.go.config.ConfigAttribute;
-import com.thoughtworks.go.config.ConfigTag;
-import com.thoughtworks.go.config.ParamsAttributeAware;
-import com.thoughtworks.go.config.PasswordEncrypter;
-import com.thoughtworks.go.config.ValidationContext;
+import com.thoughtworks.go.config.*;
 import com.thoughtworks.go.config.materials.Filter;
 import com.thoughtworks.go.config.materials.PasswordAwareMaterial;
 import com.thoughtworks.go.config.materials.ScmMaterialConfig;
@@ -35,8 +27,12 @@ import com.thoughtworks.go.util.StringUtil;
 import com.thoughtworks.go.util.command.UrlArgument;
 import org.bouncycastle.crypto.InvalidCipherTextException;
 
+import javax.annotation.PostConstruct;
+import java.util.Map;
+
 import static com.thoughtworks.go.util.ExceptionUtils.bomb;
 import static com.thoughtworks.go.util.ExceptionUtils.bombIfNull;
+import static org.apache.commons.lang.StringUtils.isNotEmpty;
 
 @ConfigTag(value = "svn", label = "Subversion")
 public class SvnMaterialConfig extends ScmMaterialConfig implements ParamsAttributeAware, PasswordEncrypter, PasswordAwareMaterial {
@@ -109,6 +105,10 @@ public class SvnMaterialConfig extends ScmMaterialConfig implements ParamsAttrib
     @Override
     public void setPassword(String password) {
         resetPassword(password);
+    }
+
+    public void setCleartextPassword(String password) {
+        this.password = password;
     }
 
     private void resetPassword(String passwordToSet) {
@@ -199,6 +199,10 @@ public class SvnMaterialConfig extends ScmMaterialConfig implements ParamsAttrib
     protected void validateConcreteScmMaterial(ValidationContext validationContext) {
         if (StringUtil.isBlank(url.forDisplay())) {
             errors().add(URL, "URL cannot be blank");
+        }
+        if (isNotEmpty(this.password) && isNotEmpty(this.encryptedPassword)){
+            addError("password", "You may only specify `password` or `encrypted_password`, not both!");
+            addError("encryptedPassword", "You may only specify `password` or `encrypted_password`, not both!");
         }
     }
 

--- a/config/config-api/src/com/thoughtworks/go/config/materials/tfs/TfsMaterialConfig.java
+++ b/config/config-api/src/com/thoughtworks/go/config/materials/tfs/TfsMaterialConfig.java
@@ -16,15 +16,7 @@
 
 package com.thoughtworks.go.config.materials.tfs;
 
-import java.util.Map;
-import javax.annotation.PostConstruct;
-
-import com.thoughtworks.go.config.CaseInsensitiveString;
-import com.thoughtworks.go.config.ConfigAttribute;
-import com.thoughtworks.go.config.ConfigTag;
-import com.thoughtworks.go.config.ParamsAttributeAware;
-import com.thoughtworks.go.config.PasswordEncrypter;
-import com.thoughtworks.go.config.ValidationContext;
+import com.thoughtworks.go.config.*;
 import com.thoughtworks.go.config.materials.Filter;
 import com.thoughtworks.go.config.materials.PasswordAwareMaterial;
 import com.thoughtworks.go.config.materials.ScmMaterialConfig;
@@ -37,7 +29,11 @@ import org.apache.commons.lang.builder.ToStringBuilder;
 import org.apache.commons.lang.builder.ToStringStyle;
 import org.bouncycastle.crypto.InvalidCipherTextException;
 
+import javax.annotation.PostConstruct;
+import java.util.Map;
+
 import static com.thoughtworks.go.util.ExceptionUtils.bomb;
+import static org.apache.commons.lang.StringUtils.isNotEmpty;
 
 @ConfigTag(value = "tfs", label = "TFS")
 public class TfsMaterialConfig extends ScmMaterialConfig implements ParamsAttributeAware, PasswordAwareMaterial, PasswordEncrypter {
@@ -113,6 +109,10 @@ public class TfsMaterialConfig extends ScmMaterialConfig implements ParamsAttrib
         resetPassword(password);
     }
 
+    public void setCleartextPassword(String password) {
+        this.password = password;
+    }
+
     @Override
     public String getPassword() {
         try {
@@ -169,6 +169,10 @@ public class TfsMaterialConfig extends ScmMaterialConfig implements ParamsAttrib
         }
         if (StringUtil.isBlank(projectPath)) {
             errors().add(PROJECT_PATH, "Project Path cannot be blank");
+        }
+        if (isNotEmpty(this.password) && isNotEmpty(this.encryptedPassword)){
+            addError("password", "You may only specify `password` or `encrypted_password`, not both!");
+            addError("encryptedPassword", "You may only specify `password` or `encrypted_password`, not both!");
         }
     }
 

--- a/server/webapp/WEB-INF/rails.new/app/presenters/api_v1/config/materials/perforce_material_representer.rb
+++ b/server/webapp/WEB-INF/rails.new/app/presenters/api_v1/config/materials/perforce_material_representer.rb
@@ -22,8 +22,11 @@ module ApiV1
         property :server_and_port, as: :port
         property :user_name, as: :username
         property :password,
-                 skip_nil:    true,
-                 skip_render: true
+                 skip_render: true,
+                 skip_nil: true,
+                 setter:      lambda { |value, options|
+                   self.setCleartextPassword(value)
+                 }
         property :encrypted_password, skip_nil: true
         property :use_tickets
         property :view

--- a/server/webapp/WEB-INF/rails.new/app/presenters/api_v1/config/materials/svn_material_representer.rb
+++ b/server/webapp/WEB-INF/rails.new/app/presenters/api_v1/config/materials/svn_material_representer.rb
@@ -21,8 +21,11 @@ module ApiV1
         property :check_externals, exec_context: :decorator
         property :user_name, as: :username
         property :password,
-                 skip_nil:    true,
-                 skip_render: true
+                 skip_render: true,
+                 skip_nil: true,
+                 setter:      lambda { |value, options|
+                   self.setCleartextPassword(value)
+                 }
         property :encrypted_password, skip_nil: true
 
         delegate :check_externals, :check_externals=, to: :material_config

--- a/server/webapp/WEB-INF/rails.new/app/presenters/api_v1/config/materials/tfs_material_representer.rb
+++ b/server/webapp/WEB-INF/rails.new/app/presenters/api_v1/config/materials/tfs_material_representer.rb
@@ -21,8 +21,11 @@ module ApiV1
         property :domain
         property :user_name, as: :username
         property :password,
-                 skip_nil:    true,
-                 skip_render: true
+                 skip_render: true,
+                 skip_nil: true,
+                 setter:      lambda { |value, options|
+                   self.setCleartextPassword(value)
+                 }
         property :encrypted_password, skip_nil: true
 
         property :project_path


### PR DESCRIPTION
When users submit both `password` and `encrypted_password` for an SCM
material, the input will be considered as ambiguous and flagged as such

```json
{
  "type": "svn",
  "attributes": {
    "url": "http://funk.com/blank",
    "username": "bob",
    "password": "p@ssw0rd",
    "encrypted_password": "c!iph3rt3xt"
  }
}
```