### PR TITLE
#2835 add ConfigTag to MergeEnvironmentConfig

### DIFF
--- a/config/config-api/src/com/thoughtworks/go/config/merge/MergeEnvironmentConfig.java
+++ b/config/config-api/src/com/thoughtworks/go/config/merge/MergeEnvironmentConfig.java
@@ -34,6 +34,7 @@ import static com.thoughtworks.go.util.ExceptionUtils.bomb;
 /**
  * Composite of many EnvironmentConfig instances. Hides elementary environment configurations.
  */
+@ConfigTag("environment")
 public class MergeEnvironmentConfig extends BaseCollection<EnvironmentConfig>  implements EnvironmentConfig {
 
     private final ConfigErrors configErrors = new ConfigErrors();


### PR DESCRIPTION
Fixes #2835

Although cruise-config.xml never contains serialized `MergeEnvironmentConfig`, UI serializes XML partials to display the environment.

This only fixes the display issue. 
Currently (16.11) editing merged environment does not work. With this fix user can declare environments via configuration repository or via UI. But when merged from both sources, UI will throw validation errors.