### PR TITLE
Fix checkbox for allowOnlyKnownUsersToLogin #736

### DIFF
--- a/server/webapp/WEB-INF/rails.new/app/views/admin/server/index.html.erb
+++ b/server/webapp/WEB-INF/rails.new/app/views/admin/server/index.html.erb
@@ -31,8 +31,8 @@
 
             <div class="form_item required">
                 <div class="form_item checkbox_row">
-                    <%- html_options = {} %>
-                    <%- html_options = {:disabled => true, :title => l.string("CANNOT_TURN_OFF_AUTO_LOGIN")} unless @allow_user_to_turn_off_auto_login %>
+                    <%- html_options = { } %>
+                    <%- html_options = {:include_hidden => false, :disabled => true, :title => l.string("CANNOT_TURN_OFF_AUTO_LOGIN")} unless @allow_user_to_turn_off_auto_login %>
                     <%= form.check_box :allow_auto_login, html_options, "true", "false" %>
                     <label class="inline" for="server_configuration_form_allow_auto_login"><%= l.string("ALLOW_AUTO_LOGIN_MESSAGE") -%></label>
                 </div>

--- a/server/webapp/WEB-INF/rails.new/app/views/admin/server/index.html.erb
+++ b/server/webapp/WEB-INF/rails.new/app/views/admin/server/index.html.erb
@@ -31,11 +31,9 @@
 
             <div class="form_item required">
                 <div class="form_item checkbox_row">
-                    <%- html_options = {:include_hidden => false} %>
-                    <%- html_options = {:include_hidden => false, :disabled => true, :title => l.string("CANNOT_TURN_OFF_AUTO_LOGIN")} unless @allow_user_to_turn_off_auto_login %>
-                    <%- allow_auto_login_value = @server_configuration_form.allow_auto_login ? "1" : "0" %>
-                    <%= form.hidden_field :allow_auto_login, :value => allow_auto_login_value %>
-                    <%= form.check_box :allow_auto_login, html_options, "1", "0" %>
+                    <%- html_options = {} %>
+                    <%- html_options = {:disabled => true, :title => l.string("CANNOT_TURN_OFF_AUTO_LOGIN")} unless @allow_user_to_turn_off_auto_login %>
+                    <%= form.check_box :allow_auto_login, html_options, "true", "false" %>
                     <label class="inline" for="server_configuration_form_allow_auto_login"><%= l.string("ALLOW_AUTO_LOGIN_MESSAGE") -%></label>
                 </div>
 

--- a/server/webapp/WEB-INF/rails.new/lib/server_configuration_form.rb
+++ b/server/webapp/WEB-INF/rails.new/lib/server_configuration_form.rb
@@ -46,7 +46,7 @@ class ServerConfigurationForm
     security_config, mail_host = server_config.security(),server_config.mailHost()
     ldap_config = security_config.ldapConfig()
     password_file_path = security_config.passwordFileConfig().path()
