### PR TITLE
Build command API main process implementation

### DIFF
--- a/agent/src/com/thoughtworks/go/agent/AgentController.java
+++ b/agent/src/com/thoughtworks/go/agent/AgentController.java
@@ -19,10 +19,12 @@ package com.thoughtworks.go.agent;
 import com.thoughtworks.go.agent.service.AgentUpgradeService;
 import com.thoughtworks.go.agent.service.AgentWebsocketService;
 import com.thoughtworks.go.agent.service.SslInfrastructureService;
+import com.thoughtworks.go.buildsession.BuildVariables;
 import com.thoughtworks.go.config.AgentAutoRegistrationProperties;
 import com.thoughtworks.go.config.AgentRegistry;
-import com.thoughtworks.go.domain.AgentRuntimeStatus;
-import com.thoughtworks.go.domain.AgentStatus;
+import com.thoughtworks.go.domain.*;
+import com.thoughtworks.go.buildsession.ArtifactsRepository;
+import com.thoughtworks.go.buildsession.BuildSession;
 import com.thoughtworks.go.domain.exception.UnregisteredAgentException;
 import com.thoughtworks.go.plugin.access.packagematerial.PackageAsRepositoryExtension;
 import com.thoughtworks.go.plugin.access.pluggabletask.TaskExtension;
@@ -33,16 +35,18 @@ import com.thoughtworks.go.publishers.GoArtifactsManipulator;
 import com.thoughtworks.go.remote.AgentIdentifier;
 import com.thoughtworks.go.remote.AgentInstruction;
 import com.thoughtworks.go.remote.BuildRepositoryRemote;
+import com.thoughtworks.go.remote.work.ConsoleOutputTransmitter;
 import com.thoughtworks.go.remote.work.NoWork;
+import com.thoughtworks.go.remote.work.RemoteConsoleAppender;
 import com.thoughtworks.go.remote.work.Work;
+import com.thoughtworks.go.server.service.AgentBuildingInfo;
 import com.thoughtworks.go.server.service.AgentRuntimeInfo;
 import com.thoughtworks.go.server.service.ElasticAgentRuntimeInfo;
-import com.thoughtworks.go.util.SubprocessLogger;
-import com.thoughtworks.go.util.SystemEnvironment;
-import com.thoughtworks.go.util.SystemUtil;
+import com.thoughtworks.go.util.*;
 import com.thoughtworks.go.websocket.Action;
 import com.thoughtworks.go.websocket.Message;
 import com.thoughtworks.go.websocket.MessageCallback;
+import com.thoughtworks.go.websocket.MessageEncoding;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -54,6 +58,8 @@ import java.io.IOException;
 import java.security.GeneralSecurityException;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static com.thoughtworks.go.util.SystemUtil.currentWorkingDirectory;
 
@@ -78,19 +84,22 @@ public class AgentController {
     private SCMExtension scmExtension;
     private TaskExtension taskExtension;
     private AgentWebsocketService websocketService;
+    private final HttpService httpService;
     private final AgentAutoRegistrationPropertiesImpl agentAutoRegistrationProperties;
     private final Map<String, MessageCallback> callbacks = new ConcurrentHashMap<>();
+    private AtomicReference<BuildSession> buildSession = new AtomicReference<>();
 
     @Autowired
     public AgentController(BuildRepositoryRemote server, GoArtifactsManipulator manipulator, SslInfrastructureService sslInfrastructureService, AgentRegistry agentRegistry,
                            AgentUpgradeService agentUpgradeService, SubprocessLogger subprocessLogger, SystemEnvironment systemEnvironment,
                            PluginManager pluginManager, PackageAsRepositoryExtension packageAsRepositoryExtension, SCMExtension scmExtension, TaskExtension taskExtension,
-                           AgentWebsocketService websocketService) {
+                           AgentWebsocketService websocketService, HttpService httpService) {
         this.agentUpgradeService = agentUpgradeService;
         this.packageAsRepositoryExtension = packageAsRepositoryExtension;
         this.scmExtension = scmExtension;
         this.taskExtension = taskExtension;
         this.websocketService = websocketService;
+        this.httpService = httpService;
         ipAddress = SystemUtil.getFirstLocalNonLoopbackIpAddress();
         hostName = SystemUtil.getLocalhostNameOrRandomNameIfNotFound();
         this.server = server;
@@ -108,10 +117,12 @@ public class AgentController {
         createPipelinesFolderIfNotExist();
         sslInfrastructureService.createSslInfrastructure();
         AgentIdentifier identifier = agentIdentifier();
+        Boolean buildCommandProtocolEnabled = new SystemEnvironment().get(SystemEnvironment.ENABLE_BUILD_COMMAND_PROTOCOL);
+
         if (agentAutoRegistrationProperties.isElastic()) {
             agentRuntimeInfo = ElasticAgentRuntimeInfo.fromAgent(identifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), systemEnvironment.getAgentLauncherVersion(), agentAutoRegistrationProperties.agentAutoRegisterElasticAgentId(), agentAutoRegistrationProperties.agentAutoRegisterElasticPluginId());
         } else {
-            agentRuntimeInfo = AgentRuntimeInfo.fromAgent(identifier, AgentStatus.Idle.getRuntimeStatus(), currentWorkingDirectory(), systemEnvironment.getAgentLauncherVersion());
+            agentRuntimeInfo = AgentRuntimeInfo.fromAgent(identifier, AgentStatus.Idle.getRuntimeStatus(), currentWorkingDirectory(), systemEnvironment.getAgentLauncherVersion(), buildCommandProtocolEnabled);
         }
 
         subprocessLogger.registerAsExitHook("Following processes were alive at shutdown: ");
@@ -263,13 +274,13 @@ public class AgentController {
                 cancelJobIfThereIsOneRunning();
                 break;
             case setCookie:
-                String cookie = (String) message.getData();
+                String cookie = MessageEncoding.decodeData(message.getData(), String.class);
                 agentRuntimeInfo.setCookie(cookie);
                 LOG.info("Got cookie: {}", cookie);
                 break;
             case assignWork:
                 cancelJobIfThereIsOneRunning();
-                Work work = (Work) message.getData();
+                Work work = MessageEncoding.decodeWork(message.getData());
                 LOG.debug("Got work from server: [{}]", work.description());
                 agentRuntimeInfo.idle();
                 runner = new JobRunner();
@@ -284,17 +295,78 @@ public class AgentController {
                     updateServerAgentRuntimeInfo();
                 }
                 break;
+            case build:
+                cancelBuild();
+                BuildSettings buildSettings = MessageEncoding.decodeData(message.getData(), BuildSettings.class);
+                runBuild(buildSettings);
+                break;
+            case cancelBuild:
+                cancelBuild();
+                break;
             case reregister:
                 LOG.warn("Reregister: invalidate current agent certificate fingerprint {} and stop websocket client.", agentRegistry.uuid());
                 websocketService.stop();
                 sslInfrastructureService.invalidateAgentCertificate();
                 break;
             case ack:
-                callbacks.remove(message.getData()).call();
+                callbacks.remove(MessageEncoding.decodeData(message.getData(), String.class)).call();
                 break;
             default:
                 throw new RuntimeException("Unknown action: " + message.getAction());
 
+        }
+    }
+
+    private void runBuild(BuildSettings buildSettings) {
+        URLService urlService = new URLService();
+        ConsoleOutputTransmitter buildConsole = new ConsoleOutputTransmitter(
+                new RemoteConsoleAppender(
+                        urlService.prefixPartialUrl(buildSettings.getConsoleUrl()),
+                        httpService,
+                        agentRuntimeInfo.getIdentifier()));
+        ArtifactsRepository artifactsRepository = new UrlBasedArtifactsRepository(
+                httpService,
+                urlService.prefixPartialUrl(buildSettings.getArtifactUploadBaseUrl()),
+                urlService.prefixPartialUrl(buildSettings.getPropertyBaseUrl()),
+                new ZipUtil());
+
+        DefaultBuildStateReporter buildStateReporter = new DefaultBuildStateReporter(websocketService, agentRuntimeInfo);
+
+        TimeProvider clock = new TimeProvider();
+        BuildVariables buildVariables = new BuildVariables(agentRuntimeInfo, clock);
+        BuildSession build = new BuildSession(
+                buildSettings.getBuildId(),
+                buildStateReporter,
+                buildConsole,
+                buildVariables,
+                artifactsRepository,
+                httpService, clock, new File("."));
+
+        this.buildSession.set(build);
+
+        build.setEnv("GO_SERVER_URL", new SystemEnvironment().getPropertyImpl("serviceUrl"));
+        agentRuntimeInfo.idle();
+        try {
+            agentRuntimeInfo.busy(new AgentBuildingInfo(buildSettings.getBuildLocatorForDisplay(), buildSettings.getBuildLocator()));
+            build.build(buildSettings.getBuildCommand());
+        } finally {
+            try {
+                buildConsole.stop();
+            } finally {
+                agentRuntimeInfo.idle();
+            }
+        }
+        this.buildSession.set(null);
+    }
+
+    private void cancelBuild() throws InterruptedException {
+        BuildSession build = this.buildSession.get();
+        if(build == null) {
+            return;
+        }
+        agentRuntimeInfo.cancel();
+        if(!build.cancel(30, TimeUnit.SECONDS)) {
+            LOG.error("Waited 30 seconds for canceling job finish, but the job is still running. Maybe canceling job does not work as expected, here is buildSession details: " + buildSession.get());
         }
     }
 
@@ -314,7 +386,7 @@ public class AgentController {
         AgentIdentifier agent = agentIdentifier();
         LOG.trace("{} is pinging server [{}]", agent, server);
         agentRuntimeInfo.refreshUsableSpace();
-        websocketService.sendAndWaitForAck(new Message(Action.ping, agentRuntimeInfo));
+        websocketService.sendAndWaitForAck(new Message(Action.ping, MessageEncoding.encodeData(agentRuntimeInfo)));
         LOG.trace("{} pinged server [{}]", agent, server);
     }
 

--- a/agent/src/com/thoughtworks/go/agent/AgentController.java
+++ b/agent/src/com/thoughtworks/go/agent/AgentController.java
@@ -270,8 +270,9 @@ public class AgentController {
 
     public void process(Message message) throws InterruptedException {
         switch (message.getAction()) {
-            case cancelJob:
+            case cancelBuild:
                 cancelJobIfThereIsOneRunning();
+                cancelBuild();
                 break;
             case setCookie:
                 String cookie = MessageEncoding.decodeData(message.getData(), String.class);
@@ -299,9 +300,6 @@ public class AgentController {
                 cancelBuild();
                 BuildSettings buildSettings = MessageEncoding.decodeData(message.getData(), BuildSettings.class);
                 runBuild(buildSettings);
-                break;
-            case cancelBuild:
-                cancelBuild();
                 break;
             case reregister:
                 LOG.warn("Reregister: invalidate current agent certificate fingerprint {} and stop websocket client.", agentRegistry.uuid());

--- a/agent/src/com/thoughtworks/go/agent/DefaultBuildStateReporter.java
+++ b/agent/src/com/thoughtworks/go/agent/DefaultBuildStateReporter.java
@@ -1,0 +1,55 @@
+/*************************** GO-LICENSE-START*********************************
+ * Copyright 2016 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ************************GO-LICENSE-END***********************************/
+package com.thoughtworks.go.agent;
+
+import com.thoughtworks.go.agent.service.AgentWebsocketService;
+import com.thoughtworks.go.buildsession.BuildStateReporter;
+import com.thoughtworks.go.domain.JobResult;
+import com.thoughtworks.go.domain.JobState;
+import com.thoughtworks.go.server.service.AgentRuntimeInfo;
+import com.thoughtworks.go.websocket.Action;
+import com.thoughtworks.go.websocket.Message;
+import com.thoughtworks.go.websocket.MessageEncoding;
+import com.thoughtworks.go.websocket.Report;
+
+import static com.thoughtworks.go.util.ExceptionUtils.bomb;
+
+public class DefaultBuildStateReporter implements BuildStateReporter {
+    private final AgentWebsocketService websocketService;
+    private final AgentRuntimeInfo agentRuntimeInfo;
+
+    public DefaultBuildStateReporter(AgentWebsocketService websocketService, AgentRuntimeInfo agentRuntimeInfo) {
+        this.websocketService = websocketService;
+        this.agentRuntimeInfo = agentRuntimeInfo;
+    }
+
+    @Override
+    public void reportBuildStatus(String buildId, JobState buildState) {
+        websocketService.sendAndWaitForAck(new Message(Action.reportCurrentStatus, MessageEncoding.encodeData(new Report(agentRuntimeInfo, buildId, buildState, null))));
+    }
+
+    @Override
+    public void reportCompleted(String buildId, JobResult buildResult) {
+        Report report = new Report(agentRuntimeInfo, buildId, null, buildResult);
+        websocketService.sendAndWaitForAck(new Message(Action.reportCompleted, MessageEncoding.encodeData(report)));
+    }
+
+    @Override
+    public void reportCompleting(String buildId, JobResult buildResult) {
+        Report report = new Report(agentRuntimeInfo, buildId, null, buildResult);
+        websocketService.sendAndWaitForAck(new Message(Action.reportCompleting, MessageEncoding.encodeData(report)));
+    }
+}

--- a/agent/src/com/thoughtworks/go/agent/UrlBasedArtifactsRepository.java
+++ b/agent/src/com/thoughtworks/go/agent/UrlBasedArtifactsRepository.java
@@ -1,0 +1,199 @@
+/*************************** GO-LICENSE-START*********************************
+ * Copyright 2016 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ************************GO-LICENSE-END***********************************/
+package com.thoughtworks.go.agent;
+
+import com.thoughtworks.go.buildsession.ArtifactsRepository;
+import com.thoughtworks.go.domain.Property;
+import com.thoughtworks.go.domain.exception.ArtifactPublishingException;
+import com.thoughtworks.go.util.*;
+import com.thoughtworks.go.util.command.StreamConsumer;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang.StringUtils;
+import org.apache.log4j.Logger;
+
+import javax.servlet.http.HttpServletResponse;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Properties;
+import java.util.zip.Deflater;
+
+import static com.thoughtworks.go.util.CachedDigestUtils.md5Hex;
+import static com.thoughtworks.go.util.ExceptionUtils.bomb;
+import static com.thoughtworks.go.util.FileUtil.normalizePath;
+import static com.thoughtworks.go.util.GoConstants.PUBLISH_MAX_RETRIES;
+import static java.lang.String.format;
+import static org.apache.commons.lang.StringUtils.removeStart;
+
+// This class is a replacement for GoArtifactsManipulator, so bear with the duplication for now
+public class UrlBasedArtifactsRepository implements ArtifactsRepository {
+    private static final Logger LOGGER = Logger.getLogger(UrlBasedArtifactsRepository.class);
+
+    private final HttpService httpService;
+    private final String artifactsBaseUrl;
+    private String propertyBaseUrl;
+    private ZipUtil zipUtil;
+
+    public UrlBasedArtifactsRepository(HttpService httpService, String artifactsBaseUrl, String propertyBaseUrl, ZipUtil zipUtil) {
+        this.httpService = httpService;
+        this.artifactsBaseUrl = artifactsBaseUrl;
+        this.propertyBaseUrl = propertyBaseUrl;
+        this.zipUtil = zipUtil;
+    }
+
+    @Override
+    public void upload(StreamConsumer console, File file, String destPath, String buildId) {
+        if (!file.exists()) {
+            String message = "Failed to find " + file.getAbsolutePath();
+            consumeLineWithPrefix(console, message);
+            throw bomb(message);
+        }
+
+        int publishingAttempts = 0;
+        Throwable lastException = null;
+        while (publishingAttempts < PUBLISH_MAX_RETRIES) {
+            File tmpDir = null;
+            try {
+                publishingAttempts++;
+
+                tmpDir = FileUtil.createTempFolder();
+                File dataToUpload = new File(tmpDir, file.getName() + ".zip");
+                zipUtil.zip(file, dataToUpload, Deflater.BEST_SPEED);
+
+                long size;
+                if (file.isDirectory()) {
+                    size = FileUtils.sizeOfDirectory(file);
+                } else {
+                    size = file.length();
+                }
+
+                consumeLineWithPrefix(console,
+                        format("Uploading artifacts from %s to %s", file.getAbsolutePath(), getDestPath(destPath)));
+
+                String normalizedDestPath = normalizePath(destPath);
+                String url = getUploadUrl(buildId, normalizedDestPath, publishingAttempts);
+
+                int statusCode = httpService.upload(url, size, dataToUpload, artifactChecksums(file, normalizedDestPath));
+
+                if (statusCode == HttpServletResponse.SC_REQUEST_ENTITY_TOO_LARGE) {
+                    String message = format("Artifact upload for file %s (Size: %s) was denied by the server. This usually happens when server runs out of disk space.",
+                            file.getAbsolutePath(), size);
+                    consumeLineWithPrefix(console, message);
+                    LOGGER.error("[Artifact Upload] Artifact upload was denied by the server. This usually happens when server runs out of disk space.");
+                    publishingAttempts = PUBLISH_MAX_RETRIES;
+                    throw bomb(message + ".  HTTP return code is " + statusCode);
+                }
+                if (statusCode < HttpServletResponse.SC_OK || statusCode >= HttpServletResponse.SC_MULTIPLE_CHOICES) {
+                    throw bomb("Failed to upload " + file.getAbsolutePath() + ".  HTTP return code is " + statusCode);
+                }
+                return;
+            } catch (Throwable e) {
+                String message = "Failed to upload " + file.getAbsolutePath();
+                LOGGER.error(message, e);
+                consumeLineWithPrefix(console, message);
+                lastException = e;
+            } finally {
+                FileUtil.deleteFolder(tmpDir);
+            }
+        }
+        if (lastException != null) {
+            throw new RuntimeException(lastException);
+        }
+    }
+
+    @Override
+    public void setProperty(Property property) {
+        try {
+            httpService.postProperty(getPropertiesUrl(property.getKey()), property.getValue());
+        } catch (Exception e) {
+            throw new ArtifactPublishingException(format("Failed to set property %s with value %s", property.getKey(), property.getValue()), e);
+        }
+    }
+
+    private String getPropertiesUrl(String propertyName) {
+        return UrlUtil.concatPath(propertyBaseUrl, UrlUtil.encodeInUtf8(propertyName));
+    }
+
+    private String getUploadUrl(String buildId, String normalizedDestPath, int publishingAttempts) {
+        String path = format("%s?attempt=%d&buildId=%s", UrlUtil.encodeInUtf8(normalizedDestPath), publishingAttempts, buildId);
+        return UrlUtil.concatPath(artifactsBaseUrl, path);
+    }
+
+    private void consumeLineWithPrefix(StreamConsumer console, String message) {
+        console.consumeLine(format("[%s] %s", GoConstants.PRODUCT_NAME, message));
+    }
+
+    private String getDestPath(String file) {
+        if (StringUtils.isEmpty(file)) {
+            return "[defaultRoot]";
+        } else {
+            return file;
+        }
+    }
+
+    private Properties artifactChecksums(File source, String destPath) throws IOException {
+        if (source.isDirectory()) {
+            return computeChecksumForContentsOfDirectory(source, destPath);
+        }
+
+        FileInputStream inputStream = null;
+        Properties properties = null;
+        try {
+            inputStream = new FileInputStream(source);
+            properties = computeChecksumForFile(source.getName(), md5Hex(inputStream), destPath);
+        } finally {
+            if (inputStream != null) {
+                inputStream.close();
+            }
+        }
+        return properties;
+    }
+
+    private Properties computeChecksumForContentsOfDirectory(File directory, String destPath) throws IOException {
+        Collection<File> fileStructure = FileUtils.listFiles(directory, null, true);
+        Properties checksumProperties = new Properties();
+        for (File file : fileStructure) {
+            String filePath = removeStart(file.getAbsolutePath(), directory.getParentFile().getAbsolutePath());
+            FileInputStream inputStream = null;
+            try {
+                inputStream = new FileInputStream(file);
+                checksumProperties.setProperty(getEffectiveFileName(destPath, normalizePath(filePath)), md5Hex(inputStream));
+            } finally {
+                if (inputStream != null) {
+                    inputStream.close();
+                }
+            }
+        }
+        return checksumProperties;
+    }
+
+    private Properties computeChecksumForFile(String sourceName, String md5, String destPath) throws IOException {
+        String effectiveFileName = getEffectiveFileName(destPath, sourceName);
+        Properties properties = new Properties();
+        properties.setProperty(effectiveFileName, md5);
+        return properties;
+    }
+
+    private String getEffectiveFileName(String computedDestPath, String filePath) {
+        File artifactDest = computedDestPath.isEmpty() ? new File(filePath) : new File(computedDestPath, filePath);
+        return removeLeadingSlash(artifactDest);
+    }
+
+    private String removeLeadingSlash(File artifactDest) {
+        return removeStart(normalizePath(artifactDest.getPath()), "/");
+    }
+}

--- a/agent/src/com/thoughtworks/go/agent/service/SslInfrastructureService.java
+++ b/agent/src/com/thoughtworks/go/agent/service/SslInfrastructureService.java
@@ -31,6 +31,7 @@ import org.apache.commons.httpclient.MultiThreadedHttpConnectionManager;
 import org.apache.commons.httpclient.methods.PostMethod;
 import org.apache.commons.httpclient.params.HttpConnectionManagerParams;
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
 import org.apache.log4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -38,7 +39,6 @@ import org.springframework.stereotype.Service;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.ObjectInputStream;
 
 import static com.thoughtworks.go.security.CertificateUtil.md5Fingerprint;
 import static com.thoughtworks.go.security.SelfSignedCertificateX509TrustManager.CRUISE_SERVER;
@@ -199,7 +199,7 @@ public class SslInfrastructureService {
         }
 
         protected Registration readResponse(InputStream is) throws IOException, ClassNotFoundException {
-            return (Registration) new ObjectInputStream(is).readObject();
+            return Registration.fromJson(IOUtils.toString(is));
         }
     }
 }

--- a/agent/test/unit/com/thoughtworks/go/agent/AgentControllerTest.java
+++ b/agent/test/unit/com/thoughtworks/go/agent/AgentControllerTest.java
@@ -21,7 +21,8 @@ import com.thoughtworks.go.agent.service.AgentWebsocketService;
 import com.thoughtworks.go.agent.service.SslInfrastructureService;
 import com.thoughtworks.go.config.AgentRegistry;
 import com.thoughtworks.go.config.GuidService;
-import com.thoughtworks.go.domain.AgentRuntimeStatus;
+import com.thoughtworks.go.domain.*;
+import com.thoughtworks.go.buildsession.BuildSessionTest;
 import com.thoughtworks.go.plugin.access.packagematerial.PackageAsRepositoryExtension;
 import com.thoughtworks.go.plugin.access.pluggabletask.TaskExtension;
 import com.thoughtworks.go.plugin.access.scm.SCMExtension;
@@ -33,30 +34,32 @@ import com.thoughtworks.go.remote.BuildRepositoryRemote;
 import com.thoughtworks.go.remote.work.Work;
 import com.thoughtworks.go.server.service.AgentBuildingInfo;
 import com.thoughtworks.go.server.service.AgentRuntimeInfo;
+import com.thoughtworks.go.util.HttpService;
 import com.thoughtworks.go.util.SubprocessLogger;
 import com.thoughtworks.go.util.SystemEnvironment;
 import com.thoughtworks.go.util.command.EnvironmentVariableContext;
-import com.thoughtworks.go.websocket.Action;
-import com.thoughtworks.go.websocket.Message;
-import com.thoughtworks.go.websocket.MessageCallback;
+import com.thoughtworks.go.websocket.*;
 import com.thoughtworks.go.work.SleepWork;
+import org.apache.commons.httpclient.HttpClient;
+import org.apache.commons.httpclient.URI;
+import org.apache.commons.httpclient.methods.PutMethod;
+import org.apache.commons.httpclient.methods.StringRequestEntity;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InOrder;
 import org.mockito.Mock;
-import org.mockito.invocation.InvocationOnMock;
-import org.mockito.stubbing.Answer;
 
 import java.io.IOException;
 import java.security.GeneralSecurityException;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static com.thoughtworks.go.util.SystemUtil.getFirstLocalNonLoopbackIpAddress;
 import static com.thoughtworks.go.util.SystemUtil.getLocalhostName;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.*;
 import static org.mockito.Matchers.any;
@@ -93,6 +96,10 @@ public class AgentControllerTest {
     private TaskExtension taskExtension;
     @Mock
     private AgentWebsocketService agentWebsocketService;
+    @Mock
+    private HttpService httpService;
+    @Mock
+    private HttpClient httpClient;
 
     private String agentUuid = "uuid";
     private AgentIdentifier agentIdentifier;
@@ -181,7 +188,7 @@ public class AgentControllerTest {
     public void shouldRegisterSubprocessLoggerAtExit() throws Exception {
         SslInfrastructureService sslInfrastructureService = mock(SslInfrastructureService.class);
         AgentRegistry agentRegistry = mock(AgentRegistry.class);
-        agentController = new AgentController(loopServer, artifactsManipulator, sslInfrastructureService, agentRegistry, agentUpgradeService, subprocessLogger, systemEnvironment,pluginManager, packageAsRepositoryExtension, scmExtension, taskExtension, agentWebsocketService);
+        agentController = new AgentController(loopServer, artifactsManipulator, sslInfrastructureService, agentRegistry, agentUpgradeService, subprocessLogger, systemEnvironment,pluginManager, packageAsRepositoryExtension, scmExtension, taskExtension, agentWebsocketService, mock(HttpService.class));
         agentController.init();
         verify(subprocessLogger).registerAsExitHook("Following processes were alive at shutdown: ");
     }
@@ -231,7 +238,7 @@ public class AgentControllerTest {
         verify(agentUpgradeService).checkForUpgrade();
         verify(sslInfrastructureService).registerIfNecessary(agentController.getAgentAutoRegistrationProperties());
         verify(agentWebsocketService).start();
-        verify(agentWebsocketService).sendAndWaitForAck(new Message(Action.ping, agentController.getAgentRuntimeInfo()));
+        verify(agentWebsocketService).sendAndWaitForAck(new Message(Action.ping, MessageEncoding.encodeData(agentController.getAgentRuntimeInfo())));
     }
 
     @Test
@@ -257,7 +264,7 @@ public class AgentControllerTest {
         agentController = createAgentController();
         agentController.init();
 
-        agentController.process(new Message(Action.setCookie, "cookie"));
+        agentController.process(new Message(Action.setCookie, MessageEncoding.encodeData("cookie")));
 
         assertThat(agentController.getAgentRuntimeInfo().getCookie(), is("cookie"));
     }
@@ -265,48 +272,134 @@ public class AgentControllerTest {
     @Test
     public void processAssignWorkAction() throws IOException, InterruptedException {
         when(agentRegistry.uuid()).thenReturn(agentUuid);
-        doAnswer(new Answer() {
-            @Override
-            public Object answer(InvocationOnMock invocationOnMock) throws Throwable {
-                AgentRuntimeInfo info = (AgentRuntimeInfo) invocationOnMock.getArguments()[4];
-                info.busy(new AgentBuildingInfo("locator for display", "build locator"));
-                return null;
-            }
-        }).when(work).doWork(any(AgentIdentifier.class), any(BuildRepositoryRemote.class), any(GoArtifactsManipulator.class), any(EnvironmentVariableContext.class), any(AgentRuntimeInfo.class), any(PackageAsRepositoryExtension.class), any(SCMExtension.class), any(TaskExtension.class));
-
         agentController = createAgentController();
         agentController.init();
-        agentController.process(new Message(Action.assignWork, work));
-
-        verify(work).doWork(eq(agentIdentifier), any(BuildRepositoryRemote.class), eq(artifactsManipulator), any(EnvironmentVariableContext.class), eq(agentController.getAgentRuntimeInfo()), eq(packageAsRepositoryExtension), eq(scmExtension), eq(taskExtension));
+        agentController.process(new Message(Action.assignWork, MessageEncoding.encodeWork(new SleepWork("work1", 0))));
         assertThat(agentController.getAgentRuntimeInfo().getRuntimeStatus(), is(AgentRuntimeStatus.Idle));
-        verify(agentWebsocketService).sendAndWaitForAck(new Message(Action.ping, agentController.getAgentRuntimeInfo()));
+        verify(agentWebsocketService).sendAndWaitForAck(new Message(Action.ping, MessageEncoding.encodeData(agentController.getAgentRuntimeInfo())));
+        verify(artifactsManipulator).setProperty(null, new Property("work1_result", "done"));
+    }
+
+
+    @Test
+    public void processBuildCommand() throws IOException, InterruptedException {
+        when(agentRegistry.uuid()).thenReturn(agentUuid);
+        when(httpService.httpClient()).thenReturn(httpClient);
+        agentController = createAgentController();
+        agentController.init();
+        BuildSettings build = new BuildSettings();
+        build.setBuildId("b001");
+        build.setConsoleUrl("http://foo.bar/console");
+        build.setArtifactUploadBaseUrl("http://foo.bar/artifacts");
+        build.setPropertyBaseUrl("http://foo.bar/properties");
+        build.setBuildLocator("build1");
+        build.setBuildLocatorForDisplay("build1ForDisplay");
+        build.setBuildCommand(BuildCommand.compose(
+                BuildCommand.echo("building"),
+                BuildCommand.reportCurrentStatus(JobState.Building)));
+        agentController.process(new Message(Action.build, MessageEncoding.encodeData(build)));
+        assertThat(agentController.getAgentRuntimeInfo().getRuntimeStatus(), is(AgentRuntimeStatus.Idle));
+
+        AgentRuntimeInfo agentRuntimeInfo  = cloneAgentRuntimeInfo(agentController.getAgentRuntimeInfo());
+        agentRuntimeInfo.busy(new AgentBuildingInfo("build1ForDisplay", "build1"));
+        verify(agentWebsocketService).sendAndWaitForAck(new Message(Action.reportCurrentStatus, MessageEncoding.encodeData(new Report(agentRuntimeInfo, "b001", JobState.Building, null))));
+        verify(agentWebsocketService).sendAndWaitForAck(new Message(Action.reportCompleted, MessageEncoding.encodeData(new Report(agentRuntimeInfo, "b001", null, JobResult.Passed))));
+
+
+        ArgumentCaptor<PutMethod> putMethodArg = ArgumentCaptor.forClass(PutMethod.class);
+        verify(httpClient).executeMethod(putMethodArg.capture());
+        assertThat(putMethodArg.getValue().getURI(), is(new URI("http://foo.bar/console", false)));
+        assertThat(((StringRequestEntity)putMethodArg.getValue().getRequestEntity()).getContent(), containsString("building"));
+    }
+
+    private AgentRuntimeInfo cloneAgentRuntimeInfo(AgentRuntimeInfo agentRuntimeInfo) {
+        return MessageEncoding.decodeData(MessageEncoding.encodeData(agentRuntimeInfo), AgentRuntimeInfo.class);
     }
 
     @Test
-    public void processCancelJobAction() throws IOException, InterruptedException {
+    public void processCancelBuildAction() throws IOException, InterruptedException {
+        when(agentRegistry.uuid()).thenReturn(agentUuid);
+        when(httpService.httpClient()).thenReturn(httpClient);
+
         agentController = createAgentController();
         agentController.init();
-        final SleepWork sleep1secWork = new SleepWork();
+        final BuildSettings build = new BuildSettings();
+        build.setBuildId("b001");
+        build.setConsoleUrl("http://foo.bar/console");
+        build.setArtifactUploadBaseUrl("http://foo.bar/artifacts");
+        build.setPropertyBaseUrl("http://foo.bar/properties");
+        build.setBuildLocator("build1");
+        build.setBuildLocatorForDisplay("build1ForDisplay");
+        build.setBuildCommand(BuildCommand.compose(
+                BuildSessionTest.execSleepScript(MAX_WAIT_IN_TEST / 1000),
+                BuildCommand.reportCurrentStatus(JobState.Building)));
+
 
         Thread buildingThread = new Thread(new Runnable() {
             @Override
             public void run() {
                 try {
-                    agentController.process(new Message(Action.assignWork, sleep1secWork));
+                    agentController.process(new Message(Action.build, MessageEncoding.encodeData(build)));
                 } catch (InterruptedException e) {
                     throw new RuntimeException(e);
                 }
             }
         });
         buildingThread.start();
-        sleep1secWork.started.await(MAX_WAIT_IN_TEST, TimeUnit.MILLISECONDS);
+
+        waitForAgentRuntimeState(agentController.getAgentRuntimeInfo(), AgentRuntimeStatus.Building);
+
+        agentController.process(new Message(Action.cancelBuild));
+        buildingThread.join(MAX_WAIT_IN_TEST);
+
+        AgentRuntimeInfo agentRuntimeInfo  = cloneAgentRuntimeInfo(agentController.getAgentRuntimeInfo());
+        agentRuntimeInfo.busy(new AgentBuildingInfo("build1ForDisplay", "build1"));
+        agentRuntimeInfo.cancel();
+
+        verify(agentWebsocketService).sendAndWaitForAck(new Message(Action.reportCompleted, MessageEncoding.encodeData(new Report(agentRuntimeInfo, "b001", null, JobResult.Cancelled))));
+
+        assertThat(agentController.getAgentRuntimeInfo().getRuntimeStatus(), is(AgentRuntimeStatus.Idle));
+    }
+
+
+    @Test
+    public void processCancelJobAction() throws IOException, InterruptedException {
+        agentController = createAgentController();
+        agentController.init();
+        final SleepWork sleep1secWork = new SleepWork("work1", MAX_WAIT_IN_TEST);
+
+        Thread buildingThread = new Thread(new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    agentController.process(new Message(Action.assignWork, MessageEncoding.encodeWork(sleep1secWork)));
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        });
+        buildingThread.start();
+
+        waitForAgentRuntimeState(agentController.getAgentRuntimeInfo(), AgentRuntimeStatus.Building);
 
         agentController.process(new Message(Action.cancelJob));
         buildingThread.join(MAX_WAIT_IN_TEST);
 
-        assertThat(sleep1secWork.done.get(), is(true));
-        assertThat(sleep1secWork.canceled.get(), is(true));
+        assertThat(agentController.getAgentRuntimeInfo().getRuntimeStatus(), is(AgentRuntimeStatus.Idle));
+        verify(artifactsManipulator).setProperty(null, new Property("work1_result", "done_canceled"));
+    }
+
+    private void waitForAgentRuntimeState(AgentRuntimeInfo runtimeInfo, AgentRuntimeStatus status) throws InterruptedException {
+        int elapsed = 0;
+        int waitStep = 100;
+        while(elapsed <= MAX_WAIT_IN_TEST) {
+            if(runtimeInfo.getRuntimeStatus() == status) {
+                return;
+            }
+            Thread.sleep(waitStep);
+            elapsed += waitStep;
+        }
+        throw new RuntimeException("wait for agent status '" + status.name() + "' timeout, current status is '" + runtimeInfo.getRuntimeStatus().name() + "'" );
     }
 
     @Test
@@ -324,27 +417,25 @@ public class AgentControllerTest {
     public void shouldCancelPreviousRunningJobIfANewAssignWorkMessageIsReceived() throws IOException, InterruptedException {
         agentController = createAgentController();
         agentController.init();
-        final SleepWork work1 = new SleepWork();
+        final SleepWork work1 = new SleepWork("work1", MAX_WAIT_IN_TEST);
         Thread work1Thread = new Thread(new Runnable() {
             @Override
             public void run() {
                 try {
-                    agentController.process(new Message(Action.assignWork, work1));
+                    agentController.process(new Message(Action.assignWork, MessageEncoding.encodeWork(work1)));
                 } catch (InterruptedException e) {
                     throw new RuntimeException(e);
                 }
             }
         });
         work1Thread.start();
-        work1.started.await(MAX_WAIT_IN_TEST, TimeUnit.MILLISECONDS);
-        SleepWork work2 = new SleepWork(0);
-        agentController.process(new Message(Action.assignWork, work2));
+        waitForAgentRuntimeState(agentController.getAgentRuntimeInfo(), AgentRuntimeStatus.Building);
+        SleepWork work2 = new SleepWork("work2", 1);
+        agentController.process(new Message(Action.assignWork, MessageEncoding.encodeWork(work2)));
         work1Thread.join(MAX_WAIT_IN_TEST);
 
-        assertThat(work1.done.get(), is(true));
-        assertThat(work1.canceled.get(), is(true));
-        assertThat(work2.done.get(), is(true));
-        assertThat(work2.canceled.get(), is(false));
+        verify(artifactsManipulator).setProperty(null, new Property("work1_result", "done_canceled"));
+        verify(artifactsManipulator).setProperty(null, new Property("work2_result", "done"));
     }
 
     @Test
@@ -361,11 +452,11 @@ public class AgentControllerTest {
             }
         });
         assertNotNull(message.getAckId());
-        agentController.process(new Message(Action.ack, message.getAckId()));
+        agentController.process(new Message(Action.ack, MessageEncoding.encodeData(message.getAckId())));
         assertTrue(callbackIsCalled.get());
     }
 
     private AgentController createAgentController() {
-        return new AgentController(loopServer, artifactsManipulator, sslInfrastructureService, agentRegistry, agentUpgradeService, subprocessLogger, systemEnvironment,pluginManager, packageAsRepositoryExtension, scmExtension, taskExtension, agentWebsocketService);
+        return new AgentController(loopServer, artifactsManipulator, sslInfrastructureService, agentRegistry, agentUpgradeService, subprocessLogger, systemEnvironment,pluginManager, packageAsRepositoryExtension, scmExtension, taskExtension, agentWebsocketService, httpService);
     }
 }

--- a/agent/test/unit/com/thoughtworks/go/agent/AgentControllerTest.java
+++ b/agent/test/unit/com/thoughtworks/go/agent/AgentControllerTest.java
@@ -317,12 +317,13 @@ public class AgentControllerTest {
     }
 
     @Test
-    public void processCancelBuildAction() throws IOException, InterruptedException {
+    public void processCancelBuildCommandBuild() throws IOException, InterruptedException {
         when(agentRegistry.uuid()).thenReturn(agentUuid);
         when(httpService.httpClient()).thenReturn(httpClient);
 
         agentController = createAgentController();
         agentController.init();
+        agentController.getAgentRuntimeInfo().setSupportsBuildCommandProtocol(true);
         final BuildSettings build = new BuildSettings();
         build.setBuildId("b001");
         build.setConsoleUrl("http://foo.bar/console");
@@ -382,7 +383,7 @@ public class AgentControllerTest {
 
         waitForAgentRuntimeState(agentController.getAgentRuntimeInfo(), AgentRuntimeStatus.Building);
 
-        agentController.process(new Message(Action.cancelJob));
+        agentController.process(new Message(Action.cancelBuild));
         buildingThread.join(MAX_WAIT_IN_TEST);
 
         assertThat(agentController.getAgentRuntimeInfo().getRuntimeStatus(), is(AgentRuntimeStatus.Idle));

--- a/agent/test/unit/com/thoughtworks/go/agent/AgentControllerTest.java
+++ b/agent/test/unit/com/thoughtworks/go/agent/AgentControllerTest.java
@@ -19,6 +19,7 @@ package com.thoughtworks.go.agent;
 import com.thoughtworks.go.agent.service.AgentUpgradeService;
 import com.thoughtworks.go.agent.service.AgentWebsocketService;
 import com.thoughtworks.go.agent.service.SslInfrastructureService;
+import com.thoughtworks.go.buildsession.BuildSessionBasedTestCase;
 import com.thoughtworks.go.config.AgentRegistry;
 import com.thoughtworks.go.config.GuidService;
 import com.thoughtworks.go.domain.*;
@@ -332,7 +333,7 @@ public class AgentControllerTest {
         build.setBuildLocator("build1");
         build.setBuildLocatorForDisplay("build1ForDisplay");
         build.setBuildCommand(BuildCommand.compose(
-                BuildSessionTest.execSleepScript(MAX_WAIT_IN_TEST / 1000),
+                BuildSessionBasedTestCase.execSleepScript(MAX_WAIT_IN_TEST / 1000),
                 BuildCommand.reportCurrentStatus(JobState.Building)));
 
 

--- a/agent/test/unit/com/thoughtworks/go/agent/JobRunnerTest.java
+++ b/agent/test/unit/com/thoughtworks/go/agent/JobRunnerTest.java
@@ -160,24 +160,24 @@ public class JobRunnerTest {
     @Test
     public void shouldDoNothingWhenJobIsNotCancelled() throws CruiseControlException {
         runner.setWork(work);
-        runner.handleInstruction(new AgentInstruction(false), new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null));
+        runner.handleInstruction(new AgentInstruction(false), new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null, false));
         assertThat(work.getCallCount(), is(0));
     }
 
     @Test
     public void shouldCancelOncePerJob() throws CruiseControlException {
         runner.setWork(work);
-        runner.handleInstruction(new AgentInstruction(true), new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null));
+        runner.handleInstruction(new AgentInstruction(true), new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null, false));
         assertThat(work.getCallCount(), is(1));
 
-        runner.handleInstruction(new AgentInstruction(true), new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null));
+        runner.handleInstruction(new AgentInstruction(true), new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null, false));
         assertThat(work.getCallCount(), is(1));
     }
 
     @Test
     public void shoudReturnTrueOnGetJobIsCancelledWhenJobIsCancelled() {
         assertThat(runner.isJobCancelled(), is(false));
-        runner.handleInstruction(new AgentInstruction(true), new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null));
+        runner.handleInstruction(new AgentInstruction(true), new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null, false));
         assertThat(runner.isJobCancelled(), is(true));
     }
 
@@ -198,12 +198,12 @@ public class JobRunnerTest {
             public void run() {
                 jobRunner.run(buildWork, agentIdentifier,
                         new BuildRepositoryRemoteStub(), stubPublisher(properties, consoleOut),
-                        new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null), null, null, null);
+                        new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null, false), null, null, null);
             }
         });
         Thread cancel = new Thread(new Runnable() {
             public void run() {
-                jobRunner.handleInstruction(new AgentInstruction(true), new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null));
+                jobRunner.handleInstruction(new AgentInstruction(true), new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null, false));
             }
         });
 
@@ -245,12 +245,12 @@ public class JobRunnerTest {
             public void run() {
                 jobRunner.run(buildWork, agentIdentifier,
                         new BuildRepositoryRemoteStub(), stubPublisher(properties, consoleOut),
-                        new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null), null, null, null);
+                        new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null, false), null, null, null);
             }
         });
         Thread cancel = new Thread(new Runnable() {
             public void run() {
-                jobRunner.handleInstruction(new AgentInstruction(true), new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null));
+                jobRunner.handleInstruction(new AgentInstruction(true), new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null, false));
             }
         });
 

--- a/agent/test/unit/com/thoughtworks/go/agent/UrlBasedArtifactsRepositoryTest.java
+++ b/agent/test/unit/com/thoughtworks/go/agent/UrlBasedArtifactsRepositoryTest.java
@@ -17,6 +17,7 @@ package com.thoughtworks.go.agent;
 
 import com.thoughtworks.go.buildsession.ArtifactsRepository;
 import com.thoughtworks.go.domain.Property;
+import com.thoughtworks.go.helper.TestStreamConsumer;
 import com.thoughtworks.go.util.*;
 import com.thoughtworks.go.util.command.InMemoryConsumer;
 import org.apache.commons.io.FileUtils;
@@ -45,14 +46,14 @@ public class UrlBasedArtifactsRepositoryTest {
     private File tempFile;
     private File artifactFolder;
     private ArtifactsRepository artifactsRepository;
-    private InMemoryConsumer console;
+    private TestStreamConsumer console;
 
     @Before
     public void setUp() throws Exception {
         httpService = mock(HttpService.class);
         artifactFolder = TestFileUtil.createTempFolder("artifact_folder");
         tempFile = TestFileUtil.createTestFile(artifactFolder, "file.txt");
-        console = new InMemoryConsumer();
+        console = new TestStreamConsumer();
         artifactsRepository = new UrlBasedArtifactsRepository(httpService, "http://baseurl/artifacts/", "http://baseurl/properties/", new ZipUtil());
     }
 

--- a/agent/test/unit/com/thoughtworks/go/agent/UrlBasedArtifactsRepositoryTest.java
+++ b/agent/test/unit/com/thoughtworks/go/agent/UrlBasedArtifactsRepositoryTest.java
@@ -1,0 +1,185 @@
+/*************************** GO-LICENSE-START*********************************
+ * Copyright 2016 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ************************GO-LICENSE-END***********************************/
+package com.thoughtworks.go.agent;
+
+import com.thoughtworks.go.buildsession.ArtifactsRepository;
+import com.thoughtworks.go.domain.Property;
+import com.thoughtworks.go.util.*;
+import com.thoughtworks.go.util.command.InMemoryConsumer;
+import org.apache.commons.io.FileUtils;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+import javax.servlet.http.HttpServletResponse;
+import java.io.File;
+import java.io.IOException;
+import java.util.Properties;
+
+import static com.thoughtworks.go.matchers.ConsoleOutMatcher.printedUploadingFailure;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyLong;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.*;
+
+public class UrlBasedArtifactsRepositoryTest {
+
+    private HttpService httpService;
+    private File tempFile;
+    private File artifactFolder;
+    private ArtifactsRepository artifactsRepository;
+    private InMemoryConsumer console;
+
+    @Before
+    public void setUp() throws Exception {
+        httpService = mock(HttpService.class);
+        artifactFolder = TestFileUtil.createTempFolder("artifact_folder");
+        tempFile = TestFileUtil.createTestFile(artifactFolder, "file.txt");
+        console = new InMemoryConsumer();
+        artifactsRepository = new UrlBasedArtifactsRepository(httpService, "http://baseurl/artifacts/", "http://baseurl/properties/", new ZipUtil());
+    }
+
+    @After
+    public void tearDown() throws IOException {
+        FileUtil.tryDeleting(artifactFolder);
+    }
+
+    @Test
+    public void shouldBombWithErrorWhenStatusCodeReturnedIsRequestEntityTooLarge() throws IOException, InterruptedException {
+        long size = anyLong();
+        when(httpService.upload(any(String.class), size, any(File.class), any(Properties.class))).thenReturn(HttpServletResponse.SC_REQUEST_ENTITY_TOO_LARGE);
+
+        try {
+            artifactsRepository.upload(console, tempFile, "some_dest", "build42");
+            fail("should have thrown request entity too large error");
+        } catch (RuntimeException e) {
+            String expectedMessage = "Artifact upload for file " + tempFile.getAbsolutePath() + " (Size: " + size + ") was denied by the server. This usually happens when server runs out of disk space.";
+            assertThat(e.getMessage(), is("java.lang.RuntimeException: " + expectedMessage + ".  HTTP return code is 413"));
+            assertThat(console.output().contains(expectedMessage), is(true));
+        }
+    }
+
+    @Test
+    public void uploadShouldBeGivenFileSize() throws IOException {
+        when(httpService.upload(any(String.class), eq(tempFile.length()), any(File.class), any(Properties.class))).thenReturn(HttpServletResponse.SC_REQUEST_ENTITY_TOO_LARGE);
+        try {
+            artifactsRepository.upload(console, tempFile, "dest", "build42");
+            fail("should have thrown request entity too large error");
+        } catch (RuntimeException e) {
+            verify(httpService).upload(eq("http://baseurl/artifacts/dest?attempt=1&buildId=build42"), eq(tempFile.length()), any(File.class), any(Properties.class));
+        }
+    }
+
+
+    @Test
+    public void shouldRetryUponUploadFailure() throws IOException {
+        String data = "Some text whose checksum can be asserted";
+        final String md5 = CachedDigestUtils.md5Hex(data);
+        FileUtils.writeStringToFile(tempFile, data);
+        Properties properties = new Properties();
+        properties.setProperty("dest/path/file.txt", md5);
+
+        when(httpService.upload(eq("http://baseurl/artifacts/dest/path?attempt=1&buildId=build42"), eq(tempFile.length()), any(File.class), eq(properties))).thenReturn(HttpServletResponse.SC_BAD_GATEWAY);
+        when(httpService.upload(eq("http://baseurl/artifacts/dest/path?attempt=2&buildId=build42"), eq(tempFile.length()), any(File.class), eq(properties))).thenReturn(HttpServletResponse.SC_BAD_GATEWAY);
+        when(httpService.upload(eq("http://baseurl/artifacts/dest/path?attempt=3&buildId=build42"), eq(tempFile.length()), any(File.class), eq(properties))).thenReturn(HttpServletResponse.SC_OK);
+        artifactsRepository.upload(console, tempFile, "dest/path", "build42");
+    }
+
+    @Test
+    public void shouldPrintFailureMessageToConosoleWhenUploadFailed() throws IOException {
+        String data = "Some text whose checksum can be asserted";
+        final String md5 = CachedDigestUtils.md5Hex(data);
+        FileUtils.writeStringToFile(tempFile, data);
+        Properties properties = new Properties();
+        properties.setProperty("dest/path/file.txt", md5);
+
+        when(httpService.upload(eq("http://baseurl/artifacts/dest/path?attempt=1&buildId=build42"), eq(tempFile.length()), any(File.class), eq(properties))).thenReturn(HttpServletResponse.SC_BAD_GATEWAY);
+        when(httpService.upload(eq("http://baseurl/artifacts/dest/path?attempt=2&buildId=build42"), eq(tempFile.length()), any(File.class), eq(properties))).thenReturn(HttpServletResponse.SC_BAD_GATEWAY);
+        when(httpService.upload(eq("http://baseurl/artifacts/dest/path?attempt=3&buildId=build42"), eq(tempFile.length()), any(File.class), eq(properties))).thenReturn(HttpServletResponse.SC_BAD_GATEWAY);
+
+        try {
+            artifactsRepository.upload(console, tempFile, "dest/path", "build42");
+            fail("should have thrown request entity too large error");
+        } catch (RuntimeException e) {
+            assertThat(console.output(), printedUploadingFailure(tempFile));
+        }
+    }
+
+
+    @Test
+    public void shouldUploadArtifactChecksumAlongWithArtifact() throws IOException {
+        String data = "Some text whose checksum can be asserted";
+        final String md5 = CachedDigestUtils.md5Hex(data);
+        FileUtils.writeStringToFile(tempFile, data);
+        Properties properties = new Properties();
+        properties.setProperty("dest/path/file.txt", md5);
+
+        when(httpService.upload(eq("http://baseurl/artifacts/dest/path?attempt=1&buildId=build42"), eq(tempFile.length()), any(File.class), eq(properties))).thenReturn(HttpServletResponse.SC_OK);
+
+        artifactsRepository.upload(console, tempFile, "dest/path", "build42");
+    }
+
+    @Test
+    public void shouldUploadArtifactChecksumWithRightPathWhenArtifactDestinationPathIsEmpty() throws IOException {
+        String data = "Some text whose checksum can be asserted";
+        final String md5 = CachedDigestUtils.md5Hex(data);
+        FileUtils.writeStringToFile(tempFile, data);
+        Properties properties = new Properties();
+        properties.setProperty("file.txt", md5);
+
+        when(httpService.upload(eq("http://baseurl/artifacts/?attempt=1&buildId=build42"), eq(tempFile.length()), any(File.class), eq(properties))).thenReturn(HttpServletResponse.SC_OK);
+
+        artifactsRepository.upload(console, tempFile, "", "build42");
+    }
+
+    @Test
+    public void shouldUploadArtifactChecksumForADirectory() throws IOException {
+        String data = "Some text whose checksum can be asserted";
+        String secondData = "some more";
+
+        FileUtils.writeStringToFile(tempFile, data);
+
+        File anotherFile = new File(artifactFolder, "bond/james_bond/another_file");
+        FileUtils.writeStringToFile(anotherFile, secondData);
+
+
+        when(httpService.upload(eq("http://baseurl/artifacts/dest?attempt=1&buildId=build42"), eq(FileUtils.sizeOfDirectory(artifactFolder)), any(File.class), eq(expectedProperties(data, secondData)))).thenReturn(HttpServletResponse.SC_OK);
+        artifactsRepository.upload(console, artifactFolder, "dest", "build42");
+    }
+
+    @Test
+    public void setRemoteBuildPropertyShouldEncodePropertyName() throws IOException {
+        ArgumentCaptor<String> url = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<String> value = ArgumentCaptor.forClass(String.class);
+
+        artifactsRepository.setProperty(new Property("fo,o", "bar"));
+        verify(httpService).postProperty(url.capture(), value.capture());
+        assertThat(value.getValue(), is("bar"));
+        assertThat(url.getValue(), is("http://baseurl/properties/fo%2Co"));
+    }
+
+    private Properties expectedProperties(String data, String secondData) {
+        Properties properties = new Properties();
+        properties.setProperty("dest/artifact_folder/file.txt", CachedDigestUtils.md5Hex(data));
+        properties.setProperty("dest/artifact_folder/bond/james_bond/another_file", CachedDigestUtils.md5Hex(secondData));
+        return properties;
+    }
+
+}

--- a/base/src/com/thoughtworks/go/util/FileUtil.java
+++ b/base/src/com/thoughtworks/go/util/FileUtil.java
@@ -145,6 +145,11 @@ public class FileUtil {
         if (actualFileToUse.isAbsolute()) {
             return actualFileToUse;
         }
+
+        if(StringUtil.isBlank(baseDir.getPath())) {
+            return actualFileToUse;
+        }
+
         return new File(baseDir, actualFileToUse.getPath());
 
     }

--- a/base/src/com/thoughtworks/go/util/SystemEnvironment.java
+++ b/base/src/com/thoughtworks/go/util/SystemEnvironment.java
@@ -184,6 +184,9 @@ public class SystemEnvironment implements Serializable, ConfigDirProvider {
 
     public static GoSystemProperty<Boolean> GO_API_WITH_SAFE_MODE = new GoBooleanSystemProperty("go.api.with.safe.mode", true);
 
+    public static final GoSystemProperty<? extends Boolean> ENABLE_BUILD_COMMAND_PROTOCOL = new GoBooleanSystemProperty("go.agent.enableBuildCommandProtocol", false);
+
+
     private volatile static Integer agentConnectionTimeout;
     private volatile static Integer cruiseSSlPort;
     private volatile static String cruiseConfigDir;

--- a/base/src/com/thoughtworks/go/util/command/InMemoryConsumer.java
+++ b/base/src/com/thoughtworks/go/util/command/InMemoryConsumer.java
@@ -1,5 +1,5 @@
 /*************************GO-LICENSE-START*********************************
- * Copyright 2014 ThoughtWorks, Inc.
+ * Copyright 2016 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,13 +16,15 @@
 
 package com.thoughtworks.go.util.command;
 
+import org.apache.log4j.Logger;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.TimeUnit;
 
 import static com.thoughtworks.go.util.ListUtil.join;
-import org.apache.log4j.Logger;
 
 public class InMemoryConsumer implements StreamConsumer {
     private Queue<String> lines = new ConcurrentLinkedQueue<String>();
@@ -45,6 +47,40 @@ public class InMemoryConsumer implements StreamConsumer {
     }
 
     public String toString() {
+        return output();
+    }
+
+    public String output() {
         return join(asList(), "\n");
+    }
+
+    public String lastLine() {
+        List<String> lines = asList();
+        return lines.get(lines.size() - 1);
+    }
+
+    public String firstLine() {
+        return asList().get(0);
+    }
+
+    public int lineCount() {
+        return lines.size();
+    }
+
+    public void waitForContain(String content, int timeoutInSeconds) throws InterruptedException {
+        long start = System.nanoTime();
+        while (true) {
+            if (contains(content)) {
+                break;
+            }
+            if (System.nanoTime() - start > TimeUnit.SECONDS.toNanos(timeoutInSeconds)) {
+                throw new RuntimeException("waiting timeout!");
+            }
+            Thread.sleep(10);
+        }
+    }
+
+    public void clear() {
+        lines.clear();
     }
 }

--- a/base/src/com/thoughtworks/go/util/command/InMemoryConsumer.java
+++ b/base/src/com/thoughtworks/go/util/command/InMemoryConsumer.java
@@ -47,40 +47,6 @@ public class InMemoryConsumer implements StreamConsumer {
     }
 
     public String toString() {
-        return output();
-    }
-
-    public String output() {
         return join(asList(), "\n");
-    }
-
-    public String lastLine() {
-        List<String> lines = asList();
-        return lines.get(lines.size() - 1);
-    }
-
-    public String firstLine() {
-        return asList().get(0);
-    }
-
-    public int lineCount() {
-        return lines.size();
-    }
-
-    public void waitForContain(String content, int timeoutInSeconds) throws InterruptedException {
-        long start = System.nanoTime();
-        while (true) {
-            if (contains(content)) {
-                break;
-            }
-            if (System.nanoTime() - start > TimeUnit.SECONDS.toNanos(timeoutInSeconds)) {
-                throw new RuntimeException("waiting timeout!");
-            }
-            Thread.sleep(10);
-        }
-    }
-
-    public void clear() {
-        lines.clear();
     }
 }

--- a/common/src/com/thoughtworks/go/buildsession/ArtifactsRepository.java
+++ b/common/src/com/thoughtworks/go/buildsession/ArtifactsRepository.java
@@ -1,0 +1,26 @@
+/*************************** GO-LICENSE-START*********************************
+ * Copyright 2016 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ************************GO-LICENSE-END***********************************/
+package com.thoughtworks.go.buildsession;
+
+import com.thoughtworks.go.domain.Property;
+import com.thoughtworks.go.util.command.StreamConsumer;
+
+import java.io.File;
+
+public interface ArtifactsRepository {
+    void upload(StreamConsumer console, File file, String destPath, String buildId);
+    void setProperty(Property property);
+}

--- a/common/src/com/thoughtworks/go/buildsession/BuildCommandExecutor.java
+++ b/common/src/com/thoughtworks/go/buildsession/BuildCommandExecutor.java
@@ -1,0 +1,22 @@
+/*************************** GO-LICENSE-START*********************************
+ * Copyright 2016 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ************************GO-LICENSE-END***********************************/
+package com.thoughtworks.go.buildsession;
+
+import com.thoughtworks.go.domain.BuildCommand;
+
+public interface BuildCommandExecutor {
+    boolean execute(BuildCommand command, BuildSession buildSession);
+}

--- a/common/src/com/thoughtworks/go/buildsession/BuildSession.java
+++ b/common/src/com/thoughtworks/go/buildsession/BuildSession.java
@@ -1,0 +1,316 @@
+/*************************** GO-LICENSE-START*********************************
+ * Copyright 2016 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ************************GO-LICENSE-END***********************************/
+package com.thoughtworks.go.buildsession;
+
+import com.thoughtworks.go.domain.*;
+import com.thoughtworks.go.util.Clock;
+import com.thoughtworks.go.util.GoConstants;
+import com.thoughtworks.go.util.HttpService;
+import com.thoughtworks.go.util.command.ProcessOutputStreamConsumer;
+import com.thoughtworks.go.util.command.SafeOutputStreamConsumer;
+import com.thoughtworks.go.util.command.StreamConsumer;
+import org.apache.commons.lang.text.StrLookup;
+import org.apache.commons.lang.text.StrSubstitutor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.util.*;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static com.thoughtworks.go.util.ExceptionUtils.bomb;
+import static com.thoughtworks.go.util.ExceptionUtils.messageOf;
+import static com.thoughtworks.go.util.FileUtil.applyBaseDirIfRelative;
+import static java.lang.String.format;
+
+public class BuildSession {
+    private static final Logger LOG = LoggerFactory.getLogger(BuildSession.class);
+    private final Map<String, String> envs;
+    private final List<SecretSubstitution> secretSubstitutions;
+    private final String buildId;
+    private final BuildStateReporter buildStateReporter;
+    private final StreamConsumer console;
+    private final DownloadAction downloadAction;
+    private File workingDir;
+    private JobResult buildResult;
+    private final StrLookup buildVariables;
+    private ArtifactsRepository artifactsRepository;
+    private HttpService httpService;
+    private Clock clock;
+    private final CountDownLatch doneLatch;
+    private CountDownLatch cancelLatch;
+
+    private static Map<String, BuildCommandExecutor> executors = new HashMap<>();
+
+    static {
+        executors.put("echo", new EchoCommandExecutor());
+        executors.put("downloadDir", new DownloadDirCommandExecutor());
+        executors.put("downloadFile", new DownloadFileCommandExecutor());
+        executors.put("uploadArtifact", new UploadArtifactCommandExecutor());
+        executors.put("secret", new SecretCommandExecutor());
+        executors.put("export", new ExportCommandExecutor());
+        executors.put("compose", new ComposeCommandExecutor());
+        executors.put("fail", new FailCommandExecutor());
+        executors.put("mkdirs", new MkdirsCommandExecutor());
+        executors.put("cleandir", new CleandirCommandExecutor());
+        executors.put("exec", new ExecCommandExecutor());
+        executors.put("test", new TestCommandExecutor());
+        executors.put("reportCurrentStatus", new ReportCurrentStatusCommandExecutor());
+        executors.put("reportCompleting", new ReportCompletingCommandExecutor());
+        executors.put("generateTestReport", new GenerateTestReportCommandExecutor());
+        executors.put("generateProperty", new GeneratePropertyCommandExecutor());
+    }
+
+    public BuildSession(String buildId, BuildStateReporter buildStateReporter, StreamConsumer console, StrLookup buildVariables, ArtifactsRepository artifactsRepository, HttpService httpService, Clock clock, File workingDir) {
+        this.buildId = buildId;
+        this.buildStateReporter = buildStateReporter;
+        this.console = console;
+        this.buildVariables = buildVariables;
+        this.artifactsRepository = artifactsRepository;
+        this.httpService = httpService;
+        this.clock = clock;
+        this.workingDir = workingDir;
+        this.envs = new HashMap<>();
+        this.secretSubstitutions = new ArrayList<>();
+        this.buildResult = JobResult.Passed;
+        this.doneLatch = new CountDownLatch(1);
+        this.cancelLatch = new CountDownLatch(1);
+        this.downloadAction = new DownloadAction(httpService, getPublisher(), clock);
+    }
+
+    public void setEnv(String name, String value) {
+        if (value == null) {
+            value = "";
+        }
+        envs.put(name, value);
+    }
+
+    /**
+     * Cancel build and wait for build session done
+     *
+     * @return {@code true} if the build session is done and {@code false}
+     * if time out happens
+     */
+    public boolean cancel(int timeout, TimeUnit timeoutUnit) throws InterruptedException {
+        if (isCanceled()) {
+            return true;
+        }
+        cancelLatch.countDown();
+        return doneLatch.await(timeout, timeoutUnit);
+    }
+
+    public JobResult build(BuildCommand command) {
+        if (isDone()) {
+            throw bomb("Shall not reuse a build session!");
+        }
+
+        try {
+            processCommand(command);
+            return buildResult;
+        } finally {
+            try {
+                buildStateReporter.reportCompleted(buildId, buildResult);
+            } finally {
+                doneLatch.countDown();
+            }
+        }
+    }
+
+    boolean processCommand(BuildCommand command) {
+        if (isCanceled()) {
+            buildResult = JobResult.Cancelled;
+            return false;
+        }
+
+        LOG.debug("Processing build command {}", command);
+
+        BuildCommandExecutor executor = executors.get(command.getName());
+        if (executor == null) {
+            LOG.error("Unknown command: " + command.getName());
+            println("error: build command " + command.getName() + " is not supported. Please upgrade GoCD agent");
+            buildResult = JobResult.Failed;
+            return false;
+        }
+
+        boolean success = doProcess(command, executor);
+
+        if (isCanceled()) {
+            buildResult = JobResult.Cancelled;
+            return false;
+        }
+
+        if(!success) {
+            this.buildResult = JobResult.Failed;
+        }
+
+        return success;
+    }
+
+    private boolean doProcess(BuildCommand command, BuildCommandExecutor executor) {
+        BuildCommand onCancelCommand = command.getOnCancel();
+
+        try {
+            if (("passed".equals(command.getRunIfConfig()) && buildResult.isFailed())
+                    || ("failed".equals(command.getRunIfConfig()) && this.buildResult.isPassed())) {
+                return true;
+            }
+
+            BuildCommand test = command.getTest();
+            if (test != null) {
+                if (!newTestingSession(console).processCommand(test)) {
+                    return true;
+                }
+            }
+
+            if (isCanceled()) {
+                return false;
+            }
+
+            return executor.execute(command, this);
+
+        } catch (Exception e) {
+            reportException(e);
+            return false;
+        } finally {
+            if (isCanceled() && onCancelCommand != null) {
+                newCancelSession().processCommand(onCancelCommand);
+            }
+        }
+    }
+
+    private void reportException(Exception e) {
+        String msg = messageOf(e);
+        try {
+            LOG.error(msg, e);
+            println(msg);
+        } catch (Exception reportException) {
+            LOG.error(format("Unable to report error message - %s.", messageOf(e)), reportException);
+        }
+    }
+
+    void addSecret(String secret, String substitution) {
+        if (substitution == null) {
+            substitution = "******";
+        }
+        this.secretSubstitutions.add(new SecretSubstitution(secret, substitution));
+    }
+
+    Map<String, String> getEnvs() {
+        return Collections.unmodifiableMap(envs);
+    }
+
+    void printlnSafely(String line) {
+        newSafeConsole().stdOutput(line);
+    }
+
+    void println(String line) {
+        console.consumeLine(line);
+    }
+
+    public void printlnWithPrefix(String line) {
+        this.println(String.format("[%s] %s", GoConstants.PRODUCT_NAME, line));
+    }
+
+    String buildVariableSubstitude(String str) {
+        return new StrSubstitutor(buildVariables).replace(str);
+    }
+
+    void upload(File file, String dest) {
+        getPublisher().upload(file, dest);
+    }
+
+    ProcessOutputStreamConsumer processOutputStreamConsumer() {
+        return new ProcessOutputStreamConsumer<>(console, console);
+    }
+
+    List<SecretSubstitution> getSecretSubstitutions() {
+        return Collections.unmodifiableList(secretSubstitutions);
+    }
+
+    void waitUntilCanceled() throws InterruptedException {
+        cancelLatch.await();
+    }
+
+    void reportBuildStatus(String status) {
+        buildStateReporter.reportBuildStatus(buildId, JobState.valueOf(status));
+    }
+
+    void reportCompleting() {
+        buildStateReporter.reportCompleting(buildId, buildResult);
+    }
+
+    BuildSession newTestingSession(StreamConsumer console) {
+        BuildSession buildSession = new BuildSession(
+                buildId, new UncaringBuildStateReport(), console, buildVariables, artifactsRepository, httpService, clock, workingDir);
+        buildSession.cancelLatch = this.cancelLatch;
+        return buildSession;
+    }
+
+
+    void download(FetchHandler handler, String url, ChecksumFileHandler checksumFileHandler, String checksumUrl) {
+        try {
+            if (checksumFileHandler != null) {
+                downloadAction.perform(checksumUrl, checksumFileHandler);
+                handler.useArtifactMd5Checksums(checksumFileHandler.getArtifactMd5Checksums());
+            }
+
+            downloadAction.perform(url, handler);
+        } catch (InterruptedException e) {
+            throw new RuntimeException("download interrupted");
+        }
+    }
+
+    BuildSessionGoPublisher getPublisher() {
+        return new BuildSessionGoPublisher(console, artifactsRepository, buildId);
+    }
+
+
+    private BuildSession newCancelSession() {
+        return new BuildSession(buildId, new UncaringBuildStateReport(),
+                console, buildVariables, artifactsRepository, httpService, clock, workingDir);
+    }
+
+
+    private boolean isDone() {
+        return doneLatch.getCount() < 1;
+    }
+
+    private boolean isCanceled() {
+        return cancelLatch.getCount() < 1;
+    }
+
+    private SafeOutputStreamConsumer newSafeConsole() {
+        ProcessOutputStreamConsumer processConsumer = new ProcessOutputStreamConsumer<>(console, console);
+        SafeOutputStreamConsumer streamConsumer = new SafeOutputStreamConsumer(processConsumer);
+        for (SecretSubstitution secretSubstitution : secretSubstitutions) {
+            streamConsumer.addSecret(secretSubstitution);
+        }
+        return streamConsumer;
+    }
+
+    File resolveRelativeDir(String... dirs) {
+        if (dirs.length == 0) {
+            return workingDir;
+        }
+
+        File result = new File(dirs[dirs.length - 1]);
+        for (int i = dirs.length - 2; i >= 0; i--) {
+            result = applyBaseDirIfRelative(new File(dirs[i]), result);
+        }
+        return applyBaseDirIfRelative(workingDir, result);
+    }
+}

--- a/common/src/com/thoughtworks/go/buildsession/BuildSession.java
+++ b/common/src/com/thoughtworks/go/buildsession/BuildSession.java
@@ -225,7 +225,7 @@ public class BuildSession {
         this.println(String.format("[%s] %s", GoConstants.PRODUCT_NAME, line));
     }
 
-    String buildVariableSubstitude(String str) {
+    String buildVariableSubstitute(String str) {
         return new StrSubstitutor(buildVariables).replace(str);
     }
 

--- a/common/src/com/thoughtworks/go/buildsession/BuildSessionGoPublisher.java
+++ b/common/src/com/thoughtworks/go/buildsession/BuildSessionGoPublisher.java
@@ -1,0 +1,64 @@
+/*************************** GO-LICENSE-START*********************************
+ * Copyright 2016 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ************************GO-LICENSE-END***********************************/
+package com.thoughtworks.go.buildsession;
+
+import com.thoughtworks.go.domain.Property;
+import com.thoughtworks.go.util.GoConstants;
+import com.thoughtworks.go.util.command.StreamConsumer;
+import com.thoughtworks.go.work.GoPublisher;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import java.io.File;
+
+class BuildSessionGoPublisher implements GoPublisher {
+    private static final Log LOG = LogFactory.getLog(BuildSessionGoPublisher.class);
+    private final StreamConsumer buildConsole;
+    private final ArtifactsRepository artifactsRepository;
+    private String buildId;
+
+    public BuildSessionGoPublisher(StreamConsumer buildConsole, ArtifactsRepository artifactsRepository, String buildId) {
+        this.buildConsole = buildConsole;
+        this.artifactsRepository = artifactsRepository;
+        this.buildId = buildId;
+    }
+
+    @Override
+    public void upload(File fileToUpload, String destPath) {
+        artifactsRepository.upload(buildConsole, fileToUpload, destPath, buildId);
+    }
+
+    @Override
+    public void consumeLineWithPrefix(String message) {
+        consumeLine(String.format("[%s] %s", GoConstants.PRODUCT_NAME, message));
+    }
+
+    @Override
+    public void setProperty(Property property) {
+        artifactsRepository.setProperty(property);
+    }
+
+    @Override
+    public void reportErrorMessage(String message, Exception e) {
+        LOG.error(message, e);
+        consumeLine(message);
+    }
+
+    @Override
+    public void consumeLine(String line) {
+        buildConsole.consumeLine(line);
+    }
+}

--- a/common/src/com/thoughtworks/go/buildsession/BuildStateReporter.java
+++ b/common/src/com/thoughtworks/go/buildsession/BuildStateReporter.java
@@ -1,0 +1,25 @@
+/*************************** GO-LICENSE-START*********************************
+ * Copyright 2016 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ************************GO-LICENSE-END***********************************/
+package com.thoughtworks.go.buildsession;
+
+import com.thoughtworks.go.domain.JobResult;
+import com.thoughtworks.go.domain.JobState;
+
+public interface BuildStateReporter {
+    void reportBuildStatus(String buildId, JobState buildState);
+    void reportCompleted(String buildId, JobResult buildResult);
+    void reportCompleting(String buildId, JobResult buildResult);
+}

--- a/common/src/com/thoughtworks/go/buildsession/BuildVariables.java
+++ b/common/src/com/thoughtworks/go/buildsession/BuildVariables.java
@@ -1,0 +1,52 @@
+/*************************** GO-LICENSE-START*********************************
+ * Copyright 2016 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ************************GO-LICENSE-END***********************************/
+package com.thoughtworks.go.buildsession;
+
+import com.thoughtworks.go.server.service.AgentRuntimeInfo;
+import com.thoughtworks.go.util.Clock;
+import org.apache.commons.lang.text.StrLookup;
+
+import java.text.SimpleDateFormat;
+
+import static com.thoughtworks.go.util.MapBuilder.map;
+
+public class BuildVariables extends StrLookup {
+    private final StrLookup staticLookup;
+    private final Clock clock;
+
+    public BuildVariables(AgentRuntimeInfo agentRuntimeInfo, Clock clock) {
+        this.clock = clock;
+        this.staticLookup = StrLookup.mapLookup(map(
+                "agent.location", agentRuntimeInfo.getLocation(),
+                "agent.hostname", agentRuntimeInfo.getHostName()
+        ));
+    }
+
+    @Override
+    public String lookup(String key) {
+        String staticResult = staticLookup.lookup(key);
+        if(staticResult != null) {
+            return staticResult;
+        }
+
+        if(key.equals("date")) {
+            return new SimpleDateFormat("yyyy-MM-dd HH:mm:ss z").format(clock.currentTime());
+        }
+
+        return null;
+    }
+
+}

--- a/common/src/com/thoughtworks/go/buildsession/CleandirCommandExecutor.java
+++ b/common/src/com/thoughtworks/go/buildsession/CleandirCommandExecutor.java
@@ -1,0 +1,46 @@
+/*************************** GO-LICENSE-START*********************************
+ * Copyright 2016 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ************************GO-LICENSE-END***********************************/
+package com.thoughtworks.go.buildsession;
+
+import com.google.gson.Gson;
+import com.thoughtworks.go.domain.BuildCommand;
+import com.thoughtworks.go.domain.materials.DirectoryCleaner;
+import org.apache.commons.io.FileUtils;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+
+public class CleandirCommandExecutor implements BuildCommandExecutor {
+    @Override
+    public boolean execute(BuildCommand command, BuildSession buildSession) {
+        File dir = buildSession.resolveRelativeDir(command.getWorkingDirectory(), command.getStringArg("path"));
+        String[] allowed = command.getArrayArg("allowed");
+        if (allowed.length == 0) {
+            try {
+                FileUtils.cleanDirectory(dir);
+            } catch (IOException e) {
+                return false;
+            }
+        } else {
+            DirectoryCleaner cleaner = new DirectoryCleaner(dir, buildSession.processOutputStreamConsumer());
+            cleaner.allowed(allowed);
+            cleaner.clean();
+        }
+        return true;
+    }
+}

--- a/common/src/com/thoughtworks/go/buildsession/CleandirCommandExecutor.java
+++ b/common/src/com/thoughtworks/go/buildsession/CleandirCommandExecutor.java
@@ -15,15 +15,12 @@
  * ************************GO-LICENSE-END***********************************/
 package com.thoughtworks.go.buildsession;
 
-import com.google.gson.Gson;
 import com.thoughtworks.go.domain.BuildCommand;
 import com.thoughtworks.go.domain.materials.DirectoryCleaner;
 import org.apache.commons.io.FileUtils;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.Collections;
-import java.util.List;
 
 public class CleandirCommandExecutor implements BuildCommandExecutor {
     @Override

--- a/common/src/com/thoughtworks/go/buildsession/ComposeCommandExecutor.java
+++ b/common/src/com/thoughtworks/go/buildsession/ComposeCommandExecutor.java
@@ -1,0 +1,31 @@
+/*************************** GO-LICENSE-START*********************************
+ * Copyright 2016 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ************************GO-LICENSE-END***********************************/
+package com.thoughtworks.go.buildsession;
+
+import com.thoughtworks.go.domain.BuildCommand;
+
+public class ComposeCommandExecutor implements BuildCommandExecutor {
+    @Override
+    public boolean execute(BuildCommand command, BuildSession buildSession) {
+        boolean success = true;
+        for (BuildCommand sub : command.getSubCommands()) {
+            if (!buildSession.processCommand(sub)) {
+                success = false;
+            }
+        }
+        return success;
+    }
+}

--- a/common/src/com/thoughtworks/go/buildsession/ConsoleCapture.java
+++ b/common/src/com/thoughtworks/go/buildsession/ConsoleCapture.java
@@ -1,0 +1,38 @@
+/*************************** GO-LICENSE-START*********************************
+ * Copyright 2016 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ************************GO-LICENSE-END***********************************/
+package com.thoughtworks.go.buildsession;
+
+import com.thoughtworks.go.util.command.StreamConsumer;
+import org.apache.commons.lang.StringUtils;
+
+import java.util.ArrayList;
+
+class ConsoleCapture implements StreamConsumer {
+    private final ArrayList<String> captured;
+
+    public ConsoleCapture() {
+        this.captured = new ArrayList<>();
+    }
+
+    @Override
+    public void consumeLine(String line) {
+        captured.add(line);
+    }
+
+    public String captured() {
+        return StringUtils.join(captured, "\n");
+    }
+}

--- a/common/src/com/thoughtworks/go/buildsession/DownloadDirCommandExecutor.java
+++ b/common/src/com/thoughtworks/go/buildsession/DownloadDirCommandExecutor.java
@@ -1,0 +1,51 @@
+/*************************** GO-LICENSE-START*********************************
+ * Copyright 2016 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ************************GO-LICENSE-END***********************************/
+package com.thoughtworks.go.buildsession;
+
+import com.thoughtworks.go.domain.BuildCommand;
+import com.thoughtworks.go.domain.ChecksumFileHandler;
+import com.thoughtworks.go.domain.DirHandler;
+import com.thoughtworks.go.util.TempFiles;
+import com.thoughtworks.go.util.URLService;
+
+import java.io.File;
+
+public class DownloadDirCommandExecutor implements BuildCommandExecutor {
+    @Override
+    public boolean execute(BuildCommand command, BuildSession buildSession) {
+        URLService urlService = new URLService();
+        String url = urlService.prefixPartialUrl(command.getStringArg("url"));
+        String dest = command.getStringArg("dest");
+        String src = command.getStringArg("src");
+        String checksumUrl = null;
+        ChecksumFileHandler checksumFileHandler = null;
+
+        if (command.hasArg("checksumUrl")) {
+            checksumUrl = new URLService().prefixPartialUrl(command.getStringArg("checksumUrl"));
+            File checksumFile;
+            if (command.hasArg("checksumFile")) {
+                checksumFile = buildSession.resolveRelativeDir(command.getWorkingDirectory(), command.getStringArg("checksumFile"));
+            } else {
+                checksumFile = TempFiles.createUniqueFile("checksum");
+            }
+            checksumFileHandler = new ChecksumFileHandler(checksumFile);
+        }
+
+        DirHandler handler = new DirHandler(src, buildSession.resolveRelativeDir(command.getWorkingDirectory(), dest));
+        buildSession.download(handler, url, checksumFileHandler, checksumUrl);
+        return true;
+    }
+}

--- a/common/src/com/thoughtworks/go/buildsession/DownloadFileCommandExecutor.java
+++ b/common/src/com/thoughtworks/go/buildsession/DownloadFileCommandExecutor.java
@@ -1,0 +1,75 @@
+/*************************** GO-LICENSE-START*********************************
+ * Copyright 2016 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ************************GO-LICENSE-END***********************************/
+package com.thoughtworks.go.buildsession;
+
+import com.thoughtworks.go.domain.BuildCommand;
+import com.thoughtworks.go.domain.ChecksumFileHandler;
+import com.thoughtworks.go.domain.FileHandler;
+import com.thoughtworks.go.util.StringUtil;
+import com.thoughtworks.go.util.TempFiles;
+import com.thoughtworks.go.util.URLService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.UnsupportedEncodingException;
+
+public class DownloadFileCommandExecutor implements BuildCommandExecutor {
+    private static final Logger LOG = LoggerFactory.getLogger(DownloadFileCommandExecutor.class);
+
+    @Override
+    public boolean execute(BuildCommand command, BuildSession buildSession) {
+        URLService urlService = new URLService();
+        String url = urlService.prefixPartialUrl(command.getStringArg("url"));
+        String dest = command.getStringArg("dest");
+        String src = command.getStringArg("src");
+        File artifact = buildSession.resolveRelativeDir(command.getWorkingDirectory(), dest);
+        FileHandler handler = new FileHandler(artifact, src);
+        String checksumUrl = null;
+        ChecksumFileHandler checksumFileHandler = null;
+
+        if (command.hasArg("checksumUrl")) {
+            checksumUrl = new URLService().prefixPartialUrl(command.getStringArg("checksumUrl"));
+            File checksumFile;
+            if (command.hasArg("checksumFile")) {
+                checksumFile = buildSession.resolveRelativeDir(command.getWorkingDirectory(), command.getStringArg("checksumFile"));
+            } else {
+                checksumFile = TempFiles.createUniqueFile("checksum");
+            }
+            checksumFileHandler = new ChecksumFileHandler(checksumFile);
+        }
+
+
+        boolean fileExist = artifact.exists();
+        if (LOG.isDebugEnabled()) {
+            LOG.debug(
+                    "Requesting the file [" + artifact.getAbsolutePath() + "], exist? [" + fileExist + "]");
+        }
+
+        if (fileExist && artifact.isFile()) {
+            try {
+                url += "?sha1=" + java.net.URLEncoder.encode(StringUtil.sha1Digest(artifact), "UTF-8");
+            } catch (UnsupportedEncodingException e) {
+                LOG.error("Download error", e);
+                return false;
+            }
+        }
+
+        buildSession.download(handler, url, checksumFileHandler, checksumUrl);
+        return true;
+
+    }
+}

--- a/common/src/com/thoughtworks/go/buildsession/EchoCommandExecutor.java
+++ b/common/src/com/thoughtworks/go/buildsession/EchoCommandExecutor.java
@@ -1,0 +1,27 @@
+/*************************** GO-LICENSE-START*********************************
+ * Copyright 2016 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ************************GO-LICENSE-END***********************************/
+package com.thoughtworks.go.buildsession;
+
+import com.thoughtworks.go.domain.BuildCommand;
+
+public class EchoCommandExecutor implements BuildCommandExecutor {
+    @Override
+    public boolean execute(BuildCommand command, BuildSession buildSession) {
+        String line = command.getStringArg("line");
+        buildSession.println(buildSession.buildVariableSubstitude(line));
+        return true;
+    }
+}

--- a/common/src/com/thoughtworks/go/buildsession/EchoCommandExecutor.java
+++ b/common/src/com/thoughtworks/go/buildsession/EchoCommandExecutor.java
@@ -21,7 +21,7 @@ public class EchoCommandExecutor implements BuildCommandExecutor {
     @Override
     public boolean execute(BuildCommand command, BuildSession buildSession) {
         String line = command.getStringArg("line");
-        buildSession.println(buildSession.buildVariableSubstitude(line));
+        buildSession.println(buildSession.buildVariableSubstitute(line));
         return true;
     }
 }

--- a/common/src/com/thoughtworks/go/buildsession/ErrorCommandExecutor.java
+++ b/common/src/com/thoughtworks/go/buildsession/ErrorCommandExecutor.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2016 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.thoughtworks.go.buildsession;
+
+import com.thoughtworks.go.domain.BuildCommand;
+
+// this is not part of the protocol. only for error flow testing
+public class ErrorCommandExecutor implements BuildCommandExecutor {
+    @Override
+    public boolean execute(BuildCommand command, BuildSession buildSession) {
+        throw new RuntimeException(command.getStringArg("message"));
+    }
+}

--- a/common/src/com/thoughtworks/go/buildsession/ExecCommandExecutor.java
+++ b/common/src/com/thoughtworks/go/buildsession/ExecCommandExecutor.java
@@ -1,0 +1,122 @@
+/*************************** GO-LICENSE-START*********************************
+ * Copyright 2016 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ************************GO-LICENSE-END***********************************/
+package com.thoughtworks.go.buildsession;
+
+import com.jezhumble.javasysmon.JavaSysMon;
+import com.thoughtworks.go.domain.BuildCommand;
+import com.thoughtworks.go.util.SystemUtil;
+import com.thoughtworks.go.util.command.CommandLine;
+import com.thoughtworks.go.util.command.CommandLineException;
+import com.thoughtworks.go.util.command.StringArgument;
+import org.apache.commons.lang.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static java.lang.String.format;
+
+public class ExecCommandExecutor implements BuildCommandExecutor {
+    private static final Logger LOG = LoggerFactory.getLogger(ExecCommandExecutor.class);
+
+    @Override
+    public boolean execute(BuildCommand command, BuildSession buildSession) {
+        File workingDir = buildSession.resolveRelativeDir(command.getWorkingDirectory());
+        if (!workingDir.isDirectory()) {
+            String message = "Working directory \"" + workingDir.getAbsolutePath() + "\" is not a directory!";
+            LOG.error(message);
+            buildSession.println(message);
+            return false;
+        }
+
+        String cmd = command.getStringArg("command");
+        String[] args = command.getArrayArg("args");
+        CommandLine commandLine;
+
+        if (SystemUtil.isWindows()) {
+            commandLine = CommandLine.createCommandLine("cmd");
+            commandLine.withArg("/c");
+            commandLine.withArg(StringUtils.replace(cmd, "/", "\\"));
+        } else {
+            commandLine = CommandLine.createCommandLine(cmd);
+        }
+        commandLine.withWorkingDir(workingDir);
+        commandLine.withEnv(buildSession.getEnvs());
+        commandLine.withArgs(args);
+        for (SecretSubstitution secretSubstitution : buildSession.getSecretSubstitutions()) {
+            commandLine.withNonArgSecret(secretSubstitution);
+        }
+        return executeCommandLine(buildSession, commandLine) == 0;
+    }
+
+    private int executeCommandLine(final BuildSession buildSession, final CommandLine commandLine) {
+        ExecutorService executorService = Executors.newFixedThreadPool(2);
+        final AtomicInteger exitCode = new AtomicInteger(-1);
+        final CountDownLatch canceledOrDone = new CountDownLatch(1);
+
+        try {
+            final Future<?> executing = executorService.submit(new Runnable() {
+                @Override
+                public void run() {
+                    try {
+                        exitCode.set(commandLine.run(buildSession.processOutputStreamConsumer(), null));
+                    } catch (CommandLineException e) {
+                        LOG.error("Command failed", e);
+                        String message = format("Error happened while attempting to execute '%s'. \nPlease make sure [%s] can be executed on this agent.\n", commandLine.toStringForDisplay(), commandLine.getExecutable());
+                        String path = System.getenv("PATH");
+                        buildSession.println(message);
+                        buildSession.println(format("[Debug Information] Environment variable PATH: %s", path));
+                        LOG.error(format("[Command Line] %s. Path: %s", message, path));
+                    } finally {
+                        canceledOrDone.countDown();
+                    }
+                }
+            });
+
+            Future<?> cancelMonitor = executorService.submit(new Runnable() {
+                @Override
+                public void run() {
+                    try {
+                        buildSession.waitUntilCanceled();
+                        executing.cancel(true);
+                        new JavaSysMon().infanticide();
+                    } catch (InterruptedException e) {
+                        //ignored
+                    } finally {
+                        canceledOrDone.countDown();
+                    }
+                }
+            });
+
+            try {
+                canceledOrDone.await();
+            } catch (InterruptedException e) {
+                LOG.error("Building thread interrupted", e);
+            }
+            executing.cancel(true);
+            cancelMonitor.cancel(true);
+            return exitCode.get();
+        } finally {
+            executorService.shutdown();
+        }
+
+    }
+}

--- a/common/src/com/thoughtworks/go/buildsession/ExportCommandExecutor.java
+++ b/common/src/com/thoughtworks/go/buildsession/ExportCommandExecutor.java
@@ -1,0 +1,54 @@
+/*************************** GO-LICENSE-START*********************************
+ * Copyright 2016 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ************************GO-LICENSE-END***********************************/
+package com.thoughtworks.go.buildsession;
+
+import com.thoughtworks.go.domain.BuildCommand;
+import com.thoughtworks.go.util.GoConstants;
+import com.thoughtworks.go.util.ProcessManager;
+import com.thoughtworks.go.util.command.EnvironmentVariableContext;
+
+import java.util.Set;
+
+import static java.lang.String.format;
+
+public class ExportCommandExecutor implements BuildCommandExecutor {
+    @Override
+    public boolean execute(BuildCommand command, BuildSession buildSession) {
+        String name = command.getStringArg("name");
+
+        if (!command.hasArg("value")) {
+            String displayValue = buildSession.getEnvs().get(name);
+            buildSession.printlnSafely(format("[%s] setting environment variable '%s' to value '%s'",
+                    GoConstants.PRODUCT_NAME, name, displayValue));
+            return true;
+        }
+
+        String value = command.getStringArg("value");
+        boolean secure = command.getBooleanArg("secure");
+        String displayValue = secure ? EnvironmentVariableContext.EnvironmentVariable.MASK_VALUE : value;
+        Set<String> processLevelEnvs = ProcessManager.getInstance().environmentVariableNames();
+
+        if (buildSession.getEnvs().containsKey(name) || processLevelEnvs.contains(name)) {
+            buildSession.printlnSafely(format("[%s] overriding environment variable '%s' with value '%s'",
+                    GoConstants.PRODUCT_NAME, name, displayValue));
+        } else {
+            buildSession.printlnSafely(format("[%s] setting environment variable '%s' to value '%s'",
+                    GoConstants.PRODUCT_NAME, name, displayValue));
+        }
+        buildSession.setEnv(name, value);
+        return true;
+    }
+}

--- a/common/src/com/thoughtworks/go/buildsession/FailCommandExecutor.java
+++ b/common/src/com/thoughtworks/go/buildsession/FailCommandExecutor.java
@@ -1,0 +1,28 @@
+/*************************** GO-LICENSE-START*********************************
+ * Copyright 2016 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ************************GO-LICENSE-END***********************************/
+package com.thoughtworks.go.buildsession;
+
+import com.thoughtworks.go.domain.BuildCommand;
+
+public class FailCommandExecutor implements BuildCommandExecutor {
+    @Override
+    public boolean execute(BuildCommand command, BuildSession buildSession) {
+        if (command.hasArg("message")) {
+            buildSession.println(command.getStringArg("message"));
+        }
+        return false;
+    }
+}

--- a/common/src/com/thoughtworks/go/buildsession/GeneratePropertyCommandExecutor.java
+++ b/common/src/com/thoughtworks/go/buildsession/GeneratePropertyCommandExecutor.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2016 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.thoughtworks.go.buildsession;
+
+import com.thoughtworks.go.domain.BuildCommand;
+import com.thoughtworks.go.domain.Property;
+import com.thoughtworks.go.util.ExceptionUtils;
+import com.thoughtworks.go.util.XpathUtils;
+
+import javax.xml.xpath.XPathExpressionException;
+import java.io.File;
+
+import static java.lang.String.format;
+
+public class GeneratePropertyCommandExecutor implements BuildCommandExecutor {
+    @Override
+    public boolean execute(BuildCommand command, BuildSession buildSession) {
+        String propertyName = command.getStringArg("name");
+        File file = buildSession.resolveRelativeDir(command.getWorkingDirectory(), command.getStringArg("src"));
+        String xpath = command.getStringArg("xpath");
+        String indent = "             ";
+        if (!file.exists()) {
+            buildSession.println(format("%sFailed to create property %s. File %s does not exist.", indent, propertyName, file.getAbsolutePath()));
+            return true;
+        }
+
+        try {
+            if (!XpathUtils.nodeExists(file, xpath)) {
+                buildSession.println(format("%sFailed to create property %s. Nothing matched xpath \"%s\" in the file: %s.", indent, propertyName, xpath, file.getAbsolutePath()));
+            } else {
+                String value = XpathUtils.evaluate(file, xpath);
+                buildSession.getPublisher().setProperty(new Property(propertyName, value));
+
+                buildSession.println(format("%sProperty %s = %s created." + "\n", indent, propertyName, value));
+            }
+        } catch (Exception e) {
+            String error = (e instanceof XPathExpressionException) ? (format("Illegal xpath: \"%s\"", xpath)) : ExceptionUtils.messageOf(e);
+            String message = format("%sFailed to create property %s. %s", indent, propertyName, error);
+            buildSession.getPublisher().reportErrorMessage(message, e);
+        }
+
+        return true;
+    }
+}

--- a/common/src/com/thoughtworks/go/buildsession/GenerateTestReportCommandExecutor.java
+++ b/common/src/com/thoughtworks/go/buildsession/GenerateTestReportCommandExecutor.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2016 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.thoughtworks.go.buildsession;
+
+import com.thoughtworks.go.domain.BuildCommand;
+import com.thoughtworks.go.domain.UnitTestReportGenerator;
+import com.thoughtworks.go.domain.WildcardScanner;
+import com.thoughtworks.go.util.FileUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.text.MessageFormat;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class GenerateTestReportCommandExecutor implements BuildCommandExecutor {
+    private static final Logger LOG = LoggerFactory.getLogger(GenerateTestReportCommandExecutor.class);
+
+    @Override
+    public boolean execute(BuildCommand command, BuildSession buildSession) {
+        File workingDirectory = buildSession.resolveRelativeDir(command.getWorkingDirectory());
+        String uploadPath = command.getStringArg("uploadPath");
+        String[] sources = command.getArrayArg("srcs");
+        ArrayList<File> allFiles = findMatchedSourceFiles(buildSession, workingDirectory, sources);
+        if (allFiles.size() > 0) {
+            File tempFolder = null;
+            try {
+                tempFolder = FileUtil.createTempFolder();
+                File testResultSource = new File(tempFolder, "result");
+                testResultSource.mkdirs();
+                UnitTestReportGenerator generator = new UnitTestReportGenerator(buildSession.getPublisher(), testResultSource);
+                generator.generate(allFiles.toArray(new File[allFiles.size()]), uploadPath);
+            } finally {
+                if (tempFolder != null) {
+                    FileUtil.deleteFolder(tempFolder);
+                }
+            }
+
+        } else {
+            String message = "No files were found in the Test Results folders";
+            buildSession.printlnWithPrefix(message);
+            LOG.warn(message);
+        }
+        return true;
+    }
+
+    private ArrayList<File> findMatchedSourceFiles(BuildSession buildSession, File workingDirectory, String[] sources) {
+        ArrayList<File> allFiles = new ArrayList<>();
+        for (String src : sources) {
+            File source = new File(FileUtil.applyBaseDirIfRelativeAndNormalize(workingDirectory, new File(src)));
+
+            WildcardScanner wildcardScanner = new WildcardScanner(workingDirectory, src);
+            File[] files = wildcardScanner.getFiles();
+
+            if (files.length > 0) {
+                final List<File> fileList = files == null ? new ArrayList<File>() : Arrays.asList(files);
+                allFiles.addAll(fileList);
+            } else {
+                final String message = MessageFormat.format("The Directory {0} specified as a test artifact was not found."
+                        + " Please check your configuration", FileUtil.normalizePath(source));
+                buildSession.printlnWithPrefix(message);
+                LOG.error(message);
+            }
+        }
+        return allFiles;
+    }
+}

--- a/common/src/com/thoughtworks/go/buildsession/MkdirsCommandExecutor.java
+++ b/common/src/com/thoughtworks/go/buildsession/MkdirsCommandExecutor.java
@@ -1,0 +1,30 @@
+/*************************** GO-LICENSE-START*********************************
+ * Copyright 2016 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ************************GO-LICENSE-END***********************************/
+package com.thoughtworks.go.buildsession;
+
+import com.thoughtworks.go.domain.BuildCommand;
+
+import java.io.File;
+
+import static com.thoughtworks.go.util.FileUtil.applyBaseDirIfRelative;
+
+public class MkdirsCommandExecutor implements BuildCommandExecutor {
+    @Override
+    public boolean execute(BuildCommand command, BuildSession buildSession) {
+        File dir = buildSession.resolveRelativeDir(command.getWorkingDirectory(), command.getStringArg("path"));
+        return dir.mkdirs();
+    }
+}

--- a/common/src/com/thoughtworks/go/buildsession/ReportCompletingCommandExecutor.java
+++ b/common/src/com/thoughtworks/go/buildsession/ReportCompletingCommandExecutor.java
@@ -1,0 +1,26 @@
+/*************************** GO-LICENSE-START*********************************
+ * Copyright 2016 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ************************GO-LICENSE-END***********************************/
+package com.thoughtworks.go.buildsession;
+
+import com.thoughtworks.go.domain.BuildCommand;
+
+public class ReportCompletingCommandExecutor implements BuildCommandExecutor {
+    @Override
+    public boolean execute(BuildCommand command, BuildSession buildSession) {
+        buildSession.reportCompleting();
+        return true;
+    }
+}

--- a/common/src/com/thoughtworks/go/buildsession/ReportCurrentStatusCommandExecutor.java
+++ b/common/src/com/thoughtworks/go/buildsession/ReportCurrentStatusCommandExecutor.java
@@ -1,0 +1,26 @@
+/*************************** GO-LICENSE-START*********************************
+ * Copyright 2016 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ************************GO-LICENSE-END***********************************/
+package com.thoughtworks.go.buildsession;
+
+import com.thoughtworks.go.domain.BuildCommand;
+
+public class ReportCurrentStatusCommandExecutor implements BuildCommandExecutor {
+    @Override
+    public boolean execute(BuildCommand command, BuildSession buildSession) {
+        buildSession.reportBuildStatus(command.getStringArg("status"));
+        return true;
+    }
+}

--- a/common/src/com/thoughtworks/go/buildsession/SecretCommandExecutor.java
+++ b/common/src/com/thoughtworks/go/buildsession/SecretCommandExecutor.java
@@ -1,0 +1,31 @@
+/*************************** GO-LICENSE-START*********************************
+ * Copyright 2016 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ************************GO-LICENSE-END***********************************/
+package com.thoughtworks.go.buildsession;
+
+import com.thoughtworks.go.domain.BuildCommand;
+
+public class SecretCommandExecutor implements BuildCommandExecutor {
+    @Override
+    public boolean execute(BuildCommand command, BuildSession buildSession) {
+        String value = command.getStringArg("value");
+        String substitution = command.getStringArg("substitution");
+
+        if (value != null) {
+            buildSession.addSecret(value, substitution);
+        }
+        return true;
+    }
+}

--- a/common/src/com/thoughtworks/go/buildsession/SecretSubstitution.java
+++ b/common/src/com/thoughtworks/go/buildsession/SecretSubstitution.java
@@ -1,0 +1,33 @@
+/*************************** GO-LICENSE-START*********************************
+ * Copyright 2016 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ************************GO-LICENSE-END***********************************/
+package com.thoughtworks.go.buildsession;
+
+import com.thoughtworks.go.util.command.SecretString;
+
+class SecretSubstitution implements SecretString {
+    private final String secret;
+    private final String substitution;
+
+    public SecretSubstitution(String secret, String substitution) {
+        this.secret = secret;
+        this.substitution = substitution;
+    }
+
+    @Override
+    public String replaceSecretInfo(String line) {
+        return line.replace(secret, substitution);
+    }
+}

--- a/common/src/com/thoughtworks/go/buildsession/SubstitutableCommandArgument.java
+++ b/common/src/com/thoughtworks/go/buildsession/SubstitutableCommandArgument.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2016 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.thoughtworks.go.buildsession;
+
+import com.thoughtworks.go.util.command.CommandArgument;
+
+public class SubstitutableCommandArgument extends CommandArgument {
+    private final String argument;
+    private final String substitution;
+
+    public SubstitutableCommandArgument(String argument, String substitution) {
+        this.argument = argument;
+        this.substitution = substitution;
+    }
+
+    @Override
+    public String forCommandline() {
+        return argument;
+    }
+
+    @Override
+    public String forDisplay() {
+        return substitution;
+    }
+}

--- a/common/src/com/thoughtworks/go/buildsession/TestCommandExecutor.java
+++ b/common/src/com/thoughtworks/go/buildsession/TestCommandExecutor.java
@@ -1,0 +1,66 @@
+/*************************** GO-LICENSE-START*********************************
+ * Copyright 2016 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ************************GO-LICENSE-END***********************************/
+package com.thoughtworks.go.buildsession;
+
+import com.thoughtworks.go.domain.BuildCommand;
+
+import java.io.File;
+
+import static com.thoughtworks.go.util.ExceptionUtils.bomb;
+import static java.lang.String.format;
+
+public class TestCommandExecutor implements BuildCommandExecutor {
+    @Override
+    public boolean execute(BuildCommand command, BuildSession buildSession) {
+
+        String flag = command.getStringArg("flag");
+        String left = command.getStringArg("left");
+
+        if ("-eq".equals(flag)) {
+            return left.equals(captureSubCommandOutput(command, buildSession));
+        }
+
+        if ("-neq".equals(flag)) {
+            return !left.equals(captureSubCommandOutput(command, buildSession));
+        }
+
+        File target = buildSession.resolveRelativeDir(command.getWorkingDirectory(), left);
+        if ("-d".equals(flag)) {
+            return target.isDirectory();
+        }
+
+        if ("-nd".equals(flag)) {
+            return !target.isDirectory();
+        }
+
+        if ("-f".equals(flag)) {
+            return target.isFile();
+        }
+
+        if ("-nf".equals(flag)) {
+            return !target.isFile();
+        }
+
+        throw bomb(format("Unknown flag %s for command: %s", flag, command));
+    }
+
+    private String captureSubCommandOutput(BuildCommand command, BuildSession buildSession) {
+        BuildCommand targetCommand = command.getSubCommands().get(0);
+        ConsoleCapture consoleCapture = new ConsoleCapture();
+        buildSession.newTestingSession(consoleCapture).processCommand(targetCommand);
+        return consoleCapture.captured();
+    }
+}

--- a/common/src/com/thoughtworks/go/buildsession/UncaringBuildStateReport.java
+++ b/common/src/com/thoughtworks/go/buildsession/UncaringBuildStateReport.java
@@ -1,0 +1,33 @@
+/*************************** GO-LICENSE-START*********************************
+ * Copyright 2016 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ************************GO-LICENSE-END***********************************/
+package com.thoughtworks.go.buildsession;
+
+import com.thoughtworks.go.domain.JobResult;
+import com.thoughtworks.go.domain.JobState;
+
+class UncaringBuildStateReport implements BuildStateReporter {
+    @Override
+    public void reportBuildStatus(String buildId, JobState buildState) {
+    }
+
+    @Override
+    public void reportCompleted(String buildId, JobResult buildResult) {
+    }
+
+    @Override
+    public void reportCompleting(String buildId, JobResult buildResult) {
+    }
+}

--- a/common/src/com/thoughtworks/go/buildsession/UploadArtifactCommandExecutor.java
+++ b/common/src/com/thoughtworks/go/buildsession/UploadArtifactCommandExecutor.java
@@ -1,0 +1,66 @@
+/*************************** GO-LICENSE-START*********************************
+ * Copyright 2016 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ************************GO-LICENSE-END***********************************/
+package com.thoughtworks.go.buildsession;
+
+import com.thoughtworks.go.domain.BuildCommand;
+import com.thoughtworks.go.domain.WildcardScanner;
+import com.thoughtworks.go.util.GoConstants;
+import org.apache.commons.lang.StringUtils;
+
+import java.io.File;
+
+import static com.thoughtworks.go.util.FileUtil.normalizePath;
+import static com.thoughtworks.go.util.FileUtil.subtractPath;
+import static com.thoughtworks.go.util.SelectorUtils.rtrimStandardrizedWildcardTokens;
+import static java.lang.String.format;
+import static org.apache.commons.lang.StringUtils.removeStart;
+
+public class UploadArtifactCommandExecutor implements BuildCommandExecutor {
+    @Override
+    public boolean execute(BuildCommand command, BuildSession buildSession) {
+        final String src = command.getStringArg("src");
+        final String dest = command.getStringArg("dest");
+        final Boolean ignoreUnmatchError = command.getBooleanArg("ignoreUnmatchError");
+        final File rootPath = buildSession.resolveRelativeDir(command.getWorkingDirectory());
+
+        WildcardScanner scanner = new WildcardScanner(rootPath, src);
+        File[] files = scanner.getFiles();
+
+        if (files.length == 0) {
+            String message = "The rule [" + src + "] cannot match any resource under [" + rootPath + "]";
+            buildSession.printlnWithPrefix(message);
+            return ignoreUnmatchError;
+        }
+
+        for (File file : files) {
+            buildSession.upload(file, destURL(rootPath, file, src, dest));
+        }
+        return true;
+    }
+
+    protected String destURL(File rootPath, File file, String src, String dest) {
+        String trimmedPattern = rtrimStandardrizedWildcardTokens(src);
+        if (StringUtils.equals(normalizePath(trimmedPattern), normalizePath(src))) {
+            return dest;
+        }
+        String trimmedPath = removeStart(subtractPath(rootPath, file), normalizePath(trimmedPattern));
+        if (!StringUtils.startsWith(trimmedPath, "/") && StringUtils.isNotEmpty(trimmedPath)) {
+            trimmedPath = "/" + trimmedPath;
+        }
+        return dest + trimmedPath;
+    }
+
+}

--- a/common/src/com/thoughtworks/go/config/materials/Materials.java
+++ b/common/src/com/thoughtworks/go/config/materials/Materials.java
@@ -30,6 +30,7 @@ import com.thoughtworks.go.config.materials.svn.SvnMaterialConfig;
 import com.thoughtworks.go.config.materials.tfs.TfsMaterial;
 import com.thoughtworks.go.config.materials.tfs.TfsMaterialConfig;
 import com.thoughtworks.go.domain.BaseCollection;
+import com.thoughtworks.go.domain.BuildCommand;
 import com.thoughtworks.go.domain.ConfigVisitor;
 import com.thoughtworks.go.domain.MaterialRevisions;
 import com.thoughtworks.go.domain.materials.*;
@@ -43,6 +44,8 @@ import org.apache.commons.lang.StringUtils;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
+
+import static com.thoughtworks.go.domain.BuildCommand.*;
 
 public class Materials extends BaseCollection<Material> {
     private static final int DEFAULT_INTERVAL = 100;
@@ -277,4 +280,14 @@ public class Materials extends BaseCollection<Material> {
         }
         return false;
     }
+
+
+    public BuildCommand cleanUpCommand(String baseDir) {
+        if (hasMaterialsWithNoDestinationFolder()) {
+            return noop();
+        }
+        List<String> allowed = allowedFolders();
+        return cleandir(baseDir, allowed.toArray(new String[allowed.size()]));
+    }
+
 }

--- a/common/src/com/thoughtworks/go/config/materials/ScmMaterial.java
+++ b/common/src/com/thoughtworks/go/config/materials/ScmMaterial.java
@@ -18,12 +18,14 @@ package com.thoughtworks.go.config.materials;
 
 import com.thoughtworks.go.config.CaseInsensitiveString;
 import com.thoughtworks.go.config.PipelineConfig;
+import com.thoughtworks.go.domain.BuildCommand;
 import com.thoughtworks.go.domain.MaterialRevision;
 import com.thoughtworks.go.domain.materials.*;
 import com.thoughtworks.go.util.command.EnvironmentVariableContext;
 import com.thoughtworks.go.util.command.InMemoryStreamConsumer;
 import com.thoughtworks.go.util.command.ProcessOutputStreamConsumer;
 import com.thoughtworks.go.util.command.UrlArgument;
+import org.apache.commons.lang.NotImplementedException;
 import org.apache.commons.lang.StringUtils;
 
 import java.io.File;
@@ -60,7 +62,7 @@ public abstract class ScmMaterial extends AbstractMaterial {
         return new File(baseFolder, getFolder());
     }
 
-    protected String updatingTarget() {
+    public String updatingTarget() {
         return StringUtils.isEmpty(getFolder()) ? "files" : getFolder();
     }
 

--- a/common/src/com/thoughtworks/go/config/materials/git/GitMaterial.java
+++ b/common/src/com/thoughtworks/go/config/materials/git/GitMaterial.java
@@ -19,6 +19,7 @@ package com.thoughtworks.go.config.materials.git;
 import com.thoughtworks.go.config.materials.ScmMaterial;
 import com.thoughtworks.go.config.materials.ScmMaterialConfig;
 import com.thoughtworks.go.config.materials.SubprocessExecutionContext;
+import com.thoughtworks.go.domain.BuildCommand;
 import com.thoughtworks.go.domain.MaterialInstance;
 import com.thoughtworks.go.domain.materials.*;
 import com.thoughtworks.go.domain.materials.git.GitCommand;
@@ -41,6 +42,7 @@ import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import static com.thoughtworks.go.domain.BuildCommand.*;
 import static com.thoughtworks.go.util.ExceptionUtils.bomb;
 import static com.thoughtworks.go.util.ExceptionUtils.bombIfFailedToRunCommandLine;
 import static com.thoughtworks.go.util.FileUtil.createParentFolderIfNotExist;
@@ -53,7 +55,7 @@ import static java.lang.String.format;
  */
 public class GitMaterial extends ScmMaterial {
     private static final Logger LOG = Logger.getLogger(GitMaterial.class);
-    private static final int UNSHALLOW_TRYOUT_STEP = 100;
+    public static final int UNSHALLOW_TRYOUT_STEP = 100;
     public static final int DEFAULT_SHALLOW_CLONE_DEPTH = 2;
 
 
@@ -271,8 +273,7 @@ public class GitMaterial extends ScmMaterial {
     }
 
     private boolean isBranchEqual(GitCommand command) {
-        String branchName = StringUtil.isBlank(this.branch) ? GitMaterialConfig.DEFAULT_BRANCH : this.branch;
-        return branchName.equals(command.getCurrentBranch());
+        return branchWithDefault().equals(command.getCurrentBranch());
     }
 
     /**
@@ -414,4 +415,9 @@ public class GitMaterial extends ScmMaterial {
         config.setShallowClone(value);
         return new GitMaterial(config);
     }
+
+    public String branchWithDefault() {
+        return StringUtil.isBlank(branch) ? GitMaterialConfig.DEFAULT_BRANCH : branch;
+    }
+
 }

--- a/common/src/com/thoughtworks/go/domain/AgentInstance.java
+++ b/common/src/com/thoughtworks/go/domain/AgentInstance.java
@@ -1,5 +1,5 @@
 /*************************GO-LICENSE-START*********************************
- * Copyright 2014 ThoughtWorks, Inc.
+ * Copyright 2016 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -47,6 +47,7 @@ public class AgentInstance implements Comparable<AgentInstance> {
     protected volatile Date lastHeardTime;
     private TimeProvider timeProvider;
     private SystemEnvironment systemEnvironment;
+    private boolean supportsBuildCommandProtocol;
 
     protected AgentInstance(AgentConfig agentConfig,AgentType agentType, SystemEnvironment systemEnvironment) {
         this.systemEnvironment = systemEnvironment;
@@ -353,6 +354,10 @@ public class AgentInstance implements Comparable<AgentInstance> {
     public boolean needsUpgrade() {
         if(isMissing()) return false;
         return StringUtil.isBlank(agentRuntimeInfo.getAgentLauncherVersion());
+    }
+
+    public boolean getSupportsBuildCommandProtocol() {
+        return agentRuntimeInfo.getSupportsBuildCommandProtocol();
     }
 
     public static enum AgentType {

--- a/common/src/com/thoughtworks/go/domain/AgentInstance.java
+++ b/common/src/com/thoughtworks/go/domain/AgentInstance.java
@@ -47,7 +47,6 @@ public class AgentInstance implements Comparable<AgentInstance> {
     protected volatile Date lastHeardTime;
     private TimeProvider timeProvider;
     private SystemEnvironment systemEnvironment;
-    private boolean supportsBuildCommandProtocol;
 
     protected AgentInstance(AgentConfig agentConfig,AgentType agentType, SystemEnvironment systemEnvironment) {
         this.systemEnvironment = systemEnvironment;

--- a/common/src/com/thoughtworks/go/domain/BuildCommand.java
+++ b/common/src/com/thoughtworks/go/domain/BuildCommand.java
@@ -1,0 +1,312 @@
+/************************** GO-LICENSE-START*********************************
+ * Copyright 2016 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ************************GO-LICENSE-END***********************************/
+
+package com.thoughtworks.go.domain;
+
+import com.google.gson.Gson;
+import com.google.gson.annotations.Expose;
+import com.thoughtworks.go.util.ArrayUtil;
+import com.thoughtworks.go.util.GoConstants;
+import org.apache.commons.lang.ArrayUtils;
+
+import java.util.*;
+
+import static com.thoughtworks.go.util.MapBuilder.map;
+
+public class BuildCommand {
+
+    private static final Gson GSON = new Gson();
+
+    public static BuildCommand echoWithPrefix(String format, Object...args) {
+        return echo("[%s] " + format, ArrayUtil.pushToArray(GoConstants.PRODUCT_NAME, args));
+    }
+
+    public static BuildCommand exec(String command, String...args) {
+        return new BuildCommand("exec", map("command", command, "args", GSON.toJson(args)));
+    }
+
+    public static BuildCommand test(String flag, String left) {
+        return new BuildCommand("test", map("flag", flag, "left", left));
+    }
+
+    public static BuildCommand test(String flag, String left, BuildCommand subCommand) {
+        return new BuildCommand("test", map("flag", flag, "left", left))
+                .setSubCommands(Collections.singletonList(subCommand));
+    }
+
+    public static BuildCommand reportCurrentStatus(JobState status) {
+        return new BuildCommand("reportCurrentStatus", map("status", status.name()));
+    }
+
+    public static BuildCommand reportCompleting() {
+        return new BuildCommand("reportCompleting");
+    }
+
+    public static BuildCommand compose(BuildCommand...subCommands) {
+        return new BuildCommand("compose").setSubCommands(Arrays.asList(subCommands));
+    }
+
+    public static BuildCommand compose(List<BuildCommand> subCommands) {
+        return new BuildCommand("compose").setSubCommands(subCommands);
+    }
+
+    public static BuildCommand echo(String format, Object...args) {
+        return new BuildCommand("echo", map("line", String.format(format, args)));
+    }
+
+    public static BuildCommand mkdirs(String path) {
+        return new BuildCommand("mkdirs", map("path", path));
+    }
+
+    public static BuildCommand cleandir(String path, String...allowedPaths) {
+        return new BuildCommand("cleandir", map("path", path, "allowed", GSON.toJson(allowedPaths)));
+    }
+
+    public static BuildCommand noop() {
+        return new BuildCommand("compose");
+    }
+
+    public static BuildCommand fail(String format, String... args) {
+        return new BuildCommand("fail", map("message", String.format(format, args)));
+    }
+
+    // set environment variable with displaying it
+    public static BuildCommand export(String name, String value, boolean isSecure) {
+        return new BuildCommand("export", map("name", name, "value", value, "secure", String.valueOf(isSecure)));
+    }
+
+    // display environment variable
+    public static BuildCommand export(String name) {
+        return new BuildCommand("export", map("name", name));
+    }
+
+    public static BuildCommand secret(String secretValue) {
+        return new BuildCommand("secret", map("value", secretValue));
+    }
+
+    public static BuildCommand secret(String secretValue, String substitution) {
+        return new BuildCommand("secret", map("value", secretValue, "substitution", substitution));
+    }
+
+
+    public static BuildCommand uploadArtifact(String src, String dest, boolean ignoreUnmatchError) {
+        return new BuildCommand("uploadArtifact", map("src", src, "dest", dest, "ignoreUnmatchError", String.valueOf(ignoreUnmatchError)));
+    }
+
+    public static BuildCommand generateTestReport(List<String> srcs, String uploadPath) {
+        return new BuildCommand("generateTestReport", map(
+                "uploadPath", uploadPath,
+                "srcs", GSON.toJson(srcs)));
+    }
+
+    public static BuildCommand downloadFile(Map<String, String> args) {
+        return new BuildCommand("downloadFile", args);
+    }
+
+    public static BuildCommand downloadDir(Map<String, String> args) {
+        return new BuildCommand("downloadDir", args);
+    }
+
+
+    public static BuildCommand generateProperty(String name, String src, String xpath) {
+        return new BuildCommand("generateProperty", map("name", name, "src", src, "xpath", xpath));
+    }
+
+    @Expose
+    private final String name;
+    @Expose
+    private Map<String, String> args;
+    @Expose
+    private List<BuildCommand> subCommands;
+    @Expose
+    private String workingDirectory;
+    @Expose
+    private BuildCommand test;
+    @Expose
+    private String runIfConfig = "passed";
+    @Expose
+    private BuildCommand onCancel;
+
+    public BuildCommand(String name) {
+        this.name = name;
+        this.subCommands = Collections.emptyList();
+        this.args = Collections.emptyMap();
+    }
+
+    public BuildCommand(String name, Map<String, String> args) {
+        this(name);
+        this.args = args;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public boolean hasArg(String arg) {
+        return args.containsKey(arg);
+    }
+
+    public String dump() {
+        StringBuilder sb = new StringBuilder();
+        doDump(0, 4, sb);
+        return sb.toString();
+    }
+
+    private void doDump(int level, int indent, StringBuilder sb) {
+        for (int i = 0; i < level * indent; i++) {
+            sb.append(' ');
+        }
+
+        sb.append(name);
+
+        for (String argName : args.keySet()) {
+            sb.append(' ').append('\"').append(argName).append(":").append(args.get(argName)).append('\"');
+        }
+
+        if (!"passed".equals(runIfConfig)) {
+            sb.append(" ").append("(runIf:").append(runIfConfig).append(")");
+        }
+
+        for (BuildCommand subCommand : subCommands) {
+            sb.append("\n");
+            subCommand.doDump(level + 1, indent, sb);
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        BuildCommand that = (BuildCommand) o;
+
+        if (name != null ? !name.equals(that.name) : that.name != null) return false;
+        if (args != null ? !args.equals(that.args) : that.args != null) return false;
+        if (subCommands != null ? !subCommands.equals(that.subCommands) : that.subCommands != null) return false;
+        if (workingDirectory != null ? !workingDirectory.equals(that.workingDirectory) : that.workingDirectory != null)
+            return false;
+        if (test != null ? !test.equals(that.test) : that.test != null) return false;
+        if (runIfConfig != null ? !runIfConfig.equals(that.runIfConfig) : that.runIfConfig != null) return false;
+        return onCancel != null ? onCancel.equals(that.onCancel) : that.onCancel == null;
+
+    }
+
+    @Override
+    public int hashCode() {
+        int result = name != null ? name.hashCode() : 0;
+        result = 31 * result + (args != null ? args.hashCode() : 0);
+        result = 31 * result + (subCommands != null ? subCommands.hashCode() : 0);
+        result = 31 * result + (workingDirectory != null ? workingDirectory.hashCode() : 0);
+        result = 31 * result + (test != null ? test.hashCode() : 0);
+        result = 31 * result + (runIfConfig != null ? runIfConfig.hashCode() : 0);
+        result = 31 * result + (onCancel != null ? onCancel.hashCode() : 0);
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "BuildCommand{" +
+                "name='" + name + '\'' +
+                ", args=" + args +
+                ", subCommands=" + subCommands +
+                ", workingDirectory='" + workingDirectory + '\'' +
+                ", test=" + test +
+                ", runIfConfig='" + runIfConfig + '\'' +
+                ", onCancel=" + onCancel +
+                '}';
+    }
+
+    public BuildCommand setWorkingDirectory(String workingDirectory) {
+        this.workingDirectory = workingDirectory;
+        return this;
+    }
+
+    public BuildCommand setWorkingDirectoryRecursively(String workingDirectory) {
+        this.setWorkingDirectory(workingDirectory);
+        for (BuildCommand subCommand : subCommands) {
+            subCommand.setWorkingDirectoryRecursively(workingDirectory);
+        }
+        return this;
+    }
+
+    public String getWorkingDirectory() {
+        return workingDirectory == null ? "" : workingDirectory;
+    }
+
+    public BuildCommand getTest() {
+        return test;
+    }
+
+    public BuildCommand setTest(BuildCommand test) {
+        this.test = test;
+        return this;
+    }
+
+    public List<BuildCommand> getSubCommands() {
+        return subCommands;
+    }
+
+    public BuildCommand setSubCommands(List<BuildCommand> subCommands) {
+        this.subCommands = subCommands;
+        return this;
+    }
+
+    public String getRunIfConfig() {
+        return runIfConfig;
+    }
+
+    public void setRunIfConfig(String runIfConfig) {
+        this.runIfConfig = runIfConfig;
+    }
+
+    public BuildCommand getOnCancel() {
+        return onCancel;
+    }
+
+    public BuildCommand setOnCancel(BuildCommand onCancel) {
+        this.onCancel = onCancel;
+        return this;
+    }
+
+    public BuildCommand runIf(String runIfConfig) {
+        setRunIfConfig(runIfConfig);
+        return this;
+    }
+
+    public BuildCommand setRunIfRecurisvely(String runIfConfig) {
+        runIf(runIfConfig);
+        for (BuildCommand subCommand : subCommands) {
+            subCommand.setRunIfRecurisvely(runIfConfig);
+        }
+        return this;
+    }
+
+    public boolean getBooleanArg(String arg) {
+        return args.containsKey(arg) ? Boolean.valueOf(args.get(arg)) : false;
+    }
+
+    public String getStringArg(String arg) {
+        return args.get(arg);
+    }
+
+
+    public String[] getArrayArg(String arg) {
+        if (!hasArg(arg)) {
+            return new String[]{};
+        }
+        return GSON.fromJson(args.get(arg), String[].class);
+    }
+}

--- a/common/src/com/thoughtworks/go/domain/BuildCommand.java
+++ b/common/src/com/thoughtworks/go/domain/BuildCommand.java
@@ -125,6 +125,11 @@ public class BuildCommand {
         return new BuildCommand("generateProperty", map("name", name, "src", src, "xpath", xpath));
     }
 
+    //not part of the protocol, only for tests
+    public static BuildCommand error(String message) {
+        return new BuildCommand("error", map("message", message));
+    }
+
     @Expose
     private final String name;
     @Expose
@@ -309,4 +314,5 @@ public class BuildCommand {
         }
         return GSON.fromJson(args.get(arg), String[].class);
     }
+
 }

--- a/common/src/com/thoughtworks/go/domain/BuildSettings.java
+++ b/common/src/com/thoughtworks/go/domain/BuildSettings.java
@@ -1,0 +1,91 @@
+/*************************** GO-LICENSE-START*********************************
+ * Copyright 2016 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ************************GO-LICENSE-END***********************************/
+package com.thoughtworks.go.domain;
+
+import com.google.gson.annotations.Expose;
+
+public class BuildSettings {
+    @Expose
+    private String buildId;
+    @Expose
+    private String consoleUrl;
+    @Expose
+    private String buildLocatorForDisplay;
+    @Expose
+    private String buildLocator;
+    @Expose
+    private String artifactUploadBaseUrl;
+    @Expose
+    private String propertyBaseUrl;
+    @Expose
+    private BuildCommand buildCommand;
+
+    public String getBuildId() {
+        return buildId;
+    }
+
+    public void setBuildId(String buildId) {
+        this.buildId = buildId;
+    }
+
+    public String getConsoleUrl() {
+        return consoleUrl;
+    }
+
+    public void setConsoleUrl(String consoleUrl) {
+        this.consoleUrl = consoleUrl;
+    }
+
+    public String getBuildLocatorForDisplay() {
+        return buildLocatorForDisplay;
+    }
+
+    public void setBuildLocatorForDisplay(String buildLocatorForDisplay) {
+        this.buildLocatorForDisplay = buildLocatorForDisplay;
+    }
+
+    public String getArtifactUploadBaseUrl() {
+        return artifactUploadBaseUrl;
+    }
+
+    public void setArtifactUploadBaseUrl(String artifactUploadBaseUrl) {
+        this.artifactUploadBaseUrl = artifactUploadBaseUrl;
+    }
+
+    public String getPropertyBaseUrl() {
+        return propertyBaseUrl;
+    }
+
+    public void setPropertyBaseUrl(String propertyBaseUrl) {
+        this.propertyBaseUrl = propertyBaseUrl;
+    }
+
+    public BuildCommand getBuildCommand() {
+        return buildCommand;
+    }
+
+    public void setBuildCommand(BuildCommand buildCommand) {
+        this.buildCommand = buildCommand;
+    }
+
+    public String getBuildLocator() {
+        return buildLocator;
+    }
+
+    public void setBuildLocator(String buildLocator) {
+        this.buildLocator = buildLocator;
+    }
+}

--- a/common/src/com/thoughtworks/go/domain/ChecksumFileHandler.java
+++ b/common/src/com/thoughtworks/go/domain/ChecksumFileHandler.java
@@ -1,5 +1,5 @@
 /*************************GO-LICENSE-START*********************************
- * Copyright 2014 ThoughtWorks, Inc.
+ * Copyright 2016 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *************************GO-LICENSE-END***********************************/
-
 package com.thoughtworks.go.domain;
 
 import java.io.File;
@@ -23,12 +22,13 @@ import javax.servlet.http.HttpServletResponse;
 
 import com.thoughtworks.go.util.ArtifactLogUtil;
 import com.thoughtworks.go.util.FileUtil;
-import com.thoughtworks.go.work.DefaultGoPublisher;
+import com.thoughtworks.go.work.GoPublisher;
 import org.apache.log4j.Logger;
 
 import static org.apache.commons.io.FileUtils.deleteQuietly;
 
 public class ChecksumFileHandler implements FetchHandler {
+
     private final File checksumFile;
     private static final Logger LOG = Logger.getLogger(ChecksumFileHandler.class);
 
@@ -44,7 +44,7 @@ public class ChecksumFileHandler implements FetchHandler {
         FileUtil.writeToFile(stream, checksumFile);
     }
 
-    public boolean handleResult(int returncode, DefaultGoPublisher goPublisher) {
+    public boolean handleResult(int returncode, GoPublisher goPublisher) {
         if (returncode == HttpServletResponse.SC_NOT_FOUND) {
             deleteQuietly(checksumFile);
             goPublisher.consumeLineWithPrefix("[WARN] The md5checksum property file was not found on the server. Hence, Go can not verify the integrity of the artifacts.");
@@ -63,6 +63,11 @@ public class ChecksumFileHandler implements FetchHandler {
 
     public void useArtifactMd5Checksums(ArtifactMd5Checksums artifactMd5Checksums) {
         throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public BuildCommand toDownloadCommand(String locator, String checksumUrl, File checksumPath) {
+        throw new UnsupportedOperationException("not supported for checksum handler");
     }
 
     @Override
@@ -90,5 +95,9 @@ public class ChecksumFileHandler implements FetchHandler {
 
     public ArtifactMd5Checksums getArtifactMd5Checksums() {
         return checksumFile.exists() ? new ArtifactMd5Checksums(checksumFile) : null;
+    }
+
+    public File getChecksumFile() {
+        return checksumFile;
     }
 }

--- a/common/src/com/thoughtworks/go/domain/ChecksumValidationPublisher.java
+++ b/common/src/com/thoughtworks/go/domain/ChecksumValidationPublisher.java
@@ -1,5 +1,5 @@
 /*************************GO-LICENSE-START*********************************
- * Copyright 2014 ThoughtWorks, Inc.
+ * Copyright 2016 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,14 +16,13 @@
 
 package com.thoughtworks.go.domain;
 
+import com.thoughtworks.go.work.GoPublisher;
+
+import javax.servlet.http.HttpServletResponse;
 import java.io.File;
 import java.io.Serializable;
 import java.util.HashSet;
 import java.util.Set;
-
-import javax.servlet.http.HttpServletResponse;
-
-import com.thoughtworks.go.work.DefaultGoPublisher;
 
 public class ChecksumValidationPublisher implements com.thoughtworks.go.agent.ChecksumValidationPublisher, Serializable {
     private Set<String> md5NotFoundPaths = new HashSet<String>();
@@ -45,7 +44,7 @@ public class ChecksumValidationPublisher implements com.thoughtworks.go.agent.Ch
         md5ChecksumFileWasNotFound = true;
     }
 
-    public void publish(int httpCode, File artifact, DefaultGoPublisher goPublisher) {
+    public void publish(int httpCode, File artifact, GoPublisher goPublisher) {
         if (!this.md5MismatchPaths.isEmpty()) {
             String mismatchedFilePath = md5MismatchPaths.iterator().next();
             goPublisher.consumeLineWithPrefix(

--- a/common/src/com/thoughtworks/go/domain/DownloadAction.java
+++ b/common/src/com/thoughtworks/go/domain/DownloadAction.java
@@ -1,5 +1,5 @@
 /*************************GO-LICENSE-START*********************************
- * Copyright 2014 ThoughtWorks, Inc.
+ * Copyright 2016 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,24 +21,25 @@ import javax.servlet.http.HttpServletResponse;
 import com.thoughtworks.go.util.Clock;
 import com.thoughtworks.go.util.HttpService;
 import com.thoughtworks.go.work.DefaultGoPublisher;
+import com.thoughtworks.go.work.GoPublisher;
 import org.apache.log4j.Logger;
 
 public class DownloadAction {
 
     private final HttpService httpService;
-    private final DefaultGoPublisher goPublisher;
+    private final GoPublisher goPublisher;
     private final Clock clock;
     private static final int DOWNLOAD_SLEEP_MILLIS = 5000;
     private static final Logger LOG = Logger.getLogger(DownloadAction.class);
 
 
-    public DownloadAction(HttpService httpService, DefaultGoPublisher goPublisher, Clock clock) {
+    public DownloadAction(HttpService httpService, GoPublisher goPublisher, Clock clock) {
         this.httpService = httpService;
         this.goPublisher = goPublisher;
         this.clock = clock;
     }
 
-    public void perform(String url, FetchHandler handler) throws Exception {
+    public void perform(String url, FetchHandler handler) throws InterruptedException {
         int retryCount = 0;
         while (true) {
             retryCount++;

--- a/common/src/com/thoughtworks/go/domain/FetchHandler.java
+++ b/common/src/com/thoughtworks/go/domain/FetchHandler.java
@@ -1,5 +1,5 @@
 /*************************GO-LICENSE-START*********************************
- * Copyright 2014 ThoughtWorks, Inc.
+ * Copyright 2016 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,18 +16,21 @@
 
 package com.thoughtworks.go.domain;
 
+import com.thoughtworks.go.work.GoPublisher;
+
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.Serializable;
-
-import com.thoughtworks.go.work.DefaultGoPublisher;
 
 public interface FetchHandler extends Serializable {
     String url(String remoteHost, String workingUrl) throws IOException;
 
     void handle(InputStream stream) throws IOException;
 
-    boolean handleResult(int returncode, DefaultGoPublisher goPublisher);
+    boolean handleResult(int returncode, GoPublisher goPublisher);
 
     void useArtifactMd5Checksums(ArtifactMd5Checksums artifactMd5Checksums);
+
+    BuildCommand toDownloadCommand(String locator, String checksumUrl, File checksumPath);
 }

--- a/common/src/com/thoughtworks/go/domain/FileHandler.java
+++ b/common/src/com/thoughtworks/go/domain/FileHandler.java
@@ -1,5 +1,5 @@
 /*************************GO-LICENSE-START*********************************
- * Copyright 2014 ThoughtWorks, Inc.
+ * Copyright 2016 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,22 +16,20 @@
 
 package com.thoughtworks.go.domain;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.Date;
-import javax.servlet.http.HttpServletResponse;
-
 import com.thoughtworks.go.util.StringUtil;
 import com.thoughtworks.go.validation.ChecksumValidator;
-import com.thoughtworks.go.work.DefaultGoPublisher;
+import com.thoughtworks.go.work.GoPublisher;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.log4j.Logger;
 
+import javax.servlet.http.HttpServletResponse;
+import java.io.*;
+import java.util.Date;
+
 import static com.thoughtworks.go.util.CachedDigestUtils.md5Hex;
+import static com.thoughtworks.go.util.MapBuilder.map;
+import static java.lang.String.format;
 
 public class FileHandler implements FetchHandler {
 
@@ -55,10 +53,10 @@ public class FileHandler implements FetchHandler {
         }
         if (fileExist && artifact.isFile()) {
             String sha1 = StringUtil.sha1Digest(artifact);
-            return java.lang.String.format("%s/%s/%s/%s?sha1=%s", remoteHost, "remoting", "files", workingUrl,
+            return format("%s/%s/%s/%s?sha1=%s", remoteHost, "remoting", "files", workingUrl,
                     java.net.URLEncoder.encode(sha1, "UTF-8"));
         } else {
-            return java.lang.String.format("%s/%s/%s/%s", remoteHost, "remoting", "files", workingUrl);
+            return format("%s/%s/%s/%s", remoteHost, "remoting", "files", workingUrl);
         }
     }
 
@@ -67,11 +65,11 @@ public class FileHandler implements FetchHandler {
         try {
             fileOutputStream = FileUtils.openOutputStream(artifact);
             if (LOG.isInfoEnabled()) {
-                LOG.info(String.format("[Artifact File Download] [%s] Download of artifact %s started", new Date(), artifact.getName()));
+                LOG.info(format("[Artifact File Download] [%s] Download of artifact %s started", new Date(), artifact.getName()));
             }
             IOUtils.copyLarge(stream, fileOutputStream);
             if (LOG.isInfoEnabled()) {
-                LOG.info(String.format("[Artifact File Download] [%s] Download of artifact %s ended", new Date(), artifact.getName()));
+                LOG.info(format("[Artifact File Download] [%s] Download of artifact %s ended", new Date(), artifact.getName()));
             }
         } finally {
             IOUtils.closeQuietly(fileOutputStream);
@@ -80,19 +78,19 @@ public class FileHandler implements FetchHandler {
         try {
             inputStream = new FileInputStream(artifact);
             if (LOG.isInfoEnabled()) {
-                LOG.info(String.format("[Artifact File Download] [%s] Checksum computation of artifact %s started", new Date(), artifact.getName()));
+                LOG.info(format("[Artifact File Download] [%s] Checksum computation of artifact %s started", new Date(), artifact.getName()));
             }
             String artifactMD5 = md5Hex(inputStream);
             new ChecksumValidator(artifactMd5Checksums).validate(srcFile, artifactMD5, checksumValidationPublisher);
             if (LOG.isInfoEnabled()) {
-                LOG.info(String.format("[Artifact File Download] [%s] Checksum computation of artifact %s ended", new Date(), artifact.getName()));
+                LOG.info(format("[Artifact File Download] [%s] Checksum computation of artifact %s ended", new Date(), artifact.getName()));
             }
         } finally {
             IOUtils.closeQuietly(inputStream);
         }
     }
 
-    public boolean handleResult(int httpCode, DefaultGoPublisher goPublisher) {
+    public boolean handleResult(int httpCode, GoPublisher goPublisher) {
         checksumValidationPublisher.publish(httpCode, artifact, goPublisher);
 
         return httpCode < HttpServletResponse.SC_BAD_REQUEST;
@@ -100,6 +98,17 @@ public class FileHandler implements FetchHandler {
 
     public void useArtifactMd5Checksums(ArtifactMd5Checksums artifactMd5Checksums) {
         this.artifactMd5Checksums = artifactMd5Checksums;
+    }
+
+    @Override
+    public BuildCommand toDownloadCommand(String locator, String checksumUrl, File checksumPath) {
+        return BuildCommand.downloadFile(map(
+                "url", format("/remoting/files/%s", locator),
+                "checksumUrl", checksumUrl,
+                "checksumFile", checksumPath.getPath(),
+                "dest", artifact.getPath(),
+                "src", srcFile
+        ));
     }
 
     @Override

--- a/common/src/com/thoughtworks/go/domain/JobIdentifier.java
+++ b/common/src/com/thoughtworks/go/domain/JobIdentifier.java
@@ -1,5 +1,5 @@
 /*************************GO-LICENSE-START*********************************
- * Copyright 2014 ThoughtWorks, Inc.
+ * Copyright 2016 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,21 +16,30 @@
 
 package com.thoughtworks.go.domain;
 
-import java.io.Serializable;
-
+import com.google.gson.annotations.Expose;
 import com.thoughtworks.go.util.UrlUtil;
 import com.thoughtworks.go.util.command.EnvironmentVariableContext;
 
+import java.io.Serializable;
+
 public class JobIdentifier implements Serializable, LocatableEntity {
+    @Expose
     private String pipelineName;
+    @Expose
     private Integer pipelineCounter;
+    @Expose
     private String pipelineLabel;
+    @Expose
     private String stageName;
+    @Expose
     private String buildName;
 
+    @Expose
     private Long buildId;
+    @Expose
     private String stageCounter;
     public static final String LATEST = "latest";
+    @Expose
     private Integer rerunOfCounter;
 
     public JobIdentifier(Pipeline pipeline, Stage stage, JobInstance jobInstance) {
@@ -78,7 +87,7 @@ public class JobIdentifier implements Serializable, LocatableEntity {
         this.pipelineCounter = pipelineCounter;
         this.pipelineLabel = pipelineLabel;
         this.stageName = stageName;
-        this.stageCounter = String.valueOf(stageCounter);
+        this.stageCounter = stageCounter;
         this.buildName = buildName;
         this.buildId = buildId;
     }

--- a/common/src/com/thoughtworks/go/domain/MaterialRevision.java
+++ b/common/src/com/thoughtworks/go/domain/MaterialRevision.java
@@ -1,5 +1,5 @@
 /*************************GO-LICENSE-START*********************************
- * Copyright 2014 ThoughtWorks, Inc.
+ * Copyright 2016 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -151,7 +151,7 @@ public class MaterialRevision implements Serializable {
         material.updateTo(consumer, baseDir, toRevisionContext(), execCtx);
     }
 
-    private RevisionContext toRevisionContext() {
+    public RevisionContext toRevisionContext() {
         return new RevisionContext(getRevision(), getOldestRevision(), numberOfModifications());
     }
 

--- a/common/src/com/thoughtworks/go/domain/builder/Builder.java
+++ b/common/src/com/thoughtworks/go/domain/builder/Builder.java
@@ -1,5 +1,5 @@
 /*************************GO-LICENSE-START*********************************
- * Copyright 2014 ThoughtWorks, Inc.
+ * Copyright 2016 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import java.io.Serializable;
 import static java.lang.String.format;
 
 import com.thoughtworks.go.config.RunIfConfig;
+import com.thoughtworks.go.domain.BuildCommand;
 import com.thoughtworks.go.domain.BuildLogElement;
 import com.thoughtworks.go.domain.RunIfConfigs;
 import com.thoughtworks.go.plugin.access.pluggabletask.TaskExtension;
@@ -62,6 +63,10 @@ public abstract class Builder implements Serializable {
 
     public void setCancelBuilder(Builder cancelBuilder) {
         this.cancelBuilder = cancelBuilder;
+    }
+
+    public Builder getCancelBuilder() {
+        return cancelBuilder;
     }
 
     public boolean equals(Object o) {
@@ -117,4 +122,11 @@ public abstract class Builder implements Serializable {
         throw new CruiseControlException(message);
     }
 
+    public BuildCommand buildCommand() {
+        return BuildCommand.fail(format("\"%s\" does not support new build command agent", this.getClass().getName()));
+    }
+
+    public RunIfConfig resolvedRunIfConfig() {
+        return this.conditions.resolveToSingle();
+    }
 }

--- a/common/src/com/thoughtworks/go/domain/builder/BuilderForKillAllChildTask.java
+++ b/common/src/com/thoughtworks/go/domain/builder/BuilderForKillAllChildTask.java
@@ -1,5 +1,5 @@
 /*************************GO-LICENSE-START*********************************
- * Copyright 2014 ThoughtWorks, Inc.
+ * Copyright 2016 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 package com.thoughtworks.go.domain.builder;
 
 import com.jezhumble.javasysmon.JavaSysMon;
+import com.thoughtworks.go.domain.BuildCommand;
 import com.thoughtworks.go.domain.BuildLogElement;
 import com.thoughtworks.go.domain.RunIfConfigs;
 import com.thoughtworks.go.plugin.access.pluggabletask.TaskExtension;
@@ -32,5 +33,10 @@ public class BuilderForKillAllChildTask extends Builder {
     @Override
     public void build(BuildLogElement buildLogElement, DefaultGoPublisher publisher, EnvironmentVariableContext environmentVariableContext, TaskExtension taskExtension) throws CruiseControlException {
         new JavaSysMon().infanticide();
+    }
+
+    @Override
+    public BuildCommand buildCommand() {
+        return BuildCommand.noop(); //killing sub process is built in for build command protocol agent
     }
 }

--- a/common/src/com/thoughtworks/go/domain/builder/CommandBuilder.java
+++ b/common/src/com/thoughtworks/go/domain/builder/CommandBuilder.java
@@ -1,5 +1,5 @@
 /*************************GO-LICENSE-START*********************************
- * Copyright 2014 ThoughtWorks, Inc.
+ * Copyright 2016 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package com.thoughtworks.go.domain.builder;
 
 import java.io.File;
 
+import com.thoughtworks.go.domain.BuildCommand;
 import com.thoughtworks.go.domain.RunIfConfigs;
 import com.thoughtworks.go.util.SystemUtil;
 import com.thoughtworks.go.util.command.CommandLine;
@@ -115,5 +116,15 @@ public class CommandBuilder extends BaseCommandBuilder {
         return "CommandBuilder{" +
                 "args='" + args + '\'' +
                 "} " + super.toString();
+    }
+
+    @Override
+    public BuildCommand buildCommand() {
+        String[] argsArray = CommandLine.translateCommandLine(args);
+        BuildCommand exec = BuildCommand.exec(command, argsArray);
+        if (workingDir != null) {
+            exec.setWorkingDirectory(workingDir.getPath());
+        }
+        return exec;
     }
 }

--- a/common/src/com/thoughtworks/go/domain/builder/CommandBuilderWithArgList.java
+++ b/common/src/com/thoughtworks/go/domain/builder/CommandBuilderWithArgList.java
@@ -1,5 +1,5 @@
 /*************************GO-LICENSE-START*********************************
- * Copyright 2014 ThoughtWorks, Inc.
+ * Copyright 2016 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package com.thoughtworks.go.domain.builder;
 
 import java.io.File;
 
+import com.thoughtworks.go.domain.BuildCommand;
 import com.thoughtworks.go.domain.RunIfConfigs;
 import com.thoughtworks.go.util.SystemUtil;
 import com.thoughtworks.go.util.command.CommandLine;
@@ -50,5 +51,14 @@ public class CommandBuilderWithArgList extends BaseCommandBuilder {
 
     private String translateToWindowsPath(String command) {
         return StringUtils.replace(command, "/", "\\");
+    }
+
+    @Override
+    public BuildCommand buildCommand() {
+        BuildCommand exec = BuildCommand.exec(this.command, args);
+        if (workingDir != null) {
+            exec.setWorkingDirectory(workingDir.getPath());
+        }
+        return exec;
     }
 }

--- a/common/src/com/thoughtworks/go/domain/builder/FetchArtifactBuilder.java
+++ b/common/src/com/thoughtworks/go/domain/builder/FetchArtifactBuilder.java
@@ -1,5 +1,5 @@
 /*************************GO-LICENSE-START*********************************
- * Copyright 2014 ThoughtWorks, Inc.
+ * Copyright 2016 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,18 +16,18 @@
 
 package com.thoughtworks.go.domain.builder;
 
-import com.thoughtworks.go.domain.BuildLogElement;
-import com.thoughtworks.go.domain.ChecksumFileHandler;
-import com.thoughtworks.go.domain.DownloadAction;
-import com.thoughtworks.go.domain.FetchHandler;
-import com.thoughtworks.go.domain.JobIdentifier;
-import com.thoughtworks.go.domain.RunIfConfigs;
+import com.thoughtworks.go.domain.*;
 import com.thoughtworks.go.plugin.access.pluggabletask.TaskExtension;
+import com.thoughtworks.go.util.ArtifactLogUtil;
 import com.thoughtworks.go.util.URLService;
 import com.thoughtworks.go.util.command.CruiseControlException;
 import com.thoughtworks.go.util.command.EnvironmentVariableContext;
 import com.thoughtworks.go.work.DefaultGoPublisher;
 import org.apache.log4j.Logger;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 
 public class FetchArtifactBuilder extends Builder {
     public static Logger LOG = Logger.getLogger(FetchArtifactBuilder.class);
@@ -95,5 +95,13 @@ public class FetchArtifactBuilder extends Builder {
 
     public JobIdentifier getJobIdentifier() {
         return jobIdentifier;
+    }
+
+    @Override
+    public BuildCommand buildCommand() {
+            String checksumUrl = String.format("/remoting/files/%s/%s/%s", jobIdentifier.buildLocator(), ArtifactLogUtil.CRUISE_OUTPUT_FOLDER, ArtifactLogUtil.MD5_CHECKSUM_FILENAME);
+            return BuildCommand.compose(
+                    BuildCommand.echoWithPrefix(String.format("Fetching artifact [%s] from [%s]", getSrc(), jobLocatorForDisplay())),
+                    handler.toDownloadCommand(artifactLocator(), checksumUrl, checksumFileHandler.getChecksumFile()));
     }
 }

--- a/common/src/com/thoughtworks/go/domain/materials/git/GitMaterialUpdater.java
+++ b/common/src/com/thoughtworks/go/domain/materials/git/GitMaterialUpdater.java
@@ -41,7 +41,7 @@ public class GitMaterialUpdater {
         UrlArgument url = material.getUrlArgument();
         return compose(
                 echoWithPrefix("Start updating %s at revision %s from %s", material.updatingTarget(), revision.getRevision(), url.forDisplay()),
-                secret(url.hostInfoForCommandline(), url.hostInfoForDisplay()),
+                secret(url.forCommandline(), url.forDisplay()),
                 cloneIfNeeded(workingDir, revisionContext.numberOfModifications() + 1),
                 fetchRemote(workingDir),
                 unshallowIfNeeded(workingDir, revision, new Integer[]{GitMaterial.UNSHALLOW_TRYOUT_STEP, Integer.MAX_VALUE}),

--- a/common/src/com/thoughtworks/go/domain/materials/git/GitMaterialUpdater.java
+++ b/common/src/com/thoughtworks/go/domain/materials/git/GitMaterialUpdater.java
@@ -1,0 +1,171 @@
+/*************************** GO-LICENSE-START*********************************
+ * Copyright 2016 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ************************GO-LICENSE-END***********************************/
+package com.thoughtworks.go.domain.materials.git;
+
+import com.thoughtworks.go.config.materials.git.GitMaterial;
+import com.thoughtworks.go.domain.BuildCommand;
+import com.thoughtworks.go.domain.materials.Revision;
+import com.thoughtworks.go.domain.materials.RevisionContext;
+import com.thoughtworks.go.util.command.UrlArgument;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
+
+import static com.thoughtworks.go.domain.BuildCommand.*;
+import static java.lang.String.format;
+
+public class GitMaterialUpdater {
+    private GitMaterial material;
+
+    public GitMaterialUpdater(GitMaterial material) {
+        this.material = material;
+    }
+
+    public BuildCommand updateTo(String baseDir, RevisionContext revisionContext) {
+        Revision revision = revisionContext.getLatestRevision();
+        String workingDir = material.workingdir(new File(baseDir)).getPath();
+        UrlArgument url = material.getUrlArgument();
+        return compose(
+                echoWithPrefix("Start updating %s at revision %s from %s", material.updatingTarget(), revision.getRevision(), url.forDisplay()),
+                secret(url.hostInfoForCommandline(), url.hostInfoForDisplay()),
+                cloneIfNeeded(workingDir, revisionContext.numberOfModifications() + 1),
+                fetchRemote(workingDir),
+                unshallowIfNeeded(workingDir, revision, new Integer[]{GitMaterial.UNSHALLOW_TRYOUT_STEP, Integer.MAX_VALUE}),
+                resetWorkingCopy(workingDir, revision),
+                echoWithPrefix("Done.\n"));
+    }
+
+    private BuildCommand fetchRemote(String workingDir) {
+        return compose(
+                echo("[GIT] Fetching changes"),
+                exec("git", "fetch", "origin").setWorkingDirectory(workingDir),
+                exec("git", "gc", "--auto").setWorkingDirectory(workingDir));
+    }
+
+    private BuildCommand resetWorkingCopy(String workingDir, Revision revision) {
+        return compose(
+                echo("[GIT] Reset working directory %s", workingDir),
+                echo("[GIT] Updating working copy to revision %s", revision.getRevision()),
+                cleanupUnversionedFiles(workingDir),
+                resetHard(workingDir, revision),
+                updateSubmodules(workingDir),
+                cleanupUnversionedFiles(workingDir));
+    }
+
+    private BuildCommand updateSubmodules(String workingDir) {
+        return compose(
+                echo("[GIT] Removing modified files in submodules"),
+                exec("git", "submodule", "foreach", "--recursive", "git", "checkout", "."),
+                echo("[GIT] Updating git sub-modules"),
+                exec("git", "submodule", "init"),
+                exec("git", "submodule", "sync"),
+                exec("git", "submodule", "foreach", "--recursive", "git", "submodule", "sync"),
+                exec("git", "submodule", "update"),
+                echo("[GIT] Git sub-module status"),
+                exec("git", "submodule", "status"))
+                .setTest(hasSubmodules(workingDir))
+                .setWorkingDirectoryRecursively(workingDir);
+    }
+
+    private BuildCommand resetHard(String workingDir, Revision revision) {
+        return exec("git", "reset", "--hard", revision.getRevision())
+                .setWorkingDirectory(workingDir);
+    }
+
+    private BuildCommand cleanupUnversionedFiles(String workingDir) {
+        return compose(
+                echo("[GIT] Cleaning all unversioned files in working copy"),
+                exec("git", "submodule", "foreach", "--recursive", "git", "clean", "-fdd")
+                        .setTest(hasSubmodules(workingDir)),
+                exec("git", "clean", "-dff"))
+                .setWorkingDirectoryRecursively(workingDir);
+    }
+
+    private BuildCommand hasSubmodules(String workingDir) {
+        return test("-f", new File(workingDir, ".gitmodules").getPath());
+    }
+
+    private BuildCommand unshallowIfNeeded(String workingDir, Revision revision, Integer[] steps) {
+        if (steps.length == 0) {
+            return noop();
+        }
+        int depth = steps[0];
+        return compose(
+                compose(
+                        echo("[GIT] Unshallowing repository with depth %d", depth),
+                        exec("git", "fetch", "origin", format("--depth=%d", depth)).setWorkingDirectory(workingDir),
+                        unshallowIfNeeded(workingDir, revision, Arrays.copyOfRange(steps, 1, steps.length))
+                ).setTest(revisionNotExists(workingDir, revision))
+        ).setTest(isShallow(workingDir));
+    }
+
+    private BuildCommand revisionNotExists(String workingDir, Revision revision) {
+        return test("-neq", "commit",
+                exec("git", "cat-file", "-t", revision.getRevision()).setWorkingDirectory(workingDir));
+    }
+
+    private BuildCommand isShallow(String workingDir) {
+        return test("-f", new File(workingDir, ".git/shallow").getPath());
+    }
+
+    private BuildCommand cloneIfNeeded(String workDir, int cloneDepth) {
+        return compose(
+                mkdirs(workDir).setTest(test("-nd", workDir)),
+                cleanWorkingDir(workDir),
+                cmdClone(workDir, cloneDepth));
+    }
+
+    private BuildCommand cleanWorkingDir(String workDir) {
+        return compose(
+                cleandir(workDir).setTest(isNotRepository(workDir)),
+                cleandir(workDir).setTest(isRepoUrlChanged(workDir)),
+                cleandir(workDir).setTest(isBranchChanged(workDir)),
+                material.isShallowClone() ? noop() : cleandir(workDir).setTest(isShallow(workDir))
+        ).setTest(test("-d", workDir));
+    }
+
+    private BuildCommand isRepoUrlChanged(String workDir) {
+        return test("-neq",
+                material.getUrlArgument().forCommandline(),
+                exec("git", "config", "remote.origin.url").setWorkingDirectory(workDir));
+    }
+
+    private BuildCommand isBranchChanged(String workDir) {
+        return test("-neq",
+                material.branchWithDefault(),
+                exec("git", "rev-parse", "--abbrev-ref", "HEAD").setWorkingDirectory(workDir));
+    }
+
+
+    private BuildCommand cmdClone(String workDir, int cloneDepth) {
+        ArrayList<String> cloneArgs = new ArrayList<>();
+        cloneArgs.add("clone");
+        cloneArgs.add("--no-checkout");
+        cloneArgs.add(format("--branch=%s", material.branchWithDefault()));
+        if (material.isShallowClone()) {
+            cloneArgs.add(format("--depth=%s", String.valueOf(cloneDepth)));
+        }
+        cloneArgs.add(material.getUrlArgument().forCommandline());
+        cloneArgs.add(workDir);
+        return exec("git", cloneArgs.toArray(new String[cloneArgs.size()]))
+                .setTest(isNotRepository(workDir));
+    }
+
+    private BuildCommand isNotRepository(String workDir) {
+        return test("-nd", new File(workDir, ".git").getPath());
+    }
+}

--- a/common/src/com/thoughtworks/go/remote/work/BuildWork.java
+++ b/common/src/com/thoughtworks/go/remote/work/BuildWork.java
@@ -1,5 +1,5 @@
 /*************************GO-LICENSE-START*********************************
- * Copyright 2014 ThoughtWorks, Inc.
+ * Copyright 2016 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,7 +31,10 @@ import com.thoughtworks.go.server.service.AgentRuntimeInfo;
 import com.thoughtworks.go.util.ProcessManager;
 import com.thoughtworks.go.util.SystemEnvironment;
 import com.thoughtworks.go.util.TimeProvider;
-import com.thoughtworks.go.util.command.*;
+import com.thoughtworks.go.util.command.EnvironmentVariableContext;
+import com.thoughtworks.go.util.command.PasswordArgument;
+import com.thoughtworks.go.util.command.ProcessOutputStreamConsumer;
+import com.thoughtworks.go.util.command.SafeOutputStreamConsumer;
 import com.thoughtworks.go.work.DefaultGoPublisher;
 import com.thoughtworks.go.work.GoPublisher;
 import org.apache.commons.io.FileUtils;
@@ -47,6 +50,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.Set;
 
+import static com.thoughtworks.go.domain.JobState.*;
 import static com.thoughtworks.go.util.ExceptionUtils.bomb;
 import static com.thoughtworks.go.util.ExceptionUtils.messageOf;
 import static java.lang.String.format;
@@ -114,7 +118,7 @@ public class BuildWork implements Work {
         try {
             builders.waitForCancelTasks();
             if (result == null) {
-                goPublisher.reportCurrentStatus(JobState.Completed);
+                goPublisher.reportCurrentStatus(Completed);
                 goPublisher.reportCompletedAction();
             } else {
                 goPublisher.reportCompleted(result);
@@ -170,7 +174,7 @@ public class BuildWork implements Work {
 
     private void prepareJob(AgentIdentifier agentIdentifier, PackageAsRepositoryExtension packageAsRepositoryExtension, SCMExtension scmExtension) {
         goPublisher.reportAction("Start to prepare");
-        goPublisher.reportCurrentStatus(JobState.Preparing);
+        goPublisher.reportCurrentStatus(Preparing);
 
         createWorkingDirectoryIfNotExist(workingDirectory);
         if (!plan.shouldFetchMaterials()) {
@@ -203,7 +207,7 @@ public class BuildWork implements Work {
     }
 
     private JobResult buildJob(EnvironmentVariableContext environmentVariableContext) {
-        goPublisher.reportCurrentStatus(JobState.Building);
+        goPublisher.reportCurrentStatus(Building);
         goPublisher.reportAction("Start to build");
         return execute(environmentVariableContext);
     }
@@ -215,7 +219,7 @@ public class BuildWork implements Work {
 
         goPublisher.consumeLineWithPrefix(format("Current job status: %s.\n", RunIfConfig.fromJobResult(result.toLowerCase())));
 
-        goPublisher.reportCurrentStatus(JobState.Completing);
+        goPublisher.reportCurrentStatus(Completing);
         goPublisher.reportAction("Start to create properties");
         harvestProperties(goPublisher);
 
@@ -265,7 +269,6 @@ public class BuildWork implements Work {
         builders.cancel(environmentVariableContext);
     }
 
-    // only for test
     public BuildAssignment getAssignment() {
         return assignment;
     }

--- a/common/src/com/thoughtworks/go/remote/work/DeniedAgentWork.java
+++ b/common/src/com/thoughtworks/go/remote/work/DeniedAgentWork.java
@@ -1,5 +1,5 @@
 /*************************GO-LICENSE-START*********************************
- * Copyright 2014 ThoughtWorks, Inc.
+ * Copyright 2016 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,10 +20,10 @@ import com.thoughtworks.go.plugin.access.packagematerial.PackageAsRepositoryExte
 import com.thoughtworks.go.plugin.access.pluggabletask.TaskExtension;
 import com.thoughtworks.go.plugin.access.scm.SCMExtension;
 import com.thoughtworks.go.publishers.GoArtifactsManipulator;
-import com.thoughtworks.go.remote.BuildRepositoryRemote;
 import com.thoughtworks.go.remote.AgentIdentifier;
-import com.thoughtworks.go.util.command.EnvironmentVariableContext;
+import com.thoughtworks.go.remote.BuildRepositoryRemote;
 import com.thoughtworks.go.server.service.AgentRuntimeInfo;
+import com.thoughtworks.go.util.command.EnvironmentVariableContext;
 
 public class DeniedAgentWork implements Work {
     private final String uuid;
@@ -45,5 +45,4 @@ public class DeniedAgentWork implements Work {
     public void cancel(EnvironmentVariableContext environmentVariableContext, AgentRuntimeInfo agentruntimeInfo) {
         agentruntimeInfo.idle();
     }
-
 }

--- a/common/src/com/thoughtworks/go/remote/work/NoWork.java
+++ b/common/src/com/thoughtworks/go/remote/work/NoWork.java
@@ -1,5 +1,5 @@
 /*************************GO-LICENSE-START*********************************
- * Copyright 2014 ThoughtWorks, Inc.
+ * Copyright 2016 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,10 +20,10 @@ import com.thoughtworks.go.plugin.access.packagematerial.PackageAsRepositoryExte
 import com.thoughtworks.go.plugin.access.pluggabletask.TaskExtension;
 import com.thoughtworks.go.plugin.access.scm.SCMExtension;
 import com.thoughtworks.go.publishers.GoArtifactsManipulator;
-import com.thoughtworks.go.remote.BuildRepositoryRemote;
 import com.thoughtworks.go.remote.AgentIdentifier;
-import com.thoughtworks.go.util.command.EnvironmentVariableContext;
+import com.thoughtworks.go.remote.BuildRepositoryRemote;
 import com.thoughtworks.go.server.service.AgentRuntimeInfo;
+import com.thoughtworks.go.util.command.EnvironmentVariableContext;
 
 /**
  * Basic null object.

--- a/common/src/com/thoughtworks/go/remote/work/UnregisteredAgentWork.java
+++ b/common/src/com/thoughtworks/go/remote/work/UnregisteredAgentWork.java
@@ -1,5 +1,5 @@
 /*************************GO-LICENSE-START*********************************
- * Copyright 2014 ThoughtWorks, Inc.
+ * Copyright 2016 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,10 +21,10 @@ import com.thoughtworks.go.plugin.access.packagematerial.PackageAsRepositoryExte
 import com.thoughtworks.go.plugin.access.pluggabletask.TaskExtension;
 import com.thoughtworks.go.plugin.access.scm.SCMExtension;
 import com.thoughtworks.go.publishers.GoArtifactsManipulator;
-import com.thoughtworks.go.remote.BuildRepositoryRemote;
 import com.thoughtworks.go.remote.AgentIdentifier;
-import com.thoughtworks.go.util.command.EnvironmentVariableContext;
+import com.thoughtworks.go.remote.BuildRepositoryRemote;
 import com.thoughtworks.go.server.service.AgentRuntimeInfo;
+import com.thoughtworks.go.util.command.EnvironmentVariableContext;
 
 public class UnregisteredAgentWork implements Work {
     private String message;
@@ -48,5 +48,4 @@ public class UnregisteredAgentWork implements Work {
     public void cancel(EnvironmentVariableContext environmentVariableContext, AgentRuntimeInfo agentruntimeInfo) {
         throw new UnregisteredAgentException(message, uuid);
     }
-
 }

--- a/common/src/com/thoughtworks/go/remote/work/Work.java
+++ b/common/src/com/thoughtworks/go/remote/work/Work.java
@@ -1,5 +1,5 @@
 /*************************GO-LICENSE-START*********************************
- * Copyright 2014 ThoughtWorks, Inc.
+ * Copyright 2016 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,16 +16,16 @@
 
 package com.thoughtworks.go.remote.work;
 
-import java.io.Serializable;
-
 import com.thoughtworks.go.plugin.access.packagematerial.PackageAsRepositoryExtension;
 import com.thoughtworks.go.plugin.access.pluggabletask.TaskExtension;
 import com.thoughtworks.go.plugin.access.scm.SCMExtension;
 import com.thoughtworks.go.publishers.GoArtifactsManipulator;
 import com.thoughtworks.go.remote.AgentIdentifier;
 import com.thoughtworks.go.remote.BuildRepositoryRemote;
-import com.thoughtworks.go.util.command.EnvironmentVariableContext;
 import com.thoughtworks.go.server.service.AgentRuntimeInfo;
+import com.thoughtworks.go.util.command.EnvironmentVariableContext;
+
+import java.io.Serializable;
 
 /**
  * Work that needs to be done by an agent.
@@ -38,5 +38,4 @@ public interface Work extends Serializable {
     String description();
 
     void cancel(EnvironmentVariableContext environmentVariableContext, AgentRuntimeInfo agentruntimeInfo);
-
 }

--- a/common/src/com/thoughtworks/go/security/Registration.java
+++ b/common/src/com/thoughtworks/go/security/Registration.java
@@ -1,5 +1,5 @@
 /*************************GO-LICENSE-START*********************************
- * Copyright 2014 ThoughtWorks, Inc.
+ * Copyright 2016 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,15 +16,53 @@
 
 package com.thoughtworks.go.security;
 
+import com.google.gson.Gson;
+import org.apache.commons.io.IOUtils;
+import org.bouncycastle.util.io.pem.PemObject;
+import org.bouncycastle.util.io.pem.PemReader;
+import org.bouncycastle.util.io.pem.PemWriter;
+import sun.security.x509.X509CertImpl;
+
+import java.io.IOException;
 import java.io.Serializable;
-import java.security.KeyStore;
-import java.security.PrivateKey;
-import java.security.PublicKey;
+import java.io.StringReader;
+import java.io.StringWriter;
+import java.security.*;
 import java.security.cert.Certificate;
+import java.security.cert.CertificateEncodingException;
+import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
-import java.util.Date;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.util.*;
+
+import static com.thoughtworks.go.util.ExceptionUtils.bomb;
 
 public class Registration implements Serializable {
+
+    public static Registration fromJson(String json) {
+        Map map = new Gson().fromJson(json, Map.class);
+        List<Certificate> chain = new ArrayList<>();
+        try {
+            PemReader reader = new PemReader(new StringReader((String) map.get("agentPrivateKey")));
+            KeyFactory kf = KeyFactory.getInstance("RSA");
+            PKCS8EncodedKeySpec spec = new PKCS8EncodedKeySpec(reader.readPemObject().getContent());
+            PrivateKey privateKey = kf.generatePrivate(spec);
+            String agentCertificate = (String) map.get("agentCertificate");
+            PemReader certReader = new PemReader(new StringReader(agentCertificate));
+            while (true) {
+                PemObject obj = certReader.readPemObject();
+                if (obj == null) {
+                    break;
+                }
+                chain.add(new X509CertImpl(obj.getContent()));
+            }
+            return new Registration(privateKey, chain.toArray(new Certificate[chain.size()]));
+        } catch (IOException | NoSuchAlgorithmException | CertificateException | InvalidKeySpecException e) {
+            throw bomb(e);
+        }
+    }
+
     private final PrivateKey privateKey;
     private final Certificate[] chain;
 
@@ -76,4 +114,34 @@ public class Registration implements Serializable {
     public KeyStore.PrivateKeyEntry asKeyStoreEntry() {
         return new KeyStore.PrivateKeyEntry(privateKey, chain);
     }
+
+    public String toJson() {
+        Map<String, Object> ret = new HashMap<>();
+        ret.put("agentPrivateKey", serialize("RSA PRIVATE KEY", privateKey.getEncoded()));
+        StringBuilder builder = new StringBuilder();
+        for (Certificate c : chain) {
+            try {
+                builder.append(serialize("CERTIFICATE", c.getEncoded()));
+            } catch (CertificateEncodingException e) {
+                throw bomb(e);
+            }
+        }
+        ret.put("agentCertificate", builder.toString());
+        return new Gson().toJson(ret);
+    }
+
+    private String serialize(String type, byte[] data) {
+        PemObject obj = new PemObject(type, data);
+        StringWriter out = new StringWriter();
+        PemWriter writer = new PemWriter(out);
+        try {
+            writer.writeObject(obj);
+        } catch (IOException e) {
+            throw bomb(e);
+        } finally {
+            IOUtils.closeQuietly(writer);
+        }
+        return out.toString();
+    }
+
 }

--- a/common/src/com/thoughtworks/go/server/service/AgentBuildingInfo.java
+++ b/common/src/com/thoughtworks/go/server/service/AgentBuildingInfo.java
@@ -1,5 +1,5 @@
 /*************************GO-LICENSE-START*********************************
- * Copyright 2014 ThoughtWorks, Inc.
+ * Copyright 2016 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,12 +16,16 @@
 
 package com.thoughtworks.go.server.service;
 
+import com.google.gson.annotations.Expose;
+
 import java.io.Serializable;
 
 import static com.thoughtworks.go.util.ExceptionUtils.bombIfNull;
 
 public class AgentBuildingInfo implements Serializable {
+    @Expose
     private final String buildingInfo;
+    @Expose
     private final String buildLocator;
     public static final AgentBuildingInfo NOT_BUILDING = new AgentBuildingInfo("", "");
 

--- a/common/src/com/thoughtworks/go/server/service/ElasticAgentRuntimeInfo.java
+++ b/common/src/com/thoughtworks/go/server/service/ElasticAgentRuntimeInfo.java
@@ -16,14 +16,16 @@
 
 package com.thoughtworks.go.server.service;
 
+import com.google.gson.annotations.Expose;
 import com.thoughtworks.go.domain.AgentRuntimeStatus;
 import com.thoughtworks.go.remote.AgentIdentifier;
 
 import java.io.Serializable;
 
 public class ElasticAgentRuntimeInfo extends AgentRuntimeInfo implements Serializable {
-
+    @Expose
     private volatile String elasticAgentId;
+    @Expose
     private volatile String elasticPluginId;
 
     private ElasticAgentRuntimeInfo(AgentRuntimeInfo runtimeInfo, String elasticAgentId, String elasticPluginId) {
@@ -39,7 +41,7 @@ public class ElasticAgentRuntimeInfo extends AgentRuntimeInfo implements Seriali
     }
 
     public ElasticAgentRuntimeInfo(AgentIdentifier identifier, AgentRuntimeStatus runtimeStatus, String location, String cookie, String agentLauncherVersion, String elasticAgentId, String elasticPluginId) {
-        super(identifier, runtimeStatus, location, cookie, agentLauncherVersion);
+        super(identifier, runtimeStatus, location, cookie, agentLauncherVersion, false);
         this.elasticAgentId = elasticAgentId;
         this.elasticPluginId = elasticPluginId;
     }

--- a/common/src/com/thoughtworks/go/util/MapBuilder.java
+++ b/common/src/com/thoughtworks/go/util/MapBuilder.java
@@ -1,0 +1,58 @@
+/*************************** GO-LICENSE-START*********************************
+ * Copyright 2016 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ************************GO-LICENSE-END***********************************/
+package com.thoughtworks.go.util;
+
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+public class MapBuilder {
+    public static <S, T> Map<S, T> map() {
+        return Collections.emptyMap();
+    }
+
+    public static <S, T> Map<S, T> map(S k, T v) {
+        Map<S, T> values = new HashMap<>();
+        values.put(k, v);
+        return values;
+    }
+
+    public static <S, T> Map<S, T> map(S k1, T v1, S k2, T v2) {
+        Map<S, T> values = map(k1, v1);
+        values.put(k2, v2);
+        return values;
+    }
+
+    public static <S, T> Map<S, T> map(S k1, T v1, S k2, T v2, S k3, T v3) {
+        Map<S, T> values = map(k1, v1, k2, v2);
+        values.put(k3, v3);
+        return values;
+    }
+
+    public static <S, T> Map<S, T> map(S k1, T v1, S k2, T v2, S k3, T v3, S k4, T v4) {
+        Map<S, T> values = map(k1, v1, k2, v2, k3, v3);
+        values.put(k4, v4);
+        return values;
+    }
+
+    public static <S, T> Map<S, T> map(S k1, T v1, S k2, T v2, S k3, T v3, S k4, T v4, S k5, T v5) {
+        Map<S, T> values = map(k1, v1, k2, v2, k3, v3, k4, v4);
+        values.put(k5, v5);
+        return values;
+    }
+
+}

--- a/common/src/com/thoughtworks/go/util/URLService.java
+++ b/common/src/com/thoughtworks/go/util/URLService.java
@@ -1,5 +1,5 @@
 /*************************GO-LICENSE-START*********************************
- * Copyright 2014 ThoughtWorks, Inc.
+ * Copyright 2016 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,6 +35,10 @@ public class URLService implements ServerUrlGenerator{
             url = url.substring(0, url.length() - 1);
         }
         baseRemotingURL = url;
+    }
+
+    public URLService(String baseRemotingURL) {
+        this.baseRemotingURL = baseRemotingURL;
     }
 
     public String baseRemoteURL() {
@@ -75,6 +79,11 @@ public class URLService implements ServerUrlGenerator{
         return format("/%s/%s", "files", jobIdentifier.artifactLocator(filePath));
     }
 
+
+    public String getUploadBaseUrlOfAgent(JobIdentifier jobIdentifier) {
+        return format("%s/%s/%s/%s", baseRemotingURL, "remoting", "files", jobIdentifier.artifactLocator(""));
+    }
+
     /*
     * Agent will use this method, the baseUrl will be injected from config xml in agent side.
     *   This is used to fix security issues with the agent uploading artifacts when security is enabled.
@@ -107,5 +116,12 @@ public class URLService implements ServerUrlGenerator{
         } catch (URISyntaxException e) {
             throw new RuntimeException("Invalid Go Server url", e);
         }
+    }
+
+    public String prefixPartialUrl(String url) {
+        if(url.startsWith("/")) {
+            return format("%s%s", baseRemoteURL(), url);
+        }
+        return url;
     }
 }

--- a/common/src/com/thoughtworks/go/util/UrlUtil.java
+++ b/common/src/com/thoughtworks/go/util/UrlUtil.java
@@ -99,6 +99,15 @@ public class UrlUtil {
         }
     }
 
+    public static String concatPath(String baseUrl, String path) {
+        StringBuilder builder = new StringBuilder(baseUrl);
+        if(!baseUrl.endsWith("/")) {
+            builder.append('/');
+        }
+        builder.append(path);
+        return builder.toString();
+    }
+
     private static class QueryTuple {
         private static final String QUERY_SEPERATOR = "&";
         private static final String QUERY_KEY_VAL_SEPERATOR = "=";

--- a/common/src/com/thoughtworks/go/util/command/CommandLine.java
+++ b/common/src/com/thoughtworks/go/util/command/CommandLine.java
@@ -1,5 +1,5 @@
 /*************************GO-LICENSE-START*********************************
- * Copyright 2014 ThoughtWorks, Inc.
+ * Copyright 2016 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -69,20 +69,14 @@
  */
 package com.thoughtworks.go.util.command;
 
-import java.io.File;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.StringTokenizer;
-import java.util.Vector;
-
 import com.thoughtworks.go.util.ProcessManager;
 import com.thoughtworks.go.util.ProcessWrapper;
 import org.apache.commons.lang.StringUtils;
 import org.apache.log4j.Logger;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.*;
 
 import static com.thoughtworks.go.util.ExceptionUtils.bomb;
 import static com.thoughtworks.go.util.ListUtil.join;

--- a/common/src/com/thoughtworks/go/websocket/Action.java
+++ b/common/src/com/thoughtworks/go/websocket/Action.java
@@ -21,5 +21,5 @@ public enum Action {
     cancelJob,
     ping,
     reregister,
-    reportCurrentStatus, reportCompleted, reportCompleting, ack, setCookie
+    reportCurrentStatus, reportCompleted, reportCompleting, ack, build, cancelBuild, setCookie
 }

--- a/common/src/com/thoughtworks/go/websocket/Action.java
+++ b/common/src/com/thoughtworks/go/websocket/Action.java
@@ -18,8 +18,8 @@ package com.thoughtworks.go.websocket;
 
 public enum Action {
     assignWork,
-    cancelJob,
+    cancelBuild,
     ping,
     reregister,
-    reportCurrentStatus, reportCompleted, reportCompleting, ack, build, cancelBuild, setCookie
+    reportCurrentStatus, reportCompleted, reportCompleting, ack, build, setCookie
 }

--- a/common/src/com/thoughtworks/go/websocket/Message.java
+++ b/common/src/com/thoughtworks/go/websocket/Message.java
@@ -16,64 +16,39 @@
 
 package com.thoughtworks.go.websocket;
 
-import org.apache.commons.io.output.ByteArrayOutputStream;
+import com.google.gson.annotations.Expose;
 
-import java.io.*;
 import java.util.UUID;
-import java.util.zip.GZIPInputStream;
-import java.util.zip.GZIPOutputStream;
 
-import static com.thoughtworks.go.util.ExceptionUtils.bomb;
+public class Message {
 
-public class Message implements Serializable {
-
-    public static byte[] encode(Message msg) {
-        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
-        try {
-            GZIPOutputStream zip = new GZIPOutputStream(bytes);
-            ObjectOutputStream output = new ObjectOutputStream(zip);
-            try {
-                output.writeObject(msg);
-            } finally {
-                output.close();
-            }
-        } catch (IOException e) {
-            throw bomb(e);
-        }
-        return bytes.toByteArray();
-    }
-
-    public static Message decode(InputStream input) {
-        try {
-            ObjectInputStream stream = new ObjectInputStream(new GZIPInputStream(input));
-            try {
-                return (Message) stream.readObject();
-            } finally {
-                stream.close();
-            }
-        } catch (Exception e) {
-            throw bomb(e);
-        }
-    }
-
+    @Expose
     private final Action action;
-    private final Object data;
+    @Expose
+    private final String data;
+    @Expose
     private String ackId;
 
     public Message(Action action) {
         this(action, null);
     }
 
-    public Message(Action action, Object data) {
+    public Message(Action action, String data) {
+        this(action, data, null);
+    }
+
+    public Message(Action action, String data, String ackId) {
         this.action = action;
         this.data = data;
+        this.ackId = ackId;
     }
+
 
     public Action getAction() {
         return action;
     }
 
-    public Object getData() {
+    public String getData() {
         return data;
     }
 

--- a/common/src/com/thoughtworks/go/websocket/MessageEncoding.java
+++ b/common/src/com/thoughtworks/go/websocket/MessageEncoding.java
@@ -1,0 +1,127 @@
+/*************************** GO-LICENSE-START*********************************
+ * Copyright 2016 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ************************GO-LICENSE-END***********************************/
+package com.thoughtworks.go.websocket;
+
+import com.google.gson.*;
+import com.thoughtworks.go.domain.AgentRuntimeStatus;
+import com.thoughtworks.go.remote.AgentIdentifier;
+import com.thoughtworks.go.remote.work.Work;
+import com.thoughtworks.go.server.service.AgentBuildingInfo;
+import com.thoughtworks.go.server.service.AgentRuntimeInfo;
+import com.thoughtworks.go.server.service.ElasticAgentRuntimeInfo;
+import com.thoughtworks.go.util.StringUtil;
+import org.apache.commons.codec.binary.Base64;
+import org.apache.commons.io.IOUtils;
+
+import java.io.*;
+import java.lang.reflect.Type;
+import java.nio.charset.StandardCharsets;
+import java.util.zip.GZIPInputStream;
+import java.util.zip.GZIPOutputStream;
+
+import static com.thoughtworks.go.util.ExceptionUtils.bomb;
+
+public class MessageEncoding {
+
+    private static Gson gson = new GsonBuilder().excludeFieldsWithoutExposeAnnotation().registerTypeAdapter(AgentRuntimeInfo.class, new AgentRuntimeInfoTypeAdapter()).create();
+
+    public static String encodeWork(Work work) {
+        try {
+            ByteArrayOutputStream binaryOutput = new ByteArrayOutputStream();
+            try (ObjectOutputStream objectStream = new ObjectOutputStream(binaryOutput)) {
+                objectStream.writeObject(work);
+            }
+
+            return Base64.encodeBase64String(binaryOutput.toByteArray());
+        } catch (IOException e) {
+            throw bomb(e);
+        }
+    }
+
+    public static Work decodeWork(String data) {
+        try {
+            byte[] binary = Base64.decodeBase64(data);
+            try (ObjectInputStream objectStream = new ObjectInputStream(new ByteArrayInputStream(binary))) {
+                return (Work) objectStream.readObject();
+            }
+        } catch (ClassNotFoundException | IOException e) {
+            throw bomb(e);
+        }
+    }
+
+    public static byte[] encodeMessage(Message msg) {
+        String encode = gson.toJson(msg);
+        org.apache.commons.io.output.ByteArrayOutputStream bytes = new org.apache.commons.io.output.ByteArrayOutputStream();
+        try {
+            GZIPOutputStream out = new GZIPOutputStream(bytes);
+            out.write(encode.getBytes(StandardCharsets.UTF_8));
+            out.finish();
+        } catch (IOException e) {
+            throw bomb(e);
+        }
+        return bytes.toByteArray();
+    }
+
+    public static Message decodeMessage(InputStream input) {
+        try {
+            GZIPInputStream zipStream = new GZIPInputStream(input);
+            String jsonStr = new String(IOUtils.toByteArray(zipStream), StandardCharsets.UTF_8);
+            return gson.fromJson(jsonStr, Message.class);
+        } catch (IOException e) {
+            throw bomb(e);
+        }
+    }
+
+    public static String encodeData(Object obj) {
+        return gson.toJson(obj);
+    }
+
+    public static <T> T decodeData(String data, Class<T> aClass) {
+        return gson.fromJson(data, aClass);
+    }
+
+    // todo: Remove hand wrote deserialization after merging ElasticAgentRuntimeInfo class into AgentRuntimeInfo (@wpc)
+    private static class AgentRuntimeInfoTypeAdapter implements JsonDeserializer<AgentRuntimeInfo> {
+        @Override
+        public AgentRuntimeInfo deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
+            JsonObject jsonObject = json.getAsJsonObject();
+
+            AgentIdentifier identifier = context.deserialize(jsonObject.get("identifier"), AgentIdentifier.class);
+            AgentRuntimeStatus runtimeStatus = context.deserialize(jsonObject.get("runtimeStatus"), AgentRuntimeStatus.class);
+            AgentBuildingInfo buildingInfo = context.deserialize(jsonObject.get("buildingInfo"), AgentBuildingInfo.class);
+            String location = jsonObject.has("location") ? jsonObject.get("location").getAsString() : null;
+            Long usableSpace = jsonObject.has("usableSpace") ? jsonObject.get("usableSpace").getAsLong() : null;
+            String operatingSystemName = jsonObject.has("operatingSystemName") ? jsonObject.get("operatingSystemName").getAsString() : null;
+            String cookie = jsonObject.has("cookie") ? jsonObject.get("cookie").getAsString() : null;
+            String agentLauncherVersion = jsonObject.has("agentLauncherVersion") ? jsonObject.get("agentLauncherVersion").getAsString() : null;
+            boolean supportsBuildCommandProtocol = jsonObject.has("supportsBuildCommandProtocol") && jsonObject.get("supportsBuildCommandProtocol").getAsBoolean();
+            String elasticPluginId = jsonObject.has("elasticPluginId") ? jsonObject.get("elasticPluginId").getAsString() : null;
+            String elasticAgentId = jsonObject.has("elasticAgentId") ? jsonObject.get("elasticAgentId").getAsString() : null;
+
+            AgentRuntimeInfo info;
+            if (elasticPluginId == null || StringUtil.isBlank(elasticPluginId)) {
+                info = new AgentRuntimeInfo(identifier, runtimeStatus, location, cookie, agentLauncherVersion, supportsBuildCommandProtocol);
+            } else {
+                info = new ElasticAgentRuntimeInfo(identifier, runtimeStatus, location, cookie, agentLauncherVersion, elasticAgentId, elasticPluginId);
+            }
+            info.setUsableSpace(usableSpace);
+            info.setOperatingSystem(operatingSystemName);
+            info.setSupportsBuildCommandProtocol(supportsBuildCommandProtocol);
+            info.setBuildingInfo(buildingInfo);
+            return info;
+        }
+    }
+}

--- a/common/src/com/thoughtworks/go/websocket/Report.java
+++ b/common/src/com/thoughtworks/go/websocket/Report.java
@@ -16,17 +16,26 @@
 
 package com.thoughtworks.go.websocket;
 
+import com.google.gson.annotations.Expose;
 import com.thoughtworks.go.domain.JobIdentifier;
 import com.thoughtworks.go.domain.JobResult;
 import com.thoughtworks.go.domain.JobState;
 import com.thoughtworks.go.server.service.AgentRuntimeInfo;
 
 import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
 
 public class Report implements Serializable {
+    @Expose
+    private String buildId;
+    @Expose
     private AgentRuntimeInfo agentRuntimeInfo;
+    @Expose
     private JobIdentifier jobIdentifier;
+    @Expose
     private JobResult result;
+    @Expose
     private JobState jobState;
 
     public Report(AgentRuntimeInfo agentRuntimeInfo, JobIdentifier jobIdentifier, JobState jobState) {
@@ -38,6 +47,13 @@ public class Report implements Serializable {
     public Report(AgentRuntimeInfo agentRuntimeInfo, JobIdentifier jobIdentifier, JobResult result) {
         this.agentRuntimeInfo = agentRuntimeInfo;
         this.jobIdentifier = jobIdentifier;
+        this.result = result;
+    }
+
+    public Report(AgentRuntimeInfo agentRuntimeInfo, String buildId, JobState jobState, JobResult result) {
+        this.agentRuntimeInfo = agentRuntimeInfo;
+        this.jobState = jobState;
+        this.buildId = buildId;
         this.result = result;
     }
 
@@ -55,5 +71,46 @@ public class Report implements Serializable {
 
     public JobResult getResult() {
         return result;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        Report report = (Report) o;
+
+        if (buildId != null ? !buildId.equals(report.buildId) : report.buildId != null) return false;
+        if (!agentRuntimeInfo.equals(report.agentRuntimeInfo)) return false;
+        if (jobIdentifier != null ? !jobIdentifier.equals(report.jobIdentifier) : report.jobIdentifier != null)
+            return false;
+        if (result != report.result) return false;
+        return jobState == report.jobState;
+
+    }
+
+    @Override
+    public int hashCode() {
+        int result1 = buildId != null ? buildId.hashCode() : 0;
+        result1 = 31 * result1 + agentRuntimeInfo.hashCode();
+        result1 = 31 * result1 + (jobIdentifier != null ? jobIdentifier.hashCode() : 0);
+        result1 = 31 * result1 + (result != null ? result.hashCode() : 0);
+        result1 = 31 * result1 + (jobState != null ? jobState.hashCode() : 0);
+        return result1;
+    }
+
+    @Override
+    public String toString() {
+        return "Report{" +
+                "buildId='" + buildId + '\'' +
+                ", agentRuntimeInfo=" + agentRuntimeInfo +
+                ", jobIdentifier=" + jobIdentifier +
+                ", result=" + result +
+                ", jobState=" + jobState +
+                '}';
+    }
+
+    public String getBuildId() {
+        return buildId;
     }
 }

--- a/common/test/unit/com/thoughtworks/go/buildsession/BuildSessionBasedTestCase.java
+++ b/common/test/unit/com/thoughtworks/go/buildsession/BuildSessionBasedTestCase.java
@@ -94,10 +94,15 @@ public class BuildSessionBasedTestCase {
 
     public static BuildCommand execSleepScript(int seconds) {
         if (SystemUtil.isWindows()) {
-            return exec("cmd", "/c", "echo start sleeping & ping 1.1.1.1 -n 1 -w " + seconds * 1000 + " >NULL & echo after sleep");
+            return exec("ping 1.1.1.1 -n 1 -w " + seconds * 1000 + " >NULL");
         } else {
-            return exec("/bin/sh", "-c", "echo start sleeping;sleep " + seconds + ";echo after sleep");
+            return exec("sleep", String.valueOf(seconds));
         }
     }
+
+    protected String execSleepScriptProcessCommand() {
+        return SystemUtil.isWindows() ? "ping" : "sleep";
+    }
+
 }
 

--- a/common/test/unit/com/thoughtworks/go/buildsession/BuildSessionBasedTestCase.java
+++ b/common/test/unit/com/thoughtworks/go/buildsession/BuildSessionBasedTestCase.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2016 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.thoughtworks.go.buildsession;
+
+import com.thoughtworks.go.domain.ArtifactsRepositoryStub;
+import com.thoughtworks.go.domain.BuildCommand;
+import com.thoughtworks.go.domain.BuildStateReporterStub;
+import com.thoughtworks.go.domain.JobResult;
+import com.thoughtworks.go.remote.work.HttpServiceStub;
+import com.thoughtworks.go.util.TestFileUtil;
+import com.thoughtworks.go.util.TestingClock;
+import com.thoughtworks.go.util.command.InMemoryConsumer;
+import org.apache.commons.lang.text.StrLookup;
+import org.junit.After;
+import org.junit.Before;
+
+import java.io.File;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+
+public class BuildSessionBasedTestCase {
+    protected BuildStateReporterStub statusReporter;
+    protected Map<String, String> buildVariables;
+    protected File sandbox;
+    protected ArtifactsRepositoryStub artifactsRepository;
+    protected InMemoryConsumer console;
+    protected HttpServiceStub httpService;
+
+    @Before
+    public void superSetup() {
+        statusReporter = new BuildStateReporterStub();
+        buildVariables = new HashMap<>();
+        artifactsRepository = new ArtifactsRepositoryStub();
+        sandbox = TestFileUtil.createTempFolder(UUID.randomUUID().toString());
+        console = new InMemoryConsumer();
+        httpService = new HttpServiceStub();
+    }
+
+    @After
+    public void superTeardown() {
+        TestFileUtil.cleanTempFiles();
+    }
+
+    protected BuildSession newBuildSession() {
+        return new BuildSession("build1",
+                statusReporter,
+                console,
+                StrLookup.mapLookup(buildVariables),
+                artifactsRepository, httpService, new TestingClock(), sandbox);
+    }
+
+    protected String buildInfo() {
+        return "\n *** current build info *** \n"
+                + "build status: " + statusReporter.status() + "\n"
+                + "build result: " + statusReporter.results() + "\n"
+                + "build console output: \n"
+                + console.output()
+                + "\n******";
+    }
+
+    protected void runBuild(BuildSession buildSession, BuildCommand command, JobResult expectedResult) {
+        JobResult result = buildSession.build(command);
+        assertThat(buildInfo(), result, is(expectedResult));
+    }
+
+    protected void runBuild(BuildCommand command, JobResult expectedResult) {
+        runBuild(newBuildSession(), command, expectedResult);
+    }
+}
+

--- a/common/test/unit/com/thoughtworks/go/buildsession/BuildSessionBasedTestCase.java
+++ b/common/test/unit/com/thoughtworks/go/buildsession/BuildSessionBasedTestCase.java
@@ -21,6 +21,7 @@ import com.thoughtworks.go.domain.BuildStateReporterStub;
 import com.thoughtworks.go.domain.JobResult;
 import com.thoughtworks.go.helper.TestStreamConsumer;
 import com.thoughtworks.go.remote.work.HttpServiceStub;
+import com.thoughtworks.go.util.SystemUtil;
 import com.thoughtworks.go.util.TestFileUtil;
 import com.thoughtworks.go.util.TestingClock;
 import com.thoughtworks.go.util.command.InMemoryConsumer;
@@ -34,6 +35,7 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
+import static com.thoughtworks.go.domain.BuildCommand.exec;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 
@@ -84,6 +86,18 @@ public class BuildSessionBasedTestCase {
 
     protected void runBuild(BuildCommand command, JobResult expectedResult) {
         runBuild(newBuildSession(), command, expectedResult);
+    }
+
+    protected String pathSystemEnvName() {
+        return SystemUtil.isWindows() ? "Path" : "PATH";
+    }
+
+    public static BuildCommand execSleepScript(int seconds) {
+        if (SystemUtil.isWindows()) {
+            return exec("cmd", "/c", "echo start sleeping & ping 1.1.1.1 -n 1 -w " + seconds * 1000 + " >NULL & echo after sleep");
+        } else {
+            return exec("/bin/sh", "-c", "echo start sleeping;sleep " + seconds + ";echo after sleep");
+        }
     }
 }
 

--- a/common/test/unit/com/thoughtworks/go/buildsession/BuildSessionBasedTestCase.java
+++ b/common/test/unit/com/thoughtworks/go/buildsession/BuildSessionBasedTestCase.java
@@ -19,6 +19,7 @@ import com.thoughtworks.go.domain.ArtifactsRepositoryStub;
 import com.thoughtworks.go.domain.BuildCommand;
 import com.thoughtworks.go.domain.BuildStateReporterStub;
 import com.thoughtworks.go.domain.JobResult;
+import com.thoughtworks.go.helper.TestStreamConsumer;
 import com.thoughtworks.go.remote.work.HttpServiceStub;
 import com.thoughtworks.go.util.TestFileUtil;
 import com.thoughtworks.go.util.TestingClock;
@@ -41,7 +42,7 @@ public class BuildSessionBasedTestCase {
     protected Map<String, String> buildVariables;
     protected File sandbox;
     protected ArtifactsRepositoryStub artifactsRepository;
-    protected InMemoryConsumer console;
+    protected TestStreamConsumer console;
     protected HttpServiceStub httpService;
 
     @Before
@@ -50,7 +51,7 @@ public class BuildSessionBasedTestCase {
         buildVariables = new HashMap<>();
         artifactsRepository = new ArtifactsRepositoryStub();
         sandbox = TestFileUtil.createTempFolder(UUID.randomUUID().toString());
-        console = new InMemoryConsumer();
+        console = new TestStreamConsumer();
         httpService = new HttpServiceStub();
     }
 

--- a/common/test/unit/com/thoughtworks/go/buildsession/BuildSessionBasedTestCase.java
+++ b/common/test/unit/com/thoughtworks/go/buildsession/BuildSessionBasedTestCase.java
@@ -101,7 +101,7 @@ public class BuildSessionBasedTestCase {
     }
 
     protected String execSleepScriptProcessCommand() {
-        return SystemUtil.isWindows() ? "ping" : "sleep";
+        return SystemUtil.isWindows() ? "PING.EXE" : "sleep";
     }
 
 }

--- a/common/test/unit/com/thoughtworks/go/buildsession/BuildSessionCancelingTest.java
+++ b/common/test/unit/com/thoughtworks/go/buildsession/BuildSessionCancelingTest.java
@@ -1,0 +1,212 @@
+/*
+ * Copyright 2016 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.thoughtworks.go.buildsession;
+
+import com.googlecode.junit.ext.JunitExtRunner;
+import com.googlecode.junit.ext.RunIf;
+import com.jezhumble.javasysmon.JavaSysMon;
+import com.jezhumble.javasysmon.OsProcess;
+import com.jezhumble.javasysmon.ProcessVisitor;
+import com.thoughtworks.go.domain.BuildCommand;
+import com.thoughtworks.go.junitext.EnhancedOSChecker;
+import com.thoughtworks.go.utils.Assertions;
+import com.thoughtworks.go.utils.Timeout;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.concurrent.TimeUnit;
+
+import static com.google.common.collect.Iterables.getLast;
+import static com.thoughtworks.go.domain.BuildCommand.*;
+import static com.thoughtworks.go.domain.JobResult.Cancelled;
+import static com.thoughtworks.go.junitext.EnhancedOSChecker.DO_NOT_RUN_ON;
+import static com.thoughtworks.go.junitext.EnhancedOSChecker.WINDOWS;
+import static com.thoughtworks.go.util.ExceptionUtils.bomb;
+import static com.thoughtworks.go.utils.Assertions.waitUntil;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsNot.not;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(JunitExtRunner.class)
+public class BuildSessionCancelingTest extends BuildSessionBasedTestCase {
+
+    @Test
+    public void cancelLongRunningBuild() throws InterruptedException {
+        final BuildSession buildSession = newBuildSession();
+        Thread buildingThread = new Thread(new Runnable() {
+            @Override
+            public void run() {
+                buildSession.build(compose(
+                        execSleepScript(50),
+                        echo("build done")));
+            }
+        });
+        buildingThread.start();
+        waitUntilSubProcessExists(execSleepScriptProcessCommand());
+        assertTrue(buildInfo(), buildSession.cancel(30, TimeUnit.SECONDS));
+        waitUntilSubProcessNotExists(execSleepScriptProcessCommand());
+        assertThat(buildInfo(), getLast(statusReporter.results()), is(Cancelled));
+        assertThat(buildInfo(), console.output(), not(containsString("build done")));
+        buildingThread.join();
+    }
+
+
+    @Test
+    public void cancelLongRunningTestCommand() throws InterruptedException {
+        final BuildSession buildSession = newBuildSession();
+        Thread buildingThread = new Thread(new Runnable() {
+            @Override
+            public void run() {
+                buildSession.build(compose(
+                        echo("after sleep").setTest(execSleepScript(50))));
+            }
+        });
+        buildingThread.start();
+        waitUntilSubProcessExists(execSleepScriptProcessCommand());
+
+        assertTrue(buildInfo(), buildSession.cancel(30, TimeUnit.SECONDS));
+        waitUntilSubProcessNotExists(execSleepScriptProcessCommand());
+        assertThat(buildInfo(), getLast(statusReporter.results()), is(Cancelled));
+        assertThat(buildInfo(), console.output(), not(containsString("after sleep")));
+        buildingThread.join();
+    }
+
+
+    @Test
+    public void doubleCancelDoNothing() throws InterruptedException {
+        final BuildSession buildSession = newBuildSession();
+        Thread buildingThread = new Thread(new Runnable() {
+            @Override
+            public void run() {
+                buildSession.build(execSleepScript(50));
+            }
+        });
+        Runnable cancel = new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    buildSession.cancel(30, TimeUnit.SECONDS);
+                } catch (InterruptedException e) {
+                    throw bomb(e);
+                }
+            }
+        };
+        Thread cancelThread1 = new Thread(cancel);
+        Thread cancelThread2 = new Thread(cancel);
+
+        buildingThread.start();
+        waitUntilSubProcessExists(execSleepScriptProcessCommand());
+        cancelThread1.start();
+        cancelThread2.start();
+        cancelThread1.join();
+        cancelThread2.join();
+        waitUntilSubProcessNotExists(execSleepScriptProcessCommand());
+        assertThat(buildInfo(), getLast(statusReporter.results()), is(Cancelled));
+        assertThat(buildInfo(), console.output(), not(containsString("after sleep")));
+        buildingThread.join();
+    }
+
+    @Test
+    public void cancelShouldProcessOnCancelCommandOfCommandThatIsRunning() throws InterruptedException {
+        final BuildSession buildSession = newBuildSession();
+        Thread buildingThread = new Thread(new Runnable() {
+            @Override
+            public void run() {
+                buildSession.build(compose(
+                        compose(
+                                execSleepScript(50).setOnCancel(echo("exec canceled")),
+                                echo("after sleep"))
+                                .setOnCancel(echo("inner oncancel"))
+                ).setOnCancel(echo("outter oncancel")));
+            }
+        });
+
+        buildingThread.start();
+        waitUntilSubProcessExists(execSleepScriptProcessCommand());
+        assertTrue(buildInfo(), buildSession.cancel(30, TimeUnit.SECONDS));
+        waitUntilSubProcessNotExists(execSleepScriptProcessCommand());
+        assertThat(subProcessWithNameExists(execSleepScriptProcessCommand()), is(false));
+
+        assertThat(buildInfo(), getLast(statusReporter.results()), is(Cancelled));
+        assertThat(buildInfo(), console.output(), not(containsString("after sleep")));
+        assertThat(buildInfo(), console.output(), containsString("exec canceled"));
+        assertThat(buildInfo(), console.output(), containsString("inner oncancel"));
+        assertThat(buildInfo(), console.output(), containsString("outter oncancel"));
+        buildingThread.join();
+    }
+
+
+    @Test
+    @RunIf(value = EnhancedOSChecker.class, arguments = {DO_NOT_RUN_ON, WINDOWS})
+    public void cancelTaskShouldBeProcessedBeforeKillChildProcess() throws InterruptedException {
+        final BuildSession buildSession = newBuildSession();
+        final BuildCommand printSubProcessCount = exec("/bin/bash", "-c", "pgrep -P " + new JavaSysMon().currentPid() + " | wc -l");
+        Thread buildingThread = new Thread(new Runnable() {
+            @Override
+            public void run() {
+                buildSession.build(compose(
+                        compose(execSleepScript(50),
+                                echo("after sleep"))
+                                .setOnCancel(printSubProcessCount)));
+            }
+        });
+
+        buildingThread.start();
+        waitUntilSubProcessExists(execSleepScriptProcessCommand());
+        assertTrue(buildInfo(), buildSession.cancel(30, TimeUnit.SECONDS));
+        waitUntilSubProcessNotExists(execSleepScriptProcessCommand());
+        assertThat(console.lastLine().trim(), is("1"));
+        buildingThread.join();
+    }
+
+
+    private void waitUntilSubProcessNotExists(final String processName) {
+        waitUntil(Timeout.FIVE_SECONDS, new Assertions.Predicate() {
+            @Override
+            public boolean call() throws Exception {
+                return !subProcessWithNameExists(processName);
+            }
+        }, 1);
+    }
+
+    private void waitUntilSubProcessExists(final String processName) {
+        waitUntil(Timeout.FIVE_SECONDS, new Assertions.Predicate() {
+            @Override
+            public boolean call() throws Exception {
+                return subProcessWithNameExists(processName);
+            }
+        }, 1);
+    }
+
+
+    private boolean subProcessWithNameExists(final String name) {
+        JavaSysMon javaSysMon = new JavaSysMon();
+        final boolean[] exists = {false};
+        javaSysMon.visitProcessTree(javaSysMon.currentPid(), new ProcessVisitor() {
+            @Override
+            public boolean visit(OsProcess osProcess, int i) {
+                String command = osProcess.processInfo().getName();
+                if (name.equals(command)) {
+                    exists[0] = true;
+                }
+                return false;
+            }
+        });
+        return exists[0];
+    }
+}

--- a/common/test/unit/com/thoughtworks/go/buildsession/BuildSessionTest.java
+++ b/common/test/unit/com/thoughtworks/go/buildsession/BuildSessionTest.java
@@ -15,40 +15,25 @@
  */
 package com.thoughtworks.go.buildsession;
 
-import com.googlecode.junit.ext.JunitExtRunner;
-import com.googlecode.junit.ext.RunIf;
-import com.thoughtworks.go.domain.BuildCommand;
-import com.thoughtworks.go.domain.JobResult;
-import com.thoughtworks.go.junitext.EnhancedOSChecker;
-import com.thoughtworks.go.util.*;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Paths;
-import java.util.*;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.concurrent.TimeUnit;
-import java.util.zip.Deflater;
 
 import static com.google.common.collect.Iterables.getLast;
 import static com.thoughtworks.go.domain.BuildCommand.*;
 import static com.thoughtworks.go.domain.JobResult.*;
 import static com.thoughtworks.go.domain.JobState.*;
-import static com.thoughtworks.go.junitext.EnhancedOSChecker.DO_NOT_RUN_ON;
-import static com.thoughtworks.go.junitext.EnhancedOSChecker.WINDOWS;
-import static com.thoughtworks.go.matchers.ConsoleOutMatcher.printedAppsMissingInfoOnUnix;
-import static com.thoughtworks.go.matchers.ConsoleOutMatcher.printedAppsMissingInfoOnWindows;
 import static com.thoughtworks.go.util.ExceptionUtils.bomb;
-import static com.thoughtworks.go.util.MapBuilder.map;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNot.not;
 import static org.junit.Assert.assertTrue;
 
-@RunWith(JunitExtRunner.class)
 public class BuildSessionTest extends BuildSessionBasedTestCase {
     @Test
     public void resolveRelativeDir() throws IOException {
@@ -86,83 +71,15 @@ public class BuildSessionTest extends BuildSessionBasedTestCase {
     }
 
     @Test
-    public void composeRunAllSubCommands() {
-        runBuild(compose(echo("hello"), echo("world")), Passed);
-        assertThat(console.asList(), is(Arrays.asList("hello", "world")));
-    }
-
-    @Test
-    public void execExecuteExternalCommandAndConnectOutputToBuildConsole() {
-        runBuild(exec("echo", "foo"), Passed);
-        assertThat(console.lastLine(), is("foo"));
-    }
-
-    @Test
-    public void execShouldFailIfWorkingDirectoryNotExists() {
-        runBuild(exec("echo", "should not show").setWorkingDirectory("not-exists"), Failed);
-        assertThat(console.asList().size(), is(1));
-        assertThat(console.firstLine(), containsString("not-exists\" is not a directory!"));
-    }
-
-    @Test
-    public void execUseSystemEnvironmentVariables() {
-        runBuild(execEchoEnv(pathSystemEnvName()), Passed);
-        assertThat(console.output(), is(System.getenv(pathSystemEnvName())));
-    }
-
-    @Test
-    public  void execUsePresetEnvs() {
-        BuildSession buildSession = newBuildSession();
-        buildSession.setEnv("GO_SERVER_URL", "https://far.far.away/go");
-        runBuild(buildSession, execEchoEnv("GO_SERVER_URL"), Passed);
-        assertThat(console.output(), is("https://far.far.away/go"));
-    }
-
-    @Test
-    public void execUseExportedEnv() throws IOException {
-        runBuild(compose(
-                export("foo", "bar", false),
-                execEchoEnv("foo")), Passed);
-        assertThat(console.lastLine(), is("bar"));
-    }
-
-    @Test
-    public void execUseExportedEnvWithOverriden() throws Exception {
-        runBuild(compose(
-                export("answer", "2", false),
-                export("answer", "42", false),
-                execEchoEnv("answer")), Passed);
-        assertThat(console.lastLine(), is("42"));
-    }
-
-
-    @Test
-    public void execUseOverriddenSystemEnvValue() throws Exception {
-        runBuild(compose(
-                export(pathSystemEnvName(), "/foo/bar", false),
-                execEchoEnv(pathSystemEnvName())), Passed);
-        assertThat(console.lastLine(), is("/foo/bar"));
-    }
-
-
-    @Test
-    @RunIf(value = EnhancedOSChecker.class, arguments = {DO_NOT_RUN_ON, WINDOWS})
-    public void execExecuteNotExistExternalCommandOnUnix() {
-        runBuild(exec("not-not-not-exist"), Failed);
-        assertThat(console.output(), printedAppsMissingInfoOnUnix("not-not-not-exist"));
-    }
-
-    @Test
-    @RunIf(value = EnhancedOSChecker.class, arguments = {EnhancedOSChecker.WINDOWS})
-    public void execExecuteNotExistExternalCommandOnWindows() {
-        runBuild(exec("not-not-not-exist"), Failed);
-        assertThat(console.output(), printedAppsMissingInfoOnWindows("not-not-not-exist"));
-    }
-
-    @Test
     public void forceBuildFailWithMessage() {
         runBuild(fail("force failure"), Failed);
         assertThat(console.output(), is("force failure"));
+    }
+
+    @Test
+    public void composeRunAllSubCommands() {
+        runBuild(compose(echo("hello"), echo("world")), Passed);
+        assertThat(console.asList(), is(Arrays.asList("hello", "world")));
     }
 
     @Test
@@ -191,92 +108,6 @@ public class BuildSessionTest extends BuildSessionBasedTestCase {
         assertThat(console.asList(), is(Arrays.asList("foo", "on passing", "force failure", "on failure")));
     }
 
-    @Test
-    public void mkdirsShouldCreateDirectoryIfNotExists() {
-        runBuild(mkdirs("foo"), Passed);
-        assertThat(new File(sandbox, "foo").isDirectory(), is(true));
-    }
-
-    @Test
-    public void mkdirsShouldFailIfDirExists() {
-        runBuild(mkdirs("foo"), Passed);
-        runBuild(mkdirs("foo"), Failed);
-        assertThat(new File(sandbox, "foo").isDirectory(), is(true));
-    }
-
-    @Test
-    public void testDirectoryExistsBeforeMkdir() {
-        File dir = new File(sandbox, "foo");
-        runBuild(mkdirs("foo"), Passed);
-        runBuild(mkdirs("foo").setTest(test("-nd", dir.getPath())), Passed);
-        assertThat(new File(sandbox, "foo").isDirectory(), is(true));
-    }
-
-    @Test
-    public void mkdirWithWorkingDir() {
-        runBuild(mkdirs("foo").setWorkingDirectory("bar"), Passed);
-        assertThat(new File(sandbox, "bar/foo").isDirectory(), is(true));
-        assertThat(new File(sandbox, "foo").isDirectory(), is(false));
-    }
-
-    @Test
-    public void shouldNotFailBuildWhenTestCommandFail() {
-        runBuild(echo("foo").setTest(fail("")), Passed);
-        assertThat(statusReporter.singleResult(), is(Passed));
-    }
-
-    @Test
-    public void shouldNotFailBuildWhenComposedTestCommandFail() {
-        runBuild(echo("foo").setTest(compose(echo(""), fail(""))), Passed);
-        assertThat(statusReporter.singleResult(), is(JobResult.Passed));
-    }
-
-    @Test
-    public void shouldNotFailBuildWhenTestEqWithComposedCommandOutputFail() {
-        runBuild(echo("foo").setTest(test("-eq", "42", compose(fail("42")))), Passed);
-        assertThat(statusReporter.singleResult(), is(Passed));
-        assertThat(console.output(), containsString("foo"));
-    }
-
-    @Test
-    public void cleanDirWithoutAllows() throws IOException {
-        runBuild(mkdirs("foo/baz"), Passed);
-        assertTrue(new File(sandbox, "foo/file1").createNewFile());
-        assertTrue(new File(sandbox, "file2").createNewFile());
-
-        runBuild(cleandir(""), Passed);
-        assertThat(sandbox.exists(), is(true));
-        assertThat(sandbox.listFiles().length, is(0));
-    }
-
-    @Test
-    public void cleanDirWithAllows() throws IOException {
-        runBuild(mkdirs("bar/foo/baz"), Passed);
-        runBuild(mkdirs("bar/foo2"), Passed);
-        assertTrue(new File(sandbox, "bar/foo/file1").createNewFile());
-        assertTrue(new File(sandbox, "bar/file2").createNewFile());
-        assertTrue(new File(sandbox, "file3").createNewFile());
-
-        runBuild(cleandir("bar", "file2", "foo2"), Passed);
-        assertThat(new File(sandbox, "bar").isDirectory(), is(true));
-        assertThat(new File(sandbox, "file3").exists(), is(true));
-        assertThat(new File(sandbox, "bar").listFiles(), is(new File[]{new File(sandbox, "bar/file2"), new File(sandbox, "bar/foo2")}));
-    }
-
-    @Test
-    public void cleanDirWithAllowsAndWorkingDir() throws IOException {
-        runBuild(mkdirs("bar/foo/baz"), Passed);
-        runBuild(mkdirs("bar/foo2"), Passed);
-        assertTrue(new File(sandbox, "bar/foo/file1").createNewFile());
-        assertTrue(new File(sandbox, "bar/file2").createNewFile());
-        assertTrue(new File(sandbox, "file3").createNewFile());
-
-        runBuild(cleandir("", "file2", "foo2").setWorkingDirectory("bar"), Passed);
-        assertThat(new File(sandbox, "bar").isDirectory(), is(true));
-        assertThat(new File(sandbox, "file3").exists(), is(true));
-        assertThat(new File(sandbox, "bar").listFiles(), is(new File[]{new File(sandbox, "bar/file2"), new File(sandbox, "bar/foo2")}));
-    }
-
 
     @Test
     public void echoWithBuildVariableSubstitution() {
@@ -285,118 +116,6 @@ public class BuildSessionTest extends BuildSessionBasedTestCase {
         buildVariables.put("test.foo", "world");
         runBuild(echo("hello ${test.foo}"), Passed);
         assertThat(console.lastLine(), is("hello world"));
-    }
-
-    @Test
-    public void testDirExists() throws IOException {
-        runBuild(test("-d", ""), Passed);
-        runBuild(test("-d", "dir"), Failed);
-        runBuild(test("-d", "file"), Failed);
-        assertTrue(new File(sandbox, "file").createNewFile());
-        assertTrue(new File(sandbox, "dir").mkdir());
-        runBuild(test("-d", "file"), Failed);
-        runBuild(test("-d", "dir"), Passed);
-    }
-
-    @Test
-    public void testDirNotExists() throws IOException {
-        runBuild(test("-nd", ""), Failed);
-        runBuild(test("-nd", "dir"), Passed);
-        runBuild(test("-nd", "file"), Passed);
-        assertTrue(new File(sandbox, "file").createNewFile());
-        assertTrue(new File(sandbox, "dir").mkdir());
-        runBuild(test("-nd", "file"), Passed);
-        runBuild(test("-nd", "dir"), Failed);
-    }
-
-    @Test
-    public void testFileExists() throws IOException {
-        runBuild(test("-f", ""), Failed);
-        runBuild(test("-f", "file"), Failed);
-        File file = new File(sandbox, "file");
-        assertTrue(file.createNewFile());
-        runBuild(test("-f", "file"), Passed);
-    }
-
-    @Test
-    public void testFileNotExists() throws IOException {
-        runBuild(test("-nf", ""), Passed);
-        runBuild(test("-nf", "file"), Passed);
-        File file = new File(sandbox, "file");
-        assertTrue(file.createNewFile());
-        runBuild(test("-nf", "file"), Failed);
-    }
-
-    @Test
-    public void testEqWithCommandOutput() throws IOException {
-        runBuild(test("-eq", "foo", echo("foo")), Passed);
-        runBuild(test("-eq", "bar", echo("foo")), Failed);
-        assertThat(console.lineCount(), is(0));
-    }
-
-    @Test
-    public void testNotEqWithCommandOutput() throws IOException {
-        runBuild(test("-neq", "foo", echo("foo")), Failed);
-        runBuild(test("-neq", "bar", echo("foo")), Passed);
-        assertThat(console.lineCount(), is(0));
-    }
-
-    @Test
-    public void exportEnvironmentVariableHasMeaningfulOutput() throws Exception {
-        runBuild(compose(
-                export("answer", "2", false),
-                export("answer", "42", false)), Passed);
-        assertThat(console.asList().get(0), is("[go] setting environment variable 'answer' to value '2'"));
-        assertThat(console.asList().get(1), is("[go] overriding environment variable 'answer' with value '42'"));
-    }
-
-    @Test
-    public void exportOutputWhenOverridingSystemEnv() throws Exception {
-        String envName = pathSystemEnvName();
-        runBuild(export(envName, "/foo/bar", false), Passed);
-        assertThat(console.output(), is(String.format("[go] overriding environment variable '%s' with value '/foo/bar'", envName)));
-    }
-
-    @Test
-    public void exportSecretEnvShouldMaskValue() throws Exception {
-        runBuild(export("answer", "42", true), Passed);
-        assertThat(console.output(), is("[go] setting environment variable 'answer' to value '********'"));
-    }
-
-    @Test
-    public void exportWithoutValueDisplayCurrentValue() throws Exception {
-        runBuild(export("foo"), Passed);
-        assertThat(console.lastLine(), is("[go] setting environment variable 'foo' to value 'null'"));
-        runBuild(compose(
-                export("foo", "bar", false),
-                export("foo")), Passed);
-        assertThat(console.lastLine(), is("[go] setting environment variable 'foo' to value 'bar'"));
-    }
-
-    @Test
-    public void secretMaskValuesInExecOutput() throws Exception {
-        runBuild(compose(
-                secret("42"),
-                exec("echo", "the answer is 42")), Passed);
-        assertThat(console.output(), containsString("the answer is ******"));
-    }
-
-    @Test
-    public void secretMaskValuesInExportOutput() throws Exception {
-        runBuild(compose(
-                secret("42"),
-                export("oracle", "the answer is 42", false)), Passed);
-        assertThat(console.output(), is("[go] setting environment variable 'oracle' to value 'the answer is ******'"));
-    }
-
-    @Test
-    public void addSecretWithSubstitution() throws  Exception {
-        runBuild(compose(
-                secret("foo:bar@ssss.com", "foo:******@ssss.com"),
-                exec("echo", "connecting to foo:bar@ssss.com"),
-                exec("echo", "connecting to foo:bar@tttt.com")), Passed);
-        assertThat(console.firstLine(), containsString("connecting to foo:******@ssss.com"));
-        assertThat(console.asList().get(1), containsString("connecting to foo:bar@tttt.com"));
     }
 
     @Test
@@ -476,7 +195,6 @@ public class BuildSessionTest extends BuildSessionBasedTestCase {
         } finally {
             buildingThread.join();
         }
-
     }
 
     @Test
@@ -507,96 +225,4 @@ public class BuildSessionTest extends BuildSessionBasedTestCase {
             buildingThread.join();
         }
     }
-
-    @Test
-    public void downloadFilePrintErrorWhenFailed() {
-        runBuild(downloadFile(map(
-                "url", "http://far.far.away/foo.jar",
-                "dest", new File(sandbox, "bar.jar").getPath())), Failed);
-        assertThat(console.output(), containsString("Could not fetch artifact"));
-    }
-
-    @Test
-    public void downloadFileWithoutMD5Check() throws IOException {
-        File dest = new File(sandbox, "bar.jar");
-        httpService.setupDownload("http://far.far.away/foo.jar", "some content");
-        runBuild(downloadFile(map(
-                "url", "http://far.far.away/foo.jar",
-                "dest", "bar.jar")), Passed);
-        assertThat(console.output(), containsString("without verifying the integrity"));
-        assertThat(FileUtil.readContentFromFile(dest), is("some content"));
-    }
-
-    @Test
-    public void downloadFileWithMD5Check() throws IOException {
-        httpService.setupDownload("http://far.far.away/foo.jar", "some content");
-        httpService.setupDownload("http://far.far.away/foo.jar.md5", "foo.jar=9893532233caff98cd083a116b013c0b");
-        runBuild(downloadFile(map(
-                "url", "http://far.far.away/foo.jar",
-                "dest", "dest.jar",
-                "src", "foo.jar",
-                "checksumUrl", "http://far.far.away/foo.jar.md5")), Passed);
-        assertThat(console.output(), containsString(String.format("Saved artifact to [%s] after verifying the integrity of its contents", new File(sandbox, "dest.jar").getPath())));
-        assertThat(FileUtil.readContentFromFile(new File(sandbox, "dest.jar")), is("some content"));
-    }
-
-    @Test
-    public void downloadFileShouldAppendSha1IntoDownloadUrlIfDestFileAlreadyExists() throws IOException {
-        File dest = new File(sandbox, "bar.jar");
-        Files.write(Paths.get(dest.getPath()), "foobar".getBytes());
-        String sha1 = java.net.URLEncoder.encode(StringUtil.sha1Digest(dest), "UTF-8");
-
-        httpService.setupDownload("http://far.far.away/foo.jar", "content without sha1");
-        httpService.setupDownload("http://far.far.away/foo.jar?sha1=" + sha1, "content with sha1");
-        runBuild(downloadFile(map(
-                "url", "http://far.far.away/foo.jar",
-                "dest", "bar.jar")), Passed);
-        assertThat(console.output(), containsString("Saved artifact"));
-        assertThat(FileUtil.readContentFromFile(dest), is("content with sha1"));
-    }
-
-    @Test
-    public void downloadDirWithChecksum() throws Exception {
-        File folder = TestFileUtil.createTempFolder("log");
-        Files.write(Paths.get(folder.getPath(), "a"), "content for a".getBytes());
-        Files.write(Paths.get(folder.getPath(), "b"), "content for b".getBytes());
-
-
-        File zip = new ZipUtil().zip(folder, TestFileUtil.createUniqueTempFile(folder.getName()), Deflater.NO_COMPRESSION);
-
-        httpService.setupDownload("http://far.far.away/log.zip", zip);
-        httpService.setupDownload("http://far.far.away/log.zip.md5", "s/log/a=524ebd45bd7de3616317127f6e639bd6\ns/log/b=83c0aa3048df233340203c74e8a93d7d");
-
-        runBuild(downloadDir(map(
-                "url", "http://far.far.away/log.zip",
-                "dest", "dest",
-                "src", "s/log",
-                "checksumUrl", "http://far.far.away/log.zip.md5")), Passed);
-        File dest = new File(sandbox, "dest");
-
-        assertThat(console.output(), containsString(String.format("Saved artifact to [%s] after verifying the integrity of its contents", dest.getPath())));
-        assertThat(FileUtil.readContentFromFile(new File(dest, "log/a")), is("content for a"));
-        assertThat(FileUtil.readContentFromFile(new File(dest, "log/b")), is("content for b"));
-    }
-
-    private BuildCommand execEchoEnv(final String envname) {
-        if (SystemUtil.isWindows()) {
-            return exec("echo", "%" + envname + "%");
-        } else {
-            return exec("/bin/sh", "-c", String.format("echo ${%s}", envname));
-        }
-    }
-
-    public static BuildCommand execSleepScript(int seconds) {
-        if (SystemUtil.isWindows()) {
-            return exec("cmd", "/c", "echo start sleeping & ping 1.1.1.1 -n 1 -w " + seconds * 1000 + " >NULL & echo after sleep");
-        } else {
-            return exec("/bin/sh", "-c", "echo start sleeping;sleep " + seconds + ";echo after sleep");
-        }
-    }
-
-    private String pathSystemEnvName() {
-        return SystemUtil.isWindows() ? "Path" : "PATH";
-    }
-
 }

--- a/common/test/unit/com/thoughtworks/go/buildsession/BuildSessionTest.java
+++ b/common/test/unit/com/thoughtworks/go/buildsession/BuildSessionTest.java
@@ -1,0 +1,602 @@
+/*
+ * Copyright 2016 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.thoughtworks.go.buildsession;
+
+import com.googlecode.junit.ext.JunitExtRunner;
+import com.googlecode.junit.ext.RunIf;
+import com.thoughtworks.go.domain.BuildCommand;
+import com.thoughtworks.go.domain.JobResult;
+import com.thoughtworks.go.junitext.EnhancedOSChecker;
+import com.thoughtworks.go.util.*;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.*;
+import java.util.concurrent.TimeUnit;
+import java.util.zip.Deflater;
+
+import static com.google.common.collect.Iterables.getLast;
+import static com.thoughtworks.go.domain.BuildCommand.*;
+import static com.thoughtworks.go.domain.JobResult.*;
+import static com.thoughtworks.go.domain.JobState.*;
+import static com.thoughtworks.go.junitext.EnhancedOSChecker.DO_NOT_RUN_ON;
+import static com.thoughtworks.go.junitext.EnhancedOSChecker.WINDOWS;
+import static com.thoughtworks.go.matchers.ConsoleOutMatcher.printedAppsMissingInfoOnUnix;
+import static com.thoughtworks.go.matchers.ConsoleOutMatcher.printedAppsMissingInfoOnWindows;
+import static com.thoughtworks.go.util.ExceptionUtils.bomb;
+import static com.thoughtworks.go.util.MapBuilder.map;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsNot.not;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(JunitExtRunner.class)
+public class BuildSessionTest extends BuildSessionBasedTestCase {
+    @Test
+    public void resolveRelativeDir() throws IOException {
+        BuildSession buildSession = newBuildSession();
+        assertThat(buildSession.resolveRelativeDir("foo"), is(new File(sandbox, "foo")));
+        assertThat(buildSession.resolveRelativeDir("foo", "bar"), is(new File(sandbox, "foo/bar")));
+        assertThat(buildSession.resolveRelativeDir("", "bar"), is(new File(sandbox, "bar")));
+    }
+
+    @Test
+    public void echoCommandAppendContentToConsole() {
+        runBuild(echo("o1o2"), Passed);
+        assertThat(console.asList(), is(Collections.singletonList("o1o2")));
+    }
+
+    @Test
+    public void testReportCurrentStatus() {
+        runBuild(compose(
+                reportCurrentStatus(Preparing),
+                reportCurrentStatus(Building),
+                reportCurrentStatus(Completing)), Passed);
+        assertThat(statusReporter.status(), is(Arrays.asList(Preparing, Building, Completing, Completed)));
+    }
+
+    @Test
+    public void testReportCompleting() {
+        runBuild(reportCompleting(), Passed);
+        assertThat(statusReporter.results(), is(Arrays.asList(Passed, Passed)));
+    }
+
+    @Test
+    public void resultShouldBeFailedWhenCommandFailed() {
+        runBuild(fail("force build failure"), Failed);
+        assertThat(statusReporter.singleResult(), is(Failed));
+    }
+
+    @Test
+    public void composeRunAllSubCommands() {
+        runBuild(compose(echo("hello"), echo("world")), Passed);
+        assertThat(console.asList(), is(Arrays.asList("hello", "world")));
+    }
+
+    @Test
+    public void execExecuteExternalCommandAndConnectOutputToBuildConsole() {
+        runBuild(exec("echo", "foo"), Passed);
+        assertThat(console.lastLine(), is("foo"));
+    }
+
+    @Test
+    public void execShouldFailIfWorkingDirectoryNotExists() {
+        runBuild(exec("echo", "should not show").setWorkingDirectory("not-exists"), Failed);
+        assertThat(console.asList().size(), is(1));
+        assertThat(console.firstLine(), containsString("not-exists\" is not a directory!"));
+    }
+
+    @Test
+    public void execUseSystemEnvironmentVariables() {
+        runBuild(execEchoEnv(pathSystemEnvName()), Passed);
+        assertThat(console.output(), is(System.getenv(pathSystemEnvName())));
+    }
+
+    @Test
+    public  void execUsePresetEnvs() {
+        BuildSession buildSession = newBuildSession();
+        buildSession.setEnv("GO_SERVER_URL", "https://far.far.away/go");
+        runBuild(buildSession, execEchoEnv("GO_SERVER_URL"), Passed);
+        assertThat(console.output(), is("https://far.far.away/go"));
+    }
+
+    @Test
+    public void execUseExportedEnv() throws IOException {
+        runBuild(compose(
+                export("foo", "bar", false),
+                execEchoEnv("foo")), Passed);
+        assertThat(console.lastLine(), is("bar"));
+    }
+
+    @Test
+    public void execUseExportedEnvWithOverriden() throws Exception {
+        runBuild(compose(
+                export("answer", "2", false),
+                export("answer", "42", false),
+                execEchoEnv("answer")), Passed);
+        assertThat(console.lastLine(), is("42"));
+    }
+
+
+    @Test
+    public void execUseOverriddenSystemEnvValue() throws Exception {
+        runBuild(compose(
+                export(pathSystemEnvName(), "/foo/bar", false),
+                execEchoEnv(pathSystemEnvName())), Passed);
+        assertThat(console.lastLine(), is("/foo/bar"));
+    }
+
+
+    @Test
+    @RunIf(value = EnhancedOSChecker.class, arguments = {DO_NOT_RUN_ON, WINDOWS})
+    public void execExecuteNotExistExternalCommandOnUnix() {
+        runBuild(exec("not-not-not-exist"), Failed);
+        assertThat(console.output(), printedAppsMissingInfoOnUnix("not-not-not-exist"));
+    }
+
+    @Test
+    @RunIf(value = EnhancedOSChecker.class, arguments = {EnhancedOSChecker.WINDOWS})
+    public void execExecuteNotExistExternalCommandOnWindows() {
+        runBuild(exec("not-not-not-exist"), Failed);
+        assertThat(console.output(), printedAppsMissingInfoOnWindows("not-not-not-exist"));
+    }
+
+    @Test
+    public void forceBuildFailWithMessage() {
+        runBuild(fail("force failure"), Failed);
+        assertThat(console.output(), is("force failure"));
+    }
+
+    @Test
+    public void shouldNotRunCommandWithRunIfFailedIfBuildIsPassing() {
+        runBuild(compose(
+                echo("on pass"),
+                echo("on failure").runIf("failed")), Passed);
+        assertThat(console.asList(), is(Collections.singletonList("on pass")));
+    }
+
+    @Test
+    public void shouldRunCommandWithRunIfFailedIfBuildIsFailed() {
+        runBuild(compose(
+                fail("force failure"),
+                echo("on failure").runIf("failed")), Failed);
+        assertThat(console.lastLine(), is("on failure"));
+    }
+
+    @Test
+    public void shouldRunCommandWithRunIfAnyRegardlessOfBuildResult() {
+        runBuild(compose(
+                echo("foo"),
+                echo("on passing").runIf("any"),
+                fail("force failure"),
+                echo("on failure").runIf("any")), Failed);
+        assertThat(console.asList(), is(Arrays.asList("foo", "on passing", "force failure", "on failure")));
+    }
+
+    @Test
+    public void mkdirsShouldCreateDirectoryIfNotExists() {
+        runBuild(mkdirs("foo"), Passed);
+        assertThat(new File(sandbox, "foo").isDirectory(), is(true));
+    }
+
+    @Test
+    public void mkdirsShouldFailIfDirExists() {
+        runBuild(mkdirs("foo"), Passed);
+        runBuild(mkdirs("foo"), Failed);
+        assertThat(new File(sandbox, "foo").isDirectory(), is(true));
+    }
+
+    @Test
+    public void testDirectoryExistsBeforeMkdir() {
+        File dir = new File(sandbox, "foo");
+        runBuild(mkdirs("foo"), Passed);
+        runBuild(mkdirs("foo").setTest(test("-nd", dir.getPath())), Passed);
+        assertThat(new File(sandbox, "foo").isDirectory(), is(true));
+    }
+
+    @Test
+    public void mkdirWithWorkingDir() {
+        runBuild(mkdirs("foo").setWorkingDirectory("bar"), Passed);
+        assertThat(new File(sandbox, "bar/foo").isDirectory(), is(true));
+        assertThat(new File(sandbox, "foo").isDirectory(), is(false));
+    }
+
+    @Test
+    public void shouldNotFailBuildWhenTestCommandFail() {
+        runBuild(echo("foo").setTest(fail("")), Passed);
+        assertThat(statusReporter.singleResult(), is(Passed));
+    }
+
+    @Test
+    public void shouldNotFailBuildWhenComposedTestCommandFail() {
+        runBuild(echo("foo").setTest(compose(echo(""), fail(""))), Passed);
+        assertThat(statusReporter.singleResult(), is(JobResult.Passed));
+    }
+
+    @Test
+    public void shouldNotFailBuildWhenTestEqWithComposedCommandOutputFail() {
+        runBuild(echo("foo").setTest(test("-eq", "42", compose(fail("42")))), Passed);
+        assertThat(statusReporter.singleResult(), is(Passed));
+        assertThat(console.output(), containsString("foo"));
+    }
+
+    @Test
+    public void cleanDirWithoutAllows() throws IOException {
+        runBuild(mkdirs("foo/baz"), Passed);
+        assertTrue(new File(sandbox, "foo/file1").createNewFile());
+        assertTrue(new File(sandbox, "file2").createNewFile());
+
+        runBuild(cleandir(""), Passed);
+        assertThat(sandbox.exists(), is(true));
+        assertThat(sandbox.listFiles().length, is(0));
+    }
+
+    @Test
+    public void cleanDirWithAllows() throws IOException {
+        runBuild(mkdirs("bar/foo/baz"), Passed);
+        runBuild(mkdirs("bar/foo2"), Passed);
+        assertTrue(new File(sandbox, "bar/foo/file1").createNewFile());
+        assertTrue(new File(sandbox, "bar/file2").createNewFile());
+        assertTrue(new File(sandbox, "file3").createNewFile());
+
+        runBuild(cleandir("bar", "file2", "foo2"), Passed);
+        assertThat(new File(sandbox, "bar").isDirectory(), is(true));
+        assertThat(new File(sandbox, "file3").exists(), is(true));
+        assertThat(new File(sandbox, "bar").listFiles(), is(new File[]{new File(sandbox, "bar/file2"), new File(sandbox, "bar/foo2")}));
+    }
+
+    @Test
+    public void cleanDirWithAllowsAndWorkingDir() throws IOException {
+        runBuild(mkdirs("bar/foo/baz"), Passed);
+        runBuild(mkdirs("bar/foo2"), Passed);
+        assertTrue(new File(sandbox, "bar/foo/file1").createNewFile());
+        assertTrue(new File(sandbox, "bar/file2").createNewFile());
+        assertTrue(new File(sandbox, "file3").createNewFile());
+
+        runBuild(cleandir("", "file2", "foo2").setWorkingDirectory("bar"), Passed);
+        assertThat(new File(sandbox, "bar").isDirectory(), is(true));
+        assertThat(new File(sandbox, "file3").exists(), is(true));
+        assertThat(new File(sandbox, "bar").listFiles(), is(new File[]{new File(sandbox, "bar/file2"), new File(sandbox, "bar/foo2")}));
+    }
+
+
+    @Test
+    public void echoWithBuildVariableSubstitution() {
+        runBuild(echo("hello ${test.foo}"), Passed);
+        assertThat(console.lastLine(), is("hello ${test.foo}"));
+        buildVariables.put("test.foo", "world");
+        runBuild(echo("hello ${test.foo}"), Passed);
+        assertThat(console.lastLine(), is("hello world"));
+    }
+
+    @Test
+    public void testDirExists() throws IOException {
+        runBuild(test("-d", ""), Passed);
+        runBuild(test("-d", "dir"), Failed);
+        runBuild(test("-d", "file"), Failed);
+        assertTrue(new File(sandbox, "file").createNewFile());
+        assertTrue(new File(sandbox, "dir").mkdir());
+        runBuild(test("-d", "file"), Failed);
+        runBuild(test("-d", "dir"), Passed);
+    }
+
+    @Test
+    public void testDirNotExists() throws IOException {
+        runBuild(test("-nd", ""), Failed);
+        runBuild(test("-nd", "dir"), Passed);
+        runBuild(test("-nd", "file"), Passed);
+        assertTrue(new File(sandbox, "file").createNewFile());
+        assertTrue(new File(sandbox, "dir").mkdir());
+        runBuild(test("-nd", "file"), Passed);
+        runBuild(test("-nd", "dir"), Failed);
+    }
+
+    @Test
+    public void testFileExists() throws IOException {
+        runBuild(test("-f", ""), Failed);
+        runBuild(test("-f", "file"), Failed);
+        File file = new File(sandbox, "file");
+        assertTrue(file.createNewFile());
+        runBuild(test("-f", "file"), Passed);
+    }
+
+    @Test
+    public void testFileNotExists() throws IOException {
+        runBuild(test("-nf", ""), Passed);
+        runBuild(test("-nf", "file"), Passed);
+        File file = new File(sandbox, "file");
+        assertTrue(file.createNewFile());
+        runBuild(test("-nf", "file"), Failed);
+    }
+
+    @Test
+    public void testEqWithCommandOutput() throws IOException {
+        runBuild(test("-eq", "foo", echo("foo")), Passed);
+        runBuild(test("-eq", "bar", echo("foo")), Failed);
+        assertThat(console.lineCount(), is(0));
+    }
+
+    @Test
+    public void testNotEqWithCommandOutput() throws IOException {
+        runBuild(test("-neq", "foo", echo("foo")), Failed);
+        runBuild(test("-neq", "bar", echo("foo")), Passed);
+        assertThat(console.lineCount(), is(0));
+    }
+
+    @Test
+    public void exportEnvironmentVariableHasMeaningfulOutput() throws Exception {
+        runBuild(compose(
+                export("answer", "2", false),
+                export("answer", "42", false)), Passed);
+        assertThat(console.asList().get(0), is("[go] setting environment variable 'answer' to value '2'"));
+        assertThat(console.asList().get(1), is("[go] overriding environment variable 'answer' with value '42'"));
+    }
+
+    @Test
+    public void exportOutputWhenOverridingSystemEnv() throws Exception {
+        String envName = pathSystemEnvName();
+        runBuild(export(envName, "/foo/bar", false), Passed);
+        assertThat(console.output(), is(String.format("[go] overriding environment variable '%s' with value '/foo/bar'", envName)));
+    }
+
+    @Test
+    public void exportSecretEnvShouldMaskValue() throws Exception {
+        runBuild(export("answer", "42", true), Passed);
+        assertThat(console.output(), is("[go] setting environment variable 'answer' to value '********'"));
+    }
+
+    @Test
+    public void exportWithoutValueDisplayCurrentValue() throws Exception {
+        runBuild(export("foo"), Passed);
+        assertThat(console.lastLine(), is("[go] setting environment variable 'foo' to value 'null'"));
+        runBuild(compose(
+                export("foo", "bar", false),
+                export("foo")), Passed);
+        assertThat(console.lastLine(), is("[go] setting environment variable 'foo' to value 'bar'"));
+    }
+
+    @Test
+    public void secretMaskValuesInExecOutput() throws Exception {
+        runBuild(compose(
+                secret("42"),
+                exec("echo", "the answer is 42")), Passed);
+        assertThat(console.output(), containsString("the answer is ******"));
+    }
+
+    @Test
+    public void secretMaskValuesInExportOutput() throws Exception {
+        runBuild(compose(
+                secret("42"),
+                export("oracle", "the answer is 42", false)), Passed);
+        assertThat(console.output(), is("[go] setting environment variable 'oracle' to value 'the answer is ******'"));
+    }
+
+    @Test
+    public void addSecretWithSubstitution() throws  Exception {
+        runBuild(compose(
+                secret("foo:bar@ssss.com", "foo:******@ssss.com"),
+                exec("echo", "connecting to foo:bar@ssss.com"),
+                exec("echo", "connecting to foo:bar@tttt.com")), Passed);
+        assertThat(console.firstLine(), containsString("connecting to foo:******@ssss.com"));
+        assertThat(console.asList().get(1), containsString("connecting to foo:bar@tttt.com"));
+    }
+
+    @Test
+    public void cancelLongRunningBuild() throws InterruptedException {
+        final BuildSession buildSession = newBuildSession();
+        Thread buildingThread = new Thread(new Runnable() {
+            @Override
+            public void run() {
+                buildSession.build(compose(
+                        execSleepScript(50),
+                        echo("build done")));
+            }
+        });
+        try {
+            buildingThread.start();
+            console.waitForContain("start sleeping", 5);
+            assertTrue(buildInfo(), buildSession.cancel(30, TimeUnit.SECONDS));
+            assertThat(buildInfo(), getLast(statusReporter.results()), is(Cancelled));
+            assertThat(buildInfo(), console.output(), not(containsString("build done")));
+        } finally {
+            buildingThread.join();
+        }
+    }
+
+    @Test
+    public void cancelLongRunningTestCommand() throws InterruptedException {
+        final BuildSession buildSession = newBuildSession();
+        Thread buildingThread = new Thread(new Runnable() {
+            @Override
+            public void run() {
+                buildSession.build(compose(
+                        echo("after sleep").setTest(execSleepScript(50))));
+            }
+        });
+        try {
+            buildingThread.start();
+            console.waitForContain("start sleeping", 5);
+            assertTrue(buildInfo(), buildSession.cancel(30, TimeUnit.SECONDS));
+            assertThat(buildInfo(), getLast(statusReporter.results()), is(Cancelled));
+            assertThat(buildInfo(), console.output(), not(containsString("after sleep")));
+        } finally {
+            buildingThread.join();
+        }
+    }
+
+    @Test
+    public void doubleCancelDoNothing() throws InterruptedException {
+        final BuildSession buildSession = newBuildSession();
+        Thread buildingThread = new Thread(new Runnable() {
+            @Override
+            public void run() {
+                buildSession.build(execSleepScript(50));
+            }
+        });
+        Runnable cancel = new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    buildSession.cancel(30, TimeUnit.SECONDS);
+                } catch (InterruptedException e) {
+                    throw bomb(e);
+                }
+            }
+        };
+        Thread cancelThread1 = new Thread(cancel);
+        Thread cancelThread2 = new Thread(cancel);
+
+        try {
+            buildingThread.start();
+            console.waitForContain("start sleeping", 5);
+            cancelThread1.start();
+            cancelThread2.start();
+            cancelThread1.join();
+            cancelThread2.join();
+            assertThat(buildInfo(), getLast(statusReporter.results()), is(Cancelled));
+            assertThat(buildInfo(), console.output(), not(containsString("after sleep")));
+        } finally {
+            buildingThread.join();
+        }
+
+    }
+
+    @Test
+    public void cancelShouldProcessOnCancelCommandOfCommandThatIsRunning() throws InterruptedException {
+        final BuildSession buildSession = newBuildSession();
+        Thread buildingThread = new Thread(new Runnable() {
+            @Override
+            public void run() {
+                buildSession.build(compose(
+                        compose(
+                            execSleepScript(50).setOnCancel(echo("exec canceled")),
+                            echo("after sleep"))
+                                .setOnCancel(echo("inner oncancel"))
+                ).setOnCancel(echo("outter oncancel")));
+            }
+        });
+
+        try {
+            buildingThread.start();
+            console.waitForContain("start sleeping", 5);
+            assertTrue(buildInfo(), buildSession.cancel(30, TimeUnit.SECONDS));
+            assertThat(buildInfo(), getLast(statusReporter.results()), is(Cancelled));
+            assertThat(buildInfo(), console.output(), not(containsString("after sleep")));
+            assertThat(buildInfo(), console.output(), containsString("exec canceled"));
+            assertThat(buildInfo(), console.output(), containsString("inner oncancel"));
+            assertThat(buildInfo(), console.output(), containsString("outter oncancel"));
+        } finally {
+            buildingThread.join();
+        }
+    }
+
+    @Test
+    public void downloadFilePrintErrorWhenFailed() {
+        runBuild(downloadFile(map(
+                "url", "http://far.far.away/foo.jar",
+                "dest", new File(sandbox, "bar.jar").getPath())), Failed);
+        assertThat(console.output(), containsString("Could not fetch artifact"));
+    }
+
+    @Test
+    public void downloadFileWithoutMD5Check() throws IOException {
+        File dest = new File(sandbox, "bar.jar");
+        httpService.setupDownload("http://far.far.away/foo.jar", "some content");
+        runBuild(downloadFile(map(
+                "url", "http://far.far.away/foo.jar",
+                "dest", "bar.jar")), Passed);
+        assertThat(console.output(), containsString("without verifying the integrity"));
+        assertThat(FileUtil.readContentFromFile(dest), is("some content"));
+    }
+
+    @Test
+    public void downloadFileWithMD5Check() throws IOException {
+        httpService.setupDownload("http://far.far.away/foo.jar", "some content");
+        httpService.setupDownload("http://far.far.away/foo.jar.md5", "foo.jar=9893532233caff98cd083a116b013c0b");
+        runBuild(downloadFile(map(
+                "url", "http://far.far.away/foo.jar",
+                "dest", "dest.jar",
+                "src", "foo.jar",
+                "checksumUrl", "http://far.far.away/foo.jar.md5")), Passed);
+        assertThat(console.output(), containsString(String.format("Saved artifact to [%s] after verifying the integrity of its contents", new File(sandbox, "dest.jar").getPath())));
+        assertThat(FileUtil.readContentFromFile(new File(sandbox, "dest.jar")), is("some content"));
+    }
+
+    @Test
+    public void downloadFileShouldAppendSha1IntoDownloadUrlIfDestFileAlreadyExists() throws IOException {
+        File dest = new File(sandbox, "bar.jar");
+        Files.write(Paths.get(dest.getPath()), "foobar".getBytes());
+        String sha1 = java.net.URLEncoder.encode(StringUtil.sha1Digest(dest), "UTF-8");
+
+        httpService.setupDownload("http://far.far.away/foo.jar", "content without sha1");
+        httpService.setupDownload("http://far.far.away/foo.jar?sha1=" + sha1, "content with sha1");
+        runBuild(downloadFile(map(
+                "url", "http://far.far.away/foo.jar",
+                "dest", "bar.jar")), Passed);
+        assertThat(console.output(), containsString("Saved artifact"));
+        assertThat(FileUtil.readContentFromFile(dest), is("content with sha1"));
+    }
+
+    @Test
+    public void downloadDirWithChecksum() throws Exception {
+        File folder = TestFileUtil.createTempFolder("log");
+        Files.write(Paths.get(folder.getPath(), "a"), "content for a".getBytes());
+        Files.write(Paths.get(folder.getPath(), "b"), "content for b".getBytes());
+
+
+        File zip = new ZipUtil().zip(folder, TestFileUtil.createUniqueTempFile(folder.getName()), Deflater.NO_COMPRESSION);
+
+        httpService.setupDownload("http://far.far.away/log.zip", zip);
+        httpService.setupDownload("http://far.far.away/log.zip.md5", "s/log/a=524ebd45bd7de3616317127f6e639bd6\ns/log/b=83c0aa3048df233340203c74e8a93d7d");
+
+        runBuild(downloadDir(map(
+                "url", "http://far.far.away/log.zip",
+                "dest", "dest",
+                "src", "s/log",
+                "checksumUrl", "http://far.far.away/log.zip.md5")), Passed);
+        File dest = new File(sandbox, "dest");
+
+        assertThat(console.output(), containsString(String.format("Saved artifact to [%s] after verifying the integrity of its contents", dest.getPath())));
+        assertThat(FileUtil.readContentFromFile(new File(dest, "log/a")), is("content for a"));
+        assertThat(FileUtil.readContentFromFile(new File(dest, "log/b")), is("content for b"));
+    }
+
+    private BuildCommand execEchoEnv(final String envname) {
+        if (SystemUtil.isWindows()) {
+            return exec("echo", "%" + envname + "%");
+        } else {
+            return exec("/bin/sh", "-c", String.format("echo ${%s}", envname));
+        }
+    }
+
+    public static BuildCommand execSleepScript(int seconds) {
+        if (SystemUtil.isWindows()) {
+            return exec("cmd", "/c", "echo start sleeping & ping 1.1.1.1 -n 1 -w " + seconds * 1000 + " >NULL & echo after sleep");
+        } else {
+            return exec("/bin/sh", "-c", "echo start sleeping;sleep " + seconds + ";echo after sleep");
+        }
+    }
+
+    private String pathSystemEnvName() {
+        return SystemUtil.isWindows() ? "Path" : "PATH";
+    }
+
+}

--- a/common/test/unit/com/thoughtworks/go/buildsession/BuildVariablesTest.java
+++ b/common/test/unit/com/thoughtworks/go/buildsession/BuildVariablesTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2016 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.thoughtworks.go.buildsession;
+
+import com.thoughtworks.go.domain.AgentRuntimeStatus;
+import com.thoughtworks.go.remote.AgentIdentifier;
+import com.thoughtworks.go.server.service.AgentRuntimeInfo;
+import com.thoughtworks.go.util.TestingClock;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Date;
+import java.util.TimeZone;
+
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+
+public class BuildVariablesTest {
+
+    private BuildVariables bvs;
+
+    @Before
+    public void setup() {
+        AgentIdentifier agentIdentifier = new AgentIdentifier("duloc", "127.0.0.1", "uuid");
+        AgentRuntimeInfo runtimeInfo = new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, "/home/lord-farquaad/builds", "cookie", null, false);
+
+        bvs = new BuildVariables(runtimeInfo, new TestingClock(new Date(0)));
+    }
+
+    @Test
+    public void lookupCurrentDate() {
+        TimeZone oldDefault = TimeZone.getDefault();
+        TimeZone.setDefault(TimeZone.getTimeZone("GMT"));
+        try {
+            assertThat(bvs.lookup("date"), is("1970-01-01 00:00:00 GMT"));
+        } finally {
+            TimeZone.setDefault(oldDefault);
+        }
+    }
+
+    @Test
+    public void lookupAgentLocation() {
+        assertThat(bvs.lookup("agent.location"), is("/home/lord-farquaad/builds"));
+    }
+
+    @Test
+    public void lookupAgentHostname() {
+        assertThat(bvs.lookup("agent.hostname"), is("duloc"));
+    }
+
+    @Test
+    public void lookupCrazyThingShouldReturnNull() {
+        assertThat(bvs.lookup("questiontoanswer42"), is(nullValue()));
+    }
+}

--- a/common/test/unit/com/thoughtworks/go/buildsession/CleandirCommandExecutorTest.java
+++ b/common/test/unit/com/thoughtworks/go/buildsession/CleandirCommandExecutorTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2016 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.thoughtworks.go.buildsession;
+
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+
+import static com.thoughtworks.go.domain.BuildCommand.cleandir;
+import static com.thoughtworks.go.domain.BuildCommand.mkdirs;
+import static com.thoughtworks.go.domain.JobResult.Passed;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertTrue;
+
+public class CleandirCommandExecutorTest extends BuildSessionBasedTestCase {
+    @Test
+    public void cleanDirWithoutAllows() throws IOException {
+        runBuild(mkdirs("foo/baz"), Passed);
+        assertTrue(new File(sandbox, "foo/file1").createNewFile());
+        assertTrue(new File(sandbox, "file2").createNewFile());
+
+        runBuild(cleandir(""), Passed);
+        assertThat(sandbox.exists(), is(true));
+        assertThat(sandbox.listFiles().length, is(0));
+    }
+
+    @Test
+    public void cleanDirWithAllows() throws IOException {
+        runBuild(mkdirs("bar/foo/baz"), Passed);
+        runBuild(mkdirs("bar/foo2"), Passed);
+        assertTrue(new File(sandbox, "bar/foo/file1").createNewFile());
+        assertTrue(new File(sandbox, "bar/file2").createNewFile());
+        assertTrue(new File(sandbox, "file3").createNewFile());
+
+        runBuild(cleandir("bar", "file2", "foo2"), Passed);
+        assertThat(new File(sandbox, "bar").isDirectory(), is(true));
+        assertThat(new File(sandbox, "file3").exists(), is(true));
+        assertThat(new File(sandbox, "bar").listFiles(), is(new File[]{new File(sandbox, "bar/file2"), new File(sandbox, "bar/foo2")}));
+    }
+
+    @Test
+    public void cleanDirWithAllowsAndWorkingDir() throws IOException {
+        runBuild(mkdirs("bar/foo/baz"), Passed);
+        runBuild(mkdirs("bar/foo2"), Passed);
+        assertTrue(new File(sandbox, "bar/foo/file1").createNewFile());
+        assertTrue(new File(sandbox, "bar/file2").createNewFile());
+        assertTrue(new File(sandbox, "file3").createNewFile());
+
+        runBuild(cleandir("", "file2", "foo2").setWorkingDirectory("bar"), Passed);
+        assertThat(new File(sandbox, "bar").isDirectory(), is(true));
+        assertThat(new File(sandbox, "file3").exists(), is(true));
+        assertThat(new File(sandbox, "bar").listFiles(), is(new File[]{new File(sandbox, "bar/file2"), new File(sandbox, "bar/foo2")}));
+    }
+
+
+}

--- a/common/test/unit/com/thoughtworks/go/buildsession/DownloadDirCommandExecutorTest.java
+++ b/common/test/unit/com/thoughtworks/go/buildsession/DownloadDirCommandExecutorTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2016 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.thoughtworks.go.buildsession;
+
+import com.thoughtworks.go.util.FileUtil;
+import com.thoughtworks.go.util.TestFileUtil;
+import com.thoughtworks.go.util.ZipUtil;
+import org.junit.Test;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.zip.Deflater;
+
+import static com.thoughtworks.go.domain.BuildCommand.downloadDir;
+import static com.thoughtworks.go.domain.JobResult.Passed;
+import static com.thoughtworks.go.util.MapBuilder.map;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+
+
+public class DownloadDirCommandExecutorTest extends BuildSessionBasedTestCase {
+
+    @Test
+    public void downloadDirWithChecksum() throws Exception {
+        File folder = TestFileUtil.createTempFolder("log");
+        Files.write(Paths.get(folder.getPath(), "a"), "content for a".getBytes());
+        Files.write(Paths.get(folder.getPath(), "b"), "content for b".getBytes());
+
+
+        File zip = new ZipUtil().zip(folder, TestFileUtil.createUniqueTempFile(folder.getName()), Deflater.NO_COMPRESSION);
+
+        httpService.setupDownload("http://far.far.away/log.zip", zip);
+        httpService.setupDownload("http://far.far.away/log.zip.md5", "s/log/a=524ebd45bd7de3616317127f6e639bd6\ns/log/b=83c0aa3048df233340203c74e8a93d7d");
+
+        runBuild(downloadDir(map(
+                "url", "http://far.far.away/log.zip",
+                "dest", "dest",
+                "src", "s/log",
+                "checksumUrl", "http://far.far.away/log.zip.md5")), Passed);
+        File dest = new File(sandbox, "dest");
+
+        assertThat(console.output(), containsString(String.format("Saved artifact to [%s] after verifying the integrity of its contents", dest.getPath())));
+        assertThat(FileUtil.readContentFromFile(new File(dest, "log/a")), is("content for a"));
+        assertThat(FileUtil.readContentFromFile(new File(dest, "log/b")), is("content for b"));
+    }
+
+}

--- a/common/test/unit/com/thoughtworks/go/buildsession/DownloadFileCommandExecutorTest.java
+++ b/common/test/unit/com/thoughtworks/go/buildsession/DownloadFileCommandExecutorTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2016 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.thoughtworks.go.buildsession;
+
+import com.thoughtworks.go.util.FileUtil;
+import com.thoughtworks.go.util.StringUtil;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+import static com.thoughtworks.go.domain.BuildCommand.downloadFile;
+import static com.thoughtworks.go.domain.JobResult.Failed;
+import static com.thoughtworks.go.domain.JobResult.Passed;
+import static com.thoughtworks.go.util.MapBuilder.map;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+
+public class DownloadFileCommandExecutorTest extends BuildSessionBasedTestCase {
+    @Test
+    public void downloadFilePrintErrorWhenFailed() {
+        runBuild(downloadFile(map(
+                "url", "http://far.far.away/foo.jar",
+                "dest", new File(sandbox, "bar.jar").getPath())), Failed);
+        assertThat(console.output(), containsString("Could not fetch artifact"));
+    }
+
+    @Test
+    public void downloadFileWithoutMD5Check() throws IOException {
+        File dest = new File(sandbox, "bar.jar");
+        httpService.setupDownload("http://far.far.away/foo.jar", "some content");
+        runBuild(downloadFile(map(
+                "url", "http://far.far.away/foo.jar",
+                "dest", "bar.jar")), Passed);
+        assertThat(console.output(), containsString("without verifying the integrity"));
+        assertThat(FileUtil.readContentFromFile(dest), is("some content"));
+    }
+
+    @Test
+    public void downloadFileWithMD5Check() throws IOException {
+        httpService.setupDownload("http://far.far.away/foo.jar", "some content");
+        httpService.setupDownload("http://far.far.away/foo.jar.md5", "foo.jar=9893532233caff98cd083a116b013c0b");
+        runBuild(downloadFile(map(
+                "url", "http://far.far.away/foo.jar",
+                "dest", "dest.jar",
+                "src", "foo.jar",
+                "checksumUrl", "http://far.far.away/foo.jar.md5")), Passed);
+        assertThat(console.output(), containsString(String.format("Saved artifact to [%s] after verifying the integrity of its contents", new File(sandbox, "dest.jar").getPath())));
+        assertThat(FileUtil.readContentFromFile(new File(sandbox, "dest.jar")), is("some content"));
+    }
+
+    @Test
+    public void downloadFileShouldAppendSha1IntoDownloadUrlIfDestFileAlreadyExists() throws IOException {
+        File dest = new File(sandbox, "bar.jar");
+        Files.write(Paths.get(dest.getPath()), "foobar".getBytes());
+        String sha1 = java.net.URLEncoder.encode(StringUtil.sha1Digest(dest), "UTF-8");
+
+        httpService.setupDownload("http://far.far.away/foo.jar", "content without sha1");
+        httpService.setupDownload("http://far.far.away/foo.jar?sha1=" + sha1, "content with sha1");
+        runBuild(downloadFile(map(
+                "url", "http://far.far.away/foo.jar",
+                "dest", "bar.jar")), Passed);
+        assertThat(console.output(), containsString("Saved artifact"));
+        assertThat(FileUtil.readContentFromFile(dest), is("content with sha1"));
+    }
+}

--- a/common/test/unit/com/thoughtworks/go/buildsession/ExecCommandExecutorTest.java
+++ b/common/test/unit/com/thoughtworks/go/buildsession/ExecCommandExecutorTest.java
@@ -109,11 +109,12 @@ public class ExecCommandExecutorTest extends BuildSessionBasedTestCase {
         assertThat(console.output(), printedAppsMissingInfoOnWindows("not-not-not-exist"));
     }
 
-    @Test
     public void shouldNotLeakSecretsToConsoleLog() {
         runBuild(compose(secret("topsecret"),
                 exec("not-not-not-exist", "topsecret")), Failed);
-        assertThat(console.output(), containsString("not-not-not-exist ******"));
+        if (!SystemUtil.isWindows()) {
+            assertThat(console.output(), containsString("not-not-not-exist ******"));
+        }
         assertThat(console.output(), not(containsString("topsecret")));
     }
 

--- a/common/test/unit/com/thoughtworks/go/buildsession/ExecCommandExecutorTest.java
+++ b/common/test/unit/com/thoughtworks/go/buildsession/ExecCommandExecutorTest.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2016 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.thoughtworks.go.buildsession;
+
+import com.googlecode.junit.ext.JunitExtRunner;
+import com.googlecode.junit.ext.RunIf;
+import com.thoughtworks.go.domain.BuildCommand;
+import com.thoughtworks.go.junitext.EnhancedOSChecker;
+import com.thoughtworks.go.util.ArrayUtil;
+import com.thoughtworks.go.util.LogFixture;
+import com.thoughtworks.go.util.SystemUtil;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.io.IOException;
+
+import static com.thoughtworks.go.domain.BuildCommand.*;
+import static com.thoughtworks.go.domain.JobResult.Failed;
+import static com.thoughtworks.go.domain.JobResult.Passed;
+import static com.thoughtworks.go.junitext.EnhancedOSChecker.DO_NOT_RUN_ON;
+import static com.thoughtworks.go.junitext.EnhancedOSChecker.WINDOWS;
+import static com.thoughtworks.go.matchers.ConsoleOutMatcher.printedAppsMissingInfoOnUnix;
+import static com.thoughtworks.go.matchers.ConsoleOutMatcher.printedAppsMissingInfoOnWindows;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.core.Is.is;
+
+@RunWith(JunitExtRunner.class)
+public class ExecCommandExecutorTest extends BuildSessionBasedTestCase {
+    @Test
+    public void execExecuteExternalCommandAndConnectOutputToBuildConsole() {
+        runBuild(exec("echo", "foo"), Passed);
+        assertThat(console.lastLine(), is("foo"));
+    }
+
+    @Test
+    public void execShouldFailIfWorkingDirectoryNotExists() {
+        runBuild(exec("echo", "should not show").setWorkingDirectory("not-exists"), Failed);
+        assertThat(console.lineCount(), is(1));
+        assertThat(console.firstLine(), containsString("not-exists\" is not a directory!"));
+    }
+
+    @Test
+    public void execUseSystemEnvironmentVariables() {
+        runBuild(execEchoEnv(pathSystemEnvName()), Passed);
+        assertThat(console.output(), is(System.getenv(pathSystemEnvName())));
+    }
+
+    @Test
+    public void execUsePresetEnvs() {
+        BuildSession buildSession = newBuildSession();
+        buildSession.setEnv("GO_SERVER_URL", "https://far.far.away/go");
+        runBuild(buildSession, execEchoEnv("GO_SERVER_URL"), Passed);
+        assertThat(console.output(), is("https://far.far.away/go"));
+    }
+
+    @Test
+    public void execUseExportedEnv() throws IOException {
+        runBuild(compose(
+                export("foo", "bar", false),
+                execEchoEnv("foo")), Passed);
+        assertThat(console.lastLine(), is("bar"));
+    }
+
+    @Test
+    public void execUseExportedEnvWithOverridden() throws Exception {
+        runBuild(compose(
+                export("answer", "2", false),
+                export("answer", "42", false),
+                execEchoEnv("answer")), Passed);
+        assertThat(console.lastLine(), is("42"));
+    }
+
+
+    @Test
+    public void execUseOverriddenSystemEnvValue() throws Exception {
+        runBuild(compose(
+                export(pathSystemEnvName(), "/foo/bar", false),
+                execEchoEnv(pathSystemEnvName())), Passed);
+        assertThat(console.lastLine(), is("/foo/bar"));
+    }
+
+
+    @Test
+    @RunIf(value = EnhancedOSChecker.class, arguments = {DO_NOT_RUN_ON, WINDOWS})
+    public void execExecuteNotExistExternalCommandOnUnix() {
+        runBuild(exec("not-not-not-exist"), Failed);
+        assertThat(console.output(), printedAppsMissingInfoOnUnix("not-not-not-exist"));
+    }
+
+    @Test
+    @RunIf(value = EnhancedOSChecker.class, arguments = {EnhancedOSChecker.WINDOWS})
+    public void execExecuteNotExistExternalCommandOnWindows() {
+        runBuild(exec("not-not-not-exist"), Failed);
+        assertThat(console.output(), printedAppsMissingInfoOnWindows("not-not-not-exist"));
+    }
+
+    @Test
+    public void shouldNotLeakSecretsToConsoleLog() {
+        runBuild(compose(secret("topsecret"),
+                exec("not-not-not-exist", "topsecret")), Failed);
+        assertThat(console.output(), containsString("not-not-not-exist ******"));
+        assertThat(console.output(), not(containsString("topsecret")));
+    }
+
+    @Test
+    public void shouldNotLeakSecretsToLog() {
+        LogFixture logFixture = LogFixture.startListening();
+        try {
+            LogFixture.enableDebug();
+            runBuild(compose(secret("topsecret"),
+                    exec("not-not-not-exist", "topsecret")), Failed);
+            String logs = ArrayUtil.join(logFixture.getMessages());
+            assertThat(logs, containsString("not-not-not-exist ******"));
+            assertThat(logs, not(containsString("topsecret")));
+        } finally {
+            logFixture.stopListening();
+        }
+    }
+
+
+    private BuildCommand execEchoEnv(final String envname) {
+        if (SystemUtil.isWindows()) {
+            return exec("echo", "%" + envname + "%");
+        } else {
+            return exec("/bin/sh", "-c", String.format("echo ${%s}", envname));
+        }
+    }
+}

--- a/common/test/unit/com/thoughtworks/go/buildsession/ExportCommandExecutorTest.java
+++ b/common/test/unit/com/thoughtworks/go/buildsession/ExportCommandExecutorTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2016 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.thoughtworks.go.buildsession;
+
+import org.junit.Test;
+
+import static com.thoughtworks.go.domain.BuildCommand.compose;
+import static com.thoughtworks.go.domain.BuildCommand.export;
+import static com.thoughtworks.go.domain.JobResult.Passed;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+
+public class ExportCommandExecutorTest extends BuildSessionBasedTestCase {
+    @Test
+    public void exportEnvironmentVariableHasMeaningfulOutput() throws Exception {
+        runBuild(compose(
+                export("answer", "2", false),
+                export("answer", "42", false)), Passed);
+        assertThat(console.asList().get(0), is("[go] setting environment variable 'answer' to value '2'"));
+        assertThat(console.asList().get(1), is("[go] overriding environment variable 'answer' with value '42'"));
+    }
+
+    @Test
+    public void exportOutputWhenOverridingSystemEnv() throws Exception {
+        String envName = pathSystemEnvName();
+        runBuild(export(envName, "/foo/bar", false), Passed);
+        assertThat(console.output(), is(String.format("[go] overriding environment variable '%s' with value '/foo/bar'", envName)));
+    }
+
+    @Test
+    public void exportSecretEnvShouldMaskValue() throws Exception {
+        runBuild(export("answer", "42", true), Passed);
+        assertThat(console.output(), is("[go] setting environment variable 'answer' to value '********'"));
+    }
+
+    @Test
+    public void exportWithoutValueDisplayCurrentValue() throws Exception {
+        runBuild(export("foo"), Passed);
+        assertThat(console.lastLine(), is("[go] setting environment variable 'foo' to value 'null'"));
+        runBuild(compose(
+                export("foo", "bar", false),
+                export("foo")), Passed);
+        assertThat(console.lastLine(), is("[go] setting environment variable 'foo' to value 'bar'"));
+    }
+}

--- a/common/test/unit/com/thoughtworks/go/buildsession/GeneratePropertyCommandExecutorTest.java
+++ b/common/test/unit/com/thoughtworks/go/buildsession/GeneratePropertyCommandExecutorTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2016 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.thoughtworks.go.buildsession;
+
+import com.thoughtworks.go.domain.BuildCommand;
+import com.thoughtworks.go.domain.JobResult;
+import org.apache.commons.io.FileUtils;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+
+public class GeneratePropertyCommandExecutorTest extends BuildSessionBasedTestCase {
+    private static final String TEST_PROPERTY = "test_property";
+
+    @Test
+    public void shouldReportFailureWhenArtifactFileDoesNotExist() throws IOException {
+        runBuild(BuildCommand.generateProperty(TEST_PROPERTY, "not-exists.xml", "//src"), JobResult.Passed);
+        assertThat(console.output(), containsString("Failed to create property"));
+        assertThat(console.output(), containsString(new File(sandbox, "not-exists.xml").getAbsolutePath()));
+        assertThat(artifactsRepository.propertyValue(TEST_PROPERTY), nullValue());
+    }
+
+    @Test
+    public void shouldReportNotingMatchedWhenNoNodeCanMatch() throws IOException {
+        createSrcFile("xmlfile");
+        runBuild(BuildCommand.generateProperty(TEST_PROPERTY, "xmlfile", "//HTML"), JobResult.Passed);
+        assertThat(console.output(), containsString("Failed to create property"));
+        assertThat(console.output(), containsString("Nothing matched xpath \"//HTML\""));
+        assertThat(artifactsRepository.propertyValue(TEST_PROPERTY), nullValue());
+    }
+
+    @Test
+    public void shouldReportNotingMatchedWhenXPATHisNotValid() throws IOException {
+        createSrcFile("xmlfile");
+        runBuild(BuildCommand.generateProperty(TEST_PROPERTY, "xmlfile", "////////HTML"), JobResult.Passed);
+        assertThat(console.output(), containsString("Failed to create property"));
+        assertThat(console.output(), containsString("Illegal xpath: \"////////HTML\""));
+        assertThat(artifactsRepository.propertyValue(TEST_PROPERTY), nullValue());
+    }
+
+    @Test
+    public void shouldReportPropertyIsCreated() throws Exception {
+        createSrcFile("xmlfile");
+        runBuild(BuildCommand.generateProperty(TEST_PROPERTY, "xmlfile", "//buildplan/@name"), JobResult.Passed);
+        assertThat(console.output(), containsString("Property " + TEST_PROPERTY + " = test created"));
+        assertThat(artifactsRepository.propertyValue(TEST_PROPERTY), is("test"));
+    }
+
+    @Test
+    public void shouldReportFirstMatchedProperty() throws Exception {
+        createSrcFile("xmlfile");
+        runBuild(BuildCommand.generateProperty(TEST_PROPERTY, "xmlfile", "//artifact/@src"), JobResult.Passed);
+        assertThat(console.output(), containsString("Property " + TEST_PROPERTY + " = target\\connectfour.jar created"));
+        assertThat(artifactsRepository.propertyValue(TEST_PROPERTY), is("target\\connectfour.jar"));
+    }
+
+    private void createSrcFile(String filename) throws IOException {
+        String content = "<buildplans>\n"
+                + "          <buildplan name=\"test\">\n"
+                + "            <artifacts>\n"
+                + "              <artifact src=\"target\\connectfour.jar\" dest=\"dist\\jars\" />\n"
+                + "              <artifact src=\"target\\test-results\" dest=\"testoutput\" type=\"junit\" />\n"
+                + "              <artifact src=\"build.xml\" />\n"
+                + "            </artifacts>\n"
+                + "            <tasks>\n"
+                + "              <ant workingdir=\"dev\" target=\"all\" />\n"
+                + "            </tasks>\n"
+                + "          </buildplan>\n"
+                + "        </buildplans>";
+        FileUtils.writeStringToFile(new File(sandbox, filename), content, "UTF-8");
+    }
+}

--- a/common/test/unit/com/thoughtworks/go/buildsession/GenerateTestReportCommandExecutorTest.java
+++ b/common/test/unit/com/thoughtworks/go/buildsession/GenerateTestReportCommandExecutorTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2016 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.thoughtworks.go.buildsession;
+
+import com.thoughtworks.go.domain.*;
+import com.thoughtworks.go.domain.exception.ArtifactPublishingException;
+import com.thoughtworks.go.util.FileUtil;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.core.io.ClassPathResource;
+
+import java.io.*;
+import java.util.Collections;
+
+import static com.thoughtworks.go.util.TestUtils.copyAndClose;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+
+public class GenerateTestReportCommandExecutorTest extends BuildSessionBasedTestCase {
+
+    private File testFolder;
+
+    @Before
+    public void setUp() {
+        testFolder = new File(sandbox, "test-reports");
+        testFolder.mkdir();
+    }
+
+
+    @Test
+    public void generateReportForNUnit() throws IOException, ArtifactPublishingException {
+        copyAndClose(source("TestResult.xml"), target("test-result.xml"));
+        runBuild(BuildCommand.generateTestReport(Collections.singletonList("test-reports/test-result.xml"), "test-out"), JobResult.Passed);
+        assertThat(artifactsRepository.getFileUploaded().size(), is(1));
+        assertThat(artifactsRepository.getFileUploaded().get(0).destPath, is("test-out"));
+        assertThat(artifactsRepository.propertyValue(TestReportGenerator.TOTAL_TEST_COUNT), is("206"));
+        assertThat(artifactsRepository.propertyValue(TestReportGenerator.FAILED_TEST_COUNT), is("0"));
+        assertThat(artifactsRepository.propertyValue(TestReportGenerator.IGNORED_TEST_COUNT), is("0"));
+        assertThat(artifactsRepository.propertyValue(TestReportGenerator.TEST_TIME), is("NaN"));
+    }
+
+
+    private OutputStream target(String targetFile) throws FileNotFoundException {
+        return new FileOutputStream(testFolder.getAbsolutePath() + FileUtil.fileseparator() + targetFile);
+    }
+
+    private InputStream source(String filename) throws IOException {
+        return new ClassPathResource(FileUtil.fileseparator() + "data" + FileUtil.fileseparator() + filename).getInputStream();
+    }
+
+}

--- a/common/test/unit/com/thoughtworks/go/buildsession/MkdirsCommandExecutorTest.java
+++ b/common/test/unit/com/thoughtworks/go/buildsession/MkdirsCommandExecutorTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2016 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.thoughtworks.go.buildsession;
+
+import org.junit.Test;
+
+import java.io.File;
+
+import static com.thoughtworks.go.domain.BuildCommand.mkdirs;
+import static com.thoughtworks.go.domain.BuildCommand.test;
+import static com.thoughtworks.go.domain.JobResult.Failed;
+import static com.thoughtworks.go.domain.JobResult.Passed;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+
+public class MkdirsCommandExecutorTest extends BuildSessionBasedTestCase {
+    @Test
+    public void mkdirsShouldCreateDirectoryIfNotExists() {
+        runBuild(mkdirs("foo"), Passed);
+        assertThat(new File(sandbox, "foo").isDirectory(), is(true));
+    }
+
+    @Test
+    public void mkdirsShouldFailIfDirExists() {
+        runBuild(mkdirs("foo"), Passed);
+        runBuild(mkdirs("foo"), Failed);
+        assertThat(new File(sandbox, "foo").isDirectory(), is(true));
+    }
+
+    @Test
+    public void testDirectoryExistsBeforeMkdir() {
+        File dir = new File(sandbox, "foo");
+        runBuild(mkdirs("foo"), Passed);
+        runBuild(mkdirs("foo").setTest(test("-nd", dir.getPath())), Passed);
+        assertThat(new File(sandbox, "foo").isDirectory(), is(true));
+    }
+}

--- a/common/test/unit/com/thoughtworks/go/buildsession/SecretCommandExecutorTest.java
+++ b/common/test/unit/com/thoughtworks/go/buildsession/SecretCommandExecutorTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2016 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.thoughtworks.go.buildsession;
+
+import org.junit.Test;
+
+import static com.thoughtworks.go.domain.BuildCommand.*;
+import static com.thoughtworks.go.domain.JobResult.Failed;
+import static com.thoughtworks.go.domain.JobResult.Passed;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsNot.not;
+
+public class SecretCommandExecutorTest extends BuildSessionBasedTestCase {
+
+    @Test
+    public void secretMaskValuesInExecOutput() throws Exception {
+        runBuild(compose(
+                secret("42"),
+                exec("echo", "the answer is 42")), Passed);
+        assertThat(console.output(), containsString("the answer is ******"));
+    }
+
+    @Test
+    public void secretMaskValuesInExportOutput() throws Exception {
+        runBuild(compose(
+                secret("42"),
+                export("oracle", "the answer is 42", false)), Passed);
+        assertThat(console.output(), is("[go] setting environment variable 'oracle' to value 'the answer is ******'"));
+    }
+
+    @Test
+    public void addSecretWithSubstitution() throws Exception {
+        runBuild(compose(
+                secret("foo:bar@ssss.com", "foo:******@ssss.com"),
+                exec("echo", "connecting to foo:bar@ssss.com"),
+                exec("echo", "connecting to foo:bar@tttt.com")), Passed);
+        assertThat(console.firstLine(), containsString("connecting to foo:******@ssss.com"));
+        assertThat(console.asList().get(1), containsString("connecting to foo:bar@tttt.com"));
+    }
+
+    @Test
+    public void shouldNotLeakSecretWhenExceptionHappened() throws Exception {
+        runBuild(compose(
+                secret("the-answer-is-42"),
+                error("error: the-answer-is-42")), Failed);
+        assertThat(console.output(), containsString("error: ******"));
+        assertThat(console.output(), not(containsString("the-anwser-is-42")));
+    }
+}

--- a/common/test/unit/com/thoughtworks/go/buildsession/TestCommandExecutorTest.java
+++ b/common/test/unit/com/thoughtworks/go/buildsession/TestCommandExecutorTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2016 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.thoughtworks.go.buildsession;
+
+import com.thoughtworks.go.domain.JobResult;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+
+import static com.thoughtworks.go.domain.BuildCommand.*;
+import static com.thoughtworks.go.domain.BuildCommand.compose;
+import static com.thoughtworks.go.domain.BuildCommand.fail;
+import static com.thoughtworks.go.domain.JobResult.Failed;
+import static com.thoughtworks.go.domain.JobResult.Passed;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertTrue;
+
+public class TestCommandExecutorTest extends BuildSessionBasedTestCase {
+    @Test
+    public void testDirExists() throws IOException {
+        runBuild(test("-d", ""), Passed);
+        runBuild(test("-d", "dir"), Failed);
+        runBuild(test("-d", "file"), Failed);
+        assertTrue(new File(sandbox, "file").createNewFile());
+        assertTrue(new File(sandbox, "dir").mkdir());
+        runBuild(test("-d", "file"), Failed);
+        runBuild(test("-d", "dir"), Passed);
+    }
+
+    @Test
+    public void testDirNotExists() throws IOException {
+        runBuild(test("-nd", ""), Failed);
+        runBuild(test("-nd", "dir"), Passed);
+        runBuild(test("-nd", "file"), Passed);
+        assertTrue(new File(sandbox, "file").createNewFile());
+        assertTrue(new File(sandbox, "dir").mkdir());
+        runBuild(test("-nd", "file"), Passed);
+        runBuild(test("-nd", "dir"), Failed);
+    }
+
+    @Test
+    public void testFileExists() throws IOException {
+        runBuild(test("-f", ""), Failed);
+        runBuild(test("-f", "file"), Failed);
+        File file = new File(sandbox, "file");
+        assertTrue(file.createNewFile());
+        runBuild(test("-f", "file"), Passed);
+    }
+
+    @Test
+    public void testFileNotExists() throws IOException {
+        runBuild(test("-nf", ""), Passed);
+        runBuild(test("-nf", "file"), Passed);
+        File file = new File(sandbox, "file");
+        assertTrue(file.createNewFile());
+        runBuild(test("-nf", "file"), Failed);
+    }
+
+    @Test
+    public void testEqWithCommandOutput() throws IOException {
+        runBuild(test("-eq", "foo", echo("foo")), Passed);
+        runBuild(test("-eq", "bar", echo("foo")), Failed);
+        assertThat(console.lineCount(), is(0));
+    }
+
+    @Test
+    public void testNotEqWithCommandOutput() throws IOException {
+        runBuild(test("-neq", "foo", echo("foo")), Failed);
+        runBuild(test("-neq", "bar", echo("foo")), Passed);
+        assertThat(console.lineCount(), is(0));
+    }
+
+    @Test
+    public void mkdirWithWorkingDir() {
+        runBuild(mkdirs("foo").setWorkingDirectory("bar"), Passed);
+        assertThat(new File(sandbox, "bar/foo").isDirectory(), is(true));
+        assertThat(new File(sandbox, "foo").isDirectory(), is(false));
+    }
+
+    @Test
+    public void shouldNotFailBuildWhenTestCommandFail() {
+        runBuild(echo("foo").setTest(fail("")), Passed);
+        assertThat(statusReporter.singleResult(), is(Passed));
+    }
+
+    @Test
+    public void shouldNotFailBuildWhenComposedTestCommandFail() {
+        runBuild(echo("foo").setTest(compose(echo(""), fail(""))), Passed);
+        assertThat(statusReporter.singleResult(), is(JobResult.Passed));
+    }
+
+    @Test
+    public void shouldNotFailBuildWhenTestEqWithComposedCommandOutputFail() {
+        runBuild(echo("foo").setTest(test("-eq", "42", compose(fail("42")))), Passed);
+        assertThat(statusReporter.singleResult(), is(Passed));
+        assertThat(console.output(), containsString("foo"));
+    }
+}

--- a/common/test/unit/com/thoughtworks/go/buildsession/UploadArtifactCommandExecutorTest.java
+++ b/common/test/unit/com/thoughtworks/go/buildsession/UploadArtifactCommandExecutorTest.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2016 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.thoughtworks.go.buildsession;
+
+import com.thoughtworks.go.util.FileUtil;
+import org.junit.Test;
+
+import java.io.File;
+
+import static com.thoughtworks.go.domain.BuildCommand.uploadArtifact;
+import static com.thoughtworks.go.domain.JobResult.Failed;
+import static com.thoughtworks.go.domain.JobResult.Passed;
+import static com.thoughtworks.go.matchers.ConsoleOutMatcher.printedRuleDoesNotMatchFailure;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertTrue;
+
+public class UploadArtifactCommandExecutorTest extends BuildSessionBasedTestCase {
+
+    @Test
+    public void uploadSingleFileArtifact() throws Exception {
+        File targetFile = new File(sandbox, "foo");
+        assertTrue(targetFile.createNewFile());
+        runBuild(uploadArtifact("foo", "foo-dest", false).setWorkingDirectory(sandbox.getPath()), Passed);
+        assertThat(artifactsRepository.getFileUploaded().size(), is(1));
+        assertThat(artifactsRepository.getFileUploaded().get(0).file, is(targetFile));
+        assertThat(artifactsRepository.getFileUploaded().get(0).destPath, is("foo-dest"));
+        assertThat(artifactsRepository.getFileUploaded().get(0).buildId, is("build1"));
+    }
+
+    @Test
+    public void uploadMultipleArtifact() throws Exception {
+        File dir = new File(sandbox, "foo");
+        assertTrue(dir.mkdirs());
+        assertTrue(new File(dir, "bar").createNewFile());
+        assertTrue(new File(dir, "baz").createNewFile());
+        runBuild(uploadArtifact("foo/*", "foo-dest", false), Passed);
+        assertThat(artifactsRepository.getFileUploaded().size(), is(2));
+        assertThat(artifactsRepository.getFileUploaded().get(0).file, is(new File(dir, "bar")));
+        assertThat(artifactsRepository.getFileUploaded().get(1).file, is(new File(dir, "baz")));
+    }
+
+    @Test
+    public void shouldUploadMatchedFolder() throws Exception {
+        FileUtil.createFilesByPath(sandbox, "logs/pic/fail.png", "logs/pic/pass.png", "README");
+        runBuild(uploadArtifact("**/*", "mypic", false), Passed);
+        assertThat(artifactsRepository.isFileUploaded(new File(sandbox, "logs/pic"), "mypic/logs"), is(true));
+        assertThat(artifactsRepository.isFileUploaded(new File(sandbox, "README"), "mypic"), is(true));
+        assertThat(artifactsRepository.isFileUploaded(new File(sandbox, "logs/pic/fail.png"), "mypic/logs/pic"), is(false));
+        assertThat(artifactsRepository.isFileUploaded(new File(sandbox, "logs/pic/pass.png"), "mypic/logs/pic"), is(false));
+    }
+
+    @Test
+    public void shouldNotUploadFileContainingFolderAgain() throws Exception {
+        FileUtil.createFilesByPath(sandbox, "logs/pic/fail.png", "logs/pic/pass.png", "README");
+        runBuild(uploadArtifact("logs/pic/*.png", "mypic", false), Passed);
+        assertThat(artifactsRepository.isFileUploaded(new File(sandbox, "logs/pic/pass.png"), "mypic"), is(true));
+        assertThat(artifactsRepository.isFileUploaded(new File(sandbox, "logs/pic/fail.png"), "mypic"), is(true));
+        assertThat(artifactsRepository.isFileUploaded(new File(sandbox, "logs/pic"), "mypic"), is(false));
+    }
+
+    @Test
+    public void shouldUploadFolderWhenMatchedWithWildCards() throws Exception {
+        FileUtil.createFilesByPath(sandbox, "logs/pic-1/fail.png", "logs/pic-1/pass.png", "logs/pic-2/cancel.png", "logs/pic-2/complete.png", "README");
+        runBuild(uploadArtifact("logs/pic-*", "mypic", false), Passed);
+        assertThat(artifactsRepository.isFileUploaded(new File(sandbox, "logs/pic-1/pass.png"), "mypic"), is(false));
+        assertThat(artifactsRepository.isFileUploaded(new File(sandbox, "logs/pic-1/fail.png"), "mypic"), is(false));
+        assertThat(artifactsRepository.isFileUploaded(new File(sandbox, "logs/pic-2/cancel.png"), "mypic"), is(false));
+        assertThat(artifactsRepository.isFileUploaded(new File(sandbox, "logs/pic-2/complete.png"), "mypic"), is(false));
+        assertThat(artifactsRepository.isFileUploaded(new File(sandbox, "logs/pic-1"), "mypic"), is(true));
+        assertThat(artifactsRepository.isFileUploaded(new File(sandbox, "logs/pic-2"), "mypic"), is(true));
+    }
+
+    @Test
+    public void shouldUploadFolderWhenDirectMatch() throws Exception {
+        FileUtil.createFilesByPath(sandbox, "logs/pic-1/fail.png", "logs/pic-1/pass.png", "logs/pic-2/cancel.png", "logs/pic-2/complete.png", "README");
+        runBuild(uploadArtifact("logs/pic-1", "mypic", false), Passed);
+        assertThat(artifactsRepository.isFileUploaded(new File(sandbox, "logs/pic-1"), "mypic"), is(true));
+    }
+
+    @Test
+    public void shouldFailBuildWhenNothingMatched() throws Exception {
+        FileUtil.createFilesByPath(sandbox, "logs/pic-1/fail.png", "logs/pic-1/pass.png", "logs/pic-2/cancel.png", "logs/pic-2/complete.png", "README");
+
+        runBuild(uploadArtifact("logs/picture", "mypic", false), Failed);
+        assertThat(artifactsRepository.getFileUploaded().size(), is(0));
+        assertThat(console.output(), printedRuleDoesNotMatchFailure(sandbox.getPath(), "logs/picture"));
+    }
+
+    @Test
+    public void shouldFailBuildWhenSourceDirectoryDoesNotExist() throws Exception {
+        FileUtil.createFilesByPath(sandbox, "logs/pic-1/fail.png", "logs/pic-1/pass.png", "logs/pic-2/cancel.png", "logs/pic-2/complete.png", "README");
+        runBuild(uploadArtifact("not-Exist-Folder", "mypic", false), Failed);
+        assertThat(console.output(), printedRuleDoesNotMatchFailure(sandbox.getPath(), "not-Exist-Folder"));
+    }
+
+    @Test
+    public void shouldFailBuildWhenNothingMatchedUsingMatcherStartDotStart() throws Exception {
+        runBuild(uploadArtifact("target/pkg/*.*", "MYDEST", false), Failed);
+        assertThat(console.output(), printedRuleDoesNotMatchFailure(sandbox.getPath(), "target/pkg/*.*"));
+    }
+
+    @Test
+    public void shouldNotFailBuildWhenNothingMatchedWhenIngnoreUnmatchError() throws Exception {
+        runBuild(uploadArtifact("target/pkg/*.*", "MYDEST", true), Passed);
+        assertThat(console.output(), printedRuleDoesNotMatchFailure(sandbox.getPath(), "target/pkg/*.*"));
+    }
+
+    @Test
+    public void shouldFailBuildWhenUploadErrorHappened() throws Exception {
+        FileUtil.createFilesByPath(sandbox, "logs/pic/pass.png", "logs/pic-1/pass.png");
+        artifactsRepository.setUploadError(new RuntimeException("upload failed!!"));
+        runBuild(uploadArtifact("**/*.png", "mypic", false), Failed);
+        assertThat(artifactsRepository.getFileUploaded().size(), is(0));
+    }
+
+    @Test
+    public void shouldStillFailBuildWhenIgnoreUnmatchErrorButUploadErrorHappened() throws Exception {
+        FileUtil.createFilesByPath(sandbox, "logs/pic/pass.png", "logs/pic-1/pass.png");
+        artifactsRepository.setUploadError(new RuntimeException("upload failed!!"));
+        runBuild(uploadArtifact("**/*.png", "mypic", true), Failed);
+        assertThat(artifactsRepository.getFileUploaded().size(), is(0));
+    }
+
+}

--- a/common/test/unit/com/thoughtworks/go/config/materials/git/GitMaterialShallowCloneTest.java
+++ b/common/test/unit/com/thoughtworks/go/config/materials/git/GitMaterialShallowCloneTest.java
@@ -39,7 +39,7 @@ import java.util.List;
 import java.util.Map;
 
 import static com.thoughtworks.go.domain.materials.git.GitTestRepo.*;
-import static com.thoughtworks.go.util.command.ProcessOutputStreamConsumer.*;
+import static com.thoughtworks.go.util.command.ProcessOutputStreamConsumer.inMemoryConsumer;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
 
@@ -147,7 +147,6 @@ public class GitMaterialShallowCloneTest {
         assertThat(original.withShallowClone(true).isShallowClone(), is(true));
         assertThat(original.withShallowClone(false).isShallowClone(), is(false));
         assertThat(original.isShallowClone(), is(false));
-
     }
 
     @Test
@@ -162,7 +161,6 @@ public class GitMaterialShallowCloneTest {
         assertThat(localRepoFor(material).isShallow(), is(true));
     }
 
-
     private TestSubprocessExecutionContext context() {
         return new TestSubprocessExecutionContext();
     }
@@ -170,6 +168,4 @@ public class GitMaterialShallowCloneTest {
     private GitCommand localRepoFor(GitMaterial material) {
         return new GitCommand(material.getFingerprint(), workingDir, GitMaterialConfig.DEFAULT_BRANCH, false);
     }
-
-
 }

--- a/common/test/unit/com/thoughtworks/go/config/materials/git/GitMaterialTest.java
+++ b/common/test/unit/com/thoughtworks/go/config/materials/git/GitMaterialTest.java
@@ -19,8 +19,7 @@ package com.thoughtworks.go.config.materials.git;
 import com.googlecode.junit.ext.JunitExtRunner;
 import com.googlecode.junit.ext.RunIf;
 import com.thoughtworks.go.config.materials.Materials;
-import com.thoughtworks.go.domain.MaterialRevision;
-import com.thoughtworks.go.domain.MaterialRevisions;
+import com.thoughtworks.go.domain.*;
 import com.thoughtworks.go.domain.materials.*;
 import com.thoughtworks.go.domain.materials.git.GitTestRepo;
 import com.thoughtworks.go.domain.materials.mercurial.StringRevision;
@@ -39,7 +38,11 @@ import static com.thoughtworks.go.domain.materials.git.GitTestRepo.*;
 import java.io.*;
 import java.util.LinkedHashMap;
 import java.util.Map;
+
+import com.thoughtworks.go.util.command.StreamConsumer;
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang.text.StrLookup;
 import org.hamcrest.Matchers;
 import org.hamcrest.core.Is;
 import org.junit.After;
@@ -57,6 +60,7 @@ import static com.thoughtworks.go.matchers.FileExistsMatcher.exists;
 import static com.thoughtworks.go.util.JsonUtils.from;
 import static com.thoughtworks.go.util.command.ProcessOutputStreamConsumer.inMemoryConsumer;
 import static java.lang.String.format;
+import static junit.framework.TestCase.assertTrue;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNot.not;
@@ -570,7 +574,6 @@ public class GitMaterialTest {
         assertThat((String) configuration.get("url"), is("http://username:******@gitrepo.com"));
         assertThat((String) configuration.get("branch"), is(GitMaterialConfig.DEFAULT_BRANCH));
     }
-
 
     private void assertWorkingCopyNotCheckedOut(File localWorkingDir) {
         assertThat(localWorkingDir.listFiles(), is(new File[]{new File(localWorkingDir, ".git")}));

--- a/common/test/unit/com/thoughtworks/go/config/materials/git/GitMaterialUpdaterTest.java
+++ b/common/test/unit/com/thoughtworks/go/config/materials/git/GitMaterialUpdaterTest.java
@@ -1,0 +1,298 @@
+/*
+ * Copyright 2016 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.config.materials.git;
+
+import com.googlecode.junit.ext.JunitExtRunner;
+import com.thoughtworks.go.buildsession.BuildSession;
+import com.thoughtworks.go.buildsession.BuildSessionBasedTestCase;
+import com.thoughtworks.go.domain.JobResult;
+import com.thoughtworks.go.domain.materials.Modification;
+import com.thoughtworks.go.domain.materials.RevisionContext;
+import com.thoughtworks.go.domain.materials.git.GitCommand;
+import com.thoughtworks.go.domain.materials.git.GitMaterialUpdater;
+import com.thoughtworks.go.domain.materials.git.GitTestRepo;
+import com.thoughtworks.go.domain.materials.mercurial.StringRevision;
+import com.thoughtworks.go.helper.GitSubmoduleRepos;
+import com.thoughtworks.go.helper.TestRepo;
+import com.thoughtworks.go.util.command.CommandLine;
+import com.thoughtworks.go.util.command.InMemoryStreamConsumer;
+import org.apache.commons.io.FileUtils;
+import org.hamcrest.Matchers;
+import org.hamcrest.core.Is;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static com.thoughtworks.go.domain.materials.git.GitTestRepo.*;
+import static com.thoughtworks.go.matchers.FileExistsMatcher.exists;
+import static com.thoughtworks.go.util.command.ProcessOutputStreamConsumer.inMemoryConsumer;
+import static java.lang.String.format;
+import static junit.framework.TestCase.assertTrue;
+import static org.apache.commons.io.filefilter.FileFilterUtils.*;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsNot.not;
+import static org.hamcrest.core.StringContains.containsString;
+import static org.junit.Assert.assertThat;
+
+@RunWith(JunitExtRunner.class)
+
+public class GitMaterialUpdaterTest extends BuildSessionBasedTestCase {
+    private static final String SUBMODULE = "submodule-1";
+
+    private File workingDir;
+
+    @Before
+    public void setup() throws Exception {
+        workingDir = new File(sandbox, "working");
+    }
+
+
+    @After
+    public void teardown() throws Exception {
+        TestRepo.internalTearDown();
+    }
+
+    @Test
+    public void shouldCreateBuildCommandUpdateToSpecificRevision() throws Exception {
+        GitMaterial material = new GitMaterial(new GitTestRepo().projectRepositoryUrl(), true);
+        File newFile = new File(workingDir, "second.txt");
+        updateTo(material, new RevisionContext(REVISION_1, REVISION_0, 2), JobResult.Passed);
+        assertThat(console.output(),
+                containsString("Start updating files at revision " + REVISION_1.getRevision()));
+        assertThat(newFile.exists(), is(false));
+
+        console.clear();
+        updateTo(material, new RevisionContext(REVISION_2, REVISION_1, 2), JobResult.Passed);
+
+        assertThat(console.output(),
+                containsString("Start updating files at revision " + REVISION_2.getRevision()));
+        assertThat(newFile.exists(), is(true));
+    }
+
+
+    @Test
+    public void shouldRemoveSubmoduleFolderFromWorkingDirWhenSubmoduleIsRemovedFromRepo() throws Exception {
+        GitSubmoduleRepos submoduleRepos = new GitSubmoduleRepos();
+        submoduleRepos.addSubmodule(SUBMODULE, "sub1");
+        GitMaterial gitMaterial = new GitMaterial(submoduleRepos.mainRepo().getUrl(), true);
+        StringRevision revision = new StringRevision("origin/master");
+        updateTo(gitMaterial, new RevisionContext(revision), JobResult.Passed);
+        assertThat(new File(workingDir, "sub1"), exists());
+        submoduleRepos.removeSubmodule("sub1");
+        updateTo(gitMaterial, new RevisionContext(revision), JobResult.Passed);
+        assertThat(new File(workingDir, "sub1"), not(exists()));
+    }
+
+    @Test
+    public void shouldDeleteAndRecheckoutDirectoryWhenUrlChanges() throws Exception {
+        updateTo(new GitMaterial(new GitTestRepo().projectRepositoryUrl(), true),
+                new RevisionContext(new StringRevision("origin/master")), JobResult.Passed);
+
+        File shouldBeRemoved = new File(workingDir, "shouldBeRemoved");
+        shouldBeRemoved.createNewFile();
+        assertThat(shouldBeRemoved.exists(), is(true));
+
+        String repositoryUrl = new GitTestRepo().projectRepositoryUrl();
+        GitMaterial material = new GitMaterial(repositoryUrl, true);
+        updateTo(material, new RevisionContext(REVISION_4), JobResult.Passed);
+        assertThat(localRepoFor(material).workingRepositoryUrl().forCommandline(), is(repositoryUrl));
+        assertThat(shouldBeRemoved.exists(), is(false));
+    }
+
+    @Test
+    public void shouldNotDeleteAndRecheckoutDirectoryWhenUrlSame() throws Exception {
+        GitMaterial material = new GitMaterial(new GitTestRepo().projectRepositoryUrl(), true);
+        updateTo(material, new RevisionContext(new StringRevision("origin/master")), JobResult.Passed);
+        File shouldNotBeRemoved = new File(new File(workingDir, ".git"), "shouldNotBeRemoved");
+        FileUtils.writeStringToFile(shouldNotBeRemoved, "gundi");
+        assertThat(shouldNotBeRemoved.exists(), is(true));
+        updateTo(material, new RevisionContext(new StringRevision("origin/master")), JobResult.Passed);
+        assertThat("Should not have deleted whole folder", shouldNotBeRemoved.exists(), is(true));
+    }
+
+    /* This is to test the functionality of the private method isRepositoryChanged() */
+    @Test
+    public void shouldNotDeleteAndRecheckoutDirectoryWhenBranchIsBlank() throws Exception {
+        String repositoryUrl = new GitTestRepo().projectRepositoryUrl();
+        GitMaterial material = new GitMaterial(repositoryUrl, false);
+        updateTo(material, new RevisionContext(new StringRevision("origin/master")), JobResult.Passed);
+
+        File shouldNotBeRemoved = new File(new File(workingDir, ".git"), "shouldNotBeRemoved");
+        FileUtils.writeStringToFile(shouldNotBeRemoved, "Text file");
+
+        GitMaterial material1 = new GitMaterial(repositoryUrl, " ");
+        updateTo(material1, new RevisionContext(new StringRevision("origin/master")), JobResult.Passed);
+        assertThat("Should not have deleted whole folder", shouldNotBeRemoved.exists(), is(true));
+    }
+
+    @Test
+    public void shouldDeleteAndRecheckoutDirectoryWhenBranchChanges() throws Exception {
+        GitTestRepo repoWithBranch = GitTestRepo.testRepoAtBranch(GIT_FOO_BRANCH_BUNDLE, "foo");
+        GitMaterial material = new GitMaterial(repoWithBranch.projectRepositoryUrl(), true);
+        updateTo(material, new RevisionContext(new StringRevision("origin/master")), JobResult.Passed);
+        InMemoryStreamConsumer output = inMemoryConsumer();
+        CommandLine.createCommandLine("git").withEncoding("UTF-8").withArg("branch").withWorkingDir(workingDir).run(output, "");
+        assertThat(output.getStdOut(), Is.is("* master"));
+
+        GitMaterial material1 = new GitMaterial(repoWithBranch.projectRepositoryUrl(), "foo", null, true);
+        updateTo(material1, new RevisionContext(new StringRevision("origin/foo")), JobResult.Passed);
+
+        output = inMemoryConsumer();
+        CommandLine.createCommandLine("git").withEncoding("UTF-8").withArg("branch").withWorkingDir(workingDir).run(output, "");
+        assertThat(output.getStdOut(), Is.is("* foo"));
+    }
+
+    @Test
+    public void shouldLogRepoInfoToConsoleOutWithoutFolder() throws Exception {
+        String repositoryUrl = new GitTestRepo().projectRepositoryUrl();
+        GitMaterial material = new GitMaterial(repositoryUrl, false);
+        updateTo(material, new RevisionContext(REVISION_1), JobResult.Passed);
+        assertThat(console.output(), containsString(
+                format("Start updating %s at revision %s from %s", "files", REVISION_1.getRevision(),
+                        repositoryUrl)));
+    }
+
+    @Test
+    public void shouldConvertExistingRepoToFullRepoWhenShallowCloneIsOff() throws IOException {
+        String repositoryUrl = new GitTestRepo().projectRepositoryUrl();
+        GitMaterial shallowMaterial = new GitMaterial(repositoryUrl, true);
+        updateTo(shallowMaterial, new RevisionContext(REVISION_3), JobResult.Passed);
+        assertThat(localRepoFor(shallowMaterial).isShallow(), is(true));
+        GitMaterial fullMaterial = new GitMaterial(repositoryUrl, false);
+        updateTo(fullMaterial, new RevisionContext(REVISION_4), JobResult.Passed);
+        assertThat(localRepoFor(fullMaterial).isShallow(), is(false));
+    }
+
+    @Test
+    public void shouldCleanDirtyFilesUponUpdate() throws IOException {
+        String repositoryUrl = new GitTestRepo().projectRepositoryUrl();
+        GitMaterial material = new GitMaterial(repositoryUrl, true);
+        updateTo(material, new RevisionContext(REVISION_4), JobResult.Passed);
+        File shouldBeRemoved = new File(workingDir, "shouldBeRemoved");
+        assertTrue(shouldBeRemoved.createNewFile());
+        updateTo(material, new RevisionContext(REVISION_4), JobResult.Passed);
+        assertThat(shouldBeRemoved.exists(), is(false));
+    }
+
+    @Test
+    public void cloneWithDeepWorkingDir() throws Exception {
+        GitMaterial material = new GitMaterial(new GitTestRepo().projectRepositoryUrl(), "", "foo/bar/baz", true);
+        updateTo(material, new RevisionContext(REVISION_4), JobResult.Passed);
+        assertThat(new File(workingDir, "foo/bar/baz/build.xml").exists(), is(true));
+    }
+
+    @Test
+    public void failureCommandShouldNotLeakPasswordOnUrl() throws Exception {
+        GitMaterial material = new GitMaterial("https://foo:foopassword@this.is.absolute.not.exists", true);
+        updateTo(material, new RevisionContext(new StringRevision("origin/master")), JobResult.Failed);
+        assertThat(console.output(), containsString("https://foo:******@this.is.absolute.not.exists/"));
+        assertThat(console.output(), not(containsString("foopassword")));
+    }
+
+    @Test
+    public void shouldCleanUnversionedFilesInsideSubmodulesBeforeUpdating() throws Exception {
+        GitSubmoduleRepos submoduleRepos = new GitSubmoduleRepos();
+        String submoduleDirectoryName = "local-submodule";
+        submoduleRepos.addSubmodule(SUBMODULE, submoduleDirectoryName);
+        GitMaterial material = new GitMaterial(submoduleRepos.projectRepositoryUrl(), true);
+
+        updateTo(material, new RevisionContext(new StringRevision("origin/HEAD")), JobResult.Passed);
+        File unversionedFile = new File(new File(workingDir, submoduleDirectoryName), "unversioned_file.txt");
+        FileUtils.writeStringToFile(unversionedFile, "this is an unversioned file. lets see you deleting me.. come on.. I dare you!!!!");
+        updateTo(material, new RevisionContext(new StringRevision("origin/HEAD")), JobResult.Passed);
+        System.out.println("console = " + console);
+        assertThat(unversionedFile.exists(), Matchers.is(false));
+    }
+
+    @Test
+    public void shouldRemoveChangesToModifiedFilesInsideSubmodulesBeforeUpdating() throws Exception {
+        GitSubmoduleRepos submoduleRepos = new GitSubmoduleRepos();
+        String submoduleDirectoryName = "local-submodule";
+        File remoteSubmoduleLocation = submoduleRepos.addSubmodule(SUBMODULE, submoduleDirectoryName);
+        GitMaterial material = new GitMaterial(submoduleRepos.projectRepositoryUrl(), true);
+
+        updateTo(material, new RevisionContext(new StringRevision("origin/HEAD")), JobResult.Passed);
+
+        /* Simulate a local modification of file inside submodule, on agent side. */
+        File fileInSubmodule = allFilesIn(new File(workingDir, submoduleDirectoryName), "file-").get(0);
+        FileUtils.writeStringToFile(fileInSubmodule, "Some other new content.");
+
+        /* Commit a change to the file on the repo. */
+        List<Modification> modifications = submoduleRepos.modifyOneFileInSubmoduleAndUpdateMainRepo(
+                remoteSubmoduleLocation, submoduleDirectoryName, fileInSubmodule.getName(), "NEW CONTENT OF FILE");
+
+        updateTo(material, new RevisionContext(new StringRevision(modifications.get(0).getRevision())), JobResult.Passed);
+        assertThat(FileUtils.readFileToString(fileInSubmodule), Matchers.is("NEW CONTENT OF FILE"));
+    }
+
+    @Test
+    public void shouldAllowSubmoduleUrlstoChange() throws Exception {
+        GitSubmoduleRepos submoduleRepos = new GitSubmoduleRepos();
+        String submoduleDirectoryName = "local-submodule";
+        submoduleRepos.addSubmodule(SUBMODULE, submoduleDirectoryName);
+        GitMaterial material = new GitMaterial(submoduleRepos.projectRepositoryUrl(), true);
+        updateTo(material, new RevisionContext(new StringRevision("origin/HEAD")), JobResult.Passed);
+        submoduleRepos.changeSubmoduleUrl(submoduleDirectoryName);
+        updateTo(material, new RevisionContext(new StringRevision("origin/HEAD")), JobResult.Passed);
+        assertThat(console.output(), containsString("Synchronizing submodule url for 'local-submodule'"));
+    }
+
+    @Test
+    public void shouldOutputSubmoduleRevisionsAfterUpdate() throws Exception {
+        GitSubmoduleRepos submoduleRepos = new GitSubmoduleRepos();
+        submoduleRepos.addSubmodule(SUBMODULE, "sub1");
+        GitMaterial material = new GitMaterial(submoduleRepos.projectRepositoryUrl(), true);
+        updateTo(material, new RevisionContext(new StringRevision("origin/HEAD")), JobResult.Passed);
+        Matcher matcher = Pattern.compile(".*^\\s[a-f0-9A-F]{40} sub1 \\(heads/master\\)$.*", Pattern.MULTILINE | Pattern.DOTALL).matcher(console.output());
+        assertThat(matcher.matches(), Matchers.is(true));
+    }
+
+    @Test
+    public void shouldBombForFetchAndResetWhenSubmoduleUpdateFails() throws Exception {
+        GitSubmoduleRepos submoduleRepos = new GitSubmoduleRepos();
+        File submoduleFolder = submoduleRepos.addSubmodule(SUBMODULE, "sub1");
+        GitMaterial material = new GitMaterial(submoduleRepos.projectRepositoryUrl(), true);
+        FileUtils.deleteDirectory(submoduleFolder);
+        assertThat(submoduleFolder.exists(), Matchers.is(false));
+        updateTo(material, new RevisionContext(new StringRevision("origin/HEAD")), JobResult.Failed);
+        assertThat(console.output(), containsString(String.format("Clone of '%s' into submodule path 'sub1' failed", submoduleFolder.getAbsolutePath())));
+    }
+
+
+    private void updateTo(GitMaterial material, RevisionContext revisionContext, JobResult expectedResult) {
+        BuildSession buildSession = newBuildSession();
+        JobResult result = buildSession.build(new GitMaterialUpdater(material).updateTo("working", revisionContext));
+        assertThat(buildInfo(), result, is(expectedResult));
+    }
+    
+    private GitCommand localRepoFor(GitMaterial material) {
+        return new GitCommand(material.getFingerprint(), workingDir, GitMaterialConfig.DEFAULT_BRANCH, false);
+    }
+
+    private List<File> allFilesIn(File directory, String prefixOfFiles) {
+        return new ArrayList<>(FileUtils.listFiles(directory, andFileFilter(fileFileFilter(), prefixFileFilter(prefixOfFiles)), null));
+    }
+}
+

--- a/common/test/unit/com/thoughtworks/go/domain/AgentInstanceTest.java
+++ b/common/test/unit/com/thoughtworks/go/domain/AgentInstanceTest.java
@@ -102,7 +102,7 @@ public class AgentInstanceTest {
     public void shouldUpdateAgentBackToIdleAfterCancelledTaskFinishes() throws Exception {
         AgentInstance cancelled = AgentInstanceMother.cancelled();
 
-        AgentRuntimeInfo fromAgent = new AgentRuntimeInfo(cancelled.agentConfig().getAgentIdentifier(), AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null);
+        AgentRuntimeInfo fromAgent = new AgentRuntimeInfo(cancelled.agentConfig().getAgentIdentifier(), AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null, false);
         fromAgent.idle();
         cancelled.update(fromAgent);
 
@@ -113,7 +113,7 @@ public class AgentInstanceTest {
     public void shouldUpdateTheIntsallLocation() throws Exception {
         AgentInstance agentInstance = AgentInstance.createFromConfig(agentConfig, systemEnvironment);
         String installPath = "/var/lib/GoServer";
-        AgentRuntimeInfo newRuntimeInfo = new AgentRuntimeInfo(agentConfig.getAgentIdentifier(), AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null);
+        AgentRuntimeInfo newRuntimeInfo = new AgentRuntimeInfo(agentConfig.getAgentIdentifier(), AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null, false);
         newRuntimeInfo.setLocation(installPath);
         agentInstance.update(newRuntimeInfo);
 
@@ -124,7 +124,7 @@ public class AgentInstanceTest {
     public void shouldUpdateTheUsableSpace() throws Exception {
         AgentInstance agentInstance = AgentInstance.createFromConfig(agentConfig, systemEnvironment);
 
-        AgentRuntimeInfo newRuntimeInfo = new AgentRuntimeInfo(agentConfig.getAgentIdentifier(), AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null);
+        AgentRuntimeInfo newRuntimeInfo = new AgentRuntimeInfo(agentConfig.getAgentIdentifier(), AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null, false);
         newRuntimeInfo.setUsableSpace(1000L);
 
         assertThat(agentInstance.getUsableSpace(), is(not(newRuntimeInfo.getUsableSpace())));
@@ -135,7 +135,7 @@ public class AgentInstanceTest {
     @Test
     public void shouldAssignCertificateToApprovedAgent() {
         AgentInstance agentInstance = AgentInstance.createFromConfig(agentConfig, systemEnvironment);
-        agentInstance.update(new AgentRuntimeInfo(agentConfig.getAgentIdentifier(), AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null));
+        agentInstance.update(new AgentRuntimeInfo(agentConfig.getAgentIdentifier(), AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null, false));
 
         Registration entry = agentInstance.assignCertification();
         assertThat(entry.getChain().length, is(not(0)));
@@ -143,7 +143,7 @@ public class AgentInstanceTest {
 
     @Test
     public void shouldNotAssignCertificateToPendingAgent() {
-        AgentRuntimeInfo agentRuntimeInfo = AgentRuntimeInfo.fromServer(agentConfig, false, "/var/lib", 0L, "linux");
+        AgentRuntimeInfo agentRuntimeInfo = AgentRuntimeInfo.fromServer(agentConfig, false, "/var/lib", 0L, "linux", false);
         AgentInstance agentInstance = AgentInstance.createFromLiveAgent(agentRuntimeInfo, systemEnvironment
         );
 
@@ -157,7 +157,7 @@ public class AgentInstanceTest {
         AgentInstance agentInstance = AgentInstance.createFromConfig(agentConfig, systemEnvironment);
         Date time = agentInstance.getLastHeardTime();
         assertThat(time, is(nullValue()));
-        agentInstance.update(new AgentRuntimeInfo(agentConfig.getAgentIdentifier(), AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null));
+        agentInstance.update(new AgentRuntimeInfo(agentConfig.getAgentIdentifier(), AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null, false));
         time = agentInstance.getLastHeardTime();
         assertThat(time, is(not(nullValue())));
     }
@@ -165,18 +165,30 @@ public class AgentInstanceTest {
     @Test
     public void shouldUpdateTheLastHeardTime() throws Exception {
         AgentInstance agentInstance = AgentInstance.createFromConfig(agentConfig, systemEnvironment);
-        agentInstance.update(new AgentRuntimeInfo(agentConfig.getAgentIdentifier(), AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null));
+        agentInstance.update(new AgentRuntimeInfo(agentConfig.getAgentIdentifier(), AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null, false));
         Date time = agentInstance.getLastHeardTime();
         Thread.sleep(1000);
-        agentInstance.update(new AgentRuntimeInfo(agentConfig.getAgentIdentifier(), AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null));
+        agentInstance.update(new AgentRuntimeInfo(agentConfig.getAgentIdentifier(), AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null, false));
         Date newtime = agentInstance.getLastHeardTime();
         assertThat(newtime.after(time), is(true));
     }
 
     @Test
+    public void shouldUpdateSupportBuildCommandProtocolFlag() throws Exception {
+        AgentInstance agentInstance = AgentInstance.createFromConfig(agentConfig, systemEnvironment);
+        assertThat(agentInstance.getSupportsBuildCommandProtocol(), is(false));
+        agentInstance.update(new AgentRuntimeInfo(agentConfig.getAgentIdentifier(), AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null, false));
+        assertThat(agentInstance.getSupportsBuildCommandProtocol(), is(false));
+
+        agentInstance.update(new AgentRuntimeInfo(agentConfig.getAgentIdentifier(), AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null, true));
+        assertThat(agentInstance.getSupportsBuildCommandProtocol(), is(true));
+    }
+
+
+    @Test
     public void shouldUpdateIPForPhysicalMachineWhenUpChanged() throws Exception {
         AgentInstance agentInstance = AgentInstance.createFromConfig(agentConfig, systemEnvironment);
-        agentInstance.update(new AgentRuntimeInfo(new AgentIdentifier("ccedev01", "10.18.7.52", "uuid"), AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null));
+        agentInstance.update(new AgentRuntimeInfo(new AgentIdentifier("ccedev01", "10.18.7.52", "uuid"), AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null, false));
 
         assertThat(agentInstance.agentConfig().getIpAddress(), is("10.18.7.52"));
     }
@@ -191,7 +203,7 @@ public class AgentInstanceTest {
     }
 
     private AgentRuntimeInfo idleRuntimeInfo() {
-        AgentRuntimeInfo agentRuntimeInfo = new AgentRuntimeInfo(agentConfig.getAgentIdentifier(), AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null);
+        AgentRuntimeInfo agentRuntimeInfo = new AgentRuntimeInfo(agentConfig.getAgentIdentifier(), AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null, false);
         agentRuntimeInfo.idle();
         return agentRuntimeInfo;
     }
@@ -199,7 +211,7 @@ public class AgentInstanceTest {
     @Test
     public void shouldUpdateBuildingInfoWhenAgentIsBuilding() throws Exception {
         AgentInstance agentInstance = AgentInstance.createFromConfig(agentConfig, systemEnvironment);
-        AgentRuntimeInfo agentRuntimeInfo = new AgentRuntimeInfo(agentConfig.getAgentIdentifier(), AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null);
+        AgentRuntimeInfo agentRuntimeInfo = new AgentRuntimeInfo(agentConfig.getAgentIdentifier(), AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null, false);
         AgentBuildingInfo buildingInfo = new AgentBuildingInfo("running pipeline/stage/build", "buildLocator");
         agentRuntimeInfo.busy(buildingInfo);
         agentInstance.update(agentRuntimeInfo);
@@ -218,7 +230,7 @@ public class AgentInstanceTest {
     }
 
     private AgentRuntimeInfo cancelRuntimeInfo() {
-        AgentRuntimeInfo agentRuntimeInfo = new AgentRuntimeInfo(agentConfig.getAgentIdentifier(), AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null);
+        AgentRuntimeInfo agentRuntimeInfo = new AgentRuntimeInfo(agentConfig.getAgentIdentifier(), AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null, false);
         agentRuntimeInfo.busy(defaultBuildingInfo);
         agentRuntimeInfo.cancel();
         return agentRuntimeInfo;
@@ -227,7 +239,7 @@ public class AgentInstanceTest {
     @Test
     public void shouldNotChangeVirtualMachineIpAddress() throws Exception {
         AgentInstance virtual = AgentInstance.create(new AgentConfig("uuid", "ccedev01", "10.18.7.51"), true, systemEnvironment);
-        final AgentRuntimeInfo info = new AgentRuntimeInfo(new AgentIdentifier("ccedev01", "10.18.7.52", "uuid"), AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null);
+        final AgentRuntimeInfo info = new AgentRuntimeInfo(new AgentIdentifier("ccedev01", "10.18.7.52", "uuid"), AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null, false);
         boolean required = virtual.isIpChangeRequired(
                 info.getIpAdress());
         assertThat(required, is(false));
@@ -235,16 +247,16 @@ public class AgentInstanceTest {
 
     @Test
     public void shouldNotChangePendingAgentIpAddress() throws Exception {
-        AgentInstance pending = AgentInstance.createFromLiveAgent(new AgentRuntimeInfo(agentConfig.getAgentIdentifier(), AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null),
+        AgentInstance pending = AgentInstance.createFromLiveAgent(new AgentRuntimeInfo(agentConfig.getAgentIdentifier(), AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null, false),
                 systemEnvironment);
-        AgentRuntimeInfo info = new AgentRuntimeInfo(new AgentIdentifier("ccedev01", "10.18.7.52", "uuid"), AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null);
+        AgentRuntimeInfo info = new AgentRuntimeInfo(new AgentIdentifier("ccedev01", "10.18.7.52", "uuid"), AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null, false);
         assertThat(pending.isIpChangeRequired(info.getIpAdress()), is(false));
     }
 
     @Test
     public void shouldChangeIpWhenSameAgentIpChanged() throws Exception {
         AgentInstance instance = AgentInstance.createFromConfig(agentConfig, systemEnvironment);
-        AgentRuntimeInfo info = new AgentRuntimeInfo(new AgentIdentifier("ccedev01", "10.18.7.52", "uuid"), AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null);
+        AgentRuntimeInfo info = new AgentRuntimeInfo(new AgentIdentifier("ccedev01", "10.18.7.52", "uuid"), AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null, false);
         assertThat(instance.isIpChangeRequired(info.getIpAdress()), is(true));
     }
 
@@ -263,7 +275,7 @@ public class AgentInstanceTest {
 
     @Test
     public void pendingAgentshouldNotBeRegistered() throws Exception {
-        AgentRuntimeInfo agentRuntimeInfo = new AgentRuntimeInfo(agentConfig.getAgentIdentifier(), AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null);
+        AgentRuntimeInfo agentRuntimeInfo = new AgentRuntimeInfo(agentConfig.getAgentIdentifier(), AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null, false);
         AgentInstance instance = AgentInstance.createFromLiveAgent(agentRuntimeInfo, systemEnvironment
         );
         assertThat(instance.isRegistered(), is(false));
@@ -286,10 +298,10 @@ public class AgentInstanceTest {
 
     @Test
     public void shouldBecomeIdleAfterApprove() throws Exception {
-        AgentInstance instance = AgentInstance.createFromLiveAgent(new AgentRuntimeInfo(agentConfig.getAgentIdentifier(), AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null),
+        AgentInstance instance = AgentInstance.createFromLiveAgent(new AgentRuntimeInfo(agentConfig.getAgentIdentifier(), AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null, false),
                 systemEnvironment);
         instance.enable();
-        instance.update(new AgentRuntimeInfo(agentConfig.getAgentIdentifier(), AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null));
+        instance.update(new AgentRuntimeInfo(agentConfig.getAgentIdentifier(), AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null, false));
         assertThat(instance.getStatus(), is(AgentStatus.Idle));
     }
 
@@ -311,7 +323,7 @@ public class AgentInstanceTest {
         });
         assertThat(instance.getStatus(), is(AgentStatus.Missing));
 
-        instance.update(new AgentRuntimeInfo(agentConfig.getAgentIdentifier(), AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null));
+        instance.update(new AgentRuntimeInfo(agentConfig.getAgentIdentifier(), AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null, false));
         instance.refresh(null);
         assertThat(instance.getStatus(), is(AgentStatus.LostContact));
     }
@@ -324,14 +336,14 @@ public class AgentInstanceTest {
                 return -1;
             }
         });
-        instance.update(new AgentRuntimeInfo(agentConfig.getAgentIdentifier(), AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null));
+        instance.update(new AgentRuntimeInfo(agentConfig.getAgentIdentifier(), AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null, false));
         instance.refresh(null);
         assertThat(instance.getStatus().getRuntimeStatus(), is(not(AgentRuntimeStatus.LostContact)));
     }
 
     @Test
     public void shouldDenyPendingAgent() throws Exception {
-        AgentRuntimeInfo agentRuntimeInfo = new AgentRuntimeInfo(agentConfig.getAgentIdentifier(), AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null);
+        AgentRuntimeInfo agentRuntimeInfo = new AgentRuntimeInfo(agentConfig.getAgentIdentifier(), AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null, false);
         AgentInstance instance = AgentInstance.createFromLiveAgent(agentRuntimeInfo, systemEnvironment
         );
         instance.deny();
@@ -351,7 +363,7 @@ public class AgentInstanceTest {
     public void shouldSyncIPWithConfig() {
         AgentInstance original = AgentInstance.createFromConfig(agentConfig, systemEnvironment);
 
-        original.update(new AgentRuntimeInfo(new AgentIdentifier("CCeDev01", "10.18.5.2", "uuid2"), AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null));
+        original.update(new AgentRuntimeInfo(new AgentIdentifier("CCeDev01", "10.18.5.2", "uuid2"), AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null, false));
 
         assertThat(original.agentConfig(), is(new AgentConfig("uuid2", "CCeDev01", "10.18.5.2")));
     }
@@ -394,7 +406,7 @@ public class AgentInstanceTest {
                 return 100 * 1024 * 1024;
             }
         });
-        AgentRuntimeInfo newRuntimeInfo = new AgentRuntimeInfo(agentConfig.getAgentIdentifier(), AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null);
+        AgentRuntimeInfo newRuntimeInfo = new AgentRuntimeInfo(agentConfig.getAgentIdentifier(), AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null, false);
         long is110M = 110 * 1024 * 1024;
         newRuntimeInfo.setUsableSpace(is110M);
         original.update(newRuntimeInfo);
@@ -409,7 +421,7 @@ public class AgentInstanceTest {
                 return 100 * 1024 * 1024;
             }
         });
-        AgentRuntimeInfo newRuntimeInfo = new AgentRuntimeInfo(agentConfig.getAgentIdentifier(), AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null);
+        AgentRuntimeInfo newRuntimeInfo = new AgentRuntimeInfo(agentConfig.getAgentIdentifier(), AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null, false);
         long is90M = 90 * 1024 * 1024;
         newRuntimeInfo.setUsableSpace(is90M);
         original.update(newRuntimeInfo);
@@ -589,7 +601,7 @@ public class AgentInstanceTest {
     }
 
     private AgentRuntimeInfo buildingRuntimeInfo(AgentConfig agentConfig) {
-        AgentRuntimeInfo runtimeInfo = new AgentRuntimeInfo(agentConfig.getAgentIdentifier(), AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null);
+        AgentRuntimeInfo runtimeInfo = new AgentRuntimeInfo(agentConfig.getAgentIdentifier(), AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null, false);
         runtimeInfo.busy(defaultBuildingInfo);
         return runtimeInfo;
     }

--- a/common/test/unit/com/thoughtworks/go/domain/ArtifactsRepositoryStub.java
+++ b/common/test/unit/com/thoughtworks/go/domain/ArtifactsRepositoryStub.java
@@ -1,0 +1,90 @@
+/*************************** GO-LICENSE-START*********************************
+ * Copyright 2016 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ************************GO-LICENSE-END***********************************/
+package com.thoughtworks.go.domain;
+
+import com.thoughtworks.go.buildsession.ArtifactsRepository;
+import com.thoughtworks.go.util.command.StreamConsumer;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class ArtifactsRepositoryStub implements ArtifactsRepository {
+
+    private final List<FileUpload> fileUploaded;
+    private final Properties properties;
+    private RuntimeException error;
+
+    public static class FileUpload {
+        public File file;
+        public String destPath;
+        public String buildId;
+
+        @Override
+        public String toString() {
+            return "FileUpload{" +
+                    "file=" + file +
+                    ", destPath='" + destPath + '\'' +
+                    ", buildId='" + buildId + '\'' +
+                    '}';
+        }
+    }
+
+    public ArtifactsRepositoryStub() {
+        fileUploaded = Collections.synchronizedList(new ArrayList<FileUpload>());
+        this.properties = new Properties();
+    }
+
+    @Override
+    public void upload(StreamConsumer console, File file, String destPath, String buildId) {
+        if(this.error != null) {
+            throw error;
+        }
+        FileUpload fu = new FileUpload();
+        fu.file = file;
+        fu.destPath = destPath;
+        fu.buildId = buildId;
+        fileUploaded.add(fu);
+    }
+
+    @Override
+    public void setProperty(Property property) {
+        this.properties.add(property);
+    }
+
+    public String propertyValue(String name) {
+        return properties.getValue(name);
+    }
+
+
+    public List<FileUpload> getFileUploaded() {
+        return fileUploaded;
+    }
+    public void setUploadError(RuntimeException error) {
+        this.error = error;
+    }
+
+    public boolean isFileUploaded(File file, String dest) throws IOException {
+        for (FileUpload fileUpload : fileUploaded) {
+            if(file.getCanonicalFile().equals(fileUpload.file.getCanonicalFile()) && dest.equals(fileUpload.destPath)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/common/test/unit/com/thoughtworks/go/domain/BuildCommandTest.java
+++ b/common/test/unit/com/thoughtworks/go/domain/BuildCommandTest.java
@@ -1,0 +1,63 @@
+/*************************GO-LICENSE-START*********************************
+ * Copyright 2016 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *************************GO-LICENSE-END***********************************/
+
+package com.thoughtworks.go.domain;
+
+import com.google.gson.Gson;
+import com.thoughtworks.go.websocket.MessageEncoding;
+import org.junit.Test;
+
+import static com.thoughtworks.go.util.MapBuilder.map;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+
+public class BuildCommandTest {
+
+    @Test
+    public void testGetArgs() {
+        assertThat(new BuildCommand("foo", map("foo", new Gson().toJson(new String[]{"arg1", "arg2"}))).getArrayArg("foo"), is(new String[]{"arg1","arg2"}));
+        assertThat(new BuildCommand("foo", map("foo", "true")).getBooleanArg("foo"), is(true));
+        assertThat(new BuildCommand("foo", map("foo", "true")).getBooleanArg("bar"), is(false));
+        assertThat(new BuildCommand("foo", map("foo", "bar")).getStringArg("foo"), is("bar"));
+    }
+
+
+    @Test
+    public void defaultSubCommandsShouldBeEmpty() {
+        assertThat(new BuildCommand("foo").getSubCommands().size(), is(0));
+        assertThat(new BuildCommand("foo", map("arg1", "42")).getSubCommands().size(), is(0));
+    }
+
+    @Test
+    public void testDumpComposedCommand() {
+        assertThat(BuildCommand.compose(new BuildCommand("bar1"), BuildCommand.compose(new BuildCommand("barz"))).dump(), is("compose\n    bar1\n    compose\n        barz"));
+    }
+
+    @Test
+    public void defaultRunIfIsPassed() {
+        assertThat(new BuildCommand("cmd").getRunIfConfig(), is("passed"));
+        assertThat(new BuildCommand("cmd").runIf("any").getRunIfConfig(), is("any"));
+    }
+
+    @Test
+    public void encodeDecode() {
+        BuildCommand bc = BuildCommand.compose(new BuildCommand("bar1", map("arg1", "1", "arg2", "2")), BuildCommand.compose(new BuildCommand("barz")));
+        bc.setRunIfConfig("any");
+        bc.setTest(new BuildCommand("t", map("k1", "v1")));
+        bc.setOnCancel(BuildCommand.compose(BuildCommand.echo("foo"), BuildCommand.echo("bar")));
+        assertThat(MessageEncoding.decodeData(MessageEncoding.encodeData(bc), BuildCommand.class), is(bc));
+    }
+}

--- a/common/test/unit/com/thoughtworks/go/domain/BuildStateReporterStub.java
+++ b/common/test/unit/com/thoughtworks/go/domain/BuildStateReporterStub.java
@@ -1,0 +1,64 @@
+/*************************** GO-LICENSE-START*********************************
+ * Copyright 2016 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ************************GO-LICENSE-END***********************************/
+package com.thoughtworks.go.domain;
+
+import com.thoughtworks.go.buildsession.BuildStateReporter;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class BuildStateReporterStub implements BuildStateReporter {
+
+    private List<JobState> reportedBuildStatus;
+    private List<JobResult> reportedBuildResult;
+
+    public BuildStateReporterStub() {
+        reportedBuildStatus = Collections.synchronizedList(new ArrayList<JobState>());
+        reportedBuildResult = Collections.synchronizedList(new ArrayList<JobResult>());
+    }
+
+    @Override
+    public void reportBuildStatus(String buildId, JobState buildState) {
+        reportedBuildStatus.add(buildState);
+    }
+
+    @Override
+    public void reportCompleted(String buildId, JobResult buildResult) {
+        reportedBuildStatus.add(JobState.Completed);
+        reportedBuildResult.add(buildResult);
+    }
+
+    @Override
+    public void reportCompleting(String buildId, JobResult buildResult) {
+        reportedBuildResult.add(buildResult);
+    }
+
+    public List<JobState> status() {
+        return reportedBuildStatus;
+    }
+
+    public List<JobResult> results() {
+        return reportedBuildResult;
+    }
+
+    public JobResult singleResult() {
+        if(results().size() != 1) {
+            throw new RuntimeException("Expect single result but was: " + results());
+        }
+        return results().get(0);
+    }
+}

--- a/common/test/unit/com/thoughtworks/go/domain/UnitTestReportGeneratorTest.java
+++ b/common/test/unit/com/thoughtworks/go/domain/UnitTestReportGeneratorTest.java
@@ -78,7 +78,7 @@ public class UnitTestReportGeneratorTest {
 
 
         copyAndClose(source("TestResult.xml"), target("test-result.xml"));
-        final Properties properties = generator.generate(testFolder.listFiles());
+        final Properties properties = generator.generate(testFolder.listFiles(), "testoutput");
         assertThat(testFolder.listFiles().length, is(2));
     }
 
@@ -95,7 +95,7 @@ public class UnitTestReportGeneratorTest {
         });
 
         copyAndClose(source("NunitTestResultWithByteOrderMark.xml"), target("test-result.xml"));
-        generator.generate(testFolder.listFiles());
+        generator.generate(testFolder.listFiles(), "testoutput");
         assertThat(testFolder.listFiles().length, is(2));
     }
 
@@ -104,7 +104,7 @@ public class UnitTestReportGeneratorTest {
         expectZeroedProperties();
 
         suppressConsoleOutput();
-        generator.generate(testFolder.listFiles());
+        generator.generate(testFolder.listFiles(), "testoutput");
         restoreConsoleOutput();
     }
 
@@ -124,7 +124,7 @@ public class UnitTestReportGeneratorTest {
         copyAndClose(source("empty.xml"), target("empty.xml"));
 
         suppressConsoleOutput();
-        generator.generate(testFolder.listFiles());
+        generator.generate(testFolder.listFiles(), "testoutput");
         restoreConsoleOutput();
     }
 
@@ -156,7 +156,7 @@ public class UnitTestReportGeneratorTest {
         copyAndClose(source("InvalidTestResult.xml"), target("Invalid.xml"));
 
         suppressConsoleOutput();
-        generator.generate(testFolder.listFiles());
+        generator.generate(testFolder.listFiles(), "testoutput");
         restoreConsoleOutput();
     }
 
@@ -177,7 +177,7 @@ public class UnitTestReportGeneratorTest {
         copyAndClose(source("xml_samples/Coverage.xml"), target("Coverage.xml"));
 
         suppressConsoleOutput();
-        generator.generate(testFolder.listFiles());
+        generator.generate(testFolder.listFiles(), "testoutput");
         restoreConsoleOutput();
     }
 
@@ -195,7 +195,7 @@ public class UnitTestReportGeneratorTest {
 
         copyAndClose(source("SerializableProjectConfigUtilTest.xml"), target("AgentTest.xml"));
 
-        generator.generate(testFolder.listFiles());
+        generator.generate(testFolder.listFiles(), "testoutput");
     }
 
     @Test
@@ -215,7 +215,7 @@ public class UnitTestReportGeneratorTest {
         copyAndClose(source("SerializableProjectConfigUtilTest.xml"),
                 target("SerializableProjectConfigUtilTest.xml"));
 
-        generator.generate(testFolder.listFiles());
+        generator.generate(testFolder.listFiles(), "testoutput");
     }
 
     @Test
@@ -233,7 +233,7 @@ public class UnitTestReportGeneratorTest {
         copyAndClose(source("TestReport-Integration.xml"), target("test-result1.xml"));
         copyAndClose(source("TestReport-Unit.xml"), target("test-result2.xml"));
 
-        generator.generate(testFolder.listFiles());
+        generator.generate(testFolder.listFiles(), "testoutput");
     }
 
     @Test
@@ -257,7 +257,7 @@ public class UnitTestReportGeneratorTest {
         copyAndClose(source("xml_samples/TestResult.xml"), target("reports/TestResult.xml"));
 
         suppressConsoleOutput();
-        generator.generate(testFolder.listFiles());
+        generator.generate(testFolder.listFiles(), "testoutput");
         restoreConsoleOutput();
     }
 

--- a/common/test/unit/com/thoughtworks/go/domain/builder/FetchArtifactBuilderBuildCommandTest.java
+++ b/common/test/unit/com/thoughtworks/go/domain/builder/FetchArtifactBuilderBuildCommandTest.java
@@ -1,0 +1,144 @@
+/*************************GO-LICENSE-START*********************************
+ * Copyright 2014 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *************************GO-LICENSE-END***********************************/
+
+package com.thoughtworks.go.domain.builder;
+
+import com.thoughtworks.go.buildsession.BuildSessionBasedTestCase;
+import com.thoughtworks.go.domain.*;
+import com.thoughtworks.go.util.*;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.util.zip.Deflater;
+
+import static java.lang.String.format;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsNot.not;
+import static org.junit.Assert.assertThat;
+
+public class FetchArtifactBuilderBuildCommandTest extends BuildSessionBasedTestCase {
+    private File zip;
+
+    @Before
+    public void setUp() throws Exception {
+        File folder = TestFileUtil.createTempFolder("log");
+        File consolelog = new File(folder, "console.log");
+        folder.mkdirs();
+        consolelog.createNewFile();
+        zip = new ZipUtil().zip(folder, TestFileUtil.createUniqueTempFile(folder.getName()), Deflater.NO_COMPRESSION);
+    }
+
+
+    @Test
+    public void shouldUnzipWhenFetchingFolder() throws Exception {
+        httpService.setupDownload(format("%s/remoting/files/cruise/1/dev/1/windows/log.zip", new URLService().baseRemoteURL()), zip);
+
+        FetchArtifactBuilder builder = getBuilder(new JobIdentifier("cruise", -10, "1", "dev", "1", "windows", 1L), "log", "dest", new DirHandler("log", new File("pipelines/cruise/dest")));
+        runBuilder(builder, JobResult.Passed);
+        assertDownloaded(new File(sandbox, "pipelines/cruise/dest"));
+    }
+
+    @Test
+    public void shouldGiveWarningWhenMd5FileNotExists() throws Exception {
+        httpService.setupDownload(format("%s/remoting/files/cruise/1/dev/1/windows/a.jar", new URLService().baseRemoteURL()), "some content");
+
+        FetchArtifactBuilder builder = getBuilder(new JobIdentifier("cruise", -1, "1", "dev", "1", "windows", 1L), "a.jar", "foo", new FileHandler(new File("pipelines/cruise/foo/a.jar"), "a.jar"));
+
+        runBuilder(builder, JobResult.Passed);
+        assertThat(new File(sandbox, "pipelines/cruise/foo/a.jar").isFile(), is(true));
+        assertThat(console.output(), containsString("[WARN] The md5checksum property file was not found"));
+    }
+
+    @Test
+    public void shouldFailBuildWhenChecksumNotValidForArtifact() throws Exception {
+        httpService.setupDownload(format("%s/remoting/files/cruise/1/dev/1/windows/cruise-output/md5.checksum", new URLService().baseRemoteURL()), "a.jar=invalid-checksum");
+        httpService.setupDownload(format("%s/remoting/files/cruise/1/dev/1/windows/a.jar", new URLService().baseRemoteURL()), "some content");
+
+        FetchArtifactBuilder builder = getBuilder(new JobIdentifier("cruise", -1, "1", "dev", "1", "windows", 1L), "a.jar", "foo", new FileHandler(new File("pipelines/cruise/foo/a.jar"), "a.jar"));
+        runBuilder(builder, JobResult.Failed);
+        assertThat(console.output(), containsString("[ERROR] Verification of the integrity of the artifact [a.jar] failed"));
+        assertThat(new File(sandbox, "pipelines/cruise/foo/a.jar").isFile(), is(true));
+    }
+
+    @Test
+    public void shouldBuildWhenChecksumValidForArtifact() throws Exception {
+        httpService.setupDownload(format("%s/remoting/files/cruise/1/dev/1/windows/cruise-output/md5.checksum", new URLService().baseRemoteURL()), "a.jar=9893532233caff98cd083a116b013c0b");
+        httpService.setupDownload(format("%s/remoting/files/cruise/1/dev/1/windows/a.jar", new URLService().baseRemoteURL()), "some content");
+
+        FetchArtifactBuilder builder = getBuilder(new JobIdentifier("cruise", -1, "1", "dev", "1", "windows", 1L), "a.jar", "foo", new FileHandler(new File("pipelines/cruise/foo/a.jar"), "a.jar"));
+        runBuilder(builder, JobResult.Passed);
+        assertThat(console.output(), containsString(format("Saved artifact to [%s] after verifying the integrity of its contents", new File(sandbox, "pipelines/cruise/foo/a.jar").getPath())));
+    }
+
+    @Test
+    public void shouldFailBuildAndPrintErrorMessageToConsoleWhenArtifactNotExisit() throws Exception {
+        FetchArtifactBuilder builder = getBuilder(new JobIdentifier("cruise", -1, "1", "dev", "1", "windows", 1L), "a.jar", "foo", new FileHandler(new File("pipelines/cruise/foo/a.jar"), "a.jar"));
+        runBuilder(builder, JobResult.Failed);
+        assertThat(console.output(), not(containsString("Saved artifact")));
+        assertThat(console.output(), containsString("Could not fetch artifact"));
+    }
+
+    @Test
+    public void shouldDownloadWithURLContainsSHA1WhenFileExists() throws Exception {
+        File artifactOnAgent = new File(sandbox, "pipelines/cruise/foo/a.jar");
+        new File(sandbox, "pipelines/cruise/foo").mkdirs();
+        FileUtil.writeContentToFile("foobar", artifactOnAgent);
+        String sha1 = java.net.URLEncoder.encode(StringUtil.sha1Digest(artifactOnAgent), "UTF-8");
+
+        httpService.setupDownload(format("%s/remoting/files/cruise/1/dev/1/windows/a.jar", new URLService().baseRemoteURL()), "content for url without sha1");
+
+        httpService.setupDownload(format("%s/remoting/files/cruise/1/dev/1/windows/a.jar?sha1=%s", new URLService().baseRemoteURL(), sha1), "content for url with sha1");
+
+
+        FetchArtifactBuilder builder = getBuilder(new JobIdentifier("cruise", -1, "1", "dev", "1", "windows", 1L), "a.jar", "foo", new FileHandler(new File("pipelines/cruise/foo/a.jar"), "a.jar"));
+
+        runBuilder(builder, JobResult.Passed);
+        assertThat(artifactOnAgent.isFile(), is(true));
+        assertThat(FileUtil.readContentFromFile(artifactOnAgent), is("content for url with sha1"));
+    }
+
+
+    private void assertDownloaded(File destOnAgent) {
+        File logFolder = new File(destOnAgent, "log");
+        assertThat(logFolder.exists(), is(true));
+        assertThat(logFolder.isDirectory(), is(true));
+        assertThat(new File(logFolder, "console.log").exists(), is(true));
+        assertThat(destOnAgent.listFiles(), is(new File[]{logFolder}));
+    }
+
+
+    private void runBuilder(FetchArtifactBuilder builder, JobResult expectedResult) {
+        BuildCommand buildCommand = builder.buildCommand();
+        JobResult result = newBuildSession().build(buildCommand);
+        assertThat(buildInfo(), result, is(expectedResult));
+    }
+
+    private String getSrc() {
+        return "";
+    }
+
+    private FetchArtifactBuilder getBuilder(JobIdentifier jobLocator, String srcdir, String dest, FetchHandler handler) {
+        return new FetchArtifactBuilder(new RunIfConfigs(), new NullBuilder(), "", jobLocator, srcdir, dest, handler, new ChecksumFileHandler(checksumFile(jobLocator, srcdir, dest)));
+    }
+
+    private File checksumFile(JobIdentifier jobIdentifier, String srcdir, String dest) {
+        File destOnAgent = new File("pipelines" + '/' + jobIdentifier.getPipelineName() + '/' + dest);
+        return new File(destOnAgent, String.format("%s_%s_%s_md5.checksum", jobIdentifier.getPipelineName(), jobIdentifier.getStageName(), jobIdentifier.getBuildName()));
+    }
+
+}

--- a/common/test/unit/com/thoughtworks/go/domain/builder/FetchArtifactBuilderTest.java
+++ b/common/test/unit/com/thoughtworks/go/domain/builder/FetchArtifactBuilderTest.java
@@ -1,5 +1,5 @@
 /*************************GO-LICENSE-START*********************************
- * Copyright 2014 ThoughtWorks, Inc.
+ * Copyright 2016 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/test/unit/com/thoughtworks/go/helper/AgentInstanceMother.java
+++ b/common/test/unit/com/thoughtworks/go/helper/AgentInstanceMother.java
@@ -42,7 +42,7 @@ public class AgentInstanceMother {
         AgentConfig virtualAgentConfig = new AgentConfig("uuid1", "ec2", "10.18.8.10");
         AgentInstance instance = AgentInstance.create(virtualAgentConfig, true, new SystemEnvironment()
         );
-        instance.update(new AgentRuntimeInfo(virtualAgentConfig.getAgentIdentifier(), AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null));
+        instance.update(new AgentRuntimeInfo(virtualAgentConfig.getAgentIdentifier(), AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null, false));
         return instance;
     }
 
@@ -57,7 +57,7 @@ public class AgentInstanceMother {
 
     public static AgentInstance idle(final Date lastHeardAt, final String hostname)  {
         AgentConfig idleAgentConfig = new AgentConfig("uuid2", hostname, "10.18.5.1");
-        AgentRuntimeInfo agentRuntimeInfo = new AgentRuntimeInfo(idleAgentConfig.getAgentIdentifier(), AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null);
+        AgentRuntimeInfo agentRuntimeInfo = new AgentRuntimeInfo(idleAgentConfig.getAgentIdentifier(), AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null, false);
         agentRuntimeInfo.setLocation("/var/lib/foo");
         agentRuntimeInfo.idle();
         agentRuntimeInfo.setUsableSpace(10*1024l);
@@ -74,7 +74,7 @@ public class AgentInstanceMother {
 
     public static AgentInstance building(String buildLocator) {
         AgentConfig buildingAgentConfig = new AgentConfig("uuid3", "CCeDev01", "10.18.5.1", new Resources("java"));
-        AgentRuntimeInfo agentRuntimeInfo = new AgentRuntimeInfo(buildingAgentConfig.getAgentIdentifier(), AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null);
+        AgentRuntimeInfo agentRuntimeInfo = new AgentRuntimeInfo(buildingAgentConfig.getAgentIdentifier(), AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null, false);
         agentRuntimeInfo.busy(new AgentBuildingInfo("pipeline", buildLocator));
         AgentInstance building = AgentInstance.createFromConfig(buildingAgentConfig, new SystemEnvironment());
         building.update(agentRuntimeInfo);
@@ -83,7 +83,7 @@ public class AgentInstanceMother {
 
     public static AgentInstance pending() {
         AgentRuntimeInfo runtimeInfo = AgentRuntimeInfo.fromServer(new AgentConfig("uuid4", "CCeDev03", "10.18.5.3", new Resources(new Resource("db"),new Resource("web"))), false,
-                "/var/lib", 0L, "linux");
+                "/var/lib", 0L, "linux", false);
         AgentInstance pending = AgentInstance.createFromLiveAgent(runtimeInfo, new SystemEnvironment()
         );
         pending.pending();
@@ -93,7 +93,7 @@ public class AgentInstanceMother {
     }
 
     public static AgentInstance pendingInstance() {
-        AgentRuntimeInfo runtimeInfo = new AgentRuntimeInfo(new AgentIdentifier("CCeDev03", "10.18.5.3", "uuid4"), AgentRuntimeStatus.Idle, currentWorkingDirectory(), null, null);
+        AgentRuntimeInfo runtimeInfo = new AgentRuntimeInfo(new AgentIdentifier("CCeDev03", "10.18.5.3", "uuid4"), AgentRuntimeStatus.Idle, currentWorkingDirectory(), null, null, false);
         return AgentInstance.createFromLiveAgent(runtimeInfo, new SystemEnvironment());
     }
 
@@ -110,14 +110,14 @@ public class AgentInstanceMother {
 
     public static AgentInstance updateUsableSpace(AgentInstance agentInstance, Long freespace) {
         AgentConfig agentConfig = agentInstance.agentConfig();
-        agentInstance.update(AgentRuntimeInfo.fromServer(agentConfig, true, agentInstance.getLocation(), freespace, "linux"));
+        agentInstance.update(AgentRuntimeInfo.fromServer(agentConfig, true, agentInstance.getLocation(), freespace, "linux", false));
         return agentInstance;
     }
 
 
     public static AgentInstance updateOS(AgentInstance agentInstance, String operatingSystem) {
         AgentConfig agentConfig = agentInstance.agentConfig();
-        AgentRuntimeInfo newRuntimeInfo = AgentRuntimeInfo.fromServer(agentConfig, true, agentInstance.getLocation(), agentInstance.getUsableSpace(), operatingSystem);
+        AgentRuntimeInfo newRuntimeInfo = AgentRuntimeInfo.fromServer(agentConfig, true, agentInstance.getLocation(), agentInstance.getUsableSpace(), operatingSystem, false);
         newRuntimeInfo.setStatus(agentInstance.getStatus());
         agentInstance.update(newRuntimeInfo);
         return agentInstance;
@@ -131,7 +131,7 @@ public class AgentInstanceMother {
 
     public static AgentInstance updateLocation(AgentInstance agentInstance, String location) {
         AgentConfig agentConfig = agentInstance.agentConfig();
-        agentInstance.update(AgentRuntimeInfo.fromServer(agentConfig, true, location, agentInstance.getUsableSpace(), "linux"));
+        agentInstance.update(AgentRuntimeInfo.fromServer(agentConfig, true, location, agentInstance.getUsableSpace(), "linux", agentInstance.getSupportsBuildCommandProtocol()));
         return agentInstance;
     }
 
@@ -143,7 +143,7 @@ public class AgentInstanceMother {
 
     public static AgentInstance updateRuntimeStatus(AgentInstance agentInstance, AgentRuntimeStatus status) {
         AgentConfig agentConfig = agentInstance.agentConfig();
-        AgentRuntimeInfo newRuntimeInfo = AgentRuntimeInfo.fromServer(agentConfig, true, agentInstance.getLocation(), agentInstance.getUsableSpace(), "linux");
+        AgentRuntimeInfo newRuntimeInfo = AgentRuntimeInfo.fromServer(agentConfig, true, agentInstance.getLocation(), agentInstance.getUsableSpace(), "linux", false);
         newRuntimeInfo.setRuntimeStatus(status, null);
         agentInstance.update(newRuntimeInfo);
         return agentInstance;
@@ -151,7 +151,7 @@ public class AgentInstanceMother {
 
     public static AgentInstance updateAgentLauncherVersion(AgentInstance agentInstance, String agentLauncherVersion) {
         AgentRuntimeInfo newRuntimeInfo = AgentRuntimeInfo.fromServer(agentInstance.agentConfig(), agentInstance.isRegistered(), agentInstance.getLocation(), agentInstance.getUsableSpace(),
-                agentInstance.getOperatingSystem());
+                agentInstance.getOperatingSystem(), false);
         newRuntimeInfo.setAgentLauncherVersion(agentLauncherVersion);
         agentInstance.update(newRuntimeInfo);
         return agentInstance;

--- a/common/test/unit/com/thoughtworks/go/helper/TestStreamConsumer.java
+++ b/common/test/unit/com/thoughtworks/go/helper/TestStreamConsumer.java
@@ -1,6 +1,5 @@
 package com.thoughtworks.go.helper;
 
-import com.thoughtworks.go.util.StringUtil;
 import com.thoughtworks.go.util.command.StreamConsumer;
 import org.apache.commons.lang.StringUtils;
 
@@ -18,6 +17,11 @@ public class TestStreamConsumer implements StreamConsumer {
 
     public String output() {
         return StringUtils.join(lines, "\n");
+    }
+
+    @Override
+    public String toString() {
+        return output();
     }
 
     public List<String> asList() {

--- a/common/test/unit/com/thoughtworks/go/helper/TestStreamConsumer.java
+++ b/common/test/unit/com/thoughtworks/go/helper/TestStreamConsumer.java
@@ -40,11 +40,11 @@ public class TestStreamConsumer implements StreamConsumer {
     public void waitForContain(String content, int timeoutInSeconds) throws InterruptedException {
         long start = System.nanoTime();
         while (true) {
-            if (lines.contains(content)) {
+            if (output().contains(content)) {
                 break;
             }
             if (System.nanoTime() - start > TimeUnit.SECONDS.toNanos(timeoutInSeconds)) {
-                throw new RuntimeException("waiting timeout!");
+                throw new RuntimeException("waiting timeout!, current output is: \n" + output());
             }
             Thread.sleep(10);
         }

--- a/common/test/unit/com/thoughtworks/go/helper/TestStreamConsumer.java
+++ b/common/test/unit/com/thoughtworks/go/helper/TestStreamConsumer.java
@@ -1,6 +1,8 @@
 package com.thoughtworks.go.helper;
 
 import com.thoughtworks.go.util.command.StreamConsumer;
+import com.thoughtworks.go.utils.Assertions;
+import com.thoughtworks.go.utils.Timeout;
 import org.apache.commons.lang.StringUtils;
 
 import java.util.ArrayList;
@@ -41,17 +43,13 @@ public class TestStreamConsumer implements StreamConsumer {
         return lines.size();
     }
 
-    public void waitForContain(String content, int timeoutInSeconds) throws InterruptedException {
-        long start = System.nanoTime();
-        while (true) {
-            if (output().contains(content)) {
-                break;
+    public void waitForContain(final String content, Timeout timeout) throws InterruptedException {
+        Assertions.waitUntil(timeout, new Assertions.Predicate() {
+            @Override
+            public boolean call() throws Exception {
+                return output().contains(content);
             }
-            if (System.nanoTime() - start > TimeUnit.SECONDS.toNanos(timeoutInSeconds)) {
-                throw new RuntimeException("waiting timeout!, current output is: \n" + output());
-            }
-            Thread.sleep(10);
-        }
+        }, 1);
     }
 
     public void clear() {

--- a/common/test/unit/com/thoughtworks/go/helper/TestStreamConsumer.java
+++ b/common/test/unit/com/thoughtworks/go/helper/TestStreamConsumer.java
@@ -1,0 +1,57 @@
+package com.thoughtworks.go.helper;
+
+import com.thoughtworks.go.util.StringUtil;
+import com.thoughtworks.go.util.command.StreamConsumer;
+import org.apache.commons.lang.StringUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.concurrent.TimeUnit;
+
+public class TestStreamConsumer implements StreamConsumer {
+    private ConcurrentLinkedDeque<String> lines = new ConcurrentLinkedDeque<>();
+
+    public void consumeLine(String line) {
+        lines.add(line);
+    }
+
+    public String output() {
+        return StringUtils.join(lines, "\n");
+    }
+
+    public List<String> asList() {
+        return new ArrayList<>(lines);
+    }
+
+
+    public String lastLine() {
+        return lines.getLast();
+    }
+
+    public String firstLine() {
+        return lines.getFirst();
+    }
+
+    public int lineCount() {
+        return lines.size();
+    }
+
+    public void waitForContain(String content, int timeoutInSeconds) throws InterruptedException {
+        long start = System.nanoTime();
+        while (true) {
+            if (lines.contains(content)) {
+                break;
+            }
+            if (System.nanoTime() - start > TimeUnit.SECONDS.toNanos(timeoutInSeconds)) {
+                throw new RuntimeException("waiting timeout!");
+            }
+            Thread.sleep(10);
+        }
+    }
+
+    public void clear() {
+        lines.clear();
+    }
+
+}

--- a/common/test/unit/com/thoughtworks/go/publishers/GoArtifactsManipulatorTest.java
+++ b/common/test/unit/com/thoughtworks/go/publishers/GoArtifactsManipulatorTest.java
@@ -63,7 +63,7 @@ public class GoArtifactsManipulatorTest {
         tempFile = TestFileUtil.createTestFile(artifactFolder, "file.txt");
         goArtifactsManipulatorStub = new GoArtifactsManipulatorStub(httpService);
         jobIdentifier = new JobIdentifier("pipeline1", 1, "label-1", "stage1", "1", "job1");
-        AgentRuntimeInfo agentRuntimeInfo = new AgentRuntimeInfo(new AgentIdentifier("h", "1", "u"), AgentRuntimeStatus.Idle, currentWorkingDirectory(), null, null);
+        AgentRuntimeInfo agentRuntimeInfo = new AgentRuntimeInfo(new AgentIdentifier("h", "1", "u"), AgentRuntimeStatus.Idle, currentWorkingDirectory(), null, null, false);
         goPublisher = new DefaultGoPublisher(goArtifactsManipulatorStub, jobIdentifier, new BuildRepositoryRemoteStub(), agentRuntimeInfo);
     }
 

--- a/common/test/unit/com/thoughtworks/go/remote/work/AgentStatusReportingIntegrationTest.java
+++ b/common/test/unit/com/thoughtworks/go/remote/work/AgentStatusReportingIntegrationTest.java
@@ -48,7 +48,7 @@ public class AgentStatusReportingIntegrationTest {
         environmentVariableContext = new EnvironmentVariableContext();
         artifactManipulator = new GoArtifactsManipulatorStub();
         buildRepository = new BuildRepositoryRemoteStub();
-        this.agentRuntimeInfo = new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null);
+        this.agentRuntimeInfo = new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null, false);
     }
 
     @After
@@ -60,28 +60,28 @@ public class AgentStatusReportingIntegrationTest {
     public void shouldReportIdleWhenAgentRunningNoWork() {
         NoWork work = new NoWork();
         work.doWork(agentIdentifier, buildRepository, artifactManipulator, environmentVariableContext, agentRuntimeInfo, packageAsRepositoryExtension, scmExtension, taskExtension);
-        assertThat(agentRuntimeInfo, is(new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null)));
+        assertThat(agentRuntimeInfo, is(new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null, false)));
     }
 
     @Test
     public void shouldReportIdleWhenAgentCancelledNoWork() {
         NoWork work = new NoWork();
         work.cancel(environmentVariableContext, agentRuntimeInfo);
-        assertThat(agentRuntimeInfo, is(new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null)));
+        assertThat(agentRuntimeInfo, is(new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null, false)));
     }
 
     @Test
     public void shouldReportIdleWhenAgentRunningDeniedWork() {
         Work work = new DeniedAgentWork("uuid");
         work.doWork(agentIdentifier, buildRepository, artifactManipulator, environmentVariableContext, agentRuntimeInfo, packageAsRepositoryExtension, scmExtension, taskExtension);
-        assertThat(agentRuntimeInfo, is(new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null)));
+        assertThat(agentRuntimeInfo, is(new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null, false)));
     }
 
     @Test
     public void shouldReportIdleWhenAgentCancelledDeniedWork() {
         Work work = new DeniedAgentWork("uuid");
         work.cancel(environmentVariableContext, agentRuntimeInfo);
-        assertThat(agentRuntimeInfo, is(new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null)));
+        assertThat(agentRuntimeInfo, is(new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null, false)));
     }
 
     @Test
@@ -91,7 +91,7 @@ public class AgentStatusReportingIntegrationTest {
             work.doWork(agentIdentifier, buildRepository, artifactManipulator, environmentVariableContext, agentRuntimeInfo, packageAsRepositoryExtension, scmExtension, taskExtension);
         } catch (Exception e) {
         }
-        assertThat(agentRuntimeInfo, is(new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null)));
+        assertThat(agentRuntimeInfo, is(new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null, false)));
     }
 
     @Test
@@ -101,6 +101,6 @@ public class AgentStatusReportingIntegrationTest {
             work.cancel(environmentVariableContext, agentRuntimeInfo);
         } catch (Exception e) {
         }
-        assertThat(agentRuntimeInfo, is(new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null)));
+        assertThat(agentRuntimeInfo, is(new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null, false)));
     }
 }

--- a/common/test/unit/com/thoughtworks/go/remote/work/BuildRepositoryRemoteStub.java
+++ b/common/test/unit/com/thoughtworks/go/remote/work/BuildRepositoryRemoteStub.java
@@ -48,7 +48,7 @@ public class BuildRepositoryRemoteStub implements BuildRepositoryRemote {
     }
 
     public Work getWork(AgentRuntimeInfo runtimeInfo) {
-        return getWork(new AgentRuntimeInfo(new AgentIdentifier("localhost", "127.0.0.1", "uuid"), AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null));
+        return getWork(new AgentRuntimeInfo(new AgentIdentifier("localhost", "127.0.0.1", "uuid"), AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null, isIgnored));
     }
 
     public void reportCurrentStatus(AgentRuntimeInfo agentRuntimeInfo, JobIdentifier jobIdentifier, JobState jobState) {

--- a/common/test/unit/com/thoughtworks/go/remote/work/BuildWorkArtifactUploadingTest.java
+++ b/common/test/unit/com/thoughtworks/go/remote/work/BuildWorkArtifactUploadingTest.java
@@ -111,7 +111,7 @@ public class BuildWorkArtifactUploadingTest {
         GoArtifactsManipulatorStub manipulator = new GoArtifactsManipulatorStub();
 
         AgentIdentifier agentIdentifier = new AgentIdentifier("somename", "127.0.0.1", AGENT_UUID);
-        work.doWork(agentIdentifier, new FakeBuildRepositoryRemote(), manipulator, environmentVariableContext, new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null), packageAsRepositoryExtension, scmExtension, taskExtension);
+        work.doWork(agentIdentifier, new FakeBuildRepositoryRemote(), manipulator, environmentVariableContext, new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null, false), packageAsRepositoryExtension, scmExtension, taskExtension);
 
         List<UploadEntry> entries = manipulator.uploadEntries();
 
@@ -132,7 +132,7 @@ public class BuildWorkArtifactUploadingTest {
 
         AgentIdentifier agentIdentifier = new AgentIdentifier("somename", "127.0.0.1", AGENT_UUID);
         work.doWork(agentIdentifier, new FakeBuildRepositoryRemote(),
-                manipulator, environmentVariableContext, new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null), packageAsRepositoryExtension, scmExtension, taskExtension);
+                manipulator, environmentVariableContext, new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null, false), packageAsRepositoryExtension, scmExtension, taskExtension);
 
         List<UploadEntry> entries = manipulator.uploadEntries();
 
@@ -156,7 +156,7 @@ public class BuildWorkArtifactUploadingTest {
 
         AgentIdentifier agentIdentifier = new AgentIdentifier("somename", "127.0.0.1", AGENT_UUID);
         work.doWork(agentIdentifier, new FakeBuildRepositoryRemote(),
-                manipulator, environmentVariableContext, new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null), packageAsRepositoryExtension, scmExtension, taskExtension);
+                manipulator, environmentVariableContext, new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null, false), packageAsRepositoryExtension, scmExtension, taskExtension);
 
         List<UploadEntry> entries = manipulator.uploadEntries();
 
@@ -178,7 +178,7 @@ public class BuildWorkArtifactUploadingTest {
 
         AgentIdentifier agentIdentifier = new AgentIdentifier("somename", "127.0.0.1", AGENT_UUID);
         work.doWork(agentIdentifier, new FakeBuildRepositoryRemote(),
-                manipulator, environmentVariableContext, new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null), packageAsRepositoryExtension, scmExtension, taskExtension);
+                manipulator, environmentVariableContext, new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null, false), packageAsRepositoryExtension, scmExtension, taskExtension);
 
         List<UploadEntry> entries = manipulator.uploadEntries();
 
@@ -203,7 +203,7 @@ public class BuildWorkArtifactUploadingTest {
 
         AgentIdentifier agentIdentifier = new AgentIdentifier("somename", "127.0.0.1", AGENT_UUID);
         work.doWork(agentIdentifier, new FakeBuildRepositoryRemote(),
-                manipulator, environmentVariableContext, new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null), packageAsRepositoryExtension, scmExtension, taskExtension);
+                manipulator, environmentVariableContext, new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null, false), packageAsRepositoryExtension, scmExtension, taskExtension);
 
         List<UploadEntry> entries = manipulator.uploadEntries();
 
@@ -223,7 +223,7 @@ public class BuildWorkArtifactUploadingTest {
 
         AgentIdentifier agentIdentifier = new AgentIdentifier("somename", "127.0.0.1", AGENT_UUID);
         work.doWork(agentIdentifier, new FakeBuildRepositoryRemote(),
-                manipulator, environmentVariableContext, new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null), packageAsRepositoryExtension, scmExtension, taskExtension);
+                manipulator, environmentVariableContext, new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null, false), packageAsRepositoryExtension, scmExtension, taskExtension);
 
         List<UploadEntry> entries = manipulator.uploadEntries();
 
@@ -243,7 +243,7 @@ public class BuildWorkArtifactUploadingTest {
         BuildRepositoryRemoteStub repository = new BuildRepositoryRemoteStub();
 
         AgentIdentifier agentIdentifier = new AgentIdentifier("somename", "127.0.0.1", AGENT_UUID);
-        work.doWork(agentIdentifier, repository, manipulator, environmentVariableContext, new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null), packageAsRepositoryExtension, scmExtension, taskExtension);
+        work.doWork(agentIdentifier, repository, manipulator, environmentVariableContext, new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null, false), packageAsRepositoryExtension, scmExtension, taskExtension);
 
         List<UploadEntry> entries = manipulator.uploadEntries();
 
@@ -267,7 +267,7 @@ public class BuildWorkArtifactUploadingTest {
         BuildRepositoryRemoteStub repository = new BuildRepositoryRemoteStub();
 
         AgentIdentifier agentIdentifier = new AgentIdentifier("somename", "127.0.0.1", AGENT_UUID);
-        work.doWork(agentIdentifier, repository, manipulator, environmentVariableContext, new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null), packageAsRepositoryExtension, scmExtension, taskExtension);
+        work.doWork(agentIdentifier, repository, manipulator, environmentVariableContext, new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null, false), packageAsRepositoryExtension, scmExtension, taskExtension);
 
         List<UploadEntry> entries = manipulator.uploadEntries();
 
@@ -290,7 +290,7 @@ public class BuildWorkArtifactUploadingTest {
         BuildRepositoryRemoteStub repository = new BuildRepositoryRemoteStub();
 
         AgentIdentifier agentIdentifier = new AgentIdentifier("somename", "127.0.0.1", AGENT_UUID);
-        work.doWork(agentIdentifier, repository, manipulator, environmentVariableContext, new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null), packageAsRepositoryExtension, scmExtension, taskExtension);
+        work.doWork(agentIdentifier, repository, manipulator, environmentVariableContext, new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null, false), packageAsRepositoryExtension, scmExtension, taskExtension);
 
         List<UploadEntry> entries = manipulator.uploadEntries();
 
@@ -316,7 +316,7 @@ public class BuildWorkArtifactUploadingTest {
 
         AgentIdentifier agentIdentifier = new AgentIdentifier("somename", "127.0.0.1", AGENT_UUID);
         work.doWork(agentIdentifier, new FakeBuildRepositoryRemote(), manipulator, environmentVariableContext,
-                new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null), packageAsRepositoryExtension, scmExtension, taskExtension);
+                new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null, false), packageAsRepositoryExtension, scmExtension, taskExtension);
 
         List<UploadEntry> entries = manipulator.uploadEntries();
         assertThat(entries.isEmpty(), is(true));

--- a/common/test/unit/com/thoughtworks/go/remote/work/BuildWorkEnvironmentVariablesTest.java
+++ b/common/test/unit/com/thoughtworks/go/remote/work/BuildWorkEnvironmentVariablesTest.java
@@ -129,7 +129,7 @@ public class BuildWorkEnvironmentVariablesTest {
 
         AgentIdentifier agentIdentifier = new AgentIdentifier("somename", "127.0.0.1", AGENT_UUID);
         work.doWork(agentIdentifier, new FakeBuildRepositoryRemote(), new GoArtifactsManipulatorStub(),
-                environmentContext, new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null), packageAsRepositoryExtension, scmExtension, taskExtension);
+                environmentContext, new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null, false), packageAsRepositoryExtension, scmExtension, taskExtension);
 
         assertEnvironmentContext(environmentContext, "foo", is("bar"));
     }
@@ -172,7 +172,7 @@ public class BuildWorkEnvironmentVariablesTest {
         AgentIdentifier agentIdentifier = new AgentIdentifier("somename", "127.0.0.1", AGENT_UUID);
         work.doWork(agentIdentifier, new FakeBuildRepositoryRemote(),
                 new GoArtifactsManipulatorStub(),
-                environmentVariableContext, new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null), packageAsRepositoryExtension, scmExtension, taskExtension);
+                environmentVariableContext, new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null, false), packageAsRepositoryExtension, scmExtension, taskExtension);
 
         assertThat(environmentVariableContext.getProperty("GO_REVISION_CRUISE"), is("3"));
     }
@@ -196,7 +196,7 @@ public class BuildWorkEnvironmentVariablesTest {
 
         AgentIdentifier agentIdentifier = new AgentIdentifier("somename", "127.0.0.1", AGENT_UUID);
         work.doWork(agentIdentifier, new FakeBuildRepositoryRemote(),
-                manipulator, environmentVariableContext, new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null), packageAsRepositoryExtension, scmExtension, taskExtension);
+                manipulator, environmentVariableContext, new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null, false), packageAsRepositoryExtension, scmExtension, taskExtension);
 
         assertThat(manipulator.consoleOut(), printedEnvVariable("GO_SERVER_URL", "some_random_place"));
         assertThat(manipulator.consoleOut(), printedEnvVariable("GO_PIPELINE_NAME", PIPELINE_NAME));
@@ -275,7 +275,7 @@ public class BuildWorkEnvironmentVariablesTest {
         AgentIdentifier agentIdentifier = new AgentIdentifier("somename", "127.0.0.1", AGENT_UUID);
         work.doWork(agentIdentifier, new FakeBuildRepositoryRemote(),
                 new GoArtifactsManipulatorStub(),
-                environmentVariableContext, new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null), packageAsRepositoryExtension, scmExtension, taskExtension);
+                environmentVariableContext, new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null, false), packageAsRepositoryExtension, scmExtension, taskExtension);
         return environmentVariableContext;
     }
 }

--- a/common/test/unit/com/thoughtworks/go/remote/work/HttpServiceStub.java
+++ b/common/test/unit/com/thoughtworks/go/remote/work/HttpServiceStub.java
@@ -1,5 +1,5 @@
 /*************************GO-LICENSE-START*********************************
- * Copyright 2014 ThoughtWorks, Inc.
+ * Copyright 2016 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,18 +16,20 @@
 
 package com.thoughtworks.go.remote.work;
 
-import java.io.File;
-import java.io.IOException;
-import java.util.Map;
+import com.thoughtworks.go.domain.FetchHandler;
+import com.thoughtworks.go.util.HttpService;
+import org.apache.commons.io.IOUtils;
+
+import javax.servlet.http.HttpServletResponse;
+import java.io.*;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
-import java.util.ArrayList;
-import javax.servlet.http.HttpServletResponse;
-
-import com.thoughtworks.go.util.HttpService;
+import java.util.Map;
 
 public class HttpServiceStub extends HttpService {
     private Map<String, File> uploadedFiles = new HashMap<String, File>();
+    private Map<String, byte[]> downloadFiles = new HashMap<>();
     private List<String> uploadedFileUrls = new ArrayList<String>();
 
     private int returnCode;
@@ -51,5 +53,24 @@ public class HttpServiceStub extends HttpService {
     public Map<String, File> getUploadedFiles() {
         return uploadedFiles;
     }
+
+    @Override
+    public int download(String url, FetchHandler handler) throws IOException {
+        byte[] body = downloadFiles.get(url);
+        if(body == null) {
+            return HttpServletResponse.SC_NOT_FOUND;
+        }
+        handler.handle(new ByteArrayInputStream(body));
+        return returnCode;
+    }
+
+    public void setupDownload(String url, String body) {
+        downloadFiles.put(url, body.getBytes());
+    }
+
+    public void setupDownload(String url, File file) throws IOException {
+        downloadFiles.put(url, IOUtils.toByteArray(new FileInputStream(file)));
+    }
+
 }
 

--- a/common/test/unit/com/thoughtworks/go/security/RegistrationTest.java
+++ b/common/test/unit/com/thoughtworks/go/security/RegistrationTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2016 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.security;
+
+import com.thoughtworks.go.util.TestFileUtil;
+import org.junit.Test;
+
+import java.io.File;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+
+public class RegistrationTest {
+    private static String authorityKeystorePath = "tempAuthorityKeystore";
+
+    @Test
+    public void decodeFromJson() {
+        String json = createRegistration().toJson();
+        Registration reg = Registration.fromJson(json);
+        assertNotNull(reg.getPrivateKey());
+        assertThat(reg.getChain().length, is(3));
+    }
+
+    public static Registration createRegistration() {
+        File tempKeystoreFile = TestFileUtil.createUniqueTempFile(authorityKeystorePath);
+        X509CertificateGenerator certificateGenerator = new X509CertificateGenerator();
+        certificateGenerator.createAndStoreCACertificates(tempKeystoreFile);
+        return certificateGenerator.createAgentCertificate(tempKeystoreFile, "blah");
+    }
+
+}

--- a/common/test/unit/com/thoughtworks/go/security/RegistrationTest.java
+++ b/common/test/unit/com/thoughtworks/go/security/RegistrationTest.java
@@ -17,8 +17,10 @@
 package com.thoughtworks.go.security;
 
 import com.thoughtworks.go.util.TestFileUtil;
+import org.bouncycastle.asn1.x509.X509Name;
 import org.junit.Test;
 
+import javax.security.auth.x500.X500Principal;
 import java.io.File;
 
 import static org.hamcrest.Matchers.is;
@@ -30,9 +32,13 @@ public class RegistrationTest {
 
     @Test
     public void decodeFromJson() {
-        String json = createRegistration().toJson();
-        Registration reg = Registration.fromJson(json);
-        assertNotNull(reg.getPrivateKey());
+        Registration origin = createRegistration();
+        Registration reg = Registration.fromJson(origin.toJson());
+        assertThat(reg.getPrivateKey(), is(origin.getPrivateKey()));
+        assertThat(reg.getPublicKey(), is(origin.getPublicKey()));
+        assertThat(reg.getChain(), is(origin.getChain()));
+        assertThat(reg.getCertificateNotBeforeDate(), is(origin.getCertificateNotBeforeDate()));
+        assertThat(reg.getFirstCertificate(), is(origin.getFirstCertificate()));
         assertThat(reg.getChain().length, is(3));
     }
 

--- a/common/test/unit/com/thoughtworks/go/server/domain/AgentInstancesTest.java
+++ b/common/test/unit/com/thoughtworks/go/server/domain/AgentInstancesTest.java
@@ -1,5 +1,5 @@
 /*************************GO-LICENSE-START*********************************
- * Copyright 2014 ThoughtWorks, Inc.
+ * Copyright 2016 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -69,9 +69,9 @@ public class AgentInstancesTest {
     public void shouldUnderstandFilteringAgentListBasedOnUuid() {
         AgentInstances instances = new AgentInstances(null);
 
-        AgentRuntimeInfo agent1 = AgentRuntimeInfo.fromServer(new AgentConfig("uuid-1", "host-1", "192.168.1.2"), true, "/foo/bar", 100l, "linux");
-        AgentRuntimeInfo agent2 = AgentRuntimeInfo.fromServer(new AgentConfig("uuid-2", "host-2", "192.168.1.3"), true, "/bar/baz", 200l, "linux");
-        AgentRuntimeInfo agent3 = AgentRuntimeInfo.fromServer(new AgentConfig("uuid-3", "host-3", "192.168.1.4"), true, "/baz/quux", 300l, "linux");
+        AgentRuntimeInfo agent1 = AgentRuntimeInfo.fromServer(new AgentConfig("uuid-1", "host-1", "192.168.1.2"), true, "/foo/bar", 100l, "linux", false);
+        AgentRuntimeInfo agent2 = AgentRuntimeInfo.fromServer(new AgentConfig("uuid-2", "host-2", "192.168.1.3"), true, "/bar/baz", 200l, "linux", false);
+        AgentRuntimeInfo agent3 = AgentRuntimeInfo.fromServer(new AgentConfig("uuid-3", "host-3", "192.168.1.4"), true, "/baz/quux", 300l, "linux", false);
 
         AgentInstance instance1 = AgentInstance.createFromLiveAgent(agent1, new SystemEnvironment());
         instances.add(instance1);
@@ -223,8 +223,8 @@ public class AgentInstancesTest {
     public void agentHostnameShouldBeUnique() {
         AgentConfig agentConfig = new AgentConfig("uuid2", "CCeDev01", "10.18.5.1");
         AgentInstances agentInstances = new AgentInstances(null);
-        agentInstances.register(AgentRuntimeInfo.fromServer(agentConfig, false, "/var/lib", 0L, "linux"));
-        agentInstances.register(AgentRuntimeInfo.fromServer(agentConfig, false, "/var/lib", 0L, "linux"));
+        agentInstances.register(AgentRuntimeInfo.fromServer(agentConfig, false, "/var/lib", 0L, "linux", false));
+        agentInstances.register(AgentRuntimeInfo.fromServer(agentConfig, false, "/var/lib", 0L, "linux", false));
         assertThat(agentInstances.findPhysicalAgents().size(), is(1));
     }
 
@@ -339,7 +339,7 @@ public class AgentInstancesTest {
             int count = 0;
             while (!stop) {
                 AgentConfig agentConfig = new AgentConfig("uuid" + count, "CCeDev_" + count, "10.18.5." + count);
-                agentInstances.register(AgentRuntimeInfo.fromServer(agentConfig, false, "/var/lib", Long.MAX_VALUE, "linux"));
+                agentInstances.register(AgentRuntimeInfo.fromServer(agentConfig, false, "/var/lib", Long.MAX_VALUE, "linux", false));
                 count++;
             }
         }

--- a/common/test/unit/com/thoughtworks/go/server/service/ElasticAgentRuntimeInfoTest.java
+++ b/common/test/unit/com/thoughtworks/go/server/service/ElasticAgentRuntimeInfoTest.java
@@ -19,8 +19,10 @@ package com.thoughtworks.go.server.service;
 import com.thoughtworks.go.domain.AgentRuntimeStatus;
 import com.thoughtworks.go.domain.AgentStatus;
 import com.thoughtworks.go.remote.AgentIdentifier;
+import com.thoughtworks.go.websocket.MessageEncoding;
 import org.junit.Test;
 
+import static com.thoughtworks.go.util.SystemUtil.currentWorkingDirectory;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
 
@@ -40,5 +42,12 @@ public class ElasticAgentRuntimeInfoTest {
         assertThat(agentRuntimeInfo.getAgentLauncherVersion(), is(newRuntimeInfo.getAgentLauncherVersion()));
         assertThat(agentRuntimeInfo.getElasticAgentId(), is(newRuntimeInfo.getElasticAgentId()));
         assertThat(agentRuntimeInfo.getElasticPluginId(), is(newRuntimeInfo.getElasticPluginId()));
+    }
+
+    @Test
+    public void dataMapEncodingAndDecoding() {
+        AgentRuntimeInfo info = new ElasticAgentRuntimeInfo(new AgentIdentifier("localhost", "127.0.0.1", "uuid"), AgentRuntimeStatus.Idle, "/foo/one", null, null, "42", "go.cd.elastic-agent-plugin.docker");
+        AgentRuntimeInfo clonedInfo = MessageEncoding.decodeData(MessageEncoding.encodeData(info), AgentRuntimeInfo.class);
+        assertThat(clonedInfo, is(info));
     }
 }

--- a/common/test/unit/com/thoughtworks/go/util/FileUtilTest.java
+++ b/common/test/unit/com/thoughtworks/go/util/FileUtilTest.java
@@ -117,6 +117,11 @@ public class FileUtilTest {
     }
 
     @Test
+    public void shouldUseSpeficiedFolderIfBaseDirIsEmpty() throws Exception {
+        assertThat(FileUtil.applyBaseDirIfRelative(new File(""), new File("zx")), is(new File("zx")));
+    }
+
+    @Test
     public void shouldAppendToDefaultIfRelative() throws Exception {
         final File relativepath = new File("zx");
         assertThat(FileUtil.applyBaseDirIfRelative(new File("xyz"), relativepath),

--- a/common/test/unit/com/thoughtworks/go/util/MapBuilderTest.java
+++ b/common/test/unit/com/thoughtworks/go/util/MapBuilderTest.java
@@ -1,0 +1,72 @@
+/*************************** GO-LICENSE-START*********************************
+ * Copyright 2016 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ************************GO-LICENSE-END***********************************/
+package com.thoughtworks.go.util;
+
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+
+public class MapBuilderTest {
+
+    @Test
+    public void testEmptyMap() {
+        assertThat(MapBuilder.map(), is(Collections.emptyMap()));
+    }
+
+    @Test
+    public void testLengthTwo() {
+        Map<String, Integer> expected = new HashMap<>();
+        expected.put("foo", 23);
+        expected.put("s", 42);
+        assertThat(MapBuilder.map("foo", 23, "s", 42), is(expected));
+    }
+
+    @Test
+    public void testLengthThree() {
+        Map<String, Integer> expected = new HashMap<>();
+        expected.put("foo", 23);
+        expected.put("s", 42);
+        expected.put("t", 42);
+        assertThat(MapBuilder.map("foo", 23, "s", 42, "t", 42), is(expected));
+    }
+
+    @Test
+    public void testLengthFour() {
+        Map<String, Integer> expected = new HashMap<>();
+        expected.put("foo", 23);
+        expected.put("s", 42);
+        expected.put("t", 42);
+        expected.put("x", 43);
+        assertThat(MapBuilder.map("foo", 23, "s", 42, "t", 42, "x", 43), is(expected));
+    }
+
+    @Test
+    public void testLengthFive() {
+        Map<String, Integer> expected = new HashMap<>();
+        expected.put("foo", 23);
+        expected.put("s", 42);
+        expected.put("t", 42);
+        expected.put("x", 43);
+        expected.put("y", 44);
+        assertThat(MapBuilder.map("foo", 23, "s", 42, "t", 42, "x", 43, "y", 44), is(expected));
+    }
+
+}

--- a/common/test/unit/com/thoughtworks/go/util/UrlUtilTest.java
+++ b/common/test/unit/com/thoughtworks/go/util/UrlUtilTest.java
@@ -72,4 +72,10 @@ public class UrlUtilTest {
         String url = "this is not valid url";
         assertThat(UrlUtil.getQueryParamFromUrl(url, "param"),is(""));
     }
+
+    @Test
+    public void concatPathWithBaseUrl() throws Exception {
+        assertThat(UrlUtil.concatPath("http://foo", "bar"), is("http://foo/bar"));
+        assertThat(UrlUtil.concatPath("http://foo/", "bar"), is("http://foo/bar"));
+    }
 }

--- a/common/test/unit/com/thoughtworks/go/websocket/ReportTest.java
+++ b/common/test/unit/com/thoughtworks/go/websocket/ReportTest.java
@@ -1,0 +1,37 @@
+/*************************** GO-LICENSE-START*********************************
+ * Copyright 2016 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ************************GO-LICENSE-END***********************************/
+package com.thoughtworks.go.websocket;
+
+import com.thoughtworks.go.domain.AgentRuntimeStatus;
+import com.thoughtworks.go.domain.JobIdentifier;
+import com.thoughtworks.go.domain.JobResult;
+import com.thoughtworks.go.remote.AgentIdentifier;
+import com.thoughtworks.go.server.service.AgentRuntimeInfo;
+import org.junit.Test;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+
+public class ReportTest {
+
+    @Test
+    public void encodeAndDecodeAsMessageData() throws Exception {
+        AgentRuntimeInfo info = new AgentRuntimeInfo(new AgentIdentifier("HostName", "ipAddress", "uuid"), AgentRuntimeStatus.Idle, null, null, null, true);
+        JobIdentifier jobIdentifier = new JobIdentifier("pipeline", 1, "pipelinelabel", "stagename", "1", "job", 1L);
+        Report report = new Report(info, jobIdentifier, JobResult.Passed);
+        assertThat(MessageEncoding.decodeData(MessageEncoding.encodeData(report), Report.class), is(report));
+    }
+}

--- a/common/test/unit/com/thoughtworks/go/work/FakeWork.java
+++ b/common/test/unit/com/thoughtworks/go/work/FakeWork.java
@@ -1,5 +1,5 @@
 /*************************GO-LICENSE-START*********************************
- * Copyright 2014 ThoughtWorks, Inc.
+ * Copyright 2016 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,12 +19,12 @@ package com.thoughtworks.go.work;
 import com.thoughtworks.go.plugin.access.packagematerial.PackageAsRepositoryExtension;
 import com.thoughtworks.go.plugin.access.pluggabletask.TaskExtension;
 import com.thoughtworks.go.plugin.access.scm.SCMExtension;
-import com.thoughtworks.go.remote.work.Work;
+import com.thoughtworks.go.publishers.GoArtifactsManipulator;
 import com.thoughtworks.go.remote.AgentIdentifier;
 import com.thoughtworks.go.remote.BuildRepositoryRemote;
-import com.thoughtworks.go.publishers.GoArtifactsManipulator;
-import com.thoughtworks.go.util.command.EnvironmentVariableContext;
+import com.thoughtworks.go.remote.work.Work;
 import com.thoughtworks.go.server.service.AgentRuntimeInfo;
+import com.thoughtworks.go.util.command.EnvironmentVariableContext;
 
 public class FakeWork implements Work {
     int callCount;

--- a/common/test/unit/com/thoughtworks/go/work/SleepWork.java
+++ b/common/test/unit/com/thoughtworks/go/work/SleepWork.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 ThoughtWorks, Inc.
+ * Copyright 2016 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package com.thoughtworks.go.work;
 
+import com.thoughtworks.go.domain.Property;
 import com.thoughtworks.go.plugin.access.packagematerial.PackageAsRepositoryExtension;
 import com.thoughtworks.go.plugin.access.pluggabletask.TaskExtension;
 import com.thoughtworks.go.plugin.access.scm.SCMExtension;
@@ -23,36 +24,37 @@ import com.thoughtworks.go.publishers.GoArtifactsManipulator;
 import com.thoughtworks.go.remote.AgentIdentifier;
 import com.thoughtworks.go.remote.BuildRepositoryRemote;
 import com.thoughtworks.go.remote.work.Work;
+import com.thoughtworks.go.server.service.AgentBuildingInfo;
 import com.thoughtworks.go.server.service.AgentRuntimeInfo;
 import com.thoughtworks.go.util.command.EnvironmentVariableContext;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 public class SleepWork implements Work {
-    private int seconds;
-    private CountDownLatch latch = new CountDownLatch(1);
-    public AtomicBoolean done = new AtomicBoolean(false);
-    public AtomicBoolean canceled = new AtomicBoolean(false);
-    public CountDownLatch started = new CountDownLatch(1);
+    private String name;
+    private int sleepInMilliSeconds;
+    private transient CountDownLatch cancelLatch;
 
-    public SleepWork() {
-        this(1);
-    }
-
-    public SleepWork(int seconds) {
-        this.seconds = seconds;
+    public SleepWork(String name, int sleepInMilliSeconds) {
+        this.name = name;
+        this.sleepInMilliSeconds = sleepInMilliSeconds;
     }
 
     @Override
     public void doWork(AgentIdentifier agentIdentifier, BuildRepositoryRemote remoteBuildRepository, GoArtifactsManipulator manipulator, EnvironmentVariableContext environmentVariableContext, AgentRuntimeInfo agentRuntimeInfo, PackageAsRepositoryExtension packageAsRepositoryExtension, SCMExtension scmExtension, TaskExtension taskExtension) {
-        started.countDown();
+        cancelLatch = new CountDownLatch(1);
+        agentRuntimeInfo.busy(new AgentBuildingInfo("sleepwork", "sleepwork1"));
+        boolean canceled = false;
+
         try {
-            if (this.seconds > 0) {
-                latch.await(this.seconds, TimeUnit.SECONDS);
+            if (this.sleepInMilliSeconds > 0) {
+                canceled = cancelLatch.await(this.sleepInMilliSeconds, TimeUnit.MILLISECONDS);
             }
-            done.set(true);
+
+            String result = canceled ? "done_canceled" : "done";
+            manipulator.setProperty(null, new Property(name + "_result", result));
+
         } catch (InterruptedException e) {
             throw new RuntimeException(e);
         }
@@ -60,12 +62,12 @@ public class SleepWork implements Work {
 
     @Override
     public String description() {
-        return "Sleep " + seconds + " seconds.";
+        return "Sleep " + sleepInMilliSeconds + " milliseconds.";
     }
 
     @Override
     public void cancel(EnvironmentVariableContext environmentVariableContext, AgentRuntimeInfo agentruntimeInfo) {
-        canceled.set(true);
-        latch.countDown();
+        agentruntimeInfo.cancel();
+        cancelLatch.countDown();
     }
 }

--- a/config/config-api/src/com/thoughtworks/go/config/RunIfConfig.java
+++ b/config/config-api/src/com/thoughtworks/go/config/RunIfConfig.java
@@ -1,5 +1,5 @@
 /*************************GO-LICENSE-START*********************************
- * Copyright 2014 ThoughtWorks, Inc.
+ * Copyright 2016 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/config/config-api/src/com/thoughtworks/go/config/TestArtifactPlan.java
+++ b/config/config-api/src/com/thoughtworks/go/config/TestArtifactPlan.java
@@ -98,7 +98,7 @@ public class TestArtifactPlan extends ArtifactPlan {
                 File testResultSource = new File(tempFolder, MERGED_RESULT_FOLDER);
                 testResultSource.mkdirs();
                 UnitTestReportGenerator generator = new UnitTestReportGenerator(publisher, testResultSource);
-                generator.generate(allFiles.toArray(new File[allFiles.size()]));
+                generator.generate(allFiles.toArray(new File[allFiles.size()]), "testoutput");
                 publisher.upload(testResultSource, "testoutput");
             } finally {
                 if (tempFolder!=null) {

--- a/config/config-api/src/com/thoughtworks/go/domain/RunIfConfigs.java
+++ b/config/config-api/src/com/thoughtworks/go/domain/RunIfConfigs.java
@@ -16,12 +16,12 @@
 
 package com.thoughtworks.go.domain;
 
-import java.util.Arrays;
-
 import com.thoughtworks.go.config.ConfigCollection;
 import com.thoughtworks.go.config.RunIfConfig;
 import com.thoughtworks.go.config.Validatable;
 import com.thoughtworks.go.config.ValidationContext;
+
+import java.util.Arrays;
 
 @ConfigCollection(value = RunIfConfig.class)
 public class RunIfConfigs extends BaseCollection<RunIfConfig> implements Validatable {
@@ -62,6 +62,25 @@ public class RunIfConfigs extends BaseCollection<RunIfConfig> implements Validat
 
     public void addError(String fieldName, String message) {
         configErrors.add(fieldName, message);
+    }
+
+    public RunIfConfig resolveToSingle() {
+        if (this.contains(RunIfConfig.ANY)) {
+            return RunIfConfig.ANY;
+        }
+
+        if (this.contains(RunIfConfig.PASSED)) {
+            if (this.contains(RunIfConfig.FAILED)) {
+                return RunIfConfig.ANY;
+            }
+            return RunIfConfig.PASSED;
+        }
+
+        if (this.contains(RunIfConfig.FAILED)) {
+            return RunIfConfig.FAILED;
+        }
+
+        return RunIfConfig.PASSED;
     }
 }
 

--- a/config/config-api/src/com/thoughtworks/go/domain/TestReportGenerator.java
+++ b/config/config-api/src/com/thoughtworks/go/domain/TestReportGenerator.java
@@ -25,5 +25,5 @@ public interface TestReportGenerator {
     public static final String IGNORED_TEST_COUNT = "tests_ignored_count";
     public static final String TEST_TIME = "tests_total_duration";
 
-    Properties generate(File[] allTestFiles);
+    Properties generate(File[] allTestFiles, String uploadDestPath);
 }

--- a/config/config-api/src/com/thoughtworks/go/domain/UnitTestReportGenerator.java
+++ b/config/config-api/src/com/thoughtworks/go/domain/UnitTestReportGenerator.java
@@ -16,17 +16,13 @@
 
 package com.thoughtworks.go.domain;
 
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
-import java.io.FileReader;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.io.PrintStream;
-import java.text.MessageFormat;
+import com.thoughtworks.go.util.FileUtil;
+import com.thoughtworks.go.util.TestFileUtil;
+import com.thoughtworks.go.util.XpathUtils;
+import com.thoughtworks.go.work.GoPublisher;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
+
 import javax.xml.transform.Source;
 import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerFactory;
@@ -34,13 +30,8 @@ import javax.xml.transform.stream.StreamResult;
 import javax.xml.transform.stream.StreamSource;
 import javax.xml.xpath.XPathExpressionException;
 import javax.xml.xpath.XPathFactory;
-
-import com.thoughtworks.go.util.FileUtil;
-import com.thoughtworks.go.util.TestFileUtil;
-import com.thoughtworks.go.util.XpathUtils;
-import com.thoughtworks.go.work.GoPublisher;
-import org.apache.commons.io.FileUtils;
-import org.apache.commons.io.IOUtils;
+import java.io.*;
+import java.text.MessageFormat;
 
 public class UnitTestReportGenerator implements TestReportGenerator {
     private final File folderToUpload;
@@ -52,7 +43,7 @@ public class UnitTestReportGenerator implements TestReportGenerator {
         this.folderToUpload = folderToUpload;
     }
 
-    public Properties generate(File[] allTestFiles) {
+    public Properties generate(File[] allTestFiles, String uploadDestPath) {
         FileOutputStream transformedHtml = null;
         File mergedResults = new File(folderToUpload.getAbsolutePath() + FileUtil.fileseparator() + TEST_RESULTS_FILE);
         File mergedResource = null;
@@ -78,7 +69,7 @@ public class UnitTestReportGenerator implements TestReportGenerator {
 
             extractProperties(mergedResults);
 
-            publisher.upload(mergedResults, "testoutput");
+            publisher.upload(mergedResults, uploadDestPath);
 
             return null;
         } catch (Exception e) {

--- a/config/config-api/src/com/thoughtworks/go/remote/AgentIdentifier.java
+++ b/config/config-api/src/com/thoughtworks/go/remote/AgentIdentifier.java
@@ -1,5 +1,5 @@
 /*************************GO-LICENSE-START*********************************
- * Copyright 2014 ThoughtWorks, Inc.
+ * Copyright 2016 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,11 +16,18 @@
 
 package com.thoughtworks.go.remote;
 
+import com.google.gson.annotations.Expose;
+
 import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
 
 public class AgentIdentifier implements Serializable {
+    @Expose
     private String hostName;
+    @Expose
     private String ipAddress;
+    @Expose
     private String uuid;
 
     public AgentIdentifier(String hostName, String ipAddress, String uuid) {
@@ -80,4 +87,5 @@ public class AgentIdentifier implements Serializable {
         result = 31 * result + (uuid != null ? uuid.hashCode() : 0);
         return result;
     }
+
 }

--- a/config/config-api/src/com/thoughtworks/go/util/command/EnvironmentVariableContext.java
+++ b/config/config-api/src/com/thoughtworks/go/util/command/EnvironmentVariableContext.java
@@ -1,5 +1,5 @@
 /*************************GO-LICENSE-START*********************************
- * Copyright 2014 ThoughtWorks, Inc.
+ * Copyright 2016 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -124,6 +124,14 @@ public class EnvironmentVariableContext implements Serializable {
             return environmentVariable.value();
         }
         return null;
+    }
+
+    public List<String> getPropertyKeys() {
+        ArrayList<String> keys = new ArrayList<>(properties.size());
+        for (EnvironmentVariable property : properties) {
+            keys.add(property.name());
+        }
+        return keys;
     }
 
     public List<EnvironmentVariable> getSecureEnvironmentVariables() {

--- a/config/config-api/src/com/thoughtworks/go/util/command/UrlArgument.java
+++ b/config/config-api/src/com/thoughtworks/go/util/command/UrlArgument.java
@@ -58,7 +58,7 @@ public class UrlArgument extends CommandArgument {
         return url;
     }
 
-    public String hostInfoForDisplay() {
+    protected String hostInfoForDisplay() {
         try {
             URI uri = new URI(url);
             if (uri.getUserInfo()!=null) {
@@ -72,7 +72,7 @@ public class UrlArgument extends CommandArgument {
         }
     }
 
-    public String hostInfoForCommandline() {
+    protected String hostInfoForCommandline() {
         try {
             URI uri = new URI(url);
             if (uri.getUserInfo()!=null) {

--- a/server/src/com/thoughtworks/go/server/controller/AgentRegistrationController.java
+++ b/server/src/com/thoughtworks/go/server/controller/AgentRegistrationController.java
@@ -187,6 +187,7 @@ public class AgentRegistrationController {
                                      @RequestParam("agentAutoRegisterHostname") String agentAutoRegisterHostname,
                                      @RequestParam("elasticAgentId") String elasticAgentId,
                                      @RequestParam("elasticPluginId") String elasticPluginId,
+                                     @RequestParam(value = "supportsBuildCommandProtocol", required = false, defaultValue = "false") boolean supportsBuildCommandProtocol,
                                      HttpServletRequest request) throws IOException {
         final String ipAddress = request.getRemoteAddr();
         if (LOG.isDebugEnabled()) {
@@ -209,7 +210,7 @@ public class AgentRegistrationController {
             boolean registeredAlready = goConfigService.hasAgent(uuid);
             long usablespace = Long.parseLong(usablespaceAsString);
 
-            AgentRuntimeInfo agentRuntimeInfo = AgentRuntimeInfo.fromServer(agentConfig, registeredAlready, location, usablespace, operatingSystem);
+            AgentRuntimeInfo agentRuntimeInfo = AgentRuntimeInfo.fromServer(agentConfig, registeredAlready, location, usablespace, operatingSystem, supportsBuildCommandProtocol);
 
             if (elasticAgentAutoregistrationInfoPresent(elasticAgentId, elasticPluginId)) {
                 agentRuntimeInfo = ElasticAgentRuntimeInfo.fromServer(agentRuntimeInfo, elasticAgentId, elasticPluginId);
@@ -229,14 +230,11 @@ public class AgentRegistrationController {
 
             public void render(Map model, HttpServletRequest request, HttpServletResponse response) throws IOException {
                 ServletOutputStream servletOutputStream = null;
-                ObjectOutputStream objectOutputStream = null;
                 try {
                     servletOutputStream = response.getOutputStream();
-                    objectOutputStream = new ObjectOutputStream(servletOutputStream);
-                    objectOutputStream.writeObject(anotherCopy);
+                    servletOutputStream.print(anotherCopy.toJson());
                 } finally {
                     IOUtils.closeQuietly(servletOutputStream);
-                    IOUtils.closeQuietly(objectOutputStream);
                 }
             }
         });

--- a/server/src/com/thoughtworks/go/server/controller/AgentRegistrationController.java
+++ b/server/src/com/thoughtworks/go/server/controller/AgentRegistrationController.java
@@ -225,7 +225,7 @@ public class AgentRegistrationController {
         final Registration anotherCopy = keyEntry;
         return new ModelAndView(new View() {
             public String getContentType() {
-                return "application/x-java-serialized-object";
+                return "application/json";
             }
 
             public void render(Map model, HttpServletRequest request, HttpServletResponse response) throws IOException {

--- a/server/src/com/thoughtworks/go/server/domain/BuildComposer.java
+++ b/server/src/com/thoughtworks/go/server/domain/BuildComposer.java
@@ -1,0 +1,213 @@
+/*************************** GO-LICENSE-START*********************************
+ * Copyright 2016 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ************************GO-LICENSE-END***********************************/
+package com.thoughtworks.go.server.domain;
+
+import com.thoughtworks.go.config.ArtifactPlan;
+import com.thoughtworks.go.config.ArtifactPropertiesGenerator;
+import com.thoughtworks.go.config.materials.Materials;
+import com.thoughtworks.go.domain.*;
+import com.thoughtworks.go.domain.builder.Builder;
+import com.thoughtworks.go.remote.work.BuildAssignment;
+import com.thoughtworks.go.util.command.EnvironmentVariableContext;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.thoughtworks.go.domain.BuildCommand.*;
+import static com.thoughtworks.go.domain.JobState.*;
+
+public class BuildComposer {
+    private BuildAssignment assignment;
+
+    public BuildComposer(BuildAssignment assignment) {
+        this.assignment = assignment;
+    }
+
+    public BuildCommand compose() {
+        return BuildCommand.compose(
+                echoWithPrefix("Job started ${date}"),
+                prepare(),
+                build(),
+                reportAction("Job completed").runIf("any"))
+                .setOnCancel(BuildCommand.compose(
+                        reportAction("Job is canceled"),
+                        reportAction("Job completed")));
+
+    }
+
+    private BuildCommand prepare() {
+        return BuildCommand.compose(
+                reportAction("Start to prepare"),
+                reportCurrentStatus(Preparing),
+                refreshWorkingDir(),
+                updateMaterials());
+    }
+
+    private BuildCommand build() {
+        return BuildCommand.compose(
+                reportAction("Start to build"),
+                reportCurrentStatus(Building),
+                setupSecrets(),
+                setupEnvironmentVariables(),
+                runBuilders(),
+                BuildCommand.compose(
+                        reportCompleting(),
+                        reportCurrentStatus(Completing),
+                        harvestProperties(),
+                        uploadArtifacts()).setRunIfRecurisvely("any"));
+    }
+
+
+    private BuildCommand harvestProperties() {
+        List<ArtifactPropertiesGenerator> generators = assignment.getPlan().getPropertyGenerators();
+        List<BuildCommand> commands = new ArrayList<>();
+
+        for (ArtifactPropertiesGenerator generator : generators) {
+            BuildCommand command = BuildCommand.generateProperty(generator.getName(), generator.getSrc(), generator.getXpath()).setWorkingDirectory(workingDirectory());
+            commands.add(command);
+        }
+        return BuildCommand.compose(
+                reportAction("Start to create properties"),
+                BuildCommand.compose(commands));
+    }
+
+
+    private BuildCommand runBuilders() {
+        List<BuildCommand> commands = new ArrayList<>();
+        for (Builder builder : assignment.getBuilders()) {
+            commands.add(runSingleBuilder(builder));
+        }
+        return BuildCommand.compose(commands);
+    }
+
+    private BuildCommand runSingleBuilder(Builder builder) {
+        String runIfConfig = builder.resolvedRunIfConfig().toString();
+        return BuildCommand.compose(
+                echoWithPrefix("Current job status: passed."),
+                echoWithPrefix("Current job status: failed.").runIf("failed"),
+                echoWithPrefix("Start to execute task: %s.", builder.getDescription()).runIf(runIfConfig),
+                builder.buildCommand()
+                        .runIf(runIfConfig)
+                        .setOnCancel(runCancelTask(builder.getCancelBuilder()))).runIf(runIfConfig);
+    }
+
+    private BuildCommand runCancelTask(Builder cancelBuilder) {
+        if (cancelBuilder == null) {
+            return null;
+        }
+        return BuildCommand.compose(
+                echoWithPrefix("Start to execute cancel task: %s", cancelBuilder.getDescription()),
+                cancelBuilder.buildCommand(),
+                echoWithPrefix("Task is canceled"));
+    }
+
+    private BuildCommand uploadArtifacts() {
+        List<BuildCommand> commands = new ArrayList<>();
+        for (ArtifactPlan ap : assignment.getPlan().getArtifactPlans()) {
+            commands.add(uploadArtifact(ap.getSrc(), ap.getDest(), ap.getArtifactType().isTest())
+                    .setWorkingDirectory(workingDirectory()));
+        }
+
+        return BuildCommand.compose(
+                reportAction("Start to upload"),
+                BuildCommand.compose(commands),
+                generateTestReport());
+    }
+
+    private BuildCommand generateTestReport() {
+        List<String> srcs = new ArrayList<>();
+        for (ArtifactPlan ap : assignment.getPlan().getArtifactPlans()) {
+            if (ap.getArtifactType() == ArtifactType.unit) {
+                srcs.add(ap.getSrc());
+            }
+        }
+        return srcs.isEmpty() ? noop() : BuildCommand.generateTestReport(srcs, "testoutput").setWorkingDirectory(workingDirectory());
+    }
+
+
+    private BuildCommand setupSecrets() {
+        List<EnvironmentVariableContext.EnvironmentVariable> secrets = environmentVariableContext().getSecureEnvironmentVariables();
+        ArrayList<BuildCommand> commands = new ArrayList<>();
+        for (EnvironmentVariableContext.EnvironmentVariable secret : secrets) {
+            commands.add(secret(secret.value()));
+        }
+        return BuildCommand.compose(commands);
+    }
+
+    private BuildCommand setupEnvironmentVariables() {
+        EnvironmentVariableContext context = environmentVariableContext();
+        ArrayList<BuildCommand> commands = new ArrayList<>();
+        commands.add(export("GO_SERVER_URL"));
+        for (String property : context.getPropertyKeys()) {
+            commands.add(export(property, context.getProperty(property), context.isPropertySecure(property)));
+        }
+        return BuildCommand.compose(commands);
+    }
+
+    private BuildCommand reportAction(String action) {
+        return echoWithPrefix("%s %s on ${agent.hostname} [${agent.location}]", action, getJobIdentifier().buildLocatorForDisplay());
+    }
+
+    private BuildCommand updateMaterials() {
+        if (!assignment.getPlan().shouldFetchMaterials()) {
+            return echoWithPrefix("Skipping material update since stage is configured not to fetch materials");
+        }
+
+        MaterialRevisions materialRevisions = assignment.materialRevisions();
+        Materials materials = materialRevisions.getMaterials();
+        return BuildCommand.compose(
+                materials.cleanUpCommand(workingDirectory()),
+                echoWithPrefix("Start to update materials \n"),
+                materialRevisions.updateToCommand(workingDirectory()));
+    }
+
+    private BuildCommand refreshWorkingDir() {
+        return BuildCommand.compose(
+                cleanWorkingDir(),
+                mkdirs(workingDirectory()).setTest(test("-nd", workingDirectory())));
+    }
+
+    private BuildCommand cleanWorkingDir() {
+        if (!assignment.getPlan().shouldCleanWorkingDir()) {
+            return noop();
+        }
+        return BuildCommand.compose(
+                cleandir(workingDirectory()),
+                echoWithPrefix("Cleaning working directory \"$%s\" since stage is configured to clean working directory", workingDirectory())
+        ).setTest(test("-d", workingDirectory()));
+    }
+
+    private String workingDirectory() {
+        return assignment.getWorkingDirectory().getPath();
+    }
+
+    private JobIdentifier getJobIdentifier() {
+        return assignment.getPlan().getIdentifier();
+    }
+
+    private EnvironmentVariableContext environmentVariableContext() {
+        JobPlan plan = assignment.getPlan();
+        EnvironmentVariableContext context = new EnvironmentVariableContext();
+
+        context.addAll(assignment.initialEnvironmentVariableContext());
+        context.setProperty("GO_TRIGGER_USER", assignment.getBuildApprover() , false);
+        getJobIdentifier().populateEnvironmentVariables(context);
+        assignment.materialRevisions().populateEnvironmentVariables(context, new File(workingDirectory()));
+        plan.applyTo(context);
+        return context;
+    }
+}

--- a/server/src/com/thoughtworks/go/server/domain/BuildComposer.java
+++ b/server/src/com/thoughtworks/go/server/domain/BuildComposer.java
@@ -39,7 +39,7 @@ public class BuildComposer {
 
     public BuildCommand compose() {
         return BuildCommand.compose(
-                echoWithPrefix("Job started ${date}"),
+                echoWithPrefix("Job Started: ${date}"),
                 prepare(),
                 build(),
                 reportAction("Job completed").runIf("any"))

--- a/server/src/com/thoughtworks/go/server/websocket/AgentRemoteHandler.java
+++ b/server/src/com/thoughtworks/go/server/websocket/AgentRemoteHandler.java
@@ -89,7 +89,7 @@ public class AgentRemoteHandler {
                 }
                 AgentInstruction instruction = this.buildRepositoryRemote.ping(info);
                 if (instruction.isShouldCancelJob()) {
-                    cancelBuild(agent, info.getSupportsBuildCommandProtocol());
+                    agent.send(new Message(Action.cancelBuild));
                 }
                 break;
             case reportCurrentStatus:
@@ -141,18 +141,8 @@ public class AgentRemoteHandler {
             return;
         }
         Agent agent = agentSessions.get(uuid);
-        AgentInstance instance = agentService.findAgentAndRefreshStatus(uuid);
-        if (agent != null && instance != null) {
-            cancelBuild(agent, instance.getSupportsBuildCommandProtocol());
-        }
-    }
-    private void cancelBuild(Agent agent, boolean supportsBuildCommandProtocol) {
-        if (supportsBuildCommandProtocol) {
+        if(agent != null) {
             agent.send(new Message(Action.cancelBuild));
-        } else {
-            agent.send(new Message(Action.cancelJob));
         }
     }
-
-
 }

--- a/server/src/com/thoughtworks/go/server/websocket/AgentRemoteServlet.java
+++ b/server/src/com/thoughtworks/go/server/websocket/AgentRemoteServlet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 ThoughtWorks, Inc.
+ * Copyright 2016 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,6 @@
 
 package com.thoughtworks.go.server.websocket;
 
-import org.eclipse.jetty.websocket.api.extensions.ExtensionConfig;
 import org.eclipse.jetty.websocket.servlet.WebSocketServlet;
 import org.eclipse.jetty.websocket.servlet.WebSocketServletFactory;
 import org.springframework.web.context.WebApplicationContext;
@@ -36,8 +35,6 @@ public class AgentRemoteServlet extends WebSocketServlet {
 
     @Override
     public void configure(WebSocketServletFactory factory) {
-        AgentRemoteSocketCreator bean = wac.getBean(AgentRemoteSocketCreator.class);
-        bean.addExtensionConfig(ExtensionConfig.parse("fragment;maxLength=" + factory.getPolicy().getMaxBinaryMessageBufferSize()));
-        factory.setCreator(bean);
+        factory.setCreator(wac.getBean(AgentRemoteSocketCreator.class));
     }
 }

--- a/server/src/com/thoughtworks/go/server/websocket/AgentRemoteSocket.java
+++ b/server/src/com/thoughtworks/go/server/websocket/AgentRemoteSocket.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 ThoughtWorks, Inc.
+ * Copyright 2016 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 package com.thoughtworks.go.server.websocket;
 
 import com.thoughtworks.go.websocket.Message;
+import com.thoughtworks.go.websocket.MessageEncoding;
 import org.eclipse.jetty.websocket.api.Session;
 import org.eclipse.jetty.websocket.api.annotations.*;
 import org.eclipse.jetty.websocket.api.extensions.Frame;
@@ -43,7 +44,7 @@ public class AgentRemoteSocket implements Agent {
 
     @OnWebSocketMessage
     public void onMessage(InputStream input) {
-        Message msg = Message.decode(input);
+        Message msg = MessageEncoding.decodeMessage(input);
         LOGGER.debug("{} message: {}", sessionName(), msg);
         handler.process(this, msg);
     }
@@ -67,7 +68,7 @@ public class AgentRemoteSocket implements Agent {
     @Override
     public void send(final Message msg) {
         LOGGER.debug("{} send message: {}", sessionName(), msg);
-        session.getRemote().sendBytesByFuture(ByteBuffer.wrap(Message.encode(msg)));
+        session.getRemote().sendBytesByFuture(ByteBuffer.wrap(MessageEncoding.encodeMessage(msg)));
     }
 
     private String sessionName() {

--- a/server/src/com/thoughtworks/go/server/websocket/AgentRemoteSocketCreator.java
+++ b/server/src/com/thoughtworks/go/server/websocket/AgentRemoteSocketCreator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 ThoughtWorks, Inc.
+ * Copyright 2016 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,22 +16,16 @@
 
 package com.thoughtworks.go.server.websocket;
 
-import org.eclipse.jetty.websocket.api.extensions.ExtensionConfig;
 import org.eclipse.jetty.websocket.servlet.ServletUpgradeRequest;
 import org.eclipse.jetty.websocket.servlet.ServletUpgradeResponse;
 import org.eclipse.jetty.websocket.servlet.WebSocketCreator;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
-import java.util.ArrayList;
-import java.util.List;
-
 @Component
 public class AgentRemoteSocketCreator implements WebSocketCreator {
 
-
     private AgentRemoteHandler handler;
-    private List<ExtensionConfig> configs = new ArrayList<>();
 
     @Autowired
     public AgentRemoteSocketCreator(AgentRemoteHandler handler) {
@@ -40,11 +34,6 @@ public class AgentRemoteSocketCreator implements WebSocketCreator {
 
     @Override
     public Object createWebSocket(ServletUpgradeRequest req, ServletUpgradeResponse resp) {
-        resp.setExtensions(configs);
         return new AgentRemoteSocket(handler);
-    }
-
-    public void addExtensionConfig(ExtensionConfig config) {
-        configs.add(config);
     }
 }

--- a/server/test/agent/com/thoughtworks/go/agent/AgentStub.java
+++ b/server/test/agent/com/thoughtworks/go/agent/AgentStub.java
@@ -38,7 +38,7 @@ public class AgentStub {
 
     public AgentStub(BuildRepositoryRemote server) {
         LOGGER.info("Agent started.");
-        Work work = server.getWork(new AgentRuntimeInfo(new AgentIdentifier("", "", "1234"), AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null));
+        Work work = server.getWork(new AgentRuntimeInfo(new AgentIdentifier("", "", "1234"), AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null, false));
         try {
             LOGGER.info(work.description());
         } catch (UnregisteredAgentException e) {

--- a/server/test/integration/com/thoughtworks/go/server/controller/ArtifactsControllerIntegrationTest.java
+++ b/server/test/integration/com/thoughtworks/go/server/controller/ArtifactsControllerIntegrationTest.java
@@ -1,5 +1,5 @@
 /*************************GO-LICENSE-START*********************************
- * Copyright 2014 ThoughtWorks, Inc.
+ * Copyright 2016 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -205,7 +205,7 @@ public class ArtifactsControllerIntegrationTest {
 
     private Date updateHeardTime() throws Exception {
         agentService.requestRegistration(AgentRuntimeInfo.fromServer(new AgentConfig("uuid", "localhost", "127.0.0.1"),
-                false, "/var/lib", 0L, "linux"));
+                false, "/var/lib", 0L, "linux", false));
         agentService.approve("uuid");
         artifactsController.putArtifact(pipelineName, "latest", "stage", null, "build2", null, "/foo.xml",
                 "uuid", request);

--- a/server/test/integration/com/thoughtworks/go/server/service/AgentServiceIntegrationTest.java
+++ b/server/test/integration/com/thoughtworks/go/server/service/AgentServiceIntegrationTest.java
@@ -340,7 +340,7 @@ public class AgentServiceIntegrationTest {
         assertThat(agents.findAgentAndRefreshStatus(uuid).getStatus(), is(AgentStatus.Building));
         AgentIdentifier agentIdentifier = instance.agentConfig().getAgentIdentifier();
         String cookie = agentService.assignCookie(agentIdentifier);
-        agentService.updateRuntimeInfo(new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), cookie, null));
+        agentService.updateRuntimeInfo(new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), cookie, null, false));
         agents = agentService.findRegisteredAgents();
         assertThat(agents.findAgentAndRefreshStatus(uuid).getStatus(), is(AgentStatus.Idle));
     }
@@ -355,7 +355,7 @@ public class AgentServiceIntegrationTest {
         assertThat(agents.findAgentAndRefreshStatus(uuid).getStatus(), is(AgentStatus.Building));
         AgentIdentifier identifier = instance.agentConfig().getAgentIdentifier();
         agentDao.associateCookie(identifier, "new_cookie");
-        AgentRuntimeInfo runtimeInfo = new AgentRuntimeInfo(identifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "old_cookie", null);
+        AgentRuntimeInfo runtimeInfo = new AgentRuntimeInfo(identifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "old_cookie", null, false);
         try {
             agentService.updateRuntimeInfo(runtimeInfo);
             fail("agent with bad cookie should not be able to update runtime info");
@@ -365,7 +365,7 @@ public class AgentServiceIntegrationTest {
         agents = agentService.findRegisteredAgents();
         assertThat(agents.findAgentAndRefreshStatus(uuid).getStatus(), is(AgentStatus.Building));AgentIdentifier agentIdentifier = instance.agentConfig().getAgentIdentifier();
         String cookie = agentService.assignCookie(agentIdentifier);
-        agentService.updateRuntimeInfo(new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), cookie, null));
+        agentService.updateRuntimeInfo(new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), cookie, null, false));
     }
 
     @Test
@@ -464,7 +464,7 @@ public class AgentServiceIntegrationTest {
     @Test
     public void shouldApproveAgent() throws Exception {
         AgentInstance pending = AgentInstanceMother.pending();
-        agentService.requestRegistration(AgentRuntimeInfo.fromServer(pending.agentConfig(), false, "var/lib", 0L, "linux"));
+        agentService.requestRegistration(AgentRuntimeInfo.fromServer(pending.agentConfig(), false, "var/lib", 0L, "linux", false));
 
         agentService.approve(pending.getUuid());
 
@@ -477,19 +477,19 @@ public class AgentServiceIntegrationTest {
     @Test
     public void shouldAddOrUpdateAgent() throws Exception {
         AgentInstance pending = AgentInstanceMother.pending();
-        agentService.requestRegistration(AgentRuntimeInfo.fromServer(pending.agentConfig(), false, "var/lib", 0L, "linux"));
+        agentService.requestRegistration(AgentRuntimeInfo.fromServer(pending.agentConfig(), false, "var/lib", 0L, "linux", false));
 
         agentService.approve(pending.getUuid());
 
-        agentService.requestRegistration(AgentRuntimeInfo.fromServer(pending.agentConfig(), true, "var/lib", 0L, "linux"));
-        agentService.requestRegistration(AgentRuntimeInfo.fromServer(pending.agentConfig(), true, "var/lib", 0L, "linux"));
+        agentService.requestRegistration(AgentRuntimeInfo.fromServer(pending.agentConfig(), true, "var/lib", 0L, "linux", false));
+        agentService.requestRegistration(AgentRuntimeInfo.fromServer(pending.agentConfig(), true, "var/lib", 0L, "linux", false));
         assertThat(agentService.findRegisteredAgents().size(), is(1));
     }
 
     @Test
     public void shouldDenyAgentFromPendingList() throws Exception {
         AgentInstance pending = AgentInstanceMother.pending();
-        agentService.requestRegistration(AgentRuntimeInfo.fromServer(pending.agentConfig(), false, "var/lib", 0L, "linux"));
+        agentService.requestRegistration(AgentRuntimeInfo.fromServer(pending.agentConfig(), false, "var/lib", 0L, "linux", false));
 
         String uuid = pending.getUuid();
 
@@ -548,7 +548,7 @@ public class AgentServiceIntegrationTest {
         addAgent(agentConfig);
         AgentIdentifier agentIdentifier = agentConfig.getAgentIdentifier();
         String cookie = agentService.assignCookie(agentIdentifier);
-        AgentRuntimeInfo agentRuntimeInfo = new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), cookie, null);
+        AgentRuntimeInfo agentRuntimeInfo = new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), cookie, null, false);
         agentRuntimeInfo.busy(new AgentBuildingInfo("path", "buildLocator"));
 
         agentService.updateRuntimeInfo(agentRuntimeInfo);
@@ -607,7 +607,7 @@ public class AgentServiceIntegrationTest {
         String agentName = "agentName";
         String agentId = DatabaseAccessHelper.AGENT_UUID;
         AgentConfig agentConfig = new AgentConfig(agentId, agentName, "50.40.30.9");
-        AgentRuntimeInfo agentRuntimeInfo = new AgentRuntimeInfo(agentConfig.getAgentIdentifier(), AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null);
+        AgentRuntimeInfo agentRuntimeInfo = new AgentRuntimeInfo(agentConfig.getAgentIdentifier(), AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null, false);
         agentRuntimeInfo.busy(new AgentBuildingInfo("path", "buildLocator"));
         agentService.requestRegistration(agentRuntimeInfo);
         HttpOperationResult operationResult = new HttpOperationResult();
@@ -621,7 +621,7 @@ public class AgentServiceIntegrationTest {
         String agentName = "agentName";
         String agentId = DatabaseAccessHelper.AGENT_UUID;
         AgentConfig agentConfig = new AgentConfig(agentId, agentName, "50.40.30.9");
-        AgentRuntimeInfo agentRuntimeInfo = new AgentRuntimeInfo(agentConfig.getAgentIdentifier(), AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null);
+        AgentRuntimeInfo agentRuntimeInfo = new AgentRuntimeInfo(agentConfig.getAgentIdentifier(), AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null, false);
         agentRuntimeInfo.busy(new AgentBuildingInfo("path", "buildLocator"));
         agentService.requestRegistration(agentRuntimeInfo);
         HttpOperationResult operationResult = new HttpOperationResult();
@@ -711,7 +711,7 @@ public class AgentServiceIntegrationTest {
         InetAddress inetAddress = InetAddress.getByName(nonLoopbackIp);
         assertThat(SystemUtil.isLocalIpAddress(nonLoopbackIp), is(true));
         AgentConfig agentConfig = new AgentConfig("uuid", inetAddress.getHostName(), nonLoopbackIp);
-        AgentRuntimeInfo agentRuntimeInfo = AgentRuntimeInfo.fromServer(agentConfig, false, "/var/lib", 0L, "linux");
+        AgentRuntimeInfo agentRuntimeInfo = AgentRuntimeInfo.fromServer(agentConfig, false, "/var/lib", 0L, "linux", false);
         agentService.requestRegistration(agentRuntimeInfo);
 
         AgentInstance agentInstance = agentService.findRegisteredAgents().findAgentAndRefreshStatus("uuid");
@@ -1160,7 +1160,7 @@ public class AgentServiceIntegrationTest {
     private void disable(AgentConfig agentConfig) {
         AgentIdentifier agentIdentifier = agentConfig.getAgentIdentifier();
         String cookie = agentService.assignCookie(agentIdentifier);
-        AgentRuntimeInfo agentRuntimeInfo = new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), cookie, null);
+        AgentRuntimeInfo agentRuntimeInfo = new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), cookie, null, false);
         agentRuntimeInfo.busy(new AgentBuildingInfo("path", "buildLocator"));
         agentService.updateRuntimeInfo(agentRuntimeInfo);
         agentService.disableAgents(USERNAME, new HttpOperationResult(), Arrays.asList(agentConfig.getUuid()));
@@ -1169,7 +1169,7 @@ public class AgentServiceIntegrationTest {
 
     private void disableAgent() {
         AgentConfig pending = new AgentConfig("uuid1", "agent1", "192.168.0.1");
-        agentService.requestRegistration(AgentRuntimeInfo.fromServer(pending, false, "/var/lib", 0L, "linux"));
+        agentService.requestRegistration(AgentRuntimeInfo.fromServer(pending, false, "/var/lib", 0L, "linux", false));
         agentService.approve("uuid1");
         agentConfigService.updateAgentApprovalStatus("uuid1", true);
     }
@@ -1179,7 +1179,7 @@ public class AgentServiceIntegrationTest {
     }
 
     public void addAgent(AgentConfig agentConfig) {
-        agentService.requestRegistration(AgentRuntimeInfo.fromServer(agentConfig, false, "/var/lib", 0L, "linux"));
+        agentService.requestRegistration(AgentRuntimeInfo.fromServer(agentConfig, false, "/var/lib", 0L, "linux", false));
         agentService.approve(agentConfig.getUuid());
     }
 
@@ -1196,7 +1196,7 @@ public class AgentServiceIntegrationTest {
 
         AgentIdentifier agentIdentifier = agentConfig.getAgentIdentifier();
         String cookie = agentService.assignCookie(agentIdentifier);
-        AgentRuntimeInfo agentRuntimeInfo = new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), cookie, null);
+        AgentRuntimeInfo agentRuntimeInfo = new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), cookie, null, false);
         agentRuntimeInfo.idle();
         agentService.updateRuntimeInfo(agentRuntimeInfo);
         assertTrue(agentService.findAgentAndRefreshStatus(uuid).isIdle());

--- a/server/test/integration/com/thoughtworks/go/server/service/EmailNotificationIntegerationTest.java
+++ b/server/test/integration/com/thoughtworks/go/server/service/EmailNotificationIntegerationTest.java
@@ -144,9 +144,9 @@ public class EmailNotificationIntegerationTest {
     private void agentReportJobIsCompleted(String unitLinux) {
         job = pipeline.getFirstStage().findJob(unitLinux);
 
-        producer.reportCompleting(new AgentRuntimeInfo(new AgentIdentifier("localhost", "127.0.0.1", job.getAgentUuid()), AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null), job.getIdentifier(),
+        producer.reportCompleting(new AgentRuntimeInfo(new AgentIdentifier("localhost", "127.0.0.1", job.getAgentUuid()), AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null, false), job.getIdentifier(),
                 JobResult.Failed);
-        producer.reportCurrentStatus(new AgentRuntimeInfo(new AgentIdentifier("", "", job.getAgentUuid()), AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null), job.getIdentifier(),
+        producer.reportCurrentStatus(new AgentRuntimeInfo(new AgentIdentifier("", "", job.getAgentUuid()), AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null, false), job.getIdentifier(),
                 JobState.Completed);
     }
 }

--- a/server/test/integration/com/thoughtworks/go/server/service/StageServiceIntegrationTest.java
+++ b/server/test/integration/com/thoughtworks/go/server/service/StageServiceIntegrationTest.java
@@ -148,7 +148,7 @@ public class StageServiceIntegrationTest {
         job.setAgentUuid(UUID);
         jobInstanceDao.updateAssignedInfo(job);
         AgentIdentifier agentIdentifier = new AgentIdentifier("localhost", "127.0.0.1", UUID);
-        agentService.updateRuntimeInfo(new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null));
+        agentService.updateRuntimeInfo(new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null, false));
         receivedState = null;
         receivedResult = null;
         receivedStageResult = null;

--- a/server/test/integration/com/thoughtworks/go/server/service/UpdateAgentStatusTest.java
+++ b/server/test/integration/com/thoughtworks/go/server/service/UpdateAgentStatusTest.java
@@ -71,8 +71,7 @@ public class UpdateAgentStatusTest {
         preCondition = new PipelineWithTwoStages(materialRepository, transactionTemplate);
         preCondition.usingConfigHelper(configHelper).usingDbHelper(dbHelper).onSetUp();
         agentService.clearAll();
-        agentService.requestRegistration(AgentRuntimeInfo.fromServer(new AgentConfig(agentId, "CCEDev01", "10.81.2.1"),
-                false, "/var/lib", 0L, "linux"));
+        agentService.requestRegistration(AgentRuntimeInfo.fromServer(new AgentConfig(agentId, "CCEDev01", "10.81.2.1"), false, "/var/lib", 0L, "linux", false));
         agentService.approve(agentId);
     }
 
@@ -88,7 +87,7 @@ public class UpdateAgentStatusTest {
         assertThat(oldIp, is("10.81.2.1"));
 
         AgentIdentifier agentIdentifier1 = new AgentIdentifier("localhost", "10.18.3.95", "uuid");
-        AgentRuntimeInfo agentRuntimeInfo1 = new AgentRuntimeInfo(agentIdentifier1, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null);
+        AgentRuntimeInfo agentRuntimeInfo1 = new AgentRuntimeInfo(agentIdentifier1, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null, false);
         agentRuntimeInfo1.busy(new AgentBuildingInfo("building", "buildLocator"));
 
         agentService.updateRuntimeInfo(agentRuntimeInfo1);
@@ -103,7 +102,7 @@ public class UpdateAgentStatusTest {
     @Test
     public void shouldUpdateAgentWorkingDirWhenItChanges() throws Exception {
         AgentIdentifier agentIdentifier1 = new AgentIdentifier("localhost", "10.18.3.95", "uuid");
-        AgentRuntimeInfo agentRuntimeInfo1 = new AgentRuntimeInfo(agentIdentifier1, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null);
+        AgentRuntimeInfo agentRuntimeInfo1 = new AgentRuntimeInfo(agentIdentifier1, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null, false);
         agentRuntimeInfo1.busy(new AgentBuildingInfo("building", "buildLocator"));
         agentRuntimeInfo1.setLocation("/myDirectory");
 
@@ -116,7 +115,7 @@ public class UpdateAgentStatusTest {
     @Test
     public void shouldLogWarningWhenIPAddressChanges() throws Exception {
         AgentIdentifier agentIdentifier1 = new AgentIdentifier("localhost", "10.18.3.95", "uuid");
-        AgentRuntimeInfo agentRuntimeInfo1 = new AgentRuntimeInfo(agentIdentifier1, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null);
+        AgentRuntimeInfo agentRuntimeInfo1 = new AgentRuntimeInfo(agentIdentifier1, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null, false);
         agentRuntimeInfo1.busy(new AgentBuildingInfo("building", "buildLocator"));
         agentRuntimeInfo1.setLocation("/myDirectory");
 

--- a/server/test/unit/com/thoughtworks/go/domain/BuildComposerTest.java
+++ b/server/test/unit/com/thoughtworks/go/domain/BuildComposerTest.java
@@ -1,0 +1,595 @@
+/*
+ * Copyright 2016 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.thoughtworks.go.domain;
+
+import com.googlecode.junit.ext.JunitExtRunner;
+import com.googlecode.junit.ext.RunIf;
+import com.thoughtworks.go.buildsession.BuildSession;
+import com.thoughtworks.go.buildsession.BuildSessionBasedTestCase;
+import com.thoughtworks.go.config.ConfigCache;
+import com.thoughtworks.go.config.CruiseConfig;
+import com.thoughtworks.go.config.JobConfig;
+import com.thoughtworks.go.config.MagicalGoConfigXmlLoader;
+import com.thoughtworks.go.domain.buildcause.BuildCause;
+import com.thoughtworks.go.domain.builder.Builder;
+import com.thoughtworks.go.helper.ConfigFileFixture;
+import com.thoughtworks.go.helper.JobInstanceMother;
+import com.thoughtworks.go.helper.StageMother;
+import com.thoughtworks.go.junitext.EnhancedOSChecker;
+import com.thoughtworks.go.plugin.access.pluggabletask.TaskExtension;
+import com.thoughtworks.go.remote.work.BuildAssignment;
+import com.thoughtworks.go.server.domain.BuildComposer;
+import com.thoughtworks.go.server.service.UpstreamPipelineResolver;
+import com.thoughtworks.go.server.service.builders.*;
+import com.thoughtworks.go.util.ConfigElementImplementationRegistryMother;
+import com.thoughtworks.go.util.FileUtil;
+import com.thoughtworks.go.util.SystemUtil;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
+import org.hamcrest.core.Is;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.springframework.core.io.ClassPathResource;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.InputStream;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static com.google.common.collect.Iterables.getLast;
+import static com.thoughtworks.go.domain.JobResult.*;
+import static com.thoughtworks.go.domain.JobState.*;
+import static com.thoughtworks.go.junitext.EnhancedOSChecker.DO_NOT_RUN_ON;
+import static com.thoughtworks.go.junitext.EnhancedOSChecker.WINDOWS;
+import static com.thoughtworks.go.matchers.ConsoleOutMatcher.*;
+import static com.thoughtworks.go.matchers.RegexMatcher.matches;
+import static com.thoughtworks.go.util.SystemUtil.isWindows;
+import static com.thoughtworks.go.util.TestUtils.copyAndClose;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.core.StringContains.containsString;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+@RunWith(JunitExtRunner.class)
+public class BuildComposerTest extends BuildSessionBasedTestCase {
+    public static final String PIPELINE_NAME = "pipeline1";
+    public static final String PIPELINE_LABEL = "100";
+    public static final String STAGE_NAME = "mingle";
+    public static final String JOB_PLAN_NAME = "run-ant";
+    private static final int STAGE_COUNTER = 100;
+    private static final JobIdentifier JOB_IDENTIFIER = new JobIdentifier(PIPELINE_NAME, -3, PIPELINE_LABEL, STAGE_NAME, String.valueOf(STAGE_COUNTER), JOB_PLAN_NAME, 1L);
+    private static final String SERVER_URL = "somewhere-does-not-matter";
+
+    private static final String NANT = "<job name=\"" + JOB_PLAN_NAME + "\">\n"
+            + "  <tasks>\n"
+            + "    <nant target=\"-help\"/>\n"
+            + "  </tasks>\n"
+            + "</job>";
+
+    private static final String NANT_WITH_WORKINGDIR = "<job name=\"" + JOB_PLAN_NAME + "\">\n"
+            + "  <tasks>\n"
+            + "    <nant target=\"-help\" workingdir=\"not-exists\" />\n"
+            + "  </tasks>\n"
+            + "</job>";
+
+    private static final String RAKE = "<job name=\"" + JOB_PLAN_NAME + "\">\n"
+            + "  <tasks>\n"
+            + "    <rake target=\"--help\"/>\n"
+            + "  </tasks>\n"
+            + "</job>";
+
+    private static final String WILL_FAIL = "<job name=\"" + JOB_PLAN_NAME + "\">\n"
+            + "  <tasks>\n"
+            + "    <ant target=\"something-not-really-exist\" />\n"
+            + "  </tasks>\n"
+            + "</job>";
+
+    private static final String WILL_PASS = "<job name=\"" + JOB_PLAN_NAME + "\">\n"
+            + "  <tasks>\n"
+            + "    <exec command=\"echo\">\n"
+            + "      <arg>hello world</arg>\n"
+            + "    </exec>\n"
+            + "  </tasks>\n"
+            + "</job>";
+
+    private static final String WITH_ENV_VAR = "<job name=\"" + JOB_PLAN_NAME + "\">\n"
+            + "  <environmentvariables>\n"
+            + "    <variable name=\"JOB_ENV\">\n"
+            + "      <value>foobar</value>\n"
+            + "    </variable>\n"
+            + "    <variable name=\"" + (isWindows() ? "Path" : "PATH") + "\">\n"
+            + "      <value>/tmp</value>\n"
+            + "    </variable>\n"
+            + "  </environmentvariables>\n"
+            + "  <tasks>\n"
+            + "    <ant target=\"-help\" />\n"
+            + "  </tasks>\n"
+            + "</job>";
+
+    private static final String WITH_SECRET_ENV_VAR = "<job name=\"" + JOB_PLAN_NAME + "\">\n"
+            + "  <environmentvariables>\n"
+            + "    <variable name=\"foo\">\n"
+            + "      <value>foo(i am a secret)</value>\n"
+            + "    </variable>\n"
+            + "    <variable name=\"bar\" secure=\"true\">\n"
+            + "      <value>i am a secret</value>\n"
+            + "    </variable>\n"
+            + "  </environmentvariables>\n"
+            + "  <tasks>\n"
+            + "    <ant target=\"-help\" />\n"
+            + "  </tasks>\n"
+            + "</job>";
+
+    private static final String SOMETHING_NOT_EXIST = "something-not-exist";
+
+    private static final String CMD_NOT_EXIST = "<job name=\"" + JOB_PLAN_NAME + "\">\n"
+            + "  <tasks>\n"
+            + "    <exec command=\"" + SOMETHING_NOT_EXIST + "\" />\n"
+            + "  </tasks>\n"
+            + "</job>";
+
+    private static final String WILL_NOT_RUN = "<job name=\"" + JOB_PLAN_NAME + "\">\n"
+            + "  <tasks>\n"
+            + "    <exec command=\"echo\" args=\"run when status is failed\">\n"
+            + "      <runif status=\"failed\" />\n"
+            + "    </exec>\n"
+            + "  </tasks>\n"
+            + "</job>";
+
+    private static final String MULTIPLE_TASKS = "<job name=\"" + JOB_PLAN_NAME + "\">\n"
+            + "  <tasks>\n"
+            + "    <exec command=\"command-not-found\" >\n"
+            + "    </exec>\n"
+            + "    <exec command=\"echo\" args=\"run when status is failed\">\n"
+            + "      <runif status=\"failed\" />\n"
+            + "    </exec>\n"
+            + "    <exec command=\"echo\" args=\"run when status is passed\">\n"
+            + "      <runif status=\"passed\" />\n"
+            + "    </exec>\n"
+            + "    <exec command=\"echo\" args=\"run when status is any\">\n"
+            + "      <runif status=\"any\" />\n"
+            + "    </exec>\n"
+            + "  </tasks>\n"
+            + "</job>";
+
+    private static final String MULTIPLE_RUN_IFS = "<job name=\"" + JOB_PLAN_NAME + "\">\n"
+            + "  <tasks>\n"
+            + "    <exec command=\"echo\" args=\"run when status is failed, passed or cancelled\">\n"
+            + "      <runif status=\"failed\" />\n"
+            + "      <runif status=\"passed\" />\n"
+            + "    </exec>\n"
+            + "  </tasks>\n"
+            + "</job>";
+
+    private static final String SLEEP_TEN_SECONDS_ON_UNIX = "<job name=\"" + JOB_PLAN_NAME + "\">\n"
+            + "  <tasks>\n"
+            + "    <exec command=\"/bin/sh\">\n"
+            + "      <arg>-c</arg>\n"
+            + "      <arg>echo before sleep; sleep 100</arg>\n"
+            + "      <oncancel>\n"
+            + "        <exec command=\"/bin/bash\">\n"
+            + "           <arg>-c</arg>\n"
+            + "           <arg>echo \"executing on cancel task\"; echo \"done\"</arg>\n"
+            + "        </exec>\n"
+            + "      </oncancel>\n"
+            + "    </exec>\n"
+            + "  </tasks>\n"
+            + "</job>";
+
+    private static final String SLEEP_TEN_SECONDS_ON_WINDOWS = "<job name=\"" + JOB_PLAN_NAME + "\">\n"
+            + "  <tasks>\n"
+            + "    <exec command=\"echo before sleep &amp; ping 1.1.1.1 -n 1 -w 100000 >NULL\">\n"
+            + "      <oncancel>\n"
+            + "        <exec command=\"echo\">\n"
+            + "           <arg>executing on cancel task</arg>\n"
+            + "        </exec>\n"
+            + "      </oncancel>\n"
+            + "    </exec>\n"
+            + "  </tasks>\n"
+            + "</job>";
+
+    private static BuilderFactory builderFactory = new BuilderFactory(new AntTaskBuilder(), new ExecTaskBuilder(), new NantTaskBuilder(), new RakeTaskBuilder(),
+            new PluggableTaskBuilderCreator(mock(TaskExtension.class)), new KillAllChildProcessTaskBuilder(), new FetchTaskBuilder(), new NullTaskBuilder());
+    @Mock
+    private static UpstreamPipelineResolver resolver;
+
+    private volatile BuildSession buildSession;
+
+    private static String willUpload(String file) {
+        return "<job name=\"" + JOB_PLAN_NAME + "\">\n"
+                + "   <artifacts>\n"
+                + "      <artifact src=\"something-not-there.txt\" dest=\"dist\" />\n"
+                + "      <artifact src=\"" + file + "\" dest=\"dist\\test\" />\n"
+                + "   </artifacts>"
+                + "  <tasks>\n"
+                + "    <exec command=\"echo\">\n"
+                + "      <arg>hello world</arg>\n"
+                + "    </exec>\n"
+                + "  </tasks>\n"
+                + "</job>";
+
+    }
+
+    private static String willUploadToDest(String file, String dest) {
+        return "<job name=\"" + JOB_PLAN_NAME + "\">\n"
+                + "   <artifacts>\n"
+                + "      <artifact src=\"" + file + "\" dest=\"" + dest + "\" />\n"
+                + "   </artifacts>"
+                + "  <tasks>\n"
+                + "    <exec command=\"echo\">\n"
+                + "      <arg>hello world</arg>\n"
+                + "    </exec>\n"
+                + "  </tasks>\n"
+                + "</job>";
+    }
+
+
+    private static String willUploadTestArtifact(String path, String dest) {
+        return "<job name=\"" + JOB_PLAN_NAME + "\">\n"
+                + "   <artifacts>\n"
+                + "      <test src=\"" + path + "\" dest=\"" + dest + "\" />\n"
+                + "   </artifacts>"
+                + "  <tasks>\n"
+                + "    <exec command=\"echo\">\n"
+                + "      <arg>hello world</arg>\n"
+                + "    </exec>\n"
+                + "  </tasks>\n"
+                + "</job>";
+    }
+
+    private String willGenerateProperties(String src, String propertyName, String xpath) {
+        return "<job name=\"" + JOB_PLAN_NAME + "\">\n"
+                + "   <properties>\n"
+                + "      <property name=\"" + propertyName + "\" src=\"" + src + "\" xpath=\"" +  xpath + "\" />\n"
+                + "   </properties>"
+                + "  <tasks>\n"
+                + "    <exec command=\"echo\">\n"
+                + "      <arg>hello world</arg>\n"
+                + "    </exec>\n"
+                + "  </tasks>\n"
+                + "</job>";
+    }
+
+
+
+    @Before
+    public void setUp() throws Exception {
+        initMocks(this);
+    }
+
+    @After
+    public void tearDown() {
+        verifyNoMoreInteractions(resolver);
+    }
+
+    private void build(String jobXml, String pipelineName, boolean fetchMaterials, boolean cleanWorkingDir) throws Exception {
+        BuildAssignment assignment = getAssigment(jobXml, pipelineName, fetchMaterials, cleanWorkingDir);
+        final BuildCommand buildCommand = new BuildComposer(assignment).compose();
+        buildSession = newBuildSession();
+        buildSession.setEnv("GO_SERVER_URL", SERVER_URL);
+        buildSession.build(buildCommand);
+    }
+
+
+    @Test
+    public void shouldUpdateBothStatusAndResultWhenBuildHasFailed() throws Exception {
+        build(WILL_FAIL, PIPELINE_NAME, true, false);
+        assertThat(statusReporter.status(), is(Arrays.asList(Preparing, Building, Completing, Completed)));
+        assertThat(getLast(statusReporter.results()), is(Failed));
+    }
+
+    @Test
+    public void shouldUpdateBothStatusAndResultWhenBuildHasPassed() throws Exception {
+        build(WILL_PASS, PIPELINE_NAME, true, false);
+        assertThat(statusReporter.status(), is(Arrays.asList(Preparing, Building, Completing, Completed)));
+        assertThat(getLast(statusReporter.results()), is(Passed));
+    }
+
+    @Test
+    public void shouldRunTaskWhenConditionMatches() throws Exception {
+        build(MULTIPLE_RUN_IFS, PIPELINE_NAME, true, false);
+        assertThat(console.output(), containsString("[go] Current job status: passed."));
+        assertThat(console.output(), containsString("[go] Start to execute task: <exec command=\"echo\" args=\"run when status is failed, passed or cancelled\" />."));
+        assertThat(console.output(), containsString("run when status is failed, passed or cancelled"));
+        assertThat(console.output(), not(containsString("Current job status: failed.")));
+    }
+
+
+    @Test
+    public void shouldNotRunTaskWhichConditionDoesNotMatch() throws Exception {
+        build(WILL_NOT_RUN, PIPELINE_NAME, true, false);
+        assertThat(console.output(), not(containsString("run when status is failed")));
+    }
+
+    @Test
+    public void shouldRunTasksBasedOnConditions() throws Exception {
+        build(MULTIPLE_TASKS, PIPELINE_NAME, true, false);
+        assertThat(console.output(), containsString("run when status is failed"));
+        assertThat(console.output(), printedExcRunIfInfo("command-not-found", "passed"));
+        assertThat(console.output(), containsString("run when status is any"));
+        assertThat(console.output(), printedExcRunIfInfo("echo", "run when status is any", "failed"));
+        assertThat(console.output(), not(containsString("run when status is passed")));
+        assertThat(console.output(), not(printedExcRunIfInfo("echo", "run when status is passed", "failed")));
+        assertThat(console.output(), not(containsString("run when status is cancelled")));
+        assertThat(console.output(), not(printedExcRunIfInfo("echo", "run when status is cancelled", "failed")));
+    }
+
+    @Test
+    public void shouldReportDirectoryNotExists() throws Exception {
+        build(NANT_WITH_WORKINGDIR, PIPELINE_NAME, true, false);
+        assertThat(console.output(), containsString("not-exists\" is not a directory!"));
+    }
+
+    @Test
+    @RunIf(value = EnhancedOSChecker.class, arguments = {DO_NOT_RUN_ON, WINDOWS})
+    public void shouldReportErrorWhenComandIsNotExistOnLinux() throws Exception {
+        build(CMD_NOT_EXIST, PIPELINE_NAME, true, false);
+        assertThat(console.output(), printedAppsMissingInfoOnUnix(SOMETHING_NOT_EXIST));
+        assertThat(statusReporter.results(), containsResult(Failed));
+    }
+
+    @Test
+    @RunIf(value = EnhancedOSChecker.class, arguments = {EnhancedOSChecker.WINDOWS})
+    public void shouldReportErrorWhenComandIsNotExistOnWindows() throws Exception {
+        build(CMD_NOT_EXIST, PIPELINE_NAME, true, false);
+        assertThat(console.output(), printedAppsMissingInfoOnWindows(SOMETHING_NOT_EXIST));
+        assertThat(statusReporter.results(), containsResult(Failed));
+    }
+    
+    @Test
+    public void shouldReportBuildStatusToConsoleout() throws Exception {
+        build(WILL_FAIL, PIPELINE_NAME, true, false);
+
+        String locator = JOB_IDENTIFIER.buildLocator();
+        assertThat(console.output(), printedPreparingInfo(locator));
+        assertThat(console.output(), printedBuildingInfo(locator));
+        assertThat(console.output(), printedUploadingInfo(locator));
+        assertThat(console.output(), printedBuildFailed());
+        assertThat(console.output(), printedJobCompletedInfo(JOB_IDENTIFIER.buildLocatorForDisplay()));
+    }
+
+    @Test
+    @RunIf(value = EnhancedOSChecker.class, arguments = {EnhancedOSChecker.WINDOWS})
+    public void nantTest() throws Exception {
+        build(NANT, PIPELINE_NAME, true, false);
+        assertThat(console.output(), containsString("Usage : NAnt [options] <target> <target> ..."));
+    }
+
+    @Test
+    public void rakeTest() throws Exception {
+        build(RAKE, PIPELINE_NAME, true, false);
+        assertThat(console.output(), containsString("rake [-f rakefile] {options} targets..."));
+    }
+
+    @Test
+    public void shouldSkipMaterialUpdateWhenFetchMaterialsIsSetToFalse() throws Exception {
+        build(WILL_PASS, PIPELINE_NAME, false, false);
+        assertThat(console.output(), containsString("Start to prepare"));
+        assertThat(console.output(), not(containsString("Start updating")));
+        assertThat(console.output(), containsString("Skipping material update since stage is configured not to fetch materials"));
+        assertThat(statusReporter.status().contains(JobState.Preparing), is(true));
+    }
+
+    @Test
+    public void shouldUpdateMaterialsWhenFetchMaterialsIsTrue() throws Exception {
+        build(WILL_PASS, PIPELINE_NAME, true, false);
+        assertThat(console.output(), containsString("Start to prepare"));
+        assertThat(console.output(), containsString("Start to update materials"));
+        assertThat(statusReporter.status().contains(JobState.Preparing), is(true));
+    }
+
+    @Test
+    public void shouldCreateAgentWorkingDirectoryIfNotExist() throws Exception {
+        String pipelineName = "pipeline1";
+        File workingdir = new File(sandbox, "pipelines/" + pipelineName);
+        assertThat(workingdir.exists(), is(false));
+        build(WILL_PASS, pipelineName, true, false);
+
+        assertThat(console.output(),
+                not(containsString("Working directory \"" + workingdir.getAbsolutePath() + "\" is not a directory")));
+
+        assertThat(statusReporter.results().contains(Passed), is(true));
+        assertThat(workingdir.exists(), is(true));
+    }
+
+    @Test
+    public void shouldNotBombWhenCreatingWorkingDirectoryIfCleanWorkingDirectoryFlagIsTrue() throws Exception {
+        String pipelineName = "p1";
+        File workingdir = new File(sandbox, "pipelines/" + pipelineName);
+        assertThat(workingdir.exists(), is(false));
+        build(WILL_PASS, pipelineName, true, true);
+
+        assertThat(console.output(),
+                not(containsString("Working directory \"" + workingdir.getAbsolutePath() + "\" is not a directory")));
+
+        assertThat(statusReporter.results().contains(Passed), is(true));
+        assertThat(workingdir.exists(), is(true));
+    }
+
+    @Test
+    public void shouldCreateAgentWorkingDirectoryIfNotExistWhenFetchMaterialsIsFalse() throws Exception {
+        String pipelineName = "p1";
+        File workingdir = new File(sandbox, "pipelines/" + pipelineName);
+        assertThat(workingdir.exists(), is(false));
+        build(WILL_PASS, pipelineName, false, false);
+
+        assertThat(console.output(), not(containsString("Working directory \"" + workingdir.getAbsolutePath() + "\" is not a directory")));
+        assertThat(statusReporter.results().contains(Passed), is(true));
+        assertThat(workingdir.exists(), is(true));
+    }
+
+    @Test
+    public void shouldCleanAgentWorkingDirectoryIfExistsWhenCleanWorkingDirIsTrue() throws Exception {
+        String pipelineName = "p1";
+        File workingdir = new File(sandbox, "pipelines/" + pipelineName);
+        workingdir.mkdirs();
+        new File(workingdir, "foo").createNewFile();
+        new File(workingdir, "bar").mkdirs();
+        assertThat(workingdir.listFiles().length, is(2));
+
+        build(WILL_PASS, pipelineName, false, true);
+        assertThat(statusReporter.results().contains(Passed), is(true));
+        assertThat(workingdir.exists(), is(true));
+        assertThat(workingdir.listFiles().length, is(0));
+    }
+
+    @Test
+    public void shouldReportAgentLocation() throws Exception {
+        buildVariables.put("agent.location", "far/far/away");
+        build(WILL_PASS, PIPELINE_NAME, true, false);
+        assertThat(console.output(), containsString("[far/far/away]"));
+    }
+
+    @Test
+    public void shouldReportEnvironmentVariables() throws Exception {
+        build(WITH_ENV_VAR, PIPELINE_NAME, true, false);
+        assertThat(console.output(), matches("'GO_SERVER_URL' (to|with) value '" + SERVER_URL));
+        assertThat(console.output(), matches("'GO_PIPELINE_LABEL' (to|with) value '" + PIPELINE_LABEL));
+        assertThat(console.output(), matches("'GO_PIPELINE_NAME' (to|with) value '" + PIPELINE_NAME));
+        assertThat(console.output(), matches("'GO_STAGE_NAME' (to|with) value '" + STAGE_NAME));
+        assertThat(console.output(), matches("'GO_STAGE_COUNTER' (to|with) value '" + STAGE_COUNTER));
+        assertThat(console.output(), matches("'GO_JOB_NAME' (to|with) value '" + JOB_PLAN_NAME));
+        assertThat(console.output(), containsString("[go] setting environment variable 'JOB_ENV' to value 'foobar'"));
+        if (isWindows()) {
+            assertThat(console.output(), containsString("[go] overriding environment variable 'Path' with value '/tmp'"));
+        } else {
+            assertThat(console.output(), containsString("[go] overriding environment variable 'PATH' with value '/tmp'"));
+        }
+    }
+
+    @Test
+    public void shouldMaskSecretInEnvironmentVarialbeReport() throws Exception {
+        build(WITH_SECRET_ENV_VAR, PIPELINE_NAME, true, false);
+        assertThat(console.output(), containsString("[go] setting environment variable 'foo' to value 'foo(******)'"));
+        assertThat(console.output(), containsString("[go] setting environment variable 'bar' to value '********'"));
+        assertThat(console.output(), not(containsString("i am a secret")));
+    }
+
+    @Test
+    public void shouldRunCancelTaskWhenBuildIsCanceled() throws Exception {
+        final Exception[] err = {null};
+        Thread buildThread = new Thread(new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    build(SystemUtil.isWindows() ? SLEEP_TEN_SECONDS_ON_WINDOWS: SLEEP_TEN_SECONDS_ON_UNIX,
+                            PIPELINE_NAME, true, false);
+                } catch (Exception e) {
+                    err[0] = e;
+                }
+            }
+        });
+
+        buildThread.start();
+        console.waitForContain("before sleep", 5);
+        assertTrue(buildSession.cancel(30, TimeUnit.SECONDS));
+        assertThat(statusReporter.status(), is(Arrays.asList(Preparing, Building, Completed)));
+        assertThat(statusReporter.results(), is(Collections.singletonList(Cancelled)));
+        assertThat(console.output(), printedJobCompletedInfo(JOB_IDENTIFIER.buildLocatorForDisplay()));
+        assertThat(console.output(), printedJobCanceledInfo(JOB_IDENTIFIER.buildLocatorForDisplay()));
+        assertThat(console.output(), containsString("executing on cancel task"));
+        buildThread.join();
+        if (err[0] != null) {
+            throw err[0];
+        }
+    }
+
+    @Test
+    public void shouldReportUploadMessageWhenUpload() throws Exception {
+        String destFolder = "dest\\test\\sub-folder";
+        File basedir = new File(sandbox, "pipelines/pipeline1");
+        basedir.mkdirs();
+        File artifact = new File(basedir, "artifact");
+        artifact.createNewFile();
+        build(willUploadToDest("artifact", destFolder), PIPELINE_NAME, true, false);
+        assertThat("build should pass, console output is" + console.output(), getLast(statusReporter.results()), is(Passed));
+        assertThat(artifactsRepository.getFileUploaded().size(), is(1));
+        assertThat(artifactsRepository.getFileUploaded().get(0).file, is(artifact));
+    }
+
+    @Test
+    public void shouldFailTheJobWhenFailedToUploadArtifact() throws Exception {
+        artifactsRepository.setUploadError(new RuntimeException("upload failed"));
+        build(willUpload("cruise-output/log.xml"), PIPELINE_NAME, true, false);
+        assertThat(statusReporter.results(), containsResult(Failed));
+    }
+
+    @Test
+    public void generateReportForNUnit() throws Exception {
+        File basedir = new File(sandbox, "pipelines/pipeline1/test-reports");
+        basedir.mkdirs();
+
+        InputStream nunitResult = new ClassPathResource(FileUtil.fileseparator() + "data" + FileUtil.fileseparator() + "TestResult.xml").getInputStream();
+        FileOutputStream testArtifact = new FileOutputStream(new File(basedir, "test-result.xml"));
+        copyAndClose(nunitResult, testArtifact);
+
+        build(willUploadTestArtifact("test-reports", "test-report-dest"), PIPELINE_NAME, false, false);
+
+        assertThat(artifactsRepository.getFileUploaded().size(), Is.is(2));
+        assertThat(artifactsRepository.getFileUploaded().get(0).file, is(basedir));
+        assertThat(artifactsRepository.getFileUploaded().get(0).destPath, is("test-report-dest"));
+        assertThat(artifactsRepository.getFileUploaded().get(1).destPath, is("testoutput"));
+        assertThat(artifactsRepository.propertyValue(TestReportGenerator.TOTAL_TEST_COUNT), is("206"));
+        assertThat(artifactsRepository.propertyValue(TestReportGenerator.FAILED_TEST_COUNT), is("0"));
+        assertThat(artifactsRepository.propertyValue(TestReportGenerator.IGNORED_TEST_COUNT), is("0"));
+        assertThat(artifactsRepository.propertyValue(TestReportGenerator.TEST_TIME), is("NaN"));
+    }
+
+    @Test
+    public void generateBuildPropertyUsingXPath() throws Exception {
+        File basedir = new File(sandbox, "pipelines/pipeline1");
+        String content = "<artifacts>\n"
+                + "         <artifact src=\"target\\connectfour.jar\" dest=\"dist\\jars\" />\n"
+                + "         <artifact src=\"target\\test-results\" dest=\"testoutput\" type=\"junit\" />\n"
+                + "         <artifact src=\"build.xml\" />\n"
+                + "       </artifacts>\n";
+        File file = new File(basedir, "xmlfile");
+        FileUtils.writeStringToFile(file, content, "UTF-8");
+        build(willGenerateProperties("xmlfile", "artifactsrc", "//artifact/@src"), PIPELINE_NAME, false, false);
+        assertThat(buildInfo(), getLast(statusReporter.results()), is(Passed));
+        assertThat(artifactsRepository.propertyValue("artifactsrc"), is("target\\connectfour.jar"));
+    }
+
+    private static BuildAssignment getAssigment(String jobXml, String pipelineName, boolean fetchMaterials, boolean cleanWorkingDir) throws Exception {
+        CruiseConfig cruiseConfig = new MagicalGoConfigXmlLoader(new ConfigCache(), ConfigElementImplementationRegistryMother.withNoPlugins()).loadConfigHolder(FileUtil.readToEnd(IOUtils.toInputStream(ConfigFileFixture.withJob(jobXml, pipelineName)))).config;
+        JobConfig jobConfig = cruiseConfig.jobConfigByName(pipelineName, STAGE_NAME, JOB_PLAN_NAME, true);
+
+        JobPlan jobPlan = JobInstanceMother.createJobPlan(jobConfig, new JobIdentifier(pipelineName, -2, PIPELINE_LABEL, STAGE_NAME, String.valueOf(STAGE_COUNTER), JOB_PLAN_NAME, 0L),
+                new DefaultSchedulingContext());
+        jobPlan.setFetchMaterials(fetchMaterials);
+        jobPlan.setCleanWorkingDir(cleanWorkingDir);
+        final Stage stage = StageMother.custom(STAGE_NAME, new JobInstance(JOB_PLAN_NAME));
+        BuildCause buildCause = BuildCause.createWithEmptyModifications();
+        final Pipeline pipeline = new Pipeline(pipelineName, buildCause, stage);
+        pipeline.setLabel(PIPELINE_LABEL);
+        List<Builder> builder = builderFactory.buildersForTasks(pipeline, jobConfig.getTasks(), resolver);
+
+        return BuildAssignment.create(jobPlan,
+                BuildCause.createWithEmptyModifications(),
+                builder, pipeline.defaultWorkingFolder()
+        );
+    }
+}

--- a/server/test/unit/com/thoughtworks/go/domain/BuildComposerTest.java
+++ b/server/test/unit/com/thoughtworks/go/domain/BuildComposerTest.java
@@ -37,6 +37,8 @@ import com.thoughtworks.go.server.service.builders.*;
 import com.thoughtworks.go.util.ConfigElementImplementationRegistryMother;
 import com.thoughtworks.go.util.FileUtil;
 import com.thoughtworks.go.util.SystemUtil;
+import com.thoughtworks.go.utils.Assertions;
+import com.thoughtworks.go.utils.Timeout;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.hamcrest.core.Is;
@@ -64,6 +66,8 @@ import static com.thoughtworks.go.matchers.ConsoleOutMatcher.*;
 import static com.thoughtworks.go.matchers.RegexMatcher.matches;
 import static com.thoughtworks.go.util.SystemUtil.isWindows;
 import static com.thoughtworks.go.util.TestUtils.copyAndClose;
+import static com.thoughtworks.go.utils.Assertions.assertWillHappen;
+import static com.thoughtworks.go.utils.Assertions.waitUntil;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.core.StringContains.containsString;
@@ -504,7 +508,7 @@ public class BuildComposerTest extends BuildSessionBasedTestCase {
         });
 
         buildThread.start();
-        console.waitForContain("before sleep", 5);
+        console.waitForContain("before sleep", Timeout.FIVE_SECONDS);
         assertTrue(buildSession.cancel(30, TimeUnit.SECONDS));
         assertThat(statusReporter.status(), is(Arrays.asList(Preparing, Building, Completed)));
         assertThat(statusReporter.results(), is(Collections.singletonList(Cancelled)));

--- a/server/test/unit/com/thoughtworks/go/remote/BuildRepositoryRemoteImplTest.java
+++ b/server/test/unit/com/thoughtworks/go/remote/BuildRepositoryRemoteImplTest.java
@@ -57,7 +57,7 @@ public class BuildRepositoryRemoteImplTest {
         jobStatusTopic = mock(JobStatusTopic.class);
         buildRepository = new BuildRepositoryRemoteImpl(repositoryService, agentService, jobStatusTopic);
         logFixture = LogFixture.startListening(Level.TRACE);
-        info = new AgentRuntimeInfo(new AgentIdentifier("host", "192.168.1.1", "uuid"), AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null);
+        info = new AgentRuntimeInfo(new AgentIdentifier("host", "192.168.1.1", "uuid"), AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null, false);
     }
 
     @After

--- a/server/test/unit/com/thoughtworks/go/remote/work/AgentStatusReportingIntegrationTest.java
+++ b/server/test/unit/com/thoughtworks/go/remote/work/AgentStatusReportingIntegrationTest.java
@@ -44,7 +44,7 @@ public class AgentStatusReportingIntegrationTest {
         environmentVariableContext = new EnvironmentVariableContext();
         artifactManipulator = new GoArtifactsManipulatorStub();
         buildRepository = new com.thoughtworks.go.remote.work.BuildRepositoryRemoteStub();
-        this.agentRuntimeInfo = new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null);
+        this.agentRuntimeInfo = new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null, false);
     }
 
     @After
@@ -56,7 +56,7 @@ public class AgentStatusReportingIntegrationTest {
     public void shouldReportBuildingWhenAgentRunningBuildWork() throws Exception {
         Work work = BuildWorkTest.getWork(WILL_PASS, BuildWorkTest.PIPELINE_NAME);
         work.doWork(agentIdentifier, buildRepository, artifactManipulator, environmentVariableContext, agentRuntimeInfo, null, null, null);
-        AgentRuntimeInfo agentRuntimeInfo1 = new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null);
+        AgentRuntimeInfo agentRuntimeInfo1 = new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null, false);
         agentRuntimeInfo1.busy(new AgentBuildingInfo("pipeline1/100/mingle/100/run-ant", "pipeline1/100/mingle/100/run-ant"));
         assertThat(agentRuntimeInfo, is(agentRuntimeInfo1));
     }
@@ -71,7 +71,7 @@ public class AgentStatusReportingIntegrationTest {
     }
 
     private AgentRuntimeInfo expectedAgentRuntimeInfo() {
-        AgentRuntimeInfo info = new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null);
+        AgentRuntimeInfo info = new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null, false);
         info.setBuildingInfo(new AgentBuildingInfo("pipeline1/100/mingle/100/run-ant", "pipeline1/100/mingle/100/run-ant"));
         info.cancel();
         return info;

--- a/server/test/unit/com/thoughtworks/go/remote/work/BuildWorkArtifactFetchingTest.java
+++ b/server/test/unit/com/thoughtworks/go/remote/work/BuildWorkArtifactFetchingTest.java
@@ -95,7 +95,7 @@ public class BuildWorkArtifactFetchingTest {
         buildWork = (BuildWork) BuildWorkTest.getWork(WITH_FETCH_FILE, PIPELINE_NAME);
         com.thoughtworks.go.remote.work.FailedToDownloadPublisherStub stubPublisher = new com.thoughtworks.go.remote.work.FailedToDownloadPublisherStub();
         buildWork.doWork(agentIdentifier, buildRepository, stubPublisher, environmentVariableContext,
-                new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null), null, null, null);
+                new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null, false), null, null, null);
 
         assertThat(stubPublisher.consoleOut(), containsString("[go] Current job status: passed."));
         assertThat(stubPublisher.consoleOut(), containsString("[go] Start to execute task: <fetchartifact pipeline=\"pipeline1\" stage=\"pre-mingle\" job=\"" + JOB_NAME + "\" srcfile=\"lib/hello.jar\" dest=\"lib\" />."));
@@ -109,7 +109,7 @@ public class BuildWorkArtifactFetchingTest {
         buildWork = (BuildWork) BuildWorkTest.getWork(WITH_FETCH_FILE, PIPELINE_NAME);
         com.thoughtworks.go.remote.work.FailedToDownloadPublisherStub stubPublisher = new FailedToDownloadPublisherStub();
         buildWork.doWork(agentIdentifier, buildRepository, stubPublisher, environmentVariableContext,
-                new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null), null, null, null);
+                new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null, false), null, null, null);
 
         assertThat(stubPublisher.consoleOut(), containsString("[go] Current job status: failed."));
         assertThat(stubPublisher.consoleOut(), containsString("[go] Start to execute task: <ant target=\"--help\" />."));
@@ -120,7 +120,7 @@ public class BuildWorkArtifactFetchingTest {
         buildWork = (BuildWork) BuildWorkTest.getWork(WITH_FETCH_FOLDER, PIPELINE_NAME);
         GoArtifactsManipulatorStub stubManipulator = new GoArtifactsManipulatorStub();
         buildWork.doWork(agentIdentifier, buildRepository, stubManipulator, environmentVariableContext,
-                new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null), null, null, null);
+                new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null, false), null, null, null);
 
         assertThat((DirHandler) stubManipulator.artifact().get(0), is(new DirHandler("lib",new File("pipelines" + File.separator + PIPELINE_NAME + File.separator + DEST))));
     }

--- a/server/test/unit/com/thoughtworks/go/remote/work/BuildWorkTest.java
+++ b/server/test/unit/com/thoughtworks/go/remote/work/BuildWorkTest.java
@@ -41,6 +41,7 @@ import com.thoughtworks.go.util.FileUtil;
 import com.thoughtworks.go.util.SystemEnvironment;
 import com.thoughtworks.go.util.SystemUtil;
 import com.thoughtworks.go.util.command.EnvironmentVariableContext;
+import com.thoughtworks.go.websocket.MessageEncoding;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.junit.After;
@@ -246,7 +247,7 @@ public class BuildWorkTest {
     public void shouldReportStatus() throws Exception {
         buildWork = (BuildWork) getWork(WILL_FAIL, PIPELINE_NAME);
 
-        buildWork.doWork(agentIdentifier, buildRepository, artifactManipulator, environmentVariableContext, new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null), packageAsRepositoryExtension, scmExtension, taskExtension);
+        buildWork.doWork(agentIdentifier, buildRepository, artifactManipulator, environmentVariableContext, new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null, false), packageAsRepositoryExtension, scmExtension, taskExtension);
 
         assertThat(buildRepository.states, containsState(Preparing));
         assertThat(buildRepository.states, containsState(Building));
@@ -258,7 +259,7 @@ public class BuildWorkTest {
         buildWork = (BuildWork) getWork(WILL_NOT_RUN, PIPELINE_NAME);
 
         buildWork.doWork(agentIdentifier, buildRepository, artifactManipulator, environmentVariableContext,
-                new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null), packageAsRepositoryExtension, scmExtension, taskExtension);
+                new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null, false), packageAsRepositoryExtension, scmExtension, taskExtension);
 
         String actual = artifactManipulator.consoleOut();
         assertThat(actual, not(containsString("run when status is failed")));
@@ -268,7 +269,7 @@ public class BuildWorkTest {
     public void shouldRunTaskWhenConditionMatches() throws Exception {
         buildWork = (BuildWork) getWork(MULTIPLE_RUN_IFS, PIPELINE_NAME);
         buildWork.doWork(agentIdentifier, buildRepository, artifactManipulator,
-                environmentVariableContext, new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null), packageAsRepositoryExtension, scmExtension, taskExtension);
+                environmentVariableContext, new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null, false), packageAsRepositoryExtension, scmExtension, taskExtension);
 
         String actual = artifactManipulator.consoleOut();
         assertThat(actual, containsString("[go] Current job status: passed."));
@@ -281,7 +282,7 @@ public class BuildWorkTest {
         buildWork = (BuildWork) getWork(MULTIPLE_TASKS, PIPELINE_NAME);
 
         buildWork.doWork(agentIdentifier, buildRepository, artifactManipulator, environmentVariableContext,
-                new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null), packageAsRepositoryExtension, scmExtension, taskExtension);
+                new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null, false), packageAsRepositoryExtension, scmExtension, taskExtension);
 
         String actual = artifactManipulator.consoleOut();
 
@@ -299,7 +300,7 @@ public class BuildWorkTest {
     public void shouldReportBuildIsFailedWhenAntBuildFailed() throws Exception {
         buildWork = (BuildWork) getWork(WILL_FAIL, PIPELINE_NAME);
         buildWork.doWork(agentIdentifier, buildRepository, artifactManipulator, environmentVariableContext,
-                new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null), packageAsRepositoryExtension, scmExtension, taskExtension);
+                new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null, false), packageAsRepositoryExtension, scmExtension, taskExtension);
 
         assertThat(buildRepository.results, containsResult(Failed));
     }
@@ -309,7 +310,7 @@ public class BuildWorkTest {
         buildWork = (BuildWork) getWork(NANT_WITH_WORKINGDIR, PIPELINE_NAME);
 
         buildWork.doWork(agentIdentifier, buildRepository, artifactManipulator, environmentVariableContext,
-                new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null), packageAsRepositoryExtension, scmExtension, taskExtension);
+                new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null, false), packageAsRepositoryExtension, scmExtension, taskExtension);
 
         assertThat(artifactManipulator.consoleOut(), containsString("not-exists\" is not a directory!"));
     }
@@ -325,7 +326,7 @@ public class BuildWorkTest {
         com.thoughtworks.go.remote.work.HttpServiceStub httpService = new com.thoughtworks.go.remote.work.HttpServiceStub(HttpServletResponse.SC_OK);
         artifactManipulator = new GoArtifactsManipulatorStub(httpService);
 
-        buildWork.doWork(agentIdentifier, buildRepository, artifactManipulator, environmentVariableContext, new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null), packageAsRepositoryExtension, scmExtension, taskExtension);
+        buildWork.doWork(agentIdentifier, buildRepository, artifactManipulator, environmentVariableContext, new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null, false), packageAsRepositoryExtension, scmExtension, taskExtension);
 
         String actual = artifactManipulator.consoleOut();
         artifactManipulator.printConsoleOut();
@@ -345,7 +346,7 @@ public class BuildWorkTest {
         artifactManipulator = new GoArtifactsManipulatorStub(new HttpServiceStub(SC_NOT_ACCEPTABLE));
 
         buildWork.doWork(agentIdentifier, buildRepository, artifactManipulator, environmentVariableContext,
-                new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null), packageAsRepositoryExtension, scmExtension, taskExtension);
+                new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null, false), packageAsRepositoryExtension, scmExtension, taskExtension);
 
         String actual = artifactManipulator.consoleOut();
 
@@ -359,7 +360,7 @@ public class BuildWorkTest {
         buildWork = (BuildWork) getWork(WILL_PASS, PIPELINE_NAME);
 
         buildWork.doWork(agentIdentifier, buildRepository, artifactManipulator, environmentVariableContext,
-                new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null), packageAsRepositoryExtension, scmExtension, taskExtension);
+                new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null, false), packageAsRepositoryExtension, scmExtension, taskExtension);
 
         assertThat(buildRepository.results, containsResult(Passed));
     }
@@ -373,7 +374,7 @@ public class BuildWorkTest {
         createBuildWorkWithJobPlan(jobPlan);
 
         try {
-            buildWork.doWork(agentIdentifier, buildRepository, artifactManipulator, environmentVariableContext, new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null), packageAsRepositoryExtension, scmExtension, taskExtension);
+            buildWork.doWork(agentIdentifier, buildRepository, artifactManipulator, environmentVariableContext, new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null, false), packageAsRepositoryExtension, scmExtension, taskExtension);
             fail("Should have thrown an assertion error");
         } catch (AssertionError e) {
             assertThat(buildRepository.results.isEmpty(), is(true));
@@ -391,7 +392,7 @@ public class BuildWorkTest {
         createBuildWorkWithJobPlan(jobPlan);
 
         try {
-            buildWork.doWork(agentIdentifier, buildRepository, artifactManipulator, environmentVariableContext, new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null), packageAsRepositoryExtension, scmExtension, taskExtension);
+            buildWork.doWork(agentIdentifier, buildRepository, artifactManipulator, environmentVariableContext, new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null, false), packageAsRepositoryExtension, scmExtension, taskExtension);
             fail("Should have thrown an assertion error");
         } catch (AssertionError e) {
             assertThat(buildRepository.results.isEmpty(), is(false));
@@ -404,7 +405,7 @@ public class BuildWorkTest {
         buildWork = (BuildWork) getWork(WILL_PASS, "pipeline1");
         buildRepository = new com.thoughtworks.go.remote.work.BuildRepositoryRemoteStub(true);
 
-        buildWork.doWork(agentIdentifier, buildRepository, artifactManipulator, environmentVariableContext, new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null), packageAsRepositoryExtension, scmExtension, taskExtension);
+        buildWork.doWork(agentIdentifier, buildRepository, artifactManipulator, environmentVariableContext, new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null, false), packageAsRepositoryExtension, scmExtension, taskExtension);
 
         assertThat(buildRepository.results.isEmpty(), is(true));
         assertThat(buildRepository.states, containsResult(JobState.Completed));
@@ -414,7 +415,7 @@ public class BuildWorkTest {
     public void shouldUpdateBothStatusAndResultWhenBuildHasPassed() throws Exception {
         buildWork = (BuildWork) getWork(WILL_PASS, "pipeline1");
 
-        buildWork.doWork(agentIdentifier, buildRepository, artifactManipulator, environmentVariableContext, new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null), packageAsRepositoryExtension, scmExtension, taskExtension);
+        buildWork.doWork(agentIdentifier, buildRepository, artifactManipulator, environmentVariableContext, new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null, false), packageAsRepositoryExtension, scmExtension, taskExtension);
 
         assertThat(buildRepository.results, containsResult(JobResult.Passed));
         assertThat(buildRepository.states, containsResult(JobState.Completed));
@@ -426,7 +427,7 @@ public class BuildWorkTest {
         buildWork = (BuildWork) getWork(CMD_NOT_EXIST, PIPELINE_NAME);
 
         buildWork.doWork(agentIdentifier, buildRepository, artifactManipulator, environmentVariableContext,
-                new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null), packageAsRepositoryExtension, scmExtension, taskExtension);
+                new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null, false), packageAsRepositoryExtension, scmExtension, taskExtension);
 
         assertThat(artifactManipulator.consoleOut(), printedAppsMissingInfoOnUnix(SOMETHING_NOT_EXIST));
         assertThat(buildRepository.results, containsResult(Failed));
@@ -437,7 +438,7 @@ public class BuildWorkTest {
     public void shouldReportErrorWhenComandIsNotExistOnWindows() throws Exception {
         buildWork = (BuildWork) getWork(CMD_NOT_EXIST, PIPELINE_NAME);
         buildWork.doWork(agentIdentifier, buildRepository, artifactManipulator,
-                environmentVariableContext, new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null), packageAsRepositoryExtension, scmExtension, taskExtension);
+                environmentVariableContext, new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null, false), packageAsRepositoryExtension, scmExtension, taskExtension);
 
         assertThat(artifactManipulator.consoleOut(), printedAppsMissingInfoOnWindows(SOMETHING_NOT_EXIST));
         assertThat(buildRepository.results, containsResult(Failed));
@@ -446,7 +447,7 @@ public class BuildWorkTest {
     @Test
     public void shouldReportConsoleout() throws Exception {
         buildWork = (BuildWork) getWork(WILL_FAIL, PIPELINE_NAME);
-        buildWork.doWork(agentIdentifier, buildRepository, artifactManipulator, environmentVariableContext, new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null), packageAsRepositoryExtension, scmExtension, taskExtension);
+        buildWork.doWork(agentIdentifier, buildRepository, artifactManipulator, environmentVariableContext, new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null, false), packageAsRepositoryExtension, scmExtension, taskExtension);
 
         String consoleOutAsString = artifactManipulator.consoleOut();
 
@@ -462,7 +463,7 @@ public class BuildWorkTest {
     public void nantTest() throws Exception {
         buildWork = (BuildWork) getWork(NANT, PIPELINE_NAME);
         buildWork.doWork(agentIdentifier, buildRepository, artifactManipulator,
-                environmentVariableContext, new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null), packageAsRepositoryExtension, scmExtension, taskExtension);
+                environmentVariableContext, new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null, false), packageAsRepositoryExtension, scmExtension, taskExtension);
 
         assertThat(artifactManipulator.consoleOut(), containsString("Usage : NAnt [options] <target> <target> ..."));
     }
@@ -471,7 +472,7 @@ public class BuildWorkTest {
     public void rakeTest() throws Exception {
         buildWork = (BuildWork) getWork(RAKE, PIPELINE_NAME);
         buildWork.doWork(agentIdentifier, buildRepository, artifactManipulator,
-                environmentVariableContext, new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null), packageAsRepositoryExtension, scmExtension, taskExtension);
+                environmentVariableContext, new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null, false), packageAsRepositoryExtension, scmExtension, taskExtension);
 
         assertThat(artifactManipulator.consoleOut(), containsString("rake [-f rakefile] {options} targets..."));
     }
@@ -479,7 +480,7 @@ public class BuildWorkTest {
     @Test
     public void doWork_shouldSkipMaterialUpdateWhenFetchMaterialsIsSetToFalse() throws Exception {
         buildWork = (BuildWork) getWork(WILL_PASS, PIPELINE_NAME, false, false);
-        buildWork.doWork(agentIdentifier, buildRepository, artifactManipulator, environmentVariableContext, new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null), packageAsRepositoryExtension, scmExtension, taskExtension);
+        buildWork.doWork(agentIdentifier, buildRepository, artifactManipulator, environmentVariableContext, new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null, false), packageAsRepositoryExtension, scmExtension, taskExtension);
         assertThat(artifactManipulator.consoleOut(), containsString("Start to prepare"));
         assertThat(artifactManipulator.consoleOut(), not(containsString("Start updating")));
         assertThat(artifactManipulator.consoleOut(), containsString("Skipping material update since stage is configured not to fetch materials"));
@@ -489,9 +490,10 @@ public class BuildWorkTest {
     @Test
     public void doWork_shouldUpdateMaterialsWhenFetchMaterialsIsTrue() throws Exception {
         buildWork = (BuildWork) getWork(WILL_PASS, PIPELINE_NAME, true, false);
-        buildWork.doWork(agentIdentifier, buildRepository, artifactManipulator, environmentVariableContext, new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null), packageAsRepositoryExtension, scmExtension, taskExtension);
+        buildWork.doWork(agentIdentifier, buildRepository, artifactManipulator, environmentVariableContext, new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null, false), packageAsRepositoryExtension, scmExtension, taskExtension);
         assertThat(artifactManipulator.consoleOut(), containsString("Start to prepare"));
         assertThat(buildRepository.states.contains(JobState.Preparing), is(true));
+        assertThat(artifactManipulator.consoleOut(), containsString("Start to update materials"));
     }
 
     @Test
@@ -505,7 +507,7 @@ public class BuildWorkTest {
         buildWork = (BuildWork) getWork(WILL_PASS, pipelineName);
 
         buildWork.doWork(agentIdentifier,
-                buildRepository, artifactManipulator, environmentVariableContext, new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null), packageAsRepositoryExtension, scmExtension, taskExtension);
+                buildRepository, artifactManipulator, environmentVariableContext, new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null, false), packageAsRepositoryExtension, scmExtension, taskExtension);
         assertThat(artifactManipulator.consoleOut(),
                 not(containsString("Working directory \"" + workingdir.getAbsolutePath() + "\" is not a directory")));
 
@@ -525,7 +527,7 @@ public class BuildWorkTest {
         buildWork = (BuildWork) getWork(WILL_PASS, pipelineName, true, true);
 
         buildWork.doWork(agentIdentifier,
-                buildRepository, artifactManipulator, environmentVariableContext, new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null), packageAsRepositoryExtension, scmExtension, taskExtension);
+                buildRepository, artifactManipulator, environmentVariableContext, new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null, false), packageAsRepositoryExtension, scmExtension, taskExtension);
         assertThat(artifactManipulator.consoleOut(),
                 not(containsString("Working directory \"" + workingdir.getAbsolutePath() + "\" is not a directory")));
 
@@ -544,7 +546,7 @@ public class BuildWorkTest {
         buildWork = (BuildWork) getWork(WILL_PASS, pipelineName, false, false);
 
         buildWork.doWork(agentIdentifier,
-                buildRepository, artifactManipulator, environmentVariableContext, new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null), packageAsRepositoryExtension, scmExtension, taskExtension);
+                buildRepository, artifactManipulator, environmentVariableContext, new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null, false), packageAsRepositoryExtension, scmExtension, taskExtension);
         assertThat(artifactManipulator.consoleOut(), not(containsString("Working directory \"" + workingdir.getAbsolutePath() + "\" is not a directory")));
         assertThat(buildRepository.results.contains(Passed), is(true));
         assertThat(workingdir.exists(), is(true));
@@ -564,7 +566,7 @@ public class BuildWorkTest {
         buildWork = (BuildWork) getWork(WILL_PASS, pipelineName, false, true);
 
         buildWork.doWork(agentIdentifier,
-                buildRepository, artifactManipulator, environmentVariableContext, new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null), packageAsRepositoryExtension, scmExtension, taskExtension);
+                buildRepository, artifactManipulator, environmentVariableContext, new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null, false), packageAsRepositoryExtension, scmExtension, taskExtension);
         assertThat(artifactManipulator.consoleOut(), containsString("Cleaning working directory \"" + workingdir.getAbsolutePath()));
         assertThat(buildRepository.results.contains(Passed), is(true));
         assertThat(workingdir.exists(), is(true));
@@ -576,7 +578,7 @@ public class BuildWorkTest {
         buildWork = (BuildWork) getWork(WILL_PASS, PIPELINE_NAME);
 
         buildWork.doWork(agentIdentifier,
-                buildRepository, artifactManipulator, environmentVariableContext, new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null), packageAsRepositoryExtension, scmExtension, taskExtension);
+                buildRepository, artifactManipulator, environmentVariableContext, new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null, false), packageAsRepositoryExtension, scmExtension, taskExtension);
         assertThat(artifactManipulator.consoleOut(),
                 containsString("[" + SystemUtil.currentWorkingDirectory() + "]"));
     }
@@ -636,7 +638,7 @@ public class BuildWorkTest {
     public void shouldReportEnvironmentVariables() throws Exception {
         buildWork = (BuildWork) getWork(WITH_ENV_VAR, PIPELINE_NAME);
 
-        buildWork.doWork(agentIdentifier, buildRepository, artifactManipulator, environmentVariableContext, new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null), packageAsRepositoryExtension, scmExtension, taskExtension);
+        buildWork.doWork(agentIdentifier, buildRepository, artifactManipulator, environmentVariableContext, new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null, false), packageAsRepositoryExtension, scmExtension, taskExtension);
 
         String consoleOut = artifactManipulator.consoleOut();
 
@@ -660,7 +662,7 @@ public class BuildWorkTest {
     public void shouldMaskSecretInEnvironmentVarialbeReport() throws Exception {
         buildWork = (BuildWork) getWork(WITH_SECRET_ENV_VAR, PIPELINE_NAME);
 
-        buildWork.doWork(agentIdentifier, buildRepository, artifactManipulator, environmentVariableContext, new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null), packageAsRepositoryExtension, scmExtension, taskExtension);
+        buildWork.doWork(agentIdentifier, buildRepository, artifactManipulator, environmentVariableContext, new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null, false), packageAsRepositoryExtension, scmExtension, taskExtension);
 
         String consoleOut = artifactManipulator.consoleOut();
         assertThat(consoleOut, containsString("[go] setting environment variable 'foo' to value 'foo(******)'"));
@@ -668,4 +670,10 @@ public class BuildWorkTest {
         assertThat(consoleOut, not(containsString("i am a secret")));
     }
 
+    @Test
+    public void encodeAndDecodeBuildWorkAsMessageData() throws Exception {
+        Work original = getWork(WILL_FAIL, PIPELINE_NAME);
+        Work clone = MessageEncoding.decodeWork(MessageEncoding.encodeWork(original));
+        assertThat(clone, is(original));
+    }
 }

--- a/server/test/unit/com/thoughtworks/go/server/controller/AgentRegistrationControllerTest.java
+++ b/server/test/unit/com/thoughtworks/go/server/controller/AgentRegistrationControllerTest.java
@@ -79,8 +79,8 @@ public class AgentRegistrationControllerTest {
         when(goConfigService.hasAgent("blahAgent-uuid")).thenReturn(false);
         ServerConfig serverConfig = new ServerConfig("artifacts", new SecurityConfig(), 10, 20, "1", null);
         when(goConfigService.serverConfig()).thenReturn(serverConfig);
-        controller.agentRequest("blahAgent-host", "blahAgent-uuid", "blah-location", "34567", "osx", "", "", "", "", "", "", request);
-        verify(agentService).requestRegistration(AgentRuntimeInfo.fromServer(new AgentConfig("blahAgent-uuid", "blahAgent-host", request.getRemoteAddr()), false, "blah-location", 34567L, "osx"));
+        controller.agentRequest("blahAgent-host", "blahAgent-uuid", "blah-location", "34567", "osx", "", "", "", "", "", "", false, request);
+        verify(agentService).requestRegistration(AgentRuntimeInfo.fromServer(new AgentConfig("blahAgent-uuid", "blahAgent-host", request.getRemoteAddr()), false, "blah-location", 34567L, "osx", false));
     }
 
     @Test
@@ -90,9 +90,9 @@ public class AgentRegistrationControllerTest {
         ServerConfig serverConfig = new ServerConfig("artifacts", new SecurityConfig(), 10, 20, "1", "someKey");
         when(goConfigService.serverConfig()).thenReturn(serverConfig);
 
-        controller.agentRequest("host", uuid, "location", "233232", "osx", "someKey", "", "", "", "", "", request);
+        controller.agentRequest("host", uuid, "location", "233232", "osx", "someKey", "", "", "", "", "", false, request);
 
-        verify(agentService).requestRegistration(AgentRuntimeInfo.fromServer(new AgentConfig(uuid, "host", request.getRemoteAddr()), false, "location", 233232L, "osx"));
+        verify(agentService).requestRegistration(AgentRuntimeInfo.fromServer(new AgentConfig(uuid, "host", request.getRemoteAddr()), false, "location", 233232L, "osx", false));
         verify(goConfigService).updateConfig(any(UpdateConfigCommand.class));
     }
 
@@ -103,9 +103,9 @@ public class AgentRegistrationControllerTest {
         ServerConfig serverConfig = new ServerConfig("artifacts", new SecurityConfig(), 10, 20, "1", "someKey");
         when(goConfigService.serverConfig()).thenReturn(serverConfig);
 
-        controller.agentRequest("host", uuid, "location", "233232", "osx", "someKey", "", "", "autoregister-hostname", "", "", request);
+        controller.agentRequest("host", uuid, "location", "233232", "osx", "someKey", "", "", "autoregister-hostname", "", "", false, request);
 
-        verify(agentService).requestRegistration(AgentRuntimeInfo.fromServer(new AgentConfig(uuid, "autoregister-hostname", request.getRemoteAddr()), false, "location", 233232L, "osx"));
+        verify(agentService).requestRegistration(AgentRuntimeInfo.fromServer(new AgentConfig(uuid, "autoregister-hostname", request.getRemoteAddr()), false, "location", 233232L, "osx", false));
         verify(goConfigService).updateConfig(any(UpdateConfigCommand.class));
     }
 
@@ -116,9 +116,9 @@ public class AgentRegistrationControllerTest {
         ServerConfig serverConfig = new ServerConfig("artifacts", new SecurityConfig(), 10, 20, "1", "");
         when(goConfigService.serverConfig()).thenReturn(serverConfig);
 
-        controller.agentRequest("host", uuid, "location", "233232", "osx", "", "", "", "", "", "", request);
+        controller.agentRequest("host", uuid, "location", "233232", "osx", "", "", "", "", "", "", false, request);
 
-        verify(agentService).requestRegistration(AgentRuntimeInfo.fromServer(new AgentConfig(uuid, "host", request.getRemoteAddr()), false, "location", 233232L, "osx"));
+        verify(agentService).requestRegistration(AgentRuntimeInfo.fromServer(new AgentConfig(uuid, "host", request.getRemoteAddr()), false, "location", 233232L, "osx", false));
         verify(goConfigService, never()).updateConfig(any(UpdateConfigCommand.class));
     }
 

--- a/server/test/unit/com/thoughtworks/go/server/controller/AgentRegistrationControllerTest.java
+++ b/server/test/unit/com/thoughtworks/go/server/controller/AgentRegistrationControllerTest.java
@@ -32,6 +32,7 @@ import org.junit.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.web.servlet.ModelAndView;
+import org.springframework.web.servlet.View;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
@@ -79,7 +80,10 @@ public class AgentRegistrationControllerTest {
         when(goConfigService.hasAgent("blahAgent-uuid")).thenReturn(false);
         ServerConfig serverConfig = new ServerConfig("artifacts", new SecurityConfig(), 10, 20, "1", null);
         when(goConfigService.serverConfig()).thenReturn(serverConfig);
-        controller.agentRequest("blahAgent-host", "blahAgent-uuid", "blah-location", "34567", "osx", "", "", "", "", "", "", false, request);
+
+        ModelAndView modelAndView = controller.agentRequest("blahAgent-host", "blahAgent-uuid", "blah-location", "34567", "osx", "", "", "", "", "", "", false, request);
+        assertThat(modelAndView.getView().getContentType(), is("application/json"));
+
         verify(agentService).requestRegistration(AgentRuntimeInfo.fromServer(new AgentConfig("blahAgent-uuid", "blahAgent-host", request.getRemoteAddr()), false, "blah-location", 34567L, "osx", false));
     }
 

--- a/server/test/unit/com/thoughtworks/go/server/messaging/BuildRepositoryMessageProducerTest.java
+++ b/server/test/unit/com/thoughtworks/go/server/messaging/BuildRepositoryMessageProducerTest.java
@@ -45,7 +45,7 @@ public class BuildRepositoryMessageProducerTest {
     private WorkAssignments newImplementation;
     private BuildRepositoryMessageProducer producer;
     private static final AgentIdentifier AGENT = new AgentIdentifier("localhost", "127.0.0.1", "uuid");
-    private static final AgentRuntimeInfo AGENT_INFO = new AgentRuntimeInfo(AGENT, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null);
+    private static final AgentRuntimeInfo AGENT_INFO = new AgentRuntimeInfo(AGENT, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null, false);
 
     @Before
     public void setUp() {
@@ -57,20 +57,20 @@ public class BuildRepositoryMessageProducerTest {
 
     @Test
     public void shouldDelegatePingToTheOldImplementation() {
-        producer.ping(new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null));
-        verify(oldImplementation).ping(new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null));
+        producer.ping(new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null, false));
+        verify(oldImplementation).ping(new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null, false));
     }
 
     @Test
     public void shouldDelegateReportJobStatusToTheOldImplementation() {
-        producer.reportCurrentStatus(new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null), jobIdentifier, assigned);
-        verify(oldImplementation).reportCurrentStatus(new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null), jobIdentifier, assigned);
+        producer.reportCurrentStatus(new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null, false), jobIdentifier, assigned);
+        verify(oldImplementation).reportCurrentStatus(new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null, false), jobIdentifier, assigned);
     }
 
     @Test
     public void shouldDelegateReportJobResultToTheOldImplementation() {
-        producer.reportCompleting(new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null), jobIdentifier, passed);
-        verify(oldImplementation).reportCompleting(new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null), jobIdentifier, passed);
+        producer.reportCompleting(new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null, false), jobIdentifier, passed);
+        verify(oldImplementation).reportCompleting(new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null, false), jobIdentifier, passed);
     }
 
     @Test

--- a/server/test/unit/com/thoughtworks/go/server/messaging/scheduling/WorkAssignmentsTest.java
+++ b/server/test/unit/com/thoughtworks/go/server/messaging/scheduling/WorkAssignmentsTest.java
@@ -56,7 +56,7 @@ public class WorkAssignmentsTest {
         }});
         assignments = new WorkAssignments(idleAgentsTopic, assignedWorkTopic);
         agentIdentifier = new AgentIdentifier("localhost", "127.0.0.1", "uuid");
-        agent = new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null);
+        agent = new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null, false);
     }
 
     @Test

--- a/server/test/unit/com/thoughtworks/go/server/messaging/scheduling/WorkFinderTest.java
+++ b/server/test/unit/com/thoughtworks/go/server/messaging/scheduling/WorkFinderTest.java
@@ -70,7 +70,7 @@ public class WorkFinderTest {
             will(returnValue(NO_WORK));
             one(assignedWorkTopic).post(new WorkAssignedMessage(AGENT_1, NO_WORK));
         }});
-        finder.onMessage(new IdleAgentMessage(new AgentRuntimeInfo(AGENT_1, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null)));
+        finder.onMessage(new IdleAgentMessage(new AgentRuntimeInfo(AGENT_1, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null, false)));
     }
 
     @Test
@@ -80,7 +80,7 @@ public class WorkFinderTest {
             will(returnValue(SOME_WORK));
             one(assignedWorkTopic).post(new WorkAssignedMessage(AGENT_1, SOME_WORK));
         }});
-        finder.onMessage(new IdleAgentMessage(new AgentRuntimeInfo(AGENT_1, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null)));
+        finder.onMessage(new IdleAgentMessage(new AgentRuntimeInfo(AGENT_1, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null, false)));
     }
 
     @Test
@@ -93,7 +93,7 @@ public class WorkFinderTest {
         }});
 
         try {
-            finder.onMessage(new IdleAgentMessage(new AgentRuntimeInfo(AGENT_1, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null)));
+            finder.onMessage(new IdleAgentMessage(new AgentRuntimeInfo(AGENT_1, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null, false)));
         } catch (Exception e) {
             assertSame(exception, e);
         }

--- a/server/test/unit/com/thoughtworks/go/server/service/AgentServiceTest.java
+++ b/server/test/unit/com/thoughtworks/go/server/service/AgentServiceTest.java
@@ -79,7 +79,7 @@ public class AgentServiceTest {
 
     @Test
     public void shouldUpdateStatus() throws Exception {
-        AgentRuntimeInfo runtimeInfo = new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "pavanIsGreat", null);
+        AgentRuntimeInfo runtimeInfo = new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "pavanIsGreat", null, false);
         when(agentDao.cookieFor(runtimeInfo.getIdentifier())).thenReturn("pavanIsGreat");
         agentService.updateRuntimeInfo(runtimeInfo);
         verify(agentInstances).updateAgentRuntimeInfo(runtimeInfo);
@@ -87,7 +87,7 @@ public class AgentServiceTest {
 
     @Test
     public void shouldThrowExceptionWhenAgentWithNoCookieTriesToUpdateStatus() throws Exception {
-        AgentRuntimeInfo runtimeInfo = new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), null, null);
+        AgentRuntimeInfo runtimeInfo = new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), null, null, false);
         try {
             agentService.updateRuntimeInfo(runtimeInfo);
             fail("should throw exception when no cookie is set");
@@ -100,9 +100,9 @@ public class AgentServiceTest {
 
     @Test
     public void shouldThrowExceptionWhenADuplicateAgentTriesToUpdateStatus() throws Exception {
-        AgentRuntimeInfo runtimeInfo = new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), null, null);
+        AgentRuntimeInfo runtimeInfo = new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), null, null, false);
         runtimeInfo.setCookie("invalid_cookie");
-        AgentInstance original = AgentInstance.createFromLiveAgent(new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), null, null), new SystemEnvironment());
+        AgentInstance original = AgentInstance.createFromLiveAgent(new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), null, null, false), new SystemEnvironment());
         try {
             when(agentService.findAgentAndRefreshStatus(runtimeInfo.getUUId())).thenReturn(original);
             agentService.updateRuntimeInfo(runtimeInfo);
@@ -127,8 +127,8 @@ public class AgentServiceTest {
 
     @Test
     public void shouldUnderstandFilteringAgentListBasedOnUuid() {
-        AgentInstance instance1 = AgentInstance.createFromLiveAgent(AgentRuntimeInfo.fromServer(new AgentConfig("uuid-1", "host-1", "192.168.1.2"), true, "/foo/bar", 100l, "linux"), new SystemEnvironment());
-        AgentInstance instance3 = AgentInstance.createFromLiveAgent(AgentRuntimeInfo.fromServer(new AgentConfig("uuid-3", "host-3", "192.168.1.4"), true, "/baz/quux", 300l, "linux"), new SystemEnvironment());
+        AgentInstance instance1 = AgentInstance.createFromLiveAgent(AgentRuntimeInfo.fromServer(new AgentConfig("uuid-1", "host-1", "192.168.1.2"), true, "/foo/bar", 100l, "linux", false), new SystemEnvironment());
+        AgentInstance instance3 = AgentInstance.createFromLiveAgent(AgentRuntimeInfo.fromServer(new AgentConfig("uuid-3", "host-3", "192.168.1.4"), true, "/baz/quux", 300l, "linux", false), new SystemEnvironment());
         when(agentInstances.filter(Arrays.asList("uuid-1", "uuid-3"))).thenReturn(Arrays.asList(instance1, instance3));
         AgentsViewModel agents = agentService.filter(Arrays.asList("uuid-1", "uuid-3"));
         AgentViewModel view1 = new AgentViewModel(instance1);

--- a/server/test/unit/com/thoughtworks/go/server/service/GoConfigServiceTest.java
+++ b/server/test/unit/com/thoughtworks/go/server/service/GoConfigServiceTest.java
@@ -60,13 +60,11 @@ import org.jdom.input.JDOMParseException;
 import org.joda.time.DateTime;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.File;
 import java.util.*;
 
-import static com.thoughtworks.go.config.PipelineConfigs.DEFAULT_GROUP;
 import static com.thoughtworks.go.helper.AgentMother.*;
 import static com.thoughtworks.go.helper.ConfigFileFixture.configWith;
 import static com.thoughtworks.go.helper.PipelineConfigMother.createGroup;
@@ -571,7 +569,7 @@ public class GoConfigServiceTest {
     public void shouldEnableAgentWhenPending() {
         String agentId = DatabaseAccessHelper.AGENT_UUID;
         AgentConfig agentConfig = new AgentConfig(agentId, "remote-host", "50.40.30.20");
-        AgentRuntimeInfo agentRuntimeInfo = new AgentRuntimeInfo(new AgentIdentifier("remote-host", "50.40.30.20", agentId), AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null);
+        AgentRuntimeInfo agentRuntimeInfo = new AgentRuntimeInfo(new AgentIdentifier("remote-host", "50.40.30.20", agentId), AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null, false);
         AgentInstance instance = AgentInstance.createFromLiveAgent(agentRuntimeInfo, new SystemEnvironment());
         goConfigService.disableAgents(false, instance);
         shouldPerformCommand(new GoConfigDao.CompositeConfigCommand(GoConfigDao.createAddAgentCommand(agentConfig)));
@@ -583,7 +581,7 @@ public class GoConfigServiceTest {
 
     @Test
     public void shouldEnableMultipleAgents() {
-        AgentRuntimeInfo agentRuntimeInfo = new AgentRuntimeInfo(new AgentIdentifier("remote-host", "50.40.30.20", "abc"), AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null);
+        AgentRuntimeInfo agentRuntimeInfo = new AgentRuntimeInfo(new AgentIdentifier("remote-host", "50.40.30.20", "abc"), AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", null, false);
         AgentInstance pending = AgentInstance.createFromLiveAgent(agentRuntimeInfo, new SystemEnvironment());
 
         AgentConfig agentConfig = new AgentConfig("UUID2", "remote-host", "50.40.30.20");

--- a/server/test/unit/com/thoughtworks/go/server/websocket/AgentRemoteHandlerTest.java
+++ b/server/test/unit/com/thoughtworks/go/server/websocket/AgentRemoteHandlerTest.java
@@ -77,7 +77,7 @@ public class AgentRemoteHandlerTest {
         assertEquals(agent, handler.connectedAgents().get("uuid"));
 
         assertEquals(1, agent.messages.size());
-        assertEquals(agent.messages.get(0).getAction(), Action.cancelJob);
+        assertEquals(agent.messages.get(0).getAction(), Action.cancelBuild);
     }
 
     @Test
@@ -127,7 +127,7 @@ public class AgentRemoteHandlerTest {
         assertEquals(2, agent.messages.size());
         assertEquals(agent.messages.get(0).getAction(), Action.setCookie);
         assertEquals(MessageEncoding.decodeData(agent.messages.get(0).getData(), String.class), "new cookie");
-        assertEquals(agent.messages.get(1).getAction(), Action.cancelJob);
+        assertEquals(agent.messages.get(1).getAction(), Action.cancelBuild);
     }
 
     private AgentRuntimeInfo withCookie(AgentRuntimeInfo info, String cookie) {

--- a/server/webapp/WEB-INF/rails.new/spec/controllers/environments_controller_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/controllers/environments_controller_spec.rb
@@ -1,5 +1,5 @@
 ##########################GO-LICENSE-START################################
-# Copyright 2014 ThoughtWorks, Inc.
+# Copyright 2016 ThoughtWorks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -453,22 +453,22 @@ describe EnvironmentsController do
       @config_helper.addPipelineToEnvironment("bar-env", "quux_pipeline")
       @config_helper.addAgent("host-1", "uuid-1")
       Spring.bean('agentDao').associateCookie(AgentIdentifier.new("host-1", "192.168.1.2", "uuid-1"), "cookie-1")
-      ri = AgentRuntimeInfo.fromServer(AgentConfig.new("uuid-1", "host-1", "192.168.1.2"), true, "/foo/bar", 100, "linux")
+      ri = AgentRuntimeInfo.fromServer(AgentConfig.new("uuid-1", "host-1", "192.168.1.2"), true, "/foo/bar", 100, "linux", false)
       ri.setCookie("cookie-1")
       Spring.bean('agentService').updateRuntimeInfo(ri)
       @config_helper.addAgent("host-2", "uuid-2")
       Spring.bean('agentDao').associateCookie(AgentIdentifier.new("host-2", "192.168.1.3", "uuid-2"), "cookie-2")
-      ri = AgentRuntimeInfo.fromServer(AgentConfig.new("uuid-2", "host-2", "192.168.1.3"), true, "/bar/baz", 100, "linux")
+      ri = AgentRuntimeInfo.fromServer(AgentConfig.new("uuid-2", "host-2", "192.168.1.3"), true, "/bar/baz", 100, "linux", false)
       ri.setCookie("cookie-2")
       Spring.bean('agentService').updateRuntimeInfo(ri)
       @config_helper.addAgent("host-3", "uuid-3")
       Spring.bean('agentDao').associateCookie(AgentIdentifier.new("host-3", "192.168.1.4", "uuid-3"), "cookie-3")
-      ri = AgentRuntimeInfo.fromServer(AgentConfig.new("uuid-3", "host-3", "192.168.1.4"), true, "/baz/quux", 100, "linux")
+      ri = AgentRuntimeInfo.fromServer(AgentConfig.new("uuid-3", "host-3", "192.168.1.4"), true, "/baz/quux", 100, "linux", false)
       ri.setCookie("cookie-3")
       Spring.bean('agentService').updateRuntimeInfo(ri)
       @config_helper.addAgent("host-4", "uuid-4")
       Spring.bean('agentDao').associateCookie(AgentIdentifier.new("host-4", "192.168.1.5", "uuid-4"), "cookie-4")
-      ri = AgentRuntimeInfo.fromServer(AgentConfig.new("uuid-4", "host-4", "192.168.1.5"), true, "/quux/bang", 100, "linux")
+      ri = AgentRuntimeInfo.fromServer(AgentConfig.new("uuid-4", "host-4", "192.168.1.5"), true, "/quux/bang", 100, "linux", false)
       ri.setCookie("cookie-4")
       Spring.bean('agentService').updateRuntimeInfo(ri)
       @config_helper.addAgentToEnvironment("foo-env", "uuid-1")

--- a/test-utils/src/com/thoughtworks/go/matchers/ConsoleOutMatcher.java
+++ b/test-utils/src/com/thoughtworks/go/matchers/ConsoleOutMatcher.java
@@ -1,5 +1,5 @@
 /*************************GO-LICENSE-START*********************************
- * Copyright 2014 ThoughtWorks, Inc.
+ * Copyright 2016 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -141,6 +141,24 @@ public class ConsoleOutMatcher {
         };
     }
 
+    public static TypeSafeMatcher<String> printedJobCanceledInfo(final Object jobIdentifer) {
+        return new TypeSafeMatcher<String>() {
+            private String consoleOut;
+            public String stdout;
+
+            public boolean matchesSafely(String consoleOut) {
+                this.consoleOut = consoleOut;
+                stdout = format("Job is canceled %s", jobIdentifer.toString());
+                return StringUtils.contains(consoleOut, stdout);
+            }
+
+            public void describeTo(Description description) {
+                description.appendText("expected console to contain [" + stdout + "]"
+                        + " but was " + consoleOut);
+            }
+        };
+    }
+
     public static TypeSafeMatcher<String> printedBuildFailed() {
         return new TypeSafeMatcher<String>() {
             private String consoleOut;
@@ -193,13 +211,9 @@ public class ConsoleOutMatcher {
             public String message;
 
             public boolean matchesSafely(String consoleOut) {
-                try {
-                    this.consoleOut = consoleOut;
-                    this.message = "Failed to upload " + file.getCanonicalPath();
-                    return StringUtils.contains(consoleOut.toLowerCase(), message.toLowerCase());
-                } catch (IOException e) {
-                    return false;
-                }
+                this.consoleOut = consoleOut;
+                this.message = "Failed to upload " + file.getAbsolutePath();
+                return StringUtils.contains(consoleOut.toLowerCase(), message.toLowerCase());
             }
 
             public void describeTo(Description description) {

--- a/test-utils/src/com/thoughtworks/go/utils/Assertions.java
+++ b/test-utils/src/com/thoughtworks/go/utils/Assertions.java
@@ -76,6 +76,10 @@ public class Assertions {
     }
 
     public static void waitUntil(Timeout timeout, Predicate predicate) {
+        waitUntil(timeout, predicate, 1000);
+    }
+
+    public static void waitUntil(Timeout timeout, Predicate predicate, int sleepInMillis) {
         long end = System.currentTimeMillis() + timeout.inMillis();
         Exception e = null;
         while (true) {
@@ -92,7 +96,7 @@ public class Assertions {
             if (timedout) {
                 break;
             } else {
-                sleepOneSec();
+                sleepMillis(sleepInMillis);
             }
         }
         String msg = e == null ? "wait timed out after " + timeout + " for: " + predicate.toString() : e.getMessage();


### PR DESCRIPTION
About this PR
==========
This PR is first part of of implementation of proposal: **https://github.com/gocd/gocd/issues/1954 New BuildCommand based Server-Agent Communication**. The goal of this PR is implement only the main follow of protocol in the proposal, so there will be a few places stubbed by UnsupportedOperationException exception.

Toggle
=====
New API will be toggled by a agent side configuration. Most code for current mechanism will be untouched for now.

Two toggle need be turn on on ***agent side*** for testing the new protocol:
```
-Dgo.agent.websocket.enabled=Y 
-Dgo.agent.enableBuildCommandProtocol=Y
```

Scope
=====

- [x] Re-enable JSON WebSocket message serialization, except for BuildWork message. We left transfering BuildWork still via Java serialization because it is not in the blue print and we have less changes to test.
- [x] Clean up the JSON structure make it less java server domain dependent.
- [x] Change agent registration api to json format (with PEM format certs and private key, for the connivence of none-java agent implementation, e.g. https://github.com/gocd-contrib/gocd-golang-agent)
- [x] Toggle
- [x] Run a build with stubbed out commands implementation but correct status report.
- [x] BuildCommand-lize GitMaterial#update_to
- [x] BuildCommand-lize CommandBuilder
- [x] Environment variables
- [x] Mask secret variables
- [x] Cancel build
- [x] Upload Artifacts
- [x] Fetch artifacts
- [x] Git submodules
- [x] Generate test reports
- [x] Generate property from xml property file
- [x] Support elastic agent ping info

What's left
========
* SVN
* HG 
* P4
* TFS 
*  Pluggable SCM
* Task extensions


You can preview other changes on this POC fork: https://github.com/wpc/gocd/tree/lightweight-agent-spike