### PR TITLE
Console log publish artifact section bug fix

### DIFF
--- a/common/test/unit/com/thoughtworks/go/domain/TestArtifactPlanTest.java
+++ b/common/test/unit/com/thoughtworks/go/domain/TestArtifactPlanTest.java
@@ -63,7 +63,7 @@ public class TestArtifactPlanTest {
                 new TestArtifactPlan("some_random_path_that_does_not_exist",
                         "testoutput"));
         compositeTestArtifact.publish(mockArtifactPublisher, rootPath);
-        verify(mockArtifactPublisher).consumeLineWithPrefix("The Directory target/test/some_random_path_that_does_not_exist specified as a test artifact was not found. Please check your configuration");
+        verify(mockArtifactPublisher).taggedConsumeLineWithPrefix(DefaultGoPublisher.PUBLISH_ERR, "The Directory target/test/some_random_path_that_does_not_exist specified as a test artifact was not found. Please check your configuration");
     }
 
     @Test

--- a/config/config-api/src/com/thoughtworks/go/config/TestArtifactPlan.java
+++ b/config/config-api/src/com/thoughtworks/go/config/TestArtifactPlan.java
@@ -83,7 +83,7 @@ public class TestArtifactPlan extends ArtifactPlan {
             } else {
                 final String message = MessageFormat.format("The Directory {0} specified as a test artifact was not found."
                         + " Please check your configuration", FileUtil.normalizePath(source));
-                publisher.consumeLineWithPrefix(message);
+                publisher.taggedConsumeLineWithPrefix(GoPublisher.PUBLISH_ERR, message);
                 LOG.error(message);
             }
         }
@@ -108,7 +108,7 @@ public class TestArtifactPlan extends ArtifactPlan {
 
         } else {
             String message = "No files were found in the Test Results folders";
-            publisher.consumeLineWithPrefix(message);
+            publisher.taggedConsumeLineWithPrefix(GoPublisher.PUBLISH_ERR, message);
             LOG.warn(message);
         }
     }


### PR DESCRIPTION
Missed annotating the test artifact error lines as part of the publish artifact foldable section