### PR TITLE
Change to use slf4j - Part 1

### DIFF
--- a/config/config-server/src/com/thoughtworks/go/config/GoConfigMigration.java
+++ b/config/config-server/src/com/thoughtworks/go/config/GoConfigMigration.java
@@ -23,10 +23,11 @@ import com.thoughtworks.go.util.CachedDigestUtils;
 import com.thoughtworks.go.util.TimeProvider;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
-import org.apache.log4j.Logger;
 import org.jdom2.Document;
 import org.jdom2.Element;
 import org.jdom2.input.SAXBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -51,7 +52,7 @@ import static com.thoughtworks.go.util.XmlUtils.buildXmlDocument;
  */
 @Component
 public class GoConfigMigration {
-    private static final Logger LOG = Logger.getLogger(GoConfigMigration.class);
+    private static final Logger LOG = LoggerFactory.getLogger(GoConfigMigration.class);
     private final String schemaVersion = "schemaVersion";
     private final UpgradeFailedHandler upgradeFailed;
     private final ConfigRepository configRepository;
@@ -67,11 +68,11 @@ public class GoConfigMigration {
             public void handle(Exception e) {
                 e.printStackTrace();
                 System.err.println(
-                        "There are errors in the Cruise config file.  Please read the error message and correct the errors.\n"
-                                + "Once fixed, please restart Cruise.\nError: " + e.getMessage());
-                LOG.fatal(
-                        "There are errors in the Cruise config file.  Please read the error message and correct the errors.\n"
-                                + "Once fixed, please restart Cruise.\nError: " + e.getMessage());
+                        "There are errors in the GoCD config file.  Please read the error message and correct the errors.\n"
+                                + "Once fixed, please restart GoCD.\nError: " + e.getMessage());
+                LOG.error(
+                        "There are errors in the GoCD config file.  Please read the error message and correct the errors.\n"
+                                + "Once fixed, please restart GoCD.\nError: " + e.getMessage());
                 // Send exit signal in a separate thread otherwise it will deadlock jetty
                 new Thread(new Runnable() {
                     public void run() {

--- a/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/authentication/AuthenticationPluginRegistrar.java
+++ b/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/authentication/AuthenticationPluginRegistrar.java
@@ -21,15 +21,14 @@ import com.thoughtworks.go.plugin.api.GoPlugin;
 import com.thoughtworks.go.plugin.infra.PluginChangeListener;
 import com.thoughtworks.go.plugin.infra.PluginManager;
 import com.thoughtworks.go.plugin.infra.plugininfo.GoPluginDescriptor;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
-import static org.apache.log4j.Logger.getLogger;
-
 @Component
 public class AuthenticationPluginRegistrar implements PluginChangeListener {
-    private static Logger LOGGER = getLogger(AuthenticationPluginRegistrar.class);
+    private static Logger LOGGER = LoggerFactory.getLogger(AuthenticationPluginRegistrar.class);
 
     private AuthenticationExtension authenticationExtension;
     private AuthenticationPluginRegistry authenticationPluginRegistry;

--- a/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/common/settings/PluginSettingsMetadataLoader.java
+++ b/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/common/settings/PluginSettingsMetadataLoader.java
@@ -21,18 +21,18 @@ import com.thoughtworks.go.plugin.api.GoPlugin;
 import com.thoughtworks.go.plugin.infra.PluginChangeListener;
 import com.thoughtworks.go.plugin.infra.PluginManager;
 import com.thoughtworks.go.plugin.infra.plugininfo.GoPluginDescriptor;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
 
 import static java.lang.String.format;
-import static org.apache.log4j.Logger.getLogger;
 
 @Component
 public class PluginSettingsMetadataLoader implements PluginChangeListener {
-    private static final Logger LOGGER = getLogger(PluginSettingsMetadataLoader.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(PluginSettingsMetadataLoader.class);
     private final List<GoPluginExtension> extensions;
     private PluginSettingsMetadataStore metadataStore = PluginSettingsMetadataStore.getInstance();
 

--- a/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/notification/NotificationPluginRegistrar.java
+++ b/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/notification/NotificationPluginRegistrar.java
@@ -20,17 +20,16 @@ import com.thoughtworks.go.plugin.api.GoPlugin;
 import com.thoughtworks.go.plugin.infra.PluginChangeListener;
 import com.thoughtworks.go.plugin.infra.PluginManager;
 import com.thoughtworks.go.plugin.infra.plugininfo.GoPluginDescriptor;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
 
-import static org.apache.log4j.Logger.getLogger;
-
 @Component
 public class NotificationPluginRegistrar implements PluginChangeListener {
-    private static Logger LOGGER = getLogger(NotificationPluginRegistrar.class);
+    private static Logger LOGGER = LoggerFactory.getLogger(NotificationPluginRegistrar.class);
 
     private NotificationExtension notificationExtension;
     private NotificationPluginRegistry notificationPluginRegistry;
@@ -62,7 +61,7 @@ public class NotificationPluginRegistrar implements PluginChangeListener {
     private void checkNotificationTypes(GoPluginDescriptor pluginDescriptor, List<String> notificationsInterestedIn) {
         for (String notificationType : notificationsInterestedIn) {
             if (!NotificationExtension.VALID_NOTIFICATION_TYPES.contains(notificationType)) {
-                LOGGER.warn(String.format("Plugin '%s' is trying to register for '%s' which is not a valid notification type. Valid notification types are: %s", pluginDescriptor.id(), notificationType, NotificationExtension.VALID_NOTIFICATION_TYPES));
+                LOGGER.warn("Plugin '{}' is trying to register for '{}' which is not a valid notification type. Valid notification types are: {}", pluginDescriptor.id(), notificationType, NotificationExtension.VALID_NOTIFICATION_TYPES);
             }
         }
     }

--- a/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/packagematerial/PackageMaterialMetadataLoader.java
+++ b/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/packagematerial/PackageMaterialMetadataLoader.java
@@ -22,12 +22,12 @@ import com.thoughtworks.go.plugin.infra.GoPluginFrameworkException;
 import com.thoughtworks.go.plugin.infra.PluginChangeListener;
 import com.thoughtworks.go.plugin.infra.PluginManager;
 import com.thoughtworks.go.plugin.infra.plugininfo.GoPluginDescriptor;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import static java.lang.String.format;
-import static org.apache.log4j.Logger.getLogger;
 
 @Component
 public class PackageMaterialMetadataLoader implements PluginChangeListener {
@@ -35,7 +35,7 @@ public class PackageMaterialMetadataLoader implements PluginChangeListener {
     private RepositoryMetadataStore repositoryMetadataStore = RepositoryMetadataStore.getInstance();
     private PackageMetadataStore packageMetadataStore = PackageMetadataStore.getInstance();
 
-    private static final Logger LOGGER = getLogger(PackageMaterialMetadataLoader.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(PackageMaterialMetadataLoader.class);
 
     PackageRepositoryExtension packageRepositoryExtension;
 

--- a/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/pluggabletask/PluggableTaskPreferenceLoader.java
+++ b/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/pluggabletask/PluggableTaskPreferenceLoader.java
@@ -22,18 +22,14 @@ import com.thoughtworks.go.plugin.infra.Action;
 import com.thoughtworks.go.plugin.infra.PluginChangeListener;
 import com.thoughtworks.go.plugin.infra.PluginManager;
 import com.thoughtworks.go.plugin.infra.plugininfo.GoPluginDescriptor;
-import org.apache.log4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-
-import static org.apache.log4j.Logger.getLogger;
 
 @Component
 public class PluggableTaskPreferenceLoader implements PluginChangeListener {
 
     private PluginManager pluginManager;
     private TaskExtension taskExtension;
-    private static final Logger LOGGER = getLogger(PluggableTaskPreferenceLoader.class);
 
     @Autowired
     public PluggableTaskPreferenceLoader(PluginManager pluginManager, TaskExtension taskExtension) {

--- a/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/scm/SCMMetadataLoader.java
+++ b/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/scm/SCMMetadataLoader.java
@@ -21,16 +21,16 @@ import com.thoughtworks.go.plugin.infra.GoPluginFrameworkException;
 import com.thoughtworks.go.plugin.infra.PluginChangeListener;
 import com.thoughtworks.go.plugin.infra.PluginManager;
 import com.thoughtworks.go.plugin.infra.plugininfo.GoPluginDescriptor;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import static java.lang.String.format;
-import static org.apache.log4j.Logger.getLogger;
 
 @Component
 public class SCMMetadataLoader implements PluginChangeListener {
-    private static final Logger LOGGER = getLogger(SCMMetadataLoader.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(SCMMetadataLoader.class);
 
     SCMExtension scmExtension;
     private SCMMetadataStore scmMetadataStore = SCMMetadataStore.getInstance();

--- a/plugin-infra/go-plugin-access/test/com/thoughtworks/go/plugin/access/notification/NotificationPluginRegistrarTest.java
+++ b/plugin-infra/go-plugin-access/test/com/thoughtworks/go/plugin/access/notification/NotificationPluginRegistrarTest.java
@@ -19,10 +19,10 @@ package com.thoughtworks.go.plugin.access.notification;
 import com.thoughtworks.go.plugin.infra.PluginManager;
 import com.thoughtworks.go.plugin.infra.plugininfo.GoPluginDescriptor;
 import com.thoughtworks.go.util.ReflectionUtil;
-import org.apache.log4j.Logger;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
+import org.slf4j.Logger;
 
 import static java.util.Arrays.asList;
 import static org.mockito.Mockito.*;
@@ -106,8 +106,8 @@ public class NotificationPluginRegistrarTest {
 
         notificationPluginRegistrar.pluginLoaded(new GoPluginDescriptor(PLUGIN_ID_1, null, null, null, null, true));
 
-        verify(logger).warn("Plugin 'plugin-id-1' is trying to register for 'pipeline-status' which is not a valid notification type. Valid notification types are: [stage-status]");
-        verify(logger).warn("Plugin 'plugin-id-1' is trying to register for 'job-status' which is not a valid notification type. Valid notification types are: [stage-status]");
+        verify(logger).warn("Plugin '{}' is trying to register for '{}' which is not a valid notification type. Valid notification types are: {}", "plugin-id-1", "pipeline-status", asList("stage-status"));
+        verify(logger).warn("Plugin '{}' is trying to register for '{}' which is not a valid notification type. Valid notification types are: {}", "plugin-id-1", "job-status", asList("stage-status"));
     }
 
     @Test

--- a/plugin-infra/go-plugin-infra/src/com/thoughtworks/go/plugin/infra/commons/PluginsList.java
+++ b/plugin-infra/go-plugin-infra/src/com/thoughtworks/go/plugin/infra/commons/PluginsList.java
@@ -20,6 +20,8 @@ import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 import com.thoughtworks.go.util.SystemEnvironment;
 import com.thoughtworks.go.util.json.JsonHelper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -32,7 +34,7 @@ import static com.thoughtworks.go.util.FileDigester.md5DigestOfFile;
 
 @Component
 public class PluginsList {
-    private static final org.apache.log4j.Logger LOG = org.apache.log4j.Logger.getLogger(PluginsList.class);
+    private static final Logger LOG = LoggerFactory.getLogger(PluginsList.class);
     private String pluginsJSON;
 
     private SystemEnvironment systemEnvironment;

--- a/plugin-infra/go-plugin-infra/src/com/thoughtworks/go/plugin/infra/commons/PluginsZip.java
+++ b/plugin-infra/go-plugin-infra/src/com/thoughtworks/go/plugin/infra/commons/PluginsZip.java
@@ -20,6 +20,8 @@ import com.thoughtworks.go.util.SystemEnvironment;
 import com.thoughtworks.go.util.ZipBuilder;
 import com.thoughtworks.go.util.ZipUtil;
 import org.apache.commons.codec.digest.DigestUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -29,7 +31,7 @@ import static com.thoughtworks.go.util.FileDigester.md5DigestOfFolderContent;
 
 @Component
 public class PluginsZip {
-    private static final org.apache.log4j.Logger LOG = org.apache.log4j.Logger.getLogger(PluginsZip.class);
+    private static final Logger LOG = LoggerFactory.getLogger(PluginsZip.class);
     private ZipUtil zipUtil;
     private String md5DigestOfPlugins;
     private final File destZipFile;
@@ -83,7 +85,7 @@ public class PluginsZip {
         boolean external = externalPlugins.canRead();
         if (!bundled || !external) {
             String folder = bundled ? externalPlugins.getAbsolutePath() : bundledPlugins.getAbsolutePath();
-            LOG.error(String.format("Could not read plugins. Please check access rights on files in folder: %s.", folder));
+            LOG.error("Could not read plugins. Please check access rights on files in folder: {}.", folder);
             throw new FileAccessRightsCheckException(String.format("Could not read plugins. Please check access rights in folder: %s", folder));
         }
     }

--- a/server/src/com/thoughtworks/go/server/dao/PipelineSqlMapDao.java
+++ b/server/src/com/thoughtworks/go/server/dao/PipelineSqlMapDao.java
@@ -39,7 +39,8 @@ import com.thoughtworks.go.server.transaction.TransactionTemplate;
 import com.thoughtworks.go.server.util.Pagination;
 import com.thoughtworks.go.server.util.SqlUtil;
 import com.thoughtworks.go.util.SystemEnvironment;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.DataRetrievalFailureException;
 import org.springframework.stereotype.Component;
@@ -58,7 +59,7 @@ import static com.thoughtworks.go.util.IBatisUtil.arguments;
 @SuppressWarnings({"ALL"})
 @Component
 public class PipelineSqlMapDao extends SqlMapClientDaoSupport implements Initializer, PipelineDao, StageStatusListener {
-    private static final Logger LOGGER = Logger.getLogger(PipelineSqlMapDao.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(PipelineSqlMapDao.class);
     private StageDao stageDao;
     private MaterialRepository materialRepository;
     private EnvironmentVariableDao environmentVariableDao;
@@ -95,7 +96,7 @@ public class PipelineSqlMapDao extends SqlMapClientDaoSupport implements Initial
             cacheActivePipelines();
             LOGGER.info("Done loading active pipelines into memory.");
         } catch (Exception e) {
-            LOGGER.fatal(e.getMessage(), e);
+            LOGGER.error(e.getMessage(), e);
             throw new RuntimeException(e);
         }
     }
@@ -494,7 +495,7 @@ public class PipelineSqlMapDao extends SqlMapClientDaoSupport implements Initial
                 continue;
             }
             if (!pipelinesInConfig.contains(new CaseInsensitiveString(model.getName()))) {
-                LOGGER.debug("Skipping PIM for pipeline " + model.getName() + " ,since its not found in current config");
+                LOGGER.debug("Skipping PIM for pipeline {}, since its not found in current config", model.getName());
                 continue;
             }
             models.add(model);
@@ -681,8 +682,8 @@ public class PipelineSqlMapDao extends SqlMapClientDaoSupport implements Initial
         List<PipelineInstanceModel> matchingPIMs = (List<PipelineInstanceModel>) getSqlMapClientTemplate().queryForList("findMatchingPipelineInstances", args);
         List<PipelineInstanceModel> exactMatchingPims = (List<PipelineInstanceModel>) getSqlMapClientTemplate().queryForList("findExactMatchingPipelineInstances", args);
         if (LOGGER.isDebugEnabled()) {
-            LOGGER.debug(String.format("[Compare Pipelines] Query initiated for pipeline %s with pattern %s. Query execution took %s milliseconds", pipelineName, pattern,
-                    System.currentTimeMillis() - begin));
+            LOGGER.debug("[Compare Pipelines] Query initiated for pipeline {} with pattern {}. Query execution took {} milliseconds", pipelineName, pattern,
+                    System.currentTimeMillis() - begin);
         }
         exactMatchingPims.addAll(matchingPIMs);
         return PipelineInstanceModels.createPipelineInstanceModels(exactMatchingPims);

--- a/server/src/com/thoughtworks/go/server/initializers/PluginsInitializer.java
+++ b/server/src/com/thoughtworks/go/server/initializers/PluginsInitializer.java
@@ -21,6 +21,8 @@ import com.thoughtworks.go.server.util.ServerVersion;
 import com.thoughtworks.go.util.SystemEnvironment;
 import com.thoughtworks.go.util.ZipUtil;
 import org.apache.commons.io.FileUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -36,7 +38,7 @@ public class PluginsInitializer implements Initializer {
     private final PluginManager pluginManager;
     private final SystemEnvironment systemEnvironment;
     private final ServerVersion serverVersion;
-    private static final org.apache.log4j.Logger LOG = org.apache.log4j.Logger.getLogger(PluginsInitializer.class);
+    private static final Logger LOG = LoggerFactory.getLogger(PluginsInitializer.class);
     private ZipUtil zipUtil;
 
     @Autowired

--- a/server/src/com/thoughtworks/go/server/messaging/MessageLogger.java
+++ b/server/src/com/thoughtworks/go/server/messaging/MessageLogger.java
@@ -16,13 +16,14 @@
 
 package com.thoughtworks.go.server.messaging;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 @Component
 public class MessageLogger implements GoMessageListener {
-    private static final Logger LOG = Logger.getLogger(MessageLogger.class);
+    private static final Logger LOG = LoggerFactory.getLogger(MessageLogger.class);
 
     @Autowired
     public MessageLogger(EmailNotificationTopic emailNotificationTopic, JobStatusTopic jobStatusTopic) {
@@ -32,7 +33,7 @@ public class MessageLogger implements GoMessageListener {
 
     public void onMessage(GoMessage message) {
         if (LOG.isDebugEnabled()) {
-            LOG.debug(message);
+            LOG.debug(message.toString());
         }
     }
 }

--- a/server/src/com/thoughtworks/go/server/messaging/scheduling/WorkFinder.java
+++ b/server/src/com/thoughtworks/go/server/messaging/scheduling/WorkFinder.java
@@ -23,13 +23,14 @@ import com.thoughtworks.go.server.messaging.GoMessageChannel;
 import com.thoughtworks.go.server.messaging.GoMessageListener;
 import com.thoughtworks.go.server.perf.WorkAssignmentPerformanceLogger;
 import com.thoughtworks.go.server.service.BuildAssignmentService;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 @Service
 public class WorkFinder implements GoMessageListener<IdleAgentMessage> {
-    private static final Logger LOGGER = Logger.getLogger(WorkFinder.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(WorkFinder.class);
 
     private static final NoWork NO_WORK = new NoWork();
     private BuildAssignmentService buildAssignmentService;
@@ -63,7 +64,7 @@ public class WorkFinder implements GoMessageListener<IdleAgentMessage> {
             try {
                 assignedWorkTopic.post(new WorkAssignedMessage(agent, work));
             } catch (Throwable e) {
-                LOGGER.fatal(null, e);
+                LOGGER.error("Failed to post work assigned message", e);
             }
         }
     }

--- a/server/src/com/thoughtworks/go/server/service/PipelineConfigService.java
+++ b/server/src/com/thoughtworks/go/server/service/PipelineConfigService.java
@@ -32,6 +32,8 @@ import com.thoughtworks.go.server.presentation.CanDeleteResult;
 import com.thoughtworks.go.server.service.result.LocalizedOperationResult;
 import com.thoughtworks.go.server.service.tasks.PluggableTaskService;
 import com.thoughtworks.go.util.Node;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -47,7 +49,7 @@ public class PipelineConfigService {
     private final SecurityService securityService;
     private final PluggableTaskService pluggableTaskService;
     private final EntityHashingService entityHashingService;
-    private static final org.apache.log4j.Logger LOGGER = org.apache.log4j.Logger.getLogger(PipelineConfigService.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(PipelineConfigService.class);
 
     @Autowired
     public PipelineConfigService(GoConfigService goConfigService, SecurityService securityService, PluggableTaskService pluggableTaskService, EntityHashingService entityHashingService) {

--- a/server/src/com/thoughtworks/go/server/service/RailsAssetsService.java
+++ b/server/src/com/thoughtworks/go/server/service/RailsAssetsService.java
@@ -23,6 +23,8 @@ import com.thoughtworks.go.util.StringUtil;
 import com.thoughtworks.go.util.SystemEnvironment;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.filefilter.RegexFileFilter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.web.context.ServletContextAware;
@@ -37,7 +39,7 @@ import java.util.regex.Pattern;
 @Service
 public class RailsAssetsService implements ServletContextAware {
     private static final Pattern MANIFEST_FILE_PATTERN = Pattern.compile("^\\.sprockets-manifest.*\\.json$");
-    private static final org.apache.log4j.Logger LOG = org.apache.log4j.Logger.getLogger(RailsAssetsService.class);
+    private static final Logger LOG = LoggerFactory.getLogger(RailsAssetsService.class);
     private RailsAssetsManifest railsAssetsManifest;
     private ServletContext servletContext;
     private final SystemEnvironment systemEnvironment;
@@ -63,11 +65,11 @@ public class RailsAssetsService implements ServletContextAware {
 
         File manifestFile = (File) files.iterator().next();
 
-        LOG.info(String.format("Found rails assets manifest file named %s ", manifestFile.getName()));
+        LOG.info("Found rails assets manifest file named {}", manifestFile.getName());
         String manifest = FileUtil.readContentFromFile(manifestFile);
         Gson gson = new Gson();
         railsAssetsManifest = gson.fromJson(manifest, RailsAssetsManifest.class);
-        LOG.info(String.format("Successfully read rails assets manifest file located at %s", manifestFile.getAbsolutePath()));
+        LOG.info("Successfully read rails assets manifest file located at {}", manifestFile.getAbsolutePath());
     }
 
     public String getAssetPath(String asset) {

--- a/server/src/com/thoughtworks/go/server/service/ValueStreamMapService.java
+++ b/server/src/com/thoughtworks/go/server/service/ValueStreamMapService.java
@@ -36,6 +36,8 @@ import com.thoughtworks.go.server.valuestreammap.RunStagesPopulator;
 import com.thoughtworks.go.server.valuestreammap.UnrunStagesPopulator;
 import com.thoughtworks.go.serverhealth.HealthStateScope;
 import com.thoughtworks.go.serverhealth.HealthStateType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -53,7 +55,7 @@ public class ValueStreamMapService {
     private final RunStagesPopulator runStagesPopulator;
     private final UnrunStagesPopulator unrunStagePopulator;
     private SecurityService securityService;
-    private static final org.apache.log4j.Logger LOGGER = org.apache.log4j.Logger.getLogger(ValueStreamMapService.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(ValueStreamMapService.class);
 
     @Autowired
     public ValueStreamMapService(PipelineService pipelineService, MaterialRepository materialRepository, GoConfigService goConfigService, DownstreamInstancePopulator downstreamInstancePopulator,
@@ -104,7 +106,7 @@ public class ValueStreamMapService {
 
         if (valueStreamMap.hasCycle()) {
             result.notImplemented(LocalizedMessage.string("VSM_CYCLIC_DEPENDENCY",pipelineName,counter));
-            LOGGER.error(String.format("[Value Stream Map] Cyclic dependency for pipeline %s with counter %s. Graph is %s", pipelineName, counter, valueStreamMap));
+            LOGGER.error("[Value Stream Map] Cyclic dependency for pipeline {} with counter {}. Graph is {}", pipelineName, counter, valueStreamMap);
             return null;
         }
         addInstanceInformationToTheGraph(valueStreamMap);

--- a/server/src/com/thoughtworks/go/server/service/lookups/CommandRepositoryDirectoryWalker.java
+++ b/server/src/com/thoughtworks/go/server/service/lookups/CommandRepositoryDirectoryWalker.java
@@ -30,7 +30,8 @@ import com.thoughtworks.go.util.SystemEnvironment;
 import org.apache.commons.io.DirectoryWalker;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -42,7 +43,7 @@ public class CommandRepositoryDirectoryWalker extends DirectoryWalker {
     private SystemEnvironment systemEnvironment;
     private CommandSnippetXmlParser commandSnippetXmlParser;
 
-    private static final Logger LOGGER = Logger.getLogger(CommandRepositoryDirectoryWalker.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(CommandRepositoryDirectoryWalker.class);
     private ThreadLocal<String> commandRepositoryBaseDirectory = new ThreadLocal<>();
 
     @Autowired
@@ -61,10 +62,10 @@ public class CommandRepositoryDirectoryWalker extends DirectoryWalker {
 
         String xmlContentOfFie = safeReadFileToString(file);
         if (xmlContentOfFie == null || !file.canRead()) {
-            serverHealthService.update(ServerHealthState.warning("Command Repository", "Failed to access command snippet XML file located in Go Server Directory at " + file.getPath() +
-                    ". Go does not have sufficient permissions to access it.", HealthStateType.commandRepositoryAccessibilityIssue(), systemEnvironment.getCommandRepoWarningTimeout()));
-            LOGGER.warn("[Command Repository] Failed to access command snippet XML file located in Go Server Directory at " + file.getAbsolutePath() +
-                    ". Go does not have sufficient permissions to access it.");
+            serverHealthService.update(ServerHealthState.warning("Command Repository", "Failed to access command snippet XML file located in GoCD Server Directory at " + file.getPath() +
+                    ". GoCD does not have sufficient permissions to access it.", HealthStateType.commandRepositoryAccessibilityIssue(), systemEnvironment.getCommandRepoWarningTimeout()));
+            LOGGER.warn("[Command Repository] Failed to access command snippet XML file located in GoCD Server Directory at " + file.getAbsolutePath() +
+                    ". GoCD does not have sufficient permissions to access it.");
             return;
         }
 
@@ -72,9 +73,10 @@ public class CommandRepositoryDirectoryWalker extends DirectoryWalker {
             String relativeFilePath = FileUtil.removeLeadingPath(commandRepositoryBaseDirectory.get(), file.getAbsolutePath());
             results.add(commandSnippetXmlParser.parse(xmlContentOfFie, FilenameUtils.getBaseName(fileName), relativeFilePath));
         } catch (Exception e) {
-            LOGGER.warn("Failed loading command snippet from " + file.getAbsolutePath());
+            String msg = "Failed loading command snippet from " + file.getAbsolutePath();
+            LOGGER.warn(msg);
             if (LOGGER.isDebugEnabled()) {
-                LOGGER.debug(e);
+                LOGGER.debug(msg, e);
             }
         }
     }
@@ -111,8 +113,8 @@ public class CommandRepositoryDirectoryWalker extends DirectoryWalker {
             if (commandRepositoryDirectory.isDirectory() && commandRepositoryDirectory.canRead() && commandRepositoryDirectory.canExecute()) {
                 return new CommandSnippets(walk(commandRepositoryDirectory));
             } else {
-                throw new IOException("Failed to access command repository located in Go Server Directory at " + repositoryDirectory +
-                        ". The directory does not exist or Go does not have sufficient permissions to access it.");
+                throw new IOException("Failed to access command repository located in GoCD Server Directory at " + repositoryDirectory +
+                        ". The directory does not exist or GoCD does not have sufficient permissions to access it.");
             }
         } catch (IOException e) {
             ServerHealthState serverHealthState = ServerHealthState.warning("Command Repository", e.getMessage(), HealthStateType.commandRepositoryAccessibilityIssue(),

--- a/server/test/unit/com/thoughtworks/go/server/service/lookups/CommandRepositoryDirectoryWalkerTest.java
+++ b/server/test/unit/com/thoughtworks/go/server/service/lookups/CommandRepositoryDirectoryWalkerTest.java
@@ -142,8 +142,8 @@ public class CommandRepositoryDirectoryWalkerTest {
 
         walker.getAllCommandSnippets(sampleDir.getPath());
 
-        verify(serverHealthService).update(serverHealthWarningMessageWhichContains("Failed to access command repository located in Go Server Directory at " + sampleDir.getPath() +
-                ". The directory does not exist or Go does not have sufficient permissions to access it."));
+        verify(serverHealthService).update(serverHealthWarningMessageWhichContains("Failed to access command repository located in GoCD Server Directory at " + sampleDir.getPath() +
+                ". The directory does not exist or GoCD does not have sufficient permissions to access it."));
     }
 
     @Test
@@ -154,8 +154,8 @@ public class CommandRepositoryDirectoryWalkerTest {
 
         walker.getAllCommandSnippets(sampleDir.getPath());
 
-        verify(serverHealthService).update(serverHealthWarningMessageWhichContains("Failed to access command repository located in Go Server Directory at " + sampleDir.getPath() +
-                ". The directory does not exist or Go does not have sufficient permissions to access it."));
+        verify(serverHealthService).update(serverHealthWarningMessageWhichContains("Failed to access command repository located in GoCD Server Directory at " + sampleDir.getPath() +
+                ". The directory does not exist or GoCD does not have sufficient permissions to access it."));
     }
 
     @Test
@@ -164,8 +164,8 @@ public class CommandRepositoryDirectoryWalkerTest {
         File nonExistentDirectory = new File("dirDoesNotExist");
         walker.getAllCommandSnippets(nonExistentDirectory.getPath());
 
-        verify(serverHealthService).update(serverHealthWarningMessageWhichContains("Failed to access command repository located in Go Server Directory at " + nonExistentDirectory.getPath() +
-                ". The directory does not exist or Go does not have sufficient permissions to access it."));
+        verify(serverHealthService).update(serverHealthWarningMessageWhichContains("Failed to access command repository located in GoCD Server Directory at " + nonExistentDirectory.getPath() +
+                ". The directory does not exist or GoCD does not have sufficient permissions to access it."));
     }
 
     @Test
@@ -174,8 +174,8 @@ public class CommandRepositoryDirectoryWalkerTest {
         sampleDir.setReadable(false);
         walker.getAllCommandSnippets(sampleDir.getPath());
 
-        verify(serverHealthService).update(serverHealthWarningMessageWhichContains("Failed to access command repository located in Go Server Directory at " + sampleDir.getPath() +
-                ". The directory does not exist or Go does not have sufficient permissions to access it."));
+        verify(serverHealthService).update(serverHealthWarningMessageWhichContains("Failed to access command repository located in GoCD Server Directory at " + sampleDir.getPath() +
+                ". The directory does not exist or GoCD does not have sufficient permissions to access it."));
 
         sampleDir.setReadable(true);
         walker.getAllCommandSnippets(sampleDir.getPath());
@@ -194,8 +194,8 @@ public class CommandRepositoryDirectoryWalkerTest {
         unreadableFile.setReadable(false);
         walker.getAllCommandSnippets(dirWithUnreadableFile.getPath());
 
-        verify(serverHealthService).update(serverHealthWarningMessageWhichContains("Failed to access command snippet XML file located in Go Server Directory at " + unreadableFile.getPath() +
-                ". Go does not have sufficient permissions to access it."));
+        verify(serverHealthService).update(serverHealthWarningMessageWhichContains("Failed to access command snippet XML file located in GoCD Server Directory at " + unreadableFile.getPath() +
+                ". GoCD does not have sufficient permissions to access it."));
 
         unreadableFile.setReadable(true);
         walker.getAllCommandSnippets(dirWithUnreadableFile.getPath());
@@ -209,8 +209,8 @@ public class CommandRepositoryDirectoryWalkerTest {
     public void shouldUpdateServerHealthServiceIfTheCommandRepositoryDirectoryIsActuallyAFile() throws IOException {
         walker.getAllCommandSnippets(xmlFile.getPath());
 
-        verify(serverHealthService).update(serverHealthWarningMessageWhichContains("Failed to access command repository located in Go Server Directory at " + xmlFile.getPath() +
-                ". The directory does not exist or Go does not have sufficient permissions to access it."));
+        verify(serverHealthService).update(serverHealthWarningMessageWhichContains("Failed to access command repository located in GoCD Server Directory at " + xmlFile.getPath() +
+                ". The directory does not exist or GoCD does not have sufficient permissions to access it."));
     }
 
     private ServerHealthState serverHealthMessageWhichSaysItsOk() {


### PR DESCRIPTION
I'm going to upgrade/change all of our usages of log4j to slf4j slowly - so that it's easier to merge. This is Part 1 of that and has some of the easier usages.

Next will be some or all of the slightly more interesting usages:

- LogFixture
- StreamLogger (used in CommandLine)
- FileUtil (add slf4j to build.gradle of util)
- DefaultPluginLoggingService and DefaultPluginLoggingServiceTest
- FileLocationProvider (root logger)
- GoMacLauncher (uses java.util.logging - change?)
- LdapUserSearchTest (mock verification)
- PipelineConfigServicePerformanceTest (ignored test, but lots of usages)
- LoggingHelper (be careful)
- SslInfrastructureService (fatal to error - make sure agent works)
- AgentUpgradeService (fatal to error - make sure agent works)
- AgentConsoleLogThread (root logger, NDC - make sure agent works)
- BootstrapperLoggingHelper (root logger - make sure agent works)

Also, have to worry about:
- Upon upgrade, what happens to log4j.properties?
- Agent bootstrapper logs - does it have access to slf4j? Bundle slf4j-api with it.
- Agent launcher logs - are different - does it have access to slf4j? Bundle slf4j-api with it.
- GoMacLauncher - Mac launcher logs

Finally, it'll be a full search-replace of all the other usages.

Related to #3243 - but this has been talked about long before and is overdue.