### PR TITLE
Server time on dashboard and history pages are now in the same format…

### DIFF
--- a/server/src/com/thoughtworks/go/server/presentation/models/PipelineHistoryJsonPresentationModel.java
+++ b/server/src/com/thoughtworks/go/server/presentation/models/PipelineHistoryJsonPresentationModel.java
@@ -152,7 +152,7 @@ public class PipelineHistoryJsonPresentationModel implements JsonAware {
             jsonMap.put("pipelineId", item.getId());
             jsonMap.put("label", item.getLabel());
             jsonMap.put("counterOrLabel", item.getPipelineIdentifier().instanceIdentifier());
-            jsonMap.put("scheduled_date", timeConverter.getHumanReadableString(item.getScheduledDate()));
+            jsonMap.put("scheduled_date", timeConverter.getHumanReadableStringWithTimeZone(item.getScheduledDate()));
             jsonMap.put("scheduled_timestamp", item.getScheduledDate() != null ? item.getScheduledDate().getTime() : null);
             jsonMap.put("buildCauseBy", item.getApprovedByForDisplay());
             jsonMap.put("modification_date", getModificationDate(item));

--- a/server/webapp/WEB-INF/rails.new/app/assets/stylesheets/css_sass/go-pages/pipeline.scss
+++ b/server/webapp/WEB-INF/rails.new/app/assets/stylesheets/css_sass/go-pages/pipeline.scss
@@ -163,6 +163,11 @@
   float:      left;
 }
 
+.pipeline_instance .schedule_time span.time{
+  display: block;
+  margin-top: 3px;
+}
+
 .highlight {
   background: #ff2;
 }

--- a/server/webapp/WEB-INF/rails.new/app/helpers/pipelines_helper.rb
+++ b/server/webapp/WEB-INF/rails.new/app/helpers/pipelines_helper.rb
@@ -30,7 +30,7 @@ module PipelinesHelper
 
   def trigger_message(actual_date_time, pim)
     if pim.class != com.thoughtworks.go.presentation.pipelinehistory.PreparingToScheduleInstance
-      "Triggered&nbsp;#{l.string('BY')}&nbsp;<span class='who'>#{h pim.getApprovedBy()}</span>&nbsp;on&nbsp;<span class='time'></span>"
+      "Triggered&nbsp;#{l.string('BY')}&nbsp;<span class='who'>#{h pim.getApprovedBy()}</span>"
     else
     ""
     end

