### PR TITLE
Fix a file handle leak (#1743)

### DIFF
--- a/base/src/com/thoughtworks/go/util/FileUtil.java
+++ b/base/src/com/thoughtworks/go/util/FileUtil.java
@@ -1,45 +1,32 @@
-/*************************GO-LICENSE-START*********************************
- * Copyright 2014 ThoughtWorks, Inc.
+/*
+ * Copyright 2015 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *************************GO-LICENSE-END***********************************/
+ */
 
 package com.thoughtworks.go.util;
-
-import java.io.File;
-import java.io.FileFilter;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.math.BigDecimal;
-import java.math.RoundingMode;
-import java.net.URI;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.Stack;
-import java.util.StringTokenizer;
-import java.util.UUID;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.log4j.Logger;
 
-import static com.thoughtworks.go.util.ExceptionUtils.bomb;
+import java.io.*;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.net.URI;
+import java.util.*;
+
 import static java.lang.System.getProperty;
 
 public class FileUtil {
@@ -77,22 +64,21 @@ public class FileUtil {
     }
 
     public static String readToEnd(File file) throws IOException {
-        FileInputStream input = new FileInputStream(file);
-        try {
-            return readToEnd(input);
-        } finally {
-            IOUtils.closeQuietly(input);
-        }
+        return readToEnd(new FileInputStream(file));
     }
 
     public static String readToEnd(InputStream input) throws IOException {
-        @SuppressWarnings("unchecked") List<String> list = IOUtils.readLines(input);
-        StringBuilder builder = new StringBuilder();
-        for (String line : list) {
-            builder.append(line);
-            builder.append(lineSeparator());
+        try {
+            @SuppressWarnings("unchecked") List<String> list = IOUtils.readLines(input);
+            StringBuilder builder = new StringBuilder();
+            for (String line : list) {
+                builder.append(line);
+                builder.append(lineSeparator());
+            }
+            return builder.toString().trim();
+        } finally {
+            IOUtils.closeQuietly(input);
         }
-        return builder.toString().trim();
     }
 
     public static boolean isHidden(File file) {

--- a/common/test/unit/com/thoughtworks/go/util/FileUtilTest.java
+++ b/common/test/unit/com/thoughtworks/go/util/FileUtilTest.java
@@ -16,12 +16,6 @@
 
 package com.thoughtworks.go.util;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
-
 import com.googlecode.junit.ext.JunitExtRunner;
 import com.googlecode.junit.ext.RunIf;
 import com.thoughtworks.go.junitext.EnhancedOSChecker;
@@ -31,6 +25,12 @@ import org.junit.After;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 
 import static com.thoughtworks.go.junitext.EnhancedOSChecker.DO_NOT_RUN_ON;
 import static com.thoughtworks.go.junitext.EnhancedOSChecker.WINDOWS;
@@ -43,12 +43,7 @@ import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNot.not;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.stub;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 @RunWith(JunitExtRunner.class)
 public class FileUtilTest {
@@ -67,6 +62,24 @@ public class FileUtilTest {
         File file = TestFileUtil.writeStringToTempFileInFolder("foo", "txt", content);
         String message = FileUtil.readToEnd(file);
         assertThat(message, is(content));
+    }
+
+    @Test
+    public void testReadToEndShouldCloseInputStream() throws Exception {
+        String content = "Hello" + FileUtil.lineSeparator() + "World";
+        File file = TestFileUtil.writeStringToTempFileInFolder("foo", "txt", content);
+        final boolean[] isClosed = {false};
+        FileInputStream inputStream = new FileInputStream(file) {
+            @Override
+            public void close() throws IOException {
+                isClosed[0] = true;
+                super.close();
+            }
+        };
+
+        String message = FileUtil.readToEnd(inputStream);
+        assertThat(message, is(content));
+        assertTrue(isClosed[0]);
     }
 
     @Test


### PR DESCRIPTION
This was caused by a combination of #1707 (which added a InputStream.close() at the wrong method)
and #1709 (which removed the InputStream.close()) with the assumption that #1707 did the right thing.