### PR TITLE
ReAuthentication fixes and logging improvements for PluginAuthenticationProvider

### DIFF
--- a/server/src/com/thoughtworks/go/server/security/userdetail/GoUserPrinciple.java
+++ b/server/src/com/thoughtworks/go/server/security/userdetail/GoUserPrinciple.java
@@ -25,12 +25,24 @@ import org.springframework.security.userdetails.User;
 public class GoUserPrinciple extends User {
 
     private final String displayName;
+    private String loginName;
 
     public GoUserPrinciple(String username, String displayName, String password, boolean enabled, boolean accountNonExpired, boolean credentialsNonExpired, boolean accountNonLocked,
                            GrantedAuthority[] authorities)
             throws IllegalArgumentException {
         super(username, password, enabled, accountNonExpired, credentialsNonExpired, accountNonLocked, authorities);
         this.displayName = displayName;
+    }
+
+    public GoUserPrinciple(String username, String displayName, String password, boolean enabled, boolean accountNonExpired, boolean credentialsNonExpired, boolean accountNonLocked,
+                           GrantedAuthority[] authorities, String loginName) {
+        this(username, displayName, password, enabled, accountNonExpired, credentialsNonExpired, accountNonLocked, authorities);
+
+        this.loginName = loginName;
+    }
+
+    public String getLoginName() {
+        return loginName;
     }
 
     public String getDisplayName() {

--- a/server/src/com/thoughtworks/go/server/security/userdetail/GoUserPrinciple.java
+++ b/server/src/com/thoughtworks/go/server/security/userdetail/GoUserPrinciple.java
@@ -30,14 +30,13 @@ public class GoUserPrinciple extends User {
     public GoUserPrinciple(String username, String displayName, String password, boolean enabled, boolean accountNonExpired, boolean credentialsNonExpired, boolean accountNonLocked,
                            GrantedAuthority[] authorities)
             throws IllegalArgumentException {
-        super(username, password, enabled, accountNonExpired, credentialsNonExpired, accountNonLocked, authorities);
-        this.displayName = displayName;
+        this(username, displayName, password, enabled, accountNonExpired, credentialsNonExpired, accountNonLocked, authorities, username);
     }
 
     public GoUserPrinciple(String username, String displayName, String password, boolean enabled, boolean accountNonExpired, boolean credentialsNonExpired, boolean accountNonLocked,
                            GrantedAuthority[] authorities, String loginName) {
-        this(username, displayName, password, enabled, accountNonExpired, credentialsNonExpired, accountNonLocked, authorities);
-
+        super(username, password, enabled, accountNonExpired, credentialsNonExpired, accountNonLocked, authorities);
+        this.displayName = displayName;
         this.loginName = loginName;
     }
 


### PR DESCRIPTION
* Roles are assigned against the username in authenticated user
   object since username used for login can be different from the username
   in the user provided by plugin. e.g when using a authorization ldap
   plugin, admins can provide an ability to login using either `uid`, `mail`
   or `cn` but on succesful authentication a User is created where the
   username is always mapped to the `cn`.
 * A plugin erroring out should not fail authentication,
   rather should try with other plugins if available.
 * Added debug logging around authentication using plugins.