### PR TITLE
#000 - Don't send 'Server:' header from Jetty

### DIFF
--- a/jetty9/src/com/thoughtworks/go/server/util/GoPlainSocketConnector.java
+++ b/jetty9/src/com/thoughtworks/go/server/util/GoPlainSocketConnector.java
@@ -35,6 +35,7 @@ public class GoPlainSocketConnector implements GoSocketConnector {
     private Connector plainConnector(Jetty9Server server) {
         HttpConfiguration httpConfig = new HttpConfiguration();
         httpConfig.setOutputBufferSize(systemEnvironment.get(SystemEnvironment.RESPONSE_BUFFER_SIZE));
+        httpConfig.setSendServerVersion(false);
 
         ServerConnector httpConnector = new ServerConnector(server.getServer(), new HttpConnectionFactory(httpConfig));
         httpConnector.setHost(systemEnvironment.getListenHost());

--- a/jetty9/src/com/thoughtworks/go/server/util/GoSslSocketConnector.java
+++ b/jetty9/src/com/thoughtworks/go/server/util/GoSslSocketConnector.java
@@ -59,6 +59,7 @@ public class GoSslSocketConnector implements GoSocketConnector {
         HttpConfiguration httpsConfig = new HttpConfiguration();
         httpsConfig.setOutputBufferSize(systemEnvironment.get(SystemEnvironment.RESPONSE_BUFFER_SIZE));
         httpsConfig.addCustomizer(new SecureRequestCustomizer());
+        httpsConfig.setSendServerVersion(false);
 
         SslContextFactory sslContextFactory = new SslContextFactory();
         sslContextFactory.setKeyStorePath(keystore.getPath());


### PR DESCRIPTION
It's a bit of a security hole to provide more information than needed.

Before:
```
$ curl -I http://localhost:8153
HTTP/1.1 301 Moved Permanently
Date: Tue, 22 Dec 2015 16:31:21 GMT
Location: /go/home
Content-Type: text/html; charset=ISO-8859-1
Content-Length: 13
Server: Jetty(9.2.z-SNAPSHOT)
```

After:
```
$ curl -I http://localhost:8153
HTTP/1.1 301 Moved Permanently
Date: Tue, 22 Dec 2015 16:31:21 GMT
Location: /go/home
Content-Type: text/html; charset=ISO-8859-1
Content-Length: 13
```