### PR TITLE
#1133 whitelist support for config repos

### DIFF
--- a/config/config-api/src/com/thoughtworks/go/config/materials/git/GitMaterialConfig.java
+++ b/config/config-api/src/com/thoughtworks/go/config/materials/git/GitMaterialConfig.java
@@ -41,8 +41,6 @@ public class GitMaterialConfig extends ScmMaterialConfig {
 
     private String submoduleFolder;
 
-
-
     public static final String TYPE = "GitMaterial";
     public static final String URL = "url";
     public static final String BRANCH = "branch";
@@ -69,7 +67,6 @@ public class GitMaterialConfig extends ScmMaterialConfig {
         this(url, branch);
         setShallowClone(shallowClone);
     }
-
 
     public GitMaterialConfig(UrlArgument url, String branch, String submoduleFolder, boolean autoUpdate, Filter filter, boolean invertFilter, String folder, CaseInsensitiveString name, Boolean shallowClone) {
         super(name, filter, invertFilter, folder, autoUpdate, TYPE, new ConfigErrors());

--- a/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/configrepo/contract/material/CRFilter.java
+++ b/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/configrepo/contract/material/CRFilter.java
@@ -9,15 +9,20 @@ import java.util.List;
 
 public class CRFilter extends CRBase {
     private List<String> ignore  = new ArrayList<String>();
-    // room for whitelist
+    private List<String> whitelist  = new ArrayList<String>();
 
-    public CRFilter(List<String> ignore) {
-        this.ignore = ignore;
+    public CRFilter(List<String> list,boolean whitelist) {
+        if(whitelist)
+            this.whitelist = list;
+        else
+            this.ignore = list;
     }
 
     @Override
     public void getErrors(ErrorCollection errors, String parentLocation) {
-
+        if (this.isBlacklist() && this.isWhitelist()) {
+            errors.addError(getLocation(parentLocation), "Material filter cannot contain both ignores and whitelist");
+        }
     }
 
     @Override
@@ -26,14 +31,34 @@ public class CRFilter extends CRBase {
         return String.format("%s; Filter",myLocation);
     }
 
-    public List<String> getIgnore() {
-        return ignore;
+    public boolean isWhitelist() {
+        return whitelist != null && whitelist.size() > 0;
+    }
+
+    public List<String> getList() {
+        if(isBlacklist())
+            return ignore;
+        else
+            return whitelist;
+    }
+
+    private boolean isBlacklist() {
+        return ignore != null && ignore.size() > 0;
     }
 
     public void setIgnore(List<String> ignore) {
         this.ignore = ignore;
+        this.whitelist = null;
     }
 
+    public void setWhitelist(List<String> whitelist) {
+        this.ignore = null;
+        this.whitelist = whitelist;
+    }
+
+    public void setWhitelistNoCheck(List<String> list) {
+        this.whitelist = list;
+    }
 
     @Override
     public boolean equals(Object o) {
@@ -48,6 +73,9 @@ public class CRFilter extends CRBase {
         if (ignore != null ? !CollectionUtils.isEqualCollection(this.ignore, that.ignore) : that.ignore != null) {
             return false;
         }
+        if (whitelist != null ? !CollectionUtils.isEqualCollection(this.whitelist, that.whitelist) : that.whitelist != null) {
+            return false;
+        }
 
         return true;
     }
@@ -56,6 +84,7 @@ public class CRFilter extends CRBase {
     public int hashCode() {
         int result = 32;
         result = 31 * result + (ignore != null ? ignore.size() : 0);
+        result = 31 * result + (whitelist != null ? whitelist.size() : 0);
         return result;
     }
 

--- a/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/configrepo/contract/material/CRGitMaterial.java
+++ b/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/configrepo/contract/material/CRGitMaterial.java
@@ -18,14 +18,14 @@ public class CRGitMaterial extends CRScmMaterial {
         type = TYPE_NAME;
     }
 
-    public CRGitMaterial(String materialName, String folder, boolean autoUpdate,Boolean shallow_clone,String url,String branch, String... filters) {
-        super(TYPE_NAME, materialName, folder, autoUpdate, filters);
+    public CRGitMaterial(String materialName, String folder, boolean autoUpdate,Boolean shallow_clone,String url,String branch,boolean whitelist, String... filters) {
+        super(TYPE_NAME, materialName, folder, autoUpdate,whitelist, filters);
         this.url = url;
         this.branch = branch;
         this.shallow_clone = shallow_clone;
     }
-    public CRGitMaterial(String name, String folder, boolean autoUpdate,Boolean shallow_clone, List<String> filter,String url,String branch) {
-        super(name, folder, autoUpdate, filter);
+    public CRGitMaterial(String name, String folder, boolean autoUpdate,Boolean shallow_clone, List<String> filter,String url,String branch,boolean whitelist) {
+        super(name, folder, autoUpdate,whitelist, filter);
         this.url = url;
         this.branch = branch;
         this.shallow_clone = shallow_clone;
@@ -93,6 +93,7 @@ public class CRGitMaterial extends CRScmMaterial {
     @Override
     public void getErrors(ErrorCollection errors, String parentLocation) {
         String location = getLocation(parentLocation);
+        getCommonErrors(errors,location);
         errors.checkMissing(location,"url",url);
     }
 

--- a/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/configrepo/contract/material/CRHgMaterial.java
+++ b/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/configrepo/contract/material/CRHgMaterial.java
@@ -16,13 +16,13 @@ public class CRHgMaterial extends CRScmMaterial {
         type = TYPE_NAME;
     }
 
-    public CRHgMaterial(String materialName, String folder, boolean autoUpdate,String url, String... filters) {
-        super(TYPE_NAME, materialName, folder, autoUpdate, filters);
+    public CRHgMaterial(String materialName, String folder, boolean autoUpdate,String url, boolean whitelist,String... filters) {
+        super(TYPE_NAME, materialName, folder, autoUpdate,whitelist, filters);
         this.url = url;
     }
 
-    public CRHgMaterial(String name, String folder, boolean autoUpdate, List<String> filter, String url) {
-        super(TYPE_NAME, name, folder, autoUpdate, filter);
+    public CRHgMaterial(String name, String folder, boolean autoUpdate,boolean whitelist, List<String> filter, String url) {
+        super(TYPE_NAME, name, folder, autoUpdate, whitelist, filter);
         this.url = url;
     }
 
@@ -70,6 +70,7 @@ public class CRHgMaterial extends CRScmMaterial {
     @Override
     public void getErrors(ErrorCollection errors, String parentLocation) {
         String location = getLocation(parentLocation);
+        getCommonErrors(errors,location);
         errors.checkMissing(location,"url",url);
     }
 

--- a/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/configrepo/contract/material/CRP4Material.java
+++ b/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/configrepo/contract/material/CRP4Material.java
@@ -11,13 +11,14 @@ public class CRP4Material extends CRScmMaterial {
     public static final String TYPE_NAME = "p4";
 
     public static CRP4Material withPlainPassword(
-            String name, String folder, boolean autoUpdate, List<String> filter,
+            String name, String folder, boolean autoUpdate,boolean whitelist, List<String> filter,
             String serverAndPort, String userName, String password, boolean useTickets,String view)
     {
         return new CRP4Material(
                 name,
                 folder,
                 autoUpdate,
+                whitelist,
                 filter,
                 serverAndPort,
                 userName,
@@ -27,13 +28,14 @@ public class CRP4Material extends CRScmMaterial {
                 view);
     }
     public static CRP4Material withEncryptedPassword(
-            String name, String folder, boolean autoUpdate, List<String> filter,
+            String name, String folder, boolean autoUpdate,boolean whitelist, List<String> filter,
             String serverAndPort, String userName, String encryptedPassword, boolean useTickets,String view)
     {
         return new CRP4Material(
                 name,
                 folder,
                 autoUpdate,
+                whitelist,
                 filter,
                 serverAndPort,
                 userName,
@@ -43,9 +45,9 @@ public class CRP4Material extends CRScmMaterial {
                 view);
     }
     
-    private CRP4Material(String name, String folder, boolean autoUpdate, List<String> filter,
+    private CRP4Material(String name, String folder, boolean autoUpdate,boolean whitelist, List<String> filter,
                          String serverAndPort, String userName, String password,String encryptedPassword, boolean useTickets,String view) {
-        super(TYPE_NAME,name, folder, autoUpdate, filter);
+        super(TYPE_NAME,name, folder, autoUpdate,whitelist, filter);
         this.port = serverAndPort;
         this.username = userName;
         this.password = password;
@@ -73,8 +75,8 @@ public class CRP4Material extends CRScmMaterial {
     }
 
     public CRP4Material(String materialName, String folder, boolean autoUpdate,String serverAndPort,String view,String userName,String password,
-                        boolean useTickets,String... filters) {
-        super(TYPE_NAME, materialName, folder, autoUpdate, filters);
+                        boolean useTickets,boolean whitelist,String... filters) {
+        super(TYPE_NAME, materialName, folder, autoUpdate,whitelist, filters);
         this.port = serverAndPort;
         this.username = userName;
         this.password = password;
@@ -202,6 +204,7 @@ public class CRP4Material extends CRScmMaterial {
     @Override
     public void getErrors(ErrorCollection errors, String parentLocation) {
         String location = getLocation(parentLocation);
+        getCommonErrors(errors,location);
         errors.checkMissing(location,"port",port);
         errors.checkMissing(location,"view",view);
         validatePassword(errors,parentLocation);

--- a/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/configrepo/contract/material/CRPluggableScmMaterial.java
+++ b/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/configrepo/contract/material/CRPluggableScmMaterial.java
@@ -22,13 +22,13 @@ public class CRPluggableScmMaterial extends CRMaterial implements SourceCodeMate
         super(TYPE_NAME,materialName);
         this.scm_id = scmId;
         this.destination = folder;
-        this.filter = new CRFilter(Arrays.asList(filters));
+        this.filter = new CRFilter(Arrays.asList(filters),false/*not supported in 16.6*/);
     }
     public CRPluggableScmMaterial(String name, String scmId, String directory, List<String> filter) {
         super(TYPE_NAME,name);
         this.scm_id = scmId;
         this.destination = directory;
-        this.filter = new CRFilter(filter);
+        this.filter = new CRFilter(filter,false);
     }
 
     @Override
@@ -79,10 +79,10 @@ public class CRPluggableScmMaterial extends CRMaterial implements SourceCodeMate
         this.scm_id = scmId;
     }
 
-    public List<String> getFilterIgnores() {
+    public List<String> getFilterList() {
         if(filter == null)
             return null;
-        return filter.getIgnore();
+        return filter.getList();
     }
 
     public void setFilterIgnore(List<String> filter) {

--- a/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/configrepo/contract/material/CRScmMaterial.java
+++ b/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/configrepo/contract/material/CRScmMaterial.java
@@ -1,5 +1,6 @@
 package com.thoughtworks.go.plugin.access.configrepo.contract.material;
 
+import com.thoughtworks.go.plugin.access.configrepo.ErrorCollection;
 import org.apache.commons.collections.CollectionUtils;
 
 import java.util.ArrayList;
@@ -13,35 +14,47 @@ public abstract class CRScmMaterial extends CRMaterial implements SourceCodeMate
 
     public CRScmMaterial() {
     }
-    public CRScmMaterial(String type,String materialName,String folder,boolean autoUpdate, String... filters)
+    public CRScmMaterial(String type,String materialName,String folder,boolean autoUpdate,boolean whitelist, String... filters)
     {
         super(type,materialName);
         this.destination = folder;
-        this.filter = new CRFilter(Arrays.asList(filters));
+        this.filter = new CRFilter(Arrays.asList(filters),whitelist);
         this.auto_update = autoUpdate;
     }
 
-    public CRScmMaterial(String type,String materialName, String folder, boolean autoUpdate, List<String> filter) {
+    public CRScmMaterial(String type,String materialName, String folder, boolean autoUpdate,boolean whitelist, List<String> filter) {
         super(type,materialName);
         this.destination = folder;
-        this.filter = new CRFilter(filter);
+        this.filter = new CRFilter(filter,whitelist);
         this.auto_update = autoUpdate;
     }
-    public CRScmMaterial(String name,String folder,boolean autoUpdate,List<String> filter) {
+    public CRScmMaterial(String name,String folder,boolean autoUpdate,boolean whitelist,List<String> filter) {
         super(name);
         this.destination = folder;
-        this.filter = new CRFilter(filter);
+        this.filter = new CRFilter(filter,whitelist);
         this.auto_update = autoUpdate;
     }
 
-    public List<String> getFilterIgnores() {
+    public List<String> getFilterList() {
         if(filter == null)
             return null;
-        return filter.getIgnore();
+        return filter.getList();
     }
 
-    public void setFilterIgnore(List<String> filter) {
-        this.filter.setIgnore(filter);
+    public boolean isWhitelist() {
+        if(this.filter != null)
+            return this.filter.isWhitelist();
+        return false;
+    }
+
+    protected void getCommonErrors(ErrorCollection errors, String parentLocation) {
+        String location = getLocation(parentLocation);
+        if(this.filter != null)
+            this.filter.getErrors(errors,location);
+    }
+
+    public void setWhitelistNoCheck(String... filters) { //for tests
+        this.filter.setWhitelistNoCheck(Arrays.asList(filters));
     }
 
     public boolean isAutoUpdate() {
@@ -95,5 +108,4 @@ public abstract class CRScmMaterial extends CRMaterial implements SourceCodeMate
         result = 31 * result + (filter != null ? filter.hashCode() : 0);
         return result;
     }
-
 }

--- a/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/configrepo/contract/material/CRSvnMaterial.java
+++ b/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/configrepo/contract/material/CRSvnMaterial.java
@@ -9,10 +9,10 @@ import java.util.List;
 public class CRSvnMaterial extends CRScmMaterial {
 
 
-    public static CRSvnMaterial withEncryptedPassword(String name, String destination, boolean autoUpdate, List<String> filter,
+    public static CRSvnMaterial withEncryptedPassword(String name, String destination, boolean autoUpdate,boolean whitelist, List<String> filter,
                                                       String url, String userName, String encryptedPassword, boolean checkExternals)
     {
-        CRSvnMaterial crSvnMaterial = new CRSvnMaterial(name, destination, autoUpdate, filter,
+        CRSvnMaterial crSvnMaterial = new CRSvnMaterial(name, destination, autoUpdate,whitelist, filter,
                 url, userName, null, checkExternals);
         crSvnMaterial.setEncryptedPassword(encryptedPassword);
         return crSvnMaterial;
@@ -32,24 +32,24 @@ public class CRSvnMaterial extends CRScmMaterial {
     }
 
     public CRSvnMaterial(String materialName, String folder, boolean autoUpdate,String url,
-                         boolean checkExternals,String... filters) {
-        super(TYPE_NAME, materialName, folder, autoUpdate, filters);
+                         boolean checkExternals,boolean whitelist,String... filters) {
+        super(TYPE_NAME, materialName, folder, autoUpdate,whitelist, filters);
         this.url = url;
         this.check_externals = checkExternals;
     }
 
     public CRSvnMaterial(String materialName, String folder, boolean autoUpdate,String url,String userName,String password,
-                         boolean checkExternals,String... filters) {
-        super(TYPE_NAME, materialName, folder, autoUpdate, filters);
+                         boolean checkExternals,boolean whitelist,String... filters) {
+        super(TYPE_NAME, materialName, folder, autoUpdate,whitelist, filters);
         this.url = url;
         this.username = userName;
         this.password = password;
         this.check_externals = checkExternals;
     }
 
-    public CRSvnMaterial(String name, String folder, boolean autoUpdate, List<String> filter,
+    public CRSvnMaterial(String name, String folder, boolean autoUpdate,boolean whitelist, List<String> filter,
                          String url, String userName, String password, boolean checkExternals) {
-        super(TYPE_NAME, name, folder, autoUpdate, filter);
+        super(TYPE_NAME, name, folder, autoUpdate,whitelist, filter);
         this.url = url;
         this.username = userName;
         this.password = password;
@@ -164,6 +164,7 @@ public class CRSvnMaterial extends CRScmMaterial {
     @Override
     public void getErrors(ErrorCollection errors, String parentLocation) {
         String location = this.getLocation(parentLocation);
+        getCommonErrors(errors,location);
         errors.checkMissing(location,"url",url);
         validatePassword(errors,location);
     }

--- a/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/configrepo/contract/material/CRTfsMaterial.java
+++ b/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/configrepo/contract/material/CRTfsMaterial.java
@@ -8,16 +8,16 @@ import java.util.List;
 public class CRTfsMaterial extends CRScmMaterial {
 
     public static CRTfsMaterial withEncryptedPassword(String name, String directory, boolean autoUpdate,
-                                                      List<String> filter, String url, String domain, String username,
+                                                      boolean whitelist,List<String> filter, String url, String domain, String username,
                                                       String encrypted_password, String project) {
-        return new CRTfsMaterial(name,directory,autoUpdate,filter,
+        return new CRTfsMaterial(name,directory,autoUpdate,whitelist,filter,
                 url,username,null,encrypted_password,project,domain);
     }
 
     public static CRTfsMaterial withPlainPassword(String name, String directory, boolean autoUpdate,
-                                               List<String> filter, String url, String domain, String username,
+                                                  boolean whitelist,List<String> filter, String url, String domain, String username,
                                                String password, String project) {
-        return new CRTfsMaterial(name,directory,autoUpdate,filter,
+        return new CRTfsMaterial(name,directory,autoUpdate,whitelist,filter,
                 url,username,password,null,project,domain);
     }
 
@@ -31,11 +31,11 @@ public class CRTfsMaterial extends CRScmMaterial {
     private String project;
 
     private CRTfsMaterial(
-            String name, String folder, boolean autoUpdate, List<String> filter,
+            String name, String folder, boolean autoUpdate, boolean whitelist, List<String> filter,
             String url,String userName,
             String password,String encryptedPassword,
             String projectPath,String domain) {
-        super(name, folder, autoUpdate, filter);
+        super(name, folder, autoUpdate, whitelist, filter);
         this.url = url;
         this.username = userName;
         this.domain = domain;
@@ -59,8 +59,8 @@ public class CRTfsMaterial extends CRScmMaterial {
 
     public CRTfsMaterial(String materialName, String folder, boolean autoUpdate,String url,String userName,
                          String password,String encryptedPassword,
-                         String projectPath,String domain,String... filters) {
-        super(TYPE_NAME, materialName, folder, autoUpdate, filters);
+                         String projectPath,String domain,boolean whitelist,String... filters) {
+        super(TYPE_NAME, materialName, folder, autoUpdate, whitelist, filters);
         this.url = url;
         this.username = userName;
         this.password = password;
@@ -186,6 +186,7 @@ public class CRTfsMaterial extends CRScmMaterial {
     @Override
     public void getErrors(ErrorCollection errors, String parentLocation) {
         String location = this.getLocation(parentLocation);
+        getCommonErrors(errors,location);
         errors.checkMissing(location,"url",url);
         errors.checkMissing(location,"username",username);
         errors.checkMissing(location,"project",project);

--- a/plugin-infra/go-plugin-access/test/com/thoughtworks/go/plugin/access/configrepo/contract/CRPipelineTest.java
+++ b/plugin-infra/go-plugin-access/test/com/thoughtworks/go/plugin/access/configrepo/contract/CRPipelineTest.java
@@ -29,7 +29,7 @@ public class CRPipelineTest extends CRBaseTest<CRPipeline> {
     {
         CRBuildTask rakeTask = CRBuildTask.rake();
         CRJob buildRake = new CRJob("build", rakeTask);
-        veryCustomGit = new CRGitMaterial("gitMaterial1", "dir1", false,true, "gitrepo", "feature12", "externals", "tools");
+        veryCustomGit = new CRGitMaterial("gitMaterial1", "dir1", false,true, "gitrepo", "feature12", false, "externals", "tools");
 
         buildStage = new CRStage("build", buildRake);
         pipe1 = new CRPipeline("pipe1","group1",veryCustomGit,buildStage);
@@ -85,7 +85,7 @@ public class CRPipelineTest extends CRBaseTest<CRPipeline> {
         CRPipeline p = new CRPipeline();
         p.setName("pipe4");
 
-        CRGitMaterial invalidGit = new CRGitMaterial("gitMaterial1", "dir1", false,true, null, "feature12", "externals", "tools");
+        CRGitMaterial invalidGit = new CRGitMaterial("gitMaterial1", "dir1", false,true, null, "feature12",false, "externals", "tools");
         p.addMaterial(invalidGit);
         // plugin may voluntarily set this
         p.setLocation("pipe4.json");

--- a/plugin-infra/go-plugin-access/test/com/thoughtworks/go/plugin/access/configrepo/contract/material/CRGitMaterialTest.java
+++ b/plugin-infra/go-plugin-access/test/com/thoughtworks/go/plugin/access/configrepo/contract/material/CRGitMaterialTest.java
@@ -17,6 +17,8 @@ public class CRGitMaterialTest extends CRBaseTest<CRGitMaterial> {
     private final CRGitMaterial simpleGitBranch;
     private final CRGitMaterial veryCustomGit;
     private final CRGitMaterial invalidNoUrl;
+    private final CRGitMaterial whitelistGit;
+    private final CRGitMaterial invalidBothWhiteListAndIgnore;
 
     public CRGitMaterialTest()
     {
@@ -27,9 +29,12 @@ public class CRGitMaterialTest extends CRBaseTest<CRGitMaterial> {
         simpleGitBranch.setUrl(url2);
         simpleGitBranch.setBranch("develop");
 
-        veryCustomGit = new CRGitMaterial("gitMaterial1","dir1",false,true,url1,"feature12","externals","tools");
+        veryCustomGit = new CRGitMaterial("gitMaterial1","dir1",false,true,url1,"feature12",false,"externals","tools");
+        whitelistGit = new CRGitMaterial("gitMaterial1","dir1",false,true,url1,"feature12",true,"externals","tools");
 
-        invalidNoUrl = new CRGitMaterial("gitMaterial1","dir1",false,true,null,"feature12","externals","tools");
+        invalidNoUrl = new CRGitMaterial("gitMaterial1","dir1",false,true,null,"feature12",false,"externals","tools");
+        invalidBothWhiteListAndIgnore = new CRGitMaterial("gitMaterial1","dir1",false,true,url1,"feature12",false,"externals","tools");
+        invalidBothWhiteListAndIgnore.setWhitelistNoCheck("src","tests");
     }
 
     @Override
@@ -37,13 +42,14 @@ public class CRGitMaterialTest extends CRBaseTest<CRGitMaterial> {
         examples.put("simpleGit",simpleGit);
         examples.put("simpleGitBranch",simpleGitBranch);
         examples.put("veryCustomGit",veryCustomGit);
+        examples.put("whitelistGit",whitelistGit);
     }
 
     @Override
     public void addBadExamples(Map<String, CRGitMaterial> examples) {
         examples.put("invalidNoUrl",invalidNoUrl);
+        examples.put("invalidBothWhiteListAndIgnore",invalidBothWhiteListAndIgnore);
     }
-
 
     @Test
     public void shouldAppendTypeFieldWhenSerializingMaterials()

--- a/plugin-infra/go-plugin-access/test/com/thoughtworks/go/plugin/access/configrepo/contract/material/CRHgMaterialTest.java
+++ b/plugin-infra/go-plugin-access/test/com/thoughtworks/go/plugin/access/configrepo/contract/material/CRHgMaterialTest.java
@@ -14,15 +14,18 @@ public class CRHgMaterialTest extends CRBaseTest<CRHgMaterial> {
     private final CRHgMaterial simpleHg;
     private final CRHgMaterial customHg;
     private final CRHgMaterial invalidHgNoUrl;
+    private final CRHgMaterial invalidHgWhitelistAndIgnores;
 
     public CRHgMaterialTest()
     {
         simpleHg = new CRHgMaterial();
         simpleHg.setUrl("myHgRepo");
 
-        customHg = new CRHgMaterial("hgMaterial1","dir1",false,"repos/myhg","externals","tools");
+        customHg = new CRHgMaterial("hgMaterial1","dir1",false,"repos/myhg",false,"externals","tools");
 
         invalidHgNoUrl = new CRHgMaterial();
+        invalidHgWhitelistAndIgnores = new CRHgMaterial("hgMaterial1","dir1",false,"repos/myhg",false,"externals","tools");
+        invalidHgWhitelistAndIgnores.setWhitelistNoCheck("src","tests");
     }
 
     @Override
@@ -34,6 +37,7 @@ public class CRHgMaterialTest extends CRBaseTest<CRHgMaterial> {
     @Override
     public void addBadExamples(Map<String, CRHgMaterial> examples) {
         examples.put("invalidHgNoUrl",invalidHgNoUrl);
+        examples.put("invalidHgWhitelistAndIgnores",invalidHgWhitelistAndIgnores);
     }
 
     @Test

--- a/plugin-infra/go-plugin-access/test/com/thoughtworks/go/plugin/access/configrepo/contract/material/CRP4MaterialTest.java
+++ b/plugin-infra/go-plugin-access/test/com/thoughtworks/go/plugin/access/configrepo/contract/material/CRP4MaterialTest.java
@@ -25,7 +25,7 @@ public class CRP4MaterialTest extends CRBaseTest<CRP4Material> {
         p4simple = new CRP4Material("10.18.3.102:1666",exampleView);
 
         p4custom= new CRP4Material(
-                "p4materialName", "dir1", false,"10.18.3.102:1666",exampleView,"user1","pass1", false,"lib","tools");
+                "p4materialName", "dir1", false,"10.18.3.102:1666",exampleView,"user1","pass1", false,false,"lib","tools");
 
         invalidP4NoView = new CRP4Material("10.18.3.102:1666",null);
         invalidP4NoServer =  new CRP4Material(null,exampleView);

--- a/plugin-infra/go-plugin-access/test/com/thoughtworks/go/plugin/access/configrepo/contract/material/CRSvnMaterialTest.java
+++ b/plugin-infra/go-plugin-access/test/com/thoughtworks/go/plugin/access/configrepo/contract/material/CRSvnMaterialTest.java
@@ -28,7 +28,7 @@ public class CRSvnMaterialTest extends CRBaseTest<CRSvnMaterial> {
         simpleSvnAuth.setPassword("pa$sw0rd");
 
         customSvn = new CRSvnMaterial("svnMaterial1","destDir1", false,
-                "http://svn","user1","pass1",true,"tools","lib");
+                "http://svn","user1","pass1",true,false,"tools","lib");
 
         invalidNoUrl = new CRSvnMaterial();
         invalidPasswordAndEncyptedPasswordSet = new CRSvnMaterial();

--- a/plugin-infra/go-plugin-access/test/com/thoughtworks/go/plugin/access/configrepo/contract/material/CRTfsMaterialTest.java
+++ b/plugin-infra/go-plugin-access/test/com/thoughtworks/go/plugin/access/configrepo/contract/material/CRTfsMaterialTest.java
@@ -23,7 +23,7 @@ public class CRTfsMaterialTest extends CRBaseTest<CRTfsMaterial> {
         simpleTfs = new CRTfsMaterial("url1","user1","projectDir");
 
         customTfs = new CRTfsMaterial("tfsMaterialName", "dir1", false,"url3","user4",
-            "pass",null,"projectDir","example.com","tools","externals");
+            "pass",null,"projectDir","example.com",false,"tools","externals");
 
         invalidTfsNoUrl = new CRTfsMaterial(null,"user1","projectDir");
         invalidTfsNoUser = new CRTfsMaterial("url1",null,"projectDir");

--- a/server/src/com/thoughtworks/go/config/ConfigConverter.java
+++ b/server/src/com/thoughtworks/go/config/ConfigConverter.java
@@ -283,7 +283,7 @@ public class ConfigConverter {
 
         return new PluggableSCMMaterialConfig(toMaterialName(crPluggableScmMaterial.getName()),
                 scmConfig, crPluggableScmMaterial.getDirectory(),
-                toFilter(crPluggableScmMaterial.getFilterIgnores()));
+                toFilter(crPluggableScmMaterial.getFilterList()));
     }
 
     private SCMs getSCMs() {
@@ -298,9 +298,10 @@ public class ConfigConverter {
             String gitBranch = git.getBranch();
             if (StringUtils.isBlank(gitBranch))
                 gitBranch = GitMaterialConfig.DEFAULT_BRANCH;
-            return new GitMaterialConfig(new UrlArgument(git.getUrl()), gitBranch,
-                    null, git.isAutoUpdate(), filter, false, crScmMaterial.getDirectory(),
-                    toMaterialName(materialName), git.shallowClone());
+            GitMaterialConfig gitConfig = new GitMaterialConfig(git.getUrl(), gitBranch, git.shallowClone());
+            setCommonMaterialMembers(gitConfig, crScmMaterial);
+            setCommonScmMaterialMembers(gitConfig, git);
+            return gitConfig;
         } else if (crScmMaterial instanceof CRHgMaterial) {
             CRHgMaterial hg = (CRHgMaterial) crScmMaterial;
             return new HgMaterialConfig(new HgUrlArgument(hg.getUrl()),
@@ -361,10 +362,11 @@ public class ConfigConverter {
         scmMaterialConfig.setFolder(crScmMaterial.getDirectory());
         scmMaterialConfig.setAutoUpdate(crScmMaterial.isAutoUpdate());
         scmMaterialConfig.setFilter(toFilter(crScmMaterial));
+        scmMaterialConfig.setInvertFilter(crScmMaterial.isWhitelist());
     }
 
     private Filter toFilter(CRScmMaterial crScmMaterial) {
-        List<String> filterList = crScmMaterial.getFilterIgnores();
+        List<String> filterList = crScmMaterial.getFilterList();
         return toFilter(filterList);
     }
 

--- a/server/test/unit/com/thoughtworks/go/config/ConfigConverterTest.java
+++ b/server/test/unit/com/thoughtworks/go/config/ConfigConverterTest.java
@@ -107,7 +107,7 @@ public class ConfigConverterTest {
         crStage = new CRStage("stageName",true,true,true, approval,environmentVariables,jobs);
         stages.add(crStage);
 
-        git = new CRGitMaterial("name", "folder", true,true, filter, "url", "branch");
+        git = new CRGitMaterial("name", "folder", true,true, filter, "url", "branch",false);
         materials.add(git);
 
         trackingTool = new CRTrackingTool("link","regex");
@@ -294,7 +294,7 @@ public class ConfigConverterTest {
 
     @Test
     public void shouldConvertGitMaterial() {
-        CRGitMaterial crGitMaterial = new CRGitMaterial("name", "folder", true,true, filter, "url", "branch");
+        CRGitMaterial crGitMaterial = new CRGitMaterial("name", "folder", true,true, filter, "url", "branch",false);
 
         GitMaterialConfig gitMaterialConfig =
                 (GitMaterialConfig) configConverter.toMaterialConfig(crGitMaterial);
@@ -302,10 +302,28 @@ public class ConfigConverterTest {
         assertThat(gitMaterialConfig.getName().toLower(), is("name"));
         assertThat(gitMaterialConfig.getFolder(), is("folder"));
         assertThat(gitMaterialConfig.getAutoUpdate(), is(true));
+        assertThat(gitMaterialConfig.isInvertFilter(), is(false));
         assertThat(gitMaterialConfig.getFilterAsString(), is("filter"));
         assertThat(gitMaterialConfig.getUrl(), is("url"));
         assertThat(gitMaterialConfig.getBranch(), is("branch"));
     }
+
+    @Test
+    public void shouldConvertGitMaterialWhenWhitelist() {
+        CRGitMaterial crGitMaterial = new CRGitMaterial("name", "folder", true,true, filter, "url", "branch",true);
+
+        GitMaterialConfig gitMaterialConfig =
+                (GitMaterialConfig) configConverter.toMaterialConfig(crGitMaterial);
+
+        assertThat(gitMaterialConfig.getName().toLower(), is("name"));
+        assertThat(gitMaterialConfig.getFolder(), is("folder"));
+        assertThat(gitMaterialConfig.getAutoUpdate(), is(true));
+        assertThat(gitMaterialConfig.isInvertFilter(), is(true));
+        assertThat(gitMaterialConfig.getFilterAsString(), is("filter"));
+        assertThat(gitMaterialConfig.getUrl(), is("url"));
+        assertThat(gitMaterialConfig.getBranch(), is("branch"));
+    }
+
     @Test
     public void shouldConvertGitMaterialWhenNulls() {
         CRGitMaterial crGitMaterial = new CRGitMaterial();
@@ -325,7 +343,7 @@ public class ConfigConverterTest {
 
     @Test
     public void shouldConvertHgMaterial() {
-        CRHgMaterial crHgMaterial = new CRHgMaterial("name", "folder", true, filter, "url");
+        CRHgMaterial crHgMaterial = new CRHgMaterial("name", "folder", true, false, filter, "url");
 
         HgMaterialConfig hgMaterialConfig =
                 (HgMaterialConfig) configConverter.toMaterialConfig(crHgMaterial);
@@ -338,7 +356,7 @@ public class ConfigConverterTest {
     }
     @Test
     public void shouldConvertHgMaterialWhenNullName() {
-        CRHgMaterial crHgMaterial = new CRHgMaterial(null, "folder", true, filter, "url");
+        CRHgMaterial crHgMaterial = new CRHgMaterial(null, "folder", true, false, filter, "url");
 
         HgMaterialConfig hgMaterialConfig =
                 (HgMaterialConfig) configConverter.toMaterialConfig(crHgMaterial);
@@ -351,7 +369,7 @@ public class ConfigConverterTest {
     }
     @Test
     public void shouldConvertHgMaterialWhenEmptyName() {
-        CRHgMaterial crHgMaterial = new CRHgMaterial("", "folder", true, filter, "url");
+        CRHgMaterial crHgMaterial = new CRHgMaterial("", "folder", true, false, filter, "url");
 
         HgMaterialConfig hgMaterialConfig =
                 (HgMaterialConfig) configConverter.toMaterialConfig(crHgMaterial);
@@ -367,7 +385,7 @@ public class ConfigConverterTest {
     public void shouldConvertP4MaterialWhenEncryptedPassword()
     {
         CRP4Material crp4Material = CRP4Material.withEncryptedPassword(
-                "name","folder",false,filter,"server:port","user","encryptedvalue",true,"view");
+                "name","folder",false,false, filter,"server:port","user","encryptedvalue",true,"view");
 
         P4MaterialConfig p4MaterialConfig =
                 (P4MaterialConfig)configConverter.toMaterialConfig(crp4Material);
@@ -388,7 +406,7 @@ public class ConfigConverterTest {
     public void shouldConvertP4MaterialWhenPlainPassword()
     {
         CRP4Material crp4Material = CRP4Material.withPlainPassword(
-                "name", "folder", false, filter, "server:port", "user", "secret", true, "view");
+                "name", "folder", false, false, filter, "server:port", "user", "secret", true, "view");
 
         P4MaterialConfig p4MaterialConfig =
                 (P4MaterialConfig)configConverter.toMaterialConfig(crp4Material);
@@ -408,7 +426,7 @@ public class ConfigConverterTest {
     @Test
     public void shouldConvertSvmMaterialWhenEncryptedPassword()
     {
-        CRSvnMaterial crSvnMaterial = CRSvnMaterial.withEncryptedPassword("name", "folder", true, filter, "url", "username", "encryptedvalue", true);
+        CRSvnMaterial crSvnMaterial = CRSvnMaterial.withEncryptedPassword("name", "folder", true, false, filter, "url", "username", "encryptedvalue", true);
 
         SvnMaterialConfig svnMaterialConfig =
                 (SvnMaterialConfig)configConverter.toMaterialConfig(crSvnMaterial);
@@ -426,7 +444,7 @@ public class ConfigConverterTest {
     @Test
     public void shouldConvertSvmMaterialWhenPlainPassword()
     {
-        CRSvnMaterial crSvnMaterial = new CRSvnMaterial("name","folder",true,filter,"url","username","secret",true);
+        CRSvnMaterial crSvnMaterial = new CRSvnMaterial("name","folder",true,false, filter,"url","username","secret",true);
 
         SvnMaterialConfig svnMaterialConfig =
                 (SvnMaterialConfig)configConverter.toMaterialConfig(crSvnMaterial);
@@ -445,7 +463,7 @@ public class ConfigConverterTest {
     public void shouldConvertTfsMaterialWhenPlainPassword()
     {
         CRTfsMaterial crTfsMaterial = CRTfsMaterial.withPlainPassword(
-                "name", "folder", false, filter, "url", "domain" ,"user", "secret", "project");
+                "name", "folder", false, false, filter, "url", "domain" ,"user", "secret", "project");
 
         TfsMaterialConfig tfsMaterialConfig =
                 (TfsMaterialConfig)configConverter.toMaterialConfig(crTfsMaterial);
@@ -465,7 +483,7 @@ public class ConfigConverterTest {
     public void shouldConvertTfsMaterialWhenEncryptedPassword()
     {
         CRTfsMaterial crTfsMaterial = CRTfsMaterial.withEncryptedPassword(
-                "name", "folder", false, filter, "url", "domain", "user", "encryptedvalue", "project");
+                "name", "folder", false, false, filter, "url", "domain", "user", "encryptedvalue", "project");
 
         TfsMaterialConfig tfsMaterialConfig =
                 (TfsMaterialConfig)configConverter.toMaterialConfig(crTfsMaterial);


### PR DESCRIPTION
Until now, config-repo extension point accepted only
```json
"filter": {
    "ignore": [
      "externals",
      "tools"
    ]
  }
```
Now it can also accepts filters with whitelist:
```json
"filter": {
    "whitelist": [
      "src",
      "tests"
    ]
  }
```

 * Added a few tests to cover git case fully. 
 * Also if user specifies both non-empty `ignore` and `whitelist` then it is considered as error in config repo.