### PR TITLE
Fixing flaky test - ConsoleOutputTransmitterTest

### DIFF
--- a/common/test/unit/com/thoughtworks/go/remote/work/ConsoleOutputTransmitterTest.java
+++ b/common/test/unit/com/thoughtworks/go/remote/work/ConsoleOutputTransmitterTest.java
@@ -1,18 +1,18 @@
-/*************************GO-LICENSE-START*********************************
- * Copyright 2014 ThoughtWorks, Inc.
+/*
+ * Copyright 2016 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *************************GO-LICENSE-END***********************************/
+ */
 
 package com.thoughtworks.go.remote.work;
 
@@ -22,6 +22,8 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
+
+import java.util.concurrent.ScheduledThreadPoolExecutor;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.assertThat;
@@ -42,7 +44,7 @@ public class ConsoleOutputTransmitterTest {
 
         requestArgumentCaptor = ArgumentCaptor.forClass(String.class);
         doNothing().when(consoleAppender).append(requestArgumentCaptor.capture());
-        transmitter = new ConsoleOutputTransmitter(consoleAppender);
+        transmitter = new ConsoleOutputTransmitter(consoleAppender, 0, mock(ScheduledThreadPoolExecutor.class));
     }
 
     @After


### PR DESCRIPTION
ScheduledThreadPoolExecutor used to invoke flushToServer periodically causing the test to be flaky