### PR TITLE
Authorization verify connection API is more descriptive

### DIFF
--- a/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/authorization/AuthorizationExtension.java
+++ b/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/authorization/AuthorizationExtension.java
@@ -27,6 +27,7 @@ import com.thoughtworks.go.plugin.access.common.settings.PluginSettingsJsonMessa
 import com.thoughtworks.go.plugin.access.common.settings.PluginSettingsJsonMessageHandler1_0;
 import com.thoughtworks.go.plugin.api.response.validation.ValidationResult;
 import com.thoughtworks.go.plugin.domain.common.PluginConfiguration;
+import com.thoughtworks.go.plugin.domain.common.VerifyConnectionResponse;
 import com.thoughtworks.go.plugin.infra.PluginManager;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -94,20 +95,15 @@ public class AuthorizationExtension extends AbstractExtension {
         });
     }
 
-    public ValidationResult verifyConnection(final String pluginId, final Map<String, String> configuration) {
-        ValidationResult validationResult = validateAuthConfig(pluginId, configuration);
-        if (!validationResult.isSuccessful()) {
-            return validationResult;
-        }
-
-        return pluginRequestHelper.submitRequest(pluginId, REQUEST_VERIFY_CONNECTION, new DefaultPluginInteractionCallback<ValidationResult>() {
+    public VerifyConnectionResponse verifyConnection(final String pluginId, final Map<String, String> configuration) {
+        return pluginRequestHelper.submitRequest(pluginId, REQUEST_VERIFY_CONNECTION, new DefaultPluginInteractionCallback<VerifyConnectionResponse>() {
             @Override
             public String requestBody(String resolvedExtensionVersion) {
                 return getMessageConverter(resolvedExtensionVersion).verifyConnectionRequestBody(configuration);
             }
 
             @Override
-            public ValidationResult onSuccess(String responseBody, String resolvedExtensionVersion) {
+            public VerifyConnectionResponse onSuccess(String responseBody, String resolvedExtensionVersion) {
                 return getMessageConverter(resolvedExtensionVersion).getVerifyConnectionResultFromResponseBody(responseBody);
             }
         });

--- a/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/authorization/AuthorizationMessageConverter.java
+++ b/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/authorization/AuthorizationMessageConverter.java
@@ -22,6 +22,7 @@ import com.thoughtworks.go.plugin.access.authentication.models.User;
 import com.thoughtworks.go.plugin.access.authorization.models.AuthenticationResponse;
 import com.thoughtworks.go.plugin.api.response.validation.ValidationResult;
 import com.thoughtworks.go.plugin.domain.common.PluginConfiguration;
+import com.thoughtworks.go.plugin.domain.common.VerifyConnectionResponse;
 
 import java.util.List;
 import java.util.Map;
@@ -43,7 +44,7 @@ public interface AuthorizationMessageConverter {
 
     String getRoleConfigurationViewFromResponseBody(String responseBody);
 
-    ValidationResult getVerifyConnectionResultFromResponseBody(String responseBody);
+    VerifyConnectionResponse getVerifyConnectionResultFromResponseBody(String responseBody);
 
     String verifyConnectionRequestBody(Map<String, String> configuration);
 

--- a/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/authorization/AuthorizationMessageConverterV1.java
+++ b/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/authorization/AuthorizationMessageConverterV1.java
@@ -27,6 +27,7 @@ import com.thoughtworks.go.plugin.access.common.models.Image;
 import com.thoughtworks.go.plugin.access.common.models.PluginProfileMetadataKeys;
 import com.thoughtworks.go.plugin.api.response.validation.ValidationResult;
 import com.thoughtworks.go.plugin.domain.common.PluginConfiguration;
+import com.thoughtworks.go.plugin.domain.common.VerifyConnectionResponse;
 import org.apache.commons.collections.map.HashedMap;
 import org.apache.commons.lang.StringUtils;
 
@@ -77,8 +78,8 @@ public class AuthorizationMessageConverterV1 implements AuthorizationMessageConv
     }
 
     @Override
-    public ValidationResult getVerifyConnectionResultFromResponseBody(String responseBody) {
-        return getPluginConfigurationValidationResultFromResponseBody(responseBody);
+    public VerifyConnectionResponse getVerifyConnectionResultFromResponseBody(String responseBody) {
+        return com.thoughtworks.go.plugin.access.authorization.models.VerifyConnectionResponse.fromJSON(responseBody).response();
     }
 
     @Override

--- a/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/authorization/models/VerifyConnectionResponse.java
+++ b/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/authorization/models/VerifyConnectionResponse.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2017 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.plugin.access.authorization.models;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.SerializedName;
+import com.thoughtworks.go.plugin.access.common.handler.JSONResultMessageHandler;
+import com.thoughtworks.go.plugin.api.response.validation.ValidationError;
+import com.thoughtworks.go.plugin.api.response.validation.ValidationResult;
+
+public class VerifyConnectionResponse {
+    private static final Gson GSON = new GsonBuilder().excludeFieldsWithoutExposeAnnotation().create();
+
+    @Expose
+    @SerializedName("status")
+    private final Status status;
+    @Expose
+    @SerializedName("message")
+    private final String message;
+
+    private ValidationResult validationResult;
+
+    public VerifyConnectionResponse(Status status, String message) {
+        this.status = status;
+        this.message = message;
+    }
+
+    public static VerifyConnectionResponse fromJSON(String json) {
+        VerifyConnectionResponse response = GSON.fromJson(json, VerifyConnectionResponse.class);
+        response.validationResult = validationResult(json);
+
+        return response;
+    }
+
+    public com.thoughtworks.go.plugin.domain.common.VerifyConnectionResponse response() {
+        return new com.thoughtworks.go.plugin.domain.common.VerifyConnectionResponse(status.getStatus(), message, result());
+    }
+
+    private com.thoughtworks.go.plugin.domain.common.ValidationResult result() {
+        if(validationResult == null) {
+            return null;
+        }
+
+        com.thoughtworks.go.plugin.domain.common.ValidationResult result = new com.thoughtworks.go.plugin.domain.common.ValidationResult();
+
+        for (ValidationError error : validationResult.getErrors()) {
+            result.addError(new com.thoughtworks.go.plugin.domain.common.ValidationError(error.getKey(), error.getMessage()));
+        }
+        return result;
+    }
+
+    private static ValidationResult validationResult(String json) {
+        JsonObject jsonObject = GSON.fromJson(json, JsonObject.class);
+
+        JsonElement errors = jsonObject.get("errors");
+
+        return errors != null ? new JSONResultMessageHandler().toValidationResult(errors.toString()) : null;
+    }
+
+    private enum Status {
+        @SerializedName("success")
+        success("success"),
+        @SerializedName("failure")
+        failure("failure"),
+        @SerializedName("validation-failed")
+        ValidationFailed("validation-failed");
+
+        private String status;
+
+        Status(String status) {
+            this.status = status;
+        }
+
+        public String getStatus() {
+            return status;
+        }
+    }
+}

--- a/plugin-infra/go-plugin-access/test/com/thoughtworks/go/plugin/access/authorization/AuthorizationExtensionTest.java
+++ b/plugin-infra/go-plugin-access/test/com/thoughtworks/go/plugin/access/authorization/AuthorizationExtensionTest.java
@@ -136,7 +136,7 @@ public class AuthorizationExtensionTest {
 
     @Test
     public void shouldTalkToPlugin_To_VerifyConnection() throws Exception {
-        String responseBody = "[]";
+        String responseBody = "{\"status\":\"success\"}";
         when(pluginManager.submitTo(eq(PLUGIN_ID), requestArgumentCaptor.capture())).thenReturn(new DefaultGoPluginApiResponse(SUCCESS_RESPONSE_CODE, responseBody));
         AuthorizationExtension authorizationExtensionSpy = spy(authorizationExtension);
 
@@ -144,7 +144,7 @@ public class AuthorizationExtensionTest {
 
         assertRequest(requestArgumentCaptor.getValue(), AuthorizationPluginConstants.EXTENSION_NAME, "1.0", REQUEST_VERIFY_CONNECTION, "{}");
 
-        verify(authorizationExtensionSpy).validateAuthConfig(PLUGIN_ID, Collections.emptyMap());
+        verify(authorizationExtensionSpy).verifyConnection(PLUGIN_ID, Collections.emptyMap());
     }
 
     @Test

--- a/plugin-infra/go-plugin-access/test/com/thoughtworks/go/plugin/access/authorization/models/CapabilitiesTest.java
+++ b/plugin-infra/go-plugin-access/test/com/thoughtworks/go/plugin/access/authorization/models/CapabilitiesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 ThoughtWorks, Inc.
+ * Copyright 2017 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,10 +14,8 @@
  * limitations under the License.
  */
 
-package com.thoughtworks.go.plugin.access.authorization;
+package com.thoughtworks.go.plugin.access.authorization.models;
 
-import com.thoughtworks.go.plugin.access.authorization.models.Capabilities;
-import com.thoughtworks.go.plugin.access.authorization.models.SupportedAuthType;
 import org.junit.Test;
 
 import static org.hamcrest.Matchers.is;

--- a/plugin-infra/go-plugin-access/test/com/thoughtworks/go/plugin/access/authorization/models/VerifyConnectionResponseTest.java
+++ b/plugin-infra/go-plugin-access/test/com/thoughtworks/go/plugin/access/authorization/models/VerifyConnectionResponseTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2017 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.plugin.access.authorization.models;
+
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.*;
+
+public class VerifyConnectionResponseTest {
+
+    @Test
+    public void shouldDeserializeSuccessResponseFromJSON() throws Exception {
+        String json = "{\n" +
+                "  \"status\": \"success\",\n" +
+                "  \"message\": \"Connection check passed\"\n" +
+                "}";
+
+        com.thoughtworks.go.plugin.domain.common.VerifyConnectionResponse response = VerifyConnectionResponse.fromJSON(json).response();
+
+        assertThat(response.getStatus(), is("success"));
+        assertThat(response.getMessage(), is("Connection check passed"));
+        assertNull(response.getValidationResult());
+    }
+
+    @Test
+    public void shouldDeserializeFailureResponseFromJSON() throws Exception {
+        String json = "{\n" +
+                "  \"status\": \"failure\",\n" +
+                "  \"message\": \"Connection check failed\"\n" +
+                "}";
+
+        com.thoughtworks.go.plugin.domain.common.VerifyConnectionResponse response = VerifyConnectionResponse.fromJSON(json).response();
+
+        assertThat(response.getStatus(), is("failure"));
+        assertThat(response.getMessage(), is("Connection check failed"));
+        assertNull(response.getValidationResult());
+    }
+
+    @Test
+    public void shouldDeserializeValidationFailedResponseFromJSON() throws Exception {
+        String json = "{\n" +
+                "  \"status\": \"validation-failed\",\n" +
+                "  \"message\": \"Validation failed\",\n" +
+                "  \"errors\": [\n" +
+                "    {" +
+                "      \"key\": \"url\",\n" +
+                "      \"message\": \"URL cannot be blank\"\n" +
+                "    },\n" +
+                "    {" +
+                "      \"key\": \"password\",\n" +
+                "      \"message\": \"Password cannot be blank\"\n" +
+                "    }\n" +
+                "  ]\n" +
+                "}";
+
+        com.thoughtworks.go.plugin.domain.common.VerifyConnectionResponse response = VerifyConnectionResponse.fromJSON(json).response();
+
+        assertThat(response.getStatus(), is("validation-failed"));
+        assertThat(response.getMessage(), is("Validation failed"));
+        assertFalse(response.getValidationResult().isSuccessful());
+        assertThat(response.getValidationResult().getErrors().get(0), is(new com.thoughtworks.go.plugin.domain.common.ValidationError("url", "URL cannot be blank")));
+        assertThat(response.getValidationResult().getErrors().get(1), is(new com.thoughtworks.go.plugin.domain.common.ValidationError("password", "Password cannot be blank")));
+    }
+}

--- a/plugin-infra/go-plugin-domain/src/com/thoughtworks/go/plugin/domain/common/ValidationError.java
+++ b/plugin-infra/go-plugin-domain/src/com/thoughtworks/go/plugin/domain/common/ValidationError.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2017 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.plugin.domain.common;
+
+public class ValidationError {
+    private static final String EMPTY_KEY = "";
+
+    private String key;
+    private String message;
+
+    public ValidationError(String key, String message) {
+        this.key = key;
+        this.message = message;
+    }
+
+    public ValidationError(String message) {
+        this.key = EMPTY_KEY;
+        this.message = message;
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        ValidationError that = (ValidationError) o;
+
+        if (key != null ? !key.equals(that.key) : that.key != null) return false;
+        return message != null ? message.equals(that.message) : that.message == null;
+
+    }
+
+    @Override
+    public int hashCode() {
+        int result = key != null ? key.hashCode() : 0;
+        result = 31 * result + (message != null ? message.hashCode() : 0);
+        return result;
+    }
+}

--- a/plugin-infra/go-plugin-domain/src/com/thoughtworks/go/plugin/domain/common/ValidationResult.java
+++ b/plugin-infra/go-plugin-domain/src/com/thoughtworks/go/plugin/domain/common/ValidationResult.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2017 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.plugin.domain.common;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ValidationResult {
+    private List<ValidationError> errors = new ArrayList<>();
+
+    public ValidationResult() {
+    }
+
+    public void addError(ValidationError validationError) {
+        errors.add(validationError);
+    }
+
+    public boolean isSuccessful() {
+        return errors.isEmpty();
+    }
+
+    public List<ValidationError> getErrors() {
+        return new ArrayList<>(errors);
+    }
+}

--- a/plugin-infra/go-plugin-domain/src/com/thoughtworks/go/plugin/domain/common/VerifyConnectionResponse.java
+++ b/plugin-infra/go-plugin-domain/src/com/thoughtworks/go/plugin/domain/common/VerifyConnectionResponse.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2017 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.plugin.domain.common;
+
+public class VerifyConnectionResponse {
+    private final String status;
+    private final String message;
+    private final ValidationResult validationResult;
+
+    public VerifyConnectionResponse(String status, String message, ValidationResult validationResult) {
+        this.status = status;
+        this.message = message;
+        this.validationResult = validationResult;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public ValidationResult getValidationResult() {
+        return validationResult;
+    }
+
+    public String getStatus() {
+
+        return status;
+    }
+}


### PR DESCRIPTION
* Verify Connection response has 'status', 'message' and
'errors'(required only for auth_config validation failure)