### PR TITLE
1133 fix invalid merged config cache

### DIFF
--- a/common/test/unit/com/thoughtworks/go/domain/BasicPipelineConfigsTest.java
+++ b/common/test/unit/com/thoughtworks/go/domain/BasicPipelineConfigsTest.java
@@ -21,11 +21,14 @@ import com.thoughtworks.go.config.BasicPipelineConfigs;
 import com.thoughtworks.go.config.PipelineConfig;
 import com.thoughtworks.go.config.PipelineConfigs;
 import com.thoughtworks.go.config.PipelineConfigsTestBase;
+import com.thoughtworks.go.config.remote.RepoConfigOrigin;
 import com.thoughtworks.go.helper.PipelineConfigMother;
 import org.hamcrest.core.Is;
 import org.junit.Test;
 
 import static com.thoughtworks.go.util.DataStructureUtils.m;
+import static junit.framework.TestCase.assertNull;
+import static junit.framework.TestCase.assertSame;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.core.IsNull.nullValue;
 import static org.junit.Assert.assertThat;
@@ -46,6 +49,32 @@ public class BasicPipelineConfigsTest extends PipelineConfigsTestBase {
     protected PipelineConfigs createWithPipelines(PipelineConfig first, PipelineConfig second) {
         return new BasicPipelineConfigs(first, second);
     }
+
+
+    @Test
+    public void shouldReturnSelfForGetLocalWhenOriginIsNull()
+    {
+        PipelineConfigs pipelineConfigs = createEmpty();
+        assertThat(pipelineConfigs.getLocal().size(), is(1));
+        assertSame(pipelineConfigs,pipelineConfigs.getLocal());
+    }
+    @Test
+    public void shouldReturnSelfForGetLocalPartsWhenOriginIsFile()
+    {
+        PipelineConfigs pipelineConfigs = createEmpty();
+        pipelineConfigs.setOrigins(new FileConfigOrigin());
+        assertThat(pipelineConfigs.getLocal().size(), is(1));
+        assertSame(pipelineConfigs, pipelineConfigs.getLocal());
+    }
+    @Test
+    public void shouldReturnNullGetLocalPartsWhenOriginIsRepo()
+    {
+        PipelineConfigs pipelineConfigs = createEmpty();
+        pipelineConfigs.setOrigins(new RepoConfigOrigin());
+        assertNull(pipelineConfigs.getLocal());
+    }
+
+
     @Test
     public void shouldSetOriginInPipelines() {
         PipelineConfig pipe = PipelineConfigMother.pipelineConfig("pipeline1");

--- a/common/test/unit/com/thoughtworks/go/domain/CruiseConfigTest.java
+++ b/common/test/unit/com/thoughtworks/go/domain/CruiseConfigTest.java
@@ -1,0 +1,1356 @@
+/*************************GO-LICENSE-START*********************************
+ * Copyright 2014 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *************************GO-LICENSE-END***********************************/
+
+package com.thoughtworks.go.domain;
+
+import com.thoughtworks.go.config.*;
+import com.thoughtworks.go.config.materials.MaterialConfigs;
+import com.thoughtworks.go.config.materials.PackageMaterialConfig;
+import com.thoughtworks.go.config.materials.PluggableSCMMaterialConfig;
+import com.thoughtworks.go.config.materials.ScmMaterialConfig;
+import com.thoughtworks.go.config.materials.dependency.DependencyMaterialConfig;
+import com.thoughtworks.go.config.materials.git.GitMaterialConfig;
+import com.thoughtworks.go.config.materials.perforce.P4MaterialConfig;
+import com.thoughtworks.go.config.materials.svn.SvnMaterialConfig;
+import com.thoughtworks.go.config.merge.MergeConfigOrigin;
+import com.thoughtworks.go.config.merge.MergeEnvironmentConfig;
+import com.thoughtworks.go.config.merge.MergePipelineConfigs;
+import com.thoughtworks.go.config.remote.*;
+import com.thoughtworks.go.domain.config.Configuration;
+import com.thoughtworks.go.domain.config.ConfigurationKey;
+import com.thoughtworks.go.domain.config.ConfigurationProperty;
+import com.thoughtworks.go.domain.config.ConfigurationValue;
+import com.thoughtworks.go.domain.materials.MaterialConfig;
+import com.thoughtworks.go.domain.packagerepository.*;
+import com.thoughtworks.go.domain.scm.SCM;
+import com.thoughtworks.go.domain.scm.SCMMother;
+import com.thoughtworks.go.helper.*;
+import com.thoughtworks.go.security.GoCipher;
+import com.thoughtworks.go.util.ReflectionUtil;
+import org.hamcrest.Matchers;
+import org.hamcrest.core.Is;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import java.util.*;
+
+import static com.thoughtworks.go.helper.PipelineConfigMother.createGroup;
+import static com.thoughtworks.go.helper.PipelineConfigMother.createPipelineConfig;
+import static org.hamcrest.Matchers.*;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.Is.isA;
+import static org.hamcrest.core.IsNull.notNullValue;
+import static org.hamcrest.core.IsNull.nullValue;
+import static org.junit.Assert.*;
+import static org.mockito.AdditionalMatchers.not;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.same;
+import static org.mockito.Mockito.*;
+
+public class CruiseConfigTest {
+    public GoConfigMother goConfigMother;
+    private BasicPipelineConfigs pipelines;
+    private CruiseConfig cruiseConfig;
+
+    @Before
+    public void setup() throws Exception {
+        pipelines = new BasicPipelineConfigs("existing_group", new Authorization());
+        cruiseConfig = new BasicCruiseConfig(pipelines);
+        goConfigMother = new GoConfigMother();
+    }
+
+    @Test
+    public void shouldSetOriginInPipelines() {
+        pipelines = new BasicPipelineConfigs("group_main", new Authorization(), PipelineConfigMother.pipelineConfig("pipe1"));
+        BasicCruiseConfig mainCruiseConfig = new BasicCruiseConfig(pipelines);
+        PipelineConfig pipe = pipelines.get(0);
+        mainCruiseConfig.setOrigins(new FileConfigOrigin());
+        assertThat(pipe.getOrigin(), Is.<ConfigOrigin>is(new FileConfigOrigin()));
+    }
+    @Test
+    public void shouldSetOriginInEnvironments() {
+        BasicCruiseConfig mainCruiseConfig = new BasicCruiseConfig(pipelines);
+        BasicEnvironmentConfig env = new BasicEnvironmentConfig(new CaseInsensitiveString("e"));
+        mainCruiseConfig.addEnvironment(env);
+        mainCruiseConfig.setOrigins(new FileConfigOrigin());
+        assertThat(env.getOrigin(), Is.<ConfigOrigin>is(new FileConfigOrigin()));
+    }
+
+    @Test
+    public void shouldLoadPasswordForGivenMaterialFingerprint() {
+        MaterialConfig svnConfig = new SvnMaterialConfig("url", "loser", "boozer", true);
+        PipelineConfig one = PipelineConfigMother.pipelineConfig("one", svnConfig, new JobConfigs(new JobConfig("job")));
+        cruiseConfig.addPipeline("group-1", one);
+
+        P4MaterialConfig p4One = new P4MaterialConfig("server_and_port", "outside_the_window");
+        p4One.setPassword("abcdef");
+        PipelineConfig two = PipelineConfigMother.pipelineConfig("two", p4One, new JobConfigs(new JobConfig("job")));
+        cruiseConfig.addPipeline("group-2", two);
+
+        P4MaterialConfig p4Two = new P4MaterialConfig("port_and_server", "inside_yourself");
+        p4Two.setPassword("fedcba");
+        PipelineConfig three = PipelineConfigMother.pipelineConfig("three", p4Two, new JobConfigs(new JobConfig("job")));
+        cruiseConfig.addPipeline("group-3", three);
+
+        assertThat(cruiseConfig.materialConfigFor(svnConfig.getFingerprint()), is(svnConfig));
+        assertThat(cruiseConfig.materialConfigFor(p4One.getFingerprint()), is((MaterialConfig) p4One));
+        assertThat(cruiseConfig.materialConfigFor(p4Two.getFingerprint()), is((MaterialConfig) p4Two));
+        assertThat(cruiseConfig.materialConfigFor("some_crazy_fingerprint"), is(nullValue()));
+    }
+
+    @Test
+    public void shouldFindAllAgentResources() {
+        cruiseConfig.agents().add(new AgentConfig("uuid", "host1", "127.0.0.1", new Resources("from-agent")));
+        assertThat(cruiseConfig.getAllResources(), hasItem(new Resource("from-agent")));
+    }
+
+    @Test
+    public void shouldGenerateAMapOfAllPipelinesAndTheirParentDependencies() {
+        /*
+        *    -----+ p2 --> p4
+        *  p1
+        *    -----+ p3
+        *
+        * */
+        PipelineConfig p1 = createPipelineConfig("p1", "s1", "j1");
+        PipelineConfig p2 = createPipelineConfig("p2", "s2", "j1");
+        p2.addMaterialConfig(new DependencyMaterialConfig(new CaseInsensitiveString("p1"), new CaseInsensitiveString("s1")));
+        PipelineConfig p3 = createPipelineConfig("p3", "s3", "j1");
+        p3.addMaterialConfig(new DependencyMaterialConfig(new CaseInsensitiveString("p1"), new CaseInsensitiveString("s1")));
+        PipelineConfig p4 = createPipelineConfig("p4", "s4", "j1");
+        p4.addMaterialConfig(new DependencyMaterialConfig(new CaseInsensitiveString("p2"), new CaseInsensitiveString("s2")));
+        pipelines.addAll(Arrays.asList(p4, p2, p1, p3));
+        Map<String, List<PipelineConfig>> expectedPipelines = cruiseConfig.generatePipelineVsDownstreamMap();
+        assertThat(expectedPipelines.size(), is(4));
+        assertThat(expectedPipelines.get("p1"), hasItems(p2, p3));
+        assertThat(expectedPipelines.get("p2"), hasItems(p4));
+        assertThat(expectedPipelines.get("p3").isEmpty(), is(true));
+        assertThat(expectedPipelines.get("p4").isEmpty(), is(true));
+    }
+
+    @Test
+    public void shouldFindBuildPlanWithStages() throws Exception {
+        try {
+            cruiseConfig.jobConfigByName("cetaceans", "whales", "right whale", true);
+            fail("Expected not to find right whale in stage whales in pipeline cetaceans");
+        } catch (RuntimeException ex) {
+            // ignore
+        }
+
+        addPipeline("cetaceans", "whales", jobConfig("whale"));
+
+        try {
+            cruiseConfig.jobConfigByName("cetaceans", "whales", "dolphin", true);
+        } catch (Exception e) {
+            assertThat(e.getMessage(), is("Job [dolphin] is not found in pipeline [cetaceans] stage [whales]."));
+        }
+
+        try {
+            cruiseConfig.jobConfigByName("primates", "whales", "dolphin", true);
+            fail("Expected not to find primates in stage whales in pipeline cetaceans");
+        } catch (RuntimeException ex) {
+            // ignore
+        }
+        JobConfig plan = jobConfig("baboon");
+        addPipeline("primates", "apes", plan);
+        assertThat(cruiseConfig.jobConfigByName("primates", "apes", "baboon", true), is(plan));
+    }
+
+    @Test
+    public void shouldFindNextStage() {
+        addPipelineWithStages("mingle", "dev", jobConfig("ut"), jobConfig("ft"));
+        assertThat(cruiseConfig.hasNextStage(new CaseInsensitiveString("mingle"), new CaseInsensitiveString("dev")), is(true));
+        StageConfig nextStage = cruiseConfig.nextStage(new CaseInsensitiveString("mingle"), new CaseInsensitiveString("dev"));
+        assertThat(nextStage.name(), is(new CaseInsensitiveString("dev2")));
+        assertThat(cruiseConfig.hasNextStage(new CaseInsensitiveString("mingle"), nextStage.name()), is(false));
+    }
+
+    @Test
+    public void shouldFindPreviousStage() {
+        addPipelineWithStages("mingle", "dev", jobConfig("ut"), jobConfig("ft"));
+        assertThat(cruiseConfig.hasPreviousStage(new CaseInsensitiveString("mingle"), new CaseInsensitiveString("dev2")), is(true));
+        StageConfig previousStage = cruiseConfig.previousStage(new CaseInsensitiveString("mingle"), new CaseInsensitiveString("dev2"));
+        assertThat(previousStage.name(), is(new CaseInsensitiveString("dev")));
+        assertThat(cruiseConfig.hasPreviousStage(new CaseInsensitiveString("mingle"), previousStage.name()), is(false));
+    }
+
+    @Test
+    public void shouldKnowWhenBuildPlanNotInConfigFile() {
+        pipelines.add(createPipelineConfig("pipeline", "stage", "build1", "build2"));
+        assertThat(cruiseConfig.hasBuildPlan(new CaseInsensitiveString("pipeline"), new CaseInsensitiveString("stage"), "build1", true), is(true));
+        assertThat(cruiseConfig.hasBuildPlan(new CaseInsensitiveString("pipeline"), new CaseInsensitiveString("stage"), "build2", true), is(true));
+        assertThat(cruiseConfig.hasBuildPlan(new CaseInsensitiveString("pipeline"), new CaseInsensitiveString("stage"), "build3", true), is(false));
+    }
+
+    @Test
+    public void shouldGetPipelinesWithGroupName() throws Exception {
+        PipelineConfigs group1 = createGroup("group1", createPipelineConfig("pipeline1", "stage1"));
+        PipelineConfigs group2 = createGroup("group2", createPipelineConfig("pipeline2", "stage2"));
+        CruiseConfig config = new BasicCruiseConfig();
+        config.setGroup(new PipelineGroups(group1, group2));
+
+
+        assertThat(config.pipelines("group1"), is(group1));
+        assertThat(config.pipelines("group2"), is(group2));
+    }
+
+    @Test
+    public void shouldTellIfSMTPIsEnabled() {
+        CruiseConfig config = new BasicCruiseConfig();
+        assertThat(config.isSmtpEnabled(), is(false));
+
+        MailHost mailHost = new MailHost("abc", 12, "admin", "p", true, true, "anc@mail.com", "anc@mail.com");
+        config.setServerConfig(new ServerConfig(null, mailHost, null, null));
+
+        config.server().updateMailHost(mailHost);
+        assertThat(config.isSmtpEnabled(), is(true));
+    }
+
+    @Test
+    public void shouldReturnAMapOfTemplateNamesToListOfAssociatedPipelinesCaseInsensitively() {
+        PipelineTemplateConfig template = template("first_template");
+        PipelineConfig pipelineConfig1 = PipelineConfigMother.pipelineConfig("first");
+        pipelineConfig1.clear();
+        pipelineConfig1.setTemplateName(new CaseInsensitiveString("first_template"));
+        pipelineConfig1.usingTemplate(template);
+
+        PipelineConfig pipelineConfig2 = PipelineConfigMother.pipelineConfig("second");
+        pipelineConfig2.clear();
+        pipelineConfig2.setTemplateName(new CaseInsensitiveString("FIRST_template"));
+        pipelineConfig2.usingTemplate(template);
+
+        PipelineConfig pipelineConfigWithoutTemplate = PipelineConfigMother.pipelineConfig("third");
+
+        CruiseConfig cruiseConfig = new BasicCruiseConfig(new BasicPipelineConfigs(pipelineConfig1, pipelineConfig2, pipelineConfigWithoutTemplate));
+
+        cruiseConfig.addTemplate(template);
+        SecurityConfig securityConfig = new SecurityConfig(new LdapConfig(new GoCipher()), new PasswordFileConfig("foo"), false);
+        securityConfig.adminsConfig().add(new AdminUser(new CaseInsensitiveString("root")));
+        cruiseConfig.server().useSecurity(securityConfig);
+
+        Map<CaseInsensitiveString, List<CaseInsensitiveString>> templateWithPipelines = cruiseConfig.templatesWithPipelinesForUser("root");
+
+        assertThat(templateWithPipelines.size(), is(1));
+        assertThat(templateWithPipelines.get(new CaseInsensitiveString("first_template")), is(Arrays.asList(new CaseInsensitiveString("first"), new CaseInsensitiveString("second"))));
+    }
+
+    @Test
+    public void shouldReturnAMapOfTemplateNamesToListOfAssociatedPipelinesBasedOnUserPermissions() {
+
+        PipelineTemplateConfig firstTemplate = PipelineTemplateConfigMother.createTemplate("first_template", new Authorization(new AdminsConfig(
+                new AdminUser(new CaseInsensitiveString("firstTemplate-admin")))), StageConfigMother.manualStage("stage-one"));
+        PipelineConfig pipelineConfig1 = PipelineConfigMother.pipelineConfig("first");
+        pipelineConfig1.clear();
+        pipelineConfig1.setTemplateName(new CaseInsensitiveString("first_template"));
+        pipelineConfig1.usingTemplate(firstTemplate);
+
+        PipelineTemplateConfig secondTemplate = PipelineTemplateConfigMother.createTemplate("second_template", new Authorization(new AdminsConfig(
+                new AdminUser(new CaseInsensitiveString("secondTemplate-admin")))), StageConfigMother.stageConfig("one-more"));
+        PipelineConfig pipelineConfig2 = PipelineConfigMother.pipelineConfig("second");
+        pipelineConfig2.clear();
+        pipelineConfig2.setTemplateName(new CaseInsensitiveString("second_template"));
+        pipelineConfig2.usingTemplate(secondTemplate);
+
+        PipelineConfig pipelineConfigWithoutTemplate = PipelineConfigMother.pipelineConfig("third");
+
+        CruiseConfig cruiseConfig = new BasicCruiseConfig(new BasicPipelineConfigs(pipelineConfig1, pipelineConfig2, pipelineConfigWithoutTemplate));
+
+        cruiseConfig.addTemplate(firstTemplate);
+        cruiseConfig.addTemplate(secondTemplate);
+
+        SecurityConfig securityConfig = new SecurityConfig(new LdapConfig(new GoCipher()), new PasswordFileConfig("foo"), false);
+        securityConfig.adminsConfig().add(new AdminUser(new CaseInsensitiveString("root")));
+        cruiseConfig.server().useSecurity(securityConfig);
+
+        Map<CaseInsensitiveString, List<CaseInsensitiveString>> templateWithPipelines = cruiseConfig.templatesWithPipelinesForUser("firstTemplate-admin");
+
+        assertThat(templateWithPipelines.size(), is(1));
+        assertThat(templateWithPipelines.get(new CaseInsensitiveString("first_template")), is(Arrays.asList(new CaseInsensitiveString("first"))));
+    }
+
+    @Test
+    public void shouldReturnAMapOfAllTemplateNamesToListOfAssociatedPipelinesIfUserIsSuperAdmin() {
+
+        PipelineTemplateConfig firstTemplate = PipelineTemplateConfigMother.createTemplate("first_template", new Authorization(new AdminsConfig(
+                new AdminUser(new CaseInsensitiveString("firstTemplate-admin")))), StageConfigMother.manualStage("stage-one"));
+        PipelineConfig pipelineConfig1 = PipelineConfigMother.pipelineConfig("first");
+        pipelineConfig1.clear();
+        pipelineConfig1.setTemplateName(new CaseInsensitiveString("first_template"));
+        pipelineConfig1.usingTemplate(firstTemplate);
+
+        PipelineTemplateConfig secondTemplate = PipelineTemplateConfigMother.createTemplate("second_template", new Authorization(new AdminsConfig(
+                new AdminUser(new CaseInsensitiveString("secondTemplate-admin")))), StageConfigMother.stageConfig("one-more"));
+        PipelineConfig pipelineConfig2 = PipelineConfigMother.pipelineConfig("second");
+        pipelineConfig2.clear();
+        pipelineConfig2.setTemplateName(new CaseInsensitiveString("second_template"));
+        pipelineConfig2.usingTemplate(secondTemplate);
+
+        PipelineConfig pipelineConfigWithoutTemplate = PipelineConfigMother.pipelineConfig("third");
+
+        CruiseConfig cruiseConfig = new BasicCruiseConfig(new BasicPipelineConfigs(pipelineConfig1, pipelineConfig2, pipelineConfigWithoutTemplate));
+
+        SecurityConfig securityConfig = new SecurityConfig(new LdapConfig(new GoCipher()), new PasswordFileConfig("foo"), false);
+        securityConfig.adminsConfig().add(new AdminUser(new CaseInsensitiveString("root")));
+        cruiseConfig.server().useSecurity(securityConfig);
+
+        cruiseConfig.addTemplate(firstTemplate);
+        cruiseConfig.addTemplate(secondTemplate);
+
+        Map<CaseInsensitiveString, List<CaseInsensitiveString>> templateWithPipelines = cruiseConfig.templatesWithPipelinesForUser("root");
+
+        assertThat(templateWithPipelines.size(), is(2));
+        assertThat(templateWithPipelines.get(new CaseInsensitiveString("first_template")), is(Arrays.asList(new CaseInsensitiveString("first"))));
+        assertThat(templateWithPipelines.get(new CaseInsensitiveString("second_template")), is(Arrays.asList(new CaseInsensitiveString("second"))));
+    }
+
+    private PipelineTemplateConfig template(final String name) {
+        return new PipelineTemplateConfig(new CaseInsensitiveString(name), StageConfigMother.stageConfig("some_stage"));
+    }
+
+    @Test
+    public void shouldThrowExceptionWhenThereIsNoGroup() {
+        CruiseConfig config = new BasicCruiseConfig();
+        try {
+            config.isInFirstGroup(new CaseInsensitiveString("any-pipeline"));
+            fail("should throw exception when there is no group");
+        } catch (Exception e) {
+            assertThat(e.getMessage(), is("No pipeline group defined yet!"));
+        }
+    }
+
+    @Test
+    public void shouldReturnTrueForPipelineThatInFirstGroup() {
+        PipelineConfigs group1 = createGroup("group1", createPipelineConfig("pipeline1", "stage1"));
+        CruiseConfig config = new BasicCruiseConfig(group1);
+        assertThat("shouldReturnTrueForPipelineThatInFirstGroup", config.isInFirstGroup(new CaseInsensitiveString("pipeline1")), is(true));
+    }
+
+    @Test
+    public void shouldReturnFalseForPipelineThatNotInFirstGroup() {
+        PipelineConfigs group1 = createGroup("group1", createPipelineConfig("pipeline1", "stage1"));
+        PipelineConfigs group2 = createGroup("group2", createPipelineConfig("pipeline2", "stage2"));
+        CruiseConfig config = new BasicCruiseConfig(group1, group2);
+        assertThat("shouldReturnFalseForPipelineThatNotInFirstGroup", config.isInFirstGroup(new CaseInsensitiveString("pipeline2")), is(false));
+    }
+
+    @Test
+    public void shouldOfferAllTasksToVisitors() throws Exception {
+        CruiseConfig config = new BasicCruiseConfig();
+        Task task1 = new ExecTask("ls", "-a", "");
+        Task task2 = new AntTask();
+        setupJobWithTasks(config, task1, task2);
+
+        final List<Task> tasksVisited = new ArrayList<Task>();
+        config.accept(new TaskConfigVisitor() {
+
+            public void visit(PipelineConfig pipelineConfig, StageConfig stageConfig, JobConfig jobConfig, Task task) {
+                tasksVisited.add(task);
+            }
+        });
+
+        assertThat(tasksVisited.size(), is(2));
+        assertThat(tasksVisited.get(0), is(task1));
+        assertThat(tasksVisited.get(1), is(task2));
+    }
+
+    @Test
+    public void shouldOfferNothingToVisitorsIfThereAreNoTasks() throws Exception {
+        CruiseConfig config = new BasicCruiseConfig();
+        setupJobWithTasks(config, new NullTask());
+
+        final List<Task> tasksVisited = new ArrayList<Task>();
+        config.accept(new TaskConfigVisitor() {
+
+            public void visit(PipelineConfig pipelineConfig, StageConfig stageConfig, JobConfig jobConfig, Task task) {
+                tasksVisited.add(task);
+            }
+        });
+
+        assertThat(tasksVisited.size(), is(0));
+    }
+
+    @Test
+    public void shouldReturnTrueIfThereAreTwoPipelineGroups() throws Exception {
+        CruiseConfig config = goConfigMother.cruiseConfigWithTwoPipelineGroups();
+        assertThat("shouldReturnTrueIfThereAreTwoPipelineGroups", config.hasMultiplePipelineGroups(), is(true));
+    }
+
+    @Test
+    public void shouldReturnFalseIfThereIsOnePipelineGroup() throws Exception {
+        CruiseConfig config = goConfigMother.cruiseConfigWithOnePipelineGroup();
+        assertThat("shouldReturnFalseIfThereIsOnePipelineGroup", config.hasMultiplePipelineGroups(), is(false));
+    }
+
+    @Test
+    public void shouldFindDownstreamPipelines() throws Exception {
+        CruiseConfig config = goConfigMother.defaultCruiseConfig();
+        goConfigMother.addPipeline(config, "pipeline-1", "stage-1", "job-1");
+        PipelineConfig pipeline2 = goConfigMother.addPipeline(config, "pipeline-2", "stage-2", "job-2");
+        PipelineConfig pipeline3 = goConfigMother.addPipeline(config, "pipeline-3", "stage-3", "job-3");
+        goConfigMother.setDependencyOn(config, pipeline2, "pipeline-1", "stage-1");
+        goConfigMother.setDependencyOn(config, pipeline3, "pipeline-1", "stage-1");
+        Iterable<PipelineConfig> downstream = config.getDownstreamPipelines("pipeline-1");
+        assertThat(downstream, hasItem(pipeline2));
+        assertThat(downstream, hasItem(pipeline3));
+    }
+
+    @Test
+    public void shouldReturnFalseForEmptyCruiseConfig() throws Exception {
+        CruiseConfig config = new BasicCruiseConfig();
+        assertThat("shouldReturnFalseForEmptyCruiseConfig", config.hasMultiplePipelineGroups(), is(false));
+    }
+
+    @Test
+    public void shouldReturnFalseIfNoMailHost() throws Exception {
+        assertThat(new BasicCruiseConfig().isMailHostConfigured(), is(false));
+    }
+
+    @Test
+    public void shouldReturnTrueIfMailHostIsConfigured() throws Exception {
+        MailHost mailHost = new MailHost("hostName", 1234, "user", "pass", true, true, "from", "admin@local.com");
+        assertThat(GoConfigMother.cruiseConfigWithMailHost(mailHost).isMailHostConfigured(), is(true));
+    }
+
+    @Test
+    public void shouldNotLockAPipelineWhenItIsAddedToAnEnvironment() throws Exception {
+        CruiseConfig config = GoConfigMother.configWithPipelines("pipeline-1");
+        EnvironmentConfig env = config.addEnvironment("environment");
+        env.addPipeline(new CaseInsensitiveString("pipeline-1"));
+        assertThat(config.isPipelineLocked("pipeline-1"), is(false));
+    }
+
+    @Test
+    public void shouldBeAbleToExplicitlyLockAPipeline() throws Exception {
+        CruiseConfig config = GoConfigMother.configWithPipelines("pipeline-1");
+        PipelineConfig pipelineConfig = config.pipelineConfigByName(new CaseInsensitiveString("pipeline-1"));
+        pipelineConfig.lockExplicitly();
+        assertThat(config.isPipelineLocked("pipeline-1"), is(true));
+    }
+
+
+    @Test
+    public void shouldCollectOriginErrorsFromEnvironments_InMergedConfig() {
+        pipelines = new BasicPipelineConfigs("group_main", new Authorization(), PipelineConfigMother.pipelineConfig("pipe1"));
+        BasicCruiseConfig mainCruiseConfig = new BasicCruiseConfig(pipelines);
+        PartialConfig partialConfig = PartialConfigMother.withPipelineInGroup("pipe2", "g2");
+        partialConfig.getGroups().get(0).get(0).setOrigin(new RepoConfigOrigin());
+        cruiseConfig = new BasicCruiseConfig(mainCruiseConfig, partialConfig);
+        BasicEnvironmentConfig uat = new BasicEnvironmentConfig(new CaseInsensitiveString("UAT"));
+        uat.addPipeline(new CaseInsensitiveString("pipe2"));
+        cruiseConfig.addEnvironment(uat);
+
+        List<ConfigErrors> allErrors = cruiseConfig.validateAfterPreprocess();
+        assertThat(allErrors.size(), is(1));
+        assertNotNull(allErrors.get(0).on("origin"));
+    }
+
+    @Test
+    public void shouldCollectOriginErrorsFromMaterialConfigs_InMergedConfig() {
+        BasicCruiseConfig mainCruiseConfig = new BasicCruiseConfig(pipelines);
+        PartialConfig partialConfig = PartialConfigMother.withPipelineInGroup("pipe2", "g2");
+        partialConfig.getGroups().get(0).get(0).setOrigin(new RepoConfigOrigin());
+        cruiseConfig = new BasicCruiseConfig(mainCruiseConfig, partialConfig);
+        PipelineConfig pipeline1 = goConfigMother.addPipeline(cruiseConfig, "pipeline1", "stage", "build");
+        PipelineConfig pipeline2 = PipelineConfigMother.createPipelineConfigWithStage("pipeline2", "stage");
+        pipeline2.setOrigin(new RepoConfigOrigin());
+        partialConfig.getGroups().addPipeline("g2",pipeline2);
+
+        goConfigMother.setDependencyOn(cruiseConfig, pipeline1, "pipeline2", "stage");
+
+        List<ConfigErrors> allErrors = cruiseConfig.validateAfterPreprocess();
+        assertThat(allErrors.size(), is(1));
+        assertNotNull(allErrors.get(0).on("origin"));
+    }
+
+    @Test
+    public void shouldCollectAllTheErrorsInTheChildren() {
+        CruiseConfig config = GoConfigMother.configWithPipelines("pipeline-1");
+
+        shouldCollectAllTheErrorsInTheChilderHelper(config);
+    }
+    @Test
+    public void shouldCollectAllTheErrorsInTheChildren_InMergedConfig() {
+        BasicCruiseConfig mainCruiseConfig = GoConfigMother.configWithPipelines("pipeline-1");
+        PartialConfig partialConfig = PartialConfigMother.withPipelineInGroup("pipe2", "g2");
+        partialConfig.getGroups().get(0).get(0).setOrigin(new RepoConfigOrigin());
+        CruiseConfig config = new BasicCruiseConfig(mainCruiseConfig, partialConfig);
+
+        shouldCollectAllTheErrorsInTheChilderHelper(config);
+    }
+
+    private void shouldCollectAllTheErrorsInTheChilderHelper(CruiseConfig config) {
+        config.server().security().ldapConfig().errors().add("uri", "invalid ldap uri");
+        config.server().security().ldapConfig().errors().add("searchBase", "invalid search base");
+
+        PipelineConfig pipelineConfig = config.pipelineConfigByName(new CaseInsensitiveString("pipeline-1"));
+        pipelineConfig.errors().add("base", "Some base errors");
+
+        P4MaterialConfig p4MaterialConfig = new P4MaterialConfig("localhost:1999", "view");
+        p4MaterialConfig.setConfigAttributes(Collections.singletonMap(ScmMaterialConfig.FOLDER, "p4_folder"));
+        pipelineConfig.addMaterialConfig(p4MaterialConfig);
+        p4MaterialConfig.errors().add("materialName", "material name does not follow pattern");
+
+        StageConfig stage = pipelineConfig.first();
+        stage.errors().add("role", "Roles must be proper");
+
+        List<ConfigErrors> allErrors = config.validateAfterPreprocess();
+        assertThat(allErrors.size(), is(5));
+        assertThat(allErrors.get(0).on("uri"), is("invalid ldap uri"));
+        assertThat(allErrors.get(0).on("searchBase"), is("invalid search base"));
+        assertThat(allErrors.get(1).on("base"), is("Some base errors"));
+        assertThat(allErrors.get(2).on("role"), is("Roles must be proper"));
+        assertThat(allErrors.get(3).on(ScmMaterialConfig.FOLDER), is("Destination directory is required when specifying multiple scm materials"));
+        assertThat(allErrors.get(4).on("materialName"), is("material name does not follow pattern"));
+    }
+
+    @Test
+    public void getAllErrors_shouldCollectAllErrorsInTheChildren() {
+        CruiseConfig config = GoConfigMother.configWithPipelines("pipeline-1");
+
+        config.server().security().ldapConfig().errors().add("uri", "invalid ldap uri");
+        config.server().security().ldapConfig().errors().add("searchBase", "invalid search base");
+
+        PipelineConfig pipelineConfig = config.pipelineConfigByName(new CaseInsensitiveString("pipeline-1"));
+        pipelineConfig.errors().add("base", "Some base errors");
+
+        P4MaterialConfig p4MaterialConfig = new P4MaterialConfig("localhost:1999", "view");
+        pipelineConfig.addMaterialConfig(p4MaterialConfig);
+        p4MaterialConfig.errors().add("materialName", "material name does not follow pattern");
+
+        StageConfig stage = pipelineConfig.first();
+        stage.errors().add("role", "Roles must be proper");
+
+        List<ConfigErrors> allErrors = config.getAllErrors();
+        assertThat(allErrors.size(), is(4));
+        assertThat(allErrors.get(0).on("uri"), is("invalid ldap uri"));
+        assertThat(allErrors.get(0).on("searchBase"), is("invalid search base"));
+        assertThat(allErrors.get(1).on("base"), is("Some base errors"));
+        assertThat(allErrors.get(2).on("role"), is("Roles must be proper"));
+        assertThat(allErrors.get(3).on("materialName"), is("material name does not follow pattern"));
+    }
+
+    @Test
+    public void getAllErrors_shouldIgnoreErrorsOnElementToBeSkipped() {
+        CruiseConfig config = GoConfigMother.configWithPipelines("pipeline-1");
+
+        config.server().security().ldapConfig().errors().add("uri", "invalid ldap uri");
+        config.server().security().ldapConfig().errors().add("searchBase", "invalid search base");
+
+        PipelineConfig pipelineConfig = config.pipelineConfigByName(new CaseInsensitiveString("pipeline-1"));
+        pipelineConfig.errors().add("base", "Some base errors");
+
+        P4MaterialConfig p4MaterialConfig = new P4MaterialConfig("localhost:1999", "view");
+        pipelineConfig.addMaterialConfig(p4MaterialConfig);
+        p4MaterialConfig.errors().add("materialName", "material name does not follow pattern");
+
+        StageConfig stage = pipelineConfig.first();
+        stage.errors().add("role", "Roles must be proper");
+
+        List<ConfigErrors> allErrors = config.getAllErrorsExceptFor(p4MaterialConfig);
+        assertThat(allErrors.size(), is(3));
+        assertThat(allErrors.get(0).on("uri"), is("invalid ldap uri"));
+        assertThat(allErrors.get(0).on("searchBase"), is("invalid search base"));
+        assertThat(allErrors.get(1).on("base"), is("Some base errors"));
+        assertThat(allErrors.get(2).on("role"), is("Roles must be proper"));
+    }
+
+    @Test
+    public void getAllErrors_shouldRetainAllErrorsWhenNoSubjectGiven() {
+        CruiseConfig config = GoConfigMother.configWithPipelines("pipeline-1");
+
+        config.server().security().ldapConfig().errors().add("uri", "invalid ldap uri");
+        config.server().security().ldapConfig().errors().add("searchBase", "invalid search base");
+
+        PipelineConfig pipelineConfig = config.pipelineConfigByName(new CaseInsensitiveString("pipeline-1"));
+        pipelineConfig.errors().add("base", "Some base errors");
+
+        P4MaterialConfig p4MaterialConfig = new P4MaterialConfig("localhost:1999", "view");
+        pipelineConfig.addMaterialConfig(p4MaterialConfig);
+        p4MaterialConfig.errors().add("materialName", "material name does not follow pattern");
+
+        StageConfig stage = pipelineConfig.first();
+        stage.errors().add("role", "Roles must be proper");
+
+        List<ConfigErrors> allErrors = config.getAllErrorsExceptFor(null);
+        assertThat(allErrors.size(), is(4));
+    }
+
+    @Test
+    public void shouldBuildTheValidationContextForAnOnCancelTask() {
+        CruiseConfig config = GoConfigMother.configWithPipelines("pipeline-1");
+        PipelineConfig pipelineConfig = config.pipelineConfigByName(new CaseInsensitiveString("pipeline-1"));
+        StageConfig stageConfig = pipelineConfig.get(0);
+        JobConfig jobConfig = stageConfig.getJobs().get(0);
+        ExecTask execTask = new ExecTask("ls", "-la", "dir");
+        Task mockTask = mock(Task.class);
+        when(mockTask.errors()).thenReturn(new ConfigErrors());
+        execTask.setCancelTask(mockTask);
+        jobConfig.addTask(execTask);
+
+        config.validateAfterPreprocess();
+
+        verify(mockTask).validate(ConfigSaveValidationContext.forChain(
+                config,
+                config.getGroups(),
+                config.getGroups().findGroup("defaultGroup"),
+                pipelineConfig,
+                stageConfig,
+                stageConfig.getJobs(),
+                jobConfig,
+                jobConfig.getTasks(),
+                execTask,
+                execTask.onCancelConfig()));
+    }
+
+    @Test
+    @Ignore("ShilpaG & RajeshM removed in 12208:39962f06092d, because they could not find any place in the codebase where circular reference existed(so the circular ref check was undone) - Sachin & JJ")
+    public void shouldNotFailOnCircularReference() {
+        MyValidatable foo = new MyValidatable();
+        MyValidatable bar = new MyValidatable();
+        foo.innerValidatable = bar;
+        bar.innerValidatable = foo;
+
+        GoConfigGraphWalker.Handler handler = mock(GoConfigGraphWalker.Handler.class);
+
+        new GoConfigGraphWalker(foo).walk(handler);
+
+        verify(handler).handle(same(foo), any(ValidationContext.class));
+        verify(handler).handle(same(bar), any(ValidationContext.class));
+    }
+
+    @Test
+    public void shouldNotConsiderEqualObjectsAsSame() {
+        MyValidatable foo = new AlwaysEqualMyValidatable();
+        MyValidatable bar = new AlwaysEqualMyValidatable();
+        foo.innerValidatable = bar;
+
+        GoConfigGraphWalker.Handler handler = mock(GoConfigGraphWalker.Handler.class);
+
+        new GoConfigGraphWalker(foo).walk(handler);
+
+        verify(handler).handle(same(foo), any(ValidationContext.class));
+        verify(handler).handle(same(bar), any(ValidationContext.class));
+    }
+
+    @Test
+    public void shouldIgnoreConstantFieldsWhileCollectingErrorsToAvoidPotentialCycles() {
+        CruiseConfig config = GoConfigMother.configWithPipelines("pipeline-1");
+        List<ConfigErrors> allErrors = config.validateAfterPreprocess();
+        assertThat(allErrors.size(), is(0));
+    }
+
+    @Test
+    public void shouldErrorOutWhenDependsOnItself() throws Exception {
+        CruiseConfig cruiseConfig = new BasicCruiseConfig();
+        PipelineConfig pipelineConfig = goConfigMother.addPipeline(cruiseConfig, "pipeline1", "stage", "build");
+        goConfigMother.addStageToPipeline(cruiseConfig, "pipeline1", "ft", "build");
+        goConfigMother.setDependencyOn(cruiseConfig, pipelineConfig, "pipeline1", "ft");
+        cruiseConfig.validate(null);
+        ConfigErrors errors = pipelineConfig.materialConfigs().errors();
+        assertThat(errors.on("base"), is("Circular dependency: pipeline1 <- pipeline1"));
+    }
+
+    @Test
+    public void shouldNotDuplicateErrorWhenPipelineDoesnotExist() throws Exception {
+        CruiseConfig cruiseConfig = new BasicCruiseConfig();
+        PipelineConfig pipelineConfig = goConfigMother.addPipeline(cruiseConfig, "pipeline1", "stage", "build");
+        PipelineConfig pipelineConfig2 = goConfigMother.addPipeline(cruiseConfig, "pipeline2", "stage", "build");
+        goConfigMother.addStageToPipeline(cruiseConfig, "pipeline1", "ft", "build");
+        goConfigMother.setDependencyOn(cruiseConfig, pipelineConfig2, "pipeline1", "ft");
+        goConfigMother.setDependencyOn(cruiseConfig, pipelineConfig, "invalid", "invalid");
+        cruiseConfig.validate(null);
+        List<ConfigErrors> allErrors = cruiseConfig.getAllErrors();
+        List<String> errors = new ArrayList<String>();
+        for (ConfigErrors allError : allErrors) {
+            errors.addAll(allError.getAllOn("base"));
+        }
+        assertThat(errors.size(), is(1));
+        assertThat(errors.get(0), is("Pipeline \"invalid\" does not exist. It is used from pipeline \"pipeline1\"."));
+    }
+
+    @Test
+    public void shouldErrorOutWhenTwoPipelinesDependsOnEachOther() throws Exception {
+        CruiseConfig cruiseConfig = new BasicCruiseConfig();
+        PipelineConfig pipeline1 = goConfigMother.addPipeline(cruiseConfig, "pipeline1", "stage", "build");
+        PipelineConfig pipeline2 = goConfigMother.addPipeline(cruiseConfig, "pipeline2", "stage", "build");
+        goConfigMother.setDependencyOn(cruiseConfig, pipeline2, "pipeline1", "stage");
+        goConfigMother.setDependencyOn(cruiseConfig, pipeline1, "pipeline2", "stage");
+
+        cruiseConfig.validate(null);
+
+        assertThat(pipeline1.materialConfigs().errors().isEmpty(), is(false));
+        assertThat(pipeline2.materialConfigs().errors().isEmpty(), is(false));
+    }
+
+    @Test
+    public void shouldAddPipelineWithoutValidationInAnExistingGroup() {
+        CruiseConfig cruiseConfig = new BasicCruiseConfig();
+        PipelineConfig pipeline1 = PipelineConfigMother.pipelineConfig("first");
+        PipelineConfig pipeline2 = PipelineConfigMother.pipelineConfig("first");
+        cruiseConfig.addPipelineWithoutValidation("first-group", pipeline1);
+
+        assertThat(cruiseConfig.getGroups().size(), is(1));
+        assertThat(cruiseConfig.findGroup("first-group").get(0), is(pipeline1));
+
+        cruiseConfig.addPipelineWithoutValidation("first-group", pipeline2);
+        assertThat(cruiseConfig.findGroup("first-group").get(0), is(pipeline1));
+        assertThat(cruiseConfig.findGroup("first-group").get(1), is(pipeline2));
+    }
+
+    @Test
+    public void shouldErrorOutWhenThreePipelinesFormACycle() throws Exception {
+        CruiseConfig cruiseConfig = new BasicCruiseConfig();
+        PipelineConfig pipeline1 = goConfigMother.addPipeline(cruiseConfig, "pipeline1", "stage", "build");
+        SvnMaterialConfig material = (SvnMaterialConfig) pipeline1.materialConfigs().get(0);
+        material.setConfigAttributes(Collections.singletonMap(ScmMaterialConfig.FOLDER, "svn_dir"));
+        P4MaterialConfig p4MaterialConfig = new P4MaterialConfig("localhost:1999", "view");
+        p4MaterialConfig.setConfigAttributes(Collections.singletonMap(ScmMaterialConfig.FOLDER, "p4_folder"));
+        pipeline1.addMaterialConfig(p4MaterialConfig);
+        PipelineConfig pipeline2 = goConfigMother.addPipeline(cruiseConfig, "pipeline3", "stage", "build");
+        PipelineConfig pipeline3 = goConfigMother.addPipeline(cruiseConfig, "pipeline2", "stage", "build");
+        goConfigMother.setDependencyOn(cruiseConfig, pipeline3, "pipeline3", "stage");
+        goConfigMother.setDependencyOn(cruiseConfig, pipeline2, "pipeline1", "stage");
+        goConfigMother.setDependencyOn(cruiseConfig, pipeline1, "pipeline2", "stage");
+        cruiseConfig.validate(null);
+        assertThat(pipeline1.materialConfigs().errors().isEmpty(), is(false));
+        assertThat(pipeline2.materialConfigs().errors().isEmpty(), is(false));
+        assertThat(pipeline3.materialConfigs().errors().isEmpty(), is(false));
+    }
+
+    @Test
+    public void shouldAllowCleanupOfNonExistentStages() {
+        CruiseConfig cruiseConfig = new BasicCruiseConfig();
+        assertThat(cruiseConfig.isArtifactCleanupProhibited("foo", "bar"), is(false));
+
+        PipelineConfig pipelineConfig = PipelineConfigMother.createPipelineConfig("foo-pipeline", "bar-stage", "baz-job");
+        cruiseConfig.addPipeline("defaultGrp", pipelineConfig);
+        assertThat(cruiseConfig.isArtifactCleanupProhibited("foo-pipeline", "baz-stage"), is(false));
+        assertThat(cruiseConfig.isArtifactCleanupProhibited("foo-pipeline", "bar-stage"), is(false));
+
+        ReflectionUtil.setField(pipelineConfig.getFirstStageConfig(), "artifactCleanupProhibited", true);
+        assertThat(cruiseConfig.isArtifactCleanupProhibited("foo-pipeline", "bar-stage"), is(true));
+        assertThat(cruiseConfig.isArtifactCleanupProhibited("fOO-pipeLINE", "BaR-StagE"), is(true));
+    }
+
+    @Test
+    public void shouldReturnDefaultGroupNameIfNoGroupNameIsSpecified() {
+        CruiseConfig cfg = new BasicCruiseConfig();
+        assertThat(cfg.sanitizedGroupName(null), is(BasicPipelineConfigs.DEFAULT_GROUP));
+        cfg.addPipeline("grp1", PipelineConfigMother.pipelineConfig("foo"));
+        assertThat(cfg.sanitizedGroupName(null), is(BasicPipelineConfigs.DEFAULT_GROUP));
+    }
+
+    @Test
+    public void shouldReturnSelectedGroupNameIfGroupNameIsSpecified() {
+        CruiseConfig cfg = new BasicCruiseConfig();
+        cfg.addPipeline("grp1", PipelineConfigMother.pipelineConfig("foo"));
+        assertThat(cfg.sanitizedGroupName("gr1"), is("gr1"));
+    }
+
+    @Test
+    public void shouldRemoveUserFromRoleWhenRoleIsDeleted() {
+        CruiseConfig config = new BasicCruiseConfig();
+        SecurityConfig securityConfig = new SecurityConfig(new LdapConfig(new GoCipher()), new PasswordFileConfig("foo"), false);
+        securityConfig.adminsConfig().add(new AdminUser(new CaseInsensitiveString("root")));
+        final Role role = goConfigMother.createRole("ldap-users", "root");
+        securityConfig.addRole(role);
+        config.server().useSecurity(securityConfig);
+
+        assertTrue(config.server().security().getRoles().isRoleExist(new CaseInsensitiveString("ldap-users")));
+        config.removeRole(role);
+        assertFalse(config.server().security().getRoles().isRoleExist(new CaseInsensitiveString("ldap-users")));
+    }
+
+    @Test
+    public void shouldDeleteAdminRolesInAllPipelineGroupWhenARoleIsDeleted() throws Exception {
+        final Role role = setupSecurityWithRole();
+
+        goConfigMother.addPipelineWithGroup(cruiseConfig, "group1", "p1", "s1", "b1");
+        goConfigMother.addPipelineWithGroup(cruiseConfig, "group2", "p2", "s2", "b2");
+        goConfigMother.addRoleAsViewerOfPipelineGroup(cruiseConfig, "ldap-users", "group1");
+        goConfigMother.addRoleAsViewerOfPipelineGroup(cruiseConfig, "ldap-users", "group2");
+
+        assertEquals(new HashSet<String>(Arrays.asList("group1", "group2")), cruiseConfig.groupsAffectedByDeletionOfRole("ldap-users").keySet());
+        cruiseConfig.removeRole(role);
+        assertEquals(new HashSet<String>(), cruiseConfig.groupsAffectedByDeletionOfRole("ldap-users").keySet());
+    }
+
+    @Test
+    public void shouldDeleteAdminRoleFromAllApprovalsWhenARoleIsDeleted() throws Exception {
+        final Role role = setupSecurityWithRole();
+        goConfigMother.addPipelineWithGroup(cruiseConfig, "group1", "p1", "s1", "b1");
+        goConfigMother.addApprovalForStage(cruiseConfig, "p1", "s1", "ldap-users");
+        assertEquals(1, cruiseConfig.stagesWithPermissionForRole(role.getName().toLower()).size());
+        cruiseConfig.removeRole(role);
+        assertEquals(0, cruiseConfig.stagesWithPermissionForRole(role.getName().toLower()).size());
+    }
+
+    @Test
+    public void shouldRemoveSystemAdminPermissionsForARoleWhenARoleIsDeleted() throws Exception {
+        String adminRoleName = "admin-role";
+        Role adminRole = new Role(new CaseInsensitiveString(adminRoleName));
+        adminRole.addUser(new RoleUser(new CaseInsensitiveString("admin")));
+        goConfigMother.addRole(cruiseConfig, adminRole);
+        goConfigMother.addRoleAsSuperAdmin(cruiseConfig, adminRoleName);
+        assertThat(cruiseConfig.doesAdminConfigContainRole(adminRoleName), is(true));
+        assertThat(cruiseConfig.server().security().getRoles().contains(adminRole), is(true));
+        cruiseConfig.removeRole(adminRole);
+        assertThat(cruiseConfig.doesAdminConfigContainRole(adminRoleName), is(false));
+        assertThat(cruiseConfig.server().security().getRoles().contains(adminRole), is(false));
+    }
+
+    @Test
+    public void shouldAddPackageRepository() throws Exception {
+        PackageRepository packageRepository = new PackageRepository();
+        cruiseConfig.savePackageRepository(packageRepository);
+        assertThat(cruiseConfig.getPackageRepositories().size(), is(1));
+        assertThat(cruiseConfig.getPackageRepositories().get(0), is(packageRepository));
+        assertThat(cruiseConfig.getPackageRepositories().get(0).getId(), is(notNullValue()));
+    }
+
+    @Test
+    public void shouldUpdatePackageRepository() throws Exception {
+        PackageRepository packageRepository = new PackageRepository();
+        packageRepository.setName("old");
+        cruiseConfig.savePackageRepository(packageRepository);
+
+        packageRepository.setName("new");
+        cruiseConfig.savePackageRepository(packageRepository);
+
+        assertThat(cruiseConfig.getPackageRepositories().size(), is(1));
+        assertThat(cruiseConfig.getPackageRepositories().get(0), is(packageRepository));
+        assertThat(cruiseConfig.getPackageRepositories().get(0).getId(), is(notNullValue()));
+        assertThat(cruiseConfig.getPackageRepositories().get(0).getName(), is("new"));
+    }
+
+    @Test
+    public void shouldAddPackageDefinitionToGivenRepository() throws Exception {
+        String repoId = "repo-id";
+        PackageRepository packageRepository = PackageRepositoryMother.create(repoId, "repo-name", "plugin-id", "1.0", new Configuration());
+        PackageDefinition existing = PackageDefinitionMother.create("pkg-1", "pkg1-name", new Configuration(), packageRepository);
+
+        packageRepository.setPackages(new Packages(existing));
+        cruiseConfig.setPackageRepositories(new PackageRepositories(packageRepository));
+
+        Configuration configuration = new Configuration();
+        configuration.add(new ConfigurationProperty(new ConfigurationKey("key"), new ConfigurationValue("value")));
+        configuration.add(new ConfigurationProperty(new ConfigurationKey("key-with-no-value"), new ConfigurationValue("")));
+        PackageDefinition packageDefinition = PackageDefinitionMother.create(null, "pkg2-name", configuration, packageRepository);
+        cruiseConfig.savePackageDefinition(packageDefinition);
+
+        assertThat(cruiseConfig.getPackageRepositories().size(), is(1));
+        assertThat(cruiseConfig.getPackageRepositories().get(0).getId(), is(repoId));
+
+        assertThat(cruiseConfig.getPackageRepositories().get(0).getPackages().size(), is(2));
+        assertThat(cruiseConfig.getPackageRepositories().get(0).getPackages().get(0).getId(), is(existing.getId()));
+        PackageDefinition createdPkgDef = cruiseConfig.getPackageRepositories().get(0).getPackages().get(1);
+        assertThat(createdPkgDef.getId(), is(notNullValue()));
+        assertThat(createdPkgDef.getConfiguration().getProperty("key"), is(Matchers.notNullValue()));
+        assertThat(createdPkgDef.getConfiguration().getProperty("key-with-no-value"), is(nullValue()));
+    }
+
+    @Test
+    public void shouldClearPackageRepositoryConfigurationsWhichAreEmptyWithNoErrors() throws Exception {
+        PackageRepository packageRepository = mock(PackageRepository.class);
+        when(packageRepository.isNew()).thenReturn(true);
+        cruiseConfig.savePackageRepository(packageRepository);
+        verify(packageRepository).clearEmptyConfigurations();
+    }
+
+    @Test
+    public void shouldRemovePackageRepositoryById() throws Exception {
+        PackageRepository packageRepository = PackageRepositoryMother.create(null, "repo", "pid", "1.3", new Configuration());
+        cruiseConfig.savePackageRepository(packageRepository);
+        cruiseConfig.removePackageRepository(packageRepository.getId());
+        assertThat(cruiseConfig.getPackageRepositories().find(packageRepository.getId()), is(Matchers.nullValue()));
+    }
+
+    @Test
+    public void shouldDecideIfRepoCanBeDeleted_BasedOnPackageRepositoryBeingUsedByPipelines() throws Exception {
+        PackageRepository repo1 = PackageRepositoryMother.create(null, "repo1", "plugin", "1.3", new Configuration());
+        PackageRepository repo2 = PackageRepositoryMother.create(null, "repo2", "plugin", "1.3", new Configuration());
+        PackageDefinition packageDefinition = PackageDefinitionMother.create("package", repo2);
+        repo2.addPackage(packageDefinition);
+        PipelineConfig pipeline = PipelineConfigMother.pipelineConfig("pipeline");
+        pipeline.addMaterialConfig(new PackageMaterialConfig(new CaseInsensitiveString("p1"), packageDefinition.getId(), packageDefinition));
+        cruiseConfig.addPipeline("existing_group", pipeline);
+        cruiseConfig.savePackageRepository(repo1);
+        cruiseConfig.savePackageRepository(repo2);
+        assertThat(cruiseConfig.canDeletePackageRepository(repo1), is(true));
+        assertThat(cruiseConfig.canDeletePackageRepository(repo2), is(false));
+    }
+
+    @Test
+    public void shouldDecideIfPluggableSCMMaterialCanBeDeleted_BasedOnPluggableSCMMaterialBeingUsedByPipelines() throws Exception {
+        SCM scmConfigOne = SCMMother.create("scm-id-1");
+        SCM scmConfigTwo = SCMMother.create("scm-id-2");
+        cruiseConfig.getSCMs().addAll(Arrays.asList(scmConfigOne, scmConfigTwo));
+        PipelineConfig pipeline = PipelineConfigMother.pipelineConfig("pipeline");
+        pipeline.addMaterialConfig(new PluggableSCMMaterialConfig(null, scmConfigOne, null, null));
+        cruiseConfig.addPipeline("existing_group", pipeline);
+
+        assertThat(cruiseConfig.canDeletePluggableSCMMaterial(scmConfigOne), is(false));
+        assertThat(cruiseConfig.canDeletePluggableSCMMaterial(scmConfigTwo), is(true));
+    }
+    @Test
+    public void shouldReturnConfigRepos(){
+        assertNotNull(cruiseConfig.getConfigRepos());
+    }
+
+    // tests merged config
+
+    @Test
+    public void shouldReturnGroupsOtherThanMain_WhenMerged()
+    {
+        BasicCruiseConfig mainCruiseConfig = new BasicCruiseConfig(pipelines);
+        cruiseConfig = new BasicCruiseConfig(mainCruiseConfig,
+                PartialConfigMother.withPipeline("pipe2"));
+        assertNotSame(mainCruiseConfig.getGroups(), cruiseConfig.getGroups());
+    }
+    @Test
+    public void shouldReturnTrueWhenHasGroup()
+    {
+        assertThat(cruiseConfig.hasPipelineGroup("existing_group"), is(true));
+    }
+    @Test
+    public void shouldReturnFalseWhenDoesNotHaveGroup()
+    {
+        assertThat(cruiseConfig.hasPipelineGroup("non_existing_group"),is(false));
+    }
+
+    @Test
+    public void getAllLocalPipelines_shouldReturnPipelinesOnlyFromMainPart()
+    {
+        PipelineConfig pipe1 = PipelineConfigMother.pipelineConfig("pipe1");
+        pipelines = new BasicPipelineConfigs("group_main", new Authorization(), pipe1);
+        BasicCruiseConfig mainCruiseConfig = new BasicCruiseConfig(pipelines);
+        cruiseConfig = new BasicCruiseConfig(mainCruiseConfig,
+                PartialConfigMother.withPipeline("pipe2"));
+
+        assertThat(cruiseConfig.getAllLocalPipelineConfigs().size(), is(1));
+        assertThat(cruiseConfig.getAllLocalPipelineConfigs(),hasItem(pipe1));
+    }
+
+    @Test
+    public void shouldReturnTrueHasPipelinesFrom2Parts()
+    {
+        pipelines = new BasicPipelineConfigs("group_main", new Authorization(), PipelineConfigMother.pipelineConfig("pipe1"));
+        BasicCruiseConfig mainCruiseConfig = new BasicCruiseConfig(pipelines);
+        cruiseConfig = new BasicCruiseConfig(mainCruiseConfig,
+                PartialConfigMother.withPipeline("pipe2"));
+
+        assertThat(cruiseConfig.hasPipelineNamed(new CaseInsensitiveString("pipe1")),is(true));
+        assertThat(cruiseConfig.hasPipelineNamed(new CaseInsensitiveString("pipe2")),is(true));
+    }
+    @Test
+    public void shouldReturnFalseWhenHasNotPipelinesFrom2Parts()
+    {
+        pipelines = new BasicPipelineConfigs("group_main", new Authorization(), PipelineConfigMother.pipelineConfig("pipe1"));
+        BasicCruiseConfig mainCruiseConfig = new BasicCruiseConfig(pipelines);
+        cruiseConfig = new BasicCruiseConfig(mainCruiseConfig,
+                PartialConfigMother.withPipeline("pipe2"));
+
+        assertThat(cruiseConfig.hasPipelineNamed(new CaseInsensitiveString("pipe3")), is(false));
+    }
+    @Test
+    public void shouldReturnGroupsFrom2Parts()
+    {
+        pipelines = new BasicPipelineConfigs("group_main", new Authorization(), PipelineConfigMother.pipelineConfig("pipe1"));
+        BasicCruiseConfig mainCruiseConfig = new BasicCruiseConfig(pipelines);
+        cruiseConfig = new BasicCruiseConfig(mainCruiseConfig,
+                PartialConfigMother.withPipelineInGroup("pipe2", "g2"));
+
+        assertThat(cruiseConfig.hasPipelineGroup("g2"),is(true));
+    }
+    @Test
+    public void shouldAddPipelineToMain()
+    {
+        pipelines = new BasicPipelineConfigs("group_main", new Authorization(), PipelineConfigMother.pipelineConfig("pipe1"));
+        pipelines.setOrigin(new FileConfigOrigin());
+        BasicCruiseConfig mainCruiseConfig = new BasicCruiseConfig(pipelines);
+        cruiseConfig = new BasicCruiseConfig(mainCruiseConfig,
+                PartialConfigMother.withPipeline("pipe2"));
+        cruiseConfig.addPipeline("group_main", PipelineConfigMother.pipelineConfig("pipe3"));
+
+        assertThat(mainCruiseConfig.hasPipelineNamed(new CaseInsensitiveString("pipe3")), is(true));
+        assertThat(cruiseConfig.hasPipelineNamed(new CaseInsensitiveString("pipe3")), is(true));
+
+    }
+    @Test
+    public void shouldgetAllPipelineNamesFromAllParts()
+    {
+        pipelines = new BasicPipelineConfigs("group_main", new Authorization(), PipelineConfigMother.pipelineConfig("pipe1"));
+        BasicCruiseConfig mainCruiseConfig = new BasicCruiseConfig(pipelines);
+        cruiseConfig = new BasicCruiseConfig(mainCruiseConfig,
+                PartialConfigMother.withPipelineInGroup("pipe2", "g2"),PartialConfigMother.withPipelineInGroup("pipe3", "g3"));
+
+        assertThat(cruiseConfig.getAllPipelineNames(), contains(
+                new CaseInsensitiveString("pipe2"),
+                new CaseInsensitiveString("pipe1"),
+                new CaseInsensitiveString("pipe3")));
+    }
+    @Test
+    public  void shouldGetJobConfigByName()
+    {
+        goConfigMother.addPipeline(cruiseConfig, "cruise", "dev", "linux-firefox");
+        JobConfig job = cruiseConfig.jobConfigByName("cruise", "dev", "linux-firefox", true);
+        assertNotNull(job);
+    }
+    @Test
+    public void createsMergePipelineConfigsOnlyWhenManyParts()
+    {
+        assertThat(cruiseConfig.getGroups().get(0) instanceof MergePipelineConfigs, is(false));
+
+        BasicCruiseConfig mainCruiseConfig = new BasicCruiseConfig(pipelines);
+        cruiseConfig = new BasicCruiseConfig(mainCruiseConfig,
+                PartialConfigMother.withPipelineInGroup("pipe2", "existing_group"));
+        assertThat(cruiseConfig.getGroups().get(0) instanceof MergePipelineConfigs, is(true));
+
+    }
+    @Test
+    public void shouldReturnOriginAsASumOfAllOrigins()
+    {
+        BasicCruiseConfig mainCruiseConfig = new BasicCruiseConfig(pipelines);
+        FileConfigOrigin fileOrigin = new FileConfigOrigin();
+        mainCruiseConfig.setOrigins(fileOrigin);
+
+        PartialConfig part = PartialConfigMother.withPipeline("pipe2");
+        RepoConfigOrigin repoOrigin = new RepoConfigOrigin();
+        part.setOrigin(repoOrigin);
+        cruiseConfig = new BasicCruiseConfig(mainCruiseConfig,part);
+
+        ConfigOrigin allOrigins = cruiseConfig.getOrigin();
+        assertThat(allOrigins instanceof MergeConfigOrigin,is(true));
+
+        MergeConfigOrigin mergeConfigOrigin = (MergeConfigOrigin)allOrigins;
+        assertThat(mergeConfigOrigin.size(),is(2));
+        assertThat(mergeConfigOrigin.contains(fileOrigin),is(true));
+        assertThat(mergeConfigOrigin.contains(repoOrigin),is(true));
+    }
+    @Test
+    public void shouldAddPipelineToNewGroup_InMergeAndLocalScope()
+    {
+        pipelines = new BasicPipelineConfigs("group_main", new Authorization(), PipelineConfigMother.pipelineConfig("pipe1"));
+        BasicCruiseConfig localCruiseConfig = new BasicCruiseConfig(pipelines);
+        cruiseConfig = new BasicCruiseConfig(localCruiseConfig,
+                PartialConfigMother.withPipelineInGroup("pipe2", "remote_group"));
+
+        PipelineConfig pipe3 = PipelineConfigMother.pipelineConfig("pipe3");
+        cruiseConfig.addPipeline("newGroup", pipe3);
+
+        assertThat(cruiseConfig.allPipelines().size(),is(3));
+        assertThat(cruiseConfig.hasPipelineNamed(new CaseInsensitiveString("pipe3")),is(true));
+
+        assertThat(localCruiseConfig.allPipelines().size(),is(2));
+        assertThat(localCruiseConfig.hasPipelineNamed(new CaseInsensitiveString("pipe1")),is(true));
+        assertThat(localCruiseConfig.hasPipelineNamed(new CaseInsensitiveString("pipe3")),is(true));
+        assertThat(localCruiseConfig.pipelines("newGroup").contains(pipe3),is(true));
+    }
+    @Test
+    public void shouldAddPipelineToExistingGroup_InMergeAndLocalScope()
+    {
+        pipelines = new BasicPipelineConfigs("group_main", new Authorization(), PipelineConfigMother.pipelineConfig("pipe1"));
+        BasicCruiseConfig localCruiseConfig = new BasicCruiseConfig(pipelines);
+        cruiseConfig = new BasicCruiseConfig(localCruiseConfig,
+                PartialConfigMother.withPipelineInGroup("pipe2", "remote_group"));
+
+        PipelineConfig pipe3 = PipelineConfigMother.pipelineConfig("pipe3");
+        cruiseConfig.addPipeline("remote_group", pipe3);
+
+        assertThat(cruiseConfig.allPipelines().size(),is(3));
+        assertThat(cruiseConfig.hasPipelineNamed(new CaseInsensitiveString("pipe3")),is(true));
+
+        assertThat(localCruiseConfig.allPipelines().size(),is(2));
+        assertThat(localCruiseConfig.hasPipelineNamed(new CaseInsensitiveString("pipe1")),is(true));
+        assertThat(localCruiseConfig.hasPipelineNamed(new CaseInsensitiveString("pipe3")),is(true));
+        assertThat(localCruiseConfig.pipelines("remote_group").contains(pipe3),is(true));
+    }
+    @Test
+    public void shouldFailToAddDuplicatePipelineAlreadyDefinedInConfigRepo()
+    {
+        pipelines = new BasicPipelineConfigs("group_main", new Authorization(), PipelineConfigMother.pipelineConfig("pipe1"));
+        BasicCruiseConfig localCruiseConfig = new BasicCruiseConfig(pipelines);
+        cruiseConfig = new BasicCruiseConfig(localCruiseConfig,
+                PartialConfigMother.withPipelineInGroup("pipe2", "remote_group"));
+
+        PipelineConfig pipe2Dup = PipelineConfigMother.pipelineConfig("pipe2");
+        try {
+            cruiseConfig.addPipeline("doesNotMatterWhichGroup", pipe2Dup);
+        }
+        catch (Exception ex)
+        {
+            assertThat(ex.getMessage(),is("Pipeline called 'pipe2' is already defined in configuration repository http://some.git at 1234fed"));
+        }
+
+        assertThat(cruiseConfig.allPipelines().size(),is(2));
+        assertThat(cruiseConfig.hasPipelineNamed(new CaseInsensitiveString("pipe2")),is(true));
+
+        assertThat(localCruiseConfig.allPipelines().size(),is(1));
+        assertThat(localCruiseConfig.hasPipelineNamed(new CaseInsensitiveString("pipe1")),is(true));
+        assertThat(localCruiseConfig.hasPipelineNamed(new CaseInsensitiveString("pipe2")),is(false));
+    }
+
+    @Test
+    public void shouldGetUniqueMaterialsWithConfigRepos()
+    {
+        BasicCruiseConfig mainCruiseConfig = new BasicCruiseConfig(pipelines);
+        ConfigReposConfig reposConfig = new ConfigReposConfig();
+        GitMaterialConfig configRepo = new GitMaterialConfig("http://git");
+        reposConfig.add(new ConfigRepoConfig(configRepo,"myplug"));
+        mainCruiseConfig.setConfigRepos(reposConfig);
+
+        PartialConfig partialConfig = PartialConfigMother.withPipeline("pipe2");
+        MaterialConfig pipeRepo = partialConfig.getGroups().get(0).get(0).materialConfigs().get(0);
+
+        cruiseConfig = new BasicCruiseConfig(mainCruiseConfig,  partialConfig);
+
+        Set<MaterialConfig> materials = cruiseConfig.getAllUniqueMaterialsBelongingToAutoPipelinesAndConfigRepos();
+        assertThat(materials,hasItem(configRepo));
+        assertThat(materials,hasItem(pipeRepo));
+        assertThat(materials.size(),is(2));
+    }
+    @Test
+    public void shouldGetUniqueMaterialsWithoutConfigRepos()
+    {
+        BasicCruiseConfig mainCruiseConfig = new BasicCruiseConfig(pipelines);
+        ConfigReposConfig reposConfig = new ConfigReposConfig();
+        GitMaterialConfig configRepo = new GitMaterialConfig("http://git");
+        reposConfig.add(new ConfigRepoConfig(configRepo,"myplug"));
+        mainCruiseConfig.setConfigRepos(reposConfig);
+
+        PartialConfig partialConfig = PartialConfigMother.withPipeline("pipe2");
+        MaterialConfig pipeRepo = partialConfig.getGroups().get(0).get(0).materialConfigs().get(0);
+
+        cruiseConfig = new BasicCruiseConfig(mainCruiseConfig,  partialConfig);
+
+        Set<MaterialConfig> materials = cruiseConfig.getAllUniqueMaterialsBelongingToAutoPipelines();
+        assertThat(materials,hasItem(pipeRepo));
+        assertThat(materials.size(),is(1));
+    }
+
+    // UI-like scenarios
+    @Test
+    public void shouldCreateEmptyEnvironmentConfigForEditsWithUIOrigin_WhenFileHasNoEnvironment_AndForEdit()
+    {
+        BasicCruiseConfig mainCruiseConfig = new BasicCruiseConfig(pipelines);
+        PartialConfig partialConfig = PartialConfigMother.withEnvironment("remoteEnv");
+        partialConfig.setOrigins(new RepoConfigOrigin());
+        cruiseConfig = new BasicCruiseConfig(mainCruiseConfig,true,  partialConfig);
+
+        assertThat(cruiseConfig.getEnvironments().size(),is(1));
+        assertThat(cruiseConfig.getEnvironments().get(0) instanceof MergeEnvironmentConfig,is(true));
+        assertThat(cruiseConfig.getEnvironments().get(0).name(), is(new CaseInsensitiveString("remoteEnv")));
+        MergeEnvironmentConfig mergedEnv = (MergeEnvironmentConfig)cruiseConfig.getEnvironments().get(0);
+        assertThat(mergedEnv.size(),is(2));
+    }
+    @Test
+    public void shouldCreateEmptyEnvironmentConfigForEditsWithUIOrigin_WhenFileHasNoEnvironmentAnd2RemoteParts_AndForEdit()
+    {
+        BasicCruiseConfig mainCruiseConfig = new BasicCruiseConfig(pipelines);
+        PartialConfig partialConfig1 = PartialConfigMother.withEnvironment("remoteEnv");
+        partialConfig1.setOrigins(new RepoConfigOrigin());
+        PartialConfig partialConfig2 = PartialConfigMother.withEnvironment("remoteEnv");
+        partialConfig2.setOrigins(new RepoConfigOrigin());
+        cruiseConfig = new BasicCruiseConfig(mainCruiseConfig,true,  partialConfig1,partialConfig2);
+
+        assertThat(cruiseConfig.getEnvironments().size(),is(1));
+        assertThat(cruiseConfig.getEnvironments().get(0) instanceof MergeEnvironmentConfig,is(true));
+        assertThat(cruiseConfig.getEnvironments().get(0).name(), is(new CaseInsensitiveString("remoteEnv")));
+        MergeEnvironmentConfig mergedEnv = (MergeEnvironmentConfig)cruiseConfig.getEnvironments().get(0);
+        assertThat(mergedEnv.size(),is(3));
+    }
+    @Test
+    public void shouldNotCreateMergeEnvironmentConfig_WhenFileHasNoEnvironment_AndNotForEdit()
+    {
+        BasicCruiseConfig mainCruiseConfig = new BasicCruiseConfig(pipelines);
+        PartialConfig partialConfig = PartialConfigMother.withEnvironment("remoteEnv");
+        partialConfig.setOrigins(new RepoConfigOrigin());
+        cruiseConfig = new BasicCruiseConfig(mainCruiseConfig,false,  partialConfig);
+
+        assertThat(cruiseConfig.getEnvironments().size(),is(1));
+        assertThat(cruiseConfig.getEnvironments().get(0) instanceof MergeEnvironmentConfig, is(false));
+        assertThat(cruiseConfig.getEnvironments().get(0).name(), is(new CaseInsensitiveString("remoteEnv")));
+        assertThat(cruiseConfig.getEnvironments().get(0).isLocal(), is(false));
+    }
+    @Test
+    public void shouldNotCreateEmptyEnvironmentConfigForEditsWithUIOrigin_WhenFileHasEnvironment_AndForEdit()
+    {
+        BasicCruiseConfig mainCruiseConfig = new BasicCruiseConfig(pipelines);
+        mainCruiseConfig.addEnvironment(new BasicEnvironmentConfig(new CaseInsensitiveString("Env")));
+        mainCruiseConfig.setOrigins(new FileConfigOrigin());
+        PartialConfig partialConfig = PartialConfigMother.withEnvironment("Env");
+        partialConfig.setOrigins(new RepoConfigOrigin());
+        cruiseConfig = new BasicCruiseConfig(mainCruiseConfig,true,  partialConfig);
+
+        assertThat(cruiseConfig.getEnvironments().size(),is(1));
+        assertThat(cruiseConfig.getEnvironments().get(0) instanceof MergeEnvironmentConfig,is(true));
+        assertThat(cruiseConfig.getEnvironments().get(0).name(), is(new CaseInsensitiveString("Env")));
+
+        MergeEnvironmentConfig mergedEnv = (MergeEnvironmentConfig)cruiseConfig.getEnvironments().get(0);
+        assertThat(mergedEnv.size(),is(2));
+        assertThat(mergedEnv.get(0).isLocal(), is(true));
+        assertThat(mergedEnv.get(1).isLocal(), is(false));
+
+    }
+
+    @Test
+    public void shouldModifyEmptyEnvironmentConfigWithUIOrigin()
+    {
+        BasicCruiseConfig mainCruiseConfig = new BasicCruiseConfig(pipelines);
+        PartialConfig partialConfig = PartialConfigMother.withEnvironment("remoteEnv");
+        partialConfig.setOrigins(new RepoConfigOrigin());
+        cruiseConfig = new BasicCruiseConfig(mainCruiseConfig,true,  partialConfig);
+
+        cruiseConfig.getEnvironments().get(0).addAgent("agent");
+        MergeEnvironmentConfig mergedEnv = (MergeEnvironmentConfig)cruiseConfig.getEnvironments().get(0);
+        assertThat(mergedEnv.getFirstEditablePart().getAgents(),hasItem(new EnvironmentAgentConfig("agent")));
+    }
+
+    @Test
+    public void shouldModifyEnvironmentConfigWithFileOrigin()
+    {
+        BasicCruiseConfig mainCruiseConfig = new BasicCruiseConfig(pipelines);
+        BasicEnvironmentConfig envInFile = new BasicEnvironmentConfig(new CaseInsensitiveString("Env"));
+        mainCruiseConfig.addEnvironment(envInFile);
+        mainCruiseConfig.setOrigins(new FileConfigOrigin());
+        PartialConfig partialConfig = PartialConfigMother.withEnvironment("Env");
+        partialConfig.setOrigins(new RepoConfigOrigin());
+        cruiseConfig = new BasicCruiseConfig(mainCruiseConfig,true,  partialConfig);
+
+        cruiseConfig.getEnvironments().get(0).addAgent("agent");
+
+        assertThat(envInFile.getAgents(),hasItem(new EnvironmentAgentConfig("agent")));
+    }
+
+    @Test
+    public void shouldReturnEnvironmentConfigAddedForUIEditsWhenGetLocal_WhenThereAreChangesViaUI()
+    {
+        BasicCruiseConfig mainCruiseConfig = new BasicCruiseConfig(pipelines);
+        PartialConfig partialConfig = PartialConfigMother.withEnvironment("remoteEnv");
+        partialConfig.setOrigins(new RepoConfigOrigin());
+        cruiseConfig = new BasicCruiseConfig(mainCruiseConfig,true,  partialConfig);
+
+        cruiseConfig.getEnvironments().get(0).addPipeline(new CaseInsensitiveString("pipeUI"));
+
+        CruiseConfig onlyLocalConfig = cruiseConfig.getLocal();
+        assertThat(onlyLocalConfig.getEnvironments().hasEnvironmentNamed(new CaseInsensitiveString("remoteEnv")),is(true));
+    }
+
+    @Test
+    public void shouldNotReturnEnvironmentConfigAddedForUIEditsWhenGetLocal_WhenThereAreNoChangesViaUI()
+    {
+        BasicCruiseConfig mainCruiseConfig = new BasicCruiseConfig(pipelines);
+        PartialConfig partialConfig = PartialConfigMother.withEnvironment("remoteEnv");
+        partialConfig.setOrigins(new RepoConfigOrigin());
+        cruiseConfig = new BasicCruiseConfig(mainCruiseConfig,true,  partialConfig);
+
+        // nothing added, no need to have remoteEnv in xml
+
+        CruiseConfig onlyLocalConfig = cruiseConfig.getLocal();
+        assertThat(onlyLocalConfig.getEnvironments().hasEnvironmentNamed(new CaseInsensitiveString("remoteEnv")),is(false));
+    }
+
+    @Test
+    public void shouldAddAuthorizationToPipelinesConfigForEditsWithUIOrigin_WhenFileHasNoPipelineGroupYet_AndForEdit()
+    {
+        BasicCruiseConfig mainCruiseConfig = new BasicCruiseConfig();
+        // only remotely defined group
+        PartialConfig partialConfig = PartialConfigMother.withPipelineInGroup("pipe1","group1");
+        partialConfig.setOrigins(new RepoConfigOrigin());
+        cruiseConfig = new BasicCruiseConfig(mainCruiseConfig,true,  partialConfig);
+
+        assertThat(cruiseConfig.getGroups().size(),is(1));
+        assertThat(cruiseConfig.getGroups().get(0) instanceof MergePipelineConfigs,is(true));
+        assertThat(cruiseConfig.getGroups().get(0).getGroup(), is("group1"));
+
+        MergePipelineConfigs mergedEnv = (MergePipelineConfigs)cruiseConfig.getGroups().get(0);
+        assertThat(mergedEnv.getLocal().getOrigin(), Is.<ConfigOrigin>is(new UIConfigOrigin()));
+
+        Authorization authorization = new Authorization(new AdminsConfig(
+                new AdminUser(new CaseInsensitiveString("firstTemplate-admin"))));
+        cruiseConfig.getGroups().get(0).setAuthorization(authorization);
+
+        assertThat(mergedEnv.getLocal().getAuthorization(),is(authorization));
+    }
+
+    private Role setupSecurityWithRole() {
+        SecurityConfig securityConfig = new SecurityConfig(new LdapConfig(new GoCipher()), new PasswordFileConfig("foo"), false);
+        securityConfig.adminsConfig().add(new AdminUser(new CaseInsensitiveString("root")));
+        final Role ldapUsersRole = goConfigMother.createRole("ldap-users", "root");
+        securityConfig.addRole(ldapUsersRole);
+        cruiseConfig.server().useSecurity(securityConfig);
+        return ldapUsersRole;
+    }
+
+    private StageConfig stageConfig(String pipelineName, String stageName) {
+        return cruiseConfig.stageConfigByName(new CaseInsensitiveString(pipelineName), new CaseInsensitiveString(stageName));
+    }
+
+    private void setupJobWithTasks(CruiseConfig config, Task... tasks) throws Exception {
+        goConfigMother.addPipeline(config, "cruise", "dev", "linux-firefox");
+        JobConfig job = config.jobConfigByName("cruise", "dev", "linux-firefox", true);
+
+        for (Task task : tasks) {
+            job.addTask(task);
+        }
+    }
+
+    private JobConfig jobConfig(String jobConfigName) {
+        return new JobConfig(new CaseInsensitiveString(jobConfigName), null, null);
+    }
+
+    private PipelineConfig addPipeline(String pipelineName, String stageName, JobConfig... jobConfigs) {
+        PipelineConfig pipeline = new PipelineConfig(new CaseInsensitiveString(pipelineName), new MaterialConfigs());
+        pipeline.add(new StageConfig(new CaseInsensitiveString(stageName), new JobConfigs(jobConfigs)));
+        pipelines.add(pipeline);
+        return pipeline;
+    }
+
+    private void addPipelineWithStages(String pipelineName, String stageName, JobConfig... jobConfigs) {
+        PipelineConfig pipeline = new PipelineConfig(new CaseInsensitiveString(pipelineName), (MaterialConfigs) null);
+        pipeline.add(new StageConfig(new CaseInsensitiveString(stageName), new JobConfigs(jobConfigs)));
+        pipeline.add(new StageConfig(new CaseInsensitiveString(stageName + "2"), new JobConfigs(jobConfigs)));
+        pipelines.add(pipeline);
+    }
+
+    private static class MyValidatable implements Validatable {
+        public Validatable innerValidatable;
+
+        public void validate(ValidationContext validationContext) {
+        }
+
+        public ConfigErrors errors() {
+            return new ConfigErrors();
+        }
+
+        public void addError(String fieldName, String message) {
+        }
+
+    }
+
+    private static class AlwaysEqualMyValidatable extends MyValidatable {
+        @Override
+        public final int hashCode() {
+            return 42;
+        }
+
+        @Override
+        public final boolean equals(Object obj) {
+            return true;
+        }
+    }
+}

--- a/common/test/unit/com/thoughtworks/go/domain/CruiseConfigTestBase.java
+++ b/common/test/unit/com/thoughtworks/go/domain/CruiseConfigTestBase.java
@@ -809,6 +809,78 @@ public abstract class CruiseConfigTestBase {
     }
 
     @Test
+    public void getAllLocalPipelines_shouldReturnPipelinesOnlyFromMainPart()
+    {
+        PipelineConfig pipe1 = PipelineConfigMother.pipelineConfig("pipe1");
+        pipelines = new BasicPipelineConfigs("group_main", new Authorization(), pipe1);
+        BasicCruiseConfig mainCruiseConfig = new BasicCruiseConfig(pipelines);
+        cruiseConfig = new BasicCruiseConfig(mainCruiseConfig,
+                PartialConfigMother.withPipeline("pipe2"));
+
+        assertThat(cruiseConfig.getAllLocalPipelineConfigs().size(), is(1));
+        assertThat(cruiseConfig.getAllLocalPipelineConfigs(),hasItem(pipe1));
+    }
+
+    @Test
+    public void shouldReturnTrueHasPipelinesFrom2Parts()
+    {
+        pipelines = new BasicPipelineConfigs("group_main", new Authorization(), PipelineConfigMother.pipelineConfig("pipe1"));
+        BasicCruiseConfig mainCruiseConfig = new BasicCruiseConfig(pipelines);
+        cruiseConfig = new BasicCruiseConfig(mainCruiseConfig,
+                PartialConfigMother.withPipeline("pipe2"));
+
+        assertThat(cruiseConfig.hasPipelineNamed(new CaseInsensitiveString("pipe1")),is(true));
+        assertThat(cruiseConfig.hasPipelineNamed(new CaseInsensitiveString("pipe2")),is(true));
+    }
+    @Test
+    public void shouldReturnFalseWhenHasNotPipelinesFrom2Parts()
+    {
+        pipelines = new BasicPipelineConfigs("group_main", new Authorization(), PipelineConfigMother.pipelineConfig("pipe1"));
+        BasicCruiseConfig mainCruiseConfig = new BasicCruiseConfig(pipelines);
+        cruiseConfig = new BasicCruiseConfig(mainCruiseConfig,
+                PartialConfigMother.withPipeline("pipe2"));
+
+        assertThat(cruiseConfig.hasPipelineNamed(new CaseInsensitiveString("pipe3")), is(false));
+    }
+    @Test
+    public void shouldReturnGroupsFrom2Parts()
+    {
+        pipelines = new BasicPipelineConfigs("group_main", new Authorization(), PipelineConfigMother.pipelineConfig("pipe1"));
+        BasicCruiseConfig mainCruiseConfig = new BasicCruiseConfig(pipelines);
+        cruiseConfig = new BasicCruiseConfig(mainCruiseConfig,
+                PartialConfigMother.withPipelineInGroup("pipe2", "g2"));
+
+        assertThat(cruiseConfig.hasPipelineGroup("g2"),is(true));
+    }
+    @Test
+    public void shouldAddPipelineToMain()
+    {
+        pipelines = new BasicPipelineConfigs("group_main", new Authorization(), PipelineConfigMother.pipelineConfig("pipe1"));
+        pipelines.setOrigin(new FileConfigOrigin());
+        BasicCruiseConfig mainCruiseConfig = new BasicCruiseConfig(pipelines);
+        cruiseConfig = new BasicCruiseConfig(mainCruiseConfig,
+                PartialConfigMother.withPipeline("pipe2"));
+        cruiseConfig.addPipeline("group_main", PipelineConfigMother.pipelineConfig("pipe3"));
+
+        assertThat(mainCruiseConfig.hasPipelineNamed(new CaseInsensitiveString("pipe3")), is(true));
+        assertThat(cruiseConfig.hasPipelineNamed(new CaseInsensitiveString("pipe3")), is(true));
+
+    }
+    @Test
+    public void shouldgetAllPipelineNamesFromAllParts()
+    {
+        pipelines = new BasicPipelineConfigs("group_main", new Authorization(), PipelineConfigMother.pipelineConfig("pipe1"));
+        BasicCruiseConfig mainCruiseConfig = new BasicCruiseConfig(pipelines);
+        cruiseConfig = new BasicCruiseConfig(mainCruiseConfig,
+                PartialConfigMother.withPipelineInGroup("pipe2", "g2"),PartialConfigMother.withPipelineInGroup("pipe3", "g3"));
+
+        assertThat(cruiseConfig.getAllPipelineNames(), contains(
+                new CaseInsensitiveString("pipe2"),
+                new CaseInsensitiveString("pipe1"),
+                new CaseInsensitiveString("pipe3")));
+    }
+
+    @Test
     public  void shouldGetJobConfigByName()
     {
         goConfigMother.addPipeline(cruiseConfig, "cruise", "dev", "linux-firefox");

--- a/common/test/unit/com/thoughtworks/go/domain/CruiseConfigTestBase.java
+++ b/common/test/unit/com/thoughtworks/go/domain/CruiseConfigTestBase.java
@@ -27,6 +27,7 @@ import com.thoughtworks.go.config.materials.git.GitMaterialConfig;
 import com.thoughtworks.go.config.materials.perforce.P4MaterialConfig;
 import com.thoughtworks.go.config.materials.svn.SvnMaterialConfig;
 import com.thoughtworks.go.config.merge.MergeConfigOrigin;
+import com.thoughtworks.go.config.merge.MergeEnvironmentConfig;
 import com.thoughtworks.go.config.merge.MergePipelineConfigs;
 import com.thoughtworks.go.config.remote.*;
 import com.thoughtworks.go.domain.config.Configuration;
@@ -53,6 +54,7 @@ import static com.thoughtworks.go.helper.PipelineConfigMother.createPipelineConf
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.*;
 import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.Is.isA;
 import static org.hamcrest.core.IsNull.notNullValue;
 import static org.hamcrest.core.IsNull.nullValue;
 import static org.junit.Assert.*;
@@ -910,6 +912,151 @@ public abstract class CruiseConfigTestBase {
         List<ConfigErrors> allErrors = cruiseConfig.getAllErrors();
         assertThat((allErrors.get(0).on("base")),is("Circular dependency: p1 <- p2 <- p3 <- p1"));
 
+    }
+
+    // UI-like scenarios
+    @Test
+    public void shouldCreateEmptyEnvironmentConfigForEditsWithUIOrigin_WhenFileHasNoEnvironment_AndForEdit()
+    {
+        BasicCruiseConfig mainCruiseConfig = new BasicCruiseConfig(pipelines);
+        PartialConfig partialConfig = PartialConfigMother.withEnvironment("remoteEnv");
+        partialConfig.setOrigins(new RepoConfigOrigin());
+        cruiseConfig = new BasicCruiseConfig(mainCruiseConfig,true,  partialConfig);
+
+        assertThat(cruiseConfig.getEnvironments().size(),is(1));
+        assertThat(cruiseConfig.getEnvironments().get(0) instanceof MergeEnvironmentConfig,is(true));
+        assertThat(cruiseConfig.getEnvironments().get(0).name(), is(new CaseInsensitiveString("remoteEnv")));
+        MergeEnvironmentConfig mergedEnv = (MergeEnvironmentConfig)cruiseConfig.getEnvironments().get(0);
+        assertThat(mergedEnv.size(),is(2));
+    }
+    @Test
+    public void shouldCreateEmptyEnvironmentConfigForEditsWithUIOrigin_WhenFileHasNoEnvironmentAnd2RemoteParts_AndForEdit()
+    {
+        BasicCruiseConfig mainCruiseConfig = new BasicCruiseConfig(pipelines);
+        PartialConfig partialConfig1 = PartialConfigMother.withEnvironment("remoteEnv");
+        partialConfig1.setOrigins(new RepoConfigOrigin());
+        PartialConfig partialConfig2 = PartialConfigMother.withEnvironment("remoteEnv");
+        partialConfig2.setOrigins(new RepoConfigOrigin());
+        cruiseConfig = new BasicCruiseConfig(mainCruiseConfig,true,  partialConfig1,partialConfig2);
+
+        assertThat(cruiseConfig.getEnvironments().size(),is(1));
+        assertThat(cruiseConfig.getEnvironments().get(0) instanceof MergeEnvironmentConfig,is(true));
+        assertThat(cruiseConfig.getEnvironments().get(0).name(), is(new CaseInsensitiveString("remoteEnv")));
+        MergeEnvironmentConfig mergedEnv = (MergeEnvironmentConfig)cruiseConfig.getEnvironments().get(0);
+        assertThat(mergedEnv.size(),is(3));
+    }
+    @Test
+    public void shouldNotCreateMergeEnvironmentConfig_WhenFileHasNoEnvironment_AndNotForEdit()
+    {
+        BasicCruiseConfig mainCruiseConfig = new BasicCruiseConfig(pipelines);
+        PartialConfig partialConfig = PartialConfigMother.withEnvironment("remoteEnv");
+        partialConfig.setOrigins(new RepoConfigOrigin());
+        cruiseConfig = new BasicCruiseConfig(mainCruiseConfig,false,  partialConfig);
+
+        assertThat(cruiseConfig.getEnvironments().size(),is(1));
+        assertThat(cruiseConfig.getEnvironments().get(0) instanceof MergeEnvironmentConfig, is(false));
+        assertThat(cruiseConfig.getEnvironments().get(0).name(), is(new CaseInsensitiveString("remoteEnv")));
+        assertThat(cruiseConfig.getEnvironments().get(0).isLocal(), is(false));
+    }
+    @Test
+    public void shouldNotCreateEmptyEnvironmentConfigForEditsWithUIOrigin_WhenFileHasEnvironment_AndForEdit()
+    {
+        BasicCruiseConfig mainCruiseConfig = new BasicCruiseConfig(pipelines);
+        mainCruiseConfig.addEnvironment(new BasicEnvironmentConfig(new CaseInsensitiveString("Env")));
+        mainCruiseConfig.setOrigins(new FileConfigOrigin());
+        PartialConfig partialConfig = PartialConfigMother.withEnvironment("Env");
+        partialConfig.setOrigins(new RepoConfigOrigin());
+        cruiseConfig = new BasicCruiseConfig(mainCruiseConfig,true,  partialConfig);
+
+        assertThat(cruiseConfig.getEnvironments().size(),is(1));
+        assertThat(cruiseConfig.getEnvironments().get(0) instanceof MergeEnvironmentConfig,is(true));
+        assertThat(cruiseConfig.getEnvironments().get(0).name(), is(new CaseInsensitiveString("Env")));
+
+        MergeEnvironmentConfig mergedEnv = (MergeEnvironmentConfig)cruiseConfig.getEnvironments().get(0);
+        assertThat(mergedEnv.size(),is(2));
+        assertThat(mergedEnv.get(0).isLocal(), is(true));
+        assertThat(mergedEnv.get(1).isLocal(), is(false));
+
+    }
+
+    @Test
+    public void shouldModifyEmptyEnvironmentConfigWithUIOrigin()
+    {
+        BasicCruiseConfig mainCruiseConfig = new BasicCruiseConfig(pipelines);
+        PartialConfig partialConfig = PartialConfigMother.withEnvironment("remoteEnv");
+        partialConfig.setOrigins(new RepoConfigOrigin());
+        cruiseConfig = new BasicCruiseConfig(mainCruiseConfig,true,  partialConfig);
+
+        cruiseConfig.getEnvironments().get(0).addAgent("agent");
+        MergeEnvironmentConfig mergedEnv = (MergeEnvironmentConfig)cruiseConfig.getEnvironments().get(0);
+        assertThat(mergedEnv.getFirstEditablePart().getAgents(),hasItem(new EnvironmentAgentConfig("agent")));
+    }
+
+    @Test
+    public void shouldModifyEnvironmentConfigWithFileOrigin()
+    {
+        BasicCruiseConfig mainCruiseConfig = new BasicCruiseConfig(pipelines);
+        BasicEnvironmentConfig envInFile = new BasicEnvironmentConfig(new CaseInsensitiveString("Env"));
+        mainCruiseConfig.addEnvironment(envInFile);
+        mainCruiseConfig.setOrigins(new FileConfigOrigin());
+        PartialConfig partialConfig = PartialConfigMother.withEnvironment("Env");
+        partialConfig.setOrigins(new RepoConfigOrigin());
+        cruiseConfig = new BasicCruiseConfig(mainCruiseConfig,true,  partialConfig);
+
+        cruiseConfig.getEnvironments().get(0).addAgent("agent");
+
+        assertThat(envInFile.getAgents(),hasItem(new EnvironmentAgentConfig("agent")));
+    }
+
+    @Test
+    public void shouldReturnEnvironmentConfigAddedForUIEditsWhenGetLocal_WhenThereAreChangesViaUI()
+    {
+        BasicCruiseConfig mainCruiseConfig = new BasicCruiseConfig(pipelines);
+        PartialConfig partialConfig = PartialConfigMother.withEnvironment("remoteEnv");
+        partialConfig.setOrigins(new RepoConfigOrigin());
+        cruiseConfig = new BasicCruiseConfig(mainCruiseConfig,true,  partialConfig);
+
+        cruiseConfig.getEnvironments().get(0).addPipeline(new CaseInsensitiveString("pipeUI"));
+
+        CruiseConfig onlyLocalConfig = cruiseConfig.getLocal();
+        assertThat(onlyLocalConfig.getEnvironments().hasEnvironmentNamed(new CaseInsensitiveString("remoteEnv")),is(true));
+    }
+
+    @Test
+    public void shouldNotReturnEnvironmentConfigAddedForUIEditsWhenGetLocal_WhenThereAreNoChangesViaUI()
+    {
+        BasicCruiseConfig mainCruiseConfig = new BasicCruiseConfig(pipelines);
+        PartialConfig partialConfig = PartialConfigMother.withEnvironment("remoteEnv");
+        partialConfig.setOrigins(new RepoConfigOrigin());
+        cruiseConfig = new BasicCruiseConfig(mainCruiseConfig,true,  partialConfig);
+
+        // nothing added, no need to have remoteEnv in xml
+
+        CruiseConfig onlyLocalConfig = cruiseConfig.getLocal();
+        assertThat(onlyLocalConfig.getEnvironments().hasEnvironmentNamed(new CaseInsensitiveString("remoteEnv")),is(false));
+    }
+
+    @Test
+    public void shouldAddAuthorizationToPipelinesConfigForEditsWithUIOrigin_WhenFileHasNoPipelineGroupYet_AndForEdit()
+    {
+        BasicCruiseConfig mainCruiseConfig = new BasicCruiseConfig();
+        // only remotely defined group
+        PartialConfig partialConfig = PartialConfigMother.withPipelineInGroup("pipe1","group1");
+        partialConfig.setOrigins(new RepoConfigOrigin());
+        cruiseConfig = new BasicCruiseConfig(mainCruiseConfig,true,  partialConfig);
+
+        assertThat(cruiseConfig.getGroups().size(),is(1));
+        assertThat(cruiseConfig.getGroups().get(0) instanceof MergePipelineConfigs,is(true));
+        assertThat(cruiseConfig.getGroups().get(0).getGroup(), is("group1"));
+
+        MergePipelineConfigs mergedEnv = (MergePipelineConfigs)cruiseConfig.getGroups().get(0);
+        assertThat(mergedEnv.getLocal().getOrigin(), Is.<ConfigOrigin>is(new UIConfigOrigin()));
+
+        Authorization authorization = new Authorization(new AdminsConfig(
+                new AdminUser(new CaseInsensitiveString("firstTemplate-admin"))));
+        cruiseConfig.getGroups().get(0).setAuthorization(authorization);
+
+        assertThat(mergedEnv.getLocal().getAuthorization(),is(authorization));
     }
 
     private Role setupSecurityWithRole() {

--- a/common/test/unit/com/thoughtworks/go/domain/PipelineGroupsTest.java
+++ b/common/test/unit/com/thoughtworks/go/domain/PipelineGroupsTest.java
@@ -31,6 +31,9 @@ import com.thoughtworks.go.config.materials.mercurial.HgMaterialConfig;
 import com.thoughtworks.go.config.materials.perforce.P4MaterialConfig;
 import com.thoughtworks.go.config.materials.svn.SvnMaterialConfig;
 import com.thoughtworks.go.config.materials.tfs.TfsMaterialConfig;
+import com.thoughtworks.go.config.merge.MergePipelineConfigs;
+import com.thoughtworks.go.config.remote.FileConfigOrigin;
+import com.thoughtworks.go.config.remote.RepoConfigOrigin;
 import com.thoughtworks.go.domain.materials.MaterialConfig;
 import com.thoughtworks.go.helper.MaterialConfigsMother;
 import com.thoughtworks.go.helper.PipelineConfigMother;
@@ -244,5 +247,49 @@ public class PipelineGroupsTest {
 
         Map<String, List<Pair<PipelineConfig, PipelineConfigs>>> pluggableSCMMaterialUsageInPipelinesTwo = groups.getPluggableSCMMaterialUsageInPipelines();
         assertSame(pluggableSCMMaterialUsageInPipelinesOne, pluggableSCMMaterialUsageInPipelinesTwo);
+    }
+
+
+    @Test
+    public void shouldGetLocalPartsWhenOriginIsNull()
+    {
+        PipelineConfigs defaultGroup = createGroup("defaultGroup", createPipelineConfig("pipeline1", "stage1"));
+        PipelineGroups groups = new PipelineGroups(defaultGroup);
+        assertThat(groups.getLocal().size(), is(1));
+        assertThat(groups.getLocal().get(0), is(defaultGroup));
+    }
+    @Test
+    public void shouldGetLocalPartsWhenOriginIsFile()
+    {
+        PipelineConfigs defaultGroup = createGroup("defaultGroup", createPipelineConfig("pipeline1", "stage1"));
+        defaultGroup.setOrigins(new FileConfigOrigin());
+        PipelineGroups groups = new PipelineGroups(defaultGroup);
+        assertThat(groups.getLocal().size(), is(1));
+        assertThat(groups.getLocal().get(0), is(defaultGroup));
+    }
+    @Test
+    public void shouldGetLocalPartsWhenOriginIsRepo()
+    {
+        PipelineConfigs defaultGroup = createGroup("defaultGroup", createPipelineConfig("pipeline1", "stage1"));
+        defaultGroup.setOrigins(new RepoConfigOrigin());
+        PipelineGroups groups = new PipelineGroups(defaultGroup);
+        assertThat(groups.getLocal().size(), is(0));
+        assertThat(groups.getLocal().isEmpty(), is(true));
+    }
+
+    @Test
+    public void shouldGetLocalPartsWhenOriginIsMixed()
+    {
+        PipelineConfigs localGroup = createGroup("defaultGroup", createPipelineConfig("pipeline1", "stage1"));
+        localGroup.setOrigins(new FileConfigOrigin());
+
+        PipelineConfigs remoteGroup = createGroup("defaultGroup", createPipelineConfig("pipeline2", "stage1"));
+        remoteGroup.setOrigins(new RepoConfigOrigin());
+
+        MergePipelineConfigs mergePipelineConfigs = new MergePipelineConfigs(localGroup, remoteGroup);
+        PipelineGroups groups = new PipelineGroups(mergePipelineConfigs);
+
+        assertThat(groups.getLocal().size(), is(1));
+        assertThat(groups.getLocal(), hasItem(localGroup));
     }
 }

--- a/config/config-api/src/com/thoughtworks/go/config/BasicCruiseConfig.java
+++ b/config/config-api/src/com/thoughtworks/go/config/BasicCruiseConfig.java
@@ -150,6 +150,8 @@ public class BasicCruiseConfig implements CruiseConfig {
         void update(String groupName, String pipelineName, PipelineConfig pipeline);
 
         List<PipelineConfig> getAllLocalPipelineConfigs();
+
+        List<PartialConfig> getRemote();
     }
     private class BasicStrategy implements CruiseStrategy {
 
@@ -237,6 +239,11 @@ public class BasicCruiseConfig implements CruiseConfig {
         @Override
         public List<PipelineConfig> getAllLocalPipelineConfigs() {
             return getAllPipelineConfigs();
+        }
+
+        @Override
+        public List<PartialConfig> getRemote() {
+            return new ArrayList<>();
         }
     }
     private class MergeStrategy implements CruiseStrategy {
@@ -548,6 +555,11 @@ public class BasicCruiseConfig implements CruiseConfig {
         public List<PipelineConfig> getAllLocalPipelineConfigs() {
             return this.main.getAllPipelineConfigs();
         }
+
+        @Override
+        public List<PartialConfig> getRemote() {
+            return parts;
+        }
     }
 
     @Override
@@ -815,6 +827,11 @@ public class BasicCruiseConfig implements CruiseConfig {
     @Override
     public CruiseConfig getLocal() {
         return strategy.getLocal();
+    }
+
+    @Override
+    public List<PartialConfig> getRemote() {
+        return strategy.getRemote();
     }
 
     @Override

--- a/config/config-api/src/com/thoughtworks/go/config/BasicCruiseConfig.java
+++ b/config/config-api/src/com/thoughtworks/go/config/BasicCruiseConfig.java
@@ -141,6 +141,8 @@ public class BasicCruiseConfig implements CruiseConfig {
         void addPipelineWithoutValidation(String groupName, PipelineConfig pipelineConfig);
 
         void update(String groupName, String pipelineName, PipelineConfig pipeline);
+
+        List<PipelineConfig> getAllLocalPipelineConfigs();
     }
     private class BasicStrategy implements CruiseStrategy {
 
@@ -223,6 +225,11 @@ public class BasicCruiseConfig implements CruiseConfig {
                 groups.add(configs);
             }
             groups.update(groupName, pipelineName, pipeline);
+        }
+
+        @Override
+        public List<PipelineConfig> getAllLocalPipelineConfigs() {
+            return getAllPipelineConfigs();
         }
     }
     private class MergeStrategy implements CruiseStrategy {
@@ -416,6 +423,11 @@ public class BasicCruiseConfig implements CruiseConfig {
         public void update(String groupName, String pipelineName, PipelineConfig pipeline) {
             // this was called only from tests
             throw bomb("Cannot update pipeline group in merged configuration");
+        }
+
+        @Override
+        public List<PipelineConfig> getAllLocalPipelineConfigs() {
+            return this.main.getAllPipelineConfigs();
         }
     }
 
@@ -1352,6 +1364,11 @@ public class BasicCruiseConfig implements CruiseConfig {
     @Override
     public boolean canDeletePluggableSCMMaterial(SCM scmConfig) {
         return groups.canDeletePluggableSCMMaterial(scmConfig);
+    }
+
+    @Override
+    public List<PipelineConfig> getAllLocalPipelineConfigs() {
+        return strategy.getAllLocalPipelineConfigs();
     }
 
     @Override

--- a/config/config-api/src/com/thoughtworks/go/config/BasicCruiseConfig.java
+++ b/config/config-api/src/com/thoughtworks/go/config/BasicCruiseConfig.java
@@ -21,6 +21,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import javax.annotation.PostConstruct;
 
+import com.rits.cloning.Cloner;
 import com.thoughtworks.go.config.materials.MaterialConfigs;
 import com.thoughtworks.go.config.materials.ScmMaterialConfig;
 import com.thoughtworks.go.config.materials.dependency.DependencyMaterialConfig;
@@ -76,18 +77,24 @@ public class BasicCruiseConfig implements CruiseConfig {
     public BasicCruiseConfig() {
         strategy = new BasicStrategy();
     }
+    public BasicCruiseConfig(BasicCruiseConfig main,boolean forEdit, PartialConfig... parts){
+        List<PartialConfig> partList = Arrays.asList(parts);
+        createMergedConfig(main, partList,forEdit);
+    }
     public BasicCruiseConfig(BasicCruiseConfig main, PartialConfig... parts){
         List<PartialConfig> partList = Arrays.asList(parts);
-
-        createMergedConfig(main, partList);
+        createMergedConfig(main, partList,false);
     }
-
     public BasicCruiseConfig(BasicCruiseConfig main,List<PartialConfig> parts)
     {
-        createMergedConfig(main, parts);
+        createMergedConfig(main, parts,false);
+    }
+    public BasicCruiseConfig(BasicCruiseConfig main,boolean forEdit,List<PartialConfig> parts)
+    {
+        createMergedConfig(main, parts,forEdit);
     }
 
-    private void createMergedConfig(BasicCruiseConfig main, List<PartialConfig> partList) {
+    private void createMergedConfig(BasicCruiseConfig main, List<PartialConfig> partList,boolean forEdit) {
         this.serverConfig = main.serverConfig;
         this.packageRepositories = main.packageRepositories;
         this.scms = main.scms;
@@ -95,7 +102,7 @@ public class BasicCruiseConfig implements CruiseConfig {
         this.agents = main.agents;
         this.configRepos = main.configRepos;
 
-        MergeStrategy mergeStrategy = new MergeStrategy(main,partList);
+        MergeStrategy mergeStrategy = new MergeStrategy(main,partList,forEdit);
         this.strategy = mergeStrategy;
 
         groups = mergeStrategy.mergePipelineConfigs();
@@ -244,10 +251,12 @@ public class BasicCruiseConfig implements CruiseConfig {
          But that is done higher in services.
          */
         @IgnoreTraversal private BasicCruiseConfig main;
+        private boolean forEdit;
         private List<PartialConfig> parts = new ArrayList<PartialConfig>();
 
-        public MergeStrategy(BasicCruiseConfig main,List<PartialConfig> parts) {
+        public MergeStrategy(BasicCruiseConfig main,List<PartialConfig> parts,boolean forEdit) {
             this.main = main;
+            this.forEdit = forEdit;
             this.parts.addAll(parts);
         }
 
@@ -280,10 +289,41 @@ public class BasicCruiseConfig implements CruiseConfig {
             }
             for(List<EnvironmentConfig> oneEnv : map.values())
             {
-                if(oneEnv.size() == 1)
-                    environments.add(oneEnv.get(0));
+                if(forEdit) {
+                    // this cruise configuration may be changed (and cloned) later
+                    // if all parts are immutable then we must add a piece for edits
+                    if (oneEnv.size() == 1) {
+                        EnvironmentConfig sole = oneEnv.get(0);
+                        if (sole.isLocal()) {
+                            // the sole part is editable anyway
+                            environments.add(sole);
+                        }
+                        else {
+                            BasicEnvironmentConfig environmentConfigForEdit = new BasicEnvironmentConfig(sole.name());
+                            environmentConfigForEdit.setOrigins(new UIConfigOrigin());
+                            environments.add(new MergeEnvironmentConfig(environmentConfigForEdit, sole));
+                        }
+                    } else {
+                        MergeEnvironmentConfig merge = new MergeEnvironmentConfig(oneEnv);
+                        if(merge.getFirstEditablePartOrNull() == null)
+                        {
+                            //no parts to edit, we must add one
+                            BasicEnvironmentConfig environmentConfigForEdit = new BasicEnvironmentConfig(merge.name());
+                            environmentConfigForEdit.setOrigins(new UIConfigOrigin());
+                            merge.add(environmentConfigForEdit);
+                        }
+                        environments.add(merge);
+                    }
+                }
                 else
-                    environments.add(new MergeEnvironmentConfig(oneEnv));
+                {
+                    // there will not be any modifications on this config.
+                    // just keep all parts in simple form
+                    if(oneEnv.size() == 1)
+                        environments.add(oneEnv.get(0));
+                    else
+                        environments.add(new MergeEnvironmentConfig(oneEnv));
+                }
             }
 
             return environments;
@@ -318,10 +358,43 @@ public class BasicCruiseConfig implements CruiseConfig {
             }
             for(List<PipelineConfigs> oneGroup : map.values())
             {
-                if(oneGroup.size() == 1)
-                    groups.add(oneGroup.get(0));
+                if(forEdit) {
+                    // this cruise configuration may be changed (and cloned) later
+                    // if all parts are immutable then we must add a piece for edits
+                    if (oneGroup.size() == 1) {
+                        PipelineConfigs sole = oneGroup.get(0);
+                        if (sole.isLocal()) {
+                            // the sole part is editable anyway
+                            groups.add(sole);
+                        }
+                        else {
+                            BasicPipelineConfigs pipelineConfigsForEdit = new BasicPipelineConfigs();
+                            pipelineConfigsForEdit.setGroup(sole.getGroup());
+                            pipelineConfigsForEdit.setOrigins(new UIConfigOrigin());
+                            groups.add(new MergePipelineConfigs(pipelineConfigsForEdit, sole));
+                        }
+                    } else {
+                        MergePipelineConfigs merge = new MergePipelineConfigs(oneGroup);
+                        if(merge.getFirstEditablePartOrNull() == null)
+                        {
+                            //no parts to edit, we must add one
+                            BasicPipelineConfigs pipelineConfigsForEdit = new BasicPipelineConfigs();
+                            pipelineConfigsForEdit.setGroup(merge.getGroup());
+                            pipelineConfigsForEdit.setOrigins(new UIConfigOrigin());
+                            merge.addPart(pipelineConfigsForEdit);
+                        }
+                        groups.add(merge);
+                    }
+                }
                 else
-                    groups.add(new MergePipelineConfigs(oneGroup));
+                {
+                    // there will not be any modifications on this config.
+                    // just keep all parts in simple form
+                    if(oneGroup.size() == 1)
+                        groups.add(oneGroup.get(0));
+                    else
+                        groups.add(new MergePipelineConfigs(oneGroup));
+                }
             }
 
             return groups;
@@ -385,7 +458,53 @@ public class BasicCruiseConfig implements CruiseConfig {
 
         @Override
         public CruiseConfig getLocal() {
-            return this.main;
+            EnvironmentsConfig localEnvironments = environments.getLocal();
+            EnvironmentsConfig configsForSave = new EnvironmentsConfig();
+            for(EnvironmentConfig environmentConfig : localEnvironments)
+            {
+                if(environmentConfig.getOrigin() instanceof UIConfigOrigin)
+                {
+                    //then we have injected this so that UI has a piece to edit
+                    // we want to keep it only if there is something added
+                    if(!environmentConfig.isEnvironmentEmpty())
+                    {
+                        configsForSave.add(environmentConfig);
+                    }
+                }
+                else
+                {
+                    //origin is local file
+                    configsForSave.add(environmentConfig);
+                }
+            }
+
+            PipelineGroups localGroups = groups.getLocal();
+            PipelineGroups pipelineConfigsForSave = new PipelineGroups();
+            for(PipelineConfigs pipelineConfigs : localGroups)
+            {
+                if(pipelineConfigs.getOrigin() instanceof UIConfigOrigin)
+                {
+                    //then we have injected this so that UI has a piece to edit
+                    // we want to keep it only if there is something added
+                    if(!pipelineConfigs.isEmpty())
+                    {
+                        pipelineConfigsForSave.add(pipelineConfigs);
+                    }
+                }
+                else
+                {
+                    //origin is local file
+                    pipelineConfigsForSave.add(pipelineConfigs);
+                }
+            }
+
+            Cloner cloner = new Cloner();
+            BasicCruiseConfig configForSave = cloner.deepClone(this.main);
+
+            configForSave.setEnvironments(configsForSave);
+            configForSave.groups = localGroups;
+
+            return configForSave;
         }
 
         @Override

--- a/config/config-api/src/com/thoughtworks/go/config/BasicEnvironmentConfig.java
+++ b/config/config-api/src/com/thoughtworks/go/config/BasicEnvironmentConfig.java
@@ -298,6 +298,10 @@ public class BasicEnvironmentConfig implements EnvironmentConfig {
     @Override
     public void setOrigins(ConfigOrigin origins) {
         this.origin = origins;
+        for(EnvironmentVariableConfig environmentVariableConfig : this.variables)
+        {
+            environmentVariableConfig.setOrigins(origins);
+        }
     }
 
     public boolean isLocal() {
@@ -307,6 +311,22 @@ public class BasicEnvironmentConfig implements EnvironmentConfig {
     @Override
     public boolean isEnvironmentEmpty() {
         return this.variables.isEmpty() && this.agents.isEmpty() && this.pipelines.isEmpty();
+    }
+
+    @Override
+    public EnvironmentPipelinesConfig getRemotePipelines() {
+        if(this.isLocal())
+            return new EnvironmentPipelinesConfig();
+        else
+            return this.pipelines;
+    }
+
+    @Override
+    public EnvironmentAgentsConfig getLocalAgents() {
+        if(this.isLocal())
+            return this.agents;
+        else
+            return new EnvironmentAgentsConfig();
     }
 
 }

--- a/config/config-api/src/com/thoughtworks/go/config/BasicEnvironmentConfig.java
+++ b/config/config-api/src/com/thoughtworks/go/config/BasicEnvironmentConfig.java
@@ -283,6 +283,14 @@ public class BasicEnvironmentConfig implements EnvironmentConfig {
     }
 
     @Override
+    public EnvironmentConfig getLocal() {
+        if(this.isLocal())
+            return this;
+        else
+            return null;
+    }
+
+    @Override
     public ConfigOrigin getOrigin() {
         return origin;
     }
@@ -291,4 +299,14 @@ public class BasicEnvironmentConfig implements EnvironmentConfig {
     public void setOrigins(ConfigOrigin origins) {
         this.origin = origins;
     }
+
+    public boolean isLocal() {
+        return this.origin == null || this.origin.isLocal();
+    }
+
+    @Override
+    public boolean isEnvironmentEmpty() {
+        return this.variables.isEmpty() && this.agents.isEmpty() && this.pipelines.isEmpty();
+    }
+
 }

--- a/config/config-api/src/com/thoughtworks/go/config/BasicPipelineConfigs.java
+++ b/config/config-api/src/com/thoughtworks/go/config/BasicPipelineConfigs.java
@@ -445,4 +445,9 @@ public class BasicPipelineConfigs extends BaseCollection<PipelineConfig> impleme
     public void setOrigin(ConfigOrigin origin) {
         this.configOrigin = origin;
     }
+
+    @Override
+    public boolean hasRemoteParts() {
+        return getOrigin() != null && !getOrigin().isLocal();
+    }
 }

--- a/config/config-api/src/com/thoughtworks/go/config/BasicPipelineConfigs.java
+++ b/config/config-api/src/com/thoughtworks/go/config/BasicPipelineConfigs.java
@@ -442,6 +442,17 @@ public class BasicPipelineConfigs extends BaseCollection<PipelineConfig> impleme
         }
     }
 
+    public PipelineConfigs getLocal() {
+        if(this.isLocal())
+            return this;
+        return null;
+    }
+
+    @Override
+    public boolean isLocal() {
+        return getOrigin() == null || getOrigin().isLocal();
+    }
+
     public void setOrigin(ConfigOrigin origin) {
         this.configOrigin = origin;
     }

--- a/config/config-api/src/com/thoughtworks/go/config/CruiseConfig.java
+++ b/config/config-api/src/com/thoughtworks/go/config/CruiseConfig.java
@@ -17,6 +17,7 @@ package com.thoughtworks.go.config;
 
 import com.thoughtworks.go.config.remote.ConfigOriginTraceable;
 import com.thoughtworks.go.config.remote.ConfigReposConfig;
+import com.thoughtworks.go.config.remote.PartialConfig;
 import com.thoughtworks.go.domain.*;
 import com.thoughtworks.go.domain.materials.MaterialConfig;
 import com.thoughtworks.go.domain.packagerepository.PackageDefinition;
@@ -51,6 +52,10 @@ public interface CruiseConfig extends Validatable, ConfigOriginTraceable {
      * Gets only elements of CruiseConfig which are defined locally.
      */
     CruiseConfig getLocal();
+    /**
+     * Gets only elements of CruiseConfig which are defined remotely.
+     */
+    List<PartialConfig> getRemote();
 
     ConfigReposConfig getConfigRepos();
 

--- a/config/config-api/src/com/thoughtworks/go/config/CruiseConfig.java
+++ b/config/config-api/src/com/thoughtworks/go/config/CruiseConfig.java
@@ -251,4 +251,6 @@ public interface CruiseConfig extends Validatable, ConfigOriginTraceable {
     boolean canDeletePackageRepository(PackageRepository repository);
 
     boolean canDeletePluggableSCMMaterial(SCM scmConfig);
+
+    List<PipelineConfig> getAllLocalPipelineConfigs();
 }

--- a/config/config-api/src/com/thoughtworks/go/config/EnvironmentConfig.java
+++ b/config/config-api/src/com/thoughtworks/go/config/EnvironmentConfig.java
@@ -90,4 +90,8 @@ public interface EnvironmentConfig extends ParamsAttributeAware, Validatable, En
     boolean isLocal();
 
     boolean isEnvironmentEmpty();
+
+    EnvironmentPipelinesConfig getRemotePipelines();
+
+    EnvironmentAgentsConfig getLocalAgents();
 }

--- a/config/config-api/src/com/thoughtworks/go/config/EnvironmentConfig.java
+++ b/config/config-api/src/com/thoughtworks/go/config/EnvironmentConfig.java
@@ -85,4 +85,9 @@ public interface EnvironmentConfig extends ParamsAttributeAware, Validatable, En
 
     EnvironmentVariablesConfig getSecureVariables();
 
+    EnvironmentConfig getLocal();
+
+    boolean isLocal();
+
+    boolean isEnvironmentEmpty();
 }

--- a/config/config-api/src/com/thoughtworks/go/config/EnvironmentVariableConfig.java
+++ b/config/config-api/src/com/thoughtworks/go/config/EnvironmentVariableConfig.java
@@ -16,6 +16,14 @@
 
 package com.thoughtworks.go.config;
 
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.annotation.PostConstruct;
+
+import com.thoughtworks.go.config.remote.ConfigOrigin;
+import com.thoughtworks.go.config.remote.ConfigOriginTraceable;
 import com.thoughtworks.go.domain.ConfigErrors;
 import com.thoughtworks.go.domain.PersistentObject;
 import com.thoughtworks.go.security.GoCipher;
@@ -37,7 +45,7 @@ import static org.apache.commons.lang.StringUtils.isNotBlank;
  * @understands an environment variable value that will be passed to a job when it is run
  */
 @ConfigTag("variable")
-public class EnvironmentVariableConfig extends PersistentObject implements Serializable, Validatable, ParamsAttributeAware, PasswordEncrypter {
+public class EnvironmentVariableConfig extends PersistentObject implements Serializable, Validatable, ParamsAttributeAware, PasswordEncrypter, ConfigOriginTraceable {
     @ConfigAttribute(value = "name", optional = false)
     private String name;
 
@@ -60,6 +68,7 @@ public class EnvironmentVariableConfig extends PersistentObject implements Seria
     public static final String SECURE = "secure";
     private GoCipher goCipher = null;
     public static final String ISCHANGED = "isChanged";
+    private ConfigOrigin origin;
 
     public EnvironmentVariableConfig() {
         this.goCipher = new GoCipher();
@@ -332,5 +341,19 @@ public class EnvironmentVariableConfig extends PersistentObject implements Seria
 
     public void setEntityType(String entityType) {
         this.entityType = entityType;
+    }
+
+    @Override
+    public ConfigOrigin getOrigin() {
+        return origin;
+    }
+
+    public boolean isRemote()
+    {
+        return origin != null && !origin.isLocal();
+    }
+
+    public void setOrigins(ConfigOrigin origins) {
+        this.origin = origins;
     }
 }

--- a/config/config-api/src/com/thoughtworks/go/config/EnvironmentVariableConfig.java
+++ b/config/config-api/src/com/thoughtworks/go/config/EnvironmentVariableConfig.java
@@ -16,12 +16,6 @@
 
 package com.thoughtworks.go.config;
 
-import java.io.Serializable;
-import java.util.HashMap;
-import java.util.Map;
-
-import javax.annotation.PostConstruct;
-
 import com.thoughtworks.go.config.remote.ConfigOrigin;
 import com.thoughtworks.go.config.remote.ConfigOriginTraceable;
 import com.thoughtworks.go.domain.ConfigErrors;

--- a/config/config-api/src/com/thoughtworks/go/config/EnvironmentsConfig.java
+++ b/config/config-api/src/com/thoughtworks/go/config/EnvironmentsConfig.java
@@ -194,4 +194,15 @@ public class EnvironmentsConfig extends BaseCollection<EnvironmentConfig> implem
             environmentConfig.removeAgent(uuid);
         }
     }
+
+    public EnvironmentsConfig getLocal() {
+        EnvironmentsConfig locals = new EnvironmentsConfig();
+        for(EnvironmentConfig environmentConfig : this)
+        {
+            EnvironmentConfig local = environmentConfig.getLocal();
+            if(local != null)
+                locals.add(local);
+        }
+        return locals;
+    }
 }

--- a/config/config-api/src/com/thoughtworks/go/config/PipelineConfig.java
+++ b/config/config-api/src/com/thoughtworks/go/config/PipelineConfig.java
@@ -938,5 +938,4 @@ public class PipelineConfig extends BaseCollection<StageConfig> implements Param
     public boolean isLocal() {
         return origin == null || this.origin.isLocal();
     }
-
 }

--- a/config/config-api/src/com/thoughtworks/go/config/PipelineConfig.java
+++ b/config/config-api/src/com/thoughtworks/go/config/PipelineConfig.java
@@ -938,4 +938,5 @@ public class PipelineConfig extends BaseCollection<StageConfig> implements Param
     public boolean isLocal() {
         return origin == null || this.origin.isLocal();
     }
+
 }

--- a/config/config-api/src/com/thoughtworks/go/config/PipelineConfigs.java
+++ b/config/config-api/src/com/thoughtworks/go/config/PipelineConfigs.java
@@ -125,4 +125,8 @@ public interface PipelineConfigs extends Iterable<PipelineConfig>, Cloneable, Va
     PipelineConfig remove(int i);
 
     void validateGroupNameAndAddErrorsTo(ConfigErrors errors);
+
+    PipelineConfigs getLocal();
+
+    boolean isLocal();
 }

--- a/config/config-api/src/com/thoughtworks/go/config/PipelineConfigs.java
+++ b/config/config-api/src/com/thoughtworks/go/config/PipelineConfigs.java
@@ -40,6 +40,8 @@ public interface PipelineConfigs extends Iterable<PipelineConfig>, Cloneable, Va
 
     boolean isEmpty();
 
+    boolean hasRemoteParts();
+
     ConfigOrigin getOrigin();
 
     PipelineConfig findBy(CaseInsensitiveString pipelineName);

--- a/config/config-api/src/com/thoughtworks/go/config/merge/MergeEnvironmentConfig.java
+++ b/config/config-api/src/com/thoughtworks/go/config/merge/MergeEnvironmentConfig.java
@@ -72,7 +72,7 @@ public class MergeEnvironmentConfig extends BaseCollection<EnvironmentConfig>  i
     }
 
     private boolean isEditable(EnvironmentConfig part) {
-        return part.getOrigin() != null && part.getOrigin().canEdit();
+        return part.getOrigin() == null || part.getOrigin().canEdit();
     }
 
     public EnvironmentConfig getFirstEditablePart()
@@ -523,6 +523,36 @@ public class MergeEnvironmentConfig extends BaseCollection<EnvironmentConfig>  i
     }
 
     @Override
+    public EnvironmentConfig getLocal() {
+        for(EnvironmentConfig part : this)
+        {
+            if(part.isLocal())
+                return  part;
+        }
+        return  null;
+    }
+
+    @Override
+    public boolean isLocal() {
+        for(EnvironmentConfig part : this)
+        {
+            if(part.isLocal())
+                return false;
+        }
+        return true;
+    }
+
+    @Override
+    public boolean isEnvironmentEmpty() {
+        for(EnvironmentConfig part : this)
+        {
+            if(!part.isEnvironmentEmpty())
+                return false;
+        }
+        return true;
+    }
+
+    @Override
     public boolean equals(Object o) {
         if (this == o) {
             return true;
@@ -566,7 +596,12 @@ public class MergeEnvironmentConfig extends BaseCollection<EnvironmentConfig>  i
 
     @Override
     public ConfigOrigin getOrigin() {
-        throw new RuntimeException("Not implemented");
+        MergeConfigOrigin mergeConfigOrigin = new MergeConfigOrigin();
+        for(EnvironmentConfig part : this)
+        {
+            mergeConfigOrigin.add(part.getOrigin());
+        }
+        return mergeConfigOrigin;
     }
 
     @Override

--- a/config/config-api/src/com/thoughtworks/go/config/merge/MergeEnvironmentConfig.java
+++ b/config/config-api/src/com/thoughtworks/go/config/merge/MergeEnvironmentConfig.java
@@ -155,204 +155,13 @@ public class MergeEnvironmentConfig extends BaseCollection<EnvironmentConfig>  i
         return false;
     }
 
-
     @Override
     public void setConfigAttributes(Object attributes) {
         if (attributes == null) {
             return;
         }
-        Map attributeMap = (Map) attributes;
-        if (attributeMap.containsKey(NAME_FIELD)) {
-            CaseInsensitiveString newName = new CaseInsensitiveString((String) attributeMap.get(NAME_FIELD));
-            if(!newName.equals(this.name()))
-                throw bomb("Cannot update name of environment defined in multiple sources");
-        }
-        if (attributeMap.containsKey(PIPELINES_FIELD)) {
-            Object pipelinesAttributes = attributeMap.get(PIPELINES_FIELD);
-            this.setPipelineAttributes(pipelinesAttributes);
-        }
-        if (attributeMap.containsKey(AGENTS_FIELD)) {
-            Object agentAttributes = attributeMap.get(AGENTS_FIELD);
-            this.setAgentAttributes(agentAttributes);
-        }
-        if (attributeMap.containsKey(VARIABLES_FIELD)) {
-            Object variablesAttributes = attributeMap.get(VARIABLES_FIELD);
-            this.setVariablesAttributes(variablesAttributes);
-        }
+        this.getFirstEditablePart().setConfigAttributes(attributes);
     }
-
-    private void setVariablesAttributes(Object variablesAttributes) {
-        if (variablesAttributes != null) {
-            // these are all k=v that user wants to have set
-            List<Map> variableAttributes = (List) variablesAttributes;
-            List<EnvironmentVariableConfig> newProposed = new ArrayList<EnvironmentVariableConfig>();
-            for (Map attributeMap : variableAttributes) {
-                EnvironmentVariableConfig environmentVariableConfig = new EnvironmentVariableConfig(new GoCipher());
-                try {
-                    environmentVariableConfig.setConfigAttributes(attributeMap);
-                    newProposed.add(environmentVariableConfig);
-                } catch (IllegalArgumentException e) {
-                    continue;
-                }
-            }
-            // but we cannot remove or change assignment of any variable from non-editable sources
-
-            List<EnvironmentVariableConfig> removals = new ArrayList<EnvironmentVariableConfig>();
-            List<EnvironmentVariableConfig> changes = new ArrayList<EnvironmentVariableConfig>();
-            List<EnvironmentVariableConfig> nochanges = new ArrayList<EnvironmentVariableConfig>();
-            for(EnvironmentConfig part : this) {
-                for (EnvironmentVariableConfig existingVariable : part.getVariables()) {
-                    // lets check if user is trying to remove or change something unmodifiable
-                    boolean found = false;
-                    for(EnvironmentVariableConfig var : newProposed)
-                    {
-                        if(var.getName().equals(existingVariable.getName()))
-                        {
-                            // trying to set variable which is already set in this part
-                            if(!var.getValue().equals(existingVariable.getValue()))
-                            {
-                                // and it is trying to change current assignment
-                                if(!isEditable(part))
-                                    throw bomb(String.format("Cannot change variable %s in environment %s because it is defined in non-editable source %s",
-                                            existingVariable.getName(), this.name(), part.getOrigin()));
-                                //otherwise it can be changed
-                                if(!changes.contains(var)) {
-                                    changes.add(var);
-                                    // existing assignment must be removed
-                                    removals.add(existingVariable);
-                                }
-                            }
-                            else
-                            {
-                                // assignment did not change so forget this change
-                                if(!nochanges.contains(var))
-                                    nochanges.add(var);
-                            }
-                            found = true;
-                        }
-                    }
-                    if(!found)
-                    {
-                        // the new proposed did not contain existingVariable
-                        // therefore intent is to remove it
-                        if(!isEditable(part))
-                            throw bomb(String.format("Cannot remove variable %s from environment %s because it is defined in non-editable source %s",
-                                    existingVariable.getName(), this.name(), part.getOrigin()));
-                        removals.add(existingVariable);
-                    }
-                    // otherwise already handled
-                }
-            }
-            for(EnvironmentVariableConfig noChange : nochanges)
-            {
-                newProposed.remove(noChange);
-            }
-            // remove modifications from newProposed so that only new variables are there
-            for(EnvironmentVariableConfig noChange : changes)
-            {
-                newProposed.remove(noChange);
-            }
-            // removes what user wanted to remove
-            // and removes existing variables to be replaced
-            for(EnvironmentVariableConfig toRemove : removals)
-            {
-                for(EnvironmentConfig part : this) {
-                    part.getVariables().remove(toRemove);
-                }
-            }
-            // add variables which are to be modified
-            this.getFirstEditablePart().getVariables().addAll(changes);
-            // add new variables
-            this.getFirstEditablePart().getVariables().addAll(newProposed);
-        }
-    }
-
-    private void setAgentAttributes(Object agentsAttributes) {
-        if (agentsAttributes != null) {
-            // these are all agents that user wants to have set
-            List<Map> agentAttributes = (List) agentsAttributes;
-            List<EnvironmentAgentConfig> newProposed = new ArrayList<EnvironmentAgentConfig>();
-            for (Map attributeMap : agentAttributes) {
-                EnvironmentAgentConfig agentInEnv = new EnvironmentAgentConfig((String) attributeMap.get("uuid"));
-                newProposed.add(agentInEnv);
-            }
-            // but we cannot remove any agent from non-editable sources
-
-            List<EnvironmentAgentConfig> removals = new ArrayList<EnvironmentAgentConfig>();
-            for(EnvironmentConfig part : this) {
-                for (EnvironmentAgentConfig existingAgent : part.getAgents()) {
-                    // lets check if user is trying to remove something unmodifiable
-                    if(!newProposed.contains(existingAgent))
-                    {
-                        if(!isEditable(part))
-                            throw bomb(String.format("Cannot remove agent %s from environment %s because it is defined in non-editable source %s",
-                                    existingAgent.getUuid(), this.name(), part.getOrigin()));
-                        // otherwise it can just be removed
-                        removals.add(existingAgent);
-                    }
-                    else
-                    {
-                        // trying to set something already set in one of the parts
-                        // remove the attempt
-                        newProposed.remove(existingAgent);
-                    }
-                }
-            }
-            for(EnvironmentAgentConfig toRemove : removals)
-            {
-                for(EnvironmentConfig part : this) {
-                    part.getAgents().remove(toRemove);
-                }
-            }
-            // all we have left now are new additions
-            // let's just add them to first editable part
-            this.getFirstEditablePart().getAgents().addAll(newProposed);
-        }
-    }
-
-    private void setPipelineAttributes(Object pipelinesAttributes) {
-        if (pipelinesAttributes != null) {
-            // these are all pipelines that user wants to have set
-            List<Map> pipelineAttributes = (List) pipelinesAttributes;
-            List<EnvironmentPipelineConfig> newProposed = new ArrayList<EnvironmentPipelineConfig>();
-            for (Map attributeMap : pipelineAttributes) {
-                EnvironmentPipelineConfig pipeInEnv = new EnvironmentPipelineConfig(new CaseInsensitiveString((String) attributeMap.get("name")));
-                newProposed.add(pipeInEnv);
-            }
-            // but we cannot remove any pipelines from non-editable sources
-
-            List<EnvironmentPipelineConfig> removals = new ArrayList<EnvironmentPipelineConfig>();
-            for(EnvironmentConfig part : this) {
-                for (EnvironmentPipelineConfig existingPipeline : part.getPipelines()) {
-                    // lets check if user is trying to remove something unmodifiable
-                    if(!newProposed.contains(existingPipeline))
-                    {
-                        if(!isEditable(part))
-                            throw bomb(String.format("Cannot remove pipeline %s from environment %s because it is defined in non-editable source %s",
-                                    existingPipeline.getName(),this.name(),part.getOrigin()));
-                        // otherwise it can just be removed
-                        removals.add(existingPipeline);
-                    }
-                    else
-                    {
-                        // trying to set something already set in one of the parts
-                        // remove the attempt
-                        newProposed.remove(existingPipeline);
-                    }
-                }
-            }
-            for(EnvironmentPipelineConfig toRemove : removals)
-            {
-                for(EnvironmentConfig part : this) {
-                    part.getPipelines().remove(toRemove);
-                }
-            }
-            // all we have left now are new additions
-            // let's just add them to first editable part
-            this.getFirstEditablePart().getPipelines().addAll(newProposed);
-        }
-    }
-
 
     @Override
     public void addEnvironmentVariable(String name, String value) {
@@ -550,6 +359,26 @@ public class MergeEnvironmentConfig extends BaseCollection<EnvironmentConfig>  i
                 return false;
         }
         return true;
+    }
+
+    @Override
+    public EnvironmentPipelinesConfig getRemotePipelines() {
+        EnvironmentPipelinesConfig remotes = new EnvironmentPipelinesConfig();
+        for(EnvironmentConfig part : this)
+        {
+            remotes.addAll(part.getRemotePipelines());
+        }
+        return  remotes;
+    }
+
+    @Override
+    public EnvironmentAgentsConfig getLocalAgents() {
+        EnvironmentAgentsConfig locals = new EnvironmentAgentsConfig();
+        for(EnvironmentConfig part : this)
+        {
+            locals.addAll(part.getLocalAgents());
+        }
+        return locals;
     }
 
     @Override

--- a/config/config-api/src/com/thoughtworks/go/config/merge/MergePipelineConfigs.java
+++ b/config/config-api/src/com/thoughtworks/go/config/merge/MergePipelineConfigs.java
@@ -18,6 +18,7 @@ package com.thoughtworks.go.config.merge;
 import com.thoughtworks.go.config.*;
 import com.thoughtworks.go.config.remote.ConfigOrigin;
 import com.thoughtworks.go.config.remote.FileConfigOrigin;
+import com.thoughtworks.go.config.remote.PartialConfig;
 import com.thoughtworks.go.config.validation.NameTypeValidator;
 import com.thoughtworks.go.domain.ConfigErrors;
 import com.thoughtworks.go.domain.PiplineConfigVisitor;
@@ -155,7 +156,12 @@ public class MergePipelineConfigs implements PipelineConfigs {
 
     @Override
     public ConfigOrigin getOrigin() {
-        throw new RuntimeException("Not implemented");
+        MergeConfigOrigin origins = new MergeConfigOrigin();
+        for(PipelineConfigs part : this.parts)
+        {
+            origins.add(part.getOrigin());
+        }
+        return origins;
     }
 
     @Override

--- a/config/config-api/src/com/thoughtworks/go/config/merge/MergePipelineConfigs.java
+++ b/config/config-api/src/com/thoughtworks/go/config/merge/MergePipelineConfigs.java
@@ -49,6 +49,12 @@ public class MergePipelineConfigs implements PipelineConfigs {
         validateGroupNameUniqueness(this.parts);
     }
 
+    public void addPart(BasicPipelineConfigs pipelineConfigs) {
+        if (!StringUtils.equals(pipelineConfigs.getGroup(), this.getGroup()))
+            throw new IllegalArgumentException("Group names must be the same in merge");
+        this.parts.add(pipelineConfigs);
+    }
+
     private void validateGroupNameUniqueness(List<PipelineConfigs> parts) {
         String name = parts.get(0).getGroup();
         for (PipelineConfigs part : parts) {
@@ -226,6 +232,20 @@ public class MergePipelineConfigs implements PipelineConfigs {
     @Override
     public void validateGroupNameAndAddErrorsTo(ConfigErrors errors) {
         this.parts.get(0).validateGroupNameAndAddErrorsTo(errors);
+    }
+
+    public PipelineConfigs getLocal() {
+        for (PipelineConfigs part : this.parts)
+        {
+            if(part.isLocal())
+                return part;
+        }
+        return null;
+    }
+
+    @Override
+    public boolean isLocal() {
+        return getOrigin() == null || getOrigin().isLocal();
     }
 
     @Override

--- a/config/config-api/src/com/thoughtworks/go/config/merge/MergePipelineConfigs.java
+++ b/config/config-api/src/com/thoughtworks/go/config/merge/MergePipelineConfigs.java
@@ -184,6 +184,11 @@ public class MergePipelineConfigs implements PipelineConfigs {
     }
 
     @Override
+    public boolean hasRemoteParts() {
+        return getOrigin() != null && !getOrigin().isLocal();
+    }
+
+    @Override
     public boolean contains(PipelineConfig o) {
         for (PipelineConfigs part : this.parts)
         {

--- a/config/config-api/src/com/thoughtworks/go/config/remote/RepoConfigOrigin.java
+++ b/config/config-api/src/com/thoughtworks/go/config/remote/RepoConfigOrigin.java
@@ -46,7 +46,7 @@ public class RepoConfigOrigin implements ConfigOrigin {
 
         RepoConfigOrigin repoConfigOrigin = (RepoConfigOrigin) o;
 
-        if (!revision.equals(repoConfigOrigin.revision)) {
+        if (revision != null ? !revision.equals(repoConfigOrigin.revision) : repoConfigOrigin.revision != null) {
             return false;
         }
         if (configRepo != null ? !configRepo.equals(repoConfigOrigin.configRepo) : repoConfigOrigin.configRepo != null) {

--- a/config/config-api/src/com/thoughtworks/go/config/remote/UIConfigOrigin.java
+++ b/config/config-api/src/com/thoughtworks/go/config/remote/UIConfigOrigin.java
@@ -1,0 +1,18 @@
+package com.thoughtworks.go.config.remote;
+
+public class UIConfigOrigin implements ConfigOrigin {
+    @Override
+    public boolean canEdit() {
+        return true;
+    }
+
+    @Override
+    public boolean isLocal() {
+        return true;
+    }
+
+    @Override
+    public String displayName() {
+        return "User";
+    }
+}

--- a/config/config-api/src/com/thoughtworks/go/config/remote/UIConfigOrigin.java
+++ b/config/config-api/src/com/thoughtworks/go/config/remote/UIConfigOrigin.java
@@ -15,4 +15,20 @@ public class UIConfigOrigin implements ConfigOrigin {
     public String displayName() {
         return "User";
     }
+
+
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        return true;
+    }
+
+    public int hashCode() {
+        return 57159;
+    }
 }

--- a/config/config-api/src/com/thoughtworks/go/domain/PipelineGroups.java
+++ b/config/config-api/src/com/thoughtworks/go/domain/PipelineGroups.java
@@ -232,4 +232,15 @@ public class PipelineGroups extends BaseCollection<PipelineConfigs> implements V
         }
         return true;
     }
+
+    public PipelineGroups getLocal() {
+        PipelineGroups locals = new PipelineGroups();
+        for(PipelineConfigs pipelineConfigs : this)
+        {
+            PipelineConfigs local = pipelineConfigs.getLocal();
+            if(local != null)
+                locals.add(local);
+        }
+        return locals;
+    }
 }

--- a/config/config-api/test/com/thoughtworks/go/config/EnvironmentConfigBasicTest.java
+++ b/config/config-api/test/com/thoughtworks/go/config/EnvironmentConfigBasicTest.java
@@ -34,6 +34,21 @@ public class EnvironmentConfigBasicTest extends EnvironmentConfigTestBase {
     }
 
     @Test
+    public void shouldReturnEmptyForRemotePipelinesWhenIsLocal()
+    {
+        environmentConfig.addPipeline(new CaseInsensitiveString("pipe"));
+        assertThat(environmentConfig.getRemotePipelines().isEmpty(), is(true));
+    }
+
+    @Test
+    public void shouldReturnAllPipelinesForRemotePipelinesWhenIsRemote()
+    {
+        environmentConfig.setOrigins(new RepoConfigOrigin());
+        environmentConfig.addPipeline(new CaseInsensitiveString("pipe"));
+        assertThat(environmentConfig.getRemotePipelines().isEmpty(), is(false));
+    }
+
+    @Test
     public void shouldReturnTrueThatLocalWhenOriginIsNotSet()
     {
         environmentConfig.setOrigins(null);

--- a/config/config-api/test/com/thoughtworks/go/config/EnvironmentConfigBasicTest.java
+++ b/config/config-api/test/com/thoughtworks/go/config/EnvironmentConfigBasicTest.java
@@ -15,14 +15,14 @@
  */
 package com.thoughtworks.go.config;
 
-import com.thoughtworks.go.config.remote.ConfigOrigin;
-import com.thoughtworks.go.config.remote.FileConfigOrigin;
-import com.thoughtworks.go.config.remote.RepoConfigOrigin;
+import com.thoughtworks.go.config.remote.*;
 import com.thoughtworks.go.helper.GoConfigMother;
 import org.apache.commons.collections.map.SingletonMap;
 import org.junit.Before;
 import org.junit.Test;
 
+import static junit.framework.TestCase.assertNull;
+import static junit.framework.TestCase.assertSame;
 import static org.hamcrest.CoreMatchers.startsWith;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
@@ -31,6 +31,43 @@ public class EnvironmentConfigBasicTest extends EnvironmentConfigTestBase {
     @Before
     public void setUp() throws Exception {
         environmentConfig = new BasicEnvironmentConfig(new CaseInsensitiveString("UAT"));
+    }
+
+    @Test
+    public void shouldReturnTrueThatLocalWhenOriginIsNotSet()
+    {
+        environmentConfig.setOrigins(null);
+        assertThat(environmentConfig.isLocal(), is(true));
+    }
+    @Test
+    public void shouldReturnTrueThatLocalWhenOriginIsFile()
+    {
+        environmentConfig.setOrigins(new FileConfigOrigin());
+        assertThat(environmentConfig.isLocal(),is(true));
+    }
+    @Test
+    public void shouldReturnFalseThatLocalWhenOriginIsConfigRepo()
+    {
+        environmentConfig.setOrigins(new RepoConfigOrigin());
+        assertThat(environmentConfig.isLocal(),is(false));
+    }
+    @Test
+    public void shouldReturnSelfAsLocalPartWhenOriginIsFile()
+    {
+        environmentConfig.setOrigins(new FileConfigOrigin());
+        assertSame(environmentConfig,environmentConfig.getLocal());
+    }
+    @Test
+    public void shouldReturnSelfAsLocalPartWhenOriginIsUI()
+    {
+        environmentConfig.setOrigins(new UIConfigOrigin());
+        assertSame(environmentConfig,environmentConfig.getLocal());
+    }
+    @Test
+    public void shouldReturnNullAsLocalPartWhenOriginIsConfigRepo()
+    {
+        environmentConfig.setOrigins(new RepoConfigOrigin());
+        assertNull(environmentConfig.getLocal());
     }
 
     @Test

--- a/config/config-api/test/com/thoughtworks/go/config/EnvironmentConfigTestBase.java
+++ b/config/config-api/test/com/thoughtworks/go/config/EnvironmentConfigTestBase.java
@@ -39,6 +39,30 @@ public abstract class EnvironmentConfigTestBase {
     private static final String AGENT_UUID = "uuid";
 
     @Test
+    public void shouldReturnTrueWhenIsEmpty()
+    {
+        assertThat(environmentConfig.isEnvironmentEmpty(),is(true));
+    }
+    @Test
+    public void shouldReturnFalseThatNotEmptyWhenHasPipeline()
+    {
+        environmentConfig.addPipeline(new CaseInsensitiveString("pipe"));
+        assertThat(environmentConfig.isEnvironmentEmpty(), is(false));
+    }
+    @Test
+    public void shouldReturnFalseThatNotEmptyWhenHasAgent()
+    {
+        environmentConfig.addAgent("agent");
+        assertThat(environmentConfig.isEnvironmentEmpty(), is(false));
+    }
+    @Test
+    public void shouldReturnFalseThatNotEmptyWhenHasVariable()
+    {
+        environmentConfig.addEnvironmentVariable("k","v");
+        assertThat(environmentConfig.isEnvironmentEmpty(), is(false));
+    }
+
+    @Test
     public void shouldCreateMatcherWhenNoPipelines() throws Exception {
         EnvironmentPipelineMatcher pipelineMatcher = environmentConfig.createMatcher();
         assertThat(pipelineMatcher.match("pipeline", AGENT_UUID), is(false));

--- a/config/config-api/test/com/thoughtworks/go/config/merge/MergeEnvironmentConfigTest.java
+++ b/config/config-api/test/com/thoughtworks/go/config/merge/MergeEnvironmentConfigTest.java
@@ -41,6 +41,7 @@ public class MergeEnvironmentConfigTest extends EnvironmentConfigTestBase {
     private static final String AGENT_UUID = "uuid";
     private EnvironmentConfig localUatEnv1;
     private EnvironmentConfig uatLocalPart2;
+    private BasicEnvironmentConfig uatRemotePart;
 
     @Before
     public void setUp() throws Exception {
@@ -50,7 +51,7 @@ public class MergeEnvironmentConfigTest extends EnvironmentConfigTestBase {
         singleEnvironmentConfig = new MergeEnvironmentConfig(localUatEnv1);
         uatLocalPart2 = new BasicEnvironmentConfig(new CaseInsensitiveString("UAT"));
         uatLocalPart2.setOrigins(new FileConfigOrigin());
-        BasicEnvironmentConfig uatRemotePart = new BasicEnvironmentConfig(new CaseInsensitiveString("UAT"));
+        uatRemotePart = new BasicEnvironmentConfig(new CaseInsensitiveString("UAT"));
         uatRemotePart.setOrigins(new RepoConfigOrigin());
         pairEnvironmentConfig = new MergeEnvironmentConfig(
                 uatLocalPart2,
@@ -64,6 +65,20 @@ public class MergeEnvironmentConfigTest extends EnvironmentConfigTestBase {
     {
         new MergeEnvironmentConfig(new BasicEnvironmentConfig(new CaseInsensitiveString("UAT")),
                 new BasicEnvironmentConfig(new CaseInsensitiveString("Two")));
+    }
+
+    @Test
+    public void getRemotePipelines_shouldReturnEmptyWhenOnlyLocalPartHasPipelines()
+    {
+        uatLocalPart2.addPipeline(new CaseInsensitiveString("pipe"));
+        assertThat(pairEnvironmentConfig.getRemotePipelines().isEmpty(), is(true));
+    }
+
+    @Test
+    public void getRemotePipelines_shouldReturnPipelinesFromRemotePartWhenRemoteHasPipesAssigned()
+    {
+        uatRemotePart.addPipeline(new CaseInsensitiveString("pipe"));
+        assertThat(environmentConfig.getRemotePipelines().isEmpty(), is(false));
     }
 
     @Test

--- a/config/config-api/test/com/thoughtworks/go/config/merge/MergeEnvironmentConfigTest.java
+++ b/config/config-api/test/com/thoughtworks/go/config/merge/MergeEnvironmentConfigTest.java
@@ -18,6 +18,7 @@ package com.thoughtworks.go.config.merge;
 import com.thoughtworks.go.config.*;
 import com.thoughtworks.go.config.remote.FileConfigOrigin;
 import com.thoughtworks.go.config.remote.RepoConfigOrigin;
+import com.thoughtworks.go.config.remote.UIConfigOrigin;
 import com.thoughtworks.go.util.command.EnvironmentVariableContext;
 import org.apache.commons.collections.map.SingletonMap;
 import org.hamcrest.Matchers;
@@ -27,6 +28,7 @@ import org.junit.Test;
 import java.util.Arrays;
 import java.util.List;
 
+import static junit.framework.TestCase.assertNull;
 import static org.hamcrest.Matchers.*;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
@@ -37,19 +39,21 @@ public class MergeEnvironmentConfigTest extends EnvironmentConfigTestBase {
     public MergeEnvironmentConfig singleEnvironmentConfig;
     public MergeEnvironmentConfig pairEnvironmentConfig;
     private static final String AGENT_UUID = "uuid";
+    private EnvironmentConfig localUatEnv1;
+    private EnvironmentConfig uatLocalPart2;
 
     @Before
     public void setUp() throws Exception {
-        BasicEnvironmentConfig localUatEnv = new BasicEnvironmentConfig(new CaseInsensitiveString("UAT"));
-        localUatEnv.setOrigins(new FileConfigOrigin());
+        localUatEnv1 = new BasicEnvironmentConfig(new CaseInsensitiveString("UAT"));
+        localUatEnv1.setOrigins(new FileConfigOrigin());
 
-        singleEnvironmentConfig = new MergeEnvironmentConfig(localUatEnv);
-        BasicEnvironmentConfig uatLocalPart = new BasicEnvironmentConfig(new CaseInsensitiveString("UAT"));
-        uatLocalPart.setOrigins(new FileConfigOrigin());
+        singleEnvironmentConfig = new MergeEnvironmentConfig(localUatEnv1);
+        uatLocalPart2 = new BasicEnvironmentConfig(new CaseInsensitiveString("UAT"));
+        uatLocalPart2.setOrigins(new FileConfigOrigin());
         BasicEnvironmentConfig uatRemotePart = new BasicEnvironmentConfig(new CaseInsensitiveString("UAT"));
         uatRemotePart.setOrigins(new RepoConfigOrigin());
         pairEnvironmentConfig = new MergeEnvironmentConfig(
-                uatLocalPart,
+                uatLocalPart2,
                 uatRemotePart);
 
         super.environmentConfig = pairEnvironmentConfig;
@@ -62,6 +66,28 @@ public class MergeEnvironmentConfigTest extends EnvironmentConfigTestBase {
                 new BasicEnvironmentConfig(new CaseInsensitiveString("Two")));
     }
 
+    @Test
+    public void shouldReturnFalseThatLocal()
+    {
+        assertThat(environmentConfig.isLocal(),is(false));
+    }
+    @Test
+    public void shouldGetLocalPartWhenOriginFile()
+    {
+        assertThat(environmentConfig.getLocal(),is(uatLocalPart2));
+    }
+    @Test
+    public void shouldGetLocalPartWhenOriginIsUI()
+    {
+        uatLocalPart2.setOrigins(new UIConfigOrigin());
+        assertThat(environmentConfig.getLocal(), is(uatLocalPart2));
+    }
+    @Test
+    public void shouldReturnNullLocalPartWhenOriginsAreRemote()
+    {
+        uatLocalPart2.setOrigins(new RepoConfigOrigin());
+        assertNull(environmentConfig.getLocal());
+    }
 
     @Test
     public void shouldFailUpdateName() {

--- a/config/config-api/test/com/thoughtworks/go/config/merge/MergePipelineConfigsTest.java
+++ b/config/config-api/test/com/thoughtworks/go/config/merge/MergePipelineConfigsTest.java
@@ -16,6 +16,7 @@
 package com.thoughtworks.go.config.merge;
 
 import com.thoughtworks.go.config.*;
+import com.thoughtworks.go.config.remote.ConfigOrigin;
 import com.thoughtworks.go.config.remote.ConfigRepoConfig;
 import com.thoughtworks.go.config.remote.FileConfigOrigin;
 import com.thoughtworks.go.config.remote.RepoConfigOrigin;
@@ -433,6 +434,23 @@ public class MergePipelineConfigsTest extends PipelineConfigsTestBase {
 
         tryAddAndAssertThatFailed(group, p1, 5);
         tryAddAndAssertThatFailed(group, p1, 4);
+    }
+    @Test
+    public void shouldReturnOriginAsASumOfAllOrigins()
+    {
+        BasicPipelineConfigs fileConfigs = new BasicPipelineConfigs(PipelineConfigMother.pipelineConfig("pipeline1"));
+        fileConfigs.setOrigin(new FileConfigOrigin());
+        BasicPipelineConfigs remoteConfigs = new BasicPipelineConfigs(PipelineConfigMother.pipelineConfig("pipeline2"));
+        remoteConfigs.setOrigin(new RepoConfigOrigin());
+        PipelineConfigs group = new MergePipelineConfigs(fileConfigs, remoteConfigs);
+
+        ConfigOrigin allOrigins = group.getOrigin();
+        assertThat(allOrigins instanceof MergeConfigOrigin,is(true));
+
+        MergeConfigOrigin mergeConfigOrigin = (MergeConfigOrigin)allOrigins;
+        assertThat(mergeConfigOrigin.size(),is(2));
+        assertThat(mergeConfigOrigin.contains(new FileConfigOrigin()),is(true));
+        assertThat(mergeConfigOrigin.contains(new RepoConfigOrigin()),is(true));
     }
 
     private void tryAddAndAssertThatFailed(PipelineConfigs group, PipelineConfig p1, int index) {

--- a/config/config-api/test/com/thoughtworks/go/config/merge/MergePipelineConfigsTest.java
+++ b/config/config-api/test/com/thoughtworks/go/config/merge/MergePipelineConfigsTest.java
@@ -16,6 +16,7 @@
 package com.thoughtworks.go.config.merge;
 
 import com.thoughtworks.go.config.*;
+import com.thoughtworks.go.config.remote.ConfigRepoConfig;
 import com.thoughtworks.go.config.remote.FileConfigOrigin;
 import com.thoughtworks.go.config.remote.RepoConfigOrigin;
 import com.thoughtworks.go.helper.PipelineConfigMother;
@@ -60,6 +61,32 @@ public class MergePipelineConfigsTest extends PipelineConfigsTestBase {
         BasicPipelineConfigs pipelineConfigsRemote = new BasicPipelineConfigs();
         pipelineConfigsRemote.setOrigin(new RepoConfigOrigin());
         return new MergePipelineConfigs(pipelineConfigsLocal,pipelineConfigsRemote);
+    }
+
+    @Test
+    public void shouldReturnNullForGetLocalWhenOnlyRemoteParts()
+    {
+        BasicPipelineConfigs firstPart = new BasicPipelineConfigs();
+        firstPart.setOrigin(new RepoConfigOrigin());
+
+        BasicPipelineConfigs secondPart = new BasicPipelineConfigs();
+        secondPart.setOrigin(new RepoConfigOrigin());
+        MergePipelineConfigs merge = new MergePipelineConfigs(firstPart, secondPart);
+
+        assertNull(merge.getLocal());
+    }
+
+    @Test
+    public void shouldReturnFilePartForGetLocalWhenHasRemoteAndFilePart()
+    {
+        BasicPipelineConfigs filePart = new BasicPipelineConfigs();
+        filePart.setOrigin(new FileConfigOrigin());
+
+        BasicPipelineConfigs secondPart = new BasicPipelineConfigs();
+        secondPart.setOrigin(new RepoConfigOrigin());
+        MergePipelineConfigs merge = new MergePipelineConfigs(filePart, secondPart);
+
+        assertThat(merge.getLocal(), Matchers.<PipelineConfigs>is(filePart));
     }
 
     @Test

--- a/config/config-server/src/com/thoughtworks/go/config/MagicalGoConfigXmlWriter.java
+++ b/config/config-server/src/com/thoughtworks/go/config/MagicalGoConfigXmlWriter.java
@@ -25,7 +25,9 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
+import com.thoughtworks.go.config.exceptions.GoConfigInvalidException;
 import com.thoughtworks.go.config.registry.ConfigElementImplementationRegistry;
+import com.thoughtworks.go.domain.ConfigErrors;
 import com.thoughtworks.go.metrics.domain.context.Context;
 import com.thoughtworks.go.security.GoCipher;
 import com.thoughtworks.go.metrics.domain.probes.ProbeType;
@@ -86,7 +88,10 @@ public class MagicalGoConfigXmlWriter {
             if(!configForEdit.getOrigin().isLocal()) {
                 if (!skipPreprocessingAndValidation) {
                     // lets validate merged config first, it will show more sensible errors
-                    loader.preprocessAndValidate(configForEdit);
+                    List<ConfigErrors> errorsAtMergedScope = configForEdit.validateAfterPreprocess();
+                    if (!errorsAtMergedScope.isEmpty()) {
+                        throw new GoConfigInvalidException(configForEdit, errorsAtMergedScope);
+                    }
                 }
                 configForEdit = configForEdit.getLocal();
             }

--- a/server/src/com/thoughtworks/go/config/MergedGoConfig.java
+++ b/server/src/com/thoughtworks/go/config/MergedGoConfig.java
@@ -95,8 +95,7 @@ public class MergedGoConfig implements CachedGoConfig, ConfigChangedListener, Pa
                     throw new GoConfigInvalidException(merge, allErrors);
                 }
                 CruiseConfig basicForEdit = this.fileService.loadForEditing();
-                CruiseConfig forEdit = new BasicCruiseConfig((BasicCruiseConfig) basicForEdit, partials);
-                //TODO change strategy into merge-edit? - done in UI branch
+                CruiseConfig forEdit = new BasicCruiseConfig((BasicCruiseConfig) basicForEdit, true, partials);
                 newConfigHolder = new GoConfigHolder(merge, forEdit);
             }
             // save to cache and fire event

--- a/server/src/com/thoughtworks/go/config/MergedGoConfig.java
+++ b/server/src/com/thoughtworks/go/config/MergedGoConfig.java
@@ -68,21 +68,21 @@ public class MergedGoConfig implements CachedGoConfig, ConfigChangedListener, Pa
 
     @Override
     public void onConfigChange(CruiseConfig newCruiseConfig) {
-        this.tryAssembleMergedConfig(this.fileService.loadConfigHolder(), this.partialConfig.lastPartials());
+        this.tryAssembleMergedConfig(this.fileService.loadConfigHolder(), this.partialConfig.lastPartials(),true);
     }
     @Override
     public void onPartialConfigChanged(List<PartialConfig> partials) {
-        this.tryAssembleMergedConfig(this.fileService.loadConfigHolder(), partials);
+        this.tryAssembleMergedConfig(this.fileService.loadConfigHolder(), partials,false);
     }
 
     /**
      * attempts to create a new merged cruise config
     */
-    public void tryAssembleMergedConfig(GoConfigHolder cruiseConfigHolder,List<PartialConfig> partials) {
+    public void tryAssembleMergedConfig(GoConfigHolder cruiseConfigHolder,List<PartialConfig> partials,boolean fallbackToOldPartials) {
         try {
             GoConfigHolder newConfigHolder;
 
-            if (partials.size() == 0) {
+            if (partials == null || partials.size() == 0) {
                 // no partial configurations
                 // then just use basic configuration from xml
                 newConfigHolder = cruiseConfigHolder;
@@ -92,7 +92,21 @@ public class MergedGoConfig implements CachedGoConfig, ConfigChangedListener, Pa
                 // validate
                 List<ConfigErrors> allErrors = validate(merge);
                 if (!allErrors.isEmpty()) {
-                    throw new GoConfigInvalidException(merge, allErrors);
+                    if(!fallbackToOldPartials)
+                        throw new GoConfigInvalidException(merge, allErrors);
+                    else
+                    {
+                        LOGGER.warn("Current merged configuration is invalid; falling back to using old partial configurations");
+                        // get last known valid (merged or not) configuration
+                        GoConfigHolder oldValidConfig = this.configHolder;
+                        // these are either last known valid remotes that DID work with old main config
+                        // or this is empty collection (which also works with any main config)
+                        List<PartialConfig> oldPartials = oldValidConfig.config.getRemote();
+                        // so we can just attempt to merge the new main configuration with old remotes
+                        // so try again, without further fallback this time.
+                        this.tryAssembleMergedConfig(cruiseConfigHolder,oldPartials,false);
+                        return;
+                    }
                 }
                 CruiseConfig basicForEdit = this.fileService.loadForEditing();
                 CruiseConfig forEdit = new BasicCruiseConfig((BasicCruiseConfig) basicForEdit, true, partials);

--- a/server/src/com/thoughtworks/go/server/service/EnvironmentConfigService.java
+++ b/server/src/com/thoughtworks/go/server/service/EnvironmentConfigService.java
@@ -188,6 +188,21 @@ public class EnvironmentConfigService implements ConfigChangedListener {
         List<PipelineConfig> pipelineConfigs = goConfigService.getAllLocalPipelineConfigs();
         return getAllPipelinesForUser(user, pipelineConfigs);
     }
+    public List<EnvironmentPipelineModel> getAllRemotePipelinesForUserInEnvironment(Username user,EnvironmentConfig environment) {
+        List<EnvironmentPipelineModel> pipelines = new ArrayList<EnvironmentPipelineModel>();
+        for (EnvironmentPipelineConfig pipelineConfig : environment.getRemotePipelines()) {
+            String pipelineName = CaseInsensitiveString.str(pipelineConfig.getName());
+            if (securityService.hasViewPermissionForPipeline(user, pipelineName)) {
+                if (environment != null) {
+                    pipelines.add(new EnvironmentPipelineModel(pipelineName, CaseInsensitiveString.str(environment.name())));
+                } else {
+                    pipelines.add(new EnvironmentPipelineModel(pipelineName));
+                }
+            }
+        }
+        Collections.sort(pipelines);
+        return pipelines;
+    }
 
     private List<EnvironmentPipelineModel> getAllPipelinesForUser(Username user, List<PipelineConfig> pipelineConfigs) {
         List<EnvironmentPipelineModel> pipelines = new ArrayList<EnvironmentPipelineModel>();

--- a/server/src/com/thoughtworks/go/server/service/EnvironmentConfigService.java
+++ b/server/src/com/thoughtworks/go/server/service/EnvironmentConfigService.java
@@ -184,9 +184,14 @@ public class EnvironmentConfigService implements ConfigChangedListener {
         }
     }
 
-    public List<EnvironmentPipelineModel> getAllPipelinesForUser(Username user) {
+    public List<EnvironmentPipelineModel> getAllLocalPipelinesForUser(Username user) {
+        List<PipelineConfig> pipelineConfigs = goConfigService.getAllLocalPipelineConfigs();
+        return getAllPipelinesForUser(user, pipelineConfigs);
+    }
+
+    private List<EnvironmentPipelineModel> getAllPipelinesForUser(Username user, List<PipelineConfig> pipelineConfigs) {
         List<EnvironmentPipelineModel> pipelines = new ArrayList<EnvironmentPipelineModel>();
-        for (PipelineConfig pipelineConfig : goConfigService.getAllPipelineConfigs()) {
+        for (PipelineConfig pipelineConfig : pipelineConfigs) {
             String pipelineName = CaseInsensitiveString.str(pipelineConfig.name());
             if (securityService.hasViewPermissionForPipeline(user, pipelineName)) {
                 EnvironmentConfig environment = environments.findEnvironmentForPipeline(new CaseInsensitiveString(pipelineName));

--- a/server/src/com/thoughtworks/go/server/service/GoConfigService.java
+++ b/server/src/com/thoughtworks/go/server/service/GoConfigService.java
@@ -555,6 +555,9 @@ public class GoConfigService implements Initializer {
     public List<PipelineConfig> getAllPipelineConfigs() {
         return getCurrentConfig().getAllPipelineConfigs();
     }
+    public List<PipelineConfig> getAllLocalPipelineConfigs() {
+        return getCurrentConfig().getAllLocalPipelineConfigs();
+    }
 
     public List<PipelineConfig> getAllPipelineConfigsForEdit() {
         return getConfigForEditing().getAllPipelineConfigs();

--- a/server/src/com/thoughtworks/go/server/service/GoConfigService.java
+++ b/server/src/com/thoughtworks/go/server/service/GoConfigService.java
@@ -22,6 +22,7 @@ import com.thoughtworks.go.config.*;
 import com.thoughtworks.go.config.exceptions.*;
 import com.thoughtworks.go.config.materials.MaterialConfigs;
 import com.thoughtworks.go.config.registry.ConfigElementImplementationRegistry;
+import com.thoughtworks.go.config.remote.ConfigOrigin;
 import com.thoughtworks.go.config.update.*;
 import com.thoughtworks.go.config.validation.GoConfigValidity;
 import com.thoughtworks.go.domain.*;
@@ -1102,6 +1103,18 @@ public class GoConfigService implements Initializer {
             currentSelections.addPipelineToSelections(pipelineToAdd);
             pipelineRepository.saveSelectedPipelines(currentSelections);
         }
+    }
+
+    public boolean isPipelineEditableViaUI(String pipelineName) {
+        PipelineConfig pipelineConfig = this.pipelineConfigNamed(new CaseInsensitiveString(pipelineName));
+        if(pipelineConfig == null)
+            return false;
+        return isOriginLocal(pipelineConfig.getOrigin());
+    }
+
+    private boolean isOriginLocal(ConfigOrigin origin) {
+        // when null we assume that it comes from file or UI
+        return origin == null || origin.isLocal();
     }
 
     public abstract class XmlPartialSaver<T> {

--- a/server/src/com/thoughtworks/go/server/service/PipelineConfigService.java
+++ b/server/src/com/thoughtworks/go/server/service/PipelineConfigService.java
@@ -20,7 +20,6 @@ import java.util.HashMap;
 import java.util.Hashtable;
 import java.util.List;
 import java.util.Map;
-
 import com.thoughtworks.go.config.*;
 import com.thoughtworks.go.config.remote.ConfigOrigin;
 import com.thoughtworks.go.i18n.LocalizedMessage;

--- a/server/src/com/thoughtworks/go/server/service/PipelineHistoryService.java
+++ b/server/src/com/thoughtworks/go/server/service/PipelineHistoryService.java
@@ -504,7 +504,8 @@ public class PipelineHistoryService implements PipelineInstanceLoader {
             }
 
             for (PipelineModel pipelineModel : groupModel.getPipelineModels()) {
-                pipelineModel.updateAdministrability(true);
+                if(goConfigService.isPipelineEditableViaUI(pipelineModel.getName()))
+                    pipelineModel.updateAdministrability(true);
             }
         }
     }
@@ -562,7 +563,10 @@ public class PipelineHistoryService implements PipelineInstanceLoader {
             populateLockStatus(instanceModel.getName(), username, instanceModel);
             pipelineModel.addPipelineInstance(instanceModel);
             String groupName = goConfigService.findGroupNameByPipeline(new CaseInsensitiveString(pipelineName));
-            pipelineModel.updateAdministrability(goConfigService.isUserAdminOfGroup(username.getUsername(), groupName));
+            if(goConfigService.isPipelineEditableViaUI(pipelineName))
+                pipelineModel.updateAdministrability(goConfigService.isUserAdminOfGroup(username.getUsername(), groupName));
+            else
+                pipelineModel.updateAdministrability(false);
             return pipelineModel;
         }
         return null;

--- a/server/test/unit/com/thoughtworks/go/config/MergedGoConfigTest.java
+++ b/server/test/unit/com/thoughtworks/go/config/MergedGoConfigTest.java
@@ -263,7 +263,7 @@ public class MergedGoConfigTest extends CachedGoConfigTestBase {
     }
 
     @Test
-    public void shouldDelegateWritePipelineConfigCallToFileService() {
+    public void shouldDelegateWritePipelineConfigCallToFileService(){
         CachedFileGoConfig fileService = mock(CachedFileGoConfig.class);
         PipelineConfigService.SaveCommand saveCommand = mock(PipelineConfigService.SaveCommand.class);
         MergedGoConfig mergedGoConfig = new MergedGoConfig(mock(ServerHealthService.class), fileService, mock(GoPartialConfig.class));

--- a/server/test/unit/com/thoughtworks/go/config/MergedGoConfigTest.java
+++ b/server/test/unit/com/thoughtworks/go/config/MergedGoConfigTest.java
@@ -35,6 +35,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 
 import static com.thoughtworks.go.helper.ConfigFileFixture.CONFIG_WITH_1CONFIGREPO;
+import static junit.framework.TestCase.assertNotSame;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertSame;
@@ -209,11 +210,21 @@ public class MergedGoConfigTest extends CachedGoConfigTestBase {
     }
 
     @Test
-    public void tryAssembleMergedConfig_shouldSetXmlConfigWhenNoPartials()
+    public void tryAssembleMergedConfig_shouldSetXmlConfigWhenNoPartialsWhenNoFallback()
     {
         GoConfigHolder fileHolder = cachedFileGoConfig.loadConfigHolder();
         MergedGoConfig mergedGoConfig = (MergedGoConfig) this.cachedGoConfig;
-        mergedGoConfig.tryAssembleMergedConfig(fileHolder, new ArrayList<PartialConfig>());
+        mergedGoConfig.tryAssembleMergedConfig(fileHolder, new ArrayList<PartialConfig>(),false);
+        assertSame(cachedFileGoConfig.loadConfigHolder(), mergedGoConfig.loadConfigHolder());
+        assertSame(cachedFileGoConfig.currentConfig(), mergedGoConfig.currentConfig());
+        assertSame(cachedFileGoConfig.loadForEditing(), mergedGoConfig.loadForEditing());
+    }
+    @Test
+    public void tryAssembleMergedConfig_shouldSetXmlConfigWhenNoPartialsWhenFallback()
+    {
+        GoConfigHolder fileHolder = cachedFileGoConfig.loadConfigHolder();
+        MergedGoConfig mergedGoConfig = (MergedGoConfig) this.cachedGoConfig;
+        mergedGoConfig.tryAssembleMergedConfig(fileHolder, new ArrayList<PartialConfig>(),true);
         assertSame(cachedFileGoConfig.loadConfigHolder(), mergedGoConfig.loadConfigHolder());
         assertSame(cachedFileGoConfig.currentConfig(), mergedGoConfig.currentConfig());
         assertSame(cachedFileGoConfig.loadForEditing(), mergedGoConfig.loadForEditing());
@@ -226,7 +237,7 @@ public class MergedGoConfigTest extends CachedGoConfigTestBase {
         MergedGoConfig mergedGoConfig = (MergedGoConfig) this.cachedGoConfig;
         PartialConfig part1 = new PartialConfig(new PipelineGroups(
                 PipelineConfigMother.createGroup("part1", PipelineConfigMother.pipelineConfig("pipe1"))));
-        mergedGoConfig.tryAssembleMergedConfig(fileHolder, Arrays.asList(part1));
+        mergedGoConfig.tryAssembleMergedConfig(fileHolder, Arrays.asList(part1),false);
 
         assertThat("configHolderHasRemotePartsOfConfigInConfig",
                 mergedGoConfig.loadConfigHolder().config.hasPipelineNamed(new CaseInsensitiveString("pipe1")), is(true));
@@ -249,17 +260,79 @@ public class MergedGoConfigTest extends CachedGoConfigTestBase {
     }
 
     @Test
-    public void tryAssembleMergedConfig_shouldNotChangeConfigWhenMergeFailed()
+    public void tryAssembleMergedConfig_shouldNotChangeConfigWhenMergeFailedWithoutFallback()
     {
         GoConfigHolder fileHolder = cachedFileGoConfig.loadConfigHolder();
         MergedGoConfig mergedGoConfig = (MergedGoConfig) this.cachedGoConfig;
         PartialConfig badPart = new PartialConfig(new PipelineGroups(
                 PipelineConfigMother.createGroup("part1",
                         PipelineConfigMother.pipelineConfig("pipe1"),PipelineConfigMother.pipelineConfig("pipe1"))));
-        mergedGoConfig.tryAssembleMergedConfig(fileHolder, Arrays.asList(badPart));
+        mergedGoConfig.tryAssembleMergedConfig(fileHolder, Arrays.asList(badPart),false);
         assertSame(cachedFileGoConfig.loadConfigHolder(), mergedGoConfig.loadConfigHolder());
         assertSame(cachedFileGoConfig.currentConfig(), mergedGoConfig.currentConfig());
         assertSame(cachedFileGoConfig.loadForEditing(), mergedGoConfig.loadForEditing());
+    }
+
+    @Test
+    public void tryAssembleMergedConfig_shouldChangeConfigWhenMergeFailedWithFallback()
+    {
+        GoConfigHolder fileHolder = cachedFileGoConfig.loadConfigHolder();
+        MergedGoConfig mergedGoConfig = (MergedGoConfig) this.cachedGoConfig;
+
+        PartialConfig goodPart = new PartialConfig(new PipelineGroups(
+                PipelineConfigMother.createGroup("part1",
+                        PipelineConfigMother.pipelineConfig("part1"))));
+        mergedGoConfig.tryAssembleMergedConfig(fileHolder, Arrays.asList(goodPart),true);
+        // check that now we operate with valid merged config
+        assertNotSame(cachedFileGoConfig.loadConfigHolder(), mergedGoConfig.loadConfigHolder());
+        assertNotSame(cachedFileGoConfig.currentConfig(), mergedGoConfig.currentConfig());
+        assertNotSame(cachedFileGoConfig.loadForEditing(), mergedGoConfig.loadForEditing());
+        assertThat(mergedGoConfig.currentConfig().hasPipelineNamed(new CaseInsensitiveString("part1")),is(true));
+
+        // try to merge again with conflicting parts
+        PartialConfig badPart = new PartialConfig(new PipelineGroups(
+                PipelineConfigMother.createGroup("part1",
+                        PipelineConfigMother.pipelineConfig("pipe1"),PipelineConfigMother.pipelineConfig("pipe3"))));
+        mergedGoConfig.tryAssembleMergedConfig(fileHolder, Arrays.asList(goodPart,badPart),true);
+        assertThat(mergedGoConfig.currentConfig().hasPipelineNamed(new CaseInsensitiveString("part1")),is(true));
+        assertThat(mergedGoConfig.currentConfig().hasPipelineNamed(new CaseInsensitiveString("part3")),is(false));
+    }
+
+    @Test
+    public void tryAssembleMergedConfig_shouldChangeConfigOnMainConfigChangesWhenMergeFailed()
+    {
+        GoConfigHolder fileHolder = cachedFileGoConfig.loadConfigHolder();
+        MergedGoConfig mergedGoConfig = (MergedGoConfig) this.cachedGoConfig;
+
+        PartialConfig goodPart = new PartialConfig(new PipelineGroups(
+                PipelineConfigMother.createGroup("part1",
+                        PipelineConfigMother.pipelineConfig("part1"))));
+        mergedGoConfig.tryAssembleMergedConfig(fileHolder, Arrays.asList(goodPart),true);
+        // check that now we operate with valid merged config
+        assertNotSame(cachedFileGoConfig.loadConfigHolder(), mergedGoConfig.loadConfigHolder());
+        assertNotSame(cachedFileGoConfig.currentConfig(), mergedGoConfig.currentConfig());
+        assertNotSame(cachedFileGoConfig.loadForEditing(), mergedGoConfig.loadForEditing());
+        assertThat(mergedGoConfig.currentConfig().hasPipelineNamed(new CaseInsensitiveString("part1")),is(true));
+
+        // try to merge again with conflicting parts
+        PartialConfig badPart = new PartialConfig(new PipelineGroups(
+                PipelineConfigMother.createGroup("part1",
+                        PipelineConfigMother.pipelineConfig("pipe1"),PipelineConfigMother.pipelineConfig("pipe3"))));
+        mergedGoConfig.tryAssembleMergedConfig(fileHolder, Arrays.asList(goodPart,badPart),true);
+        assertThat(mergedGoConfig.currentConfig().hasPipelineNamed(new CaseInsensitiveString("part1")),is(true));
+        assertThat(mergedGoConfig.currentConfig().hasPipelineNamed(new CaseInsensitiveString("part3")),is(false));
+
+        // now we are in 'invalid' state, because last merge has failed.
+        // but it should be still possible to add pipe2 now via UI
+        configHelper.addPipeline("pipe2","build");
+        assertThat(cachedFileGoConfig.currentConfig().hasPipelineNamed(new CaseInsensitiveString("pipe2")),is(true));
+        fileHolder = cachedFileGoConfig.loadConfigHolder();
+
+        mergedGoConfig.tryAssembleMergedConfig(fileHolder,Arrays.asList(goodPart,badPart),true);
+
+        assertThat(mergedGoConfig.currentConfig().hasPipelineNamed(new CaseInsensitiveString("part1")),is(true));
+        assertThat(mergedGoConfig.currentConfig().hasPipelineNamed(new CaseInsensitiveString("pipe2")),is(true));
+        assertThat(mergedGoConfig.currentConfig().hasPipelineNamed(new CaseInsensitiveString("part3")),is(false));
     }
 
     @Test

--- a/server/test/unit/com/thoughtworks/go/server/service/EnvironmentConfigServiceTest.java
+++ b/server/test/unit/com/thoughtworks/go/server/service/EnvironmentConfigServiceTest.java
@@ -27,6 +27,7 @@ import javax.servlet.http.HttpServletResponse;
 import com.thoughtworks.go.config.*;
 import com.thoughtworks.go.config.ConfigSaveState;
 import com.thoughtworks.go.config.exceptions.NoSuchEnvironmentException;
+import com.thoughtworks.go.config.remote.RepoConfigOrigin;
 import com.thoughtworks.go.domain.DefaultJobPlan;
 import com.thoughtworks.go.domain.JobIdentifier;
 import com.thoughtworks.go.domain.JobPlan;
@@ -325,18 +326,18 @@ public class EnvironmentConfigServiceTest {
     }
 
     @Test
-    public void getAllPipelinesForUser_shouldReturnAllPipelinesToWhichAlongWithTheEnvironmentsToWhichTheyBelong() {
+    public void getAllLocalPipelinesForUser_shouldReturnAllPipelinesToWhichAlongWithTheEnvironmentsToWhichTheyBelong() {
         HttpLocalizedOperationResult result = new HttpLocalizedOperationResult();
         Username user = new Username(new CaseInsensitiveString("user"));
 
-        when(mockGoConfigService.getAllPipelineConfigs()).thenReturn(asList(pipelineConfig("foo"), pipelineConfig("bar"), pipelineConfig("baz")));
+        when(mockGoConfigService.getAllLocalPipelineConfigs()).thenReturn(asList(pipelineConfig("foo"), pipelineConfig("bar"), pipelineConfig("baz")));
 
         when(securityService.hasViewPermissionForPipeline(user, "foo")).thenReturn(true);
         when(securityService.hasViewPermissionForPipeline(user, "bar")).thenReturn(true);
         when(securityService.hasViewPermissionForPipeline(user, "baz")).thenReturn(false);
 
         environmentConfigService.sync(environmentsConfig("foo-env", "foo"));
-        List<EnvironmentPipelineModel> pipelines = environmentConfigService.getAllPipelinesForUser(user);
+        List<EnvironmentPipelineModel> pipelines = environmentConfigService.getAllLocalPipelinesForUser(user);
 
 
         assertThat(pipelines.size(), is(2));

--- a/server/test/unit/com/thoughtworks/go/server/service/EnvironmentConfigServiceTest.java
+++ b/server/test/unit/com/thoughtworks/go/server/service/EnvironmentConfigServiceTest.java
@@ -345,6 +345,29 @@ public class EnvironmentConfigServiceTest {
     }
 
     @Test
+    public void getAllRemotePipelinesForUserInEnvironment_shouldReturnOnlyRemotelyAssignedPipelinesWhichUserHasPermsToView() throws NoSuchEnvironmentException
+    {
+        HttpLocalizedOperationResult result = new HttpLocalizedOperationResult();
+        Username user = new Username(new CaseInsensitiveString("user"));
+
+        when(mockGoConfigService.getAllPipelineConfigs()).thenReturn(asList(pipelineConfig("foo"), pipelineConfig("bar"), pipelineConfig("baz")));
+
+        when(securityService.hasViewPermissionForPipeline(user, "foo")).thenReturn(true);
+        when(securityService.hasViewPermissionForPipeline(user, "bar")).thenReturn(true);
+        when(securityService.hasViewPermissionForPipeline(user, "baz")).thenReturn(false);
+
+        EnvironmentsConfig environmentConfigs = environmentsConfig("foo-env", "foo");
+        EnvironmentConfig fooEnv = environmentConfigs.named(new CaseInsensitiveString("foo-env"));
+        fooEnv.setOrigins(new RepoConfigOrigin());
+        environmentConfigService.sync(environmentConfigs);
+        List<EnvironmentPipelineModel> pipelines = environmentConfigService.getAllRemotePipelinesForUserInEnvironment(user,fooEnv);
+
+
+        assertThat(pipelines.size(), is(1));
+        assertThat(pipelines, is(asList(new EnvironmentPipelineModel("foo", "foo-env"))));
+    }
+
+    @Test
     public void shouldReturnEnvironmentConfigForEdit() throws NoSuchEnvironmentException {
         HttpLocalizedOperationResult result = new HttpLocalizedOperationResult();
         CruiseConfig config = new BasicCruiseConfig();

--- a/server/test/unit/com/thoughtworks/go/server/service/GoConfigServiceTest.java
+++ b/server/test/unit/com/thoughtworks/go/server/service/GoConfigServiceTest.java
@@ -25,6 +25,9 @@ import com.thoughtworks.go.config.materials.dependency.DependencyMaterialConfig;
 import com.thoughtworks.go.config.materials.git.GitMaterialConfig;
 import com.thoughtworks.go.config.materials.svn.SvnMaterialConfig;
 import com.thoughtworks.go.config.registry.ConfigElementImplementationRegistry;
+import com.thoughtworks.go.config.remote.ConfigRepoConfig;
+import com.thoughtworks.go.config.remote.PartialConfig;
+import com.thoughtworks.go.config.remote.RepoConfigOrigin;
 import com.thoughtworks.go.config.server.security.ldap.BaseConfig;
 import com.thoughtworks.go.config.server.security.ldap.BasesConfig;
 import com.thoughtworks.go.config.update.ConfigUpdateResponse;
@@ -80,6 +83,7 @@ import static com.thoughtworks.go.helper.PipelineTemplateConfigMother.createTemp
 import static java.lang.String.format;
 import static org.apache.commons.httpclient.HttpStatus.SC_BAD_REQUEST;
 import static org.apache.commons.httpclient.HttpStatus.SC_INTERNAL_SERVER_ERROR;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNull.nullValue;
@@ -1478,6 +1482,27 @@ public class GoConfigServiceTest {
 
         verify(pipelineRepository).findPipelineSelectionsByUserId(1L);
         verify(pipelineRepository, times(1)).saveSelectedPipelines(argThat(isAPipelineSelectionsInstanceWith(false, "pipeline1", "pipeline2", "pipelineNew")));
+    }
+
+
+    @Test
+    public void pipelineEditableViaUI_shouldReturnFalseWhenPipelineIsRemote() throws Exception
+    {
+        PipelineConfigs group = new BasicPipelineConfigs();
+        PipelineConfig pipelineConfig = createPipelineConfig("pipeline", "name", "plan");
+        pipelineConfig.setOrigin(new RepoConfigOrigin());
+        group.add(pipelineConfig);
+        expectLoad(new BasicCruiseConfig(group));
+        assertThat(goConfigService.isPipelineEditableViaUI("pipeline"), is(false));
+    }
+    @Test
+    public void pipelineEditableViaUI_shouldReturnTrueWhenPipelineIsLocal() throws Exception
+    {
+        PipelineConfigs group = new BasicPipelineConfigs();
+        PipelineConfig pipelineConfig = createPipelineConfig("pipeline", "name", "plan");
+        group.add(pipelineConfig);
+        expectLoad(new BasicCruiseConfig(group));
+        assertThat(goConfigService.isPipelineEditableViaUI("pipeline"), is(true));
     }
 
     private PipelineConfig createPipelineConfig(String pipelineName, String stageName, String... buildNames) {

--- a/server/webapp/WEB-INF/rails.new/app/assets/stylesheets/patterns/action_icons.scss
+++ b/server/webapp/WEB-INF/rails.new/app/assets/stylesheets/patterns/action_icons.scss
@@ -17,7 +17,7 @@
 /**
  * Action Icons.css
  */
- 
+
 
 /**
  * TABLE OF CONTENTS
@@ -26,7 +26,7 @@
  * =ACTION_STATES
  * =DISABLED_ACTION_STATES
  */
- 
+
 
 /**
  * =BASE
@@ -80,8 +80,8 @@
 .delete_icon_disabled,
 .lock_icon_disabled,
 .edit_icon_disabled,
-.move_icon_disable,
-.clone_icon_disable {
+.move_icon_disabled,
+.clone_icon_disabled {
     color: #999999;
     cursor: default;
     display: inline-block;
@@ -106,11 +106,17 @@
 .delete_icon_disabled {
   background: image_url('g9/icons/icon_delete_disabled_16.png') no-repeat left 50%;
 }
+/**
+TODO use _disabled variants of icons
+*/
 .edit_icon_disabled {
+  background: image_url('g9/icons/icon_edit_16.png') no-repeat left 50%;
 }
 .move_icon_disabled {
+  background: image_url('g9/icons/icon_move_16.png') no-repeat left 50%;
 }
 .clone_icon_disabled {
+  background: image_url('g9/icons/icon_clone_16.png') no-repeat left 50%;
 }
 
 /**
@@ -139,4 +145,3 @@
   width: 18px;
   cursor: inherit;
 }
-

--- a/server/webapp/WEB-INF/rails.new/app/controllers/environments_controller.rb
+++ b/server/webapp/WEB-INF/rails.new/app/controllers/environments_controller.rb
@@ -104,7 +104,7 @@ class EnvironmentsController < ApplicationController
   end
 
   def load_pipelines_and_agents
-    pipelines = environment_config_service.getAllPipelinesForUser(current_user)
+    pipelines = environment_config_service.getAllLocalPipelinesForUser(current_user)
 
     @unavailable_pipelines = []
     @available_pipelines = []

--- a/server/webapp/WEB-INF/rails.new/app/controllers/environments_controller.rb
+++ b/server/webapp/WEB-INF/rails.new/app/controllers/environments_controller.rb
@@ -63,7 +63,7 @@ class EnvironmentsController < ApplicationController
   end
 
   def show
-    @agent_details = agent_service.filter(@environment.getAgents().map(&:uuid))
+    @agent_details = agent_service.filter(@environment.getLocalAgents().map(&:uuid))
   end
 
   def edit_pipelines
@@ -108,6 +108,7 @@ class EnvironmentsController < ApplicationController
 
     @unavailable_pipelines = []
     @available_pipelines = []
+    @remote_pipelines = environment_config_service.getAllRemotePipelinesForUserInEnvironment(current_user,@environment)
 
     pipelines.each do |pipeline|
       collection = pipeline.isAssociatedWithEnvironmentOtherThan(@environment && @environment.name().to_s) ? @unavailable_pipelines : @available_pipelines

--- a/server/webapp/WEB-INF/rails.new/app/views/admin/pipeline_groups/edit.html.erb
+++ b/server/webapp/WEB-INF/rails.new/app/views/admin/pipeline_groups/edit.html.erb
@@ -9,7 +9,7 @@
             <div class="fieldset">
                 <%= md5_field %>
                 <%== required_label(f, com.thoughtworks.go.config.PipelineConfigs::GROUP, l.string("PIPELINE_GROUP_NAME")) -%>
-                <%= f.text_field com.thoughtworks.go.config.PipelineConfigs::GROUP, {:class => "form_input"} -%>
+                <%= f.text_field com.thoughtworks.go.config.PipelineConfigs::GROUP, {:class => "form_input", :disabled => @group.hasRemoteParts()} -%>
                 <%= error_message_on(@group, com.thoughtworks.go.config.PipelineConfigs::GROUP, :css_class => "form_error") %>
                 <div class="clear"></div>
             </div>
@@ -57,5 +57,3 @@
 
 <%= render :partial => "admin/shared/dirty_form", :locals => {:scope => {:form_id => 'group_edit_form', :reset_id => "reset_form"}} %>
 <%= render :partial => 'shared/convert_tool_tips.html', :locals => {:scope => {}} %>
-
-

--- a/server/webapp/WEB-INF/rails.new/app/views/admin/pipeline_groups/edit.html.erb
+++ b/server/webapp/WEB-INF/rails.new/app/views/admin/pipeline_groups/edit.html.erb
@@ -9,7 +9,7 @@
             <div class="fieldset">
                 <%= md5_field %>
                 <%== required_label(f, com.thoughtworks.go.config.PipelineConfigs::GROUP, l.string("PIPELINE_GROUP_NAME")) -%>
-                <%= f.text_field com.thoughtworks.go.config.PipelineConfigs::GROUP, {:class => "form_input", :disabled => @group.hasRemoteParts()} -%>
+                <%= f.text_field com.thoughtworks.go.config.PipelineConfigs::GROUP, {:class => "form_input", :readonly => @group.hasRemoteParts()} -%>
                 <%= error_message_on(@group, com.thoughtworks.go.config.PipelineConfigs::GROUP, :css_class => "form_error") %>
                 <div class="clear"></div>
             </div>

--- a/server/webapp/WEB-INF/rails.new/app/views/admin/pipeline_groups/index.html.erb
+++ b/server/webapp/WEB-INF/rails.new/app/views/admin/pipeline_groups/index.html.erb
@@ -46,7 +46,13 @@
                     <tbody>
                     <% group.each do |pipeline| %>
                         <tr class="pipeline">
-                            <td class="name"><%= link_to smart_word_breaker(pipeline.name()), pipeline_edit_path(:pipeline_name => pipeline.name(), :current_tab => "general") %></td>
+                            <td class="name">
+															<% if pipeline.isLocal() %>
+																<%= link_to smart_word_breaker(pipeline.name()), pipeline_edit_path(:pipeline_name => pipeline.name(), :current_tab => "general") %>
+															<% else %>
+																<%= smart_word_breaker(pipeline.name()) %>
+															<% end %>
+														</td>
                             <td class="actions">
                                 <ul>
                                     <li>

--- a/server/webapp/WEB-INF/rails.new/app/views/admin/pipeline_groups/index.html.erb
+++ b/server/webapp/WEB-INF/rails.new/app/views/admin/pipeline_groups/index.html.erb
@@ -82,6 +82,10 @@
                                                <span class="action_icon add_icon_disabled extract_template_for_pipeline_<%=pipeline.name()-%>" title="<%= l.string("CANNOT_EXTRACT_TEMPLATE") -%>">
                                                    <%= l.string("EXTRACT_NEW_TEMPLATE") -%>
                                                </span>
+																						<% elsif !pipeline.isLocal() %>
+	                                               <span class="action_icon add_icon_disabled extract_template_for_pipeline_<%=pipeline.name()-%>" title="<%= l.string("CANNOT_EXTRACT_TEMPLATE_FROM_REMOTE") -%>">
+	                                                   <%= l.string("EXTRACT_NEW_TEMPLATE") -%>
+	                                               </span>
                                             <% else %>
                                                 <span class="title_secondary_info extract_template_for_pipeline_<%=pipeline.name()-%>">
                                                 <a href="#" class="add_link" onclick="Util.ajax_modal('<%= template_new_path(:pipelineToExtractFrom => pipeline.name()) -%>', {overlayClose: false, title: '<%= l.string("EXTRACT_NEW_TEMPLATE")-%>'}, function(text){return text})">
@@ -102,7 +106,7 @@
         </div>
     <% end %>
 
-    
+
 </div>
 
 <script type="text/javascript">
@@ -130,4 +134,3 @@
     });
 
 </script>
-

--- a/server/webapp/WEB-INF/rails.new/app/views/admin/pipeline_groups/index.html.erb
+++ b/server/webapp/WEB-INF/rails.new/app/views/admin/pipeline_groups/index.html.erb
@@ -66,6 +66,7 @@
                                         </li>
                                     <%- end -%>
                                     <li>
+																			<% if pipeline.isLocal() %>
                                         <% pipeline_random_id_for_clone = random_dom_id('clone_button_for_') -%>
                                         <a href="#" class="clone_pipeline clone_icon action_icon clone_button_for_<%= pipeline.name() -%>" id="<%= pipeline_random_id_for_clone -%>">
                                             <%= l.string("CLONE") -%>
@@ -78,6 +79,11 @@
                                                 });
                                             });
                                         </script>
+																			<% else %>
+																				<span class="action_icon clone_icon_disabled clone_button_for_<%=pipeline.name()-%>" title="<%= l.string("CANNOT_CLONE_REMOTE_PIPELINE") -%>">
+																					<%= l.string("CLONE") -%>
+																				</span>
+																			<% end %>
                                     </li>
                                     <li>
                                         <%= render :partial => "delete_pipeline", :locals => {:scope => {:pipeline => pipeline, :pipeline_to_can_delete => @pipeline_to_can_delete}} %>

--- a/server/webapp/WEB-INF/rails.new/app/views/admin/pipeline_groups/index.html.erb
+++ b/server/webapp/WEB-INF/rails.new/app/views/admin/pipeline_groups/index.html.erb
@@ -50,8 +50,14 @@
                             <td class="actions">
                                 <ul>
                                     <li>
+																			<% if pipeline.isLocal() %>
                                         <%= link_to l.string("EDIT"), pipeline_edit_path(:pipeline_name => pipeline.name(), :current_tab => "general"), :class=> "edit_pipeline edit_for_pipeline_#{pipeline.name()} action_icon edit_icon" %>
-                                    </li>
+																			<% else %>
+																				<span class="edit_pipeline action_icon edit_icon_disabled edit_for_pipeline_<%=pipeline.name()-%> action_icon" title="<%= l.string("CANNOT_EDIT_REMOTE_PIPELINE") -%>">
+																					<%= l.string("EDIT") -%>
+																				</span>
+																			<% end %>
+																		</li>
                                     <%- if @groups.size() > 1 -%>
                                         <li>
                                                 <a id="a_move_<%=pipeline.name()-%>" href="<%= possible_groups_path(with_md5_param(:pipeline_name => pipeline.name())) -%>" class="move_pipeline move_icon action_icon"><%= l.string("MOVE_TO") -%>

--- a/server/webapp/WEB-INF/rails.new/app/views/admin/pipeline_groups/index.html.erb
+++ b/server/webapp/WEB-INF/rails.new/app/views/admin/pipeline_groups/index.html.erb
@@ -58,7 +58,7 @@
 																				</span>
 																			<% end %>
 																		</li>
-                                    <%- if @groups.size() > 1 -%>
+                                    <%- if pipeline.isLocal() && @groups.size() > 1 -%>
                                         <li>
                                                 <a id="a_move_<%=pipeline.name()-%>" href="<%= possible_groups_path(with_md5_param(:pipeline_name => pipeline.name())) -%>" class="move_pipeline move_icon action_icon"><%= l.string("MOVE_TO") -%>
                                                     <span class="for_down_arrow">&nbsp;</span>

--- a/server/webapp/WEB-INF/rails.new/app/views/environments/_edit_environment_variables.html.erb
+++ b/server/webapp/WEB-INF/rails.new/app/views/environments/_edit_environment_variables.html.erb
@@ -7,7 +7,7 @@
         <tbody>
         <% scope[:form].object.getPlainTextVariables().each do |variable| -%>
           <%= scope[:form].fields_for :variables, variable, :index => "" do |var_form| %>
-            <%= render :partial => "environment_variable_entry", :locals => {:scope => {:var_form => var_form, :is_secure => false, :is_changed => false}} -%>
+            <%= render :partial => "environment_variable_entry", :locals => {:scope => {:var_form => var_form, :is_secure => false, :is_changed => false, :disabled => variable.isRemote()}} -%>
           <% end %>
         <%- end -%>
         </tbody>
@@ -28,7 +28,7 @@
         <tbody>
         <% scope[:form].object.getSecureVariables().each do |variable| -%>
           <%= scope[:form].fields_for :variables, variable, :index => "" do |var_form| %>
-            <%= render :partial => "environment_variable_entry", :locals => {:scope => {:var_form => var_form, :is_secure => true, :is_changed => false,:is_readonly =>true}} -%>
+            <%= render :partial => "environment_variable_entry", :locals => {:scope => {:var_form => var_form, :is_secure => true, :is_changed => false,:is_readonly =>true, :disabled => variable.isRemote()}} -%>
           <% end %>
         <%- end -%>
         </tbody>

--- a/server/webapp/WEB-INF/rails.new/app/views/environments/_edit_pipelines.html.erb
+++ b/server/webapp/WEB-INF/rails.new/app/views/environments/_edit_pipelines.html.erb
@@ -19,7 +19,18 @@
                             </div>
                  <% end %>
             </div>
-
+            <% if !scope[:remote_pipelines].empty? %>
+                <div class="available_pipelines"><%= l.string("SHOW_UNAVAILABLE_REMOTE_PIPELINES") -%></div>
+                <div class="input">
+                     <% scope[:remote_pipelines].each do |remote_pipeline| %>
+                               <div class="pipeline_selector">
+                                    <%= check_box_tag "environment[pipelines][][name]", remote_pipeline.getPipelineName(), remote_pipeline.isAssociatedWithEnvironment(scope[:environment].name.to_s),
+                                                      :disabled => true,:id => "pipeline_#{remote_pipeline.getPipelineName()}"-%>
+                                    <label for="pipeline_<%= remote_pipeline.getPipelineName() -%>" class="label inline"><%= remote_pipeline.getPipelineName() -%></label>
+                                </div>
+                     <% end %>
+                </div>
+            <% end %>
             <% if !(scope[:unavailable_pipelines].empty?) %>
                 <a id="show_unavailable_pipelines" class="hidereveal_expander"><%= l.string("SHOW_UNAVAILABLE_PIPELINES") -%></a>
                 <div class="unavailable_pipelines hidereveal_content">

--- a/server/webapp/WEB-INF/rails.new/app/views/environments/_environment_variable_entry.html.erb
+++ b/server/webapp/WEB-INF/rails.new/app/views/environments/_environment_variable_entry.html.erb
@@ -1,7 +1,7 @@
 <tr class="environment-variable-edit-row">
 
   <td class="name_value_cell">
-    <%= scope[:var_form].text_field :name, :class => 'form_input environment_variable_name', :id => nil -%>
+    <%= scope[:var_form].text_field :name, :class => 'form_input environment_variable_name', :disabled => scope[:disabled], :id => nil -%>
   </td>
 
   <td class="name_value_cell">
@@ -10,14 +10,14 @@
 
   <td class="name_value_cell">
     <% if scope[:is_secure] %>
-      <%= scope[:var_form].password_field :valueForDisplay, :class => 'form_input environment_variable_value', :id => nil, :readonly => scope[:is_readonly] ? 'readonly' : nil -%>
+      <%= scope[:var_form].password_field :valueForDisplay, :class => 'form_input environment_variable_value', :id => nil, :disabled => scope[:disabled], :readonly => scope[:is_readonly] ? 'readonly' : nil -%>
       <%= scope[:var_form].hidden_field :secure, value: true -%>
       <% if scope[:var_form].object %>
         <%= scope[:var_form].hidden_field :originalValue, value: scope[:var_form].object.getValueForDisplay, class: "original-secure-variable-value" -%>
       <% end %>
       <%= scope[:var_form].hidden_field com.thoughtworks.go.config.EnvironmentVariableConfig::ISCHANGED, value: scope[:is_changed], :class => "is-changed-field" -%>
     <% else %>
-      <%= scope[:var_form].text_field :valueForDisplay, :class => 'form_input environment_variable_value', :id => nil -%>
+      <%= scope[:var_form].text_field :valueForDisplay, :class => 'form_input environment_variable_value', :disabled => scope[:disabled], :id => nil -%>
     <% end %>
   </td>
 
@@ -29,7 +29,9 @@
   </td>
 
   <td class="name_value_cell icon_remove_cell">
-    <span class="icon_remove delete_parent"></span>
+    <% if !scope[:disabled] %>
+      <span class="icon_remove delete_parent"></span>
+    <% end %>
     <span class="wizard_error_message"></span>
   </td>
 

--- a/server/webapp/WEB-INF/rails.new/app/views/environments/_form.html.erb
+++ b/server/webapp/WEB-INF/rails.new/app/views/environments/_form.html.erb
@@ -45,7 +45,7 @@
                 <!-- Add pipelines tab -->
                 <div id="tab-content-of-env-pipelines">
                    <h2 class="section_title"><%= l.string('PIPELINES_TO_ADD') -%></h2>
-                    <%= render :partial => "edit_pipelines.html", :locals => {:scope => {:environment => scope[:environment], :available_pipelines => scope[:available_pipelines], :unavailable_pipelines => scope[:unavailable_pipelines]}} %>
+                    <%= render :partial => "edit_pipelines.html", :locals => {:scope => {:environment => scope[:environment], :available_pipelines => scope[:available_pipelines],:remote_pipelines => scope[:remote_pipelines], :unavailable_pipelines => scope[:unavailable_pipelines]}} %>
                     <div class="form_buttons actions">
                         <button class="left submit cancel_button"><span><%= l.string('CANCEL') -%></span></button>
                         <button id="next_to_pipelines" class="right primary next submit"><span><%= l.string('NEXT_BUTTON') -%></span></button>

--- a/server/webapp/WEB-INF/rails.new/app/views/environments/edit_pipelines.html.erb
+++ b/server/webapp/WEB-INF/rails.new/app/views/environments/edit_pipelines.html.erb
@@ -1,5 +1,5 @@
 <%= render :partial => "edit_before.html", :locals => {:scope => {:environment => @environment}} %>
-<%= render :partial => "edit_pipelines", :locals => {:scope => {:environment => @environment, :unavailable_pipelines => @unavailable_pipelines, :available_pipelines => @available_pipelines}} %>
+<%= render :partial => "edit_pipelines", :locals => {:scope => {:environment => @environment, :unavailable_pipelines => @unavailable_pipelines,:remote_pipelines => @remote_pipelines, :available_pipelines => @available_pipelines}} %>
 <%= config_md5_field %>
 <%= register_defaultable_list("environment>pipelines") %>
 <%= render :partial => "edit_after.html" %>

--- a/server/webapp/WEB-INF/rails.new/app/views/environments/new.html.erb
+++ b/server/webapp/WEB-INF/rails.new/app/views/environments/new.html.erb
@@ -1,4 +1,4 @@
 <% @view_title = "Add Environment" -%>
 <% @page_header = '<h1 id="page-title" class="entity_title">Add Environment</h1>' -%>
 
-<%= render :partial => "form.html", :locals => {:scope => {:environment => @environment, :available_pipelines => @available_pipelines,  :unavailable_pipelines => @unavailable_pipelines, :agents => @agents, :form_action => environment_create_path, :form_method => "post"}} %>
+<%= render :partial => "form.html", :locals => {:scope => {:environment => @environment, :available_pipelines => @available_pipelines,  :unavailable_pipelines => @unavailable_pipelines, :remote_pipelines => @remote_pipelines, :agents => @agents, :form_action => environment_create_path, :form_method => "post"}} %>

--- a/server/webapp/WEB-INF/rails.new/lib/admin/dependency_material_auto_suggestions.rb
+++ b/server/webapp/WEB-INF/rails.new/lib/admin/dependency_material_auto_suggestions.rb
@@ -19,7 +19,7 @@ module Admin
     include JavaImports
 
     def pipeline_stages_json(cruise_config, current_user, security_service, params)
-      pipelines = cruise_config.getAllPipelineConfigs()
+      pipelines = cruise_config.getAllLocalPipelineConfigs()
       pipeline_stages_array = Array.new
       pipelines.each do |pipeline|
         unless pipeline.name() == CaseInsensitiveString.new(params[:pipeline_name])

--- a/server/webapp/WEB-INF/rails.new/spec/controllers/environments_controller_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/controllers/environments_controller_spec.rb
@@ -127,7 +127,8 @@ describe EnvironmentsController do
       environment_name = "foo-environment"
       result = ""
       @env_name = @pipelines = @agents = @user = @environment_variables = ""
-      @environment_service.should_receive(:getAllPipelinesForUser).with(user).and_return([EnvironmentPipelineModel.new("foo", nil), EnvironmentPipelineModel.new("bar", nil)])
+      @environment_service.should_receive(:getAllLocalPipelinesForUser).with(user).and_return([EnvironmentPipelineModel.new("foo", nil), EnvironmentPipelineModel.new("bar", nil)])
+      @environment_service.should_receive(:getAllRemotePipelinesForUserInEnvironment).with(any_args,any_args).and_return([])
 
       @environment_service.should_receive(:createEnvironment) do |environment_config, user, operation_result|
         @env_name = environment_config.name()
@@ -154,7 +155,8 @@ describe EnvironmentsController do
       controller.stub(:environment_config_service).and_return(@environment_service)
       environment_name = "foo-environment"
       createEnvironmentCalled = false
-      @environment_service.should_receive(:getAllPipelinesForUser).with(user).and_return([EnvironmentPipelineModel.new("foo", nil), EnvironmentPipelineModel.new("bar", nil)])
+      @environment_service.should_receive(:getAllLocalPipelinesForUser).with(user).and_return([EnvironmentPipelineModel.new("foo", nil), EnvironmentPipelineModel.new("bar", nil)])
+      @environment_service.should_receive(:getAllRemotePipelinesForUserInEnvironment).with(any_args,any_args).and_return([])
       @environment_service.should_receive(:createEnvironment) do |env_config, user, result|
         expect(env_config.name()).to eq(CaseInsensitiveString.new(environment_name))
         expect(env_config.getPipelineNames().to_a).to eq([CaseInsensitiveString.new("first_pipeline"), CaseInsensitiveString.new("second_pipeline")])
@@ -215,7 +217,8 @@ describe EnvironmentsController do
       controller.stub(:current_user).and_return(current_user)
 
       pipelines = [EnvironmentPipelineModel.new("first", nil)]
-      @environment_service.should_receive(:getAllPipelinesForUser).with(current_user).and_return(pipelines)
+      @environment_service.should_receive(:getAllLocalPipelinesForUser).with(current_user).and_return(pipelines)
+      @environment_service.should_receive(:getAllRemotePipelinesForUserInEnvironment).with(any_args,any_args).and_return([])
       @environment_service.stub(:isEnvironmentFeatureEnabled).and_return(true)
 
       post :create, :no_layout => true, :environment => {'pipelines' => [{'name' => "first"}]}
@@ -318,8 +321,8 @@ describe EnvironmentsController do
       result.setMessage(LocalizedMessage.composite([LocalizedMessage.string("UPDATE_ENVIRONMENT_SUCCESS",["foo_env"].to_java(java.lang.String)),LocalizedMessage.string("CONFIG_MERGED")].to_java(com.thoughtworks.go.i18n.Localizable)))
       environment_service.should_receive(:updateEnvironment).with(any_args,any_args,any_args,any_args).and_return(result)
       environment_service.should_receive(:forEdit).with(any_args,any_args).and_return(com.thoughtworks.go.domain.ConfigElementForEdit.new(BasicEnvironmentConfig.new(),"md5"))
-      environment_service.should_receive(:getAllPipelinesForUser).with(any_args).and_return([])
-
+      environment_service.should_receive(:getAllLocalPipelinesForUser).with(any_args).and_return([])
+      environment_service.should_receive(:getAllRemotePipelinesForUserInEnvironment).with(any_args,any_args).and_return([])
 
       put :update, :no_layout => true,
           :environment => {'agents' => [{'uuid' => "uuid-1"}], 'name' => 'foo_env', 'pipelines' => [{'name' => 'bar'}], 'variables' => [{'name' => "var_name", 'value' => "var_value"}]},

--- a/server/webapp/WEB-INF/rails.new/spec/views/environments/new_html_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/views/environments/new_html_spec.rb
@@ -20,6 +20,7 @@ describe "environments/new.html.erb" do
   before do
     assign(:available_pipelines, [])
     assign(:unavailable_pipelines, [])
+    assign(:remote_pipelines, [])
     assign(:agents, [])
     assign(:environment, BasicEnvironmentConfig.new())
     allow(view).to receive(:current_user).and_return(com.thoughtworks.go.server.domain.Username.new(CaseInsensitiveString.new('user_foo')))

--- a/server/webapp/localize.xml
+++ b/server/webapp/localize.xml
@@ -278,6 +278,7 @@
     <entry key="ENV_NOT_FOUND">Environment named ''{0}'' not found.</entry>
     <entry key="SHOW_ENVIRONMENT_PAGE_TITLE">{0} - Environment</entry>
     <entry key="SHOW_UNAVAILABLE_PIPELINES">Unavailable pipelines (Already associated with environments)</entry>
+    <entry key="SHOW_UNAVAILABLE_REMOTE_PIPELINES">Pipelines associated with this environment in configuration repository</entry>
     <entry key="SHOW_AVAILABLE_PIPELINES">Available pipelines</entry>
     <entry key="NO_AVAILABLE_PIPELINES">There are no available pipelines.</entry>
     <entry key="INVALID_CONFIG_ON_DISK">Invalid config on disk. Displaying the last known valid config (Editing config through Go will overwrite the invalid copy. Edit it on disk to fix this problem).</entry>

--- a/server/webapp/localize.xml
+++ b/server/webapp/localize.xml
@@ -678,6 +678,7 @@
     <entry key="CREATE_TEMPLATE_FROM_PIPELINE_TOOL_TIP">If a pipeline is not selected, a template with a default stage and default job is created. If a pipeline is selected, the template will use the stages from the pipeline and the pipeline itself will start using this template.</entry>
     <entry key="CREATE_TEMPLATE_FROM_PIPELINE_DISABLED_TOOL_TIP">No pipelines available for extracting template. Either all pipelines use templates already or no pipelines exists.</entry>
     <entry key="CANNOT_EXTRACT_TEMPLATE">This pipeline is already using a template.</entry>
+    <entry key="CANNOT_EXTRACT_TEMPLATE_FROM_REMOTE">This pipeline is defined in configuration repository.</entry>
     <entry key="THIS_PIPELINE_WILL_NOW_START_USING_NEWLY_CREATED_TEMPLATE">This pipeline will now start using the newly created template.</entry>
     <entry key="STAGE_CANCELLED_SUCCESSFULLY">Stage cancelled successfully.</entry>
     <entry key="GO_TEST_CASE_MESSAGE_WITH_NEWLINE">Message with newline.

--- a/server/webapp/localize.xml
+++ b/server/webapp/localize.xml
@@ -510,6 +510,7 @@
     <entry key="DELETED_SUCCESSFULLY">Deleted successfully.</entry>
     <entry key="ADMINISTRATION">Administration</entry>
     <entry key="NUMBER_OF_JOBS">{0} Jobs</entry>
+    <entry key="CANNOT_DELETE_REMOTE_PIPELINE">Cannot delete pipeline ''{0}'' defined in configuration repository ''{1}''</entry>
     <entry key="CANNOT_DELETE_PIPELINE_IN_ENVIRONMENT">Cannot delete pipeline ''{0}'' as it is present in environment ''{1}''</entry>
     <entry key="CANNOT_DELETE_PIPELINE_USED_AS_MATERIALS">Cannot delete pipeline ''{0}'' as pipeline ''{1}'' depends on it</entry>
     <entry key="CAN_DELETE_PIPELINE">Delete this pipeline</entry>

--- a/server/webapp/localize.xml
+++ b/server/webapp/localize.xml
@@ -679,6 +679,7 @@
     <entry key="CREATE_TEMPLATE_FROM_PIPELINE_DISABLED_TOOL_TIP">No pipelines available for extracting template. Either all pipelines use templates already or no pipelines exists.</entry>
     <entry key="CANNOT_EXTRACT_TEMPLATE">This pipeline is already using a template.</entry>
     <entry key="CANNOT_EXTRACT_TEMPLATE_FROM_REMOTE">This pipeline is defined in configuration repository.</entry>
+    <entry key="CANNOT_EDIT_REMOTE_PIPELINE">Cannot edit pipeline defined in configuration repository.</entry>
     <entry key="THIS_PIPELINE_WILL_NOW_START_USING_NEWLY_CREATED_TEMPLATE">This pipeline will now start using the newly created template.</entry>
     <entry key="STAGE_CANCELLED_SUCCESSFULLY">Stage cancelled successfully.</entry>
     <entry key="GO_TEST_CASE_MESSAGE_WITH_NEWLINE">Message with newline.

--- a/server/webapp/localize.xml
+++ b/server/webapp/localize.xml
@@ -680,6 +680,7 @@
     <entry key="CANNOT_EXTRACT_TEMPLATE">This pipeline is already using a template.</entry>
     <entry key="CANNOT_EXTRACT_TEMPLATE_FROM_REMOTE">This pipeline is defined in configuration repository.</entry>
     <entry key="CANNOT_EDIT_REMOTE_PIPELINE">Cannot edit pipeline defined in configuration repository.</entry>
+    <entry key="CANNOT_CLONE_REMOTE_PIPELINE">Cannot clone pipeline defined in configuration repository.</entry>
     <entry key="THIS_PIPELINE_WILL_NOW_START_USING_NEWLY_CREATED_TEMPLATE">This pipeline will now start using the newly created template.</entry>
     <entry key="STAGE_CANCELLED_SUCCESSFULLY">Stage cancelled successfully.</entry>
     <entry key="GO_TEST_CASE_MESSAGE_WITH_NEWLINE">Message with newline.

--- a/server/webapp/localize_ja.xml
+++ b/server/webapp/localize_ja.xml
@@ -276,6 +276,7 @@
     <entry key="ENV_NOT_FOUND">Environment named ''{0}'' not found.</entry>
     <entry key="SHOW_ENVIRONMENT_PAGE_TITLE">{0} - Environment</entry>
     <entry key="SHOW_UNAVAILABLE_PIPELINES">Unavailable pipelines (Already associated with environments)</entry>
+    <entry key="SHOW_UNAVAILABLE_REMOTE_PIPELINES">Pipelines associated with this environment in configuration repository</entry>
     <entry key="SHOW_AVAILABLE_PIPELINES">Available pipelines</entry>
     <entry key="NO_AVAILABLE_PIPELINES">There are no available pipelines.</entry>
     <entry key="INVALID_CONFIG_ON_DISK">Invalid config on disk. Displaying the last known valid config (Editing config through Go will overwrite the invalid copy. Edit it on disk to fix this problem).</entry>

--- a/server/webapp/localize_ja.xml
+++ b/server/webapp/localize_ja.xml
@@ -677,6 +677,7 @@
     <entry key="CREATE_TEMPLATE_FROM_PIPELINE_DISABLED_TOOL_TIP">No pipelines available for extracting template. Either all pipelines use templates already or no pipelines exists.</entry>
     <entry key="CANNOT_EXTRACT_TEMPLATE">This pipeline is already using a template.</entry>
     <entry key="CANNOT_EXTRACT_TEMPLATE_FROM_REMOTE">This pipeline is defined in configuration repository.</entry>
+    <entry key="CANNOT_EDIT_REMOTE_PIPELINE">Cannot edit pipeline defined in configuration repository.</entry>
     <entry key="THIS_PIPELINE_WILL_NOW_START_USING_NEWLY_CREATED_TEMPLATE">This pipeline will now start using the newly created template.</entry>
     <entry key="STAGE_CANCELLED_SUCCESSFULLY">Stage cancelled successfully.</entry>
     <entry key="GO_TEST_CASE_MESSAGE_WITH_NEWLINE">Message with newline.

--- a/server/webapp/localize_ja.xml
+++ b/server/webapp/localize_ja.xml
@@ -678,6 +678,7 @@
     <entry key="CANNOT_EXTRACT_TEMPLATE">This pipeline is already using a template.</entry>
     <entry key="CANNOT_EXTRACT_TEMPLATE_FROM_REMOTE">This pipeline is defined in configuration repository.</entry>
     <entry key="CANNOT_EDIT_REMOTE_PIPELINE">Cannot edit pipeline defined in configuration repository.</entry>
+    <entry key="CANNOT_CLONE_REMOTE_PIPELINE">Cannot clone pipeline defined in configuration repository.</entry>
     <entry key="THIS_PIPELINE_WILL_NOW_START_USING_NEWLY_CREATED_TEMPLATE">This pipeline will now start using the newly created template.</entry>
     <entry key="STAGE_CANCELLED_SUCCESSFULLY">Stage cancelled successfully.</entry>
     <entry key="GO_TEST_CASE_MESSAGE_WITH_NEWLINE">Message with newline.

--- a/server/webapp/localize_ja.xml
+++ b/server/webapp/localize_ja.xml
@@ -676,6 +676,7 @@
     <entry key="CREATE_TEMPLATE_FROM_PIPELINE_TOOL_TIP">If a pipeline is not selected, a template with a default stage and default job is created. If a pipeline is selected, the template will use the stages from the pipeline and the pipeline itself will start using this template.</entry>
     <entry key="CREATE_TEMPLATE_FROM_PIPELINE_DISABLED_TOOL_TIP">No pipelines available for extracting template. Either all pipelines use templates already or no pipelines exists.</entry>
     <entry key="CANNOT_EXTRACT_TEMPLATE">This pipeline is already using a template.</entry>
+    <entry key="CANNOT_EXTRACT_TEMPLATE_FROM_REMOTE">This pipeline is defined in configuration repository.</entry>
     <entry key="THIS_PIPELINE_WILL_NOW_START_USING_NEWLY_CREATED_TEMPLATE">This pipeline will now start using the newly created template.</entry>
     <entry key="STAGE_CANCELLED_SUCCESSFULLY">Stage cancelled successfully.</entry>
     <entry key="GO_TEST_CASE_MESSAGE_WITH_NEWLINE">Message with newline.

--- a/server/webapp/localize_ja.xml
+++ b/server/webapp/localize_ja.xml
@@ -505,6 +505,7 @@
     <entry key="DELETED_SUCCESSFULLY">Deleted successfully.</entry>
     <entry key="ADMINISTRATION">Administration</entry>
     <entry key="NUMBER_OF_JOBS">{0} Jobs</entry>
+    <entry key="CANNOT_DELETE_REMOTE_PIPELINE">Cannot delete pipeline ''{0}'' defined in configuration repository ''{1}''</entry>
     <entry key="CANNOT_DELETE_PIPELINE_IN_ENVIRONMENT">Cannot delete pipeline ''{0}'' as it is present in environment ''{1}''</entry>
     <entry key="CANNOT_DELETE_PIPELINE_USED_AS_MATERIALS">Cannot delete pipeline ''{0}'' as pipeline ''{1}'' depends on it</entry>
     <entry key="CAN_DELETE_PIPELINE">Delete this pipeline</entry>


### PR DESCRIPTION
This should be merged after #1810, it is a single commit then.

@jyotisingh described the problem clearly

> if config save passes (ie. the new config is checked in to config.git repo) whereas tryAssembleMergedConfig fails, then the config object in memory would not be updated. So, you would have a different version of config object in memory and a different one in the git-repo and file-system. 

This is true. I added tests to confirm first. Then I altered behaviour so now when changes are introduced **because main config has changed** then in case of failed merge with **latest** partials, the merge will fallback to using previous partials (which are used anyway as current config).

In other words:
We want to ensure that UI changes are always present in current, valid,
cached config. There is always some valid base config. When partials are
involved there is at least "last known valid merged configuration". So
regardless of the fact if latest main config and partials are mergable,
we can always fallback to using old partials with new modified main
configuration.
