### PR TITLE
Add pipeline label to notification api response

### DIFF
--- a/server/src/com/thoughtworks/go/server/messaging/plugin/StageStatusPluginNotifier.java
+++ b/server/src/com/thoughtworks/go/server/messaging/plugin/StageStatusPluginNotifier.java
@@ -73,17 +73,19 @@ public class StageStatusPluginNotifier implements StageStatusListener {
         Map<String, Object> data = new LinkedHashMap<>();
         String pipelineName = stage.getIdentifier().getPipelineName();
         Integer pipelineCounter = new Integer(stage.getIdentifier().getPipelineCounter());
+        String pipelineLabel = stage.getIdentifier().getPipelineLabel();
 
-        Map<String, Object> pipelineMap = createPipelineDataMap(pipelineName, pipelineCounter, stage);
+        Map<String, Object> pipelineMap = createPipelineDataMap(pipelineName, pipelineCounter, stage, pipelineLabel);
         data.put("pipeline", pipelineMap);
 
         return data;
     }
 
-    private Map<String, Object> createPipelineDataMap(String pipelineName, Integer pipelineCounter, Stage stage) {
+    private Map<String, Object> createPipelineDataMap(String pipelineName, Integer pipelineCounter, Stage stage, String pipelineLabel) {
         Map<String, Object> pipelineMap = new LinkedHashMap<>();
         pipelineMap.put("name", pipelineName);
         pipelineMap.put("counter", pipelineCounter.toString());
+        pipelineMap.put("label", pipelineLabel);
 
         String pipelineGroup = goConfigService.findGroupNameByPipeline(new CaseInsensitiveString(pipelineName));
         pipelineMap.put("group", pipelineGroup);

--- a/server/test/unit/com/thoughtworks/go/server/messaging/plugin/StageStatusPluginNotifierTest.java
+++ b/server/test/unit/com/thoughtworks/go/server/messaging/plugin/StageStatusPluginNotifierTest.java
@@ -88,6 +88,7 @@ public class StageStatusPluginNotifierTest {
         assertThat((String) pipelineMap.get("counter"), is("1"));
 
         assertThat((String) pipelineMap.get("group"), is("pipeline-group"));
+        assertThat((String) pipelineMap.get("label"), is ("LABEL-1"));
 
         List revisionsList = (List) pipelineMap.get("build-cause");
         Map gitRevisionMap = (Map) revisionsList.get(0);


### PR DESCRIPTION
Whilst developing a notification plugin I found a need to get the `pipeline label` value but it's currently not available as it was removed in [this commit](https://github.com/gocd/gocd/commit/7e13e5203112709ff9cc806d05e13ee93ca529f7#diff-4064d61cc0533d9678ddd8cdf0aefde7L88).