### PR TITLE
Remove system properties that do not make sense on windows

### DIFF
--- a/installers/server/win/config/wrapper-server.conf
+++ b/installers/server/win/config/wrapper-server.conf
@@ -60,13 +60,13 @@ wrapper.java.additional.5=-Duser.language=en
 wrapper.java.additional.6=-Duser.country=US
 wrapper.java.additional.7="-Dcruise.config.dir=%CRUISE_SERVER_DIR%\config"
 wrapper.java.additional.8="-Dcruise.config.file=%CRUISE_SERVER_DIR%\config\cruise-config.xml"
-wrapper.java.additional.9=-Dcruise.server.port=8153
-wrapper.java.additional.10=-Dcruise.server.ssl.port=8154
-wrapper.java.additional.11="-DJAVA_SYS_MON_TEMP_DIR=%CRUISE_SERVER_DIR%\tmp"
+wrapper.java.additional.9=-DreservedForFuture.1
+wrapper.java.additional.10=-DreservedForFuture.2
+wrapper.java.additional.11=-DreservedForFuture.3
 wrapper.java.additional.12=%JVM_DEBUG%
 wrapper.java.additional.13=%GC_LOG%
-wrapper.java.additional.14="-Dorg.eclipse.jetty.server.Request.maxFormContentSize=30000000"
-wrapper.java.additional.15="-Djruby.rack.request.size.threshold.bytes=30000000"
+wrapper.java.additional.14=-DreservedForFuture.4
+wrapper.java.additional.15=-DreservedForFuture.5
 
 #include config/wrapper-properties.conf
 


### PR DESCRIPTION
* Some of these are already defaults
* the post size params are already configured elsewhere
* replace those properties with "placeholders" to not leave sequence gaps
  https://wrapper.tanukisoftware.com/doc/english/prop-ignore-sequence-gaps.html