### PR TITLE
improvement of JSON serialization for agent and server websocket communication

### DIFF
--- a/common/src/com/thoughtworks/go/websocket/JsonMessage.java
+++ b/common/src/com/thoughtworks/go/websocket/JsonMessage.java
@@ -22,6 +22,8 @@ import com.thoughtworks.go.domain.JobPlan;
 import com.thoughtworks.go.domain.MaterialInstance;
 import com.thoughtworks.go.domain.builder.Builder;
 import com.thoughtworks.go.domain.materials.Material;
+import com.thoughtworks.go.domain.materials.Modification;
+import com.thoughtworks.go.domain.materials.Modifications;
 
 import java.lang.reflect.Modifier;
 import java.lang.reflect.Type;
@@ -37,6 +39,7 @@ public class JsonMessage {
                 .registerTypeAdapter(Message.class, new MessageConverter())
                 .registerTypeAdapter(FetchHandler.class, new ObjectConverter())
                 .registerTypeAdapter(MaterialInstance.class, new ObjectConverter())
+                .registerTypeAdapter(Modifications.class, new ModificationsConverter())
                 .excludeFieldsWithModifiers(Modifier.TRANSIENT, Modifier.STATIC);
         gson = builder.create();
     }
@@ -57,6 +60,20 @@ public class JsonMessage {
             obj.addProperty("action", src.getAction().toString());
             obj.add("data", JsonMessage.serialize(src.getData()));
             return obj;
+        }
+    }
+
+    private static class ModificationsConverter implements JsonSerializer<Modifications>, JsonDeserializer<Modifications> {
+        @Override
+        public Modifications deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
+            Modifications obj = new Modifications();
+            obj.add((Modification) JsonMessage.deserialize(json));
+            return obj;
+        }
+
+        @Override
+        public JsonElement serialize(Modifications src, Type typeOfSrc, JsonSerializationContext context) {
+            return JsonMessage.serialize(src.get(0));
         }
     }
 

--- a/common/test/unit/com/thoughtworks/go/websocket/JsonMessageTest.java
+++ b/common/test/unit/com/thoughtworks/go/websocket/JsonMessageTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2016 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.websocket;
+
+import com.thoughtworks.go.domain.MaterialRevision;
+import com.thoughtworks.go.domain.MaterialRevisions;
+import com.thoughtworks.go.domain.materials.Modification;
+import com.thoughtworks.go.domain.materials.ModifiedAction;
+import com.thoughtworks.go.helper.ModificationsMother;
+import org.junit.Test;
+
+import java.util.Date;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+public class JsonMessageTest {
+    @Test
+    public void encodeDecodeMaterialRevisions() {
+        MaterialRevisions revisions = ModificationsMother.createHgMaterialRevisions();
+        Modification latestModification = new Modification("user2", "comment2", "email2", new Date(), "122cf27f16eadc362733328dd481d8a2c29915e1");
+        latestModification.createModifiedFile("file", "folder", ModifiedAction.added);
+
+        revisions.getRevisions().get(0).getModifications().add(0, latestModification);
+        String encode = JsonMessage.encode(new Message(Action.ping, revisions));
+        Message decode = JsonMessage.decode(encode);
+        MaterialRevisions data = (MaterialRevisions) decode.getData();
+        MaterialRevision revision = data.getRevisions().get(0);
+        assertThat(revision.getRevision(), is(revisions.getRevisions().get(0).getRevision()));
+        assertThat(revision.getModifications().size(), is(1));
+    }
+}


### PR DESCRIPTION
Only serialize latest modification that is used by agent.
We'll consider current JSON serialization as version 1. 
No more specialized serialization (improvement) will be added.
Will work on version 2 serialization to build a better & simpler JSON message for agent and server communication.