### PR TITLE
Handling deletion of config-repo from main config - #2353, #1133

### DIFF
--- a/config/config-api/test/com/thoughtworks/go/config/BasicCruiseConfigTest.java
+++ b/config/config-api/test/com/thoughtworks/go/config/BasicCruiseConfigTest.java
@@ -1,21 +1,22 @@
 package com.thoughtworks.go.config;
 
 import com.thoughtworks.go.config.materials.dependency.DependencyMaterialConfig;
-import com.thoughtworks.go.config.remote.ConfigOrigin;
-import com.thoughtworks.go.config.remote.FileConfigOrigin;
+import com.thoughtworks.go.config.materials.git.GitMaterialConfig;
+import com.thoughtworks.go.config.remote.*;
 import com.thoughtworks.go.domain.PipelineGroups;
-import com.thoughtworks.go.helper.GoConfigMother;
-import com.thoughtworks.go.helper.PipelineConfigMother;
+import com.thoughtworks.go.helper.*;
 import org.hamcrest.core.Is;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
 import static com.thoughtworks.go.helper.PipelineConfigMother.createGroup;
 import static com.thoughtworks.go.helper.PipelineConfigMother.createPipelineConfig;
+import static java.util.Arrays.asList;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.core.Is.is;
@@ -41,14 +42,13 @@ public class BasicCruiseConfigTest extends CruiseConfigTestBase {
     }
 
     @Test
