### PR TITLE
Added a property for auto suggestion of dependencies for templates fetch artifact.

### DIFF
--- a/base/src/com/thoughtworks/go/util/SystemEnvironment.java
+++ b/base/src/com/thoughtworks/go/util/SystemEnvironment.java
@@ -160,6 +160,7 @@ public class SystemEnvironment implements Serializable, ConfigDirProvider {
     public static GoSystemProperty<String> GO_LANDING_PAGE = new GoStringSystemProperty("go.landing.page", "/pipelines");
 
     public static GoSystemProperty<Boolean> FETCH_ARTIFACT_AUTO_SUGGEST = new GoBooleanSystemProperty("go.fetch-artifact.auto-suggest", true);
+    public static GoSystemProperty<Boolean> GO_FETCH_ARTIFACT_TEMPLATE_AUTO_SUGGEST = new GoBooleanSystemProperty("go.fetch-artifact.template.auto-suggest", true);
     public static GoSystemProperty<String> GO_SSL_TRANSPORT_PROTOCOL_TO_BE_USED_BY_AGENT = new GoStringSystemProperty("go.ssl.agent.protocol", "TLSv1.2");
     public static GoSystemProperty<String> GO_SSL_CERTS_ALGORITHM = new GoStringSystemProperty("go.ssl.cert.algorithm", "SHA512WITHRSA");
     public static GoSystemProperty<String> GO_SSL_CERTS_PUBLIC_KEY_ALGORITHM = new GoStringSystemProperty("go.ssl.cert.public-key.algorithm", "SHA256WithRSAEncryption");
@@ -742,6 +743,10 @@ public class SystemEnvironment implements Serializable, ConfigDirProvider {
 
     public boolean isGOUpdateCheckEnabled() {
         return GO_CHECK_UPDATES.getValue();
+    }
+
+    public boolean isFetchArtifactTemplateAutoSuggestEnabled() {
+        return GO_FETCH_ARTIFACT_TEMPLATE_AUTO_SUGGEST.getValue();
     }
 
     public String getUpdateServerUrl() {

--- a/common/test/unit/com/thoughtworks/go/util/SystemEnvironmentTest.java
+++ b/common/test/unit/com/thoughtworks/go/util/SystemEnvironmentTest.java
@@ -495,6 +495,18 @@ public class SystemEnvironmentTest {
     }
 
     @Test
+    public void shouldDisableTemplateAutoSuggestByDefault() {
+        assertThat(SystemEnvironment.GO_FETCH_ARTIFACT_TEMPLATE_AUTO_SUGGEST.propertyName(), is("go.fetch-artifact.template.auto-suggest"));
+        assertFalse(systemEnvironment.isFetchArtifactTemplateAutoSuggestEnabled());
+    }
+
+    @Test
+    public void shouldEnableTemplateAutoSuggest() {
+        System.setProperty("go.template.auto-suggest", "true");
+        assertTrue(systemEnvironment.isFetchArtifactTemplateAutoSuggestEnabled());
+    }
+
+    @Test
     public void shouldReturnTheDefaultGCExpireTimeInMilliSeconds() {
         assertThat(SystemEnvironment.GO_CONFIG_REPO_GC_EXPIRE.propertyName(), is("go.config.repo.gc.expire"));
         assertThat(systemEnvironment.getConfigGitGCExpireTime(), is(24*60*60*1000L));

--- a/server/src/com/thoughtworks/go/server/presentation/FetchArtifactViewHelper.java
+++ b/server/src/com/thoughtworks/go/server/presentation/FetchArtifactViewHelper.java
@@ -1,18 +1,18 @@
-/*************************GO-LICENSE-START*********************************
- * Copyright 2014 ThoughtWorks, Inc.
+/*
+ * Copyright 2016 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *************************GO-LICENSE-END***********************************/
+ */
 
 package com.thoughtworks.go.server.presentation;
 
@@ -22,6 +22,7 @@ import com.thoughtworks.go.domain.materials.MaterialConfig;
 import com.thoughtworks.go.util.SystemEnvironment;
 
 import java.util.*;
+
 
 public class FetchArtifactViewHelper {
     private SystemEnvironment systemEnvironment;
@@ -85,6 +86,9 @@ public class FetchArtifactViewHelper {
 
     public FetchSuggestionHirarchy autosuggestMap() {
         if (!systemEnvironment.get(SystemEnvironment.FETCH_ARTIFACT_AUTO_SUGGEST)) {
+            return new FetchSuggestionHirarchy();
+        }
+        if(template && !systemEnvironment.isFetchArtifactTemplateAutoSuggestEnabled()) {
             return new FetchSuggestionHirarchy();
         }
         return fetchArtifactSuggestionsForPipeline(template ? createPipelineConfigForTemplate() : cruiseConfig.pipelineConfigByName(pipelineName));

--- a/server/src/com/thoughtworks/go/server/service/support/toggle/Toggles.java
+++ b/server/src/com/thoughtworks/go/server/service/support/toggle/Toggles.java
@@ -1,18 +1,18 @@
-/*************************GO-LICENSE-START*********************************
- * Copyright 2014 ThoughtWorks, Inc.
+/*
+ * Copyright 2016 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *************************GO-LICENSE-END***********************************/
+ */
 package com.thoughtworks.go.server.service.support.toggle;
 
 public class Toggles {

--- a/server/test/unit/com/thoughtworks/go/server/presentation/FetchArtifactViewHelperTest.java
+++ b/server/test/unit/com/thoughtworks/go/server/presentation/FetchArtifactViewHelperTest.java
@@ -1,18 +1,18 @@
-/*************************GO-LICENSE-START*********************************
- * Copyright 2014 ThoughtWorks, Inc.
+/*
+ * Copyright 2016 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *************************GO-LICENSE-END***********************************/
+ */
 
 package com.thoughtworks.go.server.presentation;
 
@@ -77,6 +77,7 @@ public class FetchArtifactViewHelperTest {
     @Before
     public void setUp() {
         initMocks(this);
+        when(systemEnvironment.isFetchArtifactTemplateAutoSuggestEnabled()).thenReturn(true);
 
         when(systemEnvironment.get(SystemEnvironment.FETCH_ARTIFACT_AUTO_SUGGEST)).thenReturn(true);
 
@@ -130,6 +131,15 @@ public class FetchArtifactViewHelperTest {
         when(systemEnvironment.get(SystemEnvironment.FETCH_ARTIFACT_AUTO_SUGGEST)).thenReturn(false);
 
         Map<CaseInsensitiveString, Map<CaseInsensitiveString, List<CaseInsensitiveString>>> jobForFetchHierarchy = new FetchArtifactViewHelper(systemEnvironment, cruiseConfig, new CaseInsensitiveString("uppest"), new CaseInsensitiveString("uppest_stage_3"), false).autosuggestMap();
+
+        assertThat(jobForFetchHierarchy.isEmpty(), is(true));
+    }
+
+    @Test
+    public void shouldNotSuggestForTemplatesIfToggleIsTurnedOff() {
+        when(systemEnvironment.get(SystemEnvironment.FETCH_ARTIFACT_AUTO_SUGGEST)).thenReturn(true);
+        when(systemEnvironment.isFetchArtifactTemplateAutoSuggestEnabled()).thenReturn(false);
+        Map<CaseInsensitiveString, Map<CaseInsensitiveString, List<CaseInsensitiveString>>> jobForFetchHierarchy = new FetchArtifactViewHelper(systemEnvironment, cruiseConfig, new CaseInsensitiveString("templateName"), new CaseInsensitiveString("template_stage_3"), true).autosuggestMap();
 
         assertThat(jobForFetchHierarchy.isEmpty(), is(true));
     }


### PR DESCRIPTION
Computing the dependencies for auto suggest for fetch artifact is not performant for templates. The GoCD server computes the dependencies for all pipelines in the config. Since the auto suggest feature is helpful for pipelines and not templates, a feature toggle to stop computing the dependencies for templates fetch artifact for now should help with the performance.

This toggle should be removed once we improve the logic and the performance to compute the dependencies. 

@arvindsv - Please review