### PR TITLE
Remove empty javascript tag.

### DIFF
--- a/server/webapp/WEB-INF/rails.new/app/views/shared/_pipeline.html.erb
+++ b/server/webapp/WEB-INF/rails.new/app/views/shared/_pipeline.html.erb
@@ -58,8 +58,6 @@
                         <%= link_to(l.string("CHANGES"), build_cause_path(:pipeline_name => active_pipeline_in_pipeline.getName(), :pipeline_counter => active_pipeline_in_pipeline.getCounter()), :id => scope[:show_changes_id], :class => "show_panel submit_small dashboard_build_cause_button") -%>
                     </span>
 
-                    <script type="text/javascript">
-                    </script>
                 <% end -%>
                 <%= render :partial=> 'pipelines/pipeline_instance_details.html', :locals => {:scope =>{:active_pipeline_in_pipeline => active_pipeline_in_pipeline}} %>
             </div>


### PR DESCRIPTION
Hi there,

We are suffering performance issues when gocd is repainting all the pipelines on: /go/pipelines
One of the reasons for this is the number of pipelines we have which is about ~700 (give or take).  

- The number of elements on the page is huge:
-- document.getElementsByTagName("*").length : 46647

However, we noticed the number of script elements is also very large:
-- document.getElementsByTagName("script").length : 695


Looking through it, there's this empty javascript element.  Is there any reason for this?  Can we remove it?

thanks
/dom

