### PR TITLE
ElasticAgent messages have a ttl now

### DIFF
--- a/server/src/com/thoughtworks/go/server/messaging/GoMessageQueue.java
+++ b/server/src/com/thoughtworks/go/server/messaging/GoMessageQueue.java
@@ -43,6 +43,10 @@ public class GoMessageQueue<T extends GoMessage> implements GoMessageChannel<T> 
         sender().sendMessage(message);
     }
 
+    public void post(T message, long timeToLive) {
+        sender().sendMessage(message, timeToLive);
+    }
+
     public void stop() {
         messaging.removeQueue(queueName);
     }

--- a/server/src/com/thoughtworks/go/server/messaging/MessageSender.java
+++ b/server/src/com/thoughtworks/go/server/messaging/MessageSender.java
@@ -19,5 +19,7 @@ package com.thoughtworks.go.server.messaging;
 public interface MessageSender {
     void sendMessage(GoMessage goMessage);
 
+    void sendMessage(GoMessage goMessage, long timeToLive);
+
     void sendText(String message);
 }

--- a/server/src/com/thoughtworks/go/server/messaging/PluginMessageQueueHandler.java
+++ b/server/src/com/thoughtworks/go/server/messaging/PluginMessageQueueHandler.java
@@ -65,11 +65,11 @@ public abstract class PluginMessageQueueHandler<T extends PluginAwareMessage> im
         }
     }
 
-    public void post(T message) {
+    public void post(T message, long timeToLive) {
         String pluginId = message.pluginId();
         try {
             if (queues.containsKey(pluginId)) {
-                queues.get(pluginId).post(message);
+                queues.get(pluginId).post(message, timeToLive);
             } else {
                 LOGGER.error("Could not find a queue for {}", pluginId);
             }

--- a/server/src/com/thoughtworks/go/server/messaging/activemq/ActiveMqMessageSender.java
+++ b/server/src/com/thoughtworks/go/server/messaging/activemq/ActiveMqMessageSender.java
@@ -16,6 +16,7 @@
 
 package com.thoughtworks.go.server.messaging.activemq;
 
+import javax.jms.DeliveryMode;
 import javax.jms.MessageProducer;
 import javax.jms.Session;
 import javax.jms.JMSException;
@@ -37,6 +38,15 @@ public class ActiveMqMessageSender implements MessageSender {
     public void sendMessage(GoMessage message) {
         try {
             producer.send(session.createObjectMessage(message));
+        } catch (JMSException e) {
+            throw bomb(e);
+        }
+    }
+
+    @Override
+    public void sendMessage(GoMessage goMessage, long timeToLive) {
+        try {
+            producer.send(session.createObjectMessage(goMessage), producer.getDeliveryMode(), producer.getPriority(), timeToLive);
         } catch (JMSException e) {
             throw bomb(e);
         }


### PR DESCRIPTION
* ElasticAgent `createAgent` and `ping` messages have a ttl,
  this is to ensure we do not fill up the activeMQ queue if the plugins
  are slow.
* ActiveMQ queue's reaching a memory limit can lead to a deadlock since
  we use a sinlge connection for both producers and consumers.
  http://activemq.apache.org/producer-flow-control.html