### PR TITLE
[config repos] Enhancement: pipeline material same as config repo in xml

### DIFF
--- a/config/config-api/src/com/thoughtworks/go/config/materials/AbstractMaterialConfig.java
+++ b/config/config-api/src/com/thoughtworks/go/config/materials/AbstractMaterialConfig.java
@@ -135,6 +135,7 @@ public abstract class AbstractMaterialConfig implements MaterialConfig, ParamsAt
 
     protected abstract void appendPipelineUniqueCriteria(Map<String, Object> basicCriteria);
 
+    @Override
     public void setName(final CaseInsensitiveString name) {
         this.name = name;
     }

--- a/config/config-api/src/com/thoughtworks/go/domain/materials/MaterialConfig.java
+++ b/config/config-api/src/com/thoughtworks/go/domain/materials/MaterialConfig.java
@@ -30,6 +30,8 @@ public interface MaterialConfig extends Serializable, Validatable {
 
     CaseInsensitiveString getName();
 
+    void setName(CaseInsensitiveString name);
+
     Filter filter();
 
     boolean isInvertFilter();

--- a/config/config-server/src/com/thoughtworks/go/config/PartialConfigLoadContext.java
+++ b/config/config-server/src/com/thoughtworks/go/config/PartialConfigLoadContext.java
@@ -16,7 +16,9 @@
 package com.thoughtworks.go.config;
 
 import com.thoughtworks.go.domain.config.Configuration;
+import com.thoughtworks.go.domain.materials.MaterialConfig;
 
 public interface PartialConfigLoadContext {
     Configuration configuration();
+    MaterialConfig configMaterial();
 }

--- a/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/configrepo/codec/MaterialTypeAdapter.java
+++ b/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/configrepo/codec/MaterialTypeAdapter.java
@@ -40,6 +40,8 @@ public class MaterialTypeAdapter implements JsonDeserializer<CRMaterial>, JsonSe
             return CRP4Material.class;
         if(typeName.equals(CRTfsMaterial.TYPE_NAME))
             return CRTfsMaterial.class;
+        if(typeName.equals(CRConfigMaterial.TYPE_NAME))
+            return CRConfigMaterial.class;
         else
             throw new JsonParseException(
                     String.format("Invalid or unknown material type '%s'",typeName));

--- a/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/configrepo/contract/material/CRConfigMaterial.java
+++ b/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/configrepo/contract/material/CRConfigMaterial.java
@@ -1,0 +1,70 @@
+package com.thoughtworks.go.plugin.access.configrepo.contract.material;
+
+import com.thoughtworks.go.plugin.access.configrepo.ErrorCollection;
+
+public class CRConfigMaterial extends CRMaterial {
+    public static final String TYPE_NAME = "configrepo";
+
+    private String destination;
+
+    public CRConfigMaterial() {
+        type = TYPE_NAME;
+    }
+    public CRConfigMaterial(String name, String destination) {
+        super(TYPE_NAME,name);
+        this.destination = destination;
+    }
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        CRConfigMaterial that = (CRConfigMaterial)o;
+        if(that == null)
+            return  false;
+
+        if(!super.equals(that))
+            return false;
+
+        if (destination != null ? !destination.equals(that.destination) : that.destination != null) {
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + (destination != null ? destination.hashCode() : 0);
+        return result;
+    }
+
+    @Override
+    public String typeName() {
+        return TYPE_NAME;
+    }
+
+    @Override
+    public void getErrors(ErrorCollection errors, String parentLocation) {
+        // no errors possible
+    }
+
+    @Override
+    public String getLocation(String parent) {
+        String myLocation = getLocation() == null ? parent : getLocation();
+        String name = getName() == null ? "" : getName();
+        return String.format("%s; Config material %s",myLocation,name);
+    }
+
+    public String getDestination() {
+        return destination;
+    }
+
+    public void setDestination(String destination) {
+        this.destination = destination;
+    }
+}

--- a/plugin-infra/go-plugin-access/test/com/thoughtworks/go/plugin/access/configrepo/contract/material/CRConfigMaterialTest.java
+++ b/plugin-infra/go-plugin-access/test/com/thoughtworks/go/plugin/access/configrepo/contract/material/CRConfigMaterialTest.java
@@ -1,0 +1,50 @@
+package com.thoughtworks.go.plugin.access.configrepo.contract.material;
+
+import com.google.gson.JsonObject;
+import com.thoughtworks.go.plugin.access.configrepo.contract.CRBaseTest;
+import org.junit.Test;
+
+import java.util.Map;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+
+public class CRConfigMaterialTest extends CRBaseTest<CRConfigMaterial> {
+    private final CRConfigMaterial named;
+    private final CRConfigMaterial namedDest;
+
+    public CRConfigMaterialTest() {
+        named = new CRConfigMaterial("primary", null);
+        namedDest = new CRConfigMaterial("primary", "folder");
+    }
+
+    @Override
+    public void addGoodExamples(Map<String, CRConfigMaterial> examples) {
+        examples.put("namedExample", named);
+        examples.put("namedDest", namedDest);
+    }
+
+    @Override
+    public void addBadExamples(Map<String, CRConfigMaterial> examples) {
+    }
+
+    @Test
+    public void shouldAppendTypeFieldWhenSerializingMaterials()
+    {
+        CRMaterial value = named;
+        JsonObject jsonObject = (JsonObject)gson.toJsonTree(value);
+        assertThat(jsonObject.get("type").getAsString(), is(CRConfigMaterial.TYPE_NAME));
+    }
+
+    @Test
+    public void shouldHandlePolymorphismWhenDeserializing()
+    {
+        CRMaterial value = named;
+        String json = gson.toJson(value);
+
+        CRConfigMaterial deserializedValue = (CRConfigMaterial)gson.fromJson(json,CRMaterial.class);
+        assertThat(String.format("Deserialized value should equal to value before serialization"),
+                deserializedValue,is(value));
+    }
+
+}

--- a/server/src/com/thoughtworks/go/config/ConfigRepoPlugin.java
+++ b/server/src/com/thoughtworks/go/config/ConfigRepoPlugin.java
@@ -44,7 +44,7 @@ public class ConfigRepoPlugin implements PartialConfigProvider {
     public PartialConfig load(File configRepoCheckoutDirectory, PartialConfigLoadContext context) {
         Collection<CRConfigurationProperty> cRconfigurations = getCrConfigurations(context.configuration());
         CRParseResult crPartialConfig = parseDirectory(configRepoCheckoutDirectory, cRconfigurations);
-        return configConverter.toPartialConfig(crPartialConfig);
+        return configConverter.toPartialConfig(crPartialConfig, context);
     }
 
     @Override

--- a/server/src/com/thoughtworks/go/config/GoRepoConfigDataSource.java
+++ b/server/src/com/thoughtworks/go/config/GoRepoConfigDataSource.java
@@ -250,5 +250,10 @@ public class GoRepoConfigDataSource implements ChangedRepoConfigWatchListListene
         public Configuration configuration() {
             return repoConfig.getConfiguration();
         }
+
+        @Override
+        public MaterialConfig configMaterial() {
+            return this.repoConfig.getMaterialConfig();
+        }
     }
 }


