### PR TITLE
added support for filter in configrepo material type

### DIFF
--- a/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/configrepo/contract/material/CRConfigMaterial.java
+++ b/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/configrepo/contract/material/CRConfigMaterial.java
@@ -5,16 +5,17 @@ import com.thoughtworks.go.plugin.access.configrepo.ErrorCollection;
 public class CRConfigMaterial extends CRMaterial {
     public static final String TYPE_NAME = "configrepo";
 
+    private CRFilter filter;
     private String destination;
 
     public CRConfigMaterial() {
         type = TYPE_NAME;
     }
-    public CRConfigMaterial(String name, String destination) {
+    public CRConfigMaterial(String name, String destination,CRFilter filter) {
         super(TYPE_NAME,name);
         this.destination = destination;
+        this.filter = filter;
     }
-
 
     @Override
     public boolean equals(Object o) {
@@ -32,6 +33,9 @@ public class CRConfigMaterial extends CRMaterial {
         if (destination != null ? !destination.equals(that.destination) : that.destination != null) {
             return false;
         }
+        if (filter != null ? !filter.equals(that.filter) : that.filter != null) {
+            return false;
+        }
 
         return true;
     }
@@ -40,6 +44,7 @@ public class CRConfigMaterial extends CRMaterial {
     public int hashCode() {
         int result = super.hashCode();
         result = 31 * result + (destination != null ? destination.hashCode() : 0);
+        result = 31 * result + (filter != null ? filter.hashCode() : 0);
         return result;
     }
 
@@ -50,7 +55,9 @@ public class CRConfigMaterial extends CRMaterial {
 
     @Override
     public void getErrors(ErrorCollection errors, String parentLocation) {
-        // no errors possible
+        String location = getLocation(parentLocation);
+        if(this.filter != null)
+            this.filter.getErrors(errors,location);
     }
 
     @Override
@@ -66,5 +73,13 @@ public class CRConfigMaterial extends CRMaterial {
 
     public void setDestination(String destination) {
         this.destination = destination;
+    }
+
+    public void setFilter(CRFilter filter) {
+        this.filter = filter;
+    }
+
+    public CRFilter getFilter() {
+        return filter;
     }
 }

--- a/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/configrepo/contract/material/CRFilter.java
+++ b/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/configrepo/contract/material/CRFilter.java
@@ -31,6 +31,8 @@ public class CRFilter extends CRBase {
         return String.format("%s; Filter",myLocation);
     }
 
+    public boolean isEmpty() { return (whitelist == null || whitelist.isEmpty()) && (ignore == null || ignore.isEmpty()); }
+
     public boolean isWhitelist() {
         return whitelist != null && whitelist.size() > 0;
     }

--- a/plugin-infra/go-plugin-access/test/com/thoughtworks/go/plugin/access/configrepo/contract/material/CRConfigMaterialTest.java
+++ b/plugin-infra/go-plugin-access/test/com/thoughtworks/go/plugin/access/configrepo/contract/material/CRConfigMaterialTest.java
@@ -4,6 +4,8 @@ import com.google.gson.JsonObject;
 import com.thoughtworks.go.plugin.access.configrepo.contract.CRBaseTest;
 import org.junit.Test;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -12,20 +14,32 @@ import static org.hamcrest.core.Is.is;
 public class CRConfigMaterialTest extends CRBaseTest<CRConfigMaterial> {
     private final CRConfigMaterial named;
     private final CRConfigMaterial namedDest;
+    private final CRConfigMaterial blacklist;
+    private final CRConfigMaterial invalidList;
 
     public CRConfigMaterialTest() {
-        named = new CRConfigMaterial("primary", null);
-        namedDest = new CRConfigMaterial("primary", "folder");
+        named = new CRConfigMaterial("primary", null,null);
+        namedDest = new CRConfigMaterial("primary", "folder",null);
+        List<String> patterns = new ArrayList<>();
+        patterns.add("externals");
+        patterns.add("tools");
+        blacklist = new CRConfigMaterial("primary", "folder",new CRFilter(patterns,false));
+
+        CRFilter badFilter = new CRFilter(patterns,false);
+        badFilter.setWhitelistNoCheck(patterns);
+        invalidList = new CRConfigMaterial("primary", "folder",badFilter);
     }
 
     @Override
     public void addGoodExamples(Map<String, CRConfigMaterial> examples) {
         examples.put("namedExample", named);
         examples.put("namedDest", namedDest);
+        examples.put("blacklist", blacklist);
     }
 
     @Override
     public void addBadExamples(Map<String, CRConfigMaterial> examples) {
+        examples.put("invalidList",invalidList);
     }
 
     @Test

--- a/server/src/com/thoughtworks/go/config/ConfigConverter.java
+++ b/server/src/com/thoughtworks/go/config/ConfigConverter.java
@@ -268,6 +268,20 @@ public class ConfigConverter {
                 repoMaterial.setName(new CaseInsensitiveString(crConfigMaterial.getName()));
             if(StringUtils.isNotEmpty(crConfigMaterial.getDestination()))
                 setDestination(repoMaterial,crConfigMaterial.getDestination());
+            if(crConfigMaterial.getFilter() != null && !crConfigMaterial.getFilter().isEmpty()) {
+                if(repoMaterial instanceof ScmMaterialConfig) {
+                    ScmMaterialConfig scmMaterialConfig = (ScmMaterialConfig)repoMaterial;
+                    scmMaterialConfig.setFilter(toFilter(crConfigMaterial.getFilter().getList()));
+                    scmMaterialConfig.setInvertFilter(crConfigMaterial.getFilter().isWhitelist());
+                }
+                else //must be a pluggable SCM
+                {
+                    PluggableSCMMaterialConfig pluggableSCMMaterial = (PluggableSCMMaterialConfig)repoMaterial;
+                    pluggableSCMMaterial.setFilter(toFilter(crConfigMaterial.getFilter().getList()));
+                    if(crConfigMaterial.getFilter().isWhitelist())
+                        throw new ConfigConvertionException("Plugable SCMs do not support whitelisting");
+                }
+            }
             return repoMaterial;
         } else
             throw new ConfigConvertionException(
@@ -321,7 +335,6 @@ public class ConfigConverter {
         String materialName = crScmMaterial.getName();
         if (crScmMaterial instanceof CRGitMaterial) {
             CRGitMaterial git = (CRGitMaterial) crScmMaterial;
-            Filter filter = toFilter(crScmMaterial);
             String gitBranch = git.getBranch();
             if (StringUtils.isBlank(gitBranch))
                 gitBranch = GitMaterialConfig.DEFAULT_BRANCH;


### PR DESCRIPTION
Fixup to #2432 
Originally user(plugin) could return only custom material name and destination:
```json
"materials": [{
        "type": "configrepo",
        "name": "git-pipe",
        "destination": "folder"
    }],
```
This PR adds `filter` field too:
```json
"materials": [{
        "type": "configrepo",
        "name": "git-pipe",
        "destination": "folder",
        "filter": {
            "ignore": [
              "pattern/*"
            ]
          }
    }],
```
For pluggable SCMs whitelisting is not supported yet and server will complain if config repo was from pluggable SCM and filter looks like this:
```json
"materials": [{
        "type": "configrepo",
        "filter": {
            "whitelist": [
              "white_fldr/*"
            ]
          }
    }],
```

