### PR TITLE
Ensure that opensans gets served in production environment (#2675)

### DIFF
--- a/server/webapp/WEB-INF/rails.new/app/assets/new_stylesheets/_fonts.scss
+++ b/server/webapp/WEB-INF/rails.new/app/assets/new_stylesheets/_fonts.scss
@@ -20,7 +20,7 @@ $opensans-variants: (Bold, BoldItalic, ExtraBold, ExtraBoldItalic, Italic, Light
 
 @each $variant in $opensans-variants {
   @include font-face($font-family: 'OpenSans#{$variant}',
-                     $file-path: font-path('opensans/OpenSans-#{$variant}-webfont'),
-                     $asset-pipeline: false,
+                     $file-path: 'opensans/OpenSans-#{$variant}-webfont',
+                     $asset-pipeline: true,
                      $file-formats: eot woff ttf svg);
 }


### PR DESCRIPTION
The root cause was that we were sending in a font-path which evaluated
to the first open sans font file on disk.