### PR TITLE
Add colored border to bottom of job details header

### DIFF
--- a/server/webapp/WEB-INF/rails.new/app/assets/javascripts/json_to_css.js
+++ b/server/webapp/WEB-INF/rails.new/app/assets/javascripts/json_to_css.js
@@ -56,6 +56,7 @@ JsonToCss.prototype = {
     update_build_detail_header : function(json) {
         var css_class_name = json.building_info.current_status.toLowerCase();
         this._renew_class_name('build_status', [css_class_name]);
+        this._renew_class_name('job_details_header', [css_class_name]);
     },
 
 	update_build_list : function(json, id, imgSrc) {

--- a/server/webapp/WEB-INF/rails.new/app/assets/stylesheets/css/build_detail.scss
+++ b/server/webapp/WEB-INF/rails.new/app/assets/stylesheets/css/build_detail.scss
@@ -624,6 +624,24 @@ a.collapse-all {
   }
 }
 
+.job_details.page_header {
+  border-bottom: 1px solid #000;
+}
+.job_details.page_header.building {
+  border-bottom: 3px solid #ffc11b;
+}
+.job_details.page_header.passed {
+  border-bottom: 3px solid #78C42D;
+}
+.job_details.page_header.cancelled {
+  border-bottom: 3px dotted #ffc11b;
+}
+.job_details.page_header.failed,
+.job_details.page_header.failing
+{
+  border-bottom: 3px solid #fa2d2d;
+}
+
 .build-status.cancelled {
   background-color: #ffc11b;
   color: #000;

--- a/server/webapp/WEB-INF/rails.new/spec/javascripts/json_to_css_spec.js
+++ b/server/webapp/WEB-INF/rails.new/spec/javascripts/json_to_css_spec.js
@@ -18,8 +18,12 @@ describe("json_to_css", function () {
     var json_to_css;
 
     beforeEach(function () {
-        setFixtures("<a id=\"project1_forcebuild\"></a>\n" +
-            "<a id=\"project1_config_panel\"></a>");
+        setFixtures(
+          "<a id=\"project1_forcebuild\"></a>\n" +
+          "<a id=\"project1_config_panel\"></a>\n" +
+          "<div id=\"build_status\"></div>\n" +
+          "<div id=\"job_details_header\"></div>\n"
+        );
     });
 
     beforeEach(function () {
@@ -41,5 +45,23 @@ describe("json_to_css", function () {
     it("test_should_return_force_build_disable_when_current_status_is_paused", function () {
         json_to_css.update_force_build(paused_json("project1"));
         assertTrue($("project1_forcebuild").className, $("project1_forcebuild").hasClassName("force_build_disabled"));
+    });
+
+    it("should add current status as a class to build status and job details header", function () {
+        json_to_css.update_build_detail_header(construct_new_json('job1', 'Failed', 'Failed'));
+        assertTrue($("build_status").hasClassName('failed'));
+        assertTrue($("job_details_header").hasClassName('failed'));
+    });
+
+    it("should replace old status with current status as a class to build status and job details header", function () {
+        $("build_status").className = "failed";
+        $("job_details_header").className = "failed";
+
+        json_to_css.update_build_detail_header(construct_new_json('job1', 'passed', 'Passed'));
+
+        assertTrue($("build_status").hasClassName('passed'));
+        assertFalse($("build_status").hasClassName('failed'));
+        assertTrue($("job_details_header").hasClassName('passed'));
+        assertFalse($("job_details_header").hasClassName('failed'));
     });
 });

--- a/server/webapp/WEB-INF/vm/shared/_job_details_breadcrumbs.vm
+++ b/server/webapp/WEB-INF/vm/shared/_job_details_breadcrumbs.vm
@@ -15,7 +15,7 @@
  *************************GO-LICENSE-END***********************************#
 
 #if($_page_title)
-<div class="job_details entity_title page_header">
+<div id="job_details_header" class="job_details entity_title page_header">
   <div class="row">
     <ul class="entity_title">
       <li class="name"><a href="$req.getContextPath()/tab/pipeline/history/$presenter.pipelineName"


### PR DESCRIPTION
Helps define where it ends and the rest of the page starts.

This is how the header looks today, on a failed build:
<img width="973" alt="2017_04_18_16-35-24_b" src="https://cloud.githubusercontent.com/assets/172235/25152403/d418aec4-2456-11e7-8131-991b0d02b912.png">

It's hard to see where it ends and the page starts. This PR changes that to be like this:
<img width="974" alt="2017_04_18_16-34-28_b" src="https://cloud.githubusercontent.com/assets/172235/25152400/d4123620-2456-11e7-956f-86a2b6fe2c91.png">

It also helps a bit when scrolling down:
<img width="975" alt="2017_04_18_16-35-05_b" src="https://cloud.githubusercontent.com/assets/172235/25152401/d414b152-2456-11e7-8121-3b0ba3491051.png">

When a job starts, it looks like this:
![2017_04_18_16-31-56_b](https://cloud.githubusercontent.com/assets/172235/25152398/d40bc29a-2456-11e7-9dcc-2b5b996befe9.png)

When a job is building, it looks like this:
<img width="976" alt="2017_04_18_16-33-21_b" src="https://cloud.githubusercontent.com/assets/172235/25152402/d414a054-2456-11e7-9703-1ea5ff06fc19.png">

When a job succeeds, it looks like this:
<img width="975" alt="2017_04_18_16-33-40_b" src="https://cloud.githubusercontent.com/assets/172235/25152397/d40a7f7a-2456-11e7-9955-dd585dd588c5.png">

When a job is cancelled, it looks like this:
<img width="974" alt="2017_04_18_16-34-04_b" src="https://cloud.githubusercontent.com/assets/172235/25152399/d40e0ee2-2456-11e7-8c39-5566629d6176.png">

The colors are copied over from the status shown on the right of the header (just below these changes).