### PR TITLE
Check if BUILD_MAP_USER and BUILD_MAP_PASSWORD is set before updating build map.

### DIFF
--- a/release/build.gradle
+++ b/release/build.gradle
@@ -19,7 +19,10 @@ description = 'GoCD Release Scripts'
 task updateBuildMap {
   outputs.upToDateWhen { false }
   def checkoutDir = "${project.buildDir}/build-map"
+  String username = System.getenv('BUILD_MAP_USER')
+  String password = System.getenv('BUILD_MAP_PASSWORD')
 
+  onlyIf { username && password }
   doFirst {
     project.delete(checkoutDir)
 


### PR DESCRIPTION
* This is so that installers-PR pipeline does not update build_map unnecessarily.