### PR TITLE
Add an api for bulk updates of agents. (#2340)

### DIFF
--- a/config/config-api/src/com/thoughtworks/go/config/AgentConfig.java
+++ b/config/config-api/src/com/thoughtworks/go/config/AgentConfig.java
@@ -16,15 +16,13 @@
 
 package com.thoughtworks.go.config;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-
 import com.thoughtworks.go.domain.ConfigErrors;
 import com.thoughtworks.go.domain.IpAddress;
 import com.thoughtworks.go.remote.AgentIdentifier;
 import com.thoughtworks.go.util.StringUtil;
 import com.thoughtworks.go.util.SystemUtil;
+
+import java.util.Collection;
 
 import static java.lang.String.format;
 
@@ -134,6 +132,10 @@ public class AgentConfig implements Validatable {
 
     public void setDisabled(Boolean disabled) {
         isDisabled = disabled;
+    }
+
+    public void enable() {
+        disable(Boolean.FALSE);
     }
 
     public void disable() {

--- a/config/config-api/src/com/thoughtworks/go/config/EnvironmentsConfig.java
+++ b/config/config-api/src/com/thoughtworks/go/config/EnvironmentsConfig.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,17 +16,17 @@
 
 package com.thoughtworks.go.config;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Set;
-import java.util.TreeSet;
-
 import com.thoughtworks.go.config.exceptions.NoSuchEnvironmentException;
 import com.thoughtworks.go.domain.BaseCollection;
 import com.thoughtworks.go.domain.ConfigErrors;
 import com.thoughtworks.go.domain.EnvironmentPipelineMatcher;
 import com.thoughtworks.go.domain.EnvironmentPipelineMatchers;
 import com.thoughtworks.go.util.comparator.AlphaAsciiComparator;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
 
 /**
  * @understands the current persistent information related to multiple logical groupings of machines

--- a/server/src/com/thoughtworks/go/config/exceptions/NoSuchAgentException.java
+++ b/server/src/com/thoughtworks/go/config/exceptions/NoSuchAgentException.java
@@ -1,0 +1,27 @@
+/*************************GO-LICENSE-START*********************************
+ * Copyright 2016 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *************************GO-LICENSE-END***********************************/
+
+package com.thoughtworks.go.config.exceptions;
+
+import org.apache.commons.lang.StringUtils;
+
+import java.util.List;
+
+public class NoSuchAgentException extends Exception {
+    public NoSuchAgentException(List<String> unknownAgents) {
+        super(String.format("Agents [%s] could not be found", StringUtils.join(unknownAgents, ", ")));
+    }
+}

--- a/server/src/com/thoughtworks/go/config/update/AgentsEntityConfigUpdateCommand.java
+++ b/server/src/com/thoughtworks/go/config/update/AgentsEntityConfigUpdateCommand.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2016 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.config.update;
+
+import com.thoughtworks.go.config.*;
+import com.thoughtworks.go.config.commands.EntityConfigUpdateCommand;
+import com.thoughtworks.go.config.exceptions.NoSuchAgentException;
+import com.thoughtworks.go.config.exceptions.NoSuchEnvironmentException;
+import com.thoughtworks.go.i18n.LocalizedMessage;
+import com.thoughtworks.go.server.domain.Username;
+import com.thoughtworks.go.server.service.GoConfigService;
+import com.thoughtworks.go.server.service.result.LocalizedOperationResult;
+import com.thoughtworks.go.serverhealth.HealthStateType;
+import com.thoughtworks.go.util.TriState;
+import com.thoughtworks.go.validation.AgentConfigsUpdateValidator;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+public class AgentsEntityConfigUpdateCommand implements EntityConfigUpdateCommand<Agents> {
+    private final Username username;
+    private final LocalizedOperationResult result;
+    private final List<String> uuids;
+    private final List<String> environmentsToAdd;
+    private final List<String> environmentsToRemove;
+    private final TriState state;
+    private final List<String> resourcesToAdd;
+    private final List<String> resourcesToRemove;
+    private GoConfigService goConfigService;
+    public Agents agents;
+
+    public AgentsEntityConfigUpdateCommand(Username username, LocalizedOperationResult result, List<String> uuids, List<String> environmentsToAdd, List<String> environmentsToRemove, TriState state, List<String> resourcesToAdd, List<String> resourcesToRemove, GoConfigService goConfigService) {
+        this.username = username;
+        this.result = result;
+        this.uuids = uuids;
+        this.environmentsToAdd = environmentsToAdd;
+        this.environmentsToRemove = environmentsToRemove;
+        this.state = state;
+        this.resourcesToAdd = resourcesToAdd;
+        this.resourcesToRemove = resourcesToRemove;
+        this.goConfigService = goConfigService;
+    }
+
+    @Override
+    public boolean canContinue(CruiseConfig cruiseConfig) {
+        if (goConfigService.isAdministrator(username.getUsername())) {
+            return true;
+        }
+
+        result.unauthorized(LocalizedMessage.string("UNAUTHORIZED_TO_OPERATE_AGENTS"), HealthStateType.unauthorised());
+        return false;
+    }
+
+    private List<AgentConfig> getValidAgents(List<String> uuids, LocalizedOperationResult result, Agents agents) throws NoSuchAgentException {
+        List<AgentConfig> goodAgents = new ArrayList<>();
+        List<String> unknownAgents = new ArrayList<>();
+
+        for (String uuid : uuids) {
+            AgentConfig agent = agents.getAgentByUuid(uuid);
+            if (!agent.isNull()) {
+                goodAgents.add(agent);
+            } else {
+                unknownAgents.add(uuid);
+            }
+        }
+        if (!unknownAgents.isEmpty()) {
+            result.badRequest(LocalizedMessage.string("AGENTS_WITH_UUIDS_NOT_FOUND", unknownAgents));
+            throw new NoSuchAgentException(unknownAgents);
+        }
+
+        return goodAgents;
+    }
+
+    private void validateEnvironment(Set<CaseInsensitiveString> allEnvironmentNames, List<String> environmentsToOperate, LocalizedOperationResult result) throws NoSuchEnvironmentException {
+        for (String environment : environmentsToOperate) {
+            CaseInsensitiveString environmentName = new CaseInsensitiveString(environment);
+            if (!allEnvironmentNames.contains(environmentName)) {
+                result.badRequest(LocalizedMessage.string("ENV_NOT_FOUND", environmentName));
+                throw new NoSuchEnvironmentException(environmentName);
+            }
+        }
+    }
+
+    @Override
+    public void update(CruiseConfig preprocessedConfig) throws Exception {
+        List<AgentConfig> goodAgents = getValidAgents(uuids, result, preprocessedConfig.agents());
+
+        Set<CaseInsensitiveString> allEnvironmentNames = new HashSet<>(goConfigService.getEnvironments().names());
+
+        validateEnvironment(allEnvironmentNames, environmentsToAdd, result);
+        validateEnvironment(allEnvironmentNames, environmentsToRemove, result);
+
+        for (AgentConfig agentConfig : goodAgents) {
+            if (state.isFalse()) {
+                agentConfig.disable();
+            }
+
+            if (state.isTrue()) {
+                agentConfig.enable();
+            }
+
+            for (String r : resourcesToAdd) {
+                agentConfig.addResource(new Resource(r));
+            }
+
+            for (String r : resourcesToRemove) {
+                agentConfig.removeResource(new Resource(r));
+            }
+
+            for (String environment : environmentsToAdd) {
+                EnvironmentConfig environmentConfig = preprocessedConfig.getEnvironments().find(new CaseInsensitiveString(environment));
+                if (environmentConfig != null){
+                    environmentConfig.addAgentIfNew(agentConfig.getUuid());
+                }
+            }
+
+            for (String environment : environmentsToRemove) {
+                EnvironmentConfig environmentConfig = preprocessedConfig.getEnvironments().find(new CaseInsensitiveString(environment));
+                if (environmentConfig != null)
+                    environmentConfig.removeAgent(agentConfig.getUuid());
+            }
+        }
+    }
+
+    @Override
+    public boolean isValid(CruiseConfig preprocessedConfig) {
+        agents = preprocessedConfig.agents();
+        AgentConfigsUpdateValidator validator = new AgentConfigsUpdateValidator(uuids);
+        return validator.isValid(preprocessedConfig);
+    }
+
+    @Override
+    public void clearErrors() {
+        BasicCruiseConfig.clearErrors(agents);
+    }
+
+    @Override
+    public Agents getPreprocessedEntityConfig() {
+        return agents;
+    }
+}

--- a/server/src/com/thoughtworks/go/server/service/AgentService.java
+++ b/server/src/com/thoughtworks/go/server/service/AgentService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -29,6 +29,7 @@ import com.thoughtworks.go.server.domain.AgentInstances;
 import com.thoughtworks.go.server.domain.Username;
 import com.thoughtworks.go.server.persistence.AgentDao;
 import com.thoughtworks.go.server.service.result.HttpOperationResult;
+import com.thoughtworks.go.server.service.result.LocalizedOperationResult;
 import com.thoughtworks.go.server.service.result.OperationResult;
 import com.thoughtworks.go.server.ui.AgentViewModel;
 import com.thoughtworks.go.server.ui.AgentsViewModel;
@@ -179,6 +180,10 @@ public class AgentService {
         return null;
     }
 
+    public void bulkUpdateAgentAttributes(Username username, LocalizedOperationResult result, List<String> uuids, List<String> resourcesToAdd, List<String> resourcesToRemove, List<String> environmentsToAdd, List<String> environmentsToRemove, TriState enable) {
+        agentConfigService.bulkUpdateAgentAttributes(username, result, uuids, resourcesToAdd, resourcesToRemove, environmentsToAdd, environmentsToRemove, enable);
+    }
+
     public void enableAgents(Username username, OperationResult operationResult, List<String> uuids) {
         if (!hasOperatePermission(username, operationResult)) {
             return;
@@ -227,12 +232,8 @@ public class AgentService {
             return;
         }
         List<AgentInstance> agents = new ArrayList<>();
-        for (String uuid : uuids) {
-            AgentInstance agentInstance = findAgent(uuid);
-            if (isUnknownAgent(agentInstance, operationResult)) {
-                return;
-            }
-            agents.add(agentInstance);
+        if (!populateAgentInstancesForUUIDs(operationResult, uuids, agents)){
+            return;
         }
 
         List<AgentInstance> failedToDeleteAgents = new ArrayList<>();

--- a/server/src/com/thoughtworks/go/server/service/GoConfigService.java
+++ b/server/src/com/thoughtworks/go/server/service/GoConfigService.java
@@ -976,6 +976,10 @@ public class GoConfigService implements Initializer, CruiseConfigProvider {
         return cruiseConfig().getSCMs();
     }
 
+    public boolean isAdministrator(CaseInsensitiveString username) {
+        return isAdministrator(username.toString());
+    }
+
     public abstract class XmlPartialSaver<T> {
         protected final SAXReader reader;
         private final ConfigElementImplementationRegistry registry;

--- a/server/src/com/thoughtworks/go/server/service/PipelineConfigService.java
+++ b/server/src/com/thoughtworks/go/server/service/PipelineConfigService.java
@@ -151,7 +151,7 @@ public class PipelineConfigService {
         return list;
     }
 
-    public void createPipelineConfig(final Username currentUser, final PipelineConfig pipelineConfig, final LocalizedOperationResult result, final String groupName) {
+        public void createPipelineConfig(final Username currentUser, final PipelineConfig pipelineConfig, final LocalizedOperationResult result, final String groupName) {
         validatePluggableTasks(pipelineConfig);
         CreatePipelineConfigCommand createPipelineConfigCommand = new CreatePipelineConfigCommand(goConfigService, pipelineConfig, currentUser, result, groupName);
         update(currentUser, pipelineConfig, result, createPipelineConfigCommand);

--- a/server/test/integration/com/thoughtworks/go/server/service/AgentConfigServiceIntegrationTest.java
+++ b/server/test/integration/com/thoughtworks/go/server/service/AgentConfigServiceIntegrationTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -19,9 +19,11 @@ package com.thoughtworks.go.server.service;
 import com.thoughtworks.go.config.*;
 import com.thoughtworks.go.domain.AgentInstance;
 import com.thoughtworks.go.server.domain.Username;
+import com.thoughtworks.go.server.service.result.HttpLocalizedOperationResult;
 import com.thoughtworks.go.util.GoConfigFileHelper;
 import com.thoughtworks.go.util.ReflectionUtil;
 import com.thoughtworks.go.util.SystemEnvironment;
+import com.thoughtworks.go.util.TriState;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -30,14 +32,13 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
+import static org.hamcrest.Matchers.*;
 import static org.hamcrest.core.Is.is;
-import static org.hamcrest.core.IsNull.nullValue;
 import static org.junit.Assert.*;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.verify;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(locations = {
@@ -193,5 +194,348 @@ public class AgentConfigServiceIntegrationTest {
         cruiseConfig = goConfigDao.load();
         assertThat(cruiseConfig.agents().getAgentByUuid(agentConfig1.getUuid()).isDisabled(), is(false));
         assertThat(cruiseConfig.agents().getAgentByUuid(agentConfig2.getUuid()).isDisabled(), is(false));
+    }
+
+    @Test
+    public void shouldEnableTheProvidedAgents() throws Exception {
+        AgentConfig agentConfig1 = new AgentConfig(UUID.randomUUID().toString(), "remote-host1", "50.40.30.21");
+        AgentConfig agentConfig2 = new AgentConfig(UUID.randomUUID().toString(), "remote-host2", "50.40.30.22");
+        agentConfig1.disable();
+        agentConfig2.disable();
+        agentConfigService.addAgent(agentConfig1, Username.ANONYMOUS);
+        agentConfigService.addAgent(agentConfig2, Username.ANONYMOUS);
+        CruiseConfig cruiseConfig = goConfigDao.load();
+        assertThat(cruiseConfig.agents().getAgentByUuid(agentConfig1.getUuid()).isDisabled(), is(true));
+        assertThat(cruiseConfig.agents().getAgentByUuid(agentConfig2.getUuid()).isDisabled(), is(true));
+
+        HttpLocalizedOperationResult result = new HttpLocalizedOperationResult();
+        ArrayList<String> uuids = new ArrayList<>();
+        uuids.add(agentConfig1.getUuid());
+        uuids.add(agentConfig2.getUuid());
+
+        agentConfigService.bulkUpdateAgentAttributes(Username.ANONYMOUS, result, uuids, new ArrayList<String>(), new ArrayList<String>(), new ArrayList<String>(), new ArrayList<String>(), TriState.TRUE);
+
+        cruiseConfig = goConfigDao.load();
+        assertTrue(result.isSuccessful());
+        assertTrue(result.toString(), result.toString().contains("BULK_AGENT_UPDATE_SUCESSFUL"));
+        assertFalse(cruiseConfig.agents().getAgentByUuid(agentConfig1.getUuid()).isDisabled());
+        assertFalse(cruiseConfig.agents().getAgentByUuid(agentConfig2.getUuid()).isDisabled());
+    }
+
+    @Test
+    public void shouldDisableTheProvidedAgents() throws Exception {
+        AgentConfig agentConfig1 = new AgentConfig(UUID.randomUUID().toString(), "remote-host1", "50.40.30.21");
+        AgentConfig agentConfig2 = new AgentConfig(UUID.randomUUID().toString(), "remote-host2", "50.40.30.22");
+        agentConfigService.addAgent(agentConfig1, Username.ANONYMOUS);
+        agentConfigService.addAgent(agentConfig2, Username.ANONYMOUS);
+        CruiseConfig cruiseConfig = goConfigDao.load();
+        assertThat(cruiseConfig.agents().getAgentByUuid(agentConfig1.getUuid()).isDisabled(), is(false));
+        assertThat(cruiseConfig.agents().getAgentByUuid(agentConfig2.getUuid()).isDisabled(), is(false));
+
+        HttpLocalizedOperationResult result = new HttpLocalizedOperationResult();
+        ArrayList<String> uuids = new ArrayList<>();
+        uuids.add(agentConfig1.getUuid());
+        uuids.add(agentConfig2.getUuid());
+
+        agentConfigService.bulkUpdateAgentAttributes(Username.ANONYMOUS, result, uuids, new ArrayList<String>(), new ArrayList<String>(), new ArrayList<String>(), new ArrayList<String>(), TriState.FALSE);
+
+        cruiseConfig = goConfigDao.load();
+        assertTrue(result.isSuccessful());
+        assertTrue(result.toString(), result.toString().contains("BULK_AGENT_UPDATE_SUCESSFUL"));
+        assertTrue(cruiseConfig.agents().getAgentByUuid(agentConfig1.getUuid()).isDisabled());
+        assertTrue(cruiseConfig.agents().getAgentByUuid(agentConfig2.getUuid()).isDisabled());
+    }
+
+    @Test
+    public void shouldNotDisableOrEnableIfTheStateOfAgentIsNotChanged() throws Exception {
+        AgentConfig agentConfig1 = new AgentConfig(UUID.randomUUID().toString(), "remote-host1", "50.40.30.21");
+        AgentConfig agentConfig2 = new AgentConfig(UUID.randomUUID().toString(), "remote-host2", "50.40.30.22");
+        agentConfig1.enable();
+        agentConfig2.disable();
+        agentConfigService.addAgent(agentConfig1, Username.ANONYMOUS);
+        agentConfigService.addAgent(agentConfig2, Username.ANONYMOUS);
+        CruiseConfig cruiseConfig = goConfigDao.load();
+        assertThat(cruiseConfig.agents().getAgentByUuid(agentConfig1.getUuid()).isDisabled(), is(false));
+        assertThat(cruiseConfig.agents().getAgentByUuid(agentConfig2.getUuid()).isDisabled(), is(true));
+
+        HttpLocalizedOperationResult result = new HttpLocalizedOperationResult();
+        ArrayList<String> uuids = new ArrayList<>();
+        uuids.add(agentConfig1.getUuid());
+        uuids.add(agentConfig2.getUuid());
+
+        agentConfigService.bulkUpdateAgentAttributes(Username.ANONYMOUS, result, uuids, new ArrayList<String>(), new ArrayList<String>(), new ArrayList<String>(), new ArrayList<String>(), TriState.UNSET);
+
+        cruiseConfig = goConfigDao.load();
+        assertTrue(result.isSuccessful());
+        assertTrue(result.toString(), result.toString().contains("BULK_AGENT_UPDATE_SUCESSFUL"));
+        assertFalse(cruiseConfig.agents().getAgentByUuid(agentConfig1.getUuid()).isDisabled());
+        assertTrue(cruiseConfig.agents().getAgentByUuid(agentConfig2.getUuid()).isDisabled());
+    }
+
+    @Test
+    public void shouldNotDisableAgentsWhenInvalidAgentUUIDIsprovided() throws Exception {
+        AgentConfig agentConfig1 = new AgentConfig(UUID.randomUUID().toString(), "remote-host1", "50.40.30.21");
+        AgentConfig agentConfig2 = new AgentConfig(UUID.randomUUID().toString(), "remote-host2", "50.40.30.22");
+        agentConfigService.addAgent(agentConfig1, Username.ANONYMOUS);
+        agentConfigService.addAgent(agentConfig2, Username.ANONYMOUS);
+        CruiseConfig cruiseConfig = goConfigDao.load();
+        assertFalse(cruiseConfig.agents().getAgentByUuid(agentConfig1.getUuid()).isDisabled());
+        assertFalse(cruiseConfig.agents().getAgentByUuid(agentConfig1.getUuid()).isDisabled());
+
+        HttpLocalizedOperationResult result = new HttpLocalizedOperationResult();
+        ArrayList<String> uuids = new ArrayList<>();
+        uuids.add(agentConfig1.getUuid());
+        uuids.add(agentConfig2.getUuid());
+        uuids.add("invalid-uuid");
+
+        agentConfigService.bulkUpdateAgentAttributes(Username.ANONYMOUS, result, uuids, new ArrayList<String>(), new ArrayList<String>(), new ArrayList<String>(), new ArrayList<String>(), TriState.FALSE);
+
+        cruiseConfig = goConfigDao.load();
+        assertFalse(cruiseConfig.agents().getAgentByUuid(agentConfig1.getUuid()).isDisabled());
+        assertFalse(cruiseConfig.agents().getAgentByUuid(agentConfig2.getUuid()).isDisabled());
+
+        assertFalse(result.isSuccessful());
+        assertThat(result.toString(), result.httpCode(), is(400));
+        assertTrue(result.toString(), result.toString().contains("AGENTS_WITH_UUIDS_NOT_FOUND"));
+        assertTrue(result.toString(), result.toString().contains("invalid-uuid"));
+    }
+
+    @Test
+    public void shouldNotEnableAgentsWhenInvalidAgentUUIDIsprovided() throws Exception {
+        AgentConfig agentConfig1 = new AgentConfig(UUID.randomUUID().toString(), "remote-host1", "50.40.30.21");
+        AgentConfig agentConfig2 = new AgentConfig(UUID.randomUUID().toString(), "remote-host2", "50.40.30.22");
+        agentConfigService.addAgent(agentConfig1, Username.ANONYMOUS);
+        agentConfigService.addAgent(agentConfig2, Username.ANONYMOUS);
+        CruiseConfig cruiseConfig = goConfigDao.load();
+        assertFalse(cruiseConfig.agents().getAgentByUuid(agentConfig1.getUuid()).isDisabled());
+        assertFalse(cruiseConfig.agents().getAgentByUuid(agentConfig2.getUuid()).isDisabled());
+
+        HttpLocalizedOperationResult result = new HttpLocalizedOperationResult();
+        ArrayList<String> uuids = new ArrayList<>();
+        uuids.add(agentConfig1.getUuid());
+        uuids.add(agentConfig2.getUuid());
+        uuids.add("invalid-uuid");
+
+        agentConfigService.bulkUpdateAgentAttributes(Username.ANONYMOUS, result, uuids, new ArrayList<String>(), new ArrayList<String>(), new ArrayList<String>(), new ArrayList<String>(), TriState.TRUE);
+
+        cruiseConfig = goConfigDao.load();
+        assertThat(cruiseConfig.agents().getAgentByUuid(agentConfig1.getUuid()).isDisabled(), is(false));
+        assertThat(cruiseConfig.agents().getAgentByUuid(agentConfig2.getUuid()).isDisabled(), is(false));
+
+        assertFalse(result.isSuccessful());
+        assertThat(result.toString(), result.httpCode(), is(400));
+        assertTrue(result.toString(), result.toString().contains("AGENTS_WITH_UUIDS_NOT_FOUND"));
+        assertTrue(result.toString(), result.toString().contains("invalid-uuid"));
+    }
+
+    @Test
+    public void shouldAddResourcestoTheSpecifiedAgents() throws Exception {
+        AgentConfig agentConfig1 = new AgentConfig(UUID.randomUUID().toString(), "remote-host1", "50.40.30.21");
+        AgentConfig agentConfig2 = new AgentConfig(UUID.randomUUID().toString(), "remote-host2", "50.40.30.22");
+        agentConfigService.addAgent(agentConfig1, Username.ANONYMOUS);
+        agentConfigService.addAgent(agentConfig2, Username.ANONYMOUS);
+        CruiseConfig cruiseConfig = goConfigDao.load();
+
+        assertThat(cruiseConfig.agents().getAgentByUuid(agentConfig1.getUuid()).getResources().size(), is(0));
+        assertThat(cruiseConfig.agents().getAgentByUuid(agentConfig2.getUuid()).getResources().size(), is(0));
+
+        HttpLocalizedOperationResult result = new HttpLocalizedOperationResult();
+        ArrayList<String> uuids = new ArrayList<>();
+        uuids.add(agentConfig1.getUuid());
+        uuids.add(agentConfig2.getUuid());
+
+        ArrayList<String> resources = new ArrayList<>();
+        resources.add("resource1");
+        resources.add("resource2");
+
+        agentConfigService.bulkUpdateAgentAttributes(Username.ANONYMOUS, result, uuids, resources, new ArrayList<String>(), new ArrayList<String>(), new ArrayList<String>(), TriState.FALSE);
+
+        cruiseConfig = goConfigDao.load();
+
+        assertTrue(result.isSuccessful());
+        assertThat(result.toString(), containsString("BULK_AGENT_UPDATE_SUCESSFUL"));
+        assertThat(cruiseConfig.agents().getAgentByUuid(agentConfig1.getUuid()).getResources().size(), is(2));
+        assertThat(cruiseConfig.agents().getAgentByUuid(agentConfig1.getUuid()).getResources(), containsInAnyOrder(new Resource("resource1"), new Resource("resource2")));
+    }
+
+    @Test
+    public void shouldRemoveResourcesFromTheSpecifiedAgents() throws Exception {
+        AgentConfig agentConfig1 = new AgentConfig(UUID.randomUUID().toString(), "remote-host1", "50.40.30.21");
+        AgentConfig agentConfig2 = new AgentConfig(UUID.randomUUID().toString(), "remote-host2", "50.40.30.22");
+        agentConfig1.addResource(new Resource("resource-1"));
+        agentConfig1.addResource(new Resource("resource-2"));
+        agentConfig2.addResource(new Resource("resource-2"));
+        agentConfigService.addAgent(agentConfig1, Username.ANONYMOUS);
+        agentConfigService.addAgent(agentConfig2, Username.ANONYMOUS);
+        CruiseConfig cruiseConfig = goConfigDao.load();
+
+        assertThat(cruiseConfig.agents().getAgentByUuid(agentConfig1.getUuid()).getResources().size(), is(2));
+        assertThat(cruiseConfig.agents().getAgentByUuid(agentConfig2.getUuid()).getResources().size(), is(1));
+
+        HttpLocalizedOperationResult result = new HttpLocalizedOperationResult();
+        ArrayList<String> uuids = new ArrayList<>();
+        uuids.add(agentConfig1.getUuid());
+        uuids.add(agentConfig2.getUuid());
+
+        ArrayList<String> resources = new ArrayList<>();
+        resources.add("resource-2");
+
+        agentConfigService.bulkUpdateAgentAttributes(Username.ANONYMOUS, result, uuids, new ArrayList<String>(), resources, new ArrayList<String>(), new ArrayList<String>(), TriState.FALSE);
+
+        cruiseConfig = goConfigDao.load();
+
+        assertTrue(result.isSuccessful());
+        assertThat(result.toString(), containsString("BULK_AGENT_UPDATE_SUCESSFUL"));
+        assertThat(cruiseConfig.agents().getAgentByUuid(agentConfig1.getUuid()).getResources().size(), is(1));
+        assertThat(cruiseConfig.agents().getAgentByUuid(agentConfig1.getUuid()).getResources(), contains(new Resource("resource-1")));
+        assertThat(cruiseConfig.agents().getAgentByUuid(agentConfig2.getUuid()).getResources().size(), is(0));
+    }
+
+    @Test
+    public void shouldAddProvidedAgentsToTheSpecifiedEnvironments() throws Exception {
+        AgentConfig agentConfig1 = new AgentConfig(UUID.randomUUID().toString(), "remote-host1", "50.40.30.21");
+        AgentConfig agentConfig2 = new AgentConfig(UUID.randomUUID().toString(), "remote-host2", "50.40.30.22");
+        agentConfigService.addAgent(agentConfig1, Username.ANONYMOUS);
+        agentConfigService.addAgent(agentConfig2, Username.ANONYMOUS);
+
+        BasicEnvironmentConfig environment = new BasicEnvironmentConfig(new CaseInsensitiveString("Dev"));
+        goConfigDao.addEnvironment(environment, Username.ANONYMOUS);
+
+        assertFalse(environment.hasAgent(agentConfig1.getUuid()));
+        assertFalse(environment.hasAgent(agentConfig2.getUuid()));
+
+        HttpLocalizedOperationResult result = new HttpLocalizedOperationResult();
+        ArrayList<String> uuids = new ArrayList<>();
+        uuids.add(agentConfig1.getUuid());
+        uuids.add(agentConfig2.getUuid());
+
+        ArrayList<String> environmentsToAdd = new ArrayList<>();
+        environmentsToAdd.add("Dev");
+
+        agentConfigService.bulkUpdateAgentAttributes(Username.ANONYMOUS, result, uuids, new ArrayList<String>(), new ArrayList<String>(), environmentsToAdd, new ArrayList<String>(), TriState.TRUE);
+
+        assertTrue(result.isSuccessful());
+        assertThat(result.toString(), containsString("BULK_AGENT_UPDATE_SUCESSFUL"));
+        assertThat(goConfigDao.load().getEnvironments().find(new CaseInsensitiveString("Dev")).getAgents().getUuids(), containsInAnyOrder(agentConfig1.getUuid(), agentConfig2.getUuid()));
+    }
+
+    @Test
+    public void shouldRemoveProvidedAgentsFromTheSpecifiedEnvironments() throws Exception {
+        AgentConfig agentConfig1 = new AgentConfig(UUID.randomUUID().toString(), "remote-host1", "50.40.30.21");
+        AgentConfig agentConfig2 = new AgentConfig(UUID.randomUUID().toString(), "remote-host2", "50.40.30.22");
+        agentConfigService.addAgent(agentConfig1, Username.ANONYMOUS);
+        agentConfigService.addAgent(agentConfig2, Username.ANONYMOUS);
+
+        BasicEnvironmentConfig devEnvironment = new BasicEnvironmentConfig(new CaseInsensitiveString("Dev"));
+        BasicEnvironmentConfig testEnvironment = new BasicEnvironmentConfig(new CaseInsensitiveString("Test"));
+        goConfigDao.addEnvironment(devEnvironment, Username.ANONYMOUS);
+        goConfigDao.addEnvironment(testEnvironment, Username.ANONYMOUS);
+
+        testEnvironment.addAgent(agentConfig1.getUuid());
+        devEnvironment.addAgent(agentConfig1.getUuid());
+        devEnvironment.addAgent(agentConfig2.getUuid());
+
+        assertThat(devEnvironment.getAgents().getUuids(), containsInAnyOrder(agentConfig1.getUuid(), agentConfig2.getUuid()));
+
+        HttpLocalizedOperationResult result = new HttpLocalizedOperationResult();
+        ArrayList<String> uuids = new ArrayList<>();
+        uuids.add(agentConfig1.getUuid());
+        uuids.add(agentConfig2.getUuid());
+
+        ArrayList<String> environmentsToRemove = new ArrayList<>();
+        environmentsToRemove.add("Dev");
+
+        agentConfigService.bulkUpdateAgentAttributes(Username.ANONYMOUS, result, uuids, new ArrayList<String>(), new ArrayList<String>(), new ArrayList<String>(), environmentsToRemove, TriState.TRUE);
+
+        assertTrue(result.isSuccessful());
+        assertThat(result.toString(), containsString("BULK_AGENT_UPDATE_SUCESSFUL"));
+        assertFalse(goConfigDao.load().getEnvironments().find(new CaseInsensitiveString("Dev")).hasAgent(agentConfig1.getUuid()));
+        assertFalse(goConfigDao.load().getEnvironments().find(new CaseInsensitiveString("Dev")).hasAgent(agentConfig2.getUuid()));
+    }
+
+    @Test
+    public void shouldNotAddAgentToNonExistingEnvironment() throws Exception {
+        AgentConfig agentConfig1 = new AgentConfig(UUID.randomUUID().toString(), "remote-host1", "50.40.30.21");
+        AgentConfig agentConfig2 = new AgentConfig(UUID.randomUUID().toString(), "remote-host2", "50.40.30.22");
+        agentConfigService.addAgent(agentConfig1, Username.ANONYMOUS);
+        agentConfigService.addAgent(agentConfig2, Username.ANONYMOUS);
+
+
+        HttpLocalizedOperationResult result = new HttpLocalizedOperationResult();
+        ArrayList<String> uuids = new ArrayList<>();
+        uuids.add(agentConfig1.getUuid());
+        uuids.add(agentConfig2.getUuid());
+
+        ArrayList<String> environmentsToAdd = new ArrayList<>();
+        environmentsToAdd.add("Non-Existing-Environment");
+
+        agentConfigService.bulkUpdateAgentAttributes(Username.ANONYMOUS, result, uuids, new ArrayList<String>(), new ArrayList<String>(), environmentsToAdd, new ArrayList<String>(), TriState.TRUE);
+
+        assertFalse(result.isSuccessful());
+        assertThat(result.toString(), result.httpCode(), is(400));
+        assertThat(result.toString(), containsString("ENV_NOT_FOUND"));
+        assertThat(result.toString(), containsString("Non-Existing-Environment"));
+    }
+
+    @Test
+    public void shouldNotRemoveAgentFromNonExistingEnvironment() throws Exception {
+        AgentConfig agentConfig1 = new AgentConfig(UUID.randomUUID().toString(), "remote-host1", "50.40.30.21");
+        AgentConfig agentConfig2 = new AgentConfig(UUID.randomUUID().toString(), "remote-host2", "50.40.30.22");
+        agentConfigService.addAgent(agentConfig1, Username.ANONYMOUS);
+        agentConfigService.addAgent(agentConfig2, Username.ANONYMOUS);
+
+
+        HttpLocalizedOperationResult result = new HttpLocalizedOperationResult();
+        ArrayList<String> uuids = new ArrayList<>();
+        uuids.add(agentConfig1.getUuid());
+        uuids.add(agentConfig2.getUuid());
+
+        ArrayList<String> environmentsToRemove = new ArrayList<>();
+        environmentsToRemove.add("NonExistingEnvironment");
+
+        agentConfigService.bulkUpdateAgentAttributes(Username.ANONYMOUS, result, uuids, new ArrayList<String>(), new ArrayList<String>(), new ArrayList<String>(), environmentsToRemove, TriState.TRUE);
+
+        assertFalse(result.isSuccessful());
+        assertThat(result.toString(), result.httpCode(), is(400));
+        assertThat(result.toString(), containsString("ENV_NOT_FOUND"));
+        assertThat(result.toString(), containsString("NonExistingEnvironment"));
+    }
+
+    @Test
+    public void shouldUpdateResourcesEnvironmentsAndAgentStateOfTheProvidedStatesAllTogether() throws Exception {
+        AgentConfig agentConfig1 = new AgentConfig(UUID.randomUUID().toString(), "remote-host1", "50.40.30.21");
+        AgentConfig agentConfig2 = new AgentConfig(UUID.randomUUID().toString(), "remote-host2", "50.40.30.22");
+        agentConfigService.addAgent(agentConfig1, Username.ANONYMOUS);
+        agentConfigService.addAgent(agentConfig2, Username.ANONYMOUS);
+
+        CruiseConfig cruiseConfig = goConfigDao.load();
+        BasicEnvironmentConfig environment = new BasicEnvironmentConfig(new CaseInsensitiveString("Dev"));
+        goConfigDao.addEnvironment(environment, Username.ANONYMOUS);
+
+        assertThat(environment.getAgents().getUuids(), not(containsInAnyOrder(agentConfig1.getUuid(), agentConfig2.getUuid())));
+        assertFalse(cruiseConfig.agents().getAgentByUuid(agentConfig1.getUuid()).isDisabled());
+        assertFalse(cruiseConfig.agents().getAgentByUuid(agentConfig1.getUuid()).isDisabled());
+        assertThat(cruiseConfig.agents().getAgentByUuid(agentConfig1.getUuid()).getResources().size(), is(0));
+        assertThat(cruiseConfig.agents().getAgentByUuid(agentConfig2.getUuid()).getResources().size(), is(0));
+
+        HttpLocalizedOperationResult result = new HttpLocalizedOperationResult();
+        ArrayList<String> uuids = new ArrayList<>();
+        uuids.add(agentConfig1.getUuid());
+        uuids.add(agentConfig2.getUuid());
+        ArrayList<String> resources = new ArrayList<>();
+        resources.add("resource1");
+        ArrayList<String> environmentsToAdd = new ArrayList<>();
+        environmentsToAdd.add("Dev");
+
+        agentConfigService.bulkUpdateAgentAttributes(Username.ANONYMOUS, result, uuids, resources, new ArrayList<String>(), environmentsToAdd, new ArrayList<String>(), TriState.FALSE);
+
+        cruiseConfig = goConfigDao.load();
+        assertTrue(result.isSuccessful());
+        assertThat(result.toString(), containsString("BULK_AGENT_UPDATE_SUCESSFUL"));
+        assertTrue(cruiseConfig.agents().getAgentByUuid(agentConfig1.getUuid()).isDisabled());
+        assertTrue(cruiseConfig.agents().getAgentByUuid(agentConfig2.getUuid()).isDisabled());
+        assertThat(cruiseConfig.agents().getAgentByUuid(agentConfig1.getUuid()).getResources(), contains(new Resource("resource1")));
+        assertThat(cruiseConfig.agents().getAgentByUuid(agentConfig2.getUuid()).getResources(), contains(new Resource("resource1")));
+        assertThat(cruiseConfig.getEnvironments().find(new CaseInsensitiveString("Dev")).getAgents().getUuids(), containsInAnyOrder(agentConfig1.getUuid(), agentConfig2.getUuid()));
     }
 }

--- a/server/test/unit/com/thoughtworks/go/server/service/GoConfigServiceTest.java
+++ b/server/test/unit/com/thoughtworks/go/server/service/GoConfigServiceTest.java
@@ -77,7 +77,8 @@ import static org.hamcrest.Matchers.*;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNull.nullValue;
 import static org.hamcrest.core.StringContains.containsString;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.*;
 
@@ -1216,6 +1217,14 @@ public class GoConfigServiceTest {
         group.add(pipelineConfig);
         expectLoad(new BasicCruiseConfig(group));
         assertThat(goConfigService.isPipelineEditableViaUI("pipeline"), is(true));
+    }
+
+    @Test
+    public void shouldTellIfAnUserIsAdministrator() throws Exception {
+        final Username user = new Username(new CaseInsensitiveString("user"));
+        expectLoad(mock(BasicCruiseConfig.class));
+        goConfigService.isAdministrator(user.getUsername());
+        verify(goConfigDao.load()).isAdministrator(user.getUsername().toString());
     }
 
     private PipelineConfig createPipelineConfig(String pipelineName, String stageName, String... buildNames) {

--- a/server/webapp/WEB-INF/rails.new/config/routes.rb
+++ b/server/webapp/WEB-INF/rails.new/config/routes.rb
@@ -258,6 +258,8 @@ Go::Application.routes.draw do
     api_version(:module => 'ApiV2', header: {name: 'Accept', value: 'application/vnd.go.cd.v2+json'}) do
       resources :agents, param: :uuid, except: [:new, :create, :edit, :update] do
         patch :update, on: :member
+        patch on: :collection, action: :bulk_update
+        delete on: :collection, action: :bulk_destroy
       end
 
       match '*url', via: :all, to: 'errors#not_found'

--- a/server/webapp/WEB-INF/rails.new/spec/controllers/api_v2/agents_controller_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/controllers/api_v2/agents_controller_spec.rb
@@ -328,4 +328,116 @@ describe ApiV2::AgentsController do
     end
   end
 
+  describe :bulk_delete do
+    describe :security do
+      it 'should allow anyone, with security disabled' do
+        disable_security
+        expect(controller).to allow_action(:delete, :bulk_destroy)
+      end
+
+      it 'should disallow anonymous users, with security enabled' do
+        enable_security
+        login_as_anonymous
+        expect(controller).to disallow_action(:delete, :bulk_destroy)
+      end
+
+      it 'should not allow normal users, with security enabled' do
+        login_as_user
+        expect(controller).to disallow_action(:delete, :bulk_destroy)
+      end
+    end
+
+    describe 'as user' do
+      it 'should not allow normal users to bulk_destroy the agents' do
+        login_as_user
+
+        delete_with_api_header :bulk_destroy, :uuids => ['foo']
+        expect(response).to have_api_message_response(401, 'You are not authorized to perform this action.')
+      end
+    end
+
+    describe 'as admin user' do
+      before(:each) do
+        login_as_admin
+      end
+
+      it 'should allow admin users to delete a group of agents' do
+        agent1 = AgentInstanceMother.idle()
+        agent2= AgentInstanceMother.idle()
+
+        @agent_service.should_receive(:deleteAgents).with(@user, anything(), [agent1.getUuid(), agent2.getUuid()]) do |user, result, uuids|
+          result.ok('Deleted 2 agent(s).')
+        end
+
+        delete_with_api_header :bulk_destroy, :uuids => [agent1.getUuid(), agent2.getUuid()]
+        expect(response).to be_ok
+        expect(response).to have_api_message_response(200, 'Deleted 2 agent(s).')
+      end
+
+      it 'should render result in case of error' do
+        agent1 = AgentInstanceMother.idle()
+        agent2 = AgentInstanceMother.idle()
+
+        @agent_service.should_receive(:deleteAgents).with(@user, anything(), [agent1.getUuid(), agent2.getUuid()]) do |user, result, uuids|
+          result.notAcceptable('Not Acceptable', HealthStateType.general(HealthStateScope::GLOBAL))
+        end
+
+        delete_with_api_header :bulk_destroy, :uuids => [agent1.getUuid(), agent2.getUuid()]
+        expect(response).to have_api_message_response(406, 'Not Acceptable')
+      end
+    end
+
+  end
+
+  describe :bulk_update do
+    describe :security do
+      it 'should allow anyone, with security disabled' do
+        disable_security
+        expect(controller).to allow_action(:patch, :bulk_update)
+      end
+
+      it 'should disallow anonymous users, with security enabled' do
+        enable_security
+        login_as_anonymous
+        expect(controller).to disallow_action(:patch, :bulk_update)
+      end
+
+      it 'should not allow normal users, with security enabled' do
+        login_as_user
+        expect(controller).to disallow_action(:patch, :bulk_update)
+      end
+
+      it 'should allow admin users, with security enabled' do
+        login_as_admin
+        expect(controller).to allow_action(:patch, :bulk_update)
+      end
+    end
+
+    describe 'as user ' do
+      it 'should not allow normal users to bulk_destroy the agents' do
+        login_as_user
+
+        patch_with_api_header :bulk_update, :uuids => ['foo']
+        expect(response).to have_api_message_response(401, 'You are not authorized to perform this action.')
+      end
+    end
+
+    describe 'as admin user' do
+      before(:each) do
+        login_as_admin
+      end
+
+      it 'should allow admin users to update a group of agents' do
+        uuids = %w(agent-1 agent-2)
+        @agent_service.should_receive(:bulkUpdateAgentAttributes).with(@user, anything(), uuids, anything(), anything(), anything(), anything(), anything()) do |user, result, uuids, r_add, r_remove, e_add, e_remove, state|
+          result.setMessage(LocalizedMessage.string("BULK_AGENT_UPDATE_SUCESSFUL", uuids.join(', ')));
+        end
+
+        patch_with_api_header :bulk_update, :uuids => uuids
+        expect(response).to be_ok
+        expect(response).to have_api_message_response(200, 'Updated agent(s) with uuid(s): [agent-1, agent-2].')
+      end
+    end
+  end
+
 end

--- a/server/webapp/localize.xml
+++ b/server/webapp/localize.xml
@@ -622,6 +622,7 @@
     <entry key="DURATION_HEADER">Duration</entry>
     <entry key="DOES_NOT_APPLY">-</entry>
     <entry key="AGENT_WITH_UUID_NOT_FOUND">Agent with uuid ''{0}'' not found.</entry>
+    <entry key="AGENTS_WITH_UUIDS_NOT_FOUND">Agent(s) with uuid(s) [{0}] not found.</entry>
     <entry key="CLONE">Clone</entry>
     <entry key="CLONE_PIPELINE">Clone Pipeline</entry>
     <entry key="AGENT_NO_JOB_RUN_HISTORY">This agent has no completed job runs.</entry>
@@ -801,4 +802,6 @@
     <entry key="PIPELINE_DELETE_SUCCESSFUL">Pipeline ''{0}'' was deleted successfully.</entry>
     <entry key="UNAUTHORIZED_TO_DELETE_PIPELINE">Unauthorized to delete pipeline.</entry>
     <entry key="PIPELINE_GROUP_MANDATORY_FOR_PIPELINE_CREATE">Pipeline group must be specified for creating a pipeline.</entry>
+    <entry key="UNAUTHORIZED_TO_OPERATE">You are not authorized to perform this operation.</entry>
+    <entry key="BULK_AGENT_UPDATE_SUCESSFUL">Updated agent(s) with uuid(s): [{0}].</entry>
 </properties>

--- a/server/webapp/localize_ja.xml
+++ b/server/webapp/localize_ja.xml
@@ -618,6 +618,7 @@
     <entry key="DURATION_HEADER">Duration</entry>
     <entry key="DOES_NOT_APPLY">-</entry>
     <entry key="AGENT_WITH_UUID_NOT_FOUND">Agent with uuid ''{0}'' not found.</entry>
+    <entry key="AGENTS_WITH_UUIDS_NOT_FOUND">Agent(s) with uuid(s) [{0}] not found.</entry>
     <entry key="CLONE">Clone</entry>
     <entry key="CLONE_PIPELINE">Clone Pipeline</entry>
     <entry key="AGENT_NO_JOB_RUN_HISTORY">This agent has no completed job runs.</entry>
@@ -797,4 +798,6 @@
     <entry key="PIPELINE_DELETE_SUCCESSFUL">Pipeline ''{0}'' was deleted successfully.</entry>
     <entry key="UNAUTHORIZED_TO_DELETE_PIPELINE">Unauthorized to delete pipeline.</entry>
     <entry key="PIPELINE_GROUP_MANDATORY_FOR_PIPELINE_CREATE">Pipeline group must be specified for creating a pipeline.</entry>
+    <entry key="UNAUTHORIZED_TO_OPERATE">You are not authorized to perform this operation.</entry>
+    <entry key="BULK_AGENT_UPDATE_SUCESSFUL">Updated agent(s) with uuid(s): [{0}].</entry>
 </properties>


### PR DESCRIPTION
API endpoint to bulk update agents

DELETE agents request --
```
curl 'https://ci.example.com/go/api/agents' \
      -u 'username:password' \
      -H 'Accept: application/vnd.go.cd.v2+json' \
      -H 'Content-Type: application/json' \
      -X DELETE \
      -d '{
            "uuids": [ "uuid1", "uuid2" ]
          }' 
```

UPDATE agents request --
```
curl 'https://ci.example.com/go/api/agents' \
      -u 'username:password' \
      -H 'Accept: application/vnd.go.cd.v2+json' \
      -H 'Content-Type: application/json' \
      -X PATCH \
      -d '{
            "uuids" : ["uuid1", "uuid2"],
            "operations": {
              "environments": {
                "add": ["dev"],
                "remove": ["testing"]
              },
              "resources": {
                "add": ["linux"],
                "remove": ["gauge"]
              }
            },
            "agent_config_state" : "disabled"
          }'
```

for updating the agent, if we want to update the specific parts such as only adding resources, we don't need to provide the other information

example:
```
curl 'https://ci.example.com/go/api/agents' \
      -u 'username:password' \
      -H 'Accept: application/vnd.go.cd.v2+json' \
      -H 'Content-Type: application/json' \
      -X PATCH \
      -d '{
            "uuids" : ["uuid1", "uuid2"],
            "operations": {
              "resources": {
                "add": ["linux"]
               }
             }
          }'
```