### PR TITLE
#2299 Removed HTML escaping of build-cause-author-name 

### DIFF
--- a/server/src/com/thoughtworks/go/server/presentation/models/JobDetailPresentationModel.java
+++ b/server/src/com/thoughtworks/go/server/presentation/models/JobDetailPresentationModel.java
@@ -138,12 +138,6 @@ public class JobDetailPresentationModel {
         return new ModificationSummaries(pipeline.getMaterialRevisions());
     }
 
-    public String getMaterialRevisionsJson() {
-        MaterialRevisionsJsonBuilder jsonVisitor = new MaterialRevisionsJsonBuilder(trackingTool);
-        pipeline.getMaterialRevisions().accept(jsonVisitor);
-        return render(jsonVisitor.json());
-    }
-
     public String getModificationTime() {
         return converter.nullSafeDate(pipeline.getModifiedDate());
     }

--- a/server/src/com/thoughtworks/go/server/presentation/models/MaterialRevisionsJsonBuilder.java
+++ b/server/src/com/thoughtworks/go/server/presentation/models/MaterialRevisionsJsonBuilder.java
@@ -70,7 +70,7 @@ public class MaterialRevisionsJsonBuilder extends ModificationVisitorAdapter {
         modifiedFilesJson = new ArrayList();
 
         Map<String, Object> jsonMap = new LinkedHashMap<>();
-        jsonMap.put("user", escapeHtml(modification.getUserDisplayName()));
+        jsonMap.put("user", modification.getUserDisplayName());
         jsonMap.put("revision", modification.getRevision());
         jsonMap.put("date", formatISO8601(modification.getModifiedTime()));
         String comment = modification.getComment();

--- a/server/src/com/thoughtworks/go/server/presentation/models/StageDetailPresentationModel.java
+++ b/server/src/com/thoughtworks/go/server/presentation/models/StageDetailPresentationModel.java
@@ -83,12 +83,6 @@ public class StageDetailPresentationModel {
         return stage.stageState().toString().toLowerCase();
     }
 
-    public String getMaterialRevisionsJson() {
-        MaterialRevisionsJsonBuilder jsonVisitor = new MaterialRevisionsJsonBuilder(trackingTool);
-        pipeline.getBuildCause().getMaterialRevisions().accept(jsonVisitor);
-        return render(jsonVisitor.json());
-    }
-
     public TimeConverter.ConvertedTime getModificationTime() {
         return this.converter.getConvertedTime(pipeline.getBuildCause().getMaterialRevisions().getDateOfLatestModification());
     }

--- a/server/test/unit/com/thoughtworks/go/server/presentation/models/MaterialRevisionsJsonBuilderTest.java
+++ b/server/test/unit/com/thoughtworks/go/server/presentation/models/MaterialRevisionsJsonBuilderTest.java
@@ -118,7 +118,7 @@ public class MaterialRevisionsJsonBuilderTest {
         JSONArray jsonArray = (JSONArray) revision.get("modifications");
         JSONObject modification = (JSONObject) jsonArray.get(0);
 
-        assertAttributeInJson(modification, "user", escapeHtml(ModificationsMother.MOD_USER_WITH_HTML_CHAR));
+        assertAttributeInJson(modification, "user", ModificationsMother.MOD_USER_WITH_HTML_CHAR);
         assertAttributeInJson(modification, "comment", escapeHtml(ModificationsMother.MOD_COMMENT_3));
     }
 

--- a/server/webapp/WEB-INF/vm/build_detail/_material_revisions_jstemplate.vm
+++ b/server/webapp/WEB-INF/vm/build_detail/_material_revisions_jstemplate.vm
@@ -41,7 +41,7 @@
             <tr>
                 <th colspan="2" class="highlight-${%revision.changed%}">
 
-                    <span class="normal revision_information">Revision: ${%modification.revision%}, modified by ${%modification.user%} on ${%modification.date%} </span>
+                    <span class="normal revision_information">Revision: ${%modification.revision%}, modified by ${%modification.user.escapeHTML()%} on ${%modification.date%} </span>
                     <br/>
 
                     <span title="Comment" class="comment">


### PR DESCRIPTION
Removed HTML escaping of build-cause-author-name to display the name without escaping

author details:

previous result : `ganeshpl &lt;ganespl@INganespl.local&gt;`
Changed to     : `ganeshpl <ganespl@INganespl.local>`