### PR TITLE
Add icon for elastic agents on agent screen

### DIFF
--- a/server/webapp/WEB-INF/rails.new/app/assets/new_stylesheets/single_page_apps/agents.scss
+++ b/server/webapp/WEB-INF/rails.new/app/assets/new_stylesheets/single_page_apps/agents.scss
@@ -222,15 +222,16 @@ $arrow-color: #000;
   margin:        0;
 
   $column-widths: (
-                    "1": 2%,
-                    "2": 13%,
-                    "3": 7%,
-                    "4": 10%,
+                    "1": 1%,
+                    "2": 2%,
+                    "3": 13%,
+                    "4": 7%,
                     "5": 10%,
-                    "6": 7%,
-                    "7": 11%,
-                    "8": 22%,
-                    "9": 18%,
+                    "6": 10%,
+                    "7": 7%,
+                    "8": 9%,
+                    "9": 22%,
+                    "10": 18%,
                   );
 
   @each $key, $val in $column-widths {
@@ -266,6 +267,14 @@ $arrow-color: #000;
   td {
     word-break:    break-all;
     border-bottom: 1px dotted #ddd;
+
+    .agent-icon {
+      height: 25%;
+
+      &[src=''] {
+        display: none;
+      }
+    }
   }
   .select-agent {
     margin: 0;

--- a/server/webapp/WEB-INF/rails.new/app/assets/new_stylesheets/single_page_apps/agents.scss
+++ b/server/webapp/WEB-INF/rails.new/app/assets/new_stylesheets/single_page_apps/agents.scss
@@ -270,10 +270,6 @@ $arrow-color: #000;
 
     .agent-icon {
       height: 25%;
-
-      &[src=''] {
-        display: none;
-      }
     }
   }
   .select-agent {

--- a/server/webapp/WEB-INF/rails.new/app/assets/new_stylesheets/single_page_apps/agents.scss
+++ b/server/webapp/WEB-INF/rails.new/app/assets/new_stylesheets/single_page_apps/agents.scss
@@ -25,7 +25,6 @@
   }
 }
 
