### PR TITLE
Warnings on VSM if pipeline built with incompatible revisions

### DIFF
--- a/server/src/com/thoughtworks/go/domain/valuestreammap/SCMDependencyNode.java
+++ b/server/src/com/thoughtworks/go/domain/valuestreammap/SCMDependencyNode.java
@@ -16,13 +16,23 @@
 
 package com.thoughtworks.go.domain.valuestreammap;
 
+import com.thoughtworks.go.domain.MaterialRevision;
+import com.thoughtworks.go.domain.materials.Material;
+import com.thoughtworks.go.domain.materials.Modification;
+import com.thoughtworks.go.domain.materials.Modifications;
+
 import java.util.*;
+
+import static com.thoughtworks.go.util.ExceptionUtils.bomb;
+import static com.thoughtworks.go.util.ExceptionUtils.bombIfNull;
 
 
 public class SCMDependencyNode extends Node {
     private Set<Revision> revisions = new HashSet<>();
     private String materialType;
     private HashSet<String> materialNames = new LinkedHashSet<>();
+    private Set<MaterialRevisionWrapper> materialRevisionWrappers = new HashSet<>();
+    private List<MaterialRevision> materialRevisions = new ArrayList<>();
 
     public SCMDependencyNode(String nodeId, String nodeName, String materialType) {
         super(DependencyNodeType.MATERIAL, nodeId, nodeName);
@@ -31,12 +41,17 @@ public class SCMDependencyNode extends Node {
 
     @Override
     public void addRevision(Revision revision) {
-        this.revisions.add(revision);
+        bomb("SCMDependencyNode can have only MaterialRevisions, revisions are derived from material revisions.");
     }
 
     @Override
     public List<Revision> revisions() {
         ArrayList<Revision> revisions = new ArrayList<>(this.revisions);
+        for(MaterialRevision revision : materialRevisions) {
+            for(Modification modification : revision.getModifications()) {
+                revisions.add(new SCMRevision(modification));
+            }
+        }
         Collections.sort(revisions, new Comparator<Revision>() {
             @Override
             public int compare(Revision o1, Revision o2) {
@@ -48,7 +63,7 @@ public class SCMDependencyNode extends Node {
 
     @Override
     public void addRevisions(List<Revision> revisions) {
-        this.revisions.addAll(revisions);
+        bomb("SCMDependencyNode can have only MaterialRevisions, revisions are derived from material revisions.");
     }
 
     public String getMaterialType() {
@@ -61,5 +76,62 @@ public class SCMDependencyNode extends Node {
 
     public HashSet<String> getMaterialNames() {
         return materialNames;
+    }
+
+    public void addMaterialRevision(MaterialRevision materialRevision) {
+        if (materialRevisionWrappers.add(new MaterialRevisionWrapper(materialRevision))) {
+            materialRevisions.add(materialRevision);
+        }
+    }
+
+    public List<MaterialRevision> getMaterialRevisions() {
+        return materialRevisions;
+    }
+
+    private class MaterialRevisionWrapper {
+        private MaterialRevision materialRevision;
+
+        public MaterialRevisionWrapper(MaterialRevision materialRevision) {
+            bombIfNull(materialRevision, "Material Revision cannot be null");
+            this.materialRevision = materialRevision;
+        }
+
+        public MaterialRevision getMaterialRevision() {
+            return materialRevision;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            MaterialRevisionWrapper that = (MaterialRevisionWrapper) o;
+
+            if(this.materialRevision == that.materialRevision) return true;
+
+            return sameMaterial(that.materialRevision.getMaterial()) &&
+                    sameModifications(that.materialRevision.getModifications());
+        }
+
+        @Override
+        public int hashCode() {
+            int result;
+            result = (materialRevision.getMaterial() != null ? materialRevision.getMaterial().getFingerprint().hashCode() : 0);
+            result = 31 * result + (materialRevision.getModifications() != null ? materialRevision.getModifications().hashCode() : 0);
+            return result;
+        }
+
+        private boolean sameMaterial(Material thatMaterial) {
+            Material material = this.materialRevision.getMaterial();
+
+            if(material == thatMaterial) return true;
+            return material != null ? (thatMaterial != null && material.getFingerprint().equals(thatMaterial.getFingerprint())) : thatMaterial == null;
+        }
+
+        private boolean sameModifications(Modifications thatModifications) {
+            Modifications modifications = this.materialRevision.getModifications();
+
+            return modifications != null ? modifications.equals(thatModifications) : thatModifications == null;
+        }
     }
 }

--- a/server/src/com/thoughtworks/go/domain/valuestreammap/VSMViewType.java
+++ b/server/src/com/thoughtworks/go/domain/valuestreammap/VSMViewType.java
@@ -17,5 +17,5 @@
 package com.thoughtworks.go.domain.valuestreammap;
 
 public enum VSMViewType {
-    NO_PERMISSION, DELETED
+    NO_PERMISSION, DELETED, WARNING
 }

--- a/server/src/com/thoughtworks/go/server/service/ValueStreamMapService.java
+++ b/server/src/com/thoughtworks/go/server/service/ValueStreamMapService.java
@@ -40,8 +40,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 @Service
 public class ValueStreamMapService {
@@ -109,8 +111,12 @@ public class ValueStreamMapService {
         }
         addInstanceInformationToTheGraph(valueStreamMap);
         removeRevisionsBasedOnPermissionAndCurrentConfig(valueStreamMap, username);
+
+        valueStreamMap.addWarningIfBuiltFromInCompatibleRevisions();
+
         return valueStreamMap;
     }
+
 
 	public ValueStreamMapPresentationModel getValueStreamMap(String materialFingerprint, String revision, Username username, LocalizedOperationResult result) {
 		try {
@@ -207,7 +213,7 @@ public class ValueStreamMapService {
                 String upstreamPipeline = ((DependencyMaterial) material).getPipelineName().toString();
                 DependencyMaterialRevision revision = (DependencyMaterialRevision) materialRevision.getRevision();
 
-                graph.addUpstreamNode(new PipelineDependencyNode(upstreamPipeline, upstreamPipeline),new PipelineRevision(revision.getPipelineName(), revision.getPipelineCounter(), revision.getPipelineLabel()),
+                graph.addUpstreamNode(new PipelineDependencyNode(upstreamPipeline, upstreamPipeline), new PipelineRevision(revision.getPipelineName(), revision.getPipelineCounter(), revision.getPipelineLabel()),
                         pipelineName);
 
                 if (visitedNodes.contains(materialRevision)) {
@@ -219,7 +225,7 @@ public class ValueStreamMapService {
                 traverseUpstream(upstreamPipeline, buildCauseForUpstreamPipeline, graph, visitedNodes);
             } else {
                 graph.addUpstreamMaterialNode(new SCMDependencyNode(material.getFingerprint(), material.getUriForDisplay(), materialRevision.getMaterialType()), material.getName(),
-                        materialRevision.getModifications(), pipelineName);
+                        pipelineName, materialRevision);
             }
         }
     }

--- a/server/test/integration/com/thoughtworks/go/server/valuestreammap/DownstreamInstancePopulatorIntegrationTest.java
+++ b/server/test/integration/com/thoughtworks/go/server/valuestreammap/DownstreamInstancePopulatorIntegrationTest.java
@@ -22,15 +22,14 @@ import com.thoughtworks.go.config.CaseInsensitiveString;
 import com.thoughtworks.go.config.GoConfigDao;
 import com.thoughtworks.go.config.materials.git.GitMaterial;
 import com.thoughtworks.go.domain.MaterialInstance;
+import com.thoughtworks.go.domain.MaterialRevision;
 import com.thoughtworks.go.domain.materials.Modification;
-import com.thoughtworks.go.domain.materials.Modifications;
 import com.thoughtworks.go.domain.valuestreammap.Node;
 import com.thoughtworks.go.domain.valuestreammap.PipelineDependencyNode;
 import com.thoughtworks.go.domain.valuestreammap.PipelineRevision;
 import com.thoughtworks.go.domain.valuestreammap.Revision;
 import com.thoughtworks.go.domain.valuestreammap.SCMDependencyNode;
 import com.thoughtworks.go.domain.valuestreammap.ValueStreamMap;
-import com.thoughtworks.go.helper.ModificationsMother;
 import com.thoughtworks.go.server.cache.GoCache;
 import com.thoughtworks.go.server.dao.DatabaseAccessHelper;
 import com.thoughtworks.go.server.dao.PipelineDao;
@@ -101,7 +100,7 @@ public class DownstreamInstancePopulatorIntegrationTest {
         Node nodep4 = valueStreamMap.addDownstreamNode(new PipelineDependencyNode("p4", "p4"), "p3");
         valueStreamMap.addDownstreamNode(new PipelineDependencyNode("p4", "p4"), "p2");
 
-        valueStreamMap.addUpstreamMaterialNode(new SCMDependencyNode("g1", "g1", "git"),new CaseInsensitiveString("git"), new Modifications(ModificationsMother.multipleModificationList()), "p");
+        valueStreamMap.addUpstreamMaterialNode(new SCMDependencyNode("g1", "g1", "git"),new CaseInsensitiveString("git"), "p", new MaterialRevision(null));
 
         GitMaterial g1 = u.wf(new GitMaterial("g1"), "folder3");
         u.checkinInOrder(g1,"g_1");
@@ -137,7 +136,7 @@ public class DownstreamInstancePopulatorIntegrationTest {
         Node nodep3 = valueStreamMap.addDownstreamNode(new PipelineDependencyNode("p3", "p3"), "p2");
         Node nodep4 = valueStreamMap.addDownstreamNode(new PipelineDependencyNode("p4", "p4"), "p3");
         valueStreamMap.addDownstreamNode(new PipelineDependencyNode("p4", "p4"), "p2");
-        valueStreamMap.addUpstreamMaterialNode(new SCMDependencyNode("g1", "g1", "git"),new CaseInsensitiveString("git"), new Modifications(ModificationsMother.multipleModificationList()), "p");
+        valueStreamMap.addUpstreamMaterialNode(new SCMDependencyNode("g1", "g1", "git"),new CaseInsensitiveString("git"), "p", new MaterialRevision(null));
 
         GitMaterial g1 = u.wf(new GitMaterial("g1"), "folder3");
         u.checkinInOrder(g1,"g_1");
@@ -176,7 +175,7 @@ public class DownstreamInstancePopulatorIntegrationTest {
         Node nodep4 = valueStreamMap.addDownstreamNode(new PipelineDependencyNode("p4", "p4"), "p2");
         valueStreamMap.addDownstreamNode(new PipelineDependencyNode("p4", "p4"), "p3");
         Node nodep5 = valueStreamMap.addDownstreamNode(new PipelineDependencyNode("p5", "p5"), "p4");
-        valueStreamMap.addUpstreamMaterialNode(new SCMDependencyNode("g1", "g1", "git"),new CaseInsensitiveString("git"), new Modifications(ModificationsMother.multipleModificationList()), "p");
+        valueStreamMap.addUpstreamMaterialNode(new SCMDependencyNode("g1", "g1", "git"),new CaseInsensitiveString("git"), "p", new MaterialRevision(null));
 
         GitMaterial g1 = u.wf(new GitMaterial("g1"), "folder3");
         u.checkinInOrder(g1,"g_1");

--- a/server/test/unit/com/thoughtworks/go/domain/valuestreammap/NodeTest.java
+++ b/server/test/unit/com/thoughtworks/go/domain/valuestreammap/NodeTest.java
@@ -17,6 +17,7 @@
 package com.thoughtworks.go.domain.valuestreammap;
 
 import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
@@ -135,19 +136,6 @@ public class NodeTest {
         assertThat(revisions.toString(), revisions.size(), is(2));
         assertThat(revisions, hasItems(p11, p12));
     }
-
-    @Test
-    public void shouldGetRevisionsSortedInOrderOfModificationTimes_ForAnScmMaterialNode() {
-        SCMDependencyNode node = new SCMDependencyNode("finger-print", "svn-material", "svn");
-        Revision revision_Mar4th = scmRevision("rev", new Date(2013, 3, 4));
-        Revision revision_Mar3rd = scmRevision("rev", new Date(2013, 3, 3));
-        Revision revision_Mar2nd = scmRevision("rev", new Date(2013, 3, 2));
-        node.addRevision(revision_Mar3rd);
-        node.addRevision(revision_Mar4th);
-        node.addRevision(revision_Mar2nd);
-        assertThat(node.revisions(), is(Arrays.asList(revision_Mar4th, revision_Mar3rd, revision_Mar2nd)));
-    }
-
 
     @Test
     public void shouldGetRevisionsSortedInOrderOfPipelineCounters() {

--- a/server/test/unit/com/thoughtworks/go/domain/valuestreammap/SCMDependencyNodeTest.java
+++ b/server/test/unit/com/thoughtworks/go/domain/valuestreammap/SCMDependencyNodeTest.java
@@ -1,0 +1,100 @@
+/*************************GO-LICENSE-START*********************************
+ * Copyright 2015 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *************************GO-LICENSE-END***********************************/
+
+package com.thoughtworks.go.domain.valuestreammap;
+
+
+import com.thoughtworks.go.config.materials.ScmMaterial;
+import com.thoughtworks.go.domain.MaterialRevision;
+import com.thoughtworks.go.domain.materials.Modification;
+import com.thoughtworks.go.helper.MaterialsMother;
+import com.thoughtworks.go.helper.ModificationsMother;
+import org.joda.time.DateTime;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+
+public class SCMDependencyNodeTest {
+    @Test
+    public void shouldBeAbleToAddMaterialRevisions() {
+        ScmMaterial gitMaterial = MaterialsMother.gitMaterial("/url/for/repo");
+        List<Modification> modifications = ModificationsMother.multipleModificationList();
+
+        SCMDependencyNode node = new SCMDependencyNode("nodeID", "nodeName", "GIT");
+
+        node.addMaterialRevision(new MaterialRevision(null, modifications));
+        node.addMaterialRevision(new MaterialRevision(gitMaterial, modifications));
+
+        assertThat(node.getMaterialRevisions().size(), is(2));
+    }
+
+    @Test
+    public void addMaterialRevisionShouldNotAllowDuplicates() {
+        ScmMaterial gitMaterial = MaterialsMother.gitMaterial("/url/for/repo");
+        List<Modification> modifications = ModificationsMother.multipleModificationList();
+
+        SCMDependencyNode node = new SCMDependencyNode("nodeID", "nodeName", "GIT");
+
+        node.addMaterialRevision(new MaterialRevision(gitMaterial, modifications));
+        node.addMaterialRevision(new MaterialRevision(gitMaterial, modifications));
+
+        assertThat(node.getMaterialRevisions().size(), is(1));
+    }
+
+    @Test(expected=Exception.class)
+    public void addMaterialRevisionShouldNotAllowNull() {
+        new SCMDependencyNode("nodeID", "nodeName", "GIT").addMaterialRevision(null);
+    }
+
+    @Test(expected=Exception.class)
+    public void addRevisionShouldBeDisallowed() {
+        new SCMDependencyNode("nodeID", "nodeName", "GIT").
+                addRevision(new SCMRevision(ModificationsMother.oneModifiedFile("some_revision")));
+    }
+
+    @Test(expected=Exception.class)
+    public void addRevisionsShouldBeDisallowed() {
+        ArrayList<Revision> revisions = new ArrayList<>();
+        revisions.add(new SCMRevision(ModificationsMother.oneModifiedFile("some_revision")));
+
+        new SCMDependencyNode("nodeID", "nodeName", "GIT").addRevisions(revisions);
+    }
+
+    @Test
+    public void revisionsShouldFetchRevisionsFromMaterialRevisionSorted() {
+        ScmMaterial gitMaterial = MaterialsMother.gitMaterial("/url/for/repo");
+        Modification twoDaysAgo = ModificationsMother.oneModifiedFile("rev1", new DateTime().minusDays(2).toDate());
+        Modification yesterday = ModificationsMother.oneModifiedFile("rev2", new DateTime().minusDays(1).toDate());
+        Modification today = ModificationsMother.oneModifiedFile("rev3", new Date());
+
+        SCMDependencyNode node = new SCMDependencyNode("nodeID", "nodeName", "GIT");
+        node.addMaterialRevision(new MaterialRevision(gitMaterial, false, twoDaysAgo));
+        node.addMaterialRevision(new MaterialRevision(gitMaterial, false, yesterday));
+        node.addMaterialRevision(new MaterialRevision(gitMaterial, false, today));
+
+        assertThat(node.revisions().size(), is(3));
+        assertThat(node.revisions().get(0).getRevisionString(), is(today.getRevision()));
+        assertThat(node.revisions().get(1).getRevisionString(), is(yesterday.getRevision()));
+        assertThat(node.revisions().get(2).getRevisionString(), is(twoDaysAgo.getRevision()));
+    }
+}

--- a/server/test/unit/com/thoughtworks/go/domain/valuestreammap/VSMTestHelper.java
+++ b/server/test/unit/com/thoughtworks/go/domain/valuestreammap/VSMTestHelper.java
@@ -24,6 +24,7 @@ import com.thoughtworks.go.domain.PipelineIdentifier;
 import com.thoughtworks.go.domain.Stage;
 import com.thoughtworks.go.domain.StageState;
 import com.thoughtworks.go.domain.Stages;
+import com.thoughtworks.go.domain.MaterialRevision;
 import com.thoughtworks.go.domain.materials.Modification;
 import com.thoughtworks.go.server.presentation.models.ValueStreamMapPresentationModel;
 
@@ -98,6 +99,13 @@ public class VSMTestHelper {
         List<Revision> revisions = node.revisions();
         assertThat(revisions.toString(), revisions.size(), is(expectedRevisions.length));
         assertThat(revisions, hasItems(expectedRevisions));
+    }
+
+    public static void assertSCMNodeHasMaterialRevisions(ValueStreamMapPresentationModel graph, String nodeId, MaterialRevision... expectedMaterialRevisions) {
+        SCMDependencyNode node = (SCMDependencyNode)graph.findNode(nodeId);
+        List<MaterialRevision> materialRevisions = node.getMaterialRevisions();
+        assertThat(materialRevisions.toString(), materialRevisions.size(), is(expectedMaterialRevisions.length));
+        assertThat(materialRevisions, hasItems(expectedMaterialRevisions));
     }
 
     public static void assertStageDetailsOf(ValueStreamMap graph, String nodeId, String counter, Stages expectedStages) {

--- a/server/test/unit/com/thoughtworks/go/domain/valuestreammap/ValueStreamMapTest.java
+++ b/server/test/unit/com/thoughtworks/go/domain/valuestreammap/ValueStreamMapTest.java
@@ -17,16 +17,23 @@
 package com.thoughtworks.go.domain.valuestreammap;
 
 import com.thoughtworks.go.config.CaseInsensitiveString;
+import com.thoughtworks.go.domain.MaterialRevision;
 import com.thoughtworks.go.domain.materials.Modifications;
+import com.thoughtworks.go.helper.MaterialsMother;
 import com.thoughtworks.go.helper.ModificationsMother;
 import org.hamcrest.MatcherAssert;
 import org.junit.Test;
 
-import java.util.*;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
 
+import static com.thoughtworks.go.helper.ModificationsMother.oneModifiedFile;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
@@ -55,7 +62,7 @@ public class ValueStreamMapTest {
          */
         String dependent = "P1";
         ValueStreamMap graph = new ValueStreamMap(dependent, null);
-        graph.addUpstreamNode(new SCMDependencyNode("git_fingerprint", "git", "git"), null, dependent);
+        graph.addUpstreamMaterialNode(new SCMDependencyNode("git_fingerprint", "git", "git"), null, dependent, new MaterialRevision(null));
         List<List<Node>> nodesAtEachLevel = graph.presentationModel().getNodesAtEachLevel();
 
         assertThat(nodesAtEachLevel.size(), is(2));
@@ -77,9 +84,9 @@ public class ValueStreamMapTest {
         String P1 = "P1";
         String currentPipeline = "P2";
         ValueStreamMap graph = new ValueStreamMap(currentPipeline, null);
-        graph.addUpstreamMaterialNode(new SCMDependencyNode("git_fingerprint", "git", "git"), new CaseInsensitiveString("git1"), new Modifications(ModificationsMother.multipleModificationList()), currentPipeline);
+        graph.addUpstreamMaterialNode(new SCMDependencyNode("git_fingerprint", "git", "git"), new CaseInsensitiveString("git1"), currentPipeline, new MaterialRevision(null));
         graph.addUpstreamNode(new PipelineDependencyNode(P1, P1), null, currentPipeline);
-        graph.addUpstreamMaterialNode(new SCMDependencyNode("git_fingerprint", "git", "git"), new CaseInsensitiveString("git2"), new Modifications(ModificationsMother.multipleModificationList()), P1);
+        graph.addUpstreamMaterialNode(new SCMDependencyNode("git_fingerprint", "git", "git"), new CaseInsensitiveString("git2"), P1, new MaterialRevision(null));
 
         SCMDependencyNode node = (SCMDependencyNode) graph.findNode("git_fingerprint");
         HashSet<String> materialNames = new HashSet<String>();
@@ -87,6 +94,33 @@ public class ValueStreamMapTest {
         materialNames.add("git2");
 
         assertThat(node.getMaterialNames(), is(materialNames));
+    }
+
+    @Test
+    public void shouldPopulateSCMDependencyNodeWithMaterialRevisions() {
+        /*
+            git_fingerprint -> P1 ---- \
+                          \              -> p3
+                            -> P2 ---- /
+         */
+
+        String P1 = "P1";
+        String P2 = "P2";
+        String currentPipeline = "P3";
+        ValueStreamMap graph = new ValueStreamMap(currentPipeline, null);
+        MaterialRevision revision1 = new MaterialRevision(MaterialsMother.gitMaterial("test/repo1"), oneModifiedFile("revision1"));
+        MaterialRevision revision2 = new MaterialRevision(MaterialsMother.gitMaterial("test/repo2"), oneModifiedFile("revision2"));
+
+        graph.addUpstreamNode(new PipelineDependencyNode(P1, P1), null, currentPipeline);
+        graph.addUpstreamNode(new PipelineDependencyNode(P2, P2), null, currentPipeline);
+        graph.addUpstreamMaterialNode(new SCMDependencyNode("git_fingerprint", "git", "git"), new CaseInsensitiveString("git1"), P1, revision1);
+        graph.addUpstreamMaterialNode(new SCMDependencyNode("git_fingerprint", "git", "git"), new CaseInsensitiveString("git1"), P2, revision2);
+
+        SCMDependencyNode node = (SCMDependencyNode) graph.findNode("git_fingerprint");
+
+        assertThat(node.getMaterialRevisions().size(), is(2));
+        assertTrue(node.getMaterialRevisions().contains(revision1));
+        assertTrue(node.getMaterialRevisions().contains(revision2));
     }
 
     @Test
@@ -99,9 +133,9 @@ public class ValueStreamMapTest {
         String P1 = "P1";
         String currentPipeline = "P2";
         ValueStreamMap graph = new ValueStreamMap(currentPipeline, null);
-        graph.addUpstreamMaterialNode(new SCMDependencyNode("git_fingerprint", "git", "git"), new CaseInsensitiveString("git1"), new Modifications(), currentPipeline);
+        graph.addUpstreamMaterialNode(new SCMDependencyNode("git_fingerprint", "git", "git"), new CaseInsensitiveString("git1"), currentPipeline, new MaterialRevision(null));
         graph.addUpstreamNode(new PipelineDependencyNode(P1, P1), null, currentPipeline);
-        graph.addUpstreamMaterialNode(new SCMDependencyNode("git_fingerprint", "git", "git"), new CaseInsensitiveString("git1"), new Modifications(), P1);
+        graph.addUpstreamMaterialNode(new SCMDependencyNode("git_fingerprint", "git", "git"), new CaseInsensitiveString("git1"), P1, new MaterialRevision(null));
 
         SCMDependencyNode node = (SCMDependencyNode) graph.findNode("git_fingerprint");
         HashSet<String> materialNames = new HashSet<String>();
@@ -120,9 +154,9 @@ public class ValueStreamMapTest {
         String P1 = "P1";
         String currentPipeline = "P2";
         ValueStreamMap graph = new ValueStreamMap(currentPipeline, null);
-        graph.addUpstreamMaterialNode(new SCMDependencyNode("git_fingerprint", "http://git.com", "git"), null, new Modifications(), currentPipeline);
+        graph.addUpstreamMaterialNode(new SCMDependencyNode("git_fingerprint", "http://git.com", "git"), null, currentPipeline, new MaterialRevision(null));
         graph.addUpstreamNode(new PipelineDependencyNode(P1, P1), null, currentPipeline);
-        graph.addUpstreamMaterialNode(new SCMDependencyNode("git_fingerprint", "http://git.com", "git"), null , new Modifications(), P1);
+        graph.addUpstreamMaterialNode(new SCMDependencyNode("git_fingerprint", "http://git.com", "git"), null , P1, new MaterialRevision(null));
 
         SCMDependencyNode node = (SCMDependencyNode) graph.findNode("git_fingerprint");
 
@@ -221,10 +255,10 @@ public class ValueStreamMapTest {
 		graph.addUpstreamNode(new PipelineDependencyNode(plugins, plugins), null, acceptance);
 		graph.addUpstreamNode(new PipelineDependencyNode(gitPlugins, gitPlugins), null, plugins);
 		graph.addUpstreamNode(new PipelineDependencyNode(cruise, cruise), null, plugins);
-		graph.addUpstreamNode(new SCMDependencyNode(gitTrunk, gitTrunk, "git"), null, cruise);
-		graph.addUpstreamNode(new SCMDependencyNode(hgTrunk, hgTrunk, "hg"), null, cruise);
+		graph.addUpstreamMaterialNode(new SCMDependencyNode(gitTrunk, gitTrunk, "git"), null, cruise, new MaterialRevision(null));
+		graph.addUpstreamMaterialNode(new SCMDependencyNode(hgTrunk, hgTrunk, "hg"), null, cruise, new MaterialRevision(null));
 		graph.addUpstreamNode(new PipelineDependencyNode(cruise, cruise), null, acceptance);
-		graph.addUpstreamNode(new SCMDependencyNode(hgTrunk, hgTrunk, "hg"), null, acceptance);
+		graph.addUpstreamMaterialNode(new SCMDependencyNode(hgTrunk, hgTrunk, "hg"), null, acceptance, new MaterialRevision(null));
 
 		List<Node> rootNodes = graph.getRootNodes();
 		assertThat(rootNodes.size(), is(3));
@@ -333,10 +367,10 @@ public class ValueStreamMapTest {
         graph.addUpstreamNode(new PipelineDependencyNode(plugins, plugins), null, acceptance);
         graph.addUpstreamNode(new PipelineDependencyNode(gitPlugins, gitPlugins), null, plugins);
         graph.addUpstreamNode(new PipelineDependencyNode(cruise, cruise), null, plugins);
-        graph.addUpstreamNode(new SCMDependencyNode(gitTrunk, gitTrunk, "git"), null, cruise);
-        graph.addUpstreamNode(new SCMDependencyNode(hgTrunk, hgTrunk, "hg"), null, cruise);
+        graph.addUpstreamMaterialNode(new SCMDependencyNode(gitTrunk, gitTrunk, "git"), null, cruise, new MaterialRevision(null));
+        graph.addUpstreamMaterialNode(new SCMDependencyNode(hgTrunk, hgTrunk, "hg"), null, cruise, new MaterialRevision(null));
         graph.addUpstreamNode(new PipelineDependencyNode(cruise, cruise), null, acceptance);
-        graph.addUpstreamNode(new SCMDependencyNode(hgTrunk, hgTrunk, "hg"), null, acceptance);
+        graph.addUpstreamMaterialNode(new SCMDependencyNode(hgTrunk, hgTrunk, "hg"), null, acceptance, new MaterialRevision(null));
 
         graph.addDownstreamNode(new PipelineDependencyNode(deployGo03, deployGo03), acceptance);
         graph.addDownstreamNode(new PipelineDependencyNode(publish, publish), deployGo03);
@@ -383,8 +417,8 @@ public class ValueStreamMapTest {
         graph.addDownstreamNode(new PipelineDependencyNode(grandParent, grandParent), child);
         graph.addUpstreamNode(new PipelineDependencyNode(parent, parent), null, currentPipeline);
         graph.addUpstreamNode(new PipelineDependencyNode(grandParent, grandParent), null, parent);
-        graph.addUpstreamNode(new SCMDependencyNode("g","g","git") , null, grandParent);
-        graph.addUpstreamNode(new SCMDependencyNode("g","g","git") , null, parent);
+        graph.addUpstreamMaterialNode(new SCMDependencyNode("g","g","git") , null, grandParent, new MaterialRevision(null));
+        graph.addUpstreamMaterialNode(new SCMDependencyNode("g","g","git") , null, parent, new MaterialRevision(null));
 
         assertThat(graph.hasCycle(), is(true));
     }
@@ -405,7 +439,7 @@ public class ValueStreamMapTest {
         valueStreamMap.addUpstreamNode(new PipelineDependencyNode(b, b), null, c);
         valueStreamMap.addUpstreamNode(new PipelineDependencyNode(d, d), null, b);
         valueStreamMap.addUpstreamNode(new PipelineDependencyNode(a, a), null, d);
-        valueStreamMap.addUpstreamNode(new SCMDependencyNode("g", "g", "git"), null, a);
+        valueStreamMap.addUpstreamMaterialNode(new SCMDependencyNode("g", "g", "git"), null, a, new MaterialRevision(null));
 
         assertThat(valueStreamMap.hasCycle(), is(false));
     }
@@ -425,7 +459,7 @@ public class ValueStreamMapTest {
         String c = "C";
         ValueStreamMap graph = new ValueStreamMap(b, null);
         graph.addUpstreamNode(new PipelineDependencyNode(a, a), null, b);
-        graph.addUpstreamNode(new SCMDependencyNode("g","g","git"), null, a);
+        graph.addUpstreamMaterialNode(new SCMDependencyNode("g","g","git"), null, a, new MaterialRevision(null));
         graph.addDownstreamNode(new PipelineDependencyNode(a, a), b);
         graph.addDownstreamNode(new PipelineDependencyNode(c, c), a);
 
@@ -456,15 +490,48 @@ public class ValueStreamMapTest {
         valueStreamMap.addUpstreamNode(new PipelineDependencyNode(p3, p3), null, p4);
         valueStreamMap.addUpstreamNode(new PipelineDependencyNode(p2, p2), null, p3);
         valueStreamMap.addUpstreamNode(new PipelineDependencyNode(p1, p1), null, p2);
-        valueStreamMap.addUpstreamNode(new SCMDependencyNode(g1, g1, "git"), null, p1);
+        valueStreamMap.addUpstreamMaterialNode(new SCMDependencyNode(g1, g1, "git"), null, p1, new MaterialRevision(null));
 
         valueStreamMap.addUpstreamNode(new PipelineDependencyNode(p5, p5), new PipelineRevision(p5,2,"2"), current);
         valueStreamMap.addUpstreamNode(new PipelineDependencyNode(p6, p6), new PipelineRevision(p6,1,"1"), p5);
         valueStreamMap.addUpstreamNode(new PipelineDependencyNode(p5, p5), new PipelineRevision(p5,1,"1"), p6);
-        valueStreamMap.addUpstreamNode(new SCMDependencyNode(g2,g2,"git"), null, p5);
+        valueStreamMap.addUpstreamMaterialNode(new SCMDependencyNode(g2,g2,"git"), null, p5, new MaterialRevision(null));
 
         assertThat(valueStreamMap.hasCycle(), is(true));
     }
 
+    @Test
+    public void currentPipelineShouldHaveWarningsIfBuiltFromIncompatibleRevisions() {
+        String current = "current";
+
+        ValueStreamMap valueStreamMap = new ValueStreamMap(current, null);
+        SCMDependencyNode scmDependencyNode = new SCMDependencyNode("id", "git_node", "git");
+        MaterialRevision rev1 = new MaterialRevision(MaterialsMother.gitMaterial("git/repo/url"), ModificationsMother.oneModifiedFile("rev1"));
+        MaterialRevision rev2 = new MaterialRevision(MaterialsMother.gitMaterial("git/repo/url"), ModificationsMother.oneModifiedFile("rev2"));
+
+        valueStreamMap.addUpstreamMaterialNode(scmDependencyNode, new CaseInsensitiveString("git"), valueStreamMap.getCurrentPipeline().getId(), rev1);
+        valueStreamMap.addUpstreamMaterialNode(scmDependencyNode, new CaseInsensitiveString("git"), valueStreamMap.getCurrentPipeline().getId(), rev2);
+
+        valueStreamMap.addWarningIfBuiltFromInCompatibleRevisions();
+
+        assertThat(valueStreamMap.getCurrentPipeline().getViewType(), is(is(VSMViewType.WARNING)));
+    }
+
+    @Test
+    public void currentPipelineShouldNotHaveWarningsIfBuiltFromMultipleMaterialRevisionsWithSameLatestRevision() {
+        String current = "current";
+
+        ValueStreamMap valueStreamMap = new ValueStreamMap(current, null);
+        SCMDependencyNode scmDependencyNode = new SCMDependencyNode("id", "git_node", "git");
+        MaterialRevision rev1 = new MaterialRevision(MaterialsMother.gitMaterial("git/repo/url"), ModificationsMother.oneModifiedFile("rev1"));
+        MaterialRevision rev2 = new MaterialRevision(MaterialsMother.gitMaterial("git/repo/url"), ModificationsMother.oneModifiedFile("rev1"), ModificationsMother.oneModifiedFile("rev2"));
+
+        valueStreamMap.addUpstreamMaterialNode(scmDependencyNode, new CaseInsensitiveString("git"), valueStreamMap.getCurrentPipeline().getId(), rev1);
+        valueStreamMap.addUpstreamMaterialNode(scmDependencyNode, new CaseInsensitiveString("git"), valueStreamMap.getCurrentPipeline().getId(), rev2);
+
+        valueStreamMap.addWarningIfBuiltFromInCompatibleRevisions();
+
+        assertNull(valueStreamMap.getCurrentPipeline().getViewType());
+    }
 }
 

--- a/server/test/unit/com/thoughtworks/go/server/service/ValueStreamMapServiceTest.java
+++ b/server/test/unit/com/thoughtworks/go/server/service/ValueStreamMapServiceTest.java
@@ -53,6 +53,7 @@ import java.util.*;
 import static com.thoughtworks.go.domain.valuestreammap.VSMTestHelper.assertDepth;
 import static com.thoughtworks.go.helper.ModificationsMother.checkinWithComment;
 import static java.util.Arrays.asList;
+import static junit.framework.TestCase.assertNull;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
@@ -518,14 +519,13 @@ public class ValueStreamMapServiceTest {
         VSMTestHelper.assertNodeHasRevisions(graph, "p1", new PipelineRevision("p1", 1, "LABEL-p1-1"), new PipelineRevision("p1", 2, "LABEL-p1-2"));
         VSMTestHelper.assertNodeHasRevisions(graph, "p2", new PipelineRevision("p2", 1, "LABEL-p2-1"));
         VSMTestHelper.assertNodeHasRevisions(graph, "p3", new PipelineRevision("p3", 1, "LABEL-P3"));
-        VSMTestHelper.assertNodeHasRevisions(graph, git.getFingerprint(),
-                new SCMRevision(modifications.get(2)),new SCMRevision(modifications.get(1)),new SCMRevision(modifications.get(0)));
+        VSMTestHelper.assertSCMNodeHasMaterialRevisions(graph, git.getFingerprint(), new MaterialRevision(git, false, modifications));
 
         verify(runStagesPopulator).apply(any(ValueStreamMap.class));
     }
 
     @Test
-    public void shouldPopulateAllSCMModificationsThatCausedPipelineRun() {
+    public void shouldPopulateAllMaterialRevisionsThatCausedPipelineRun() {
         /*
         * git---> p1 --->p2
         *  |             ^
@@ -555,13 +555,13 @@ public class ValueStreamMapServiceTest {
         VSMTestHelper.assertNodeHasRevisions(graph, "p1", new PipelineRevision("p1", 1, "LABEL-p1-1"));
         VSMTestHelper.assertNodeHasRevisions(graph, "p2", new PipelineRevision("p2", 1, "LABEL-P2"));
 
-        VSMTestHelper.assertNodeHasRevisions(graph, git.getFingerprint(), new SCMRevision(gitModifications.get(2)), new SCMRevision(gitModifications.get(1)), new SCMRevision(gitModifications.get(0)));
+        VSMTestHelper.assertSCMNodeHasMaterialRevisions(graph, git.getFingerprint(), new MaterialRevision(git, false, gitModifications));
 
         verify(runStagesPopulator).apply(any(ValueStreamMap.class));
     }
 
     @Test
-    public void shouldPopulateAllSCMModificationsThatCausedPipelineRun_WhenFaninIsNotObeyed() {
+    public void shouldPopulateAllSCMMaterialRevisionsThatCausedPipelineRun_WhenFaninIsNotObeyed() {
         /*
         * git---> p1 --->p2
         *  |             ^
@@ -594,9 +594,87 @@ public class ValueStreamMapServiceTest {
         VSMTestHelper.assertNodeHasRevisions(graph, "p1", new PipelineRevision("p1", 1, "LABEL-p1-1"));
         VSMTestHelper.assertNodeHasRevisions(graph, "p2", new PipelineRevision("p2", 1, "LABEL-P2"));
 
-        VSMTestHelper.assertNodeHasRevisions(graph, git.getFingerprint(), new SCMRevision(modification3), new SCMRevision(modification2), new SCMRevision(modification1));
+        VSMTestHelper.assertSCMNodeHasMaterialRevisions(graph, git.getFingerprint(),
+                new MaterialRevision(git, false, modification1, modification2),
+                new MaterialRevision(git, false, modification3));
 
         verify(runStagesPopulator).apply(any(ValueStreamMap.class));
+    }
+
+    @Test
+    public void currentPipelineShouldHaveWarningsIfBuiltFromIncompatibleRevisions() {
+        /*
+                            /-> P1 -- \
+                        git            -> p3
+                            \-> P2 -- /
+         */
+
+
+        GitMaterial git = new GitMaterial("git");
+        MaterialConfig gitConfig = git.config();
+        BuildCause p1buildCause = createBuildCauseForRevisions(new ArrayList<DependencyMaterialDetail>(), asList(git), Arrays.asList(ModificationsMother.oneModifiedFile("rev1")));
+        BuildCause p2buildCause = createBuildCauseForRevisions(new ArrayList<DependencyMaterialDetail>(), asList(git), Arrays.asList(ModificationsMother.oneModifiedFile("rev2")));
+
+        BuildCause p3buildCause = createBuildCauseForRevisions(asList(dependencyMaterial("p1", 1), dependencyMaterial("p2", 1)), new ArrayList<GitMaterial>(), new ArrayList<Modification>());
+
+
+        when(pipelineService.buildCauseFor("p3", 1)).thenReturn(p3buildCause);
+        when(pipelineService.buildCauseFor("p1", 1)).thenReturn(p1buildCause);
+        when(pipelineService.buildCauseFor("p2", 1)).thenReturn(p2buildCause);
+
+        PipelineConfig p1Config = PipelineConfigMother.pipelineConfig("p1", new MaterialConfigs(gitConfig));
+        PipelineConfig p2Config = PipelineConfigMother.pipelineConfig("p2", new MaterialConfigs(gitConfig));
+        PipelineConfig p3Config = PipelineConfigMother.pipelineConfig("p3",
+                new MaterialConfigs(new DependencyMaterialConfig(p1Config.name(), p1Config.getFirstStageConfig().name()), new DependencyMaterialConfig(p2Config.name(), p2Config.getFirstStageConfig().name())));
+        CruiseConfig cruiseConfig = new BasicCruiseConfig(new BasicPipelineConfigs(p1Config, p2Config, p3Config));
+        when(pipelineService.findPipelineByCounterOrLabel("p3", "1")).thenReturn(new Pipeline("p3", "LABEL-P3", p3buildCause));
+
+        when(goConfigService.currentCruiseConfig()).thenReturn(cruiseConfig);
+
+
+        ValueStreamMapPresentationModel graph = valueStreamMapService.getValueStreamMap("p3", 1, user, result);
+
+        assertThat(graph.getCurrentPipeline().getViewType(), is(VSMViewType.WARNING));
+    }
+
+    @Test
+    public void currentPipelineShouldNotHaveWarningsIfBuiltFromMultipleRevisionsWithSameLatestRevision() {
+        /*
+                            /-> P1 -- \
+                        git            -> p3
+                            \-> P2 -- /
+         */
+
+
+        GitMaterial git = new GitMaterial("git");
+        MaterialConfig gitConfig = git.config();
+        Modification rev1 = ModificationsMother.oneModifiedFile("rev1");
+        Modification rev2 = ModificationsMother.oneModifiedFile("rev2");
+        Modification rev3 = ModificationsMother.oneModifiedFile("rev3");
+
+        BuildCause p1buildCause = createBuildCauseForRevisions(new ArrayList<DependencyMaterialDetail>(), asList(git), Arrays.asList(rev3, rev2, rev1));
+        BuildCause p2buildCause = createBuildCauseForRevisions(new ArrayList<DependencyMaterialDetail>(), asList(git), Arrays.asList(rev3));
+
+        BuildCause p3buildCause = createBuildCauseForRevisions(asList(dependencyMaterial("p1", 1), dependencyMaterial("p2", 1)), new ArrayList<GitMaterial>(), new ArrayList<Modification>());
+
+
+        when(pipelineService.buildCauseFor("p3", 1)).thenReturn(p3buildCause);
+        when(pipelineService.buildCauseFor("p1", 1)).thenReturn(p1buildCause);
+        when(pipelineService.buildCauseFor("p2", 1)).thenReturn(p2buildCause);
+
+        PipelineConfig p1Config = PipelineConfigMother.pipelineConfig("p1", new MaterialConfigs(gitConfig));
+        PipelineConfig p2Config = PipelineConfigMother.pipelineConfig("p2", new MaterialConfigs(gitConfig));
+        PipelineConfig p3Config = PipelineConfigMother.pipelineConfig("p3",
+                new MaterialConfigs(new DependencyMaterialConfig(p1Config.name(), p1Config.getFirstStageConfig().name()), new DependencyMaterialConfig(p2Config.name(), p2Config.getFirstStageConfig().name())));
+        CruiseConfig cruiseConfig = new BasicCruiseConfig(new BasicPipelineConfigs(p1Config, p2Config, p3Config));
+        when(pipelineService.findPipelineByCounterOrLabel("p3", "1")).thenReturn(new Pipeline("p3", "LABEL-P3", p3buildCause));
+
+        when(goConfigService.currentCruiseConfig()).thenReturn(cruiseConfig);
+
+
+        ValueStreamMapPresentationModel graph = valueStreamMapService.getValueStreamMap("p3", 1, user, result);
+
+        assertNull(graph.getCurrentPipeline().getViewType());
     }
 
     @Test

--- a/server/test/unit/com/thoughtworks/go/server/valuestreammap/CrossingMinimizationTest.java
+++ b/server/test/unit/com/thoughtworks/go/server/valuestreammap/CrossingMinimizationTest.java
@@ -18,6 +18,7 @@ package com.thoughtworks.go.server.valuestreammap;
 
 import java.util.Arrays;
 
+import com.thoughtworks.go.domain.MaterialRevision;
 import com.thoughtworks.go.domain.valuestreammap.Node;
 import com.thoughtworks.go.domain.valuestreammap.NodeLevelMap;
 import com.thoughtworks.go.domain.valuestreammap.SCMDependencyNode;
@@ -55,10 +56,10 @@ public class CrossingMinimizationTest {
         String g2 = "g2";
         ValueStreamMap graph = new ValueStreamMap(p3, null);
         graph.addUpstreamNode(new PipelineDependencyNode(p1, p1), null, p3);
-        graph.addUpstreamNode(new SCMDependencyNode(g1, g1, "git"), null, p1);
-        graph.addUpstreamNode(new SCMDependencyNode(g2, g2, "git"), null, p1);
+        graph.addUpstreamMaterialNode(new SCMDependencyNode(g1, g1, "git"), null, p1, new MaterialRevision(null));
+        graph.addUpstreamMaterialNode(new SCMDependencyNode(g2, g2, "git"), null, p1, new MaterialRevision(null));
         graph.addUpstreamNode(new PipelineDependencyNode(p2, p2), null, p3);
-        graph.addUpstreamNode(new SCMDependencyNode(g1, g1, "git"), null, p2);
+        graph.addUpstreamMaterialNode(new SCMDependencyNode(g1, g1, "git"), null, p2, new MaterialRevision(null));
 
         NodeLevelMap levelToNodesMap = nodeLevelMap(graph);
         assertThat(levelToNodesMap.get(-1), is(Arrays.asList(graph.findNode(p1), graph.findNode(p2))));
@@ -99,12 +100,12 @@ public class CrossingMinimizationTest {
         ValueStreamMap graph = new ValueStreamMap(p, null);
 
         graph.addUpstreamNode(new PipelineDependencyNode(p1, p1), null, p);
-        graph.addUpstreamNode(new SCMDependencyNode(g1, g1, "git"), null, p1);
+        graph.addUpstreamMaterialNode(new SCMDependencyNode(g1, g1, "git"), null, p1, new MaterialRevision(null));
         graph.addUpstreamNode(new PipelineDependencyNode(p2, p2), null, p);
-        graph.addUpstreamNode(new SCMDependencyNode(g1, g1, "git"), null, p2);
+        graph.addUpstreamMaterialNode(new SCMDependencyNode(g1, g1, "git"), null, p2, new MaterialRevision(null));
         graph.addUpstreamNode(new PipelineDependencyNode(p3, p3), null, p);
-        graph.addUpstreamNode(new SCMDependencyNode(g2, g2, "git"), null, p3);
-        graph.addUpstreamNode(new SCMDependencyNode(g3, g3, "git"), null, p3);
+        graph.addUpstreamMaterialNode(new SCMDependencyNode(g2, g2, "git"), null, p3, new MaterialRevision(null));
+        graph.addUpstreamMaterialNode(new SCMDependencyNode(g3, g3, "git"), null, p3, new MaterialRevision(null));
 
         NodeLevelMap levelToNodesMap = nodeLevelMap(graph);
         crossingMinimization.apply(levelToNodesMap);
@@ -131,7 +132,7 @@ public class CrossingMinimizationTest {
          */
 
         ValueStreamMap graph = new ValueStreamMap("P", null);
-        Node g1 = graph.addUpstreamNode(new SCMDependencyNode("g1","g1", "git"), null, "P");
+        Node g1 = graph.addUpstreamMaterialNode(new SCMDependencyNode("g1","g1", "git"), null, "P", new MaterialRevision(null));
         Node p1 = graph.addDownstreamNode(new PipelineDependencyNode("p1","p1"), "P");
         Node p2 = graph.addDownstreamNode(new PipelineDependencyNode("P2", "P2"), "P");
         Node p3 = graph.addDownstreamNode(new PipelineDependencyNode("P3", "P3"), "P2");
@@ -163,12 +164,12 @@ public class CrossingMinimizationTest {
         */
 
         ValueStreamMap graph = new ValueStreamMap("P", null);
-        Node g4 = graph.addUpstreamNode(new SCMDependencyNode("g4", "g4", "git"), null, "P");
+        Node g4 = graph.addUpstreamMaterialNode(new SCMDependencyNode("g4", "g4", "git"), null, "P", new MaterialRevision(null));
         Node p1 = graph.addUpstreamNode(new PipelineDependencyNode("P1", "P1"), null, "P");
-        Node g1 = graph.addUpstreamNode(new SCMDependencyNode("g1", "g1", "git"), null, "P1");
-        Node g2 = graph.addUpstreamNode(new SCMDependencyNode("g2", "g2", "git"), null, "P1");
+        Node g1 = graph.addUpstreamMaterialNode(new SCMDependencyNode("g1", "g1", "git"), null, "P1", new MaterialRevision(null));
+        Node g2 = graph.addUpstreamMaterialNode(new SCMDependencyNode("g2", "g2", "git"), null, "P1", new MaterialRevision(null));
         Node p2 = graph.addUpstreamNode(new PipelineDependencyNode("P2", "P2"), null, "P");
-        Node g3 = graph.addUpstreamNode(new SCMDependencyNode("g3", "g3", "git"), null, "P2");
+        Node g3 = graph.addUpstreamMaterialNode(new SCMDependencyNode("g3", "g3", "git"), null, "P2", new MaterialRevision(null));
 
         NodeLevelMap levelToNodesMap = nodeLevelMap(graph);
         crossingMinimization.apply(levelToNodesMap);
@@ -206,7 +207,7 @@ public class CrossingMinimizationTest {
         String p4 = "P4";
         String p5 = "P5";
         ValueStreamMap graph = new ValueStreamMap(p, null);
-        graph.addUpstreamNode(new SCMDependencyNode(g1, g1, "git"), null, p);
+        graph.addUpstreamMaterialNode(new SCMDependencyNode(g1, g1, "git"), null, p, new MaterialRevision(null));
         graph.addDownstreamNode(new PipelineDependencyNode(p1, p1), p);
         graph.addDownstreamNode(new PipelineDependencyNode(p4, p4), p1);
         graph.addDownstreamNode(new PipelineDependencyNode(p2, p2), p);
@@ -248,10 +249,10 @@ public class CrossingMinimizationTest {
         String p = "P";
 
         ValueStreamMap graph = new ValueStreamMap(p, null);
-        graph.addUpstreamNode(new SCMDependencyNode(g3, g3, "git"), null, p);
+        graph.addUpstreamMaterialNode(new SCMDependencyNode(g3, g3, "git"), null, p, new MaterialRevision(null));
         graph.addUpstreamNode(new PipelineDependencyNode(p1, p1), null, p);
-        graph.addUpstreamNode(new SCMDependencyNode(g1, g1, "git"), null, p1);
-        graph.addUpstreamNode(new SCMDependencyNode(g2, g2, "git"), null, p1);
+        graph.addUpstreamMaterialNode(new SCMDependencyNode(g1, g1, "git"), null, p1, new MaterialRevision(null));
+        graph.addUpstreamMaterialNode(new SCMDependencyNode(g2, g2, "git"), null, p1, new MaterialRevision(null));
 
         NodeLevelMap levelToNodesMap = nodeLevelMap(graph);
         crossingMinimization.apply(levelToNodesMap);
@@ -290,8 +291,8 @@ public class CrossingMinimizationTest {
         ValueStreamMap graph = new ValueStreamMap(p, null);
         graph.addUpstreamNode(new PipelineDependencyNode(p1, p1), null, p);
         graph.addUpstreamNode(new PipelineDependencyNode(p2, p2), null, p);
-        graph.addUpstreamNode(new SCMDependencyNode(g2, g2, "git"), null, p2);
-        graph.addUpstreamNode(new SCMDependencyNode(g1, g1, "git"), null, p1);
+        graph.addUpstreamMaterialNode(new SCMDependencyNode(g2, g2, "git"), null, p2, new MaterialRevision(null));
+        graph.addUpstreamMaterialNode(new SCMDependencyNode(g1, g1, "git"), null, p1, new MaterialRevision(null));
 
         graph.addDownstreamNode(new PipelineDependencyNode(p3, p3), p);
         graph.addDownstreamNode(new PipelineDependencyNode(p4, p4), p);

--- a/server/test/unit/com/thoughtworks/go/server/valuestreammap/DummyNodeCreationTest.java
+++ b/server/test/unit/com/thoughtworks/go/server/valuestreammap/DummyNodeCreationTest.java
@@ -16,6 +16,7 @@
 
 package com.thoughtworks.go.server.valuestreammap;
 
+import com.thoughtworks.go.domain.MaterialRevision;
 import com.thoughtworks.go.domain.valuestreammap.DependencyNodeType;
 import com.thoughtworks.go.domain.valuestreammap.NodeLevelMap;
 import com.thoughtworks.go.domain.valuestreammap.SCMDependencyNode;
@@ -48,8 +49,8 @@ public class DummyNodeCreationTest {
         ValueStreamMap graph = new ValueStreamMap(currentPipeline, null);
         graph.addUpstreamNode(new PipelineDependencyNode("d2", "d2"), null, currentPipeline);
         graph.addUpstreamNode(new PipelineDependencyNode("d1", "d1"), null, "d2");
-        graph.addUpstreamNode(new SCMDependencyNode("g", "g", "git"), null, "d1");
-        graph.addUpstreamNode(new SCMDependencyNode("g", "g", "git"), null, currentPipeline);
+        graph.addUpstreamMaterialNode(new SCMDependencyNode("g", "g", "git"), null, "d1", new MaterialRevision(null));
+        graph.addUpstreamMaterialNode(new SCMDependencyNode("g", "g", "git"), null, currentPipeline, new MaterialRevision(null));
 
         NodeLevelMap nodeLevelMap = new LevelAssignment().apply(graph);
         dummyNodeCreation.apply(graph, nodeLevelMap);
@@ -102,8 +103,8 @@ public class DummyNodeCreationTest {
         graph.addUpstreamNode(new PipelineDependencyNode("d2", "d2"), null, currentPipeline);
         graph.addUpstreamNode(new PipelineDependencyNode("d1", "d1"), null, currentPipeline);
         graph.addUpstreamNode(new PipelineDependencyNode("d1", "d1"), null, "d2");
-        graph.addUpstreamNode(new SCMDependencyNode("g", "g", "git"), null, "d1");
-        graph.addUpstreamNode(new SCMDependencyNode("g", "g", "git"), null, "d2");
+        graph.addUpstreamMaterialNode(new SCMDependencyNode("g", "g", "git"), null, "d1", new MaterialRevision(null));
+        graph.addUpstreamMaterialNode(new SCMDependencyNode("g", "g", "git"), null, "d2", new MaterialRevision(null));
 
         NodeLevelMap nodeLevelMap = new LevelAssignment().apply(graph);
         dummyNodeCreation.apply(graph, nodeLevelMap);
@@ -146,6 +147,7 @@ public class DummyNodeCreationTest {
         assertThat(nodeLevelMap.get(-1).size(), is(3));
         assertThat(nodeLevelMap.get(-2).size(), is(2));
     }
+
     @Test
     public void shouldMoveNodeAndIntroduceDummyNodesToCorrectLayer_crossMaterialPipelineDependency() {
         /*
@@ -161,12 +163,12 @@ public class DummyNodeCreationTest {
         ValueStreamMap graph = new ValueStreamMap(currentPipeline, null);
         graph.addUpstreamNode(new PipelineDependencyNode("d2", "d2"), null, currentPipeline);
         graph.addUpstreamNode(new PipelineDependencyNode("d1", "d1"), null, "d2");
-        graph.addUpstreamNode(new SCMDependencyNode("g1", "g1", "git"), null, "d1");
-        graph.addUpstreamNode(new SCMDependencyNode("g1", "g1", "git"), null, "d2");
+        graph.addUpstreamMaterialNode(new SCMDependencyNode("g1", "g1", "git"), null, "d1", new MaterialRevision(null));
+        graph.addUpstreamMaterialNode(new SCMDependencyNode("g1", "g1", "git"), null, "d2", new MaterialRevision(null));
         graph.addUpstreamNode(new PipelineDependencyNode("d4", "d4"), null, currentPipeline);
         graph.addUpstreamNode(new PipelineDependencyNode("d3", "d3"), null, "d4");
-        graph.addUpstreamNode(new SCMDependencyNode("g2", "g2", "git"), null, "d3");
-        graph.addUpstreamNode(new SCMDependencyNode("g2", "g2", "git"), null, "d4");
+        graph.addUpstreamMaterialNode(new SCMDependencyNode("g2", "g2", "git"), null, "d3", new MaterialRevision(null));
+        graph.addUpstreamMaterialNode(new SCMDependencyNode("g2", "g2", "git"), null, "d4", new MaterialRevision(null));
 
         NodeLevelMap nodeLevelMap = new LevelAssignment().apply(graph);
         dummyNodeCreation.apply(graph, nodeLevelMap);
@@ -192,19 +194,19 @@ public class DummyNodeCreationTest {
         ValueStreamMap graph = new ValueStreamMap(currentPipeline, null);
         graph.addUpstreamNode(new PipelineDependencyNode("p4", "p4"), null, currentPipeline);
         graph.addUpstreamNode(new PipelineDependencyNode("p1", "p1"), null, "p4");
-        graph.addUpstreamNode(new SCMDependencyNode("git", "git", "git"), null, "p1");
+        graph.addUpstreamMaterialNode(new SCMDependencyNode("git", "git", "git"), null, "p1", new MaterialRevision(null));
         graph.addUpstreamNode(new PipelineDependencyNode("p2", "p2"), null, "p4");
-        graph.addUpstreamNode(new SCMDependencyNode("git", "git", "git"), null, "p2");
+        graph.addUpstreamMaterialNode(new SCMDependencyNode("git", "git", "git"), null, "p2", new MaterialRevision(null));
 
         graph.addUpstreamNode(new PipelineDependencyNode("p5", "p5"), null, currentPipeline);
         graph.addUpstreamNode(new PipelineDependencyNode("p3", "p3"), null, "p5");
-        graph.addUpstreamNode(new SCMDependencyNode("git", "git", "git"), null, "p3");
+        graph.addUpstreamMaterialNode(new SCMDependencyNode("git", "git", "git"), null, "p3", new MaterialRevision(null));
         graph.addUpstreamNode(new PipelineDependencyNode("p4", "p4"), null, "p5");
 
         graph.addUpstreamNode(new PipelineDependencyNode("p1", "p1"), null, "p4");
-        graph.addUpstreamNode(new SCMDependencyNode("git", "git", "git"), null, "p1");
+        graph.addUpstreamMaterialNode(new SCMDependencyNode("git", "git", "git"), null, "p1", new MaterialRevision(null));
         graph.addUpstreamNode(new PipelineDependencyNode("p2", "p2"), null, "p4");
-        graph.addUpstreamNode(new SCMDependencyNode("git", "git", "git"), null, "p2");
+        graph.addUpstreamMaterialNode(new SCMDependencyNode("git", "git", "git"), null, "p2", new MaterialRevision(null));
 
         NodeLevelMap nodeLevelMap = new LevelAssignment().apply(graph);
         dummyNodeCreation.apply(graph, nodeLevelMap);

--- a/server/test/unit/com/thoughtworks/go/server/valuestreammap/LevelAssignmentTest.java
+++ b/server/test/unit/com/thoughtworks/go/server/valuestreammap/LevelAssignmentTest.java
@@ -18,8 +18,8 @@ package com.thoughtworks.go.server.valuestreammap;
 
 import com.thoughtworks.go.config.CaseInsensitiveString;
 import com.thoughtworks.go.config.materials.git.GitMaterial;
+import com.thoughtworks.go.domain.MaterialRevision;
 import com.thoughtworks.go.domain.materials.Modification;
-import com.thoughtworks.go.domain.materials.Modifications;
 import com.thoughtworks.go.domain.valuestreammap.Node;
 import com.thoughtworks.go.domain.valuestreammap.NodeLevelMap;
 import com.thoughtworks.go.domain.valuestreammap.PipelineDependencyNode;
@@ -55,9 +55,9 @@ public class LevelAssignmentTest {
         ValueStreamMap valueStreamMap = new ValueStreamMap(current, new PipelineRevision(current, 1, "1"));
         valueStreamMap.addUpstreamNode(p1, new PipelineRevision("p1", 1, "1"), current);
         valueStreamMap.addUpstreamNode(p2, new PipelineRevision("p2", 1, "1"), current);
-        valueStreamMap.addUpstreamMaterialNode(gitNode, new CaseInsensitiveString("trunk"), new Modifications(ModificationsMother.aCheckIn("1")), "p1");
-        valueStreamMap.addUpstreamMaterialNode(gitNode, new CaseInsensitiveString("main-branch"), new Modifications(ModificationsMother.aCheckIn("1")), "p3");
-        valueStreamMap.addUpstreamMaterialNode(gitNode, new CaseInsensitiveString("main-branch"), new Modifications(ModificationsMother.aCheckIn("1")), "p2");
+        valueStreamMap.addUpstreamMaterialNode(gitNode, new CaseInsensitiveString("trunk"), "p1", new MaterialRevision(null));
+        valueStreamMap.addUpstreamMaterialNode(gitNode, new CaseInsensitiveString("main-branch"), "p3", new MaterialRevision(null));
+        valueStreamMap.addUpstreamMaterialNode(gitNode, new CaseInsensitiveString("main-branch"), "p2", new MaterialRevision(null));
         NodeLevelMap levelToNodeMap = new LevelAssignment().apply(valueStreamMap);
 
         assertThat(valueStreamMap.getCurrentPipeline().getLevel(), is(0));
@@ -88,7 +88,7 @@ public class LevelAssignmentTest {
         Node gitNode = new SCMDependencyNode("git", "g", "git");
 
         ValueStreamMap valueStreamMap = new ValueStreamMap(current, new PipelineRevision(current, 1, "1"));
-        valueStreamMap.addUpstreamMaterialNode(gitNode, new CaseInsensitiveString("trunk"), new Modifications(ModificationsMother.aCheckIn("1")), "p");
+        valueStreamMap.addUpstreamMaterialNode(gitNode, new CaseInsensitiveString("trunk"), "p", new MaterialRevision(null));
 
         valueStreamMap.addDownstreamNode(p1, current);
         valueStreamMap.addDownstreamNode(p2, current);

--- a/server/test/unit/com/thoughtworks/go/server/valuestreammap/RunStagesPopulatorTest.java
+++ b/server/test/unit/com/thoughtworks/go/server/valuestreammap/RunStagesPopulatorTest.java
@@ -16,10 +16,8 @@
 
 package com.thoughtworks.go.server.valuestreammap;
 
-import java.util.ArrayList;
-import java.util.Date;
-
 import com.thoughtworks.go.config.CaseInsensitiveString;
+import com.thoughtworks.go.domain.MaterialRevision;
 import com.thoughtworks.go.domain.Stage;
 import com.thoughtworks.go.domain.Stages;
 import com.thoughtworks.go.domain.materials.Modifications;
@@ -34,6 +32,9 @@ import com.thoughtworks.go.helper.StageMother;
 import com.thoughtworks.go.server.dao.StageDao;
 import org.junit.Before;
 import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Date;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -60,8 +61,8 @@ public class RunStagesPopulatorTest {
         graph.addUpstreamNode(new PipelineDependencyNode("p1", "p1"), new PipelineRevision("p1", 1, "labelp1-1"), "p3");
         graph.addUpstreamNode(new PipelineDependencyNode("p2", "p2"), new PipelineRevision("p2", 1, "labelp2-1"), "p3");
         graph.addUpstreamNode(new PipelineDependencyNode("p1", "p1"), new PipelineRevision("p1", 2, "labelp1-2"), "p2");
-        graph.addUpstreamMaterialNode(new SCMDependencyNode("g1", "g1", "git"), new CaseInsensitiveString("git"), new Modifications(ModificationsMother.aCheckIn("1")), "p1");
-        graph.addUpstreamMaterialNode(new SCMDependencyNode("g1", "g1", "git"), new CaseInsensitiveString("git"), new Modifications(ModificationsMother.aCheckIn("1")), "p2");
+        graph.addUpstreamMaterialNode(new SCMDependencyNode("g1", "g1", "git"), new CaseInsensitiveString("git"), "p1", new MaterialRevision(null));
+        graph.addUpstreamMaterialNode(new SCMDependencyNode("g1", "g1", "git"), new CaseInsensitiveString("git"), "p2", new MaterialRevision(null));
 
         Stages stagesForP1_1 = stages("stages-for-p1-1");
         Stages stagesForP1_2 = stages("stages-for-p1-2");
@@ -89,7 +90,7 @@ public class RunStagesPopulatorTest {
         ValueStreamMap graph = new ValueStreamMap("p2", new PipelineRevision("p2", 1, ""));
 
         graph.addUpstreamNode(new PipelineDependencyNode("p1", "p1"), new PipelineRevision("p1", 1, "1"), "p2");
-        graph.addUpstreamMaterialNode(new SCMDependencyNode("g1", "g1", "git"), new CaseInsensitiveString("git"), new Modifications(ModificationsMother.aCheckIn("1")), "p1");
+        graph.addUpstreamMaterialNode(new SCMDependencyNode("g1", "g1", "git"), new CaseInsensitiveString("git"), "p1", new MaterialRevision(null));
         Node p3_node = graph.addDownstreamNode(new PipelineDependencyNode("p3", "p3"), "p2");
 
         p3_node.addRevision(new PipelineRevision("p3", 1, "1"));

--- a/server/webapp/WEB-INF/rails.new/app/assets/stylesheets/module.scss
+++ b/server/webapp/WEB-INF/rails.new/app/assets/stylesheets/module.scss
@@ -2644,6 +2644,20 @@ li.task_property {
     opacity: 0.7;
 }
 
+.vsm-entity .warning {
+    background: image_url('g9/icons/icon_warning_16.png') no-repeat 0 0;
+    color: red;
+    padding-bottom: inherit;
+    font-weight: bold;
+    padding-left: 21px;
+    line-height: 20px;
+}
+
+.vsm-entity.conflicts {
+    border-color: red;
+    border-width: medium;
+}
+
 .vsm-entity h3 a {
     cursor: pointer;
 }
@@ -2874,6 +2888,9 @@ li.task_property {
     overflow: hidden;
     padding: 7px;
     text-overflow: ellipsis;
+    &.instance{
+        border-left: 2px solid #94399E;
+    }
 }
 
 #vsm-container > .instances li:first-child{
@@ -2883,7 +2900,7 @@ li.task_property {
     margin-top: -14px;
 }
 
-#vsm-container > .instances li:nth-child(2) {
+#vsm-container > .instances > .material_revision_header {
     border: 0 none;
     font-weight: bold;
     background-color: #eee;

--- a/server/webapp/WEB-INF/rails.new/spec/controllers/value_stream_map_controller_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/controllers/value_stream_map_controller_spec.rb
@@ -136,8 +136,8 @@ describe ValueStreamMapController do
         pipeline = "current"
         vsm = ValueStreamMap.new(pipeline, nil)
         vsm.addUpstreamNode(PipelineDependencyNode.new("p1", "p1"), revision_p1_1, pipeline)
-        vsm.addUpstreamMaterialNode(SCMDependencyNode.new("git1", "http://git.com", "Git"),CaseInsensitiveString.new("git"), modifications, "p1")
-        vsm.addUpstreamMaterialNode(SCMDependencyNode.new("git2", "http://git.com", "Git"), nil, modifications, "p1")
+        vsm.addUpstreamMaterialNode(SCMDependencyNode.new("git1", "http://git.com", "Git"),CaseInsensitiveString.new("git"), "p1", MaterialRevision.new(nil, false, modification))
+        vsm.addUpstreamMaterialNode(SCMDependencyNode.new("git2", "http://git.com", "Git"), nil, "p1", MaterialRevision.new(nil, false, modifications))
         model = vsm.presentationModel()
         @value_stream_map_service.should_receive(:getValueStreamMap).with(pipeline, 1,@user, @result).and_return(model)
 
@@ -180,14 +180,19 @@ describe ValueStreamMapController do
                 "parents": [],
                 "locator": "",
                 "depth": 1,
-                "instances": [
+                "instances": [],
+                "material_revisions": [
                   {
-                    "comment": "comment",
-                    "revision": "r1",
-                    "user": "user",
-                    "modified_time": "less than a minute ago",
-                    "locator": "/materials/value_stream_map/git1/r1"
-                  }
+                  "modifications": [
+                    {
+                     "comment": "comment",
+                     "revision": "r1",
+                     "user": "user",
+                     "modified_time": "less than a minute ago",
+                     "locator": "/materials/value_stream_map/git1/r1"
+                    }
+                  ]
+                 }
                 ],
                 "dependents": [
                   "p1"
@@ -201,7 +206,10 @@ describe ValueStreamMapController do
                 "parents": [],
                 "locator": "",
                 "depth": 2,
-                "instances": [
+                "instances":[],
+                "material_revisions": [
+                  {
+                  "modifications": [
                   {
                     "comment": "comment",
                     "revision": "r1",
@@ -209,6 +217,8 @@ describe ValueStreamMapController do
                     "modified_time": "less than a minute ago",
                     "locator": "/materials/value_stream_map/git2/r1"
                   }
+                 ]
+                }
                 ],
                 "dependents": [
                   "p1"

--- a/server/webapp/WEB-INF/rails.new/spec/javascripts/value_stream_map_renderer_spec.js
+++ b/server/webapp/WEB-INF/rails.new/spec/javascripts/value_stream_map_renderer_spec.js
@@ -56,7 +56,9 @@ describe("value_stream_map_renderer", function () {
     });
 
     it("testCurrentPipelineShouldHaveHighlightingBackground", function () {
-        var hg_material = scmMaterialNode('hg_fingerprint', '../manual-testing/ant_hg/dummy', "hg", '["p1"]', 1, '[{"revision": "revision1","comment":"comment1","user":"user1","modified_time":"modified_time1"}, {"revision": "revision2","comment":"comment2","user":"user2","modified_time":"modified_time2"}]');
+        var hg_material = scmMaterialNode('hg_fingerprint', '../manual-testing/ant_hg/dummy', "hg", '["p1"]', 1,
+          '[{"modifications": [{"revision": "revision1","comment":"comment1","user":"user1","modified_time":"modified_time1"}, ' +
+          '{"revision": "revision2","comment":"comment2","user":"user2","modified_time":"modified_time2"}]}]');
         var node_p1 = pipelineNode("p1", '["hg_fingerprint"]', '[]', 1, "", '[]');
         var vsm = eval('({"current_pipeline":"p1","levels":[{"nodes":[' + hg_material + ']},{"nodes":[' + node_p1 + ']}]})');
         new Graph_Renderer("#vsm-container").invoke(vsm);
@@ -65,7 +67,9 @@ describe("value_stream_map_renderer", function () {
     });
 
     it("testVSMForCommitShouldNotHaveHighlightingBackground", function () {
-        var hg_material = scmMaterialNode('hg_fingerprint', '../manual-testing/ant_hg/dummy', "hg", '["p1"]', 1, '[{"revision": "revision1","comment":"comment1","user":"user1","modified_time":"modified_time1"}, {"revision": "revision2","comment":"comment2","user":"user2","modified_time":"modified_time2"}]');
+        var hg_material = scmMaterialNode('hg_fingerprint', '../manual-testing/ant_hg/dummy', "hg", '["p1"]', 1,
+          '[{"modifications": [{"revision": "revision1","comment":"comment1","user":"user1","modified_time":"modified_time1"}, ' +
+          '{"revision": "revision2","comment":"comment2","user":"user2","modified_time":"modified_time2"}]}]');
         var node_p1 = pipelineNode("p1", '["hg_fingerprint"]', '[]', 1, "", '[]');
         var vsm = eval('({"current_material":"hg_fingerprint","levels":[{"nodes":[' + hg_material + ']},{"nodes":[' + node_p1 + ']}]})');
         new Graph_Renderer("#vsm-container").invoke(vsm);
@@ -283,7 +287,8 @@ describe("value_stream_map_renderer", function () {
              */
 
             var hg_material = scmMaterialNode('hg_fingerprint', '../manual-testing/ant_hg/dummy', "hg", '["p1"]', 1,
-                '[{"revision": "revision1","comment":"comment1","user":"user1","modified_time":"modified_time1"}, {"revision": "revision2","comment":"comment2","user":"user2","modified_time":"modified_time2"}]');
+                '[{modifications:[{"revision": "revision1","comment":"comment1","user":"user1","modified_time":"modified_time1"}, ' +
+                '{"revision": "revision2","comment":"comment2","user":"user2","modified_time":"modified_time2"}]}]');
             var node_p1 = pipelineNode("p1", '["hg_fingerprint"]', '[]', 1, "", '[]');
 
             var vsm = eval('({"current_pipeline":"p1","levels":[{"nodes":[' + hg_material + ']},{"nodes":[' + node_p1 + ']}]})');
@@ -334,8 +339,8 @@ describe("value_stream_map_renderer", function () {
     it("testShouldCommitDetailsForPackageMaterial", function () {
         var vsm = {"current_pipeline": "sample", "levels": [
             {"nodes": [
-                {"name": "Repository: [repo_url=file:///tmp/repo] - Package: [package_spec=go-agent]", "node_type": "PACKAGE", "depth": 1, "parents": [], "instances": [
-                    {"modified_time": "5 months ago", "user": "anonymous", "comment": "{\"COMMENT\":\"Built on server.\",\"TRACKBACK_URL\":\"google.com\",\"TYPE\":\"PACKAGE_MATERIAL\"}", "revision": "go-agent-13.1.1-16714.noarch"}
+                {"name": "Repository: [repo_url=file:///tmp/repo] - Package: [package_spec=go-agent]", "node_type": "PACKAGE", "depth": 1, "parents": [], "material_revisions": [
+                    {"modifications": [{"modified_time": "5 months ago", "user": "anonymous", "comment": "{\"COMMENT\":\"Built on server.\",\"TRACKBACK_URL\":\"google.com\",\"TYPE\":\"PACKAGE_MATERIAL\"}", "revision": "go-agent-13.1.1-16714.noarch"}]}
                 ], "locator": "", "id": "pkg_id", "dependents": ["sample"], "material_names": ["yum:go-agent"]}
             ]},
             {"nodes": [
@@ -365,8 +370,8 @@ describe("value_stream_map_renderer", function () {
     it("testShouldShowTrackbackUrlAsNotProvidedWhenItIsEmpty", function () {
         var vsm = {"current_pipeline": "sample", "levels": [
             {"nodes": [
-                {"name": "Repository: [repo_url=file:///tmp/repo] - Package: [package_spec=go-agent]", "node_type": "PACKAGE", "depth": 1, "parents": [], "instances": [
-                    {"modified_time": "5 months ago", "user": "anonymous", "comment": "{\"TYPE\":\"PACKAGE_MATERIAL\"}", "revision": "go-agent-13.1.1-16714.noarch"}
+                {"name": "Repository: [repo_url=file:///tmp/repo] - Package: [package_spec=go-agent]", "node_type": "PACKAGE", "depth": 1, "parents": [], "material_revisions": [
+                    {"modifications": [{"modified_time": "5 months ago", "user": "anonymous", "comment": "{\"TYPE\":\"PACKAGE_MATERIAL\"}", "revision": "go-agent-13.1.1-16714.noarch"}]}
                 ], "locator": "", "id": "pkg_id", "dependents": ["sample"], "material_names": ["yum:go-agent"]}
             ]},
             {"nodes": [
@@ -395,9 +400,11 @@ describe("value_stream_map_renderer", function () {
     if (window.navigator.userAgent.indexOf("MSIE")<=0) {
         it("testShouldCheckIfCommentsBoxIsShownCorrectlyIfTwoOrMoreSameSVNorTFSorP4IsConfiguredWithDifferentCredentials", function () {
             var svn_material_1 = scmMaterialNode('svn_fingerprint_1', 'http://username1:password1@svn.com', "svn", '["p1"]', 1,
-                '[{"revision": "revision1","comment":"comment1","user":"user1","modified_time":"modified_time1"}, {"revision": "revision2","comment":"comment2","user":"user2","modified_time":"modified_time2"}]');
+                '[{"modifications":[{"revision": "revision1","comment":"comment1","user":"user1","modified_time":"modified_time1"}, ' +
+                '{"revision": "revision2","comment":"comment2","user":"user2","modified_time":"modified_time2"}]}]');
             var svn_material_2 = scmMaterialNode('svn_fingerprint_2', 'http://username2:password2@svn.com', "svn", '["p1"]', 1,
-                '[{"revision": "revision1","comment":"comment1","user":"user1","modified_time":"modified_time1"}, {"revision": "revision2","comment":"comment2","user":"user2","modified_time":"modified_time2"}]');
+                '[{"modifications":[{"revision": "revision1","comment":"comment1","user":"user1","modified_time":"modified_time1"}, ' +
+                '{"revision": "revision2","comment":"comment2","user":"user2","modified_time":"modified_time2"}]}]');
             var node_p1 = pipelineNode("p1", '["svn_fingerprint_1", "svn_fingerprint_2"]', '[]', 1, "", '[]');
 
             var vsm = eval('({"current_pipeline":"p1","levels":[{"nodes":[' + svn_material_1 + ',' + svn_material_2 + ']},{"nodes":[' + node_p1 + ']}]})');
@@ -420,7 +427,8 @@ describe("value_stream_map_renderer", function () {
         var current_pipeline_instance_details = '{"stages": [{"locator": "/go/pipelines/current/1/defaultStage/1","status": "Passed","name": "defaultStage"},' +
             '{"locator": "","status": "Unknown","name": "oneMore"}],"locator": "/go/pipelines/value_stream_map/current/1","counter": 1,"label": "1" }';
 
-        var hg_material = scmMaterialNode('hg_fingerprint', '../manual-testing/ant_hg/dummy', "hg", '["current"]', 1, '[{"revision": "revision1"}, {"revision": "revision2"}]');
+        var hg_material = scmMaterialNode('hg_fingerprint', '../manual-testing/ant_hg/dummy', "hg", '["current"]', 1,
+          '[{"modifications":[{"revision": "revision1"}, {"revision": "revision2"}]}]');
         var current = pipelineNode("current", '["hg_fingerprint"]', '[]', 1, "/go/tab/pipeline/history/current", '[' + current_pipeline_instance_details + ']');
 
         var vsm = eval('({"current_pipeline":"p1","levels":[{"nodes":[' + hg_material + ']},{"nodes":[' + current + ']}]})');
@@ -447,7 +455,8 @@ describe("value_stream_map_renderer", function () {
             ' "locator": "/go/pipelines/value_stream_map/downstream/1","counter": 1,"label": "1" },' + '{"stages": [{"locator": "/go/pipelines/downstream/2/defaultStage/1","status": "Passed","name": "defaultStage"}],' +
             ' "locator": "/go/pipelines/downstream/current/2","counter": 2,"label": "2" }';
 
-        var hg_material = scmMaterialNode('hg_fingerprint', '../manual-testing/ant_hg/dummy', "hg", '["current"]', 1, '[{"revision": "revision1"}, {"revision": "revision2"}]');
+        var hg_material = scmMaterialNode('hg_fingerprint', '../manual-testing/ant_hg/dummy', "hg", '["current"]', 1,
+          '[{"modifications":[{"revision": "revision1"}, {"revision": "revision2"}]}]');
         var current = pipelineNode("current", '["hg_fingerprint"]', '["downstream"]', 1, "/go/tab/pipeline/history/current", '[' + current_pipeline_instance_details + ']');
         var downstream = pipelineNode("downstream", '["current"]', '[]', 2, "/go/tab/pipeline/history/downstream", '[' + downstream_pipeline_instance_details + ']');
 
@@ -485,9 +494,9 @@ describe("value_stream_map_renderer", function () {
             ',"id":"' + nodeId + '", "depth":' + depth + ', "locator":' + '""' + '}';
     }
 
-    function scmMaterialNode(nodeId, nodeName, type, dependents, depth, instances) {
+    function scmMaterialNode(nodeId, nodeName, type, dependents, depth, material_revisions) {
         return '{"node_type":"' + type + '","name":"' + nodeName + '","parents":' + '[]' + ',"dependents":' + dependents +
-            ',"id":"' + nodeId + '", "depth":' + depth + ', "locator":' + '""' + ', "instances":' + instances + '}';
+            ',"id":"' + nodeId + '", "depth":' + depth + ', "locator":' + '""' + ', "material_revisions":' + material_revisions + '}';
     }
 
     function pipelineNode(nodeId, parents, dependents, depth, locator, instances) {

--- a/server/webapp/localize.xml
+++ b/server/webapp/localize.xml
@@ -735,6 +735,7 @@
     <entry key="VSM_CYCLIC_DEPENDENCY">Value Stream Map of Pipeline ''{0}'' with counter ''{1}'' can not be rendered. Changes to the configuration have introduced complex dependencies for this instance which are not supported currently.</entry>
     <entry key="VSM_INTERNAL_SERVER_ERROR">Value Stream Map of pipeline ''{0}'' with counter ''{1}'' can not be rendered. Please check the server log for details.</entry>
     <entry key="VSM_INTERNAL_SERVER_ERROR_FOR_MATERIAL">Value Stream Map of material with fingerprint ''{0}'' with revision ''{1}'' can not be rendered. Please check the server log for details.</entry>
+    <entry key="VSM_WARNING">Built from incompatible revisions.</entry>
     <entry key="USER_DELETE_SUCCESSFUL">User ''{0}'' was deleted successfully.</entry>
     <entry key="USER_NOT_FOUND">User ''{0}'' not found.</entry>
     <entry key="USER_NOT_DISABLED">User ''{0}'' is not disabled.</entry>


### PR DESCRIPTION
* Partial fix for #1924
* VSM for a pipeline shows warning message if built with incompatible revisions
* SCM Nodes list MaterialRevisions instead modifications.