### PR TITLE
Pipeline Config validation fixes

### DIFF
--- a/common/test/unit/com/thoughtworks/go/config/materials/tfs/TfsMaterialConfigUpdateTest.java
+++ b/common/test/unit/com/thoughtworks/go/config/materials/tfs/TfsMaterialConfigUpdateTest.java
@@ -16,10 +16,6 @@
 
 package com.thoughtworks.go.config.materials.tfs;
 
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
-
 import com.thoughtworks.go.config.CaseInsensitiveString;
 import com.thoughtworks.go.config.ConfigSaveValidationContext;
 import com.thoughtworks.go.config.materials.AbstractMaterialConfig;
@@ -33,10 +29,15 @@ import org.bouncycastle.crypto.InvalidCipherTextException;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNull.nullValue;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
+import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -209,5 +210,31 @@ public class TfsMaterialConfigUpdateTest {
         catch (Exception e) {
             assertThat(e.getMessage(), is("Password encryption failed. Please verify your cipher key."));
         }
+    }
+
+    @Test
+    public void shouldReturnTheUrl() {
+        String url = "git@github.com/my/repo";
+        TfsMaterialConfig config = new TfsMaterialConfig();
+
+        config.setUrl(url);
+
+        assertThat(config.getUrl(), is(url));
+    }
+
+    @Test
+    public void shouldReturnNullIfUrlForMaterialNotSpecified() {
+        TfsMaterialConfig config = new TfsMaterialConfig();
+
+        assertNull(config.getUrl());
+    }
+
+    @Test
+    public void shouldHandleNullWhenSettingUrlForAMaterial() {
+        TfsMaterialConfig config = new TfsMaterialConfig();
+
+        config.setUrl(null);
+
+        assertNull(config.getUrl());
     }
 }

