### PR TITLE
Display Duration on VSM for stages

### DIFF
--- a/Dockerfile.debug
+++ b/Dockerfile.debug
@@ -11,6 +11,3 @@ WORKDIR /root/work
 VOLUME /root/.m2
 VOLUME /root/.gradle
 
-ENTRYPOINT '/root/work/gradlew'
-
-CMD ['tasks']

--- a/Dockerfile.debug
+++ b/Dockerfile.debug
@@ -1,0 +1,16 @@
+FROM nimmis/java-centos:oracle-8-jdk 
+
+RUN yum install -y git
+RUN yum install -y epel-release 
+RUN yum install -y nodejs npm
+
+ENV JAVA_HOME /usr
+
+WORKDIR /root/work
+
+VOLUME /root/.m2
+VOLUME /root/.gradle
+
+ENTRYPOINT '/root/work/gradlew'
+
+CMD ['tasks']

--- a/server/webapp/WEB-INF/rails.new/app/assets/javascripts/vsm_renderer.js
+++ b/server/webapp/WEB-INF/rails.new/app/assets/javascripts/vsm_renderer.js
@@ -335,7 +335,7 @@ Graph_Renderer = function (container) {
                     gui += '" style="width:' + ((stagesWidth - (stagesCount * 4)) / stagesCount) + 'px" title="' + instance.stages[i].name + '"><span>' + instance.stages[i].name + '</span></li>'
                 }
                 else {
-                    gui += '" style="width:' + ((stagesWidth - (stagesCount * 4)) / stagesCount) + 'px" title="' + instance.stages[i].name + '"><span><span></span></span><a href="' + instance.stages[i].locator + '"><span>' + instance.stages[i].name + '</span></a></li>'
+                    gui += '" style="width:' + ((stagesWidth - (stagesCount * 4)) / stagesCount) + 'px" title="' + instance.stages[i].name + ': took ' + instance.stages[i].duration + ' seconds"><span><span></span></span><a href="' + instance.stages[i].locator + '"><span>' + instance.stages[i].name + '</span></a></li>'
                 }
             }
             gui += '</ul>';

--- a/server/webapp/WEB-INF/rails.new/app/assets/javascripts/vsm_renderer.js
+++ b/server/webapp/WEB-INF/rails.new/app/assets/javascripts/vsm_renderer.js
@@ -335,7 +335,7 @@ Graph_Renderer = function (container) {
                     gui += '" style="width:' + ((stagesWidth - (stagesCount * 4)) / stagesCount) + 'px" title="' + instance.stages[i].name + '"><span>' + instance.stages[i].name + '</span></li>'
                 }
                 else {
-                    gui += '" style="width:' + ((stagesWidth - (stagesCount * 4)) / stagesCount) + 'px" title="' + instance.stages[i].name + ': took ' + instance.stages[i].duration + ' seconds"><span><span></span></span><a href="' + instance.stages[i].locator + '"><span>' + instance.stages[i].name + '</span></a></li>'
+                    gui += '" style="width:' + ((stagesWidth - (stagesCount * 4)) / stagesCount) + 'px" title="' + instance.stages[i].name + ': took ' + cruiseTimeConverter.fromSecondsToHHMMSS(instance.stages[i].duration) + '"><span><span></span></span><a href="' + instance.stages[i].locator + '"><span>' + instance.stages[i].name + '</span></a></li>'
                 }
             }
             gui += '</ul>';

--- a/server/webapp/WEB-INF/rails.new/app/models/value_stream_map_model.rb
+++ b/server/webapp/WEB-INF/rails.new/app/models/value_stream_map_model.rb
@@ -112,7 +112,7 @@ class VSMPipelineInstanceModel
     @counter = counter
     @locator = ""
     @locator = pdg_path_partial.call name, counter unless counter == 0
-    @stages = stages.map { |stage| VSMPipelineInstanceStageModel.new(stage.getName(), stage.getState().to_s, stage.getCounter(), name, counter, stage_detail_path_partial) }
+    @stages = stages.map { |stage| VSMPipelineInstanceStageModel.new(stage.getName(), stage.getState().to_s, stage.getDuration().getTotalSeconds(), stage.getCounter(), name, counter, stage_detail_path_partial) }
   end
 end
 
@@ -141,12 +141,13 @@ class VSMSCMModificationsModel
 end
 
 class VSMPipelineInstanceStageModel
-  attr_accessor :name, :status, :locator
+  attr_accessor :name, :status, :locator, :duration
 
