### PR TITLE
Enable re-authentication by default

### DIFF
--- a/base/src/com/thoughtworks/go/util/SystemEnvironment.java
+++ b/base/src/com/thoughtworks/go/util/SystemEnvironment.java
@@ -206,7 +206,7 @@ public class SystemEnvironment implements Serializable, ConfigDirProvider {
 
     public static GoSystemProperty<Boolean> OPTIMIZE_FULL_CONFIG_SAVE = new GoBooleanSystemProperty("optimize.full.config.save", true);
     public static GoSystemProperty<String> GO_SERVER_MODE = new GoStringSystemProperty("go.server.mode", "production");
-    public static GoBooleanSystemProperty REAUTHENTICATION_ENABLED = new GoBooleanSystemProperty("go.security.reauthentication.enabled", false);
+    public static GoBooleanSystemProperty REAUTHENTICATION_ENABLED = new GoBooleanSystemProperty("go.security.reauthentication.enabled", true);
     public static GoSystemProperty<Long> REAUTHENTICATION_TIME_INTERVAL = new GoLongSystemProperty("go.security.reauthentication.interval", 1800 * 1000L);
     public static GoSystemProperty<Boolean> INBUILT_LDAP_PASSWORD_AUTH_ENABLED = new GoBooleanSystemProperty("go.security.inbuilt.auth.enabled", false);
 

--- a/server/src/com/thoughtworks/go/server/security/userdetail/GoUserPrinciple.java
+++ b/server/src/com/thoughtworks/go/server/security/userdetail/GoUserPrinciple.java
@@ -26,18 +26,21 @@ public class GoUserPrinciple extends User {
 
     private final String displayName;
     private String loginName;
+    private boolean authenticatedUsingAuthorizationPlugin;
 
     public GoUserPrinciple(String username, String displayName, String password, boolean enabled, boolean accountNonExpired, boolean credentialsNonExpired, boolean accountNonLocked,
                            GrantedAuthority[] authorities)
             throws IllegalArgumentException {
-        this(username, displayName, password, enabled, accountNonExpired, credentialsNonExpired, accountNonLocked, authorities, username);
+        this(username, displayName, password, enabled, accountNonExpired, credentialsNonExpired, accountNonLocked, authorities, username, false);
     }
 
-    public GoUserPrinciple(String username, String displayName, String password, boolean enabled, boolean accountNonExpired, boolean credentialsNonExpired, boolean accountNonLocked,
-                           GrantedAuthority[] authorities, String loginName) {
+    public GoUserPrinciple(String username, String displayName, String password, boolean enabled, boolean accountNonExpired,
+                           boolean credentialsNonExpired, boolean accountNonLocked, GrantedAuthority[] authorities,
+                           String loginName, boolean authenticatedUsingAuthorizationPlugin) {
         super(username, password, enabled, accountNonExpired, credentialsNonExpired, accountNonLocked, authorities);
         this.displayName = displayName;
         this.loginName = loginName;
+        this.authenticatedUsingAuthorizationPlugin = authenticatedUsingAuthorizationPlugin;
     }
 
     public String getLoginName() {
@@ -46,5 +49,9 @@ public class GoUserPrinciple extends User {
 
     public String getDisplayName() {
         return displayName;
+    }
+
+    public boolean authenticatedUsingAuthorizationPlugin() {
+        return authenticatedUsingAuthorizationPlugin;
     }
 }

--- a/server/test/unit/com/thoughtworks/go/server/security/providers/PluginAuthenticationProviderTest.java
+++ b/server/test/unit/com/thoughtworks/go/server/security/providers/PluginAuthenticationProviderTest.java
@@ -128,6 +128,7 @@ public class PluginAuthenticationProviderTest {
         assertThat(goUserPrincipal.getDisplayName(), is("display-name"));
         assertThat(goUserPrincipal.getAuthorities().length, is(1));
         assertThat(goUserPrincipal.getAuthorities()[0], is(userAuthority));
+        assertTrue(goUserPrincipal.authenticatedUsingAuthorizationPlugin());
     }
 
     @Test
@@ -147,6 +148,7 @@ public class PluginAuthenticationProviderTest {
         assertThat(goUserPrincipal.getDisplayName(), is("username"));
         assertThat(goUserPrincipal.getAuthorities().length, is(1));
         assertThat(goUserPrincipal.getAuthorities()[0], is(userAuthority));
+        assertFalse(goUserPrincipal.authenticatedUsingAuthorizationPlugin());
     }
 
     @Test
@@ -329,7 +331,7 @@ public class PluginAuthenticationProviderTest {
                         Arrays.asList("blackbird", "admins")
                 )
         );
-        GoUserPrinciple principal = new GoUserPrinciple("username", "Display", "password", true, true, true, true, new GrantedAuthority[]{}, "foo@bar.com");
+        GoUserPrinciple principal = new GoUserPrinciple("username", "Display", "password", true, true, true, true, new GrantedAuthority[]{}, "foo@bar.com", true);
 
         UserDetails userDetails = provider.retrieveUser("username", new UsernamePasswordAuthenticationToken(principal, "password"));
 
@@ -373,7 +375,7 @@ public class PluginAuthenticationProviderTest {
                         Arrays.asList("blackbird", "admins")
                 )
         );
-        GoUserPrinciple principal = new GoUserPrinciple("username", "Display", "password", true, true, true, true, new GrantedAuthority[]{}, null);
+        GoUserPrinciple principal = new GoUserPrinciple("username", "Display", "password", true, true, true, true, new GrantedAuthority[]{}, null, true);
 
         UserDetails userDetails = provider.retrieveUser("username", new UsernamePasswordAuthenticationToken(principal, "password"));
 


### PR DESCRIPTION
* Enabled re-authentication by default, this would force a
  re-authentication of users based on the System Env  `go.security.reauthentication.interval`
* Only users authenticated using the authorization plugins are
  re-authenticated, this done since `Authentication Plugins like
  github.oauth` do not support re-auth