### PR TITLE
[WIP] Support for implementation if multiple extensions in a plugin

### DIFF
--- a/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/PluginRequestHelper.java
+++ b/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/PluginRequestHelper.java
@@ -25,7 +25,7 @@ public class PluginRequestHelper {
             throw new PluginNotFoundException(format("Did not find '%s' plugin with id '%s'. Looks like plugin is missing", extensionName, pluginId));
         }
         try {
-            String resolvedExtensionVersion = pluginManager.resolveExtensionVersion(pluginId, goSupportedVersions);
+            String resolvedExtensionVersion = pluginManager.resolveExtensionVersion(pluginId, goSupportedVersions, extensionName);
             DefaultGoPluginApiRequest apiRequest = new DefaultGoPluginApiRequest(extensionName, resolvedExtensionVersion, requestName);
             apiRequest.setRequestBody(pluginInteractionCallback.requestBody(resolvedExtensionVersion));
             apiRequest.setRequestParams(pluginInteractionCallback.requestParams(resolvedExtensionVersion));

--- a/plugin-infra/go-plugin-access/test/com/thoughtworks/go/plugin/access/authentication/AuthenticationExtensionTest.java
+++ b/plugin-infra/go-plugin-access/test/com/thoughtworks/go/plugin/access/authentication/AuthenticationExtensionTest.java
@@ -69,7 +69,7 @@ public class AuthenticationExtensionTest {
         pluginSettingsConfiguration = new PluginSettingsConfiguration();
         requestArgumentCaptor = ArgumentCaptor.forClass(GoPluginApiRequest.class);
 
-        when(pluginManager.resolveExtensionVersion(PLUGIN_ID, Arrays.asList("1.0"))).thenReturn("1.0");
+        when(pluginManager.resolveExtensionVersion(PLUGIN_ID, Arrays.asList("1.0"), authenticationExtension.extensionName())).thenReturn("1.0");
         when(pluginManager.isPluginOfType(AuthenticationExtension.EXTENSION_NAME, PLUGIN_ID)).thenReturn(true);
         when(pluginManager.submitTo(eq(PLUGIN_ID), requestArgumentCaptor.capture())).thenReturn(DefaultGoPluginApiResponse.success(RESPONSE_BODY));
     }

--- a/plugin-infra/go-plugin-access/test/com/thoughtworks/go/plugin/access/authorization/AuthorizationExtensionTest.java
+++ b/plugin-infra/go-plugin-access/test/com/thoughtworks/go/plugin/access/authorization/AuthorizationExtensionTest.java
@@ -70,7 +70,7 @@ public class AuthorizationExtensionTest {
     @Before
     public void setUp() throws Exception {
         initMocks(this);
-        when(pluginManager.resolveExtensionVersion(PLUGIN_ID, Arrays.asList("1.0"))).thenReturn("1.0");
+        when(pluginManager.resolveExtensionVersion(PLUGIN_ID, Arrays.asList("1.0"), AuthorizationPluginConstants.EXTENSION_NAME)).thenReturn("1.0");
         when(pluginManager.isPluginOfType(AuthorizationPluginConstants.EXTENSION_NAME, PLUGIN_ID)).thenReturn(true);
 
         authorizationExtension = new AuthorizationExtension(pluginManager);

--- a/plugin-infra/go-plugin-access/test/com/thoughtworks/go/plugin/access/configrepo/ConfigRepoExtensionTest.java
+++ b/plugin-infra/go-plugin-access/test/com/thoughtworks/go/plugin/access/configrepo/ConfigRepoExtensionTest.java
@@ -39,7 +39,7 @@ public class ConfigRepoExtensionTest {
 
         requestArgumentCaptor = ArgumentCaptor.forClass(GoPluginApiRequest.class);
 
-        when(pluginManager.resolveExtensionVersion(PLUGIN_ID, asList("1.0"))).thenReturn("1.0");
+        when(pluginManager.resolveExtensionVersion(PLUGIN_ID, asList("1.0"), ConfigRepoExtension.EXTENSION_NAME)).thenReturn("1.0");
         when(pluginManager.isPluginOfType(ConfigRepoExtension.EXTENSION_NAME, PLUGIN_ID)).thenReturn(true);
         when(pluginManager.submitTo(eq(PLUGIN_ID), requestArgumentCaptor.capture())).thenReturn(DefaultGoPluginApiResponse.success(responseBody));
     }

--- a/plugin-infra/go-plugin-access/test/com/thoughtworks/go/plugin/access/notification/NotificationExtensionTestBase.java
+++ b/plugin-infra/go-plugin-access/test/com/thoughtworks/go/plugin/access/notification/NotificationExtensionTestBase.java
@@ -65,7 +65,7 @@ public abstract class NotificationExtensionTestBase {
         pluginSettingsConfiguration = new PluginSettingsConfiguration();
         requestArgumentCaptor = ArgumentCaptor.forClass(GoPluginApiRequest.class);
 
-        when(pluginManager.resolveExtensionVersion(PLUGIN_ID, NotificationExtension.goSupportedVersions)).thenReturn(apiVersion());
+        when(pluginManager.resolveExtensionVersion(PLUGIN_ID, NotificationExtension.goSupportedVersions, NotificationExtension.EXTENSION_NAME)).thenReturn(apiVersion());
         when(pluginManager.isPluginOfType(NotificationExtension.EXTENSION_NAME, PLUGIN_ID)).thenReturn(true);
         when(pluginManager.submitTo(eq(PLUGIN_ID), requestArgumentCaptor.capture())).thenReturn(DefaultGoPluginApiResponse.success(RESPONSE_BODY));
     }

--- a/plugin-infra/go-plugin-access/test/com/thoughtworks/go/plugin/access/packagematerial/PackageRepositoryExtensionTest.java
+++ b/plugin-infra/go-plugin-access/test/com/thoughtworks/go/plugin/access/packagematerial/PackageRepositoryExtensionTest.java
@@ -83,7 +83,7 @@ public class PackageRepositoryExtensionTest {
         packageConfiguration.add(new PackageMaterialProperty("key-four", "value-four"));
 
         requestArgumentCaptor = ArgumentCaptor.forClass(GoPluginApiRequest.class);
-        when(pluginManager.resolveExtensionVersion(PLUGIN_ID, asList("1.0"))).thenReturn("1.0");
+        when(pluginManager.resolveExtensionVersion(PLUGIN_ID, asList("1.0"), PackageRepositoryExtension.EXTENSION_NAME)).thenReturn("1.0");
     }
 
     @Test

--- a/plugin-infra/go-plugin-access/test/com/thoughtworks/go/plugin/access/pluggabletask/JsonBasedPluggableTaskTest.java
+++ b/plugin-infra/go-plugin-access/test/com/thoughtworks/go/plugin/access/pluggabletask/JsonBasedPluggableTaskTest.java
@@ -59,7 +59,7 @@ public class JsonBasedPluggableTaskTest {
         task = new JsonBasedPluggableTask(pluginId, new PluginRequestHelper(pluginManager, goSupportedVersions, TaskExtension.TASK_EXTENSION), handlerMap);
         goPluginApiResponse = mock(GoPluginApiResponse.class);
         when(pluginManager.submitTo(eq(pluginId), any(GoPluginApiRequest.class))).thenReturn(goPluginApiResponse);
-        when(pluginManager.resolveExtensionVersion(pluginId, goSupportedVersions)).thenReturn("1.0");
+        when(pluginManager.resolveExtensionVersion(pluginId, goSupportedVersions, TaskExtension.TASK_EXTENSION)).thenReturn("1.0");
         when(goPluginApiResponse.responseCode()).thenReturn(DefaultGoApiResponse.SUCCESS_RESPONSE_CODE);
         when(pluginManager.isPluginOfType(TaskExtension.TASK_EXTENSION, pluginId)).thenReturn(true);
     }

--- a/plugin-infra/go-plugin-access/test/com/thoughtworks/go/plugin/access/pluggabletask/JsonBasedTaskExecutorTest.java
+++ b/plugin-infra/go-plugin-access/test/com/thoughtworks/go/plugin/access/pluggabletask/JsonBasedTaskExecutorTest.java
@@ -62,7 +62,7 @@ public class JsonBasedTaskExecutorTest {
         handlerHashMap.put("1.0", handler);
         final List<String> goSupportedVersions = asList("1.0");
         pluginRequestHelper = new PluginRequestHelper(pluginManager, goSupportedVersions, TaskExtension.TASK_EXTENSION);
-        when(pluginManager.resolveExtensionVersion(pluginId, goSupportedVersions)).thenReturn(extensionVersion);
+        when(pluginManager.resolveExtensionVersion(pluginId, goSupportedVersions, TaskExtension.TASK_EXTENSION)).thenReturn(extensionVersion);
         when(response.responseCode()).thenReturn(DefaultGoApiResponse.SUCCESS_RESPONSE_CODE);
         when(pluginManager.isPluginOfType(TaskExtension.TASK_EXTENSION, pluginId)).thenReturn(true);
     }

--- a/plugin-infra/go-plugin-access/test/com/thoughtworks/go/plugin/access/pluggabletask/TaskExtensionTest.java
+++ b/plugin-infra/go-plugin-access/test/com/thoughtworks/go/plugin/access/pluggabletask/TaskExtensionTest.java
@@ -62,7 +62,7 @@ public class TaskExtensionTest {
         initMocks(this);
         extension = new TaskExtension(pluginManager);
         pluginId = "plugin-id";
-        when(pluginManager.resolveExtensionVersion(eq(pluginId), any(ArrayList.class))).thenReturn("1.0");
+        when(pluginManager.resolveExtensionVersion(eq(pluginId), any(ArrayList.class), TaskExtension.TASK_EXTENSION)).thenReturn("1.0");
 
         pluginSettingsConfiguration = new PluginSettingsConfiguration();
         requestArgumentCaptor = ArgumentCaptor.forClass(GoPluginApiRequest.class);

--- a/plugin-infra/go-plugin-access/test/com/thoughtworks/go/plugin/access/scm/SCMExtensionTest.java
+++ b/plugin-infra/go-plugin-access/test/com/thoughtworks/go/plugin/access/scm/SCMExtensionTest.java
@@ -73,7 +73,7 @@ public class SCMExtensionTest {
 
         requestArgumentCaptor = ArgumentCaptor.forClass(GoPluginApiRequest.class);
 
-        when(pluginManager.resolveExtensionVersion(PLUGIN_ID, asList("1.0"))).thenReturn("1.0");
+        when(pluginManager.resolveExtensionVersion(PLUGIN_ID, asList("1.0"), SCMExtension.EXTENSION_NAME)).thenReturn("1.0");
         when(pluginManager.isPluginOfType(SCMExtension.EXTENSION_NAME, PLUGIN_ID)).thenReturn(true);
         when(pluginManager.submitTo(eq(PLUGIN_ID), requestArgumentCaptor.capture())).thenReturn(DefaultGoPluginApiResponse.success(responseBody));
     }

--- a/plugin-infra/go-plugin-infra/src/com/thoughtworks/go/plugin/infra/DefaultPluginManager.java
+++ b/plugin-infra/go-plugin-infra/src/com/thoughtworks/go/plugin/infra/DefaultPluginManager.java
@@ -31,6 +31,8 @@ import com.thoughtworks.go.util.SystemEnvironment;
 import org.apache.commons.io.FileUtils;
 import org.apache.http.HttpStatus;
 import org.apache.log4j.Logger;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceReference;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -102,6 +104,16 @@ public class DefaultPluginManager implements PluginManager {
     @Override
     public <T, R> R doOn(Class<T> serviceReferenceClass, String pluginId, ActionWithReturn<T, R> actionToDoOnTheRegisteredServiceWhichMatches) {
         return goPluginOSGiFramework.doOn(serviceReferenceClass, pluginId, actionToDoOnTheRegisteredServiceWhichMatches);
+    }
+
+    @Override
+    public <R> R doOnPluginExtensionImpl(String pluginId, ActionWithReturn<GoPlugin, R> actionToDoOnTheRegisteredServiceWhichMatches, String extension) {
+        return goPluginOSGiFramework.doOnPluginExtensionImpl(pluginId, actionToDoOnTheRegisteredServiceWhichMatches, extension);
+    }
+
+    @Override
+    public void doOnPluginExtensionImpl(String pluginId, Action<GoPlugin> actionToDoOnTheRegisteredServiceWhichMatches, String extension) {
+        goPluginOSGiFramework.doOnPluginExtensionImpl(pluginId, actionToDoOnTheRegisteredServiceWhichMatches, extension);
     }
 
     @Override

--- a/plugin-infra/go-plugin-infra/src/com/thoughtworks/go/plugin/infra/FelixGoPluginOSGiFramework.java
+++ b/plugin-infra/go-plugin-infra/src/com/thoughtworks/go/plugin/infra/FelixGoPluginOSGiFramework.java
@@ -295,12 +295,33 @@ public class FelixGoPluginOSGiFramework implements GoPluginOSGiFramework {
             throw new RuntimeException(t.getMessage(), t);
         }
     }
-    private <R> R executeActionOnTheService(Action<GoPlugin> action, GoPlugin service, GoPluginDescriptor goPluginDescriptor) {
+    private void executeActionOnTheService(Action<GoPlugin> action, GoPlugin service, GoPluginDescriptor goPluginDescriptor) {
         try {
             action.execute(service, goPluginDescriptor);
         } catch (Throwable t) {
             throw new RuntimeException(t.getMessage(), t);
         }
+    }
+
+
+    @Override
+    public boolean hasReferenceFor(String extensionName, String pluginId) {
+        if (framework == null) {
+            LOGGER.warn("[Plugin Framework] Plugins are not enabled, so cannot do an action on implementations of " + extensionName);
+            return false;
+        }
+
+        BundleContext bundleContext = framework.getBundleContext();
+        Collection<ServiceReference<GoPlugin>> matchingServiceReferences = findServiceReferenceWithPluginId(GoPlugin.class, pluginId, bundleContext);
+
+        for (ServiceReference<GoPlugin> currentServiceReference : matchingServiceReferences) {
+            GoPlugin service = bundleContext.getService(currentServiceReference);
+            GoPluginIdentifier goPluginIdentifier = service.pluginIdentifier();
+            if(extensionName.equals(goPluginIdentifier.getExtension())){
+                return true;
+            }
+        }
+        return false;
     }
 
 

--- a/plugin-infra/go-plugin-infra/src/com/thoughtworks/go/plugin/infra/GoPluginOSGiFramework.java
+++ b/plugin-infra/go-plugin-infra/src/com/thoughtworks/go/plugin/infra/GoPluginOSGiFramework.java
@@ -16,6 +16,7 @@
 
 package com.thoughtworks.go.plugin.infra;
 
+import com.thoughtworks.go.plugin.api.GoPlugin;
 import com.thoughtworks.go.plugin.infra.plugininfo.GoPluginDescriptor;
 import org.osgi.framework.Bundle;
 
@@ -35,6 +36,10 @@ public interface GoPluginOSGiFramework {
     <T> void doOnAllWithExceptionHandling(Class<T> serviceReferenceClass, Action<T> actionToDoOnEachRegisteredServiceWhichMatches, ExceptionHandler<T> handler);
 
     <T, R> R doOn(Class<T> serviceReferenceClass, String pluginId, ActionWithReturn<T, R> action);
+
+    <R> R doOnPluginExtensionImpl(String pluginId, ActionWithReturn<GoPlugin, R> action, String extension);
+
+    void doOnPluginExtensionImpl(String pluginId, Action<GoPlugin> action, String extension);
 
     <T> void doOn(Class<T> serviceReferenceClass, String pluginId, Action<T> action);
 

--- a/plugin-infra/go-plugin-infra/src/com/thoughtworks/go/plugin/infra/GoPluginOSGiFramework.java
+++ b/plugin-infra/go-plugin-infra/src/com/thoughtworks/go/plugin/infra/GoPluginOSGiFramework.java
@@ -41,6 +41,8 @@ public interface GoPluginOSGiFramework {
 
     void doOnPluginExtensionImpl(String pluginId, Action<GoPlugin> action, String extension);
 
+    boolean hasReferenceFor(String extensionName, String pluginId);
+
     <T> void doOn(Class<T> serviceReferenceClass, String pluginId, Action<T> action);
 
     <T> void doOnWithExceptionHandling(Class<T> serviceReferenceClass, String pluginId, Action<T> action, ExceptionHandler<T> handler);

--- a/plugin-infra/go-plugin-infra/src/com/thoughtworks/go/plugin/infra/PluginManager.java
+++ b/plugin-infra/go-plugin-infra/src/com/thoughtworks/go/plugin/infra/PluginManager.java
@@ -54,5 +54,5 @@ public interface PluginManager {
 
     boolean isPluginOfType(String extension, String pluginId);
 
-    String resolveExtensionVersion(String pluginId, List<String> goSupportedExtensionVersions);
+    String resolveExtensionVersion(String pluginId, List<String> goSupportedExtensionVersions, String extensionName);
 }

--- a/plugin-infra/go-plugin-infra/src/com/thoughtworks/go/plugin/infra/PluginManager.java
+++ b/plugin-infra/go-plugin-infra/src/com/thoughtworks/go/plugin/infra/PluginManager.java
@@ -16,6 +16,7 @@
 
 package com.thoughtworks.go.plugin.infra;
 
+import com.thoughtworks.go.plugin.api.GoPlugin;
 import com.thoughtworks.go.plugin.api.request.GoPluginApiRequest;
 import com.thoughtworks.go.plugin.api.response.GoPluginApiResponse;
 import com.thoughtworks.go.plugin.infra.plugininfo.GoPluginDescriptor;
@@ -32,6 +33,10 @@ public interface PluginManager {
     <T> void doOnAll(Class<T> serviceReferenceClass, Action<T> actionToDoOnEachRegisteredServiceWhichMatches, ExceptionHandler<T> exceptionHandler);
 
     <T, R> R doOn(Class<T> serviceReferenceClass, String pluginId, ActionWithReturn<T, R> actionToDoOnTheRegisteredServiceWhichMatches);
+
+    <R> R doOnPluginExtensionImpl(String pluginId, ActionWithReturn<GoPlugin, R> actionToDoOnTheRegisteredServiceWhichMatches, String extension);
+
+    void doOnPluginExtensionImpl(String pluginId, Action<GoPlugin> actionToDoOnTheRegisteredServiceWhichMatches, String extension);
 
     <T> void doOn(Class<T> serviceReferenceClass, String pluginId, Action<T> action);
 

--- a/plugin-infra/go-plugin-infra/test/com/thoughtworks/go/plugin/infra/DefaultPluginManagerTest.java
+++ b/plugin-infra/go-plugin-infra/test/com/thoughtworks/go/plugin/infra/DefaultPluginManagerTest.java
@@ -368,7 +368,7 @@ public class DefaultPluginManagerTest {
         osGiFrameworkStub.addHasReferenceFor(GoPlugin.class, pluginId, true);
         when(goPlugin.pluginIdentifier()).thenReturn(new GoPluginIdentifier("sample-extension", asList("1.0", "2.0")));
         DefaultPluginManager pluginManager = new DefaultPluginManager(monitor, registry, osGiFrameworkStub, jarChangeListener, pluginRequestProcessorRegistry, pluginWriter, pluginValidator, systemEnvironment);
-        assertThat(pluginManager.resolveExtensionVersion(pluginId, asList("1.0", "2.0", "3.0")), is("2.0"));
+        assertThat(pluginManager.resolveExtensionVersion(pluginId, asList("1.0", "2.0", "3.0"), "sample-extension"), is("2.0"));
 
     }
 
@@ -381,7 +381,7 @@ public class DefaultPluginManagerTest {
         when(goPlugin.pluginIdentifier()).thenReturn(new GoPluginIdentifier("sample-extension", asList("1.0", "2.0")));
         DefaultPluginManager pluginManager = new DefaultPluginManager(monitor, registry, osGiFrameworkStub, jarChangeListener, pluginRequestProcessorRegistry, pluginWriter, pluginValidator, systemEnvironment);
         try {
-            pluginManager.resolveExtensionVersion(pluginId, asList("3.0", "4.0"));
+            pluginManager.resolveExtensionVersion(pluginId, asList("3.0", "4.0"), "sample-extension");
             fail("should have thrown exception for not finding matching extension version");
         } catch (Exception e) {
             assertThat(e.getMessage(), is("Could not find matching extension version between Plugin[plugin-id] and Go"));
@@ -469,6 +469,21 @@ public class DefaultPluginManagerTest {
         @Override
         public <T, R> R doOn(Class<T> serviceReferenceClass, String pluginId, ActionWithReturn<T, R> action) {
             return action.execute((T) serviceReferenceInstance, mock(GoPluginDescriptor.class));
+        }
+
+        @Override
+        public <R> R doOnPluginExtensionImpl(String pluginId, ActionWithReturn<GoPlugin, R> action, String extension) {
+            return null;
+        }
+
+        @Override
+        public void doOnPluginExtensionImpl(String pluginId, Action<GoPlugin> action, String extension) {
+
+        }
+
+        @Override
+        public boolean hasReferenceFor(String extensionName, String pluginId) {
+            return false;
         }
 
         @Override


### PR DESCRIPTION
Right now plugins users are forced to install multiple plugins to implement things around the same tool, because of the restriction in GoCD which allows for just a single implementation for a given extension in a given plugin jar. For instance, for someone following github PR workflow would need to install both https://github.com/ashwanthkumar/gocd-build-github-pull-requests (implements SCM extension) and https://github.com/gocd-contrib/gocd-build-status-notifier (implements Notification extension) to make things work. This PR would allow merging those two plugins into a single one. 

* This PR introduces support for implementation of different extensions as a part of the same plugin jar
* This PR does NOT introduce support for multiple implementation of the same extension in a single jar.