### PR TITLE
Send console lines using the default encoding for the platform instea…

### DIFF
--- a/common/src/com/thoughtworks/go/remote/work/RemoteConsoleAppender.java
+++ b/common/src/com/thoughtworks/go/remote/work/RemoteConsoleAppender.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 ThoughtWorks, Inc.
+ * Copyright 2017 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/com/thoughtworks/go/remote/work/RemoteConsoleAppender.java
+++ b/common/src/com/thoughtworks/go/remote/work/RemoteConsoleAppender.java
@@ -23,6 +23,7 @@ import org.apache.http.entity.StringEntity;
 import org.apache.log4j.Logger;
 
 import java.io.IOException;
+import java.nio.charset.Charset;
 
 public class RemoteConsoleAppender implements ConsoleAppender {
 
@@ -42,8 +43,7 @@ public class RemoteConsoleAppender implements ConsoleAppender {
             if (LOGGER.isDebugEnabled()) {
                 LOGGER.debug("Appending console to URL -> " + consoleUri);
             }
-
-            putMethod.setEntity(new StringEntity(content));
+            putMethod.setEntity(new StringEntity(content, Charset.defaultCharset()));
             HttpService.setSizeHeader(putMethod, content.getBytes().length);
             CloseableHttpResponse response = httpService.execute(putMethod);
             if (LOGGER.isDebugEnabled()) {

--- a/server/src/com/thoughtworks/go/server/service/ConsoleService.java
+++ b/server/src/com/thoughtworks/go/server/service/ConsoleService.java
@@ -31,6 +31,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import java.io.*;
+import java.nio.charset.Charset;
 
 import static com.thoughtworks.go.util.ArtifactLogUtil.getConsoleOutputFolderAndFileName;
 
@@ -116,7 +117,7 @@ public class ConsoleService {
 
         LOGGER.trace("Updating console log [" + dest.getAbsolutePath() + "]");
         try (BufferedWriter writer = new BufferedWriter(new FileWriter(dest, dest.exists()))) {
-            IOUtils.copy(in, writer);
+            IOUtils.copy(in, writer, Charset.defaultCharset());
         } catch (IOException e) {
             LOGGER.error("Failed to update console log at : [" + dest.getAbsolutePath() + "]", e);
             return false;

--- a/server/src/com/thoughtworks/go/server/service/ConsoleService.java
+++ b/server/src/com/thoughtworks/go/server/service/ConsoleService.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2016 ThoughtWorks, Inc.
+ * Copyright 2017 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -31,7 +31,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import java.io.*;
-import java.nio.charset.Charset;
 
 import static com.thoughtworks.go.util.ArtifactLogUtil.getConsoleOutputFolderAndFileName;
 
@@ -116,8 +115,8 @@ public class ConsoleService {
         parentFile.mkdirs();
 
         LOGGER.trace("Updating console log [" + dest.getAbsolutePath() + "]");
-        try (BufferedWriter writer = new BufferedWriter(new FileWriter(dest, dest.exists()))) {
-            IOUtils.copy(in, writer, Charset.defaultCharset());
+        try (OutputStream out = new BufferedOutputStream(new FileOutputStream(dest, dest.exists()))) {
+            IOUtils.copy(in, out);
         } catch (IOException e) {
             LOGGER.error("Failed to update console log at : [" + dest.getAbsolutePath() + "]", e);
             return false;


### PR DESCRIPTION
…d of forcing ISO-8859-1

Should fix https://github.com/gocd/gocd/issues/3218 (Emoji in console output rendered as '?') on
platforms set to UTF-8.