### PR TITLE
Escaping commit message (#1383)

### DIFF
--- a/server/webapp/WEB-INF/rails.new/app/views/pipelines/material_search.html.erb
+++ b/server/webapp/WEB-INF/rails.new/app/views/pipelines/material_search.html.erb
@@ -4,7 +4,7 @@
             <div class="revision" title="<%= matched_revision.getLongRevision() %>"><%= matched_revision.getShortRevision() %></div>
             <div class="user"><%= matched_revision.getUser().blank? ? "anonymous" : h(matched_revision.getUser()) %></div>
             <div class="date"><%= matched_revision.getCheckinTime().display_time %></div>
-            <div class="comment"><%= truncate(h(render_simple_comment(matched_revision.getComment())), :length => 40) %></div>
+            <div class="comment"><%= truncate(render_simple_comment(matched_revision.getComment()), :length => 40) %></div>
         </li>
     <% end %>
 </ul>


### PR DESCRIPTION
Happening Because of double escaping of text

Before:
<img width="765" alt="screen shot 2016-07-14 at 7 03 42 pm" src="https://cloud.githubusercontent.com/assets/15275847/16841294/2f7def04-49f6-11e6-9fe1-e4e824e49c51.png">

now:
<img width="760" alt="screen shot 2016-07-14 at 7 04 11 pm" src="https://cloud.githubusercontent.com/assets/15275847/16841299/3464d000-49f6-11e6-8865-907e417d8806.png">
