### PR TITLE
Remove deprecated -XX:PermSize JVM option

### DIFF
--- a/development-utility/development-server/src/com/thoughtworks/go/server/DevelopmentServer.java
+++ b/development-utility/development-server/src/com/thoughtworks/go/server/DevelopmentServer.java
@@ -33,7 +33,7 @@ import static org.hibernate.cfg.Environment.GENERATE_STATISTICS;
  * @understands how to run a local development mode webserver so we can develop live
  * Set the following before running the main method:
  * Working directory: <project-path>/server
- * VM arguments: -Xms512m -Xmx1024m -XX:PermSize=400m -Djava.awt.headless=true
+ * VM arguments: -Xms512m -Xmx1024m -Djava.awt.headless=true
  * classpath: Use classpath of 'development-server'
  */
 

--- a/installers/go-server/osx/Info.plist
+++ b/installers/go-server/osx/Info.plist
@@ -60,8 +60,6 @@
                 <string>512</string>
                 <key>cruise.server.maxmem</key>
                 <string>1024</string>
-                <key>cruise.server.permgen</key>
-                <string>128</string>
                 <key>cruise.server.maxpermgen</key>
                 <string>256</string>
                 <key>cruise.server.lang</key>

--- a/installers/go-server/release/server.cmd
+++ b/installers/go-server/release/server.cmd
@@ -19,7 +19,6 @@ if not defined SERVER_DIR set SERVER_DIR=%cd%
 if not defined SERVER_MEM set SERVER_MEM=512m
 if not defined SERVER_MAX_MEM set SERVER_MAX_MEM=1024m
 if not defined SERVER_MAX_PERM_GEN set SERVER_MAX_PERM_GEN=256m
-if not defined SERVER_MIN_PERM_GEN set SERVER_MIN_PERM_GEN=128m
 if not defined GO_SERVER_PORT set GO_SERVER_PORT=8153
 if not defined GO_SERVER_SSL_PORT set GO_SERVER_SSL_PORT=8154
 if not defined JAVA_CMD set JAVA_CMD=%GO_SERVER_JAVA_HOME%\bin\java.exe
@@ -66,4 +65,4 @@ set OPTION=-client
 
 :done
 
-"%JAVA_CMD%" %OPTION% %YOURKIT% -Xms%SERVER_MEM% -Xmx%SERVER_MAX_MEM% -XX:PermSize=%SERVER_MIN_PERM_GEN% -XX:MaxMetaspaceSize=%SERVER_MAX_PERM_GEN% %JVM_DEBUG% %GC_LOG% %GO_SERVER_SYSTEM_PROPERTIES% -Duser.language=en -DJAVA_SYS_MON_TEMP_DIR="%SERVER_DIR%\tmp" -Dorg.eclipse.jetty.server.Request.maxFormContentSize=30000000 -Djruby.rack.request.size.threshold.bytes=30000000 -Duser.country=US -Dcruise.config.dir="%SERVER_DIR%\config" -Dcruise.config.file="%SERVER_DIR%\config\cruise-config.xml" -Dcruise.server.port=%GO_SERVER_PORT% -Dcruise.server.ssl.port=%GO_SERVER_SSL_PORT% -jar "%SERVER_DIR%\go.jar"
+"%JAVA_CMD%" %OPTION% %YOURKIT% -Xms%SERVER_MEM% -Xmx%SERVER_MAX_MEM% -XX:MaxMetaspaceSize=%SERVER_MAX_PERM_GEN% %JVM_DEBUG% %GC_LOG% %GO_SERVER_SYSTEM_PROPERTIES% -Duser.language=en -DJAVA_SYS_MON_TEMP_DIR="%SERVER_DIR%\tmp" -Dorg.eclipse.jetty.server.Request.maxFormContentSize=30000000 -Djruby.rack.request.size.threshold.bytes=30000000 -Duser.country=US -Dcruise.config.dir="%SERVER_DIR%\config" -Dcruise.config.file="%SERVER_DIR%\config\cruise-config.xml" -Dcruise.server.port=%GO_SERVER_PORT% -Dcruise.server.ssl.port=%GO_SERVER_SSL_PORT% -jar "%SERVER_DIR%\go.jar"

