### PR TITLE
#695 Fixing admin email length to fit RFC 3696, Errata 1003

### DIFF
--- a/server/webapp/WEB-INF/rails.new/app/views/admin/server/index.html.erb
+++ b/server/webapp/WEB-INF/rails.new/app/views/admin/server/index.html.erb
@@ -158,7 +158,7 @@
                     <div class="form_item">
 
                         <label for="server_configuration_form_adminMail"><%= required_label_text(l.string("MAIL_HOST_ADMIN_MAIL")) -%></label>
-                        <%= form.text_field :adminMail, :size => 30, :maxLength => 64, :onblur => "serverConfiguration.validateEmail('server_configuration_form_adminMail', 'admin_mail_error_message')" %>
+                        <%= form.text_field :adminMail, :size => 30, :maxLength => 254, :onblur => "serverConfiguration.validateEmail('server_configuration_form_adminMail', 'admin_mail_error_message')" %>
                         <button type="button" class="submit tertiary" id="testNotification"
                                 onclick="serverConfiguration.sendTestEmail(this, '<%= send_test_email_path %>', '<%= form_authenticity_token %>')">
                             <span><%= l.string("MAIL_HOST_SEND_TEST_EMAIL") -%></span>


### PR DESCRIPTION
According to the IETF, [RFC 3696](https://tools.ietf.org/html/rfc3696) in [Errata 1003](https://www.rfc-editor.org/errata_search.php?rfc=3696&eid=1003) states that email address lengths are to be 254 octets. This is a fix to both follow that standard and fix the root of [issue #695](https://github.com/gocd/gocd/issues/695).