### PR TITLE
Fix broken Normal Edit Link (#3387)

### DIFF
--- a/server/webapp/WEB-INF/rails.new/spec/webpack/views/pipeline_configs/pipeline_config_widget_spec.js
+++ b/server/webapp/WEB-INF/rails.new/spec/webpack/views/pipeline_configs/pipeline_config_widget_spec.js
@@ -21,6 +21,7 @@ describe("PipelineConfigWidget", () => {
   const _             = require('lodash');
   const s             = require('string-plus');
   const simulateEvent = require('simulate-event');
+  const Modal         = require('views/shared/new_modal');
 
   require('jasmine-jquery');
 
@@ -70,12 +71,36 @@ describe("PipelineConfigWidget", () => {
   afterEach(() => {
     m.mount(root, null);
     m.redraw();
+    Modal.destroyAll();
   });
 
   function inputFieldFor(propName, modelType) {
     modelType = s.defaultToIfBlank(modelType, 'pipeline');
     return $root.find(`.pipeline input[data-model-type=${modelType}][data-prop-name=${propName}]`);
   }
+
+  it("should render normal edit button", () => {
+    expect($root.find("a.toggle-old-view")).toContainText("Normal Edit");
+  });
+
+  it("should show the proceed confirm modal when clicked on normal edit link", () => {
+    simulateEvent.simulate($root.find("a.toggle-old-view").get(0), 'click');
+    m.redraw();
+
+    expect($(".modal-title")).toContainText("Unsaved Changes");
+    expect($(".modal-content > p")).toContainText("'Proceed' will discard any unsaved data.");
+
+    expect($(".actions > a.secondary")).toContainText("Cancel");
+    expect($(".actions > a.primary")).toContainText("Proceed");
+  });
+
+  it("should contain the appropriate href link on proceed button", () => {
+    simulateEvent.simulate($root.find("a.toggle-old-view").get(0), 'click');
+    m.redraw();
+
+    const proceedButton = $(".actions > a.primary");
+    expect(proceedButton.attr('href')).toBe('/go/admin/pipelines/yourproject/general');
+  });
 
   it("should render the pipeline name", () => {
     expect($root.find('.pipeline .heading h1')).toHaveText('Pipeline configuation for pipeline yourproject');

--- a/server/webapp/WEB-INF/rails.new/webpack/views/pipeline_configs/pipeline_config_widget.js.msx
+++ b/server/webapp/WEB-INF/rails.new/webpack/views/pipeline_configs/pipeline_config_widget.js.msx
@@ -24,7 +24,7 @@ const Stream          = require('mithril/stream');
 const s               = require('string-plus');
 const ComponentMixins = require('helpers/mithril_component_mixins');
 const Pipeline        = require('models/pipeline_configs/pipeline');
-const Modal           = require('views/shared/modal');
+const Modal           = require('views/shared/new_modal');
 
 const ToggleViewWarning = {
   view (vnode) {
@@ -33,7 +33,7 @@ const ToggleViewWarning = {
         <p> 'Proceed' will discard any unsaved data.</p>
         <div class='actions'>
           <a class='button secondary' href="javascript:void(0)"
-             onclick={vnode.attrs.parentView.close.bind(vnode.attrs.parentView)}>Cancel</a>
+             onclick={vnode.attrs.modal.destroy.bind(vnode.attrs.modal)}>Cancel</a>
           <a class='button primary'
              href={['/go/admin/pipelines/', vnode.attrs.pipeline().name(), '/general'].join('')}>Proceed</a>
         </div>
@@ -59,11 +59,16 @@ const PipelineConfigWidget = function (options) {
 
       ComponentMixins.HasViewModel.call(this);
 
-      self.modal = new Modal({
-        subView: {component: ToggleViewWarning, args: {pipeline: self.pipeline}},
-        title:   'Unsaved Changes'
-      });
+      self.normalEditConfirm      = function () {
+        const modal = new Modal({
+          title:    'Unsaved Changes',
+          body:     () => (<ToggleViewWarning pipeline={self.pipeline} modal={modal}/>),
+          oncancel: () => modal.destroy(),
+          buttons:  () => []
+        });
 
+        modal.render();
+      };
       window.pipelineConfigWidget = Stream(this);
 
       self.setPipelineAndPreserveSelection = function (newPipeline) {
@@ -143,7 +148,7 @@ const PipelineConfigWidget = function (options) {
                   {pipeline.name()}
                 </h1>
                 <a class='toggle-old-view' href="javascript:void(0)"
-                   onclick={vnode.state.modal.open.bind(vnode.state.modal)}>Normal Edit</a>
+                   onclick={vnode.state.normalEditConfirm.bind(vnode.state)}>Normal Edit</a>
               </f.column>
               <f.column size={1}>
                 <f.button onclick={vnode.state.onSavePipeline.bind(vnode.state)}
@@ -195,7 +200,6 @@ const PipelineConfigWidget = function (options) {
             </f.column>
           </f.row>
           <f.row class={vnode.state.vm.pageSaveSpinner()}/>
-          {vnode.state.modal.view()}
         </form>
       );
     }


### PR DESCRIPTION
* Fix the broken link of normal edit page
* Make use of new_modal to render the confirm proceed modal
* Add a spec to verify the Normal edit link