--- a/installers/go-server/release/server.sh
+++ b/installers/go-server/release/server.sh
@@ -73,7 +73,6 @@ SERVER_DIR="$(cd "$CWD" && pwd)"
 [ ! -z $SERVER_MEM ] || SERVER_MEM="512m"
 [ ! -z $SERVER_MAX_MEM ] || SERVER_MAX_MEM="1024m"
 [ ! -z $SERVER_MAX_PERM_GEN ] || SERVER_MAX_PERM_GEN="256m"
-[ ! -z $SERVER_MIN_PERM_GEN ] || SERVER_MIN_PERM_GEN="128m"
 [ ! -z $GO_SERVER_PORT ] || GO_SERVER_PORT="8153"
 [ ! -z $GO_SERVER_SSL_PORT ] || GO_SERVER_SSL_PORT="8154"
 [ ! -z "$SERVER_WORK_DIR" ] || SERVER_WORK_DIR="$SERVER_DIR"
@@ -171,7 +170,7 @@ if [ "$USE_URANDOM" != "false" ] && [ -e "/dev/urandom" ]; then
     SERVER_STARTUP_ARGS+=("-Djava.security.egd=file:/dev/./urandom")
 fi
 
-SERVER_STARTUP_ARGS+=("-Xms$SERVER_MEM" "-Xmx$SERVER_MAX_MEM" "-XX:PermSize=$SERVER_MIN_PERM_GEN" "-XX:MaxMetaspaceSize=$SERVER_MAX_PERM_GEN")
+SERVER_STARTUP_ARGS+=("-Xms$SERVER_MEM" "-Xmx$SERVER_MAX_MEM" "-XX:MaxMetaspaceSize=$SERVER_MAX_PERM_GEN")
 SERVER_STARTUP_ARGS+=("${JVM_DEBUG[@]}" "${GC_LOG[@]}" "${GO_SERVER_SYSTEM_PROPERTIES[@]}")
 SERVER_STARTUP_ARGS+=("-Duser.language=en" "-Djruby.rack.request.size.threshold.bytes=30000000")
 SERVER_STARTUP_ARGS+=("-Duser.country=US" "-Dcruise.config.dir=$GO_CONFIG_DIR" "-Dcruise.config.file=$GO_CONFIG_DIR/cruise-config.xml")

--- a/installers/go-server/win/config/wrapper-server.conf
+++ b/installers/go-server/win/config/wrapper-server.conf
@@ -52,20 +52,25 @@ set.JAVA_HOME=%GO_SERVER_JAVA_HOME%
 # Uncomment below to enable Agent GC logging
 # set.GC_LOG=-verbose:gc -Xloggc:%GC_LOG_LOCATION% -XX:+PrintGCTimeStamps -XX:+PrintTenuringDistribution -XX:+PrintGCDetails -XX:+PrintGC
 
+# These variables are expected to be overridden in another file. As
+# such, changing the indices of properties will likely cause the
+# overrides to break. It is recommended to set a dummy value for a
+# property that is removed, e.g. '-DreservedForFuture.X'.
 wrapper.java.additional.1=-Xms512m
 wrapper.java.additional.2=-Xmx1024m
-wrapper.java.additional.3=-XX:MaxMetaspaceSize=256m
-wrapper.java.additional.4=-Duser.language=en
-wrapper.java.additional.5=-Duser.country=US
-wrapper.java.additional.6="-Dcruise.config.dir=%CRUISE_SERVER_DIR%\config"
-wrapper.java.additional.7="-Dcruise.config.file=%CRUISE_SERVER_DIR%\config\cruise-config.xml"
-wrapper.java.additional.8=-DreservedForFuture.1
-wrapper.java.additional.9=-DreservedForFuture.2
-wrapper.java.additional.10="-DJAVA_SYS_MON_TEMP_DIR=%CRUISE_SERVER_DIR%\tmp"
-wrapper.java.additional.11=%JVM_DEBUG%
-wrapper.java.additional.12=%GC_LOG%
-wrapper.java.additional.13=-DreservedForFuture.4
-wrapper.java.additional.14=-DreservedForFuture.5
+wrapper.java.additional.3=-DreservedForFuture.6
+wrapper.java.additional.4=-XX:MaxMetaspaceSize=256m
+wrapper.java.additional.5=-Duser.language=en
+wrapper.java.additional.6=-Duser.country=US
+wrapper.java.additional.7="-Dcruise.config.dir=%CRUISE_SERVER_DIR%\config"
+wrapper.java.additional.8="-Dcruise.config.file=%CRUISE_SERVER_DIR%\config\cruise-config.xml"
+wrapper.java.additional.9=-DreservedForFuture.1
+wrapper.java.additional.10=-DreservedForFuture.2
+wrapper.java.additional.11="-DJAVA_SYS_MON_TEMP_DIR=%CRUISE_SERVER_DIR%\tmp"
+wrapper.java.additional.12=%JVM_DEBUG%
+wrapper.java.additional.13=%GC_LOG%
+wrapper.java.additional.14=-DreservedForFuture.4
+wrapper.java.additional.15=-DreservedForFuture.5
 
 #include config/wrapper-properties.conf
 

