### PR TITLE
Make pipeline related errors more visible on dashboard

### DIFF
--- a/common/src/com/thoughtworks/go/serverhealth/HealthStateType.java
+++ b/common/src/com/thoughtworks/go/serverhealth/HealthStateType.java
@@ -140,4 +140,8 @@ public class HealthStateType implements Comparable<HealthStateType> {
     public int compareTo(HealthStateType o) {
         return scope.compareTo(o.scope);
     }
+
+    public String getPipelineNames(CruiseConfig cruiseConfig) {
+        return scope.getPipelineNames(cruiseConfig);
+    }
 }

--- a/common/src/com/thoughtworks/go/serverhealth/ServerHealthState.java
+++ b/common/src/com/thoughtworks/go/serverhealth/ServerHealthState.java
@@ -16,6 +16,7 @@
 
 package com.thoughtworks.go.serverhealth;
 
+import com.thoughtworks.go.config.CruiseConfig;
 import com.thoughtworks.go.util.Clock;
 import com.thoughtworks.go.util.SystemTimeClock;
 import com.thoughtworks.go.utils.Timeout;
@@ -213,5 +214,9 @@ public class ServerHealthState {
 
     public boolean hasExpired() {
         return expiryTime != null && expiryTime.isBefore(clock.currentDateTime());
+    }
+
+    public String getPipelineNames(CruiseConfig config) {
+        return type.getPipelineNames(config);
     }
 }

--- a/common/test/unit/com/thoughtworks/go/serverhealth/ServerHealthServiceTest.java
+++ b/common/test/unit/com/thoughtworks/go/serverhealth/ServerHealthServiceTest.java
@@ -18,10 +18,12 @@ package com.thoughtworks.go.serverhealth;
 
 import com.thoughtworks.go.config.*;
 import com.thoughtworks.go.config.materials.MaterialConfigs;
+import com.thoughtworks.go.config.materials.mercurial.HgMaterial;
 import com.thoughtworks.go.config.materials.svn.SvnMaterialConfig;
 import com.thoughtworks.go.helper.GoConfigMother;
 import com.thoughtworks.go.helper.MaterialConfigsMother;
 import com.thoughtworks.go.helper.MaterialsMother;
+import com.thoughtworks.go.helper.PipelineConfigMother;
 import com.thoughtworks.go.util.SystemTimeClock;
 import com.thoughtworks.go.util.TestingClock;
 import com.thoughtworks.go.utils.Timeout;
