### PR TITLE
Fix some logic that broke because we changed the version format.

### DIFF
--- a/server/src/com/thoughtworks/go/domain/GoVersion.java
+++ b/server/src/com/thoughtworks/go/domain/GoVersion.java
@@ -59,7 +59,7 @@ public class GoVersion implements Comparable<GoVersion> {
 
     private Matcher matcherFor(String version) {
         Pattern updateServerPattern = Pattern.compile("^(?:(\\d+)\\.)?(?:(\\d+)\\.)?(?:(\\d+)\\-)?(?:(\\d+))$");
-        Pattern serverVersionPattern = Pattern.compile("^(?:(\\d+)\\.)?(?:(\\d+)\\.)?(?:(\\d+)\\()?(?:(\\d+)\\-)?(?:(\\w+)\\))$");
+        Pattern serverVersionPattern = Pattern.compile("^(?:(\\d+)\\.)?(?:(\\d+)\\.)?(?:(\\d+)\\s*\\()?(?:(\\d+)\\-)?(?:(\\w+)\\))$");
         Matcher matcher = null;
 
         matcher = updateServerPattern.matcher(version);

--- a/server/test/unit/com/thoughtworks/go/domain/GoVersionTest.java
+++ b/server/test/unit/com/thoughtworks/go/domain/GoVersionTest.java
@@ -45,6 +45,16 @@ public class GoVersionTest {
         assertThat(goVersion.getModifications(), is(2689));
     }
 
+    @Test
+    public void shouldCreateAGOVersionFromNewStyleServerVersionString(){
+        GoVersion goVersion = new GoVersion("16.5.0 (2689-762ce7739db26e8dc7db45ae12c5acbe5c494a57)");
+
+        assertThat(goVersion.getMajor(), is(16));
+        assertThat(goVersion.getMinor(), is(5));
+        assertThat(goVersion.getPatches(), is(0));
+        assertThat(goVersion.getModifications(), is(2689));
+    }
+
     @Test(expected = VersionFormatException.class)
     public void shouldErrorOutIfStringVersionIsNotInCorrectFormat(){
         new GoVersion("12.abc.1");


### PR DESCRIPTION
Old format `16.5.0(1234-a7a5717cbd60c30006314fb8dd529796c93adaf0)`
New format `16.5.0 (1234-a7a5717cbd60c30006314fb8dd529796c93adaf0)`

Note the witespace change.