### PR TITLE
Allow turning on web request logging by tweaking `log4j.properties`

### DIFF
--- a/cruise-modules.rb
+++ b/cruise-modules.rb
@@ -202,6 +202,7 @@ define "cruise:server", :layout => server_layout("server") do
     include_fileset_from_target(jar, 'jetty9', "**/Jetty9ServletHelper*.class")
     include_fileset_from_target(jar, 'jetty9', "**/Jetty9Request.class")
     include_fileset_from_target(jar, 'jetty9', "**/Jetty9Response.class")
+    include_fileset_from_target(jar, 'jetty9', "**/Slf4jRequestLogger.class")
     # # ---- Jetty 9 end ---
 
     include_fileset_from_target(jar, 'common', "**/SubprocessLogger*.class")

--- a/jetty9/src/com/thoughtworks/go/server/logging/Slf4jRequestLogger.java
+++ b/jetty9/src/com/thoughtworks/go/server/logging/Slf4jRequestLogger.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2016 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.server.logging;
+
+import org.eclipse.jetty.server.AbstractNCSARequestLog;
+import org.eclipse.jetty.server.RequestLog;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+
+public class Slf4jRequestLogger extends AbstractNCSARequestLog implements RequestLog {
+
+    private static Logger LOG = LoggerFactory.getLogger("org.eclipse.jetty.server.RequestLog");
+
+    @Override
+    protected boolean isEnabled() {
+        return LOG.isInfoEnabled();
+    }
+
+    @Override
+    public void write(String requestEntry) throws IOException {
+        LOG.info(requestEntry);
+    }
+
+}

--- a/server/config/jetty.xml
+++ b/server/config/jetty.xml
@@ -1,19 +1,19 @@
 <?xml version="1.0"?>
-<!-- *************************GO-LICENSE-START******************************
- * Copyright 2015 ThoughtWorks, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *************************GO-LICENSE-END******************************* -->
+<!--
+  ~ Copyright 2016 ThoughtWorks, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
 
 <!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure.dtd">
 
@@ -53,26 +53,26 @@
     <!-- =========================================================== -->
     <!-- Logging                                                     -->
     <!-- =========================================================== -->
-    <!-- Note: Please create the weblogs directory if not exist -->
-    <!--
+    <!-- To turn this on, set the log level for org.eclipse.jetty.server.RequestLog to INFO -->
     <Get name="handler">
         <Call name="addHandler">
             <Arg>
                 <New class="org.eclipse.jetty.server.handler.RequestLogHandler">
                     <Set name="requestLog">
-                        <New class="org.eclipse.jetty.server.NCSARequestLog">
-                            <Arg><SystemProperty name="jetty.logs" default="./weblogs"/>/jetty-yyyy_mm_dd.request.log</Arg>
-                            <Set name="filenameDateFormat">yyyy_MM_dd</Set>
-                            <Set name="retainDays">7</Set>
-                            <Set name="append">true</Set>
+                        <New class="com.thoughtworks.go.server.logging.Slf4jRequestLogger">
                             <Set name="extended">false</Set>
                             <Set name="logCookies">false</Set>
-                            <Set name="logLatency">false</Set>
+                            <Set name="logLatency">true</Set>
+                            <Set name="ignorePaths">
+                              <Array type="java.lang.String">
+                                <Item>/go/assets/*</Item>
+                                <Item>/go/server/messages.json</Item>
+                              </Array>
+                            </Set>
                         </New>
                     </Set>
                 </New>
             </Arg>
         </Call>
     </Get>
-    -->
 </Configure>

--- a/server/properties/src/log4j.properties
+++ b/server/properties/src/log4j.properties
@@ -1,5 +1,5 @@
-##########################GO-LICENSE-START################################
-# Copyright 2014 ThoughtWorks, Inc.
+#
+# Copyright 2016 ThoughtWorks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,13 +12,15 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-##########################GO-LICENSE-END##################################
+#
 
 log4j.rootLogger=WARN, FileAppender
 log4j.logger.com.thoughtworks.go=INFO
 # turn on all shine logging
 log4j.logger.com.thoughtworks.studios.shine=WARN,ShineFileAppender
 log4j.logger.com.thoughtworks.go.server.Rails=WARN
+log4j.logger.org.eclipse.jetty.server.RequestLog=WARN
+
 log4j.logger.org.springframework=WARN
 log4j.logger.org.apache.velocity=WARN
 


### PR DESCRIPTION
RequestLogHandler is added into the handler chain by default, however
since request logging is a CPU intensive operation, we short circuit it
by disabling logging if the log level is set to `WARN` or higher level.