### PR TITLE
Pipeline config SPA toggle

### DIFF
--- a/server/webapp/WEB-INF/rails.new/app/views/layouts/single_page_app.html.erb
+++ b/server/webapp/WEB-INF/rails.new/app/views/layouts/single_page_app.html.erb
@@ -9,7 +9,7 @@
   <link rel="shortcut icon" href="<%= asset_path('cruise.ico') %>"/>
   <%= stylesheet_link_tag 'frameworks' %>
   <%= stylesheet_link_tag "single_page_apps/#{controller_name}" %>
-  <% if controller_name == 'pipeline_configs' %>
+  <% if controller_name == 'pipeline_configs' && params[:old_view] == 'true' %>
       <%= requirejs_include_tag 'single_page_apps/pipeline_configs' %>
   <% else %>
       <%= javascript_include_tag *webpack_asset_paths("single_page_apps/#{controller_name}") %>


### PR DESCRIPTION
* Render pipeline-config SPA using _mithril-1.1.1_ by default
* Use 'old_view=true' query param to switch the pipeline config page to be rendered using _mithril-0.2.5_