### PR TITLE
Git branch name should default to master

### DIFF
--- a/server/webapp/WEB-INF/rails.new/app/assets/javascripts/pipeline_configs/models/materials.js
+++ b/server/webapp/WEB-INF/rails.new/app/assets/javascripts/pipeline_configs/models/materials.js
@@ -199,7 +199,7 @@ define(['mithril', 'lodash', 'string-plus', './model_mixins', './encrypted_value
     Materials.Material.call(this, "git", true, data);
     this.destination  = m.prop(s.defaultToIfBlank(data.destination, ''));
     this.url          = m.prop(s.defaultToIfBlank(data.url, ''));
-    this.branch       = m.prop(s.defaultToIfBlank(data.branch, ''));
+    this.branch       = m.prop(s.defaultToIfBlank(data.branch, 'master'));
     this.shallowClone = m.prop(data.shallowClone);
 
     this.validate = function () {

--- a/server/webapp/WEB-INF/rails.new/spec/new_javascripts/pipeline_configs/models/materials_spec.js
+++ b/server/webapp/WEB-INF/rails.new/spec/new_javascripts/pipeline_configs/models/materials_spec.js
@@ -295,6 +295,26 @@ define(['lodash', "pipeline_configs/models/materials"], function (_, Materials) 
         });
       });
 
+      describe("Default Value", function(){
+        beforeEach(function () {
+          gitMaterial = Materials.Material.fromJSON(sampleJSON());
+        });
+
+        it("should use the default branch value when not provided", function () {
+          expect(gitMaterial.branch()).toBe('master');
+        });
+
+        function sampleJSON() {
+          return {
+            type:       "git",
+            attributes: {
+              url:         "http://git.example.com/git/myProject",
+              branch:      null,
+            }
+          };
+        }
+      });
+
       describe("Deserialization from JSON", function () {
         beforeEach(function () {
           gitMaterial = Materials.Material.fromJSON(sampleJSON());


### PR DESCRIPTION
On the single page app, while adding a new git material, the value for the git branch is set to `master` as default, because check connection internally uses the master as default value when no branch name is provided