### PR TITLE
Added partial representation for pluggable scm index api.

### DIFF
--- a/server/webapp/WEB-INF/rails.new/app/controllers/api_v1/admin/pluggable_scms_controller.rb
+++ b/server/webapp/WEB-INF/rails.new/app/controllers/api_v1/admin/pluggable_scms_controller.rb
@@ -33,7 +33,7 @@ module ApiV1
 
       def create
         result = HttpLocalizedOperationResult.new
-        @scm = ApiV1::Scms::PluggableScmRepresenter.new(SCM.new).from_hash(params)
+        @scm = ApiV1::Scms::PluggableScmRepresenter.new(SCM.new).from_hash(params[:pluggable_scm])
         @scm.ensureIdExists
         pluggable_scm_service.createPluggableScmMaterial(current_user, @scm, result)
 
@@ -43,7 +43,7 @@ module ApiV1
 
       def update
         result = HttpLocalizedOperationResult.new
-        @scm = ApiV1::Scms::PluggableScmRepresenter.new(SCM.new).from_hash(params)
+        @scm = ApiV1::Scms::PluggableScmRepresenter.new(SCM.new).from_hash(params[:pluggable_scm])
         pluggable_scm_service.updatePluggableScmMaterial(current_user, @scm, result)
 
         json = ApiV1::Scms::PluggableScmRepresenter.new(@scm).to_hash(url_builder: self)
@@ -67,7 +67,7 @@ module ApiV1
       end
 
       def check_for_scm_rename
-        unless params[:name].downcase == params[:material_name].downcase
+        unless params[:pluggable_scm][:name].downcase == params[:material_name].downcase
           render_message('Renaming of SCM material is not supported by this API.', :unprocessable_entity)
         end
       end

--- a/server/webapp/WEB-INF/rails.new/app/presenters/api_v1/scms/pluggable_scm_representer.rb
+++ b/server/webapp/WEB-INF/rails.new/app/presenters/api_v1/scms/pluggable_scm_representer.rb
@@ -16,26 +16,10 @@
 
 module ApiV1
   module Scms
-    class PluggableScmRepresenter < BaseRepresenter
-      alias_method :scm, :represented
+    class PluggableScmRepresenter < ApiV1::Scms::PluggableScmSummaryRepresenter
+      alias_method :scm_config, :represented
 
-      error_representer
-
-      link :self do |opts|
-        opts[:url_builder].apiv1_admin_scm_url(material_name: scm.getName) if scm.getName
-      end
-
-      link :doc do
-        'http://api.go.cd/#scms'
-      end
-      property :errors, exec_context: :decorator, decorator: ApiV1::Config::ErrorRepresenter, skip_parse: true, skip_render: lambda { |object, options| object.empty? }
-      property :id
-      property :name
-      property :auto_update
-      property :plugin_configuration, as: :plugin_metadata,
-               decorator: ApiV1::Config::PluginConfigurationRepresenter,
-               class: com.thoughtworks.go.domain.config.PluginConfiguration
-
+      property   :auto_update
       collection :configuration,
                  exec_context: :decorator,
                  decorator: ApiV1::Config::PluginConfigurationPropertyRepresenter,
@@ -51,3 +35,4 @@ module ApiV1
     end
   end
 end
+

--- a/server/webapp/WEB-INF/rails.new/app/presenters/api_v1/scms/pluggable_scm_summary_representer.rb
+++ b/server/webapp/WEB-INF/rails.new/app/presenters/api_v1/scms/pluggable_scm_summary_representer.rb
@@ -16,21 +16,24 @@
 
 module ApiV1
   module Scms
-    class PluggableScmsRepresenter < BaseRepresenter
+    class PluggableScmSummaryRepresenter < BaseRepresenter
+      alias_method :scm, :represented
+
+      error_representer
 
       link :self do |opts|
-        opts[:url_builder].apiv1_admin_scms_url
+        opts[:url_builder].apiv1_admin_scm_url(material_name: scm.getName) if scm.getName
       end
 
       link :doc do
         'http://api.go.cd/#scms'
       end
-
-      collection :scms, embedded: true, exec_context: :decorator, decorator: PluggableScmSummaryRepresenter
-
-      def scms
-        represented
-      end
+      property :errors, exec_context: :decorator, decorator: ApiV1::Config::ErrorRepresenter, skip_parse: true, skip_render: lambda { |object, options| object.empty? }
+      property :id
+      property :name
+      property :plugin_configuration, as: :plugin_metadata,
+               decorator: ApiV1::Config::PluginConfigurationRepresenter,
+               class: com.thoughtworks.go.domain.config.PluginConfiguration
     end
   end
 end

--- a/server/webapp/WEB-INF/rails.new/config/routes.rb
+++ b/server/webapp/WEB-INF/rails.new/config/routes.rb
@@ -235,7 +235,7 @@ Go::Application.routes.draw do
           resources :command_snippets, only: [:index]
         end
         resources :plugin_infos, param: :id, only: [:index, :show], constraints: {id: PLUGIN_ID_FORMAT}
