### PR TITLE
Fixed bugs with full-screen

### DIFF
--- a/server/webapp/WEB-INF/rails.new/app/assets/javascripts/lib/jquery-pinOnScroll.js
+++ b/server/webapp/WEB-INF/rails.new/app/assets/javascripts/lib/jquery-pinOnScroll.js
@@ -79,11 +79,6 @@
     }
   }
 
-  function overrideRequiredScroll(elem, opts) {
-    var newRequiredScroll = elem.offset().top - $(".application_nav").outerHeight(true) - $(".page_header").outerHeight(true);
-    opts.requiredScroll = newRequiredScroll;
-  }
-
   $.fn.pinOnScroll = function (opts) {
     this.each(function () {
       var elem = $(this);
@@ -110,9 +105,9 @@
         });
       })
 
-      $(window).on('resetPinOnScroll', function () {
-            if (opts.requiredScroll) {
-              overrideRequiredScroll(elem, opts);
+      $(window).on('resetPinOnScroll', function (e, eParams) {
+            if (eParams.calcRequiredScroll) {
+              opts.requiredScroll = eParams.calcRequiredScroll();
             }
             throttledUnFixElement(elem, opts);
             throttledFixElement(elem, opts);

--- a/server/webapp/WEB-INF/rails.new/app/assets/stylesheets/css/build_detail.scss
+++ b/server/webapp/WEB-INF/rails.new/app/assets/stylesheets/css/build_detail.scss
@@ -851,17 +851,34 @@ a.collapse-all {
   }
 
   #build-status-panel {
+    padding: 0px;
+    
     .build_detail_container {
-      position: absolute;
-      top: 0;
-      left: 0;
-      right: 0;
       margin: 0;
+
+      div.clear {
+        height: 0px;
+      }
+      .sub_tab_container_content {
+        padding: 0;
+      }
     }
 
-    .sub_tab_container_content {
-      padding: 0;
+    .build_detail_summary {
+      display: none;
     }
+
+    .sidebar_history {
+      display: none;
+    }
+
+    .sub_tabs_container {
+      display: none;
+    }
+
+   .console-area {
+      position: relative;
+   }
   }
 }
 
@@ -870,5 +887,9 @@ a.collapse-all {
 }
 
 .compress {
+  display: none;
+}
+
+#cruise_message_counts.hide {
   display: none;
 }

--- a/server/webapp/WEB-INF/vm/build_detail/build_detail_page.vm
+++ b/server/webapp/WEB-INF/vm/build_detail/build_detail_page.vm
@@ -185,8 +185,12 @@
   jQuery(function() {
     jQuery(document).on("click.fullScreen", '#full-screen', function () {
       jQuery(".content_wrapper_outer").toggleClass("full-screen");
-      jQuery("#cruise_message_counts").hide();
-      jQuery(window).trigger(jQuery.Event("resetPinOnScroll"));
+      jQuery("#cruise_message_counts").toggleClass("hide");
+      jQuery(window).trigger(jQuery.Event("resetPinOnScroll"), [{
+        calcRequiredScroll: function() {
+          return jQuery(".console-area").offset().top - jQuery("#header").outerHeight(true) - jQuery(".page_header").outerHeight(true);
+        }
+      }]);
     });
   });
 


### PR DESCRIPTION
Bug Fix - Errors disappear after enter full-screen

Bug Fix - Console action bar doesn't remained fixed to the top of the console area if enter full-screen after having scrolled.
Steps to recreate:
 - Open job details page 
 - Scroll to end of logs
 - Enter full-screen
 - Scroll up & console action bar disappears

Bug Fix - Console does not extend to the footer in full-screen for very short log
Steps to recreate:
 - Open job details page for very short log ([example](https://build.gocd.io/go/tab/build/detail/trigger/853/do-nothing/1/do-nothing))
 - Scroll to bottom of page
 - Enter full-screen
 - See space between end of console and beginning of footer