### PR TITLE
Removed duplicated pipeline lock checker

### DIFF
--- a/server/src/com/thoughtworks/go/server/service/SchedulingCheckerService.java
+++ b/server/src/com/thoughtworks/go/server/service/SchedulingCheckerService.java
@@ -122,7 +122,6 @@ public class SchedulingCheckerService {
                 new PipelineLockChecker(pipelineName, pipelineLockService),
                 new ManualPipelineChecker(pipelineConfig),
                 new PipelinePauseChecker(pipelineName, pipelinePauseService),
-                new PipelineLockChecker(pipelineName, pipelineLockService),
                 new StageActiveChecker(pipelineName, CaseInsensitiveString.str(pipelineConfig.getFirstStageConfig().name()), activityService)));
         checker.check(operationResult);
     }


### PR DESCRIPTION
Removed duplicate `PipelineLockChecker` in can `canAutoTriggerProducer`.