### PR DESCRIPTION
## Behavior changes

When user has configured a config repo in XML as such
```xml
<config-repos>
   <config-repo plugin="json.config.plugin">
     <git url="https://github.com/tomzo/gocd-json-config-example.git" branch="ci" />
   </config-repo>
</config-repos>
```
Then server uses that information only to fetch pipelines configuration from that git repository.
There is a **common case** when above repository contains pipelines whose scm material is exactly the same as config repo above (both `url` and `branch`). Without this PR it means user has to declare materials in pipelines in `https://github.com/tomzo/gocd-json-config-example.git` in JSON as such
```json
...
  "materials": [
    {
      "url": "https://github.com/tomzo/gocd-json-config-example.git",
      "branch" : "ci",
      "type": "git",
      "name" : "mygit"
    }
  ],
...
```

This is repetition of material already specified in xml. We can suspect that what user actually needs is to say that pipeline material is the same as *material* of the config repository. So with this PR user can specify this instead:
```json
...
  "materials": [
    {
      "type": "configrepo",
       "name" : "mygit"
    }
  ],
...
```

## Implementation

There are 2 ways to solves this - long and short, I used short way. config repo plugin can return new material type `configrepo` now:
```
{
   "name" : "something-optional",
   "destination" : "optional-folder",
   "type" : "configrepo"
}
```
which is understood by server as a message to
> clone the material config of repository we are parsing from as is in XML with all its attributes and replace name and destination, use that in place of material returned by plugin.

Longer method is to send current config repo material as JSON to plugin in the parse request, then plugin can do whatever it wants with config repo material (e.g. like change branch) and return it back.
That requires to implement serializing all scm materials to json format as in CR classes. We can still do that later, I think. I just don't see any benefit yet.

CC: @arvindsv this is my idea of `material-url-same-as-config-repo-url` (https://gitter.im/gocd/gocd?at=5774396a632b75030faf6963)

#### Edit 1

Added `destination` too