### PR TITLE
removed agent waiting after successfull registration

### DIFF
--- a/agent/src/com/thoughtworks/go/agent/service/SslInfrastructureService.java
+++ b/agent/src/com/thoughtworks/go/agent/service/SslInfrastructureService.java
@@ -106,10 +106,13 @@ public class SslInfrastructureService {
                 throw e;
             }
 
-            try {
-                Thread.sleep(REGISTER_RETRY_INTERVAL);
-            } catch (InterruptedException e) {
-                // Ok
+            if((!keyEntry.isValid())) {
+                try {
+                    LOGGER.debug("[Agent Registration] Retrieved agent key from Go server is not valid.");
+                    Thread.sleep(REGISTER_RETRY_INTERVAL);
+                } catch (InterruptedException e) {
+                    // Ok
+                }
             }
         }
         LOGGER.info("[Agent Registration] Retrieved registration from Go server.");


### PR DESCRIPTION
Follow up to @ketan's fixes on #2464 

Currently after agent received a valid key, it would wait 5 seconds before continuing. But what was intended is to wait only when key is not valid and registration should be re-attempted.

I haven't solved my problem yet, but I found out this during debugging.
