### PR TITLE
Send console log from agent to server via websocket

### DIFF
--- a/agent/src/com/thoughtworks/go/agent/AgentWebSocketClientController.java
+++ b/agent/src/com/thoughtworks/go/agent/AgentWebSocketClientController.java
@@ -160,7 +160,7 @@ public class AgentWebSocketClientController extends AgentController {
         URLService urlService = new URLService();
         StreamConsumer buildConsole;
 
-        if (new SystemEnvironment().isConsoleLogsThroughWebsocketEnabled()) {
+        if (getSystemEnvironment().isConsoleLogsThroughWebsocketEnabled()) {
             buildConsole = new ConsoleOutputWebsocketTransmitter(webSocketSessionHandler, buildSettings.getBuildId());
         } else {
             buildConsole = new ConsoleOutputTransmitter(

--- a/agent/src/com/thoughtworks/go/agent/AgentWebSocketClientController.java
+++ b/agent/src/com/thoughtworks/go/agent/AgentWebSocketClientController.java
@@ -157,10 +157,8 @@ public class AgentWebSocketClientController extends AgentController {
 
     private void runBuild(BuildSettings buildSettings) {
         URLService urlService = new URLService();
-        ConsoleOutputTransmitter buildConsole = new ConsoleOutputTransmitter(
-                new RemoteConsoleAppender(
-                        urlService.prefixPartialUrl(buildSettings.getConsoleUrl()),
-                        httpService));
+        ConsoleOutputWebsocketTransmitter buildConsole = new ConsoleOutputWebsocketTransmitter(webSocketSessionHandler, buildSettings.getBuildId());
+
         ArtifactsRepository artifactsRepository = new UrlBasedArtifactsRepository(
                 httpService,
                 urlService.prefixPartialUrl(buildSettings.getArtifactUploadBaseUrl()),
@@ -187,11 +185,7 @@ public class AgentWebSocketClientController extends AgentController {
             getAgentRuntimeInfo().busy(new AgentBuildingInfo(buildSettings.getBuildLocatorForDisplay(), buildSettings.getBuildLocator()));
             build.build(buildSettings.getBuildCommand());
         } finally {
-            try {
-                buildConsole.stop();
-            } finally {
-                getAgentRuntimeInfo().idle();
-            }
+            getAgentRuntimeInfo().idle();
         }
         this.buildSession.set(null);
     }

--- a/agent/src/com/thoughtworks/go/agent/BuildRemoteRepositoryAdapter.java
+++ b/agent/src/com/thoughtworks/go/agent/BuildRemoteRepositoryAdapter.java
@@ -8,10 +8,7 @@ import com.thoughtworks.go.remote.AgentInstruction;
 import com.thoughtworks.go.remote.BuildRepositoryRemote;
 import com.thoughtworks.go.remote.work.Work;
 import com.thoughtworks.go.server.service.AgentRuntimeInfo;
-import com.thoughtworks.go.websocket.Action;
-import com.thoughtworks.go.websocket.Message;
-import com.thoughtworks.go.websocket.MessageEncoding;
-import com.thoughtworks.go.websocket.Report;
+import com.thoughtworks.go.websocket.*;
 
 class BuildRepositoryRemoteAdapter implements BuildRepositoryRemote {
     private JobRunner runner;
@@ -58,5 +55,11 @@ class BuildRepositoryRemoteAdapter implements BuildRepositoryRemote {
     @Override
     public String getCookie(AgentIdentifier identifier, String location) {
         throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void consumeLine(String line, JobIdentifier jobIdentifier) {
+        ConsoleTransmission consoleTransmission = new ConsoleTransmission(line, jobIdentifier);
+        webSocketSessionHandler.sendAndWaitForAcknowledgement(new Message(Action.consoleOut, MessageEncoding.encodeData(consoleTransmission)));
     }
 }

--- a/agent/src/com/thoughtworks/go/agent/ConsoleOutputWebsocketTransmitter.java
+++ b/agent/src/com/thoughtworks/go/agent/ConsoleOutputWebsocketTransmitter.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2017 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.agent;
+
+import com.thoughtworks.go.domain.JobIdentifier;
+import com.thoughtworks.go.server.service.AgentRuntimeInfo;
+import com.thoughtworks.go.util.command.StreamConsumer;
+import com.thoughtworks.go.websocket.Action;
+import com.thoughtworks.go.websocket.ConsoleTransmission;
+import com.thoughtworks.go.websocket.Message;
+import com.thoughtworks.go.websocket.MessageEncoding;
+
+public class ConsoleOutputWebsocketTransmitter implements StreamConsumer {
+    private WebSocketSessionHandler webSocketSessionHandler;
+    private String buildId;
+
+    public ConsoleOutputWebsocketTransmitter(WebSocketSessionHandler webSocketSessionHandler, String buildId) {
+        this.webSocketSessionHandler = webSocketSessionHandler;
+        this.buildId = buildId;
+    }
+
+    @Override
+    public void consumeLine(String line) {
+        ConsoleTransmission transmission = new ConsoleTransmission(line, buildId);
+        this.webSocketSessionHandler.sendAndWaitForAcknowledgement(new Message(Action.consoleOut, MessageEncoding.encodeData(transmission)));
+    }
+}

--- a/agent/test/unit/com/thoughtworks/go/agent/AgentWebSocketClientControllerTest.java
+++ b/agent/test/unit/com/thoughtworks/go/agent/AgentWebSocketClientControllerTest.java
@@ -156,7 +156,8 @@ public class AgentWebSocketClientControllerTest {
 
     @Test
     public void processAssignWorkAction() throws IOException, InterruptedException {
-        new SystemEnvironment().set(SystemEnvironment.WEBSOCKET_ENABLED, true);
+        SystemEnvironment env = new SystemEnvironment();
+        env.set(SystemEnvironment.WEBSOCKET_ENABLED, true);
         ArgumentCaptor<Message> argumentCaptor = ArgumentCaptor.forClass(Message.class);
         agentController = createAgentController();
         agentController.init();
@@ -175,6 +176,7 @@ public class AgentWebSocketClientControllerTest {
         assertThat(message2.getAcknowledgementId(), notNullValue());
         assertThat(message2.getAction(), is(Action.consoleOut));
         assertThat(message2.getData(), is(MessageEncoding.encodeData(new ConsoleTransmission("Sleeping for 0 milliseconds", new JobIdentifier()))));
+        env.set(SystemEnvironment.WEBSOCKET_ENABLED, false);
     }
 
     @Test

--- a/agent/test/unit/com/thoughtworks/go/agent/AgentWebSocketClientControllerTest.java
+++ b/agent/test/unit/com/thoughtworks/go/agent/AgentWebSocketClientControllerTest.java
@@ -157,7 +157,27 @@ public class AgentWebSocketClientControllerTest {
     @Test
     public void processAssignWorkAction() throws IOException, InterruptedException {
         SystemEnvironment env = new SystemEnvironment();
+        ArgumentCaptor<Message> argumentCaptor = ArgumentCaptor.forClass(Message.class);
+        agentController = createAgentController();
+        agentController.init();
+        agentController.process(new Message(Action.assignWork, MessageEncoding.encodeWork(new SleepWork("work1", 0))));
+        assertThat(agentController.getAgentRuntimeInfo().getRuntimeStatus(), is(AgentRuntimeStatus.Idle));
+
+        verify(webSocketSessionHandler, times(1)).sendAndWaitForAcknowledgement(argumentCaptor.capture());
+        verify(artifactsManipulator).setProperty(null, new Property("work1_result", "done"));
+
+        Message message = argumentCaptor.getAllValues().get(0);
+        assertThat(message.getAcknowledgementId(), notNullValue());
+        assertThat(message.getAction(), is(Action.ping));
+        assertThat(message.getData(), is(MessageEncoding.encodeData(agentController.getAgentRuntimeInfo())));
+
+    }
+
+    @Test
+    public void processAssignWorkActionWitConsoleLogsThroughhWebsockets() throws IOException, InterruptedException {
+        SystemEnvironment env = new SystemEnvironment();
         env.set(SystemEnvironment.WEBSOCKET_ENABLED, true);
+        env.set(SystemEnvironment.CONSOLE_LOGS_THROUGH_WEBSOCKET_ENABLED, true);
         ArgumentCaptor<Message> argumentCaptor = ArgumentCaptor.forClass(Message.class);
         agentController = createAgentController();
         agentController.init();
@@ -177,11 +197,14 @@ public class AgentWebSocketClientControllerTest {
         assertThat(message2.getAction(), is(Action.consoleOut));
         assertThat(message2.getData(), is(MessageEncoding.encodeData(new ConsoleTransmission("Sleeping for 0 milliseconds", new JobIdentifier()))));
         env.set(SystemEnvironment.WEBSOCKET_ENABLED, false);
+        env.set(SystemEnvironment.CONSOLE_LOGS_THROUGH_WEBSOCKET_ENABLED, false);
     }
 
     @Test
-    public void processBuildCommand() throws Exception {
+    public void processBuildCommandWithConsoleLogsThroughWebsockets() throws Exception {
         ArgumentCaptor<Message> currentStatusMessageCaptor = ArgumentCaptor.forClass(Message.class);
+        SystemEnvironment env = new SystemEnvironment();
+        env.set(SystemEnvironment.CONSOLE_LOGS_THROUGH_WEBSOCKET_ENABLED, true);
         when(agentRegistry.uuid()).thenReturn(agentUuid);
 
         agentController = createAgentController();
@@ -217,6 +240,46 @@ public class AgentWebSocketClientControllerTest {
         assertThat(message.getData(), is(MessageEncoding.encodeData(new Report(agentRuntimeInfo, "b001", JobState.Building, null))));
 
         Message jobCompletedMessage = currentStatusMessageCaptor.getAllValues().get(2);
+        assertThat(jobCompletedMessage.getAcknowledgementId(), notNullValue());
+        assertThat(jobCompletedMessage.getAction(), is(Action.reportCompleted));
+        assertThat(jobCompletedMessage.getData(), is(MessageEncoding.encodeData(new Report(agentRuntimeInfo, "b001", null, JobResult.Passed))));
+        env.set(SystemEnvironment.CONSOLE_LOGS_THROUGH_WEBSOCKET_ENABLED, false);
+
+    }
+
+    @Test
+    public void processBuildCommand() throws Exception {
+        ArgumentCaptor<Message> currentStatusMessageCaptor = ArgumentCaptor.forClass(Message.class);
+        when(agentRegistry.uuid()).thenReturn(agentUuid);
+
+        agentController = createAgentController();
+        agentController.init();
+        BuildSettings build = new BuildSettings();
+        build.setBuildId("b001");
+        build.setConsoleUrl("http://foo.bar/console");
+        build.setArtifactUploadBaseUrl("http://foo.bar/artifacts");
+        build.setPropertyBaseUrl("http://foo.bar/properties");
+        build.setBuildLocator("build1");
+        build.setBuildLocatorForDisplay("build1ForDisplay");
+        build.setBuildCommand(BuildCommand.compose(
+                BuildCommand.echo("building"),
+                BuildCommand.reportCurrentStatus(JobState.Building)));
+
+        agentController.process(new Message(Action.build, MessageEncoding.encodeData(build)));
+
+        assertThat(agentController.getAgentRuntimeInfo().getRuntimeStatus(), is(AgentRuntimeStatus.Idle));
+
+        AgentRuntimeInfo agentRuntimeInfo = cloneAgentRuntimeInfo(agentController.getAgentRuntimeInfo());
+        agentRuntimeInfo.busy(new AgentBuildingInfo("build1ForDisplay", "build1"));
+
+        verify(webSocketSessionHandler, times(2)).sendAndWaitForAcknowledgement(currentStatusMessageCaptor.capture());
+
+        Message message = currentStatusMessageCaptor.getAllValues().get(0);
+        assertThat(message.getAcknowledgementId(), notNullValue());
+        assertThat(message.getAction(), is(Action.reportCurrentStatus));
+        assertThat(message.getData(), is(MessageEncoding.encodeData(new Report(agentRuntimeInfo, "b001", JobState.Building, null))));
+
+        Message jobCompletedMessage = currentStatusMessageCaptor.getAllValues().get(1);
         assertThat(jobCompletedMessage.getAcknowledgementId(), notNullValue());
         assertThat(jobCompletedMessage.getAction(), is(Action.reportCompleted));
         assertThat(jobCompletedMessage.getData(), is(MessageEncoding.encodeData(new Report(agentRuntimeInfo, "b001", null, JobResult.Passed))));

--- a/agent/test/unit/com/thoughtworks/go/agent/AgentWebSocketClientControllerTest.java
+++ b/agent/test/unit/com/thoughtworks/go/agent/AgentWebSocketClientControllerTest.java
@@ -156,7 +156,6 @@ public class AgentWebSocketClientControllerTest {
 
     @Test
     public void processAssignWorkAction() throws IOException, InterruptedException {
-        SystemEnvironment env = new SystemEnvironment();
         ArgumentCaptor<Message> argumentCaptor = ArgumentCaptor.forClass(Message.class);
         agentController = createAgentController();
         agentController.init();
@@ -203,8 +202,7 @@ public class AgentWebSocketClientControllerTest {
     @Test
     public void processBuildCommandWithConsoleLogsThroughWebsockets() throws Exception {
         ArgumentCaptor<Message> currentStatusMessageCaptor = ArgumentCaptor.forClass(Message.class);
-        SystemEnvironment env = new SystemEnvironment();
-        env.set(SystemEnvironment.CONSOLE_LOGS_THROUGH_WEBSOCKET_ENABLED, true);
+        when(systemEnvironment.isConsoleLogsThroughWebsocketEnabled()).thenReturn(true);
         when(agentRegistry.uuid()).thenReturn(agentUuid);
 
         agentController = createAgentController();
@@ -243,8 +241,6 @@ public class AgentWebSocketClientControllerTest {
         assertThat(jobCompletedMessage.getAcknowledgementId(), notNullValue());
         assertThat(jobCompletedMessage.getAction(), is(Action.reportCompleted));
         assertThat(jobCompletedMessage.getData(), is(MessageEncoding.encodeData(new Report(agentRuntimeInfo, "b001", null, JobResult.Passed))));
-        env.set(SystemEnvironment.CONSOLE_LOGS_THROUGH_WEBSOCKET_ENABLED, false);
-
     }
 
     @Test

--- a/base/src/com/thoughtworks/go/util/SystemEnvironment.java
+++ b/base/src/com/thoughtworks/go/util/SystemEnvironment.java
@@ -184,6 +184,8 @@ public class SystemEnvironment implements Serializable, ConfigDirProvider {
     public static GoSystemProperty<Integer> GO_ENCRYPTION_API_MAX_REQUESTS = new GoIntSystemProperty("go.encryption.api.max.requests", 30);
 
     public static GoSystemProperty<Boolean> WEBSOCKET_ENABLED = new GoBooleanSystemProperty("go.agent.websocket.enabled", false);
+    public static GoSystemProperty<Boolean> CONSOLE_LOGS_THROUGH_WEBSOCKET_ENABLED = new GoBooleanSystemProperty("go.agent.console.logs.websocket.enabled", false);
+
     public static GoSystemProperty<Boolean> AUTO_REGISTER_LOCAL_AGENT_ENABLED = new GoBooleanSystemProperty("go.auto.register.local.agent.enabled", true);
     public static GoSystemProperty<Long> GO_WEBSOCKET_ACK_MESSAGE_TIMEOUT = new GoLongSystemProperty("go.websocket.ack.message.timeout", 300 * 1000L);
 
@@ -766,6 +768,10 @@ public class SystemEnvironment implements Serializable, ConfigDirProvider {
 
     public boolean isWebsocketEnabled() {
         return WEBSOCKET_ENABLED.getValue();
+    }
+
+    public boolean isConsoleLogsThroughWebsocketEnabled() {
+        return CONSOLE_LOGS_THROUGH_WEBSOCKET_ENABLED.getValue();
     }
 
     public boolean isAutoRegisterLocalAgentEnabled() {

--- a/base/src/com/thoughtworks/go/util/SystemEnvironment.java
+++ b/base/src/com/thoughtworks/go/util/SystemEnvironment.java
@@ -184,7 +184,7 @@ public class SystemEnvironment implements Serializable, ConfigDirProvider {
     public static GoSystemProperty<Integer> GO_ENCRYPTION_API_MAX_REQUESTS = new GoIntSystemProperty("go.encryption.api.max.requests", 30);
 
     public static GoSystemProperty<Boolean> WEBSOCKET_ENABLED = new GoBooleanSystemProperty("go.agent.websocket.enabled", false);
-    public static GoSystemProperty<Boolean> CONSOLE_LOGS_THROUGH_WEBSOCKET_ENABLED = new GoBooleanSystemProperty("go.agent.console.logs.websocket.enabled", false);
+    public static GoSystemProperty<Boolean> CONSOLE_LOGS_THROUGH_WEBSOCKET_ENABLED = new GoBooleanSystemProperty("go.agent.console.logs.websocket.enabled", true);
 
     public static GoSystemProperty<Boolean> AUTO_REGISTER_LOCAL_AGENT_ENABLED = new GoBooleanSystemProperty("go.auto.register.local.agent.enabled", true);
     public static GoSystemProperty<Long> GO_WEBSOCKET_ACK_MESSAGE_TIMEOUT = new GoLongSystemProperty("go.websocket.ack.message.timeout", 300 * 1000L);

--- a/base/src/com/thoughtworks/go/util/command/StreamConsumer.java
+++ b/base/src/com/thoughtworks/go/util/command/StreamConsumer.java
@@ -30,4 +30,6 @@ public interface StreamConsumer {
      * Called when the StreamPumper pumps a line from the Stream.
      */
     public void consumeLine(String line);
+
+    default public void stop() {};
 }

--- a/common/src/com/thoughtworks/go/buildsession/BuildSession.java
+++ b/common/src/com/thoughtworks/go/buildsession/BuildSession.java
@@ -245,7 +245,7 @@ public class BuildSession {
     }
 
     void println(String line) {
-        console.consumeLine(line);
+        getPublisher().consumeLine(line);
     }
 
     public void printlnWithPrefix(String line) {

--- a/common/src/com/thoughtworks/go/publishers/GoArtifactsManipulator.java
+++ b/common/src/com/thoughtworks/go/publishers/GoArtifactsManipulator.java
@@ -211,5 +211,4 @@ public class GoArtifactsManipulator {
         String consoleUrl = urlService.getUploadUrlOfAgent(jobIdentifier, getConsoleOutputFolderAndFileNameUrl());
         return new ConsoleOutputTransmitter(new RemoteConsoleAppender(consoleUrl, httpService));
     }
-
 }

--- a/common/src/com/thoughtworks/go/remote/BuildRepositoryRemote.java
+++ b/common/src/com/thoughtworks/go/remote/BuildRepositoryRemote.java
@@ -39,4 +39,6 @@ public interface BuildRepositoryRemote {
     boolean isIgnored(JobIdentifier jobIdentifier);
 
     String getCookie(AgentIdentifier identifier, String location);
+
+    void consumeLine(String line, JobIdentifier jobIdentifier);
 }

--- a/common/src/com/thoughtworks/go/remote/work/ConsoleOutputTransmitter.java
+++ b/common/src/com/thoughtworks/go/remote/work/ConsoleOutputTransmitter.java
@@ -18,6 +18,7 @@ package com.thoughtworks.go.remote.work;
 
 import com.thoughtworks.go.util.SystemEnvironment;
 import com.thoughtworks.go.util.command.StreamConsumer;
+import com.thoughtworks.go.websocket.ConsoleTransmission;
 import org.apache.commons.collections.buffer.CircularFifoBuffer;
 import org.apache.log4j.Logger;
 

--- a/common/src/com/thoughtworks/go/websocket/ConsoleTransmission.java
+++ b/common/src/com/thoughtworks/go/websocket/ConsoleTransmission.java
@@ -18,8 +18,8 @@ package com.thoughtworks.go.websocket;
 
 import com.google.gson.annotations.Expose;
 import com.thoughtworks.go.domain.JobIdentifier;
-import org.apache.commons.io.IOUtils;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.Serializable;
@@ -50,7 +50,7 @@ public class ConsoleTransmission implements Serializable, Transmission {
     }
 
     public InputStream getLineAsStream() throws IOException {
-        return IOUtils.toInputStream(getLine(), "UTF-8");
+        return new ByteArrayInputStream(getLine().getBytes());
     }
 
     public String getLine() {

--- a/common/src/com/thoughtworks/go/websocket/ConsoleTransmission.java
+++ b/common/src/com/thoughtworks/go/websocket/ConsoleTransmission.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2017 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.websocket;
+
+import com.google.gson.annotations.Expose;
+import com.thoughtworks.go.domain.JobIdentifier;
+import org.apache.commons.io.IOUtils;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.Serializable;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+import static java.lang.String.format;
+
+public class ConsoleTransmission implements Serializable, Transmission {
+    @Expose
+    private JobIdentifier jobIdentifier;
+    @Expose
+    private String line;
+    @Expose
+    private String buildId;
+    @Expose
+    private SimpleDateFormat dateFormat = new SimpleDateFormat("HH:mm:ss.SSS");
+
+
+    public ConsoleTransmission(String line, JobIdentifier jobIdentifier) {
+        this.line = line;
+        this.jobIdentifier = jobIdentifier;
+    }
+
+    public ConsoleTransmission(String line, String buildId) {
+        this.line = line;
+        this.buildId = buildId;
+    }
+
+    public InputStream getLineAsStream() throws IOException {
+        return IOUtils.toInputStream(getLine(), "UTF-8");
+    }
+
+    public String getLine() {
+        return format("%s %s\n", dateFormat.format(new Date()), line);
+    }
+
+    @Override
+    public JobIdentifier getJobIdentifier() {
+        return jobIdentifier;
+    }
+
+    @Override
+    public String getBuildId() {
+        return buildId;
+    }
+}

--- a/common/src/com/thoughtworks/go/websocket/Report.java
+++ b/common/src/com/thoughtworks/go/websocket/Report.java
@@ -24,7 +24,7 @@ import com.thoughtworks.go.server.service.AgentRuntimeInfo;
 
 import java.io.Serializable;
 
-public class Report implements Serializable {
+public class Report implements Serializable, Transmission {
     @Expose
     private String buildId;
     @Expose
@@ -59,6 +59,7 @@ public class Report implements Serializable {
         return jobState;
     }
 
+    @Override
     public JobIdentifier getJobIdentifier() {
         return jobIdentifier;
     }
@@ -108,6 +109,7 @@ public class Report implements Serializable {
                 '}';
     }
 
+    @Override
     public String getBuildId() {
         return buildId;
     }

--- a/common/src/com/thoughtworks/go/websocket/Transmission.java
+++ b/common/src/com/thoughtworks/go/websocket/Transmission.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 ThoughtWorks, Inc.
+ * Copyright 2017 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,10 +16,13 @@
 
 package com.thoughtworks.go.websocket;
 
-public enum Action {
-    assignWork,
-    cancelBuild,
-    ping,
-    reregister,
-    reportCurrentStatus, reportCompleted, reportCompleting, acknowledge, build, consoleOut, setCookie
+import com.google.gson.annotations.Expose;
+import com.thoughtworks.go.domain.JobIdentifier;
+
+/**
+ * Created by kierarad on 2/22/17.
+ */
+public interface Transmission {
+    public JobIdentifier getJobIdentifier();
+    public String getBuildId();
 }

--- a/common/src/com/thoughtworks/go/websocket/Transmission.java
+++ b/common/src/com/thoughtworks/go/websocket/Transmission.java
@@ -19,9 +19,6 @@ package com.thoughtworks.go.websocket;
 import com.google.gson.annotations.Expose;
 import com.thoughtworks.go.domain.JobIdentifier;
 
-/**
- * Created by kierarad on 2/22/17.
- */
 public interface Transmission {
     public JobIdentifier getJobIdentifier();
     public String getBuildId();

--- a/common/src/com/thoughtworks/go/work/DefaultGoPublisher.java
+++ b/common/src/com/thoughtworks/go/work/DefaultGoPublisher.java
@@ -29,6 +29,7 @@ import com.thoughtworks.go.remote.BuildRepositoryRemote;
 import com.thoughtworks.go.remote.work.ConsoleOutputTransmitter;
 import com.thoughtworks.go.server.service.AgentRuntimeInfo;
 import com.thoughtworks.go.util.GoConstants;
+import com.thoughtworks.go.util.SystemEnvironment;
 import com.thoughtworks.go.util.SystemUtil;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -77,7 +78,11 @@ public class DefaultGoPublisher implements GoPublisher {
 
     @Override
     public void consumeLine(String line) {
-        consoleOutputTransmitter.consumeLine(line);
+        if(new SystemEnvironment().isWebsocketEnabled()) {
+            remoteBuildRepository.consumeLine(line, jobIdentifier);
+        } else {
+            consoleOutputTransmitter.consumeLine(line);
+        }
     }
 
     public void flushToServer() {

--- a/common/src/com/thoughtworks/go/work/DefaultGoPublisher.java
+++ b/common/src/com/thoughtworks/go/work/DefaultGoPublisher.java
@@ -78,7 +78,8 @@ public class DefaultGoPublisher implements GoPublisher {
 
     @Override
     public void consumeLine(String line) {
-        if(new SystemEnvironment().isWebsocketEnabled()) {
+        SystemEnvironment env = new SystemEnvironment();
+        if(env.isWebsocketEnabled() && env.isConsoleLogsThroughWebsocketEnabled()) {
             remoteBuildRepository.consumeLine(line, jobIdentifier);
         } else {
             consoleOutputTransmitter.consumeLine(line);

--- a/common/test/unit/com/thoughtworks/go/agent/testhelpers/FakeBuildRepositoryRemote.java
+++ b/common/test/unit/com/thoughtworks/go/agent/testhelpers/FakeBuildRepositoryRemote.java
@@ -86,6 +86,11 @@ public class FakeBuildRepositoryRemote implements BuildRepositoryRemote {
         throw new UnsupportedOperationException("Not implemented");
     }
 
+    @Override
+    public void consumeLine(String line, JobIdentifier jobIdentifier) {
+
+    }
+
 
     public static void waitUntilBuildCompleted() throws InterruptedException {
         while (!isBuildCompleted()) {

--- a/common/test/unit/com/thoughtworks/go/remote/work/BuildRepositoryRemoteStub.java
+++ b/common/test/unit/com/thoughtworks/go/remote/work/BuildRepositoryRemoteStub.java
@@ -71,4 +71,9 @@ public class BuildRepositoryRemoteStub implements BuildRepositoryRemote {
     public String getCookie(AgentIdentifier identifier, String location) {
         throw new RuntimeException("implement me");
     }
+
+    @Override
+    public void consumeLine(String line, JobIdentifier jobIdentifier) {
+
+    }
 }

--- a/server/src/com/thoughtworks/go/remote/BuildRepositoryRemoteImpl.java
+++ b/server/src/com/thoughtworks/go/remote/BuildRepositoryRemoteImpl.java
@@ -138,6 +138,10 @@ public class BuildRepositoryRemoteImpl {
         }
     }
 
+    public void consumeLine(String line) {
+
+    }
+
     private interface ReportingAction {
         void call() throws Exception;
     }

--- a/server/src/com/thoughtworks/go/server/messaging/BuildRepositoryMessageProducer.java
+++ b/server/src/com/thoughtworks/go/server/messaging/BuildRepositoryMessageProducer.java
@@ -72,6 +72,10 @@ public class BuildRepositoryMessageProducer implements BuildRepositoryRemote {
         return buildRepository.getCookie(identifier, location);
     }
 
+    public void consumeLine(String line, JobIdentifier jobIdentifier) {
+        buildRepository.consumeLine(line);
+    }
+
     public void reportCompleted(AgentRuntimeInfo agentRuntimeInfo, JobIdentifier jobId, JobResult result) {
         long startTime = System.currentTimeMillis();
 

--- a/server/src/com/thoughtworks/go/server/websocket/AgentRemoteHandler.java
+++ b/server/src/com/thoughtworks/go/server/websocket/AgentRemoteHandler.java
@@ -23,17 +23,16 @@ import com.thoughtworks.go.remote.AgentInstruction;
 import com.thoughtworks.go.remote.BuildRepositoryRemote;
 import com.thoughtworks.go.server.service.AgentRuntimeInfo;
 import com.thoughtworks.go.server.service.AgentService;
+import com.thoughtworks.go.server.service.ConsoleService;
 import com.thoughtworks.go.server.service.JobInstanceService;
-import com.thoughtworks.go.websocket.Action;
-import com.thoughtworks.go.websocket.Message;
-import com.thoughtworks.go.websocket.MessageEncoding;
-import com.thoughtworks.go.websocket.Report;
+import com.thoughtworks.go.websocket.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
+import java.io.File;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -51,15 +50,17 @@ public class AgentRemoteHandler {
     private AgentService agentService;
     @Autowired
     private JobInstanceService jobInstanceService;
+    private ConsoleService consoleService;
 
     @Autowired
-    public AgentRemoteHandler(@Qualifier("buildRepositoryMessageProducer") BuildRepositoryRemote buildRepositoryRemote, AgentService agentService, JobInstanceService jobInstanceService) {
+    public AgentRemoteHandler(@Qualifier("buildRepositoryMessageProducer") BuildRepositoryRemote buildRepositoryRemote, AgentService agentService, JobInstanceService jobInstanceService, ConsoleService consoleService) {
         this.buildRepositoryRemote = buildRepositoryRemote;
         this.agentService = agentService;
         this.jobInstanceService = jobInstanceService;
+        this.consoleService = consoleService;
     }
 
-    public void process(Agent agent, Message msg) {
+    public void process(Agent agent, Message msg) throws Exception {
         try {
             processWithoutAcknowledgement(agent, msg);
         } finally {
@@ -67,7 +68,7 @@ public class AgentRemoteHandler {
         }
     }
 
-    public void processWithoutAcknowledgement(Agent agent, Message msg) {
+    public void processWithoutAcknowledgement(Agent agent, Message msg) throws Exception {
         switch (msg.getAction()) {
             case ping:
                 AgentRuntimeInfo info = MessageEncoding.decodeData(msg.getData(), AgentRuntimeInfo.class);
@@ -102,17 +103,22 @@ public class AgentRemoteHandler {
                 report = MessageEncoding.decodeData(msg.getData(), Report.class);
                 buildRepositoryRemote.reportCompleted(report.getAgentRuntimeInfo(), findJobIdentifier(report), report.getResult());
                 break;
+            case consoleOut:
+                ConsoleTransmission consoleTransmission = MessageEncoding.decodeData(msg.getData(), ConsoleTransmission.class);
+                File consoleLogFile = consoleService.consoleLogFile(findJobIdentifier(consoleTransmission));
+                consoleService.updateConsoleLog(consoleLogFile, consoleTransmission.getLineAsStream());
+                break;
             default:
                 throw new RuntimeException("Unknown action: " + msg.getAction());
         }
     }
 
-    private JobIdentifier findJobIdentifier(Report report) {
-        if (report.getJobIdentifier() != null) {
-            return report.getJobIdentifier();
+    private JobIdentifier findJobIdentifier(Transmission transmission) {
+        if (transmission.getJobIdentifier() != null) {
+            return transmission.getJobIdentifier();
         }
 
-        JobInstance instance = jobInstanceService.buildById(Long.valueOf(report.getBuildId()));
+        JobInstance instance = jobInstanceService.buildById(Long.valueOf(transmission.getBuildId()));
         return instance.getIdentifier();
     }
 

--- a/server/src/com/thoughtworks/go/server/websocket/AgentRemoteSocket.java
+++ b/server/src/com/thoughtworks/go/server/websocket/AgentRemoteSocket.java
@@ -43,7 +43,7 @@ public class AgentRemoteSocket implements Agent {
     }
 
     @OnWebSocketMessage
-    public void onMessage(InputStream input) {
+    public void onMessage(InputStream input) throws Exception {
         Message msg = MessageEncoding.decodeMessage(input);
         LOGGER.debug("{} message: {}", sessionName(), msg);
         handler.process(this, msg);

--- a/server/test/integration/com/thoughtworks/go/server/service/BuildAssignmentServiceIntegrationTest.java
+++ b/server/test/integration/com/thoughtworks/go/server/service/BuildAssignmentServiceIntegrationTest.java
@@ -696,7 +696,7 @@ public class BuildAssignmentServiceIntegrationTest {
     }
 
     @Test
-    public void shouldAssignMatchedJobToAgentsRegisteredInAgentRemoteHandler() {
+    public void shouldAssignMatchedJobToAgentsRegisteredInAgentRemoteHandler() throws Exception {
         AgentConfig agentConfig = AgentMother.remoteAgent();
         configHelper.addAgent(agentConfig);
         fixture.createPipelineWithFirstStageScheduled();
@@ -716,7 +716,7 @@ public class BuildAssignmentServiceIntegrationTest {
     }
 
     @Test
-    public void shouldNotAssignNoWorkToAgentsRegisteredInAgentRemoteHandler() {
+    public void shouldNotAssignNoWorkToAgentsRegisteredInAgentRemoteHandler() throws Exception {
         AgentConfig agentConfig = AgentMother.remoteAgent();
         configHelper.addAgent(agentConfig);
         fixture.createdPipelineWithAllStagesPassed();
@@ -731,7 +731,7 @@ public class BuildAssignmentServiceIntegrationTest {
     }
 
     @Test
-    public void shouldNotAssignDeniedAgentWorkToAgentsRegisteredInAgentRemoteHandler() {
+    public void shouldNotAssignDeniedAgentWorkToAgentsRegisteredInAgentRemoteHandler() throws Exception {
         AgentConfig agentConfig = AgentMother.remoteAgent();
         agentConfig.disable();
 
@@ -747,7 +747,7 @@ public class BuildAssignmentServiceIntegrationTest {
     }
 
     @Test
-    public void shouldOnlyAssignWorkToIdleAgentsRegisteredInAgentRemoteHandler() {
+    public void shouldOnlyAssignWorkToIdleAgentsRegisteredInAgentRemoteHandler() throws Exception {
         AgentConfig agentConfig = AgentMother.remoteAgent();
         configHelper.addAgent(agentConfig);
         fixture.createPipelineWithFirstStageScheduled();
@@ -771,7 +771,7 @@ public class BuildAssignmentServiceIntegrationTest {
     }
 
     @Test
-    public void shouldNotAssignWorkToCanceledAgentsRegisteredInAgentRemoteHandler() {
+    public void shouldNotAssignWorkToCanceledAgentsRegisteredInAgentRemoteHandler() throws Exception {
         AgentConfig agentConfig = AgentMother.remoteAgent();
         configHelper.addAgent(agentConfig);
         fixture.createPipelineWithFirstStageScheduled();
@@ -790,7 +790,7 @@ public class BuildAssignmentServiceIntegrationTest {
 
 
     @Test
-    public void shouldCallForReregisterIfAgentInstanceIsNotRegistered() {
+    public void shouldCallForReregisterIfAgentInstanceIsNotRegistered() throws Exception {
         AgentConfig agentConfig = AgentMother.remoteAgent();
         fixture.createPipelineWithFirstStageScheduled();
         AgentRuntimeInfo info = AgentRuntimeInfo.fromServer(agentConfig, true, "location", 1000000l, "OS", false);
@@ -807,7 +807,7 @@ public class BuildAssignmentServiceIntegrationTest {
     }
 
     @Test
-    public void shouldAssignAgentsWhenThereAreAgentsAreDisabledOrNeedReregister() {
+    public void shouldAssignAgentsWhenThereAreAgentsAreDisabledOrNeedReregister() throws Exception {
         fixture.createPipelineWithFirstStageScheduled();
 
         AgentConfig canceledAgentConfig = AgentMother.remoteAgent();

--- a/server/test/integration/com/thoughtworks/go/server/websocket/JobInstanceStatusMonitorTest.java
+++ b/server/test/integration/com/thoughtworks/go/server/websocket/JobInstanceStatusMonitorTest.java
@@ -129,7 +129,7 @@ public class JobInstanceStatusMonitorTest {
     }
 
     @Test
-    public void shouldSendCancelMessageIfJobIsCancelled() {
+    public void shouldSendCancelMessageIfJobIsCancelled() throws Exception {
         AgentConfig agentConfig = AgentMother.remoteAgent();
         configHelper.addAgent(agentConfig);
         fixture.createPipelineWithFirstStageScheduled();
@@ -156,7 +156,7 @@ public class JobInstanceStatusMonitorTest {
     }
 
     @Test
-    public void shouldSendCancelMessageIfJobIsRescheduled() {
+    public void shouldSendCancelMessageIfJobIsRescheduled() throws Exception {
         AgentConfig agentConfig = AgentMother.remoteAgent();
         configHelper.addAgent(agentConfig);
         fixture.createPipelineWithFirstStageScheduled();

--- a/server/test/unit/com/thoughtworks/go/server/websocket/AgentRemoteHandlerTest.java
+++ b/server/test/unit/com/thoughtworks/go/server/websocket/AgentRemoteHandlerTest.java
@@ -174,7 +174,7 @@ public class AgentRemoteHandlerTest {
         verify(consoleService).consoleLogFile(eq(jobIdentifier));
         ArgumentCaptor<InputStream> arg = ArgumentCaptor.forClass(InputStream.class);
         verify(consoleService).updateConsoleLog(eq(consoleFile), arg.capture());
-        assertThat(IOUtils.toString(arg.getValue(), "UTF-8"), containsString(consoleLine + "\n"));
+        assertThat(IOUtils.toString(arg.getValue()), containsString(consoleLine + "\n"));
     }
 
     @Test


### PR DESCRIPTION
 - Behind toggle existing websocket enabled toggle
 - BuildSession commands use the websocket to send console output as well
 - Ensure all console output sent via the websocket is properly formatted

In an effort to improve the responsiveness of console logs, this utilizes websockets to send console output to the server from the agent instead of buffering and appending it via HTTP PUT request. In other words, sending the console log output as the agent produces it.

This does not include any analysis or testing of the performance impact of using websockets.