### PR TITLE
Isolating the new jasmine tests 

### DIFF
--- a/server/prepare_go_server_webapp.rake
+++ b/server/prepare_go_server_webapp.rake
@@ -190,6 +190,16 @@ task :jasmine_tests do
       'CLASSPATH'           => classpath
     }
     sh_with_environment("#{ruby_executable} -S ./bin/rake jasmine:ci", environment.merge('JASMINE_CONFIG_PATH' => './spec/javascripts/support/jasmine-ci-old.yml'))
+  end
+end
+
+task :new_jasmine_tests do
+  cd rails_root do
+    environment = {
+      'RAILS_ENV'           => 'test',
+      'REPORTERS'           => 'console,junit',
+      'CLASSPATH'           => classpath
+    }
     sh_with_environment("#{ruby_executable} -S ./bin/rake jasmine:ci", environment.merge("JASMINE_CONFIG_PATH" => './spec/javascripts/support/jasmine-ci-new.yml', 'REQUIRE_JS' => 'true'))
   end
 end


### PR DESCRIPTION
As they hang on internet explorer making the tests flaky. As this is an experimental feature which will be toggled off (or with limited access) we'll have to monitor this better as a separate task.

Once this is merged we'll set up a separate job for the new tests on windows and linux.