### PR TITLE
Add build and out directories to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -142,3 +142,6 @@ tools/jruby
 tools/node_modules/
 tools/npm-debug.log
 plugin-infra/go-plugin-access/config/cipher
+
+build/
+out/


### PR DESCRIPTION
IntelliJ generates these directories as part of the default project import.