### PR TITLE
Spring bean reinit bug

### DIFF
--- a/agent/build.gradle
+++ b/agent/build.gradle
@@ -21,7 +21,7 @@ description = 'GoCD Agent'
 sourceSets {
   test {
     java {
-      srcDirs = ['test/functional', 'test/unit']
+      srcDirs = ['test/functional', 'test/unit', 'test/integration']
     }
   }
 }

--- a/agent/resources/applicationContext.xml
+++ b/agent/resources/applicationContext.xml
@@ -64,13 +64,9 @@
   <bean id="httpClient" class="com.thoughtworks.go.agent.common.ssl.GoAgentServerHttpClient">
     <constructor-arg ref="httpClientBuilder"/>
   </bean>
-  <bean id="httpClientBuilder" class="com.thoughtworks.go.agent.common.ssl.GoAgentServerHttpClientBuilder">
-    <constructor-arg ref="systemEnvironment"/>
-  </bean>
+  <bean id="httpClientBuilder" class="com.thoughtworks.go.agent.common.ssl.GoAgentServerHttpClientBuilder" autowire="constructor" />
 
-  <bean id="webSocketClientBuilder" class="com.thoughtworks.go.agent.common.ssl.GoAgentServerWebSocketClientBuilder">
-    <constructor-arg ref="systemEnvironment"/>
-  </bean>
+  <bean id="webSocketClientBuilder" class="com.thoughtworks.go.agent.common.ssl.GoAgentServerWebSocketClientBuilder" autowire="constructor" />
 
   <bean id="webSocketClientHandler" class="com.thoughtworks.go.agent.WebSocketClientHandler"/>
   <bean id="webSocketSessionHandler" class="com.thoughtworks.go.agent.WebSocketSessionHandler"/>

--- a/agent/src/com/thoughtworks/go/agent/common/ssl/GoAgentServerWebSocketClientBuilder.java
+++ b/agent/src/com/thoughtworks/go/agent/common/ssl/GoAgentServerWebSocketClientBuilder.java
@@ -20,6 +20,7 @@ import com.thoughtworks.go.util.SslVerificationMode;
 import com.thoughtworks.go.util.SystemEnvironment;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.eclipse.jetty.websocket.client.WebSocketClient;
+import org.springframework.beans.factory.annotation.Autowired;
 
 import javax.net.ssl.TrustManager;
 import java.security.KeyStore;
