### PR TITLE
Add withconfigrepo link on environments #(3301)

### DIFF
--- a/server/webapp/WEB-INF/rails.new/app/presenters/api_v3/admin/environments/environment_config_representer.rb
+++ b/server/webapp/WEB-INF/rails.new/app/presenters/api_v3/admin/environments/environment_config_representer.rb
@@ -28,12 +28,20 @@ module ApiV3
           opts[:url_builder].apiv3_admin_environment_url(name: environment.name)
         end
 
+        link :self_with_config_repo do |opts|
+          opts[:url_builder].apiv3_admin_environment_url(name: environment.name) << '?withconfigrepo=true'
+        end
+
         link :doc do |opts|
           'https://api.gocd.io/#environment-config'
         end
 
         link :find do |opts|
           opts[:url_builder].apiv3_admin_environment_url(name: '__environment_name__').gsub(/__environment_name__/, ':environment_name')
+        end
+
+        link :find_with_config_repo do |opts|
+          opts[:url_builder].apiv3_admin_environment_url(name: '__environment_name__').gsub(/__environment_name__/, ':environment_name') << '?withconfigrepo=true'
         end
 
         property :name, case_insensitive_string: true

--- a/server/webapp/WEB-INF/rails.new/app/presenters/api_v3/admin/environments/environments_config_representer.rb
+++ b/server/webapp/WEB-INF/rails.new/app/presenters/api_v3/admin/environments/environments_config_representer.rb
@@ -23,6 +23,10 @@ module ApiV3
           opts[:url_builder].apiv3_admin_environments_url
         end
 
+        link :self_with_config_repo do |opts|
+          opts[:url_builder].apiv3_admin_environments_url << '?withconfigrepo=true'
+        end
+
         link :doc do
           'https://api.gocd.io/#environment-config'
         end

--- a/server/webapp/WEB-INF/rails.new/spec/presenters/api_v3/admin/environments/environment_config_representer_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/presenters/api_v3/admin/environments/environment_config_representer_spec.rb
@@ -23,9 +23,11 @@ describe ApiV3::Admin::Environments::EnvironmentConfigRepresenter do
       presenter = ApiV3::Admin::Environments::EnvironmentConfigRepresenter.new(get_environment_config)
       actual_json = presenter.to_hash(url_builder: UrlBuilder.new)
 
-      expect(actual_json).to have_links(:self, :find, :doc)
+      expect(actual_json).to have_links(:self, :find, :doc, :find_with_config_repo, :self_with_config_repo)
       expect(actual_json).to have_link(:find).with_url('http://test.host/api/admin/environments/:environment_name')
+      expect(actual_json).to have_link(:find_with_config_repo).with_url('http://test.host/api/admin/environments/:environment_name?withconfigrepo=true')
       expect(actual_json).to have_link(:self).with_url('http://test.host/api/admin/environments/dev')
+      expect(actual_json).to have_link(:self_with_config_repo).with_url('http://test.host/api/admin/environments/dev?withconfigrepo=true')
       expect(actual_json).to have_link(:doc).with_url('https://api.gocd.io/#environment-config')
 
       actual_json.delete(:_links)

--- a/server/webapp/WEB-INF/rails.new/spec/presenters/api_v3/admin/environments/environments_config_representer_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/presenters/api_v3/admin/environments/environments_config_representer_spec.rb
@@ -24,7 +24,12 @@ describe ApiV3::Admin::Environments::EnvironmentsConfigRepresenter do
 
     presenter   = ApiV3::Admin::Environments::EnvironmentsConfigRepresenter.new([environment_config_one, environment_config_two])
     actual_json = presenter.to_hash(url_builder: UrlBuilder.new)
-    expect(actual_json).to have_links(:self, :doc)
+    expect(actual_json).to have_links(:self, :doc, :self_with_config_repo)
+
+    expect(actual_json).to have_link(:self).with_url('http://test.host/api/admin/environments')
+    expect(actual_json).to have_link(:self_with_config_repo).with_url('http://test.host/api/admin/environments?withconfigrepo=true')
+    expect(actual_json).to have_link(:doc).with_url('https://api.gocd.io/#environment-config')
+
     actual_json.fetch(:_embedded).should == {
       :environments => [ ApiV3::Admin::Environments::EnvironmentConfigRepresenter.new(environment_config_one).to_hash(url_builder: UrlBuilder.new),
                          ApiV3::Admin::Environments::EnvironmentConfigRepresenter.new(environment_config_two).to_hash(url_builder: UrlBuilder.new) ]


### PR DESCRIPTION
##### Get Environment links:
```
"_links": {
  "self": {
    "href": "http://localhost:8153/go/api/admin/environments/env1"
  },
  "self_with_config_repo": {
    "href": "http://localhost:8153/go/api/admin/environments/env1?withconfigrepo=true"
  },
  "doc": {
    "href": "https://api.gocd.io/#environment-config"
  },
  "find": {
    "href": "http://localhost:8153/go/api/admin/environments/:environment_name"
  },
  "find_with_config_repo": {
    "href": "http://localhost:8153/go/api/admin/environments/:environment_name?withconfigrepo=true"
  }
}
```

##### Index Environment links:
```
"_links": {
  "self": {
    "href": "http://localhost:8153/go/api/admin/environments"
  },
  "self_with_config_repo": {
    "href": "http://localhost:8153/go/api/admin/environments?withconfigrepo=true"
  },
  "doc": {
    "href": "https://api.gocd.io/#environment-config"
  }
}
```
