### PR TITLE
Adapt ServerCall to respect the Proxy system properties.

### DIFF
--- a/agent-common/pom.xml
+++ b/agent-common/pom.xml
@@ -51,6 +51,14 @@
     </dependencies>
 
     <build>
+        <testResources>
+            <testResource>
+                <directory>test</directory>
+                <includes>
+                    <include>**/proxy.properties</include>
+                </includes>
+            </testResource>
+        </testResources>
         <sourceDirectory>src</sourceDirectory>
         <testSourceDirectory>test</testSourceDirectory>
         <finalName>agent-common</finalName>

--- a/agent-common/src/com/thoughtworks/go/agent/launcher/ProxyConfigurator.java
+++ b/agent-common/src/com/thoughtworks/go/agent/launcher/ProxyConfigurator.java
@@ -74,7 +74,8 @@ public class ProxyConfigurator {
      * @param httpProxyPort     - http.proxyPort from System.properties
      * @param httpsProxyHost    - https.proxyHost from System.properties
      * @param httpsProxyPort    - https.proxyPort from System.properties
-     * @param nonProxyHosts     - nonProxyHosts from System.properties  @return the ProxyHost to be used or null
+     * @param nonProxyHosts     - nonProxyHosts from System.properties
+     * @return the ProxyHost to be used or null
      */
     public static ProxyHost create(final HttpMethod method, final String httpProxyHost, final String httpProxyPort, final String httpsProxyHost, final String httpsProxyPort, final String nonProxyHosts) {
         final String scheme;
@@ -96,5 +97,23 @@ public class ProxyConfigurator {
         } else {
             return null;
         }
+    }
+
+    /**
+     * Creates a {@link ProxyHost} for the given method or null
+     * when the properties are not set or the host of the method
+     * matches nonProxyHosts.
+     *
+     * @param method            - called HttpMethod
+     * @param properties        - propeties
+     * @return the ProxyHost to be used or null
+     */
+    public static ProxyHost create(final HttpMethod method, final Properties properties) {
+        final String httpProxyHost = properties.getProperty("http.proxyHost");
+        final String httpProxyPort = properties.getProperty("http.proxyPort");
+        final String httpsProxyHost = properties.getProperty("https.proxyHost");
+        final String httpsProxyPort = properties.getProperty("https.proxyPort");
+        final String nonProxyHosts = properties.getProperty("http.nonProxyHosts");
+        return create(method, httpProxyHost, httpProxyPort, httpsProxyHost, httpsProxyPort, nonProxyHosts);
     }
 }

--- a/agent-common/src/com/thoughtworks/go/agent/launcher/ProxyConfigurator.java
+++ b/agent-common/src/com/thoughtworks/go/agent/launcher/ProxyConfigurator.java
@@ -1,0 +1,87 @@
+/*************************GO-LICENSE-START*********************************
+ * Copyright 2016 Mirko Friedenhagen.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *************************GO-LICENSE-END***********************************/
+
+package com.thoughtworks.go.agent.launcher;
+
+import org.apache.commons.httpclient.HttpMethod;
+import org.apache.commons.httpclient.ProxyHost;
+import org.apache.commons.httpclient.URI;
+import org.apache.commons.httpclient.URIException;
+
+import java.util.*;
+
+/**
+ * Proxy Configurator for {@link ServerCall}.
+ */
+public class ProxyConfigurator {
+
+    private final HttpMethod method;
+    private final String proxyHost;
+    private final int proxyPort;
+    private final String nonProxyHosts;
+
+    private ProxyConfigurator(final HttpMethod method, String proxyHost, int proxyPort, String nonProxyHosts) {
+        this.method = method;
+        this.proxyHost = proxyHost;
+        this.proxyPort = proxyPort;
+        this.nonProxyHosts = nonProxyHosts;
+    }
+
+    private ProxyHost getProxy() {
+        final ProxyHost proxyHost = new ProxyHost(this.proxyHost, proxyPort);
+        final String host;
+        try {
+            final URI uri = method.getURI();
+            host = uri.getHost();
+        } catch (URIException e) {
+            throw new RuntimeException(e);
+        }
+        final Set<String> nonProxySet;
+        if (nonProxyHosts != null) {
+            final List<String> strings = Arrays.asList(nonProxyHosts.split("\\|"));
+            nonProxySet = new HashSet<>(strings);
+        } else {
+            nonProxySet = Collections.emptySet();
+        }
+        for (String nonProxy : nonProxySet) {
+            if (nonProxy.contains("*.") && host.endsWith(nonProxy.substring(2))) {
+                return null;
+            }
+        }
+        return nonProxySet.contains(host) ? null : proxyHost;
+    }
+
+    /**
+     * Creates a {@link ProxyHost} for the given method or null
+     * when the properties are not set or the host of the method
+     * matches nonProxyHosts.
+     *
+     * @param method        - called HttpMethod
+     * @param proxyHost     - proxyHost from System.properties
+     * @param proxyPort     - proxyPort from System.properties
+     * @param nonProxyHosts - nonProxyHosts from System.properties
+     * @return the ProxyHost to be used or null
+     */
+    public static ProxyHost create(final HttpMethod method, String proxyHost, String proxyPort, String nonProxyHosts) {
+        if (method == null || proxyHost == null || proxyPort == null) {
+            return null;
+        } else {
+            final ProxyConfigurator proxyConfigurator = new ProxyConfigurator(
+                    method, proxyHost, Integer.valueOf(proxyPort), nonProxyHosts);
+            return proxyConfigurator.getProxy();
+        }
+    }
+}

