### PR TITLE
Gear settings links should send you to the settings for the page you are on

### DIFF
--- a/server/src/com/thoughtworks/go/server/controller/JobController.java
+++ b/server/src/com/thoughtworks/go/server/controller/JobController.java
@@ -110,10 +110,12 @@ public class JobController {
 
     private ModelAndView getModelAndView(JobInstance jobDetail) throws Exception {
         final JobDetailPresentationModel presenter = presenter(jobDetail);
+        String pipelineName = jobDetail.getPipelineName();
         Map data = new HashMap();
         data.put("presenter", presenter);
         data.put("l", localizer);
-        data.put("isEditableViaUI", goConfigService.isPipelineEditableViaUI(jobDetail.getPipelineName()));
+        data.put("isEditableViaUI", goConfigService.isPipelineEditableViaUI(pipelineName));
+        data.put("templateName", goConfigService.getCurrentConfig().pipelineConfigByName(new CaseInsensitiveString(pipelineName)).getTemplateName());
         return new ModelAndView("build_detail/build_detail_page", data);
     }
 

--- a/server/webapp/WEB-INF/rails.new/app/controllers/stages_controller.rb
+++ b/server/webapp/WEB-INF/rails.new/app/controllers/stages_controller.rb
@@ -170,6 +170,7 @@ class StagesController < ApplicationController
       return
     end
 
+    @templateName = go_config_service.getCurrentConfig().pipelineConfigByName(CaseInsensitiveString.new(pipeline_name)).getTemplateName()
     @pipeline = pipeline_history_service.findPipelineInstance(pipeline_name, params[:pipeline_counter].to_i, @stage.getPipelineId(), current_user, result = HttpOperationResult.new)
     @lockedPipeline = pipeline_lock_service.lockedPipeline(pipeline_name)
   end

--- a/server/webapp/WEB-INF/rails.new/app/views/pipelines/_pipeline_header.html.erb
+++ b/server/webapp/WEB-INF/rails.new/app/views/pipelines/_pipeline_header.html.erb
@@ -8,7 +8,11 @@
 
     <% if @can_user_view_settings %>
         <div class="stage_detail_setting">
-          <%= link_to '', pipeline_edit_path(pipeline_name: @pipeline.getName(), current_tab: 'general'), class: 'icon16 setting' %>
+          <% if @templateName %>
+              <%= link_to '', admin_stage_edit_path(pipeline_name: @templateName, stage_name: @stage.getName() , current_tab: 'settings', stage_parent: 'templates'), class: 'icon16 setting' %>
+          <% else %>
+              <%= link_to '', admin_stage_edit_path(pipeline_name: @pipeline.getName(), stage_name: @stage.getName() , current_tab: 'settings', stage_parent: 'pipelines'), class: 'icon16 setting' %>
+          <% end %>
         </div>
     <% end %>
     <% if @lockedPipeline %>

--- a/server/webapp/WEB-INF/vm/shared/_job_details_breadcrumbs.vm
+++ b/server/webapp/WEB-INF/vm/shared/_job_details_breadcrumbs.vm
@@ -29,8 +29,17 @@
       <li class='last'><h1>$presenter.buildName</h1></li>
     </ul>
     #if($isEditableViaUI && ($userHasAdministratorRights || $userHasGroupAdministratorRights))
-      <div class="job_detail_setting"><a href="$req.getContextPath()/admin/pipelines/$presenter.pipelineName/general"
-                                         class="icon16 setting"></a></div>
+      #if($templateName)
+        <div class="job_detail_setting">
+          <a href="$req.getContextPath()/admin/templates/$templateName/stages/$presenter.stageName/job/$presenter.buildName/tasks"
+             class="icon16 setting"></a>
+        </div>
+      #else
+        <div class="job_detail_setting">
+          <a href="$req.getContextPath()/admin/pipelines/$presenter.pipelineName/stages/$presenter.stageName/job/$presenter.buildName/tasks"
+             class="icon16 setting"></a>
+        </div>
+      #end
     #end
   </div>
 </div>


### PR DESCRIPTION
* stage details page -> that stage's settings
* job details page -> that job's settings

Note: We were unsure what the behavior should be for pipelines with templates. We debated maintaining the original behavior (links would go to pipeline general tab) so that users wouldn't inadvertently update a template. However, we ultimately decided to keep the behavior the same for pipelines with and without templates. In both cases stage details links to stage settings and job details link to job settings. 

