### PR TITLE
Validate entity before save or update on SPA

### DIFF
--- a/server/webapp/WEB-INF/rails.new/spec/webpack/models/auth_configs/auth_configs_spec.js
+++ b/server/webapp/WEB-INF/rails.new/spec/webpack/models/auth_configs/auth_configs_spec.js
@@ -444,6 +444,51 @@ describe('Authorization Configuration', () => {
         expect(request.url).toBe('/go/api/admin/internal/security/auth_configs/verify_connection');
       });
     });
-
   });
+
+  describe('Validate auth config id', () => {
+    let authConfig;
+    beforeEach(() => {
+      authConfig =  AuthConfigs.AuthConfig.fromJSON(authConfigJSON());
+    });
+
+    it('should return empty object on valid auth config id', () => {
+      authConfig.id("foo.bar-baz_bar");
+
+      const result = authConfig.validate();
+
+      expect(result._isEmpty()).toEqual(true);
+    });
+
+    it('should return error if auth config id contains `!`', () => {
+      authConfig.id("foo!bar");
+
+      const result = authConfig.validate();
+
+      expect(result._isEmpty()).toEqual(false);
+      expect(result.errors().id[0]).toContain('Invalid id.');
+
+    });
+
+    it('should return error if auth config id contains `*`', () => {
+      authConfig.id("foo*bar");
+
+      const result = authConfig.validate();
+
+      expect(result._isEmpty()).toEqual(false);
+      expect(result.errors().id[0]).toContain('Invalid id.');
+
+    });
+
+    it('should return error if auth config id start with `.`', () => {
+      authConfig.id(".foo");
+
+      const result = authConfig.validate();
+
+      expect(result._isEmpty()).toEqual(false);
+      expect(result.errors().id[0]).toContain('Invalid id.');
+
+    });
+  });
+
 });

--- a/server/webapp/WEB-INF/rails.new/spec/webpack/models/elastic_profiles/elastic_profiles_spec.js
+++ b/server/webapp/WEB-INF/rails.new/spec/webpack/models/elastic_profiles/elastic_profiles_spec.js
@@ -369,4 +369,49 @@ describe('Elastic Agent Profile', () => {
       });
     });
   });
+
+  describe('Validate elastic profile id', () => {
+    let elasticProfile;
+    beforeEach(() => {
+      elasticProfile =  ElasticProfiles.Profile.fromJSON(profileJSON);
+    });
+
+    it('should return empty object on valid elastic profile id', () => {
+      elasticProfile.id("foo.bar-baz_bar");
+
+      const result = elasticProfile.validate();
+
+      expect(result._isEmpty()).toEqual(true);
+    });
+
+    it('should return error if elastic profile id contains `!`', () => {
+      elasticProfile.id("foo!bar");
+
+      const result = elasticProfile.validate();
+
+      expect(result._isEmpty()).toEqual(false);
+      expect(result.errors().id[0]).toContain('Invalid id.');
+
+    });
+
+    it('should return error if elastic profile id contains `*`', () => {
+      elasticProfile.id("foo*bar");
+
+      const result = elasticProfile.validate();
+
+      expect(result._isEmpty()).toEqual(false);
+      expect(result.errors().id[0]).toContain('Invalid id.');
+
+    });
+
+    it('should return error if elastic profile id starts with `.`', () => {
+      elasticProfile.id(".foo");
+
+      const result = elasticProfile.validate();
+
+      expect(result._isEmpty()).toEqual(false);
+      expect(result.errors().id[0]).toContain('Invalid id.');
+
+    });
+  });
 });

--- a/server/webapp/WEB-INF/rails.new/spec/webpack/views/elastic_profiles/elastic_profiles_widget_spec.js
+++ b/server/webapp/WEB-INF/rails.new/spec/webpack/views/elastic_profiles/elastic_profiles_widget_spec.js
@@ -402,11 +402,13 @@ describe("ElasticProfilesWidget", () => {
         responseText:    JSON.stringify(profileJSON),
         status:          200,
         responseHeaders: {
-          'ETag': '"foo"'
+          'ETag': '"foo"',
+          'Content-Type': 'application/json'
         }
       });
 
       simulateEvent.simulate($root.find('.clone-profile').get(0), 'click');
+      m.redraw();
 
       const profileId = $('.reveal:visible .modal-body').find('[data-prop-name="id"]').get(0);
       $(profileId).val("foo-clone");

--- a/server/webapp/WEB-INF/rails.new/webpack/models/auth_configs/auth_configs.js
+++ b/server/webapp/WEB-INF/rails.new/webpack/models/auth_configs/auth_configs.js
@@ -58,6 +58,11 @@ AuthConfigs.AuthConfig = function (data) {
 
   this.validatePresenceOf('id');
   this.validatePresenceOf('pluginId');
+  this.validateFormatOf('id', {
+    format:  /^[a-zA-Z0-9_\-]{1}[a-zA-Z0-9_\-.]*$/,
+    message: 'Invalid id. This must be alphanumeric and can contain underscores and periods (however, it cannot start ' +
+             'with a period). The maximum allowed length is 255 characters.'
+  });
 
   CrudMixins.AllOperations.call(this, ['refresh', 'update', 'delete', 'create'], {
     type:     AuthConfigs.AuthConfig,

--- a/server/webapp/WEB-INF/rails.new/webpack/models/elastic_profiles/elastic_profiles.js
+++ b/server/webapp/WEB-INF/rails.new/webpack/models/elastic_profiles/elastic_profiles.js
@@ -53,6 +53,11 @@ ElasticProfiles.Profile = function (data) {
 
   this.validatePresenceOf('id');
   this.validatePresenceOf('pluginId');
+  this.validateFormatOf('id', {
+    format:  /^[a-zA-Z0-9_\-]{1}[a-zA-Z0-9_\-.]*$/,
+    message: 'Invalid id. This must be alphanumeric and can contain underscores and periods (however, it cannot start ' +
+             'with a period). The maximum allowed length is 255 characters.'
+  });
 
   CrudMixins.AllOperations.call(this, ['refresh', 'update', 'delete', 'create'],
     {

--- a/server/webapp/WEB-INF/rails.new/webpack/models/roles/roles.js
+++ b/server/webapp/WEB-INF/rails.new/webpack/models/roles/roles.js
@@ -57,6 +57,11 @@ Roles.Role = function (type, data) {
 
   role.validatePresenceOf('name');
   role.validatePresenceOf('type');
+  role.validateFormatOf('name', {
+    format:  /^[a-zA-Z0-9_\-]{1}[a-zA-Z0-9_\-.]*$/,
+    message: 'Invalid name. This must be alphanumeric and can contain underscores and periods (however, it cannot start ' +
+             'with a period). The maximum allowed length is 255 characters.'
+  });
 
   role.isPluginRole = function () {
     return role.type() === 'plugin';


### PR DESCRIPTION
This will perform client side validataion of entity on `create` or
`update` call and will not make an ajax call if entity is havin any validation errors.