### PR TITLE
Fix for editing config-repo environments, renamed method names according to the usage forEdit or forDisplay

### DIFF
--- a/server/src/com/thoughtworks/go/server/service/EnvironmentConfigService.java
+++ b/server/src/com/thoughtworks/go/server/service/EnvironmentConfigService.java
@@ -161,11 +161,11 @@ public class EnvironmentConfigService implements ConfigChangedListener {
         return environments.named(new CaseInsensitiveString(environmentName));
     }
 
-    public EnvironmentConfig forEdit(String environmentName) {
-        return cloner.deepClone(environments.find(new CaseInsensitiveString(environmentName)));
+    public EnvironmentConfig getEnvironmentForEdit(String environmentName) {
+        return cloner.deepClone(goConfigService.getConfigForEditing().getEnvironments().find(new CaseInsensitiveString(environmentName)));
     }
 
-    public ConfigElementForEdit<EnvironmentConfig> forDisplay(String environmentName, HttpLocalizedOperationResult result) {
+    public ConfigElementForEdit<EnvironmentConfig> getMergedEnvironmentforDisplay(String environmentName, HttpLocalizedOperationResult result) {
         ConfigElementForEdit<EnvironmentConfig> edit = null;
         try {
             CruiseConfig config = goConfigService.getMergedConfigForEditing();

--- a/server/test/integration/com/thoughtworks/go/server/service/EnvironmentConfigServiceIntegrationTest.java
+++ b/server/test/integration/com/thoughtworks/go/server/service/EnvironmentConfigServiceIntegrationTest.java
@@ -18,7 +18,6 @@ package com.thoughtworks.go.server.service;
 
 import com.thoughtworks.go.config.*;
 import com.thoughtworks.go.config.exceptions.NoSuchEnvironmentException;
-import com.thoughtworks.go.config.merge.MergeEnvironmentConfig;
 import com.thoughtworks.go.domain.ConfigElementForEdit;
 import com.thoughtworks.go.helper.PipelineConfigMother;
 import com.thoughtworks.go.i18n.Localizer;
@@ -273,14 +272,14 @@ public class EnvironmentConfigServiceIntegrationTest {
         HttpLocalizedOperationResult result = new HttpLocalizedOperationResult();
         configHelper.addEnvironments("foo-env");
         assertThat(service.named("foo-env"), sameInstance(service.named("foo-env")));
-        assertThat(service.named("foo-env"), not(sameInstance(service.forDisplay("foo-env", result).getConfigElement())));
+        assertThat(service.named("foo-env"), not(sameInstance(service.getMergedEnvironmentforDisplay("foo-env", result).getConfigElement())));
         assertThat(result.isSuccessful(), is(true));
     }
 
     @Test
     public void shouldPopulateResultWithErrorIfEnvNotFound() throws NoSuchEnvironmentException {
         HttpLocalizedOperationResult result = new HttpLocalizedOperationResult();
-        ConfigElementForEdit<EnvironmentConfig> edit = service.forDisplay("foo-env", result);
+        ConfigElementForEdit<EnvironmentConfig> edit = service.getMergedEnvironmentforDisplay("foo-env", result);
         assertThat(result.message(localizer), is("Environment 'foo-env' not found."));
         assertThat(edit, is(nullValue()));
     }

--- a/server/test/unit/com/thoughtworks/go/server/service/EnvironmentConfigServiceTest.java
+++ b/server/test/unit/com/thoughtworks/go/server/service/EnvironmentConfigServiceTest.java
@@ -346,7 +346,7 @@ public class EnvironmentConfigServiceTest {
         environments.add(env);
         environmentConfigService.sync(environments);
         when(mockGoConfigService.getMergedConfigForEditing()).thenReturn(config);
-        assertThat(environmentConfigService.forDisplay("foo", result).getConfigElement(), Is.is(env));
+        assertThat(environmentConfigService.getMergedEnvironmentforDisplay("foo", result).getConfigElement(), Is.is(env));
         assertThat(result.isSuccessful(), is(true));
     }
 

--- a/server/test/unit/com/thoughtworks/go/server/service/EnvironmentConfigServiceTest.java
+++ b/server/test/unit/com/thoughtworks/go/server/service/EnvironmentConfigServiceTest.java
@@ -16,8 +16,10 @@
 
 package com.thoughtworks.go.server.service;
 
+import com.rits.cloning.Cloner;
 import com.thoughtworks.go.config.*;
 import com.thoughtworks.go.config.exceptions.NoSuchEnvironmentException;
+import com.thoughtworks.go.config.merge.MergeEnvironmentConfig;
 import com.thoughtworks.go.config.remote.RepoConfigOrigin;
 import com.thoughtworks.go.domain.DefaultJobPlan;
 import com.thoughtworks.go.domain.JobIdentifier;
@@ -69,6 +71,31 @@ public class EnvironmentConfigServiceTest {
     public void shouldRegisterAsACruiseConfigChangeListener() throws Exception {
         environmentConfigService.initialize();
         Mockito.verify(mockGoConfigService).register(environmentConfigService);
+    }
+
+    @Test
+    public void shouldGetEditablePartOfEnvironmentConfig() throws Exception {
+        String uat = "uat";
+
+        BasicEnvironmentConfig local = new BasicEnvironmentConfig(new CaseInsensitiveString("uat"));
+        local.addEnvironmentVariable("user", "admin");
+        BasicEnvironmentConfig remote = new BasicEnvironmentConfig(new CaseInsensitiveString("uat"));
+        remote.addEnvironmentVariable("foo", "bar");
+        MergeEnvironmentConfig merged = new MergeEnvironmentConfig(local, remote);
+
+        EnvironmentsConfig environments = new EnvironmentsConfig();
+        environments.add(merged);
+
+        environmentConfigService.sync(environments);
+
+        BasicCruiseConfig cruiseConfig = new BasicCruiseConfig();
+        BasicEnvironmentConfig env = (BasicEnvironmentConfig) environmentConfigService.named(uat).getLocal();
+        cruiseConfig.addEnvironment(env);
+        BasicEnvironmentConfig expectedToEdit = new Cloner().deepClone(env);
+
+        when(mockGoConfigService.getConfigForEditing()).thenReturn(cruiseConfig);
+
+        assertThat(environmentConfigService.getEnvironmentForEdit(uat), is(expectedToEdit));
     }
 
     @Test
@@ -312,8 +339,7 @@ public class EnvironmentConfigServiceTest {
     }
 
     @Test
-    public void getAllRemotePipelinesForUserInEnvironment_shouldReturnOnlyRemotelyAssignedPipelinesWhichUserHasPermsToView() throws NoSuchEnvironmentException
-    {
+    public void getAllRemotePipelinesForUserInEnvironment_shouldReturnOnlyRemotelyAssignedPipelinesWhichUserHasPermsToView() throws NoSuchEnvironmentException {
         HttpLocalizedOperationResult result = new HttpLocalizedOperationResult();
         Username user = new Username(new CaseInsensitiveString("user"));
 
@@ -327,7 +353,7 @@ public class EnvironmentConfigServiceTest {
         EnvironmentConfig fooEnv = environmentConfigs.named(new CaseInsensitiveString("foo-env"));
         fooEnv.setOrigins(new RepoConfigOrigin());
         environmentConfigService.sync(environmentConfigs);
-        List<EnvironmentPipelineModel> pipelines = environmentConfigService.getAllRemotePipelinesForUserInEnvironment(user,fooEnv);
+        List<EnvironmentPipelineModel> pipelines = environmentConfigService.getAllRemotePipelinesForUserInEnvironment(user, fooEnv);
 
 
         assertThat(pipelines.size(), is(1));

--- a/server/webapp/WEB-INF/rails.new/app/controllers/api_v1/admin/environments_controller.rb
+++ b/server/webapp/WEB-INF/rails.new/app/controllers/api_v1/admin/environments_controller.rb
@@ -67,7 +67,7 @@ module ApiV1
       protected
 
       def load_environment(environment_name = params[:name])
-        @environment_config = environment_config_service.forEdit(environment_name)
+        @environment_config = environment_config_service.getEnvironmentForEdit(environment_name)
         @environment_config.setOrigins(com.thoughtworks.go.config.remote.FileConfigOrigin.new)
       rescue com.thoughtworks.go.config.exceptions.NoSuchEnvironmentException
         raise ApiV1::RecordNotFound

--- a/server/webapp/WEB-INF/rails.new/app/controllers/api_v2/admin/environments_with_remote_controller.rb
+++ b/server/webapp/WEB-INF/rails.new/app/controllers/api_v2/admin/environments_with_remote_controller.rb
@@ -29,7 +29,7 @@ module ApiV2
 
       def load_remote_environment(environment_name = params[:name])
         result = HttpLocalizedOperationResult.new
-        @environment_config = environment_config_service.forDisplay(environment_name, result).getConfigElement()
+        @environment_config = environment_config_service.getMergedEnvironmentForDisplay(environment_name, result).getConfigElement()
       rescue com.thoughtworks.go.config.exceptions.NoSuchEnvironmentException
         raise ApiV2::RecordNotFound
       end

--- a/server/webapp/WEB-INF/rails.new/app/controllers/api_v2/admin/environments_with_remote_controller.rb
+++ b/server/webapp/WEB-INF/rails.new/app/controllers/api_v2/admin/environments_with_remote_controller.rb
@@ -22,7 +22,7 @@ module ApiV2
       def show
         load_remote_environment
         json = ApiV2::Config::EnvironmentConfigRepresenter.new(@environment_config).to_hash(url_builder: self)
-        render DEFAULT_FORMAT => json if stale?(etag: etag_for(environment_config_service.forEdit(params[:name])))
+        render DEFAULT_FORMAT => json if stale?(etag: etag_for(environment_config_service.getEnvironmentForEdit(params[:name])))
       end
 
       protected

--- a/server/webapp/WEB-INF/rails.new/app/controllers/environments_controller.rb
+++ b/server/webapp/WEB-INF/rails.new/app/controllers/environments_controller.rb
@@ -47,7 +47,7 @@ class EnvironmentsController < ApplicationController
   end
 
   def update
-    @environment = environment_config_service.forEdit(params[:name])
+    @environment = environment_config_service.getEnvironmentForEdit(params[:name])
     @environment.setConfigAttributes(params[:environment])
     if @environment.name().blank?
       render_error_response l.string("ENVIRONMENT_NAME_REQUIRED"), 400, true
@@ -89,10 +89,10 @@ class EnvironmentsController < ApplicationController
 
   def load_existing_environment
     result = HttpLocalizedOperationResult.new
-    env_for_display = environment_config_service.forDisplay(params[:name], result)
+    env_for_display = environment_config_service.getMergedEnvironmentforDisplay(params[:name], result)
     if (result.isSuccessful())
       @environment = env_for_display.getConfigElement()
-      @cruise_config_md5 = entity_hashing_service.md5ForEntity(environment_config_service.forEdit(params[:name]))
+      @cruise_config_md5 = entity_hashing_service.md5ForEntity(environment_config_service.getEnvironmentForEdit(params[:name]))
     end
     render_if_error(result.message(Spring.bean('localizer')), result.httpCode())
     result.isSuccessful()

--- a/server/webapp/WEB-INF/rails.new/spec/controllers/api_v1/admin/environments_controller_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/controllers/api_v1/admin/environments_controller_spec.rb
@@ -80,7 +80,7 @@ describe ApiV1::Admin::EnvironmentsController do
       @environment_config = BasicEnvironmentConfig.new(CaseInsensitiveString.new(@environment_name))
       @environment_config_service = double('environment-config-service')
       controller.stub(:environment_config_service).and_return(@environment_config_service)
-      @environment_config_service.stub(:forEdit).with(@environment_name).and_return(@environment_config)
+      @environment_config_service.stub(:getEnvironmentForEdit).with(@environment_name).and_return(@environment_config)
     end
 
     describe :for_admins do
@@ -96,7 +96,7 @@ describe ApiV1::Admin::EnvironmentsController do
         login_as_admin
 
         @environment_name = SecureRandom.hex
-        @environment_config_service.stub(:forEdit).and_raise(com.thoughtworks.go.config.exceptions.NoSuchEnvironmentException.new(CaseInsensitiveString.new('foo-env')))
+        @environment_config_service.stub(:getEnvironmentForEdit).and_raise(com.thoughtworks.go.config.exceptions.NoSuchEnvironmentException.new(CaseInsensitiveString.new('foo-env')))
         get_with_api_header :show, name: @environment_name
         expect(response).to have_api_message_response(404, 'Either the resource you requested was not found, or you are not authorized to perform this action.')
       end
@@ -164,7 +164,7 @@ describe ApiV1::Admin::EnvironmentsController do
       @entity_hashing_service = double('entity-hashing-see=rvice')
       controller.stub(:environment_config_service).and_return(@environment_config_service)
       controller.stub(:entity_hashing_service).and_return(@entity_hashing_service)
-      @environment_config_service.stub(:forEdit).with(@environment_name).and_return(@environment_config)
+      @environment_config_service.stub(:getEnvironmentForEdit).with(@environment_name).and_return(@environment_config)
       @entity_hashing_service.stub(:md5ForEntity).and_return(@md5)
     end
 
@@ -204,7 +204,7 @@ describe ApiV1::Admin::EnvironmentsController do
         login_as_admin
 
         @environment_name = SecureRandom.hex
-        @environment_config_service.stub(:forEdit).and_raise(com.thoughtworks.go.config.exceptions.NoSuchEnvironmentException.new(CaseInsensitiveString.new('foo-env')))
+        @environment_config_service.stub(:getEnvironmentForEdit).and_raise(com.thoughtworks.go.config.exceptions.NoSuchEnvironmentException.new(CaseInsensitiveString.new('foo-env')))
         put_with_api_header :put, name: @environment_name
         expect(response).to have_api_message_response(404, 'Either the resource you requested was not found, or you are not authorized to perform this action.')
       end
@@ -273,7 +273,7 @@ describe ApiV1::Admin::EnvironmentsController do
       @environment_config = BasicEnvironmentConfig.new(CaseInsensitiveString.new(@environment_name))
       @environment_config_service = double('environment-config-service')
       controller.stub(:environment_config_service).and_return(@environment_config_service)
-      @environment_config_service.stub(:forEdit).with(@environment_name).and_return(@environment_config)
+      @environment_config_service.stub(:getEnvironmentForEdit).with(@environment_name).and_return(@environment_config)
     end
 
     describe :for_admins do
@@ -310,7 +310,7 @@ describe ApiV1::Admin::EnvironmentsController do
         login_as_admin
 
         @environment_name = SecureRandom.hex
-        @environment_config_service.stub(:forEdit).and_raise(com.thoughtworks.go.config.exceptions.NoSuchEnvironmentException.new(CaseInsensitiveString.new('foo-env')))
+        @environment_config_service.stub(:getEnvironmentForEdit).and_raise(com.thoughtworks.go.config.exceptions.NoSuchEnvironmentException.new(CaseInsensitiveString.new('foo-env')))
         patch_with_api_header :patch, name: @environment_name
         expect(response).to have_api_message_response(404, 'Either the resource you requested was not found, or you are not authorized to perform this action.')
       end
@@ -374,7 +374,7 @@ describe ApiV1::Admin::EnvironmentsController do
       @environment_config = BasicEnvironmentConfig.new(CaseInsensitiveString.new(@environment_name))
       @environment_config_service = double('environment-config-service')
       controller.stub(:environment_config_service).and_return(@environment_config_service)
-      @environment_config_service.stub(:forEdit).with(@environment_name).and_return(@environment_config)
+      @environment_config_service.stub(:getEnvironmentForEdit).with(@environment_name).and_return(@environment_config)
     end
 
     describe :for_admins do
@@ -394,7 +394,7 @@ describe ApiV1::Admin::EnvironmentsController do
         login_as_admin
 
         @environment_name = SecureRandom.hex
-        @environment_config_service.stub(:forEdit).and_raise(com.thoughtworks.go.config.exceptions.NoSuchEnvironmentException.new(CaseInsensitiveString.new('foo-env')))
+        @environment_config_service.stub(:getEnvironmentForEdit).and_raise(com.thoughtworks.go.config.exceptions.NoSuchEnvironmentException.new(CaseInsensitiveString.new('foo-env')))
         delete_with_api_header :destroy, name: @environment_name
         expect(response).to have_api_message_response(404, 'Either the resource you requested was not found, or you are not authorized to perform this action.')
       end
@@ -458,7 +458,7 @@ describe ApiV1::Admin::EnvironmentsController do
       @environment_config = BasicEnvironmentConfig.new(CaseInsensitiveString.new(@environment_name))
       @environment_config_service = double('environment-config-service')
       controller.stub(:environment_config_service).and_return(@environment_config_service)
-      @environment_config_service.stub(:forEdit).with(@environment_name).and_return(@environment_config)
+      @environment_config_service.stub(:getEnvironmentForEdit).with(@environment_name).and_return(@environment_config)
     end
 
 

--- a/server/webapp/WEB-INF/rails.new/spec/controllers/api_v2/admin/environments_with_remote_controller_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/controllers/api_v2/admin/environments_with_remote_controller_spec.rb
@@ -28,8 +28,8 @@ describe ApiV2::Admin::EnvironmentsWithRemoteController do
       @environment_config_service = double('environment-config-service')
       controller.stub(:environment_config_service).and_return(@environment_config_service)
       display_element = com.thoughtworks.go.domain.ConfigElementForEdit.new(@environment_config, 'md5')
-      @environment_config_service.stub(:forDisplay).and_return(display_element)
-      @environment_config_service.stub(:forEdit).and_return(local)
+      @environment_config_service.stub(:getMergedEnvironmentForDisplay).and_return(display_element)
+      @environment_config_service.stub(:getEnvironmentForEdit).and_return(local)
     end
 
     describe :for_admins do
@@ -45,7 +45,7 @@ describe ApiV2::Admin::EnvironmentsWithRemoteController do
         login_as_admin
 
         @environment_name = SecureRandom.hex
-        @environment_config_service.stub(:forDisplay).and_raise(com.thoughtworks.go.config.exceptions.NoSuchEnvironmentException.new(CaseInsensitiveString.new('foo-env')))
+        @environment_config_service.stub(:getMergedEnvironmentForDisplay).and_raise(com.thoughtworks.go.config.exceptions.NoSuchEnvironmentException.new(CaseInsensitiveString.new('foo-env')))
         get_with_api_header :show, name: @environment_name
         expect(response).to have_api_message_response(404, 'Either the resource you requested was not found, or you are not authorized to perform this action.')
       end

--- a/server/webapp/WEB-INF/rails.new/spec/controllers/environments_controller_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/controllers/environments_controller_spec.rb
@@ -255,8 +255,8 @@ describe EnvironmentsController do
 
     it "should return error message and the response status code of the passed in result" do
       result = HttpLocalizedOperationResult.new()
-      @environment_service.should_receive(:forDisplay).with(@environment_name, an_instance_of(HttpLocalizedOperationResult)).and_return(com.thoughtworks.go.domain.ConfigElementForEdit.new(@environment,"md5"))
-      @environment_service.stub(:forEdit).and_return(@environment)
+      @environment_service.should_receive(:getMergedEnvironmentforDisplay).with(@environment_name, an_instance_of(HttpLocalizedOperationResult)).and_return(com.thoughtworks.go.domain.ConfigElementForEdit.new(@environment,"md5"))
+      @environment_service.stub(:getEnvironmentForEdit).and_return(@environment)
       @environment_service.should_receive(:getAllLocalPipelinesForUser).with(@user).and_return([])
       @environment_service.should_receive(:getAllRemotePipelinesForUserInEnvironment).with(@user,@environment).and_return([])
 
@@ -273,8 +273,8 @@ describe EnvironmentsController do
     end
 
     it "should return error message if environment name is blank" do
-      @environment_service.should_receive(:forDisplay).with(@environment_name, an_instance_of(HttpLocalizedOperationResult)).and_return(com.thoughtworks.go.domain.ConfigElementForEdit.new(@environment,"md5"))
-      @environment_service.stub(:forEdit).with(@environment_name).and_return(@environment)
+      @environment_service.should_receive(:getMergedEnvironmentforDisplay).with(@environment_name, an_instance_of(HttpLocalizedOperationResult)).and_return(com.thoughtworks.go.domain.ConfigElementForEdit.new(@environment,"md5"))
+      @environment_service.stub(:getEnvironmentForEdit).with(@environment_name).and_return(@environment)
       @environment_service.should_receive(:getAllLocalPipelinesForUser).with(@user).and_return([])
       @environment_service.should_receive(:getAllRemotePipelinesForUserInEnvironment).with(@user,@environment).and_return([])
 
@@ -287,7 +287,7 @@ describe EnvironmentsController do
     it "should return error occured while loading the environment for edit" do
       result = HttpLocalizedOperationResult.new()
 
-      @environment_service.should_receive(:forDisplay).with(any_args, any_args) do |name, result|
+      @environment_service.should_receive(:getMergedEnvironmentforDisplay).with(any_args, any_args) do |name, result|
         result.unprocessableEntity(LocalizedMessage.string("ENV_UPDATE_FAILED", @environment_name))
       end
 
@@ -301,8 +301,8 @@ describe EnvironmentsController do
 
     it "should successfully update environment" do
       result = HttpLocalizedOperationResult.new()
-      @environment_service.should_receive(:forDisplay).with(@environment_name, an_instance_of(HttpLocalizedOperationResult)).and_return(com.thoughtworks.go.domain.ConfigElementForEdit.new(@environment,"md5"))
-      @environment_service.stub(:forEdit).and_return(@environment)
+      @environment_service.should_receive(:getMergedEnvironmentforDisplay).with(@environment_name, an_instance_of(HttpLocalizedOperationResult)).and_return(com.thoughtworks.go.domain.ConfigElementForEdit.new(@environment,"md5"))
+      @environment_service.stub(:getEnvironmentForEdit).and_return(@environment)
       @environment_service.should_receive(:getAllLocalPipelinesForUser).with(@user).and_return([])
       @environment_service.should_receive(:getAllRemotePipelinesForUserInEnvironment).with(@user,@environment).and_return([])
       @environment_service.should_receive(:updateEnvironment).with(any_args,any_args,any_args,'md5',result) do |old_config, new_config, user, md5, result|
@@ -332,14 +332,14 @@ describe EnvironmentsController do
       entity_hashing_service.stub(:md5ForEntity).and_return('md5')
       environment_service.stub(:getEnvironmentConfig).with("environment_name").and_return(BasicEnvironmentConfig.new(CaseInsensitiveString.new("environment_name")))
 
-      environment_service.stub(:forEdit).with(any_args).and_return(BasicEnvironmentConfig.new)
+      environment_service.stub(:getEnvironmentForEdit).with(any_args).and_return(BasicEnvironmentConfig.new)
 
       result = HttpLocalizedOperationResult.new()
       environment_service.should_receive(:updateEnvironment).with(any_args,any_args,any_args,'md5',result) do |old_config, new_config, user, md5, result|
         result.setMessage(LocalizedMessage.composite([LocalizedMessage.string("UPDATE_ENVIRONMENT_SUCCESS",["foo_env"].to_java(java.lang.String)),LocalizedMessage.string("CONFIG_MERGED")].to_java(com.thoughtworks.go.i18n.Localizable)))
       end
 
-      environment_service.should_receive(:forDisplay).with(any_args,any_args).and_return(com.thoughtworks.go.domain.ConfigElementForEdit.new(BasicEnvironmentConfig.new(),"md5"))
+      environment_service.should_receive(:getMergedEnvironmentforDisplay).with(any_args,any_args).and_return(com.thoughtworks.go.domain.ConfigElementForEdit.new(BasicEnvironmentConfig.new(),"md5"))
       environment_service.should_receive(:getAllLocalPipelinesForUser).with(any_args).and_return([])
       environment_service.should_receive(:getAllRemotePipelinesForUserInEnvironment).with(any_args,any_args).and_return([])
 


### PR DESCRIPTION
contains a tiny fix as well for editing config-repo environments.

needs to be merged for release 17.2