### PR TITLE
Version updater fixes

### DIFF
--- a/base/src/com/thoughtworks/go/util/SystemEnvironment.java
+++ b/base/src/com/thoughtworks/go/util/SystemEnvironment.java
@@ -203,6 +203,7 @@ public class SystemEnvironment implements Serializable, ConfigDirProvider {
     public static GoIntSystemProperty DEPENDENCY_MATERIAL_UPDATE_LISTENERS = new GoIntSystemProperty("dependency.material.check.threads", 3);
 
     public static GoSystemProperty<Boolean> OPTIMIZE_FULL_CONFIG_SAVE = new GoBooleanSystemProperty("optimize.full.config.save", true);
+    public static GoSystemProperty<String> GO_SERVER_MODE = new GoStringSystemProperty("go.server.mode", "production");
 
     private final static Map<String, String> GIT_ALLOW_PROTOCOL;
 
@@ -804,6 +805,10 @@ public class SystemEnvironment implements Serializable, ConfigDirProvider {
 
     public boolean optimizeFullConfigSave() {
         return OPTIMIZE_FULL_CONFIG_SAVE.getValue();
+    }
+
+    public boolean isProductionMode() {
+        return GO_SERVER_MODE.getValue().equalsIgnoreCase("production");
     }
 
     public static abstract class GoSystemProperty<T> {

--- a/development-utility/development-server/src/com/thoughtworks/go/server/DevelopmentServer.java
+++ b/development-utility/development-server/src/com/thoughtworks/go/server/DevelopmentServer.java
@@ -62,6 +62,7 @@ public class DevelopmentServer {
 
         systemEnvironment.set(SystemEnvironment.DEFAULT_PLUGINS_ZIP, "/plugins.zip");
         systemEnvironment.setProperty(GoConstants.I18N_CACHE_LIFE, "0"); //0 means reload when stale
+        systemEnvironment.set(SystemEnvironment.GO_SERVER_MODE, "development");
         setupPeriodicGC(systemEnvironment);
         PropertyConfigurator.configureAndWatch("./properties/src/log4j.properties", 100L);
         File pluginsDist = new File("../tw-go-plugins/dist/");

--- a/server/src/com/thoughtworks/go/server/service/ServerVersionInfoManager.java
+++ b/server/src/com/thoughtworks/go/server/service/ServerVersionInfoManager.java
@@ -97,7 +97,7 @@ public class ServerVersionInfoManager {
     }
 
     private boolean isDevelopmentServer() {
-        return serverVersionInfo == null;
+        return !systemEnvironment.isProductionMode() || (serverVersionInfo == null);
     }
 
     private boolean isVersionInfoUpdatedToday() {

--- a/server/src/com/thoughtworks/go/server/service/VersionInfoService.java
+++ b/server/src/com/thoughtworks/go/server/service/VersionInfoService.java
@@ -34,6 +34,10 @@ public class VersionInfoService {
     }
 
     public VersionInfo getStaleVersionInfo() {
+        if (!manager.isUpdateCheckEnabled()) {
+            return null;
+        }
+
         return manager.versionInfoForUpdate();
     }
 

--- a/server/test/unit/com/thoughtworks/go/server/service/ServerVersionInfoManagerTest.java
+++ b/server/test/unit/com/thoughtworks/go/server/service/ServerVersionInfoManagerTest.java
@@ -48,6 +48,7 @@ public class ServerVersionInfoManagerTest {
         systemEnvironment = mock(SystemEnvironment.class);
         manager = new ServerVersionInfoManager(builder, versionInfoDao, new SystemTimeClock(), goCache, systemEnvironment);
 
+        stub(systemEnvironment.isProductionMode()).toReturn(true);
         when(systemEnvironment.isGOUpdateCheckEnabled()).thenReturn(true);
     }
 
@@ -126,12 +127,12 @@ public class ServerVersionInfoManagerTest {
     @Test
     public void shouldNotReturnVersionInfoForDevelopementServer(){
         when(builder.getServerVersionInfo()).thenReturn(null);
+        when(systemEnvironment.isProductionMode()).thenReturn(false);
 
         manager.initialize();
 
         assertNull(manager.versionInfoForUpdate());
     }
-
 
     @Test
     public void shouldNotGetVersionInfoIfLatestVersionIsBeingUpdated(){
@@ -221,6 +222,7 @@ public class ServerVersionInfoManagerTest {
 
         when(builder.getServerVersionInfo()).thenReturn(new VersionInfo());
         when(systemEnvironment.isGOUpdateCheckEnabled()).thenReturn(true);
+        when(systemEnvironment.isProductionMode()).thenReturn(true);
 
         manager = new ServerVersionInfoManager(builder, versionInfoDao, new SystemTimeClock(), goCache, systemEnvironment);
         manager.initialize();
@@ -229,10 +231,11 @@ public class ServerVersionInfoManagerTest {
     }
 
     @Test
-    public void shouldBeFalseForADevelopmentServer(){
+    public void updateCheckShouldBeDisabledForADevelopmentServer(){
         SystemEnvironment systemEnvironment = mock(SystemEnvironment.class);
 
-        when(builder.getServerVersionInfo()).thenReturn(null);
+        when(builder.getServerVersionInfo()).thenReturn(new VersionInfo());
+        when(systemEnvironment.isProductionMode()).thenReturn(false);
         when(systemEnvironment.isGOUpdateCheckEnabled()).thenReturn(true);
 
         manager = new ServerVersionInfoManager(builder, versionInfoDao, new SystemTimeClock(), goCache, systemEnvironment);
@@ -245,8 +248,9 @@ public class ServerVersionInfoManagerTest {
     public void shouldBeFalseIfVersionCheckIsDisabled(){
         SystemEnvironment systemEnvironment = mock(SystemEnvironment.class);
 
-        when(builder.getServerVersionInfo()).thenReturn(null);
-        when(systemEnvironment.isGOUpdateCheckEnabled()).thenReturn(true);
+        when(builder.getServerVersionInfo()).thenReturn(new VersionInfo());
+        when(systemEnvironment.isProductionMode()).thenReturn(true);
+        when(systemEnvironment.isGOUpdateCheckEnabled()).thenReturn(false);
 
         manager = new ServerVersionInfoManager(builder, versionInfoDao, new SystemTimeClock(), goCache, systemEnvironment);
         manager.initialize();

--- a/server/test/unit/com/thoughtworks/go/server/service/VersionInfoServiceTest.java
+++ b/server/test/unit/com/thoughtworks/go/server/service/VersionInfoServiceTest.java
@@ -22,9 +22,7 @@ import com.thoughtworks.go.server.service.result.HttpLocalizedOperationResult;
 import org.junit.Test;
 
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
 public class VersionInfoServiceTest {
@@ -35,11 +33,24 @@ public class VersionInfoServiceTest {
         VersionInfo versionInfo = mock(VersionInfo.class);
 
         when(versionInfoManager.versionInfoForUpdate()).thenReturn(versionInfo);
+        when(versionInfoManager.isUpdateCheckEnabled()).thenReturn(true);
 
         VersionInfoService versionInfoService = new VersionInfoService(versionInfoManager);
         VersionInfo info = versionInfoService.getStaleVersionInfo();
 
         assertThat(info, is(versionInfo));
+    }
+
+    @Test
+    public void shouldReturnNullIfVersionUpdateIsDisabled() {
+        ServerVersionInfoManager versionInfoManager = mock(ServerVersionInfoManager.class);
+
+        when(versionInfoManager.isUpdateCheckEnabled()).thenReturn(true);
+
+        VersionInfoService versionInfoService = new VersionInfoService(versionInfoManager);
+        VersionInfo info = versionInfoService.getStaleVersionInfo();
+
+        assertNull(info);
     }
 
     @Test

--- a/server/webapp/WEB-INF/rails.new/app/assets/new_javascripts/models/shared/version_updater.js
+++ b/server/webapp/WEB-INF/rails.new/app/assets/new_javascripts/models/shared/version_updater.js
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2017 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+define(['mithril', 'lodash', 'helpers/mrequest', 'js-routes'], function (m, _, mrequest, Routes) {
+
+  var VersionUpdater = function () {
+    this.update = function () {
+      if (canUpdateVersion()) {
+        fetchStaleVersionInfo().then(function (data) {
+          _.isEmpty(data) ? markUpdateDone() : fetchLatestVersion(data);
+        });
+      }
+    };
+
+    var fetchStaleVersionInfo = function () {
+      return m.request({
+        method:     'GET',
+        url:        Routes.apiv1StaleVersionInfoPath(),
+        background: true,
+        config:     mrequest.xhrConfig.v1
+      });
+    };
+
+    var fetchLatestVersion = function (versionInfo) {
+      m.request({
+        method:  'GET',
+        url:     versionInfo['update_server_url'],
+        background: true,
+        config: function (xhr) {
+          xhr.setRequestHeader("Accept", "application/vnd.update.go.cd.v1+json");
+        }}).then(function (data) {
+          updateLatestVersion(data);
+        }
+      );
+    };
+
+    var updateLatestVersion = function (data) {
+      m.request({
+        method:     'PATCH',
+        background: true,
+        config:     mrequest.xhrConfig.v1,
+        url:        Routes.apiv1UpdateServerVersionInfoPath(),
+        data:       data
+      }).then(function () {
+        markUpdateDone();
+      });
+    };
+
+    var canUpdateVersion = function () {
+      var versionCheckInfo = localStorage.getItem('versionCheckInfo');
+      if (_.isEmpty(versionCheckInfo)) {
+        return true;
+      }
+      versionCheckInfo = JSON.parse(versionCheckInfo);
+      var lastUpdateAt = new Date(versionCheckInfo.last_updated_at);
+      var halfHourAgo = new Date(_.now() - 30 * 60 * 1000);
+      return halfHourAgo > lastUpdateAt;
+    };
+
+    var markUpdateDone = function () {
+      var versionCheckInfo = JSON.stringify({last_updated_at: new Date().getTime()}); //eslint-disable-line camelcase
+      localStorage.setItem('versionCheckInfo', versionCheckInfo);
+    };
+  };
+
+  return VersionUpdater;
+});

--- a/server/webapp/WEB-INF/rails.new/app/assets/new_javascripts/single_page_apps/agents.js
+++ b/server/webapp/WEB-INF/rails.new/app/assets/new_javascripts/single_page_apps/agents.js
@@ -15,14 +15,13 @@
  */
 
 require([
-  'jquery', 'mithril',
-  'models/agents/agents',
-  'views/agents/agents_widget',
-  'views/agents/models/agents_widget_view_model',
-  'foundation.util.mediaQuery', 'foundation.dropdownMenu', 'foundation.responsiveToggle', 'foundation.dropdown'
-], function ($, m, Agents, AgentsWidget, AgentsVM) {
+  'jquery', 'mithril', 'models/agents/agents', 'views/agents/agents_widget', 'views/agents/models/agents_widget_view_model',
+  'models/shared/version_updater', 'foundation.util.mediaQuery', 'foundation.dropdownMenu', 'foundation.responsiveToggle',
+  'foundation.dropdown'
+], function ($, m, Agents, AgentsWidget, AgentsVM, VersionUpdater) {
 
   $(function () {
+    new VersionUpdater().update();
 
     var agentsDOMElement = document.getElementById('agents');
 

--- a/server/webapp/WEB-INF/rails.new/app/assets/new_javascripts/single_page_apps/elastic_profiles.js
+++ b/server/webapp/WEB-INF/rails.new/app/assets/new_javascripts/single_page_apps/elastic_profiles.js
@@ -15,14 +15,14 @@
  */
 
 require([
-  'jquery', 'mithril',
-  'views/elastic_profiles/elastic_profiles_widget',
-  'models/pipeline_configs/plugin_infos',
-  'foundation.util.mediaQuery', 'foundation.dropdownMenu', 'foundation.responsiveToggle', 'foundation.dropdown'
-], function ($, m, ElasticProfilesWidget, PluginInfos) {
+  'jquery', 'mithril', 'views/elastic_profiles/elastic_profiles_widget', 'models/pipeline_configs/plugin_infos',
+  'models/shared/version_updater', 'foundation.util.mediaQuery', 'foundation.dropdownMenu',
+  'foundation.responsiveToggle', 'foundation.dropdown'
+], function ($, m, ElasticProfilesWidget, PluginInfos, VersionUpdater) {
 
   $(function () {
     $(document).foundation();
+    new VersionUpdater().update();
 
     var onSuccess = function () {
       m.mount($("#elastic-profiles").get(0), ElasticProfilesWidget);

--- a/server/webapp/WEB-INF/rails.new/app/assets/new_javascripts/single_page_apps/pipeline_configs.js
+++ b/server/webapp/WEB-INF/rails.new/app/assets/new_javascripts/single_page_apps/pipeline_configs.js
@@ -18,9 +18,9 @@ require([
   'jquery', 'mithril', 'models/pipeline_configs/pluggable_tasks', 'models/pipeline_configs/resources', 'models/pipeline_configs/users',
   'models/pipeline_configs/roles', 'views/pipeline_configs/pipeline_config_widget', 'models/pipeline_configs/plugin_infos',
   'models/pipeline_configs/pluggable_scms', 'models/pipeline_configs/scms', 'models/elastic_profiles/elastic_profiles',
-  'foundation.util.mediaQuery', 'foundation.dropdownMenu',
-  'foundation.responsiveToggle', 'foundation.dropdown'
-], function ($, m, PluggableTasks, Resources, Users, Roles, PipelineConfigWidget, PluginInfos, PluggableSCMs, SCMs, ElasticProfiles) {
+  'models/shared/version_updater', 'foundation.util.mediaQuery', 'foundation.dropdownMenu', 'foundation.responsiveToggle',
+  'foundation.dropdown'
+], function ($, m, PluggableTasks, Resources, Users, Roles, PipelineConfigWidget, PluginInfos, PluggableSCMs, SCMs, ElasticProfiles, VersionUpdater) {
 
   $(function () {
     var pipelineConfigElem = $('#pipeline-config');
@@ -32,6 +32,7 @@ require([
     Resources.initializeWith(allResourceNames);
     Users.initializeWith(allUserNames);
     Roles.initializeWith(allRoleNames);
+    new VersionUpdater().update();
     m.sync([PluginInfos.init(), SCMs.init(), ElasticProfiles.all()]).then(function (args) {
 
       PluggableTasks.init();

--- a/server/webapp/WEB-INF/rails.new/app/assets/new_stylesheets/shared/_common.scss
+++ b/server/webapp/WEB-INF/rails.new/app/assets/new_stylesheets/shared/_common.scss
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 @import "go-variables";
+@import "notifications";
 
 %boxshadow {
   box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.2);

--- a/server/webapp/WEB-INF/rails.new/app/assets/new_stylesheets/shared/_header.scss
+++ b/server/webapp/WEB-INF/rails.new/app/assets/new_stylesheets/shared/_header.scss
@@ -142,3 +142,7 @@ $menu-hover: #3e3d3d;
     }
   }
 }
+
+.nav-right {
+  float: right;
+}

--- a/server/webapp/WEB-INF/rails.new/app/assets/new_stylesheets/shared/_notifications.scss
+++ b/server/webapp/WEB-INF/rails.new/app/assets/new_stylesheets/shared/_notifications.scss
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2017 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@import 'mixins';
+
+.notifications {
+  margin:   7px 10px 0;
+  position: relative;
+  float:right;
+
+  .hover-container {
+    display:     none;
+    position:    absolute;
+    right:       -7px;
+    top:         100%;
+    padding-top: 5px;
+  }
+
+  .hover {
+    position:           relative;
+    background:         #fff;
+    color:              #000;
+    padding:            10px;
+    border-radius:      5px;
+    width:              296px;
+    font-size:          13px;
+    box-shadow:         3px 3px 5px 0 rgba(0, 0, 0, 0.2);
+    &:after {
+      bottom:              100%;
+      right:               14px;
+      border:              solid transparent;
+      content:             " ";
+      height:              0;
+      width:               0;
+      position:            absolute;
+      pointer-events:      none;
+      border-color:        rgba(255, 255, 255, 0);
+      border-bottom-color: #fff;
+      border-width:        6px;
+
+    }
+    a, a:hover {
+      color:     #1f66bd;
+      font-size: 13px;
+    }
+
+  }
+  &:hover {
+    .hover-container {
+      display: block;
+    }
+  }
+
+  .bell {
+    @include icon-before(bell-o, $color: #fff);
+    font-size: 18px;
+  }
+}
+
+.top-bar .menu .notifications {
+  a {
+    padding: 0;
+  }
+}

--- a/server/webapp/WEB-INF/rails.new/app/views/navigation_elements/_footer.html.erb
+++ b/server/webapp/WEB-INF/rails.new/app/views/navigation_elements/_footer.html.erb
@@ -26,7 +26,7 @@
 
 <%- if check_go_updates? -%>
   <script type="text/javascript">
-    var updater = new VersionUpdater('<%= apiv1_stale_version_info_url %>', '<%= apiv1_update_server_version_info_url%>');
+    var updater = new VersionUpdater('<%= apiv1_stale_version_info_path %>', '<%= apiv1_update_server_version_info_path%>');
     updater.update();
   </script>
 <%- end -%>

--- a/server/webapp/WEB-INF/rails.new/app/views/new_navigation_elements/_navigation.html.erb
+++ b/server/webapp/WEB-INF/rails.new/app/views/new_navigation_elements/_navigation.html.erb
@@ -33,8 +33,8 @@
   <div class="medium-6 columns">
     <div class="top-bar-right">
       <ul class="dropdown menu current-user nav-right" data-dropdown-menu>
+        <li><%= link_to(l.string('HELP_SMALL'), 'https://gocd.io/help', :target => '_blank') %></li>
         <% unless @user.anonymous? %>
-            <li><%= link_to(l.string('HELP_SMALL'), 'https://gocd.io/help', :target => '_blank') %></li>
             <li class="current-user">
               <a href="#"><i class="user"></i><%= @user.display_name %></a>
               <ul class="menu vertical">
@@ -43,8 +43,17 @@
               </ul>
             </li>
         <% end %>
-
       </ul>
+      <% if check_go_updates? and go_update %>
+          <div class="notifications">
+            <span class="bell"></span>
+            <div class="hover-container">
+              <div class="hover">
+                <span>A new release of GoCD - <a href="https://www.gocd.io/download/" target="_blank"><%= go_update %></a> is available.</span>
+              </div>
+            </div>
+          </div>
+      <% end %>
     </div>
   </div>
 </div>

--- a/server/webapp/WEB-INF/rails.new/spec/new_javascripts/models/shared/version_updater_spec.js
+++ b/server/webapp/WEB-INF/rails.new/spec/new_javascripts/models/shared/version_updater_spec.js
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2017 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+define(['mithril', 'jquery', 'models/shared/version_updater'], function (m, $, VersionUpdater) {
+  describe("VersionUpdater", function () {
+    describe('update', function() {
+      beforeEach(function () {
+        localStorage.clear();
+      });
+
+      it('should fetch the stale version info', function () {
+        var deferred = $.Deferred();
+        var xhr = jasmine.createSpyObj(xhr, ['setRequestHeader']);
+        var thirtyOneMinutesBack = new Date(Date.now() - 31 * 60 * 1000);
+
+        localStorage.setItem('versionCheckInfo', JSON.stringify({last_updated_at: thirtyOneMinutesBack})); //eslint-disable-line camelcase
+        spyOn(m, 'request').and.returnValue(deferred.promise());
+
+        new VersionUpdater().update();
+
+        var requestArgs = m.request.calls.mostRecent().args[0];
+        requestArgs.config(xhr);
+
+        expect(requestArgs.method).toBe('GET');
+        expect(requestArgs.url).toBe('/go/api/version_infos/stale');
+        expect(xhr.setRequestHeader).toHaveBeenCalledWith("Content-Type", "application/json");
+        expect(xhr.setRequestHeader).toHaveBeenCalledWith("Accept", "application/vnd.go.cd.v1+json");
+      });
+
+      it('should skip updates if update tried in last half hour', function() {
+        var deferred = $.Deferred();
+        var twentyNineMinutesBack = new Date(Date.now() - 29 * 60 * 1000);
+
+        spyOn(m, 'request').and.returnValue(deferred.promise());
+        localStorage.setItem('versionCheckInfo', JSON.stringify({last_updated_at: twentyNineMinutesBack})); //eslint-disable-line camelcase
+
+        new VersionUpdater().update();
+
+        expect(m.request).not.toHaveBeenCalled();
+      });
+
+      it('should skip updates in absence of stale version info and update local storage with last update time', function () {
+        var deferred = $.Deferred();
+        var myDate = jasmine.createSpyObj('Date', ['getTime']);
+
+        spyOn(window, 'Date').and.returnValue(myDate);
+        myDate.getTime.and.callFake(function() { return 123;});
+
+        spyOn(m, 'request').and.returnValue(deferred.promise());
+
+        deferred.resolve({});
+
+        new VersionUpdater().update();
+
+        expect(m.request).toHaveBeenCalledTimes(1);
+        expect(localStorage.getItem('versionCheckInfo')).toEqual('{"last_updated_at":123}');
+      });
+
+      it('should fetch latest version info if can update', function () {
+        var deferred = $.Deferred();
+        var xhr = jasmine.createSpyObj(xhr, ['setRequestHeader']);
+
+        spyOn(m, 'request').and.returnValue(deferred.promise());
+
+        new VersionUpdater().update();
+        deferred.resolve({'update_server_url': 'update.server.url'});
+
+        var requestArgs = m.request.calls.all()[1].args[0];
+        requestArgs.config(xhr);
+
+        expect(requestArgs.method).toBe('GET');
+        expect(requestArgs.url).toBe('update.server.url');
+        expect(xhr.setRequestHeader).toHaveBeenCalledWith("Accept", "application/vnd.update.go.cd.v1+json");
+      });
+
+      it('should post the latest version info to server', function () {
+        var deferred = $.Deferred();
+        var xhr = jasmine.createSpyObj(xhr, ['setRequestHeader']);
+        var lastestVersionDeferred = $.Deferred();
+        var myDate = jasmine.createSpyObj('Date', ['getTime']);
+
+        spyOn(window, 'Date').and.returnValue(myDate);
+        myDate.getTime.and.callFake(function() { return 123;});
+        spyOn(m, 'request').and.returnValues(deferred.promise(), lastestVersionDeferred.promise(), deferred.promise());
+
+        new VersionUpdater().update();
+        deferred.resolve({'update_server_url': 'update.server.url'});
+        lastestVersionDeferred.resolve({foo: 'bar'});
+
+        var requestArgs = m.request.calls.all()[2].args[0];
+        requestArgs.config(xhr);
+
+        expect(requestArgs.method).toBe('PATCH');
+        expect(requestArgs.url).toBe('/go/api/version_infos/go_server');
+        expect(requestArgs.data).toEqual({foo: 'bar'});
+        expect(xhr.setRequestHeader).toHaveBeenCalledWith("Content-Type", "application/json");
+        expect(xhr.setRequestHeader).toHaveBeenCalledWith("Accept", "application/vnd.go.cd.v1+json");
+        expect(localStorage.getItem('versionCheckInfo')).toEqual('{"last_updated_at":123}');
+      });
+    });
+  });
+});


### PR DESCRIPTION

* Version update check was enabled on new SPA pages.
* New Go version notifications are displayed on new SPA pages.
* Version check is skipped on DevelopmentServer
* Using route helper with _path rather than _url to fix https://github.com/gocd/gocd/issues/2350