--- a/server/webapp/WEB-INF/rails.new/app/views/environments/index.html.erb
+++ b/server/webapp/WEB-INF/rails.new/app/views/environments/index.html.erb
@@ -8,11 +8,11 @@
 <script type="text/javascript">
     Util.on_load(function() {
         var reformatAllBuildTimes = function() {
-          jQuery(".pipeline_instance .schedule_time").map(function(idx, timeDiv) {
-            var timestamp = parseInt(jQuery(timeDiv).attr("data"));
+          jQuery(".pipeline_instance .schedule_time span.time").each(function(idx, timeSpan) {
+            var timestamp = parseInt(jQuery(timeSpan).attr("data"));
             if (isNaN(timestamp)) return;
             var time = new Date(timestamp);
-            jQuery(timeDiv).find("span.time").text(moment(time).format('DD MMM YYYY HH:mm:ss'));
+            jQuery(timeSpan).text(moment(time).format('[On] DD MMM YYYY [at] HH:mm:ss [Local Time]'));
           });
         };
         reformatAllBuildTimes();

--- a/server/webapp/WEB-INF/rails.new/app/views/pipelines/_pipeline_instance_details.html.erb
+++ b/server/webapp/WEB-INF/rails.new/app/views/pipelines/_pipeline_instance_details.html.erb
@@ -1,6 +1,9 @@
 <div class="pipeline_instance_details">
-    <div class="schedule_time" title="Server Time: <%= scope[:active_pipeline_in_pipeline].getScheduledDate()%>" data="<%= scope[:active_pipeline_in_pipeline].getScheduledDate().getTime()%>">
-        <%== trigger_message(scope[:active_pipeline_in_pipeline].getScheduledDate(), scope[:active_pipeline_in_pipeline]) -%>
+    <div class="schedule_time" title="Server Time: <%= scope[:active_pipeline_in_pipeline].getScheduledDate().to_long_display_date_time%>">
+        <% if scope[:active_pipeline_in_pipeline].class != com.thoughtworks.go.presentation.pipelinehistory.PreparingToScheduleInstance -%>
+          <%== trigger_message(scope[:active_pipeline_in_pipeline].getScheduledDate(), scope[:active_pipeline_in_pipeline]) -%>
+          <span class='time' data="<%= scope[:active_pipeline_in_pipeline].getScheduledDate().getTime()%>"></span>
+        <% end -%>
     </div>
     <%= render :partial=> 'shared/stage_bar.html', :locals => {:scope =>{:pipeline => scope[:active_pipeline_in_pipeline],
                                                                          :total_width => 20.0,

--- a/server/webapp/WEB-INF/rails.new/app/views/pipelines/index.html.erb
+++ b/server/webapp/WEB-INF/rails.new/app/views/pipelines/index.html.erb
@@ -22,11 +22,11 @@
 <script type="text/javascript">
   Util.on_load(function () {
     var reformatAllBuildTimes = function() {
-      jQuery(".pipeline_instance .schedule_time").map(function(idx, timeDiv) {
-        var timestamp = parseInt(jQuery(timeDiv).attr("data"));
+      jQuery(".pipeline_instance .schedule_time span.time").each(function(idx, timeSpan) {
+        var timestamp = parseInt(jQuery(timeSpan).attr("data"));
         if (isNaN(timestamp)) return;
         var time = new Date(timestamp);
-        jQuery(timeDiv).find("span.time").text(moment(time).format('DD MMM YYYY HH:mm:ss'));
+        jQuery(timeSpan).text(moment(time).format('[On] DD MMM YYYY [at] HH:mm:ss [Local Time]'));
       });
     };
 

--- a/server/webapp/WEB-INF/rails.new/spec/helpers/pipelines_helper_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/helpers/pipelines_helper_spec.rb
@@ -68,7 +68,6 @@ describe PipelinesHelper do
       message = trigger_message(triggered_date, pim)
 
       expect(message).to have_selector(".who", text: "Anonymous")
-      expect(message).to have_selector("span.time", text: "")
     end
 
     it "should not display the trigger message when the pipeline is being scheduled for the first time" do

--- a/server/webapp/WEB-INF/rails.new/spec/views/environments/_environment_pipeline_html_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/views/environments/_environment_pipeline_html_spec.rb
@@ -54,8 +54,8 @@ describe "/environments/_environment_pipeline.html.erb" do
     Capybara.string(response.body).find(".status .label", :text => /Label:\s+1/).tap do |label|
       expect(label).to have_selector("a", :text => "1")
     end
-    expect(response.body).to have_selector(".status .schedule_time[title='Server Time: #{now.toDate()}']")
-    expect(response.body).to have_selector(".status .schedule_time[data='#{now.toDate().getTime()}']")
+    expect(response.body).to have_selector(".status .schedule_time[title='Server Time: #{now.toDate().to_long_display_date_time}']")
+    expect(response.body).to have_selector(".status .schedule_time span.time[data='#{now.toDate().getTime()}']")
   end
 
   it "should display status for last active stage" do

--- a/server/webapp/WEB-INF/rails.new/spec/views/environments/environment_html_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/views/environments/environment_html_spec.rb
@@ -109,7 +109,7 @@ describe "/environments/_environment.html.erb" do
 
     it "should set the the pipeline scheduled timestamp as data to be used by javascript" do
       expect(response).to have_selector(".pipeline .status .schedule_time", :text => /Triggered/)
-      expect(response).to have_selector(".pipeline .status .schedule_time[data='#{@stages_for_pipeline_1.getScheduledDate().getTime()}']")
+      expect(response).to have_selector(".pipeline .status .schedule_time span.time[data='#{@stages_for_pipeline_1.getScheduledDate().getTime()}']")
     end
 
     it "should display all stages for the pipeline" do

--- a/server/webapp/WEB-INF/vm/pipeline/pipeline_history.vm
+++ b/server/webapp/WEB-INF/vm/pipeline/pipeline_history.vm
@@ -109,7 +109,7 @@
         var timestamp = parseInt(jQuery(scheduledDate).attr("data"));
         if (isNaN(timestamp)) return;
         var time = new Date(timestamp);
-        jQuery(scheduledDate).text(moment(time).format('DD MMM YYYY HH:mm:ss'));
+        jQuery(scheduledDate).text(moment(time).format('DD MMM YYYY [at] HH:mm:ss [Local Time]'));
       });
     }
   }


### PR DESCRIPTION
… as that on stage details page ie. 'DD MMM YYYY [at] HH:mm:ss [ZZ]', eg: '23 Apr 2017 at 19:24:01 [+0530]'. The local time on both these pages would read like '23 Apr 2017 at 19:24:01 Local Time'. Decided to use 'Local Time' instead of the timezone name as there is no good way to reliably get the timezone name from the timezone offset because more than one timezone names can be mapped to the same timezone offset.