### PR TITLE
Allow plugins with API version 2.0 to access plugin settings

### DIFF
--- a/server/src/com/thoughtworks/go/server/service/plugins/processor/pluginsettings/PluginSettingsRequestProcessor.java
+++ b/server/src/com/thoughtworks/go/server/service/plugins/processor/pluginsettings/PluginSettingsRequestProcessor.java
@@ -41,7 +41,7 @@ public class PluginSettingsRequestProcessor implements GoPluginApiRequestProcess
     private static final Logger LOGGER = Logger.getLogger(PluginSettingsRequestProcessor.class);
 
     public static final String GET_PLUGIN_SETTINGS = "go.processor.plugin-settings.get";
-    private static final List<String> goSupportedVersions = asList("1.0");
+    private static final List<String> goSupportedVersions = asList("1.0", "2.0");
 
     private PluginSqlMapDao pluginSqlMapDao;
     private Map<String, JsonMessageHandler> messageHandlerMap = new HashMap<>();
@@ -51,6 +51,7 @@ public class PluginSettingsRequestProcessor implements GoPluginApiRequestProcess
         this.pluginSqlMapDao = pluginSqlMapDao;
         registry.registerProcessorFor(GET_PLUGIN_SETTINGS, this);
         this.messageHandlerMap.put("1.0", new JsonMessageHandler1_0());
+        this.messageHandlerMap.put("2.0", new JsonMessageHandler1_0());
     }
 
     @Override

--- a/server/test/unit/com/thoughtworks/go/server/service/plugins/processor/pluginsettings/PluginSettingsRequestProcessorTest.java
+++ b/server/test/unit/com/thoughtworks/go/server/service/plugins/processor/pluginsettings/PluginSettingsRequestProcessorTest.java
@@ -84,6 +84,14 @@ public class PluginSettingsRequestProcessorTest {
     }
 
     @Test
+    public void shouldAccept2_0AsAnAPIVersion() {
+        when(pluginDescriptor.id()).thenReturn("plugin-foo-id");
+        when(pluginSqlMapDao.findPlugin("plugin-foo-id")).thenReturn(new Plugin("plugin-foo-id", "{\"k1\": \"v1\",\"k2\": \"v2\"}"));
+        GoApiResponse response = processor.process(pluginDescriptor, new DefaultGoApiRequest(PluginSettingsRequestProcessor.GET_PLUGIN_SETTINGS, "2.0", null));
+        assertThat(response.responseCode(), is(200));
+    }
+
+    @Test
     public void shouldGetPluginSettingsForPluginThatExistsInDB() {
         when(pluginDescriptor.id()).thenReturn("plugin-foo-id");
         when(pluginSqlMapDao.findPlugin("plugin-foo-id")).thenReturn(new Plugin("plugin-foo-id", "{\"k1\": \"v1\",\"k2\": \"v2\"}"));


### PR DESCRIPTION
With the changes in https://github.com/gocd/gocd/pull/3022, if you set your plugin message version to 2.0 the server throws an exception when you try and access the plugin settings.  These changes are to prevent that exception from occurring.