### PR TITLE
Update test for console log websockets toggle

### DIFF
--- a/agent/src/com/thoughtworks/go/agent/AgentControllerFactory.java
+++ b/agent/src/com/thoughtworks/go/agent/AgentControllerFactory.java
@@ -83,7 +83,7 @@ public class AgentControllerFactory {
     }
 
     public AgentController createInstance() {
-        if (systemEnvironment.isWebsocketEnabled()) {
+        if (systemEnvironment.isWebsocketsForAgentsEnabled()) {
             LOG.info("Connecting to server using WebSockets");
             return new AgentWebSocketClientController(
                     server,

--- a/agent/test/unit/com/thoughtworks/go/agent/AgentWebSocketClientControllerTest.java
+++ b/agent/test/unit/com/thoughtworks/go/agent/AgentWebSocketClientControllerTest.java
@@ -37,8 +37,6 @@ import com.thoughtworks.go.util.SystemEnvironment;
 import com.thoughtworks.go.websocket.*;
 import com.thoughtworks.go.work.SleepWork;
 import org.apache.http.client.HttpClient;
-import org.apache.http.client.methods.HttpPut;
-import org.eclipse.jetty.util.IO;
 import org.eclipse.jetty.websocket.api.RemoteEndpoint;
 import org.junit.After;
 import org.junit.Rule;
@@ -50,10 +48,8 @@ import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import java.io.IOException;
-import java.net.URI;
 import java.security.GeneralSecurityException;
 
-import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertThat;
@@ -106,6 +102,8 @@ public class AgentWebSocketClientControllerTest {
     @After
     public void tearDown() {
         GuidService.deleteGuid();
+        System.clearProperty("go.agent.websocket.enabled");
+        System.clearProperty("go.agent.console.logs.websocket.enabled");
     }
 
     @Test
@@ -173,10 +171,9 @@ public class AgentWebSocketClientControllerTest {
     }
 
     @Test
-    public void processAssignWorkActionWitConsoleLogsThroughhWebsockets() throws IOException, InterruptedException {
-        SystemEnvironment env = new SystemEnvironment();
-        env.set(SystemEnvironment.WEBSOCKET_ENABLED, true);
-        env.set(SystemEnvironment.CONSOLE_LOGS_THROUGH_WEBSOCKET_ENABLED, true);
+    public void processAssignWorkActionWithConsoleLogsThroughWebsockets() throws IOException, InterruptedException {
+        System.setProperty("go.agent.websocket.enabled", "Y");
+        System.setProperty("go.agent.console.logs.websocket.enabled", "Y");
         ArgumentCaptor<Message> argumentCaptor = ArgumentCaptor.forClass(Message.class);
         agentController = createAgentController();
         agentController.init();
@@ -195,8 +192,6 @@ public class AgentWebSocketClientControllerTest {
         assertThat(message2.getAcknowledgementId(), notNullValue());
         assertThat(message2.getAction(), is(Action.consoleOut));
         assertThat(message2.getData(), is(MessageEncoding.encodeData(new ConsoleTransmission("Sleeping for 0 milliseconds", new JobIdentifier()))));
-        env.set(SystemEnvironment.WEBSOCKET_ENABLED, false);
-        env.set(SystemEnvironment.CONSOLE_LOGS_THROUGH_WEBSOCKET_ENABLED, false);
     }
 
     @Test

--- a/agent/test/unit/com/thoughtworks/go/agent/AgentWebSocketClientControllerTest.java
+++ b/agent/test/unit/com/thoughtworks/go/agent/AgentWebSocketClientControllerTest.java
@@ -172,8 +172,8 @@ public class AgentWebSocketClientControllerTest {
 
     @Test
     public void processAssignWorkActionWithConsoleLogsThroughWebsockets() throws IOException, InterruptedException {
-        System.setProperty("go.agent.websocket.enabled", "Y");
-        System.setProperty("go.agent.console.logs.websocket.enabled", "Y");
+        System.setProperty(SystemEnvironment.WEBSOCKET_ENABLED.propertyName(), "Y");
+        System.setProperty(SystemEnvironment.CONSOLE_LOGS_THROUGH_WEBSOCKET_ENABLED.propertyName(), "Y");
         ArgumentCaptor<Message> argumentCaptor = ArgumentCaptor.forClass(Message.class);
         agentController = createAgentController();
         agentController.init();

--- a/agent/test/unit/com/thoughtworks/go/agent/AgentWebSocketClientControllerTest.java
+++ b/agent/test/unit/com/thoughtworks/go/agent/AgentWebSocketClientControllerTest.java
@@ -102,8 +102,8 @@ public class AgentWebSocketClientControllerTest {
     @After
     public void tearDown() {
         GuidService.deleteGuid();
-        System.clearProperty("go.agent.websocket.enabled");
-        System.clearProperty("go.agent.console.logs.websocket.enabled");
+        System.clearProperty(SystemEnvironment.WEBSOCKET_ENABLED.propertyName());
+        System.clearProperty(SystemEnvironment.CONSOLE_LOGS_THROUGH_WEBSOCKET_ENABLED.propertyName());
     }
 
     @Test

--- a/base/src/com/thoughtworks/go/util/SystemEnvironment.java
+++ b/base/src/com/thoughtworks/go/util/SystemEnvironment.java
@@ -766,7 +766,7 @@ public class SystemEnvironment implements Serializable, ConfigDirProvider {
         return GO_UPDATE_SERVER_URL.getValue();
     }
 
-    public boolean isWebsocketEnabled() {
+    public boolean isWebsocketsForAgentsEnabled() {
         return WEBSOCKET_ENABLED.getValue();
     }
 

--- a/common/src/com/thoughtworks/go/work/DefaultGoPublisher.java
+++ b/common/src/com/thoughtworks/go/work/DefaultGoPublisher.java
@@ -79,7 +79,7 @@ public class DefaultGoPublisher implements GoPublisher {
     @Override
     public void consumeLine(String line) {
         SystemEnvironment env = new SystemEnvironment();
-        if(env.isWebsocketEnabled() && env.isConsoleLogsThroughWebsocketEnabled()) {
+        if(env.isWebsocketsForAgentsEnabled() && env.isConsoleLogsThroughWebsocketEnabled()) {
             remoteBuildRepository.consumeLine(line, jobIdentifier);
         } else {
             consoleOutputTransmitter.consumeLine(line);

--- a/common/test/unit/com/thoughtworks/go/work/SleepWork.java
+++ b/common/test/unit/com/thoughtworks/go/work/SleepWork.java
@@ -60,7 +60,8 @@ public class SleepWork implements Work {
 
             String result = canceled ? "done_canceled" : "done";
             manipulator.setProperty(null, new Property(name + "_result", result));
-            if (new SystemEnvironment().isWebsocketEnabled()) {
+            SystemEnvironment systemEnvironment = new SystemEnvironment();
+            if (systemEnvironment.isConsoleLogsThroughWebsocketEnabled() && systemEnvironment.isWebsocketsForAgentsEnabled()) {
                 goPublisher.consumeLine(format("Sleeping for %s milliseconds", this.sleepInMilliSeconds));
             }
         } catch (InterruptedException e) {


### PR DESCRIPTION
@jyotisingh Per your request on the previous PR #3198, I've changed the [test](https://github.com/kierarad/gocd/blob/bee4e3d6d97d7e7b79873bd5a79cf08f63296845/agent/test/unit/com/thoughtworks/go/agent/AgentWebSocketClientControllerTest.java#L177) so that we aren't instantiating a new system environment. 

It is necessary to set the properties, because the mock system environment available in the controller is not what is being called in this test. I accounted for your comment that "if one of the assertions fail, resetting of the properties will not happen, causing some other tests to fail" by moving the property clearing to the tear down so that it will happen regardless of is it passes or fails. 