### PR TITLE
Parse `variables` and `secure_variables` from request so it would be possible to schedule pipeline with custom variables.

### DIFF
--- a/server/webapp/WEB-INF/rails.new/app/controllers/api/pipelines_controller.rb
+++ b/server/webapp/WEB-INF/rails.new/app/controllers/api/pipelines_controller.rb
@@ -14,6 +14,8 @@
 # limitations under the License.
 ##########################GO-LICENSE-END##################################
 
+require 'json'
+
 class Api::PipelinesController < Api::ApiController
   include ComparisonHelper
   def url(params={})#FIXME: we should not have such common method names(we work with all helpers mixed in each response, which means we need to be have more specific method names to avoid conflicts)
@@ -114,8 +116,10 @@ class Api::PipelinesController < Api::ApiController
 
   def schedule
     pipeline_name = params[:pipeline_name]
+    variables = if params.key?(:variables) then JSON.parse(params[:variables]) else {} end
+    secure_variables = if params.key?(:secure_variables) then JSON.parse(params[:secure_variables]) else {} end
     revisions = merge_revisions(pipeline_name, params["materials"]||{}, params["original_fingerprint"]||{}, params['material_fingerprint']||{})
-    pipeline_scheduler.manualProduceBuildCauseAndSave(pipeline_name, @user, ScheduleOptions.new(revisions, params[:variables]||{}, params[:secure_variables]||{}), result = HttpOperationResult.new)
+    pipeline_scheduler.manualProduceBuildCauseAndSave(pipeline_name, @user, ScheduleOptions.new(revisions, variables secure_variables), result = HttpOperationResult.new)
     render_operation_result(result)
   end
 


### PR DESCRIPTION
Parameters in request are plain text, so they must be parsed to hash in
order instance of `server/src/com/thoughtworks/go/server/scheduling/ScheduleOptions.java` would accept them. I took a look at tests at `server/webapp/WEB-INF/rails.new/spec/controllers/api/pipelines_controller_spec.rb` -- they work because you pass Hashes to tests.