### PR TITLE
Having fixed delay does not honour the cron. Removing it because aggressive git gc keeps happening.

### DIFF
--- a/development-utility/development-server/src/com/thoughtworks/go/server/DevelopmentServer.java
+++ b/development-utility/development-server/src/com/thoughtworks/go/server/DevelopmentServer.java
@@ -88,7 +88,6 @@ public class DevelopmentServer {
         systemEnvironment.set(SystemEnvironment.GO_CONFIG_REPO_PERIODIC_GC, true);
         systemEnvironment.set(SystemEnvironment.GO_CONFIG_REPO_GC_AGGRESSIVE, true);
         systemEnvironment.setProperty("go.config.repo.gc.cron", "0 0/1 * 1/1 * ?");
-        systemEnvironment.setProperty("go.config.repo.gc.min.interval", "10000");
         systemEnvironment.setProperty("go.config.repo.gc.check.interval", "10000");
     }
 

--- a/server/properties/src/cruise.properties
+++ b/server/properties/src/cruise.properties
@@ -27,7 +27,6 @@ go.elasticplugin.heartbeat.interval=60000
 cruise.build.assignment.service.interval=5000
 cruise.config.refresh.interval=5000
 go.config.repo.gc.cron=0 0 7 ? * SUN
-go.config.repo.gc.min.interval=300000
 go.config.repo.gc.check.interval=28800000
 cruise.disk.space.check.interval=5000
 cruise.agent.service.refresh.interval=5000

--- a/server/webapp/WEB-INF/spring-cruise-remoting-servlet.xml
+++ b/server/webapp/WEB-INF/spring-cruise-remoting-servlet.xml
@@ -30,7 +30,7 @@
     <import resource="propertyConfigurer.xml"/>
 
     <task:scheduled-tasks>
-        <task:scheduled ref="configRepository" method="garbageCollect" cron="${go.config.repo.gc.cron}" fixed-delay="${go.config.repo.gc.min.interval}" />
+        <task:scheduled ref="configRepository" method="garbageCollect" cron="${go.config.repo.gc.cron}" />
         <task:scheduled ref="configRepositoryGCWarningService" method="checkRepoAndAddWarningIfRequired" fixed-delay="${go.config.repo.gc.check.interval}"/>
     </task:scheduled-tasks>
 


### PR DESCRIPTION
Aggressive gc happens every 5 mins (the default) or whatever the delay interval is set to. Instead of the cron.