### PR TITLE
Improvements to the `EntityHashingService`

### DIFF
--- a/server/src/com/thoughtworks/go/config/update/UpdateEnvironmentCommand.java
+++ b/server/src/com/thoughtworks/go/config/update/UpdateEnvironmentCommand.java
@@ -70,7 +70,7 @@ public class UpdateEnvironmentCommand extends EnvironmentCommand implements Enti
 
     private boolean isRequestFresh(CruiseConfig cruiseConfig) {
         EnvironmentConfig config = cruiseConfig.getEnvironments().find(oldEnvironmentConfig.name());
-        boolean freshRequest =  hashingService.md5ForEntity(config, config.name().toString()).equals(md5);
+        boolean freshRequest =  hashingService.md5ForEntity(config).equals(md5);
         if (!freshRequest) {
             result.stale(LocalizedMessage.string("STALE_RESOURCE_CONFIG", "Environment", oldEnvironmentConfig.name()));
         }

--- a/server/src/com/thoughtworks/go/config/update/UpdatePipelineConfigCommand.java
+++ b/server/src/com/thoughtworks/go/config/update/UpdatePipelineConfigCommand.java
@@ -80,15 +80,15 @@ public class UpdatePipelineConfigCommand implements EntityConfigUpdateCommand<Pi
 
     @Override
     public boolean canContinue(CruiseConfig cruiseConfig) {
-        return canEditPipeline() && isRequestFresh();
+        return canEditPipeline() && isRequestFresh(cruiseConfig);
     }
 
     private boolean canEditPipeline() {
         return goConfigService.canEditPipeline(pipelineConfig.name().toString(), currentUser, result, getPipelineGroup());
     }
 
-    private boolean isRequestFresh() {
-        boolean freshRequest = entityHashingService.md5ForPipelineConfig(pipelineConfig.name().toString()).equals(md5);
+    private boolean isRequestFresh(CruiseConfig cruiseConfig) {
+        boolean freshRequest = entityHashingService.md5ForEntity(cruiseConfig.getPipelineConfigByName(pipelineConfig.name())).equals(md5);
 
         if (!freshRequest) {
             result.stale(LocalizedMessage.string("STALE_RESOURCE_CONFIG", "pipeline", pipelineConfig.name().toString()));

--- a/server/src/com/thoughtworks/go/config/update/UpdateSCMConfigCommand.java
+++ b/server/src/com/thoughtworks/go/config/update/UpdateSCMConfigCommand.java
@@ -55,7 +55,7 @@ public class UpdateSCMConfigCommand extends SCMConfigCommand {
 
     private boolean isRequestFresh(CruiseConfig cruiseConfig) {
         SCM existingSCM = findSCM(cruiseConfig);
-        boolean freshRequest =  entityHashingService.md5ForEntity(existingSCM, existingSCM.getName()).equals(md5);
+        boolean freshRequest =  entityHashingService.md5ForEntity(existingSCM).equals(md5);
         if (!freshRequest) {
             result.stale(LocalizedMessage.string("STALE_RESOURCE_CONFIG", "SCM", globalScmConfig.getName()));
         }

--- a/server/src/com/thoughtworks/go/config/update/UpdateTemplateConfigCommand.java
+++ b/server/src/com/thoughtworks/go/config/update/UpdateTemplateConfigCommand.java
@@ -24,7 +24,6 @@ import com.thoughtworks.go.server.domain.Username;
 import com.thoughtworks.go.server.service.EntityHashingService;
 import com.thoughtworks.go.server.service.GoConfigService;
 import com.thoughtworks.go.server.service.result.LocalizedOperationResult;
-import com.thoughtworks.go.serverhealth.HealthStateType;
 
 public class UpdateTemplateConfigCommand extends TemplateConfigCommand{
     private String md5;
@@ -52,7 +51,7 @@ public class UpdateTemplateConfigCommand extends TemplateConfigCommand{
 
     private boolean isRequestFresh(CruiseConfig cruiseConfig) {
         PipelineTemplateConfig pipelineTemplateConfig = findAddedTemplate(cruiseConfig);
-        boolean freshRequest =  entityHashingService.md5ForEntity(pipelineTemplateConfig, pipelineTemplateConfig.name().toString()).equals(md5);
+        boolean freshRequest =  entityHashingService.md5ForEntity(pipelineTemplateConfig).equals(md5);
         if (!freshRequest) {
             result.stale(LocalizedMessage.string("STALE_RESOURCE_CONFIG", "Template", templateConfig.name()));
         }

--- a/server/test/integration/com/thoughtworks/go/server/service/EnvironmentConfigServiceIntegrationTest.java
+++ b/server/test/integration/com/thoughtworks/go/server/service/EnvironmentConfigServiceIntegrationTest.java
@@ -144,7 +144,7 @@ public class EnvironmentConfigServiceIntegrationTest {
         newUat.addAgent("uuid-1");
         newUat.addEnvironmentVariable("env-three", "THREE");
         HttpLocalizedOperationResult result = new HttpLocalizedOperationResult();
-        String md5 = entityHashingService.md5ForEntity(uat, uat.name().toString());
+        String md5 = entityHashingService.md5ForEntity(uat);
         service.updateEnvironment(uat, newUat, new Username(new CaseInsensitiveString("foo")), md5, result);
         EnvironmentConfig updatedEnv = service.named("prod");
         assertThat(updatedEnv.name(), is(new CaseInsensitiveString("prod")));
@@ -165,7 +165,7 @@ public class EnvironmentConfigServiceIntegrationTest {
         configHelper.addAdmins("super_hero");
         HttpLocalizedOperationResult result = new HttpLocalizedOperationResult();
 
-        String md5 = entityHashingService.md5ForEntity(service.getEnvironmentConfig("foo"), "foo");
+        String md5 = entityHashingService.md5ForEntity(service.getEnvironmentConfig("foo"));
         service.updateEnvironment(service.getEnvironmentConfig("foo"), env("foo-env", new ArrayList<String>(), new ArrayList<Map<String, String>>(), new ArrayList<String>()), new Username(new CaseInsensitiveString("evil_hacker")), md5, result);
         assertThat(result.message(localizer), is("Failed to update environment 'foo'. User 'evil_hacker' does not have permission to update environments"));
     }
@@ -175,7 +175,7 @@ public class EnvironmentConfigServiceIntegrationTest {
         configHelper.addEnvironments("foo-env");
         configHelper.addEnvironments("bar-env");
         HttpLocalizedOperationResult result = new HttpLocalizedOperationResult();
-        String md5 = entityHashingService.md5ForEntity(service.getEnvironmentConfig("bar-env"), "bar-env");
+        String md5 = entityHashingService.md5ForEntity(service.getEnvironmentConfig("bar-env"));
         service.updateEnvironment(service.getEnvironmentConfig("bar-env"), env("foo-env", new ArrayList<String>(), new ArrayList<Map<String, String>>(), new ArrayList<String>()), new Username(new CaseInsensitiveString("any")), md5, result);
         assertThat(result.message(localizer), is("Failed to update environment 'bar-env'. failed to save : Duplicate unique value [foo-env] declared for identity constraint \"uniqueEnvironmentName\" of element \"environments\"."));
     }
@@ -194,7 +194,7 @@ public class EnvironmentConfigServiceIntegrationTest {
     public void shouldReturnBadRequestForUpdateWhenUsingInvalidEnvName_ForNewUpdateEnvironmentMethod_ForNewUpdateEnvironmentMethod() throws NoSuchEnvironmentException {
         configHelper.addEnvironments("foo-env");
         HttpLocalizedOperationResult result = new HttpLocalizedOperationResult();
-        String md5 = entityHashingService.md5ForEntity(service.getEnvironmentConfig("foo-env"), "foo-env");
+        String md5 = entityHashingService.md5ForEntity(service.getEnvironmentConfig("foo-env"));
         service.updateEnvironment(service.getEnvironmentConfig("foo-env"), env("foo env", new ArrayList<String>(), new ArrayList<Map<String, String>>(), new ArrayList<String>()), new Username(new CaseInsensitiveString("any")), md5, result);
         assertThat(result.httpCode(), is(HttpServletResponse.SC_BAD_REQUEST));
         assertThat(result.message(localizer), containsString("Failed to update environment 'foo-env'."));

--- a/server/test/integration/com/thoughtworks/go/server/service/PipelineConfigServicePerformanceTest.java
+++ b/server/test/integration/com/thoughtworks/go/server/service/PipelineConfigServicePerformanceTest.java
@@ -20,7 +20,6 @@ import com.thoughtworks.go.config.*;
 import com.thoughtworks.go.config.materials.MaterialConfigs;
 import com.thoughtworks.go.config.materials.git.GitMaterialConfig;
 import com.thoughtworks.go.domain.ConfigErrors;
-import com.thoughtworks.go.domain.Task;
 import com.thoughtworks.go.server.dao.DatabaseAccessHelper;
 import com.thoughtworks.go.server.domain.Username;
 import com.thoughtworks.go.server.service.result.HttpLocalizedOperationResult;
@@ -144,7 +143,7 @@ public class PipelineConfigServicePerformanceTest {
                 PipelineConfig pipelineConfig = goConfigService.getConfigForEditing().pipelineConfigByName(new CaseInsensitiveString(Thread.currentThread().getName()));
                 pipelineConfig.add(new StageConfig(new CaseInsensitiveString("additional_stage"), new JobConfigs(new JobConfig(new CaseInsensitiveString("addtn_job")))));
                 PerfTimer updateTimer = PerfTimer.start("Saving pipelineConfig : " + pipelineConfig.name());
-                pipelineConfigService.updatePipelineConfig(user, pipelineConfig, entityHashingService.md5ForPipelineConfig(pipelineConfig.name().toString()), result);
+                pipelineConfigService.updatePipelineConfig(user, pipelineConfig, entityHashingService.md5ForEntity(pipelineConfig), result);
                 updateTimer.stop();
                 results.put(Thread.currentThread().getName(), result.isSuccessful());
                 if (!result.isSuccessful()) {

--- a/server/test/unit/com/thoughtworks/go/config/update/UpdateEnvironmentCommandTest.java
+++ b/server/test/unit/com/thoughtworks/go/config/update/UpdateEnvironmentCommandTest.java
@@ -135,7 +135,7 @@ public class UpdateEnvironmentCommandTest {
     public void shouldNotContinueIfTheUserSubmittedStaleEtag() throws Exception {
         UpdateEnvironmentCommand command = new UpdateEnvironmentCommand(goConfigService, oldEnvironmentConfig, newEnvironmentConfig, currentUser, actionFailed, md5, entityHashingService, result);
         when(goConfigService.isAdministrator(currentUser.getUsername())).thenReturn(true);
-        when(entityHashingService.md5ForEntity(oldEnvironmentConfig, oldEnvironmentConfig.name().toString())).thenReturn("foo");
+        when(entityHashingService.md5ForEntity(oldEnvironmentConfig)).thenReturn("foo");
         assertThat(command.canContinue(cruiseConfig), is(false));
         HttpLocalizedOperationResult expectResult = new HttpLocalizedOperationResult();
         expectResult.stale(LocalizedMessage.string("STALE_RESOURCE_CONFIG", "Environment", oldEnvironmentConfig.name()));

--- a/server/test/unit/com/thoughtworks/go/config/update/UpdatePipelineConfigCommandTest.java
+++ b/server/test/unit/com/thoughtworks/go/config/update/UpdatePipelineConfigCommandTest.java
@@ -1,9 +1,10 @@
 package com.thoughtworks.go.config.update;
 
+import com.thoughtworks.go.config.BasicCruiseConfig;
+import com.thoughtworks.go.config.BasicPipelineConfigs;
 import com.thoughtworks.go.config.CruiseConfig;
 import com.thoughtworks.go.config.PipelineConfig;
 import com.thoughtworks.go.helper.PipelineConfigMother;
-import com.thoughtworks.go.i18n.LocalizedMessage;
 import com.thoughtworks.go.server.domain.Username;
 import com.thoughtworks.go.server.service.EntityHashingService;
 import com.thoughtworks.go.server.service.GoConfigService;
@@ -12,10 +13,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import static org.junit.Assert.assertFalse;
-import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 public class UpdatePipelineConfigCommandTest {
 
@@ -42,9 +40,10 @@ public class UpdatePipelineConfigCommandTest {
 
         when(goConfigService.findGroupNameByPipeline(pipelineConfig.name())).thenReturn("group1");
         when(goConfigService.canEditPipeline(pipelineConfig.name().toString(), username, localizedOperationResult, "group1")).thenReturn(true);
-        when(entityHashingService.md5ForPipelineConfig(pipelineConfig.name().toString())).thenReturn("latest_md5");
+        when(entityHashingService.md5ForEntity(pipelineConfig)).thenReturn("latest_md5");
 
-        assertFalse(command.canContinue(mock(CruiseConfig.class)));
+        BasicCruiseConfig basicCruiseConfig = new BasicCruiseConfig(new BasicPipelineConfigs(pipelineConfig));
+        assertFalse(command.canContinue(basicCruiseConfig));
     }
 
     @Test

--- a/server/test/unit/com/thoughtworks/go/config/update/UpdateSCMConfigCommandTest.java
+++ b/server/test/unit/com/thoughtworks/go/config/update/UpdateSCMConfigCommandTest.java
@@ -114,7 +114,7 @@ public class UpdateSCMConfigCommandTest {
 
         SCM updatedScm = new SCM("id", new PluginConfiguration("plugin-id", "1"), new Configuration(new ConfigurationProperty(new ConfigurationKey("key1"),new ConfigurationValue("value1"))));
         updatedScm.setName("material");
-        when(entityHashingService.md5ForEntity(cruiseConfig.getSCMs().find("id"), "material")).thenReturn("another-md5");
+        when(entityHashingService.md5ForEntity(cruiseConfig.getSCMs().find("id"))).thenReturn("another-md5");
         UpdateSCMConfigCommand command = new UpdateSCMConfigCommand(updatedScm, pluggableScmService, goConfigService, currentUser, result, "md5", entityHashingService);
 
         assertThat(command.canContinue(cruiseConfig), is(false));

--- a/server/test/unit/com/thoughtworks/go/config/update/UpdateTemplateConfigCommandTest.java
+++ b/server/test/unit/com/thoughtworks/go/config/update/UpdateTemplateConfigCommandTest.java
@@ -97,7 +97,7 @@ public class UpdateTemplateConfigCommandTest {
     public void shouldNotContinueWithConfigSaveIfRequestIsNotFresh() {
         cruiseConfig.addTemplate(pipelineTemplateConfig);
         when(goConfigService.isUserAdmin(currentUser)).thenReturn(true);
-        when(entityHashingService.md5ForEntity(pipelineTemplateConfig, pipelineTemplateConfig.name().toString())).thenReturn("another-md5");
+        when(entityHashingService.md5ForEntity(pipelineTemplateConfig)).thenReturn("another-md5");
 
         UpdateTemplateConfigCommand command = new UpdateTemplateConfigCommand(pipelineTemplateConfig, currentUser, goConfigService, result, "md5", entityHashingService);
 

--- a/server/webapp/WEB-INF/rails.new/app/controllers/api_v1/admin/environments_controller.rb
+++ b/server/webapp/WEB-INF/rails.new/app/controllers/api_v1/admin/environments_controller.rb
@@ -79,7 +79,7 @@ module ApiV1
       end
 
       def get_etag_for_environment
-        entity_hashing_service.md5ForEntity(@environment_config, @environment_config.name.to_s)
+        entity_hashing_service.md5ForEntity(@environment_config)
       end
 
       def handle_config_save_result(result, environment_name)

--- a/server/webapp/WEB-INF/rails.new/app/controllers/api_v1/admin/pluggable_scms_controller.rb
+++ b/server/webapp/WEB-INF/rails.new/app/controllers/api_v1/admin/pluggable_scms_controller.rb
@@ -66,7 +66,7 @@ module ApiV1
       end
 
       def get_etag_for_scm_object(material_name)
-        entity_hashing_service.md5ForEntity(find_scm(material_name), material_name)
+        entity_hashing_service.md5ForEntity(find_scm(material_name))
       end
 
       def check_for_scm_rename

--- a/server/webapp/WEB-INF/rails.new/app/controllers/api_v1/admin/templates_controller.rb
+++ b/server/webapp/WEB-INF/rails.new/app/controllers/api_v1/admin/templates_controller.rb
@@ -83,7 +83,7 @@ module ApiV1
       end
 
       def get_etag_for_template(template)
-        entity_hashing_service.md5ForEntity(template, template.name.to_s)
+        entity_hashing_service.md5ForEntity(template)
       end
     end
   end

--- a/server/webapp/WEB-INF/rails.new/app/controllers/api_v2/admin/pipelines_controller.rb
+++ b/server/webapp/WEB-INF/rails.new/app/controllers/api_v2/admin/pipelines_controller.rb
@@ -1,5 +1,5 @@
 ##########################################################################
-# Copyright 2016 ThoughtWorks, Inc.
+# Copyright 2015 ThoughtWorks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,12 +18,12 @@ module ApiV2
   module Admin
     class PipelinesController < ApiV2::BaseController
       before_action :check_pipeline_group_admin_user_and_401
-      before_action :load_pipeline, only: [:show, :destroy]
+      before_action :load_pipeline, only: [:show, :update, :destroy]
       before_action :check_if_pipeline_by_same_name_already_exists, :check_group_not_blank, only: [:create]
       before_action :check_for_stale_request, :check_for_attempted_pipeline_rename, only: [:update]
 
       def show
-        if stale?(etag: get_etag_for_pipeline(@pipeline_config.name.to_s))
+        if stale?(etag: get_etag_for(@pipeline_config))
           json = ApiV2::Config::PipelineConfigRepresenter.new(@pipeline_config).to_hash(url_builder: self)
           render DEFAULT_FORMAT => json
         end
@@ -42,7 +42,7 @@ module ApiV2
       def update
         result = HttpLocalizedOperationResult.new
         get_pipeline_from_request
-        pipeline_config_service.updatePipelineConfig(current_user, @pipeline_config_from_request, get_etag_for_pipeline(params[:pipeline_name]), result)
+        pipeline_config_service.updatePipelineConfig(current_user, @pipeline_config_from_request, get_etag_for(@pipeline_config), result)
         handle_config_save_or_update_result(result)
       end
 
@@ -64,7 +64,7 @@ module ApiV2
         if result.isSuccessful
           load_pipeline(pipeline_name)
           json = ApiV2::Config::PipelineConfigRepresenter.new(@pipeline_config).to_hash(url_builder: self)
-          response.etag = [get_etag_for_pipeline(@pipeline_config.name.to_s)]
+          response.etag = [get_etag_for(@pipeline_config)]
           render DEFAULT_FORMAT => json
         else
           json = ApiV2::Config::PipelineConfigRepresenter.new(@pipeline_config_from_request).to_hash(url_builder: self)
@@ -80,20 +80,16 @@ module ApiV2
         end
       end
 
-      def get_etag_for_pipeline(pipeline_name)
-        entity_hashing_service.md5ForPipelineConfig(pipeline_name)
+      def get_etag_for(pipeline)
+        entity_hashing_service.md5ForEntity(pipeline)
       end
 
       def check_for_stale_request
-        return unless stale_request?
-
-        result = HttpLocalizedOperationResult.new
-        result.stale(LocalizedMessage::string("STALE_RESOURCE_CONFIG", 'pipeline', params[:pipeline_name]))
-        render_http_operation_result(result)
-      end
-
-      def stale_request?
-        request.env["HTTP_IF_MATCH"] != "\"#{Digest::MD5.hexdigest(get_etag_for_pipeline(params[:pipeline_name]))}\""
+        if request.env["HTTP_IF_MATCH"] != "\"#{Digest::MD5.hexdigest(get_etag_for(@pipeline_config))}\""
+          result = HttpLocalizedOperationResult.new
+          result.stale(LocalizedMessage::string("STALE_RESOURCE_CONFIG", 'pipeline', params[:pipeline_name]))
+          render_http_operation_result(result)
+        end
       end
 
       def load_pipeline(pipeline_name = params[:pipeline_name])

--- a/server/webapp/WEB-INF/rails.new/app/controllers/environments_controller.rb
+++ b/server/webapp/WEB-INF/rails.new/app/controllers/environments_controller.rb
@@ -92,7 +92,7 @@ class EnvironmentsController < ApplicationController
     env_for_edit = environment_config_service.forEdit(params[:name], result)
     if (result.isSuccessful())
       @environment = env_for_edit.getConfigElement()
-      @cruise_config_md5 = entity_hashing_service.md5ForEntity(@environment, @environment.name.to_s)
+      @cruise_config_md5 = entity_hashing_service.md5ForEntity(@environment)
     end
     render_if_error(result.message(Spring.bean('localizer')), result.httpCode())
     result.isSuccessful()

--- a/server/webapp/WEB-INF/rails.new/spec/controllers/api_v1/admin/pluggable_scms_controller_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/controllers/api_v1/admin/pluggable_scms_controller_spec.rb
@@ -139,7 +139,7 @@ describe ApiV1::Admin::PluggableScmsController do
 
       it 'should render the pluggable scm material of specified name' do
         @pluggable_scm_service.should_receive(:findPluggableScmMaterial).with('material').exactly(2).times.and_return(@scm)
-        @entity_hashing_service.should_receive(:md5ForEntity).with(@scm, 'material').and_return('md5')
+        @entity_hashing_service.should_receive(:md5ForEntity).with(@scm).and_return('md5')
 
         get_with_api_header :show, material_name: 'material'
 
@@ -327,7 +327,7 @@ describe ApiV1::Admin::PluggableScmsController do
 
         hash = {id: '1', name: 'material', auto_update: false, plugin_metadata: {id: 'some-plugin', version: '1'}, configuration: [{"key" => 'url', "value" => 'git@github.com:foo/bar.git'}]}
 
-        @entity_hashing_service.should_receive(:md5ForEntity).with(an_instance_of(SCM), anything).exactly(2).times.and_return('md5')
+        @entity_hashing_service.should_receive(:md5ForEntity).with(an_instance_of(SCM)).exactly(2).times.and_return('md5')
         @pluggable_scm_service.should_receive(:findPluggableScmMaterial).exactly(2).times.and_return(@scm)
         @pluggable_scm_service.should_receive(:updatePluggableScmMaterial).with(anything, an_instance_of(SCM), anything, 'md5')
 
@@ -354,7 +354,7 @@ describe ApiV1::Admin::PluggableScmsController do
 
         result = HttpLocalizedOperationResult.new
 
-        @entity_hashing_service.should_receive(:md5ForEntity).with(an_instance_of(SCM), anything).and_return('md5')
+        @entity_hashing_service.should_receive(:md5ForEntity).with(an_instance_of(SCM)).and_return('md5')
         @pluggable_scm_service.should_receive(:findPluggableScmMaterial).and_return(@scm)
         @pluggable_scm_service.stub(:updatePluggableScmMaterial).with(anything, an_instance_of(SCM), result, anything)  do |user, scm, result|
           result.unprocessableEntity(LocalizedMessage::string("SAVE_FAILED_WITH_REASON", "Validation failed"))
@@ -370,7 +370,7 @@ describe ApiV1::Admin::PluggableScmsController do
       it 'should fail update if etag does not match' do
         controller.request.env['HTTP_IF_MATCH'] = "some-etag"
         params = {id: '1', name: 'foo', auto_update: false, plugin_metadata: {id: 'some-plugin', version: '1'}, configuration: [{"key" => 'url', "value" => 'git@github.com:foo/bar.git'}]}
-        @entity_hashing_service.should_receive(:md5ForEntity).with(an_instance_of(SCM), anything).and_return('another-etag')
+        @entity_hashing_service.should_receive(:md5ForEntity).with(an_instance_of(SCM)).and_return('another-etag')
         @pluggable_scm_service.should_receive(:findPluggableScmMaterial).with('foo').and_return(@scm)
 
         put_with_api_header :update, material_name: 'foo', pluggable_scm: params
@@ -383,7 +383,7 @@ describe ApiV1::Admin::PluggableScmsController do
         controller.request.env['HTTP_IF_MATCH'] = "\"#{Digest::MD5.hexdigest("md5")}\""
         hash = {id: '1', name: 'material', auto_update: false, plugin_metadata: {id: 'some-plugin', version: '1'}, configuration: [{"key" => 'url', "value" => 'git@github.com:foo/bar.git'}]}
 
-        @entity_hashing_service.should_receive(:md5ForEntity).with(an_instance_of(SCM), 'material').exactly(3).times.and_return('md5')
+        @entity_hashing_service.should_receive(:md5ForEntity).with(an_instance_of(SCM)).exactly(3).times.and_return('md5')
         @pluggable_scm_service.should_receive(:findPluggableScmMaterial).with('material').exactly(3).times.and_return(@scm)
         @pluggable_scm_service.should_receive(:updatePluggableScmMaterial).with(anything, an_instance_of(SCM), anything, "md5")
 

--- a/server/webapp/WEB-INF/rails.new/spec/controllers/api_v1/admin/templates_controller_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/controllers/api_v1/admin/templates_controller_spec.rb
@@ -132,7 +132,7 @@ describe ApiV1::Admin::TemplatesController do
       end
 
       it 'should render the template of specified name' do
-        @entity_hashing_service.should_receive(:md5ForEntity).with(an_instance_of(PipelineTemplateConfig), anything).and_return('md5')
+        @entity_hashing_service.should_receive(:md5ForEntity).with(an_instance_of(PipelineTemplateConfig)).and_return('md5')
         @template_config_service.should_receive(:loadForView).with('template', @result).and_return(@template)
 
         get_with_api_header :show, template_name: 'template'
@@ -344,7 +344,7 @@ describe ApiV1::Admin::TemplatesController do
         controller.request.env['HTTP_IF_MATCH'] = "\"#{Digest::MD5.hexdigest("md5")}\""
 
         @template_config_service.should_receive(:loadForView).with('some-template', anything).and_return(@template)
-        @entity_hashing_service.should_receive(:md5ForEntity).with(an_instance_of(PipelineTemplateConfig), 'some-template').exactly(3).times.and_return('md5')
+        @entity_hashing_service.should_receive(:md5ForEntity).with(an_instance_of(PipelineTemplateConfig)).exactly(3).times.and_return('md5')
         @template_config_service.should_receive(:updateTemplateConfig).with(anything, an_instance_of(PipelineTemplateConfig), anything, "md5")
 
         put_with_api_header :update, template_name: 'some-template', template: template_hash
@@ -359,7 +359,7 @@ describe ApiV1::Admin::TemplatesController do
 
         result = HttpLocalizedOperationResult.new
 
-        @entity_hashing_service.should_receive(:md5ForEntity).with(an_instance_of(PipelineTemplateConfig), anything).and_return('md5')
+        @entity_hashing_service.should_receive(:md5ForEntity).with(an_instance_of(PipelineTemplateConfig)).and_return('md5')
         @template_config_service.should_receive(:loadForView).and_return(@template)
         @template_config_service.stub(:updateTemplateConfig).with(anything, an_instance_of(PipelineTemplateConfig), result, anything)  do |user, template, result|
           result.unprocessableEntity(LocalizedMessage::string("SAVE_FAILED_WITH_REASON", "Validation failed"))

--- a/server/webapp/WEB-INF/rails.new/spec/controllers/api_v2/admin/pipelines_controller_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/controllers/api_v2/admin/pipelines_controller_spec.rb
@@ -39,12 +39,12 @@ describe ApiV2::Admin::PipelinesController do
     @pipeline_groups = com.thoughtworks.go.domain.PipelineGroups.new
     @go_config_service.stub(:groups).and_return(@pipeline_groups)
     @pipeline_groups.stub(:hasGroup).and_return(true)
-    @entity_hashing_service.stub(:md5ForPipelineConfig).and_return(@pipeline_md5)
+    @entity_hashing_service.stub(:md5ForEntity).and_return(@pipeline_md5)
     @latest_etag = "\"#{Digest::MD5.hexdigest(@pipeline_md5)}\""
   end
 
   after(:each) do
-    controller.send(:go_cache).remove("GO_PIPELINE_CONFIGS_ETAGS_CACHE")
+    controller.send(:go_cache).remove("GO_ETAG_CACHE")
   end
 
   describe :security do
@@ -73,6 +73,7 @@ describe ApiV2::Admin::PipelinesController do
 
     describe :update do
       it 'should allow anyone, with security disabled' do
+        @pipeline_config_service.stub(:getPipelineConfig).with(anything()).and_return(PipelineConfig.new)
         disable_security
         controller.stub(:check_for_stale_request).and_return(nil)
         controller.stub(:check_for_attempted_pipeline_rename).and_return(nil)
@@ -86,6 +87,7 @@ describe ApiV2::Admin::PipelinesController do
       end
 
       it 'should allow admin users, with security enabled' do
+        @pipeline_config_service.stub(:getPipelineConfig).with(anything()).and_return(PipelineConfig.new)
         login_as_pipeline_group_admin_user(@group)
         controller.stub(:check_for_stale_request).and_return(nil)
         controller.stub(:check_for_attempted_pipeline_rename).and_return(nil)
@@ -170,7 +172,7 @@ describe ApiV2::Admin::PipelinesController do
         pipeline_md5 = 'md5_for_pipeline_config'
 
         @pipeline_config_service.should_receive(:getPipelineConfig).with(pipeline_name).and_return(pipeline)
-        @entity_hashing_service.should_receive(:md5ForPipelineConfig).with(pipeline_name).and_return(pipeline_md5)
+        @entity_hashing_service.should_receive(:md5ForEntity).with(pipeline).and_return(pipeline_md5)
 
         get_with_api_header :show, :pipeline_name => pipeline_name
 
@@ -187,7 +189,7 @@ describe ApiV2::Admin::PipelinesController do
         pipeline_md5 = 'md5_for_pipeline_config'
 
         @pipeline_config_service.should_receive(:getPipelineConfig).with(pipeline_name).and_return(pipeline)
-        @entity_hashing_service.should_receive(:md5ForPipelineConfig).with(pipeline_name).and_return(pipeline_md5)
+        @entity_hashing_service.should_receive(:md5ForEntity).with(pipeline).and_return(pipeline_md5)
 
         controller.request.env['HTTP_IF_NONE_MATCH'] = Digest::MD5.hexdigest(pipeline_md5)
 
@@ -216,7 +218,7 @@ describe ApiV2::Admin::PipelinesController do
         pipeline_md5 = 'md5_for_pipeline_config'
 
         @pipeline_config_service.should_receive(:getPipelineConfig).with(pipeline_name).and_return(pipeline)
-        @entity_hashing_service.should_receive(:md5ForPipelineConfig).with(pipeline_name).and_return(pipeline_md5)
+        @entity_hashing_service.should_receive(:md5ForEntity).with(pipeline).and_return(pipeline_md5)
 
         controller.request.env['HTTP_IF_NONE_MATCH'] = 'stale-etag'
 
@@ -282,8 +284,8 @@ describe ApiV2::Admin::PipelinesController do
       end
 
       it "should update pipeline config for an admin" do
-        @entity_hashing_service.should_receive(:md5ForPipelineConfig).with(@pipeline_name).and_return(@pipeline_md5)
-        @pipeline_config_service.should_receive(:getPipelineConfig).with(@pipeline_name).and_return(@pipeline)
+        @entity_hashing_service.should_receive(:md5ForEntity).with(@pipeline).and_return(@pipeline_md5)
+        @pipeline_config_service.should_receive(:getPipelineConfig).twice.with(@pipeline_name).and_return(@pipeline)
         @pipeline_config_service.should_receive(:updatePipelineConfig).with(anything(), anything(), @pipeline_md5, anything())
 
         controller.request.env['HTTP_IF_MATCH'] = "\"#{Digest::MD5.hexdigest(@pipeline_md5)}\""
@@ -295,6 +297,7 @@ describe ApiV2::Admin::PipelinesController do
       end
 
       it "should not update pipeline config if etag passed does not match the one on server" do
+        @pipeline_config_service.should_receive(:getPipelineConfig).with(@pipeline_name).and_return(@pipeline)
         controller.request.env['HTTP_IF_MATCH'] = "old-etag"
 
         put_with_api_header :update, pipeline_name: @pipeline_name, :pipeline => pipeline
@@ -305,6 +308,7 @@ describe ApiV2::Admin::PipelinesController do
 
 
       it "should not update pipeline config if no etag is passed" do
+        @pipeline_config_service.should_receive(:getPipelineConfig).with(@pipeline_name).and_return(@pipeline)
         put_with_api_header :update, pipeline_name: @pipeline_name, :pipeline => pipeline
 
         expect(response.code).to eq("412")
@@ -312,6 +316,7 @@ describe ApiV2::Admin::PipelinesController do
       end
 
       it "should handle server validation errors" do
+        @pipeline_config_service.should_receive(:getPipelineConfig).with(@pipeline_name).and_return(@pipeline)
         result = double('HttpLocalizedOperationResult')
         result.stub(:isSuccessful).and_return(false)
         result.stub(:message).with(anything()).and_return("message from server")
@@ -322,7 +327,6 @@ describe ApiV2::Admin::PipelinesController do
         controller.stub(:get_pipeline_from_request) do
           controller.instance_variable_set(:@pipeline_config_from_request, @pipeline)
         end
-        @pipeline_config_service.should_not_receive(:getPipelineConfig).with(@pipeline_name)
         @pipeline_config_service.should_receive(:updatePipelineConfig).with(anything(), anything(), @pipeline_md5, result)
         controller.request.env['HTTP_IF_MATCH'] = @latest_etag
 
@@ -339,6 +343,7 @@ describe ApiV2::Admin::PipelinesController do
       end
 
       it "should not allow renaming a pipeline" do
+        @pipeline_config_service.should_receive(:getPipelineConfig).with(@pipeline_name).and_return(@pipeline)
         controller.request.env['HTTP_IF_MATCH'] = @latest_etag
 
         put_with_api_header :update, pipeline_name: @pipeline_name, :pipeline => pipeline("renamed_pipeline")
@@ -348,7 +353,7 @@ describe ApiV2::Admin::PipelinesController do
       end
 
       it "should set package definition on to package material before save" do
-        @pipeline_config_service.should_receive(:getPipelineConfig).with(@pipeline_name).and_return(@pipeline)
+        @pipeline_config_service.should_receive(:getPipelineConfig).twice.with(@pipeline_name).and_return(@pipeline)
         pipeline_being_saved = nil
         allow(@pipeline_config_service).to receive(:updatePipelineConfig) do |user, pipeline, result|
           pipeline_being_saved = pipeline
@@ -363,7 +368,7 @@ describe ApiV2::Admin::PipelinesController do
 
       it "should set scm config on to pluggable scm material before save" do
         pipeline_being_saved = nil
-        @pipeline_config_service.should_receive(:getPipelineConfig).with(@pipeline_name).and_return(@pipeline)
+        @pipeline_config_service.should_receive(:getPipelineConfig).twice.with(@pipeline_name).and_return(@pipeline)
 
         allow(@pipeline_config_service).to receive(:updatePipelineConfig) do |user, pipeline, result|
           pipeline_being_saved = pipeline
@@ -486,7 +491,7 @@ describe ApiV2::Admin::PipelinesController do
         controller.stub(:get_pipeline_from_request) do
           controller.instance_variable_set(:@pipeline_config_from_request, @pipeline)
         end
-        @pipeline_config_service.should_not_receive(:getPipelineConfig).with(@pipeline_name)
+
         @pipeline_config_service.should_receive(:createPipelineConfig).with(anything(), anything(), result, "group")
         controller.request.env['HTTP_IF_MATCH'] = "\"#{Digest::MD5.hexdigest("latest-etag")}\""
 


### PR DESCRIPTION
Let the `EntityHashingService` be in charge of generating the cache keys and
managing if the key is supposed to be case insensitive based on the type of
the entity being passed.