--- a/agent-common/src/com/thoughtworks/go/agent/launcher/ServerBinaryDownloader.java
+++ b/agent-common/src/com/thoughtworks/go/agent/launcher/ServerBinaryDownloader.java
@@ -168,6 +168,8 @@ public class ServerBinaryDownloader implements Downloader {
     private boolean download() throws Exception {
         HttpClient httpClient = new HttpClient();
         HttpMethod method = new GetMethod(checkUrl());
+        httpClient.getHostConfiguration().setProxyHost(
+                ProxyConfigurator.create(method, System.getProperties()));
         InputStream body = null;
         OutputStream outputFile = null;
         httpClient.setConnectionTimeout(ServerCall.HTTP_TIMEOUT_IN_MILLISECONDS);

--- a/agent-common/src/com/thoughtworks/go/agent/launcher/ServerCall.java
+++ b/agent-common/src/com/thoughtworks/go/agent/launcher/ServerCall.java
@@ -45,6 +45,11 @@ public class ServerCall {
         HashMap<String, String> headers = new HashMap<String, String>();
         HttpClient httpClient = new HttpClient();
         httpClient.setConnectionTimeout(HTTP_TIMEOUT_IN_MILLISECONDS);
+        final String proxyHost = System.getProperty("http.proxyHost");
+        final String proxyPort = System.getProperty("http.proxyPort");
+        final String nonProxyHosts = System.getProperty("http.nonProxyHosts");
+        httpClient.getHostConfiguration().setProxyHost(
+                ProxyConfigurator.create(method, proxyHost, proxyPort, nonProxyHosts));
         try {
             final int status = httpClient.executeMethod(method);
             if (status == HttpStatus.SC_NOT_FOUND) {

--- a/agent-common/src/com/thoughtworks/go/agent/launcher/ServerCall.java
+++ b/agent-common/src/com/thoughtworks/go/agent/launcher/ServerCall.java
@@ -45,11 +45,13 @@ public class ServerCall {
         HashMap<String, String> headers = new HashMap<String, String>();
         HttpClient httpClient = new HttpClient();
         httpClient.setConnectionTimeout(HTTP_TIMEOUT_IN_MILLISECONDS);
-        final String proxyHost = System.getProperty("http.proxyHost");
-        final String proxyPort = System.getProperty("http.proxyPort");
+        final String httpProxyHost = System.getProperty("http.proxyHost");
+        final String httpProxyPort = System.getProperty("http.proxyPort");
+        final String httpsProxyHost = System.getProperty("https.proxyHost");
+        final String httpsProxyPort = System.getProperty("https.proxyPort");
         final String nonProxyHosts = System.getProperty("http.nonProxyHosts");
         httpClient.getHostConfiguration().setProxyHost(
-                ProxyConfigurator.create(method, proxyHost, proxyPort, nonProxyHosts));
+                ProxyConfigurator.create(method, httpProxyHost, httpProxyPort, httpsProxyHost, httpsProxyPort, nonProxyHosts));
         try {
             final int status = httpClient.executeMethod(method);
             if (status == HttpStatus.SC_NOT_FOUND) {

--- a/agent-common/src/com/thoughtworks/go/agent/launcher/ServerCall.java
+++ b/agent-common/src/com/thoughtworks/go/agent/launcher/ServerCall.java
@@ -45,13 +45,8 @@ public class ServerCall {
         HashMap<String, String> headers = new HashMap<String, String>();
         HttpClient httpClient = new HttpClient();
         httpClient.setConnectionTimeout(HTTP_TIMEOUT_IN_MILLISECONDS);
-        final String httpProxyHost = System.getProperty("http.proxyHost");
-        final String httpProxyPort = System.getProperty("http.proxyPort");
-        final String httpsProxyHost = System.getProperty("https.proxyHost");
-        final String httpsProxyPort = System.getProperty("https.proxyPort");
-        final String nonProxyHosts = System.getProperty("http.nonProxyHosts");
         httpClient.getHostConfiguration().setProxyHost(
-                ProxyConfigurator.create(method, httpProxyHost, httpProxyPort, httpsProxyHost, httpsProxyPort, nonProxyHosts));
+                ProxyConfigurator.create(method, System.getProperties()));
         try {
             final int status = httpClient.executeMethod(method);
             if (status == HttpStatus.SC_NOT_FOUND) {

--- a/agent-common/test/com/thoughtworks/go/agent/launcher/ProxyConfiguratorTest.java
+++ b/agent-common/test/com/thoughtworks/go/agent/launcher/ProxyConfiguratorTest.java
@@ -44,41 +44,41 @@ public class ProxyConfiguratorTest {
 
     @Test
     public void shouldReturnProxyHost() throws IOException {
-        final Properties properties = readProperties();
-        properties.remove("http.nonProxyHosts");
-        final ProxyHost httpProxy = ProxyConfigurator.create(HTTP_METHOD, properties);
+        final Properties proxyProperties = readProxyProperties();
+        proxyProperties.remove("http.nonProxyHosts");
+        final ProxyHost httpProxy = ProxyConfigurator.create(HTTP_METHOD, proxyProperties);
         assertThat(httpProxy.getHostName(), is(HTTP_PROXY_HOST));
         assertThat(httpProxy.getPort(), is(Integer.valueOf(HTTP_PROXY_PORT)));
-        final ProxyHost httpsProxy = ProxyConfigurator.create(HTTPS_METHOD, properties);
+        final ProxyHost httpsProxy = ProxyConfigurator.create(HTTPS_METHOD, proxyProperties);
         assertThat(httpsProxy.getHostName(), is(HTTPS_PROXY_HOST));
         assertThat(httpsProxy.getPort(), is(Integer.valueOf(HTTPS_PROXY_PORT)));
     }
 
     @Test
     public void shouldReturnProxyHostWhenHostDoesNotMatchNonProxyHosts() throws IOException {
-        final Properties properties = readProperties();
-        properties.setProperty("http.nonProxyHosts", "www.example.org");
-        final ProxyHost httpProxy = ProxyConfigurator.create(HTTP_METHOD, properties);
+        final Properties proxyProperties = readProxyProperties();
+        proxyProperties.setProperty("http.nonProxyHosts", "www.example.org");
+        final ProxyHost httpProxy = ProxyConfigurator.create(HTTP_METHOD, proxyProperties);
         assertThat(httpProxy.getHostName(), is(HTTP_PROXY_HOST));
         assertThat(httpProxy.getPort(), is(Integer.valueOf(HTTP_PROXY_PORT)));
     }
 
     @Test
     public void shouldReturnNullWhenHostIsInNonProxyHosts() throws IOException {
-        final Properties properties = readProperties();
-        properties.setProperty("http.nonProxyHosts", NON_PROXY_HOSTS);
-        assertNull(ProxyConfigurator.create(HTTP_METHOD, properties));
-        assertNull(ProxyConfigurator.create(HTTPS_METHOD, properties));
+        final Properties proxyProperties = readProxyProperties();
+        proxyProperties.setProperty("http.nonProxyHosts", NON_PROXY_HOSTS);
+        assertNull(ProxyConfigurator.create(HTTP_METHOD, proxyProperties));
+        assertNull(ProxyConfigurator.create(HTTPS_METHOD, proxyProperties));
     }
 
     @Test
     public void shouldReturnNullWhenHostMatchesNonProxyHosts() throws IOException {
-        final Properties properties = readProperties();
-        assertNull(ProxyConfigurator.create(HTTP_METHOD, properties));
-        assertNull(ProxyConfigurator.create(HTTPS_METHOD, properties));
+        final Properties proxyProperties = readProxyProperties();
+        assertNull(ProxyConfigurator.create(HTTP_METHOD, proxyProperties));
+        assertNull(ProxyConfigurator.create(HTTPS_METHOD, proxyProperties));
     }
 
-    private Properties readProperties() throws IOException {
+    private Properties readProxyProperties() throws IOException {
         final Properties properties = new Properties();
         try (final InputStream stream = ProxyConfiguratorTest.class.getResourceAsStream("proxy.properties")) {
             properties.load(stream);

--- a/agent-common/test/com/thoughtworks/go/agent/launcher/ProxyConfiguratorTest.java
+++ b/agent-common/test/com/thoughtworks/go/agent/launcher/ProxyConfiguratorTest.java
@@ -16,38 +16,53 @@
 
 package com.thoughtworks.go.agent.launcher;
 
-import org.apache.commons.httpclient.HttpMethod;
+import org.apache.commons.httpclient.ProxyHost;
 import org.apache.commons.httpclient.methods.GetMethod;
 import org.junit.Test;
 
+import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.*;
 
 public class ProxyConfiguratorTest {
 
-    final GetMethod method = new GetMethod("http://www.example.com/foo");
+    private static final String HTTP_PROXY_HOST = "httpproxy.example.org";
+    private static final String HTTP_PROXY_PORT = "3128";
+    private static final String HTTPS_PROXY_HOST = "httpsproxy.example.org";
+    private static final String HTTPS_PROXY_PORT = "3129";
+    private static final GetMethod HTTP_METHOD = new GetMethod("http://www.example.com/foo");
+    private static final GetMethod HTTPS_METHOD = new GetMethod("https://www.example.com/foo");
 
     @Test
     public void shouldReturnNullIfRequiredVariablesAreNotSet() {
-        assertNull(ProxyConfigurator.create(method, null, null, null));
+        assertNull(ProxyConfigurator.create(HTTP_METHOD, null, null, null, null, null));
     }
 
     @Test
     public void shouldReturnProxyHost() {
-        assertNotNull(ProxyConfigurator.create(method, "proxy.example.org", "3128", null));
+        final ProxyHost httpProxy = ProxyConfigurator.create(HTTP_METHOD, HTTP_PROXY_HOST, HTTP_PROXY_PORT, null, null, null);
+        assertThat(httpProxy.getHostName(), is(HTTP_PROXY_HOST));
+        assertThat(httpProxy.getPort(), is(Integer.valueOf(HTTP_PROXY_PORT)));
+        final ProxyHost httpsProxy = ProxyConfigurator.create(HTTPS_METHOD, null, null, HTTPS_PROXY_HOST, HTTPS_PROXY_PORT, null);
+        assertThat(httpsProxy.getHostName(), is(HTTPS_PROXY_HOST));
+        assertThat(httpsProxy.getPort(), is(Integer.valueOf(HTTPS_PROXY_PORT)));
     }
 
     @Test
     public void shouldReturnProxyHostWhenHostDoesNotMatchNonProxyHosts() {
-        assertNotNull(ProxyConfigurator.create(method, "proxy.example.org", "3128", "www.example.org"));
+        final ProxyHost httpProxy = ProxyConfigurator.create(HTTP_METHOD, HTTP_PROXY_HOST, HTTP_PROXY_PORT, null, null, "www.example.org");
+        assertThat(httpProxy.getHostName(), is(HTTP_PROXY_HOST));
+        assertThat(httpProxy.getPort(), is(Integer.valueOf(HTTP_PROXY_PORT)));
     }
 
     @Test
     public void shouldReturnNullWhenHostIsInNonProxyHosts() {
-        assertNull(ProxyConfigurator.create(method, "proxy.example.org", "3128", "www.example.com|example.org"));
+        assertNull(ProxyConfigurator.create(HTTP_METHOD, HTTP_PROXY_HOST, HTTP_PROXY_PORT, null, null, "www.example.com|example.org"));
+        assertNull(ProxyConfigurator.create(HTTPS_METHOD, null, null, HTTPS_PROXY_HOST, HTTPS_PROXY_PORT, "www.example.com|example.org"));
     }
 
     @Test
     public void shouldReturnNullWhenHostMatchesNonProxyHosts() {
-        assertNull(ProxyConfigurator.create(method, "proxy.example.org", "3128", "*.example.com|example.org"));
+        assertNull(ProxyConfigurator.create(HTTP_METHOD, HTTP_PROXY_HOST, HTTP_PROXY_PORT, null, null, "*.example.com|example.org"));
+        assertNull(ProxyConfigurator.create(HTTPS_METHOD, null, null, HTTPS_PROXY_HOST, HTTPS_PROXY_PORT, "*.example.com|example.org"));
     }
 }

--- a/agent-common/test/com/thoughtworks/go/agent/launcher/ProxyConfiguratorTest.java
+++ b/agent-common/test/com/thoughtworks/go/agent/launcher/ProxyConfiguratorTest.java
@@ -1,0 +1,53 @@
+/*************************GO-LICENSE-START*********************************
+ * Copyright 2016 Mirko Friedenhagen.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *************************GO-LICENSE-END***********************************/
+
+package com.thoughtworks.go.agent.launcher;
+
+import org.apache.commons.httpclient.HttpMethod;
+import org.apache.commons.httpclient.methods.GetMethod;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class ProxyConfiguratorTest {
+
+    final GetMethod method = new GetMethod("http://www.example.com/foo");
+
+    @Test
+    public void shouldReturnNullIfRequiredVariablesAreNotSet() {
+        assertNull(ProxyConfigurator.create(method, null, null, null));
+    }
+
+    @Test
+    public void shouldReturnProxyHost() {
+        assertNotNull(ProxyConfigurator.create(method, "proxy.example.org", "3128", null));
+    }
+
+    @Test
+    public void shouldReturnProxyHostWhenHostDoesNotMatchNonProxyHosts() {
+        assertNotNull(ProxyConfigurator.create(method, "proxy.example.org", "3128", "www.example.org"));
+    }
+
+    @Test
+    public void shouldReturnNullWhenHostIsInNonProxyHosts() {
+        assertNull(ProxyConfigurator.create(method, "proxy.example.org", "3128", "www.example.com|example.org"));
+    }
+
+    @Test
+    public void shouldReturnNullWhenHostMatchesNonProxyHosts() {
+        assertNull(ProxyConfigurator.create(method, "proxy.example.org", "3128", "*.example.com|example.org"));
+    }
+}

--- a/agent-common/test/com/thoughtworks/go/agent/launcher/proxy.properties
+++ b/agent-common/test/com/thoughtworks/go/agent/launcher/proxy.properties
@@ -1,0 +1,5 @@
+http.proxyHost=httpproxy.example.org
+http.proxyPort=3128
+https.proxyHost=httpsproxy.example.org
+https.proxyPort=3129
+http.nonProxyHosts=*.example.com|example.org


### PR DESCRIPTION
ServerCall should respect the Proxy system properties.
For more information, see https://docs.oracle.com/javase/8/docs/technotes/guides/net/proxies.html