### PR TITLE
Fix some compatibility when installing RPM packages on RHEL5 and derivatives (#1766)

### DIFF
--- a/installers/agent/rpm/go-agent.spec
+++ b/installers/agent/rpm/go-agent.spec
@@ -1,3 +1,12 @@
+%define __spec_install_pre %{___build_pre}
+
+# use md5 for digest algorithm because it works on most platforms
+%define _binary_filedigest_algorithm 1
+%define _build_binary_file_digest_algo 1
+
+# use gzip for compression because it works on most platforms
+%define _binary_payload w9.gzdio
+
 Name: go-agent
 Version: @VERSION@
 Release: @RELEASE@
@@ -99,4 +108,3 @@ fi
 /etc/init.d/go-agent
 %config /etc/default/go-agent
 %config /var/lib/go-agent/log4j.properties
-

--- a/installers/server/rpm/go-server.spec
+++ b/installers/server/rpm/go-server.spec
@@ -1,3 +1,12 @@
+%define __spec_install_pre %{___build_pre}
+
+# use md5 for digest algorithm because it works on most platforms
+%define _binary_filedigest_algorithm 1
+%define _build_binary_file_digest_algo 1
+
+# use gzip for compression because it works on most platforms
+%define _binary_payload w9.gzdio
+
 Name: go-server
 Version: @VERSION@
 Release: @RELEASE@

--- a/tasks/buildr_extensions.rake
+++ b/tasks/buildr_extensions.rake
@@ -335,7 +335,7 @@ module RpmPackageHelper
     task :rpm => depend_on do
       mkdir_p rpm_ctrl_dir, :mode => 0755
       sub_and_copy_with_mode rpm_metadata(package), "#{package_name}.spec", rpm_ctrl_dir, "#{package_name}.spec", {:VERSION => VERSION_NUMBER, :RELEASE => RELEASE_REVISION, :ROOT => linux_dir, :pre => shared_pre, :post => shared_post, :rpm_pre => shared_rpm_pre, :rpm_post => shared_rpm_post}, 0644
-      sh "fakeroot rpmbuild --buildroot #{linux_dir} --define '_rpmdir #{rpm_ctrl_dir}' --define '__spec_install_pre %{___build_pre}' -bb --target noarch #{rpm_ctrl_dir}/#{package_name}.spec"
+      sh "fakeroot rpmbuild --buildroot #{linux_dir} --define '_rpmdir #{rpm_ctrl_dir}' -bb --target noarch #{rpm_ctrl_dir}/#{package_name}.spec"
       cp_r File.join(rpm_ctrl_dir, "noarch", "#{package_name}-#{VERSION_NUMBER}-#{RELEASE_REVISION}.noarch.rpm"), _(:redhat_package)
     end
   end


### PR DESCRIPTION
This happens when packaging on RHEL6/CentOS6 distro using the macros
defined in `redhat-rpm-config`. This PR does two things —

* Use MD5 (instead of SHA256) for file digests
* Use gzip (instead of uses `xz`) for RPM compression