### PR TITLE
Environment Update use the loaded md5

### DIFF
--- a/server/webapp/WEB-INF/rails.new/app/controllers/environments_controller.rb
+++ b/server/webapp/WEB-INF/rails.new/app/controllers/environments_controller.rb
@@ -55,8 +55,7 @@ class EnvironmentsController < ApplicationController
 
     old_environment = environment_config_service.getEnvironmentConfig(params[:name])
     result = HttpLocalizedOperationResult.new
-    md5 = entity_hashing_service.md5ForEntity(old_environment, old_environment.name.to_s)
-    environment_config_service.updateEnvironment(old_environment, @environment, current_user, md5, result)
+    environment_config_service.updateEnvironment(old_environment, @environment, current_user, params[:cruise_config_md5], result)
 
     message = result.message(Spring.bean('localizer'))
     if result.isSuccessful()
@@ -93,6 +92,7 @@ class EnvironmentsController < ApplicationController
     env_for_edit = environment_config_service.forEdit(params[:name], result)
     if (result.isSuccessful())
       @environment = env_for_edit.getConfigElement()
+      @cruise_config_md5 = entity_hashing_service.md5ForEntity(@environment, @environment.name.to_s)
     end
     render_if_error(result.message(Spring.bean('localizer')), result.httpCode())
     result.isSuccessful()

--- a/server/webapp/WEB-INF/rails.new/app/views/environments/edit_agents.html.erb
+++ b/server/webapp/WEB-INF/rails.new/app/views/environments/edit_agents.html.erb
@@ -1,4 +1,5 @@
 <%= render :partial => "edit_before.html", :locals => {:scope => {:environment => @environment}} %>
 <%= render :partial => "edit_agents", :locals => {:scope => {:environment => @environment, :agents => @agents}} %>
+<%= config_md5_field %>
 <%= register_defaultable_list("environment>agents") %>
 <%= render :partial => "edit_after.html" %>

--- a/server/webapp/WEB-INF/rails.new/app/views/environments/edit_pipelines.html.erb
+++ b/server/webapp/WEB-INF/rails.new/app/views/environments/edit_pipelines.html.erb
@@ -1,4 +1,5 @@
 <%= render :partial => "edit_before.html", :locals => {:scope => {:environment => @environment}} %>
 <%= render :partial => "edit_pipelines", :locals => {:scope => {:environment => @environment, :unavailable_pipelines => @unavailable_pipelines,:remote_pipelines => @remote_pipelines, :available_pipelines => @available_pipelines}} %>
+<%= config_md5_field %>
 <%= register_defaultable_list("environment>pipelines") %>
 <%= render :partial => "edit_after.html" %>

--- a/server/webapp/WEB-INF/rails.new/app/views/environments/edit_variables.html.erb
+++ b/server/webapp/WEB-INF/rails.new/app/views/environments/edit_variables.html.erb
@@ -1,6 +1,7 @@
 <%= form_for @environment, {as: :environment, url: environment_update_path, html: {method: :put, onsubmit: "return AjaxForm.jquery_ajax_submit(this);"}} do |f| %>
     <%= flash_message_pane_start("env_form_error_box", true) %>
     <%= render :partial => "edit_environment_variables", :locals => {:scope => {:environment => @environment, :form => f}} %>
+    <%= config_md5_field %>
     <%= register_defaultable_list("environment>variables") %>
     <%= render :partial => "shared/form_buttons.html", :locals => {:scope => {:submit_label => "Save"}} %>
 <% end %>

--- a/server/webapp/WEB-INF/rails.new/spec/views/environments/edit_agents_html_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/views/environments/edit_agents_html_spec.rb
@@ -26,4 +26,10 @@ describe "environments/edit_agents.html.erb" do
 
     view.stub(:cruise_config_md5).and_return("foo_bar_baz")
   end
+
+  it "should have cruise_config_md5 as part of output" do
+    stub_template "environments/_edit_agents.html.erb" => "DUMMY"
+    render
+    expect(response.body).to have_selector("form input[type='hidden'][name='cruise_config_md5'][value='foo_bar_baz']")
+  end
 end

--- a/server/webapp/WEB-INF/rails.new/spec/views/environments/edit_pipelines_html_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/views/environments/edit_pipelines_html_spec.rb
@@ -26,4 +26,10 @@ describe "environments/edit_pipelines.html.erb" do
 
     view.stub(:cruise_config_md5).and_return("foo_bar_baz")
   end
+
+  it "should have cruise_config_md5 as part of output" do
+    stub_template "environments/_edit_pipelines.html.erb" => "DUMMY"
+    render
+    expect(response.body).to have_selector("form input[type='hidden'][name='cruise_config_md5'][value='foo_bar_baz']")
+  end
 end

--- a/server/webapp/WEB-INF/rails.new/spec/views/environments/edit_variables_html_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/views/environments/edit_variables_html_spec.rb
@@ -37,6 +37,10 @@ describe "environments/edit_variables.html.erb" do
     end
   end
 
+  it "should have cruise_config_md5 as part of output" do
+    expect(response.body).to have_selector("form input[type='hidden'][name='cruise_config_md5'][value='foo_bar_baz']")
+  end
+
   it "should have a template for newly added environment variables" do
     Capybara.string(response.body).find('div.plain-text-variables tbody.template', visible: false).tap do |template|
       expect(template).to have_selector("input.environment_variable_name[name='environment[variables][][name]']", visible: false)


### PR DESCRIPTION
for every edit environment request, initially we were getting the md5 of environment from hashing_service, which will give the latest md5_etag everytime,

Now the md5 is injected at the time of edit_page load
And at the time of edit_environment_request we are reading it from the parameters
