### PR TITLE
[Bug fix] Moving error/warnings box to be up in the navigation

### DIFF
--- a/server/webapp/WEB-INF/rails.new/app/assets/stylesheets/new-theme.scss
+++ b/server/webapp/WEB-INF/rails.new/app/assets/stylesheets/new-theme.scss
@@ -100,6 +100,26 @@ h4 {
 }
 
 .application_nav {
+  .error_messaging_counter {
+    float: right;
+    .cruise_messages {
+      position: static;
+      padding-top: 9px;
+
+      a {
+        border: initial;
+        border-radius: 4px;
+        background-color: #a50000;
+        font-weight: 700;
+        line-height: 11px;
+
+        span {
+          line-height: 11px;
+        }
+      }
+    }
+  }
+
   .tabs {
     margin-top:    0px;
     margin-bottom: 0;

--- a/server/webapp/WEB-INF/rails.new/app/assets/stylesheets/new-theme.scss
+++ b/server/webapp/WEB-INF/rails.new/app/assets/stylesheets/new-theme.scss
@@ -105,6 +105,7 @@ h4 {
     .cruise_messages {
       position: static;
       padding-top: 9px;
+      box-shadow: none;
 
       a {
         border: initial;

--- a/server/webapp/WEB-INF/vm/shared/_header.vm
+++ b/server/webapp/WEB-INF/vm/shared/_header.vm
@@ -136,8 +136,10 @@
                             #end
                         </li>
                       </ul>
-                      <div id="cruise_message_counts" class="cruise_messages"></div>
-                      <div id="cruise_message_body" style="display:none;" class="cruise_message_body"></div>
+                      <div class="error_messaging_counter">
+                        <div id="cruise_message_counts" class="cruise_messages"></div>
+                        <div id="cruise_message_body" style="display:none;" class="cruise_message_body"></div>
+                      </div>
                     </div>
                   #end
               </div>


### PR DESCRIPTION
These Changes have two benifits:
* These Changes make it more discoverable
* These Changes fix an issue with it overlapping wiht the "back to top" button on the console log (issues: #3363)

Screenshot:
<img width="1440" alt="error_warnings_box_position" src="https://cloud.githubusercontent.com/assets/5726224/24875964/c0b6ca2e-1dde-11e7-8544-1405acb8c260.png">


These changes were made with the advisement of @naveenbhaskar. There's a mockup in the issue