### PR TITLE
Use 'command' instead of 'which' to auto detect java

### DIFF
--- a/installers/go-agent/release/agent.sh
+++ b/installers/go-agent/release/agent.sh
@@ -54,7 +54,7 @@ location of your Java installation."
       fi
   else
       java_cmd="java"
-      which java >/dev/null 2>&1 || die "ERROR: GO_JAVA_HOME is not set and no 'java' command could be found in your PATH.
+      command -v java >/dev/null 2>&1 || die "ERROR: GO_JAVA_HOME is not set and no 'java' command could be found in your PATH.
 
 Please set the GO_JAVA_HOME variable in your environment to match the
 location of your Java installation."

--- a/installers/go-server/release/server.sh
+++ b/installers/go-server/release/server.sh
@@ -53,7 +53,7 @@ location of your Java installation."
       fi
   else
       java_cmd="java"
-      which java >/dev/null 2>&1 || die "ERROR: GO_JAVA_HOME is not set and no 'java' command could be found in your PATH.
+      command -v java >/dev/null 2>&1 || die "ERROR: GO_JAVA_HOME is not set and no 'java' command could be found in your PATH.
 
 Please set the GO_JAVA_HOME variable in your environment to match the
 location of your Java installation."


### PR DESCRIPTION
There's a lot of info about why here
http://unix.stackexchange.com/questions/85249/why-not-use-which-what-to-use-then

Also, base images on centos or redhat don't have ```which``` command.