### PR TITLE
Improves the Material API notification error message

### DIFF
--- a/server/src/com/thoughtworks/go/server/materials/MaterialUpdateService.java
+++ b/server/src/com/thoughtworks/go/server/materials/MaterialUpdateService.java
@@ -133,7 +133,7 @@ public class MaterialUpdateService implements GoMessageListener<MaterialUpdateCo
             final Set<Material> prunedMaterialList = materialTypeImplementer.prune(allUniquePostCommitSchedulableMaterials, attributes);
 
             if (prunedMaterialList.isEmpty()) {
-                result.notFound(LocalizedMessage.string("MATERIAL_NOT_FOUND"), HealthStateType.general(HealthStateScope.GLOBAL));
+                result.notFound(LocalizedMessage.string("MATERIAL_SUITABLE_FOR_NOTIFICATION_NOT_FOUND"), HealthStateType.general(HealthStateScope.GLOBAL));
                 return;
             }
 

--- a/server/test/unit/com/thoughtworks/go/server/materials/MaterialUpdateServiceTest.java
+++ b/server/test/unit/com/thoughtworks/go/server/materials/MaterialUpdateServiceTest.java
@@ -205,7 +205,7 @@ public class MaterialUpdateServiceTest {
         service.notifyMaterialsForUpdate(username, params, result);
 
         HttpLocalizedOperationResult operationResult = new HttpLocalizedOperationResult();
-        operationResult.notFound(LocalizedMessage.string("MATERIAL_NOT_FOUND"), HealthStateType.general(HealthStateScope.GLOBAL));
+        operationResult.notFound(LocalizedMessage.string("MATERIAL_SUITABLE_FOR_NOTIFICATION_NOT_FOUND"), HealthStateType.general(HealthStateScope.GLOBAL));
 
         assertThat(result, is(operationResult));
 

--- a/server/webapp/localize.xml
+++ b/server/webapp/localize.xml
@@ -61,7 +61,7 @@
     <entry key="PIPELINE_CANNOT_VIEW">You do not have view permissions for pipeline ''{0}''.</entry>
     <entry key="PIPELINE_CANNOT_OPERATE">You do not have operate permissions for pipeline ''{0}''.</entry>
     <entry key="MATERIAL_WITH_FINGERPRINT_NOT_FOUND">Pipeline ''{0}'' does not contain material with fingerprint ''{1}''.</entry>
-    <entry key="MATERIAL_NOT_FOUND">Unable to find material.</entry>
+    <entry key="MATERIAL_SUITABLE_FOR_NOTIFICATION_NOT_FOUND">Unable to find material. Materials must be configured not to poll for new changes before they can be used with the notification mechanism.</entry>
     <entry key="MATERIAL_SCHEDULE_NOTIFICATION_ACCEPTED">The material is now scheduled for an update. Please check relevant pipeline(s) for status.</entry>
     <entry key="MATERIAL_CANNOT_VIEW">You do not have view permissions for material with fingerprint ''{0}''.</entry>
     <entry key="MATERIAL_CONFIG_WITH_FINGERPRINT_NOT_FOUND">Material with fingerprint ''{0}'' not found.</entry>


### PR DESCRIPTION
Fixes #1787 by improving the error message when the API receives a call to notify a material which either does not exist or can not be notified, explaining that this might be because the material is set to autoUpdate. Changes the name of the message to better reflect it’s content.