### PR TITLE
set merging order of config partials matching order of appearing in xml

### DIFF
--- a/config/config-api/src/com/thoughtworks/go/config/BasicCruiseConfig.java
+++ b/config/config-api/src/com/thoughtworks/go/config/BasicCruiseConfig.java
@@ -45,12 +45,14 @@ import java.util.concurrent.ConcurrentMap;
 
 import static com.thoughtworks.go.util.ExceptionUtils.bomb;
 import static com.thoughtworks.go.util.ExceptionUtils.bombIfNull;
+import org.apache.log4j.Logger;
 
 /**
  * @understands the configuration for cruise
  */
 @ConfigTag("cruise")
 public class BasicCruiseConfig implements CruiseConfig {
+    private static final Logger LOGGER = Logger.getLogger(BasicCruiseConfig.class);
     @ConfigSubtag
     @SkipParameterResolution
     private ServerConfig serverConfig = new ServerConfig();
@@ -115,6 +117,7 @@ public class BasicCruiseConfig implements CruiseConfig {
             return;
         }
         partList = removePartialsThatDoNotCorrespondToTheCurrentConfigReposList(partList);
+        LOGGER.trace("[ Config Merge ] corresponded list of partials: " + partList);
 
         if (this.strategy instanceof MergeStrategy)
             throw new RuntimeException("cannot merge partials to already merged configuration");
@@ -1055,8 +1058,8 @@ public class BasicCruiseConfig implements CruiseConfig {
     }
 
     private Set<MaterialConfig> getUniqueMaterials(boolean ignoreManualPipelines, boolean ignoreConfigRepos) {
-        Set<MaterialConfig> materialConfigs = new HashSet<>();
-        Set<Map> uniqueMaterials = new HashSet<>();
+        Set<MaterialConfig> materialConfigs = new LinkedHashSet<>();
+        Set<Map> uniqueMaterials = new LinkedHashSet<>();
         for (PipelineConfig pipelineConfig : pipelinesFromAllGroups()) {
             for (MaterialConfig materialConfig : pipelineConfig.materialConfigs()) {
                 if (!uniqueMaterials.contains(materialConfig.getSqlCriteria())) {
@@ -1072,6 +1075,7 @@ public class BasicCruiseConfig implements CruiseConfig {
         }
         if (!ignoreConfigRepos) {
             for (ConfigRepoConfig configRepo : this.configRepos) {
+                LOGGER.trace("[ Config Merge ] check for unique material: " + configRepo);
                 MaterialConfig materialConfig = configRepo.getMaterialConfig();
                 if (!uniqueMaterials.contains(materialConfig.getSqlCriteria())) {
                     materialConfigs.add(materialConfig);

--- a/domain/src/com/thoughtworks/go/server/service/MaterialConfigConverter.java
+++ b/domain/src/com/thoughtworks/go/server/service/MaterialConfigConverter.java
@@ -18,6 +18,7 @@ package com.thoughtworks.go.server.service;
 
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Set;
 
 import com.thoughtworks.go.config.materials.MaterialConfigs;
@@ -75,7 +76,7 @@ public class MaterialConfigConverter {
     }
 
     public Set<Material> toMaterials(Set<MaterialConfig> materialConfigs) {
-        HashSet<Material> materials = new HashSet<>();
+        Set<Material> materials = new LinkedHashSet<>();
         for (MaterialConfig materialConfig : materialConfigs) {
             materials.add(toMaterial(materialConfig));
         }

--- a/server/src/com/thoughtworks/go/server/materials/SCMMaterialSource.java
+++ b/server/src/com/thoughtworks/go/server/materials/SCMMaterialSource.java
@@ -32,6 +32,7 @@ import org.springframework.stereotype.Component;
 
 import java.util.Date;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -97,9 +98,10 @@ public class SCMMaterialSource implements ConfigChangedListener, MaterialSource,
     }
 
     private Set<Material> materialsWithUpdateIntervalElapsed() {
-        Set<Material> materialsForUpdate = new HashSet<>();
+        Set<Material> materialsForUpdate = new LinkedHashSet<>();
         for (Material material : schedulableMaterials) {
             if (hasUpdateIntervalElapsedForScmMaterial(material)) {
+                LOGGER.trace("shedule update for material: " + material);
                 materialsForUpdate.add(material);
             }
         }

--- a/server/src/com/thoughtworks/go/server/service/GoConfigService.java
+++ b/server/src/com/thoughtworks/go/server/service/GoConfigService.java
@@ -540,7 +540,7 @@ public class GoConfigService implements Initializer, CruiseConfigProvider {
     }
 
     public Set<MaterialConfig> getSchedulableSCMMaterials() {
-        HashSet<MaterialConfig> scmMaterials = new HashSet<>();
+        HashSet<MaterialConfig> scmMaterials = new LinkedHashSet<>();
 
         for (MaterialConfig materialConfig : getSchedulableMaterials()) {
             if (!(materialConfig instanceof DependencyMaterialConfig)) {


### PR DESCRIPTION
Case: there are few pipelines, defined in config-repos. One of them (lets call it pipeline A) depends on another (pipeline B). When server loads config, it checks and merges every pipeline one by one. Pipeline internally stores in hashsets, so they merge with main config in random order - and server throw "Pipeline not exists" exception if pipeline A was merged before pipeline B 

Tests would be later, when I would understand test structure