### PR TITLE
Fix a bug with date serialization in websocket ConsoleTransmission

### DIFF
--- a/common/src/com/thoughtworks/go/websocket/ConsoleTransmission.java
+++ b/common/src/com/thoughtworks/go/websocket/ConsoleTransmission.java
@@ -36,16 +36,21 @@ public class ConsoleTransmission implements Serializable, Transmission {
     @Expose
     private String buildId;
     @Expose
-    private SimpleDateFormat dateFormat = new SimpleDateFormat("HH:mm:ss.SSS");
+    private String timestamp;
 
+    private static final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("HH:mm:ss.SSS");
 
     public ConsoleTransmission(String line, JobIdentifier jobIdentifier) {
         this.line = line;
+        // Dates don't serialize well (or at least with enough precision), so bake the timestamp as a String
+        this.timestamp = DATE_FORMAT.format(new Date());
         this.jobIdentifier = jobIdentifier;
     }
 
     public ConsoleTransmission(String line, String buildId) {
         this.line = line;
+        // Dates don't serialize well (or at least with enough precision), so bake the timestamp as a String
+        this.timestamp = DATE_FORMAT.format(new Date());
         this.buildId = buildId;
     }
 
@@ -54,7 +59,7 @@ public class ConsoleTransmission implements Serializable, Transmission {
     }
 
     public String getLine() {
-        return format("%s %s\n", dateFormat.format(new Date()), line);
+        return format("%s %s", timestamp, line) + "\n";
     }
 
     @Override


### PR DESCRIPTION
   - Console logs were written with the timestamp a message was received, not generated
   - SimpleDateFormat was not serializing/deserializing correctly, so the log line written to disk used the default format,
     rather than the specified format, which doesn't parse on the UI
   - Date objects don't serialize with the needed precision, so write timestamps as Strings

[https://github.com/gocd/gocd/issues/3274] Console logs have a different timestamp/date format when websockets are enabled.