### PR TITLE
Removed setting of user.dir property in tests. Changes the working directory for subsequent tests.

### DIFF
--- a/common/src/com/thoughtworks/go/util/validators/JettyWorkDirValidator.java
+++ b/common/src/com/thoughtworks/go/util/validators/JettyWorkDirValidator.java
@@ -22,14 +22,23 @@ import java.io.IOException;
 import static java.text.MessageFormat.format;
 
 import com.thoughtworks.go.util.SystemEnvironment;
-import com.thoughtworks.go.util.validators.Validation;
-import com.thoughtworks.go.util.validators.Validator;
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang.StringUtils;
 
 public class JettyWorkDirValidator implements Validator {
+
+    private SystemEnvironment systemEnvironment;
+
+    public JettyWorkDirValidator() {
+        this(new SystemEnvironment());
+    }
+
+    protected JettyWorkDirValidator(SystemEnvironment systemEnvironment) {
+        this.systemEnvironment = systemEnvironment;
+    }
+
     public Validation validate(Validation val) {
-        SystemEnvironment systemEnvironment = new SystemEnvironment();
-        if (SystemEnvironment.getProperty("jetty.home", "").equals("")) {
+        if (StringUtils.isBlank(systemEnvironment.getPropertyImpl("jetty.home"))) {
             systemEnvironment.setProperty("jetty.home", systemEnvironment.getPropertyImpl("user.dir"));
         }
         systemEnvironment.setProperty("jetty.base", systemEnvironment.getPropertyImpl("jetty.home"));


### PR DESCRIPTION
Setting some system properties in tests affects the subsequent tests that are executed. There were some tests in ```FileUtilTest.java``` that are dependent on the current working directory's path. If the working dir, set by ```user.dir``` in ```JettyWorkDirValidatorTest``` is something that doesn't exist, it can cause issues while other tests. 