### PR TITLE
Stop propogating web request logging to root logger

### DIFF
--- a/server/properties/src/config/log4j.properties
+++ b/server/properties/src/config/log4j.properties
@@ -40,7 +40,7 @@ log4j.appender.FileAppender.layout=org.apache.log4j.PatternLayout
 log4j.appender.FileAppender.layout.conversionPattern=%d{ISO8601} %5p [%t] %c{1}:%L - %m%n
 
 #Rolling log file output for web requests
-log4j.additivity.WebRequestsFileAppender=false
+log4j.additivity.org.eclipse.jetty.server.RequestLog=false
 log4j.appender.WebRequestsFileAppender=org.apache.log4j.RollingFileAppender
 log4j.appender.WebRequestsFileAppender.File=logs/web-requests.log
 log4j.appender.WebRequestsFileAppender.MaxFileSize=10240KB


### PR DESCRIPTION
Set additivity flag on logger class instead of appender. This will stop propagation of log message to root logger.

* Set following property to `false` to write web request log to only web-request.log file

```
log4j.additivity.org.eclipse.jetty.server.RequestLog=false
```

If it set to `true` then, it will propagate the web request log to root appender.