### PR TITLE
Used fixed delay instead rate execution of agent ping thread.

### DIFF
--- a/agent/resources/applicationContext.xml
+++ b/agent/resources/applicationContext.xml
@@ -102,7 +102,6 @@
                 <bean class="org.springframework.scheduling.timer.ScheduledTimerTask"
                       p:delay="${agent.ping.delay}"
                       p:period="${agent.ping.interval}"
-                      p:fixedRate="true"
                       p:timerTask-ref="agentControllerPinger"/>
             </list>
         </property>


### PR DESCRIPTION
This should ease load on the server immediately after a network outage.