### PR TITLE
Force encoding of the console log to utf-8

### DIFF
--- a/common/src/com/thoughtworks/go/remote/work/RemoteConsoleAppender.java
+++ b/common/src/com/thoughtworks/go/remote/work/RemoteConsoleAppender.java
@@ -23,6 +23,7 @@ import org.apache.http.entity.StringEntity;
 import org.apache.log4j.Logger;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 
 public class RemoteConsoleAppender implements ConsoleAppender {
 
@@ -43,7 +44,7 @@ public class RemoteConsoleAppender implements ConsoleAppender {
                 LOGGER.debug("Appending console to URL -> " + consoleUri);
             }
 
-            putMethod.setEntity(new StringEntity(content));
+            putMethod.setEntity(new StringEntity(content, StandardCharsets.UTF_8));
             HttpService.setSizeHeader(putMethod, content.getBytes().length);
             CloseableHttpResponse response = httpService.execute(putMethod);
             if (LOGGER.isDebugEnabled()) {

--- a/server/src/com/thoughtworks/go/server/service/ConsoleService.java
+++ b/server/src/com/thoughtworks/go/server/service/ConsoleService.java
@@ -31,6 +31,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import java.io.*;
+import java.nio.charset.StandardCharsets;
 
 import static com.thoughtworks.go.util.ArtifactLogUtil.getConsoleOutputFolderAndFileName;
 
@@ -63,7 +64,7 @@ public class ConsoleService {
 
         StringBuilder builder = new StringBuilder();
         try {
-            BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream));
+            BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream, StandardCharsets.UTF_8));
             String consoleLine;
             while (null != (consoleLine = reader.readLine())) {
                 if (lineNumber >= startingLine) {
@@ -115,8 +116,8 @@ public class ConsoleService {
         parentFile.mkdirs();
 
         LOGGER.trace("Updating console log [" + dest.getAbsolutePath() + "]");
-        try (BufferedWriter writer = new BufferedWriter(new FileWriter(dest, dest.exists()))) {
-            IOUtils.copy(in, writer);
+        try (OutputStream out = new BufferedOutputStream(new FileOutputStream(dest, dest.exists()))) {
+            IOUtils.copyLarge(in, out);
         } catch (IOException e) {
             LOGGER.error("Failed to update console log at : [" + dest.getAbsolutePath() + "]", e);
             return false;

--- a/util/src/com/thoughtworks/go/util/command/StreamPumper.java
+++ b/util/src/com/thoughtworks/go/util/command/StreamPumper.java
@@ -69,17 +69,14 @@
  */
 package com.thoughtworks.go.util.command;
 
-import java.io.BufferedReader;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.LineNumberReader;
-import java.io.UnsupportedEncodingException;
-import java.util.concurrent.TimeUnit;
-
 import com.thoughtworks.go.util.Clock;
 import com.thoughtworks.go.util.SystemTimeClock;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
+
+import java.io.*;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.TimeUnit;
 
 import static com.thoughtworks.go.util.ExceptionUtils.bomb;
 import static java.lang.String.format;
@@ -116,7 +113,7 @@ public class StreamPumper implements Runnable {
         this.lastHeard = System.currentTimeMillis();
         try {
             if ( encoding==null){
-                this.in = new LineNumberReader(new InputStreamReader(in));
+                this.in = new LineNumberReader(new InputStreamReader(in, StandardCharsets.UTF_8));
             }
             else {
                 this.in = new LineNumberReader(new InputStreamReader(in, encoding));


### PR DESCRIPTION
* ensure that the output is read in utf-8
* ensure that it is transmitted in utf-8
* ensure that it is written AS-IS byte-by-byte
* ensure that it is read in utf-8 before being rendered to the browser