### PR TITLE
Allow pipeline group admins to create or update scms.

### DIFF
--- a/server/src/com/thoughtworks/go/config/update/CreateSCMConfigCommand.java
+++ b/server/src/com/thoughtworks/go/config/update/CreateSCMConfigCommand.java
@@ -38,14 +38,4 @@ public class CreateSCMConfigCommand extends SCMConfigCommand {
         scms.add(globalScmConfig);
         modifiedConfig.setSCMs(scms);
     }
-
-    @Override
-    public boolean canContinue(CruiseConfig cruiseConfig) {
-        if (!(goConfigService.isUserAdmin(currentUser)) || goConfigService.isGroupAdministrator(currentUser.getUsername())) {
-            result.unauthorized(LocalizedMessage.string("UNAUTHORIZED_TO_EDIT"), HealthStateType.unauthorised());
-            return false;
-        }
-        return true;
-    }
-
 }

--- a/server/src/com/thoughtworks/go/config/update/SCMConfigCommand.java
+++ b/server/src/com/thoughtworks/go/config/update/SCMConfigCommand.java
@@ -68,4 +68,17 @@ public abstract class SCMConfigCommand implements EntityConfigUpdateCommand<SCM>
     public void clearErrors() {
         BasicCruiseConfig.clearErrors(globalScmConfig);
     }
+
+    @Override
+    public boolean canContinue(CruiseConfig cruiseConfig) {
+        return isAuthorized();
+    }
+
+    private boolean isAuthorized() {
+        if (!(goConfigService.isUserAdmin(currentUser) || goConfigService.isGroupAdministrator(currentUser.getUsername()))) {
+            result.unauthorized(LocalizedMessage.string("UNAUTHORIZED_TO_EDIT"), HealthStateType.unauthorised());
+            return false;
+        }
+        return true;
+    }
 }

--- a/server/src/com/thoughtworks/go/config/update/UpdateSCMConfigCommand.java
+++ b/server/src/com/thoughtworks/go/config/update/UpdateSCMConfigCommand.java
@@ -50,7 +50,7 @@ public class UpdateSCMConfigCommand extends SCMConfigCommand {
 
     @Override
     public boolean canContinue(CruiseConfig cruiseConfig) {
-        return isUserAuthorized() && isRequestFresh(cruiseConfig);
+        return super.canContinue(cruiseConfig) && isRequestFresh(cruiseConfig);
     }
 
     private boolean isRequestFresh(CruiseConfig cruiseConfig) {
@@ -61,14 +61,6 @@ public class UpdateSCMConfigCommand extends SCMConfigCommand {
         }
 
         return freshRequest;
-    }
-
-    private boolean isUserAuthorized() {
-        if (!(goConfigService.isUserAdmin(currentUser)) || goConfigService.isGroupAdministrator(currentUser.getUsername())) {
-            result.unauthorized(LocalizedMessage.string("UNAUTHORIZED_TO_EDIT"), HealthStateType.unauthorised());
-            return false;
-        }
-        return true;
     }
 
     private SCM findSCM(CruiseConfig modifiedConfig) {

--- a/server/test/unit/com/thoughtworks/go/config/update/CreateSCMConfigCommandTest.java
+++ b/server/test/unit/com/thoughtworks/go/config/update/CreateSCMConfigCommandTest.java
@@ -79,4 +79,24 @@ public class CreateSCMConfigCommandTest {
         assertThat(command.canContinue(cruiseConfig), is(false));
     }
 
+    @Test
+    public void shouldContinueWithConfigSaveIfUserIsAdmin() {
+        when(goConfigService.isUserAdmin(currentUser)).thenReturn(true);
+        when(goConfigService.isGroupAdministrator(currentUser.getUsername())).thenReturn(false);
+
+        CreateSCMConfigCommand command = new CreateSCMConfigCommand(scm, pluggableScmService, result, currentUser, goConfigService);
+
+        assertThat(command.canContinue(cruiseConfig), is(true));
+    }
+
+    @Test
+    public void shouldContinueWithConfigSaveIfUserIsGroupAdmin() {
+        when(goConfigService.isUserAdmin(currentUser)).thenReturn(false);
+        when(goConfigService.isGroupAdministrator(currentUser.getUsername())).thenReturn(true);
+
+        CreateSCMConfigCommand command = new CreateSCMConfigCommand(scm, pluggableScmService, result, currentUser, goConfigService);
+
+        assertThat(command.canContinue(cruiseConfig), is(true));
+    }
+
 }

--- a/server/test/unit/com/thoughtworks/go/config/update/UpdateSCMConfigCommandTest.java
+++ b/server/test/unit/com/thoughtworks/go/config/update/UpdateSCMConfigCommandTest.java
@@ -38,6 +38,7 @@ import org.mockito.Mock;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.StringContains.containsString;
 import static org.junit.Assert.*;
+import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 
@@ -105,6 +106,30 @@ public class UpdateSCMConfigCommandTest {
 
         assertThat(command.canContinue(cruiseConfig), is(false));
         assertThat(result.toString(), containsString("UNAUTHORIZED_TO_EDIT"));
+    }
+
+    @Test
+    public void shouldContinueWithConfigSaveIfUserIsAdmin() {
+        when(goConfigService.isUserAdmin(currentUser)).thenReturn(true);
+        when(goConfigService.isGroupAdministrator(currentUser.getUsername())).thenReturn(false);
+        when(entityHashingService.md5ForEntity(any(SCM.class))).thenReturn("md5");
+
+        SCM updatedScm = new SCM("id", new PluginConfiguration("plugin-id", "1"), new Configuration(new ConfigurationProperty(new ConfigurationKey("key1"),new ConfigurationValue("value1"))));
+        UpdateSCMConfigCommand command = new UpdateSCMConfigCommand(updatedScm, pluggableScmService, goConfigService, currentUser, result, "md5", entityHashingService);
+
+        assertThat(command.canContinue(cruiseConfig), is(true));
+    }
+
+    @Test
+    public void shouldContinueWithConfigSaveIfUserIsGroupAdmin() {
+        when(goConfigService.isUserAdmin(currentUser)).thenReturn(false);
+        when(goConfigService.isGroupAdministrator(currentUser.getUsername())).thenReturn(true);
+        when(entityHashingService.md5ForEntity(any(SCM.class))).thenReturn("md5");
+
+        SCM updatedScm = new SCM("id", new PluginConfiguration("plugin-id", "1"), new Configuration(new ConfigurationProperty(new ConfigurationKey("key1"),new ConfigurationValue("value1"))));
+        UpdateSCMConfigCommand command = new UpdateSCMConfigCommand(updatedScm, pluggableScmService, goConfigService, currentUser, result, "md5", entityHashingService);
+
+        assertThat(command.canContinue(cruiseConfig), is(true));
     }
 
     @Test


### PR DESCRIPTION
To Do: Check if a role as pipeline group admin is permitted.