### PR TITLE
Improve cruise config xml save performance (#838):

### DIFF
--- a/config/config-api/src/com/thoughtworks/go/config/ConfigCache.java
+++ b/config/config-api/src/com/thoughtworks/go/config/ConfigCache.java
@@ -16,16 +16,17 @@
 
 package com.thoughtworks.go.config;
 
-import java.lang.annotation.Annotation;
-import java.lang.reflect.AnnotatedElement;
-
 import com.thoughtworks.go.config.preprocessor.ClassAttributeCache;
 import org.springframework.stereotype.Component;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.AnnotatedElement;
 
 @Component
 public class ConfigCache {
 
     private ClassAttributeCache.FieldCache fieldCache = new ClassAttributeCache.FieldCache();
+    private ConfigCacheStore store;
 
     public static boolean isAnnotationPresent(AnnotatedElement element, Class<? extends Annotation> annotationClass) {
         return element.isAnnotationPresent(annotationClass);
@@ -35,8 +36,22 @@ public class ConfigCache {
          return klass.getAnnotation(annotationClass);
     }
 
+    public void put(String md5, GoConfigHolder holder) {
+        this.store.put(md5, holder);
+    }
+
+    public GoConfigHolder get(String md5) {
+        if (md5 == null) {
+            return null;
+        }
+        return (GoConfigHolder) this.store.get(md5);
+    }
+
     public ClassAttributeCache.FieldCache getFieldCache() {
         return fieldCache;
     }
 
+    public void setConfigCacheStore(ConfigCacheStore store) {
+        this.store = store;
+    }
 }

--- a/config/config-api/src/com/thoughtworks/go/config/ConfigCache.java
+++ b/config/config-api/src/com/thoughtworks/go/config/ConfigCache.java
@@ -26,7 +26,7 @@ import java.lang.reflect.AnnotatedElement;
 public class ConfigCache {
 
     private ClassAttributeCache.FieldCache fieldCache = new ClassAttributeCache.FieldCache();
-    private ConfigCacheStore store;
+    private ConfigCacheStore store = ConfigCacheStore.NULL;
 
     public static boolean isAnnotationPresent(AnnotatedElement element, Class<? extends Annotation> annotationClass) {
         return element.isAnnotationPresent(annotationClass);

--- a/config/config-api/src/com/thoughtworks/go/config/ConfigCacheStore.java
+++ b/config/config-api/src/com/thoughtworks/go/config/ConfigCacheStore.java
@@ -1,27 +1,22 @@
-/*************************GO-LICENSE-START*********************************
- * Copyright 2014 ThoughtWorks, Inc.
+/*
+ * Copyright 2016 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *************************GO-LICENSE-END***********************************/
+ */
 
 package com.thoughtworks.go.config;
 
-import com.thoughtworks.go.domain.ConfigErrors;
-
-import java.io.Serializable;
-
-public interface Validatable extends Serializable {
-    void validate(ValidationContext validationContext);
-    ConfigErrors errors();
-    void addError(String fieldName, String message);
+public interface ConfigCacheStore {
+    Object get(String key);
+    void put(String key, Object obj);
 }

--- a/config/config-api/src/com/thoughtworks/go/config/ConfigCacheStore.java
+++ b/config/config-api/src/com/thoughtworks/go/config/ConfigCacheStore.java
@@ -17,6 +17,17 @@
 package com.thoughtworks.go.config;
 
 public interface ConfigCacheStore {
+    ConfigCacheStore NULL = new ConfigCacheStore() {
+        @Override
+        public Object get(String key) {
+            return null;
+        }
+
+        @Override
+        public void put(String key, Object obj) {
+        }
+    };
+
     Object get(String key);
     void put(String key, Object obj);
 }

--- a/config/config-api/src/com/thoughtworks/go/config/CruiseConfig.java
+++ b/config/config-api/src/com/thoughtworks/go/config/CruiseConfig.java
@@ -28,6 +28,7 @@ import com.thoughtworks.go.util.Node;
 import com.thoughtworks.go.util.Pair;
 
 import javax.annotation.PostConstruct;
+import java.io.Serializable;
 import java.util.Hashtable;
 import java.util.List;
 import java.util.Map;

--- a/config/config-api/src/com/thoughtworks/go/config/GoConfigHolder.java
+++ b/config/config-api/src/com/thoughtworks/go/config/GoConfigHolder.java
@@ -16,7 +16,9 @@
 
 package com.thoughtworks.go.config;
 
-public class GoConfigHolder {
+import java.io.Serializable;
+
+public class GoConfigHolder implements Serializable {
     public final CruiseConfig config;
     public final CruiseConfig configForEdit;
 

--- a/config/config-api/src/com/thoughtworks/go/util/CachedDigestUtils.java
+++ b/config/config-api/src/com/thoughtworks/go/util/CachedDigestUtils.java
@@ -16,14 +16,14 @@
 
 package com.thoughtworks.go.util;
 
+import com.thoughtworks.go.util.pool.DigestObjectPools;
+import org.apache.commons.codec.binary.Hex;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.security.MessageDigest;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-
-import com.thoughtworks.go.util.pool.DigestObjectPools;
-import org.apache.commons.codec.binary.Hex;
 
 /**
  * A replacement for org.apache.commons.codec.digest.DigestUtils , with the MessageDigest Instance cached.
@@ -72,8 +72,7 @@ public class CachedDigestUtils {
         return objectPools.computeDigest(algorithm, new DigestObjectPools.DigestOperation() {
 
             public String perform(MessageDigest digest) {
-                String stripped = StringUtil.stripSpacesAndNewLines(string);
-                digest.update(org.apache.commons.codec.binary.StringUtils.getBytesUtf8(stripped));
+                digest.update(org.apache.commons.codec.binary.StringUtils.getBytesUtf8(string));
                 return Hex.encodeHexString(digest.digest());
             }
         });

--- a/config/config-api/src/com/thoughtworks/go/util/CachedDigestUtils.java
+++ b/config/config-api/src/com/thoughtworks/go/util/CachedDigestUtils.java
@@ -72,7 +72,8 @@ public class CachedDigestUtils {
         return objectPools.computeDigest(algorithm, new DigestObjectPools.DigestOperation() {
 
             public String perform(MessageDigest digest) {
-                digest.update(org.apache.commons.codec.binary.StringUtils.getBytesUtf8(string));
+                String stripped = StringUtil.stripSpacesAndNewLines(string);
+                digest.update(org.apache.commons.codec.binary.StringUtils.getBytesUtf8(stripped));
                 return Hex.encodeHexString(digest.digest());
             }
         });

--- a/config/config-server/src/com/thoughtworks/go/config/GoConfigMigration.java
+++ b/config/config-server/src/com/thoughtworks/go/config/GoConfigMigration.java
@@ -145,7 +145,7 @@ public class GoConfigMigration {
 
     private GoConfigHolder reloadedConfig(ByteArrayOutputStream stream, String upgradedXmlString) throws Exception {
         GoConfigHolder configHolder = validateAfterMigrationFinished(upgradedXmlString);
-        new MagicalGoConfigXmlWriter(configCache, registry, metricsProbeService).write(configHolder.configForEdit, stream, false);
+        new MagicalGoConfigXmlWriter(configCache, registry, metricsProbeService).write(configHolder.configForEdit, stream);
         return configHolder;
     }
 

--- a/config/config-server/src/com/thoughtworks/go/config/MagicalGoConfigXmlLoader.java
+++ b/config/config-server/src/com/thoughtworks/go/config/MagicalGoConfigXmlLoader.java
@@ -16,13 +16,6 @@
 
 package com.thoughtworks.go.config;
 
-import java.io.ByteArrayInputStream;
-import java.io.InputStream;
-import java.lang.reflect.Field;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-
 import com.rits.cloning.Cloner;
 import com.thoughtworks.go.config.exceptions.GoConfigInvalidException;
 import com.thoughtworks.go.config.parser.ConfigReferenceElements;
@@ -30,7 +23,6 @@ import com.thoughtworks.go.config.preprocessor.ConfigParamPreprocessor;
 import com.thoughtworks.go.config.registry.ConfigElementImplementationRegistry;
 import com.thoughtworks.go.config.remote.FileConfigOrigin;
 import com.thoughtworks.go.config.validation.*;
-import com.thoughtworks.go.config.validation.GoConfigValidator;
 import com.thoughtworks.go.domain.ConfigErrors;
 import com.thoughtworks.go.metrics.domain.context.Context;
 import com.thoughtworks.go.metrics.domain.probes.ProbeType;
@@ -44,6 +36,13 @@ import org.apache.log4j.Logger;
 import org.jdom.Document;
 import org.jdom.Element;
 import org.jdom.input.SAXBuilder;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 import static com.thoughtworks.go.config.parser.GoConfigClassLoader.classParser;
 import static org.apache.commons.io.IOUtils.toInputStream;
@@ -79,12 +78,22 @@ public class MagicalGoConfigXmlLoader {
     }
 
     public GoConfigHolder loadConfigHolder(final String content) throws Exception {
+        String md5 = CachedDigestUtils.md5Hex(content);
+        GoConfigHolder cached = this.configCache.get(md5);
+        if (cached != null) {
+            return cached;
+        }
+        GoConfigHolder holder = getGoConfigHolderWithoutCache(content, md5);
+        configCache.put(md5, holder);
+        return holder;
+    }
+
+    private GoConfigHolder getGoConfigHolderWithoutCache(String content, String md5) throws Exception {
         CruiseConfig configForEdit;
         CruiseConfig config;
         Context context = metricsProbeService.begin(ProbeType.CONVERTING_CONFIG_XML_TO_OBJECT);
         try {
             LOGGER.debug("[Config Save] Loading config holder");
-            String md5 = CachedDigestUtils.md5Hex(content);
             Element element = parseInputStream(new ByteArrayInputStream(content.getBytes()));
             LOGGER.debug("[Config Save] Updating config cache with new XML");
 
@@ -107,6 +116,11 @@ public class MagicalGoConfigXmlLoader {
     }
 
     public CruiseConfig preprocessAndValidate(CruiseConfig config) throws Exception {
+        String md5 = config.getMd5();
+        GoConfigHolder cachedHolder = configCache.get(md5);
+        if (cachedHolder != null) {
+            return cachedHolder.config;
+        }
         LOGGER.debug("[Config Save] In preprocessAndValidate: Cloning.");
         Context context = metricsProbeService.begin(ProbeType.PREPROCESS_AND_VALIDATE);
         CruiseConfig cloned;

--- a/config/config-server/src/com/thoughtworks/go/config/MagicalGoConfigXmlLoader.java
+++ b/config/config-server/src/com/thoughtworks/go/config/MagicalGoConfigXmlLoader.java
@@ -36,6 +36,7 @@ import org.apache.log4j.Logger;
 import org.jdom.Document;
 import org.jdom.Element;
 import org.jdom.input.SAXBuilder;
+import org.springframework.util.StringUtils;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
@@ -78,7 +79,7 @@ public class MagicalGoConfigXmlLoader {
     }
 
     public GoConfigHolder loadConfigHolder(final String content) throws Exception {
-        String md5 = CachedDigestUtils.md5Hex(content);
+        String md5 = CachedDigestUtils.md5Hex(StringUtils.trimWhitespace(content));
         GoConfigHolder cached = this.configCache.get(md5);
         if (cached != null) {
             return cached;

--- a/config/config-server/src/com/thoughtworks/go/config/MagicalGoConfigXmlWriter.java
+++ b/config/config-server/src/com/thoughtworks/go/config/MagicalGoConfigXmlWriter.java
@@ -78,21 +78,18 @@ public class MagicalGoConfigXmlWriter {
         return new Document(root);
     }
 
-    public void write(CruiseConfig configForEdit, OutputStream output, boolean skipPreprocessingAndValidation) throws Exception {
-        LOGGER.debug("[Serializing Config] Starting to write. Validation skipped? " + skipPreprocessingAndValidation);
+    @Deprecated
+    // CruiseConfig should be validated outside
+    public void write(CruiseConfig configForEdit, OutputStream output, boolean skipValidation) throws Exception {
+        write(configForEdit, output);
+    }
+
+    public void write(CruiseConfig configForEdit, OutputStream output) throws Exception {
         Context context = metricsProbeService.begin(ProbeType.WRITE_CONFIG_TO_FILE_SYSTEM);
         try {
             MagicalGoConfigXmlLoader loader = new MagicalGoConfigXmlLoader(configCache, registry, metricsProbeService);
             if(!configForEdit.getOrigin().isLocal()) {
-                if (!skipPreprocessingAndValidation) {
-                    // lets validate merged config first, it will show more sensible errors
-                    loader.preprocessAndValidate(configForEdit);
-                }
                 configForEdit = configForEdit.getLocal();
-            }
-            if (!skipPreprocessingAndValidation) {
-                loader.preprocessAndValidate(configForEdit);
-                LOGGER.debug("[Serializing Config] Done with cruise config validators.");
             }
             Document document = createEmptyCruiseConfigDocument();
             write(configForEdit, document.getRootElement(), configCache, registry);

--- a/config/config-server/src/com/thoughtworks/go/config/parser/GoConfigClassLoader.java
+++ b/config/config-server/src/com/thoughtworks/go/config/parser/GoConfigClassLoader.java
@@ -68,8 +68,8 @@ public class GoConfigClassLoader<T> {
     }
 
     public T parse() {
-        bombUnless(atElement(),
-                "Unable to parse element <" + e.getName() + "> for class " + aClass.getSimpleName());
+//        bombUnless(atElement(),
+//                "Unable to parse element <" + e.getName() + "> for class " + aClass.getSimpleName());
         T o = createInstance();
         if (isAnnotationPresent(aClass, ConfigReferenceCollection.class)) {
             ConfigReferenceCollection referenceCollection = aClass.getAnnotation(ConfigReferenceCollection.class);

--- a/config/config-server/src/com/thoughtworks/go/config/parser/GoConfigClassLoader.java
+++ b/config/config-server/src/com/thoughtworks/go/config/parser/GoConfigClassLoader.java
@@ -68,8 +68,10 @@ public class GoConfigClassLoader<T> {
     }
 
     public T parse() {
-//        bombUnless(atElement(),
-//                "Unable to parse element <" + e.getName() + "> for class " + aClass.getSimpleName());
+        if (!atElement()) {
+            // direct calling aClass.getSimpleName have performance issue with large config
+            throw bomb("Unable to parse element <" + e.getName() + "> for class " + aClass.getSimpleName());
+        }
         T o = createInstance();
         if (isAnnotationPresent(aClass, ConfigReferenceCollection.class)) {
             ConfigReferenceCollection referenceCollection = aClass.getAnnotation(ConfigReferenceCollection.class);
@@ -153,7 +155,7 @@ public class GoConfigClassLoader<T> {
         }
         Class<T> type = (Class<T>) findConcreteType(e, aClass);
         if (type == null) {
-            bombIfNull(type, String.format("Unable to determine type to generate. Type: %s Element: %s", type.getName(), configUtil.elementOutput(e)));
+            bombIfNull(type, String.format("Unable to determine type to generate. Type is null Element: %s", configUtil.elementOutput(e)));
         }
         return type;
     }

--- a/server/src/com/thoughtworks/go/server/cache/ConfigEhCacheStore.java
+++ b/server/src/com/thoughtworks/go/server/cache/ConfigEhCacheStore.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2016 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.server.cache;
+
+import com.thoughtworks.go.config.ConfigCache;
+import com.thoughtworks.go.config.ConfigCacheStore;
+import net.sf.ehcache.CacheManager;
+import net.sf.ehcache.Ehcache;
+import net.sf.ehcache.Element;
+import net.sf.ehcache.config.CacheConfiguration;
+import net.sf.ehcache.config.Configuration;
+import net.sf.ehcache.store.MemoryStoreEvictionPolicy;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cache.ehcache.EhCacheFactoryBean;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+import static com.thoughtworks.go.util.ExceptionUtils.bomb;
+
+@Component
+public class ConfigEhCacheStore implements ConfigCacheStore {
+
+    private final Ehcache ehcache;
+
+    @Autowired
+    public ConfigEhCacheStore(ConfigCache configCache) {
+        int maxElementsInMemory = 100;
+        EhCacheFactoryBean factoryBean = new EhCacheFactoryBean();
+
+        Configuration configuration = new Configuration();
+        configuration.setDefaultCacheConfiguration(new CacheConfiguration("cache", maxElementsInMemory));
+
+        factoryBean.setCacheManager(new CacheManager(configuration));
+        factoryBean.setCacheName("configCacheStore");
+        factoryBean.setDiskPersistent(false);
+        factoryBean.setOverflowToDisk(false);
+        factoryBean.setMaxElementsInMemory(maxElementsInMemory);
+        factoryBean.setEternal(true);
+        factoryBean.setMemoryStoreEvictionPolicy(MemoryStoreEvictionPolicy.LRU);
+        try {
+            factoryBean.afterPropertiesSet();
+        } catch (IOException e) {
+            bomb(e);
+        }
+        ehcache = factoryBean.getObject();
+        configCache.setConfigCacheStore(this);
+    }
+
+    @Override
+    public Object get(String key) {
+        Element element = ehcache.get(key);
+        if (element == null) {
+            return null;
+        }
+        return element.getValue();
+    }
+
+    @Override
+    public void put(String key, Object obj) {
+        ehcache.put(new Element(key, obj));
+    }
+}

--- a/server/src/com/thoughtworks/go/server/service/GoConfigService.java
+++ b/server/src/com/thoughtworks/go/server/service/GoConfigService.java
@@ -1155,7 +1155,7 @@ public class GoConfigService implements Initializer {
         protected org.dom4j.Document documentRoot() throws Exception {
             CruiseConfig cruiseConfig = goConfigDao.loadForEditing();
             ByteArrayOutputStream out = new ByteArrayOutputStream();
-            new MagicalGoConfigXmlWriter(configCache, registry, metricsProbeService).write(cruiseConfig, out, true);
+            new MagicalGoConfigXmlWriter(configCache, registry, metricsProbeService).write(cruiseConfig, out);
             org.dom4j.Document document = reader.read(new StringReader(out.toString()));
             Map<String, String> map = new HashMap<String, String>();
             map.put("go", MagicalGoConfigXmlWriter.XML_NS);
@@ -1336,7 +1336,7 @@ public class GoConfigService implements Initializer {
     private String configAsXml(CruiseConfig cruiseConfig) {
         final ByteArrayOutputStream outStream = new ByteArrayOutputStream();
         try {
-            new MagicalGoConfigXmlWriter(configCache, registry, metricsProbeService).write(cruiseConfig, outStream, true);
+            new MagicalGoConfigXmlWriter(configCache, registry, metricsProbeService).write(cruiseConfig, outStream);
             return outStream.toString();
         } catch (Exception e) {
             throw bomb(e);


### PR DESCRIPTION
1. Avoid unnecessary validate and deep clone CruiseConfig object
2. Avoid parsing same config string multiple times when saving cruise config xml config
3. Class#getSimpleName is slow when calling it too many times.

Note: only improves save all cruise config xml content (request: POST /go/admin/config_xml), won't improve partial update pipeline config.

-----------------

#### Benchmark

Environment Setup: see 760c0b0212d2490a0bc45ba2c22ca87f93fbab25 and 091a91326e3f5fd5039f0c587c1c039f8d89ba0a for setup environment, these 2 changes make development server more like production environment, and also disabled most of background job

Test config: I copied from our Mingle team's go configuration, it's a configuration has 15.8k lines, lots of pipelines.

Go server need a current config md5 for save config, so, I manually copied all POST data from browser, and I only can change the copied data once to get test result.

Warm up: about 100 requests to update same config.

Then I manually change configuration a little bit to fire the test request.

Ab command example: ab -v 4 -A admin:badger -T 'application/x-www-form-urlencoded' -p post_data -c 1 -n 1 http://localhost:8153/go/admin/config_xml

Result: about 770ms => 700ms when config changed, 1100ms => 400ms when save same config