### PR TITLE
WIP: Make build reproducible

### DIFF
--- a/addon-api/database/pom.xml
+++ b/addon-api/database/pom.xml
@@ -45,6 +45,11 @@
             </plugin>
 
             <plugin>
+              <groupId>io.github.zlika</groupId>
+              <artifactId>reproducible-build-maven-plugin</artifactId>
+            </plugin>
+
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
                 <version>2.4</version>

--- a/addon-api/licensing/pom.xml
+++ b/addon-api/licensing/pom.xml
@@ -69,6 +69,11 @@
             </plugin>
 
             <plugin>
+              <groupId>io.github.zlika</groupId>
+              <artifactId>reproducible-build-maven-plugin</artifactId>
+            </plugin>
+
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
                 <version>2.4</version>

--- a/agent-bootstrapper/pom.xml
+++ b/agent-bootstrapper/pom.xml
@@ -86,6 +86,32 @@
             </plugin>
 
             <plugin>
+                <groupId>io.github.zlika</groupId>
+                <artifactId>reproducible-build-maven-plugin</artifactId>
+                <executions>
+
+                    <!-- First run of strip-jar since agent-bootstrapper-classes.jar needs to be stripped before it is packaged into agent-bootstrapper.jar -->
+                    <execution>
+                        <id>make-jar-reproducible-after-it-is-created</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>strip-jar</goal>
+                        </goals>
+                    </execution>
+
+                    <!-- Second run of strip-jar since agent-bootstrapper.jar will be updated to include some other jars,
+                         after run 1 above (in update-one-jar execution below). -->
+                    <execution>
+                        <id>make-both-launcher-jars-reproducible-after-they-are-created</id>
+                        <phase>pre-integration-test</phase>
+                        <goals>
+                            <goal>strip-jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
                 <groupId>org.dstovall</groupId>
                 <artifactId>onejar-maven-plugin</artifactId>
                 <version>1.4.5</version>

--- a/agent-common/pom.xml
+++ b/agent-common/pom.xml
@@ -62,6 +62,11 @@
             </plugin>
 
             <plugin>
+              <groupId>io.github.zlika</groupId>
+              <artifactId>reproducible-build-maven-plugin</artifactId>
+            </plugin>
+
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
                 <version>2.4</version>

--- a/agent-launcher/pom.xml
+++ b/agent-launcher/pom.xml
@@ -80,6 +80,33 @@
             </plugin>
 
             <plugin>
+                <groupId>io.github.zlika</groupId>
+                <artifactId>reproducible-build-maven-plugin</artifactId>
+                <executions>
+
+                    <!-- First run of strip-jar since agent-launcher-classes.jar needs to be stripped before it is packaged
+                         into agent-laucher.jar below. -->
+                    <execution>
+                        <id>make-jar-reproducible-after-it-is-created</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>strip-jar</goal>
+                        </goals>
+                    </execution>
+
+                    <!-- Second run of strip-jar since agent-launcher.jar was not yet created during run 1 above and
+                         is updated during the one-jar execution above. -->
+                    <execution>
+                        <id>make-both-launcher-jars-reproducible-after-they-are-created</id>
+                        <phase>pre-integration-test</phase>
+                        <goals>
+                            <goal>strip-jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
                 <version>2.8</version>

--- a/agent/pom.xml
+++ b/agent/pom.xml
@@ -130,6 +130,32 @@
             </plugin>
 
             <plugin>
+                <groupId>io.github.zlika</groupId>
+                <artifactId>reproducible-build-maven-plugin</artifactId>
+                <executions>
+
+                    <!-- First run of strip-jar since agent-classes.jar needs to be stripped before it is packaged into agent.jar -->
+                    <execution>
+                        <id>make-jar-reproducible-after-it-is-created</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>strip-jar</goal>
+                        </goals>
+                    </execution>
+
+                    <!-- Second run of strip-jar since agent.jar will be updated to include some other jars,
+                         after run 1 above (in update-one-jar execution below). -->
+                    <execution>
+                        <id>make-both-launcher-jars-reproducible-after-they-are-created</id>
+                        <phase>pre-integration-test</phase>
+                        <goals>
+                            <goal>strip-jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
                 <groupId>org.dstovall</groupId>
                 <artifactId>onejar-maven-plugin</artifactId>
                 <version>1.4.5</version>

