### PR TITLE
Update for the code of conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -9,4 +9,4 @@ Project maintainers have the right and responsibility to remove, edit, or reject
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by opening an issue or contacting one or more of the project maintainers.
 
-We promise to extend courtesy and respect to everyone involved in this project regardless of gender, gender identity, sexual orientation, ability or disability, ethnicity, religion, or level of experience.
+We promise to extend courtesy and respect to everyone involved in this project regardless of gender identity, sexual orientation, ability or disability, ethnicity, religion, or level of experience.


### PR DESCRIPTION
This PR removes the word gender from the following paragraph:

`
We promise to extend courtesy and respect to everyone involved in this project regardless of gender, gender identity, sexual orientation, ability or disability, ethnicity, religion, or level of experience.
`

Here's the paragraph with the word removed:

`
We promise to extend courtesy and respect to everyone involved in this project regardless of gender identity, sexual orientation, ability or disability, ethnicity, religion, or level of experience.
`

The reason I'm removing it is because it's tautological. Gender and gender identity are exactly the same thing. There's no real difference between the two except that gender is one word and gender identity is two words. They're entirely interchangeable.

Using the word gender as if it's different from gender identity is problematic because it implies that [cis](https://en.wikipedia.org/wiki/Cisgender) folks have genders, and trans folks only have gender identities. It sets up a dichotomy wherein trans folks' genders are some how less valid than that of cis folks. In other words, it's otherizing 

FYI, I'm trans
