### PR TITLE
Fix spelling of GitHub

### DIFF
--- a/server/test/unit/com/thoughtworks/go/server/service/SecurityAuthConfigServiceTest.java
+++ b/server/test/unit/com/thoughtworks/go/server/service/SecurityAuthConfigServiceTest.java
@@ -122,7 +122,7 @@ public class SecurityAuthConfigServiceTest {
     public void shouldGetAListOfAllConfiguredWebBasedAuthorizationPlugins() {
         Set<AuthorizationPluginInfo> installedWebBasedPlugins = new HashSet<>();
         String githubPluginId = "cd.go.github";
-        AuthorizationPluginInfo githubPluginInfo = pluginInfo(githubPluginId, "Github Auth Plugin", SupportedAuthType.Web);
+        AuthorizationPluginInfo githubPluginInfo = pluginInfo(githubPluginId, "GitHub Auth Plugin", SupportedAuthType.Web);
         installedWebBasedPlugins.add(githubPluginInfo);
         installedWebBasedPlugins.add(pluginInfo(githubPluginId, "Google Auth Plugin", SupportedAuthType.Web));
         when(authorizationMetadataStore.getPluginsThatSupportsWebBasedAuthentication()).thenReturn(installedWebBasedPlugins);
@@ -140,7 +140,7 @@ public class SecurityAuthConfigServiceTest {
         assertThat(allWebBasedAuthorizationConfigs.size(), is(1));
         AuthPluginInfoViewModel pluginInfoViewModel = allWebBasedAuthorizationConfigs.get(0);
         assertThat(pluginInfoViewModel.pluginId(), is(githubPluginId));
-        assertThat(pluginInfoViewModel.name(), is("Github Auth Plugin"));
+        assertThat(pluginInfoViewModel.name(), is("GitHub Auth Plugin"));
         assertThat(pluginInfoViewModel.imageUrl(), is("/go/api/plugin_images/cd.go.github/hash"));
     }
 

--- a/server/test/unit/com/thoughtworks/go/server/service/plugins/builder/AuthenticationViewModelBuilderTest.java
+++ b/server/test/unit/com/thoughtworks/go/server/service/plugins/builder/AuthenticationViewModelBuilderTest.java
@@ -50,7 +50,7 @@ public class AuthenticationViewModelBuilderTest {
         initMocks(this);
         builder = new AuthenticationViewModelBuilder(manager, registry);
         githubDescriptor = new GoPluginDescriptor("github.oauth", "version1",
-                new GoPluginDescriptor.About("Github OAuth Plugin", "1.0", null, null, null,null),
+                new GoPluginDescriptor.About("GitHub OAuth Plugin", "1.0", null, null, null,null),
                 null, null, false);
 
         googleDescriptor = new GoPluginDescriptor("google.oauth", "version1",

--- a/server/test/unit/com/thoughtworks/go/server/service/plugins/builder/PluginInfoBuilderTest.java
+++ b/server/test/unit/com/thoughtworks/go/server/service/plugins/builder/PluginInfoBuilderTest.java
@@ -76,7 +76,7 @@ public class PluginInfoBuilderTest {
     public void setUp() {
         initMocks(this);
         githubDescriptor = new GoPluginDescriptor("github.oauth", "version1",
-                new GoPluginDescriptor.About("Github OAuth Plugin", "1.0", null, null, null, null),
+                new GoPluginDescriptor.About("GitHub OAuth Plugin", "1.0", null, null, null, null),
                 null, null, false);
         emailNotifier = new GoPluginDescriptor("email.notifier", "version1",
                 new GoPluginDescriptor.About("Email Notifier", "1.0", null, null, null, null),
@@ -88,7 +88,7 @@ public class PluginInfoBuilderTest {
                 new GoPluginDescriptor.About("Xunit Convertor", "1.0", null, null, null, null),
                 null, null, false);
         githubPR = new GoPluginDescriptor("github.pr", "version1",
-                new GoPluginDescriptor.About("Github PR", "1.0", null, null, null, null),
+                new GoPluginDescriptor.About("GitHub PR", "1.0", null, null, null, null),
                 null, null, false);
 
         dockerElasticAgentPlugin = new GoPluginDescriptor("cd.go.elastic-agent.docker", "1.0",

--- a/server/test/unit/com/thoughtworks/go/server/ui/AuthPluginInfoViewModelTest.java
+++ b/server/test/unit/com/thoughtworks/go/server/ui/AuthPluginInfoViewModelTest.java
@@ -30,13 +30,13 @@ public class AuthPluginInfoViewModelTest {
 
     @Test
     public void shouldGetDetailsAboutThePlugin() {
-        GoPluginDescriptor.About about = new GoPluginDescriptor.About("Github Auth Plugin", "1.0", null, null, null, null);
+        GoPluginDescriptor.About about = new GoPluginDescriptor.About("GitHub Auth Plugin", "1.0", null, null, null, null);
         String pluginId = "github";
         GoPluginDescriptor descriptor = new GoPluginDescriptor(pluginId, "1.0", about, null, null, false);
         AuthorizationPluginInfo pluginInfo = new AuthorizationPluginInfo(descriptor, null, null, new Image("svg", "data", "hash"), new Capabilities(SupportedAuthType.Web, true, true), null);
         AuthPluginInfoViewModel model = new AuthPluginInfoViewModel(pluginInfo);
         assertThat(model.imageUrl(), is("/go/api/plugin_images/github/hash"));
         assertThat(model.pluginId(), is("github"));
-        assertThat(model.name(), is("Github Auth Plugin"));
+        assertThat(model.name(), is("GitHub Auth Plugin"));
     }
 }

--- a/server/webapp/WEB-INF/rails.new/spec/webpack/models/pipeline_configs/materials_spec.js
+++ b/server/webapp/WEB-INF/rails.new/spec/webpack/models/pipeline_configs/materials_spec.js
@@ -848,7 +848,7 @@ describe("Material Model", () => {
       const github = new SCMs.SCM({
         /* eslint-disable camelcase */
         id:              '43c45e0b-1b0c-46f3-a60a-2bbc5cec069c',
-        name:            'Github PR',
+        name:            'GitHub PR',
         auto_update:     true,
         plugin_metadata: {id: 'github.pr', version: '1.1'},
         configuration:   [{key: 'url', value: 'path/to/repo'}, {key: 'username', value: 'some_name'}]

--- a/server/webapp/WEB-INF/rails.new/spec/webpack/models/shared/plugin_infos_spec.js
+++ b/server/webapp/WEB-INF/rails.new/spec/webpack/models/shared/plugin_infos_spec.js
@@ -135,7 +135,7 @@ describe('PluginInfos', () => {
         "version": "1",
         "type":    "notification",
         "about":   {
-          "name":                     "Github Pull Requests status notifier",
+          "name":                     "GitHub Pull Requests status notifier",
           "version":                  "1.2",
           "target_go_version":        "15.1.0",
           "description":              "Updates build status for GitHub pull request",
@@ -352,7 +352,7 @@ describe('PluginInfos', () => {
         "version":      "1",
         "type":         "scm",
         "about":        {
-          "name":                     "Github Pull Requests Builder",
+          "name":                     "GitHub Pull Requests Builder",
           "version":                  "1.3.0-RC2",
           "target_go_version":        "15.1.0",
           "description":              "Plugin that polls a GitHub repository for pull requests and triggers a build for each of them",
@@ -362,7 +362,7 @@ describe('PluginInfos', () => {
             "url":  "https://github.com/ashwanthkumar/gocd-build-github-pull-requests"
           }
         },
-        "display_name": "Github",
+        "display_name": "GitHub",
         "scm_settings": {
           "configurations": [
             {
@@ -554,7 +554,7 @@ describe('PluginInfos', () => {
       "id":      "github.pr",
       "version": "1",
       "about":   {
-        "name":                     "Github Pull Requests Builder",
+        "name":                     "GitHub Pull Requests Builder",
         "version":                  "1.3.0-RC2",
         "target_go_version":        "15.1.0",
         "description":              "Plugin that polls a GitHub repository for pull requests and triggers a build for each of them",

--- a/server/webapp/WEB-INF/rails.new/spec/webpack/views/auth_configs/auth_configs_widget_spec.js
+++ b/server/webapp/WEB-INF/rails.new/spec/webpack/views/auth_configs/auth_configs_widget_spec.js
@@ -90,7 +90,7 @@ describe("AuthConfigsWidget", () => {
     "id":                   "cd.go.authorization.github",
     "type":                 "authorization",
     "about":                {
-      "name":    "Github authorization plugin",
+      "name":    "GitHub authorization plugin",
       "version": "1.x.x",
     },
     "capabilities":         {

--- a/server/webapp/WEB-INF/rails.new/spec/webpack/views/pipeline_configs/edit_pluggable_scm_material_widget_spec.js
+++ b/server/webapp/WEB-INF/rails.new/spec/webpack/views/pipeline_configs/edit_pluggable_scm_material_widget_spec.js
@@ -53,7 +53,7 @@ describe("Edit Pluggable SCM Material Widget", () => {
 
     it('should show the pluggable scm metadata', () => {
       expect($('label.name')).toContainText('Name');
-      expect($root.find('span')[0]).toContainText('Github PR');
+      expect($root.find('span')[0]).toContainText('GitHub PR');
 
       expect($('label.autoupdate')).toContainText('AutoUpdate');
       expect($root.find('span')[1]).toContainText('true');
@@ -102,7 +102,7 @@ describe("Edit Pluggable SCM Material Widget", () => {
       "version":      "1",
       "type":         "scm",
       "about":        {
-        "name":                     "Github Pull Requests Builder",
+        "name":                     "GitHub Pull Requests Builder",
         "version":                  "1.3.0-RC2",
         "target_go_version":        "15.1.0",
         "description":              "Plugin that polls a GitHub repository for pull requests and triggers a build for each of them",
@@ -124,7 +124,7 @@ describe("Edit Pluggable SCM Material Widget", () => {
   /* eslint-disable camelcase */
   const githubSCMJSON = {
     id:              '43c45e0b-1b0c-46f3-a60a-2bbc5cec069c',
-    name:            'Github PR',
+    name:            'GitHub PR',
     auto_update:     true,
     plugin_metadata: {id: 'github.pr', version: '1.1'},
     configuration:   [{key: 'url', value: 'path/to/repo'}, {key: 'username', value: 'some_name'}]

--- a/server/webapp/WEB-INF/rails.new/spec/webpack/views/pipeline_configs/new_pluggable_scm_widget_spec.js
+++ b/server/webapp/WEB-INF/rails.new/spec/webpack/views/pipeline_configs/new_pluggable_scm_widget_spec.js
@@ -107,7 +107,7 @@ describe("New Pluggable SCM Material Widget", () => {
       "version":      "1",
       "type":         "scm",
       "about":        {
-        "name":                     "Github Pull Requests Builder",
+        "name":                     "GitHub Pull Requests Builder",
         "version":                  "1.3.0-RC2",
         "target_go_version":        "15.1.0",
         "description":              "Plugin that polls a GitHub repository for pull requests and triggers a build for each of them",
@@ -129,7 +129,7 @@ describe("New Pluggable SCM Material Widget", () => {
   /* eslint-disable camelcase */
   const githubSCMJSON = {
     id:              '43c45e0b-1b0c-46f3-a60a-2bbc5cec069c',
-    name:            'Github PR',
+    name:            'GitHub PR',
     auto_update:     true,
     plugin_metadata: {id: 'github.pr', version: '1.1'},
     configuration:   [{key: 'url', value: 'path/to/repo'}, {key: 'username', value: 'some_name'}]

--- a/server/webapp/WEB-INF/rails.new/spec/webpack/views/roles/roles_widget_spec.js
+++ b/server/webapp/WEB-INF/rails.new/spec/webpack/views/roles/roles_widget_spec.js
@@ -93,11 +93,11 @@ describe("RolesWidget", () => {
   const githubPluginInfoJSON = {
     "id":            "cd.go.authorization.github",
     "type":          "authorization",
-    "about":         {"name": "Github authorization plugin"},
+    "about":         {"name": "GitHub authorization plugin"},
     "role_settings": {
       "configurations": [],
       "view":           {
-        "template": '<div class="plugin-role-view"><label>Github username:</label><input id="name" type="text"/></div>'
+        "template": '<div class="plugin-role-view"><label>GitHub username:</label><input id="name" type="text"/></div>'
       }
     }
   };
@@ -321,7 +321,7 @@ describe("RolesWidget", () => {
 
       expect($('.reveal input[data-prop-name]')).not.toBeDisabled();
       expect($('.reveal [data-prop-name=authConfigId] option:selected').text()).toEqual(`${secondValidAuthConfigJSON.id} (${githubPluginInfoJSON.about.name})`);
-      expect($('.reveal .plugin-role-view label').text()).toEqual("Github username:");
+      expect($('.reveal .plugin-role-view label').text()).toEqual("GitHub username:");
     });
 
     it("should make request to save role on click of save button", () => {


### PR DESCRIPTION
GitHub is spelled GitHub, not Github.

I believe that this change is safe, because it only changes the display names (no class names etc).