### PR TITLE
Moving to rubygems.lasagna.io for rubygems maven repo as torquebox do…

### DIFF
--- a/tools/build.gradle
+++ b/tools/build.gradle
@@ -18,7 +18,7 @@ description = 'GoCD build tools'
 apply from: 'lint.gradle'
 
 repositories {
-  maven { url 'http://rubygems-proxy.torquebox.org/releases/' }
+  maven { url 'http://rubygems.lasagna.io/proxy/maven/releases/' }
 }
 
 configurations {


### PR DESCRIPTION
…es not seem to be redirecting properly. Bundler gem download was failing.
rubygems.lasagna.io is managed by jruby-gradle guys (https://github.com/jruby-gradle/jruby-gradle-plugin)