### PR TITLE
Blow up if the JVM version is not 1.8.

### DIFF
--- a/agent-bootstrapper/src/com/thoughtworks/go/agent/bootstrapper/AgentBootstrapper.java
+++ b/agent-bootstrapper/src/com/thoughtworks/go/agent/bootstrapper/AgentBootstrapper.java
@@ -33,6 +33,8 @@ import org.apache.log4j.NDC;
 
 import java.io.File;
 
+import static com.thoughtworks.go.utils.AssertJava8.assertVMVersion;
+
 public class AgentBootstrapper {
 
     private static final int DEFAULT_WAIT_TIME_BEFORE_RELAUNCH_IN_MS = 10000;
@@ -56,6 +58,7 @@ public class AgentBootstrapper {
     }
 
     public static void main(String[] argv) {
+        assertVMVersion();
         AgentBootstrapperArgs args = new AgentCLI().parse(argv);
         LogConfigurator logConfigurator = new LogConfigurator(DEFAULT_LOG4J_CONFIGURATION_FILE);
         logConfigurator.initialize();

--- a/agent/src/com/thoughtworks/go/agent/AgentMain.java
+++ b/agent/src/com/thoughtworks/go/agent/AgentMain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 ThoughtWorks, Inc.
+ * Copyright 2017 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,11 +22,14 @@ import com.thoughtworks.go.logging.LogConfigurator;
 import com.thoughtworks.go.util.SystemEnvironment;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 
+import static com.thoughtworks.go.utils.AssertJava8.assertVMVersion;
+
 
 public final class AgentMain {
     private static final String DEFAULT_LOG4J_CONFIGURATION_FILE = "agent-log4j.properties";
 
     public static void main(String... argv) throws Exception {
+        assertVMVersion();
         AgentBootstrapperArgs args = new AgentCLI().parse(argv);
         LogConfigurator logConfigurator = new LogConfigurator(DEFAULT_LOG4J_CONFIGURATION_FILE);
         logConfigurator.initialize();

--- a/base/src/com/thoughtworks/go/utils/AssertJava8.java
+++ b/base/src/com/thoughtworks/go/utils/AssertJava8.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2017 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.utils;
+
+public class AssertJava8 {
+    public static void assertVMVersion() {
+        String jvmVersion = System.getProperty("java.vm.specification.version");
+
+        if (!"1.8".equals(jvmVersion)) {
+            System.err.println("Running GoCD requires Java version 1.8. You are currently running with Java version " + jvmVersion + ". GoCD will now exit!");
+            System.exit(1);
+        }
+    }
+}

--- a/server/src/com/thoughtworks/go/server/util/GoLauncher.java
+++ b/server/src/com/thoughtworks/go/server/util/GoLauncher.java
@@ -24,6 +24,8 @@ import org.apache.commons.io.FileUtils;
 
 import java.io.File;
 
+import static com.thoughtworks.go.utils.AssertJava8.assertVMVersion;
+
 public final class GoLauncher {
 
     public static final String DEFAULT_LOG4J_CONFIGURATION_FILE = "log4j.properties";
@@ -32,6 +34,7 @@ public final class GoLauncher {
     }
 
     public static void main(String[] args) throws Exception {
+        assertVMVersion();
         SystemEnvironment systemEnvironment = new SystemEnvironment();
         systemEnvironment.setProperty(GoConstants.USE_COMPRESSED_JAVASCRIPT, Boolean.toString(true));
 


### PR DESCRIPTION
Since newer ubuntu systems ship with java 9, which is still
in development, and breaks GoCD and it's libraries. This will
fail with a better error message than it currently does.