### PR TITLE
Clear out all OAuth token on auth config change

### DIFF
--- a/config/config-api/src/com/thoughtworks/go/config/SecurityConfig.java
+++ b/config/config-api/src/com/thoughtworks/go/config/SecurityConfig.java
@@ -126,9 +126,12 @@ public class SecurityConfig implements Validatable {
         if (newSecurity == null) {
             return true;
         }
+
         boolean ldapChanged = !ObjectUtil.equal(ldapConfig, newSecurity.ldapConfig());
         boolean passwordFileChanged = !ObjectUtil.equal(passwordFileConfig, newSecurity.passwordFileConfig());
-        return ldapChanged || passwordFileChanged;
+        final boolean securityAuthConfigChanged = !ObjectUtil.equal(securityAuthConfigs, newSecurity.securityAuthConfigs());
+
+        return ldapChanged || passwordFileChanged || securityAuthConfigChanged;
     }
 
     public boolean isUserMemberOfRole(final CaseInsensitiveString userName, final CaseInsensitiveString roleName) {

--- a/config/config-api/test/com/thoughtworks/go/config/SecurityConfigTest.java
+++ b/config/config-api/test/com/thoughtworks/go/config/SecurityConfigTest.java
@@ -173,6 +173,16 @@ public class SecurityConfigTest {
         assertTrue(new SecurityConfig().hasSecurityMethodChanged(ldapSecurity));
     }
 
+    @Test
+    public void hasSecurityMethodChanged_shouldReturnTrueIfSecurityAuthConfigIsChanged() {
+        final SecurityConfig oldSecurityConfig = new SecurityConfig();
+
+        final SecurityConfig newSecurityConfig = new SecurityConfig();
+        newSecurityConfig.securityAuthConfigs().add(new SecurityAuthConfig("ldap", "cd.go.authorization.ldap"));
+
+        assertTrue(oldSecurityConfig.hasSecurityMethodChanged(newSecurityConfig));
+    }
+
     private void assertUserRoles(SecurityConfig securityConfig, String username, Role... roles) {
         assertThat(securityConfig.memberRoleFor(new CaseInsensitiveString(username)), is(Arrays.asList(roles)));
     }


### PR DESCRIPTION
`OauthTokenSweeper` is a config change listner. Which clears out OAuth
tokens on security config change. This class is using SecurityConfig#hasSecurityMethodChanged
to determine change in security config

Updated `SecurityConfig#hasSecurityMethodChanged` to check config change
in auth config along with inbuilt password file and ldap