### PR TITLE
Display the correct footer on the login page. Render the page without footer for modals.

### DIFF
--- a/server/webapp/WEB-INF/rails.new/app/assets/stylesheets/css/application-old.scss
+++ b/server/webapp/WEB-INF/rails.new/app/assets/stylesheets/css/application-old.scss
@@ -1,5 +1,5 @@
 /*************************GO-LICENSE-START*********************************
- * Copyright 2014 ThoughtWorks, Inc.
+ * Copyright 2016 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -597,15 +597,15 @@ body#login-page {
 }
 
 body#login-page #bd {
-    background: transparent;
+    height:100%;
+    background: #444444;
 }
 
 body#login-page #yui-main {
     border: 0;
 }
 
-    
-    
+
 /* Graphical dialog */
 #graphic-dialog-container {
 

--- a/server/webapp/WEB-INF/rails.new/app/assets/stylesheets/css_sass/gadgets/modals.scss
+++ b/server/webapp/WEB-INF/rails.new/app/assets/stylesheets/css_sass/gadgets/modals.scss
@@ -1,5 +1,5 @@
 /*************************GO-LICENSE-START*********************************
- * Copyright 2014 ThoughtWorks, Inc.
+ * Copyright 2016 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -174,7 +174,7 @@
   max-height: 400px;
 }
 
-#MB_content #footer {
+#MB_content #footer-new-foundation {
   display: none;
 }
 

--- a/server/webapp/WEB-INF/rails.new/app/controllers/environments_controller.rb
+++ b/server/webapp/WEB-INF/rails.new/app/controllers/environments_controller.rb
@@ -1,5 +1,5 @@
 ##########################GO-LICENSE-START################################
-# Copyright 2014 ThoughtWorks, Inc.
+# Copyright 2016 ThoughtWorks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -67,12 +67,15 @@ class EnvironmentsController < ApplicationController
   end
 
   def edit_pipelines
+    render layout:false
   end
 
   def edit_agents
+    render layout:false
   end
 
   def edit_variables
+    render layout:false
   end
 
   private

--- a/server/webapp/WEB-INF/rails.new/app/views/navigation_elements/_footer.html.erb
+++ b/server/webapp/WEB-INF/rails.new/app/views/navigation_elements/_footer.html.erb
@@ -2,8 +2,8 @@
     <div class="row">
         <div class="small-12 medium-6 large-8 columns">
             <p class="copyright">Copyright &copy; 2016
-                <a href="http://www.thoughtworks.com/products" target='_blank'>ThoughtWorks, Inc.</a>
-                Licensed under <%= link_to('Apache License, Version 2.0', "http://www.apache.org/licenses/LICENSE-2.0", :target => '_blank') -%>.<br/>
+                <a href="https://www.thoughtworks.com/products" target='_blank'>ThoughtWorks, Inc.</a>
+                Licensed under <%= link_to('Apache License, Version 2.0', "https://www.apache.org/licenses/LICENSE-2.0", :target => '_blank') -%>.<br/>
                 Go includes <%= link_to('third-party software', url_for_path('NOTICE/cruise_notice_file.pdf'), :target => '_blank') -%>.
                 Go Version: <%= version %>.
             </p>
@@ -11,10 +11,10 @@
         </div>
       <div class="small-12 medium-6 large-4 columns">
             <span class="inline-list social">
-                <a href="http://twitter.com/goforcd" title="twitter" class="twitter"></a>
+                <a href="https://twitter.com/goforcd" title="twitter" class="twitter"></a>
                 <a href="https://github.com/gocd/gocd" title="github" class="github"></a>
                 <a href="https://groups.google.com/d/forum/go-cd" title="forums" class="forums"></a>
-                <a href="https://go.cd/current/documentation" title="documentation" class="documentation"></a>
+                <a href="https://docs.go.cd/current" title="documentation" class="documentation"></a>
                 <a href="https://www.go.cd/community/plugins.html" title="plugins" class="plugins"></a>
                 <a href="https://api.go.cd" title="api" class="api"></a>
                 <a href="<%= about_path %>" title="about" class="server-details"></a>

--- a/server/webapp/WEB-INF/vm/auth/login.vm
+++ b/server/webapp/WEB-INF/vm/auth/login.vm
@@ -1,5 +1,5 @@
 #*************************GO-LICENSE-START*********************************
- * Copyright 2014 ThoughtWorks, Inc.
+ * Copyright 2016 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,177 +15,138 @@
  *************************GO-LICENSE-END***********************************#
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
-        "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html>
 <head>
-    <meta http-equiv="content-type" content="text/html; charset=UTF-8"></meta>
+  <meta http-equiv="content-type" content="text/html; charset=UTF-8"></meta>
 
-    <link rel="shortcut icon" href="$req.getContextPath()/$concatenatedCruiseIconFilePath?#include("admin/admin_version.txt.vm")"/>
-    <link href="$req.getContextPath()/$concatenatedCssApplicationCssFilePath" rel="stylesheet" type="text/css"></link>
-    <link href="$req.getContextPath()/$concatenatedVmApplicationCssFilePath" rel="stylesheet" type="text/css"></link>
-    <!--[if lte IE 7]><link href="$req.getContextPath()/css/ie_hacks.css" rel="stylesheet" type="text/css"></link><![endif]-->
-    <script type="text/javascript">var contextPath = "$req.getContextPath()";</script>
-    <script src="$req.getContextPath()/$concatenatedJavascriptFilePath" type="text/javascript"></script>
+  <link href="$req.getContextPath()/$concatenatedCruiseIconFilePath?#include("admin/admin_version.txt.vm")"
+        rel="shortcut icon"/>
+  <link rel="stylesheet" type="text/css" href="$req.getContextPath()/$concatenatedApplicationCssFilePath" media="all"/>
+  <link rel="stylesheet" type="text/css" href="$req.getContextPath()/$concatenatedCssApplicationCssFilePath"
+        media="all"/>
+  <link rel="stylesheet" type="text/css" href="$req.getContextPath()/$concatenatedVmApplicationCssFilePath"
+        media="all"/>
+  <script type="text/javascript">var contextPath = "$req.getContextPath()";</script>
+  <script src="$req.getContextPath()/$concatenatedJavascriptFilePath" type="text/javascript"></script>
 
-    <style type="text/css">
-        body {
-            background: #000;
-        }
-        #bd {
-            background: #000;
-            border: none;
-            padding-top:0;
-        }
-        h1, h2, h3, h4 {
-            font-family: "Helvetica Neue", Arial, Helvetica, sans-serif;
-            font-weight: 500;
-        }
-        a:link.help, a:visited.help {
-            float: right;
-            text-decoration: underline;
+  <style type="text/css">
+    body {
+      background: #000;
+    }
 
-            padding-top: 0.2em;
-        }
-        a{
-            cursor: pointer;
-            color: #FFF;
-            text-decoration: none;
-        }
-        a:hover{
-            color: #FFF;
-        }
-        #footer {
-            background: none repeat scroll 0 0 #333333;
-            clear: both;
-            font-size: 11px;
-            padding: 15px;
-            width: auto;
-        }
-        #footer a {
-            color: #FFFFFF;
-        }
-        #footer ul li {
-            border-right: 1px dotted #CCCCCC;
-            color: #BBBBBB !important;
-            display: inline;
-            padding: 0 0.5em;
-        }
-        #footer ul li.last {
-            border: 0 none !important;
-        }
-        #footer ul li, #footer ul li a, #footer ul li span {
-            font-size: 11px !important;
-        }
-        #footer .copyright {
-            float: left;
-        }
-        #footer ul.links {
-            float: right;
-        }
-        #footer #copyright {
-            clear: both;
-            color: #1F2314;
-            float: left;
-            font-size: 0.9em;
-            padding-left: 2em;
-            width: 20em;
-        }
-        #footer #copyright a, #footer #copyright a:visited {
-            color: #1F2314;
-        }
+    #bd {
+      background: #000;
+      border: none;
+      padding-top: 0;
+    }
 
-    </style>
-    <title>Go - Login</title>
+    h1, h2, h3, h4 {
+      font-family: "Helvetica Neue", Arial, Helvetica, sans-serif;
+      font-weight: 500;
+    }
+
+    a:link.help, a:visited.help {
+      float: right;
+      text-decoration: underline;
+
+      padding-top: 0.2em;
+    }
+
+    a {
+      cursor: pointer;
+      color: #FFF;
+      text-decoration: none;
+    }
+
+    a:hover {
+      color: #FFF;
+    }
+
+  </style>
+  <title>Go - Login</title>
 </head>
 <body id="login-page">
 <div id="doc3" class="yui-t7">
-    <div id="bd">
-        <div id="yui-main">
-            <div id="main" class="yui-b">
-                #if ($login_error && $SPRING_SECURITY_LAST_EXCEPTION)
-                <div id="error-container" style="">
-                    <div class="ab-bg">
-                        <span class="ab-corner lvl1"></span>
-                        <span class="ab-corner lvl2"></span>
-                        <span class="ab-corner lvl3"></span>
-                        <span class="ab-corner lvl4"></span>
-                    </div>
-                    <div id="error-box">
-                        $SPRING_SECURITY_LAST_EXCEPTION.message.replaceAll(";.*", "")
-                        <a target="_blank" href="http://www.go.cd/documentation/user/current/configuration/dev_authentication.html#common-errors">Help Topic: Authentication</a>
-                    </div>
-                    <div class="ab-bg">
-                        <span class="ab-corner lvl4"></span>
-                        <span class="ab-corner lvl3"></span>
-                        <span class="ab-corner lvl2"></span>
-                        <span class="ab-corner lvl1"></span>
-                    </div>
-                </div>
-                #end
+  <div id="bd">
+    <div id="yui-main">
+      <div id="main" class="yui-b">
+        #if ($login_error && $SPRING_SECURITY_LAST_EXCEPTION)
+          <div id="error-container" style="">
+            <div class="ab-bg">
+              <span class="ab-corner lvl1"></span>
+              <span class="ab-corner lvl2"></span>
+              <span class="ab-corner lvl3"></span>
+              <span class="ab-corner lvl4"></span>
+            </div>
+            <div id="error-box">
+              $SPRING_SECURITY_LAST_EXCEPTION.message.replaceAll(";.*", "")
+              <a target="_blank"
+                 href="https://docs.go.cd/current/configuration/dev_authentication.html#common-errors">Help
+                Topic: Authentication</a>
+            </div>
+            <div class="ab-bg">
+              <span class="ab-corner lvl4"></span>
+              <span class="ab-corner lvl3"></span>
+              <span class="ab-corner lvl2"></span>
+              <span class="ab-corner lvl1"></span>
+            </div>
+          </div>
+        #end
+        <div class='clear-both'><!-- Clear floats --></div>
+        <div id="graphic-dialog-container" style="padding-top:1px">
+          <div id="graphic-dialog" class="graphic-dialog-${edition.getDisplayType()}">
+            <div id="logo-login"><h2>&nbsp;</h2></div>
+            <div id="graphic-dialog-input">
+              <!-- <h3>$l.localize("PLEASE_SIGN_IN")</h3> -->
+              <form action="security_check" id="login_form" method="post">
+                <p>
+                  <label for="user_login">$l.localize("USERNAME")</label>
+                  <input class="" id="user_login" name="j_username" onfocus="true"
+                         type="text"/>
+                </p>
+
+                <p>
+                  <label for="user_password">$l.localize("PASSWORD")</label>
+                  <input class="" type="password" name="j_password" id="user_password"
+                         value=""/>
+                </p>
+
+                <p id="login-actions">
+                  <a target="_blank" href="https://go.cd/help"
+                     title="Click to open help documentation" class="help">$l.localize("HELP_SMALL")</a>
+                ##                                    <input class="default" name="commit" type="submit" id="signin" value="Sign in &#187;"/>
+
+                  <button class="submit_hover submit primary" type="submit" id="signin2" value="Sign in &#187;">
+                    <span>$l.localize("SIGN_IN")</span>
+                  </button>
+
+                </p>
+
                 <div class='clear-both'><!-- Clear floats --></div>
-                <div id="graphic-dialog-container" style="padding-top:1px">
-                    <div id="graphic-dialog" class="graphic-dialog-${edition.getDisplayType()}">
-                        <div id="logo-login"><h2>&nbsp;</h2></div>
-                        <div id="graphic-dialog-input">
-                            <!-- <h3>$l.localize("PLEASE_SIGN_IN")</h3> -->
-                            <form action="security_check" id="login_form" method="post">
-                                <p>
-                                    <label for="user_login">$l.localize("USERNAME")</label>
-                                    <input class="" id="user_login" name="j_username" onfocus="true"
-                                           type="text"/>
-                                </p>
-
-                                <p>
-                                    <label for="user_password">$l.localize("PASSWORD")</label>
-                                    <input class="" type="password" name="j_password" id="user_password"
-                                           value=""/>
-                                </p>
-
-                                <p id="login-actions">
-                                    <a target="_blank" href="https://go.cd/help"
-                                       title="Click to open help documentation" class="help">$l.localize("HELP_SMALL")</a>
-##                                    <input class="default" name="commit" type="submit" id="signin" value="Sign in &#187;"/>
-
-                                    <button class="submit_hover submit primary" type="submit" id="signin2" value="Sign in &#187;">
-                                        <span>$l.localize("SIGN_IN")</span>
-                                    </button>
-
-                                </p>
-
-                                <div class='clear-both'><!-- Clear floats --></div>
-                            </form>
-                        </div>
-
-                        #foreach ($authentication_plugin_id in $authentication_plugin_registry.getPluginsThatSupportsWebBasedAuthentication())
-                            <a href="/go/plugin/interact/$authentication_plugin_id/index"><img src="$authentication_plugin_registry.getDisplayImageURLFor($authentication_plugin_id)" alt="$authentication_plugin_registry.getDisplayNameFor($authentication_plugin_id)" /></a>
-                        #end
-
-                    </div>
-                </div>
-
-               <div id="footer">
-                <ul class="copyright" onclick="dashboard_periodical_executer.stop();">
-                    <li>Copyright &copy; 2016 <a href="http://www.thoughtworks.com/products" target='blank'>ThoughtWorks, Inc.</a>
-                        Licensed under <a href="http://www.apache.org/licenses/LICENSE-2.0" target="_blank">$l.localize("APACHE_LICENSE_2_0")</a>.
-                        Go includes <a href="$req.getContextPath()/NOTICE/cruise_notice_file.pdf" target="_blank">$l.localize("THIRD_PARTY_SOFTWARE")</a>.</li>
-                    <li class="last">$l.localize("GO_VERSION"): #include("admin/admin_version.txt.vm")</li>
-                </ul>
-                <ul class="links">
-                    <li><a target="_blank" href="http://api.go.cd">$l.localize("APIS")</a></li>
-                    <li><a target="_blank" href="http://www.go.cd/community/plugins.html">$l.localize("PLUGINS")</a></li>
-                    <li><a target="_blank" href="http://www.go.cd/community/resources.html">$l.localize("COMMUNITY")</a></li>
-                    <li class="last"><a href="https://go.cd/help" target="_blank">$l.localize("HELP_SMALL")</a></li>
-                </ul>
-                <div class="clear"></div>
-                <script type="text/javascript">
-                    var url = "security_check" + self.document.location.hash;
-                    document.getElementById('login_form').action = url;
-                    document.getElementById('user_login').focus();
-                </script>
+              </form>
             </div>
-            </div>
+
+            #foreach ($authentication_plugin_id in $authentication_plugin_registry.getPluginsThatSupportsWebBasedAuthentication())
+              <a href="/go/plugin/interact/$authentication_plugin_id/index"><img
+                  src="$authentication_plugin_registry.getDisplayImageURLFor($authentication_plugin_id)"
+                  alt="$authentication_plugin_registry.getDisplayNameFor($authentication_plugin_id)"/></a>
+            #end
+
+          </div>
         </div>
+
+        <script type="text/javascript">
+          var url = "security_check" + self.document.location.hash;
+          document.getElementById('login_form').action = url;
+          document.getElementById('user_login').focus();
+        </script>
+      </div>
     </div>
+  </div>
+
+  #parse("shared/_copyright_license_info.vm")
+
 </div>
 </body>
 </html>

--- a/server/webapp/WEB-INF/vm/shared/_copyright_license_info.vm
+++ b/server/webapp/WEB-INF/vm/shared/_copyright_license_info.vm
@@ -1,0 +1,27 @@
+<div id="footer-new-foundation">
+  <footer class="footer">
+    <div class="row">
+      <div class="small-12 medium-6 large-8 columns">
+        <p class="copyright">Copyright &copy; 2016
+          <a href="https://www.thoughtworks.com/products" target="_blank">ThoughtWorks, Inc.</a>
+          Licensed under <a href="https://www.apache.org/licenses/LICENSE-2.0" target="_blank">Apache License, Version 2.0</a>.<br>
+          Go includes <a href="/go/NOTICE/cruise_notice_file.pdf" target="_blank">third-party software</a>.
+          Go Version: #include("admin/admin_version.txt.vm").
+        </p>
+
+      </div>
+      <div class="small-12 medium-6 large-4 columns">
+                    <span class="inline-list social">
+                        <a href="https://twitter.com/goforcd" title="twitter" class="twitter"></a>
+                        <a href="https://github.com/gocd/gocd" title="github" class="github"></a>
+                        <a href="https://groups.google.com/d/forum/go-cd" title="forums" class="forums"></a>
+                        <a href="https://docs.go.cd/current" title="documentation" class="documentation"></a>
+                        <a href="https://www.go.cd/community/plugins.html" title="plugins" class="plugins"></a>
+                        <a href="https://api.go.cd" title="api" class="api"></a>
+                        <a href="$req.getContextPath()/about" title="about" class="server-details"></a>
+                        <a href="$req.getContextPath()/cctray.xml" title="cctray" class="cctray"></a>
+                    </span>
+      </div>
+    </div>
+  </footer>
+</div>

--- a/server/webapp/WEB-INF/vm/shared/_footer.vm
+++ b/server/webapp/WEB-INF/vm/shared/_footer.vm
@@ -14,33 +14,8 @@
  * limitations under the License.
  *************************GO-LICENSE-END***********************************#
 
-            <div id="footer-new-foundation">
-              <footer class="footer">
-                <div class="row">
-                  <div class="small-12 medium-6 large-8 columns">
-                    <p class="copyright">Copyright &copy; 2016
-                      <a href="http://www.thoughtworks.com/products" target="_blank">ThoughtWorks, Inc.</a>
-                      Licensed under <a href="http://www.apache.org/licenses/LICENSE-2.0" target="_blank">Apache License, Version 2.0</a>.<br>
-                      Go includes <a href="/go/NOTICE/cruise_notice_file.pdf" target="_blank">third-party software</a>.
-                      Go Version: #include("admin/admin_version.txt.vm").
-                    </p>
+#parse("shared/_copyright_license_info.vm")
 
-                  </div>
-                  <div class="small-12 medium-6 large-4 columns">
-                    <span class="inline-list social">
-                        <a href="http://twitter.com/goforcd" title="twitter" class="twitter"></a>
-                        <a href="https://github.com/gocd/gocd" title="github" class="github"></a>
-                        <a href="https://groups.google.com/d/forum/go-cd" title="forums" class="forums"></a>
-                        <a href="https://go.cd/current/documentation" title="documentation" class="documentation"></a>
-                        <a href="https://www.go.cd/community/plugins.html" title="plugins" class="plugins"></a>
-                        <a href="https://api.go.cd" title="api" class="api"></a>
-                        <a href="$req.getContextPath()/about" title="about" class="server-details"></a>
-                        <a href="$req.getContextPath()/cctray.xml" title="cctray" class="cctray"></a>
-                    </span>
-                  </div>
-                </div>
-              </footer>
-            </div>
         </div>
         <!-- end content -->
 


### PR DESCRIPTION
The login page displayed the old footer. 
<img width="1058" alt="screen shot 2016-07-13 at 8 15 56 pm" src="https://cloud.githubusercontent.com/assets/54427/16807615/bfb26610-4936-11e6-943c-16e9b8e50cde.png">

There was also a problem with the footer getting rendered on modal windows
<img width="920" alt="screen shot 2016-07-13 at 8 16 23 pm" src="https://cloud.githubusercontent.com/assets/54427/16807632/d16b6a32-4936-11e6-8ce6-3d91d93d6ae8.png">

This fix updates the login page to
<img width="1050" alt="screen shot 2016-07-13 at 8 18 17 pm" src="https://cloud.githubusercontent.com/assets/54427/16807674/fc150cca-4936-11e6-85cd-ee1914e7088a.png">

And displays the modal without including the footer (improves the modal load time as it now fetched and renders only the fragment).
<img width="790" alt="screen shot 2016-07-13 at 8 19 57 pm" src="https://cloud.githubusercontent.com/assets/54427/16807735/359c45ee-4937-11e6-8d5f-9fff2085ccf7.png">



