### PR TITLE
whitelisting remoting calls

### DIFF
--- a/server/src/com/thoughtworks/go/server/security/X509AuthoritiesPopulator.java
+++ b/server/src/com/thoughtworks/go/server/security/X509AuthoritiesPopulator.java
@@ -59,7 +59,7 @@ public class X509AuthoritiesPopulator implements org.springframework.security.pr
         Matcher ouMatcher = OU_PATTERN.matcher(principal.getName());
         if (cnMatcher.find() && ouMatcher.find()) {
             GrantedAuthorityImpl agentAuthority = new GrantedAuthorityImpl(role);
-            return new User(cnMatcher.group(1), "", true, true, true, true, new GrantedAuthority[]{agentAuthority});
+            return new User("_go_agent_" + cnMatcher.group(1), "", true, true, true, true, new GrantedAuthority[]{agentAuthority});
         }
         throw new BadCredentialsException("Couldn't find CN and/or OU for the certificate");
     }

--- a/server/test/unit/com/thoughtworks/go/server/security/X509AuthoritiesPopulatorTest.java
+++ b/server/test/unit/com/thoughtworks/go/server/security/X509AuthoritiesPopulatorTest.java
@@ -53,6 +53,7 @@ public class X509AuthoritiesPopulatorTest {
         GrantedAuthority expected = new GrantedAuthorityImpl(ROLE_AGENT);
         assertThat(actual.length, is(1));
         assertThat(actual[0], is(expected));
+        assertThat(userDetails.getUsername(), is("_go_agent_hostname"));
     }
 
 }

--- a/server/webapp/WEB-INF/applicationContext-acegi-security.xml
+++ b/server/webapp/WEB-INF/applicationContext-acegi-security.xml
@@ -239,7 +239,10 @@
             <value><![CDATA[
                 CONVERT_URL_TO_LOWERCASE_BEFORE_COMPARISON
                 PATTERN_TYPE_APACHE_ANT
-                /remoting/**=ROLE_AGENT
+                /remoting/remotebuildrepository=ROLE_AGENT
+                /remoting/files/**=ROLE_AGENT
+                /remoting/properties/**=ROLE_AGENT
+                /remoting/**=ROLE_SUPERVISOR
                 /agent-websocket/**=ROLE_AGENT
             ]]></value>
         </property>


### PR DESCRIPTION
* url_rewrite rules for remoting calls allows agent to make any api
  calls masked as a remoting call. This commit restricts the enpoints
  accessible by an agent by adding a whitelist of allowed endpoints
  using spring `FilterSecurityInterceptor`