--- a/app-server/pom.xml
+++ b/app-server/pom.xml
@@ -219,6 +219,11 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
             </plugin>
+
+            <plugin>
+              <groupId>io.github.zlika</groupId>
+              <artifactId>reproducible-build-maven-plugin</artifactId>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/base/pom.xml
+++ b/base/pom.xml
@@ -147,6 +147,11 @@
             </plugin>
 
             <plugin>
+              <groupId>io.github.zlika</groupId>
+              <artifactId>reproducible-build-maven-plugin</artifactId>
+            </plugin>
+
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.16</version>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -201,6 +201,11 @@
             </plugin>
 
             <plugin>
+              <groupId>io.github.zlika</groupId>
+              <artifactId>reproducible-build-maven-plugin</artifactId>
+            </plugin>
+
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-antrun-plugin</artifactId>
                 <version>1.7</version>

--- a/config/config-api/pom.xml
+++ b/config/config-api/pom.xml
@@ -114,6 +114,11 @@
             </plugin>
 
             <plugin>
+              <groupId>io.github.zlika</groupId>
+              <artifactId>reproducible-build-maven-plugin</artifactId>
+            </plugin>
+
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
                 <version>2.4</version>

--- a/config/config-server/pom.xml
+++ b/config/config-server/pom.xml
@@ -154,6 +154,11 @@
             </plugin>
 
             <plugin>
+              <groupId>io.github.zlika</groupId>
+              <artifactId>reproducible-build-maven-plugin</artifactId>
+            </plugin>
+
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.16</version>

--- a/db/pom.xml
+++ b/db/pom.xml
@@ -45,6 +45,11 @@
             </plugin>
 
             <plugin>
+              <groupId>io.github.zlika</groupId>
+              <artifactId>reproducible-build-maven-plugin</artifactId>
+            </plugin>
+
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
                 <version>2.4</version>

--- a/development-utility/development-agent/pom.xml
+++ b/development-utility/development-agent/pom.xml
@@ -56,6 +56,11 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
             </plugin>
+
+            <plugin>
+              <groupId>io.github.zlika</groupId>
+              <artifactId>reproducible-build-maven-plugin</artifactId>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/development-utility/development-server/pom.xml
+++ b/development-utility/development-server/pom.xml
@@ -116,6 +116,11 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
             </plugin>
+
+            <plugin>
+              <groupId>io.github.zlika</groupId>
+              <artifactId>reproducible-build-maven-plugin</artifactId>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/jetty9/pom.xml
+++ b/jetty9/pom.xml
@@ -232,6 +232,11 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
             </plugin>
+
+            <plugin>
+              <groupId>io.github.zlika</groupId>
+              <artifactId>reproducible-build-maven-plugin</artifactId>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>

--- a/metrics/pom.xml
+++ b/metrics/pom.xml
@@ -91,6 +91,11 @@
             </plugin>
 
             <plugin>
+              <groupId>io.github.zlika</groupId>
+              <artifactId>reproducible-build-maven-plugin</artifactId>
+            </plugin>
+
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
                 <version>2.4</version>

--- a/plugin-infra/go-plugin-access/pom.xml
+++ b/plugin-infra/go-plugin-access/pom.xml
@@ -62,6 +62,11 @@
             </plugin>
 
             <plugin>
+              <groupId>io.github.zlika</groupId>
+              <artifactId>reproducible-build-maven-plugin</artifactId>
+            </plugin>
+
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
                 <version>2.4</version>

