### PR TITLE
Backups header fix

### DIFF
--- a/server/webapp/WEB-INF/rails.new/config/routes.rb
+++ b/server/webapp/WEB-INF/rails.new/config/routes.rb
@@ -218,7 +218,7 @@ Go::Application.routes.draw do
 
   scope :api, as: :apiv1, format: false do
     api_version(:module => 'ApiV1', header: {name: 'Accept', value: 'application/vnd.go.cd.v1+json'}) do
-      resources :backups, only: [:create]
+      resources :backups, only: [:create], constraints: HeaderConstraint.new
 
       resources :users, param: :login_name, only: [:create, :index, :show, :destroy], constraints: {login_name: /(.*?)/} do
         patch :update, on: :member


### PR DESCRIPTION
Since, we will anyway break the backups API with the custom header, thought we could also change the url by moving it to admin namespace. 

Old URL: ```http://localhost:8153/go/api/backups```
New URL: ```http://localhost:8153/go/api/admin/backups```

Custom Header: ```'Confirm:true'```

Is this okay or not? 