### PR TITLE
Preventing duplicate modifications from getting inserted to database

### DIFF
--- a/common/test/unit/com/thoughtworks/go/helper/ModificationsMother.java
+++ b/common/test/unit/com/thoughtworks/go/helper/ModificationsMother.java
@@ -16,11 +16,7 @@
 
 package com.thoughtworks.go.helper;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
+import java.util.*;
 
 import com.thoughtworks.go.config.CaseInsensitiveString;
 import com.thoughtworks.go.config.PipelineConfig;
@@ -314,7 +310,7 @@ public class ModificationsMother {
         MaterialRevisions materialRevisions = new MaterialRevisions();
         for (Material material : MaterialsMother.createMaterialsFromMaterialConfigs(config.materialConfigs())) {
             ArrayList<Modification> list = new ArrayList<Modification>();
-            list.add(new Modification("no-user", "comment", "dummy-email", new Date(), "Dummy Modification"));
+            list.add(new Modification("no-user", "comment", "dummy-email", new Date(), "Dummy Modification"+ UUID.randomUUID().toString()));
             materialRevisions.addRevision(material, list);
         }
         return BuildCause.createWithModifications(materialRevisions, "");

--- a/server/test/common/com/thoughtworks/go/server/dao/DatabaseAccessHelper.java
+++ b/server/test/common/com/thoughtworks/go/server/dao/DatabaseAccessHelper.java
@@ -1,18 +1,18 @@
-/*************************GO-LICENSE-START*********************************
- * Copyright 2014 ThoughtWorks, Inc.
+/*
+ * Copyright 2016 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *************************GO-LICENSE-END***********************************/
+ */
 
 package com.thoughtworks.go.server.dao;
 
@@ -254,12 +254,12 @@ public class DatabaseAccessHelper extends HibernateDaoSupport {
 
     public Pipeline savePipelineWithStagesAndMaterials(Pipeline pipeline) {
         saveRevs(pipeline.getBuildCause().getMaterialRevisions());
-        return pipelineDao.saveWithStages(pipeline);
+        return save(pipeline);
     }
 
     public Pipeline savePipelineWithMaterials(Pipeline pipeline) {
         saveRevs(pipeline.getBuildCause().getMaterialRevisions());
-        return pipelineDao.saveWithStages(pipeline);
+        return save(pipeline);
     }
 
     public Pipeline save(Pipeline pipeline) {
@@ -508,12 +508,36 @@ public class DatabaseAccessHelper extends HibernateDaoSupport {
     }
 
     public void saveRevs(final MaterialRevisions materialRevisions) {
+        final MaterialRevisions unsavedRevisions = new MaterialRevisions();
+        for (MaterialRevision materialRevision : materialRevisions) {
+            unsavedRevisions.addRevision(filterUnsaved(materialRevision));
+        }
+        if (unsavedRevisions.isEmpty()) {
+            return;
+        }
         transactionTemplate.execute(new TransactionCallbackWithoutResult() {
             @Override
             protected void doInTransactionWithoutResult(TransactionStatus status) {
-                materialRepository.save(materialRevisions);
+                materialRepository.save(unsavedRevisions);
             }
         });
+
+//        transactionTemplate.execute(new TransactionCallbackWithoutResult() {
+//            @Override
+//            protected void doInTransactionWithoutResult(TransactionStatus status) {
+//                materialRepository.save(materialRevisions);
+//            }
+//        });
+    }
+
+    private MaterialRevision filterUnsaved(MaterialRevision materialRevision) {
+        ArrayList<Modification> unsavedModifications = new ArrayList<>();
+        for (Modification modification : materialRevision.getModifications()) {
+            if (!modification.hasId()) {
+                unsavedModifications.add(modification);
+            }
+        }
+        return new MaterialRevision(materialRevision.getMaterial(), unsavedModifications);
     }
 
     public void execute(String sql) throws SQLException {
@@ -596,7 +620,10 @@ public class DatabaseAccessHelper extends HibernateDaoSupport {
     }
 
     public MaterialRevision addRevisionsWithModifications(Material material, Modification... modifications) {
-        final MaterialRevision revision = new MaterialRevision(material, modifications);
+        final MaterialRevision revision = filterUnsaved(new MaterialRevision(material, modifications));
+        if (revision.getModifications().isEmpty()){
+            return revision;
+        }
         transactionTemplate.execute(new TransactionCallbackWithoutResult() {
             @Override
             protected void doInTransactionWithoutResult(TransactionStatus status) {

--- a/server/test/integration/com/thoughtworks/go/server/persistence/MaterialRepositoryIntegrationTest.java
+++ b/server/test/integration/com/thoughtworks/go/server/persistence/MaterialRepositoryIntegrationTest.java
@@ -1,18 +1,18 @@
-/*************************GO-LICENSE-START*********************************
- * Copyright 2014 ThoughtWorks, Inc.
+/*
+ * Copyright 2016 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *************************GO-LICENSE-END***********************************/
+ */
 
 package com.thoughtworks.go.server.persistence;
 
@@ -58,16 +58,16 @@ import com.thoughtworks.go.server.service.ScheduleTestUtil;
 import com.thoughtworks.go.server.transaction.TransactionSynchronizationManager;
 import com.thoughtworks.go.server.transaction.TransactionTemplate;
 import com.thoughtworks.go.server.util.Pagination;
-import com.thoughtworks.go.util.GoConfigFileHelper;
-import com.thoughtworks.go.util.TestUtils;
-import com.thoughtworks.go.util.TimeProvider;
+import com.thoughtworks.go.util.*;
 import com.thoughtworks.go.util.json.JsonHelper;
 import com.thoughtworks.go.utils.SerializationTester;
 import org.hibernate.SessionFactory;
 import org.hibernate.criterion.DetachedCriteria;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -79,9 +79,13 @@ import org.springframework.transaction.TransactionStatus;
 import org.springframework.transaction.support.TransactionCallback;
 import org.springframework.transaction.support.TransactionCallbackWithoutResult;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.UUID;
 
 import static com.thoughtworks.go.util.GoConstants.DEFAULT_APPROVED_BY;
+import static java.util.Arrays.asList;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNot.not;
 import static org.hamcrest.core.IsNull.notNullValue;
@@ -91,6 +95,7 @@ import static org.junit.Assert.*;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.*;
+
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(locations = {
         "classpath:WEB-INF/applicationContext-global.xml",
@@ -130,7 +135,8 @@ public class MaterialRepositoryIntegrationTest {
         dbHelper.onTearDown();
     }
 
-    @Test public void shouldBeAbleToPersistAMaterial() throws Exception {
+    @Test
+    public void shouldBeAbleToPersistAMaterial() throws Exception {
         MaterialInstance original = new SvnMaterialInstance("url", "username", UUID.randomUUID().toString(), true);
         repo.saveOrUpdate(original);
 
@@ -166,7 +172,8 @@ public class MaterialRepositoryIntegrationTest {
         assertThat(repo.find(materialInstance.getId()), is(changedInstance));
     }
 
-    @Test public void findModificationsFor_shouldCacheModifications() {
+    @Test
+    public void findModificationsFor_shouldCacheModifications() {
         HibernateTemplate mockTemplate = mock(HibernateTemplate.class);
         repo.setHibernateTemplate(mockTemplate);
 
@@ -174,7 +181,7 @@ public class MaterialRepositoryIntegrationTest {
         when(mockTemplate.find("FROM Modification WHERE materialId = ? AND id BETWEEN ? AND ? ORDER BY id DESC", new Object[]{10L, -1L, -1L})).thenReturn(modifications);
         MaterialInstance materialInstance = material().createMaterialInstance();
         materialInstance.setId(10);
-        when(mockTemplate.findByCriteria(any(DetachedCriteria.class))).thenReturn(Arrays.asList(materialInstance));
+        when(mockTemplate.findByCriteria(any(DetachedCriteria.class))).thenReturn(asList(materialInstance));
 
         PipelineMaterialRevision pmr = pipelineMaterialRevision();
         List<Modification> actual;
@@ -186,7 +193,8 @@ public class MaterialRepositoryIntegrationTest {
         verify(mockTemplate, times(1)).find("FROM Modification WHERE materialId = ? AND id BETWEEN ? AND ? ORDER BY id DESC", new Object[]{10L, -1L, -1L});
     }
 
-    @Test public void findPipelineMaterialRevisions_shouldCacheResults() {
+    @Test
+    public void findPipelineMaterialRevisions_shouldCacheResults() {
         HibernateTemplate mockTemplate = mock(HibernateTemplate.class);
         repo.setHibernateTemplate(mockTemplate);
 
@@ -196,7 +204,8 @@ public class MaterialRepositoryIntegrationTest {
         verify(mockTemplate, times(1)).find("FROM PipelineMaterialRevision WHERE pipelineId = ? ORDER BY id", 2L);
     }
 
-    @Test public void findModificationsSince_shouldNotCacheIfTheResultsetLarge() {
+    @Test
+    public void findModificationsSince_shouldNotCacheIfTheResultsetLarge() {
         SvnMaterial material = MaterialsMother.svnMaterial();
         MaterialRevision first = saveOneScmModification(material, "user1", "file1");
         MaterialRevision second = saveOneScmModification(material, "user2", "file2");
@@ -213,19 +222,21 @@ public class MaterialRepositoryIntegrationTest {
         assertThat(repo.cachedModifications(repo.findMaterialInstance(material)), is(nullValue()));
     }
 
-    @Test public void findModificationsSince_shouldHandleConcurrentModificationToCache() throws InterruptedException {
+    @Test
+    public void findModificationsSince_shouldHandleConcurrentModificationToCache() throws InterruptedException {
         final SvnMaterial svn = MaterialsMother.svnMaterial();
         final MaterialRevision first = saveOneScmModification(svn, "user1", "file1");
         final MaterialRevision second = saveOneScmModification(svn, "user2", "file2");
         final MaterialRevision third = saveOneScmModification(svn, "user2", "file3");
 
         repo = new MaterialRepository(sessionFactory, goCache = new GoCache(goCache) {
-            @Override public Object get(String key) {
+            @Override
+            public Object get(String key) {
                 Object value = super.get(key);
                 TestUtils.sleepQuietly(200); // sleep so we can have multiple threads enter the critical section
                 return value;
             }
-        }, 200,transactionSynchronizationManager, materialConfigConverter, materialExpansionService, databaseStrategy);
+        }, 200, transactionSynchronizationManager, materialConfigConverter, materialExpansionService, databaseStrategy);
 
         Thread thread1 = new Thread(new Runnable() {
             public void run() {
@@ -248,7 +259,8 @@ public class MaterialRepositoryIntegrationTest {
         assertThat(repo.cachedModifications(repo.findMaterialInstance(svn)).size(), is(3));
     }
 
-    @Test public void findModificationsSince_shouldCacheResults() {
+    @Test
+    public void findModificationsSince_shouldCacheResults() {
         SvnMaterial material = MaterialsMother.svnMaterial();
         MaterialRevision zero = saveOneScmModification(material, "user1", "file1");
         MaterialRevision first = saveOneScmModification(material, "user1", "file1");
@@ -266,7 +278,8 @@ public class MaterialRepositoryIntegrationTest {
         verifyNoMoreInteractions(mockTemplate);
     }
 
-    @Test public void findLatestModifications_shouldCacheResults() {
+    @Test
+    public void findLatestModifications_shouldCacheResults() {
         SvnMaterial material = MaterialsMother.svnMaterial();
         MaterialInstance materialInstance = material.createMaterialInstance();
         repo.saveOrUpdate(materialInstance);
@@ -287,7 +300,8 @@ public class MaterialRepositoryIntegrationTest {
 
     }
 
-    @Test public void findLatestModifications_shouldQueryIfNotEnoughElementsInCache() {
+    @Test
+    public void findLatestModifications_shouldQueryIfNotEnoughElementsInCache() {
         SvnMaterial material = MaterialsMother.svnMaterial();
         MaterialRevision mod = saveOneScmModification(material, "user2", "file3");
         goCache.remove(repo.latestMaterialModificationsKey(repo.findMaterialInstance(material)));
@@ -300,7 +314,8 @@ public class MaterialRepositoryIntegrationTest {
         verify(mockTemplate).execute(any(HibernateCallback.class));
     }
 
-    @Test public void findLatestModifications_shouldQueryIfNotEnoughElementsInCache_Integration() {
+    @Test
+    public void findLatestModifications_shouldQueryIfNotEnoughElementsInCache_Integration() {
         SvnMaterial material = MaterialsMother.svnMaterial();
         MaterialRevision mod = saveOneScmModification(material, "user2", "file3");
         goCache.clear();
@@ -308,7 +323,8 @@ public class MaterialRepositoryIntegrationTest {
         assertEquals(mod.getLatestModification(), modification);
     }
 
-    @Test public void shouldFindMaterialInstanceIfExists() throws Exception {
+    @Test
+    public void shouldFindMaterialInstanceIfExists() throws Exception {
         Material svn = MaterialsMother.svnMaterial();
         MaterialInstance material1 = repo.findOrCreateFrom(svn);
         MaterialInstance material2 = repo.findOrCreateFrom(svn);
@@ -316,7 +332,8 @@ public class MaterialRepositoryIntegrationTest {
         assertThat(material1.getId(), is(material2.getId()));
     }
 
-    @Test public void materialShouldNotBeSameIfOneFieldIsNull() throws Exception {
+    @Test
+    public void materialShouldNotBeSameIfOneFieldIsNull() throws Exception {
         Material svn1 = MaterialsMother.svnMaterial("url", null, "username", "password", false, null);
         MaterialInstance material1 = repo.findOrCreateFrom(svn1);
 
@@ -332,7 +349,8 @@ public class MaterialRepositoryIntegrationTest {
 
         HibernateTemplate mockTemplate = mock(HibernateTemplate.class);
         repo = new MaterialRepository(repo.getSessionFactory(), goCache, 200, transactionSynchronizationManager, materialConfigConverter, materialExpansionService, databaseStrategy) {
-            @Override public MaterialInstance findMaterialInstance(Material material) {
+            @Override
+            public MaterialInstance findMaterialInstance(Material material) {
                 MaterialInstance result = super.findMaterialInstance(material);
                 TestUtils.sleepQuietly(20); // force multiple threads to try to create the material
                 return result;
@@ -363,7 +381,8 @@ public class MaterialRepositoryIntegrationTest {
         verify(mockTemplate, times(1)).saveOrUpdate(Mockito.<MaterialInstance>any());
     }
 
-    @Test public void findOrCreateFrom_shouldCacheMaterialInstanceOnCreate() throws Exception {
+    @Test
+    public void findOrCreateFrom_shouldCacheMaterialInstanceOnCreate() throws Exception {
         Material svn = MaterialsMother.svnMaterial("url", null, "username", "password", false, null);
 
         MaterialInstance instance = repo.findOrCreateFrom(svn);
@@ -378,7 +397,8 @@ public class MaterialRepositoryIntegrationTest {
         verifyNoMoreInteractions(mockTemplate);
     }
 
-    @Test public void findMaterialInstance_shouldCacheMaterialInstance() throws Exception {
+    @Test
+    public void findMaterialInstance_shouldCacheMaterialInstance() throws Exception {
         Material svn1 = MaterialsMother.svnMaterial("url", null, "username", "password", false, null);
         repo.saveOrUpdate(svn1.createMaterialInstance());
 
@@ -412,7 +432,8 @@ public class MaterialRepositoryIntegrationTest {
         assertThat((P4Material) restored, is(p4Material));
     }
 
-    @Test public void shouldPersistModificationsWithMaterials() throws Exception {
+    @Test
+    public void shouldPersistModificationsWithMaterials() throws Exception {
         MaterialInstance original = new SvnMaterialInstance("url", "username", UUID.randomUUID().toString(), false);
         repo.saveOrUpdate(original);
 
@@ -420,7 +441,8 @@ public class MaterialRepositoryIntegrationTest {
         assertThat(loaded, is(original));
     }
 
-    @Test public void shouldPersistModifiedFiles() throws Exception {
+    @Test
+    public void shouldPersistModifiedFiles() throws Exception {
         MaterialInstance original = new SvnMaterialInstance("url", "username", UUID.randomUUID().toString(), true);
         Modification modification = new Modification("user", "comment", "email", new Date(), ModificationsMother.nextRevision());
         modification.createModifiedFile("file1", "folder1", ModifiedAction.added);
@@ -431,7 +453,8 @@ public class MaterialRepositoryIntegrationTest {
         assertThat(loaded, is(original));
     }
 
-    @Test public void shouldBeAbleToFindModificationsSinceAPreviousChange() throws Exception {
+    @Test
+    public void shouldBeAbleToFindModificationsSinceAPreviousChange() throws Exception {
         SvnMaterial original = MaterialsMother.svnMaterial();
 
         MaterialRevision originalRevision = saveOneScmModification(original, "user1", "file1");
@@ -442,7 +465,8 @@ public class MaterialRepositoryIntegrationTest {
         assertEquals(later.getLatestModification(), modifications.get(0));
     }
 
-    @Test public void shouldFindNoModificationsSinceLatestChange() throws Exception {
+    @Test
+    public void shouldFindNoModificationsSinceLatestChange() throws Exception {
         SvnMaterial original = MaterialsMother.svnMaterial();
 
         MaterialRevision originalRevision = saveOneScmModification(original, "user", "file1");
@@ -609,7 +633,7 @@ public class MaterialRepositoryIntegrationTest {
         GoCache spyGoCache = spy(goCache);
         when(spyGoCache.get(any(String.class))).thenCallRealMethod();
         Mockito.doCallRealMethod().when(spyGoCache).put(any(String.class), any(Object.class));
-        repo = new MaterialRepository(sessionFactory, spyGoCache, 2,transactionSynchronizationManager, materialConfigConverter, materialExpansionService, databaseStrategy);
+        repo = new MaterialRepository(sessionFactory, spyGoCache, 2, transactionSynchronizationManager, materialConfigConverter, materialExpansionService, databaseStrategy);
 
         pipelineSqlMapDao.save(pipeline);
 
@@ -653,7 +677,8 @@ public class MaterialRepositoryIntegrationTest {
         assertCanLoadAndSaveMaterialRevisionsFor(dependencyMaterialConfig);
     }
 
-    @Test public void shouldReturnModificationForASpecificRevision() throws Exception {
+    @Test
+    public void shouldReturnModificationForASpecificRevision() throws Exception {
         DependencyMaterial dependencyMaterial = new DependencyMaterial(new CaseInsensitiveString("blahPipeline"), new CaseInsensitiveString("blahStage"));
         MaterialRevision originalRevision = saveOneDependencyModification(dependencyMaterial, "blahPipeline/3/blahStage/1");
 
@@ -663,7 +688,8 @@ public class MaterialRepositoryIntegrationTest {
         assertEquals(originalRevision.getModification(0).getModifiedTime(), modification.getModifiedTime());
     }
 
-    @Test public void shouldPickupTheRightFromAndToForMaterialRevisions() throws Exception {
+    @Test
+    public void shouldPickupTheRightFromAndToForMaterialRevisions() throws Exception {
         HgMaterial material = new HgMaterial("sdg", null);
         MaterialRevision firstRevision = new MaterialRevision(material, new Modifications(modification("6")));
         saveMaterialRev(firstRevision);
@@ -678,7 +704,8 @@ public class MaterialRepositoryIntegrationTest {
         assertThat(modificationsSince.get(modificationsSince.size() - 1).getRevision(), is("13"));
     }
 
-    @Test public void shouldUseToAndFromAsRangeForSCMMaterialRevisionWhileSavingAndUpdating() throws Exception {
+    @Test
+    public void shouldUseToAndFromAsRangeForSCMMaterialRevisionWhileSavingAndUpdating() throws Exception {
         HgMaterial material = new HgMaterial("sdg", null);
         final MaterialRevision firstRevision = new MaterialRevision(material, new Modifications(modification("10"), modification("9"), modification("8")));
         saveMaterialRev(firstRevision);
@@ -711,7 +738,8 @@ public class MaterialRepositoryIntegrationTest {
         assertThat(revisionsFor13.getModifications(material).get(0).getRevision(), is("12"));
     }
 
-    @Test public void shouldFixToAsFromForDependencyMaterialRevisionWhileSavingAndUpdating() throws Exception {
+    @Test
+    public void shouldFixToAsFromForDependencyMaterialRevisionWhileSavingAndUpdating() throws Exception {
         Material material = new DependencyMaterial(new CaseInsensitiveString("pipeline_name"), new CaseInsensitiveString("stage_name"));
         MaterialRevision firstRevision = new MaterialRevision(material, new Modifications(modification("pipeline_name/10/stage_name/1"), modification("pipeline_name/9/stage_name/2"), modification("pipeline_name/8/stage_name/2")));
         saveMaterialRev(firstRevision);
@@ -742,7 +770,8 @@ public class MaterialRepositoryIntegrationTest {
         assertThat(revisionsFor13.getModifications(material).get(0).getRevision(), is("pipeline_name/12/stage_name/1"));
     }
 
-    @Test public void shouldPersistActualFromRevisionSameAsFromForSCMMaterial() throws Exception {
+    @Test
+    public void shouldPersistActualFromRevisionSameAsFromForSCMMaterial() throws Exception {
         HgMaterial material = new HgMaterial("sdg", null);
         MaterialRevision firstRevision = new MaterialRevision(material, new Modifications(modification("10"), modification("9"), modification("8")));
         saveMaterialRev(firstRevision);
@@ -752,7 +781,8 @@ public class MaterialRepositoryIntegrationTest {
         assertThat(pmrs.get(0).getActualFromRevisionId(), is(pmrs.get(0).getFromModification().getId()));
     }
 
-    @Test public void shouldPersistActualFromRevisionUsingTheRealFromForDependencyMaterial() throws Exception {
+    @Test
+    public void shouldPersistActualFromRevisionUsingTheRealFromForDependencyMaterial() throws Exception {
         Material material = new DependencyMaterial(new CaseInsensitiveString("pipeline_name"), new CaseInsensitiveString("stage_name"));
         Modification actualFrom = modification("pipeline_name/8/stage_name/2");
         Modification from = modification("pipeline_name/10/stage_name/1");
@@ -766,7 +796,8 @@ public class MaterialRepositoryIntegrationTest {
         assertEquals(from, pmrs.get(0).getFromModification());
     }
 
-    @Test public void shouldUseTheFromIdAsActualFromIdWhenThePipelineIsBeingBuiltForTheFirstTime() throws Exception {
+    @Test
+    public void shouldUseTheFromIdAsActualFromIdWhenThePipelineIsBeingBuiltForTheFirstTime() throws Exception {
         Material material = new DependencyMaterial(new CaseInsensitiveString("pipeline_name"), new CaseInsensitiveString("stage_name"));
         Modification actualFrom = modification("pipeline_name/8/stage_name/2");
         MaterialRevision firstRevision = new MaterialRevision(material, new Modifications(modification("pipeline_name/9/stage_name/2"), actualFrom));
@@ -789,7 +820,8 @@ public class MaterialRepositoryIntegrationTest {
         assertEquals(from, pmrs.get(0).getFromModification());
     }
 
-    @Test public void shouldPersistActualFromRevisionForSameRevisionOfDependencyMaterialModifications() throws Exception {
+    @Test
+    public void shouldPersistActualFromRevisionForSameRevisionOfDependencyMaterialModifications() throws Exception {
         Material material = new DependencyMaterial(new CaseInsensitiveString("pipeline_name"), new CaseInsensitiveString("stage_name"));
         Modification actualFrom = modification("pipeline_name/8/stage_name/2");
         MaterialRevision firstRevision = new MaterialRevision(material, new Modifications(actualFrom));
@@ -824,25 +856,6 @@ public class MaterialRepositoryIntegrationTest {
 
         List<PipelineMaterialRevision> pipelineMaterialRevisions = repo.findPipelineMaterialRevisions(secondPipeline.getId());
         assertThat(pipelineMaterialRevisions.get(0).getMaterialId(), is(material.getId()));
-    }
-
-    @Test
-    public void shouldAllowMoreThanOnceOccuranceOfARevisionForTheSameMaterial() {
-        final GitMaterial gitFoo = new GitMaterial("foo");
-        final Modification modOne = new Modification("user", "comment", "email@gmail.com", new Date(), "123");
-        final Modification modTwo = new Modification("user", "comment", "email@gmail.com", new Date(), "456");
-        final Modification modOneRepeat = new Modification("user", "comment", "email@gmail.com", new Date(), "123");
-        transactionTemplate.execute(new TransactionCallbackWithoutResult() {
-            @Override protected void doInTransactionWithoutResult(TransactionStatus status) {
-                MaterialInstance foo = repo.findOrCreateFrom(gitFoo);
-
-                repo.saveModifications(foo, Arrays.asList(modOne));
-                repo.saveModifications(foo, Arrays.asList(modTwo));
-                repo.saveModifications(foo, Arrays.asList(modOneRepeat));
-            }
-        });
-
-        assertEquals(Arrays.asList(modOneRepeat, modTwo), repo.findModificationsSince(gitFoo, new MaterialRevision(gitFoo, modOne)));
     }
 
     @Test
@@ -990,7 +1003,7 @@ public class MaterialRepositoryIntegrationTest {
             protected void doInTransactionWithoutResult(TransactionStatus status) {
                 MaterialInstance foo = repo.findOrCreateFrom(material);
 
-                repo.saveModifications(foo, Arrays.asList(modOne));
+                repo.saveModifications(foo, asList(modOne));
             }
         });
 
@@ -1069,7 +1082,7 @@ public class MaterialRepositoryIntegrationTest {
             protected void doInTransactionWithoutResult(TransactionStatus status) {
                 MaterialInstance foo = repo.findOrCreateFrom(material);
 
-                repo.saveModifications(foo, Arrays.asList(modOne));
+                repo.saveModifications(foo, asList(modOne));
             }
         });
 
@@ -1119,7 +1132,7 @@ public class MaterialRepositoryIntegrationTest {
     }
 
     @Test
-    public void shouldSavePackageMaterialInstance(){
+    public void shouldSavePackageMaterialInstance() {
         PackageMaterial material = new PackageMaterial();
         PackageRepository repository = PackageRepositoryMother.create("repo-id", "repo", "pluginid", "version", new Configuration(ConfigurationPropertyMother.create("k1", false, "v1")));
         material.setPackageDefinition(PackageDefinitionMother.create("p-id", "name", new Configuration(ConfigurationPropertyMother.create("k2", false, "v2")), repository));
@@ -1145,7 +1158,142 @@ public class MaterialRepositoryIntegrationTest {
         assertThat(JsonHelper.fromJson(savedMaterialInstance.getConfiguration(), PluggableSCMMaterial.class).getScmConfig().getConfiguration(), is(material.getScmConfig().getConfiguration()));
         assertThat(JsonHelper.fromJson(savedMaterialInstance.getConfiguration(), PluggableSCMMaterial.class).getScmConfig().getPluginConfiguration().getId(), is(material.getScmConfig().getPluginConfiguration().getId()));
     }
-    
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    @Test
+    public void shouldRemoveDuplicatesBeforeInsertingModifications() {
+        final MaterialInstance materialInstance = repo.findOrCreateFrom(new GitMaterial(UUID.randomUUID().toString(), "branch"));
+        final ArrayList<Modification> firstSetOfModifications = getModifications(3);
+        transactionTemplate.execute(new TransactionCallback() {
+            public Object doInTransaction(TransactionStatus status) {
+                repo.saveModifications(materialInstance, firstSetOfModifications);
+                return null;
+            }
+        });
+
+        Modifications firstSetOfModificationsFromDb = repo.getModificationsFor(materialInstance, Pagination.pageByNumber(1, 10, 10));
+        assertThat(firstSetOfModificationsFromDb.size(), is(3));
+        for (Modification modification : firstSetOfModifications) {
+            assertThat(firstSetOfModificationsFromDb.containsRevisionFor(modification), is(true));
+        }
+
+        final ArrayList<Modification> secondSetOfModificationsContainingDuplicateRevisions = getModifications(4);
+
+        transactionTemplate.execute(new TransactionCallback() {
+            public Object doInTransaction(TransactionStatus status) {
+                repo.saveModifications(materialInstance, secondSetOfModificationsContainingDuplicateRevisions);
+                return null;
+            }
+        });
+        Modifications secondSetOfModificationsFromDb = repo.getModificationsFor(materialInstance, Pagination.pageByNumber(1, 10, 10));
+        assertThat(secondSetOfModificationsFromDb.size(), is(4));
+        for (final Modification fromPreviousCycle : firstSetOfModificationsFromDb) {
+            Modification modification = ListUtil.find(secondSetOfModificationsFromDb, new ListUtil.Condition() {
+                @Override
+                public <T> boolean isMet(T item) {
+                    Modification modification = (Modification) item;
+                    return modification.getId() == fromPreviousCycle.getId();
+                }
+            });
+            assertThat(modification, is(notNullValue()));
+        }
+        for (Modification modification : secondSetOfModificationsContainingDuplicateRevisions) {
+            assertThat(secondSetOfModificationsFromDb.containsRevisionFor(modification), is(true));
+        }
+    }
+
+    @Test
+    public void shouldReportErrorIfAnAttemptIsMadeToInsertOnlyDuplicateModificationsForAGivenMaterial() {
+        final MaterialInstance materialInstance = repo.findOrCreateFrom(new GitMaterial(UUID.randomUUID().toString(), "branch"));
+        final ArrayList<Modification> firstSetOfModifications = getModifications(3);
+        transactionTemplate.execute(new TransactionCallback() {
+            public Object doInTransaction(TransactionStatus status) {
+                repo.saveModifications(materialInstance, firstSetOfModifications);
+                return null;
+            }
+        });
+        Modifications firstSetOfModificationsFromDb = repo.getModificationsFor(materialInstance, Pagination.pageByNumber(1, 10, 10));
+        assertThat(firstSetOfModificationsFromDb.size(), is(3));
+        for (Modification modification : firstSetOfModifications) {
+            assertThat(firstSetOfModificationsFromDb.containsRevisionFor(modification), is(true));
+        }
+
+        final ArrayList<Modification> secondSetOfModificationsContainingAllDuplicateRevisions = getModifications(3);
+        thrown.expect(RuntimeException.class);
+        thrown.expectMessage("All modifications already exist in db: [r0, r1, r2]");
+        transactionTemplate.execute(new TransactionCallback() {
+            public Object doInTransaction(TransactionStatus status) {
+                repo.saveModifications(materialInstance, secondSetOfModificationsContainingAllDuplicateRevisions);
+                return null;
+            }
+        });
+    }
+
+    @Test
+    public void shouldAllowSavingModificationsIfRevisionsAcrossDifferentMaterialsHappenToBeSame() {
+        final MaterialInstance materialInstance1 = repo.findOrCreateFrom(new GitMaterial(UUID.randomUUID().toString(), "branch"));
+        final MaterialInstance materialInstance2 = repo.findOrCreateFrom(new GitMaterial(UUID.randomUUID().toString(), "branch"));
+        final ArrayList<Modification> modificationsForFirstMaterial = getModifications(3);
+        transactionTemplate.execute(new TransactionCallback() {
+            public Object doInTransaction(TransactionStatus status) {
+                repo.saveModifications(materialInstance1, modificationsForFirstMaterial);
+                return null;
+            }
+        });
+
+        assertThat(repo.getModificationsFor(materialInstance1, Pagination.pageByNumber(1, 10, 10)).size(), is(3));
+
+        final ArrayList<Modification> modificationsForSecondMaterial = getModifications(3);
+
+        transactionTemplate.execute(new TransactionCallback() {
+            public Object doInTransaction(TransactionStatus status) {
+                repo.saveModifications(materialInstance2, modificationsForSecondMaterial);
+                return null;
+            }
+        });
+        Modifications modificationsFromDb = repo.getModificationsFor(materialInstance2, Pagination.pageByNumber(1, 10, 10));
+        assertThat(modificationsFromDb.size(), is(3));
+        for (Modification modification : modificationsForSecondMaterial) {
+            assertThat(modificationsFromDb.containsRevisionFor(modification), is(true));
+        }
+    }
+
+    //Slow test - takes ~1 min to run. Will remove if it causes issues. - Jyoti
+    @Test
+    public void shouldBeAbleToHandleLargeNumberOfModifications() {
+        final MaterialInstance materialInstance = repo.findOrCreateFrom(new GitMaterial(UUID.randomUUID().toString(), "branch"));
+        int count = 10000;
+        final ArrayList<Modification> firstSetOfModifications = getModifications(count);
+        transactionTemplate.execute(new TransactionCallback() {
+            public Object doInTransaction(TransactionStatus status) {
+                repo.saveModifications(materialInstance, firstSetOfModifications);
+                return null;
+            }
+        });
+
+        assertThat(repo.getTotalModificationsFor(materialInstance), is(new Long(count)));
+
+        final ArrayList<Modification> secondSetOfModifications = getModifications(count + 1);
+        transactionTemplate.execute(new TransactionCallback() {
+            public Object doInTransaction(TransactionStatus status) {
+                repo.saveModifications(materialInstance, secondSetOfModifications);
+                return null;
+            }
+        });
+
+        assertThat(repo.getTotalModificationsFor(materialInstance), is(new Long(count+1)));
+    }
+
+    private ArrayList<Modification> getModifications(int count) {
+        final ArrayList<Modification> modifications = new ArrayList<>();
+        for (int i = 0; i < count; i++) {
+            modifications.add(new Modification("user", "comment", "email", new Date(), "r" + i));
+        }
+        return modifications;
+    }
+
     private MaterialRevision saveOneDependencyModification(DependencyMaterial dependencyMaterial, String revision) {
         return saveOneDependencyModification(dependencyMaterial, revision, "MOCK_LABEL-12");
     }
@@ -1177,7 +1325,8 @@ public class MaterialRepositoryIntegrationTest {
 
     private void savePMR(final MaterialRevision revision, final Pipeline pipeline) {
         transactionTemplate.execute(new TransactionCallbackWithoutResult() {
-            @Override protected void doInTransactionWithoutResult(TransactionStatus status) {
+            @Override
+            protected void doInTransactionWithoutResult(TransactionStatus status) {
                 repo.savePipelineMaterialRevision(pipeline, pipeline.getId(), revision);
             }
         });
@@ -1246,7 +1395,8 @@ public class MaterialRepositoryIntegrationTest {
         final Pipeline[] pipeline = new Pipeline[1];
 
         transactionTemplate.execute(new TransactionCallbackWithoutResult() {
-            @Override protected void doInTransactionWithoutResult(TransactionStatus status) {
+            @Override
+            protected void doInTransactionWithoutResult(TransactionStatus status) {
                 //assume that we have saved the materials
                 repo.save(materialRevisions);
 

--- a/server/test/integration/com/thoughtworks/go/server/persistence/PipelineRepositoryIntegrationTest.java
+++ b/server/test/integration/com/thoughtworks/go/server/persistence/PipelineRepositoryIntegrationTest.java
@@ -123,7 +123,6 @@ public class PipelineRepositoryIntegrationTest {
         u.checkinInOrder(git1, "g1");
 
         GitMaterial git2 = u.wf(new GitMaterial("git"), "folder2");
-        u.checkinInOrder(git2, "g1");
 
         ScheduleTestUtil.AddedPipeline p = u.saveConfigWith("P", u.m(git1), u.m(git2));
         CruiseConfig cruiseConfig = goConfigDao.load();

--- a/server/test/integration/com/thoughtworks/go/server/service/BuildCauseProducerServiceWithFlipModificationTest.java
+++ b/server/test/integration/com/thoughtworks/go/server/service/BuildCauseProducerServiceWithFlipModificationTest.java
@@ -189,9 +189,9 @@ public class BuildCauseProducerServiceWithFlipModificationTest {
     }
 
     private void consume(final BuildCause buildCause) throws SQLException {
+        dbHelper.saveRevs(buildCause.getMaterialRevisions());
         transactionTemplate.execute(new TransactionCallbackWithoutResult() {
             @Override protected void doInTransactionWithoutResult(TransactionStatus status) {
-                materialRepository.save(buildCause.getMaterialRevisions());
                 Pipeline latestPipeline = pipelineScheduleQueue.createPipeline(buildCause, mingleConfig, new DefaultSchedulingContext(buildCause.getApprover(), new Agents()), "md5",
                         new TimeProvider());
 //        Pipeline latestPipeline = PipelineMother.schedule(mingleConfig, buildCause);

--- a/server/test/integration/com/thoughtworks/go/server/service/ChangesetServiceIntegrationTest.java
+++ b/server/test/integration/com/thoughtworks/go/server/service/ChangesetServiceIntegrationTest.java
@@ -1,27 +1,22 @@
-/*************************GO-LICENSE-START*********************************
- * Copyright 2014 ThoughtWorks, Inc.
+/*
+ * Copyright 2016 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *************************GO-LICENSE-END***********************************/
+ */
 
 package com.thoughtworks.go.server.service;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Date;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import com.thoughtworks.go.config.*;
 import com.thoughtworks.go.config.materials.MaterialConfigs;
@@ -72,14 +67,21 @@ import static org.junit.Assert.assertThat;
         "classpath:WEB-INF/applicationContext-acegi-security.xml"
 })
 
-public class ChangesetServiceIntegrationTest  {
-    @Autowired MaterialRepository materialRepository;
-    @Autowired PipelineService pipelineService;
-    @Autowired ChangesetService changesetService;
-    @Autowired private GoConfigDao goConfigDao;
-    @Autowired private Localizer localizer;
-    @Autowired private DatabaseAccessHelper dbHelper;
-    @Autowired private TransactionTemplate transactionTemplate;
+public class ChangesetServiceIntegrationTest {
+    @Autowired
+    MaterialRepository materialRepository;
+    @Autowired
+    PipelineService pipelineService;
+    @Autowired
+    ChangesetService changesetService;
+    @Autowired
+    private GoConfigDao goConfigDao;
+    @Autowired
+    private Localizer localizer;
+    @Autowired
+    private DatabaseAccessHelper dbHelper;
+    @Autowired
+    private TransactionTemplate transactionTemplate;
 
     private PipelineConfig pipelineConfigWithTwoMaterials;
     private PipelineConfig pipelineConfig;
@@ -231,38 +233,38 @@ public class ChangesetServiceIntegrationTest  {
         assertThat(cardsInBetween, is(Arrays.asList("4200", "4521", "3750", "4520")));
     }
 
-   @Test
+    @Test
     public void shouldFilterOutCardNumbersWhenGivingTheCardNumbersWhenMingleConfigIsDifferentFromParent() {
         Username loser = new Username(new CaseInsensitiveString("loser"));
         ManualBuild build = new ManualBuild(loser);
         Date checkinTime = new Date();
 
 
-       PipelineConfig upstream = configHelper.addPipeline("upstream", "up-stage", git.config(), new MingleConfig("https://upstream-mingle", "go"), "job");
+        PipelineConfig upstream = configHelper.addPipeline("upstream", "up-stage", git.config(), new MingleConfig("https://upstream-mingle", "go"), "job");
 
-       DependencyMaterial dependencyMaterial = MaterialsMother.dependencyMaterial("upstream", "up-stage");
-       PipelineConfig downstream = configHelper.addPipeline("downstream", "down-stage", dependencyMaterial.config(), new MingleConfig("https://downstream-mingle", "go"), "job");
+        DependencyMaterial dependencyMaterial = MaterialsMother.dependencyMaterial("upstream", "up-stage");
+        PipelineConfig downstream = configHelper.addPipeline("downstream", "down-stage", dependencyMaterial.config(), new MingleConfig("https://downstream-mingle", "go"), "job");
 
-       //Schedule upstream
-       Modification gitCommit1 = checkinWithComment("1234", "#3750, #3123 - agent index", checkinTime);
-       MaterialRevision materialRevision = dbHelper.addRevisionsWithModifications(git, gitCommit1);
-       Pipeline upInstance1 = dbHelper.checkinRevisionsToBuild(build, upstream, materialRevision);
+        //Schedule upstream
+        Modification gitCommit1 = checkinWithComment("1234", "#3750, #3123 - agent index", checkinTime);
+        MaterialRevision materialRevision = dbHelper.addRevisionsWithModifications(git, gitCommit1);
+        Pipeline upInstance1 = dbHelper.checkinRevisionsToBuild(build, upstream, materialRevision);
 
-       Modification gitCommit2 = checkinWithComment("1239", "#4150, #786 - agent index", checkinTime);
-       materialRevision = dbHelper.addRevisionsWithModifications(git, gitCommit2);
-       Pipeline upInstance2 = dbHelper.checkinRevisionsToBuild(build, upstream, materialRevision);
+        Modification gitCommit2 = checkinWithComment("1239", "#4150, #786 - agent index", checkinTime);
+        materialRevision = dbHelper.addRevisionsWithModifications(git, gitCommit2);
+        Pipeline upInstance2 = dbHelper.checkinRevisionsToBuild(build, upstream, materialRevision);
 
-       //Schedule downstream
-       ArrayList<MaterialRevision> materialRevisions = new ArrayList<MaterialRevision>();
-       dbHelper.addDependencyRevisionModification(materialRevisions, dependencyMaterial, upInstance1);
-       Pipeline downInstance1 = dbHelper.checkinRevisionsToBuild(build, downstream, materialRevisions);
+        //Schedule downstream
+        ArrayList<MaterialRevision> materialRevisions = new ArrayList<MaterialRevision>();
+        dbHelper.addDependencyRevisionModification(materialRevisions, dependencyMaterial, upInstance1);
+        Pipeline downInstance1 = dbHelper.checkinRevisionsToBuild(build, downstream, materialRevisions);
 
-       materialRevisions.clear();
-       dbHelper.addDependencyRevisionModification(materialRevisions, dependencyMaterial, upInstance2);
-       Pipeline downInstance2 = dbHelper.checkinRevisionsToBuild(build, downstream, materialRevisions);
+        materialRevisions.clear();
+        dbHelper.addDependencyRevisionModification(materialRevisions, dependencyMaterial, upInstance2);
+        Pipeline downInstance2 = dbHelper.checkinRevisionsToBuild(build, downstream, materialRevisions);
 
-       HttpLocalizedOperationResult result = new HttpLocalizedOperationResult();
-       List<String> cardsInBetween = changesetService.getCardNumbersBetween("downstream", downInstance1.getCounter(), downInstance2.getCounter(), loser, result, false);
+        HttpLocalizedOperationResult result = new HttpLocalizedOperationResult();
+        List<String> cardsInBetween = changesetService.getCardNumbersBetween("downstream", downInstance1.getCounter(), downInstance2.getCounter(), loser, result, false);
 
         assertThat(result.isSuccessful(), is(true));
         assertThat(cardsInBetween.size(), is(0));
@@ -275,12 +277,13 @@ public class ChangesetServiceIntegrationTest  {
         Date checkinTime = new Date();
 
         Modification hgCommit1 = checkinWithComment("abcd", "#4518 - foo", checkinTime);
-        Pipeline pipelineOne = dbHelper.checkinRevisionsToBuild(build, pipelineConfig, dbHelper.addRevisionsWithModifications(hg, hgCommit1));
+        MaterialRevision materialRevision = dbHelper.addRevisionsWithModifications(hg, hgCommit1);
+        Pipeline pipelineOne = dbHelper.checkinRevisionsToBuild(build, pipelineConfig, materialRevision);
 
-        dbHelper.checkinRevisionsToBuild(build, pipelineConfig, dbHelper.addRevisionsWithModifications(hg, hgCommit1));
-        dbHelper.checkinRevisionsToBuild(build, pipelineConfig, dbHelper.addRevisionsWithModifications(hg, hgCommit1));
+        dbHelper.checkinRevisionsToBuild(build, pipelineConfig, materialRevision);
+        dbHelper.checkinRevisionsToBuild(build, pipelineConfig, materialRevision);
 
-        Pipeline pipelineFour = dbHelper.checkinRevisionsToBuild(build, pipelineConfig, dbHelper.addRevisionsWithModifications(hg, hgCommit1));
+        Pipeline pipelineFour = dbHelper.checkinRevisionsToBuild(build, pipelineConfig, materialRevision);
 
 
         List<MaterialRevision> expectedRevisions = Arrays.asList(new MaterialRevision(hg, hgCommit1));
@@ -304,13 +307,12 @@ public class ChangesetServiceIntegrationTest  {
         ManualBuild build = new ManualBuild(loser);
         Date checkinTime = new Date();
 
-        Modification hgCommit1 = checkinWithComment("abcd", "Commit made against no card number - foo", checkinTime);
-        Pipeline pipelineOne = dbHelper.checkinRevisionsToBuild(build, pipelineConfig, dbHelper.addRevisionsWithModifications(hg, hgCommit1));
+        Pipeline pipelineOne = dbHelper.checkinRevisionsToBuild(build, pipelineConfig, dbHelper.addRevisionsWithModifications(hg, modificationWithNoCardNumberInComment(checkinTime)));
 
-        dbHelper.checkinRevisionsToBuild(build, pipelineConfig, dbHelper.addRevisionsWithModifications(hg, hgCommit1));
-        dbHelper.checkinRevisionsToBuild(build, pipelineConfig, dbHelper.addRevisionsWithModifications(hg, hgCommit1));
+        dbHelper.checkinRevisionsToBuild(build, pipelineConfig, dbHelper.addRevisionsWithModifications(hg, modificationWithNoCardNumberInComment(checkinTime)));
+        dbHelper.checkinRevisionsToBuild(build, pipelineConfig, dbHelper.addRevisionsWithModifications(hg, modificationWithNoCardNumberInComment(checkinTime)));
 
-        Pipeline pipelineFour = dbHelper.checkinRevisionsToBuild(build, pipelineConfig, dbHelper.addRevisionsWithModifications(hg, hgCommit1));
+        Pipeline pipelineFour = dbHelper.checkinRevisionsToBuild(build, pipelineConfig, dbHelper.addRevisionsWithModifications(hg, modificationWithNoCardNumberInComment(checkinTime)));
 
         HttpLocalizedOperationResult result = new HttpLocalizedOperationResult();
         List<String> cardsInBetween = changesetService.getCardNumbersBetween(CaseInsensitiveString.str(pipelineConfig.name()), pipelineOne.getCounter(), pipelineFour.getCounter(), loser, result,
@@ -319,13 +321,17 @@ public class ChangesetServiceIntegrationTest  {
         assertThat(cardsInBetween.size(), is(0));
     }
 
+    private Modification modificationWithNoCardNumberInComment(Date checkinTime) {
+        return checkinWithComment("abcd" + UUID.randomUUID(), "Commit made against no card number - foo", checkinTime);
+    }
+
     @Test
     public void shouldShowCardsWhenMaterialsChange() {
         Username loser = new Username(new CaseInsensitiveString("loser"));
         ManualBuild build = new ManualBuild(loser);
 
         Pipeline pipelineFrom = dbHelper.checkinRevisionsToBuild(build, pipelineConfig,
-                dbHelper.addRevisionsWithModifications(hg, checkinWithComment("abcd", "Commit made against no card number - foo", new Date())));
+                dbHelper.addRevisionsWithModifications(hg, modificationWithNoCardNumberInComment(new Date())));
         dbHelper.checkinRevisionsToBuild(build, pipelineConfig, dbHelper.addRevisionsWithModifications(hg, checkinWithComment("8923", "hg commit for card #2750 and #3400", new Date())));
 
         CruiseConfig config = configHelper.load();
@@ -437,7 +443,7 @@ public class ChangesetServiceIntegrationTest  {
 
         dbHelper.checkinRevisionsToBuild(build, pipelineConfig, dbHelper.addRevisionsWithModifications(hg, checkinWithComment("5", "#5750 - Rev 5", now.plusDays(5).toDate())));
 
-        Pipeline bisectPipeline = dbHelper.checkinRevisionsToBuild(build, pipelineConfig, dbHelper.addRevisionsWithModifications(hg, bisectModification));
+        Pipeline bisectPipeline = dbHelper.checkinRevisionsToBuild(build, pipelineConfig, new MaterialRevision(hg, bisectModification));
 
         Pipeline nextPipeline = dbHelper.checkinRevisionsToBuild(build, pipelineConfig, dbHelper.addRevisionsWithModifications(hg, checkinWithComment("6", "#4150 - Rev 6", now.plusDays(7).toDate())));
 
@@ -458,40 +464,6 @@ public class ChangesetServiceIntegrationTest  {
     }
 
     @Test
-    public void shouldReturnResults_WhenUserWantsToViewCompareResultsForBisect_AndFromGtThanToPipelineCounter() {
-        Username loser = new Username(new CaseInsensitiveString("loser"));
-        ManualBuild build = new ManualBuild(loser);
-
-        DateTime now = new DateTime();
-        Pipeline firstPipeline = dbHelper.checkinRevisionsToBuild(build, pipelineConfig, dbHelper.addRevisionsWithModifications(hg, checkinWithComment("1", "#3518 - hg - foo", now.toDate())));
-
-        Modification bisectModification = checkinWithComment("3", "#4750 - Rev 3", now.plusDays(3).toDate());
-        dbHelper.checkinRevisionsToBuild(build, pipelineConfig, dbHelper.addRevisionsWithModifications(hg, checkinWithComment("2", "#3750 - Rev 2", now.plusDays(2).toDate()), bisectModification,
-                checkinWithComment("4", "#4750 - Rev 4", now.plus(4).toDate())));
-
-        dbHelper.checkinRevisionsToBuild(build, pipelineConfig, dbHelper.addRevisionsWithModifications(hg, checkinWithComment("5", "#5750 - Rev 5", now.plusDays(5).toDate())));
-
-        Pipeline bisectPipeline = dbHelper.checkinRevisionsToBuild(build, pipelineConfig, dbHelper.addRevisionsWithModifications(hg, bisectModification));
-
-        Pipeline nextPipeline = dbHelper.checkinRevisionsToBuild(build, pipelineConfig, dbHelper.addRevisionsWithModifications(hg, checkinWithComment("6", "#4150 - Rev 6", now.plusDays(7).toDate())));
-
-        HttpLocalizedOperationResult result = new HttpLocalizedOperationResult();
-        //when to counter is a bisect
-        List<MaterialRevision> revisionList = changesetService.
-                revisionsBetween("foo-bar", firstPipeline.getCounter(), bisectPipeline.getCounter(), new Username(new CaseInsensitiveString("loser")), result, true, true);
-        assertThat(stringRevisions(revisionList), is(Arrays.asList("5", "2", "3", "4")));
-        List<String> cardList = changesetService.getCardNumbersBetween("foo-bar", firstPipeline.getCounter(), bisectPipeline.getCounter(),
-                new Username(new CaseInsensitiveString("loser")), result, true);
-        assertThat(cardList, is(Arrays.asList("5750", "3750", "4750")));
-
-        //When from counter is a bisect
-        revisionList = changesetService.revisionsBetween("foo-bar", nextPipeline.getCounter(), bisectPipeline.getCounter(), new Username(new CaseInsensitiveString("loser")), result, true, true);
-        assertThat(stringRevisions(revisionList), is(Arrays.asList("6", "5", "2")));
-        cardList = changesetService.getCardNumbersBetween("foo-bar", nextPipeline.getCounter(), bisectPipeline.getCounter(), new Username(new CaseInsensitiveString("loser")), result, true);
-        assertThat(cardList, is(Arrays.asList("4150", "5750", "3750")));
-    }
-
-    @Test
     public void shouldReturnAnEmptyListWhenEitherOfThePipelineCounterIsABisect() {
         Username loser = new Username(new CaseInsensitiveString("loser"));
         ManualBuild build = new ManualBuild(loser);
@@ -505,7 +477,7 @@ public class ChangesetServiceIntegrationTest  {
 
         dbHelper.checkinRevisionsToBuild(build, pipelineConfig, dbHelper.addRevisionsWithModifications(hg, checkinWithComment("5", "#5750 - Rev 5", now.plusDays(5).toDate())));
 
-        Pipeline bisectPipeline = dbHelper.checkinRevisionsToBuild(build, pipelineConfig, dbHelper.addRevisionsWithModifications(hg, bisectModification));
+        Pipeline bisectPipeline = dbHelper.checkinRevisionsToBuild(build, pipelineConfig, new MaterialRevision(hg, bisectModification));
 
         Pipeline nextPipeline = dbHelper.checkinRevisionsToBuild(build, pipelineConfig, dbHelper.addRevisionsWithModifications(hg, checkinWithComment("6", "#4150 - Rev 6", now.plusDays(7).toDate())));
 
@@ -513,16 +485,16 @@ public class ChangesetServiceIntegrationTest  {
         //when to counter is a bisect
         List<MaterialRevision> revisionList = changesetService.revisionsBetween("foo-bar", firstPipeline.getCounter(), bisectPipeline.getCounter(), new Username(new CaseInsensitiveString("loser")), result, true,
                 false);
-        assertThat(revisionList.isEmpty(), is(true) );
+        assertThat(revisionList.isEmpty(), is(true));
         List<String> cardList = changesetService.getCardNumbersBetween("foo-bar", firstPipeline.getCounter(), bisectPipeline.getCounter(), new Username(new CaseInsensitiveString("loser")), result,
                 false);
-        assertThat(cardList.isEmpty(), is(true) );
+        assertThat(cardList.isEmpty(), is(true));
 
         //When from counter is a bisect
         revisionList = changesetService.revisionsBetween("foo-bar", bisectPipeline.getCounter(), nextPipeline.getCounter(), new Username(new CaseInsensitiveString("loser")), result, true, false);
-        assertThat(revisionList.isEmpty(), is(true) );
+        assertThat(revisionList.isEmpty(), is(true));
         cardList = changesetService.getCardNumbersBetween("foo-bar", bisectPipeline.getCounter(), nextPipeline.getCounter(), new Username(new CaseInsensitiveString("loser")), result, false);
-        assertThat(cardList.isEmpty(), is(true) );
+        assertThat(cardList.isEmpty(), is(true));
     }
 
     @Test
@@ -536,14 +508,13 @@ public class ChangesetServiceIntegrationTest  {
 
         Modification bisectModification = checkinWithComment("3", "#4750 - Rev 3", now.plusDays(3).toDate());
         dbHelper.checkinRevisionsToBuild(build, pipelineConfig, dbHelper.addRevisionsWithModifications(hg,
-                        checkinWithComment("2", "#3750 - Rev 2", now.plusDays(2).toDate()),
-                        bisectModification,
-                        checkinWithComment("4", "#4750 - Rev 4", now.plusDays(4).toDate())));
+                checkinWithComment("2", "#3750 - Rev 2", now.plusDays(2).toDate()),
+                bisectModification,
+                checkinWithComment("4", "#4750 - Rev 4", now.plusDays(4).toDate())));
 
         dbHelper.checkinRevisionsToBuild(build, pipelineConfig, dbHelper.addRevisionsWithModifications(hg, checkinWithComment("5", "#5750 - Rev 5", now.plusDays(5).toDate())));
 
-        dbHelper.checkinRevisionsToBuild(build, pipelineConfig, dbHelper.addRevisionsWithModifications(hg,
-                        bisectModification));
+        dbHelper.checkinRevisionsToBuild(build, pipelineConfig, new MaterialRevision(hg, bisectModification));
 
         Pipeline lastPipeline = dbHelper.checkinRevisionsToBuild(build, pipelineConfig, dbHelper.addRevisionsWithModifications(hg,
                 checkinWithComment("6", "#6760 - Rev 6", now.plusDays(6).toDate())));
@@ -557,7 +528,8 @@ public class ChangesetServiceIntegrationTest  {
         assertThat(actualMods.size(), is(5));
     }
 
-    @Test public void shouldPopulateActualFromRevisionId() {
+    @Test
+    public void shouldPopulateActualFromRevisionId() {
         PipelineConfig upstreamPipeline = configHelper.addPipeline("upstream", "stage", git.config(), "job");
 
         DependencyMaterial dependencyMaterial = MaterialsMother.dependencyMaterial("upstream", "stage");
@@ -613,7 +585,8 @@ public class ChangesetServiceIntegrationTest  {
 
     private void saveRev(final Modification expectedMod, final MaterialInstance dep) {
         transactionTemplate.execute(new TransactionCallbackWithoutResult() {
-            @Override protected void doInTransactionWithoutResult(TransactionStatus status) {
+            @Override
+            protected void doInTransactionWithoutResult(TransactionStatus status) {
                 materialRepository.saveModification(dep, expectedMod);
             }
         });
@@ -1097,7 +1070,7 @@ public class ChangesetServiceIntegrationTest  {
         Modification mod2 = new Modification("user1", "comment", "email", new Date(), "revision");
         mod2.setMaterialInstance(new SvnMaterialInstance("url", "user1", "flyweight1", false));
 
-        Map<Material,Modifications> map = changesetService.groupModsByMaterial(Arrays.asList(mod1, mod2));
+        Map<Material, Modifications> map = changesetService.groupModsByMaterial(Arrays.asList(mod1, mod2));
         assertThat(map.size(), is(1));
         assertThat(map.get(first), is(new Modifications(mod1, mod2)));
     }

--- a/server/test/integration/com/thoughtworks/go/server/service/PipelineServiceIntegrationTest.java
+++ b/server/test/integration/com/thoughtworks/go/server/service/PipelineServiceIntegrationTest.java
@@ -36,6 +36,7 @@ import com.thoughtworks.go.server.persistence.MaterialRepository;
 import com.thoughtworks.go.server.transaction.TransactionTemplate;
 import com.thoughtworks.go.util.GoConfigFileHelper;
 import com.thoughtworks.go.util.ReflectionUtil;
+import org.apache.commons.lang.time.DateUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -124,11 +125,12 @@ public class PipelineServiceIntegrationTest {
         File file3 = new File("file3");
         File file4 = new File("file4");
         Material hg1 = new HgMaterial("url1", "Dest1");
-        String[] hgRevs = new String[]{"h1"};
+        String[] hgRevs = new String[]{"hg1_2"};
 
         Date latestModification = new Date();
-        u.checkinFiles(hg1, "h1", a(file1, file2, file3, file4), ModifiedAction.added, org.apache.commons.lang.time.DateUtils.addDays(latestModification, -1));
-        u.checkinFiles(hg1, "h1", a(file1, file2, file3, file4), ModifiedAction.added, latestModification);
+        Date older = DateUtils.addDays(latestModification, -1);
+        u.checkinFiles(hg1, "hg1_1", a(file1, file2, file3, file4), ModifiedAction.added, older);
+        u.checkinFiles(hg1, "hg1_2", a(file1, file2, file3, file4), ModifiedAction.modified, latestModification);
 
 
         ScheduleTestUtil.AddedPipeline pair01 = u.saveConfigWith("pair01", "stageName", u.m(hg1));

--- a/server/test/integration/com/thoughtworks/go/server/service/ScheduleTestUtil.java
+++ b/server/test/integration/com/thoughtworks/go/server/service/ScheduleTestUtil.java
@@ -217,13 +217,13 @@ public class ScheduleTestUtil {
     private Pipeline scheduleWith(AddedPipeline pipeline, RevisionsForMaterial... revisions) {
         Pipeline oldInstance = triggeredPipelines.get(pipeline.config.name());
 
-        Map<Material, List<Modification>> modMap = new HashMap<Material, List<Modification>>();
-        Map<Modification, Modification> identityMap = new HashMap<Modification, Modification>();
+        Map<Material, List<Modification>> modMap = new HashMap<>();
+        Map<Modification, Modification> identityMap = new HashMap<>();
 
         MaterialRevisions buildCause = new MaterialRevisions();
         int i = 0;
         for (Material material : MaterialsMother.createMaterialsFromMaterialConfigs(pipeline.config.materialConfigs())) {
-            List<Modification> modifications = new ArrayList<Modification>();
+            List<Modification> modifications = new ArrayList<>();
             for (Modification modification : modForRev(revisions[i++])) {
                 if (!identityMap.containsKey(modification)) {
                     identityMap.put(modification, modification);


### PR DESCRIPTION
When the scm history is re-written or a commit is merged without rebase, the scm-pollers do return duplicate revisions. These revisions are blindly inserted to db as new modification, even though these revisions were already part of db. This causes pipelines to trigger with the revisions that they had already triggered with and a whole lot of other confusion. This commit causes the duplicates to be ignored while inserting the modifications to db. If all revisions in a given MDU cycle for a material happen to be duplicate, then an exception is thrown to indicate the same - This would normally happen when the poller incorrectly keeps returning the same set of modifications all the time.

Adding a db constraint for materialid + revision makes sense, but it would require data correction which could get very complicated.

This prevents a bug in any given material-poller from screwing up the db with numerous duplicate modifications, and thereafter causing issues for everything else that relies on modifications data from db, ie. scheduling etc