### PR TITLE
Fix broken pages because of missing require statements.

### DIFF
--- a/server/webapp/WEB-INF/rails.new/Gemfile.lock
+++ b/server/webapp/WEB-INF/rails.new/Gemfile.lock
@@ -10,6 +10,7 @@ PATH
   specs:
     oauth2_provider (1.0.3)
       rails (~> 4.0.4)
+      validatable (>= 1.6.0)
 
 GEM
   remote: https://rubygems.org/

--- a/server/webapp/WEB-INF/rails.new/vendor/engines/oauth2_provider/lib/oauth2_provider/engine.rb
+++ b/server/webapp/WEB-INF/rails.new/vendor/engines/oauth2_provider/lib/oauth2_provider/engine.rb
@@ -10,11 +10,16 @@ require File.expand_path(File.join(File.dirname(__FILE__), 'url_parser'))
 
 module Oauth2Provider
   class Engine < ::Rails::Engine
+    require 'active_model'
+    require 'active_model/validations'
+    require 'active_model/errors'
+    require 'ext/validatable_ext.rb'
+
     isolate_namespace Oauth2Provider
     engine_name 'oauth_engine'
-    
+
     Oauth2Provider::ModelBase.datasource = ENV["OAUTH2_PROVIDER_DATASOURCE"]
-    
+
     config.generators do |g|
       g.test_framework :rspec
       g.fixture_replacement :factory_girl, :dir => 'spec/factories'

--- a/server/webapp/WEB-INF/rails.new/vendor/engines/oauth2_provider/lib/oauth2_provider/validatable_ext.rb
+++ b/server/webapp/WEB-INF/rails.new/vendor/engines/oauth2_provider/lib/oauth2_provider/validatable_ext.rb
@@ -1,0 +1,22 @@
+module ActiveModel
+  class Errors
+    unless method_defined?(:add_without_humanize_options)
+      alias :add_without_humanize_options :add
+      def add(attribute, message, humanized_name=nil) #:nodoc:
+        humanized_names[attribute.to_sym] = humanized_name
+        add_without_humanize_options(attribute, message)
+      end
+
+      def humanize(lower_case_and_underscored_word) #:nodoc:
+        humanized_names[lower_case_and_underscored_word.to_sym] || humanize_without_humanize_options(lower_case_and_underscored_word)
+      end
+
+      alias :humanize_without_humanize_options :humanize
+
+      private
+      def humanized_names
+        @humanized_names ||= {}
+      end
+    end
+  end
+end

--- a/server/webapp/WEB-INF/rails.new/vendor/engines/oauth2_provider/oauth2_provider.gemspec
+++ b/server/webapp/WEB-INF/rails.new/vendor/engines/oauth2_provider/oauth2_provider.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency "rails", "~> 4.0.4"
+  s.add_dependency "validatable", ">=1.6.0"
   s.add_development_dependency "sqlite3"
   s.add_development_dependency "rspec-rails"
   s.add_development_dependency 'capybara'


### PR DESCRIPTION
Some dependencies and monkey patches that the oauth plugin requires were
require`d by the (now disabled) gadget plugin. As a result the oauth
admin pages were broken.

This PR ports the monkey patch and adds the requires in the oauth plugin