-    public void getAllLocalPipelineConfigs_shouldReturnOnlyLocalPipelinesWhenNoRemotes()
-    {
+    public void getAllLocalPipelineConfigs_shouldReturnOnlyLocalPipelinesWhenNoRemotes() {
         PipelineConfig pipeline1 = createPipelineConfig("local-pipe-1", "stage1");
         cruiseConfig.getGroups().addPipeline("existing_group", pipeline1);
 
         List<PipelineConfig> localPipelines = cruiseConfig.getAllLocalPipelineConfigs(false);
-        assertThat(localPipelines.size(),is(1));
-        assertThat(localPipelines,hasItem(pipeline1));
+        assertThat(localPipelines.size(), is(1));
+        assertThat(localPipelines, hasItem(pipeline1));
     }
 
     @Test
@@ -66,7 +66,7 @@ public class BasicCruiseConfigTest extends CruiseConfigTestBase {
         p3.addMaterialConfig(new DependencyMaterialConfig(new CaseInsensitiveString("p1"), new CaseInsensitiveString("s1")));
         PipelineConfig p4 = createPipelineConfig("p4", "s4", "j1");
         p4.addMaterialConfig(new DependencyMaterialConfig(new CaseInsensitiveString("p2"), new CaseInsensitiveString("s2")));
-        pipelines.addAll(Arrays.asList(p4, p2, p1, p3));
+        pipelines.addAll(asList(p4, p2, p1, p3));
         Map<String, List<PipelineConfig>> expectedPipelines = cruiseConfig.generatePipelineVsDownstreamMap();
         assertThat(expectedPipelines.size(), is(4));
         assertThat(expectedPipelines.get("p1"), hasItems(p2, p3));
@@ -84,6 +84,7 @@ public class BasicCruiseConfigTest extends CruiseConfigTestBase {
         mainCruiseConfig.setOrigins(new FileConfigOrigin());
         assertThat(pipe.getOrigin(), Is.<ConfigOrigin>is(new FileConfigOrigin()));
     }
+
     @Test
     public void shouldSetOriginInEnvironments() {
         BasicCruiseConfig mainCruiseConfig = new BasicCruiseConfig(pipelines);
@@ -119,5 +120,32 @@ public class BasicCruiseConfigTest extends CruiseConfigTestBase {
         PipelineConfigs group2 = createGroup("group2", createPipelineConfig("pipeline2", "stage2"));
         CruiseConfig config = new BasicCruiseConfig(group1, group2);
         assertThat("shouldReturnFalseForPipelineThatNotInFirstGroup", config.isInFirstGroup(new CaseInsensitiveString("pipeline2")), is(false));
+    }
+
+    @Test
+    public void shouldIncludeRemotePipelinesAsPartOfCachedPipelineConfigs() {
+        BasicCruiseConfig cruiseConfig = GoConfigMother.configWithPipelines("p1", "p2");
+        ConfigRepoConfig repoConfig1 = new ConfigRepoConfig(MaterialConfigsMother.gitMaterialConfig("url1"), "plugin");
+        ConfigRepoConfig repoConfig2 = new ConfigRepoConfig(MaterialConfigsMother.gitMaterialConfig("url2"), "plugin");
+        cruiseConfig.setConfigRepos(new ConfigReposConfig(repoConfig1, repoConfig2));
+        PartialConfig partialConfigInRepo1 = PartialConfigMother.withPipeline("pipeline_in_repo1", new RepoConfigOrigin(repoConfig1, "repo1_r1"));
+        PartialConfig partialConfigInRepo2 = PartialConfigMother.withPipeline("pipeline_in_repo2", new RepoConfigOrigin(repoConfig2, "repo2_r1"));
+
+        cruiseConfig.merge(asList(partialConfigInRepo1, partialConfigInRepo2), false);
+        assertThat(cruiseConfig.getAllPipelineNames().contains(new CaseInsensitiveString("pipeline_in_repo1")), is(true));
+        assertThat(cruiseConfig.getAllPipelineNames().contains(new CaseInsensitiveString("pipeline_in_repo2")), is(true));
+    }
+
+    @Test
+    public void shouldRejectRemotePipelinesNotOriginatingFromRegisteredConfigReposFromCachedPipelineConfigs() {
+        BasicCruiseConfig cruiseConfig = GoConfigMother.configWithPipelines("p1", "p2");
+        ConfigRepoConfig repoConfig1 = new ConfigRepoConfig(MaterialConfigsMother.gitMaterialConfig("url1"), "plugin");
+        ConfigRepoConfig repoConfig2 = new ConfigRepoConfig(MaterialConfigsMother.gitMaterialConfig("url2"), "plugin");
+        cruiseConfig.setConfigRepos(new ConfigReposConfig(repoConfig2));
+        PartialConfig partialConfigInRepo1 = PartialConfigMother.withPipeline("pipeline_in_repo1", new RepoConfigOrigin(repoConfig1, "repo1_r1"));
+        PartialConfig partialConfigInRepo2 = PartialConfigMother.withPipeline("pipeline_in_repo2", new RepoConfigOrigin(repoConfig2, "repo2_r1"));
+        cruiseConfig.merge(asList(partialConfigInRepo1, partialConfigInRepo2), false);
+        assertThat(cruiseConfig.getAllPipelineNames().contains(new CaseInsensitiveString("pipeline_in_repo1")), is(false));
+        assertThat(cruiseConfig.getAllPipelineNames().contains(new CaseInsensitiveString("pipeline_in_repo2")), is(true));
     }
 }

--- a/server/src/com/thoughtworks/go/config/CachedGoPartials.java
+++ b/server/src/com/thoughtworks/go/config/CachedGoPartials.java
@@ -52,6 +52,7 @@ public class CachedGoPartials {
     public void removeKnown(String fingerprint) {
         if (fingerprintToLatestKnownConfigMap.containsKey(fingerprint)) {
             fingerprintToLatestKnownConfigMap.remove(fingerprint);
+            serverHealthService.removeByScope(HealthStateScope.forPartialConfigRepo(fingerprint));
         }
     }
 

--- a/server/test/integration/com/thoughtworks/go/config/CachedGoConfigIntegrationTest.java
+++ b/server/test/integration/com/thoughtworks/go/config/CachedGoConfigIntegrationTest.java
@@ -27,12 +27,17 @@ import com.thoughtworks.go.config.remote.PartialConfig;
 import com.thoughtworks.go.config.remote.RepoConfigOrigin;
 import com.thoughtworks.go.config.update.CreatePipelineConfigCommand;
 import com.thoughtworks.go.config.validation.GoConfigValidity;
+import com.thoughtworks.go.domain.config.Admin;
 import com.thoughtworks.go.domain.materials.MaterialConfig;
 import com.thoughtworks.go.helper.*;
 import com.thoughtworks.go.listener.ConfigChangedListener;
+import com.thoughtworks.go.presentation.TriStateSelection;
+import com.thoughtworks.go.security.GoCipher;
 import com.thoughtworks.go.server.domain.Username;
 import com.thoughtworks.go.server.service.GoConfigService;
 import com.thoughtworks.go.server.service.result.DefaultLocalizedOperationResult;
+import com.thoughtworks.go.server.service.result.HttpLocalizedOperationResult;
+import com.thoughtworks.go.server.util.EntityDigest;
 import com.thoughtworks.go.serverhealth.HealthStateScope;
 import com.thoughtworks.go.serverhealth.HealthStateType;
 import com.thoughtworks.go.serverhealth.ServerHealthService;
@@ -895,6 +900,67 @@ public class CachedGoConfigIntegrationTest {
         });
         assertThat(state, is(ConfigSaveState.UPDATED));
         assertThat(goConfigService.getCurrentConfig().server().getCommandRepositoryLocation(), is("newlocation"));
+    }
+
+    @Test
+    public void shouldRemoveCorrespondingRemotePipelinesFromCachedGoConfigIfTheConfigRepoIsDeleted(){
+        final ConfigRepoConfig repoConfig1 = new ConfigRepoConfig(MaterialConfigsMother.gitMaterialConfig("url1"), XmlPartialConfigProvider.providerName);
+        final ConfigRepoConfig repoConfig2 = new ConfigRepoConfig(MaterialConfigsMother.gitMaterialConfig("url2"), XmlPartialConfigProvider.providerName);
+        goConfigService.updateConfig(new UpdateConfigCommand() {
+            @Override
+            public CruiseConfig update(CruiseConfig cruiseConfig) throws Exception {
+                cruiseConfig.getConfigRepos().add(repoConfig1);
+                cruiseConfig.getConfigRepos().add(repoConfig2);
+                return cruiseConfig;
+            }
+        });
+        PartialConfig partialConfigInRepo1 = PartialConfigMother.withPipeline("pipeline_in_repo1", new RepoConfigOrigin(repoConfig1, "repo1_r1"));
+        PartialConfig partialConfigInRepo2 = PartialConfigMother.withPipeline("pipeline_in_repo2", new RepoConfigOrigin(repoConfig2, "repo2_r1"));
+        goPartialConfig.onSuccessPartialConfig(repoConfig1, partialConfigInRepo1);
+        goPartialConfig.onSuccessPartialConfig(repoConfig2, partialConfigInRepo2);
+
+        // introduce an invalid change in repo1 so that there is a server health message corresponding to it
+        PartialConfig invalidPartialInRepo1Revision2 = PartialConfigMother.invalidPartial("pipeline_in_repo1", new RepoConfigOrigin(repoConfig1, "repo1_r2"));
+        goPartialConfig.onSuccessPartialConfig(repoConfig1, invalidPartialInRepo1Revision2);
+        assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).size(), is(1));
+        assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).get(0).getMessage(), is("Invalid Merged Configuration"));
+        assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).get(0).getDescription(), is("1+ errors :: Invalid stage name ''. This must be alphanumeric and can contain underscores and periods (however, it cannot start with a period). The maximum allowed length is 255 characters.;;  -  Config-Repo: url1 at repo1_r2"));
+        assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig2)).isEmpty(), is(true));
+
+        int countBeforeDeletion = cachedGoConfig.currentConfig().getConfigRepos().size();
+        ConfigSaveState configSaveState = cachedGoConfig.writeWithLock(new UpdateConfigCommand() {
+            @Override
+            public CruiseConfig update(CruiseConfig cruiseConfig) throws Exception {
+                cruiseConfig.getConfigRepos().remove(repoConfig1);
+                return cruiseConfig;
+            }
+        });
+        assertThat(configSaveState, is(ConfigSaveState.UPDATED));
+        assertThat(cachedGoConfig.currentConfig().getConfigRepos().size(), is(countBeforeDeletion - 1));
+        assertThat(cachedGoConfig.currentConfig().getConfigRepos().contains(repoConfig2), is(true));
+        assertThat(cachedGoConfig.currentConfig().getAllPipelineNames().contains(new CaseInsensitiveString("pipeline_in_repo1")), is(false));
+        assertThat(cachedGoConfig.currentConfig().getAllPipelineNames().contains(new CaseInsensitiveString("pipeline_in_repo2")), is(true));
+        assertThat(cachedGoPartials.lastKnownPartials().size(), is(1));
+        assertThat(((RepoConfigOrigin)cachedGoPartials.lastKnownPartials().get(0).getOrigin()).getMaterial().getFingerprint().equals(repoConfig2.getMaterialConfig().getFingerprint()), is(true));
+        assertThat(ListUtil.find(cachedGoPartials.lastKnownPartials(), new ListUtil.Condition() {
+            @Override
+            public <T> boolean isMet(T item) {
+                PartialConfig partialConfig = (PartialConfig) item;
+                return ((RepoConfigOrigin) partialConfig.getOrigin()).getMaterial().getFingerprint().equals(repoConfig1.getMaterialConfig().getFingerprint());
+            }
+        }), is(nullValue()));
+        assertThat(cachedGoPartials.lastValidPartials().size(), is(1));
+        assertThat(((RepoConfigOrigin)cachedGoPartials.lastValidPartials().get(0).getOrigin()).getMaterial().getFingerprint().equals(repoConfig2.getMaterialConfig().getFingerprint()), is(true));
+        assertThat(ListUtil.find(cachedGoPartials.lastValidPartials(), new ListUtil.Condition() {
+            @Override
+            public <T> boolean isMet(T item) {
+                PartialConfig partialConfig = (PartialConfig) item;
+                return ((RepoConfigOrigin) partialConfig.getOrigin()).getMaterial().getFingerprint().equals(repoConfig1.getMaterialConfig().getFingerprint());
+            }
+        }), is(nullValue()));
+
+        assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).isEmpty(), is(true));
+        assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig2)).isEmpty(), is(true));
     }
 
     private void addPipelineWithParams(CruiseConfig cruiseConfig) {


### PR DESCRIPTION
All server health messages and pipelines should get cleared from dashboard when the correspondign config-repo is deleted from the main config