### PR TITLE
Added migration to handle removal of whitespaces from encrypted strin…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -149,3 +149,4 @@ plugin-infra/go-plugin-access/config/cipher
 
 build/
 out/
+config/config-server/warnings.log

--- a/base/src/com/thoughtworks/go/util/GoConstants.java
+++ b/base/src/com/thoughtworks/go/util/GoConstants.java
@@ -57,7 +57,7 @@ public class GoConstants {
 
     public static final String PRODUCT_NAME = "go";
 
-    public static final int CONFIG_SCHEMA_VERSION = 89;
+    public static final int CONFIG_SCHEMA_VERSION = 90;
 
     public static final String APPROVAL_SUCCESS = "success";
     public static final String APPROVAL_MANUAL = "manual";

--- a/config/config-api/test/com/thoughtworks/go/helper/ConfigFileFixture.java
+++ b/config/config-api/test/com/thoughtworks/go/helper/ConfigFileFixture.java
@@ -237,6 +237,20 @@ public final class ConfigFileFixture {
                 + pipelinesBlock
                 + "</cruise>";
     }
+    public static String configWithPluggableScm(String scmBlock, int schemaVersion) {
+        return "<cruise schemaVersion='" + schemaVersion + "'>\n"
+                + "<server artifactsdir='artifactsDir' >"
+                + "</server>"
+                + "<scms>"
+                + scmBlock
+                + "</scms>"
+                + "</cruise>";
+    }
+    public static String config(String block, int schemaVersion) {
+        return "<cruise schemaVersion='" + schemaVersion + "'>\n"
+                + block
+                + "</cruise>";
+    }
 
     public static final String WITH_MULTIPLE_LOCAL_AGENT_CONFIG =
             "<cruise schemaVersion='" + CONFIG_SCHEMA_VERSION + "'>\n"

--- a/config/config-server/resources/schemas/89_cruise-config.xsd
+++ b/config/config-server/resources/schemas/89_cruise-config.xsd
@@ -77,7 +77,7 @@
                     </xsd:unique>
                 </xsd:element>
             </xsd:sequence>
-            <xsd:attribute name="schemaVersion" type="xsd:int" use="required" fixed="90"/>
+            <xsd:attribute name="schemaVersion" type="xsd:int" use="required" fixed="89"/>
         </xsd:complexType>
         <xsd:unique name="uniquePipelines">
             <xsd:selector xpath="pipelines"/>

--- a/config/config-server/resources/upgrades/90.xsl
+++ b/config/config-server/resources/upgrades/90.xsl
@@ -1,0 +1,47 @@
+<?xml version="1.0"?>
+<!--
+  ~ Copyright 2017 ThoughtWorks, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:template match="/cruise/@schemaVersion">
+    <xsl:attribute name="schemaVersion">90</xsl:attribute>
+  </xsl:template>
+  <!-- Copy everything -->
+  <xsl:template match="@*|node()">
+    <xsl:copy>
+      <xsl:apply-templates select="@*|node()"/>
+    </xsl:copy>
+  </xsl:template>
+
+  <xsl:template name="remove_whitespaces_from_encrypted_values">
+    <xsl:param name="encryptedValue"/>
+    <xsl:value-of select="translate(translate(translate($encryptedValue, ' ', ''), '&#xD;', ''), '&#xA;', '')"/>
+  </xsl:template>
+
+  <xsl:template match="//environmentvariables/variable/encryptedValue/text()|//configuration/property/encryptedValue/text()">
+    <xsl:call-template name="remove_whitespaces_from_encrypted_values">
+      <xsl:with-param name="encryptedValue" select="."/>
+    </xsl:call-template>
+  </xsl:template>
+
+  <xsl:template match="//pipeline/materials/*/@encryptedPassword|//server/mailhost/@encryptedPassword|//server/security/ldap/@encryptedManagerPassword">
+    <xsl:attribute name="{name(.)}">
+      <xsl:call-template name="remove_whitespaces_from_encrypted_values">
+        <xsl:with-param name="encryptedValue" select="."/>
+      </xsl:call-template>
+    </xsl:attribute>
+  </xsl:template>
+</xsl:stylesheet>


### PR DESCRIPTION
…gs in config.

As a part of 17.2, we moved to Base64 implementation in Java 8 for encoding secrets from the one in commons-codec. The one in commons-codec would ignore whitespace characters, this allowed encrypted values to have newline, carriage-returns and spaces in an encrypted-value. Base64 impl in java8 is strict about this check and hence Go server fails to startup after an upgrade from 17.1 to 17.2 if the config had encrypted values with whitespace characters. This commit handles migration of such configs to remove the whitespaces.