### PR TITLE
Pluggable tasks secure configurations are encrypted before saving in …

### DIFF
--- a/common/test/unit/com/thoughtworks/go/domain/config/ConfigurationPropertyTest.java
+++ b/common/test/unit/com/thoughtworks/go/domain/config/ConfigurationPropertyTest.java
@@ -81,7 +81,7 @@ public class ConfigurationPropertyTest {
                 goCipher);
         property.handleSecureValueConfiguration(true);
         assertThat(property.isSecure(), is(true));
-        assertThat(property.getEncryptedValue().getValue(), is(encryptedText));
+        assertThat(property.getEncryptedValue(), is(encryptedText));
         assertThat(property.getConfigurationKey().getName(), is("secureKey"));
         assertThat(property.getConfigurationValue(), is(nullValue()));
     }
@@ -94,7 +94,7 @@ public class ConfigurationPropertyTest {
         assertThat(property.isSecure(), is(false));
         assertThat(property.getConfigurationKey().getName(), is("secureKey"));
         assertThat(property.getConfigurationValue().getValue(), is("secureValue"));
-        assertThat(property.getEncryptedValue(), is(nullValue()));
+        assertThat(property.getEncryptedConfigurationValue(), is(nullValue()));
     }
 
     @Test
@@ -105,8 +105,8 @@ public class ConfigurationPropertyTest {
         assertThat(property.isSecure(), is(true));
         assertThat(property.getConfigurationKey().getName(), is("secureKey"));
         assertThat(property.getConfigurationValue(), is(nullValue()));
-        assertThat(property.getEncryptedValue(), is(notNullValue()));
-        assertThat(property.getEncryptedValue().getValue(), is("secureValue"));
+        assertThat(property.getEncryptedConfigurationValue(), is(notNullValue()));
+        assertThat(property.getEncryptedValue(), is("secureValue"));
     }
 
     @Test
@@ -114,7 +114,7 @@ public class ConfigurationPropertyTest {
         GoCipher goCipher = mock(GoCipher.class);
         ConfigurationProperty property = new ConfigurationProperty(new ConfigurationKey("secureKey"), new ConfigurationValue(""), new EncryptedConfigurationValue("old"), goCipher);
         property.handleSecureValueConfiguration(true);
-        assertThat(property.getEncryptedValue().getValue(), is(""));
+        assertThat(property.getEncryptedValue(), is(""));
         verify(cipher, never()).decrypt(anyString());
     }
 
@@ -175,7 +175,7 @@ public class ConfigurationPropertyTest {
         assertThat(configurationProperty.getConfigurationKey().getName(), is("key"));
         assertThat(configurationProperty.getConfigurationValue(), is(notNullValue()));
         assertThat(configurationProperty.getConfigurationValue().getValue(), is(""));
-        assertThat(configurationProperty.getEncryptedValue(), is(nullValue()));
+        assertThat(configurationProperty.getEncryptedConfigurationValue(), is(nullValue()));
         Method initializeMethod = ReflectionUtils.findMethod(ConfigurationProperty.class, "initialize");
         assertThat(initializeMethod.getAnnotation(PostConstruct.class), is(notNullValue()));
     }
@@ -204,7 +204,7 @@ public class ConfigurationPropertyTest {
 
         assertThat(configurationProperty.getConfigurationKey().getName(), is(secureKey));
         assertThat(configurationProperty.getConfigurationValue(), is(nullValue()));
-        assertThat(configurationProperty.getEncryptedValue().getValue(), is(encryptedValue));
+        assertThat(configurationProperty.getEncryptedValue(), is(encryptedValue));
     }
 
     @Test
@@ -231,7 +231,7 @@ public class ConfigurationPropertyTest {
 
         assertThat(configurationProperty.getConfigurationKey().getName(), is(secureKey));
         assertThat(configurationProperty.getConfigurationValue(), is(nullValue()));
-        assertThat(configurationProperty.getEncryptedValue().getValue(), is("encryptedValue"));
+        assertThat(configurationProperty.getEncryptedValue(), is("encryptedValue"));
     }
 
     @Test
@@ -249,7 +249,7 @@ public class ConfigurationPropertyTest {
 
         assertThat(configurationProperty.getConfigurationKey().getName(), is("fooKey"));
         assertThat(configurationProperty.getConfigurationValue().getValue(), is("fooValue"));
-        assertThat(configurationProperty.getEncryptedValue(), is(nullValue()));
+        assertThat(configurationProperty.getEncryptedConfigurationValue(), is(nullValue()));
     }
 
     @Test

