### PR TITLE
Rate limit `git gc --aggressive` activity.

### DIFF
--- a/development-utility/development-server/src/com/thoughtworks/go/server/DevelopmentServer.java
+++ b/development-utility/development-server/src/com/thoughtworks/go/server/DevelopmentServer.java
@@ -88,6 +88,7 @@ public class DevelopmentServer {
         systemEnvironment.set(SystemEnvironment.GO_CONFIG_REPO_PERIODIC_GC, true);
         systemEnvironment.set(SystemEnvironment.GO_CONFIG_REPO_GC_AGGRESSIVE, true);
         systemEnvironment.setProperty("go.config.repo.gc.cron", "0 0/1 * 1/1 * ?");
+        systemEnvironment.setProperty("go.config.repo.gc.min.interval", "1000");
         systemEnvironment.setProperty("go.config.repo.gc.check.interval", "5000");
     }
 

--- a/server/properties/src/cruise.properties
+++ b/server/properties/src/cruise.properties
@@ -27,6 +27,7 @@ go.elasticplugin.heartbeat.interval=60000
 cruise.build.assignment.service.interval=5000
 cruise.config.refresh.interval=5000
 go.config.repo.gc.cron=0 0 7 ? * SUN
+go.config.repo.gc.min.interval=300000
 go.config.repo.gc.check.interval=28800000
 cruise.disk.space.check.interval=5000
 cruise.agent.service.refresh.interval=5000

--- a/server/webapp/WEB-INF/spring-cruise-remoting-servlet.xml
+++ b/server/webapp/WEB-INF/spring-cruise-remoting-servlet.xml
@@ -30,7 +30,7 @@
     <import resource="propertyConfigurer.xml"/>
 
     <task:scheduled-tasks>
-        <task:scheduled ref="configRepository" method="garbageCollect" cron="${go.config.repo.gc.cron}"/>
+        <task:scheduled ref="configRepository" method="garbageCollect" cron="${go.config.repo.gc.cron}" fixed-delay="${go.config.repo.gc.min.interval}" />
         <task:scheduled ref="configRepositoryGCWarningService" method="checkRepoAndAddWarningIfRequired" fixed-delay="${go.config.repo.gc.check.interval}"/>
     </task:scheduled-tasks>
 


### PR DESCRIPTION
This is done to prevent new gc jobs to be executed immediately after on GC completes,
in case users provide a very aggressive GC cron expression (for e.g. every minute)