### PR TITLE
Display Plugin name instead of plugin id in dropdown. Aded spec to validate dropdown selection

### DIFF
--- a/server/webapp/WEB-INF/rails.new/spec/webpack/views/elastic_profiles/elastic_profiles_widget_spec.js
+++ b/server/webapp/WEB-INF/rails.new/spec/webpack/views/elastic_profiles/elastic_profiles_widget_spec.js
@@ -56,8 +56,10 @@ describe("ElasticProfilesWidget", () => {
 
   const dockerPluginInfoJSON = {
     "id":               "cd.go.contrib.elastic-agent.docker",
-    "name":             "Docker Elastic Agent Plugin",
-    "version":          "0.5",
+    "about":            {
+      "name":    "Docker Elastic Agent Plugin",
+      "version": "0.5"
+    },
     "type":             "elastic-agent",
     "profile_settings": {
       "configurations": [
@@ -84,12 +86,27 @@ describe("ElasticProfilesWidget", () => {
         }
       ],
       "view":           {
-        "template": "<div></div>"
+        "template": '<div><label class="docker-image">Docker image</label></div>'
       }
     }
   };
 
-  const allPluginInfosJSON = [dockerPluginInfoJSON];
+  const ecsPluginInfoJSON = {
+    "id":               "cd.go.contrib.elastic-agent.ecs",
+    "about":            {
+      "name":    "ECS Elastic Agent Plugin",
+      "version": "0.5"
+    },
+    "type":             "elastic-agent",
+    "profile_settings": {
+      "configurations": [],
+      "view":           {
+        "template": '<div><label class="ecs-ami">AMI</label></div>'
+      }
+    }
+  };
+
+  const allPluginInfosJSON = [dockerPluginInfoJSON, ecsPluginInfoJSON];
   const allPluginInfos     = Stream(PluginInfos.fromJSON([]));
 
   beforeEach(() => {
@@ -239,6 +256,25 @@ describe("ElasticProfilesWidget", () => {
 
       expect($('.alert')).toContainText('Boom!');
     });
+
+    it("should change elastic profile view in modal on change of plugin from dropdown", () => {
+      simulateEvent.simulate($root.find('.add-profile').get(0), 'click');
+      m.redraw();
+
+      expect($('.reveal .modal-body input[data-prop-name]')).not.toBeDisabled();
+      expect($('.reveal .modal-body [data-prop-name=pluginId] option:selected').text()).toEqual(dockerPluginInfoJSON.about.name);
+      expect($('.reveal .modal-body label.docker-image').text()).toEqual("Docker image");
+
+      $('.reveal [data-prop-name=pluginId]').val("cd.go.contrib.elastic-agent.ecs");
+      simulateEvent.simulate($('.reveal [data-prop-name=pluginId]').get(0), 'change');
+      m.redraw();
+
+
+      expect($('.reveal input[data-prop-name]')).not.toBeDisabled();
+      expect($('.reveal .modal-body [data-prop-name=pluginId] option:selected').text()).toEqual(ecsPluginInfoJSON.about.name);
+      expect($('.reveal .modal-body label.ecs-ami').text()).toEqual("AMI");
+    });
+
   });
 
   describe("edit an existing profile", () => {

--- a/server/webapp/WEB-INF/rails.new/webpack/views/elastic_profiles/elastic_profile_modal_body.js.msx
+++ b/server/webapp/WEB-INF/rails.new/webpack/views/elastic_profiles/elastic_profile_modal_body.js.msx
@@ -14,10 +14,11 @@
  * limitations under the License.
  */
 
-let m             = require("mithril");
-let f             = require('helpers/form_helper');
-let AngularPlugin = require('views/shared/angular_plugin');
+let m                 = require("mithril");
+let f                 = require('helpers/form_helper');
+let AngularPlugin     = require('views/shared/angular_plugin');
 const ElasticProfiles = require('models/elastic_profiles/elastic_profiles');
+const s               = require('string-plus');
 
 const ElasticProfileModalBody = {
   oninit (vnode) {
@@ -42,7 +43,7 @@ const ElasticProfileModalBody = {
       return vnode.attrs.pluginInfos().mapPluginInfos((pluginInfo) => {
         return {
           id:   pluginInfo.id(),
-          text: pluginInfo.id()
+          text: s.isBlank(pluginInfo.about().name()) ? pluginInfo.id() : pluginInfo.about().name()
         };
       });
     };


### PR DESCRIPTION
Elastic profile modal now have plugin name in dropdown instead of plugin id.

Added missing spec to validate dropdown selection change