--- a/common/test/unit/com/thoughtworks/go/domain/packagerepository/PackageDefinitionTest.java
+++ b/common/test/unit/com/thoughtworks/go/domain/packagerepository/PackageDefinitionTest.java
@@ -225,10 +225,10 @@ public class PackageDefinitionTest extends PackageMaterialTestBase {
         assertThat(definition.getName(), is("package-name"));
         assertThat(definition.getConfiguration().size(), is(3));
         assertThat(definition.getConfiguration().getProperty("key1").getConfigurationValue().getValue(), is("value1"));
-        assertThat(definition.getConfiguration().getProperty("key1").getEncryptedValue(), is(nullValue()));
-        assertThat(definition.getConfiguration().getProperty("key2").getEncryptedValue().getValue(), is(encryptedValue));
+        assertThat(definition.getConfiguration().getProperty("key1").getEncryptedConfigurationValue(), is(nullValue()));
+        assertThat(definition.getConfiguration().getProperty("key2").getEncryptedValue(), is(encryptedValue));
         assertThat(definition.getConfiguration().getProperty("key2").getConfigurationValue(), is(nullValue()));
-        assertThat(definition.getConfiguration().getProperty("key3").getEncryptedValue().getValue(), is("encrypted-value"));
+        assertThat(definition.getConfiguration().getProperty("key3").getEncryptedValue(), is("encrypted-value"));
         assertThat(definition.getConfiguration().getProperty("key3").getConfigurationValue(), is(nullValue()));
     }
 

