### PR TITLE
Add exit code to failed or errored tasks in console log

### DIFF
--- a/common/src/com/thoughtworks/go/domain/builder/BaseCommandBuilder.java
+++ b/common/src/com/thoughtworks/go/domain/builder/BaseCommandBuilder.java
@@ -63,6 +63,10 @@ public abstract class BaseCommandBuilder extends Builder {
             commandLine.runScript(execScript, consumer, environmentVariableContext, null);
             setBuildDuration(startTime, buildLogElement);
 
+            if (SUCCESS_EXIT_CODE != execScript.getExitCode()) {
+                setExitCode(execScript.getExitCode());
+            }
+
             if (execScript.foundError()) {
                 // detected the error string in the command output
                 String message = "Build failed. Command " + this.command + " reported ["
@@ -70,8 +74,7 @@ public abstract class BaseCommandBuilder extends Builder {
                 setBuildError(buildLogElement, message);
                 buildLogElement.setTaskError();
                 throw new CruiseControlException(message);
-
-            } else if (execScript.getExitCode() != 0) {
+            } else if (SUCCESS_EXIT_CODE != execScript.getExitCode()) {
                 String message = "return code is " + execScript.getExitCode();
                 setBuildError(buildLogElement, message);
                 throw new CruiseControlException(message);

--- a/common/src/com/thoughtworks/go/domain/builder/Builder.java
+++ b/common/src/com/thoughtworks/go/domain/builder/Builder.java
@@ -32,10 +32,14 @@ import static java.lang.String.format;
 
 public abstract class Builder implements Serializable {
     private static final Logger LOGGER = Logger.getLogger(Builder.class);
+    public static final int UNSET_EXIT_CODE = -1;
+    static final int SUCCESS_EXIT_CODE = 0;
+
+    private int exitCode = UNSET_EXIT_CODE;
+
     protected final RunIfConfigs conditions;
     private String description;
     private Builder cancelBuilder;
-
     public Builder(RunIfConfigs conditions, Builder cancelBuilder, String description) {
         this.conditions = conditions;
         this.cancelBuilder = cancelBuilder;
@@ -124,5 +128,13 @@ public abstract class Builder implements Serializable {
 
     public RunIfConfig resolvedRunIfConfig() {
         return this.conditions.resolveToSingle();
+    }
+
+    public int getExitCode() {
+        return exitCode;
+    }
+
+    protected void setExitCode(int exitCode) {
+        this.exitCode = exitCode;
     }
 }

--- a/server/webapp/WEB-INF/rails.new/app/assets/stylesheets/css/console-log.scss
+++ b/server/webapp/WEB-INF/rails.new/app/assets/stylesheets/css/console-log.scss
@@ -153,7 +153,7 @@ $PROGRESS_BAR_BG_SIZE: 70px;
   content: attr(data-timestamp) " ";
 }
 
-.log-fs-duration {
+.log-fs-duration, .log-fs-exitcode {
   display: inline-block;
   border-radius: 0.5rem;
   margin-left: 0.5rem;


### PR DESCRIPTION
Somewhat generified the duration and exit code JS by abstracting them both as "annotations", in concept.