### PR TITLE
Retry to send websocket messages if there's an error

### DIFF
--- a/agent/src/com/thoughtworks/go/agent/WebSocketSessionHandler.java
+++ b/agent/src/com/thoughtworks/go/agent/WebSocketSessionHandler.java
@@ -65,8 +65,19 @@ public class WebSocketSessionHandler {
     }
 
     private void send(Message message) {
-        LOG.debug("{} send message: {}", sessionName(), message);
-        session.getRemote().sendBytesByFuture(ByteBuffer.wrap(MessageEncoding.encodeMessage(message)));
+        for (int retries = 1; retries < 6; retries++) {
+            try {
+                LOG.info("{} attempt {} to send message: {}", sessionName(), retries, message);
+                session.getRemote().sendBytesByFuture(ByteBuffer.wrap(MessageEncoding.encodeMessage(message)));
+                break;
+            } catch (Throwable e) {
+                try {
+                    LOG.debug("{} failed to send message: {}.", sessionName(), message);
+                    Thread.sleep(1000L);
+                } catch (InterruptedException ignored) {
+                }
+            }
+        }
     }
 
     void sendAndWaitForAcknowledgement(Message message) {

--- a/base/src/com/thoughtworks/go/util/SystemEnvironment.java
+++ b/base/src/com/thoughtworks/go/util/SystemEnvironment.java
@@ -188,6 +188,7 @@ public class SystemEnvironment implements Serializable, ConfigDirProvider {
 
     public static GoSystemProperty<Boolean> AUTO_REGISTER_LOCAL_AGENT_ENABLED = new GoBooleanSystemProperty("go.auto.register.local.agent.enabled", true);
     public static GoSystemProperty<Long> GO_WEBSOCKET_ACK_MESSAGE_TIMEOUT = new GoLongSystemProperty("go.websocket.ack.message.timeout", 300 * 1000L);
+    public static GoSystemProperty<Integer> GO_WEBSOCKET_SEND_RETRY_COUNT = new GoIntSystemProperty("go.websocket.send.retry.count", 5);
 
     public static GoSystemProperty<Long> GO_WEBSOCKET_MAX_IDLE_TIME = new GoLongSystemProperty("go.websocket.max.idle.time", 60 * 1000L);
     public static GoSystemProperty<Boolean> GO_SERVER_SHALLOW_CLONE = new GoBooleanSystemProperty("go.server.shallowClone", false);
@@ -788,6 +789,10 @@ public class SystemEnvironment implements Serializable, ConfigDirProvider {
 
     public Long getWebsocketAckMessageTimeout() {
         return GO_WEBSOCKET_ACK_MESSAGE_TIMEOUT.getValue();
+    }
+
+    public Integer getWebsocketSendRetryCount() {
+        return GO_WEBSOCKET_SEND_RETRY_COUNT.getValue();
     }
 
     public Long getConfigGitGCExpireTime() {


### PR DESCRIPTION
When the socket disconnects due to being idle, we still attempt to send messages before waiting for the agent loop to reconnect the websocket. This PR contains retry logic around sending the messages to better ensure we don't lose messages.

This is in relation to https://github.com/gocd/gocd/issues/3438