### PR TITLE
Fixing an issue with the bottom console action bar for short logs

### DIFF
--- a/server/webapp/WEB-INF/rails.new/app/assets/javascripts/lib/jquery-pinOnScroll.js
+++ b/server/webapp/WEB-INF/rails.new/app/assets/javascripts/lib/jquery-pinOnScroll.js
@@ -57,7 +57,8 @@
       applyStyle(parentElement, { "padding-top": element.height() });
     } else if (scroll >= options.requiredScroll && options.bottomLimit) {
       applyStyle(element, $.extend({}, styleAttrs, {
-        top: options.bottomLimit()
+        top: options.bottomLimit(),
+        width: parentElement.width()
       }));
     } else {
       clearStyles(element);

--- a/server/webapp/WEB-INF/rails.new/app/assets/stylesheets/new-theme.scss
+++ b/server/webapp/WEB-INF/rails.new/app/assets/stylesheets/new-theme.scss
@@ -1849,7 +1849,7 @@ a:link#link-to-this-page, a:visited#link-to-this-page {
 
     &.open #buildlist-container {
       position: absolute;
-      z-index: 1;
+      z-index: 101;
       top: 43px;
       bottom: 0;
       overflow: auto;


### PR DESCRIPTION
* It wasn't calculating its height correctly because it never had a change to be a static element
* Also increasing the z-index of the job history dropdown to ensure it covers the console action bars


Here's a screenshot of the issue with the bottom console action bar (loot at the bottom left of the console area. Notice how the bottom action bar isn't there, and the back to top text is to the left of the console area):
<img width="1440" alt="screen shot 2017-04-03 at 1 01 06 pm" src="https://cloud.githubusercontent.com/assets/5726224/24630992/9b9b269c-1873-11e7-93a0-b04e15221e7c.png">




Here's a screenshot of the job history dropdown before my changes:
<img width="1386" alt="before" src="https://cloud.githubusercontent.com/assets/5726224/24631048/d39162a0-1873-11e7-9e9a-e7057c47b43e.png">


After my changes:
<img width="1412" alt="after" src="https://cloud.githubusercontent.com/assets/5726224/24631050/d60d1402-1873-11e7-8166-df2836c29982.png">





