### PR TITLE
Fix multiple threading issues with `XSLTTransformerRegistry`

### DIFF
--- a/base/src/com/thoughtworks/go/util/SystemEnvironment.java
+++ b/base/src/com/thoughtworks/go/util/SystemEnvironment.java
@@ -102,8 +102,6 @@ public class SystemEnvironment implements Serializable, ConfigDirProvider {
     public static final String CONFIG_DIR_PROPERTY = "cruise.config.dir";
     public static final String CONFIG_CIPHER = "cipher";
     public static final String HOSTNAME_SHINE_USES = "localhost";
-    public static final String SHINE_XSL_TRANSFORMER_REGISTRY_CACHE_SIZE = "shine.xsl.transformer.registry.cache.size";
-    private static final String DEFAULT_SHINE_XSL_TRANSFORMER_REGISTRY_CACHE_SIZE = "20";
     public static final int TFS_SOCKET_TIMEOUT_IN_MILLISECONDS = 20 * 60 * 1000;
     public static final String TFS_SOCKET_TIMEOUT_PROPERTY = "tfs.socket.block.timeout";
 
@@ -581,10 +579,6 @@ public class SystemEnvironment implements Serializable, ConfigDirProvider {
 
     public String getCruiseDbCacheSize() {
         return getPropertyImpl(CRUISE_DB_CACHE_SIZE, CRUISE_DB_CACHE_SIZE_DEFAULT);
-    }
-
-    public int getShineXslTransformerRegistryCacheSize() {
-        return Integer.parseInt(getPropertyImpl(SHINE_XSL_TRANSFORMER_REGISTRY_CACHE_SIZE, DEFAULT_SHINE_XSL_TRANSFORMER_REGISTRY_CACHE_SIZE));
     }
 
     public long getUnresponsiveJobWarningThreshold() {

--- a/common/test/unit/com/thoughtworks/go/util/SystemEnvironmentTest.java
+++ b/common/test/unit/com/thoughtworks/go/util/SystemEnvironmentTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 ThoughtWorks, Inc.
+ * Copyright 2016 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,7 +32,6 @@ import java.util.Properties;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
 
 @RunWith(JunitExtRunner.class)
 public class SystemEnvironmentTest {
@@ -179,13 +178,6 @@ public class SystemEnvironmentTest {
         assertThat(systemEnvironment.getCruiseDbCacheSize(), is(String.valueOf(128 * 1024)));
         System.setProperty(SystemEnvironment.CRUISE_DB_CACHE_SIZE, String.valueOf(512 * 1024));
         assertThat(systemEnvironment.getCruiseDbCacheSize(), is(String.valueOf(512 * 1024)));
-    }
-
-    @Test
-    public void shouldUnderstandLazyLoadXslTransformerRegistryCacheSize() {
-        assertThat(systemEnvironment.getShineXslTransformerRegistryCacheSize(), is(20));
-        systemEnvironment.setProperty(SystemEnvironment.SHINE_XSL_TRANSFORMER_REGISTRY_CACHE_SIZE, "50");
-        assertThat(systemEnvironment.getShineXslTransformerRegistryCacheSize(), is(50));
     }
 
     @Test

--- a/server/src/com/thoughtworks/studios/shine/cruise/BackgroundStageLoader.java
+++ b/server/src/com/thoughtworks/studios/shine/cruise/BackgroundStageLoader.java
@@ -1,18 +1,18 @@
-/*************************GO-LICENSE-START*********************************
- * Copyright 2014 ThoughtWorks, Inc.
+/*
+ * Copyright 2016 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *************************GO-LICENSE-END***********************************/
+ */
 
 package com.thoughtworks.studios.shine.cruise;
 
@@ -67,7 +67,6 @@ public class BackgroundStageLoader implements StageFeedHandler {
             LOGGER.debug("handling stage:<" + stageIdentifier + ">...");
         }
         try {
-            transformerRegistry.reset();
             stageStorage.save(stageResourceImporter.load(stageIdentifier, new InMemoryTempGraphFactory(), transformerRegistry));
             if (LOGGER.isDebugEnabled()) {
                 LOGGER.debug("importing stage:<" + stageIdentifier + "> finished.");

--- a/server/src/com/thoughtworks/studios/shine/cruise/stage/details/LazyStageGraphLoader.java
+++ b/server/src/com/thoughtworks/studios/shine/cruise/stage/details/LazyStageGraphLoader.java
@@ -1,55 +1,41 @@
-/*************************GO-LICENSE-START*********************************
- * Copyright 2014 ThoughtWorks, Inc.
+/*
+ * Copyright 2016 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *************************GO-LICENSE-END***********************************/
+ */
 
 package com.thoughtworks.studios.shine.cruise.stage.details;
 
 import com.thoughtworks.go.domain.StageIdentifier;
-import com.thoughtworks.go.util.SystemEnvironment;
 import com.thoughtworks.studios.shine.semweb.Graph;
 import com.thoughtworks.studios.shine.semweb.grddl.XSLTTransformerRegistry;
 import com.thoughtworks.studios.shine.semweb.sesame.InMemoryTempGraphFactory;
-import org.apache.commons.pool.BasePoolableObjectFactory;
-import org.apache.commons.pool.impl.GenericObjectPool;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+
+import static com.thoughtworks.go.util.ExceptionUtils.bomb;
 
 @Component
 public class LazyStageGraphLoader implements StageGraphLoader {
     private final StageResourceImporter importer;
     private final StageStorage stageStorage;
-    private final GenericObjectPool transformerRegistryPool;
+    private final XSLTTransformerRegistry transformerRegistry;
 
     @Autowired
-    public LazyStageGraphLoader(StageResourceImporter importer, StageStorage stageStorage, SystemEnvironment env) {
-        this(importer, stageStorage, env.getShineXslTransformerRegistryCacheSize());
-    }
-
-    LazyStageGraphLoader(StageResourceImporter importer, StageStorage stageStorage, int transformerRegistryPoolSize) {
+    public LazyStageGraphLoader(StageResourceImporter importer, StageStorage stageStorage) {
         this.importer = importer;
         this.stageStorage = stageStorage;
-        transformerRegistryPool = new GenericObjectPool(new BasePoolableObjectFactory() {
-            @Override public Object makeObject() throws Exception {
-                return new XSLTTransformerRegistry();
-            }
-
-            @Override public void activateObject(Object obj) throws Exception {
-                XSLTTransformerRegistry registry = (XSLTTransformerRegistry) obj;
-                registry.reset();
-            }
-        }, transformerRegistryPoolSize, GenericObjectPool.WHEN_EXHAUSTED_GROW, GenericObjectPool.DEFAULT_MAX_WAIT);
+        this.transformerRegistry = new XSLTTransformerRegistry();
     }
 
     public Graph load(StageIdentifier stageIdentifier) {
@@ -57,21 +43,11 @@ public class LazyStageGraphLoader implements StageGraphLoader {
             return stageStorage.load(stageIdentifier);
         }
 
-        Graph graph = null;
-        XSLTTransformerRegistry transformerRegistry = null;
+        Graph graph;
         try {
-            transformerRegistry = (XSLTTransformerRegistry) transformerRegistryPool.borrowObject();
             graph = importer.load(stageIdentifier, new InMemoryTempGraphFactory(), transformerRegistry);
         } catch (Exception e) {
-            throw new RuntimeException(e);
-        } finally {
-            if (transformerRegistry != null) {
-                try {
-                    transformerRegistryPool.returnObject(transformerRegistry);
-                } catch (Exception e) {
-                    throw new RuntimeException(e);
-                }
-            }
+            throw bomb(e);
         }
         stageStorage.save(graph);
         return graph;

--- a/server/src/com/thoughtworks/studios/shine/semweb/grddl/XSLTTransformerRegistry.java
+++ b/server/src/com/thoughtworks/studios/shine/semweb/grddl/XSLTTransformerRegistry.java
@@ -16,6 +16,7 @@
 
 package com.thoughtworks.studios.shine.semweb.grddl;
 
+import javax.xml.transform.Templates;
 import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerConfigurationException;
 import javax.xml.transform.TransformerFactory;
@@ -27,11 +28,8 @@ import java.util.Map;
 
 import static com.thoughtworks.go.util.ExceptionUtils.bomb;
 
-/**
- * IMPORTANT: This is completely thread unsafe
- */
 public class XSLTTransformerRegistry {
-    private final Map<String, Transformer> transformerMap;
+    private final Map<String, Templates> transformerMap;
 
     public XSLTTransformerRegistry() {
         transformerMap = new HashMap<>();
@@ -53,21 +51,20 @@ public class XSLTTransformerRegistry {
     }
 
     public Transformer getTransformer(String xsltPath) {
-        return transformerMap.get(xsltPath);
+        try {
+            return transformerMap.get(xsltPath).newTransformer();
+        } catch (TransformerConfigurationException e) {
+            throw bomb(e);
+        }
     }
 
-    private Transformer transformerForXSLStream(InputStream xsl) {
+    private Templates transformerForXSLStream(InputStream xsl) {
         TransformerFactory transformerFactory = TransformerFactory.newInstance();
         try {
-            return transformerFactory.newTransformer(new StreamSource(xsl));
+            return transformerFactory.newTemplates(new StreamSource(xsl));
         } catch (TransformerConfigurationException e) {
             throw new InvalidGrddlTransformationException(e);
         }
     }
 
-    public void reset() {
-        for (Transformer transformer : transformerMap.values()) {
-            transformer.reset();
-        }
-    }
 }

--- a/server/test/integration/com/thoughtworks/go/server/dao/sparql/ShineDaoIntegrationTest.java
+++ b/server/test/integration/com/thoughtworks/go/server/dao/sparql/ShineDaoIntegrationTest.java
@@ -1,18 +1,18 @@
-/*************************GO-LICENSE-START*********************************
- * Copyright 2014 ThoughtWorks, Inc.
+/*
+ * Copyright 2016 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *************************GO-LICENSE-END***********************************/
+ */
 
 package com.thoughtworks.go.server.dao.sparql;
 
@@ -111,7 +111,7 @@ public class ShineDaoIntegrationTest {
         stageStorage.clear();
         StageResourceImporter importer = new StageResourceImporter(artifactsRoot, xmlApiService, stageService, pipelineHistoryService,systemEnvironment);
 
-        LazyStageGraphLoader graphLoader = new LazyStageGraphLoader(importer, stageStorage, systemEnvironment);
+        LazyStageGraphLoader graphLoader = new LazyStageGraphLoader(importer, stageStorage);
         StagesQuery stagesQuery = new StagesQuery(graphLoader, stagesQueryCache);
         shineDao = new ShineDao(stagesQuery, stageService, pipelineHistoryService);
         goURLRepository = new StubGoURLRepository("http://localhost:8153", artifactsRoot);
@@ -188,7 +188,7 @@ public class ShineDaoIntegrationTest {
         assertThat("not successful", result.isSuccessful(), is(false));
         assertThat(result.replacementContent(localizer), is("Unable to retrieve failure results."));
     }
-    
+
     @Test
     public void shouldRetriveHistoricalFailureWithNoTests() throws Exception {
         failureSetup.setupPipelineInstance(true, null, goURLRepository);

--- a/server/test/unit/com/thoughtworks/studios/shine/semweb/grddl/XSLTTransformerRegistryTest.java
+++ b/server/test/unit/com/thoughtworks/studios/shine/semweb/grddl/XSLTTransformerRegistryTest.java
@@ -1,39 +1,35 @@
-/*************************GO-LICENSE-START*********************************
- * Copyright 2014 ThoughtWorks, Inc.
+/*
+ * Copyright 2016 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *************************GO-LICENSE-END***********************************/
+ */
 
 package com.thoughtworks.studios.shine.semweb.grddl;
+
+import org.junit.Test;
 
 import javax.xml.transform.Transformer;
 
 import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertSame;
-import org.junit.Test;
 
-public class GRDDLTransformerRegistryTest {
+public class XSLTTransformerRegistryTest {
 
     @Test
-    public void canGetATransformerBasedOnAGrddlResource() {
+    public void getTransformerShouldNeverReturnTheSameTransformerTwice() throws Exception {
         XSLTTransformerRegistry registry = new XSLTTransformerRegistry();
-
         Transformer transformer1 = registry.getTransformer("xunit/ant-junit-grddl.xsl");
         Transformer transformer2 = registry.getTransformer("xunit/ant-junit-grddl.xsl");
-        Transformer transformer3 = registry.getTransformer("cruise/job-grddl.xsl");
 
-        assertSame(transformer1, transformer2);
-        assertNotSame(transformer1, transformer3);
+        assertNotSame(transformer1, transformer2);
     }
-
 }


### PR DESCRIPTION
* `XSLTTransformerRegistry` was fundamentally unsafe because of incorrect
  usage of the `Transformer`. Instead of storing instances of `Transformer`
  store instances of `Templates` that can create transformers on demand.
* Since creating instances of `XSLTTransformerRegistry` was expensive,
  `LazyStageGraphLoader` was holding an object pool containing instances
  of `XSLTTransformerRegistry` objects, which is no longer required.
  This class was also potentially leaking file handles before #2187