### PR TITLE
Ensure order of auth_config is used to authenticate users #3608

### DIFF
--- a/common/test/unit/com/thoughtworks/go/config/RolesConfigTest.java
+++ b/common/test/unit/com/thoughtworks/go/config/RolesConfigTest.java
@@ -21,6 +21,7 @@ import org.junit.Test;
 import java.util.List;
 
 import static java.util.Arrays.asList;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.core.Is.is;
@@ -92,6 +93,21 @@ public class RolesConfigTest {
 
         assertThat(roles, hasSize(2));
         assertThat(roles, contains(blackbird, spacetiger));
+    }
+
+    @Test
+    public void shouldBeAbleToFetchPluginRolesForAAuthConfig() throws Exception {
+        PluginRoleConfig admin = new PluginRoleConfig("admin", "corporate_ldap");
+        PluginRoleConfig view = new PluginRoleConfig("view", "corporate_ldap");
+        PluginRoleConfig operator = new PluginRoleConfig("operator", "internal_ldap");
+
+        RolesConfig rolesConfig = new RolesConfig(admin, view, operator, new RoleConfig(new CaseInsensitiveString("committer")));
+
+        assertThat(rolesConfig.pluginRoleConfigsFor("corporate_ldap"), hasSize(2));
+        assertThat(rolesConfig.pluginRoleConfigsFor("corporate_ldap"), containsInAnyOrder(admin, view));
+
+        assertThat(rolesConfig.pluginRoleConfigsFor("internal_ldap"), hasSize(1));
+        assertThat(rolesConfig.pluginRoleConfigsFor("internal_ldap"), containsInAnyOrder(operator));
     }
 
     @Test

--- a/config/config-api/src/com/thoughtworks/go/config/RolesConfig.java
+++ b/config/config-api/src/com/thoughtworks/go/config/RolesConfig.java
@@ -142,6 +142,19 @@ public class RolesConfig extends BaseCollection<Role> implements Validatable {
         return filterRolesBy(PluginRoleConfig.class);
     }
 
+    public List<PluginRoleConfig> pluginRoleConfigsFor(String authConfigId) {
+        List<PluginRoleConfig> rolesConfig = new ArrayList<>();
+        for (Role role : this) {
+            if (role instanceof PluginRoleConfig) {
+                if (((PluginRoleConfig) role).getAuthConfigId().equals(authConfigId)) {
+                    rolesConfig.add((PluginRoleConfig) role);
+                }
+            }
+        }
+
+        return rolesConfig;
+    }
+
     public List<RoleConfig> getRoleConfigs() {
         return filterRolesBy(RoleConfig.class);
     }

--- a/plugin-infra/plugin-metadata-store/src/com/thoughtworks/go/plugin/access/authorization/AuthorizationMetadataStore.java
+++ b/plugin-infra/plugin-metadata-store/src/com/thoughtworks/go/plugin/access/authorization/AuthorizationMetadataStore.java
@@ -60,4 +60,12 @@ public class AuthorizationMetadataStore extends MetadataStore<AuthorizationPlugi
     public Set<AuthorizationPluginInfo> getPluginsThatSupportsWebBasedAuthentication() {
         return getPluginsThatSupports(SupportedAuthType.Web);
     }
+
+    public boolean doesPluginSupportPasswordBasedAuthentication(String pluginId) {
+        if (!pluginInfos.containsKey(pluginId)) {
+            return false;
+        }
+
+        return pluginInfos.get(pluginId).getCapabilities().getSupportedAuthType() == SupportedAuthType.Password;
+    }
 }

--- a/plugin-infra/plugin-metadata-store/test/com/thoughtworks/go/plugin/access/authorization/AuthorizationMetadataStoreTest.java
+++ b/plugin-infra/plugin-metadata-store/test/com/thoughtworks/go/plugin/access/authorization/AuthorizationMetadataStoreTest.java
@@ -9,8 +9,10 @@ import org.junit.Test;
 
 import java.util.Set;
 
+import static junit.framework.TestCase.assertFalse;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -48,6 +50,12 @@ public class AuthorizationMetadataStoreTest {
         assertThat(pluginsThatSupportsWebBasedAuthentication.contains(plugin2), is(true));
     }
 
+    @Test
+    public void shouldBeAbleToAnswerIfPluginSupportsPasswordBasedAuthentication() throws Exception {
+        assertTrue(store.doesPluginSupportPasswordBasedAuthentication("plugin-2"));
+        assertFalse(store.doesPluginSupportPasswordBasedAuthentication("plugin-1"));
+    }
+
     private AuthorizationPluginInfo pluginInfo(String pluginId, SupportedAuthType supportedAuthType) {
         AuthorizationPluginInfo pluginInfo = mock(AuthorizationPluginInfo.class);
         PluginDescriptor pluginDescriptor = mock(PluginDescriptor.class);
@@ -58,5 +66,4 @@ public class AuthorizationMetadataStoreTest {
         when(pluginInfo.getCapabilities()).thenReturn(capabilities);
         return pluginInfo;
     }
-
 }


### PR DESCRIPTION


* With this commit the auth_config order in config xml is used to
  derive the order in which plugins are used for authentication.