### PR TITLE
Upgrade jgit to 4.7.0.201704051617-r.

### DIFF
--- a/config/config-server/build.gradle
+++ b/config/config-server/build.gradle
@@ -19,7 +19,7 @@ description = 'API to configure/access cruise-config.xml'
 dependencies {
   compile project(':config-api')
   compile project(':common')
-  compile(group: 'org.eclipse.jgit', name: 'org.eclipse.jgit', version: '4.5.0.201609210915-r') {
+  compile(group: 'org.eclipse.jgit', name: 'org.eclipse.jgit', version: '4.7.0.201704051617-r') {
     exclude(group: 'org.apache.httpcomponents')
   }
   compile group: 'org.slf4j', name: 'slf4j-api', version: '1.7.21'

--- a/config/config-server/src/com/thoughtworks/go/service/ConfigRepository.java
+++ b/config/config-server/src/com/thoughtworks/go/service/ConfigRepository.java
@@ -69,6 +69,7 @@ public class ConfigRepository {
         workingDir = this.systemEnvironment.getConfigRepoDir();
         File configRepoDir = new File(workingDir, ".git");
         gitRepo = new FileRepositoryBuilder().setGitDir(configRepoDir).build();
+        gitRepo.getConfig().setInt("gc", null, "auto", 0);
         git = new Git(gitRepo);
     }
 

--- a/development-utility/development-server/build.gradle
+++ b/development-utility/development-server/build.gradle
@@ -24,7 +24,7 @@ dependencies {
   compile group: 'org.eclipse.jetty', name: 'jetty-servlets', version: versions.jetty
   compile group: 'org.eclipse.jetty', name: 'jetty-util', version: versions.jetty
   compile group: 'org.eclipse.jetty.websocket', name: 'websocket-server', version: versions.jetty
-  compile group: 'org.eclipse.jgit', name: 'org.eclipse.jgit.http.server', version: '4.5.0.201609210915-r'
+  compile group: 'org.eclipse.jgit', name: 'org.eclipse.jgit.http.server', version: '4.7.0.201704051617-r'
   compile project(':jetty9')
   compile group: 'javax.servlet', name: 'javax.servlet-api', version: '3.1.0'
   compile group: 'org.jruby', name: 'jruby-complete', version: '1.7.26'

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -186,7 +186,7 @@ dependencies {
   compile group: 'org.slf4j', name: 'slf4j-api', version: '1.7.21'
   compile group: 'org.slf4j', name: 'slf4j-log4j12', version: '1.7.21'
   compile group: 'org.slf4j', name: 'jul-to-slf4j', version: '1.7.21'
-  compile group: 'org.eclipse.jgit', name: 'org.eclipse.jgit.http.server', version: '4.5.0.201609210915-r'
+  compile group: 'org.eclipse.jgit', name: 'org.eclipse.jgit.http.server', version: '4.7.0.201704051617-r'
   compileOnly project(':app-server')
   compileOnly group: 'org.bouncycastle', name: 'bcprov-jdk15on', version: '1.47'
   compileOnly group: 'org.eclipse.jetty.websocket', name: 'websocket-server', version: versions.jetty


### PR DESCRIPTION
Set `gc.auto` to 0 in the repository config. This will ensure that gc won't be run during a merge operation in config.git. Now, `git gc` will only run through `ConfigRepository#garbageCollect`