### PR TITLE
Server now checks if the elastic agent is brought up by the same plug…

### DIFF
--- a/server/src/com/thoughtworks/go/server/service/ElasticAgentPluginService.java
+++ b/server/src/com/thoughtworks/go/server/service/ElasticAgentPluginService.java
@@ -20,8 +20,8 @@ import com.google.common.collect.Sets;
 import com.thoughtworks.go.config.elastic.ElasticProfile;
 import com.thoughtworks.go.domain.JobInstance;
 import com.thoughtworks.go.domain.JobPlan;
-import com.thoughtworks.go.plugin.access.elastic.models.AgentMetadata;
 import com.thoughtworks.go.plugin.access.elastic.ElasticAgentPluginRegistry;
+import com.thoughtworks.go.plugin.access.elastic.models.AgentMetadata;
 import com.thoughtworks.go.plugin.api.info.PluginDescriptor;
 import com.thoughtworks.go.plugin.infra.PluginManager;
 import com.thoughtworks.go.server.domain.ElasticAgentMetadata;
@@ -162,7 +162,7 @@ public class ElasticAgentPluginService implements JobStatusListener {
     }
 
     public boolean shouldAssignWork(ElasticAgentMetadata metadata, String environment, ElasticProfile elasticProfile) {
-        return elasticAgentPluginRegistry.shouldAssignWork(pluginManager.getPluginDescriptorFor(metadata.elasticPluginId()), toAgentMetadata(metadata), environment, elasticProfile.getConfigurationAsMap(true));
+        return elasticProfile.getPluginId().equals(metadata.elasticPluginId()) && elasticAgentPluginRegistry.shouldAssignWork(pluginManager.getPluginDescriptorFor(metadata.elasticPluginId()), toAgentMetadata(metadata), environment, elasticProfile.getConfigurationAsMap(true));
     }
 
     @Override


### PR DESCRIPTION
…in as was expected by the scheduled elastic job during assignment before asking the same to the plugin. Without this, a buggy plugin implementation for shouldAssignWork could cause agents brought up by a different plugin to start building jobs that were configured to use a different plugin