### PR TITLE
Select a range of agents via shift-clicking checkboxes

### DIFF
--- a/server/webapp/WEB-INF/rails.new/app/views/agents/_agents_table.html.erb
+++ b/server/webapp/WEB-INF/rails.new/app/views/agents/_agents_table.html.erb
@@ -8,18 +8,38 @@
 
 <script type="text/javascript">
 Util.on_load(function() {
-    jQuery("#select_all_agents").live('click',function() {
+    var $allAgentsSelector = jQuery("#select_all_agents")
+
+    $allAgentsSelector.live('click',function() {
         var val = this.checked;
         jQuery(".agent_select").each(function() {
             this.checked = val;
         });
     });
 
-    jQuery("input.agent_select").live("click", function() {
-        var unchecked_check_boxes = jQuery("input.agent_select:not(:checked)");
-        if(unchecked_check_boxes.length > 0) {
-            jQuery("#select_all_agents").removeAttr("checked");
-        }
+    var lastChecked = null;
+
+    jQuery(document).ready(function() {
+        jQuery('.agent_select').live('click', function(e) {
+            if (!this.checked) {
+                $allAgentsSelector.removeAttr("checked");
+            }
+
+            if (!lastChecked) {
+                lastChecked = this;
+                return;
+            }
+
+            var $checkboxes = jQuery('.agent_select');
+            var start = $checkboxes.index(this);
+            var end = $checkboxes.index(lastChecked);
+
+            if (e.shiftKey) {
+                $checkboxes.slice(Math.min(start, end), Math.max(start, end) + 1).prop('checked', lastChecked.checked);
+            }
+
+            lastChecked = this;
+        });
     });
 })
 


### PR DESCRIPTION
1. If you tick or untick a checkbox, then press shift while checking
   a different checkbox, all the agents between the two will be ticked
   or unticked to match the previous tick.
2. A bit of optimisation on caching jquery selectors
3. I tried to use `jQuery().click...` but the handlers would eventually
   be removed from the elements, forcing me to use `live`, which may
   not be ideal.