### PR TITLE
#1133 config repos integration with post commit hooks

### DIFF
--- a/common/test/unit/com/thoughtworks/go/domain/PipelineGroupsTest.java
+++ b/common/test/unit/com/thoughtworks/go/domain/PipelineGroupsTest.java
@@ -17,6 +17,7 @@
 package com.thoughtworks.go.domain;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -48,6 +49,7 @@ import org.junit.Test;
 
 import static com.thoughtworks.go.helper.PipelineConfigMother.createGroup;
 import static com.thoughtworks.go.helper.PipelineConfigMother.createPipelineConfig;
+import static com.thoughtworks.go.helper.PipelineConfigMother.pipelineConfig;
 import static java.util.Arrays.asList;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsCollectionContaining.hasItem;
@@ -192,41 +194,6 @@ public class PipelineGroupsTest {
         PipelineGroups pipelineGroups = new PipelineGroups(defaultGroup);
 
         pipelineGroups.findGroup("NonExistantGroup");
-    }
-
-    @Test
-    public void shouldReturnAllUniqueSchedulableScmMaterials() {
-        final MaterialConfig svnMaterialConfig = new SvnMaterialConfig("http://svn_url_1", "username", "password", false);
-        ((ScmMaterialConfig) svnMaterialConfig).setAutoUpdate(false);
-        final MaterialConfig svnMaterialConfigWithAutoUpdate = new SvnMaterialConfig("http://svn_url_2", "username", "password", false);
-        ((ScmMaterialConfig) svnMaterialConfigWithAutoUpdate).setAutoUpdate(true);
-        final MaterialConfig hgMaterialConfig = new HgMaterialConfig("http://hg_url", null);
-        ((ScmMaterialConfig) hgMaterialConfig).setAutoUpdate(false);
-        final MaterialConfig gitMaterialConfig = new GitMaterialConfig("http://git_url");
-        ((ScmMaterialConfig) gitMaterialConfig).setAutoUpdate(false);
-        final MaterialConfig tfsMaterialConfig = new TfsMaterialConfig(mock(GoCipher.class), new UrlArgument("http://tfs_url"), "username", "domain", "password", "project_path");
-        ((ScmMaterialConfig) tfsMaterialConfig).setAutoUpdate(false);
-        final MaterialConfig p4MaterialConfig = new P4MaterialConfig("http://p4_url", "view", "username");
-        ((ScmMaterialConfig) p4MaterialConfig).setAutoUpdate(false);
-        final MaterialConfig dependencyMaterialConfig = MaterialConfigsMother.dependencyMaterialConfig();
-        final PluggableSCMMaterialConfig pluggableSCMMaterialConfig = MaterialConfigsMother.pluggableSCMMaterialConfig("scm-id-1", null, null);
-        pluggableSCMMaterialConfig.getSCMConfig().setAutoUpdate(false);
-
-        final PipelineConfig p1 = PipelineConfigMother.pipelineConfig("pipeline1", new MaterialConfigs(svnMaterialConfig), new JobConfigs(new JobConfig(new CaseInsensitiveString("jobName"))));
-        final PipelineConfig p2 = PipelineConfigMother.pipelineConfig("pipeline2", new MaterialConfigs(svnMaterialConfig, gitMaterialConfig),
-                new JobConfigs(new JobConfig(new CaseInsensitiveString("jobName"))));
-        final PipelineConfig p3 = PipelineConfigMother.pipelineConfig("pipeline3", new MaterialConfigs(hgMaterialConfig, dependencyMaterialConfig),
-                new JobConfigs(new JobConfig(new CaseInsensitiveString("jobName"))));
-        final PipelineConfig p4 = PipelineConfigMother.pipelineConfig("pipeline4", new MaterialConfigs(p4MaterialConfig, pluggableSCMMaterialConfig), new JobConfigs(new JobConfig(new CaseInsensitiveString("jobName"))));
-        final PipelineConfig p5 = PipelineConfigMother.pipelineConfig("pipeline5", new MaterialConfigs(svnMaterialConfigWithAutoUpdate, tfsMaterialConfig),
-                new JobConfigs(new JobConfig(new CaseInsensitiveString("jobName"))));
-        final PipelineGroups groups = new PipelineGroups(new BasicPipelineConfigs(p1, p2, p3, p4, p5));
-
-        final Set<MaterialConfig> materials = groups.getAllUniquePostCommitSchedulableMaterials();
-
-        assertThat(materials.size(), is(6));
-        assertThat(materials, hasItems(svnMaterialConfig, hgMaterialConfig, gitMaterialConfig, tfsMaterialConfig, p4MaterialConfig, pluggableSCMMaterialConfig));
-        assertThat(materials, not(hasItem(svnMaterialConfigWithAutoUpdate)));
     }
 
     @Test