--- a/plugin-infra/go-plugin-activator/pom.xml
+++ b/plugin-infra/go-plugin-activator/pom.xml
@@ -87,6 +87,11 @@
             </plugin>
 
             <plugin>
+              <groupId>io.github.zlika</groupId>
+              <artifactId>reproducible-build-maven-plugin</artifactId>
+            </plugin>
+
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
                 <version>2.4</version>

--- a/plugin-infra/go-plugin-api-internal/pom.xml
+++ b/plugin-infra/go-plugin-api-internal/pom.xml
@@ -46,6 +46,11 @@
             </plugin>
 
             <plugin>
+              <groupId>io.github.zlika</groupId>
+              <artifactId>reproducible-build-maven-plugin</artifactId>
+            </plugin>
+
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
                 <version>2.4</version>

--- a/plugin-infra/go-plugin-api/pom.xml
+++ b/plugin-infra/go-plugin-api/pom.xml
@@ -98,6 +98,11 @@
             </plugin>
 
             <plugin>
+                <groupId>io.github.zlika</groupId>
+                <artifactId>reproducible-build-maven-plugin</artifactId>
+            </plugin>
+
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <version>2.9.1</version>

--- a/plugin-infra/go-plugin-infra/pom.xml
+++ b/plugin-infra/go-plugin-infra/pom.xml
@@ -144,6 +144,11 @@
             </plugin>
 
             <plugin>
+              <groupId>io.github.zlika</groupId>
+              <artifactId>reproducible-build-maven-plugin</artifactId>
+            </plugin>
+
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
                 <version>2.4</version>

--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,18 @@
                         <useIncrementalCompilation>false</useIncrementalCompilation>
                     </configuration>
                 </plugin>
+                <plugin>
+                    <groupId>io.github.zlika</groupId>
+                    <artifactId>reproducible-build-maven-plugin</artifactId>
+                    <version>0.2</version>
+                    <executions>
+                        <execution>
+                            <goals>
+                                <goal>strip-jar</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
             </plugins>
         </pluginManagement>
     </build>

--- a/rack_hack/pom.xml
+++ b/rack_hack/pom.xml
@@ -68,6 +68,11 @@
             </plugin>
 
             <plugin>
+              <groupId>io.github.zlika</groupId>
+              <artifactId>reproducible-build-maven-plugin</artifactId>
+            </plugin>
+
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
                 <version>2.4</version>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -692,6 +692,11 @@
             </plugin>
 
             <plugin>
+              <groupId>io.github.zlika</groupId>
+              <artifactId>reproducible-build-maven-plugin</artifactId>
+            </plugin>
+
+            <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
                 <version>1.8</version>

--- a/tasks/jars.rake
+++ b/tasks/jars.rake
@@ -33,8 +33,7 @@ def tw_go_jar(module_name, jar_name = module_name)
 end
 
 def server_launcher_dependencies
-  jars = Dir.glob($PROJECT_BASE + '/server-launcher/target/libs/*.jar')
-  jars
+  Dir.glob($PROJECT_BASE + '/server-launcher/target/libs/*.jar')
 end
 def jetty_jars
   Dir.glob($PROJECT_BASE + '/jetty9/target/lib/*.jar')
@@ -43,11 +42,9 @@ end
 def maven_dependency(groupid, artifactid, version, maven_repository = File.expand_path('~') + '/.m2/repository')
   groupid.gsub!('.', '/')
   path = maven_repository + '/' + groupid + '/' + artifactid + '/' + version + '/*.jar'
-  jars = Dir.glob(path)
-  jars
+  Dir.glob(path)
 end
 
 def local_maven_dependency(groupid, artifactid, version)
-  jars = maven_dependency(groupid, artifactid, version, $PROJECT_BASE + '/local-maven-repo')
-  jars
+  maven_dependency(groupid, artifactid, version, $PROJECT_BASE + '/local-maven-repo')
 end