@@ -30,17 +32,16 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import static com.thoughtworks.go.serverhealth.HealthStateScope.GLOBAL;
-import static com.thoughtworks.go.serverhealth.HealthStateScope.forGroup;
-import static com.thoughtworks.go.serverhealth.HealthStateScope.forMaterial;
-import static com.thoughtworks.go.serverhealth.HealthStateScope.forMaterialConfig;
-import static com.thoughtworks.go.serverhealth.HealthStateScope.forPipeline;
+import java.util.Arrays;
+
+import static com.thoughtworks.go.serverhealth.HealthStateScope.*;
 import static com.thoughtworks.go.serverhealth.ServerHealthMatcher.doesNotContainState;
 import static com.thoughtworks.go.serverhealth.ServerHealthState.warning;
 import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNull.nullValue;
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertThat;
 
 public class ServerHealthServiceTest {
@@ -166,5 +167,93 @@ public class ServerHealthServiceTest {
         serverHealthService.removeByScope(scope);
         assertThat(serverHealthService.getAllLogs().size(), is(1));
         assertThat(serverHealthService, ServerHealthMatcher.containsState(globalId));
+    }
+
+    @Test
+    public void stateRelatedPipelineNames() {
+        HgMaterial hgMaterial = MaterialsMother.hgMaterial();
+        CruiseConfig config = new BasicCruiseConfig();
+        config.addPipeline("group", PipelineConfigMother.pipelineConfig(PIPELINE_NAME, new MaterialConfigs(hgMaterial.config())));
+        config.addPipeline("group", PipelineConfigMother.pipelineConfig("pipeline2", new MaterialConfigs(hgMaterial.config())));
+        config.addPipeline("group", PipelineConfigMother.pipelineConfig("pipeline3"));
+
+        serverHealthService = new ServerHealthService();
+        serverHealthService.update(ServerHealthState.error("message", "description", HealthStateType.general(forPipeline(PIPELINE_NAME))));
+        assertThat((serverHealthService.getAllLogs().get(0)).getPipelineNames(config), is(PIPELINE_NAME));
+
+        serverHealthService = new ServerHealthService();
+        serverHealthService.update(ServerHealthState.error("message", "description", HealthStateType.general(forStage(PIPELINE_NAME, "stage1"))));
+        assertThat((serverHealthService.getAllLogs().get(0)).getPipelineNames(config), is(PIPELINE_NAME));
+
+
+        serverHealthService = new ServerHealthService();
+        serverHealthService.update(ServerHealthState.error("message", "description", HealthStateType.general(forJob(PIPELINE_NAME, "stage1", "job1"))));
+        assertThat((serverHealthService.getAllLogs().get(0)).getPipelineNames(config), is(PIPELINE_NAME));
+    }
+
+    @Test
+    public void globalStateRelatedPipelineNames() {
+        HgMaterial hgMaterial = MaterialsMother.hgMaterial();
+        CruiseConfig config = new BasicCruiseConfig();
+        config.addPipeline("group", PipelineConfigMother.pipelineConfig(PIPELINE_NAME, new MaterialConfigs(hgMaterial.config())));
+        config.addPipeline("group", PipelineConfigMother.pipelineConfig("pipeline2", new MaterialConfigs(hgMaterial.config())));
+        config.addPipeline("group", PipelineConfigMother.pipelineConfig("pipeline3"));
+
+        serverHealthService.update(ServerHealthState.error("message", "description", HealthStateType.invalidConfig()));
+        assertThat((serverHealthService.getAllLogs().get(0)).getPipelineNames(config), is(""));
+
+    }
+
+    @Test
+    public void noPipelineMatchMaterialStateRelatedPipelineNames() {
+        HgMaterial hgMaterial = MaterialsMother.hgMaterial();
+        CruiseConfig config = new BasicCruiseConfig();
+        config.addPipeline("group", PipelineConfigMother.pipelineConfig(PIPELINE_NAME, new MaterialConfigs(hgMaterial.config())));
+        config.addPipeline("group", PipelineConfigMother.pipelineConfig("pipeline2", new MaterialConfigs(hgMaterial.config())));
+        config.addPipeline("group", PipelineConfigMother.pipelineConfig("pipeline3"));
+
+        serverHealthService.update(ServerHealthState.error("message", "description", HealthStateType.general(forMaterial(MaterialsMother.p4Material()))));
+        assertThat((serverHealthService.getAllLogs().get(0)).getPipelineNames(config), is(""));
+    }
+
+    @Test
+    public void materialStateRelatedPipelineNames() {
+        HgMaterial hgMaterial = MaterialsMother.hgMaterial();
+        CruiseConfig config = new BasicCruiseConfig();
+        config.addPipeline("group", PipelineConfigMother.pipelineConfig(PIPELINE_NAME, new MaterialConfigs(hgMaterial.config())));
+        config.addPipeline("group", PipelineConfigMother.pipelineConfig("pipeline2", new MaterialConfigs(hgMaterial.config())));
+        config.addPipeline("group", PipelineConfigMother.pipelineConfig("pipeline3"));
+
+        serverHealthService.update(ServerHealthState.error("message", "description", HealthStateType.general(forMaterial(hgMaterial))));
+        String[] pipelines = (serverHealthService.getAllLogs().get(0)).getPipelineNames(config).split(",");
+        Arrays.sort(pipelines);
+        assertArrayEquals("pipeline,pipeline2".split(","), pipelines);
+    }
+
+    @Test
+    public void materialUpdateStateRelatedPipelineNames() {
+        HgMaterial hgMaterial = MaterialsMother.hgMaterial();
+        CruiseConfig config = new BasicCruiseConfig();
+        config.addPipeline("group", PipelineConfigMother.pipelineConfig(PIPELINE_NAME, new MaterialConfigs(hgMaterial.config())));
+        config.addPipeline("group", PipelineConfigMother.pipelineConfig("pipeline2", new MaterialConfigs(hgMaterial.config())));
+        config.addPipeline("group", PipelineConfigMother.pipelineConfig("pipeline3"));
+
+        serverHealthService.update(ServerHealthState.error("message", "description", HealthStateType.general(forMaterialUpdate(hgMaterial))));
+        String[] pipelines = (serverHealthService.getAllLogs().get(0)).getPipelineNames(config).split(",");
+        Arrays.sort(pipelines);
+        assertArrayEquals("pipeline,pipeline2".split(","), pipelines);
+    }
+
+    @Test
+    public void faninErrorStateRelatedPipelineNames() {
+        HgMaterial hgMaterial = MaterialsMother.hgMaterial();
+        CruiseConfig config = new BasicCruiseConfig();
+        config.addPipeline("group", PipelineConfigMother.pipelineConfig(PIPELINE_NAME, new MaterialConfigs(hgMaterial.config())));
+        config.addPipeline("group", PipelineConfigMother.pipelineConfig("pipeline2", new MaterialConfigs(hgMaterial.config())));
+        config.addPipeline("group", PipelineConfigMother.pipelineConfig("pipeline3"));
+
+        serverHealthService.update(ServerHealthState.error("message", "description", HealthStateType.general(HealthStateScope.forFanin("pipeline2"))));
+        String pipelines = (serverHealthService.getAllLogs().get(0)).getPipelineNames(config);
+        assertThat(pipelines, is("pipeline2"));
     }
 }

