### PR TITLE
#2922 add elastic_profile_id to job in configrepos

### DIFF
--- a/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/configrepo/contract/CRJob.java
+++ b/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/configrepo/contract/CRJob.java
@@ -13,7 +13,7 @@ public class CRJob extends CRBase {
     private Collection<String> resources = new ArrayList<>();
     private Collection<CRArtifact> artifacts = new ArrayList<>();
     private Collection<CRPropertyGenerator> properties = new ArrayList<>();
-
+    private String elastic_profile_id;
     private String run_instance_count;
     private Integer timeout;
 
@@ -28,10 +28,11 @@ public class CRJob extends CRBase {
         this.tasks = Arrays.asList(tasks);
     }
     public CRJob(String name, Collection<CREnvironmentVariable> environmentVariables, Collection<CRTab> tabs,
-                 Collection<String> resources, Collection<CRArtifact> artifacts,
+                 Collection<String> resources, String elasticProfileId, Collection<CRArtifact> artifacts,
                  Collection<CRPropertyGenerator> artifactPropertiesGenerators,
                  String runInstanceCount, int timeout, List<CRTask> tasks) {
         this.name = name;
+        this.elastic_profile_id = elasticProfileId;
         this.environment_variables = environmentVariables;
         this.tabs = tabs;
         this.resources = resources;
@@ -42,10 +43,11 @@ public class CRJob extends CRBase {
         this.tasks = tasks;
     }
     public CRJob(String name, Collection<CREnvironmentVariable> environmentVariables, Collection<CRTab> tabs,
-                 Collection<String> resources, Collection<CRArtifact> artifacts,
+                 Collection<String> resources, String elasticProfileId, Collection<CRArtifact> artifacts,
                  Collection<CRPropertyGenerator> artifactPropertiesGenerators,
                  boolean runOnAllAgents, int runInstanceCount, int timeout, List<CRTask> tasks) {
         this.name = name;
+        this.elastic_profile_id = elasticProfileId;
         this.environment_variables = environmentVariables;
         this.tabs = tabs;
         this.resources = resources;
@@ -67,6 +69,16 @@ public class CRJob extends CRBase {
         validateArtifacts(errors,location);
         validateProperties(errors,location);
         validateTasks(errors,location);
+        validateElasticProfile(errors,location);
+    }
+
+    private void validateElasticProfile(ErrorCollection errors, String location) {
+        if(elastic_profile_id != null)
+        {
+            if(this.resources != null && this.resources.size() > 0) {
+                errors.addError(location,"elastic_profile_id cannot be specified together with resources");
+            }
+        }
     }
 
     private void validateTasks(ErrorCollection errors, String location) {
@@ -128,7 +140,9 @@ public class CRJob extends CRBase {
         if (name != null ? !name.equals(that.getName()) : that.getName() != null) {
             return false;
         }
-
+        if (elastic_profile_id != null ? !elastic_profile_id.equals(that.elastic_profile_id) : that.elastic_profile_id != null) {
+            return false;
+        }
         if (environment_variables != null ? !CollectionUtils.isEqualCollection(this.environment_variables, that.environment_variables) : that.environment_variables != null) {
             return false;
         }
@@ -294,5 +308,13 @@ public class CRJob extends CRBase {
         String myLocation = getLocation() == null ? parent : getLocation();
         String stage = getName() == null ? "unknown name" : getName();
         return String.format("%s; Job (%s)",myLocation,stage);
+    }
+
+    public String getElasticProfileId() {
+        return elastic_profile_id;
+    }
+
+    public void setElasticProfileId(String elastic_profile_id) {
+        this.elastic_profile_id = elastic_profile_id;
     }
 }

--- a/plugin-infra/go-plugin-access/test/com/thoughtworks/go/plugin/access/configrepo/contract/CRJobTest.java
+++ b/plugin-infra/go-plugin-access/test/com/thoughtworks/go/plugin/access/configrepo/contract/CRJobTest.java
@@ -21,6 +21,7 @@ public class CRJobTest extends CRBaseTest<CRJob> {
     private final CRJob jobWithTab;
     private final CRJob jobWithProp;
     private final CRJob invalidJobNoName;
+    private final CRJob invalidJobResourcesAndElasticProfile;
 
     public CRJobTest()
     {
@@ -40,6 +41,10 @@ public class CRJobTest extends CRBaseTest<CRJob> {
         jobWithProp.addProperty(new CRPropertyGenerator("perf","test.xml","substring-before(//report/data/all/coverage[starts-with(@type,'class')]/@value, '%')"));
 
         invalidJobNoName = new CRJob();
+
+        invalidJobResourcesAndElasticProfile = new CRJob("build",rakeTask);
+        invalidJobResourcesAndElasticProfile.addResource("linux");
+        invalidJobResourcesAndElasticProfile.setElasticProfileId("profile");
     }
 
     @Override
@@ -55,6 +60,7 @@ public class CRJobTest extends CRBaseTest<CRJob> {
     @Override
     public void addBadExamples(Map<String, CRJob> examples) {
         examples.put("invalidJobNoName",invalidJobNoName);
+        examples.put("invalidJobResourcesAndElasticProfile",invalidJobResourcesAndElasticProfile);
     }
 
 

--- a/server/src/com/thoughtworks/go/config/ConfigConverter.java
+++ b/server/src/com/thoughtworks/go/config/ConfigConverter.java
@@ -446,6 +446,9 @@ public class ConfigConverter {
                 resources.add(new Resource(crResource));
             }
 
+        if(crJob.getElasticProfileId() != null)
+            jobConfig.setElasticProfileId(crJob.getElasticProfileId());
+
         ArtifactPlans artifactPlans = jobConfig.artifactPlans();
         if (crJob.getArtifacts() != null)
             for (CRArtifact crArtifact : crJob.getArtifacts()) {

--- a/server/test/unit/com/thoughtworks/go/config/ConfigConverterTest.java
+++ b/server/test/unit/com/thoughtworks/go/config/ConfigConverterTest.java
@@ -102,7 +102,7 @@ public class ConfigConverterTest {
                 "upstream", "stage", "job", "src", "dest", false));
 
         jobs.add(new CRJob("name",environmentVariables, tabs,
-                resources, artifacts, artifactPropertiesGenerators,
+                resources,null, artifacts, artifactPropertiesGenerators,
                 true, 5, 120, tasks));
 
         authorizedUsers.add("authUser");
@@ -729,7 +729,7 @@ public class ConfigConverterTest {
     public void shouldConvertJob()
     {
         CRJob crJob = new CRJob("name",environmentVariables, tabs,
-                 resources, artifacts, artifactPropertiesGenerators,
+                 resources, null, artifacts, artifactPropertiesGenerators,
                 false, 5, 120, tasks);
 
         JobConfig jobConfig = configConverter.toJobConfig(crJob);
@@ -745,11 +745,25 @@ public class ConfigConverterTest {
         assertThat(jobConfig.getTimeout(),is("120"));
         assertThat(jobConfig.getTasks().size(),is(1));
     }
+
+    @Test
+    public void shouldConvertJobWhenHasElasticProfileId()
+    {
+        CRJob crJob = new CRJob("name",environmentVariables, tabs,
+                null, "myprofile", artifacts, artifactPropertiesGenerators,
+                false, 5, 120, tasks);
+
+        JobConfig jobConfig = configConverter.toJobConfig(crJob);
+
+        assertThat(jobConfig.getElasticProfileId(),is("myprofile"));
+        assertThat(jobConfig.resources().size(),is(0));
+    }
+
     @Test
     public void shouldConvertJobWhenRunInstanceCountIsNotSpecified()
     {
         CRJob crJob = new CRJob("name",environmentVariables, tabs,
-                resources, artifacts, artifactPropertiesGenerators,
+                resources, null, artifacts, artifactPropertiesGenerators,
                 null, 120, tasks);
 
         JobConfig jobConfig = configConverter.toJobConfig(crJob);
@@ -763,7 +777,7 @@ public class ConfigConverterTest {
     public void shouldConvertJobWhenRunInstanceCountIsAll()
     {
         CRJob crJob = new CRJob("name",environmentVariables, tabs,
-                resources, artifacts, artifactPropertiesGenerators,
+                resources, null, artifacts, artifactPropertiesGenerators,
                 "all", 120, tasks);
 
         JobConfig jobConfig = configConverter.toJobConfig(crJob);


### PR DESCRIPTION
As in #2922
This PR adds ability to specify elastic_profile_id in job in configuration repository. E.g. in JSON:
```json
....
  "jobs": [
        {
          "name": "build",
          "elastic_profile_id" : "example-docker",
...
       }
]
```

[Here is example repository](https://github.com/tomzo/gocd-json-config-example/blob/elastic-profile/elastic.gopipeline.json) with which I have tested this.

When profile with correct name is not specified in server, invalid merged config error is displayed in server health messages.
```
Invalid Merged Configuration [Dec-01 18:32:18]
1+ errors :: No profile defined corresponding to profile_id 'example-docker';; - Config-Repo: https://github.com/tomzo/gocd-json-config-example.git at 563d31956ed88cfcb923c419a0b6ba31e860416c
```

When correct profile exists, job did not get scheduled on normal agent. (I did not not configure elastic docker plugin to check fully).