### PR TITLE
Change and rejig some dependencies —

### DIFF
--- a/agent-bootstrapper/pom.xml
+++ b/agent-bootstrapper/pom.xml
@@ -42,12 +42,6 @@
         </dependency>
 
         <dependency>
-            <groupId>com.thoughtworks.go</groupId>
-            <artifactId>agent-launcher</artifactId>
-            <version>${project.parent.version}</version>
-        </dependency>
-
-        <dependency>
             <groupId>com.apple</groupId>
             <artifactId>AppleJavaExtensions</artifactId>
             <version>1.4</version>

--- a/agent/pom.xml
+++ b/agent/pom.xml
@@ -65,6 +65,12 @@
             <version>${jetty.version}</version>
         </dependency>
 
+        <dependency>
+            <groupId>commons-configuration</groupId>
+            <artifactId>commons-configuration</artifactId>
+            <version>1.10</version>
+        </dependency>
+
         <!-- test dependencies -->
         <dependency>
             <groupId>com.thoughtworks.go</groupId>

--- a/agent/src/com/thoughtworks/go/agent/AgentAutoRegistrationPropertiesImpl.java
+++ b/agent/src/com/thoughtworks/go/agent/AgentAutoRegistrationPropertiesImpl.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright 2016 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.agent;
+
+import com.thoughtworks.go.config.AgentAutoRegistrationProperties;
+import org.apache.commons.configuration.ConfigurationException;
+import org.apache.commons.configuration.PropertiesConfiguration;
+import org.apache.commons.configuration.PropertiesConfigurationLayout;
+import org.apache.commons.io.FileUtils;
+import org.apache.log4j.Logger;
+
+import java.io.*;
+import java.util.Properties;
+
+import static org.apache.commons.lang.StringUtils.isBlank;
+
+public class AgentAutoRegistrationPropertiesImpl implements AgentAutoRegistrationProperties {
+    private static final Logger LOG = Logger.getLogger(AgentAutoRegistrationPropertiesImpl.class);
+
+    public static final String AGENT_AUTO_REGISTER_KEY = "agent.auto.register.key";
+    public static final String AGENT_AUTO_REGISTER_RESOURCES = "agent.auto.register.resources";
+    public static final String AGENT_AUTO_REGISTER_ENVIRONMENTS = "agent.auto.register.environments";
+    public static final String AGENT_AUTO_REGISTER_HOSTNAME = "agent.auto.register.hostname";
+    public static final String AGENT_AUTO_REGISTER_ELASTIC_PLUGIN_ID = "agent.auto.register.elasticAgent.pluginId";
+    public static final String AGENT_AUTO_REGISTER_ELASTIC_AGENT_ID = "agent.auto.register.elasticAgent.agentId";
+
+    private final File configFile;
+    private final Properties properties;
+
+    public AgentAutoRegistrationPropertiesImpl(File config) {
+        this(config, new Properties());
+    }
+
+    public AgentAutoRegistrationPropertiesImpl(File config, Properties properties) {
+        this.configFile = config;
+        this.properties = properties;
+    }
+
+    private boolean exist() {
+        return configFile.exists();
+    }
+
+    public boolean isElastic() {
+        return exist() && !isBlank(agentAutoRegisterElasticPluginId());
+    }
+
+    @Override
+    public String agentAutoRegisterKey() {
+        return getProperty(AGENT_AUTO_REGISTER_KEY, "");
+    }
+
+    @Override
+    public String agentAutoRegisterResources() {
+        return getProperty(AGENT_AUTO_REGISTER_RESOURCES, "");
+    }
+
+    @Override
+    public String agentAutoRegisterEnvironments() {
+        return getProperty(AGENT_AUTO_REGISTER_ENVIRONMENTS, "");
+    }
+
+    @Override
+    public String agentAutoRegisterElasticPluginId() {
+        return getProperty(AGENT_AUTO_REGISTER_ELASTIC_PLUGIN_ID, "");
+    }
+
+    @Override
+    public String agentAutoRegisterElasticAgentId() {
+        return getProperty(AGENT_AUTO_REGISTER_ELASTIC_AGENT_ID, "");
+    }
+
+    @Override
+    public String agentAutoRegisterHostname() {
+        return getProperty(AGENT_AUTO_REGISTER_HOSTNAME, "");
+    }
+
+    @Override
+    public void scrubRegistrationProperties() {
+        if (!exist()) {
+            return;
+        }
+        try {
+            PropertiesConfiguration config = new PropertiesConfiguration();
+            config.setIOFactory(new FilteringOutputWriterFactory());
+            PropertiesConfigurationLayout layout = new PropertiesConfigurationLayout(config);
+            layout.setLineSeparator("\n");
+            layout.load(reader());
+            try (FileWriter out = new FileWriter(this.configFile)) {
+                layout.save(out);
+            }
+            loadProperties();
+        } catch (ConfigurationException | IOException e) {
+            LOG.warn("[Agent Auto Registration] Unable to scrub registration key.", e);
+        }
+    }
+
+    private String getProperty(String property, String defaultValue) {
+        return properties().getProperty(property, defaultValue);
+    }
+
+    private Properties properties() {
+        if (this.properties.isEmpty()) {
+            loadProperties();
+        }
+        return this.properties;
+    }
+
+    private void loadProperties() {
+        try {
+            this.properties.clear();
+            this.properties.load(reader());
+        } catch (IOException e) {
+            LOG.debug("[Agent Auto Registration] Unable to load agent auto register properties file. This agent will not auto-register.", e);
+        }
+    }
+
+    private StringReader reader() throws IOException {
+        return new StringReader(FileUtils.readFileToString(configFile));
+    }
+
+    private class FilteringOutputWriterFactory extends PropertiesConfiguration.DefaultIOFactory {
+        class FilteringPropertiesWriter extends PropertiesConfiguration.PropertiesWriter {
+            public FilteringPropertiesWriter(Writer out, char delimiter) {
+                super(out, delimiter);
+            }
+
+            @Override
+            public void writeProperty(String key, Object value, boolean forceSingleLine) throws IOException {
+                if (key.equals(AGENT_AUTO_REGISTER_KEY)) {
+                    scrubWithMessage("The autoregister key has been intentionally removed by Go as a security measure.");
+                }
+
+                if (key.equals(AGENT_AUTO_REGISTER_RESOURCES) || key.equals(AGENT_AUTO_REGISTER_ENVIRONMENTS) || key.equals(AGENT_AUTO_REGISTER_HOSTNAME)) {
+                    scrubWithMessage("This property has been removed by Go after attempting to auto-register with the Go server.");
+                }
+                super.writeProperty(key, value, forceSingleLine);
+            }
+
+            private void scrubWithMessage(String message) throws IOException {
+                write("# ");
+                writeln(message);
+                write("# ");
+            }
+        }
+
+        @Override
+        public PropertiesConfiguration.PropertiesWriter createPropertiesWriter(Writer out, char delimiter) {
+            return new FilteringPropertiesWriter(out, delimiter);
+        }
+    }
+}

