### PR TITLE
Fixed the Error Message to show proper config element type

### DIFF
--- a/server/src/com/thoughtworks/go/server/service/TemplateConfigService.java
+++ b/server/src/com/thoughtworks/go/server/service/TemplateConfigService.java
@@ -87,7 +87,7 @@ public class TemplateConfigService {
             goConfigService.updateConfig(command, currentUser);
         } catch (Exception e) {
             if (e instanceof GoConfigInvalidException) {
-                result.unprocessableEntity(LocalizedMessage.string("ENTITY_CONFIG_VALIDATION_FAILED", templateConfig.getClass().getAnnotation(ConfigTag.class).value(), templateConfig.name(), e.getMessage()));
+                result.unprocessableEntity(LocalizedMessage.string("ENTITY_CONFIG_VALIDATION_FAILED", "template", templateConfig.name(), e.getMessage()));
             } else {
                 if (!result.hasMessage()) {
                     LOGGER.error(e.getMessage(), e);


### PR DESCRIPTION
When Templates API failed to perform any operations,

Previous error message:
"Validations failed for pipeline 'template-name'. Error(s): [Validation failed.]. Please correct and resubmit."

Fixed:
"Validations failed for template 'template-name'. Error(s): [Validation failed.]. Please correct and resubmit."