### PR TITLE
Make the notifications API more consistent

### DIFF
--- a/server/webapp/WEB-INF/rails.new/app/controllers/api_v1/notification_filters_controller.rb
+++ b/server/webapp/WEB-INF/rails.new/app/controllers/api_v1/notification_filters_controller.rb
@@ -61,9 +61,7 @@ module ApiV1
         params["pipeline"],
         params["stage"],
         StageEvent.valueOf(params["event"]),
-        # default checkbox behavior is to send value (defaults to "on") if checked, or to send
-        # nothing if unchecked; thus, only check for presence of the key
-        params.has_key?("myCheckin")
+        !!params["match_commits"]
       )
     end
 

--- a/server/webapp/WEB-INF/rails.new/app/presenters/api_v1/notification_filters_representer.rb
+++ b/server/webapp/WEB-INF/rails.new/app/presenters/api_v1/notification_filters_representer.rb
@@ -9,8 +9,8 @@ module ApiV1
 
     collection :filters do
       property :id
-      property :pipelineName, as: :pipeline_name
-      property :stageName, as: :stage_name
+      property :pipelineName, as: :pipeline
+      property :stageName, as: :stage
       property :event
       property :myCheckin, as: :match_commits
     end

--- a/server/webapp/WEB-INF/rails.new/spec/controllers/api_v1/notification_filters_controller_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/controllers/api_v1/notification_filters_controller_spec.rb
@@ -36,8 +36,8 @@ describe ApiV1::NotificationFiltersController do
 
       get_with_api_header(:index)
       expected = [
-        {"pipeline_name" => "pipeline1", "stage_name" => "defaultStage", "event" => "Fails", "id" => 1, "match_commits" => true},
-        {"pipeline_name" => "[Any Pipeline]", "stage_name" => "[Any Stage]", "event" => "Breaks", "id" => 2, "match_commits" => false}
+        {"pipeline" => "pipeline1", "stage" => "defaultStage", "event" => "Fails", "id" => 1, "match_commits" => true},
+        {"pipeline" => "[Any Pipeline]", "stage" => "[Any Stage]", "event" => "Breaks", "id" => 2, "match_commits" => false}
       ].sort_by {|h| h["id"]}
 
       assert_equal 200, response.status
@@ -59,7 +59,7 @@ describe ApiV1::NotificationFiltersController do
       @user.stub(:notificationFilters).and_return([]) # not verifying this
       @user_service.should_receive(:addNotificationFilter).with(@user.id, filter_for("foo", "bar", "Breaks", true))
 
-      post_with_api_header(:create, pipeline: "foo", stage: "bar", event: "Breaks", myCheckin: "on")
+      post_with_api_header(:create, pipeline: "foo", stage: "bar", event: "Breaks", match_commits: true)
 
       assert_equal 200, response.status
     end
@@ -67,7 +67,7 @@ describe ApiV1::NotificationFiltersController do
     it("validates input") do
       @user.stub(:notificationFilters).and_return([]) # not verifying this
 
-      post_with_api_header(:create, pipeline: "foo", event: "Breaks", myCheckin: "on")
+      post_with_api_header(:create, pipeline: "foo", event: "Breaks", match_commits: true)
 
       assert_equal 400, response.status
       assert_equal "You must specify pipeline, stage, and event.", JSON.parse(response.body)["message"]

--- a/server/webapp/WEB-INF/rails.new/webpack/models/preferences/notification_filters.js
+++ b/server/webapp/WEB-INF/rails.new/webpack/models/preferences/notification_filters.js
@@ -36,6 +36,9 @@
       result[entry[0]] = entry[1];
     }
 
+    result.match_commits = !!result.myCheckin; // eslint-disable-line camelcase
+    delete result.myCheckin;
+
     return JSON.stringify(result);
   }
 

--- a/server/webapp/WEB-INF/rails.new/webpack/views/preferences/notification_filters_list_widget.js.msx
+++ b/server/webapp/WEB-INF/rails.new/webpack/views/preferences/notification_filters_list_widget.js.msx
@@ -40,8 +40,8 @@
         <tbody>
           {_.map(model.filters(), (filter) => {
             return <tr>
-              <td>{filter.pipeline_name}</td>
-              <td>{filter.stage_name}</td>
+              <td>{filter.pipeline}</td>
+              <td>{filter.stage}</td>
               <td>{filter.event}</td>
               <td>{filter.match_commits ? "Mine" : "All"}</td>
               <td>


### PR DESCRIPTION
The JSON input for a notification filter object should match the outputted object

@ketan @jyotisingh Can we get this merged for the release? As I was working on the API docs, I realized that the Notification Filters API was strange, and I fixed it. Would hate to publish the weird implementation as v1.