### PR TITLE
Skip dependency material update during integration test.

### DIFF
--- a/common/test/unit/com/thoughtworks/go/util/command/CommandLineTest.java
+++ b/common/test/unit/com/thoughtworks/go/util/command/CommandLineTest.java
@@ -140,10 +140,9 @@ public class CommandLineTest {
     @RunIf(value = EnhancedOSChecker.class, arguments = {DO_NOT_RUN_ON, OSChecker.WINDOWS})
     public void shouldNotLogPasswordsFromStream() {
         LogFixture logFixture = LogFixture.startListening();
-        LogFixture.enableDebug();
         CommandLine line = CommandLine.createCommandLine("/bin/echo").withArg("=>").withArg(new PasswordArgument("secret"));
         line.runOrBomb(null);
-
+        System.out.println(ArrayUtil.join(logFixture.getMessages()));
         assertThat(ArrayUtil.join(logFixture.getMessages()), not(containsString("secret")));
         assertThat(ArrayUtil.join(logFixture.getMessages()), containsString("=> ******"));
         logFixture.stopListening();

--- a/server/test/integration/com/thoughtworks/go/server/service/BuildAssignmentServiceIntegrationTest.java
+++ b/server/test/integration/com/thoughtworks/go/server/service/BuildAssignmentServiceIntegrationTest.java
@@ -47,6 +47,7 @@ import com.thoughtworks.go.server.dao.JobInstanceDao;
 import com.thoughtworks.go.server.dao.PipelineDao;
 import com.thoughtworks.go.server.dao.StageDao;
 import com.thoughtworks.go.server.domain.Username;
+import com.thoughtworks.go.server.materials.DependencyMaterialUpdateNotifier;
 import com.thoughtworks.go.server.persistence.MaterialRepository;
 import com.thoughtworks.go.server.scheduling.ScheduleHelper;
 import com.thoughtworks.go.server.service.builders.BuilderFactory;
@@ -115,6 +116,7 @@ public class BuildAssignmentServiceIntegrationTest {
     @Autowired private PipelineConfigService pipelineConfigService;
     @Autowired private EntityHashingService entityHashingService;
     @Autowired private ElasticAgentPluginService elasticAgentPluginService;
+    @Autowired private DependencyMaterialUpdateNotifier notifier;
 
     private PipelineConfig evolveConfig;
     private static final String STAGE_NAME = "dev";
@@ -161,10 +163,12 @@ public class BuildAssignmentServiceIntegrationTest {
         u = new ScheduleTestUtil(transactionTemplate, materialRepository, dbHelper, configHelper);
 
         agent = new AgentStub();
+        notifier.disableUpdates();
     }
 
     @After
     public void teardown() throws Exception {
+        notifier.enableUpdates();
         goCache.clear();
         agentService.clearAll();
         fixture.onTearDown();


### PR DESCRIPTION
* Display reason for failure for flaky tests on log messages.