### PR TITLE
#1133 fix CRTimer mapping to TimerConfig

### DIFF
--- a/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/configrepo/contract/CRTimer.java
+++ b/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/configrepo/contract/CRTimer.java
@@ -12,7 +12,7 @@ public class CRTimer extends CRBase {
     {
         this.spec = timerSpec;
     }
-    public CRTimer(String timerSpec, boolean onlyOnChanges) {
+    public CRTimer(String timerSpec, Boolean onlyOnChanges) {
         this.spec = timerSpec;
         this.only_on_changes = onlyOnChanges;
     }
@@ -25,7 +25,7 @@ public class CRTimer extends CRBase {
         this.spec = timerSpec;
     }
 
-    public boolean isOnlyOnChanges() {
+    public Boolean isOnlyOnChanges() {
         return only_on_changes;
     }
 

--- a/server/src/com/thoughtworks/go/config/ConfigConverter.java
+++ b/server/src/com/thoughtworks/go/config/ConfigConverter.java
@@ -23,6 +23,7 @@ import com.thoughtworks.go.plugin.access.configrepo.contract.*;
 import com.thoughtworks.go.plugin.access.configrepo.contract.material.*;
 import com.thoughtworks.go.plugin.access.configrepo.contract.tasks.*;
 import com.thoughtworks.go.security.GoCipher;
+import com.thoughtworks.go.util.StringUtil;
 import com.thoughtworks.go.util.command.HgUrlArgument;
 import com.thoughtworks.go.util.command.UrlArgument;
 import org.apache.commons.lang.StringUtils;
@@ -514,7 +515,7 @@ public class ConfigConverter {
 
         CRTimer crTimer = crPipeline.getTimer();
         if (crTimer != null) {
-            pipelineConfig.setTimer(new TimerConfig(crTimer.getTimerSpec(), crTimer.isOnlyOnChanges()));
+            pipelineConfig.setTimer(toTimerConfig(crTimer));
         }
 
         EnvironmentVariablesConfig variables = pipelineConfig.getVariables();
@@ -525,6 +526,13 @@ public class ConfigConverter {
         pipelineConfig.setLock(crPipeline.isLocked());
 
         return pipelineConfig;
+    }
+
+    public TimerConfig toTimerConfig(CRTimer crTimer) {
+        String spec = crTimer.getTimerSpec();
+        if(StringUtil.isBlank(spec))
+            throw new RuntimeException("timer schedule is not specified");
+        return new TimerConfig(spec, crTimer.isOnlyOnChanges() == null ? false : crTimer.isOnlyOnChanges());
     }
 
     private MingleConfig toMingleConfig(CRMingle crMingle) {

--- a/server/test/unit/com/thoughtworks/go/config/ConfigConverterTest.java
+++ b/server/test/unit/com/thoughtworks/go/config/ConfigConverterTest.java
@@ -30,6 +30,7 @@ import org.junit.Test;
 
 import java.util.*;
 
+import static junit.framework.TestCase.fail;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsCollectionContaining.hasItem;
 import static org.junit.Assert.assertNotNull;
@@ -763,4 +764,32 @@ public class ConfigConverterTest {
         assertThat(partialConfig.getEnvironments().size(),is(1));
     }
 
+    @Test
+    public void shouldConvertCRTimerWhenAllAssigned(){
+        CRTimer timer = new CRTimer("0 15 * * 6",true);
+        TimerConfig result = configConverter.toTimerConfig(timer);
+        assertThat(result.getTimerSpec(),is("0 15 * * 6"));
+        assertThat(result.getOnlyOnChanges(),is(true));
+    }
+
+    @Test
+    public void shouldConvertCRTimerWhenNullOnChanges(){
+        CRTimer timer = new CRTimer("0 15 * * 6",null);
+        TimerConfig result = configConverter.toTimerConfig(timer);
+        assertThat(result.getTimerSpec(),is("0 15 * * 6"));
+        assertThat(result.getOnlyOnChanges(),is(false));
+    }
+
+    @Test
+    public void shouldFailConvertCRTimerWhenNullSpec(){
+        CRTimer timer = new CRTimer(null,false);
+        try {
+            configConverter.toTimerConfig(timer);
+            fail("should have thrown");
+        }
+        catch(Exception ex)
+        {
+            //ok
+        }
+    }
 }


### PR DESCRIPTION
Minor fix to config repos. If user (plugin) does not return `only_on_changes` in timer specification null pointer would be thrown. This is a fix + tests to cover all `CRTimer` conversion cases.