### PR TITLE
Job Status Accessibility 

### DIFF
--- a/server/webapp/WEB-INF/rails.new/app/assets/new_stylesheets/shared/_go-variables.scss
+++ b/server/webapp/WEB-INF/rails.new/app/assets/new_stylesheets/shared/_go-variables.scss
@@ -57,6 +57,7 @@ $btn-hover: #666;
 $building: #ffc11b;
 $passed-icon: check;
 $failed-icon: exclamation-circle;
+$cancelled-icon: ban;
 
 // agents
 

--- a/server/webapp/WEB-INF/rails.new/app/assets/new_stylesheets/shared/_go-variables.scss
+++ b/server/webapp/WEB-INF/rails.new/app/assets/new_stylesheets/shared/_go-variables.scss
@@ -55,6 +55,8 @@ $passed: #00c853;
 $failed: #fa2d2d;
 $btn-hover: #666;
 $building: #ffc11b;
+$passed-icon: check;
+$failed-icon: exclamation-circle;
 
 // agents
 

--- a/server/webapp/WEB-INF/rails.new/app/assets/stylesheets/css/build_detail.scss
+++ b/server/webapp/WEB-INF/rails.new/app/assets/stylesheets/css/build_detail.scss
@@ -785,26 +785,26 @@ a.collapse-all {
 
 .sidebar_history .passed .color_code_small /* legacy velocity style */
 {
-  background: none;
-  background-image: image_url('g9/backgrounds/bg_status_gradient.png');
-  background-repeat: repeat-x;
-  background-color: #78c42d;
+  height: 14px;
+  width: 14px;
+  @include icon-before(check, 14px, 0);
+  color: #78c42d;
 }
 
 .sidebar_history .failed .color_code_small /* legacy velocity style */
 {
-  background: none;
-  background-image: image_url('g9/backgrounds/bg_status_gradient.png');
-  background-repeat: repeat-x;
-  background-color: #fa2d2d;
+  height: 14px;
+  width: 14px;
+  @include icon-before(exclamation-circle, 14px, 0);
+  color: #fa2d2d;
 }
 
 .sidebar_history .cancelled .color_code_small /* legacy velocity style */
 {
-  background: none;
-  background-image: image_url('g9/backgrounds/bg_status_diagonal.png');
-  background-repeat: repeat-x;
-  background-color: #ffc11b;
+  height: 14px;
+  width: 14px;
+  @include icon-before(ban, 14px, 0);
+  color: #ffc11b;
   text-align: center;
 }
 

--- a/server/webapp/WEB-INF/rails.new/app/assets/stylesheets/css/build_detail.scss
+++ b/server/webapp/WEB-INF/rails.new/app/assets/stylesheets/css/build_detail.scss
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 @import "css_sass/base/mixins";
+@import '_font-awesome-glyphs';
 
 #build_detail_summary_container .ab-corner {
   border-color: #FFF;
@@ -687,19 +688,21 @@ a.collapse-all {
 .cancelled h3 {
   background-color: #ffc11b;
   color: #000;
+  @include icon-after(ban, 16px, 0 0 0 10px);
 }
 
 .failed h3,
 .failing h3 {
   background-color: #fa2d2d;
   color: #fff;
+  @include icon-after(exclamation-circle, 16px, 0 0 0 10px);
 
 }
 
 .passed h3 {
   background-color: #78C42D;
   color: #fff;
-
+  @include icon-after(check, 16px, 0 0 0 10px);
 }
 
 .inactive h3,

--- a/server/webapp/WEB-INF/rails.new/app/assets/stylesheets/css/build_detail.scss
+++ b/server/webapp/WEB-INF/rails.new/app/assets/stylesheets/css/build_detail.scss
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+@import "../new_stylesheets/shared/go-variables";
 @import "css_sass/base/mixins";
 @import '_font-awesome-glyphs';
 
@@ -787,7 +788,7 @@ a.collapse-all {
 {
   height: 14px;
   width: 14px;
-  @include icon-before(check, 14px, 0);
+  @include icon-before($passed-icon, 14px, 0);
   color: #78c42d;
 }
 
@@ -795,7 +796,7 @@ a.collapse-all {
 {
   height: 14px;
   width: 14px;
-  @include icon-before(exclamation-circle, 14px, 0);
+  @include icon-before($failed-icon, 14px, 0);
   color: #fa2d2d;
 }
 

--- a/server/webapp/WEB-INF/rails.new/app/assets/stylesheets/module.scss
+++ b/server/webapp/WEB-INF/rails.new/app/assets/stylesheets/module.scss
@@ -2793,7 +2793,6 @@ li.task_property {
 }
 
 .vsm-entity.pipeline .stages li.Cancelled a {
-    background-image: image_url('g9/stage_bar_cancelled_icon.png');
     background-repeat: no-repeat;
     background-position: center;
 }

--- a/server/webapp/WEB-INF/rails.new/app/assets/stylesheets/new-theme.scss
+++ b/server/webapp/WEB-INF/rails.new/app/assets/stylesheets/new-theme.scss
@@ -601,7 +601,6 @@ h1.entity_title {
 
 #build_detail_summary_container.passed h3 {
   background-color: $passed;
-
 }
 
 .pipeline_bundle {

--- a/server/webapp/WEB-INF/rails.new/app/assets/stylesheets/new-theme.scss
+++ b/server/webapp/WEB-INF/rails.new/app/assets/stylesheets/new-theme.scss
@@ -1643,14 +1643,84 @@ input[type='submit'], input[type='submit']:hover, button.submit, button.submit:h
   }
 }
 
-.Passed {
+#new-pipeline-history {
+  .failed-stage, .passed-stage {
+    text-align: center;
+    color: white;
+  }
+}
+
+.Passed, #new-pipeline-history .passed-stage {
   background-image: none;
   background-color: $passed;
+
+  a {
+    @include icon-after($passed-icon, $margin: 0);
+  }
 }
 
 .Failed, #new-pipeline-history .failed-stage {
   background-image: none;
   background-color: $failed;
+
+  a {
+    @include icon-after($failed-icon, $margin: 0);
+  }
+}
+
+.Passed, .Failed {
+  a {
+    text-align: center;
+    text-indent: 0px;
+    color: white;
+    line-height: 0;
+    font-size: 12px;
+    span {
+      display: none;
+    }
+  }
+}
+
+#new-pipeline-history .passed-stage {
+  @include icon-before($passed-icon, 12px, 0);
+}
+
+#new-pipeline-history .failed-stage {
+  @include icon-before($failed-icon, 12px, 0);
+}
+
+.color_code, .color_code_small {
+  &.Passed, &.Failed {
+    height: 14px;
+    width: 14px;
+    background-color: inherit;
+    font-size: 14px;
+  }
+
+  &.Passed {
+    @include icon-before($passed-icon, $margin: 0);
+    color: $passed;
+  }
+
+  &.Failed {
+    @include icon-before($failed-icon, $margin: 0);
+    color: $failed;
+  }
+}
+
+.color_code_stage, a.stage_bar, div.stage_bar {
+  &.Passed, &.Failed {
+    color: white;
+    text-align: center;
+  }
+
+  &.Passed {
+    @include icon-before($passed-icon, $margin: 0);
+  }
+
+  &.Failed {
+    @include icon-before($failed-icon, $margin: 0);
+  }
 }
 
 .Cancelled, .cancelled-stage {
@@ -2918,7 +2988,6 @@ button.edit-environment {
     border-bottom: 1px dotted $border-color;
     padding:       6px 0;
     .color_code_small {
-      margin-top: 5px;
       &.Active, &.Cancelled {
         margin-top: 0;
       }

--- a/server/webapp/WEB-INF/rails.new/app/assets/stylesheets/new-theme.scss
+++ b/server/webapp/WEB-INF/rails.new/app/assets/stylesheets/new-theme.scss
@@ -1728,8 +1728,6 @@ a:link#link-to-this-page, a:visited#link-to-this-page {
 
 .sidebar_history .passed .color_code_small {
   background-image: none !important;
-  background-color: $passed;
-
 }
 
 #buildlist-container .buildlist li.current a, #buildlist-container .buildlist li.current a:hover {

--- a/server/webapp/WEB-INF/rails.new/app/assets/stylesheets/new-theme.scss
+++ b/server/webapp/WEB-INF/rails.new/app/assets/stylesheets/new-theme.scss
@@ -1644,8 +1644,11 @@ input[type='submit'], input[type='submit']:hover, button.submit, button.submit:h
 }
 
 #new-pipeline-history {
-  .failed-stage, .passed-stage {
+  .failed-stage, .passed-stage, .cancelled-stage {
     text-align: center;
+  }
+
+  .failed-stage, .passed-stage {
     color: white;
   }
 }
@@ -1668,7 +1671,13 @@ input[type='submit'], input[type='submit']:hover, button.submit, button.submit:h
   }
 }
 
