### PR TITLE
Styling changes to the white console log theme

### DIFF
--- a/server/webapp/WEB-INF/rails.new/app/assets/stylesheets/css/build_detail.scss
+++ b/server/webapp/WEB-INF/rails.new/app/assets/stylesheets/css/build_detail.scss
@@ -301,7 +301,7 @@ div.build_detail_container_content {
 .console-area {
   background-color: #333;
   .white-theme & {
-    background-color: white;
+    background-color: #fdfdfd;
   }
 }
 
@@ -352,8 +352,9 @@ div.build_detail_container_content {
   }
 
   .white-theme & {
+    background-color: rgba(#fdfdfd, 0.85);
     div > a {
-      color: white;
+      color: #025695;
     }
   }
 
@@ -458,7 +459,7 @@ div.build_detail_container_content {
   color: white;
 
   .white-theme & {
-    background-color: white;
+    background-color: #fdfdfd;
     color: black;
   }
 


### PR DESCRIPTION
* Changed action bar colors to be more consistent with how the theme is handled in the darker theme
* Changed the white console log bg color to be an ever so off white to provide subtle separation (#fdfdfd as opposed to #ffffff)
* Changed action bar link colors to accommodate the bg color changes.

One thing I'm not 100% confident about is the link color for the actions in the action bar. I'm open for feedback on my choice of color.


Before:
<img width="1114" alt="screen shot 2017-02-17 at 11 14 40 am" src="https://cloud.githubusercontent.com/assets/5726224/23079648/a2218f0e-f502-11e6-8ca4-df159153cdc7.png">


After:
<img width="1144" alt="screen shot 2017-02-17 at 11 16 19 am" src="https://cloud.githubusercontent.com/assets/5726224/23079628/8f230e50-f502-11e6-802f-839b17507eac.png">