--- a/common/test/unit/com/thoughtworks/go/domain/JobConfigTest.java
+++ b/common/test/unit/com/thoughtworks/go/domain/JobConfigTest.java
@@ -36,6 +36,7 @@ import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
 import static org.hamcrest.core.IsNull.nullValue;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.*;
 
 public class JobConfigTest {
@@ -217,6 +218,24 @@ public class JobConfigTest {
 
         assertThat(defaultJobAllLowerCase.errors().isEmpty(), is(false));
         assertThat(defaultJobAllLowerCase.errors().on(JobConfig.NAME), is("You have defined multiple jobs called 'defaultjob'. Job names are case-insensitive and must be unique."));
+    }
+
+    @Test
+    public void shouldNotValidateJobNameUniquenessInAbsenceOfName(){
+        JobConfig job = new JobConfig();
+
+        job.validateNameUniqueness(new HashMap<String, JobConfig>());
+
+        assertTrue(job.errors().isEmpty());
+    }
+
+    @Test
+    public void shouldNotValidateJobNameUniquenessIfNameIsEmptyString(){
+        JobConfig job = new JobConfig(" ");
+
+        job.validateNameUniqueness(new HashMap<String, JobConfig>());
+
+        assertTrue(job.errors().isEmpty());
     }
 
     @Test

--- a/common/test/unit/com/thoughtworks/go/domain/PipelineConfigTest.java
+++ b/common/test/unit/com/thoughtworks/go/domain/PipelineConfigTest.java
@@ -228,6 +228,15 @@ public class PipelineConfigTest {
     }
 
     @Test
+    public void shouldValidateMissingLabel() {
+        PipelineConfig pipelineConfig = createAndValidatePipelineLabel(null);
+        assertThat(pipelineConfig.errors().on(PipelineConfig.LABEL_TEMPLATE), is(PipelineConfig.BLANK_LABEL_TEMPLATE_ERROR_MESSAGE));
+
+        pipelineConfig = createAndValidatePipelineLabel("");
+        assertThat(pipelineConfig.errors().on(PipelineConfig.LABEL_TEMPLATE), is(PipelineConfig.BLANK_LABEL_TEMPLATE_ERROR_MESSAGE));
+    }
+
+    @Test
     public void shouldValidateCorrectPipelineLabelWithoutTruncationSyntax() {
         String labelFormat = "pipeline-${COUNT}-${git}-454";
         PipelineConfig pipelineConfig = createAndValidatePipelineLabel(labelFormat);

--- a/config/config-api/src/com/thoughtworks/go/config/ExecTask.java
+++ b/config/config-api/src/com/thoughtworks/go/config/ExecTask.java
@@ -16,14 +16,14 @@
 
 package com.thoughtworks.go.config;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-
 import com.thoughtworks.go.domain.TaskProperty;
 import com.thoughtworks.go.domain.config.Arguments;
 import com.thoughtworks.go.util.FileUtil;
 import com.thoughtworks.go.util.StringUtil;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 
 /**
  * This was copied from the ExecBuilder class in ccmain. Look for references there.
@@ -204,7 +204,7 @@ public class ExecTask extends AbstractTask implements CommandTask {
         if (argList != null ? !argList.equals(execTask.argList) : execTask.argList != null) {
             return false;
         }
-        if (!command.equals(execTask.command)) {
+        if (command != null ? !command.equals(execTask.command) : execTask.command != null) {
             return false;
         }
         if (workingDirectory != null ? !workingDirectory.equals(execTask.workingDirectory) : execTask.workingDirectory != null) {

--- a/config/config-api/src/com/thoughtworks/go/config/JobConfig.java
+++ b/config/config-api/src/com/thoughtworks/go/config/JobConfig.java
@@ -451,6 +451,8 @@ public class JobConfig implements Validatable, ParamsAttributeAware, Environment
 	}
 
     public void validateNameUniqueness(Map<String, JobConfig> visitedConfigs) {
+        if (StringUtil.isBlank(CaseInsensitiveString.str(name()))) return;
+
         String currentJob = name().toLower();
         if (visitedConfigs.containsKey(CaseInsensitiveString.str(name())) || visitedConfigs.containsKey(currentJob)) {
             JobConfig conflictingConfig = visitedConfigs.get(currentJob);

--- a/config/config-api/src/com/thoughtworks/go/config/PipelineConfig.java
+++ b/config/config-api/src/com/thoughtworks/go/config/PipelineConfig.java
@@ -81,8 +81,9 @@ public class PipelineConfig extends BaseCollection<StageConfig> implements Param
     public static final String CONFIGURATION_TYPE = "configurationType";
     public static final String CONFIGURATION_TYPE_STAGES = "configurationType_stages";
     public static final String CONFIGURATION_TYPE_TEMPLATE = "configurationType_template";
-    public static final String LABEL_TEMPLATE_ERROR_MESSAGE =
-            "Invalid label. Label should be composed of alphanumeric text, it should contain the builder number as ${COUNT}, can contain a material revision as ${<material-name>} of ${<material-name>[:<number>]}, or use params as #{<param-name>}.";
+    public static final String LABEL_TEMPLATE_FORMAT_MESSAGE = "Label should be composed of alphanumeric text, it should contain the builder number as ${COUNT}, can contain a material revision as ${<material-name>} of ${<material-name>[:<number>]}, or use params as #{<param-name>}.";
+    public static final String LABEL_TEMPLATE_ERROR_MESSAGE = "Invalid label. ".concat(LABEL_TEMPLATE_FORMAT_MESSAGE);
+    public static final String BLANK_LABEL_TEMPLATE_ERROR_MESSAGE = "Label cannot be blank. ".concat(LABEL_TEMPLATE_FORMAT_MESSAGE);
 
     @SkipParameterResolution
     @ConfigAttribute(value = "name", optional = false)
@@ -193,6 +194,11 @@ public class PipelineConfig extends BaseCollection<StageConfig> implements Param
     }
 
     private void validateLabelTemplate() {
+        if (StringUtil.isBlank(labelTemplate)) {
+            addError("labelTemplate", BLANK_LABEL_TEMPLATE_ERROR_MESSAGE);
+            return;
+        }
+
         if (XmlUtils.doesNotMatchUsingXsdRegex(LABEL_TEMPLATE_FORMAT_REGEX, labelTemplate)) {
             addError("labelTemplate", LABEL_TEMPLATE_ERROR_MESSAGE);
             return;

--- a/config/config-api/src/com/thoughtworks/go/config/StageConfig.java
+++ b/config/config-api/src/com/thoughtworks/go/config/StageConfig.java
@@ -256,10 +256,10 @@ public class StageConfig implements Validatable, ParamsAttributeAware, Environme
     }
 
     public void validate(ValidationContext validationContext) {
-        isValidateName();
+        isNameValid();
     }
 
-    private boolean isValidateName() {
+    private boolean isNameValid() {
         if (!new NameTypeValidator().isNameValid(name)) {
             this.errors.add(NAME, NameTypeValidator.errorMessage("stage", name));
             return false;
@@ -268,7 +268,7 @@ public class StageConfig implements Validatable, ParamsAttributeAware, Environme
     }
 
     public void validateNameUniqueness(Map<String, StageConfig> stageNameMap) {
-        if (isValidateName()) {
+        if (isNameValid()) {
             String currentName = name.toLower();
             StageConfig stageWithSameName = stageNameMap.get(currentName);
             if (stageWithSameName == null) {

--- a/config/config-api/src/com/thoughtworks/go/config/materials/git/GitMaterialConfig.java
+++ b/config/config-api/src/com/thoughtworks/go/config/materials/git/GitMaterialConfig.java
@@ -80,12 +80,14 @@ public class GitMaterialConfig extends ScmMaterialConfig {
 
     @Override
     public String getUrl() {
-        return url.forCommandline();
+        return url != null ? url.forCommandline() : null;
     }
 
     @Override
     public void setUrl(String url) {
-        this.url = new UrlArgument(url);
+        if (url != null) {
+            this.url = new UrlArgument(url);
+        }
     }
 
     @Override

--- a/config/config-api/src/com/thoughtworks/go/config/materials/mercurial/HgMaterialConfig.java
+++ b/config/config-api/src/com/thoughtworks/go/config/materials/mercurial/HgMaterialConfig.java
@@ -85,12 +85,14 @@ public class HgMaterialConfig extends ScmMaterialConfig implements ParamsAttribu
 
     @Override
     public String getUrl() {
-        return url.forCommandline();
+        return url != null ? url.forCommandline() : null;
     }
 
     @Override
-    public void setUrl(String hgUrl) {
-        this.url = new HgUrlArgument(hgUrl);
+    public void setUrl(String url) {
+        if (url != null) {
+            this.url = new HgUrlArgument(url);
+        }
     }
 
     @Override

--- a/config/config-api/src/com/thoughtworks/go/config/materials/svn/SvnMaterialConfig.java
+++ b/config/config-api/src/com/thoughtworks/go/config/materials/svn/SvnMaterialConfig.java
@@ -170,12 +170,14 @@ public class SvnMaterialConfig extends ScmMaterialConfig implements ParamsAttrib
 
     @Override
     public String getUrl() {
-        return url == null ? null : url.forCommandline();
+        return url != null ? url.forCommandline() : null;
     }
 
     @Override
     public void setUrl(String url) {
-        this.url = new UrlArgument(url);
+        if (url != null) {
+            this.url = new UrlArgument(url);
+        }
     }
 
     @Override

--- a/config/config-api/src/com/thoughtworks/go/config/materials/tfs/TfsMaterialConfig.java
+++ b/config/config-api/src/com/thoughtworks/go/config/materials/tfs/TfsMaterialConfig.java
@@ -134,12 +134,14 @@ public class TfsMaterialConfig extends ScmMaterialConfig implements ParamsAttrib
 
     @Override
     public String getUrl() {
-        return url == null ? null : url.forCommandline();
+        return url != null ? url.forCommandline() : null;
     }
 
     @Override
     public void setUrl(String url) {
-        this.url = new UrlArgument(url);
+        if (url != null) {
+            this.url = new UrlArgument(url);
+        }
     }
 
     @Override

--- a/config/config-api/test/com/thoughtworks/go/config/ExecTaskTest.java
+++ b/config/config-api/test/com/thoughtworks/go/config/ExecTaskTest.java
@@ -16,8 +16,6 @@
 
 package com.thoughtworks.go.config;
 
-import java.util.List;
-
 import com.thoughtworks.go.domain.ConfigErrors;
 import com.thoughtworks.go.domain.TaskProperty;
 import com.thoughtworks.go.domain.config.Arguments;
@@ -27,12 +25,16 @@ import org.hamcrest.core.Is;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.List;
+
 import static com.thoughtworks.go.util.DataStructureUtils.m;
 import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNull.nullValue;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
 
 public class ExecTaskTest {
 
@@ -187,8 +189,8 @@ public class ExecTaskTest {
     public void shouldReturnCommandTaskAttributes(){
         ExecTask task = new ExecTask("ls", "-laht", "src/build");
         assertThat(task.command(),is("ls"));
-        assertThat(task.arguments(),is("-laht"));
-        assertThat(task.workingDirectory(),is("src/build"));
+        assertThat(task.arguments(), is("-laht"));
+        assertThat(task.workingDirectory(), is("src/build"));
     }
 
     @Test
@@ -201,5 +203,33 @@ public class ExecTaskTest {
     public void shouldReturnEmptyCommandArguments(){
         ExecTask task = new ExecTask("./bn", new Arguments(), "src/build" );
         assertThat(task.arguments(),is(""));
+    }
+
+    @Test
+    public void shouldBeSameIfCommandMatches() {
+        ExecTask task = new ExecTask("ls", new Arguments());
+
+        assertTrue(task.equals(new ExecTask("ls", new Arguments())));
+    }
+
+    @Test
+    public void shouldUnEqualIfCommandsDontMatch() {
+        ExecTask task = new ExecTask("ls", new Arguments());
+
+        assertFalse(task.equals(new ExecTask("rm", new Arguments())));
+    }
+
+    @Test
+    public void shouldUnEqualIfCommandIsNull() {
+        ExecTask task = new ExecTask(null, new Arguments());
+
+        assertFalse(task.equals(new ExecTask("rm", new Arguments())));
+    }
+
+    @Test
+    public void shouldUnEqualIfOtherTaskCommandIsNull() {
+        ExecTask task = new ExecTask("ls", new Arguments());
+
+        assertFalse(task.equals(new ExecTask(null, new Arguments())));
     }
 }

--- a/config/config-api/test/com/thoughtworks/go/config/materials/git/GitMaterialConfigTest.java
+++ b/config/config-api/test/com/thoughtworks/go/config/materials/git/GitMaterialConfigTest.java
@@ -16,9 +16,6 @@
 
 package com.thoughtworks.go.config.materials.git;
 
-import java.util.HashMap;
-import java.util.Map;
-
 import com.thoughtworks.go.config.CaseInsensitiveString;
 import com.thoughtworks.go.config.ConfigSaveValidationContext;
 import com.thoughtworks.go.config.materials.AbstractMaterialConfig;
@@ -27,7 +24,11 @@ import com.thoughtworks.go.config.materials.IgnoredFiles;
 import com.thoughtworks.go.config.materials.ScmMaterialConfig;
 import org.junit.Test;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 
 public class GitMaterialConfigTest {
@@ -67,4 +68,37 @@ public class GitMaterialConfigTest {
         assertThat(gitMaterialConfig, is(new GitMaterialConfig("")));
     }
 
+    @Test
+    public void shouldReturnTheUrl() {
+        String url = "git@github.com/my/repo";
+        GitMaterialConfig config = new GitMaterialConfig(url);
+
+        assertThat(config.getUrl(), is(url));
+    }
+
+    @Test
+    public void shouldReturnNullIfUrlForMaterialNotSpecified() {
+        GitMaterialConfig config = new GitMaterialConfig();
+
+        assertNull(config.getUrl());
+    }
+
+    @Test
+    public void shouldSetUrlForAMaterial() {
+        String url = "git@github.com/my/repo";
+        GitMaterialConfig config = new GitMaterialConfig();
+
+        config.setUrl(url);
+
+        assertThat(config.getUrl(), is(url));
+    }
+
+    @Test
+    public void shouldHandleNullWhenSettingUrlForAMaterial() {
+        GitMaterialConfig config = new GitMaterialConfig();
+
+        config.setUrl(null);
+
+        assertNull(config.getUrl());
+    }
 }

--- a/config/config-api/test/com/thoughtworks/go/config/materials/mercurial/HgMaterialConfigTest.java
+++ b/config/config-api/test/com/thoughtworks/go/config/materials/mercurial/HgMaterialConfigTest.java
@@ -16,9 +16,6 @@
 
 package com.thoughtworks.go.config.materials.mercurial;
 
-import java.util.HashMap;
-import java.util.Map;
-
 import com.thoughtworks.go.config.CaseInsensitiveString;
 import com.thoughtworks.go.config.ConfigSaveValidationContext;
 import com.thoughtworks.go.config.materials.AbstractMaterialConfig;
@@ -27,7 +24,11 @@ import com.thoughtworks.go.config.materials.IgnoredFiles;
 import com.thoughtworks.go.config.materials.ScmMaterialConfig;
 import org.junit.Test;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 
 public class HgMaterialConfigTest {
@@ -65,5 +66,39 @@ public class HgMaterialConfigTest {
         hgMaterialConfig.setConfigAttributes(null);
 
         assertThat(hgMaterialConfig, is(new HgMaterialConfig("", null)));
+    }
+
+    @Test
+    public void shouldReturnTheUrl() {
+        String url = "git@github.com/my/repo";
+        HgMaterialConfig config = new HgMaterialConfig(url, null);
+
+        assertThat(config.getUrl(), is(url));
+    }
+
+    @Test
+    public void shouldReturnNullIfUrlForMaterialNotSpecified() {
+        HgMaterialConfig config = new HgMaterialConfig();
+
+        assertNull(config.getUrl());
+    }
+
+    @Test
+    public void shouldSetUrlForAMaterial() {
+        String url = "git@github.com/my/repo";
+        HgMaterialConfig config = new HgMaterialConfig();
+
+        config.setUrl(url);
+
+        assertThat(config.getUrl(), is(url));
+    }
+
+    @Test
+    public void shouldHandleNullWhenSettingUrlForAMaterial() {
+        HgMaterialConfig config = new HgMaterialConfig();
+
+        config.setUrl(null);
+
+        assertNull(config.getUrl());
     }
 }

--- a/config/config-api/test/com/thoughtworks/go/config/materials/svn/SvnMaterialConfigTest.java
+++ b/config/config-api/test/com/thoughtworks/go/config/materials/svn/SvnMaterialConfigTest.java
@@ -16,10 +16,6 @@
 
 package com.thoughtworks.go.config.materials.svn;
 
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
-
 import com.thoughtworks.go.config.CaseInsensitiveString;
 import com.thoughtworks.go.config.ConfigSaveValidationContext;
 import com.thoughtworks.go.config.materials.AbstractMaterialConfig;
@@ -32,8 +28,13 @@ import org.hamcrest.core.Is;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNull.nullValue;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 
 public class SvnMaterialConfigTest {
@@ -120,5 +121,30 @@ public class SvnMaterialConfigTest {
 
         assertThat(svnMaterial.getPassword(), is(nullValue()));
         assertThat(svnMaterial.getEncryptedPassword(), is(nullValue()));
+    }
+
+    @Test
+    public void shouldReturnTheUrl() {
+        String url = "git@github.com/my/repo";
+        SvnMaterialConfig config = new SvnMaterialConfig();
+        config.setUrl(url);
+
+        assertThat(config.getUrl(), is(url));
+    }
+
+    @Test
+    public void shouldReturnNullIfUrlForMaterialNotSpecified() {
+        SvnMaterialConfig config = new SvnMaterialConfig();
+
+        assertNull(config.getUrl());
+    }
+
+    @Test
+    public void shouldHandleNullWhenSettingUrlForAMaterial() {
+        SvnMaterialConfig config = new SvnMaterialConfig();
+
+        config.setUrl(null);
+
+        assertNull(config.getUrl());
     }
 }

--- a/server/webapp/WEB-INF/rails.new/app/presenters/api_v1/config/materials/scm_material_representer.rb
+++ b/server/webapp/WEB-INF/rails.new/app/presenters/api_v1/config/materials/scm_material_representer.rb
@@ -4,9 +4,7 @@ module ApiV1
       class ScmMaterialRepresenter < ApiV1::BaseRepresenter
         alias_method :material_config, :represented
 
-        property :url, getter: lambda { |options|
-                       self.getUrlArgument().forCommandline() if self.getUrlArgument()
-                     }
+        property :url
         property :folder, as: :destination, skip_parse: SkipParseOnBlank
         property :filter,
                  decorator:  ApiV1::Config::Materials::FilterRepresenter,

--- a/server/webapp/WEB-INF/rails.new/spec/presenters/api_v1/config/pipeline_config_representer_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/presenters/api_v1/config/pipeline_config_representer_spec.rb
@@ -356,7 +356,7 @@ describe ApiV1::Config::PipelineConfigRepresenter do
       errors:                  {
         materials:     ["A pipeline must have at least one material"],
         pipeline:      ["Pipeline 'wunderbar' does not have any stages configured. A pipeline must have at least one stage."],
-        label_template: ["Invalid label. Label should be composed of alphanumeric text, it should contain the builder number as ${COUNT}, can contain a material revision as ${<material-name>} of ${<material-name>[:<number>]}, or use params as \#{<param-name>}."]
+        label_template: ["Label cannot be blank. Label should be composed of alphanumeric text, it should contain the builder number as ${COUNT}, can contain a material revision as ${<material-name>} of ${<material-name>[:<number>]}, or use params as \#{<param-name>}."]
       }
     }
   end


### PR DESCRIPTION
- In absence of job name skip uniqueness validation
- Validate presence of Pipeline Label
- ExecTask equality considers null commands
- Handling MaterialConfig URL setter and getter in absence of url