### PR TITLE
#1133 fix server-side checkout destination in config repos

### DIFF
--- a/common/src/com/thoughtworks/go/config/materials/git/GitMaterial.java
+++ b/common/src/com/thoughtworks/go/config/materials/git/GitMaterial.java
@@ -148,7 +148,8 @@ public class GitMaterial extends ScmMaterial {
         Revision revision = revisionContext.getLatestRevision();
         try {
             outputStreamConsumer.stdOutput(format("[%s] Start updating %s at revision %s from %s", GoConstants.PRODUCT_NAME, updatingTarget(), revision.getRevision(), url));
-            GitCommand git = git(outputStreamConsumer, workingdir(baseDir), revisionContext.numberOfModifications() + 1, execCtx);
+            File workingDir = execCtx.isServer() ? baseDir : workingdir(baseDir);
+            GitCommand git = git(outputStreamConsumer, workingDir, revisionContext.numberOfModifications() + 1, execCtx);
             git.fetch(outputStreamConsumer);
             unshallowIfNeeded(git, outputStreamConsumer, revisionContext.getOldestRevision(), baseDir);
             git.resetWorkingDir(outputStreamConsumer, revision);

--- a/common/src/com/thoughtworks/go/config/materials/mercurial/HgMaterial.java
+++ b/common/src/com/thoughtworks/go/config/materials/mercurial/HgMaterial.java
@@ -125,7 +125,8 @@ public class HgMaterial extends ScmMaterial {
         Revision revision = revisionContext.getLatestRevision();
         try {
             outputStreamConsumer.stdOutput(format("[%s] Start updating %s at revision %s from %s", GoConstants.PRODUCT_NAME, updatingTarget(), revision.getRevision(), url.forDisplay()));
-            hg(workingdir(baseDir), outputStreamConsumer).updateTo(revision, outputStreamConsumer);
+            File workingDir = execCtx.isServer() ? baseDir : workingdir(baseDir);
+            hg(workingDir, outputStreamConsumer).updateTo(revision, outputStreamConsumer);
             outputStreamConsumer.stdOutput(format("[%s] Done.\n", GoConstants.PRODUCT_NAME));
         } catch (Exception e) {
             bomb(e);

--- a/common/src/com/thoughtworks/go/config/materials/svn/SvnMaterial.java
+++ b/common/src/com/thoughtworks/go/config/materials/svn/SvnMaterial.java
@@ -138,7 +138,7 @@ public class SvnMaterial extends ScmMaterial implements PasswordEncrypter, Passw
 
     public void updateTo(ProcessOutputStreamConsumer outputStreamConsumer, File baseDir, RevisionContext revisionContext, final SubprocessExecutionContext execCtx) {
         Revision revision = revisionContext.getLatestRevision();
-        File workingDir = workingdir(baseDir);
+        File workingDir = execCtx.isServer() ? baseDir : workingdir(baseDir);
         if (LOGGER.isDebugEnabled()) {
             LOGGER.debug("Updating to revision: " + revision + " in workingdirectory " + workingDir);
         }

--- a/common/src/com/thoughtworks/go/config/materials/tfs/TfsMaterial.java
+++ b/common/src/com/thoughtworks/go/config/materials/tfs/TfsMaterial.java
@@ -148,7 +148,7 @@ public class TfsMaterial extends ScmMaterial implements PasswordAwareMaterial, P
 
     public void updateTo(ProcessOutputStreamConsumer outputStreamConsumer, File baseDir, RevisionContext revisionContext, final SubprocessExecutionContext execCtx) {
         Revision revision = revisionContext.getLatestRevision();
-        File workingDir = workingdir(baseDir);
+        File workingDir = execCtx.isServer() ? baseDir : workingdir(baseDir);
         if (LOGGER.isDebugEnabled()) {
             LOGGER.debug("[TFS] Updating to revision: " + revision + " in workingdirectory " + workingDir);
         }

--- a/common/test/unit/com/thoughtworks/go/config/materials/hg/HgMultipleMaterialsTest.java
+++ b/common/test/unit/com/thoughtworks/go/config/materials/hg/HgMultipleMaterialsTest.java
@@ -75,6 +75,18 @@ public class HgMultipleMaterialsTest {
     }
 
     @Test
+    public void shouldIgnoreDestinationFolderWhenServerSide() throws Exception {
+        HgMaterial material1 = repo.createMaterial("dest1");
+
+        MaterialRevision materialRevision = new MaterialRevision(material1, material1.latestModification(pipelineDir, new TestSubprocessExecutionContext()));
+
+        materialRevision.updateTo(pipelineDir, ProcessOutputStreamConsumer.inMemoryConsumer(), new TestSubprocessExecutionContext(true));
+
+        assertThat(new File(pipelineDir, "dest1").exists(), is(false));
+        assertThat(new File(pipelineDir, ".hg").exists(), is(true));
+    }
+
+    @Test
     public void shouldFindModificationsForBothMaterials() throws Exception {
         Materials materials = new Materials(repo.createMaterial("dest1"), repo.createMaterial("dest2"));
         repo.commitAndPushFile("SomeDocumentation.txt");

--- a/common/test/unit/com/thoughtworks/go/config/materials/perforce/P4MultipleMaterialsTest.java
+++ b/common/test/unit/com/thoughtworks/go/config/materials/perforce/P4MultipleMaterialsTest.java
@@ -88,6 +88,18 @@ public class P4MultipleMaterialsTest {
     }
 
     @Test
+    public void shouldIgnoreDestinationFolderWhenUpdateToOnServerSide() {
+        P4Material p4Material = p4Fixture.material(VIEW_SRC, "dest1");
+
+        MaterialRevision revision = new MaterialRevision(p4Material, p4Material.latestModification(clientFolder, new TestSubprocessExecutionContext()));
+
+        revision.updateTo(clientFolder, inMemoryConsumer(), new TestSubprocessExecutionContext(true));
+
+        assertThat(new File(clientFolder, "dest1/net").exists(), is(false));
+        assertThat(new File(clientFolder, "net").exists(), is(true));
+    }
+
+    @Test
     public void shouldFoundModificationsForEachMaterial() throws Exception {
         P4Material p4Material1 = p4Fixture.material(VIEW_SRC, "src");
         P4Material p4Material2 = p4Fixture.material(VIEW_LIB, "lib");

--- a/common/test/unit/com/thoughtworks/go/config/materials/svn/SvnMultipleMaterialsTest.java
+++ b/common/test/unit/com/thoughtworks/go/config/materials/svn/SvnMultipleMaterialsTest.java
@@ -217,6 +217,15 @@ public class SvnMultipleMaterialsTest {
         assertThat(new File(pipelineDir, "part1").exists(), is(true));
     }
 
+    @Test
+    public void shouldIgnoreDestinationFolderWhenServerSide() throws Exception {
+        SvnMaterial material1 = repo.createMaterial("multiple-materials/trunk/part1", "part1");
+
+        MaterialRevision materialRevision = new MaterialRevision(material1, material1.latestModification(pipelineDir, new TestSubprocessExecutionContext()));
+        materialRevision.updateTo(pipelineDir, ProcessOutputStreamConsumer.inMemoryConsumer(), new TestSubprocessExecutionContext(true));
+
+        assertThat(new File(pipelineDir, "part1").exists(), is(false));
+    }
 
     @Test
     public void shouldFindModificationForEachMaterial() throws Exception {

--- a/common/test/unit/com/thoughtworks/go/domain/materials/git/GitMultipleMaterialsTest.java
+++ b/common/test/unit/com/thoughtworks/go/domain/materials/git/GitMultipleMaterialsTest.java
@@ -71,6 +71,18 @@ public class GitMultipleMaterialsTest {
     }
 
     @Test
+    public void shouldIgnoreDestinationFolderWhenCloningMaterialWhenServerSide() throws Exception {
+        GitMaterial material1 = repo.createMaterial("dest1");
+
+        MaterialRevision materialRevision = new MaterialRevision(material1, material1.latestModification(pipelineDir, new TestSubprocessExecutionContext()));
+
+        materialRevision.updateTo(pipelineDir, ProcessOutputStreamConsumer.inMemoryConsumer(), new TestSubprocessExecutionContext(true));
+
+        assertThat(new File(pipelineDir, "dest1").exists(), is(false));
+        assertThat(new File(pipelineDir, ".git").exists(), is(true));
+    }
+
+    @Test
     public void shouldFindModificationsForBothMaterials() throws Exception {
         Materials materials = new Materials(repo.createMaterial("dest1"), repo.createMaterial("dest2"));
 

--- a/server/src/com/thoughtworks/go/server/materials/ConfigMaterialUpdater.java
+++ b/server/src/com/thoughtworks/go/server/materials/ConfigMaterialUpdater.java
@@ -111,7 +111,7 @@ public class ConfigMaterialUpdater implements GoMessageListener<MaterialUpdateCo
 
     private void updateConfigurationFromCheckout(File folder, Revision revision, Material material) {
         MaterialPoller poller = this.materialService.getPollerImplementation(material);
-        poller.checkout(material,folder,revision,this.subprocessExecutionContext);
+        poller.checkout(material,folder, revision,this.subprocessExecutionContext);
         this.repoConfigDataSource.onCheckoutComplete(material.config(),folder, revision.getRevision());
     }
 

--- a/server/src/com/thoughtworks/go/server/service/materials/HgPoller.java
+++ b/server/src/com/thoughtworks/go/server/service/materials/HgPoller.java
@@ -38,6 +38,6 @@ public class HgPoller implements MaterialPoller<HgMaterial> {
 
     @Override
     public void checkout(HgMaterial material, File baseDir, Revision revision, SubprocessExecutionContext execCtx) {
-        material.checkout(baseDir,revision, execCtx);
+        material.checkout(baseDir, revision, execCtx);
     }
 }

--- a/server/src/com/thoughtworks/go/server/service/materials/MaterialPoller.java
+++ b/server/src/com/thoughtworks/go/server/service/materials/MaterialPoller.java
@@ -30,6 +30,9 @@ public interface MaterialPoller<T extends Material> {
 
     List<Modification> modificationsSince(T material, File baseDir, Revision revision, final SubprocessExecutionContext execCtx);
 
+    /**
+     * Performs a server-side checkout of this material. Ignores destination directory, always checkouts directly to flyweight folder.
+     */
     void checkout(T material, File baseDir, Revision revision, final SubprocessExecutionContext execCtx);
 }
 

--- a/server/src/com/thoughtworks/go/server/service/materials/P4Poller.java
+++ b/server/src/com/thoughtworks/go/server/service/materials/P4Poller.java
@@ -38,6 +38,6 @@ public class P4Poller implements MaterialPoller<P4Material> {
 
     @Override
     public void checkout(P4Material material, File baseDir, Revision revision, SubprocessExecutionContext execCtx) {
-        material.checkout(baseDir,revision, execCtx);
+        material.checkout(baseDir, revision, execCtx);
     }
 }

--- a/server/src/com/thoughtworks/go/server/service/materials/SvnPoller.java
+++ b/server/src/com/thoughtworks/go/server/service/materials/SvnPoller.java
@@ -38,6 +38,6 @@ public class SvnPoller implements MaterialPoller<SvnMaterial> {
 
     @Override
     public void checkout(SvnMaterial material, File baseDir, Revision revision, SubprocessExecutionContext execCtx) {
-        material.checkout(baseDir,revision, execCtx);
+        material.checkout(baseDir, revision, execCtx);
     }
 }

--- a/server/src/com/thoughtworks/go/server/service/materials/TfsPoller.java
+++ b/server/src/com/thoughtworks/go/server/service/materials/TfsPoller.java
@@ -38,6 +38,6 @@ public class TfsPoller implements MaterialPoller<TfsMaterial> {
 
     @Override
     public void checkout(TfsMaterial material, File baseDir, Revision revision, SubprocessExecutionContext execCtx) {
-        material.checkout(baseDir,revision, execCtx);
+        material.checkout(baseDir, revision, execCtx);
     }
 }


### PR DESCRIPTION
This is a critical bug fix for config repos in cases when many scm materials are used in a pipeline.

## What's broken

In case when we have a pipeline with 2+ scm materials, eg.
```json
  "materials" : [
    {
      "type" : "git",
      "name" : "git1",
      "destination" : "dest1",
      "url"  : "repo1.git"
    },
    {
      "type" : "git",
      "name" : "git2",
      "destination" : "dest2",
      "url"  : "url2"
    }
  ]
```
And one of above materials is also a config repo. Let's assume it's `git1` repository. 

Then expected behaviour is to have `git1` repository checkout **in flyweight directory**. Meaning something like 
```
/var/lib/go-server/pipelines/flyweight/3bdb04b2-44d0-4c15-9a5e-4159ffcec626
```
and **NOT in**
```
/var/lib/go-server/pipelines/flyweight/3bdb04b2-44d0-4c15-9a5e-4159ffcec626/dest1
```
I have observed checkouts done in both folders above on my prod server.

## Cause

As part of work on #1133 I added this `checkout` method on `MaterialPoller` interface
```
void checkout(T material, File baseDir, Revision revision, final SubprocessExecutionContext execCtx);
```
which internally calls `updateTo` in particular material implementations. The problem is that `updateTo`  was designed to be used on agents, so it performs checkout to `flyweight/destination` directory when `destination` is specified.

## Changes

I have added extra parameter `ignoreDestination` to `updateTo` method and few tests to assert that final directory is correct.
Then`MaterialPoller.checkout` is calling `updateTo` with `ignoreDestination=true`