### PR TITLE
Fixed the issue of the flyweight folder getting cloned repeatedly (#1785)

### DIFF
--- a/common/src/com/thoughtworks/go/config/materials/git/GitMaterial.java
+++ b/common/src/com/thoughtworks/go/config/materials/git/GitMaterial.java
@@ -54,7 +54,7 @@ public class GitMaterial extends ScmMaterial {
     private static final Logger LOG = Logger.getLogger(GitMaterial.class);
 
     private UrlArgument url;
-    private String branch;
+    private String branch = GitMaterialConfig.DEFAULT_BRANCH;
     private String submoduleFolder;
 
     //TODO: use iBatis to set the type for us, and we can get rid of this field.
@@ -76,7 +76,9 @@ public class GitMaterial extends ScmMaterial {
 
     public GitMaterial(String url, String branch) {
         this(url);
-        this.branch = (branch == null)? GitMaterialConfig.DEFAULT_BRANCH : branch;
+        if(branch != null) {
+            this.branch = branch;
+        }
     }
 
     public GitMaterial(String url, String branch, String folder) {

--- a/config/config-api/src/com/thoughtworks/go/config/materials/git/GitMaterialConfig.java
+++ b/config/config-api/src/com/thoughtworks/go/config/materials/git/GitMaterialConfig.java
@@ -34,7 +34,7 @@ public class GitMaterialConfig extends ScmMaterialConfig {
     private UrlArgument url;
 
     @ConfigAttribute(value = "branch")
-    private String branch;
+    private String branch = DEFAULT_BRANCH;
 
     private String submoduleFolder;
 
@@ -54,13 +54,17 @@ public class GitMaterialConfig extends ScmMaterialConfig {
 
     public GitMaterialConfig(String url, String branch) {
         this(url);
-        this.branch = (branch == null)? DEFAULT_BRANCH : branch;
+        if(branch != null) {
+            this.branch = branch;
+        }
     }
 
     public GitMaterialConfig(UrlArgument url, String branch, String submoduleFolder, boolean autoUpdate, Filter filter, String folder, CaseInsensitiveString name) {
         super(name, filter, folder, autoUpdate, TYPE, new ConfigErrors());
         this.url = url;
-        this.branch = (branch == null)? DEFAULT_BRANCH : branch;
+        if(branch != null) {
+            this.branch = branch;
+        }
         this.submoduleFolder = submoduleFolder;
     }
 


### PR DESCRIPTION

* Defaults to master when branch is saved as empty from the UI.
* Added tests to handle null Url and branch at the time of GitMaterialConfig object creation.
* Defaults branch to master when it is saved as empty while creating a pipeline using the api.
* Split the tests and removed redundant assertions, fixed failing tests.