### PR TITLE
Fixed plus icon getting cropped, fixed agents page having issue in in…

### DIFF
--- a/server/webapp/WEB-INF/rails.new/app/assets/new_stylesheets/single_page_apps/agents.scss
+++ b/server/webapp/WEB-INF/rails.new/app/assets/new_stylesheets/single_page_apps/agents.scss
@@ -197,12 +197,11 @@
   margin:          0;
   padding:         0;
   float:           right;
-  width:           350px;
   li {
-    width:       25%;
     border-left: 1px solid rgba(255, 255, 255, 0.12);
     text-align:  center;
     font-weight: 600;
+    margin-left: 10px;
     &:first-child {
       border: 0;
     }

--- a/server/webapp/WEB-INF/rails.new/app/assets/stylesheets/_new-footer-with-old-css.scss
+++ b/server/webapp/WEB-INF/rails.new/app/assets/stylesheets/_new-footer-with-old-css.scss
@@ -1,4 +1,4 @@
-/*!
+/*
  * Copyright 2016 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/server/webapp/WEB-INF/rails.new/app/assets/stylesheets/new-theme.scss
+++ b/server/webapp/WEB-INF/rails.new/app/assets/stylesheets/new-theme.scss
@@ -2421,10 +2421,16 @@ table.variables th {
 
 #plugin_settings_angular_plugin_settings {
   textarea {
-    resize: both;
-    height: inherit;
+    resize:      both;
+    height:      inherit;
     font-family: "courier new", monospace !important;
-    font-size: 14px;
+    font-size:   14px;
     line-height: 1.25em;
+  }
+}
+
+.vsm-entity.pipeline ul.instances {
+  .message {
+    padding: 0px 7px;
   }
 }

--- a/server/webapp/WEB-INF/rails.new/app/assets/stylesheets/new-theme.scss
+++ b/server/webapp/WEB-INF/rails.new/app/assets/stylesheets/new-theme.scss
@@ -668,6 +668,13 @@ $arrow-border-active-color: lighten(#000, 50%);
   }
 }
 
+
+.job_details.entity_title.page_header {
+  .last {
+    padding-top: 5px;
+  }
+}
+
 ul.entity_title li {
   background:    none;
   padding-right: 0;

--- a/server/webapp/WEB-INF/rails.new/app/assets/stylesheets/new-theme.scss
+++ b/server/webapp/WEB-INF/rails.new/app/assets/stylesheets/new-theme.scss
@@ -1136,6 +1136,7 @@ button#confirm-pause-up42 {
 
 .add_link {
   padding: 0px 5px 0px 20px;
+  line-height: 16px;
 }
 
 .sub_tab_container_content {

--- a/server/webapp/WEB-INF/rails.new/app/assets/stylesheets/new-theme.scss
+++ b/server/webapp/WEB-INF/rails.new/app/assets/stylesheets/new-theme.scss
@@ -2182,8 +2182,6 @@ input.compare_pipeline_input {
 
 @mixin new-theme-changes-table {
   td.user, td.modified_by {
-    //word-wrap:  break-word;
-    //word-break: keep-all;
     max-width: 20em;
     width:     20em;
   }
@@ -2419,4 +2417,14 @@ table.variables th {
 
 .back_to_top {
   border-radius: 50%;
+}
+
+#plugin_settings_angular_plugin_settings {
+  textarea {
+    resize: both;
+    height: inherit;
+    font-family: "courier new", monospace !important;
+    font-size: 14px;
+    line-height: 1.25em;
+  }
 }

--- a/server/webapp/WEB-INF/rails.new/app/assets/stylesheets/new-theme.scss
+++ b/server/webapp/WEB-INF/rails.new/app/assets/stylesheets/new-theme.scss
@@ -1135,7 +1135,7 @@ button#confirm-pause-up42 {
 }
 
 .add_link {
-  padding: 0px 5px 0px 20px;
+  padding:     0px 5px 0px 20px;
   line-height: 16px;
 }
 
@@ -2178,7 +2178,66 @@ input.compare_pipeline_input {
 
 .checkbox_row div.contextual_help {
   position: relative;
-  top:      9px;
+}
+
+@mixin new-theme-changes-table {
+  td.user, td.modified_by {
+    //word-wrap:  break-word;
+    //word-break: keep-all;
+    max-width: 20em;
+    width:     20em;
+  }
+
+  td.comment {
+    word-wrap:  break-word;
+    word-break: keep-all;
+  }
+
+  td.revision {
+    overflow:      hidden;
+    max-width:     12em;
+    width:         12em;
+    font-family:   "courier new", monospace !important;
+    font-style:    normal;
+    white-space:   nowrap;
+    text-overflow: ellipsis;
+    overflow:      hidden;
+  }
+}
+
+#new-pipeline-history #content_wrapper_inner_pipeline_history {
+  .popup {
+    max-width: 900px;
+    width:     900px;
+    .build-cause-summary-container {
+      table {
+        @include new-theme-changes-table;
+      }
+    }
+  }
+}
+
+#pipelines .enhanced_dropdown, #stages .fbh_microcontent_popup .enhanced_dropdown, #pipelines .enhanced_dropdown .scrollable_panel {
+  max-width: 80%;
+  z-index:   2 !important;
+
+  .build_cause.list_table {
+    .change {
+      @include new-theme-changes-table;
+      td.revision {
+        span.wrapped_word {
+          vertical-align: text-bottom;
+          font-family:    "courier new", monospace !important;
+          font-style:     normal;
+          max-width:      12em;
+          display:        inline-block;
+          white-space:    nowrap;
+          text-overflow:  ellipsis;
+          overflow:       hidden;
+        }
+      }
+    }
+  }
 }
 
 //plugins


### PR DESCRIPTION
1)Fixed plus icon getting cropped, 
<img width="1177" alt="screen shot 2016-12-01 at 11 54 20 am" src="https://cloud.githubusercontent.com/assets/7871209/20783829/6103f9ea-b7bc-11e6-960e-52908b9f59e8.png">


2)Fixed agents page having issue in indication number of agents

<img width="392" alt="screen shot 2016-12-01 at 11 09 51 am" src="https://cloud.githubusercontent.com/assets/7871209/20783833/6584c5b2-b7bc-11e6-893f-44f24f0484c3.png">

3)Fixed alignment of help tooltip(Issue is only with checkboxes) 
<img width="575" alt="screen shot 2016-12-01 at 12 09 29 pm" src="https://cloud.githubusercontent.com/assets/7871209/20788951/b180aa3c-b7d8-11e6-8b4a-a9a8ce378722.png">


4)Fixed material popup ui

![](https://cloud.githubusercontent.com/assets/54427/20784005/a0bc5324-b7bd-11e6-99c8-e35d1a72ccba.png)

5) Textareas are not high enough — They are forced to be 30px.

![](https://cloud.githubusercontent.com/assets/10598/20789062/1f8dcb72-b7d9-11e6-8f98-fe1557b7345a.png)

6)Fixed vsm message is getting cropped at bottom.

<img width="816" alt="screen shot 2016-12-01 at 4 03 57 pm" src="https://cloud.githubusercontent.com/assets/7871209/20790613/165596e2-b7df-11e6-844b-6edd2c44329c.png">

7)The breadcrumb on the job detail page is mis-aligned, renders fine on the stage details page.

![](https://cloud.githubusercontent.com/assets/10598/20792591/a0329ffa-b7e8-11e6-804d-7ac95d3e2a7c.png)


Changes reviewed by @naveenbhaskar 