### PR TITLE
Fix JS errors when navigating to single_page_app pages where controll…

### DIFF
--- a/server/webapp/WEB-INF/rails.new/app/views/layouts/single_page_app.html.erb
+++ b/server/webapp/WEB-INF/rails.new/app/views/layouts/single_page_app.html.erb
@@ -9,10 +9,10 @@
   <link rel="shortcut icon" href="<%= asset_path('cruise.ico') %>"/>
   <%= stylesheet_link_tag 'frameworks' %>
   <%= stylesheet_link_tag "single_page_apps/#{controller_name}" %>
-  <% if (controller_name == 'pipeline_configs' && @enable_new_quick_edit_page) %>
-      <%= javascript_include_tag *webpack_asset_paths("single_page_apps/#{controller_name}") %>
+  <% if (controller_name == 'pipeline_configs' && !@enable_new_quick_edit_page) %>
+    <%= requirejs_include_tag 'single_page_apps/pipeline_configs' %>
   <% else %>
-      <%= requirejs_include_tag 'single_page_apps/pipeline_configs' %>
+    <%= javascript_include_tag *webpack_asset_paths("single_page_apps/#{controller_name}") %>
   <% end %>
   <%= csrf_meta_tags %>
 </head>


### PR DESCRIPTION
…er_name != "pipeline_configs"

The previous logic caused pipeline_configs.js to load for other single_page_app pages, which would
throw errors as the script tried to perform operations on elements that did not exist.