### PR TITLE
Change current directory to batch file location

### DIFF
--- a/installers/go-agent/release/start-agent.bat
+++ b/installers/go-agent/release/start-agent.bat
@@ -14,6 +14,8 @@ REM See the License for the specific language governing permissions and
 REM limitations under the License.
 REM *************************GO-LICENSE-END**********************************
 
+cd /d "%~dp0"
+
 IF "%DAEMON%"=="N" (
 	START "go agent - %CD%" /WAIT agent.cmd
 ) ELSE	(

--- a/installers/go-agent/release/stop-agent.bat
+++ b/installers/go-agent/release/stop-agent.bat
@@ -14,5 +14,7 @@ REM See the License for the specific language governing permissions and
 REM limitations under the License.
 REM *************************GO-LICENSE-END**********************************
 
+cd /d "%~dp0"
+
 FOR /F "tokens=2" %%I in ('TASKLIST /NH /FI "WINDOWTITLE eq go agent - %CD% - agent.cmd"' ) DO TASKKILL /F /T /PID %%I
 if exist .agent-bootstrapper.running del /Q .agent-bootstrapper.running


### PR DESCRIPTION
In windows 8 when we run `start-agent.bat or stop-agent.bat` these files are executed under the directory `windows/system32`, so it can't find `agent.cmd`. This pull request changes the current directory to the location from where batch file is executed.