### PR TITLE
Using the correct plugin_id format

### DIFF
--- a/server/src/com/thoughtworks/go/server/security/WebBasedAuthenticationFilter.java
+++ b/server/src/com/thoughtworks/go/server/security/WebBasedAuthenticationFilter.java
@@ -35,7 +35,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class WebBasedAuthenticationFilter extends SpringSecurityFilter {
-    private static final Pattern LOGIN_REQUEST_PATTERN = Pattern.compile("^/go/plugin/([^\\s]+)/login$");
+    private static final Pattern LOGIN_REQUEST_PATTERN = Pattern.compile("^/go/plugin/([\\w\\-.]+)/login$");
     private AuthorizationExtension authorizationExtension;
     private GoConfigService goConfigService;
     private SiteUrlProvider siteUrlProvider;

--- a/server/test/unit/com/thoughtworks/go/server/security/PreAuthenticatedRequestsProcessingFilterTest.java
+++ b/server/test/unit/com/thoughtworks/go/server/security/PreAuthenticatedRequestsProcessingFilterTest.java
@@ -67,7 +67,7 @@ public class PreAuthenticatedRequestsProcessingFilterTest {
         securityConfig = new SecurityConfig();
 
         filter.setAuthenticationManager(authenticationManager);
-        filter.setFilterProcessesUrl("^/go/plugin/([^\\s]+)/authenticate$");
+        filter.setFilterProcessesUrl("^/go/plugin/([\\w\\-.]+)/authenticate$");
         stub(configService.security()).toReturn(securityConfig);
         stub(request.getHeaderNames()).toReturn(Collections.emptyEnumeration());
     }
@@ -84,6 +84,16 @@ public class PreAuthenticatedRequestsProcessingFilterTest {
         filter.attemptAuthentication(request);
 
         verify(authenticationManager).authenticate(any(PreAuthenticatedAuthenticationToken.class));
+    }
+
+    @Test
+    public void shouldNotAttemptAuthenticationForAuthenticationPluginRequests() throws IOException, ServletException {
+        when(request.getRequestURI()).thenReturn("/go/plugin/interact/github.oauth/authenticate");
+
+        filter.doFilter(request, response, filterChain);
+
+        verifyZeroInteractions(authenticationManager);
+        verifyZeroInteractions(authorizationExtension);
     }
 
     @Test

--- a/server/test/unit/com/thoughtworks/go/server/security/WebBasedAuthenticationFilterTest.java
+++ b/server/test/unit/com/thoughtworks/go/server/security/WebBasedAuthenticationFilterTest.java
@@ -84,8 +84,8 @@ public class WebBasedAuthenticationFilterTest {
     }
 
     @Test
-    public void shouldIgnoreNonWebBasedAuthenticationRequests() throws Exception {
-        when(request.getRequestURI()).thenReturn("/go/api/agents");
+    public void shouldIgnoreRequestsToAuthenticationPlugins() throws Exception {
+        when(request.getRequestURI()).thenReturn("/go/plugin/interact/github.oauth/login");
 
         filter.doFilter(request, response, filterChain);
 

--- a/server/webapp/WEB-INF/applicationContext-acegi-security.xml
+++ b/server/webapp/WEB-INF/applicationContext-acegi-security.xml
@@ -87,7 +87,7 @@
         p:authenticationFailureUrl="/auth/login?login_error=1"
         p:defaultTargetUrl="/"
         p:alwaysUseDefaultTargetUrl="true"
-        p:filterProcessesUrl="/go/plugin/([^\s]+)/authenticate$" />
+        p:filterProcessesUrl="/go/plugin/([\w\-.]+)/authenticate$" />
 
 
     <bean id="webBasedAuthFilter" class="com.thoughtworks.go.server.security.WebBasedAuthenticationFilter"/>


### PR DESCRIPTION
* WebBasedAuthenticationFilter and PreAuthenticatedRequestsProcessingFilter are supposed to handle requests only for authorization plugins, this is a fix to ensure a correct plugin_id
format is used so that the filters do not handle non-authorization requests.