### PR TITLE
Don't need excess width for enhanced dropdown

### DIFF
--- a/server/webapp/WEB-INF/rails.new/app/assets/stylesheets/module.scss
+++ b/server/webapp/WEB-INF/rails.new/app/assets/stylesheets/module.scss
@@ -1811,7 +1811,6 @@ span.locked {
 #pipelines .enhanced_dropdown, #stages .fbh_microcontent_popup .enhanced_dropdown,
 #pipelines .enhanced_dropdown .scrollable_panel {
     max-width: 50em;
-    width: 50em;
     padding: 0;
 }
 


### PR DESCRIPTION
Should fix https://github.com/gocd/gocd/issues/3478