### PR TITLE
A proposed change to how authentication is enabled

### DIFF
--- a/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/authentication/AuthenticationPluginRequestHelper.java
+++ b/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/authentication/AuthenticationPluginRequestHelper.java
@@ -1,0 +1,59 @@
+package com.thoughtworks.go.plugin.access.authentication;
+
+import com.google.gson.Gson;
+import com.thoughtworks.go.plugin.api.request.DefaultGoPluginApiRequest;
+import com.thoughtworks.go.plugin.api.response.DefaultGoApiResponse;
+import com.thoughtworks.go.plugin.api.response.GoPluginApiResponse;
+import com.thoughtworks.go.plugin.infra.PluginManager;
+import org.apache.log4j.Logger;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+import static java.lang.String.format;
+import static java.util.Arrays.asList;
+
+@Component
+public class AuthenticationPluginRequestHelper {
+
+    private static final Logger LOG = Logger.getLogger(AuthenticationPluginRequestHelper.class);
+    private PluginManager pluginManager;
+
+    private final static String REQUEST_NAME = "go.authentication.auth_enabled";
+    private final static String EXTENSION_NAME = "authentication";
+    private static final List<String> GO_SUPPORTED_VERSIONS = asList("1.0");
+
+    @Autowired
+    public AuthenticationPluginRequestHelper(PluginManager pluginManager) {
+        this.pluginManager = pluginManager;
+    }
+
+    public boolean isEnabled(String pluginId) {
+        if (!pluginManager.isPluginOfType(EXTENSION_NAME, pluginId)) {
+            throw new RuntimeException(format("Did not find '%s' plugin with id '%s'. Looks like plugin is missing", EXTENSION_NAME, pluginId));
+        }
+        try {
+            final String resolvedExtensionVersion = pluginManager.resolveExtensionVersion(pluginId, GO_SUPPORTED_VERSIONS);
+            final DefaultGoPluginApiRequest apiRequest = new DefaultGoPluginApiRequest("authentication", resolvedExtensionVersion, REQUEST_NAME);
+            apiRequest.setRequestBody("{}");
+            final GoPluginApiResponse response = pluginManager.submitTo(pluginId, apiRequest);
+            if (DefaultGoApiResponse.SUCCESS_RESPONSE_CODE == response.responseCode()) {
+                final String responseBody = response.responseBody();
+                final AuthEnabledResponse authEnabledResponse = new Gson().fromJson(responseBody, AuthEnabledResponse.class);
+                return authEnabledResponse.enabled;
+            } else if (404 == response.responseCode()) {
+                LOG.warn(format("The authentication plugin %s responded with a 404. It does not support authentication enablement.", pluginId));
+                return false;
+            }
+            throw new RuntimeException(format("The plugin sent a response that could not be understood by Go. Plugin returned with code '%s' and the following response: '%s'", response.responseCode(), response.responseBody()));
+        } catch (Exception e) {
+            throw new RuntimeException(format("Interaction with plugin with id '%s' implementing '%s' extension failed while requesting for '%s'. Reason: [%s]", pluginId, EXTENSION_NAME, REQUEST_NAME, e.getMessage()), e);
+        }
+    }
+
+
+    public static class AuthEnabledResponse {
+        public boolean enabled;
+    }
+}