-    auto_login = (!security_config.isAllowOnlyKnownUsersToLogin()) ? "1" : "0"
+    auto_login = security_config.isAllowOnlyKnownUsersToLogin() ? "false" : "true"
 
     allow_auto_login = {:allow_auto_login => auto_login}
     mail_host_params= {:hostName => mail_host.getHostName(), :port => mail_host.getPort().to_s, :username => mail_host.getUserName(),
@@ -94,7 +94,7 @@ class ServerConfigurationForm
   end
 
   def should_allow_auto_login
-    allow_auto_login == "1"
+    allow_auto_login == "true"
   end
 
   def to_security

--- a/server/webapp/WEB-INF/rails.new/lib/server_configuration_form.rb
+++ b/server/webapp/WEB-INF/rails.new/lib/server_configuration_form.rb
@@ -94,7 +94,7 @@ class ServerConfigurationForm
   end
 
   def should_allow_auto_login
-    allow_auto_login == "true"
+    allow_auto_login != "false"
   end
 
   def to_security

--- a/server/webapp/WEB-INF/rails.new/spec/lib/server_configuration_form_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/lib/server_configuration_form_spec.rb
@@ -63,6 +63,12 @@ describe ServerConfigurationForm do
   end
 
   describe "allow_auto_login" do
+    it "should default it to true when a new instance is created without a value being provided for it" do
+      form = ServerConfigurationForm.new({})
+      expect(form.allow_auto_login).to eq nil
+      expect(form.should_allow_auto_login).to eq true
+    end
+
     it "should set it when a new instance is created" do
       form = ServerConfigurationForm.new({:allow_auto_login => "true"})
       expect(form.allow_auto_login).to eq "true"

--- a/server/webapp/WEB-INF/rails.new/spec/lib/server_configuration_form_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/lib/server_configuration_form_spec.rb
@@ -64,34 +64,34 @@ describe ServerConfigurationForm do
 
   describe "allow_auto_login" do
     it "should set it when a new instance is created" do
-      form = ServerConfigurationForm.new({:allow_auto_login => "1"})
-      expect(form.allow_auto_login).to eq "1"
+      form = ServerConfigurationForm.new({:allow_auto_login => "true"})
+      expect(form.allow_auto_login).to eq "true"
       expect(form.should_allow_auto_login).to eq true
 
-      form = ServerConfigurationForm.new({:allow_auto_login => "0"})
-      expect(form.allow_auto_login).to eq "0"
+      form = ServerConfigurationForm.new({:allow_auto_login => "false"})
+      expect(form.allow_auto_login).to eq "false"
       expect(form.should_allow_auto_login).to eq false
     end
 
-    it "should set allow_auto_login to 1 when form is being created from_server_config and isAllowOnlyKnownUsersToLogin is false" do
+    it "should set allow_auto_login to 'true' when form is being created from_server_config and isAllowOnlyKnownUsersToLogin is false" do
       @ldap_config = LdapConfig.new("ldap://test.com", "test", "password", @encrypted_password, true,BasesConfig.new([BaseConfig.new('base1'), BaseConfig.new('base2')].to_java(BaseConfig)), "searchFilter")
       @password_file_config = PasswordFileConfig.new("path")
       @security_config = SecurityConfig.new(@ldap_config, @password_file_config, false)
       @mail_host = MailHost.new("blrstdcrspair02", 9999, "pavan", "strong_password", true, true, "from@from.com", "admin@admin.com")
 
       form = ServerConfigurationForm.from_server_config(com.thoughtworks.go.config.ServerConfig.new(@security_config, @mail_host))
-      expect(form.allow_auto_login).to eq "1"
+      expect(form.allow_auto_login).to eq "true"
       expect(form.should_allow_auto_login).to eq true
     end
 
-    it "should set allow_auto_login to 0 when form is being created from_server_config and isAllowOnlyKnownUsersToLogin is true" do
+    it "should set allow_auto_login to 'false' when form is being created from_server_config and isAllowOnlyKnownUsersToLogin is true" do
       @ldap_config = LdapConfig.new("ldap://test.com", "test", "password", @encrypted_password, true,BasesConfig.new([BaseConfig.new('base1'), BaseConfig.new('base2')].to_java(BaseConfig)), "searchFilter")
       @password_file_config = PasswordFileConfig.new("path")
       @security_config = SecurityConfig.new(@ldap_config, @password_file_config, true)
       @mail_host = MailHost.new("blrstdcrspair02", 9999, "pavan", "strong_password", true, true, "from@from.com", "admin@admin.com")
 
       form = ServerConfigurationForm.from_server_config(com.thoughtworks.go.config.ServerConfig.new(@security_config, @mail_host))
-      expect(form.allow_auto_login).to eq "0"
+      expect(form.allow_auto_login).to eq "false"
       expect(form.should_allow_auto_login).to eq false
     end
   end

--- a/server/webapp/WEB-INF/rails.new/spec/views/admin/server/index_html_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/views/admin/server/index_html_spec.rb
@@ -193,7 +193,7 @@ describe "admin/server/index.html.erb" do
 
       Capybara.string(response.body).find('#user_management').tap do |div|
         expect(div).to have_selector("label[for='server_configuration_form_allow_auto_login']", :text => /Allow users that exist/)
-        expect(div).to have_selector("input[name='server_configuration_form[allow_auto_login]'][disabled='disabled'][type='hidden'][value='false']")
+        expect(div).to_not have_selector("input[name='server_configuration_form[allow_auto_login]'][type='hidden']")
         expect(div).to have_selector("input#server_configuration_form_allow_auto_login[name='server_configuration_form[allow_auto_login]'][disabled='disabled'][type='checkbox'][value='true']")
       end
     end

--- a/server/webapp/WEB-INF/rails.new/spec/views/admin/server/index_html_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/views/admin/server/index_html_spec.rb
@@ -182,4 +182,56 @@ describe "admin/server/index.html.erb" do
       end
     end
   end
+
+  describe "allow auto login (allow_auto_login)" do
+    it "should disable the check box if changing it is not allowed (when no admins are enabled)" do
+      server_config_form = ServerConfigurationForm.new({:allow_auto_login => "true"})
+      assign(:server_configuration_form, server_config_form)
+      assign(:allow_user_to_turn_off_auto_login, false)
+
+      render
+
+      Capybara.string(response.body).find('#user_management').tap do |div|
+        expect(div).to have_selector("label[for='server_configuration_form_allow_auto_login']", :text => /Allow users that exist/)
+        expect(div).to have_selector("input[name='server_configuration_form[allow_auto_login]'][disabled='disabled'][type='hidden'][value='false']")
+        expect(div).to have_selector("input#server_configuration_form_allow_auto_login[name='server_configuration_form[allow_auto_login]'][disabled='disabled'][type='checkbox'][value='true']")
+      end
+    end
+
+    it "should enable the check box and set it to 'checked' when auto login is allowed" do
+      server_config_form = ServerConfigurationForm.new({:allow_auto_login => "true"})
+      assign(:server_configuration_form, server_config_form)
+      assign(:allow_user_to_turn_off_auto_login, true)
+
+      render
+
+      Capybara.string(response.body).find('#user_management').tap do |div|
+        div.find("input[name='server_configuration_form[allow_auto_login]'][type='hidden'][value='false']").tap do |hidden_value_for_checkbox|
+          expect(hidden_value_for_checkbox).to_not be_disabled
+        end
+        div.find("input#server_configuration_form_allow_auto_login[name='server_configuration_form[allow_auto_login]'][type='checkbox'][value='true']").tap do |checkbox|
+          expect(checkbox).to_not be_disabled
+          expect(checkbox).to be_checked
+        end
+      end
+    end
+
+    it "should enable the check box and set it to not be 'checked' when auto login is not allowed" do
+      server_config_form = ServerConfigurationForm.new({:allow_auto_login => "false"})
+      assign(:server_configuration_form, server_config_form)
+      assign(:allow_user_to_turn_off_auto_login, true)
+
+      render
+
+      Capybara.string(response.body).find('#user_management').tap do |div|
+        div.find("input[name='server_configuration_form[allow_auto_login]'][type='hidden'][value='false']").tap do |hidden_value_for_checkbox|
+          expect(hidden_value_for_checkbox).to_not be_disabled
+        end
+        div.find("input#server_configuration_form_allow_auto_login[name='server_configuration_form[allow_auto_login]'][type='checkbox'][value='true']").tap do |checkbox|
+          expect(checkbox).to_not be_disabled
+          expect(checkbox).to_not be_checked
+        end
+      end
+    end
+  end
 end

--- a/server/webapp/localize.xml
+++ b/server/webapp/localize.xml
@@ -255,7 +255,7 @@
     <entry key="ABLE_TO_CONNECT_TO_LDAP">Connected to LDAP successfully.</entry>
     <entry key="PASSWORD_FILE_SETTINGS">Password File Settings</entry>
     <entry key="PASSWORD_FILE_PATH">Password File Path</entry>
-    <entry key="ALLOW_AUTO_LOGIN_MESSAGE">Allow users that exist in LDAP or in the password file to log into Go, even if they haven't been explicitly added to Go.</entry>
+    <entry key="ALLOW_AUTO_LOGIN_MESSAGE">Allow users that exist in LDAP or in the password file to log into GoCD, even if they haven't been explicitly added to GoCD.</entry>
     <entry key="FAILED_TO_SAVE_THE_SERVER_CONFIGURATION">Failed to save the server configuration. Reason: {0}</entry>
     <entry key="LICENSE_DETAILS">License Details</entry>
     <entry key="VIEW_FAILURE_DETAILS">View failure details</entry>


### PR DESCRIPTION
Issue described in #736. Was not working because the understanding of how the hidden value works in a form with a checkbox seemed wrong. It's now correct.

- When disabled: It's checked and disabled. (First time server is started and no users are enabled)
- When checkbox is checked: The hidden value is set to "false" (so that it can take over if the checkbox is disabled by the user). Checkbox value is set to "true" and checked attribute is set to "checked".
- When checkbox is unchecked: The hidden value is set to "false" and the checkbox value is set to "true" (so that it can override the hidden value if checked by the user).

