### PR TITLE
Fix a CNFE with Shine (#2249)

### DIFF
--- a/server/src/com/thoughtworks/studios/shine/XSLTTransformerExecutor.java
+++ b/server/src/com/thoughtworks/studios/shine/XSLTTransformerExecutor.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2016 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.studios.shine;
+
+import com.thoughtworks.studios.shine.semweb.grddl.GrddlTransformException;
+
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerException;
+
+public interface XSLTTransformerExecutor<T> {
+
+    T execute(Transformer transformer) throws TransformerException, GrddlTransformException;
+}

--- a/server/src/com/thoughtworks/studios/shine/cruise/GoGRDDLResourceRDFizer.java
+++ b/server/src/com/thoughtworks/studios/shine/cruise/GoGRDDLResourceRDFizer.java
@@ -1,22 +1,20 @@
-/*************************GO-LICENSE-START*********************************
- * Copyright 2014 ThoughtWorks, Inc.
+/*
+ * Copyright 2016 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *************************GO-LICENSE-END***********************************/
+ */
 
 package com.thoughtworks.studios.shine.cruise;
-
-import java.io.IOException;
 
 import com.thoughtworks.go.domain.XmlRepresentable;
 import com.thoughtworks.go.server.service.XmlApiService;
@@ -25,10 +23,12 @@ import com.thoughtworks.studios.shine.semweb.Graph;
 import com.thoughtworks.studios.shine.semweb.TempGraphFactory;
 import com.thoughtworks.studios.shine.semweb.XMLRDFizer;
 import com.thoughtworks.studios.shine.semweb.grddl.GRDDLTransformer;
-import com.thoughtworks.studios.shine.semweb.grddl.XSLTTransformerRegistry;
 import com.thoughtworks.studios.shine.semweb.grddl.GrddlTransformException;
+import com.thoughtworks.studios.shine.semweb.grddl.XSLTTransformerRegistry;
 import org.dom4j.Document;
 import org.dom4j.DocumentException;
+
+import java.io.IOException;
 
 public class GoGRDDLResourceRDFizer implements XMLRDFizer {
     private final GRDDLTransformer grddlTransformer;
@@ -40,7 +40,7 @@ public class GoGRDDLResourceRDFizer implements XMLRDFizer {
         this.rootNodeName = rootNodeName;
         this.graphFactory = graphFactory;
         this.xmlApiService = xmlApiService;
-        this.grddlTransformer = new GRDDLTransformer(transformerRegistry.getTransformer(grddlResourcePath));
+        this.grddlTransformer = new GRDDLTransformer(transformerRegistry, grddlResourcePath);
     }
 
     public boolean canHandle(Document doc) {

--- a/server/src/com/thoughtworks/studios/shine/cruise/stage/details/JobResourceImporter.java
+++ b/server/src/com/thoughtworks/studios/shine/cruise/stage/details/JobResourceImporter.java
@@ -1,18 +1,18 @@
-/*************************GO-LICENSE-START*********************************
- * Copyright 2014 ThoughtWorks, Inc.
+/*
+ * Copyright 2016 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *************************GO-LICENSE-END***********************************/
+ */
 
 package com.thoughtworks.studios.shine.cruise.stage.details;
 
@@ -53,7 +53,7 @@ public class JobResourceImporter {
 
     public JobResourceImporter(String artifactBaseDir, TempGraphFactory graphFactory, XSLTTransformerRegistry transformerRegistry, XmlApiService xmlApiService, SystemEnvironment systemEnvironment) {
         this.artifactBaseDir = artifactBaseDir;
-        rdfizer = new GoGRDDLResourceRDFizer("job", "cruise/job-grddl.xsl", graphFactory, transformerRegistry, xmlApiService);
+        rdfizer = new GoGRDDLResourceRDFizer("job", XSLTTransformerRegistry.CRUISE_JOB_GRDDL_XSL, graphFactory, transformerRegistry, xmlApiService);
         importer = new XMLArtifactImporter(systemEnvironment);
         AntJUnitReportRDFizer junitRDFizer = new AntJUnitReportRDFizer(graphFactory, transformerRegistry);
         importer.registerHandler(junitRDFizer);

--- a/server/src/com/thoughtworks/studios/shine/cruise/stage/details/StageResourceImporter.java
+++ b/server/src/com/thoughtworks/studios/shine/cruise/stage/details/StageResourceImporter.java
@@ -1,18 +1,18 @@
-/*************************GO-LICENSE-START*********************************
- * Copyright 2014 ThoughtWorks, Inc.
+/*
+ * Copyright 2016 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *************************GO-LICENSE-END***********************************/
+ */
 
 package com.thoughtworks.studios.shine.cruise.stage.details;
 
@@ -92,7 +92,7 @@ public class StageResourceImporter {
 
     private Graph loadIsolatedStageGraph(StageIdentifier stageIdentifier, TempGraphFactory tempGraphFactory, XSLTTransformerRegistry transformerRegistry,
                                          final Stage stageWithIdentifier, final String baseUri) throws GoIntegrationException {
-        GoGRDDLResourceRDFizer stageRdfizer = new GoGRDDLResourceRDFizer("stage", "cruise/stage-graph-grddl.xsl", tempGraphFactory, transformerRegistry, xmlApiService);
+        GoGRDDLResourceRDFizer stageRdfizer = new GoGRDDLResourceRDFizer("stage", XSLTTransformerRegistry.CRUISE_STAGE_GRAPH_GRDDL_XSL, tempGraphFactory, transformerRegistry, xmlApiService);
         Graph graph = stageRdfizer.importURIUsingGRDDL(new StageXmlViewModel(stageWithIdentifier), baseUri);
         if (!stageCompleted(graph)) {
             throw new CanNotImportABuildingStageException(stageIdentifier + " is not completed yet, can not load test details");
@@ -112,7 +112,7 @@ public class StageResourceImporter {
     }
 
     private void importPipeline(PipelineInstanceModel pipelineInstance, Graph graph, XSLTTransformerRegistry transformerRegistry, String baseUri) throws GoIntegrationException {
-        final GoGRDDLResourceRDFizer pipeline = new GoGRDDLResourceRDFizer("pipeline", "cruise/pipeline-graph-grddl.xsl", graph, transformerRegistry, xmlApiService);
+        final GoGRDDLResourceRDFizer pipeline = new GoGRDDLResourceRDFizer("pipeline", XSLTTransformerRegistry.CRUISE_PIPELINE_GRAPH_GRDDL_XSL, graph, transformerRegistry, xmlApiService);
         Graph pipelineGraph = pipeline.importURIUsingGRDDL(new PipelineXmlViewModel(pipelineInstance), baseUri);
 
         graph.addTriplesFromGraph(pipelineGraph);

--- a/server/src/com/thoughtworks/studios/shine/semweb/grddl/GRDDLTransformer.java
+++ b/server/src/com/thoughtworks/studios/shine/semweb/grddl/GRDDLTransformer.java
@@ -1,27 +1,23 @@
-/*************************GO-LICENSE-START*********************************
- * Copyright 2014 ThoughtWorks, Inc.
+/*
+ * Copyright 2016 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *************************GO-LICENSE-END***********************************/
+ */
 
 package com.thoughtworks.studios.shine.semweb.grddl;
 
-import java.io.InputStream;
-import java.io.StringReader;
-import javax.xml.transform.Transformer;
-import javax.xml.transform.TransformerException;
-
 import com.thoughtworks.studios.shine.ShineRuntimeException;
+import com.thoughtworks.studios.shine.XSLTTransformerExecutor;
 import com.thoughtworks.studios.shine.semweb.Graph;
 import com.thoughtworks.studios.shine.semweb.TempGraphFactory;
 import org.apache.log4j.Logger;
@@ -31,19 +27,34 @@ import org.dom4j.io.DocumentResult;
 import org.dom4j.io.DocumentSource;
 import org.dom4j.io.SAXReader;
 
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerException;
+import java.io.InputStream;
+import java.io.StringReader;
+
 public class GRDDLTransformer {
-    private Transformer transformer;
+    private final XSLTTransformerRegistry xsltTransformerRegistry;
+    private final String key;
     private final static Logger LOGGER = Logger.getLogger(GRDDLTransformer.class);
 
-    public GRDDLTransformer(Transformer xsltTransformer) {
-        this.transformer = xsltTransformer;
+
+    public GRDDLTransformer(XSLTTransformerRegistry xsltTransformerRegistry, String key) {
+        this.xsltTransformerRegistry = xsltTransformerRegistry;
+        this.key = key;
     }
 
-    public Graph transform(Document inputDoc, TempGraphFactory graphFactory) throws GrddlTransformException {
-        DocumentResult result = new DocumentResult();
+    public Graph transform(final Document inputDoc, TempGraphFactory graphFactory) throws GrddlTransformException {
+        final DocumentResult result = new DocumentResult();
         try {
-            DocumentSource source = new DocumentSource(inputDoc);
-            transformer.transform(source, result);
+            xsltTransformerRegistry.transformWithCorrectClassLoader(key, new XSLTTransformerExecutor<Void>() {
+                @Override
+                public Void execute(Transformer transformer) throws TransformerException {
+                    DocumentSource source = new DocumentSource(inputDoc);
+                    transformer.transform(source, result);
+                    return null;
+                }
+            });
+
             // TODO: likely need to optimize with some sort of streaming document reader here
             Graph graph = graphFactory.createTempGraph();
             graph.addTriplesFromRDFXMLAbbrev(new StringReader(result.getDocument().asXML()));

--- a/server/src/com/thoughtworks/studios/shine/xunit/AntJUnitReportRDFizer.java
+++ b/server/src/com/thoughtworks/studios/shine/xunit/AntJUnitReportRDFizer.java
@@ -1,34 +1,29 @@
-/*************************GO-LICENSE-START*********************************
- * Copyright 2014 ThoughtWorks, Inc.
+/*
+ * Copyright 2016 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *************************GO-LICENSE-END***********************************/
+ */
 
 package com.thoughtworks.studios.shine.xunit;
 
+import com.thoughtworks.studios.shine.semweb.*;
+import com.thoughtworks.studios.shine.semweb.grddl.GRDDLTransformer;
+import com.thoughtworks.studios.shine.semweb.grddl.GrddlTransformException;
+import com.thoughtworks.studios.shine.semweb.grddl.XSLTTransformerRegistry;
+import org.dom4j.Document;
+
 import java.util.ArrayList;
 import java.util.List;
-
-import com.thoughtworks.studios.shine.semweb.BoundVariables;
-import com.thoughtworks.studios.shine.semweb.Graph;
-import com.thoughtworks.studios.shine.semweb.Resource;
-import com.thoughtworks.studios.shine.semweb.TempGraphFactory;
-import com.thoughtworks.studios.shine.semweb.URIReference;
-import com.thoughtworks.studios.shine.semweb.XMLRDFizer;
-import com.thoughtworks.studios.shine.semweb.grddl.GRDDLTransformer;
-import com.thoughtworks.studios.shine.semweb.grddl.XSLTTransformerRegistry;
-import com.thoughtworks.studios.shine.semweb.grddl.GrddlTransformException;
-import org.dom4j.Document;
 
 public class AntJUnitReportRDFizer implements XMLRDFizer {
     private TempGraphFactory graphFactory;
@@ -42,9 +37,9 @@ public class AntJUnitReportRDFizer implements XMLRDFizer {
             "}";
     private GRDDLTransformer grddlTransformer;
 
-    public AntJUnitReportRDFizer(TempGraphFactory graphFactory, XSLTTransformerRegistry XSLTTransformerRegistry) {
+    public AntJUnitReportRDFizer(TempGraphFactory graphFactory, XSLTTransformerRegistry xsltTransformerRegistry) {
         this.graphFactory = graphFactory;
-        grddlTransformer = new GRDDLTransformer(XSLTTransformerRegistry.getTransformer("xunit/ant-junit-grddl.xsl"));
+        grddlTransformer = new GRDDLTransformer(xsltTransformerRegistry, XSLTTransformerRegistry.XUNIT_ANT_JUNIT_GRDDL_XSL);
     }
 
     public boolean canHandle(Document doc) {

--- a/server/test/unit/com/thoughtworks/studios/shine/semweb/grddl/XSLTTransformerRegistryTest.java
+++ b/server/test/unit/com/thoughtworks/studios/shine/semweb/grddl/XSLTTransformerRegistryTest.java
@@ -16,9 +16,11 @@
 
 package com.thoughtworks.studios.shine.semweb.grddl;
 
+import com.thoughtworks.studios.shine.XSLTTransformerExecutor;
 import org.junit.Test;
 
 import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerException;
 
 import static org.junit.Assert.assertNotSame;
 
@@ -27,9 +29,18 @@ public class XSLTTransformerRegistryTest {
     @Test
     public void getTransformerShouldNeverReturnTheSameTransformerTwice() throws Exception {
         XSLTTransformerRegistry registry = new XSLTTransformerRegistry();
-        Transformer transformer1 = registry.getTransformer("xunit/ant-junit-grddl.xsl");
-        Transformer transformer2 = registry.getTransformer("xunit/ant-junit-grddl.xsl");
-
+        Transformer transformer1 = registry.transformWithCorrectClassLoader("xunit/ant-junit-grddl.xsl", new XSLTTransformerExecutor<Transformer>() {
+            @Override
+            public Transformer execute(Transformer transformer) throws TransformerException, GrddlTransformException {
+                return transformer;
+            }
+        });
+        Transformer transformer2 = registry.transformWithCorrectClassLoader("xunit/ant-junit-grddl.xsl", new XSLTTransformerExecutor<Transformer>() {
+            @Override
+            public Transformer execute(Transformer transformer) throws TransformerException, GrddlTransformException {
+                return transformer;
+            }
+        });
         assertNotSame(transformer1, transformer2);
     }
 }

--- a/server/test/unit/com/thoughtworks/studios/shine/xunit/AntJUnitGRDDLTest.java
+++ b/server/test/unit/com/thoughtworks/studios/shine/xunit/AntJUnitGRDDLTest.java
@@ -1,32 +1,33 @@
-/*************************GO-LICENSE-START*********************************
- * Copyright 2014 ThoughtWorks, Inc.
+/*
+ * Copyright 2016 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *************************GO-LICENSE-END***********************************/
+ */
 
 package com.thoughtworks.studios.shine.xunit;
 
-import java.io.ByteArrayInputStream;
-import java.io.InputStream;
-
-import static com.thoughtworks.studios.shine.AssertUtils.assertAskIsFalse;
-import static com.thoughtworks.studios.shine.AssertUtils.assertAskIsTrue;
 import com.thoughtworks.studios.shine.semweb.Graph;
 import com.thoughtworks.studios.shine.semweb.grddl.GRDDLTransformer;
 import com.thoughtworks.studios.shine.semweb.grddl.XSLTTransformerRegistry;
 import com.thoughtworks.studios.shine.semweb.sesame.InMemoryTempGraphFactory;
 import org.junit.Before;
 import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+
+import static com.thoughtworks.studios.shine.AssertUtils.assertAskIsFalse;
+import static com.thoughtworks.studios.shine.AssertUtils.assertAskIsTrue;
 
 public class AntJUnitGRDDLTest {
     String minimalXUnitXML =
@@ -47,9 +48,9 @@ public class AntJUnitGRDDLTest {
     @Before
     public void setUp() throws Exception {
         InputStream xunitXMLStream = new ByteArrayInputStream(minimalXUnitXML.getBytes());
-        XSLTTransformerRegistry XSLTTransformerRegistry = new XSLTTransformerRegistry();
+        XSLTTransformerRegistry xsltTransformerRegistry = new XSLTTransformerRegistry();
 
-        transformer = new GRDDLTransformer(XSLTTransformerRegistry.getTransformer("xunit/ant-junit-grddl.xsl"));
+        transformer = new GRDDLTransformer(xsltTransformerRegistry, XSLTTransformerRegistry.XUNIT_ANT_JUNIT_GRDDL_XSL);
         minimalDataGraph = transformer.transform(xunitXMLStream, new InMemoryTempGraphFactory());
     }
 

--- a/server/test/unit/com/thoughtworks/studios/shine/xunit/NUnitRDFizerTest.java
+++ b/server/test/unit/com/thoughtworks/studios/shine/xunit/NUnitRDFizerTest.java
@@ -230,7 +230,7 @@ public class NUnitRDFizerTest {
                 + "</testsuite>"
                 + "</testsuites>";
 
-        try(InputStream xsl = getClass().getClassLoader().getResourceAsStream("xunit/nunit-to-junit.xsl")) {
+        try(InputStream xsl = getClass().getClassLoader().getResourceAsStream(XSLTTransformerRegistry.XUNIT_NUNIT_TO_JUNIT_XSL)) {
             TransformerFactory transformerFactory = TransformerFactory.newInstance();
             DocumentSource source = new DocumentSource(new SAXReader().read(new InputSource(new ByteArrayInputStream(nunitInputXml.getBytes("utf-8")))));
             DocumentResult result = new DocumentResult();
@@ -289,7 +289,7 @@ public class NUnitRDFizerTest {
                 + "</testsuite>"
                 + "</testsuites>";
 
-        try (InputStream xsl = getClass().getClassLoader().getResourceAsStream("xunit/nunit-to-junit.xsl")) {
+        try (InputStream xsl = getClass().getClassLoader().getResourceAsStream(XSLTTransformerRegistry.XUNIT_NUNIT_TO_JUNIT_XSL)) {
             TransformerFactory transformerFactory = TransformerFactory.newInstance();
             DocumentSource source = new DocumentSource(new SAXReader().read(new InputSource(new ByteArrayInputStream(nunitInputXml.getBytes("utf-8")))));
             DocumentResult result = new DocumentResult();


### PR DESCRIPTION
Websockets execute in the context of a separate class loader, this causes
CNFE when executing shine XSLT transformations.

The fix is to use the same classloader the one that constructs
`XSLTTransformerRegistry` to perform the actual transforms.