### PR TITLE
Use "legacy" path to set disconnected agent status to "lost contact" for websockets

### DIFF
--- a/server/src/com/thoughtworks/go/server/websocket/AgentRemoteHandler.java
+++ b/server/src/com/thoughtworks/go/server/websocket/AgentRemoteHandler.java
@@ -129,11 +129,6 @@ public class AgentRemoteHandler {
             return;
         }
         agentSessions.remove(uuid);
-        AgentInstance instance = agentService.findAgent(uuid);
-        if (instance != null) {
-            instance.lostContact();
-            LOGGER.info("{} lost contact because websocket connection is closed", instance.getAgentIdentifier());
-        }
     }
 
     public Map<String, Agent> connectedAgents() {

--- a/server/test/unit/com/thoughtworks/go/server/websocket/AgentRemoteHandlerTest.java
+++ b/server/test/unit/com/thoughtworks/go/server/websocket/AgentRemoteHandlerTest.java
@@ -204,7 +204,6 @@ public class AgentRemoteHandlerTest {
 
         handler.remove(agent);
         assertEquals(0, handler.connectedAgents().size());
-        assertEquals(AgentStatus.LostContact, instance.getStatus());
     }
 
     @Test


### PR DESCRIPTION
Sometimes the agents using websockets will disconnect because of the idle timeout. This can make it appear to the user that there is an issue with that agent when no issues exists. The agents that disconnect due to the idle timeout will reconnect within 10 seconds.

This is one of the problems outlined in https://github.com/gocd/gocd/issues/3438