--- a/server/webapp/WEB-INF/rails.new/app/assets/javascripts/pipeline_errors.js
+++ b/server/webapp/WEB-INF/rails.new/app/assets/javascripts/pipeline_errors.js
@@ -1,0 +1,67 @@
+/*************************GO-LICENSE-START*********************************
+ * Copyright 2014 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *************************GO-LICENSE-END**********************************/
+
+PipelineErrors = function ($) {
+    var refreshPipelineErrors = function() {
+        var pipelinesHaveError = [];
+        $("#cruise_message_body [data-pipelines]").each(function (i, ele) {
+            if ($(ele).data("pipelines")) {
+                var pipelines = $(ele).data("pipelines").split(",");
+                $.each(pipelines, function(i, name) {
+                   if (pipelinesHaveError.indexOf(name) == -1) {
+                       pipelinesHaveError.push(name);
+                   }
+                });
+            }
+        });
+
+        $(".pipeline").each(function (i, pipeline) {
+            var name = $(pipeline).find(".pipeline_name_link a").text();
+            if (pipelinesHaveError.include(name)) {
+                if ($(pipeline).find(".pipeline-error").length == 0) {
+                    var icon = $('<i class="pipeline-error"></i>');
+                    icon.data("pipeline", name);
+                    $(pipeline).find(".pipeline_operations").prepend(icon);
+                }
+            } else {
+                $(pipeline).find(".pipeline-error").remove();
+            }
+        });
+    };
+    var showPipelineErrors = function(errorIcon) {
+        var pipelineName = $(errorIcon).data("pipeline");
+        var errors = $('<div class="cruise_message_body"/>');
+        $('#cruise_message_body .error').each(function(i, ele) {
+            var pipelines = $(ele).data("pipelines").split(",");
+            if (pipelines.include(pipelineName)) {
+                errors.append($(ele).clone());
+            }
+        });
+        Modalbox.show(errors[0], { title: pipelineName + ' error and warning messages', overlayClose: false });
+    };
+    var initialize = function() {
+        $(document).bind("dashboard-refresh-completed", refreshPipelineErrors);
+        refreshPipelineErrors();
+        $(document).on("click", ".pipeline-error", function(e) {
+            showPipelineErrors(e.target);
+        });
+    };
+
+    return {
+        initialize: initialize,
+        showPipelineErrors: showPipelineErrors
+    };
+}(jQuery);

--- a/server/webapp/WEB-INF/rails.new/app/assets/stylesheets/views/pipelines.scss
+++ b/server/webapp/WEB-INF/rails.new/app/assets/stylesheets/views/pipelines.scss
@@ -46,6 +46,17 @@
 **/
 
 
+.pipeline-error {
+  background: image_url('g9/icons/icon_error_16.png') no-repeat;
+  width: 16px;
+  height: 16px;
+  display: inline-block;
+  float: right;
+  margin-top: 2px;
+  margin-right: 4px;
+  cursor: pointer;
+}
+
 /**
  * =MATERIAL_SEARCH
 **/

--- a/server/webapp/WEB-INF/rails.new/app/assets/stylesheets/views/shared.scss
+++ b/server/webapp/WEB-INF/rails.new/app/assets/stylesheets/views/shared.scss
@@ -124,44 +124,44 @@
 /**
  * ==ERROR_MESSAGING_COUNTER
 **/
-#cruise_message_body{
+.cruise_message_body{
   max-height: 400px;
   padding: 10px;
   overflow: auto;
 }
-*+html #cruise_message_body{
+*+html .cruise_message_body{
   height: expression(this.scrollHeight >  400 ? "400px" : "auto");
   overflow: auto;
 }
-#cruise_message_body .error {
+.cruise_message_body .error {
   margin-bottom: 10px;
   border-bottom: 1px dotted #CCC;
   padding-bottom: 10px;
 }
