### PR TITLE
Throw server health messages only when it is required

### DIFF
--- a/server/src/com/thoughtworks/go/server/service/ServerConfigService.java
+++ b/server/src/com/thoughtworks/go/server/service/ServerConfigService.java
@@ -31,6 +31,7 @@ import com.thoughtworks.go.server.service.result.LocalizedResult;
 import com.thoughtworks.go.server.web.BaseUrlProvider;
 import com.thoughtworks.go.validators.HostNameValidator;
 import com.thoughtworks.go.validators.PortValidator;
+import org.apache.commons.lang.StringUtils;
 import org.apache.commons.validator.EmailValidator;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.ldap.DefaultSpringSecurityContextSource;
@@ -182,6 +183,10 @@ public class ServerConfigService implements BaseUrlProvider {
         return serverConfig().getAgentAutoRegisterKey();
     }
 
+    public boolean hasAutoregisterKey() {
+        return StringUtils.isNotBlank(getAutoregisterKey());
+    }
+
     public boolean hasAnyUrlConfigured() {
         return serverConfig().hasAnyUrlConfigured();
     }
@@ -189,5 +194,4 @@ public class ServerConfigService implements BaseUrlProvider {
     public Long elasticJobStarvationThreshold() {
         return serverConfig().getElasticConfig().getJobStarvationThreshold();
     }
-
 }

--- a/server/test/unit/com/thoughtworks/go/server/service/ElasticAgentPluginServiceTest.java
+++ b/server/test/unit/com/thoughtworks/go/server/service/ElasticAgentPluginServiceTest.java
@@ -45,7 +45,6 @@ import org.springframework.util.LinkedMultiValueMap;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Date;
 import java.util.List;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -101,7 +100,7 @@ public class ElasticAgentPluginServiceTest {
     @Test
     public void shouldNotCreateAgentIfAutoRegisterIsNotSetup() {
         JobPlan plan = plan(1);
-        when(serverConfigService.getAutoregisterKey()).thenReturn(null);
+        when(serverConfigService.hasAutoregisterKey()).thenReturn(false);
         ArgumentCaptor<ServerHealthState> captor = ArgumentCaptor.forClass(ServerHealthState.class);
 
         service.createAgentsFor(new ArrayList<JobPlan>(), Arrays.asList(plan));
@@ -114,6 +113,7 @@ public class ElasticAgentPluginServiceTest {
 
     @Test
     public void shouldCreateAgentForNewlyAddedJobPlansOnly() {
+        when(serverConfigService.hasAutoregisterKey()).thenReturn(true);
         JobPlan plan1 = plan(1);
         JobPlan plan2 = plan(2);
         ArgumentCaptor<ServerHealthState> captorForHealthState = ArgumentCaptor.forClass(ServerHealthState.class);
@@ -136,6 +136,7 @@ public class ElasticAgentPluginServiceTest {
 
     @Test
     public void shouldRetryCreateAgentForJobThatHasBeenWaitingForAnAgentForALongTime() {
+        when(serverConfigService.hasAutoregisterKey()).thenReturn(true);
         when(serverConfigService.elasticJobStarvationThreshold()).thenReturn(0L);
         JobPlan plan1 = plan(1);
         ArgumentCaptor<ServerHealthState> captorForHealthState = ArgumentCaptor.forClass(ServerHealthState.class);


### PR DESCRIPTION
Also clear out the server health messages when -
* jobs are not starved of agents
* server `autoregisterKey` is added to the config