### PR TITLE
Reauth filter takes lock on session id

### DIFF
--- a/server/src/com/thoughtworks/go/server/security/ReAuthenticationFilter.java
+++ b/server/src/com/thoughtworks/go/server/security/ReAuthenticationFilter.java
@@ -43,12 +43,13 @@ public class ReAuthenticationFilter extends SpringSecurityFilter {
     protected void doFilterHttp(HttpServletRequest request, HttpServletResponse response, FilterChain chain) throws IOException, ServletException {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
 
+
         if (!systemEnvironment.isReAuthenticationEnabled() || (authentication == null)) {
             chain.doFilter(request, response);
             return;
         }
 
-        synchronized (request.getRequestedSessionId().intern()) {
+        synchronized (request.getSession().getId().intern()) {
             Long lastAuthenticationTime = (Long) request.getSession().getAttribute(LAST_REAUTHENICATION_CHECK_TIME);
             if (lastAuthenticationTime == null) {
                 request.getSession().setAttribute(LAST_REAUTHENICATION_CHECK_TIME, timeProvider.currentTimeMillis());

--- a/server/test/integration/com/thoughtworks/go/server/security/ReAuthenticationFilterTest.java
+++ b/server/test/integration/com/thoughtworks/go/server/security/ReAuthenticationFilterTest.java
@@ -68,7 +68,7 @@ public class ReAuthenticationFilterTest {
         filter = new ReAuthenticationFilter(systemEnvironment, timeProvider);
 
         stub(request.getSession()).toReturn(session);
-        stub(request.getRequestedSessionId()).toReturn("session_id");
+        stub(session.getId()).toReturn("session_id");
     }
 
     @Test


### PR DESCRIPTION
* Acquire lock on session id over requestedSessionId since API requests
  might not have requestedSessionId set.