### PR TITLE
Remove redundant code (See #1801, #1802)

### DIFF
--- a/server/webapp/WEB-INF/rails.new/config/routes.rb
+++ b/server/webapp/WEB-INF/rails.new/config/routes.rb
@@ -230,8 +230,8 @@ Go::Application.routes.draw do
 
       namespace :admin do
         resources :pipelines, param: :name, only: [:show, :update, :create]
-        resources :command_snippets, only: [:index], format: false
-        get 'command_snippets/show', controller: :command_snippets, action: :show, as: :command_snippet, format: false
+        resources :command_snippets, only: [:index]
+        get 'command_snippets/show', controller: :command_snippets, action: :show, as: :command_snippet
       end
 
       get 'stages/:pipeline_name/:pipeline_counter/:stage_name/:stage_counter' => 'stages#show', constraints: {pipeline_name: PIPELINE_NAME_FORMAT, pipeline_counter: PIPELINE_COUNTER_FORMAT, stage_name: STAGE_NAME_FORMAT, stage_counter: STAGE_COUNTER_FORMAT}, as: :stage_instance_by_counter_api


### PR DESCRIPTION
Takes care of removing `format` option on some of the api routes, since that's set globally