### PR TITLE
fixed issue: #1411 Spaces are not trimmed from environment variables

### DIFF
--- a/base/src/com/thoughtworks/go/util/GoConstants.java
+++ b/base/src/com/thoughtworks/go/util/GoConstants.java
@@ -58,7 +58,7 @@ public class GoConstants {
 
     public static final String PRODUCT_NAME = "go";
 
-    public static final int CONFIG_SCHEMA_VERSION = 84;
+    public static final int CONFIG_SCHEMA_VERSION = 85;
 
     public static final String APPROVAL_SUCCESS = "success";
     public static final String APPROVAL_MANUAL = "manual";

--- a/config/config-api/src/com/thoughtworks/go/config/EnvironmentVariableConfig.java
+++ b/config/config-api/src/com/thoughtworks/go/config/EnvironmentVariableConfig.java
@@ -172,6 +172,10 @@ public class EnvironmentVariableConfig extends PersistentObject implements Seria
         String currentVariableName = name.toLowerCase();
         String parentDisplayName = validationContext.getParentDisplayName();
         CaseInsensitiveString parentName = getParentNameFrom(validationContext);
+        if(currentVariableName.startsWith(" ") || currentVariableName.endsWith(" ")){
+            configErrors.add(NAME, String.format("Environment Variable cannot start or end with spaces for %s '%s'.", parentDisplayName, parentName));
+            return;
+        }
         if (StringUtil.isBlank(currentVariableName)) {
             configErrors.add(NAME, String.format("Environment Variable cannot have an empty name for %s '%s'.", parentDisplayName, parentName));
             return;

--- a/config/config-api/test/com/thoughtworks/go/config/domain/EnvironmentVariablesConfigTest.java
+++ b/config/config-api/test/com/thoughtworks/go/config/domain/EnvironmentVariablesConfigTest.java
@@ -99,6 +99,30 @@ public class EnvironmentVariablesConfigTest {
     }
 
     @Test
+    public void shouldPopulateErrorWhenVariableNameStartsWithSpace() {
+        environmentVariablesConfig = new EnvironmentVariablesConfig();
+        EnvironmentVariableConfig one = new EnvironmentVariableConfig(" foo", "BAR");
+        environmentVariablesConfig.add(one);
+
+        environmentVariablesConfig.validate(context);
+
+        assertThat(one.errors().isEmpty(), is(false));
+        assertThat(one.errors().on(EnvironmentVariableConfig.NAME), contains("Environment Variable cannot start or end with spaces for pipeline 'some-pipeline'."));
+    }
+
+    @Test
+    public void shouldPopulateErrorWhenVariableNameEndsWithSpace() {
+        environmentVariablesConfig = new EnvironmentVariablesConfig();
+        EnvironmentVariableConfig one = new EnvironmentVariableConfig("FOO  ", "BAR");
+        environmentVariablesConfig.add(one);
+
+        environmentVariablesConfig.validate(context);
+
+        assertThat(one.errors().isEmpty(), is(false));
+        assertThat(one.errors().on(EnvironmentVariableConfig.NAME), contains("Environment Variable cannot start or end with spaces for pipeline 'some-pipeline'."));
+    }
+
+    @Test
     public void shouldClearEnvironmentVariablesWhenTheMapIsNull() {
         environmentVariablesConfig = new EnvironmentVariablesConfig();
         EnvironmentVariableConfig one = new EnvironmentVariableConfig("FOO", "BAR");

--- a/config/config-server/resources/schemas/84_cruise-config.xsd
+++ b/config/config-server/resources/schemas/84_cruise-config.xsd
@@ -77,7 +77,7 @@
                     </xsd:unique>
                 </xsd:element>
             </xsd:sequence>
-            <xsd:attribute name="schemaVersion" type="xsd:int" use="required" fixed="85"/>
+            <xsd:attribute name="schemaVersion" type="xsd:int" use="required" fixed="84"/>
         </xsd:complexType>
         <xsd:unique name="uniquePipelines">
             <xsd:selector xpath="pipelines"/>

--- a/config/config-server/resources/upgrades/85.xsl
+++ b/config/config-server/resources/upgrades/85.xsl
@@ -1,0 +1,37 @@
+<?xml version="1.0"?>
+<!--
+  ~ Copyright 2016 ThoughtWorks, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+    <xsl:template match="/cruise/@schemaVersion">
+        <xsl:attribute name="schemaVersion">85</xsl:attribute>
+    </xsl:template>
+    <!-- Copy everything -->
+    <xsl:template match="@*|node()">
+        <xsl:copy>
+            <xsl:apply-templates select="@*|node()"/>
+        </xsl:copy>
+    </xsl:template>
+
+    <xsl:template match="//environmentvariables/variable">
+        <xsl:copy>
+            <xsl:attribute name="name">
+                <xsl:value-of select="translate(@name, ' ','')"/>
+            </xsl:attribute>
+            <xsl:apply-templates />
+        </xsl:copy>
+    </xsl:template>
+</xsl:stylesheet>

--- a/server/config/cruise-config.xml
+++ b/server/config/cruise-config.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<cruise xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="cruise-config.xsd" schemaVersion="84">
+<cruise xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="cruise-config.xsd" schemaVersion="85">
   <server artifactsdir="logs" agentAutoRegisterKey="041b5c7e-dab2-11e5-a908-13f95f3c6ef6" commandRepositoryLocation="default" serverId="dev-id">
     <security>
       <passwordFile path="../manual-testing/ant_hg/password.properties" />

--- a/server/test-resources/cruise-config-with-encrypted-with-flawed-cipher.xml
+++ b/server/test-resources/cruise-config-with-encrypted-with-flawed-cipher.xml
@@ -16,7 +16,7 @@
   ~
   -->
 
-<cruise xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="cruise-config.xsd" schemaVersion="81">
+<cruise xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="cruise-config.xsd" schemaVersion="85">
     <server artifactsdir="logs" commandRepositoryLocation="default" serverId="dev-id">
         <security>
             <ldap uri="ldap://ldap-server" managerDn="manager-dn" encryptedManagerPassword="ruRUF0mi2ia/BWpWMISbjQ==" searchFilter="(sAMAccountName={0})">

--- a/server/test/integration/com/thoughtworks/go/config/GoConfigMigrationIntegrationTest.java
+++ b/server/test/integration/com/thoughtworks/go/config/GoConfigMigrationIntegrationTest.java
@@ -1182,6 +1182,32 @@ public class GoConfigMigrationIntegrationTest {
         assertThat(migratedXml, not(containsString("<authorization>")));
     }
 
+    @Test
+    public void ShouldTrimEnvironmentVariables_asPartOfMigration85() throws Exception {
+        String configXml =
+                "<cruise schemaVersion='84'>"
+                        +"  <pipelines group='first'>"
+                        +"    <authorization>"
+                        +"       <view>"
+                        +"         <user></user>"
+                        +"       </view>"
+                        +"    </authorization>"
+                        +"    <pipeline name='up42'>"
+                        +"      <environmentvariables>"
+                        +"        <variable name=\"test  \">"
+                        +"          <value>abcd</value>"
+                        +"        </variable>"
+                        +"      </environmentvariables>"
+                        +"      <materials>"
+                        +"        <hg url='../manual-testing/ant_hg/dummy' />"
+                        +"      </materials>"
+                        +"     </pipeline>"
+                        +"  </pipelines>"
+                        +"</cruise>";
+        String migratedXml = migrateXmlString(configXml, 84);
+        assertThat(migratedXml, not(containsString("test  ")));
+        assertThat(migratedXml, containsString("test"));
+    }
 
     private void assertStringsIgnoringCarriageReturnAreEqual(String expected, String actual) {
         assertEquals(expected.replaceAll("\\r", ""), actual.replaceAll("\\r", ""));


### PR DESCRIPTION
added a validation for leading and trailing spaces of environmentVariable name. 
Added a xsl transformation to trim the existing environment variable name from cruise-config.xml file