### PR TITLE
 fixed : Spaces are trimmed from environment variables, issue : 1411

### DIFF
--- a/config/config-api/src/com/thoughtworks/go/config/EnvironmentVariableConfig.java
+++ b/config/config-api/src/com/thoughtworks/go/config/EnvironmentVariableConfig.java
@@ -71,8 +71,8 @@ public class EnvironmentVariableConfig extends PersistentObject implements Seria
 
     public EnvironmentVariableConfig(GoCipher goCipher, String name, String value, boolean isSecure) {
         this(goCipher);
-        this.name = name;
         this.isSecure = isSecure;
+        setName(name);
         setValue(value);
     }
 
@@ -140,7 +140,7 @@ public class EnvironmentVariableConfig extends PersistentObject implements Seria
     }
 
     public void setName(String name) {
-        this.name = name;
+        this.name = name.trim();
     }
 
     void addTo(EnvironmentVariableContext context) {
@@ -275,7 +275,7 @@ public class EnvironmentVariableConfig extends PersistentObject implements Seria
 
     public void setConfigAttributes(Object attributes) {
         Map attributeMap = (Map) attributes;
-        this.name = (String) attributeMap.get(EnvironmentVariableConfig.NAME);
+        setName((String) attributeMap.get(EnvironmentVariableConfig.NAME));
         String value = (String) attributeMap.get(EnvironmentVariableConfig.VALUE);
         if (StringUtil.isBlank(name) && StringUtil.isBlank(value)) {
             throw new IllegalArgumentException(String.format("Need not null/empty name & value %s:%s", this.name, value));

--- a/config/config-api/src/com/thoughtworks/go/util/command/EnvironmentVariableContext.java
+++ b/config/config-api/src/com/thoughtworks/go/util/command/EnvironmentVariableContext.java
@@ -111,11 +111,11 @@ public class EnvironmentVariableContext implements Serializable {
     }
 
     public void setProperty(String key, String value, boolean isSecure) {
-        properties.add(new EnvironmentVariable(key, value, isSecure));
+        properties.add(new EnvironmentVariable(key.trim(), value, isSecure));
     }
 
     public void setPropertyWithEscape(String key, String value) {
-        properties.add(new EnvironmentVariable(escapeEnvironmentVariable(key), value));
+        properties.add(new EnvironmentVariable(escapeEnvironmentVariable(key.trim()), value));
     }
 
     public String getProperty(String key) {

--- a/config/config-api/test/com/thoughtworks/go/config/EnvironmentVariableConfigTest.java
+++ b/config/config-api/test/com/thoughtworks/go/config/EnvironmentVariableConfigTest.java
@@ -49,6 +49,13 @@ public class EnvironmentVariableConfigTest {
     }
 
     @Test
+    public void setNameShouldTrimTheNameBeforeSetting() throws Exception {
+        EnvironmentVariableConfig environmentVariableConfig = new EnvironmentVariableConfig();
+        environmentVariableConfig.setName("foo ");
+        assertThat(environmentVariableConfig.getName(), is("foo"));
+    }
+    
+    @Test
     public void shouldEncryptValueWhenConstructedAsSecure() throws InvalidCipherTextException {
         GoCipher goCipher = mock(GoCipher.class);
         String encryptedText = "encrypted";

--- a/config/config-api/test/com/thoughtworks/go/util/command/EnvironmentVariableContextTest.java
+++ b/config/config-api/test/com/thoughtworks/go/util/command/EnvironmentVariableContextTest.java
@@ -28,6 +28,7 @@ import static org.junit.Assert.assertThat;
 
 public class EnvironmentVariableContextTest {
     private static final String PROPERTY_NAME = "PROPERTY_NAME";
+    private static final String PROPERTY_NAME_WITH_END_SPACE = "PROPERTY_NAME ";
     private static final String PROPERTY_VALUE = "property value";
     private static final String NEW_VALUE = "new value";
 
@@ -35,6 +36,13 @@ public class EnvironmentVariableContextTest {
     public void shouldBeAbleToAddProperties() {
         EnvironmentVariableContext context = new EnvironmentVariableContext();
         context.setProperty(PROPERTY_NAME, PROPERTY_VALUE, false);
+        assertThat(context.getProperty(PROPERTY_NAME), is(PROPERTY_VALUE));
+    }
+
+    @Test
+    public void shouldBeAbleToTrimPropertiesBeforeAdding() {
+        EnvironmentVariableContext context = new EnvironmentVariableContext();
+        context.setProperty(PROPERTY_NAME_WITH_END_SPACE, PROPERTY_VALUE, false);
         assertThat(context.getProperty(PROPERTY_NAME), is(PROPERTY_VALUE));
     }
 
@@ -66,6 +74,7 @@ public class EnvironmentVariableContextTest {
         assertThat(report.get(0), is("[go] setting environment variable 'PROPERTY_NAME' to value 'property value'"));
         assertThat(report.get(1), is("[go] overriding environment variable 'PROPERTY_NAME' with value 'new value'"));
     }
+
 
     @Test
     public void shouldMaskOverRiddenSecureVariable() {


### PR DESCRIPTION
    Trailing spaces removed from the name of the environment variable.
    If the env variable is already present it will override the old one.

    Files Modified:
      modified: config/config-api/src/com/thoughtworks/go/util/command/EnvironmentVariableContext.java
      modified: config/config-api/test/com/thoughtworks/go/util/command/EnvironmentVariableContextTest.java