### PR TITLE
#2166  Wrong Response Message while creating the User using API

### DIFF
--- a/server/webapp/WEB-INF/rails.new/app/controllers/api_v1/users_controller.rb
+++ b/server/webapp/WEB-INF/rails.new/app/controllers/api_v1/users_controller.rb
@@ -40,13 +40,13 @@ module ApiV1
     def create
       result = HttpLocalizedOperationResult.new
 
-      user, created = user_service.withEnableUserMutex do
+      user = nil
+      created = false
+      user_service.withEnableUserMutex do
         user = user_service.findUserByName(params[:login_name])
         if user.instance_of?(com.thoughtworks.go.domain.NullUser)
           user = save_user(result, com.thoughtworks.go.domain.User.new(params[:login_name]))
-          [user, true]
-        else
-          [user, false]
+          created = true
         end
       end
 


### PR DESCRIPTION
Chnaged the response message to give the JSON user summary.
Initially it was giving wrong response message as 'The user `USERNAME` already exists.'