### PR TITLE
fix #2071: git repo get unshallowed unnecessarily on agent side

### DIFF
--- a/common/src/com/thoughtworks/go/config/materials/git/GitMaterial.java
+++ b/common/src/com/thoughtworks/go/config/materials/git/GitMaterial.java
@@ -144,9 +144,9 @@ public class GitMaterial extends ScmMaterial {
         try {
             outputStreamConsumer.stdOutput(format("[%s] Start updating %s at revision %s from %s", GoConstants.PRODUCT_NAME, updatingTarget(), revision.getRevision(), url));
             GitCommand git = git(outputStreamConsumer, workingdir(baseDir), revisionContext.numberOfModifications() + 1);
+            git.fetch(outputStreamConsumer);
             unshallowIfNeeded(git, outputStreamConsumer, revisionContext.getOldestRevision(), baseDir);
-
-            git.fetchAndReset(outputStreamConsumer, revision);
+            git.resetWorkingDir(outputStreamConsumer, revision);
             outputStreamConsumer.stdOutput(format("[%s] Done.\n", GoConstants.PRODUCT_NAME));
         } catch (Exception e) {
             bomb(e);

--- a/common/src/com/thoughtworks/go/domain/materials/git/GitCommand.java
+++ b/common/src/com/thoughtworks/go/domain/materials/git/GitCommand.java
@@ -92,7 +92,6 @@ public class GitCommand extends SCMCommand {
         try {
             if (!isSubmodule) {
                 fetch(outputStreamConsumer);
-                gc(outputStreamConsumer);
             }
         } catch (Exception e) {
             throw new RuntimeException(String.format("Working directory: %s\n%s", workingDir, outputStreamConsumer.getStdError()), e);
@@ -134,12 +133,10 @@ public class GitCommand extends SCMCommand {
     }
 
 
-    public void fetchAndReset(ProcessOutputStreamConsumer outputStreamConsumer, Revision revision) {
-        outputStreamConsumer.stdOutput(String.format("[GIT] Fetch and reset in working directory %s", workingDir));
+    public void resetWorkingDir(ProcessOutputStreamConsumer outputStreamConsumer, Revision revision) {
+        outputStreamConsumer.stdOutput(String.format("[GIT] Reset working directory %s", workingDir));
         cleanAllUnversionedFiles(outputStreamConsumer);
         removeSubmoduleSectionsFromGitConfig(outputStreamConsumer);
-        fetch(outputStreamConsumer);
-        gc(outputStreamConsumer);
         resetHard(outputStreamConsumer, revision);
         checkoutAllModifiedFilesInSubmodules(outputStreamConsumer);
         updateSubmoduleWithInit(outputStreamConsumer);
@@ -180,7 +177,8 @@ public class GitCommand extends SCMCommand {
     }
 
     public void fetchAndResetToHead(ProcessOutputStreamConsumer outputStreamConsumer) {
-        fetchAndReset(outputStreamConsumer, new StringRevision(remoteBranch()));
+        fetch(outputStreamConsumer);
+        resetWorkingDir(outputStreamConsumer, new StringRevision(remoteBranch()));
     }
 
     public void updateSubmoduleWithInit(ProcessOutputStreamConsumer outputStreamConsumer) {
@@ -295,6 +293,7 @@ public class GitCommand extends SCMCommand {
         if (result != 0) {
             throw new RuntimeException(String.format("git fetch failed for [%s]", this.workingRepositoryUrl()));
         }
+        gc(outputStreamConsumer);
     }
 
     // Unshallow a shallow cloned repository with "git fetch --depth n".

--- a/common/test/unit/com/thoughtworks/go/config/materials/git/GitMaterialShallowCloneTest.java
+++ b/common/test/unit/com/thoughtworks/go/config/materials/git/GitMaterialShallowCloneTest.java
@@ -23,6 +23,7 @@ import com.thoughtworks.go.domain.materials.RevisionContext;
 import com.thoughtworks.go.domain.materials.TestSubprocessExecutionContext;
 import com.thoughtworks.go.domain.materials.git.GitCommand;
 import com.thoughtworks.go.domain.materials.git.GitTestRepo;
+import com.thoughtworks.go.domain.materials.mercurial.StringRevision;
 import com.thoughtworks.go.helper.TestRepo;
 import com.thoughtworks.go.util.TestFileUtil;
 import org.hamcrest.Matchers;
@@ -147,6 +148,18 @@ public class GitMaterialShallowCloneTest {
         assertThat(original.withShallowClone(false).isShallowClone(), is(false));
         assertThat(original.isShallowClone(), is(false));
 
+    }
+
+    @Test
+    public void updateToANewRevisionShouldNotResultInUnshallowing() throws IOException {
+        GitMaterial material = new GitMaterial(repo.projectRepositoryUrl(), true);
+        material.updateTo(inMemoryConsumer(), workingDir, new RevisionContext(REVISION_4, REVISION_4, 1), context());
+        assertThat(localRepoFor(material).isShallow(), is(true));
+        List<Modification> modifications = repo.addFileAndPush("newfile", "add new file");
+        StringRevision newRevision = new StringRevision(modifications.get(0).getRevision());
+        material.updateTo(inMemoryConsumer(), workingDir, new RevisionContext(newRevision, newRevision, 1), context());
+        assertThat(new File(workingDir, "newfile").exists(), is(true));
+        assertThat(localRepoFor(material).isShallow(), is(true));
     }
 
 


### PR DESCRIPTION
This PR fix issue #2071. It fixes a mistake I made in #1846: unshallow check was put before git fetch.