--- a/agent/src/com/thoughtworks/go/agent/AgentController.java
+++ b/agent/src/com/thoughtworks/go/agent/AgentController.java
@@ -75,7 +75,7 @@ public class AgentController {
     private SCMExtension scmExtension;
     private TaskExtension taskExtension;
     private AgentWebsocketService websocketService;
-    private final AgentAutoRegistrationProperties agentAutoRegistrationProperties;
+    private final AgentAutoRegistrationPropertiesImpl agentAutoRegistrationProperties;
 
     @Autowired
     public AgentController(BuildRepositoryRemote server, GoArtifactsManipulator manipulator, SslInfrastructureService sslInfrastructureService, AgentRegistry agentRegistry,
@@ -96,7 +96,7 @@ public class AgentController {
         this.subprocessLogger = subprocessLogger;
         this.systemEnvironment = systemEnvironment;
         PluginManagerReference.reference().setPluginManager(pluginManager);
-        this.agentAutoRegistrationProperties = new AgentAutoRegistrationProperties(new File("config", "autoregister.properties"));
+        this.agentAutoRegistrationProperties = new AgentAutoRegistrationPropertiesImpl(new File("config", "autoregister.properties"));
     }
 
     void init() throws IOException {
@@ -105,7 +105,7 @@ public class AgentController {
         sslInfrastructureService.createSslInfrastructure();
         AgentIdentifier identifier = agentIdentifier();
         if (agentAutoRegistrationProperties.isElastic()) {
-            agentRuntimeInfo = ElasticAgentRuntimeInfo.fromAgent(identifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), systemEnvironment.getAgentLauncherVersion(), agentAutoRegistrationProperties.getAgentAutoRegisterElasticAgentId(), agentAutoRegistrationProperties.getAgentAutoRegisterElasticPluginId());
+            agentRuntimeInfo = ElasticAgentRuntimeInfo.fromAgent(identifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), systemEnvironment.getAgentLauncherVersion(), agentAutoRegistrationProperties.agentAutoRegisterElasticAgentId(), agentAutoRegistrationProperties.agentAutoRegisterElasticPluginId());
         } else {
             agentRuntimeInfo = AgentRuntimeInfo.fromAgent(identifier, AgentStatus.Idle.getRuntimeStatus(), currentWorkingDirectory(), systemEnvironment.getAgentLauncherVersion());
         }

--- a/agent/src/com/thoughtworks/go/agent/service/SslInfrastructureService.java
+++ b/agent/src/com/thoughtworks/go/agent/service/SslInfrastructureService.java
@@ -187,8 +187,8 @@ public class SslInfrastructureService {
             postMethod.addParameter("agentAutoRegisterResources", agentAutoRegisterProperties.agentAutoRegisterResources());
             postMethod.addParameter("agentAutoRegisterEnvironments", agentAutoRegisterProperties.agentAutoRegisterEnvironments());
             postMethod.addParameter("agentAutoRegisterHostname", agentAutoRegisterProperties.agentAutoRegisterHostname());
-            postMethod.addParameter("elasticAgentId", agentAutoRegisterProperties.getAgentAutoRegisterElasticAgentId());
-            postMethod.addParameter("elasticPluginId", agentAutoRegisterProperties.getAgentAutoRegisterElasticPluginId());
+            postMethod.addParameter("elasticAgentId", agentAutoRegisterProperties.agentAutoRegisterElasticAgentId());
+            postMethod.addParameter("elasticPluginId", agentAutoRegisterProperties.agentAutoRegisterElasticPluginId());
             try {
                 httpClient.executeMethod(postMethod);
                 InputStream is = postMethod.getResponseBodyAsStream();

--- a/agent/test/functional/com/thoughtworks/go/agent/service/RemoteRegistrationRequesterTest.java
+++ b/agent/test/functional/com/thoughtworks/go/agent/service/RemoteRegistrationRequesterTest.java
@@ -16,7 +16,7 @@
 
 package com.thoughtworks.go.agent.service;
 
-import com.thoughtworks.go.config.AgentAutoRegistrationProperties;
+import com.thoughtworks.go.agent.AgentAutoRegistrationPropertiesImpl;
 import com.thoughtworks.go.config.DefaultAgentRegistry;
 import com.thoughtworks.go.security.Registration;
 import com.thoughtworks.go.util.SystemEnvironment;
@@ -60,12 +60,12 @@ public class RemoteRegistrationRequesterTest {
         HttpClient httpClient = Mockito.mock(HttpClient.class);
         final DefaultAgentRegistry defaultAgentRegistry = new DefaultAgentRegistry();
         Properties properties = new Properties();
-        properties.put(AgentAutoRegistrationProperties.AGENT_AUTO_REGISTER_KEY, "t0ps3cret");
-        properties.put(AgentAutoRegistrationProperties.AGENT_AUTO_REGISTER_RESOURCES, "linux, java");
-        properties.put(AgentAutoRegistrationProperties.AGENT_AUTO_REGISTER_ENVIRONMENTS, "uat, staging");
-        properties.put(AgentAutoRegistrationProperties.AGENT_AUTO_REGISTER_HOSTNAME, "agent01.example.com");
+        properties.put(AgentAutoRegistrationPropertiesImpl.AGENT_AUTO_REGISTER_KEY, "t0ps3cret");
+        properties.put(AgentAutoRegistrationPropertiesImpl.AGENT_AUTO_REGISTER_RESOURCES, "linux, java");
+        properties.put(AgentAutoRegistrationPropertiesImpl.AGENT_AUTO_REGISTER_ENVIRONMENTS, "uat, staging");
+        properties.put(AgentAutoRegistrationPropertiesImpl.AGENT_AUTO_REGISTER_HOSTNAME, "agent01.example.com");
 
-        remoteRegistryRequester(url, httpClient, defaultAgentRegistry).requestRegistration("cruise.com", new AgentAutoRegistrationProperties(null, properties));
+        remoteRegistryRequester(url, httpClient, defaultAgentRegistry).requestRegistration("cruise.com", new AgentAutoRegistrationPropertiesImpl(null, properties));
         verify(httpClient).executeMethod(argThat(hasAllParams(defaultAgentRegistry.uuid(), "", "")));
     }
 
@@ -76,14 +76,14 @@ public class RemoteRegistrationRequesterTest {
         HttpClient httpClient = Mockito.mock(HttpClient.class);
         final DefaultAgentRegistry defaultAgentRegistry = new DefaultAgentRegistry();
         Properties properties = new Properties();
-        properties.put(AgentAutoRegistrationProperties.AGENT_AUTO_REGISTER_KEY, "t0ps3cret");
-        properties.put(AgentAutoRegistrationProperties.AGENT_AUTO_REGISTER_RESOURCES, "linux, java");
-        properties.put(AgentAutoRegistrationProperties.AGENT_AUTO_REGISTER_ENVIRONMENTS, "uat, staging");
-        properties.put(AgentAutoRegistrationProperties.AGENT_AUTO_REGISTER_HOSTNAME, "agent01.example.com");
-        properties.put(AgentAutoRegistrationProperties.AGENT_AUTO_REGISTER_ELASTIC_AGENT_ID, "42");
-        properties.put(AgentAutoRegistrationProperties.AGENT_AUTO_REGISTER_ELASTIC_PLUGIN_ID, "tw.go.elastic-agent.docker");
+        properties.put(AgentAutoRegistrationPropertiesImpl.AGENT_AUTO_REGISTER_KEY, "t0ps3cret");
+        properties.put(AgentAutoRegistrationPropertiesImpl.AGENT_AUTO_REGISTER_RESOURCES, "linux, java");
+        properties.put(AgentAutoRegistrationPropertiesImpl.AGENT_AUTO_REGISTER_ENVIRONMENTS, "uat, staging");
+        properties.put(AgentAutoRegistrationPropertiesImpl.AGENT_AUTO_REGISTER_HOSTNAME, "agent01.example.com");
+        properties.put(AgentAutoRegistrationPropertiesImpl.AGENT_AUTO_REGISTER_ELASTIC_AGENT_ID, "42");
+        properties.put(AgentAutoRegistrationPropertiesImpl.AGENT_AUTO_REGISTER_ELASTIC_PLUGIN_ID, "tw.go.elastic-agent.docker");
 
-        remoteRegistryRequester(url, httpClient, defaultAgentRegistry).requestRegistration("cruise.com", new AgentAutoRegistrationProperties(null, properties));
+        remoteRegistryRequester(url, httpClient, defaultAgentRegistry).requestRegistration("cruise.com", new AgentAutoRegistrationPropertiesImpl(null, properties));
         verify(httpClient).executeMethod(argThat(hasAllParams(defaultAgentRegistry.uuid(), "42", "tw.go.elastic-agent.docker")));
     }
 

--- a/agent/test/functional/com/thoughtworks/go/agent/service/SslInfrastructureServiceTest.java
+++ b/agent/test/functional/com/thoughtworks/go/agent/service/SslInfrastructureServiceTest.java
@@ -16,9 +16,7 @@
 
 package com.thoughtworks.go.agent.service;
 
-import java.io.File;
-import java.io.IOException;
-
+import com.thoughtworks.go.agent.AgentAutoRegistrationPropertiesImpl;
 import com.thoughtworks.go.agent.testhelpers.AgentCertificateMother;
 import com.thoughtworks.go.config.AgentAutoRegistrationProperties;
 import com.thoughtworks.go.config.AgentRegistry;
@@ -40,6 +38,9 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
+
+import java.io.File;
+import java.io.IOException;
 
 import static com.thoughtworks.go.util.TestUtils.exists;
 import static org.hamcrest.core.Is.is;
@@ -81,15 +82,15 @@ public class SslInfrastructureServiceTest {
 
         shouldCreateSslInfrastucture();
 
-        sslInfrastructureService.registerIfNecessary(new AgentAutoRegistrationProperties(configFile));
+        sslInfrastructureService.registerIfNecessary(new AgentAutoRegistrationPropertiesImpl(configFile));
         assertThat(SslInfrastructureService.AGENT_CERTIFICATE_FILE, exists());
         assertRemoteCalled();
 
-        sslInfrastructureService.registerIfNecessary(new AgentAutoRegistrationProperties(configFile));
+        sslInfrastructureService.registerIfNecessary(new AgentAutoRegistrationPropertiesImpl(configFile));
         assertRemoteNotCalled();
 
         sslInfrastructureService.invalidateAgentCertificate();
-        sslInfrastructureService.registerIfNecessary(new AgentAutoRegistrationProperties(configFile));
+        sslInfrastructureService.registerIfNecessary(new AgentAutoRegistrationPropertiesImpl(configFile));
         assertRemoteCalled();
     }
 

--- a/agent/test/unit/com/thoughtworks/go/agent/AgentAutoRegistrationPropertiesImplTest.java
+++ b/agent/test/unit/com/thoughtworks/go/agent/AgentAutoRegistrationPropertiesImplTest.java
@@ -14,8 +14,9 @@
  * limitations under the License.
  */
 
-package com.thoughtworks.go.config;
+package com.thoughtworks.go.agent;
 
+import com.thoughtworks.go.config.AgentAutoRegistrationProperties;
 import org.apache.commons.io.FileUtils;
 import org.junit.Before;
 import org.junit.Rule;
@@ -30,7 +31,7 @@ import java.util.Properties;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
 
-public class AgentAutoRegistrationPropertiesTest {
+public class AgentAutoRegistrationPropertiesImplTest {
 
     @Rule
     public TemporaryFolder folder = new TemporaryFolder();
@@ -45,13 +46,13 @@ public class AgentAutoRegistrationPropertiesTest {
     public void shouldReturnAgentAutoRegisterPropertiesIfPresent() throws Exception {
         Properties properties = new Properties();
 
-        properties.put(AgentAutoRegistrationProperties.AGENT_AUTO_REGISTER_KEY, "foo");
-        properties.put(AgentAutoRegistrationProperties.AGENT_AUTO_REGISTER_RESOURCES, "foo, zoo");
-        properties.put(AgentAutoRegistrationProperties.AGENT_AUTO_REGISTER_ENVIRONMENTS, "foo, bar");
-        properties.put(AgentAutoRegistrationProperties.AGENT_AUTO_REGISTER_HOSTNAME, "agent01.example.com");
+        properties.put(AgentAutoRegistrationPropertiesImpl.AGENT_AUTO_REGISTER_KEY, "foo");
+        properties.put(AgentAutoRegistrationPropertiesImpl.AGENT_AUTO_REGISTER_RESOURCES, "foo, zoo");
+        properties.put(AgentAutoRegistrationPropertiesImpl.AGENT_AUTO_REGISTER_ENVIRONMENTS, "foo, bar");
+        properties.put(AgentAutoRegistrationPropertiesImpl.AGENT_AUTO_REGISTER_HOSTNAME, "agent01.example.com");
         properties.store(new FileOutputStream(configFile), "");
 
-        AgentAutoRegistrationProperties reader = new AgentAutoRegistrationProperties(configFile);
+        AgentAutoRegistrationProperties reader = new AgentAutoRegistrationPropertiesImpl(configFile);
         assertThat(reader.agentAutoRegisterKey(), is("foo"));
         assertThat(reader.agentAutoRegisterResources(), is("foo, zoo"));
         assertThat(reader.agentAutoRegisterEnvironments(), is("foo, bar"));
@@ -60,7 +61,7 @@ public class AgentAutoRegistrationPropertiesTest {
 
     @Test
     public void shouldReturnEmptyStringIfPropertiesNotPresent() {
-        AgentAutoRegistrationProperties reader = new AgentAutoRegistrationProperties(configFile);
+        AgentAutoRegistrationProperties reader = new AgentAutoRegistrationPropertiesImpl(configFile);
         assertThat(reader.agentAutoRegisterKey().isEmpty(), is(true));
         assertThat(reader.agentAutoRegisterResources().isEmpty(), is(true));
         assertThat(reader.agentAutoRegisterEnvironments().isEmpty(), is(true));
@@ -87,7 +88,7 @@ public class AgentAutoRegistrationPropertiesTest {
                 "\n";
         FileUtils.write(configFile, originalContents);
 
-        AgentAutoRegistrationProperties properties = new AgentAutoRegistrationProperties(configFile);
+        AgentAutoRegistrationProperties properties = new AgentAutoRegistrationPropertiesImpl(configFile);
         properties.scrubRegistrationProperties();
 
         String newContents = "" +

--- a/base/pom.xml
+++ b/base/pom.xml
@@ -46,7 +46,7 @@
         <dependency>
             <groupId>commons-lang</groupId>
             <artifactId>commons-lang</artifactId>
-            <version>2.4</version>
+            <version>2.6</version>
         </dependency>
 
         <dependency>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -101,12 +101,6 @@
             <scope>provided</scope>
         </dependency>
 
-        <dependency>
-            <groupId>commons-configuration</groupId>
-            <artifactId>commons-configuration</artifactId>
-            <version>1.10</version>
-        </dependency>
-
         <!-- test dependencies -->
         <dependency>
             <groupId>com.thoughtworks.go</groupId>

--- a/common/src/com/thoughtworks/go/config/AgentAutoRegistrationProperties.java
+++ b/common/src/com/thoughtworks/go/config/AgentAutoRegistrationProperties.java
@@ -16,142 +16,18 @@
 
 package com.thoughtworks.go.config;
 
-import org.apache.commons.configuration.ConfigurationException;
-import org.apache.commons.configuration.PropertiesConfiguration;
-import org.apache.commons.configuration.PropertiesConfigurationLayout;
-import org.apache.commons.io.FileUtils;
-import org.apache.log4j.Logger;
+public interface AgentAutoRegistrationProperties {
+    String agentAutoRegisterKey();
 
-import java.io.*;
-import java.util.Properties;
+    String agentAutoRegisterResources();
 
-import static org.apache.commons.lang.StringUtils.isBlank;
+    String agentAutoRegisterEnvironments();
 
-public class AgentAutoRegistrationProperties {
-    private static final Logger LOG = Logger.getLogger(AgentAutoRegistrationProperties.class);
+    String agentAutoRegisterElasticPluginId();
 
-    public static final String AGENT_AUTO_REGISTER_KEY = "agent.auto.register.key";
-    public static final String AGENT_AUTO_REGISTER_RESOURCES = "agent.auto.register.resources";
-    public static final String AGENT_AUTO_REGISTER_ENVIRONMENTS = "agent.auto.register.environments";
-    public static final String AGENT_AUTO_REGISTER_HOSTNAME = "agent.auto.register.hostname";
-    public static final String AGENT_AUTO_REGISTER_ELASTIC_PLUGIN_ID = "agent.auto.register.elasticAgent.pluginId";
-    public static final String AGENT_AUTO_REGISTER_ELASTIC_AGENT_ID = "agent.auto.register.elasticAgent.agentId";
+    String agentAutoRegisterElasticAgentId();
 
-    private final File configFile;
-    private final Properties properties;
+    String agentAutoRegisterHostname();
 
-    public AgentAutoRegistrationProperties(File config) {
-        this(config, new Properties());
-    }
-
-    public AgentAutoRegistrationProperties(File config, Properties properties) {
-        this.configFile = config;
-        this.properties = properties;
-    }
-
-    public boolean exist() {
-        return configFile.exists();
-    }
-
-    public boolean isElastic() {
-        return exist() && !isBlank(getAgentAutoRegisterElasticPluginId());
-    }
-
-    public String agentAutoRegisterKey() {
-        return getProperty(AGENT_AUTO_REGISTER_KEY, "");
-    }
-
-    public String agentAutoRegisterResources() {
-        return getProperty(AGENT_AUTO_REGISTER_RESOURCES, "");
-    }
-
-    public String agentAutoRegisterEnvironments() {
-        return getProperty(AGENT_AUTO_REGISTER_ENVIRONMENTS, "");
-    }
-
-    public String getAgentAutoRegisterElasticPluginId() {
-        return getProperty(AGENT_AUTO_REGISTER_ELASTIC_PLUGIN_ID, "");
-    }
-
-    public String getAgentAutoRegisterElasticAgentId() {
-        return getProperty(AGENT_AUTO_REGISTER_ELASTIC_AGENT_ID, "");
-    }
-
-    public String agentAutoRegisterHostname() {
-        return getProperty(AGENT_AUTO_REGISTER_HOSTNAME, "");
-    }
-
-    public void scrubRegistrationProperties() {
-        if (!exist()) {
-            return;
-        }
-        try {
-            PropertiesConfiguration config = new PropertiesConfiguration();
-            config.setIOFactory(new FilteringOutputWriterFactory());
-            PropertiesConfigurationLayout layout = new PropertiesConfigurationLayout(config);
-            layout.setLineSeparator("\n");
-            layout.load(reader());
-            try (FileWriter out = new FileWriter(this.configFile)) {
-                layout.save(out);
-            }
-            loadProperties();
-        } catch (ConfigurationException | IOException e) {
-            LOG.warn("[Agent Auto Registration] Unable to scrub registration key.", e);
-        }
-    }
-
-    private String getProperty(String property, String defaultValue) {
-        return properties().getProperty(property, defaultValue);
-    }
-
-    private Properties properties() {
-        if (this.properties.isEmpty()) {
-            loadProperties();
-        }
-        return this.properties;
-    }
-
-    private void loadProperties() {
-        try {
-            this.properties.clear();
-            this.properties.load(reader());
-        } catch (IOException e) {
-            LOG.debug("[Agent Auto Registration] Unable to load agent auto register properties file. This agent will not auto-register.", e);
-        }
-    }
-
-    private StringReader reader() throws IOException {
-        return new StringReader(FileUtils.readFileToString(configFile));
-    }
-
-    private class FilteringOutputWriterFactory extends PropertiesConfiguration.DefaultIOFactory {
-        class FilteringPropertiesWriter extends PropertiesConfiguration.PropertiesWriter {
-            public FilteringPropertiesWriter(Writer out, char delimiter) {
-                super(out, delimiter);
-            }
-
-            @Override
-            public void writeProperty(String key, Object value, boolean forceSingleLine) throws IOException {
-                if (key.equals(AGENT_AUTO_REGISTER_KEY)) {
-                    scrubWithMessage("The autoregister key has been intentionally removed by Go as a security measure.");
-                }
-
-                if (key.equals(AGENT_AUTO_REGISTER_RESOURCES) || key.equals(AGENT_AUTO_REGISTER_ENVIRONMENTS) || key.equals(AGENT_AUTO_REGISTER_HOSTNAME)) {
-                    scrubWithMessage("This property has been removed by Go after attempting to auto-register with the Go server.");
-                }
-                super.writeProperty(key, value, forceSingleLine);
-            }
-
-            private void scrubWithMessage(String message) throws IOException {
-                write("# ");
-                writeln(message);
-                write("# ");
-            }
-        }
-
-        @Override
-        public PropertiesConfiguration.PropertiesWriter createPropertiesWriter(Writer out, char delimiter) {
-            return new FilteringPropertiesWriter(out, delimiter);
-        }
-    }
+    void scrubRegistrationProperties();
 }

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright 2015 ThoughtWorks, Inc.
+  ~ Copyright 2016 ThoughtWorks, Inc.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -647,6 +647,7 @@
             <groupId>org.eclipse.jetty.websocket</groupId>
             <artifactId>websocket-server</artifactId>
             <version>${jetty.version}</version>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
* move commons-configuration dependency from common module into the
  agent module because it's only ever needed on the agent, not on the
  server
* extract out an interface to break apart the
 `AgentAutoRegistrationProperties` dependency on commons-configuration
* upgrade `commons-lang` from 2.4 to 2.6 because commons-configuration
  needs it
* server module's websocket dependency should be `provides` because it's
  expected to be provided by the top level `go.jar` aka container