### PR TITLE
Adding debug logging to help debug issue #3438

### DIFF
--- a/agent/src/com/thoughtworks/go/agent/AgentWebSocketClientController.java
+++ b/agent/src/com/thoughtworks/go/agent/AgentWebSocketClientController.java
@@ -251,11 +251,14 @@ public class AgentWebSocketClientController extends AgentController {
             @Override
             public void run() {
                 try {
+                    LOG.debug("Processing message[" + msg + "].");
                     process(msg);
                 } catch (InterruptedException e) {
                     LOG.error("Process message[" + msg + "] is interruptted.", e);
                 } catch (RuntimeException e) {
                     LOG.error("Unexpected error while processing message[" + msg + "]: " + e.getMessage(), e);
+                } finally {
+                    LOG.debug("Finished trying to process message[" + msg + "].");
                 }
             }
         });


### PR DESCRIPTION
These debug messages are to help us get a better picture as to why there is a 5 minute gab in the processing of an acknowledgement message