### PR TITLE
Console log performance improvements

### DIFF
--- a/server/webapp/WEB-INF/rails.new/app/assets/javascripts/console_log_foldable_section.js
+++ b/server/webapp/WEB-INF/rails.new/app/assets/javascripts/console_log_foldable_section.js
@@ -78,10 +78,10 @@
     }
 
     function insertLine(cursor, prefix, line) {
-      var output = c("dd", {"class": "log-fs-line log-fs-line-" + ReverseTypes[prefix]});
+      var output = c("div", {"class": "log-fs-line log-fs-line-" + ReverseTypes[prefix]});
 
       formatContent(output, prefix, line);
-      cursor.write(output);
+      cursor.writeBody(output);
 
       return output;
     }
@@ -103,7 +103,7 @@
 
     // the internal cursor reference is the Node object to append new content.
     // sometimes this is the section element, and sometimes it is the "node" argument,
-    // which may be a DocumentFragment that
+    // which may be a DocumentFragment that is a continuation of an unclosed section.
     cursor = $.contains(node, section) ? section : node;
 
     function blankSectionElement() {
@@ -120,11 +120,16 @@
     }
 
     function cloneTo(newNode) {
+      if (section.body) newNode.body = section.body;
       return new SectionCursor(newNode, section);
     }
 
     function write(childNode) {
       cursor.appendChild(childNode);
+    }
+
+    function writeBody(childNode) {
+      cursor.body.appendChild(childNode);
     }
 
     function type() {
@@ -137,6 +142,8 @@
 
     function markMultiline() {
       if (!section.priv.multiline) {
+        section.body = cursor.body = c("dd", {class: "fs-multiline"});
+        cursor.appendChild(cursor.body);
         section.insertBefore(c("a", {class: "fa toggle"}), section.childNodes[0]);
         section.priv.multiline = true;
       }
@@ -235,6 +242,7 @@
     this.closeAndStartNew = closeAndStartNew;
 
     this.write = write;
+    this.writeBody = writeBody;
 
     this.element = getSection;
     this.cloneTo = cloneTo;

--- a/server/webapp/WEB-INF/rails.new/app/assets/javascripts/log_output_transformer.js
+++ b/server/webapp/WEB-INF/rails.new/app/assets/javascripts/log_output_transformer.js
@@ -18,7 +18,7 @@
 
   function LogOutputTransformer(consoleElement, Section, deferTransform) {
     var self = this, writer = new Section.LineWriter();
-    var currentSection, currentLine, lineNumber = 0;
+    var currentSection, currentLine;
     var deferred = [];
 
     var PREFIXED_LOG_LINE = /^([^|]{2})\|(\d\d:\d\d:\d\d\.\d\d\d) (.*)/, // parses prefix, timestamp, and line content
@@ -79,7 +79,6 @@
       resetBuffers();
 
       for (var i = 0, prefix, line, timestamp, len = logLines.length; i < len; i++) {
-        lineNumber++;
         rawLine = logLines[i];
         match = rawLine.match(PREFIXED_LOG_LINE);
 
@@ -122,7 +121,6 @@
           currentLine = writer.insertBasic(currentSection, line);
         }
 
-        currentLine.setAttribute("data-line", lineNumber);
         currentLine.setAttribute("data-timestamp", timestamp);
       }
 

--- a/server/webapp/WEB-INF/rails.new/app/assets/stylesheets/css/console-log.scss
+++ b/server/webapp/WEB-INF/rails.new/app/assets/stylesheets/css/console-log.scss
@@ -79,7 +79,7 @@ $CONSOLE_SETUP_ERR_WHITE: darken($CONSOLE_SETUP_ERR, 10%);
 }
 
 .foldable-section {
-  margin-left: 20px;
+  margin-left: 25px;
   position: relative;
 
   dd {
@@ -88,7 +88,7 @@ $CONSOLE_SETUP_ERR_WHITE: darken($CONSOLE_SETUP_ERR, 10%);
 
   .toggle {
     float: left;
-    margin-left: -9px;
+    margin-left: -11px;
     cursor: pointer;
     text-decoration: none;
     color: inherit;
@@ -110,32 +110,12 @@ $CONSOLE_SETUP_ERR_WHITE: darken($CONSOLE_SETUP_ERR, 10%);
     }
 
     .toggle {
-      margin-left: -11px;
+      margin-left: -13px;
     }
 
     .toggle:before {
       content: $fa-var-caret-down;
     }
-  }
-}
-
-.log-fs-line {
-  position: relative;
-  margin-left: 2.5rem;
-  padding-left: 1ex;
-
-  &:after {
-    position: absolute;
-    content: attr(data-line);
-    color: #666;
-    left: -2.5rem;
-    top: 0;
-    width: 2.5rem;
-    text-align: right;
-
-    white-space: nowrap;
-    text-overflow: ellipsis;
-    overflow: hidden;
   }
 }
 
@@ -178,7 +158,7 @@ dt.log-fs-line, dt.log-fs-line:before {
   &:before {
     @include fa-icon;
     position: absolute;
-    left: -25px;
+    left: -30px;
     top: 3px;
   }
 

--- a/server/webapp/WEB-INF/rails.new/app/assets/stylesheets/css/console-log.scss
+++ b/server/webapp/WEB-INF/rails.new/app/assets/stylesheets/css/console-log.scss
@@ -78,13 +78,17 @@ $CONSOLE_SETUP_ERR_WHITE: darken($CONSOLE_SETUP_ERR, 10%);
   }
 }
 
