### PR TITLE
Add indices to improve performance of queries that run in the background.

### DIFF
--- a/server/db/migrate/h2deltas/1606001_add_index_to_buildstatetransitions.sql
+++ b/server/db/migrate/h2deltas/1606001_add_index_to_buildstatetransitions.sql
@@ -1,0 +1,21 @@
+--
+-- Copyright 2016 ThoughtWorks, Inc.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--    http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+CREATE INDEX idx_buildstatetransition_build_id ON buildstatetransitions(buildid);
+
+--//@UNDO
+
+DROP INDEX idx_buildstatetransition_build_id IF EXISTS;

--- a/server/db/migrate/h2deltas/1606002_add_index_to_artifactplans.sql
+++ b/server/db/migrate/h2deltas/1606002_add_index_to_artifactplans.sql
@@ -1,0 +1,21 @@
+--
+-- Copyright 2016 ThoughtWorks, Inc.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--    http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+CREATE INDEX idx_artifactplan_build_id ON artifactplans(buildid);
+
+--//@UNDO
+
+DROP INDEX idx_artifactplan_build_id IF EXISTS;


### PR DESCRIPTION
* the index on BST is needed when listing builds that an agent has run.
* the index on artifactplans is needed because it is frequently called via
  the "scheduledPlan" from `BuildAssignmentService` on every timer tick.