### PR TITLE
Make TFS work with BuildSession architecture

### DIFF
--- a/agent/src/com/thoughtworks/go/agent/AgentWebSocketClientController.java
+++ b/agent/src/com/thoughtworks/go/agent/AgentWebSocketClientController.java
@@ -182,6 +182,7 @@ public class AgentWebSocketClientController extends AgentController {
         BuildVariables buildVariables = new BuildVariables(getAgentRuntimeInfo(), clock);
         BuildSession build = new BuildSession(
                 buildSettings.getBuildId(),
+                getAgentRuntimeInfo().getIdentifier(),
                 buildStateReporter,
                 buildConsole,
                 buildVariables,

--- a/common/src/com/thoughtworks/go/buildsession/BuildSession.java
+++ b/common/src/com/thoughtworks/go/buildsession/BuildSession.java
@@ -17,6 +17,7 @@ package com.thoughtworks.go.buildsession;
 
 import com.jezhumble.javasysmon.JavaSysMon;
 import com.thoughtworks.go.domain.*;
+import com.thoughtworks.go.remote.AgentIdentifier;
 import com.thoughtworks.go.util.Clock;
 import com.thoughtworks.go.util.GoConstants;
 import com.thoughtworks.go.util.HttpService;
@@ -44,6 +45,7 @@ public class BuildSession {
     private final Map<String, String> envs;
     private final Map<String, String> secretSubstitutions;
     private final String buildId;
+    private AgentIdentifier agentIdentifier;
     private final BuildStateReporter buildStateReporter;
     private final TaggedStreamConsumer console;
     private final DownloadAction downloadAction;
@@ -71,6 +73,7 @@ public class BuildSession {
         executors.put("mkdirs", new MkdirsCommandExecutor());
         executors.put("cleandir", new CleandirCommandExecutor());
         executors.put("exec", new ExecCommandExecutor());
+        executors.put("plugin", new PluginCommandExecutor());
         executors.put("test", new TestCommandExecutor());
         executors.put("reportCurrentStatus", new ReportCurrentStatusCommandExecutor());
         executors.put("reportCompleting", new ReportCompletingCommandExecutor());
@@ -79,8 +82,9 @@ public class BuildSession {
         executors.put("error", new ErrorCommandExecutor());
     }
 
-    public BuildSession(String buildId, BuildStateReporter buildStateReporter, TaggedStreamConsumer console, StrLookup buildVariables, ArtifactsRepository artifactsRepository, HttpService httpService, Clock clock, File workingDir) {
+    public BuildSession(String buildId, AgentIdentifier agentIdentifier, BuildStateReporter buildStateReporter, TaggedStreamConsumer console, StrLookup buildVariables, ArtifactsRepository artifactsRepository, HttpService httpService, Clock clock, File workingDir) {
         this.buildId = buildId;
+        this.agentIdentifier = agentIdentifier;
         this.buildStateReporter = buildStateReporter;
         this.console = console;
         this.buildVariables = buildVariables;
@@ -282,7 +286,7 @@ public class BuildSession {
 
     BuildSession newTestingSession(TaggedStreamConsumer console) {
         BuildSession buildSession = new BuildSession(
-                buildId, new UncaringBuildStateReport(), console, buildVariables, artifactsRepository, httpService, clock, workingDir);
+                buildId, agentIdentifier, new UncaringBuildStateReport(), console, buildVariables, artifactsRepository, httpService, clock, workingDir);
         buildSession.cancelLatch = this.cancelLatch;
         return buildSession;
     }
@@ -307,7 +311,7 @@ public class BuildSession {
 
 
     private BuildSession newCancelSession() {
-        return new BuildSession(buildId, new UncaringBuildStateReport(),
+        return new BuildSession(buildId, agentIdentifier, new UncaringBuildStateReport(),
                 console, buildVariables, artifactsRepository, httpService, clock, workingDir);
     }
 
@@ -337,5 +341,9 @@ public class BuildSession {
         } catch (Exception reportException) {
             LOG.error(format("Unable to report error message - %s.", messageOf(e)), reportException);
         }
+    }
+
+    public AgentIdentifier getAgentIdentifier() {
+        return agentIdentifier;
     }
 }

--- a/common/src/com/thoughtworks/go/buildsession/PluginCommandExecutor.java
+++ b/common/src/com/thoughtworks/go/buildsession/PluginCommandExecutor.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2017 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.thoughtworks.go.buildsession;
+
+import com.thoughtworks.go.domain.BuildCommand;
+
+public class PluginCommandExecutor implements BuildCommandExecutor {
+    BuildCommandExecutor buildCommandExecutor;
+
+    public PluginCommandExecutor() {
+        buildCommandExecutor = null;
+    }
+
+    public PluginCommandExecutor(BuildCommandExecutor buildCommandExecutor) {
+        this.buildCommandExecutor = buildCommandExecutor;
+    }
+
+    @Override
+    public boolean execute(BuildCommand command, BuildSession buildSession) {
+        String type = command.getStringArg("type");
+        boolean executorResult = false;
+
+        if ("tfs".equals(type)) {
+            buildCommandExecutor = (buildCommandExecutor == null) ? new TfsExecutor() : buildCommandExecutor;
+            executorResult = buildCommandExecutor.execute(command, buildSession);
+        }
+
+        return executorResult;
+    }
+}

--- a/common/src/com/thoughtworks/go/buildsession/TfsExecutor.java
+++ b/common/src/com/thoughtworks/go/buildsession/TfsExecutor.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2017 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.buildsession;
+
+import com.thoughtworks.go.config.materials.tfs.TfsMaterial;
+import com.thoughtworks.go.domain.BuildCommand;
+import com.thoughtworks.go.domain.materials.AgentSubprocessExecutionContext;
+import com.thoughtworks.go.domain.materials.RevisionContext;
+import com.thoughtworks.go.domain.materials.mercurial.StringRevision;
+import com.thoughtworks.go.security.GoCipher;
+import com.thoughtworks.go.util.command.ConsoleOutputStreamConsumer;
+import com.thoughtworks.go.util.command.LabeledOutputStreamConsumer;
+import com.thoughtworks.go.util.command.TaggedStreamConsumer;
+import com.thoughtworks.go.util.command.UrlArgument;
+
+import java.io.File;
+
+public class TfsExecutor implements BuildCommandExecutor {
+
+    TfsMaterial tfsMaterial;
+
+    public TfsExecutor() {
+        tfsMaterial = null;
+    }
+
+    public TfsExecutor(TfsMaterial tfsMaterial) {
+        this.tfsMaterial = tfsMaterial;
+    }
+
+    @Override
+    public boolean execute(BuildCommand command, BuildSession buildSession) {
+        String url = command.getStringArg("url");
+        String username = command.getStringArg("username");
+        String password = command.getStringArg("password");
+        String domain = command.getStringArg("domain");
+        String projectPath = command.getStringArg("projectPath");
+        String revision = command.getStringArg("revision");
+        File workingDir = buildSession.resolveRelativeDir(command.getWorkingDirectory());
+
+        ConsoleOutputStreamConsumer consoleOutputStreamConsumer = new LabeledOutputStreamConsumer(TaggedStreamConsumer.PREP, TaggedStreamConsumer.PREP_ERR,
+                buildSession.processOutputStreamConsumer());
+        RevisionContext revisionContext = new RevisionContext(new StringRevision(revision));
+        AgentSubprocessExecutionContext execCtx = new AgentSubprocessExecutionContext(buildSession.getAgentIdentifier(), workingDir.getAbsolutePath());
+
+        tfsMaterial = (tfsMaterial == null) ? new TfsMaterial(new GoCipher(), new UrlArgument(url), username, domain, password, projectPath) : tfsMaterial;
+        tfsMaterial.updateTo(consoleOutputStreamConsumer, workingDir, revisionContext, execCtx);
+
+        return true;
+    }
+}

--- a/common/src/com/thoughtworks/go/domain/materials/AgentSubprocessExecutionContext.java
+++ b/common/src/com/thoughtworks/go/domain/materials/AgentSubprocessExecutionContext.java
@@ -23,11 +23,11 @@ import com.thoughtworks.go.util.CachedDigestUtils;
 import java.util.HashMap;
 import java.util.Map;
 
-class AgentSubprocessExecutionContext implements SubprocessExecutionContext {
+public class AgentSubprocessExecutionContext implements SubprocessExecutionContext {
     private AgentIdentifier agentIdentifier;
     private final String workingDirectory;
 
-    AgentSubprocessExecutionContext(final AgentIdentifier agentIdentifier, String workingDirectory) {
+    public AgentSubprocessExecutionContext(final AgentIdentifier agentIdentifier, String workingDirectory) {
         this.agentIdentifier = agentIdentifier;
         this.workingDirectory = workingDirectory;
     }

--- a/common/test/unit/com/thoughtworks/go/buildsession/BuildSessionBasedTestCase.java
+++ b/common/test/unit/com/thoughtworks/go/buildsession/BuildSessionBasedTestCase.java
@@ -20,6 +20,7 @@ import com.thoughtworks.go.domain.BuildCommand;
 import com.thoughtworks.go.domain.BuildStateReporterStub;
 import com.thoughtworks.go.domain.JobResult;
 import com.thoughtworks.go.helper.TestStreamConsumer;
+import com.thoughtworks.go.remote.AgentIdentifier;
 import com.thoughtworks.go.remote.work.HttpServiceStub;
 import com.thoughtworks.go.util.SystemUtil;
 import com.thoughtworks.go.util.TestFileUtil;
@@ -44,6 +45,7 @@ public class BuildSessionBasedTestCase {
     protected ArtifactsRepositoryStub artifactsRepository;
     protected TestStreamConsumer console;
     protected HttpServiceStub httpService;
+    protected AgentIdentifier agentIdentifier;
 
     @Before
     public void superSetup() {
@@ -53,6 +55,7 @@ public class BuildSessionBasedTestCase {
         sandbox = TestFileUtil.createTempFolder(UUID.randomUUID().toString());
         console = new TestStreamConsumer();
         httpService = new HttpServiceStub();
+        agentIdentifier = new AgentIdentifier("hostname", "ipaddress", "uuid");
     }
 
     @After
@@ -62,7 +65,7 @@ public class BuildSessionBasedTestCase {
 
     protected BuildSession newBuildSession() {
         return new BuildSession("build1",
-                statusReporter,
+                agentIdentifier, statusReporter,
                 console,
                 StrLookup.mapLookup(buildVariables),
                 artifactsRepository, httpService, new TestingClock(), sandbox);

--- a/common/test/unit/com/thoughtworks/go/buildsession/PluginCommandExecutorTest.java
+++ b/common/test/unit/com/thoughtworks/go/buildsession/PluginCommandExecutorTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2017 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.buildsession;
+
+import com.thoughtworks.go.domain.BuildCommand;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+public class PluginCommandExecutorTest {
+    PluginCommandExecutor pluginCommandExecutor;
+    BuildCommandExecutor buildCommandExecutor;
+    BuildCommand buildCommand;
+    BuildSession buildSession;
+
+    @Before
+    public void setUp() throws Exception {
+        buildCommandExecutor = mock(BuildCommandExecutor.class);
+        pluginCommandExecutor = new PluginCommandExecutor(buildCommandExecutor);
+        buildCommand = mock(BuildCommand.class);
+        buildSession = mock(BuildSession.class);
+    }
+
+    @Test
+    public void shouldNotExecuteATfsExecutorIfPluginTypeIsNotTfs() throws Exception {
+        when(buildCommand.getStringArg("type")).thenReturn("non-tfs type");
+
+        boolean result = pluginCommandExecutor.execute(buildCommand, buildSession);
+
+        verify(buildCommandExecutor, never()).execute(buildCommand, buildSession);
+        assertThat(result, is(false));
+    }
+
+    @Test
+    public void shouldExecuteATfsExecutorIfPluginTypeIsTfs() throws Exception {
+        when(buildCommand.getStringArg("type")).thenReturn("tfs");
+        when(buildCommandExecutor.execute(buildCommand, buildSession)).thenReturn(true);
+
+        boolean result = pluginCommandExecutor.execute(buildCommand, buildSession);
+
+        verify(buildCommandExecutor).execute(buildCommand, buildSession);
+        assertThat(result, is(true));
+    }
+}

--- a/common/test/unit/com/thoughtworks/go/buildsession/TfsExecutorTest.java
+++ b/common/test/unit/com/thoughtworks/go/buildsession/TfsExecutorTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2017 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.buildsession;
+
+import com.thoughtworks.go.config.materials.SubprocessExecutionContext;
+import com.thoughtworks.go.config.materials.tfs.TfsMaterial;
+import com.thoughtworks.go.domain.BuildCommand;
+import com.thoughtworks.go.domain.materials.RevisionContext;
+import com.thoughtworks.go.domain.materials.mercurial.StringRevision;
+import com.thoughtworks.go.remote.AgentIdentifier;
+import com.thoughtworks.go.util.command.ConsoleOutputStreamConsumer;
+import com.thoughtworks.go.util.command.ProcessOutputStreamConsumer;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.*;
+
+public class TfsExecutorTest {
+
+    TfsExecutor tfsExecutor;
+    TfsMaterial tfsMaterial;
+    ConsoleOutputStreamConsumer consoleOutputStreamConsumer;
+    SubprocessExecutionContext subprocessExecutionContext;
+    BuildCommand buildCommand;
+    BuildSession buildSession;
+    File workingDir;
+    RevisionContext revisionContext;
+
+    @Before
+    public void setUp() throws Exception {
+        createBuildCommand();
+        createBuildSession();
+        tfsMaterial = mock(TfsMaterial.class);
+        consoleOutputStreamConsumer = mock(ConsoleOutputStreamConsumer.class);
+        subprocessExecutionContext = mock(SubprocessExecutionContext.class);
+        revisionContext = new RevisionContext(new StringRevision("revision"));
+
+        tfsExecutor = new TfsExecutor(tfsMaterial);
+    }
+
+    public void createBuildSession() {
+        AgentIdentifier agentIdentifier = mock(AgentIdentifier.class);
+
+        workingDir = mock(File.class);
+        when(workingDir.getAbsolutePath()).thenReturn("working dir");
+
+        ProcessOutputStreamConsumer processOutputStreamConsumer = mock(ProcessOutputStreamConsumer.class);
+
+        buildSession = mock(BuildSession.class);
+        when(buildSession.resolveRelativeDir("working dir")).thenReturn(workingDir);
+        when(buildSession.getAgentIdentifier()).thenReturn(agentIdentifier);
+        when(buildSession.processOutputStreamConsumer()).thenReturn(processOutputStreamConsumer);
+    }
+
+    public void createBuildCommand() {
+        buildCommand = mock(BuildCommand.class);
+        when(buildCommand.getStringArg("url")).thenReturn("some url");
+        when(buildCommand.getStringArg("username")).thenReturn("username");
+        when(buildCommand.getStringArg("password")).thenReturn("password");
+        when(buildCommand.getStringArg("domain")).thenReturn("domain");
+        when(buildCommand.getStringArg("projectPath")).thenReturn("project path");
+        when(buildCommand.getStringArg("revision")).thenReturn("revision");
+        when(buildCommand.getWorkingDirectory()).thenReturn("working dir");
+    }
+
+    @Test
+    public void shouldUpdateTheTfsMaterial() throws Exception {
+        boolean result = tfsExecutor.execute(buildCommand, buildSession);
+
+        verify(tfsMaterial).updateTo(any(ConsoleOutputStreamConsumer.class), any(File.class), any(RevisionContext.class),
+                any(SubprocessExecutionContext.class));
+        assertThat(result, is(true));
+    }
+}

--- a/common/test/unit/com/thoughtworks/go/config/materials/git/GitMaterialUpdaterTest.java
+++ b/common/test/unit/com/thoughtworks/go/config/materials/git/GitMaterialUpdaterTest.java
@@ -70,7 +70,6 @@ public class GitMaterialUpdaterTest extends BuildSessionBasedTestCase {
         workingDir = new File(sandbox, "working");
     }
 
-
     @After
     public void teardown() throws Exception {
         TestRepo.internalTearDown();
@@ -92,8 +91,7 @@ public class GitMaterialUpdaterTest extends BuildSessionBasedTestCase {
                 containsString("Start updating files at revision " + REVISION_2.getRevision()));
         assertThat(newFile.exists(), is(true));
     }
-
-
+    
     @Test
     public void shouldRemoveSubmoduleFolderFromWorkingDirWhenSubmoduleIsRemovedFromRepo() throws Exception {
         GitSubmoduleRepos submoduleRepos = new GitSubmoduleRepos();

--- a/common/test/unit/com/thoughtworks/go/config/materials/tfs/TFSMaterialUpdaterTest.java
+++ b/common/test/unit/com/thoughtworks/go/config/materials/tfs/TFSMaterialUpdaterTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2017 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.config.materials.tfs;
+
+import com.thoughtworks.go.domain.BuildCommand;
+import com.thoughtworks.go.domain.materials.Revision;
+import com.thoughtworks.go.domain.materials.RevisionContext;
+import com.thoughtworks.go.domain.materials.tfs.TfsMaterialUpdater;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+
+import static com.thoughtworks.go.domain.BuildCommand.compose;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class TFSMaterialUpdaterTest {
+    TfsMaterialUpdater tfsMaterialUpdater;
+    RevisionContext revisionContext;
+    TfsMaterial tfsMaterial;
+
+    @Before
+    public void setUp() throws Exception {
+        mockRevisionContext();
+        mockTfsMaterial();
+        tfsMaterialUpdater = new TfsMaterialUpdater(tfsMaterial);
+    }
+
+    public void mockRevisionContext() {
+        String mockRevision = "11111";
+
+        Revision revision = mock(Revision.class);
+        when(revision.getRevision()).thenReturn(mockRevision);
+
+        revisionContext = mock(RevisionContext.class);
+        when(revisionContext.getLatestRevision()).thenReturn(revision);
+    }
+
+    public void mockTfsMaterial() {
+        File workingDir = mock(File.class);
+        when(workingDir.getPath()).thenReturn("someDir");
+
+        tfsMaterial = mock(TfsMaterial.class);
+        when(tfsMaterial.workingdir(any(File.class))).thenReturn(workingDir);
+        when(tfsMaterial.getPassword()).thenReturn("password");
+        when(tfsMaterial.getUserName()).thenReturn("username");
+        when(tfsMaterial.getDomain()).thenReturn("domain");
+        when(tfsMaterial.getProjectPath()).thenReturn("projectpath");
+        when(tfsMaterial.getUrl()).thenReturn("url");
+    }
+
+    @Test
+    public void shouldCreateBuildCommandUpdateToSpecificRevision() throws Exception {
+        String expectedCommand = "compose\n    secret \"value:password\"\n    plugin \"password:password\" " +
+                "\"projectPath:projectpath\" \"domain:domain\" \"type:tfs\" \"url:url\" \"username:username\" " +
+                "\"revision:11111\"";
+
+        BuildCommand buildCommand = tfsMaterialUpdater.updateTo("baseDir", revisionContext);
+
+        assertThat(buildCommand.dump(), is(expectedCommand));
+    }
+
+}

--- a/common/test/unit/com/thoughtworks/go/domain/BuildCommandTest.java
+++ b/common/test/unit/com/thoughtworks/go/domain/BuildCommandTest.java
@@ -34,7 +34,6 @@ public class BuildCommandTest {
         assertThat(new BuildCommand("foo", map("foo", "bar")).getStringArg("foo"), is("bar"));
     }
 
-
     @Test
     public void defaultSubCommandsShouldBeEmpty() {
         assertThat(new BuildCommand("foo").getSubCommands().size(), is(0));

--- a/domain/src/com/thoughtworks/go/domain/BuildCommand.java
+++ b/domain/src/com/thoughtworks/go/domain/BuildCommand.java
@@ -111,6 +111,10 @@ public class BuildCommand {
                 "srcs", GSON.toJson(srcs)));
     }
 
+    public static BuildCommand plugin(Map<String, String> properties) {
+        return new BuildCommand("plugin", properties);
+    }
+
     public static BuildCommand downloadFile(Map<String, String> args) {
         return new BuildCommand("downloadFile", args);
     }

--- a/domain/src/com/thoughtworks/go/domain/MaterialRevisions.java
+++ b/domain/src/com/thoughtworks/go/domain/MaterialRevisions.java
@@ -32,9 +32,11 @@ import com.thoughtworks.go.config.materials.Materials;
 import com.thoughtworks.go.config.materials.ScmMaterial;
 import com.thoughtworks.go.config.materials.dependency.DependencyMaterial;
 import com.thoughtworks.go.config.materials.git.GitMaterial;
+import com.thoughtworks.go.config.materials.tfs.TfsMaterial;
 import com.thoughtworks.go.domain.materials.*;
 import com.thoughtworks.go.domain.materials.dependency.DependencyMaterialRevision;
 import com.thoughtworks.go.domain.materials.git.GitMaterialUpdater;
+import com.thoughtworks.go.domain.materials.tfs.TfsMaterialUpdater;
 import com.thoughtworks.go.util.ObjectUtil;
 import com.thoughtworks.go.util.command.EnvironmentVariableContext;
 import org.apache.log4j.Logger;
@@ -378,6 +380,9 @@ public class MaterialRevisions implements Serializable, Iterable<MaterialRevisio
             if(material instanceof ScmMaterial) {
                 if (material instanceof GitMaterial) {
                     GitMaterialUpdater updater = new GitMaterialUpdater((GitMaterial) material);
+                    commands.add(updater.updateTo(baseDir, revision.toRevisionContext()));
+                } else if (material instanceof TfsMaterial) {
+                    TfsMaterialUpdater updater = new TfsMaterialUpdater((TfsMaterial) material);
                     commands.add(updater.updateTo(baseDir, revision.toRevisionContext()));
                 } else {
                     commands.add(BuildCommand.fail("%s Material is not supported for new build command agent", material.getTypeForDisplay()));

--- a/domain/src/com/thoughtworks/go/domain/materials/tfs/TfsMaterialUpdater.java
+++ b/domain/src/com/thoughtworks/go/domain/materials/tfs/TfsMaterialUpdater.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2017 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.domain.materials.tfs;
+
+import com.thoughtworks.go.config.materials.tfs.TfsMaterial;
+import com.thoughtworks.go.domain.BuildCommand;
+import com.thoughtworks.go.domain.materials.Revision;
+import com.thoughtworks.go.domain.materials.RevisionContext;
+import com.thoughtworks.go.util.MapBuilder;
+
+import java.io.File;
+import java.util.Map;
+
+import static com.thoughtworks.go.domain.BuildCommand.*;
+import static com.thoughtworks.go.util.MapBuilder.map;
+
+public class TfsMaterialUpdater {
+
+    private TfsMaterial material;
+
+    public TfsMaterialUpdater(TfsMaterial material) {
+        this.material = material;
+    }
+
+    public BuildCommand updateTo(String baseDir, RevisionContext revisionContext) {
+        Revision revision = revisionContext.getLatestRevision();
+        String workingDir = material.workingdir(new File(baseDir)).getPath();
+        return compose(
+                secret(material.getPassword()),
+                execTfsCheckout(material, revision, workingDir)
+        );
+    }
+
+    private BuildCommand execTfsCheckout(TfsMaterial material, Revision revision, String workingDir) {
+        Map<String, String> properties = map(
+                "type", "tfs",
+                "username", material.getUserName(),
+                "password", material.getPassword(),
+                "domain", material.getDomain(),
+                "projectPath",  material.getProjectPath(),
+                "url", material.getUrl(),
+                "revision", revision.getRevision());
+        return plugin(properties).setWorkingDirectory(workingDir);
+    }
+}

--- a/util/src/com/thoughtworks/go/util/MapBuilder.java
+++ b/util/src/com/thoughtworks/go/util/MapBuilder.java
@@ -55,4 +55,16 @@ public class MapBuilder {
         return values;
     }
 
+    public static <S, T> Map<S, T> map(S k1, T v1, S k2, T v2, S k3, T v3, S k4, T v4, S k5, T v5, S k6, T v6) {
+        Map<S, T> values = map(k1, v1, k2, v2, k3, v3, k4, v4, k5, v5);
+        values.put(k6, v6);
+        return values;
+    }
+
+    public static <S, T> Map<S, T> map(S k1, T v1, S k2, T v2, S k3, T v3, S k4, T v4, S k5, T v5, S k6, T v6, S k7, T v7) {
+        Map<S, T> values = map(k1, v1, k2, v2, k3, v3, k4, v4, k5, v5, k6, v6);
+        values.put(k7, v7);
+        return values;
+    }
+
 }

--- a/util/test/com/thoughtworks/go/util/MapBuilderTest.java
+++ b/util/test/com/thoughtworks/go/util/MapBuilderTest.java
@@ -69,4 +69,29 @@ public class MapBuilderTest {
         assertThat(MapBuilder.map("foo", 23, "s", 42, "t", 42, "x", 43, "y", 44), is(expected));
     }
 
+    @Test
+    public void testLengthSix() {
+        Map<String, Integer> expected = new HashMap<>();
+        expected.put("foo", 23);
+        expected.put("s", 42);
+        expected.put("t", 42);
+        expected.put("x", 43);
+        expected.put("y", 44);
+        expected.put("z", 45);
+        assertThat(MapBuilder.map("foo", 23, "s", 42, "t", 42, "x", 43, "y", 44, "z", 45), is(expected));
+    }
+
+    @Test
+    public void testLengthSeven() {
+        Map<String, Integer> expected = new HashMap<>();
+        expected.put("foo", 23);
+        expected.put("s", 42);
+        expected.put("t", 42);
+        expected.put("x", 43);
+        expected.put("y", 44);
+        expected.put("z", 45);
+        expected.put("q", 46);
+        assertThat(MapBuilder.map("foo", 23, "s", 42, "t", 42, "x", 43, "y", 44, "z", 45, "q", 46), is(expected));
+    }
+
 }


### PR DESCRIPTION
* Mostly just a wrapper around the existing TFSMaterial class.
* Chose not to use the 'tf' command line tool due to previous performance problems (per Duck)
* Created a generic 'Plugin' BuildCommand that is used to invoke the existing TFSMaterial for TFS checkouts. This can be used with Task and SCM plugins in the build session as well.