### PR TITLE
Merged Environments API (v1) endpoint (#3301)

### DIFF
--- a/server/webapp/WEB-INF/rails.new/app/controllers/api_v1/admin/merged_environments_controller.rb
+++ b/server/webapp/WEB-INF/rails.new/app/controllers/api_v1/admin/merged_environments_controller.rb
@@ -24,7 +24,7 @@ module ApiV1
       end
 
       def show
-        environment_name = params[:name]
+        environment_name = params[:environment_name]
         load_merged_environment(environment_name)
         json = ApiV1::Admin::MergedEnvironments::MergedEnvironmentConfigRepresenter.new(@environment_config).to_hash(url_builder: self)
         render DEFAULT_FORMAT => json if stale?(etag: etag_for(environment_config_service.getEnvironmentForEdit(environment_name)))

--- a/server/webapp/WEB-INF/rails.new/app/controllers/api_v1/admin/merged_environments_controller.rb
+++ b/server/webapp/WEB-INF/rails.new/app/controllers/api_v1/admin/merged_environments_controller.rb
@@ -1,0 +1,43 @@
+##########################################################################
+# Copyright 2017 ThoughtWorks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+
+module ApiV1
+  module Admin
+    class MergedEnvironmentsController < ApiV1::BaseController
+      before_action :check_admin_user_and_401
+
+      def index
+        render DEFAULT_FORMAT => Admin::MergedEnvironments::MergedEnvironmentsConfigRepresenter.new(environment_config_service.getAllMergedEnvironments()).to_hash(url_builder: self)
+      end
+
+      def show
+        environment_name = params[:name]
+        load_merged_environment(environment_name)
+        json = ApiV1::Admin::MergedEnvironments::MergedEnvironmentConfigRepresenter.new(@environment_config).to_hash(url_builder: self)
+        render DEFAULT_FORMAT => json if stale?(etag: etag_for(environment_config_service.getEnvironmentForEdit(environment_name)))
+      end
+
+      protected
+
+      def load_merged_environment(environment_name)
+        result = HttpLocalizedOperationResult.new
+        config_element = environment_config_service.getMergedEnvironmentforDisplay(environment_name, result)
+        raise RecordNotFound if config_element.nil?
+        @environment_config = config_element.getConfigElement()
+      end
+    end
+  end
+end

--- a/server/webapp/WEB-INF/rails.new/app/presenters/api_v1/admin/merged_environments/agent_summary_representer.rb
+++ b/server/webapp/WEB-INF/rails.new/app/presenters/api_v1/admin/merged_environments/agent_summary_representer.rb
@@ -1,0 +1,46 @@
+##########################################################################
+# Copyright 2017 ThoughtWorks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+
+module ApiV1
+  module Admin
+    module MergedEnvironments
+      class AgentSummaryRepresenter < Shared::AgentSummaryRepresenter
+        def initialize(options)
+          @environment = options[:environment]
+          @agent = options[:agent]
+
+          super(@agent)
+        end
+
+        property :origin,
+                 exec_context: :decorator,
+                 decorator: lambda {|origin, *|
+                   (origin.instance_of? FileConfigOrigin) ?
+                     Shared::ConfigOrigin::ConfigXmlOriginRepresenter :
+                     Shared::ConfigOrigin::ConfigRepoOriginRepresenter
+                 }
+
+        def origin
+          @environment.isLocal ? FileConfigOrigin.new : @environment.getOriginForAgent(@agent.getUuid)
+        end
+
+        def uuid
+          @agent.getUuid()
+        end
+      end
+    end
+  end
+end

--- a/server/webapp/WEB-INF/rails.new/app/presenters/api_v1/admin/merged_environments/environment_variable_representer.rb
+++ b/server/webapp/WEB-INF/rails.new/app/presenters/api_v1/admin/merged_environments/environment_variable_representer.rb
@@ -1,0 +1,42 @@
+##########################################################################
+# Copyright 2017 ThoughtWorks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+
+module ApiV1
+  module Admin
+    module MergedEnvironments
+      class EnvironmentVariableRepresenter < Shared::EnvironmentVariableRepresenter
+        def initialize(options)
+          @environment = options[:environment]
+          @env_var = options[:env_var]
+
+          super(@env_var)
+        end
+
+        property :origin,
+                 exec_context: :decorator,
+                 decorator: lambda {|origin, *|
+                   (origin.instance_of? FileConfigOrigin) ?
+                     Shared::ConfigOrigin::ConfigXmlOriginRepresenter :
+                     Shared::ConfigOrigin::ConfigRepoOriginRepresenter
+                 }
+
+        def origin
+          @environment.isLocal ? FileConfigOrigin.new : @environment.getOriginForEnvironmentVariable(@env_var.getName)
+        end
+      end
+    end
+  end
+end

--- a/server/webapp/WEB-INF/rails.new/app/presenters/api_v1/admin/merged_environments/merged_environment_config_representer.rb
+++ b/server/webapp/WEB-INF/rails.new/app/presenters/api_v1/admin/merged_environments/merged_environment_config_representer.rb
@@ -21,15 +21,15 @@ module ApiV1
         alias_method :environment, :represented
 
         link :self do |opts|
-          opts[:url_builder].apiv1_admin_merged_environment_show_url(name: environment.name)
+          opts[:url_builder].apiv1_admin_merged_environment_show_url(environment_name: environment.name)
         end
 
         link :doc do |opts|
-          'https://api.gocd.io/#merged-environment-config'
+          'https://api.gocd.org/#merged-environment-config'
         end
 
         link :find do |opts|
-          opts[:url_builder].apiv1_admin_merged_environment_show_url(name: '__environment_name__').gsub(/__environment_name__/, ':environment_name')
+          opts[:url_builder].apiv1_admin_merged_environment_show_url(environment_name: '__environment_name__').gsub(/__environment_name__/, ':environment_name')
         end
 
         property :name, case_insensitive_string: true

--- a/server/webapp/WEB-INF/rails.new/app/presenters/api_v1/admin/merged_environments/merged_environment_config_representer.rb
+++ b/server/webapp/WEB-INF/rails.new/app/presenters/api_v1/admin/merged_environments/merged_environment_config_representer.rb
@@ -1,0 +1,84 @@
+##########################################################################
+# Copyright 2017 ThoughtWorks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+
+module ApiV1
+  module Admin
+    module MergedEnvironments
+      class MergedEnvironmentConfigRepresenter < ApiV1::BaseRepresenter
+        alias_method :environment, :represented
+
+        link :self do |opts|
+          opts[:url_builder].apiv1_admin_merged_environment_show_url(name: environment.name)
+        end
+
+        link :doc do |opts|
+          'https://api.gocd.io/#merged-environment-config'
+        end
+
+        link :find do |opts|
+          opts[:url_builder].apiv1_admin_merged_environment_show_url(name: '__environment_name__').gsub(/__environment_name__/, ':environment_name')
+        end
+
+        property :name, case_insensitive_string: true
+
+        collection :origin, as: :origins,
+                   skip_parse: true,
+                   getter: lambda {|options|
+                     origin = self.getOrigin
+                     (origin.instance_of? FileConfigOrigin) ? [origin] : origin
+                   },
+                   decorator: lambda {|origin, *|
+                     if origin.instance_of? FileConfigOrigin
+                       Shared::ConfigOrigin::ConfigXmlOriginRepresenter
+                     else
+                       Shared::ConfigOrigin::ConfigRepoOriginRepresenter
+                     end
+                   }
+
+        collection :pipelines,
+                   exec_context: :decorator,
+                   decorator: ApiV1::Admin::MergedEnvironments::PipelineConfigSummaryRepresenter
+
+        collection :agents,
+                   exec_context: :decorator,
+                   decorator: ApiV1::Admin::MergedEnvironments::AgentSummaryRepresenter
+
+        collection :environment_variables,
+                   exec_context: :decorator,
+                   decorator: ApiV1::Admin::MergedEnvironments::EnvironmentVariableRepresenter,
+                   expect_hash: true
+
+        def environment_variables
+          environment.getVariables.map do |env_var|
+            {env_var: env_var, environment: environment}
+          end
+        end
+
+        def agents
+          environment.getAgents.map do |agent|
+            {agent: agent, environment: environment}
+          end
+        end
+
+        def pipelines
+          environment.getPipelines.map do |pipeline|
+            {pipeline: pipeline, environment: environment}
+          end
+        end
+      end
+    end
+  end
+end

--- a/server/webapp/WEB-INF/rails.new/app/presenters/api_v1/admin/merged_environments/merged_environments_config_representer.rb
+++ b/server/webapp/WEB-INF/rails.new/app/presenters/api_v1/admin/merged_environments/merged_environments_config_representer.rb
@@ -1,0 +1,38 @@
+##########################################################################
+# Copyright 2017 ThoughtWorks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+
+module ApiV1
+  module Admin
+    module MergedEnvironments
+      class MergedEnvironmentsConfigRepresenter < ApiV1::BaseRepresenter
+
+        link :self do |opts|
+          opts[:url_builder].apiv1_admin_merged_environment_index_url
+        end
+
+        link :doc do |opts|
+          'https://api.gocd.io/#merged-environment-config'
+        end
+
+        collection :environments, embedded: true, exec_context: :decorator, decorator: MergedEnvironmentConfigRepresenter
+
+        def environments
+          represented
+        end
+      end
+    end
+  end
+end

--- a/server/webapp/WEB-INF/rails.new/app/presenters/api_v1/admin/merged_environments/pipeline_config_summary_representer.rb
+++ b/server/webapp/WEB-INF/rails.new/app/presenters/api_v1/admin/merged_environments/pipeline_config_summary_representer.rb
@@ -1,0 +1,61 @@
+##########################################################################
+# Copyright 2017 ThoughtWorks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+
+module ApiV1
+  module Admin
+    module MergedEnvironments
+      class PipelineConfigSummaryRepresenter < ApiV1::BaseRepresenter
+        def initialize(options)
+          @environment = options[:environment]
+          @pipeline = options[:pipeline]
+
+          super(@pipeline)
+        end
+
+        link :self do |opts|
+          opts[:url_builder].apiv3_admin_pipeline_url(@pipeline.getName())
+        end
+
+        link :doc do |opts|
+          'https://api.gocd.org/#pipeline-config'
+        end
+
+        link :find do |opts|
+          opts[:url_builder].apiv3_admin_pipeline_url(pipeline_name: '__pipeline_name__').gsub(/__pipeline_name__/, ':pipeline_name')
+        end
+
+        property :name,
+                 exec_context: :decorator
+
+        property :origin,
+                 exec_context: :decorator,
+                 decorator: lambda {|origin, *|
+                   (origin.instance_of? FileConfigOrigin) ?
+                     Shared::ConfigOrigin::ConfigXmlOriginRepresenter :
+                     Shared::ConfigOrigin::ConfigRepoOriginRepresenter
+                 }
+
+        def origin
+          @environment.isLocal ? FileConfigOrigin.new : @environment.getOriginForPipeline(@pipeline.name)
+        end
+
+        def name
+          @pipeline.getName.to_s
+        end
+      end
+    end
+  end
+end

--- a/server/webapp/WEB-INF/rails.new/app/presenters/api_v1/shared/agent_summary_representer.rb
+++ b/server/webapp/WEB-INF/rails.new/app/presenters/api_v1/shared/agent_summary_representer.rb
@@ -24,7 +24,7 @@ module ApiV1
       end
 
       link :doc do |opts|
-        'https://api.gocd.io/#agents'
+        'https://api.gocd.org/#agents'
       end
 
       link :find do |opts|

--- a/server/webapp/WEB-INF/rails.new/app/presenters/api_v1/shared/agent_summary_representer.rb
+++ b/server/webapp/WEB-INF/rails.new/app/presenters/api_v1/shared/agent_summary_representer.rb
@@ -1,0 +1,38 @@
+##########################################################################
+# Copyright 2017 ThoughtWorks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+
+module ApiV1
+  module Shared
+    class AgentSummaryRepresenter < ApiV1::BaseRepresenter
+      alias_method :agent, :represented
+
+      link :self do |opts|
+        opts[:url_builder].apiv4_agent_url(agent.getUuid())
+      end
+
+      link :doc do |opts|
+        'https://api.gocd.io/#agents'
+      end
+
+      link :find do |opts|
+        opts[:url_builder].apiv4_agent_url(':uuid')
+      end
+
+      property :uuid
+    end
+  end
+end
+

--- a/server/webapp/WEB-INF/rails.new/app/presenters/api_v1/shared/config_origin/config_repo_origin_representer.rb
+++ b/server/webapp/WEB-INF/rails.new/app/presenters/api_v1/shared/config_origin/config_repo_origin_representer.rb
@@ -1,0 +1,39 @@
+##########################################################################
+# Copyright 2017 ThoughtWorks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+
+module ApiV1
+  module Shared
+    module ConfigOrigin
+      class ConfigRepoOriginRepresenter < BaseRepresenter
+        alias_method :config_repo_origin, :represented
+
+        property :type, exec_context: :decorator
+
+        property :repo,
+                 exec_context: :decorator,
+                 decorator: ApiV1::Shared::ConfigOrigin::ConfigRepoSummaryRepresenter
+
+        def type
+          'config repo'
+        end
+
+        def repo
+          config_repo_origin.getConfigRepo
+        end
+      end
+    end
+  end
+end

--- a/server/webapp/WEB-INF/rails.new/app/presenters/api_v1/shared/config_origin/config_repo_summary_representer.rb
+++ b/server/webapp/WEB-INF/rails.new/app/presenters/api_v1/shared/config_origin/config_repo_summary_representer.rb
@@ -1,0 +1,39 @@
+##########################################################################
+# Copyright 2017 ThoughtWorks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+
+module ApiV1
+  module Shared
+    module ConfigOrigin
+      class ConfigRepoSummaryRepresenter < BaseRepresenter
+        alias_method :config_repo, :represented
+
+        link :self do |opts|
+          opts[:url_builder].apiv1_admin_config_repo_url(id: config_repo.getId)
+        end
+
+        link :doc do |opts|
+          'https://api.gocd.org/#config-repos'
+        end
+
+        link :find do |opts|
+          opts[:url_builder].apiv1_admin_config_repo_url(id: '__id__').gsub(/__id__/, ':id')
+        end
+
+        property :id
+      end
+    end
+  end
+end

--- a/server/webapp/WEB-INF/rails.new/app/presenters/api_v1/shared/config_origin/config_xml_origin_representer.rb
+++ b/server/webapp/WEB-INF/rails.new/app/presenters/api_v1/shared/config_origin/config_xml_origin_representer.rb
@@ -1,0 +1,39 @@
+##########################################################################
+# Copyright 2017 ThoughtWorks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+
+module ApiV1
+  module Shared
+    module ConfigOrigin
+      class ConfigXmlOriginRepresenter < BaseRepresenter
+        alias_method :config_xml_config, :represented
+
+        property :type, exec_context: :decorator
+        property :displayName, as: :file
+        property :file,
+                 exec_context: :decorator,
+                 decorator: ApiV1::Shared::ConfigOrigin::ConfigXmlSummaryRepresenter
+
+        def type
+          'local'
+        end
+
+        def file
+          config_xml_config
+        end
+      end
+    end
+  end
+end

--- a/server/webapp/WEB-INF/rails.new/app/presenters/api_v1/shared/config_origin/config_xml_origin_representer.rb
+++ b/server/webapp/WEB-INF/rails.new/app/presenters/api_v1/shared/config_origin/config_xml_origin_representer.rb
@@ -21,7 +21,7 @@ module ApiV1
         alias_method :config_xml_config, :represented
 
         property :type, exec_context: :decorator
-        property :displayName, as: :file
+
         property :file,
                  exec_context: :decorator,
                  decorator: ApiV1::Shared::ConfigOrigin::ConfigXmlSummaryRepresenter

--- a/server/webapp/WEB-INF/rails.new/app/presenters/api_v1/shared/config_origin/config_xml_summary_representer.rb
+++ b/server/webapp/WEB-INF/rails.new/app/presenters/api_v1/shared/config_origin/config_xml_summary_representer.rb
@@ -1,0 +1,35 @@
+##########################################################################
+# Copyright 2017 ThoughtWorks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+
+module ApiV1
+  module Shared
+    module ConfigOrigin
+      class ConfigXmlSummaryRepresenter < BaseRepresenter
+        alias_method :config_xml, :represented
+
+        link :self do |opts|
+          opts[:url_builder].config_view_url()
+        end
+
+        link :doc do |opts|
+          'https://api.gocd.org/#get-configuration'
+        end
+
+        property :displayName, as: :name
+      end
+    end
+  end
+end

--- a/server/webapp/WEB-INF/rails.new/app/presenters/api_v1/shared/environment_variable_representer.rb
+++ b/server/webapp/WEB-INF/rails.new/app/presenters/api_v1/shared/environment_variable_representer.rb
@@ -1,0 +1,45 @@
+##########################################################################
+# Copyright 2017 ThoughtWorks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+
+module ApiV1
+  module Shared
+    class EnvironmentVariableRepresenter < BaseRepresenter
+      alias_method :environment_variable, :represented
+
+      error_representer({'encryptedValue' => 'encrypted_value'})
+
+      property :isSecure, as: :secure, writable: false
+      property :name, writable: false
+      property :value, skip_nil: true, writable: false, exec_context: :decorator
+      property :encrypted_value, skip_nil: true, writable: false, exec_context: :decorator
+      property :errors, exec_context: :decorator, decorator: ApiV1::Config::ErrorRepresenter, skip_parse: true, skip_render: lambda { |object, options| object.empty? }
+
+      def value
+        environment_variable.getValueForDisplay() if environment_variable.isPlain
+      end
+
+      def encrypted_value
+        environment_variable.getValueForDisplay() if environment_variable.isSecure
+      end
+
+      def from_hash(data, options={})
+        data = data.with_indifferent_access
+        environment_variable.deserialize(data[:name], data[:value], data[:secure].to_bool, data[:encrypted_value])
+        environment_variable
+      end
+    end
+  end
+end

--- a/server/webapp/WEB-INF/rails.new/config/routes.rb
+++ b/server/webapp/WEB-INF/rails.new/config/routes.rb
@@ -25,6 +25,7 @@ Go::Application.routes.draw do
     PIPELINE_LOCATOR_CONSTRAINTS = {:pipeline_name => PIPELINE_NAME_FORMAT, :pipeline_counter => PIPELINE_COUNTER_FORMAT}
     STAGE_LOCATOR_CONSTRAINTS = {:stage_name => STAGE_NAME_FORMAT, :stage_counter => STAGE_COUNTER_FORMAT}.merge(PIPELINE_LOCATOR_CONSTRAINTS)
     ENVIRONMENT_NAME_CONSTRAINT = {:name => ENVIRONMENT_NAME_FORMAT}
+    MERGED_ENVIRONMENT_NAME_CONSTRAINT = {:environment_name => ENVIRONMENT_NAME_FORMAT}
     PLUGIN_ID_FORMAT = /[\w\-.]+/
     ALLOW_DOTS = /[^\/]+/
     CONSTANTS = true
@@ -243,8 +244,8 @@ Go::Application.routes.draw do
         resources :config_repos, param: :id, only: [:create, :update, :show, :index, :destroy], constraints: {id: CONFIG_REPO_ID_FORMAT}
         resources :templates, param: :template_name, except: [:new, :edit], constraints: {template_name: TEMPLATE_NAME_FORMAT}
 
-        get 'environments/:name/merged' => 'merged_environments#show', constraints: ENVIRONMENT_NAME_CONSTRAINT, as: :merged_environment_show
-        get 'environments/merged' => 'merged_environments#index', constraints: ENVIRONMENT_NAME_CONSTRAINT, as: :merged_environment_index
+        get 'environments/:environment_name/merged' => 'merged_environments#show', constraints: MERGED_ENVIRONMENT_NAME_CONSTRAINT, as: :merged_environment_show
+        get 'environments/merged' => 'merged_environments#index', as: :merged_environment_index
         resources :repositories, param: :repo_id, only: [:show, :index, :destroy, :create, :update], constraints: {repo_id: ALLOW_DOTS}
         resources :plugin_settings, param: :plugin_id, only: [:show, :create, :update], constraints: {plugin_id: ALLOW_DOTS}
 

--- a/server/webapp/WEB-INF/rails.new/config/routes.rb
+++ b/server/webapp/WEB-INF/rails.new/config/routes.rb
@@ -242,6 +242,9 @@ Go::Application.routes.draw do
 
         resources :config_repos, param: :id, only: [:create, :update, :show, :index, :destroy], constraints: {id: CONFIG_REPO_ID_FORMAT}
         resources :templates, param: :template_name, except: [:new, :edit], constraints: {template_name: TEMPLATE_NAME_FORMAT}
+
+        get 'environments/:name/merged' => 'merged_environments#show', constraints: ENVIRONMENT_NAME_CONSTRAINT, as: :merged_environment_show
+        get 'environments/merged' => 'merged_environments#index', constraints: ENVIRONMENT_NAME_CONSTRAINT, as: :merged_environment_index
         resources :repositories, param: :repo_id, only: [:show, :index, :destroy, :create, :update], constraints: {repo_id: ALLOW_DOTS}
         resources :plugin_settings, param: :plugin_id, only: [:show, :create, :update], constraints: {plugin_id: ALLOW_DOTS}
 

--- a/server/webapp/WEB-INF/rails.new/spec/controllers/api_v1/admin/merged_environments_controller_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/controllers/api_v1/admin/merged_environments_controller_spec.rb
@@ -1,0 +1,186 @@
+##########################################################################
+# Copyright 2017 ThoughtWorks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+
+require 'spec_helper'
+
+describe ApiV1::Admin::MergedEnvironmentsController do
+  include ApiHeaderSetupTeardown, ApiV1::ApiVersionHelper
+
+  describe :index do
+    before(:each) do
+      @environment_name = 'foo-environment'
+      @environment_config = BasicEnvironmentConfig.new(CaseInsensitiveString.new(@environment_name))
+      @environment_config_service = double('environment-config-service')
+      controller.stub(:environment_config_service).and_return(@environment_config_service)
+      @environment_config_service.stub(:getAllMergedEnvironments).and_return([@environment_config])
+    end
+
+    describe :for_admins do
+      it 'should render the environment' do
+        login_as_admin
+
+        get_with_api_header :index, withconfigrepo: 'true'
+        expect(response).to be_ok
+        expect(actual_response).to eq(expected_response([@environment_config], ApiV1::Admin::MergedEnvironments::MergedEnvironmentsConfigRepresenter))
+      end
+    end
+
+    describe :security do
+      it 'should allow anyone, with security disabled' do
+        disable_security
+        expect(controller).to allow_action(:get, :index)
+      end
+
+      it 'should disallow anonymous users, with security enabled' do
+        enable_security
+        login_as_anonymous
+        expect(controller).to disallow_action(:get, :index).with(401, 'You are not authorized to perform this action.')
+      end
+
+      it 'should disallow normal users, with security enabled' do
+        login_as_user
+        expect(controller).to disallow_action(:get, :index).with(401, 'You are not authorized to perform this action.')
+      end
+
+      it 'should allow admin users, with security enabled' do
+        login_as_admin
+        expect(controller).to allow_action(:get, :index)
+      end
+
+      it 'should disallow pipeline group admin users, with security enabled' do
+        login_as_group_admin
+        expect(controller).to disallow_action(:get, :index).with(401, 'You are not authorized to perform this action.')
+      end
+    end
+
+    describe :route do
+      describe :with_header do
+        it 'should route to index action of environments controller' do
+          expect(:get => 'api/admin/environments/merged').to route_to(action: 'index', controller: 'api_v1/admin/merged_environments')
+        end
+      end
+      describe :without_header do
+        before :each do
+          teardown_header
+        end
+        it 'should not route to index action of environments controller without header' do
+          expect(:get => 'api/admin/environments/merged').to_not route_to(action: 'index', controller: 'api_v1/admin/merged_environments')
+          expect(:get => 'api/admin/environments/merged').to route_to(controller: 'application', action: 'unresolved', url: 'api/admin/environments/merged')
+        end
+      end
+    end
+  end
+
+  describe :show do
+    before(:each) do
+      @environment_name = 'foo-environment'
+      @environment_config = BasicEnvironmentConfig.new(CaseInsensitiveString.new(@environment_name))
+      @environment_config_service = double('environment-config-service')
+      controller.stub(:environment_config_service).and_return(@environment_config_service)
+      environment_config_element = com.thoughtworks.go.domain.ConfigElementForEdit.new(@environment_config, "md5")
+      @environment_config_service.stub(:getMergedEnvironmentforDisplay).and_return(environment_config_element)
+      @environment_config_service.stub(:getEnvironmentForEdit).with(@environment_name).and_return(@environment_config)
+    end
+
+    describe :for_admins do
+      it 'should render the environment' do
+        login_as_admin
+
+        get_with_api_header :show, name: @environment_name, withconfigrepo: 'true'
+        expect(response).to be_ok
+        expect(actual_response).to eq(expected_response(@environment_config, ApiV1::Admin::MergedEnvironments::MergedEnvironmentConfigRepresenter))
+      end
+
+      it 'should render 404 when a environment does not exist' do
+        login_as_admin
+
+        @environment_name = SecureRandom.hex
+        @environment_config_service.stub(:getMergedEnvironmentforDisplay).and_return(nil)
+        get_with_api_header :show, name: @environment_name, withconfigrepo: 'true'
+        expect(response).to have_api_message_response(404, 'Either the resource you requested was not found, or you are not authorized to perform this action.')
+      end
+    end
+
+    describe :security do
+      before(:each) do
+        @environment_name = 'foo-environment'
+        @environment_config = BasicEnvironmentConfig.new(CaseInsensitiveString.new(@environment_name))
+        @environment_config_service = double('environment-config-service')
+        controller.stub(:environment_config_service).and_return(@environment_config_service)
+        @environment_config_service.stub(:getMergedEnvironmentforDisplay).with(@environment_name).and_return(@environment_config)
+      end
+
+      it 'should allow anyone, with security disabled' do
+        disable_security
+        expect(controller).to allow_action(:get, :show, name: @environment_name)
+      end
+
+      it 'should disallow anonymous users, with security enabled' do
+        enable_security
+        login_as_anonymous
+        expect(controller).to disallow_action(:get, :show, name: @environment_name).with(401, 'You are not authorized to perform this action.')
+      end
+
+      it 'should disallow normal users, with security enabled' do
+        login_as_user
+        expect(controller).to disallow_action(:get, :show, name: @environment_name).with(401, 'You are not authorized to perform this action.')
+      end
+
+      it 'should allow admin users, with security enabled' do
+        login_as_admin
+        expect(controller).to allow_action(:get, :show, name: @environment_name)
+      end
+
+      it 'should disallow pipeline group admin users, with security enabled' do
+        login_as_group_admin
+        expect(controller).to disallow_action(:get, :show, name: @environment_name).with(401, 'You are not authorized to perform this action.')
+      end
+    end
+
+    describe :route do
+      describe :with_header do
+        it 'should route to show action of environments controller for alphanumeric environment name' do
+          expect(:get => 'api/admin/environments/foo123/merged').to route_to(action: 'show', controller: 'api_v1/admin/merged_environments', name: 'foo123')
+        end
+
+        it 'should route to show action of environments controller for environment name with dots' do
+          expect(:get => 'api/admin/environments/foo.123/merged').to route_to(action: 'show', controller: 'api_v1/admin/merged_environments', name: 'foo.123')
+        end
+
+        it 'should route to show action of environments controller for environment name with hyphen' do
+          expect(:get => 'api/admin/environments/foo-123/merged').to route_to(action: 'show', controller: 'api_v1/admin/merged_environments', name: 'foo-123')
+        end
+
+        it 'should route to show action of environments controller for environment name with underscore' do
+          expect(:get => 'api/admin/environments/foo_123/merged').to route_to(action: 'show', controller: 'api_v1/admin/merged_environments', name: 'foo_123')
+        end
+
+        it 'should route to show action of environments controller for capitalized environment name' do
+          expect(:get => 'api/admin/environments/FOO/merged').to route_to(action: 'show', controller: 'api_v1/admin/merged_environments', name: 'FOO')
+        end
+      end
+      describe :without_header do
+        before :each do
+          teardown_header
+        end
+        it 'should not route to show action of environments controller without header' do
+          expect(:get => 'api/admin/environments/foo/merged').to_not route_to(action: 'show', controller: 'api_v1/admin/merged_environments')
+          expect(:get => 'api/admin/environments/foo/merged').to route_to(controller: 'application', action: 'unresolved', url: 'api/admin/environments/foo/merged')
+        end
+      end
+    end
+  end
+end

--- a/server/webapp/WEB-INF/rails.new/spec/controllers/api_v1/admin/merged_environments_controller_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/controllers/api_v1/admin/merged_environments_controller_spec.rb
@@ -21,8 +21,8 @@ describe ApiV1::Admin::MergedEnvironmentsController do
 
   describe :index do
     before(:each) do
-      @environment_name = 'foo-environment'
-      @environment_config = BasicEnvironmentConfig.new(CaseInsensitiveString.new(@environment_name))
+      environment_name = 'foo-environment'
+      @environment_config = BasicEnvironmentConfig.new(CaseInsensitiveString.new(environment_name))
       @environment_config_service = double('environment-config-service')
       controller.stub(:environment_config_service).and_return(@environment_config_service)
       @environment_config_service.stub(:getAllMergedEnvironments).and_return([@environment_config])
@@ -32,7 +32,7 @@ describe ApiV1::Admin::MergedEnvironmentsController do
       it 'should render the environment' do
         login_as_admin
 
-        get_with_api_header :index, withconfigrepo: 'true'
+        get_with_api_header :index
         expect(response).to be_ok
         expect(actual_response).to eq(expected_response([@environment_config], ApiV1::Admin::MergedEnvironments::MergedEnvironmentsConfigRepresenter))
       end
@@ -99,7 +99,7 @@ describe ApiV1::Admin::MergedEnvironmentsController do
       it 'should render the environment' do
         login_as_admin
 
-        get_with_api_header :show, name: @environment_name, withconfigrepo: 'true'
+        get_with_api_header :show, environment_name: @environment_name
         expect(response).to be_ok
         expect(actual_response).to eq(expected_response(@environment_config, ApiV1::Admin::MergedEnvironments::MergedEnvironmentConfigRepresenter))
       end
@@ -109,67 +109,59 @@ describe ApiV1::Admin::MergedEnvironmentsController do
 
         @environment_name = SecureRandom.hex
         @environment_config_service.stub(:getMergedEnvironmentforDisplay).and_return(nil)
-        get_with_api_header :show, name: @environment_name, withconfigrepo: 'true'
+        get_with_api_header :show, environment_name: @environment_name, withconfigrepo: 'true'
         expect(response).to have_api_message_response(404, 'Either the resource you requested was not found, or you are not authorized to perform this action.')
       end
     end
 
     describe :security do
-      before(:each) do
-        @environment_name = 'foo-environment'
-        @environment_config = BasicEnvironmentConfig.new(CaseInsensitiveString.new(@environment_name))
-        @environment_config_service = double('environment-config-service')
-        controller.stub(:environment_config_service).and_return(@environment_config_service)
-        @environment_config_service.stub(:getMergedEnvironmentforDisplay).with(@environment_name).and_return(@environment_config)
-      end
-
       it 'should allow anyone, with security disabled' do
         disable_security
-        expect(controller).to allow_action(:get, :show, name: @environment_name)
+        expect(controller).to allow_action(:get, :show, environment_name: @environment_name)
       end
 
       it 'should disallow anonymous users, with security enabled' do
         enable_security
         login_as_anonymous
-        expect(controller).to disallow_action(:get, :show, name: @environment_name).with(401, 'You are not authorized to perform this action.')
+        expect(controller).to disallow_action(:get, :show, environment_name: @environment_name).with(401, 'You are not authorized to perform this action.')
       end
 
       it 'should disallow normal users, with security enabled' do
         login_as_user
-        expect(controller).to disallow_action(:get, :show, name: @environment_name).with(401, 'You are not authorized to perform this action.')
+        expect(controller).to disallow_action(:get, :show, environment_name: @environment_name).with(401, 'You are not authorized to perform this action.')
       end
 
       it 'should allow admin users, with security enabled' do
         login_as_admin
-        expect(controller).to allow_action(:get, :show, name: @environment_name)
+        expect(controller).to allow_action(:get, :show, environment_name: @environment_name)
       end
 
       it 'should disallow pipeline group admin users, with security enabled' do
         login_as_group_admin
-        expect(controller).to disallow_action(:get, :show, name: @environment_name).with(401, 'You are not authorized to perform this action.')
+        expect(controller).to disallow_action(:get, :show, environment_name: @environment_name).with(401, 'You are not authorized to perform this action.')
       end
     end
 
     describe :route do
       describe :with_header do
         it 'should route to show action of environments controller for alphanumeric environment name' do
-          expect(:get => 'api/admin/environments/foo123/merged').to route_to(action: 'show', controller: 'api_v1/admin/merged_environments', name: 'foo123')
+          expect(:get => 'api/admin/environments/foo123/merged').to route_to(action: 'show', controller: 'api_v1/admin/merged_environments', environment_name: 'foo123')
         end
 
         it 'should route to show action of environments controller for environment name with dots' do
-          expect(:get => 'api/admin/environments/foo.123/merged').to route_to(action: 'show', controller: 'api_v1/admin/merged_environments', name: 'foo.123')
+          expect(:get => 'api/admin/environments/foo.123/merged').to route_to(action: 'show', controller: 'api_v1/admin/merged_environments', environment_name: 'foo.123')
         end
 
         it 'should route to show action of environments controller for environment name with hyphen' do
-          expect(:get => 'api/admin/environments/foo-123/merged').to route_to(action: 'show', controller: 'api_v1/admin/merged_environments', name: 'foo-123')
+          expect(:get => 'api/admin/environments/foo-123/merged').to route_to(action: 'show', controller: 'api_v1/admin/merged_environments', environment_name: 'foo-123')
         end
 
         it 'should route to show action of environments controller for environment name with underscore' do
-          expect(:get => 'api/admin/environments/foo_123/merged').to route_to(action: 'show', controller: 'api_v1/admin/merged_environments', name: 'foo_123')
+          expect(:get => 'api/admin/environments/foo_123/merged').to route_to(action: 'show', controller: 'api_v1/admin/merged_environments', environment_name: 'foo_123')
         end
 
         it 'should route to show action of environments controller for capitalized environment name' do
-          expect(:get => 'api/admin/environments/FOO/merged').to route_to(action: 'show', controller: 'api_v1/admin/merged_environments', name: 'FOO')
+          expect(:get => 'api/admin/environments/FOO/merged').to route_to(action: 'show', controller: 'api_v1/admin/merged_environments', environment_name: 'FOO')
         end
       end
       describe :without_header do

--- a/server/webapp/WEB-INF/rails.new/spec/presenters/api_v1/admin/merged_environments/agent_summary_representer_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/presenters/api_v1/admin/merged_environments/agent_summary_representer_spec.rb
@@ -1,0 +1,61 @@
+##########################################################################
+# Copyright 2017 ThoughtWorks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+
+
+require 'spec_helper'
+
+describe ApiV1::Admin::MergedEnvironments::AgentSummaryRepresenter do
+
+  it 'renders an agent summary' do
+    presenter = ApiV1::Admin::MergedEnvironments::AgentSummaryRepresenter.new({agent: EnvironmentAgentConfig.new('agent-uuid'), environment: get_environment_config})
+    actual_json = presenter.to_hash(url_builder: UrlBuilder.new)
+
+    expect(actual_json).to have_links(:self, :find, :doc)
+
+    expect(actual_json).to have_link(:self).with_url('http://test.host/api/agents/agent-uuid')
+    expect(actual_json).to have_link(:find).with_url('http://test.host/api/agents/:uuid')
+    expect(actual_json).to have_link(:doc).with_url('https://api.gocd.io/#agents')
+
+    actual_json.delete(:_links)
+    expect(actual_json).to eq(get_agent_summary)
+  end
+
+  def get_environment_config
+    env = EnvironmentConfigMother.environment('dev')
+    env.setOrigins(com.thoughtworks.go.config.remote.FileConfigOrigin.new)
+    env
+  end
+
+  def get_agent_summary
+    {
+      uuid: 'agent-uuid',
+      origin: {
+        type: 'local',
+        file: {
+          _links: {
+            self: {
+              href: 'http://test.host/admin/config_xml'
+            },
+            doc: {
+              href: 'https://api.gocd.org/#get-configuration'
+            }
+          },
+          name: 'cruise-config.xml'
+        }
+      }
+    }
+  end
+end

--- a/server/webapp/WEB-INF/rails.new/spec/presenters/api_v1/admin/merged_environments/agent_summary_representer_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/presenters/api_v1/admin/merged_environments/agent_summary_representer_spec.rb
@@ -27,7 +27,7 @@ describe ApiV1::Admin::MergedEnvironments::AgentSummaryRepresenter do
 
     expect(actual_json).to have_link(:self).with_url('http://test.host/api/agents/agent-uuid')
     expect(actual_json).to have_link(:find).with_url('http://test.host/api/agents/:uuid')
-    expect(actual_json).to have_link(:doc).with_url('https://api.gocd.io/#agents')
+    expect(actual_json).to have_link(:doc).with_url('https://api.gocd.org/#agents')
 
     actual_json.delete(:_links)
     expect(actual_json).to eq(get_agent_summary)

--- a/server/webapp/WEB-INF/rails.new/spec/presenters/api_v1/admin/merged_environments/environment_variable_representer_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/presenters/api_v1/admin/merged_environments/environment_variable_representer_spec.rb
@@ -1,0 +1,89 @@
+##########################################################################
+# Copyright 2017 ThoughtWorks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+
+require 'spec_helper'
+
+describe ApiV1::Admin::MergedEnvironments::EnvironmentVariableRepresenter do
+  it 'should render plain environment variable with hal representation' do
+    presenter = ApiV1::Admin::MergedEnvironments::EnvironmentVariableRepresenter.new({env_var: get_plain_variable, environment: get_environment_config})
+    actual_json = presenter.to_hash(url_builder: UrlBuilder.new)
+    expect(actual_json).to eq(get_plain_text_hash)
+  end
+
+  it 'should render secure environment variable with hal representation' do
+    presenter = ApiV1::Admin::MergedEnvironments::EnvironmentVariableRepresenter.new({env_var: get_secure_variable, environment: get_environment_config})
+    actual_json = presenter.to_hash(url_builder: UrlBuilder.new)
+    expect(actual_json).to eq(get_secure_hash_with_encrypted_value)
+  end
+
+  def get_secure_variable
+    EnvironmentVariableConfig.new(GoCipher.new, 'secure', 'confidential', true)
+  end
+
+  def get_plain_variable
+    EnvironmentVariableConfig.new(GoCipher.new, 'plain', 'plain', false)
+  end
+
+  def get_plain_text_hash
+    {
+      name: 'plain',
+      value: 'plain',
+      secure: false,
+      origin: {
+        type: 'local',
+        file: {
+          _links: {
+            self: {
+              href: 'http://test.host/admin/config_xml'
+            },
+            doc: {
+              href: 'https://api.gocd.org/#get-configuration'
+            }
+          },
+          name: 'cruise-config.xml'
+        }
+      }
+    }
+  end
+
+  def get_secure_hash_with_encrypted_value
+    {
+      secure: true,
+      name: 'secure',
+      encrypted_value: GoCipher.new.encrypt('confidential'),
+      origin: {
+        type: 'local',
+        file: {
+          _links: {
+            self: {
+              href: 'http://test.host/admin/config_xml'
+            },
+            doc: {
+              href: 'https://api.gocd.org/#get-configuration'
+            }
+          },
+          name: 'cruise-config.xml'
+        }
+      }
+    }
+  end
+
+  def get_environment_config
+    env = EnvironmentConfigMother.environment('dev').tap {|c| c.addEnvironmentVariable('username', 'admin')}
+    env.setOrigins(com.thoughtworks.go.config.remote.FileConfigOrigin.new)
+    env
+  end
+end

--- a/server/webapp/WEB-INF/rails.new/spec/presenters/api_v1/admin/merged_environments/merged_environment_config_representer_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/presenters/api_v1/admin/merged_environments/merged_environment_config_representer_spec.rb
@@ -1,0 +1,53 @@
+##########################################################################
+# Copyright 2017 ThoughtWorks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+
+require 'spec_helper'
+
+describe ApiV1::Admin::MergedEnvironments::MergedEnvironmentConfigRepresenter do
+
+  describe :serialize do
+    it 'renders an environment with hal representation' do
+      environment = get_environment_config
+      presenter = ApiV1::Admin::MergedEnvironments::MergedEnvironmentConfigRepresenter.new(environment)
+      actual_json = presenter.to_hash(url_builder: UrlBuilder.new)
+
+      expect(actual_json).to have_links(:self, :find, :doc)
+      expect(actual_json).to have_link(:find).with_url('http://test.host/api/admin/environments/:environment_name/merged')
+      expect(actual_json).to have_link(:self).with_url('http://test.host/api/admin/environments/dev/merged')
+      expect(actual_json).to have_link(:doc).with_url('https://api.gocd.io/#merged-environment-config')
+
+      actual_json.delete(:_links)
+      expect(actual_json).to eq({
+                                  name: 'dev',
+                                  origins: [ApiV1::Shared::ConfigOrigin::ConfigXmlOriginRepresenter.new(com.thoughtworks.go.config.remote.FileConfigOrigin.new).to_hash(url_builder: UrlBuilder.new)],
+                                  pipelines: [ApiV1::Admin::MergedEnvironments::PipelineConfigSummaryRepresenter.new({pipeline: com.thoughtworks.go.config.EnvironmentPipelineConfig.new('dev-pipeline'), environment: environment}).to_hash(url_builder: UrlBuilder.new)],
+                                  agents: [ApiV1::Admin::MergedEnvironments::AgentSummaryRepresenter.new({agent: EnvironmentAgentConfig.new('dev-agent'), environment: environment}).to_hash(url_builder: UrlBuilder.new),
+                                           ApiV1::Admin::MergedEnvironments::AgentSummaryRepresenter.new({agent: EnvironmentAgentConfig.new('omnipresent-agent'), environment: environment}).to_hash(url_builder: UrlBuilder.new)],
+                                  environment_variables: [
+                                    ApiV1::Admin::MergedEnvironments::EnvironmentVariableRepresenter.new({env_var: EnvironmentVariableConfig.new('username', 'admin'), environment: environment}).to_hash(url_builder: UrlBuilder.new)
+                                  ]
+                                })
+    end
+
+
+    def get_environment_config
+      env = EnvironmentConfigMother.environment('dev').tap { |c| c.addEnvironmentVariable('username', 'admin') }
+      env.setOrigins(com.thoughtworks.go.config.remote.FileConfigOrigin.new)
+      env
+    end
+
+  end
+end

--- a/server/webapp/WEB-INF/rails.new/spec/presenters/api_v1/admin/merged_environments/merged_environment_config_representer_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/presenters/api_v1/admin/merged_environments/merged_environment_config_representer_spec.rb
@@ -27,7 +27,7 @@ describe ApiV1::Admin::MergedEnvironments::MergedEnvironmentConfigRepresenter do
       expect(actual_json).to have_links(:self, :find, :doc)
       expect(actual_json).to have_link(:find).with_url('http://test.host/api/admin/environments/:environment_name/merged')
       expect(actual_json).to have_link(:self).with_url('http://test.host/api/admin/environments/dev/merged')
-      expect(actual_json).to have_link(:doc).with_url('https://api.gocd.io/#merged-environment-config')
+      expect(actual_json).to have_link(:doc).with_url('https://api.gocd.org/#merged-environment-config')
 
       actual_json.delete(:_links)
       expect(actual_json).to eq({

--- a/server/webapp/WEB-INF/rails.new/spec/presenters/api_v1/admin/merged_environments/merged_environments_config_representer_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/presenters/api_v1/admin/merged_environments/merged_environments_config_representer_spec.rb
@@ -1,0 +1,40 @@
+##########################################################################
+# Copyright 2017 ThoughtWorks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+
+require 'spec_helper'
+
+describe ApiV1::Admin::MergedEnvironments::MergedEnvironmentsConfigRepresenter do
+
+  describe :serialize do
+    it 'renders a list of environments' do
+      environment_config_one = EnvironmentConfigMother.environment("dev")
+      environment_config_two = EnvironmentConfigMother.environment("testing")
+
+      presenter = ApiV1::Admin::MergedEnvironments::MergedEnvironmentsConfigRepresenter.new([environment_config_one, environment_config_two])
+      actual_json = presenter.to_hash(url_builder: UrlBuilder.new)
+      expect(actual_json).to have_links(:self, :doc)
+
+      expect(actual_json).to have_link(:self).with_url('http://test.host/api/admin/environments/merged')
+      expect(actual_json).to have_link(:doc).with_url('https://api.gocd.io/#merged-environment-config')
+
+      actual_json.fetch(:_embedded).should == {
+        :environments => [ApiV1::Admin::MergedEnvironments::MergedEnvironmentConfigRepresenter.new(environment_config_one).to_hash(url_builder: UrlBuilder.new),
+                          ApiV1::Admin::MergedEnvironments::MergedEnvironmentConfigRepresenter.new(environment_config_two).to_hash(url_builder: UrlBuilder.new)]
+      }
+
+    end
+  end
+end

--- a/server/webapp/WEB-INF/rails.new/spec/presenters/api_v1/admin/merged_environments/pipeline_config_summary_representer_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/presenters/api_v1/admin/merged_environments/pipeline_config_summary_representer_spec.rb
@@ -1,0 +1,61 @@
+##########################################################################
+# Copyright 2017 ThoughtWorks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+
+
+require 'spec_helper'
+
+describe ApiV1::Admin::MergedEnvironments::PipelineConfigSummaryRepresenter do
+
+  it 'renders pipeline summary' do
+    presenter = ApiV1::Admin::MergedEnvironments::PipelineConfigSummaryRepresenter.new({pipeline: com.thoughtworks.go.config.EnvironmentPipelineConfig.new('pipeline1'), environment: get_environment_config})
+    actual_json = presenter.to_hash(url_builder: UrlBuilder.new)
+
+    expect(actual_json).to have_links(:self, :find, :doc)
+
+    expect(actual_json).to have_link(:self).with_url('http://test.host/api/admin/pipelines/pipeline1')
+    expect(actual_json).to have_link(:find).with_url('http://test.host/api/admin/pipelines/:pipeline_name')
+    expect(actual_json).to have_link(:doc).with_url('https://api.gocd.org/#pipeline-config')
+
+    actual_json.delete(:_links)
+    expect(actual_json).to eq(get_pipeline_config_summary)
+  end
+
+  def get_environment_config
+    env = EnvironmentConfigMother.environment('dev')
+    env.setOrigins(com.thoughtworks.go.config.remote.FileConfigOrigin.new)
+    env
+  end
+
+  def get_pipeline_config_summary
+    {
+      name: 'pipeline1',
+      origin: {
+        type: 'local',
+        file: {
+          _links: {
+            self: {
+              href: 'http://test.host/admin/config_xml'
+            },
+            doc: {
+              href: 'https://api.gocd.org/#get-configuration'
+            }
+          },
+          name: 'cruise-config.xml'
+        }
+      }
+    }
+  end
+end

--- a/server/webapp/WEB-INF/rails.new/spec/presenters/api_v1/shared/agent_summary_representer_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/presenters/api_v1/shared/agent_summary_representer_spec.rb
@@ -1,0 +1,36 @@
+##########################################################################
+# Copyright 2017 ThoughtWorks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+
+
+require 'spec_helper'
+
+describe ApiV1::Shared::AgentSummaryRepresenter do
+
+  it 'renders an agent summary' do
+    presenter = ApiV1::Shared::AgentSummaryRepresenter.new(EnvironmentAgentConfig.new('agent-uuid'))
+    actual_json = presenter.to_hash(url_builder: UrlBuilder.new)
+
+    expect(actual_json).to have_links(:self, :find, :doc)
+
+    expect(actual_json).to have_link(:self).with_url('http://test.host/api/agents/agent-uuid')
+    expect(actual_json).to have_link(:find).with_url('http://test.host/api/agents/:uuid')
+    expect(actual_json).to have_link(:doc).with_url('https://api.gocd.io/#agents')
+
+    actual_json.delete(:_links)
+    expect(actual_json).to eq({uuid: 'agent-uuid'})
+  end
+
+end

--- a/server/webapp/WEB-INF/rails.new/spec/presenters/api_v1/shared/agent_summary_representer_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/presenters/api_v1/shared/agent_summary_representer_spec.rb
@@ -27,7 +27,7 @@ describe ApiV1::Shared::AgentSummaryRepresenter do
 
     expect(actual_json).to have_link(:self).with_url('http://test.host/api/agents/agent-uuid')
     expect(actual_json).to have_link(:find).with_url('http://test.host/api/agents/:uuid')
-    expect(actual_json).to have_link(:doc).with_url('https://api.gocd.io/#agents')
+    expect(actual_json).to have_link(:doc).with_url('https://api.gocd.org/#agents')
 
     actual_json.delete(:_links)
     expect(actual_json).to eq({uuid: 'agent-uuid'})

--- a/server/webapp/WEB-INF/rails.new/spec/presenters/api_v1/shared/config_origin/config_repo_origin_representer_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/presenters/api_v1/shared/config_origin/config_repo_origin_representer_spec.rb
@@ -1,0 +1,47 @@
+##########################################################################
+# Copyright 2017 ThoughtWorks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+
+require 'spec_helper'
+
+describe ApiV1::Shared::ConfigOrigin::ConfigRepoOriginRepresenter do
+  it 'should render remote config origin with hal representation' do
+    config_repo = ConfigRepoConfig.new(GitMaterialConfig.new('https://github.com/config-repos/repo', 'master'), 'json-plugin', 'repo1')
+    config_repo_origin = RepoConfigOrigin.new(config_repo, 'revision1')
+    actual_json = ApiV1::Shared::ConfigOrigin::ConfigRepoOriginRepresenter.new(config_repo_origin).to_hash(url_builder: UrlBuilder.new)
+
+    expect(actual_json).to eq(expected_json)
+  end
+
+  def expected_json
+    {
+      type: 'config repo',
+      repo: {
+        _links: {
+          self: {
+            href: 'http://test.host/api/admin/config_repos/repo1'
+          },
+          doc: {
+            href: 'https://api.gocd.org/#config-repos'
+          },
+          find: {
+            href: 'http://test.host/api/admin/config_repos/:id'
+          }
+        },
+        id: 'repo1'
+      }
+    }
+  end
+end

--- a/server/webapp/WEB-INF/rails.new/spec/presenters/api_v1/shared/config_origin/config_xml_origin_representer_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/presenters/api_v1/shared/config_origin/config_xml_origin_representer_spec.rb
@@ -1,0 +1,45 @@
+##########################################################################
+# Copyright 2017 ThoughtWorks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+
+require 'spec_helper'
+
+describe ApiV1::Shared::ConfigOrigin::ConfigXmlOriginRepresenter do
+  it 'should render local config origin' do
+    presenter = ApiV1::Shared::ConfigOrigin::ConfigXmlOriginRepresenter.new(get_config_xml_origin)
+    actual_json = presenter.to_hash(url_builder: UrlBuilder.new)
+    expect(actual_json).to eq(expected_json)
+  end
+
+  def get_config_xml_origin
+    FileConfigOrigin.new
+  end
+
+  def expected_json
+    {
+      type: 'local',
+      file: {
+        _links: {
+          self: {
+            href: 'http://test.host/admin/config_xml'
+          }, doc: {
+            href: 'https://api.gocd.org/#get-configuration'
+          }
+        },
+        name: 'cruise-config.xml'
+      }
+    }
+  end
+end

--- a/server/webapp/WEB-INF/rails.new/spec/presenters/api_v1/shared/environment_variable_representer_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/presenters/api_v1/shared/environment_variable_representer_spec.rb
@@ -1,0 +1,97 @@
+##########################################################################
+# Copyright 2017 ThoughtWorks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+
+require 'spec_helper'
+
+describe ApiV1::Shared::EnvironmentVariableRepresenter do
+  it 'should render plain environment variable with hal representation' do
+    presenter   = ApiV1::Shared::EnvironmentVariableRepresenter.new(get_plain_variable)
+    actual_json = presenter.to_hash(url_builder: UrlBuilder.new)
+    expect(actual_json).to eq(get_plain_text_hash)
+  end
+
+  it 'should render secure environment variable with hal representation' do
+    presenter   = ApiV1::Shared::EnvironmentVariableRepresenter.new(get_secure_variable)
+    actual_json = presenter.to_hash(url_builder: UrlBuilder.new)
+    expect(actual_json).to eq(get_secure_hash_with_encrypted_value)
+  end
+
+  it 'should convert from secure hash with encrypted value to EnvironmentVariableConfig' do
+    config    = EnvironmentVariableConfig.new
+    presenter = ApiV1::Shared::EnvironmentVariableRepresenter.new(config)
+    presenter.from_hash(get_secure_hash_with_encrypted_value)
+    expect(config).to eq(get_secure_variable)
+  end
+
+  it 'should convert from secure hash with clear text value to EnvironmentVariableConfig' do
+    config    = EnvironmentVariableConfig.new
+    presenter = ApiV1::Shared::EnvironmentVariableRepresenter.new(config)
+    presenter.from_hash(secure_hash_with_clear_text_value)
+    expect(config).to eq(get_secure_variable)
+  end
+
+  it 'should deserialize an ambiguous encrypted variable (with both value and encrypted_value) to a variable with errors' do
+    config    = EnvironmentVariableConfig.new
+    presenter = ApiV1::Shared::EnvironmentVariableRepresenter.new(config)
+    config = presenter.from_hash(name: 'PASSWORD', secure: true, value: 'plainText', encrypted_value: 'c!ph3rt3xt')
+    expect(config.errors.getAllOn('value').to_a).to eq(['You may only specify `value` or `encrypted_value`, not both!'])
+    expect(config.errors.getAllOn('encryptedValue').to_a).to eq(['You may only specify `value` or `encrypted_value`, not both!'])
+  end
+
+  it 'should deserialize an unambiguous encrypted variable (with either value or encrypted_value) to a variable without errors' do
+    config    = EnvironmentVariableConfig.new
+    presenter = ApiV1::Shared::EnvironmentVariableRepresenter.new(config)
+    config = presenter.from_hash(name: 'PASSWORD', secure: true, value: 'plainText')
+    expect(config.errors).to be_empty
+
+    config    = EnvironmentVariableConfig.new
+    presenter = ApiV1::Shared::EnvironmentVariableRepresenter.new(config)
+    config = presenter.from_hash(name: 'PASSWORD', secure: true, encrypted_value: 'c!ph3rt3xt')
+    expect(config.errors).to be_empty
+  end
+
+  def get_secure_variable
+    EnvironmentVariableConfig.new(GoCipher.new, 'secure', 'confidential', true)
+  end
+
+  def get_plain_variable
+    EnvironmentVariableConfig.new(GoCipher.new, 'plain', 'plain', false)
+  end
+
+  def get_plain_text_hash
+    {
+      name:   'plain',
+      value:  'plain',
+      secure: false
+    }
+  end
+
+  def get_secure_hash_with_encrypted_value
+    {
+      secure:          true,
+      name:            'secure',
+      encrypted_value: GoCipher.new.encrypt('confidential')
+    }
+  end
+
+  def secure_hash_with_clear_text_value
+    {
+      secure: true,
+      name:   'secure',
+      value:  'confidential'
+    }
+  end
+end


### PR DESCRIPTION
* a seperate endpoint for managing config-repo environments
    - INDEX api/admin/enviroments/merged
    - GET api/admin/enviroments/{:envionment_name}/merged
* config-repo environments API should contain:
    - list of all the origins where the current environment is defined
    - origin attribute on each individual sub-entity to specify the origin of the association