### PR TITLE
Add origins to show all the origins of an environment where it is defined (#3301)

### DIFF
--- a/config/config-api/src/com/thoughtworks/go/config/remote/RepoConfigOrigin.java
+++ b/config/config-api/src/com/thoughtworks/go/config/remote/RepoConfigOrigin.java
@@ -98,6 +98,10 @@ public class RepoConfigOrigin implements ConfigOrigin {
         this.configRepo = configRepo;
     }
 
+    public ConfigRepoConfig getConfigRepo() {
+        return configRepo;
+    }
+
     public String getRevision() {
         return revision;
     }

--- a/server/webapp/WEB-INF/rails.new/app/presenters/api_v3/admin/environments/environment_config_representer.rb
+++ b/server/webapp/WEB-INF/rails.new/app/presenters/api_v3/admin/environments/environment_config_representer.rb
@@ -38,6 +38,20 @@ module ApiV3
 
         property :name, case_insensitive_string: true
 
+        collection :origin, as: :origins,
+                   skip_parse: true,
+                   getter: lambda {|options|
+                     origin = self.getOrigin
+                     (origin.instance_of? FileConfigOrigin) ? [origin] : origin
+                   },
+                   decorator: lambda {|origin, *|
+                     if origin.instance_of? FileConfigOrigin
+                       Shared::ConfigOrigin::ConfigXmlOriginRepresenter
+                     else
+                       Shared::ConfigOrigin::ConfigRepoOriginRepresenter
+                     end
+                   }
+
         collection :pipelines,
                    exec_context: :decorator,
                    decorator: ApiV3::Admin::Environments::PipelineConfigSummaryRepresenter,

--- a/server/webapp/WEB-INF/rails.new/app/presenters/api_v3/shared/config_origin/config_repo_origin_representer.rb
+++ b/server/webapp/WEB-INF/rails.new/app/presenters/api_v3/shared/config_origin/config_repo_origin_representer.rb
@@ -1,0 +1,39 @@
+##########################################################################
+# Copyright 2017 ThoughtWorks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+
+module ApiV3
+  module Shared
+    module ConfigOrigin
+      class ConfigRepoOriginRepresenter < BaseRepresenter
+        alias_method :config_repo_origin, :represented
+
+        property :type, exec_context: :decorator
+
+        property :repo,
+                 exec_context: :decorator,
+                 decorator: ApiV3::Shared::ConfigOrigin::ConfigRepoSummaryRepresenter
+
+        def type
+          'config repo'
+        end
+
+        def repo
+          config_repo_origin.getConfigRepo
+        end
+      end
+    end
+  end
+end

--- a/server/webapp/WEB-INF/rails.new/app/presenters/api_v3/shared/config_origin/config_repo_summary_representer.rb
+++ b/server/webapp/WEB-INF/rails.new/app/presenters/api_v3/shared/config_origin/config_repo_summary_representer.rb
@@ -1,0 +1,39 @@
+##########################################################################
+# Copyright 2017 ThoughtWorks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+
+module ApiV3
+  module Shared
+    module ConfigOrigin
+      class ConfigRepoSummaryRepresenter < BaseRepresenter
+        alias_method :config_repo, :represented
+
+        link :self do |opts|
+          opts[:url_builder].apiv1_admin_config_repo_url(id: config_repo.getId)
+        end
+
+        link :doc do |opts|
+          'https://api.gocd.org/#config-repos'
+        end
+
+        link :find do |opts|
+          opts[:url_builder].apiv1_admin_config_repo_url(id: '__id__').gsub(/__id__/, ':id')
+        end
+
+        property :id
+      end
+    end
+  end
+end

--- a/server/webapp/WEB-INF/rails.new/app/presenters/api_v3/shared/config_origin/config_xml_origin_representer.rb
+++ b/server/webapp/WEB-INF/rails.new/app/presenters/api_v3/shared/config_origin/config_xml_origin_representer.rb
@@ -1,0 +1,39 @@
+##########################################################################
+# Copyright 2017 ThoughtWorks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+
+module ApiV3
+  module Shared
+    module ConfigOrigin
+      class ConfigXmlOriginRepresenter < BaseRepresenter
+        alias_method :config_xml_config, :represented
+
+        property :type, exec_context: :decorator
+        property :displayName, as: :file
+        property :file,
+                 exec_context: :decorator,
+                 decorator: ApiV3::Shared::ConfigOrigin::ConfigXmlSummaryRepresenter
+
+        def type
+          'local'
+        end
+
+        def file
+          config_xml_config
+        end
+      end
+    end
+  end
+end

--- a/server/webapp/WEB-INF/rails.new/app/presenters/api_v3/shared/config_origin/config_xml_summary_representer.rb
+++ b/server/webapp/WEB-INF/rails.new/app/presenters/api_v3/shared/config_origin/config_xml_summary_representer.rb
@@ -1,0 +1,35 @@
+##########################################################################
+# Copyright 2017 ThoughtWorks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+
+module ApiV3
+  module Shared
+    module ConfigOrigin
+      class ConfigXmlSummaryRepresenter < BaseRepresenter
+        alias_method :config_xml, :represented
+
+        link :self do |opts|
+          opts[:url_builder].config_view_url()
+        end
+
+        link :doc do |opts|
+          'https://api.gocd.org/#get-configuration'
+        end
+
+        property :displayName, as: :name
+      end
+    end
+  end
+end

--- a/server/webapp/WEB-INF/rails.new/spec/presenters/api_v3/admin/environments/environment_config_representer_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/presenters/api_v3/admin/environments/environment_config_representer_spec.rb
@@ -31,6 +31,7 @@ describe ApiV3::Admin::Environments::EnvironmentConfigRepresenter do
       actual_json.delete(:_links)
       expect(actual_json).to eq({
                                   name: 'dev',
+                                  origins: [ApiV3::Shared::ConfigOrigin::ConfigXmlOriginRepresenter.new(com.thoughtworks.go.config.remote.FileConfigOrigin.new).to_hash(url_builder: UrlBuilder.new)],
                                   pipelines: [ApiV3::Admin::Environments::PipelineConfigSummaryRepresenter.new(com.thoughtworks.go.config.EnvironmentPipelineConfig.new('dev-pipeline')).to_hash(url_builder: UrlBuilder.new)],
                                   agents: [ApiV3::Shared::AgentSummaryRepresenter.new(EnvironmentAgentConfig.new('dev-agent')).to_hash(url_builder: UrlBuilder.new),
                                            ApiV3::Shared::AgentSummaryRepresenter.new(EnvironmentAgentConfig.new('omnipresent-agent')).to_hash(url_builder: UrlBuilder.new)],
@@ -42,7 +43,9 @@ describe ApiV3::Admin::Environments::EnvironmentConfigRepresenter do
 
 
     def get_environment_config
-      EnvironmentConfigMother.environment('dev').tap { |c| c.addEnvironmentVariable('username', 'admin') }
+      env = EnvironmentConfigMother.environment('dev').tap { |c| c.addEnvironmentVariable('username', 'admin') }
+      env.setOrigins(com.thoughtworks.go.config.remote.FileConfigOrigin.new)
+      env
     end
 
   end

--- a/server/webapp/WEB-INF/rails.new/spec/presenters/api_v3/shared/config_origin/config_repo_origin_representer_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/presenters/api_v3/shared/config_origin/config_repo_origin_representer_spec.rb
@@ -1,0 +1,47 @@
+##########################################################################
+# Copyright 2017 ThoughtWorks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+
+require 'spec_helper'
+
+describe ApiV3::Shared::ConfigOrigin::ConfigRepoOriginRepresenter do
+  it 'should render remote config origin with hal representation' do
+    config_repo = ConfigRepoConfig.new(GitMaterialConfig.new('https://github.com/config-repos/repo', 'master'), 'json-plugin', 'repo1')
+    config_repo_origin = RepoConfigOrigin.new(config_repo, 'revision1')
+    actual_json = ApiV3::Shared::ConfigOrigin::ConfigRepoOriginRepresenter.new(config_repo_origin).to_hash(url_builder: UrlBuilder.new)
+
+    expect(actual_json).to eq(expected_json)
+  end
+
+  def expected_json
+    {
+      type: 'config repo',
+      repo: {
+        _links: {
+          self: {
+            href: 'http://test.host/api/admin/config_repos/repo1'
+          },
+          doc: {
+            href: 'https://api.gocd.org/#config-repos'
+          },
+          find: {
+            href: 'http://test.host/api/admin/config_repos/:id'
+          }
+        },
+        id: 'repo1'
+      }
+    }
+  end
+end

--- a/server/webapp/WEB-INF/rails.new/spec/presenters/api_v3/shared/config_origin/config_xml_origin_representer_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/presenters/api_v3/shared/config_origin/config_xml_origin_representer_spec.rb
@@ -1,0 +1,45 @@
+##########################################################################
+# Copyright 2017 ThoughtWorks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+
+require 'spec_helper'
+
+describe ApiV3::Shared::ConfigOrigin::ConfigXmlOriginRepresenter do
+  it 'should render local config origin' do
+    presenter = ApiV3::Shared::ConfigOrigin::ConfigXmlOriginRepresenter.new(get_config_xml_origin)
+    actual_json = presenter.to_hash(url_builder: UrlBuilder.new)
+    expect(actual_json).to eq(expected_json)
+  end
+
+  def get_config_xml_origin
+    FileConfigOrigin.new
+  end
+
+  def expected_json
+    {
+      type: 'local',
+      file: {
+        _links: {
+          self: {
+            href: 'http://test.host/admin/config_xml'
+          }, doc: {
+            href: 'https://api.gocd.org/#get-configuration'
+          }
+        },
+        name: 'cruise-config.xml'
+      }
+    }
+  end
+end


### PR DESCRIPTION
### Origins attribute on Environments API JSON Response:
```
{
  "name": "env1",
  "origins": [
    {
      "type": "local",
      "file": {
        "_links": {
          "self": {
            "href": "http://localhost:8153/go/admin/config_xml"
          },
          "doc": {
            "href": "https://api.gocd.org/#get-configuration"
          }
        },
        "name": "cruise-config.xml"
      }
    },
    {
      "type": "config repo",
      "repo": {
        "_links": {
          "self": {
            "href": "http://localhost:8153/go/api/admin/config_repos/repo2"
          },
          "doc": {
            "href": "https://api.gocd.org/#config-repos"
          },
          "find": {
            "href": "http://localhost:8153/go/api/admin/config_repos/:id"
          }
        },
        "id": "repo2"
      }
    },
    {
      "type": "config repo",
      "repo": {
        "_links": {
          "self": {
            "href": "http://localhost:8153/go/api/admin/config_repos/repo1"
          },
          "doc": {
            "href": "https://api.gocd.org/#config-repos"
          },
          "find": {
            "href": "http://localhost:8153/go/api/admin/config_repos/:id"
          }
        },
        "id": "repo1"
      }
    }
  ]
}
```