### PR TITLE
Freeze/Disable Edits on pipeline config page until the save finishes

### DIFF
--- a/server/webapp/WEB-INF/rails.new/app/assets/new_javascripts/models/pipeline_configs/pipeline.js
+++ b/server/webapp/WEB-INF/rails.new/app/assets/new_javascripts/models/pipeline_configs/pipeline.js
@@ -138,10 +138,15 @@ define([
 
   Pipeline.vm = function () {
     this.saveState = m.prop('');
+    this.pageSaveSpinner = m.prop('');
+    this.pageSaveState = m.prop('');
+
     var errors    = [];
 
     this.updating = function () {
       this.saveState('in-progress disabled');
+      this.pageSaveSpinner('page-spinner');
+      this.pageSaveState('page-save-in-progress');
     };
 
     this.saveFailed = function (data) {
@@ -158,6 +163,8 @@ define([
 
     this.saveSuccess = function () {
       this.saveState('success');
+      this.pageSaveSpinner('');
+      this.pageSaveState('');
     };
 
     this.defaultState = function () {

--- a/server/webapp/WEB-INF/rails.new/app/assets/new_javascripts/views/pipeline_configs/pipeline_config_widget.js.msx
+++ b/server/webapp/WEB-INF/rails.new/app/assets/new_javascripts/views/pipeline_configs/pipeline_config_widget.js.msx
@@ -97,6 +97,7 @@ define([
           }
 
           self.vm.updating();
+          m.redraw();
 
           self.pipeline().update(self.etag(), extractEtag).then(function (data) {
             ctrl.setPipelineAndPreserveSelection(Pipeline.fromJSON(data));
@@ -158,7 +159,7 @@ define([
         return (
           <form class='pipeline'>
             {header()}
-            <f.row class='pipeline-body'>
+            <f.row class={'pipeline-body ' + ctrl.vm.pageSaveState()}>
               {errors}
               <f.column end={true} size={12}>
                 <PipelineSettingsWidget pipeline={ctrl.pipeline}
@@ -170,6 +171,7 @@ define([
                 {pipelineFlowWidget()}
               </f.column>
             </f.row>
+            <f.row class={ctrl.vm.pageSaveSpinner()}/>
             {ctrl.modal.view()}
           </form>
         );

--- a/server/webapp/WEB-INF/rails.new/app/assets/new_stylesheets/single_page_apps/pipeline_configs/_pipeline.scss
+++ b/server/webapp/WEB-INF/rails.new/app/assets/new_stylesheets/single_page_apps/pipeline_configs/_pipeline.scss
@@ -220,10 +220,7 @@
   }
 }
 
-// scss-lint:disable VendorPrefix
 .page-save-in-progress {
   pointer-events: none;
-  -webkit-filter: blur(3px);
+  opacity:        0.3;
 }
-
-// scss-lint:enable VendorPrefix

--- a/server/webapp/WEB-INF/rails.new/app/assets/new_stylesheets/single_page_apps/pipeline_configs/_pipeline.scss
+++ b/server/webapp/WEB-INF/rails.new/app/assets/new_stylesheets/single_page_apps/pipeline_configs/_pipeline.scss
@@ -219,3 +219,11 @@
     margin-top: 25px;
   }
 }
+
+// scss-lint:disable VendorPrefix
+.page-save-in-progress {
+  pointer-events: none;
+  -webkit-filter: blur(3px);
+}
+
+// scss-lint:enable VendorPrefix

--- a/server/webapp/WEB-INF/rails.new/spec/new_javascripts/views/pipeline_configs/pipeline_config_widget_spec.js
+++ b/server/webapp/WEB-INF/rails.new/spec/new_javascripts/views/pipeline_configs/pipeline_config_widget_spec.js
@@ -63,6 +63,26 @@ define([
       expect($root.find('.pipeline .heading h1')).toHaveText('Pipeline configuation for pipeline yourproject');
     });
 
+    it('should disable button and page edits while pipeline config save is in progress', function () {
+      jasmine.Ajax.install();
+      jasmine.Ajax.stubRequest('/go/api/admin/pipelines/yourproject', undefined, 'PATCH');
+
+      var saveButton = $root.find('button.save-pipeline');
+      var pipelineBody = $root.find('.pipeline-body');
+
+      expect($(saveButton)).not.toHaveClass('in-progress');
+      expect($(pipelineBody)).not.toHaveClass('page-save-in-progress');
+
+      $(saveButton).trigger('click');
+      m.redraw(true);
+
+      expect($(saveButton)).toHaveClass('in-progress');
+      expect($(saveButton)).toHaveClass('disabled');
+      expect($(pipelineBody)).toHaveClass('page-save-in-progress');
+
+      jasmine.Ajax.uninstall();
+    });
+
     it("should render enablePipelineLocking checkbox", function () {
       expect(inputFieldFor('enablePipelineLocking')).toBeChecked();
       expect(pipeline.enablePipelineLocking()).toBe(true);

--- a/server/webapp/WEB-INF/rails.new/spec/webpack/views/pipeline_configs/pipeline_config_widget_spec.js
+++ b/server/webapp/WEB-INF/rails.new/spec/webpack/views/pipeline_configs/pipeline_config_widget_spec.js
@@ -84,23 +84,21 @@ describe("PipelineConfigWidget", () => {
   });
 
   it('should disable button and page edits while pipeline config save is in progress', () => {
-    jasmine.Ajax.install();
-    jasmine.Ajax.stubRequest('/go/api/admin/pipelines/yourproject', undefined, 'PATCH');
+    jasmine.Ajax.withMock(() => {
+      jasmine.Ajax.stubRequest('/go/api/admin/pipelines/yourproject', undefined, 'PATCH');
+      const saveButton   = $root.find('button.save-pipeline');
+      const pipelineBody = $root.find('.pipeline-body');
 
-    const saveButton = $root.find('button.save-pipeline');
-    const pipelineBody = $root.find('.pipeline-body');
+      expect($(saveButton)).not.toHaveClass('in-progress');
+      expect($(pipelineBody)).not.toHaveClass('page-save-in-progress');
 
-    expect($(saveButton)).not.toHaveClass('in-progress');
-    expect($(pipelineBody)).not.toHaveClass('page-save-in-progress');
+      $(saveButton).trigger('click');
+      m.redraw(true);
 
-    $(saveButton).trigger('click');
-    m.redraw(true);
-
-    expect($(saveButton)).toHaveClass('in-progress');
-    expect($(saveButton)).toHaveClass('disabled');
-    expect($(pipelineBody)).toHaveClass('page-save-in-progress');
-
-    jasmine.Ajax.uninstall();
+      expect($(saveButton)).toHaveClass('in-progress');
+      expect($(saveButton)).toHaveClass('disabled');
+      expect($(pipelineBody)).toHaveClass('page-save-in-progress');
+    });
   });
 
   it("should render enablePipelineLocking checkbox", () => {

--- a/server/webapp/WEB-INF/rails.new/spec/webpack/views/pipeline_configs/pipeline_config_widget_spec.js
+++ b/server/webapp/WEB-INF/rails.new/spec/webpack/views/pipeline_configs/pipeline_config_widget_spec.js
@@ -83,6 +83,26 @@ describe("PipelineConfigWidget", () => {
     expect($root.find('.pipeline .heading h1')).toHaveText('Pipeline configuation for pipeline yourproject');
   });
 
+  it('should disable button and page edits while pipeline config save is in progress', () => {
+    jasmine.Ajax.install();
+    jasmine.Ajax.stubRequest('/go/api/admin/pipelines/yourproject', undefined, 'PATCH');
+
+    const saveButton = $root.find('button.save-pipeline');
+    const pipelineBody = $root.find('.pipeline-body');
+
+    expect($(saveButton)).not.toHaveClass('in-progress');
+    expect($(pipelineBody)).not.toHaveClass('page-save-in-progress');
+
+    $(saveButton).trigger('click');
+    m.redraw(true);
+
+    expect($(saveButton)).toHaveClass('in-progress');
+    expect($(saveButton)).toHaveClass('disabled');
+    expect($(pipelineBody)).toHaveClass('page-save-in-progress');
+
+    jasmine.Ajax.uninstall();
+  });
+
   it("should render enablePipelineLocking checkbox", () => {
     expect(inputFieldFor('enablePipelineLocking')).toBeChecked();
     expect(pipeline.enablePipelineLocking()).toBe(true);

--- a/server/webapp/WEB-INF/rails.new/webpack/models/pipeline_configs/pipeline.js
+++ b/server/webapp/WEB-INF/rails.new/webpack/models/pipeline_configs/pipeline.js
@@ -171,10 +171,14 @@ Pipeline.find = (url, extract) => $.Deferred(() => {
 
 Pipeline.vm = function () {
   this.saveState = Stream('');
+  this.pageSaveSpinner = Stream('');
+  this.pageSaveState = Stream('');
   let errors     = [];
 
   this.updating = function () {
     this.saveState('in-progress disabled');
+    this.pageSaveSpinner('page-spinner');
+    this.pageSaveState('page-save-in-progress');
   };
 
   this.saveFailed = function (data) {
@@ -191,6 +195,8 @@ Pipeline.vm = function () {
 
   this.saveSuccess = function () {
     this.saveState('success');
+    this.pageSaveSpinner('');
+    this.pageSaveState('');
   };
 
   this.defaultState = function () {

--- a/server/webapp/WEB-INF/rails.new/webpack/views/pipeline_configs/pipeline_config_widget.js.msx
+++ b/server/webapp/WEB-INF/rails.new/webpack/views/pipeline_configs/pipeline_config_widget.js.msx
@@ -105,6 +105,7 @@ const PipelineConfigWidget = function (options) {
         }
 
         self.vm.updating();
+        m.redraw();
 
         const onReject  = function (data) {
           self.vm.saveFailed(data);
@@ -176,7 +177,7 @@ const PipelineConfigWidget = function (options) {
       return (
         <form class='pipeline'>
           {header()}
-          <f.row class='pipeline-body'>
+          <f.row class={'pipeline-body ' + vnode.state.vm.pageSaveState()}>
             {errors}
             <f.column end={true} size={12}>
               <PipelineSettingsWidget pipeline={vnode.state.pipeline}
@@ -188,6 +189,7 @@ const PipelineConfigWidget = function (options) {
               {pipelineFlowWidget()}
             </f.column>
           </f.row>
+          <f.row class={vnode.state.vm.pageSaveSpinner()}/>
           {vnode.state.modal.view()}
         </form>
       );

--- a/server/webapp/WEB-INF/rails.new/webpack/views/pipeline_configs/pipeline_config_widget.js.msx
+++ b/server/webapp/WEB-INF/rails.new/webpack/views/pipeline_configs/pipeline_config_widget.js.msx
@@ -177,7 +177,7 @@ const PipelineConfigWidget = function (options) {
       return (
         <form class='pipeline'>
           {header()}
-          <f.row class={`pipeline-body ${  vnode.state.vm.pageSaveState()}`}>
+          <f.row class={`pipeline-body ${vnode.state.vm.pageSaveState()}`}>
             {errors}
             <f.column end={true} size={12}>
               <PipelineSettingsWidget pipeline={vnode.state.pipeline}

--- a/server/webapp/WEB-INF/rails.new/webpack/views/pipeline_configs/pipeline_config_widget.js.msx
+++ b/server/webapp/WEB-INF/rails.new/webpack/views/pipeline_configs/pipeline_config_widget.js.msx
@@ -177,7 +177,7 @@ const PipelineConfigWidget = function (options) {
       return (
         <form class='pipeline'>
           {header()}
-          <f.row class={'pipeline-body ' + vnode.state.vm.pageSaveState()}>
+          <f.row class={`pipeline-body ${  vnode.state.vm.pageSaveState()}`}>
             {errors}
             <f.column end={true} size={12}>
               <PipelineSettingsWidget pipeline={vnode.state.pipeline}


### PR DESCRIPTION
![screen shot 2017-03-15 at 12 14 13 pm](https://cloud.githubusercontent.com/assets/15275847/23936602/1aa87660-0979-11e7-8c22-8680f811c8a3.png)


for background blur, we have used `-webkit-filter` which is supported on [these](http://caniuse.com/#search=-webkit-filter) browsers.

@naveenbhaskar -- can you review the css changes?