-.Passed, .Failed {
+.Cancelled, #new-pipeline-history .cancelled-stage {
+  a {
+    @include icon-after($cancelled-icon, $margin: 0);
+  }
+}
+
+.Passed, .Failed, .Cancelled {
   a {
     text-align: center;
     text-indent: 0px;
@@ -1681,6 +1690,12 @@ input[type='submit'], input[type='submit']:hover, button.submit, button.submit:h
   }
 }
 
+.Cancelled {
+  a {
+    color: black;
+  }
+}
+
 #new-pipeline-history .passed-stage {
   @include icon-before($passed-icon, 12px, 0);
 }
@@ -1689,8 +1704,12 @@ input[type='submit'], input[type='submit']:hover, button.submit, button.submit:h
   @include icon-before($failed-icon, 12px, 0);
 }
 
+#new-pipeline-history .cancelled-stage {
+  @include icon-before($cancelled-icon, 12px, 0);
+}
+
 .color_code, .color_code_small {
-  &.Passed, &.Failed {
+  &.Passed, &.Failed, &.Cancelled {
     height: 14px;
     width: 14px;
     background-color: inherit;
@@ -1706,20 +1725,31 @@ input[type='submit'], input[type='submit']:hover, button.submit, button.submit:h
     @include icon-before($failed-icon, $margin: 0);
     color: $failed;
   }
+
+  &.Cancelled {
+    @include icon-before($cancelled-icon, $margin: 0);
+    color: $building;
+  }
 }
 
 .color_code_stage, a.stage_bar, div.stage_bar {
-  &.Passed, &.Failed {
-    color: white;
+  &.Passed, &.Failed, &.Cancelled {
     text-align: center;
   }
 
   &.Passed {
+    color: white;
     @include icon-before($passed-icon, $margin: 0);
   }
 
   &.Failed {
+    color: white;
     @include icon-before($failed-icon, $margin: 0);
+  }
+
+  &.Cancelled {
+    color: black;
+    @include icon-before($cancelled-icon, $margin: 0);
   }
 }
 

--- a/server/webapp/WEB-INF/rails.new/app/assets/stylesheets/vm/structure_for_old_ui.scss
+++ b/server/webapp/WEB-INF/rails.new/app/assets/stylesheets/vm/structure_for_old_ui.scss
@@ -1129,7 +1129,7 @@ table{
   {
     display: inline-block;
     height: 1%;
-  }  
+  }
 }
 
 

--- a/server/webapp/WEB-INF/rails.new/app/views/comparison/_modal_timeline.html.erb
+++ b/server/webapp/WEB-INF/rails.new/app/views/comparison/_modal_timeline.html.erb
@@ -16,7 +16,7 @@
                                     <% pim.getStageHistory().each do |sim_for_pipeline| %>
                                         <div style='width: <%= stage_width_em(pim.numberOfStages(), false, 10.9) %>' class="stage inline">
                                             <div class="stage_bar_wrapper">
-                                                <div <%= stage_bar_options(sim_for_pipeline) -%>><%= check_for_cancelled_contents(sim_for_pipeline.getState()) %><span><span></span></span> </div>
+                                                <div <%= stage_bar_options(sim_for_pipeline) -%>><span><span></span></span> </div>
                                             </div>
                                         </div>
                                     <% end %>

--- a/server/webapp/WEB-INF/rails.new/app/views/comparison/_pipeline_instances_drop_down.html.erb
+++ b/server/webapp/WEB-INF/rails.new/app/views/comparison/_pipeline_instances_drop_down.html.erb
@@ -9,12 +9,12 @@
                 <div style='width: <%= stage_width_percent(pipeline_instance.numberOfStages(), false, 95) %>' class="stage">
                     <div class="stage_bar_wrapper">
                         <% if placeholder_stage?(sim_for_pipeline) %>
-                            <div <%= scope[:html_options] -%>><%= check_for_cancelled_contents(sim_for_pipeline.getState()) %></div>
+                            <div <%= scope[:html_options] -%>></div>
                         <% elsif pipeline_instance.isBisect() %>
                             <div class="text_in_dropdown disabled_text_in_dropdown"><%= l.string("BISECT_TRIGGERED_PIPELINE") %></div>
                         <% else %>
                             <a href="<%= pipeline_compare_href(scope[:pipeline_name], scope[:fixed_pipeline_counter], pipeline_instance.getCounter()) -%>" <%= scope[:html_options] -%> id="<%= "stage_detail_#{scope[:suffix]}_#{pipeline_instance.getCounter()}" %>">
-                                <%= check_for_cancelled_contents(sim_for_pipeline.getState()) %><span><span></span></span>
+                                <span><span></span></span>
                             </a>
                         <% end %>
                     </div>

--- a/server/webapp/WEB-INF/rails.new/app/views/comparison/_stage_bar.html.erb
+++ b/server/webapp/WEB-INF/rails.new/app/views/comparison/_stage_bar.html.erb
@@ -3,11 +3,10 @@
     <div style='width: <%= stage_width_percent(scope[:pipeline].numberOfStages(), false, 97) %>' class="stage">
         <div class="stage_bar_wrapper">
             <% if placeholder_stage?(sim_for_pipeline) %>
-                <div <%= scope[:html_options] -%>><%= check_for_cancelled_contents(sim_for_pipeline.getState()) %><span><span></span></span></div>
+                <div <%= scope[:html_options] -%>><span><span></span></span></div>
             <% else %>
                 <a href="<%= scope[:disable_stage_bar_href] ? '#' : stage_detail_tab_path(:pipeline_name => scope[:pipeline].getName(), :pipeline_counter => scope[:pipeline].getCounter(), :stage_name => sim_for_pipeline.getName(), :stage_counter => sim_for_pipeline.getCounter()) -%>">
                     <div <%= scope[:html_options] -%>>
-                        <%= check_for_cancelled_contents(sim_for_pipeline.getState()) %>
                     </div>
                   <span><span></span></span></a>
             <% end %>

--- a/server/webapp/WEB-INF/rails.new/app/views/pipelines/_pipeline_stage_bar.html.erb
+++ b/server/webapp/WEB-INF/rails.new/app/views/pipelines/_pipeline_stage_bar.html.erb
@@ -35,10 +35,9 @@
 <% scope[:stage_bar_html_options] = stage_bar_options(scope[:stage_in_status_bar]) %>
 <div class="stage_bar_wrapper">
     <% if placeholder_stage?(scope[:stage_in_status_bar]) %>
-        <div <%= scope[:stage_bar_html_options] -%>><%= check_for_cancelled_contents(scope[:stage_in_status_bar].getState()) %></div>
+        <div <%= scope[:stage_bar_html_options] -%>></div>
     <% else %>
         <a href="<%= stage_bar_url(scope[:stage_in_status_bar], scope[:stage_details_action]) -%>" <%= scope[:stage_bar_html_options] -%>>
-            <%= check_for_cancelled_contents(scope[:stage_in_status_bar].getState()) %>
         <span><span></span></span></a>
     <% end %>
 </div>

--- a/server/webapp/WEB-INF/rails.new/app/views/pipelines/_previously_blurb.html.erb
+++ b/server/webapp/WEB-INF/rails.new/app/views/pipelines/_previously_blurb.html.erb
@@ -11,7 +11,6 @@
                 <a class="result" href="<%= stage_detail_path_for_identifier(scope[:previous_stage_identifier], :only_path => !scope[:rendering_gadget]) -%>" <%== scope[:rendering_gadget] ? "target='_blank'" : "" -%>
                    title="<%= scope[:previous_stage_identifier].getPipelineLabel() -%>">
                     <span class="color_code_small <%= scope[:stage_result] -%>">
-                        <%= check_for_cancelled_contents(scope[:stage_result]) %>
                     </span> <%= scope[:stage_result] -%>
                 </a>
             </div>

--- a/server/webapp/WEB-INF/rails.new/app/views/shared/_bare_stage.html.erb
+++ b/server/webapp/WEB-INF/rails.new/app/views/shared/_bare_stage.html.erb
@@ -5,5 +5,4 @@
 <div class="stage_bar <%= scope[:state] %>"
      title="<%= "%s (%s)" % [scope[:stage_name], scope[:state]] %>"
      style='width: <%= stage_width_em(scope[:pipeline].getStageHistory().size(), false, scope[:total_width]) %>'>
-    <%= check_for_cancelled_contents(scope[:state]) -%>
 </div>

--- a/server/webapp/WEB-INF/rails.new/app/views/shared/_stage.html.erb
+++ b/server/webapp/WEB-INF/rails.new/app/views/shared/_stage.html.erb
@@ -5,6 +5,6 @@
 %>
 <div class="stage_bar_wrapper <%= scope[:last_run_stage] ? " last_run_stage" : "" -%>">
     <div class="stage_bar <%= scope[:state] -%>" title="<%= "%s (%s)" % [scope[:stage_name], scope[:state]] -%>" data-stage="<%= scope[:stage_name] %>" style='width: <%= stage_width_em(scope[:pipeline].getStageHistory().size(), scope[:last_run_stage], scope[:total_width]) -%>'>
-        <%= check_for_cancelled_contents(scope[:state]) -%> <span><span></span></span>
+      <span><span></span></span>
     </div>
 </div>

--- a/server/webapp/WEB-INF/rails.new/app/views/stages/_job_listing.html.erb
+++ b/server/webapp/WEB-INF/rails.new/app/views/stages/_job_listing.html.erb
@@ -14,7 +14,6 @@
         </td>
         <td class="job_result">
             <div class="color_code_small <%= l.string(job.getStatus()) -%>">
-                <%= check_for_cancelled_contents(job.getStatus()) %>
             </div>
             <%- if job.isRerun() -%>
                 <img class="rerun_job_icon" src="<%=image_path('g9/icons/icon_rerun_flag.png')%>">

--- a/server/webapp/WEB-INF/rails.new/app/views/stages/_jobs_breakdown.html.erb
+++ b/server/webapp/WEB-INF/rails.new/app/views/stages/_jobs_breakdown.html.erb
@@ -5,7 +5,6 @@
             <li class="job">
                 <a class="" href="<%= url_for_job(job_in_job_breakdown) %>">
                     <div class="color_code_small <%= job_in_job_breakdown.getStatus() -%>">
-                        <%= check_for_cancelled_contents(job_in_job_breakdown.getStatus()) %>
                     </div>
                     <span class="wrapped_word"> <%= job_in_job_breakdown.getName() %> </span>
                 </a>

--- a/server/webapp/WEB-INF/rails.new/app/views/stages/_stage_history.html.erb
+++ b/server/webapp/WEB-INF/rails.new/app/views/stages/_stage_history.html.erb
@@ -24,7 +24,6 @@
             <a class="<%= is_current_stage?(stage_id_in_stage_history = stage_in_stage_history.getIdentifier()) ? "selected alert" : "" %>" href="<%= tab_aware_path_for_stage stage_id_in_stage_history, scope[:tab] %>">
                 <div class="label_counter_wrapper">
                     <div class="color_code_stage <%= stage_in_stage_history.getState() -%> <%= stage_in_stage_history.hasRerunJobs() ? "has_rerun_jobs" : "has_no_rerun_jobs" -%>">
-                        <%= check_for_cancelled_contents(stage_in_stage_history.getState()) %>
                       <span><span></span></span>
                     </div>
                     <%- if stage_in_stage_history.hasRerunJobs() -%>

--- a/server/webapp/WEB-INF/rails.new/app/views/stages/_stage_result.html.erb
+++ b/server/webapp/WEB-INF/rails.new/app/views/stages/_stage_result.html.erb
@@ -1,2 +1,2 @@
-<div class="color_code <%= scope[:state] %>"><%= check_for_cancelled_contents(scope[:state]) %></div>
+<div class="color_code <%= scope[:state] %>"></div>
 <span class="message" style="float:right; padding: 0;"><%= l.string(scope[:state]) %></span>

--- a/server/webapp/WEB-INF/rails.new/spec/views/stages/_stage_history_html_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/views/stages/_stage_history_html_spec.rb
@@ -216,7 +216,7 @@ describe "_stage_history.html.erb" do
     top_of_this_page = double('top_of_this_page')
     top_of_this_page.should_receive(:getConfigVersion).exactly(3).times.and_return('some-old-config-version')
     top_of_this_page.should_receive(:getIdentifier).exactly(7).times.and_return(StageIdentifier.new('p1', java.lang.Integer.new(1), 'label1', 'stage', '1'))
-    top_of_this_page.should_receive(:getState).twice.and_return(StageState::Building)
+    top_of_this_page.should_receive(:getState).and_return(StageState::Building)
     top_of_this_page.should_receive(:hasRerunJobs).twice.and_return(false)
 
     stage_history_page.should_receive(:getImmediateChronologicallyForwardStageHistoryEntry).and_return(bottom_of_previous_page)
@@ -239,7 +239,7 @@ describe "_stage_history.html.erb" do
     top_of_this_page = double('top_of_this_page')
     top_of_this_page.should_receive(:getConfigVersion).twice.and_return('some-old-config-version')
     top_of_this_page.should_receive(:getIdentifier).exactly(5).times.and_return(StageIdentifier.new('p1', java.lang.Integer.new(1), 'label1', 'stage', '1'))
-    top_of_this_page.should_receive(:getState).twice.and_return(StageState::Building)
+    top_of_this_page.should_receive(:getState).and_return(StageState::Building)
     top_of_this_page.should_receive(:hasRerunJobs).twice.and_return(false)
 
     stage_history_page.should_receive(:getImmediateChronologicallyForwardStageHistoryEntry).and_return(bottom_of_previous_page)

--- a/server/webapp/WEB-INF/vm/pipeline/_pipeline_history_list_jstemplate.vm
+++ b/server/webapp/WEB-INF/vm/pipeline/_pipeline_history_list_jstemplate.vm
@@ -138,9 +138,6 @@
                         {/if}
                         {if stage.scheduled == 'true'}
                             <div id="stage-detail-${% pipeline.counterOrLabel %}-${% stage.stageName %}" class="${% pipelineHistoryPage.getState(stage.stageStatus) %}-stage">
-                             {if stage.stageStatus == 'Cancelled'}
-                                <img alt="" src="$req.getContextPath()/$concatenatedStageBarCancelledIconFilePath">
-                             {/if}
                                 {if stage.getCanRun == 'true'}
                                 <a id="rerun-${% data.pipelineName %}-${% pipeline.counterOrLabel %}-${% stage.stageName %}" class="rerun" title="rerun this stage"
                                         href="javascript:stageActions.runStage('${% data.pipelineName %}', '${% pipeline.counterOrLabel %}', '${% stage.stageName %}');">Re-run</a>


### PR DESCRIPTION
Currently, the main signifier of the status of a job is the color. Using color as the primary signifier makes the job details page less accessible to colorblind folks. The red and green that's used to signify failed or passed are hard to differentiate for the colorblind. Bellow are screenshots of the passed and failed colors with a colorblind simulation filter applied.

Passed:
<img width="1376" alt="passed" src="https://cloud.githubusercontent.com/assets/5726224/23631708/1dcb3a0a-0274-11e7-955c-bc39bb267985.png">

Failed
<img width="1377" alt="failed" src="https://cloud.githubusercontent.com/assets/5726224/23631725/27cf10ee-0274-11e7-8b1b-dfb4fbb12d17.png">


The changes in this PR add symbolic signifiers to the job details page to indicate the status of the job. This will help quickly signify the status of the job without solely relying on colors. Bellow are screenshots of what the ui looks like with my changes (with the same colorblind simulation filter applied as above).

Passed:
<img width="1380" alt="pass" src="https://cloud.githubusercontent.com/assets/5726224/23631880/c226c538-0274-11e7-9968-97b9fb1e8be4.png">

Failed:
<img width="1375" alt="fail" src="https://cloud.githubusercontent.com/assets/5726224/23631891/c9e10c3e-0274-11e7-9c09-570e4cb32c80.png">

Cancelled:
<img width="1373" alt="cancel" src="https://cloud.githubusercontent.com/assets/5726224/23631904/cef60b3e-0274-11e7-8c7a-7f09f3c35f42.png">


The job history sidebar has the same issues. I've changed that over to use the same symbols as above. See screenshot bellow:

<img width="287" alt="job_history" src="https://cloud.githubusercontent.com/assets/5726224/23632751/f6a09598-0277-11e7-8bed-db1ddc641cc9.png">


