### PR TITLE
Revert "Copied approval related errors. Showed role validation errors on config SPA."

### DIFF
--- a/config/config-api/src/com/thoughtworks/go/config/AdminRole.java
+++ b/config/config-api/src/com/thoughtworks/go/config/AdminRole.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 ThoughtWorks, Inc.
+ * Copyright 2015 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@ import com.thoughtworks.go.domain.config.Admin;
 public class AdminRole implements Admin {
     @ConfigValue private CaseInsensitiveString name;
     private ConfigErrors configErrors = new ConfigErrors();
-    public static final String ROLES = "roles";
+    public static final String NAME = "name";
 
     public AdminRole() {
     }
@@ -93,7 +93,7 @@ public class AdminRole implements Admin {
         }
         SecurityConfig securityConfig = validationContext.getServerSecurityConfig();
         if (!securityConfig.isRoleExist(this.name)) {
-            configErrors.add(ROLES, String.format("Role \"%s\" does not exist.", this.name));
+            configErrors.add(NAME, String.format("Role \"%s\" does not exist.", this.name));
         }
     }
 

--- a/config/config-api/test/com/thoughtworks/go/config/AdminRoleTest.java
+++ b/config/config-api/test/com/thoughtworks/go/config/AdminRoleTest.java
@@ -39,7 +39,7 @@ public class AdminRoleTest {
         role.validate(ConfigSaveValidationContext.forChain(config));
         ConfigErrors configErrors = role.errors();
         assertThat(configErrors.isEmpty(), is(false));
-        assertThat(configErrors.on(AdminRole.ROLES), is("Role \"role2\" does not exist."));
+        assertThat(configErrors.on(AdminRole.NAME), is("Role \"role2\" does not exist."));
     }
 
     @Test
@@ -50,7 +50,7 @@ public class AdminRoleTest {
         role.validate(ConfigSaveValidationContext.forChain(config));
         ConfigErrors errors = role.errors();
         assertThat(errors.isEmpty(), is(false));
-        assertThat(errors.on(AdminRole.ROLES), is("Role \"role2\" does not exist."));
+        assertThat(errors.on(AdminRole.NAME), is("Role \"role2\" does not exist."));
     }
 
     @Test
@@ -62,7 +62,7 @@ public class AdminRoleTest {
         role.validate(PipelineConfigSaveValidationContext.forChain(true, "group",config, pipelineConfig));
         ConfigErrors errors = role.errors();
         assertThat(errors.isEmpty(), is(false));
-        assertThat(errors.on(AdminRole.ROLES), is("Role \"role2\" does not exist."));
+        assertThat(errors.on(AdminRole.NAME), is("Role \"role2\" does not exist."));
     }
 
     @Test
@@ -107,7 +107,7 @@ public class AdminRoleTest {
         role.validate(ConfigSaveValidationContext.forChain(config));
         ConfigErrors errors = role.errors();
         assertThat(errors.isEmpty(), is(false));
-        assertThat(errors.on(AdminRole.ROLES), is("Role \"shilpaIsNotHere\" does not exist."));
+        assertThat(errors.on(AdminRole.NAME), is("Role \"shilpaIsNotHere\" does not exist."));
     }
 
     @Test

