### PR TITLE
Defaulting quick edit page to old view

### DIFF
--- a/server/resources/available.toggles
+++ b/server/resources/available.toggles
@@ -10,6 +10,11 @@
          "key": "pipeline_config_single_page_app_key",
          "description": "Enables the pipeline config single page application. Default: enabled.",
          "value": true
+      },
+      {
+         "key": "pipeline_config_spa_on_new_mithril_toggle_key",
+         "description": "Enables the new pipeline config single page application on mithril 1.0. Default: disabled.",
+         "value": false
       }
    ]
 }

--- a/server/src/com/thoughtworks/go/server/service/support/toggle/Toggles.java
+++ b/server/src/com/thoughtworks/go/server/service/support/toggle/Toggles.java
@@ -18,6 +18,7 @@ package com.thoughtworks.go.server.service.support.toggle;
 public class Toggles {
     public static String PIPELINE_COMMENT_FEATURE_TOGGLE_KEY = "pipeline_comment_feature_toggle_key";
     public static String PIPELINE_CONFIG_SINGLE_PAGE_APP = "pipeline_config_single_page_app_key";
+    public static String PIPELINE_CONFIG_SPA_ON_NEW_MITHRIL_TOGGLE_KEY = "pipeline_config_spa_on_new_mithril_toggle_key";
 
     private static FeatureToggleService service;
 

--- a/server/webapp/WEB-INF/rails.new/app/controllers/admin/pipeline_configs_controller.rb
+++ b/server/webapp/WEB-INF/rails.new/app/controllers/admin/pipeline_configs_controller.rb
@@ -28,6 +28,7 @@ module Admin
       @all_users     = user_service.allUsernames()
       @all_roles     = user_service.allRoleNames()
       @view_title    = "Edit Pipeline - #{params[:pipeline_name]}"
+      @enable_new_quick_edit_page = Toggles.isToggleOn(Toggles.PIPELINE_CONFIG_SPA_ON_NEW_MITHRIL_TOGGLE_KEY)
     end
 
     private

--- a/server/webapp/WEB-INF/rails.new/app/views/layouts/single_page_app.html.erb
+++ b/server/webapp/WEB-INF/rails.new/app/views/layouts/single_page_app.html.erb
@@ -9,10 +9,10 @@
   <link rel="shortcut icon" href="<%= asset_path('cruise.ico') %>"/>
   <%= stylesheet_link_tag 'frameworks' %>
   <%= stylesheet_link_tag "single_page_apps/#{controller_name}" %>
-  <% if controller_name == 'pipeline_configs' && params[:old_view] == 'true' %>
-      <%= requirejs_include_tag 'single_page_apps/pipeline_configs' %>
-  <% else %>
+  <% if (controller_name == 'pipeline_configs' && @enable_new_quick_edit_page) %>
       <%= javascript_include_tag *webpack_asset_paths("single_page_apps/#{controller_name}") %>
+  <% else %>
+      <%= requirejs_include_tag 'single_page_apps/pipeline_configs' %>
   <% end %>
   <%= csrf_meta_tags %>
 </head>


### PR DESCRIPTION
* Defaulting to quick_edit page on older mithril as the new page needs
  more fixes
* The new quick_edit page can be defaulted using the feature toggle
`pipeline_config_spa_on_new_mithril_toggle_key`