### PR TITLE
Shallow cloning for git material (rebased)

### DIFF
--- a/base/src/com/thoughtworks/go/util/GoConstants.java
+++ b/base/src/com/thoughtworks/go/util/GoConstants.java
@@ -58,7 +58,7 @@ public class GoConstants {
 
     public static final String PRODUCT_NAME = "go";
 
-    public static final int CONFIG_SCHEMA_VERSION = 79;
+    public static final int CONFIG_SCHEMA_VERSION = 80;
 
     public static final String APPROVAL_SUCCESS = "success";
     public static final String APPROVAL_MANUAL = "manual";

--- a/base/src/com/thoughtworks/go/util/SystemEnvironment.java
+++ b/base/src/com/thoughtworks/go/util/SystemEnvironment.java
@@ -177,6 +177,8 @@ public class SystemEnvironment implements Serializable, ConfigDirProvider {
     public static GoSystemProperty<Boolean> AUTO_REGISTER_LOCAL_AGENT_ENABLED = new GoBooleanSystemProperty("go.auto.register.local.agent.enabled", true);
 
     public static GoSystemProperty<Long> GO_WEBSOCKET_MAX_IDLE_TIME = new GoLongSystemProperty("go.websocket.max.idle.time", 60 * 1000L);
+    public static GoSystemProperty<Boolean> GO_SERVER_SHALLOW_CLONE = new GoBooleanSystemProperty("go.server.shallowClone", true);
+    public static GoSystemProperty<Boolean> GO_SERVER_SCHEDULED_PIPELINE_LOADER_GLOBAL_MATERIAL_LOOKUP = new GoBooleanSystemProperty("go.server.scheduledPipelineLoader.globalMaterialLookup", false);
 
     private volatile static Integer agentConnectionTimeout;
     private volatile static Integer cruiseSSlPort;

--- a/common/src/com/thoughtworks/go/config/materials/AbstractMaterial.java
+++ b/common/src/com/thoughtworks/go/config/materials/AbstractMaterial.java
@@ -192,4 +192,12 @@ public abstract class AbstractMaterial extends PersistentObject implements Mater
     public boolean supportsDestinationFolder() {
         return false;
     }
+
+    @Override
+    public void updateFromConfig(MaterialConfig materialConfig) {
+        if(materialConfig instanceof PasswordAwareMaterial) {
+            PasswordAwareMaterial passwordConfig = (PasswordAwareMaterial) materialConfig;
+            ((PasswordAwareMaterial) this).setPassword(passwordConfig.getPassword());
+        }
+    }
 }

--- a/common/src/com/thoughtworks/go/config/materials/Materials.java
+++ b/common/src/com/thoughtworks/go/config/materials/Materials.java
@@ -105,14 +105,6 @@ public class Materials extends BaseCollection<Material> {
         return revisions;
     }
 
-    public void updateTo(Revision revision, File baseFolder, ProcessOutputStreamConsumer outputStreamConsumer, final SubprocessExecutionContext execCtx) {
-        cleanUp(baseFolder, outputStreamConsumer);
-
-        for (Material material : this) {
-            material.updateTo(outputStreamConsumer, revision, baseFolder, execCtx);
-        }
-    }
-
     public void cleanUp(File baseFolder, ConsoleOutputStreamConsumer consumer) {
         if (hasMaterialsWithNoDestinationFolder()) {
             return;

--- a/common/src/com/thoughtworks/go/config/materials/PackageMaterial.java
+++ b/common/src/com/thoughtworks/go/config/materials/PackageMaterial.java
@@ -117,7 +117,7 @@ public class PackageMaterial extends AbstractMaterial {
     }
 
     @Override
-    public void updateTo(ProcessOutputStreamConsumer outputStreamConsumer, Revision revision, File baseDir, SubprocessExecutionContext execCtx) {
+    public void updateTo(ProcessOutputStreamConsumer outputStreamConsumer, File baseDir, RevisionContext revisionContext, SubprocessExecutionContext execCtx) {
         //do nothing
     }
 

--- a/common/src/com/thoughtworks/go/config/materials/PluggableSCMMaterial.java
+++ b/common/src/com/thoughtworks/go/config/materials/PluggableSCMMaterial.java
@@ -155,7 +155,7 @@ public class PluggableSCMMaterial extends AbstractMaterial {
     }
 
     @Override
-    public void updateTo(ProcessOutputStreamConsumer outputStreamConsumer, Revision revision, File baseDir, SubprocessExecutionContext execCtx) {
+    public void updateTo(ProcessOutputStreamConsumer outputStreamConsumer, File baseDir, RevisionContext revisionContext, SubprocessExecutionContext execCtx) {
         // do nothing. used in tests.
     }
 

--- a/common/src/com/thoughtworks/go/config/materials/ScmMaterial.java
+++ b/common/src/com/thoughtworks/go/config/materials/ScmMaterial.java
@@ -19,11 +19,10 @@ package com.thoughtworks.go.config.materials;
 import com.thoughtworks.go.config.CaseInsensitiveString;
 import com.thoughtworks.go.config.PipelineConfig;
 import com.thoughtworks.go.domain.MaterialRevision;
-import com.thoughtworks.go.domain.materials.MatchedRevision;
-import com.thoughtworks.go.domain.materials.Modification;
-import com.thoughtworks.go.domain.materials.Modifications;
-import com.thoughtworks.go.domain.materials.Revision;
+import com.thoughtworks.go.domain.materials.*;
 import com.thoughtworks.go.util.command.EnvironmentVariableContext;
+import com.thoughtworks.go.util.command.InMemoryStreamConsumer;
+import com.thoughtworks.go.util.command.ProcessOutputStreamConsumer;
 import com.thoughtworks.go.util.command.UrlArgument;
 import org.apache.commons.lang.StringUtils;
 
@@ -85,7 +84,10 @@ public abstract class ScmMaterial extends AbstractMaterial {
         return name.matches(regex);
     }
 
-    public abstract void checkout(File baseDir, Revision revision, SubprocessExecutionContext execCtx) ;
+    public void checkout(File baseDir, Revision revision, SubprocessExecutionContext execCtx) {
+        InMemoryStreamConsumer output = ProcessOutputStreamConsumer.inMemoryConsumer();
+        this.updateTo(output, baseDir, new RevisionContext(revision), execCtx);
+    }
 
     public abstract String getUserName();
 

--- a/common/src/com/thoughtworks/go/config/materials/dependency/DependencyMaterial.java
+++ b/common/src/com/thoughtworks/go/config/materials/dependency/DependencyMaterial.java
@@ -90,7 +90,7 @@ public class DependencyMaterial extends AbstractMaterial {
 
     //Unused (legacy) methods
 
-    public void updateTo(ProcessOutputStreamConsumer outputStreamConsumer, Revision revision, File baseDir, final SubprocessExecutionContext execCtx) {
+    public void updateTo(ProcessOutputStreamConsumer outputStreamConsumer, File baseDir, RevisionContext revisionContext, final SubprocessExecutionContext execCtx) {
 
     }
 

--- a/common/src/com/thoughtworks/go/config/materials/git/GitMaterial.java
+++ b/common/src/com/thoughtworks/go/config/materials/git/GitMaterial.java
@@ -23,8 +23,8 @@ import com.thoughtworks.go.domain.MaterialInstance;
 import com.thoughtworks.go.domain.materials.*;
 import com.thoughtworks.go.domain.materials.git.GitCommand;
 import com.thoughtworks.go.domain.materials.git.GitMaterialInstance;
-import com.thoughtworks.go.server.transaction.TransactionSynchronizationManager;
 import com.thoughtworks.go.domain.materials.svn.MaterialUrl;
+import com.thoughtworks.go.server.transaction.TransactionSynchronizationManager;
 import com.thoughtworks.go.util.GoConstants;
 import com.thoughtworks.go.util.StringUtil;
 import com.thoughtworks.go.util.command.InMemoryStreamConsumer;
@@ -41,7 +41,8 @@ import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import static com.thoughtworks.go.util.ExceptionUtils.*;
+import static com.thoughtworks.go.util.ExceptionUtils.bomb;
+import static com.thoughtworks.go.util.ExceptionUtils.bombIfFailedToRunCommandLine;
 import static com.thoughtworks.go.util.FileUtil.createParentFolderIfNotExist;
 import static com.thoughtworks.go.util.FileUtil.deleteDirectoryNoisily;
 import static com.thoughtworks.go.util.command.ProcessOutputStreamConsumer.inMemoryConsumer;
@@ -52,9 +53,13 @@ import static java.lang.String.format;
  */
 public class GitMaterial extends ScmMaterial {
     private static final Logger LOG = Logger.getLogger(GitMaterial.class);
+    private static final int UNSHALLOW_TRYOUT_STEP = 100;
+    public static final int DEFAULT_SHALLOW_CLONE_DEPTH = 2;
+
 
     private UrlArgument url;
     private String branch = GitMaterialConfig.DEFAULT_BRANCH;
+    private boolean shallowClone = false;
     private String submoduleFolder;
 
     //TODO: use iBatis to set the type for us, and we can get rid of this field.
@@ -68,15 +73,14 @@ public class GitMaterial extends ScmMaterial {
         this.url = new UrlArgument(url);
     }
 
-    @Override
-    public void checkout(File baseDir, Revision revision, SubprocessExecutionContext execCtx) {
-        InMemoryStreamConsumer output = ProcessOutputStreamConsumer.inMemoryConsumer();
-        this.updateTo(output,revision,baseDir,execCtx);
+    public GitMaterial(String url, boolean shallowClone) {
+        this(url, null, null, shallowClone);
     }
+
 
     public GitMaterial(String url, String branch) {
         this(url);
-        if(branch != null) {
+        if (branch != null) {
             this.branch = branch;
         }
     }
@@ -86,8 +90,15 @@ public class GitMaterial extends ScmMaterial {
         this.folder = folder;
     }
 
+    public GitMaterial(String url, String branch, String folder, Boolean shallowClone) {
+        this(url, branch, folder);
+        if (shallowClone != null) {
+            this.shallowClone = shallowClone;
+        }
+    }
+
     public GitMaterial(GitMaterialConfig config) {
-        this(config.getUrl(), config.getBranch(), config.getFolder());
+        this(config.getUrl(), config.getBranch(), config.getFolder(), config.isShallowClone());
         this.autoUpdate = config.getAutoUpdate();
         this.filter = config.rawFilter();
         this.name = config.getName();
@@ -96,17 +107,18 @@ public class GitMaterial extends ScmMaterial {
 
     @Override
     public MaterialConfig config() {
-        return new GitMaterialConfig(url, branch, submoduleFolder, autoUpdate, filter, folder, name);
+        return new GitMaterialConfig(url, branch, submoduleFolder, autoUpdate, filter, folder, name, shallowClone);
     }
 
     public List<Modification> latestModification(File baseDir, final SubprocessExecutionContext execCtx) {
         ArrayList<Modification> mods = new ArrayList<Modification>();
-        mods.add(getGit(baseDir).latestModification());
+        mods.add(getGit(baseDir, DEFAULT_SHALLOW_CLONE_DEPTH).latestModification());
         return mods;
     }
 
     public List<Modification> modificationsSince(File baseDir, Revision revision, final SubprocessExecutionContext execCtx) {
-        GitCommand gitCommand = getGit(baseDir);
+        GitCommand gitCommand = getGit(baseDir, DEFAULT_SHALLOW_CLONE_DEPTH);
+        unshallowIfNeeded(gitCommand, ProcessOutputStreamConsumer.inMemoryConsumer(), revision, baseDir);
         return gitCommand.modificationsSince(revision);
     }
 
@@ -124,12 +136,16 @@ public class GitMaterial extends ScmMaterial {
     protected void appendAttributes(Map<String, Object> parameters) {
         parameters.put("url", url);
         parameters.put("branch", branch);
+        parameters.put("shallowClone", shallowClone);
     }
 
-    public void updateTo(ProcessOutputStreamConsumer outputStreamConsumer, Revision revision, File baseDir, final SubprocessExecutionContext execCtx) {
+    public void updateTo(ProcessOutputStreamConsumer outputStreamConsumer, File baseDir, RevisionContext revisionContext, final SubprocessExecutionContext execCtx) {
+        Revision revision = revisionContext.getLatestRevision();
         try {
             outputStreamConsumer.stdOutput(format("[%s] Start updating %s at revision %s from %s", GoConstants.PRODUCT_NAME, updatingTarget(), revision.getRevision(), url));
-            GitCommand git = git(outputStreamConsumer, workingdir(baseDir));
+            GitCommand git = git(outputStreamConsumer, workingdir(baseDir), revisionContext.numberOfModifications() + 1);
+            unshallowIfNeeded(git, outputStreamConsumer, revisionContext.getOldestRevision(), baseDir);
+
             git.fetchAndReset(outputStreamConsumer, revision);
             outputStreamConsumer.stdOutput(format("[%s] Done.\n", GoConstants.PRODUCT_NAME));
         } catch (Exception e) {
@@ -181,16 +197,16 @@ public class GitMaterial extends ScmMaterial {
         }
     }
 
-    private GitCommand getGit(File workingdir) {
+    private GitCommand getGit(File workingdir, int preferredCloneDepth) {
         InMemoryStreamConsumer output = inMemoryConsumer();
         try {
-            return git(output, workingdir);
+            return git(output, workingdir, preferredCloneDepth);
         } catch (Exception e) {
             throw bomb(e.getMessage() + " " + output.getStdError(), e);
         }
     }
 
-    private GitCommand git(ProcessOutputStreamConsumer outputStreamConsumer, final File workingFolder) throws Exception {
+    private GitCommand git(ProcessOutputStreamConsumer outputStreamConsumer, final File workingFolder, int preferredCloneDepth) throws Exception {
         if (isSubmoduleFolder()) {
             return new GitCommand(getFingerprint(), new File(workingFolder.getPath()), GitMaterialConfig.DEFAULT_BRANCH, true);
         }
@@ -207,17 +223,32 @@ public class GitMaterial extends ScmMaterial {
             TransactionSynchronizationManager txManager = new TransactionSynchronizationManager();
             if (txManager.isActualTransactionActive()) {
                 txManager.registerSynchronization(new TransactionSynchronizationAdapter() {
-                    @Override public void afterCompletion(int status) {
+                    @Override
+                    public void afterCompletion(int status) {
                         if (status != TransactionSynchronization.STATUS_COMMITTED) {
                             FileUtils.deleteQuietly(workingFolder);
                         }
                     }
                 });
             }
-            int returnValue = gitCommand.cloneFrom(outputStreamConsumer, url.forCommandline());
+            int cloneDepth = shallowClone ? preferredCloneDepth : Integer.MAX_VALUE;
+            int returnValue = gitCommand.cloneFrom(outputStreamConsumer, url.forCommandline(), cloneDepth);
             bombIfFailedToRunCommandLine(returnValue, "Failed to run git clone command");
         }
         return gitCommand;
+    }
+
+    // Unshallow local repo to include a revision operating on via two step process:
+    // First try to fetch forward 100 level with "git fetch -depth 100". If revision still missing,
+    // unshallow the whole repo with "git fetch --2147483647".
+    private void unshallowIfNeeded(GitCommand gitCommand, ProcessOutputStreamConsumer streamConsumer, Revision revision, File workingDir) {
+        if (gitCommand.isShallow() && !gitCommand.hasRevision(revision)) {
+            gitCommand.unshallow(streamConsumer, UNSHALLOW_TRYOUT_STEP);
+
+            if (gitCommand.isShallow() && !gitCommand.hasRevision(revision)) {
+                gitCommand.unshallow(streamConsumer, Integer.MAX_VALUE);
+            }
+        }
     }
 
     private boolean isSubmoduleFolder() {
@@ -234,11 +265,13 @@ public class GitMaterial extends ScmMaterial {
             LOG.trace("Current repository url of [" + workingDirectory + "]: " + currentWorkingUrl);
             LOG.trace("Target repository url: " + url);
         }
-        return !MaterialUrl.sameUrl(url.forCommandline(), currentWorkingUrl.forCommandline()) || !isBranchEqual(command);
+        return !MaterialUrl.sameUrl(url.forCommandline(), currentWorkingUrl.forCommandline())
+                || !isBranchEqual(command)
+                || (!shallowClone && command.isShallow());
     }
 
     private boolean isBranchEqual(GitCommand command) {
-        String branchName =  StringUtil.isBlank(this.branch)? GitMaterialConfig.DEFAULT_BRANCH: this.branch;
+        String branchName = StringUtil.isBlank(this.branch) ? GitMaterialConfig.DEFAULT_BRANCH : this.branch;
         return branchName.equals(command.getCurrentBranch());
     }
 
@@ -253,7 +286,7 @@ public class GitMaterial extends ScmMaterial {
         return url;
     }
 
-    public String getLongDescription(){
+    public String getLongDescription() {
         return String.format("URL: %s, Branch: %s", url.forDisplay(), branch);
     }
 
@@ -329,10 +362,15 @@ public class GitMaterial extends ScmMaterial {
         return false;
     }
 
-    @Override public String getShortRevision(String revision) {
+    public boolean isShallowClone() {
+        return shallowClone;
+    }
+
+    @Override
+    public String getShortRevision(String revision) {
         if (revision == null) return null;
-        if (revision.length()<7) return revision;
-        return revision.substring(0,7);
+        if (revision.length() < 7) return revision;
+        return revision.substring(0, 7);
     }
 
     @Override
@@ -346,6 +384,7 @@ public class GitMaterial extends ScmMaterial {
             configurationMap.put("url", url.forDisplay());
         }
         configurationMap.put("branch", branch);
+        configurationMap.put("shallow-clone", shallowClone);
         materialMap.put("git-configuration", configurationMap);
         return materialMap;
     }
@@ -354,12 +393,25 @@ public class GitMaterial extends ScmMaterial {
         return GitMaterialInstance.class;
     }
 
-    @Override public String toString() {
+    @Override
+    public String toString() {
         return "GitMaterial{" +
                 "url=" + url +
                 ", branch='" + branch + '\'' +
                 ", submoduleFolder='" + submoduleFolder + '\'' +
+                ", shallowClone=" + shallowClone +
                 '}';
     }
 
+    @Override
+    public void updateFromConfig(MaterialConfig materialConfig) {
+        super.updateFromConfig(materialConfig);
+        this.shallowClone = ((GitMaterialConfig) materialConfig).isShallowClone();
+    }
+
+    public GitMaterial withShallowClone(boolean value) {
+        GitMaterialConfig config = (GitMaterialConfig) config();
+        config.setShallowClone(value);
+        return new GitMaterial(config);
+    }
 }

--- a/common/src/com/thoughtworks/go/config/materials/mercurial/HgMaterial.java
+++ b/common/src/com/thoughtworks/go/config/materials/mercurial/HgMaterial.java
@@ -20,10 +20,7 @@ import com.thoughtworks.go.config.materials.ScmMaterial;
 import com.thoughtworks.go.config.materials.ScmMaterialConfig;
 import com.thoughtworks.go.config.materials.SubprocessExecutionContext;
 import com.thoughtworks.go.domain.MaterialInstance;
-import com.thoughtworks.go.domain.materials.MaterialConfig;
-import com.thoughtworks.go.domain.materials.Modification;
-import com.thoughtworks.go.domain.materials.Revision;
-import com.thoughtworks.go.domain.materials.ValidationBean;
+import com.thoughtworks.go.domain.materials.*;
 import com.thoughtworks.go.domain.materials.mercurial.HgCommand;
 import com.thoughtworks.go.domain.materials.mercurial.HgMaterialInstance;
 import com.thoughtworks.go.domain.materials.svn.MaterialUrl;
@@ -81,12 +78,6 @@ public class HgMaterial extends ScmMaterial {
         this.name = config.getName();
     }
 
-
-    @Override
-    public void checkout(File baseDir, Revision revision, SubprocessExecutionContext execCtx) {
-        InMemoryStreamConsumer output = ProcessOutputStreamConsumer.inMemoryConsumer();
-        this.updateTo(output,revision,baseDir,execCtx);
-    }
     @Override
     public MaterialConfig config() {
         return new HgMaterialConfig(url, autoUpdate, filter, folder, name);
@@ -129,7 +120,8 @@ public class HgMaterial extends ScmMaterial {
         return hgCommand;
     }
 
-    public void updateTo(ProcessOutputStreamConsumer outputStreamConsumer, Revision revision, File baseDir, final SubprocessExecutionContext execCtx) {
+    public void updateTo(ProcessOutputStreamConsumer outputStreamConsumer, File baseDir, RevisionContext revisionContext, final SubprocessExecutionContext execCtx) {
+        Revision revision = revisionContext.getLatestRevision();
         try {
             outputStreamConsumer.stdOutput(format("[%s] Start updating %s at revision %s from %s", GoConstants.PRODUCT_NAME, updatingTarget(), revision.getRevision(), url.forDisplay()));
             hg(workingdir(baseDir), outputStreamConsumer).updateTo(revision, outputStreamConsumer);

--- a/common/src/com/thoughtworks/go/config/materials/perforce/P4Material.java
+++ b/common/src/com/thoughtworks/go/config/materials/perforce/P4Material.java
@@ -109,11 +109,6 @@ public class P4Material extends ScmMaterial implements PasswordEncrypter, Passwo
     }
 
     @Override
-    public void checkout(File baseDir, Revision revision, SubprocessExecutionContext execCtx) {
-        InMemoryStreamConsumer output = ProcessOutputStreamConsumer.inMemoryConsumer();
-        this.updateTo(output, revision, baseDir, execCtx);
-    }
-    @Override
     public MaterialConfig config() {
         return new P4MaterialConfig(serverAndPort, userName, getPassword(), useTickets, view == null ? null : view.getValue(), goCipher, name, autoUpdate, filter, folder);
     }
@@ -155,11 +150,12 @@ public class P4Material extends ScmMaterial implements PasswordEncrypter, Passwo
         return p4;
     }
 
-    public void updateTo(ProcessOutputStreamConsumer outputConsumer, Revision revision, File baseDir, final SubprocessExecutionContext execCtx) {
+    public void updateTo(ProcessOutputStreamConsumer outputConsumer, File baseDir, RevisionContext revisionContext, final SubprocessExecutionContext execCtx) {
         boolean cleaned = cleanDirectoryIfRepoChanged(workingdir(baseDir), outputConsumer);
+        String revision = revisionContext.getLatestRevision().getRevision();
         try {
-            outputConsumer.stdOutput(format("[%s] Start updating %s at revision %s from %s", GoConstants.PRODUCT_NAME, updatingTarget(), revision.getRevision(), serverAndPort));
-            p4(baseDir, outputConsumer).sync(parseLong(revision.getRevision()), cleaned, outputConsumer);
+            outputConsumer.stdOutput(format("[%s] Start updating %s at revision %s from %s", GoConstants.PRODUCT_NAME, updatingTarget(), revision, serverAndPort));
+            p4(baseDir, outputConsumer).sync(parseLong(revision), cleaned, outputConsumer);
             outputConsumer.stdOutput(format("[%s] Done.\n", GoConstants.PRODUCT_NAME));
         } catch (Exception e) {
             bomb(e);

--- a/common/src/com/thoughtworks/go/config/materials/svn/SvnMaterial.java
+++ b/common/src/com/thoughtworks/go/config/materials/svn/SvnMaterial.java
@@ -28,7 +28,6 @@ import com.thoughtworks.go.security.GoCipher;
 import com.thoughtworks.go.util.FileUtil;
 import com.thoughtworks.go.util.GoConstants;
 import com.thoughtworks.go.util.StringUtil;
-import com.thoughtworks.go.util.command.InMemoryStreamConsumer;
 import com.thoughtworks.go.util.command.ProcessOutputStreamConsumer;
 import com.thoughtworks.go.util.command.UrlArgument;
 import org.apache.log4j.Logger;
@@ -110,12 +109,6 @@ public class SvnMaterial extends ScmMaterial implements PasswordEncrypter, Passw
         return svnLazyLoaded;
     }
 
-    @Override
-    public void checkout(File baseDir, Revision revision, SubprocessExecutionContext execCtx) {
-        InMemoryStreamConsumer output = ProcessOutputStreamConsumer.inMemoryConsumer();
-        this.updateTo(output,revision,baseDir,execCtx);
-    }
-
     public List<Modification> latestModification(File baseDir, final SubprocessExecutionContext execCtx) {
         return svn().latestModification();
     }
@@ -142,7 +135,8 @@ public class SvnMaterial extends ScmMaterial implements PasswordEncrypter, Passw
         parameters.put("checkExternals", checkExternals);
     }
 
-    public void updateTo(ProcessOutputStreamConsumer outputStreamConsumer, Revision revision, File baseDir, final SubprocessExecutionContext execCtx) {
+    public void updateTo(ProcessOutputStreamConsumer outputStreamConsumer, File baseDir, RevisionContext revisionContext, final SubprocessExecutionContext execCtx) {
+        Revision revision = revisionContext.getLatestRevision();
         File workingDir = workingdir(baseDir);
         if (LOGGER.isDebugEnabled()) {
             LOGGER.debug("Updating to revision: " + revision + " in workingdirectory " + workingDir);

--- a/common/src/com/thoughtworks/go/config/materials/tfs/TfsMaterial.java
+++ b/common/src/com/thoughtworks/go/config/materials/tfs/TfsMaterial.java
@@ -16,13 +16,6 @@
 
 package com.thoughtworks.go.config.materials.tfs;
 
-import java.io.File;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
-import javax.annotation.PostConstruct;
-
 import com.thoughtworks.go.config.PasswordEncrypter;
 import com.thoughtworks.go.config.materials.PasswordAwareMaterial;
 import com.thoughtworks.go.config.materials.ScmMaterial;
@@ -36,13 +29,19 @@ import com.thoughtworks.go.domain.materials.tfs.TfsMaterialInstance;
 import com.thoughtworks.go.security.GoCipher;
 import com.thoughtworks.go.util.GoConstants;
 import com.thoughtworks.go.util.StringUtil;
-import com.thoughtworks.go.util.command.InMemoryStreamConsumer;
 import com.thoughtworks.go.util.command.ProcessOutputStreamConsumer;
 import com.thoughtworks.go.util.command.UrlArgument;
 import org.apache.commons.lang.builder.ToStringBuilder;
 import org.apache.commons.lang.builder.ToStringStyle;
 import org.apache.log4j.Logger;
 import org.bouncycastle.crypto.InvalidCipherTextException;
+
+import javax.annotation.PostConstruct;
+import java.io.File;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
 
 import static com.thoughtworks.go.util.ExceptionUtils.bomb;
 import static java.lang.String.format;
@@ -86,13 +85,6 @@ public class TfsMaterial extends ScmMaterial implements PasswordAwareMaterial, P
     public MaterialConfig config() {
         return new TfsMaterialConfig(url, userName, domain, getPassword(), projectPath, goCipher, autoUpdate, filter, folder, name);
     }
-
-    @Override
-    public void checkout(File baseDir, Revision revision, SubprocessExecutionContext execCtx) {
-        InMemoryStreamConsumer output = ProcessOutputStreamConsumer.inMemoryConsumer();
-        this.updateTo(output,revision,baseDir,execCtx);
-    }
-
 
     public String getDomain() {
         return domain;
@@ -153,7 +145,8 @@ public class TfsMaterial extends ScmMaterial implements PasswordAwareMaterial, P
         appendCriteria(parameters);
     }
 
-    public void updateTo(ProcessOutputStreamConsumer outputStreamConsumer, Revision revision, File baseDir, final SubprocessExecutionContext execCtx) {
+    public void updateTo(ProcessOutputStreamConsumer outputStreamConsumer, File baseDir, RevisionContext revisionContext, final SubprocessExecutionContext execCtx) {
+        Revision revision = revisionContext.getLatestRevision();
         File workingDir = workingdir(baseDir);
         if (LOGGER.isDebugEnabled()) {
             LOGGER.debug("[TFS] Updating to revision: " + revision + " in workingdirectory " + workingDir);

--- a/common/src/com/thoughtworks/go/domain/MaterialRevision.java
+++ b/common/src/com/thoughtworks/go/domain/MaterialRevision.java
@@ -28,11 +28,7 @@ import java.util.TreeSet;
 import com.thoughtworks.go.config.materials.PackageMaterial;
 import com.thoughtworks.go.config.materials.SubprocessExecutionContext;
 import com.thoughtworks.go.config.materials.dependency.DependencyMaterial;
-import com.thoughtworks.go.domain.materials.Material;
-import com.thoughtworks.go.domain.materials.Modification;
-import com.thoughtworks.go.domain.materials.Modifications;
-import com.thoughtworks.go.domain.materials.NullRevision;
-import com.thoughtworks.go.domain.materials.Revision;
+import com.thoughtworks.go.domain.materials.*;
 import com.thoughtworks.go.util.command.EnvironmentVariableContext;
 import com.thoughtworks.go.util.command.ProcessOutputStreamConsumer;
 
@@ -152,7 +148,11 @@ public class MaterialRevision implements Serializable {
     }
 
     public void updateTo(File baseDir, ProcessOutputStreamConsumer consumer, final SubprocessExecutionContext execCtx) {
-        material.updateTo(consumer, getRevision(), baseDir, execCtx);
+        material.updateTo(consumer, baseDir, toRevisionContext(), execCtx);
+    }
+
+    private RevisionContext toRevisionContext() {
+        return new RevisionContext(getRevision(), getOldestRevision(), numberOfModifications());
     }
 
     public Boolean hasChangedSince(MaterialRevision original) {

--- a/common/src/com/thoughtworks/go/domain/materials/Material.java
+++ b/common/src/com/thoughtworks/go/domain/materials/Material.java
@@ -23,12 +23,11 @@ import com.thoughtworks.go.domain.MaterialInstance;
 import com.thoughtworks.go.domain.MaterialRevision;
 import com.thoughtworks.go.util.command.EnvironmentVariableContext;
 import com.thoughtworks.go.util.command.ProcessOutputStreamConsumer;
-import java.util.LinkedHashMap;
+
 import java.util.Map;
 
 import java.io.File;
 import java.io.Serializable;
-import java.util.Map;
 
 public interface Material extends Serializable {
 
@@ -45,7 +44,7 @@ public interface Material extends Serializable {
     //scm.findModificationsSince(revision)
     //scm.findRecentModifications(5)
 
-    void updateTo(ProcessOutputStreamConsumer outputStreamConsumer, Revision revision, File baseDir, final SubprocessExecutionContext execCtx);
+    void updateTo(ProcessOutputStreamConsumer outputStreamConsumer, File baseDir, RevisionContext revisionContext, final SubprocessExecutionContext execCtx);
 
     void toJson(Map jsonMap, Revision revision);
 
@@ -101,5 +100,11 @@ public interface Material extends Serializable {
 
     MaterialConfig config();
 
-    public Map<String, Object> getAttributes(boolean addSecureFields);
+    Map<String, Object> getAttributes(boolean addSecureFields);
+
+    // updateFromConfig is called during BuildWork creation upon a Material loaded from database. Material implementations
+    // should use this method fill in configure attributes that are not persisted in database, such as SVN password.
+    // Material implementations can safely assume correct MaterialConfig subtype is passed in. E.g For a SVNMaterial
+    // materialConfig will be SVNMaterialConfig
+    void updateFromConfig(MaterialConfig materialConfig);
 }

--- a/common/src/com/thoughtworks/go/domain/materials/RevisionContext.java
+++ b/common/src/com/thoughtworks/go/domain/materials/RevisionContext.java
@@ -1,0 +1,45 @@
+/*************************GO-LICENSE-START*********************************
+ * Copyright 2014 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *************************GO-LICENSE-END***********************************/
+
+package com.thoughtworks.go.domain.materials;
+
+public class RevisionContext {
+    private final Revision oldest;
+    private final int numberOfModifications;
+    private Revision latest;
+
+    public RevisionContext(Revision latest) {
+        this(latest, latest, 1);
+    }
+
+    public RevisionContext(Revision latest, Revision oldest, int numberOfModifications) {
+        this.latest = latest;
+        this.oldest = oldest;
+        this.numberOfModifications = numberOfModifications;
+    }
+
+    public Revision getLatestRevision() {
+        return latest;
+    }
+
+    public Revision getOldestRevision() {
+        return oldest;
+    }
+
+    public int numberOfModifications() {
+        return numberOfModifications;
+    }
+}

--- a/common/src/com/thoughtworks/go/domain/materials/TestingMaterial.java
+++ b/common/src/com/thoughtworks/go/domain/materials/TestingMaterial.java
@@ -16,19 +16,18 @@
 
 package com.thoughtworks.go.domain.materials;
 
+import com.thoughtworks.go.config.materials.ScmMaterial;
+import com.thoughtworks.go.config.materials.SubprocessExecutionContext;
+import com.thoughtworks.go.domain.MaterialInstance;
+import com.thoughtworks.go.util.command.ProcessOutputStreamConsumer;
+import com.thoughtworks.go.util.command.UrlArgument;
+import org.joda.time.DateTime;
+
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
-
-import com.thoughtworks.go.config.materials.ScmMaterial;
-import com.thoughtworks.go.config.materials.SubprocessExecutionContext;
-import com.thoughtworks.go.domain.MaterialInstance;
-import com.thoughtworks.go.util.command.InMemoryStreamConsumer;
-import com.thoughtworks.go.util.command.UrlArgument;
-import com.thoughtworks.go.util.command.ProcessOutputStreamConsumer;
-import org.joda.time.DateTime;
 
 public class TestingMaterial extends ScmMaterial {
     public static final Date TWO_DAYS_AGO_CHECKIN = new DateTime().minusDays(2).toDate();
@@ -47,12 +46,6 @@ public class TestingMaterial extends ScmMaterial {
     public TestingMaterial(TestingMaterialConfig config) {
         this();
         this.url = config.getUrl();
-    }
-
-    @Override
-    public void checkout(File baseDir, Revision revision, SubprocessExecutionContext execCtx) {
-        InMemoryStreamConsumer output = ProcessOutputStreamConsumer.inMemoryConsumer();
-        this.updateTo(output,revision,baseDir,execCtx);
     }
 
     public List<Modification> latestModification(File baseDir, final SubprocessExecutionContext execCtx) {
@@ -88,7 +81,7 @@ public class TestingMaterial extends ScmMaterial {
         return new TestingMaterialInstance(url, "FLYWEIGHTNAME");
     }
 
-    public void updateTo(ProcessOutputStreamConsumer outputStreamConsumer, Revision revision, File baseDir, final SubprocessExecutionContext execCtx) {
+    public void updateTo(ProcessOutputStreamConsumer outputStreamConsumer, File baseDir, RevisionContext revisionContext, final SubprocessExecutionContext execCtx) {
     }
 
     public void setUrl(String url) {

--- a/common/test/unit/com/thoughtworks/go/config/materials/git/GitMaterialShallowCloneTest.java
+++ b/common/test/unit/com/thoughtworks/go/config/materials/git/GitMaterialShallowCloneTest.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2016 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.config.materials.git;
+
+
+import com.googlecode.junit.ext.JunitExtRunner;
+import com.thoughtworks.go.domain.materials.Modification;
+import com.thoughtworks.go.domain.materials.RevisionContext;
+import com.thoughtworks.go.domain.materials.TestSubprocessExecutionContext;
+import com.thoughtworks.go.domain.materials.git.GitCommand;
+import com.thoughtworks.go.domain.materials.git.GitTestRepo;
+import com.thoughtworks.go.helper.TestRepo;
+import com.thoughtworks.go.util.TestFileUtil;
+import org.hamcrest.Matchers;
+import org.hamcrest.core.Is;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+import static com.thoughtworks.go.domain.materials.git.GitTestRepo.*;
+import static com.thoughtworks.go.util.command.ProcessOutputStreamConsumer.*;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+
+@RunWith(JunitExtRunner.class)
+
+public class GitMaterialShallowCloneTest {
+    private GitTestRepo repo;
+    private File workingDir;
+
+    @Before
+    public void setup() throws Exception {
+        repo = new GitTestRepo();
+        workingDir = TestFileUtil.createUniqueTempFolder("working");
+    }
+
+
+    @After
+    public void teardown() throws Exception {
+        TestRepo.internalTearDown();
+    }
+
+    @Test
+    public void defaultShallowFlagIsOff() throws Exception {
+        assertThat(new GitMaterial(repo.projectRepositoryUrl()).isShallowClone(), is(false));
+        assertThat(new GitMaterial(repo.projectRepositoryUrl(), null).isShallowClone(), is(false));
+        assertThat(new GitMaterial(repo.projectRepositoryUrl(), true).isShallowClone(), is(true));
+        assertThat(new GitMaterial(new GitMaterialConfig(repo.projectRepositoryUrl())).isShallowClone(), is(false));
+        assertThat(new GitMaterial(new GitMaterialConfig(repo.projectRepositoryUrl(), GitMaterialConfig.DEFAULT_BRANCH, true)).isShallowClone(), is(true));
+        assertThat(new GitMaterial(new GitMaterialConfig(repo.projectRepositoryUrl(), GitMaterialConfig.DEFAULT_BRANCH, false)).isShallowClone(), is(false));
+        TestRepo.internalTearDown();
+    }
+
+    @Test
+    public void shouldGetLatestModificationWithShallowClone() throws IOException {
+        GitMaterial material = new GitMaterial(repo.projectRepositoryUrl(), true);
+        List<Modification> mods = material.latestModification(workingDir, context());
+        assertThat(mods.size(), is(1));
+        assertThat(mods.get(0).getComment(), Matchers.is("Added 'run-till-file-exists' ant target"));
+        assertThat(localRepoFor(material).isShallow(), is(true));
+        assertThat(localRepoFor(material).hasRevision(REVISION_0), is(false));
+        assertThat(localRepoFor(material).currentRevision(), is(REVISION_4.getRevision()));
+    }
+
+    @Test
+    public void shouldGetModificationSinceANotInitiallyClonedRevision() {
+        GitMaterial material = new GitMaterial(repo.projectRepositoryUrl(), true);
+
+        List<Modification> modifications = material.modificationsSince(workingDir, REVISION_0, context());
+        assertThat(modifications.size(), is(4));
+        assertThat(modifications.get(0).getRevision(), is(REVISION_4.getRevision()));
+        assertThat(modifications.get(0).getComment(), is("Added 'run-till-file-exists' ant target"));
+        assertThat(modifications.get(1).getRevision(), is(REVISION_3.getRevision()));
+        assertThat(modifications.get(1).getComment(), is("adding build.xml"));
+        assertThat(modifications.get(2).getRevision(), is(REVISION_2.getRevision()));
+        assertThat(modifications.get(2).getComment(), is("Created second.txt from first.txt"));
+        assertThat(modifications.get(3).getRevision(), is(REVISION_1.getRevision()));
+        assertThat(modifications.get(3).getComment(), is("Added second line"));
+    }
+
+
+    @Test
+    public void shouldBeAbleToUpdateToRevisionNotFetched() {
+        GitMaterial material = new GitMaterial(repo.projectRepositoryUrl(), true);
+
+        material.updateTo(inMemoryConsumer(), workingDir, new RevisionContext(REVISION_3, REVISION_2, 2), context());
+
+        assertThat(localRepoFor(material).currentRevision(), is(REVISION_3.getRevision()));
+        assertThat(localRepoFor(material).hasRevision(REVISION_2), is(true));
+        assertThat(localRepoFor(material).hasRevision(REVISION_3), is(true));
+    }
+
+    @Test
+    public void configShouldIncludesShallowFlag() {
+        GitMaterialConfig shallowConfig = (GitMaterialConfig) new GitMaterial(repo.projectRepositoryUrl(), true).config();
+        assertThat(shallowConfig.isShallowClone(), is(true));
+        GitMaterialConfig normalConfig = (GitMaterialConfig) new GitMaterial(repo.projectRepositoryUrl(), null).config();
+        assertThat(normalConfig.isShallowClone(), is(false));
+    }
+
+    @Test
+    public void xmlAttributesShouldIncludesShallowFlag() {
+        GitMaterial material = new GitMaterial(repo.projectRepositoryUrl(), true);
+        assertThat(material.getAttributesForXml().get("shallowClone"), Is.<Object>is(true));
+    }
+    @Test
+    public void attributesShouldIncludeShallowFlag() {
+        GitMaterial material = new GitMaterial(repo.projectRepositoryUrl(), true);
+        Map gitConfig = (Map) (material.getAttributes(false).get("git-configuration"));
+        assertThat(gitConfig.get("shallow-clone"), Is.<Object>is(true));
+    }
+
+    @Test
+    public void shouldConvertExistingRepoToFullRepoWhenShallowCloneIsOff() {
+        GitMaterial material = new GitMaterial(repo.projectRepositoryUrl(), true);
+        material.latestModification(workingDir, context());
+        assertThat(localRepoFor(material).isShallow(), is(true));
+        material = new GitMaterial(repo.projectRepositoryUrl(), false);
+        material.latestModification(workingDir, context());
+        assertThat(localRepoFor(material).isShallow(), is(false));
+    }
+
+    @Test
+    public void withShallowCloneShouldGenerateANewMaterialWithOverriddenShallowConfig() {
+        GitMaterial original = new GitMaterial(repo.projectRepositoryUrl(), false);
+        assertThat(original.withShallowClone(true).isShallowClone(), is(true));
+        assertThat(original.withShallowClone(false).isShallowClone(), is(false));
+        assertThat(original.isShallowClone(), is(false));
+
+    }
+
+
+    private TestSubprocessExecutionContext context() {
+        return new TestSubprocessExecutionContext();
+    }
+
+    private GitCommand localRepoFor(GitMaterial material) {
+        return new GitCommand(material.getFingerprint(), workingDir, GitMaterialConfig.DEFAULT_BRANCH, false);
+    }
+
+
+}

--- a/common/test/unit/com/thoughtworks/go/config/materials/git/GitMaterialTest.java
+++ b/common/test/unit/com/thoughtworks/go/config/materials/git/GitMaterialTest.java
@@ -27,13 +27,16 @@ import com.thoughtworks.go.domain.materials.mercurial.StringRevision;
 import com.thoughtworks.go.helper.GitSubmoduleRepos;
 import com.thoughtworks.go.helper.MaterialsMother;
 import com.thoughtworks.go.helper.TestRepo;
+import com.thoughtworks.go.domain.materials.RevisionContext;
 import com.thoughtworks.go.junitext.EnhancedOSChecker;
-import com.thoughtworks.go.util.JsonUtils;
 import com.thoughtworks.go.util.JsonValue;
 import com.thoughtworks.go.util.TestFileUtil;
 import com.thoughtworks.go.util.command.CommandLine;
 import com.thoughtworks.go.util.command.InMemoryStreamConsumer;
 import com.thoughtworks.go.util.command.ProcessOutputStreamConsumer;
+import static com.thoughtworks.go.domain.materials.git.GitTestRepo.*;
+
+import java.io.*;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import org.apache.commons.io.FileUtils;
@@ -46,10 +49,6 @@ import org.junit.Test;
 import org.junit.rules.TestName;
 import org.junit.runner.RunWith;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.RandomAccessFile;
 import java.nio.channels.FileLock;
 import java.util.*;
 
@@ -82,11 +81,6 @@ public class GitMaterialTest {
     private static final String GIT_VERSION_1_5_4_3 = "git version 1.5.4.3";
     private static final String GIT_VERSION_1_6_0_2_ON_WINDOWS = "git version 1.6.0.2.1172.ga5ed0";
     private static final String GIT_VERSION_NODE_ON_WINDOWS = "git version ga5ed0asdasd.ga5ed0";
-    private static final StringRevision REVISION_0 = new StringRevision("55502a724dd8574f1e4bcf19b605a1f4f182e892");
-    private static final StringRevision REVISION_1 = new StringRevision("b613aee673d96e967100306222246aa9decbc53c");
-    private static final StringRevision REVISION_2 = new StringRevision("4ab7833f55024c975cf5b918af640954c108825e");
-    private static final StringRevision REVISION_3 = new StringRevision("ab9ff2cee965ae4d0778dbcda1fadffbbc202e85");
-    private static final StringRevision REVISION_4 = new StringRevision("5def073a425dfe239aabd4bf8039ffe3b0e8856b");
     private static final String SUBMODULE = "submodule-1";
     private GitTestRepo gitFooBranchBundle;
 
@@ -169,13 +163,13 @@ public class GitMaterialTest {
         assertThat(outputStreamConsumer.getStdError(), is(""));
 
         InMemoryStreamConsumer output = inMemoryConsumer();
-        git.updateTo(output, REVISION_1, workingDir, new TestSubprocessExecutionContext());
+        git.updateTo(output, workingDir, new RevisionContext(REVISION_1, REVISION_0, 2), new TestSubprocessExecutionContext());
         assertThat(output.getStdOut(),
                 containsString("Start updating files at revision " + REVISION_1.getRevision()));
         assertThat(newFile.exists(), is(false));
 
         output = inMemoryConsumer();
-        git.updateTo(output, REVISION_2, workingDir, new TestSubprocessExecutionContext());
+        git.updateTo(output, workingDir, new RevisionContext(REVISION_2, REVISION_1, 2), new TestSubprocessExecutionContext());
         assertThat(output.getStdOut(),
                 containsString("Start updating files at revision " + REVISION_2.getRevision()));
         assertThat(newFile.exists(), is(true));
@@ -187,13 +181,14 @@ public class GitMaterialTest {
         submoduleRepos.addSubmodule(SUBMODULE, "sub1");
         GitMaterial gitMaterial = new GitMaterial(submoduleRepos.mainRepo().getUrl());
 
-        gitMaterial.updateTo(outputStreamConsumer, new StringRevision("origin/master"), workingDir, new TestSubprocessExecutionContext());
+        StringRevision revision = new StringRevision("origin/master");
+        gitMaterial.updateTo(outputStreamConsumer, workingDir, new RevisionContext(revision), new TestSubprocessExecutionContext());
         assertThat(new File(workingDir, "sub1"), exists());
 
         submoduleRepos.removeSubmodule("sub1");
 
         outputStreamConsumer = inMemoryConsumer();
-        gitMaterial.updateTo(outputStreamConsumer, new StringRevision("origin/master"), workingDir, new TestSubprocessExecutionContext());
+        gitMaterial.updateTo(outputStreamConsumer, workingDir, new RevisionContext(revision), new TestSubprocessExecutionContext());
         assertThat(new File(workingDir, "sub1"), not(exists()));
     }
 
@@ -231,7 +226,7 @@ public class GitMaterialTest {
         FileUtils.writeStringToFile(shouldNotBeRemoved, "gundi");
         assertThat(shouldNotBeRemoved.exists(), is(true));
 
-        git = new GitMaterial("file://" + repositoryUrl);
+        git = new GitMaterial(repositoryUrl.replace("file://", ""));
         git.latestModification(workingDir, new TestSubprocessExecutionContext());
         assertThat("Should not have deleted whole folder", shouldNotBeRemoved.exists(), is(true));
     }
@@ -408,7 +403,7 @@ public class GitMaterialTest {
 
     @Test
     public void shouldLogRepoInfoToConsoleOutWithoutFolder() throws Exception {
-        git.updateTo(outputStreamConsumer, REVISION_1, workingDir, new TestSubprocessExecutionContext());
+        git.updateTo(outputStreamConsumer, workingDir, new RevisionContext(REVISION_1), new TestSubprocessExecutionContext());
         assertThat(outputStreamConsumer.getStdOut(), containsString(
                 format("Start updating %s at revision %s from %s", "files", REVISION_1.getRevision(),
                         git.getUrl())));

--- a/common/test/unit/com/thoughtworks/go/config/materials/mercurial/HgMaterialTest.java
+++ b/common/test/unit/com/thoughtworks/go/config/materials/mercurial/HgMaterialTest.java
@@ -16,15 +16,13 @@
 
 package com.thoughtworks.go.config.materials.mercurial;
 
-import com.thoughtworks.go.domain.materials.Material;
-import com.thoughtworks.go.domain.materials.Modification;
-import com.thoughtworks.go.domain.materials.TestSubprocessExecutionContext;
-import com.thoughtworks.go.domain.materials.ValidationBean;
+import com.thoughtworks.go.domain.materials.*;
 import com.thoughtworks.go.domain.materials.mercurial.HgCommand;
 import com.thoughtworks.go.domain.materials.mercurial.StringRevision;
 import com.thoughtworks.go.helper.HgTestRepo;
 import com.thoughtworks.go.helper.MaterialsMother;
 import com.thoughtworks.go.helper.TestRepo;
+import com.thoughtworks.go.domain.materials.RevisionContext;
 import com.thoughtworks.go.util.*;
 import com.thoughtworks.go.util.command.ConsoleResult;
 import com.thoughtworks.go.util.command.InMemoryStreamConsumer;
@@ -118,11 +116,15 @@ public class HgMaterialTest {
         File testFile = createNewFileInWorkingFolder();
 
         hgMaterial = MaterialsMother.hgMaterial("file://" + hgTestRepo.projectRepositoryUrl());
-        hgMaterial.updateTo(outputStreamConsumer, new StringRevision("0"), workingFolder, new TestSubprocessExecutionContext());
+        updateMaterial(hgMaterial, new StringRevision("0"));
 
         String workingUrl = new HgCommand(null, workingFolder, "default", hgTestRepo.url().forCommandline()).workingRepositoryUrl().outputAsString();
         assertThat(workingUrl, is(hgTestRepo.projectRepositoryUrl()));
         assertThat(testFile.exists(), is(true));
+    }
+
+    private void updateMaterial(HgMaterial hgMaterial, StringRevision revision) {
+        hgMaterial.updateTo(outputStreamConsumer, workingFolder, new RevisionContext(revision), new TestSubprocessExecutionContext());
     }
 
     @Test
@@ -180,26 +182,25 @@ public class HgMaterialTest {
 
     @Test
     public void shouldUpdateToSpecificRevision() throws Exception {
-        hgMaterial.updateTo(outputStreamConsumer, new StringRevision("0"), workingFolder, new TestSubprocessExecutionContext());
+        updateMaterial(hgMaterial, new StringRevision("0"));
         File end2endFolder = new File(workingFolder, "end2end");
         assertThat(end2endFolder.listFiles().length, is(3));
         assertThat(outputStreamConsumer.getStdOut(), is(not("")));
-
-        hgMaterial.updateTo(outputStreamConsumer, new StringRevision("1"), workingFolder, new TestSubprocessExecutionContext());
+        updateMaterial(hgMaterial, new StringRevision("1"));
         assertThat(end2endFolder.listFiles().length, is(4));
     }
 
     @Test
     public void shouldUpdateToDestinationFolder() throws Exception {
         hgMaterial.setFolder("dest");
-        hgMaterial.updateTo(outputStreamConsumer, new StringRevision("0"), workingFolder, new TestSubprocessExecutionContext());
+        updateMaterial(hgMaterial, new StringRevision("0"));
         File end2endFolder = new File(workingFolder, "dest/end2end");
         assertThat(end2endFolder.exists(), is(true));
     }
 
     @Test
     public void shouldLogRepoInfoToConsoleOutWithoutFolder() throws Exception {
-        hgMaterial.updateTo(outputStreamConsumer, new StringRevision("0"), workingFolder, new TestSubprocessExecutionContext());
+        updateMaterial(hgMaterial, new StringRevision("0"));
         assertThat(outputStreamConsumer.getStdOut(), containsString(
                 format("Start updating %s at revision %s from %s", "files", "0",
                         hgMaterial.getUrl())));

--- a/common/test/unit/com/thoughtworks/go/config/materials/svn/SvnMultipleMaterialsTest.java
+++ b/common/test/unit/com/thoughtworks/go/config/materials/svn/SvnMultipleMaterialsTest.java
@@ -24,11 +24,9 @@ import java.util.UUID;
 import com.thoughtworks.go.config.materials.Materials;
 import com.thoughtworks.go.domain.MaterialRevision;
 import com.thoughtworks.go.domain.MaterialRevisions;
-import com.thoughtworks.go.domain.materials.Modification;
-import com.thoughtworks.go.domain.materials.Modifications;
-import com.thoughtworks.go.domain.materials.Revision;
-import com.thoughtworks.go.domain.materials.TestSubprocessExecutionContext;
+import com.thoughtworks.go.domain.materials.*;
 import com.thoughtworks.go.helper.SvnTestRepo;
+import com.thoughtworks.go.domain.materials.RevisionContext;
 import com.thoughtworks.go.util.ArtifactLogUtil;
 import com.thoughtworks.go.util.FileUtil;
 import com.thoughtworks.go.util.TestFileUtil;
@@ -60,17 +58,16 @@ public class SvnMultipleMaterialsTest {
 
     @Test
     public void shouldNotThrowNPEIfTheWorkingDirectoryIsEmpty() throws Exception {
-
         SvnMaterial svnMaterial1 = repo.createMaterial("multiple-materials/trunk/part1", "part1");
         SvnMaterial svnMaterial2 = repo.createMaterial("multiple-materials/trunk/part2", "part2");
         Materials materials = new Materials(svnMaterial1, svnMaterial2);
 
         Revision revision = latestRevision(svnMaterial1, pipelineDir, new TestSubprocessExecutionContext());
-        materials.updateTo(revision, pipelineDir, inMemoryConsumer(), new TestSubprocessExecutionContext());
+        updateMaterials(materials, revision);
 
         FileUtil.deleteFolder(pipelineDir);
 
-        materials.updateTo(revision, pipelineDir, inMemoryConsumer(), new TestSubprocessExecutionContext());
+        updateMaterials(materials, revision);
     }
 
     @Test
@@ -82,7 +79,7 @@ public class SvnMultipleMaterialsTest {
 
         Revision revision = latestRevision(part1, pipelineDir, new TestSubprocessExecutionContext());
 
-        materials.updateTo(revision, pipelineDir, inMemoryConsumer(), new TestSubprocessExecutionContext());
+        updateMaterials(materials, revision);
 
         assertThat(new File(pipelineDir, "part1").exists(), is(true));
         assertThat(new File(pipelineDir, "part2").exists(), is(true));
@@ -91,7 +88,7 @@ public class SvnMultipleMaterialsTest {
 
         Materials changedMaterials = new Materials(part1, newFolder);
 
-        changedMaterials.updateTo(revision, pipelineDir, inMemoryConsumer(), new TestSubprocessExecutionContext());
+        updateMaterials(changedMaterials, revision);
 
         assertThat(new File(pipelineDir, "part1").exists(), is(true));
         assertThat(new File(pipelineDir, "newFolder").exists(), is(true));
@@ -106,14 +103,14 @@ public class SvnMultipleMaterialsTest {
 
         Revision revision = latestRevision(part1, pipelineDir, new TestSubprocessExecutionContext());
 
-        materials.updateTo(revision, pipelineDir, inMemoryConsumer(), new TestSubprocessExecutionContext());
+        updateMaterials(materials, revision);
 
         assertThat(new File(pipelineDir, "part1").exists(), is(true));
         assertThat(new File(pipelineDir, "part2").exists(), is(true));
 
         Materials changedMaterials = new Materials(part1);
 
-        changedMaterials.updateTo(revision, pipelineDir, inMemoryConsumer(), new TestSubprocessExecutionContext());
+        updateMaterials(changedMaterials, revision);
 
         assertThat(new File(pipelineDir, "part1").exists(), is(true));
         assertThat(new File(pipelineDir, "part2").exists(), is(false));
@@ -128,7 +125,7 @@ public class SvnMultipleMaterialsTest {
 
         Revision revision = latestRevision(svnMaterial1, pipelineDir, new TestSubprocessExecutionContext());
 
-        materials.updateTo(revision, pipelineDir, inMemoryConsumer(), new TestSubprocessExecutionContext());
+        updateMaterials(materials, revision);
 
         assertThat(new File(pipelineDir, "part1").exists(), is(true));
         assertThat(new File(pipelineDir, "part2").exists(), is(true));
@@ -140,7 +137,7 @@ public class SvnMultipleMaterialsTest {
         TestFileUtil.createTestFolder(pipelineDir, ArtifactLogUtil.CRUISE_OUTPUT_FOLDER);
         assertThat(pipelineDir.listFiles().length, is(3));
 
-        materials.updateTo(revision, pipelineDir, inMemoryConsumer(), new TestSubprocessExecutionContext());
+        updateMaterials(materials, revision);
 
         assertThat(new File(pipelineDir, "part1").exists(), is(true));
         assertThat(new File(pipelineDir, "part2").exists(), is(true));
@@ -155,13 +152,13 @@ public class SvnMultipleMaterialsTest {
         Materials materials = new Materials(part);
 
         Revision revision = latestRevision(part, pipelineDir, new TestSubprocessExecutionContext());
-        materials.updateTo(revision, pipelineDir, inMemoryConsumer(), new TestSubprocessExecutionContext());
+        updateMaterials(materials, revision);
 
         File shouldNotCleanUp = new File(pipelineDir, "shouldNotDelete");
         shouldNotCleanUp.createNewFile();
         assertThat(shouldNotCleanUp.exists(), is(true));
 
-        materials.updateTo(revision, pipelineDir, inMemoryConsumer(), new TestSubprocessExecutionContext());
+        updateMaterials(materials, revision);
         assertThat("should not clean up working dir for this pipeline if none of the materials specified a sub folder",
                 shouldNotCleanUp.exists(), is(true));
     }
@@ -175,7 +172,7 @@ public class SvnMultipleMaterialsTest {
 
         Revision revision = latestRevision(svnMaterial1, pipelineDir, new TestSubprocessExecutionContext());
 
-        materials.updateTo(revision, pipelineDir, inMemoryConsumer(), new TestSubprocessExecutionContext());
+        updateMaterials(materials, revision);
 
         assertThat(new File(pipelineDir, "root/part1").exists(), is(true));
         assertThat(new File(pipelineDir, "root/part2").exists(), is(true));
@@ -187,7 +184,7 @@ public class SvnMultipleMaterialsTest {
         TestFileUtil.createTestFolder(pipelineDir, ArtifactLogUtil.CRUISE_OUTPUT_FOLDER);
         assertThat(pipelineDir.listFiles().length, is(2));
 
-        materials.updateTo(revision, pipelineDir, inMemoryConsumer(), new TestSubprocessExecutionContext());
+        updateMaterials(materials, revision);
 
         assertThat(new File(pipelineDir, "root/part1").exists(), is(true));
         assertThat(new File(pipelineDir, "root/part2").exists(), is(true));
@@ -242,5 +239,14 @@ public class SvnMultipleMaterialsTest {
     private Revision latestRevision(SvnMaterial material, File workingDir, TestSubprocessExecutionContext execCtx) {
         List<Modification> modifications = material.latestModification(workingDir, execCtx);
         return new Modifications(modifications).latestRevision(material);
+    }
+
+    private void updateMaterials(Materials materials, Revision revision) {
+        ProcessOutputStreamConsumer outputStreamConsumer = inMemoryConsumer();
+        TestSubprocessExecutionContext execCtx = new TestSubprocessExecutionContext();
+        materials.cleanUp(pipelineDir, outputStreamConsumer);
+        for (Material material : materials) {
+            material.updateTo(outputStreamConsumer, pipelineDir, new RevisionContext(revision), execCtx);
+        }
     }
 }

--- a/common/test/unit/com/thoughtworks/go/domain/CruiseConfigTestBase.java
+++ b/common/test/unit/com/thoughtworks/go/domain/CruiseConfigTestBase.java
@@ -92,6 +92,27 @@ public abstract class CruiseConfigTestBase {
     }
 
     @Test
+    public void canFindMaterialConfigForUnderGivenPipelineWithMaterialFingerprint() {
+        MaterialConfig fullClone = new GitMaterialConfig("url", "master", false);
+        PipelineConfig one = PipelineConfigMother.pipelineConfig("one", fullClone, new JobConfigs(new JobConfig("job")));
+        cruiseConfig.addPipeline("group-1", one);
+
+        MaterialConfig shallowClone = new GitMaterialConfig("url", "master", true);
+        PipelineConfig two = PipelineConfigMother.pipelineConfig("two", shallowClone, new JobConfigs(new JobConfig("job")));
+        cruiseConfig.addPipeline("group-2", two);
+
+        MaterialConfig others = new GitMaterialConfig("bar", "master", true);
+        PipelineConfig three = PipelineConfigMother.pipelineConfig("three", others, new JobConfigs(new JobConfig("job")));
+        cruiseConfig.addPipeline("group-3", three);
+
+        String fingerprint = new GitMaterialConfig("url", "master").getFingerprint();
+
+        assertThat(((GitMaterialConfig) cruiseConfig.materialConfigFor(one.name(), fingerprint)).isShallowClone(), is(false));
+        assertThat(((GitMaterialConfig) cruiseConfig.materialConfigFor(two.name(), fingerprint)).isShallowClone(), is(true));
+        assertThat(cruiseConfig.materialConfigFor(three.name(), fingerprint), is(nullValue()));
+    }
+
+    @Test
     public void shouldFindAllAgentResources() {
         cruiseConfig.agents().add(new AgentConfig("uuid", "host1", "127.0.0.1", new Resources("from-agent")));
         assertThat(cruiseConfig.getAllResources(), hasItem(new Resource("from-agent")));

--- a/common/test/unit/com/thoughtworks/go/domain/MaterialRevisionTest.java
+++ b/common/test/unit/com/thoughtworks/go/domain/MaterialRevisionTest.java
@@ -29,16 +29,11 @@ import com.thoughtworks.go.config.materials.SubprocessExecutionContext;
 import com.thoughtworks.go.config.materials.dependency.DependencyMaterial;
 import com.thoughtworks.go.config.materials.mercurial.HgMaterial;
 import com.thoughtworks.go.config.materials.svn.SvnMaterial;
-import com.thoughtworks.go.domain.materials.Material;
-import com.thoughtworks.go.domain.materials.Modification;
-import com.thoughtworks.go.domain.materials.Modifications;
-import com.thoughtworks.go.domain.materials.Revision;
-import com.thoughtworks.go.domain.materials.TestSubprocessExecutionContext;
+import com.thoughtworks.go.domain.materials.*;
 import com.thoughtworks.go.domain.materials.dependency.DependencyMaterialRevision;
 import com.thoughtworks.go.domain.materials.mercurial.StringRevision;
 import com.thoughtworks.go.helper.*;
 import com.thoughtworks.go.helper.GoConfigMother;
-import com.thoughtworks.go.util.FileUtil;
 import com.thoughtworks.go.util.TestFileUtil;
 import com.thoughtworks.go.util.command.InMemoryStreamConsumer;
 import org.apache.commons.io.FileUtils;
@@ -392,7 +387,8 @@ public class MaterialRevisionTest {
     private void checkInFiles(HgMaterial hgMaterial, String... fileNames) throws Exception {
         final File localDir = TestFileUtil.createTempFolder("foo");
         InMemoryStreamConsumer consumer = inMemoryConsumer();
-        hgMaterial.updateTo(consumer, latestRevision(hgMaterial, workingFolder, new TestSubprocessExecutionContext()), localDir, new TestSubprocessExecutionContext());
+        Revision revision = latestRevision(hgMaterial, workingFolder, new TestSubprocessExecutionContext());
+        hgMaterial.updateTo(consumer, localDir, new RevisionContext(revision), new TestSubprocessExecutionContext());
         for (String fileName : fileNames) {
             File file = new File(localDir, fileName);
             FileUtils.writeStringToFile(file, "");

--- a/common/test/unit/com/thoughtworks/go/domain/materials/AbstractMaterialTest.java
+++ b/common/test/unit/com/thoughtworks/go/domain/materials/AbstractMaterialTest.java
@@ -23,13 +23,12 @@ import com.thoughtworks.go.domain.MaterialInstance;
 import com.thoughtworks.go.domain.MaterialRevision;
 import com.thoughtworks.go.util.command.EnvironmentVariableContext;
 import com.thoughtworks.go.util.command.ProcessOutputStreamConsumer;
-import java.util.LinkedHashMap;
+
 import java.util.Map;
 import org.junit.Test;
 
 import java.io.File;
 import java.util.List;
-import java.util.Map;
 
 import static org.hamcrest.Matchers.sameInstance;
 import static org.hamcrest.core.Is.is;
@@ -65,7 +64,7 @@ public class AbstractMaterialTest {
             throw new UnsupportedOperationException();
         }
 
-        public void updateTo(ProcessOutputStreamConsumer outputStreamConsumer, Revision revision, File baseDir, final SubprocessExecutionContext execCtx) {
+        public void updateTo(ProcessOutputStreamConsumer outputStreamConsumer, File baseDir, RevisionContext revisionContext, final SubprocessExecutionContext execCtx) {
             throw new UnsupportedOperationException();
         }
 

--- a/common/test/unit/com/thoughtworks/go/domain/materials/DummyMaterial.java
+++ b/common/test/unit/com/thoughtworks/go/domain/materials/DummyMaterial.java
@@ -78,7 +78,7 @@ public final class DummyMaterial extends ScmMaterial {
         throw new UnsupportedOperationException();
     }
 
-    public void updateTo(ProcessOutputStreamConsumer outputStreamConsumer, Revision revision, File baseDir, final SubprocessExecutionContext execCtx) {
+    public void updateTo(ProcessOutputStreamConsumer outputStreamConsumer, File baseDir, RevisionContext revisionContext, final SubprocessExecutionContext execCtx) {
         throw unsupported();
     }
 

--- a/common/test/unit/com/thoughtworks/go/domain/materials/git/GitCommandTest.java
+++ b/common/test/unit/com/thoughtworks/go/domain/materials/git/GitCommandTest.java
@@ -110,6 +110,43 @@ public class GitCommandTest {
         assertThat(output.getStdOut(), Is.is("* master"));
     }
 
+
+    @Test
+    public void fullCloneIsNotShallow() {
+        assertThat(git.isShallow(), is(false));
+    }
+
+    @Test
+    public void shouldOnlyCloneLimitedRevisionsIfDepthSpecified() throws Exception {
+        FileUtil.deleteFolder(this.gitLocalRepoDir);
+        git.cloneFrom(inMemoryConsumer(), repoUrl, 2);
+        assertThat(git.isShallow(), is(true));
+        assertThat(git.hasRevision(GitTestRepo.REVISION_4), is(true));
+        assertThat(git.hasRevision(GitTestRepo.REVISION_3), is(true));
+        // can not assert on revision_2, because on old version of git (1.7)
+        // depth '2' actually clone 3 revisions
+        assertThat(git.hasRevision(GitTestRepo.REVISION_1), is(false));
+        assertThat(git.hasRevision(GitTestRepo.REVISION_0), is(false));
+
+    }
+
+    @Test
+    public void unshallowALocalRepoWithArbitraryDepth() throws Exception {
+        FileUtil.deleteFolder(this.gitLocalRepoDir);
+        git.cloneFrom(inMemoryConsumer(), repoUrl, 2);
+        git.unshallow(inMemoryConsumer(), 3);
+        assertThat(git.isShallow(), is(true));
+        assertThat(git.hasRevision(GitTestRepo.REVISION_2), is(true));
+        // can not assert on revision_1, because on old version of git (1.7)
+        // depth '3' actually clone 4 revisions
+        assertThat(git.hasRevision(GitTestRepo.REVISION_0), is(false));
+
+        git.unshallow(inMemoryConsumer(), Integer.MAX_VALUE);
+        assertThat(git.isShallow(), is(false));
+
+        assertThat(git.hasRevision(GitTestRepo.REVISION_0), is(true));
+    }
+
     @Test
     public void shouldCloneFromBranchWhenMaterialPointsToABranch() throws IOException {
         gitLocalRepoDir = createTempWorkingDirectory();

--- a/common/test/unit/com/thoughtworks/go/domain/materials/git/GitTestRepo.java
+++ b/common/test/unit/com/thoughtworks/go/domain/materials/git/GitTestRepo.java
@@ -21,12 +21,15 @@ import com.thoughtworks.go.config.materials.git.GitMaterialConfig;
 import com.thoughtworks.go.domain.materials.Material;
 import com.thoughtworks.go.domain.materials.Modification;
 import com.thoughtworks.go.domain.materials.TestSubprocessExecutionContext;
+import com.thoughtworks.go.domain.materials.mercurial.StringRevision;
 import com.thoughtworks.go.helper.TestRepo;
+import com.thoughtworks.go.util.FileUtil;
 import com.thoughtworks.go.util.TestFileUtil;
 import com.thoughtworks.go.util.command.InMemoryStreamConsumer;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.MalformedURLException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -37,6 +40,12 @@ public class GitTestRepo extends TestRepo {
     private static final String GIT_3_REVISIONS_BUNDLE = "../common/test-resources/unit/data/git/git-3-revisions.git";
     public static final String GIT_FOO_BRANCH_BUNDLE = "../common/test-resources/unit/data/git/foo-branch.git";
     public static final String GIT_SUBMODULE_REF_BUNDLE = "../common/test-resources/unit/data/git/referenced-submodule.git";
+
+    public static final StringRevision REVISION_0 = new StringRevision("55502a724dd8574f1e4bcf19b605a1f4f182e892");
+    public static final StringRevision REVISION_1 = new StringRevision("b613aee673d96e967100306222246aa9decbc53c");
+    public static final StringRevision REVISION_2 = new StringRevision("4ab7833f55024c975cf5b918af640954c108825e");
+    public static final StringRevision REVISION_3 = new StringRevision("ab9ff2cee965ae4d0778dbcda1fadffbbc202e85");
+    public static final StringRevision REVISION_4 = new StringRevision("5def073a425dfe239aabd4bf8039ffe3b0e8856b");
     private File gitRepo;
 
     public GitTestRepo(String path) throws IOException {
@@ -67,7 +76,7 @@ public class GitTestRepo extends TestRepo {
     }
 
     public String projectRepositoryUrl() {
-        return gitRepo.getAbsolutePath();
+        return FileUtil.toFileURI(gitRepo);
     }
 
     @Override public List<Modification> checkInOneFile(String fileName, String comment) throws IOException {

--- a/common/test/unit/com/thoughtworks/go/domain/materials/svn/SvnCommandTest.java
+++ b/common/test/unit/com/thoughtworks/go/domain/materials/svn/SvnCommandTest.java
@@ -19,11 +19,9 @@ package com.thoughtworks.go.domain.materials.svn;
 import com.googlecode.junit.ext.JunitExtRunner;
 import com.googlecode.junit.ext.RunIf;
 import com.thoughtworks.go.config.materials.svn.SvnMaterial;
-import com.thoughtworks.go.domain.materials.Modification;
-import com.thoughtworks.go.domain.materials.ModifiedFile;
-import com.thoughtworks.go.domain.materials.TestSubprocessExecutionContext;
-import com.thoughtworks.go.domain.materials.ValidationBean;
+import com.thoughtworks.go.domain.materials.*;
 import com.thoughtworks.go.helper.SvnTestRepo;
+import com.thoughtworks.go.domain.materials.RevisionContext;
 import com.thoughtworks.go.junitext.EnhancedOSChecker;
 import com.thoughtworks.go.util.FileUtil;
 import com.thoughtworks.go.util.TestFileUtil;
@@ -115,7 +113,7 @@ public class SvnCommandTest {
         assertThat(output.getAllOutput(), containsString("Checked out revision 3"));
 
         InMemoryStreamConsumer output2 = new InMemoryStreamConsumer();
-        material.updateTo(output2, new SubversionRevision("4"), working, new TestSubprocessExecutionContext());
+        material.updateTo(output2, working, new RevisionContext(new SubversionRevision("4")), new TestSubprocessExecutionContext());
         assertThat(output2.getAllOutput(), containsString("Updated to revision 4"));
 
     }
@@ -131,9 +129,13 @@ public class SvnCommandTest {
         assertThat(output.getAllOutput(), containsString("Checked out revision 3"));
 
         InMemoryStreamConsumer output2 = new InMemoryStreamConsumer();
-        material.updateTo(output2, new SubversionRevision("4"), working, new TestSubprocessExecutionContext());
+        updateMaterial(material, new SubversionRevision("4"), working, output2);
         assertThat(output2.getAllOutput(), containsString("Updated to revision 4"));
 
+    }
+
+    private void updateMaterial(SvnMaterial material, SubversionRevision revision, File working, InMemoryStreamConsumer output2) {
+        material.updateTo(output2, working, new RevisionContext(revision), new TestSubprocessExecutionContext());
     }
 
 
@@ -149,7 +151,7 @@ public class SvnCommandTest {
         assertThat(output.getAllOutput(), containsString("Checked out revision 3"));
 
         InMemoryStreamConsumer output2 = new InMemoryStreamConsumer();
-        material.updateTo(output2, new SubversionRevision("4"), working, new TestSubprocessExecutionContext());
+        updateMaterial(material, new SubversionRevision("4"), working, output2);
         assertThat(output2.getAllOutput(), containsString("Updated to revision 4"));
 
     }

--- a/common/test/unit/com/thoughtworks/go/domain/materials/svn/SvnMaterialMockitoTest.java
+++ b/common/test/unit/com/thoughtworks/go/domain/materials/svn/SvnMaterialMockitoTest.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 
 import com.thoughtworks.go.config.materials.svn.SvnMaterial;
+import com.thoughtworks.go.domain.materials.RevisionContext;
 import com.thoughtworks.go.domain.materials.TestSubprocessExecutionContext;
 import com.thoughtworks.go.util.TestFileUtil;
 import com.thoughtworks.go.util.command.InMemoryStreamConsumer;
@@ -73,7 +74,7 @@ public class SvnMaterialMockitoTest {
         when(subversion.getUrl()).thenReturn(new UrlArgument(url));
         SvnMaterial svnMaterial = SvnMaterial.createSvnMaterialWithMock(subversion);
         svnMaterial.setUrl(url);
-        svnMaterial.updateTo(outputStreamConsumer, revision, workingCopy, new TestSubprocessExecutionContext());
+        svnMaterial.updateTo(outputStreamConsumer, workingCopy, new RevisionContext(revision), new TestSubprocessExecutionContext());
 
         assertThat(workingCopy.exists(), is(true));
         verify(subversion).updateTo(outputStreamConsumer, workingCopy, revision);

--- a/common/test/unit/com/thoughtworks/go/domain/materials/svn/SvnMaterialTest.java
+++ b/common/test/unit/com/thoughtworks/go/domain/materials/svn/SvnMaterialTest.java
@@ -27,12 +27,12 @@ import java.util.*;
 import com.thoughtworks.go.config.materials.svn.SvnMaterial;
 import com.thoughtworks.go.config.materials.svn.SvnMaterialConfig;
 import com.thoughtworks.go.domain.materials.Material;
+import com.thoughtworks.go.domain.materials.RevisionContext;
 import com.thoughtworks.go.domain.materials.TestSubprocessExecutionContext;
 import com.thoughtworks.go.helper.MaterialConfigsMother;
 import com.thoughtworks.go.helper.MaterialsMother;
 import com.thoughtworks.go.security.GoCipher;
 import com.thoughtworks.go.util.ClassMockery;
-import com.thoughtworks.go.util.JsonUtils;
 import com.thoughtworks.go.util.JsonValue;
 import com.thoughtworks.go.util.ReflectionUtil;
 import com.thoughtworks.go.util.TestFileUtil;
@@ -128,7 +128,7 @@ public class SvnMaterialTest {
                 one(subversion).checkoutTo(outputStreamConsumer, workingCopy, revision);
             }
         });
-        svnMaterial.updateTo(outputStreamConsumer, revision, workingCopy, new TestSubprocessExecutionContext());
+        updateMaterial(svnMaterial, revision, workingCopy);
     }
 
     @Test
@@ -140,7 +140,7 @@ public class SvnMaterialTest {
                 one(subversion).checkoutTo(outputStreamConsumer, workingCopy, revision);
             }
         });
-        svnMaterial.updateTo(outputStreamConsumer, revision, workingCopy, new TestSubprocessExecutionContext());
+        updateMaterial(svnMaterial, revision, workingCopy);
         String stdout = outputStreamConsumer.getStdOut();
         assertThat(stdout, containsString(
                 String.format("Start updating %s at revision %s from %s", "files", revision.getRevision(),
@@ -155,8 +155,12 @@ public class SvnMaterialTest {
                 one(subversion).checkoutTo(outputStreamConsumer, workingCopy, revision);
             }
         });
-        svnMaterial.updateTo(outputStreamConsumer, revision, workingCopy, new TestSubprocessExecutionContext());
+        updateMaterial(svnMaterial, revision, workingCopy);
         assertThat(workingCopy.exists(), is(false));
+    }
+
+    private void updateMaterial(SvnMaterial svnMaterial, SubversionRevision revision, File workingCopy) {
+        svnMaterial.updateTo(outputStreamConsumer, workingCopy, new RevisionContext(revision), new TestSubprocessExecutionContext());
     }
 
     @Test
@@ -169,7 +173,7 @@ public class SvnMaterialTest {
                 one(subversion).checkoutTo(outputStreamConsumer, workingCopy, revision);
             }
         });
-        svnMaterial.updateTo(outputStreamConsumer, revision, workingCopy, new TestSubprocessExecutionContext());
+        updateMaterial(svnMaterial, revision, workingCopy);
         assertThat(workingCopy.exists(), is(false));
     }
 
@@ -184,7 +188,7 @@ public class SvnMaterialTest {
                 one(subversion).updateTo(outputStreamConsumer, workingCopy, revision);
             }
         });
-        svnMaterial.updateTo(outputStreamConsumer, revision, workingCopy, new TestSubprocessExecutionContext());
+        updateMaterial(svnMaterial, revision, workingCopy);
     }
 
     @Test

--- a/common/test/unit/com/thoughtworks/go/helper/HgTestRepo.java
+++ b/common/test/unit/com/thoughtworks/go/helper/HgTestRepo.java
@@ -19,10 +19,7 @@ package com.thoughtworks.go.helper;
 import com.thoughtworks.go.config.materials.ScmMaterialConfig;
 import com.thoughtworks.go.config.materials.mercurial.HgMaterial;
 import com.thoughtworks.go.config.materials.mercurial.HgMaterialConfig;
-import com.thoughtworks.go.domain.materials.Modification;
-import com.thoughtworks.go.domain.materials.Modifications;
-import com.thoughtworks.go.domain.materials.Revision;
-import com.thoughtworks.go.domain.materials.TestSubprocessExecutionContext;
+import com.thoughtworks.go.domain.materials.*;
 import com.thoughtworks.go.domain.materials.mercurial.HgCommand;
 import com.thoughtworks.go.util.TestFileUtil;
 import com.thoughtworks.go.util.command.CommandLine;
@@ -149,7 +146,7 @@ public class HgTestRepo extends TestRepo {
     public HgMaterial updateTo(File baseDir) {
         HgMaterial material = material();
         Revision tip = latestRevision(material, baseDir, new TestSubprocessExecutionContext());
-        material.updateTo(ProcessOutputStreamConsumer.inMemoryConsumer(), tip, baseDir, new TestSubprocessExecutionContext());
+        material.updateTo(ProcessOutputStreamConsumer.inMemoryConsumer(), baseDir, new RevisionContext(tip), new TestSubprocessExecutionContext());
         return material;
     }
 

--- a/common/test/unit/com/thoughtworks/go/helper/SvnTestRepo.java
+++ b/common/test/unit/com/thoughtworks/go/helper/SvnTestRepo.java
@@ -18,10 +18,7 @@ package com.thoughtworks.go.helper;
 
 import com.thoughtworks.go.config.materials.svn.SvnMaterial;
 import com.thoughtworks.go.config.materials.svn.SvnMaterialConfig;
-import com.thoughtworks.go.domain.materials.Modification;
-import com.thoughtworks.go.domain.materials.Modifications;
-import com.thoughtworks.go.domain.materials.Revision;
-import com.thoughtworks.go.domain.materials.TestSubprocessExecutionContext;
+import com.thoughtworks.go.domain.materials.*;
 import com.thoughtworks.go.util.FileUtil;
 import com.thoughtworks.go.util.TestFileUtil;
 import com.thoughtworks.go.util.command.InMemoryStreamConsumer;
@@ -121,7 +118,8 @@ public class SvnTestRepo extends TestRepo {
         InMemoryStreamConsumer consumer = inMemoryConsumer();
 
 
-        svnMaterial.updateTo(consumer, getLatestRevision(svnMaterial), workingCopy, new TestSubprocessExecutionContext());
+        Revision latestRevision = getLatestRevision(svnMaterial);
+        svnMaterial.updateTo(consumer, workingCopy, new RevisionContext(latestRevision), new TestSubprocessExecutionContext());
 
 
         File newFileToAdd = new File(workingCopy, filename);
@@ -149,7 +147,8 @@ public class SvnTestRepo extends TestRepo {
 
         ProcessOutputStreamConsumer consumer = inMemoryConsumer();
 
-        svnMaterial.updateTo(consumer, latestRevision(svnMaterial, baseDir, new TestSubprocessExecutionContext()), baseDir, new TestSubprocessExecutionContext());
+        Revision revision = latestRevision(svnMaterial, baseDir, new TestSubprocessExecutionContext());
+        svnMaterial.updateTo(consumer, baseDir, new RevisionContext(revision), new TestSubprocessExecutionContext());
 
         File workingDir = new File(baseDir, svnMaterial.getFolder());
         File newFileToAdd = new File(workingDir, fileName);

--- a/common/test/unit/com/thoughtworks/go/server/service/MagicalMaterialAndMaterialConfigConversionTest.java
+++ b/common/test/unit/com/thoughtworks/go/server/service/MagicalMaterialAndMaterialConfigConversionTest.java
@@ -70,7 +70,7 @@ public class MagicalMaterialAndMaterialConfigConversionTest {
     private static Map<Class, String[]> fieldsWhichShouldBeIgnoredWhenSavedInDbAndGotBack = new HashMap<Class, String[]>();
     private MaterialConfigConverter materialConfigConverter = new MaterialConfigConverter();
 
-    @DataPoint public static MaterialConfig gitMaterialConfig = new GitMaterialConfig(url("git-url"), "branch", "submodule", true, filterFor("*.doc"), "folder", cis("gitMaterial"));
+    @DataPoint public static MaterialConfig gitMaterialConfig = new GitMaterialConfig(url("git-url"), "branch", "submodule", true, filterFor("*.doc"), "folder", cis("gitMaterial"), false);
     @DataPoint public static MaterialConfig hgMaterialConfig = new HgMaterialConfig(new HgUrlArgument("hg-url"), true, filterFor("*.png"), "folder", cis("hgMaterial"));
     @DataPoint public static MaterialConfig svnMaterialConfig = new SvnMaterialConfig(url("svn-url"), "user", "pass", true, new GoCipher(), true, filterFor("*.txt"), "folder", cis("name1"));
     @DataPoint public static MaterialConfig p4MaterialConfig = new P4MaterialConfig("localhost:9090", "user", "pass", true, "view", new GoCipher(), cis("p4Material"), true, filterFor("*.jpg"), "folder");

--- a/config/config-api/src/com/thoughtworks/go/config/BasicCruiseConfig.java
+++ b/config/config-api/src/com/thoughtworks/go/config/BasicCruiseConfig.java
@@ -1293,6 +1293,18 @@ public class BasicCruiseConfig implements CruiseConfig {
     }
 
     @Override
+    public MaterialConfig materialConfigFor(CaseInsensitiveString pipelineName, String fingerprint) {
+        PipelineConfig pipelineConfig = pipelineConfigByName(pipelineName);
+        MaterialConfigs materialConfigs = pipelineConfig.materialConfigs();
+        for (MaterialConfig materialConfig : materialConfigs) {
+            if(materialConfig.getFingerprint().equals(fingerprint)) {
+                return materialConfig;
+            }
+        }
+        return null;
+    }
+
+    @Override
     public String sanitizedGroupName(String name) {
         return BasicPipelineConfigs.sanitizedGroupName(name);
     }

--- a/config/config-api/src/com/thoughtworks/go/config/CruiseConfig.java
+++ b/config/config-api/src/com/thoughtworks/go/config/CruiseConfig.java
@@ -232,6 +232,8 @@ public interface CruiseConfig extends Validatable, ConfigOriginTraceable {
 
     MaterialConfig materialConfigFor(String fingerprint);
 
+    MaterialConfig materialConfigFor(CaseInsensitiveString pipelineName, String fingerprint);
+
     String sanitizedGroupName(String name);
 
     void removePackageRepository(String id);
@@ -251,4 +253,6 @@ public interface CruiseConfig extends Validatable, ConfigOriginTraceable {
     boolean canDeletePackageRepository(PackageRepository repository);
 
     boolean canDeletePluggableSCMMaterial(SCM scmConfig);
+
+
 }

--- a/config/config-api/src/com/thoughtworks/go/config/materials/git/GitMaterialConfig.java
+++ b/config/config-api/src/com/thoughtworks/go/config/materials/git/GitMaterialConfig.java
@@ -16,8 +16,6 @@
 
 package com.thoughtworks.go.config.materials.git;
 
-import java.util.Map;
-
 import com.thoughtworks.go.config.CaseInsensitiveString;
 import com.thoughtworks.go.config.ConfigAttribute;
 import com.thoughtworks.go.config.ConfigTag;
@@ -28,20 +26,29 @@ import com.thoughtworks.go.domain.ConfigErrors;
 import com.thoughtworks.go.util.StringUtil;
 import com.thoughtworks.go.util.command.UrlArgument;
 
+import java.util.Map;
+
 @ConfigTag("git")
 public class GitMaterialConfig extends ScmMaterialConfig {
+
     @ConfigAttribute(value = "url")
     private UrlArgument url;
 
     @ConfigAttribute(value = "branch")
     private String branch = DEFAULT_BRANCH;
 
+    @ConfigAttribute(value = "shallowClone")
+    private boolean shallowClone;
+
     private String submoduleFolder;
+
+
 
     public static final String TYPE = "GitMaterial";
     public static final String URL = "url";
     public static final String BRANCH = "branch";
     public static final String DEFAULT_BRANCH = "master";
+    public static final String SHALLOW_CLONE = "shallowClone";
 
     public GitMaterialConfig() {
         super(TYPE);
@@ -59,13 +66,20 @@ public class GitMaterialConfig extends ScmMaterialConfig {
         }
     }
 
-    public GitMaterialConfig(UrlArgument url, String branch, String submoduleFolder, boolean autoUpdate, Filter filter, String folder, CaseInsensitiveString name) {
+    public GitMaterialConfig(String url, String branch, Boolean shallowClone) {
+        this(url, branch);
+        setShallowClone(shallowClone);
+    }
+
+
+    public GitMaterialConfig(UrlArgument url, String branch, String submoduleFolder, boolean autoUpdate, Filter filter, String folder, CaseInsensitiveString name, Boolean shallowClone) {
         super(name, filter, folder, autoUpdate, TYPE, new ConfigErrors());
         this.url = url;
         if(branch != null) {
             this.branch = branch;
         }
         this.submoduleFolder = submoduleFolder;
+        this.shallowClone = shallowClone;
     }
 
     @Override
@@ -78,6 +92,7 @@ public class GitMaterialConfig extends ScmMaterialConfig {
     protected void appendAttributes(Map<String, Object> parameters) {
         parameters.put("url", url);
         parameters.put("branch", branch);
+        parameters.put("shallowClone", shallowClone);
     }
 
     @Override
@@ -204,6 +219,7 @@ public class GitMaterialConfig extends ScmMaterialConfig {
                 "url=" + url +
                 ", branch='" + branch + '\'' +
                 ", submoduleFolder='" + submoduleFolder + '\'' +
+                ", shallowClone=" + shallowClone +
                 '}';
     }
 
@@ -220,6 +236,18 @@ public class GitMaterialConfig extends ScmMaterialConfig {
         }
         if (map.containsKey(URL)) {
             this.url = new UrlArgument((String) map.get(URL));
+        }
+
+        this.shallowClone = "true".equals(map.get(SHALLOW_CLONE));
+    }
+
+    public boolean isShallowClone() {
+        return shallowClone;
+    }
+
+    public void setShallowClone(Boolean shallowClone) {
+        if (shallowClone != null) {
+            this.shallowClone = shallowClone;
         }
     }
 }

--- a/config/config-api/test/com/thoughtworks/go/config/materials/git/GitMaterialConfigTest.java
+++ b/config/config-api/test/com/thoughtworks/go/config/materials/git/GitMaterialConfigTest.java
@@ -41,6 +41,7 @@ public class GitMaterialConfigTest {
         Map<String, String> map = new HashMap<String, String>();
         map.put(GitMaterialConfig.URL, "url");
         map.put(GitMaterialConfig.BRANCH, "some-branch");
+        map.put(GitMaterialConfig.SHALLOW_CLONE, "true");
         map.put(ScmMaterialConfig.FOLDER, "folder");
         map.put(ScmMaterialConfig.AUTO_UPDATE, null);
         map.put(ScmMaterialConfig.FILTER, "/root,/**/*.help");
@@ -53,7 +54,17 @@ public class GitMaterialConfigTest {
         assertThat(gitMaterialConfig.getBranch(), is("some-branch"));
         assertThat(gitMaterialConfig.getName(), is(new CaseInsensitiveString("material-name")));
         assertThat(gitMaterialConfig.isAutoUpdate(), is(false));
+        assertThat(gitMaterialConfig.isShallowClone(), is(true));
         assertThat(gitMaterialConfig.filter(), is(new Filter(new IgnoredFiles("/root"), new IgnoredFiles("/**/*.help"))));
+    }
+
+
+    @Test
+    public void byDefaultShallowCloneShouldBeOff() {
+        assertThat(new GitMaterialConfig("http://url", "foo").isShallowClone(), is(false));
+        assertThat(new GitMaterialConfig("http://url", "foo", false).isShallowClone(), is(false));
+        assertThat(new GitMaterialConfig("http://url", "foo", null).isShallowClone(), is(false));
+        assertThat(new GitMaterialConfig("http://url", "foo", true).isShallowClone(), is(true));
     }
 
     @Test
@@ -114,7 +125,7 @@ public class GitMaterialConfigTest {
     @Test
     public void shouldHandleNullBranchAtTheTimeOfMaterialConfigCreation() {
         GitMaterialConfig config1 = new GitMaterialConfig("http://url", null);
-        GitMaterialConfig config2 = new GitMaterialConfig(new UrlArgument("http://url"), null, "sub1", true, new Filter(), "folder", new CaseInsensitiveString("git"));
+        GitMaterialConfig config2 = new GitMaterialConfig(new UrlArgument("http://url"), null, "sub1", true, new Filter(), "folder", new CaseInsensitiveString("git"), false);
 
         assertThat(config1.getBranch(), is("master"));
         assertThat(config2.getBranch(), is("master"));
@@ -132,6 +143,5 @@ public class GitMaterialConfigTest {
         GitMaterialConfig gitMaterialConfig = new GitMaterialConfig("http://url", "foo");
         gitMaterialConfig.setConfigAttributes(Collections.singletonMap(GitMaterialConfig.BRANCH, "     "));
         assertThat(gitMaterialConfig.getBranch(), is("master"));
-
     }
 }

--- a/config/config-api/test/com/thoughtworks/go/helper/MaterialConfigsMother.java
+++ b/config/config-api/test/com/thoughtworks/go/helper/MaterialConfigsMother.java
@@ -103,15 +103,16 @@ public class MaterialConfigsMother {
         return new HgMaterialConfig(url, folder);
     }
 
-    public static GitMaterialConfig gitMaterialConfig(String url, String submoduleFolder, String branch) {
+    public static GitMaterialConfig gitMaterialConfig(String url, String submoduleFolder, String branch, boolean shallowClone) {
         GitMaterialConfig gitMaterialConfig = new GitMaterialConfig(url, branch);
+        gitMaterialConfig.setShallowClone(shallowClone);
         gitMaterialConfig.setSubmoduleFolder(submoduleFolder);
         return gitMaterialConfig;
     }
 
     public static GitMaterialConfig gitMaterialConfig() {
         Filter filter = new Filter(new IgnoredFiles("**/*.html"), new IgnoredFiles("**/foobar/"));
-        return new GitMaterialConfig(new UrlArgument("http://user:password@funk.com/blank"), "branch", "sub_module_folder", false, filter, "destination", new CaseInsensitiveString("AwesomeGitMaterial"));
+        return new GitMaterialConfig(new UrlArgument("http://user:password@funk.com/blank"), "branch", "sub_module_folder", false, filter, "destination", new CaseInsensitiveString("AwesomeGitMaterial"), false);
     }
 
     public static GitMaterialConfig gitMaterialConfig(String url) {

--- a/config/config-server/resources/schemas/79_cruise-config.xsd
+++ b/config/config-server/resources/schemas/79_cruise-config.xsd
@@ -76,7 +76,7 @@
                     </xsd:unique>
                 </xsd:element>
             </xsd:sequence>
-            <xsd:attribute name="schemaVersion" type="xsd:int" use="required" fixed="80"/>
+            <xsd:attribute name="schemaVersion" type="xsd:int" use="required" fixed="79"/>
         </xsd:complexType>
         <xsd:unique name="uniquePipelines">
             <xsd:selector xpath="pipelines"/>
@@ -392,7 +392,6 @@
         <xsd:attribute name="url" type="xsd:string" use="required"/>
         <xsd:attribute name="dest" type="filePathType" use="optional"/>
         <xsd:attribute name="branch" type="xsd:string" use="optional"/>
-        <xsd:attribute name="shallowClone" type="xsd:boolean" use="optional"/>
         <xsd:attribute name="materialName" type="nameType" use="optional"/>
         <xsd:attribute name="autoUpdate" type="xsd:boolean" use="optional"/>
     </xsd:complexType>

--- a/config/config-server/resources/upgrades/80.xsl
+++ b/config/config-server/resources/upgrades/80.xsl
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+<!--
+  ~ Copyright 2016 ThoughtWorks, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+    <xsl:template match="/cruise/@schemaVersion">
+        <xsl:attribute name="schemaVersion">80</xsl:attribute>
+    </xsl:template>
+    <!-- Copy everything -->
+    <xsl:template match="@*|node()" name="identity">
+        <xsl:copy>
+            <xsl:apply-templates select="@*|node()"/>
+        </xsl:copy>
+    </xsl:template>
+</xsl:stylesheet>

--- a/config/config-server/test/com/thoughtworks/go/config/MagicalGoConfigXmlLoaderTest.java
+++ b/config/config-server/test/com/thoughtworks/go/config/MagicalGoConfigXmlLoaderTest.java
@@ -90,6 +90,7 @@ import static org.hamcrest.core.IsCollectionContaining.hasItem;
 import static org.hamcrest.core.IsNot.not;
 import static org.hamcrest.core.IsNull.nullValue;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 @RunWith(JunitExtRunner.class)
@@ -566,6 +567,13 @@ public class MagicalGoConfigXmlLoaderTest {
         Filter expectedFilter = new Filter();
         expectedFilter.add(new IgnoredFiles("x"));
         assertThat(parsedFilter, is(expectedFilter));
+    }
+
+    @Test
+    public void shouldLoadShallowFlagFromGitPartial() throws Exception {
+        String gitPartial = "<git url='file:///tmp/testGitRepo/project1' shallowClone=\"true\" />";
+        GitMaterialConfig gitMaterial = xmlLoader.fromXmlPartial(toInputStream(gitPartial), GitMaterialConfig.class);
+        assertTrue(gitMaterial.isShallowClone());
     }
 
     @Test

--- a/server/config/cruise-config.xml
+++ b/server/config/cruise-config.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<cruise xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="cruise-config.xsd" schemaVersion="79">
+<cruise xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="cruise-config.xsd" schemaVersion="80">
   <server artifactsdir="logs" commandRepositoryLocation="default" serverId="dev-id">
     <security>
       <passwordFile path="../manual-testing/ant_hg/password.properties" />
@@ -36,4 +36,3 @@
     </pipeline>
   </pipelines>
 </cruise>
-

--- a/server/src/com/thoughtworks/go/server/service/materials/GitPoller.java
+++ b/server/src/com/thoughtworks/go/server/service/materials/GitPoller.java
@@ -16,29 +16,34 @@
 
 package com.thoughtworks.go.server.service.materials;
 
-import java.io.File;
-import java.util.List;
-
 import com.thoughtworks.go.config.materials.SubprocessExecutionContext;
 import com.thoughtworks.go.config.materials.git.GitMaterial;
 import com.thoughtworks.go.domain.materials.Modification;
 import com.thoughtworks.go.domain.materials.Revision;
+import com.thoughtworks.go.util.SystemEnvironment;
+
+import java.io.File;
+import java.util.List;
 
 public class GitPoller implements MaterialPoller<GitMaterial> {
 
     @Override
     public List<Modification> latestModification(GitMaterial material, File baseDir, SubprocessExecutionContext execCtx) {
-        return material.latestModification(baseDir, execCtx);
+        return toggleShallowCloneFeature(material).latestModification(baseDir, execCtx);
     }
 
     @Override
     public List<Modification> modificationsSince(GitMaterial material, File baseDir, Revision revision, SubprocessExecutionContext execCtx) {
-        return material.modificationsSince(baseDir, revision, execCtx);
+        return toggleShallowCloneFeature(material).modificationsSince(baseDir, revision, execCtx);
     }
 
     @Override
     public void checkout(GitMaterial material, File baseDir, Revision revision, SubprocessExecutionContext execCtx) {
-        material.checkout(baseDir,revision,execCtx);
+        toggleShallowCloneFeature(material).checkout(baseDir, revision, execCtx);
     }
 
+    private GitMaterial toggleShallowCloneFeature(GitMaterial material) {
+        Boolean serverSideShallowCloneOn = new SystemEnvironment().get(SystemEnvironment.GO_SERVER_SHALLOW_CLONE);
+        return material.withShallowClone(serverSideShallowCloneOn);
+    }
 }

--- a/server/src/com/thoughtworks/go/server/service/materials/HgPoller.java
+++ b/server/src/com/thoughtworks/go/server/service/materials/HgPoller.java
@@ -38,6 +38,6 @@ public class HgPoller implements MaterialPoller<HgMaterial> {
 
     @Override
     public void checkout(HgMaterial material, File baseDir, Revision revision, SubprocessExecutionContext execCtx) {
-        material.checkout(baseDir,revision,execCtx);
+        material.checkout(baseDir,revision, execCtx);
     }
 }

--- a/server/src/com/thoughtworks/go/server/service/materials/P4Poller.java
+++ b/server/src/com/thoughtworks/go/server/service/materials/P4Poller.java
@@ -38,6 +38,6 @@ public class P4Poller implements MaterialPoller<P4Material> {
 
     @Override
     public void checkout(P4Material material, File baseDir, Revision revision, SubprocessExecutionContext execCtx) {
-        material.checkout(baseDir,revision,execCtx);
+        material.checkout(baseDir,revision, execCtx);
     }
 }

--- a/server/src/com/thoughtworks/go/server/service/materials/SvnPoller.java
+++ b/server/src/com/thoughtworks/go/server/service/materials/SvnPoller.java
@@ -38,6 +38,6 @@ public class SvnPoller implements MaterialPoller<SvnMaterial> {
 
     @Override
     public void checkout(SvnMaterial material, File baseDir, Revision revision, SubprocessExecutionContext execCtx) {
-        material.checkout(baseDir,revision,execCtx);
+        material.checkout(baseDir,revision, execCtx);
     }
 }

--- a/server/src/com/thoughtworks/go/server/service/materials/TfsPoller.java
+++ b/server/src/com/thoughtworks/go/server/service/materials/TfsPoller.java
@@ -38,6 +38,6 @@ public class TfsPoller implements MaterialPoller<TfsMaterial> {
 
     @Override
     public void checkout(TfsMaterial material, File baseDir, Revision revision, SubprocessExecutionContext execCtx) {
-        material.checkout(baseDir,revision,execCtx);
+        material.checkout(baseDir,revision, execCtx);
     }
 }

--- a/server/test/integration/com/thoughtworks/go/server/persistence/MaterialRepositoryIntegrationTest.java
+++ b/server/test/integration/com/thoughtworks/go/server/persistence/MaterialRepositoryIntegrationTest.java
@@ -631,7 +631,7 @@ public class MaterialRepositoryIntegrationTest {
 
     @Test
     public void shouldSaveGitPipelineMaterialRevisions() throws Exception {
-        GitMaterialConfig gitMaterialConfig = MaterialConfigsMother.gitMaterialConfig("gitUrl", "submoduleFolder", "branch");
+        GitMaterialConfig gitMaterialConfig = MaterialConfigsMother.gitMaterialConfig("gitUrl", "submoduleFolder", "branch", false);
         assertCanLoadAndSaveMaterialRevisionsFor(gitMaterialConfig);
     }
 
@@ -1145,7 +1145,7 @@ public class MaterialRepositoryIntegrationTest {
         assertThat(JsonHelper.fromJson(savedMaterialInstance.getConfiguration(), PluggableSCMMaterial.class).getScmConfig().getConfiguration(), is(material.getScmConfig().getConfiguration()));
         assertThat(JsonHelper.fromJson(savedMaterialInstance.getConfiguration(), PluggableSCMMaterial.class).getScmConfig().getPluginConfiguration().getId(), is(material.getScmConfig().getPluginConfiguration().getId()));
     }
-
+    
     private MaterialRevision saveOneDependencyModification(DependencyMaterial dependencyMaterial, String revision) {
         return saveOneDependencyModification(dependencyMaterial, revision, "MOCK_LABEL-12");
     }

--- a/server/test/integration/com/thoughtworks/go/server/service/BackupServiceIntegrationTest.java
+++ b/server/test/integration/com/thoughtworks/go/server/service/BackupServiceIntegrationTest.java
@@ -38,6 +38,7 @@ import com.thoughtworks.go.config.materials.git.GitMaterial;
 import com.thoughtworks.go.database.Database;
 import com.thoughtworks.go.domain.materials.Modification;
 import com.thoughtworks.go.domain.materials.mercurial.StringRevision;
+import com.thoughtworks.go.domain.materials.RevisionContext;
 import com.thoughtworks.go.i18n.Localizable;
 import com.thoughtworks.go.i18n.Localizer;
 import com.thoughtworks.go.security.CipherProvider;
@@ -201,7 +202,8 @@ public class BackupServiceIntegrationTest {
         List<Modification> modifications = git.latestModification(cloneDir, subprocessExecutionContext);
         String latestChangeRev = modifications.get(0).getRevision();
         assertThat(FileUtil.readContentFromFile(new File(cloneDir, "cruise-config.xml")).indexOf("too-unique-to-be-present"), greaterThan(0));
-        git.updateTo(new InMemoryStreamConsumer(), new StringRevision(latestChangeRev + "~1"), cloneDir, subprocessExecutionContext);
+        StringRevision revision = new StringRevision(latestChangeRev + "~1");
+        git.updateTo(new InMemoryStreamConsumer(), cloneDir, new RevisionContext(revision), subprocessExecutionContext);
         assertThat(FileUtil.readContentFromFile(new File(cloneDir, "cruise-config.xml")).indexOf("too-unique-to-be-present"), is(-1));
     }
 

--- a/server/test/integration/com/thoughtworks/go/server/service/ScheduledPipelineLoaderIntegrationTest.java
+++ b/server/test/integration/com/thoughtworks/go/server/service/ScheduledPipelineLoaderIntegrationTest.java
@@ -24,6 +24,8 @@ import com.thoughtworks.go.config.*;
 import com.thoughtworks.go.config.GoConfigDao;
 import com.thoughtworks.go.config.materials.MaterialConfigs;
 import com.thoughtworks.go.config.materials.ScmMaterialConfig;
+import com.thoughtworks.go.config.materials.git.GitMaterial;
+import com.thoughtworks.go.config.materials.git.GitMaterialConfig;
 import com.thoughtworks.go.config.materials.perforce.P4Material;
 import com.thoughtworks.go.config.materials.perforce.P4MaterialConfig;
 import com.thoughtworks.go.config.materials.svn.SvnMaterial;
@@ -34,6 +36,7 @@ import com.thoughtworks.go.domain.JobState;
 import com.thoughtworks.go.domain.MaterialRevisions;
 import com.thoughtworks.go.domain.Pipeline;
 import com.thoughtworks.go.domain.exception.IllegalArtifactLocationException;
+import com.thoughtworks.go.domain.materials.git.GitTestRepo;
 import com.thoughtworks.go.helper.MaterialConfigsMother;
 import com.thoughtworks.go.helper.MaterialsMother;
 import com.thoughtworks.go.helper.ModificationsMother;
@@ -206,21 +209,47 @@ public class ScheduledPipelineLoaderIntegrationTest {
         pipelineConfig.addMaterialConfig(materialConfig);
         configHelper.addPipeline(pipelineConfig);
 
-        MaterialConfigs allConfigsWithExpandedExternals = materialExpansionService.expandMaterialConfigsForScheduling(pipelineConfig.materialConfigs());
-        MaterialRevisions materialRevisions = ModificationsMother.modifyOneFile(MaterialsMother.createMaterialsFromMaterialConfigs(allConfigsWithExpandedExternals));
-        Pipeline building = PipelineMother.buildingWithRevisions(pipelineConfig, materialRevisions);
-        Pipeline pipeline = dbHelper.savePipelineWithMaterials(building);
-
-        final long jobId = pipeline.getStages().get(0).getJobInstances().get(0).getId();
-        Pipeline loadedPipeline = (Pipeline) transactionTemplate.execute(new TransactionCallback() {
-            public Object doInTransaction(TransactionStatus status) {
-                return loader.pipelineWithPasswordAwareBuildCauseByBuildId(jobId);
-            }
-        });
+        Pipeline loadedPipeline = createAndLoadModifyOneFilePipeline(pipelineConfig);
 
         MaterialRevisions revisions = loadedPipeline.getBuildCause().getMaterialRevisions();
         assertThat(revisions.getRevisions().size(), is(2));
         assertThat(((SvnMaterial) revisions.getRevisions().get(0).getMaterial()).getPassword(), is("boozer"));
         assertThat(((SvnMaterial) revisions.getRevisions().get(1).getMaterial()).getPassword(), is("boozer"));
+    }
+
+    @Test
+    public void shouldLoadShallowCloneFlagForGitMaterialsBaseOnTheirOwnPipelineConfig() throws IOException {
+        GitTestRepo testRepo = new GitTestRepo();
+
+        PipelineConfig shallowPipeline = PipelineConfigMother.pipelineConfig("shallowPipeline", new StageConfig(new CaseInsensitiveString("stage"), new JobConfigs(new JobConfig("job-one"))));
+        shallowPipeline.materialConfigs().clear();
+        shallowPipeline.addMaterialConfig(new GitMaterialConfig(testRepo.projectRepositoryUrl(), null, true));
+        configHelper.addPipeline(shallowPipeline);
+
+        PipelineConfig fullPipeline = PipelineConfigMother.pipelineConfig("fullPipeline", new StageConfig(new CaseInsensitiveString("stage"), new JobConfigs(new JobConfig("job-one"))));
+        fullPipeline.materialConfigs().clear();
+        fullPipeline.addMaterialConfig(new GitMaterialConfig(testRepo.projectRepositoryUrl(), null, false));
+        configHelper.addPipeline(fullPipeline);
+
+        Pipeline shallowPipelineInstance = createAndLoadModifyOneFilePipeline(shallowPipeline);
+        MaterialRevisions shallowRevisions = shallowPipelineInstance.getBuildCause().getMaterialRevisions();
+        assertThat(((GitMaterial) shallowRevisions.getRevisions().get(0).getMaterial()).isShallowClone(), is(true));
+
+        Pipeline fullPipelineInstance = createAndLoadModifyOneFilePipeline(fullPipeline);
+        MaterialRevisions fullRevisions = fullPipelineInstance.getBuildCause().getMaterialRevisions();
+        assertThat(((GitMaterial) fullRevisions.getRevisions().get(0).getMaterial()).isShallowClone(), is(false));
+    }
+
+    private Pipeline createAndLoadModifyOneFilePipeline(PipelineConfig pipelineConfig) {
+        MaterialConfigs expandedConfigs = materialExpansionService.expandMaterialConfigsForScheduling(pipelineConfig.materialConfigs());
+        MaterialRevisions materialRevisions = ModificationsMother.modifyOneFile(MaterialsMother.createMaterialsFromMaterialConfigs(expandedConfigs));
+        Pipeline building = PipelineMother.buildingWithRevisions(pipelineConfig, materialRevisions);
+        Pipeline pipeline = dbHelper.savePipelineWithMaterials(building);
+        final long jobId = pipeline.getStages().get(0).getJobInstances().get(0).getId();
+        return (Pipeline) transactionTemplate.execute(new TransactionCallback() {
+            public Object doInTransaction(TransactionStatus status) {
+                return loader.pipelineWithPasswordAwareBuildCauseByBuildId(jobId);
+            }
+        });
     }
 }

--- a/server/test/unit/com/thoughtworks/go/server/domain/PipelineConfigDependencyGraphTest.java
+++ b/server/test/unit/com/thoughtworks/go/server/domain/PipelineConfigDependencyGraphTest.java
@@ -101,7 +101,7 @@ public class PipelineConfigDependencyGraphTest {
         HgMaterialConfig common1 = MaterialConfigsMother.hgMaterialConfig("hg-url", "one-folder");
         HgMaterialConfig common2 = MaterialConfigsMother.hgMaterialConfig("hg-url", "another-folder");
         SvnMaterialConfig firstOrderSVNMaterial = MaterialConfigsMother.svnMaterialConfig();
-        GitMaterialConfig firstOrderGitMaterial = MaterialConfigsMother.gitMaterialConfig("url", "submodule", "branch");
+        GitMaterialConfig firstOrderGitMaterial = MaterialConfigsMother.gitMaterialConfig("url", "submodule", "branch", false);
         P4MaterialConfig firstOrderP4Material = MaterialConfigsMother.p4MaterialConfig();
 
         DependencyMaterialConfig up1DependencyMaterial = new DependencyMaterialConfig(new CaseInsensitiveString("up1"), new CaseInsensitiveString("first"));
@@ -139,7 +139,7 @@ public class PipelineConfigDependencyGraphTest {
     public void shouldReturnTheSetOfFingerprintsOfAllMaterials() throws Exception {
         HgMaterialConfig common = MaterialConfigsMother.hgMaterialConfig();
         SvnMaterialConfig firstOrderSVNMaterial = MaterialConfigsMother.svnMaterialConfig();
-        GitMaterialConfig firstOrderGitMaterial = MaterialConfigsMother.gitMaterialConfig("url", "submodule", "branch");
+        GitMaterialConfig firstOrderGitMaterial = MaterialConfigsMother.gitMaterialConfig("url", "submodule", "branch", false);
         P4MaterialConfig firstOrderP4Material = MaterialConfigsMother.p4MaterialConfig();
 
         DependencyMaterialConfig up1DependencyMaterial = new DependencyMaterialConfig(new CaseInsensitiveString("up1"), new CaseInsensitiveString("first"));

--- a/server/test/unit/com/thoughtworks/go/server/service/MaterialServiceTest.java
+++ b/server/test/unit/com/thoughtworks/go/server/service/MaterialServiceTest.java
@@ -151,6 +151,11 @@ public class MaterialServiceTest {
         }
 
         @Override
+        public GitMaterial withShallowClone(boolean value) {
+            return this;
+        }
+
+        @Override
         public List<Modification> modificationsSince(File baseDir, Revision revision, SubprocessExecutionContext execCtx) {
             return (List<Modification>) MODIFICATIONS;
         }

--- a/server/webapp/WEB-INF/rails.new/spec/presenters/api_v1/config/materials/material_representer_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/presenters/api_v1/config/materials/material_representer_spec.rb
@@ -60,9 +60,8 @@ describe ApiV1::Config::Materials::MaterialRepresenter do
     end
 
     def existing_material_with_errors
-
-      git_config       = GitMaterialConfig.new(UrlArgument.new(''), '', '', true, nil, '', CaseInsensitiveString.new('!nV@l!d'))
-      dup_git_material =GitMaterialConfig.new(UrlArgument.new(''), '', '', true, nil, '', CaseInsensitiveString.new('!nV@l!d'))
+      git_config       = GitMaterialConfig.new(UrlArgument.new(''), '', '', true, nil, '', CaseInsensitiveString.new('!nV@l!d'), true)
+      dup_git_material =GitMaterialConfig.new(UrlArgument.new(''), '', '', true, nil, '', CaseInsensitiveString.new('!nV@l!d'), true)
       material_configs = MaterialConfigs.new(git_config);
       material_configs.add(dup_git_material)
 


### PR DESCRIPTION
This PR is rebased version of PR #1846, please find the original comments and discussion in #1846 
====

This PR implement the [proposal](https://github.com/gocd/gocd/issues/313#issuecomment-174103478) on issue #313. 

What it does
---
* Added a configuration option for git material called `shallowClone`, default to false
* Shallow clone config only applies to agent. On server side flyweight clone (includes configuration repository) is always shallow.
* If shallowClone is specified, git repository on agents clone will be a shallow clone with depth 2.
* If build is triggered with a missing revision on a shallow cloned repo, use a 2 steps process to unshallow the repo. 
* Convert existing shallow cloned repos to full clone when user turning shallowClone off.

How to test it
---
Since UI part of the shallow clone configuration is not included, enabling the configuration option need be through editing cruise-config.xml. The following xml snippet setup a pipeline checkout linux-kernel repository with shallow clone enabled.

```xml
<pipeline name="linux-kernel">
  <materials>
    <git url="git://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git" shallowClone="true" materialName="linux-kernel" />
  </materials>
  <stage name="ls-stage">
    <jobs>
      <job name="ls-job">
        <tasks>
          <exec command="ls" />
        </tasks>
      </job>
    </jobs>
  </stage>
</pipeline>
```

Benefits
---
For the linux kernel repo,  on my machine/network,  without shallow clone, it takes more than 15 minutes to complete first build. With shallow clone option enabled, it takes about two minutes to complete first build.

Other notes
---
* This PR works with old git versions,  tested back to 1.7.1.
* This PR includes configuration migration (bumped schema version to 79)
* Server side shallow clone can be turn off by setting system property `go.server.shallowClone` to `N`
* This PR changed the way how ScheduledPipelineLoader lookup `knownMaterials`. It scopes material config lookup under the current pipeline. Set system property `go.server.scheduledPipelineLoader.globalMaterialLookup` to `Y` can bring the old behavior back (lookup material through whole cruise config)