### PR TITLE
Improve page load performance across the board.

### DIFF
--- a/common/src/com/thoughtworks/go/config/CruiseConfigProvider.java
+++ b/common/src/com/thoughtworks/go/config/CruiseConfigProvider.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2016 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.config;
+
+public interface CruiseConfigProvider {
+    CruiseConfig getCurrentConfig();
+}

--- a/common/src/com/thoughtworks/go/serverhealth/HealthStateType.java
+++ b/common/src/com/thoughtworks/go/serverhealth/HealthStateType.java
@@ -1,22 +1,24 @@
-/*************************GO-LICENSE-START*********************************
- * Copyright 2014 ThoughtWorks, Inc.
+/*
+ * Copyright 2016 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *************************GO-LICENSE-END***********************************/
+ */
 
 package com.thoughtworks.go.serverhealth;
 
 import com.thoughtworks.go.config.CruiseConfig;
+
+import java.util.Set;
 
 public class HealthStateType implements Comparable<HealthStateType> {
 
@@ -141,7 +143,7 @@ public class HealthStateType implements Comparable<HealthStateType> {
         return scope.compareTo(o.scope);
     }
 
-    public String getPipelineNames(CruiseConfig cruiseConfig) {
+    public Set<String> getPipelineNames(CruiseConfig cruiseConfig) {
         return scope.getPipelineNames(cruiseConfig);
     }
 }

--- a/common/src/com/thoughtworks/go/serverhealth/ServerHealthState.java
+++ b/common/src/com/thoughtworks/go/serverhealth/ServerHealthState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 ThoughtWorks, Inc.
+ * Copyright 2016 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -215,7 +215,7 @@ public class ServerHealthState {
         return expiryTime != null && expiryTime.isBefore(clock.currentDateTime());
     }
 
-    public String getPipelineNames(CruiseConfig config) {
+    public Set<String> getPipelineNames(CruiseConfig config) {
         return type.getPipelineNames(config);
     }
 }

--- a/common/test/unit/com/thoughtworks/go/serverhealth/ServerHealthServiceTest.java
+++ b/common/test/unit/com/thoughtworks/go/serverhealth/ServerHealthServiceTest.java
@@ -16,6 +16,7 @@
 
 package com.thoughtworks.go.serverhealth;
 
+import com.google.common.collect.Sets;
 import com.thoughtworks.go.config.*;
 import com.thoughtworks.go.config.materials.MaterialConfigs;
 import com.thoughtworks.go.config.materials.mercurial.HgMaterial;
@@ -32,17 +33,18 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.util.Arrays;
+import java.util.Collections;
+import java.util.Set;
 
 import static com.thoughtworks.go.serverhealth.HealthStateScope.*;
 import static com.thoughtworks.go.serverhealth.ServerHealthMatcher.doesNotContainState;
 import static com.thoughtworks.go.serverhealth.ServerHealthState.warning;
+import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNull.nullValue;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertThat;
+import static org.junit.Assert.*;
 
 public class ServerHealthServiceTest {
     private ServerHealthService serverHealthService;
@@ -179,16 +181,16 @@ public class ServerHealthServiceTest {
 
         serverHealthService = new ServerHealthService();
         serverHealthService.update(ServerHealthState.error("message", "description", HealthStateType.general(forPipeline(PIPELINE_NAME))));
-        assertThat((serverHealthService.getAllLogs().get(0)).getPipelineNames(config), is(PIPELINE_NAME));
+        assertThat((serverHealthService.getAllLogs().get(0)).getPipelineNames(config), equalTo(Collections.singleton(PIPELINE_NAME)));
 
         serverHealthService = new ServerHealthService();
         serverHealthService.update(ServerHealthState.error("message", "description", HealthStateType.general(forStage(PIPELINE_NAME, "stage1"))));
-        assertThat((serverHealthService.getAllLogs().get(0)).getPipelineNames(config), is(PIPELINE_NAME));
+        assertThat((serverHealthService.getAllLogs().get(0)).getPipelineNames(config), equalTo(Collections.singleton(PIPELINE_NAME)));
 
 
         serverHealthService = new ServerHealthService();
         serverHealthService.update(ServerHealthState.error("message", "description", HealthStateType.general(forJob(PIPELINE_NAME, "stage1", "job1"))));
-        assertThat((serverHealthService.getAllLogs().get(0)).getPipelineNames(config), is(PIPELINE_NAME));
+        assertThat((serverHealthService.getAllLogs().get(0)).getPipelineNames(config), equalTo(Collections.singleton(PIPELINE_NAME)));
     }
 
     @Test
@@ -200,7 +202,7 @@ public class ServerHealthServiceTest {
         config.addPipeline("group", PipelineConfigMother.pipelineConfig("pipeline3"));
 
         serverHealthService.update(ServerHealthState.error("message", "description", HealthStateType.invalidConfig()));
-        assertThat((serverHealthService.getAllLogs().get(0)).getPipelineNames(config), is(""));
+        assertTrue((serverHealthService.getAllLogs().get(0)).getPipelineNames(config).isEmpty());
 
     }
 
@@ -213,7 +215,7 @@ public class ServerHealthServiceTest {
         config.addPipeline("group", PipelineConfigMother.pipelineConfig("pipeline3"));
 
         serverHealthService.update(ServerHealthState.error("message", "description", HealthStateType.general(forMaterial(MaterialsMother.p4Material()))));
-        assertThat((serverHealthService.getAllLogs().get(0)).getPipelineNames(config), is(""));
+        assertTrue((serverHealthService.getAllLogs().get(0)).getPipelineNames(config).isEmpty());
     }
 
     @Test
@@ -225,9 +227,8 @@ public class ServerHealthServiceTest {
         config.addPipeline("group", PipelineConfigMother.pipelineConfig("pipeline3"));
 
         serverHealthService.update(ServerHealthState.error("message", "description", HealthStateType.general(forMaterial(hgMaterial))));
-        String[] pipelines = (serverHealthService.getAllLogs().get(0)).getPipelineNames(config).split(",");
-        Arrays.sort(pipelines);
-        assertArrayEquals("pipeline,pipeline2".split(","), pipelines);
+        Set<String> pipelines = (serverHealthService.getAllLogs().get(0)).getPipelineNames(config);
+        assertEquals(Sets.newHashSet("pipeline", "pipeline2"), pipelines);
     }
 
     @Test
@@ -239,9 +240,8 @@ public class ServerHealthServiceTest {
         config.addPipeline("group", PipelineConfigMother.pipelineConfig("pipeline3"));
 
         serverHealthService.update(ServerHealthState.error("message", "description", HealthStateType.general(forMaterialUpdate(hgMaterial))));
-        String[] pipelines = (serverHealthService.getAllLogs().get(0)).getPipelineNames(config).split(",");
-        Arrays.sort(pipelines);
-        assertArrayEquals("pipeline,pipeline2".split(","), pipelines);
+        Set<String> pipelines = (serverHealthService.getAllLogs().get(0)).getPipelineNames(config);
+        assertEquals(Sets.newHashSet("pipeline", "pipeline2"), pipelines);
     }
 
     @Test
@@ -253,7 +253,7 @@ public class ServerHealthServiceTest {
         config.addPipeline("group", PipelineConfigMother.pipelineConfig("pipeline3"));
 
         serverHealthService.update(ServerHealthState.error("message", "description", HealthStateType.general(HealthStateScope.forFanin("pipeline2"))));
-        String pipelines = (serverHealthService.getAllLogs().get(0)).getPipelineNames(config);
-        assertThat(pipelines, is("pipeline2"));
+        Set<String> pipelines = (serverHealthService.getAllLogs().get(0)).getPipelineNames(config);
+        assertEquals(Sets.newHashSet("pipeline2"), pipelines);
     }
 }

--- a/server/resources/available.toggles
+++ b/server/resources/available.toggles
@@ -10,11 +10,6 @@
          "key": "pipeline_config_single_page_app_key",
          "description": "Enables the pipeline config single page application. Default: off.",
          "value": false
-      },
-      {
-         "key": "better_dashboard_errors_key",
-         "description": "Makes pipeline related errors more visible in the dashboard (https://github.com/gocd/gocd/pull/1842). Default: off.",
-         "value": false
       }
    ]
 }

