### PR TITLE
Fix flaky test caused by incorrect cleanup of system properties

### DIFF
--- a/base/test/com/thoughtworks/go/util/TempFilesTest.java
+++ b/base/test/com/thoughtworks/go/util/TempFilesTest.java
@@ -16,6 +16,10 @@
 
 package com.thoughtworks.go.util;
 
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
 import java.io.File;
 import java.io.IOException;
 import java.util.Properties;
@@ -23,10 +27,7 @@ import java.util.UUID;
 
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.core.Is.is;
-import org.junit.After;
 import static org.junit.Assert.assertThat;
-import org.junit.Before;
-import org.junit.Test;
 
 public class TempFilesTest {
     TempFiles files;
@@ -34,7 +35,8 @@ public class TempFilesTest {
 
     @Before
     public void setUp() {
-        original = new Properties(System.getProperties());
+        original = new Properties();
+        original.putAll(System.getProperties());
         files = new TempFiles();
     }
 
@@ -83,7 +85,7 @@ public class TempFilesTest {
         files.cleanUp();
     }
 
-    @Test 
+    @Test
     public void shouldCreateFilesInTempDirectory() throws IOException {
         File file = files.createFile("foo");
         File parentFile = file.getParentFile();
@@ -114,8 +116,8 @@ public class TempFilesTest {
 
     @Test
     public void shouldCreateUniqueFilesParentDirectoryIfDoesNotExist() throws IOException {
-        String tmpDir = original + "/" + UUID.randomUUID();
-        System.setProperty("java.io.tmpdir", tmpDir);
+        String newTmpDir = original.getProperty("java.io.tmpdir") + "/" + UUID.randomUUID();
+        System.setProperty("java.io.tmpdir", newTmpDir);
         File file = files.createUniqueFile("foo");
         assertThat(file.getParentFile().exists(), is(true));
     }


### PR DESCRIPTION
The `Properties(Properties)` constructor is not a copy constructor,
as a result the system properties were being cleared out to in the
tearDown method, causing side-effects in other tests.

Since this was an ordering issue that could be reproduced in some,
but not all cases. I had to resort to using a junit `Suite` to run
tests in a very specific order to reproduce the failure -


```java

package com.thoughtworks.go;

import org.junit.runner.RunWith;
import org.junit.runners.Suite;

@RunWith(Suite.class)
@Suite.SuiteClasses(
        {
                com.thoughtworks.go.util.ListUtilTest.class,
                com.thoughtworks.go.util.DateUtilsConcurrencyTest.class,
                com.thoughtworks.go.util.SystemTimeClockTest.class,
                com.thoughtworks.go.util.TempFilesTest.class,
                com.thoughtworks.go.util.StringUtilTest.class,
                com.thoughtworks.go.util.GoConstantsTest.class,
                com.thoughtworks.go.util.FileDigesterTest.class,
                com.thoughtworks.go.util.comparator.AlphaAsciiCollectionComparatorTest.class,
                com.thoughtworks.go.util.TriStateTest.class,
                com.thoughtworks.go.util.PairTest.class,
                com.thoughtworks.go.util.command.StringArgumentTest.class,
                com.thoughtworks.go.util.DateUtilsTest.class,
                com.thoughtworks.go.util.SystemUtilTest.class,
                com.thoughtworks.go.util.ZipUtilTest.class,
                com.thoughtworks.go.domain.DirectoryScannerTest.class,
                com.thoughtworks.go.logging.LogConfiguratorTest.class,
        }
)
public class FooTest {
}

```