### PR TITLE
Allow template admins to access templates APIs v4.

### DIFF
--- a/server/src/com/thoughtworks/go/config/update/DeleteTemplateConfigCommand.java
+++ b/server/src/com/thoughtworks/go/config/update/DeleteTemplateConfigCommand.java
@@ -57,15 +57,7 @@ public class DeleteTemplateConfigCommand extends TemplateConfigCommand {
 
     @Override
     public boolean canContinue(CruiseConfig cruiseConfig) {
-        return isUserAuthorized() && doesTemplateExist(cruiseConfig);
-    }
-
-    private boolean isUserAuthorized() {
-        if (!goConfigService.isAuthorizedToEditTemplate(templateConfig.name().toString(), currentUser)) {
-            result.unauthorized(LocalizedMessage.string("UNAUTHORIZED_TO_EDIT"), HealthStateType.unauthorised());
-            return false;
-        }
-        return true;
+        return super.canContinue(cruiseConfig) && doesTemplateExist(cruiseConfig);
     }
 
     private boolean doesTemplateExist(CruiseConfig cruiseConfig) {

--- a/server/test/unit/com/thoughtworks/go/config/update/DeleteTemplateConfigCommandTest.java
+++ b/server/test/unit/com/thoughtworks/go/config/update/DeleteTemplateConfigCommandTest.java
@@ -94,7 +94,7 @@ public class DeleteTemplateConfigCommandTest {
     @Test
     public void shouldContinueWithConfigSaveIfUserIsAuthorized() {
         cruiseConfig.addTemplate(pipelineTemplateConfig);
-        when(goConfigService.isAuthorizedToEditTemplate("template", currentUser)).thenReturn(true);
+        when(goConfigService.isUserAdmin(currentUser)).thenReturn(true);
 
         DeleteTemplateConfigCommand command = new DeleteTemplateConfigCommand(pipelineTemplateConfig, result, goConfigService, currentUser);
 

--- a/server/webapp/WEB-INF/rails.new/app/controllers/api_v2/admin/templates_controller.rb
+++ b/server/webapp/WEB-INF/rails.new/app/controllers/api_v2/admin/templates_controller.rb
@@ -17,8 +17,8 @@
 module ApiV2
   module Admin
     class TemplatesController < ApiV2::BaseController
-      before_action :check_admin_user_and_401, only: [:create]
-      before_action :check_admin_or_template_admin_and_401, only: [:index, :show, :update, :destroy]
+      before_action :check_admin_user_and_401, only: [:create, :destroy]
+      before_action :check_admin_or_template_admin_and_401, only: [:index, :show, :update]
       before_action :load_template, only: [:show, :update, :destroy]
       before_action :check_for_stale_request, :check_for_attempted_template_rename, only: [:update]
 

--- a/server/webapp/WEB-INF/rails.new/app/controllers/api_v3/admin/templates_controller.rb
+++ b/server/webapp/WEB-INF/rails.new/app/controllers/api_v3/admin/templates_controller.rb
@@ -17,8 +17,8 @@
 module ApiV3
   module Admin
     class TemplatesController < ApiV3::BaseController
-      before_action :check_admin_user_and_401, only: [:create]
-      before_action :check_admin_or_template_admin_and_401, only: [:index, :show, :update, :destroy]
+      before_action :check_admin_user_and_401, only: [:create, :destroy]
+      before_action :check_admin_or_template_admin_and_401, only: [:index, :show, :update]
       before_action :load_template, only: [:show, :update, :destroy]
       before_action :check_for_stale_request, :check_for_attempted_template_rename, only: [:update]
 

--- a/server/webapp/WEB-INF/rails.new/app/controllers/api_v4/admin/templates_controller.rb
+++ b/server/webapp/WEB-INF/rails.new/app/controllers/api_v4/admin/templates_controller.rb
@@ -17,8 +17,8 @@
 module ApiV4
   module Admin
     class TemplatesController < ApiV4::BaseController
-      before_action :check_admin_user_and_401, only: [:create]
-      before_action :check_admin_or_template_admin_and_401, only: [:index, :show, :update, :destroy]
+      before_action :check_admin_user_and_401, only: [:create, :destroy]
+      before_action :check_admin_or_template_admin_and_401, only: [:index, :show, :update]
       before_action :load_template, only: [:show, :update, :destroy]
       before_action :check_for_stale_request, :check_for_attempted_template_rename, only: [:update]
 

--- a/server/webapp/WEB-INF/rails.new/app/controllers/api_v4/admin/templates_controller.rb
+++ b/server/webapp/WEB-INF/rails.new/app/controllers/api_v4/admin/templates_controller.rb
@@ -17,7 +17,8 @@
 module ApiV4
   module Admin
     class TemplatesController < ApiV4::BaseController
-      before_action :check_admin_user_and_401
+      before_action :check_admin_user_and_401, only: [:create]
+      before_action :check_admin_or_template_admin_and_401, only: [:index, :show, :update, :destroy]
       before_action :load_template, only: [:show, :update, :destroy]
       before_action :check_for_stale_request, :check_for_attempted_template_rename, only: [:update]
 

--- a/server/webapp/WEB-INF/rails.new/spec/controllers/api_v2/admin/templates_controller_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/controllers/api_v2/admin/templates_controller_spec.rb
@@ -456,17 +456,16 @@ describe ApiV2::Admin::TemplatesController do
         expect(controller).to allow_action(:delete, :destroy)
       end
 
-      it 'show allow template admin, with security enabled' do
+      it 'show disallow template admin, with security enabled' do
         login_as_template_admin
 
-        expect(controller).to allow_action(:delete, :destroy, template_name: 'foo')
+        expect(controller).to disallow_action(:delete, :destroy, template_name: 'foo')
       end
     end
     describe 'admin' do
       before(:each) do
         enable_security
         login_as_admin
-        @security_service.should_receive(:isAuthorizedToEditTemplate).with(anything, anything).and_return(true)
       end
 
       it 'should raise an error if template is not found' do

--- a/server/webapp/WEB-INF/rails.new/spec/controllers/api_v3/admin/templates_controller_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/controllers/api_v3/admin/templates_controller_spec.rb
@@ -456,17 +456,16 @@ describe ApiV3::Admin::TemplatesController do
         expect(controller).to allow_action(:delete, :destroy)
       end
 
-      it 'show allow template admin, with security enabled' do
+      it 'show disallow template admin, with security enabled' do
         login_as_template_admin
 
-        expect(controller).to allow_action(:delete, :destroy, template_name: 'foo')
+        expect(controller).to disallow_action(:delete, :destroy, template_name: 'foo')
       end
     end
     describe 'admin' do
       before(:each) do
         enable_security
         login_as_admin
-        @security_service.should_receive(:isAuthorizedToEditTemplate).with(anything, anything).and_return(true)
       end
 
       it 'should raise an error if template is not found' do

--- a/server/webapp/WEB-INF/rails.new/spec/controllers/api_v4/admin/templates_controller_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/controllers/api_v4/admin/templates_controller_spec.rb
@@ -456,17 +456,16 @@ describe ApiV4::Admin::TemplatesController do
         expect(controller).to allow_action(:delete, :destroy)
       end
 
-      it 'show allow template admin, with security enabled' do
+      it 'show disallow template admin, with security enabled' do
         login_as_template_admin
 
-        expect(controller).to allow_action(:delete, :destroy, template_name: 'foo')
+        expect(controller).to disallow_action(:delete, :destroy, template_name: 'foo')
       end
     end
     describe 'admin' do
       before(:each) do
         enable_security
         login_as_admin
-        @security_service.should_receive(:isAuthorizedToEditTemplate).with(anything, anything).and_return(true)
       end
 
       it 'should raise an error if template is not found' do

--- a/server/webapp/WEB-INF/rails.new/spec/controllers/api_v4/admin/templates_controller_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/controllers/api_v4/admin/templates_controller_spec.rb
@@ -23,8 +23,10 @@ describe ApiV4::Admin::TemplatesController do
     @template = PipelineTemplateConfig.new(CaseInsensitiveString.new('some-template'), StageConfig.new(CaseInsensitiveString.new('stage'), JobConfigs.new(JobConfig.new(CaseInsensitiveString.new('job')))))
     @template_config_service = double('template_config_service')
     @entity_hashing_service = double('entity_hashing_service')
+    @security_service = double('security_service')
     controller.stub(:entity_hashing_service).and_return(@entity_hashing_service)
     controller.stub(:template_config_service).and_return(@template_config_service)
+    controller.stub(:security_service).and_return(@security_service)
   end
 
   describe :index do
@@ -52,6 +54,12 @@ describe ApiV4::Admin::TemplatesController do
       it 'should allow admin, with security enabled' do
         enable_security
         login_as_admin
+
+        expect(controller).to allow_action(:get, :index)
+      end
+
+      it 'show allow template admin, with security enabled' do
+        login_as_template_admin
 
         expect(controller).to allow_action(:get, :index)
       end
@@ -121,12 +129,19 @@ describe ApiV4::Admin::TemplatesController do
 
         expect(controller).to allow_action(:get, :show)
       end
+
+      it 'show allow template admin, with security enabled' do
+        login_as_template_admin
+
+        expect(controller).to allow_action(:get, :show, template_name: 'foo')
+      end
     end
     describe 'admin' do
 
       before(:each) do
         enable_security
         login_as_admin
+        @security_service.should_receive(:isAuthorizedToEditTemplate).with(anything, anything).and_return(true)
         @result =HttpLocalizedOperationResult.new
       end
 
@@ -212,6 +227,12 @@ describe ApiV4::Admin::TemplatesController do
 
         expect(controller).to allow_action(:post, :create)
       end
+
+      it 'show disallow template admin, with security enabled' do
+        login_as_template_admin
+
+        expect(controller).to disallow_action(:post, :create)
+      end
     end
     describe 'admin' do
       before(:each) do
@@ -292,11 +313,18 @@ describe ApiV4::Admin::TemplatesController do
 
         expect(controller).to allow_action(:put, :update)
       end
+
+      it 'show allow template admin, with security enabled' do
+        login_as_template_admin
+
+        expect(controller).to allow_action(:put, :update, template_name: 'foo')
+      end
     end
     describe 'admin' do
       before(:each) do
         enable_security
         login_as_admin
+        @security_service.should_receive(:isAuthorizedToEditTemplate).with(anything, anything).and_return(true)
       end
 
       it 'should deserialize template from given parameters' do
@@ -427,11 +455,18 @@ describe ApiV4::Admin::TemplatesController do
 
         expect(controller).to allow_action(:delete, :destroy)
       end
+
+      it 'show allow template admin, with security enabled' do
+        login_as_template_admin
+
+        expect(controller).to allow_action(:delete, :destroy, template_name: 'foo')
+      end
     end
     describe 'admin' do
       before(:each) do
         enable_security
         login_as_admin
+        @security_service.should_receive(:isAuthorizedToEditTemplate).with(anything, anything).and_return(true)
       end
 
       it 'should raise an error if template is not found' do


### PR DESCRIPTION
@arvindsv, @jyotisingh, @ketan - According to https://github.com/gocd/gocd/blob/master/server/webapp/WEB-INF/rails.new/app/views/admin/templates/_templates_listing.html.erb#L23 , only Go System Administrators can delete a template. Do you know why we should retain this behaviour? If so, I'll update the PR to remove access to delete template API for template admins.  