### PR TITLE
Add Origin Attribute on Pipeline config (#3301)

### DIFF
--- a/server/webapp/WEB-INF/rails.new/app/controllers/api_v4/admin/pipelines_controller.rb
+++ b/server/webapp/WEB-INF/rails.new/app/controllers/api_v4/admin/pipelines_controller.rb
@@ -1,5 +1,5 @@
 ##########################################################################
-# Copyright 2016 ThoughtWorks, Inc.
+# Copyright 2017 ThoughtWorks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 
 module ApiV4
   module Admin
-    class PipelinesController < ApiV4::BaseController
+    class PipelinesController < BaseController
       before_action :check_pipeline_group_admin_user_and_401
       before_action :load_pipeline, only: [:show, :update, :destroy]
       before_action :check_if_pipeline_is_defined_remotely, only: [:update, :destroy]
@@ -25,7 +25,7 @@ module ApiV4
 
       def show
         if stale?(etag: etag_for(@pipeline_config))
-          json = ApiV4::Admin::Pipelines::PipelineConfigRepresenter.new(@pipeline_config).to_hash(url_builder: self)
+          json = Admin::Pipelines::PipelineConfigRepresenter.new(@pipeline_config).to_hash(url_builder: self)
           render DEFAULT_FORMAT => json
         end
       end
@@ -57,18 +57,18 @@ module ApiV4
 
       def get_pipeline_from_request
         @pipeline_config_from_request ||= PipelineConfig.new.tap do |config|
-          ApiV4::Admin::Pipelines::PipelineConfigRepresenter.new(config).from_hash(params[:pipeline], {go_config: go_config_service.getCurrentConfig()})
+          Admin::Pipelines::PipelineConfigRepresenter.new(config).from_hash(params[:pipeline], {go_config: go_config_service.getCurrentConfig()})
         end
       end
 
       def handle_config_save_or_update_result(result, pipeline_name = params[:pipeline_name])
         if result.isSuccessful
           load_pipeline(pipeline_name)
-          json = ApiV4::Admin::Pipelines::PipelineConfigRepresenter.new(@pipeline_config).to_hash(url_builder: self)
+          json = Admin::Pipelines::PipelineConfigRepresenter.new(@pipeline_config).to_hash(url_builder: self)
           response.etag = [etag_for(@pipeline_config)]
           render DEFAULT_FORMAT => json
         else
-          json = ApiV4::Admin::Pipelines::PipelineConfigRepresenter.new(@pipeline_config_from_request).to_hash(url_builder: self)
+          json = Admin::Pipelines::PipelineConfigRepresenter.new(@pipeline_config_from_request).to_hash(url_builder: self)
           render_http_operation_result(result, {data: json})
         end
       end
@@ -103,9 +103,9 @@ module ApiV4
       end
 
       def check_if_pipeline_is_defined_remotely
-        if (!@pipeline_config.isLocal())
+        unless @pipeline_config.isLocal()
           result = HttpLocalizedOperationResult.new
-          pipeline_name = @pipeline_config.name().toString()
+          pipeline_name = @pipeline_config.name()
           origin = @pipeline_config.getOrigin().displayName()
           result.unprocessableEntity(LocalizedMessage.string("CAN_NOT_OPERATE_ON_REMOTE_ENTITY", "pipeline", pipeline_name, origin))
           render_http_operation_result(result)

--- a/server/webapp/WEB-INF/rails.new/app/controllers/api_v4/admin/pipelines_controller.rb
+++ b/server/webapp/WEB-INF/rails.new/app/controllers/api_v4/admin/pipelines_controller.rb
@@ -1,0 +1,124 @@
+##########################################################################
+# Copyright 2016 ThoughtWorks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+
+module ApiV4
+  module Admin
+    class PipelinesController < ApiV4::BaseController
+      before_action :check_pipeline_group_admin_user_and_401
+      before_action :load_pipeline, only: [:show, :update, :destroy]
+      before_action :check_if_pipeline_is_defined_remotely, only: [:update, :destroy]
+      before_action :check_if_pipeline_by_same_name_already_exists, :check_group_not_blank, only: [:create]
+      before_action :check_for_stale_request, :check_for_attempted_pipeline_rename, only: [:update]
+
+      def show
+        if stale?(etag: etag_for(@pipeline_config))
+          json = ApiV4::Admin::Pipelines::PipelineConfigRepresenter.new(@pipeline_config).to_hash(url_builder: self)
+          render DEFAULT_FORMAT => json
+        end
+      end
+
+      def create
+        result = HttpLocalizedOperationResult.new
+        get_pipeline_from_request
+        pipeline_config_service.createPipelineConfig(current_user, @pipeline_config_from_request, result, params[:group])
+        handle_config_save_or_update_result(result, @pipeline_config_from_request.name.to_s)
+        if result.isSuccessful
+          pipeline_pause_service.pause(@pipeline_config_from_request.name.to_s, "Under construction", current_user)
+        end
+      end
+
+      def update
+        result = HttpLocalizedOperationResult.new
+        get_pipeline_from_request
+        pipeline_config_service.updatePipelineConfig(current_user, @pipeline_config_from_request, etag_for(@pipeline_config), result)
+        handle_config_save_or_update_result(result)
+      end
+
+      def destroy
+        result = HttpLocalizedOperationResult.new
+        pipeline_config_service.deletePipelineConfig(current_user, @pipeline_config, result)
+        render_http_operation_result(result)
+      end
+
+      protected
+
+      def get_pipeline_from_request
+        @pipeline_config_from_request ||= PipelineConfig.new.tap do |config|
+          ApiV4::Admin::Pipelines::PipelineConfigRepresenter.new(config).from_hash(params[:pipeline], {go_config: go_config_service.getCurrentConfig()})
+        end
+      end
+
+      def handle_config_save_or_update_result(result, pipeline_name = params[:pipeline_name])
+        if result.isSuccessful
+          load_pipeline(pipeline_name)
+          json = ApiV4::Admin::Pipelines::PipelineConfigRepresenter.new(@pipeline_config).to_hash(url_builder: self)
+          response.etag = [etag_for(@pipeline_config)]
+          render DEFAULT_FORMAT => json
+        else
+          json = ApiV4::Admin::Pipelines::PipelineConfigRepresenter.new(@pipeline_config_from_request).to_hash(url_builder: self)
+          render_http_operation_result(result, {data: json})
+        end
+      end
+
+      def check_for_attempted_pipeline_rename
+        unless CaseInsensitiveString.new(params[:pipeline][:name]) == CaseInsensitiveString.new(params[:pipeline_name])
+          result = HttpLocalizedOperationResult.new
+          result.notAcceptable(LocalizedMessage::string("RENAMING_NOT_ALLOWED", 'pipeline'))
+          render_http_operation_result(result)
+        end
+      end
+
+      def stale_message
+        LocalizedMessage::string("STALE_RESOURCE_CONFIG", 'pipeline', params[:pipeline_name])
+      end
+
+      def etag_for_entity_in_config
+        etag_for(@pipeline_config)
+      end
+
+      def load_pipeline(pipeline_name = params[:pipeline_name])
+        @pipeline_config = pipeline_config_service.getPipelineConfig(pipeline_name)
+        raise RecordNotFound if @pipeline_config.nil?
+      end
+
+      def check_if_pipeline_by_same_name_already_exists
+        if (!pipeline_config_service.getPipelineConfig(params[:pipeline][:name]).nil?)
+          result = HttpLocalizedOperationResult.new
+          result.unprocessableEntity(LocalizedMessage::string("RESOURCE_ALREADY_EXISTS", 'pipeline', params[:pipeline][:name]))
+          render_http_operation_result(result)
+        end
+      end
+
+      def check_if_pipeline_is_defined_remotely
+        if (!@pipeline_config.isLocal())
+          result = HttpLocalizedOperationResult.new
+          pipeline_name = @pipeline_config.name().toString()
+          origin = @pipeline_config.getOrigin().displayName()
+          result.unprocessableEntity(LocalizedMessage.string("CAN_NOT_OPERATE_ON_REMOTE_ENTITY", "pipeline", pipeline_name, origin))
+          render_http_operation_result(result)
+        end
+      end
+
+      def check_group_not_blank
+        if (params[:group].blank?)
+          result = HttpLocalizedOperationResult.new
+          result.unprocessableEntity(LocalizedMessage::string("PIPELINE_GROUP_MANDATORY_FOR_PIPELINE_CREATE"))
+          render_http_operation_result(result)
+        end
+      end
+    end
+  end
+end

--- a/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/admin/pipelines/materials/dependency_material_representer.rb
+++ b/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/admin/pipelines/materials/dependency_material_representer.rb
@@ -1,5 +1,5 @@
 ##########################################################################
-# Copyright 2016 ThoughtWorks, Inc.
+# Copyright 2017 ThoughtWorks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/admin/pipelines/materials/dependency_material_representer.rb
+++ b/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/admin/pipelines/materials/dependency_material_representer.rb
@@ -1,0 +1,32 @@
+##########################################################################
+# Copyright 2016 ThoughtWorks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+
+module ApiV4
+  module Admin
+    module Pipelines
+      module Materials
+        class DependencyMaterialRepresenter < BaseRepresenter
+          alias_method :material_config, :represented
+
+          property :pipeline_name, as: :pipeline, case_insensitive_string: true
+          property :stage_name, as: :stage, case_insensitive_string: true
+          property :name, case_insensitive_string: true
+          property :auto_update
+        end
+      end
+    end
+  end
+end

--- a/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/admin/pipelines/materials/encrypted_password_support.rb
+++ b/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/admin/pipelines/materials/encrypted_password_support.rb
@@ -1,0 +1,33 @@
+##########################################################################
+# Copyright 2016 ThoughtWorks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+
+module ApiV4
+  module Admin
+    module Pipelines
+      module Materials
+        module EncryptedPasswordSupport
+          def from_hash(data, options={})
+            super
+            data = data.with_indifferent_access
+            encrypted_password = Services.password_deserializer.deserialize(data[:password], data[:encrypted_password], represented)
+            represented.setEncryptedPassword(encrypted_password)
+            represented
+          end
+        end
+      end
+    end
+  end
+end

--- a/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/admin/pipelines/materials/filter_representer.rb
+++ b/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/admin/pipelines/materials/filter_representer.rb
@@ -1,5 +1,5 @@
 ##########################################################################
-# Copyright 2016 ThoughtWorks, Inc.
+# Copyright 2017 ThoughtWorks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/admin/pipelines/materials/filter_representer.rb
+++ b/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/admin/pipelines/materials/filter_representer.rb
@@ -1,0 +1,39 @@
+##########################################################################
+# Copyright 2016 ThoughtWorks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+
+module ApiV4
+  module Admin
+    module Pipelines
+      module Materials
+        class FilterRepresenter < BaseRepresenter
+          alias_method :filter, :represented
+
+          collection :ignore, exec_context: :decorator
+
+          def to_hash(*options)
+            ignored_files=filter.map { |item| item.getPattern() }
+            {ignore: ignored_files} if !ignored_files.empty?
+          end
+
+          def ignore=(value)
+            filter.clear()
+            value.each { |pattern| filter.add(IgnoredFiles.new(pattern)) }
+          end
+        end
+      end
+    end
+  end
+end

--- a/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/admin/pipelines/materials/git_material_representer.rb
+++ b/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/admin/pipelines/materials/git_material_representer.rb
@@ -1,5 +1,5 @@
 ##########################################################################
-# Copyright 2016 ThoughtWorks, Inc.
+# Copyright 2017 ThoughtWorks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/admin/pipelines/materials/git_material_representer.rb
+++ b/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/admin/pipelines/materials/git_material_representer.rb
@@ -1,0 +1,36 @@
+##########################################################################
+# Copyright 2016 ThoughtWorks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+
+module ApiV4
+  module Admin
+    module Pipelines
+      module Materials
+        class GitMaterialRepresenter < ScmMaterialRepresenter
+          property :branch,
+                   getter: lambda { |args|
+                     branch = self.getBranch
+                     branch.blank? ? 'master' : branch
+                   },
+                   setter: lambda { |value, options|
+                     value.blank? ? self.setBranch('master') : self.setBranch(value)
+                   }
+          property :submodule_folder
+          property :shallow_clone
+        end
+      end
+    end
+  end
+end

--- a/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/admin/pipelines/materials/hg_material_representer.rb
+++ b/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/admin/pipelines/materials/hg_material_representer.rb
@@ -1,5 +1,5 @@
 ##########################################################################
-# Copyright 2016 ThoughtWorks, Inc.
+# Copyright 2017 ThoughtWorks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/admin/pipelines/materials/hg_material_representer.rb
+++ b/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/admin/pipelines/materials/hg_material_representer.rb
@@ -1,0 +1,26 @@
+##########################################################################
+# Copyright 2016 ThoughtWorks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+
+module ApiV4
+  module Admin
+    module Pipelines
+      module Materials
+        class HgMaterialRepresenter < ScmMaterialRepresenter
+        end
+      end
+    end
+  end
+end

--- a/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/admin/pipelines/materials/material_representer.rb
+++ b/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/admin/pipelines/materials/material_representer.rb
@@ -1,5 +1,5 @@
 ##########################################################################
-# Copyright 2016 ThoughtWorks, Inc.
+# Copyright 2017 ThoughtWorks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/admin/pipelines/materials/material_representer.rb
+++ b/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/admin/pipelines/materials/material_representer.rb
@@ -1,0 +1,81 @@
+##########################################################################
+# Copyright 2016 ThoughtWorks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+
+module ApiV4
+  module Admin
+    module Pipelines
+      module Materials
+        class MaterialRepresenter < BaseRepresenter
+          TYPE_TO_MATERIAL_MAP = {
+            'git' => GitMaterialConfig,
+            'svn' => SvnMaterialConfig,
+            'hg' => HgMaterialConfig,
+            'p4' => P4MaterialConfig,
+            'tfs' => TfsMaterialConfig,
+            'dependency' => DependencyMaterialConfig,
+            'package' => PackageMaterialConfig,
+            'plugin' => PluggableSCMMaterialConfig
+          }
+
+          MATERIAL_TO_TYPE_MAP = TYPE_TO_MATERIAL_MAP.invert
+
+          MATERIAL_TYPE_TO_REPRESENTER_MAP = {
+            GitMaterialConfig => GitMaterialRepresenter,
+            SvnMaterialConfig => SvnMaterialRepresenter,
+            HgMaterialConfig => HgMaterialRepresenter,
+            P4MaterialConfig => PerforceMaterialRepresenter,
+            TfsMaterialConfig => TfsMaterialRepresenter,
+            DependencyMaterialConfig => DependencyMaterialRepresenter,
+            PackageMaterialConfig => PackageMaterialRepresenter,
+            PluggableSCMMaterialConfig => PluggableScmMaterialRepresenter
+          }
+          alias_method :material_config, :represented
+
+          error_representer({
+                              "materialName" => "name",
+                              "folder" => "destination",
+                              "autoUpdate" => "auto_update",
+                              "filterAsString" => "filter",
+                              "checkexternals" => "check_externals",
+                              "serverAndPort" => "port",
+                              "useTickets" => "use_tickets",
+                              "pipelineName" => "pipeline",
+                              "stageName" => "stage",
+                              "pipelineStageName" => "pipeline",
+                              "packageId" => "ref",
+                              "scmId" => "ref",
+                              "password" => "password",
+                              "encryptedPassword" => "encrypted_password",
+                            }
+          )
+
+          property :type, getter: lambda { |options| MATERIAL_TO_TYPE_MAP[self.class] }, skip_parse: true
+
+          nested :attributes,
+                 decorator: lambda { |material_config, *|
+                   MATERIAL_TYPE_TO_REPRESENTER_MAP[material_config.class]
+                 }
+
+          class << self
+            def get_material_type(type)
+              TYPE_TO_MATERIAL_MAP[type] or (raise UnprocessableEntity, "Invalid material type '#{type}'. It has to be one of '#{TYPE_TO_MATERIAL_MAP.keys.join(' ')}'")
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/admin/pipelines/materials/package_material_representer.rb
+++ b/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/admin/pipelines/materials/package_material_representer.rb
@@ -1,5 +1,5 @@
 ##########################################################################
-# Copyright 2016 ThoughtWorks, Inc.
+# Copyright 2017 ThoughtWorks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/admin/pipelines/materials/package_material_representer.rb
+++ b/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/admin/pipelines/materials/package_material_representer.rb
@@ -1,0 +1,33 @@
+##########################################################################
+# Copyright 2016 ThoughtWorks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+
+module ApiV4
+  module Admin
+    module Pipelines
+      module Materials
+        class PackageMaterialRepresenter < BaseRepresenter
+          alias_method :material_config, :represented
+
+          property :packageId, as: :ref, setter: lambda { |value, options|
+            package_definition = options[:go_config].getPackageRepositories().findPackageDefinitionWith(value)
+            self.setPackageDefinition(package_definition)
+            self.setPackageId(value)
+          }
+        end
+      end
+    end
+  end
+end

--- a/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/admin/pipelines/materials/perforce_material_representer.rb
+++ b/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/admin/pipelines/materials/perforce_material_representer.rb
@@ -1,5 +1,5 @@
 ##########################################################################
-# Copyright 2016 ThoughtWorks, Inc.
+# Copyright 2017 ThoughtWorks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/admin/pipelines/materials/perforce_material_representer.rb
+++ b/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/admin/pipelines/materials/perforce_material_representer.rb
@@ -1,0 +1,39 @@
+##########################################################################
+# Copyright 2016 ThoughtWorks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+
+module ApiV4
+  module Admin
+    module Pipelines
+      module Materials
+        class PerforceMaterialRepresenter < ScmMaterialRepresenter
+          include EncryptedPasswordSupport
+
+          property :url, skip_render: true, skip_parse: true #This is done so as to avoid setting the url property of super class ScmMaterialConfig
+          property :server_and_port, as: :port
+          property :user_name, as: :username
+          property :password,
+                   skip_render: true,
+                   skip_nil: true,
+                   skip_parse: true
+
+          property :encrypted_password, skip_nil: true, skip_parse: true
+          property :use_tickets
+          property :view
+        end
+      end
+    end
+  end
+end

--- a/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/admin/pipelines/materials/pluggable_scm_material_representer.rb
+++ b/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/admin/pipelines/materials/pluggable_scm_material_representer.rb
@@ -1,5 +1,5 @@
 ##########################################################################
-# Copyright 2016 ThoughtWorks, Inc.
+# Copyright 2017 ThoughtWorks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/admin/pipelines/materials/pluggable_scm_material_representer.rb
+++ b/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/admin/pipelines/materials/pluggable_scm_material_representer.rb
@@ -1,0 +1,39 @@
+##########################################################################
+# Copyright 2016 ThoughtWorks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+
+module ApiV4
+  module Admin
+    module Pipelines
+      module Materials
+        class PluggableScmMaterialRepresenter < BaseRepresenter
+          alias_method :material_config, :represented
+
+          property :scmId, as: :ref, setter: lambda { |value, options|
+            scm = options[:go_config].getSCMs().find(value)
+            self.setSCMConfig(scm)
+            self.setScmId(value)
+          }
+
+          property :filter,
+                   decorator: FilterRepresenter,
+                   class: com.thoughtworks.go.config.materials.Filter,
+                   skip_parse: SkipParseOnBlank
+          property :folder, as: :destination, skip_parse: SkipParseOnBlank
+        end
+      end
+    end
+  end
+end

--- a/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/admin/pipelines/materials/scm_material_representer.rb
+++ b/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/admin/pipelines/materials/scm_material_representer.rb
@@ -1,5 +1,5 @@
 ##########################################################################
-# Copyright 2016 ThoughtWorks, Inc.
+# Copyright 2017 ThoughtWorks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/admin/pipelines/materials/scm_material_representer.rb
+++ b/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/admin/pipelines/materials/scm_material_representer.rb
@@ -1,0 +1,39 @@
+##########################################################################
+# Copyright 2016 ThoughtWorks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+
+module ApiV4
+  module Admin
+    module Pipelines
+      module Materials
+        class ScmMaterialRepresenter < BaseRepresenter
+          alias_method :material_config, :represented
+
+          property :url
+          property :folder, as: :destination, skip_parse: SkipParseOnBlank
+          property :filter,
+                   decorator: FilterRepresenter,
+                   class: com.thoughtworks.go.config.materials.Filter,
+                   skip_parse: SkipParseOnBlank
+          property :invert_filter,
+                   skip_parse: SkipParseOnBlank
+          property :name, case_insensitive_string: true, skip_parse: SkipParseOnBlank
+          property :auto_update
+
+        end
+      end
+    end
+  end
+end

--- a/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/admin/pipelines/materials/svn_material_representer.rb
+++ b/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/admin/pipelines/materials/svn_material_representer.rb
@@ -1,5 +1,5 @@
 ##########################################################################
-# Copyright 2016 ThoughtWorks, Inc.
+# Copyright 2017 ThoughtWorks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/admin/pipelines/materials/svn_material_representer.rb
+++ b/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/admin/pipelines/materials/svn_material_representer.rb
@@ -1,0 +1,38 @@
+##########################################################################
+# Copyright 2016 ThoughtWorks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+
+module ApiV4
+  module Admin
+    module Pipelines
+      module Materials
+        class SvnMaterialRepresenter < ScmMaterialRepresenter
+          include EncryptedPasswordSupport
+
+          property :check_externals
+          property :user_name, as: :username
+          property :password,
+                   skip_render: true,
+                   skip_nil: true,
+                   skip_parse: true
+
+          property :encrypted_password, skip_nil: true, skip_parse: true
+
+        end
+
+      end
+    end
+  end
+end

--- a/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/admin/pipelines/materials/tfs_material_representer.rb
+++ b/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/admin/pipelines/materials/tfs_material_representer.rb
@@ -1,5 +1,5 @@
 ##########################################################################
-# Copyright 2016 ThoughtWorks, Inc.
+# Copyright 2017 ThoughtWorks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/admin/pipelines/materials/tfs_material_representer.rb
+++ b/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/admin/pipelines/materials/tfs_material_representer.rb
@@ -1,0 +1,39 @@
+##########################################################################
+# Copyright 2016 ThoughtWorks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+
+module ApiV4
+  module Admin
+    module Pipelines
+      module Materials
+        class TfsMaterialRepresenter < ScmMaterialRepresenter
+          include EncryptedPasswordSupport
+
+          property :domain
+          property :user_name, as: :username
+          property :password,
+                   skip_render: true,
+                   skip_nil: true,
+                   skip_parse: true
+
+          property :encrypted_password, skip_nil: true, skip_parse: true
+
+          property :project_path
+
+        end
+      end
+    end
+  end
+end

--- a/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/admin/pipelines/param_representer.rb
+++ b/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/admin/pipelines/param_representer.rb
@@ -1,5 +1,5 @@
 ##########################################################################
-# Copyright 2016 ThoughtWorks, Inc.
+# Copyright 2017 ThoughtWorks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/admin/pipelines/param_representer.rb
+++ b/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/admin/pipelines/param_representer.rb
@@ -1,0 +1,29 @@
+##########################################################################
+# Copyright 2016 ThoughtWorks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+
+module ApiV4
+  module Admin
+    module Pipelines
+      class ParamRepresenter < BaseRepresenter
+        alias_method :param, :represented
+        error_representer
+        property :name
+        property :value
+
+      end
+    end
+  end
+end

--- a/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/admin/pipelines/pipeline_config_representer.rb
+++ b/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/admin/pipelines/pipeline_config_representer.rb
@@ -1,0 +1,151 @@
+##########################################################################
+# Copyright 2016 ThoughtWorks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+
+module ApiV4
+  module Admin
+    module Pipelines
+      class PipelineConfigRepresenter < BaseRepresenter
+        alias_method :pipeline, :represented
+
+        error_representer({
+                            'labelTemplate' => 'label_template',
+                            'params' => 'parameters',
+                            'variables' => 'environment_variables',
+                            'trackingTool' => 'tracking_tool'
+                          })
+
+        link :self do |opts|
+          opts[:url_builder].apiv4_admin_pipeline_url(pipeline_name: pipeline.name) if pipeline.errors().isEmpty()
+        end
+
+        link :doc do |opts|
+          'https://api.gocd.io/#pipeline-config'
+        end
+
+        link :find do |opts|
+          opts[:url_builder].apiv4_admin_pipeline_url(pipeline_name: '__pipeline_name__').gsub(/__pipeline_name__/, ':pipeline_name')
+        end
+
+        property :label_template
+        property :enable_pipeline_locking,
+                 getter: lambda { |options| self.isLock },
+                 setter: lambda { |val, options| val ? self.lockExplicitly : self.unlockExplicitly }
+
+        property :name, case_insensitive_string: true
+        property :template_name, as: :template, case_insensitive_string: true
+
+        collection :parameters,
+                   exec_context: :decorator,
+                   decorator: ParamRepresenter,
+                   expect_hash: true,
+                   class: com.thoughtworks.go.config.ParamConfig
+
+        collection :environment_variables,
+                   exec_context: :decorator,
+                   decorator: Shared::EnvironmentVariableRepresenter,
+                   expect_hash: true,
+                   class: com.thoughtworks.go.config.EnvironmentVariableConfig
+
+        collection :materials,
+                   exec_context: :decorator,
+                   decorator: Admin::Pipelines::Materials::MaterialRepresenter,
+                   expect_hash: true,
+                   class: lambda { |fragment, *|
+                     Admin::Pipelines::Materials::MaterialRepresenter.get_material_type(fragment[:type]||fragment['type'])
+                   }
+        collection :stages,
+                   exec_context: :decorator,
+                   decorator: Shared::Stages::StageRepresenter,
+                   expect_hash: true,
+                   class: com.thoughtworks.go.config.StageConfig
+
+        property :tracking_tool,
+                 exec_context: :decorator,
+                 decorator: Admin::Pipelines::TrackingTool::TrackingToolRepresenter,
+                 expect_hash: true,
+                 class: lambda { |object, *|
+                   Admin::Pipelines::TrackingTool::TrackingToolRepresenter.get_class(object[:type] || object['type'])
+                 }
+
+        property :timer,
+                 decorator: Admin::Pipelines::TimerRepresenter,
+                 class: com.thoughtworks.go.config.TimerConfig,
+                 skip_parse: SkipParseOnBlank
+
+        delegate :name, :name=, to: :pipeline
+
+        def parameters
+          pipeline.params
+        end
+
+        def parameters=(new_params)
+          pipeline.params = new_params
+        end
+
+        def environment_variables
+          pipeline.getVariables()
+        end
+
+        def environment_variables=(array_of_variables)
+          pipeline.setVariables(EnvironmentVariablesConfig.new(array_of_variables))
+        end
+
+        def materials
+          pipeline.materialConfigs()
+        end
+
+        def materials=(value)
+          pipeline.materialConfigs().clear
+          value.each { |material| pipeline.materialConfigs().add(material) }
+        end
+
+        def stages
+          pipeline.getStages() if !pipeline.getStages().isEmpty
+        end
+
+        def stages=(value)
+          pipeline.getStages().clear()
+          value.each { |stage| pipeline.addStageWithoutValidityAssertion(stage) }
+        end
+
+        def tracking_tool
+          if pipeline.getTrackingTool()
+            pipeline.getTrackingTool()
+          elsif pipeline.getMingleConfig().isDefined()
+            pipeline.getMingleConfig()
+          end
+
+        end
+
+        def tracking_tool=(value)
+          if value.instance_of? com.thoughtworks.go.config.MingleConfig
+            pipeline.setMingleConfig(value)
+          elsif value.instance_of? com.thoughtworks.go.config.TrackingTool
+            pipeline.setTrackingTool(value)
+          end
+        end
+
+        def errors_with_material_config_errors
+          pipeline.errors.addAll(pipeline.materialConfigs.errors)
+
+          errors_without_material_config_errors
+        end
+
+        alias_method_chain :errors, :material_config_errors
+      end
+    end
+  end
+end

--- a/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/admin/pipelines/pipeline_config_representer.rb
+++ b/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/admin/pipelines/pipeline_config_representer.rb
@@ -1,5 +1,5 @@
 ##########################################################################
-# Copyright 2016 ThoughtWorks, Inc.
+# Copyright 2017 ThoughtWorks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -46,6 +46,16 @@ module ApiV4
 
         property :name, case_insensitive_string: true
         property :template_name, as: :template, case_insensitive_string: true
+
+        property :origin,
+                 decorator: lambda { |origin, *|
+                   if origin.instance_of? FileConfigOrigin
+                     Shared::ConfigOrigin::ConfigXmlOriginRepresenter
+                   else
+                     Shared::ConfigOrigin::ConfigRepoOriginRepresenter
+                   end
+                 },
+                 skip_parse: true
 
         collection :parameters,
                    exec_context: :decorator,

--- a/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/admin/pipelines/timer_representer.rb
+++ b/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/admin/pipelines/timer_representer.rb
@@ -1,5 +1,5 @@
 ##########################################################################
-# Copyright 2016 ThoughtWorks, Inc.
+# Copyright 2017 ThoughtWorks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/admin/pipelines/timer_representer.rb
+++ b/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/admin/pipelines/timer_representer.rb
@@ -1,0 +1,31 @@
+##########################################################################
+# Copyright 2016 ThoughtWorks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+
+module ApiV4
+  module Admin
+    module Pipelines
+      class TimerRepresenter < BaseRepresenter
+        alias_method :timer, :represented
+
+        error_representer({"timerSpec" => "spec"})
+
+        property :timer_spec, as: :spec
+        property :onlyOnChanges, as: :only_on_changes
+
+      end
+    end
+  end
+end

--- a/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/admin/pipelines/tracking_tool/external_tracking_tool_representer.rb
+++ b/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/admin/pipelines/tracking_tool/external_tracking_tool_representer.rb
@@ -1,5 +1,5 @@
 ##########################################################################
-# Copyright 2016 ThoughtWorks, Inc.
+# Copyright 2017 ThoughtWorks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/admin/pipelines/tracking_tool/external_tracking_tool_representer.rb
+++ b/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/admin/pipelines/tracking_tool/external_tracking_tool_representer.rb
@@ -1,0 +1,32 @@
+##########################################################################
+# Copyright 2016 ThoughtWorks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+
+module ApiV4
+  module Admin
+    module Pipelines
+      module TrackingTool
+        class ExternalTrackingToolRepresenter < BaseRepresenter
+          alias_method :tracking_tool, :represented
+
+          ERROR_KEYS = {'link' => 'url_pattern'}
+
+          property :link, as: :url_pattern
+          property :regex
+        end
+      end
+    end
+  end
+end

--- a/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/admin/pipelines/tracking_tool/mingle_tracking_tool_representer.rb
+++ b/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/admin/pipelines/tracking_tool/mingle_tracking_tool_representer.rb
@@ -1,5 +1,5 @@
 ##########################################################################
-# Copyright 2016 ThoughtWorks, Inc.
+# Copyright 2017 ThoughtWorks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/admin/pipelines/tracking_tool/mingle_tracking_tool_representer.rb
+++ b/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/admin/pipelines/tracking_tool/mingle_tracking_tool_representer.rb
@@ -1,0 +1,44 @@
+##########################################################################
+# Copyright 2016 ThoughtWorks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+
+module ApiV4
+  module Admin
+    module Pipelines
+      module TrackingTool
+        class MingleTrackingToolRepresenter < BaseRepresenter
+          alias_method :mingle, :represented
+
+          ERROR_KEYS = {
+            'baseUrl' => 'base_url',
+            'projectIdentifier' => 'project_identifier'
+          }
+
+          property :base_url
+          property :project_identifier
+          property :mql_grouping_conditions, exec_context: :decorator
+
+          def mql_grouping_conditions
+            mingle.getMqlCriteria().getMql
+          end
+
+          def mql_grouping_conditions=(value)
+            mingle.setMqlCriteria(value)
+          end
+        end
+      end
+    end
+  end
+end

--- a/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/admin/pipelines/tracking_tool/tracking_tool_representer.rb
+++ b/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/admin/pipelines/tracking_tool/tracking_tool_representer.rb
@@ -1,5 +1,5 @@
 ##########################################################################
-# Copyright 2016 ThoughtWorks, Inc.
+# Copyright 2017 ThoughtWorks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/admin/pipelines/tracking_tool/tracking_tool_representer.rb
+++ b/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/admin/pipelines/tracking_tool/tracking_tool_representer.rb
@@ -1,0 +1,62 @@
+##########################################################################
+# Copyright 2016 ThoughtWorks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+
+module ApiV4
+  module Admin
+    module Pipelines
+      module TrackingTool
+        class TrackingToolRepresenter < BaseRepresenter
+          TRACKING_TOOL_TYPE_TO_REPRESENTER_MAP = {
+            com.thoughtworks.go.config.MingleConfig => MingleTrackingToolRepresenter,
+            com.thoughtworks.go.config.TrackingTool => ExternalTrackingToolRepresenter
+          }
+
+          TRACKING_TOOL_TYPE_TO_CLASS_MAP = {
+            'generic' => com.thoughtworks.go.config.TrackingTool,
+            'mingle' => com.thoughtworks.go.config.MingleConfig
+          }.freeze
+
+          TRACKING_TOOL_CLASS_TO_TYPE_MAP = TRACKING_TOOL_TYPE_TO_CLASS_MAP.invert.freeze
+
+          alias_method :tracking_tool, :represented
+
+          error_representer(lambda { |tracking_tool|
+            if tracking_tool
+              TRACKING_TOOL_TYPE_TO_REPRESENTER_MAP[tracking_tool.class()]::ERROR_KEYS
+            end
+          })
+          property :type, exec_context: :decorator, skip_parse: true
+          nested :attributes,
+                 decorator: lambda { |tracking_tool, *|
+                   TRACKING_TOOL_TYPE_TO_REPRESENTER_MAP[tracking_tool.class]
+                 }
+
+          class << self
+            def get_class(type)
+              TRACKING_TOOL_TYPE_TO_CLASS_MAP[type] || (raise UnprocessableEntity, "Invalid Tracking Tool type '#{type}'. It has to be one of '#{TRACKING_TOOL_TYPE_TO_CLASS_MAP.keys.join(', ')}.'")
+            end
+          end
+
+          private
+
+          def type
+            TRACKING_TOOL_CLASS_TO_TYPE_MAP[tracking_tool.class] || (raise UnprocessableEntity, "Invalid Tracking Tool type '#{tracking_tool.class}'. It has to be one of '#{TRACKING_TOOL_CLASS_TO_TYPE_MAP.keys.join(', ')}.'")
+          end
+        end
+      end
+    end
+  end
+end

--- a/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/config/error_representer.rb
+++ b/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/config/error_representer.rb
@@ -1,5 +1,5 @@
 ##########################################################################
-# Copyright 2016 ThoughtWorks, Inc.
+# Copyright 2017 ThoughtWorks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/shared/config_origin/config_repo_origin_representer.rb
+++ b/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/shared/config_origin/config_repo_origin_representer.rb
@@ -15,17 +15,22 @@
 ##########################################################################
 
 module ApiV4
-  module Admin
-    module Pipelines
-      module Materials
-        module EncryptedPasswordSupport
-          def from_hash(data, options={})
-            super
-            data = data.with_indifferent_access
-            encrypted_password = Services.password_deserializer.deserialize(data[:password], data[:encrypted_password], represented)
-            represented.setEncryptedPassword(encrypted_password)
-            represented
-          end
+  module Shared
+    module ConfigOrigin
+      class ConfigRepoOriginRepresenter < BaseRepresenter
+        alias_method :config_repo, :represented
+
+        property :type, exec_context: :decorator
+        property :repo, exec_context: :decorator
+
+        def type
+          'config repo'
+        end
+
+        def repo
+          material = ApiV4::Admin::Pipelines::Materials::MaterialRepresenter.new(config_repo.getMaterial).to_hash(url_builder: self)
+          material[:revision] = config_repo.getRevision()
+          material
         end
       end
     end

--- a/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/shared/config_origin/config_xml_origin_representer.rb
+++ b/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/shared/config_origin/config_xml_origin_representer.rb
@@ -15,17 +15,16 @@
 ##########################################################################
 
 module ApiV4
-  module Admin
-    module Pipelines
-      module Materials
-        module EncryptedPasswordSupport
-          def from_hash(data, options={})
-            super
-            data = data.with_indifferent_access
-            encrypted_password = Services.password_deserializer.deserialize(data[:password], data[:encrypted_password], represented)
-            represented.setEncryptedPassword(encrypted_password)
-            represented
-          end
+  module Shared
+    module ConfigOrigin
+      class ConfigXmlOriginRepresenter < BaseRepresenter
+        alias_method :origin, :represented
+
+        property :type, exec_context: :decorator
+        property :displayName, as: :file
+
+        def type
+          'local'
         end
       end
     end

--- a/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/shared/environment_variable_representer.rb
+++ b/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/shared/environment_variable_representer.rb
@@ -1,5 +1,5 @@
 ##########################################################################
-# Copyright 2016 ThoughtWorks, Inc.
+# Copyright 2017 ThoughtWorks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/shared/environment_variable_representer.rb
+++ b/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/shared/environment_variable_representer.rb
@@ -1,0 +1,45 @@
+##########################################################################
+# Copyright 2016 ThoughtWorks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+
+module ApiV4
+  module Shared
+    class EnvironmentVariableRepresenter < BaseRepresenter
+      alias_method :environment_variable, :represented
+
+      error_representer({'encryptedValue' => 'encrypted_value'})
+
+      property :isSecure, as: :secure, writable: false
+      property :name, writable: false
+      property :value, skip_nil: true, writable: false, exec_context: :decorator
+      property :encrypted_value, skip_nil: true, writable: false, exec_context: :decorator
+      property :errors, exec_context: :decorator, decorator: Shared::ErrorRepresenter, skip_parse: true, skip_render: lambda { |object, options| object.empty? }
+
+      def value
+        environment_variable.getValueForDisplay() if environment_variable.isPlain
+      end
+
+      def encrypted_value
+        environment_variable.getValueForDisplay() if environment_variable.isSecure
+      end
+
+      def from_hash(data, options={})
+        data = data.with_indifferent_access
+        environment_variable.deserialize(data[:name], data[:value], data[:secure].to_bool, data[:encrypted_value])
+        environment_variable
+      end
+    end
+  end
+end

--- a/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/shared/error_representer.rb
+++ b/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/shared/error_representer.rb
@@ -1,5 +1,5 @@
 ##########################################################################
-# Copyright 2016 ThoughtWorks, Inc.
+# Copyright 2017 ThoughtWorks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/shared/error_representer.rb
+++ b/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/shared/error_representer.rb
@@ -1,0 +1,34 @@
+##########################################################################
+# Copyright 2016 ThoughtWorks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+
+module ApiV4
+  module Shared
+    class ErrorRepresenter < BaseRepresenter
+      alias_method :errors, :represented
+
+      def to_hash(*options)
+        hash = {}
+        errors.each do |key, value|
+          hash[key]||=[]
+          value.each do |message|
+            hash[key] << message
+          end
+        end
+        hash
+      end
+    end
+  end
+end

--- a/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/shared/stages/approval_representer.rb
+++ b/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/shared/stages/approval_representer.rb
@@ -1,5 +1,5 @@
 ##########################################################################
-# Copyright 2016 ThoughtWorks, Inc.
+# Copyright 2017 ThoughtWorks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/shared/stages/approval_representer.rb
+++ b/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/shared/stages/approval_representer.rb
@@ -1,0 +1,30 @@
+##########################################################################
+# Copyright 2016 ThoughtWorks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+
+module ApiV4
+  module Shared
+    module Stages
+      class ApprovalRepresenter < BaseRepresenter
+        alias_method :approval, :represented
+
+        error_representer
+
+        property :type
+        property :auth_config, as: :authorization, decorator: StageAuthorizationRepresenter, class: AuthConfig
+      end
+    end
+  end
+end

--- a/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/shared/stages/artifact_representer.rb
+++ b/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/shared/stages/artifact_representer.rb
@@ -1,5 +1,5 @@
 ##########################################################################
-# Copyright 2016 ThoughtWorks, Inc.
+# Copyright 2017 ThoughtWorks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/shared/stages/artifact_representer.rb
+++ b/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/shared/stages/artifact_representer.rb
@@ -1,0 +1,51 @@
+##########################################################################
+# Copyright 2016 ThoughtWorks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+
+module ApiV4
+  module Shared
+    module Stages
+      class ArtifactRepresenter < BaseRepresenter
+        alias_method :artifact, :represented
+
+        error_representer({"src" => "source", "dest" => "destination"})
+
+        ARTIFACT_TYPE_TO_STRING_TYPE_MAP = {
+          ArtifactType::unit => 'test',
+          ArtifactType::file => 'build'
+        }
+
+        ARTIFACT_TYPE_TO_ARTIFACT_CLASS_MAP = {
+          'test' => TestArtifactPlan,
+          'build' => ArtifactPlan
+        }
+
+        property :src, as: :source
+        property :dest, as: :destination
+        property :type, exec_context: :decorator, skip_parse: true
+
+        def type
+          ARTIFACT_TYPE_TO_STRING_TYPE_MAP[artifact.getArtifactType]
+        end
+
+        class << self
+          def get_class_for_artifact_type(type)
+            ARTIFACT_TYPE_TO_ARTIFACT_CLASS_MAP[type] || (raise UnprocessableEntity, "Invalid Artifact type: '#{type}'. It has to be one of #{ARTIFACT_TYPE_TO_ARTIFACT_CLASS_MAP.keys.join(', ')}")
+          end
+        end
+      end
+    end
+  end
+end

--- a/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/shared/stages/job_representer.rb
+++ b/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/shared/stages/job_representer.rb
@@ -1,5 +1,5 @@
 ##########################################################################
-# Copyright 2016 ThoughtWorks, Inc.
+# Copyright 2017 ThoughtWorks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/shared/stages/job_representer.rb
+++ b/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/shared/stages/job_representer.rb
@@ -1,0 +1,154 @@
+##########################################################################
+# Copyright 2016 ThoughtWorks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+
+module ApiV4
+  module Shared
+    module Stages
+      class JobRepresenter < BaseRepresenter
+        alias_method :job, :represented
+
+        error_representer({'runType' => 'run_instance_count'})
+        property :name,
+                 case_insensitive_string: true
+
+        property :run_instance_count,
+                 exec_context: :decorator
+
+        property :timeout,
+                 exec_context: :decorator
+
+        property :elastic_profile_id, skip_nil: true
+
+        collection :environment_variables,
+                   exec_context: :decorator,
+                   decorator: Shared::EnvironmentVariableRepresenter,
+                   class: com.thoughtworks.go.config.EnvironmentVariableConfig
+        collection :resources,
+                   exec_context: :decorator,
+                   skip_nil: true
+        collection :tasks,
+                   exec_context: :decorator,
+                   decorator: Shared::Stages::Tasks::TaskRepresenter,
+                   expect_hash: true,
+                   class: lambda { |fragment, *|
+                     Shared::Stages::Tasks::TaskRepresenter.task_class_for_type(fragment[:type]||fragment['type'])
+                   }
+        collection :tabs,
+                   exec_context: :decorator,
+                   decorator: TabConfigRepresenter,
+                   expect_hash: true,
+                   class: com.thoughtworks.go.config.Tab
+        collection :artifacts,
+                   exec_context: :decorator,
+                   decorator: Shared::Stages::ArtifactRepresenter,
+                   expect_hash: true,
+                   class: lambda { |fragment, *|
+                     Shared::Stages::ArtifactRepresenter.get_class_for_artifact_type(fragment[:type] || fragment['type'])
+                   }
+
+        collection :properties, exec_context: :decorator, decorator: Shared::Stages::PropertyConfigRepresenter, class: com.thoughtworks.go.config.ArtifactPropertiesGenerator, render_empty: false
+
+        def run_instance_count
+          if job.getRunInstanceCount.present?
+            job.getRunInstanceCount.to_i
+          elsif job.isRunOnAllAgents
+            'all'
+          else
+            nil
+          end
+        end
+
+        def run_instance_count=(val)
+          return if val.blank? || val.to_s.strip.downcase == 'null'
+          if val.to_s.strip.downcase == 'all'
+            job.setRunOnAllAgents(true)
+          else
+            job.setRunInstanceCount(val.to_s)
+          end
+        end
+
+        def timeout
+          if job.timeout == '0'
+            'never'
+          elsif job.timeout.present?
+            job.timeout.to_i
+          else
+            nil
+          end
+        end
+
+        def timeout=(val)
+          return if val.blank? || val.to_s.strip.downcase == 'null'
+
+          if val.to_s.strip.downcase == 'never'
+            job.timeout = '0'
+          elsif job.timeout = nil
+          else
+            job.timeout = val.to_s
+          end
+        end
+
+        def artifacts
+          job.artifactPlans
+        end
+
+        def artifacts=(value)
+          job.setArtifactPlans(com.thoughtworks.go.config.ArtifactPlans.new(value))
+        end
+
+        def environment_variables
+          job.getVariables
+        end
+
+        def environment_variables=(array_of_variables)
+          job.setVariables(EnvironmentVariablesConfig.new(array_of_variables))
+        end
+
+        def resources
+          job.resources.collect(&:name)
+        end
+
+        def resources=(values)
+          job.setResources(com.thoughtworks.go.config.Resources.new(values.map { |name| com.thoughtworks.go.config.Resource.new(name) }))
+        end
+
+        def tasks
+          job.getTasks
+        end
+
+        def tasks=(value)
+          job.setTasks(com.thoughtworks.go.config.Tasks.new(value.to_java(com.thoughtworks.go.domain.Task)))
+        end
+
+        def tabs
+          job.getTabs
+        end
+
+        def tabs=(value)
+          job.setTabs(com.thoughtworks.go.config.Tabs.new(value.to_java(com.thoughtworks.go.config.Tab)))
+        end
+
+        def properties
+          job.getProperties
+        end
+
+        def properties=(value)
+          job.setProperties(com.thoughtworks.go.config.ArtifactPropertiesGenerators.new(value))
+        end
+      end
+    end
+  end
+end

--- a/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/shared/stages/plugin_configuration_property_representer.rb
+++ b/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/shared/stages/plugin_configuration_property_representer.rb
@@ -1,5 +1,5 @@
 ##########################################################################
-# Copyright 2016 ThoughtWorks, Inc.
+# Copyright 2017 ThoughtWorks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/shared/stages/plugin_configuration_property_representer.rb
+++ b/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/shared/stages/plugin_configuration_property_representer.rb
@@ -1,0 +1,60 @@
+##########################################################################
+# Copyright 2016 ThoughtWorks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+
+module ApiV4
+  module Shared
+    module Stages
+      class PluginConfigurationPropertyRepresenter < BaseRepresenter
+        alias_method :configuration_property, :represented
+
+        error_representer(
+          {
+            'encryptedValue' => 'encrypted_value',
+            'configurationValue' => 'configuration_value',
+            'configurationKey' => 'configuration_key'
+          }
+        )
+        property :key, exec_context: :decorator
+        property :value, skip_nil: true, exec_context: :decorator
+        property :encrypted_value, skip_nil: true, exec_context: :decorator
+
+        def value
+          configuration_property.getValue unless configuration_property.isSecure
+        end
+
+        def encrypted_value
+          configuration_property.getEncryptedValue if configuration_property.isSecure
+        end
+
+        def value=(val)
+          configuration_property.setConfigurationValue(ConfigurationValue.new(val))
+        end
+
+        def encrypted_value=(encrypted_val)
+          configuration_property.setEncryptedConfigurationValue(EncryptedConfigurationValue.new(encrypted_val))
+        end
+
+        def key
+          configuration_property.getConfigurationKey.getName
+        end
+
+        def key=(value)
+          configuration_property.setConfigurationKey(ConfigurationKey.new(value))
+        end
+      end
+    end
+  end
+end

--- a/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/shared/stages/plugin_configuration_representer.rb
+++ b/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/shared/stages/plugin_configuration_representer.rb
@@ -1,5 +1,5 @@
 ##########################################################################
-# Copyright 2016 ThoughtWorks, Inc.
+# Copyright 2017 ThoughtWorks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/shared/stages/plugin_configuration_representer.rb
+++ b/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/shared/stages/plugin_configuration_representer.rb
@@ -1,0 +1,31 @@
+##########################################################################
+# Copyright 2016 ThoughtWorks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+
+module ApiV4
+  module Shared
+    module Stages
+      class PluginConfigurationRepresenter < BaseRepresenter
+        alias_method :plugin_configuration, :represented
+
+        error_representer
+
+        property :id
+        property :version
+
+      end
+    end
+  end
+end

--- a/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/shared/stages/property_config_representer.rb
+++ b/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/shared/stages/property_config_representer.rb
@@ -1,5 +1,5 @@
 ##########################################################################
-# Copyright 2016 ThoughtWorks, Inc.
+# Copyright 2017 ThoughtWorks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/shared/stages/property_config_representer.rb
+++ b/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/shared/stages/property_config_representer.rb
@@ -1,0 +1,32 @@
+##########################################################################
+# Copyright 2016 ThoughtWorks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+
+module ApiV4
+  module Shared
+    module Stages
+      class PropertyConfigRepresenter < BaseRepresenter
+        alias_method :property, :represented
+
+        error_representer({"name" => "name", "src" => "source", "xpath" => "xpath"})
+
+        property :name
+        property :src, as: :source
+        property :xpath
+
+      end
+    end
+  end
+end

--- a/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/shared/stages/stage_authorization_representer.rb
+++ b/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/shared/stages/stage_authorization_representer.rb
@@ -1,5 +1,5 @@
 ##########################################################################
-# Copyright 2016 ThoughtWorks, Inc.
+# Copyright 2017 ThoughtWorks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/shared/stages/stage_authorization_representer.rb
+++ b/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/shared/stages/stage_authorization_representer.rb
@@ -1,0 +1,33 @@
+##########################################################################
+# Copyright 2016 ThoughtWorks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+
+module ApiV4
+  module Shared
+    module Stages
+      class StageAuthorizationRepresenter < BaseRepresenter
+        alias_method :authorization, :represented
+
+        error_representer
+
+        collection :roles,
+                   getter: lambda { |roles| roles().map { |role| role.getName().to_s } },
+                   setter: lambda { |val, options| val.map { |role| self.add(com.thoughtworks.go.config.AdminRole.new(CaseInsensitiveString.new(role))) } }
+        collection :users, getter: lambda { |users| users().map { |user| user.getName().to_s } },
+                   setter: lambda { |val, options| val.each { |user| self.add(com.thoughtworks.go.config.AdminUser.new(CaseInsensitiveString.new(user))) } }
+      end
+    end
+  end
+end

--- a/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/shared/stages/stage_representer.rb
+++ b/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/shared/stages/stage_representer.rb
@@ -1,5 +1,5 @@
 ##########################################################################
-# Copyright 2016 ThoughtWorks, Inc.
+# Copyright 2017 ThoughtWorks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/shared/stages/stage_representer.rb
+++ b/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/shared/stages/stage_representer.rb
@@ -1,0 +1,80 @@
+##########################################################################
+# Copyright 2016 ThoughtWorks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+
+module ApiV4
+  module Shared
+    module Stages
+      class StageRepresenter < BaseRepresenter
+        alias_method :stage, :represented
+
+        error_representer
+
+        property :name, case_insensitive_string: true
+        property :fetch_materials
+        property :clean_working_dir, as: :clean_working_directory
+        property :artifact_cleanup_prohibited, as: :never_cleanup_artifacts
+        property :approval,
+                 decorator: Shared::Stages::ApprovalRepresenter,
+                 class: com.thoughtworks.go.config.Approval
+        collection :environment_variables,
+                   exec_context: :decorator,
+                   decorator: Shared::EnvironmentVariableRepresenter,
+                   expect_hash: true,
+                   class: com.thoughtworks.go.config.EnvironmentVariableConfig
+        collection :jobs,
+                   exec_context: :decorator,
+                   decorator: Shared::Stages::JobRepresenter,
+                   expect_hash: true,
+                   class: com.thoughtworks.go.config.JobConfig
+
+        delegate :name, :name=, to: :stage
+
+        # delegate :fetch_materials, :fetch_materials=, to: :stage
+
+        # delegate :clean_working_dir, :clean_working_dir=, to: :stage
+
+        # delegate :artifact_cleanup_prohibited, :artifact_cleanup_prohibited=, to: :stage
+
+
+        def jobs
+          stage.getJobs()
+        end
+
+        def jobs=(value)
+          stage.setJobs(JobConfigs.new(value.to_java(JobConfig)))
+        end
+
+        def environment_variables
+          stage.getVariables()
+        end
+
+        def environment_variables=(array_of_variables)
+          stage.setVariables(EnvironmentVariablesConfig.new(array_of_variables))
+        end
+
+        def errors_with_jobs_and_environment_variable_errors
+          stage.errors.addAll(jobs.errors)
+          stage.errors.addAll(environment_variables.errors)
+
+          errors_without_jobs_and_environment_variable_errors
+        end
+
+        alias_method_chain :errors, :jobs_and_environment_variable_errors
+
+      end
+    end
+  end
+end

--- a/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/shared/stages/tab_config_representer.rb
+++ b/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/shared/stages/tab_config_representer.rb
@@ -1,5 +1,5 @@
 ##########################################################################
-# Copyright 2016 ThoughtWorks, Inc.
+# Copyright 2017 ThoughtWorks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/shared/stages/tab_config_representer.rb
+++ b/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/shared/stages/tab_config_representer.rb
@@ -1,0 +1,31 @@
+##########################################################################
+# Copyright 2016 ThoughtWorks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+
+module ApiV4
+  module Shared
+    module Stages
+      class TabConfigRepresenter < BaseRepresenter
+        alias_method :tab, :represented
+
+        error_representer
+
+        property :name
+        property :path
+
+      end
+    end
+  end
+end

--- a/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/shared/stages/tasks/ant_task_representer.rb
+++ b/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/shared/stages/tasks/ant_task_representer.rb
@@ -1,5 +1,5 @@
 ##########################################################################
-# Copyright 2016 ThoughtWorks, Inc.
+# Copyright 2017 ThoughtWorks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/shared/stages/tasks/ant_task_representer.rb
+++ b/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/shared/stages/tasks/ant_task_representer.rb
@@ -1,0 +1,37 @@
+##########################################################################
+# Copyright 2016 ThoughtWorks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+
+module ApiV4
+  module Shared
+    module Stages
+      module Tasks
+        class AntTaskRepresenter < BaseTaskRepresenter
+          alias_method :task, :represented
+          ERROR_KEYS = {
+            'buildFile' => 'build_file',
+            'onCancelConfig' => 'on_cancel',
+            'runIf' => 'run_if'
+          }
+
+          property :working_directory, skip_parse: SkipParseOnBlank
+          property :build_file, skip_parse: SkipParseOnBlank
+          property :target, skip_parse: SkipParseOnBlank
+
+        end
+      end
+    end
+  end
+end

--- a/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/shared/stages/tasks/base_task_representer.rb
+++ b/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/shared/stages/tasks/base_task_representer.rb
@@ -1,5 +1,5 @@
 ##########################################################################
-# Copyright 2016 ThoughtWorks, Inc.
+# Copyright 2017 ThoughtWorks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/shared/stages/tasks/base_task_representer.rb
+++ b/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/shared/stages/tasks/base_task_representer.rb
@@ -1,0 +1,55 @@
+##########################################################################
+# Copyright 2016 ThoughtWorks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+
+module ApiV4
+  module Shared
+    module Stages
+      module Tasks
+        class BaseTaskRepresenter < BaseRepresenter
+          alias_method :task, :represented
+          collection :run_if, embedded: false, exec_context: :decorator, expect_hash: true
+          property :on_cancel_config,
+                   expect_hash: true,
+                   as: :on_cancel,
+                   exec_context: :decorator,
+                   decorator: OnCancelRepresenter,
+                   class: com.thoughtworks.go.config.OnCancelConfig
+
+
+          def run_if
+            task.getConditions().map { |condition| condition.to_s }
+          end
+
+          def run_if=(value)
+            run_if_conditions= RunIfConfigs.new
+            value.each { |condition|
+              run_if_conditions.add(RunIfConfig.new(condition))
+            }
+            task.setConditions(run_if_conditions)
+          end
+
+          def on_cancel_config
+            task.getOnCancelConfig() if task.hasCancelTask()
+          end
+
+          def on_cancel_config=(value)
+            @represented.setOnCancelConfig(value)
+          end
+        end
+      end
+    end
+  end
+end

--- a/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/shared/stages/tasks/exec_task_representer.rb
+++ b/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/shared/stages/tasks/exec_task_representer.rb
@@ -1,5 +1,5 @@
 ##########################################################################
-# Copyright 2016 ThoughtWorks, Inc.
+# Copyright 2017 ThoughtWorks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/shared/stages/tasks/exec_task_representer.rb
+++ b/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/shared/stages/tasks/exec_task_representer.rb
@@ -1,0 +1,57 @@
+##########################################################################
+# Copyright 2016 ThoughtWorks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+
+module ApiV4
+  module Shared
+    module Stages
+      module Tasks
+        class ExecTaskRepresenter < BaseTaskRepresenter
+          alias_method :task, :represented
+          ERROR_KEYS = {
+            "buildFile" => "build_file",
+            "onCancelConfig" => "on_cancel",
+            "runIf" => "run_if",
+            "nantPath" => "nant_path",
+            "argListString" => "arguments"
+          }
+
+          property :command
+          collection :arguments, skip_nil: true, exec_context: :decorator
+          property :args, skip_nil: true, exec_context: :decorator
+          property :working_directory
+
+          def arguments
+            return nil if task.getArgList().isEmpty()
+            task.getArgList().map { |arg| arg.getValue() }
+          end
+
+          def arguments=(value)
+            task.setArgsList(value)
+          end
+
+          def args
+            return nil if com.thoughtworks.go.util.StringUtil.isBlank(task.getArgs)
+            task.getArgs
+          end
+
+          def args=(value)
+            task.setArgs(value)
+          end
+        end
+      end
+    end
+  end
+end

--- a/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/shared/stages/tasks/fetch_task_representer.rb
+++ b/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/shared/stages/tasks/fetch_task_representer.rb
@@ -1,5 +1,5 @@
 ##########################################################################
-# Copyright 2016 ThoughtWorks, Inc.
+# Copyright 2017 ThoughtWorks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/shared/stages/tasks/fetch_task_representer.rb
+++ b/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/shared/stages/tasks/fetch_task_representer.rb
@@ -1,0 +1,62 @@
+##########################################################################
+# Copyright 2016 ThoughtWorks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+
+module ApiV4
+  module Shared
+    module Stages
+      module Tasks
+        class FetchTaskRepresenter < BaseTaskRepresenter
+          alias_method :fetch_task, :represented
+          ERROR_KEYS = {
+            'src' => 'source',
+            'dest' => 'destination',
+            'pipelineName' => 'pipeline',
+            'onCancelConfig' => 'on_cancel',
+            'runIf' => 'run_if'
+          }
+
+          property :pipeline_name, as: :pipeline, case_insensitive_string: true
+          property :stage, case_insensitive_string: true
+          property :job, case_insensitive_string: true
+          property :is_source_a_file, exec_context: :decorator
+          property :source, exec_context: :decorator
+          property :dest, as: :destination
+
+          def is_source_a_file
+            fetch_task.isSourceAFile
+          end
+
+          def is_source_a_file=(value)
+            @is_source_a_file = value
+          end
+
+          def source
+            return fetch_task.getRawSrcfile if fetch_task.isSourceAFile
+            fetch_task.getRawSrcdir
+          end
+
+          def source=(value)
+            if @is_source_a_file
+              fetch_task.setSrcfile(value)
+            else
+              fetch_task.setSrcdir(value)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/shared/stages/tasks/nant_task_representer.rb
+++ b/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/shared/stages/tasks/nant_task_representer.rb
@@ -1,5 +1,5 @@
 ##########################################################################
-# Copyright 2016 ThoughtWorks, Inc.
+# Copyright 2017 ThoughtWorks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/shared/stages/tasks/nant_task_representer.rb
+++ b/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/shared/stages/tasks/nant_task_representer.rb
@@ -1,0 +1,39 @@
+##########################################################################
+# Copyright 2016 ThoughtWorks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+
+module ApiV4
+  module Shared
+    module Stages
+      module Tasks
+        class NantTaskRepresenter < BaseTaskRepresenter
+          alias_method :task, :represented
+          ERROR_KEYS = {
+            'buildFile' => 'build_file',
+            'onCancelConfig' => 'on_cancel',
+            'runIf' => 'run_if',
+            'nantPath' => 'nant_path'
+          }
+
+          property :working_directory, skip_parse: SkipParseOnBlank
+          property :build_file, skip_parse: SkipParseOnBlank
+          property :target, skip_parse: SkipParseOnBlank
+          property :nant_path, skip_parse: SkipParseOnBlank
+
+        end
+      end
+    end
+  end
+end

--- a/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/shared/stages/tasks/on_cancel_representer.rb
+++ b/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/shared/stages/tasks/on_cancel_representer.rb
@@ -1,5 +1,5 @@
 ##########################################################################
-# Copyright 2016 ThoughtWorks, Inc.
+# Copyright 2017 ThoughtWorks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/shared/stages/tasks/on_cancel_representer.rb
+++ b/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/shared/stages/tasks/on_cancel_representer.rb
@@ -1,0 +1,37 @@
+##########################################################################
+# Copyright 2016 ThoughtWorks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+
+module ApiV4
+  module Shared
+    module Stages
+      module Tasks
+        class OnCancelRepresenter < BaseRepresenter
+          alias_method :on_cancel_config, :represented
+
+          def from_hash(hash, options={})
+            representer = TaskRepresenter.from_hash(hash, options)
+            com.thoughtworks.go.config.OnCancelConfig.new(representer.task)
+          end
+
+          def to_hash(*options)
+            return nil if on_cancel_config.getTask.getTaskType.eql?("killallchildprocess")
+            TaskRepresenter.new(on_cancel_config.getTask).to_hash
+          end
+        end
+      end
+    end
+  end
+end

--- a/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/shared/stages/tasks/pluggable_task_representer.rb
+++ b/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/shared/stages/tasks/pluggable_task_representer.rb
@@ -1,5 +1,5 @@
 ##########################################################################
-# Copyright 2016 ThoughtWorks, Inc.
+# Copyright 2017 ThoughtWorks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/shared/stages/tasks/pluggable_task_representer.rb
+++ b/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/shared/stages/tasks/pluggable_task_representer.rb
@@ -1,0 +1,38 @@
+##########################################################################
+# Copyright 2016 ThoughtWorks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+
+module ApiV4
+  module Shared
+    module Stages
+      module Tasks
+        class PluggableTaskRepresenter < BaseTaskRepresenter
+          alias_method :pluggable_task, :represented
+
+          property :plugin_configuration, decorator: Shared::Stages::PluginConfigurationRepresenter, class: com.thoughtworks.go.domain.config.PluginConfiguration
+          collection :configuration, exec_context: :decorator, decorator: PluginConfigurationPropertyRepresenter, class: com.thoughtworks.go.domain.config.ConfigurationProperty
+
+          def configuration
+            pluggable_task.getConfiguration()
+          end
+
+          def configuration=(value)
+            pluggable_task.addConfigurations(value)
+          end
+        end
+      end
+    end
+  end
+end

--- a/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/shared/stages/tasks/rake_task_representer.rb
+++ b/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/shared/stages/tasks/rake_task_representer.rb
@@ -1,5 +1,5 @@
 ##########################################################################
-# Copyright 2016 ThoughtWorks, Inc.
+# Copyright 2017 ThoughtWorks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/shared/stages/tasks/rake_task_representer.rb
+++ b/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/shared/stages/tasks/rake_task_representer.rb
@@ -1,0 +1,37 @@
+##########################################################################
+# Copyright 2016 ThoughtWorks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+
+module ApiV4
+  module Shared
+    module Stages
+      module Tasks
+        class RakeTaskRepresenter < BaseTaskRepresenter
+          alias_method :task, :represented
+          ERROR_KEYS = {
+            'buildFile' => 'build_file',
+            'onCancelConfig' => 'on_cancel',
+            'runIf' => 'run_if'
+          }
+
+          property :working_directory, skip_parse: SkipParseOnBlank
+          property :build_file, skip_parse: SkipParseOnBlank
+          property :target, skip_parse: SkipParseOnBlank
+
+        end
+      end
+    end
+  end
+end

--- a/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/shared/stages/tasks/task_representer.rb
+++ b/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/shared/stages/tasks/task_representer.rb
@@ -1,5 +1,5 @@
 ##########################################################################
-# Copyright 2016 ThoughtWorks, Inc.
+# Copyright 2017 ThoughtWorks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/shared/stages/tasks/task_representer.rb
+++ b/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/shared/stages/tasks/task_representer.rb
@@ -1,0 +1,94 @@
+##########################################################################
+# Copyright 2016 ThoughtWorks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+
+module ApiV4
+  module Shared
+    module Stages
+      module Tasks
+        class TaskRepresenter < BaseRepresenter
+
+          TASK_TYPE_TO_REPRESENTER_MAP = {
+            ExecTask::TYPE => ExecTaskRepresenter,
+            AntTask::TYPE => AntTaskRepresenter,
+            NantTask::TYPE => NantTaskRepresenter,
+            RakeTask::TYPE => RakeTaskRepresenter,
+            FetchTask::TYPE => FetchTaskRepresenter
+          }
+
+          TASK_TYPE_TO_TASK_CLASS_MAP = {
+            ExecTask::TYPE => ExecTask,
+            AntTask::TYPE => AntTask,
+            NantTask::TYPE => NantTask,
+            RakeTask::TYPE => RakeTask,
+            FetchTask::TYPE => FetchTask,
+            PluggableTask::TYPE => PluggableTask,
+          }
+
+          alias_method :task, :represented
+          property :type, exec_context: :decorator, skip_parse: true
+
+          error_representer do |task|
+            if task
+              unless task.instance_of? PluggableTask
+                TASK_TYPE_TO_REPRESENTER_MAP[task.getTaskType()]::ERROR_KEYS
+              end
+            end
+          end
+
+          nested :attributes,
+                 skip_parse: lambda { |fragment, options|
+                   !fragment.respond_to?(:has_key?) || fragment.empty?
+                 },
+                 decorator: lambda { |task, *|
+                   if task.instance_of? PluggableTask
+                     PluggableTaskRepresenter
+                   else
+                     TASK_TYPE_TO_REPRESENTER_MAP[task.getTaskType()]
+                   end
+                 }
+
+          def type
+            (task.instance_of? PluggableTask) ? 'pluggable_task' : task.getTaskType
+          end
+
+          def task_attributes
+            task
+          end
+
+          def task_attributes=(value)
+            @represented = value
+          end
+
+          class << self
+            def from_hash(hash, options={})
+              task_type = hash[:type]
+              if task_klass = task_class_for_type(task_type)
+                representer = TaskRepresenter.new(task_klass.new)
+                representer.from_hash(hash, options)
+                representer
+              end
+            end
+
+            def task_class_for_type(task_type)
+              TASK_TYPE_TO_TASK_CLASS_MAP[task_type] || (raise UnprocessableEntity, "Invalid task type '#{task_type}'. It has to be one of '#{TASK_TYPE_TO_TASK_CLASS_MAP.keys.join(', ')}.'")
+            end
+          end
+        end
+      end
+    end
+  end
+end
+

--- a/server/webapp/WEB-INF/rails.new/config/routes.rb
+++ b/server/webapp/WEB-INF/rails.new/config/routes.rb
@@ -296,6 +296,10 @@ Go::Application.routes.draw do
   scope :api, as: :apiv4, format: false do
     api_version(:module => 'ApiV4', header: {name: 'Accept', value: 'application/vnd.go.cd.v4+json'}) do
 
+      namespace :admin do
+        resources :pipelines, param: :pipeline_name, only: [:show, :update, :create, :destroy], constraints: {pipeline_name: PIPELINE_NAME_FORMAT}
+      end
+
       resources :agents, param: :uuid, only: [:show, :destroy], constraints: {uuid: ALLOW_DOTS} do
         patch :update, on: :member
       end

--- a/server/webapp/WEB-INF/rails.new/lib/java_imports.rb
+++ b/server/webapp/WEB-INF/rails.new/lib/java_imports.rb
@@ -253,4 +253,6 @@ module JavaImports
   java_import com.thoughtworks.go.config.EnvironmentVariableConfig unless defined? EnvironmentVariableConfig
   java_import com.thoughtworks.go.config.elastic.ElasticProfile unless defined? ElasticProfile
   java_import com.thoughtworks.go.server.ui.TemplatesViewModel unless defined? TemplatesViewModel
+  java_import com.thoughtworks.go.config.remote.RepoConfigOrigin unless defined? RepoConfigOrigin
+  java_import com.thoughtworks.go.config.remote.FileConfigOrigin unless defined? FileConfigOrigin
 end

--- a/server/webapp/WEB-INF/rails.new/spec/controllers/api_v4/admin/pipelines_controller_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/controllers/api_v4/admin/pipelines_controller_spec.rb
@@ -1,0 +1,718 @@
+##########################################################################
+# Copyright 2016 ThoughtWorks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+
+require 'spec_helper'
+
+describe ApiV4::Admin::PipelinesController do
+  include ApiHeaderSetupTeardown, ApiV4::ApiVersionHelper
+
+  before(:each) do
+    @pipeline_md5 = 'md5'
+    @group = "group"
+    @pipeline_config_service = double("pipeline_config_service")
+    controller.stub("pipeline_config_service").and_return(@pipeline_config_service)
+    @pipeline_pause_service = double("pipeline_pause_service")
+    controller.stub("pipeline_pause_service").and_return(@pipeline_pause_service)
+    @go_config_service = double("go_config_service")
+    controller.stub("go_config_service").and_return(@go_config_service)
+    @entity_hashing_service = double('entity_hashing_service')
+    controller.stub('entity_hashing_service').and_return(@entity_hashing_service)
+    go_config = BasicCruiseConfig.new
+    @repo = PackageRepositoryMother.create("repoid")
+    @scm= SCMMother.create("scm-id")
+    go_config.getPackageRepositories().add(@repo)
+    go_config.getSCMs().add(@scm)
+    @go_config_service.stub(:getCurrentConfig).and_return(go_config)
+    @go_config_service.stub(:checkConfigFileValid).and_return(GoConfigValidity::valid())
+    @go_config_service.stub(:findGroupNameByPipeline).and_return(@group)
+    @pipeline_groups = com.thoughtworks.go.domain.PipelineGroups.new
+    @go_config_service.stub(:groups).and_return(@pipeline_groups)
+    @pipeline_groups.stub(:hasGroup).and_return(true)
+    @entity_hashing_service.stub(:md5ForEntity).and_return(@pipeline_md5)
+    @latest_etag = "\"#{Digest::MD5.hexdigest(@pipeline_md5)}\""
+  end
+
+  after(:each) do
+    controller.send(:go_cache).remove("GO_ETAG_CACHE")
+  end
+
+  describe :security do
+    describe :show do
+      before(:each) do
+        @pipeline_config_service.stub(:getPipelineConfig).with(anything()).and_return(PipelineConfig.new)
+      end
+
+      it 'should allow anyone, with security disabled' do
+        disable_security
+        expect(controller).to allow_action(:get, :show)
+      end
+
+      it 'should disallow non-admin user, with security enabled' do
+        enable_security
+        login_as_pipeline_group_Non_Admin_user
+        @security_service.stub(:hasViewPermissionForPipeline).and_return(false)
+        expect(controller).to disallow_action(:get, :show, {:pipeline_name => "pipeline1"}).with(401, "You are not authorized to perform this action.")
+      end
+
+      it 'should allow admin users, with security enabled' do
+        login_as_pipeline_group_admin_user(@group)
+        expect(controller).to allow_action(:get, :show)
+      end
+    end
+
+    describe :update do
+      it 'should allow anyone, with security disabled' do
+        @pipeline_config_service.stub(:getPipelineConfig).with(anything()).and_return(PipelineConfig.new)
+        disable_security
+        controller.stub(:check_for_stale_request).and_return(nil)
+        controller.stub(:check_for_attempted_pipeline_rename).and_return(nil)
+        expect(controller).to allow_action(:put, :update)
+      end
+
+      it 'should disallow non-admin user, with security enabled' do
+        enable_security
+        login_as_pipeline_group_Non_Admin_user
+        expect(controller).to disallow_action(:put, :update, {:pipeline_name => "pipeline1"}).with(401, "You are not authorized to perform this action.")
+      end
+
+      it 'should allow admin users, with security enabled' do
+        @pipeline_config_service.stub(:getPipelineConfig).with(anything()).and_return(PipelineConfig.new)
+        login_as_pipeline_group_admin_user(@group)
+        controller.stub(:check_for_stale_request).and_return(nil)
+        controller.stub(:check_for_attempted_pipeline_rename).and_return(nil)
+        expect(controller).to allow_action(:put, :update)
+      end
+    end
+
+    describe :create do
+      before :each do
+        controller.stub(:check_if_pipeline_by_same_name_already_exists).and_return(nil)
+      end
+
+      it 'should allow anyone, with security disabled' do
+        disable_security
+        expect(controller).to allow_action(:post, :create, :group => @group)
+      end
+
+      it 'should disallow non-admin user, with security enabled' do
+        enable_security
+        login_as_pipeline_group_Non_Admin_user
+        expect(controller).to disallow_action(:post, :create, :pipeline => {:name => "pipeline1"}, :group => @group).with(401, "You are not authorized to perform this action.")
+      end
+
+      it 'should allow admin users, with security enabled' do
+        login_as_pipeline_group_admin_user(@group)
+        expect(controller).to allow_action(:post, :create, :group => @group)
+      end
+    end
+
+    describe :destroy do
+      before(:each) do
+        @pipeline_config_service.stub(:getPipelineConfig).with(anything()).and_return(PipelineConfig.new)
+      end
+      it 'should allow anyone, with security disabled' do
+        disable_security
+        expect(controller).to allow_action(:delete, :destroy)
+      end
+
+      it 'should disallow anonymous users, with security enabled' do
+        enable_security
+        login_as_anonymous
+        @security_service.stub(:isUserAdminOfGroup).and_return(false)
+        expect(controller).to disallow_action(:delete, :destroy, :pipeline_name => "pipeline1").with(401, 'You are not authorized to perform this action.')
+      end
+
+      it 'should disallow normal users, with security enabled' do
+        login_as_user
+        @security_service.stub(:isUserAdminOfGroup).and_return(false)
+        expect(controller).to disallow_action(:delete, :destroy, :pipeline_name => "pipeline1").with(401, 'You are not authorized to perform this action.')
+      end
+
+      it 'should allow admin users, with security enabled' do
+        login_as_admin
+        @security_service.stub(:isUserAdminOfGroup).and_return(true)
+        expect(controller).to allow_action(:delete, :destroy)
+      end
+    end
+  end
+
+  describe :action do
+    before :each do
+      enable_security
+      @security_service.stub(:hasViewPermissionForPipeline).and_return(true)
+      @pipeline_name = 'pipeline1'
+    end
+
+    describe :show do
+
+      it "should not show pipeline config for Non Admin users" do
+        login_as_pipeline_group_Non_Admin_user
+        pipeline = PipelineConfigMother.pipelineConfig(@pipeline_name)
+
+        get_with_api_header :show, :pipeline_name => @pipeline_name
+
+        expect(response.code).to eq("401")
+        json = JSON.parse(response.body).deep_symbolize_keys
+        expect(json[:message]).to eq("You are not authorized to perform this action.")
+      end
+
+      it 'should show pipeline config for an admin' do
+        login_as_pipeline_group_admin_user(@group)
+        pipeline = PipelineConfigMother.pipelineConfig(@pipeline_name)
+        pipeline_md5 = 'md5_for_pipeline_config'
+
+        @pipeline_config_service.should_receive(:getPipelineConfig).with(@pipeline_name).and_return(pipeline)
+        @entity_hashing_service.should_receive(:md5ForEntity).with(pipeline).and_return(pipeline_md5)
+
+        get_with_api_header :show, :pipeline_name => @pipeline_name
+
+        expect(response).to be_ok
+        expected_response = expected_response(pipeline, ApiV4::Admin::Pipelines::PipelineConfigRepresenter)
+        expect(actual_response).to eq(expected_response)
+        expect(response.headers['ETag']).to eq("\"#{Digest::MD5.hexdigest(pipeline_md5)}\"")
+      end
+
+      it "should return 304 for show pipeline config if etag sent in request is fresh" do
+        login_as_pipeline_group_admin_user(@group)
+        pipeline = PipelineConfigMother.pipelineConfig(@pipeline_name)
+        pipeline_md5 = 'md5_for_pipeline_config'
+
+        @pipeline_config_service.should_receive(:getPipelineConfig).with(@pipeline_name).and_return(pipeline)
+        @entity_hashing_service.should_receive(:md5ForEntity).with(pipeline).and_return(pipeline_md5)
+
+        controller.request.env['HTTP_IF_NONE_MATCH'] = Digest::MD5.hexdigest(pipeline_md5)
+
+        get_with_api_header :show, {:pipeline_name => @pipeline_name}
+
+        expect(response.code).to eq('304')
+        expect(response.body).to be_empty
+      end
+
+      it "should return 404 for show pipeline config if pipeline is not found" do
+        login_as_pipeline_group_admin_user(@group)
+        @pipeline_config_service.should_receive(:getPipelineConfig).with(@pipeline_name).and_return(nil)
+
+        get_with_api_header :show, :pipeline_name => @pipeline_name
+
+        expect(response.code).to eq("404")
+        json = JSON.parse(response.body).deep_symbolize_keys
+        expect(json[:message]).to eq("Either the resource you requested was not found, or you are not authorized to perform this action.")
+      end
+
+      it "should show pipeline config if etag sent in request is stale" do
+        login_as_pipeline_group_admin_user(@group)
+        pipeline = PipelineConfigMother.pipelineConfig(@pipeline_name)
+        pipeline_md5 = 'md5_for_pipeline_config'
+
+        @pipeline_config_service.should_receive(:getPipelineConfig).with(@pipeline_name).and_return(pipeline)
+        @entity_hashing_service.should_receive(:md5ForEntity).with(pipeline).and_return(pipeline_md5)
+
+        controller.request.env['HTTP_IF_NONE_MATCH'] = 'stale-etag'
+
+        get_with_api_header :show, {pipeline_name: @pipeline_name}
+        expect(response).to be_ok
+        expect(response.body).to_not be_empty
+      end
+
+      describe :route do
+        describe :with_header do
+          it 'should route to show action of pipelines controller for alphanumeric pipeline name' do
+            expect(:get => 'api/admin/pipelines/foo123').to route_to(action: 'show', controller: 'api_v4/admin/pipelines', pipeline_name: 'foo123')
+          end
+
+          it 'should route to show action of pipelines controller for pipeline name with dots' do
+            expect(:get => 'api/admin/pipelines/foo.123').to route_to(action: 'show', controller: 'api_v4/admin/pipelines', pipeline_name: 'foo.123')
+          end
+
+          it 'should route to show action of pipelines controller for pipeline name with hyphen' do
+            expect(:get => 'api/admin/pipelines/foo-123').to route_to(action: 'show', controller: 'api_v4/admin/pipelines', pipeline_name: 'foo-123')
+          end
+
+          it 'should route to show action of pipelines controller for pipeline name with underscore' do
+            expect(:get => 'api/admin/pipelines/foo_123').to route_to(action: 'show', controller: 'api_v4/admin/pipelines', pipeline_name: 'foo_123')
+          end
+
+          it 'should route to show action of pipelines controller for capitalized pipeline name' do
+            expect(:get => 'api/admin/pipelines/FOO').to route_to(action: 'show', controller: 'api_v4/admin/pipelines', pipeline_name: 'FOO')
+          end
+        end
+        describe :without_header do
+          before :each do
+            teardown_header
+          end
+          it 'should not route to show action of pipelines controller without header' do
+            expect(:get => 'api/admin/pipelines/foo').to_not route_to(action: 'show', controller: 'api_v4/admin/pipelines')
+            expect(:get => 'api/admin/pipelines/foo').to route_to(controller: 'application', action: 'unresolved', url: 'api/admin/pipelines/foo')
+          end
+        end
+      end
+    end
+
+    describe :update do
+      before(:each) do
+        login_as_pipeline_group_admin_user(@group)
+        @pipeline = PipelineConfigMother.pipelineConfig(@pipeline_name)
+        controller.send(:go_cache).put("GO_PIPELINE_CONFIGS_ETAGS_CACHE", @pipeline_name, "latest-etag")
+      end
+
+      it "should not update pipeline config if the user is not admin" do
+        @pipeline_groups.stub(:hasGroup).and_return(true)
+        @security_service.stub(:isUserAdminOfGroup).and_return(false)
+        put_with_api_header :update, pipeline_name: @pipeline_name, :pipeline => pipeline
+
+        # expect(response.code).to eq("401")
+
+        json = JSON.parse(response.body).deep_symbolize_keys
+        expect(json[:message]).to eq("You are not authorized to perform this action.")
+      end
+
+      it "should update pipeline config for an admin" do
+        @entity_hashing_service.should_receive(:md5ForEntity).with(@pipeline).and_return(@pipeline_md5)
+        @pipeline_config_service.should_receive(:getPipelineConfig).twice.with(@pipeline_name).and_return(@pipeline)
+        @pipeline_config_service.should_receive(:updatePipelineConfig).with(anything(), anything(), @pipeline_md5, anything())
+
+        controller.request.env['HTTP_IF_MATCH'] = "\"#{Digest::MD5.hexdigest(@pipeline_md5)}\""
+
+        put_with_api_header :update, pipeline_name: @pipeline_name, :pipeline => pipeline
+
+        expect(response).to be_ok
+        expect(actual_response).to eq(expected_response(@pipeline, ApiV4::Admin::Pipelines::PipelineConfigRepresenter))
+      end
+
+      it "should not update pipeline config if etag passed does not match the one on server" do
+        @pipeline_config_service.should_receive(:getPipelineConfig).with(@pipeline_name).and_return(@pipeline)
+        controller.request.env['HTTP_IF_MATCH'] = "old-etag"
+
+        put_with_api_header :update, pipeline_name: @pipeline_name, :pipeline => pipeline
+
+        expect(response.code).to eq("412")
+        expect(actual_response).to eq({:message => "Someone has modified the configuration for pipeline 'pipeline1'. Please update your copy of the config with the changes."})
+      end
+
+      it "should not update pipeline config if no etag is passed" do
+        @pipeline_config_service.should_receive(:getPipelineConfig).with(@pipeline_name).and_return(@pipeline)
+        put_with_api_header :update, pipeline_name: @pipeline_name, :pipeline => pipeline
+
+        expect(response.code).to eq("412")
+        expect(actual_response).to eq({:message => "Someone has modified the configuration for pipeline 'pipeline1'. Please update your copy of the config with the changes."})
+      end
+
+      it "should not update pipeline config when the pipeline is defined remotely" do
+        gitMaterial = GitMaterialConfig.new("https://github.com/config-repos/repo", "master")
+        origin = RepoConfigOrigin.new(ConfigRepoConfig.new(gitMaterial, "json-plugib"), "revision1")
+        @pipeline.setOrigin(origin)
+
+        @pipeline_config_service.should_receive(:getPipelineConfig).with(@pipeline_name).and_return(@pipeline)
+        put_with_api_header :update, pipeline_name: @pipeline_name, :pipeline => pipeline
+
+        expect(response.code).to eq("422")
+        expect(actual_response).to eq({:message => "Can not operate on pipeline 'pipeline1' as it is defined remotely in 'https://github.com/config-repos/repo at revision1'."})
+      end
+
+      it "should handle server validation errors" do
+        @pipeline_config_service.should_receive(:getPipelineConfig).with(@pipeline_name).and_return(@pipeline)
+        result = double('HttpLocalizedOperationResult')
+        result.stub(:isSuccessful).and_return(false)
+        result.stub(:message).with(anything()).and_return("message from server")
+        result.stub(:httpCode).and_return(406)
+        HttpLocalizedOperationResult.stub(:new).and_return(result)
+
+        @pipeline.addError("labelTemplate", PipelineConfig::LABEL_TEMPLATE_ERROR_MESSAGE)
+        controller.stub(:get_pipeline_from_request) do
+          controller.instance_variable_set(:@pipeline_config_from_request, @pipeline)
+        end
+        @pipeline_config_service.should_receive(:updatePipelineConfig).with(anything(), anything(), @pipeline_md5, result)
+        controller.request.env['HTTP_IF_MATCH'] = @latest_etag
+
+        put_with_api_header :update, pipeline_name: @pipeline_name, :pipeline => invalid_pipeline
+
+        expect(response.code).to eq("406")
+        json = JSON.parse(response.body).deep_symbolize_keys
+        expect(json[:message]).to eq("message from server")
+        data = json[:data]
+        data.delete(:_links)
+        data[:materials].first.deep_symbolize_keys!
+        data[:stages].first.deep_symbolize_keys!
+        expect(data).to eq(expected_data_with_validation_errors)
+      end
+
+      it "should not allow renaming a pipeline" do
+        @pipeline_config_service.should_receive(:getPipelineConfig).with(@pipeline_name).and_return(@pipeline)
+        controller.request.env['HTTP_IF_MATCH'] = @latest_etag
+
+        put_with_api_header :update, pipeline_name: @pipeline_name, :pipeline => pipeline("renamed_pipeline")
+
+        expect(response.code).to eq("406")
+        expect(actual_response).to eq({:message => "Renaming the pipeline resource is not supported by this API."})
+      end
+
+      it "should set package definition on to package material before save" do
+        @pipeline_config_service.should_receive(:getPipelineConfig).twice.with(@pipeline_name).and_return(@pipeline)
+        pipeline_being_saved = nil
+        allow(@pipeline_config_service).to receive(:updatePipelineConfig) do |user, pipeline, result|
+          pipeline_being_saved = pipeline
+        end
+        controller.request.env['HTTP_IF_MATCH'] = @latest_etag
+
+        put_with_api_header :update, pipeline_name: @pipeline_name, :pipeline => pipeline_with_pluggable_material("pipeline1", "package", "package-name")
+
+        expect(response).to be_ok
+        expect(pipeline_being_saved.materialConfigs().first().getPackageDefinition()).to eq(@repo.findPackage("package-name"))
+      end
+
+      it "should set scm config on to pluggable scm material before save" do
+        pipeline_being_saved = nil
+        @pipeline_config_service.should_receive(:getPipelineConfig).twice.with(@pipeline_name).and_return(@pipeline)
+
+        allow(@pipeline_config_service).to receive(:updatePipelineConfig) do |user, pipeline, result|
+          pipeline_being_saved = pipeline
+        end
+        controller.request.env['HTTP_IF_MATCH'] = @latest_etag
+
+        put_with_api_header :update, pipeline_name: @pipeline_name, :pipeline => pipeline_with_pluggable_material("pipeline1", "plugin", "scm-id")
+        expect(response).to be_ok
+        expect(pipeline_being_saved.materialConfigs().first().getSCMConfig()).to eq(@scm)
+      end
+
+      describe :route do
+        describe :with_header do
+          it 'should route to update action of pipelines controller for alphanumeric pipeline name' do
+            expect(:put => 'api/admin/pipelines/foo123').to route_to(action: 'update', controller: 'api_v4/admin/pipelines', pipeline_name: 'foo123')
+          end
+
+          it 'should route to update action of pipelines controller for pipeline name with dots' do
+            expect(:put => 'api/admin/pipelines/foo.123').to route_to(action: 'update', controller: 'api_v4/admin/pipelines', pipeline_name: 'foo.123')
+          end
+
+          it 'should route to update action of pipelines controller for pipeline name with hyphen' do
+            expect(:put => 'api/admin/pipelines/foo-123').to route_to(action: 'update', controller: 'api_v4/admin/pipelines', pipeline_name: 'foo-123')
+          end
+
+          it 'should route to update action of pipelines controller for pipeline name with underscore' do
+            expect(:put => 'api/admin/pipelines/foo_123').to route_to(action: 'update', controller: 'api_v4/admin/pipelines', pipeline_name: 'foo_123')
+          end
+
+          it 'should route to update action of pipelines controller for capitalized pipeline name' do
+            expect(:put => 'api/admin/pipelines/FOO').to route_to(action: 'update', controller: 'api_v4/admin/pipelines', pipeline_name: 'FOO')
+          end
+        end
+        describe :without_header do
+          before :each do
+            teardown_header
+          end
+
+          it 'should not route to update action of pipelines controller without header' do
+            expect(:put => 'api/admin/pipelines/foo').to_not route_to(action: 'update', controller: 'api_v4/admin/pipelines')
+            expect(:put => 'api/admin/pipelines/foo').to route_to(controller: 'application', action: 'unresolved', url: 'api/admin/pipelines/foo')
+          end
+        end
+      end
+    end
+
+    describe :create do
+      before(:each) do
+        @pipeline = PipelineConfigMother.pipelineConfig(@pipeline_name)
+      end
+
+      it "should not allow non admin users to create a new pipeline config" do
+        login_as_pipeline_group_Non_Admin_user
+        post_with_api_header :create, :pipeline => pipeline, :group => "new_grp"
+
+        expect(response.code).to eq("401")
+
+        json = JSON.parse(response.body).deep_symbolize_keys
+        expect(json[:message]).to eq("You are not authorized to perform this action.")
+      end
+
+      it "should not allow admin users of one pipeline group to create a new pipeline config in another group" do
+        enable_security
+        controller.stub(:current_user).and_return(@user = Username.new(CaseInsensitiveString.new(SecureRandom.hex)))
+        @pipeline_groups.stub(:hasGroup).and_return(true)
+        @security_service.stub(:isUserAdminOfGroup).and_return(false) # pipeline group admin
+        @security_service.stub(:isUserAdmin).and_return(false) # not an admin
+
+        post_with_api_header :create, :pipeline => pipeline, :group => "another_group"
+
+        expect(response.code).to eq("401")
+
+        json = JSON.parse(response.body).deep_symbolize_keys
+        expect(json[:message]).to eq("You are not authorized to perform this action.")
+      end
+
+      it "should allow admin users create a new pipeline config in any group" do
+        enable_security
+        controller.stub(:current_user).and_return(@user = Username.new(CaseInsensitiveString.new(SecureRandom.hex)))
+        @pipeline_groups.stub(:hasGroup).and_return(false)
+        @security_service.stub(:isUserAdmin).and_return(true)
+
+        @pipeline_config_service.should_receive(:getPipelineConfig).with(@pipeline_name).and_return(nil)
+        @pipeline_config_service.should_receive(:getPipelineConfig).with(@pipeline_name).and_return(@pipeline)
+        @pipeline_config_service.should_receive(:createPipelineConfig).with(anything(), anything(), anything(), "new_grp")
+        expect(@pipeline_pause_service).to receive(:pause).with("pipeline1", "Under construction", @user)
+
+        post_with_api_header :create, :pipeline => pipeline, :group => "new_grp"
+
+        expect(response).to be_ok
+        expect(actual_response).to eq(expected_response(@pipeline, ApiV4::Admin::Pipelines::PipelineConfigRepresenter))
+      end
+
+      it "should create a new pipeline config" do
+        login_as_pipeline_group_admin_user("new_grp")
+        @pipeline_config_service.should_receive(:getPipelineConfig).with(@pipeline_name).and_return(nil)
+        @pipeline_config_service.should_receive(:getPipelineConfig).with(@pipeline_name).and_return(@pipeline)
+        @pipeline_config_service.should_receive(:createPipelineConfig).with(anything(), anything(), anything(), "new_grp")
+        expect(@pipeline_pause_service).to receive(:pause).with("pipeline1", "Under construction", @user)
+
+        post_with_api_header :create, :pipeline => pipeline, :group => "new_grp"
+
+        expect(response).to be_ok
+        expect(actual_response).to eq(expected_response(@pipeline, ApiV4::Admin::Pipelines::PipelineConfigRepresenter))
+      end
+
+      it "should handle server validation errors" do
+        login_as_pipeline_group_admin_user("group")
+        @pipeline_config_service.should_receive(:getPipelineConfig).with(@pipeline_name).and_return(nil)
+        result = double('HttpLocalizedOperationResult')
+        result.stub(:isSuccessful).and_return(false)
+        result.stub(:message).with(anything()).and_return("message from server")
+        result.stub(:httpCode).and_return(406)
+        HttpLocalizedOperationResult.stub(:new).and_return(result)
+
+        @pipeline.addError("labelTemplate", PipelineConfig::LABEL_TEMPLATE_ERROR_MESSAGE)
+        controller.stub(:get_pipeline_from_request) do
+          controller.instance_variable_set(:@pipeline_config_from_request, @pipeline)
+        end
+
+        @pipeline_config_service.should_receive(:createPipelineConfig).with(anything(), anything(), result, "group")
+        controller.request.env['HTTP_IF_MATCH'] = "\"#{Digest::MD5.hexdigest("latest-etag")}\""
+
+        post_with_api_header :create, :pipeline => invalid_pipeline, :group => "group"
+
+        expect(response.code).to eq("406")
+        json = JSON.parse(response.body).deep_symbolize_keys
+        expect(json[:message]).to eq("message from server")
+        data = json[:data]
+        data.delete(:_links)
+        data[:materials].first.deep_symbolize_keys!
+        data[:stages].first.deep_symbolize_keys!
+        expect(data).to eq(expected_data_with_validation_errors)
+      end
+
+      it "should fail if a pipeline by same name already exists" do
+        login_as_pipeline_group_admin_user("new_grp")
+        @pipeline_config_service.should_receive(:getPipelineConfig).with(@pipeline_name).and_return(@pipeline)
+        @pipeline_config_service.should_not_receive(:createPipelineConfig).with(anything(), anything(), anything(), "new_grp")
+
+        post_with_api_header :create, :pipeline => pipeline, :group => "new_grp"
+
+        expect(response.code).to eq("422")
+
+        json = JSON.parse(response.body).deep_symbolize_keys
+        expect(json[:message]).to eq("Failed to add pipeline. The pipeline '#{@pipeline_name}' already exists.")
+      end
+
+      it "should fail if group is blank" do
+        @security_service.stub(:isUserAdminOfGroup).and_return(true)
+        @security_service.stub(:isUserAdmin).and_return(true)
+        @pipeline_config_service.stub(:getPipelineConfig).and_return(nil)
+
+        post_with_api_header :create, :pipeline => pipeline, :group => ""
+
+        expect(response.code).to eq("422")
+
+        json = JSON.parse(response.body).deep_symbolize_keys
+        expect(json[:message]).to eq("Pipeline group must be specified for creating a pipeline.")
+      end
+
+      it "should set package definition on to package material before save" do
+        login_as_pipeline_group_admin_user("group")
+        pipeline_being_saved = nil
+        @pipeline_config_service.should_receive(:getPipelineConfig).with(@pipeline_name).and_return(nil)
+        @pipeline_config_service.should_receive(:getPipelineConfig).with(@pipeline_name).and_return(@pipeline)
+        expect(@pipeline_pause_service).to receive(:pause).with("pipeline1", "Under construction", @user)
+
+        allow(@pipeline_config_service).to receive(:createPipelineConfig) do |user, pipeline, result, group|
+          pipeline_being_saved = pipeline
+        end
+
+        post_with_api_header :create, :pipeline => pipeline_with_pluggable_material("pipeline1", "package", "package-name"), :group => "group"
+        expect(response).to be_ok
+        expect(pipeline_being_saved.materialConfigs().first().getPackageDefinition()).to eq(@repo.findPackage("package-name"))
+      end
+
+      it "should set scm config on to pluggable scm material before save" do
+        login_as_pipeline_group_admin_user("group")
+        pipeline_being_saved = nil
+        @pipeline_config_service.should_receive(:getPipelineConfig).with(@pipeline_name).and_return(nil)
+        @pipeline_config_service.should_receive(:getPipelineConfig).with(@pipeline_name).and_return(@pipeline)
+        expect(@pipeline_pause_service).to receive(:pause).with("pipeline1", "Under construction", @user)
+
+        allow(@pipeline_config_service).to receive(:createPipelineConfig) do |user, pipeline, result, group|
+          pipeline_being_saved = pipeline
+        end
+
+        post_with_api_header :create, :pipeline => pipeline_with_pluggable_material("pipeline1", "plugin", "scm-id"), :group => "group"
+        expect(response).to be_ok
+        expect(pipeline_being_saved.materialConfigs().first().getSCMConfig()).to eq(@scm)
+      end
+
+      describe :route do
+        describe :with_header do
+
+          it 'should route to create action of pipelines controller' do
+            expect(:post => 'api/admin/pipelines/').to route_to(action: 'create', controller: 'api_v4/admin/pipelines')
+          end
+        end
+        describe :without_header do
+          before :each do
+            teardown_header
+          end
+
+          it 'should not route to create action of pipelines controller without header' do
+            expect(:post => 'api/admin/pipelines').to_not route_to(action: 'create', controller: 'api_v4/admin/pipelines')
+            expect(:post => 'api/admin/pipelines').to route_to(controller: 'application', action: 'unresolved', url: 'api/admin/pipelines')
+          end
+        end
+      end
+    end
+
+    describe :destroy do
+      before(:each) do
+        login_as_admin
+        @pipeline_name = "pipeline1"
+        @pipeline = PipelineConfigMother.pipelineConfig(@pipeline_name)
+        @pipeline_config_service.stub(:getPipelineConfig).with(@pipeline_name).and_return(@pipeline)
+        @security_service.stub(:isUserAdminOfGroup).and_return(true)
+      end
+
+      it "should delete pipeline config for an admin" do
+        @pipeline_config_service.should_receive(:deletePipelineConfig).with(anything(), @pipeline, an_instance_of(HttpLocalizedOperationResult)) do |username, pipeline, result|
+          result.setMessage(LocalizedMessage.string("RESOURCE_DELETE_SUCCESSFUL", 'pipeline', pipeline.name.to_s))
+        end
+
+        put_with_api_header :destroy, pipeline_name: @pipeline_name
+
+        expect(response.code).to eq("200")
+        expect(actual_response).to eq({:message => "The pipeline 'pipeline1' was deleted successfully."})
+      end
+
+
+      it "should render not found if the specified pipeline is absent" do
+        @pipeline_config_service.stub(:getPipelineConfig).with(@pipeline_name).and_return(nil)
+        put_with_api_header :destroy, pipeline_name: @pipeline_name
+
+        expect(response.code).to eq("404")
+        expect(actual_response).to eq({:message => "Either the resource you requested was not found, or you are not authorized to perform this action."})
+      end
+
+      it "should not delete pipeline config when the pipeline is defined remotely" do
+        gitMaterial = GitMaterialConfig.new("https://github.com/config-repos/repo", "master")
+        origin = RepoConfigOrigin.new(ConfigRepoConfig.new(gitMaterial, "json-plugib"), "revision1")
+        @pipeline.setOrigin(origin)
+
+        @pipeline_config_service.should_receive(:getPipelineConfig).with(@pipeline_name).and_return(@pipeline)
+        put_with_api_header :destroy, pipeline_name: @pipeline_name
+
+        expect(response.code).to eq("422")
+        expect(actual_response).to eq({:message => "Can not operate on pipeline 'pipeline1' as it is defined remotely in 'https://github.com/config-repos/repo at revision1'."})
+      end
+
+      describe :route do
+        describe :with_header do
+
+          it 'should route to destroy action of pipelines controller for alphanumeric pipeline name' do
+            expect(:delete => 'api/admin/pipelines/foo123').to route_to(action: 'destroy', controller: 'api_v4/admin/pipelines', pipeline_name: 'foo123')
+          end
+
+          it 'should route to destroy action of pipelines controller for pipeline name with dots' do
+            expect(:delete => 'api/admin/pipelines/foo.123').to route_to(action: 'destroy', controller: 'api_v4/admin/pipelines', pipeline_name: 'foo.123')
+          end
+
+          it 'should route to destroy action of pipelines controller for pipeline name with hyphen' do
+            expect(:delete => 'api/admin/pipelines/foo-123').to route_to(action: 'destroy', controller: 'api_v4/admin/pipelines', pipeline_name: 'foo-123')
+          end
+
+          it 'should route to destroy action of pipelines controller for pipeline name with underscore' do
+            expect(:delete => 'api/admin/pipelines/foo_123').to route_to(action: 'destroy', controller: 'api_v4/admin/pipelines', pipeline_name: 'foo_123')
+          end
+
+          it 'should route to destroy action of pipelines controller for capitalized pipeline name' do
+            expect(:delete => 'api/admin/pipelines/FOO').to route_to(action: 'destroy', controller: 'api_v4/admin/pipelines', pipeline_name: 'FOO')
+          end
+        end
+        describe :without_header do
+          before :each do
+            teardown_header
+          end
+          it 'should not route to destroy action of pipelines controller without header' do
+            expect(:delete => 'api/admin/pipelines/foo').to_not route_to(action: 'destroy', controller: 'api_v4/admin/pipelines')
+            expect(:delete => 'api/admin/pipelines/foo').to route_to(controller: 'application', action: 'unresolved', url: 'api/admin/pipelines/foo')
+          end
+        end
+      end
+    end
+
+    def expected_data_with_validation_errors
+      {
+        enable_pipeline_locking: false,
+        errors: {label_template: ["Invalid label. Label should be composed of alphanumeric text, it should contain the builder number as ${COUNT}, can contain a material revision as ${<material-name>} of ${<material-name>[:<number>]}, or use params as \#{<param-name>}."]},
+        label_template: "${COUNT}",
+        materials: [{type: "svn", attributes: {url: "http://some/svn/url", destination: "svnDir", filter: nil, invert_filter: false, name: "http___some_svn_url", auto_update: true, check_externals: false, username: nil}}],
+        name: "pipeline1",
+        environment_variables: [],
+        parameters: [],
+        stages: [{name: "mingle", fetch_materials: true, clean_working_directory: false, never_cleanup_artifacts: false, approval: {:type => "success", :authorization => {:roles => [], :users => []}}, environment_variables: [], jobs: []}],
+        template: nil,
+        timer: nil,
+        tracking_tool: nil
+      }
+    end
+
+    def invalid_pipeline
+      {
+        label_template: "${COUNT}",
+        enable_pipeline_locking: false,
+        name: "pipeline1",
+        materials: [
+          {
+            type: "SvnMaterial",
+            attributes: {
+              name: "http___some_svn_url",
+              auto_update: true,
+              url: "http://some/svn/url",
+              destination: "svnDir",
+              filter: nil,
+              check_externals: false,
+              username: nil,
+              password: nil
+            }
+          }
+        ],
+        stages: [{name: "mingle", fetch_materials: true, clean_working_directory: false, never_cleanup_artifacts: false, approval: {type: "success", authorization: {}}, jobs: []}],
+        errors: {label_template: ["Invalid label. Label should be composed of alphanumeric text, it should contain the builder number as ${COUNT}, can contain a material revision as ${<material-name>} of ${<material-name>[:<number>]}, or use params as \#{<param-name>}."]}
+      }
+    end
+
+    def pipeline (pipeline_name="pipeline1", material_type="hg", task_type="exec")
+      {label_template: "Jyoti-${COUNT}", enable_pipeline_locking: false, name: pipeline_name, template_name: nil, parameters: [], environment_variables: [], materials: [{type: material_type, attributes: {url: "../manual-testing/ant_hg/dummy", destination: "dest_dir", filter: {ignore: []}}, name: "dummyhg", auto_update: true}], stages: [{name: "up42_stage", fetch_materials: true, clean_working_directory: false, never_cleanup_artifacts: false, approval: {type: "success", authorization: {roles: [], users: []}}, environment_variables: [], jobs: [{name: "up42_job", run_on_all_agents: false, environment_variables: [], resources: [], tasks: [{type: task_type, attributes: {command: "ls", working_dir: nil}, run_if: []}], tabs: [], artifacts: [], properties: []}]}], mingle: {base_url: nil, project_identifier: nil, mql_grouping_conditions: nil}}
+    end
+
+    def pipeline_with_pluggable_material (pipeline_name, material_type, ref)
+      {label_template: "${COUNT}", name: pipeline_name, materials: [{type: material_type, attributes: {ref: ref}}], stages: [{name: "up42_stage", jobs: [{name: "up42_job", tasks: [{type: "exec", attributes: {command: "ls"}}]}]}]}
+    end
+  end
+
+end

--- a/server/webapp/WEB-INF/rails.new/spec/controllers/api_v4/admin/pipelines_controller_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/controllers/api_v4/admin/pipelines_controller_spec.rb
@@ -1,5 +1,5 @@
 ##########################################################################
-# Copyright 2016 ThoughtWorks, Inc.
+# Copyright 2017 ThoughtWorks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -265,6 +265,7 @@ describe ApiV4::Admin::PipelinesController do
       before(:each) do
         login_as_pipeline_group_admin_user(@group)
         @pipeline = PipelineConfigMother.pipelineConfig(@pipeline_name)
+        @pipeline.setOrigin(FileConfigOrigin.new)
         controller.send(:go_cache).put("GO_PIPELINE_CONFIGS_ETAGS_CACHE", @pipeline_name, "latest-etag")
       end
 
@@ -425,6 +426,7 @@ describe ApiV4::Admin::PipelinesController do
     describe :create do
       before(:each) do
         @pipeline = PipelineConfigMother.pipelineConfig(@pipeline_name)
+        @pipeline.setOrigin(FileConfigOrigin.new)
       end
 
       it "should not allow non admin users to create a new pipeline config" do
@@ -672,6 +674,10 @@ describe ApiV4::Admin::PipelinesController do
         label_template: "${COUNT}",
         materials: [{type: "svn", attributes: {url: "http://some/svn/url", destination: "svnDir", filter: nil, invert_filter: false, name: "http___some_svn_url", auto_update: true, check_externals: false, username: nil}}],
         name: "pipeline1",
+        origin: {
+          type: 'local',
+          file: 'cruise-config.xml'
+        },
         environment_variables: [],
         parameters: [],
         stages: [{name: "mingle", fetch_materials: true, clean_working_directory: false, never_cleanup_artifacts: false, approval: {:type => "success", :authorization => {:roles => [], :users => []}}, environment_variables: [], jobs: []}],

--- a/server/webapp/WEB-INF/rails.new/spec/presenters/api_v4/admin/pipelines/materials/filter_representer_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/presenters/api_v4/admin/pipelines/materials/filter_representer_spec.rb
@@ -1,5 +1,5 @@
 ##########################################################################
-# Copyright 2016 ThoughtWorks, Inc.
+# Copyright 2017 ThoughtWorks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/server/webapp/WEB-INF/rails.new/spec/presenters/api_v4/admin/pipelines/materials/filter_representer_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/presenters/api_v4/admin/pipelines/materials/filter_representer_spec.rb
@@ -1,0 +1,60 @@
+##########################################################################
+# Copyright 2016 ThoughtWorks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+
+require 'spec_helper'
+
+describe ApiV4::Admin::Pipelines::Materials::FilterRepresenter do
+  it 'should serialize' do
+    filter      = com.thoughtworks.go.config.materials.Filter.new(IgnoredFiles.new('**/*.html'), IgnoredFiles.new('**/foobar/'))
+    presenter   = ApiV4::Admin::Pipelines::Materials::FilterRepresenter.prepare(filter)
+    actual_json = presenter.to_hash(url_builder: UrlBuilder.new)
+    expect(actual_json).to eq(filter_hash)
+  end
+
+  it 'should deserialize' do
+    expected_filter = com.thoughtworks.go.config.materials.Filter.new(IgnoredFiles.new('**/*.html'), IgnoredFiles.new('**/foobar/'))
+    actual_filter   = com.thoughtworks.go.config.materials.Filter.new
+    presenter       = ApiV4::Admin::Pipelines::Materials::FilterRepresenter.prepare(actual_filter)
+    presenter.from_hash(filter_hash)
+    expect(actual_filter).to eq(expected_filter)
+  end
+  it 'should serialize to nil when ignored is empty' do
+    filter      = com.thoughtworks.go.config.materials.Filter.new()
+    presenter   = ApiV4::Admin::Pipelines::Materials::FilterRepresenter.prepare(filter)
+    actual_json = presenter.to_hash(url_builder: UrlBuilder.new)
+    expect(actual_json).to eq(nil)
+  end
+
+  it 'should deserialize to nil when no ignored files' do
+    actual_filter   = com.thoughtworks.go.config.materials.Filter.new
+    presenter       = ApiV4::Admin::Pipelines::Materials::FilterRepresenter.prepare(actual_filter)
+    presenter.from_hash(empty_filter_hash)
+    expect(actual_filter).to eq(com.thoughtworks.go.config.materials.Filter.new)
+  end
+
+  def filter_hash
+    {
+      ignore: %w(**/*.html **/foobar/)
+    }
+  end
+
+  def empty_filter_hash
+    {
+      ignore: []
+    }
+  end
+
+end

--- a/server/webapp/WEB-INF/rails.new/spec/presenters/api_v4/admin/pipelines/materials/material_representer_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/presenters/api_v4/admin/pipelines/materials/material_representer_spec.rb
@@ -1,5 +1,5 @@
 ##########################################################################
-# Copyright 2016 ThoughtWorks, Inc.
+# Copyright 2017 ThoughtWorks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/server/webapp/WEB-INF/rails.new/spec/presenters/api_v4/admin/pipelines/materials/material_representer_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/presenters/api_v4/admin/pipelines/materials/material_representer_spec.rb
@@ -1,0 +1,649 @@
+##########################################################################
+# Copyright 2016 ThoughtWorks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+
+require 'spec_helper'
+default_branch = 'master'
+describe ApiV4::Admin::Pipelines::Materials::MaterialRepresenter do
+  shared_examples_for 'materials' do
+
+    describe :serialize do
+      it 'should render material with hal representation' do
+        presenter = ApiV4::Admin::Pipelines::Materials::MaterialRepresenter.new(existing_material)
+        actual_json = presenter.to_hash(url_builder: UrlBuilder.new)
+        expected_material_hash = material_hash
+        expect(actual_json).to eq(expected_material_hash)
+      end
+
+      it "should render errors" do
+        presenter = ApiV4::Admin::Pipelines::Materials::MaterialRepresenter.new(existing_material_with_errors)
+        actual_json = presenter.to_hash(url_builder: UrlBuilder.new)
+        expected_material_hash = expected_material_hash_with_errors
+        expect(actual_json).to eq(expected_material_hash)
+      end
+    end
+
+    describe :deserialize do
+      it 'should convert hash to Material' do
+        new_material = material_type.new
+        presenter = ApiV4::Admin::Pipelines::Materials::MaterialRepresenter.new(new_material)
+        presenter.from_hash(ApiV4::Admin::Pipelines::Materials::MaterialRepresenter.new(existing_material).to_hash(url_builder: UrlBuilder.new))
+        expect(new_material.autoUpdate).to eq(existing_material.autoUpdate)
+        expect(new_material.name).to eq(existing_material.name)
+        expect(new_material).to eq(existing_material)
+      end
+    end
+
+  end
+
+  describe :git do
+    it_should_behave_like 'materials'
+
+    def existing_material
+      MaterialConfigsMother.gitMaterialConfig
+    end
+
+    def material_type
+      GitMaterialConfig
+    end
+
+    def existing_material_with_errors
+      git_config = GitMaterialConfig.new(UrlArgument.new(''), '', '', true, nil, false, '', CaseInsensitiveString.new('!nV@l!d'), false)
+      dup_git_material = GitMaterialConfig.new(UrlArgument.new(''), '', '', true, nil, false, '', CaseInsensitiveString.new('!nV@l!d'), false)
+      material_configs = MaterialConfigs.new(git_config);
+      material_configs.add(dup_git_material)
+
+      material_configs.validateTree(PipelineConfigSaveValidationContext.forChain(true, "group", BasicCruiseConfig.new(), PipelineConfig.new()))
+      material_configs.get(0)
+    end
+
+    it "should serialize material without name" do
+      presenter = ApiV4::Admin::Pipelines::Materials::MaterialRepresenter.prepare(GitMaterialConfig.new("http://user:password@funk.com/blank"))
+      actual_json = presenter.to_hash(url_builder: UrlBuilder.new)
+      expect(actual_json).to eq(git_material_basic_hash)
+    end
+
+
+    it "should serialize material with blank branch" do
+      presenter = ApiV4::Admin::Pipelines::Materials::MaterialRepresenter.prepare(GitMaterialConfig.new("http://user:password@funk.com/blank", ""))
+      actual_json = presenter.to_hash(url_builder: UrlBuilder.new)
+      expect(actual_json).to eq(git_material_basic_hash)
+    end
+
+    it "should deserialize material without name" do
+      presenter = ApiV4::Admin::Pipelines::Materials::MaterialRepresenter.new(GitMaterialConfig.new)
+      deserialized_object = presenter.from_hash({
+                                                  type: 'git',
+                                                  attributes: {
+                                                    url: "http://user:password@funk.com/blank",
+                                                    branch: "master",
+                                                    auto_update: true,
+                                                    name: nil
+                                                  }
+                                                })
+      expected = GitMaterialConfig.new("http://user:password@funk.com/blank")
+      expect(deserialized_object.autoUpdate).to eq(expected.autoUpdate)
+      expect(deserialized_object.name.to_s).to eq("")
+      expect(deserialized_object).to eq(expected)
+    end
+
+    it "should deserialize material without invert_filter" do
+      presenter = ApiV4::Admin::Pipelines::Materials::MaterialRepresenter.new(GitMaterialConfig.new)
+      deserialized_object = presenter.from_hash({
+                                                  type: 'git',
+                                                  attributes: {
+                                                    url: "http://user:password@funk.com/blank",
+                                                    branch: "master",
+                                                    auto_update: true,
+                                                    name: nil,
+                                                    invert_filter: nil
+                                                  }
+                                                })
+      expected = GitMaterialConfig.new("http://user:password@funk.com/blank")
+      expect(deserialized_object.invertFilter).to eq(expected.invertFilter)
+      expect(deserialized_object).to eq(expected)
+    end
+
+    it "should deserialize material with invert_filter" do
+      presenter = ApiV4::Admin::Pipelines::Materials::MaterialRepresenter.new(GitMaterialConfig.new)
+      deserialized_object = presenter.from_hash({
+                                                  type: 'git',
+                                                  attributes: {
+                                                    url: "http://user:password@funk.com/blank",
+                                                    branch: "master",
+                                                    auto_update: true,
+                                                    name: nil,
+                                                    invert_filter: true
+                                                  }
+                                                })
+      expected = GitMaterialConfig.new("http://user:password@funk.com/blank")
+      expected.setInvertFilter(true)
+      expect(deserialized_object.invertFilter).to eq(expected.invertFilter)
+      expect(deserialized_object).to eq(expected)
+    end
+
+    it "should deserialize material with blank branch" do
+      presenter = ApiV4::Admin::Pipelines::Materials::MaterialRepresenter.new(GitMaterialConfig.new)
+      deserialized_object = presenter.from_hash({
+                                                  type: 'git',
+                                                  attributes: {
+                                                    url: "http://user:password@funk.com/blank",
+                                                    branch: "",
+                                                    auto_update: true,
+                                                    name: nil
+                                                  }
+                                                })
+      expect(deserialized_object.branch.to_s).to eq(default_branch)
+    end
+
+    def material_hash
+      {
+        type: 'git',
+        attributes: {
+          url: "http://user:password@funk.com/blank",
+          destination: "destination",
+          filter: {
+            ignore: %w(**/*.html **/foobar/)
+          },
+          invert_filter: false,
+          branch: 'branch',
+          submodule_folder: 'sub_module_folder',
+          shallow_clone: true,
+          name: 'AwesomeGitMaterial',
+          auto_update: false
+        }
+      }
+    end
+
+    def git_material_basic_hash
+      {
+        type: 'git',
+        attributes: {
+          url: "http://user:password@funk.com/blank",
+          destination: nil,
+          filter: nil,
+          invert_filter: false,
+          name: nil,
+          auto_update: true,
+          branch: "master",
+          submodule_folder: nil,
+          shallow_clone: false
+        }
+      }
+    end
+
+    def expected_material_hash_with_errors
+      {
+        type: "git",
+        attributes: {
+          url: "",
+          destination: "",
+          filter: nil,
+          invert_filter: false,
+          name: "!nV@l!d",
+          auto_update: true,
+          branch: "master",
+          submodule_folder: "",
+          shallow_clone: false
+        },
+        errors: {
+          name: ["You have defined multiple materials called '!nV@l!d'. Material names are case-insensitive and must be unique. Note that for dependency materials the default materialName is the name of the upstream pipeline. You can override this by setting the materialName explicitly for the upstream pipeline.", "Invalid material name '!nV@l!d'. This must be alphanumeric and can contain underscores and periods (however, it cannot start with a period). The maximum allowed length is 255 characters."],
+          destination: ["Destination directory is required when specifying multiple scm materials"],
+          url: ["URL cannot be blank"]
+        }
+      }
+    end
+
+  end
+
+  describe :svn do
+    it_should_behave_like 'materials'
+
+    def existing_material
+      MaterialConfigsMother.svnMaterialConfig
+    end
+
+    def material_type
+      SvnMaterialConfig
+    end
+
+    def existing_material_with_errors
+      svn_config = SvnMaterialConfig.new(UrlArgument.new(''), '', '', true, GoCipher.new, true, nil, false, '', CaseInsensitiveString.new('!nV@l!d'))
+      material_configs = MaterialConfigs.new(svn_config);
+      material_configs.validateTree(PipelineConfigSaveValidationContext.forChain(true, "group", BasicCruiseConfig.new(), PipelineConfig.new()))
+      material_configs.get(0)
+    end
+
+    def material_hash
+      {
+        type: 'svn',
+        attributes: {
+          url: "url",
+          destination: "svnDir",
+          filter: {
+            ignore: [
+              "*.doc"
+            ]
+          },
+          invert_filter: false,
+          name: "svn-material",
+          auto_update: false,
+          check_externals: true,
+          username: "user",
+          encrypted_password: GoCipher.new.encrypt("pass")
+        }
+      }
+    end
+
+    def expected_material_hash_with_errors
+      {
+        type: "svn",
+        attributes: {
+          url: "",
+          destination: "",
+          filter: nil,
+          invert_filter: false,
+          name: "!nV@l!d",
+          auto_update: true,
+          check_externals: true,
+          username: ""
+        },
+        errors: {
+          name: ["Invalid material name '!nV@l!d'. This must be alphanumeric and can contain underscores and periods (however, it cannot start with a period). The maximum allowed length is 255 characters."],
+          url: ["URL cannot be blank"]
+        }
+      }
+    end
+  end
+
+  describe :hg do
+    it_should_behave_like 'materials'
+
+    def existing_material
+      MaterialConfigsMother.hgMaterialConfigFull
+    end
+
+    def material_type
+      HgMaterialConfig
+    end
+
+    def existing_material_with_errors
+      hg_config = HgMaterialConfig.new(com.thoughtworks.go.util.command::HgUrlArgument.new(''), true, nil, false, '/dest/', CaseInsensitiveString.new('!nV@l!d'))
+      material_configs = MaterialConfigs.new(hg_config);
+      material_configs.validateTree(PipelineConfigSaveValidationContext.forChain(true, "group", BasicCruiseConfig.new(), PipelineConfig.new()))
+      material_configs.get(0)
+    end
+
+    def material_hash
+      {
+        type: 'hg',
+        attributes: {
+          url: "http://user:pass@domain/path##branch",
+          destination: "dest-folder",
+          filter: {
+            ignore: %w(**/*.html **/foobar/)
+          },
+          invert_filter: false,
+          name: "hg-material",
+          auto_update: true
+        }
+      }
+    end
+
+    def expected_material_hash_with_errors
+      {
+        type: "hg",
+        attributes: {
+          url: "",
+          destination: "/dest/",
+          filter: nil,
+          invert_filter: false,
+          name: "!nV@l!d",
+          auto_update: true
+        },
+        errors: {
+          name: ["Invalid material name '!nV@l!d'. This must be alphanumeric and can contain underscores and periods (however, it cannot start with a period). The maximum allowed length is 255 characters."],
+          destination: ["Dest folder '/dest/' is not valid. It must be a sub-directory of the working folder."],
+          url: ["URL cannot be blank"]
+        }
+      }
+    end
+
+  end
+
+  describe :tfs do
+    it_should_behave_like 'materials'
+
+    def existing_material
+      MaterialConfigsMother.tfsMaterialConfig
+    end
+
+    def material_type
+      TfsMaterialConfig
+    end
+
+    def existing_material_with_errors
+      tfs_config = TfsMaterialConfig.new(GoCipher.new, com.thoughtworks.go.util.command::HgUrlArgument.new(''), '', '', '', '/some-path/')
+      material_configs = MaterialConfigs.new(tfs_config);
+      material_configs.validateTree(PipelineConfigSaveValidationContext.forChain(true, "group", BasicCruiseConfig.new(), PipelineConfig.new()))
+      material_configs.first()
+    end
+
+    def material_hash
+      {
+        type: 'tfs',
+        attributes: {
+          url: "http://10.4.4.101:8080/tfs/Sample",
+          destination: "dest-folder",
+          filter: {
+            ignore: %w(**/*.html **/foobar/)
+          },
+          invert_filter: false,
+          domain: "some_domain",
+          username: "loser",
+          encrypted_password: com.thoughtworks.go.security.GoCipher.new.encrypt("passwd"),
+          project_path: "walk_this_path",
+          name: "tfs-material",
+          auto_update: true
+        }
+      }
+    end
+
+    def expected_material_hash_with_errors
+      {
+        :type => "tfs",
+        :attributes => {
+          url: "",
+          destination: nil,
+          filter: nil,
+          invert_filter: false,
+          name: nil,
+          auto_update: true,
+          domain: "",
+          username: "",
+          project_path: "/some-path/"
+        },
+        errors:
+          {
+            url: ["URL cannot be blank"],
+            username: ["Username cannot be blank"]
+          }
+      }
+    end
+
+  end
+
+  describe :p4 do
+    it_should_behave_like 'materials'
+
+    def existing_material
+      MaterialConfigsMother.p4MaterialConfigFull
+    end
+
+    def material_type
+      P4MaterialConfig
+    end
+
+    def existing_material_with_errors
+      p4_config = P4MaterialConfig.new('', '', '', false, '', GoCipher.new, CaseInsensitiveString.new(''), true, nil, false, '/dest/')
+      material_configs = MaterialConfigs.new(p4_config);
+      material_configs.validateTree(PipelineConfigSaveValidationContext.forChain(true, "group", BasicCruiseConfig.new(), PipelineConfig.new()))
+      material_configs.first()
+    end
+
+    def material_hash
+      {
+        type: 'p4',
+        attributes: {
+          destination: "dest-folder",
+          filter: {
+            ignore: %w(**/*.html **/foobar/)
+          },
+          invert_filter: false,
+          port: "host:9876",
+          username: "user",
+          encrypted_password: GoCipher.new.encrypt("password"),
+          use_tickets: true,
+          view: "view",
+          name: "p4-material",
+          auto_update: true
+        }
+      }
+    end
+
+    def expected_material_hash_with_errors
+      {
+        type: "p4",
+        attributes: {
+          destination: "/dest/",
+          filter: nil,
+          invert_filter: false,
+          name: "",
+          auto_update: true,
+          port: "",
+          username: "",
+          use_tickets: false,
+          view: ""
+        },
+        errors: {
+          view: ["P4 view cannot be empty."],
+          destination: ["Dest folder '/dest/' is not valid. It must be a sub-directory of the working folder."],
+          port: ["P4 port cannot be empty."]
+        }
+      }
+    end
+
+  end
+
+  describe :dependency do
+    it_should_behave_like 'materials'
+
+    def existing_material
+      MaterialConfigsMother.dependencyMaterialConfig
+    end
+
+    def material_type
+      DependencyMaterialConfig
+    end
+
+    def existing_material_with_errors
+      dependency_config = DependencyMaterialConfig.new(CaseInsensitiveString.new(''), CaseInsensitiveString.new(''))
+      material_configs = MaterialConfigs.new(dependency_config);
+      pipeline = PipelineConfig.new(CaseInsensitiveString.new("p"), material_configs)
+      pipeline.setOrigins(com.thoughtworks.go.config.remote.FileConfigOrigin.new)
+      material_configs.validateTree(PipelineConfigSaveValidationContext.forChain(true, "group", BasicCruiseConfig.new(), pipeline))
+      material_configs.first()
+    end
+
+    def material_hash
+      {
+        type: 'dependency',
+        attributes: {
+          pipeline: "pipeline-name",
+          stage: "stage-name",
+          name: "pipeline-name",
+          auto_update: true
+        }
+      }
+    end
+
+    def expected_material_hash_with_errors
+      {
+        type: "dependency",
+        attributes:
+          {
+            pipeline: "",
+            stage: "",
+            name: "",
+            auto_update: true
+          },
+        errors: {
+          pipeline: ["Pipeline with name '' does not exist, it is defined as a dependency for pipeline 'p' (cruise-config.xml)"]
+        }
+      }
+    end
+
+  end
+
+  describe :package do
+    it "should represent a package material" do
+      presenter = ApiV4::Admin::Pipelines::Materials::MaterialRepresenter.prepare(MaterialConfigsMother.packageMaterialConfig())
+      actual_json = presenter.to_hash(url_builder: UrlBuilder.new)
+      expect(actual_json).to eq(package_material_hash)
+    end
+
+    it "should deserialize" do
+      presenter = ApiV4::Admin::Pipelines::Materials::MaterialRepresenter.prepare(PackageMaterialConfig.new)
+      go_config = BasicCruiseConfig.new
+      repo = PackageRepositoryMother.create("repoid")
+      go_config.getPackageRepositories().add(repo)
+
+      deserialized_object = presenter.from_hash(package_material_hash("package-name"), {go_config: go_config})
+      expect(deserialized_object.getPackageId).to eq("package-name")
+      expect(deserialized_object.getPackageDefinition).to eq(repo.findPackage("package-name"))
+    end
+
+    it "should set packageId during deserialisation if matching package definition is not present in config" do
+      presenter = ApiV4::Admin::Pipelines::Materials::MaterialRepresenter.prepare(PackageMaterialConfig.new)
+      go_config = BasicCruiseConfig.new
+
+      deserialized_object = presenter.from_hash(package_material_hash("package-name"), {go_config: go_config})
+      expect(deserialized_object.getPackageId).to eq("package-name")
+      expect(deserialized_object.getPackageDefinition).to eq(nil)
+    end
+
+    it "should render errors" do
+      package_config = PackageMaterialConfig.new(CaseInsensitiveString.new(''), '', nil)
+      material_configs = MaterialConfigs.new(package_config);
+      material_configs.validateTree(PipelineConfigSaveValidationContext.forChain(true, "group", BasicCruiseConfig.new(), PipelineConfig.new()))
+
+      presenter = ApiV4::Admin::Pipelines::Materials::MaterialRepresenter.new(material_configs.first())
+      actual_json = presenter.to_hash(url_builder: UrlBuilder.new)
+      expected_material_hash = expected_material_hash_with_errors
+      expect(actual_json).to eq(expected_material_hash)
+    end
+
+
+    def package_material_hash(package_id = "p-id")
+      {
+        type: 'package',
+        attributes: {
+          ref: package_id
+        }
+      }
+    end
+
+    def expected_material_hash_with_errors
+      {
+        type: "package",
+        attributes: {
+          ref: ""
+        },
+        errors: {
+          ref: ["Please select a repository and package"]
+        }
+      }
+    end
+  end
+
+  describe :pluggable do
+    before :each do
+      @go_config = BasicCruiseConfig.new
+
+    end
+    it "should represent a pluggable scm material" do
+      pluggable_scm_material = MaterialConfigsMother.pluggableSCMMaterialConfig()
+      presenter = ApiV4::Admin::Pipelines::Materials::MaterialRepresenter.prepare(pluggable_scm_material)
+      actual_json = presenter.to_hash(url_builder: UrlBuilder.new)
+      expect(actual_json).to eq(pluggable_scm_material_hash)
+    end
+
+    it "should deserialize" do
+      scm= SCMMother.create("scm-id")
+      @go_config.getSCMs().add(scm)
+
+      presenter = ApiV4::Admin::Pipelines::Materials::MaterialRepresenter.new(PluggableSCMMaterialConfig.new)
+      deserialized_object = presenter.from_hash(pluggable_scm_material_hash, {go_config: @go_config})
+      expect(deserialized_object.getScmId).to eq("scm-id")
+      expect(deserialized_object.getSCMConfig).to eq(scm)
+      expect(deserialized_object.getFolder).to eq("des-folder")
+      expect(deserialized_object.filter.getStringForDisplay).to eq("**/*.html,**/foobar/")
+    end
+
+    it "should set scmId during deserialisation if matching package definition is not present in config" do
+      presenter = ApiV4::Admin::Pipelines::Materials::MaterialRepresenter.new(PluggableSCMMaterialConfig.new)
+
+      deserialized_object = presenter.from_hash(pluggable_scm_material_hash, {go_config: @go_config})
+      expect(deserialized_object.getScmId).to eq("scm-id")
+      expect(deserialized_object.getSCMConfig).to eq(nil)
+    end
+
+    it "should deserialize pluggable scm material with nulls" do
+      presenter = ApiV4::Admin::Pipelines::Materials::MaterialRepresenter.new(PluggableSCMMaterialConfig.new)
+      deserialized_object = presenter.from_hash({
+                                                  type: "plugin",
+                                                  attributes: {
+                                                    ref: "23a28171-3d5a-4912-9f36-d4e1536281b0",
+                                                    filter: nil,
+                                                    destination: nil
+                                                  }
+                                                }, {go_config: @go_config})
+      expect(deserialized_object.name.to_s).to eq("")
+      expect(deserialized_object.getScmId).to eq("23a28171-3d5a-4912-9f36-d4e1536281b0")
+      expect(deserialized_object.getFolder).to be_nil
+      expect(ReflectionUtil::getField(deserialized_object, "filter")).to be_nil
+    end
+
+    it "should render errors" do
+      pluggable_scm_material = PluggableSCMMaterialConfig.new(CaseInsensitiveString.new(''), nil, '/dest', nil)
+      material_configs = MaterialConfigs.new(pluggable_scm_material);
+      material_configs.validateTree(PipelineConfigSaveValidationContext.forChain(true, "group", BasicCruiseConfig.new(), PipelineConfig.new()))
+
+      presenter = ApiV4::Admin::Pipelines::Materials::MaterialRepresenter.new(material_configs.first())
+      actual_json = presenter.to_hash(url_builder: UrlBuilder.new)
+      expected_material_hash = expected_material_hash_with_errors
+      expect(actual_json).to eq(expected_material_hash)
+    end
+
+    def pluggable_scm_material_hash
+      {
+        type: 'plugin',
+        attributes: {
+          ref: "scm-id",
+          filter: {
+            ignore: %w(**/*.html **/foobar/)
+          },
+          destination: 'des-folder'
+        }
+      }
+    end
+
+    def expected_material_hash_with_errors
+      {
+        type: "plugin",
+        attributes: {
+          ref: nil,
+          filter: nil,
+          destination: "/dest"
+        },
+        errors: {
+          destination: ["Dest folder '/dest' is not valid. It must be a sub-directory of the working folder."],
+          ref: ["Please select a SCM"]
+        }
+      }
+    end
+
+  end
+end

--- a/server/webapp/WEB-INF/rails.new/spec/presenters/api_v4/admin/pipelines/param_representer_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/presenters/api_v4/admin/pipelines/param_representer_spec.rb
@@ -1,5 +1,5 @@
 ##########################################################################
-# Copyright 2016 ThoughtWorks, Inc.
+# Copyright 2017 ThoughtWorks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/server/webapp/WEB-INF/rails.new/spec/presenters/api_v4/admin/pipelines/param_representer_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/presenters/api_v4/admin/pipelines/param_representer_spec.rb
@@ -1,0 +1,40 @@
+##########################################################################
+# Copyright 2016 ThoughtWorks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+
+require 'spec_helper'
+
+describe ApiV4::Admin::Pipelines::ParamRepresenter do
+
+  it "should represent a param" do
+    presenter = ApiV4::Admin::Pipelines::ParamRepresenter.new(ParamConfig.new("command","echo"))
+    actual_json = presenter.to_hash(url_builder: UrlBuilder.new)
+    expect(actual_json).to eq(param_hash)
+  end
+
+  it "should deserialize" do
+    presenter = ApiV4::Admin::Pipelines::ParamRepresenter.new(ParamConfig.new)
+    deserialized_object = presenter.from_hash(param_hash)
+    expected = ParamConfig.new("command","echo")
+    expect(deserialized_object).to eq(expected)
+  end
+
+  def param_hash
+    {
+      name:         "command",
+      value:       "echo"
+    }
+  end
+end

--- a/server/webapp/WEB-INF/rails.new/spec/presenters/api_v4/admin/pipelines/pipeline_config_representer_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/presenters/api_v4/admin/pipelines/pipeline_config_representer_spec.rb
@@ -1,0 +1,448 @@
+##########################################################################
+# Copyright 2016 ThoughtWorks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+
+require 'spec_helper'
+
+describe ApiV4::Admin::Pipelines::PipelineConfigRepresenter do
+
+  describe :serialize do
+    it 'renders a pipeline with hal representation' do
+      presenter   = ApiV4::Admin::Pipelines::PipelineConfigRepresenter.new(get_pipeline_config)
+      actual_json = presenter.to_hash(url_builder: UrlBuilder.new)
+
+      expect(actual_json).to have_links(:self, :find, :doc)
+      expect(actual_json).to have_link(:self).with_url('http://test.host/api/admin/pipelines/wunderbar')
+      expect(actual_json).to have_link(:find).with_url('http://test.host/api/admin/pipelines/:pipeline_name')
+      expect(actual_json).to have_link(:doc).with_url('https://api.gocd.io/#pipeline-config')
+      actual_json.delete(:_links)
+      expect(actual_json).to eq(pipeline_hash)
+    end
+
+    it 'should serialize pipeline with template' do
+      pipeline_config = pipeline_with_template
+      presenter       = ApiV4::Admin::Pipelines::PipelineConfigRepresenter.new(pipeline_config)
+      actual_json     = presenter.to_hash(url_builder: UrlBuilder.new)
+      actual_json.delete(:_links)
+      expect(actual_json).to eq(pipeline_with_template_hash)
+    end
+
+    def pipeline_with_template_hash
+      {
+        label_template:          "${COUNT}",
+        enable_pipeline_locking: false,
+        name:                    "wunderbar",
+        template:                "template1",
+        parameters:              [],
+        environment_variables:   [],
+        materials:               pipeline_with_template.materialConfigs().collect { |j| ApiV4::Admin::Pipelines::Materials::MaterialRepresenter.new(j).to_hash(url_builder: UrlBuilder.new) },
+        stages:                  nil,
+        tracking_tool:           nil,
+        timer:                   nil
+      }
+    end
+
+    def pipeline_with_template
+      pipeline_config = PipelineConfig.new(CaseInsensitiveString.new("wunderbar"), "${COUNT}", nil, true, MaterialConfigsMother.defaultMaterialConfigs(), ArrayList.new)
+      pipeline_config.setTemplateName(CaseInsensitiveString.new("template1"))
+      pipeline_config
+    end
+  end
+
+  describe :deserialise do
+
+    it "should convert from minimal json to PipelineConfig" do
+      pipeline_config = PipelineConfig.new
+
+      ApiV4::Admin::Pipelines::PipelineConfigRepresenter.new(pipeline_config).from_hash(pipeline_hash_basic)
+      expect(pipeline_config.name.to_s).to eq("wunderbar")
+      expect(pipeline_config.getParams.isEmpty).to eq(true)
+      expect(pipeline_config.variables.isEmpty).to eq(true)
+    end
+
+    def pipeline_hash_basic
+      {
+        label_template:          "foo-1.0.${COUNT}-${svn}",
+        enable_pipeline_locking: false,
+        name:                    "wunderbar",
+        materials:               [
+                                   {
+                                     type:        "svn",
+                                     attributes:  {
+                                       url:             "http://some/svn/url",
+                                       destination:     "svnDir",
+                                       check_externals: false
+                                     },
+                                     name:        "http___some_svn_url",
+                                     auto_update: true
+                                   }
+                                 ],
+        stages:                  [
+                                   {
+                                     name:                    "stage1",
+                                     fetch_materials:         true,
+                                     clean_working_directory: false,
+                                     never_cleanup_artifacts: false,
+                                     jobs:                    [
+                                                                {
+                                                                  name:  "defaultJob",
+                                                                  tasks: [
+                                                                           {
+                                                                             type:       "ant",
+                                                                             attributes: {
+                                                                               working_dir: "working-directory",
+                                                                               build_file:  "build-file",
+                                                                               target:      "target"
+                                                                             }
+                                                                           }
+                                                                         ]
+                                                                }
+                                                              ]
+                                   }
+                                 ],
+      }
+    end
+
+    describe :pipeline_with_environment_varibales do
+      it "should convert pipeline hash with environment variables  to PipelineConfig" do
+        pipeline_config = PipelineConfig.new
+
+        environment_variables=[
+          {
+            name:   'plain',
+            value:  'plain',
+            secure: false
+          },
+          {
+            secure:          true,
+            name:            'secure',
+            encrypted_value: GoCipher.new.encrypt('confidential')
+          }
+        ]
+
+        ApiV4::Admin::Pipelines::PipelineConfigRepresenter.new(pipeline_config).from_hash({ environment_variables: environment_variables })
+        expect(pipeline_config.variables.map(&:name)).to eq(['plain', 'secure'])
+      end
+
+      it "should convert pipeline hash with empty environment variables  to PipelineConfig" do
+        pipeline_config = PipelineConfig.new
+        ApiV4::Admin::Pipelines::PipelineConfigRepresenter.new(pipeline_config).from_hash({ environment_variables: [] })
+        expect(pipeline_config.variables.size).to eq(0)
+      end
+    end
+
+    describe :pipeline_with_parmas do
+      it "should convert pipeline hash with parameters to PipelineConfig" do
+        pipeline_config = PipelineConfig.new
+        ApiV4::Admin::Pipelines::PipelineConfigRepresenter.new(pipeline_config).from_hash({ parameters: [{
+                                                                                                 name:  "command",
+                                                                                                 value: "echo"
+                                                                                               }, {
+                                                                                                 name:  "command",
+                                                                                                 value: "sleep"
+                                                                                               }] })
+        expect(pipeline_config.getParams.map(&:name)).to eq(['command', 'command'])
+      end
+
+      it "should convert pipeline hash with empty parmas to PipelineConfig" do
+        pipeline_config = PipelineConfig.new
+        ApiV4::Admin::Pipelines::PipelineConfigRepresenter.new(pipeline_config).from_hash({ parameters: nil })
+        expect(pipeline_config.getParams.size).to eq(0)
+      end
+    end
+
+    describe :pipeline_with_materials do
+      it "should convert pipeline hash with materials  to PipelineConfig" do
+        pipeline_config = PipelineConfig.new
+        ApiV4::Admin::Pipelines::PipelineConfigRepresenter.new(pipeline_config).from_hash({ materials: [
+                                                                                               {
+                                                                                                 type:       'git',
+                                                                                                 attributes: {
+                                                                                                   url:              "http://user:password@funk.com/blank",
+                                                                                                   destination:      "destination",
+                                                                                                   filter:           {
+                                                                                                     ignore: %w(**/*.html **/foobar/)
+                                                                                                   },
+                                                                                                   branch:           'branch',
+                                                                                                   submodule_folder: 'sub_module_folder',
+                                                                                                   name:             'AwesomeGitMaterial',
+                                                                                                   auto_update:      false
+                                                                                                 }
+                                                                                               },
+                                                                                               {
+                                                                                                 type:       'svn',
+                                                                                                 attributes: {
+                                                                                                   url:                "url",
+                                                                                                   destination:        "svnDir",
+                                                                                                   filter:             {
+                                                                                                     ignore: [
+                                                                                                               "*.doc"
+                                                                                                             ]
+                                                                                                   },
+                                                                                                   name:               "svn-material",
+                                                                                                   auto_update:        false,
+                                                                                                   check_externals:    true,
+                                                                                                   username:           "user",
+                                                                                                   encrypted_password: GoCipher.new.encrypt("pass")
+                                                                                                 }
+                                                                                               }
+                                                                                             ] })
+        expect(pipeline_config.materialConfigs.map(&:type)).to eq(['GitMaterial', 'SvnMaterial'])
+      end
+
+      it "should convert pipeline hash with empty materials  to PipelineConfig" do
+        pipeline_config = PipelineConfig.new
+        ApiV4::Admin::Pipelines::PipelineConfigRepresenter.new(pipeline_config).from_hash({ materials: nil })
+        expect(pipeline_config.materialConfigs.size).to eq(0)
+      end
+
+      it 'should raise exception when passing invalid material type' do
+        hash             = pipeline_hash_basic
+        hash[:materials] = [{ type: 'bad-material-type', attributes: { foo: 'bar' } }]
+        pipeline_config  = PipelineConfig.new
+
+        expect do
+          ApiV4::Admin::Pipelines::PipelineConfigRepresenter.new(pipeline_config).from_hash(hash)
+        end.to raise_error(ApiV4::UnprocessableEntity, /Invalid material type 'bad-material-type'. It has to be one of/)
+      end
+
+    end
+
+    describe :pipeline_with_stages do
+      it "should convert pipeline hash with stages  to PipelineConfig" do
+        pipeline_config = PipelineConfig.new
+        stages          =[{
+                            name:                    'stage1',
+                            fetch_materials:         true,
+                            clean_working_directory: false,
+                            never_cleanup_artifacts: false,
+                            approval:                {
+                              type:          'success',
+                              authorization: {
+                                roles: [],
+                                users: []
+                              }
+                            },
+                            environment_variables:   [
+                                                       {
+                                                         name:   'plain',
+                                                         value:  'plain',
+                                                         secure: false
+                                                       },
+                                                       {
+                                                         secure:          true,
+                                                         name:            'secure',
+                                                         encrypted_value: GoCipher.new.encrypt('confidential')
+                                                       }
+                                                     ],
+                            jobs:                    [{
+                                                        name:               'some-job',
+                                                        run_on_all_agents:  true,
+                                                        run_instance_count: '3',
+                                                        timeout:            '100',
+                                                      }]
+                          }]
+
+        ApiV4::Admin::Pipelines::PipelineConfigRepresenter.new(pipeline_config).from_hash({ stages: stages })
+        expect(pipeline_config.getStages.map(&:name).map(&:to_s)).to eq(['stage1'])
+        expect(pipeline_config.getStages.first.getJobs.map(&:name).map(&:to_s)).to eq(['some-job'])
+        expect(pipeline_config.getStages.first.variables.map(&:name)).to eq(['plain', 'secure'])
+
+      end
+
+      it "should convert pipeline hash with empty stages  to PipelineConfig" do
+        pipeline_config = PipelineConfig.new
+        ApiV4::Admin::Pipelines::PipelineConfigRepresenter.new(pipeline_config).from_hash({ stages: nil })
+        expect(pipeline_config.getStages.size).to eq(0)
+      end
+
+    end
+
+    describe :pipeline_with_tracking_tool do
+      it "should convert pipeline hash with tracking tool  to PipelineConfig" do
+        pipeline_config = PipelineConfig.new
+        ApiV4::Admin::Pipelines::PipelineConfigRepresenter.new(pipeline_config).from_hash({ tracking_tool: {
+          type:       "generic",
+          attributes: {
+            url_pattern:  "link",
+            regex: "regex"
+          }
+        } })
+        expect(pipeline_config.getTrackingTool.getLink).to eq('link')
+        expect(pipeline_config.getTrackingTool.getRegex).to eq('regex')
+      end
+
+      it 'should raise exception when passing invalid tracking tool type' do
+        pipeline_config = PipelineConfig.new
+        expect do
+          ApiV4::Admin::Pipelines::PipelineConfigRepresenter.new(pipeline_config).from_hash({ tracking_tool: {
+            type:       "bad-tracking-tool",
+            attributes: {
+              link:  "link",
+              regex: "regex"
+            }
+          } })
+        end.to raise_error(ApiV4::UnprocessableEntity, /Invalid Tracking Tool type 'bad-tracking-tool'. It has to be one of/)
+      end
+
+
+    end
+
+    it "should convert from full blown document to PipelineConfig" do
+      pipeline_config = PipelineConfig.new
+
+      ApiV4::Admin::Pipelines::PipelineConfigRepresenter.new(pipeline_config).from_hash(pipeline_hash)
+      expect(pipeline_config).to eq(get_pipeline_config)
+    end
+
+
+    describe :pipeline_with_timer do
+      it "should convert pipeline hash with timer  to PipelineConfig" do
+        pipeline_config = PipelineConfig.new
+        ApiV4::Admin::Pipelines::PipelineConfigRepresenter.new(pipeline_config).from_hash({ timer: { spec: "0 0 22 ? * MON-FRI", only_on_changes: true } })
+        expect(pipeline_config.getTimer.getOnlyOnChanges).to eq(true)
+      end
+    end
+
+    it "should render errors" do
+      pipeline_config = PipelineConfig.new(CaseInsensitiveString.new("wunderbar"), "", "", true, nil, ArrayList.new)
+      config          = BasicCruiseConfig.new(BasicPipelineConfigs.new("grp", Authorization.new, pipeline_config))
+
+      pipeline_config.validateTree(com.thoughtworks.go.config.PipelineConfigSaveValidationContext::forChain(true, "grp", config, pipeline_config))
+
+      presenter   = ApiV4::Admin::Pipelines::PipelineConfigRepresenter.new(pipeline_config)
+      actual_json = presenter.to_hash(url_builder: UrlBuilder.new)
+      actual_json.delete(:_links)
+      expect(actual_json).to eq(expected_hash_with_errors)
+    end
+
+    it "should render errors on nested objects" do
+      pipeline_config = get_invalid_pipeline_config
+      config          = BasicCruiseConfig.new(BasicPipelineConfigs.new("grp", Authorization.new, get_pipeline_config))
+      pipeline_config.validateTree(com.thoughtworks.go.config.PipelineConfigSaveValidationContext::forChain(true, "grp", config, pipeline_config))
+
+      presenter   = ApiV4::Admin::Pipelines::PipelineConfigRepresenter.new(pipeline_config)
+      actual_json = presenter.to_hash(url_builder: UrlBuilder.new)
+      actual_json.delete(:_links)
+      expect(actual_json).to eq(expected_hash_with_nested_errors)
+    end
+
+  end
+
+  def expected_hash_with_errors
+    {
+      label_template:          "",
+      enable_pipeline_locking: false,
+      name:                    "wunderbar",
+      template:                nil,
+      parameters:              [],
+      environment_variables:   [],
+      materials:               [],
+      stages:                  nil,
+      tracking_tool:           nil,
+      timer:                   { spec: "", only_on_changes: true, errors: { spec: ["Invalid cron syntax: Unexpected end of expression."] } },
+      errors:                  {
+        materials:     ["A pipeline must have at least one material"],
+        pipeline:      ["Pipeline 'wunderbar' does not have any stages configured. A pipeline must have at least one stage."],
+        label_template: ["Label cannot be blank. Label should be composed of alphanumeric text, it should contain the builder number as ${COUNT}, can contain a material revision as ${<material-name>} of ${<material-name>[:<number>]}, or use params as \#{<param-name>}."]
+      }
+    }
+  end
+
+  def expected_hash_with_nested_errors
+    {
+      label_template:          "foo-1.0.${COUNT}-${svn}",
+      enable_pipeline_locking: false,
+      name:                    "wunderbar",
+      template:                nil,
+      parameters:              [
+                                 {
+                                   name:   nil, value: "echo",
+                                   errors: {
+                                     name: [
+                                             "Parameter cannot have an empty name for pipeline 'wunderbar'.",
+                                             "Invalid parameter name 'null'. This must be alphanumeric and can contain underscores and periods (however, it cannot start with a period). The maximum allowed length is 255 characters."
+                                           ]
+                                   }
+                                 }
+                               ],
+      environment_variables:   [{:secure=>false, :name=>"", :value=>"", :errors=>{:name=>["Environment Variable cannot have an empty name for pipeline 'wunderbar'."]}}],
+      materials:               [
+                                 {
+                                   type: "svn", attributes: { url: "http://some/svn/url", destination: "svnDir", filter: nil, invert_filter:false, name: "http___some_svn_url", auto_update: true, check_externals: false, username: nil }
+                                 },
+                                 {
+                                   type:   "git", attributes: { url: nil, destination: nil, filter: nil, invert_filter:false, name: nil, auto_update: true, branch: "master", submodule_folder: nil, shallow_clone: false },
+                                   errors: { destination: ["Destination directory is required when specifying multiple scm materials"], url: ["URL cannot be blank"] }
+                                 }
+                               ],
+      stages:                  [{ name: "stage1", fetch_materials: true, clean_working_directory: false, never_cleanup_artifacts: false, approval: { type: "success", authorization: { :roles => [], :users => [] } }, environment_variables: [], jobs: [] }],
+      timer:                   { spec: "0 0 22 ? * MON-FRI", only_on_changes: true },
+      tracking_tool:           {
+        type:   "generic", attributes: { url_pattern: "", regex: "" },
+        errors: {
+          regex: ["Regex should be populated"],
+          url_pattern:  ["Link should be populated", "Link must be a URL containing '${ID}'. Go will replace the string '${ID}' with the first matched group from the regex at run-time."]
+
+        }
+      },
+      errors:                  {
+        label_template: ["You have defined a label template in pipeline wunderbar that refers to a material called svn, but no material with this name is defined."]
+      }
+    }
+  end
+
+  def get_invalid_pipeline_config
+    material_configs = MaterialConfigsMother.defaultMaterialConfigs()
+    git              = GitMaterialConfig.new
+    git.setFolder(nil);
+    material_configs.add(git);
+
+    pipeline_config = PipelineConfig.new(CaseInsensitiveString.new("wunderbar"), "foo-1.0.${COUNT}-${svn}", "0 0 22 ? * MON-FRI", true, material_configs, ArrayList.new)
+    pipeline_config.addParam(ParamConfig.new(nil, "echo"))
+    pipeline_config.addEnvironmentVariable('','')
+    pipeline_config.add(StageConfigMother.stageConfig("stage1"))
+    pipeline_config.setTrackingTool(TrackingTool.new())
+    pipeline_config
+  end
+
+
+  def get_pipeline_config
+    material_configs = MaterialConfigsMother.defaultMaterialConfigs()
+    pipeline_config  = PipelineConfig.new(CaseInsensitiveString.new("wunderbar"), "foo-1.0.${COUNT}-${svn}", "0 0 22 ? * MON-FRI", true, material_configs, ArrayList.new)
+    pipeline_config.setVariables(EnvironmentVariablesConfigMother.environmentVariables())
+    pipeline_config.addParam(ParamConfig.new("COMMAND", "echo"))
+    pipeline_config.addParam(ParamConfig.new("WORKING_DIR", "/repo/branch"))
+    pipeline_config.add(StageConfigMother.stageConfigWithEnvironmentVariable("stage1"))
+    pipeline_config.setTrackingTool(TrackingTool.new("link", "regex"))
+    pipeline_config
+  end
+
+  def pipeline_hash
+    {
+      label_template:          "foo-1.0.${COUNT}-${svn}",
+      enable_pipeline_locking: false,
+      name:                    "wunderbar",
+      template:                nil,
+      parameters:              get_pipeline_config.getParams().collect { |j| ApiV4::Admin::Pipelines::ParamRepresenter.new(j).to_hash(url_builder: UrlBuilder.new) },
+      environment_variables:   get_pipeline_config.variables().collect { |j| ApiV4::Shared::EnvironmentVariableRepresenter.new(j).to_hash(url_builder: UrlBuilder.new) },
+      materials:               get_pipeline_config.materialConfigs().collect { |j| ApiV4::Admin::Pipelines::Materials::MaterialRepresenter.new(j).to_hash(url_builder: UrlBuilder.new) },
+      stages:                  get_pipeline_config.getStages().collect { |j| ApiV4::Shared::Stages::StageRepresenter.new(j).to_hash(url_builder: UrlBuilder.new) },
+      tracking_tool:           ApiV4::Admin::Pipelines::TrackingTool::TrackingToolRepresenter.new(get_pipeline_config.getTrackingTool).to_hash(url_builder: UrlBuilder.new),
+      timer:                   ApiV4::Admin::Pipelines::TimerRepresenter.new(get_pipeline_config.getTimer).to_hash(url_builder: UrlBuilder.new)
+    }
+  end
+
+end

--- a/server/webapp/WEB-INF/rails.new/spec/presenters/api_v4/admin/pipelines/pipeline_config_representer_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/presenters/api_v4/admin/pipelines/pipeline_config_representer_spec.rb
@@ -1,5 +1,5 @@
 ##########################################################################
-# Copyright 2016 ThoughtWorks, Inc.
+# Copyright 2017 ThoughtWorks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@ describe ApiV4::Admin::Pipelines::PipelineConfigRepresenter do
 
   describe :serialize do
     it 'renders a pipeline with hal representation' do
-      presenter   = ApiV4::Admin::Pipelines::PipelineConfigRepresenter.new(get_pipeline_config)
+      presenter = ApiV4::Admin::Pipelines::PipelineConfigRepresenter.new(get_pipeline_config)
       actual_json = presenter.to_hash(url_builder: UrlBuilder.new)
 
       expect(actual_json).to have_links(:self, :find, :doc)
@@ -33,185 +33,190 @@ describe ApiV4::Admin::Pipelines::PipelineConfigRepresenter do
 
     it 'should serialize pipeline with template' do
       pipeline_config = pipeline_with_template
-      presenter       = ApiV4::Admin::Pipelines::PipelineConfigRepresenter.new(pipeline_config)
-      actual_json     = presenter.to_hash(url_builder: UrlBuilder.new)
+      presenter = ApiV4::Admin::Pipelines::PipelineConfigRepresenter.new(pipeline_config)
+      actual_json = presenter.to_hash(url_builder: UrlBuilder.new)
       actual_json.delete(:_links)
       expect(actual_json).to eq(pipeline_with_template_hash)
     end
 
     def pipeline_with_template_hash
       {
-        label_template:          "${COUNT}",
+        label_template: '${COUNT}',
         enable_pipeline_locking: false,
-        name:                    "wunderbar",
-        template:                "template1",
-        parameters:              [],
-        environment_variables:   [],
-        materials:               pipeline_with_template.materialConfigs().collect { |j| ApiV4::Admin::Pipelines::Materials::MaterialRepresenter.new(j).to_hash(url_builder: UrlBuilder.new) },
-        stages:                  nil,
-        tracking_tool:           nil,
-        timer:                   nil
+        name: 'wunderbar',
+        origin: {
+          type: 'local',
+          file: 'cruise-config.xml'
+        },
+        template: 'template1',
+        parameters: [],
+        environment_variables: [],
+        materials: pipeline_with_template.materialConfigs().collect { |j| ApiV4::Admin::Pipelines::Materials::MaterialRepresenter.new(j).to_hash(url_builder: UrlBuilder.new) },
+        stages: nil,
+        tracking_tool: nil,
+        timer: nil
       }
     end
 
     def pipeline_with_template
-      pipeline_config = PipelineConfig.new(CaseInsensitiveString.new("wunderbar"), "${COUNT}", nil, true, MaterialConfigsMother.defaultMaterialConfigs(), ArrayList.new)
-      pipeline_config.setTemplateName(CaseInsensitiveString.new("template1"))
+      pipeline_config = PipelineConfig.new(CaseInsensitiveString.new('wunderbar'), '${COUNT}', nil, true, MaterialConfigsMother.defaultMaterialConfigs(), ArrayList.new)
+      pipeline_config.setOrigin(FileConfigOrigin.new)
+      pipeline_config.setTemplateName(CaseInsensitiveString.new('template1'))
       pipeline_config
     end
   end
 
   describe :deserialise do
 
-    it "should convert from minimal json to PipelineConfig" do
+    it 'should convert from minimal json to PipelineConfig' do
       pipeline_config = PipelineConfig.new
 
       ApiV4::Admin::Pipelines::PipelineConfigRepresenter.new(pipeline_config).from_hash(pipeline_hash_basic)
-      expect(pipeline_config.name.to_s).to eq("wunderbar")
+      expect(pipeline_config.name.to_s).to eq('wunderbar')
       expect(pipeline_config.getParams.isEmpty).to eq(true)
       expect(pipeline_config.variables.isEmpty).to eq(true)
     end
 
     def pipeline_hash_basic
       {
-        label_template:          "foo-1.0.${COUNT}-${svn}",
+        label_template: 'foo-1.0.${COUNT}-${svn}',
         enable_pipeline_locking: false,
-        name:                    "wunderbar",
-        materials:               [
-                                   {
-                                     type:        "svn",
-                                     attributes:  {
-                                       url:             "http://some/svn/url",
-                                       destination:     "svnDir",
-                                       check_externals: false
-                                     },
-                                     name:        "http___some_svn_url",
-                                     auto_update: true
-                                   }
-                                 ],
-        stages:                  [
-                                   {
-                                     name:                    "stage1",
-                                     fetch_materials:         true,
-                                     clean_working_directory: false,
-                                     never_cleanup_artifacts: false,
-                                     jobs:                    [
-                                                                {
-                                                                  name:  "defaultJob",
-                                                                  tasks: [
-                                                                           {
-                                                                             type:       "ant",
-                                                                             attributes: {
-                                                                               working_dir: "working-directory",
-                                                                               build_file:  "build-file",
-                                                                               target:      "target"
-                                                                             }
-                                                                           }
-                                                                         ]
-                                                                }
-                                                              ]
-                                   }
-                                 ],
+        name: 'wunderbar',
+        materials: [
+          {
+            type: 'svn',
+            attributes: {
+              url: 'http://some/svn/url',
+              destination: 'svnDir',
+              check_externals: false
+            },
+            name: 'http___some_svn_url',
+            auto_update: true
+          }
+        ],
+        stages: [
+          {
+            name: 'stage1',
+            fetch_materials: true,
+            clean_working_directory: false,
+            never_cleanup_artifacts: false,
+            jobs: [
+              {
+                name: 'defaultJob',
+                tasks: [
+                  {
+                    type: 'ant',
+                    attributes: {
+                      working_dir: 'working-directory',
+                      build_file: 'build-file',
+                      target: 'target'
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        ],
       }
     end
 
     describe :pipeline_with_environment_varibales do
-      it "should convert pipeline hash with environment variables  to PipelineConfig" do
+      it 'should convert pipeline hash with environment variables  to PipelineConfig' do
         pipeline_config = PipelineConfig.new
 
         environment_variables=[
           {
-            name:   'plain',
-            value:  'plain',
+            name: 'plain',
+            value: 'plain',
             secure: false
           },
           {
-            secure:          true,
-            name:            'secure',
+            secure: true,
+            name: 'secure',
             encrypted_value: GoCipher.new.encrypt('confidential')
           }
         ]
 
-        ApiV4::Admin::Pipelines::PipelineConfigRepresenter.new(pipeline_config).from_hash({ environment_variables: environment_variables })
+        ApiV4::Admin::Pipelines::PipelineConfigRepresenter.new(pipeline_config).from_hash({environment_variables: environment_variables})
         expect(pipeline_config.variables.map(&:name)).to eq(['plain', 'secure'])
       end
 
-      it "should convert pipeline hash with empty environment variables  to PipelineConfig" do
+      it 'should convert pipeline hash with empty environment variables  to PipelineConfig' do
         pipeline_config = PipelineConfig.new
-        ApiV4::Admin::Pipelines::PipelineConfigRepresenter.new(pipeline_config).from_hash({ environment_variables: [] })
+        ApiV4::Admin::Pipelines::PipelineConfigRepresenter.new(pipeline_config).from_hash({environment_variables: []})
         expect(pipeline_config.variables.size).to eq(0)
       end
     end
 
     describe :pipeline_with_parmas do
-      it "should convert pipeline hash with parameters to PipelineConfig" do
+      it 'should convert pipeline hash with parameters to PipelineConfig' do
         pipeline_config = PipelineConfig.new
-        ApiV4::Admin::Pipelines::PipelineConfigRepresenter.new(pipeline_config).from_hash({ parameters: [{
-                                                                                                 name:  "command",
-                                                                                                 value: "echo"
-                                                                                               }, {
-                                                                                                 name:  "command",
-                                                                                                 value: "sleep"
-                                                                                               }] })
+        ApiV4::Admin::Pipelines::PipelineConfigRepresenter.new(pipeline_config).from_hash({parameters: [{
+                                                                                                          name: 'command',
+                                                                                                          value: 'echo'
+                                                                                                        }, {
+                                                                                                          name: 'command',
+                                                                                                          value: 'sleep'
+                                                                                                        }]})
         expect(pipeline_config.getParams.map(&:name)).to eq(['command', 'command'])
       end
 
-      it "should convert pipeline hash with empty parmas to PipelineConfig" do
+      it 'should convert pipeline hash with empty parmas to PipelineConfig' do
         pipeline_config = PipelineConfig.new
-        ApiV4::Admin::Pipelines::PipelineConfigRepresenter.new(pipeline_config).from_hash({ parameters: nil })
+        ApiV4::Admin::Pipelines::PipelineConfigRepresenter.new(pipeline_config).from_hash({parameters: nil})
         expect(pipeline_config.getParams.size).to eq(0)
       end
     end
 
     describe :pipeline_with_materials do
-      it "should convert pipeline hash with materials  to PipelineConfig" do
+      it 'should convert pipeline hash with materials  to PipelineConfig' do
         pipeline_config = PipelineConfig.new
-        ApiV4::Admin::Pipelines::PipelineConfigRepresenter.new(pipeline_config).from_hash({ materials: [
-                                                                                               {
-                                                                                                 type:       'git',
-                                                                                                 attributes: {
-                                                                                                   url:              "http://user:password@funk.com/blank",
-                                                                                                   destination:      "destination",
-                                                                                                   filter:           {
-                                                                                                     ignore: %w(**/*.html **/foobar/)
-                                                                                                   },
-                                                                                                   branch:           'branch',
-                                                                                                   submodule_folder: 'sub_module_folder',
-                                                                                                   name:             'AwesomeGitMaterial',
-                                                                                                   auto_update:      false
-                                                                                                 }
-                                                                                               },
-                                                                                               {
-                                                                                                 type:       'svn',
-                                                                                                 attributes: {
-                                                                                                   url:                "url",
-                                                                                                   destination:        "svnDir",
-                                                                                                   filter:             {
-                                                                                                     ignore: [
-                                                                                                               "*.doc"
-                                                                                                             ]
-                                                                                                   },
-                                                                                                   name:               "svn-material",
-                                                                                                   auto_update:        false,
-                                                                                                   check_externals:    true,
-                                                                                                   username:           "user",
-                                                                                                   encrypted_password: GoCipher.new.encrypt("pass")
-                                                                                                 }
-                                                                                               }
-                                                                                             ] })
+        ApiV4::Admin::Pipelines::PipelineConfigRepresenter.new(pipeline_config).from_hash({materials: [
+          {
+            type: 'git',
+            attributes: {
+              url: 'http://user:password@funk.com/blank',
+              destination: 'destination',
+              filter: {
+                ignore: %w(**/*.html **/foobar/)
+              },
+              branch: 'branch',
+              submodule_folder: 'sub_module_folder',
+              name: 'AwesomeGitMaterial',
+              auto_update: false
+            }
+          },
+          {
+            type: 'svn',
+            attributes: {
+              url: 'url',
+              destination: 'svnDir',
+              filter: {
+                ignore: [
+                  '*.doc'
+                ]
+              },
+              name: 'svn-material',
+              auto_update: false,
+              check_externals: true,
+              username: 'user',
+              encrypted_password: GoCipher.new.encrypt('pass')
+            }
+          }
+        ]})
         expect(pipeline_config.materialConfigs.map(&:type)).to eq(['GitMaterial', 'SvnMaterial'])
       end
 
-      it "should convert pipeline hash with empty materials  to PipelineConfig" do
+      it 'should convert pipeline hash with empty materials  to PipelineConfig' do
         pipeline_config = PipelineConfig.new
-        ApiV4::Admin::Pipelines::PipelineConfigRepresenter.new(pipeline_config).from_hash({ materials: nil })
+        ApiV4::Admin::Pipelines::PipelineConfigRepresenter.new(pipeline_config).from_hash({materials: nil})
         expect(pipeline_config.materialConfigs.size).to eq(0)
       end
 
       it 'should raise exception when passing invalid material type' do
-        hash             = pipeline_hash_basic
-        hash[:materials] = [{ type: 'bad-material-type', attributes: { foo: 'bar' } }]
-        pipeline_config  = PipelineConfig.new
+        hash = pipeline_hash_basic
+        hash[:materials] = [{type: 'bad-material-type', attributes: {foo: 'bar'}}]
+        pipeline_config = PipelineConfig.new
 
         expect do
           ApiV4::Admin::Pipelines::PipelineConfigRepresenter.new(pipeline_config).from_hash(hash)
@@ -221,65 +226,65 @@ describe ApiV4::Admin::Pipelines::PipelineConfigRepresenter do
     end
 
     describe :pipeline_with_stages do
-      it "should convert pipeline hash with stages  to PipelineConfig" do
+      it 'should convert pipeline hash with stages  to PipelineConfig' do
         pipeline_config = PipelineConfig.new
-        stages          =[{
-                            name:                    'stage1',
-                            fetch_materials:         true,
-                            clean_working_directory: false,
-                            never_cleanup_artifacts: false,
-                            approval:                {
-                              type:          'success',
-                              authorization: {
-                                roles: [],
-                                users: []
-                              }
-                            },
-                            environment_variables:   [
-                                                       {
-                                                         name:   'plain',
-                                                         value:  'plain',
-                                                         secure: false
-                                                       },
-                                                       {
-                                                         secure:          true,
-                                                         name:            'secure',
-                                                         encrypted_value: GoCipher.new.encrypt('confidential')
-                                                       }
-                                                     ],
-                            jobs:                    [{
-                                                        name:               'some-job',
-                                                        run_on_all_agents:  true,
-                                                        run_instance_count: '3',
-                                                        timeout:            '100',
-                                                      }]
+        stages =[{
+                   name: 'stage1',
+                   fetch_materials: true,
+                   clean_working_directory: false,
+                   never_cleanup_artifacts: false,
+                   approval: {
+                     type: 'success',
+                     authorization: {
+                       roles: [],
+                       users: []
+                     }
+                   },
+                   environment_variables: [
+                     {
+                       name: 'plain',
+                       value: 'plain',
+                       secure: false
+                     },
+                     {
+                       secure: true,
+                       name: 'secure',
+                       encrypted_value: GoCipher.new.encrypt('confidential')
+                     }
+                   ],
+                   jobs: [{
+                            name: 'some-job',
+                            run_on_all_agents: true,
+                            run_instance_count: '3',
+                            timeout: '100',
                           }]
+                 }]
 
-        ApiV4::Admin::Pipelines::PipelineConfigRepresenter.new(pipeline_config).from_hash({ stages: stages })
+        ApiV4::Admin::Pipelines::PipelineConfigRepresenter.new(pipeline_config).from_hash({stages: stages})
         expect(pipeline_config.getStages.map(&:name).map(&:to_s)).to eq(['stage1'])
         expect(pipeline_config.getStages.first.getJobs.map(&:name).map(&:to_s)).to eq(['some-job'])
         expect(pipeline_config.getStages.first.variables.map(&:name)).to eq(['plain', 'secure'])
 
       end
 
-      it "should convert pipeline hash with empty stages  to PipelineConfig" do
+      it 'should convert pipeline hash with empty stages  to PipelineConfig' do
         pipeline_config = PipelineConfig.new
-        ApiV4::Admin::Pipelines::PipelineConfigRepresenter.new(pipeline_config).from_hash({ stages: nil })
+        ApiV4::Admin::Pipelines::PipelineConfigRepresenter.new(pipeline_config).from_hash({stages: nil})
         expect(pipeline_config.getStages.size).to eq(0)
       end
 
     end
 
     describe :pipeline_with_tracking_tool do
-      it "should convert pipeline hash with tracking tool  to PipelineConfig" do
+      it 'should convert pipeline hash with tracking tool  to PipelineConfig' do
         pipeline_config = PipelineConfig.new
-        ApiV4::Admin::Pipelines::PipelineConfigRepresenter.new(pipeline_config).from_hash({ tracking_tool: {
-          type:       "generic",
+        ApiV4::Admin::Pipelines::PipelineConfigRepresenter.new(pipeline_config).from_hash({tracking_tool: {
+          type: 'generic',
           attributes: {
-            url_pattern:  "link",
-            regex: "regex"
+            url_pattern: 'link',
+            regex: 'regex'
           }
-        } })
+        }})
         expect(pipeline_config.getTrackingTool.getLink).to eq('link')
         expect(pipeline_config.getTrackingTool.getRegex).to eq('regex')
       end
@@ -287,53 +292,54 @@ describe ApiV4::Admin::Pipelines::PipelineConfigRepresenter do
       it 'should raise exception when passing invalid tracking tool type' do
         pipeline_config = PipelineConfig.new
         expect do
-          ApiV4::Admin::Pipelines::PipelineConfigRepresenter.new(pipeline_config).from_hash({ tracking_tool: {
-            type:       "bad-tracking-tool",
+          ApiV4::Admin::Pipelines::PipelineConfigRepresenter.new(pipeline_config).from_hash({tracking_tool: {
+            type: 'bad-tracking-tool',
             attributes: {
-              link:  "link",
-              regex: "regex"
+              link: 'link',
+              regex: 'regex'
             }
-          } })
+          }})
         end.to raise_error(ApiV4::UnprocessableEntity, /Invalid Tracking Tool type 'bad-tracking-tool'. It has to be one of/)
       end
 
 
     end
 
-    it "should convert from full blown document to PipelineConfig" do
+    it 'should convert from full blown document to PipelineConfig' do
       pipeline_config = PipelineConfig.new
-
+      pipeline_config.setOrigin(FileConfigOrigin.new)
       ApiV4::Admin::Pipelines::PipelineConfigRepresenter.new(pipeline_config).from_hash(pipeline_hash)
       expect(pipeline_config).to eq(get_pipeline_config)
     end
 
 
     describe :pipeline_with_timer do
-      it "should convert pipeline hash with timer  to PipelineConfig" do
+      it 'should convert pipeline hash with timer  to PipelineConfig' do
         pipeline_config = PipelineConfig.new
-        ApiV4::Admin::Pipelines::PipelineConfigRepresenter.new(pipeline_config).from_hash({ timer: { spec: "0 0 22 ? * MON-FRI", only_on_changes: true } })
+        ApiV4::Admin::Pipelines::PipelineConfigRepresenter.new(pipeline_config).from_hash({timer: {spec: '0 0 22 ? * MON-FRI', only_on_changes: true}})
         expect(pipeline_config.getTimer.getOnlyOnChanges).to eq(true)
       end
     end
 
-    it "should render errors" do
-      pipeline_config = PipelineConfig.new(CaseInsensitiveString.new("wunderbar"), "", "", true, nil, ArrayList.new)
-      config          = BasicCruiseConfig.new(BasicPipelineConfigs.new("grp", Authorization.new, pipeline_config))
+    it 'should render errors' do
+      pipeline_config = PipelineConfig.new(CaseInsensitiveString.new('wunderbar'), '', '', true, nil, ArrayList.new)
+      pipeline_config.setOrigin(FileConfigOrigin.new)
+      config = BasicCruiseConfig.new(BasicPipelineConfigs.new('grp', Authorization.new, pipeline_config))
 
-      pipeline_config.validateTree(com.thoughtworks.go.config.PipelineConfigSaveValidationContext::forChain(true, "grp", config, pipeline_config))
+      pipeline_config.validateTree(com.thoughtworks.go.config.PipelineConfigSaveValidationContext::forChain(true, 'grp', config, pipeline_config))
 
-      presenter   = ApiV4::Admin::Pipelines::PipelineConfigRepresenter.new(pipeline_config)
+      presenter = ApiV4::Admin::Pipelines::PipelineConfigRepresenter.new(pipeline_config)
       actual_json = presenter.to_hash(url_builder: UrlBuilder.new)
       actual_json.delete(:_links)
       expect(actual_json).to eq(expected_hash_with_errors)
     end
 
-    it "should render errors on nested objects" do
+    it 'should render errors on nested objects' do
       pipeline_config = get_invalid_pipeline_config
-      config          = BasicCruiseConfig.new(BasicPipelineConfigs.new("grp", Authorization.new, get_pipeline_config))
-      pipeline_config.validateTree(com.thoughtworks.go.config.PipelineConfigSaveValidationContext::forChain(true, "grp", config, pipeline_config))
+      config = BasicCruiseConfig.new(BasicPipelineConfigs.new('grp', Authorization.new, get_pipeline_config))
+      pipeline_config.validateTree(com.thoughtworks.go.config.PipelineConfigSaveValidationContext::forChain(true, 'grp', config, pipeline_config))
 
-      presenter   = ApiV4::Admin::Pipelines::PipelineConfigRepresenter.new(pipeline_config)
+      presenter = ApiV4::Admin::Pipelines::PipelineConfigRepresenter.new(pipeline_config)
       actual_json = presenter.to_hash(url_builder: UrlBuilder.new)
       actual_json.delete(:_links)
       expect(actual_json).to eq(expected_hash_with_nested_errors)
@@ -343,19 +349,23 @@ describe ApiV4::Admin::Pipelines::PipelineConfigRepresenter do
 
   def expected_hash_with_errors
     {
-      label_template:          "",
+      label_template: '',
       enable_pipeline_locking: false,
-      name:                    "wunderbar",
-      template:                nil,
-      parameters:              [],
-      environment_variables:   [],
-      materials:               [],
-      stages:                  nil,
-      tracking_tool:           nil,
-      timer:                   { spec: "", only_on_changes: true, errors: { spec: ["Invalid cron syntax: Unexpected end of expression."] } },
-      errors:                  {
-        materials:     ["A pipeline must have at least one material"],
-        pipeline:      ["Pipeline 'wunderbar' does not have any stages configured. A pipeline must have at least one stage."],
+      name: 'wunderbar',
+      origin: {
+        type: 'local',
+        file: 'cruise-config.xml'
+      },
+      template: nil,
+      parameters: [],
+      environment_variables: [],
+      materials: [],
+      stages: nil,
+      tracking_tool: nil,
+      timer: {spec: '', only_on_changes: true, errors: {spec: ['Invalid cron syntax: Unexpected end of expression.']}},
+      errors: {
+        materials: ['A pipeline must have at least one material'],
+        pipeline: ["Pipeline 'wunderbar' does not have any stages configured. A pipeline must have at least one stage."],
         label_template: ["Label cannot be blank. Label should be composed of alphanumeric text, it should contain the builder number as ${COUNT}, can contain a material revision as ${<material-name>} of ${<material-name>[:<number>]}, or use params as \#{<param-name>}."]
       }
     }
@@ -363,85 +373,95 @@ describe ApiV4::Admin::Pipelines::PipelineConfigRepresenter do
 
   def expected_hash_with_nested_errors
     {
-      label_template:          "foo-1.0.${COUNT}-${svn}",
+      label_template: 'foo-1.0.${COUNT}-${svn}',
       enable_pipeline_locking: false,
-      name:                    "wunderbar",
-      template:                nil,
-      parameters:              [
-                                 {
-                                   name:   nil, value: "echo",
-                                   errors: {
-                                     name: [
-                                             "Parameter cannot have an empty name for pipeline 'wunderbar'.",
-                                             "Invalid parameter name 'null'. This must be alphanumeric and can contain underscores and periods (however, it cannot start with a period). The maximum allowed length is 255 characters."
-                                           ]
-                                   }
-                                 }
-                               ],
-      environment_variables:   [{:secure=>false, :name=>"", :value=>"", :errors=>{:name=>["Environment Variable cannot have an empty name for pipeline 'wunderbar'."]}}],
-      materials:               [
-                                 {
-                                   type: "svn", attributes: { url: "http://some/svn/url", destination: "svnDir", filter: nil, invert_filter:false, name: "http___some_svn_url", auto_update: true, check_externals: false, username: nil }
-                                 },
-                                 {
-                                   type:   "git", attributes: { url: nil, destination: nil, filter: nil, invert_filter:false, name: nil, auto_update: true, branch: "master", submodule_folder: nil, shallow_clone: false },
-                                   errors: { destination: ["Destination directory is required when specifying multiple scm materials"], url: ["URL cannot be blank"] }
-                                 }
-                               ],
-      stages:                  [{ name: "stage1", fetch_materials: true, clean_working_directory: false, never_cleanup_artifacts: false, approval: { type: "success", authorization: { :roles => [], :users => [] } }, environment_variables: [], jobs: [] }],
-      timer:                   { spec: "0 0 22 ? * MON-FRI", only_on_changes: true },
-      tracking_tool:           {
-        type:   "generic", attributes: { url_pattern: "", regex: "" },
+      name: 'wunderbar',
+      origin: {
+        type: 'local',
+        file: 'cruise-config.xml'
+      },
+      template: nil,
+      parameters: [
+        {
+          name: nil, value: 'echo',
+          errors: {
+            name: [
+              "Parameter cannot have an empty name for pipeline 'wunderbar'.",
+              "Invalid parameter name 'null'. This must be alphanumeric and can contain underscores and periods (however, it cannot start with a period). The maximum allowed length is 255 characters."
+            ]
+          }
+        }
+      ],
+      environment_variables: [{:secure => false, :name => '', :value => '', :errors => {:name => ["Environment Variable cannot have an empty name for pipeline 'wunderbar'."]}}],
+      materials: [
+        {
+          type: 'svn', attributes: {url: 'http://some/svn/url', destination: 'svnDir', filter: nil, invert_filter: false, name: 'http___some_svn_url', auto_update: true, check_externals: false, username: nil}
+        },
+        {
+          type: 'git', attributes: {url: nil, destination: nil, filter: nil, invert_filter: false, name: nil, auto_update: true, branch: 'master', submodule_folder: nil, shallow_clone: false},
+          errors: {destination: ['Destination directory is required when specifying multiple scm materials'], url: ['URL cannot be blank']}
+        }
+      ],
+      stages: [{name: 'stage1', fetch_materials: true, clean_working_directory: false, never_cleanup_artifacts: false, approval: {type: 'success', authorization: {:roles => [], :users => []}}, environment_variables: [], jobs: []}],
+      timer: {spec: '0 0 22 ? * MON-FRI', only_on_changes: true},
+      tracking_tool: {
+        type: 'generic', attributes: {url_pattern: '', regex: ''},
         errors: {
-          regex: ["Regex should be populated"],
-          url_pattern:  ["Link should be populated", "Link must be a URL containing '${ID}'. Go will replace the string '${ID}' with the first matched group from the regex at run-time."]
+          regex: ['Regex should be populated'],
+          url_pattern: ['Link should be populated', "Link must be a URL containing '${ID}'. Go will replace the string '${ID}' with the first matched group from the regex at run-time."]
 
         }
       },
-      errors:                  {
-        label_template: ["You have defined a label template in pipeline wunderbar that refers to a material called svn, but no material with this name is defined."]
+      errors: {
+        label_template: ['You have defined a label template in pipeline wunderbar that refers to a material called svn, but no material with this name is defined.']
       }
     }
   end
 
   def get_invalid_pipeline_config
     material_configs = MaterialConfigsMother.defaultMaterialConfigs()
-    git              = GitMaterialConfig.new
-    git.setFolder(nil);
-    material_configs.add(git);
+    git = GitMaterialConfig.new
+    git.setFolder(nil)
+    material_configs.add(git)
 
-    pipeline_config = PipelineConfig.new(CaseInsensitiveString.new("wunderbar"), "foo-1.0.${COUNT}-${svn}", "0 0 22 ? * MON-FRI", true, material_configs, ArrayList.new)
-    pipeline_config.addParam(ParamConfig.new(nil, "echo"))
-    pipeline_config.addEnvironmentVariable('','')
-    pipeline_config.add(StageConfigMother.stageConfig("stage1"))
+    pipeline_config = PipelineConfig.new(CaseInsensitiveString.new('wunderbar'), 'foo-1.0.${COUNT}-${svn}', '0 0 22 ? * MON-FRI', true, material_configs, ArrayList.new)
+    pipeline_config.addParam(ParamConfig.new(nil, 'echo'))
+    pipeline_config.addEnvironmentVariable('', '')
+    pipeline_config.add(StageConfigMother.stageConfig('stage1'))
     pipeline_config.setTrackingTool(TrackingTool.new())
+    pipeline_config.setOrigin(FileConfigOrigin.new)
     pipeline_config
   end
 
 
   def get_pipeline_config
     material_configs = MaterialConfigsMother.defaultMaterialConfigs()
-    pipeline_config  = PipelineConfig.new(CaseInsensitiveString.new("wunderbar"), "foo-1.0.${COUNT}-${svn}", "0 0 22 ? * MON-FRI", true, material_configs, ArrayList.new)
+    pipeline_config = PipelineConfig.new(CaseInsensitiveString.new('wunderbar'), 'foo-1.0.${COUNT}-${svn}', '0 0 22 ? * MON-FRI', true, material_configs, ArrayList.new)
     pipeline_config.setVariables(EnvironmentVariablesConfigMother.environmentVariables())
-    pipeline_config.addParam(ParamConfig.new("COMMAND", "echo"))
-    pipeline_config.addParam(ParamConfig.new("WORKING_DIR", "/repo/branch"))
-    pipeline_config.add(StageConfigMother.stageConfigWithEnvironmentVariable("stage1"))
-    pipeline_config.setTrackingTool(TrackingTool.new("link", "regex"))
+    pipeline_config.addParam(ParamConfig.new('COMMAND', 'echo'))
+    pipeline_config.addParam(ParamConfig.new('WORKING_DIR', '/repo/branch'))
+    pipeline_config.add(StageConfigMother.stageConfigWithEnvironmentVariable('stage1'))
+    pipeline_config.setTrackingTool(TrackingTool.new('link', 'regex'))
+    pipeline_config.setOrigin(FileConfigOrigin.new)
     pipeline_config
   end
 
   def pipeline_hash
     {
-      label_template:          "foo-1.0.${COUNT}-${svn}",
+      label_template: 'foo-1.0.${COUNT}-${svn}',
       enable_pipeline_locking: false,
-      name:                    "wunderbar",
-      template:                nil,
-      parameters:              get_pipeline_config.getParams().collect { |j| ApiV4::Admin::Pipelines::ParamRepresenter.new(j).to_hash(url_builder: UrlBuilder.new) },
-      environment_variables:   get_pipeline_config.variables().collect { |j| ApiV4::Shared::EnvironmentVariableRepresenter.new(j).to_hash(url_builder: UrlBuilder.new) },
-      materials:               get_pipeline_config.materialConfigs().collect { |j| ApiV4::Admin::Pipelines::Materials::MaterialRepresenter.new(j).to_hash(url_builder: UrlBuilder.new) },
-      stages:                  get_pipeline_config.getStages().collect { |j| ApiV4::Shared::Stages::StageRepresenter.new(j).to_hash(url_builder: UrlBuilder.new) },
-      tracking_tool:           ApiV4::Admin::Pipelines::TrackingTool::TrackingToolRepresenter.new(get_pipeline_config.getTrackingTool).to_hash(url_builder: UrlBuilder.new),
-      timer:                   ApiV4::Admin::Pipelines::TimerRepresenter.new(get_pipeline_config.getTimer).to_hash(url_builder: UrlBuilder.new)
+      name: 'wunderbar',
+      origin: {
+        type: 'local',
+        file: 'cruise-config.xml'
+      },
+      template: nil,
+      parameters: get_pipeline_config.getParams().collect { |j| ApiV4::Admin::Pipelines::ParamRepresenter.new(j).to_hash(url_builder: UrlBuilder.new) },
+      environment_variables: get_pipeline_config.variables().collect { |j| ApiV4::Shared::EnvironmentVariableRepresenter.new(j).to_hash(url_builder: UrlBuilder.new) },
+      materials: get_pipeline_config.materialConfigs().collect { |j| ApiV4::Admin::Pipelines::Materials::MaterialRepresenter.new(j).to_hash(url_builder: UrlBuilder.new) },
+      stages: get_pipeline_config.getStages().collect { |j| ApiV4::Shared::Stages::StageRepresenter.new(j).to_hash(url_builder: UrlBuilder.new) },
+      tracking_tool: ApiV4::Admin::Pipelines::TrackingTool::TrackingToolRepresenter.new(get_pipeline_config.getTrackingTool).to_hash(url_builder: UrlBuilder.new),
+      timer: ApiV4::Admin::Pipelines::TimerRepresenter.new(get_pipeline_config.getTimer).to_hash(url_builder: UrlBuilder.new)
     }
   end
 

--- a/server/webapp/WEB-INF/rails.new/spec/presenters/api_v4/admin/pipelines/timer_representer_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/presenters/api_v4/admin/pipelines/timer_representer_spec.rb
@@ -1,5 +1,5 @@
 ##########################################################################
-# Copyright 2016 ThoughtWorks, Inc.
+# Copyright 2017 ThoughtWorks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/server/webapp/WEB-INF/rails.new/spec/presenters/api_v4/admin/pipelines/timer_representer_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/presenters/api_v4/admin/pipelines/timer_representer_spec.rb
@@ -1,0 +1,61 @@
+##########################################################################
+# Copyright 2016 ThoughtWorks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+
+require 'spec_helper'
+
+describe ApiV4::Admin::Pipelines::TimerRepresenter do
+
+  it "should represent a timer" do
+    timer = com.thoughtworks.go.config.TimerConfig.new("0 0 7 ? * MON", false)
+    timer.validateTree(nil)
+
+    presenter   = ApiV4::Admin::Pipelines::TimerRepresenter.new(timer)
+    actual_json = presenter.to_hash(url_builder: UrlBuilder.new)
+    expect(actual_json).to eq(timer_hash)
+  end
+
+  it "should represent validation errors" do
+    timer = com.thoughtworks.go.config.TimerConfig.new("SOME JUNK TIMER SPEC", false)
+    timer.validateTree(nil)
+    presenter   = ApiV4::Admin::Pipelines::TimerRepresenter.new(timer)
+    actual_json = presenter.to_hash(url_builder: UrlBuilder.new)
+    expect(actual_json).to eq(timer_hash_with_error)
+  end
+
+  it "should deserialize" do
+    presenter           = ApiV4::Admin::Pipelines::TimerRepresenter.new(com.thoughtworks.go.config.TimerConfig.new)
+    deserialized_object = presenter.from_hash(timer_hash)
+    expected            = com.thoughtworks.go.config.TimerConfig.new("0 0 7 ? * MON", false)
+    expect(deserialized_object).to eq(expected)
+  end
+
+  def timer_hash
+    {
+      spec:            "0 0 7 ? * MON",
+      only_on_changes: false
+    }
+  end
+
+  def timer_hash_with_error
+    {
+        spec: "SOME JUNK TIMER SPEC",
+        only_on_changes: false,
+        errors: {
+          spec: ["Invalid cron syntax: Illegal characters for this position: 'SOM'"]
+        }
+    }
+  end
+end

--- a/server/webapp/WEB-INF/rails.new/spec/presenters/api_v4/shared/config_origin/config_repo_origin_representer_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/presenters/api_v4/shared/config_origin/config_repo_origin_representer_spec.rb
@@ -1,0 +1,50 @@
+##########################################################################
+# Copyright 2017 ThoughtWorks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+
+require 'spec_helper'
+
+describe ApiV4::Shared::ConfigOrigin::ConfigRepoOriginRepresenter do
+  it 'should render remote config origin' do
+    git_material = GitMaterialConfig.new('https://github.com/config-repos/repo', 'master')
+    config_repo = RepoConfigOrigin.new(ConfigRepoConfig.new(git_material, 'json-plugin'), 'revision1')
+
+    actual_json = ApiV4::Shared::ConfigOrigin::ConfigRepoOriginRepresenter.new(config_repo).to_hash(url_builder: UrlBuilder.new)
+    material_json = ApiV4::Admin::Pipelines::Materials::GitMaterialRepresenter.new(git_material).to_hash(url_builder: UrlBuilder.new)
+
+    expect(actual_json).to eq(expected_json)
+  end
+
+  def expected_json
+    {
+      type: 'config repo',
+      repo: {
+        type: 'git',
+        attributes: {
+          url: 'https://github.com/config-repos/repo',
+          destination: nil,
+          filter: nil,
+          invert_filter: false,
+          name: nil,
+          auto_update: true,
+          branch: 'master',
+          submodule_folder: nil,
+          shallow_clone: false
+        },
+        revision: 'revision1'
+      }
+    }
+  end
+end

--- a/server/webapp/WEB-INF/rails.new/spec/presenters/api_v4/shared/config_origin/config_xml_origin_representer_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/presenters/api_v4/shared/config_origin/config_xml_origin_representer_spec.rb
@@ -14,20 +14,23 @@
 # limitations under the License.
 ##########################################################################
 
-module ApiV4
-  module Admin
-    module Pipelines
-      module Materials
-        module EncryptedPasswordSupport
-          def from_hash(data, options={})
-            super
-            data = data.with_indifferent_access
-            encrypted_password = Services.password_deserializer.deserialize(data[:password], data[:encrypted_password], represented)
-            represented.setEncryptedPassword(encrypted_password)
-            represented
-          end
-        end
-      end
-    end
+require 'spec_helper'
+
+describe ApiV4::Shared::ConfigOrigin::ConfigXmlOriginRepresenter do
+  it 'should render local config origin' do
+    presenter = ApiV4::Shared::ConfigOrigin::ConfigXmlOriginRepresenter.new(get_config_xml_origin)
+    actual_json = presenter.to_hash(url_builder: UrlBuilder.new)
+    expect(actual_json).to eq(expected_json)
+  end
+
+  def get_config_xml_origin
+    FileConfigOrigin.new
+  end
+
+  def expected_json
+    {
+      type: 'local',
+      file: 'cruise-config.xml'
+    }
   end
 end

--- a/server/webapp/WEB-INF/rails.new/spec/presenters/api_v4/shared/environment_variable_representer_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/presenters/api_v4/shared/environment_variable_representer_spec.rb
@@ -1,5 +1,5 @@
 ##########################################################################
-# Copyright 2016 ThoughtWorks, Inc.
+# Copyright 2017 ThoughtWorks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/server/webapp/WEB-INF/rails.new/spec/presenters/api_v4/shared/environment_variable_representer_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/presenters/api_v4/shared/environment_variable_representer_spec.rb
@@ -1,0 +1,97 @@
+##########################################################################
+# Copyright 2016 ThoughtWorks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+
+require 'spec_helper'
+
+describe ApiV4::Shared::EnvironmentVariableRepresenter do
+  it 'should render plain environment variable with hal representation' do
+    presenter   = ApiV4::Shared::EnvironmentVariableRepresenter.new(get_plain_variable)
+    actual_json = presenter.to_hash(url_builder: UrlBuilder.new)
+    expect(actual_json).to eq(get_plain_text_hash)
+  end
+
+  it 'should render secure environment variable with hal representation' do
+    presenter   = ApiV4::Shared::EnvironmentVariableRepresenter.new(get_secure_variable)
+    actual_json = presenter.to_hash(url_builder: UrlBuilder.new)
+    expect(actual_json).to eq(get_secure_hash_with_encrypted_value)
+  end
+
+  it 'should convert from secure hash with encrypted value to EnvironmentVariableConfig' do
+    config    = EnvironmentVariableConfig.new
+    presenter = ApiV4::Shared::EnvironmentVariableRepresenter.new(config)
+    presenter.from_hash(get_secure_hash_with_encrypted_value)
+    expect(config).to eq(get_secure_variable)
+  end
+
+  it 'should convert from secure hash with clear text value to EnvironmentVariableConfig' do
+    config    = EnvironmentVariableConfig.new
+    presenter = ApiV4::Shared::EnvironmentVariableRepresenter.new(config)
+    presenter.from_hash(secure_hash_with_clear_text_value)
+    expect(config).to eq(get_secure_variable)
+  end
+
+  it 'should deserialize an ambiguous encrypted variable (with both value and encrypted_value) to a variable with errors' do
+    config    = EnvironmentVariableConfig.new
+    presenter = ApiV4::Shared::EnvironmentVariableRepresenter.new(config)
+    config = presenter.from_hash(name: 'PASSWORD', secure: true, value: 'plainText', encrypted_value: 'c!ph3rt3xt')
+    expect(config.errors.getAllOn('value').to_a).to eq(['You may only specify `value` or `encrypted_value`, not both!'])
+    expect(config.errors.getAllOn('encryptedValue').to_a).to eq(['You may only specify `value` or `encrypted_value`, not both!'])
+  end
+
+  it 'should deserialize an unambiguous encrypted variable (with either value or encrypted_value) to a variable without errors' do
+    config    = EnvironmentVariableConfig.new
+    presenter = ApiV4::Shared::EnvironmentVariableRepresenter.new(config)
+    config = presenter.from_hash(name: 'PASSWORD', secure: true, value: 'plainText')
+    expect(config.errors).to be_empty
+
+    config    = EnvironmentVariableConfig.new
+    presenter = ApiV4::Shared::EnvironmentVariableRepresenter.new(config)
+    config = presenter.from_hash(name: 'PASSWORD', secure: true, encrypted_value: 'c!ph3rt3xt')
+    expect(config.errors).to be_empty
+  end
+
+  def get_secure_variable
+    EnvironmentVariableConfig.new(GoCipher.new, 'secure', 'confidential', true)
+  end
+
+  def get_plain_variable
+    EnvironmentVariableConfig.new(GoCipher.new, 'plain', 'plain', false)
+  end
+
+  def get_plain_text_hash
+    {
+      name:   'plain',
+      value:  'plain',
+      secure: false
+    }
+  end
+
+  def get_secure_hash_with_encrypted_value
+    {
+      secure:          true,
+      name:            'secure',
+      encrypted_value: GoCipher.new.encrypt('confidential')
+    }
+  end
+
+  def secure_hash_with_clear_text_value
+    {
+      secure: true,
+      name:   'secure',
+      value:  'confidential'
+    }
+  end
+end

--- a/server/webapp/WEB-INF/rails.new/spec/presenters/api_v4/shared/stages/approval_representer_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/presenters/api_v4/shared/stages/approval_representer_spec.rb
@@ -1,5 +1,5 @@
 ##########################################################################
-# Copyright 2016 ThoughtWorks, Inc.
+# Copyright 2017 ThoughtWorks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/server/webapp/WEB-INF/rails.new/spec/presenters/api_v4/shared/stages/approval_representer_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/presenters/api_v4/shared/stages/approval_representer_spec.rb
@@ -1,0 +1,94 @@
+##########################################################################
+# Copyright 2016 ThoughtWorks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+
+require 'spec_helper'
+
+describe ApiV4::Shared::Stages::ApprovalRepresenter do
+  it 'renders approval with hal representation' do
+    approval = get_approval
+    presenter = ApiV4::Shared::Stages::ApprovalRepresenter.new(approval)
+    actual_json = presenter.to_hash(url_builder: UrlBuilder.new)
+    expect(actual_json).to eq(approval_hash)
+  end
+
+  it 'should convert basic hash to Approval object' do
+    approval = Approval.new()
+
+    ApiV4::Shared::Stages::ApprovalRepresenter.new(approval).from_hash(approval_hash)
+    expect(approval.getType).to eq(get_approval.getType)
+  end
+
+  it "should render error" do
+    approval = Approval.new()
+    approval.setType("junk")
+    admins = [AdminRole.new(CaseInsensitiveString.new("role1")), AdminUser.new(CaseInsensitiveString.new("user1"))].to_java(com.thoughtworks.go.domain.config.Admin)
+    auth_config = AuthConfig.new(admins)
+    approval.setAuthConfig(auth_config)
+    auth_config.addError("name", "error")
+    approval.addError("type", "You have defined approval type as 'junk'. Approval can only be of the type 'manual' or 'success'.")
+
+    presenter = ApiV4::Shared::Stages::ApprovalRepresenter.new(approval)
+    actual_json = presenter.to_hash(url_builder: UrlBuilder.new)
+    expect(actual_json).to eq(approval_hash_with_errors)
+  end
+
+  it "should deserialize" do
+    admins = [
+        AdminRole.new(CaseInsensitiveString.new("role1")), AdminRole.new(CaseInsensitiveString.new("role2")),
+        AdminUser.new(CaseInsensitiveString.new("user1")), AdminUser.new(CaseInsensitiveString.new("user2"))].to_java(com.thoughtworks.go.domain.config.Admin)
+    auth_config = AuthConfig.new(admins)
+    expected = Approval.new(auth_config)
+
+    approval = Approval.new
+    ApiV4::Shared::Stages::ApprovalRepresenter.new(approval).from_hash(approval_hash)
+    expect(approval).to eq(expected)
+  end
+
+  def approval_hash
+    {
+      type: "manual",
+      authorization: {
+        roles: ["role1", "role2"],
+        users: ["user1", "user2"]
+      }
+    }
+  end
+
+  def get_approval
+    admins      = [
+      AdminRole.new(CaseInsensitiveString.new("role1")), AdminRole.new(CaseInsensitiveString.new("role2")),
+      AdminUser.new(CaseInsensitiveString.new("user1")), AdminUser.new(CaseInsensitiveString.new("user2"))].to_java(com.thoughtworks.go.domain.config.Admin)
+    auth_config = AuthConfig.new(admins)
+
+    approval = Approval.new(auth_config)
+  end
+
+  def approval_hash_with_errors
+    {
+      type: "junk",
+        authorization: {
+        roles: ["role1"],
+        users: ["user1"],
+        errors: {
+          name: ["error"]
+        }
+    },
+    errors: {
+        type: ["You have defined approval type as 'junk'. Approval can only be of the type 'manual' or 'success'."]
+      }
+    }
+  end
+end

--- a/server/webapp/WEB-INF/rails.new/spec/presenters/api_v4/shared/stages/artifact_representer_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/presenters/api_v4/shared/stages/artifact_representer_spec.rb
@@ -1,5 +1,5 @@
 ##########################################################################
-# Copyright 2016 ThoughtWorks, Inc.
+# Copyright 2017 ThoughtWorks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/server/webapp/WEB-INF/rails.new/spec/presenters/api_v4/shared/stages/artifact_representer_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/presenters/api_v4/shared/stages/artifact_representer_spec.rb
@@ -1,0 +1,110 @@
+##########################################################################
+# Copyright 2016 ThoughtWorks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+
+require 'spec_helper'
+
+describe ApiV4::Shared::Stages::ArtifactRepresenter do
+  it 'should serialize build artifact' do
+    presenter   = ApiV4::Shared::Stages::ArtifactRepresenter.new(ArtifactPlan.new('target/dist.jar', 'pkg'))
+    actual_json = presenter.to_hash(url_builder: UrlBuilder.new)
+
+    expect(actual_json).to eq(build_artifact_hash)
+  end
+
+  it 'should serialize test artifact' do
+    config = TestArtifactPlan.new
+    config.setSrc('target/reports/**/*Test.xml')
+    config.setDest('reports')
+    presenter   = ApiV4::Shared::Stages::ArtifactRepresenter.new(config)
+    actual_json = presenter.to_hash(url_builder: UrlBuilder.new)
+
+    expect(actual_json).to eq(test_artifact_hash)
+  end
+
+  it 'should deserialize test artifact' do
+    expected = TestArtifactPlan.new
+    expected.setSrc('target/reports/**/*Test.xml')
+    expected.setDest('reports')
+
+    actual    = TestArtifactPlan.new
+    presenter = ApiV4::Shared::Stages::ArtifactRepresenter.new(actual)
+    presenter.from_hash(test_artifact_hash)
+    expect(actual.getSrc).to eq(expected.getSrc)
+    expect(actual.getDest).to eq(expected.getDest)
+    expect(actual.getArtifactType).to eq(expected.getArtifactType)
+    expect(actual).to eq(expected)
+  end
+
+  it 'should map errors' do
+    plan = TestArtifactPlan.new(nil, '../foo')
+
+    plan.validateTree(PipelineConfigSaveValidationContext.forChain(true, "g", PipelineConfig.new, StageConfig.new, JobConfig.new))
+    presenter   = ApiV4::Shared::Stages::ArtifactRepresenter.new(plan)
+    actual_json = presenter.to_hash(url_builder: UrlBuilder.new)
+
+    expect(actual_json).to eq(test_artifact_with_errors)
+  end
+
+  def test_artifact_with_errors
+    {source: nil, destination: '../foo', type: 'test',
+     errors: {
+       destination: ['Invalid destination path. Destination path should match the pattern (([.]\\/)?[.][^. ]+)|([^. ].+[^. ])|([^. ][^. ])|([^. ])'],
+       source:      ["Job 'null' has an artifact with an empty source"]
+     }
+    }
+  end
+
+  def build_artifact_hash
+    {
+      source:      'target/dist.jar',
+      destination: 'pkg',
+      type:        'build'
+    }
+  end
+
+  def build_artifact_hash_with_errors
+    {
+      source:      nil,
+      destination: '../foo',
+      type:        'build',
+      errors:      {
+        source:      ["Job 'null' has an artifact with an empty source"],
+        destination: ['Invalid destination path. Destination path should match the pattern '+ com.thoughtworks.go.config.validation.FilePathTypeValidator::PATH_PATTERN]
+      }
+    }
+  end
+
+  def test_artifact_hash
+    {
+      source:      'target/reports/**/*Test.xml',
+      destination: 'reports',
+      type:        'test'
+    }
+  end
+
+
+  def test_artifact_hash_with_errors
+    {
+      source:      nil,
+      destination: '../foo',
+      type:        'test',
+      errors:      {
+        source:      ["Job 'null' has an artifact with an empty source"],
+        destination: ['Invalid destination path. Destination path should match the pattern '+ com.thoughtworks.go.config.validation.FilePathTypeValidator::PATH_PATTERN]
+      }
+    }
+  end
+end

--- a/server/webapp/WEB-INF/rails.new/spec/presenters/api_v4/shared/stages/job_representer_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/presenters/api_v4/shared/stages/job_representer_spec.rb
@@ -1,5 +1,5 @@
 ##########################################################################
-# Copyright 2016 ThoughtWorks, Inc.
+# Copyright 2017 ThoughtWorks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/server/webapp/WEB-INF/rails.new/spec/presenters/api_v4/shared/stages/job_representer_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/presenters/api_v4/shared/stages/job_representer_spec.rb
@@ -1,0 +1,349 @@
+##########################################################################
+# Copyright 2016 ThoughtWorks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+
+require 'spec_helper'
+
+describe ApiV4::Shared::Stages::JobRepresenter do
+
+  describe :serialize do
+    it 'should render job with hal representation' do
+
+      presenter   = ApiV4::Shared::Stages::JobRepresenter.new(com.thoughtworks.go.helper.JobConfigMother.jobConfig())
+      actual_json = presenter.to_hash(url_builder: UrlBuilder.new)
+
+      expect(actual_json).to eq(job_hash)
+    end
+
+    it 'should serialize run_instance_count with value set to 10' do
+      job_config = JobConfig.new
+      job_config.setRunInstanceCount(10)
+
+      presenter   = ApiV4::Shared::Stages::JobRepresenter.new(job_config)
+      actual_json = presenter.to_hash(url_builder: UrlBuilder.new)
+      expect(actual_json[:run_instance_count]).to be(10)
+    end
+
+    it 'should serialize run_instance_count with value `all` when runOnAllAgents is true' do
+      job_config = JobConfig.new
+      job_config.setRunOnAllAgents(true)
+
+      presenter   = ApiV4::Shared::Stages::JobRepresenter.new(job_config)
+      actual_json = presenter.to_hash(url_builder: UrlBuilder.new)
+      expect(actual_json[:run_instance_count]).to eq('all')
+    end
+
+    it 'should serialize run_instance_count with value `nil` when runOnAllAgents is false and eunInstanceCount is unset' do
+      job_config = JobConfig.new
+
+      presenter   = ApiV4::Shared::Stages::JobRepresenter.new(job_config)
+      actual_json = presenter.to_hash(url_builder: UrlBuilder.new)
+      expect(actual_json[:run_instance_count]).to be(nil)
+    end
+
+    it 'should serialize timeout with value set to `10` to `10`' do
+      job_config = JobConfig.new
+      job_config.setTimeout('10')
+
+      presenter   = ApiV4::Shared::Stages::JobRepresenter.new(job_config)
+      actual_json = presenter.to_hash(url_builder: UrlBuilder.new)
+      expect(actual_json[:timeout]).to be(10)
+    end
+
+    it 'should serialize timeout with value `0` to `never`' do
+      job_config = JobConfig.new
+      job_config.setTimeout('0')
+
+      presenter   = ApiV4::Shared::Stages::JobRepresenter.new(job_config)
+      actual_json = presenter.to_hash(url_builder: UrlBuilder.new)
+      expect(actual_json[:timeout]).to eq('never')
+    end
+
+    it 'should serialize timeout with value `nil` to `default`' do
+      job_config = JobConfig.new
+      job_config.setTimeout(nil)
+
+      presenter   = ApiV4::Shared::Stages::JobRepresenter.new(job_config)
+      actual_json = presenter.to_hash(url_builder: UrlBuilder.new)
+      expect(actual_json[:timeout]).to eq(nil)
+    end
+
+    it 'should serialize job elastic_profile_id' do
+      job_config = JobConfig.new
+      job_config.setElasticProfileId('docker.unit-test')
+
+      presenter   = ApiV4::Shared::Stages::JobRepresenter.new(job_config)
+      actual_json = presenter.to_hash(url_builder: UrlBuilder.new)
+      expect(actual_json[:elastic_profile_id]).to eq('docker.unit-test')
+    end
+
+    def job_hash
+      {
+        name:                  'defaultJob',
+        run_instance_count:    3,
+        timeout:               100,
+        environment_variables: [
+                                 { secure: true, name: 'MULTIPLE_LINES', encrypted_value: com.thoughtworks.go.helper.JobConfigMother.jobConfig().variables.get(0).getEncryptedValue },
+                                 { secure: false, name: 'COMPLEX', value: 'This has very <complex> data' }
+                               ],
+        resources:             %w(Linux Java),
+        tasks:                 [
+                                 { type: 'ant', attributes: {working_directory: 'working-directory', build_file: 'build-file', target: 'target', run_if: [], on_cancel: nil} }
+                               ],
+        tabs:                  [
+                                 { name: 'coverage', path: 'Jcoverage/index.html' },
+                                 { name: 'something', path: 'something/path.html' }
+                               ],
+        artifacts:             [
+                                 { source: 'target/dist.jar', destination: 'pkg', type: 'build' },
+                                 { source: 'target/reports/**/*Test.xml', destination: 'reports', type: 'test' }
+                               ],
+
+        properties:            [{ name: 'coverage.class', source: 'target/emma/coverage.xml', xpath: "substring-before(//report/data/all/coverage[starts-with(@type,'class')]/@value, '%')" }]
+      }
+    end
+  end
+
+  describe :deserialize do
+    it 'should convert basic hash to Job' do
+      job_config = JobConfig.new
+      ApiV4::Shared::Stages::JobRepresenter.new(job_config).from_hash({
+                                                                name:    'some-job',
+                                                                timeout: '100',
+                                                              })
+      expect(job_config.name.to_s).to eq('some-job')
+      expect(job_config.timeout).to eq('100')
+    end
+
+    it 'should convert attribute run_instance_count with value `all` to Job' do
+      job_config = JobConfig.new
+      ApiV4::Shared::Stages::JobRepresenter.new(job_config).from_hash(run_instance_count: 'all')
+      expect(job_config.run_on_all_agents).to eq(true)
+      expect(job_config.run_instance_count).to eq(nil)
+    end
+
+    it 'should convert attribute run_instance_count with value `nil` to Job' do
+      job_config = JobConfig.new
+      ApiV4::Shared::Stages::JobRepresenter.new(job_config).from_hash(run_instance_count: nil)
+      expect(job_config.run_on_all_agents).to eq(false)
+      expect(job_config.run_instance_count).to eq(nil)
+    end
+
+    it 'should convert attribute run_instance_count with integer value `nil` to Job' do
+      job_config = JobConfig.new
+      ApiV4::Shared::Stages::JobRepresenter.new(job_config).from_hash(run_instance_count: '10')
+      expect(job_config.run_on_all_agents).to eq(false)
+      expect(job_config.run_instance_count).to eq('10')
+
+      job_config = JobConfig.new
+      ApiV4::Shared::Stages::JobRepresenter.new(job_config).from_hash(run_instance_count: 10)
+      expect(job_config.run_on_all_agents).to eq(false)
+      expect(job_config.run_instance_count).to eq('10')
+    end
+
+    it 'should convert attribute timeout with value `never` to Job with timeout `0`' do
+      job_config = JobConfig.new
+      ApiV4::Shared::Stages::JobRepresenter.new(job_config).from_hash(timeout: 'never')
+      expect(job_config.timeout).to eq('0')
+    end
+
+    it 'should convert attribute timeout with value `nil` to Job with timeout `nil`' do
+      job_config = JobConfig.new
+      ApiV4::Shared::Stages::JobRepresenter.new(job_config).from_hash(timeout: nil)
+      expect(job_config.timeout).to eq(nil)
+    end
+
+    it 'should convert attribute timeout with integer value `10` to Job with timeout `10`' do
+      job_config = JobConfig.new
+      ApiV4::Shared::Stages::JobRepresenter.new(job_config).from_hash(timeout: '10')
+      expect(job_config.timeout).to eq('10')
+
+      job_config = JobConfig.new
+      ApiV4::Shared::Stages::JobRepresenter.new(job_config).from_hash(timeout: 10)
+      expect(job_config.timeout).to eq('10')
+    end
+
+    it 'should convert basic hash with environment variable to Job' do
+      job_config            = JobConfig.new
+      environment_variables = [
+        {
+          name:   'USERNAME',
+          value:  'bob',
+          secure: true
+        },
+        {
+          name:   'API_KEY',
+          value:  'tOps3cret',
+          secure: false
+        }
+      ]
+
+      ApiV4::Shared::Stages::JobRepresenter.new(job_config).from_hash({ environment_variables: environment_variables })
+      expect(job_config.variables.map(&:name)).to eq(%w(USERNAME API_KEY))
+    end
+
+    it 'should convert basic hash with resources to Job' do
+      job_config = JobConfig.new
+
+      ApiV4::Shared::Stages::JobRepresenter.new(job_config).from_hash({ resources: %w(java linux) })
+      expect(job_config.resources.map(&:name)).to eq(%w(java linux))
+    end
+
+    it 'should convert basic hash with task to Job' do
+      job_config = JobConfig.new
+      task_hash  = { type: 'ant', attributes: { working_directory: 'working-directory', build_file: 'build-file', target: 'target' } }
+      ApiV4::Shared::Stages::JobRepresenter.new(job_config).from_hash({ tasks: [task_hash] })
+      expect(job_config.tasks.size).to eq(1)
+      expect(job_config.tasks.first.getTaskType).to eq('ant')
+      expect(job_config.tasks.first.getBuildFile).to eq('build-file')
+    end
+
+    it 'should  raise exception when invalid task type is passed' do
+      expect do
+        job_config = JobConfig.new
+        ApiV4::Shared::Stages::JobRepresenter.new(job_config).from_hash({ tasks: [{ type: 'invalid' }] })
+      end.to raise_error(ApiV4::UnprocessableEntity, /Invalid task type 'invalid'. It has to be one of /)
+    end
+
+    it 'should convert basic hash with tabs to Job' do
+      job_config = JobConfig.new
+      tab_hash   = [
+        {
+          name: 'coverage', path: 'Jcoverage/index.html' },
+        { name: 'something', path: 'something/path.html' }
+      ]
+      ApiV4::Shared::Stages::JobRepresenter.new(job_config).from_hash({ tabs: tab_hash })
+      expect(job_config.getTabs.map(&:name)).to eq(%w(coverage something))
+    end
+
+    it 'should convert basic hash with artifact to Job' do
+      job_config = JobConfig.new
+      artifacts  = [
+        { source: 'target/dist.jar', destination: 'pkg', type: 'build' },
+        { source: nil, destination: 'testoutput', type: 'test' }
+      ]
+
+      ApiV4::Shared::Stages::JobRepresenter.new(job_config).from_hash({ artifacts: artifacts })
+      expect(job_config.artifactPlans.map(&:dest)).to eq(%w(pkg testoutput))
+      expect(job_config.artifactPlans.map(&:getArtifactType).map(&:to_s)).to eq(%w(file unit))
+    end
+
+    it 'should raise exception when invalid artifact type is passed' do
+      expect do
+        job_config = JobConfig.new
+        ApiV4::Shared::Stages::JobRepresenter.new(job_config).from_hash({ artifacts: [{ type: 'invalid' }] })
+      end.to raise_error(ApiV4::UnprocessableEntity, /Invalid Artifact type: 'invalid'. It has to be one of/)
+    end
+
+    it 'should convert basic hash with properties to Job' do
+      job_config = JobConfig.new
+      properties = [
+        {
+          name:   'coverage.class',
+          source: 'target/emma/coverage.xml',
+          xpath:  "substring-before(//report/data/all/coverage[starts-with(@type,'class')]/@value, '%')"
+        }
+      ]
+
+      ApiV4::Shared::Stages::JobRepresenter.new(job_config).from_hash({ properties: properties })
+      expect(job_config.getProperties.map(&:name)).to eq(['coverage.class'])
+    end
+
+    it 'should convert attribute elastic_profile_id to Job with elastic_profile_id' do
+      job_config = JobConfig.new
+      ApiV4::Shared::Stages::JobRepresenter.new(job_config).from_hash({elastic_profile_id: 'docker.unit-test'})
+
+      expect(job_config.getElasticProfileId).to eq('docker.unit-test')
+    end
+
+    it 'should convert attribute elastic_profile_id to Job with `nil` elastic_profile_id' do
+      job_config = JobConfig.new
+      ApiV4::Shared::Stages::JobRepresenter.new(job_config).from_hash({})
+
+      expect(job_config.getElasticProfileId).to eq(nil)
+    end
+  end
+
+  it 'should map errors' do
+    job_config = JobConfig.new
+    job_config.setRunInstanceCount(-2);
+    plans      = ArtifactPlans.new
+    plans.add(TestArtifactPlan.new(nil, '../foo'))
+    job_config.setArtifactPlans(plans)
+    job_config.setTasks(com.thoughtworks.go.config.Tasks.new(FetchTask.new(CaseInsensitiveString.new(''), CaseInsensitiveString.new(''), CaseInsensitiveString.new(''), nil, nil)))
+    job_config.setTabs(com.thoughtworks.go.config.Tabs.new(com.thoughtworks.go.config.Tab.new('coverage#1', '/Jcoverage/index.html'), com.thoughtworks.go.config.Tab.new('coverage#1', '/Jcoverage/path.html')))
+    job_config.validateTree(PipelineConfigSaveValidationContext.forChain(true, "grp", PipelineConfig.new, StageConfig.new, job_config))
+    presenter   = ApiV4::Shared::Stages::JobRepresenter.new(job_config)
+    actual_json = presenter.to_hash(url_builder: UrlBuilder.new)
+
+    expect(actual_json).to eq(job_hash_with_errors)
+  end
+
+  def job_hash_with_errors
+    {
+      name:                  nil,
+      run_instance_count:    -2,
+      timeout:               nil,
+      environment_variables: [],
+      resources:             [],
+      tasks:                 [
+                               {
+                                 type:       'fetch',
+                                 attributes: {pipeline: '', stage: '', job: '', is_source_a_file: false, source: nil, destination: '', run_if: [], on_cancel: nil},
+                                 errors:     {
+                                   job:    ['Job is a required field.'],
+                                   source: ['Should provide either srcdir or srcfile'],
+                                   stage:  ['Stage is a required field.']
+                                 }
+                               }
+                             ],
+      tabs:                  [
+                               {
+                                 errors: {
+                                   name: ["Tab name 'coverage#1' is not unique.",
+                                          "Tab name 'coverage#1' is invalid. This must be alphanumeric and can contain underscores and periods."
+                                         ]
+                                 },
+                                 name:   'coverage#1',
+                                 path:   '/Jcoverage/index.html'
+                               },
+                               {
+                                 errors: {
+                                   name: ["Tab name 'coverage#1' is not unique.",
+                                          "Tab name 'coverage#1' is invalid. This must be alphanumeric and can contain underscores and periods."
+                                         ]
+                                 },
+                                 name:   'coverage#1',
+                                 path:   '/Jcoverage/path.html'
+                               }
+                             ],
+      artifacts:             [
+                               {
+                                 errors:      {
+                                   source:      ["Job 'null' has an artifact with an empty source"],
+                                   destination: ["Invalid destination path. Destination path should match the pattern (([.]\\/)?[.][^. ]+)|([^. ].+[^. ])|([^. ][^. ])|([^. ])"]
+                                 },
+                                 source:      nil,
+                                 destination: "../foo",
+                                 type:        "test"}],
+      properties:            nil,
+      errors:                {
+        run_instance_count: ["'Run Instance Count' cannot be a negative number as it represents number of instances Go needs to spawn during runtime."],
+        name:               ["Name is a required field"]
+      }
+    }
+  end
+
+end

--- a/server/webapp/WEB-INF/rails.new/spec/presenters/api_v4/shared/stages/property_config_representer_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/presenters/api_v4/shared/stages/property_config_representer_spec.rb
@@ -1,5 +1,5 @@
 ##########################################################################
-# Copyright 2016 ThoughtWorks, Inc.
+# Copyright 2017 ThoughtWorks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/server/webapp/WEB-INF/rails.new/spec/presenters/api_v4/shared/stages/property_config_representer_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/presenters/api_v4/shared/stages/property_config_representer_spec.rb
@@ -1,0 +1,68 @@
+##########################################################################
+# Copyright 2016 ThoughtWorks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+
+require 'spec_helper'
+
+describe ApiV4::Shared::Stages::PropertyConfigRepresenter do
+  before :each do
+    @property = com.thoughtworks.go.config.ArtifactPropertiesGenerator.new('foo', 'target/emma/coverage.xml', 'substring-before(//report/data/all/coverage[starts-with(@type,class)]/@value, %)')
+  end
+
+  it 'should serialize property' do
+    presenter = ApiV4::Shared::Stages::PropertyConfigRepresenter.new(@property)
+    actual_json = presenter.to_hash(url_builder: UrlBuilder.new)
+
+    expect(actual_json).to eq(property_hash)
+  end
+
+  it 'should deserialize test artifact' do
+    actual    = com.thoughtworks.go.config.ArtifactPropertiesGenerator.new
+    presenter = ApiV4::Shared::Stages::PropertyConfigRepresenter.new(actual)
+    presenter.from_hash(property_hash)
+    expect(actual.getSrc).to eq(@property.getSrc)
+    expect(actual.getName).to eq(@property.getName)
+    expect(actual.getXpath).to eq(@property.getXpath)
+    expect(actual).to eq(@property)
+  end
+
+  it 'should map errors' do
+    @property.setName('')
+    @property.validateTree(PipelineConfigSaveValidationContext.forChain(true, "g", PipelineConfig.new, StageConfig.new, JobConfig.new))
+    presenter   = ApiV4::Shared::Stages::PropertyConfigRepresenter.new(@property)
+    actual_json = presenter.to_hash(url_builder: UrlBuilder.new)
+
+    expect(actual_json).to eq(property_with_errors)
+  end
+
+  def property_hash
+    {
+        name: 'foo',
+        source: 'target/emma/coverage.xml',
+        xpath: 'substring-before(//report/data/all/coverage[starts-with(@type,class)]/@value, %)'
+    }
+  end
+
+  def property_with_errors
+    {
+        name: '',
+        source: 'target/emma/coverage.xml',
+        xpath: 'substring-before(//report/data/all/coverage[starts-with(@type,class)]/@value, %)',
+        errors:      {
+            name:      ["Invalid property name ''. This must be alphanumeric and can contain underscores and periods (however, it cannot start with a period). The maximum allowed length is 255 characters."]
+        }
+    }
+  end
+end

--- a/server/webapp/WEB-INF/rails.new/spec/presenters/api_v4/shared/stages/stage_authorization_representer_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/presenters/api_v4/shared/stages/stage_authorization_representer_spec.rb
@@ -1,5 +1,5 @@
 ##########################################################################
-# Copyright 2016 ThoughtWorks, Inc.
+# Copyright 2017 ThoughtWorks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/server/webapp/WEB-INF/rails.new/spec/presenters/api_v4/shared/stages/stage_authorization_representer_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/presenters/api_v4/shared/stages/stage_authorization_representer_spec.rb
@@ -1,0 +1,48 @@
+##########################################################################
+# Copyright 2016 ThoughtWorks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+
+require 'spec_helper'
+
+describe ApiV4::Shared::Stages::StageAuthorizationRepresenter do
+  it 'should render stage authorization with hal representation' do
+    presenter = ApiV4::Shared::Stages::StageAuthorizationRepresenter.new(get_admins_config)
+    actual_json = presenter.to_hash(url_builder: UrlBuilder.new)
+
+    expect(actual_json).to eq(stage_authorization_hash)
+  end
+
+  it "should convert from document to AdminsConfig" do
+    admins_config = com.thoughtworks.go.config.AdminsConfig.new
+
+    ApiV4::Shared::Stages::StageAuthorizationRepresenter.new(admins_config).from_hash(stage_authorization_hash)
+
+    expected = get_admins_config
+    expect(admins_config).to eq(expected)
+  end
+
+  def get_admins_config
+    com.thoughtworks.go.config.AdminsConfig.new(
+      com.thoughtworks.go.config.AdminRole.new(com.thoughtworks.go.config.CaseInsensitiveString.new('admin_role')),
+      com.thoughtworks.go.config.AdminUser.new(com.thoughtworks.go.config.CaseInsensitiveString.new('admin_user')))
+  end
+
+  def stage_authorization_hash
+    {
+      roles: ['admin_role'],
+      users: ['admin_user']
+    }
+  end
+end

--- a/server/webapp/WEB-INF/rails.new/spec/presenters/api_v4/shared/stages/stage_representer_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/presenters/api_v4/shared/stages/stage_representer_spec.rb
@@ -1,5 +1,5 @@
 ##########################################################################
-# Copyright 2016 ThoughtWorks, Inc.
+# Copyright 2017 ThoughtWorks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/server/webapp/WEB-INF/rails.new/spec/presenters/api_v4/shared/stages/stage_representer_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/presenters/api_v4/shared/stages/stage_representer_spec.rb
@@ -1,0 +1,188 @@
+##########################################################################
+# Copyright 2016 ThoughtWorks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+
+require 'spec_helper'
+
+describe ApiV4::Shared::Stages::StageRepresenter do
+  describe :serialize do
+    it 'should render stage with hal representation' do
+      presenter   = ApiV4::Shared::Stages::StageRepresenter.new(get_stage_config)
+      actual_json = presenter.to_hash(url_builder: UrlBuilder.new)
+      expect(actual_json).to eq(stage_hash)
+    end
+
+    def stage_hash
+      {
+        name:                    'stage1',
+        fetch_materials:         true,
+        clean_working_directory: false,
+        never_cleanup_artifacts: false,
+        approval:                {
+          type:          'success',
+          authorization: {
+            roles: [],
+            users: []
+          }
+        },
+        environment_variables:   [
+                                   {
+                                     secure:          true,
+                                     name:            'MULTIPLE_LINES',
+                                     encrypted_value: get_stage_config.variables.get(0).getEncryptedValue
+                                   },
+                                   {
+                                     secure: false,
+                                     name:   'COMPLEX',
+                                     value:  'This has very <complex> data'
+                                   }
+                                 ],
+        jobs:                    get_stage_config.getJobs().collect { |j| ApiV4::Shared::Stages::JobRepresenter.new(j).to_hash(url_builder: UrlBuilder.new) }
+      }
+    end
+
+  end
+
+  describe :deserialize do
+    it 'should convert basic hash to StageConfig' do
+      stage_config = StageConfig.new
+
+      ApiV4::Shared::Stages::StageRepresenter.new(stage_config).from_hash({name:                    'stage1',
+                                                                   fetch_materials:         true,
+                                                                   clean_working_directory: false,
+                                                                   never_cleanup_artifacts: false, })
+      expect(stage_config.name.to_s).to eq('stage1')
+      expect(stage_config.isFetchMaterials).to eq(true)
+    end
+
+    it 'should convert basic hash with Approval to StageConfig' do
+      stage_config = StageConfig.new
+
+      ApiV4::Shared::Stages::StageRepresenter.new(stage_config).from_hash({approval: {
+                                                                    type:          "manual",
+                                                                    authorization: {
+                                                                      roles: ["role1", "role2"],
+                                                                      users: ["user1", "user2"]
+                                                                    }}})
+      admins      = [
+        AdminRole.new(CaseInsensitiveString.new("role1")), AdminRole.new(CaseInsensitiveString.new("role2")),
+        AdminUser.new(CaseInsensitiveString.new("user1")), AdminUser.new(CaseInsensitiveString.new("user2"))].to_java(com.thoughtworks.go.domain.config.Admin)
+      auth_config = AuthConfig.new(admins)
+
+      approval = Approval.new(auth_config)
+      expect(stage_config.getApproval).to eq(approval)
+    end
+
+    it 'should convert basic hash with Environment variables to StageConfig' do
+      stage_config         = StageConfig.new
+      environment_variables={environment_variables: [
+                                                      {
+                                                        secure:          true,
+                                                        name:            'MULTIPLE_LINES',
+                                                        encrypted_value: get_stage_config.variables.get(0).getEncryptedValue
+                                                      },
+                                                      {
+                                                        secure: false,
+                                                        name:   'COMPLEX',
+                                                        value:  'This has very <complex> data'
+                                                      }
+                                                    ]}
+      ApiV4::Shared::Stages::StageRepresenter.new(stage_config).from_hash(environment_variables)
+      expect(stage_config.variables.map(&:name)).to eq(%w(MULTIPLE_LINES COMPLEX))
+    end
+
+    it 'should convert basic hash with Jobs to StageConfig' do
+      stage_config = StageConfig.new
+
+      ApiV4::Shared::Stages::StageRepresenter.new(stage_config).from_hash({jobs: [job_hash]})
+      expect(stage_config.getJobs.first).to eq(com.thoughtworks.go.helper.JobConfigMother.jobConfig())
+    end
+
+    def job_hash
+      {
+        name:                  'defaultJob',
+        run_on_all_agents:     false,
+        run_instance_count:    3,
+        timeout:               100,
+        environment_variables: [
+                                 {secure: true, name: 'MULTIPLE_LINES', encrypted_value: com.thoughtworks.go.helper.JobConfigMother.jobConfig().variables.get(0).getEncryptedValue},
+                                 {secure: false, name: 'COMPLEX', value: 'This has very <complex> data'}
+                               ],
+        resources:             %w(Linux Java),
+        tasks:                 [
+                                 {type: 'ant', attributes: {working_directory: 'working-directory', build_file: 'build-file', target: 'target'}}
+                               ],
+        tabs:                  [
+                                 {name: 'coverage', path: 'Jcoverage/index.html'},
+                                 {name: 'something', path: 'something/path.html'}
+                               ],
+        artifacts:             [
+                                 {source: 'target/dist.jar', destination: 'pkg', type: 'build'},
+                                 {source: 'target/reports/**/*Test.xml', destination: 'reports', type: 'test'}
+                               ],
+
+        properties:            [{name: 'coverage.class', source: 'target/emma/coverage.xml', xpath: "substring-before(//report/data/all/coverage[starts-with(@type,'class')]/@value, '%')"}]
+      }
+    end
+
+  end
+
+  it "should render errors" do
+    stage_config = StageConfigMother.stageConfigWithEnvironmentVariable("stage#1")
+    stage_config.getJobs().get(0).setTasks(com.thoughtworks.go.config.Tasks.new(FetchTask.new(CaseInsensitiveString.new(""),CaseInsensitiveString.new(""), CaseInsensitiveString.new(""),nil, nil )))
+    stage_config.addError('name','Invalid stage name')
+    presenter = ApiV4::Shared::Stages::StageRepresenter.new(stage_config)
+    actual_json = presenter.to_hash(url_builder: UrlBuilder.new)
+
+    expect(actual_json).to eq(stage_hash_with_errors(stage_config))
+  end
+
+
+  def stage_hash_with_errors(stage_config)
+    {
+      name:                    "stage#1",
+      fetch_materials:         true,
+      clean_working_directory: false,
+      never_cleanup_artifacts: false,
+      approval:                {
+        type:          "success",
+        authorization: {
+          roles: [],
+          users: []
+        }
+      },
+      environment_variables:   [
+                                 {
+                                   secure:          true,
+                                   name:            "MULTIPLE_LINES",
+                                   encrypted_value: stage_config.variables.get(0).getEncryptedValue
+                                 },
+                                 {
+                                   secure: false,
+                                   name:   "COMPLEX",
+                                   value:  "This has very <complex> data"
+                                 }
+                               ],
+      jobs:                    stage_config.getJobs().collect { |j| ApiV4::Shared::Stages::JobRepresenter.new(j).to_hash(url_builder: UrlBuilder.new) },
+      errors:                  {
+        name: ["Invalid stage name"]
+      }
+    }
+  end
+
+  def get_stage_config
+    StageConfigMother.stageConfigWithEnvironmentVariable("stage1")
+  end
+end

--- a/server/webapp/WEB-INF/rails.new/spec/presenters/api_v4/shared/stages/task_representer_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/presenters/api_v4/shared/stages/task_representer_spec.rb
@@ -1,5 +1,5 @@
 ##########################################################################
-# Copyright 2016 ThoughtWorks, Inc.
+# Copyright 2017 ThoughtWorks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/server/webapp/WEB-INF/rails.new/spec/presenters/api_v4/shared/stages/task_representer_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/presenters/api_v4/shared/stages/task_representer_spec.rb
@@ -1,0 +1,489 @@
+##########################################################################
+# Copyright 2016 ThoughtWorks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+
+require 'spec_helper'
+
+describe ApiV4::Shared::Stages::Tasks::TaskRepresenter do
+  include TaskMother
+
+  shared_examples_for 'tasks' do
+
+    describe :serialize do
+      it 'should render task with hal representation' do
+        presenter          = ApiV4::Shared::Stages::Tasks::TaskRepresenter.new(existing_task)
+        actual_json        = presenter.to_hash(url_builder: UrlBuilder.new)
+        expected_task_hash = task_hash
+        expect(actual_json).to eq(expected_task_hash)
+      end
+
+      it 'should render task with hal representation with run_if' do
+        run_if_config                            = [RunIfConfig::PASSED, RunIfConfig::FAILED, RunIfConfig::ANY].sample
+        presenter                                = ApiV4::Shared::Stages::Tasks::TaskRepresenter.new(with_run_if(run_if_config, existing_task))
+        actual_json                              = presenter.to_hash(url_builder: UrlBuilder.new)
+        expected_task_hash                       = task_hash
+        expected_task_hash[:attributes][:run_if] = [run_if_config.to_s]
+        expect(actual_json).to eq(expected_task_hash)
+      end
+
+      it 'should render task with hal representation with oncancel' do
+        on_cancel_task = ant_task('build.xml', 'package', 'hero/ka/directory')
+        existing_task.setCancelTask(on_cancel_task)
+        presenter                                   = ApiV4::Shared::Stages::Tasks::TaskRepresenter.new(existing_task)
+        actual_json                                 = presenter.to_hash(url_builder: UrlBuilder.new)
+        expected_task_hash                          = task_hash
+        expected_task_hash[:attributes][:on_cancel] = ApiV4::Shared::Stages::Tasks::OnCancelRepresenter.new(existing_task.getOnCancelConfig).to_hash(url_builder: UrlBuilder.new)
+        expect(actual_json).to eq(expected_task_hash)
+      end
+    end
+
+    describe :deserialize do
+      it 'should convert hash to Task' do
+        new_task = task_type.new
+
+        presenter = ApiV4::Shared::Stages::Tasks::TaskRepresenter.new(new_task)
+        presenter.from_hash(ApiV4::Shared::Stages::Tasks::TaskRepresenter.new(existing_task).to_hash(url_builder: UrlBuilder.new))
+        expect(new_task).to eq(existing_task)
+      end
+
+      it 'should convert hash with run_if to Task with run_if' do
+        new_task = task_type.new
+
+        run_if_config    = [RunIfConfig::PASSED, RunIfConfig::FAILED, RunIfConfig::ANY].sample
+        task_with_run_if = with_run_if(run_if_config, existing_task)
+
+        presenter = ApiV4::Shared::Stages::Tasks::TaskRepresenter.new(new_task)
+        presenter.from_hash(ApiV4::Shared::Stages::Tasks::TaskRepresenter.new(task_with_run_if).to_hash(url_builder: UrlBuilder.new))
+
+        expect(new_task).to eq(task_with_run_if)
+      end
+
+      it 'should convert hash with oncancel to Task with oncancel' do
+        on_cancel_task = ant_task('build.xml', 'package', 'hero/ka/directory')
+        existing_task.setCancelTask(on_cancel_task)
+
+        new_task = task_type.new
+
+        presenter = ApiV4::Shared::Stages::Tasks::TaskRepresenter.new(new_task)
+        presenter.from_hash(ApiV4::Shared::Stages::Tasks::TaskRepresenter.new(existing_task).to_hash(url_builder: UrlBuilder.new))
+
+        expect(new_task).to eq(existing_task)
+      end
+    end
+  end
+
+  describe :exec do
+    it_should_behave_like 'tasks'
+
+    def existing_task
+      @task ||= simple_exec_task_with_args_list
+    end
+
+    def task_type
+      ExecTask
+    end
+
+    def task_hash
+      {
+        type:       'exec',
+        attributes: {
+          command:           'ls',
+          arguments:         ['-l', '-a'],
+          working_directory: 'hero/ka/directory',
+          run_if:     [],
+          on_cancel:  nil
+        }
+      }
+    end
+
+    it 'should represent errors' do
+      task         = ExecTask.new()
+      task.setWorkingDirectory("../outside")
+      validation_context = double('ValidationContext')
+      validation_context.stub(:isWithinPipelines).and_return(true)
+      pipeline = PipelineConfigMother::createPipelineConfigWithStage("this_pipeline", "stage")
+      validation_context.stub(:getPipeline).and_return(pipeline)
+      validation_context.stub(:getStage).and_return(pipeline.first)
+      validation_context.stub(:getJob).and_return(pipeline.first.getJobs.first)
+      task.validateTree(validation_context)
+
+      presenter   = ApiV4::Shared::Stages::Tasks::TaskRepresenter.new(task)
+      actual_json = presenter.to_hash(url_builder: UrlBuilder.new)
+      expect(actual_json).to eq(errors_hash)
+      expect(errors_hash[:errors].keys.size).to eq(task.errors.size)
+    end
+
+    def errors_hash
+      {
+          type:       'exec',
+          attributes: { run_if: [], on_cancel: nil, command: "", working_directory: "../outside"},
+          errors: {
+            command: ["Command cannot be empty"],
+            workingDirectory: ["The path of the working directory for the custom command in job 'dev' in stage 'stage' of pipeline 'this_pipeline' is outside the agent sandbox."]
+          }
+      }
+    end
+  end
+
+  describe :ant do
+    it_should_behave_like 'tasks'
+
+    def existing_task
+      @task ||= ant_task('build.xml', 'package', 'hero/ka/directory')
+    end
+
+    def task_type
+      AntTask
+    end
+
+    def task_hash
+      {
+        type:       'ant',
+        attributes: {
+          working_directory: 'hero/ka/directory',
+          build_file:        'build.xml',
+          target:            'package',
+          on_cancel:         nil,
+          run_if:            []
+        }
+      }
+    end
+
+    def default_task_hash
+      {
+        type:       'ant',
+        attributes: {
+          working_directory: '',
+          build_file:        '',
+          target:            ' '
+        }
+      }
+    end
+
+    it 'should represent errors' do
+      task         = AntTask.new()
+      task.setWorkingDirectory("../outside")
+      validation_context = double('ValidationContext')
+      validation_context.stub(:isWithinPipelines).and_return(true)
+      pipeline = PipelineConfigMother::createPipelineConfigWithStage("this_pipeline", "stage")
+      validation_context.stub(:getPipeline).and_return(pipeline)
+      validation_context.stub(:getStage).and_return(pipeline.first)
+      validation_context.stub(:getJob).and_return(pipeline.first.getJobs.first)
+      task.validateTree(validation_context)
+
+      presenter   = ApiV4::Shared::Stages::Tasks::TaskRepresenter.new(task)
+      actual_json = presenter.to_hash(url_builder: UrlBuilder.new)
+      expect(actual_json).to eq(errors_hash)
+      expect(errors_hash[:errors].keys.size).to eq(task.errors.size)
+    end
+
+    it 'should represent the ant task attributes as null if blank' do
+      task = AntTask.new
+      ApiV4::Shared::Stages::Tasks::TaskRepresenter.new(task).from_hash(default_task_hash)
+      actual_json = ApiV4::Shared::Stages::Tasks::TaskRepresenter.new(task).to_hash(url_builder: UrlBuilder.new)
+      expect(task.getTarget).to eq(nil)
+      expect(task.getBuildFile).to eq(nil)
+      expect(task.workingDirectory).to eq(nil)
+      expect(actual_json).to eq({ type: 'ant',
+                                  attributes: {run_if: [], on_cancel: nil, working_directory: nil, build_file: nil, target: nil}
+                                })
+    end
+
+    def errors_hash
+      {
+          type:       'ant',
+          attributes: { run_if: [], on_cancel: nil, working_directory: "../outside", build_file: nil, target: nil},
+          errors: {
+            workingDirectory: ["Task of job 'dev' in stage 'stage' of pipeline 'this_pipeline' has path '../outside' which is outside the working directory."]
+          }
+      }
+    end
+  end
+
+  describe :nant do
+    it_should_behave_like 'tasks'
+
+    def task_type
+      NantTask
+    end
+
+    def existing_task
+      @task ||=nant_task('build.xml', 'package', 'hero/ka/directory')
+    end
+
+    def task_hash
+      {
+        type:       'nant',
+        attributes: {
+          build_file:        'build.xml',
+          target:            'package',
+          working_directory: 'hero/ka/directory',
+          nant_path:         nil,
+          run_if:     [],
+          on_cancel:  nil
+        }
+      }
+    end
+
+    def default_task_hash
+      {
+        type:       'nant',
+        attributes: {
+          working_directory: '',
+          build_file:        '',
+          target:            ' ',
+          nant_path:         ''
+        }
+      }
+    end
+
+    it 'should represent errors' do
+      task         = NantTask.new()
+      task.setWorkingDirectory("../outside")
+      validation_context = double('ValidationContext')
+      validation_context.stub(:isWithinPipelines).and_return(true)
+      pipeline = PipelineConfigMother::createPipelineConfigWithStage("this_pipeline", "stage")
+      validation_context.stub(:getPipeline).and_return(pipeline)
+      validation_context.stub(:getStage).and_return(pipeline.first)
+      validation_context.stub(:getJob).and_return(pipeline.first.getJobs.first)
+      task.validateTree(validation_context)
+
+      presenter   = ApiV4::Shared::Stages::Tasks::TaskRepresenter.new(task)
+      actual_json = presenter.to_hash(url_builder: UrlBuilder.new)
+      expect(actual_json).to eq(errors_hash)
+      expect(errors_hash[:errors].keys.size).to eq(task.errors.size)
+    end
+
+    it 'should represent the nant task attributes as null if blank' do
+      task = NantTask.new
+      ApiV4::Shared::Stages::Tasks::TaskRepresenter.new(task).from_hash(default_task_hash)
+      actual_json = ApiV4::Shared::Stages::Tasks::TaskRepresenter.new(task).to_hash(url_builder: UrlBuilder.new)
+      expect(task.getTarget).to eq(nil)
+      expect(task.getBuildFile).to eq(nil)
+      expect(task.workingDirectory).to eq(nil)
+      expect(actual_json).to eq({ type: 'nant',
+                                  attributes: {run_if: [], on_cancel: nil, working_directory: nil, build_file: nil, target: nil, nant_path: nil}
+                                })
+    end
+
+    def errors_hash
+      {
+          type:       'nant',
+          attributes: { run_if: [], on_cancel: nil, working_directory: "../outside", build_file: nil, target: nil, nant_path:nil},
+          errors: {
+            workingDirectory: ["Task of job 'dev' in stage 'stage' of pipeline 'this_pipeline' has path '../outside' which is outside the working directory."]
+          }
+      }
+    end
+  end
+
+  describe :rake do
+    it_should_behave_like 'tasks'
+
+    def existing_task
+      @task ||= rake_task('rakefile', 'package', 'hero/ka/directory')
+    end
+
+    def task_type
+      RakeTask
+    end
+
+    def task_hash
+      {
+        type:       'rake',
+        attributes: {
+          build_file:        'rakefile',
+          target:            'package',
+          working_directory: 'hero/ka/directory',
+          run_if:     [],
+          on_cancel:  nil
+        }
+      }
+    end
+
+    def default_task_hash
+      {
+        type: 'rake',
+        attributes: {
+          working_directory: '',
+          build_file: '',
+          target: ' ',
+          nant_path: ''
+        }
+      }
+    end
+
+    it 'should represent errors' do
+      task         = RakeTask.new()
+      task.setWorkingDirectory("../outside")
+      validation_context = double('ValidationContext')
+      validation_context.stub(:isWithinPipelines).and_return(true)
+      pipeline = PipelineConfigMother::createPipelineConfigWithStage("this_pipeline", "stage")
+      validation_context.stub(:getPipeline).and_return(pipeline)
+      validation_context.stub(:getStage).and_return(pipeline.first)
+      validation_context.stub(:getJob).and_return(pipeline.first.getJobs.first)
+      task.validateTree(validation_context)
+
+      presenter   = ApiV4::Shared::Stages::Tasks::TaskRepresenter.new(task)
+      actual_json = presenter.to_hash(url_builder: UrlBuilder.new)
+      expect(actual_json).to eq(errors_hash)
+      expect(errors_hash[:errors].keys.size).to eq(task.errors.size)
+    end
+
+    it 'should represent the rake task attributes as null if not provided' do
+      task = RakeTask.new
+      ApiV4::Shared::Stages::Tasks::TaskRepresenter.new(task).from_hash(default_task_hash)
+      actual_json = ApiV4::Shared::Stages::Tasks::TaskRepresenter.new(task).to_hash(url_builder: UrlBuilder.new)
+      expect(task.getTarget).to eq(nil)
+      expect(task.getBuildFile).to eq(nil)
+      expect(task.workingDirectory).to eq(nil)
+      expect(actual_json).to eq({type: 'rake',
+                                 attributes: {run_if: [], on_cancel: nil, working_directory: nil, build_file: nil, target: nil}
+                                })
+    end
+
+    def errors_hash
+      {
+          type:       'rake',
+          attributes: {run_if: [], on_cancel: nil, working_directory: "../outside", build_file: nil, target: nil},
+          errors: {
+            workingDirectory: ["Task of job 'dev' in stage 'stage' of pipeline 'this_pipeline' has path '../outside' which is outside the working directory."]
+          }
+
+      }
+    end
+  end
+
+  describe :fetch do
+
+    it_should_behave_like 'tasks'
+
+    def existing_task
+      @task ||= fetch_task
+    end
+
+    def task_type
+      FetchTask
+    end
+
+    it 'should represent errors' do
+      fetch_task         = FetchTask.new(CaseInsensitiveString.new('this_pipeline'), CaseInsensitiveString.new(''), CaseInsensitiveString.new(''), "../src", "../dest")
+      validation_context = double('ValidationContext')
+      validation_context.stub(:isWithinPipelines).and_return(true)
+      pipeline = PipelineConfigMother::createPipelineConfigWithStage("this_pipeline", "stage")
+      validation_context.stub(:getPipeline).and_return(pipeline)
+      validation_context.stub(:getStage).and_return(pipeline.first)
+      validation_context.stub(:getJob).and_return(pipeline.first.getJobs.first)
+      fetch_task.validateTree(validation_context)
+
+      presenter   = ApiV4::Shared::Stages::Tasks::TaskRepresenter.new(fetch_task)
+      actual_json = presenter.to_hash(url_builder: UrlBuilder.new)
+      expect(actual_json).to eq(errors_hash)
+      expect(errors_hash[:errors].keys.size).to eq(fetch_task.errors.size)
+    end
+
+    def errors_hash
+      {
+        type:       'fetch',
+        attributes: {pipeline: "this_pipeline", stage: "", job: "", is_source_a_file: true, source: "../src", destination: "../dest", run_if: [], on_cancel: nil},
+        errors:     {
+          job:   ['Job is a required field.'],
+          stage: ['Stage is a required field.'],
+          destination: ["Task of job 'dev' in stage 'stage' of pipeline 'this_pipeline' has dest path '../dest' which is outside the working directory."],
+          source: ["Task of job 'dev' in stage 'stage' of pipeline 'this_pipeline' has src path '../src' which is outside the working directory."]
+        }
+      }
+    end
+
+    def task_hash
+      {
+        type:       'fetch',
+        attributes: {
+          pipeline:         'pipeline',
+          stage:            'stage',
+          job:              'job',
+          source:           'src',
+          is_source_a_file: true,
+          destination:      'dest',
+          run_if:     [],
+          on_cancel:  nil
+        }
+      }
+    end
+
+  end
+
+  describe :pluggable do
+    it_should_behave_like 'tasks'
+
+    before(:each) do
+      task            = TaskMother::StubTask.new
+      simple_property = TaskConfigProperty.new('simple_key', 'value')
+      secure_property = TaskConfigProperty.new('secure_key', 'encrypted').with(com.thoughtworks.go.plugin.api.config.Property::SECURE, true)
+
+      task.config.add(simple_property)
+      task.config.add(secure_property)
+      task_preference = TaskPreference.new(task)
+
+      PluggableTaskConfigStore.store().setPreferenceFor("curl", task_preference);
+    end
+
+
+
+    def existing_task
+      @task ||= begin
+        config = [
+          ConfigurationProperty.new(ConfigurationKey.new('simple_key'), ConfigurationValue.new('value')),
+          ConfigurationProperty.new(ConfigurationKey.new('secure_key'), EncryptedConfigurationValue.new('encrypted'))
+        ]
+        plugin_task('curl', config)
+      end
+    end
+
+    def task_type
+      PluggableTask
+    end
+
+    def task_hash
+      {
+        type:       'pluggable_task',
+        attributes: {
+          plugin_configuration: {
+            id:      'curl',
+            version: '1.0'
+          },
+          configuration:        [
+                                  {
+                                    key:   'simple_key',
+                                    value: 'value'
+                                  },
+                                  {
+                                    key:             'secure_key',
+                                    encrypted_value: 'encrypted'
+                                  }
+                                ],
+          on_cancel:            nil,
+          run_if:               [],
+        }
+      }
+    end
+  end
+
+  it 'should raise error when de-serializing a type that does not exist' do
+    expect do
+      ApiV4::Shared::Stages::Tasks::TaskRepresenter.from_hash({type: :foo})
+    end.to raise_error(ApiV4::UnprocessableEntity, /Invalid task type 'foo'. It has to be one of/)
+  end
+end

--- a/server/webapp/WEB-INF/rails.new/spec/support/java_spec_imports.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/support/java_spec_imports.rb
@@ -112,4 +112,5 @@ module JavaSpecImports
   java_import com.thoughtworks.go.server.service.CheckConnectionSubprocessExecutionContext unless defined? CheckConnectionSubprocessExecutionContext
   java_import com.thoughtworks.go.config.remote.RepoConfigOrigin unless defined? RepoConfigOrigin
   java_import com.thoughtworks.go.config.remote.ConfigRepoConfig unless defined? ConfigRepoConfig
+  java_import com.thoughtworks.go.config.remote.FileConfigOrigin unless defined? FileConfigOrigin
 end


### PR DESCRIPTION
Add a origin attribute on pipeline config to show the origin of the pipeline
Origin could be: 
* cruise-config.xml (for pipelines defined locally)
* url/path to config-repository (for pipelines defined remotely).
   Example: `https://github.com/config-repos/repo1 at 858497bac97889dc8e912d47ec03c102c00099b7`