### PR TITLE
BuildSession Package Material Support

### DIFF
--- a/domain/src/com/thoughtworks/go/domain/MaterialRevisions.java
+++ b/domain/src/com/thoughtworks/go/domain/MaterialRevisions.java
@@ -29,6 +29,7 @@ import java.util.Map;
 
 import com.thoughtworks.go.config.CaseInsensitiveString;
 import com.thoughtworks.go.config.materials.Materials;
+import com.thoughtworks.go.config.materials.PackageMaterial;
 import com.thoughtworks.go.config.materials.ScmMaterial;
 import com.thoughtworks.go.config.materials.dependency.DependencyMaterial;
 import com.thoughtworks.go.config.materials.git.GitMaterial;
@@ -379,6 +380,8 @@ public class MaterialRevisions implements Serializable, Iterable<MaterialRevisio
                 if (material instanceof GitMaterial) {
                     GitMaterialUpdater updater = new GitMaterialUpdater((GitMaterial) material);
                     commands.add(updater.updateTo(baseDir, revision.toRevisionContext()));
+                } else if (material instanceof PackageMaterial) {
+                    //do nothing
                 } else {
                     commands.add(BuildCommand.fail("%s Material is not supported for new build command agent", material.getTypeForDisplay()));
                 }


### PR DESCRIPTION
Which amounts to simply not throwing an error if the pipeline has a package material.