### PR TITLE
#000 - Add debug information for flaky test (processCancelBuildCommandBuild)

### DIFF
--- a/agent/test/unit/com/thoughtworks/go/agent/AgentControllerTest.java
+++ b/agent/test/unit/com/thoughtworks/go/agent/AgentControllerTest.java
@@ -35,6 +35,7 @@ import com.thoughtworks.go.remote.work.Work;
 import com.thoughtworks.go.server.service.AgentBuildingInfo;
 import com.thoughtworks.go.server.service.AgentRuntimeInfo;
 import com.thoughtworks.go.util.HttpService;
+import com.thoughtworks.go.util.LogFixture;
 import com.thoughtworks.go.util.SubprocessLogger;
 import com.thoughtworks.go.util.SystemEnvironment;
 import com.thoughtworks.go.util.command.EnvironmentVariableContext;
@@ -102,6 +103,10 @@ public class AgentControllerTest {
     private String agentUuid = "uuid";
     private AgentIdentifier agentIdentifier;
     private AgentController agentController;
+
+    private LogFixture logListener;
+    private boolean printOutLogMessagesOnExit;
+
     @Rule
     public TemporaryFolder folder = new TemporaryFolder();
 
@@ -109,13 +114,18 @@ public class AgentControllerTest {
     public void setUp() throws Exception {
         initMocks(this);
         agentIdentifier = new AgentIdentifier(getLocalhostName(), getFirstLocalNonLoopbackIpAddress(), agentUuid);
+
+        logListener = LogFixture.startListening();
+        printOutLogMessagesOnExit = false;
     }
 
     @After
     public void tearDown() {
         GuidService.deleteGuid();
-    }
 
+        printDebugLoggingInformation();
+        logListener.stopListening();
+    }
 
     @Test
     public void shouldSetPluginManagerReference() throws Exception {
@@ -316,6 +326,7 @@ public class AgentControllerTest {
 
     @Test
     public void processCancelBuildCommandBuild() throws IOException, InterruptedException {
+        printOutLogMessagesOnExit = true;
         when(agentRegistry.uuid()).thenReturn(agentUuid);
         when(httpService.httpClient()).thenReturn(httpClient);
 
@@ -457,5 +468,15 @@ public class AgentControllerTest {
 
     private AgentController createAgentController() {
         return new AgentController(loopServer, artifactsManipulator, sslInfrastructureService, agentRegistry, agentUpgradeService, subprocessLogger, systemEnvironment,pluginManager, packageAsRepositoryExtension, scmExtension, taskExtension, agentWebsocketService, httpService);
+    }
+
+    private void printDebugLoggingInformation() {
+        if (printOutLogMessagesOnExit) {
+            System.err.println("Debug information:");
+            for (StackTraceElement traceElement : Thread.currentThread().getStackTrace()) {
+                System.err.println("  " + traceElement);
+            }
+            System.err.println(logListener.allLogsWithVerboseInformation());
+        }
     }
 }

--- a/common/src/com/thoughtworks/go/remote/work/RemoteConsoleAppender.java
+++ b/common/src/com/thoughtworks/go/remote/work/RemoteConsoleAppender.java
@@ -55,7 +55,7 @@ public class RemoteConsoleAppender implements ConsoleAppender {
             putMethod.setParams(clientParams);
             httpClient.executeMethod(putMethod);
             if (LOGGER.isDebugEnabled()) {
-                LOGGER.debug("Got " + putMethod.getStatusCode());
+                LOGGER.debug("Got " + putMethod.getStatusLine());
             }
         } finally {
             putMethod.releaseConnection();

--- a/util/src/com/thoughtworks/go/util/LogFixture.java
+++ b/util/src/com/thoughtworks/go/util/LogFixture.java
@@ -18,12 +18,14 @@
 package com.thoughtworks.go.util;
 
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 
 import org.apache.log4j.AppenderSkeleton;
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
 import org.apache.log4j.spi.LoggingEvent;
+import org.joda.time.DateTime;
 
 public class LogFixture extends AppenderSkeleton {
 
@@ -101,6 +103,20 @@ public class LogFixture extends AppenderSkeleton {
             if (event.getThrowableInformation() != null) {
                 for (String s : event.getThrowableStrRep()) {
                     builder.append(s).append("\n");
+                }
+            }
+        }
+        return builder.toString();
+    }
+
+    public String allLogsWithVerboseInformation() {
+        StringBuilder builder = new StringBuilder();
+        for (LoggingEvent event : events) {
+            builder.append(new DateTime(event.timeStamp)).append(" - ").append(event.getLevel())
+                    .append(" - ").append(event.getMessage()).append("\n");
+            if (event.getThrowableInformation() != null) {
+                for (String s : event.getThrowableStrRep()) {
+                    builder.append(new DateTime(event.timeStamp)).append(" - ").append(s).append("\n");
                 }
             }
         }


### PR DESCRIPTION
Trying to find out why [this failure](https://build.go.cd/go/tab/build/detail/build-linux/944/build-non-server/1/agent#tab-tests) keeps happening intermittently. This extra logging information might give a clue.

It looks like, sometimes, the test build command fails, rather than running the "sleep" and getting cancelled. So, instead of [this](https://github.com/gocd/gocd/blob/5feec49c4413035f71e8c0646502ee85287ad5d5/common/src/com/thoughtworks/go/buildsession/BuildSession.java#L170-L173) happening, [this](https://github.com/gocd/gocd/blob/5feec49c4413035f71e8c0646502ee85287ad5d5/common/src/com/thoughtworks/go/buildsession/BuildSession.java#L161-L166) or [this](https://github.com/gocd/gocd/blob/5feec49c4413035f71e8c0646502ee85287ad5d5/common/src/com/thoughtworks/go/buildsession/BuildSession.java#L170-L173) seems to happen. The extra logging *might* help pinpoint it, but not sure.