### PR TITLE
undeprecating JobConsoleLogger as json api based task controllers dep…

### DIFF
--- a/plugin-infra/go-plugin-api/src/com/thoughtworks/go/plugin/api/task/JobConsoleLogger.java
+++ b/plugin-infra/go-plugin-api/src/com/thoughtworks/go/plugin/api/task/JobConsoleLogger.java
@@ -19,8 +19,6 @@ package com.thoughtworks.go.plugin.api.task;
 import java.io.InputStream;
 import java.util.Map;
 
-@Deprecated
-//Will be moved to internal scope
 public class JobConsoleLogger {
     protected static TaskExecutionContext context;
 


### PR DESCRIPTION
…end on it. Leaving the others as deprecated since we already pass along context, env-vars and working directory as part of the execution request