### PR TITLE
Fix background error: when job does not have agent uuid (websocket communication)

### DIFF
--- a/server/src/com/thoughtworks/go/server/websocket/AgentRemoteHandler.java
+++ b/server/src/com/thoughtworks/go/server/websocket/AgentRemoteHandler.java
@@ -105,6 +105,9 @@ public class AgentRemoteHandler {
     }
 
     public void sendCancelMessage(String uuid) {
+        if (uuid == null) {
+            return;
+        }
         Agent agent = agentSessions.get(uuid);
         if (agent != null) {
             agent.send(new Message(Action.cancelJob));

--- a/server/test/unit/com/thoughtworks/go/server/websocket/AgentRemoteHandlerTest.java
+++ b/server/test/unit/com/thoughtworks/go/server/websocket/AgentRemoteHandlerTest.java
@@ -158,4 +158,22 @@ public class AgentRemoteHandlerTest {
         assertEquals(0, handler.connectedAgents().size());
         assertEquals(AgentStatus.LostContact, instance.getStatus());
     }
+
+    @Test
+    public void sendCancelMessage() {
+        AgentInstance instance = AgentInstanceMother.idle();
+        AgentRuntimeInfo info = new AgentRuntimeInfo(instance.getAgentIdentifier(), AgentRuntimeStatus.Idle, null, null, null);
+        when(remote.ping(info)).thenReturn(new AgentInstruction(false));
+        handler.process(agent, new Message(Action.ping, info));
+
+        agent.messages.clear();
+        handler.sendCancelMessage(instance.getAgentIdentifier().getUuid());
+        assertEquals(1, agent.messages.size());
+    }
+
+    @Test
+    public void sendCancelMessageShouldNotErrorOutWhenGivenUUIDIsUnknown() {
+        handler.sendCancelMessage(null);
+        handler.sendCancelMessage("hello");
+    }
 }


### PR DESCRIPTION
Job maybe rescheduled before assigned to an agent, so should ignore those job reschedule caused sending cancel message request.