### PR TITLE
Allow adding some metadata for jobs that should be run via elastic agent plugins (#1082)

### DIFF
--- a/base/src/com/thoughtworks/go/util/GoConstants.java
+++ b/base/src/com/thoughtworks/go/util/GoConstants.java
@@ -58,7 +58,7 @@ public class GoConstants {
 
     public static final String PRODUCT_NAME = "go";
 
-    public static final int CONFIG_SCHEMA_VERSION = 78;
+    public static final int CONFIG_SCHEMA_VERSION = 79;
 
     public static final String APPROVAL_SUCCESS = "success";
     public static final String APPROVAL_MANUAL = "manual";

--- a/config/config-api/src/com/thoughtworks/go/config/JobAgentConfig.java
+++ b/config/config-api/src/com/thoughtworks/go/config/JobAgentConfig.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2016 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.config;
+
+import com.thoughtworks.go.domain.ConfigErrors;
+import com.thoughtworks.go.domain.config.Configuration;
+import com.thoughtworks.go.domain.config.ConfigurationProperty;
+import com.thoughtworks.go.util.StringUtil;
+
+import static java.lang.String.format;
+
+@ConfigTag("agentConfig")
+@ConfigCollection(value = ConfigurationProperty.class)
+public class JobAgentConfig extends Configuration implements Validatable {
+
+    public static final String PLUGIN_ID = "pluginId";
+    private final ConfigErrors errors = new ConfigErrors();
+
+    @ConfigAttribute(value = "pluginId", allowNull = false)
+    private String pluginId;
+
+    public JobAgentConfig() {
+
+    }
+
+    JobAgentConfig(String pluginId, ConfigurationProperty... configurationProperties) {
+        super(configurationProperties);
+        this.pluginId = pluginId;
+    }
+
+    @Override
+    public void validate(ValidationContext validationContext) {
+        super.validateUniqueness(format("agent config of job '%s::%s::%s'", validationContext.getPipeline().name(), validationContext.getStage().name(), validationContext.getJob().name()));
+        if (StringUtil.isBlank(pluginId)) {
+            addError(PLUGIN_ID,
+                    format("Agent config on job '%s::%s::%s' cannot have a blank plugin id.",
+                            validationContext.getPipeline().name(),
+                            validationContext.getStage().name(),
+                            validationContext.getJob().name())
+            );
+        }
+    }
+
+    @Override
+    public ConfigErrors errors() {
+        return errors;
+    }
+
+    @Override
+    public void addError(String fieldName, String message) {
+        errors().add(fieldName, message);
+    }
+
+    public String getPluginId() {
+        return pluginId;
+    }
+}

--- a/config/config-api/src/com/thoughtworks/go/config/JobConfig.java
+++ b/config/config-api/src/com/thoughtworks/go/config/JobConfig.java
@@ -23,15 +23,11 @@ import com.thoughtworks.go.domain.NullTask;
 import com.thoughtworks.go.domain.Task;
 import com.thoughtworks.go.service.TaskFactory;
 import com.thoughtworks.go.util.StringUtil;
-import com.thoughtworks.go.util.SystemEnvironment;
 import com.thoughtworks.go.util.XmlUtils;
 import org.apache.commons.lang.StringUtils;
 
-import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
-
-import static com.thoughtworks.go.util.ExceptionUtils.bomb;
 
 /**
  * @understands configuratin for a job
@@ -55,6 +51,8 @@ public class JobConfig implements Validatable, ParamsAttributeAware, Environment
     private ArtifactPlans artifactPlans = new ArtifactPlans();
     @ConfigSubtag
     private ArtifactPropertiesGenerators artifactPropertiesGenerators = new ArtifactPropertiesGenerators();
+    @ConfigSubtag
+    private JobAgentConfig jobAgentConfig;
 
     @ConfigAttribute(value = "runOnAllAgents", optional = true) private boolean runOnAllAgents = false;
     @ConfigAttribute(value = "runInstanceCount", optional = true, allowNull = true) private String runInstanceCount;
@@ -329,11 +327,12 @@ public class JobConfig implements Validatable, ParamsAttributeAware, Environment
     }
 
     public void validate(ValidationContext validationContext) {
-        if (StringUtil.isBlank(CaseInsensitiveString.str(name()))) {
+
+        if (StringUtil.isBlank(CaseInsensitiveString.str(jobName))) {
             errors.add(NAME, "Name is a required field");
         } else {
-            if ((CaseInsensitiveString.str(name()).length() > 255 || XmlUtils.doesNotMatchUsingXsdRegex(JOB_NAME_PATTERN_REGEX, CaseInsensitiveString.str(name())))) {
-                String message = String.format("Invalid job name '%s'. This must be alphanumeric and may contain underscores and periods. The maximum allowed length is %d characters.", name(),
+            if ((CaseInsensitiveString.str(jobName).length() > 255 || XmlUtils.doesNotMatchUsingXsdRegex(JOB_NAME_PATTERN_REGEX, CaseInsensitiveString.str(jobName)))) {
+                String message = String.format("Invalid job name '%s'. This must be alphanumeric and may contain underscores and periods. The maximum allowed length is %d characters.", jobName,
                         NameTypeValidator.MAX_LENGTH);
                 errors.add(NAME, message);
             }
@@ -371,7 +370,6 @@ public class JobConfig implements Validatable, ParamsAttributeAware, Environment
             if (StringUtils.isEmpty(resource.getName())) {
                 CaseInsensitiveString pipelineName = validationContext.getPipeline().name();
                 CaseInsensitiveString stageName = validationContext.getStage().name();
-                CaseInsensitiveString jobName = name();
                 String message = String.format("Empty resource name in job \"%s\" of stage \"%s\" of pipeline \"%s\". If a template is used, please ensure that the resource parameters are defined for this pipeline.", jobName, stageName, pipelineName);
                 errors.add(RESOURCES, message);
             }
@@ -493,5 +491,9 @@ public class JobConfig implements Validatable, ParamsAttributeAware, Environment
 
     public void injectTasksForTest(Tasks tasks) {
         this.tasks = tasks;
+    }
+
+    public JobAgentConfig getJobAgentConfig() {
+        return jobAgentConfig;
     }
 }

--- a/config/config-api/src/com/thoughtworks/go/config/PipelineConfig.java
+++ b/config/config-api/src/com/thoughtworks/go/config/PipelineConfig.java
@@ -250,6 +250,10 @@ public class PipelineConfig extends BaseCollection<StageConfig> implements Param
         return findBy(stageName);
     }
 
+    public StageConfig getStage(String stageName) {
+        return getStage(new CaseInsensitiveString(stageName));
+    }
+
     public StageConfig findBy(final CaseInsensitiveString stageName) {
         for (StageConfig stageConfig : this) {
             if (stageConfig.name().equals(stageName)) {

--- a/config/config-api/src/com/thoughtworks/go/config/StageConfig.java
+++ b/config/config-api/src/com/thoughtworks/go/config/StageConfig.java
@@ -116,6 +116,10 @@ public class StageConfig implements Validatable, ParamsAttributeAware, Environme
         return null;
     }
 
+    public JobConfig jobConfigByConfigName(String jobName) {
+        return jobConfigByConfigName(new CaseInsensitiveString(jobName));
+    }
+
     // TODO - #2491 - rename jobConfig to job
 
     public JobConfigs allBuildPlans() {
@@ -367,5 +371,4 @@ public class StageConfig implements Validatable, ParamsAttributeAware, Environme
     public boolean canBeOperatedBy(Role role) {
         return getOperateRoles().contains(new AdminRole(role));
     }
-
 }

--- a/config/config-api/test/com/thoughtworks/go/config/JobAgentConfigTest.java
+++ b/config/config-api/test/com/thoughtworks/go/config/JobAgentConfigTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2016 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.config;
+
+import com.thoughtworks.go.domain.config.ConfigurationProperty;
+import com.thoughtworks.go.domain.packagerepository.ConfigurationPropertyMother;
+import com.thoughtworks.go.helper.JobConfigMother;
+import com.thoughtworks.go.helper.PipelineConfigMother;
+import com.thoughtworks.go.helper.StageConfigMother;
+import org.junit.Test;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+
+public class JobAgentConfigTest {
+
+    @Test
+    public void shouldNotAllowNullPluginId() throws Exception {
+        JobAgentConfig config = new JobAgentConfig(null);
+
+        PipelineConfigSaveValidationContext context = PipelineConfigSaveValidationContext.forChain(true, null, PipelineConfigMother.pipelineConfig("pipeline"), StageConfigMother.manualStage("stage"), JobConfigMother.job());
+        config.validate(context);
+        assertThat(config.errors().size(), is(1));
+        assertThat(config.errors().on(JobAgentConfig.PLUGIN_ID), is("Agent config on job 'pipeline::stage::defaultJob' cannot have a blank plugin id."));
+    }
+
+    @Test
+    public void shouldValidateConfigPropertyNameUniqueness() throws Exception {
+        ConfigurationProperty prop1 = ConfigurationPropertyMother.create("USERNAME");
+        ConfigurationProperty prop2 = ConfigurationPropertyMother.create("USERNAME");
+        JobAgentConfig config = new JobAgentConfig("cd.go-contrib.elasticagent.docker", prop1, prop2);
+
+        PipelineConfigSaveValidationContext context = PipelineConfigSaveValidationContext.forChain(true, null, PipelineConfigMother.pipelineConfig("pipeline"), StageConfigMother.manualStage("stage"), JobConfigMother.job());
+        config.validate(context);
+
+        assertThat(config.errors().size(), is(0));
+
+        assertThat(prop1.errors().size(), is(1));
+        assertThat(prop2.errors().size(), is(1));
+
+        assertThat(prop1.errors().on(ConfigurationProperty.CONFIGURATION_KEY), is("Duplicate key 'USERNAME' found for agent config of job 'pipeline::stage::defaultJob'"));
+        assertThat(prop2.errors().on(ConfigurationProperty.CONFIGURATION_KEY), is("Duplicate key 'USERNAME' found for agent config of job 'pipeline::stage::defaultJob'"));
+    }
+}

--- a/config/config-server/resources/schemas/78_cruise-config.xsd
+++ b/config/config-server/resources/schemas/78_cruise-config.xsd
@@ -76,7 +76,7 @@
                     </xsd:unique>
                 </xsd:element>
             </xsd:sequence>
-            <xsd:attribute name="schemaVersion" type="xsd:int" use="required" fixed="79"/>
+            <xsd:attribute name="schemaVersion" type="xsd:int" use="required" fixed="78"/>
         </xsd:complexType>
         <xsd:unique name="uniquePipelines">
             <xsd:selector xpath="pipelines"/>
@@ -174,14 +174,15 @@
     </xsd:complexType>
     <xsd:complexType name="configurationType">
         <xsd:sequence>
-            <xsd:element name="property" minOccurs="1" maxOccurs="unbounded" type="pluginPropertyType"/>
-        </xsd:sequence>
-    </xsd:complexType>
-    <xsd:complexType name="pluginPropertyType">
-        <xsd:sequence>
-            <xsd:element type="xsd:string" name="key"/>
-            <xsd:element type="xsd:string" name="value" minOccurs="0" maxOccurs="1"/>
-            <xsd:element type="xsd:string" name="encryptedValue" minOccurs="0" maxOccurs="1"/>
+            <xsd:element name="property" minOccurs="1" maxOccurs="unbounded">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element type="xsd:string" name="key"/>
+                        <xsd:element type="xsd:string" name="value" minOccurs="0" maxOccurs="1"/>
+                        <xsd:element type="xsd:string" name="encryptedValue" minOccurs="0" maxOccurs="1"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
         </xsd:sequence>
     </xsd:complexType>
     <xsd:complexType name="securityType">
@@ -439,7 +440,7 @@
             <xsd:element ref="environmentvariables" minOccurs="0" maxOccurs="1"/>
             <xsd:element minOccurs="0" name="tasks" type="tasksType"/>
             <xsd:element minOccurs="0" name="artifacts" type="artifactsType"/>
-            <xsd:element minOccurs="0" ref="jobAgentOrResourceConfigType" />
+            <xsd:element minOccurs="0" name="resources" type="resourcesType"/>
             <xsd:element minOccurs="0" name="tabs" type="tabsType">
                 <xsd:unique name="uniqueTabsName">
                     <xsd:selector xpath="tab"/>
@@ -458,26 +459,6 @@
         <xsd:attribute name="runInstanceCount" type="xsd:positiveInteger" use="optional"/>
         <xsd:attribute name="timeout" type="xsd:double" use="optional"/>
     </xsd:complexType>
-
-    <xsd:element name="jobAgentOrResourceConfigType" abstract="true"/>
-
-    <xsd:element name="agentConfig" substitutionGroup="jobAgentOrResourceConfigType">
-        <xsd:complexType>
-            <xsd:sequence>
-                <xsd:element name="property" minOccurs="0" maxOccurs="unbounded" type="pluginPropertyType"/>
-            </xsd:sequence>
-            <xsd:attribute type="xsd:string" name="pluginId" use="required"/>
-        </xsd:complexType>
-    </xsd:element>
-
-    <xsd:element name="resources" substitutionGroup="jobAgentOrResourceConfigType">
-        <xsd:complexType>
-            <xsd:sequence>
-                <xsd:element minOccurs="0" maxOccurs="unbounded" name="resource" type="xsd:string"/>
-            </xsd:sequence>
-        </xsd:complexType>
-    </xsd:element>
-
     <xsd:complexType name="resourcesType">
         <xsd:sequence>
             <xsd:element minOccurs="0" maxOccurs="unbounded" name="resource" type="xsd:string"/>

--- a/config/config-server/resources/upgrades/79.xsl
+++ b/config/config-server/resources/upgrades/79.xsl
@@ -1,0 +1,28 @@
+<?xml version="1.0"?>
+<!--
+  ~ Copyright 2016 ThoughtWorks, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+    <xsl:template match="/cruise/@schemaVersion">
+        <xsl:attribute name="schemaVersion">79</xsl:attribute>
+    </xsl:template>
+    <!-- Copy everything -->
+    <xsl:template match="@*|node()">
+        <xsl:copy>
+            <xsl:apply-templates select="@*|node()"/>
+        </xsl:copy>
+    </xsl:template>
+</xsl:stylesheet>

--- a/server/config/cruise-config.xml
+++ b/server/config/cruise-config.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<cruise xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="cruise-config.xsd" schemaVersion="78">
+<cruise xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="cruise-config.xsd" schemaVersion="79">
   <server artifactsdir="logs" commandRepositoryLocation="default" serverId="dev-id">
     <security>
       <passwordFile path="../manual-testing/ant_hg/password.properties" />


### PR DESCRIPTION
```xml
<job>
  <agentConfig pluginId="...">
    <property>
      <key>Dockerfile</key>
      <value>Dockerfile.example</value>
    </property>
  </agentConfig>
</job>
```