### PR TITLE
Disable `format` on all new API routes (#1801)

### DIFF
--- a/server/webapp/WEB-INF/rails.new/config/routes.rb
+++ b/server/webapp/WEB-INF/rails.new/config/routes.rb
@@ -216,11 +216,11 @@ Go::Application.routes.draw do
   end
   match "environments(.:format)" => 'environments#index', defaults: {:format => :html}, via: [:post, :get], as: :environments
 
-  scope :api, as: :apiv1 do
+  scope :api, as: :apiv1, format: false do
     api_version(:module => 'ApiV1', header: {name: 'Accept', value: 'application/vnd.go.cd.v1+json'}) do
       resources :backups, only: [:create]
 
-      resources :users, param: :login_name, only: [:create, :index, :show, :destroy], :format => false, constraints: { login_name: /(.*?)/ } do
+      resources :users, param: :login_name, only: [:create, :index, :show, :destroy], constraints: { login_name: /(.*?)/ } do
         patch :update, on: :member
       end
 
@@ -248,7 +248,7 @@ Go::Application.routes.draw do
     end
   end
 
-  scope :api, as: :apiv2 do
+  scope :api, as: :apiv2, format: false do
     api_version(:module => 'ApiV2', header: {name: 'Accept', value: 'application/vnd.go.cd.v2+json'}) do
       resources :agents, param: :uuid, except: [:new, :create, :edit, :update] do
         patch :update, on: :member


### PR DESCRIPTION
Before —

```
$ rake --rakefile server/run_rspec_tests.rake exec command="rake routes" | egrep '(Controller#Action)|(:format.*api_v)'
                              Prefix Verb     URI Pattern                                                                       Controller#Action
                       apiv1_backups POST     /api/backups(.:format)                                                            api_v1/backups#create
                         apiv1_agent PATCH    /api/agents/:uuid(.:format)                                                       api_v1/agents#update
                        apiv1_agents GET      /api/agents(.:format)                                                             api_v1/agents#index
                                     GET      /api/agents/:uuid(.:format)                                                       api_v1/agents#show
                                     DELETE   /api/agents/:uuid(.:format)                                                       api_v1/agents#destroy
               apiv1_admin_pipelines POST     /api/admin/pipelines(.:format)                                                    api_v1/admin/pipelines#create
                apiv1_admin_pipeline GET      /api/admin/pipelines/:name(.:format)                                              api_v1/admin/pipelines#show
                                     PATCH    /api/admin/pipelines/:name(.:format)                                              api_v1/admin/pipelines#update
                                     PUT      /api/admin/pipelines/:name(.:format)                                              api_v1/admin/pipelines#update
 apiv1_stage_instance_by_counter_api GET      /api/stages/:pipeline_name/:pipeline_counter/:stage_name/:stage_counter(.:format) api_v1/stages#show {:pipeline_name=>/[\w\-][\w\-.]*/, :pipeline_counter=>/-?\d+/, :stage_name=>/[\w\-][\w\-.]*/, :stage_counter=>/-?\d+/}
             apiv1_stage_history_api GET      /api/stages/:pipeline_name/:stage_name(.:format)                                  api_v1/stages#history {:pipeline_name=>/[\w\-][\w\-.]*/, :stage_name=>/[\w\-][\w\-.]*/}
                apiv1_show_dashboard GET      /api/dashboard(.:format)                                                          api_v1/dashboard#dashboard
                 apiv1_material_test POST     /api/material_test(.:format)                                                      api_v1/material_test#test
            apiv1_stale_version_info GET      /api/version_infos/stale(.:format)                                                api_v1/version_infos#stale
    apiv1_update_server_version_info PATCH    /api/version_infos/go_server(.:format)                                            api_v1/version_infos#update_server
                               apiv1          /api/*url(.:format)                                                               api_v1/errors#not_found
                         apiv2_agent PATCH    /api/agents/:uuid(.:format)                                                       api_v2/agents#update
                        apiv2_agents GET      /api/agents(.:format)                                                             api_v2/agents#index
                                     GET      /api/agents/:uuid(.:format)                                                       api_v2/agents#show
                                     DELETE   /api/agents/:uuid(.:format)                                                       api_v2/agents#destroy
                               apiv2          /api/*url(.:format)                                                               api_v2/errors#not_found
```

After:

```
$ rake --rakefile server/run_rspec_tests.rake exec command="rake routes" | egrep '(Controller#Action)|(:format.*api_v)'
                              Prefix Verb     URI Pattern                                                                       Controller#Action
```