### PR TITLE
Redirect back to the original link after successful login (using web based authorization plugin)

### DIFF
--- a/server/src/com/thoughtworks/go/server/security/PreAuthenticatedRequestsProcessingFilter.java
+++ b/server/src/com/thoughtworks/go/server/security/PreAuthenticatedRequestsProcessingFilter.java
@@ -45,7 +45,6 @@ public class PreAuthenticatedRequestsProcessingFilter extends AbstractProcessing
     public PreAuthenticatedRequestsProcessingFilter(AuthorizationExtension authorizationExtension, GoConfigService configService) {
         this.authorizationExtension = authorizationExtension;
         this.configService = configService;
-        setAlwaysUseDefaultTargetUrl(true);
     }
 
     protected Map<String, String> fetchAuthorizationServerAccessToken(HttpServletRequest request) {

--- a/server/src/com/thoughtworks/go/server/security/WebBasedAuthenticationFilter.java
+++ b/server/src/com/thoughtworks/go/server/security/WebBasedAuthenticationFilter.java
@@ -52,6 +52,7 @@ public class WebBasedAuthenticationFilter extends SpringSecurityFilter {
     public void doFilterHttp(HttpServletRequest httpRequest, HttpServletResponse httpResponse, FilterChain chain) throws IOException, ServletException {
         if(isWebBasedPluginLoginRequest(httpRequest)) {
             httpResponse.sendRedirect(authorizationServerUrl(pluginId(httpRequest), siteUrlProvider.siteUrl(httpRequest)));
+            return;
         }
 
         chain.doFilter(httpRequest, httpResponse);

--- a/server/test/unit/com/thoughtworks/go/server/security/WebBasedAuthenticationFilterTest.java
+++ b/server/test/unit/com/thoughtworks/go/server/security/WebBasedAuthenticationFilterTest.java
@@ -81,6 +81,7 @@ public class WebBasedAuthenticationFilterTest {
         filter.doFilter(request, response, filterChain);
 
         verify(response).sendRedirect(redirectUrl);
+        verifyNoMoreInteractions(filterChain);
     }
 
     @Test

--- a/server/webapp/WEB-INF/applicationContext-acegi-security.xml
+++ b/server/webapp/WEB-INF/applicationContext-acegi-security.xml
@@ -86,10 +86,8 @@
         p:authenticationManager-ref="preAuthenticationManager"
         p:authenticationFailureUrl="/auth/login?login_error=1"
         p:defaultTargetUrl="/"
-        p:alwaysUseDefaultTargetUrl="true"
         p:filterProcessesUrl="/go/plugin/([\w\-.]+)/authenticate$"
         p:invalidateSessionOnSuccessfulAuthentication="true"/>
-
 
     <bean id="webBasedAuthFilter" class="com.thoughtworks.go.server.security.WebBasedAuthenticationFilter"/>
 


### PR DESCRIPTION
Step to validate fix:

1) Install any web based authorization plugin on GoCD server and configure it.
2) End the GoCD server browser session.
3) Try to access a resource that requires login (e.g.
https://gocd.server.url/go/agents#!/agentState/asc)
4) Click on authorization plugin icon
5) After login it should redirect back to original link.