### PR TITLE
Return a JobResult of Cancelled when the job is cancelled during preperation

### DIFF
--- a/common/src/com/thoughtworks/go/remote/work/BuildWork.java
+++ b/common/src/com/thoughtworks/go/remote/work/BuildWork.java
@@ -47,6 +47,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.Set;
 
+import static com.thoughtworks.go.domain.JobResult.Cancelled;
 import static com.thoughtworks.go.domain.JobState.*;
 import static com.thoughtworks.go.util.ExceptionUtils.bomb;
 import static com.thoughtworks.go.util.ExceptionUtils.messageOf;
@@ -129,7 +130,7 @@ public class BuildWork implements Work {
                             PackageRepositoryExtension packageRepositoryExtension, SCMExtension scmExtension) throws Exception {
         if (this.goPublisher.isIgnored()) {
             this.goPublisher.reportAction("Job is cancelled");
-            return null;
+            return Cancelled;
         }
 
         goPublisher.consumeLineWithPrefix(format("Job Started: %s\n", new SimpleDateFormat("yyyy-MM-dd HH:mm:ss z").format(timeProvider.currentTime())));
@@ -142,7 +143,7 @@ public class BuildWork implements Work {
 
         if (this.goPublisher.isIgnored()) {
             this.goPublisher.reportAction("Job is cancelled");
-            return null;
+            return Cancelled;
         }
 
         return completeJob(buildJob(environmentVariableContext));

--- a/server/test/unit/com/thoughtworks/go/remote/work/BuildWorkTest.java
+++ b/server/test/unit/com/thoughtworks/go/remote/work/BuildWorkTest.java
@@ -402,13 +402,13 @@ public class BuildWorkTest {
     }
 
     @Test
-    public void shouldUpdateOnlyStatusWhenBuildIsIgnored() throws Exception {
+    public void shouldUpdateStatusAndSetResultCancelledWhenBuildIsIgnored() throws Exception {
         buildWork = (BuildWork) getWork(WILL_PASS, "pipeline1");
         buildRepository = new com.thoughtworks.go.remote.work.BuildRepositoryRemoteStub(true);
 
         buildWork.doWork(agentIdentifier, buildRepository, artifactManipulator, environmentVariableContext, new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", false), packageRepositoryExtension, scmExtension, taskExtension);
 
-        assertThat(buildRepository.results.isEmpty(), is(true));
+        assertThat(buildRepository.results.contains(JobResult.Cancelled), is(true));
         assertThat(buildRepository.states, containsResult(JobState.Completed));
     }
 


### PR DESCRIPTION
It makes more sense, and will prevent the stage and job result/states from getting into a bad spot. See the screenshot bellow

<img width="1421" alt="screen shot 2017-05-09 at 3 39 38 pm" src="https://cloud.githubusercontent.com/assets/5726224/25875697/bcb2843a-34cd-11e7-85c0-bfc71bd5a9f5.png">

@jyotisingh I found a cancelBuild message while digging deeper into the logs.

```
2017-05-06 20:03:43,614 [pool-1-thread-2] DEBUG thoughtworks.go.agent.AgentWebSocketClientController:254 - Processing message[Message{action=cancelBuild, data=null, acknowledgementId=945c2073-cd38-4eda-b185-150f03b4b831}].
```
Which was received at pretty much the exact time we started to prepare:
```
2017-05-06 20:03:43,615 [pool-1-thread-5] DEBUG thoughtworks.go.agent.WebSocketSessionHandler:70 - Session[172.16.38.74/172.16.38.74:8154] attempt 1 to send message: Message{action=consoleOut, data={"jobIdentifier":{"pipelineName":"gocd.perf126","pipelineCounter":40,"pipelineLabel":"40","stageName":"default","buildName":"defaultJob","buildId":28098,"stageCounter":"1"},"tag":"pr","line":"[go] Start to prepare gocd.perf126/40/default/1/defaultJob on blrstdgoprf04.thoughtworks.com [/home/go/agent/go-agents/agent-12]","timestamp":"20:03:43.614"}, acknowledgementId=f50fc419-2ec7-4bd5-8b37-d78b76d39901}
2017-05-06 20:03:52,674 [pool-1-thread-3] ERROR thoughtworks.go.agent.AgentWebSocketClientController:227 - Waited 30 seconds for canceling job finish, but the job is still running. Maybe canceling job does not work as expected, here is running job details: JobRunner{handled=true, isJobCancelled=true, running=true, doneSignal=java.util.concurrent.CountDownLatch@70c4a90f[Count = 1], work=BuildWork[BuildAssignment{plan=[JobPlan identifier=JobIdentifier[gocd.perf126, 40, 40, default, 1, defaultJob, 28098]resources= plans=[] generators=[]], materialRevisions=MaterialRevision[
        [GitMaterial{url=git://172.16.38.50/git-repo-gocd.perf126, branch='master', submoduleFolder='null', shallowClone=true}, StringRevision[3174d32396427d3bd8206055655e3d392b07e023];[Material: com.thoughtworks.go.domain.materials.git.GitMaterialInstance@41043e4f[url=git://172.16.38.50/git-repo-gocd.perf126,username=<null>,pipelineName=<null>,stageName=<null>,view=<null>,useTickets=<null>,branch=master,submoduleFolder=<null>,flyweightName=861fd42a-bf8a-4714-ac45-fcb50e806be9,fingerprint=4463da5ed46e7c4ee6ee16484e1fab547142068e56d7ec8861be26303e75de67,checkExternals=<null>,workspace=<null>,projectPath=<null>,domain=<null>,configuration=<null>,additionalData=<null>,additionalDataMap=<null>,id=239]
, Material: com.thoughtworks.go.domain.materials.git.GitMaterialInstance@41043e4f[url=git://172.16.38.50/git-repo-gocd.perf126,username=<null>,pipelineName=<null>,stageName=<null>,view=<null>,useTickets=<null>,branch=master,submoduleFolder=<null>,flyweightName=861fd42a-bf8a-4714-ac45-fcb50e806be9,fingerprint=4463da5ed46e7c4ee6ee16484e1fab547142068e56d7ec8861be26303e75de67,checkExternals=<null>,workspace=<null>,projectPath=<null>,domain=<null>,configuration=<null>,additionalData=<null>,additionalDataMap=<null>,id=239]
, Material: com.thoughtworks.go.domain.materials.git.GitMaterialInstance@41043e4f[url=git://172.16.38.50/git-repo-gocd.perf126,username=<null>,pipelineName=<null>,stageName=<null>,view=<null>,useTickets=<null>,branch=master,submoduleFolder=<null>,flyweightName=861fd42a-bf8a-4714-ac45-fcb50e806be9,fingerprint=4463da5ed46e7c4ee6ee16484e1fab547142068e56d7ec8861be26303e75de67,checkExternals=<null>,workspace=<null>,projectPath=<null>,domain=<null>,configuration=<null>,additionalData=<null>,additionalDataMap=<null>,id=239]
, Material: com.thoughtworks.go.domain.materials.git.GitMaterialInstance@41043e4f[url=git://172.16.38.50/git-repo-gocd.perf126,username=<null>,pipelineName=<null>,stageName=<null>,view=<null>,useTickets=<null>,branch=master,submoduleFolder=<null>,flyweightName=861fd42a-bf8a-4714-ac45-fcb50e806be9,fingerprint=4463da5ed46e7c4ee6ee16484e1fab547142068e56d7ec8861be26303e75de67,checkExternals=<null>,workspace=<null>,projectPath=<null>,domain=<null>,configuration=<null>,additionalData=<null>,additionalDataMap=<null>,id=239]
, Material: com.thoughtworks.go.domain.materials.git.GitMaterialInstance@41043e4f[url=git://172.16.38.50/git-repo-gocd.perf126,username=<null>,pipelineName=<null>,stageName=<null>,view=<null>,useTickets=<null>,branch=master,submoduleFolder=<null>,flyweightName=861fd42a-bf8a-4714-ac45-fcb50e806be9,fingerprint=4463da5ed46e7c4ee6ee16484e1fab547142068e56d7ec8861be26303e75de67,checkExternals=<null>,workspace=<null>,projectPath=<null>,domain=<null>,configuration=<null>,additionalData=<null>,additionalDataMap=<null>,id=239]
2017-05-06 20:03:52,675 [pool-1-thread-5] INFO  thoughtworks.go.work.DefaultGoPublisher:94 - Agent [blrstdgoprf04.thoughtworks.com, 10.132.4.124, 69af98d9-007c-4844-ba06-4eaf327a769a] is reporting status [Preparing] to Go Server for Build [gocd.perf126/40/default/1/defaultJob/28098]
```

Returning a JobResult of Cancelled will be more consistent with what is actually going on, and it will cause the agent to call reportCompleted instead of reportCurrentStatus. Reporting completed though reportCompleted will update the job result which will prevent the stage from having an Unknown result.

Let me know if you see any problems with this 