### PR TITLE
#3375 fix default cancel task when configured via configrepo

### DIFF
--- a/server/src/com/thoughtworks/go/config/ConfigConverter.java
+++ b/server/src/com/thoughtworks/go/config/ConfigConverter.java
@@ -134,7 +134,8 @@ public class ConfigConverter {
 
     private void setCommonTaskMembers(AbstractTask task, CRTask crTask) {
         CRTask crTaskOnCancel = crTask.getOnCancel();
-        task.setCancelTask(crTaskOnCancel != null ? toAbstractTask(crTaskOnCancel) : null);
+        if(crTaskOnCancel != null)
+            task.setCancelTask(toAbstractTask(crTaskOnCancel));
         task.runIfConfigs = toRunIfConfigs(crTask.getRunIf());
     }
 

--- a/server/src/com/thoughtworks/go/config/GoRepoConfigDataSource.java
+++ b/server/src/com/thoughtworks/go/config/GoRepoConfigDataSource.java
@@ -156,7 +156,7 @@ public class GoRepoConfigDataSource implements ChangedRepoConfigWatchListListene
             {
                 fingerprintOfPartialToLatestParseResultMap.put(fingerprint, new PartialConfigParseResult(revision,ex));
                 LOGGER.error(String.format("Failed to parse configuration material %s by %s",
-                        material.getDisplayName(),plugin.displayName()));
+                        material.getDisplayName(),plugin.displayName()), ex);
                 String message = String.format("Parsing configuration repository using %s failed for material: %s",
                         plugin.displayName(), material.getLongDescription());
                 String errorDescription = ex.getMessage() == null ? ex.toString()


### PR DESCRIPTION
A task configured with configrepo, like this
```
              tasks:
               - exec:
                  command: bash
                  arguments:
                    - -c
                    - while true; do date; sleep 1; done
```

Was converted to configuration where on-cancel task was null. But it should have been kill-all.
Added unit test and verified cancel works as expected with yaml configuration.
```
pipelines:
  gocd-cancel-task:
    group: gocd
    label_template: "${git[:8]}"
    materials:
      git:
        git: "git@git.ai-traders.com:gocd/gocd-cancel-task.git"
        branch: master
    stages:
      - style_unit:
          clean_workspace: true
          jobs:
            bash_loop:
              tasks:
               - exec:
                  command: bash
                  arguments:
                    - -c
                    - while true; do date; sleep 1; done
```