### PR TITLE
#2145 - BuildCause in not kept in memory as a part of workAssignments, moreover it is not serialized over to the agents

### DIFF
--- a/common/src/com/thoughtworks/go/domain/materials/Modification.java
+++ b/common/src/com/thoughtworks/go/domain/materials/Modification.java
@@ -93,17 +93,23 @@ public class Modification extends PersistentObject implements Comparable, Serial
     }
 
     public Modification(Modification modification) {
-        this(modification.userName, modification.comment, modification.emailAddress, modification.modifiedTime, modification.getRevision());
-        this.id = modification.id;
-        this.files = modification.files;
-        this.pipelineLabel = modification.pipelineLabel;
-        this.pipelineId = modification.pipelineId;
-        this.materialInstance = modification.materialInstance;
+        this(modification, true);
     }
 
     public Modification(String user, String comment, String email, Date dateTime, String revision, String additionalData) {
         this(user, comment, email, dateTime, revision);
         setAdditionalData(additionalData);
+    }
+
+    public Modification(Modification modification, boolean shouldCopyModifiedFiles) {
+        this(modification.userName, modification.comment, modification.emailAddress, modification.modifiedTime, modification.getRevision());
+        this.id = modification.id;
+        if(shouldCopyModifiedFiles){
+            this.files = modification.files;
+        }
+        this.pipelineLabel = modification.pipelineLabel;
+        this.pipelineId = modification.pipelineId;
+        this.materialInstance = modification.materialInstance;
     }
 
     public final ModifiedFile createModifiedFile(String filename, String folder, ModifiedAction modifiedAction) {
@@ -161,7 +167,7 @@ public class Modification extends PersistentObject implements Comparable, Serial
      * @deprecated used only in tests
      */
     public void setModifiedFiles(List<ModifiedFile> files) {
-        this.files = files == null ? new LinkedHashSet<ModifiedFile>() : new LinkedHashSet<ModifiedFile>(files);
+        this.files = files == null ? new LinkedHashSet<ModifiedFile>() : new LinkedHashSet<>(files);
     }
 
     /**
@@ -337,9 +343,9 @@ public class Modification extends PersistentObject implements Comparable, Serial
         materialInstance = (MaterialInstance) in.readObject();
         Set files = (Set) in.readObject();
         if (files == null) {
-            this.files = new LinkedHashSet<ModifiedFile>();
+            this.files = new LinkedHashSet<>();
         } else {
-            this.files = new LinkedHashSet<ModifiedFile>(files);
+            this.files = new LinkedHashSet<>(files);
         }
     }
 

--- a/common/src/com/thoughtworks/go/remote/work/BuildAssignment.java
+++ b/common/src/com/thoughtworks/go/remote/work/BuildAssignment.java
@@ -1,47 +1,63 @@
-/*************************GO-LICENSE-START*********************************
- * Copyright 2014 ThoughtWorks, Inc.
+/*
+ * Copyright 2016 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *************************GO-LICENSE-END***********************************/
+ */
 
 package com.thoughtworks.go.remote.work;
 
 import java.io.File;
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.List;
 
+import com.thoughtworks.go.domain.MaterialRevision;
 import com.thoughtworks.go.domain.builder.Builder;
 import com.thoughtworks.go.domain.JobPlan;
 import com.thoughtworks.go.domain.MaterialRevisions;
 import com.thoughtworks.go.domain.buildcause.BuildCause;
+import com.thoughtworks.go.domain.materials.Modification;
 import com.thoughtworks.go.util.command.EnvironmentVariableContext;
 
 public class BuildAssignment implements Serializable {
     private final File buildWorkingDirectory;
     private final List<Builder> builders;
     private final JobPlan plan;
-    private final BuildCause buildCause;
     private final EnvironmentVariableContext initialContext = new EnvironmentVariableContext();
+    private final MaterialRevisions materialRevisions = new MaterialRevisions();
+    private final String approver;
 
     private BuildAssignment(BuildCause buildCause, File buildWorkingDirectory, List<Builder> builder, JobPlan plan) {
-        this.buildCause = buildCause;
         this.buildWorkingDirectory = buildWorkingDirectory;
         this.builders = builder;
         this.plan = plan;
+        for (MaterialRevision materialRevision : buildCause.getMaterialRevisions()) {
+            ArrayList<Modification> modifications = new ArrayList<>();
+            for (Modification modification : materialRevision.getModifications()) {
+                modifications.add(new Modification(modification, false));
+            }
+            materialRevisions.addRevision(new MaterialRevision(materialRevision.getMaterial(), materialRevision.isChanged(), modifications));
+        }
+        approver = buildCause.getApprover();
     }
 
+    @Override
     public String toString() {
-        return "plan: [" + plan + "] buildCause: ["+ buildCause + "]";
+        return "BuildAssignment{" +
+                "plan=" + plan +
+                ", materialRevisions=" + materialRevisions +
+                ", approver='" + approver + '\'' +
+                '}';
     }
 
     public JobPlan getPlan() {
@@ -53,7 +69,7 @@ public class BuildAssignment implements Serializable {
     }
 
     public MaterialRevisions materialRevisions() {
-        return buildCause.getMaterialRevisions();
+        return materialRevisions;
     }
 
     public boolean equals(Object o) {
@@ -66,7 +82,10 @@ public class BuildAssignment implements Serializable {
 
         BuildAssignment that = (BuildAssignment) o;
 
-        if (buildCause != null ? !buildCause.equals(that.buildCause) : that.buildCause != null) {
+        if (materialRevisions != null ? !materialRevisions.equals(that.materialRevisions) : that.materialRevisions != null) {
+            return false;
+        }
+        if (approver != null ? !approver.equals(that.approver) : that.approver != null) {
             return false;
         }
         if (plan != null ? !plan.equals(that.plan) : that.plan != null) {
@@ -84,7 +103,8 @@ public class BuildAssignment implements Serializable {
         int result;
         result = (plan != null ? plan.hashCode() : 0);
         result = 31 * result + (buildWorkingDirectory != null ? buildWorkingDirectory.hashCode() : 0);
-        result = 31 * result + (buildCause != null ? buildCause.hashCode() : 0);
+        result = 31 * result + (materialRevisions != null ? materialRevisions.hashCode() : 0);
+        result = 31 * result + (approver != null ? approver.hashCode() : 0);
         return result;
     }
 
@@ -105,6 +125,6 @@ public class BuildAssignment implements Serializable {
     }
 
     public String getBuildApprover(){
-        return buildCause.getApprover();
+        return approver;
     }
 }


### PR DESCRIPTION
BuildCause can be a huge object when there are too many modifications involved or even when a small number of modifications have a huge number of modifiedFiles in them. We seem to be loading up this object in memory for each job. When a given pipeline instance has a huge number of modifications/modifiedFiles, and the scheduled stage has too many jobs, this causes an out of memory of the agent. As the size of these modifiedFiles increase, it also tends to bring down the server. We do not need modifiedFiles to be passed along to the agents. We certainly don't need all of buildcause on the agent or in server memory as part of work-assignments, so removing that off.