+.fs-multiline {
+  display: none;
+}
+
+.open .fs-multiline {
+  display: block;
+}
+
 .foldable-section {
   margin-left: 25px;
   position: relative;
-
-  dd {
-    display: none;
-  }
 
   .toggle {
     float: left;
@@ -105,10 +109,6 @@ $CONSOLE_SETUP_ERR_WHITE: darken($CONSOLE_SETUP_ERR, 10%);
 
 
   &.open {
-    dd {
-      display: block;
-    }
-
     .toggle {
       margin-left: -13px;
     }

--- a/server/webapp/WEB-INF/rails.new/spec/javascripts/console_log_foldable_section_spec.js
+++ b/server/webapp/WEB-INF/rails.new/spec/javascripts/console_log_foldable_section_spec.js
@@ -161,12 +161,19 @@
     });
 
     it("markMultiline prepends the toggle widget exactly once", function () {
+      assert(!el.body); // initially, there is no body wrapping element
+
       el.appendChild(c("dt", "a message"));
       fs.markMultiline();
-      // "the widget should be the first child"
+
+      // the widget should be the first child
       assertEquals(1, $(el).find(".toggle:first-child").length);
-      fs.markMultiline();
+
+      // the wrapper element should be set
+      assert(el.body instanceof Node);
+
       // subsequent invocations should not add more widgets; markMultiline() must be idempotent
+      fs.markMultiline();
       assertEquals(1, $(el).find(".toggle").length);
     });
 
@@ -266,12 +273,14 @@
     });
 
     it("LineWriter insertLine/Header handles ANSI color", function () {
+      fs.markMultiline(); // insertLine() requires a section body element
       var l = $(lw.insertLine(fs, t.OUT, "Starting \u001B[1;33;40mcolor"));
       assertEquals(1, l.find(".ansi-bright-yellow-fg.ansi-black-bg").length);
       assertEquals("color", l.find(".ansi-bright-yellow-fg.ansi-black-bg").text());
     });
 
     it("LineWriter insertLine", function () {
+      fs.markMultiline(); // insertLine() requires a section body element
       var l = $(lw.insertLine(fs, t.OUT, "Starting build"));
       assertEquals(l.is("dd.log-fs-line-OUT"));
     });

--- a/server/webapp/WEB-INF/rails.new/spec/javascripts/log_output_transformer_spec.js
+++ b/server/webapp/WEB-INF/rails.new/spec/javascripts/log_output_transformer_spec.js
@@ -62,9 +62,6 @@
         var timestamps = extractAttr(section.find(".log-fs-line"), "data-timestamp").join(",");
         assertEquals(["01:01:00.123", "01:02:00.123"].join(","), timestamps);
 
-        var lineNums = extractAttr(section.find(".log-fs-line"), "data-line").join(",");
-        assertEquals(["1", "2"].join(","), lineNums);
-
         output.find(".ts").remove(); // exclude timestamps so it's easier to assert content
         var actual = extractText(output.find(".log-fs-line-INFO"));
         assertEquals(["Starting build", "Build finished in no time!"].join("\n"), actual.join("\n")); // can't assertEquals() on arrays, so compare as strings


### PR DESCRIPTION
Remove line numbers - this has a significant impact on scrolling performance and expand/collapse performance. No measurable change to first render.

Wrap foldable section lines (except header line) in a separate element to improve CSS rule matching performance for expand/collapse. This improves CSS style calculations significantly. I saw a drop from 750 -> 120ms in style calc times on a 50,000 line log. Not the biggest contributor, but improvement is visually perceptible.