### PR TITLE
Add a loading message while waiting for first bytes of console logs

### DIFF
--- a/server/webapp/WEB-INF/rails.new/app/assets/javascripts/log_output_transformer.js
+++ b/server/webapp/WEB-INF/rails.new/app/assets/javascripts/log_output_transformer.js
@@ -32,6 +32,8 @@
       section.toggleClass("open");
     });
 
+    var loading = consoleElement.siblings(".console-log-loading");
+
     function injectFragment(fragment, parentElement) {
       if (!!fragment.childNodes.length) {
         window.requestAnimationFrame(function attachSubtree() {
@@ -49,6 +51,11 @@
     }
 
     function buildDomFromLogs(logLines) {
+      if (loading) {
+        loading.remove();
+        loading = null;
+      }
+
       var rawLine, match, continuedSection;
       var residual, queue;
 

--- a/server/webapp/WEB-INF/rails.new/app/assets/stylesheets/css/console-log.scss
+++ b/server/webapp/WEB-INF/rails.new/app/assets/stylesheets/css/console-log.scss
@@ -30,6 +30,8 @@ $CONSOLE_SETUP_WHITE: darken($CONSOLE_SETUP, 13%);
 $CONSOLE_SETUP_ERR: #A567A5;
 $CONSOLE_SETUP_ERR_WHITE: darken($CONSOLE_SETUP_ERR, 10%);
 
+$PROGRESS_BAR_BG_SIZE: 70px;
+
 .console-area {
   [data-collapsed] {
     display: none;
@@ -44,6 +46,38 @@ $CONSOLE_SETUP_ERR_WHITE: darken($CONSOLE_SETUP_ERR, 10%);
     display: inline-block;
     content: "Expand all"
   }
+}
+
+@-webkit-keyframes progress-bar-stripes {
+  from {
+    background-position: 0 0;
+  }
+  to {
+    background-position: $PROGRESS_BAR_BG_SIZE 0;
+  }
+}
+
+@keyframes progress-bar-stripes {
+  from {
+    background-position: 0 0;
+  }
+  to {
+    background-position: $PROGRESS_BAR_BG_SIZE 0;
+  }
+}
+
+.console-log-loading {
+  font-family: Monaco, Consolas, Inconsolata, "Liberation Mono", "Courier New", monospace;
+  font-size: 13px;
+  line-height: 19px;
+  color: white;
+  padding: 10px 20px;
+  text-align: center;
+
+  background-image: linear-gradient(-45deg, rgba(128, 128, 128, 0.2) 25%, transparent 25%, transparent 50%, rgba(128, 128, 128, 0.2) 50%, rgba(128, 128, 128, 0.2) 75%, transparent 75%, transparent);
+  background-size: $PROGRESS_BAR_BG_SIZE $PROGRESS_BAR_BG_SIZE;
+  -webkit-animation: progress-bar-stripes 1s linear infinite;
+  animation: progress-bar-stripes 1s linear infinite;
 }
 
 .buildoutput_pre {
@@ -228,6 +262,10 @@ dt.log-fs-line, dt.log-fs-line:before {
 }
 
 .white-theme {
+
+  .console-log-loading {
+    color: #000;
+  }
 
   dt.log-fs-line, dt.log-fs-line:before {
     background-color: $CONSOLE_SECTION_HEADER_WHITE;

--- a/server/webapp/WEB-INF/vm/build_detail/_build_output_raw.vm
+++ b/server/webapp/WEB-INF/vm/build_detail/_build_output_raw.vm
@@ -12,6 +12,7 @@
         <a class='change-theme' href="javascript:void(0);">Change theme</a>
     </div>
 </div>
+<div class="console-log-loading">Waiting for console logs&hellip;</div>
 <pre class="buildoutput_pre"></pre>
 <div class="console-footer-action-bar">
     <div>


### PR DESCRIPTION
On slow networks and/or large logs, it may take a relatively long time to receive the first bytes of the logs, so display a progress bar/loading message to inform the user.

Should address feedback about network in https://github.com/gocd/gocd/issues/3371