### PR TITLE
Dropped GET settings request for Task Plugin

### DIFF
--- a/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/common/settings/AbstractExtension.java
+++ b/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/common/settings/AbstractExtension.java
@@ -41,6 +41,11 @@ public abstract class AbstractExtension implements GoPluginExtension {
         return pluginManager.isPluginOfType(this.extensionName, pluginId);
     }
 
+    @Override
+    public String extensionName() {
+        return extensionName;
+    }
+
     public PluginSettingsConfiguration getPluginSettingsConfiguration(String pluginId) {
         return pluginRequestHelper.submitRequest(pluginId, PluginSettingsConstants.REQUEST_PLUGIN_SETTINGS_CONFIGURATION, new DefaultPluginInteractionCallback<PluginSettingsConfiguration>() {
             @Override

--- a/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/common/settings/GoPluginExtension.java
+++ b/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/common/settings/GoPluginExtension.java
@@ -22,6 +22,8 @@ public interface GoPluginExtension {
 
     boolean canHandlePlugin(String pluginId);
 
+    String extensionName();
+
     PluginSettingsConfiguration getPluginSettingsConfiguration(String pluginId);
 
     String getPluginSettingsView(String pluginId);

--- a/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/packagematerial/PackageAsRepositoryExtension.java
+++ b/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/packagematerial/PackageAsRepositoryExtension.java
@@ -104,4 +104,9 @@ public class PackageAsRepositoryExtension implements PackageAsRepositoryExtensio
     public boolean canHandlePlugin(String pluginId) {
         return pluginManager.hasReferenceFor(PackageMaterialProvider.class, pluginId) || pluginManager.isPluginOfType(JsonBasedPackageRepositoryExtension.EXTENSION_NAME, pluginId);
     }
+
+    @Override
+    public String extensionName() {
+        return jsonBasedPackageRepositoryExtension.extensionName();
+    }
 }

--- a/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/pluggabletask/TaskExtension.java
+++ b/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/pluggabletask/TaskExtension.java
@@ -98,4 +98,9 @@ public class TaskExtension implements TaskExtensionContract, GoPluginExtension {
     public boolean canHandlePlugin(String pluginId) {
         return pluginManager.hasReferenceFor(Task.class, pluginId) || pluginManager.isPluginOfType(JsonBasedTaskExtension.TASK_EXTENSION, pluginId);
     }
+
+    @Override
+    public String extensionName() {
+        return JsonBasedTaskExtension.TASK_EXTENSION;
+    }
 }

--- a/plugin-infra/go-plugin-access/test/com/thoughtworks/go/plugin/access/common/settings/PluginSettingsMetadataLoaderTest.java
+++ b/plugin-infra/go-plugin-access/test/com/thoughtworks/go/plugin/access/common/settings/PluginSettingsMetadataLoaderTest.java
@@ -37,8 +37,8 @@ import java.util.UUID;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.*;
 import static org.mockito.MockitoAnnotations.initMocks;
 
 public class PluginSettingsMetadataLoaderTest {
@@ -86,6 +86,7 @@ public class PluginSettingsMetadataLoaderTest {
             pluginDescriptor = new GoPluginDescriptor(UUID.randomUUID().toString(), "1.0", null, null, null, true);
 
             when(extension.canHandlePlugin(pluginDescriptor.id())).thenReturn(true);
+            when(extension.extensionName()).thenReturn("extension-name");
             when(extension.getPluginSettingsConfiguration(pluginDescriptor.id())).thenReturn(configuration);
             when(extension.getPluginSettingsView(pluginDescriptor.id())).thenReturn("template");
 
@@ -93,6 +94,24 @@ public class PluginSettingsMetadataLoaderTest {
 
             verifyMetadataForPlugin(pluginDescriptor.id());
         }
+    }
+
+    @Test
+    public void shouldNotFetchPluginSettingsMetadataForTaskPlugin() throws Exception {
+        PluginSettingsConfiguration configuration = new PluginSettingsConfiguration();
+        configuration.add(new PluginSettingsProperty("k1").with(Property.REQUIRED, true).with(Property.SECURE, false));
+
+        pluginDescriptor = new GoPluginDescriptor(UUID.randomUUID().toString(), "1.0", null, null, null, true);
+
+        when(taskExtension.canHandlePlugin(pluginDescriptor.id())).thenReturn(true);
+        when(taskExtension.extensionName()).thenReturn("task");
+        when(taskExtension.getPluginSettingsView(pluginDescriptor.id())).thenReturn("template");
+
+        metadataLoader.fetchPluginSettingsMetaData(pluginDescriptor);
+
+        verify(taskExtension, never()).getPluginSettingsConfiguration(pluginDescriptor.id());
+        PluginSettingsConfiguration configurationInStore = PluginSettingsMetadataStore.getInstance().configuration(pluginDescriptor.id());
+        assertNull(configurationInStore);
     }
 
     @Test


### PR DESCRIPTION
Dropped following requests for task-plugins: 
- GET-plugin-settings.get-configuration 
- GET-plugin-settings.get-view

GoCD does not supports retrieving plugin settings for task plugins.
