### PR TITLE
Update build summary at top of job details page

### DIFF
--- a/server/test/unit/com/thoughtworks/go/server/view/velocity/BuildDetailPageVelocityTemplateTest.java
+++ b/server/test/unit/com/thoughtworks/go/server/view/velocity/BuildDetailPageVelocityTemplateTest.java
@@ -57,7 +57,7 @@ public class BuildDetailPageVelocityTemplateTest {
     @Test
     public void shouldEscapeBuildCauseOnVelocityTemplate() throws Exception {
         Document actualDoc = Jsoup.parse(getBuildDetailVelocityView(createJobDetailModel()).render());
-        assertThat(actualDoc.select("#build-detail-summary li").last().html(), containsString("modified by Ernest Hemingway &lt;oldman@sea.com&gt;"));
+        assertThat(actualDoc.select("#build-detail-summary").last().html(), containsString("modified by Ernest Hemingway &lt;oldman@sea.com&gt;"));
     }
 
     @Test

--- a/server/webapp/WEB-INF/rails.new/app/assets/javascripts/build_output_observer.js
+++ b/server/webapp/WEB-INF/rails.new/app/assets/javascripts/build_output_observer.js
@@ -173,16 +173,12 @@ BuildOutputObserver.prototype = {
     },
     update_build_detail_summary_result : function (json) {
         var result = json.building_info.result.toLowerCase();
-        $('build_name_status').update(result);
-        var div = $$('.build_detail_summary')[0].ancestors()[0];
+        var div = $("build_status");
         clean_active_css_class_on_element(div);
         $(div).addClassName(result.toLowerCase());
     },
     update_build_detail_summary_status : function(json) {
-        var status = json.building_info.current_status.toLowerCase();
-        $('build_name_status').update(status);
         this.update_date($('build_scheduled_date'), json.building_info.build_scheduled_date);
-
         this.update_date($('build_assigned_date'), json.building_info.build_assigned_date)
         this.update_date($('build_preparing_date'), json.building_info.build_preparing_date)
         this.update_date($('build_building_date'), json.building_info.build_building_date)
@@ -190,7 +186,6 @@ BuildOutputObserver.prototype = {
         this.update_date($('build_completed_date'), json.building_info.build_completed_date)
         $('agent_name').setAttribute("href", context_path("agents/" + json.building_info.agent_uuid));
         $('agent_name').update(json.building_info.agent.escapeHTML() + ' (ip:' + json.building_info.agent_ip + ')');
-        // TODO: update css on building panel
         json_to_css.update_build_detail_header(json);
     },
     update_date : function(element, content) {

--- a/server/webapp/WEB-INF/rails.new/app/assets/javascripts/json_to_css.js
+++ b/server/webapp/WEB-INF/rails.new/app/assets/javascripts/json_to_css.js
@@ -54,8 +54,8 @@ JsonToCss.prototype = {
     },
 
     update_build_detail_header : function(json) {
-		var css_class_name = json.building_info.current_status.toLowerCase();
-        this._renew_class_name('build_detail_summary_container', [css_class_name]);
+        var css_class_name = json.building_info.current_status.toLowerCase();
+        this._renew_class_name('build_status', [css_class_name]);
     },
 
 	update_build_list : function(json, id, imgSrc) {

--- a/server/webapp/WEB-INF/rails.new/app/assets/stylesheets/css/build_detail.scss
+++ b/server/webapp/WEB-INF/rails.new/app/assets/stylesheets/css/build_detail.scss
@@ -32,36 +32,10 @@ $page-margin: 15px;
 
 #build_detail_summary_container {
   zoom: 1;
-  padding: 0 0 10px 0;
   -moz-border-radius: 5px;
   -webkit-border-radius: 5px;
   border-radius: 5px;
   border: 1px solid #ccc;
-}
-
-#build_detail_summary_container h3 {
-  font-size: 18px;
-  font-weight: 500;
-  padding: 8px 15px 10px 15px;
-  background-image: image_url('g9/backgrounds/bg_gradient_50.png');
-  background-repeat: repeat-x;
-  background-position: bottom left;
-  /* seems silly, but it's to fix background image overlap onto border radius of the parent */
-  -moz-border-radius-topright: 4px;
-  -moz-border-radius-topleft: 4px;
-  -webkit-border-top-right-radius: 4px;
-  -webkit-border-top-left-radius: 4px;
-  border-top-right-radius: 4px;
-  border-top-left-radius: 4px;
-  margin-bottom: 15px;
-}
-
-#build_detail_summary_container h3 span {
-  font-size: 14px;
-  font-weight: 500;
-  border-left: 1px solid #fff;
-  padding-left: 10px;
-  margin-left: 5px;
 }
 
 .build_detail_summary li span {
@@ -680,45 +654,50 @@ a.collapse-all {
   background: #fAC361;
 }
 
-.build_detail_summary h3 {
-  font-size: 1.2em;
-  margin-bottom: 1em;
-  padding: 0.25em 0.64em;
+.build-status {
+  width: 36px;
+  height: 36px; //height of .page_header minus the top and bottom padding
+  border-radius: 50%;
+  float: right;
+  line-height: 18px;
+  &:before {
+    width: 18px;
+    text-align: center;
+  }
 }
 
-.cancelled h3 {
+.build-status.cancelled {
   background-color: #ffc11b;
   color: #000;
-  @include icon-after(ban, 16px, 0 0 0 10px);
+  @include icon-before($cancelled-icon, $margin: 9px);
 }
 
-.failed h3,
-.failing h3 {
+.build-status.failed,
+.build-status.failing {
   background-color: #fa2d2d;
   color: #fff;
-  @include icon-after(exclamation-circle, 16px, 0 0 0 10px);
-
+  @include icon-before($failed-icon, $margin: 9px);
 }
 
-.passed h3 {
+.build-status.passed {
   background-color: #78C42D;
   color: #fff;
-  @include icon-after(check, 16px, 0 0 0 10px);
+  @include icon-before($passed-icon, $margin: 9px);
 }
 
-.inactive h3,
-.building_unknown h3,
-.unknown h3,
-.discontinued h3 {
+.build-status.inactive,
+.build-status.building_unknown,
+.build-status.unknown,
+.build-status.discontinued {
   background: #EEEEEE;
   color: #000;
 }
 
-.scheduled h3,
-.assigned h3,
-.preparing h3,
-.building h3,
-.completing h3 {
+.build-status.scheduled,
+.build-status.assigned,
+.build-status.preparing,
+.build-status.building,
+.build-status.completing {
   background: #ebc26d;
   color: #000;
 }

--- a/server/webapp/WEB-INF/rails.new/app/assets/stylesheets/new-theme.scss
+++ b/server/webapp/WEB-INF/rails.new/app/assets/stylesheets/new-theme.scss
@@ -599,10 +599,6 @@ h1.entity_title {
   background-color: $passed;
 }
 
-#build_detail_summary_container.passed h3 {
-  background-color: $passed;
-}
-
 .pipeline_bundle {
   .pipeline {
     border:     0;
@@ -771,6 +767,10 @@ ul.entity_title {
   margin: 8px 0 0 10px;
 }
 
+.job_details {
+  font-size: rem-calc(18px);
+}
+
 .admin_pause_info_and_controls {
   float:       left;
   margin-top:  7px;
@@ -870,6 +870,7 @@ ul.entity_title {
 
 #build_detail_summary_container {
   background: #fff;
+  padding: 10px 0;
 }
 
 .material_revision {
@@ -1790,12 +1791,6 @@ tr.Cancelled, tr.cancelled-stage {
   }
 }
 
-#build_detail_summary_container h3 {
-  background-image: none !important;
-  font-size:        14px !important;
-  font-weight:      600 !important;
-}
-
 .job_details_content .sub_tabs_container {
   margin-bottom: 0;
   position:      relative;
@@ -1995,7 +1990,6 @@ form#package_repositories_edit_form {
 }
 
 #yui-main .content_wrapper_outer, #yui-main .content_wrapper_inner {
-  margin:     15px 0;
   padding:    0;
   background: transparent;
 }

--- a/server/webapp/WEB-INF/rails.new/spec/javascripts/build_detail_observer_spec.js
+++ b/server/webapp/WEB-INF/rails.new/spec/javascripts/build_detail_observer_spec.js
@@ -23,19 +23,19 @@ describe("build_detail_observer", function () {
         setFixtures("<div id=\"container\">\n" +
             "    <span class=\"page_panel\"><b class=\"rtop\"><b class=\"r1\"></b> <b class=\"r2\"></b> <b class=\"r3\"></b> <b class=\"r4\"></b></b></span>\n" +
             "\n" +
-            "    <div class=\"build_detail_summary\">\n" +
-            "        <h3>project1 is now <span id=\"build_status_id\" class='build_status'></span></h3>\n" +
-            "        <ul class=\"summary\">\n" +
-            "            <li><strong>Building since:</strong> $buildSince</li>\n" +
-            "            <li><strong>Elapsed time:</strong> <span id=\"${projectName}_time_elapsed\"><img\n" +
-            "                    src=\"images/spinner.gif\"/></span></li>\n" +
-            "            <li><strong>Previous successful build:</strong> $durationToSuccessfulBuild</li>\n" +
-            "            <li><strong>Remaining time:</strong> <span id=\"${projectName}_time_remaining\"><img\n" +
-            "                    src=\"images/spinner.gif\"/></span></li>\n" +
-            "            <span id=\"build_name_status\"></span>\n" +
-            "        </ul>\n" +
-            "    </div>\n" +
-            "    <span class=\"page_panel\"><b class=\"rbottom\"><b class=\"r4\"></b> <b class=\"r3\"></b> <b class=\"r2\"></b> <b\n" +
+            "<div id=\"build_status\" class=\"build-status\"></div>\n" +
+            "<div class=\"build_detail_summary\">\n" +
+            "    <ul class=\"summary\">\n" +
+            "        <li><strong>Building since:</strong> $buildSince</li>\n" +
+            "        <li><strong>Elapsed time:</strong> <span id=\"${projectName}_time_elapsed\"><img\n" +
+            "                src=\"images/spinner.gif\"/></span></li>\n" +
+            "        <li><strong>Previous successful build:</strong> $durationToSuccessfulBuild</li>\n" +
+            "        <li><strong>Remaining time:</strong> <span id=\"${projectName}_time_remaining\"><img\n" +
+            "                src=\"images/spinner.gif\"/></span></li>\n" +
+            "        <span id=\"build_status\"></span>\n" +
+            "    </ul>\n" +
+            "</div>\n" +
+            "<span class=\"page_panel\"><b class=\"rbottom\"><b class=\"r4\"></b> <b class=\"r3\"></b> <b class=\"r2\"></b> <b\n" +
             "            class=\"r1\"></b></b></span>\n" +
             "</div>\n" +
             "\n" +
@@ -53,10 +53,11 @@ describe("build_detail_observer", function () {
     });
 
     it("test_ajax_periodical_refresh_active_build_should_update_css", function () {
-        jQuery('.build_detail_summary').parent().addClass("building_passed");
+        var status = jQuery(".build-status");
+        status.addClass("building_passed");
         var json = failed_json('project1')
         observer.update_page(json);
-        assertTrue("failed", jQuery('.build_detail_summary').parent().hasClass("failed"));
+        assertTrue("failed", status.hasClass("failed"));
     });
 
     it("test_ajax_periodical_refresh_active_build_output_executer_oncomplete_should_update_output", function () {

--- a/server/webapp/WEB-INF/vm/build_detail/_build_detail_summary_jstemplate.vm
+++ b/server/webapp/WEB-INF/vm/build_detail/_build_detail_summary_jstemplate.vm
@@ -16,12 +16,12 @@
 
 <textarea id="build-summary-template" style="display:none;">
 <li><span class="header">Scheduled on: </span><span id="build_scheduled_date">${% build.build_scheduled_date %}</span></li>
-<li><span class="header">Completed on: </span><span id="build_completed_date">${% build.build_completed_date %}</span><a  href="#tab-properties" class ="more" target="_blank" onclick="new TabsManager('properties')">more...</a></li>
-{if build.current_status.toLowerCase() == 'passed' ||  build.current_status.toLowerCase() == 'failed'}
+<li><span class="header">Agent: </span><span><a id="agent_name" href="$req.getContextPath()/agents/${% build.agent_uuid %}">${% build.agent.escapeHTML() %} (ip:${% build.agent_ip %})</a></span></li>
+  <li><span class="header">Completed on: </span><span id="build_completed_date">${% build.build_completed_date %}</span><a  href="#tab-properties" class ="more" target="_blank" onclick="new TabsManager('properties')">more...</a></li>
+<li><span class="header">Build cause: </span><span id="stage-${% build.id %}-buildCause">$esc.html($esc.html($presenter.buildCauseMessage))</span></li>
+  {if build.current_status.toLowerCase() == 'passed' ||  build.current_status.toLowerCase() == 'failed'}
 <li><span class="header">Duration: </span><span>${% cruiseTimeConverter.fromSecondsToHHMMSS(parseInt(build.current_build_duration)) %}</span></li>
 {/if}
-<li><span class="header">Agent: </span><span><a id="agent_name" href="$req.getContextPath()/agents/${% build.agent_uuid %}">${% build.agent.escapeHTML() %} (ip:${% build.agent_ip %})</a></span></li>
-<li><span class="header">Build cause: </span><span id="stage-${% build.id %}-buildCause">$esc.html($esc.html($presenter.buildCauseMessage))</span></li>
 {if isEstimatable(build.current_status) }
 <li class="progress-info">
     <span class="header">Progress:</span>

--- a/server/webapp/WEB-INF/vm/build_detail/build_detail_page.vm
+++ b/server/webapp/WEB-INF/vm/build_detail/build_detail_page.vm
@@ -48,12 +48,10 @@
       <div class="row">
         <div class="content_wrapper_inner">
           <div id="build-status-panel" class="bd-container rounded-corner-for-pipeline">
-
             <div class="maincol build_detail">
                 #parse("shared/_flash_message.vm")
                 #set($jobConfigName = $presenter.buildName)
               <div id="build_detail_summary_container" class="build_detail_summary">
-                <h3>$presenter.buildLocatorForDisplay job <span id="build_name_status">Status loading...</span></h3>
                 <ul id="build-detail-summary" class="summary">
                   <li><span class="header">Scheduled on: </span><span id="build_scheduled_date">Loading...</span></li>
                   <li><span class="header">Completed on: </span><span id="build_completed_date">Loading...</span><a
@@ -160,11 +158,6 @@
     </div>
   </div>
 </div>
-<!-- project summary -->
-##    <div id="sidebar" class="yui-b">
-##        #parse("sidebar/_sidebar_build_list.vm")
-##    </div>
-<!-- end project summary -->
 </div>
 <script type="text/javascript">
   var cruise_stage_or_build_detail_page_status = '$presenter.result';

--- a/server/webapp/WEB-INF/vm/build_detail/build_detail_page.vm
+++ b/server/webapp/WEB-INF/vm/build_detail/build_detail_page.vm
@@ -54,8 +54,11 @@
               <div id="build_detail_summary_container" class="build_detail_summary">
                 <ul id="build-detail-summary" class="summary">
                   <li><span class="header">Scheduled on: </span><span id="build_scheduled_date">Loading...</span></li>
+                  <li><span class="header">Agent: </span><span id="agent_name">Loading...</span></li>
                   <li><span class="header">Completed on: </span><span id="build_completed_date">Loading...</span><a
                     href="#tab-properties" class="more" onclick="new TabsManager('properties')">more...</a></li>
+                  <li><span class="header">Build cause: </span><span
+                    id="stage-${presenter.id}-buildCause">$esc.html($presenter.buildCauseMessage)</span></li>
                   <li class="timer_area">
                     <div class="progress-info">
                       <div id="${presenter.buildName}_progress_bar" class="progress-bar" style="display: none;">
@@ -67,9 +70,6 @@
                       </div>
                     </div>
                   </li>
-                  <li><span class="header">Agent: </span><span id="agent_name">Loading...</span></li>
-                  <li><span class="header">Build cause: </span><span
-                    id="stage-${presenter.id}-buildCause">$esc.html($presenter.buildCauseMessage)</span></li>
                 </ul>
                 <div class="clear"></div>
               </div>

--- a/server/webapp/WEB-INF/vm/shared/_job_details_breadcrumbs.vm
+++ b/server/webapp/WEB-INF/vm/shared/_job_details_breadcrumbs.vm
@@ -32,6 +32,7 @@
       <div class="job_detail_setting"><a href="$req.getContextPath()/admin/pipelines/$presenter.pipelineName/general"
                                          class="icon16 setting"></a></div>
     #end
+    <div id="build_status" class="build-status"></div>
   </div>
 </div>
 #end


### PR DESCRIPTION
These changes are per @naveenbhaskar's screenshot.
- Move the status bar into an indicator in the top right of the breadcrumb toolbar to reduce the amount of space the build summary is occupying. 
- Switch the order of the information provided so all times are on the left, build cause and agent info are on the right. 