### PR TITLE
Fixing an issue with pipeline state read/save order

### DIFF
--- a/server/test/unit/com/thoughtworks/go/server/dao/PipelineStateDaoTest.java
+++ b/server/test/unit/com/thoughtworks/go/server/dao/PipelineStateDaoTest.java
@@ -84,7 +84,9 @@ public class PipelineStateDaoTest {
             fail("save should have thrown an exception!");
         } catch (Exception e) {
             PipelineState stateFromCache = (PipelineState) goCache.get(pipelineStateDao.pipelineLockStateCacheKey(pipelineName));
-            assertThat(stateFromCache, is(nullValue()));
+            assertThat(stateFromCache.isLocked(), is(false));
+            assertThat(stateFromCache.getLockedByPipelineId(), is(0L));
+            assertThat(stateFromCache.getLockedBy(), is(nullValue()));
         }
     }
 
@@ -92,7 +94,8 @@ public class PipelineStateDaoTest {
     public void shouldNotCorruptCacheIfSaveFailsWhileUnLocking() {
         String pipelineName = UUID.randomUUID().toString();
         PipelineState pipelineState = new PipelineState(pipelineName);
-        pipelineState.lock(1);
+        long lockedByPipelineId = 1;
+        pipelineState.lock(lockedByPipelineId);
         goCache.put(pipelineStateDao.pipelineLockStateCacheKey(pipelineName), pipelineState);
 
         when(transactionTemplate.execute(any(org.springframework.transaction.support.TransactionCallbackWithoutResult.class))).thenAnswer(new Answer<Object>() {
@@ -110,7 +113,8 @@ public class PipelineStateDaoTest {
             fail("save should have thrown an exception!");
         } catch (Exception e) {
             PipelineState stateFromCache = (PipelineState) goCache.get(pipelineStateDao.pipelineLockStateCacheKey(pipelineName));
-            assertThat(stateFromCache, is(nullValue()));
+            assertThat(stateFromCache.isLocked(), is(true));
+            assertThat(stateFromCache.getLockedByPipelineId(), is(lockedByPipelineId));
         }
     }
 }


### PR DESCRIPTION
The PipelineState maintains the pipeline lock status of a pipeline. A significantly high number of queries are made to the PipelineStateDAO to check the pipeline lock status. To avoid frequent queries to database the DAO maintains a cache of the PipelineState and was cleared upon a lock or unlock, which was done as part of a synchronised block. We came across a scenario where the cache got out of sync with the db, below is the scenario.

When an unlock thread exits the synchronized block but hasn't executed a transaction.commit, immediately followed by a read thread ie. pipelineStateFor, the (eh)cache would have been updated with a stale entry from the query-cache (since cacheable was set to true). This cache entry is not cleared thereafter, ie. even after the transaction.commit of unlock happens. This used to lead to a bug wherein some of the pipelines would show up as locked on dashboard even when they were unlocked.

Now, we clear off the ehcache entry only after a transaction commit. This means some of the reads could potentially get seemingly stale data even after the unlock thread exits the synchronized block and before the transaction.commit happens, but that should be ok.