### PR TITLE
Change the migration number for the removal of gadget related tables

### DIFF
--- a/server/db/migrate/h2deltas/1701001_remove_gadget_oauth_tables.sql
+++ b/server/db/migrate/h2deltas/1701001_remove_gadget_oauth_tables.sql
@@ -14,14 +14,9 @@
 -- limitations under the License.
 --
 
--- H2 automatically creates indices on primary keys and foreign keys,
--- while postgres only creates indices on primary keys.
--- A migration was added to create the missing index on a foreign key in postgres.
--- To maintain sanity, and avoid mismatch of the migrations we have on h2 and postgres, this migration is added.
-
-DROP TABLE gadgetOauthAuthorizationCodes;
-DROP TABLE gadgetOauthAccessTokens;
-DROP TABLE gadgetOauthClients;
+DROP TABLE IF EXISTS gadgetOauthAuthorizationCodes;
+DROP TABLE IF EXISTS gadgetOauthAccessTokens ;
+DROP TABLE IF EXISTS gadgetOauthClients;
 
 --//@UNDO
 


### PR DESCRIPTION
Change the sql syntax to include the 'IF EXISTS' clause so that the migration doesn't bomb if already applied previously.