### PR TITLE
Modify build scripts to work in a windows environment

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -137,7 +137,7 @@ allprojects {
   rootProject.ext.gitRevision = GIT_REVISION
   rootProject.ext.copyrightYear = COPYRIGHT_YEAR
 
-  rootProject.ext.commandRepoUrl = System.getenv('COMMAND_REPO_URL') ? System.getenv('COMMAND_REPO_URL') : "git://github.com/gocd/go-command-repo"
+  rootProject.ext.commandRepoUrl = System.getenv('COMMAND_REPO_URL') ? System.getenv('COMMAND_REPO_URL') : "https://github.com/gocd/go-command-repo"
 
   group = 'com.thoughtworks.go'
   version = project.fullVersion

--- a/server/inline-partials.rake
+++ b/server/inline-partials.rake
@@ -14,7 +14,7 @@
 # limitations under the License.
 ##########################################################################
 
-RAILS_INTERPOLATED_VIEWS = (ENV['INPUT_DIR'] or raise 'INPUT_DIR not defined')
+RAILS_INTERPOLATED_VIEWS = (ENV['INPUT_DIR'].split("\\").join("/") or raise 'INPUT_DIR not defined')
 
 def inline_partials(dir = RAILS_INTERPOLATED_VIEWS)
   Dir[File.join(dir, '*')].each do |path|

--- a/server/rails.gradle
+++ b/server/rails.gradle
@@ -16,7 +16,6 @@
 
 
 import com.thoughtworks.go.build.ExecuteUnderRailsTask
-import com.thoughtworks.go.build.NpmInstallTask
 import com.thoughtworks.go.build.PrepareRailsCommandHelper
 
 task pathingJar(type: Jar) {
@@ -54,8 +53,16 @@ private boolean isWindows() {
   org.gradle.internal.os.OperatingSystem.current().isWindows()
 }
 
-task npmInstall(type: NpmInstallTask) {
+task npmInstall(type: Exec) {
+  standardOutput = System.out
+  errorOutput = System.err
+
+  commandLine = [isWindows() ? "yarn.cmd" : "yarn", "install"]
   workingDir = project.railsRoot
+
+  doFirst {
+    println "[${workingDir}]\$ ${executable} ${args.join(' ')}"
+  }
 }
 
 prepare.dependsOn


### PR DESCRIPTION
These are the changes I had to make to the build so that I could compile from the command line on Windows.

build.gradle => change git:// url to https:// 
inline-partials.rake => change Windows-style paths to Unix-style
rails.gradle => ensure yarn has been ran without arguments first (to restore the packages) before we try to run webpack