-        resources :scms, param: :material_name, controller: :pluggable_scms, except: [:delete]
+        resources :scms, param: :material_name, controller: :pluggable_scms, only: [:index, :show, :create, :update], constraints: {material_name: ALLOW_DOTS}
       end
 
       get 'stages/:pipeline_name/:pipeline_counter/:stage_name/:stage_counter' => 'stages#show', constraints: {pipeline_name: PIPELINE_NAME_FORMAT, pipeline_counter: PIPELINE_COUNTER_FORMAT, stage_name: STAGE_NAME_FORMAT, stage_counter: STAGE_COUNTER_FORMAT}, as: :stage_instance_by_counter_api

--- a/server/webapp/WEB-INF/rails.new/spec/presenters/api_v1/scms/pluggable_scm_representer_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/presenters/api_v1/scms/pluggable_scm_representer_spec.rb
@@ -26,7 +26,7 @@ describe ApiV1::Scms::PluggableScmRepresenter do
     @scm.setName('material')
   end
 
-  it 'should render a pluggable scm material with hal representation' do
+  it 'should render all of pluggable scm material with hal representation' do
     actual_json = ApiV1::Scms::PluggableScmRepresenter.new(@scm).to_hash(url_builder: UrlBuilder.new)
 
     expect(actual_json).to have_link(:self).with_url(UrlBuilder.new.apiv1_admin_scm_url(material_name: @scm.get_name))
@@ -39,7 +39,7 @@ describe ApiV1::Scms::PluggableScmRepresenter do
   it 'should deserialize given json to scm object' do
     deserialized_scm = SCM.new
     ApiV1::Scms::PluggableScmRepresenter.new(deserialized_scm).from_hash(json)
-    expect(deserialized_scm.getId).to eq(@scm.getId)
+    expect(deserialized_scm).to eq(@scm)
   end
 
   it 'should render configuration value with hal representation' do
@@ -100,13 +100,11 @@ describe ApiV1::Scms::PluggableScmRepresenter do
         configuration: [
             {
                 key: "username",
-                value: "user",
-                secure: false
+                value: "user"
             },
             {
                 key: "password",
-                encrypted_value: "bar",
-                secure: true
+                encrypted_value: "bar"
             }
         ]
     }

--- a/server/webapp/WEB-INF/rails.new/spec/presenters/api_v1/scms/pluggable_scm_summary_representer_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/presenters/api_v1/scms/pluggable_scm_summary_representer_spec.rb
@@ -1,0 +1,48 @@
+##########################################################################
+# Copyright 2016 ThoughtWorks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+
+require 'spec_helper'
+
+describe ApiV1::Scms::PluggableScmSummaryRepresenter do
+
+  before :each do
+    @scm = SCM.new("1", PluginConfiguration.new("foo", "1"),
+                   Configuration.new(
+                       ConfigurationProperty.new(ConfigurationKey.new("username"), ConfigurationValue.new("user")),
+                       ConfigurationProperty.new(ConfigurationKey.new("password"), EncryptedConfigurationValue.new("bar"))))
+    @scm.setName('material')
+  end
+
+  it 'should render some details of pluggable scm material with hal representation' do
+    actual_json = ApiV1::Scms::PluggableScmSummaryRepresenter.new(@scm).to_hash(url_builder: UrlBuilder.new)
+
+    expect(actual_json).to have_link(:self).with_url(UrlBuilder.new.apiv1_admin_scm_url(material_name: @scm.get_name))
+    expect(actual_json).to have_link(:doc).with_url('http://api.go.cd/#scms')
+    actual_json.delete(:_links)
+    expect(actual_json).to eq(expected_partial_representation)
+  end
+
+  def expected_partial_representation
+    {
+        id: "1",
+        name: "material",
+        plugin_metadata: {
+            id: "foo",
+            version:"1"
+        }
+    }
+  end
+end

--- a/server/webapp/WEB-INF/rails.new/spec/presenters/api_v1/scms/pluggable_scms_representer_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/presenters/api_v1/scms/pluggable_scms_representer_spec.rb
@@ -28,6 +28,6 @@ describe ApiV1::Scms::PluggableScmsRepresenter do
     expect(actual_json).to have_link(:doc).with_url('http://api.go.cd/#scms')
     actual_json.delete(:_links)
 
-    actual_json.fetch(:_embedded).should == { :scms => [ApiV1::Scms::PluggableScmRepresenter.new(scm).to_hash(url_builder: UrlBuilder.new)] }
+    actual_json.fetch(:_embedded).should == { :scms => [ApiV1::Scms::PluggableScmSummaryRepresenter.new(scm).to_hash(url_builder: UrlBuilder.new)] }
   end
 end


### PR DESCRIPTION
This is done keeping the config SPA in mind. An index call need not have the full SCM object, but just the details necessary to make a Get SCM API call and subsequently the update SCM call. 

The index call now returns the following for all SCMs:
1. id
2. name
3. plugin_metadata

The show action returns the above along with ```auto_update``` and ```configuration``` 

@maheshp, Please review the changes