### PR TITLE
Issue #1849 and some other page performance improvements

### DIFF
--- a/server/webapp/WEB-INF/rails.new/app/assets/javascripts/tabs.js
+++ b/server/webapp/WEB-INF/rails.new/app/assets/javascripts/tabs.js
@@ -81,7 +81,10 @@ var SubTabs = Class.create({
             this.before_open_callback();
         }
         if(this.content){
+            this._hideProggressiveContents();
             this.content.show();
+            this._recoverProgressiveContents();
+
             var init_method_name = this.content.id+ "_callback";
             if(window[init_method_name]){
                 window[init_method_name]();
@@ -90,6 +93,31 @@ var SubTabs = Class.create({
         this.storeCurrentTabNameInCookie(this.tab_name);
         TabsManager.prototype.updateLinkToThisPage(this.tab_name);
     },
+
+    _hideProggressiveContents: function() {
+        this._progressiveContents().each(function(node) {
+                node._html = node.innerHTML;
+                node.innerHTML = "";
+        });
+    },
+
+    _recoverProgressiveContents: function() {
+        var needsToBeRecovered = this._progressiveContents().filter(function(node) {
+            return node._html !== null;
+        });
+        if(!needsToBeRecovered.length) {
+            return;
+        }
+        var first = needsToBeRecovered.first();
+        first.innerHTML = first._html;
+        first._html = null;
+        setTimeout(this._recoverProgressiveContents.bind(this), 20)
+    },
+
+    _progressiveContents: function() {
+        return this.content.select(".progressive-display");
+    },
+
     storeCurrentTabNameInCookie: function(tabName){
         var type = this.container.tab_type;
         var id = this.container.tab_id;
@@ -164,7 +192,7 @@ var TabsManager = Class.create({
     },
     getCurrentTabFromUrl: function() {
         var url = window.location.href;
-        
+
         try {
             if(url.lastIndexOf('#tab-') > -1) {
                 var tabName = url.substring(url.lastIndexOf('#tab-') + 5, url.length);

--- a/server/webapp/WEB-INF/rails.new/app/assets/javascripts/util.js
+++ b/server/webapp/WEB-INF/rails.new/app/assets/javascripts/util.js
@@ -59,7 +59,7 @@ Util = function() {
                 var shower = new MicroContentPopup.ClickShower(microContentPopup, {cleanup: true});
                 Util.namespace('build_cause').set(popup_panel_id, shower);
             };
-        },       
+        },
         set_value: function(field, value) {
             return function() {
                 $(field).value = value;
@@ -168,7 +168,7 @@ Util = function() {
                 }
             });
         },
-        
+
         server_timestamp: function() {
             var client_server_timestamp_delta = null;
 
@@ -223,37 +223,49 @@ Util.on_load(function() {
 });
 
 ViewportPredicate = function() {
-    var y, x, dy, dx;
+    var _y, _x, _dy, _dx;
 
     jQuery(window).resize(reset_caches);
     jQuery(window).scroll(reset_offsets);
-    jQuery(reset_caches);
+    reset_caches();
 
     function reset_caches() {
-        dy = jQuery(window).height();
-        dx = jQuery(window).width();
+        _dy = null;
+        _dx = null;
         reset_offsets();
     }
 
     function reset_offsets() {
-        y = jQuery(document).scrollTop();
-        x = jQuery(document).scrollLeft();
+        _y = null;
+        _x = null;
     }
 
     function port_y() {
-        return y;
+        if(_y === null) {
+            _y = jQuery(document).scrollTop();
+        }
+        return _y;
     }
 
     function port_x() {
-        return x;
+        if(_x === null) {
+            _x = jQuery(document).scrollLeft();
+        }
+        return _x;
     }
 
     function port_dy() {
-        return dy;
+        if(_dy === null) {
+            _dy = jQuery(window).height();
+        }
+        return _dy;
     }
 
     function port_dx() {
-        return dx;
+        if(_dx === null) {
+            _dx = jQuery(window).width();
+        }
+        return _dx;
     }
 
     function is_in_viewport(elem) {

--- a/server/webapp/WEB-INF/rails.new/app/assets/stylesheets/css/build_detail.scss
+++ b/server/webapp/WEB-INF/rails.new/app/assets/stylesheets/css/build_detail.scss
@@ -462,7 +462,7 @@ div.build_detail_container_content {
     color: black;
   }
 
-  * {
+  *:not(.console-output-chunk) {
     font-family: Monaco, Consolas, Inconsolata, "Liberation Mono", "Courier New", monospace;
     font-size: 13px;
     line-height: 19px;


### PR DESCRIPTION
* Fix issue #1849: A simple workaround that incrementally insert log lines into the DOM to avoid page freezing.  The fix also handles the case when user switch to console tab from other tabs.

* In ViewportPredicate module, void calling jQuery(window).scrollTop in onScroll handler. Because window.pageYOffset triggers DOM reflow, it is super expensive when there are new contents inserted into the DOM.