### PR TITLE
#2119 Pipeline Config API does not allow Pipeline Group Admin to create/edit/get a pipeline

### DIFF
--- a/server/webapp/WEB-INF/applicationContext-acegi-security.xml
+++ b/server/webapp/WEB-INF/applicationContext-acegi-security.xml
@@ -264,6 +264,8 @@
                 /admin/package_definitions/**=ROLE_SUPERVISOR,ROLE_GROUP_SUPERVISOR
                 /api/admin/material_test=ROLE_SUPERVISOR,ROLE_GROUP_SUPERVISOR
                 /api/admin/internal/pipelines=ROLE_SUPERVISOR,ROLE_GROUP_SUPERVISOR
+                /api/admin/pipelines=ROLE_SUPERVISOR,ROLE_GROUP_SUPERVISOR
+                /api/admin/pipelines/*=ROLE_SUPERVISOR,ROLE_GROUP_SUPERVISOR
                 /api/admin/**=ROLE_SUPERVISOR
                 /api/config-repository.git/**=ROLE_SUPERVISOR
                 /api/jobs/scheduled.xml=ROLE_SUPERVISOR

--- a/server/webapp/WEB-INF/rails.new/app/controllers/api_v1/admin/pipelines_controller.rb
+++ b/server/webapp/WEB-INF/rails.new/app/controllers/api_v1/admin/pipelines_controller.rb
@@ -54,7 +54,7 @@ module ApiV1
         end
       end
 
-      def handle_config_save_or_update_result(result, pipeline_name = params[:name])
+      def handle_config_save_or_update_result(result, pipeline_name = params[:pipeline_name])
         if result.isSuccessful
           load_pipeline(pipeline_name)
           json = ApiV1::Config::PipelineConfigRepresenter.new(@pipeline_config).to_hash(url_builder: self)
@@ -68,7 +68,7 @@ module ApiV1
 
 
       def check_for_attempted_pipeline_rename
-        unless CaseInsensitiveString.new(params[:pipeline][:name]) == CaseInsensitiveString.new(params[:name])
+        unless CaseInsensitiveString.new(params[:pipeline][:name]) == CaseInsensitiveString.new(params[:pipeline_name])
           result = HttpLocalizedOperationResult.new
           result.notAcceptable(LocalizedMessage::string("PIPELINE_RENAMING_NOT_ALLOWED"))
           render_http_operation_result(result)
@@ -76,14 +76,14 @@ module ApiV1
       end
 
       def check_for_stale_request
-        if (request.env["HTTP_IF_MATCH"] != "\"#{Digest::MD5.hexdigest(get_etag_for_pipeline_from_cache(params[:name]))}\"")
+        if (request.env["HTTP_IF_MATCH"] != "\"#{Digest::MD5.hexdigest(get_etag_for_pipeline_from_cache(params[:pipeline_name]))}\"")
           result = HttpLocalizedOperationResult.new
-          result.stale(LocalizedMessage::string("STALE_PIPELINE_CONFIG", params[:name]))
+          result.stale(LocalizedMessage::string("STALE_PIPELINE_CONFIG", params[:pipeline_name]))
           render_http_operation_result(result)
         end
       end
 
-      def load_pipeline(pipeline_name = params[:name])
+      def load_pipeline(pipeline_name = params[:pipeline_name])
         @pipeline_config = pipeline_config_service.getPipelineConfig(pipeline_name)
         raise RecordNotFound if @pipeline_config.nil?
       end
@@ -112,9 +112,9 @@ module ApiV1
       end
 
       def check_if_pipeline_by_same_name_already_exists
-        if (!pipeline_config_service.getPipelineConfig(params[:name]).nil?)
+        if (!pipeline_config_service.getPipelineConfig(params[:pipeline_name]).nil?)
           result = HttpLocalizedOperationResult.new
-          result.unprocessableEntity(LocalizedMessage::string("CANNOT_CREATE_PIPELINE_ALREADY_EXISTS", params[:name]))
+          result.unprocessableEntity(LocalizedMessage::string("CANNOT_CREATE_PIPELINE_ALREADY_EXISTS", params[:pipeline_name]))
           render_http_operation_result(result)
         end
       end

--- a/server/webapp/WEB-INF/rails.new/app/controllers/api_v1/admin/pipelines_controller.rb
+++ b/server/webapp/WEB-INF/rails.new/app/controllers/api_v1/admin/pipelines_controller.rb
@@ -17,7 +17,7 @@
 module ApiV1
   module Admin
     class PipelinesController < ApiV1::BaseController
-      before_action :check_admin_user_and_401
+      before_action :check_pipeline_group_admin_user_and_401
       before_action :load_pipeline, only: [:show]
       before_action :check_if_pipeline_by_same_name_already_exists, :check_group_not_blank, only: [:create]
       before_action :check_for_stale_request, :check_for_attempted_pipeline_rename, only: [:update]

--- a/server/webapp/WEB-INF/rails.new/app/presenters/api_v1/config/pipeline_config_representer.rb
+++ b/server/webapp/WEB-INF/rails.new/app/presenters/api_v1/config/pipeline_config_representer.rb
@@ -27,7 +27,7 @@ module ApiV1
                         })
 
       link :self do |opts|
-        opts[:url_builder].apiv1_admin_pipeline_url(name: pipeline.name)
+        opts[:url_builder].apiv1_admin_pipeline_url(pipeline_name: pipeline.name)
       end
 
       link :doc do |opts|
@@ -35,7 +35,7 @@ module ApiV1
       end
 
       link :find do |opts|
-        opts[:url_builder].apiv1_admin_pipeline_url(name: '__pipeline_name__').gsub(/__pipeline_name__/, ':pipeline_name')
+        opts[:url_builder].apiv1_admin_pipeline_url(pipeline_name: '__pipeline_name__').gsub(/__pipeline_name__/, ':pipeline_name')
       end
 
       property :label_template

--- a/server/webapp/WEB-INF/rails.new/config/routes.rb
+++ b/server/webapp/WEB-INF/rails.new/config/routes.rb
@@ -229,7 +229,7 @@ Go::Application.routes.draw do
       end
 
       namespace :admin do
-        resources :pipelines, param: :name, only: [:show, :update, :create], constraints: {name: PIPELINE_NAME_FORMAT}
+        resources :pipelines, param: :pipeline_name, only: [:show, :update, :create], constraints: {name: PIPELINE_NAME_FORMAT}
         resources :command_snippets, only: [:index]
         get 'command_snippets/show', controller: :command_snippets, action: :show, as: :command_snippet
         post :material_test, controller: :material_test, action: :test, as: :material_test

--- a/server/webapp/WEB-INF/rails.new/spec/support/api_spec_helper.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/support/api_spec_helper.rb
@@ -37,6 +37,20 @@ module ApiSpecHelper
     EOS
   end
 
+  def login_as_pipeline_group_Non_Admin_user
+    enable_security
+    controller.stub(:current_user).and_return(@user = Username.new(CaseInsensitiveString.new(SecureRandom.hex)))
+    @security_service.stub(:isUserAdminOfGroup).and_return(false)
+    @security_service.stub(:isUserAdmin).with(@user).and_return(false)
+  end
+
+  def login_as_pipeline_group_admin_user(group_name)
+    enable_security
+    controller.stub(:current_user).and_return(@user = Username.new(CaseInsensitiveString.new(SecureRandom.hex)))
+    @security_service.stub(:isUserAdminOfGroup).with(@user.getUsername, group_name).and_return(true)
+    @security_service.stub(:isUserAdmin).with(@user).and_return(true)
+  end
+
   def login_as_user
     enable_security
     controller.stub(:current_user).and_return(@user = Username.new(CaseInsensitiveString.new(SecureRandom.hex)))


### PR DESCRIPTION
made the pipeline config api accessible to the pipeline group admin users and Go admin users