### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,7 +97,7 @@ plugin-infra/go-plugin-infra/target/
 rack_hack/target/
 release/target/
 server-launcher/target/
-server/*.log
+server/*.log*
 server/agent.jar
 server/agent-launcher.jar
 server/artifactsDir/


### PR DESCRIPTION
* When server logs roll over, they become server/go-server.log.1. Ignore that.