### PR TITLE
Config save optimizations

### DIFF
--- a/base/src/com/thoughtworks/go/util/SystemEnvironment.java
+++ b/base/src/com/thoughtworks/go/util/SystemEnvironment.java
@@ -202,6 +202,8 @@ public class SystemEnvironment implements Serializable, ConfigDirProvider {
 
     public static GoIntSystemProperty DEPENDENCY_MATERIAL_UPDATE_LISTENERS = new GoIntSystemProperty("dependency.material.check.threads", 3);
 
+    public static GoSystemProperty<Boolean> OPTIMIZE_FULL_CONFIG_SAVE = new GoBooleanSystemProperty("optimize.full.config.save", true);
+
     private final static Map<String, String> GIT_ALLOW_PROTOCOL;
 
     static {
@@ -798,6 +800,10 @@ public class SystemEnvironment implements Serializable, ConfigDirProvider {
 
     public String getAgentKeyStorePassword() {
         return get(SystemEnvironment.GO_AGENT_KEYSTORE_PASSWORD);
+    }
+
+    public boolean optimizeFullConfigSave() {
+        return OPTIMIZE_FULL_CONFIG_SAVE.getValue();
     }
 
     public static abstract class GoSystemProperty<T> {

--- a/config/config-api/test/com/thoughtworks/go/helper/ConfigFileFixture.java
+++ b/config/config-api/test/com/thoughtworks/go/helper/ConfigFileFixture.java
@@ -1371,6 +1371,17 @@ public final class ConfigFileFixture {
                     + "</cruise>";
 
     public static final String DEFAULT_XML_WITH_2_AGENTS = xml();
+
+    public static final String XML_WITH_SINGLE_ENVIRONMENT = "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n"
+            + "<cruise xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" "
+            + " xsi:noNamespaceSchemaLocation=\"cruise-config.xsd\" schemaVersion='" + CONFIG_SCHEMA_VERSION + "'>\n"
+            + "<server artifactsdir=\"artifactsDir\">\n"
+            + "</server>"
+            + "<environments>"
+            + "<environment name='dummy'/>"
+            + "</environments>"
+            + "</cruise>";
+
     public static final String XML_WITH_ENTERPRISE_LICENSE_FOR_TWO_USERS = xml();
 
     private static String xml() {

--- a/config/config-server/src/com/thoughtworks/go/config/GoConfigMigration.java
+++ b/config/config-server/src/com/thoughtworks/go/config/GoConfigMigration.java
@@ -92,6 +92,8 @@ public class GoConfigMigration {
         this.registry = registry;
     }
 
+//  This method should be removed once upgrade is done using new com.thoughtworks.go.config.GoConfigMigrator#migrate()
+    @Deprecated
     public GoConfigMigrationResult upgradeIfNecessary(File configFile, final String currentGoServerVersion) {
         try {
             return upgradeValidateAndVersion(configFile, true, currentGoServerVersion);
@@ -137,6 +139,18 @@ public class GoConfigMigration {
         GoConfigHolder configHolder = validateAfterMigrationFinished(upgradedXmlString);
         new MagicalGoConfigXmlWriter(configCache, registry).write(configHolder.configForEdit, stream, false);
         return configHolder;
+    }
+
+    public File revertFileToVersion(File configFile, GoConfigRevision currentConfigRevision) throws Exception {
+        File backupFile = getBackupFile(configFile, "invalid.");
+        try {
+            backup(configFile, backupFile);
+            FileUtils.writeStringToFile(configFile, currentConfigRevision.getContent());
+        } catch (IOException e1) {
+            throw new RuntimeException(String.format("Could not write to config file '%s'.", configFile.getAbsolutePath()), e1);
+        }
+
+        return backupFile;
     }
 
     private GoConfigMigrationResult revertFileToVersion(File configFile, GoConfigRevision currentConfigRevision, Exception e) throws Exception {

--- a/config/config-server/src/com/thoughtworks/go/config/MagicalGoConfigXmlWriter.java
+++ b/config/config-server/src/com/thoughtworks/go/config/MagicalGoConfigXmlWriter.java
@@ -29,6 +29,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.lang.reflect.Field;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -88,7 +90,19 @@ public class MagicalGoConfigXmlWriter {
         LOGGER.debug("[Serializing Config] Finished writing config partial.");
     }
 
-    private void verifyXsdValid(Document document) throws Exception {
+    public Document documentFrom(CruiseConfig config) {
+        Document document = createEmptyCruiseConfigDocument();
+        write(config, document.getRootElement(), configCache, registry);
+        return document;
+    }
+
+    public String toString(Document document) throws IOException {
+        org.apache.commons.io.output.ByteArrayOutputStream outputStream = new org.apache.commons.io.output.ByteArrayOutputStream();
+        XmlUtils.writeXml(document, outputStream);
+        return outputStream.toString(StandardCharsets.UTF_8);
+    }
+
+    public void verifyXsdValid(Document document) throws Exception {
         ByteArrayOutputStream buffer = new ByteArrayOutputStream();
         XmlUtils.writeXml(document, buffer);
         InputStream content = toInputStream(buffer.toString());

--- a/server/src/com/thoughtworks/go/config/FullConfigSaveFlow.java
+++ b/server/src/com/thoughtworks/go/config/FullConfigSaveFlow.java
@@ -71,16 +71,12 @@ public abstract class FullConfigSaveFlow {
 
     public abstract GoConfigHolder execute(FullConfigUpdateCommand updatingCommand, List<PartialConfig> partials, String currentUser) throws Exception;
 
-    protected void postValidationUpdates(CruiseConfig preProcessedConfig, CruiseConfig configForEdit, String xmlString, List<PartialConfig> partials) throws NoSuchFieldException, IllegalAccessException {
+    protected void postValidationUpdates(CruiseConfig configForEdit, String xmlString) throws NoSuchFieldException, IllegalAccessException {
         String md5 = CachedDigestUtils.md5Hex(xmlString);
 
         configForEdit.setOrigins(new FileConfigOrigin());
-        preProcessedConfig.setOrigins(new FileConfigOrigin());
 
-        MagicalGoConfigXmlLoader.setMd5(preProcessedConfig, md5);
         MagicalGoConfigXmlLoader.setMd5(configForEdit, md5);
-
-        cachedGoPartials.markAsValid(partials);
     }
 
     protected String toXmlString(CruiseConfig configForEdit) throws Exception {

--- a/server/src/com/thoughtworks/go/config/FullConfigSaveFlow.java
+++ b/server/src/com/thoughtworks/go/config/FullConfigSaveFlow.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright 2016 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.config;
+
+import com.rits.cloning.Cloner;
+import com.thoughtworks.go.config.registry.ConfigElementImplementationRegistry;
+import com.thoughtworks.go.config.remote.FileConfigOrigin;
+import com.thoughtworks.go.config.remote.PartialConfig;
+import com.thoughtworks.go.config.update.FullConfigUpdateCommand;
+import com.thoughtworks.go.domain.GoConfigRevision;
+import com.thoughtworks.go.server.util.ServerVersion;
+import com.thoughtworks.go.service.ConfigRepository;
+import com.thoughtworks.go.util.CachedDigestUtils;
+import com.thoughtworks.go.util.SystemEnvironment;
+import com.thoughtworks.go.util.TimeProvider;
+import org.jdom.Document;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.List;
+
+public abstract class FullConfigSaveFlow {
+    protected final MagicalGoConfigXmlLoader loader;
+    protected final MagicalGoConfigXmlWriter writer;
+    protected final ServerVersion serverVersion;
+    protected final TimeProvider timeProvider;
+    protected final ConfigRepository configRepository;
+    protected final CachedGoPartials cachedGoPartials;
+    protected final GoConfigFileWriter fileWriter;
+    protected final ConfigElementImplementationRegistry configElementImplementationRegistry;
+    protected final Cloner cloner = new Cloner();
+    protected final Logger LOGGER = LoggerFactory.getLogger(getClass().getName());
+
+    public FullConfigSaveFlow(MagicalGoConfigXmlLoader loader, MagicalGoConfigXmlWriter writer,
+                              ConfigElementImplementationRegistry configElementImplementationRegistry,
+                              ServerVersion serverVersion, TimeProvider timeProvider,
+                              ConfigRepository configRepository, CachedGoPartials cachedGoPartials,
+                              GoConfigFileWriter fileWriter) {
+        this.loader = loader;
+        this.writer = writer;
+        this.configElementImplementationRegistry = configElementImplementationRegistry;
+        this.serverVersion = serverVersion;
+        this.timeProvider = timeProvider;
+        this.configRepository = configRepository;
+        this.cachedGoPartials = cachedGoPartials;
+        this.fileWriter = fileWriter;
+    }
+
+    public FullConfigSaveFlow(MagicalGoConfigXmlLoader loader, MagicalGoConfigXmlWriter writer,
+                              ConfigElementImplementationRegistry configElementImplementationRegistry,
+                              SystemEnvironment systemEnvironment, ServerVersion serverVersion,
+                              TimeProvider timeProvider, ConfigRepository configRepository, CachedGoPartials cachedGoPartials) {
+        this(loader, writer, configElementImplementationRegistry, serverVersion, timeProvider, configRepository, cachedGoPartials,
+                new GoConfigFileWriter(systemEnvironment));
+    }
+
+    public abstract GoConfigHolder execute(FullConfigUpdateCommand updatingCommand, List<PartialConfig> partials, String currentUser) throws Exception;
+
+    protected void postValidationUpdates(CruiseConfig preProcessedConfig, CruiseConfig configForEdit, String xmlString, List<PartialConfig> partials) throws NoSuchFieldException, IllegalAccessException {
+        String md5 = CachedDigestUtils.md5Hex(xmlString);
+
+        configForEdit.setOrigins(new FileConfigOrigin());
+        preProcessedConfig.setOrigins(new FileConfigOrigin());
+
+        MagicalGoConfigXmlLoader.setMd5(preProcessedConfig, md5);
+        MagicalGoConfigXmlLoader.setMd5(configForEdit, md5);
+
+        cachedGoPartials.markAsValid(partials);
+    }
+
+    protected String toXmlString(CruiseConfig configForEdit) throws Exception {
+        Document document = documentFrom(configForEdit);
+
+        validateDocument(document);
+
+        return toXmlString(document);
+    }
+
+    protected void checkinToConfigRepo(String currentUser, CruiseConfig updatedConfig, String xmlString) throws Exception {
+        LOGGER.debug("[Config Save] Checkin updated config to git: Starting.");
+        configRepository.checkin(new GoConfigRevision(xmlString, updatedConfig.getMd5(), currentUser, serverVersion.version(), timeProvider));
+        LOGGER.debug("[Config Save] Checkin updated config to git: Done.");
+    }
+
+    protected void writeToConfigXml(String xmlString) {
+        LOGGER.debug("[Config Save] Writing config xml to file: Starting.");
+        this.fileWriter.writeToConfigXmlFile(xmlString);
+        LOGGER.debug("[Config Save] Writing config xml to file: Done.");
+    }
+
+    protected CruiseConfig configForEditWithPartials(FullConfigUpdateCommand updatingCommand, List<PartialConfig> partials) throws Exception {
+        CruiseConfig config = updatingCommand.configForEdit();
+        config.setPartials(partials);
+
+        return config;
+    }
+
+    protected CruiseConfig preprocessAndValidate(CruiseConfig configForEdit) throws Exception {
+        return loader.preprocessAndValidate(configForEdit);
+    }
+
+    protected org.jdom.Document documentFrom(CruiseConfig configForEdit) {
+        LOGGER.debug("[Config Save] Building Document from CruiseConfig object: Starting.");
+        Document document = writer.documentFrom(configForEdit);
+        LOGGER.debug("[Config Save] Building Document from CruiseConfig object: Done.");
+
+        return document;
+    }
+
+    protected void validateDocument(Document document) throws Exception {
+        LOGGER.debug("[Config Save] In XSD validation: Starting.");
+        writer.verifyXsdValid(document);
+        LOGGER.debug("[Config Save] In XSD validation: Done.");
+
+        LOGGER.debug("[Config Save] In DOM validation: Starting.");
+        MagicalGoConfigXmlLoader.validateDom(document.getRootElement(), configElementImplementationRegistry);
+        LOGGER.debug("[Config Save] In DOM validation: Done.");
+    }
+
+    protected String toXmlString(Document document) throws IOException {
+        LOGGER.debug("[Config Save] Serializing Document to xml: Starting.");
+        String xmlString = writer.toString(document);
+        LOGGER.debug("[Config Save] Serializing Document to xml: Done.");
+
+        return xmlString;
+    }
+
+    protected void setMergedConfigForEditOn(GoConfigHolder validatedConfigHolder, List<PartialConfig> partials) {
+        if (partials.isEmpty()) return;
+
+        LOGGER.debug("[Config Save] Updating GoConfigHolder with mergedCruiseConfigForEdit: Starting.");
+        CruiseConfig mergedCruiseConfigForEdit = cloner.deepClone(validatedConfigHolder.configForEdit);
+        mergedCruiseConfigForEdit.merge(partials, true);
+        validatedConfigHolder.mergedConfigForEdit = mergedCruiseConfigForEdit;
+        LOGGER.debug("[Config Save] Updating GoConfigHolder with mergedCruiseConfigForEdit: Done.");
+    }
+}

--- a/server/src/com/thoughtworks/go/config/FullConfigSaveMergeFlow.java
+++ b/server/src/com/thoughtworks/go/config/FullConfigSaveMergeFlow.java
@@ -33,6 +33,11 @@ import java.util.List;
 
 import static java.lang.String.format;
 
+/*
+Given a CruiseConfig object, FullConfigSaveMergeFlow updates the config by merging with existing config in repo and by orchestrating the required steps from preprocessing,
+validating to writing the config in appropriate locations.
+*/
+
 @Component
 public class FullConfigSaveMergeFlow extends FullConfigSaveFlow{
     @Autowired
@@ -84,7 +89,7 @@ public class FullConfigSaveMergeFlow extends FullConfigSaveFlow{
                 }
             });
         } catch (Exception e) {
-            LOGGER.info(format("[CONFIG_MERGE] Post merge validation failed"));
+            LOGGER.debug("[CONFIG_MERGE] Post merge validation failed");
             throw new ConfigMergePostValidationException(e.getMessage(), e);
         }
     }
@@ -97,17 +102,17 @@ public class FullConfigSaveMergeFlow extends FullConfigSaveFlow{
     }
 
     private String toXmlString(CruiseConfig configForEdit, String md5) {
-        LOGGER.info(format("[CONFIG_MERGE] Validating and serializing CruiseConfig to xml before merge: Starting"));
+        LOGGER.debug("[CONFIG_MERGE] Validating and serializing CruiseConfig to xml before merge: Starting");
         String configForEditXml;
 
         try {
             preprocessAndValidate(configForEdit);
             configForEditXml = toXmlString(configForEdit);
         } catch (Exception e) {
-            LOGGER.info(format("[CONFIG_MERGE] Pre merge validation failed, latest-md5: %s", md5));
+            LOGGER.debug("[CONFIG_MERGE] Pre merge validation failed, latest-md5: {}", md5);
             throw new ConfigMergePreValidationException(e.getMessage(), e);
         }
-        LOGGER.info(format("[CONFIG_MERGE] Validating and serializing CruiseConfig to xml before merge: Done"));
+        LOGGER.debug("[CONFIG_MERGE] Validating and serializing CruiseConfig to xml before merge: Done");
 
         return configForEditXml;
     }

--- a/server/src/com/thoughtworks/go/config/FullConfigSaveMergeFlow.java
+++ b/server/src/com/thoughtworks/go/config/FullConfigSaveMergeFlow.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2016 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.config;
+
+import com.thoughtworks.go.config.exceptions.ConfigMergePostValidationException;
+import com.thoughtworks.go.config.exceptions.ConfigMergePreValidationException;
+import com.thoughtworks.go.config.registry.ConfigElementImplementationRegistry;
+import com.thoughtworks.go.config.remote.PartialConfig;
+import com.thoughtworks.go.config.update.FullConfigUpdateCommand;
+import com.thoughtworks.go.domain.GoConfigRevision;
+import com.thoughtworks.go.server.util.ServerVersion;
+import com.thoughtworks.go.service.ConfigRepository;
+import com.thoughtworks.go.util.SystemEnvironment;
+import com.thoughtworks.go.util.TimeProvider;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+import static java.lang.String.format;
+
+@Component
+public class FullConfigSaveMergeFlow extends FullConfigSaveFlow{
+    @Autowired
+    public FullConfigSaveMergeFlow(ConfigCache configCache, ConfigElementImplementationRegistry configElementImplementationRegistry,
+                                   SystemEnvironment systemEnvironment, ServerVersion serverVersion, TimeProvider timeProvider,
+                                   ConfigRepository configRepository, CachedGoPartials cachedGoPartials) {
+        this(new MagicalGoConfigXmlLoader(configCache, configElementImplementationRegistry),
+                new MagicalGoConfigXmlWriter(configCache, configElementImplementationRegistry), configElementImplementationRegistry,
+                serverVersion, timeProvider, configRepository, cachedGoPartials, new GoConfigFileWriter(systemEnvironment));
+    }
+
+    FullConfigSaveMergeFlow(MagicalGoConfigXmlLoader loader, MagicalGoConfigXmlWriter writer,
+                            ConfigElementImplementationRegistry configElementImplementationRegistry,
+                            ServerVersion serverVersion, TimeProvider timeProvider, ConfigRepository configRepository,
+                            CachedGoPartials cachedGoPartials, GoConfigFileWriter fileWriter) {
+        super(loader, writer, configElementImplementationRegistry, serverVersion, timeProvider, configRepository, cachedGoPartials, fileWriter);
+    }
+
+    public GoConfigHolder execute(FullConfigUpdateCommand updatingCommand, final List<PartialConfig> partials, String currentUser) throws Exception {
+        LOGGER.debug("[Config Save] Starting Config Save using FullConfigSaveMergeFlow");
+
+        CruiseConfig configForEdit = configForEditWithPartials(updatingCommand, partials);
+
+        String configForEditXml = toXmlString(configForEdit, updatingCommand.unmodifiedMd5());
+
+        String mergedConfig = getMergedConfig(configForEditXml, currentUser, updatingCommand.unmodifiedMd5());
+
+        GoConfigHolder goConfigHolder = reloadConfig(mergedConfig, partials);
+
+        checkinToConfigRepo(currentUser, goConfigHolder.configForEdit, mergedConfig);
+
+        writeToConfigXml(mergedConfig);
+
+        cachedGoPartials.markAsValid(partials);
+
+        setMergedConfigForEditOn(goConfigHolder, partials);
+
+        LOGGER.debug("[Config Save] Done Config Save using FullConfigSaveMergeFlow");
+
+        return goConfigHolder;
+    }
+
+    private GoConfigHolder reloadConfig(String configXml, final List<PartialConfig> partials) throws Exception {
+        try {
+            return loader.loadConfigHolder(configXml, new MagicalGoConfigXmlLoader.Callback() {
+                @Override
+                public void call(CruiseConfig cruiseConfig) {
+                    cruiseConfig.setPartials(partials);
+                }
+            });
+        } catch (Exception e) {
+            LOGGER.info(format("[CONFIG_MERGE] Post merge validation failed"));
+            throw new ConfigMergePostValidationException(e.getMessage(), e);
+        }
+    }
+
+    private String getMergedConfig(String modifiedConfigAsXml, String currentUser, String oldMd5) throws Exception {
+        GoConfigRevision configRevision = new GoConfigRevision(modifiedConfigAsXml, "temporary-md5-for-branch", currentUser,
+                serverVersion.version(), timeProvider);
+
+        return configRepository.getConfigMergedWithLatestRevision(configRevision, oldMd5);
+    }
+
+    private String toXmlString(CruiseConfig configForEdit, String md5) {
+        LOGGER.info(format("[CONFIG_MERGE] Validating and serializing CruiseConfig to xml before merge: Starting"));
+        String configForEditXml;
+
+        try {
+            preprocessAndValidate(configForEdit);
+            configForEditXml = toXmlString(configForEdit);
+        } catch (Exception e) {
+            LOGGER.info(format("[CONFIG_MERGE] Pre merge validation failed, latest-md5: %s", md5));
+            throw new ConfigMergePreValidationException(e.getMessage(), e);
+        }
+        LOGGER.info(format("[CONFIG_MERGE] Validating and serializing CruiseConfig to xml before merge: Done"));
+
+        return configForEditXml;
+    }
+}

--- a/server/src/com/thoughtworks/go/config/FullConfigSaveNormalFlow.java
+++ b/server/src/com/thoughtworks/go/config/FullConfigSaveNormalFlow.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2016 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.config;
+
+import com.thoughtworks.go.config.registry.ConfigElementImplementationRegistry;
+import com.thoughtworks.go.config.remote.PartialConfig;
+import com.thoughtworks.go.config.update.FullConfigUpdateCommand;
+import com.thoughtworks.go.server.util.ServerVersion;
+import com.thoughtworks.go.service.ConfigRepository;
+import com.thoughtworks.go.util.SystemEnvironment;
+import com.thoughtworks.go.util.TimeProvider;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+public class FullConfigSaveNormalFlow extends FullConfigSaveFlow {
+
+    @Autowired
+    public FullConfigSaveNormalFlow(ConfigCache configCache, ConfigElementImplementationRegistry configElementImplementationRegistry,
+                                   SystemEnvironment systemEnvironment, ServerVersion serverVersion, TimeProvider timeProvider,
+                                   ConfigRepository configRepository, CachedGoPartials cachedGoPartials) {
+        this(new MagicalGoConfigXmlLoader(configCache, configElementImplementationRegistry),
+                new MagicalGoConfigXmlWriter(configCache, configElementImplementationRegistry), configElementImplementationRegistry,
+                serverVersion, timeProvider, configRepository, cachedGoPartials, new GoConfigFileWriter(systemEnvironment));
+    }
+
+    public FullConfigSaveNormalFlow(MagicalGoConfigXmlLoader loader, MagicalGoConfigXmlWriter writer,
+                                    ConfigElementImplementationRegistry configElementImplementationRegistry,
+                                    ServerVersion serverVersion, TimeProvider timeProvider,
+                                    ConfigRepository configRepository, CachedGoPartials cachedGoPartials,
+                                    GoConfigFileWriter fileWriter) {
+        super(loader, writer, configElementImplementationRegistry, serverVersion, timeProvider, configRepository, cachedGoPartials, fileWriter);
+    }
+
+    public GoConfigHolder execute(FullConfigUpdateCommand updatingCommand, List<PartialConfig> partials, String currentUser) throws Exception {
+        LOGGER.debug("[Config Save] Starting Config Save using FullConfigSaveNormalFlow");
+
+        CruiseConfig configForEdit = configForEditWithPartials(updatingCommand, partials);
+
+        CruiseConfig preProcessedConfig = preprocessAndValidate(configForEdit);
+
+        String configForEditXmlString = toXmlString(configForEdit);
+
+        postValidationUpdates(preProcessedConfig, configForEdit, configForEditXmlString, partials);
+
+        checkinToConfigRepo(currentUser, configForEdit, configForEditXmlString);
+
+        writeToConfigXml(configForEditXmlString);
+
+        GoConfigHolder goConfigHolder = new GoConfigHolder(preProcessedConfig, configForEdit);
+
+        setMergedConfigForEditOn(goConfigHolder, partials);
+
+        LOGGER.debug("[Config Save] Done Config Save using FullConfigSaveNormalFlow");
+
+        return goConfigHolder;
+    }
+}

--- a/server/src/com/thoughtworks/go/config/FullConfigSaveNormalFlow.java
+++ b/server/src/com/thoughtworks/go/config/FullConfigSaveNormalFlow.java
@@ -28,6 +28,10 @@ import org.springframework.stereotype.Component;
 
 import java.util.List;
 
+/*
+Given a CruiseConfig object, FullConfigSaveNormalFlow updates the config by orchestrating the required steps from preprocessing,
+validating to writing the config in appropriate locations.
+*/
 @Component
 public class FullConfigSaveNormalFlow extends FullConfigSaveFlow {
 
@@ -53,11 +57,11 @@ public class FullConfigSaveNormalFlow extends FullConfigSaveFlow {
 
         CruiseConfig configForEdit = configForEditWithPartials(updatingCommand, partials);
 
-        CruiseConfig preProcessedConfig = preprocessAndValidate(configForEdit);
-
         String configForEditXmlString = toXmlString(configForEdit);
 
-        postValidationUpdates(preProcessedConfig, configForEdit, configForEditXmlString, partials);
+        postValidationUpdates(configForEdit, configForEditXmlString);
+
+        CruiseConfig preProcessedConfig = preprocessAndValidate(configForEdit);
 
         checkinToConfigRepo(currentUser, configForEdit, configForEditXmlString);
 
@@ -66,6 +70,8 @@ public class FullConfigSaveNormalFlow extends FullConfigSaveFlow {
         GoConfigHolder goConfigHolder = new GoConfigHolder(preProcessedConfig, configForEdit);
 
         setMergedConfigForEditOn(goConfigHolder, partials);
+
+        cachedGoPartials.markAsValid(partials);
 
         LOGGER.debug("[Config Save] Done Config Save using FullConfigSaveNormalFlow");
 

--- a/server/src/com/thoughtworks/go/config/GoConfigDao.java
+++ b/server/src/com/thoughtworks/go/config/GoConfigDao.java
@@ -19,13 +19,12 @@ package com.thoughtworks.go.config;
 import com.rits.cloning.Cloner;
 import com.thoughtworks.go.config.commands.CheckedUpdateCommand;
 import com.thoughtworks.go.config.commands.EntityConfigUpdateCommand;
-import com.thoughtworks.go.config.update.AddEnvironmentCommand;
 import com.thoughtworks.go.config.update.ConfigUpdateCheckFailedException;
+import com.thoughtworks.go.config.update.FullConfigUpdateCommand;
 import com.thoughtworks.go.config.validation.GoConfigValidity;
 import com.thoughtworks.go.listener.ConfigChangedListener;
 import com.thoughtworks.go.presentation.TriStateSelection;
 import com.thoughtworks.go.server.domain.Username;
-import com.thoughtworks.go.server.service.EnvironmentConfigService;
 import com.thoughtworks.go.server.util.UserHelper;
 import com.thoughtworks.go.util.ExceptionUtils;
 import org.slf4j.Logger;
@@ -120,6 +119,19 @@ public class GoConfigDao {
                 }
                 LOGGER.info("Config update request by {} is completed", UserHelper.getUserName().getUsername());
             }
+        }
+        return configSaveState;
+    }
+
+    public ConfigSaveState updateFullConfig(FullConfigUpdateCommand command) {
+        ConfigSaveState configSaveState;
+        LOGGER.info("Config update request by {} is in queue - {}", UserHelper.getUserName().getUsername(), command);
+        synchronized (GoConfigWriteLock.class) {
+            LOGGER.info("Config update request by {} is being processed", UserHelper.getUserName().getUsername());
+
+            configSaveState = cachedConfigService.writeFullConfigWithLock(command);
+
+            LOGGER.info("Config update request by {} is completed", UserHelper.getUserName().getUsername());
         }
         return configSaveState;
     }

--- a/server/src/com/thoughtworks/go/config/GoConfigFileReader.java
+++ b/server/src/com/thoughtworks/go/config/GoConfigFileReader.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2016 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.config;
+
+import com.thoughtworks.go.util.SystemEnvironment;
+import org.apache.commons.io.FileUtils;
+
+import java.io.File;
+import java.io.IOException;
+
+public class GoConfigFileReader {
+    private final SystemEnvironment systemEnvironment;
+
+    public GoConfigFileReader(SystemEnvironment systemEnvironment) {
+        this.systemEnvironment = systemEnvironment;
+    }
+
+    public String configXml() throws IOException {
+        return FileUtils.readFileToString(fileLocation());
+    }
+
+    public File fileLocation() {
+        return new File(systemEnvironment.getCruiseConfigFile());
+    }
+}

--- a/server/src/com/thoughtworks/go/config/GoConfigFileWriter.java
+++ b/server/src/com/thoughtworks/go/config/GoConfigFileWriter.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2016 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.config;
+
+import com.thoughtworks.go.util.SystemEnvironment;
+import org.apache.commons.io.IOUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.nio.channels.FileChannel;
+import java.nio.channels.FileLock;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+
+public class GoConfigFileWriter {
+    private final Charset UTF_8 = StandardCharsets.UTF_8;
+    private SystemEnvironment systemEnvironment;
+    protected final Logger LOGGER = LoggerFactory.getLogger(getClass().getName());
+
+    public GoConfigFileWriter(SystemEnvironment systemEnvironment) {
+        this.systemEnvironment = systemEnvironment;
+    }
+
+    public synchronized void writeToConfigXmlFile(String content) {
+        FileChannel channel = null;
+        FileOutputStream outputStream = null;
+        FileLock lock = null;
+
+        try {
+            RandomAccessFile randomAccessFile = new RandomAccessFile(fileLocation(), "rw");
+            channel = randomAccessFile.getChannel();
+            lock = channel.lock();
+            randomAccessFile.seek(0);
+            randomAccessFile.setLength(0);
+            outputStream = new FileOutputStream(randomAccessFile.getFD());
+
+            IOUtils.write(content, outputStream, UTF_8);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        } finally {
+            if (channel != null && lock != null) {
+                try {
+                    lock.release();
+                    channel.close();
+                    IOUtils.closeQuietly(outputStream);
+                } catch (IOException e) {
+                    LOGGER.error("Error occured when releasing file lock and closing file.", e);
+                }
+            }
+        }
+    }
+
+    public File fileLocation() {
+        return new File(systemEnvironment.getCruiseConfigFile());
+    }
+}

--- a/server/src/com/thoughtworks/go/config/GoConfigMigrator.java
+++ b/server/src/com/thoughtworks/go/config/GoConfigMigrator.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2016 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.config;
+
+import com.thoughtworks.go.config.registry.ConfigElementImplementationRegistry;
+import com.thoughtworks.go.config.remote.PartialConfig;
+import com.thoughtworks.go.config.update.FullConfigUpdateCommand;
+import com.thoughtworks.go.domain.GoConfigRevision;
+import com.thoughtworks.go.serverhealth.HealthStateScope;
+import com.thoughtworks.go.serverhealth.HealthStateType;
+import com.thoughtworks.go.serverhealth.ServerHealthService;
+import com.thoughtworks.go.serverhealth.ServerHealthState;
+import com.thoughtworks.go.service.ConfigRepository;
+import com.thoughtworks.go.util.SystemEnvironment;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.MarkerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.io.File;
+import java.util.ArrayList;
+
+@Component
+public class GoConfigMigrator {
+    private final GoConfigMigration goConfigMigration;
+    private final SystemEnvironment systemEnvironment;
+    private FullConfigSaveNormalFlow fullConfigSaveNormalFlow;
+    private MagicalGoConfigXmlLoader loader;
+    private GoConfigFileReader goConfigFileReader;
+    private ConfigRepository configRepository;
+    private ServerHealthService serverHealthService;
+    private static final Logger LOGGER = LoggerFactory.getLogger(GoConfigMigrator.class.getName());
+
+    @Autowired
+    public GoConfigMigrator(GoConfigMigration goConfigMigration, SystemEnvironment systemEnvironment, ConfigCache configCache,
+                            ConfigElementImplementationRegistry registry, FullConfigSaveNormalFlow fullConfigSaveNormalFlow,
+                            ConfigRepository configRepository, ServerHealthService serverHealthService) {
+
+        this(goConfigMigration, systemEnvironment, fullConfigSaveNormalFlow,
+                new MagicalGoConfigXmlLoader(configCache, registry), new GoConfigFileReader(systemEnvironment), configRepository, serverHealthService);
+    }
+
+    public GoConfigMigrator(GoConfigMigration goConfigMigration, SystemEnvironment systemEnvironment,
+                            FullConfigSaveNormalFlow fullConfigSaveNormalFlow, MagicalGoConfigXmlLoader loader,
+                            GoConfigFileReader goConfigFileReader, ConfigRepository configRepository, ServerHealthService serverHealthService) {
+        this.goConfigMigration = goConfigMigration;
+        this.systemEnvironment = systemEnvironment;
+        this.fullConfigSaveNormalFlow = fullConfigSaveNormalFlow;
+        this.loader = loader;
+        this.goConfigFileReader = goConfigFileReader;
+        this.configRepository = configRepository;
+        this.serverHealthService = serverHealthService;
+    }
+
+    public GoConfigHolder migrate() throws Exception {
+        try {
+            return upgrade();
+        } catch (Exception e) {
+            e.printStackTrace();
+            System.err.println(
+                    "There are errors in the Cruise config file.  Please read the error message and correct the errors.\n"
+                            + "Once fixed, please restart Cruise.\nError: " + e.getMessage());
+            LOGGER.error(MarkerFactory.getMarker("FATAL"),
+                    "There are errors in the Cruise config file.  Please read the error message and correct the errors.\n"
+                            + "Once fixed, please restart Cruise.\nError: " + e.getMessage());
+            // Send exit signal in a separate thread otherwise it will deadlock jetty
+            new Thread(new Runnable() {
+                public void run() {
+                    System.exit(1);
+                }
+            }).start();
+        }
+        return null;
+    }
+
+    private GoConfigHolder upgrade() throws Exception {
+        try {
+            return upgradeConfigFile();
+        } catch (Exception e) {
+            return upgradeVersionedConfigFile(e);
+        }
+    }
+
+    private GoConfigHolder upgradeConfigFile() throws Exception {
+        String upgradedXml = this.goConfigMigration.upgradeIfNecessary(this.goConfigFileReader.configXml());
+
+        CruiseConfig cruiseConfig = this.loader.deserializeConfig(upgradedXml);
+
+        return fullConfigSaveNormalFlow.execute(new FullConfigUpdateCommand(cruiseConfig, null), new ArrayList<>(), "Upgrade");
+    }
+
+    private GoConfigHolder upgradeVersionedConfigFile(Exception originalException) throws Exception {
+        LOGGER.warn("Error upgrading config file, trying to upgrade using the versioned config file.");
+
+        GoConfigRevision currentConfigRevision = configRepository.getCurrentRevision();
+        if(currentConfigRevision == null) {
+            LOGGER.warn("There is no versioned configuration to fallback for migration.");
+            throw originalException;
+        }
+
+        try {
+            File backupFile = this.goConfigMigration.revertFileToVersion(fileLocation(), currentConfigRevision);
+            logException(backupFile.getAbsolutePath(), originalException.getMessage());
+
+            return upgradeConfigFile();
+        } catch (Exception e) {
+            LOGGER.warn("The versioned config file could be invalid or migrating the versioned config resulted in an invalid configuration");
+            throw e;
+        }
+    }
+
+    private void logException(String backupFileLocation, String exceptionMessage) {
+        String invalidConfigMessage = String.format("Go encountered an invalid configuration file while starting up. "
+                + "The invalid configuration file has been renamed to ‘%s’ and a new configuration file has been automatically " +
+                "created using the last good configuration. Cause: '%s'", backupFileLocation, exceptionMessage);
+
+        serverHealthService.update(ServerHealthState.warning("Invalid Configuration", invalidConfigMessage, HealthStateType.general(HealthStateScope.forInvalidConfig())));
+        LOGGER.warn(invalidConfigMessage);
+    }
+
+    public File fileLocation() {
+        return new File(systemEnvironment.getCruiseConfigFile());
+    }
+}

--- a/server/src/com/thoughtworks/go/config/GoFileConfigDataSource.java
+++ b/server/src/com/thoughtworks/go/config/GoFileConfigDataSource.java
@@ -86,7 +86,7 @@ public class GoFileConfigDataSource {
         this(upgrader, configRepository, systemEnvironment, timeProvider, serverVersion,
                 new MagicalGoConfigXmlLoader(configCache, configElementImplementationRegistry),
                 new MagicalGoConfigXmlWriter(configCache, configElementImplementationRegistry), serverHealthService,
-                cachedGoPartials, configElementImplementationRegistry, fullConfigSaveMergeFlow, fullConfigSaveNormalFlow,
+                cachedGoPartials, fullConfigSaveMergeFlow, fullConfigSaveNormalFlow,
                 new GoConfigFileReader(systemEnvironment), new GoConfigFileWriter(systemEnvironment));
         this.configElementImplementationRegistry = configElementImplementationRegistry;
     }
@@ -94,9 +94,9 @@ public class GoFileConfigDataSource {
     GoFileConfigDataSource(GoConfigMigration upgrader, ConfigRepository configRepository, SystemEnvironment systemEnvironment,
                            TimeProvider timeProvider, ServerVersion serverVersion, MagicalGoConfigXmlLoader magicalGoConfigXmlLoader,
                            MagicalGoConfigXmlWriter magicalGoConfigXmlWriter, ServerHealthService serverHealthService,
-                           CachedGoPartials cachedGoPartials, ConfigElementImplementationRegistry configElementImplementationRegistry,
-                           FullConfigSaveMergeFlow fullConfigSaveMergeFlow, FullConfigSaveNormalFlow fullConfigSaveNormalFlow,
-                           GoConfigFileReader goConfigFileReader, GoConfigFileWriter goConfigFileWriter) {
+                           CachedGoPartials cachedGoPartials, FullConfigSaveMergeFlow fullConfigSaveMergeFlow,
+                           FullConfigSaveNormalFlow fullConfigSaveNormalFlow, GoConfigFileReader goConfigFileReader,
+                           GoConfigFileWriter goConfigFileWriter) {
         this.configRepository = configRepository;
         this.systemEnvironment = systemEnvironment;
         this.upgrader = upgrader;
@@ -110,7 +110,6 @@ public class GoFileConfigDataSource {
         this.fullConfigSaveNormalFlow = fullConfigSaveNormalFlow;
         this.goConfigFileReader = goConfigFileReader;
         this.goConfigFileWriter = goConfigFileWriter;
-        this.reloadStrategy = reloadStrategy;
     }
 
     public GoFileConfigDataSource reloadEveryTime() {

--- a/server/src/com/thoughtworks/go/config/GoFileConfigDataSource.java
+++ b/server/src/com/thoughtworks/go/config/GoFileConfigDataSource.java
@@ -22,6 +22,7 @@ import com.thoughtworks.go.config.exceptions.*;
 import com.thoughtworks.go.config.registry.ConfigElementImplementationRegistry;
 import com.thoughtworks.go.config.remote.ConfigOrigin;
 import com.thoughtworks.go.config.remote.PartialConfig;
+import com.thoughtworks.go.config.update.FullConfigUpdateCommand;
 import com.thoughtworks.go.domain.GoConfigRevision;
 import com.thoughtworks.go.server.domain.Username;
 import com.thoughtworks.go.server.util.ServerVersion;
@@ -32,15 +33,12 @@ import com.thoughtworks.go.serverhealth.ServerHealthState;
 import com.thoughtworks.go.service.ConfigRepository;
 import com.thoughtworks.go.util.*;
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.output.ByteArrayOutputStream;
 import org.apache.log4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import java.io.*;
-import java.nio.channels.FileChannel;
-import java.nio.channels.FileLock;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.List;
@@ -69,20 +67,33 @@ public class GoFileConfigDataSource {
     private Cloner cloner = new Cloner();
     public static final String FILESYSTEM = "Filesystem";
     private ServerHealthService serverHealthService;
+    private ConfigElementImplementationRegistry configElementImplementationRegistry;
+    private final FullConfigSaveMergeFlow fullConfigSaveMergeFlow;
+    private final FullConfigSaveNormalFlow fullConfigSaveNormalFlow;
+    private GoConfigFileReader goConfigFileReader;
+    private GoConfigFileWriter goConfigFileWriter;
 
     /* Will only upgrade cruise config file on application startup. */
     @Autowired
-    public GoFileConfigDataSource(GoConfigMigration upgrader, ConfigRepository configRepository, SystemEnvironment systemEnvironment, TimeProvider timeProvider, ConfigCache configCache,
-                                  ServerVersion serverVersion, ConfigElementImplementationRegistry configElementImplementationRegistry,
-                                  ServerHealthService serverHealthService, CachedGoPartials cachedGoPartials) {
+    public GoFileConfigDataSource(GoConfigMigration upgrader, ConfigRepository configRepository, SystemEnvironment systemEnvironment,
+                                  TimeProvider timeProvider, ConfigCache configCache, ServerVersion serverVersion,
+                                  ConfigElementImplementationRegistry configElementImplementationRegistry,
+                                  ServerHealthService serverHealthService, CachedGoPartials cachedGoPartials,
+                                  FullConfigSaveMergeFlow fullConfigSaveMergeFlow, FullConfigSaveNormalFlow fullConfigSaveNormalFlow) {
         this(upgrader, configRepository, systemEnvironment, timeProvider, serverVersion,
                 new MagicalGoConfigXmlLoader(configCache, configElementImplementationRegistry),
-                new MagicalGoConfigXmlWriter(configCache, configElementImplementationRegistry), serverHealthService, cachedGoPartials);
+                new MagicalGoConfigXmlWriter(configCache, configElementImplementationRegistry), serverHealthService,
+                cachedGoPartials, configElementImplementationRegistry, fullConfigSaveMergeFlow, fullConfigSaveNormalFlow,
+                new GoConfigFileReader(systemEnvironment), new GoConfigFileWriter(systemEnvironment));
+        this.configElementImplementationRegistry = configElementImplementationRegistry;
     }
 
-    GoFileConfigDataSource(GoConfigMigration upgrader, ConfigRepository configRepository, SystemEnvironment systemEnvironment, TimeProvider timeProvider,
-                           ServerVersion serverVersion, MagicalGoConfigXmlLoader magicalGoConfigXmlLoader, MagicalGoConfigXmlWriter magicalGoConfigXmlWriter,
-                           ServerHealthService serverHealthService, CachedGoPartials cachedGoPartials) {
+    GoFileConfigDataSource(GoConfigMigration upgrader, ConfigRepository configRepository, SystemEnvironment systemEnvironment,
+                           TimeProvider timeProvider, ServerVersion serverVersion, MagicalGoConfigXmlLoader magicalGoConfigXmlLoader,
+                           MagicalGoConfigXmlWriter magicalGoConfigXmlWriter, ServerHealthService serverHealthService,
+                           CachedGoPartials cachedGoPartials, ConfigElementImplementationRegistry configElementImplementationRegistry,
+                           FullConfigSaveMergeFlow fullConfigSaveMergeFlow, FullConfigSaveNormalFlow fullConfigSaveNormalFlow,
+                           GoConfigFileReader goConfigFileReader, GoConfigFileWriter goConfigFileWriter) {
         this.configRepository = configRepository;
         this.systemEnvironment = systemEnvironment;
         this.upgrader = upgrader;
@@ -92,6 +103,11 @@ public class GoFileConfigDataSource {
         this.magicalGoConfigXmlWriter = magicalGoConfigXmlWriter;
         this.serverHealthService = serverHealthService;
         this.cachedGoPartials = cachedGoPartials;
+        this.fullConfigSaveMergeFlow = fullConfigSaveMergeFlow;
+        this.fullConfigSaveNormalFlow = fullConfigSaveNormalFlow;
+        this.goConfigFileReader = goConfigFileReader;
+        this.goConfigFileWriter = goConfigFileWriter;
+        this.reloadStrategy = reloadStrategy;
     }
 
     public GoFileConfigDataSource reloadEveryTime() {
@@ -128,9 +144,13 @@ public class GoFileConfigDataSource {
             LOGGER.info("Config file changed at " + result.modifiedTime);
             LOGGER.info("Reloading config file: " + configFile);
 
-            encryptPasswords(configFile);
-            LOGGER.debug("Detected change in config file.");
-            return forceLoad(configFile);
+            if(systemEnvironment.optimizeFullConfigSave()) {
+                return forceLoad();
+            } else {
+                encryptPasswords(configFile);
+                LOGGER.debug("Detected change in config file.");
+                return forceLoad(configFile);
+            }
         }
     }
 
@@ -143,6 +163,38 @@ public class GoFileConfigDataSource {
         if (!currentContent.equals(postEncryptContent)) {
             LOGGER.debug("[Encrypt] Writing config to file");
             FileUtils.writeStringToFile(configFile, postEncryptContent);
+        }
+    }
+
+    synchronized GoConfigHolder forceLoad() throws Exception {
+        File configFile = goConfigFileReader.fileLocation();
+
+        CruiseConfig cruiseConfig = this.magicalGoConfigXmlLoader.deserializeConfig(goConfigFileReader.configXml());
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug(String.format("Reloading config file: %s",configFile.getAbsolutePath()));
+        }
+
+        GoConfigHolder goConfigHolder;
+        try {
+            try {
+                goConfigHolder = fullConfigSaveNormalFlow.execute(new FullConfigUpdateCommand(cruiseConfig, null), cachedGoPartials.lastKnownPartials(), FILESYSTEM);
+            } catch (GoConfigInvalidException e) {
+                if (!canUpdateConfigWithLastValidPartials())
+                    throw e;
+
+                goConfigHolder = fullConfigSaveNormalFlow.execute(new FullConfigUpdateCommand(cruiseConfig, null), cachedGoPartials.lastValidPartials(), FILESYSTEM);
+            }
+            reloadStrategy.latestState(goConfigHolder.config);
+            return goConfigHolder;
+        } catch (Exception e) {
+            LOGGER.error(String.format("Unable to load config file: %s %s", configFile.getAbsolutePath(), e.getMessage()), e);
+            if (configFile.exists()) {
+                LOGGER.warn(String.format("--- %s ---", configFile.getAbsolutePath()));
+                LOGGER.warn(FileUtil.readContentFromFile(configFile));
+                LOGGER.warn("------");
+            }
+            LOGGER.debug(e);
+            throw e;
         }
     }
 
@@ -198,31 +250,7 @@ public class GoFileConfigDataSource {
     }
 
     private void writeToConfigXmlFile(String content) {
-        FileChannel channel = null;
-        FileOutputStream outputStream = null;
-        FileLock lock = null;
-        try {
-            RandomAccessFile randomAccessFile = new RandomAccessFile(fileLocation(), "rw");
-            channel = randomAccessFile.getChannel();
-            lock = channel.lock();
-            randomAccessFile.seek(0);
-            randomAccessFile.setLength(0);
-            outputStream = new FileOutputStream(randomAccessFile.getFD());
-
-            IOUtils.write(content, outputStream, UTF_8);
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        } finally {
-            if (channel != null && lock != null) {
-                try {
-                    lock.release();
-                    channel.close();
-                    IOUtils.closeQuietly(outputStream);
-                } catch (IOException e) {
-                    LOGGER.error("Error occured when releasing file lock and closing file.", e);
-                }
-            }
-        }
+        this.goConfigFileWriter.writeToConfigXmlFile(content);
     }
 
     public synchronized EntityConfigSaveResult writeEntityWithLock(EntityConfigUpdateCommand updatingCommand, GoConfigHolder configHolder, Username currentUser) {
@@ -291,6 +319,8 @@ public class GoFileConfigDataSource {
         }
     }
 
+//  This method should be removed once we have API's for all entities which should use writeEntityWithLock and full config save should use writeFullConfigWithLock
+    @Deprecated
     public synchronized GoConfigSaveResult writeWithLock(UpdateConfigCommand updatingCommand, GoConfigHolder configHolder) {
         try {
 
@@ -338,6 +368,63 @@ public class GoFileConfigDataSource {
         }
     }
 
+    public synchronized GoConfigSaveResult writeFullConfigWithLock(FullConfigUpdateCommand updatingCommand, GoConfigHolder configHolder) {
+        try {
+            GoConfigHolder validatedConfigHolder;
+            try {
+                validatedConfigHolder = trySavingConfigWithLastKnownPartials(updatingCommand, configHolder);
+            } catch (Exception e) {
+                if (!canUpdateConfigWithLastValidPartials())
+                    throw e;
+
+                LOGGER.warn(String.format("Merged config update operation failed on LATEST %s partials. Falling back to using LAST VALID %s partials." +
+                        " Exception message was: %s", cachedGoPartials.lastKnownPartials().size(), cachedGoPartials.lastValidPartials().size(), e.getMessage()), e);
+
+                validatedConfigHolder = trySavingConfigWithLastValidPartials(updatingCommand, configHolder);
+            }
+            ConfigSaveState configSaveState = shouldMergeConfig(updatingCommand, configHolder) ? ConfigSaveState.MERGED : ConfigSaveState.UPDATED;
+            return new GoConfigSaveResult(validatedConfigHolder, configSaveState);
+        } catch (ConfigFileHasChangedException e) {
+            LOGGER.warn(String.format("Configuration file could not be merged successfully after a concurrent edit: %s", e.getMessage()), e);
+            throw e;
+        } catch (GoConfigInvalidException e) {
+            LOGGER.warn(String.format("Configuration file is invalid: %s", e.getMessage()), e);
+            throw bomb(e.getMessage(), e);
+        } catch (Exception e) {
+            LOGGER.error(String.format("Configuration file is not valid: %s", e.getMessage()), e);
+            throw bomb(e.getMessage(), e);
+        } finally {
+            LOGGER.debug("[Config Save] Done writing with lock");
+        }
+    }
+
+    private GoConfigHolder trySavingConfigWithLastKnownPartials(FullConfigUpdateCommand updateCommand, GoConfigHolder configHolder) throws Exception {
+        return trySavingFullConfig(updateCommand, configHolder, cachedGoPartials.lastKnownPartials());
+    }
+
+    private GoConfigHolder trySavingConfigWithLastValidPartials(FullConfigUpdateCommand updateCommand, GoConfigHolder configHolder) throws Exception {
+        List<PartialConfig> lastValidPartials = cachedGoPartials.lastValidPartials();
+        GoConfigHolder goConfigHolder;
+
+        try {
+            goConfigHolder = trySavingFullConfig(updateCommand, configHolder, cachedGoPartials.lastValidPartials());
+            LOGGER.info(String.format("Update operation on merged configuration succeeded with old %s LAST VALID partials.", lastValidPartials.size()));
+        } catch (GoConfigInvalidException fallbackFailed) {
+            LOGGER.warn(String.format(
+                    "Merged config update operation failed using fallback LAST VALID %s partials. Exception message was: %s",
+                    lastValidPartials.size(), fallbackFailed.getMessage()), fallbackFailed);
+            throw new GoConfigInvalidMergeException("Fallback merge failed", lastValidPartials, fallbackFailed);
+        }
+        return goConfigHolder;
+    }
+
+    private boolean canUpdateConfigWithLastValidPartials() {
+        List<PartialConfig> lastKnownPartials = cachedGoPartials.lastKnownPartials();
+        List<PartialConfig> lastValidPartials = cachedGoPartials.lastValidPartials();
+
+        return (!lastKnownPartials.isEmpty() && !areKnownPartialsSameAsValidPartials(lastKnownPartials, lastValidPartials));
+    }
+
     protected boolean areKnownPartialsSameAsValidPartials(List<PartialConfig> lastKnownPartials, List<PartialConfig> lastValidPartials) {
         if (lastKnownPartials.size() != lastValidPartials.size()) {
             return false;
@@ -362,6 +449,27 @@ public class GoFileConfigDataSource {
         CruiseConfig mergedCruiseConfigForEdit = cloner.deepClone(validatedConfigHolder.configForEdit);
         mergedCruiseConfigForEdit.merge(partialConfigs, true);
         validatedConfigHolder.mergedConfigForEdit = mergedCruiseConfigForEdit;
+    }
+
+    private GoConfigHolder trySavingFullConfig(FullConfigUpdateCommand updatingCommand, GoConfigHolder configHolder, List<PartialConfig> partials) throws Exception {
+        String userName = getConfigUpdatingUser(updatingCommand).getUserName();
+        GoConfigHolder goConfigHolder;
+
+        LOGGER.debug("[Config Save] ==-- Getting modified config");
+
+        if (shouldMergeConfig(updatingCommand, configHolder)) {
+            if (!systemEnvironment.get(SystemEnvironment.ENABLE_CONFIG_MERGE_FEATURE)) {
+                throw new ConfigMergeException(ConfigFileHasChangedException.CONFIG_CHANGED_PLEASE_REFRESH);
+            }
+                goConfigHolder = this.fullConfigSaveMergeFlow.execute(updatingCommand, partials, userName);
+        } else {
+            goConfigHolder = this.fullConfigSaveNormalFlow.execute(updatingCommand, partials, userName);
+        }
+
+        reloadStrategy.latestState(goConfigHolder.config);
+
+        LOGGER.info(String.format("[Configuration Changed] Saving updated configuration."));
+        return goConfigHolder;
     }
 
     private GoConfigHolder trySavingConfig(UpdateConfigCommand updatingCommand, GoConfigHolder configHolder, List<PartialConfig> partials) throws Exception {

--- a/server/src/com/thoughtworks/go/config/update/FullConfigUpdateCommand.java
+++ b/server/src/com/thoughtworks/go/config/update/FullConfigUpdateCommand.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2016 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.config.update;
+
+import com.thoughtworks.go.config.CruiseConfig;
+import com.thoughtworks.go.config.NoOverwriteUpdateConfigCommand;
+
+public class FullConfigUpdateCommand implements NoOverwriteUpdateConfigCommand{
+    private final CruiseConfig configForEdit;
+    private final String unmodifiedMd5;
+
+    public FullConfigUpdateCommand(CruiseConfig configForEdit, String unmodifiedMd5) {
+        this.configForEdit = configForEdit;
+        this.unmodifiedMd5 = unmodifiedMd5;
+    }
+
+    @Override
+    public String unmodifiedMd5() {
+        return this.unmodifiedMd5;
+    }
+
+    @Override
+    public CruiseConfig update(CruiseConfig cruiseConfig) throws Exception {
+        return configForEdit;
+    }
+
+    public CruiseConfig configForEdit() {
+        return this.configForEdit;
+    }
+}

--- a/server/src/com/thoughtworks/go/server/initializers/ApplicationInitializer.java
+++ b/server/src/com/thoughtworks/go/server/initializers/ApplicationInitializer.java
@@ -105,7 +105,7 @@ public class ApplicationInitializer implements ApplicationListener<ContextRefres
             configCipherUpdater.migrate(); // Should be done before configs get loaded
             configElementImplementationRegistrar.initialize();
             configRepository.initialize();
-            goFileConfigDataSource.upgradeIfNecessary();
+            cachedGoConfig.upgradeConfig();
             cachedGoConfig.loadConfigIfNull();
             goConfigService.initialize();
             entityHashingService.initialize();

--- a/server/test/common/com/thoughtworks/go/helpers/LogFileHelper.java
+++ b/server/test/common/com/thoughtworks/go/helpers/LogFileHelper.java
@@ -214,13 +214,13 @@ public final class LogFileHelper {
         private File artifactsDir;
 
         public FakeGoConfigService(File artifactsDir) throws IOException {
-            super(new GoConfigDao(new CachedGoConfig(new ServerHealthService(), mock(GoFileConfigDataSource.class), mock(CachedGoPartials.class))) {
+            super(new GoConfigDao(new CachedGoConfig(new ServerHealthService(), mock(GoFileConfigDataSource.class), mock(CachedGoPartials.class), null, null)) {
                 public CruiseConfig load() {
                     return null;
                 }
             }, null, new SystemTimeClock(), new GoConfigMigration(mock(ConfigRepository.class), new TimeProvider(), new ConfigCache(), ConfigElementImplementationRegistryMother.withNoPlugins()
                     ), null, null, ConfigElementImplementationRegistryMother.withNoPlugins(),
-                    new InstanceFactory(), mock(CachedGoPartials.class));
+                    new InstanceFactory(), mock(CachedGoPartials.class), null);
             this.artifactsDir = artifactsDir;
         }
 

--- a/server/test/integration/com/thoughtworks/go/config/GoConfigMigrationIntegrationTest.java
+++ b/server/test/integration/com/thoughtworks/go/config/GoConfigMigrationIntegrationTest.java
@@ -24,7 +24,6 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 
 import com.thoughtworks.go.config.elastic.ElasticProfile;
 import com.thoughtworks.go.config.elastic.ElasticProfiles;
@@ -1544,8 +1543,9 @@ public class GoConfigMigrationIntegrationTest {
         }, configRepository, new TimeProvider(), configCache, registry
         );
         SystemEnvironment sysEnv = new SystemEnvironment();
+        FullConfigSaveNormalFlow normalFlow = new FullConfigSaveNormalFlow(configCache, registry, sysEnv, serverVersion, new TimeProvider(), configRepository, cachedGoPartials);
         GoFileConfigDataSource configDataSource = new GoFileConfigDataSource(migration, configRepository, sysEnv, new TimeProvider(), configCache, serverVersion,
-                registry, serverHealthService, cachedGoPartials);
+                registry, serverHealthService, cachedGoPartials, null, normalFlow);
         configDataSource.upgradeIfNecessary();
         return configDataSource.forceLoad(configFile);
     }

--- a/server/test/integration/com/thoughtworks/go/config/GoFileConfigDataSourceTest.java
+++ b/server/test/integration/com/thoughtworks/go/config/GoFileConfigDataSourceTest.java
@@ -542,7 +542,7 @@ public class GoFileConfigDataSourceTest {
         ServerHealthService serverHealthService = mock(ServerHealthService.class);
         CachedGoPartials cachedGoPartials = mock(CachedGoPartials.class);
         ConfigRepository configRepository = mock(ConfigRepository.class);
-        dataSource = new GoFileConfigDataSource(migration, configRepository, systemEnvironment, timeProvider, mock(ServerVersion.class), loader, writer, serverHealthService, cachedGoPartials, null, null, null, null, null);
+        dataSource = new GoFileConfigDataSource(migration, configRepository, systemEnvironment, timeProvider, mock(ServerVersion.class), loader, writer, serverHealthService, cachedGoPartials, null, null, null, null);
 
         final String pipelineName = UUID.randomUUID().toString();
         BasicCruiseConfig cruiseConfig = GoConfigMother.configWithPipelines(pipelineName);
@@ -758,7 +758,7 @@ public class GoFileConfigDataSourceTest {
         when(fullConfigSaveNormalFlow.execute(commandArgumentCaptor.capture(), listArgumentCaptor.capture(), stringArgumentCaptor.capture())).thenReturn(goConfigHolder);
 
         GoFileConfigDataSource source = new GoFileConfigDataSource(null, null, systemEnvironment, null, null, loader, null, null, cachedGoPartials,
-                null, fullConfigSaveMergeFlow, fullConfigSaveNormalFlow, goConfigFileReader, null);
+                fullConfigSaveMergeFlow, fullConfigSaveNormalFlow, goConfigFileReader, null);
 
         GoConfigHolder configHolder = source.load();
 
@@ -794,7 +794,7 @@ public class GoFileConfigDataSourceTest {
                 .thenThrow(new GoConfigInvalidException(null, null)).thenReturn(goConfigHolder);
 
         GoFileConfigDataSource source = new GoFileConfigDataSource(null, null, systemEnvironment, null, null, loader, null, null, cachedGoPartials,
-                null, fullConfigSaveMergeFlow, fullConfigSaveNormalFlow, goConfigFileReader, null);
+                fullConfigSaveMergeFlow, fullConfigSaveNormalFlow, goConfigFileReader, null);
 
         GoConfigHolder configHolder = source.load();
 

--- a/server/test/integration/com/thoughtworks/go/server/security/IsSecurityEnabledVoterTest.java
+++ b/server/test/integration/com/thoughtworks/go/server/security/IsSecurityEnabledVoterTest.java
@@ -54,7 +54,7 @@ public class IsSecurityEnabledVoterTest {
         configHelper.addSecurityWithBogusLdapConfig(false);
         GoConfigService configService = new GoConfigService(goConfigDao, null, new SystemTimeClock(), mock(GoConfigMigration.class), null, null,
                 ConfigElementImplementationRegistryMother.withNoPlugins(),
-                new InstanceFactory(), mock(CachedGoPartials.class));
+                new InstanceFactory(), mock(CachedGoPartials.class), null);
         IsSecurityEnabledVoter voter = new IsSecurityEnabledVoter(configService);
         int accessStatus = voter.vote(null, null, null);
         assertThat(accessStatus, Is.is(AccessDecisionVoter.ACCESS_ABSTAIN));

--- a/server/test/unit/com/thoughtworks/go/config/FullConfigSaveMergeFlowTest.java
+++ b/server/test/unit/com/thoughtworks/go/config/FullConfigSaveMergeFlowTest.java
@@ -1,0 +1,228 @@
+/*
+ * Copyright 2016 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.config;
+
+import com.thoughtworks.go.config.exceptions.ConfigMergeException;
+import com.thoughtworks.go.config.exceptions.ConfigMergePostValidationException;
+import com.thoughtworks.go.config.exceptions.ConfigMergePreValidationException;
+import com.thoughtworks.go.config.registry.ConfigElementImplementationRegistry;
+import com.thoughtworks.go.config.remote.PartialConfig;
+import com.thoughtworks.go.config.update.FullConfigUpdateCommand;
+import com.thoughtworks.go.domain.GoConfigRevision;
+import com.thoughtworks.go.server.util.ServerVersion;
+import com.thoughtworks.go.service.ConfigRepository;
+import com.thoughtworks.go.util.SystemEnvironment;
+import com.thoughtworks.go.util.TimeProvider;
+import org.jdom.Document;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.*;
+
+public class FullConfigSaveMergeFlowTest {
+    private MagicalGoConfigXmlLoader loader;
+    private MagicalGoConfigXmlWriter writer;
+    private ConfigElementImplementationRegistry configElementImplementationRegistry;
+    private FullConfigSaveMergeFlow flow;
+    private FullConfigUpdateCommand updateConfigCommand;
+    private SystemEnvironment systemEnvironment;
+    private CruiseConfig configForEdit;
+    private Document document;
+    private GoConfigFileWriter fileWriter;
+    private ServerVersion serverVersion;
+    private TimeProvider timeProvider;
+    private ConfigRepository configRepository;
+    private CachedGoPartials cachedGoPartials;
+    private List<PartialConfig> partials;
+
+    @Before
+    public void setup() throws Exception {
+        configForEdit = mock(CruiseConfig.class);
+        updateConfigCommand = new FullConfigUpdateCommand(configForEdit, "md5");
+        loader = mock(MagicalGoConfigXmlLoader.class);
+        writer = mock(MagicalGoConfigXmlWriter.class);
+        document = mock(Document.class);
+        systemEnvironment = mock(SystemEnvironment.class);
+        fileWriter = mock(GoConfigFileWriter.class);
+        serverVersion = mock(ServerVersion.class);
+        timeProvider = mock(TimeProvider.class);
+        configRepository = mock(ConfigRepository.class);
+        cachedGoPartials = mock(CachedGoPartials.class);
+        configElementImplementationRegistry = mock(ConfigElementImplementationRegistry.class);
+        partials = new ArrayList<>();
+
+        flow = new FullConfigSaveMergeFlow(loader, writer, configElementImplementationRegistry, serverVersion, timeProvider,
+                configRepository, cachedGoPartials, fileWriter);
+    }
+
+    @Test
+    public void shouldUpdateGivenConfigWithPartials() throws Exception {
+        when(writer.documentFrom(configForEdit)).thenReturn(document);
+        when(writer.toString(document)).thenReturn("cruise_config");
+        when(loader.loadConfigHolder(any(String.class), any(MagicalGoConfigXmlLoader.Callback.class)))
+                .thenReturn(new GoConfigHolder(new BasicCruiseConfig(), new BasicCruiseConfig()));
+
+        flow.execute(updateConfigCommand, partials, null);
+
+        verify(configForEdit).setPartials(partials);
+    }
+
+    @Test
+    public void shouldPreprocessAndValidateTheUpdatedConfig() throws Exception {
+        when(writer.documentFrom(configForEdit)).thenReturn(document);
+        when(writer.toString(document)).thenReturn("cruise_config");
+        when(loader.loadConfigHolder(any(String.class), any(MagicalGoConfigXmlLoader.Callback.class)))
+                .thenReturn(new GoConfigHolder(new BasicCruiseConfig(), new BasicCruiseConfig()));
+
+        flow.execute(updateConfigCommand, partials, null);
+
+        verify(loader).preprocessAndValidate(configForEdit);
+    }
+
+    @Test
+    public void shouldValidateDomRepresentationOfCruiseConfig() throws Exception {
+        when(writer.documentFrom(configForEdit)).thenReturn(document);
+        when(writer.toString(document)).thenReturn("cruise_config");
+        when(loader.loadConfigHolder(any(String.class), any(MagicalGoConfigXmlLoader.Callback.class)))
+                .thenReturn(new GoConfigHolder(new BasicCruiseConfig(), new BasicCruiseConfig()));
+
+        flow.execute(updateConfigCommand, partials, null);
+
+        verify(writer).verifyXsdValid(document);
+    }
+
+    @Test(expected = ConfigMergePreValidationException.class)
+    public void shouldErrorOutIfPreprocessOrValidateFails() throws Exception {
+        when(writer.documentFrom(configForEdit)).thenReturn(document);
+        when(loader.preprocessAndValidate(configForEdit)).thenThrow(new Exception());
+        when(writer.toString(document)).thenReturn("cruise_config");
+        when(loader.loadConfigHolder(any(String.class), any(MagicalGoConfigXmlLoader.Callback.class)))
+                .thenReturn(new GoConfigHolder(new BasicCruiseConfig(), new BasicCruiseConfig()));
+
+        flow.execute(updateConfigCommand, partials, null);
+    }
+
+    @Test(expected = ConfigMergePostValidationException.class)
+    public void shouldErrorOutIfSavingConfigPostValidationFails() throws Exception {
+        when(writer.documentFrom(configForEdit)).thenReturn(document);
+        when(writer.toString(document)).thenReturn("cruise_config");
+        when(loader.loadConfigHolder(any(String.class), any(MagicalGoConfigXmlLoader.Callback.class)))
+                .thenThrow(new Exception());
+        when(configRepository.getConfigMergedWithLatestRevision(any(GoConfigRevision.class), anyString())).thenReturn("merged_config");
+
+        flow.execute(updateConfigCommand, partials, null);
+    }
+
+    @Test(expected = ConfigMergeException.class)
+    public void shouldErrorOutIfConfigMergeFails() throws Exception {
+        when(writer.documentFrom(configForEdit)).thenReturn(document);
+        when(writer.toString(document)).thenReturn("cruise_config");
+        when(configRepository.getConfigMergedWithLatestRevision(any(GoConfigRevision.class), anyString())).thenThrow(new ConfigMergeException("merge fails"));
+
+        flow.execute(updateConfigCommand, partials, null);
+    }
+
+    @Test
+    public void shouldMergeConfigWithLatestRevision() throws Exception {
+        when(writer.documentFrom(configForEdit)).thenReturn(document);
+        when(writer.toString(document)).thenReturn("cruise_config");
+        when(loader.loadConfigHolder(any(String.class), any(MagicalGoConfigXmlLoader.Callback.class)))
+                .thenReturn(new GoConfigHolder(new BasicCruiseConfig(), new BasicCruiseConfig()));
+
+        flow.execute(updateConfigCommand, partials, null);
+
+        verify(configRepository).getConfigMergedWithLatestRevision(new GoConfigRevision("config", "temporary-md5-for-branch", "user", "version", new TimeProvider()), "md5");
+    }
+
+    @Test
+    public void shouldLoadConfigHolderFromTheMergedConfigXML() throws Exception {
+        String mergedConfig = "merged_config";
+
+        when(writer.documentFrom(configForEdit)).thenReturn(document);
+        when(configRepository.getConfigMergedWithLatestRevision(any(GoConfigRevision.class), any(String.class))).thenReturn(mergedConfig);
+        when(writer.toString(document)).thenReturn("cruise_config");
+        when(loader.loadConfigHolder(any(String.class), any(MagicalGoConfigXmlLoader.Callback.class)))
+                .thenReturn(new GoConfigHolder(new BasicCruiseConfig(), new BasicCruiseConfig()));
+
+        flow.execute(updateConfigCommand, partials, null);
+
+        verify(loader).loadConfigHolder(any(String.class), any(MagicalGoConfigXmlLoader.Callback.class));
+    }
+
+    @Test
+    public void shouldPersistXmlRepresentationOfMergedCruiseConfig() throws Exception {
+        String mergedConfig = "merged_config";
+
+        when(writer.documentFrom(configForEdit)).thenReturn(document);
+        when(configRepository.getConfigMergedWithLatestRevision(any(GoConfigRevision.class), any(String.class))).thenReturn(mergedConfig);
+        when(writer.toString(document)).thenReturn("cruise_config");
+        when(loader.loadConfigHolder(any(String.class), any(MagicalGoConfigXmlLoader.Callback.class)))
+                .thenReturn(new GoConfigHolder(new BasicCruiseConfig(), new BasicCruiseConfig()));
+
+        flow.execute(updateConfigCommand, partials, null);
+
+        verify(fileWriter).writeToConfigXmlFile(mergedConfig);
+    }
+
+    @Test
+    public void shouldCheckinGeneratedConfigXMLToConfigRepo() throws Exception {
+        String mergedConfig = "merged_config";
+        Date currentTime = mock(Date.class);
+        ArgumentCaptor<GoConfigRevision> revisionArgumentCaptor = ArgumentCaptor.forClass(GoConfigRevision.class);
+
+        when(writer.documentFrom(configForEdit)).thenReturn(document);
+        when(configRepository.getConfigMergedWithLatestRevision(any(GoConfigRevision.class), any(String.class))).thenReturn(mergedConfig);
+        when(writer.toString(document)).thenReturn("cruise_config");
+        when(serverVersion.version()).thenReturn("16.13.0");
+        when(timeProvider.currentTime()).thenReturn(currentTime);
+        when(loader.loadConfigHolder(any(String.class), any(MagicalGoConfigXmlLoader.Callback.class)))
+                .thenReturn(new GoConfigHolder(new BasicCruiseConfig(), new BasicCruiseConfig()));
+        doNothing().when(configRepository).checkin(revisionArgumentCaptor.capture());
+
+        flow.execute(updateConfigCommand, partials, "test_user");
+
+        GoConfigRevision goConfigRevision = revisionArgumentCaptor.getValue();
+        assertThat(goConfigRevision.getContent(), is(mergedConfig));
+        assertThat(goConfigRevision.getUsername(), is("test_user"));
+        assertThat(goConfigRevision.getMd5(), is(updateConfigCommand.configForEdit().getMd5()));
+        assertThat(goConfigRevision.getGoVersion(), is("16.13.0"));
+    }
+
+    @Test
+    public void shouldUpdateCachedGoPartialsWithValidPartials() throws Exception {
+        String mergedConfig = "merged_config";
+        ArrayList<PartialConfig> partials = new ArrayList<>();
+
+        when(writer.documentFrom(configForEdit)).thenReturn(document);
+        when(configRepository.getConfigMergedWithLatestRevision(any(GoConfigRevision.class), any(String.class))).thenReturn(mergedConfig);
+        when(writer.toString(document)).thenReturn("cruise_config");
+        when(loader.loadConfigHolder(any(String.class), any(MagicalGoConfigXmlLoader.Callback.class)))
+                .thenReturn(new GoConfigHolder(new BasicCruiseConfig(), new BasicCruiseConfig()));
+
+        flow.execute(updateConfigCommand, partials, null);
+
+        verify(cachedGoPartials).markAsValid(partials);
+    }
+}

--- a/server/test/unit/com/thoughtworks/go/config/FullConfigSaveMergeFlowTest.java
+++ b/server/test/unit/com/thoughtworks/go/config/FullConfigSaveMergeFlowTest.java
@@ -31,6 +31,7 @@ import org.jdom.Document;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
 
 import java.util.ArrayList;
 import java.util.Date;
@@ -220,9 +221,12 @@ public class FullConfigSaveMergeFlowTest {
         when(writer.toString(document)).thenReturn("cruise_config");
         when(loader.loadConfigHolder(any(String.class), any(MagicalGoConfigXmlLoader.Callback.class)))
                 .thenReturn(new GoConfigHolder(new BasicCruiseConfig(), new BasicCruiseConfig()));
+        InOrder inOrder = inOrder(configRepository, fileWriter, cachedGoPartials);
 
         flow.execute(updateConfigCommand, partials, null);
 
-        verify(cachedGoPartials).markAsValid(partials);
+        inOrder.verify(configRepository).checkin(any(GoConfigRevision.class));
+        inOrder.verify(fileWriter).writeToConfigXmlFile(any(String.class));
+        inOrder.verify(cachedGoPartials).markAsValid(partials);
     }
 }

--- a/server/test/unit/com/thoughtworks/go/config/FullConfigSaveNormalFlowTest.java
+++ b/server/test/unit/com/thoughtworks/go/config/FullConfigSaveNormalFlowTest.java
@@ -29,6 +29,7 @@ import org.jdom.Document;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
 
 import java.util.ArrayList;
 import java.util.Date;
@@ -37,6 +38,7 @@ import java.util.List;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.inOrder;
 
 public class FullConfigSaveNormalFlowTest {
     private MagicalGoConfigXmlLoader loader;
@@ -145,15 +147,18 @@ public class FullConfigSaveNormalFlowTest {
     }
 
     @Test
-    public void shouldUpdateCachedGoPartialsWithValidPartials() throws Exception {
+    public void shouldUpdateCachedGoPartialsWithValidPartialsPostAllSteps() throws Exception {
         String configAsXml = "cruise config as xml";
 
         when(writer.documentFrom(configForEdit)).thenReturn(document);
         when(writer.toString(document)).thenReturn(configAsXml);
         when(loader.preprocessAndValidate(configForEdit)).thenReturn(new BasicCruiseConfig());
+        InOrder inOrder = inOrder(configRepository, fileWriter, cachedGoPartials);
 
         flow.execute(updateConfigCommand, partials, null);
 
-        verify(cachedGoPartials).markAsValid(partials);
+        inOrder.verify(configRepository).checkin(any(GoConfigRevision.class));
+        inOrder.verify(fileWriter).writeToConfigXmlFile(any(String.class));
+        inOrder.verify(cachedGoPartials).markAsValid(partials);
     }
 }

--- a/server/test/unit/com/thoughtworks/go/config/FullConfigSaveNormalFlowTest.java
+++ b/server/test/unit/com/thoughtworks/go/config/FullConfigSaveNormalFlowTest.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright 2016 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.config;
+
+import com.thoughtworks.go.config.registry.ConfigElementImplementationRegistry;
+import com.thoughtworks.go.config.remote.PartialConfig;
+import com.thoughtworks.go.config.update.FullConfigUpdateCommand;
+import com.thoughtworks.go.domain.GoConfigRevision;
+import com.thoughtworks.go.server.util.ServerVersion;
+import com.thoughtworks.go.service.ConfigRepository;
+import com.thoughtworks.go.util.SystemEnvironment;
+import com.thoughtworks.go.util.TimeProvider;
+import org.hamcrest.core.Is;
+import org.jdom.Document;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.mockito.Mockito.*;
+
+public class FullConfigSaveNormalFlowTest {
+    private MagicalGoConfigXmlLoader loader;
+    private MagicalGoConfigXmlWriter writer;
+    private ConfigElementImplementationRegistry configElementImplementationRegistry;
+    private FullConfigSaveNormalFlow flow;
+    private FullConfigUpdateCommand updateConfigCommand;
+    private SystemEnvironment systemEnvironment;
+    private CruiseConfig configForEdit;
+    private Document document;
+    private GoConfigFileWriter fileWriter;
+    private ServerVersion serverVersion;
+    private TimeProvider timeProvider;
+    private ConfigRepository configRepository;
+    private CachedGoPartials cachedGoPartials;
+    private List<PartialConfig> partials;
+
+    @Before
+    public void setup() throws Exception {
+        configForEdit = new BasicCruiseConfig();
+        updateConfigCommand = new FullConfigUpdateCommand(configForEdit, "md5");
+        loader = mock(MagicalGoConfigXmlLoader.class);
+        writer = mock(MagicalGoConfigXmlWriter.class);
+        document = mock(Document.class);
+        systemEnvironment = mock(SystemEnvironment.class);
+        fileWriter = mock(GoConfigFileWriter.class);
+        serverVersion = mock(ServerVersion.class);
+        timeProvider = mock(TimeProvider.class);
+        configRepository = mock(ConfigRepository.class);
+        cachedGoPartials = mock(CachedGoPartials.class);
+        configElementImplementationRegistry = mock(ConfigElementImplementationRegistry.class);
+        partials = new ArrayList<>();
+
+        flow = new FullConfigSaveNormalFlow(loader, writer, configElementImplementationRegistry, serverVersion, timeProvider,
+                configRepository, cachedGoPartials, fileWriter);
+    }
+
+    @Test
+    public void shouldUpdateGivenConfigWithPartials() throws Exception {
+        when(writer.documentFrom(configForEdit)).thenReturn(document);
+        when(writer.toString(document)).thenReturn("cruise_config");
+        when(loader.preprocessAndValidate(configForEdit)).thenReturn(new BasicCruiseConfig());
+
+        flow.execute(updateConfigCommand, partials, null);
+
+        assertThat(configForEdit.getPartials(), Is.<List<PartialConfig>>is(partials));
+    }
+
+    @Test
+    public void shouldPreprocessAndValidateTheUpdatedConfigForEdit() throws Exception {
+        when(writer.documentFrom(configForEdit)).thenReturn(document);
+        when(writer.toString(document)).thenReturn("cruise_config");
+        when(loader.preprocessAndValidate(configForEdit)).thenReturn(new BasicCruiseConfig());
+
+        flow.execute(updateConfigCommand, partials, null);
+
+        verify(loader).preprocessAndValidate(configForEdit);
+    }
+
+    @Test
+    public void shouldValidateDomRepresentationOfCruiseConfig() throws Exception {
+        when(writer.documentFrom(configForEdit)).thenReturn(document);
+        when(writer.toString(document)).thenReturn("cruise_config");
+        when(loader.preprocessAndValidate(configForEdit)).thenReturn(new BasicCruiseConfig());
+
+        flow.execute(updateConfigCommand, partials, null);
+
+        verify(writer).verifyXsdValid(document);
+    }
+
+    @Test
+    public void shouldPersistXmlRepresentationOfConfigForEdit() throws Exception {
+        String configAsXml = "cruise config as xml";
+
+        when(writer.documentFrom(configForEdit)).thenReturn(document);
+        when(writer.toString(document)).thenReturn(configAsXml);
+        when(loader.preprocessAndValidate(configForEdit)).thenReturn(new BasicCruiseConfig());
+
+        flow.execute(updateConfigCommand, partials, null);
+
+        verify(fileWriter).writeToConfigXmlFile(configAsXml);
+    }
+
+    @Test
+    public void shouldCheckinGeneratedConfigXMLToConfigRepo() throws Exception {
+        String configAsXml = "cruise config as xml";
+        Date currentTime = mock(Date.class);
+        ArgumentCaptor<GoConfigRevision> revisionArgumentCaptor = ArgumentCaptor.forClass(GoConfigRevision.class);
+
+        when(writer.documentFrom(configForEdit)).thenReturn(document);
+        when(writer.toString(document)).thenReturn(configAsXml);
+        when(loader.preprocessAndValidate(configForEdit)).thenReturn(new BasicCruiseConfig());
+        when(serverVersion.version()).thenReturn("16.13.0");
+        when(timeProvider.currentTime()).thenReturn(currentTime);
+        doNothing().when(configRepository).checkin(revisionArgumentCaptor.capture());
+
+        flow.execute(updateConfigCommand, partials, "test_user");
+
+
+        GoConfigRevision goConfigRevision = revisionArgumentCaptor.getValue();
+        assertThat(goConfigRevision.getContent(), is(configAsXml));
+        assertThat(goConfigRevision.getUsername(), is("test_user"));
+        assertThat(goConfigRevision.getMd5(), is(updateConfigCommand.configForEdit().getMd5()));
+        assertThat(goConfigRevision.getGoVersion(), is("16.13.0"));
+        assertThat(goConfigRevision.getTime(), is(currentTime));
+    }
+
+    @Test
+    public void shouldUpdateCachedGoPartialsWithValidPartials() throws Exception {
+        String configAsXml = "cruise config as xml";
+
+        when(writer.documentFrom(configForEdit)).thenReturn(document);
+        when(writer.toString(document)).thenReturn(configAsXml);
+        when(loader.preprocessAndValidate(configForEdit)).thenReturn(new BasicCruiseConfig());
+
+        flow.execute(updateConfigCommand, partials, null);
+
+        verify(cachedGoPartials).markAsValid(partials);
+    }
+}

--- a/server/test/unit/com/thoughtworks/go/config/GoConfigMigratorTest.java
+++ b/server/test/unit/com/thoughtworks/go/config/GoConfigMigratorTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2016 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.config;
+
+import com.thoughtworks.go.config.update.FullConfigUpdateCommand;
+import com.thoughtworks.go.domain.GoConfigRevision;
+import com.thoughtworks.go.serverhealth.ServerHealthService;
+import com.thoughtworks.go.service.ConfigRepository;
+import com.thoughtworks.go.util.SystemEnvironment;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.*;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+public class GoConfigMigratorTest {
+
+    @Mock private GoConfigMigration goConfigMigration;
+    @Mock private SystemEnvironment systemEnvironment;
+    @Mock private ConfigCache configCache;
+    @Mock private FullConfigSaveNormalFlow fullConfigSaveNormalFlow;
+    @Mock MagicalGoConfigXmlLoader loader;
+    @Mock GoConfigFileReader reader;
+    @Mock ConfigRepository configRepository;
+    @Mock ServerHealthService serverHealthService;
+
+    private GoConfigMigrator goConfigMigrator;
+
+    @Before
+    public void setup() {
+        initMocks(this);
+
+        goConfigMigrator = new GoConfigMigrator(goConfigMigration, systemEnvironment, fullConfigSaveNormalFlow, loader,
+                reader, configRepository, serverHealthService);
+    }
+
+    @Test
+    public void shouldUpgradeConfigToLatestVersion() throws Exception {
+        String configXml = "cruise_config_xml_contents";
+
+        when(reader.configXml()).thenReturn(configXml);
+
+        goConfigMigrator.migrate();
+
+        verify(goConfigMigration).upgradeIfNecessary(configXml);
+    }
+
+    @Test
+    public void shouldExecuteFullConfigSaveWithNormalFlowPostConfigUpgrade() throws Exception {
+        String configXml = "cruise_config_xml_contents";
+        CruiseConfig cruiseConfig = mock(CruiseConfig.class);
+        ArgumentCaptor<FullConfigUpdateCommand> commandArgumentCaptor = ArgumentCaptor.forClass(FullConfigUpdateCommand.class);
+        ArgumentCaptor<List> listArgumentCaptor = ArgumentCaptor.forClass(List.class);
+        ArgumentCaptor<String> stringArgumentCaptor = ArgumentCaptor.forClass(String.class);
+        GoConfigHolder goConfigHolder = mock(GoConfigHolder.class);
+
+        when(reader.configXml()).thenReturn(configXml);
+        when(goConfigMigration.upgradeIfNecessary(configXml)).thenReturn(configXml);
+        when(loader.deserializeConfig(configXml)).thenReturn(cruiseConfig);
+        when(fullConfigSaveNormalFlow.execute(commandArgumentCaptor.capture(), listArgumentCaptor.capture(), stringArgumentCaptor.capture())).thenReturn(goConfigHolder);
+
+        GoConfigHolder configHolder = goConfigMigrator.migrate();
+
+        assertThat(configHolder, is(goConfigHolder));
+        assertThat(stringArgumentCaptor.getValue(), is("Upgrade"));
+        assertThat(commandArgumentCaptor.getValue().configForEdit(), is(cruiseConfig));
+        assertThat(listArgumentCaptor.getValue().size(), is(0));
+    }
+
+    @Test
+    public void shouldUpgradeConfigUsingLatestConfigRevisionInRepoIfUpgradingConfigFileFails() throws Exception {
+        String configInFile = "cruise_config_in_file";
+        String versionedConfig = "versioned_cruise_config";
+        CruiseConfig cruiseConfig = mock(CruiseConfig.class);
+        ArgumentCaptor<FullConfigUpdateCommand> commandArgumentCaptor = ArgumentCaptor.forClass(FullConfigUpdateCommand.class);
+        ArgumentCaptor<List> listArgumentCaptor = ArgumentCaptor.forClass(List.class);
+        ArgumentCaptor<String> stringArgumentCaptor = ArgumentCaptor.forClass(String.class);
+
+        when(systemEnvironment.getCruiseConfigFile()).thenReturn("");
+        when(reader.configXml()).thenReturn(configInFile).thenReturn(versionedConfig);
+        when(configRepository.getCurrentRevision()).thenReturn(mock(GoConfigRevision.class));
+        when(goConfigMigration.upgradeIfNecessary(configInFile)).thenThrow(new RuntimeException());
+        when(goConfigMigration.upgradeIfNecessary(versionedConfig)).thenReturn(versionedConfig);
+        when(loader.deserializeConfig(versionedConfig)).thenReturn(cruiseConfig);
+        when(goConfigMigration.revertFileToVersion(any(File.class), any(GoConfigRevision.class))).thenReturn(new File("path_to_backup_file"));
+        when(fullConfigSaveNormalFlow.execute(commandArgumentCaptor.capture(), listArgumentCaptor.capture(), stringArgumentCaptor.capture())).thenReturn(mock(GoConfigHolder.class));
+
+        goConfigMigrator.migrate();
+
+        assertThat(stringArgumentCaptor.getValue(), is("Upgrade"));
+        assertThat(commandArgumentCaptor.getValue().configForEdit(), is(cruiseConfig));
+        assertThat(listArgumentCaptor.getValue().size(), is(0));
+        verify(goConfigMigration).revertFileToVersion(any(File.class), any(GoConfigRevision.class));
+    }
+
+
+//    TODO: Test shouldErrorOutIfConfigFileUpgradeFailsAndInAbsenceOfVersionedConfigFile
+}

--- a/server/test/unit/com/thoughtworks/go/server/initializers/ApplicationInitializerTest.java
+++ b/server/test/unit/com/thoughtworks/go/server/initializers/ApplicationInitializerTest.java
@@ -167,7 +167,7 @@ public class ApplicationInitializerTest {
         inOrder.verify(configCipherUpdater).migrate();
         inOrder.verify(configElementImplementationRegistrar).initialize();
         inOrder.verify(configRepository).initialize();
-        inOrder.verify(goFileConfigDataSource).upgradeIfNecessary();
+        inOrder.verify(cachedGoConfig).upgradeConfig();
         inOrder.verify(cachedGoConfig).loadConfigIfNull();
         inOrder.verify(goConfigService).initialize();
     }

--- a/server/test/unit/com/thoughtworks/go/server/service/PipelinePauseServiceTest.java
+++ b/server/test/unit/com/thoughtworks/go/server/service/PipelinePauseServiceTest.java
@@ -47,7 +47,7 @@ public class PipelinePauseServiceTest {
     public void setUp() throws Exception {
         pipelineDao = mock(PipelineSqlMapDao.class);
         goConfigDao = mock(GoConfigDao.class);
-        goConfigService = new GoConfigService(goConfigDao, null, (GoConfigMigration) null, null, null, null, null, null, null);
+        goConfigService = new GoConfigService(goConfigDao, null, (GoConfigMigration) null, null, null, null, null, null, null, null);
         securityService = mock(SecurityService.class);
         pipelinePauseService = new PipelinePauseService(pipelineDao, goConfigService, securityService);
     }


### PR DESCRIPTION
* Current config save handles multiple scenarios so there are repetitive preprocess, validation,
  cloning..., which is one of reason for slow config updates on servers
  with large config.
* This commit introduces an optimized config save which handles only full config
  saves through UI, API, config upgrade(during server restart) and config loads(timer every 5 secs)
* Entity updates through UI which do not have an API still follow the old flow.
* Config save can be toggled between new and old flow using the System
  Environment 'optimize.full.config.save', this is 'true' by default.