@@ -27,6 +28,11 @@ import java.security.cert.CRL;
 import java.util.Collection;
 
 public class GoAgentServerWebSocketClientBuilder extends GoAgentServerClientBuilder<WebSocketClient> {
+    @Autowired
+    public GoAgentServerWebSocketClientBuilder(SystemEnvironment systemEnvironment) {
+        super(systemEnvironment);
+    }
+
     @Override
     public WebSocketClient build() throws Exception {
         SslContextFactory sslContextFactory = sslVerificationMode == SslVerificationMode.NONE ? new TrustAllSSLContextFactory() : new SslContextFactory();
@@ -48,10 +54,6 @@ public class GoAgentServerWebSocketClientBuilder extends GoAgentServerClientBuil
         WebSocketClient client = new WebSocketClient(sslContextFactory);
         client.setMaxIdleTimeout(systemEnvironment.getWebsocketMaxIdleTime());
         return client;
-    }
-
-    public GoAgentServerWebSocketClientBuilder(SystemEnvironment systemEnvironment) {
-        super(systemEnvironment);
     }
 
     private class TrustAllSSLContextFactory extends SslContextFactory {

--- a/agent/test/integration/com/thoughtworks/go/agent/SpringBeanCandidateConstructorIntegrationTest.java
+++ b/agent/test/integration/com/thoughtworks/go/agent/SpringBeanCandidateConstructorIntegrationTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2017 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.agent;
+
+import com.thoughtworks.go.agent.common.ssl.GoAgentServerHttpClient;
+import com.thoughtworks.go.agent.common.ssl.GoAgentServerHttpClientBuilder;
+import com.thoughtworks.go.agent.common.ssl.GoAgentServerWebSocketClientBuilder;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.BeanUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.AutowiredAnnotationBeanPostProcessor;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.support.AbstractApplicationContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsNull.notNullValue;
+import static org.junit.Assert.fail;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(locations = {
+        "classpath:applicationContext.xml",
+})
+public class SpringBeanCandidateConstructorIntegrationTest {
+    @Autowired
+    private ApplicationContext applicationContext;
+
+    @Test
+    public void shouldEnsureThatNoBeanHasMoreThanOneCandidateConstructors() throws IllegalAccessException, InvocationTargetException, InstantiationException, NoSuchMethodException {
+        String[] allBeans = applicationContext.getBeanDefinitionNames();
+        ConfigurableListableBeanFactory beanFactory = ((AbstractApplicationContext) applicationContext).getBeanFactory();
+        AutowiredAnnotationBeanPostProcessor autowiredAnnotationBeanPostProcessor = new AutowiredAnnotationBeanPostProcessor();
+
+        //Beans which are instantiated by explicitly specifying a constructor and its args in the applicationContext xml files
+        List<Class<?>> exclusions = Arrays.asList(GoAgentServerHttpClient.class, GoAgentServerHttpClientBuilder.class,
+                AgentHTTPClientController.class);
+        for (String name : allBeans) {
+            Object bean = beanFactory.getSingleton(name);
+            if (bean != null) {
+                if (bean.getClass().getCanonicalName().startsWith("com.thoughtworks.go")) {
+                    Constructor<?>[] candidateConstructors = autowiredAnnotationBeanPostProcessor.determineCandidateConstructors(bean.getClass(), name);
+                    if (candidateConstructors == null) {
+                        Constructor[] declaredConstructors = bean.getClass().getDeclaredConstructors();
+                        Constructor<?> defaultConstructor = null;
+                        for (Constructor<?> declaredConstructor : declaredConstructors) {
+                            if (declaredConstructor.getParameterCount() == 0) {
+                                defaultConstructor = declaredConstructor;
+                                break;
+                            }
+                        }
+                        if (!exclusions.contains(bean.getClass())) {
+                            assertThat(String.format("Bean doesn't have a default or autowired constructor => name: %s, class: %s", name, bean.getClass()), defaultConstructor, is(notNullValue()));
+                            try {
+                                BeanUtils.instantiateClass(defaultConstructor);
+                            } catch (Exception e) {
+                                fail(String.format("Default constructor failed : %s. Stacktrace: %s", e.getMessage(), e.getStackTrace()));
+                            }
+                        }
+
+                    } else {
+                        assertThat(String.format("name: %s class: %s", name, bean.getClass()), candidateConstructors.length, is(1));
+                    }
+                }
+            }
+        }
+    }
+}

--- a/base/src/com/thoughtworks/go/agent/common/ssl/GoAgentServerHttpClientBuilder.java
+++ b/base/src/com/thoughtworks/go/agent/common/ssl/GoAgentServerHttpClientBuilder.java
@@ -30,7 +30,6 @@ import org.apache.http.ssl.SSLContextBuilder;
 import javax.net.ssl.HostnameVerifier;
 import java.io.*;
 import java.security.*;
-
 public class GoAgentServerHttpClientBuilder extends GoAgentServerClientBuilder<CloseableHttpClient> {
 
     public GoAgentServerHttpClientBuilder(File rootCertFile, SslVerificationMode sslVerificationMode) {

--- a/base/src/com/thoughtworks/go/util/SystemEnvironment.java
+++ b/base/src/com/thoughtworks/go/util/SystemEnvironment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 ThoughtWorks, Inc.
+ * Copyright 2017 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -54,6 +54,7 @@ public class SystemEnvironment implements Serializable, ConfigDirProvider {
 
     public static final String PARENT_LOADER_PRIORITY = "parent.loader.priority";
     public static final String AGENT_CONTENT_MD5_HEADER = "Agent-Content-MD5";
+    public static final String GO_ARTIFACT_PAYLOAD_SIZE_HEADER = "X-GO-ARTIFACT-SIZE";
 
     public static final String AGENT_LAUNCHER_CONTENT_MD5_HEADER = "Agent-Launcher-Content-MD5";
 

--- a/common/src/com/thoughtworks/go/remote/work/RemoteConsoleAppender.java
+++ b/common/src/com/thoughtworks/go/remote/work/RemoteConsoleAppender.java
@@ -44,7 +44,7 @@ public class RemoteConsoleAppender implements ConsoleAppender {
                 LOGGER.debug("Appending console to URL -> " + consoleUri);
             }
             putMethod.setEntity(new StringEntity(content, Charset.defaultCharset()));
-            HttpService.setSizeHeader(putMethod, content.getBytes().length);
+            httpService.setSizeHeader(putMethod, content.getBytes().length);
             CloseableHttpResponse response = httpService.execute(putMethod);
             if (LOGGER.isDebugEnabled()) {
                 LOGGER.debug("Got " + response.getStatusLine().getStatusCode());

--- a/common/src/com/thoughtworks/go/util/HttpService.java
+++ b/common/src/com/thoughtworks/go/util/HttpService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 ThoughtWorks, Inc.
+ * Copyright 2017 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,6 @@
 package com.thoughtworks.go.util;
 
 import com.thoughtworks.go.agent.common.ssl.GoAgentServerHttpClient;
-import com.thoughtworks.go.agent.common.ssl.GoAgentServerHttpClientBuilder;
 import com.thoughtworks.go.domain.FetchHandler;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.logging.Log;
@@ -33,24 +32,17 @@ import org.apache.http.entity.mime.content.ByteArrayBody;
 import org.apache.http.entity.mime.content.FileBody;
 import org.apache.http.message.BasicNameValuePair;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Component;
 
 import javax.servlet.http.HttpServletResponse;
 import java.io.*;
 import java.util.Arrays;
 import java.util.Properties;
 
-@Component
 public class HttpService {
     private HttpClientFactory httpClientFactory;
     private static final Log LOGGER = LogFactory.getLog(HttpService.class);
-    public static final String GO_ARTIFACT_PAYLOAD_SIZE = "X-GO-ARTIFACT-SIZE";
 
-    public HttpService() {
-        this(new GoAgentServerHttpClient(new GoAgentServerHttpClientBuilder(new SystemEnvironment())));
-    }
-
-    @Autowired(required = false)
+    @Autowired
     public HttpService(GoAgentServerHttpClient httpClient) {
         this(new HttpClientFactory(httpClient));
     }
@@ -137,8 +129,8 @@ public class HttpService {
         return response;
     }
 
-    public static void setSizeHeader(HttpRequestBase method, long size) {
-        method.setHeader(GO_ARTIFACT_PAYLOAD_SIZE, String.valueOf(size));
+    public void setSizeHeader(HttpRequestBase method, long size) {
+        method.setHeader(SystemEnvironment.GO_ARTIFACT_PAYLOAD_SIZE_HEADER, String.valueOf(size));
     }
 
     /**

--- a/common/test/unit/com/thoughtworks/go/domain/DownloadActionTest.java
+++ b/common/test/unit/com/thoughtworks/go/domain/DownloadActionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 ThoughtWorks, Inc.
+ * Copyright 2017 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -122,6 +122,7 @@ public class DownloadActionTest {
         private int timesCalled = 0;
 
         MockCachingFetchZipHttpService(int count) {
+            super(null);
             this.count = count;
         }
 
@@ -151,6 +152,7 @@ public class DownloadActionTest {
         private int timesCalled = 0;
 
         public FailSometimesHttpService(int count) {
+            super(null);
             this.count = count;
         }
 

--- a/common/test/unit/com/thoughtworks/go/domain/builder/FetchArtifactBuilderTest.java
+++ b/common/test/unit/com/thoughtworks/go/domain/builder/FetchArtifactBuilderTest.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.zip.Deflater;
 
+import com.thoughtworks.go.agent.common.ssl.GoAgentServerHttpClient;
 import com.thoughtworks.go.domain.*;
 import com.thoughtworks.go.util.HttpService;
 import com.thoughtworks.go.util.TestFileUtil;
@@ -222,6 +223,10 @@ public class FetchArtifactBuilderTest {
     }
 
     private class StubFetchZipHttpService extends HttpService {
+        public StubFetchZipHttpService() {
+            super(null);
+        }
+
         public int download(String url, FetchHandler handler) throws IOException {
             handler.handle(new FileInputStream(zip));
             return SC_OK;

--- a/common/test/unit/com/thoughtworks/go/remote/work/HttpServiceStub.java
+++ b/common/test/unit/com/thoughtworks/go/remote/work/HttpServiceStub.java
@@ -39,6 +39,7 @@ public class HttpServiceStub extends HttpService {
     }
 
     public HttpServiceStub(int returnCode) {
+        super(null);
         this.returnCode = returnCode;
     }
 

--- a/common/test/unit/com/thoughtworks/go/util/HttpServiceTest.java
+++ b/common/test/unit/com/thoughtworks/go/util/HttpServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 ThoughtWorks, Inc.
+ * Copyright 2017 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,7 +36,6 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.Arrays;
 
-import static com.thoughtworks.go.util.HttpService.GO_ARTIFACT_PAYLOAD_SIZE;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.*;
@@ -82,7 +81,7 @@ public class HttpServiceTest {
 
         service.upload(uploadUrl, 100L, uploadingFile, checksums);
 
-        verify(mockPostMethod).setHeader(GO_ARTIFACT_PAYLOAD_SIZE, "100");
+        verify(mockPostMethod).setHeader(SystemEnvironment.GO_ARTIFACT_PAYLOAD_SIZE_HEADER, "100");
         verify(mockPostMethod).setHeader("Confirm", "true");
         verify(httpClientFactory).createMultipartRequestEntity(uploadingFile, checksums);
         verify(httpClient).execute(mockPostMethod);

--- a/domain/src/com/thoughtworks/go/server/transaction/TransactionSynchronizationManager.java
+++ b/domain/src/com/thoughtworks/go/server/transaction/TransactionSynchronizationManager.java
@@ -16,8 +16,10 @@
 
 package com.thoughtworks.go.server.transaction;
 
+import org.springframework.stereotype.Component;
 import org.springframework.transaction.support.TransactionSynchronization;
 
+@Component
 public class TransactionSynchronizationManager {
     public void registerSynchronization(TransactionSynchronization synchronization) {
         TransactionTemplate.txnCtx().registerSynchronization(synchronization);

--- a/server/src/com/thoughtworks/go/server/dao/sparql/ShineDao.java
+++ b/server/src/com/thoughtworks/go/server/dao/sparql/ShineDao.java
@@ -1,23 +1,20 @@
-/*************************GO-LICENSE-START*********************************
- * Copyright 2014 ThoughtWorks, Inc.
+/*
+ * Copyright 2017 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *************************GO-LICENSE-END***********************************/
+ */
 
 package com.thoughtworks.go.server.dao.sparql;
-
-import java.util.Arrays;
-import java.util.List;
 
 import com.thoughtworks.go.domain.JobIdentifier;
 import com.thoughtworks.go.domain.StageIdentifier;
@@ -35,15 +32,21 @@ import com.thoughtworks.studios.shine.semweb.BoundVariables;
 import com.thoughtworks.studios.shine.xunit.XUnitOntology;
 import org.apache.commons.lang.StringUtils;
 import org.apache.log4j.Logger;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.Arrays;
+import java.util.List;
 
 /**
  * @understands how to get data out of shine
  */
+
 public class ShineDao {
     private static final Logger LOGGER = Logger.getLogger(ShineDao.class);
     private StagesQuery stagesQuery;
     private final StageService stageService;
 
+    @Autowired
     public ShineDao(StagesQuery stagesQuery, StageService stageService, PipelineInstanceLoader pipelineInstanceLoader) {
         this.stagesQuery = stagesQuery;
         this.stageService = stageService;

--- a/server/src/com/thoughtworks/go/server/security/ArtifactSizeEnforcementFilter.java
+++ b/server/src/com/thoughtworks/go/server/security/ArtifactSizeEnforcementFilter.java
@@ -1,39 +1,33 @@
-/*************************GO-LICENSE-START*********************************
- * Copyright 2014 ThoughtWorks, Inc.
+/*
+ * Copyright 2017 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *************************GO-LICENSE-END***********************************/
+ */
 
 package com.thoughtworks.go.server.security;
-
-import java.io.IOException;
-import javax.servlet.Filter;
-import javax.servlet.FilterChain;
-import javax.servlet.FilterConfig;
-import javax.servlet.ServletException;
-import javax.servlet.ServletRequest;
-import javax.servlet.ServletResponse;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 
 import com.thoughtworks.go.server.service.ArtifactsDirHolder;
 import com.thoughtworks.go.server.util.LastOperationTime;
 import com.thoughtworks.go.util.GoConstants;
-import com.thoughtworks.go.util.HttpService;
 import com.thoughtworks.go.util.StringUtil;
 import com.thoughtworks.go.util.SystemEnvironment;
 import org.apache.log4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
+
+import javax.servlet.*;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
 
 public class ArtifactSizeEnforcementFilter implements Filter {
 
@@ -55,7 +49,7 @@ public class ArtifactSizeEnforcementFilter implements Filter {
         HttpServletRequest req = (HttpServletRequest) request;
         HttpServletResponse res = (HttpServletResponse) response;
 
-        String headerValue = req.getHeader(HttpService.GO_ARTIFACT_PAYLOAD_SIZE);
+        String headerValue = req.getHeader(SystemEnvironment.GO_ARTIFACT_PAYLOAD_SIZE_HEADER);
 
         if (lastOperationTime.pastWaitingPeriod()) {
             synchronized (this) {

--- a/server/src/com/thoughtworks/go/server/security/ReAuthenticationFilter.java
+++ b/server/src/com/thoughtworks/go/server/security/ReAuthenticationFilter.java
@@ -19,6 +19,7 @@ package com.thoughtworks.go.server.security;
 import com.thoughtworks.go.server.security.userdetail.GoUserPrinciple;
 import com.thoughtworks.go.util.SystemEnvironment;
 import com.thoughtworks.go.util.TimeProvider;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.Authentication;
 import org.springframework.security.context.SecurityContextHolder;
 import org.springframework.security.ui.FilterChainOrder;
@@ -35,6 +36,7 @@ public class ReAuthenticationFilter extends SpringSecurityFilter {
     private final TimeProvider timeProvider;
     protected static final String LAST_REAUTHENICATION_CHECK_TIME = "last_reauthentication_check_time";
 
+    @Autowired
     public ReAuthenticationFilter(SystemEnvironment systemEnvironment, TimeProvider timeProvider) {
         this.systemEnvironment = systemEnvironment;
         this.timeProvider = timeProvider;

--- a/server/src/com/thoughtworks/go/server/security/RemoveAdminPermissionFilter.java
+++ b/server/src/com/thoughtworks/go/server/security/RemoveAdminPermissionFilter.java
@@ -1,18 +1,18 @@
-/*************************GO-LICENSE-START*********************************
- * Copyright 2014 ThoughtWorks, Inc.
+/*
+ * Copyright 2017 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *************************GO-LICENSE-END***********************************/
+ */
 
 package com.thoughtworks.go.server.security;
 
@@ -25,6 +25,7 @@ import com.thoughtworks.go.server.service.GoConfigService;
 import com.thoughtworks.go.server.service.PluginRoleService;
 import com.thoughtworks.go.util.TimeProvider;
 import org.apache.log4j.Logger;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.Authentication;
 import org.springframework.security.context.SecurityContextHolder;
 import org.springframework.security.ui.FilterChainOrder;
@@ -49,6 +50,7 @@ public class RemoveAdminPermissionFilter extends SpringSecurityFilter implements
     private PluginRoleService pluginRoleService;
     private volatile long lastChangedTime;
 
+    @Autowired
     public RemoveAdminPermissionFilter(GoConfigService goConfigService, TimeProvider timeProvider, PluginRoleService pluginRoleService) {
         this.goConfigService = goConfigService;
         this.timeProvider = timeProvider;

--- a/server/src/com/thoughtworks/go/server/security/UserEnabledCheckFilter.java
+++ b/server/src/com/thoughtworks/go/server/security/UserEnabledCheckFilter.java
@@ -1,26 +1,20 @@
-/*************************GO-LICENSE-START*********************************
- * Copyright 2014 ThoughtWorks, Inc.
+/*
+ * Copyright 2017 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *************************GO-LICENSE-END***********************************/
+ */
 
 package com.thoughtworks.go.server.security;
-
-import java.io.IOException;
-import javax.servlet.FilterChain;
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 
 import com.thoughtworks.go.config.CaseInsensitiveString;
 import com.thoughtworks.go.domain.NullUser;
@@ -28,11 +22,18 @@ import com.thoughtworks.go.domain.User;
 import com.thoughtworks.go.server.domain.Username;
 import com.thoughtworks.go.server.service.UserService;
 import com.thoughtworks.go.server.util.UserHelper;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.DisabledException;
 import org.springframework.security.context.SecurityContext;
 import org.springframework.security.context.SecurityContextHolder;
 import org.springframework.security.ui.FilterChainOrder;
 import org.springframework.security.ui.SpringSecurityFilter;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
 
 import static com.thoughtworks.go.domain.PersistentObject.NOT_PERSISTED;
 import static com.thoughtworks.go.server.security.SessionDenialAwareAuthenticationProcessingFilterEntryPoint.SESSION_DENIED;
@@ -44,6 +45,7 @@ import static org.springframework.security.ui.AbstractProcessingFilter.SPRING_SE
 public class UserEnabledCheckFilter  extends SpringSecurityFilter {
     private final UserService userService;
 
+    @Autowired
     public UserEnabledCheckFilter(UserService userService) {
         this.userService = userService;
     }

--- a/server/src/com/thoughtworks/go/server/security/providers/GoAuthenticationProviderFactory.java
+++ b/server/src/com/thoughtworks/go/server/security/providers/GoAuthenticationProviderFactory.java
@@ -1,27 +1,30 @@
-/*************************GO-LICENSE-START*********************************
- * Copyright 2015 ThoughtWorks, Inc.
+/*
+ * Copyright 2017 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *************************GO-LICENSE-END***********************************/
+ */
 
 package com.thoughtworks.go.server.security.providers;
 
 import com.thoughtworks.go.server.service.UserService;
 import org.springframework.beans.factory.FactoryBean;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
 
 public class GoAuthenticationProviderFactory implements FactoryBean {
     private final UserService userService;
 
+    @Autowired
     public GoAuthenticationProviderFactory(UserService userService) {
         this.userService = userService;
     }

--- a/server/src/com/thoughtworks/go/server/security/providers/PreAuthenticatedAuthenticationProvider.java
+++ b/server/src/com/thoughtworks/go/server/security/providers/PreAuthenticatedAuthenticationProvider.java
@@ -28,6 +28,7 @@ import com.thoughtworks.go.server.security.userdetail.GoUserPrinciple;
 import com.thoughtworks.go.server.service.GoConfigService;
 import com.thoughtworks.go.server.service.PluginRoleService;
 import com.thoughtworks.go.server.service.UserService;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.Authentication;
 import org.springframework.security.AuthenticationException;
 import org.springframework.security.BadCredentialsException;
@@ -46,6 +47,7 @@ public class PreAuthenticatedAuthenticationProvider implements AuthenticationPro
     private final AuthorityGranter authorityGranter;
     private GoConfigService configService;
 
+    @Autowired
     public PreAuthenticatedAuthenticationProvider(AuthorizationExtension authorizationExtension, PluginRoleService pluginRoleService,
                                                   UserService userService, AuthorityGranter authorityGranter, GoConfigService configService) {
         this.authorizationExtension = authorizationExtension;

--- a/server/test/integration/com/thoughtworks/go/server/SpringBeanCandidateConstructorIntegrationTest.java
+++ b/server/test/integration/com/thoughtworks/go/server/SpringBeanCandidateConstructorIntegrationTest.java
@@ -19,15 +19,8 @@ package com.thoughtworks.go.server;
 import com.thoughtworks.go.i18n.Localizer;
 import com.thoughtworks.go.server.cache.GoCache;
 import com.thoughtworks.go.server.cache.GoCacheFactory;
-import com.thoughtworks.go.server.dao.sparql.ShineDao;
 import com.thoughtworks.go.server.persistence.MaterialRepository;
 import com.thoughtworks.go.server.security.OauthAuthenticationFilter;
-import com.thoughtworks.go.server.security.ReAuthenticationFilter;
-import com.thoughtworks.go.server.security.RemoveAdminPermissionFilter;
-import com.thoughtworks.go.server.security.UserEnabledCheckFilter;
-import com.thoughtworks.go.server.security.providers.GoAuthenticationProviderFactory;
-import com.thoughtworks.go.server.security.providers.PreAuthenticatedAuthenticationProvider;
-import com.thoughtworks.go.server.transaction.TransactionSynchronizationManager;
 import com.thoughtworks.go.server.transaction.TransactionTemplate;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -54,6 +47,7 @@ import static org.junit.Assert.fail;
 @ContextConfiguration(locations = {
         "classpath:WEB-INF/applicationContext-global.xml",
         "classpath:WEB-INF/applicationContext-dataLocalAccess.xml",
+        "classpath:WEB-INF/applicationContext-shine-server.xml",
         "classpath:WEB-INF/applicationContext-acegi-security.xml"
 })
 public class SpringBeanCandidateConstructorIntegrationTest {
@@ -66,10 +60,9 @@ public class SpringBeanCandidateConstructorIntegrationTest {
         ConfigurableListableBeanFactory clbf = ((AbstractApplicationContext) applicationContext).getBeanFactory();
         AutowiredAnnotationBeanPostProcessor autowiredAnnotationBeanPostProcessor = new AutowiredAnnotationBeanPostProcessor();
 
-        List<Class<?>> exclusions = Arrays.asList(Localizer.class, TransactionTemplate.class, TransactionSynchronizationManager.class,
-                GoCacheFactory.class, GoCache.class, MaterialRepository.class, PreAuthenticatedAuthenticationProvider.class,
-                UserEnabledCheckFilter.class, GoAuthenticationProviderFactory.class, OauthAuthenticationFilter.class,
-                RemoveAdminPermissionFilter.class, ReAuthenticationFilter.class, ShineDao.class);
+        //Beans which are instantiated by explicitly specifying a constructor and its args in the applicationContext xml files
+        List<Class<?>> exclusions = Arrays.asList(Localizer.class, TransactionTemplate.class, GoCacheFactory.class,
+                GoCache.class, MaterialRepository.class, OauthAuthenticationFilter.class);
         for (String name : allBeans) {
             Object bean = clbf.getSingleton(name);
             if (bean != null) {
@@ -100,5 +93,4 @@ public class SpringBeanCandidateConstructorIntegrationTest {
             }
         }
     }
-
 }

--- a/server/test/integration/com/thoughtworks/go/server/SpringBeanCandidateConstructorIntegrationTest.java
+++ b/server/test/integration/com/thoughtworks/go/server/SpringBeanCandidateConstructorIntegrationTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2017 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.server;
+
+import com.thoughtworks.go.i18n.Localizer;
+import com.thoughtworks.go.server.cache.GoCache;
+import com.thoughtworks.go.server.cache.GoCacheFactory;
+import com.thoughtworks.go.server.dao.sparql.ShineDao;
+import com.thoughtworks.go.server.persistence.MaterialRepository;
+import com.thoughtworks.go.server.security.OauthAuthenticationFilter;
+import com.thoughtworks.go.server.security.ReAuthenticationFilter;
+import com.thoughtworks.go.server.security.RemoveAdminPermissionFilter;
+import com.thoughtworks.go.server.security.UserEnabledCheckFilter;
+import com.thoughtworks.go.server.security.providers.GoAuthenticationProviderFactory;
+import com.thoughtworks.go.server.security.providers.PreAuthenticatedAuthenticationProvider;
+import com.thoughtworks.go.server.transaction.TransactionSynchronizationManager;
+import com.thoughtworks.go.server.transaction.TransactionTemplate;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.BeanUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.AutowiredAnnotationBeanPostProcessor;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.support.AbstractApplicationContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsNull.notNullValue;
+import static org.junit.Assert.fail;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(locations = {
+        "classpath:WEB-INF/applicationContext-global.xml",
+        "classpath:WEB-INF/applicationContext-dataLocalAccess.xml",
+        "classpath:WEB-INF/applicationContext-acegi-security.xml"
+})
+public class SpringBeanCandidateConstructorIntegrationTest {
+    @Autowired
+    private ApplicationContext applicationContext;
+
+    @Test
+    public void shouldEnsureThatNoBeanHasMoreThanOneCandidateConstructors() throws IllegalAccessException, InvocationTargetException, InstantiationException, NoSuchMethodException {
+        String[] allBeans = applicationContext.getBeanDefinitionNames();
+        ConfigurableListableBeanFactory clbf = ((AbstractApplicationContext) applicationContext).getBeanFactory();
+        AutowiredAnnotationBeanPostProcessor autowiredAnnotationBeanPostProcessor = new AutowiredAnnotationBeanPostProcessor();
+
+        List<Class<?>> exclusions = Arrays.asList(Localizer.class, TransactionTemplate.class, TransactionSynchronizationManager.class,
+                GoCacheFactory.class, GoCache.class, MaterialRepository.class, PreAuthenticatedAuthenticationProvider.class,
+                UserEnabledCheckFilter.class, GoAuthenticationProviderFactory.class, OauthAuthenticationFilter.class,
+                RemoveAdminPermissionFilter.class, ReAuthenticationFilter.class, ShineDao.class);
+        for (String name : allBeans) {
+            Object bean = clbf.getSingleton(name);
+            if (bean != null) {
+                if (bean.getClass().getCanonicalName().startsWith("com.thoughtworks.go")) {
+                    Constructor<?>[] candidateConstructors = autowiredAnnotationBeanPostProcessor.determineCandidateConstructors(bean.getClass(), name);
+                    if (candidateConstructors == null) {
+                        Constructor[] declaredConstructors = bean.getClass().getDeclaredConstructors();
+                        Constructor<?> defaultConstructor = null;
+                        for (Constructor<?> declaredConstructor : declaredConstructors) {
+                            if (declaredConstructor.getParameterCount() == 0) {
+                                defaultConstructor = declaredConstructor;
+                                break;
+                            }
+                        }
+                        if (!exclusions.contains(bean.getClass())) {
+                            assertThat(String.format("Bean doesn't have a default or autowired constructor => name: %s, class: %s", name, bean.getClass()), defaultConstructor, is(notNullValue()));
+                            try {
+                                BeanUtils.instantiateClass(defaultConstructor);
+                            } catch (Exception e) {
+                                fail(String.format("Default constructor failed : %s. Stacktrace: %s", e.getMessage(), e.getStackTrace()));
+                            }
+                        }
+
+                    } else {
+                        assertThat(String.format("name: %s class: %s", name, bean.getClass()), candidateConstructors.length, is(1));
+                    }
+                }
+            }
+        }
+    }
+
+}

--- a/server/test/unit/com/thoughtworks/go/server/security/ArtifactSizeEnforcementFilterTest.java
+++ b/server/test/unit/com/thoughtworks/go/server/security/ArtifactSizeEnforcementFilterTest.java
@@ -1,18 +1,18 @@
-/*************************GO-LICENSE-START*********************************
- * Copyright 2014 ThoughtWorks, Inc.
+/*
+ * Copyright 2017 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *************************GO-LICENSE-END***********************************/
+ */
 
 package com.thoughtworks.go.server.security;
 
@@ -66,7 +66,7 @@ public class ArtifactSizeEnforcementFilterTest {
     public void shouldRejectRequestBasedOnArtifactSize() throws IOException, ServletException {
         ArtifactSizeEnforcementFilter artifactSizeEnforcementFilter = new ArtifactSizeEnforcementFilter(mockArtifactsDirHolder, mockSysEnv);
 
-        request.addHeader(HttpService.GO_ARTIFACT_PAYLOAD_SIZE, "713");
+        request.addHeader(SystemEnvironment.GO_ARTIFACT_PAYLOAD_SIZE_HEADER, "713");
         artifactSizeEnforcementFilter.doFilter(request, response, filterChain);
         assertThat(response.getStatus(), is(HttpServletResponse.SC_REQUEST_ENTITY_TOO_LARGE));
 
@@ -79,7 +79,7 @@ public class ArtifactSizeEnforcementFilterTest {
         ArtifactSizeEnforcementFilter artifactSizeEnforcementFilter = new ArtifactSizeEnforcementFilter(mockArtifactsDirHolder, mockSysEnv);
         when(mockArtifactsDirHolder.getArtifactsDir()).thenReturn(artifactsDir);
         when(artifactsDir.getUsableSpace()).thenReturn(30000000L);
-        request.addHeader(HttpService.GO_ARTIFACT_PAYLOAD_SIZE, "713");
+        request.addHeader(SystemEnvironment.GO_ARTIFACT_PAYLOAD_SIZE_HEADER, "713");
         artifactSizeEnforcementFilter.doFilter(request, response, filterChain);
         artifactSizeEnforcementFilter.doFilter(request, response, filterChain); //another request within 5seconds
         verify(filterChain, times(2)).doFilter(request, response);

--- a/server/webapp/WEB-INF/applicationContext-acegi-security.xml
+++ b/server/webapp/WEB-INF/applicationContext-acegi-security.xml
@@ -111,16 +111,10 @@
           p:filterProcessesUrl="/auth/security_check"
           p:invalidateSessionOnSuccessfulAuthentication="true"/>
 
-     <bean id="userEnabledCheckFilter" class="com.thoughtworks.go.server.security.UserEnabledCheckFilter">
-         <constructor-arg index="0">
-            <bean class="com.thoughtworks.go.server.service.UserService" autowire="autodetect"/>
-        </constructor-arg>
+     <bean id="userEnabledCheckFilter" class="com.thoughtworks.go.server.security.UserEnabledCheckFilter" autowire="autodetect">
      </bean>
 
-    <bean id="goAuthenticationProviderFactory" class="com.thoughtworks.go.server.security.providers.GoAuthenticationProviderFactory">
-        <constructor-arg index="0">
-            <bean class="com.thoughtworks.go.server.service.UserService" autowire="autodetect"/>
-        </constructor-arg>
+    <bean id="goAuthenticationProviderFactory" class="com.thoughtworks.go.server.security.providers.GoAuthenticationProviderFactory" autowire="autodetect">
     </bean>
 
     <bean id="goAuthenticationManager" class="org.springframework.security.providers.ProviderManager">


### PR DESCRIPTION
Fixing the bug wherein DbDeploy migration would run multiple times
* This used to happen because HttpService had a autowired contructor with required false and a default constructor. As a part of the first initialization on the server side if a db-migration failed(for that matter anything threw an exception), spring would destroy all the beans that it created until it hits a class with more than one candidate-constructors. It would now use the second constructor, and retry the flow. From a class instantiation point of view this seems fine, but since db-migration is linked to the initilization it wouldn't work for us
* Added a test to ensure that we do not add something like this by mistake in future.