### PR TITLE
Build commands: Support empty tasks in a job

### DIFF
--- a/common/src/com/thoughtworks/go/domain/builder/NullBuilder.java
+++ b/common/src/com/thoughtworks/go/domain/builder/NullBuilder.java
@@ -16,6 +16,7 @@
 
 package com.thoughtworks.go.domain.builder;
 
+import com.thoughtworks.go.domain.BuildCommand;
 import com.thoughtworks.go.domain.BuildLogElement;
 import com.thoughtworks.go.domain.RunIfConfigs;
 import com.thoughtworks.go.plugin.access.pluggabletask.TaskExtension;
@@ -36,5 +37,10 @@ public class NullBuilder extends Builder {
     public void build(BuildLogElement buildElement, DefaultGoPublisher publisher, EnvironmentVariableContext environmentVariableContext, TaskExtension taskExtension) throws
             CruiseControlException {
         buildElement.setBuildDuration(DateUtils.getDurationAsString(0));
+    }
+
+    @Override
+    public BuildCommand buildCommand() {
+        return BuildCommand.noop();
     }
 }

--- a/common/test/unit/com/thoughtworks/go/domain/builder/NullBuilderTest.java
+++ b/common/test/unit/com/thoughtworks/go/domain/builder/NullBuilderTest.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2017 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.domain.builder;
+
+import com.thoughtworks.go.buildsession.BuildSessionBasedTestCase;
+import com.thoughtworks.go.domain.BuildCommand;
+import com.thoughtworks.go.domain.JobResult;
+import org.junit.Test;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.*;
+
+public class NullBuilderTest extends BuildSessionBasedTestCase {
+    @Test
+    public void shouldSupportBuildCommand() throws Exception {
+        BuildCommand command = new NullBuilder().buildCommand();
+        assertThat(newBuildSession().build(command), is(JobResult.Passed));
+    }
+}


### PR DESCRIPTION
Apparently we support empty tasks. So, adding support for that in build commands. A regression test had such a setup.