--- a/server/src/com/thoughtworks/go/config/update/PipelineConfigErrorCopier.java
+++ b/server/src/com/thoughtworks/go/config/update/PipelineConfigErrorCopier.java
@@ -45,8 +45,6 @@ public class PipelineConfigErrorCopier {
             StageConfig fromStage = from.findBy(toStage.name());
             copy(fromStage, toStage);
             copyCollectionErrors(fromStage.getVariables(), toStage.getVariables());
-            copy(fromStage.getApproval(), toStage.getApproval());
-            copyCollectionErrors(fromStage.getApproval().getAuthConfig(), toStage.getApproval().getAuthConfig());
 
             for (JobConfig toJob : toStage.getJobs()) {
                 JobConfig fromJob = fromStage.jobConfigByConfigName(toJob.name());

--- a/server/test/integration/com/thoughtworks/go/server/service/PipelineConfigServiceIntegrationTest.java
+++ b/server/test/integration/com/thoughtworks/go/server/service/PipelineConfigServiceIntegrationTest.java
@@ -398,34 +398,6 @@ public class PipelineConfigServiceIntegrationTest {
     }
 
     @Test
-    public void shouldShowPipelineConfigErrorMessageWhenPipelineConfigHasApprovalRelatedErrors() {
-        PipelineConfig pipeline = GoConfigMother.createPipelineConfigWithMaterialConfig(UUID.randomUUID().toString(), new DependencyMaterialConfig(pipelineConfig.name(), pipelineConfig.first().name()));
-        StageConfig stageConfig= pipeline.get(0);
-        stageConfig.setApproval(new Approval(new AuthConfig(new AdminRole(new CaseInsensitiveString("non-existent-role")))));
-
-        pipelineConfigService.createPipelineConfig(user, pipeline, result, groupName);
-
-        assertThat(result.toString(), result.isSuccessful(), is(false));
-        assertThat(result.httpCode(), is(422));
-        assertThat(stageConfig.getApproval().getAuthConfig().errors().firstError(), is("Role \"non-existent-role\" does not exist."));
-    }
-
-    @Test
-    public void shouldShowPipelineConfigErrorMessageWhenPipelineConfigHasApprovalTypeErrors() {
-        PipelineConfig pipeline = GoConfigMother.createPipelineConfigWithMaterialConfig(UUID.randomUUID().toString(), new DependencyMaterialConfig(pipelineConfig.name(), pipelineConfig.first().name()));
-        StageConfig stageConfig= pipeline.get(0);
-        Approval approval = new Approval();
-        approval.setType("not-success-or-manual");
-        stageConfig.setApproval(approval);
-
-        pipelineConfigService.createPipelineConfig(user, pipeline, result, groupName);
-
-        assertThat(result.toString(), result.isSuccessful(), is(false));
-        assertThat(result.httpCode(), is(422));
-        assertThat(stageConfig.getApproval().errors().firstError(), is("You have defined approval type as 'not-success-or-manual'. Approval can only be of the type 'manual' or 'success'."));
-    }
-
-    @Test
     public void shouldShowThePipelineConfigErrorMessageWhenPipelineBeingCreatedHasErrorsOnProperties() throws GitAPIException {
         PipelineConfig pipeline = GoConfigMother.createPipelineConfigWithMaterialConfig(UUID.randomUUID().toString(), new DependencyMaterialConfig(pipelineConfig.name(), pipelineConfig.first().name()));
         JobConfig jobConfig = pipeline.get(0).getJobs().get(0);

--- a/server/webapp/WEB-INF/rails.new/app/assets/new_javascripts/models/pipeline_configs/approval.js
+++ b/server/webapp/WEB-INF/rails.new/app/assets/new_javascripts/models/pipeline_configs/approval.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-define(['mithril', 'lodash', 'string-plus', 'models/model_mixins', 'models/validatable_mixin'], function (m, _, s, Mixins, Validatable) {
+define(['mithril', 'lodash', 'string-plus', 'models/model_mixins'], function (m, _, s, Mixins) {
 
   var Approval = function (data) {
     this.constructor.modelType = 'approval';
@@ -43,14 +43,13 @@ define(['mithril', 'lodash', 'string-plus', 'models/model_mixins', 'models/valid
   Approval.AuthConfig = function (data) {
     this.constructor.modelType = 'approvalAuthorization';
     Mixins.HasUUID.call(this);
-    Validatable.call(this, data);
 
     this.roles = s.withNewJSONImpl(m.prop(s.defaultToIfBlank(data.roles, '')), s.stringToArray);
     this.users = s.withNewJSONImpl(m.prop(s.defaultToIfBlank(data.users, '')), s.stringToArray);
   };
 
   Approval.AuthConfig.fromJSON = function (data) {
-    return new Approval.AuthConfig({roles: data.roles, users: data.users, errors: data.errors});
+    return new Approval.AuthConfig({roles: data.roles, users: data.users});
   };
 
   Approval.fromJSON = function (data) {

--- a/server/webapp/WEB-INF/rails.new/app/assets/new_javascripts/views/pipeline_configs/stages_config_widget.js.msx
+++ b/server/webapp/WEB-INF/rails.new/app/assets/new_javascripts/views/pipeline_configs/stages_config_widget.js.msx
@@ -76,7 +76,6 @@ define([
                                 model={args.approval().authorization()}/>
               <f.inputWithLabel config={autoComplete(Roles.list, args.approval().authorization(), 'roles')}
                                 attrName='roles'
-                                validate={true}
                                 model={args.approval().authorization()} end/>
 
             </f.row>


### PR DESCRIPTION
Reverts gocd/gocd#2705

These changes breaks displaying errors on pipeline group edit page which needs to be fixed, reverting for now. 