--- a/common/test/unit/com/thoughtworks/go/domain/packagerepository/PackageRepositoryTest.java
+++ b/common/test/unit/com/thoughtworks/go/domain/packagerepository/PackageRepositoryTest.java
@@ -164,16 +164,16 @@ public class PackageRepositoryTest extends PackageMaterialTestBase {
 
         //assert package properties
         assertThat(secureProperty.isSecure(), is(true));
-        assertThat(secureProperty.getEncryptedValue(), is(notNullValue()));
-        assertThat(secureProperty.getEncryptedValue().getValue(), is(goCipher.encrypt("value1")));
+        assertThat(secureProperty.getEncryptedConfigurationValue(), is(notNullValue()));
+        assertThat(secureProperty.getEncryptedValue(), is(goCipher.encrypt("value1")));
 
         assertThat(nonSecureProperty.isSecure(), is(false));
         assertThat(nonSecureProperty.getValue(), is("value2"));
 
         //assert repository properties
         assertThat(secureRepoProperty.isSecure(), is(true));
-        assertThat(secureRepoProperty.getEncryptedValue(), is(notNullValue()));
-        assertThat(secureRepoProperty.getEncryptedValue().getValue(), is(goCipher.encrypt("value1")));
+        assertThat(secureRepoProperty.getEncryptedConfigurationValue(), is(notNullValue()));
+        assertThat(secureRepoProperty.getEncryptedValue(), is(goCipher.encrypt("value1")));
 
         assertThat(nonSecureRepoProperty.isSecure(), is(false));
         assertThat(nonSecureRepoProperty.getValue(), is("value2"));
@@ -193,17 +193,17 @@ public class PackageRepositoryTest extends PackageMaterialTestBase {
 
         packageRepository.applyPackagePluginMetadata();
 
-        assertThat(secureProperty.getEncryptedValue(), is(notNullValue()));
+        assertThat(secureProperty.getEncryptedConfigurationValue(), is(notNullValue()));
         assertThat(secureProperty.getConfigurationValue(), is(nullValue()));
 
         assertThat(nonSecureProperty.getConfigurationValue(), is(notNullValue()));
-        assertThat(nonSecureProperty.getEncryptedValue(), is(nullValue()));
+        assertThat(nonSecureProperty.getEncryptedConfigurationValue(), is(nullValue()));
 
-        assertThat(secureRepoProperty.getEncryptedValue(), is(notNullValue()));
+        assertThat(secureRepoProperty.getEncryptedConfigurationValue(), is(notNullValue()));
         assertThat(secureRepoProperty.getConfigurationValue(), is(nullValue()));
 
         assertThat(nonSecureRepoProperty.getConfigurationValue(), is(notNullValue()));
-        assertThat(nonSecureRepoProperty.getEncryptedValue(), is(nullValue()));
+        assertThat(nonSecureRepoProperty.getEncryptedConfigurationValue(), is(nullValue()));
     }
 
     @Test
@@ -244,11 +244,11 @@ public class PackageRepositoryTest extends PackageMaterialTestBase {
         assertThat(packageRepository.getConfiguration().get(1).getConfigurationValue().getValue(), is(username.value));
 
         assertThat(packageRepository.getConfiguration().get(2).getConfigurationKey().getName(), is(password.name));
-        assertThat(packageRepository.getConfiguration().get(2).getEncryptedValue().getValue(), is(new GoCipher().encrypt(password.value)));
+        assertThat(packageRepository.getConfiguration().get(2).getEncryptedValue(), is(new GoCipher().encrypt(password.value)));
         assertThat(packageRepository.getConfiguration().get(2).getConfigurationValue(), is(nullValue()));
 
         assertThat(packageRepository.getConfiguration().get(3).getConfigurationKey().getName(), is(secureKeyNotChanged.name));
-        assertThat(packageRepository.getConfiguration().get(3).getEncryptedValue().getValue(), is(oldEncryptedValue));
+        assertThat(packageRepository.getConfiguration().get(3).getEncryptedValue(), is(oldEncryptedValue));
         assertThat(packageRepository.getConfiguration().get(3).getConfigurationValue(), is(nullValue()));
 
         assertSame(packageRepository.getPackages(), packages);

--- a/config/config-api/src/com/thoughtworks/go/domain/config/Configuration.java
+++ b/config/config-api/src/com/thoughtworks/go/domain/config/Configuration.java
@@ -111,7 +111,7 @@ public class Configuration extends BaseCollection<ConfigurationProperty> {
         List<ConfigurationProperty> propertiesToRemove = new ArrayList<>();
         for (ConfigurationProperty configurationProperty : this) {
             ConfigurationValue configurationValue = configurationProperty.getConfigurationValue();
-            EncryptedConfigurationValue encryptedValue = configurationProperty.getEncryptedValue();
+            EncryptedConfigurationValue encryptedValue = configurationProperty.getEncryptedConfigurationValue();
 
             if (StringUtil.isBlank(configurationProperty.getValue()) && (configurationValue == null || configurationValue.errors().isEmpty()) && (encryptedValue == null || encryptedValue.errors().isEmpty())) {
                 propertiesToRemove.add(configurationProperty);

--- a/config/config-api/src/com/thoughtworks/go/domain/config/ConfigurationProperty.java
+++ b/config/config-api/src/com/thoughtworks/go/domain/config/ConfigurationProperty.java
@@ -147,7 +147,7 @@ public class ConfigurationProperty implements Serializable, Validatable {
         return format("%s=%s", configurationKey.getName(), getValue());
     }
 
-    public EncryptedConfigurationValue getEncryptedValue() {
+    public EncryptedConfigurationValue getEncryptedConfigurationValue() {
         return encryptedValue;
     }
 
@@ -206,7 +206,7 @@ public class ConfigurationProperty implements Serializable, Validatable {
 
     public void addErrorAgainstConfigurationValue(String message) {
         if (isSecure()) {
-            getEncryptedValue().errors().add("value", message);
+            getEncryptedConfigurationValue().errors().add("value", message);
         } else {
             getConfigurationValue().errors().add("value", message);
         }
@@ -214,7 +214,7 @@ public class ConfigurationProperty implements Serializable, Validatable {
 
     public boolean doesNotHaveErrorsAgainstConfigurationValue() {
         if (isSecure()) {
-            List<String> errorsOnValue = getEncryptedValue().errors().getAllOn("value");
+            List<String> errorsOnValue = getEncryptedConfigurationValue().errors().getAllOn("value");
             return errorsOnValue == null || errorsOnValue.isEmpty();
         } else {
             List<String> errorsOnValue = getConfigurationValue().errors().getAllOn("value");
@@ -278,11 +278,15 @@ public class ConfigurationProperty implements Serializable, Validatable {
     }
 
     public String getConfigKeyName() {
-        return configurationKey.getName();
+        return configurationKey != null ? configurationKey.getName() : null;
     }
 
     public String getConfigValue() {
-        return configurationValue.getValue();
+        return configurationValue != null ? configurationValue.getValue() : null;
+    }
+
+    public String getEncryptedValue() {
+        return encryptedValue != null ? encryptedValue.getValue() : null;
     }
 
     public String getDisplayValue() {

--- a/config/config-api/src/com/thoughtworks/go/domain/scm/SCM.java
+++ b/config/config-api/src/com/thoughtworks/go/domain/scm/SCM.java
@@ -135,18 +135,14 @@ public class SCM implements Serializable, Validatable {
     public void addConfigurations(List<ConfigurationProperty> configurations) {
         ConfigurationPropertyBuilder builder = new ConfigurationPropertyBuilder();
         for (ConfigurationProperty property : configurations) {
-            String configKey = property.getConfigurationKey() != null ? property.getConfigKeyName() : null;
-            String encryptedValue = property.getEncryptedValue() != null ? property.getEncryptedValue().getValue() : null;
-            String configValue = property.getConfigurationValue() != null ? property.getConfigValue() : null;
-
             SCMConfigurations scmConfigurations = SCMMetadataStore.getInstance().getConfigurationMetadata(getPluginId());
-            if (isValidPluginConfiguration(configKey, scmConfigurations)) {
-                configuration.add(builder.create(configKey, configValue, encryptedValue, scmConfigurationFor(configKey, scmConfigurations).getOption(SCMConfiguration.SECURE)));
+            if (isValidPluginConfiguration(property.getConfigKeyName(), scmConfigurations)) {
+                configuration.add(builder.create(property.getConfigKeyName(), property.getConfigValue(), property.getEncryptedValue(),
+                                                 scmConfigurationFor(property.getConfigKeyName(), scmConfigurations).getOption(SCMConfiguration.SECURE)));
             }
             else {
                 configuration.add(property);
             }
-
         }
     }
 

--- a/config/config-api/test/com/thoughtworks/go/config/builder/ConfigurationPropertyBuilderTest.java
+++ b/config/config-api/test/com/thoughtworks/go/config/builder/ConfigurationPropertyBuilderTest.java
@@ -18,7 +18,7 @@ public class ConfigurationPropertyBuilderTest {
         ConfigurationProperty property = new ConfigurationPropertyBuilder().create("key", null, "enc_value", true);
 
         assertThat(property.getConfigKeyName(), is("key"));
-        assertThat(property.getEncryptedValue().getValue(), is("enc_value"));
+        assertThat(property.getEncryptedValue(), is("enc_value"));
         assertNull(property.getConfigurationValue());
     }
 
@@ -30,7 +30,7 @@ public class ConfigurationPropertyBuilderTest {
         ConfigurationProperty property = new ConfigurationPropertyBuilder().create("key", "value", null, true);
 
         assertThat(property.getConfigKeyName(), is("key"));
-        assertThat(property.getEncryptedValue().getValue(), is(new GoCipher().encrypt("value")));
+        assertThat(property.getEncryptedValue(), is(new GoCipher().encrypt("value")));
         assertNull(property.getConfigurationValue());
     }
 
@@ -42,7 +42,7 @@ public class ConfigurationPropertyBuilderTest {
         ConfigurationProperty property = new ConfigurationPropertyBuilder().create("key", null, null, true);
 
         assertThat(property.getConfigKeyName(), is("key"));
-        assertNull(property.getEncryptedValue());
+        assertNull(property.getEncryptedConfigurationValue());
         assertNull(property.getConfigurationValue());
     }
 
@@ -56,7 +56,7 @@ public class ConfigurationPropertyBuilderTest {
         assertThat(property.errors().get("configurationValue").get(0), is("You may only specify `value` or `encrypted_value`, not both!"));
         assertThat(property.errors().get("encryptedValue").get(0), is("You may only specify `value` or `encrypted_value`, not both!"));
         assertThat(property.getConfigurationValue().getValue(), is("value"));
-        assertThat(property.getEncryptedValue().getValue(), is("enc_value"));
+        assertThat(property.getEncryptedValue(), is("enc_value"));
     }
 
     @Test
@@ -69,7 +69,7 @@ public class ConfigurationPropertyBuilderTest {
         assertThat(property.errors().get("configurationValue").get(0), is("You may only specify `value` or `encrypted_value`, not both!"));
         assertThat(property.errors().get("encryptedValue").get(0), is("You may only specify `value` or `encrypted_value`, not both!"));
         assertThat(property.getConfigurationValue().getValue(), is("value"));
-        assertThat(property.getEncryptedValue().getValue(), is("enc_value"));
+        assertThat(property.getEncryptedValue(), is("enc_value"));
     }
 
     @Test
@@ -80,7 +80,7 @@ public class ConfigurationPropertyBuilderTest {
         ConfigurationProperty property = new ConfigurationPropertyBuilder().create("key", null, "enc_value", false);
 
         assertThat(property.errors().get("encryptedValue").get(0), is("encrypted_value cannot be specified to a unsecured property."));
-        assertThat(property.getEncryptedValue().getValue(), is("enc_value"));
+        assertThat(property.getEncryptedValue(), is("enc_value"));
     }
 
     @Test
@@ -91,6 +91,6 @@ public class ConfigurationPropertyBuilderTest {
         ConfigurationProperty property = new ConfigurationPropertyBuilder().create("key", "value", null, false);
 
         assertThat(property.getConfigurationValue().getValue(), is("value"));
-        assertNull(property.getEncryptedValue());
+        assertNull(property.getEncryptedConfigurationValue());
     }
 }

--- a/config/config-api/test/com/thoughtworks/go/domain/scm/SCMTest.java
+++ b/config/config-api/test/com/thoughtworks/go/domain/scm/SCMTest.java
@@ -146,8 +146,8 @@ public class SCMTest {
 
         //assert SCM properties
         assertThat(secureProperty.isSecure(), is(true));
-        assertThat(secureProperty.getEncryptedValue(), is(notNullValue()));
-        assertThat(secureProperty.getEncryptedValue().getValue(), is(goCipher.encrypt("value1")));
+        assertThat(secureProperty.getEncryptedConfigurationValue(), is(notNullValue()));
+        assertThat(secureProperty.getEncryptedValue(), is(goCipher.encrypt("value1")));
 
         assertThat(nonSecureProperty.isSecure(), is(false));
         assertThat(nonSecureProperty.getValue(), is("value2"));
@@ -163,11 +163,11 @@ public class SCMTest {
 
         scm.applyPluginMetadata();
 
-        assertThat(secureProperty.getEncryptedValue(), is(notNullValue()));
+        assertThat(secureProperty.getEncryptedConfigurationValue(), is(notNullValue()));
         assertThat(secureProperty.getConfigurationValue(), is(nullValue()));
 
         assertThat(nonSecureProperty.getConfigurationValue(), is(notNullValue()));
-        assertThat(nonSecureProperty.getEncryptedValue(), is(nullValue()));
+        assertThat(nonSecureProperty.getEncryptedConfigurationValue(), is(nullValue()));
     }
 
     @Test
@@ -205,7 +205,7 @@ public class SCMTest {
         assertThat(scm.getConfigAsMap().get("password").get(SCM.VALUE_KEY), is("pass"));
 
         assertThat(scm.getConfiguration().getProperty("password").getConfigurationValue(), is(nullValue()));
-        assertThat(scm.getConfiguration().getProperty("password").getEncryptedValue(), is(not(nullValue())));
+        assertThat(scm.getConfiguration().getProperty("password").getEncryptedConfigurationValue(), is(not(nullValue())));
     }
 
     @Test

--- a/config/config-server/test/com/thoughtworks/go/config/MagicalGoConfigXmlWriterTest.java
+++ b/config/config-server/test/com/thoughtworks/go/config/MagicalGoConfigXmlWriterTest.java
@@ -29,7 +29,6 @@ import com.thoughtworks.go.config.remote.PartialConfig;
 import com.thoughtworks.go.config.remote.RepoConfigOrigin;
 import com.thoughtworks.go.config.server.security.ldap.BaseConfig;
 import com.thoughtworks.go.config.server.security.ldap.BasesConfig;
-import com.thoughtworks.go.domain.ConfigErrors;
 import com.thoughtworks.go.domain.RunIfConfigs;
 import com.thoughtworks.go.domain.config.*;
 import com.thoughtworks.go.domain.packagerepository.PackageDefinition;
@@ -58,7 +57,6 @@ import javax.xml.validation.SchemaFactory;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
-import java.util.List;
 
 import static com.thoughtworks.go.util.DataStructureUtils.m;
 import static com.thoughtworks.go.util.GoConstants.CONFIG_SCHEMA_VERSION;
@@ -854,12 +852,12 @@ public class MagicalGoConfigXmlWriterTest {
         PackageRepositories packageRepositories = goConfigHolder.config.getPackageRepositories();
         assertThat(packageRepositories, is(configToSave.getPackageRepositories()));
         assertThat(packageRepositories.get(0).getConfiguration().first().getConfigurationValue().getValue(), is("http://go"));
-        assertThat(packageRepositories.get(0).getConfiguration().first().getEncryptedValue(), is(nullValue()));
-        assertThat(packageRepositories.get(0).getConfiguration().last().getEncryptedValue().getValue(), is(new GoCipher().encrypt("secure")));
+        assertThat(packageRepositories.get(0).getConfiguration().first().getEncryptedConfigurationValue(), is(nullValue()));
+        assertThat(packageRepositories.get(0).getConfiguration().last().getEncryptedValue(), is(new GoCipher().encrypt("secure")));
         assertThat(packageRepositories.get(0).getConfiguration().last().getConfigurationValue(), is(nullValue()));
         assertThat(packageRepositories.get(0).getPackages().get(0), is(packageDefinition));
         assertThat(packageRepositories.get(0).getPackages().get(0).getConfiguration().first().getConfigurationValue().getValue(), is("go-agent"));
-        assertThat(packageRepositories.get(0).getPackages().get(0).getConfiguration().first().getEncryptedValue(), is(nullValue()));
+        assertThat(packageRepositories.get(0).getPackages().get(0).getConfiguration().first().getEncryptedConfigurationValue(), is(nullValue()));
     }
 
     @Test

--- a/config/config-server/test/com/thoughtworks/go/config/crud/SCMConfigXmlLoaderTest.java
+++ b/config/config-server/test/com/thoughtworks/go/config/crud/SCMConfigXmlLoaderTest.java
@@ -339,7 +339,7 @@ public class SCMConfigXmlLoaderTest extends BaseConfigXmlLoaderTest {
         assertThat(pluggableSCMMaterialConfig.getSCMConfig(), is(scmConfig));
         Configuration configuration = pluggableSCMMaterialConfig.getSCMConfig().getConfiguration();
         assertThat(configuration.get(0).getConfigurationValue().getValue(), is("value"));
-        assertThat(configuration.get(1).getEncryptedValue().getValue(), is(new GoCipher().encrypt("secure-value")));
-        assertThat(configuration.get(2).getEncryptedValue().getValue(), is(encryptedValue));
+        assertThat(configuration.get(1).getEncryptedValue(), is(new GoCipher().encrypt("secure-value")));
+        assertThat(configuration.get(2).getEncryptedValue(), is(encryptedValue));
     }
 }

--- a/config/config-server/test/com/thoughtworks/go/config/crud/SCMConfigXmlWriterTest.java
+++ b/config/config-server/test/com/thoughtworks/go/config/crud/SCMConfigXmlWriterTest.java
@@ -55,8 +55,8 @@ public class SCMConfigXmlWriterTest extends BaseConfigXmlWriterTest {
         SCMs scms = goConfigHolder.config.getSCMs();
         assertThat(scms, is(configToSave.getSCMs()));
         assertThat(scms.get(0).getConfiguration().first().getConfigurationValue().getValue(), is("http://go"));
-        assertThat(scms.get(0).getConfiguration().first().getEncryptedValue(), is(nullValue()));
-        assertThat(scms.get(0).getConfiguration().last().getEncryptedValue().getValue(), is(new GoCipher().encrypt("secure")));
+        assertThat(scms.get(0).getConfiguration().first().getEncryptedConfigurationValue(), is(nullValue()));
+        assertThat(scms.get(0).getConfiguration().last().getEncryptedValue(), is(new GoCipher().encrypt("secure")));
         assertThat(scms.get(0).getConfiguration().last().getConfigurationValue(), is(nullValue()));
     }
 

--- a/server/src/com/thoughtworks/go/config/ConfigRepoPlugin.java
+++ b/server/src/com/thoughtworks/go/config/ConfigRepoPlugin.java
@@ -30,11 +30,11 @@ import java.util.Collection;
 import java.util.List;
 
 public class ConfigRepoPlugin implements PartialConfigProvider {
-    private ConfigConverter configConverter ;
+    private ConfigConverter configConverter;
     private ConfigRepoExtension crExtension;
     private String pluginId;
 
-    public ConfigRepoPlugin(ConfigConverter configConverter,ConfigRepoExtension crExtension, String pluginId) {
+    public ConfigRepoPlugin(ConfigConverter configConverter, ConfigRepoExtension crExtension, String pluginId) {
         this.configConverter = configConverter;
         this.crExtension = crExtension;
         this.pluginId = pluginId;
@@ -54,21 +54,19 @@ public class ConfigRepoPlugin implements PartialConfigProvider {
 
     public CRParseResult parseDirectory(File configRepoCheckoutDirectory, Collection<CRConfigurationProperty> cRconfigurations) {
         CRParseResult crParseResult = this.crExtension.parseDirectory(this.pluginId, configRepoCheckoutDirectory.getAbsolutePath(), cRconfigurations);
-        if(crParseResult.hasErrors())
-            throw new InvalidPartialConfigException(crParseResult,crParseResult.getErrors().getErrorsAsText());
+        if (crParseResult.hasErrors())
+            throw new InvalidPartialConfigException(crParseResult, crParseResult.getErrors().getErrorsAsText());
         return crParseResult;
     }
 
     public static List<CRConfigurationProperty> getCrConfigurations(Configuration configuration) {
         List<CRConfigurationProperty> config = new ArrayList<>();
-        for(ConfigurationProperty prop : configuration)
-        {
+        for (ConfigurationProperty prop : configuration) {
             String configKeyName = prop.getConfigKeyName();
-            if(!prop.isSecure())
-                config.add(new CRConfigurationProperty(configKeyName,prop.getValue(),null));
-            else
-            {
-                CRConfigurationProperty crProp = new CRConfigurationProperty(configKeyName,null,prop.getEncryptedValue().getValue());
+            if (!prop.isSecure())
+                config.add(new CRConfigurationProperty(configKeyName, prop.getValue(), null));
+            else {
+                CRConfigurationProperty crProp = new CRConfigurationProperty(configKeyName, null, prop.getEncryptedValue());
                 config.add(crProp);
             }
         }

--- a/server/src/com/thoughtworks/go/server/service/tasks/TaskViewService.java
+++ b/server/src/com/thoughtworks/go/server/service/tasks/TaskViewService.java
@@ -133,7 +133,7 @@ public class TaskViewService implements TaskFactory {
     private Configuration getConfiguration(TaskConfig taskConfig) {
         Configuration configuration = new Configuration();
         for (Property property : taskConfig.list()) {
-            configuration.addNewConfigurationWithValue(property.getKey(), property.getValue(), false);
+            configuration.addNewConfigurationWithValue(property.getKey(), property.getValue(), property.getOption(Property.SECURE));
         }
         return configuration;
     }

--- a/server/test/unit/com/thoughtworks/go/server/service/materials/PackageDefinitionServiceTest.java
+++ b/server/test/unit/com/thoughtworks/go/server/service/materials/PackageDefinitionServiceTest.java
@@ -97,8 +97,8 @@ public class PackageDefinitionServiceTest {
         service.performPluginValidationsFor(packageDefinition);
 
         assertThat(packageDefinition.getConfiguration().get(0).getConfigurationValue().errors().getAllOn("value"), is(Arrays.asList("mandatory field")));
-        assertThat(packageDefinition.getConfiguration().get(1).getEncryptedValue().errors().getAllOn("value"), is(Arrays.asList("mandatory field")));
-        assertThat(packageDefinition.getConfiguration().get(2).getEncryptedValue().errors().isEmpty(), is(true));
+        assertThat(packageDefinition.getConfiguration().get(1).getEncryptedConfigurationValue().errors().getAllOn("value"), is(Arrays.asList("mandatory field")));
+        assertThat(packageDefinition.getConfiguration().get(2).getEncryptedConfigurationValue().errors().isEmpty(), is(true));
         assertThat(packageDefinition.getConfiguration().get(3).getConfigurationValue().errors().isEmpty(), is(true));
         assertThat(packageDefinition.getConfiguration().get(4).getConfigurationValue().errors().getAllOn("value"), is(Arrays.asList("invalid spec")));
     }

--- a/server/test/unit/com/thoughtworks/go/server/service/materials/PackageRepositoryServiceTest.java
+++ b/server/test/unit/com/thoughtworks/go/server/service/materials/PackageRepositoryServiceTest.java
@@ -222,7 +222,7 @@ public class PackageRepositoryServiceTest {
         service.performPluginValidationsFor(packageRepository);
 
         assertThat(packageRepository.getConfiguration().get(0).getConfigurationValue().errors().getAllOn("value"), is(Arrays.asList("mandatory field")));
-        assertThat(packageRepository.getConfiguration().get(1).getEncryptedValue().errors().getAllOn("value"), is(Arrays.asList("mandatory field")));
+        assertThat(packageRepository.getConfiguration().get(1).getEncryptedConfigurationValue().errors().getAllOn("value"), is(Arrays.asList("mandatory field")));
     }
 
     @Test

--- a/server/test/unit/com/thoughtworks/go/server/service/tasks/TaskViewServiceTest.java
+++ b/server/test/unit/com/thoughtworks/go/server/service/tasks/TaskViewServiceTest.java
@@ -47,6 +47,7 @@ import java.util.*;
 import static com.thoughtworks.go.domain.packagerepository.ConfigurationPropertyMother.create;
 import static com.thoughtworks.go.util.DataStructureUtils.s;
 import static java.util.Arrays.asList;
+import static junit.framework.TestCase.assertTrue;
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.core.Is.is;
@@ -150,6 +151,19 @@ public class TaskViewServiceTest {
         assertThat(pluggableTask.getConfiguration().getProperty("key1").getValue(), is("default1"));
         assertThat(pluggableTask.getConfiguration().getProperty("key2").getValue(), is("default2"));
         assertNull(pluggableTask.getConfiguration().getProperty("key3").getValue());
+    }
+
+    @Test
+    public void shouldFetchPluggableTasksWithSecureConfigurations() throws Exception {
+        String plugin = "task-plugin";
+        when(pluginManager.getPluginDescriptorFor(plugin)).thenReturn(new GoPluginDescriptor(plugin, "1", null, null, null, false));
+        Property taskConfigProperty = new TaskConfigProperty("key1", null).with(Property.SECURE, true);
+
+        storeTaskPreferences(plugin, taskConfigProperty);
+        when(registry.implementersOf(Task.class)).thenReturn(Arrays.<Class<? extends Task>>asList(PluggableTask.class));
+
+        PluggableTask pluggableTask = (PluggableTask) taskViewService.taskInstanceFor(new PluggableTask(new PluginConfiguration(plugin, "1"), null).getTaskType());
+        assertTrue(pluggableTask.getConfiguration().first().isSecure());
     }
 
     @Test

--- a/server/webapp/WEB-INF/rails.new/app/models/package_property_model.rb
+++ b/server/webapp/WEB-INF/rails.new/app/models/package_property_model.rb
@@ -23,9 +23,9 @@ class PackagePropertyModel
     @is_secure = package_configuration.getOption(com.thoughtworks.go.plugin.access.packagematerial.PackageConfiguration::SECURE)
     if config_property
       if (@is_secure)
-        @value = config_property.getEncryptedValue().getValue()
+        @value = config_property.getEncryptedValue()
       else
-        @value = config_property.getConfigurationValue().getValue()
+        @value = config_property.getConfigValue()
       end
     end
     @name = package_configuration.getKey()

--- a/server/webapp/WEB-INF/rails.new/app/presenters/api_v1/config/plugin_configuration_property_representer.rb
+++ b/server/webapp/WEB-INF/rails.new/app/presenters/api_v1/config/plugin_configuration_property_representer.rb
@@ -35,7 +35,7 @@ module ApiV1
       end
 
       def encrypted_value
-        configuration_property.getEncryptedValue.getValue if configuration_property.isSecure
+        configuration_property.getEncryptedValue if configuration_property.isSecure
       end
 
       def value=(val)

--- a/server/webapp/WEB-INF/rails.new/spec/models/repo_view_model_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/models/repo_view_model_spec.rb
@@ -48,7 +48,7 @@ describe RepoViewModel do
     model.properties[0].display_name.should == "Key 1"
     model.properties[0].value.should == "v1"
     model.properties[1].display_name.should == "Key 2"
-    model.properties[1].value.should == secure_property.getEncryptedValue().getValue()
+    model.properties[1].value.should == secure_property.getEncryptedValue()
   end
 
   it "should create repo view model from metadata when repo doesn't have all configuration " do


### PR DESCRIPTION
…config.xml #903

* Pluggable tasks with secure configurations were saved as plain text in config.xml, this fix is to store them as encrypted value
* Not migrating existing secure configurations saved as plain text,
  these configurations will be encrypted on update of the PluggableTask