### PR TITLE
fix: lost last line log when put console log has multiple lines and no "\n"

### DIFF
--- a/server/src/com/thoughtworks/go/server/controller/ArtifactsController.java
+++ b/server/src/com/thoughtworks/go/server/controller/ArtifactsController.java
@@ -304,7 +304,7 @@ public class ArtifactsController {
 
     private ModelAndView putConsoleOutput(final JobIdentifier jobIdentifier, final InputStream inputStream) throws Exception {
         File consoleLogFile = consoleService.consoleLogFile(jobIdentifier);
-        boolean updated = consoleService.updateConsoleLog(consoleLogFile, inputStream, ConsoleService.LineListener.NO_OP_LINE_LISTENER);
+        boolean updated = consoleService.updateConsoleLog(consoleLogFile, inputStream);
         if (updated) {
             consoleActivityMonitor.consoleUpdatedFor(jobIdentifier);
             return FileModelAndView.fileAppended(consoleLogFile.getPath());

--- a/server/test/integration/com/thoughtworks/go/server/controller/ArtifactsControllerIntegrationTest.java
+++ b/server/test/integration/com/thoughtworks/go/server/controller/ArtifactsControllerIntegrationTest.java
@@ -410,6 +410,32 @@ public class ArtifactsControllerIntegrationTest {
     }
 
     @Test
+    public void shouldPutConsoleOutput_withNoNewLineAtTheAtOfTheLog() throws Exception {
+        String log = "junit report\nstart\n....";
+        ModelAndView mav = putConsoleLogContent("cruise-output/console.log", log);
+
+        String consoleLogContent = FileUtils.readFileToString(file(consoleLogFile));
+        String[] lines = consoleLogContent.split("\n");
+        assertThat(lines.length, is(3));
+        assertThat(lines[0], is("junit report"));
+        assertThat(lines[1], is("start"));
+        assertThat(lines[2], is("...."));
+        assertStatus(mav, SC_OK);
+    }
+
+    @Test
+    public void shouldPutConsoleOutput_withoutNewLineChar() throws Exception {
+        String log = "....";
+        ModelAndView mav = putConsoleLogContent("cruise-output/console.log", log);
+
+        String consoleLogContent = FileUtils.readFileToString(file(consoleLogFile));
+        String[] lines = consoleLogContent.split("\n");
+        assertThat(lines.length, is(1));
+        assertThat(lines[0], is("...."));
+        assertStatus(mav, SC_OK);
+    }
+
+    @Test
     public void shouldReturnBuildOutputAsPlainText() throws Exception {
         String firstLine = "Chris sucks.\n";
         String secondLine = "Build succeeded.";

--- a/server/test/unit/com/thoughtworks/go/server/controller/ArtifactsControllerTest.java
+++ b/server/test/unit/com/thoughtworks/go/server/controller/ArtifactsControllerTest.java
@@ -78,7 +78,7 @@ public class ArtifactsControllerTest {
         String path = "cruise-output/console.log";
         File artifactFile = new File("junk");
         when(consoleService.consoleLogFile(jobIdentifier)).thenReturn(artifactFile);
-        when(consoleService.updateConsoleLog(eq(artifactFile), any(InputStream.class), any(ConsoleService.LineListener.class))).thenReturn(true);
+        when(consoleService.updateConsoleLog(eq(artifactFile), any(InputStream.class))).thenReturn(true);
         assertThat(((ResponseCodeView) artifactsController.putArtifact("pipeline", "10", "stage", "2", "build", 103l, path, "agent-id", request).getView()).getStatusCode(), is(HttpServletResponse.SC_OK));
         verify(consoleActivityMonitor).consoleUpdatedFor(jobIdentifier);
     }


### PR DESCRIPTION
Current Java agent always put console log with whole lines.
So this change will not effect current Java agent. 
However, if we decided to change to put half line log so that user can see a long time junit test suite running progress, then this change makes server side ready to process those kind of log.

I need this change because new golang agent will not base on new line to put console log, it will just put all console log buffer when tried to flush local console log buffer to server.
It is better because we can see long running junit test suite running progress. here is example:
![output_dultlp](https://cloud.githubusercontent.com/assets/17474/14049684/1c6b7424-f274-11e5-9fa2-c8cf5311166e.gif)


