### PR TITLE
Fix agent sending websocket message blocking error and wrong order issue

### DIFF
--- a/agent/src/com/thoughtworks/go/agent/AgentController.java
+++ b/agent/src/com/thoughtworks/go/agent/AgentController.java
@@ -243,6 +243,7 @@ public class AgentController {
             sslInfrastructureService.registerIfNecessary(agentAutoRegistrationProperties);
             if (sslInfrastructureService.isRegistered()) {
                 if (!websocketService.isRunning()) {
+                    callbacks.clear();
                     websocketService.start();
                 }
                 updateServerAgentRuntimeInfo();

--- a/agent/src/com/thoughtworks/go/agent/AgentController.java
+++ b/agent/src/com/thoughtworks/go/agent/AgentController.java
@@ -54,9 +54,7 @@ import java.io.IOException;
 import java.security.GeneralSecurityException;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.CountDownLatch;
 
-import static com.thoughtworks.go.util.ExceptionUtils.bomb;
 import static com.thoughtworks.go.util.SystemUtil.currentWorkingDirectory;
 
 @Component
@@ -291,11 +289,7 @@ public class AgentController {
                 sslInfrastructureService.invalidateAgentCertificate();
                 break;
             case ack:
-                String messageId = (String) message.getData();
-                MessageCallback callback = callbacks.remove(messageId);
-                if (callback != null) {
-                    callback.call();
-                }
+                callbacks.remove(message.getData()).call();
                 break;
             default:
                 throw new RuntimeException("Unknown action: " + message.getAction());

--- a/agent/src/com/thoughtworks/go/agent/AgentController.java
+++ b/agent/src/com/thoughtworks/go/agent/AgentController.java
@@ -275,7 +275,7 @@ public class AgentController {
                 runner = new JobRunner();
                 try {
                     runner.run(work, agentIdentifier(),
-                            new AgentWebsocketService.BuildRepositoryRemoteAdapter(runner, websocketService),
+                            websocketService.buildRepositoryRemote(runner),
                             manipulator, agentRuntimeInfo,
                             packageAsRepositoryExtension, scmExtension,
                             taskExtension);

--- a/agent/src/com/thoughtworks/go/agent/service/AgentWebsocketService.java
+++ b/agent/src/com/thoughtworks/go/agent/service/AgentWebsocketService.java
@@ -53,7 +53,7 @@ import static com.thoughtworks.go.util.ExceptionUtils.bomb;
 @Component
 @WebSocket
 public class AgentWebsocketService {
-    public static class BuildRepositoryRemoteAdapter implements BuildRepositoryRemote {
+    private static class BuildRepositoryRemoteAdapter implements BuildRepositoryRemote {
         private JobRunner runner;
         private AgentWebsocketService service;
 
@@ -163,6 +163,9 @@ public class AgentWebsocketService {
         }
     }
 
+    public BuildRepositoryRemote buildRepositoryRemote(JobRunner runner) {
+        return new BuildRepositoryRemoteAdapter(runner, this);
+    }
 
     @OnWebSocketConnect
     public void onConnect(Session session) {
@@ -191,7 +194,7 @@ public class AgentWebsocketService {
 
     @OnWebSocketClose
     public void onClose(int closeCode, String closeReason) {
-        LOGGER.info(sessionName() + " closed.");
+        LOGGER.info("{} closed: {}", sessionName(), closeReason);
     }
 
     @OnWebSocketError

--- a/base/src/com/thoughtworks/go/util/SystemEnvironment.java
+++ b/base/src/com/thoughtworks/go/util/SystemEnvironment.java
@@ -175,6 +175,7 @@ public class SystemEnvironment implements Serializable, ConfigDirProvider {
 
     public static GoSystemProperty<Boolean> WEBSOCKET_ENABLED = new GoBooleanSystemProperty("go.agent.websocket.enabled", true);
     public static GoSystemProperty<Boolean> AUTO_REGISTER_LOCAL_AGENT_ENABLED = new GoBooleanSystemProperty("go.auto.register.local.agent.enabled", true);
+    public static GoSystemProperty<Long> GO_WEBSOCKET_ACK_MESSAGE_TIMEOUT = new GoLongSystemProperty("go.websocket.ack.message.timeout", 300 * 1000L);
 
     public static GoSystemProperty<Long> GO_WEBSOCKET_MAX_IDLE_TIME = new GoLongSystemProperty("go.websocket.max.idle.time", 60 * 1000L);
     public static GoSystemProperty<Boolean> GO_SERVER_SHALLOW_CLONE = new GoBooleanSystemProperty("go.server.shallowClone", true);
@@ -705,6 +706,9 @@ public class SystemEnvironment implements Serializable, ConfigDirProvider {
 
     public Long getWebsocketMaxIdleTime() {
         return GO_WEBSOCKET_MAX_IDLE_TIME.getValue();
+    }
+    public Long getWebsocketAckMessageTimeout() {
+        return GO_WEBSOCKET_ACK_MESSAGE_TIMEOUT.getValue();
     }
 
     public static abstract class GoSystemProperty<T> {

--- a/base/src/com/thoughtworks/go/util/SystemEnvironment.java
+++ b/base/src/com/thoughtworks/go/util/SystemEnvironment.java
@@ -173,7 +173,7 @@ public class SystemEnvironment implements Serializable, ConfigDirProvider {
     public static GoSystemProperty<String> GO_UPDATE_SERVER_URL = new GoStringSystemProperty("go.update.server.url", "https://update.go.cd/channels/supported/latest.json");
     public static GoSystemProperty<Boolean> GO_CHECK_UPDATES = new GoBooleanSystemProperty("go.check.updates", true);
 
-    public static GoSystemProperty<Boolean> WEBSOCKET_ENABLED = new GoBooleanSystemProperty("go.agent.websocket.enabled", false);
+    public static GoSystemProperty<Boolean> WEBSOCKET_ENABLED = new GoBooleanSystemProperty("go.agent.websocket.enabled", true);
     public static GoSystemProperty<Boolean> AUTO_REGISTER_LOCAL_AGENT_ENABLED = new GoBooleanSystemProperty("go.auto.register.local.agent.enabled", true);
 
     public static GoSystemProperty<Long> GO_WEBSOCKET_MAX_IDLE_TIME = new GoLongSystemProperty("go.websocket.max.idle.time", 60 * 1000L);

--- a/common/src/com/thoughtworks/go/websocket/Message.java
+++ b/common/src/com/thoughtworks/go/websocket/Message.java
@@ -19,6 +19,7 @@ package com.thoughtworks.go.websocket;
 import org.apache.commons.io.output.ByteArrayOutputStream;
 
 import java.io.*;
+import java.util.UUID;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
 
@@ -57,6 +58,7 @@ public class Message implements Serializable {
 
     private final Action action;
     private final Object data;
+    private String ackId;
 
     public Message(Action action) {
         this(action, null);
@@ -75,11 +77,16 @@ public class Message implements Serializable {
         return data;
     }
 
+    public String getAckId() {
+        return ackId;
+    }
+
     @Override
     public String toString() {
         return "Message{" +
                 "action=" + action +
                 ", data=" + data +
+                ", ackId=" + ackId +
                 '}';
     }
 
@@ -91,15 +98,20 @@ public class Message implements Serializable {
         Message message = (Message) o;
 
         if (action != message.action) return false;
-        return data != null ? data.equals(message.data) : message.data == null;
+        if (data != null ? !data.equals(message.data) : message.data != null) return false;
+        return ackId != null ? ackId.equals(message.ackId) : message.ackId == null;
 
     }
 
     @Override
     public int hashCode() {
-        int result = action != null ? action.hashCode() : 0;
+        int result = action.hashCode();
         result = 31 * result + (data != null ? data.hashCode() : 0);
+        result = 31 * result + (ackId != null ? ackId.hashCode() : 0);
         return result;
     }
 
+    public void generateAckId() {
+        this.ackId = UUID.randomUUID().toString();
+    }
 }

--- a/common/src/com/thoughtworks/go/websocket/MessageCallback.java
+++ b/common/src/com/thoughtworks/go/websocket/MessageCallback.java
@@ -16,10 +16,6 @@
 
 package com.thoughtworks.go.websocket;
 
-public enum Action {
-    assignWork,
-    cancelJob,
-    ping,
-    reregister,
-    reportCurrentStatus, reportCompleted, reportCompleting, ack, setCookie
+public interface MessageCallback {
+    void call();
 }

--- a/server/test/unit/com/thoughtworks/go/server/websocket/AgentRemoteHandlerTest.java
+++ b/server/test/unit/com/thoughtworks/go/server/websocket/AgentRemoteHandlerTest.java
@@ -201,4 +201,20 @@ public class AgentRemoteHandlerTest {
         assertNotEquals(cookie, info.getCookie());
         assertEquals("new cookie", info.getCookie());
     }
+
+    @Test
+    public void shouldSendBackAnAckMessageIfMessageHasAckId() {
+        AgentInstance instance = AgentInstanceMother.idle();
+        AgentRuntimeInfo info = new AgentRuntimeInfo(instance.getAgentIdentifier(), AgentRuntimeStatus.Idle, null, null, null);
+        info.setCookie("cookie");
+        when(remote.ping(info)).thenReturn(new AgentInstruction(false));
+        when(agentService.findAgent(instance.getUuid())).thenReturn(instance);
+
+        Message msg = new Message(Action.ping, info);
+        msg.generateAckId();
+        handler.process(agent, msg);
+        assertEquals(1, agent.messages.size());
+        assertEquals(Action.ack, agent.messages.get(0).getAction());
+        assertEquals(msg.getAckId(), agent.messages.get(0).getData().toString());
+    }
 }

--- a/server/webapp/WEB-INF/applicationContext-acegi-security.xml
+++ b/server/webapp/WEB-INF/applicationContext-acegi-security.xml
@@ -212,7 +212,7 @@
                 CONVERT_URL_TO_LOWERCASE_BEFORE_COMPARISON
                 PATTERN_TYPE_APACHE_ANT
                 /remoting/**=ROLE_AGENT
-                /aws/**=ROLE_AGENT
+                /agent-websocket/**=ROLE_AGENT
             ]]></value>
         </property>
     </bean>


### PR DESCRIPTION
Add synch sending message support, server will send back an ack message if a message had ackId.
All agent messages will be sent with ack id, hence agent report current job status will wait until server responsed message is processed. The reason we need this change is because we need save job state in right order (preparing, building, completing and completed) on server side when agent reported status.

Notice: this pull request has a change to enable agent websocket communication by default (a756b0a). Please only revert change a756b0a when AC builds continue to fail after merged.
