### PR TITLE
Select a range of agents via shift-clicking checkboxes

### DIFF
--- a/server/webapp/WEB-INF/rails.new/app/views/agents/_agents_table.html.erb
+++ b/server/webapp/WEB-INF/rails.new/app/views/agents/_agents_table.html.erb
@@ -10,9 +10,7 @@
 Util.on_load(function() {
     jQuery("#select_all_agents").live('click',function() {
         var val = this.checked;
-        jQuery(".agent_select").each(function() {
-            this.checked = val;
-        });
+        jQuery(".agent_select").prop("checked", val);
     });
 
     var lastChecked = null;
@@ -20,7 +18,7 @@ Util.on_load(function() {
     jQuery(document).ready(function() {
         jQuery('.agent_select').live('click', function(e) {
             if (!this.checked) {
-                jQuery("#select_all_agents").removeAttr("checked");
+                jQuery("#select_all_agents").prop("checked", false);
             }
 
             if (!lastChecked) {

--- a/server/webapp/WEB-INF/rails.new/app/views/agents/_agents_table.html.erb
+++ b/server/webapp/WEB-INF/rails.new/app/views/agents/_agents_table.html.erb
@@ -8,33 +8,33 @@
 
 <script type="text/javascript">
 Util.on_load(function() {
-    jQuery("#select_all_agents").live('click',function() {
-        var val = this.checked;
-        jQuery(".agent_select").prop("checked", val);
+    jQuery('#body_content').on('click', '#select_all_agents', function() {
+        jQuery('.agent_select').prop("checked", $(this).checked);
     });
 
     var lastChecked = null;
 
     jQuery(document).ready(function() {
-        jQuery('.agent_select').live('click', function(e) {
-            if (!this.checked) {
+        jQuery('#body_content').on('click', '.agent_select', function(e) {
+            $this = $(this);
+            if (!$this.checked) {
                 jQuery("#select_all_agents").prop("checked", false);
             }
 
             if (!lastChecked) {
-                lastChecked = this;
+                lastChecked = $this;
                 return;
             }
 
             var $checkboxes = jQuery('.agent_select');
-            var start = $checkboxes.index(this);
+            var start = $checkboxes.index($this);
             var end = $checkboxes.index(lastChecked);
 
             if (e.shiftKey) {
                 $checkboxes.slice(Math.min(start, end), Math.max(start, end) + 1).prop('checked', lastChecked.checked);
             }
 
-            lastChecked = this;
+            lastChecked = $this;
         });
     });
 })

--- a/server/webapp/WEB-INF/rails.new/app/views/agents/_agents_table.html.erb
+++ b/server/webapp/WEB-INF/rails.new/app/views/agents/_agents_table.html.erb
@@ -15,11 +15,29 @@ Util.on_load(function() {
         });
     });
 
-    jQuery("input.agent_select").live("click", function() {
-        var unchecked_check_boxes = jQuery("input.agent_select:not(:checked)");
-        if(unchecked_check_boxes.length > 0) {
-            jQuery("#select_all_agents").removeAttr("checked");
-        }
+    var lastChecked = null;
+
+    jQuery(document).ready(function() {
+        jQuery('.agent_select').live('click', function(e) {
+            if (!this.checked) {
+                jQuery("#select_all_agents").removeAttr("checked");
+            }
+
+            if (!lastChecked) {
+                lastChecked = this;
+                return;
+            }
+
+            var $checkboxes = jQuery('.agent_select');
+            var start = $checkboxes.index(this);
+            var end = $checkboxes.index(lastChecked);
+
+            if (e.shiftKey) {
+                $checkboxes.slice(Math.min(start, end), Math.max(start, end) + 1).prop('checked', lastChecked.checked);
+            }
+
+            lastChecked = this;
+        });
     });
 })
 


### PR DESCRIPTION
![screencast-uywrw](https://cloud.githubusercontent.com/assets/76716/12364880/de7a0626-bb96-11e5-878e-6ee8602e88ec.gif)

1. If you tick or untick a checkbox, then press shift while checking
   a different checkbox, all the agents between the two will be ticked
   or unticked to match the previous tick.
2. I tried to use `jQuery().click...` but the handlers would eventually
   be removed from the elements, forcing me to use `live`, which may
   not be ideal.
3. A small improvement in the check-all/none code.