### PR TITLE
update the link to how to set up your development environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 This is the main repository for Go Continuous Delivery. Go helps you automate and streamline the build-test-release cycle for worry-free, continuous delivery of your product.
 
-This is a Java/JRuby on Rails project. Here is the guide to setup your [development environment](https://github.com/gocd/documentation/blob/master/developer/2/2.1.md).
+This is a Java/JRuby on Rails project. Here is the guide to setup your [development environment](https://developer.go.cd/current/2/2.1.html).
 
 All information to help you get started with Go can be found on the <a href="http://www.go.cd/">go.cd</a> website.
 


### PR DESCRIPTION
Maybe this pr is too trivial. So, feel free to drop it. I just updated the link to how to set up your development environment. The original link was not any longer working.

I linked to https://developer.go.cd/current/2/2.1.html, so that people can easily browse related content.