### PR TITLE
Handle pluggable task in template properly

### DIFF
--- a/config/config-api/src/com/thoughtworks/go/config/pluggabletask/PluggableTask.java
+++ b/config/config-api/src/com/thoughtworks/go/config/pluggabletask/PluggableTask.java
@@ -48,6 +48,7 @@ public class PluggableTask extends AbstractTask {
     public static final String TYPE = "pluggable_task";
     public static final String VALUE_KEY = "value";
     public static final String ERRORS_KEY = "errors";
+    public static final String PLUGGABLE_TASK_PREFIX = TYPE;
 
     @ConfigSubtag
     private PluginConfiguration pluginConfiguration = new PluginConfiguration();
@@ -170,7 +171,7 @@ public class PluggableTask extends AbstractTask {
 
     @Override
     public String getTaskType() {
-        return "pluggable_task_" + getPluginConfiguration().getId().replaceAll("[^a-zA-Z0-9_]", "_");
+        return PLUGGABLE_TASK_PREFIX + "_" + getPluginConfiguration().getId().replaceAll("[^a-zA-Z0-9_]", "_");
     }
 
     @Override

--- a/server/webapp/WEB-INF/rails.new/app/assets/stylesheets/css_sass/go-pages/admin/templates.sass
+++ b/server/webapp/WEB-INF/rails.new/app/assets/stylesheets/css_sass/go-pages/admin/templates.sass
@@ -1,3 +1,10 @@
+=clearfix()
+	&:before, &:after
+		content: ""
+		display: table
+	&:after
+		clear: both
+
 #templates
 	&.view
 		height: 400px
@@ -34,10 +41,10 @@
 			&:hover
 				background-color: #FEFEFE
 		li
+			@include clearfix
 			padding: 4px
 			border-bottom: 1px dotted #999
 			float: none
-			clear: both
 			.condition
 				background: #F6F6F6
 				padding: 3px
@@ -55,6 +62,41 @@
 			clear: both
 			color: #999999
 			.working_dir
-			.command, .arguments, .pipeline, .stage, .job, .source, .destination, .plugin-task-key, .plugin-name
+			.command, .arguments, .pipeline, .stage, .job, .source, .destination
 				color: #666666
 				font-weight: bold
+
+		.plugin-task
+			background-color: #f5f5f5
+			border-radius: 5px
+			padding: 10px
+			margin: 15px 0 3px
+			float: left
+			width: 100%
+
+			h5
+				margin-bottom: 10px
+
+			.plugin-name
+				font-weight: bold
+
+			.plugin-task-properties
+				.plugin-task-property
+					@include clearfix
+					margin-bottom: 15px
+
+					.plugin-task-key
+						float: left
+						width: 25%
+						margin-right: 3%
+						word-break: break-all
+
+						.plugin-task-key-name
+							font-weight: bold
+
+					.plugin-task-value
+						float: left
+						width: 60%
+						white-space: pre-wrap
+						word-break: break-all
+						color: #636363

--- a/server/webapp/WEB-INF/rails.new/app/assets/stylesheets/css_sass/go-pages/admin/templates.sass
+++ b/server/webapp/WEB-INF/rails.new/app/assets/stylesheets/css_sass/go-pages/admin/templates.sass
@@ -55,6 +55,6 @@
 			clear: both
 			color: #999999
 			.working_dir
-			.command, .arguments, .pipeline, .stage, .job, .source, .destination
+			.command, .arguments, .pipeline, .stage, .job, .source, .destination, .plugin-task-key, .plugin-name
 				color: #666666
 				font-weight: bold

--- a/server/webapp/WEB-INF/rails.new/app/helpers/config_view/config_view_helper.rb
+++ b/server/webapp/WEB-INF/rails.new/app/helpers/config_view/config_view_helper.rb
@@ -1,0 +1,19 @@
+module ConfigView
+  module ConfigViewHelper
+    def plugin_task_type task
+      task_view_service.getViewModel(task, "new").getTypeForDisplay()
+    end
+
+    def plugin_properties task
+      props = task.getPropertiesForDisplay().collect do |property|
+        [property.getName(), property.getValue()]
+      end
+
+      Hash[props]
+    end
+
+    def is_a_pluggable_task task
+      task.getTaskType().start_with?(com.thoughtworks.go.config.pluggabletask.PluggableTask::PLUGGABLE_TASK_PREFIX)
+    end
+  end
+end

--- a/server/webapp/WEB-INF/rails.new/app/views/config_view/templates/_job_view.html.erb
+++ b/server/webapp/WEB-INF/rails.new/app/views/config_view/templates/_job_view.html.erb
@@ -143,21 +143,19 @@
                             <code>
                                 <span><%= l.string('FETCH_TASK') %> - </span>
                                 <span title="<%= l.string('PIPELINE_NAME') %>" class="pipeline"><%= task.getPipelineName().blank? ? "[#{l.string('CURRENT_PIPELINE')}]" : task.getPipelineName() %></span>
-                                <span class='path_separator'>
-                                    >
-                                </span>
+                                <span class='path_separator'>&gt;</span>
                                 <span title="<%= l.string('STAGE_NAME') %>" class="stage"><%= task.getStage() %></span>
-                                <span class='path_separator'>
-                                    >
-                                </span>
+                                <span class='path_separator'>&gt;</span>
                                 <span title="<%= l.string('JOB_NAME') %>" class="job"><%= task.getJob() %></span>
                                 <span class='delimiter'>:</span>
                                 <span title="<%= l.string('SOURCE') %>" class="source"><%= task.getSrc() %></span>
-                                <span class="direction_arrow">
-                                    ->
-                                </span>
+                                <span class="direction_arrow">-&gt;</span>
                                 <span title="<%= l.string('DESTINATION') %>" class="destination"><%= task.getDest() %></span>
                             </code>
+                        <% elsif is_a_pluggable_task(task) %>
+                          <code>
+                            <%= render :partial => "config_view/templates/plugin_view.html", :locals => {:scope => {:task => task}} -%>
+                          </code>
                         <% else %>
                             <code>
                                 <% working_dir_title = (task.workingDirectory()==nil || task.workingDirectory() == '') ? "Working Directory": "Working Directory: " + task.workingDirectory()  %>
@@ -169,13 +167,20 @@
                         <% if task.hasCancelTask() %>
                             <ul>
                                 <li>
-                                    <code>
-                                        <% working_dir_title = (task.getTypeForDisplay() == "Fetch Artifact" || task.workingDirectory()==nil || task.workingDirectory() == '') ? "Working Directory": "Working Directory: " + task.workingDirectory() %>
+                                  <% if is_a_pluggable_task(task.cancelTask()) %>
+                                      <code>
+                                        <span class="on_cancel"> <%= l.string("ON_CANCEL") %></span>
+                                        <%= render :partial => "config_view/templates/plugin_view.html", :locals => {:scope => {:task => task.cancelTask()}} -%>
+                                      </code>
+                                  <% else %>
+                                      <code>
+                                        <% working_dir_title = (task.cancelTask().getTypeForDisplay() == "Fetch Artifact" || task.cancelTask().workingDirectory()==nil || task.cancelTask().workingDirectory() == '') ? "Working Directory": "Working Directory: " + task.cancelTask().workingDirectory() %>
                                         <span class="on_cancel"> <%= l.string("ON_CANCEL") %></span>
                                         <span class="working_dir" title="<%= working_dir_title %>"><%= "#{task.cancelTask().workingDirectory()}$" %></span>
                                         <span class="command"><%= task.cancelTask().command() %></span>
                                         <span class="arguments"><%= task.cancelTask().arguments() %></span>
-                                    </code>
+                                      </code>
+                                  <% end %>
                                 </li>
                             </ul>
                         <% end %>

--- a/server/webapp/WEB-INF/rails.new/app/views/config_view/templates/_plugin_view.html.erb
+++ b/server/webapp/WEB-INF/rails.new/app/views/config_view/templates/_plugin_view.html.erb
@@ -1,7 +1,13 @@
-<span>Plugin:</span>
-<span class="plugin-name"><%= plugin_task_type(scope[:task]) %></span>
-<span>- Properties - </span>
-<% plugin_properties(scope[:task]).each do |key, value| %>
-  <span class="plugin-task-key"><%= key %></span>
-  <span class="plugin-task-value"><%= value %></span>
-<% end %>
+<div class="plugin-task">
+  <h5>
+    Plugin: <span class="plugin-name"><%= plugin_task_type(scope[:task]) %></span>
+  </h5>
+  <div class="plugin-task-properties">
+    <% plugin_properties(scope[:task]).each do |key, value| %>
+        <div class="plugin-task-property">
+          <dt class="plugin-task-key">Property: <span class="plugin-task-key-name"><%= key %></span></dt>
+          <dd class="plugin-task-value"><%= value %></dd>
+        </div>
+    <% end %>
+  </div>
+</div>

--- a/server/webapp/WEB-INF/rails.new/app/views/config_view/templates/_plugin_view.html.erb
+++ b/server/webapp/WEB-INF/rails.new/app/views/config_view/templates/_plugin_view.html.erb
@@ -1,0 +1,7 @@
+<span>Plugin:</span>
+<span class="plugin-name"><%= plugin_task_type(scope[:task]) %></span>
+<span>- Properties - </span>
+<% plugin_properties(scope[:task]).each do |key, value| %>
+  <span class="plugin-task-key"><%= key %></span>
+  <span class="plugin-task-value"><%= value %></span>
+<% end %>


### PR DESCRIPTION
Will fix #1368 and #1585.

Here's a config which reproduces this (Go to "Templates" and click on "View" of the template):

```
<?xml version="1.0" encoding="utf-8"?>
<cruise xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="cruise-config.xsd" schemaVersion="89">
  <server artifactsdir="artifacts" agentAutoRegisterKey="041b5c7e-dab2-11e5-a908-13f95f3c6ef6" commandRepositoryLocation="default" serverId="dev-id" />
  <pipelines group="first">
    <pipeline name="up42">
      <materials>
        <hg url="../manual-testing/ant_hg/dummy" dest="dest_dir" materialName="dummyhg" />
      </materials>
      <stage name="up42_stage">
        <jobs>
          <job name="up42_job">
            <tasks>
              <exec command="ls" />
            </tasks>
          </job>
        </jobs>
      </stage>
    </pipeline>
  </pipelines>
  <templates>
    <pipeline name="Template1">
      <stage name="defaultStage">
        <jobs>
          <job name="defaultJob">
            <tasks>
              <fetchartifact pipeline="#{abc}" stage="#{abc}" job="#{abc}" srcdir="#{abc}" dest="#{abc}">
                <runif status="passed" />
                <oncancel>
                  <task>
                    <pluginConfiguration id="script-executor" version="1" />
                    <configuration>
                      <property>
                        <key>script</key>
                        <value>echo on-cancel-task</value>
                      </property>
                      <property>
                        <key>shtype</key>
                        <value>bash</value>
                      </property>
                    </configuration>
                  </task>
                </oncancel>
              </fetchartifact>
              <task>
                <pluginConfiguration id="script-executor" version="1" />
                <configuration>
                  <property>
                    <key>script</key>
                    <value>echo Multi&#xD;
echo Line&#xD;
echo Scripts</value>
                  </property>
                  <property>
                    <key>shtype</key>
                    <value>bash</value>
                  </property>
                </configuration>
                <runif status="passed" />
                <oncancel>
                  <exec command="ls" />
                </oncancel>
              </task>
            </tasks>
          </job>
        </jobs>
      </stage>
    </pipeline>
  </templates>
</cruise>
```

This works even if the plugin does not exist.

It looks like this:

![image](https://cloud.githubusercontent.com/assets/172235/23607281/4b4e1e64-028a-11e7-838a-80d72ff933de.png)
