### PR TITLE
PluginAuthenticationProvider finds or creates a user on successful authentication

### DIFF
--- a/server/src/com/thoughtworks/go/server/dao/UserDao.java
+++ b/server/src/com/thoughtworks/go/server/dao/UserDao.java
@@ -16,11 +16,11 @@
 
 package com.thoughtworks.go.server.dao;
 
-import java.util.List;
-import java.util.Set;
-
 import com.thoughtworks.go.domain.User;
 import com.thoughtworks.go.domain.Users;
+
+import java.util.List;
+import java.util.Set;
 
 public interface UserDao {
     void saveOrUpdate(User user);
@@ -46,4 +46,6 @@ public interface UserDao {
     User load(long id);
 
     boolean deleteUser(String username);
+
+    User findOrCreate(final User user);
 }

--- a/server/src/com/thoughtworks/go/server/dao/UserSqlMapDao.java
+++ b/server/src/com/thoughtworks/go/server/dao/UserSqlMapDao.java
@@ -16,12 +16,6 @@
 
 package com.thoughtworks.go.server.dao;
 
-import java.sql.SQLException;
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-
 import com.thoughtworks.go.domain.NullUser;
 import com.thoughtworks.go.domain.User;
 import com.thoughtworks.go.domain.Users;
@@ -31,11 +25,7 @@ import com.thoughtworks.go.server.exceptions.UserNotFoundException;
 import com.thoughtworks.go.server.transaction.TransactionSynchronizationManager;
 import com.thoughtworks.go.server.transaction.TransactionTemplate;
 import com.thoughtworks.go.util.StringUtil;
-import org.hibernate.Criteria;
-import org.hibernate.HibernateException;
-import org.hibernate.Query;
-import org.hibernate.Session;
-import org.hibernate.SessionFactory;
+import org.hibernate.*;
 import org.hibernate.criterion.Projections;
 import org.hibernate.criterion.Restrictions;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -48,8 +38,14 @@ import org.springframework.transaction.support.TransactionCallback;
 import org.springframework.transaction.support.TransactionCallbackWithoutResult;
 import org.springframework.transaction.support.TransactionSynchronizationAdapter;
 
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
 @Component
-public class UserSqlMapDao  extends HibernateDaoSupport implements UserDao {
+public class UserSqlMapDao extends HibernateDaoSupport implements UserDao {
     private SessionFactory sessionFactory;
     private TransactionTemplate transactionTemplate;
     private GoCache goCache;
@@ -79,6 +75,16 @@ public class UserSqlMapDao  extends HibernateDaoSupport implements UserDao {
                 sessionFactory.getCurrentSession().saveOrUpdate(copyLoginToDisplayNameIfNotPresent(user));
             }
         });
+    }
+
+    public User findOrCreate(final User user) {
+        final User userInDB = findUser(user.getName());
+        if (!(userInDB instanceof NullUser)) {
+            return userInDB;
+        }
+
+        saveOrUpdate(user);
+        return user;
     }
 
     public User findUser(final String userName) {

--- a/server/src/com/thoughtworks/go/server/security/providers/PluginAuthenticationProvider.java
+++ b/server/src/com/thoughtworks/go/server/security/providers/PluginAuthenticationProvider.java
@@ -88,13 +88,13 @@ public class PluginAuthenticationProvider extends AbstractUserDetailsAuthenticat
             throw new UsernameNotFoundException("Unable to authenticate user: " + username);
         }
 
-        userService.addUserIfDoesNotExist(toDomainUser(user));
-        GoUserPrinciple goUserPrinciple = getGoUserPrinciple(user);
+        final com.thoughtworks.go.domain.User savedUser = userService.findOrCreate(toDomainUser(user));
+        GoUserPrinciple goUserPrinciple = getGoUserPrinciple(savedUser);
         return goUserPrinciple;
     }
 
     private com.thoughtworks.go.domain.User toDomainUser(User user) {
-        return new com.thoughtworks.go.domain.User(user.getUsername(),user.getDisplayName(),user.getEmailId());
+        return new com.thoughtworks.go.domain.User(user.getUsername(), user.getDisplayName(), user.getEmailId());
     }
 
     private void removeAnyAssociatedPluginRolesFor(String username) {
@@ -133,8 +133,8 @@ public class PluginAuthenticationProvider extends AbstractUserDetailsAuthenticat
         return null;
     }
 
-    private GoUserPrinciple getGoUserPrinciple(User user) {
-        return new GoUserPrinciple(user.getUsername(), user.getDisplayName(), "", true, true, true, true, authorityGranter.authorities(user.getUsername()));
+    private GoUserPrinciple getGoUserPrinciple(com.thoughtworks.go.domain.User user) {
+        return new GoUserPrinciple(user.getName(), user.getDisplayName(), "", true, true, true, true, authorityGranter.authorities(user.getName()));
     }
 
     @Override

--- a/server/src/com/thoughtworks/go/server/service/UserService.java
+++ b/server/src/com/thoughtworks/go/server/service/UserService.java
@@ -352,10 +352,19 @@ public class UserService {
         synchronized (enableUserMutex) {
             if (!(user.isAnonymous() || userExists(user))) {
                 assertUnknownUsersAreAllowedToLogin();
-
                 userDao.saveOrUpdate(user);
             }
         }
+    }
+
+    public User findOrCreate(User user) {
+        synchronized (enableUserMutex) {
+            if (!user.isAnonymous()) {
+                assertUnknownUsersAreAllowedToLogin();
+                return userDao.findOrCreate(user);
+            }
+        }
+        return user;
     }
 
     public void withEnableUserMutex(Runnable runnable) {


### PR DESCRIPTION
* UserDao and UserService can findOrCreate users

#### Why findOrCreate over addUserIfDoesNotExist?

This handles scenarios where a user exists in DB with all the attributes defined, but on authentication the plugin returns User with only the username, e.g file based authentication. 


