### PR TITLE
Add the security filter only if it's missing.

### DIFF
--- a/server/src/com/thoughtworks/go/server/web/DefaultHeadersFilter.java
+++ b/server/src/com/thoughtworks/go/server/web/DefaultHeadersFilter.java
@@ -24,18 +24,27 @@ public class DefaultHeadersFilter implements Filter {
     public void destroy() {
     }
 
-    public void doFilter(ServletRequest req, ServletResponse resp, FilterChain chain) throws ServletException, IOException {
-        HttpServletResponse response = (HttpServletResponse) resp;
-
-        response.setHeader("X-XSS-Protection", "1; mode=block");
-        response.setHeader("X-Content-Type-Options", "nosniff");
-        response.setHeader("X-Frame-Options", "SAMEORIGIN");
-        response.setHeader("X-UA-Compatible", "chrome=1");
-
-        chain.doFilter(req, resp);
-    }
-
     public void init(FilterConfig config) throws ServletException {
         // No default config
     }
+
+    public void doFilter(ServletRequest req, ServletResponse resp, FilterChain chain) throws ServletException, IOException {
+        HttpServletResponse response = (HttpServletResponse) resp;
+
+        chain.doFilter(req, resp);
+
+        if (!response.isCommitted()) {
+            addSecureHeader(response, "X-XSS-Protection", "1; mode=block");
+            addSecureHeader(response, "X-Content-Type-Options", "nosniff");
+            addSecureHeader(response, "X-Frame-Options", "SAMEORIGIN");
+            addSecureHeader(response, "X-UA-Compatible", "chrome=1");
+        }
+    }
+
+    private void addSecureHeader(HttpServletResponse response, String securityHeader, String value) {
+        if (!response.containsHeader(securityHeader)) {
+            response.setHeader(securityHeader, value);
+        }
+    }
+
 }

--- a/server/test/unit/com/thoughtworks/go/server/web/DefaultHeadersFilterTest.java
+++ b/server/test/unit/com/thoughtworks/go/server/web/DefaultHeadersFilterTest.java
@@ -25,6 +25,8 @@ import javax.servlet.ServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 
 public class DefaultHeadersFilterTest {
@@ -35,21 +37,33 @@ public class DefaultHeadersFilterTest {
     private FilterChain chain;
     @Mock
     private ServletRequest request;
+    private DefaultHeadersFilter filter;
 
     @Before
     public void setUp() throws Exception {
         initMocks(this);
+        filter = new DefaultHeadersFilter();
     }
 
     @Test
     public void shouldAddDefaultHeaders() throws Exception {
-        DefaultHeadersFilter filter = new DefaultHeadersFilter();
         filter.doFilter(request, response, chain);
 
+        verify(response).isCommitted();
         verify(response).setHeader("X-XSS-Protection", "1; mode=block");
         verify(response).setHeader("X-Content-Type-Options", "nosniff");
         verify(response).setHeader("X-Frame-Options", "SAMEORIGIN");
         verify(response).setHeader("X-UA-Compatible", "chrome=1");
+    }
+
+    @Test
+    public void shouldNotAddDefaultHeadersIfResponseIsCommitted() throws Exception {
+        when(response.isCommitted()).thenReturn(true);
+
+        filter.doFilter(request, response, chain);
+
+        verify(response).isCommitted();
+        verifyNoMoreInteractions(response);
     }
 
     @Test

--- a/server/webapp/WEB-INF/web.xml
+++ b/server/webapp/WEB-INF/web.xml
@@ -26,13 +26,13 @@
   </context-param>
 
   <filter>
-    <filter-name>Redirect During Backup</filter-name>
-    <filter-class>com.thoughtworks.go.server.web.BackupFilter</filter-class>
+    <filter-name>Default headers filter</filter-name>
+    <filter-class>com.thoughtworks.go.server.web.DefaultHeadersFilter</filter-class>
   </filter>
 
   <filter>
-    <filter-name>Default headers filter</filter-name>
-    <filter-class>com.thoughtworks.go.server.web.DefaultHeadersFilter</filter-class>
+    <filter-name>Redirect During Backup</filter-name>
+    <filter-class>com.thoughtworks.go.server.web.BackupFilter</filter-class>
   </filter>
 
   <filter>
@@ -55,12 +55,12 @@
   </filter>
 
   <filter-mapping>
-    <filter-name>Redirect During Backup</filter-name>
+    <filter-name>Default headers filter</filter-name>
     <url-pattern>/*</url-pattern>
   </filter-mapping>
 
   <filter-mapping>
-    <filter-name>Default headers filter</filter-name>
+    <filter-name>Redirect During Backup</filter-name>
     <url-pattern>/*</url-pattern>
   </filter-mapping>
 


### PR DESCRIPTION
This is to avoid adding the header twice as Rails writes it to the response.