### PR TITLE
Fixed spelling of 'characters'

### DIFF
--- a/common/test/unit/com/thoughtworks/go/domain/PipelineConfigTest.java
+++ b/common/test/unit/com/thoughtworks/go/domain/PipelineConfigTest.java
@@ -305,7 +305,7 @@ public class PipelineConfigTest {
     }
 
     @Test
-    public void shouldSupportSpecialCharactors() {
+    public void shouldSupportSpecialCharacters() {
         PipelineConfig pipelineConfig = new PipelineConfig(new CaseInsensitiveString("cruise"), new MaterialConfigs());
         pipelineConfig.setLabelTemplate("pipeline-${COUN_T}-${my-material}${h.i}${**}");
 

--- a/domain/src/com/thoughtworks/go/validation/LengthValidator.java
+++ b/domain/src/com/thoughtworks/go/validation/LengthValidator.java
@@ -23,7 +23,7 @@ public class LengthValidator extends Validator<String> {
     private final int length;
 
     public LengthValidator(int length) {
-        super("Only " + length + " charactors are allowed");
+        super("Only " + length + " characters are allowed");
         this.length = length;
     }
 


### PR DESCRIPTION
noticed the following validation notification in the email settings:

![spelling](https://cloud.githubusercontent.com/assets/1716584/22923614/7aa941d6-f2a2-11e6-9caf-0433b1d60d2c.png)

Fixing a couple of old spelling mistakes. Should not have an all too large of an impact