-  def initialize(name, status, counter, pipeline_name, pipeline_counter, stage_detail_path_partial)
+  def initialize(name, status, duration, counter, pipeline_name, pipeline_counter, stage_detail_path_partial)
     @name = name
     @status = status
     @locator = ""
+    @duration = duration
     @locator = stage_detail_path_partial.call pipeline_name, pipeline_counter, name, counter unless com.thoughtworks.go.domain.StageState::Unknown.to_s == status
   end
 end

--- a/server/webapp/WEB-INF/rails.new/spec/controllers/value_stream_map_controller_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/controllers/value_stream_map_controller_spec.rb
@@ -244,11 +244,13 @@ describe ValueStreamMapController do
                     "stages": [
                       {
                         "name": "stage-1-for-p1-1",
+                        "duration": 0,
                         "locator": "/pipelines/p1/1/stage-1-for-p1-1/1",
                         "status": "Passed"
                       },
                       {
                         "name": "stage-2-for-p1-1",
+                        "duration": 0,
                         "locator": "/pipelines/p1/1/stage-2-for-p1-1/1",
                         "status": "Passed"
                       }

--- a/server/webapp/WEB-INF/rails.new/spec/javascripts/value_stream_map_renderer_spec.js
+++ b/server/webapp/WEB-INF/rails.new/spec/javascripts/value_stream_map_renderer_spec.js
@@ -440,7 +440,7 @@ describe("value_stream_map_renderer", function () {
         assertEquals("stage details for pipeline instances are not populated correctly.", 2, jQuery("#vsm-container #current ul ul").find(".stage_bar").length);
         assertEquals("stage details for pipeline instances are not populated correctly.", "/go/pipelines/current/1/defaultStage/1",
             jQuery("#vsm-container #current ul ul li.stage_bar.Passed a").attr("href"));
-        assertEquals("stage hover message is not correctly populated", "defaultStage: took 10 seconds", jQuery("#vsm-container #current ul ul li.stage_bar.Passed").attr('title'));
+        assertEquals("stage hover message is not correctly populated", "defaultStage: took 00:00:10", jQuery("#vsm-container #current ul ul li.stage_bar.Passed").attr('title'));
         assertEquals("stage details for pipeline instances are not populated correctly.", 1, jQuery("#vsm-container #current ul ul li.stage_bar.Unknown > span").length);
     });
 

--- a/server/webapp/WEB-INF/rails.new/spec/javascripts/value_stream_map_renderer_spec.js
+++ b/server/webapp/WEB-INF/rails.new/spec/javascripts/value_stream_map_renderer_spec.js
@@ -424,7 +424,7 @@ describe("value_stream_map_renderer", function () {
          hg_fingerprint -> current -> downstream
          */
 
-        var current_pipeline_instance_details = '{"stages": [{"locator": "/go/pipelines/current/1/defaultStage/1","status": "Passed","name": "defaultStage"},' +
+        var current_pipeline_instance_details = '{"stages": [{"locator": "/go/pipelines/current/1/defaultStage/1","duration": 10,"status": "Passed","name": "defaultStage"},' +
             '{"locator": "","status": "Unknown","name": "oneMore"}],"locator": "/go/pipelines/value_stream_map/current/1","counter": 1,"label": "1" }';
 
         var hg_material = scmMaterialNode('hg_fingerprint', '../manual-testing/ant_hg/dummy', "hg", '["current"]', 1,
@@ -440,6 +440,7 @@ describe("value_stream_map_renderer", function () {
         assertEquals("stage details for pipeline instances are not populated correctly.", 2, jQuery("#vsm-container #current ul ul").find(".stage_bar").length);
         assertEquals("stage details for pipeline instances are not populated correctly.", "/go/pipelines/current/1/defaultStage/1",
             jQuery("#vsm-container #current ul ul li.stage_bar.Passed a").attr("href"));
+        assertEquals("stage hover message is not correctly populated", "defaultStage: took 10 seconds", jQuery("#vsm-container #current ul ul li.stage_bar.Passed").attr('title'));
         assertEquals("stage details for pipeline instances are not populated correctly.", 1, jQuery("#vsm-container #current ul ul li.stage_bar.Unknown > span").length);
     });
 


### PR DESCRIPTION
As part of software maturity assessment, we would like to extract stats from GoCD about a particular repository's VSM with regards to how much time it takes to either successfully deploy to production or fail.
We also need to extract the data regarding mean time to recover. Due to these requirements, we need a feature in GoCD which can quickly display the times on hover for each stage on the VSM itself.
Thanks,
RohitG