### PR TITLE
#1753 - Using the same lock to synchronize during all possible types of confi…

### DIFF
--- a/server/src/com/thoughtworks/go/config/CachedFileGoConfig.java
+++ b/server/src/com/thoughtworks/go/config/CachedFileGoConfig.java
@@ -43,7 +43,6 @@ public class CachedFileGoConfig implements CachedGoConfig {
 
     private final GoFileConfigDataSource dataSource;
     private final ServerHealthService serverHealthService;
-    private final GoConfigWriteLock goConfigWriteLock;
     private List<ConfigChangedListener> listeners = new ArrayList<ConfigChangedListener>();
 
     private volatile CruiseConfig currentConfig;
@@ -51,10 +50,9 @@ public class CachedFileGoConfig implements CachedGoConfig {
     private volatile Exception lastException;
     private volatile GoConfigHolder configHolder;
 
-    @Autowired public CachedFileGoConfig(GoFileConfigDataSource dataSource, ServerHealthService serverHealthService, GoConfigWriteLock goConfigWriteLock) {
+    @Autowired public CachedFileGoConfig(GoFileConfigDataSource dataSource, ServerHealthService serverHealthService) {
         this.dataSource = dataSource;
         this.serverHealthService = serverHealthService;
-        this.goConfigWriteLock = goConfigWriteLock;
     }
 
     @Override
@@ -86,7 +84,7 @@ public class CachedFileGoConfig implements CachedGoConfig {
 
     @Override
     public void forceReload() {
-            loadFromDisk();
+        loadFromDisk();
     }
 
     //NOTE: This method is called on a thread from Spring
@@ -94,10 +92,9 @@ public class CachedFileGoConfig implements CachedGoConfig {
         this.forceReload();
     }
 
-    private synchronized void loadFromDisk() {
+    private void loadFromDisk() {
         try {
-            synchronized (goConfigWriteLock.mutex())
-            {
+            synchronized (GoConfigWriteLock.class) {
                 GoConfigHolder configHolder = dataSource.load();
                 if (configHolder != null) {
                     saveValidConfigToCacheAndNotifyConfigChangeListeners(configHolder);

--- a/server/src/com/thoughtworks/go/config/GoConfigWriteLock.java
+++ b/server/src/com/thoughtworks/go/config/GoConfigWriteLock.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2016 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.config;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class GoConfigWriteLock {
+    private final Object writeLock;
+
+    public GoConfigWriteLock() {
+        this.writeLock = new Object();
+    }
+
+    public Object mutex() {
+        return writeLock;
+    }
+}

--- a/server/src/com/thoughtworks/go/config/GoConfigWriteLock.java
+++ b/server/src/com/thoughtworks/go/config/GoConfigWriteLock.java
@@ -20,13 +20,4 @@ import org.springframework.stereotype.Component;
 
 @Component
 public class GoConfigWriteLock {
-    private final Object writeLock;
-
-    public GoConfigWriteLock() {
-        this.writeLock = new Object();
-    }
-
-    public Object mutex() {
-        return writeLock;
-    }
 }

--- a/server/src/com/thoughtworks/go/config/GoFileConfigDataSource.java
+++ b/server/src/com/thoughtworks/go/config/GoFileConfigDataSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 ThoughtWorks, Inc.
+ * Copyright 2016 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -221,9 +221,13 @@ public class GoFileConfigDataSource {
             try {
                 LOGGER.info(String.format("[Configuration Changed] Saving updated configuration."));
                 String configAsXml = configAsXml(modifiedConfig, true);
+                String md5 = CachedDigestUtils.md5Hex(configAsXml);
+                MagicalGoConfigXmlLoader.setMd5(modifiedConfig, md5);
+                MagicalGoConfigXmlLoader.setMd5(preprocessedConfig, md5);
                 writeToConfigXmlFile(configAsXml);
-                configRepository.checkin(new GoConfigRevision(configAsXml, CachedDigestUtils.md5Hex(configAsXml), currentUser.getUsername().toString(), serverVersion.version(), timeProvider));
+                configRepository.checkin(new GoConfigRevision(configAsXml, md5, currentUser.getUsername().toString(), serverVersion.version(), timeProvider));
                 LOGGER.debug("[Config Save] Done writing with lock");
+                reloadStrategy.latestState(preprocessedConfig);
                 return new CachedFileGoConfig.PipelineConfigSaveResult(pipelineConfig, saveCommand.getPipelineGroup(), new GoConfigHolder(preprocessedConfig, modifiedConfig));
             } catch (Exception e) {
                 throw new RuntimeException("failed to save : " + e.getMessage());

--- a/server/test/common/com/thoughtworks/go/helpers/LogFileHelper.java
+++ b/server/test/common/com/thoughtworks/go/helpers/LogFileHelper.java
@@ -221,8 +221,8 @@ public final class LogFileHelper {
             super(new GoConfigDao(new MergedGoConfig(new ServerHealthService(),
                           new CachedFileGoConfig(new GoFileConfigDataSource(new DoNotUpgrade(), mock(ConfigRepository.class), new SystemEnvironment(), new TimeProvider(),
                                   new ConfigCache(), new ServerVersion(), ConfigElementImplementationRegistryMother.withNoPlugins(), metricsProbeService, new ServerHealthService()),
-                                  new ServerHealthService(), new GoConfigWriteLock()),mock(GoPartialConfig.class)),
-                    metricsProbeService, new GoConfigWriteLock()) {
+                                  new ServerHealthService()),mock(GoPartialConfig.class)),
+                    metricsProbeService) {
                 public CruiseConfig load() {
                     return null;
                 }

--- a/server/test/common/com/thoughtworks/go/helpers/LogFileHelper.java
+++ b/server/test/common/com/thoughtworks/go/helpers/LogFileHelper.java
@@ -1,5 +1,5 @@
-/*************************GO-LICENSE-START*********************************
- * Copyright 2014 ThoughtWorks, Inc.
+/*
+ * Copyright 2016 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *************************GO-LICENSE-END***********************************/
+ */
 
 package com.thoughtworks.go.helpers;
 
@@ -221,8 +221,8 @@ public final class LogFileHelper {
             super(new GoConfigDao(new MergedGoConfig(new ServerHealthService(),
                           new CachedFileGoConfig(new GoFileConfigDataSource(new DoNotUpgrade(), mock(ConfigRepository.class), new SystemEnvironment(), new TimeProvider(),
                                   new ConfigCache(), new ServerVersion(), ConfigElementImplementationRegistryMother.withNoPlugins(), metricsProbeService, new ServerHealthService()),
-                                  new ServerHealthService()),mock(GoPartialConfig.class)),
-                    metricsProbeService) {
+                                  new ServerHealthService(), new GoConfigWriteLock()),mock(GoPartialConfig.class)),
+                    metricsProbeService, new GoConfigWriteLock()) {
                 public CruiseConfig load() {
                     return null;
                 }

--- a/server/test/integration/com/thoughtworks/go/config/GoConfigDaoTestBase.java
+++ b/server/test/integration/com/thoughtworks/go/config/GoConfigDaoTestBase.java
@@ -571,7 +571,7 @@ public abstract class GoConfigDaoTestBase {
         when(saveCommand.hasWritePermissions()).thenReturn(false);
 
         CachedGoConfig cachedConfigService = mock(CachedGoConfig.class);
-        goConfigDao = new GoConfigDao(cachedConfigService, null, new GoConfigWriteLock());
+        goConfigDao = new GoConfigDao(cachedConfigService, null);
         goConfigDao.updatePipeline(pipelineConfig, result, new Username(new CaseInsensitiveString("user")), saveCommand);
 
         verifyZeroInteractions(cachedConfigService);
@@ -587,7 +587,7 @@ public abstract class GoConfigDaoTestBase {
 
         CachedGoConfig cachedConfigService = mock(CachedGoConfig.class);
         doThrow(new ConfigUpdateCheckFailedException()).when(cachedConfigService).writePipelineWithLock(pipelineConfig, saveCommand, username);
-        goConfigDao = new GoConfigDao(cachedConfigService, null, new GoConfigWriteLock());
+        goConfigDao = new GoConfigDao(cachedConfigService, null);
         goConfigDao.updatePipeline(pipelineConfig, result, username, saveCommand);
 
         verify(result).unprocessableEntity(Matchers.<Localizable>any());
@@ -602,7 +602,7 @@ public abstract class GoConfigDaoTestBase {
         when(saveCommand.hasWritePermissions()).thenReturn(true);
 
         CachedGoConfig cachedConfigService = mock(CachedGoConfig.class);
-        goConfigDao = new GoConfigDao(cachedConfigService, null, new GoConfigWriteLock());
+        goConfigDao = new GoConfigDao(cachedConfigService, null);
         Username currentUser = new Username(new CaseInsensitiveString("user"));
         goConfigDao.updatePipeline(pipelineConfig, result, currentUser, saveCommand);
 

--- a/server/test/integration/com/thoughtworks/go/config/GoConfigDaoTestBase.java
+++ b/server/test/integration/com/thoughtworks/go/config/GoConfigDaoTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 ThoughtWorks, Inc.
+ * Copyright 2016 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -571,7 +571,7 @@ public abstract class GoConfigDaoTestBase {
         when(saveCommand.hasWritePermissions()).thenReturn(false);
 
         CachedGoConfig cachedConfigService = mock(CachedGoConfig.class);
-        goConfigDao = new GoConfigDao(cachedConfigService, null);
+        goConfigDao = new GoConfigDao(cachedConfigService, null, new GoConfigWriteLock());
         goConfigDao.updatePipeline(pipelineConfig, result, new Username(new CaseInsensitiveString("user")), saveCommand);
 
         verifyZeroInteractions(cachedConfigService);
@@ -587,7 +587,7 @@ public abstract class GoConfigDaoTestBase {
 
         CachedGoConfig cachedConfigService = mock(CachedGoConfig.class);
         doThrow(new ConfigUpdateCheckFailedException()).when(cachedConfigService).writePipelineWithLock(pipelineConfig, saveCommand, username);
-        goConfigDao = new GoConfigDao(cachedConfigService, null);
+        goConfigDao = new GoConfigDao(cachedConfigService, null, new GoConfigWriteLock());
         goConfigDao.updatePipeline(pipelineConfig, result, username, saveCommand);
 
         verify(result).unprocessableEntity(Matchers.<Localizable>any());
@@ -602,7 +602,7 @@ public abstract class GoConfigDaoTestBase {
         when(saveCommand.hasWritePermissions()).thenReturn(true);
 
         CachedGoConfig cachedConfigService = mock(CachedGoConfig.class);
-        goConfigDao = new GoConfigDao(cachedConfigService, null);
+        goConfigDao = new GoConfigDao(cachedConfigService, null, new GoConfigWriteLock());
         Username currentUser = new Username(new CaseInsensitiveString("user"));
         goConfigDao.updatePipeline(pipelineConfig, result, currentUser, saveCommand);
 

--- a/server/test/integration/com/thoughtworks/go/config/GoFileConfigDataSourceTest.java
+++ b/server/test/integration/com/thoughtworks/go/config/GoFileConfigDataSourceTest.java
@@ -1,5 +1,5 @@
-/*************************GO-LICENSE-START*********************************
- * Copyright 2014 ThoughtWorks, Inc.
+/*
+ * Copyright 2016 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *************************GO-LICENSE-END***********************************/
+ */
 
 package com.thoughtworks.go.config;
 
@@ -92,9 +92,10 @@ public class GoFileConfigDataSourceTest {
         }, configRepository, new TimeProvider(), configCache, registry, metricsProbeService),
                 configRepository, systemEnvironment, timeProvider, configCache, serverVersion, registry, metricsProbeService, mock(ServerHealthService.class));
         dataSource.upgradeIfNecessary();
-        CachedFileGoConfig fileService = new CachedFileGoConfig(dataSource, new ServerHealthService());
+        GoConfigWriteLock goConfigWriteLock = new GoConfigWriteLock();
+        CachedFileGoConfig fileService = new CachedFileGoConfig(dataSource, new ServerHealthService(), goConfigWriteLock);
         fileService.loadConfigIfNull();
-        goConfigDao = new GoConfigDao(fileService, metricsProbeService);
+        goConfigDao = new GoConfigDao(fileService, metricsProbeService, goConfigWriteLock);
         configHelper.load();
         configHelper.usingCruiseConfigDao(goConfigDao);
     }

--- a/server/test/integration/com/thoughtworks/go/config/GoFileConfigDataSourceTest.java
+++ b/server/test/integration/com/thoughtworks/go/config/GoFileConfigDataSourceTest.java
@@ -93,9 +93,9 @@ public class GoFileConfigDataSourceTest {
                 configRepository, systemEnvironment, timeProvider, configCache, serverVersion, registry, metricsProbeService, mock(ServerHealthService.class));
         dataSource.upgradeIfNecessary();
         GoConfigWriteLock goConfigWriteLock = new GoConfigWriteLock();
-        CachedFileGoConfig fileService = new CachedFileGoConfig(dataSource, new ServerHealthService(), goConfigWriteLock);
+        CachedFileGoConfig fileService = new CachedFileGoConfig(dataSource, new ServerHealthService());
         fileService.loadConfigIfNull();
-        goConfigDao = new GoConfigDao(fileService, metricsProbeService, goConfigWriteLock);
+        goConfigDao = new GoConfigDao(fileService, metricsProbeService);
         configHelper.load();
         configHelper.usingCruiseConfigDao(goConfigDao);
     }

--- a/server/test/integration/com/thoughtworks/go/server/service/ConfigSaveDeadlockDetectionIntegrationTest.java
+++ b/server/test/integration/com/thoughtworks/go/server/service/ConfigSaveDeadlockDetectionIntegrationTest.java
@@ -1,0 +1,188 @@
+/*
+ * Copyright 2016 ThoughtWorks, Inc. *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.server.service;
+
+import com.thoughtworks.go.config.*;
+import com.thoughtworks.go.config.materials.git.GitMaterialConfig;
+import com.thoughtworks.go.helper.GoConfigMother;
+import com.thoughtworks.go.server.domain.Username;
+import com.thoughtworks.go.server.service.result.HttpLocalizedOperationResult;
+import com.thoughtworks.go.server.service.support.ServerStatusService;
+import com.thoughtworks.go.util.FileUtil;
+import com.thoughtworks.go.util.GoConfigFileHelper;
+import org.bouncycastle.crypto.InvalidCipherTextException;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+import org.junit.rules.TestRule;
+import org.junit.rules.TestWatcher;
+import org.junit.rules.Timeout;
+import org.junit.runner.Description;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.UUID;
+import java.util.concurrent.TimeoutException;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(locations = {
+        "classpath:WEB-INF/applicationContext-global.xml",
+        "classpath:WEB-INF/applicationContext-dataLocalAccess.xml",
+        "classpath:WEB-INF/applicationContext-acegi-security.xml"
+})
+public class ConfigSaveDeadlockDetectionIntegrationTest {
+    @Autowired
+    private GoConfigDao goConfigDao;
+    @Autowired
+    private GoConfigService goConfigService;
+    @Autowired
+    private CachedFileGoConfig cachedFileGoConfig;
+    @Autowired
+    private PipelineConfigService pipelineConfigService;
+    @Autowired
+    private ServerStatusService serverStatusService;
+
+    private GoConfigFileHelper configHelper;
+    private final int TWO_MINUTES = 2 * 60 * 1000;
+
+    @Before
+    public void setup() throws Exception {
+        configHelper = new GoConfigFileHelper();
+        configHelper.usingCruiseConfigDao(goConfigDao).initializeConfigFile();
+        configHelper.onSetUp();
+        goConfigService.forceNotifyListeners();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        configHelper.onTearDown();
+    }
+
+    @Rule
+    public final TestRule timeout = RuleChain
+            .outerRule(new TestWatcher() {
+                @Override
+                protected void failed(Throwable e, Description description) {
+                    if(e.getMessage().contains("test timed out") || e instanceof TimeoutException){
+                        try {
+                            fail("Test timed out, possible deadlock. Thread Dump:" + serverStatusService.captureServerInfo(Username.ANONYMOUS, new HttpLocalizedOperationResult()));
+                        } catch (IOException e1) {
+                            throw new RuntimeException(e1);
+                        }
+                    }
+
+                }
+            })
+            .around(new Timeout(TWO_MINUTES));
+
+    @Test
+    public void shouldNotDeadlockWhenAllPossibleWaysOfUpdatingTheConfigAreBeingUsedAtTheSameTime() throws Exception {
+        final ArrayList<Thread> configSaveThreads = new ArrayList<>();
+        final int pipelineCreatedThroughApiCount = 100;
+        final int pipelineCreatedThroughUICount = 100;
+
+        for (int i = 0; i < pipelineCreatedThroughUICount; i++) {
+            Thread thread = configSaveThread(i);
+            configSaveThreads.add(thread);
+        }
+
+        for (int i = 0; i < pipelineCreatedThroughApiCount; i++) {
+            Thread thread = pipelineSaveThread(i);
+            configSaveThreads.add(thread);
+        }
+
+        for (Thread configSaveThread : configSaveThreads) {
+            Thread timerThread = null;
+            try {
+                timerThread = createThread(new Runnable() {
+                    @Override
+                    public void run() {
+                        try {
+                            File configFile = new File(goConfigDao.fileLocation());
+                            String currentConfig = FileUtil.readContentFromFile(configFile);
+                            String updatedConfig = currentConfig.replaceFirst("artifactsdir=\".*\"", "artifactsdir=\"" + UUID.randomUUID().toString() + "\"");
+                            FileUtil.writeContentToFile(updatedConfig, configFile);
+                        } catch (IOException e) {
+                            fail("Failed with error: " + e.getMessage());
+                        }
+                        cachedFileGoConfig.forceReload();
+
+                    }
+                }, "timer-thread");
+            } catch (InterruptedException e) {
+                fail(e.getMessage());
+            }
+
+            try {
+                configSaveThread.start();
+                timerThread.start();
+                configSaveThread.join();
+                timerThread.join();
+            } catch (InterruptedException e) {
+                fail(e.getMessage());
+            }
+        }
+        assertThat(goConfigService.getAllPipelineConfigs().size(), is(pipelineCreatedThroughApiCount + pipelineCreatedThroughUICount));
+    }
+
+    private Thread pipelineSaveThread(int counter) throws InterruptedException {
+        return createThread(new Runnable() {
+            @Override
+            public void run() {
+                PipelineConfig pipelineConfig = GoConfigMother.createPipelineConfigWithMaterialConfig(UUID.randomUUID().toString(), new GitMaterialConfig("FOO"));
+                pipelineConfigService.createPipelineConfig(new Username(new CaseInsensitiveString("root")), pipelineConfig, new HttpLocalizedOperationResult(), "default");
+            }
+        }, "pipeline-config-save-thread" + counter);
+    }
+
+    private Thread configSaveThread(final int counter) throws InvalidCipherTextException, InterruptedException {
+        return createThread(new Runnable() {
+            @Override
+            public void run() {
+                goConfigService.updateConfig(new UpdateConfigCommand() {
+                    @Override
+                    public CruiseConfig update(CruiseConfig cruiseConfig) throws Exception {
+                        PipelineConfig pipelineConfig = GoConfigMother.createPipelineConfigWithMaterialConfig(UUID.randomUUID().toString(), new GitMaterialConfig("FOO"));
+                        cruiseConfig.addPipeline("default", pipelineConfig);
+                        return cruiseConfig;
+                    }
+                });
+
+            }
+        }, "config-save-thread" + counter);
+    }
+
+    private Thread createThread(Runnable runnable, String name) throws InterruptedException {
+        Thread thread = new Thread(runnable, name);
+        thread.setUncaughtExceptionHandler(new Thread.UncaughtExceptionHandler() {
+            public void uncaughtException(Thread t, Throwable e) {
+                throw new RuntimeException(e);
+            }
+        });
+        return thread;
+    }
+}

--- a/server/test/integration/com/thoughtworks/go/server/service/PipelineConfigServiceIntegrationTest.java
+++ b/server/test/integration/com/thoughtworks/go/server/service/PipelineConfigServiceIntegrationTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright 2016 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
 package com.thoughtworks.go.server.service;
 
 import com.thoughtworks.go.config.*;
@@ -112,6 +129,9 @@ public class PipelineConfigServiceIntegrationTest {
         assertThat(savedPipelineConfig, is(pipelineConfig));
         assertThat(configRepository.getCurrentRevCommit().name(), is(not(headCommitBeforeUpdate)));
         assertThat(configRepository.getCurrentRevision().getUsername(), is(user.getDisplayName()));
+        assertThat(configRepository.getCurrentRevision().getMd5(), is(not(goConfigHolderBeforeUpdate.config.getMd5())));
+        assertThat(configRepository.getCurrentRevision().getMd5(), is(goConfigDao.loadConfigHolder().config.getMd5()));
+        assertThat(configRepository.getCurrentRevision().getMd5(), is(goConfigDao.loadConfigHolder().configForEdit.getMd5()));
     }
 
     @Test

--- a/server/test/integration/com/thoughtworks/go/util/GoConfigFileHelper.java
+++ b/server/test/integration/com/thoughtworks/go/util/GoConfigFileHelper.java
@@ -1,5 +1,5 @@
-/*************************GO-LICENSE-START*********************************
- * Copyright 2014 ThoughtWorks, Inc.
+/*
+ * Copyright 2016 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *************************GO-LICENSE-END***********************************/
+ */
 
 package com.thoughtworks.go.util;
 
@@ -50,6 +50,7 @@ import java.util.List;
 
 import static com.thoughtworks.go.config.PipelineConfigs.DEFAULT_GROUP;
 import static com.thoughtworks.go.util.ExceptionUtils.bomb;
+import static org.mockito.Mockito.mock;
 
 /**
  * @understands how to edit the cruise config file for testing
@@ -120,14 +121,15 @@ public class GoConfigFileHelper {
             GoFileConfigDataSource dataSource = new GoFileConfigDataSource(new DoNotUpgrade(), configRepository, systemEnvironment, new TimeProvider(),
                     configCache, new ServerVersion(), configElementImplementationRegistry, probeService, serverHealthService);
             dataSource.upgradeIfNecessary();
-            CachedFileGoConfig fileService = new CachedFileGoConfig(dataSource,serverHealthService);
+            GoConfigWriteLock goConfigWriteLock = new GoConfigWriteLock();
+            CachedFileGoConfig fileService = new CachedFileGoConfig(dataSource,serverHealthService, goConfigWriteLock);
             GoConfigWatchList configWatchList = new GoConfigWatchList(fileService);
             GoRepoConfigDataSource repoConfigDataSource = new GoRepoConfigDataSource(configWatchList,
                     new GoConfigPluginService(configCache,configElementImplementationRegistry,probeService));
             GoPartialConfig partialConfig = new GoPartialConfig(repoConfigDataSource,configWatchList);
             MergedGoConfig cachedConfigService = new MergedGoConfig(serverHealthService,fileService,partialConfig);
             cachedConfigService.loadConfigIfNull();
-            return new GoConfigDao(cachedConfigService, probeService);
+            return new GoConfigDao(cachedConfigService, probeService, goConfigWriteLock);
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
@@ -142,13 +144,14 @@ public class GoConfigFileHelper {
             ServerHealthService serverHealthService = new ServerHealthService();
             ConfigRepository configRepository = new ConfigRepository(systemEnvironment);
             configRepository.initialize();
+            GoConfigWriteLock goConfigWriteLock = new GoConfigWriteLock();
             GoFileConfigDataSource dataSource = new GoFileConfigDataSource(new DoNotUpgrade(), configRepository, systemEnvironment, new TimeProvider(),
                     new ConfigCache(), new ServerVersion(), com.thoughtworks.go.util.ConfigElementImplementationRegistryMother.withNoPlugins(), probeService, serverHealthService);
             dataSource.upgradeIfNecessary();
-            CachedFileGoConfig fileService = new CachedFileGoConfig(dataSource,serverHealthService);
+            CachedFileGoConfig fileService = new CachedFileGoConfig(dataSource,serverHealthService, goConfigWriteLock);
             MergedGoConfig cachedConfigService = new MergedGoConfig(serverHealthService,fileService,partialConfig);
             cachedConfigService.loadConfigIfNull();
-            return new GoConfigDao(cachedConfigService, probeService);
+            return new GoConfigDao(cachedConfigService, probeService, goConfigWriteLock );
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/server/test/integration/com/thoughtworks/go/util/GoConfigFileHelper.java
+++ b/server/test/integration/com/thoughtworks/go/util/GoConfigFileHelper.java
@@ -122,14 +122,14 @@ public class GoConfigFileHelper {
                     configCache, new ServerVersion(), configElementImplementationRegistry, probeService, serverHealthService);
             dataSource.upgradeIfNecessary();
             GoConfigWriteLock goConfigWriteLock = new GoConfigWriteLock();
-            CachedFileGoConfig fileService = new CachedFileGoConfig(dataSource,serverHealthService, goConfigWriteLock);
+            CachedFileGoConfig fileService = new CachedFileGoConfig(dataSource,serverHealthService);
             GoConfigWatchList configWatchList = new GoConfigWatchList(fileService);
             GoRepoConfigDataSource repoConfigDataSource = new GoRepoConfigDataSource(configWatchList,
                     new GoConfigPluginService(configCache,configElementImplementationRegistry,probeService));
             GoPartialConfig partialConfig = new GoPartialConfig(repoConfigDataSource,configWatchList);
             MergedGoConfig cachedConfigService = new MergedGoConfig(serverHealthService,fileService,partialConfig);
             cachedConfigService.loadConfigIfNull();
-            return new GoConfigDao(cachedConfigService, probeService, goConfigWriteLock);
+            return new GoConfigDao(cachedConfigService, probeService);
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
@@ -148,10 +148,10 @@ public class GoConfigFileHelper {
             GoFileConfigDataSource dataSource = new GoFileConfigDataSource(new DoNotUpgrade(), configRepository, systemEnvironment, new TimeProvider(),
                     new ConfigCache(), new ServerVersion(), com.thoughtworks.go.util.ConfigElementImplementationRegistryMother.withNoPlugins(), probeService, serverHealthService);
             dataSource.upgradeIfNecessary();
-            CachedFileGoConfig fileService = new CachedFileGoConfig(dataSource,serverHealthService, goConfigWriteLock);
+            CachedFileGoConfig fileService = new CachedFileGoConfig(dataSource,serverHealthService);
             MergedGoConfig cachedConfigService = new MergedGoConfig(serverHealthService,fileService,partialConfig);
             cachedConfigService.loadConfigIfNull();
-            return new GoConfigDao(cachedConfigService, probeService, goConfigWriteLock );
+            return new GoConfigDao(cachedConfigService, probeService);
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/server/test/unit/com/thoughtworks/go/config/CachedFileGoConfigTest.java
+++ b/server/test/unit/com/thoughtworks/go/config/CachedFileGoConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 ThoughtWorks, Inc.
+ * Copyright 2016 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,13 +36,14 @@ public class CachedFileGoConfigTest extends CachedGoConfigTestBase {
         SystemEnvironment env = new SystemEnvironment();
         ConfigRepository configRepository = new ConfigRepository(env);
         configRepository.initialize();
+        GoConfigWriteLock goConfigWriteLock = new GoConfigWriteLock();
         dataSource = new GoFileConfigDataSource(new DoNotUpgrade(), configRepository, env, new TimeProvider(),
                 new ConfigCache(), new ServerVersion(), ConfigElementImplementationRegistryMother.withNoPlugins(),
                 metricsProbeService, serverHealthService);
         serverHealthService = new ServerHealthService();
-        CachedFileGoConfig cachedFileGoConfig = new CachedFileGoConfig(dataSource, serverHealthService);
+        CachedFileGoConfig cachedFileGoConfig = new CachedFileGoConfig(dataSource, serverHealthService, goConfigWriteLock);
         cachedGoConfig = cachedFileGoConfig;
         cachedGoConfig.loadConfigIfNull();
-        configHelper.usingCruiseConfigDao(new GoConfigDao(cachedFileGoConfig, mock(MetricsProbeService.class)));
+        configHelper.usingCruiseConfigDao(new GoConfigDao(cachedFileGoConfig, mock(MetricsProbeService.class), goConfigWriteLock));
     }
 }

--- a/server/test/unit/com/thoughtworks/go/config/CachedFileGoConfigTest.java
+++ b/server/test/unit/com/thoughtworks/go/config/CachedFileGoConfigTest.java
@@ -41,9 +41,9 @@ public class CachedFileGoConfigTest extends CachedGoConfigTestBase {
                 new ConfigCache(), new ServerVersion(), ConfigElementImplementationRegistryMother.withNoPlugins(),
                 metricsProbeService, serverHealthService);
         serverHealthService = new ServerHealthService();
-        CachedFileGoConfig cachedFileGoConfig = new CachedFileGoConfig(dataSource, serverHealthService, goConfigWriteLock);
+        CachedFileGoConfig cachedFileGoConfig = new CachedFileGoConfig(dataSource, serverHealthService);
         cachedGoConfig = cachedFileGoConfig;
         cachedGoConfig.loadConfigIfNull();
-        configHelper.usingCruiseConfigDao(new GoConfigDao(cachedFileGoConfig, mock(MetricsProbeService.class), goConfigWriteLock));
+        configHelper.usingCruiseConfigDao(new GoConfigDao(cachedFileGoConfig, mock(MetricsProbeService.class)));
     }
 }

--- a/server/test/unit/com/thoughtworks/go/config/CachedGoConfigTestBase.java
+++ b/server/test/unit/com/thoughtworks/go/config/CachedGoConfigTestBase.java
@@ -297,14 +297,14 @@ public abstract class CachedGoConfigTestBase {
     @Test
     public void shouldReturnDefaultCruiseConfigIfLoadingTheConfigFailsForTheFirstTime() throws Exception {
         configHelper.writeXmlToConfigFile("invalid-xml");
-        cachedGoConfig = new CachedFileGoConfig(dataSource, new ServerHealthService(), new GoConfigWriteLock());
+        cachedGoConfig = new CachedFileGoConfig(dataSource, new ServerHealthService());
         assertThat(cachedGoConfig.currentConfig(), Matchers.<CruiseConfig>is(new BasicCruiseConfig()));
     }
 
     @Test
     public void shouldLoadConfigHolderIfNotAvailable() throws Exception {
         configHelper.addPipeline("foo", "bar");
-        cachedGoConfig = new CachedFileGoConfig(dataSource, new ServerHealthService(), new GoConfigWriteLock());
+        cachedGoConfig = new CachedFileGoConfig(dataSource, new ServerHealthService());
         dataSource.reloadIfModified();
         cachedGoConfig.forceReload();
         GoConfigHolder loaded = cachedGoConfig.loadConfigHolder();
@@ -317,7 +317,7 @@ public abstract class CachedGoConfigTestBase {
         CruiseConfig cruiseConfig = configHelper.load();
         addPipelineWithParams(cruiseConfig);
         configHelper.writeConfigFile(cruiseConfig);
-        cachedGoConfig = new CachedFileGoConfig(dataSource, new ServerHealthService(), new GoConfigWriteLock());
+        cachedGoConfig = new CachedFileGoConfig(dataSource, new ServerHealthService());
         dataSource.reloadIfModified();
 
         cachedGoConfig.forceReload();
@@ -407,7 +407,7 @@ public abstract class CachedGoConfigTestBase {
 
     @Test public void shouldNotNotifyWhenConfigIsNullDuringRegistration() throws Exception {
         configHelper.deleteConfigFile();
-        cachedGoConfig = new CachedFileGoConfig(dataSource, new ServerHealthService(), new GoConfigWriteLock());
+        cachedGoConfig = new CachedFileGoConfig(dataSource, new ServerHealthService());
         final ConfigChangedListener listener = mock(ConfigChangedListener.class);
         cachedGoConfig.registerListener(listener);
         verifyNoMoreInteractions(listener);
@@ -420,7 +420,7 @@ public abstract class CachedGoConfigTestBase {
         CruiseConfig currentConfig = GoConfigMother.configWithPipelines("p1");
         GoFileConfigDataSource.GoConfigSaveResult goConfigSaveResult = new GoFileConfigDataSource.GoConfigSaveResult(new GoConfigHolder(currentConfig, currentConfig), ConfigSaveState.MERGED);
         when(goFileConfigDataSource.writeWithLock(argThat(is(updateConfigCommand)), any(GoConfigHolder.class))).thenReturn(goConfigSaveResult);
-        cachedGoConfig = new CachedFileGoConfig(goFileConfigDataSource, serverHealthService, new GoConfigWriteLock());
+        cachedGoConfig = new CachedFileGoConfig(goFileConfigDataSource, serverHealthService);
 
         ConfigSaveState configSaveState = cachedGoConfig.writeWithLock(updateConfigCommand);
         assertThat(configSaveState, is(ConfigSaveState.MERGED));
@@ -433,7 +433,7 @@ public abstract class CachedGoConfigTestBase {
         CruiseConfig currentConfig = GoConfigMother.configWithPipelines("p1");
         GoFileConfigDataSource.GoConfigSaveResult goConfigSaveResult = new GoFileConfigDataSource.GoConfigSaveResult(new GoConfigHolder(currentConfig, currentConfig), ConfigSaveState.UPDATED);
         when(goFileConfigDataSource.writeWithLock(argThat(is(updateConfigCommand)), any(GoConfigHolder.class))).thenReturn(goConfigSaveResult);
-        cachedGoConfig = new CachedFileGoConfig(goFileConfigDataSource, serverHealthService, new GoConfigWriteLock());
+        cachedGoConfig = new CachedFileGoConfig(goFileConfigDataSource, serverHealthService);
 
         ConfigSaveState configSaveState = cachedGoConfig.writeWithLock(updateConfigCommand);
         assertThat(configSaveState, is(ConfigSaveState.UPDATED));

--- a/server/test/unit/com/thoughtworks/go/config/CachedGoConfigTestBase.java
+++ b/server/test/unit/com/thoughtworks/go/config/CachedGoConfigTestBase.java
@@ -1,5 +1,5 @@
-/*************************GO-LICENSE-START*********************************
- * Copyright 2014 ThoughtWorks, Inc.
+/*
+ * Copyright 2016 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *************************GO-LICENSE-END***********************************/
+ */
 
 package com.thoughtworks.go.config;
 
@@ -297,14 +297,14 @@ public abstract class CachedGoConfigTestBase {
     @Test
     public void shouldReturnDefaultCruiseConfigIfLoadingTheConfigFailsForTheFirstTime() throws Exception {
         configHelper.writeXmlToConfigFile("invalid-xml");
-        cachedGoConfig = new CachedFileGoConfig(dataSource, new ServerHealthService());
+        cachedGoConfig = new CachedFileGoConfig(dataSource, new ServerHealthService(), new GoConfigWriteLock());
         assertThat(cachedGoConfig.currentConfig(), Matchers.<CruiseConfig>is(new BasicCruiseConfig()));
     }
 
     @Test
     public void shouldLoadConfigHolderIfNotAvailable() throws Exception {
         configHelper.addPipeline("foo", "bar");
-        cachedGoConfig = new CachedFileGoConfig(dataSource, new ServerHealthService());
+        cachedGoConfig = new CachedFileGoConfig(dataSource, new ServerHealthService(), new GoConfigWriteLock());
         dataSource.reloadIfModified();
         cachedGoConfig.forceReload();
         GoConfigHolder loaded = cachedGoConfig.loadConfigHolder();
@@ -317,7 +317,7 @@ public abstract class CachedGoConfigTestBase {
         CruiseConfig cruiseConfig = configHelper.load();
         addPipelineWithParams(cruiseConfig);
         configHelper.writeConfigFile(cruiseConfig);
-        cachedGoConfig = new CachedFileGoConfig(dataSource, new ServerHealthService());
+        cachedGoConfig = new CachedFileGoConfig(dataSource, new ServerHealthService(), new GoConfigWriteLock());
         dataSource.reloadIfModified();
 
         cachedGoConfig.forceReload();
@@ -407,7 +407,7 @@ public abstract class CachedGoConfigTestBase {
 
     @Test public void shouldNotNotifyWhenConfigIsNullDuringRegistration() throws Exception {
         configHelper.deleteConfigFile();
-        cachedGoConfig = new CachedFileGoConfig(dataSource, new ServerHealthService());
+        cachedGoConfig = new CachedFileGoConfig(dataSource, new ServerHealthService(), new GoConfigWriteLock());
         final ConfigChangedListener listener = mock(ConfigChangedListener.class);
         cachedGoConfig.registerListener(listener);
         verifyNoMoreInteractions(listener);
@@ -420,7 +420,7 @@ public abstract class CachedGoConfigTestBase {
         CruiseConfig currentConfig = GoConfigMother.configWithPipelines("p1");
         GoFileConfigDataSource.GoConfigSaveResult goConfigSaveResult = new GoFileConfigDataSource.GoConfigSaveResult(new GoConfigHolder(currentConfig, currentConfig), ConfigSaveState.MERGED);
         when(goFileConfigDataSource.writeWithLock(argThat(is(updateConfigCommand)), any(GoConfigHolder.class))).thenReturn(goConfigSaveResult);
-        cachedGoConfig = new CachedFileGoConfig(goFileConfigDataSource, serverHealthService);
+        cachedGoConfig = new CachedFileGoConfig(goFileConfigDataSource, serverHealthService, new GoConfigWriteLock());
 
         ConfigSaveState configSaveState = cachedGoConfig.writeWithLock(updateConfigCommand);
         assertThat(configSaveState, is(ConfigSaveState.MERGED));
@@ -433,7 +433,7 @@ public abstract class CachedGoConfigTestBase {
         CruiseConfig currentConfig = GoConfigMother.configWithPipelines("p1");
         GoFileConfigDataSource.GoConfigSaveResult goConfigSaveResult = new GoFileConfigDataSource.GoConfigSaveResult(new GoConfigHolder(currentConfig, currentConfig), ConfigSaveState.UPDATED);
         when(goFileConfigDataSource.writeWithLock(argThat(is(updateConfigCommand)), any(GoConfigHolder.class))).thenReturn(goConfigSaveResult);
-        cachedGoConfig = new CachedFileGoConfig(goFileConfigDataSource, serverHealthService);
+        cachedGoConfig = new CachedFileGoConfig(goFileConfigDataSource, serverHealthService, new GoConfigWriteLock());
 
         ConfigSaveState configSaveState = cachedGoConfig.writeWithLock(updateConfigCommand);
         assertThat(configSaveState, is(ConfigSaveState.UPDATED));

--- a/server/test/unit/com/thoughtworks/go/config/MergedGoConfigTest.java
+++ b/server/test/unit/com/thoughtworks/go/config/MergedGoConfigTest.java
@@ -67,7 +67,7 @@ public class MergedGoConfigTest extends CachedGoConfigTestBase {
                 new ConfigCache(), new ServerVersion(), ConfigElementImplementationRegistryMother.withNoPlugins(),
                 metricsProbeService, serverHealthService);
         serverHealthService = new ServerHealthService();
-        cachedFileGoConfig = new CachedFileGoConfig(dataSource, serverHealthService, goConfigWriteLock);
+        cachedFileGoConfig = new CachedFileGoConfig(dataSource, serverHealthService);
         cachedFileGoConfig.loadConfigIfNull();
 
         configPluginService = mock(GoConfigPluginService.class);
@@ -81,7 +81,7 @@ public class MergedGoConfigTest extends CachedGoConfigTestBase {
         partials = new GoPartialConfig(repoConfigDataSource,configWatchList);
 
         cachedGoConfig = new MergedGoConfig(serverHealthService,cachedFileGoConfig, partials);
-        configHelper.usingCruiseConfigDao(new GoConfigDao(cachedFileGoConfig, metricsProbeService, goConfigWriteLock));
+        configHelper.usingCruiseConfigDao(new GoConfigDao(cachedFileGoConfig, metricsProbeService));
     }
 
     @Test

--- a/server/test/unit/com/thoughtworks/go/config/MergedGoConfigTest.java
+++ b/server/test/unit/com/thoughtworks/go/config/MergedGoConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 ThoughtWorks, Inc.
+ * Copyright 2016 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package com.thoughtworks.go.config;
 
 import com.thoughtworks.go.config.remote.ConfigRepoConfig;
@@ -61,11 +62,12 @@ public class MergedGoConfigTest extends CachedGoConfigTestBase {
         SystemEnvironment env = new SystemEnvironment();
         ConfigRepository configRepository = new ConfigRepository(env);
         configRepository.initialize();
+        GoConfigWriteLock goConfigWriteLock = new GoConfigWriteLock();
         dataSource = new GoFileConfigDataSource(new DoNotUpgrade(), configRepository, env, new TimeProvider(),
                 new ConfigCache(), new ServerVersion(), ConfigElementImplementationRegistryMother.withNoPlugins(),
                 metricsProbeService, serverHealthService);
         serverHealthService = new ServerHealthService();
-        cachedFileGoConfig = new CachedFileGoConfig(dataSource, serverHealthService);
+        cachedFileGoConfig = new CachedFileGoConfig(dataSource, serverHealthService, goConfigWriteLock);
         cachedFileGoConfig.loadConfigIfNull();
 
         configPluginService = mock(GoConfigPluginService.class);
@@ -79,7 +81,7 @@ public class MergedGoConfigTest extends CachedGoConfigTestBase {
         partials = new GoPartialConfig(repoConfigDataSource,configWatchList);
 
         cachedGoConfig = new MergedGoConfig(serverHealthService,cachedFileGoConfig, partials);
-        configHelper.usingCruiseConfigDao(new GoConfigDao(cachedFileGoConfig, metricsProbeService));
+        configHelper.usingCruiseConfigDao(new GoConfigDao(cachedFileGoConfig, metricsProbeService, goConfigWriteLock));
     }
 
     @Test


### PR DESCRIPTION
…g save triggers to handle the deadlock error. Also, MD5 wasn't being set during config save api calls