### PR TITLE
Prevent rendering of parameter when command is not found

### DIFF
--- a/server/webapp/WEB-INF/rails.new/app/controllers/admin/commands_controller.rb
+++ b/server/webapp/WEB-INF/rails.new/app/controllers/admin/commands_controller.rb
@@ -26,7 +26,7 @@ class Admin::CommandsController < AdminController
   def show
     relative_path_of_snippet = params[:command_name]
     definition = command_repository_service.getCommandSnippetByRelativePath(relative_path_of_snippet)
-    render :text => "Command Definition for '#{relative_path_of_snippet}' could not be found", :status => 404 and return if definition.nil?
+    render :text => "Command definition not found", :status => 404 and return if definition.nil?
 
     render :json => {:name => definition.getName(), :description => definition.getDescription(), :author => definition.getAuthor(), :authorinfo => definition.getAuthorInfo(),
         :moreinfo => definition.getMoreInfo(), :command => definition.getCommandName(), :arguments => definition.getArguments().join("\n")}


### PR DESCRIPTION
Rely on the 404 header instead