### PR TITLE
Adjustments to the position of the console action bar

### DIFF
--- a/server/webapp/WEB-INF/rails.new/app/assets/javascripts/console_log_tailing.js
+++ b/server/webapp/WEB-INF/rails.new/app/assets/javascripts/console_log_tailing.js
@@ -64,8 +64,8 @@
 
         topActionBar.pinOnScroll({
           'z-index':      100,
-          top:            91,
-          requiredScroll: 250
+          top:            90,
+          requiredScroll: 233
         });
 
         bottomActionBar.pinOnScroll({

--- a/server/webapp/WEB-INF/rails.new/app/assets/javascripts/lib/jquery-pinOnScroll.js
+++ b/server/webapp/WEB-INF/rails.new/app/assets/javascripts/lib/jquery-pinOnScroll.js
@@ -48,17 +48,20 @@
   }
 
   function fixElement(element, options) {
-    var scroll     = $window.scrollTop();
-    var styleAttrs = existingStyleAttrs(element) || createStyleAttrs(element, options);
+    var scroll        = $window.scrollTop();
+    var styleAttrs    = existingStyleAttrs(element) || createStyleAttrs(element, options);
+    var parentElement = element.parent();
 
     if (scroll >= options.requiredScroll && options.top) {
       applyStyle(element, styleAttrs);
+      applyStyle(parentElement, { "padding-top": element.height() });
     } else if (scroll >= options.requiredScroll && options.bottomLimit) {
       applyStyle(element, $.extend({}, styleAttrs, {
         top: options.bottomLimit()
       }));
     } else {
       clearStyles(element);
+      clearStyles(parentElement);
     }
   }
 


### PR DESCRIPTION
Now that the page header is a fixed element again, the console action bar's positioning and scrolling are off. This PR contains fixes for both, and makes the scrolling action smoother by ensuring we take into account the height of the action bar when it becomes a fixed element. Making the scrolling smoother required changes to the pinOnScroll jquery plugin that I believe @ketan wrote; so, I'd love your feedback @ketan.

Before positioning fixes:
<img width="1101" alt="before" src="https://cloud.githubusercontent.com/assets/5726224/23078030/efd01a7e-f4fb-11e6-8b76-c0a30db1fcd6.png">

before making the scrolling smoother:
<img width="1124" alt="before_scroll" src="https://cloud.githubusercontent.com/assets/5726224/23078033/f2282172-f4fb-11e6-9673-db6a46bad31b.png">

End result:
<img width="1116" alt="after" src="https://cloud.githubusercontent.com/assets/5726224/23078059/fef843e6-f4fb-11e6-8b5e-068df4a898d5.png">


