### PR TITLE
Users api v2 bulk delete

### DIFF
--- a/server/src/com/thoughtworks/go/server/dao/UserDao.java
+++ b/server/src/com/thoughtworks/go/server/dao/UserDao.java
@@ -1,5 +1,5 @@
 /*************************GO-LICENSE-START*********************************
- * Copyright 2014 ThoughtWorks, Inc.
+ * Copyright 2017 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,11 +16,11 @@
 
 package com.thoughtworks.go.server.dao;
 
-import java.util.List;
-import java.util.Set;
-
 import com.thoughtworks.go.domain.User;
 import com.thoughtworks.go.domain.Users;
+
+import java.util.List;
+import java.util.Set;
 
 public interface UserDao {
     void saveOrUpdate(User user);
@@ -46,4 +46,6 @@ public interface UserDao {
     User load(long id);
 
     boolean deleteUser(String username);
+
+    boolean deleteUsers(List<String> userNames);
 }

--- a/server/src/com/thoughtworks/go/server/dao/UserSqlMapDao.java
+++ b/server/src/com/thoughtworks/go/server/dao/UserSqlMapDao.java
@@ -1,5 +1,5 @@
 /*************************GO-LICENSE-START*********************************
- * Copyright 2014 ThoughtWorks, Inc.
+ * Copyright 2017 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -49,7 +49,7 @@ import org.springframework.transaction.support.TransactionCallbackWithoutResult;
 import org.springframework.transaction.support.TransactionSynchronizationAdapter;
 
 @Component
-public class UserSqlMapDao  extends HibernateDaoSupport implements UserDao {
+public class UserSqlMapDao extends HibernateDaoSupport implements UserDao {
     private SessionFactory sessionFactory;
     private TransactionTemplate transactionTemplate;
     private GoCache goCache;
@@ -164,6 +164,7 @@ public class UserSqlMapDao  extends HibernateDaoSupport implements UserDao {
         changeEnabledStatus(usernames, true);
     }
 
+    @Override
     public List<User> enabledUsers() {
         List<User> enabledUsers = new ArrayList<>();
         for (User user : allUsers()) {
@@ -207,6 +208,20 @@ public class UserSqlMapDao  extends HibernateDaoSupport implements UserDao {
                     throw new UserEnabledException();
                 }
                 sessionFactory.getCurrentSession().delete(user);
+                return Boolean.TRUE;
+            }
+        });
+    }
+
+    @Override
+    public boolean deleteUsers(List<String> userNames) {
+        return (Boolean) transactionTemplate.execute(new TransactionCallback() {
+            @Override
+            public Object doInTransaction(TransactionStatus status) {
+                String queryString = "delete from User where name in (:userNames)";
+                Query query = sessionFactory.getCurrentSession().createQuery(queryString);
+                query.setParameterList("userNames", userNames);
+                query.executeUpdate();
                 return Boolean.TRUE;
             }
         });

--- a/server/src/com/thoughtworks/go/server/service/result/BulkDeletionFailureResult.java
+++ b/server/src/com/thoughtworks/go/server/service/result/BulkDeletionFailureResult.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2017 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.server.service.result;
+
+import java.util.ArrayList;
+import java.util.List;
+public class BulkDeletionFailureResult {
+    private List<String> nonExistentUsers;
+    private List<String> enabledUsers;
+
+    public BulkDeletionFailureResult() {
+        nonExistentUsers = new ArrayList<>();
+        enabledUsers = new ArrayList<>();
+    }
+
+    public BulkDeletionFailureResult(List<String> nonExistentUsers, List<String> enabledUsers) {
+        this.nonExistentUsers = new ArrayList<>();
+        this.nonExistentUsers = nonExistentUsers;
+        this.enabledUsers = new ArrayList<>();
+        this.enabledUsers = enabledUsers;
+    }
+
+    public List<String> getNonExistentUsers(){
+        return nonExistentUsers;
+    }
+
+    public List<String> getEnabledUsers(){
+        return enabledUsers;
+    }
+
+    public void addNonExistentUserName(String userName) {
+        nonExistentUsers.add(userName);
+    }
+
+    public void addEnabledUserName(String userName) {
+        enabledUsers.add(userName);
+    }
+
+    public boolean isEmpty() {
+        return nonExistentUsers.isEmpty() && enabledUsers.isEmpty();
+    }
+}

--- a/server/test/integration/com/thoughtworks/go/server/dao/UserSqlMapDaoIntegrationTest.java
+++ b/server/test/integration/com/thoughtworks/go/server/dao/UserSqlMapDaoIntegrationTest.java
@@ -43,6 +43,7 @@ import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 import static org.junit.matchers.JUnitMatchers.hasItems;
+
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(locations = {
         "classpath:WEB-INF/applicationContext-global.xml",
@@ -50,9 +51,12 @@ import static org.junit.matchers.JUnitMatchers.hasItems;
         "classpath:WEB-INF/applicationContext-acegi-security.xml"
 })
 public class UserSqlMapDaoIntegrationTest {
-    @Autowired private UserSqlMapDao userDao;
-    @Autowired private DatabaseAccessHelper dbHelper;
-    @Autowired private SessionFactory sessionFactory;
+    @Autowired
+    private UserSqlMapDao userDao;
+    @Autowired
+    private DatabaseAccessHelper dbHelper;
+    @Autowired
+    private SessionFactory sessionFactory;
 
     @Before
     public void setup() throws Exception {
@@ -77,7 +81,7 @@ public class UserSqlMapDaoIntegrationTest {
     }
 
     @Test
-    public void shouldSaveLoginAsDisplayNameIfDisplayNameIsNotPresent(){
+    public void shouldSaveLoginAsDisplayNameIfDisplayNameIsNotPresent() {
         User user = new User("loser");
         userDao.saveOrUpdate(user);
 
@@ -85,7 +89,7 @@ public class UserSqlMapDaoIntegrationTest {
     }
 
     @Test
-    public void shouldNotUpdateDisplayNameToNullOrBlank(){
+    public void shouldNotUpdateDisplayNameToNullOrBlank() {
         User user = new User("loser", "moocow", "moocow@example.com");
         userDao.saveOrUpdate(user);
         user.setDisplayName("");
@@ -193,7 +197,7 @@ public class UserSqlMapDaoIntegrationTest {
     }
 
     @Test
-    public void shouldUpdateUserWithEnabledStatusWhenUserExist(){
+    public void shouldUpdateUserWithEnabledStatusWhenUserExist() {
         User user = new User("user", "my name", "user2@mail.com");
         userDao.saveOrUpdate(user);
         final User foundUser = userDao.findUser("user");
@@ -311,7 +315,7 @@ public class UserSqlMapDaoIntegrationTest {
     }
 
     @Test
-    public void shouldLoadSubscribersOfNotification(){
+    public void shouldLoadSubscribersOfNotification() {
         User user1 = new User("user1");
         user1.addNotificationFilter(new NotificationFilter("pipeline", "stage", StageEvent.Fails, true));
         userDao.saveOrUpdate(user1);
@@ -348,7 +352,7 @@ public class UserSqlMapDaoIntegrationTest {
 
 
     @Test
-    public void shouldDeleteNotificationOnAUser(){
+    public void shouldDeleteNotificationOnAUser() {
         User user = new User("user1");
         user.addNotificationFilter(new NotificationFilter("pipeline1", "stage", StageEvent.Fails, true));
         user.addNotificationFilter(new NotificationFilter("pipeline2", "stage", StageEvent.Fails, true));
@@ -423,6 +427,25 @@ public class UserSqlMapDaoIntegrationTest {
         assertThat(retrievedUser instanceof NullUser, is(false));
         assertThat(retrievedUser, is(addingTheUserNow));
         assertThat(userDao.deleteUser(userName), is(true));
+    }
+
+    @Test
+    public void shouldDeleteUsers() {
+        User john = new User("john");
+        john.disable();
+        User joan = new User("joan");
+        joan.disable();
+
+        List<String> userNames = Arrays.asList("john", "joan");
+
+        userDao.saveOrUpdate(john);
+        userDao.saveOrUpdate(joan);
+
+        boolean result = userDao.deleteUsers(userNames);
+        assertThat(result, is(true));
+
+        Users users = userDao.allUsers();
+        assertThat(users, is(empty()));
     }
 
     private User anUser() {

--- a/server/test/unit/com/thoughtworks/go/server/dao/UserSqlMapDaoTest.java
+++ b/server/test/unit/com/thoughtworks/go/server/dao/UserSqlMapDaoTest.java
@@ -16,9 +16,6 @@
 
 package com.thoughtworks.go.server.dao;
 
-import java.util.Arrays;
-import java.util.Set;
-
 import com.thoughtworks.go.domain.User;
 import com.thoughtworks.go.server.cache.GoCache;
 import com.thoughtworks.go.server.service.StubGoCache;
@@ -34,24 +31,26 @@ import org.springframework.orm.hibernate3.HibernateCallback;
 import org.springframework.orm.hibernate3.HibernateTemplate;
 import org.springframework.transaction.support.TransactionCallback;
 
+import java.util.Arrays;
+import java.util.Set;
+
 import static com.thoughtworks.go.util.DataStructureUtils.s;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
 import static org.junit.matchers.JUnitMatchers.hasItems;
 import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 import static org.mockito.MockitoAnnotations.initMocks;
 
 public class UserSqlMapDaoTest {
-    @Mock private SessionFactory sessionFactory;
-    @Mock private TransactionTemplate transactionTemplate;
-    @Mock private HibernateTemplate mockHibernateTemplate;
-    @Mock private TransactionSynchronizationManager transactionSynchronizationManager;
+    @Mock
+    private SessionFactory sessionFactory;
+    @Mock
+    private TransactionTemplate transactionTemplate;
+    @Mock
+    private HibernateTemplate mockHibernateTemplate;
+    @Mock
+    private TransactionSynchronizationManager transactionSynchronizationManager;
     private StubGoCache goCache;
     private UserSqlMapDao dao;
 

--- a/server/test/unit/com/thoughtworks/go/server/service/result/BulkDeletionFailureResultTest.java
+++ b/server/test/unit/com/thoughtworks/go/server/service/result/BulkDeletionFailureResultTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2017 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.server.service.result;
+
+import org.junit.Test;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+
+public class BulkDeletionFailureResultTest {
+    @Test
+    public void isSuccessfulIfThereAreNoEnabledOrNonExistentUsers() throws Exception {
+        assertThat(new BulkDeletionFailureResult().isEmpty(), is(true));
+    }
+}

--- a/server/webapp/WEB-INF/rails.new/app/controllers/api_v2/base_controller.rb
+++ b/server/webapp/WEB-INF/rails.new/app/controllers/api_v2/base_controller.rb
@@ -1,5 +1,5 @@
 ##########################GO-LICENSE-START################################
-# Copyright 2015 ThoughtWorks, Inc.
+# Copyright 2017 ThoughtWorks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/server/webapp/WEB-INF/rails.new/app/controllers/api_v2/users_controller.rb
+++ b/server/webapp/WEB-INF/rails.new/app/controllers/api_v2/users_controller.rb
@@ -1,0 +1,88 @@
+##########################################################################
+# Copyright 2017 ThoughtWorks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+
+module ApiV2
+  class UsersController < ApiV2::BaseController
+    include ApiV2::UsersHelper
+
+    before_action :check_admin_user_and_401
+    before_action :load_user, only: [:show, :update, :destroy]
+
+    def index
+      render DEFAULT_FORMAT => UsersRepresenter.new(user_service.allUsers).to_hash(url_builder: self)
+    end
+
+    def show
+      render DEFAULT_FORMAT => UserRepresenter.new(@user_to_operate).to_hash(url_builder: self)
+    end
+
+    def update
+      result = HttpLocalizedOperationResult.new
+      @user_to_operate = save_user(result, @user_to_operate)
+      if result.isSuccessful
+        render DEFAULT_FORMAT => UserRepresenter.new(@user_to_operate).to_hash(url_builder: self)
+      else
+        render_http_operation_result(result)
+      end
+    end
+
+    def create
+      result = HttpLocalizedOperationResult.new
+
+      user = nil
+      created = false
+      user_service.withEnableUserMutex do
+        user = user_service.findUserByName(params[:login_name])
+        if user.instance_of?(com.thoughtworks.go.domain.NullUser)
+          user = save_user(result, com.thoughtworks.go.domain.User.new(params[:login_name]))
+          created = true
+        end
+      end
+
+      unless created
+        return render_message("The user `#{params[:login_name]}` already exists.", :conflict)
+      end
+
+      if result.httpCode == 200
+        response.location = apiv1_user_url(login_name: params[:login_name])
+        render DEFAULT_FORMAT => UserRepresenter.new(user).to_hash(url_builder: self), status: :created
+      else
+        render_http_operation_result(result)
+      end
+    end
+
+    def destroy
+      result = HttpLocalizedOperationResult.new
+      user_service.deleteUser(params[:login_name], result)
+      render_http_operation_result(result)
+    end
+
+    def bulk_delete
+      result = HttpLocalizedOperationResult.new
+      bulk_deletion_obstruct = user_service.deleteUsers(Array.wrap(params[:users]), result)
+      if result.isSuccessful
+        render_http_operation_result(result)
+      elsif bulk_deletion_obstruct
+        render_http_operation_result(result, BulkDeletionFailureResultRepresenter.new(bulk_deletion_obstruct).to_hash(url_builder: self))
+      else
+        render_http_operation_result(result)
+      end
+    end
+
+    private
+
+  end
+end

--- a/server/webapp/WEB-INF/rails.new/app/helpers/api_v2/users_helper.rb
+++ b/server/webapp/WEB-INF/rails.new/app/helpers/api_v2/users_helper.rb
@@ -1,0 +1,46 @@
+##########################################################################
+# Copyright 2017 ThoughtWorks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+
+module ApiV2
+  module UsersHelper
+
+    def save_user(result, user)
+      # sending empty arrays through JSON are deserialized to nil
+      # yay rails. https://github.com/rails/rails/pull/8862
+      params["checkin_aliases"] = [] if params.has_key?("checkin_aliases") && params["checkin_aliases"].blank?
+
+      checkin_aliases = if params[:checkin_aliases].is_a?(Array)
+                          params[:checkin_aliases].join(',')
+                        else
+                          params[:checkin_aliases]
+                        end
+      user_service.save(user, to_tristate(params[:enabled]), to_tristate(params[:email_me]), params[:email], checkin_aliases, result)
+    end
+
+    def load_user(username=params[:login_name])
+      @user_to_operate = user_service.findUserByName(username)
+
+      if !@user_to_operate || @user_to_operate.instance_of?(com.thoughtworks.go.domain.NullUser)
+        raise ApiV2::RecordNotFound
+      end
+    end
+
+    def load_current_user
+      load_user(current_user.username.to_s)
+    end
+
+  end
+end

--- a/server/webapp/WEB-INF/rails.new/app/presenters/api_v2/base_representer.rb
+++ b/server/webapp/WEB-INF/rails.new/app/presenters/api_v2/base_representer.rb
@@ -1,5 +1,5 @@
 ##########################GO-LICENSE-START################################
-# Copyright 2015 ThoughtWorks, Inc.
+# Copyright 2017 ThoughtWorks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/server/webapp/WEB-INF/rails.new/app/presenters/api_v2/bulk_deletion_failure_result_representer.rb
+++ b/server/webapp/WEB-INF/rails.new/app/presenters/api_v2/bulk_deletion_failure_result_representer.rb
@@ -1,0 +1,32 @@
+##########################################################################
+# Copyright 2017 ThoughtWorks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+
+module ApiV2
+  class BulkDeletionFailureResultRepresenter < ApiV2::BaseRepresenter
+    #workaround required due to issues with skip_render on collections in roar (https://github.com/trailblazer/roar/issues/161)
+    property :non_existent_users, exec_context: :decorator, skip_render: lambda { |array, options| array.empty? }
+    property :enabled_users, exec_context: :decorator, skip_render: lambda { |array, options| array.empty? }
+
+    def non_existent_users
+      represented.getNonExistentUsers.to_a
+    end
+
+    def enabled_users
+      represented.getEnabledUsers.to_a
+    end
+  end
+
+end

--- a/server/webapp/WEB-INF/rails.new/app/presenters/api_v2/user_representer.rb
+++ b/server/webapp/WEB-INF/rails.new/app/presenters/api_v2/user_representer.rb
@@ -1,0 +1,44 @@
+##########################################################################
+# Copyright 2017 ThoughtWorks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+
+module ApiV2
+  class UserRepresenter < ApiV2::UserSummaryRepresenter
+    attr_reader :user
+
+    def initialize(user)
+      @user = user
+      super(user.name)
+    end
+
+    property :displayName, as: :display_name
+    property :isEnabled, as: :enabled
+    property :email, exec_context: :decorator
+    property :isEmailMe, as: :email_me
+    property :checkin_aliases, exec_context: :decorator
+
+    def email
+      user.email.blank? ? nil : user.email
+    end
+
+    def checkin_aliases
+      user.getMatchers().to_a
+    end
+
+    def represented
+      user
+    end
+  end
+end

--- a/server/webapp/WEB-INF/rails.new/app/presenters/api_v2/user_summary_representer.rb
+++ b/server/webapp/WEB-INF/rails.new/app/presenters/api_v2/user_summary_representer.rb
@@ -1,0 +1,41 @@
+##########################################################################
+# Copyright 2017 ThoughtWorks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+
+module ApiV2
+  class UserSummaryRepresenter < ApiV2::BaseRepresenter
+
+    alias_method :login_name, :represented
+
+    link :doc do
+      'https://api.gocd.org/#users'
+    end
+
+    link :current_user do |opts|
+      opts[:url_builder].apiv1_current_user_url
+    end
+
+    link :self do |opts|
+      opts[:url_builder].apiv1_user_url(login_name: login_name)
+    end
+
+    link :find do |opts|
+      opts[:url_builder].apiv1_user_url(login_name: '__login_name__').gsub(/__login_name__/, ':login_name')
+    end
+
+    property :login_name, exec_context: :decorator
+
+  end
+end

--- a/server/webapp/WEB-INF/rails.new/app/presenters/api_v2/users_representer.rb
+++ b/server/webapp/WEB-INF/rails.new/app/presenters/api_v2/users_representer.rb
@@ -1,0 +1,39 @@
+##########################################################################
+# Copyright 2017 ThoughtWorks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+
+module ApiV2
+  class UsersRepresenter < ApiV2::BaseRepresenter
+
+    link :self do |opts|
+      opts[:url_builder].apiv1_users_url
+    end
+
+    link :current_user do |opts|
+      opts[:url_builder].apiv1_current_user_url
+    end
+
+    link :doc do
+      'https://api.gocd.org/#users'
+    end
+
+    collection :users, embedded: true, exec_context: :decorator, decorator: UserRepresenter
+
+    def users
+      represented
+    end
+
+  end
+end

--- a/server/webapp/WEB-INF/rails.new/config/routes.rb
+++ b/server/webapp/WEB-INF/rails.new/config/routes.rb
@@ -287,6 +287,10 @@ Go::Application.routes.draw do
           put on: :member, action: :put
         end
       end
+      delete 'users', controller: 'users', action: 'bulk_delete'
+      resources :users, param: :login_name, only: [:create, :index, :show, :destroy], constraints: {login_name: /(.*?)/} do
+        patch :update, on: :member
+      end
 
       match '*url', via: :all, to: 'errors#not_found'
     end

--- a/server/webapp/WEB-INF/rails.new/lib/java_imports.rb
+++ b/server/webapp/WEB-INF/rails.new/lib/java_imports.rb
@@ -1,5 +1,5 @@
 ##########################GO-LICENSE-START################################
-# Copyright 2015 ThoughtWorks, Inc.
+# Copyright 2017 ThoughtWorks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -267,4 +267,5 @@ module JavaImports
   java_import com.thoughtworks.go.config.AdminUser unless defined? AdminUser
   java_import com.thoughtworks.go.plugin.access.elastic.ElasticAgentExtension unless defined? ElasticAgentExtension
   java_import com.thoughtworks.go.plugin.access.elastic.ElasticAgentMetadataStore unless defined? ElasticAgentMetadataStore
+  java_import com.thoughtworks.go.server.service.result.BulkDeletionFailureResult unless defined? BulkDeletionFailureResult
 end

--- a/server/webapp/WEB-INF/rails.new/spec/controllers/api_v2/users_controller_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/controllers/api_v2/users_controller_spec.rb
@@ -1,0 +1,477 @@
+##########################################################################
+# Copyright 2016 ThoughtWorks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+
+require 'spec_helper'
+
+describe ApiV2::UsersController do
+  include ApiHeaderSetupTeardown, ApiV2::ApiVersionHelper
+
+  before :each do
+    @user_service = double('user service')
+    controller.stub(:user_service).and_return(@user_service)
+  end
+
+  describe :index do
+    describe :for_admins do
+      it 'should render a list of users, for admins' do
+        login_as_admin
+        john = User.new('jdoe', 'Jon Doe', ['jdoe', 'jdoe@example.com'].to_java(:string), 'jdoe@example.com', true)
+
+        @user_service.should_receive(:allUsers).and_return([john])
+
+        get_with_api_header :index
+        expect(response).to be_ok
+        expect(actual_response).to eq(expected_response([john], ApiV2::UsersRepresenter))
+      end
+    end
+
+    describe :security do
+      it 'should allow anyone, with security disabled' do
+        disable_security
+        expect(controller).to allow_action(:get, :index)
+      end
+
+      it 'should disallow anonymous users, with security enabled' do
+        enable_security
+        login_as_anonymous
+        expect(controller).to disallow_action(:get, :index).with(401, 'You are not authorized to perform this action.')
+      end
+
+      it 'should disallow normal users, with security enabled' do
+        login_as_user
+        expect(controller).to disallow_action(:get, :index).with(401, 'You are not authorized to perform this action.')
+      end
+    end
+
+    describe :route do
+      describe :with_header do
+        it 'should route to index action of users controller' do
+          expect(:get => 'api/users').to route_to(action: 'index', controller: 'api_v2/users')
+        end
+      end
+      describe :without_header do
+        before :each do
+          teardown_header
+        end
+        it 'should not route to index action of users controller without header' do
+          expect(:get => 'api/users').to_not route_to(action: 'index', controller: 'api_v2/users')
+          expect(:get => 'api/users').to route_to(controller: 'application', action: 'unresolved', url: 'api/users')
+        end
+      end
+    end
+  end
+
+  describe :show do
+    before(:each) do
+      @john = User.new('jdoe', 'Jon Doe', ['jdoe', 'jdoe@example.com'].to_java(:string), 'jdoe@example.com', true)
+
+      @user_service = double('user service')
+      controller.stub(:user_service).and_return(@user_service)
+      @user_service.stub(:findUserByName).with(@john.name).and_return(@john)
+    end
+
+    describe :for_admins do
+      it 'should render the user' do
+        login_as_admin
+
+        get_with_api_header :show, login_name: @john.name
+        expect(response).to be_ok
+        expect(actual_response).to eq(expected_response(@john, ApiV2::UserRepresenter))
+      end
+
+      it 'should render 404 when a user does not exist' do
+        login_as_admin
+
+        login_name = SecureRandom.hex
+        @user_service.stub(:findUserByName).with(login_name).and_return(com.thoughtworks.go.domain.NullUser.new)
+        get_with_api_header :show, login_name: login_name
+        expect(response).to have_api_message_response(404, 'Either the resource you requested was not found, or you are not authorized to perform this action.')
+      end
+    end
+
+    describe :security do
+      it 'should allow anyone, with security disabled' do
+        disable_security
+        expect(controller).to allow_action(:get, :show, login_name: @john.name)
+      end
+
+      it 'should disallow anonymous users, with security enabled' do
+        enable_security
+        login_as_anonymous
+        expect(controller).to disallow_action(:get, :show, login_name: @john.name).with(401, 'You are not authorized to perform this action.')
+      end
+
+      it 'should disallow normal users, with security enabled' do
+        login_as_user
+        expect(controller).to disallow_action(:get, :show, login_name: @john.name).with(401, 'You are not authorized to perform this action.')
+      end
+    end
+    describe :route do
+      describe :with_header do
+        it 'should route to show action of users controller for alphanumeric login name' do
+          expect(:get => 'api/users/foo123').to route_to(action: 'show', controller: 'api_v2/users', login_name: 'foo123')
+        end
+
+        it 'should route to show action of users controller having dots in login name' do
+          expect(:get => 'api/users/foo.bar').to route_to(action: 'show', controller: 'api_v2/users', login_name: 'foo.bar')
+        end
+
+        it 'should route to show action of users controller for capitalized login name' do
+          expect(:get => 'api/users/Foo').to route_to(action: 'show', controller: 'api_v2/users', login_name: 'Foo')
+        end
+
+        it 'should not route to show action of users controller for invalid login name' do
+          expect(:get => 'api/users/foo#%$').not_to be_routable
+        end
+      end
+      describe :without_header do
+        before :each do
+          teardown_header
+        end
+        it 'should not route to show action of users controller without header' do
+          expect(:get => 'api/users/foo').to_not route_to(action: 'show', controller: 'api_v2/users')
+          expect(:get => 'api/users/foo').to route_to(controller: 'application', action: 'unresolved', url: 'api/users/foo')
+        end
+      end
+    end
+  end
+
+  describe :destroy do
+    before(:each) do
+      @john = User.new('jdoe', 'Jon Doe', ['jdoe', 'jdoe@example.com'].to_java(:string), 'jdoe@example.com', true)
+
+      @user_service = double('user service')
+      controller.stub(:user_service).and_return(@user_service)
+      @user_service.stub(:findUserByName).with(@john.name).and_return(@john)
+      @user_service.stub(:deleteUser).with(@john.name, anything()).and_return(@john)
+    end
+
+    describe :for_admins do
+      it 'should allow deleting users' do
+        login_as_admin
+
+        @user_service.should_receive(:deleteUser).with(@john.name, an_instance_of(HttpLocalizedOperationResult)) do |username, result|
+          result.setMessage(LocalizedMessage.string("RESOURCE_DELETE_SUCCESSFUL", "user", username))
+        end
+
+        delete_with_api_header :destroy, login_name: @john.name
+        expect(response).to be_ok
+        expect(response).to have_api_message_response(200, "The user 'jdoe' was deleted successfully.")
+      end
+
+      it 'should render 404 when a user does not exist' do
+        login_as_admin
+
+        login_name = SecureRandom.hex
+        @user_service.stub(:findUserByName).with(login_name).and_return(com.thoughtworks.go.domain.NullUser.new)
+        delete_with_api_header :destroy, login_name: login_name
+        expect(response).to have_api_message_response(404, 'Either the resource you requested was not found, or you are not authorized to perform this action.')
+      end
+    end
+
+
+    describe :security do
+      it 'should allow anyone, with security disabled' do
+        disable_security
+        expect(controller).to allow_action(:delete, :destroy, login_name: @john.name)
+      end
+
+      it 'should disallow anonymous users, with security enabled' do
+        enable_security
+        login_as_anonymous
+        expect(controller).to disallow_action(:delete, :destroy, login_name: @john.name).with(401, 'You are not authorized to perform this action.')
+      end
+
+      it 'should disallow normal users, with security enabled' do
+        login_as_user
+        expect(controller).to disallow_action(:delete, :destroy, login_name: @john.name).with(401, 'You are not authorized to perform this action.')
+      end
+    end
+
+    describe :route do
+      describe :with_header do
+        it 'should route to destroy action of users controller for alphanumeric login name' do
+          expect(:delete => 'api/users/foo123').to route_to(action: 'destroy', controller: 'api_v2/users', login_name: 'foo123')
+        end
+
+        it 'should route to destroy action of users controller having dots in login name' do
+          expect(:delete => 'api/users/foo.bar').to route_to(action: 'destroy', controller: 'api_v2/users', login_name: 'foo.bar')
+        end
+
+        it 'should route to destroy action of users controller for capitalized login name' do
+          expect(:delete => 'api/users/Foo').to route_to(action: 'destroy', controller: 'api_v2/users', login_name: 'Foo')
+        end
+
+        it 'should not route to show action of users controller for invalid login name' do
+          expect(:delete => 'api/users/foo#%$').not_to be_routable
+        end
+      end
+      describe :without_header do
+        before :each do
+          teardown_header
+        end
+        it 'should not route to show action of users controller without header' do
+          expect(:delete => 'api/users/foo').to_not route_to(action: 'destroy', controller: 'api_v2/users')
+          expect(:delete => 'api/users/foo').to route_to(controller: 'application', action: 'unresolved', url: 'api/users/foo')
+        end
+      end
+    end
+  end
+
+  describe 'delete' do
+    before(:each) do
+      @john = User.new('jdoe', 'Jon Doe', ['jdoe', 'jdoe@example.com'].to_java(:string), 'jdoe@example.com', true)
+      @joanne = User.new('jrowling', 'Joanne Rowling', ['jrowling'].to_java(:string), 'jrowling@example.com', false)
+    end
+
+    describe 'for_admins' do
+      it 'should delete users' do
+        login_as_admin
+
+        @user_service = double('user_service')
+        controller.stub(:user_service).and_return(@user_service)
+        @user_service.should_receive(:deleteUsers).with([@john.name, @joanne.name], an_instance_of(HttpLocalizedOperationResult)) do |users, result|
+          result.setMessage(LocalizedMessage.string("RESOURCE_DELETE_SUCCESSFUL", "users", users))
+        end
+
+        delete_with_api_header :bulk_delete, users: [@john.name, @joanne.name]
+
+        expect(response).to have_api_message_response(200, "The users '[\"jdoe\", \"jrowling\"]' was deleted successfully.")
+      end
+
+      it 'should throw an error if delete users was unsuccessful when some users are enabled or non existent' do
+        login_as_admin
+
+        @user_service = double('user_service')
+        controller.stub(:user_service).and_return(@user_service)
+        non_existent_users = java.util.ArrayList.new
+        non_existent_users.add('jane')
+        non_existent_users.add('joe')
+
+        enabled_users = java.util.ArrayList.new
+        enabled_users.add('john')
+
+        bulkDeletionFailureResult = BulkDeletionFailureResult.new(non_existent_users, enabled_users)
+        @user_service.should_receive(:deleteUsers).with([@john.name, @joanne.name], an_instance_of(HttpLocalizedOperationResult)).and_return do |users, result|
+          result.unprocessableEntity(LocalizedMessage.string("USER_ENABLED_OR_NOT_FOUND", [users[0]], [users[1]]))
+          bulkDeletionFailureResult
+        end
+
+        delete_with_api_header :bulk_delete, users: [@john.name, @joanne.name]
+
+        expect(response).to have_api_message_response(422, "Deletion failed because some users were either enabled or do not exist.")
+      end
+
+      it 'should throw an error if delete users was unsuccessful when no users are provided' do
+        login_as_admin
+
+        @user_service = double('user_service')
+        controller.stub(:user_service).and_return(@user_service)
+
+        @user_service.should_receive(:deleteUsers).with([], an_instance_of(HttpLocalizedOperationResult)).and_return do |users, result|
+          result.badRequest(LocalizedMessage.string("NO_USERS_SELECTED"))
+          BulkDeletionFailureResult.new()
+        end
+
+        delete_with_api_header :bulk_delete, users: []
+
+        expect(response).to have_api_message_response(400, "No users selected.")
+      end
+    end
+
+    describe 'security' do
+      it 'should allow admins to bulk delete users' do
+        login_as_admin
+        expect(controller).to allow_action(:delete, 'bulk_delete')
+      end
+
+      it 'should not allow non-admins to bulk delete users' do
+        login_as_user
+        expect(controller).to disallow_action(:delete, 'bulk_delete')
+      end
+
+      it 'should allow anybody to bulk delete users if security is disabled' do
+        disable_security
+        expect(controller).to allow_action(:delete, 'bulk_delete')
+      end
+    end
+
+    describe 'routes' do
+      describe 'with header' do
+        it 'should route to the bulk_delete action for users controller' do
+          expect(:delete => '/api/users').to route_to(action: 'bulk_delete', controller: 'api_v2/users')
+        end
+      end
+
+      describe 'without header' do
+        before :each do
+          teardown_header
+        end
+
+        it 'should not route to the bulk_delete action for users controller' do
+          expect(:delete => '/api/users').to_not route_to(action: 'bulk_delete', controller: 'api_v2/users')
+          expect(:delete => '/api/users').to route_to(controller: 'application', action: 'unresolved', url: 'api/users')
+        end
+      end
+    end
+  end
+
+  describe :update do
+    before(:each) do
+      @john = User.new('jdoe', 'Jon Doe', ['jdoe', 'jdoe@example.com'].to_java(:string), 'jdoe@example.com', true)
+
+      @user_service = double('user service')
+      controller.stub(:user_service).and_return(@user_service)
+      @user_service.stub(:findUserByName).with(@john.name).and_return(@john)
+    end
+
+    describe :for_admins do
+      it 'should allow patching users' do
+        login_as_admin
+        @user_service.should_receive(:save).with(@john, TriState.TRUE, TriState.FALSE, 'foo@example.com', 'foo, bar', an_instance_of(HttpLocalizedOperationResult)).and_return(@john)
+
+        patch_with_api_header :update, login_name: @john.name, enabled: true, email_me: false, email: 'foo@example.com', checkin_aliases: 'foo, bar'
+        expect(response).to be_ok
+        expect(actual_response).to eq(expected_response(@john, ApiV2::UserRepresenter))
+      end
+
+      it 'should render 404 when a user does not exist' do
+        login_as_admin
+
+        login_name = SecureRandom.hex
+        @user_service.stub(:findUserByName).with(login_name).and_return(com.thoughtworks.go.domain.NullUser.new)
+        patch_with_api_header :update, login_name: login_name
+        expect(response).to have_api_message_response(404, 'Either the resource you requested was not found, or you are not authorized to perform this action.')
+      end
+    end
+
+    describe :security do
+      it 'should allow anyone, with security disabled' do
+        disable_security
+        expect(controller).to allow_action(:patch, :update, login_name: @john.name)
+      end
+
+      it 'should disallow anonymous users, with security enabled' do
+        enable_security
+        login_as_anonymous
+        expect(controller).to disallow_action(:patch, :update, login_name: @john.name).with(401, 'You are not authorized to perform this action.')
+      end
+
+      it 'should disallow normal users, with security enabled' do
+        login_as_user
+        expect(controller).to disallow_action(:patch, :update, login_name: @john.name).with(401, 'You are not authorized to perform this action.')
+      end
+    end
+
+    describe :route do
+      describe :with_header do
+        it 'should route to update action of users controller for alphanumeric login name' do
+          expect(:patch => 'api/users/foo123').to route_to(action: 'update', controller: 'api_v2/users', login_name: 'foo123')
+        end
+
+        it 'should route to update action of users controller having dots in login name' do
+          expect(:patch => 'api/users/foo.bar').to route_to(action: 'update', controller: 'api_v2/users', login_name: 'foo.bar')
+        end
+
+        it 'should route to update action of users controller for capitalized login name' do
+          expect(:patch => 'api/users/Foo').to route_to(action: 'update', controller: 'api_v2/users', login_name: 'Foo')
+        end
+
+        it 'should not route to show action of users controller for invalid login name' do
+          expect(:patch => 'api/users/foo#%$').not_to be_routable
+        end
+      end
+      describe :without_header do
+        before :each do
+          teardown_header
+        end
+        it 'should not route to show action of users controller without header' do
+          expect(:patch => 'api/users/foo').to_not route_to(action: 'update', controller: 'api_v2/users')
+          expect(:patch => 'api/users/foo').to route_to(controller: 'application', action: 'unresolved', url: 'api/users/foo')
+        end
+      end
+    end
+  end
+
+  describe :create do
+    before(:each) do
+      @john = User.new('jdoe')
+
+      @user_service = double('user service')
+      controller.stub(:user_service).and_return(@user_service)
+      @user_service.stub(:findUserByName).with(anything()).and_return(com.thoughtworks.go.domain.NullUser.new)
+    end
+
+    describe :for_admins do
+      it 'should render 201 created when user is created' do
+        login_as_admin
+
+        @user_service.should_receive(:withEnableUserMutex).and_yield
+
+        @user_service.should_receive(:save).with(@john, TriState.TRUE, TriState.FALSE, 'foo@example.com', 'foo, bar', an_instance_of(HttpLocalizedOperationResult)).and_return(@john)
+
+        post_with_api_header :create, login_name: @john.name, enabled: true, email_me: false, email: 'foo@example.com', checkin_aliases: 'foo, bar'
+        expect(response.status).to be(201)
+        expect(actual_response).to eq(expected_response(@john, ApiV2::UserRepresenter))
+      end
+
+      it 'should render 409 conflict when a user already exists' do
+        login_as_admin
+
+        login_name = SecureRandom.hex
+        @user_service.should_receive(:withEnableUserMutex).and_yield
+        @user_service.stub(:findUserByName).with(login_name).and_return(User.new(login_name))
+        post_with_api_header :create, login_name: login_name
+        expect(response).to have_api_message_response(409, "The user `#{login_name}` already exists.")
+      end
+    end
+
+    describe :security do
+      it 'should allow anyone, with security disabled' do
+        disable_security
+        expect(controller).to allow_action(:create, :create)
+      end
+
+      it 'should disallow anonymous users, with security enabled' do
+        enable_security
+        login_as_anonymous
+        expect(controller).to disallow_action(:post, :create).with(401, 'You are not authorized to perform this action.')
+      end
+
+      it 'should disallow normal users, with security enabled' do
+        login_as_user
+        expect(controller).to disallow_action(:post, :create).with(401, 'You are not authorized to perform this action.')
+      end
+    end
+
+    describe :route do
+      describe :with_header do
+        it 'should route to create action of users controller' do
+          expect(:post => 'api/users').to route_to(action: 'create', controller: 'api_v2/users')
+        end
+      end
+      describe :without_header do
+        before :each do
+          teardown_header
+        end
+        it 'should not route to create action of users controller without header' do
+          expect(:post => 'api/users').to_not route_to(action: 'create', controller: 'api_v2/users')
+          expect(:post => 'api/users').to route_to(controller: 'application', action: 'unresolved', url: 'api/users')
+        end
+      end
+    end
+  end
+end

--- a/server/webapp/WEB-INF/rails.new/spec/presenters/api_v2/bulk_deletion_failure_result_representer_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/presenters/api_v2/bulk_deletion_failure_result_representer_spec.rb
@@ -1,0 +1,55 @@
+##########################################################################
+# Copyright 2017 ThoughtWorks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+
+require 'spec_helper'
+
+describe ApiV2::BulkDeletionFailureResultRepresenter do
+
+  it 'renders a bulk delete result' do
+    non_existent_users = java.util.ArrayList.new
+    non_existent_users.add('jane')
+    non_existent_users.add('joe')
+
+    enabled_users = java.util.ArrayList.new
+    enabled_users.add('john')
+
+    presenter   = ApiV2::BulkDeletionFailureResultRepresenter.new(BulkDeletionFailureResult.new(non_existent_users, enabled_users))
+
+    actual_json = presenter.to_hash(url_builder: UrlBuilder.new)
+
+    expect(actual_json).to eq({
+                                non_existent_users: ['jane','joe'],
+                                enabled_users: ['john']
+                              })
+  end
+
+  it 'renders a bulk delete result skipping fields that are empty' do
+    non_existent_users = java.util.ArrayList.new
+    non_existent_users.add('jane')
+    non_existent_users.add('joe')
+
+    enabled_users = java.util.ArrayList.new
+
+    presenter   = ApiV2::BulkDeletionFailureResultRepresenter.new(BulkDeletionFailureResult.new(non_existent_users, enabled_users))
+
+    actual_json = presenter.to_hash(url_builder: UrlBuilder.new)
+
+    expect(actual_json).to eq({
+                                non_existent_users: ['jane','joe'],
+                              })
+  end
+
+end

--- a/server/webapp/WEB-INF/rails.new/spec/presenters/api_v2/user_representer_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/presenters/api_v2/user_representer_spec.rb
@@ -1,0 +1,44 @@
+##########################################################################
+# Copyright 2017 ThoughtWorks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+
+
+require 'spec_helper'
+
+describe ApiV2::UserRepresenter do
+
+  it 'renders a user' do
+    presenter   = ApiV2::UserRepresenter.new(User.new('jdoe', 'Jon Doe', ['jdoe', 'jdoe@example.com'].to_java(:string), 'jdoe@example.com', true))
+    actual_json = presenter.to_hash(url_builder: UrlBuilder.new)
+
+    expect(actual_json).to have_links(:self, :find, :doc, :current_user)
+
+    expect(actual_json).to have_link(:self).with_url('http://test.host/api/users/jdoe')
+    expect(actual_json).to have_link(:find).with_url('http://test.host/api/users/:login_name')
+    expect(actual_json).to have_link(:doc).with_url('https://api.gocd.org/#users')
+    expect(actual_json).to have_link(:current_user).with_url('http://test.host/api/current_user')
+
+    actual_json.delete(:_links)
+    expect(actual_json).to eq({
+                                login_name:      'jdoe',
+                                checkin_aliases: ['jdoe', 'jdoe@example.com'],
+                                display_name:    'Jon Doe',
+                                email:           'jdoe@example.com',
+                                enabled:         true,
+                                email_me:        true
+                              })
+  end
+
+end

--- a/server/webapp/WEB-INF/rails.new/spec/presenters/api_v2/user_summary_representer_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/presenters/api_v2/user_summary_representer_spec.rb
@@ -1,0 +1,37 @@
+##########################################################################
+# Copyright 2017 ThoughtWorks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+
+
+require 'spec_helper'
+
+describe ApiV2::UserSummaryRepresenter do
+
+  it 'renders a user summary' do
+    presenter = ApiV2::UserSummaryRepresenter.new("jdoe")
+    actual_json = presenter.to_hash(url_builder: UrlBuilder.new)
+
+    expect(actual_json).to have_links(:self, :find, :doc, :current_user)
+
+    expect(actual_json).to have_link(:self).with_url('http://test.host/api/users/jdoe')
+    expect(actual_json).to have_link(:find).with_url('http://test.host/api/users/:login_name')
+    expect(actual_json).to have_link(:current_user).with_url('http://test.host/api/current_user')
+    expect(actual_json).to have_link(:doc).with_url('https://api.gocd.org/#users')
+
+    actual_json.delete(:_links)
+    expect(actual_json).to eq({login_name: 'jdoe'})
+  end
+
+end

--- a/server/webapp/WEB-INF/rails.new/spec/presenters/api_v2/users_representer_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/presenters/api_v2/users_representer_spec.rb
@@ -1,0 +1,35 @@
+##########################################################################
+# Copyright 2017 ThoughtWorks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+require 'spec_helper'
+
+describe ApiV2::UsersRepresenter do
+
+  it 'renders a list of users' do
+    user = User.new('jdoe', 'Jon Doe', ['jdoe', 'jdoe@example.com'].to_java(:string), 'jdoe@example.com', true)
+
+    presenter   = ApiV2::UsersRepresenter.new([user])
+    actual_json = presenter.to_hash(url_builder: UrlBuilder.new)
+
+    expect(actual_json).to have_links(:self, :doc, :current_user)
+
+    expect(actual_json).to have_link(:self).with_url('http://test.host/api/users')
+    expect(actual_json).to have_link(:doc).with_url('https://api.gocd.org/#users')
+    expect(actual_json).to have_link(:current_user).with_url('http://test.host/api/current_user')
+
+    actual_json.fetch(:_embedded).should == { :users => [ApiV2::UserRepresenter.new(user).to_hash(url_builder: UrlBuilder.new)] }
+  end
+
+end

--- a/server/webapp/localize.xml
+++ b/server/webapp/localize.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright 2016 ThoughtWorks, Inc.
+  ~ Copyright 2017 ThoughtWorks, Inc.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -512,6 +512,7 @@
     <entry key="NO_ENVIRONMENTS_CONFIGURED">No environments are displayed because either no environments have been set up or you are not authorized to view the pipelines within any of the environments.</entry>
     <entry key="CANNOT_DELETE_TEMPLATE">Cannot delete the template ''{0}'' as it is used by pipeline(s): ''{1}''</entry>
     <entry key="RESOURCE_DELETE_SUCCESSFUL">The {0} ''{1}'' was deleted successfully.</entry>
+    <entry key="RESOURCES_DELETE_SUCCESSFUL">{0} ''{1}'' were deleted successfully.</entry>
     <entry key="RESOURCE_UPDATE_SUCCESSFUL">The {0} ''{1}'' was updated successfully.</entry>
     <entry key="RESOURCE_ADD_FAILED">Failed to add {0}. {1}</entry>
     <entry key="RESOURCE_UPDATE_FAILED">Failed to update {0}. {1}</entry>
@@ -725,6 +726,7 @@
     <entry key="VSM_INTERNAL_SERVER_ERROR">Value Stream Map of pipeline ''{0}'' with counter ''{1}'' can not be rendered. Please check the server log for details.</entry>
     <entry key="VSM_INTERNAL_SERVER_ERROR_FOR_MATERIAL">Value Stream Map of material with fingerprint ''{0}'' with revision ''{1}'' can not be rendered. Please check the server log for details.</entry>
     <entry key="VSM_WARNING">Built from incompatible revisions.</entry>
+    <entry key="USER_ENABLED_OR_NOT_FOUND">Deletion failed because some users were either enabled or do not exist.</entry>
     <entry key="USER_NOT_DISABLED">User ''{0}'' is not disabled.</entry>
     <entry key="RESOURCE_NOT_FOUND">{0} ''{1}'' not found.</entry>
     <entry key="CAN_NOT_OPERATE_ON_REMOTE_ENTITY"> Can not operate on {0} ''{1}'' as it is defined remotely in ''{2}''.</entry>


### PR DESCRIPTION
#### API call invocation example:
```
curl 'http://ci.example.com/go/api/users/' \
      -u 'username:password' \
      -H 'Accept: application/vnd.go.cd.v2+json' \
      -X DELETE \
      -H 'Content-Type: application/json'
      -d '{"users": ["tez", "joan"]}'
```

Atomicity is considered when bulk deleting, i.e., if deletion of one user fails no users are deleted. Deletion of a user fails if either the user is not present or if the user is enabled.

The api call returns a JSON with a single attribute `message`.  
**Successful response:**  
{  
  "message": "The users '[\"tez\", "joan"]' was deleted successfully."  
}

**Failure response:**  
{  
  "message": "Deletion failed because some users were either enabled or do not exist." ,
  "enabled": ["tez"],
  "non_existent": ["joan"]
}

Or
{
  "message": "Deletion failed because some users were either enabled or do not exist." ,
  "non_existent": ["tez", "joan"]
}

Or
{
  "message": "Deletion failed because some users were either enabled or do not exist." ,
  "enabled" : ["tez", "joan],
}

Or
If no users are provided,

{
  "message": "No users selected."
}