### PR TITLE
Fix issue with empty map response for latest package revision since

### DIFF
--- a/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/packagematerial/JsonMessageHandler1_0.java
+++ b/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/packagematerial/JsonMessageHandler1_0.java
@@ -159,7 +159,10 @@ public class JsonMessageHandler1_0 implements JsonMessageHandler {
 
     @Override
     public PackageRevision responseMessageForLatestRevision(String responseBody) {
-        return toPackageRevision(responseBody);
+        PackageRevision packageRevision = toPackageRevision(responseBody);
+        if( packageRevision == null) {
+            throw new RuntimeException("Empty response body");
+        } else return packageRevision;
     }
 
     @Override
@@ -173,7 +176,6 @@ public class JsonMessageHandler1_0 implements JsonMessageHandler {
 
     @Override
     public PackageRevision responseMessageForLatestRevisionSince(String responseBody) {
-        if (isEmpty(responseBody)) return null;
         return toPackageRevision(responseBody);
     }
 
@@ -270,8 +272,9 @@ public class JsonMessageHandler1_0 implements JsonMessageHandler {
                 throw new RuntimeException("Package revision should be returned as a map");
             }
             if (map == null || map.isEmpty()) {
-                throw new RuntimeException("Empty response body");
+                return null;
             }
+
 
             String revision;
             try {

--- a/plugin-infra/go-plugin-access/test/com/thoughtworks/go/plugin/access/packagematerial/JsonMessageHandler1_0Test.java
+++ b/plugin-infra/go-plugin-access/test/com/thoughtworks/go/plugin/access/packagematerial/JsonMessageHandler1_0Test.java
@@ -183,6 +183,13 @@ public class JsonMessageHandler1_0Test {
     }
 
     @Test
+    public void shouldThrowExceptionWhenAttemptingToGetLatestRevisionFromEmptyResponse(){
+        assertThat(getErrorMessageFromLatestRevision(""), is("Empty response body"));
+        assertThat(getErrorMessageFromLatestRevision("{}"), is("Empty response body"));
+        assertThat(getErrorMessageFromLatestRevision(null), is("Empty response body"));
+    }
+
+    @Test
     public void shouldBuildRequestBodyForLatestRevisionSinceRequest() throws Exception {
         Date timestamp = new SimpleDateFormat(DATE_FORMAT).parse("2011-07-13T19:43:37.100Z");
         Map data = new LinkedHashMap();
@@ -208,6 +215,7 @@ public class JsonMessageHandler1_0Test {
     public void shouldBuildNullPackageRevisionFromLatestRevisionSinceWhenEmptyResponse() throws Exception {
         assertThat(messageHandler.responseMessageForLatestRevisionSince(""), nullValue());
         assertThat(messageHandler.responseMessageForLatestRevisionSince(null), nullValue());
+        assertThat(messageHandler.responseMessageForLatestRevisionSince("{}"), nullValue());
     }
 
     @Test
@@ -269,7 +277,6 @@ public class JsonMessageHandler1_0Test {
 
     @Test
     public void shouldValidateIncorrectJsonForPackageRevision() {
-        assertThat(errorMessageForPackageRevision(""), is("Unable to de-serialize json response. Empty response body"));
         assertThat(errorMessageForPackageRevision("[{\"revision\":\"abc.rpm\"}]"), is("Unable to de-serialize json response. Package revision should be returned as a map"));
         assertThat(errorMessageForPackageRevision("{\"revision\":{}}"), is("Unable to de-serialize json response. Package revision should be of type string"));
         assertThat(errorMessageForPackageRevision("{\"revisionComment\":{}}"), is("Unable to de-serialize json response. Package revision comment should be of type string"));
@@ -342,5 +349,14 @@ public class JsonMessageHandler1_0Test {
             return e.getMessage();
         }
         return null;
+    }
+
+    private String getErrorMessageFromLatestRevision(String responseBody) {
+        try{
+            messageHandler.responseMessageForLatestRevision(responseBody);
+            fail("Should throw exception");
+        } catch( RuntimeException e){
+            return e.getMessage();
+        } return null;
     }
 }


### PR DESCRIPTION
Update handling of empty map response from latest-package-revision and latest-package-revision-since. Empty map is an acceptable response from latest-package-revision-since. Addresses issue akin to #2641