### PR TITLE
Escape the jar URL to allow symbols such as #.

### DIFF
--- a/agent-common/src/com/thoughtworks/go/agent/common/util/JarUtil.java
+++ b/agent-common/src/com/thoughtworks/go/agent/common/util/JarUtil.java
@@ -98,10 +98,11 @@ public class JarUtil {
                 depsDir.mkdirs();
                 String entryBaseName = entryName.replaceAll(".*/", "");
                 File extractedJar = new File(depsDir, entryBaseName);
+                String escapedJarURL = new File(absolutePath).toURI().toURL().toExternalForm();
                 InputStream jarStream = null;
                 FileOutputStream fileOutputStream = null;
                 try {
-                    URL jarUrl = new URL("jar:file:" + absolutePath + "!/" + entryName);
+                    URL jarUrl = new URL("jar:" + escapedJarURL + "!/" + entryName);
                     URLConnection conn = jarUrl.openConnection();
                     conn.setUseCaches(false);
                     jarStream = conn.getInputStream();

--- a/agent-common/test/com/thoughtworks/go/agent/common/JarUtilTest.java
+++ b/agent-common/test/com/thoughtworks/go/agent/common/JarUtilTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2016 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.thoughtworks.go.agent.common.util;
+
+import com.thoughtworks.go.agent.common.util.JarUtil;
+
+import org.junit.Test;
+import org.junit.Before;
+import org.junit.After;
+import static org.junit.Assert.*;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.apache.commons.io.FileUtils;
+
+public class JarUtilTest {
+
+  private static final String PATH_WITH_HASHES = "#hashes#in#path/";
+
+  @Before
+  public void setUp() throws IOException {
+      FileUtils.copyFile(new File("testdata/test-agent.jar"), new File(PATH_WITH_HASHES + "test-agent.jar"));
+  }
+
+  @After
+  public void tearDown() throws IOException {
+      FileUtils.deleteQuietly(new File(PATH_WITH_HASHES + "test-agent.jar"));
+      FileUtils.deleteDirectory(new File(PATH_WITH_HASHES));
+  }
+
+  @Test
+  public void shouldNotThrowMalformedUrlException() throws Exception {
+    String absolutePath =  new File(PATH_WITH_HASHES + "test-agent.jar").getAbsolutePath();
+
+    try {
+      Object agent_launcher = JarUtil.objectFromJar(absolutePath, "Go-Agent-Bootstrap-Class");
+    } catch (Exception e) {
+      fail();
+    }
+  }
+}


### PR DESCRIPTION
I am attempting to run GoCD on Mesos (https://mesos.apache.org/) using persistent volumes which ensure that even if the Mesos task dies, GoCD will recognize the new task as the same Agent and not list the old task as "lost contact".  I ran into an issue, however, since Mesos stores its persistent volumes under a directory path that contains the '#' symbol.  The GoCD utility method objectFromJar could not handle the # symbol, and would omit everything in the string after that point, thus throwing an MalformedUrlException.  This change addresses this issue by properly escaping any symbols such as # that are valid directory paths but have special meaning with an URL.  I am a new contributor, and just signed the CLA.  Thanks!