### PR TITLE
Fix `If-None-Match` weak etags to work with jetty's weak etags

### DIFF
--- a/server/webapp/WEB-INF/rails.new/lib/jetty_weak_etag_middleware.rb
+++ b/server/webapp/WEB-INF/rails.new/lib/jetty_weak_etag_middleware.rb
@@ -5,11 +5,14 @@ class JettyWeakEtagMiddleware
 
   def call(env)
     # make weak etags sent by jetty strong see: http://stackoverflow.com/questions/18693718/weak-etags-in-rails
-    etag=env['HTTP_IF_MATCH']
-    if etag && etag =~ /--gzip\"$/
-      etag = env['HTTP_IF_MATCH'].gsub(/--gzip\"?$/, '"')
-      env['HTTP_IF_MATCH'] = etag
+    if env['HTTP_IF_MATCH'] =~ /--gzip"$/
+      env['HTTP_IF_MATCH'] = env['HTTP_IF_MATCH'].gsub(/--gzip"?$/, '"')
     end
+
+    if env['HTTP_IF_NONE_MATCH'] =~ /--gzip"$/
+      env['HTTP_IF_NONE_MATCH'] = env['HTTP_IF_NONE_MATCH'].gsub(/--gzip"?$/, '"')
+    end
+
     status, headers, body = @app.call(env)
     [status, headers, body]
   end


### PR DESCRIPTION
These have been broken ever since we turned on gzipping