### PR TITLE
Reduce the console output from server startup.

### DIFF
--- a/server/pom.xml
+++ b/server/pom.xml
@@ -550,6 +550,11 @@
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
+            <artifactId>jul-to-slf4j</artifactId>
+            <version>1.7.2</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
             <version>1.7.2</version>
         </dependency>

--- a/server/webapp/WEB-INF/rails.new/vendor/engines/gadgets/lib/gadgets.rb
+++ b/server/webapp/WEB-INF/rails.new/vendor/engines/gadgets/lib/gadgets.rb
@@ -1,3 +1,6 @@
+org.slf4j.bridge.SLF4JBridgeHandler.removeHandlersForRootLogger()
+org.slf4j.bridge.SLF4JBridgeHandler.install()
+
 require "gadgets/engine"
 require 'gadgets/a_r_datasource'
 require 'gadgets/cache_control'


### PR DESCRIPTION
java.util.logging which is used by shindig logs to `System.err` by default.
Instead redirect those logs to slf4j instead, so that they can be better
managed by log4j.properties instead of being lost on stdout.