### PR TITLE
Fix MDU for PluggableMaterials

### DIFF
--- a/config/config-api/src/com/thoughtworks/go/config/pluggabletask/PluggableTask.java
+++ b/config/config-api/src/com/thoughtworks/go/config/pluggabletask/PluggableTask.java
@@ -47,7 +47,6 @@ public class PluggableTask extends AbstractTask {
     public static final String TYPE = "pluggable_task";
     public static final String VALUE_KEY = "value";
     public static final String ERRORS_KEY = "errors";
-    private ConfigurationPropertyBuilder builder;
 
     @ConfigSubtag
     private PluginConfiguration pluginConfiguration = new PluginConfiguration();
@@ -56,19 +55,11 @@ public class PluggableTask extends AbstractTask {
     private Configuration configuration = new Configuration();
 
     public PluggableTask() {
-        this.builder = new ConfigurationPropertyBuilder();
     }
 
     public PluggableTask(PluginConfiguration pluginConfiguration, Configuration configuration) {
-        this();
         this.pluginConfiguration = pluginConfiguration;
         this.configuration = configuration;
-    }
-
-    //For Tests Only
-    protected PluggableTask(PluginConfiguration pluginConfiguration, Configuration configuration, ConfigurationPropertyBuilder builder) {
-        this(pluginConfiguration, configuration);
-        this.builder = builder;
     }
 
     public PluginConfiguration getPluginConfiguration() {
@@ -116,6 +107,7 @@ public class PluggableTask extends AbstractTask {
     }
 
     public void addConfigurations(List<ConfigurationProperty> configurations) {
+        ConfigurationPropertyBuilder builder = new ConfigurationPropertyBuilder();
         for (ConfigurationProperty property : configurations) {
             String configKey = property.getConfigurationKey() != null ? property.getConfigKeyName() : null;
             String encryptedValue = property.getEncryptedValue() != null ? property.getEncryptedValue().getValue() : null;
@@ -123,7 +115,7 @@ public class PluggableTask extends AbstractTask {
 
         TaskPreference taskPreference = taskPreference();
             if(isValidPluginConfiguration(configKey, taskPreference)) {
-                configuration.add(this.builder.create(configKey, configValue, encryptedValue, pluginConfigurationFor(configKey, taskPreference).getOption(Property.SECURE)));
+                configuration.add(builder.create(configKey, configValue, encryptedValue, pluginConfigurationFor(configKey, taskPreference).getOption(Property.SECURE)));
             } else
             {
                 configuration.add(property);

--- a/config/config-api/src/com/thoughtworks/go/domain/scm/SCM.java
+++ b/config/config-api/src/com/thoughtworks/go/domain/scm/SCM.java
@@ -57,7 +57,6 @@ public class SCM implements Serializable, Validatable {
     public static final String ERRORS_KEY = "errors";
 
     private ConfigErrors errors = new ConfigErrors();
-    private ConfigurationPropertyBuilder builder;
 
     @ConfigAttribute(value = "id", allowNull = true)
     private String id;
@@ -79,7 +78,6 @@ public class SCM implements Serializable, Validatable {
     private Configuration configuration = new Configuration();
 
     public SCM() {
-        this.builder = new ConfigurationPropertyBuilder();
     }
 
     public SCM(String id, PluginConfiguration pluginConfiguration, Configuration configuration) {
@@ -135,6 +133,7 @@ public class SCM implements Serializable, Validatable {
     }
 
     public void addConfigurations(List<ConfigurationProperty> configurations) {
+        ConfigurationPropertyBuilder builder = new ConfigurationPropertyBuilder();
         for (ConfigurationProperty property : configurations) {
             String configKey = property.getConfigurationKey() != null ? property.getConfigKeyName() : null;
             String encryptedValue = property.getEncryptedValue() != null ? property.getEncryptedValue().getValue() : null;
@@ -142,7 +141,7 @@ public class SCM implements Serializable, Validatable {
 
             SCMConfigurations scmConfigurations = SCMMetadataStore.getInstance().getConfigurationMetadata(getPluginId());
             if (isValidPluginConfiguration(configKey, scmConfigurations)) {
-                configuration.add(this.builder.create(configKey, configValue, encryptedValue, scmConfigurationFor(configKey, scmConfigurations).getOption(SCMConfiguration.SECURE)));
+                configuration.add(builder.create(configKey, configValue, encryptedValue, scmConfigurationFor(configKey, scmConfigurations).getOption(SCMConfiguration.SECURE)));
             }
             else {
                 configuration.add(property);

--- a/config/config-api/test/com/thoughtworks/go/config/pluggabletask/PluggableTaskTest.java
+++ b/config/config-api/test/com/thoughtworks/go/config/pluggabletask/PluggableTaskTest.java
@@ -18,16 +18,17 @@ package com.thoughtworks.go.config.pluggabletask;
 
 import com.thoughtworks.go.config.AntTask;
 import com.thoughtworks.go.config.OnCancelConfig;
-import com.thoughtworks.go.config.ValidationContext;
-import com.thoughtworks.go.config.builder.ConfigurationPropertyBuilder;
 import com.thoughtworks.go.domain.TaskProperty;
-import com.thoughtworks.go.domain.config.*;
+import com.thoughtworks.go.domain.config.Configuration;
+import com.thoughtworks.go.domain.config.ConfigurationKey;
+import com.thoughtworks.go.domain.config.ConfigurationProperty;
+import com.thoughtworks.go.domain.config.ConfigurationValue;
+import com.thoughtworks.go.domain.config.EncryptedConfigurationValue;
+import com.thoughtworks.go.domain.config.PluginConfiguration;
 import com.thoughtworks.go.domain.packagerepository.ConfigurationPropertyMother;
 import com.thoughtworks.go.plugin.access.pluggabletask.PluggableTaskConfigStore;
 import com.thoughtworks.go.plugin.access.pluggabletask.TaskPreference;
-import com.thoughtworks.go.plugin.api.config.Option;
 import com.thoughtworks.go.plugin.api.config.Property;
-import com.thoughtworks.go.plugin.api.response.validation.ValidationResult;
 import com.thoughtworks.go.plugin.api.task.Task;
 import com.thoughtworks.go.plugin.api.task.TaskConfig;
 import com.thoughtworks.go.plugin.api.task.TaskConfigProperty;
@@ -43,7 +44,9 @@ import java.util.Map;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -294,7 +297,6 @@ public class PluggableTaskTest {
         TaskPreference taskPreference = mock(TaskPreference.class);
         TaskConfig taskConfig = new TaskConfig();
         Configuration configuration = new Configuration();
-        ConfigurationPropertyBuilder builder = mock(ConfigurationPropertyBuilder.class);
         Property property = new Property("key");
         property.with(Property.SECURE, false);
 
@@ -303,11 +305,10 @@ public class PluggableTaskTest {
 
         when(taskPreference.getConfig()).thenReturn(taskConfig);
 
-        PluggableTask pluggableTask = new PluggableTask(pluginConfiguration, configuration, builder);
+        PluggableTask pluggableTask = new PluggableTask(pluginConfiguration, configuration);
         pluggableTask.addConfigurations(configurationProperties);
 
         assertThat(configuration.size(), is(2));
-        verify(builder).create("key", "value", "encValue", false);
     }
 
     @Test
@@ -316,9 +317,8 @@ public class PluggableTaskTest {
         PluginConfiguration pluginConfiguration = new PluginConfiguration("does_not_exist", "1.1");
 
         Configuration configuration = new Configuration();
-        ConfigurationPropertyBuilder builder = mock(ConfigurationPropertyBuilder.class);
 
-        PluggableTask pluggableTask = new PluggableTask(pluginConfiguration, configuration, builder);
+        PluggableTask pluggableTask = new PluggableTask(pluginConfiguration, configuration);
         pluggableTask.addConfigurations(configurationProperties);
 
         assertThat(configuration.size(), is(1));


### PR DESCRIPTION
* MDU is broken because of having state of non-serializable ConfigurationPropertyBuilder
 in SCM and PluggableTask