--- a/tasks/onejar.rake
+++ b/tasks/onejar.rake
@@ -28,9 +28,11 @@ def in_classpath_form deps
 end
 
 def onejar jarname
-  package(:jar, :file => _(:target, 'main.jar')).with(:manifest => manifest.merge("Class-Path" => in_classpath_form(compile.dependencies)))
+  package(:jar, :file => _(:target, 'main.jar'))
+      .with(:manifest => manifest.merge("Class-Path" => in_classpath_form(compile.dependencies)))
+      .make_reproducible
 
-  one_jar = package(:onejar, :file => jarname)
+  one_jar = package(:onejar, :file => jarname).make_reproducible
   self.main_jars << one_jar
   one_jar
 end

--- a/test-agent/pom.xml
+++ b/test-agent/pom.xml
@@ -53,6 +53,11 @@
             </plugin>
 
             <plugin>
+              <groupId>io.github.zlika</groupId>
+              <artifactId>reproducible-build-maven-plugin</artifactId>
+            </plugin>
+
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
                 <version>2.4</version>

--- a/test-utils/pom.xml
+++ b/test-utils/pom.xml
@@ -313,6 +313,11 @@
             </plugin>
 
             <plugin>
+              <groupId>io.github.zlika</groupId>
+              <artifactId>reproducible-build-maven-plugin</artifactId>
+            </plugin>
+
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
                 <version>2.4</version>

--- a/tfs-impl/pom.xml
+++ b/tfs-impl/pom.xml
@@ -118,6 +118,32 @@
             </plugin>
 
             <plugin>
+                <groupId>io.github.zlika</groupId>
+                <artifactId>reproducible-build-maven-plugin</artifactId>
+                <executions>
+
+                    <!-- First run of strip-jar since tfs-impl-classes.jar needs to be stripped before it is packaged into agent-bootstrapper.jar -->
+                    <execution>
+                        <id>make-jar-reproducible-after-it-is-created</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>strip-jar</goal>
+                        </goals>
+                    </execution>
+
+                    <!-- Second run of strip-jar since tfs-impl.jar will be updated to include some other jars,
+                         after run 1 above (in one-jar execution below). -->
+                    <execution>
+                        <id>make-both-launcher-jars-reproducible-after-they-are-created</id>
+                        <phase>pre-integration-test</phase>
+                        <goals>
+                            <goal>strip-jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
                 <version>2.8</version>

--- a/util/pom.xml
+++ b/util/pom.xml
@@ -118,6 +118,11 @@
             </plugin>
 
             <plugin>
+              <groupId>io.github.zlika</groupId>
+              <artifactId>reproducible-build-maven-plugin</artifactId>
+            </plugin>
+
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
                 <version>2.4</version>


### PR DESCRIPTION
This is needed so that we can easily re-release an older version of Go, with some security fixes, etc. To be able to truly verify that an new build is just an old build with the new changes, we need the ability to rebuild old revisions, given a gocd/gocd commit SHA.

* Strip time from JAR and ZIP files so that they remain the same across runs.
* Handle one-jar files, which package jars and zips inside them.
* Command repository zip is not full reproducible because .git/index changes
  across clones, even if nothing has changed.

This works for mostly everything. The only thing in go.jar which is not reproducible is the command repository. I think we will need to store the command repository zip packaged with the installer (for every commit in the repo) somewhere, and reuse it if we truly want a reproducible build.

Second, installers are not handled in this PR. We should probably move everything out of cruise-modules.rb into fpm and try and handle it there. It won't be easy if we don't control building though.

Third, plugins need to be made reproducible too. Since it is a different repo, it can be done there. This is very easy to do.

This PR needs JDK8 (the reproducible-build-maven-plugin needs it). So, it cannot be merged now.

My idea is to run our build inside some VM or container, so that the version of JDK and other dependencies are fixed.

PS:  I really hate buildr and maven.