### PR TITLE
Check for stale request before pipeline_config save #2337

### DIFF
--- a/server/src/com/thoughtworks/go/config/update/UpdatePipelineConfigCommand.java
+++ b/server/src/com/thoughtworks/go/config/update/UpdatePipelineConfigCommand.java
@@ -5,22 +5,29 @@ import com.thoughtworks.go.config.CruiseConfig;
 import com.thoughtworks.go.config.PipelineConfig;
 import com.thoughtworks.go.config.PipelineConfigSaveValidationContext;
 import com.thoughtworks.go.config.commands.EntityConfigUpdateCommand;
+import com.thoughtworks.go.i18n.LocalizedMessage;
 import com.thoughtworks.go.server.domain.Username;
+import com.thoughtworks.go.server.service.EntityHashingService;
 import com.thoughtworks.go.server.service.GoConfigService;
 import com.thoughtworks.go.server.service.result.LocalizedOperationResult;
 
 public class UpdatePipelineConfigCommand implements EntityConfigUpdateCommand<PipelineConfig> {
     private final GoConfigService goConfigService;
+    private final EntityHashingService entityHashingService;
     private final PipelineConfig pipelineConfig;
     private final Username currentUser;
+    private final String md5;
     private final LocalizedOperationResult result;
     public String group;
     private PipelineConfig preprocessedPipelineConfig;
 
-    public UpdatePipelineConfigCommand(GoConfigService goConfigService, PipelineConfig pipelineConfig, Username currentUser, LocalizedOperationResult result) {
+    public UpdatePipelineConfigCommand(GoConfigService goConfigService, EntityHashingService entityHashingService, PipelineConfig pipelineConfig,
+                                       Username currentUser, String md5, LocalizedOperationResult result) {
         this.goConfigService = goConfigService;
+        this.entityHashingService = entityHashingService;
         this.pipelineConfig = pipelineConfig;
         this.currentUser = currentUser;
+        this.md5 = md5;
         this.result = result;
     }
 
@@ -51,7 +58,21 @@ public class UpdatePipelineConfigCommand implements EntityConfigUpdateCommand<Pi
 
     @Override
     public boolean canContinue(CruiseConfig cruiseConfig) {
+        return canEditPipeline() && isRequestFresh();
+    }
+
+    private boolean canEditPipeline() {
         return goConfigService.canEditPipeline(pipelineConfig.name().toString(), currentUser, result, getPipelineGroup());
+    }
+
+    private boolean isRequestFresh() {
+        boolean freshRequest = entityHashingService.md5ForPipelineConfig(pipelineConfig.name().toString()).equals(md5);
+
+        if (!freshRequest) {
+            result.stale(LocalizedMessage.string("STALE_PIPELINE_CONFIG", pipelineConfig.name().toString()));
+        }
+
+        return freshRequest;
     }
 }
 

--- a/server/src/com/thoughtworks/go/server/initializers/ApplicationInitializer.java
+++ b/server/src/com/thoughtworks/go/server/initializers/ApplicationInitializer.java
@@ -90,6 +90,7 @@ public class ApplicationInitializer implements ApplicationListener<ContextRefres
     @Autowired private GoPartialConfig goPartialConfig;
     @Autowired private ConfigCache configCache;
     @Autowired private ConfigElementImplementationRegistry configElementImplementationRegistry;
+    @Autowired private EntityHashingService entityHashingService;
 
     @Override
     public void onApplicationEvent(ContextRefreshedEvent contextRefreshedEvent) {
@@ -113,6 +114,7 @@ public class ApplicationInitializer implements ApplicationListener<ContextRefres
             cachedGoConfig.loadConfigIfNull();
             goConfigService.initialize();
             pipelineConfigService.initialize();
+            entityHashingService.initialize();
 
             //artifacts
             artifactsDirHolder.initialize();

--- a/server/src/com/thoughtworks/go/server/service/EntityHashingService.java
+++ b/server/src/com/thoughtworks/go/server/service/EntityHashingService.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2016 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.server.service;
+
+import com.thoughtworks.go.config.CaseInsensitiveString;
+import com.thoughtworks.go.config.CruiseConfig;
+import com.thoughtworks.go.config.PipelineConfig;
+import com.thoughtworks.go.listener.ConfigChangedListener;
+import com.thoughtworks.go.listener.EntityConfigChangedListener;
+import com.thoughtworks.go.server.cache.GoCache;
+import com.thoughtworks.go.server.initializers.Initializer;
+import com.thoughtworks.go.server.util.EntityDigest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class EntityHashingService implements ConfigChangedListener, Initializer {
+    private GoConfigService goConfigService;
+    private GoCache goCache;
+    private EntityDigest entityDigest;
+    private static final String PIPELINE_CONFIG_CACHE_KEY = "GO_PIPELINE_CONFIGS_ETAGS_CACHE".intern();
+
+    @Autowired
+    public EntityHashingService(GoConfigService goConfigService, GoCache goCache) {
+        this.goConfigService = goConfigService;
+        this.goCache = goCache;
+    }
+
+    public void initialize() {
+        goConfigService.register(this);
+        goConfigService.register(new PipelineConfigChangedListener());
+    }
+
+    public EntityHashingService initializeWith(EntityDigest entityDigest) {
+        this.entityDigest = entityDigest;
+        return this;
+    }
+
+    public String md5ForPipelineConfig(String pipelineName) {
+        String cachedMD5 = cachedMD5(pipelineName);
+
+        return cachedMD5 != null ? cachedMD5 : md5For(pipelineName);
+    }
+
+    @Override
+    public void onConfigChange(CruiseConfig newCruiseConfig) {
+        goCache.remove(PIPELINE_CONFIG_CACHE_KEY);
+    }
+
+    private String md5For(String pipelineName) {
+        String md5 = entityDigest.md5ForPipeline(goConfigService.pipelineConfigNamed(new CaseInsensitiveString(pipelineName)));
+
+        addToCache(pipelineName, md5);
+
+        return md5;
+    }
+
+    private String cachedMD5(String pipelineName) {
+        return (String) goCache.get(PIPELINE_CONFIG_CACHE_KEY, pipelineName.toLowerCase());
+    }
+
+    private void addToCache(String pipelineName, String md5) {
+        goCache.put(PIPELINE_CONFIG_CACHE_KEY, pipelineName.toLowerCase(), md5);
+    }
+
+    class PipelineConfigChangedListener extends EntityConfigChangedListener<PipelineConfig> {
+        @Override
+        public void onEntityConfigChange(PipelineConfig pipelineConfig) {
+            goCache.remove(PIPELINE_CONFIG_CACHE_KEY, pipelineConfig.name().toLower());
+        }
+    }
+}

--- a/server/src/com/thoughtworks/go/server/util/EntityDigest.java
+++ b/server/src/com/thoughtworks/go/server/util/EntityDigest.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2016 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.server.util;
+
+import com.thoughtworks.go.config.PipelineConfig;
+
+public interface EntityDigest {
+    String md5ForPipeline(PipelineConfig pipelineConfig);
+}

--- a/server/test/integration/com/thoughtworks/go/server/service/PipelineConfigServicePerformanceTest.java
+++ b/server/test/integration/com/thoughtworks/go/server/service/PipelineConfigServicePerformanceTest.java
@@ -95,6 +95,8 @@ public class PipelineConfigServicePerformanceTest {
     private DatabaseAccessHelper dbHelper;
     @Autowired
     private GoConfigMigration goConfigMigration;
+    @Autowired
+    private EntityHashingService entityHashingService;
 
     private GoConfigFileHelper configHelper;
     private final int numberOfRequests = 100;
@@ -142,7 +144,7 @@ public class PipelineConfigServicePerformanceTest {
                 PipelineConfig pipelineConfig = goConfigService.getConfigForEditing().pipelineConfigByName(new CaseInsensitiveString(Thread.currentThread().getName()));
                 pipelineConfig.add(new StageConfig(new CaseInsensitiveString("additional_stage"), new JobConfigs(new JobConfig(new CaseInsensitiveString("addtn_job")))));
                 PerfTimer updateTimer = PerfTimer.start("Saving pipelineConfig : " + pipelineConfig.name());
-                pipelineConfigService.updatePipelineConfig(user, pipelineConfig, result);
+                pipelineConfigService.updatePipelineConfig(user, pipelineConfig, entityHashingService.md5ForPipelineConfig(pipelineConfig.name().toString()), result);
                 updateTimer.stop();
                 results.put(Thread.currentThread().getName(), result.isSuccessful());
                 if (!result.isSuccessful()) {

--- a/server/test/unit/com/thoughtworks/go/config/update/UpdatePipelineConfigCommandTest.java
+++ b/server/test/unit/com/thoughtworks/go/config/update/UpdatePipelineConfigCommandTest.java
@@ -1,0 +1,71 @@
+package com.thoughtworks.go.config.update;
+
+import com.thoughtworks.go.config.CruiseConfig;
+import com.thoughtworks.go.config.PipelineConfig;
+import com.thoughtworks.go.helper.PipelineConfigMother;
+import com.thoughtworks.go.i18n.LocalizedMessage;
+import com.thoughtworks.go.server.domain.Username;
+import com.thoughtworks.go.server.service.EntityHashingService;
+import com.thoughtworks.go.server.service.GoConfigService;
+import com.thoughtworks.go.server.service.result.LocalizedOperationResult;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class UpdatePipelineConfigCommandTest {
+
+    private EntityHashingService entityHashingService;
+    private GoConfigService goConfigService;
+    private Username username;
+    private LocalizedOperationResult localizedOperationResult;
+    private PipelineConfig pipelineConfig;
+
+
+    @Before
+    public void setUp() throws Exception {
+        entityHashingService = mock(EntityHashingService.class);
+        goConfigService = mock(GoConfigService.class);
+        username = mock(Username.class);
+        localizedOperationResult = mock(LocalizedOperationResult.class);
+        pipelineConfig = PipelineConfigMother.pipelineConfig("p1");
+    }
+
+    @Test
+    public void shouldDisallowStaleRequest() {
+        UpdatePipelineConfigCommand command = new UpdatePipelineConfigCommand(goConfigService, entityHashingService,
+                pipelineConfig, username, "stale_md5", localizedOperationResult);
+
+        when(goConfigService.findGroupNameByPipeline(pipelineConfig.name())).thenReturn("group1");
+        when(goConfigService.canEditPipeline(pipelineConfig.name().toString(), username, localizedOperationResult, "group1")).thenReturn(true);
+        when(entityHashingService.md5ForPipelineConfig(pipelineConfig.name().toString())).thenReturn("latest_md5");
+
+        assertFalse(command.canContinue(mock(CruiseConfig.class)));
+    }
+
+    @Test
+    public void shouldDisallowUpdateIfPipelineEditIsDisAllowed() throws Exception {
+        UpdatePipelineConfigCommand command = new UpdatePipelineConfigCommand(goConfigService, null,
+                pipelineConfig, username, "stale_md5", localizedOperationResult);
+
+        when(goConfigService.findGroupNameByPipeline(pipelineConfig.name())).thenReturn("group1");
+        when(goConfigService.canEditPipeline(pipelineConfig.name().toString(),username,localizedOperationResult,"group1")).thenReturn(false);
+        assertFalse(command.canContinue(mock(CruiseConfig.class)));
+    }
+
+    @Test
+    public void shouldInvokeUpdateMethodOfCruiseConfig() throws Exception {
+        UpdatePipelineConfigCommand command = new UpdatePipelineConfigCommand(goConfigService, null,
+                pipelineConfig, username, "stale_md5", localizedOperationResult);
+
+        CruiseConfig cruiseConfig = mock(CruiseConfig.class);
+        when(goConfigService.findGroupNameByPipeline(pipelineConfig.name())).thenReturn("group1");
+
+        command.update(cruiseConfig);
+        verify(cruiseConfig).update("group1", pipelineConfig.name().toString(),pipelineConfig);
+    }
+}

--- a/server/test/unit/com/thoughtworks/go/server/initializers/ApplicationInitializerTest.java
+++ b/server/test/unit/com/thoughtworks/go/server/initializers/ApplicationInitializerTest.java
@@ -128,6 +128,8 @@ public class ApplicationInitializerTest {
     private ServerVersionInfoManager serverVersionInfoManager;
     @Mock
     private ConfigCipherUpdater configCipherUpdater;
+    @Mock
+    private EntityHashingService entityHashingService;
 
     @InjectMocks
     ApplicationInitializer initializer = new ApplicationInitializer();

--- a/server/test/unit/com/thoughtworks/go/server/service/EntityHashingServiceTest.java
+++ b/server/test/unit/com/thoughtworks/go/server/service/EntityHashingServiceTest.java
@@ -1,0 +1,81 @@
+package com.thoughtworks.go.server.service;
+
+import com.thoughtworks.go.config.CaseInsensitiveString;
+import com.thoughtworks.go.config.PipelineConfig;
+import com.thoughtworks.go.helper.PipelineConfigMother;
+import com.thoughtworks.go.server.cache.GoCache;
+import com.thoughtworks.go.server.util.EntityDigest;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+
+public class EntityHashingServiceTest {
+    private EntityDigest entityDigest;
+    private GoConfigService goConfigService;
+    private GoCache goCache;
+    private EntityHashingService entityHashingService;
+
+    @Before
+    public void setUp() {
+        this.entityDigest = mock(EntityDigest.class);
+        this.goConfigService = mock(GoConfigService.class);
+        this.goCache = mock(GoCache.class);
+        this.entityHashingService = new EntityHashingService(this.goConfigService, this.goCache);
+
+        this.entityHashingService.initializeWith(entityDigest);
+    }
+
+    @Test
+    public void shouldGenerateMD5ForAPipelineConfig() {
+        PipelineConfig pipelineConfig = mock(PipelineConfig.class);
+
+        when(goConfigService.pipelineConfigNamed(any(CaseInsensitiveString.class))).thenReturn(pipelineConfig);
+        when(entityDigest.md5ForPipeline(pipelineConfig)).thenReturn("pipeline_config_md5");
+
+        String md5ForPipeline = entityHashingService.md5ForPipelineConfig("P1");
+
+        assertThat(md5ForPipeline, is("pipeline_config_md5"));
+        verify(goCache).put("GO_PIPELINE_CONFIGS_ETAGS_CACHE", "p1", "pipeline_config_md5");
+    }
+
+    @Test
+    public void shouldReturnCachedMD5IfPresent() {
+        when(goCache.get("GO_PIPELINE_CONFIGS_ETAGS_CACHE", "p1")).thenReturn("pipeline_config_md5");
+
+        assertThat(entityHashingService.md5ForPipelineConfig("P1"), is("pipeline_config_md5"));
+
+        verifyZeroInteractions(goConfigService);
+        verifyZeroInteractions(entityDigest);
+    }
+
+    @Test
+    public void shouldRegisterToListenForConfigChange() {
+        entityHashingService.initialize();
+
+        verify(goConfigService).register(entityHashingService);
+//        verify(goConfigService, times(1)).register(any(entityHashingService.new PipelineConfigChangedListener));
+    }
+
+    @Test
+    public void shouldInvalidatePipelineConfigEtagsFromCacheOnConfigChange() {
+        entityHashingService.onConfigChange(null);
+
+        verify(goCache).remove("GO_PIPELINE_CONFIGS_ETAGS_CACHE");
+    }
+
+    @Test
+    public void shouldInvalidatePipelineConfigEtagsFromCacheOnPipelineChange() {
+        EntityHashingService.PipelineConfigChangedListener listener = entityHashingService.new PipelineConfigChangedListener();
+
+        listener.onEntityConfigChange(PipelineConfigMother.pipelineConfig("P1"));
+
+        verify(goCache).remove("GO_PIPELINE_CONFIGS_ETAGS_CACHE", "p1");
+    }
+}

--- a/server/webapp/WEB-INF/rails.new/app/views/admin/pipeline_configs/edit.html.erb
+++ b/server/webapp/WEB-INF/rails.new/app/views/admin/pipeline_configs/edit.html.erb
@@ -1,5 +1,5 @@
 <div id="pipeline-config"
-     data-pipeline-api-url="<%= apiv1_admin_pipeline_url(name: params[:pipeline_name]) %>"
+     data-pipeline-api-url="<%= apiv1_admin_pipeline_url(pipeline_name: params[:pipeline_name]) %>"
      data-resource-names="<%= @all_resources.to_json %>"
      data-user-names="<%= @all_users.to_json %>"
      data-role-names="<%= @all_roles.to_json %>"

--- a/server/webapp/WEB-INF/rails.new/lib/java_imports.rb
+++ b/server/webapp/WEB-INF/rails.new/lib/java_imports.rb
@@ -245,4 +245,5 @@ module JavaImports
   java_import com.thoughtworks.go.server.ui.plugins.PluginInfo unless defined? PluginInfo
   java_import com.thoughtworks.go.server.ui.plugins.PluggableInstanceSettings unless defined? PluggableInstanceSettings
   java_import com.thoughtworks.go.server.service.plugins.InvalidPluginTypeException unless defined? InvalidPluginTypeException
+  java_import com.thoughtworks.go.server.service.EntityHashingService unless defined? EntityHashingService
 end

--- a/server/webapp/WEB-INF/rails.new/lib/pipeline_digest.rb
+++ b/server/webapp/WEB-INF/rails.new/lib/pipeline_digest.rb
@@ -1,0 +1,30 @@
+##########################################################################
+# Copyright 2016 ThoughtWorks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+
+class PipelineDigest
+  include com.thoughtworks.go.server.util.EntityDigest
+  include Rails.application.routes.url_helpers
+
+  def md5ForPipeline(pipeline_config)
+    json = ApiV1::Config::PipelineConfigRepresenter.new(pipeline_config).to_hash(url_builder: self)
+
+    Digest::MD5.hexdigest(JSON.generate(json))
+  end
+
+  def self.default_url_options
+    {host: 'localhost'}
+  end
+end

--- a/server/webapp/WEB-INF/rails.new/lib/services.rb
+++ b/server/webapp/WEB-INF/rails.new/lib/services.rb
@@ -32,7 +32,7 @@ module Services
            :mingle_config_service, :schedule_service, :flash_message_service, :template_config_service, :shine_dao, :xml_api_service, :pipeline_pause_service, :luau_service,
            :task_view_service, :view_rendering_service, :role_service, :server_status_service, :pipeline_configs_service, :pipeline_service, :material_update_service,
            :system_service, :default_plugin_manager, :command_repository_service, :value_stream_map_service, :admin_service, :config_repository, :package_repository_service, :package_definition_service, :pipeline_sql_map_dao, :pluggable_task_service, :garage_service,
-           :material_config_service, :feature_toggle_service, :cc_tray_service, :pluggable_scm_service, :cc_tray_status_service, :plugin_service, :artifacts_dir_holder, :version_info_service)
+           :material_config_service, :feature_toggle_service, :cc_tray_service, :pluggable_scm_service, :cc_tray_status_service, :plugin_service, :artifacts_dir_holder, :version_info_service, :entity_hashing_service)
 
   service_with_alias_name(:go_config_service_for_url, "goConfigService")
 end

--- a/server/webapp/WEB-INF/rails.new/lib/spring.rb
+++ b/server/webapp/WEB-INF/rails.new/lib/spring.rb
@@ -38,6 +38,7 @@ class Spring
           @context =  load_context
           begin
             self.bean("viewRenderingService").registerRenderer(com.thoughtworks.go.plugins.presentation.Renderer.ERB, ErbRenderer.new) if @context
+            self.bean("entityHashingService").initializeWith(PipelineDigest.new) if @context
           rescue => e
             raise $! if Rails.configuration.fail_if_unable_to_register_renderer
             puts "WARNING: Failed to register renderer. Continuing, though: #{e}"

--- a/server/webapp/WEB-INF/rails.new/spec/lib/pipeline_digest_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/lib/pipeline_digest_spec.rb
@@ -1,0 +1,30 @@
+##########################################################################
+# Copyright 2016 ThoughtWorks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+
+require 'spec_helper'
+
+describe PipelineDigest do
+  describe :md5ForPipeline do
+    it 'should generate md5 for a pipeline_config' do
+      pipeline_config = PipelineConfigMother.pipelineConfig('P1')
+      json = ApiV1::Config::PipelineConfigRepresenter.new(pipeline_config).to_hash(url_builder: PipelineDigest.new)
+
+      Digest::MD5.should_receive(:hexdigest).with(JSON.generate(json)).and_return('pipeline_config_md5')
+
+      expect(PipelineDigest.new.md5ForPipeline(pipeline_config)).to eq('pipeline_config_md5')
+    end
+  end
+end


### PR DESCRIPTION
* EntityHashingService responsible for hashing pipeline_config
* EntityHashingService relies on rails lib to generate md5 for
  pipeline_config, this was done to use the existing representers
  to_hash else would have required a reimplementation in Java
* UpdatePipelineConfigCommand canContinue verifies for stale request
* pipeline_controller use EntityCachingService to fetch pipeline md5