### PR TITLE
Improve jasmine test speeds

### DIFF
--- a/server/webapp/WEB-INF/rails.new/app/views/layouts/jasmine_rails/spec_runner.html.erb
+++ b/server/webapp/WEB-INF/rails.new/app/views/layouts/jasmine_rails/spec_runner.html.erb
@@ -54,5 +54,12 @@
     });
   </script>
 <% end %>
+
+<!-- invisible container for element that contains the mithril app -->
+<div style="display: none">
+  <!-- mount your mithril app here -->
+  <div id='mithril-mount-point'></div>
+</div>
+
 </body>
 </html>

--- a/server/webapp/WEB-INF/rails.new/spec/javascripts/support/jasmine-ci-new.yml
+++ b/server/webapp/WEB-INF/rails.new/spec/javascripts/support/jasmine-ci-new.yml
@@ -28,9 +28,6 @@ src_files:
 #   - stylesheets/*.css
 #
 stylesheets:
-#  - assets/pipeline_configs/application.css
-  - assets/frameworks.css
-  - assets/single_page_apps/pipeline_configs.css
 
 
 # helpers

--- a/server/webapp/WEB-INF/rails.new/spec/javascripts/support/jasmine_with_selenium_runner.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/javascripts/support/jasmine_with_selenium_runner.rb
@@ -52,11 +52,11 @@ class JasmineWithSeleniumRunner
   attr_reader :formatter, :config, :web_driver, :jasmine_server_url, :result_batch_size
 
   def jasmine_testing_started?
-    web_driver.execute_script "return jsApiReporter && jsApiReporter.started"
+    web_driver.execute_script "return window.jsApiReporter && window.jsApiReporter.started"
   end
 
   def jasmine_testing_finished?
-    web_driver.execute_script "return jsApiReporter && jsApiReporter.finished"
+    web_driver.execute_script "return window.jsApiReporter && window.jsApiReporter.finished"
   end
 
   def wait_for_jasmine_to_start

--- a/server/webapp/WEB-INF/rails.new/spec/new_javascripts/run.html.erb
+++ b/server/webapp/WEB-INF/rails.new/spec/new_javascripts/run.html.erb
@@ -78,4 +78,10 @@
     });
   });
 </script>
+
+<!-- invisible container for element that contains the mithril app -->
+<div style="display: none">
+  <!-- mount your mithril app here -->
+  <div id='mithril-mount-point'></div>
+</div>
 </html>

--- a/server/webapp/WEB-INF/rails.new/spec/new_javascripts/views/pipeline_configs/cancel_task_widget_spec.js
+++ b/server/webapp/WEB-INF/rails.new/spec/new_javascripts/views/pipeline_configs/cancel_task_widget_spec.js
@@ -16,7 +16,8 @@
 
 define(["jquery", "mithril", "models/pipeline_configs/tasks", "views/pipeline_configs/cancel_task_widget"], function ($, m, Tasks, CancelTaskWidget) {
   describe('Cancel Task Widget', function () {
-    var root, $root, task;
+    var $root = $('#mithril-mount-point'), root = $root.get(0);
+    var task;
     describe('view task with onCancel task', function () {
       beforeAll(function () {
         task = new Tasks.Task.Ant({
@@ -35,12 +36,7 @@ define(["jquery", "mithril", "models/pipeline_configs/tasks", "views/pipeline_co
           }
         });
 
-        createRootElement();
         mount(task);
-      });
-
-      afterAll(function () {
-        removeRootElement();
       });
 
       it('should bind target', function () {
@@ -77,16 +73,11 @@ define(["jquery", "mithril", "models/pipeline_configs/tasks", "views/pipeline_co
           onCancelTask:     null
         });
 
-        createRootElement();
         mount(task);
 
         expect($root.find("input[type=checkbox][data-prop-name=checked]").is(':checked')).toBe(false);
         expect($root.find("input").size()).toBe(1);
         expect($root.find("select").size()).toBe(0);
-      });
-
-      afterAll(function () {
-        removeRootElement();
       });
 
     });
@@ -100,7 +91,6 @@ define(["jquery", "mithril", "models/pipeline_configs/tasks", "views/pipeline_co
           onCancelTask:      null
         });
 
-        createRootElement();
         mount(task);
 
         $root.find("input[type=checkbox][data-prop-name=checked]").click();
@@ -108,10 +98,6 @@ define(["jquery", "mithril", "models/pipeline_configs/tasks", "views/pipeline_co
 
         expect($root.find("select :checked").val()).toBe('exec');
         expect(task.onCancelTask.type()).toBe('exec');
-      });
-
-      afterAll(function () {
-        removeRootElement();
       });
 
     });
@@ -134,7 +120,6 @@ define(["jquery", "mithril", "models/pipeline_configs/tasks", "views/pipeline_co
           }
         });
 
-        createRootElement();
         mount(task);
 
         $root.find('.on-cancel select').val('exec');
@@ -143,10 +128,6 @@ define(["jquery", "mithril", "models/pipeline_configs/tasks", "views/pipeline_co
 
         expect(task.onCancelTask.type()).toBe('exec');
         expect($root.find("input[data-prop-name='command']").val()).toBe(task.onCancelTask.command());
-      });
-
-      afterAll(function () {
-        removeRootElement();
       });
 
     });