-#cruise_message_body .warning {
+.cruise_message_body .warning {
   margin-bottom: 10px;
   border-bottom: 1px dotted #CCC;
   padding-bottom: 10px;
 }
-#cruise_message_body .message {
+.cruise_message_body .message {
   font-weight: bold;
    font-size: 12px;
 }
-#cruise_message_body .error .description {
+.cruise_message_body .error .description {
   border-left: 5px solid #f7d4d4;
   padding-left: 10px;
   font-size: 11px;
   margin-top: 5px;
   color: #555;
 }
-#cruise_message_body .warning .description {
+.cruise_message_body .warning .description {
   border-left: 5px solid #FFF0C0;
   padding-left: 10px;
   font-size: 11px;
   margin-top: 5px;
   color: #555;
 }
-#cruise_message_body .messages {
+.cruise_message_body .messages {
   overflow: scroll;
 }
 

--- a/server/webapp/WEB-INF/rails.new/app/assets/stylesheets/vm/structure_for_old_ui.scss
+++ b/server/webapp/WEB-INF/rails.new/app/assets/stylesheets/vm/structure_for_old_ui.scss
@@ -574,33 +574,33 @@ a.xlink_as_button {
     padding:6px 10px 6px 30px;
 }
 
-#cruise_message_body{
+.cruise_message_body{
     max-height: 400px;
     padding: 10px;
     overflow: auto;
 }
 
-*+html #cruise_message_body{
+*+html .cruise_message_body{
     height: expression(this.scrollHeight >  400 ? "400px" : "auto");
     overflow: auto;
 }
-#cruise_message_body .error {
+.cruise_message_body .error {
   margin-bottom: 10px;
   border-bottom: 1px dotted #CCC;
   padding-bottom: 10px;
 }
-#cruise_message_body .message {
+.cruise_message_body .message {
     font-weight: bold;
     font-size: 12px;
 
 }
 
-#cruise_message_body .warning {
+.cruise_message_body .warning {
     margin-bottom: 10px;
     border-bottom: 1px dotted #CCC;
     padding-bottom: 10px;
 }
-#cruise_message_body .warning .description {
+.cruise_message_body .warning .description {
     border-left: 5px solid #FFF0C0;
     padding-left: 10px;
     margin-top: 5px;
@@ -609,14 +609,14 @@ a.xlink_as_button {
 }
 
 
-#cruise_message_body .error .description {
+.cruise_message_body .error .description {
     border-left: 5px solid #f7d4d4;
     padding-left: 10px;
     margin-top: 5px;
     font-size: 11px;
     color: #555;
 }
-#cruise_message_body .messages {
+.cruise_message_body .messages {
     overflow: scroll;
 }
 

--- a/server/webapp/WEB-INF/rails.new/app/views/pipelines/index.html.erb
+++ b/server/webapp/WEB-INF/rails.new/app/views/pipelines/index.html.erb
@@ -53,5 +53,6 @@
         jQuery('.dashboard_build_cause_button').live('click', function(event) {
             popupShower.toggle_popup(event, this);
         });
+        PipelineErrors.initialize();
     });
 </script>

--- a/server/webapp/WEB-INF/rails.new/app/views/server/_messages_body.html.erb
+++ b/server/webapp/WEB-INF/rails.new/app/views/server/_messages_body.html.erb
@@ -1,7 +1,9 @@
-<% if !@current_server_health_states.isRealSuccess() %>
+<% if !@current_server_health_states.isRealSuccess()
+        cruise_config = go_config_service.getCurrentConfig()
+%>
         <% @current_server_health_states.each do |state_in_messages_body| %>
             <% if !state_in_messages_body.isRealSuccess() %>
-                <div class="<%=state_in_messages_body.getLogLevel().name().downcase%>">
+                <div class="<%=state_in_messages_body.getLogLevel().name().downcase%>" data-pipelines="<%= state_in_messages_body.getPipelineNames(cruise_config) %>">
                     <div class="message"><%==state_in_messages_body.getMessageWithTimestamp()%></div>
                     <div class="description"><%==state_in_messages_body.getDescription()%></div>
                 </div>

--- a/server/webapp/WEB-INF/rails.new/app/views/shared/_error_messaging_counter.html.erb
+++ b/server/webapp/WEB-INF/rails.new/app/views/shared/_error_messaging_counter.html.erb
@@ -2,7 +2,7 @@
   <div id="cruise_message_counts" class="cruise_messages">
       <%= render :partial => "server/counts.html" -%>
   </div>
