### PR TITLE
Providing support for Web based authentication

### DIFF
--- a/app-server/src/com/thoughtworks/go/server/util/ServletRequest.java
+++ b/app-server/src/com/thoughtworks/go/server/util/ServletRequest.java
@@ -21,4 +21,5 @@ public interface ServletRequest {
     String getUriPath();
     String getUriAsString();
     void setRequestURI(String uri);
+    String getRootURL();
 }

--- a/jetty9/src/com/thoughtworks/go/server/util/Jetty9Request.java
+++ b/jetty9/src/com/thoughtworks/go/server/util/Jetty9Request.java
@@ -44,4 +44,9 @@ public class Jetty9Request implements ServletRequest {
     public void setRequestURI(String uri) {
         request.setRequestURI(uri);
     }
+
+    @Override
+    public String getRootURL() {
+        return request.getRootURL().toString();
+    }
 }

--- a/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/DefaultPluginInteractionCallback.java
+++ b/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/DefaultPluginInteractionCallback.java
@@ -30,6 +30,11 @@ public class DefaultPluginInteractionCallback<T> implements PluginInteractionCal
     }
 
     @Override
+    public Map<String, String> requestHeaders(String resolvedExtensionVersion) {
+        return null;
+    }
+
+    @Override
     public T onSuccess(String responseBody, String resolvedExtensionVersion) {
         return null;
     }

--- a/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/PluginInteractionCallback.java
+++ b/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/PluginInteractionCallback.java
@@ -23,5 +23,7 @@ public interface PluginInteractionCallback<T> {
 
     Map<String, String> requestParams(String resolvedExtensionVersion);
 
+    Map<String, String> requestHeaders(String resolvedExtensionVersion);
+
     T onSuccess(String responseBody, String resolvedExtensionVersion);
 }

--- a/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/authorization/AuthorizationExtension.java
+++ b/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/authorization/AuthorizationExtension.java
@@ -236,7 +236,7 @@ public class AuthorizationExtension extends AbstractExtension {
 
             @Override
             public String onSuccess(String responseBody, String resolvedExtensionVersion) {
-                return getMessageConverter(resolvedExtensionVersion).getIdentityProviderUrl(responseBody);
+                return getMessageConverter(resolvedExtensionVersion).getAuthorizationServerUrl(responseBody);
             }
         });
     }

--- a/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/authorization/AuthorizationExtension.java
+++ b/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/authorization/AuthorizationExtension.java
@@ -181,8 +181,8 @@ public class AuthorizationExtension extends AbstractExtension {
         });
     }
 