@@ -158,14 +139,5 @@ define(["jquery", "mithril", "models/pipeline_configs/tasks", "views/pipeline_co
       m.redraw(true);
     };
 
-    function createRootElement() {
-      root = document.createElement("div");
-      document.body.appendChild(root);
-      $root = $(root);
-    }
-
-    function removeRootElement() {
-      root.parentNode.removeChild(root);
-    }
   });
 });

--- a/server/webapp/WEB-INF/rails.new/spec/new_javascripts/views/pipeline_configs/environment_variables_config_widget_spec.js
+++ b/server/webapp/WEB-INF/rails.new/spec/new_javascripts/views/pipeline_configs/environment_variables_config_widget_spec.js
@@ -16,7 +16,7 @@
 
 define(["jquery", "mithril", "models/pipeline_configs/environment_variables", "views/pipeline_configs/environment_variables_config_widget"], function ($, m, EnvironmentVariables, EnvironmentVariableWidget) {
   describe("EnvironmentVariable Widget", function () {
-    var $root;
+    var $root = $('#mithril-mount-point'), root = $root.get(0);
     var variables;
 
     beforeEach(function () {
@@ -31,10 +31,6 @@ define(["jquery", "mithril", "models/pipeline_configs/environment_variables", "v
         }
       ]));
 
-      root = document.createElement("div");
-      document.body.appendChild(root);
-      $root = $(root);
-
       m.mount(root,
         m.component(EnvironmentVariableWidget, {variables: variables})
       );
@@ -46,10 +42,6 @@ define(["jquery", "mithril", "models/pipeline_configs/environment_variables", "v
       evObj.initEvent('click', true, false);
       accordion.onclick(evObj);
       m.redraw(true);
-    });
-
-    afterEach(function () {
-      root.parentNode.removeChild(root);
     });
 
     it("should display environment variables", function () {

--- a/server/webapp/WEB-INF/rails.new/spec/new_javascripts/views/pipeline_configs/lookup_command_widget_spec.js
+++ b/server/webapp/WEB-INF/rails.new/spec/new_javascripts/views/pipeline_configs/lookup_command_widget_spec.js
@@ -16,13 +16,7 @@
 
 define(["mithril", "lodash", "views/pipeline_configs/lookup_command_widget", "models/pipeline_configs/tasks"], function (m, _, LookupCommandWidget, Tasks) {
   describe("Lookup Command Widget", function () {
-    var $root, root;
-
-    function createRootElement() {
-      root = document.createElement("div");
-      document.body.appendChild(root);
-      $root = $(root);
-    }
+    var $root = $('#mithril-mount-point'), root = $root.get(0);
 
     function mount(model, snippet) {
       m.mount(root,
@@ -53,12 +47,7 @@ define(["mithril", "lodash", "views/pipeline_configs/lookup_command_widget", "mo
           return enableTextComplete;
         });
 
-        createRootElement();
         mount(model, snippet);
-      });
-
-      afterAll(function () {
-        root.parentNode.removeChild(root);
       });
 
       it("should render a text box with textcomplete enabled", function () {

--- a/server/webapp/WEB-INF/rails.new/spec/new_javascripts/views/pipeline_configs/materials_config_widget_spec.js
+++ b/server/webapp/WEB-INF/rails.new/spec/new_javascripts/views/pipeline_configs/materials_config_widget_spec.js
@@ -16,7 +16,7 @@
 
 define(["jquery", "mithril", "models/pipeline_configs/materials", "views/pipeline_configs/materials_config_widget"], function ($, m, Materials, MaterialsConfigWidget) {
   describe("Material Widget", function () {
-    var $root, root;
+    var $root = $('#mithril-mount-point'), root = $root.get(0);
     beforeAll(function() {
       spyOn(m, 'request').and.callFake(function() {
         return $.Deferred().promise();
@@ -39,13 +39,8 @@ define(["jquery", "mithril", "models/pipeline_configs/materials", "views/pipelin
           filter:         new Materials.Filter({ignore: ['*.doc']})
         });
 
-        createRootElement();
         mount(materials);
         viewMaterial();
-      });
-
-      afterAll(function () {
-        removeRootElement();
       });
 
       it('should bind url', function () {
@@ -96,13 +91,8 @@ define(["jquery", "mithril", "models/pipeline_configs/materials", "views/pipelin
           shallowClone: true
         });
 
-        createRootElement();
         mount(materials);
         viewMaterial();
-      });
-
-      afterAll(function () {
-        removeRootElement();
       });
 
       it('should bind url', function () {
@@ -147,13 +137,8 @@ define(["jquery", "mithril", "models/pipeline_configs/materials", "views/pipelin
           filter:      new Materials.Filter({ignore: ['*.doc']})
         });
 
-        createRootElement();
         mount(materials);
         viewMaterial();
-      });
-
-      afterAll(function () {
-        removeRootElement();
       });
 
       it('should bind url', function () {
@@ -194,13 +179,8 @@ define(["jquery", "mithril", "models/pipeline_configs/materials", "views/pipelin
           filter:      new Materials.Filter({ignore: ['*.doc']})
         });
 
-        createRootElement();
         mount(materials);
         viewMaterial();
-      });
-
-      afterAll(function () {
-        removeRootElement();
       });
 
       it('should bind port', function () {
@@ -257,13 +237,8 @@ define(["jquery", "mithril", "models/pipeline_configs/materials", "views/pipelin
           filter:      new Materials.Filter({ignore: ['*.doc']})
         });
 
-        createRootElement();
         mount(materials);
         viewMaterial();
-      });
-
-      afterAll(function () {
-        removeRootElement();
       });
 
       it('should bind url', function () {
@@ -316,13 +291,8 @@ define(["jquery", "mithril", "models/pipeline_configs/materials", "views/pipelin
 
         });
 
-        createRootElement();
         mount(materials);
         viewMaterial();
-      });
-
-      afterAll(function () {
-        removeRootElement();
       });
 
       it('should bind name', function () {
@@ -333,16 +303,6 @@ define(["jquery", "mithril", "models/pipeline_configs/materials", "views/pipelin
         expect($root.find("input[name='pipeline-stage']").val()).toBe('pipeline1 [stage1]');
       });
     });
-
-    function createRootElement() {
-      root = document.createElement("div");
-      document.body.appendChild(root);
-      $root = $(root);
-    }
-
-    function removeRootElement() {
-      root.parentNode.removeChild(root);
-    }
 
     function mount(materials) {
       m.mount(root,

--- a/server/webapp/WEB-INF/rails.new/spec/new_javascripts/views/pipeline_configs/parameter_config_widget_spec.js
+++ b/server/webapp/WEB-INF/rails.new/spec/new_javascripts/views/pipeline_configs/parameter_config_widget_spec.js
@@ -16,16 +16,12 @@
 
 define(["jquery", "mithril", "models/pipeline_configs/parameters", "views/pipeline_configs/parameters_config_widget"], function ($, m, Parameters, ParametersConfigWidget) {
   describe("Parameter Widget", function () {
-    var root, $root;
+    var $root = $('#mithril-mount-point'), root = $root.get(0);
     var parameters;
     beforeEach(function () {
       parameters = m.prop(new Parameters.fromJSON([
         {name: "COMMAND", value: "echo"}
       ]));
-
-      root = document.createElement("div");
-      document.body.appendChild(root);
-      $root = $(root);
 
       m.mount(root,
         m.component(ParametersConfigWidget, {parameters: parameters})
@@ -37,10 +33,6 @@ define(["jquery", "mithril", "models/pipeline_configs/parameters", "views/pipeli
       evObj.initEvent('click', true, false);
       accordion.onclick(evObj);
       m.redraw(true);
-    });
-
-    afterEach(function () {
-      root.parentNode.removeChild(root);
     });
 
     it("should display parameters", function () {

--- a/server/webapp/WEB-INF/rails.new/spec/new_javascripts/views/pipeline_configs/pipeline_config_widget_spec.js
+++ b/server/webapp/WEB-INF/rails.new/spec/new_javascripts/views/pipeline_configs/pipeline_config_widget_spec.js
@@ -16,14 +16,10 @@
 
 define(["jquery", "mithril", 'lodash', 'string-plus', "models/pipeline_configs/pipeline", "views/pipeline_configs/pipeline_config_widget"], function ($, m, _, s, Pipeline, PipelineConfigWidget) {
   describe("PipelineConfigWidget", function () {
-    var root, $root;
+    var $root = $('#mithril-mount-point'), root = $root.get(0);
     var pipeline;
 
     beforeAll(function (done) {
-      root = document.createElement("div");
-      document.body.appendChild(root);
-      $root = $(root);
-
       jasmine.Ajax.install();
       jasmine.Ajax.stubRequest(/\/pipeline.json\?_=\d+/).andReturn({
         contentType:  'application/vnd.go.cd.v1+json',
@@ -48,7 +44,6 @@ define(["jquery", "mithril", 'lodash', 'string-plus', "models/pipeline_configs/p
     });
 
     afterAll(function () {
-      root.parentNode.removeChild(root);
       jasmine.Ajax.uninstall();
     });
 

--- a/server/webapp/WEB-INF/rails.new/spec/new_javascripts/views/pipeline_configs/pipeline_stage_field_widget_spec.js
+++ b/server/webapp/WEB-INF/rails.new/spec/new_javascripts/views/pipeline_configs/pipeline_stage_field_widget_spec.js
@@ -17,13 +17,7 @@
 define(["mithril", "lodash", "views/pipeline_configs/pipeline_stage_field_widget", "models/pipeline_configs/pipelines", "models/pipeline_configs/materials"],
   function (m, _, PipelineStageFieldWidget, Pipelines, Materials) {
   describe("PipelineStageField Widget", function () {
-    var $root, root;
-
-    function createRootElement() {
-      root = document.createElement("div");
-      document.body.appendChild(root);
-      $root = $(root);
-    }
+    var $root = $('#mithril-mount-point'), root = $root.get(0);
 
     function mount(material, pipelines) {
       m.mount(root,
@@ -33,10 +27,6 @@ define(["mithril", "lodash", "views/pipeline_configs/pipeline_stage_field_widget
     }
 
     describe('view', function () {
-      afterEach(function () {
-        root.parentNode.removeChild(root);
-      });
-
       it('should render the pipeline stage field', function() {
         var material = Materials.create({
           type:     "dependency",
@@ -44,7 +34,6 @@ define(["mithril", "lodash", "views/pipeline_configs/pipeline_stage_field_widget
           stage:    "first_stage"
         });
 
-        createRootElement();
         mount(material, Pipelines);
 
         expect($root.find("input[name='pipeline-stage']").val()).toBe('p1 [first_stage]');
@@ -56,7 +45,6 @@ define(["mithril", "lodash", "views/pipeline_configs/pipeline_stage_field_widget
           type:     "dependency"
         });
 
-        createRootElement();
         mount(material, Pipelines);
 
         expect(_.isEmpty($root.find("input[name='pipeline-stage']").val())).toBe(true);
@@ -67,7 +55,6 @@ define(["mithril", "lodash", "views/pipeline_configs/pipeline_stage_field_widget
           type:     "dependency"
         });
 
-        createRootElement();
         mount(material, Pipelines);
 
         $root.find("input[name='pipeline-stage']").val('pipeline [stage]');
@@ -85,7 +72,6 @@ define(["mithril", "lodash", "views/pipeline_configs/pipeline_stage_field_widget
           stage:    "first_stage"
         });
 
-        createRootElement();
         mount(material, Pipelines);
 
         $root.find("input[name='pipeline-stage']").val('invalid-input');
@@ -104,7 +90,6 @@ define(["mithril", "lodash", "views/pipeline_configs/pipeline_stage_field_widget
           type:     "dependency"
         });
 
-        createRootElement();
         mount(material, Pipelines);
 
         $root.find("input[name='pipeline-stage']").val('invalid-input');

--- a/server/webapp/WEB-INF/rails.new/spec/new_javascripts/views/pipeline_configs/run_if_conditions_widget_spec.js
+++ b/server/webapp/WEB-INF/rails.new/spec/new_javascripts/views/pipeline_configs/run_if_conditions_widget_spec.js
@@ -16,13 +16,7 @@
 
 define(["mithril", "lodash", "views/pipeline_configs/run_if_conditions_widget", "models/pipeline_configs/tasks"], function (m, _, RunIfConditionsWidget, Tasks) {
   describe("RunIfConditions Widget", function() {
-    var $root, root;
-
-    function createRootElement() {
-      root = document.createElement("div");
-      document.body.appendChild(root);
-      $root = $(root);
-    }
+    var $root = $('#mithril-mount-point'), root = $root.get(0);
 
     function mount(task) {
       m.mount(root,
@@ -32,13 +26,6 @@ define(["mithril", "lodash", "views/pipeline_configs/run_if_conditions_widget", 
     }
 
     describe("View", function() {
-      beforeAll(function() {
-        createRootElement();
-      });
-
-      afterAll(function () {
-        root.parentNode.removeChild(root);
-      });
 
       it("should render checkbox for runIf conditions", function () {
         var task = new Tasks.Task.Exec({runIf: ['any']});
@@ -60,14 +47,6 @@ define(["mithril", "lodash", "views/pipeline_configs/run_if_conditions_widget", 
     });
 
     describe("Selection", function() {
-      beforeAll(function() {
-        createRootElement();
-      });
-
-      afterAll(function () {
-        root.parentNode.removeChild(root);
-      });
-
       it("should be either 'any' or 'passed || failed'", function() {
         var task = new Tasks.Task.Exec({runIf: ['passed', 'failed']});
         mount(task);

--- a/server/webapp/WEB-INF/rails.new/spec/new_javascripts/views/pipeline_configs/tasks_config_widget_spec.js
+++ b/server/webapp/WEB-INF/rails.new/spec/new_javascripts/views/pipeline_configs/tasks_config_widget_spec.js
@@ -16,7 +16,7 @@
 
 define(["jquery", "mithril", "models/pipeline_configs/tasks", "views/pipeline_configs/tasks_config_widget"], function ($, m, Tasks, TasksConfigWidget) {
   describe("Tasks Widget", function () {
-    var root, $root;
+    var $root = $('#mithril-mount-point'), root = $root.get(0);
 
     describe('Ant Task View', function () {
       var task;
@@ -41,12 +41,7 @@ define(["jquery", "mithril", "models/pipeline_configs/tasks", "views/pipeline_co
         });
         tasks().addTask(task);
 
-        createRootElement();
         mount(tasks);
-      });
-
-      afterAll(function () {
-        removeRootElement();
       });
 
       it('should bind target', function () {
@@ -91,12 +86,7 @@ define(["jquery", "mithril", "models/pipeline_configs/tasks", "views/pipeline_co
         });
         tasks().addTask(task);
 
-        createRootElement();
         mount(tasks);
-      });
-
-      afterAll(function () {
-        removeRootElement();
       });
 
       it('should bind target', function () {
@@ -139,12 +129,7 @@ define(["jquery", "mithril", "models/pipeline_configs/tasks", "views/pipeline_co
         });
         tasks().addTask(task);
 
-        createRootElement();
         mount(tasks);
-      });
-
-      afterAll(function () {
-        removeRootElement();
       });
 
       describe('render', function () {
@@ -185,12 +170,7 @@ define(["jquery", "mithril", "models/pipeline_configs/tasks", "views/pipeline_co
         });
         tasks().addTask(task);
 
-        createRootElement();
         mount(tasks);
-      });
-
-      afterAll(function () {
-        removeRootElement();
       });
 
       it('should bind target', function () {
@@ -230,12 +210,7 @@ define(["jquery", "mithril", "models/pipeline_configs/tasks", "views/pipeline_co
         });
         tasks().addTask(task);
 
-        createRootElement();
         mount(tasks);
-      });
-
-      afterAll(function () {
-        removeRootElement();
       });
 
       it('should bind pipeline', function () {
@@ -316,12 +291,7 @@ define(["jquery", "mithril", "models/pipeline_configs/tasks", "views/pipeline_co
           tasks().addTask(task);
         });
 
-        createRootElement();
         mount(tasks);
-      });
-
-      afterEach(function () {
-        root.parentNode.removeChild(root);
       });
 
       it("should add a new task", function () {
@@ -346,14 +316,5 @@ define(["jquery", "mithril", "models/pipeline_configs/tasks", "views/pipeline_co
       m.redraw(true);
     };
 
-    function createRootElement() {
-      root = document.createElement("div");
-      document.body.appendChild(root);
-      $root = $(root);
-    }
-
-    function removeRootElement() {
-      root.parentNode.removeChild(root);
-    }
   });
 });

--- a/server/webapp/WEB-INF/rails.new/spec/new_javascripts/views/pipeline_configs/test_connection_widget_spec.js
+++ b/server/webapp/WEB-INF/rails.new/spec/new_javascripts/views/pipeline_configs/test_connection_widget_spec.js
@@ -17,20 +17,14 @@
 define(["mithril", "lodash", "models/pipeline_configs/materials", "views/pipeline_configs/test_connection_widget"], function (m, _, Materials, TestConnectionWidget) {
   describe("Test Connection Widget", function () {
     describe('view', function() {
-      var $root, root, material;
+      var $root = $('#mithril-mount-point'), root = $root.get(0);
+      var material;
       beforeEach(function () {
         material = new Materials().createMaterial({
           type: 'git',
           url: "http://git.example.com/git/myProject"
         });
 
-        root = document.createElement("div");
-        document.body.appendChild(root);
-        $root = $(root);
-      });
-
-      afterEach(function () {
-        root.parentNode.removeChild(root);
       });
 
       it("should render test connection button", function () {

--- a/server/webapp/WEB-INF/rails.new/spec/new_javascripts/views/pipeline_configs/tracking_tool_widget_spec.js
+++ b/server/webapp/WEB-INF/rails.new/spec/new_javascripts/views/pipeline_configs/tracking_tool_widget_spec.js
@@ -16,7 +16,7 @@
 
 define(["jquery", "mithril", 'lodash', "models/pipeline_configs/tracking_tool", "views/pipeline_configs/tracking_tool_widget"], function ($, m, _, TrackingTool, TrackingToolWidget) {
   describe("Tracking Tool Widget", function () {
-    var root, $root;
+    var $root = $('#mithril-mount-point'), root = $root.get(0);
     var genericTrackingTool, mingleTrackingTool, trackingToolProp;
 
     beforeEach(function () {
@@ -32,11 +32,7 @@ define(["jquery", "mithril", 'lodash', "models/pipeline_configs/tracking_tool", 
         projectIdentifier:     "gocd",
         mqlGroupingConditions: "status > 'In Dev'"
       });
-
-      root = document.createElement("div");
-      document.body.appendChild(root);
-      $root = $(root);
-
+      
       m.mount(root,
         m.component(TrackingToolWidget, {trackingTool: trackingToolProp})
       );
@@ -47,10 +43,6 @@ define(["jquery", "mithril", 'lodash', "models/pipeline_configs/tracking_tool", 
       evObj.initEvent('click', true, false);
       accordion.onclick(evObj);
       m.redraw(true);
-    });
-
-    afterEach(function () {
-      root.parentNode.removeChild(root);
     });
 
     it("should select none tracking tool when none is selected", function () {


### PR DESCRIPTION
Mithril seems to keep track of DOM elements (https://github.com/gocd/gocd/blob/master/server/webapp/WEB-INF/rails.new/app/assets/javascripts/lib/mithril-0.2.0.js#L550)
even when the element is removed from the document. It keeps re-painting
the elements on a 60Hz cycle.

The "fix" is to re-use the same DOM element and mount mithril components
onto the same DOM element so that we don't "leak" DOM elements and slow
down mithril re-draws as more and more tests run.