### PR TITLE
Added Pipeline-config DELETE api (#1773)

### DIFF
--- a/common/test/unit/com/thoughtworks/go/domain/PipelineGroupsTest.java
+++ b/common/test/unit/com/thoughtworks/go/domain/PipelineGroupsTest.java
@@ -75,6 +75,18 @@ public class PipelineGroupsTest {
     }
 
     @Test
+    public void shouldRemovePipelineFromTheGroup() throws Exception {
+        PipelineConfig pipelineConfig = createPipelineConfig("pipeline1", "stage1");
+        PipelineConfigs defaultGroup = createGroup("defaultGroup", pipelineConfig);
+        PipelineGroups pipelineGroups = new PipelineGroups(defaultGroup);
+
+        assertThat(pipelineGroups.size(), is(1));
+        pipelineGroups.deletePipeline(pipelineConfig);
+        assertThat(pipelineGroups.size(), is(1));
+        assertThat(defaultGroup.size(), is(0));
+    }
+
+    @Test
     public void shouldSaveNewPipelineGroupOnTheTop() {
         PipelineConfigs defaultGroup = createGroup("defaultGroup", createPipelineConfig("pipeline1", "stage1"));
         PipelineConfigs defaultGroup2 = createGroup("defaultGroup2", createPipelineConfig("pipeline2", "stage2"));

--- a/config/config-api/src/com/thoughtworks/go/config/BasicCruiseConfig.java
+++ b/config/config-api/src/com/thoughtworks/go/config/BasicCruiseConfig.java
@@ -779,6 +779,11 @@ public class BasicCruiseConfig implements CruiseConfig {
     }
 
     @Override
+    public void deletePipeline(PipelineConfig pipelineConfig) {
+        groups.deletePipeline(pipelineConfig);
+    }
+
+    @Override
     public void addPipelineWithoutValidation(String groupName, PipelineConfig pipelineConfig) {
         groups.addPipelineWithoutValidation(sanitizedGroupName(groupName), pipelineConfig);
     }

--- a/config/config-api/src/com/thoughtworks/go/config/CruiseConfig.java
+++ b/config/config-api/src/com/thoughtworks/go/config/CruiseConfig.java
@@ -124,6 +124,8 @@ public interface CruiseConfig extends Validatable, ConfigOriginTraceable {
 
     void update(String groupName, String pipelineName, PipelineConfig pipeline);
 
+    void deletePipeline(PipelineConfig pipelineConfig);
+
     boolean exist(int pipelineIndex);
 
     boolean hasPipeline();

--- a/config/config-api/src/com/thoughtworks/go/domain/PipelineGroups.java
+++ b/config/config-api/src/com/thoughtworks/go/domain/PipelineGroups.java
@@ -72,6 +72,15 @@ public class PipelineGroups extends BaseCollection<PipelineConfigs> implements V
         }
     }
 
+    public void deletePipeline(PipelineConfig pipelineConfig) {
+        for (PipelineConfigs group : this) {
+            if(group.hasPipeline(pipelineConfig.name())){
+                group.remove(pipelineConfig);
+                return;
+            }
+        }
+    }
+
     private void createNewGroup(String sanitizedGroupName, PipelineConfig pipeline) {
         PipelineConfigs configs = new BasicPipelineConfigs(pipeline);
         configs.setGroup(sanitizedGroupName);

--- a/server/src/com/thoughtworks/go/config/update/DeletePipelineConfigCommand.java
+++ b/server/src/com/thoughtworks/go/config/update/DeletePipelineConfigCommand.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2016 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.config.update;
+
+import com.thoughtworks.go.config.BasicCruiseConfig;
+import com.thoughtworks.go.config.CruiseConfig;
+import com.thoughtworks.go.config.PipelineConfig;
+import com.thoughtworks.go.config.PipelineConfigSaveValidationContext;
+import com.thoughtworks.go.config.commands.EntityConfigUpdateCommand;
+import com.thoughtworks.go.i18n.LocalizedMessage;
+import com.thoughtworks.go.server.domain.Username;
+import com.thoughtworks.go.server.service.GoConfigService;
+import com.thoughtworks.go.server.service.result.LocalizedOperationResult;
+import com.thoughtworks.go.serverhealth.HealthStateType;
+
+public class DeletePipelineConfigCommand implements EntityConfigUpdateCommand<PipelineConfig> {
+    private final GoConfigService goConfigService;
+    private PipelineConfig pipelineConfig;
+    private final Username currentUser;
+    private final LocalizedOperationResult result;
+    private PipelineConfig preprocessedPipelineConfig;
+
+    public DeletePipelineConfigCommand(GoConfigService goConfigService, PipelineConfig pipelineConfig, Username currentUser, LocalizedOperationResult result) {
+        this.goConfigService = goConfigService;
+        this.pipelineConfig = pipelineConfig;
+        this.currentUser = currentUser;
+        this.result = result;
+    }
+
+
+    @Override
+    public void update(CruiseConfig cruiseConfig) throws Exception {
+        preprocessedPipelineConfig = cruiseConfig.getPipelineConfigByName(pipelineConfig.name());
+        cruiseConfig.deletePipeline(pipelineConfig);
+    }
+
+    @Override
+    public boolean isValid(CruiseConfig preprocessedConfig) {
+        return true;
+    }
+
+    @Override
+    public PipelineConfig getPreprocessedEntityConfig() {
+        return preprocessedPipelineConfig;
+    }
+
+    @Override
+    public boolean canContinue(CruiseConfig cruiseConfig) {
+        String groupName = goConfigService.findGroupNameByPipeline(pipelineConfig.name());
+        if (goConfigService.groups().hasGroup(groupName) && !goConfigService.isUserAdminOfGroup(currentUser.getUsername(), groupName)) {
+            result.unauthorized(LocalizedMessage.string("UNAUTHORIZED_TO_DELETE_PIPELINE", groupName), HealthStateType.unauthorised());
+            return false;
+        }
+        return true;
+    }
+}
+

--- a/server/src/com/thoughtworks/go/server/service/PipelineConfigService.java
+++ b/server/src/com/thoughtworks/go/server/service/PipelineConfigService.java
@@ -21,6 +21,7 @@ import com.thoughtworks.go.config.commands.EntityConfigUpdateCommand;
 import com.thoughtworks.go.config.exceptions.GoConfigInvalidException;
 import com.thoughtworks.go.config.update.ConfigUpdateCheckFailedException;
 import com.thoughtworks.go.config.update.CreatePipelineConfigCommand;
+import com.thoughtworks.go.config.update.DeletePipelineConfigCommand;
 import com.thoughtworks.go.config.update.UpdatePipelineConfigCommand;
 import com.thoughtworks.go.config.remote.ConfigOrigin;
 import com.thoughtworks.go.i18n.LocalizedMessage;
@@ -171,6 +172,14 @@ public class PipelineConfigService implements ConfigChangedListener, Initializer
     public void createPipelineConfig(final Username currentUser, final PipelineConfig pipelineConfig, final LocalizedOperationResult result, final String groupName) {
         CreatePipelineConfigCommand createPipelineConfigCommand = new CreatePipelineConfigCommand(goConfigService, pipelineConfig, currentUser, result, groupName);
         update(currentUser, pipelineConfig, result, createPipelineConfigCommand);
+    }
+
+    public void deletePipelineConfig(final Username currentUser, final PipelineConfig pipelineConfig, final LocalizedOperationResult result) {
+        DeletePipelineConfigCommand deletePipelineConfigCommand = new DeletePipelineConfigCommand(goConfigService, pipelineConfig, currentUser, result);
+        update(currentUser, pipelineConfig, result, deletePipelineConfigCommand);
+        if(result.isSuccessful()) {
+            result.setMessage(LocalizedMessage.string("PIPELINE_DELETE_SUCCESSFUL", pipelineConfig.name()));
+        }
     }
 
     @Override

--- a/server/test/integration/com/thoughtworks/go/server/service/PipelineConfigServicePerformanceTest.java
+++ b/server/test/integration/com/thoughtworks/go/server/service/PipelineConfigServicePerformanceTest.java
@@ -155,6 +155,28 @@ public class PipelineConfigServicePerformanceTest {
 
     @Test
     @Ignore
+    public void performanceTestForDeletePipeline() throws Exception {
+        setupPipelines(numberOfRequests);
+        final ConcurrentHashMap<String, Boolean> results = new ConcurrentHashMap<>();
+        run(new Runnable() {
+            @Override
+            public void run() {
+                PipelineConfig pipelineConfig = goConfigService.getConfigForEditing().pipelineConfigByName(new CaseInsensitiveString(Thread.currentThread().getName()));
+                pipelineConfig.add(new StageConfig(new CaseInsensitiveString("additional_stage"), new JobConfigs(new JobConfig(new CaseInsensitiveString("addtn_job")))));
+                PerfTimer updateTimer = PerfTimer.start("Saving pipelineConfig : " + pipelineConfig.name());
+                pipelineConfigService.deletePipelineConfig(user, pipelineConfig, result);
+                updateTimer.stop();
+                results.put(Thread.currentThread().getName(), result.isSuccessful());
+                if (!result.isSuccessful()) {
+                    LOGGER.error(result.toString());
+                    LOGGER.error("Errors on pipeline" + Thread.currentThread().getName() + " are : " + ListUtil.join(getAllErrors(pipelineConfig)));
+                }
+            }
+        }, numberOfRequests, results);
+    }
+
+    @Test
+    @Ignore
     public void performanceTestForCreatePipeline() throws Exception {
         setupPipelines(0);
         final ConcurrentHashMap<String, Boolean> results = new ConcurrentHashMap<>();

--- a/server/webapp/WEB-INF/rails.new/app/controllers/api_v1/admin/pipelines_controller.rb
+++ b/server/webapp/WEB-INF/rails.new/app/controllers/api_v1/admin/pipelines_controller.rb
@@ -18,9 +18,10 @@ module ApiV1
   module Admin
     class PipelinesController < ApiV1::BaseController
       before_action :check_pipeline_group_admin_user_and_401
-      before_action :load_pipeline, only: [:show]
+      before_action :load_pipeline, only: [:show, :destroy]
       before_action :check_if_pipeline_by_same_name_already_exists, :check_group_not_blank, only: [:create]
       before_action :check_for_stale_request, :check_for_attempted_pipeline_rename, only: [:update]
+      before_action :check_for_pipeline_dependency, only: [:destroy]
 
       def show
         json = ApiV1::Config::PipelineConfigRepresenter.new(@pipeline_config).to_hash(url_builder: self)
@@ -44,6 +45,12 @@ module ApiV1
         get_pipeline_from_request
         pipeline_config_service.updatePipelineConfig(current_user, @pipeline_config_from_request, result)
         handle_config_save_or_update_result(result)
+      end
+
+      def destroy
+        result = HttpLocalizedOperationResult.new
+        pipeline_config_service.deletePipelineConfig(current_user, @pipeline_config, result)
+        render_http_operation_result(result)
       end
 
       private
@@ -115,6 +122,16 @@ module ApiV1
         if (!pipeline_config_service.getPipelineConfig(params[:pipeline_name]).nil?)
           result = HttpLocalizedOperationResult.new
           result.unprocessableEntity(LocalizedMessage::string("CANNOT_CREATE_PIPELINE_ALREADY_EXISTS", params[:pipeline_name]))
+          render_http_operation_result(result)
+        end
+      end
+
+      def check_for_pipeline_dependency
+        pipelines_can_be_deleted = pipeline_config_service.canDeletePipelines()
+        delete_result = pipelines_can_be_deleted[CaseInsensitiveString.new(params[:pipeline_name])]
+        if(!delete_result.canDelete())
+          result = HttpLocalizedOperationResult.new
+          result.unprocessableEntity(delete_result.message)
           render_http_operation_result(result)
         end
       end

--- a/server/webapp/WEB-INF/rails.new/config/routes.rb
+++ b/server/webapp/WEB-INF/rails.new/config/routes.rb
@@ -229,7 +229,7 @@ Go::Application.routes.draw do
       end
 
       namespace :admin do
-        resources :pipelines, param: :pipeline_name, only: [:show, :update, :create], constraints: {name: PIPELINE_NAME_FORMAT}
+        resources :pipelines, param: :pipeline_name, only: [:show, :update, :create, :destroy], constraints: {name: PIPELINE_NAME_FORMAT}
         resources :command_snippets, only: [:index]
         get 'command_snippets/show', controller: :command_snippets, action: :show, as: :command_snippet
         post :material_test, controller: :material_test, action: :test, as: :material_test

--- a/server/webapp/localize.xml
+++ b/server/webapp/localize.xml
@@ -793,5 +793,7 @@
     <entry key="ENTITY_CONFIG_VALIDATION_FAILED">Validations failed for {0} ''{1}''. Please correct and resubmit.</entry>
     <entry key="PIPELINE_RENAMING_NOT_ALLOWED">Renaming of pipeline is not supported by this API.</entry>
     <entry key="CANNOT_CREATE_PIPELINE_ALREADY_EXISTS">Failed to create pipeline ''{0}'' as another pipeline by the same name already exists.</entry>
+    <entry key="PIPELINE_DELETE_SUCCESSFUL">Pipeline ''{0}'' was deleted successfully.</entry>
+    <entry key="UNAUTHORIZED_TO_DELETE_PIPELINE">Unauthorized to delete pipeline.</entry>
     <entry key="PIPELINE_GROUP_MANDATORY_FOR_PIPELINE_CREATE">Pipeline group must be specified for creating a pipeline.</entry>
 </properties>

--- a/server/webapp/localize_ja.xml
+++ b/server/webapp/localize_ja.xml
@@ -789,5 +789,7 @@
     <entry key="ENTITY_CONFIG_VALIDATION_FAILED">Validations failed for {0} ''{1}''. Please correct and resubmit.</entry>
     <entry key="PIPELINE_RENAMING_NOT_ALLOWED">Renaming of pipeline is not supported by this API.</entry>
     <entry key="CANNOT_CREATE_PIPELINE_ALREADY_EXISTS">Failed to create pipeline ''{0}'' as another pipeline by the same name already exists.</entry>
+    <entry key="PIPELINE_DELETE_SUCCESSFUL">Pipeline ''{0}'' was deleted successfully.</entry>
+    <entry key="UNAUTHORIZED_TO_DELETE_PIPELINE">Unauthorized to delete pipeline.</entry>
     <entry key="PIPELINE_GROUP_MANDATORY_FOR_PIPELINE_CREATE">Pipeline group must be specified for creating a pipeline.</entry>
 </properties>


### PR DESCRIPTION
Pipelines can only be deleted if they don't have any dependencies

Pipelines CAN NOT be deleted
-- If it is used as a material in some another pipeline (if it has downstream pipelines)
--If is belongs to any environment

