### PR TITLE
Update pipeline history header style

### DIFF
--- a/server/webapp/WEB-INF/rails.new/app/assets/stylesheets/new-theme.scss
+++ b/server/webapp/WEB-INF/rails.new/app/assets/stylesheets/new-theme.scss
@@ -1024,6 +1024,14 @@ $arrow-border-active-color: lighten(#000, 50%);
   #content_wrapper_outer_pipeline_history {
     margin: 0;
   }
+
+  #page-title {
+    text-transform: none;
+
+    &:before {
+      content: "Pipeline: ";
+    }
+  }
 }
 
 table.pipeline-history-group {


### PR DESCRIPTION
Should fix https://github.com/gocd/gocd/issues/3407

  - don't capitalize the pipeline name
  - prefix the title with "Pipeline: "
    - yes, I cheated by using a :before pseudoelement for a CSS-only solution
      because I did not want to break any functional tests, in case this is validated.
      What can I say, I'm cheap with my commits :)