### PR TITLE
Make git material checking out working copy only when necessary

### DIFF
--- a/common/src/com/thoughtworks/go/domain/materials/git/GitCommand.java
+++ b/common/src/com/thoughtworks/go/domain/materials/git/GitCommand.java
@@ -59,7 +59,11 @@ public class GitCommand extends SCMCommand {
     // Clone repository from url with specified depth.
     // Special depth 2147483647 (Integer.MAX_VALUE) are treated as full clone
     public int cloneFrom(ProcessOutputStreamConsumer outputStreamConsumer, String url, Integer depth) {
-        CommandLine gitClone = git().withArg("clone").withArg(String.format("--branch=%s", branch));
+        CommandLine gitClone = git()
+                .withArg("clone")
+                .withArg(String.format("--branch=%s", branch))
+                .withArg("--no-checkout");
+
         if(depth < Integer.MAX_VALUE) {
             gitClone.withArg(String.format("--depth=%s", depth));
         }

--- a/common/test/unit/com/thoughtworks/go/domain/materials/git/GitCommandTest.java
+++ b/common/test/unit/com/thoughtworks/go/domain/materials/git/GitCommandTest.java
@@ -268,7 +268,7 @@ public class GitCommandTest {
         GitCommand gitWithSubmodule = new GitCommand(null, createTempWorkingDirectory(), GitMaterialConfig.DEFAULT_BRANCH, false);
         InMemoryStreamConsumer outputStreamConsumer = inMemoryConsumer();
         gitWithSubmodule.cloneFrom(outputStreamConsumer, submoduleRepos.mainRepo().getUrl());
-
+        gitWithSubmodule.fetchAndResetToHead(outputStreamConsumer);
         gitWithSubmodule.updateSubmoduleWithInit(outputStreamConsumer);
         List<String> folders = gitWithSubmodule.submoduleFolders();
         assertThat(folders.size(), is(1));
@@ -299,7 +299,7 @@ public class GitCommandTest {
         GitCommand gitWithSubmodule = new GitCommand(null, createTempWorkingDirectory(), GitMaterialConfig.DEFAULT_BRANCH, false);
         InMemoryStreamConsumer outputStreamConsumer = inMemoryConsumer();
         gitWithSubmodule.cloneFrom(outputStreamConsumer, submoduleRepos.mainRepo().getUrl());
-
+        gitWithSubmodule.fetchAndResetToHead(outputStreamConsumer);
         gitWithSubmodule.updateSubmoduleWithInit(outputStreamConsumer);
         List<String> folders = gitWithSubmodule.submoduleFolders();
         assertThat(folders.size(), is(1));
@@ -313,6 +313,7 @@ public class GitCommandTest {
         GitCommand gitWithSubmodule = new GitCommand(null, createTempWorkingDirectory(), GitMaterialConfig.DEFAULT_BRANCH, false);
         InMemoryStreamConsumer outputStreamConsumer = inMemoryConsumer();
         gitWithSubmodule.cloneFrom(outputStreamConsumer, submoduleRepos.mainRepo().getUrl());
+        gitWithSubmodule.fetchAndResetToHead(outputStreamConsumer);
 
         gitWithSubmodule.updateSubmoduleWithInit(outputStreamConsumer);
         Map<String, String> urls = gitWithSubmodule.submoduleUrls();

--- a/common/test/unit/com/thoughtworks/go/domain/materials/git/GitTestRepo.java
+++ b/common/test/unit/com/thoughtworks/go/domain/materials/git/GitTestRepo.java
@@ -105,6 +105,8 @@ public class GitTestRepo extends TestRepo {
 
         createCommandLine("git").withEncoding("UTF-8").withWorkingDir(workingDir).withArgs("config", "user.name", "go_test").runOrBomb(true, "git_config");
         createCommandLine("git").withEncoding("UTF-8").withWorkingDir(workingDir).withArgs("config", "user.email", "go_test@go_test.me").runOrBomb(true, "git_config");
+
+        git.fetchAndResetToHead(outputStreamConsumer);
     }
 
     private GitCommand git(File workingDir) {


### PR DESCRIPTION
For #1890. This PR helps saving disk space on server and speedup checking out both on server and agent.