--- a/config/config-api/src/com/thoughtworks/go/config/CruiseConfig.java
+++ b/config/config-api/src/com/thoughtworks/go/config/CruiseConfig.java
@@ -50,6 +50,8 @@ public interface CruiseConfig extends Validatable, ConfigOriginTraceable {
 
     int schemaVersion();
 
+    Set<MaterialConfig> getAllUniquePostCommitSchedulableMaterials();
+
     ConfigReposConfig getConfigRepos();
 
     void setConfigRepos(ConfigReposConfig repos);

--- a/server/src/com/thoughtworks/go/server/materials/MaterialUpdateService.java
+++ b/server/src/com/thoughtworks/go/server/materials/MaterialUpdateService.java
@@ -140,8 +140,8 @@ public class MaterialUpdateService implements GoMessageListener<MaterialUpdateCo
                 return;
             }
             final PostCommitHookImplementer materialTypeImplementer = materialType.getImplementer();
-            final PipelineGroups allGroups = goConfigService.currentCruiseConfig().getGroups();
-            Set<Material> allUniquePostCommitSchedulableMaterials = materialConfigConverter.toMaterials(allGroups.getAllUniquePostCommitSchedulableMaterials());
+            final CruiseConfig cruiseConfig = goConfigService.currentCruiseConfig();
+            Set<Material> allUniquePostCommitSchedulableMaterials = materialConfigConverter.toMaterials(cruiseConfig.getAllUniquePostCommitSchedulableMaterials());
             final Set<Material> prunedMaterialList = materialTypeImplementer.prune(allUniquePostCommitSchedulableMaterials, attributes);
 
             if (prunedMaterialList.isEmpty()) {

--- a/server/test/unit/com/thoughtworks/go/server/materials/MaterialUpdateServiceTest.java
+++ b/server/test/unit/com/thoughtworks/go/server/materials/MaterialUpdateServiceTest.java
@@ -347,6 +347,20 @@ public class MaterialUpdateServiceTest {
     }
 
     @Test
+    public void shouldNotAllowPostCommitNotificationsToPassThroughToTheConfigQueue_WhenTheSameMaterialIsCurrentlyInProgressAndMaterialIsAutoUpdateTrueAndMaterialIsConfigRepo() throws Exception {
+        ScmMaterial material = mock(ScmMaterial.class);
+        when(material.isAutoUpdate()).thenReturn(true);
+        when(material.getFingerprint()).thenReturn("fingerprint");
+        when(watchList.hasConfigRepoWithFingerprint("fingerprint")).thenReturn(true);
+        MaterialUpdateMessage message = new MaterialUpdateMessage(material, 0);
+        doNothing().when(configQueue).post(message);
+        service.updateMaterial(material); //prune inprogress queue to have this material in it
+        service.updateMaterial(material); // immediately notify another check-in
+        verify(configQueue, times(1)).post(message);
+        verify(material).isAutoUpdate();
+    }
+
+    @Test
     public void shouldNotAllowPostCommitNotificationsToPassThroughToTheQueue_WhenTheSameMaterialIsCurrentlyInProgressAndMaterialIsAutoUpdateTrue() throws Exception {
         ScmMaterial material = mock(ScmMaterial.class);
         when(material.isAutoUpdate()).thenReturn(true);


### PR DESCRIPTION
As a user of [configuration repositories](#1133) I may find it frustrating to wait up to 1 minute for newly pushed Go configuration to be parsed and validated in Go server.
There are 2 solutions for that -
 1. Make the dedicated config repo poller's interval smaller. (We can always do that anyway.)
 2. Use post commit hooks, just like on other materials. This is the fastest feedback, obviously.

## Problem

There is one problem with how current post commit hooks works. It requires `autoUpdate=false`. Which is in conflict with what config repo material requires -`autoUpdate=true`.
There is a **good reason why config repos must be polled anyway**:
1. At server start we must ensure latest remote configurations are fetched.
2. We cannot rely on post commit hooks to be **the only source of MDU requests**, because:
  * There would be no event to fetch **newly added repository**. E.g. user just adds new git repository where he has new pipelines, but in order to *see* any pipelines configured remotely, he would have to trigger the hook first, at least once.
  * If any API call to `api/material/notify` fails for whatever reason, there would be no mechanism to ensure that latest config finally gets parsed by server.

## Implementation

 * We keep the requirement that `autoUpdate=true` for all configuration repositories. We keep polling all configuration repositories. (No changes here)
 * If material is used in configuration repository then it is allowed to be triggered via post commit hook (API call to `api/material/notify`).

The effect is that any configuration repository is both 
 * polled once a minute
 * and it can be additionaly triggred by API call to `api/material/notify`