### PR TITLE
Windows installers use the value of REGVER decide if Go is being upgr…

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -12,7 +12,7 @@ Vagrant.configure(2) do |config|
 
   packages = []
 
-  packages << 'java-1.7.0-openjdk-devel'
+  packages << 'java-1.8.0-openjdk-devel'
   packages << %w(zip unzip gzip bzip2) # compression tools
   packages << %w(git)
   packages << %w(createrepo yum-utils rpm-build yum-utils) #for building rpm packages

--- a/buildSrc/src/main/groovy/com/thoughtworks/go/build/WindowsPackagingTask.groovy
+++ b/buildSrc/src/main/groovy/com/thoughtworks/go/build/WindowsPackagingTask.groovy
@@ -131,7 +131,7 @@ class WindowsPackagingTask extends DefaultTask {
           'MODULE'           : packageName.replaceAll(/^go-/, ''),
           'GO_ICON'          : project.file('windows-shared/gocd.ico').absolutePath,
           'VERSION'          : "${version}-${distVersion}",
-          'REGVER'           : "${version}${distVersion.padRight(5, '0')}".replaceAll(/\./, ''),
+          'REGVER'           : "${version.split(/\./).collect{it.padLeft(2, '0')}.join()}${distVersion.padRight(5, '0')}",
           'JAVA'             : 'jre',
           'JAVASRC'          : jreDir,
           'DISABLE_LOGGING'  : System.getenv('DISABLE_WIN_INSTALLER_LOGGING') ?: false,

--- a/installers/windows-shared/windows-installer-base.nsi
+++ b/installers/windows-shared/windows-installer-base.nsi
@@ -98,7 +98,15 @@ Function .onInit
     IfErrors done
         ReadRegStr $1 HKLM "Software\ThoughtWorks Studios\Go $%NAME%" "Ver"
         ReadRegStr $2 HKLM "Software\ThoughtWorks Studios\Go $%NAME%" "Version"
-        IntCmp $1 $%REGVER% issame isnewer isolder
+
+        ${If} $1 L= $%REGVER%
+            Goto issame
+        ${ElseIf} $1 L< $%REGVER%
+            Goto isnewer
+        ${Else}
+            Goto isolder
+        ${EndIf}
+
 
         issame:
             IfSilent IsSameSilentLabel IsSameNonSilentLabel


### PR DESCRIPTION
…aded/downgraded/no-change

For windows installations, a comparison of 'Ver' registry entry (from current installation) with the REGVER variable(from the version being installed) is done to determine if Go is being upgraded/downgraded/no-change. Hence, the value for this variable must he higher than the previous versions.