### PR TITLE
[CONFIG_SPA] Enabling new pipeline edit page

### DIFF
--- a/server/resources/available.toggles
+++ b/server/resources/available.toggles
@@ -9,7 +9,7 @@
       {
          "key": "pipeline_config_single_page_app_key",
          "description": "Enables the pipeline config single page application. Default: off.",
-         "value": false
+         "value": true
       },
       {
         "key": "agents_single_page_app_key",

--- a/server/webapp/WEB-INF/rails.new/app/assets/new_javascripts/views/pipeline_configs/cancel_task_widget.js.msx
+++ b/server/webapp/WEB-INF/rails.new/app/assets/new_javascripts/views/pipeline_configs/cancel_task_widget.js.msx
@@ -22,7 +22,7 @@ define([
     controller: function (args) {
       var self = this;
       self.task = args.task;
-      const DEFAULT_TASK_TYPE = 'exec';
+      var DEFAULT_TASK_TYPE = 'exec';
 
 
       this.selected = function (val) {

--- a/server/webapp/WEB-INF/rails.new/app/assets/new_javascripts/views/pipeline_configs/pipeline_config_widget.js.msx
+++ b/server/webapp/WEB-INF/rails.new/app/assets/new_javascripts/views/pipeline_configs/pipeline_config_widget.js.msx
@@ -101,7 +101,7 @@ define([
                 </h1>
               </f.column>
               <f.column size={3}>
-                <a class='toggele-old-view'
+                <a class='toggle-old-view'
                    href={['/go/admin/pipelines/', ctrl.pipeline().name(), '/general'].join('')}>Switch back to old view</a>
               </f.column>
               <f.column size={1}>

--- a/server/webapp/WEB-INF/rails.new/app/assets/new_javascripts/views/pipeline_configs/pipeline_stage_field_widget.js.msx
+++ b/server/webapp/WEB-INF/rails.new/app/assets/new_javascripts/views/pipeline_configs/pipeline_stage_field_widget.js.msx
@@ -43,7 +43,7 @@ define(['mithril', 'lodash', 'jquery', 'string-plus', 'helpers/form_helper', 'jq
       },
 
       vm: function (material) {
-        const PIPELINE_STAGE_PATTERN = /^(.+) \[(.+)\]$/;
+        var PIPELINE_STAGE_PATTERN = /^(.+) \[(.+)\]$/;
         this.material  = material;
         this.errors    = [];
 

--- a/server/webapp/WEB-INF/rails.new/app/assets/new_stylesheets/shared/_common.scss
+++ b/server/webapp/WEB-INF/rails.new/app/assets/new_stylesheets/shared/_common.scss
@@ -37,32 +37,56 @@
 }
 
 .add-button {
-  @include icon-before($type : plus-circle);
+  @include icon-before($type: plus-circle);
 }
 
 //sticky footer
 
-$app-footer-height : 76px;
+$app-footer-height: 76px;
 
 * {
-  margin : 0;
+  margin: 0;
 }
 
 html, body {
-  height : 100%;
+  height: 100%;
 }
 
 .page-wrap {
-  min-height    : 100%;
+  min-height: 100%;
   /* equal to footer height */
-  margin-bottom : -$app-footer-height;
+  margin-bottom: -$app-footer-height;
 }
 
 .page-wrap:after {
-  content : "";
-  display : block;
+  content: "";
+  display: block;
 }
 
 .app-footer, .page-wrap:after {
-  height : $app-footer-height;
+  height: $app-footer-height;
+}
+
+.toggle-old-view {
+  color: #333;
+  display: inline-block;
+  font-size: 13px;
+  margin: 14px 0 0 0;
+  float: right;
+  &:hover {
+    text-decoration: underline;
+  }
+}
+
+.spinner {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  border: 16px solid #f3f3f3; /* Light grey */
+  border-top: 16px solid #963fb7;
+  border-radius: 50%;
+  width: 100px;
+  height: 100px;
+  margin: -50px 0 0 -50px;
+  animation: spin 2s linear infinite;
 }

--- a/server/webapp/WEB-INF/rails.new/app/assets/stylesheets/patterns/titles.scss
+++ b/server/webapp/WEB-INF/rails.new/app/assets/stylesheets/patterns/titles.scss
@@ -69,6 +69,15 @@ h3.entity_title {
   background-position: -12px -10px;
 }
 
+.pipeline_header .toggle-new-view {
+  display: inline-block;
+  margin-left: 10px;
+  color: #333;
+  &:hover{
+    text-decoration: underline;
+  }
+}
+
 
 /**
  * =! MISC NEEDS MIGRATION

--- a/server/webapp/WEB-INF/rails.new/app/helpers/application_helper.rb
+++ b/server/webapp/WEB-INF/rails.new/app/helpers/application_helper.rb
@@ -450,6 +450,10 @@ module ApplicationHelper
     form_remote_tag(options)
   end
 
+  def is_pipeline_config_spa_enabled?
+    Toggles.isToggleOn(Toggles.PIPELINE_CONFIG_SINGLE_PAGE_APP)
+  end
+
   private
   def form_remote_tag(options = {})
     options[:form] = true

--- a/server/webapp/WEB-INF/rails.new/app/views/admin/pipeline_configs/edit.html.erb
+++ b/server/webapp/WEB-INF/rails.new/app/views/admin/pipeline_configs/edit.html.erb
@@ -4,4 +4,5 @@
      data-user-names="<%= @all_users.to_json %>"
      data-role-names="<%= @all_roles.to_json %>"
 >
+  <span class='spinner'/>
 </div>

--- a/server/webapp/WEB-INF/rails.new/app/views/layouts/pipelines/details.html.erb
+++ b/server/webapp/WEB-INF/rails.new/app/views/layouts/pipelines/details.html.erb
@@ -31,6 +31,9 @@
                     <h3 class="title entity_title">
                         <%= link_to @pipeline.name(), pipeline_edit_path(:pipeline_name => params[:pipeline_name], :current_tab => 'general'), :class => 'wrapped_word' %>
                     </h3>
+                  <% if (is_pipeline_config_spa_enabled?) %>
+                      <%= link_to 'Check out the new pipline edit page', edit_admin_pipeline_config_path(:pipeline_name => params[:pipeline_name]), :class => 'toggle-new-view' %>
+                  <% end %>
                 </div>
                 <div class="sub_tabs_container <%= params[:current_tab] -%>">
                     <%= render :partial => "admin/pipelines/pipeline_navigation", :locals=> {:scope=> {:pipeline => @pipeline}} %>


### PR DESCRIPTION
* Enabling pipeline config edit SPA by default, this feature can still
  be turned off using feature toggles.
* Provided links on the old and new edit pages to toggle between views.
* Added loading spinner
* js 'const' not supported by IE9 & IE10, getting rid of it.