### PR TITLE
Handling missing elastic agent plugin when requesting for agent creation

### DIFF
--- a/common/src/com/thoughtworks/go/serverhealth/HealthStateScope.java
+++ b/common/src/com/thoughtworks/go/serverhealth/HealthStateScope.java
@@ -101,6 +101,10 @@ public class HealthStateScope implements Comparable<HealthStateScope> {
         return type == ScopeType.MATERIAL;
     }
 
+    public boolean isForJob() {
+        return type == ScopeType.JOB;
+    }
+
     ScopeType getType() {
         return type;
     }

--- a/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/elastic/ElasticAgentPluginRegistry.java
+++ b/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/elastic/ElasticAgentPluginRegistry.java
@@ -70,4 +70,8 @@ public class ElasticAgentPluginRegistry extends AbstractPluginRegistry<ElasticAg
     public String getProfileView(String pluginId) {
         return extension.getProfileView(pluginId);
     }
+
+    public boolean has(String pluginId) {
+        return findPlugin(pluginId) != null;
+    }
 }

--- a/server/test/integration/com/thoughtworks/go/server/service/PipelineServiceTest.java
+++ b/server/test/integration/com/thoughtworks/go/server/service/PipelineServiceTest.java
@@ -47,6 +47,8 @@ import com.thoughtworks.go.server.transaction.TestTransactionSynchronizationMana
 import com.thoughtworks.go.server.transaction.TestTransactionTemplate;
 import com.thoughtworks.go.server.transaction.TransactionSynchronizationManager;
 import com.thoughtworks.go.server.transaction.TransactionTemplate;
+import com.thoughtworks.go.serverhealth.ServerHealthService;
+import com.thoughtworks.go.serverhealth.ServerHealthStates;
 import com.thoughtworks.go.util.SystemEnvironment;
 import org.junit.Before;
 import org.junit.Test;
@@ -138,8 +140,10 @@ public class PipelineServiceTest {
 
     private Pipeline stubPipelineSaveForStatusListener(StageStatusListener stageStatusListener, JobStatusListener jobStatusListener) {
         StageDao stageDao = mock(StageDao.class);
+        ServerHealthService serverHealthService = mock(ServerHealthService.class);
+        when(serverHealthService.getAllLogs()).thenReturn(new ServerHealthStates());
         JobInstanceService jobInstanceService = new JobInstanceService(mock(JobInstanceDao.class), mock(PropertiesService.class), mock(JobResultTopic.class), mock(JobStatusCache.class),
-                actualTransactionTemplate, transactionSynchronizationManager, null, null, goConfigService, null, pluginManager, jobStatusListener);
+                actualTransactionTemplate, transactionSynchronizationManager, null, null, goConfigService, null, pluginManager, serverHealthService, jobStatusListener);
 
         StageService stageService = new StageService(stageDao, jobInstanceService, mock(StageStatusTopic.class), mock(StageStatusCache.class), mock(SecurityService.class), mock(PipelineDao.class),
                 mock(ChangesetService.class), mock(GoConfigService.class), actualTransactionTemplate, transactionSynchronizationManager,

--- a/server/test/integration/com/thoughtworks/go/server/service/PipelineServiceTriangleDependencyTest.java
+++ b/server/test/integration/com/thoughtworks/go/server/service/PipelineServiceTriangleDependencyTest.java
@@ -56,6 +56,8 @@ import com.thoughtworks.go.server.transaction.TestTransactionSynchronizationMana
 import com.thoughtworks.go.server.transaction.TestTransactionTemplate;
 import com.thoughtworks.go.server.transaction.TransactionSynchronizationManager;
 import com.thoughtworks.go.server.transaction.TransactionTemplate;
+import com.thoughtworks.go.serverhealth.ServerHealthService;
+import com.thoughtworks.go.serverhealth.ServerHealthStates;
 import com.thoughtworks.go.util.SystemEnvironment;
 import com.thoughtworks.go.plugin.infra.PluginManager;
 import org.junit.Before;
@@ -185,8 +187,10 @@ public class PipelineServiceTriangleDependencyTest {
 
     private Pipeline stubPipelineSaveForStatusListener(StageStatusListener stageStatusListener, JobStatusListener jobStatusListener) {
         StageDao stageDao = mock(StageDao.class);
+        ServerHealthService serverHealthService = mock(ServerHealthService.class);
+        when(serverHealthService.getAllLogs()).thenReturn(new ServerHealthStates());
         JobInstanceService jobInstanceService = new JobInstanceService(mock(JobInstanceDao.class), mock(PropertiesService.class), mock(JobResultTopic.class), mock(JobStatusCache.class),
-                actualTransactionTemplate, transactionSynchronizationManager, null, null, goConfigService, null, pluginManager, jobStatusListener);
+                actualTransactionTemplate, transactionSynchronizationManager, null, null, goConfigService, null, pluginManager, serverHealthService, jobStatusListener);
 
         StageService stageService = new StageService(stageDao, jobInstanceService, mock(StageStatusTopic.class), mock(StageStatusCache.class), mock(SecurityService.class), mock(PipelineDao.class),
                 mock(ChangesetService.class), mock(GoConfigService.class), actualTransactionTemplate, transactionSynchronizationManager,

--- a/server/test/integration/com/thoughtworks/go/server/service/ScheduleServiceStageTriggerTest.java
+++ b/server/test/integration/com/thoughtworks/go/server/service/ScheduleServiceStageTriggerTest.java
@@ -48,6 +48,7 @@ import com.thoughtworks.go.server.transaction.TransactionCallback;
 import com.thoughtworks.go.server.transaction.TransactionSynchronizationManager;
 import com.thoughtworks.go.server.transaction.TransactionTemplate;
 import com.thoughtworks.go.serverhealth.ServerHealthService;
+import com.thoughtworks.go.serverhealth.ServerHealthStates;
 import com.thoughtworks.go.util.GoConfigFileHelper;
 import com.thoughtworks.go.plugin.infra.PluginManager;
 import org.junit.After;
@@ -280,8 +281,10 @@ public class ScheduleServiceStageTriggerTest {
     }
 
     private JobInstanceService jobInstanceService(JobResultTopic jobResultTopic) {
+        ServerHealthService serverHealthService = mock(ServerHealthService.class);
+        when(serverHealthService.getAllLogs()).thenReturn(new ServerHealthStates());
         return new JobInstanceService(jobInstanceDao, propertiesService, jobResultTopic, jobStatusCache, transactionTemplate,
-                transactionSynchronizationManager, null, null, goConfigService, null, pluginManager);
+                transactionSynchronizationManager, null, null, goConfigService, null, pluginManager, serverHealthService);
     }
 
     @Test


### PR DESCRIPTION
For missing elastic agent plugins, a misleading queue not found error was being displayed. Added a server health error instead.
Handled clearing of job related server health messages when the config changes (just in case the job/stage/pipeline was renamed/deleted)
BuildAssignmentService should reconsider such jobs for assignment after the configured starvation-threshold