### PR TITLE
Add support for http proxy

### DIFF
--- a/base/src/com/thoughtworks/go/agent/common/ssl/GoAgentServerHttpClientBuilder.java
+++ b/base/src/com/thoughtworks/go/agent/common/ssl/GoAgentServerHttpClientBuilder.java
@@ -18,6 +18,7 @@ package com.thoughtworks.go.agent.common.ssl;
 
 import com.thoughtworks.go.util.SslVerificationMode;
 import com.thoughtworks.go.util.SystemEnvironment;
+import org.apache.http.HttpHost;
 import org.apache.http.config.SocketConfig;
 import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
 import org.apache.http.conn.ssl.TrustStrategy;
@@ -64,7 +65,11 @@ public class GoAgentServerHttpClientBuilder extends GoAgentServerClientBuilder<C
         }
 
         sslContextBuilder.loadKeyMaterial(agentKeystore(), keystorePassword().toCharArray());
-
+        String proxyUrl = systemEnvironment.getProxyUrl();
+        if (!proxyUrl.isEmpty()) {
+            HttpHost proxy = HttpHost.create(proxyUrl);
+            builder.setProxy(proxy);
+        }
         SSLConnectionSocketFactory sslConnectionSocketFactory = new SSLConnectionSocketFactory(sslContextBuilder.build(), hostnameVerifier);
         builder.setSSLSocketFactory(sslConnectionSocketFactory);
         return builder.build();

--- a/base/src/com/thoughtworks/go/util/SystemEnvironment.java
+++ b/base/src/com/thoughtworks/go/util/SystemEnvironment.java
@@ -209,7 +209,7 @@ public class SystemEnvironment implements Serializable, ConfigDirProvider {
     public static GoBooleanSystemProperty REAUTHENTICATION_ENABLED = new GoBooleanSystemProperty("go.security.reauthentication.enabled", true);
     public static GoSystemProperty<Long> REAUTHENTICATION_TIME_INTERVAL = new GoLongSystemProperty("go.security.reauthentication.interval", 1800 * 1000L);
     public static GoSystemProperty<Boolean> INBUILT_LDAP_PASSWORD_AUTH_ENABLED = new GoBooleanSystemProperty("go.security.inbuilt.auth.enabled", false);
-
+    public static GoSystemProperty<String> PROXY_URL = new GoStringSystemProperty("go.proxy.url", "");
     private final static Map<String, String> GIT_ALLOW_PROTOCOL;
 
     static {
@@ -825,6 +825,10 @@ public class SystemEnvironment implements Serializable, ConfigDirProvider {
 
     public long getReAuthenticationTimeInterval() {
         return REAUTHENTICATION_TIME_INTERVAL.getValue();
+    }
+
+    public String getProxyUrl(){
+        return PROXY_URL.getValue();
     }
 
     public static abstract class GoSystemProperty<T> {


### PR DESCRIPTION
It is now possible to run the agent and server in
an environment where network access requires a proxy.
While this has not been tested to work against a proxy
that requires authentication, it is an extraction of a
setup which works with a proxy setup.

Set go.proxy.url=http:/proxy.host.com:8080 to enable
proxy access.

Addresses #995