### PR TITLE
Gradle cleanup

### DIFF
--- a/development-utility/development-server/build.gradle
+++ b/development-utility/development-server/build.gradle
@@ -16,6 +16,12 @@
 
 description = 'GoCD Server used for development'
 
+configurations {
+  copyOnly {
+    transitive = false
+  }
+}
+
 dependencies {
   compile project(':server')
   compile group: 'org.eclipse.jetty', name: 'jetty-server', version: versions.jetty
@@ -33,4 +39,31 @@ dependencies {
   compile group: 'org.bouncycastle', name: 'bcprov-jdk15on', version: '1.47'
   compile group: 'org.slf4j', name: 'slf4j-api', version: '1.7.21'
   compile group: 'org.slf4j', name: 'slf4j-log4j12', version: '1.7.21'
+
+  copyOnly project(path: ':tw-go-plugins', configuration: 'pluginsZipConfig')
+  copyOnly project(':go-plugin-activator')
+}
+
+def generatedResourcesOutput = file("resources-generated")
+
+sourceSets {
+  main {
+    resources {
+      output.dir generatedResourcesOutput, builtBy: 'generateResources'
+      srcDirs += generatedResourcesOutput
+    }
+  }
+}
+
+clean {
+  delete(generatedResourcesOutput)
+}
+
+task generateResources(type: Copy) {
+  outputs.dir(generatedResourcesOutput)
+
+  into generatedResourcesOutput
+  from(project.configurations.copyOnly) {
+    rename "(.*)-${project.version}.(jar|zip)", '$1.$2'
+  }
 }

--- a/server/webapp/WEB-INF/rails.new/app/controllers/api/plugin_images_controller.rb
+++ b/server/webapp/WEB-INF/rails.new/app/controllers/api/plugin_images_controller.rb
@@ -16,7 +16,6 @@
 
 module Api
   class PluginImagesController < ::ApplicationController
-    Rails.logger.fatal('reached here')
     def show
       image = default_plugin_info_finder.getImage(params[:plugin_id], params[:hash])
       if image

--- a/test-utils/build.gradle
+++ b/test-utils/build.gradle
@@ -15,6 +15,13 @@
  */
 
 description = 'GoCD Test Utilities'
+
+configurations {
+  copyOnly {
+    transitive = false
+  }
+}
+
 dependencies {
   compile project(':util')
   compile group: 'cglib', name: 'cglib', version: '2.1_3'
@@ -45,18 +52,29 @@ dependencies {
   compile(group: 'org.dbunit', name: 'dbunit', version: '2.5.1')
 
   compile group: 'org.apache.mina', name: 'mina-core', version: '2.0.0'
+  copyOnly project(path: ':agent-launcher', configuration: 'fatJarConfig')
+  copyOnly project(path: ':test-agent')
+  copyOnly project(path: ':tfs-impl-14', configuration: 'fatJarConfig')
 }
 
-processResources {
-  dependsOn ':agent-launcher:fatJar', ':test-agent:jar', ':tfs-impl-14:fatJar'
-  from({
-    [
-      project(':agent-launcher').fatJar.archivePath,
-      project(':tfs-impl-14').fatJar.archivePath,
-      project(':test-agent').jar.archivePath
-    ]
-  }) {
-    into "testdata/gen"
-    rename "(.*)-${project.version}.jar", '$1.jar'
+def generatedResourcesOutput = file("resources-generated")
+
+sourceSets {
+  main {
+    resources {
+      output.dir generatedResourcesOutput, builtBy: 'generateResources'
+      srcDirs += generatedResourcesOutput
+    }
+  }
+}
+
+clean {
+  delete(generatedResourcesOutput)
+}
+
+task generateResources(type: Copy) {
+  into "$generatedResourcesOutput/testdata/gen"
+  from(project.configurations.copyOnly) {
+    rename "(.*)-${project.version}.(jar|zip)", '$1.$2'
   }
 }

--- a/tw-go-plugins/build.gradle
+++ b/tw-go-plugins/build.gradle
@@ -79,13 +79,8 @@ task createVersionFile {
 task downloadPlugins {
 }
 
-task copyPlugins(type: Delete) {
-  dependsOn downloadPlugins
-}
-
 task pluginsZip(type: Zip) {
   finalizedBy 'verifyPluginZip'
-  dependsOn copyPlugins
 
   baseName = 'plugins'
   dependsOn createVersionFile
@@ -106,15 +101,18 @@ artifacts {
 }
 
 dependencies.each { dep ->
-  def destFile = new File(gradle.gradleUserHomeDir, "download-cache/${DigestUtils.md5Hex(dep.downloadUrl)}/${dep.repo}.jar")
   task "download-${dep.repo}"(type: DownloadFile) { downloadTask ->
     downloadPlugins.dependsOn downloadTask
-    src dep.downloadUrl
-    dest destFile
-    checksum dep.checksum
+    downloadTask.src dep.downloadUrl
+    downloadTask.dest destFile(dep)
+    downloadTask.checksum dep.checksum
   }
 
-  pluginsZip.from(destFile)
+  pluginsZip.from(destFile(dep))
+}
+
+private File destFile(GithubArtifact dep) {
+  new File(gradle.gradleUserHomeDir, "download-cache/${DigestUtils.md5Hex(dep.downloadUrl)}/${dep.repo}.jar")
 }
 
 task prepare(dependsOn: pluginsZip)


### PR DESCRIPTION
Instead of copying files as part of gradle tasks setup sourceSets with
`builtBy` option to "generate" these resources as part of the build
files.

IntelliJ understands source sets better than resources appearing in the
`target` directory automagically. These resources were removed by
IntelliJ because it could not find the corresponding source for the
resource.