### PR TITLE
Security bug: when editing svn material, plain password is printed in html

### DIFF
--- a/server/webapp/WEB-INF/rails.new/app/views/admin/materials/shared/_password.html.erb
+++ b/server/webapp/WEB-INF/rails.new/app/views/admin/materials/shared/_password.html.erb
@@ -1,7 +1,7 @@
 <div class="form_item_block">
     <label><%= l.string('PASSWORD') -%></label>
     <%= scope[:form].hidden_field(com.thoughtworks.go.config.materials.ScmMaterialConfig::ENCRYPTED_PASSWORD, {:include_blank => true, :class => "form_input encrypted_password"}) -%>
-    <%= scope[:form].password_field(com.thoughtworks.go.config.materials.ScmMaterialConfig::PASSWORD, {:include_blank => true, :class => "form_input password", :disabled => true}) -%>
+    <%= password_field_tag("material[password]", '', {:include_blank => true, :class => "form_input password", :disabled => true}) -%>
     <%= error_message_on(scope[:form].object, com.thoughtworks.go.config.materials.ScmMaterialConfig::PASSWORD, :css_class => "form_error") %>
     <div class="checkbox_row">
         <%= check_box_tag("material[#{com.thoughtworks.go.config.materials.ScmMaterialConfig::PASSWORD_CHANGED}]", "1", false, :class => "password_changed") %>

--- a/server/webapp/WEB-INF/rails.new/spec/views/admin/materials/p4/form_html_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/views/admin/materials/p4/form_html_spec.rb
@@ -56,7 +56,7 @@ describe "_form.html.erb" do
 
     render :partial => "admin/materials/p4/form.html", :locals => {:scope => {:material => @material_config, :url => "http://google.com", :method => "POST", :submit_label => "FOO", :edit_mode => true}}
 
-    expect(response.body).to have_selector(".popup_form input[disabled='disabled'][type='password'][name='material[#{com.thoughtworks.go.config.materials.svn.SvnMaterialConfig::PASSWORD}]'][value='secret']")
+    expect(response.body).to have_selector(".popup_form input[disabled='disabled'][type='password'][name='material[#{com.thoughtworks.go.config.materials.svn.SvnMaterialConfig::PASSWORD}]'][value='']")
     expect(response.body).to have_selector(".popup_form input[type='checkbox'][name='material[#{com.thoughtworks.go.config.materials.svn.SvnMaterialConfig::PASSWORD_CHANGED}]']")
   end
 

--- a/server/webapp/WEB-INF/rails.new/spec/views/admin/materials/svn/form_html_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/views/admin/materials/svn/form_html_spec.rb
@@ -53,7 +53,7 @@ describe "_form.html.erb" do
 
     render :partial => "admin/materials/svn/form.html", :locals => {:scope => {:material => @material_config, :url => "http://google.com", :method => "POST", :submit_label => "FOO", :edit_mode => true}}
 
-    expect(response.body).to have_selector(".popup_form input[disabled='disabled'][type='password'][name='material[#{com.thoughtworks.go.config.materials.svn.SvnMaterialConfig::PASSWORD}]'][value='secret']")
+    expect(response.body).to have_selector(".popup_form input[disabled='disabled'][type='password'][name='material[#{com.thoughtworks.go.config.materials.svn.SvnMaterialConfig::PASSWORD}]'][value='']")
     expect(response.body).to have_selector(".popup_form input[type='checkbox'][name='material[#{com.thoughtworks.go.config.materials.svn.SvnMaterialConfig::PASSWORD_CHANGED}]']")
   end
 

--- a/server/webapp/WEB-INF/rails.new/spec/views/admin/materials/tfs/form_html_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/views/admin/materials/tfs/form_html_spec.rb
@@ -58,7 +58,7 @@ describe "_form.html.erb" do
 
     render :partial => "admin/materials/tfs/form.html", :locals => {:scope => {:material => @material_config, :url => "http://google.com", :method => "POST", :submit_label => "FOO", :edit_mode => true}}
 
-    expect(response.body).to have_selector(".popup_form input[disabled='disabled'][type='password'][name='material[#{com.thoughtworks.go.config.materials.ScmMaterialConfig::PASSWORD}]'][value='passwd']")
+    expect(response.body).to have_selector(".popup_form input[disabled='disabled'][type='password'][name='material[#{com.thoughtworks.go.config.materials.ScmMaterialConfig::PASSWORD}]'][value='']")
     expect(response.body).to have_selector(".popup_form input[type='checkbox'][name='material[#{com.thoughtworks.go.config.materials.ScmMaterialConfig::PASSWORD_CHANGED}]']")
   end
 


### PR DESCRIPTION
Change to output "" instead of svn material password.

p4 and tfs materials have similar problem, changed together.