### PR TITLE
Use stricter conditions for detecting error states

### DIFF
--- a/server/webapp/WEB-INF/rails.new/webpack/helpers/mrequest.js
+++ b/server/webapp/WEB-INF/rails.new/webpack/helpers/mrequest.js
@@ -54,7 +54,7 @@ const mrequest   = {
       entity.etag(xhr.getResponseHeader('ETag'));
       return entity;
     }
-    if (xhr.status === 422) {
+    if (xhr.status === 422 && !!data.data) {
       const fromJSON = new type.fromJSON(data.data);
       fromJSON.etag(originalEtag);
       return fromJSON;


### PR DESCRIPTION
Should fix https://github.com/gocd/gocd/issues/3505 because the failure message will
be handled by unwrapErrorExtractMessage when the data argument resembles the form: `{ message: "error message" }`