-
 .info {
   color:         #fff;
   clear:         right;
@@ -216,21 +215,20 @@
 $arrow-color: #000;
 
 .go-table {
-  border-bottom: 2px solid #ccc;
   background:    transparent;
   border:        0;
   margin:        0;
 
   $column-widths: (
                     "1": 1%,
-                    "2": 2%,
-                    "3": 13%,
+                    "2": 38px,
+                    "3": 16%,
                     "4": 7%,
                     "5": 10%,
                     "6": 10%,
                     "7": 7%,
                     "8": 9%,
-                    "9": 22%,
+                    "9": calc(22% - 38px),
                     "10": 18%,
                   );
 
@@ -238,6 +236,10 @@ $arrow-color: #000;
     td:nth-child(#{$key}), th:nth-child(#{$key}) {
       width: $val;
     }
+  }
+
+  td:nth-child(2), th:nth-child(2) {
+    padding: 0;
   }
 
   thead {
@@ -269,7 +271,8 @@ $arrow-color: #000;
     border-bottom: 1px dotted #ddd;
 
     .agent-icon {
-      height: 25%;
+      height: 38px;
+      width:  38px;
     }
   }
   .select-agent {

--- a/server/webapp/WEB-INF/rails.new/spec/webpack/views/agents/agent_row_widget_spec.js
+++ b/server/webapp/WEB-INF/rails.new/spec/webpack/views/agents/agent_row_widget_spec.js
@@ -49,7 +49,7 @@ describe("Agent Row Widget", () => {
     const row         = $root.find('tr')[0];
     const checkbox    = $(row).find('input');
     const information = row.children;
-    expect(information[1]).toContainElement('img');
+    expect(information[1]).toExist();
     expect(information[2]).toHaveText('in-john.local');
     expect(information[2]).toContainElement('a');
     expect(information[3]).toHaveText('/var/lib/go-agent');

--- a/server/webapp/WEB-INF/rails.new/spec/webpack/views/agents/agent_row_widget_spec.js
+++ b/server/webapp/WEB-INF/rails.new/spec/webpack/views/agents/agent_row_widget_spec.js
@@ -49,15 +49,16 @@ describe("Agent Row Widget", () => {
     const row         = $root.find('tr')[0];
     const checkbox    = $(row).find('input');
     const information = row.children;
-    expect(information[1]).toHaveText('in-john.local');
-    expect(information[1]).toContainElement('a');
-    expect(information[2]).toHaveText('/var/lib/go-agent');
-    expect(information[3]).toHaveText('Linux');
-    expect(information[4]).toHaveText('10.12.2.200');
-    expect(information[5]).toHaveText('Missing');
-    expect(information[6]).toHaveText('Unknown');
-    expect(information[7]).toHaveText('firefox');
-    expect(information[8]).toHaveText('Dev');
+    expect(information[1]).toContainElement('img');
+    expect(information[2]).toHaveText('in-john.local');
+    expect(information[2]).toContainElement('a');
+    expect(information[3]).toHaveText('/var/lib/go-agent');
+    expect(information[4]).toHaveText('Linux');
+    expect(information[5]).toHaveText('10.12.2.200');
+    expect(information[6]).toHaveText('Missing');
+    expect(information[7]).toHaveText('Unknown');
+    expect(information[8]).toHaveText('firefox');
+    expect(information[9]).toHaveText('Dev');
     expect(checkbox).toBeChecked();
   });
 
@@ -68,8 +69,8 @@ describe("Agent Row Widget", () => {
 
     const row         = $root.find('tr')[0];
     const information = row.children;
-    expect(information[1]).toHaveText('in-john.local');
-    expect(information[1]).not.toContainElement('a');
+    expect(information[2]).toHaveText('in-john.local');
+    expect(information[2]).not.toContainElement('a');
   });
 
   it('should check the value based on the checkbox model', () => {
@@ -92,7 +93,7 @@ describe("Agent Row Widget", () => {
     mount(agents(), model, true);
     const row         = $root.find('tr')[0];
     const information = row.children;
-    expect(information[7]).toHaveText('none specified');
+    expect(information[8]).toHaveText('none specified');
   });
 
   it('should show none specified if agent has no environment', () => {
@@ -100,7 +101,7 @@ describe("Agent Row Widget", () => {
     mount(agents(), model, true);
     const row         = $root.find('tr')[0];
     const information = row.children;
-    expect(information[8]).toHaveText('none specified');
+    expect(information[9]).toHaveText('none specified');
   });
 
   it('should set the class based on the status of the agent', () => {

--- a/server/webapp/WEB-INF/rails.new/spec/webpack/views/agents/agents_widget_spec.js
+++ b/server/webapp/WEB-INF/rails.new/spec/webpack/views/agents/agents_widget_spec.js
@@ -111,16 +111,17 @@ describe("Agents Widget", () => {
   it('should contain the agent row information', () => {
     const agentInfo      = $root.find('table tbody tr')[0];
     const firstAgentInfo = $(agentInfo).find('td');
-    expect(firstAgentInfo).toHaveLength(9);
+    expect(firstAgentInfo).toHaveLength(10);
     expect($(firstAgentInfo[0]).find(':checkbox')).toExist();
-    expect(firstAgentInfo[1]).toHaveText('host-1');
-    expect(firstAgentInfo[2]).toHaveText('usr/local/foo');
-    expect(firstAgentInfo[3]).toHaveText('Linux');
-    expect(firstAgentInfo[4]).toHaveText('10.12.2.200');
-    expect(firstAgentInfo[5]).toContainText('Disabled (Building)');
-    expect(firstAgentInfo[6]).toHaveText('Unknown');
-    expect(firstAgentInfo[7]).toHaveText('Firefox');
-    expect(firstAgentInfo[8]).toHaveText('Dev, Test');
+    expect(firstAgentInfo[1]).toContainElement('img');
+    expect(firstAgentInfo[2]).toHaveText('host-1');
+    expect(firstAgentInfo[3]).toHaveText('usr/local/foo');
+    expect(firstAgentInfo[4]).toHaveText('Linux');
+    expect(firstAgentInfo[5]).toHaveText('10.12.2.200');
+    expect(firstAgentInfo[6]).toContainText('Disabled (Building)');
+    expect(firstAgentInfo[7]).toHaveText('Unknown');
+    expect(firstAgentInfo[8]).toHaveText('Firefox');
+    expect(firstAgentInfo[9]).toHaveText('Dev, Test');
   });
 
   it('should select all the agents when selectAll checkbox is checked', () => {
@@ -323,7 +324,7 @@ describe("Agents Widget", () => {
 
   it('should allow sorting', () => {
     const getHostnamesInTable = () => {
-      const hostnameCells = $root.find(".go-table tbody td:nth-child(2)");
+      const hostnameCells = $root.find(".go-table tbody td:nth-child(3)");
 
       return hostnameCells.map((_i, cell) => $(cell).text()).toArray();
     };
@@ -435,14 +436,14 @@ describe("Agents Widget", () => {
   });
 
   it('should show build details dropdown for building agent', () => {
-    let buildingAgentStatus = $root.find(".agents-table tbody td:nth-child(6)")[0];
+    let buildingAgentStatus = $root.find(".agents-table tbody td:nth-child(7)")[0];
     expect(buildingAgentStatus).not.toHaveClass('is-open');
     const buildingDetailsLink = $(buildingAgentStatus).find('.has-build-details-drop-down')[0];
 
     $(buildingDetailsLink).click();
     m.redraw();
 
-    buildingAgentStatus = $root.find(".agents-table tbody td:nth-child(6)")[0];
+    buildingAgentStatus = $root.find(".agents-table tbody td:nth-child(7)")[0];
     expect(buildingAgentStatus).toHaveClass('is-open');
   });
 

--- a/server/webapp/WEB-INF/rails.new/spec/webpack/views/agents/agents_widget_spec.js
+++ b/server/webapp/WEB-INF/rails.new/spec/webpack/views/agents/agents_widget_spec.js
@@ -113,7 +113,7 @@ describe("Agents Widget", () => {
     const firstAgentInfo = $(agentInfo).find('td');
     expect(firstAgentInfo).toHaveLength(10);
     expect($(firstAgentInfo[0]).find(':checkbox')).toExist();
-    expect(firstAgentInfo[1]).toContainElement('img');
+    expect(firstAgentInfo[1]).toExist();
     expect(firstAgentInfo[2]).toHaveText('host-1');
     expect(firstAgentInfo[3]).toHaveText('usr/local/foo');
     expect(firstAgentInfo[4]).toHaveText('Linux');

--- a/server/webapp/WEB-INF/rails.new/webpack/models/agents/agents.js
+++ b/server/webapp/WEB-INF/rails.new/webpack/models/agents/agents.js
@@ -275,18 +275,6 @@ Agents.Agent = function (data) {
     });
   };
 
-  this.fetchElasticAgentIcon = function() {
-    $.ajax({
-      method:     'GET',
-      url:        Routes.apiv3AdminPluginInfoPath(self.elasticPluginId()),
-      timeout:    mrequest.timeout,
-      beforeSend: mrequest.xhrConfig.forVersion("v3"),
-      async: false
-    }).success((data) => {
-      self.elasticAgentIcon(data["_links"]["image"]["href"]);
-    });
-  };
-
   this.isElasticAgent = () => !_.isNil(self.elasticAgentId());
 
   this.toJSON = function () {

--- a/server/webapp/WEB-INF/rails.new/webpack/models/agents/agents.js
+++ b/server/webapp/WEB-INF/rails.new/webpack/models/agents/agents.js
@@ -244,6 +244,7 @@ Agents.Agent = function (data) {
   this.buildDetails      = Stream(data.buildDetails);
   this.elasticAgentId    = Stream(data.elasticAgentId);
   this.elasticPluginId   = Stream(data.elasticPluginId);
+  this.elasticAgentIcon  = Stream();
   this.parent            = Mixins.GetterSetter();
 
   this.status = function () {
@@ -271,6 +272,18 @@ Agents.Agent = function (data) {
     return _.some(keys, (field) => {
       const agentInfo = self[field]().toString().toLowerCase();
       return s.include(agentInfo, filterText);
+    });
+  };
+
+  this.fetchElasticAgentIcon = function() {
+    $.ajax({
+      method:     'GET',
+      url:        Routes.apiv3AdminPluginInfoPath(self.elasticPluginId()),
+      timeout:    mrequest.timeout,
+      beforeSend: mrequest.xhrConfig.forVersion("v3"),
+      async: false
+    }).success((data) => {
+      self.elasticAgentIcon(data["_links"]["image"]["href"]);
     });
   };
 

--- a/server/webapp/WEB-INF/rails.new/webpack/views/agents/agent_row_widget.js.msx
+++ b/server/webapp/WEB-INF/rails.new/webpack/views/agents/agent_row_widget.js.msx
@@ -62,16 +62,20 @@ const AgentRowWidget = {
     let agentStatus       = agent.status();
     const isBuildingAgent = !agent.buildDetails().isEmpty();
     const isElasticAgent  = agent.isElasticAgent();
+    let pluginInfos = args.pluginInfos;
     let selectAgentCheckbox;
+    let elasticAgentIcon;
     let hostnameLink      = <span>{agent.hostname()}</span>;
-
-    if (isElasticAgent) {
-      agent.fetchElasticAgentIcon();
-    }
 
     if (isBuildingAgent) {
       agentStatus = <f.link onclick={ctrl.buildDetailsClicked.bind(ctrl, agent.uuid())}
                             class="has-build-details-drop-down">{agent.status()}</f.link>;
+    }
+
+    if (isElasticAgent && pluginInfos()) {
+      let elasticAgentIconURL = pluginInfos().findById(agent.elasticPluginId()).imageUrl;
+      elasticAgentIcon =
+        <img class="agent-icon" src={elasticAgentIconURL} />;
     }
 
     if (args.isUserAdmin) {
@@ -92,7 +96,7 @@ const AgentRowWidget = {
           {selectAgentCheckbox}
         </td>
         <td key="agentIcon">
-          <img class='agent-icon' src={ isElasticAgent ? agent.elasticAgentIcon() : ''} />
+          {elasticAgentIcon}
         </td>
         <td key="hostname">
           {hostnameLink}

--- a/server/webapp/WEB-INF/rails.new/webpack/views/agents/agent_row_widget.js.msx
+++ b/server/webapp/WEB-INF/rails.new/webpack/views/agents/agent_row_widget.js.msx
@@ -61,8 +61,13 @@ const AgentRowWidget = {
     const environments    = joinOrNoneSpecified(agent.environments());
     let agentStatus       = agent.status();
     const isBuildingAgent = !agent.buildDetails().isEmpty();
+    const isElasticAgent  = agent.isElasticAgent();
     let selectAgentCheckbox;
     let hostnameLink      = <span>{agent.hostname()}</span>;
+
+    if (isElasticAgent) {
+      agent.fetchElasticAgentIcon();
+    }
 
     if (isBuildingAgent) {
       agentStatus = <f.link onclick={ctrl.buildDetailsClicked.bind(ctrl, agent.uuid())}
@@ -85,6 +90,9 @@ const AgentRowWidget = {
       <tr key={agent.uuid()} class={agent.status().toLowerCase()}>
         <td key="checkbox">
           {selectAgentCheckbox}
+        </td>
+        <td key="agentIcon">
+          <img class='agent-icon' src={ isElasticAgent ? agent.elasticAgentIcon() : ''} />
         </td>
         <td key="hostname">
           {hostnameLink}

--- a/server/webapp/WEB-INF/rails.new/webpack/views/agents/agent_row_widget.js.msx
+++ b/server/webapp/WEB-INF/rails.new/webpack/views/agents/agent_row_widget.js.msx
@@ -62,7 +62,7 @@ const AgentRowWidget = {
     let agentStatus       = agent.status();
     const isBuildingAgent = !agent.buildDetails().isEmpty();
     const isElasticAgent  = agent.isElasticAgent();
-    let pluginInfos = args.pluginInfos;
+    const pluginInfos     = args.pluginInfos;
     let selectAgentCheckbox;
     let elasticAgentIcon;
     let hostnameLink      = <span>{agent.hostname()}</span>;
@@ -73,9 +73,10 @@ const AgentRowWidget = {
     }
 
     if (isElasticAgent && pluginInfos()) {
-      let elasticAgentIconURL = pluginInfos().findById(agent.elasticPluginId()).imageUrl;
-      elasticAgentIcon =
-        <img class="agent-icon" src={elasticAgentIconURL} />;
+      const elasticAgentIconURL = pluginInfos().findById(agent.elasticPluginId()).imageUrl;
+      elasticAgentIcon          = (
+        <img class="agent-icon" src={elasticAgentIconURL}/>
+      );
     }
 
     if (args.isUserAdmin) {

--- a/server/webapp/WEB-INF/rails.new/webpack/views/agents/agent_table_header.js.msx
+++ b/server/webapp/WEB-INF/rails.new/webpack/views/agents/agent_table_header.js.msx
@@ -55,6 +55,7 @@ const AgentsTableHeader = {
         <th>
           {selectAllAgentsCheckbox}
         </th>
+        <th></th>
         <th>
           <SortHeaderWidget attrName='hostname'
                             attrLabel='Agent Name'

--- a/server/webapp/WEB-INF/rails.new/webpack/views/agents/agents_widget.js.msx
+++ b/server/webapp/WEB-INF/rails.new/webpack/views/agents/agents_widget.js.msx
@@ -42,6 +42,8 @@ const AgentsWidget = {
 
     this.allAgents = args.allAgents;
 
+    this.pluginInfos = args.pluginInfos;
+
     this.donePerformingUpdate = function () {
       clearAllCheckboxes();
       args.doRefreshImmediately();
@@ -242,11 +244,11 @@ const AgentsWidget = {
                   return (
                     <AgentRowWidget agent={agent}
                                     key={uuid}
+                                    pluginInfos={ctrl.pluginInfos}
                                     checkBoxModel={checkboxModel}
                                     show={agent.matches(filterText)}
                                     dropdown={args.vm.dropdown}
                                     isUserAdmin={args.isUserAdmin}
-
                     />
                   );
 


### PR DESCRIPTION
Elastic agents provide an icon related to the type of agent in use.
This change just adds the icon to the beginning of the agent listing
on the agents page.

![screen shot 2017-03-16 at 3 23 35 pm](https://cloud.githubusercontent.com/assets/229792/24021182/e10dee5a-0a5c-11e7-97ca-b02407568803.png)