### PR TITLE
Fix working directory disallow hidden folder and a relative path start with "./" issue

### DIFF
--- a/base/src/com/thoughtworks/go/util/GoConstants.java
+++ b/base/src/com/thoughtworks/go/util/GoConstants.java
@@ -58,7 +58,7 @@ public class GoConstants {
 
     public static final String PRODUCT_NAME = "go";
 
-    public static final int CONFIG_SCHEMA_VERSION = 80;
+    public static final int CONFIG_SCHEMA_VERSION = 81;
 
     public static final String APPROVAL_SUCCESS = "success";
     public static final String APPROVAL_MANUAL = "manual";

--- a/common/test/unit/com/thoughtworks/go/domain/ArtifactPlanTest.java
+++ b/common/test/unit/com/thoughtworks/go/domain/ArtifactPlanTest.java
@@ -20,6 +20,7 @@ import com.rits.cloning.Cloner;
 import com.thoughtworks.go.config.ArtifactPlan;
 import com.thoughtworks.go.config.ConfigSaveValidationContext;
 import com.thoughtworks.go.config.JobConfig;
+import com.thoughtworks.go.config.validation.FilePathTypeValidator;
 import com.thoughtworks.go.util.ClassMockery;
 import com.thoughtworks.go.work.DefaultGoPublisher;
 import org.jmock.Expectations;
@@ -139,7 +140,7 @@ public class ArtifactPlanTest {
    public void validate_shouldFailIfDestDoesNotMatchAFilePattern() {
         ArtifactPlan artifactPlan = new ArtifactPlan("foo/bar", "..");
         artifactPlan.validate(null);
-        assertThat(artifactPlan.errors().on(ArtifactPlan.DEST), is("Invalid destination path. Destination path should match the pattern ([^. ].+[^. ])|([^. ][^. ])|([^. ])"));
+        assertThat(artifactPlan.errors().on(ArtifactPlan.DEST), is("Invalid destination path. Destination path should match the pattern (([.]\\/)?[.][^. ]+)|([^. ].+[^. ])|([^. ][^. ])|([^. ])"));
     }
 
     @Test

--- a/config/config-api/src/com/thoughtworks/go/config/validation/FilePathTypeValidator.java
+++ b/config/config-api/src/com/thoughtworks/go/config/validation/FilePathTypeValidator.java
@@ -21,7 +21,7 @@ import java.util.regex.Pattern;
 import com.thoughtworks.go.util.XmlUtils;
 
 public class FilePathTypeValidator {
-    public static final String PATH_PATTERN = "([^. ].+[^. ])|([^. ][^. ])|([^. ])";
+    public static final String PATH_PATTERN = "(([.]\\/)?[.][^. ]+)|([^. ].+[^. ])|([^. ][^. ])|([^. ])";
     private static final Pattern PATH_PATTERN_REGEX = Pattern.compile(String.format("^(%s)$", PATH_PATTERN));
 
     public boolean isPathValid(String path) {

--- a/config/config-api/test/com/thoughtworks/go/config/materials/PluggableSCMMaterialConfigTest.java
+++ b/config/config-api/test/com/thoughtworks/go/config/materials/PluggableSCMMaterialConfigTest.java
@@ -115,12 +115,12 @@ public class PluggableSCMMaterialConfigTest {
         assertThat(pluggableSCMMaterialConfig.errors().getAll().size(), is(1));
         assertThat(pluggableSCMMaterialConfig.errors().on(PluggableSCMMaterialConfig.FOLDER), is("Dest folder '/usr/home' is not valid. It must be a sub-directory of the working folder."));
 
-        pluggableSCMMaterialConfig = new PluggableSCMMaterialConfig(null, scmConfig, ".crap", null);
+        pluggableSCMMaterialConfig = new PluggableSCMMaterialConfig(null, scmConfig, "./../crap", null);
         pluggableSCMMaterialConfig.setScmId("scm-id");
         pluggableSCMMaterialConfig.validateConcreteMaterial(configSaveValidationContext);
 
-        assertThat(pluggableSCMMaterialConfig.errors().getAll().size(), is(1));
-        assertThat(pluggableSCMMaterialConfig.errors().on(PluggableSCMMaterialConfig.FOLDER), is("Invalid directory name '.crap'. It should be a valid relative path."));
+        assertThat(pluggableSCMMaterialConfig.errors().getAll().size(), is(2));
+        assertThat(pluggableSCMMaterialConfig.errors().on(PluggableSCMMaterialConfig.FOLDER), is("Invalid directory name './../crap'. It should be a valid relative path."));
     }
 
 

--- a/config/config-api/test/com/thoughtworks/go/config/validation/FilePathTypeValidatorTest.java
+++ b/config/config-api/test/com/thoughtworks/go/config/validation/FilePathTypeValidatorTest.java
@@ -39,7 +39,7 @@ public class FilePathTypeValidatorTest {
         assertThat(filePathTypeValidator.isPathValid(".."), is(false));
         assertThat(filePathTypeValidator.isPathValid("../a"), is(false));
         assertThat(filePathTypeValidator.isPathValid(" "), is(false));
-        assertThat(filePathTypeValidator.isPathValid("./a"), is(false));
+        assertThat(filePathTypeValidator.isPathValid("./a"), is(true));
         assertThat(filePathTypeValidator.isPathValid(". "), is(false));
         assertThat(filePathTypeValidator.isPathValid(" ."), is(false));
         assertThat(filePathTypeValidator.isPathValid("abc"), is(true));

--- a/config/config-server/resources/schemas/80_cruise-config.xsd
+++ b/config/config-server/resources/schemas/80_cruise-config.xsd
@@ -76,7 +76,7 @@
                     </xsd:unique>
                 </xsd:element>
             </xsd:sequence>
-            <xsd:attribute name="schemaVersion" type="xsd:int" use="required" fixed="81"/>
+            <xsd:attribute name="schemaVersion" type="xsd:int" use="required" fixed="80"/>
         </xsd:complexType>
         <xsd:unique name="uniquePipelines">
             <xsd:selector xpath="pipelines"/>
@@ -828,7 +828,7 @@
     </xsd:element>
     <xsd:simpleType name="filePathType">
         <xsd:restriction base="xsd:string" xml:space="default">
-            <xsd:pattern value="(([.]\/)?[.][^. ]+)|([^. ].+[^. ])|([^. ][^. ])|([^. ])"/>
+            <xsd:pattern value="([^. ].+[^. ])|([^. ][^. ])|([^. ])"/>
         </xsd:restriction>
     </xsd:simpleType>
     <xsd:complexType name="timerType">

--- a/config/config-server/resources/upgrades/81.xsl
+++ b/config/config-server/resources/upgrades/81.xsl
@@ -1,0 +1,28 @@
+<?xml version="1.0"?>
+<!--
+  ~ Copyright 2016 ThoughtWorks, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+    <xsl:template match="/cruise/@schemaVersion">
+        <xsl:attribute name="schemaVersion">81</xsl:attribute>
+    </xsl:template>
+    <!-- Copy everything -->
+    <xsl:template match="@*|node()">
+        <xsl:copy>
+            <xsl:apply-templates select="@*|node()"/>
+        </xsl:copy>
+    </xsl:template>
+</xsl:stylesheet>

--- a/config/config-server/test/com/thoughtworks/go/config/MagicalGoConfigXmlLoaderTest.java
+++ b/config/config-server/test/com/thoughtworks/go/config/MagicalGoConfigXmlLoaderTest.java
@@ -1176,7 +1176,31 @@ public class MagicalGoConfigXmlLoaderTest {
                         + "    <svn url=\"/hgrepo2\" dest=\"../../..\" />\n"
                         + "  </materials>\n";
         MagicalGoConfigXmlLoaderFixture.assertNotValid(
-                "File path is invalid. \"../../..\" should conform to the pattern - ([^. ].+[^. ])|([^. ][^. ])|([^. ])", materials2);
+                "File path is invalid. \"../../..\" should conform to the pattern - (([.]\\/)?[.][^. ]+)|([^. ].+[^. ])|([^. ][^. ])|([^. ])", materials2);
+    }
+
+    @Test
+    public void shouldAllowPathStartWithDotSlash() throws Exception {
+        String materials =
+                "  <materials>\n"
+                        + "    <svn url=\"/hgrepo2\" dest=\"./folder3\" />\n"
+                        + "  </materials>\n";
+        MagicalGoConfigXmlLoaderFixture.assertValid(materials);
+    }
+
+    @Test
+    public void shouldAllowHiddenFolders() throws Exception {
+        String materials =
+                "  <materials>\n"
+                        + "    <svn url=\"/hgrepo2\" dest=\".folder3\" />\n"
+                        + "  </materials>\n";
+        MagicalGoConfigXmlLoaderFixture.assertValid(materials);
+
+        materials =
+                "  <materials>\n"
+                        + "    <svn url=\"/hgrepo2\" dest=\"./.folder3\" />\n"
+                        + "  </materials>\n";
+        MagicalGoConfigXmlLoaderFixture.assertValid(materials);
     }
 
     @Test

--- a/server/webapp/WEB-INF/rails.new/spec/presenters/api_v1/config/artifact_representer_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/presenters/api_v1/config/artifact_representer_spec.rb
@@ -61,7 +61,7 @@ describe ApiV1::Config::ArtifactRepresenter do
   def test_artifact_with_errors
     {source: nil, destination: '../foo', type: 'test',
      errors: {
-       destination: ['Invalid destination path. Destination path should match the pattern ([^. ].+[^. ])|([^. ][^. ])|([^. ])'],
+       destination: ['Invalid destination path. Destination path should match the pattern (([.]\\/)?[.][^. ]+)|([^. ].+[^. ])|([^. ][^. ])|([^. ])'],
        source:      ["Job 'null' has an artifact with an empty source"]
      }
     }

--- a/server/webapp/WEB-INF/rails.new/spec/presenters/api_v1/config/job_representer_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/presenters/api_v1/config/job_representer_spec.rb
@@ -310,7 +310,7 @@ describe ApiV1::Config::JobRepresenter do
                                {
                                  errors:      {
                                    source:      ["Job 'null' has an artifact with an empty source"],
-                                   destination: ["Invalid destination path. Destination path should match the pattern ([^. ].+[^. ])|([^. ][^. ])|([^. ])"]
+                                   destination: ["Invalid destination path. Destination path should match the pattern (([.]\\/)?[.][^. ]+)|([^. ].+[^. ])|([^. ][^. ])|([^. ])"]
                                  },
                                  source:      nil,
                                  destination: "../foo",


### PR DESCRIPTION
Fix #1900 about hidden directory as working directory issue.

Example:
  allow ".hidden" as working directory.
  allow "./.hidden" as working directory.
  allow "./hello-working-dir" as working directory.
