### PR TITLE
Adding CPU time in api/support for the threads.

### DIFF
--- a/base/src/com/thoughtworks/go/util/SystemEnvironment.java
+++ b/base/src/com/thoughtworks/go/util/SystemEnvironment.java
@@ -198,6 +198,7 @@ public class SystemEnvironment implements Serializable, ConfigDirProvider {
     public static GoSystemProperty<String> GO_AGENT_KEYSTORE_PASSWORD = new GoStringSystemProperty("go.agent.keystore.password", "agent5s0repa55w0rd");
     private static final GoSystemProperty<Boolean> GO_AGENT_USE_SSL_CONTEXT = new GoBooleanSystemProperty("go.agent.reuse.ssl.context", true);
     public static final GoSystemProperty<? extends Boolean> ENABLE_BUILD_COMMAND_PROTOCOL = new GoBooleanSystemProperty("go.agent.enableBuildCommandProtocol", false);
+    public static final GoSystemProperty<? extends Boolean> GO_DIAGNOSTICS_MODE = new GoBooleanSystemProperty("go.diagnostics.mode", false);
 
     public static GoIntSystemProperty DEPENDENCY_MATERIAL_UPDATE_LISTENERS = new GoIntSystemProperty("dependency.material.check.threads", 3);
 

--- a/server/src/com/thoughtworks/go/server/GoServer.java
+++ b/server/src/com/thoughtworks/go/server/GoServer.java
@@ -69,7 +69,6 @@ public class GoServer {
     protected void startServer() throws Exception {
         server = configureServer();
         server.start();
-
         Throwable exceptionAtServerStart = server.getUnavailableException();
         if (exceptionAtServerStart != null) {
             server.stop();

--- a/server/src/com/thoughtworks/go/server/initializers/ApplicationInitializer.java
+++ b/server/src/com/thoughtworks/go/server/initializers/ApplicationInitializer.java
@@ -35,6 +35,7 @@ import com.thoughtworks.go.server.security.GoCasServiceProperties;
 import com.thoughtworks.go.server.security.LdapContextFactory;
 import com.thoughtworks.go.server.security.RemoveAdminPermissionFilter;
 import com.thoughtworks.go.server.service.*;
+import com.thoughtworks.go.server.service.support.ResourceMonitoring;
 import com.thoughtworks.go.server.service.support.toggle.FeatureToggleService;
 import com.thoughtworks.go.server.service.support.toggle.Toggles;
 import com.thoughtworks.go.server.util.ServletHelper;
@@ -86,6 +87,7 @@ public class ApplicationInitializer implements ApplicationListener<ContextRefres
     @Autowired private EntityHashingService entityHashingService;
     @Autowired private DependencyMaterialUpdateNotifier dependencyMaterialUpdateNotifier;
     @Autowired private SCMMaterialSource scmMaterialSource;
+    @Autowired private ResourceMonitoring resourceMonitoring;
 
     @Override
     public void onApplicationEvent(ContextRefreshedEvent contextRefreshedEvent) {
@@ -93,6 +95,7 @@ public class ApplicationInitializer implements ApplicationListener<ContextRefres
             return;
         }
         try {
+            resourceMonitoring.enableIfDiagnosticsModeIsEnabled();
             //plugin
             defaultPluginJarLocationMonitor.initialize();
             pluginsInitializer.initialize();

--- a/server/src/com/thoughtworks/go/server/materials/MaterialUpdateListenerFactory.java
+++ b/server/src/com/thoughtworks/go/server/materials/MaterialUpdateListenerFactory.java
@@ -22,6 +22,7 @@ import com.thoughtworks.go.server.messaging.GoMessageTopic;
 import com.thoughtworks.go.server.perf.MDUPerformanceLogger;
 import com.thoughtworks.go.server.persistence.MaterialRepository;
 import com.thoughtworks.go.server.service.MaterialExpansionService;
+import com.thoughtworks.go.server.service.support.DaemonThreadStatsCollector;
 import com.thoughtworks.go.server.transaction.TransactionTemplate;
 import com.thoughtworks.go.serverhealth.ServerHealthService;
 import com.thoughtworks.go.util.SystemEnvironment;
@@ -36,6 +37,7 @@ public class MaterialUpdateListenerFactory {
     private MaterialUpdateQueue queue;
     private ConfigMaterialUpdateQueue configQueue;
     private DependencyMaterialUpdateQueue dependencyMaterialQueue;
+    private final DaemonThreadStatsCollector daemonThreadStatsCollector;
     private SystemEnvironment systemEnvironment;
     private final ServerHealthService serverHealthService;
     private final GoDiskSpaceMonitor diskSpaceMonitor;
@@ -63,7 +65,7 @@ public class MaterialUpdateListenerFactory {
                                          PluggableSCMMaterialUpdater pluggableSCMMaterialUpdater,
                                          MaterialExpansionService materialExpansionService,
                                          MDUPerformanceLogger mduPerformanceLogger,
-                                         DependencyMaterialUpdateQueue dependencyMaterialQueue) {
+                                         DependencyMaterialUpdateQueue dependencyMaterialQueue, DaemonThreadStatsCollector daemonThreadStatsCollector) {
         this.topic = topic;
         this.configTopic = configTopic;
         this.queue = queue;
@@ -80,6 +82,7 @@ public class MaterialUpdateListenerFactory {
         this.materialExpansionService = materialExpansionService;
         this.mduPerformanceLogger = mduPerformanceLogger;
         this.dependencyMaterialQueue = dependencyMaterialQueue;
+        this.daemonThreadStatsCollector = daemonThreadStatsCollector;
     }
 
     public void init(){

--- a/server/src/com/thoughtworks/go/server/scheduling/ScheduleCheckListenerFactory.java
+++ b/server/src/com/thoughtworks/go/server/scheduling/ScheduleCheckListenerFactory.java
@@ -16,6 +16,7 @@
 
 package com.thoughtworks.go.server.scheduling;
 
+import com.thoughtworks.go.server.service.support.DaemonThreadStatsCollector;
 import com.thoughtworks.go.server.perf.SchedulingPerformanceLogger;
 import com.thoughtworks.go.util.SystemEnvironment;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -28,18 +29,20 @@ public class ScheduleCheckListenerFactory {
     private ScheduleCheckQueue queue;
     private SystemEnvironment systemEnvironment;
     private SchedulingPerformanceLogger schedulingPerformanceLogger;
+    private final DaemonThreadStatsCollector daemonThreadStatsCollector;
 
     @Autowired
     public ScheduleCheckListenerFactory(ScheduleCheckCompletedTopic topic,
                                         BuildCauseProducerService producerService,
                                         ScheduleCheckQueue queue,
                                         SystemEnvironment systemEnvironment,
-                                        SchedulingPerformanceLogger schedulingPerformanceLogger) {
+                                        SchedulingPerformanceLogger schedulingPerformanceLogger, DaemonThreadStatsCollector daemonThreadStatsCollector) {
         this.topic = topic;
         this.producerService = producerService;
         this.queue = queue;
         this.systemEnvironment = systemEnvironment;
         this.schedulingPerformanceLogger = schedulingPerformanceLogger;
+        this.daemonThreadStatsCollector = daemonThreadStatsCollector;
     }
 
     public void init(){

--- a/server/src/com/thoughtworks/go/server/service/support/DaemonThreadStatsCollector.java
+++ b/server/src/com/thoughtworks/go/server/service/support/DaemonThreadStatsCollector.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2016 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.server.service.support;
+
+import org.springframework.stereotype.Component;
+
+import java.lang.management.ManagementFactory;
+import java.lang.management.ThreadMXBean;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Component
+public class DaemonThreadStatsCollector {
+    private final ConcurrentHashMap<Long, Info> cpuInfoConcurrentHashMap = new ConcurrentHashMap<>();
+
+    public void captureStats(long threadId) {
+        ThreadMXBean threadMXBean = ManagementFactory.getThreadMXBean();
+        long threadCpuTime = threadMXBean.getThreadCpuTime(threadId);
+        cpuInfoConcurrentHashMap.put(threadId, new Info(threadCpuTime, UUID.randomUUID().toString()));
+    }
+
+    public void clearStats(long threadId) {
+        if (cpuInfoConcurrentHashMap.containsKey(threadId)) {
+            cpuInfoConcurrentHashMap.remove(threadId);
+        }
+    }
+
+    public Map<String, Object> statsFor(long threadId) {
+        if (!cpuInfoConcurrentHashMap.containsKey(threadId)) {
+            return null;
+        }
+        ThreadMXBean threadMXBean = ManagementFactory.getThreadMXBean();
+        long end = threadMXBean.getThreadCpuTime(threadId);
+        Info info = cpuInfoConcurrentHashMap.get(threadId);
+        Long start = info.time;
+        HashMap<String, Object> map = new HashMap<>();
+        map.put("CPUTime(nanoseconds)", end - start);
+        map.put("UUID", info.uuid);
+        return map;
+    }
+
+    private class Info {
+        public long time;
+        public String uuid;
+
+        public Info(long threadCpuTime, String uuid) {
+            time = threadCpuTime;
+            this.uuid = uuid;
+        }
+    }
+
+}

--- a/server/src/com/thoughtworks/go/server/service/support/ResourceMonitoring.java
+++ b/server/src/com/thoughtworks/go/server/service/support/ResourceMonitoring.java
@@ -45,7 +45,7 @@ public class ResourceMonitoring {
             if (threadMXBean.isThreadCpuTimeSupported()) {
                 threadMXBean.setThreadCpuTimeEnabled(true);
             }
-            if (((com.sun.management.ThreadMXBean) threadMXBean).isThreadAllocatedMemorySupported()) {
+            if ((threadMXBean instanceof com.sun.management.ThreadMXBean) && ((com.sun.management.ThreadMXBean) threadMXBean).isThreadAllocatedMemorySupported()) {
                 ((com.sun.management.ThreadMXBean) threadMXBean).setThreadAllocatedMemoryEnabled(true);
             }
         }

--- a/server/src/com/thoughtworks/go/server/service/support/ResourceMonitoring.java
+++ b/server/src/com/thoughtworks/go/server/service/support/ResourceMonitoring.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2016 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.server.service.support;
+
+import com.thoughtworks.go.util.SystemEnvironment;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.lang.management.ManagementFactory;
+import java.lang.management.ThreadMXBean;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Component
+public class ResourceMonitoring {
+    private SystemEnvironment systemEnvironment;
+
+    @Autowired
+    public ResourceMonitoring(SystemEnvironment systemEnvironment) {
+        this.systemEnvironment = systemEnvironment;
+    }
+
+    public void enableIfDiagnosticsModeIsEnabled() {
+        if (systemEnvironment.get(SystemEnvironment.GO_DIAGNOSTICS_MODE)) {
+            ThreadMXBean threadMXBean = ManagementFactory.getThreadMXBean();
+            if (threadMXBean.isThreadContentionMonitoringSupported()) {
+                threadMXBean.setThreadContentionMonitoringEnabled(true);
+            }
+            if (threadMXBean.isThreadCpuTimeSupported()) {
+                threadMXBean.setThreadCpuTimeEnabled(true);
+            }
+            if (((com.sun.management.ThreadMXBean) threadMXBean).isThreadAllocatedMemorySupported()) {
+                ((com.sun.management.ThreadMXBean) threadMXBean).setThreadAllocatedMemoryEnabled(true);
+            }
+        }
+    }
+}

--- a/server/src/com/thoughtworks/go/server/service/support/ServerStatusService.java
+++ b/server/src/com/thoughtworks/go/server/service/support/ServerStatusService.java
@@ -16,6 +16,8 @@
 
 package com.thoughtworks.go.server.service.support;
 
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 import com.thoughtworks.go.i18n.LocalizedMessage;
 import com.thoughtworks.go.server.domain.Username;
 import com.thoughtworks.go.server.service.SecurityService;
@@ -46,6 +48,16 @@ public class ServerStatusService {
                 return Double.compare(oneProvider.priority(), anotherProvider.priority());
             }
         });
+        Runtime.getRuntime().addShutdownHook(logServerInfo());
+    }
+
+    private Thread logServerInfo() {
+        return new Thread(new Runnable() {
+            @Override
+            public void run() {
+                LOGGER.info(new GsonBuilder().setPrettyPrinting().serializeNulls().create().toJson(serverInfoAsJson()));
+            }
+        });
     }
 
     public Map<String, Object> asJson(Username username, LocalizedOperationResult result) {
@@ -54,6 +66,11 @@ public class ServerStatusService {
             return null;
         }
 
+        return serverInfoAsJson();
+
+    }
+
+    private Map<String, Object> serverInfoAsJson() {
         LinkedHashMap<String, Object> json = new LinkedHashMap<>();
         json.put("Timestamp", DateUtils.formatISO8601(new Date()));
 
@@ -66,6 +83,5 @@ public class ServerStatusService {
             }
         }
         return json;
-
     }
 }

--- a/server/test/integration/com/thoughtworks/go/server/messaging/activemq/ActiveMqTest.java
+++ b/server/test/integration/com/thoughtworks/go/server/messaging/activemq/ActiveMqTest.java
@@ -43,7 +43,7 @@ public class ActiveMqTest implements GoMessageListener {
 
     @Before
     public void setUp() throws Exception {
-        messaging = new ActiveMqMessagingService();
+        messaging = new ActiveMqMessagingService(null);
 
     }
 

--- a/server/test/unit/com/thoughtworks/go/server/initializers/ApplicationInitializerTest.java
+++ b/server/test/unit/com/thoughtworks/go/server/initializers/ApplicationInitializerTest.java
@@ -35,6 +35,7 @@ import com.thoughtworks.go.server.security.GoCasServiceProperties;
 import com.thoughtworks.go.server.security.LdapContextFactory;
 import com.thoughtworks.go.server.security.RemoveAdminPermissionFilter;
 import com.thoughtworks.go.server.service.*;
+import com.thoughtworks.go.server.service.support.ResourceMonitoring;
 import com.thoughtworks.go.server.service.support.toggle.FeatureToggleService;
 import com.thoughtworks.go.server.service.support.toggle.Toggles;
 import com.thoughtworks.go.service.ConfigRepository;
@@ -136,6 +137,8 @@ public class ApplicationInitializerTest {
     private DependencyMaterialUpdateNotifier dependencyMaterialUpdateNotifier;
     @Mock
     private SCMMaterialSource scmMaterialSource;
+    @Mock
+    private ResourceMonitoring resourceMonitoring;
     @InjectMocks
     ApplicationInitializer initializer = new ApplicationInitializer();
 

--- a/server/test/unit/com/thoughtworks/go/server/materials/MaterialUpdateListenerFactoryTest.java
+++ b/server/test/unit/com/thoughtworks/go/server/materials/MaterialUpdateListenerFactoryTest.java
@@ -75,7 +75,7 @@ public class MaterialUpdateListenerFactoryTest {
                 materialRepository, systemEnvironment, healthService, diskSpaceMonitor,
                 transactionTemplate, dependencyMaterialUpdater, scmMaterialUpdater,
                 packageMaterialUpdater, pluggableSCMMaterialUpdater, materialExpansionService, mduPerformanceLogger,
-                dependencyMaterialQueue);
+                dependencyMaterialQueue, null);
         factory.init();
 
         verify(queue, new Times(NUMBER_OF_CONSUMERS)).addListener(any(GoMessageListener.class));
@@ -89,7 +89,7 @@ public class MaterialUpdateListenerFactoryTest {
                 materialRepository, systemEnvironment, healthService, diskSpaceMonitor,
                 transactionTemplate, dependencyMaterialUpdater, scmMaterialUpdater,
                 packageMaterialUpdater, pluggableSCMMaterialUpdater, materialExpansionService, mduPerformanceLogger,
-                dependencyMaterialQueue);
+                dependencyMaterialQueue, null);
         factory.init();
 
         verify(configQueue, new Times(NUMBER_OF_CONFIG_CONSUMERS)).addListener(any(GoMessageListener.class));
@@ -105,7 +105,7 @@ public class MaterialUpdateListenerFactoryTest {
                 materialRepository, systemEnvironment, healthService, diskSpaceMonitor,
                 transactionTemplate, dependencyMaterialUpdater, scmMaterialUpdater,
                 packageMaterialUpdater, pluggableSCMMaterialUpdater, materialExpansionService, mduPerformanceLogger,
-                dependencyMaterialQueue);
+                dependencyMaterialQueue, null);
         factory.init();
 
         verify(dependencyMaterialQueue, new Times(noOfDependencyMaterialCheckListeners)).addListener(any(GoMessageListener.class));

--- a/server/test/unit/com/thoughtworks/go/server/messaging/activemq/JMSMessageListenerAdapterTest.java
+++ b/server/test/unit/com/thoughtworks/go/server/messaging/activemq/JMSMessageListenerAdapterTest.java
@@ -18,6 +18,7 @@ package com.thoughtworks.go.server.messaging.activemq;
 
 import javax.jms.MessageConsumer;
 
+import com.thoughtworks.go.server.service.support.DaemonThreadStatsCollector;
 import com.thoughtworks.go.server.messaging.GoMessage;
 import com.thoughtworks.go.server.messaging.GoMessageListener;
 import static org.junit.Assert.fail;
@@ -39,7 +40,7 @@ public class JMSMessageListenerAdapterTest {
                 return "test-listener";
             }
         };
-        JMSMessageListenerAdapter listenerAdapter = JMSMessageListenerAdapter.startListening(consumer, mockListener);
+        JMSMessageListenerAdapter listenerAdapter = JMSMessageListenerAdapter.startListening(consumer, mockListener, mock(DaemonThreadStatsCollector.class));
         try {
             listenerAdapter.runImpl();
         } catch (Exception e) {


### PR DESCRIPTION
* CPU time for all threads
* CPU consumed by the current set of operations for daemon threads used for MDU/Scheduling etc
* AllocatedMemory for each thread
* Capturing of allocated-memory, thread-wait times and thread-blocked times are not enabled by default. Enabling capturing of these stats based on a diagnostics flag