-    public Map<String, String> grantIdentityProviderAccess(String pluginId, Map<String, String> requestHeaders, final Map<String, String> requestParams, List<SecurityAuthConfig> authConfigs) {
-        return pluginRequestHelper.submitRequest(pluginId, REQUEST_IDENTITY_PROVIDER_ACCESS, new DefaultPluginInteractionCallback<Map<String, String>>() {
+    public Map<String, String> fetchAccessToken(String pluginId, Map<String, String> requestHeaders, final Map<String, String> requestParams, List<SecurityAuthConfig> authConfigs) {
+        return pluginRequestHelper.submitRequest(pluginId, REQUEST_ACCESS_TOKEN, new DefaultPluginInteractionCallback<Map<String, String>>() {
             @Override
             public String requestBody(String resolvedExtensionVersion) {
                 return getMessageConverter(resolvedExtensionVersion).grantAccessRequestBody(authConfigs);
@@ -227,11 +227,11 @@ public class AuthorizationExtension extends AbstractExtension {
         });
     }
 
-    public String getIdentityProviderRedirectUrl(String pluginId, List<SecurityAuthConfig> authConfigs) {
-        return pluginRequestHelper.submitRequest(pluginId, REQUEST_IDENTITY_PROVIDER_URL, new DefaultPluginInteractionCallback<String>() {
+    public String getAuthorizationServerRedirectUrl(String pluginId, List<SecurityAuthConfig> authConfigs, String siteUrl) {
+        return pluginRequestHelper.submitRequest(pluginId, REQUEST_AUTHORIZATION_SERVER_REDIRECT_URL, new DefaultPluginInteractionCallback<String>() {
             @Override
             public String requestBody(String resolvedExtensionVersion) {
-                return getMessageConverter(resolvedExtensionVersion).identityProviderUrlRequestBody(authConfigs);
+                return getMessageConverter(resolvedExtensionVersion).authorizationServerRedirectUrlRequestBody(pluginId, authConfigs, siteUrl);
             }
 
             @Override

--- a/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/authorization/AuthorizationMessageConverter.java
+++ b/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/authorization/AuthorizationMessageConverter.java
@@ -56,7 +56,15 @@ public interface AuthorizationMessageConverter {
 
     String searchUsersRequestBody(String searchTerm, List<SecurityAuthConfig> authConfigs);
 
-    String processGetRoleConfigsRequest(String requestBody);
-
     String getProcessRoleConfigsResponseBody(List<PluginRoleConfig> roles);
+
+    String grantAccessRequestBody(List<SecurityAuthConfig> authConfigs);
+
+    Map<String,String> getCredentials(String responseBody);
+
+    String authenticateUserRequestBody(Map<String, String> credentials, List<SecurityAuthConfig> authConfigs, List<PluginRoleConfig> roleConfigs);
+
+    String getIdentityProviderUrl(String responseBody);
+
+    String identityProviderUrlRequestBody(List<SecurityAuthConfig> authConfigs);
 }

--- a/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/authorization/AuthorizationMessageConverter.java
+++ b/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/authorization/AuthorizationMessageConverter.java
@@ -64,7 +64,7 @@ public interface AuthorizationMessageConverter {
 
     String authenticateUserRequestBody(Map<String, String> credentials, List<SecurityAuthConfig> authConfigs, List<PluginRoleConfig> roleConfigs);
 
-    String getIdentityProviderUrl(String responseBody);
+    String getAuthorizationServerUrl(String responseBody);
 
     String authorizationServerRedirectUrlRequestBody(String pluginId, List<SecurityAuthConfig> authConfigs, String siteUrl);
 }

--- a/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/authorization/AuthorizationMessageConverter.java
+++ b/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/authorization/AuthorizationMessageConverter.java
@@ -66,5 +66,5 @@ public interface AuthorizationMessageConverter {
 
     String getIdentityProviderUrl(String responseBody);
 
-    String identityProviderUrlRequestBody(List<SecurityAuthConfig> authConfigs);
+    String authorizationServerRedirectUrlRequestBody(String pluginId, List<SecurityAuthConfig> authConfigs, String siteUrl);
 }

--- a/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/authorization/AuthorizationMessageConverterV1.java
+++ b/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/authorization/AuthorizationMessageConverterV1.java
@@ -197,9 +197,10 @@ public class AuthorizationMessageConverterV1 implements AuthorizationMessageConv
     }
 
     @Override
-    public String identityProviderUrlRequestBody(List<SecurityAuthConfig> authConfigs) {
+    public String authorizationServerRedirectUrlRequestBody(String pluginId, List<SecurityAuthConfig> authConfigs, String siteUrl) {
         Map<String, Object> requestMap = new HashMap<>();
         requestMap.put("auth_configs", getAuthConfigs(authConfigs));
+        requestMap.put("authorization_server_callback_url", authorizationServerCallbackUrl(pluginId, siteUrl));
 
         return GSON.toJson(requestMap);
     }
@@ -212,4 +213,7 @@ public class AuthorizationMessageConverterV1 implements AuthorizationMessageConv
         return template;
     }
 
+    private String authorizationServerCallbackUrl(String pluginId, String siteUrl) {
+        return String.format("%s/go/plugin/%s/authenticate", siteUrl, pluginId);
+    }
 }

--- a/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/authorization/AuthorizationMessageConverterV1.java
+++ b/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/authorization/AuthorizationMessageConverterV1.java
@@ -192,8 +192,8 @@ public class AuthorizationMessageConverterV1 implements AuthorizationMessageConv
     }
 
     @Override
-    public String getIdentityProviderUrl(String responseBody) {
-        return (String) new Gson().fromJson(responseBody, Map.class).get("identity_provider_url");
+    public String getAuthorizationServerUrl(String responseBody) {
+        return (String) new Gson().fromJson(responseBody, Map.class).get("authorization_server_url");
     }
 
     @Override

--- a/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/authorization/AuthorizationPluginConstants.java
+++ b/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/authorization/AuthorizationPluginConstants.java
@@ -42,4 +42,7 @@ public interface AuthorizationPluginConstants {
 
     String REQUEST_AUTHENTICATE_USER = REQUEST_PREFIX + ".authenticate-user";
     String REQUEST_SEARCH_USERS = REQUEST_PREFIX + ".search-users";
+
+    String REQUEST_IDENTITY_PROVIDER_ACCESS = REQUEST_PREFIX + ".identity-provider-access";
+    String REQUEST_IDENTITY_PROVIDER_URL = REQUEST_PREFIX + ".identity-provider-url";
 }

--- a/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/authorization/AuthorizationPluginConstants.java
+++ b/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/authorization/AuthorizationPluginConstants.java
@@ -43,6 +43,6 @@ public interface AuthorizationPluginConstants {
     String REQUEST_AUTHENTICATE_USER = REQUEST_PREFIX + ".authenticate-user";
     String REQUEST_SEARCH_USERS = REQUEST_PREFIX + ".search-users";
 
-    String REQUEST_IDENTITY_PROVIDER_ACCESS = REQUEST_PREFIX + ".identity-provider-access";
-    String REQUEST_IDENTITY_PROVIDER_URL = REQUEST_PREFIX + ".identity-provider-url";
+    String REQUEST_ACCESS_TOKEN = REQUEST_PREFIX + ".fetch-access-token";
+    String REQUEST_AUTHORIZATION_SERVER_REDIRECT_URL = REQUEST_PREFIX + ".authorization-server-redirect-url";
 }

--- a/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/common/models/Image.java
+++ b/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/common/models/Image.java
@@ -80,7 +80,7 @@ public class Image {
     }
 
     public com.thoughtworks.go.plugin.domain.common.Image toDomainImage() {
-        return new com.thoughtworks.go.plugin.domain.common.Image(this.contentType, this.data);
+        return new com.thoughtworks.go.plugin.domain.common.Image(this.contentType, this.data, getHash());
     }
 
     @Override

--- a/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/configrepo/ConfigRepoExtension.java
+++ b/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/configrepo/ConfigRepoExtension.java
@@ -16,6 +16,7 @@
 
 package com.thoughtworks.go.plugin.access.configrepo;
 
+import com.thoughtworks.go.plugin.access.DefaultPluginInteractionCallback;
 import com.thoughtworks.go.plugin.access.PluginInteractionCallback;
 import com.thoughtworks.go.plugin.access.PluginRequestHelper;
 import com.thoughtworks.go.plugin.access.common.AbstractExtension;
@@ -51,7 +52,7 @@ public class ConfigRepoExtension extends AbstractExtension implements ConfigRepo
 
     @Override
     public CRParseResult parseDirectory(String pluginId, final String destinationFolder, final Collection<CRConfigurationProperty> configurations) {
-        return pluginRequestHelper.submitRequest(pluginId, REQUEST_PARSE_DIRECTORY, new PluginInteractionCallback<CRParseResult>() {
+        return pluginRequestHelper.submitRequest(pluginId, REQUEST_PARSE_DIRECTORY, new DefaultPluginInteractionCallback<CRParseResult>() {
             @Override
             public String requestBody(String resolvedExtensionVersion) {
                 return messageHandlerMap.get(resolvedExtensionVersion).requestMessageForParseDirectory(destinationFolder,configurations);

--- a/plugin-infra/go-plugin-access/test/com/thoughtworks/go/plugin/access/authorization/AuthorizationExtensionTest.java
+++ b/plugin-infra/go-plugin-access/test/com/thoughtworks/go/plugin/access/authorization/AuthorizationExtensionTest.java
@@ -311,7 +311,7 @@ public class AuthorizationExtensionTest {
                 "  ],\n" +
                 "  \"authorization_server_callback_url\": \"http://go.site.url/go/plugin/plugin-id/authenticate\"\n"+
                 "}";
-        String responseBody = "{\"identity_provider_url\":\"url_to_identity_provder\"}";
+        String responseBody = "{\"authorization_server_url\":\"url_to_authorization_server\"}";
         SecurityAuthConfig authConfig = new SecurityAuthConfig("github", "cd.go.github", ConfigurationPropertyMother.create("url", false, "some-url"));
 
         when(pluginManager.submitTo(eq(PLUGIN_ID), requestArgumentCaptor.capture())).thenReturn(new DefaultGoPluginApiResponse(SUCCESS_RESPONSE_CODE, responseBody));
@@ -319,7 +319,7 @@ public class AuthorizationExtensionTest {
         String authorizationServerRedirectUrl = authorizationExtension.getAuthorizationServerRedirectUrl(PLUGIN_ID, Collections.singletonList(authConfig), "http://go.site.url");
 
         assertRequest(requestArgumentCaptor.getValue(), AuthorizationPluginConstants.EXTENSION_NAME, "1.0", REQUEST_AUTHORIZATION_SERVER_REDIRECT_URL, requestBody);
-        assertThat(authorizationServerRedirectUrl, is("url_to_identity_provder"));
+        assertThat(authorizationServerRedirectUrl, is("url_to_authorization_server"));
     }
 
     private void assertRequest(GoPluginApiRequest goPluginApiRequest, String extensionName, String version, String requestName, String requestBody) throws JSONException {

--- a/plugin-infra/go-plugin-access/test/com/thoughtworks/go/plugin/access/authorization/AuthorizationExtensionTest.java
+++ b/plugin-infra/go-plugin-access/test/com/thoughtworks/go/plugin/access/authorization/AuthorizationExtensionTest.java
@@ -299,7 +299,7 @@ public class AuthorizationExtensionTest {
     }
 
     @Test
-    public void shouldTalkToPlugin_To_GetIdentityProviderRedirectUrl() throws JSONException {
+    public void shouldTalkToPlugin_To_GetAuthorizationServerRedirectUrl() throws JSONException {
         String requestBody = "{\n" +
                 "  \"auth_configs\": [\n" +
                 "    {\n" +
@@ -308,17 +308,18 @@ public class AuthorizationExtensionTest {
                 "        \"url\": \"some-url\"\n" +
                 "      }\n" +
                 "    }\n" +
-                "  ]\n" +
+                "  ],\n" +
+                "  \"authorization_server_callback_url\": \"http://go.site.url/go/plugin/plugin-id/authenticate\"\n"+
                 "}";
         String responseBody = "{\"identity_provider_url\":\"url_to_identity_provder\"}";
         SecurityAuthConfig authConfig = new SecurityAuthConfig("github", "cd.go.github", ConfigurationPropertyMother.create("url", false, "some-url"));
 
         when(pluginManager.submitTo(eq(PLUGIN_ID), requestArgumentCaptor.capture())).thenReturn(new DefaultGoPluginApiResponse(SUCCESS_RESPONSE_CODE, responseBody));
 
-        String identityProviderRedirectUrl = authorizationExtension.getIdentityProviderRedirectUrl(PLUGIN_ID, Collections.singletonList(authConfig));
+        String authorizationServerRedirectUrl = authorizationExtension.getAuthorizationServerRedirectUrl(PLUGIN_ID, Collections.singletonList(authConfig), "http://go.site.url");
 
-        assertRequest(requestArgumentCaptor.getValue(), AuthorizationPluginConstants.EXTENSION_NAME, "1.0", REQUEST_IDENTITY_PROVIDER_URL, requestBody);
-        assertThat(identityProviderRedirectUrl, is("url_to_identity_provder"));
+        assertRequest(requestArgumentCaptor.getValue(), AuthorizationPluginConstants.EXTENSION_NAME, "1.0", REQUEST_AUTHORIZATION_SERVER_REDIRECT_URL, requestBody);
+        assertThat(authorizationServerRedirectUrl, is("url_to_identity_provder"));
     }
 
     private void assertRequest(GoPluginApiRequest goPluginApiRequest, String extensionName, String version, String requestName, String requestBody) throws JSONException {

--- a/plugin-infra/go-plugin-access/test/com/thoughtworks/go/plugin/access/authorization/AuthorizationPluginInfoBuilderTest.java
+++ b/plugin-infra/go-plugin-access/test/com/thoughtworks/go/plugin/access/authorization/AuthorizationPluginInfoBuilderTest.java
@@ -25,7 +25,6 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
 import static org.hamcrest.core.Is.is;
@@ -94,7 +93,7 @@ public class AuthorizationPluginInfoBuilderTest {
     @Test
     public void shouldBuildPluginInfoWithImage() throws Exception {
         GoPluginDescriptor descriptor =  new GoPluginDescriptor("plugin1", null, null, null, null, false);
-        Image icon = new Image("content_type", "data");
+        Image icon = new Image("content_type", "data", "hash");
 
         when(extension.getIcon(descriptor.id())).thenReturn(icon);
 

--- a/plugin-infra/go-plugin-access/test/com/thoughtworks/go/plugin/access/elastic/ElasticAgentPluginInfoBuilderTest.java
+++ b/plugin-infra/go-plugin-access/test/com/thoughtworks/go/plugin/access/elastic/ElasticAgentPluginInfoBuilderTest.java
@@ -23,7 +23,6 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
 import static org.hamcrest.core.Is.is;
@@ -64,7 +63,7 @@ public class ElasticAgentPluginInfoBuilderTest {
     @Test
     public void shouldBuildPluginInfoWithImage() throws Exception {
         GoPluginDescriptor descriptor =  new GoPluginDescriptor("plugin1", null, null, null, null, false);
-        Image icon = new Image("content_type", "data");
+        Image icon = new Image("content_type", "data", "hash");
 
         when(extension.getIcon(descriptor.id())).thenReturn(icon);
 

--- a/plugin-infra/go-plugin-domain/src/com/thoughtworks/go/plugin/domain/authorization/AuthorizationPluginInfo.java
+++ b/plugin-infra/go-plugin-domain/src/com/thoughtworks/go/plugin/domain/authorization/AuthorizationPluginInfo.java
@@ -64,8 +64,8 @@ public class AuthorizationPluginInfo extends PluginInfo {
             return false;
         if (roleSettings != null ? !roleSettings.equals(that.roleSettings) : that.roleSettings != null) return false;
         if (image != null ? !image.equals(that.image) : that.image != null) return false;
-        return capabilities != null ? capabilities.equals(that.capabilities) : that.capabilities == null;
-
+        if (capabilities != null ? !capabilities.equals(that.capabilities) : that.capabilities != null) return false;
+        return super.equals(that);
     }
 
     @Override

--- a/plugin-infra/go-plugin-domain/src/com/thoughtworks/go/plugin/domain/common/Image.java
+++ b/plugin-infra/go-plugin-domain/src/com/thoughtworks/go/plugin/domain/common/Image.java
@@ -19,10 +19,12 @@ package com.thoughtworks.go.plugin.domain.common;
 public class Image {
     private final String contentType;
     private final String data;
+    private String hash;
 
-    public Image(String contentType, String data) {
+    public Image(String contentType, String data, String hash) {
         this.contentType = contentType;
         this.data = data;
+        this.hash = hash;
     }
 
     public String getContentType() {
@@ -33,6 +35,10 @@ public class Image {
         return data;
     }
 
+    public String getHash() {
+        return hash;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -41,14 +47,15 @@ public class Image {
         Image image = (Image) o;
 
         if (contentType != null ? !contentType.equals(image.contentType) : image.contentType != null) return false;
-        return data != null ? data.equals(image.data) : image.data == null;
-
+        if (data != null ? !data.equals(image.data) : image.data != null) return false;
+        return hash != null ? hash.equals(image.hash) : image.hash == null;
     }
 
     @Override
     public int hashCode() {
         int result = contentType != null ? contentType.hashCode() : 0;
         result = 31 * result + (data != null ? data.hashCode() : 0);
+        result = 31 * result + (hash != null ? hash.hashCode() : 0);
         return result;
     }
 }

--- a/plugin-infra/plugin-metadata-store/src/com/thoughtworks/go/plugin/access/authorization/AuthorizationMetadataStore.java
+++ b/plugin-infra/plugin-metadata-store/src/com/thoughtworks/go/plugin/access/authorization/AuthorizationMetadataStore.java
@@ -33,15 +33,15 @@ public class AuthorizationMetadataStore extends MetadataStore<AuthorizationPlugi
         return store;
     }
 
-    public Set<String> getPluginsThatSupportsPasswordBasedAuthentication() {
+    public Set<AuthorizationPluginInfo> getPluginsThatSupportsPasswordBasedAuthentication() {
         return getPluginsThatSupports(SupportedAuthType.Password);
     }
 
-    private Set<String> getPluginsThatSupports(SupportedAuthType supportedAuthType) {
-        Set<String> plugins = new HashSet<>();
+    private Set<AuthorizationPluginInfo> getPluginsThatSupports(SupportedAuthType supportedAuthType) {
+        Set<AuthorizationPluginInfo> plugins = new HashSet<>();
         for (AuthorizationPluginInfo pluginInfo : this.pluginInfos.values()) {
             if (pluginInfo.getCapabilities().getSupportedAuthType() == supportedAuthType) {
-                plugins.add(pluginInfo.getDescriptor().id());
+                plugins.add(pluginInfo);
             }
         }
         return plugins;
@@ -57,7 +57,7 @@ public class AuthorizationMetadataStore extends MetadataStore<AuthorizationPlugi
         return plugins;
     }
 
-    public Set<String> getPluginsThatSupportsWebBasedAuthentication() {
+    public Set<AuthorizationPluginInfo> getPluginsThatSupportsWebBasedAuthentication() {
         return getPluginsThatSupports(SupportedAuthType.Web);
     }
 }

--- a/plugin-infra/plugin-metadata-store/src/com/thoughtworks/go/plugin/access/authorization/AuthorizationMetadataStore.java
+++ b/plugin-infra/plugin-metadata-store/src/com/thoughtworks/go/plugin/access/authorization/AuthorizationMetadataStore.java
@@ -26,7 +26,7 @@ import java.util.Set;
 public class AuthorizationMetadataStore extends MetadataStore<AuthorizationPluginInfo> {
     private static final AuthorizationMetadataStore store = new AuthorizationMetadataStore();
 
-    private AuthorizationMetadataStore() {
+    protected AuthorizationMetadataStore() {
     }
 
     public static AuthorizationMetadataStore instance() {
@@ -55,5 +55,9 @@ public class AuthorizationMetadataStore extends MetadataStore<AuthorizationPlugi
             }
         }
         return plugins;
+    }
+
+    public Set<String> getPluginsThatSupportsWebBasedAuthentication() {
+        return getPluginsThatSupports(SupportedAuthType.Web);
     }
 }

--- a/plugin-infra/plugin-metadata-store/test/com/thoughtworks/go/plugin/access/authorization/AuthorizationMetadataStoreTest.java
+++ b/plugin-infra/plugin-metadata-store/test/com/thoughtworks/go/plugin/access/authorization/AuthorizationMetadataStoreTest.java
@@ -1,0 +1,59 @@
+package com.thoughtworks.go.plugin.access.authorization;
+
+import com.thoughtworks.go.plugin.api.info.PluginDescriptor;
+import com.thoughtworks.go.plugin.domain.authorization.AuthorizationPluginInfo;
+import com.thoughtworks.go.plugin.domain.authorization.Capabilities;
+import com.thoughtworks.go.plugin.domain.authorization.SupportedAuthType;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Set;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class AuthorizationMetadataStoreTest {
+
+    private AuthorizationMetadataStore store;
+
+    @Before
+    public void setUp() throws Exception {
+        store = new AuthorizationMetadataStore();
+        AuthorizationPluginInfo plugin1 = pluginInfo("plugin-1", SupportedAuthType.Web);
+        AuthorizationPluginInfo plugin2 = pluginInfo("plugin-2", SupportedAuthType.Password);
+        AuthorizationPluginInfo plugin3 = pluginInfo("plugin-3", SupportedAuthType.Web);
+        store.setPluginInfo(plugin1);
+        store.setPluginInfo(plugin2);
+        store.setPluginInfo(plugin3);
+
+    }
+
+    @Test
+    public void shouldGetPluginsThatSupportWebBasedAuthorization() {
+        Set<String> pluginsThatSupportsWebBasedAuthentication = store.getPluginsThatSupportsWebBasedAuthentication();
+        assertThat(pluginsThatSupportsWebBasedAuthentication.size(), is(2));
+        assertThat(pluginsThatSupportsWebBasedAuthentication.contains("plugin-1"), is(true));
+        assertThat(pluginsThatSupportsWebBasedAuthentication.contains("plugin-3"), is(true));
+    }
+
+    @Test
+    public void shouldGetPluginsThatSupportPasswordBasedAuthorization() {
+        Set<String> pluginsThatSupportsWebBasedAuthentication = store.getPluginsThatSupportsPasswordBasedAuthentication();
+        assertThat(pluginsThatSupportsWebBasedAuthentication.size(), is(1));
+        assertThat(pluginsThatSupportsWebBasedAuthentication.contains("plugin-2"), is(true));
+    }
+
+    private AuthorizationPluginInfo pluginInfo(String pluginId, SupportedAuthType supportedAuthType) {
+        AuthorizationPluginInfo pluginInfo = mock(AuthorizationPluginInfo.class);
+        PluginDescriptor pluginDescriptor = mock(PluginDescriptor.class);
+        when(pluginDescriptor.id()).thenReturn(pluginId);
+        when(pluginInfo.getDescriptor()).thenReturn(pluginDescriptor);
+        Capabilities capabilities = mock(Capabilities.class);
+        when(capabilities.getSupportedAuthType()).thenReturn(supportedAuthType);
+        when(pluginInfo.getCapabilities()).thenReturn(capabilities);
+        return pluginInfo;
+    }
+
+}

--- a/plugin-infra/plugin-metadata-store/test/com/thoughtworks/go/plugin/access/authorization/AuthorizationMetadataStoreTest.java
+++ b/plugin-infra/plugin-metadata-store/test/com/thoughtworks/go/plugin/access/authorization/AuthorizationMetadataStoreTest.java
@@ -17,13 +17,16 @@ import static org.mockito.Mockito.when;
 public class AuthorizationMetadataStoreTest {
 
     private AuthorizationMetadataStore store;
+    private AuthorizationPluginInfo plugin1;
+    private AuthorizationPluginInfo plugin2;
+    private AuthorizationPluginInfo plugin3;
 
     @Before
     public void setUp() throws Exception {
         store = new AuthorizationMetadataStore();
-        AuthorizationPluginInfo plugin1 = pluginInfo("plugin-1", SupportedAuthType.Web);
-        AuthorizationPluginInfo plugin2 = pluginInfo("plugin-2", SupportedAuthType.Password);
-        AuthorizationPluginInfo plugin3 = pluginInfo("plugin-3", SupportedAuthType.Web);
+        plugin1 = pluginInfo("plugin-1", SupportedAuthType.Web);
+        plugin2 = pluginInfo("plugin-2", SupportedAuthType.Password);
+        plugin3 = pluginInfo("plugin-3", SupportedAuthType.Web);
         store.setPluginInfo(plugin1);
         store.setPluginInfo(plugin2);
         store.setPluginInfo(plugin3);
@@ -32,17 +35,17 @@ public class AuthorizationMetadataStoreTest {
 
     @Test
     public void shouldGetPluginsThatSupportWebBasedAuthorization() {
-        Set<String> pluginsThatSupportsWebBasedAuthentication = store.getPluginsThatSupportsWebBasedAuthentication();
+        Set<AuthorizationPluginInfo> pluginsThatSupportsWebBasedAuthentication = store.getPluginsThatSupportsWebBasedAuthentication();
         assertThat(pluginsThatSupportsWebBasedAuthentication.size(), is(2));
-        assertThat(pluginsThatSupportsWebBasedAuthentication.contains("plugin-1"), is(true));
-        assertThat(pluginsThatSupportsWebBasedAuthentication.contains("plugin-3"), is(true));
+        assertThat(pluginsThatSupportsWebBasedAuthentication.contains(plugin1), is(true));
+        assertThat(pluginsThatSupportsWebBasedAuthentication.contains(plugin3), is(true));
     }
 
     @Test
     public void shouldGetPluginsThatSupportPasswordBasedAuthorization() {
-        Set<String> pluginsThatSupportsWebBasedAuthentication = store.getPluginsThatSupportsPasswordBasedAuthentication();
+        Set<AuthorizationPluginInfo> pluginsThatSupportsWebBasedAuthentication = store.getPluginsThatSupportsPasswordBasedAuthentication();
         assertThat(pluginsThatSupportsWebBasedAuthentication.size(), is(1));
-        assertThat(pluginsThatSupportsWebBasedAuthentication.contains("plugin-2"), is(true));
+        assertThat(pluginsThatSupportsWebBasedAuthentication.contains(plugin2), is(true));
     }
 
     private AuthorizationPluginInfo pluginInfo(String pluginId, SupportedAuthType supportedAuthType) {

--- a/server/src/com/thoughtworks/go/server/controller/AuthorizationController.java
+++ b/server/src/com/thoughtworks/go/server/controller/AuthorizationController.java
@@ -19,6 +19,8 @@ package com.thoughtworks.go.server.controller;
 import com.thoughtworks.go.CurrentGoCDVersion;
 import com.thoughtworks.go.i18n.Localizer;
 import com.thoughtworks.go.plugin.access.authentication.AuthenticationPluginRegistry;
+import com.thoughtworks.go.plugin.access.authorization.AuthorizationMetadataStore;
+import com.thoughtworks.go.server.service.SecurityAuthConfigService;
 import com.thoughtworks.go.server.web.GoVelocityView;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
@@ -35,11 +37,13 @@ import java.util.HashMap;
 public class AuthorizationController {
     private final Localizer localizer;
     private AuthenticationPluginRegistry authenticationPluginRegistry;
+    private SecurityAuthConfigService securityAuthConfigService;
 
     @Autowired
-    public AuthorizationController(Localizer localizer, AuthenticationPluginRegistry authenticationPluginRegistry) {
+    public AuthorizationController(Localizer localizer, AuthenticationPluginRegistry authenticationPluginRegistry, SecurityAuthConfigService securityAuthConfigService) {
         this.localizer = localizer;
         this.authenticationPluginRegistry = authenticationPluginRegistry;
+        this.securityAuthConfigService = securityAuthConfigService;
     }
 
     @RequestMapping(value = "/auth/login", method = RequestMethod.GET)
@@ -53,6 +57,7 @@ public class AuthorizationController {
         model.put("login_error", loginError);
         model.put("l", localizer);
         model.put("authentication_plugin_registry", authenticationPluginRegistry);
+        model.put("security_auth_config_service", securityAuthConfigService);
         model.put(GoVelocityView.CURRENT_GOCD_VERSION, CurrentGoCDVersion.getInstance());
         return new ModelAndView("auth/login", model);
     }

--- a/server/src/com/thoughtworks/go/server/security/BasicAuthenticationFilter.java
+++ b/server/src/com/thoughtworks/go/server/security/BasicAuthenticationFilter.java
@@ -17,11 +17,16 @@
 package com.thoughtworks.go.server.security;
 
 import com.thoughtworks.go.i18n.Localizer;
+import com.thoughtworks.go.server.util.ServletHelper;
+import com.thoughtworks.go.server.web.BaseUrlProvider;
+import com.thoughtworks.go.server.web.SiteUrlProvider;
 import org.apache.log4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.security.ui.AbstractProcessingFilter;
 import org.springframework.security.ui.basicauth.BasicProcessingFilter;
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.context.support.WebApplicationContextUtils;
 
 import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
@@ -29,6 +34,7 @@ import javax.servlet.ServletRequest;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.net.URISyntaxException;
 import java.util.List;
 
 public class BasicAuthenticationFilter extends BasicProcessingFilter {

--- a/server/src/com/thoughtworks/go/server/security/PreAuthenticatedRequestsProcessingFilter.java
+++ b/server/src/com/thoughtworks/go/server/security/PreAuthenticatedRequestsProcessingFilter.java
@@ -47,17 +47,17 @@ public class PreAuthenticatedRequestsProcessingFilter extends AbstractProcessing
         this.configService = configService;
     }
 
-    protected Map<String, String> getPreAuthenticatedCredentials(HttpServletRequest request) {
+    protected Map<String, String> fetchAuthorizationServerAccessToken(HttpServletRequest request) {
         String pluginId = pluginId(request);
         List<SecurityAuthConfig> authConfigs = configService.security().securityAuthConfigs().findByPluginId(pluginId);
 
-        return authorizationExtension.grantIdentityProviderAccess(pluginId, getRequestHeaders(request), getParameterMap(request), authConfigs);
+        return authorizationExtension.fetchAccessToken(pluginId, getRequestHeaders(request), getParameterMap(request), authConfigs);
     }
 
     @Override
     public Authentication attemptAuthentication(HttpServletRequest request) throws AuthenticationException {
         PreAuthenticatedAuthenticationToken authRequest = new PreAuthenticatedAuthenticationToken(null,
-                getPreAuthenticatedCredentials(request), pluginId(request));
+                fetchAuthorizationServerAccessToken(request), pluginId(request));
 
         Authentication authResult = this.getAuthenticationManager().authenticate(authRequest);
 

--- a/server/src/com/thoughtworks/go/server/security/PreAuthenticatedRequestsProcessingFilter.java
+++ b/server/src/com/thoughtworks/go/server/security/PreAuthenticatedRequestsProcessingFilter.java
@@ -45,6 +45,7 @@ public class PreAuthenticatedRequestsProcessingFilter extends AbstractProcessing
     public PreAuthenticatedRequestsProcessingFilter(AuthorizationExtension authorizationExtension, GoConfigService configService) {
         this.authorizationExtension = authorizationExtension;
         this.configService = configService;
+        setAlwaysUseDefaultTargetUrl(true);
     }
 
     protected Map<String, String> fetchAuthorizationServerAccessToken(HttpServletRequest request) {

--- a/server/src/com/thoughtworks/go/server/security/PreAuthenticatedRequestsProcessingFilter.java
+++ b/server/src/com/thoughtworks/go/server/security/PreAuthenticatedRequestsProcessingFilter.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2017 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.server.security;
+
+
+import com.thoughtworks.go.config.SecurityAuthConfig;
+import com.thoughtworks.go.plugin.access.authorization.AuthorizationExtension;
+import com.thoughtworks.go.server.security.tokens.PreAuthenticatedAuthenticationToken;
+import com.thoughtworks.go.server.service.GoConfigService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.Authentication;
+import org.springframework.security.AuthenticationException;
+import org.springframework.security.context.SecurityContextHolder;
+import org.springframework.security.ui.AbstractProcessingFilter;
+import org.springframework.security.ui.FilterChainOrder;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class PreAuthenticatedRequestsProcessingFilter extends AbstractProcessingFilter {
+    private final AuthorizationExtension authorizationExtension;
+    private final GoConfigService configService;
+
+    @Autowired
+    public PreAuthenticatedRequestsProcessingFilter(AuthorizationExtension authorizationExtension, GoConfigService configService) {
+        this.authorizationExtension = authorizationExtension;
+        this.configService = configService;
+    }
+
+    protected Map<String, String> getPreAuthenticatedCredentials(HttpServletRequest request) {
+        String pluginId = pluginId(request);
+        List<SecurityAuthConfig> authConfigs = configService.security().securityAuthConfigs().findByPluginId(pluginId);
+
+        return authorizationExtension.grantIdentityProviderAccess(pluginId, getRequestHeaders(request), getParameterMap(request), authConfigs);
+    }
+
+    @Override
+    public Authentication attemptAuthentication(HttpServletRequest request) throws AuthenticationException {
+        PreAuthenticatedAuthenticationToken authRequest = new PreAuthenticatedAuthenticationToken(null,
+                getPreAuthenticatedCredentials(request), pluginId(request));
+
+        Authentication authResult = this.getAuthenticationManager().authenticate(authRequest);
+
+        return authResult;
+    }
+
+    @Override
+    protected boolean requiresAuthentication(HttpServletRequest request, HttpServletResponse response) {
+        return isPreAuthenticationRequest(request);
+    }
+
+    @Override
+    public String getDefaultFilterProcessesUrl() {
+        return null;
+    }
+
+    @Override
+    public int getOrder() {
+        return FilterChainOrder.PRE_AUTH_FILTER;
+    }
+
+    private boolean isPreAuthenticationRequest(HttpServletRequest request) {
+        return SecurityContextHolder.getContext().getAuthentication() == null &&
+                Pattern.compile(getFilterProcessesUrl()).matcher(request.getRequestURI()).matches();
+    }
+
+    private String pluginId(HttpServletRequest request) {
+        Matcher matcher = Pattern.compile(getFilterProcessesUrl()).matcher(request.getRequestURI());
+        matcher.matches();
+        return matcher.group(1);
+    }
+
+    private Map<String, String> getParameterMap(HttpServletRequest request) {
+        Map<String, String[]> springParameterMap = request.getParameterMap();
+        Map<String, String> pluginParameterMap = new HashMap<>();
+        for (String parameterName : springParameterMap.keySet()) {
+            String[] values = springParameterMap.get(parameterName);
+            if (values != null && values.length > 0) {
+                pluginParameterMap.put(parameterName, values[0]);
+            } else {
+                pluginParameterMap.put(parameterName, null);
+            }
+        }
+        return pluginParameterMap;
+    }
+
+    private HashMap<String, String> getRequestHeaders(HttpServletRequest request) {
+        HashMap<String, String> headers = new HashMap<>();
+        Enumeration headerNames = request.getHeaderNames();
+        while (headerNames.hasMoreElements()) {
+            String header = (String) headerNames.nextElement();
+            String value = request.getHeader(header);
+            headers.put(header, value);
+        }
+        return headers;
+    }
+}

--- a/server/src/com/thoughtworks/go/server/security/WebBasedPluginAuthenticationFilter.java
+++ b/server/src/com/thoughtworks/go/server/security/WebBasedPluginAuthenticationFilter.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2017 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.server.security;
+
+
+import com.thoughtworks.go.config.SecurityAuthConfig;
+import com.thoughtworks.go.plugin.access.authorization.AuthorizationExtension;
+import com.thoughtworks.go.server.service.GoConfigService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.ui.basicauth.BasicProcessingFilter;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class WebBasedPluginAuthenticationFilter extends BasicProcessingFilter {
+    private static final Pattern LOGIN_REQUEST_PATTERN = Pattern.compile("^/go/plugin/([^\\s]+)/login$");
+    private AuthorizationExtension authorizationExtension;
+    private GoConfigService goConfigService;
+
+    @Autowired
+    public WebBasedPluginAuthenticationFilter(AuthorizationExtension authorizationExtension, GoConfigService goConfigService) {
+        this.authorizationExtension = authorizationExtension;
+        this.goConfigService = goConfigService;
+    }
+
+    @Override
+    public void doFilterHttp(HttpServletRequest httpRequest, HttpServletResponse httpResponse, FilterChain chain) throws IOException, ServletException {
+        if(isWebBasedPluginLoginRequest(httpRequest)) {
+            httpResponse.sendRedirect(identityProviderRedirectUrl(pluginId(httpRequest)));
+        }
+
+        super.doFilterHttp(httpRequest, httpResponse, chain);
+    }
+
+    private String pluginId(HttpServletRequest request) {
+        Matcher matcher = LOGIN_REQUEST_PATTERN.matcher(request.getRequestURI());
+        matcher.matches();
+
+        return matcher.group(1);
+    }
+
+    private String identityProviderRedirectUrl(String pluginId) {
+        List<SecurityAuthConfig> authConfigs = goConfigService.security().securityAuthConfigs().findByPluginId(pluginId);
+        return this.authorizationExtension.getIdentityProviderRedirectUrl(pluginId, authConfigs);
+    }
+
+    private boolean isWebBasedPluginLoginRequest(HttpServletRequest request) {
+        return LOGIN_REQUEST_PATTERN.matcher(request.getRequestURI()).matches();
+    }
+}

--- a/server/src/com/thoughtworks/go/server/security/providers/PreAuthenticatedAuthenticationProvider.java
+++ b/server/src/com/thoughtworks/go/server/security/providers/PreAuthenticatedAuthenticationProvider.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2017 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.server.security.providers;
+
+import com.thoughtworks.go.config.CaseInsensitiveString;
+import com.thoughtworks.go.config.PluginRoleConfig;
+import com.thoughtworks.go.config.SecurityAuthConfig;
+import com.thoughtworks.go.plugin.access.authentication.models.User;
+import com.thoughtworks.go.plugin.access.authorization.AuthorizationExtension;
+import com.thoughtworks.go.plugin.access.authorization.models.AuthenticationResponse;
+import com.thoughtworks.go.server.security.AuthorityGranter;
+import com.thoughtworks.go.server.security.tokens.PreAuthenticatedAuthenticationToken;
+import com.thoughtworks.go.server.security.userdetail.GoUserPrinciple;
+import com.thoughtworks.go.server.service.GoConfigService;
+import com.thoughtworks.go.server.service.PluginRoleService;
+import com.thoughtworks.go.server.service.UserService;
+import org.springframework.security.Authentication;
+import org.springframework.security.AuthenticationException;
+import org.springframework.security.BadCredentialsException;
+import org.springframework.security.providers.AuthenticationProvider;
+import org.springframework.security.userdetails.UserDetails;
+
+import java.util.List;
+
+import static org.apache.commons.lang.StringUtils.isNotBlank;
+
+public class PreAuthenticatedAuthenticationProvider implements AuthenticationProvider {
+    private final AuthorizationExtension authorizationExtension;
+    private final PluginRoleService pluginRoleService;
+    private final UserService userService;
+    private final AuthorityGranter authorityGranter;
+    private GoConfigService configService;
+
+    public PreAuthenticatedAuthenticationProvider(AuthorizationExtension authorizationExtension, PluginRoleService pluginRoleService,
+                                                  UserService userService, AuthorityGranter authorityGranter, GoConfigService configService) {
+        this.authorizationExtension = authorizationExtension;
+        this.pluginRoleService = pluginRoleService;
+        this.userService = userService;
+        this.authorityGranter = authorityGranter;
+        this.configService = configService;
+    }
+
+    @Override
+    public Authentication authenticate(Authentication authentication) throws AuthenticationException {
+        if (!supports(authentication.getClass())) {
+            return null;
+        }
+
+        if (authentication.getCredentials() == null) {
+            throw new BadCredentialsException("No pre-authenticated credentials found in request.");
+        }
+
+        PreAuthenticatedAuthenticationToken preAuthToken = (PreAuthenticatedAuthenticationToken) authentication;
+
+        return doAuthenticate(preAuthToken);
+    }
+
+    private Authentication doAuthenticate(PreAuthenticatedAuthenticationToken preAuthToken) {
+        String pluginId = preAuthToken.getPluginId();
+
+        AuthenticationResponse response = authorizationExtension.authenticateUser(pluginId, preAuthToken.getCredentials(),
+                authConfigs(pluginId), pluginRoleConfigs(pluginId));
+
+        if(authenticationFailed(response)) {
+            return null;
+        }
+
+        UserDetails userDetails = getUserDetails(response.getUser());
+
+        userService.addUserIfDoesNotExist(toDomainUser(response.getUser()));
+
+        assignRoles(pluginId, userDetails.getUsername(), response.getRoles());
+
+        PreAuthenticatedAuthenticationToken result =
+                new PreAuthenticatedAuthenticationToken(userDetails, preAuthToken.getCredentials(), pluginId, userDetails.getAuthorities());
+
+        result.setAuthenticated(true);
+
+        return result;
+    }
+
+    @Override
+    public boolean supports(Class authentication) {
+        return PreAuthenticatedAuthenticationToken.class.isAssignableFrom(authentication);
+    }
+
+    private boolean authenticationFailed(AuthenticationResponse response) {
+        return response.getUser() == null;
+    }
+
+    private List<PluginRoleConfig> pluginRoleConfigs(String pluginId) {
+        return configService.security().getPluginRoles(pluginId);
+    }
+
+    private List<SecurityAuthConfig> authConfigs(String pluginId) {
+        return configService.security().securityAuthConfigs().findByPluginId(pluginId);
+    }
+
+    private void assignRoles(String pluginId, String username, List<String> roles) {
+        pluginRoleService.updatePluginRoles(pluginId, username, CaseInsensitiveString.caseInsensitiveStrings(roles));
+    }
+
+    private UserDetails getUserDetails(User user) {
+        user = ensureDisplayNamePresent(user);
+
+        return new GoUserPrinciple(user.getUsername(), user.getDisplayName(), "", true, true, true, true, authorityGranter.authorities(user.getUsername()));
+    }
+
+    private com.thoughtworks.go.domain.User toDomainUser(User user) {
+        return new com.thoughtworks.go.domain.User(user.getUsername(), user.getDisplayName(), user.getEmailId());
+    }
+
+    private User ensureDisplayNamePresent(User user) {
+        if (user == null) {
+            return null;
+        }
+
+        if (isNotBlank(user.getDisplayName())) {
+            return user;
+        }
+
+        return new User(user.getUsername(), user.getUsername(), user.getEmailId());
+    }
+}

--- a/server/src/com/thoughtworks/go/server/security/tokens/PreAuthenticatedAuthenticationToken.java
+++ b/server/src/com/thoughtworks/go/server/security/tokens/PreAuthenticatedAuthenticationToken.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2017 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.server.security.tokens;
+
+import org.springframework.security.GrantedAuthority;
+import org.springframework.security.providers.AbstractAuthenticationToken;
+import org.springframework.security.userdetails.UserDetails;
+
+import java.util.Map;
+
+public class PreAuthenticatedAuthenticationToken extends AbstractAuthenticationToken {
+    private final UserDetails principal;
+    private final Map<String, String> credentials;
+    private final String pluginId;
+
+    public PreAuthenticatedAuthenticationToken(UserDetails principal, Map<String, String> credentials, String pluginId, GrantedAuthority[] authorities) {
+        super(authorities);
+        this.principal = principal;
+        this.credentials = credentials;
+        this.pluginId = pluginId;
+    }
+
+    public PreAuthenticatedAuthenticationToken(UserDetails principal, Map<String, String> credentials, String pluginId) {
+        this(principal, credentials, pluginId, null);
+    }
+
+    @Override
+    public Map<String, String> getCredentials() {
+        return credentials;
+    }
+
+    @Override
+    public UserDetails getPrincipal() {
+        return principal;
+    }
+
+    public String getPluginId() {
+        return pluginId;
+    }
+}

--- a/server/src/com/thoughtworks/go/server/ui/AuthPluginInfoViewModel.java
+++ b/server/src/com/thoughtworks/go/server/ui/AuthPluginInfoViewModel.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2017 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.server.ui;
+
+import com.thoughtworks.go.plugin.domain.authorization.AuthorizationPluginInfo;
+
+public class AuthPluginInfoViewModel {
+    private AuthorizationPluginInfo pluginInfo;
+
+    public AuthPluginInfoViewModel(AuthorizationPluginInfo pluginInfo) {
+        this.pluginInfo = pluginInfo;
+    }
+
+    public String name() {
+        return pluginInfo.getDescriptor().about().name();
+    }
+
+    public String imageUrl() {
+        return String.format("/go/api/plugin_images/%s/%s", pluginId(), pluginInfo.getImage().getHash());
+    }
+
+    public String pluginId() {
+        return pluginInfo.getDescriptor().id();
+    }
+}
+

--- a/server/src/com/thoughtworks/go/server/web/SiteUrlProvider.java
+++ b/server/src/com/thoughtworks/go/server/web/SiteUrlProvider.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2017 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.server.web;
+
+import com.thoughtworks.go.server.service.ServerConfigService;
+import com.thoughtworks.go.server.util.ServletHelper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import javax.servlet.http.HttpServletRequest;
+import java.net.URISyntaxException;
+
+@Component
+public class SiteUrlProvider {
+    private ServerConfigService urlProvider;
+    private static final Logger LOGGER = LoggerFactory.getLogger(SiteUrlProvider.class.getName());
+
+    @Autowired
+    public SiteUrlProvider(ServerConfigService serverConfigService) {
+        urlProvider = serverConfigService;
+    }
+
+    public String siteUrl(HttpServletRequest httpRequest) {
+        String requestRootUrl = ServletHelper.getInstance().getRequest(httpRequest).getRootURL();
+        String siteUrl = null;
+
+        try {
+            siteUrl = urlProvider.siteUrlFor(requestRootUrl, true);
+            if (requestRootUrl.equals(siteUrl)) {
+                siteUrl = urlProvider.siteUrlFor(requestRootUrl, false);
+            }
+        } catch (URISyntaxException e) {
+            LOGGER.error(String.format("Error fetching site url, reasons: %s", e.getMessage()), e);
+        }
+
+        return siteUrl;
+    }
+}

--- a/server/test/unit/com/thoughtworks/go/server/controller/AuthorizationControllerTest.java
+++ b/server/test/unit/com/thoughtworks/go/server/controller/AuthorizationControllerTest.java
@@ -19,6 +19,7 @@ package com.thoughtworks.go.server.controller;
 import com.thoughtworks.go.CurrentGoCDVersion;
 import com.thoughtworks.go.i18n.Localizer;
 import com.thoughtworks.go.plugin.access.authentication.AuthenticationPluginRegistry;
+import com.thoughtworks.go.server.service.SecurityAuthConfigService;
 import com.thoughtworks.go.server.web.GoVelocityView;
 import org.junit.Before;
 import org.junit.Test;
@@ -39,13 +40,15 @@ public class AuthorizationControllerTest {
 
     private AuthorizationController authorizationController;
     private MockHttpServletResponse response;
+    private SecurityAuthConfigService securityAuthConfigService;
 
     @Before
     public void setUp() throws Exception {
         authenticationPluginRegistry = mock(AuthenticationPluginRegistry.class);
         localizer = mock(Localizer.class);
 
-        authorizationController = new AuthorizationController(localizer, authenticationPluginRegistry);
+        securityAuthConfigService = mock(SecurityAuthConfigService.class);
+        authorizationController = new AuthorizationController(localizer, authenticationPluginRegistry, securityAuthConfigService);
         response = new MockHttpServletResponse();
     }
 
@@ -71,12 +74,14 @@ public class AuthorizationControllerTest {
             put("login_error", false);
             put("l", localizer);
             put("authentication_plugin_registry", authenticationPluginRegistry);
+            put("security_auth_config_service", securityAuthConfigService);
             put(GoVelocityView.CURRENT_GOCD_VERSION, CurrentGoCDVersion.getInstance());
         }};
 
         Map<String, Object> responseModelMap = responseModel.getModel();
         assertThat(responseModelMap, is(modelMap));
     }
+
 
     @Test
     public void shouldRedirectToGo() throws Exception {

--- a/server/test/unit/com/thoughtworks/go/server/security/PreAuthenticatedRequestsProcessingFilterTest.java
+++ b/server/test/unit/com/thoughtworks/go/server/security/PreAuthenticatedRequestsProcessingFilterTest.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2017 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.server.security;
+
+import com.thoughtworks.go.config.SecurityAuthConfig;
+import com.thoughtworks.go.config.SecurityConfig;
+import com.thoughtworks.go.plugin.access.authorization.AuthorizationExtension;
+import com.thoughtworks.go.server.security.tokens.PreAuthenticatedAuthenticationToken;
+import com.thoughtworks.go.server.service.GoConfigService;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.security.Authentication;
+import org.springframework.security.AuthenticationManager;
+import org.springframework.security.context.SecurityContextHolder;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.*;
+
+public class PreAuthenticatedRequestsProcessingFilterTest {
+
+    private HttpServletRequest request;
+    private HttpServletResponse response;
+    private FilterChain filterChain;
+    private AuthenticationManager authenticationManager;
+    private PreAuthenticatedRequestsProcessingFilter filter;
+    private AuthorizationExtension authorizationExtension;
+    private GoConfigService configService;
+    private SecurityConfig securityConfig;
+
+    @Before
+    public void setUp() throws Exception {
+        request = mock(HttpServletRequest.class);
+        response = mock(HttpServletResponse.class);
+        filterChain = mock(FilterChain.class);
+        authenticationManager = mock(AuthenticationManager.class);
+        authorizationExtension = mock(AuthorizationExtension.class);
+        configService = mock(GoConfigService.class);
+        filter = new PreAuthenticatedRequestsProcessingFilter(authorizationExtension, configService);
+        securityConfig = new SecurityConfig();
+
+        filter.setAuthenticationManager(authenticationManager);
+        filter.setFilterProcessesUrl("^/go/plugin/([^\\s]+)/authenticate$");
+        stub(configService.security()).toReturn(securityConfig);
+        stub(request.getHeaderNames()).toReturn(Collections.emptyEnumeration());
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        SecurityContextHolder.getContext().setAuthentication(null);
+    }
+
+    @Test
+    public void shouldAttemptAuthenticationOnlyForPluginAuthRequests() throws IOException, ServletException {
+        when(request.getRequestURI()).thenReturn("/go/plugin/github.oauth/authenticate");
+
+        filter.attemptAuthentication(request);
+
+        verify(authenticationManager).authenticate(any(PreAuthenticatedAuthenticationToken.class));
+    }
+
+    @Test
+    public void shouldIgnoreAuthenticationIfUserIsAlreadyAuthenticated() throws IOException, ServletException {
+        when(request.getRequestURI()).thenReturn("/go/plugin/github.oauth/authenticate");
+        SecurityContextHolder.getContext().setAuthentication(new PreAuthenticatedAuthenticationToken(null, null, null));
+
+        filter.setAuthenticationManager(authenticationManager);
+
+        filter.doFilter(request, response, filterChain);
+
+        verifyZeroInteractions(authenticationManager);
+        verify(filterChain).doFilter(request, response);
+    }
+
+    @Test
+    public void shouldIgnoreNonPluginAuthenticationRequests() throws IOException, ServletException {
+        when(request.getRequestURI()).thenReturn("/go/api/agents");
+
+        filter.setAuthenticationManager(authenticationManager);
+
+        filter.doFilter(request, response, filterChain);
+
+        verifyZeroInteractions(authenticationManager);
+        verify(filterChain).doFilter(request, response);
+    }
+
+    @Test
+    public void shouldGetCredentialsFromThePlugin() {
+        HashMap<String, String[]> params = new HashMap<>();
+        params.put("code", new String[]{"some_auth_code"});
+        SecurityAuthConfig githubAuthConfig = new SecurityAuthConfig("github", "github.oauth");
+        securityConfig.securityAuthConfigs().add(githubAuthConfig);
+
+        when(request.getRequestURI()).thenReturn("/go/plugin/github.oauth/authenticate");
+        when(request.getParameterMap()).thenReturn(params);
+        when(request.getHeaderNames()).thenReturn(Collections.enumeration(Arrays.asList("Authorization")));
+        when(request.getHeader("Authorization")).thenReturn("qwe123");
+
+        when(authorizationExtension.grantIdentityProviderAccess("github.oauth", Collections.singletonMap("Authorization", "qwe123"),
+                Collections.singletonMap("code", "some_auth_code"), Collections.singletonList(githubAuthConfig))).
+                thenReturn(Collections.singletonMap("access_token", "token"));
+
+        Map<String, String> credentials = filter.getPreAuthenticatedCredentials(request);
+
+        assertThat(credentials, hasEntry("access_token", "token"));
+    }
+
+    @Test
+    public void shouldAuthenticateUsersWithCredentials() throws IOException, ServletException {
+        PreAuthenticatedAuthenticationToken token = mock(PreAuthenticatedAuthenticationToken.class);
+        HashMap<String, String[]> params = new HashMap<>();
+        params.put("code", new String[]{"some_auth_code"});
+        SecurityAuthConfig githubAuthConfig = new SecurityAuthConfig("github", "github.oauth");
+        securityConfig.securityAuthConfigs().add(githubAuthConfig);
+
+        when(request.getRequestURI()).thenReturn("/go/plugin/github.oauth/authenticate");
+        when(request.getHeaderNames()).thenReturn(Collections.enumeration(Arrays.asList("Authorization")));
+        when(request.getHeader("Authorization")).thenReturn("qwe123");
+        when(request.getParameterMap()).thenReturn(params);
+        when(authorizationExtension.grantIdentityProviderAccess("github.oauth", Collections.singletonMap("Authorization", "qwe123"),
+                Collections.singletonMap("code", "some_auth_code"), Collections.singletonList(githubAuthConfig))).
+                thenReturn(Collections.singletonMap("access_token", "token"));
+        when(authenticationManager.authenticate(any(PreAuthenticatedAuthenticationToken.class))).thenReturn(token);
+        filter.setDefaultTargetUrl("/");
+
+        filter.doFilter(request, response, filterChain);
+
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        assertThat(authentication, is(token));
+    }
+}

--- a/server/test/unit/com/thoughtworks/go/server/security/PreAuthenticatedRequestsProcessingFilterTest.java
+++ b/server/test/unit/com/thoughtworks/go/server/security/PreAuthenticatedRequestsProcessingFilterTest.java
@@ -112,7 +112,7 @@ public class PreAuthenticatedRequestsProcessingFilterTest {
     }
 
     @Test
-    public void shouldGetCredentialsFromThePlugin() {
+    public void shouldFetchAuthorizationServerAccessTokenFromThePlugin() {
         HashMap<String, String[]> params = new HashMap<>();
         params.put("code", new String[]{"some_auth_code"});
         SecurityAuthConfig githubAuthConfig = new SecurityAuthConfig("github", "github.oauth");
@@ -123,11 +123,11 @@ public class PreAuthenticatedRequestsProcessingFilterTest {
         when(request.getHeaderNames()).thenReturn(Collections.enumeration(Arrays.asList("Authorization")));
         when(request.getHeader("Authorization")).thenReturn("qwe123");
 
-        when(authorizationExtension.grantIdentityProviderAccess("github.oauth", Collections.singletonMap("Authorization", "qwe123"),
+        when(authorizationExtension.fetchAccessToken("github.oauth", Collections.singletonMap("Authorization", "qwe123"),
                 Collections.singletonMap("code", "some_auth_code"), Collections.singletonList(githubAuthConfig))).
                 thenReturn(Collections.singletonMap("access_token", "token"));
 
-        Map<String, String> credentials = filter.getPreAuthenticatedCredentials(request);
+        Map<String, String> credentials = filter.fetchAuthorizationServerAccessToken(request);
 
         assertThat(credentials, hasEntry("access_token", "token"));
     }
@@ -144,7 +144,7 @@ public class PreAuthenticatedRequestsProcessingFilterTest {
         when(request.getHeaderNames()).thenReturn(Collections.enumeration(Arrays.asList("Authorization")));
         when(request.getHeader("Authorization")).thenReturn("qwe123");
         when(request.getParameterMap()).thenReturn(params);
-        when(authorizationExtension.grantIdentityProviderAccess("github.oauth", Collections.singletonMap("Authorization", "qwe123"),
+        when(authorizationExtension.fetchAccessToken("github.oauth", Collections.singletonMap("Authorization", "qwe123"),
                 Collections.singletonMap("code", "some_auth_code"), Collections.singletonList(githubAuthConfig))).
                 thenReturn(Collections.singletonMap("access_token", "token"));
         when(authenticationManager.authenticate(any(PreAuthenticatedAuthenticationToken.class))).thenReturn(token);

--- a/server/test/unit/com/thoughtworks/go/server/security/WebBasedPluginAuthenticationFilterTest.java
+++ b/server/test/unit/com/thoughtworks/go/server/security/WebBasedPluginAuthenticationFilterTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2017 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.server.security;
+
+import com.thoughtworks.go.config.SecurityAuthConfig;
+import com.thoughtworks.go.config.SecurityConfig;
+import com.thoughtworks.go.domain.config.ConfigurationProperty;
+import com.thoughtworks.go.plugin.access.authorization.AuthorizationExtension;
+import com.thoughtworks.go.server.service.GoConfigService;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.servlet.FilterChain;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.mockito.Mockito.*;
+
+public class WebBasedPluginAuthenticationFilterTest {
+    private HttpServletRequest request;
+    private HttpServletResponse response;
+    private FilterChain filterChain;
+    private WebBasedPluginAuthenticationFilter filter;
+    private AuthorizationExtension authorizationExtension;
+    private GoConfigService goConfigService;
+    private SecurityConfig securityConfig;
+    private SecurityAuthConfig securityAuthConfig;
+
+    @Before
+    public void setUp() throws Exception {
+        request = mock(HttpServletRequest.class);
+        response = mock(HttpServletResponse.class);
+        filterChain = mock(FilterChain.class);
+        authorizationExtension = mock(AuthorizationExtension.class);
+        goConfigService = mock(GoConfigService.class);
+        securityConfig = new SecurityConfig();
+
+        securityAuthConfig = new SecurityAuthConfig("github", "github.oauth", new ConfigurationProperty());
+        securityConfig.securityAuthConfigs().add(securityAuthConfig);
+        stub(goConfigService.security()).toReturn(securityConfig);
+        filter = new WebBasedPluginAuthenticationFilter(authorizationExtension, goConfigService);
+    }
+
+    @Test
+    public void shouldHandleOnlyWebBasedPluginAuthenticationRequests() throws Exception {
+        when(request.getRequestURI()).thenReturn("/go/plugin/github.oauth/login");
+
+        filter.doFilter(request, response, filterChain);
+
+        verify(authorizationExtension).getIdentityProviderRedirectUrl("github.oauth", Collections.singletonList(securityAuthConfig));
+    }
+
+    @Test
+    public void shouldRedirectToIdentityProviderUrlProvidedByPlugin() throws Exception {
+        String redirectUrl = "http://github/oauth/login";
+
+        when(request.getRequestURI()).thenReturn("/go/plugin/github.oauth/login");
+        when(authorizationExtension.getIdentityProviderRedirectUrl(eq("github.oauth"), any(List.class))).thenReturn(redirectUrl);
+
+        filter.doFilter(request, response, filterChain);
+
+        verify(response).sendRedirect(redirectUrl);
+    }
+
+    @Test
+    public void shouldIgnoreNonWebBasedAuthenticationRequests() throws Exception {
+        when(request.getRequestURI()).thenReturn("/go/api/agents");
+
+        filter.doFilter(request, response, filterChain);
+
+        verifyZeroInteractions(authorizationExtension);
+        verify(filterChain).doFilter(request, response);
+    }
+}

--- a/server/test/unit/com/thoughtworks/go/server/security/providers/PluginAuthenticationProviderTest.java
+++ b/server/test/unit/com/thoughtworks/go/server/security/providers/PluginAuthenticationProviderTest.java
@@ -189,6 +189,7 @@ public class PluginAuthenticationProviderTest {
         AuthenticationResponse response = new AuthenticationResponse(new User("username", "display-name", "test@test.com"), Collections.emptyList());
         when(authorizationExtension.authenticateUser(pluginId2, "username", "password", securityConfig.securityAuthConfigs().findByPluginId(pluginId2), securityConfig.getPluginRoles(pluginId2))).thenReturn(response);
 
+
         UserDetails userDetails = provider.retrieveUser("username", authenticationToken);
 
         assertThat(userDetails, is(instanceOf(GoUserPrinciple.class)));

--- a/server/test/unit/com/thoughtworks/go/server/security/providers/PreAuthenticatedAuthenticationProviderTest.java
+++ b/server/test/unit/com/thoughtworks/go/server/security/providers/PreAuthenticatedAuthenticationProviderTest.java
@@ -1,0 +1,201 @@
+/*
+ * Copyright 2017 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.server.security.providers;
+
+import com.thoughtworks.go.config.CaseInsensitiveString;
+import com.thoughtworks.go.config.PluginRoleConfig;
+import com.thoughtworks.go.config.SecurityAuthConfig;
+import com.thoughtworks.go.config.SecurityConfig;
+import com.thoughtworks.go.domain.config.ConfigurationProperty;
+import com.thoughtworks.go.plugin.access.authentication.models.User;
+import com.thoughtworks.go.plugin.access.authorization.AuthorizationExtension;
+import com.thoughtworks.go.plugin.access.authorization.models.AuthenticationResponse;
+import com.thoughtworks.go.server.security.AuthorityGranter;
+import com.thoughtworks.go.server.security.GoAuthority;
+import com.thoughtworks.go.server.security.tokens.PreAuthenticatedAuthenticationToken;
+import com.thoughtworks.go.server.security.userdetail.GoUserPrinciple;
+import com.thoughtworks.go.server.service.GoConfigService;
+import com.thoughtworks.go.server.service.PluginRoleService;
+import com.thoughtworks.go.server.service.UserService;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.mockito.ArgumentCaptor;
+import org.springframework.security.Authentication;
+import org.springframework.security.BadCredentialsException;
+import org.springframework.security.GrantedAuthority;
+import org.springframework.security.providers.UsernamePasswordAuthenticationToken;
+
+import java.util.*;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.*;
+
+public class PreAuthenticatedAuthenticationProviderTest {
+    private AuthorizationExtension authorizationExtension;
+    private String pluginId;
+    private AuthorityGranter authorityGranter;
+    private UserService userService;
+    private PluginRoleService pluginRoleService;
+    private PreAuthenticatedAuthenticationProvider authenticationProvider;
+    private User user;
+    private GrantedAuthority[] authorities;
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+    private GoConfigService goConfigService;
+    private SecurityConfig securityConfig;
+
+
+    @Before
+    public void setUp() throws Exception {
+        pluginId = "github.oauth";
+        user = new User("username", "displayname", "emailId");
+        authorities = new GrantedAuthority[]{GoAuthority.ROLE_USER.asAuthority()};
+
+        authorizationExtension = mock(AuthorizationExtension.class);
+        authorityGranter = mock(AuthorityGranter.class);
+        userService = mock(UserService.class);
+        pluginRoleService = mock(PluginRoleService.class);
+        goConfigService = mock(GoConfigService.class);
+        authenticationProvider = new PreAuthenticatedAuthenticationProvider(authorizationExtension, pluginRoleService, userService, authorityGranter, goConfigService);
+        AuthenticationResponse authenticationResponse = new AuthenticationResponse(user, Arrays.asList("admin"));
+
+        securityConfig = new SecurityConfig();
+        stub(goConfigService.security()).toReturn(securityConfig);
+        stub(authorizationExtension.authenticateUser(any(String.class), any(Map.class), any(List.class), any(List.class))).toReturn(authenticationResponse);
+        stub(authorityGranter.authorities(anyString())).toReturn(authorities);
+    }
+
+    @Test
+    public void authenticate_shouldAuthenticateUserAgainstTheSpecifiedPlugin() throws Exception {
+        Map<String, String> credentials = Collections.singletonMap("access_token", "some_token");
+        SecurityAuthConfig githubConfig = new SecurityAuthConfig("github", pluginId);
+        PluginRoleConfig adminRole = new PluginRoleConfig("admin", "github", new ConfigurationProperty());
+
+        securityConfig.securityAuthConfigs().add(githubConfig);
+        securityConfig.addRole(adminRole);
+        PreAuthenticatedAuthenticationToken authenticationToken = new PreAuthenticatedAuthenticationToken(null, credentials, pluginId);
+
+        authenticationProvider.authenticate(authenticationToken);
+
+        verify(authorizationExtension).authenticateUser(pluginId, credentials, Collections.singletonList(githubConfig), Collections.singletonList(adminRole));
+    }
+
+    @Test
+    public void authenticate_shouldCreateUserIfDoesNotExist() {
+        Map<String, String> credentials = Collections.singletonMap("access_token", "some_token");
+        PreAuthenticatedAuthenticationToken authenticationToken = new PreAuthenticatedAuthenticationToken(null, credentials, pluginId);
+
+        authenticationProvider.authenticate(authenticationToken);
+
+        ArgumentCaptor<com.thoughtworks.go.domain.User> argumentCaptor = ArgumentCaptor.forClass(com.thoughtworks.go.domain.User.class);
+        verify(userService).addUserIfDoesNotExist(argumentCaptor.capture());
+
+        com.thoughtworks.go.domain.User user = argumentCaptor.getValue();
+        assertThat(user.getName(), is(this.user.getUsername()));
+        assertThat(user.getDisplayName(), is(this.user.getDisplayName()));
+        assertThat(user.getEmail(), is(this.user.getEmailId()));
+    }
+
+    @Test
+    public void authenticate_shouldAssignRolesToUser() throws Exception {
+        Map<String, String> credentials = Collections.singletonMap("access_token", "some_token");
+        PreAuthenticatedAuthenticationToken authenticationToken = new PreAuthenticatedAuthenticationToken(null, credentials, pluginId);
+
+        authenticationProvider.authenticate(authenticationToken);
+
+        verify(pluginRoleService).updatePluginRoles(pluginId, user.getUsername(), CaseInsensitiveString.caseInsensitiveStrings("admin"));
+    }
+
+    @Test
+    public void authenticate_shouldReturnAuthenticationTokenOnSuccessfulAuthorization() throws Exception {
+        Map<String, String> credentials = Collections.singletonMap("access_token", "some_token");
+        PreAuthenticatedAuthenticationToken authenticationToken = new PreAuthenticatedAuthenticationToken(null, credentials, pluginId);
+
+        PreAuthenticatedAuthenticationToken authenticate = (PreAuthenticatedAuthenticationToken) authenticationProvider.authenticate(authenticationToken);
+
+        assertThat(authenticate.getCredentials(), is(credentials));
+        assertThat(authenticate.getPluginId(), is(pluginId));
+        assertThat(authenticate.getAuthorities(), is(authorities));
+        assertThat(authenticate.isAuthenticated(), is(true));
+    }
+
+    @Test
+    public void authenticate_shouldReturnAuthTokenWithUserDetails() throws Exception {
+        Map<String, String> credentials = Collections.singletonMap("access_token", "some_token");
+        PreAuthenticatedAuthenticationToken authenticationToken = new PreAuthenticatedAuthenticationToken(null, credentials, pluginId);
+
+        PreAuthenticatedAuthenticationToken authenticate = (PreAuthenticatedAuthenticationToken) authenticationProvider.authenticate(authenticationToken);
+
+        GoUserPrinciple principal = (GoUserPrinciple) authenticate.getPrincipal();
+
+        assertThat(principal.getDisplayName(), is(user.getDisplayName()));
+        assertThat(principal.getUsername(), is(user.getUsername()));
+        assertThat(principal.getAuthorities(), is(authorities));
+    }
+
+    @Test
+    public void authenticate_shouldEnsureUserDetailsInAuthTokenHasDisplayName() {
+        Map<String, String> credentials = Collections.singletonMap("access_token", "some_token");
+        PreAuthenticatedAuthenticationToken authenticationToken = new PreAuthenticatedAuthenticationToken(null, credentials, pluginId);
+        AuthenticationResponse authenticationResponse = new AuthenticationResponse(new User("username", null, "email"), Arrays.asList("admin"));
+
+        when(authorizationExtension.authenticateUser(any(String.class), any(Map.class), any(List.class), any(List.class))).thenReturn(authenticationResponse);
+
+        PreAuthenticatedAuthenticationToken authenticate = (PreAuthenticatedAuthenticationToken) authenticationProvider.authenticate(authenticationToken);
+
+        GoUserPrinciple principal = (GoUserPrinciple) authenticate.getPrincipal();
+
+        assertThat(principal.getDisplayName(), is(authenticationResponse.getUser().getUsername()));
+    }
+
+    @Test
+    public void authenticate_shouldSupportAuthenticationForPreAuthenticatedAuthenticationTokenOnly() throws Exception {
+        Authentication authenticate = authenticationProvider.authenticate(new UsernamePasswordAuthenticationToken("p", "c"));
+
+        assertNull(authenticate);
+
+        verifyZeroInteractions(authorizationExtension);
+    }
+
+    @Test
+    public void authenticate_shouldErrorOutInAbsenceOfCredentials() throws Exception {
+        thrown.expect(BadCredentialsException.class);
+        thrown.expectMessage("No pre-authenticated credentials found in request.");
+
+        authenticationProvider.authenticate(new PreAuthenticatedAuthenticationToken(null, null, null));
+    }
+
+    @Test
+    public void authenticate_shouldHandleFailedAuthentication() throws Exception {
+        PreAuthenticatedAuthenticationToken authenticationToken = new PreAuthenticatedAuthenticationToken(null, Collections.singletonMap("access_token", "invalid_token"), pluginId);
+        AuthenticationResponse authenticationResponse = new AuthenticationResponse(null, null);
+
+        when(authorizationExtension.authenticateUser(any(String.class), any(Map.class), any(List.class), any(List.class))).thenReturn(authenticationResponse);
+
+        PreAuthenticatedAuthenticationToken authenticate = (PreAuthenticatedAuthenticationToken) authenticationProvider.authenticate(authenticationToken);
+
+        assertNull(authenticate);
+    }
+}
+

--- a/server/test/unit/com/thoughtworks/go/server/service/SecurityAuthConfigServiceTest.java
+++ b/server/test/unit/com/thoughtworks/go/server/service/SecurityAuthConfigServiceTest.java
@@ -120,14 +120,13 @@ public class SecurityAuthConfigServiceTest {
 
     @Test
     public void shouldGetAListOfAllConfiguredWebBasedAuthorizationPlugins() {
-        Set<String> installedWebBasedPlugins = new HashSet<>();
+        Set<AuthorizationPluginInfo> installedWebBasedPlugins = new HashSet<>();
         String githubPluginId = "cd.go.github";
-        installedWebBasedPlugins.add(githubPluginId);
-        installedWebBasedPlugins.add("cd.go.google");
+        AuthorizationPluginInfo githubPluginInfo = pluginInfo(githubPluginId, "Github Auth Plugin", SupportedAuthType.Web);
+        installedWebBasedPlugins.add(githubPluginInfo);
+        installedWebBasedPlugins.add(pluginInfo(githubPluginId, "Google Auth Plugin", SupportedAuthType.Web));
         when(authorizationMetadataStore.getPluginsThatSupportsWebBasedAuthentication()).thenReturn(installedWebBasedPlugins);
-        GoPluginDescriptor.About about = new GoPluginDescriptor.About("Github Auth Plugin", "1.0", null, null, null, null);
-        GoPluginDescriptor descriptor = new GoPluginDescriptor(githubPluginId, "1.0", about, null, null, false);
-        when(authorizationMetadataStore.getPluginInfo(githubPluginId)).thenReturn(new AuthorizationPluginInfo(descriptor, null, null, new Image("svg", "data", "hash"), new Capabilities(SupportedAuthType.Web, true, true)));
+        when(authorizationMetadataStore.getPluginInfo(githubPluginId)).thenReturn(githubPluginInfo);
 
         SecurityConfig securityConfig = new SecurityConfig();
         SecurityAuthConfig github = new SecurityAuthConfig("github", githubPluginId);
@@ -143,5 +142,11 @@ public class SecurityAuthConfigServiceTest {
         assertThat(pluginInfoViewModel.pluginId(), is(githubPluginId));
         assertThat(pluginInfoViewModel.name(), is("Github Auth Plugin"));
         assertThat(pluginInfoViewModel.imageUrl(), is("/go/api/plugin_images/cd.go.github/hash"));
+    }
+
+    private AuthorizationPluginInfo pluginInfo(String githubPluginId, String name, SupportedAuthType supportedAuthType) {
+        GoPluginDescriptor.About about = new GoPluginDescriptor.About(name, "1.0", null, null, null, null);
+        GoPluginDescriptor descriptor = new GoPluginDescriptor(githubPluginId, "1.0", about, null, null, false);
+        return new AuthorizationPluginInfo(descriptor, null, null, new Image("svg", "data", "hash"), new Capabilities(supportedAuthType, true, true));
     }
 }

--- a/server/test/unit/com/thoughtworks/go/server/service/SecurityAuthConfigServiceTest.java
+++ b/server/test/unit/com/thoughtworks/go/server/service/SecurityAuthConfigServiceTest.java
@@ -17,16 +17,29 @@
 package com.thoughtworks.go.server.service;
 
 import com.thoughtworks.go.config.SecurityAuthConfig;
+import com.thoughtworks.go.config.SecurityConfig;
+import com.thoughtworks.go.config.ServerConfig;
 import com.thoughtworks.go.domain.config.ConfigurationKey;
 import com.thoughtworks.go.domain.config.ConfigurationProperty;
 import com.thoughtworks.go.domain.config.ConfigurationValue;
 import com.thoughtworks.go.plugin.access.PluginNotFoundException;
 import com.thoughtworks.go.plugin.access.authorization.AuthorizationExtension;
+import com.thoughtworks.go.plugin.access.authorization.AuthorizationMetadataStore;
+import com.thoughtworks.go.plugin.domain.authorization.AuthorizationPluginInfo;
+import com.thoughtworks.go.plugin.domain.authorization.Capabilities;
+import com.thoughtworks.go.plugin.domain.authorization.SupportedAuthType;
+import com.thoughtworks.go.plugin.domain.common.Image;
 import com.thoughtworks.go.plugin.domain.common.ValidationError;
 import com.thoughtworks.go.plugin.domain.common.ValidationResult;
 import com.thoughtworks.go.plugin.domain.common.VerifyConnectionResponse;
+import com.thoughtworks.go.plugin.infra.plugininfo.GoPluginDescriptor;
+import com.thoughtworks.go.server.ui.AuthPluginInfoViewModel;
 import org.junit.Before;
 import org.junit.Test;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
@@ -39,13 +52,15 @@ public class SecurityAuthConfigServiceTest {
     private EntityHashingService hashingService;
     private GoConfigService goConfigService;
     private SecurityAuthConfigService securityAuthConfigService;
+    private AuthorizationMetadataStore authorizationMetadataStore;
 
     @Before
     public void setUp() throws Exception {
         extension = mock(AuthorizationExtension.class);
         hashingService = mock(EntityHashingService.class);
         goConfigService = mock(GoConfigService.class);
-        securityAuthConfigService = new SecurityAuthConfigService(goConfigService, hashingService, extension);
+        authorizationMetadataStore = mock(AuthorizationMetadataStore.class);
+        securityAuthConfigService = new SecurityAuthConfigService(goConfigService, hashingService, extension, authorizationMetadataStore);
     }
 
     @Test
@@ -101,5 +116,32 @@ public class SecurityAuthConfigServiceTest {
 
         assertThat(response, is(new VerifyConnectionResponse("failure", "Unable to verify connection, missing plugin: cd.go.ldap",
                 new com.thoughtworks.go.plugin.domain.common.ValidationResult())));
+    }
+
+    @Test
+    public void shouldGetAListOfAllConfiguredWebBasedAuthorizationPlugins() {
+        Set<String> installedWebBasedPlugins = new HashSet<>();
+        String githubPluginId = "cd.go.github";
+        installedWebBasedPlugins.add(githubPluginId);
+        installedWebBasedPlugins.add("cd.go.google");
+        when(authorizationMetadataStore.getPluginsThatSupportsWebBasedAuthentication()).thenReturn(installedWebBasedPlugins);
+        GoPluginDescriptor.About about = new GoPluginDescriptor.About("Github Auth Plugin", "1.0", null, null, null, null);
+        GoPluginDescriptor descriptor = new GoPluginDescriptor(githubPluginId, "1.0", about, null, null, false);
+        when(authorizationMetadataStore.getPluginInfo(githubPluginId)).thenReturn(new AuthorizationPluginInfo(descriptor, null, null, new Image("svg", "data", "hash"), new Capabilities(SupportedAuthType.Web, true, true)));
+
+        SecurityConfig securityConfig = new SecurityConfig();
+        SecurityAuthConfig github = new SecurityAuthConfig("github", githubPluginId);
+        SecurityAuthConfig ldap = new SecurityAuthConfig("ldap", "cd.go.ldap");
+        securityConfig.securityAuthConfigs().add(github);
+
+        securityConfig.securityAuthConfigs().add(ldap);
+        when(goConfigService.serverConfig()).thenReturn(new ServerConfig(securityConfig, null));
+
+        List<AuthPluginInfoViewModel> allWebBasedAuthorizationConfigs = securityAuthConfigService.getAllConfiguredWebBasedAuthorizationPlugins();
+        assertThat(allWebBasedAuthorizationConfigs.size(), is(1));
+        AuthPluginInfoViewModel pluginInfoViewModel = allWebBasedAuthorizationConfigs.get(0);
+        assertThat(pluginInfoViewModel.pluginId(), is(githubPluginId));
+        assertThat(pluginInfoViewModel.name(), is("Github Auth Plugin"));
+        assertThat(pluginInfoViewModel.imageUrl(), is("/go/api/plugin_images/cd.go.github/hash"));
     }
 }

--- a/server/test/unit/com/thoughtworks/go/server/service/SecurityServiceTest.java
+++ b/server/test/unit/com/thoughtworks/go/server/service/SecurityServiceTest.java
@@ -21,8 +21,13 @@ import com.thoughtworks.go.helper.GoConfigMother;
 import com.thoughtworks.go.helper.StageConfigMother;
 import com.thoughtworks.go.server.domain.Username;
 import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
 import org.junit.Before;
 import org.junit.Test;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 import static com.thoughtworks.go.helper.PipelineTemplateConfigMother.createTemplate;
 import static org.hamcrest.core.Is.is;

--- a/server/test/unit/com/thoughtworks/go/server/service/plugins/builder/AuthorizationPluginInfoBuilderTest.java
+++ b/server/test/unit/com/thoughtworks/go/server/service/plugins/builder/AuthorizationPluginInfoBuilderTest.java
@@ -53,7 +53,7 @@ public class AuthorizationPluginInfoBuilderTest {
                         new com.thoughtworks.go.plugin.domain.common.PluginView("role_config_view"));
         final Capabilities domainCapabilities = new Capabilities(SupportedAuthType.Password, true, true);
 
-        com.thoughtworks.go.plugin.domain.common.Image image = new com.thoughtworks.go.plugin.domain.common.Image("image/png", Base64.getEncoder().encodeToString("some-base64-encoded-data".getBytes(UTF_8)));
+        com.thoughtworks.go.plugin.domain.common.Image image = new com.thoughtworks.go.plugin.domain.common.Image("image/png", Base64.getEncoder().encodeToString("some-base64-encoded-data".getBytes(UTF_8)), "hash");
         AuthorizationMetadataStore authorizationMetadataStore = AuthorizationMetadataStore.instance();
         authorizationMetadataStore.setPluginInfo(new com.thoughtworks.go.plugin.domain.authorization.AuthorizationPluginInfo(plugin, authSettings, roleSettings, image, domainCapabilities));
 
@@ -99,7 +99,7 @@ public class AuthorizationPluginInfoBuilderTest {
                         new com.thoughtworks.go.plugin.domain.common.PluginView("role_config_view"));
         final Capabilities domainCapabilities = new Capabilities(SupportedAuthType.Password, true, true);
 
-        com.thoughtworks.go.plugin.domain.common.Image image = new com.thoughtworks.go.plugin.domain.common.Image("image/png", Base64.getEncoder().encodeToString("some-base64-encoded-data".getBytes(UTF_8)));
+        com.thoughtworks.go.plugin.domain.common.Image image = new com.thoughtworks.go.plugin.domain.common.Image("image/png", Base64.getEncoder().encodeToString("some-base64-encoded-data".getBytes(UTF_8)), "hash");
         AuthorizationMetadataStore authorizationMetadataStore = AuthorizationMetadataStore.instance();
         authorizationMetadataStore.setPluginInfo(new com.thoughtworks.go.plugin.domain.authorization.AuthorizationPluginInfo(plugin, authSettings, roleSettings, image, domainCapabilities));
 

--- a/server/test/unit/com/thoughtworks/go/server/service/plugins/builder/ElasticAgentPluginInfoBuilderTest.java
+++ b/server/test/unit/com/thoughtworks/go/server/service/plugins/builder/ElasticAgentPluginInfoBuilderTest.java
@@ -47,7 +47,7 @@ public class ElasticAgentPluginInfoBuilderTest {
         com.thoughtworks.go.plugin.domain.common.PluggableInstanceSettings profileSettings = new com.thoughtworks.go.plugin.domain.common.PluggableInstanceSettings(Arrays.asList(new com.thoughtworks.go.plugin.domain.common.PluginConfiguration("password", new Metadata(true, true))),
                 new com.thoughtworks.go.plugin.domain.common.PluginView("profile_view"));
         com.thoughtworks.go.plugin.domain.common.Image image =
-                new com.thoughtworks.go.plugin.domain.common.Image("image/png", Base64.getEncoder().encodeToString("some-base64-encoded-data".getBytes(UTF_8)));
+                new com.thoughtworks.go.plugin.domain.common.Image("image/png", Base64.getEncoder().encodeToString("some-base64-encoded-data".getBytes(UTF_8)), "hash");
 
         ElasticAgentMetadataStore metadataStore = ElasticAgentMetadataStore.instance();
         metadataStore.setPluginInfo(new ElasticAgentPluginInfo(plugin, profileSettings, image));
@@ -78,7 +78,7 @@ public class ElasticAgentPluginInfoBuilderTest {
         com.thoughtworks.go.plugin.domain.common.PluggableInstanceSettings profileSettings = new com.thoughtworks.go.plugin.domain.common.PluggableInstanceSettings(Arrays.asList(new com.thoughtworks.go.plugin.domain.common.PluginConfiguration("password", new Metadata(true, true))),
                 new com.thoughtworks.go.plugin.domain.common.PluginView("profile_view"));
         com.thoughtworks.go.plugin.domain.common.Image image =
-                new com.thoughtworks.go.plugin.domain.common.Image("image/png", Base64.getEncoder().encodeToString("some-base64-encoded-data".getBytes(UTF_8)));
+                new com.thoughtworks.go.plugin.domain.common.Image("image/png", Base64.getEncoder().encodeToString("some-base64-encoded-data".getBytes(UTF_8)), "hash");
 
         ElasticAgentMetadataStore metadataStore = ElasticAgentMetadataStore.instance();
         metadataStore.setPluginInfo(new ElasticAgentPluginInfo(plugin, profileSettings, image));

--- a/server/test/unit/com/thoughtworks/go/server/service/plugins/builder/ElasticAgentViewViewModelBuilderTest.java
+++ b/server/test/unit/com/thoughtworks/go/server/service/plugins/builder/ElasticAgentViewViewModelBuilderTest.java
@@ -83,7 +83,7 @@ public class ElasticAgentViewViewModelBuilderTest {
     @Test
     public void shouldBeAbleToFetchPluginInfoForSinglePlugin() throws Exception {
         ElasticAgentMetadataStore metadataStore = ElasticAgentMetadataStore.instance();
-        com.thoughtworks.go.plugin.domain.common.Image image = new com.thoughtworks.go.plugin.domain.common.Image("image/png", Base64.getEncoder().encodeToString("some-base64-encoded-data".getBytes(UTF_8)));;
+        com.thoughtworks.go.plugin.domain.common.Image image = new com.thoughtworks.go.plugin.domain.common.Image("image/png", Base64.getEncoder().encodeToString("some-base64-encoded-data".getBytes(UTF_8)), "hash");;
         ElasticAgentPluginInfo elasticAgentPluginInfo = new ElasticAgentPluginInfo(dockerPlugin,
                 new PluggableInstanceSettings(Arrays.asList(new com.thoughtworks.go.plugin.domain.common.PluginConfiguration("foo", new Metadata(false, true))),
                 new com.thoughtworks.go.plugin.domain.common.PluginView("foo_template")), image);

--- a/server/test/unit/com/thoughtworks/go/server/ui/AuthPluginInfoViewModelTest.java
+++ b/server/test/unit/com/thoughtworks/go/server/ui/AuthPluginInfoViewModelTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2017 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.server.ui;
+
+import com.thoughtworks.go.plugin.domain.authorization.AuthorizationPluginInfo;
+import com.thoughtworks.go.plugin.domain.authorization.Capabilities;
+import com.thoughtworks.go.plugin.domain.authorization.SupportedAuthType;
+import com.thoughtworks.go.plugin.domain.common.Image;
+import com.thoughtworks.go.plugin.infra.plugininfo.GoPluginDescriptor;
+import org.junit.Test;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+
+public class AuthPluginInfoViewModelTest {
+
+    @Test
+    public void shouldGetDetailsAboutThePlugin() {
+        GoPluginDescriptor.About about = new GoPluginDescriptor.About("Github Auth Plugin", "1.0", null, null, null, null);
+        String pluginId = "github";
+        GoPluginDescriptor descriptor = new GoPluginDescriptor(pluginId, "1.0", about, null, null, false);
+        AuthorizationPluginInfo pluginInfo = new AuthorizationPluginInfo(descriptor, null, null, new Image("svg", "data", "hash"), new Capabilities(SupportedAuthType.Web, true, true));
+        AuthPluginInfoViewModel model = new AuthPluginInfoViewModel(pluginInfo);
+        assertThat(model.imageUrl(), is("/go/api/plugin_images/github/hash"));
+        assertThat(model.pluginId(), is("github"));
+        assertThat(model.name(), is("Github Auth Plugin"));
+    }
+}

--- a/server/test/unit/com/thoughtworks/go/server/web/SiteUrlProviderTest.java
+++ b/server/test/unit/com/thoughtworks/go/server/web/SiteUrlProviderTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2017 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.server.web;
+
+import com.thoughtworks.go.server.service.ServerConfigService;
+import com.thoughtworks.go.server.util.ServletHelper;
+import org.eclipse.jetty.server.Request;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.stub;
+import static org.mockito.Mockito.when;
+
+public class SiteUrlProviderTest {
+
+    private ServerConfigService configService;
+
+    @Before
+    public void setUp() throws Exception {
+        configService = mock(ServerConfigService.class);
+        ServletHelper.init();
+    }
+
+    @Test
+    public void siteUrl_shouldFetchTheSecureSiteUrl() throws Exception {
+        SiteUrlProvider siteUrlProvider = new SiteUrlProvider(configService);
+        Request httpRequest = mock(Request.class);
+        String requestRootUrl = "http://localhost:8153";
+
+        stub(httpRequest.getRootURL()).toReturn(new StringBuilder(requestRootUrl));
+        when(configService.siteUrlFor(requestRootUrl, true)).thenReturn("https://secure_site_url");
+
+        String siteUrl = siteUrlProvider.siteUrl(httpRequest);
+
+        assertThat(siteUrl, is("https://secure_site_url"));
+    }
+
+    @Test
+    public void siteUrl_shouldFetchSiteUrlInAbsenceOfSecureSiteUrl() throws Exception {
+        SiteUrlProvider siteUrlProvider = new SiteUrlProvider(configService);
+        Request httpRequest = mock(Request.class);
+        String requestRootUrl = "http://localhost:8153";
+
+        stub(httpRequest.getRootURL()).toReturn(new StringBuilder(requestRootUrl));
+        when(configService.siteUrlFor(requestRootUrl, true)).thenReturn(requestRootUrl);
+        when(configService.siteUrlFor(requestRootUrl, false)).thenReturn("http://site_url");
+
+        String siteUrl = siteUrlProvider.siteUrl(httpRequest);
+
+        assertThat(siteUrl, is("http://site_url"));
+    }
+
+    @Test
+    public void siteUrl_shouldReturnRequestRootUrlInAbsenceOfSiteUrls() throws Exception {
+        SiteUrlProvider siteUrlProvider = new SiteUrlProvider(configService);
+        Request httpRequest = mock(Request.class);
+        String requestRootUrl = "http://localhost:8153";
+
+        stub(httpRequest.getRootURL()).toReturn(new StringBuilder(requestRootUrl));
+        when(configService.siteUrlFor(requestRootUrl, true)).thenReturn(requestRootUrl);
+        when(configService.siteUrlFor(requestRootUrl, false)).thenReturn(requestRootUrl);
+
+        String siteUrl = siteUrlProvider.siteUrl(httpRequest);
+
+        assertThat(siteUrl, is(requestRootUrl));
+    }
+}

--- a/server/webapp/WEB-INF/applicationContext-acegi-security.xml
+++ b/server/webapp/WEB-INF/applicationContext-acegi-security.xml
@@ -86,7 +86,8 @@
         p:authenticationManager-ref="preAuthenticationManager"
         p:authenticationFailureUrl="/auth/login?login_error=1"
         p:defaultTargetUrl="/"
-        p:filterProcessesUrl="/go/plugin/([^\s]+)/authenticate$"/>
+        p:alwaysUseDefaultTargetUrl="true"
+        p:filterProcessesUrl="/go/plugin/([^\s]+)/authenticate$" />
 
 
     <bean id="webBasedAuthFilter" class="com.thoughtworks.go.server.security.WebBasedAuthenticationFilter"/>

--- a/server/webapp/WEB-INF/applicationContext-acegi-security.xml
+++ b/server/webapp/WEB-INF/applicationContext-acegi-security.xml
@@ -82,6 +82,25 @@
         </constructor-arg>
     </bean>
 
+    <bean id="preAuthenticationFilter" class="com.thoughtworks.go.server.security.PreAuthenticatedRequestsProcessingFilter"
+        p:authenticationManager-ref="preAuthenticationManager"
+        p:authenticationFailureUrl="/auth/login?login_error=1"
+        p:defaultTargetUrl="/"
+        p:filterProcessesUrl="/go/plugin/([^\s]+)/authenticate$"/>
+
+
+    <bean id="preAuthenticationManager" class="org.springframework.security.providers.ProviderManager">
+      <property name="providers">
+        <list>
+          <bean factory-bean="goAuthenticationProviderFactory" factory-method="setProvider">
+            <constructor-arg index="0">
+              <bean class="com.thoughtworks.go.server.security.providers.PreAuthenticatedAuthenticationProvider" autowire="autodetect"/>
+            </constructor-arg>
+          </bean>
+        </list>
+      </property>
+    </bean>
+
     <bean id="authenticationProcessingFilter" class="com.thoughtworks.go.server.security.AuthenticationProcessingFilter"
           p:authenticationManager-ref="goAuthenticationManager"
           p:authenticationFailureUrl="/auth/login?login_error=1"

--- a/server/webapp/WEB-INF/applicationContext-acegi-security.xml
+++ b/server/webapp/WEB-INF/applicationContext-acegi-security.xml
@@ -50,7 +50,7 @@
                 /cctray.xml=modeAwareFilter,i18nlocaleResolver,httpSessionContextIntegrationFilter,apiSessionFilter,goLogoutFilter,removeAdminPermissionFilter,casAuthProcessingFilter,oauthProcessingFilter,basicProcessingFilter,authenticationProcessingFilter,reAuthenticationFilter,userEnabledCheckFilter,anonymousProcessingFilter,basicAuthenticationAccessDenied,filterInvocationInterceptor,flashLoader,urlRewriter
                 /api/**=modeAwareFilter,i18nlocaleResolver,httpSessionContextIntegrationFilter,apiSessionFilter,goLogoutFilter,removeAdminPermissionFilter,casAuthProcessingFilter,oauthProcessingFilter,basicProcessingFilter,authenticationProcessingFilter,reAuthenticationFilter,userEnabledCheckFilter,anonymousProcessingFilter,basicAuthenticationAccessDenied,filterInvocationInterceptor,flashLoader,urlRewriter
                 /files/**=modeAwareFilter,artifactSizeEnforcementFilter,i18nlocaleResolver,httpSessionContextIntegrationFilter,goLogoutFilter,removeAdminPermissionFilter,casAuthProcessingFilter,oauthProcessingFilter,basicProcessingFilter,authenticationProcessingFilter,reAuthenticationFilter,userEnabledCheckFilter,anonymousProcessingFilter,cruiseLoginOrBasicAuthentication,filterInvocationInterceptor,flashLoader,urlRewriter
-                /**=modeAwareFilter,i18nlocaleResolver,httpSessionContextIntegrationFilter,goLogoutFilter,removeAdminPermissionFilter,casAuthProcessingFilter,oauthProcessingFilter,basicProcessingFilter,authenticationProcessingFilter,reAuthenticationFilter,userEnabledCheckFilter,anonymousProcessingFilter,cruiseLoginOrBasicAuthentication,filterInvocationInterceptor,flashLoader,urlRewriter
+                /**=modeAwareFilter,i18nlocaleResolver,httpSessionContextIntegrationFilter,goLogoutFilter,removeAdminPermissionFilter,casAuthProcessingFilter,oauthProcessingFilter,webBasedAuthFilter,preAuthenticationFilter,basicProcessingFilter,authenticationProcessingFilter,reAuthenticationFilter,userEnabledCheckFilter,anonymousProcessingFilter,cruiseLoginOrBasicAuthentication,filterInvocationInterceptor,flashLoader,urlRewriter
             </value>
         </property>
     </bean>
@@ -89,12 +89,16 @@
         p:filterProcessesUrl="/go/plugin/([^\s]+)/authenticate$"/>
 
 
+    <bean id="webBasedAuthFilter" class="com.thoughtworks.go.server.security.WebBasedAuthenticationFilter"/>
+
+    <bean id="preAuthenticatedAuthenticationProvider" class="com.thoughtworks.go.server.security.providers.PreAuthenticatedAuthenticationProvider" autowire="autodetect"/>
+
     <bean id="preAuthenticationManager" class="org.springframework.security.providers.ProviderManager">
       <property name="providers">
         <list>
           <bean factory-bean="goAuthenticationProviderFactory" factory-method="setProvider">
             <constructor-arg index="0">
-              <bean class="com.thoughtworks.go.server.security.providers.PreAuthenticatedAuthenticationProvider" autowire="autodetect"/>
+                <ref bean="preAuthenticatedAuthenticationProvider"/>
             </constructor-arg>
           </bean>
         </list>
@@ -140,6 +144,7 @@
                         <bean class="com.thoughtworks.go.server.security.providers.PluginAuthenticationProvider" autowire="autodetect"/>
                     </constructor-arg>
                 </bean>
+                <ref bean="preAuthenticatedAuthenticationProvider"/>
                 <bean class="org.springframework.security.providers.anonymous.AnonymousAuthenticationProvider" p:key="anonymousKey"/>
             </list>
         </property>

--- a/server/webapp/WEB-INF/applicationContext-acegi-security.xml
+++ b/server/webapp/WEB-INF/applicationContext-acegi-security.xml
@@ -310,6 +310,7 @@
                 /api/support=ROLE_SUPERVISOR
                 /api/pipelines.xml=ROLE_USER
                 /api/version=IS_AUTHENTICATED_ANONYMOUSLY
+                /api/plugin_images/**=IS_AUTHENTICATED_ANONYMOUSLY
                 /api/*/*.xml=ROLE_USER
                 /api/pipelines/*/*.xml=ROLE_USER,ROLE_OAUTH_USER
                 /api/agents/**=ROLE_USER

--- a/server/webapp/WEB-INF/rails.new/app/assets/stylesheets/vm/_login.scss
+++ b/server/webapp/WEB-INF/rails.new/app/assets/stylesheets/vm/_login.scss
@@ -49,3 +49,16 @@ html, body {
 .app-footer, .page-wrap:after {
   height : 76px;
 }
+
+.authorization-plugins {
+  .authorization-plugin-icon {
+    height: 64px;
+    width: 64px;
+  }
+  .vertical-line {
+    border-left: 1px solid #ccc;
+    display: inline-block;
+    height: 40px;
+    margin: 10px;
+  }
+}

--- a/server/webapp/WEB-INF/vm/auth/login.vm
+++ b/server/webapp/WEB-INF/vm/auth/login.vm
@@ -156,13 +156,15 @@
             </div>
 
             <div class="authorization-plugins">
-              #foreach ($model in $security_auth_config_service.getAllConfiguredWebBasedAuthorizationPlugins())
+              #set( $allConfiguredWebBasedAuthorizationPlugins = $security_auth_config_service.getAllConfiguredWebBasedAuthorizationPlugins() )
+              #set( $allAuthenticationPlugins = $authentication_plugin_registry.getPluginsThatSupportsWebBasedAuthentication() )
+              #foreach ($model in $allConfiguredWebBasedAuthorizationPlugins)
                   <a href="/go/plugin/$model.pluginId()/login"><img class="authorization-plugin-icon" src="$model.imageUrl()" alt="$model.name()"/></a>
               #end
-              #if($security_auth_config_service.getAllConfiguredWebBasedAuthorizationPlugins().size() > 0 && $authentication_plugin_registry.getPluginsThatSupportsWebBasedAuthentication().size() > 0)
+              #if($allConfiguredWebBasedAuthorizationPlugins.size() > 0 && $allAuthenticationPlugins.size() > 0)
                 <div class="vertical-line"></div>
               #end
-              #foreach ($authentication_plugin_id in $authentication_plugin_registry.getPluginsThatSupportsWebBasedAuthentication())
+              #foreach ($authentication_plugin_id in $allAuthenticationPlugins)
                 <a href="/go/plugin/interact/$authentication_plugin_id/index"><img
                     src="$authentication_plugin_registry.getDisplayImageURLFor($authentication_plugin_id)"
                     alt="$authentication_plugin_registry.getDisplayNameFor($authentication_plugin_id)"/></a>

--- a/server/webapp/WEB-INF/vm/auth/login.vm
+++ b/server/webapp/WEB-INF/vm/auth/login.vm
@@ -155,11 +155,19 @@
               </form>
             </div>
 
-            #foreach ($authentication_plugin_id in $authentication_plugin_registry.getPluginsThatSupportsWebBasedAuthentication())
-              <a href="/go/plugin/interact/$authentication_plugin_id/index"><img
-                  src="$authentication_plugin_registry.getDisplayImageURLFor($authentication_plugin_id)"
-                  alt="$authentication_plugin_registry.getDisplayNameFor($authentication_plugin_id)"/></a>
-            #end
+            <div class="authorization-plugins">
+              #foreach ($model in $security_auth_config_service.getAllConfiguredWebBasedAuthorizationPlugins())
+                  <a href="/go/plugin/$model.pluginId()/login"><img class="authorization-plugin-icon" src="$model.imageUrl()" alt="$model.name()"/></a>
+              #end
+              #if($security_auth_config_service.getAllConfiguredWebBasedAuthorizationPlugins().size() > 0 && $authentication_plugin_registry.getPluginsThatSupportsWebBasedAuthentication().size() > 0)
+                <div class="vertical-line"></div>
+              #end
+              #foreach ($authentication_plugin_id in $authentication_plugin_registry.getPluginsThatSupportsWebBasedAuthentication())
+                <a href="/go/plugin/interact/$authentication_plugin_id/index"><img
+                    src="$authentication_plugin_registry.getDisplayImageURLFor($authentication_plugin_id)"
+                    alt="$authentication_plugin_registry.getDisplayNameFor($authentication_plugin_id)"/></a>
+              #end
+            </div>
 
           </div>
         </div>


### PR DESCRIPTION
* Authorization plugins have endpoints to handle web-based
  authentication
* WebBasedAuthFilter responsible to get the identity provider url and redirect
* PreAuthFilter handles requests for pre-authenticated requests by
  interacting with authorization plugin
* PluginInteraction callbacks handles request headers
* ToDo - Integrate the above filters to filter chain