### PR TITLE
#2210 - go-server and go-agent Depends on java instead of Pre-Depends.

### DIFF
--- a/installers/agent/deb/control.go-agent
+++ b/installers/agent/deb/control.go-agent
@@ -3,7 +3,7 @@ Section: base
 Priority: optional
 Version: @VERSION@-@RELEASE@
 Architecture: all
-Pre-Depends: java7-runtime-headless
+Depends: java7-runtime-headless
 Maintainer: The Go Team <studios@thoughtworks.com>
 Conflicts: cruise-agent
 Replaces: cruise-agent

--- a/installers/server/deb/control.go-server
+++ b/installers/server/deb/control.go-server
@@ -6,7 +6,7 @@ Section: base
 Priority: optional
 Version: @VERSION@-@RELEASE@
 Architecture: all
-Pre-Depends: java7-runtime-headless
+Depends: java7-runtime-headless
 Maintainer: The Go Team <studios@thoughtworks.com>
 Installed-Size: 409600
 Description: Go Server Component


### PR DESCRIPTION
#2210 - The ability to use `--ignore-depends` for the Java dependency in `go-server` and `go-agent` deb packages.