### PR TITLE
Disable editing plugin settings for task plugins

### DIFF
--- a/server/webapp/WEB-INF/rails.new/app/controllers/admin/plugins/plugins_controller.rb
+++ b/server/webapp/WEB-INF/rails.new/app/controllers/admin/plugins/plugins_controller.rb
@@ -17,6 +17,7 @@
 class Admin::Plugins::PluginsController < AdminController
 
   before_filter :set_tab_name
+  helper_method :can_edit_plugin_settings?
 
   def index
     @plugin_descriptors = default_plugin_manager.plugins()
@@ -64,7 +65,15 @@ class Admin::Plugins::PluginsController < AdminController
     end
   end
 
+  def can_edit_plugin_settings?(plugin_id)
+    meta_data_store.hasPlugin(plugin_id) && is_admin_user? && !meta_data_store.preferenceFor(plugin_id).getTemplate().blank?
+  end
+
   private
+  def is_admin_user?
+    security_service.isUserAdmin(current_user)
+  end
+
   def set_tab_name
     @tab_name = 'plugins-listing'
   end

--- a/server/webapp/WEB-INF/rails.new/app/views/admin/plugins/plugins/index.html.erb
+++ b/server/webapp/WEB-INF/rails.new/app/views/admin/plugins/plugins/index.html.erb
@@ -31,7 +31,7 @@
 
                 <div class="plugin-data">
                     <div class="plugin-details">
-                        <% if @meta_data_store.hasPlugin(descriptor.id()) && is_user_an_admin? %>
+                        <% if can_edit_plugin_settings?(descriptor.id()) %>
                             <span class="settings"><%= link_to '', '#', :onclick => "Modalbox.show('#{edit_settings_path(:plugin_id => descriptor.id())}', {overlayClose: false, title: 'Plugin Settings'})", :class => 'icon16 setting-left' -%></span>
                         <% end %>
                         <span class="name"><%= about.name() %></span>


### PR DESCRIPTION
https://github.com/gocd/gocd/pull/2593 dropped support for plugin settings for Task Plugins. 
All task plugins except ```Script Executor``` supports  plugin settings. Post https://github.com/gocd/gocd/pull/2593 editing plugin settings for Script Executor breaks the UI. 

This PR is to disable editing plugin settings for task plugins.