--- a/installers/go-server/win/config/wrapper-server.conf
+++ b/installers/go-server/win/config/wrapper-server.conf
@@ -54,19 +54,18 @@ set.JAVA_HOME=%GO_SERVER_JAVA_HOME%
 
 wrapper.java.additional.1=-Xms512m
 wrapper.java.additional.2=-Xmx1024m
-wrapper.java.additional.3=-XX:PermSize=128m
-wrapper.java.additional.4=-XX:MaxMetaspaceSize=256m
-wrapper.java.additional.5=-Duser.language=en
-wrapper.java.additional.6=-Duser.country=US
-wrapper.java.additional.7="-Dcruise.config.dir=%CRUISE_SERVER_DIR%\config"
-wrapper.java.additional.8="-Dcruise.config.file=%CRUISE_SERVER_DIR%\config\cruise-config.xml"
-wrapper.java.additional.9=-DreservedForFuture.1
-wrapper.java.additional.10=-DreservedForFuture.2
-wrapper.java.additional.11="-DJAVA_SYS_MON_TEMP_DIR=%CRUISE_SERVER_DIR%\tmp"
-wrapper.java.additional.12=%JVM_DEBUG%
-wrapper.java.additional.13=%GC_LOG%
-wrapper.java.additional.14=-DreservedForFuture.4
-wrapper.java.additional.15=-DreservedForFuture.5
+wrapper.java.additional.3=-XX:MaxMetaspaceSize=256m
+wrapper.java.additional.4=-Duser.language=en
+wrapper.java.additional.5=-Duser.country=US
+wrapper.java.additional.6="-Dcruise.config.dir=%CRUISE_SERVER_DIR%\config"
+wrapper.java.additional.7="-Dcruise.config.file=%CRUISE_SERVER_DIR%\config\cruise-config.xml"
+wrapper.java.additional.8=-DreservedForFuture.1
+wrapper.java.additional.9=-DreservedForFuture.2
+wrapper.java.additional.10="-DJAVA_SYS_MON_TEMP_DIR=%CRUISE_SERVER_DIR%\tmp"
+wrapper.java.additional.11=%JVM_DEBUG%
+wrapper.java.additional.12=%GC_LOG%
+wrapper.java.additional.13=-DreservedForFuture.4
+wrapper.java.additional.14=-DreservedForFuture.5
 
 #include config/wrapper-properties.conf
 

--- a/server-launcher/src/com/thoughtworks/go/server/launcher/GoMacLauncher.java
+++ b/server-launcher/src/com/thoughtworks/go/server/launcher/GoMacLauncher.java
@@ -71,7 +71,6 @@ public class GoMacLauncher extends JFrame {
 
         String startMem = System.getProperty("cruise.server.mem", "512");
         String maxMem = System.getProperty("cruise.server.maxmem", "1024");
-        String perm = System.getProperty("cruise.server.permgen", "128");
         String maxPerm = System.getProperty("cruise.server.maxpermgen", "256");
         String lang = System.getProperty("cruise.server.lang", "en");
         String country = System.getProperty("cruise.server.country", "US");
@@ -81,7 +80,6 @@ public class GoMacLauncher extends JFrame {
         arguments.add(java);
         arguments.add("-Xms" + startMem + "m");
         arguments.add("-Xmx" + maxMem + "m");
-        arguments.add("-XX:PermSize=" + perm + "m");
         arguments.add("-XX:MaxMetaspaceSize=" + maxPerm + "m");
         if (dbDebugMode) {
             arguments.add("-DDB_DEBUG_MODE=true");


### PR DESCRIPTION
The command line option `-XX:PermSize` has been removed in Java 8 and
is now ignored. Remove it from server launch scripts to avoid a JVM
warning.

Issue-Id: #3216