### PR TITLE
Stub out client-side validation for EmailSettings

### DIFF
--- a/server/webapp/WEB-INF/rails.new/webpack/models/preferences/email_settings.js
+++ b/server/webapp/WEB-INF/rails.new/webpack/models/preferences/email_settings.js
@@ -19,7 +19,8 @@
   const m      = require("mithril"),
     Stream     = require("mithril/stream"),
     _          = require("lodash"),
-    CrudMixins = require("models/mixins/crud_mixins");
+    CrudMixins = require("models/mixins/crud_mixins"),
+    Errors     = require("models/mixins/errors");
 
   function splitter(string) {
     return _.compact(_.map(string.split(","), _.trim));
@@ -70,6 +71,10 @@
         }).always(() => m.redraw());
       }});
     };
+
+    // just stub this out; the only thing that needs validation is email, and we rely on the default
+    // input[type="email"] pattern for client-side validation
+    this.validate = () => new Errors();
 
     CrudMixins.AllOperations.call(this, ["refresh", "update"], {type: this, resourceUrl, version: "v1"}, {update: {method: "PATCH"}});
   }


### PR DESCRIPTION
There's no need to specify Validatable statements as we rely on the default HTML5 email pattern
validation, so we just need a validate() function to satisfy CrudMixins.

Fixes https://github.com/gocd/gocd/issues/3576