### PR TITLE
for #871 output env variable once instead of per task

### DIFF
--- a/common/src/com/thoughtworks/go/remote/work/BuildWork.java
+++ b/common/src/com/thoughtworks/go/remote/work/BuildWork.java
@@ -134,8 +134,10 @@ public class BuildWork implements Work {
         goPublisher.consumeLineWithPrefix(format("Job Started: %s\n", new SimpleDateFormat("yyyy-MM-dd HH:mm:ss z").format(timeProvider.currentTime())));
 
         prepareJob(agentIdentifier, packageAsRepositoryExtension, scmExtension);
+
         setupEnvrionmentContext(environmentVariableContext);
         plan.applyTo(environmentVariableContext);
+        dumpEnviromentVariables(environmentVariableContext);
 
         if (this.goPublisher.isIgnored()) {
             this.goPublisher.reportAction("Job is cancelled");
@@ -145,6 +147,12 @@ public class BuildWork implements Work {
         JobResult result = buildJob(environmentVariableContext);
         completeJob(result);
         return result;
+    }
+
+    private void dumpEnviromentVariables(EnvironmentVariableContext environmentVariableContext) {
+        for(String line : environmentVariableContext.report()) {
+            goPublisher.consumeLine(line);
+        }
     }
 
     private void prepareJob(AgentIdentifier agentIdentifier, PackageAsRepositoryExtension packageAsRepositoryExtension, SCMExtension scmExtension) {

--- a/common/src/com/thoughtworks/go/remote/work/BuildWork.java
+++ b/common/src/com/thoughtworks/go/remote/work/BuildWork.java
@@ -28,6 +28,7 @@ import com.thoughtworks.go.remote.AgentIdentifier;
 import com.thoughtworks.go.remote.BuildRepositoryRemote;
 import com.thoughtworks.go.server.service.AgentBuildingInfo;
 import com.thoughtworks.go.server.service.AgentRuntimeInfo;
+import com.thoughtworks.go.util.ProcessManager;
 import com.thoughtworks.go.util.SystemEnvironment;
 import com.thoughtworks.go.util.TimeProvider;
 import com.thoughtworks.go.util.command.EnvironmentVariableContext;
@@ -45,6 +46,7 @@ import java.net.SocketTimeoutException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.List;
+import java.util.Set;
 
 import static com.thoughtworks.go.util.ExceptionUtils.bomb;
 import static com.thoughtworks.go.util.ExceptionUtils.messageOf;
@@ -137,7 +139,7 @@ public class BuildWork implements Work {
 
         setupEnvrionmentContext(environmentVariableContext);
         plan.applyTo(environmentVariableContext);
-        dumpEnviromentVariables(environmentVariableContext);
+        dumpEnvironmentVariables(environmentVariableContext);
 
         if (this.goPublisher.isIgnored()) {
             this.goPublisher.reportAction("Job is cancelled");
@@ -149,9 +151,12 @@ public class BuildWork implements Work {
         return result;
     }
 
-    private void dumpEnviromentVariables(EnvironmentVariableContext environmentVariableContext) {
-        for(String line : environmentVariableContext.report()) {
-            goPublisher.consumeLine(line);
+    private void dumpEnvironmentVariables(EnvironmentVariableContext environmentVariableContext) {
+        Set<String> processLevelEnvVariables = ProcessManager.getInstance().environmentVariableNames();
+        List<String> report = environmentVariableContext.report(processLevelEnvVariables);
+        for (int i = 0; i < report.size(); i++) {
+            String line = report.get(i);
+            goPublisher.consumeLine((i == report.size() - 1) ? line + "\n" : line);
         }
     }
 

--- a/common/src/com/thoughtworks/go/util/ProcessManager.java
+++ b/common/src/com/thoughtworks/go/util/ProcessManager.java
@@ -57,7 +57,10 @@ public class ProcessManager {
             processBuilder.directory(workingDir);
         }
 
-        environmentVariableContext.setupRuntimeEnvironment(processBuilder.environment(), consumer);
+        for (String line : environmentVariableContext.report()) {
+            consumer.stdOutput(line);
+        }
+        processBuilder.environment().putAll(environmentVariableContext.getProperties());
         processBuilder.environment().putAll(envMap);
 
         Process process = startProcess(processBuilder, commandLineForDisplay);

--- a/common/src/com/thoughtworks/go/util/ProcessManager.java
+++ b/common/src/com/thoughtworks/go/util/ProcessManager.java
@@ -88,7 +88,7 @@ public class ProcessManager {
     }
 
     public Set<String> environmentVariableNames() {
-        return new ProcessBuilder().environment().keySet();
+        return System.getenv().keySet();
     }
 
     //should be used only for tests

--- a/common/src/com/thoughtworks/go/util/ProcessManager.java
+++ b/common/src/com/thoughtworks/go/util/ProcessManager.java
@@ -57,9 +57,6 @@ public class ProcessManager {
             processBuilder.directory(workingDir);
         }
 
-        for (String line : environmentVariableContext.report()) {
-            consumer.stdOutput(line);
-        }
         processBuilder.environment().putAll(environmentVariableContext.getProperties());
         processBuilder.environment().putAll(envMap);
 

--- a/common/src/com/thoughtworks/go/util/ProcessManager.java
+++ b/common/src/com/thoughtworks/go/util/ProcessManager.java
@@ -25,6 +25,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
@@ -86,6 +87,10 @@ public class ProcessManager {
         return processMap.values();
     }
 
+    public Set<String> environmentVariableNames() {
+        return new ProcessBuilder().environment().keySet();
+    }
+
     //should be used only for tests
     ConcurrentMap<Process, ProcessWrapper> getProcessMap() {
         return processMap;
@@ -108,4 +113,5 @@ public class ProcessManager {
         }
         return process;
     }
+
 }

--- a/common/src/com/thoughtworks/go/util/command/CommandLine.java
+++ b/common/src/com/thoughtworks/go/util/command/CommandLine.java
@@ -368,15 +368,6 @@ public class CommandLine {
                 errorPrefix);
     }
 
-    public static void setEnvironmentVariables(ProcessBuilder pb, EnvironmentVariableContext environmentVariableContext,
-                                               ConsoleOutputStreamConsumer consumer) {
-        Map<String, String> env = pb.environment();
-        for (String line : environmentVariableContext.report()) {
-            consumer.stdOutput(line);
-        }
-        env.putAll(environmentVariableContext.getProperties());
-    }
-
     public void waitForSuccess(int timeout) {
         ConsoleResult lastResult = ConsoleResult.unknownResult();
         long start = System.currentTimeMillis();

--- a/common/src/com/thoughtworks/go/util/command/CommandLine.java
+++ b/common/src/com/thoughtworks/go/util/command/CommandLine.java
@@ -371,8 +371,10 @@ public class CommandLine {
     public static void setEnvironmentVariables(ProcessBuilder pb, EnvironmentVariableContext environmentVariableContext,
                                                ConsoleOutputStreamConsumer consumer) {
         Map<String, String> env = pb.environment();
-
-        environmentVariableContext.setupRuntimeEnvironment(env, consumer);
+        for (String line : environmentVariableContext.report()) {
+            consumer.stdOutput(line);
+        }
+        env.putAll(environmentVariableContext.getProperties());
     }
 
     public void waitForSuccess(int timeout) {

--- a/common/test/unit/com/thoughtworks/go/util/ProcessManagerTest.java
+++ b/common/test/unit/com/thoughtworks/go/util/ProcessManagerTest.java
@@ -29,6 +29,7 @@ import java.util.concurrent.ConcurrentMap;
 import static com.thoughtworks.go.util.command.ProcessOutputStreamConsumer.inMemoryConsumer;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -117,5 +118,10 @@ public class ProcessManagerTest {
 
         Collection<ProcessWrapper> processWrappersForDisplay = processManager.currentProcessListForDisplay();
         assertThat(processWrappersForDisplay, is(processMap.values()));
+    }
+
+    @Test
+    public void canGetProcessLevelEnvironmentVariableNames() {
+        assertTrue(processManager.environmentVariableNames().contains("PATH"));
     }
 }

--- a/common/test/unit/com/thoughtworks/go/util/command/CommandLineTest.java
+++ b/common/test/unit/com/thoughtworks/go/util/command/CommandLineTest.java
@@ -29,8 +29,6 @@ import com.googlecode.junit.ext.checkers.OSChecker;
 import com.thoughtworks.go.util.*;
 import com.thoughtworks.go.util.LogFixture;
 import com.thoughtworks.go.util.ProcessWrapper;
-import org.apache.commons.io.FileUtils;
-import org.dbunit.util.FileHelper;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -119,56 +117,6 @@ public class CommandLineTest {
         cl2.withArg(argWithMismatchedDblQuote);
         assertEquals("Did behavior of mismatched quotes change? Previously it would truncate args.",
                 DBL_QUOTE + EXEC_WITH_SPACES + DBL_QUOTE + " ", cl2.toString());
-    }
-
-    @Test
-    public void testShouldGetEnvironmentVariablesInOrder() throws Exception {
-        ProcessBuilder builder = new ProcessBuilder();
-
-        EnvironmentVariableContext environmentVariableContext = new EnvironmentVariableContext();
-        environmentVariableContext.setProperty("GO_SERVER_URL", "abc", false);
-        environmentVariableContext.setProperty("GO_PIPELINE_NAME", "pipelineName", false);
-        environmentVariableContext.setProperty("GO_PIPELINE_LABEL", "label", false);
-        environmentVariableContext.setProperty("GO_STAGE_NAME", "stageName", false);
-        environmentVariableContext.setProperty("GO_STAGE_COUNTER", "stageCounter", false);
-
-        InMemoryStreamConsumer consumer = new InMemoryStreamConsumer();
-        CommandLine.setEnvironmentVariables(builder, environmentVariableContext, consumer);
-
-        String output = consumer.getAllOutput();
-
-        assertThat(output.indexOf("GO_SERVER_URL"), lessThan(output.indexOf("GO_PIPELINE_NAME")));
-        assertThat(output.indexOf("GO_PIPELINE_NAME"), lessThan(output.indexOf("GO_PIPELINE_LABEL")));
-        assertThat(output.indexOf("GO_PIPELINE_LABEL"), lessThan(output.indexOf("GO_STAGE_NAME")));
-        assertThat(output.indexOf("GO_STAGE_NAME"), lessThan(output.indexOf("GO_STAGE_COUNTER")));
-    }
-
-    @Test
-    public void testShouldGetEnvironmentVariablesFromTheEnvironmentContext() throws Exception {
-        ProcessBuilder builder = new ProcessBuilder();
-
-        EnvironmentVariableContext environmentVariableContext = new EnvironmentVariableContext();
-        environmentVariableContext.setProperty("GO_SERVER_URL", "abc", false);
-        environmentVariableContext.setProperty("GO_PIPELINE_NAME", "pipelineName", false);
-        environmentVariableContext.setProperty("GO_PIPELINE_LABEL", "label", false);
-        environmentVariableContext.setProperty("GO_STAGE_NAME", "stageName", false);
-        environmentVariableContext.setProperty("GO_STAGE_COUNTER", "stageCounter", false);
-        environmentVariableContext.setProperty("GO_JOB_NAME", "jobName", false);
-        environmentVariableContext.setProperty("GO_DEPENDENCY_LABEL_pipelineName_stageName", "dependency", false);
-        environmentVariableContext.setProperty("GO_REVISION", "someRevision", false);
-        environmentVariableContext.setProperty("GO_REVISION_SRC_TEST", "anotherRevision", false);
-
-        CommandLine.setEnvironmentVariables(builder, environmentVariableContext, new InMemoryStreamConsumer());
-        Map<String, String> environment = builder.environment();
-
-        assertThat(environment.get("GO_SERVER_URL"), is("abc"));
-        assertThat(environment.get("GO_PIPELINE_NAME"), is("pipelineName"));
-        assertThat(environment.get("GO_PIPELINE_LABEL"), is("label"));
-        assertThat(environment.get("GO_STAGE_NAME"), is("stageName"));
-        assertThat(environment.get("GO_STAGE_COUNTER"), is("stageCounter"));
-        assertThat(environment.get("GO_JOB_NAME"), is("jobName"));
-        assertThat(environment.get("GO_REVISION"), is("someRevision"));
-        assertThat(environment.get("GO_REVISION_SRC_TEST"), is("anotherRevision"));
     }
 
     @Test

--- a/config/config-api/src/com/thoughtworks/go/util/command/EnvironmentVariableContext.java
+++ b/config/config-api/src/com/thoughtworks/go/util/command/EnvironmentVariableContext.java
@@ -17,10 +17,7 @@
 package com.thoughtworks.go.util.command;
 
 import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import com.thoughtworks.go.util.GoConstants;
 
@@ -227,25 +224,21 @@ public class EnvironmentVariableContext implements Serializable {
         return properties != null ? properties.hashCode() : 0;
     }
 
-    public String reportText() {
-        throw new RuntimeException("IMPLEMENT ME");
-    }
-
-    public void setupRuntimeEnvironment(Map<String, String> env, ConsoleOutputStreamConsumer consumer) {
+    public List<String> report() {
+        ArrayList<String> lines = new ArrayList<>(properties.size());
+        HashSet<String> names = new HashSet<>();
         for (EnvironmentVariable property : properties) {
             String name = property.name;
             String value = property.value;
             if (value != null) {
-                String line;
-                if (env.containsKey(name)) {
-                    line = format("[%s] overriding environment variable '%s' with value '%s'", GoConstants.PRODUCT_NAME, name, property.valueForDisplay());
+                if (names.contains(name)) {
+                    lines.add(format("[%s] overriding environment variable '%s' with value '%s'", GoConstants.PRODUCT_NAME, name, property.valueForDisplay()));
                 } else {
-                    line = format("[%s] setting environment variable '%s' to value '%s'", GoConstants.PRODUCT_NAME, name, property.valueForDisplay());
+                    lines.add(format("[%s] setting environment variable '%s' to value '%s'", GoConstants.PRODUCT_NAME, name, property.valueForDisplay()));
                 }
-
-                consumer.stdOutput(line);
-                env.put(name, value);
+                names.add(name);
             }
         }
+        return lines;
     }
 }

--- a/config/config-api/src/com/thoughtworks/go/util/command/EnvironmentVariableContext.java
+++ b/config/config-api/src/com/thoughtworks/go/util/command/EnvironmentVariableContext.java
@@ -16,12 +16,12 @@
 
 package com.thoughtworks.go.util.command;
 
+import com.thoughtworks.go.util.GoConstants;
+
 import java.io.Serializable;
 import java.util.*;
 
-import com.thoughtworks.go.util.GoConstants;
-
-import static java.lang.String.*;
+import static java.lang.String.format;
 
 /**
  * @understands a set of variables to be passed to the Agent for a job
@@ -224,19 +224,19 @@ public class EnvironmentVariableContext implements Serializable {
         return properties != null ? properties.hashCode() : 0;
     }
 
-    public List<String> report() {
+    public List<String> report(Collection<String> predefinedEnvs) {
         ArrayList<String> lines = new ArrayList<>(properties.size());
-        HashSet<String> names = new HashSet<>();
+        Set<String> existing = new HashSet<>(predefinedEnvs);
         for (EnvironmentVariable property : properties) {
             String name = property.name;
             String value = property.value;
             if (value != null) {
-                if (names.contains(name)) {
+                if (existing.contains(name)) {
                     lines.add(format("[%s] overriding environment variable '%s' with value '%s'", GoConstants.PRODUCT_NAME, name, property.valueForDisplay()));
                 } else {
                     lines.add(format("[%s] setting environment variable '%s' to value '%s'", GoConstants.PRODUCT_NAME, name, property.valueForDisplay()));
                 }
-                names.add(name);
+                existing.add(name);
             }
         }
         return lines;

--- a/config/config-api/test/com/thoughtworks/go/util/command/EnvironmentVariableContextTest.java
+++ b/config/config-api/test/com/thoughtworks/go/util/command/EnvironmentVariableContextTest.java
@@ -17,11 +17,11 @@
 package com.thoughtworks.go.util.command;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.List;
 
 import org.junit.Test;
 
-import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
@@ -50,8 +50,9 @@ public class EnvironmentVariableContextTest {
     public void shouldReportWhenAVariableIsSet() {
         EnvironmentVariableContext context = new EnvironmentVariableContext();
         context.setProperty(PROPERTY_NAME, PROPERTY_VALUE, false);
-        assertThat(context.report().size(), is(1));
-        assertThat(context.report().get(0),
+        List<String> repo = context.report(Collections.<String>emptyList());
+        assertThat(repo.size(), is(1));
+        assertThat(repo.get(0),
                 is("[go] setting environment variable 'PROPERTY_NAME' to value 'property value'"));
     }
 
@@ -60,9 +61,10 @@ public class EnvironmentVariableContextTest {
         EnvironmentVariableContext context = new EnvironmentVariableContext();
         context.setProperty(PROPERTY_NAME, PROPERTY_VALUE, false);
         context.setProperty(PROPERTY_NAME, NEW_VALUE, false);
-        assertThat(context.report().size(), is(2));
-        assertThat(context.report().get(0), is("[go] setting environment variable 'PROPERTY_NAME' to value 'property value'"));
-        assertThat(context.report().get(1), is("[go] overriding environment variable 'PROPERTY_NAME' with value 'new value'"));
+        List<String> report = context.report(Collections.<String>emptyList());
+        assertThat(report.size(), is(2));
+        assertThat(report.get(0), is("[go] setting environment variable 'PROPERTY_NAME' to value 'property value'"));
+        assertThat(report.get(1), is("[go] overriding environment variable 'PROPERTY_NAME' with value 'new value'"));
     }
 
     @Test
@@ -70,17 +72,28 @@ public class EnvironmentVariableContextTest {
         EnvironmentVariableContext context = new EnvironmentVariableContext();
         context.setProperty(PROPERTY_NAME, PROPERTY_VALUE, true);
         context.setProperty(PROPERTY_NAME, NEW_VALUE, true);
-        assertThat(context.report().size(), is(2));
-        assertThat(context.report().get(0), is(String.format("[go] setting environment variable 'PROPERTY_NAME' to value '%s'", EnvironmentVariableContext.EnvironmentVariable.MASK_VALUE)));
-        assertThat(context.report().get(1), is(String.format("[go] overriding environment variable 'PROPERTY_NAME' with value '%s'", EnvironmentVariableContext.EnvironmentVariable.MASK_VALUE)));
+        List<String> report = context.report(Collections.<String>emptyList());
+        assertThat(report.size(), is(2));
+        assertThat(report.get(0), is(String.format("[go] setting environment variable 'PROPERTY_NAME' to value '%s'", EnvironmentVariableContext.EnvironmentVariable.MASK_VALUE)));
+        assertThat(report.get(1), is(String.format("[go] overriding environment variable 'PROPERTY_NAME' with value '%s'", EnvironmentVariableContext.EnvironmentVariable.MASK_VALUE)));
     }
 
     @Test
     public void shouldReportSecureVariableAsMaskedValue() {
         EnvironmentVariableContext context = new EnvironmentVariableContext();
         context.setProperty(PROPERTY_NAME, PROPERTY_VALUE, true);
-        assertThat(context.report().size(), is(1));
-        assertThat(context.report().get(0), is(String.format("[go] setting environment variable 'PROPERTY_NAME' to value '%s'", EnvironmentVariableContext.EnvironmentVariable.MASK_VALUE)));
+        List<String> repot = context.report(Collections.<String>emptyList());
+        assertThat(repot.size(), is(1));
+        assertThat(repot.get(0), is(String.format("[go] setting environment variable 'PROPERTY_NAME' to value '%s'", EnvironmentVariableContext.EnvironmentVariable.MASK_VALUE)));
+    }
+
+    @Test
+    public void testReportOverrideForProcessEnvironmentVariables() {
+        EnvironmentVariableContext context = new EnvironmentVariableContext();
+        context.setProperty("PATH", "/foo", false);
+        List<String> report = context.report(Collections.singleton("PATH"));
+        assertThat(report.size(), is(1));
+        assertThat(report.get(0), is("[go] overriding environment variable 'PATH' with value '/foo'"));
     }
 
     @Test

--- a/config/config-api/test/com/thoughtworks/go/util/command/EnvironmentVariableContextTest.java
+++ b/config/config-api/test/com/thoughtworks/go/util/command/EnvironmentVariableContextTest.java
@@ -17,9 +17,7 @@
 package com.thoughtworks.go.util.command;
 
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 import org.junit.Test;
 
@@ -52,13 +50,9 @@ public class EnvironmentVariableContextTest {
     public void shouldReportWhenAVariableIsSet() {
         EnvironmentVariableContext context = new EnvironmentVariableContext();
         context.setProperty(PROPERTY_NAME, PROPERTY_VALUE, false);
-        InMemoryStreamConsumer consumer = ProcessOutputStreamConsumer.inMemoryConsumer();
-        Map<String, String> map = new HashMap<String, String>();
-        context.setupRuntimeEnvironment(map, consumer);
-
-        assertThat(map.get(PROPERTY_NAME), is(PROPERTY_VALUE));
-        assertThat(consumer.getAllOutput(),
-                containsString("[go] setting environment variable 'PROPERTY_NAME' to value 'property value'"));
+        assertThat(context.report().size(), is(1));
+        assertThat(context.report().get(0),
+                is("[go] setting environment variable 'PROPERTY_NAME' to value 'property value'"));
     }
 
     @Test
@@ -66,13 +60,9 @@ public class EnvironmentVariableContextTest {
         EnvironmentVariableContext context = new EnvironmentVariableContext();
         context.setProperty(PROPERTY_NAME, PROPERTY_VALUE, false);
         context.setProperty(PROPERTY_NAME, NEW_VALUE, false);
-        InMemoryStreamConsumer consumer = ProcessOutputStreamConsumer.inMemoryConsumer();
-        Map<String, String> map = new HashMap<String, String>();        
-        context.setupRuntimeEnvironment(map, consumer);
-
-        assertThat(map.get(PROPERTY_NAME), is(NEW_VALUE));
-        assertThat(consumer.getAllOutput(), containsString("[go] setting environment variable 'PROPERTY_NAME' to value 'property value'"));
-        assertThat(consumer.getAllOutput(), containsString("[go] overriding environment variable 'PROPERTY_NAME' with value 'new value'"));
+        assertThat(context.report().size(), is(2));
+        assertThat(context.report().get(0), is("[go] setting environment variable 'PROPERTY_NAME' to value 'property value'"));
+        assertThat(context.report().get(1), is("[go] overriding environment variable 'PROPERTY_NAME' with value 'new value'"));
     }
 
     @Test
@@ -80,25 +70,17 @@ public class EnvironmentVariableContextTest {
         EnvironmentVariableContext context = new EnvironmentVariableContext();
         context.setProperty(PROPERTY_NAME, PROPERTY_VALUE, true);
         context.setProperty(PROPERTY_NAME, NEW_VALUE, true);
-        InMemoryStreamConsumer consumer = ProcessOutputStreamConsumer.inMemoryConsumer();
-        Map<String, String> map = new HashMap<String, String>();
-        context.setupRuntimeEnvironment(map, consumer);
-
-        assertThat(map.get(PROPERTY_NAME), is(NEW_VALUE));
-        assertThat(consumer.getAllOutput(), containsString(String.format("[go] setting environment variable 'PROPERTY_NAME' to value '%s'", EnvironmentVariableContext.EnvironmentVariable.MASK_VALUE)));
-        assertThat(consumer.getAllOutput(), containsString(String.format("[go] overriding environment variable 'PROPERTY_NAME' with value '%s'", EnvironmentVariableContext.EnvironmentVariable.MASK_VALUE)));
+        assertThat(context.report().size(), is(2));
+        assertThat(context.report().get(0), is(String.format("[go] setting environment variable 'PROPERTY_NAME' to value '%s'", EnvironmentVariableContext.EnvironmentVariable.MASK_VALUE)));
+        assertThat(context.report().get(1), is(String.format("[go] overriding environment variable 'PROPERTY_NAME' with value '%s'", EnvironmentVariableContext.EnvironmentVariable.MASK_VALUE)));
     }
 
     @Test
     public void shouldReportSecureVariableAsMaskedValue() {
         EnvironmentVariableContext context = new EnvironmentVariableContext();
         context.setProperty(PROPERTY_NAME, PROPERTY_VALUE, true);
-        InMemoryStreamConsumer consumer = ProcessOutputStreamConsumer.inMemoryConsumer();
-        Map<String, String> map = new HashMap<String, String>();
-        context.setupRuntimeEnvironment(map, consumer);
-
-        assertThat(map.get(PROPERTY_NAME), is(PROPERTY_VALUE));
-        assertThat(consumer.getAllOutput(), containsString(String.format("[go] setting environment variable 'PROPERTY_NAME' to value '%s'", EnvironmentVariableContext.EnvironmentVariable.MASK_VALUE)));
+        assertThat(context.report().size(), is(1));
+        assertThat(context.report().get(0), is(String.format("[go] setting environment variable 'PROPERTY_NAME' to value '%s'", EnvironmentVariableContext.EnvironmentVariable.MASK_VALUE)));
     }
 
     @Test

--- a/server/config/cruise-config.xml
+++ b/server/config/cruise-config.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<cruise xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="cruise-config.xsd" schemaVersion="76">
+<cruise xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="cruise-config.xsd" schemaVersion="77">
   <server artifactsdir="logs" commandRepositoryLocation="default" serverId="dev-id">
     <security>
       <passwordFile path="../manual-testing/ant_hg/password.properties" />
@@ -22,7 +22,7 @@
     </authorization>
     <pipeline name="up42">
       <materials>
-        <hg url="../manual-testing/ant_hg/dummy" dest="dest_dir" materialName="dummyhg" />
+        <git url="https://github.com/ThoughtWorksStudios/node-aws-lambda.git" materialName="node-aws-lambda" />
       </materials>
       <stage name="up42_stage">
         <jobs>
@@ -35,5 +35,8 @@
       </stage>
     </pipeline>
   </pipelines>
+  <agents>
+    <agent hostname="PW9950-338.local" ipaddress="192.168.0.108" uuid="ff93e3e8-7c07-45ee-bee3-8b05adb62a52" />
+  </agents>
 </cruise>
 

--- a/server/config/cruise-config.xml
+++ b/server/config/cruise-config.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<cruise xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="cruise-config.xsd" schemaVersion="77">
+<cruise xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="cruise-config.xsd" schemaVersion="76">
   <server artifactsdir="logs" commandRepositoryLocation="default" serverId="dev-id">
     <security>
       <passwordFile path="../manual-testing/ant_hg/password.properties" />
@@ -22,7 +22,7 @@
     </authorization>
     <pipeline name="up42">
       <materials>
-        <git url="https://github.com/ThoughtWorksStudios/node-aws-lambda.git" materialName="node-aws-lambda" />
+        <hg url="../manual-testing/ant_hg/dummy" dest="dest_dir" materialName="dummyhg" />
       </materials>
       <stage name="up42_stage">
         <jobs>
@@ -35,8 +35,5 @@
       </stage>
     </pipeline>
   </pipelines>
-  <agents>
-    <agent hostname="PW9950-338.local" ipaddress="192.168.0.108" uuid="ff93e3e8-7c07-45ee-bee3-8b05adb62a52" />
-  </agents>
 </cruise>
 

--- a/server/test/unit/com/thoughtworks/go/remote/work/BuildWorkTest.java
+++ b/server/test/unit/com/thoughtworks/go/remote/work/BuildWorkTest.java
@@ -116,6 +116,9 @@ public class BuildWorkTest {
             + "    <variable name=\"JOB_ENV\">\n"
             + "      <value>foobar</value>\n"
             + "    </variable>\n"
+            + "    <variable name=\"PATH\">\n"
+            + "      <value>/tmp</value>\n"
+            + "    </variable>\n"
             + "  </environmentvariables>\n"
             + "  <tasks>\n"
             + "    <ant target=\"-help\" />\n"
@@ -630,7 +633,8 @@ public class BuildWorkTest {
                 + "[go] setting environment variable 'GO_STAGE_NAME' to value 'mingle'\n"
                 + "[go] setting environment variable 'GO_STAGE_COUNTER' to value '100'\n"
                 + "[go] setting environment variable 'GO_JOB_NAME' to value 'run-ant'\n"
-                + "[go] setting environment variable 'JOB_ENV' to value 'foobar'"));
+                + "[go] setting environment variable 'JOB_ENV' to value 'foobar'\n"
+                + "[go] overriding environment variable 'PATH' with value '/tmp'\n\n"));
 
     }
 

--- a/server/test/unit/com/thoughtworks/go/remote/work/BuildWorkTest.java
+++ b/server/test/unit/com/thoughtworks/go/remote/work/BuildWorkTest.java
@@ -18,7 +18,10 @@ package com.thoughtworks.go.remote.work;
 
 import com.googlecode.junit.ext.JunitExtRunner;
 import com.googlecode.junit.ext.RunIf;
-import com.thoughtworks.go.config.*;
+import com.thoughtworks.go.config.ConfigCache;
+import com.thoughtworks.go.config.CruiseConfig;
+import com.thoughtworks.go.config.JobConfig;
+import com.thoughtworks.go.config.MagicalGoConfigXmlLoader;
 import com.thoughtworks.go.domain.*;
 import com.thoughtworks.go.domain.buildcause.BuildCause;
 import com.thoughtworks.go.domain.builder.Builder;
@@ -27,6 +30,7 @@ import com.thoughtworks.go.helper.JobInstanceMother;
 import com.thoughtworks.go.helper.NoOpMetricsProbeService;
 import com.thoughtworks.go.helper.StageMother;
 import com.thoughtworks.go.junitext.EnhancedOSChecker;
+import static com.thoughtworks.go.matchers.RegexMatcher.matches;
 import com.thoughtworks.go.metrics.service.MetricsProbeService;
 import com.thoughtworks.go.plugin.access.packagematerial.PackageAsRepositoryExtension;
 import com.thoughtworks.go.plugin.access.pluggabletask.TaskExtension;
@@ -61,7 +65,6 @@ import static com.thoughtworks.go.domain.JobState.*;
 import static com.thoughtworks.go.junitext.EnhancedOSChecker.DO_NOT_RUN_ON;
 import static com.thoughtworks.go.junitext.EnhancedOSChecker.WINDOWS;
 import static com.thoughtworks.go.matchers.ConsoleOutMatcher.*;
-import static com.thoughtworks.go.matchers.RegexMatcher.matches;
 import static javax.servlet.http.HttpServletResponse.SC_NOT_ACCEPTABLE;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
@@ -625,16 +628,17 @@ public class BuildWorkTest {
 
         String consoleOut = artifactManipulator.consoleOut();
 
-        assertThat(trimTimeStamp(consoleOut), containsString("[go] setting environment variable 'GO_SERVER_URL' to value 'somewhere-does-not-matter'\n"
-                + "[go] setting environment variable 'GO_TRIGGER_USER' to value ''\n"
-                + "[go] setting environment variable 'GO_PIPELINE_NAME' to value 'pipeline1'\n"
-                + "[go] setting environment variable 'GO_PIPELINE_COUNTER' to value '-2'\n"
-                + "[go] setting environment variable 'GO_PIPELINE_LABEL' to value '100'\n"
-                + "[go] setting environment variable 'GO_STAGE_NAME' to value 'mingle'\n"
-                + "[go] setting environment variable 'GO_STAGE_COUNTER' to value '100'\n"
-                + "[go] setting environment variable 'GO_JOB_NAME' to value 'run-ant'\n"
-                + "[go] setting environment variable 'JOB_ENV' to value 'foobar'\n"
-                + "[go] overriding environment variable 'PATH' with value '/tmp'\n\n"));
+
+        assertThat(consoleOut, matches("'GO_SERVER_URL' (to|with) value '" + SERVER_URL));
+        assertThat(consoleOut, matches("'GO_PIPELINE_LABEL' (to|with) value '" + PIPELINE_LABEL));
+        assertThat(consoleOut, matches("'GO_PIPELINE_NAME' (to|with) value '" + PIPELINE_NAME));
+        assertThat(consoleOut, matches("'GO_STAGE_NAME' (to|with) value '" + STAGE_NAME));
+        assertThat(consoleOut, matches("'GO_STAGE_COUNTER' (to|with) value '" + STAGE_COUNTER));
+        assertThat(consoleOut, matches("'GO_JOB_NAME' (to|with) value '" + JOB_PLAN_NAME));
+
+        assertThat(trimTimeStamp(consoleOut), containsString(
+                "[go] setting environment variable 'JOB_ENV' to value 'foobar'\n" +
+                        "[go] overriding environment variable 'PATH' with value '/tmp'\n\n"));
 
     }
 


### PR DESCRIPTION
As described in the issue #871, this PR dump environment variables at job level once. 