### PR TITLE
Changing authorization enpoint for web based authentication

### DIFF
--- a/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/authorization/AuthorizationExtension.java
+++ b/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/authorization/AuthorizationExtension.java
@@ -227,11 +227,11 @@ public class AuthorizationExtension extends AbstractExtension {
         });
     }
 
-    public String getAuthorizationServerRedirectUrl(String pluginId, List<SecurityAuthConfig> authConfigs, String siteUrl) {
-        return pluginRequestHelper.submitRequest(pluginId, REQUEST_AUTHORIZATION_SERVER_REDIRECT_URL, new DefaultPluginInteractionCallback<String>() {
+    public String getAuthorizationServerUrl(String pluginId, List<SecurityAuthConfig> authConfigs, String siteUrl) {
+        return pluginRequestHelper.submitRequest(pluginId, REQUEST_AUTHORIZATION_SERVER_URL, new DefaultPluginInteractionCallback<String>() {
             @Override
             public String requestBody(String resolvedExtensionVersion) {
-                return getMessageConverter(resolvedExtensionVersion).authorizationServerRedirectUrlRequestBody(pluginId, authConfigs, siteUrl);
+                return getMessageConverter(resolvedExtensionVersion).authorizationServerUrlRequestBody(pluginId, authConfigs, siteUrl);
             }
 
             @Override

--- a/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/authorization/AuthorizationMessageConverter.java
+++ b/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/authorization/AuthorizationMessageConverter.java
@@ -66,5 +66,5 @@ public interface AuthorizationMessageConverter {
 
     String getAuthorizationServerUrl(String responseBody);
 
-    String authorizationServerRedirectUrlRequestBody(String pluginId, List<SecurityAuthConfig> authConfigs, String siteUrl);
+    String authorizationServerUrlRequestBody(String pluginId, List<SecurityAuthConfig> authConfigs, String siteUrl);
 }

--- a/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/authorization/AuthorizationMessageConverterV1.java
+++ b/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/authorization/AuthorizationMessageConverterV1.java
@@ -197,7 +197,7 @@ public class AuthorizationMessageConverterV1 implements AuthorizationMessageConv
     }
 
     @Override
-    public String authorizationServerRedirectUrlRequestBody(String pluginId, List<SecurityAuthConfig> authConfigs, String siteUrl) {
+    public String authorizationServerUrlRequestBody(String pluginId, List<SecurityAuthConfig> authConfigs, String siteUrl) {
         Map<String, Object> requestMap = new HashMap<>();
         requestMap.put("auth_configs", getAuthConfigs(authConfigs));
         requestMap.put("authorization_server_callback_url", authorizationServerCallbackUrl(pluginId, siteUrl));

--- a/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/authorization/AuthorizationPluginConstants.java
+++ b/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/authorization/AuthorizationPluginConstants.java
@@ -44,5 +44,5 @@ public interface AuthorizationPluginConstants {
     String REQUEST_SEARCH_USERS = REQUEST_PREFIX + ".search-users";
 
     String REQUEST_ACCESS_TOKEN = REQUEST_PREFIX + ".fetch-access-token";
-    String REQUEST_AUTHORIZATION_SERVER_REDIRECT_URL = REQUEST_PREFIX + ".authorization-server-redirect-url";
+    String REQUEST_AUTHORIZATION_SERVER_URL = REQUEST_PREFIX + ".authorization-server-url";
 }

--- a/plugin-infra/go-plugin-access/test/com/thoughtworks/go/plugin/access/authorization/AuthorizationExtensionTest.java
+++ b/plugin-infra/go-plugin-access/test/com/thoughtworks/go/plugin/access/authorization/AuthorizationExtensionTest.java
@@ -43,7 +43,6 @@ import org.skyscreamer.jsonassert.JSONAssert;
 
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 
 import static com.thoughtworks.go.plugin.access.authorization.AuthorizationPluginConstants.*;
@@ -299,7 +298,7 @@ public class AuthorizationExtensionTest {
     }
 
     @Test
-    public void shouldTalkToPlugin_To_GetAuthorizationServerRedirectUrl() throws JSONException {
+    public void shouldTalkToPlugin_To_GetAuthorizationServerUrl() throws JSONException {
         String requestBody = "{\n" +
                 "  \"auth_configs\": [\n" +
                 "    {\n" +
@@ -316,9 +315,9 @@ public class AuthorizationExtensionTest {
 
         when(pluginManager.submitTo(eq(PLUGIN_ID), requestArgumentCaptor.capture())).thenReturn(new DefaultGoPluginApiResponse(SUCCESS_RESPONSE_CODE, responseBody));
 
-        String authorizationServerRedirectUrl = authorizationExtension.getAuthorizationServerRedirectUrl(PLUGIN_ID, Collections.singletonList(authConfig), "http://go.site.url");
+        String authorizationServerRedirectUrl = authorizationExtension.getAuthorizationServerUrl(PLUGIN_ID, Collections.singletonList(authConfig), "http://go.site.url");
 
-        assertRequest(requestArgumentCaptor.getValue(), AuthorizationPluginConstants.EXTENSION_NAME, "1.0", REQUEST_AUTHORIZATION_SERVER_REDIRECT_URL, requestBody);
+        assertRequest(requestArgumentCaptor.getValue(), AuthorizationPluginConstants.EXTENSION_NAME, "1.0", REQUEST_AUTHORIZATION_SERVER_URL, requestBody);
         assertThat(authorizationServerRedirectUrl, is("url_to_authorization_server"));
     }
 

--- a/server/src/com/thoughtworks/go/server/security/WebBasedAuthenticationFilter.java
+++ b/server/src/com/thoughtworks/go/server/security/WebBasedAuthenticationFilter.java
@@ -51,7 +51,7 @@ public class WebBasedAuthenticationFilter extends SpringSecurityFilter {
     @Override
     public void doFilterHttp(HttpServletRequest httpRequest, HttpServletResponse httpResponse, FilterChain chain) throws IOException, ServletException {
         if(isWebBasedPluginLoginRequest(httpRequest)) {
-            httpResponse.sendRedirect(authorizationServerRedirectUrl(pluginId(httpRequest), siteUrlProvider.siteUrl(httpRequest)));
+            httpResponse.sendRedirect(authorizationServerUrl(pluginId(httpRequest), siteUrlProvider.siteUrl(httpRequest)));
         }
 
         chain.doFilter(httpRequest, httpResponse);
@@ -64,9 +64,9 @@ public class WebBasedAuthenticationFilter extends SpringSecurityFilter {
         return matcher.group(1);
     }
 
-    private String authorizationServerRedirectUrl(String pluginId, String siteUrl) {
+    private String authorizationServerUrl(String pluginId, String siteUrl) {
         List<SecurityAuthConfig> authConfigs = goConfigService.security().securityAuthConfigs().findByPluginId(pluginId);
-        return this.authorizationExtension.getAuthorizationServerRedirectUrl(pluginId, authConfigs, siteUrl);
+        return this.authorizationExtension.getAuthorizationServerUrl(pluginId, authConfigs, siteUrl);
     }
 
     private boolean isWebBasedPluginLoginRequest(HttpServletRequest request) {

--- a/server/test/unit/com/thoughtworks/go/server/security/WebBasedAuthenticationFilterTest.java
+++ b/server/test/unit/com/thoughtworks/go/server/security/WebBasedAuthenticationFilterTest.java
@@ -68,7 +68,7 @@ public class WebBasedAuthenticationFilterTest {
 
         filter.doFilter(request, response, filterChain);
 
-        verify(authorizationExtension).getAuthorizationServerRedirectUrl("github.oauth", Collections.singletonList(securityAuthConfig), "http://go.site.url");
+        verify(authorizationExtension).getAuthorizationServerUrl("github.oauth", Collections.singletonList(securityAuthConfig), "http://go.site.url");
     }
 
     @Test
@@ -76,7 +76,7 @@ public class WebBasedAuthenticationFilterTest {
         String redirectUrl = "http://github/oauth/login";
 
         when(request.getRequestURI()).thenReturn("/go/plugin/github.oauth/login");
-        when(authorizationExtension.getAuthorizationServerRedirectUrl(eq("github.oauth"), any(List.class), any(String.class))).thenReturn(redirectUrl);
+        when(authorizationExtension.getAuthorizationServerUrl(eq("github.oauth"), any(List.class), any(String.class))).thenReturn(redirectUrl);
 
         filter.doFilter(request, response, filterChain);
 


### PR DESCRIPTION
* Renamed `go.cd.authorization.authorization-server-redirect-url` to
  more appropriate `go.cd.authorization.authorization-server-url`.