### PR TITLE
Make artifact upload its own foldable section

### DIFF
--- a/base/src/com/thoughtworks/go/util/command/TaggedStreamConsumer.java
+++ b/base/src/com/thoughtworks/go/util/command/TaggedStreamConsumer.java
@@ -17,7 +17,8 @@
 package com.thoughtworks.go.util.command;
 
 /**
- * Created by marqueslee on 2/15/17.
+ * Adds ability to annotate lines received by {@link StreamConsumer} so that console
+ * log lines can be meaningfully parsed.
  */
 public interface TaggedStreamConsumer extends StreamConsumer {
     String NOTICE = "##";
@@ -34,6 +35,9 @@ public interface TaggedStreamConsumer extends StreamConsumer {
     String TASK_CANCELLED = "^C";
     String JOB_PASS = "j0";
     String JOB_FAIL = "j1";
+    String PUBLISH = "ar";
+    String PUBLISH_ERR = "ae";
+    String COMPLETED = "ex";
 
     void taggedConsumeLine(String tag, String line);
 }

--- a/common/src/com/thoughtworks/go/buildsession/ArtifactsRepository.java
+++ b/common/src/com/thoughtworks/go/buildsession/ArtifactsRepository.java
@@ -16,11 +16,11 @@
 package com.thoughtworks.go.buildsession;
 
 import com.thoughtworks.go.domain.Property;
-import com.thoughtworks.go.util.command.StreamConsumer;
+import com.thoughtworks.go.util.command.TaggedStreamConsumer;
 
 import java.io.File;
 
 public interface ArtifactsRepository {
-    void upload(StreamConsumer console, File file, String destPath, String buildId);
+    void upload(TaggedStreamConsumer console, File file, String destPath, String buildId);
     void setProperty(Property property);
 }

--- a/common/src/com/thoughtworks/go/work/DefaultGoPublisher.java
+++ b/common/src/com/thoughtworks/go/work/DefaultGoPublisher.java
@@ -110,7 +110,7 @@ public class DefaultGoPublisher implements GoPublisher {
     }
 
     public void reportCompletedAction() {
-        reportAction("Job completed");
+        reportAction(COMPLETED, "Job completed");
     }
 
     public boolean isIgnored() {

--- a/common/test/unit/com/thoughtworks/go/domain/ArtifactsRepositoryStub.java
+++ b/common/test/unit/com/thoughtworks/go/domain/ArtifactsRepositoryStub.java
@@ -16,7 +16,7 @@
 package com.thoughtworks.go.domain;
 
 import com.thoughtworks.go.buildsession.ArtifactsRepository;
-import com.thoughtworks.go.util.command.StreamConsumer;
+import com.thoughtworks.go.util.command.TaggedStreamConsumer;
 
 import java.io.File;
 import java.io.IOException;
@@ -51,7 +51,7 @@ public class ArtifactsRepositoryStub implements ArtifactsRepository {
     }
 
     @Override
-    public void upload(StreamConsumer console, File file, String destPath, String buildId) {
+    public void upload(TaggedStreamConsumer console, File file, String destPath, String buildId) {
         if(this.error != null) {
             throw error;
         }

--- a/config/config-api/src/com/thoughtworks/go/config/ArtifactPlan.java
+++ b/config/config-api/src/com/thoughtworks/go/config/ArtifactPlan.java
@@ -122,7 +122,7 @@ public class ArtifactPlan extends PersistentObject implements Artifact {
         File[] files = scanner.getFiles();
         if (files.length == 0) {
             String message = "The rule [" + getSrc() + "] cannot match any resource under [" + rootPath + "]";
-            publisher.consumeLineWithPrefix(message);
+            publisher.taggedConsumeLineWithPrefix(GoPublisher.PUBLISH_ERR, message);
             throw new RuntimeException(message);
         }
         for (File file : files) {

--- a/server/webapp/WEB-INF/rails.new/app/assets/javascripts/console_log_foldable_section.js
+++ b/server/webapp/WEB-INF/rails.new/app/assets/javascripts/console_log_foldable_section.js
@@ -17,8 +17,9 @@
   "use strict";
 
   var Types = {
-    INFO: "##",
+    INFO: "##", COMPLETED: "ex",
     PREP: "pr", PREP_ERR: "pe",
+    PUBLISH: "ar", PUBLISH_ERR: "ae",
     TASK_START: "!!", OUT: "&1", ERR: "&2", PASS: "?0", FAIL: "?1", CANCELLED: "^C",
     CANCEL_TASK_START: "!x", CANCEL_TASK_PASS: "x0", CANCEL_TASK_FAIL: "x1",
     JOB_PASS: "j0", JOB_FAIL: "j1"
@@ -177,6 +178,10 @@
         section.classList.add("log-fs-status");
         section.classList.add("log-fs-job-status-failed");
         section.priv.errored = true;
+      } else if (Types.PUBLISH_ERR === prefix) { // we only care if it failed, so no need to detect a success status
+        section.classList.add("log-fs-status");
+        section.classList.add("log-fs-publish-failed");
+        section.priv.errored = true;
       }
     }
 
@@ -185,12 +190,16 @@
         section.priv.type = "info";
       } else if ([Types.PREP, Types.PREP_ERR].indexOf(prefix) > -1) {
         section.priv.type = "prep";
+      } else if ([Types.PUBLISH, Types.PUBLISH_ERR].indexOf(prefix) > -1) {
+        section.priv.type = "publish";
       } else if ([Types.TASK_START, Types.OUT, Types.ERR, Types.PASS, Types.FAIL, Types.CANCELLED].indexOf(prefix) > -1) {
         section.priv.type = "task";
       } else if ([Types.CANCEL_TASK_START, Types.CANCEL_TASK_PASS, Types.CANCEL_TASK_FAIL].indexOf(prefix) > -1) {
         section.priv.type = "cancel";
       } else if ([Types.JOB_PASS, Types.JOB_FAIL].indexOf(prefix) > -1) {
         section.priv.type = "result";
+      } else if (Types.COMPLETED === prefix) {
+        section.priv.type = "end";
       } else {
         section.priv.type = "info";
       }
@@ -206,6 +215,10 @@
 
       if (section.priv.type === "prep") {
         return [Types.PREP, Types.PREP_ERR].indexOf(prefix) > -1;
+      }
+
+      if (section.priv.type === "publish") {
+        return [Types.PUBLISH, Types.PUBLISH_ERR].indexOf(prefix) > -1;
       }
 
       if (section.priv.type === "task") {

--- a/server/webapp/WEB-INF/rails.new/app/assets/stylesheets/css/console-log.scss
+++ b/server/webapp/WEB-INF/rails.new/app/assets/stylesheets/css/console-log.scss
@@ -128,15 +128,15 @@ dt.log-fs-line, dt.log-fs-line:before {
   background: $CONSOLE_SECTION_HEADER;
 }
 
-.log-fs-line-PREP {
+.log-fs-line-PREP, .log-fs-line-PUBLISH {
   color: $CONSOLE_SETUP;
 }
 
-.log-fs-line-PREP_ERR {
+.log-fs-line-PREP_ERR, .log-fs-line-PUBLISH_ERR {
   color: $CONSOLE_SETUP_ERR;
 }
 
-.log-fs-line-INFO {
+.log-fs-line-INFO, .log-fs-line-COMPLETED {
   color: $CONSOLE_INFO;
 }
 
@@ -179,7 +179,7 @@ dt.log-fs-line, dt.log-fs-line:before {
   }
 }
 
-.log-fs-task-status-failed, .log-fs-job-status-failed {
+.log-fs-task-status-failed, .log-fs-job-status-failed, .log-fs-publish-failed {
   &:before {
     content: $fa-var-exclamation-circle;
     color: red;

--- a/server/webapp/WEB-INF/rails.new/spec/javascripts/console_log_foldable_section_spec.js
+++ b/server/webapp/WEB-INF/rails.new/spec/javascripts/console_log_foldable_section_spec.js
@@ -27,6 +27,12 @@
       node.appendChild(el);
     }
 
+    function detectPrefixesWhichArePartOfSection(section) {
+      return _.filter(t, function(val, key) {
+        return section.isPartOfSection(val);
+      }).sort();
+    }
+
     beforeEach(reset);
 
     it("assignType", function () {
@@ -38,6 +44,15 @@
 
       fs.assignType(t.PREP);
       assertEquals("prep", fs.type());
+
+      fs.assignType(t.PUBLISH);
+      assertEquals("publish", fs.type());
+
+      fs.assignType(t.COMPLETED);
+      assertEquals("end", fs.type());
+
+      fs.assignType(t.PUBLISH_ERR);
+      assertEquals("publish", fs.type());
 
       fs.assignType(t.CANCEL_TASK_START);
       assertEquals("cancel", fs.type());
@@ -72,92 +87,37 @@
 
     it("isPartOfSection info", function () {
       el.priv.type = "info";
-      assert(fs.isPartOfSection(t.INFO));
-      assert(!fs.isPartOfSection(t.PREP));
-      assert(!fs.isPartOfSection(t.PREP_ERR));
-      assert(!fs.isPartOfSection(t.TASK_START));
-      assert(!fs.isPartOfSection(t.OUT));
-      assert(!fs.isPartOfSection(t.ERR));
-      assert(!fs.isPartOfSection(t.PASS));
-      assert(!fs.isPartOfSection(t.FAIL));
-      assert(!fs.isPartOfSection(t.CANCELLED));
-      assert(!fs.isPartOfSection(t.CANCEL_TASK_START));
-      assert(!fs.isPartOfSection(t.CANCEL_TASK_PASS));
-      assert(!fs.isPartOfSection(t.CANCEL_TASK_FAIL));
-      assert(!fs.isPartOfSection(t.JOB_PASS));
-      assert(!fs.isPartOfSection(t.JOB_FAIL));
+      assert(_.isEqual([t.INFO], detectPrefixesWhichArePartOfSection(fs)));
     });
 
     it("isPartOfSection prep", function () {
       el.priv.type = "prep";
-      assert(!fs.isPartOfSection(t.INFO));
-      assert(fs.isPartOfSection(t.PREP));
-      assert(fs.isPartOfSection(t.PREP_ERR));
-      assert(!fs.isPartOfSection(t.TASK_START));
-      assert(!fs.isPartOfSection(t.OUT));
-      assert(!fs.isPartOfSection(t.ERR));
-      assert(!fs.isPartOfSection(t.PASS));
-      assert(!fs.isPartOfSection(t.FAIL));
-      assert(!fs.isPartOfSection(t.CANCELLED));
-      assert(!fs.isPartOfSection(t.CANCEL_TASK_START));
-      assert(!fs.isPartOfSection(t.CANCEL_TASK_PASS));
-      assert(!fs.isPartOfSection(t.CANCEL_TASK_FAIL));
-      assert(!fs.isPartOfSection(t.JOB_PASS));
-      assert(!fs.isPartOfSection(t.JOB_FAIL));
+      assert(_.isEqual([t.PREP, t.PREP_ERR].sort(), detectPrefixesWhichArePartOfSection(fs)));
+    });
+
+    it("isPartOfSection publish", function () {
+      el.priv.type = "publish";
+      assert(_.isEqual([t.PUBLISH, t.PUBLISH_ERR].sort(), detectPrefixesWhichArePartOfSection(fs)));
     });
 
     it("isPartOfSection task", function () {
       el.priv.type = "task";
-      assert(!fs.isPartOfSection(t.INFO));
-      assert(!fs.isPartOfSection(t.PREP));
-      assert(!fs.isPartOfSection(t.PREP_ERR));
-      assert(!fs.isPartOfSection(t.TASK_START));
-      assert(fs.isPartOfSection(t.OUT));
-      assert(fs.isPartOfSection(t.ERR));
-      assert(fs.isPartOfSection(t.PASS));
-      assert(fs.isPartOfSection(t.FAIL));
-      assert(fs.isPartOfSection(t.CANCELLED));
-      assert(!fs.isPartOfSection(t.CANCEL_TASK_START));
-      assert(!fs.isPartOfSection(t.CANCEL_TASK_PASS));
-      assert(!fs.isPartOfSection(t.CANCEL_TASK_FAIL));
-      assert(!fs.isPartOfSection(t.JOB_PASS));
-      assert(!fs.isPartOfSection(t.JOB_FAIL));
+      assert(_.isEqual([t.OUT, t.ERR, t.PASS, t.FAIL, t.CANCELLED].sort(), detectPrefixesWhichArePartOfSection(fs)));
     });
 
     it("isPartOfSection cancel", function () {
       el.priv.type = "cancel";
-      assert(!fs.isPartOfSection(t.INFO));
-      assert(!fs.isPartOfSection(t.PREP));
-      assert(!fs.isPartOfSection(t.PREP_ERR));
-      assert(!fs.isPartOfSection(t.TASK_START));
-      assert(fs.isPartOfSection(t.OUT));
-      assert(fs.isPartOfSection(t.ERR));
-      assert(!fs.isPartOfSection(t.PASS));
-      assert(!fs.isPartOfSection(t.FAIL));
-      assert(!fs.isPartOfSection(t.CANCELLED));
-      assert(!fs.isPartOfSection(t.CANCEL_TASK_START));
-      assert(fs.isPartOfSection(t.CANCEL_TASK_PASS));
-      assert(fs.isPartOfSection(t.CANCEL_TASK_FAIL));
-      assert(!fs.isPartOfSection(t.JOB_PASS));
-      assert(!fs.isPartOfSection(t.JOB_FAIL));
+      assert(_.isEqual([t.OUT, t.ERR, t.CANCEL_TASK_PASS, t.CANCEL_TASK_FAIL].sort(), detectPrefixesWhichArePartOfSection(fs)));
     });
 
     it("isPartOfSection result", function () {
       el.priv.type = "result";
-      assert(!fs.isPartOfSection(t.INFO));
-      assert(!fs.isPartOfSection(t.PREP));
-      assert(!fs.isPartOfSection(t.PREP_ERR));
-      assert(!fs.isPartOfSection(t.TASK_START));
-      assert(!fs.isPartOfSection(t.OUT));
-      assert(!fs.isPartOfSection(t.ERR));
-      assert(!fs.isPartOfSection(t.PASS));
-      assert(!fs.isPartOfSection(t.FAIL));
-      assert(!fs.isPartOfSection(t.CANCELLED));
-      assert(!fs.isPartOfSection(t.CANCEL_TASK_START));
-      assert(!fs.isPartOfSection(t.CANCEL_TASK_PASS));
-      assert(!fs.isPartOfSection(t.CANCEL_TASK_FAIL));
-      assert(!fs.isPartOfSection(t.JOB_PASS));
-      assert(!fs.isPartOfSection(t.JOB_FAIL));
+      assertEquals(0, detectPrefixesWhichArePartOfSection(fs).length);
+    });
+
+    it("isPartOfSection end", function () {
+      el.priv.type = "end";
+      assertEquals(0, detectPrefixesWhichArePartOfSection(fs).length);
     });
 
     it("markMultiline prepends the toggle widget exactly once", function () {


### PR DESCRIPTION
On some jobs, artifact upload can generate many, many lines and the user is not necessarily interested
unless there's a failure.

  - Add annotations/prefixes for artifact publish and artifact publish error
  - Add a prefix for job completion/end-of-log for good measure, which has the
    nice side effect of ensuring the artifact publish section collapses when
    successful