### PR TITLE
Fix broken pagination links on pipeline history page

### DIFF
--- a/server/webapp/WEB-INF/rails.new/app/assets/javascripts/pipeline.js
+++ b/server/webapp/WEB-INF/rails.new/app/assets/javascripts/pipeline.js
@@ -105,7 +105,7 @@ var BuildCause = Class.create({
         this._buildCauseKey = buildCauseKey;
     },
     _linkElementId: function(id){
-        return this._buildCauseKey + '-' + id + '-buildCause'; 
+        return this._buildCauseKey + '-' + id + '-buildCause';
     },
     hideOrShowBuildCause: function(id) {
         ExclusivePopup.create(this._linkElementId(id)).toggle();
@@ -287,8 +287,8 @@ var PipelinePage = Class.create({
         var start = (pageNumber - 1) * paginator.perPage;
         var url = contextPath + "/stageHistory.json?pipelineName="
                 + pipelineName + "&stageName=" + stageName + "&start=" + start;
-        dashboard_periodical_executer.setUrl(url);
-        dashboard_periodical_executer.fireNow();
+        dashboard_periodical_executor.setUrl(url);
+        dashboard_periodical_executor.fireNow();
     },
     fixIEZIndexBugs: function(zindex_seed) {
         if (zindex_seed) {
@@ -368,7 +368,7 @@ var PipelineActions = Class.create({
                     Confirm: 'true'
                 },
                 onComplete: function() {
-                    dashboard_periodical_executer.fireNow();
+                    dashboard_periodical_executor.fireNow();
                 }
             });
         }
@@ -391,7 +391,7 @@ var PipelineActions = Class.create({
                 Confirm: 'true'
             },
             onComplete: function() {
-                dashboard_periodical_executer.fireNow();
+                dashboard_periodical_executor.fireNow();
             },
             on406: function(transport) {
                 var json = transport.responseText.evalJSON();
@@ -437,7 +437,7 @@ var PipelineActions = Class.create({
                     Confirm: 'true'
                 },
                 onComplete: function() {
-                    dashboard_periodical_executer.fireNow();
+                    dashboard_periodical_executor.fireNow();
                 }
             });
         }
@@ -459,14 +459,14 @@ var PipelineActions = Class.create({
         if($(linkElement)){
             linkElement.addClassName('submiting-link');
         }
-        
+
         new Ajax.Request(url, {
             method: 'post',
             requestHeaders: {
                 Confirm: 'true'
             },
             onComplete: function() {
-                dashboard_periodical_executer.fireNow();
+                dashboard_periodical_executor.fireNow();
             }
         });
     },
@@ -504,7 +504,7 @@ var StageActions = Class.create({
                     Confirm: 'true'
                 },
                 onComplete: function() {
-                    dashboard_periodical_executer.fireNow();
+                    dashboard_periodical_executor.fireNow();
                 },
                 on401: function(transport) {
                     alert("Not authorized to approve this stage.");

--- a/server/webapp/WEB-INF/rails.new/app/assets/javascripts/pipeline_history.js
+++ b/server/webapp/WEB-INF/rails.new/app/assets/javascripts/pipeline_history.js
@@ -52,8 +52,8 @@ PipelineHistoryPage.prototype = {
     switchToPage: function(pipelineName, pageNumber) {
         var start = (pageNumber - 1) * paginator.perPage;
         var url = contextPath + "/pipelineHistory.json?pipelineName=" + pipelineName + "&start=" + start;
-        dashboard_periodical_executer.setUrl(url);
-        dashboard_periodical_executer.fireNow();
+        dashboard_periodical_executor.setUrl(url);
+        dashboard_periodical_executor.fireNow();
     },
     findLastStageNameFromConfiguration: function(stageConfigs) {
         this.lastStageName = stageConfigs[stageConfigs.length - 1].stageName;
@@ -155,8 +155,8 @@ PipelineHistoryPage.prototype = {
         return config.stages[stageIndex].isAutoApproved == 'true' ? "auto" : "manual";
     },
     getState: function(stageStatus){
-        return stageStatus.toLowerCase();        
-    },    
+        return stageStatus.toLowerCase();
+    },
     fixLayout: function(){
         var max_width = 0;
         $$('table').each(function(table){

--- a/server/webapp/WEB-INF/rails.new/app/assets/javascripts/pipeline_history_search.js
+++ b/server/webapp/WEB-INF/rails.new/app/assets/javascripts/pipeline_history_search.js
@@ -15,10 +15,10 @@ function applyLabelFilter() {
 // Filters histories that match the search text. Rerenders the view with histories that match the text
 function filterHistories(pipelineHistory, filter) {
     //Need to stop periodic executor to show only the pipelines matching the filter
-    dashboard_periodical_executer.stop();
+    dashboard_periodical_executor.stop();
     $('page_links').innerHTML = "";
 
-    var histories = pipelineHistory.groups[0].history;
+    var histories = pipelineHistory.groups[0] ? pipelineHistory.groups[0].history : [];
     var count = histories.length;
     if(count == 0) {
         jQuery('.pipeline-history-group').html("");
@@ -42,8 +42,8 @@ function removeLabelFilter() {
     jQuery('#search-message').text("");
     jQuery('#labelFilterClear').hide();
 
-    if(!dashboard_periodical_executer.is_execution_start)
-        dashboard_periodical_executer.start();
+    if(!dashboard_periodical_executor.is_execution_start)
+        dashboard_periodical_executor.start();
 }
 
 jQuery( document ).ready(function() {

--- a/server/webapp/WEB-INF/rails.new/spec/javascripts/dashboard_periodical_executor_spec.js
+++ b/server/webapp/WEB-INF/rails.new/spec/javascripts/dashboard_periodical_executor_spec.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  *************************GO-LICENSE-END**********************************/
 
-describe("dashboard_periodical_executer", function(){
+describe("dashboard_periodical_executor", function(){
     var dashboard_periodical_executor = new DashboardPeriodicalExecutor('pipelineStatus.json');
 
     beforeEach(function(){
@@ -278,16 +278,16 @@ describe("dashboard_periodical_executer", function(){
             invoked = true;
         }};
 
-        var pausable_dashboard_periodical_executer = new DashboardPeriodicalExecutor('pipelineStatus.json', function(data) {return data.pause;});
-        pausable_dashboard_periodical_executer.start();
+        var pausable_dashboard_periodical_executor = new DashboardPeriodicalExecutor('pipelineStatus.json', function(data) {return data.pause;});
+        pausable_dashboard_periodical_executor.start();
 
-        pausable_dashboard_periodical_executer.fireNow();
+        pausable_dashboard_periodical_executor.fireNow();
 
-        pausable_dashboard_periodical_executer.register(fakeOb);
-        pausable_dashboard_periodical_executer.start();
-        pausable_dashboard_periodical_executer.fireNow();
+        pausable_dashboard_periodical_executor.register(fakeOb);
+        pausable_dashboard_periodical_executor.start();
+        pausable_dashboard_periodical_executor.fireNow();
 
-        assertEquals(pausable_dashboard_periodical_executer.is_paused, true);
+        assertEquals(pausable_dashboard_periodical_executor.is_paused, true);
         assertFalse(invoked);
     });
 

--- a/server/webapp/WEB-INF/rails.new/spec/javascripts/pipeline_history_spec.js
+++ b/server/webapp/WEB-INF/rails.new/spec/javascripts/pipeline_history_spec.js
@@ -20,10 +20,16 @@ describe("pipeline_history", function () {
     beforeEach(function () {
         page = new PipelineHistoryPage();
         pipelineActions = new PipelineActions();
+        paginator = new Paginator();
+        contextPath = '';
+        dashboard_periodical_executor = new DashboardPeriodicalExecutor('pipelineHistory.json?pipelineName=up42');
     });
 
     afterEach(function () {
         pipelineActions = undefined;
+        paginator = undefined;
+        contextPath = undefined;
+        dashboard_periodical_executor = undefined;
     });
 
     it("testCompleteAutomatically", function () {
@@ -82,6 +88,13 @@ describe("pipeline_history", function () {
         assertFalse(page.isPipelineScheduleButtonEnabled(pipeline1Json));
     });
 
+    it("testShouldSwitchToPage", function () {
+      var pipelinesWithoutAnyBuildingStage = getPipelines()
+      var pipeline1Json = pipelinesWithoutAnyBuildingStage[0]
+      assertEquals(dashboard_periodical_executor.url, "/pipelineHistory.json?pipelineName=up42");
+      page.switchToPage(pipeline1Json.pipelineId, "1");
+      assertEquals(dashboard_periodical_executor.url, "//pipelineHistory.json?pipelineName=11&start=0");
+    });
 
     function getPipelines() {
         return [

--- a/server/webapp/WEB-INF/vm/shared/_footer.vm
+++ b/server/webapp/WEB-INF/vm/shared/_footer.vm
@@ -36,8 +36,8 @@
 
         if(FirebugDetector){
             FirebugDetector.check();
-            if(window.dashboard_periodical_executer){
-                dashboard_periodical_executer.register(FirebugDetector);
+            if(window.dashboard_periodical_executor){
+                dashboard_periodical_executor.register(FirebugDetector);
             }
         }
 


### PR DESCRIPTION
These links were broken due to change in the [dashboard_periodical_executor](https://github.com/gocd/gocd/blob/master/server/webapp/WEB-INF/vm/pipeline/pipeline_history.vm#L103) variable name.

Typo was fixed [here](https://github.com/gocd/gocd/pull/3199/files#diff-7a1f57562c328138c680e9254b136431L103)

