### PR TITLE
Make job history sidebar be a dropdown

### DIFF
--- a/server/webapp/WEB-INF/rails.new/app/assets/stylesheets/css/build_detail.scss
+++ b/server/webapp/WEB-INF/rails.new/app/assets/stylesheets/css/build_detail.scss
@@ -724,6 +724,7 @@ a.collapse-all {
 #build-status-panel .job_details_content {
   /*margin-right: 260px;*/
   overflow: hidden;
+  position: relative;
 }
 
 #build-status-panel .sub_tabs_container,

--- a/server/webapp/WEB-INF/rails.new/app/assets/stylesheets/new-theme.scss
+++ b/server/webapp/WEB-INF/rails.new/app/assets/stylesheets/new-theme.scss
@@ -860,7 +860,7 @@ ul.entity_title {
 }
 
 .build_detail .sidebar_history h4.entity_title {
-  padding:       11px 10px !important;
+  padding:       12px 10px !important;
   background:    $stage-history-head-bg;
   margin-bottom: 0 !important;;
   font-weight:   600;
@@ -1793,7 +1793,9 @@ tr.Cancelled, tr.cancelled-stage {
 
 .job_details_content .sub_tabs_container {
   margin-bottom: 0;
-  position:      relative;
+  position: relative;
+  float: left;
+  width: calc(100% - 272px);
 }
 
 a:link#link-to-this-page, a:visited#link-to-this-page {
@@ -1816,9 +1818,48 @@ a:link#link-to-this-page, a:visited#link-to-this-page {
 
 }
 
-.sidebar_history #build_history_holder {
-  padding:    0px 0px 0 !important;
-  box-shadow: none !important;
+.sidebar_history {
+  height: 43px;
+
+  #build_history_holder {
+    padding:    0px 0px 0 !important;
+    border-radius: 3px 3px 0px 0px;
+
+    .entity_title {
+      cursor: pointer;
+      -moz-user-select: none;
+      -khtml-user-select: none;
+      -webkit-user-select: none;
+      -ms-user-select: none;
+      user-select: none;
+      @include icon-after(caret-down,
+                          $size: 20px,
+                          $margin: 0,
+                          $line-height: 0.85em
+                          );
+
+      &:after {
+        float: right;
+        padding-right: 2px;
+      }
+    }
+
+    &.open #buildlist-container {
+      position: absolute;
+      z-index: 1;
+      top: 43px;
+      bottom: 0;
+      overflow: auto;
+      width: 257px;
+
+      .dropdown-menu {
+        background-color: #F5F5F5;
+        padding: 0;
+        position: static;
+        border-radius: 0;
+      }
+    }
+  }
 }
 
 .sidebar_history .passed .color_code_small {
@@ -2993,9 +3034,13 @@ button.edit-environment {
   padding: 0 30px;
 }
 
-.job_details_content .build_detail_container #tab-content-of-materials .material_revision {
-  padding:       20px !important;
-  margin-bottom: 0;
+.job_details_content .build_detail_container {
+  margin-right: 0px !important;
+  clear: left;
+  #tab-content-of-materials .material_revision {
+    padding:       20px !important;
+    margin-bottom: 0;
+  }
 }
 
 .overview_widget {

--- a/server/webapp/WEB-INF/vm/build_detail/build_detail_page.vm
+++ b/server/webapp/WEB-INF/vm/build_detail/build_detail_page.vm
@@ -74,10 +74,6 @@
                 <div class="clear"></div>
               </div>
 
-
-              <div class="sidebar_history">
-                  #parse("sidebar/_sidebar_build_list.vm")
-              </div>
               <div class="job_details_content">
                 <div class="sub_tabs_container">
                   <ul>
@@ -119,6 +115,10 @@
 
                   <div class="clear"></div>
                 </div>
+
+              <div class="sidebar_history">
+                  #parse("sidebar/_sidebar_build_list.vm")
+              </div>
                 <div class="build_detail_container sub_tab_container rounded-corner-for-tab-container">
 
 

--- a/server/webapp/WEB-INF/vm/sidebar/_sidebar_build_list.vm
+++ b/server/webapp/WEB-INF/vm/sidebar/_sidebar_build_list.vm
@@ -25,12 +25,12 @@
     #end
 #end
 <div id="build_history_holder" class="sidebar-container">
-    <h4 class="entity_title">Job History</h4>
+    <h4 class="entity_title dropdown-arrow-icon" data-toggle='dropdown'>Job History</h4>
     <div id="buildlist-container" class="round-content">
         #if($presenter.recent25.size() == 0)
             <p class="text-only">No jobs found.</p>
         #end
-        <ul class="buildlist">
+        <ul class="buildlist dropdown-menu">
             #foreach( $listPresenter in $presenter.recent25 )
             <li id="build_list_${velocityCount}" #if($listPresenter.isSame($presenter.id)) class="current" #end >
                 <a href="$req.getContextPath()/tab/build/detail/${listPresenter.buildLocator}">


### PR DESCRIPTION
This PR changes the job history sidebar to be a dropdown instead. This frees up the space it is currently taking up for the console log (257px to be exact). I based the styling of this work off of mock ups provided by @naveenbhaskar. Bellow are screenshots

Console Tab:
<img width="1427" alt="console-tab" src="https://cloud.githubusercontent.com/assets/5726224/24218440/9cd35ff6-0f00-11e7-8815-666fff75cbb6.png">

Console Tab with job history expanded:
<img width="1427" alt="console-tab-with-history-dropped" src="https://cloud.githubusercontent.com/assets/5726224/24218458/acd52b50-0f00-11e7-8b9c-6ca3a25063db.png">


Note: The other tabs don't take up nearly as much vertical real estate as the console tab, and thus sometimes the the content of the job history dropdown will be too long. In this case, the dropdown's content will scroll. See bellow for an example.

Non Console Tab:
<img width="1396" alt="artifacts-tab" src="https://cloud.githubusercontent.com/assets/5726224/24218533/da0f2a76-0f00-11e7-8628-7f79e5492150.png">

Non Console Tab with job history expanded (Note that in this case, the job history dropdown scrolls the overflow):
<img width="1407" alt="artifacts-tab-with-scrolling" src="https://cloud.githubusercontent.com/assets/5726224/24218543/eb060520-0f00-11e7-8869-0e9a081ff51d.png">