--- a/plugin-infra/go-plugin-access/test/com/thoughtworks/go/plugin/access/authentication/AuthenticationPluginRequestHelperTest.java
+++ b/plugin-infra/go-plugin-access/test/com/thoughtworks/go/plugin/access/authentication/AuthenticationPluginRequestHelperTest.java
@@ -1,0 +1,93 @@
+package com.thoughtworks.go.plugin.access.authentication;
+
+import com.google.gson.JsonObject;
+import com.thoughtworks.go.plugin.api.request.GoPluginApiRequest;
+import com.thoughtworks.go.plugin.api.response.DefaultGoPluginApiResponse;
+import com.thoughtworks.go.plugin.infra.PluginManager;
+import org.hamcrest.CustomMatcher;
+import org.hamcrest.Matcher;
+import org.junit.Before;
+import org.junit.Test;
+
+import static java.lang.String.format;
+import static java.util.Arrays.asList;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.argThat;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class AuthenticationPluginRequestHelperTest {
+
+    private final PluginManager pluginManager = mock(PluginManager.class);
+    private AuthenticationPluginRequestHelper authenticationPluginRequestHelper = new AuthenticationPluginRequestHelper(pluginManager);
+
+
+    @Before
+    public void setup() {
+        when(pluginManager.isPluginOfType("authentication", "myEnabledPlugin")).thenReturn(true);
+        when(pluginManager.isPluginOfType("authentication", "myDisabledPlugin")).thenReturn(true);
+        when(pluginManager.isPluginOfType("authentication", "myLegacyPlugin")).thenReturn(true);
+
+        when(pluginManager.resolveExtensionVersion("myEnabledPlugin", asList("1.0"))).thenReturn("1.0");
+        when(pluginManager.resolveExtensionVersion("myDisabledPlugin", asList("1.0"))).thenReturn("1.0");
+        when(pluginManager.resolveExtensionVersion("myLegacyPlugin", asList("1.0"))).thenReturn("1.0");
+
+        when(pluginManager.submitTo(eq("myEnabledPlugin"), argThat(matchesGoApiRequest("authentication", "1.0", "go.authentication.auth_enabled"))))
+                .thenReturn(enabledResponse());
+        when(pluginManager.submitTo(eq("myDisabledPlugin"), argThat(matchesGoApiRequest("authentication", "1.0", "go.authentication.auth_enabled"))))
+                .thenReturn(disabledResponse());
+
+        when(pluginManager.submitTo(eq("myLegacyPlugin"), argThat(matchesGoApiRequest("authentication", "1.0", "go.authentication.auth_enabled"))))
+                .thenReturn(new DefaultGoPluginApiResponse(404));
+    }
+
+    @Test
+    public void helperShouldReturnTrueResponseForPluginRespondingEnabled() {
+        assertThat(authenticationPluginRequestHelper.isEnabled("myEnabledPlugin"), is(true));
+    }
+
+    @Test
+    public void helperShouldReturnFalseResponseForPluginRespondingDisabled() {
+        assertThat(authenticationPluginRequestHelper.isEnabled("myDisabledPlugin"), is(false));
+    }
+
+    @Test
+    public void helperShouldReturnFalseResponseForNonRespondingPlugin() {
+        assertThat(authenticationPluginRequestHelper.isEnabled("myLegacyPlugin"), is(false));
+    }
+
+    private DefaultGoPluginApiResponse enabledResponse() {
+        DefaultGoPluginApiResponse response = new DefaultGoPluginApiResponse(200);
+        JsonObject responseBody = new JsonObject();
+        responseBody.addProperty("enabled", true);
+        response.setResponseBody(responseBody.toString());
+        return response;
+    }
+
+    private DefaultGoPluginApiResponse disabledResponse() {
+        DefaultGoPluginApiResponse response = new DefaultGoPluginApiResponse(200);
+        JsonObject responseBody = new JsonObject();
+        responseBody.addProperty("enabled", false);
+        response.setResponseBody(responseBody.toString());
+        return response;
+    }
+
+    private Matcher<? extends GoPluginApiRequest> matchesGoApiRequest(final String extension, final String version, final String requestName) {
+        return new CustomMatcher<GoPluginApiRequest>(format("extension: %s, version: %s, message: %s", extension, version, requestName)) {
+            @Override
+            public boolean matches(final Object request) {
+                if (request instanceof GoPluginApiRequest) {
+                    GoPluginApiRequest actualRequest = (GoPluginApiRequest) request;
+                    return actualRequest.extension().equals(extension) &&
+                            actualRequest.extensionVersion().equals(version) &&
+                            actualRequest.requestName().equals(requestName);
+
+                }
+                return false;
+            }
+        };
+    }
+
+}