-  <div id="cruise_message_body" style="display:none;">
+  <div id="cruise_message_body" style="display:none;" class="cruise_message_body">
       <%= render :partial => "server/messages_body.html" -%>
   </div>
 

--- a/server/webapp/WEB-INF/rails.new/spec/javascripts/add_new_package_definition_state_spec.js
+++ b/server/webapp/WEB-INF/rails.new/spec/javascripts/add_new_package_definition_state_spec.js
@@ -16,6 +16,7 @@
 
 describe("add_new_package_definition_state", function () {
     var originalPackageMaterialDefinition = PackageMaterialDefinition;
+    var originalMailbox = Modalbox;
     beforeEach(function () {
         setFixtures("<input id=\"repo_containter\" value=\"value\"/>\n" +
             "<div id=\"packageConfigContainer\"></div>\n" +
@@ -26,6 +27,7 @@ describe("add_new_package_definition_state", function () {
 
     afterEach(function(){
         PackageMaterialDefinition = originalPackageMaterialDefinition;
+        Modalbox = originalMailbox;
     });
 
     it("test_should_setup_MBFocusable_on_elements_inserted_via_ajax", function () {

--- a/server/webapp/WEB-INF/rails.new/spec/javascripts/pipeline_errors_spec.js
+++ b/server/webapp/WEB-INF/rails.new/spec/javascripts/pipeline_errors_spec.js
@@ -1,0 +1,58 @@
+/*************************GO-LICENSE-START*********************************
+ * Copyright 2016 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *************************GO-LICENSE-END**********************************/
+describe("pipeline_errors", function () {
+    beforeEach(function () {
+        setFixtures("<div id='pipeline_pipeline1_panel' class='pipeline'>\n" +
+            "  <div class='pipeline_header'>\n" +
+            "    <div class='pipeline_name_link'>\n" +
+            "      <a href='/go/tab/pipeline/history/pipeline1'>pipeline1</a>\n" +
+            "    </div>\n" +
+            "  </div>\n" +
+            "  <div class='pipeline_operations'></div>\n" +
+            "</div>\n" +
+            "<div id='cruise_message_body' class='cruise_message_body'>\n" +
+            "  <div class='error' data-pipelines=''>\n" +
+            "    <div class='message'>global msg</div>\n" +
+            "    <div class='description'>global desc</div>\n" +
+            "  </div>\n" +
+            "  <div class='error' data-pipelines='pipeline1'>\n" +
+            "    <div class='message'>pipeline1 msg</div>\n" +
+            "    <div class='description'>pipeline1 desc</div>\n" +
+            "  </div>\n" +
+            "</div>");
+    });
+
+    beforeEach(function () {
+        PipelineErrors.initialize();
+    });
+
+    afterEach(function () {
+        if (Modalbox.initialized) {
+            Modalbox.hide();
+        }
+    });
+
+
+    it("should show error icon in pipeline panel", function () {
+        assertEquals(1, jQuery("#pipeline_pipeline1_panel .pipeline_operations .pipeline-error").length);
+    });
+
+    it("should show errors related to pipeline when click error icon in pipeline panel", function () {
+        PipelineErrors.showPipelineErrors(jQuery("#pipeline_pipeline1_panel .pipeline_operations .pipeline-error"));
+        assertEquals(1, jQuery("#MB_content .cruise_message_body .error").length);
+        assertEquals("pipeline1 msg", jQuery("#MB_content .cruise_message_body .error .message").text());
+    });
+});

--- a/server/webapp/WEB-INF/vm/shared/_header.vm
+++ b/server/webapp/WEB-INF/vm/shared/_header.vm
@@ -128,7 +128,7 @@
                         </li>
                     </ul>
                     <div id="cruise_message_counts" class="cruise_messages"></div>
-                    <div id="cruise_message_body" style="display:none;"></div>
+                    <div id="cruise_message_body" style="display:none;" class="cruise_message_body"></div>
                 </div>
             #end
             </div>


### PR DESCRIPTION
* Show an error icon for pipelines that have errors/warnings related like the following screenshot:

![pipelines_-_go](https://cloud.githubusercontent.com/assets/17474/12527465/a2355fe0-c130-11e5-9683-963b86c33254.jpg)

* When user click the icon, we'll show all errors/warnings related to the pipeline in a modal dialog, which is same with current all errors modal dialog behavior. 
* Existing showing all errors at right bottom corner is not changed.
* Only show pipeline related errors icon on dashboard, no other places added yet.  I think it is enough to show errors on dashboard, because showing errors everywhere won't really help. However, if we'd like it show up somewhere else (e.g. pipeline details page), it should be easy to just add it. 




see #1595 for more details