### PR TITLE
#1596 explicitly set PWD when agent starts process

### DIFF
--- a/common/src/com/thoughtworks/go/util/ProcessManager.java
+++ b/common/src/com/thoughtworks/go/util/ProcessManager.java
@@ -55,6 +55,7 @@ public class ProcessManager {
                 LOG.debug(String.format("[Command Line] Using working directory %s to start the process.", workingDir.getAbsolutePath()));
             }
             processBuilder.directory(workingDir);
+            envMap.put("PWD", workingDir.getAbsolutePath());
         }
 
         environmentVariableContext.setupRuntimeEnvironment(processBuilder.environment(), consumer);


### PR DESCRIPTION
Proposed fix for #1596 

We just force setting PWD when agents spawns a process.

I tested this by debugging development agent running exec task `env`. 

Before the change, it is set to agent root workspace.
```
21:19:41.450 PWD=/ide/work/agent
```

After this change, it is set to pipeline workspace as one would expect
```
21:42:14.495 PWD=/ide/work/agent/pipelines/pwd-test
```