### PR TITLE
Let Subversion use the password out of the store

### DIFF
--- a/common/src/com/thoughtworks/go/domain/materials/svn/SvnCommand.java
+++ b/common/src/com/thoughtworks/go/domain/materials/svn/SvnCommand.java
@@ -255,10 +255,7 @@ public class SvnCommand extends SCMCommand implements Subversion {
     private void addCredentials(CommandLine line, StringArgument svnUserName, PasswordArgument svnPassword) {
         if (!StringUtils.isBlank(svnUserName.forCommandline())) {
             line.withArgs("--username", svnUserName.forCommandline());
-            if (StringUtils.isBlank(svnPassword.forCommandline())) {
-                line.withArg(String.format("--password="));
-            }
-            else {
+            if (!StringUtils.isBlank(svnPassword.forCommandline())) {
                 line.withArg("--password");
                 line.withArg(svnPassword);
             }

--- a/common/test/unit/com/thoughtworks/go/domain/materials/svn/SvnCommandTest.java
+++ b/common/test/unit/com/thoughtworks/go/domain/materials/svn/SvnCommandTest.java
@@ -452,10 +452,10 @@ public class SvnCommandTest {
     }
 
     @Test
-    public void shouldAddEmptyPasswordWhenUsernameIsProvidedWithNoPassword() throws IOException {
+    public void shouldNotAddEmptyPasswordWhenUsernameIsProvidedWithNoPassword() throws IOException {
         SvnCommand command = new SvnCommand(null, "url", "shilpaIsGreat", null, false);
         CommandArgument argument = new StringArgument(String.format("--password="));
-        assertThat(command.buildSvnLogCommandForLatestOne().getArguments(), hasItem(argument));
+        assertThat(command.buildSvnLogCommandForLatestOne().getArguments(), not(hasItem(argument)));
     }
 
     @Test


### PR DESCRIPTION
The current command line causes the svn updates to fail, with or without using a password store (not plaintext).

Windows: `password-stores = windows-cryptoapi`
Ubuntu: `password-stores = gnome-keyring`

Windows:

```
16:17:00.108 [go] Start updating ...repo at revision #### from http://my.../trunk
16:17:01.342 Updating 'pipelines\My\first':
16:17:01.373 STDERR: svn: E170013: Unable to connect to a repository at URL 'http://my.../trunk'
16:17:01.373 STDERR: svn: E215004: No more credentials or we tried too many times.
16:17:01.373 STDERR: Authentication failed
16:17:01.404 Failed to run svn --username my_username --password= update --non-interactive -r #### c:\...\pipelines\My\first
                                                      ^^^^^^^^^^^
16:17:01.467 [go] Job completed ...job_name on DESKTOP-MY_D [...\agent1]
```

same happens on Ubuntu. Without supplying the empty password parameter, the password caching doesn't fail at least on Windows.

An integration test is highly dependent on the environment: setting up different credential stores, checking out with full credentials, then updating to different revisions, etc. Is there a strategy already to test that?