--- a/server/src/com/thoughtworks/go/server/service/GoConfigService.java
+++ b/server/src/com/thoughtworks/go/server/service/GoConfigService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -65,7 +65,7 @@ import static com.thoughtworks.go.util.ExceptionUtils.bomb;
 import static java.lang.String.format;
 
 @Service
-public class GoConfigService implements Initializer {
+public class GoConfigService implements Initializer, CruiseConfigProvider {
     private GoConfigDao goConfigDao;
     private PipelineRepository pipelineRepository;
     private GoConfigMigration upgrader;

--- a/server/src/com/thoughtworks/go/server/service/support/toggle/Toggles.java
+++ b/server/src/com/thoughtworks/go/server/service/support/toggle/Toggles.java
@@ -18,7 +18,6 @@ package com.thoughtworks.go.server.service.support.toggle;
 public class Toggles {
     public static String PIPELINE_COMMENT_FEATURE_TOGGLE_KEY = "pipeline_comment_feature_toggle_key";
     public static String PIPELINE_CONFIG_SINGLE_PAGE_APP = "pipeline_config_single_page_app_key";
-    public static String BETTER_DASHBOARD_ERRORS = "better_dashboard_errors_key";
 
     private static FeatureToggleService service;
 

--- a/server/webapp/WEB-INF/rails.new/app/assets/javascripts/pipeline_errors.js
+++ b/server/webapp/WEB-INF/rails.new/app/assets/javascripts/pipeline_errors.js
@@ -1,25 +1,25 @@
-/*************************GO-LICENSE-START*********************************
- * Copyright 2014 ThoughtWorks, Inc.
+/*
+ * Copyright 2016 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *************************GO-LICENSE-END**********************************/
+ */
 
 PipelineErrors = function ($) {
     var refreshPipelineErrors = function() {
         var pipelinesHaveError = [];
         $("#cruise_message_body [data-pipelines]").each(function (i, ele) {
             if ($(ele).data("pipelines")) {
-                var pipelines = $(ele).data("pipelines").split(",");
+                var pipelines = $(ele).data("pipelines");
                 $.each(pipelines, function(i, name) {
                    if (pipelinesHaveError.indexOf(name) == -1) {
                        pipelinesHaveError.push(name);
@@ -45,7 +45,7 @@ PipelineErrors = function ($) {
         var pipelineName = $(errorIcon).data("pipeline");
         var errors = $('<div class="cruise_message_body"/>');
         $('#cruise_message_body .error').each(function(i, ele) {
-            var pipelines = $(ele).data("pipelines").split(",");
+            var pipelines = $(ele).data("pipelines");
             if (pipelines.include(pipelineName)) {
                 errors.append($(ele).clone());
             }
@@ -53,7 +53,7 @@ PipelineErrors = function ($) {
         Modalbox.show(errors[0], { title: pipelineName + ' error and warning messages', overlayClose: false });
     };
     var initialize = function() {
-        $(document).bind("dashboard-refresh-completed", refreshPipelineErrors);
+        $(document).bind("server-health-messages-refresh-completed", refreshPipelineErrors);
         refreshPipelineErrors();
         $(document).on("click", ".pipeline-error", function(e) {
             showPipelineErrors(e.target);

--- a/server/webapp/WEB-INF/rails.new/app/controllers/application_controller.rb
+++ b/server/webapp/WEB-INF/rails.new/app/controllers/application_controller.rb
@@ -25,7 +25,7 @@ class ApplicationController < ActionController::Base
 
   attr_accessor :error_template_for_request
 
-  before_filter :set_current_user, :populate_health_messages, :local_access_only, :populate_config_validity, :set_site_urls_in_thread
+  before_filter :set_current_user, :local_access_only, :populate_config_validity, :set_site_urls_in_thread
 
   helper_method :current_user_id_for_oauth
 
@@ -81,11 +81,6 @@ class ApplicationController < ActionController::Base
 
   def set_flash_message(msg, klass)
     flash_message_service.add(FlashMessageModel.new(msg, klass))
-  end
-
-  # health messages
-  def populate_health_messages
-      @current_server_health_states = server_health_service.getAllValidLogs(go_config_service.getCurrentConfig())
   end
 
   def local_access_only

--- a/server/webapp/WEB-INF/rails.new/app/controllers/server_controller.rb
+++ b/server/webapp/WEB-INF/rails.new/app/controllers/server_controller.rb
@@ -15,4 +15,7 @@
 ##########################GO-LICENSE-END##################################
 
 class ServerController < ApplicationController
+  def messages
+    @current_server_health_states = server_health_service.logs()
+  end
 end

--- a/server/webapp/WEB-INF/rails.new/app/views/server/_messages_body.html.erb
+++ b/server/webapp/WEB-INF/rails.new/app/views/server/_messages_body.html.erb
@@ -1,14 +1,10 @@
-<% if !@current_server_health_states.isRealSuccess()
-        cruise_config = go_config_service.getCurrentConfig()
-        should_show_dashboard_errors = com.thoughtworks.go.server.service.support.toggle.Toggles.isToggleOn(com.thoughtworks.go.server.service.support.toggle.Toggles.BETTER_DASHBOARD_ERRORS)
-%>
-        <% @current_server_health_states.each do |state_in_messages_body| %>
-            <% pipeline_error_mappings =  should_show_dashboard_errors ? state_in_messages_body.getPipelineNames(cruise_config) : '' %>
-            <% if !state_in_messages_body.isRealSuccess() %>
-                <div class="<%=state_in_messages_body.getLogLevel().name().downcase%>" data-pipelines="<%= pipeline_error_mappings %>">
-                    <div class="message"><%==state_in_messages_body.getMessageWithTimestamp()%></div>
-                    <div class="description"><%==state_in_messages_body.getDescription()%></div>
-                </div>
-            <% end %>
-        <% end %>
+<% unless @current_server_health_states.isRealSuccess() %>
+  <% @current_server_health_states.each do |state_in_messages_body| %>
+    <% unless state_in_messages_body.isRealSuccess() %>
+      <div class="<%= state_in_messages_body.getLogLevel().name().downcase %>" data-pipelines="<%= json_escape(server_health_service.getPipelinesWithErrors(state_in_messages_body).to_a) %>">
+        <div class="message"><%== state_in_messages_body.getMessageWithTimestamp() %></div>
+        <div class="description"><%== state_in_messages_body.getDescription() %></div>
+      </div>
+    <% end %>
+  <% end %>
 <% end %>

--- a/server/webapp/WEB-INF/rails.new/app/views/shared/_error_messaging_counter.html.erb
+++ b/server/webapp/WEB-INF/rails.new/app/views/shared/_error_messaging_counter.html.erb
@@ -1,14 +1,19 @@
 <div class="error_messaging_counter">
   <div id="cruise_message_counts" class="cruise_messages">
-      <%= render :partial => "server/counts.html" -%>
   </div>
   <div id="cruise_message_body" style="display:none;" class="cruise_message_body">
-      <%= render :partial => "server/messages_body.html" -%>
   </div>
 
   <%- if auto_refresh? -%>
      <script type="text/javascript">
-        Util.on_load(function() {new AjaxRefresher('<%= main_app.global_message_path() %>', null);});
+        Util.on_load(function() {
+          new AjaxRefresher('<%= main_app.global_message_path %>', null, {
+            executeImmediately: true,
+            afterRefresh: function(){
+              jQuery(document).trigger("server-health-messages-refresh-completed");
+            }
+          });
+        });
      </script>
     <%- end -%>
 </div>

--- a/server/webapp/WEB-INF/rails.new/spec/controllers/admin/jobs_controller_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/controllers/admin/jobs_controller_spec.rb
@@ -25,10 +25,6 @@ describe Admin::JobsController do
     @pipeline.getFirstStageConfig().getJobs().getJob(CaseInsensitiveString.new(job_name)).addResource(resource)
   end
 
-  before do
-    controller.stub(:populate_health_messages)
-  end
-
   describe "routes" do
     it "should resolve new" do
       {:get => "/admin/pipelines/dev/stages/test.1/jobs/new"}.should route_to(:controller => "admin/jobs", :action => "new", :pipeline_name => "dev", :stage_name => "test.1", :stage_parent => "pipelines")

--- a/server/webapp/WEB-INF/rails.new/spec/controllers/admin/materials/dependency_controller_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/controllers/admin/materials/dependency_controller_spec.rb
@@ -20,7 +20,6 @@ load File.join(File.dirname(__FILE__), 'material_controller_examples.rb')
 describe Admin::Materials::DependencyController do
   include MockRegistryModule
   before do
-    controller.stub(:populate_health_messages)
     controller.stub(:go_config_service).and_return(@go_config_service = Object.new)
     @go_config_service.stub(:registry).and_return(MockRegistryModule::MockRegistry.new)
   end

--- a/server/webapp/WEB-INF/rails.new/spec/controllers/admin/materials/material_controller_examples.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/controllers/admin/materials/material_controller_examples.rb
@@ -19,10 +19,6 @@ shared_examples_for :material_controller do
   include ConfigSaveStubbing
   include MockRegistryModule
 
-  before do
-    controller.stub(:populate_health_messages)
-  end
-
   describe "routes should resolve and generate" do
     it "new" do
       {:get => "/admin/pipelines/pipeline.name/materials/#{@short_material_type}/new"}.should route_to(:controller => "admin/materials/#{@short_material_type}", :action => "new", :pipeline_name => "pipeline.name")
@@ -78,7 +74,7 @@ shared_examples_for :material_controller do
         setup_for_new_material
         @go_config_service.stub(:registry).and_return(MockRegistryModule::MockRegistry.new)
       end
-      
+
       it "should add new material" do
         stub_save_for_success
 

--- a/server/webapp/WEB-INF/rails.new/spec/controllers/admin/materials/pluggable_scm_controller_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/controllers/admin/materials/pluggable_scm_controller_spec.rb
@@ -20,10 +20,6 @@ describe Admin::Materials::PluggableScmController do
   include ConfigSaveStubbing
   include MockRegistryModule
 
-  before do
-    controller.stub(:populate_health_messages)
-  end
-
   describe "routes should resolve and generate" do
     it "show_existing" do
       {:get => '/admin/pipelines/pipeline.name/materials/pluggable_scm/show_existing'}.should route_to(:controller => 'admin/materials/pluggable_scm', :action => 'show_existing', :pipeline_name => 'pipeline.name')

--- a/server/webapp/WEB-INF/rails.new/spec/controllers/admin/materials_controller_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/controllers/admin/materials_controller_spec.rb
@@ -18,10 +18,6 @@ require 'spec_helper'
 
 describe Admin::MaterialsController do
   include MockRegistryModule
-  before do
-    controller.stub(:populate_health_messages)
-  end
-
   include ConfigSaveStubbing
 
   describe "routes" do

--- a/server/webapp/WEB-INF/rails.new/spec/controllers/admin/package_definitions_controller_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/controllers/admin/package_definitions_controller_spec.rb
@@ -60,7 +60,6 @@ describe Admin::PackageDefinitionsController do
   describe "action" do
     before(:each) do
       controller.stub(:populate_config_validity)
-      controller.stub(:populate_health_messages)
       @cruise_config = BasicCruiseConfig.new()
       @go_config_service = stub_service(:go_config_service)
       @go_config_service.stub(:registry).and_return(MockRegistryModule::MockRegistry.new)

--- a/server/webapp/WEB-INF/rails.new/spec/controllers/admin/package_repositories_controller_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/controllers/admin/package_repositories_controller_spec.rb
@@ -85,7 +85,6 @@ describe Admin::PackageRepositoriesController do
       controller.stub(:go_config_service).and_return(@go_config_service)
       @go_config_service.should_receive(:checkConfigFileValid).and_return(config_validity)
       @go_config_service.stub(:registry)
-      controller.stub(:populate_health_messages)
 
       @cloner = double('cloner')
       controller.stub(:get_cloner_instance).and_return(@cloner)

--- a/server/webapp/WEB-INF/rails.new/spec/controllers/admin/pipeline_groups_controller_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/controllers/admin/pipeline_groups_controller_spec.rb
@@ -19,7 +19,6 @@ require 'spec_helper'
 describe Admin::PipelineGroupsController do
   include MockRegistryModule
   before do
-    controller.stub(:populate_health_messages)
     controller.stub(:set_current_user)
   end
   include ConfigSaveStubbing

--- a/server/webapp/WEB-INF/rails.new/spec/controllers/admin/pipelines_controller_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/controllers/admin/pipelines_controller_spec.rb
@@ -18,7 +18,6 @@ require 'spec_helper'
 
 describe Admin::PipelinesController do
   before do
-    controller.stub(:populate_health_messages)
     controller.stub(:pipeline_pause_service).with().and_return(@pipeline_pause_service = double('Pipeline Pause Service'))
   end
 
@@ -141,9 +140,6 @@ describe Admin::PipelinesController do
       render_views
 
       before do
-        controller.stub(:populate_health_messages) do
-          controller.instance_variable_set :@current_server_health_states, com.thoughtworks.go.serverhealth.ServerHealthStates.new
-        end
         @go_config_service.stub(:isSecurityEnabled).and_return(false)
       end
 

--- a/server/webapp/WEB-INF/rails.new/spec/controllers/admin/pipelines_snippet_controller_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/controllers/admin/pipelines_snippet_controller_spec.rb
@@ -49,7 +49,6 @@ describe Admin::PipelinesSnippetController do
       controller.stub(:pipeline_configs_service).and_return(@pipeline_configs_service)
       controller.stub(:go_config_service).and_return(@go_config_service)
       controller.should_receive(:populate_config_validity).and_return(true)
-      controller.should_receive(:populate_health_messages)
       controller.should_receive(:load_context)
       @result = HttpLocalizedOperationResult.new
       HttpLocalizedOperationResult.stub(:new).and_return(@result)

--- a/server/webapp/WEB-INF/rails.new/spec/controllers/admin/server_controller_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/controllers/admin/server_controller_spec.rb
@@ -20,7 +20,6 @@ describe Admin::ServerController do
   include MockRegistryModule
 
   before do
-    controller.stub(:populate_health_messages)
     controller.stub(:set_current_user)
   end
 
@@ -156,9 +155,6 @@ describe Admin::ServerController do
       render_views
 
       before do
-        controller.stub(:populate_health_messages) do
-          controller.instance_variable_set :@current_server_health_states, com.thoughtworks.go.serverhealth.ServerHealthStates.new
-        end
         user = com.thoughtworks.go.server.domain.Username.new(CaseInsensitiveString.new("foo"))
         controller.stub(:set_current_user) do
           controller.instance_variable_set :@user, user

--- a/server/webapp/WEB-INF/rails.new/spec/controllers/admin/stages_controller_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/controllers/admin/stages_controller_spec.rb
@@ -22,7 +22,6 @@ describe Admin::StagesController do
   include TaskMother
 
   before do
-    controller.stub(:populate_health_messages)
     controller.stub(:pipeline_pause_service).with().and_return(@pipeline_pause_service = double('Pipeline Pause Service'))
     controller.stub(:set_current_user)
   end

--- a/server/webapp/WEB-INF/rails.new/spec/controllers/admin/stages_controller_view_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/controllers/admin/stages_controller_view_spec.rb
@@ -24,9 +24,6 @@ describe Admin::StagesController, "view" do
     render_views
 
     before do
-      controller.stub(:populate_health_messages) do
-        controller.instance_variable_set(:@current_server_health_states,com.thoughtworks.go.serverhealth.ServerHealthStates.new)
-      end
       controller.stub(:populate_config_validity)
       controller.stub(:checkConfigFileValid)
 

--- a/server/webapp/WEB-INF/rails.new/spec/controllers/admin/tasks/fetch_task_controller_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/controllers/admin/tasks/fetch_task_controller_spec.rb
@@ -68,8 +68,6 @@ describe Admin::TasksController, "fetch task" do
       @cruise_config.addTemplate(@template)
       set(@cruise_config, "md5", "abcd1234")
 
-      @go_config_service.should_receive(:getCurrentConfig).and_return(@cruise_config)
-
       @pipeline_config_for_edit = ConfigForEdit.new(@pipeline, @cruise_config, @cruise_config)
 
       @pause_info = PipelinePauseInfo.paused("just for fun", "loser")

--- a/server/webapp/WEB-INF/rails.new/spec/controllers/admin/tasks/nonpluggable_task_with_pluggable_on_cancel_task_controller_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/controllers/admin/tasks/nonpluggable_task_with_pluggable_on_cancel_task_controller_spec.rb
@@ -31,7 +31,6 @@ describe Admin::TasksController do
   end
 
   before :each do
-    controller.stub(:populate_health_messages)
     @on_cancel_task = plugin_task
     @on_cancel_task.configuration.addNewConfiguration("Url", false)
     @on_cancel_task_type = plugin_task.getTaskType()

--- a/server/webapp/WEB-INF/rails.new/spec/controllers/admin/tasks/pluggable_task_controller_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/controllers/admin/tasks/pluggable_task_controller_spec.rb
@@ -70,7 +70,6 @@ describe Admin::TasksController do
       @pipeline_config_for_edit = ConfigForEdit.new(@pipeline, @cruise_config, @cruise_config)
       @pause_info = PipelinePauseInfo.paused("just for fun", "loser")
       @go_config_service.stub(:registry).and_return(MockRegistryModule::MockRegistry.new)
-      @go_config_service.should_receive(:getCurrentConfig).and_return(@cruise_config)
 
       @go_config_service.should_receive(:loadForEdit).with("pipeline.name", @user, @result).and_return(@pipeline_config_for_edit)
       @pipeline_pause_service.should_receive(:pipelinePauseInfo).with("pipeline.name").and_return(@pause_info)

--- a/server/webapp/WEB-INF/rails.new/spec/controllers/admin/tasks/task_controller_examples.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/controllers/admin/tasks/task_controller_examples.rb
@@ -23,10 +23,6 @@ end
 shared_examples_for :task_controller  do
   include ConfigSaveStubbing, TaskMother
 
-  before do
-    controller.stub(:populate_health_messages)
-  end
-
   describe "routes" do
     describe "index" do
       it "should resolve templates as :stage_parent" do

--- a/server/webapp/WEB-INF/rails.new/spec/controllers/admin/tasks_controller_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/controllers/admin/tasks_controller_spec.rb
@@ -17,12 +17,7 @@
 require 'spec_helper'
 
 describe Admin::TasksController do
-  include MockRegistryModule
-  before do
-    controller.stub(:populate_health_messages)
-  end
-
-  include TaskMother, ReflectiveUtil, ConfigSaveStubbing
+  include MockRegistryModule, TaskMother, ReflectiveUtil, ConfigSaveStubbing
 
   describe "increment" do
 

--- a/server/webapp/WEB-INF/rails.new/spec/controllers/admin/templates_controller_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/controllers/admin/templates_controller_spec.rb
@@ -21,10 +21,6 @@ describe Admin::TemplatesController do
   include ConfigSaveStubbing
   include GoUtil
 
-  before do
-    controller.stub(:populate_health_messages)
-  end
-
   describe "routes" do
     it "should resolve route to the templates listing page" do
       {:get => "/admin/templates"}.should route_to(:controller => "admin/templates", :action => "index")

--- a/server/webapp/WEB-INF/rails.new/spec/controllers/agent_autocomplete_controller_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/controllers/agent_autocomplete_controller_spec.rb
@@ -36,7 +36,6 @@ describe AgentAutocompleteController do
       controller.stub(:environment_config_service).and_return(@environment_config_service = Object.new)
       controller.stub(:agent_service).and_return(@agent_service = Object.new)
       @go_config_service.stub(:checkConfigFileValid).and_return(com.thoughtworks.go.config.validation.GoConfigValidity.valid())
-      @go_config_service.should_receive(:getCurrentConfig).and_return(new_config = BasicCruiseConfig.new)
     end
 
     describe :resource do

--- a/server/webapp/WEB-INF/rails.new/spec/controllers/api/pipelines_controller_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/controllers/api/pipelines_controller_spec.rb
@@ -26,7 +26,6 @@ describe Api::PipelinesController do
   include APIModelMother
 
   before :each do
-    controller.stub(:populate_health_messages)
     @pipeline_service = Object.new
     @pipeline_history_service = double('pipeline_history_service')
     @pipeline_unlock_api_service = double('pipeline_unlock_api_service')

--- a/server/webapp/WEB-INF/rails.new/spec/controllers/api/server_controller_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/controllers/api/server_controller_spec.rb
@@ -19,9 +19,6 @@ require 'spec_helper'
 describe Api::ServerController do
 
   before :each do
-    controller.stub(:populate_health_messages) do
-      stub_server_health_messages_for_controllers
-    end
     @system_environment = double('system_environment')
     @go_config_service = double('go_config_service')
     controller.stub(:system_environment).and_return(@system_environment)

--- a/server/webapp/WEB-INF/rails.new/spec/controllers/api_v1/dashboard_controller_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/controllers/api_v1/dashboard_controller_spec.rb
@@ -19,7 +19,6 @@ require 'spec_helper'
 describe ApiV1::DashboardController do
 
   before do
-    controller.stub(:populate_health_messages)
     @user                  = Username.new(CaseInsensitiveString.new("foo"))
     @pipeline_group_models = java.util.ArrayList.new
     controller.stub(:current_user).and_return(@user)

--- a/server/webapp/WEB-INF/rails.new/spec/controllers/application_controller_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/controllers/application_controller_spec.rb
@@ -20,7 +20,6 @@ require 'java'
 describe ApplicationController do
 
   before do
-    stub_server_health_messages_for_controllers
     UserHelper.stub(:getUserId).and_return(1)
   end
 
@@ -188,25 +187,12 @@ describe ApplicationController do
     end
 
     it "should populate the config file validity for every request" do
-      @controller.stub(:populate_health_messages)
       go_config_service = stub_service(:go_config_service)
       expect(go_config_service).to receive(:checkConfigFileValid).and_return(com.thoughtworks.go.config.validation.GoConfigValidity.valid())
 
       get :index
 
       expect(assigns[:config_valid]).to eq(true)
-    end
-
-    it "should populate server-health-messages for every request" do
-      health_service = stub_service(:server_health_service)
-      config_service = stub_service(:go_config_service)
-      config_service.should_receive(:getCurrentConfig).and_return(new_config = BasicCruiseConfig.new)
-      config_service.stub(:checkConfigFileValid).and_return(com.thoughtworks.go.config.validation.GoConfigValidity.valid())
-      health_service.should_receive(:getAllValidLogs).with(new_config).and_return(:all_health_messages)
-
-      get :index
-
-      expect(assigns[:current_server_health_states]).to eq(:all_health_messages)
     end
 
     it "should set the siteUrl and secureSiteUrl on the thread" do
@@ -248,9 +234,6 @@ describe ApplicationController do
     before(:each) do
       @routes.draw do
         get "/anonymous/test_action"
-      end
-      controller.stub(:populate_health_messages) do
-        stub_server_health_messages_for_controllers
       end
       config_service = stub_service(:go_config_service)
       config_service.stub(:checkConfigFileValid).and_return(com.thoughtworks.go.config.validation.GoConfigValidity.valid)

--- a/server/webapp/WEB-INF/rails.new/spec/controllers/comparison_controller_view_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/controllers/comparison_controller_view_spec.rb
@@ -22,9 +22,6 @@ describe ComparisonController, "view" do
   render_views
 
   before do
-    controller.stub(:populate_health_messages) do
-      controller.instance_variable_set(:@current_server_health_states, com.thoughtworks.go.serverhealth.ServerHealthStates.new)
-    end
     controller.stub(:pipeline_history_service).and_return(@phs = double('PipelineHistoryService'))
     controller.stub(:current_user).and_return(@loser = Username.new(CaseInsensitiveString.new("loser")))
     controller.stub(:populate_config_validity)

--- a/server/webapp/WEB-INF/rails.new/spec/controllers/gadgets/pipeline_controller_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/controllers/gadgets/pipeline_controller_spec.rb
@@ -18,7 +18,6 @@ require 'spec_helper'
 
 describe Gadgets::PipelineController do
   before :each do
-    controller.stub(:populate_health_messages)
     controller.stub(:current_user).and_return(@user = Username.new(CaseInsensitiveString.new("user")))
     UserHelper.stub(:getUserId).and_return(1)
     controller.stub(:populate_config_validity)

--- a/server/webapp/WEB-INF/rails.new/spec/controllers/pipelines_controller_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/controllers/pipelines_controller_spec.rb
@@ -19,7 +19,6 @@ require 'spec_helper'
 describe PipelinesController do
 
   before(:each)  do
-    controller.stub(:populate_health_messages)
     @stage_service = double('stage service')
     @material_service = double('material service')
     @user = Username.new(CaseInsensitiveString.new("foo"))

--- a/server/webapp/WEB-INF/rails.new/spec/controllers/pipelines_controller_view_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/controllers/pipelines_controller_view_spec.rb
@@ -21,9 +21,6 @@ describe PipelinesController do
   render_views
 
   before(:each) do
-    controller.stub(:populate_health_messages) do
-      controller.instance_variable_set(:@current_server_health_states,com.thoughtworks.go.serverhealth.ServerHealthStates.new)
-    end
     @user = Username.new(CaseInsensitiveString.new("foo"))
     controller.stub(:pipeline_history_service).and_return(@pipeline_history_service=double())
     controller.stub(:go_config_service).and_return(@go_config_service=double())

--- a/server/webapp/WEB-INF/rails.new/spec/controllers/server_controller_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/controllers/server_controller_spec.rb
@@ -30,15 +30,10 @@ describe ServerController do
     second = ServerHealthState.error("second error", "second description", HealthStateType.invalidConfig())
     third = ServerHealthState.warning("first warning", "third description", HealthStateType.artifactsDirChanged())
     states = ServerHealthStates.new([first, second, third])
-    config = BasicCruiseConfig.new()
 
     @server_health_service = double('server health service')
-    @go_config_service = double('go config service')
     controller.stub(:server_health_service).and_return(@server_health_service)
-    controller.stub(:go_config_service).and_return(@go_config_service)
-
-    @go_config_service.should_receive(:getCurrentConfig).and_return(config)
-    @server_health_service.should_receive(:getAllValidLogs).with(config).and_return(states)
+    @server_health_service.should_receive(:logs).and_return(states)
 
     get 'messages', :format => 'json'
 

--- a/server/webapp/WEB-INF/rails.new/spec/controllers/stages_controller_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/controllers/stages_controller_spec.rb
@@ -29,9 +29,6 @@ describe StagesController do
   include JobMother
 
   before(:each) do
-    controller.stub(:populate_health_messages) do
-      stub_server_health_messages_for_controllers
-    end
     controller.go_cache.clear
     @stage_service = double('stage service')
     @shine_dao = double('shine dao')

--- a/server/webapp/WEB-INF/rails.new/spec/javascripts/pipeline_errors_spec.js
+++ b/server/webapp/WEB-INF/rails.new/spec/javascripts/pipeline_errors_spec.js
@@ -28,7 +28,7 @@ describe("pipeline_errors", function () {
             "    <div class='message'>global msg</div>\n" +
             "    <div class='description'>global desc</div>\n" +
             "  </div>\n" +
-            "  <div class='error' data-pipelines='pipeline1'>\n" +
+            "  <div class='error' data-pipelines='[&quot;pipeline1&quot;]'>\n" +
             "    <div class='message'>pipeline1 msg</div>\n" +
             "    <div class='description'>pipeline1 desc</div>\n" +
             "  </div>\n" +

--- a/server/webapp/WEB-INF/rails.new/spec/support/misc_spec_extensions.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/support/misc_spec_extensions.rb
@@ -3,14 +3,6 @@ module MiscSpecExtensions
     org.joda.time.DateTime.new(year, month, day, hour, minute, second, 0, org.joda.time.DateTimeZone::UTC).toDate()
   end
 
-  def stub_server_health_messages
-    assign(:current_server_health_states, com.thoughtworks.go.serverhealth.ServerHealthStates.new)
-  end
-
-  def stub_server_health_messages_for_controllers
-    assigns[:current_server_health_states] = com.thoughtworks.go.serverhealth.ServerHealthStates.new
-  end
-
   def current_user
     @user ||= com.thoughtworks.go.server.domain.Username.new(CaseInsensitiveString.new("some-user"), "display name")
     @controller.stub(:current_user).and_return(@user)

--- a/server/webapp/WEB-INF/rails.new/spec/views/agents/index_html_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/views/agents/index_html_spec.rb
@@ -16,9 +16,6 @@
 
 require 'spec_helper'
 describe "/agents/index.html.erb" do
-  before do
-    stub_server_health_messages
-  end
   include AgentsHelper
   include AgentMother
   include GoUtil

--- a/server/webapp/WEB-INF/rails.new/spec/views/layouts/admin_html_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/views/layouts/admin_html_spec.rb
@@ -21,9 +21,6 @@ describe "/layouts/admin" do
   include EngineUrlHelper
 
   before do
-    stub_server_health_messages
-  end
-  before do
     @layout_name = 'layouts/admin'
     @admin_url = "/admin/pipelines"
     @user = Object.new

--- a/server/webapp/WEB-INF/rails.new/spec/views/layouts/agent_detail_html_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/views/layouts/agent_detail_html_spec.rb
@@ -18,9 +18,6 @@ require 'spec_helper'
 load File.join(File.dirname(__FILE__), 'layout_html_examples.rb')
 
 describe "/layouts/agent_detail" do
-before do
-stub_server_health_messages
-end
   include AgentMother
   include GoUtil
 

--- a/server/webapp/WEB-INF/rails.new/spec/views/layouts/application_html_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/views/layouts/application_html_spec.rb
@@ -21,10 +21,6 @@ describe "/layouts/application" do
   include EngineUrlHelper
 
   before do
-    stub_server_health_messages
-  end
-
-  before do
     @layout_name = "layouts/application"
     @admin_url = "/admin/pipelines"
     assign(:user, @user = Object.new)

--- a/server/webapp/WEB-INF/rails.new/spec/views/layouts/pipeline_admin_html_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/views/layouts/pipeline_admin_html_spec.rb
@@ -22,10 +22,6 @@ describe "/layouts/pipeline_admin" do
   include EngineUrlHelper
 
   before do
-    stub_server_health_messages
-  end
-
-  before do
     @layout_name = "layouts/pipeline_admin"
     @admin_url = "/admin/pipelines"
     assign(:user,@user = Object.new)

--- a/server/webapp/WEB-INF/rails.new/spec/views/layouts/pipelines_html_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/views/layouts/pipelines_html_spec.rb
@@ -21,7 +21,6 @@ describe "layouts/pipelines.html.eb" do
 
   before do
     @layout_name = 'layouts/pipelines'
-    stub_server_health_messages
     @user = Username.new(CaseInsensitiveString.new("blah-name"), "blah diaply name")
     assign(:user,@user)
     now = org.joda.time.DateTime.new

--- a/server/webapp/WEB-INF/rails.new/spec/views/navigation_elements/_navigation_html_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/views/navigation_elements/_navigation_html_spec.rb
@@ -23,7 +23,6 @@ describe "/navigation_elements/navigation" do
     class << view
       include ApplicationHelper
     end
-    stub_server_health_messages
     assign(:user, com.thoughtworks.go.server.domain.Username::ANONYMOUS)
     allow(view).to receive(:is_user_an_admin?).and_return(true)
   end

--- a/server/webapp/WEB-INF/rails.new/spec/views/shared/_application_nav_html_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/views/shared/_application_nav_html_spec.rb
@@ -23,7 +23,6 @@ describe "/shared/_application_nav.html.erb" do
     class << view
       include ApplicationHelper
     end
-    stub_server_health_messages
     assign(:user, com.thoughtworks.go.server.domain.Username::ANONYMOUS)
     allow(view).to receive(:is_user_an_admin?).and_return(true)
   end
@@ -138,7 +137,7 @@ describe "/shared/_application_nav.html.erb" do
 
       render :partial => partial_page
 
-      expect(response.body).to have_selector("script", visible: false, text: /Util.on_load\(function\(\) {new AjaxRefresher\('\/server\/messages.json', null\);}\);/)
+      expect(response.body).to have_selector("script", visible: false, text: /new AjaxRefresher\('\/server\/messages.json', /)
     end
 
     it "should hookup auto refresh with update once when auto refresh is false" do

--- a/server/webapp/WEB-INF/rails.new/spec/views/stages/stage_html_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/views/stages/stage_html_spec.rb
@@ -22,7 +22,6 @@ describe 'stages/stage.html.erb' do
   include StageModelMother, GoUtil, JobMother, PipelineModelMother, ApplicationHelper
 
   before(:each) do
-    stub_server_health_messages
     view.stub(:is_user_an_admin?).and_return(true)
     view.stub(:config_change_path)
 
@@ -37,7 +36,6 @@ describe 'stages/stage.html.erb' do
     assign :pipeline, @pipeline =  pipeline_model("pipeline_name", "blah_label", false, false, "working with agent", false, @revisions).getLatestPipelineInstance()
     assign :current_tab,  "overview"
     assign :fbh_pipeline_instances, []
-    assign :current_server_health_states, ServerHealthStates.new([])
   end
 
   def mat_revisions()

--- a/server/webapp/WEB-INF/rails.new/spec/views/value_stream_map/show_html_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/views/value_stream_map/show_html_spec.rb
@@ -18,9 +18,6 @@ require 'spec_helper'
 
 
 describe "/value_stream_map/show.html.erb" do
-  before do
-    stub_server_health_messages
-  end
   include GoUtil
 
   before(:each)  do

--- a/server/webapp/WEB-INF/rails.new/spec/views/value_stream_map/show_material_html_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/views/value_stream_map/show_material_html_spec.rb
@@ -17,9 +17,6 @@
 require 'spec_helper'
 
 describe "/value_stream_map/show_material.html.erb" do
-  before do
-    stub_server_health_messages
-  end
   include GoUtil
 
   before(:each)  do

--- a/server/webapp/WEB-INF/spring-cruise-remoting-servlet.xml
+++ b/server/webapp/WEB-INF/spring-cruise-remoting-servlet.xml
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- *************************GO-LICENSE-START******************************
- * Copyright 2015 ThoughtWorks, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *************************GO-LICENSE-END******************************* -->
+<!--
+  ~ Copyright 2016 ThoughtWorks, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
 
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -41,6 +41,12 @@
     <bean id="produceBuildCausesTask" class="com.thoughtworks.go.timer.ModeAwareMethodInvokingTimerTaskFactoryBean"
           p:targetObject-ref="pipelineScheduler"
           p:targetMethod="onTimer"/>
+
+    <bean id="serverHealthRecomputeTask" class="com.thoughtworks.go.timer.ModeAwareMethodInvokingTimerTaskFactoryBean"
+          p:targetObject-ref="serverHealthService"
+          p:targetMethod="onTimer"
+          p:arguments-ref="goConfigService"
+    />
 
     <bean id="consumeBuildCausesTask" class="com.thoughtworks.go.timer.ModeAwareMethodInvokingTimerTaskFactoryBean"
           p:targetObject-ref="scheduleService"
@@ -78,6 +84,17 @@
                       p:delay="${cruise.produce.build.cause.delay}"
                       p:period="${cruise.produce.build.cause.interval}"
                       p:timerTask-ref="produceBuildCausesTask"/>
+            </list>
+        </property>
+    </bean>
+
+    <bean name="recomputeMaterialPipelineMappingsThread" class="org.springframework.scheduling.timer.TimerFactoryBean">
+        <property name="scheduledTimerTasks">
+            <list>
+                <bean class="org.springframework.scheduling.timer.ScheduledTimerTask"
+                      p:delay="10000"
+                      p:period="5000"
+                      p:timerTask-ref="serverHealthRecomputeTask"/>
             </list>
         </property>
     </bean>


### PR DESCRIPTION
This PR solves 2 problems —

Problem 1
---------

The `ApplicationController#populate_health_messages` filter was called
on every page load, and was re-computing all health state messages.
This computation had n^2 complexity for every health state message that
had to be rendered, this health state was rendered at the bottom of
every page inside go.

We now don't render the errors on page load, but rely on the ajax poll
to eventually render the errors in a few seconds after the page loads

Problem 2
---------

To further reduce the cost of computation, we now pre-compute the health
state messages, and the pipelines that each server health state message
belongs to, via a background thread.