### PR TITLE
Remove console log's loading bar when build is finished

### DIFF
--- a/server/webapp/WEB-INF/rails.new/app/assets/javascripts/log_output_transformer.js
+++ b/server/webapp/WEB-INF/rails.new/app/assets/javascripts/log_output_transformer.js
@@ -34,6 +34,17 @@
 
     var loading = consoleElement.siblings(".console-log-loading");
 
+    function removeLoadingBar() {
+      if (loading) {
+        loading.remove();
+        loading = null;
+      }
+    }
+
+    consoleElement.on("consoleCompleted", function () {
+      removeLoadingBar();
+    });
+
     function injectFragment(fragment, parentElement) {
       if (!!fragment.childNodes.length) {
         window.requestAnimationFrame(function attachSubtree() {
@@ -68,10 +79,7 @@
     }
 
     function buildDomFromLogs(logLines) {
-      if (loading) {
-        loading.remove();
-        loading = null;
-      }
+      removeLoadingBar();
 
       var rawLine, match, continuedSection;
       var residual, queue;

--- a/server/webapp/WEB-INF/rails.new/spec/javascripts/log_output_transformer_spec.js
+++ b/server/webapp/WEB-INF/rails.new/spec/javascripts/log_output_transformer_spec.js
@@ -17,7 +17,7 @@
   "use strict";
 
   describe("LogOutputTransformerSpec", function LogOutputTransformerSpec() {
-      var transformer, output;
+      var transformer, output, fixture;
 
       function extractText(collection) {
         return _.map(collection, function (el) { return $(el).text(); });
@@ -32,7 +32,8 @@
       }
 
       beforeEach(function () {
-          setFixtures("<div id=\"console\"></div>");
+          setFixtures("<div id='fixture'><div class='console-log-loading'></div><div id=\"console\"></div></div>");
+          fixture = $('#fixture');
           transformer = new LogOutputTransformer(output = $("#console"), FoldableSection, false);
       });
 
@@ -67,6 +68,24 @@
         assertEquals(["Starting build", "Build finished in no time!"].join("\n"), actual.join("\n")); // can't assertEquals() on arrays, so compare as strings
       });
 
+      it("should remove loading bar when console has lines to show", function() {
+        var lines = [
+          "##|01:01:00.123 Starting build",
+          "##|01:02:00.123 Build finished in no time!"
+        ];
+
+        assertTrue(fixture.find(".console-log-loading").is(':visible'));
+        transformer.transform(lines);
+
+        assertFalse(fixture.find(".console-log-loading").is(':visible'));
+      });
+
+      it("should remove loading bar when build has finished and there is no output", function() {
+        assertTrue(fixture.find(".console-log-loading").is(':visible'));
+        output.trigger('consoleCompleted');
+
+        assertFalse(fixture.find(".console-log-loading").is(':visible'));
+      });
   });
 
 })(jQuery);


### PR DESCRIPTION
Remove it even if there's no data available (cancelled before assignment).