### PR TITLE
Can disable material updates as part of integration tests

### DIFF
--- a/server/src/com/thoughtworks/go/server/materials/MaterialUpdateService.java
+++ b/server/src/com/thoughtworks/go/server/materials/MaterialUpdateService.java
@@ -76,6 +76,7 @@ public class MaterialUpdateService implements GoMessageListener<MaterialUpdateCo
     private final Set<MaterialSource> materialSources = new HashSet<>();
     private final Set<MaterialUpdateCompleteListener> materialUpdateCompleteListeners = new HashSet<>();
     public static final String TYPE = "post_commit_hook_material_type";
+    private boolean skipUpdate = false;
 
     @Autowired
     public MaterialUpdateService(MaterialUpdateQueue queue, ConfigMaterialUpdateQueue configUpdateQueue,
@@ -148,6 +149,8 @@ public class MaterialUpdateService implements GoMessageListener<MaterialUpdateCo
     }
 
     public boolean updateMaterial(Material material) {
+        if(skipUpdate) return false;
+
         Date inProgressSince = inProgress.putIfAbsent(material, new Date());
         if (inProgressSince == null || !material.isAutoUpdate()) {
             if (LOGGER.isDebugEnabled()) {
@@ -175,6 +178,16 @@ public class MaterialUpdateService implements GoMessageListener<MaterialUpdateCo
             }
             return false;
         }
+    }
+
+    //    for integration tests
+    public void disableUpdates() {
+        this.skipUpdate = true;
+    }
+
+    //    for integration tests
+    public void enableUpdates() {
+        this.skipUpdate = false;
     }
 
     public void registerMaterialSources(MaterialSource materialSource) {

--- a/server/test/integration/com/thoughtworks/go/server/service/ScheduleServiceRunOnAllAgentIntegrationTest.java
+++ b/server/test/integration/com/thoughtworks/go/server/service/ScheduleServiceRunOnAllAgentIntegrationTest.java
@@ -34,7 +34,7 @@ import com.thoughtworks.go.helper.TestRepo;
 import com.thoughtworks.go.server.cache.GoCache;
 import com.thoughtworks.go.server.dao.DatabaseAccessHelper;
 import com.thoughtworks.go.server.domain.Username;
-import com.thoughtworks.go.server.materials.DependencyMaterialUpdateNotifier;
+import com.thoughtworks.go.server.materials.MaterialUpdateService;
 import com.thoughtworks.go.server.scheduling.ScheduleOptions;
 import com.thoughtworks.go.server.service.result.ServerHealthStateOperationResult;
 import com.thoughtworks.go.serverhealth.HealthStateScope;
@@ -73,7 +73,7 @@ public class ScheduleServiceRunOnAllAgentIntegrationTest {
     @Autowired private PipelineScheduleQueue pipelineScheduleQueue;
     @Autowired private AgentAssignment agentAssignment;
     @Autowired private GoCache goCache;
-    @Autowired private DependencyMaterialUpdateNotifier notifier;
+    @Autowired private MaterialUpdateService updateService;
 
     @Autowired private DatabaseAccessHelper dbHelper;
     private GoConfigFileHelper CONFIG_HELPER;
@@ -104,14 +104,14 @@ public class ScheduleServiceRunOnAllAgentIntegrationTest {
 
         CONFIG_HELPER.addPipeline("blahPipeline", "blahStage", MaterialConfigsMother.hgMaterialConfig("file:///home/cruise/projects/cruisen/manual-testing/ant_hg/dummy"), "job1", "job2");
         CONFIG_HELPER.makeJobRunOnAllAgents("blahPipeline", "blahStage", "job2");
-        notifier.disableUpdates();
+        updateService.disableUpdates();
 
     }
 
     @After
     public void teardown() throws Exception {
         dbHelper.onTearDown();
-        notifier.enableUpdates();
+        updateService.enableUpdates();
         FileUtil.deleteFolder(goConfigService.artifactsDir());
         pipelineScheduleQueue.clear();
         agentAssignment.clear();


### PR DESCRIPTION
**Testing do not merge**
* As part of some of our integration tests we create a material instance
 e.g ScheduleServiceRunOnAllAgentIntegrationTest. There have been
 intermittent tests failures when material creation happens concurrently
 thro test as well as MaterialUpdateService.
* Adding an option to turn off material update through tests