### PR TITLE
Fix update call to copy over the existing authorization.

### DIFF
--- a/server/src/com/thoughtworks/go/config/update/UpdateTemplateConfigCommand.java
+++ b/server/src/com/thoughtworks/go/config/update/UpdateTemplateConfigCommand.java
@@ -39,6 +39,7 @@ public class UpdateTemplateConfigCommand extends TemplateConfigCommand{
     @Override
     public void update(CruiseConfig modifiedConfig) throws Exception {
         PipelineTemplateConfig existingTemplateConfig = findAddedTemplate(modifiedConfig);
+        templateConfig.setAuthorization(existingTemplateConfig.getAuthorization());
         TemplatesConfig templatesConfig = modifiedConfig.getTemplates();
         templatesConfig.removeTemplateNamed(existingTemplateConfig.name());
         templatesConfig.add(templateConfig);


### PR DESCRIPTION
Leaving Templates API V4 as is for now, in case we need to have a PATCH call for stage and auth config.