### PR TITLE
Integrate dependency checker into gradle build

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -26,8 +26,11 @@ buildscript {
 
   dependencies {
     classpath group: 'org.jruby', name: 'jruby-complete', version: '1.7.11'
+    classpath 'org.owasp:dependency-check-gradle:+'
   }
 }
+
+apply plugin: 'org.owasp.dependencycheck'
 
 configurations {
   warConfig


### PR DESCRIPTION
To generate report, from the root folder run

```
$ gradle server:dependencyCheck --info
```