### PR TITLE
Group Admins can access PluginInfo API and changed the route#1873

### DIFF
--- a/server/webapp/WEB-INF/applicationContext-acegi-security.xml
+++ b/server/webapp/WEB-INF/applicationContext-acegi-security.xml
@@ -266,6 +266,7 @@
                 /api/admin/pipelines=ROLE_SUPERVISOR,ROLE_GROUP_SUPERVISOR
                 /api/admin/pipelines/*=ROLE_SUPERVISOR,ROLE_GROUP_SUPERVISOR
                 /api/admin/scms/**=ROLE_SUPERVISOR, ROLE_GROUP_SUPERVISOR
+                /api/admin/plugin_info/**=ROLE_SUPERVISOR, ROLE_GROUP_SUPERVISOR
                 /api/admin/**=ROLE_SUPERVISOR
                 /api/config-repository.git/**=ROLE_SUPERVISOR
                 /api/jobs/scheduled.xml=ROLE_SUPERVISOR

--- a/server/webapp/WEB-INF/rails.new/app/assets/new_javascripts/models/pipeline_configs/plugin_infos.js
+++ b/server/webapp/WEB-INF/rails.new/app/assets/new_javascripts/models/pipeline_configs/plugin_infos.js
@@ -19,12 +19,12 @@ define(['mithril', 'lodash', 'string-plus', 'helpers/mrequest'], function (m, _,
 
   PluginInfos.init = function () {
     var unwrap = function (response) {
-      return response._embedded.plugin_infos;
+      return response._embedded.plugin_info;
     };
 
     return m.request({
       method:        'GET',
-      url:           Routes.apiv1AdminPluginInfosPath(),
+      url:           Routes.apiv1AdminPluginInfoIndexPath(),
       background:    true,
       config:        mrequest.xhrConfig.v1,
       unwrapSuccess: unwrap,

--- a/server/webapp/WEB-INF/rails.new/app/presenters/api_v1/plugin/plugin_info_representer.rb
+++ b/server/webapp/WEB-INF/rails.new/app/presenters/api_v1/plugin/plugin_info_representer.rb
@@ -24,7 +24,7 @@ module ApiV1
       end
 
       link :doc do |opts|
-        'http://api.go.cd/#plugin_info'
+        'http://api.go.cd/#plugin-info'
       end
 
       link :find do |opts|

--- a/server/webapp/WEB-INF/rails.new/app/presenters/api_v1/plugin/plugin_infos_representer.rb
+++ b/server/webapp/WEB-INF/rails.new/app/presenters/api_v1/plugin/plugin_infos_representer.rb
@@ -17,17 +17,17 @@
 module ApiV1
   module Plugin
     class PluginInfosRepresenter < BaseRepresenter
-      alias_method :plugin_infos, :represented
+      alias_method :plugin_info, :represented
 
       link :self do |opts|
-        opts[:url_builder].apiv1_admin_plugin_infos_url
+        opts[:url_builder].apiv1_admin_plugin_info_index_url
       end
 
       link :doc do
-        'http://api.go.cd/#plugin_info'
+        'http://api.go.cd/#plugin-info'
       end
 
-      collection :plugin_infos,
+      collection :plugin_info,
                  embedded: true,
                  exec_context: :decorator,
                  decorator: PluginInfoRepresenter

--- a/server/webapp/WEB-INF/rails.new/config/routes.rb
+++ b/server/webapp/WEB-INF/rails.new/config/routes.rb
@@ -234,7 +234,7 @@ Go::Application.routes.draw do
           resources :environments, only: [:index]
           resources :command_snippets, only: [:index]
         end
-        resources :plugin_infos, param: :id, only: [:index, :show], constraints: {id: PLUGIN_ID_FORMAT}
+        resources :plugin_info, controller: 'plugin_infos', param: :id, only: [:index, :show], constraints: {id: PLUGIN_ID_FORMAT}
         resources :scms, param: :material_name, controller: :pluggable_scms, only: [:index, :show, :create, :update], constraints: {material_name: ALLOW_DOTS}
       end
 

--- a/server/webapp/WEB-INF/rails.new/spec/new_javascripts/models/pipeline_configs/plugin_infos_spec.js
+++ b/server/webapp/WEB-INF/rails.new/spec/new_javascripts/models/pipeline_configs/plugin_infos_spec.js
@@ -30,7 +30,7 @@ define(['mithril', 'lodash', "models/pipeline_configs/plugin_infos"], function (
 
       it('should fetch all plugin_infos', function () {
         expect(requestArgs.method).toBe('GET');
-        expect(requestArgs.url).toBe('/go/api/admin/plugin_infos')
+        expect(requestArgs.url).toBe('/go/api/admin/plugin_info')
       });
 
       it('should post required headers', function () {
@@ -145,7 +145,7 @@ define(['mithril', 'lodash', "models/pipeline_configs/plugin_infos"], function (
 
       it('should fetch the plugin for the given id', function () {
         expect(requestArgs.method).toBe('GET');
-        expect(requestArgs.url).toBe('/go/api/admin/plugin_infos/plugin_id')
+        expect(requestArgs.url).toBe('/go/api/admin/plugin_info/plugin_id')
       });
 
       it('should post required headers', function () {

--- a/server/webapp/WEB-INF/rails.new/spec/presenters/api_v1/plugins/plugin_info_representer_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/presenters/api_v1/plugins/plugin_info_representer_spec.rb
@@ -29,9 +29,9 @@ describe ApiV1::Plugin::PluginInfoRepresenter do
     actual_json = ApiV1::Plugin::PluginInfoRepresenter.new(plugin_info).to_hash(url_builder: UrlBuilder.new)
 
     expect(actual_json).to have_links(:self, :find, :doc)
-    expect(actual_json).to have_link(:self).with_url('http://test.host/api/admin/plugin_infos/plugin_id')
-    expect(actual_json).to have_link(:find).with_url('http://test.host/api/admin/plugin_infos/:id')
-    expect(actual_json).to have_link(:doc).with_url('http://api.go.cd/#plugin_info')
+    expect(actual_json).to have_link(:self).with_url('http://test.host/api/admin/plugin_info/plugin_id')
+    expect(actual_json).to have_link(:find).with_url('http://test.host/api/admin/plugin_info/:id')
+    expect(actual_json).to have_link(:doc).with_url('http://api.go.cd/#plugin-info')
 
     actual_json.delete(:_links)
     expect(actual_json).to eq({id:             'plugin_id',

--- a/server/webapp/WEB-INF/rails.new/spec/presenters/api_v1/plugins/plugin_infos_representer_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/presenters/api_v1/plugins/plugin_infos_representer_spec.rb
@@ -23,9 +23,9 @@ describe ApiV1::Plugin::PluginInfosRepresenter do
     actual_json = ApiV1::Plugin::PluginInfosRepresenter.new([plugin_info]).to_hash(url_builder: UrlBuilder.new)
 
     expect(actual_json).to have_links(:self, :doc)
-    expect(actual_json).to have_link(:self).with_url('http://test.host/api/admin/plugin_infos')
-    expect(actual_json).to have_link(:doc).with_url('http://api.go.cd/#plugin_info')
+    expect(actual_json).to have_link(:self).with_url('http://test.host/api/admin/plugin_info')
+    expect(actual_json).to have_link(:doc).with_url('http://api.go.cd/#plugin-info')
     actual_json.delete(:_links)
-    actual_json.fetch(:_embedded).should == { :plugin_infos => [ApiV1::Plugin::PluginInfoRepresenter.new(plugin_info).to_hash(url_builder: UrlBuilder.new)] }
+    actual_json.fetch(:_embedded).should == { :plugin_info => [ApiV1::Plugin::PluginInfoRepresenter.new(plugin_info).to_hash(url_builder: UrlBuilder.new)] }
   end
 end


### PR DESCRIPTION
* 'plugin_infos' seems grammatically wrong, so changing only the route
      to 'api/admin/plugin_info'
* Group Admins were authorized to access this API in rails filter but
  was missed in acegi-security filter, fixed it.
* Fixed links to api docs in json_hal