### PR TITLE
Admins/Group Admins PluginInfos API to list and view #1873

### DIFF
--- a/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/notification/NotificationPluginRegistrar.java
+++ b/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/notification/NotificationPluginRegistrar.java
@@ -46,6 +46,7 @@ public class NotificationPluginRegistrar implements PluginChangeListener {
     public void pluginLoaded(GoPluginDescriptor pluginDescriptor) {
         if (notificationExtension.canHandlePlugin(pluginDescriptor.id())) {
             try {
+                notificationPluginRegistry.registerPlugin(pluginDescriptor.id());
                 List<String> notificationsInterestedIn = notificationExtension.getNotificationsOfInterestFor(pluginDescriptor.id());
                 if (notificationsInterestedIn != null && !notificationsInterestedIn.isEmpty()) {
                     checkNotificationTypes(pluginDescriptor, notificationsInterestedIn);
@@ -69,6 +70,7 @@ public class NotificationPluginRegistrar implements PluginChangeListener {
     @Override
     public void pluginUnLoaded(GoPluginDescriptor pluginDescriptor) {
         if (notificationExtension.canHandlePlugin(pluginDescriptor.id())) {
+            notificationPluginRegistry.deregisterPlugin(pluginDescriptor.id());
             notificationPluginRegistry.removePluginInterests(pluginDescriptor.id());
         }
     }

--- a/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/notification/NotificationPluginRegistry.java
+++ b/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/notification/NotificationPluginRegistry.java
@@ -27,6 +27,7 @@ import java.util.concurrent.ConcurrentHashMap;
 @Component
 public class NotificationPluginRegistry {
     private final Map<String, Set<String>> notificationNameToPluginsInterestedMap = new ConcurrentHashMap<>();
+    private Set<String> notificationPlugins = new HashSet<>();
 
     public void registerPluginInterests(String pluginId, List<String> notificationNames) {
         if (notificationNames != null && !notificationNames.isEmpty()) {
@@ -73,5 +74,17 @@ public class NotificationPluginRegistry {
     @Deprecated
     public void clear() {
         notificationNameToPluginsInterestedMap.clear();
+    }
+
+    public void registerPlugin(String pluginId) {
+        notificationPlugins.add(pluginId);
+    }
+
+    public void deregisterPlugin(String pluginId) {
+        notificationPlugins.remove(pluginId);
+    }
+
+    public Set<String> getNotificationPlugins() {
+        return notificationPlugins;
     }
 }

--- a/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/pluggabletask/JsonBasedTaskExtension.java
+++ b/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/pluggabletask/JsonBasedTaskExtension.java
@@ -33,7 +33,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-class JsonBasedTaskExtension extends AbstractExtension implements TaskExtensionContract {
+public class JsonBasedTaskExtension extends AbstractExtension implements TaskExtensionContract {
     public final static String TASK_EXTENSION = "task";
     private final static List<String> supportedVersions = Arrays.asList(JsonBasedTaskExtensionHandler_V1.VERSION);
 

--- a/plugin-infra/go-plugin-access/test/com/thoughtworks/go/plugin/access/notification/NotificationPluginRegistrarTest.java
+++ b/plugin-infra/go-plugin-access/test/com/thoughtworks/go/plugin/access/notification/NotificationPluginRegistrarTest.java
@@ -25,6 +25,9 @@ import org.junit.Test;
 import org.mockito.Mock;
 
 import static java.util.Arrays.asList;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.*;
 import static org.mockito.MockitoAnnotations.initMocks;
 
@@ -108,5 +111,23 @@ public class NotificationPluginRegistrarTest {
 
         verify(logger).warn("Plugin 'plugin-id-1' is trying to register for 'pipeline-status' which is not a valid notification type. Valid notification types are: [stage-status]");
         verify(logger).warn("Plugin 'plugin-id-1' is trying to register for 'job-status' which is not a valid notification type. Valid notification types are: [stage-status]");
+    }
+
+    @Test
+    public void shouldRegisterPluginOnPluginLoad() {
+        NotificationPluginRegistrar notificationPluginRegistrar = new NotificationPluginRegistrar(pluginManager, notificationExtension, notificationPluginRegistry);
+
+        notificationPluginRegistrar.pluginLoaded(new GoPluginDescriptor(PLUGIN_ID_1, null, null, null, null, true));
+
+        verify(notificationPluginRegistry).registerPlugin(PLUGIN_ID_1);
+    }
+
+    @Test
+    public void shouldUnregisterPluginOnPluginUnLoad() {
+        NotificationPluginRegistrar notificationPluginRegistrar = new NotificationPluginRegistrar(pluginManager, notificationExtension, notificationPluginRegistry);
+
+        notificationPluginRegistrar.pluginUnLoaded(new GoPluginDescriptor(PLUGIN_ID_1, null, null, null, null, true));
+
+        verify(notificationPluginRegistry).deregisterPlugin(PLUGIN_ID_1);
     }
 }

--- a/plugin-infra/go-plugin-access/test/com/thoughtworks/go/plugin/access/notification/NotificationPluginRegistryTest.java
+++ b/plugin-infra/go-plugin-access/test/com/thoughtworks/go/plugin/access/notification/NotificationPluginRegistryTest.java
@@ -24,6 +24,7 @@ import static java.util.Arrays.asList;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 public class NotificationPluginRegistryTest {
     public static final String PLUGIN_ID_1 = "plugin-id-1";
@@ -82,5 +83,32 @@ public class NotificationPluginRegistryTest {
     public void should_isAnyPluginInterestedIn_Correctly() {
         assertThat(notificationPluginRegistry.isAnyPluginInterestedIn(PIPELINE_STATUS), is(true));
         assertThat(notificationPluginRegistry.isAnyPluginInterestedIn(UNKNOWN_NOTIFICATION), is(false));
+    }
+
+    @Test
+    public void shouldListRegisteredPlugins() {
+        notificationPluginRegistry.registerPlugin("plugin_id_1");
+        notificationPluginRegistry.registerPlugin("plugin_id_2");
+
+        assertThat(notificationPluginRegistry.getNotificationPlugins().size(), is(2));
+        assertTrue(notificationPluginRegistry.getNotificationPlugins().contains("plugin_id_1"));
+        assertTrue(notificationPluginRegistry.getNotificationPlugins().contains("plugin_id_2"));
+    }
+
+    @Test
+    public void shouldNotRegisterDuplicatePlugins() {
+        notificationPluginRegistry.registerPlugin("plugin_id_1");
+        notificationPluginRegistry.registerPlugin("plugin_id_1");
+
+        assertThat(notificationPluginRegistry.getNotificationPlugins().size(), is(1));
+        assertTrue(notificationPluginRegistry.getNotificationPlugins().contains("plugin_id_1"));
+    }
+
+    @Test
+    public void shouldNotListDeRegisteredPlugins() {
+        notificationPluginRegistry.registerPlugin("plugin_id_1");
+        notificationPluginRegistry.deregisterPlugin("plugin_id_1");
+
+        assertTrue(notificationPluginRegistry.getNotificationPlugins().isEmpty());
     }
 }

--- a/server/src/com/thoughtworks/go/server/service/PluginService.java
+++ b/server/src/com/thoughtworks/go/server/service/PluginService.java
@@ -26,6 +26,8 @@ import com.thoughtworks.go.plugin.api.response.validation.ValidationError;
 import com.thoughtworks.go.plugin.api.response.validation.ValidationResult;
 import com.thoughtworks.go.server.dao.PluginDao;
 import com.thoughtworks.go.server.domain.PluginSettings;
+import com.thoughtworks.go.server.service.plugins.builder.PluginInfoBuilder;
+import com.thoughtworks.go.server.ui.plugins.PluginInfo;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -36,11 +38,13 @@ import java.util.Map;
 public class PluginService {
     private final List<GoPluginExtension> extensions;
     private final PluginDao pluginDao;
+    private PluginInfoBuilder pluginInfoBuilder;
 
     @Autowired
-    public PluginService(List<GoPluginExtension> extensions, PluginDao pluginDao) {
+    public PluginService(List<GoPluginExtension> extensions, PluginDao pluginDao, PluginInfoBuilder pluginInfoBuilder) {
         this.extensions = extensions;
         this.pluginDao = pluginDao;
+        this.pluginInfoBuilder = pluginInfoBuilder;
     }
 
     public PluginSettings getPluginSettingsFor(String pluginId) {
@@ -91,6 +95,14 @@ public class PluginService {
         Map<String, String> settingsMap = pluginSettings.getSettingsAsKeyValuePair();
         plugin.setConfiguration(toJSON(settingsMap));
         pluginDao.saveOrUpdate(plugin);
+    }
+
+    public List<PluginInfo> pluginInfos(String type) {
+        return pluginInfoBuilder.allPluginInfos(type);
+    }
+
+    public PluginInfo pluginInfo(String pluginId) {
+        return pluginInfoBuilder.pluginInfoFor(pluginId);
     }
 
     private String toJSON(Map<String, String> settingsMap) {

--- a/server/src/com/thoughtworks/go/server/service/plugins/InvalidPluginTypeException.java
+++ b/server/src/com/thoughtworks/go/server/service/plugins/InvalidPluginTypeException.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2016 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.server.service.plugins;
+
+public class InvalidPluginTypeException extends RuntimeException {
+
+}

--- a/server/src/com/thoughtworks/go/server/service/plugins/builder/AuthenticationViewModelBuilder.java
+++ b/server/src/com/thoughtworks/go/server/service/plugins/builder/AuthenticationViewModelBuilder.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2016 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.server.service.plugins.builder;
+
+import com.thoughtworks.go.plugin.access.authentication.AuthenticationExtension;
+import com.thoughtworks.go.plugin.access.authentication.AuthenticationPluginRegistry;
+import com.thoughtworks.go.plugin.infra.PluginManager;
+import com.thoughtworks.go.plugin.infra.plugininfo.GoPluginDescriptor;
+import com.thoughtworks.go.server.ui.plugins.PluginInfo;
+
+import java.util.ArrayList;
+import java.util.List;
+
+class AuthenticationViewModelBuilder implements ViewModelBuilder {
+    private PluginManager pluginManager;
+    private AuthenticationPluginRegistry registry;
+
+    public AuthenticationViewModelBuilder(PluginManager manager, AuthenticationPluginRegistry registry) {
+        this.pluginManager = manager;
+        this.registry = registry;
+    }
+
+    public List<PluginInfo> allPluginInfos() {
+        List<PluginInfo> pluginInfos = new ArrayList<>();
+
+        for(String pluginId : registry.getAuthenticationPlugins()) {
+            GoPluginDescriptor descriptor = pluginManager.getPluginDescriptorFor(pluginId);
+
+            pluginInfos.add(new PluginInfo(pluginId, descriptor.about().name(), descriptor.about().version(),
+                    AuthenticationExtension.EXTENSION_NAME, null));
+        }
+        return pluginInfos;
+    }
+
+    public PluginInfo pluginInfoFor(String pluginId) {
+        if(!registry.getAuthenticationPlugins().contains(pluginId)) {
+            return null;
+        }
+
+        GoPluginDescriptor descriptor = pluginManager.getPluginDescriptorFor(pluginId);
+
+        return new PluginInfo(pluginId, descriptor.about().name(), descriptor.about().version(),
+                AuthenticationExtension.EXTENSION_NAME, null, null);
+    }
+}

--- a/server/src/com/thoughtworks/go/server/service/plugins/builder/NotificationViewModelBuilder.java
+++ b/server/src/com/thoughtworks/go/server/service/plugins/builder/NotificationViewModelBuilder.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2016 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.server.service.plugins.builder;
+
+import com.thoughtworks.go.plugin.access.notification.NotificationExtension;
+import com.thoughtworks.go.plugin.access.notification.NotificationPluginRegistry;
+import com.thoughtworks.go.plugin.infra.PluginManager;
+import com.thoughtworks.go.plugin.infra.plugininfo.GoPluginDescriptor;
+import com.thoughtworks.go.server.ui.plugins.PluginInfo;
+
+import java.util.ArrayList;
+import java.util.List;
+
+class NotificationViewModelBuilder implements ViewModelBuilder {
+    private PluginManager pluginManager;
+    private NotificationPluginRegistry notificationPluginRegistry;
+
+    public NotificationViewModelBuilder(PluginManager manager, NotificationPluginRegistry notificationPluginRegistry) {
+        this.pluginManager = manager;
+        this.notificationPluginRegistry = notificationPluginRegistry;
+    }
+
+    public List<PluginInfo> allPluginInfos() {
+        List<PluginInfo> pluginInfos = new ArrayList<>();
+
+        for(String pluginId : notificationPluginRegistry.getNotificationPlugins()) {
+            GoPluginDescriptor descriptor = pluginManager.getPluginDescriptorFor(pluginId);
+
+            pluginInfos.add(new PluginInfo(pluginId, descriptor.about().name(), descriptor.about().version(),
+                    NotificationExtension.EXTENSION_NAME, null));
+        }
+        return pluginInfos;
+    }
+
+    @Override
+    public PluginInfo pluginInfoFor(String pluginId) {
+        if(!notificationPluginRegistry.getNotificationPlugins().contains(pluginId)) {
+            return null;
+        }
+
+        GoPluginDescriptor descriptor = pluginManager.getPluginDescriptorFor(pluginId);
+
+        return new PluginInfo(pluginId, descriptor.about().name(), descriptor.about().version(),
+                NotificationExtension.EXTENSION_NAME, null);
+    }
+}

--- a/server/src/com/thoughtworks/go/server/service/plugins/builder/PackageViewModelBuilder.java
+++ b/server/src/com/thoughtworks/go/server/service/plugins/builder/PackageViewModelBuilder.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2016 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.server.service.plugins.builder;
+
+import com.thoughtworks.go.plugin.access.packagematerial.JsonBasedPackageRepositoryExtension;
+import com.thoughtworks.go.plugin.access.packagematerial.PackageConfiguration;
+import com.thoughtworks.go.plugin.access.packagematerial.PackageConfigurations;
+import com.thoughtworks.go.plugin.access.packagematerial.PackageMetadataStore;
+import com.thoughtworks.go.plugin.access.packagematerial.RepositoryMetadataStore;
+import com.thoughtworks.go.plugin.api.config.Property;
+import com.thoughtworks.go.plugin.infra.PluginManager;
+import com.thoughtworks.go.plugin.infra.plugininfo.GoPluginDescriptor;
+import com.thoughtworks.go.server.ui.plugins.PluginConfiguration;
+import com.thoughtworks.go.server.ui.plugins.PluggableInstanceSettings;
+import com.thoughtworks.go.server.ui.plugins.PluginInfo;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+class PackageViewModelBuilder implements ViewModelBuilder {
+    private PluginManager pluginManager;
+
+    public PackageViewModelBuilder(PluginManager manager) {
+        this.pluginManager = manager;
+    }
+
+    public List<PluginInfo> allPluginInfos() {
+        List<PluginInfo> pluginInfos = new ArrayList<>();
+
+        for(String pluginId : PackageMetadataStore.getInstance().pluginIds()) {
+            GoPluginDescriptor descriptor = pluginManager.getPluginDescriptorFor(pluginId);
+
+            pluginInfos.add(new PluginInfo(pluginId, descriptor.about().name(), descriptor.about().version(),
+                    JsonBasedPackageRepositoryExtension.EXTENSION_NAME, null));
+        }
+        return pluginInfos;
+    }
+
+    public PluginInfo pluginInfoFor(String pluginId) {
+        String PACKAGE_CONFIGRATION_TYPE = "package";
+        String REPOSITORY_CONFIGRATION_TYPE = "repository";
+
+        if(!PackageMetadataStore.getInstance().hasPreferenceFor(pluginId)) {
+            return null;
+        }
+
+        GoPluginDescriptor descriptor = pluginManager.getPluginDescriptorFor(pluginId);
+        ArrayList<PluginConfiguration> pluginConfigurations = new ArrayList<>();
+
+        pluginConfigurations.addAll(configurations(PackageMetadataStore.getInstance().getMetadata(pluginId), PACKAGE_CONFIGRATION_TYPE));
+        pluginConfigurations.addAll(configurations(RepositoryMetadataStore.getInstance().getMetadata(pluginId),  REPOSITORY_CONFIGRATION_TYPE));
+
+        return new PluginInfo(pluginId, descriptor.about().name(), descriptor.about().version(),
+                JsonBasedPackageRepositoryExtension.EXTENSION_NAME, null, new PluggableInstanceSettings(pluginConfigurations));
+    }
+
+    private List<PluginConfiguration> configurations(PackageConfigurations packageConfigurations, String type) {
+        ArrayList<PluginConfiguration> pluginConfigurations = new ArrayList<>();
+
+        for(PackageConfiguration configuration: packageConfigurations.list()) {
+            Map<String, Object> metaData = new HashMap<>();
+
+            metaData.put(REQUIRED_OPTION, configuration.getOption(Property.REQUIRED));
+            metaData.put(SECURE_OPTION, configuration.getOption(Property.SECURE));
+            metaData.put(PART_OF_IDENTITY_OPTION, configuration.getOption(Property.PART_OF_IDENTITY));
+
+            pluginConfigurations.add(new PluginConfiguration(configuration.getKey(), metaData, type));
+        }
+        return pluginConfigurations;
+    }
+}

--- a/server/src/com/thoughtworks/go/server/service/plugins/builder/PluggableTaskViewModelBuilder.java
+++ b/server/src/com/thoughtworks/go/server/service/plugins/builder/PluggableTaskViewModelBuilder.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2016 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.server.service.plugins.builder;
+
+import com.thoughtworks.go.plugin.access.pluggabletask.JsonBasedTaskExtension;
+import com.thoughtworks.go.plugin.access.pluggabletask.PluggableTaskConfigStore;
+import com.thoughtworks.go.plugin.access.pluggabletask.TaskPreference;
+import com.thoughtworks.go.plugin.api.config.Property;
+import com.thoughtworks.go.plugin.api.task.TaskConfig;
+import com.thoughtworks.go.plugin.infra.PluginManager;
+import com.thoughtworks.go.plugin.infra.plugininfo.GoPluginDescriptor;
+import com.thoughtworks.go.server.ui.plugins.PluginConfiguration;
+import com.thoughtworks.go.server.ui.plugins.PluggableInstanceSettings;
+import com.thoughtworks.go.server.ui.plugins.PluginInfo;
+import com.thoughtworks.go.server.ui.plugins.PluginView;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+class PluggableTaskViewModelBuilder implements ViewModelBuilder {
+    private PluginManager pluginManager;
+
+    public PluggableTaskViewModelBuilder(PluginManager manager) {
+        this.pluginManager = manager;
+    }
+
+    public List<PluginInfo> allPluginInfos() {
+        List<PluginInfo> pluginInfos = new ArrayList<>();
+
+        for(String pluginId : PluggableTaskConfigStore.store().pluginIds()) {
+            GoPluginDescriptor descriptor = pluginManager.getPluginDescriptorFor(pluginId);
+
+            TaskPreference taskPreference = PluggableTaskConfigStore.store().preferenceFor(pluginId);
+
+            pluginInfos.add(new PluginInfo(pluginId, descriptor.about().name(), descriptor.about().version(),
+                    JsonBasedTaskExtension.TASK_EXTENSION, taskPreference.getView().displayValue()));
+        }
+        return pluginInfos;
+    }
+
+    public PluginInfo pluginInfoFor(String pluginId) {
+        if(!PluggableTaskConfigStore.store().hasPreferenceFor(pluginId)) {
+            return null;
+        }
+
+        GoPluginDescriptor descriptor = pluginManager.getPluginDescriptorFor(pluginId);
+        TaskPreference taskPreference = PluggableTaskConfigStore.store().preferenceFor(pluginId);
+
+        List<PluginConfiguration> pluginConfigurations = configurations(taskPreference.getConfig());
+        PluginView pluginView = new PluginView(taskPreference.getView().template());
+
+        return new PluginInfo(pluginId, descriptor.about().name(), descriptor.about().version(), JsonBasedTaskExtension.TASK_EXTENSION,
+                taskPreference.getView().displayValue(), new PluggableInstanceSettings(pluginConfigurations, pluginView));
+    }
+
+    private List<PluginConfiguration> configurations(TaskConfig config) {
+        ArrayList<PluginConfiguration> pluginConfigurations = new ArrayList<>();
+
+        for(Property property: config.list()) {
+            Map<String, Object> metaData = new HashMap<>();
+            metaData.put(REQUIRED_OPTION, property.getOption(Property.REQUIRED));
+            metaData.put(SECURE_OPTION, property.getOption(Property.SECURE));
+
+            pluginConfigurations.add(new PluginConfiguration(property.getKey(), metaData));
+        }
+        return pluginConfigurations;
+    }
+}

--- a/server/src/com/thoughtworks/go/server/service/plugins/builder/PluginInfoBuilder.java
+++ b/server/src/com/thoughtworks/go/server/service/plugins/builder/PluginInfoBuilder.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2016 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.server.service.plugins.builder;
+
+import com.thoughtworks.go.plugin.access.authentication.AuthenticationExtension;
+import com.thoughtworks.go.plugin.access.authentication.AuthenticationPluginRegistry;
+import com.thoughtworks.go.plugin.access.notification.NotificationExtension;
+import com.thoughtworks.go.plugin.access.notification.NotificationPluginRegistry;
+import com.thoughtworks.go.plugin.access.packagematerial.JsonBasedPackageRepositoryExtension;
+import com.thoughtworks.go.plugin.access.pluggabletask.JsonBasedTaskExtension;
+import com.thoughtworks.go.plugin.access.scm.SCMExtension;
+import com.thoughtworks.go.plugin.infra.PluginManager;
+import com.thoughtworks.go.server.service.plugins.InvalidPluginTypeException;
+import com.thoughtworks.go.server.ui.plugins.PluginInfo;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Component
+public class PluginInfoBuilder {
+
+    private Map<String, ViewModelBuilder> pluginExtensionToBuilder = new HashMap<>();
+
+    @Autowired
+    public PluginInfoBuilder(AuthenticationPluginRegistry authenticationPluginRegistry, NotificationPluginRegistry notificationPluginRegistry, PluginManager pluginManager) {
+        pluginExtensionToBuilder.put(AuthenticationExtension.EXTENSION_NAME, new AuthenticationViewModelBuilder(pluginManager, authenticationPluginRegistry));
+        pluginExtensionToBuilder.put(NotificationExtension.EXTENSION_NAME, new NotificationViewModelBuilder(pluginManager, notificationPluginRegistry));
+        pluginExtensionToBuilder.put(JsonBasedPackageRepositoryExtension.EXTENSION_NAME, new PackageViewModelBuilder(pluginManager));
+        pluginExtensionToBuilder.put(JsonBasedTaskExtension.TASK_EXTENSION, new PluggableTaskViewModelBuilder(pluginManager));
+        pluginExtensionToBuilder.put(SCMExtension.EXTENSION_NAME, new SCMViewModelBuilder(pluginManager));
+    }
+
+    public List<PluginInfo> allPluginInfos(String type) {
+        List<PluginInfo> plugins = new ArrayList<>();
+
+        if (type != null) {
+            if (!pluginExtensionToBuilder.containsKey(type)) {
+                throw new InvalidPluginTypeException();
+            }
+
+            return pluginExtensionToBuilder.get(type).allPluginInfos();
+        }
+
+        for (ViewModelBuilder builder : pluginExtensionToBuilder.values()) {
+            plugins.addAll(builder.allPluginInfos());
+        }
+
+        return plugins;
+    }
+
+    public PluginInfo pluginInfoFor(String pluginId) {
+        for (ViewModelBuilder builder : pluginExtensionToBuilder.values()) {
+            PluginInfo pluginInfo = builder.pluginInfoFor(pluginId);
+
+            if(pluginInfo != null) {
+                return pluginInfo;
+            }
+        }
+        return null;
+    }
+}

--- a/server/src/com/thoughtworks/go/server/service/plugins/builder/SCMViewModelBuilder.java
+++ b/server/src/com/thoughtworks/go/server/service/plugins/builder/SCMViewModelBuilder.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2016 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.server.service.plugins.builder;
+
+import com.thoughtworks.go.plugin.access.scm.SCMConfiguration;
+import com.thoughtworks.go.plugin.access.scm.SCMConfigurations;
+import com.thoughtworks.go.plugin.access.scm.SCMExtension;
+import com.thoughtworks.go.plugin.access.scm.SCMMetadataStore;
+import com.thoughtworks.go.plugin.access.scm.SCMPreference;
+import com.thoughtworks.go.plugin.api.config.Property;
+import com.thoughtworks.go.plugin.infra.PluginManager;
+import com.thoughtworks.go.plugin.infra.plugininfo.GoPluginDescriptor;
+import com.thoughtworks.go.server.ui.plugins.PluginConfiguration;
+import com.thoughtworks.go.server.ui.plugins.PluggableInstanceSettings;
+import com.thoughtworks.go.server.ui.plugins.PluginInfo;
+import com.thoughtworks.go.server.ui.plugins.PluginView;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+class SCMViewModelBuilder implements ViewModelBuilder {
+    private PluginManager pluginManager;
+
+    public SCMViewModelBuilder(PluginManager manager) {
+        this.pluginManager = manager;
+    }
+
+    public List<PluginInfo> allPluginInfos() {
+        List<PluginInfo> pluginInfos = new ArrayList<>();
+
+        for(String pluginId : SCMMetadataStore.getInstance().pluginIds()) {
+            GoPluginDescriptor descriptor = pluginManager.getPluginDescriptorFor(pluginId);
+
+            SCMPreference scmPreference = SCMMetadataStore.getInstance().preferenceFor(pluginId);
+
+            pluginInfos.add(new PluginInfo(pluginId, descriptor.about().name(), descriptor.about().version(),
+                    SCMExtension.EXTENSION_NAME, scmPreference.getScmView().displayValue()));
+        }
+        return pluginInfos;
+    }
+
+    public PluginInfo pluginInfoFor(String pluginId) {
+        if(!SCMMetadataStore.getInstance().hasPreferenceFor(pluginId)) {
+            return null;
+        }
+
+        GoPluginDescriptor descriptor = pluginManager.getPluginDescriptorFor(pluginId);
+        SCMPreference scmPreference = SCMMetadataStore.getInstance().preferenceFor(pluginId);
+
+        List<PluginConfiguration> pluginConfigurations = configurations(scmPreference.getScmConfigurations());
+        PluginView pluginView = new PluginView(scmPreference.getScmView().template());
+
+        return new PluginInfo(pluginId, descriptor.about().name(), descriptor.about().version(), SCMExtension.EXTENSION_NAME,
+                scmPreference.getScmView().displayValue(), new PluggableInstanceSettings(pluginConfigurations, pluginView));
+    }
+
+    private List<PluginConfiguration> configurations(SCMConfigurations scmConfigurations) {
+        List<PluginConfiguration> pluginConfigurations = new ArrayList<>();
+
+        for(SCMConfiguration configuration : scmConfigurations.list()) {
+            Map<String, Object> metaData = new HashMap<>();
+            metaData.put(REQUIRED_OPTION, configuration.getOption(Property.REQUIRED));
+            metaData.put(SECURE_OPTION, configuration.getOption(Property.SECURE));
+            metaData.put(PART_OF_IDENTITY_OPTION, configuration.getOption(Property.PART_OF_IDENTITY));
+
+            pluginConfigurations.add(new PluginConfiguration(configuration.getKey(), metaData));
+        }
+        return pluginConfigurations;
+    }
+}

--- a/server/src/com/thoughtworks/go/server/service/plugins/builder/ViewModelBuilder.java
+++ b/server/src/com/thoughtworks/go/server/service/plugins/builder/ViewModelBuilder.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2016 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.server.service.plugins.builder;
+
+import com.thoughtworks.go.server.ui.plugins.PluginInfo;
+
+import java.util.List;
+
+interface ViewModelBuilder {
+    String REQUIRED_OPTION = "required";
+    String SECURE_OPTION = "secure";
+    String PART_OF_IDENTITY_OPTION = "part_of_identity";
+
+    List<PluginInfo> allPluginInfos();
+
+    PluginInfo pluginInfoFor(String pluginId);
+}

--- a/server/src/com/thoughtworks/go/server/ui/plugins/PluggableInstanceSettings.java
+++ b/server/src/com/thoughtworks/go/server/ui/plugins/PluggableInstanceSettings.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2016 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.server.ui.plugins;
+
+import java.util.List;
+
+public class PluggableInstanceSettings {
+    private final List<PluginConfiguration> configurations;
+    private final PluginView view;
+
+    public PluggableInstanceSettings(List<PluginConfiguration> pluginConfigurations, PluginView pluginView) {
+        this.configurations = pluginConfigurations;
+        this.view = pluginView;
+    }
+
+    public PluggableInstanceSettings(List<PluginConfiguration> pluginConfigurations) {
+        this(pluginConfigurations, null);
+    }
+
+    public List<PluginConfiguration> getConfigurations() {
+        return configurations;
+    }
+
+    public PluginView getView() {
+        return view;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        PluggableInstanceSettings that = (PluggableInstanceSettings) o;
+
+        if (configurations != null ? !configurations.equals(that.configurations) : that.configurations != null)
+            return false;
+        return view != null ? view.equals(that.view) : that.view == null;
+
+    }
+
+    @Override
+    public int hashCode() {
+        int result = configurations != null ? configurations.hashCode() : 0;
+        result = 31 * result + (view != null ? view.hashCode() : 0);
+        return result;
+    }
+}

--- a/server/src/com/thoughtworks/go/server/ui/plugins/PluginConfiguration.java
+++ b/server/src/com/thoughtworks/go/server/ui/plugins/PluginConfiguration.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2016 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.server.ui.plugins;
+
+import java.util.Map;
+
+public class PluginConfiguration {
+    private final String key;
+    private final Map<String, Object> metadata;
+    private final String type;
+
+    public PluginConfiguration(String key, Map<String, Object> metadata, String type) {
+        this.key = key;
+        this.metadata = metadata;
+        this.type = type;
+    }
+
+    public PluginConfiguration(String key, Map<String, Object> metadata) {
+        this(key, metadata, null);
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public Map<String, Object> getMetadata() {
+        return metadata;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        PluginConfiguration that = (PluginConfiguration) o;
+
+        if (key != null ? !key.equals(that.key) : that.key != null) return false;
+        if (metadata != null ? !metadata.equals(that.metadata) : that.metadata != null) return false;
+        return type != null ? type.equals(that.type) : that.type == null;
+
+    }
+
+    @Override
+    public int hashCode() {
+        int result = key != null ? key.hashCode() : 0;
+        result = 31 * result + (metadata != null ? metadata.hashCode() : 0);
+        result = 31 * result + (type != null ? type.hashCode() : 0);
+        return result;
+    }
+}

--- a/server/src/com/thoughtworks/go/server/ui/plugins/PluginInfo.java
+++ b/server/src/com/thoughtworks/go/server/ui/plugins/PluginInfo.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2016 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.server.ui.plugins;
+
+public class PluginInfo {
+    private final String id;
+    private final String name;
+    private final String version;
+    private final String type;
+    private final String displayName;
+    private final PluggableInstanceSettings pluggableInstanceSettings;
+
+    public PluginInfo(String id, String name, String version, String type, String displayName, PluggableInstanceSettings settings) {
+        this.id = id;
+        this.name = name;
+        this.version = version;
+        this.type = type;
+        this.displayName = displayName;
+        this.pluggableInstanceSettings = settings;
+    }
+
+    public PluginInfo(String id, String name, String version, String type, String displayName) {
+        this(id, name, version, type, displayName, null);
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getVersion() {
+        return version;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public PluggableInstanceSettings getPluggableInstanceSettings() {
+        return pluggableInstanceSettings;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        PluginInfo that = (PluginInfo) o;
+
+        if (id != null ? !id.equals(that.id) : that.id != null) return false;
+        if (name != null ? !name.equals(that.name) : that.name != null) return false;
+        if (version != null ? !version.equals(that.version) : that.version != null) return false;
+        if (type != null ? !type.equals(that.type) : that.type != null) return false;
+        if (displayName != null ? !displayName.equals(that.displayName) : that.displayName != null) return false;
+        return pluggableInstanceSettings != null ? pluggableInstanceSettings.equals(that.pluggableInstanceSettings) : that.pluggableInstanceSettings == null;
+
+    }
+
+    @Override
+    public int hashCode() {
+        int result = id != null ? id.hashCode() : 0;
+        result = 31 * result + (name != null ? name.hashCode() : 0);
+        result = 31 * result + (version != null ? version.hashCode() : 0);
+        result = 31 * result + (type != null ? type.hashCode() : 0);
+        result = 31 * result + (displayName != null ? displayName.hashCode() : 0);
+        result = 31 * result + (pluggableInstanceSettings != null ? pluggableInstanceSettings.hashCode() : 0);
+        return result;
+    }
+}

--- a/server/src/com/thoughtworks/go/server/ui/plugins/PluginView.java
+++ b/server/src/com/thoughtworks/go/server/ui/plugins/PluginView.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2016 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.server.ui.plugins;
+
+public class PluginView {
+    private final String template;
+
+
+    public PluginView(String template) {
+        this.template = template;
+    }
+
+    public String getTemplate() {
+        return template;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        PluginView that = (PluginView) o;
+
+        return template != null ? template.equals(that.template) : that.template == null;
+
+    }
+
+    @Override
+    public int hashCode() {
+        return template != null ? template.hashCode() : 0;
+    }
+}

--- a/server/test/unit/com/thoughtworks/go/server/service/plugins/builder/AuthenticationViewModelBuilderTest.java
+++ b/server/test/unit/com/thoughtworks/go/server/service/plugins/builder/AuthenticationViewModelBuilderTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2016 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.server.service.plugins.builder;
+
+import com.thoughtworks.go.plugin.access.authentication.AuthenticationPluginRegistry;
+import com.thoughtworks.go.plugin.infra.PluginManager;
+import com.thoughtworks.go.plugin.infra.plugininfo.GoPluginDescriptor;
+import com.thoughtworks.go.server.ui.plugins.PluginInfo;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+
+import static junit.framework.TestCase.assertNull;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+public class AuthenticationViewModelBuilderTest {
+    @Mock
+    AuthenticationPluginRegistry registry;
+
+    @Mock
+    PluginManager manager;
+
+    private AuthenticationViewModelBuilder builder;
+    private GoPluginDescriptor githubDescriptor;
+    private GoPluginDescriptor googleDescriptor;
+
+    @Before
+    public void setUp() {
+        initMocks(this);
+        builder = new AuthenticationViewModelBuilder(manager, registry);
+        githubDescriptor = new GoPluginDescriptor("github.oauth", "version1",
+                new GoPluginDescriptor.About("Github OAuth Plugin", "1.0", null, null, null,null),
+                null, null, false);
+
+        googleDescriptor = new GoPluginDescriptor("google.oauth", "version1",
+                new GoPluginDescriptor.About("auth_plugin", "2.0", null, null, null,null),
+                null, null, false);
+    }
+
+    @Test
+    public void shouldBeAbleToFetchAllPluginInfos() {
+        HashSet<String> pluginIds = new HashSet<>(Arrays.asList("github.oauth", "google.oauth"));
+
+        when(registry.getAuthenticationPlugins()).thenReturn(pluginIds);
+        when(manager.getPluginDescriptorFor("github.oauth")).thenReturn(githubDescriptor);
+        when(manager.getPluginDescriptorFor("google.oauth")).thenReturn(googleDescriptor);
+
+        List<PluginInfo> pluginInfos = builder.allPluginInfos();
+
+        assertThat(pluginInfos.size(), is(2));
+        PluginInfo pluginInfo = pluginInfos.get(0).getId() == "github.oauth" ? pluginInfos.get(0) : pluginInfos.get(1);
+        assertThat(pluginInfo.getId(), is("github.oauth"));
+        assertThat(pluginInfo.getType(), is("authentication"));
+        assertThat(pluginInfo.getName(), is(githubDescriptor.about().name()));
+        assertThat(pluginInfo.getVersion(), is(githubDescriptor.about().version()));
+        assertNull(pluginInfo.getPluggableInstanceSettings());
+    }
+
+    @Test
+    public void shouldBeAbleToFetchAPluginInfoForAGivenId() {
+        HashSet<String> pluginIds = new HashSet<>(Arrays.asList("github.oauth", "google.oauth"));
+
+        when(registry.getAuthenticationPlugins()).thenReturn(pluginIds);
+        when(manager.getPluginDescriptorFor("github.oauth")).thenReturn(githubDescriptor);
+
+        PluginInfo pluginInfo = builder.pluginInfoFor("github.oauth");
+
+        assertThat(pluginInfo.getId(), is("github.oauth"));
+        assertThat(pluginInfo.getType(), is("authentication"));
+        assertThat(pluginInfo.getName(), is(githubDescriptor.about().name()));
+        assertThat(pluginInfo.getVersion(), is(githubDescriptor.about().version()));
+        assertNull(pluginInfo.getPluggableInstanceSettings());
+    }
+
+    @Test
+    public void shouldBeNullIfPluginNotRegistered() {
+        HashSet<String> pluginIds = new HashSet<>(Arrays.asList("github.oauth", "google.oauth"));
+        when(registry.getAuthenticationPlugins()).thenReturn(pluginIds);
+
+        assertNull(builder.pluginInfoFor("unregistered_plugin"));
+    }
+}

--- a/server/test/unit/com/thoughtworks/go/server/service/plugins/builder/NotificationViewModelBuilderTest.java
+++ b/server/test/unit/com/thoughtworks/go/server/service/plugins/builder/NotificationViewModelBuilderTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2016 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.server.service.plugins.builder;
+
+import com.thoughtworks.go.plugin.access.notification.NotificationPluginRegistry;
+import com.thoughtworks.go.plugin.infra.PluginManager;
+import com.thoughtworks.go.plugin.infra.plugininfo.GoPluginDescriptor;
+import com.thoughtworks.go.server.ui.plugins.PluginInfo;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+
+import static junit.framework.TestCase.assertNull;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+public class NotificationViewModelBuilderTest {
+    @Mock
+    NotificationPluginRegistry registry;
+
+    @Mock
+    PluginManager manager;
+
+    private NotificationViewModelBuilder builder;
+    private GoPluginDescriptor emailNotifier;
+    private GoPluginDescriptor slackNotifier;
+
+    @Before
+    public void setUp() {
+        initMocks(this);
+        builder = new NotificationViewModelBuilder(manager, registry);
+        emailNotifier = new GoPluginDescriptor("email.notifier", "version1",
+                new GoPluginDescriptor.About("Email Notifier", "1.0", null, null, null,null),
+                null, null, false);
+
+        slackNotifier = new GoPluginDescriptor("slack.notifier", "version1",
+                new GoPluginDescriptor.About("Slack Notifier", "2.0", null, null, null,null),
+                null, null, false);
+    }
+
+    @Test
+    public void shouldBeAbleToFetchAllPluginInfos() {
+        HashSet<String> pluginIds = new HashSet<>(Arrays.asList("email.notifier", "slack.notifier"));
+
+        when(registry.getNotificationPlugins()).thenReturn(pluginIds);
+        when(manager.getPluginDescriptorFor("email.notifier")).thenReturn(emailNotifier);
+        when(manager.getPluginDescriptorFor("slack.notifier")).thenReturn(slackNotifier);
+
+        List<PluginInfo> pluginInfos = builder.allPluginInfos();
+
+        assertThat(pluginInfos.size(), is(2));
+        PluginInfo pluginInfo = pluginInfos.get(0).getId() == "email.notifier" ? pluginInfos.get(0) : pluginInfos.get(1);
+        assertThat(pluginInfo.getId(), is("email.notifier"));
+        assertThat(pluginInfo.getType(), is("notification"));
+        assertThat(pluginInfo.getName(), is(emailNotifier.about().name()));
+        assertThat(pluginInfo.getVersion(), is(emailNotifier.about().version()));
+        assertNull(pluginInfo.getPluggableInstanceSettings());
+    }
+
+    @Test
+    public void shouldBeAbleToFetchAPluginInfoForAGivenId() {
+        HashSet<String> pluginIds = new HashSet<>(Arrays.asList("email.notifier", "slack.notifier"));
+
+        when(registry.getNotificationPlugins()).thenReturn(pluginIds);
+        when(manager.getPluginDescriptorFor("email.notifier")).thenReturn(emailNotifier);
+        ;
+
+        PluginInfo pluginInfo = builder.pluginInfoFor("email.notifier");
+
+        assertThat(pluginInfo.getId(), is("email.notifier"));
+        assertThat(pluginInfo.getType(), is("notification"));
+        assertThat(pluginInfo.getName(), is(emailNotifier.about().name()));
+        assertThat(pluginInfo.getVersion(), is(emailNotifier.about().version()));
+        assertNull(pluginInfo.getPluggableInstanceSettings());
+    }
+
+    @Test
+    public void shouldBeNullIfPluginNotRegistered() {
+        HashSet<String> pluginIds = new HashSet<>(Arrays.asList("email.notifier", "slack.notifier"));
+
+        when(registry.getNotificationPlugins()).thenReturn(pluginIds);
+
+        assertNull(builder.pluginInfoFor("unregistered_plugin"));
+    }
+}

--- a/server/test/unit/com/thoughtworks/go/server/service/plugins/builder/PackageViewModelBuilderTest.java
+++ b/server/test/unit/com/thoughtworks/go/server/service/plugins/builder/PackageViewModelBuilderTest.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2016 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.server.service.plugins.builder;
+
+import com.thoughtworks.go.plugin.access.packagematerial.PackageConfiguration;
+import com.thoughtworks.go.plugin.access.packagematerial.PackageConfigurations;
+import com.thoughtworks.go.plugin.access.packagematerial.PackageMetadataStore;
+import com.thoughtworks.go.plugin.access.packagematerial.RepositoryMetadataStore;
+import com.thoughtworks.go.plugin.infra.PluginManager;
+import com.thoughtworks.go.plugin.infra.plugininfo.GoPluginDescriptor;
+import com.thoughtworks.go.server.ui.plugins.PluginConfiguration;
+import com.thoughtworks.go.server.ui.plugins.PluginInfo;
+import org.hamcrest.core.Is;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static junit.framework.TestCase.assertNull;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+public class PackageViewModelBuilderTest {
+    @Mock
+    PluginManager manager;
+
+    private PackageViewModelBuilder builder;
+    private GoPluginDescriptor yumPoller;
+    private GoPluginDescriptor npmPoller;
+
+    @Before
+    public void setUp() {
+        initMocks(this);
+        builder = new PackageViewModelBuilder(manager);
+        yumPoller = new GoPluginDescriptor("yum.poller", "version1",
+                                           new GoPluginDescriptor.About("Yum Poller", "1.0", null, null, null,null),
+                                           null, null, false);
+
+        npmPoller = new GoPluginDescriptor("npm.poller", "version1",
+                                           new GoPluginDescriptor.About("NPM Poller", "2.0", null, null, null,null),
+                                           null, null, false);
+
+        PackageConfigurations packageConfigurations = new PackageConfigurations();
+        packageConfigurations.add(new PackageConfiguration("key1"));
+        packageConfigurations.add(new PackageConfiguration("key2"));
+
+        PackageConfigurations repositoryConfigurations = new PackageConfigurations();
+        repositoryConfigurations.add(new PackageConfiguration("key1"));
+
+        PackageMetadataStore.getInstance().addMetadataFor(yumPoller.id(), packageConfigurations);
+        PackageMetadataStore.getInstance().addMetadataFor(npmPoller.id(), new PackageConfigurations());
+
+        RepositoryMetadataStore.getInstance().addMetadataFor(yumPoller.id(), repositoryConfigurations);
+    }
+
+    @Test
+    public void shouldBeAbleToFetchAllPluginInfos() {
+        when(manager.getPluginDescriptorFor("yum.poller")).thenReturn(yumPoller);
+        when(manager.getPluginDescriptorFor("npm.poller")).thenReturn(npmPoller);
+
+        List<PluginInfo> pluginInfos = builder.allPluginInfos();
+
+        assertThat(pluginInfos.size(), is(2));
+        PluginInfo pluginInfo = pluginInfos.get(0).getId() == "yum.poller" ? pluginInfos.get(0) : pluginInfos.get(1);
+        assertThat(pluginInfo.getId(), is("yum.poller"));
+        assertThat(pluginInfo.getType(), is("package-repository"));
+        assertThat(pluginInfo.getName(), is(yumPoller.about().name()));
+        assertThat(pluginInfo.getVersion(), is(yumPoller.about().version()));
+        assertNull(pluginInfo.getPluggableInstanceSettings());
+    }
+
+    @Test
+    public void shouldBeAbleToFetchAPluginInfoForAGivenId() {
+        when(manager.getPluginDescriptorFor("yum.poller")).thenReturn(yumPoller);
+
+        PluginInfo pluginInfo = builder.pluginInfoFor("yum.poller");
+
+        assertThat(pluginInfo.getId(), is("yum.poller"));
+        assertThat(pluginInfo.getType(), is("package-repository"));
+        assertThat(pluginInfo.getName(), is(yumPoller.about().name()));
+        assertThat(pluginInfo.getVersion(), is(yumPoller.about().version()));
+        assertNull(pluginInfo.getPluggableInstanceSettings().getView());
+    }
+
+    @Test
+    public void shouldBeAbleToFetchAPluginInfoForAGivenIdWithConfigurations() {
+        when(manager.getPluginDescriptorFor("yum.poller")).thenReturn(yumPoller);
+
+        PluginInfo pluginInfo = builder.pluginInfoFor("yum.poller");
+
+        HashMap expectedMetadata = new HashMap<String, Object>() {{
+            put("required",true);
+            put("secure",false);
+            put("part_of_identity",true);
+        }};
+
+        List<PluginConfiguration> configurations = pluginInfo.getPluggableInstanceSettings().getConfigurations();
+        assertThat(configurations.size(), is(3));
+
+        PluginConfiguration configuration2 = configurations.get(0);
+        assertThat(configuration2.getKey(), is("key1"));
+        assertThat(configuration2.getType(), is("package"));
+        assertThat(configuration2.getMetadata(), Is.<Map<String, Object>>is(expectedMetadata));
+
+        PluginConfiguration configuration3 = configurations.get(1);
+        assertThat(configuration3.getKey(), is("key2"));
+        assertThat(configuration3.getType(), is("package"));
+        assertThat(configuration3.getMetadata(), Is.<Map<String, Object>>is(expectedMetadata));
+
+        PluginConfiguration configuration1 = configurations.get(2);
+        assertThat(configuration1.getKey(), is("key1"));
+        assertThat(configuration1.getType(), is("repository"));
+        assertThat(configuration1.getMetadata(), Is.<Map<String, Object>>is(expectedMetadata));
+    }
+
+    @Test
+    public void shouldBeNullIfPluginNotRegistered() {
+        assertNull(builder.pluginInfoFor("unregistered_plugin"));
+    }
+}

--- a/server/test/unit/com/thoughtworks/go/server/service/plugins/builder/PluggableTaskViewModelBuilderTest.java
+++ b/server/test/unit/com/thoughtworks/go/server/service/plugins/builder/PluggableTaskViewModelBuilderTest.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright 2016 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.server.service.plugins.builder;
+
+import com.thoughtworks.go.plugin.access.pluggabletask.JsonBasedPluggableTask;
+import com.thoughtworks.go.plugin.access.pluggabletask.PluggableTaskConfigStore;
+import com.thoughtworks.go.plugin.access.pluggabletask.TaskPreference;
+import com.thoughtworks.go.plugin.api.task.Task;
+import com.thoughtworks.go.plugin.api.task.TaskConfig;
+import com.thoughtworks.go.plugin.api.task.TaskConfigProperty;
+import com.thoughtworks.go.plugin.api.task.TaskView;
+import com.thoughtworks.go.plugin.infra.PluginManager;
+import com.thoughtworks.go.plugin.infra.plugininfo.GoPluginDescriptor;
+import com.thoughtworks.go.server.ui.plugins.PluginConfiguration;
+import com.thoughtworks.go.server.ui.plugins.PluginInfo;
+import com.thoughtworks.go.server.ui.plugins.PluginView;
+import org.hamcrest.core.Is;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static junit.framework.TestCase.assertNull;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+public class PluggableTaskViewModelBuilderTest {
+    @Mock
+    PluginManager manager;
+
+    private PluggableTaskViewModelBuilder builder;
+    private GoPluginDescriptor xunitConvertor;
+    private GoPluginDescriptor powershellTask;
+    private TaskPreference taskPreference;
+
+    @Before
+    public void setUp() {
+        initMocks(this);
+        builder = new PluggableTaskViewModelBuilder(manager);
+
+        xunitConvertor = new GoPluginDescriptor("xunit.convertor", "version1",
+                new GoPluginDescriptor.About("Xunit Convertor", "1.0", null, null, null,null),
+                null, null, false);
+
+        powershellTask = new GoPluginDescriptor("powershell.task", "version1",
+                new GoPluginDescriptor.About("Powershell Task", "2.0", null, null, null,null),
+                null, null, false);
+
+        JsonBasedPluggableTask jsonBasedPluggableTask = mock(JsonBasedPluggableTask.class);
+        TaskView taskView = new TaskView() {
+            @Override
+            public String displayValue() {
+                return "task display value";
+            }
+
+            @Override
+            public String template() {
+                return "pluggable task view template";
+            }
+        };
+
+        TaskConfig taskConfig = new TaskConfig();
+        taskConfig.add(new TaskConfigProperty("key1", null));
+        taskConfig.add(new TaskConfigProperty("key2", null));
+
+        when(jsonBasedPluggableTask.config()).thenReturn(taskConfig);
+        when(jsonBasedPluggableTask.view()).thenReturn(taskView);
+
+        taskPreference = new TaskPreference(jsonBasedPluggableTask);
+
+        PluggableTaskConfigStore.store().setPreferenceFor("xunit.convertor", taskPreference);
+        PluggableTaskConfigStore.store().setPreferenceFor("powershell.task", taskPreference);
+    }
+
+    @Test
+    public void shouldBeAbleToFetchAllPluginInfos() {
+        when(manager.getPluginDescriptorFor("xunit.convertor")).thenReturn(xunitConvertor);
+        when(manager.getPluginDescriptorFor("powershell.task")).thenReturn(powershellTask);
+
+        List<PluginInfo> pluginInfos = builder.allPluginInfos();
+
+        assertThat(pluginInfos.size(), is(2));
+        PluginInfo pluginInfo = pluginInfos.get(0).getId() == "xunit.convertor" ? pluginInfos.get(0) : pluginInfos.get(1);
+        assertThat(pluginInfo.getId(), is("xunit.convertor"));
+        assertThat(pluginInfo.getType(), is("task"));
+        assertThat(pluginInfo.getName(), is(xunitConvertor.about().name()));
+        assertThat(pluginInfo.getDisplayName(), is("task display value"));
+        assertThat(pluginInfo.getVersion(), is(xunitConvertor.about().version()));
+        assertNull(pluginInfo.getPluggableInstanceSettings());
+    }
+
+    @Test
+    public void shouldBeAbleToFetchAPluginInfoForAGivenId() {
+        when(manager.getPluginDescriptorFor("xunit.convertor")).thenReturn(xunitConvertor);
+
+        PluginInfo pluginInfo = builder.pluginInfoFor("xunit.convertor");
+
+        assertThat(pluginInfo.getId(), is("xunit.convertor"));
+        assertThat(pluginInfo.getType(), is("task"));
+        assertThat(pluginInfo.getName(), is(xunitConvertor.about().name()));
+        assertThat(pluginInfo.getDisplayName(), is("task display value"));
+        assertThat(pluginInfo.getVersion(), is(xunitConvertor.about().version()));
+    }
+
+    @Test
+    public void shouldBeAbleToFetchAPluginInfoForAGivenIdWithView() {
+        when(manager.getPluginDescriptorFor("xunit.convertor")).thenReturn(xunitConvertor);
+
+        PluginInfo pluginInfo = builder.pluginInfoFor("xunit.convertor");
+
+        PluginView view = pluginInfo.getPluggableInstanceSettings().getView();
+        assertThat(view.getTemplate(), is("pluggable task view template"));
+    }
+
+    @Test
+    public void shouldBeAbleToFetchAPluginInfoForAGivenIdWithConfigurations() {
+        when(manager.getPluginDescriptorFor("xunit.convertor")).thenReturn(xunitConvertor);
+
+        PluginInfo pluginInfo = builder.pluginInfoFor("xunit.convertor");
+
+        HashMap expectedMetadata = new HashMap<String, Object>() {{
+            put("required",false);
+            put("secure",false);
+        }};
+
+        List<PluginConfiguration> configurations = pluginInfo.getPluggableInstanceSettings().getConfigurations();
+        assertThat(configurations.size(), is(2));
+
+        PluginConfiguration configuration1 = configurations.get(0);
+        assertThat(configuration1.getKey(), is("key1"));
+        assertNull(configuration1.getType());
+        assertThat(configuration1.getMetadata(), Is.<Map<String, Object>>is(expectedMetadata));
+
+
+        PluginConfiguration configuration2 = configurations.get(1);
+        assertThat(configuration2.getKey(), is("key2"));
+        assertNull(configuration2.getType());
+        assertThat(configuration1.getMetadata(), Is.<Map<String, Object>>is(expectedMetadata));
+    }
+
+    @Test
+    public void shouldBeNullIfPluginNotRegistered() {
+        assertNull(builder.pluginInfoFor("unregistered_plugin"));
+    }
+}

--- a/server/test/unit/com/thoughtworks/go/server/service/plugins/builder/PluginInfoBuilderTest.java
+++ b/server/test/unit/com/thoughtworks/go/server/service/plugins/builder/PluginInfoBuilderTest.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright 2016 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.server.service.plugins.builder;
+
+import com.thoughtworks.go.plugin.access.authentication.AuthenticationPluginRegistry;
+import com.thoughtworks.go.plugin.access.notification.NotificationPluginRegistry;
+import com.thoughtworks.go.plugin.access.packagematerial.PackageConfigurations;
+import com.thoughtworks.go.plugin.access.packagematerial.PackageMetadataStore;
+import com.thoughtworks.go.plugin.access.pluggabletask.JsonBasedPluggableTask;
+import com.thoughtworks.go.plugin.access.pluggabletask.PluggableTaskConfigStore;
+import com.thoughtworks.go.plugin.access.pluggabletask.TaskPreference;
+import com.thoughtworks.go.plugin.access.scm.SCMConfigurations;
+import com.thoughtworks.go.plugin.access.scm.SCMMetadataStore;
+import com.thoughtworks.go.plugin.access.scm.SCMPreference;
+import com.thoughtworks.go.plugin.access.scm.SCMView;
+import com.thoughtworks.go.plugin.api.task.Task;
+import com.thoughtworks.go.plugin.api.task.TaskView;
+import com.thoughtworks.go.plugin.infra.PluginManager;
+import com.thoughtworks.go.plugin.infra.plugininfo.GoPluginDescriptor;
+import com.thoughtworks.go.server.service.plugins.InvalidPluginTypeException;
+import com.thoughtworks.go.server.ui.plugins.PluginInfo;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+public class PluginInfoBuilderTest {
+    @Mock
+    AuthenticationPluginRegistry authenticationPluginRegistry;
+
+    @Mock
+    NotificationPluginRegistry notificationPluginRegistry;
+
+    @Mock
+    PluginManager manager;
+
+    private GoPluginDescriptor githubDescriptor;
+    private GoPluginDescriptor emailNotifier;
+    private GoPluginDescriptor yumPoller;
+    private GoPluginDescriptor xunitConvertor;
+    private GoPluginDescriptor githubPR;
+    private PluginInfoBuilder pluginViewModelBuilder;
+
+    @Before
+    public void setUp() {
+        initMocks(this);
+        githubDescriptor = new GoPluginDescriptor("github.oauth", "version1",
+                new GoPluginDescriptor.About("Github OAuth Plugin", "1.0", null, null, null,null),
+                null, null, false);
+        emailNotifier = new GoPluginDescriptor("email.notifier", "version1",
+                new GoPluginDescriptor.About("Email Notifier", "1.0", null, null, null,null),
+                null, null, false);
+        yumPoller = new GoPluginDescriptor("yum.poller", "version1",
+                new GoPluginDescriptor.About("Yum Poller", "1.0", null, null, null,null),
+                null, null, false);
+        xunitConvertor = new GoPluginDescriptor("xunit.convertor", "version1",
+                new GoPluginDescriptor.About("Xunit Convertor", "1.0", null, null, null,null),
+                null, null, false);
+        githubPR = new GoPluginDescriptor("github.pr", "version1",
+                new GoPluginDescriptor.About("Github PR", "1.0", null, null, null,null),
+                null, null, false);
+
+        JsonBasedPluggableTask jsonBasedPluggableTask = mock(JsonBasedPluggableTask.class);
+        TaskView taskView = new TaskView() {
+            @Override
+            public String displayValue() {
+                return "task display value";
+            }
+
+            @Override
+            public String template() {
+                return "pluggable task view template";
+            }
+        };
+
+
+        when(authenticationPluginRegistry.getAuthenticationPlugins()).thenReturn(new HashSet<>(Arrays.asList("github.oauth")));
+        when(notificationPluginRegistry.getNotificationPlugins()).thenReturn(new HashSet<>(Arrays.asList("email.notifier")));
+        when(jsonBasedPluggableTask.view()).thenReturn(taskView);
+
+        when(manager.getPluginDescriptorFor("github.oauth")).thenReturn(githubDescriptor);
+        when(manager.getPluginDescriptorFor("email.notifier")).thenReturn(emailNotifier);
+        when(manager.getPluginDescriptorFor("yum.poller")).thenReturn(yumPoller);
+        when(manager.getPluginDescriptorFor("xunit.convertor")).thenReturn(xunitConvertor);
+        when(manager.getPluginDescriptorFor("github.pr")).thenReturn(githubPR);
+
+        PackageMetadataStore.getInstance().addMetadataFor(yumPoller.id(), new PackageConfigurations());
+        PluggableTaskConfigStore.store().setPreferenceFor("xunit.convertor", new TaskPreference(jsonBasedPluggableTask));
+        SCMMetadataStore.getInstance().setPreferenceFor("github.pr", new SCMPreference(new SCMConfigurations(), mock(SCMView.class)));
+        pluginViewModelBuilder = new PluginInfoBuilder(authenticationPluginRegistry, notificationPluginRegistry, manager);
+    }
+
+    @Test
+    public void shouldBeAbleToFetchAllPluginInfos() {
+        List<PluginInfo> pluginInfos = pluginViewModelBuilder.allPluginInfos(null);
+
+        assertThat(pluginInfos.size(), is(5));
+        List<String> expectedPlugins = new ArrayList();
+        for(PluginInfo pluginInfo: pluginInfos) {
+            expectedPlugins.add(pluginInfo.getId());
+        }
+        assertTrue(expectedPlugins.contains(githubDescriptor.id()));
+        assertTrue(expectedPlugins.contains(emailNotifier.id()));
+        assertTrue(expectedPlugins.contains(yumPoller.id()));
+        assertTrue(expectedPlugins.contains(xunitConvertor.id()));
+        assertTrue(expectedPlugins.contains(githubPR.id()));
+    }
+
+    @Test
+    public void shouldBeAbleToFetchAllPluginInfosByType() {
+        List<PluginInfo> pluginInfos = pluginViewModelBuilder.allPluginInfos("scm");
+
+        assertThat(pluginInfos.size(), is(1));
+        assertThat(pluginInfos.get(0).getId(), is(githubPR.id()));
+    }
+
+    @Test(expected=InvalidPluginTypeException.class)
+    public void shouldErrorOutForInvalidPluginType() {
+        assertThat(pluginViewModelBuilder.allPluginInfos("invalid_type").size(), is(0));
+    }
+
+    @Test
+    public void shouldBeAbleToAPluginInfoById() {
+        PluginInfo pluginInfo = pluginViewModelBuilder.pluginInfoFor("email.notifier");
+
+        assertThat(pluginInfo.getId(), is(emailNotifier.id()));
+    }
+
+    @Test
+    public void shouldReturnNullInAbsenceOfPluginForAGivenId() {
+        assertNull(pluginViewModelBuilder.pluginInfoFor("plugin_not_present"));
+    }
+}

--- a/server/test/unit/com/thoughtworks/go/server/service/plugins/builder/SCMViewModelBuilderTest.java
+++ b/server/test/unit/com/thoughtworks/go/server/service/plugins/builder/SCMViewModelBuilderTest.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2016 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.server.service.plugins.builder;
+
+import com.thoughtworks.go.plugin.access.scm.SCMConfiguration;
+import com.thoughtworks.go.plugin.access.scm.SCMConfigurations;
+import com.thoughtworks.go.plugin.access.scm.SCMMetadataStore;
+import com.thoughtworks.go.plugin.access.scm.SCMPreference;
+import com.thoughtworks.go.plugin.access.scm.SCMView;
+import com.thoughtworks.go.plugin.infra.PluginManager;
+import com.thoughtworks.go.plugin.infra.plugininfo.GoPluginDescriptor;
+import com.thoughtworks.go.server.ui.plugins.PluginConfiguration;
+import com.thoughtworks.go.server.ui.plugins.PluginInfo;
+import com.thoughtworks.go.server.ui.plugins.PluginView;
+import org.hamcrest.core.Is;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static junit.framework.TestCase.assertNull;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+public class SCMViewModelBuilderTest {
+    @Mock
+    PluginManager manager;
+
+    private SCMViewModelBuilder builder;
+    private GoPluginDescriptor githubPR;
+    private GoPluginDescriptor stashPR;
+    private SCMPreference preference;
+
+    @Before
+    public void setUp() {
+        initMocks(this);
+        builder = new SCMViewModelBuilder(manager);
+
+        githubPR = new GoPluginDescriptor("github.pr", "version1",
+                new GoPluginDescriptor.About("Github PR", "1.0", null, null, null,null),
+                null, null, false);
+
+        stashPR = new GoPluginDescriptor("stash.pr", "version1",
+                new GoPluginDescriptor.About("Stash PR", "2.0", null, null, null,null),
+                null, null, false);
+
+        SCMConfigurations configurations = new SCMConfigurations();
+        configurations.add(new SCMConfiguration("key1"));
+        configurations.add(new SCMConfiguration("key2"));
+
+        SCMView view = new SCMView() {
+            @Override
+            public String displayValue() {
+                return "SCM Display Value";
+            }
+
+            @Override
+            public String template() {
+                return "scm view template";
+            }
+        };
+
+        preference = new SCMPreference(configurations, view);
+        SCMMetadataStore.getInstance().setPreferenceFor("github.pr", preference);
+        SCMMetadataStore.getInstance().setPreferenceFor("stash.pr", preference);
+    }
+
+    @Test
+    public void shouldBeAbleToFetchAllPluginInfos() {
+        when(manager.getPluginDescriptorFor("github.pr")).thenReturn(githubPR);
+        when(manager.getPluginDescriptorFor("stash.pr")).thenReturn(stashPR);
+
+        List<PluginInfo> pluginInfos = builder.allPluginInfos();
+
+        assertThat(pluginInfos.size(), is(2));
+        PluginInfo pluginInfo = pluginInfos.get(0).getId() == "github.pr" ? pluginInfos.get(0) : pluginInfos.get(1);
+        assertThat(pluginInfo.getId(), is("github.pr"));
+        assertThat(pluginInfo.getType(), is("scm"));
+        assertThat(pluginInfo.getName(), is(githubPR.about().name()));
+        assertThat(pluginInfo.getDisplayName(), is(preference.getScmView().displayValue()));
+        assertThat(pluginInfo.getVersion(), is(githubPR.about().version()));
+        assertNull(pluginInfo.getPluggableInstanceSettings());
+    }
+
+    @Test
+    public void shouldBeAbleToFetchAPluginInfoForAGivenId() {
+        when(manager.getPluginDescriptorFor("github.pr")).thenReturn(githubPR);
+
+        PluginInfo pluginInfo = builder.pluginInfoFor("github.pr");
+
+        assertThat(pluginInfo.getId(), is("github.pr"));
+        assertThat(pluginInfo.getType(), is("scm"));
+        assertThat(pluginInfo.getName(), is(githubPR.about().name()));
+        assertThat(pluginInfo.getDisplayName(), is(preference.getScmView().displayValue()));
+        assertThat(pluginInfo.getVersion(), is(githubPR.about().version()));
+    }
+
+    @Test
+    public void shouldBeAbleToFetchAPluginInfoForAGivenIdWithViewTemplate() {
+        when(manager.getPluginDescriptorFor("github.pr")).thenReturn(githubPR);
+
+        PluginInfo pluginInfo = builder.pluginInfoFor("github.pr");
+
+        PluginView view = pluginInfo.getPluggableInstanceSettings().getView();
+        assertThat(view.getTemplate(), is("scm view template"));
+    }
+
+    @Test
+    public void shouldBeAbleToFetchAPluginInfoForAGivenIdWithConfigurations() {
+        when(manager.getPluginDescriptorFor("github.pr")).thenReturn(githubPR);
+
+        PluginInfo pluginInfo = builder.pluginInfoFor("github.pr");
+
+        HashMap expectedMetadata = new HashMap<String, Object>() {{
+            put("required",true);
+            put("secure",false);
+            put("part_of_identity",true);
+        }};
+
+        List<PluginConfiguration> configurations = pluginInfo.getPluggableInstanceSettings().getConfigurations();
+        assertThat(configurations.size(), is(2));
+        PluginConfiguration configuration1 = configurations.get(0);
+        assertThat(configuration1.getKey(), is("key1"));
+        assertNull(configuration1.getType());
+        assertThat(configuration1.getMetadata(), Is.<Map<String, Object>>is(expectedMetadata));
+
+        PluginConfiguration configuration2 = configurations.get(1);
+        assertThat(configuration2.getKey(), is("key2"));
+        assertNull(configuration2.getType());
+        assertThat(configuration1.getMetadata(), Is.<Map<String, Object>>is(expectedMetadata));
+    }
+
+    @Test
+    public void shouldBeNullIfPluginNotRegistered() {
+        assertNull(builder.pluginInfoFor("unregistered_plugin"));
+    }
+}

--- a/server/webapp/WEB-INF/rails.new/app/controllers/api_v1/admin/plugin_infos_controller.rb
+++ b/server/webapp/WEB-INF/rails.new/app/controllers/api_v1/admin/plugin_infos_controller.rb
@@ -1,0 +1,38 @@
+##########################################################################
+# Copyright 2016 ThoughtWorks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+
+module ApiV1
+  module Admin
+    class PluginInfosController < ApiV1::BaseController
+      before_action :check_admin_user_or_group_admin_user_and_401
+
+      def index
+        plugin_infos = plugin_service.pluginInfos(params[:type])
+        render json_hal_v1: ApiV1::Plugin::PluginInfosRepresenter.new(plugin_infos).to_hash(url_builder: self)
+      rescue InvalidPluginTypeException
+        raise ApiV1::UnprocessableEntity, "Invalid plugins type - `#{params[:type]}` !"
+      end
+
+      def show
+        plugin = plugin_service.pluginInfo(params[:id])
+
+        raise RecordNotFound unless plugin
+
+        render json_hal_v1: ApiV1::Plugin::PluginInfoRepresenter.new(plugin).to_hash(url_builder: self)
+      end
+    end
+  end
+end

--- a/server/webapp/WEB-INF/rails.new/app/presenters/api_v1/config/tasks/pluggable_task_representer.rb
+++ b/server/webapp/WEB-INF/rails.new/app/presenters/api_v1/config/tasks/pluggable_task_representer.rb
@@ -20,7 +20,7 @@ module ApiV1
       class PluggableTaskRepresenter < ApiV1::Config::Tasks::BaseTaskRepresenter
         alias_method :pluggable_task, :represented
 
-        property :plugin_configuration, decorator: PluginConfigurationRepresenter, class: PluginConfiguration
+        property :plugin_configuration, decorator: ApiV1::Config::PluginConfigurationRepresenter, class: com.thoughtworks.go.domain.config.PluginConfiguration
         collection :configuration, exec_context: :decorator, decorator: PluginConfigurationPropertyRepresenter, class: com.thoughtworks.go.domain.config.ConfigurationProperty
 
         def configuration

--- a/server/webapp/WEB-INF/rails.new/app/presenters/api_v1/plugin/pluggable_instance_settings_representer.rb
+++ b/server/webapp/WEB-INF/rails.new/app/presenters/api_v1/plugin/pluggable_instance_settings_representer.rb
@@ -1,0 +1,36 @@
+##########################################################################
+# Copyright 2016 ThoughtWorks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+
+module ApiV1
+  module Plugin
+    class PluggableInstanceSettingsRepresenter < BaseRepresenter
+
+      collection :configurations,
+                 skip_nil: true,
+                 expect_hash: true,
+                 inherit: false,
+                 class: com.thoughtworks.go.server.ui.plugins.PluginConfiguration,
+                 decorator: ApiV1::Plugin::PluginConfigurationRepresenter
+
+      property :view,
+               skip_nil: true,
+               expect_hash: true,
+               inherit: false,
+               class: com.thoughtworks.go.server.ui.plugins.PluginView,
+               decorator: ApiV1::Plugin::PluginViewRepresenter
+    end
+  end
+end

--- a/server/webapp/WEB-INF/rails.new/app/presenters/api_v1/plugin/plugin_configuration_representer.rb
+++ b/server/webapp/WEB-INF/rails.new/app/presenters/api_v1/plugin/plugin_configuration_representer.rb
@@ -1,0 +1,29 @@
+##########################################################################
+# Copyright 2016 ThoughtWorks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+
+module ApiV1
+  module Plugin
+    class PluginConfigurationRepresenter < BaseRepresenter
+      property :key
+      property :type, skip_nil: true
+      property :metadata, exec_context: :decorator
+
+      def metadata
+        represented.metadata.to_hash
+      end
+    end
+  end
+end

--- a/server/webapp/WEB-INF/rails.new/app/presenters/api_v1/plugin/plugin_info_representer.rb
+++ b/server/webapp/WEB-INF/rails.new/app/presenters/api_v1/plugin/plugin_info_representer.rb
@@ -1,0 +1,48 @@
+##########################################################################
+# Copyright 2016 ThoughtWorks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+
+module ApiV1
+  module Plugin
+    class PluginInfoRepresenter < BaseRepresenter
+      alias_method :plugin, :represented
+
+      link :self do |opts|
+        opts[:url_builder].apiv1_admin_plugin_info_url(plugin.id())
+      end
+
+      link :doc do |opts|
+        'http://api.go.cd/#plugin_info'
+      end
+
+      link :find do |opts|
+        opts[:url_builder].apiv1_admin_plugin_info_url(id: '__plugin_id__').gsub(/__plugin_id__/, ':id')
+      end
+
+      property :id
+      property :name
+      property :display_name, skip_nil: true
+      property :version
+      property :type
+      property :getPluggableInstanceSettings,
+               as: :pluggable_instance_settings,
+               skip_nil: true,
+               expect_hash: true,
+               inherit: false,
+               class: PluggableInstanceSettings,
+               decorator: ApiV1::Plugin::PluggableInstanceSettingsRepresenter
+    end
+  end
+end

--- a/server/webapp/WEB-INF/rails.new/app/presenters/api_v1/plugin/plugin_infos_representer.rb
+++ b/server/webapp/WEB-INF/rails.new/app/presenters/api_v1/plugin/plugin_infos_representer.rb
@@ -1,0 +1,36 @@
+##########################################################################
+# Copyright 2016 ThoughtWorks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+
+module ApiV1
+  module Plugin
+    class PluginInfosRepresenter < BaseRepresenter
+      alias_method :plugin_infos, :represented
+
+      link :self do |opts|
+        opts[:url_builder].apiv1_admin_plugin_infos_url
+      end
+
+      link :doc do
+        'http://api.go.cd/#plugin_info'
+      end
+
+      collection :plugin_infos,
+                 embedded: true,
+                 exec_context: :decorator,
+                 decorator: PluginInfoRepresenter
+    end
+  end
+end

--- a/server/webapp/WEB-INF/rails.new/app/presenters/api_v1/plugin/plugin_view_representer.rb
+++ b/server/webapp/WEB-INF/rails.new/app/presenters/api_v1/plugin/plugin_view_representer.rb
@@ -1,0 +1,25 @@
+##########################################################################
+# Copyright 2016 ThoughtWorks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+
+module ApiV1
+  module Plugin
+    class PluginViewRepresenter < BaseRepresenter
+      alias_method :view, :represented
+
+      property :template
+    end
+  end
+end

--- a/server/webapp/WEB-INF/rails.new/config/routes.rb
+++ b/server/webapp/WEB-INF/rails.new/config/routes.rb
@@ -26,6 +26,7 @@ Go::Application.routes.draw do
     PIPELINE_LOCATOR_CONSTRAINTS = {:pipeline_name => PIPELINE_NAME_FORMAT, :pipeline_counter => PIPELINE_COUNTER_FORMAT}
     STAGE_LOCATOR_CONSTRAINTS = {:stage_name => STAGE_NAME_FORMAT, :stage_counter => STAGE_COUNTER_FORMAT}.merge(PIPELINE_LOCATOR_CONSTRAINTS)
     ENVIRONMENT_NAME_CONSTRAINT = {:name => ENVIRONMENT_NAME_FORMAT}
+    PLUGIN_ID_FORMAT = /[a-zA-Z0-9\-_.]+/
     ALLOW_DOTS = /[^\/]+/
     CONSTANTS = true
   end
@@ -233,10 +234,10 @@ Go::Application.routes.draw do
         resources :command_snippets, only: [:index]
         get 'command_snippets/show', controller: :command_snippets, action: :show, as: :command_snippet
         post :material_test, controller: :material_test, action: :test, as: :material_test
-
         namespace :internal do
           resources :pipelines, param: :name, only: [:index]
         end
+        resources :plugin_infos, param: :id, only: [:index, :show], constraints: {id: PLUGIN_ID_FORMAT}
       end
 
       get 'stages/:pipeline_name/:pipeline_counter/:stage_name/:stage_counter' => 'stages#show', constraints: {pipeline_name: PIPELINE_NAME_FORMAT, pipeline_counter: PIPELINE_COUNTER_FORMAT, stage_name: STAGE_NAME_FORMAT, stage_counter: STAGE_COUNTER_FORMAT}, as: :stage_instance_by_counter_api

--- a/server/webapp/WEB-INF/rails.new/lib/java_imports.rb
+++ b/server/webapp/WEB-INF/rails.new/lib/java_imports.rb
@@ -242,4 +242,7 @@ module JavaImports
   java_import com.thoughtworks.go.config.PipelineConfigSaveValidationContext unless defined? PipelineConfigSaveValidationContext
   java_import com.thoughtworks.go.domain.GoVersion unless defined? GoVersion
   java_import com.thoughtworks.go.domain.VersionInfo unless defined? VersionInfo
+  java_import com.thoughtworks.go.server.ui.plugins.PluginInfo unless defined? PluginInfo
+  java_import com.thoughtworks.go.server.ui.plugins.PluggableInstanceSettings unless defined? PluggableInstanceSettings
+  java_import com.thoughtworks.go.server.service.plugins.InvalidPluginTypeException unless defined? InvalidPluginTypeException
 end

--- a/server/webapp/WEB-INF/rails.new/spec/controllers/api_v1/admin/plugin_infos_controller_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/controllers/api_v1/admin/plugin_infos_controller_spec.rb
@@ -1,0 +1,137 @@
+##########################################################################
+# Copyright 2016 ThoughtWorks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+
+require 'spec_helper'
+
+describe ApiV1::Admin::PluginInfosController do
+  before(:each) do
+    @plugin_service = double('plugin_service')
+    controller.stub('plugin_service').and_return(@plugin_service)
+  end
+
+  describe :security do
+    describe :show do
+      it 'should allow anyone, with security disabled' do
+        disable_security
+        expect(controller).to allow_action(:get, :show)
+      end
+
+      it 'should disallow non-admin user, with security enabled' do
+        enable_security
+        login_as_user
+        expect(controller).to disallow_action(:get, :show, {:id => 'plugin_id'}).with(401, 'You are not authorized to perform this action.')
+      end
+
+      it 'should allow admin users, with security enabled' do
+        login_as_admin
+        expect(controller).to allow_action(:get, :show)
+      end
+
+      it 'should allow pipeline group admin users, with security enabled' do
+        login_as_group_admin
+        expect(controller).to allow_action(:get, :show)
+      end
+    end
+
+    describe :index do
+      it 'should allow anyone, with security disabled' do
+        disable_security
+        expect(controller).to allow_action(:get, :index)
+      end
+
+      it 'should disallow non-admin user, with security enabled' do
+        enable_security
+        login_as_user
+        expect(controller).to disallow_action(:get, :index).with(401, 'You are not authorized to perform this action.')
+      end
+
+      it 'should allow admin users, with security enabled' do
+        login_as_admin
+        expect(controller).to allow_action(:get, :index)
+      end
+
+      it 'should allow pipeline group admin users, with security enabled' do
+        login_as_group_admin
+        expect(controller).to allow_action(:get, :index)
+      end
+    end
+  end
+
+  describe :index do
+    before(:each) do
+      login_as_group_admin
+    end
+
+    it 'should list all plugin_infos' do
+      plugin_info = PluginInfo.new('plugin_id', 'plugin_name','plugin_version', 'plugin_type', nil, nil)
+
+      @plugin_service.should_receive(:pluginInfos).with(nil).and_return([plugin_info])
+
+      get_with_api_header :index
+
+      expect(response).to be_ok
+      expect(actual_response).to eq(expected_response([plugin_info], ApiV1::Plugin::PluginInfosRepresenter))
+    end
+
+    it 'should filter plugin_infos by type' do
+      plugin_info = PluginInfo.new('plugin_id', 'plugin_name', 'plugin_version', 'plugin_type', nil, nil)
+
+      @plugin_service.should_receive(:pluginInfos).with('scm').and_return([plugin_info])
+
+      get_with_api_header :index, type: 'scm'
+
+      expect(response).to be_ok
+      expect(actual_response).to eq(expected_response([plugin_info], ApiV1::Plugin::PluginInfosRepresenter))
+    end
+
+    it 'should be a unprocessible entity for a invalid plugin type' do
+      @plugin_service.should_receive(:pluginInfos).with('invalid_type').and_raise(InvalidPluginTypeException.new)
+
+      get_with_api_header :index, type: 'invalid_type'
+
+      expect(response.code).to eq('422')
+      json = JSON.parse(response.body).deep_symbolize_keys
+      expect(json[:message]).to eq('Your request could not be processed. Invalid plugins type - `invalid_type` !')
+    end
+  end
+
+  describe :show do
+    before(:each) do
+      login_as_group_admin
+    end
+
+    it 'should fetch a plugin_info for the given id' do
+      plugin_info = PluginInfo.new('plugin_id', 'plugin_name', 'plugin_version', 'plugin_type', nil, nil)
+
+      @plugin_service.should_receive(:pluginInfo).with('plugin_id').and_return(plugin_info)
+
+      get_with_api_header :show, id: 'plugin_id'
+
+      expect(response).to be_ok
+      expect(actual_response).to eq(expected_response(plugin_info, ApiV1::Plugin::PluginInfoRepresenter))
+    end
+
+    it 'should return 404 in absence of plugin_info' do
+      @plugin_service.should_receive(:pluginInfo).with('plugin_id').and_return(nil)
+
+      get_with_api_header :show, id: 'plugin_id'
+
+      expect(response.code).to eq('404')
+      json = JSON.parse(response.body).deep_symbolize_keys
+      expect(json[:message]).to eq('Either the resource you requested was not found, or you are not authorized to perform this action.')
+    end
+  end
+end

--- a/server/webapp/WEB-INF/rails.new/spec/presenters/api_v1/plugins/plugin_info_representer_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/presenters/api_v1/plugins/plugin_info_representer_spec.rb
@@ -1,0 +1,73 @@
+##########################################################################
+# Copyright 2016 ThoughtWorks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+
+require 'spec_helper'
+
+describe ApiV1::Plugin::PluginInfoRepresenter do
+  it 'renders plugin_info with hal representation' do
+
+    url_configuration = com.thoughtworks.go.server.ui.plugins.PluginConfiguration.new('url', HashMap.new({:required => :true, :secure => false}), nil)
+    username_configuration = com.thoughtworks.go.server.ui.plugins.PluginConfiguration.new('username', HashMap.new({:required => :true, :secure => false}), 'package')
+    view = com.thoughtworks.go.server.ui.plugins.PluginView.new('plugin_view_template')
+    settings = PluggableInstanceSettings.new([url_configuration, username_configuration], view)
+
+    plugin_info = PluginInfo.new('plugin_id', 'plugin_name', 'plugin_version', 'plugin_type', 'plugin_display_name', settings)
+
+    actual_json = ApiV1::Plugin::PluginInfoRepresenter.new(plugin_info).to_hash(url_builder: UrlBuilder.new)
+
+    expect(actual_json).to have_links(:self, :find, :doc)
+    expect(actual_json).to have_link(:self).with_url('http://test.host/api/admin/plugin_infos/plugin_id')
+    expect(actual_json).to have_link(:find).with_url('http://test.host/api/admin/plugin_infos/:id')
+    expect(actual_json).to have_link(:doc).with_url('http://api.go.cd/#plugin_info')
+
+    actual_json.delete(:_links)
+    expect(actual_json).to eq({id:             'plugin_id',
+                               name:           'plugin_name',
+                               display_name:   'plugin_display_name',
+                               version:        'plugin_version',
+                               type:           'plugin_type',
+                               pluggable_instance_settings: {
+                                   configurations: [
+                                       {
+                                           key:      'url',
+                                           metadata: {:required => :true, :secure => false}
+                                       },
+                                       {
+                                           key:      'username',
+                                           type:     'package',
+                                           metadata: {:required => :true, :secure => false}
+                                       }
+                                   ],
+                                   view: {
+                                       template: 'plugin_view_template'
+                                   }
+                               }
+                               })
+  end
+
+  it 'should render plugin_info in absence of pluggable_settings' do
+    plugin_info = PluginInfo.new('plugin_id', 'plugin_name','plugin_version', 'plugin_type', nil, nil)
+
+    actual_json = ApiV1::Plugin::PluginInfoRepresenter.new(plugin_info).to_hash(url_builder: UrlBuilder.new)
+
+    actual_json.delete(:_links)
+    expect(actual_json).to eq({id:      'plugin_id',
+                               name:    'plugin_name',
+                               version: 'plugin_version',
+                               type:    'plugin_type'
+                              })
+  end
+end

--- a/server/webapp/WEB-INF/rails.new/spec/presenters/api_v1/plugins/plugin_infos_representer_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/presenters/api_v1/plugins/plugin_infos_representer_spec.rb
@@ -1,0 +1,31 @@
+##########################################################################
+# Copyright 2016 ThoughtWorks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+
+require 'spec_helper'
+
+describe ApiV1::Plugin::PluginInfosRepresenter do
+  it 'renders all plugin_infos with hal representation' do
+    plugin_info = PluginInfo.new('plugin_id', 'plugin_name', 'plugin_version', 'plugin_type', 'plugin_display_name', nil)
+
+    actual_json = ApiV1::Plugin::PluginInfosRepresenter.new([plugin_info]).to_hash(url_builder: UrlBuilder.new)
+
+    expect(actual_json).to have_links(:self, :doc)
+    expect(actual_json).to have_link(:self).with_url('http://test.host/api/admin/plugin_infos')
+    expect(actual_json).to have_link(:doc).with_url('http://api.go.cd/#plugin_info')
+    actual_json.delete(:_links)
+    actual_json.fetch(:_embedded).should == { :plugin_infos => [ApiV1::Plugin::PluginInfoRepresenter.new(plugin_info).to_hash(url_builder: UrlBuilder.new)] }
+  end
+end


### PR DESCRIPTION
*    PluginInfo api to fetch plugin details, this will be used to build views on SPA
* PluginService exposes methods to list all plugins and fetch a plugin_info by id
* Added PluginInfoViewModelBuilders for each plugin type
* PluginInfo represents all types of plugins
* plugin_infos_controller exposes api's to list and show