### PR TITLE
Ignore NullPointerException when there is no callback for an acknowledgementId

### DIFF
--- a/agent/src/com/thoughtworks/go/agent/WebSocketSessionHandler.java
+++ b/agent/src/com/thoughtworks/go/agent/WebSocketSessionHandler.java
@@ -119,7 +119,11 @@ public class WebSocketSessionHandler {
     void acknowledge(Message message) {
         String acknowledgementId = MessageEncoding.decodeData(message.getData(), String.class);
         LOG.debug("Acknowledging {}", acknowledgementId);
-        callbacks.remove(acknowledgementId).call();
+        try {
+            callbacks.remove(acknowledgementId).call();
+        } catch (NullPointerException e) {
+           LOG.debug("Acknowledgement {} was already acknowledged or removed", acknowledgementId);
+        }
     }
 
     void clearCallBacks() {


### PR DESCRIPTION
This related to https://github.com/gocd/gocd/issues/3438

The situation under which the error is thrown is harmless. When the websocket connection times out due to being idle too long, we reestablish the connection. Whenever we establish the connection, the agent clears out all of the pending callbacks waiting for acknowledgement. 

The changes here in this PR will remove the error from the logs