### PR TITLE
Deriving roles for users on authentication using the Authorization plugins #2956

### DIFF
--- a/common/src/com/thoughtworks/go/listener/AuthorizationPluginUnloadListener.java
+++ b/common/src/com/thoughtworks/go/listener/AuthorizationPluginUnloadListener.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2017 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.listener;
+
+public interface AuthorizationPluginUnloadListener {
+    void onUnload();
+}

--- a/common/src/com/thoughtworks/go/listener/PluginRoleChangeListener.java
+++ b/common/src/com/thoughtworks/go/listener/PluginRoleChangeListener.java
@@ -16,6 +16,6 @@
 
 package com.thoughtworks.go.listener;
 
-public interface AuthorizationPluginUnloadListener {
-    void onUnload();
+public interface PluginRoleChangeListener {
+    void onPluginRoleChange();
 }

--- a/config/config-api/build.gradle
+++ b/config/config-api/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 ThoughtWorks, Inc.
+ * Copyright 2017 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@ dependencies {
   compile group: 'org.apache.felix', name: 'org.apache.felix.framework', version: '4.2.1'
   testCompile project(':test-utils')
   testCompile group: 'jaxen', name: 'jaxen', version: '1.1.6'
+  compileOnly group: 'com.google.guava', name: 'guava', version: '20.0'
 
   compileOnly(group: 'org.bouncycastle', name: 'bcprov-jdk15on', version: '1.47')
 }

--- a/config/config-api/src/com/thoughtworks/go/config/PluginRoleConfig.java
+++ b/config/config-api/src/com/thoughtworks/go/config/PluginRoleConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 ThoughtWorks, Inc.
+ * Copyright 2017 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,6 @@ import com.thoughtworks.go.domain.ConfigErrors;
 import com.thoughtworks.go.domain.config.Configuration;
 import com.thoughtworks.go.domain.config.ConfigurationProperty;
 
-import java.util.Collection;
 import java.util.List;
 
 @ConfigTag("pluginRole")
@@ -36,8 +35,6 @@ public class PluginRoleConfig extends Configuration implements Role {
 
     @ConfigAttribute(value = "authConfigId", optional = false)
     private String authConfigId;
-
-    private Users users = new Users();
 
     public PluginRoleConfig() {
     }
@@ -65,13 +62,12 @@ public class PluginRoleConfig extends Configuration implements Role {
     }
 
     @Override
-    public Collection<RoleUser> doGetUsers() {
-        return users;
+    public void addUser(RoleUser user) {
+        throw new RuntimeException("PluginRoleConfig does not support adding users, should be added through PluginRoleService");
     }
 
-    @Override
-    public void doSetUsers(Collection<RoleUser> users) {
-        this.users = Users.users(users);
+    public void removeUser(RoleUser roleUser) {
+        throw new RuntimeException("PluginRoleConfig does not support removing users, should be removed through PluginRoleService");
     }
 
     public ConfigErrors errors() {
@@ -90,6 +86,11 @@ public class PluginRoleConfig extends Configuration implements Role {
     @Override
     public void setName(CaseInsensitiveString name) {
         this.name = name;
+    }
+
+    @Override
+    public List<RoleUser> getUsers() {
+        return PluginRoleUsersStore.instance().usersInRole(this);
     }
 
     public void addConfigurations(List<ConfigurationProperty> configurations) {

--- a/config/config-api/src/com/thoughtworks/go/config/PluginRoleUsersStore.java
+++ b/config/config-api/src/com/thoughtworks/go/config/PluginRoleUsersStore.java
@@ -25,17 +25,13 @@ import static com.google.common.collect.Multimaps.synchronizedSetMultimap;
 
 public class PluginRoleUsersStore {
     private final SetMultimap<PluginRoleConfig, RoleUser> roleToUsersMappings = synchronizedSetMultimap(HashMultimap.create());
-    private static PluginRoleUsersStore self;
 
     private PluginRoleUsersStore() {
 
     }
 
     public static PluginRoleUsersStore instance() {
-        if (self == null) {
-            self = new PluginRoleUsersStore();
-        }
-        return self;
+        return PluginRoleUsersStoreHolder.PLUGIN_ROLE_USERS_STORE;
     }
 
     public void assignRole(String user, PluginRoleConfig pluginRoleConfig) {
@@ -46,8 +42,12 @@ public class PluginRoleUsersStore {
         return new ArrayList(roleToUsersMappings.get(pluginRoleConfig));
     }
 
-    public Set<PluginRoleConfig> pluginRoles() {
-        return new HashSet<>(roleToUsersMappings.keySet());
+    public void removePluginRolesNotIn(List<PluginRoleConfig> pluginRoles) {
+        for (PluginRoleConfig pluginRole : pluginRoles()) {
+            if (!pluginRoles.contains(pluginRole)) {
+                remove(pluginRole);
+            }
+        }
     }
 
     public void remove(PluginRoleConfig pluginRole) {
@@ -70,7 +70,16 @@ public class PluginRoleUsersStore {
         }
     }
 
+    protected Set<PluginRoleConfig> pluginRoles() {
+        return new HashSet<>(roleToUsersMappings.keySet());
+    }
+
+//    Used only in tests
     public void clearAll() {
         roleToUsersMappings.clear();
+    }
+
+    private static class PluginRoleUsersStoreHolder {
+        static final PluginRoleUsersStore PLUGIN_ROLE_USERS_STORE = new PluginRoleUsersStore();
     }
 }

--- a/config/config-api/src/com/thoughtworks/go/config/PluginRoleUsersStore.java
+++ b/config/config-api/src/com/thoughtworks/go/config/PluginRoleUsersStore.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2017 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.config;
+
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.SetMultimap;
+
+import java.util.*;
+
+import static com.google.common.collect.Multimaps.synchronizedSetMultimap;
+
+public class PluginRoleUsersStore {
+    private final SetMultimap<PluginRoleConfig, RoleUser> roleToUsersMappings = synchronizedSetMultimap(HashMultimap.create());
+    private static PluginRoleUsersStore self;
+
+    private PluginRoleUsersStore() {
+
+    }
+
+    public static PluginRoleUsersStore instance() {
+        if (self == null) {
+            self = new PluginRoleUsersStore();
+        }
+        return self;
+    }
+
+    public void assignRole(String user, PluginRoleConfig pluginRoleConfig) {
+        roleToUsersMappings.put(pluginRoleConfig, new RoleUser(user));
+    }
+
+    public List<RoleUser> usersInRole(PluginRoleConfig pluginRoleConfig) {
+        return new ArrayList(roleToUsersMappings.get(pluginRoleConfig));
+    }
+
+    public Set<PluginRoleConfig> pluginRoles() {
+        return new HashSet<>(roleToUsersMappings.keySet());
+    }
+
+    public void remove(PluginRoleConfig pluginRole) {
+        roleToUsersMappings.removeAll(pluginRole);
+    }
+
+    public void remove(Collection<PluginRoleConfig> pluginRoles) {
+        for (PluginRoleConfig role : pluginRoles) {
+            remove(role);
+        }
+    }
+
+    public void revokeAllRolesFor(String username) {
+        final RoleUser roleUser = new RoleUser(username);
+        synchronized (roleToUsersMappings) {
+            Set<PluginRoleConfig> pluginRoles = new HashSet<>(roleToUsersMappings.keySet());
+            for (PluginRoleConfig pluginRole : pluginRoles) {
+                roleToUsersMappings.get(pluginRole).remove(roleUser);
+            }
+        }
+    }
+
+    public void clearAll() {
+        roleToUsersMappings.clear();
+    }
+}

--- a/config/config-api/src/com/thoughtworks/go/config/Role.java
+++ b/config/config-api/src/com/thoughtworks/go/config/Role.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 ThoughtWorks, Inc.
+ * Copyright 2017 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,9 +27,11 @@ public interface Role extends Validatable {
 
     void setName(CaseInsensitiveString name);
 
-    Collection<RoleUser> doGetUsers();
+    List<RoleUser> getUsers();
 
-    void doSetUsers(Collection<RoleUser> users);
+    void addUser(RoleUser user);
+
+    void removeUser(RoleUser roleUser);
 
     default void validate(ValidationContext validationContext) {
         if (getName().isBlank() || !new NameTypeValidator().isNameValid(getName())) {
@@ -37,7 +39,7 @@ public interface Role extends Validatable {
         }
 
         Set<RoleUser> roleUsers = new HashSet<>();
-        for (RoleUser user : doGetUsers()) {
+        for (RoleUser user : getUsers()) {
             if (roleUsers.contains(user)) {
                 new ErrorMarkingDuplicateHandler(this).invoke(user);
             } else {
@@ -50,7 +52,7 @@ public interface Role extends Validatable {
         if (user == null) {
             return false;
         }
-        for (RoleUser roleUser : doGetUsers()) {
+        for (RoleUser roleUser : getUsers()) {
             if (roleUser.getName().equals(user)) {
                 return true;
             }
@@ -58,28 +60,13 @@ public interface Role extends Validatable {
         return false;
     }
 
-    default void addUser(RoleUser user) {
-        if (!doGetUsers().contains(user)) {
-            doGetUsers().add(user);
-        }
-    }
-
-    default void removeUser(RoleUser roleUser) {
-        doGetUsers().remove(roleUser);
-    }
-
     default Collection<String> usersOfRole() {
         List<String> users = new ArrayList<>();
-        for (RoleUser roleUser : doGetUsers()) {
+        for (RoleUser roleUser : getUsers()) {
             users.add(CaseInsensitiveString.str(roleUser.getName()));
         }
         return users;
     }
-
-    default List<RoleUser> getUsers() {
-        return new ArrayList<>(doGetUsers());
-    }
-
 
     default List<ConfigErrors> getAllErrors() {
         return ErrorCollector.getAllErrors(this);

--- a/config/config-api/src/com/thoughtworks/go/config/RoleConfig.java
+++ b/config/config-api/src/com/thoughtworks/go/config/RoleConfig.java
@@ -1,24 +1,25 @@
-/*************************GO-LICENSE-START*********************************
- * Copyright 2014 ThoughtWorks, Inc.
+/*
+ * Copyright 2017 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *************************GO-LICENSE-END***********************************/
+ */
 
 package com.thoughtworks.go.config;
-    
+
 import com.thoughtworks.go.domain.ConfigErrors;
 
-import java.util.Collection;
+import java.util.ArrayList;
+import java.util.List;
 
 @ConfigTag("role")
 public class RoleConfig implements Role {
@@ -41,21 +42,6 @@ public class RoleConfig implements Role {
 
     public RoleConfig(CaseInsensitiveString name, Users users) {
         this.name = name;
-        doSetUsers(new Users());
-        for (RoleUser user : users) {
-            addUser(user);
-        }
-    }
-
-    @Override
-    public Collection<RoleUser> doGetUsers() {
-        return users;
-    }
-
-    @Override
-    public void doSetUsers(Collection<RoleUser> users) {
-        this.users = new Users();
-
         for (RoleUser user : users) {
             addUser(user);
         }
@@ -79,6 +65,20 @@ public class RoleConfig implements Role {
         this.name = name;
     }
 
+    @Override
+    public List<RoleUser> getUsers() {
+        return new ArrayList<>(users);
+    }
+
+    public void addUser(RoleUser user) {
+        if (!this.users.contains(user)) {
+            this.users.add(user);
+        }
+    }
+
+    public void removeUser(RoleUser roleUser) {
+        this.users.remove(roleUser);
+    }
 
     @Override
     public boolean equals(Object o) {

--- a/config/config-api/src/com/thoughtworks/go/config/RolesConfig.java
+++ b/config/config-api/src/com/thoughtworks/go/config/RolesConfig.java
@@ -101,6 +101,16 @@ public class RolesConfig extends BaseCollection<Role> implements Validatable {
         return null;
     }
 
+
+    public PluginRoleConfig findPluginRoleByName(CaseInsensitiveString pluginRoleName) {
+        for (PluginRoleConfig pluginRoleConfig : getPluginRolesConfig()) {
+            if (pluginRoleConfig.getName().equals(pluginRoleName)) {
+                return pluginRoleConfig;
+            }
+        }
+        return null;
+    }
+
     public boolean isUserMemberOfRole(final CaseInsensitiveString userName, final CaseInsensitiveString roleName) {
         Role role = findByName(roleName);
         bombIfNull(role, String.format("Role \"%s\" does not exist!", roleName));

--- a/config/config-api/src/com/thoughtworks/go/config/SecurityConfig.java
+++ b/config/config-api/src/com/thoughtworks/go/config/SecurityConfig.java
@@ -216,15 +216,16 @@ public class SecurityConfig implements Validatable {
         return this.securityAuthConfigs;
     }
 
-    public List<PluginRoleConfig> getPluginRolesConfig(String pluginId, List<CaseInsensitiveString> roleNames) {
-        ArrayList<PluginRoleConfig> result = new ArrayList<>();
+    public List<PluginRoleConfig> getPluginRoles(String pluginId) {
+        List<PluginRoleConfig> result = new ArrayList<>();
+
         List<SecurityAuthConfig> authConfigs = securityAuthConfigs.findByPluginId(pluginId);
         List<PluginRoleConfig> pluginRoles = rolesConfig.getPluginRolesConfig();
 
         for (SecurityAuthConfig authConfig : authConfigs) {
-            for (PluginRoleConfig role : pluginRoles) {
-                if (roleNames.contains(role.getName()) && authConfig.hasRole(role)) {
-                    result.add(role);
+            for (PluginRoleConfig pluginRole : pluginRoles) {
+                if (pluginRole.getAuthConfigId().equals(authConfig.getId())) {
+                    result.add(pluginRole);
                 }
             }
         }

--- a/config/config-api/test/com/thoughtworks/go/config/PluginRoleUsersStoreTest.java
+++ b/config/config-api/test/com/thoughtworks/go/config/PluginRoleUsersStoreTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2017 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.config;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+public class PluginRoleUsersStoreTest {
+
+    private PluginRoleUsersStore pluginRoleUsersStore;
+
+    @Before
+    public void setUp() throws Exception {
+        pluginRoleUsersStore = PluginRoleUsersStore.instance();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        pluginRoleUsersStore.clearAll();
+    }
+
+    @Test
+    public void assignRole_ShouldAssignPluginRoleToAnUser() throws Exception {
+        assertThat(pluginRoleUsersStore.pluginRoles(), hasSize(0));
+
+        PluginRoleConfig pluginRoleConfig = new PluginRoleConfig("spacetiger", "ldap");
+        pluginRoleUsersStore.assignRole("wing-commander", pluginRoleConfig);
+
+        assertThat(pluginRoleUsersStore.pluginRoles(), hasSize(1));
+        assertThat(pluginRoleUsersStore.usersInRole(pluginRoleConfig), hasItem(new RoleUser("wing-commander")));
+    }
+
+    @Test
+    public void removePluginRole_ShouldRemovePluginRoleFromStore() throws Exception {
+        PluginRoleConfig pluginRoleConfig = new PluginRoleConfig("spacetiger", "ldap");
+        pluginRoleUsersStore.assignRole("wing-commander", pluginRoleConfig);
+
+        assertThat(pluginRoleUsersStore.pluginRoles(), hasSize(1));
+        assertThat(pluginRoleUsersStore.usersInRole(pluginRoleConfig), hasItem(new RoleUser("wing-commander")));
+
+        pluginRoleUsersStore.remove(pluginRoleConfig);
+
+        assertThat(pluginRoleUsersStore.pluginRoles(), hasSize(0));
+    }
+
+    @Test
+    public void revokeAllRolesFor_ShouldRevokeAllRolesForAGivenUser() throws Exception {
+        PluginRoleConfig pluginRoleSpaceTiger = new PluginRoleConfig("spacetiger", "ldap");
+        PluginRoleConfig pluginRoleBlackBird = new PluginRoleConfig("blackbird", "ldap");
+        pluginRoleUsersStore.assignRole("wing-commander", pluginRoleSpaceTiger);
+        pluginRoleUsersStore.assignRole("wing-commander", pluginRoleBlackBird);
+        pluginRoleUsersStore.assignRole("bob", pluginRoleBlackBird);
+
+        assertThat(pluginRoleUsersStore.pluginRoles(), hasSize(2));
+        assertThat(pluginRoleUsersStore.usersInRole(pluginRoleSpaceTiger), hasSize(1));
+        assertThat(pluginRoleUsersStore.usersInRole(pluginRoleBlackBird), hasSize(2));
+        assertThat(pluginRoleUsersStore.usersInRole(pluginRoleSpaceTiger), hasItem(new RoleUser("wing-commander")));
+        assertThat(pluginRoleUsersStore.usersInRole(pluginRoleBlackBird), containsInAnyOrder(new RoleUser("wing-commander"), new RoleUser("bob")));
+
+        pluginRoleUsersStore.revokeAllRolesFor("wing-commander");
+
+        assertThat(pluginRoleUsersStore.pluginRoles(), hasSize(1));
+        assertThat(pluginRoleUsersStore.usersInRole(pluginRoleSpaceTiger), hasSize(0));
+        assertThat(pluginRoleUsersStore.usersInRole(pluginRoleBlackBird), hasSize(1));
+    }
+}

--- a/config/config-api/test/com/thoughtworks/go/config/SecurityConfigTest.java
+++ b/config/config-api/test/com/thoughtworks/go/config/SecurityConfigTest.java
@@ -223,7 +223,7 @@ public class SecurityConfigTest {
         securityConfig.securityAuthConfigs().add(new SecurityAuthConfig("github", "cd.go.github"));
 
 
-        List<PluginRoleConfig> pluginRolesConfig = securityConfig.getPluginRolesConfig("cd.go.ldap", CaseInsensitiveString.caseInsensitiveStrings("foo", "bar", "xyz", "none-existing-role"));
+        List<PluginRoleConfig> pluginRolesConfig = securityConfig.getPluginRoles("cd.go.ldap");
 
         assertThat(pluginRolesConfig, hasSize(1));
         assertThat(pluginRolesConfig, contains(new PluginRoleConfig("foo", "ldap")));
@@ -238,7 +238,7 @@ public class SecurityConfigTest {
         securityConfig.securityAuthConfigs().add(new SecurityAuthConfig("ldap", "cd.go.ldap"));
         securityConfig.securityAuthConfigs().add(new SecurityAuthConfig("github", "cd.go.github"));
 
-        List<PluginRoleConfig> pluginRolesConfig = securityConfig.getPluginRolesConfig("non-existant-plugin", CaseInsensitiveString.caseInsensitiveStrings("foo", "bar", "xyz", "none-existing-role"));
+        List<PluginRoleConfig> pluginRolesConfig = securityConfig.getPluginRoles("non-existant-plugin");
 
         assertThat(pluginRolesConfig, hasSize(0));
     }

--- a/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/authorization/AuthorizationExtension.java
+++ b/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/authorization/AuthorizationExtension.java
@@ -16,14 +16,15 @@
 
 package com.thoughtworks.go.plugin.access.authorization;
 
+import com.thoughtworks.go.config.SecurityAuthConfig;
 import com.thoughtworks.go.plugin.access.DefaultPluginInteractionCallback;
 import com.thoughtworks.go.plugin.access.PluginRequestHelper;
+import com.thoughtworks.go.plugin.access.authentication.models.User;
 import com.thoughtworks.go.plugin.access.authorization.models.AuthenticationResponse;
 import com.thoughtworks.go.plugin.access.authorization.models.Capabilities;
-import com.thoughtworks.go.plugin.access.authentication.models.User;
+import com.thoughtworks.go.plugin.access.common.AbstractExtension;
 import com.thoughtworks.go.plugin.access.common.models.Image;
 import com.thoughtworks.go.plugin.access.common.models.PluginProfileMetadataKeys;
-import com.thoughtworks.go.plugin.access.common.AbstractExtension;
 import com.thoughtworks.go.plugin.access.common.settings.PluginSettingsJsonMessageHandler;
 import com.thoughtworks.go.plugin.access.common.settings.PluginSettingsJsonMessageHandler1_0;
 import com.thoughtworks.go.plugin.api.response.validation.ValidationResult;
@@ -113,11 +114,11 @@ public class AuthorizationExtension extends AbstractExtension {
         });
     }
 
-    public AuthenticationResponse authenticateUser(String pluginId, final String username, final String password) {
+    public AuthenticationResponse authenticateUser(String pluginId, final String username, final String password, List<SecurityAuthConfig> authConfigs) {
         return pluginRequestHelper.submitRequest(pluginId, REQUEST_AUTHENTICATE_USER, new DefaultPluginInteractionCallback<AuthenticationResponse>() {
             @Override
             public String requestBody(String resolvedExtensionVersion) {
-                return getMessageConverter(resolvedExtensionVersion).authenticateUserRequestBody(username, password);
+                return getMessageConverter(resolvedExtensionVersion).authenticateUserRequestBody(username, password, authConfigs);
             }
 
             @Override
@@ -159,11 +160,11 @@ public class AuthorizationExtension extends AbstractExtension {
         });
     }
 
-    public List<User> searchUsers(String pluginId, final String searchTerm) {
+    public List<User> searchUsers(String pluginId, final String searchTerm, List<SecurityAuthConfig> authConfigs) {
         return pluginRequestHelper.submitRequest(pluginId, REQUEST_SEARCH_USERS, new DefaultPluginInteractionCallback<List<User>>() {
             @Override
             public String requestBody(String resolvedExtensionVersion) {
-                return getMessageConverter(resolvedExtensionVersion).searchUsersRequestBody(searchTerm);
+                return getMessageConverter(resolvedExtensionVersion).searchUsersRequestBody(searchTerm, authConfigs);
             }
 
             @Override

--- a/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/authorization/AuthorizationExtension.java
+++ b/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/authorization/AuthorizationExtension.java
@@ -72,7 +72,7 @@ public class AuthorizationExtension extends AbstractExtension {
     }
 
     String getPluginConfigurationView(String pluginId) {
-        return pluginRequestHelper.submitRequest(pluginId, REQUEST_PLUGIN_CONFIG_VIEW, new DefaultPluginInteractionCallback<String>() {
+        return pluginRequestHelper.submitRequest(pluginId, REQUEST_GET_PLUGIN_CONFIG_VIEW, new DefaultPluginInteractionCallback<String>() {
             @Override
             public String onSuccess(String responseBody, String resolvedExtensionVersion) {
                 return getMessageConverter(resolvedExtensionVersion).getPluginConfigurationViewFromResponseBody(responseBody);
@@ -137,7 +137,7 @@ public class AuthorizationExtension extends AbstractExtension {
     }
 
     public String getRoleConfigurationView(String pluginId) {
-        return pluginRequestHelper.submitRequest(pluginId, REQUEST_ROLE_CONFIG_VIEW, new DefaultPluginInteractionCallback<String>() {
+        return pluginRequestHelper.submitRequest(pluginId, REQUEST_GET_ROLE_CONFIG_VIEW, new DefaultPluginInteractionCallback<String>() {
             @Override
             public String onSuccess(String responseBody, String resolvedExtensionVersion) {
                 return getMessageConverter(resolvedExtensionVersion).getRoleConfigurationViewFromResponseBody(responseBody);

--- a/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/authorization/AuthorizationMessageConverter.java
+++ b/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/authorization/AuthorizationMessageConverter.java
@@ -59,4 +59,8 @@ public interface AuthorizationMessageConverter {
     String processGetRoleConfigsRequest(String requestBody);
 
     String getProcessRoleConfigsResponseBody(List<PluginRoleConfig> roles);
+
+    String getInvalidateCacheResponseBody();
+
+    String getProcessPluginConfigResponseBody(Map<String, Map<String,String>> authConfigProfiles);
 }

--- a/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/authorization/AuthorizationMessageConverter.java
+++ b/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/authorization/AuthorizationMessageConverter.java
@@ -17,6 +17,7 @@
 package com.thoughtworks.go.plugin.access.authorization;
 
 import com.thoughtworks.go.config.PluginRoleConfig;
+import com.thoughtworks.go.config.SecurityAuthConfig;
 import com.thoughtworks.go.plugin.access.authentication.models.User;
 import com.thoughtworks.go.plugin.access.authorization.models.AuthenticationResponse;
 import com.thoughtworks.go.plugin.access.authorization.models.Capabilities;
@@ -48,19 +49,15 @@ public interface AuthorizationMessageConverter {
 
     String verifyConnectionRequestBody(Map<String, String> configuration);
 
-    String authenticateUserRequestBody(String username, String password);
+    String authenticateUserRequestBody(String username, String password, List<SecurityAuthConfig> authConfigs);
 
     AuthenticationResponse getAuthenticatedUserFromResponseBody(String responseBody);
 
     List<User> getSearchUsersFromResponseBody(String responseBody);
 
-    String searchUsersRequestBody(String searchTerm);
+    String searchUsersRequestBody(String searchTerm, List<SecurityAuthConfig> authConfigs);
 
     String processGetRoleConfigsRequest(String requestBody);
 
     String getProcessRoleConfigsResponseBody(List<PluginRoleConfig> roles);
-
-    String getInvalidateCacheResponseBody();
-
-    String getProcessPluginConfigResponseBody(Map<String, Map<String,String>> authConfigProfiles);
 }

--- a/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/authorization/AuthorizationMessageConverterV1.java
+++ b/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/authorization/AuthorizationMessageConverterV1.java
@@ -18,6 +18,7 @@ package com.thoughtworks.go.plugin.access.authorization;
 
 import com.google.gson.Gson;
 import com.thoughtworks.go.config.PluginRoleConfig;
+import com.thoughtworks.go.config.SecurityAuthConfig;
 import com.thoughtworks.go.plugin.access.authentication.models.User;
 import com.thoughtworks.go.plugin.access.authorization.models.AuthenticationResponse;
 import com.thoughtworks.go.plugin.access.authorization.models.Capabilities;
@@ -84,11 +85,25 @@ public class AuthorizationMessageConverterV1 implements AuthorizationMessageConv
     }
 
     @Override
-    public String authenticateUserRequestBody(String username, String password) {
+    public String authenticateUserRequestBody(String username, String password, List<SecurityAuthConfig> authConfigs) {
         Map<String, Object> requestMap = new HashMap<>();
         requestMap.put("username", username);
         requestMap.put("password", password);
+        requestMap.put("profiles", getAuthConfigProfiles(authConfigs));
         return GSON.toJson(requestMap);
+    }
+
+    private Map<String, Map<String, String>> getAuthConfigProfiles(List<SecurityAuthConfig> authConfigs) {
+        Map<String, Map<String, String>> authConfigsMap = new HashMap<>();
+
+        if (authConfigs == null) {
+            return authConfigsMap;
+        }
+
+        for (SecurityAuthConfig securityAuthConfig : authConfigs) {
+            authConfigsMap.put(securityAuthConfig.getId(), securityAuthConfig.getConfigurationAsMap(true));
+        }
+        return authConfigsMap;
     }
 
     @Override
@@ -102,9 +117,10 @@ public class AuthorizationMessageConverterV1 implements AuthorizationMessageConv
     }
 
     @Override
-    public String searchUsersRequestBody(String searchTerm) {
+    public String searchUsersRequestBody(String searchTerm, List<SecurityAuthConfig> authConfigs) {
         Map<String, Object> requestMap = new HashMap<>();
         requestMap.put("search_term", searchTerm);
+        requestMap.put("profiles", getAuthConfigProfiles(authConfigs));
         return GSON.toJson(requestMap);
     }
 
@@ -123,16 +139,6 @@ public class AuthorizationMessageConverterV1 implements AuthorizationMessageConv
             list.add(e);
         }
         return GSON.toJson(list);
-    }
-
-    @Override
-    public String getInvalidateCacheResponseBody() {
-        return StringUtils.EMPTY;
-    }
-
-    @Override
-    public String getProcessPluginConfigResponseBody(Map<String, Map<String, String>> authConfigProfiles) {
-        return GSON.toJson(authConfigProfiles);
     }
 
     private String getTemplateFromResponse(String responseBody, String message) {

--- a/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/authorization/AuthorizationMessageConverterV1.java
+++ b/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/authorization/AuthorizationMessageConverterV1.java
@@ -125,6 +125,16 @@ public class AuthorizationMessageConverterV1 implements AuthorizationMessageConv
         return GSON.toJson(list);
     }
 
+    @Override
+    public String getInvalidateCacheResponseBody() {
+        return StringUtils.EMPTY;
+    }
+
+    @Override
+    public String getProcessPluginConfigResponseBody(Map<String, Map<String, String>> authConfigProfiles) {
+        return GSON.toJson(authConfigProfiles);
+    }
+
     private String getTemplateFromResponse(String responseBody, String message) {
         String template = (String) new Gson().fromJson(responseBody, Map.class).get("template");
         if (StringUtils.isBlank(template)) {

--- a/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/authorization/AuthorizationPluginConstants.java
+++ b/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/authorization/AuthorizationPluginConstants.java
@@ -16,13 +16,11 @@
 
 package com.thoughtworks.go.plugin.access.authorization;
 
-import com.thoughtworks.go.plugin.access.elastic.ElasticAgentExtensionConverterV1;
-
 import java.util.Arrays;
 import java.util.List;
 
 public interface AuthorizationPluginConstants {
-    List<String> SUPPORTED_VERSIONS = Arrays.asList(ElasticAgentExtensionConverterV1.VERSION);
+    List<String> SUPPORTED_VERSIONS = Arrays.asList(AuthorizationMessageConverterV1.VERSION);
 
     String EXTENSION_NAME = "authorization";
 
@@ -34,12 +32,12 @@ public interface AuthorizationPluginConstants {
     String _ROLE_CONFIG_METADATA = "role-config";
 
     String REQUEST_GET_PLUGIN_CONFIG_METADATA = String.join(".", REQUEST_PREFIX, _PLUGIN_CONFIG_METADATA, "get-metadata");
-    String REQUEST_PLUGIN_CONFIG_VIEW = String.join(".", REQUEST_PREFIX, _PLUGIN_CONFIG_METADATA, "get-view");
+    String REQUEST_GET_PLUGIN_CONFIG_VIEW = String.join(".", REQUEST_PREFIX, _PLUGIN_CONFIG_METADATA, "get-view");
     String REQUEST_VALIDATE_PLUGIN_CONFIG = String.join(".", REQUEST_PREFIX, _PLUGIN_CONFIG_METADATA, "validate");
     String REQUEST_VERIFY_CONNECTION = String.join(".", REQUEST_PREFIX, _PLUGIN_CONFIG_METADATA, "verify-connection");
 
     String REQUEST_GET_ROLE_CONFIG_METADATA = String.join(".", REQUEST_PREFIX, _ROLE_CONFIG_METADATA, "get-metadata");
-    String REQUEST_ROLE_CONFIG_VIEW = String.join(".", REQUEST_PREFIX, _ROLE_CONFIG_METADATA, "get-view");
+    String REQUEST_GET_ROLE_CONFIG_VIEW = String.join(".", REQUEST_PREFIX, _ROLE_CONFIG_METADATA, "get-view");
     String REQUEST_VALIDATE_ROLE_CONFIG = String.join(".", REQUEST_PREFIX, _ROLE_CONFIG_METADATA, "validate");
 
     String REQUEST_AUTHENTICATE_USER = REQUEST_PREFIX + ".authenticate-user";

--- a/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/common/AbstractPluginRegistry.java
+++ b/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/common/AbstractPluginRegistry.java
@@ -54,10 +54,8 @@ public abstract class AbstractPluginRegistry<Extension extends AbstractExtension
 
     @Override
     public void pluginUnLoaded(GoPluginDescriptor pluginDescriptor) {
-        if (extension.canHandlePlugin(pluginDescriptor.id())) {
-            plugins.remove(pluginDescriptor);
-            store.remove(pluginDescriptor);
-        }
+        plugins.remove(pluginDescriptor);
+        store.remove(pluginDescriptor);
     }
 
     public List<PluginDescriptor> getPlugins() {

--- a/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/common/models/PluginProfileMetadata.java
+++ b/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/common/models/PluginProfileMetadata.java
@@ -41,4 +41,22 @@ public class PluginProfileMetadata {
     public boolean isSecure() {
         return secure;
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof PluginProfileMetadata)) return false;
+
+        PluginProfileMetadata that = (PluginProfileMetadata) o;
+
+        if (required != that.required) return false;
+        return secure == that.secure;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = (required ? 1 : 0);
+        result = 31 * result + (secure ? 1 : 0);
+        return result;
+    }
 }

--- a/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/common/models/PluginProfileMetadataKey.java
+++ b/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/common/models/PluginProfileMetadataKey.java
@@ -42,4 +42,22 @@ public class PluginProfileMetadataKey {
         }
         return metadata;
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof PluginProfileMetadataKey)) return false;
+
+        PluginProfileMetadataKey that = (PluginProfileMetadataKey) o;
+
+        if (key != null ? !key.equals(that.key) : that.key != null) return false;
+        return metadata != null ? metadata.equals(that.metadata) : that.metadata == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = key != null ? key.hashCode() : 0;
+        result = 31 * result + (metadata != null ? metadata.hashCode() : 0);
+        return result;
+    }
 }

--- a/plugin-infra/go-plugin-access/test/com/thoughtworks/go/plugin/access/authorization/AuthorizationExtensionTest.java
+++ b/plugin-infra/go-plugin-access/test/com/thoughtworks/go/plugin/access/authorization/AuthorizationExtensionTest.java
@@ -16,6 +16,8 @@
 
 package com.thoughtworks.go.plugin.access.authorization;
 
+import com.thoughtworks.go.config.SecurityAuthConfig;
+import com.thoughtworks.go.domain.packagerepository.ConfigurationPropertyMother;
 import com.thoughtworks.go.plugin.access.authentication.models.User;
 import com.thoughtworks.go.plugin.access.authorization.models.AuthenticationResponse;
 import com.thoughtworks.go.plugin.access.authorization.models.Capabilities;
@@ -179,11 +181,11 @@ public class AuthorizationExtensionTest {
 
     @Test
     public void shouldTalkToPlugin_To_AuthenticateUser() throws Exception {
-        String requestBody = "{\"password\":\"secret\",\"username\":\"bob\"}";
+        String requestBody = "{\"password\":\"secret\",\"profiles\":{},\"username\":\"bob\"}";
         String responseBody = "{\"user\":{\"username\":\"bob\",\"display_name\":\"Bob\",\"email\":\"bob@example.com\"},\"roles\":[\"blackbird\"]}";
         when(pluginManager.submitTo(eq(PLUGIN_ID), requestArgumentCaptor.capture())).thenReturn(new DefaultGoPluginApiResponse(SUCCESS_RESPONSE_CODE, responseBody));
 
-        AuthenticationResponse authenticationResponse = authorizationExtension.authenticateUser(PLUGIN_ID, "bob", "secret");
+        AuthenticationResponse authenticationResponse = authorizationExtension.authenticateUser(PLUGIN_ID, "bob", "secret", null);
 
         assertRequest(requestArgumentCaptor.getValue(), AuthorizationPluginConstants.EXTENSION_NAME, "1.0", REQUEST_AUTHENTICATE_USER, requestBody);
         assertThat(authenticationResponse.getUser(), is(new User("bob", "Bob", "bob@example.com")));
@@ -192,11 +194,11 @@ public class AuthorizationExtensionTest {
 
     @Test
     public void shouldTalkToPlugin_To_SearchUsers() throws Exception {
-        String requestBody = "{\"search_term\":\"bob\"}";
+        String requestBody = "{\"search_term\":\"bob\",\"profiles\":{\"ldap\":{\"foo\":\"bar\"}}}";
         String responseBody = "[{\"username\":\"bob\",\"display_name\":\"Bob\",\"email\":\"bob@example.com\"}]";
         when(pluginManager.submitTo(eq(PLUGIN_ID), requestArgumentCaptor.capture())).thenReturn(new DefaultGoPluginApiResponse(SUCCESS_RESPONSE_CODE, responseBody));
 
-        List<User> users = authorizationExtension.searchUsers(PLUGIN_ID, "bob");
+        List<User> users = authorizationExtension.searchUsers(PLUGIN_ID, "bob", Collections.singletonList(new SecurityAuthConfig("ldap", "cd.go.ldap", ConfigurationPropertyMother.create("foo", false, "bar"))));
 
         assertRequest(requestArgumentCaptor.getValue(), AuthorizationPluginConstants.EXTENSION_NAME, "1.0", REQUEST_SEARCH_USERS, requestBody);
         assertThat(users, hasSize(1));

--- a/server/src/com/thoughtworks/go/server/initializers/ApplicationInitializer.java
+++ b/server/src/com/thoughtworks/go/server/initializers/ApplicationInitializer.java
@@ -16,10 +16,7 @@
 
 package com.thoughtworks.go.server.initializers;
 
-import com.thoughtworks.go.config.CachedGoConfig;
-import com.thoughtworks.go.config.ConfigCipherUpdater;
-import com.thoughtworks.go.config.GoFileConfigDataSource;
-import com.thoughtworks.go.config.InvalidConfigMessageRemover;
+import com.thoughtworks.go.config.*;
 import com.thoughtworks.go.config.registry.ConfigElementImplementationRegistrar;
 import com.thoughtworks.go.domain.cctray.CcTrayActivityListener;
 import com.thoughtworks.go.plugin.infra.commons.PluginsZip;

--- a/server/src/com/thoughtworks/go/server/security/RemoveAdminPermissionFilter.java
+++ b/server/src/com/thoughtworks/go/server/security/RemoveAdminPermissionFilter.java
@@ -19,7 +19,7 @@ package com.thoughtworks.go.server.security;
 import com.thoughtworks.go.config.CruiseConfig;
 import com.thoughtworks.go.config.SecurityConfig;
 import com.thoughtworks.go.listener.ConfigChangedListener;
-import com.thoughtworks.go.listener.AuthorizationPluginUnloadListener;
+import com.thoughtworks.go.listener.PluginRoleChangeListener;
 import com.thoughtworks.go.server.service.GoConfigService;
 import com.thoughtworks.go.server.service.PluginRoleService;
 import com.thoughtworks.go.util.TimeProvider;
@@ -38,7 +38,7 @@ import java.io.IOException;
 /**
  * @understands when a logged in user's authorization needs to be redone to get the new roles.
  */
-public class RemoveAdminPermissionFilter extends SpringSecurityFilter implements ConfigChangedListener, AuthorizationPluginUnloadListener {
+public class RemoveAdminPermissionFilter extends SpringSecurityFilter implements ConfigChangedListener, PluginRoleChangeListener {
     private static final Logger LOGGER = Logger.getLogger(RemoveAdminPermissionFilter.class);
 
     protected static final String SECURITY_CONFIG_LAST_CHANGE = "security_config_last_changed_time";
@@ -96,7 +96,7 @@ public class RemoveAdminPermissionFilter extends SpringSecurityFilter implements
     }
 
     @Override
-    public void onUnload() {
+    public void onPluginRoleChange() {
         this.lastChangedTime = timeProvider.currentTimeMillis();
     }
 }

--- a/server/src/com/thoughtworks/go/server/security/RemoveAdminPermissionFilter.java
+++ b/server/src/com/thoughtworks/go/server/security/RemoveAdminPermissionFilter.java
@@ -16,42 +16,47 @@
 
 package com.thoughtworks.go.server.security;
 
-import java.io.IOException;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import javax.servlet.FilterChain;
-import javax.servlet.ServletException;
-
 import com.thoughtworks.go.config.CruiseConfig;
 import com.thoughtworks.go.config.SecurityConfig;
-import com.thoughtworks.go.server.service.GoConfigService;
 import com.thoughtworks.go.listener.ConfigChangedListener;
+import com.thoughtworks.go.listener.AuthorizationPluginUnloadListener;
+import com.thoughtworks.go.server.service.GoConfigService;
+import com.thoughtworks.go.server.service.PluginRoleService;
 import com.thoughtworks.go.util.TimeProvider;
 import org.apache.log4j.Logger;
-import org.springframework.security.ui.SpringSecurityFilter;
-import org.springframework.security.ui.FilterChainOrder;
-import org.springframework.security.context.SecurityContextHolder;
 import org.springframework.security.Authentication;
+import org.springframework.security.context.SecurityContextHolder;
+import org.springframework.security.ui.FilterChainOrder;
+import org.springframework.security.ui.SpringSecurityFilter;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
 
 /**
  * @understands when a logged in user's authorization needs to be redone to get the new roles.
  */
-public class RemoveAdminPermissionFilter extends SpringSecurityFilter implements ConfigChangedListener {
+public class RemoveAdminPermissionFilter extends SpringSecurityFilter implements ConfigChangedListener, AuthorizationPluginUnloadListener {
     private static final Logger LOGGER = Logger.getLogger(RemoveAdminPermissionFilter.class);
 
     protected static final String SECURITY_CONFIG_LAST_CHANGE = "security_config_last_changed_time";
     private SecurityConfig securityConfig;
     private GoConfigService goConfigService;
     private TimeProvider timeProvider;
+    private PluginRoleService pluginRoleService;
     private volatile long lastChangedTime;
 
-    public RemoveAdminPermissionFilter(GoConfigService goConfigService, TimeProvider timeProvider) {
+    public RemoveAdminPermissionFilter(GoConfigService goConfigService, TimeProvider timeProvider, PluginRoleService pluginRoleService) {
         this.goConfigService = goConfigService;
         this.timeProvider = timeProvider;
+        this.pluginRoleService = pluginRoleService;
     }
 
     public void initialize() {
         goConfigService.register(this);
+        pluginRoleService.register(this);
     }
 
     public void doFilterHttp(HttpServletRequest request, HttpServletResponse response, FilterChain chain) throws IOException, ServletException {
@@ -88,5 +93,10 @@ public class RemoveAdminPermissionFilter extends SpringSecurityFilter implements
 
     private SecurityConfig securityConfig(CruiseConfig newCruiseConfig) {
         return newCruiseConfig.server().security();
+    }
+
+    @Override
+    public void onUnload() {
+        this.lastChangedTime = timeProvider.currentTimeMillis();
     }
 }

--- a/server/src/com/thoughtworks/go/server/security/UserSearchService.java
+++ b/server/src/com/thoughtworks/go/server/security/UserSearchService.java
@@ -16,6 +16,7 @@
 
 package com.thoughtworks.go.server.security;
 
+import com.thoughtworks.go.config.SecurityAuthConfig;
 import com.thoughtworks.go.domain.User;
 import com.thoughtworks.go.i18n.LocalizedMessage;
 import com.thoughtworks.go.plugin.access.authentication.AuthenticationExtension;
@@ -138,7 +139,8 @@ public class UserSearchService {
     private List<com.thoughtworks.go.plugin.access.authentication.models.User> getUsersConfiguredViaPlugin(String pluginId, String searchTerm) {
         List<com.thoughtworks.go.plugin.access.authentication.models.User> users = new ArrayList<>();
         if (authorizationExtension.canHandlePlugin(pluginId)) {
-            users.addAll(authorizationExtension.searchUsers(pluginId, searchTerm));
+            List<SecurityAuthConfig> authConfigs = goConfigService.security().securityAuthConfigs().findByPluginId(pluginId);
+            users.addAll(authorizationExtension.searchUsers(pluginId, searchTerm, authConfigs));
         }
         if (authenticationExtension.canHandlePlugin(pluginId)) {
             users.addAll(authenticationExtension.searchUser(pluginId, searchTerm));

--- a/server/src/com/thoughtworks/go/server/service/PluginRoleService.java
+++ b/server/src/com/thoughtworks/go/server/service/PluginRoleService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 ThoughtWorks, Inc.
+ * Copyright 2017 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,81 +16,100 @@
 
 package com.thoughtworks.go.server.service;
 
-import com.thoughtworks.go.config.CaseInsensitiveString;
-import com.thoughtworks.go.config.ConfigTag;
-import com.thoughtworks.go.config.Role;
-import com.thoughtworks.go.config.RolesConfig;
-import com.thoughtworks.go.config.commands.EntityConfigUpdateCommand;
-import com.thoughtworks.go.config.exceptions.GoConfigInvalidException;
-import com.thoughtworks.go.config.update.RoleConfigCreateCommand;
-import com.thoughtworks.go.config.update.RoleConfigDeleteCommand;
-import com.thoughtworks.go.config.update.RoleConfigUpdateCommand;
-import com.thoughtworks.go.i18n.LocalizedMessage;
-import com.thoughtworks.go.plugin.access.authorization.AuthorizationExtension;
-import com.thoughtworks.go.server.domain.Username;
-import com.thoughtworks.go.server.service.result.LocalizedOperationResult;
-import org.slf4j.LoggerFactory;
+import com.thoughtworks.go.config.*;
+import com.thoughtworks.go.listener.AuthorizationPluginUnloadListener;
+import com.thoughtworks.go.listener.ConfigChangedListener;
+import com.thoughtworks.go.plugin.api.GoPlugin;
+import com.thoughtworks.go.plugin.infra.PluginChangeListener;
+import com.thoughtworks.go.plugin.infra.PluginManager;
+import com.thoughtworks.go.plugin.infra.plugininfo.GoPluginDescriptor;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
 
-@Component
-public class PluginRoleService {
-    private static final org.slf4j.Logger LOGGER = LoggerFactory.getLogger(PluginRoleService.class);
-    private final AuthorizationExtension authorizationExtension;
+import java.util.*;
+
+@Service
+public class PluginRoleService implements ConfigChangedListener, PluginChangeListener {
     private final GoConfigService goConfigService;
-    private final EntityHashingService hashingService;
+    private final PluginRoleUsersStore pluginRoleUsersStore = PluginRoleUsersStore.instance();
+    private final Set<AuthorizationPluginUnloadListener> listeners = new HashSet<>();
 
     @Autowired
-    public PluginRoleService(GoConfigService goConfigService, EntityHashingService hashingService, AuthorizationExtension authorizationExtension) {
+    public PluginRoleService(GoConfigService goConfigService, PluginManager pluginManager) {
         this.goConfigService = goConfigService;
-        this.hashingService = hashingService;
-        this.authorizationExtension = authorizationExtension;
+        pluginManager.addPluginChangeListener(this, GoPlugin.class);
     }
 
-    public Role findRole(String name) {
-        return getRoles().findByName(new CaseInsensitiveString(name));
+    public void updatePluginRoles(String pluginId, String username, List<CaseInsensitiveString> pluginRolesName) {
+        pluginRoleUsersStore.revokeAllRolesFor(username);
+
+        Map<CaseInsensitiveString, PluginRoleConfig> pluginRoles = getPluginRoles(pluginId);
+        for (CaseInsensitiveString pluginRoleName : pluginRolesName) {
+            PluginRoleConfig pluginRoleConfig = pluginRoles.get(pluginRoleName);
+            if (pluginRoleConfig == null) {
+                continue;
+            }
+
+            pluginRoleUsersStore.assignRole(username, pluginRoleConfig);
+        }
     }
 
-    public RolesConfig listAll() {
-        return getRoles();
+    public void register(AuthorizationPluginUnloadListener listener) {
+        listeners.add(listener);
     }
 
-    protected void update(Username currentUser, Role role, LocalizedOperationResult result, EntityConfigUpdateCommand<Role> command) {
-        try {
-            goConfigService.updateConfig(command, currentUser);
-        } catch (Exception e) {
-            if (e instanceof GoConfigInvalidException) {
-                result.unprocessableEntity(LocalizedMessage.string("ENTITY_CONFIG_VALIDATION_FAILED", getTagName(role), role.getName(), e.getMessage()));
-            } else {
-                if (!result.hasMessage()) {
-                    LOGGER.error(e.getMessage(), e);
-                    result.internalServerError(LocalizedMessage.string("SAVE_FAILED_WITH_REASON", "An error occurred while saving the role config. Please check the logs for more information."));
-                }
+    private void notifyListeners() {
+        for (AuthorizationPluginUnloadListener listener : listeners) {
+            listener.onUnload();
+        }
+    }
+
+    public void invalidateRolesFor(String pluginId) {
+        List<PluginRoleConfig> pluginRoles = goConfigService.security().getPluginRoles(pluginId);
+
+        if (!pluginRoles.isEmpty()) {
+            pluginRoleUsersStore.remove(pluginRoles);
+            notifyListeners();
+        }
+    }
+
+    public List<RoleUser> usersForPluginRole(String roleName) {
+        return pluginRoleUsersStore.usersInRole(pluginRole(roleName));
+    }
+
+    @Override
+    public void onConfigChange(CruiseConfig newCruiseConfig) {
+        List<PluginRoleConfig> pluginRoles = newCruiseConfig.server().security().getRoles().getPluginRolesConfig();
+
+        for (PluginRoleConfig pluginRole : pluginRoleUsersStore.pluginRoles()) {
+            if (!pluginRoles.contains(pluginRole)) {
+                pluginRoleUsersStore.remove(pluginRole);
             }
         }
     }
 
-    private String getTagName(Role role) {
-        return role.getClass().getAnnotation(ConfigTag.class).value();
+    private PluginRoleConfig pluginRole(String roleName) {
+        return goConfigService.security().getRoles().findPluginRoleByName(new CaseInsensitiveString(roleName));
     }
 
-    private RolesConfig getRoles() {
-        return goConfigService.serverConfig().security().getRoles();
-    }
+    private Map<CaseInsensitiveString, PluginRoleConfig> getPluginRoles(String pluginId) {
+        Map<CaseInsensitiveString, PluginRoleConfig> result = new HashMap<>();
 
-    public void update(Username currentUser, String md5, Role newRole, LocalizedOperationResult result) {
-        update(currentUser, newRole, result, new RoleConfigUpdateCommand(goConfigService, newRole, authorizationExtension, currentUser, result, hashingService, md5));
-    }
+        List<PluginRoleConfig> pluginRoles = goConfigService.security().getPluginRoles(pluginId);
 
-    public void delete(Username currentUser, Role role, LocalizedOperationResult result) {
-        update(currentUser, role, result, new RoleConfigDeleteCommand(goConfigService, role, authorizationExtension, currentUser, result));
-        if (result.isSuccessful()) {
-            result.setMessage(LocalizedMessage.string("RESOURCE_DELETE_SUCCESSFUL", "plugin role config", role.getName()));
+        for (PluginRoleConfig pluginRole : pluginRoles) {
+            result.put(pluginRole.getName(), pluginRole);
         }
+        return result;
     }
 
-    public void create(Username currentUser, Role newRole, LocalizedOperationResult result) {
-        update(currentUser, newRole, result, new RoleConfigCreateCommand(goConfigService, newRole, authorizationExtension, currentUser, result));
+    @Override
+    public void pluginLoaded(GoPluginDescriptor pluginDescriptor) {
+//        do nothing
     }
 
+    @Override
+    public void pluginUnLoaded(GoPluginDescriptor pluginDescriptor) {
+        invalidateRolesFor(pluginDescriptor.id());
+    }
 }

--- a/server/src/com/thoughtworks/go/server/service/RoleConfigService.java
+++ b/server/src/com/thoughtworks/go/server/service/RoleConfigService.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2016 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.server.service;
+
+import com.thoughtworks.go.config.CaseInsensitiveString;
+import com.thoughtworks.go.config.ConfigTag;
+import com.thoughtworks.go.config.Role;
+import com.thoughtworks.go.config.RolesConfig;
+import com.thoughtworks.go.config.commands.EntityConfigUpdateCommand;
+import com.thoughtworks.go.config.exceptions.GoConfigInvalidException;
+import com.thoughtworks.go.config.update.RoleConfigCreateCommand;
+import com.thoughtworks.go.config.update.RoleConfigDeleteCommand;
+import com.thoughtworks.go.config.update.RoleConfigUpdateCommand;
+import com.thoughtworks.go.i18n.LocalizedMessage;
+import com.thoughtworks.go.plugin.access.authorization.AuthorizationExtension;
+import com.thoughtworks.go.server.domain.Username;
+import com.thoughtworks.go.server.service.result.LocalizedOperationResult;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class RoleConfigService {
+    private static final org.slf4j.Logger LOGGER = LoggerFactory.getLogger(RoleConfigService.class);
+    private final AuthorizationExtension authorizationExtension;
+    private final GoConfigService goConfigService;
+    private final EntityHashingService hashingService;
+
+    @Autowired
+    public RoleConfigService(GoConfigService goConfigService, EntityHashingService hashingService, AuthorizationExtension authorizationExtension) {
+        this.goConfigService = goConfigService;
+        this.hashingService = hashingService;
+        this.authorizationExtension = authorizationExtension;
+    }
+
+    public Role findRole(String name) {
+        return getRoles().findByName(new CaseInsensitiveString(name));
+    }
+
+    public RolesConfig listAll() {
+        return getRoles();
+    }
+
+    protected void update(Username currentUser, Role role, LocalizedOperationResult result, EntityConfigUpdateCommand<Role> command) {
+        try {
+            goConfigService.updateConfig(command, currentUser);
+        } catch (Exception e) {
+            if (e instanceof GoConfigInvalidException) {
+                result.unprocessableEntity(LocalizedMessage.string("ENTITY_CONFIG_VALIDATION_FAILED", getTagName(role), role.getName(), e.getMessage()));
+            } else {
+                if (!result.hasMessage()) {
+                    LOGGER.error(e.getMessage(), e);
+                    result.internalServerError(LocalizedMessage.string("SAVE_FAILED_WITH_REASON", "An error occurred while saving the role config. Please check the logs for more information."));
+                }
+            }
+        }
+    }
+
+    private String getTagName(Role role) {
+        return role.getClass().getAnnotation(ConfigTag.class).value();
+    }
+
+    private RolesConfig getRoles() {
+        return goConfigService.serverConfig().security().getRoles();
+    }
+
+    public void update(Username currentUser, String md5, Role newRole, LocalizedOperationResult result) {
+        update(currentUser, newRole, result, new RoleConfigUpdateCommand(goConfigService, newRole, authorizationExtension, currentUser, result, hashingService, md5));
+    }
+
+    public void delete(Username currentUser, Role role, LocalizedOperationResult result) {
+        update(currentUser, role, result, new RoleConfigDeleteCommand(goConfigService, role, authorizationExtension, currentUser, result));
+        if (result.isSuccessful()) {
+            result.setMessage(LocalizedMessage.string("RESOURCE_DELETE_SUCCESSFUL", "plugin role config", role.getName()));
+        }
+    }
+
+    public void create(Username currentUser, Role newRole, LocalizedOperationResult result) {
+        update(currentUser, newRole, result, new RoleConfigCreateCommand(goConfigService, newRole, authorizationExtension, currentUser, result));
+    }
+
+}

--- a/server/test/unit/com/thoughtworks/go/server/security/UserSearchServiceTest.java
+++ b/server/test/unit/com/thoughtworks/go/server/security/UserSearchServiceTest.java
@@ -16,6 +16,7 @@
 
 package com.thoughtworks.go.server.security;
 
+import com.thoughtworks.go.config.SecurityConfig;
 import com.thoughtworks.go.domain.User;
 import com.thoughtworks.go.i18n.LocalizedMessage;
 import com.thoughtworks.go.plugin.access.authentication.AuthenticationExtension;
@@ -31,10 +32,7 @@ import org.junit.Test;
 import org.mockito.Mock;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.List;
+import java.util.*;
 
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
@@ -87,10 +85,11 @@ public class UserSearchServiceTest {
         List<String> pluginIds = Arrays.asList("plugin-id-1", "plugin-id-2", "plugin-id-3", "plugin-id-4");
         when(metadataStore.getPluginsThatSupportsUserSearch()).thenReturn(new HashSet<>(pluginIds));
         when(authorizationExtension.canHandlePlugin(anyString())).thenReturn(true);
-        when(authorizationExtension.searchUsers("plugin-id-1", searchTerm)).thenReturn(Arrays.asList(getPluginUser(1)));
-        when(authorizationExtension.searchUsers("plugin-id-2", searchTerm)).thenReturn(Arrays.asList(getPluginUser(2), getPluginUser(3)));
-        when(authorizationExtension.searchUsers("plugin-id-3", searchTerm)).thenReturn(new ArrayList<>());
-        when(authorizationExtension.searchUsers("plugin-id-4", searchTerm)).thenReturn(Arrays.asList(new com.thoughtworks.go.plugin.access.authentication.models.User("username-" + 4, null, null)));
+        when(goConfigService.security()).thenReturn(new SecurityConfig());
+        when(authorizationExtension.searchUsers("plugin-id-1", searchTerm, Collections.emptyList())).thenReturn(Arrays.asList(getPluginUser(1)));
+        when(authorizationExtension.searchUsers("plugin-id-2", searchTerm, Collections.emptyList())).thenReturn(Arrays.asList(getPluginUser(2), getPluginUser(3)));
+        when(authorizationExtension.searchUsers("plugin-id-3", searchTerm, Collections.emptyList())).thenReturn(new ArrayList<>());
+        when(authorizationExtension.searchUsers("plugin-id-4", searchTerm, Collections.emptyList())).thenReturn(Arrays.asList(new com.thoughtworks.go.plugin.access.authentication.models.User("username-" + 4, null, null)));
 
         List<UserSearchModel> models = userSearchService.search(searchTerm, new HttpLocalizedOperationResult());
 

--- a/server/test/unit/com/thoughtworks/go/server/security/providers/PluginAuthenticationProviderTest.java
+++ b/server/test/unit/com/thoughtworks/go/server/security/providers/PluginAuthenticationProviderTest.java
@@ -25,11 +25,13 @@ import com.thoughtworks.go.plugin.access.authentication.models.User;
 import com.thoughtworks.go.plugin.access.authorization.AuthorizationExtension;
 import com.thoughtworks.go.plugin.access.authorization.AuthorizationPluginConfigMetadataStore;
 import com.thoughtworks.go.plugin.access.authorization.models.AuthenticationResponse;
+import com.thoughtworks.go.server.domain.Username;
 import com.thoughtworks.go.server.security.AuthorityGranter;
 import com.thoughtworks.go.server.security.GoAuthority;
 import com.thoughtworks.go.server.security.userdetail.GoUserPrinciple;
 import com.thoughtworks.go.server.service.GoConfigService;
 import com.thoughtworks.go.server.service.PluginRoleService;
+import com.thoughtworks.go.server.service.UserService;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -47,8 +49,7 @@ import java.util.HashSet;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.*;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 import static org.mockito.MockitoAnnotations.initMocks;
 
 public class PluginAuthenticationProviderTest {
@@ -70,6 +71,8 @@ public class PluginAuthenticationProviderTest {
     private GoConfigService goConfigService;
     @Mock
     private PluginRoleService pluginRoleService;
+    @Mock
+    private UserService userService;
 
     private GrantedAuthority userAuthority;
     private PluginAuthenticationProvider provider;
@@ -87,7 +90,7 @@ public class PluginAuthenticationProviderTest {
         when(authorityGranter.authorities("username")).thenReturn(new GrantedAuthority[]{userAuthority});
 
         provider = new PluginAuthenticationProvider(authenticationPluginRegistry, authenticationExtension, authorizationExtension, store, authorityGranter,
-                goConfigService, pluginRoleService);
+                goConfigService, pluginRoleService, userService);
 
         securityConfig = new SecurityConfig();
         when(goConfigService.security()).thenReturn(securityConfig);
@@ -101,7 +104,7 @@ public class PluginAuthenticationProviderTest {
         when(authenticationPluginRegistry.getPluginsThatSupportsPasswordBasedAuthentication()).thenReturn(new HashSet<>(Arrays.asList("password")));
         when(store.getPluginsThatSupportsPasswordBasedAuthentication()).thenReturn(new HashSet<>(Arrays.asList("ldap")));
 
-        when(authorizationExtension.authenticateUser("ldap", "bob", "password")).thenReturn(NULL_AUTH_RESPONSE);
+        when(authorizationExtension.authenticateUser("ldap", "bob", "password", securityConfig.securityAuthConfigs().findByPluginId(null))).thenReturn(NULL_AUTH_RESPONSE);
         when(authenticationExtension.authenticateUser("password", "bob", "password")).thenReturn(null);
 
         provider.retrieveUser("bob", authenticationToken);
@@ -112,7 +115,7 @@ public class PluginAuthenticationProviderTest {
         String pluginId = "plugin-id-1";
         when(authenticationPluginRegistry.getPluginsThatSupportsPasswordBasedAuthentication()).thenReturn(new HashSet<>(Arrays.asList(pluginId)));
         when(store.getPluginsThatSupportsPasswordBasedAuthentication()).thenReturn(new HashSet<>(Arrays.asList(pluginId)));
-        when(authorizationExtension.authenticateUser(pluginId, "username", "password")).thenReturn(NULL_AUTH_RESPONSE);
+        when(authorizationExtension.authenticateUser(pluginId, "username", "password", securityConfig.securityAuthConfigs().findByPluginId(pluginId))).thenReturn(NULL_AUTH_RESPONSE);
 
         try {
             provider.retrieveUser("username", authenticationToken);
@@ -124,14 +127,55 @@ public class PluginAuthenticationProviderTest {
     }
 
     @Test
+    public void shouldAddUserIfDoesNotExistOnSuccessfulAuthenticationUsingTheAuthorizationPlugin() {
+        String pluginId = "plugin-id-1";
+        securityConfig.securityAuthConfigs().add(new SecurityAuthConfig("github", pluginId));
+        when(authenticationPluginRegistry.getPluginsThatSupportsPasswordBasedAuthentication()).thenReturn(new HashSet<>(Arrays.asList()));
+        when(store.getPluginsThatSupportsPasswordBasedAuthentication()).thenReturn(new HashSet<>(Arrays.asList(pluginId)));
+
+        AuthenticationResponse response = new AuthenticationResponse(new User("username", "display-name", "test@test.com"), Collections.emptyList());
+        when(authorizationExtension.authenticateUser(pluginId, "username", "password", securityConfig.securityAuthConfigs().findByPluginId(pluginId))).thenReturn(response);
+
+        provider.retrieveUser("username", authenticationToken);
+
+        verify(userService).addUserIfDoesNotExist(new Username(new CaseInsensitiveString("username"), "display-name"));
+    }
+
+    @Test
+    public void shouldAddUserIfDoesNotExistOnSuccessfulAuthenticationUsingTheAuthenticationPlugin() {
+        String pluginId = "plugin-id-1";
+        securityConfig.securityAuthConfigs().add(new SecurityAuthConfig("github", pluginId));
+        when(authenticationPluginRegistry.getPluginsThatSupportsPasswordBasedAuthentication()).thenReturn(new HashSet<>(Arrays.asList(pluginId)));
+        when(authenticationExtension.authenticateUser(pluginId, "username", "password")).thenReturn(new User("username", "display-name", null));
+
+        provider.retrieveUser("username", authenticationToken);
+
+        verify(userService).addUserIfDoesNotExist(new Username(new CaseInsensitiveString("username"), "display-name"));
+    }
+
+    @Test(expected = UsernameNotFoundException.class)
+    public void shouldErrorOutIfUnableToAuthenticateUsingAnyOfThePlugins() {
+        when(authenticationPluginRegistry.getPluginsThatSupportsPasswordBasedAuthentication()).thenReturn(new HashSet<>(Arrays.asList()));
+        when(store.getPluginsThatSupportsPasswordBasedAuthentication()).thenReturn(new HashSet<>(Arrays.asList()));
+
+        try {
+            provider.retrieveUser("username", authenticationToken);
+            fail("should have thrown up");
+        } finally {
+            verify(userService, never()).addUserIfDoesNotExist(any(Username.class));
+        }
+    }
+
+    @Test
     public void shouldCreateGoUserPrincipalWhenAnAuthorizationPluginIsAbleToAuthenticateUser() {
         String pluginId1 = "plugin-id-1";
         String pluginId2 = "plugin-id-2";
+        securityConfig.securityAuthConfigs().add(new SecurityAuthConfig("github", pluginId2));
         when(store.getPluginsThatSupportsPasswordBasedAuthentication()).thenReturn(new HashSet<>(Arrays.asList(pluginId1, pluginId2)));
-        when(authorizationExtension.authenticateUser(pluginId1, "username", "password")).thenReturn(NULL_AUTH_RESPONSE);
+        when(authorizationExtension.authenticateUser(pluginId1, "username", "password", securityConfig.securityAuthConfigs().findByPluginId(pluginId1))).thenReturn(NULL_AUTH_RESPONSE);
 
         AuthenticationResponse response = new AuthenticationResponse(new User("username", "display-name", "test@test.com"), Collections.emptyList());
-        when(authorizationExtension.authenticateUser(pluginId2, "username", "password")).thenReturn(response);
+        when(authorizationExtension.authenticateUser(pluginId2, "username", "password", securityConfig.securityAuthConfigs().findByPluginId(pluginId2))).thenReturn(response);
 
         UserDetails userDetails = provider.retrieveUser("username", authenticationToken);
 
@@ -187,14 +231,14 @@ public class PluginAuthenticationProviderTest {
 
         when(store.getPluginsThatSupportsPasswordBasedAuthentication()).thenReturn(new HashSet<>(Arrays.asList(pluginId1, pluginId2)));
 
-        when(authorizationExtension.authenticateUser(pluginId1, "username", "password")).thenReturn(
+        when(authorizationExtension.authenticateUser(pluginId1, "username", "password", securityConfig.securityAuthConfigs().findByPluginId(pluginId1))).thenReturn(
                 new AuthenticationResponse(
                         new User("username", "bob", "bob@example.com"),
                         Arrays.asList("blackbird", "admins")
                 )
         );
 
-        when(authorizationExtension.authenticateUser(pluginId2, "username", "password")).thenReturn(NULL_AUTH_RESPONSE);
+        when(authorizationExtension.authenticateUser(pluginId2, "username", "password", securityConfig.securityAuthConfigs().findByPluginId(pluginId2))).thenReturn(NULL_AUTH_RESPONSE);
 
         UserDetails userDetails = provider.retrieveUser("username", new UsernamePasswordAuthenticationToken(null, "password"));
 

--- a/server/test/unit/com/thoughtworks/go/server/security/providers/PluginAuthenticationProviderTest.java
+++ b/server/test/unit/com/thoughtworks/go/server/security/providers/PluginAuthenticationProviderTest.java
@@ -17,7 +17,6 @@
 package com.thoughtworks.go.server.security.providers;
 
 import com.thoughtworks.go.config.CaseInsensitiveString;
-import com.thoughtworks.go.config.PluginRoleConfig;
 import com.thoughtworks.go.config.SecurityAuthConfig;
 import com.thoughtworks.go.config.SecurityConfig;
 import com.thoughtworks.go.plugin.access.authentication.AuthenticationExtension;
@@ -30,6 +29,7 @@ import com.thoughtworks.go.server.security.AuthorityGranter;
 import com.thoughtworks.go.server.security.GoAuthority;
 import com.thoughtworks.go.server.security.userdetail.GoUserPrinciple;
 import com.thoughtworks.go.server.service.GoConfigService;
+import com.thoughtworks.go.server.service.PluginRoleService;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -47,6 +47,7 @@ import java.util.HashSet;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.*;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 
@@ -67,6 +68,8 @@ public class PluginAuthenticationProviderTest {
     private UsernamePasswordAuthenticationToken authenticationToken;
     @Mock
     private GoConfigService goConfigService;
+    @Mock
+    private PluginRoleService pluginRoleService;
 
     private GrantedAuthority userAuthority;
     private PluginAuthenticationProvider provider;
@@ -83,7 +86,9 @@ public class PluginAuthenticationProviderTest {
         userAuthority = GoAuthority.ROLE_USER.asAuthority();
         when(authorityGranter.authorities("username")).thenReturn(new GrantedAuthority[]{userAuthority});
 
-        provider = new PluginAuthenticationProvider(authenticationPluginRegistry, authenticationExtension, authorizationExtension, store, authorityGranter, goConfigService);
+        provider = new PluginAuthenticationProvider(authenticationPluginRegistry, authenticationExtension, authorizationExtension, store, authorityGranter,
+                goConfigService, pluginRoleService);
+
         securityConfig = new SecurityConfig();
         when(goConfigService.security()).thenReturn(securityConfig);
     }
@@ -173,14 +178,9 @@ public class PluginAuthenticationProviderTest {
     }
 
     @Test
-    public void shouldAddUserToTheCorrectRole() throws Exception {
-        securityConfig.addRole(new PluginRoleConfig("blackbird", "ldap"));
-        securityConfig.addRole(new PluginRoleConfig("admins", "ldap"));
-        securityConfig.addRole(new PluginRoleConfig("view", "github"));
-
+    public void shouldUpdatePluginRolesForAUserPostAuthentication() throws Exception {
         securityConfig.securityAuthConfigs().add(new SecurityAuthConfig("ldap", "cd.go.ldap"));
         securityConfig.securityAuthConfigs().add(new SecurityAuthConfig("github", "cd.go.github"));
-
 
         String pluginId1 = "cd.go.ldap";
         String pluginId2 = "cd.go.github";
@@ -193,45 +193,14 @@ public class PluginAuthenticationProviderTest {
                         Arrays.asList("blackbird", "admins")
                 )
         );
+
         when(authorizationExtension.authenticateUser(pluginId2, "username", "password")).thenReturn(NULL_AUTH_RESPONSE);
 
         UserDetails userDetails = provider.retrieveUser("username", new UsernamePasswordAuthenticationToken(null, "password"));
 
         assertNotNull(userDetails);
 
-        assertTrue(securityConfig.isUserMemberOfRole(new CaseInsensitiveString("username"), new CaseInsensitiveString("blackbird")));
-        assertTrue(securityConfig.isUserMemberOfRole(new CaseInsensitiveString("username"), new CaseInsensitiveString("admins")));
-        assertFalse(securityConfig.isUserMemberOfRole(new CaseInsensitiveString("username"), new CaseInsensitiveString("view")));
+        verify(pluginRoleService).updatePluginRoles("cd.go.ldap", "username", CaseInsensitiveString.caseInsensitiveStrings(Arrays.asList("blackbird", "admins")));
     }
 
-    @Test
-    public void shouldNotAddUserToRolesWhenPluginRespondsWithRoleNamesItDoesNotOwn() throws Exception {
-        securityConfig.addRole(new PluginRoleConfig("blackbird", "ldap"));
-        securityConfig.addRole(new PluginRoleConfig("admins", "ldap"));
-        securityConfig.addRole(new PluginRoleConfig("view", "ldap"));
-
-        securityConfig.securityAuthConfigs().add(new SecurityAuthConfig("ldap", "cd.go.ldap"));
-        securityConfig.securityAuthConfigs().add(new SecurityAuthConfig("github", "cd.go.github"));
-
-        String pluginId1 = "cd.go.ldap";
-        String pluginId2 = "cd.go.github";
-
-        when(store.getPluginsThatSupportsPasswordBasedAuthentication()).thenReturn(new HashSet<>(Arrays.asList(pluginId1, pluginId2)));
-
-        when(authorizationExtension.authenticateUser(pluginId1, "username", "password")).thenReturn(NULL_AUTH_RESPONSE);
-        when(authorizationExtension.authenticateUser(pluginId2, "username", "password")).thenReturn(
-                new AuthenticationResponse(
-                        new User("username", "bob", "bob@example.com"),
-                        Arrays.asList("blackbird", "admins", "view")
-                )
-        );
-
-        UserDetails userDetails = provider.retrieveUser("username", new UsernamePasswordAuthenticationToken(null, "password"));
-
-        assertNotNull(userDetails);
-
-        assertFalse(securityConfig.isUserMemberOfRole(new CaseInsensitiveString("username"), new CaseInsensitiveString("blackbird")));
-        assertFalse(securityConfig.isUserMemberOfRole(new CaseInsensitiveString("username"), new CaseInsensitiveString("admins")));
-        assertFalse(securityConfig.isUserMemberOfRole(new CaseInsensitiveString("username"), new CaseInsensitiveString("view")));
-    }
 }

--- a/server/test/unit/com/thoughtworks/go/server/service/PluginRoleServiceTest.java
+++ b/server/test/unit/com/thoughtworks/go/server/service/PluginRoleServiceTest.java
@@ -1,0 +1,207 @@
+/*
+ * Copyright 2017 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.server.service;
+
+import com.thoughtworks.go.config.*;
+import com.thoughtworks.go.helper.GoConfigMother;
+import com.thoughtworks.go.plugin.infra.DefaultPluginManager;
+import com.thoughtworks.go.plugin.infra.PluginManager;
+import com.thoughtworks.go.plugin.infra.plugininfo.GoPluginDescriptor;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+
+import java.util.Arrays;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.mockito.Mockito.*;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+public class PluginRoleServiceTest {
+
+    @Mock
+    private GoConfigService goConfigService;
+    @Mock
+    private PluginManager pluginManager;
+    private SecurityConfig securityConfig;
+
+    @Before
+    public void setUp() throws Exception {
+        initMocks(this);
+        securityConfig = new SecurityConfig();
+        stub(goConfigService.security()).toReturn(securityConfig);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        PluginRoleUsersStore.instance().clearAll();
+    }
+
+    @Test
+    public void shouldBeAbleToUpdatePluginRolesToUser() throws Exception {
+        securityConfig.securityAuthConfigs().add(new SecurityAuthConfig("github", "cd.go.authorization.github"));
+        securityConfig.addRole(new PluginRoleConfig("blackbird", "github"));
+        PluginRoleService pluginRoleService = new PluginRoleService(goConfigService, pluginManager);
+
+        pluginRoleService.updatePluginRoles("cd.go.authorization.github", "bob", CaseInsensitiveString.caseInsensitiveStrings(Arrays.asList("blackbird")));
+
+        assertThat(pluginRoleService.usersForPluginRole("blackbird"), hasSize(1));
+        assertThat(pluginRoleService.usersForPluginRole("blackbird"), hasItem(new RoleUser("bob")));
+    }
+
+    @Test
+    public void updatePluginRoleShouldIgnoreRolesWhichAreNotMappedToThePlugin() throws Exception {
+        securityConfig.securityAuthConfigs().add(new SecurityAuthConfig("github", "cd.go.authorization.github"));
+        securityConfig.addRole(new PluginRoleConfig("blackbird", "github"));
+        securityConfig.addRole(new PluginRoleConfig("spacetiger", "ldap"));
+        PluginRoleService pluginRoleService = new PluginRoleService(goConfigService, pluginManager);
+
+        pluginRoleService.updatePluginRoles("cd.go.authorization.github", "bob", CaseInsensitiveString.caseInsensitiveStrings(Arrays.asList("blackbird", "spacetiger")));
+
+        assertThat(pluginRoleService.usersForPluginRole("blackbird"), hasSize(1));
+        assertThat(pluginRoleService.usersForPluginRole("spacetiger"), hasSize(0));
+        assertThat(pluginRoleService.usersForPluginRole("blackbird"), hasItem(new RoleUser("bob")));
+        assertThat(pluginRoleService.usersForPluginRole("spacetiger"), not(hasItem(new RoleUser("bob"))));
+    }
+
+    @Test
+    public void updatePluginRolesShouldIgnoreNonExistentRoles() throws Exception {
+        securityConfig.securityAuthConfigs().add(new SecurityAuthConfig("github", "cd.go.authorization.github"));
+        securityConfig.addRole(new PluginRoleConfig("blackbird", "github"));
+        PluginRoleService pluginRoleService = new PluginRoleService(goConfigService, pluginManager);
+
+        pluginRoleService.updatePluginRoles("cd.go.authorization.github", "alice", CaseInsensitiveString.caseInsensitiveStrings(Arrays.asList("blackbird", "non_existent_role")));
+
+        assertThat(pluginRoleService.usersForPluginRole("blackbird"), hasSize(1));
+        assertThat(pluginRoleService.usersForPluginRole("blackbird"), hasItem(new RoleUser("alice")));
+        assertThat(pluginRoleService.usersForPluginRole("non_existent_role"), hasSize(0));
+    }
+
+    @Test
+    public void updatePluginRolesShouldNotChangeRoleConfig() throws Exception {
+        securityConfig.securityAuthConfigs().add(new SecurityAuthConfig("github", "cd.go.authorization.github"));
+        securityConfig.addRole(new PluginRoleConfig("blackbird", "github"));
+        securityConfig.addRole(new RoleConfig(new CaseInsensitiveString("go_system_admin")));
+        PluginRoleService pluginRoleService = new PluginRoleService(goConfigService, pluginManager);
+
+        pluginRoleService.updatePluginRoles("cd.go.authorization.github", "bob", CaseInsensitiveString.caseInsensitiveStrings(Arrays.asList("blackbird", "non_existent_role", "go_system_admin")));
+
+        assertThat(pluginRoleService.usersForPluginRole("blackbird"), hasItem(new RoleUser("bob")));
+        assertThat(pluginRoleService.usersForPluginRole("non_existent_role"), hasSize(0));
+        assertThat(pluginRoleService.usersForPluginRole("go_system_admin"), hasSize(0));
+    }
+
+    @Test
+    public void updatePluginRolesShouldHandleDeletionOfRoleForAUser() throws Exception {
+        securityConfig.securityAuthConfigs().add(new SecurityAuthConfig("github", "cd.go.authorization.github"));
+        securityConfig.addRole(new PluginRoleConfig("blackbird", "github"));
+        securityConfig.addRole(new PluginRoleConfig("spacetiger", "github"));
+        PluginRoleService pluginRoleService = new PluginRoleService(goConfigService, pluginManager);
+
+        pluginRoleService.updatePluginRoles("cd.go.authorization.github", "bob", CaseInsensitiveString.caseInsensitiveStrings(Arrays.asList("blackbird", "spacetiger")));
+
+        assertThat(pluginRoleService.usersForPluginRole("blackbird"), hasItem(new RoleUser("bob")));
+        assertThat(pluginRoleService.usersForPluginRole("spacetiger"), hasItem(new RoleUser("bob")));
+
+        pluginRoleService.updatePluginRoles("cd.go.authorization.github", "bob", CaseInsensitiveString.caseInsensitiveStrings(Arrays.asList("blackbird")));
+
+        assertThat(pluginRoleService.usersForPluginRole("blackbird"), hasItem(new RoleUser("bob")));
+        assertThat(pluginRoleService.usersForPluginRole("spacetiger"), not(hasItem(new RoleUser("bob"))));
+    }
+
+    @Test
+    public void updatePluginRolesShouldHandleAdditionOfRoleForUser() throws Exception {
+        securityConfig.securityAuthConfigs().add(new SecurityAuthConfig("github", "cd.go.authorization.github"));
+        securityConfig.addRole(new PluginRoleConfig("blackbird", "github"));
+        securityConfig.addRole(new PluginRoleConfig("spacetiger", "github"));
+        PluginRoleService pluginRoleService = new PluginRoleService(goConfigService, pluginManager);
+
+        pluginRoleService.updatePluginRoles("cd.go.authorization.github", "bob", CaseInsensitiveString.caseInsensitiveStrings(Arrays.asList("blackbird")));
+
+        assertThat(pluginRoleService.usersForPluginRole("blackbird"), hasItem(new RoleUser("bob")));
+        assertThat(pluginRoleService.usersForPluginRole("spacetiger"), not(hasItem(new RoleUser("bob"))));
+
+        pluginRoleService.updatePluginRoles("cd.go.authorization.github", "bob", CaseInsensitiveString.caseInsensitiveStrings(Arrays.asList("blackbird", "spacetiger")));
+
+        assertThat(pluginRoleService.usersForPluginRole("blackbird"), hasItem(new RoleUser("bob")));
+        assertThat(pluginRoleService.usersForPluginRole("spacetiger"), hasItem(new RoleUser("bob")));
+
+    }
+
+    @Test
+    public void shouldInvalidateCacheForPluginRolesDeleted_OnConfigChange() throws Exception {
+        securityConfig.securityAuthConfigs().add(new SecurityAuthConfig("github", "cd.go.authorization.github"));
+        securityConfig.addRole(new PluginRoleConfig("blackbird", "github"));
+        securityConfig.addRole(new PluginRoleConfig("spacetiger", "github"));
+        PluginRoleService pluginRoleService = new PluginRoleService(goConfigService, pluginManager);
+
+        pluginRoleService.updatePluginRoles("cd.go.authorization.github", "bob",
+                CaseInsensitiveString.caseInsensitiveStrings(Arrays.asList("blackbird", "spacetiger")));
+
+        assertThat(pluginRoleService.usersForPluginRole("blackbird"), hasItem(new RoleUser("bob")));
+        assertThat(pluginRoleService.usersForPluginRole("spacetiger"), hasItem(new RoleUser("bob")));
+
+        BasicCruiseConfig newCruiseConfig = GoConfigMother.defaultCruiseConfig();
+        newCruiseConfig.server().security().addRole(new PluginRoleConfig("blackbird", "github"));
+        pluginRoleService.onConfigChange(newCruiseConfig);
+
+        assertThat(pluginRoleService.usersForPluginRole("blackbird"), hasItem(new RoleUser("bob")));
+        assertThat(pluginRoleService.usersForPluginRole("spacetiger"), hasSize(0));
+    }
+
+    @Test
+    public void onPluginUnloadShouldRemoveCorrespondingPluginRolesFromStore() throws Exception {
+        securityConfig.securityAuthConfigs().add(new SecurityAuthConfig("github", "cd.go.authorization.github"));
+        securityConfig.addRole(new PluginRoleConfig("blackbird", "github"));
+        GoPluginDescriptor goPluginDescriptor = mock(GoPluginDescriptor.class);
+        DefaultPluginManager pluginManager = mock(DefaultPluginManager.class);
+
+        PluginRoleService pluginRoleService = new PluginRoleService(goConfigService, pluginManager);
+
+        pluginRoleService.updatePluginRoles("cd.go.authorization.github", "bob", CaseInsensitiveString.caseInsensitiveStrings(Arrays.asList("blackbird")));
+
+        assertThat(pluginRoleService.usersForPluginRole("blackbird"), hasSize(1));
+        assertThat(pluginRoleService.usersForPluginRole("blackbird"), hasItem(new RoleUser("bob")));
+
+        when(goPluginDescriptor.id()).thenReturn("cd.go.authorization.github");
+
+        pluginRoleService.pluginUnLoaded(goPluginDescriptor);
+
+        assertThat(pluginRoleService.usersForPluginRole("blackbird"), hasSize(0));
+    }
+
+    @Test
+    public void invalidatePluginRolesShouldRemoveRolesCorrespondingToThePluginFromStore() throws Exception {
+        securityConfig.securityAuthConfigs().add(new SecurityAuthConfig("github", "cd.go.authorization.github"));
+        securityConfig.securityAuthConfigs().add(new SecurityAuthConfig("ldap", "cd.go.authorization.ldap"));
+        securityConfig.addRole(new PluginRoleConfig("blackbird", "github"));
+        securityConfig.addRole(new PluginRoleConfig("spacetiger", "ldap"));
+
+        PluginRoleService pluginRoleService = new PluginRoleService(goConfigService, pluginManager);
+
+        pluginRoleService.updatePluginRoles("cd.go.authorization.github", "bob", CaseInsensitiveString.caseInsensitiveStrings(Arrays.asList("blackbird")));
+        pluginRoleService.updatePluginRoles("cd.go.authorization.ldap", "bob", CaseInsensitiveString.caseInsensitiveStrings(Arrays.asList("spacetiger")));
+        pluginRoleService.updatePluginRoles("cd.go.authorization.github", "alice", CaseInsensitiveString.caseInsensitiveStrings(Arrays.asList("blackbird")));
+
+        pluginRoleService.invalidateRolesFor("cd.go.authorization.github");
+
+        assertThat(pluginRoleService.usersForPluginRole("blackbird"), hasSize(0));
+        assertThat(pluginRoleService.usersForPluginRole("spacetiger"), hasSize(1));
+    }
+}

--- a/server/test/unit/com/thoughtworks/go/server/service/plugins/processor/authorization/AuthorizationRequestProcessorTest.java
+++ b/server/test/unit/com/thoughtworks/go/server/service/plugins/processor/authorization/AuthorizationRequestProcessorTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2017 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.server.service.plugins.processor.authorization;
+
+import com.thoughtworks.go.config.*;
+import com.thoughtworks.go.plugin.access.authorization.AuthorizationExtension;
+import com.thoughtworks.go.plugin.access.authorization.AuthorizationMessageConverterV1;
+import com.thoughtworks.go.plugin.api.request.DefaultGoApiRequest;
+import com.thoughtworks.go.plugin.api.request.GoApiRequest;
+import com.thoughtworks.go.plugin.api.response.GoApiResponse;
+import com.thoughtworks.go.plugin.infra.PluginRequestProcessorRegistry;
+import com.thoughtworks.go.plugin.infra.plugininfo.GoPluginDescriptor;
+import com.thoughtworks.go.server.service.GoConfigService;
+import com.thoughtworks.go.server.service.PluginRoleService;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import static com.thoughtworks.go.server.service.plugins.processor.authorization.AuthorizationRequestProcessor.Request.*;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.*;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+public class AuthorizationRequestProcessorTest {
+
+    @Mock
+    private PluginRequestProcessorRegistry registry;
+    @Mock
+    private AuthorizationExtension authorizationExtension;
+    @Mock
+    private GoPluginDescriptor pluginDescriptor;
+    @Mock
+    private GoConfigService goConfigService;
+    @Mock
+    private SecurityConfig securityConfig;
+    private SecurityAuthConfigs securityAuthConfigsSpy;
+
+    @Before
+    public void setUp() throws Exception {
+        initMocks(this);
+        when(pluginDescriptor.id()).thenReturn("cd.go.authorization.github");
+        stub(goConfigService.security()).toReturn(securityConfig);
+        securityAuthConfigsSpy = spy(new SecurityAuthConfigs());
+        stub(securityConfig.securityAuthConfigs()).toReturn(securityAuthConfigsSpy);
+    }
+
+    @Test
+    public void shouldProcessInvalidateCacheRequest() throws Exception {
+        PluginRoleService pluginRoleService = mock(PluginRoleService.class);
+        when(authorizationExtension.getMessageConverter(AuthorizationMessageConverterV1.VERSION)).thenReturn(new AuthorizationMessageConverterV1());
+
+        GoApiRequest request = new DefaultGoApiRequest(INVALIDATE_CACHE_REQUEST.requestName(), "1.0", null);
+        AuthorizationRequestProcessor authorizationRequestProcessor = new AuthorizationRequestProcessor(registry, null, authorizationExtension, pluginRoleService);
+
+        GoApiResponse response = authorizationRequestProcessor.process(pluginDescriptor, request);
+
+        assertThat(response.responseCode(), is(200));
+        verify(pluginRoleService).invalidateRolesFor("cd.go.authorization.github");
+    }
+
+    @Test
+    public void shouldProcessRoleConfigRequest() throws Exception {
+        securityAuthConfigsSpy.add(new SecurityAuthConfig("github", "cd.go.authorization.github"));
+        AuthorizationMessageConverterV1 converterV1 = spy(new AuthorizationMessageConverterV1());
+        when(authorizationExtension.getMessageConverter(AuthorizationMessageConverterV1.VERSION)).thenReturn(converterV1);
+
+        PluginRoleConfig pluginRoleConfig = new PluginRoleConfig("blackbird", "github");
+        RolesConfig rolesConfigSpy = spy(new RolesConfig(pluginRoleConfig));
+        when(securityConfig.getRoles()).thenReturn(rolesConfigSpy);
+
+        DefaultGoApiRequest request = new DefaultGoApiRequest(GET_ROLE_CONFIG_REQUEST.requestName(), "1.0", null);
+        request.setRequestBody("{\"auth_config_id\":\"github\"}");
+
+        AuthorizationRequestProcessor authorizationRequestProcessor = new AuthorizationRequestProcessor(registry, goConfigService, authorizationExtension, null);
+        GoApiResponse response = authorizationRequestProcessor.process(pluginDescriptor, request);
+
+        assertThat(response.responseCode(), is(200));
+        verify(authorizationExtension.getMessageConverter(AuthorizationMessageConverterV1.VERSION)).processGetRoleConfigsRequest(request.requestBody());
+        verify(authorizationExtension.getMessageConverter(AuthorizationMessageConverterV1.VERSION)).getProcessRoleConfigsResponseBody(Arrays.asList(pluginRoleConfig));
+        verify(securityAuthConfigsSpy).findByPluginIdAndProfileId(pluginDescriptor.id(), "github");
+        verify(securityConfig.getRoles()).getPluginRolesConfig("github");
+
+    }
+
+    @Test
+    public void shouldProcessPluginConfigRequest() throws Exception {
+        SecurityAuthConfig githubSecurityAuthConfig = new SecurityAuthConfig("github", "cd.go.authorization.github");
+        securityAuthConfigsSpy.add(githubSecurityAuthConfig);
+        securityAuthConfigsSpy.add(new SecurityAuthConfig("ldap", "cd.go.authorization.ldap"));
+        AuthorizationMessageConverterV1 converterV1 = spy(new AuthorizationMessageConverterV1());
+        when(authorizationExtension.getMessageConverter(AuthorizationMessageConverterV1.VERSION)).thenReturn(converterV1);
+
+        DefaultGoApiRequest request = new DefaultGoApiRequest(GET_PLUGIN_CONFIG_REQUEST.requestName(), "1.0", null);
+        AuthorizationRequestProcessor authorizationRequestProcessor = new AuthorizationRequestProcessor(registry, goConfigService, authorizationExtension, null);
+        GoApiResponse response = authorizationRequestProcessor.process(pluginDescriptor, request);
+
+        assertThat(response.responseCode(), is(200));
+        verify(authorizationExtension.getMessageConverter(AuthorizationMessageConverterV1.VERSION)).getProcessPluginConfigResponseBody(Collections.singletonMap("github", githubSecurityAuthConfig.getConfigurationAsMap(true)));
+    }
+}

--- a/server/test/unit/com/thoughtworks/go/server/service/plugins/processor/authorization/AuthorizationRequestProcessorTest.java
+++ b/server/test/unit/com/thoughtworks/go/server/service/plugins/processor/authorization/AuthorizationRequestProcessorTest.java
@@ -31,9 +31,9 @@ import org.junit.Test;
 import org.mockito.Mock;
 
 import java.util.Arrays;
-import java.util.Collections;
 
-import static com.thoughtworks.go.server.service.plugins.processor.authorization.AuthorizationRequestProcessor.Request.*;
+import static com.thoughtworks.go.server.service.plugins.processor.authorization.AuthorizationRequestProcessor.Request.GET_ROLE_CONFIG_REQUEST;
+import static com.thoughtworks.go.server.service.plugins.processor.authorization.AuthorizationRequestProcessor.Request.INVALIDATE_CACHE_REQUEST;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.*;
@@ -98,21 +98,5 @@ public class AuthorizationRequestProcessorTest {
         verify(securityAuthConfigsSpy).findByPluginIdAndProfileId(pluginDescriptor.id(), "github");
         verify(securityConfig.getRoles()).getPluginRolesConfig("github");
 
-    }
-
-    @Test
-    public void shouldProcessPluginConfigRequest() throws Exception {
-        SecurityAuthConfig githubSecurityAuthConfig = new SecurityAuthConfig("github", "cd.go.authorization.github");
-        securityAuthConfigsSpy.add(githubSecurityAuthConfig);
-        securityAuthConfigsSpy.add(new SecurityAuthConfig("ldap", "cd.go.authorization.ldap"));
-        AuthorizationMessageConverterV1 converterV1 = spy(new AuthorizationMessageConverterV1());
-        when(authorizationExtension.getMessageConverter(AuthorizationMessageConverterV1.VERSION)).thenReturn(converterV1);
-
-        DefaultGoApiRequest request = new DefaultGoApiRequest(GET_PLUGIN_CONFIG_REQUEST.requestName(), "1.0", null);
-        AuthorizationRequestProcessor authorizationRequestProcessor = new AuthorizationRequestProcessor(registry, goConfigService, authorizationExtension, null);
-        GoApiResponse response = authorizationRequestProcessor.process(pluginDescriptor, request);
-
-        assertThat(response.responseCode(), is(200));
-        verify(authorizationExtension.getMessageConverter(AuthorizationMessageConverterV1.VERSION)).getProcessPluginConfigResponseBody(Collections.singletonMap("github", githubSecurityAuthConfig.getConfigurationAsMap(true)));
     }
 }


### PR DESCRIPTION
refer #2956
* PluginRoleService manages PluginRoles for a user
* PluginRoleUserStore used to store users for a PluginRole
* Added endpoint for invalidation of cache from authorization plugin
* Unloading an Authentication plugins forces re-authentication of all
users through the RemoveAdminPermissionFilter