--- a/server/src/com/thoughtworks/go/server/security/AuthenticationService.java
+++ b/server/src/com/thoughtworks/go/server/security/AuthenticationService.java
@@ -1,0 +1,31 @@
+package com.thoughtworks.go.server.security;
+
+import com.thoughtworks.go.plugin.access.authentication.AuthenticationPluginRegistry;
+import com.thoughtworks.go.plugin.access.authentication.AuthenticationPluginRequestHelper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class AuthenticationService {
+
+    private AuthenticationPluginRegistry authenticationPluginRegistry;
+    private final AuthenticationPluginRequestHelper authenticationPluginRequestHelper;
+
+    @Autowired
+    public AuthenticationService(
+            AuthenticationPluginRegistry authenticationPluginRegistry,
+            AuthenticationPluginRequestHelper authenticationPluginRequestHelper
+    ) {
+        this.authenticationPluginRegistry = authenticationPluginRegistry;
+        this.authenticationPluginRequestHelper = authenticationPluginRequestHelper;
+    }
+
+    public boolean isAuthEnabled() {
+        for (final String authPlugin: authenticationPluginRegistry.getAuthenticationPlugins()) {
+            if (authenticationPluginRequestHelper.isEnabled(authPlugin)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/server/src/com/thoughtworks/go/server/security/IsSecurityEnabledVoter.java
+++ b/server/src/com/thoughtworks/go/server/security/IsSecurityEnabledVoter.java
@@ -25,10 +25,12 @@ import org.springframework.security.vote.AccessDecisionVoter;
 
 public class IsSecurityEnabledVoter implements AccessDecisionVoter {
     private GoConfigService goConfigService;
+    private AuthenticationService authenticationService;
 
     @Autowired
-    public IsSecurityEnabledVoter(GoConfigService goConfigService) {
+    public IsSecurityEnabledVoter(GoConfigService goConfigService, AuthenticationService authenticationService) {
         this.goConfigService = goConfigService;
+        this.authenticationService = authenticationService;
     }
 
     public boolean supports(ConfigAttribute configAttribute) {
@@ -40,6 +42,14 @@ public class IsSecurityEnabledVoter implements AccessDecisionVoter {
     }
 
     public int vote(Authentication authentication, Object o, ConfigAttributeDefinition configAttributeDefinition) {
-        return goConfigService.isSecurityEnabled() ? ACCESS_ABSTAIN : ACCESS_GRANTED;
+        return isLegacyBuiltInAuthEnabled() ? ACCESS_ABSTAIN : getAuthServiceVote();
+    }
+
+    private boolean isLegacyBuiltInAuthEnabled() {
+        return goConfigService.isSecurityEnabled();
+    }
+
+    private int getAuthServiceVote() {
+        return authenticationService.isAuthEnabled() ? ACCESS_ABSTAIN : ACCESS_GRANTED;
     }
 }

--- a/server/test/unit/com/thoughtworks/go/server/security/AuthenticationServiceTest.java
+++ b/server/test/unit/com/thoughtworks/go/server/security/AuthenticationServiceTest.java
@@ -1,0 +1,48 @@
+package com.thoughtworks.go.server.security;
+
+import com.google.common.collect.ImmutableSet;
+import com.thoughtworks.go.plugin.access.authentication.AuthenticationPluginRegistry;
+import com.thoughtworks.go.plugin.access.authentication.AuthenticationPluginRequestHelper;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class AuthenticationServiceTest {
+
+    private AuthenticationPluginRegistry authenticationPluginRegistry = mock(AuthenticationPluginRegistry.class);
+    private AuthenticationPluginRequestHelper authenticationPluginRequestHelper = mock(AuthenticationPluginRequestHelper.class);
+
+    @Before
+    public void setup() {
+        when(authenticationPluginRegistry.getAuthenticationPlugins()).thenReturn(ImmutableSet.of("authFoo", "authBar"));
+        when(authenticationPluginRequestHelper.isEnabled(any(String.class))).thenReturn(false);
+    }
+
+    @Test
+    public void shouldBeEnabledIfAnyPluginIndicatesEnabled() {
+        when(authenticationPluginRequestHelper.isEnabled(eq("authFoo"))).thenReturn(true);
+        AuthenticationService authenticationService = new AuthenticationService(
+                authenticationPluginRegistry,
+                authenticationPluginRequestHelper
+
+        );
+        assertThat(authenticationService.isAuthEnabled(), is(true));
+    }
+
+    @Test
+    public void shouldNotBeEnabledIfNoPluginIndicatesEnabled() {
+        AuthenticationService authenticationService = new AuthenticationService(
+                authenticationPluginRegistry,
+                authenticationPluginRequestHelper
+
+        );
+        assertThat(authenticationService.isAuthEnabled(), is(false));
+    }
+
+}


### PR DESCRIPTION
This is one possible way that Go CD could decide whether to enable auth is by asking the auth plugins. Here is an example implementation of that. There are a few things I'm unsure of:
- I'm handling versioning very naively, and I expect it has to be handled better. I'm covering cases where the plugin doesn't know it has to respond to by handling 404s, but my guess is there are better ways but I don't quite understand the API versioning model yet
- I'm hitting the plugins on every auth request to the IsSecurityEnabledVoter and I would guess it should be cached in some ways
- I like the idea of ultimately removing the hard coded checks to the two built-in providers, but that probably has to wait until the file-based one goes away and the LDAP one is broken out into a plugin.

Before making those changes, I wanted to propose the general approach and see what you thought.

Let me know if you think it's valid, or if you have another way.
