### PR TITLE
[WIP] Allow support for h2 mvstore

### DIFF
--- a/base/src/com/thoughtworks/go/util/H2DbStore.java
+++ b/base/src/com/thoughtworks/go/util/H2DbStore.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2017 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.util;
+
+public enum H2DbStore {
+    h2default,
+    mvstore
+}

--- a/base/src/com/thoughtworks/go/util/SystemEnvironment.java
+++ b/base/src/com/thoughtworks/go/util/SystemEnvironment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 ThoughtWorks, Inc.
+ * Copyright 2017 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -110,6 +110,7 @@ public class SystemEnvironment implements Serializable, ConfigDirProvider {
     public static GoSystemProperty<Integer> H2_DB_TRACE_LEVEL = new GoIntSystemProperty("h2.trace.level", 1);
     public static GoSystemProperty<Integer> H2_DB_TRACE_FILE_SIZE_MB = new GoIntSystemProperty("h2.trace.file.size.mb", 16);
     private static GoSystemProperty<String> CRUISE_DATABASE_DIR = new GoStringSystemProperty("cruise.database.dir", DB_DEFAULT_PATH);
+    public static GoSystemProperty<String> H2_DB_STORE = new GoStringSystemProperty("go.h2.db.store", H2DbStore.h2default.name());
 
     public static final String MATERIAL_UPDATE_IDLE_INTERVAL_PROPERTY = "material.update.idle.interval";
     private static GoSystemProperty<Long> MATERIAL_UPDATE_IDLE_INTERVAL = new GoLongSystemProperty(MATERIAL_UPDATE_IDLE_INTERVAL_PROPERTY, 60000L);
@@ -264,6 +265,13 @@ public class SystemEnvironment implements Serializable, ConfigDirProvider {
         if (systemProperty instanceof CachedProperty) {
             ((CachedProperty) systemProperty).clear();
         }
+    }
+
+    public String getDbFileName() {
+        if (get(H2_DB_STORE).equalsIgnoreCase(H2DbStore.mvstore.name())) {
+            return get(GO_DATABASE_NAME) + ".mv.db";
+        }
+        return get(GO_DATABASE_NAME) + ".h2.db";
     }
 
     public File configDir() {
@@ -507,7 +515,7 @@ public class SystemEnvironment implements Serializable, ConfigDirProvider {
     private Properties properties() {
         if (properties == null) {
             properties = new Properties();
-            try(InputStream is = getClass().getResourceAsStream(CRUISE_PROPERTIES)) {
+            try (InputStream is = getClass().getResourceAsStream(CRUISE_PROPERTIES)) {
                 properties.load(is);
             } catch (Exception e) {
                 LOG.error("Unable to load newProperties file " + CRUISE_PROPERTIES);

--- a/base/src/com/thoughtworks/go/util/SystemEnvironment.java
+++ b/base/src/com/thoughtworks/go/util/SystemEnvironment.java
@@ -110,7 +110,7 @@ public class SystemEnvironment implements Serializable, ConfigDirProvider {
     public static GoSystemProperty<Integer> H2_DB_TRACE_LEVEL = new GoIntSystemProperty("h2.trace.level", 1);
     public static GoSystemProperty<Integer> H2_DB_TRACE_FILE_SIZE_MB = new GoIntSystemProperty("h2.trace.file.size.mb", 16);
     private static GoSystemProperty<String> CRUISE_DATABASE_DIR = new GoStringSystemProperty("cruise.database.dir", DB_DEFAULT_PATH);
-    public static GoSystemProperty<String> H2_DB_STORE = new GoStringSystemProperty("go.h2.db.store", H2DbStore.h2default.name());
+    public static GoSystemProperty<String> H2_DB_STORE = new GoStringSystemProperty("go.h2.db.store", H2DbStore.mvstore.name());
 
     public static final String MATERIAL_UPDATE_IDLE_INTERVAL_PROPERTY = "material.update.idle.interval";
     private static GoSystemProperty<Long> MATERIAL_UPDATE_IDLE_INTERVAL = new GoLongSystemProperty(MATERIAL_UPDATE_IDLE_INTERVAL_PROPERTY, 60000L);

--- a/common/src/com/thoughtworks/go/util/validators/DatabaseValidator.java
+++ b/common/src/com/thoughtworks/go/util/validators/DatabaseValidator.java
@@ -1,45 +1,45 @@
-/*************************GO-LICENSE-START*********************************
- * Copyright 2014 ThoughtWorks, Inc.
+/*
+ * Copyright 2017 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *************************GO-LICENSE-END***********************************/
+ */
 
 package com.thoughtworks.go.util.validators;
+
+import com.thoughtworks.go.util.SystemEnvironment;
 
 import java.io.File;
 import java.io.IOException;
 import java.util.zip.ZipInputStream;
 
-import com.thoughtworks.go.util.SystemEnvironment;
-
 public class DatabaseValidator extends ZipValidator {
 
     public Validation validate(Validation validation) {
-        File destDir = new File(new SystemEnvironment().getPropertyImpl("user.dir"), "db");
+        SystemEnvironment systemEnvironment = new SystemEnvironment();
+        File destDir = new File(systemEnvironment.getPropertyImpl("user.dir"), "db");
         destDir.mkdirs();
         try {
             unzip(new ZipInputStream(this.getClass().getResourceAsStream("/defaultFiles/h2deltas.zip")), destDir);
         } catch (IOException e) {
             validation.addError(e);
         }
-
-        File dbFile = new File(destDir, "h2db/cruise.h2.db");
+        File dbFile = new File(destDir, "h2db/" + systemEnvironment.getDbFileName());
 
         if (dbFile.exists() && dbFile.canWrite() && dbFile.canRead()) {
             return Validation.SUCCESS;
         } else {
             try {
-                unzip(new ZipInputStream(this.getClass().getResourceAsStream("/defaultFiles/h2db.zip")), destDir);
+                unzip(new ZipInputStream(this.getClass().getResourceAsStream("/defaultFiles/h2db.zip")), destDir, systemEnvironment.getDbFileName());
             } catch (Exception e) {
                 return validation.addError(e);
             }

--- a/common/src/com/thoughtworks/go/util/validators/ZipValidator.java
+++ b/common/src/com/thoughtworks/go/util/validators/ZipValidator.java
@@ -1,20 +1,22 @@
-/*************************GO-LICENSE-START*********************************
- * Copyright 2014 ThoughtWorks, Inc.
+/*
+ * Copyright 2017 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *************************GO-LICENSE-END***********************************/
+ */
 
 package com.thoughtworks.go.util.validators;
+
+import org.apache.commons.io.IOUtils;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -22,9 +24,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
-
-import com.thoughtworks.go.util.validators.Validator;
-import org.apache.commons.io.IOUtils;
 
 /**
  * @understands
@@ -38,6 +37,22 @@ public abstract class ZipValidator implements Validator {
             ZipEntry zipEntry = zipInputStream.getNextEntry();
             while (zipEntry != null) {
                 extractTo(zipEntry, zipInputStream, destDir);
+                zipEntry = zipInputStream.getNextEntry();
+            }
+        } finally {
+            IOUtils.closeQuietly(zipInputStream);
+        }
+    }
+
+    protected void unzip(ZipInputStream zipInputStream, File destDir, String fileToExtract) throws IOException {
+        destDir.mkdirs();
+        try {
+            ZipEntry zipEntry = zipInputStream.getNextEntry();
+            while (zipEntry != null) {
+                if (zipEntry.getName().equalsIgnoreCase(fileToExtract)) {
+                    extractTo(zipEntry, zipInputStream, destDir);
+                    return;
+                }
                 zipEntry = zipInputStream.getNextEntry();
             }
         } finally {

--- a/development-utility/development-server/src/com/thoughtworks/go/server/DevelopmentServer.java
+++ b/development-utility/development-server/src/com/thoughtworks/go/server/DevelopmentServer.java
@@ -39,14 +39,14 @@ public class DevelopmentServer {
     public static void main(String[] args) throws Exception {
         LogConfigurator logConfigurator = new LogConfigurator(DEFAULT_LOG4J_CONFIGURATION_FILE);
         logConfigurator.initialize();
-        copyDbFiles();
+        SystemEnvironment systemEnvironment = new SystemEnvironment();
+        copyDbFiles(systemEnvironment);
         File webApp = new File("webapp");
         if (!webApp.exists()) {
             throw new RuntimeException("No webapp found in " + webApp.getAbsolutePath());
         }
 
         assertActivationJarPresent();
-        SystemEnvironment systemEnvironment = new SystemEnvironment();
         systemEnvironment.setProperty(GENERATE_STATISTICS, "true");
 
         systemEnvironment.setProperty(SystemEnvironment.PARENT_LOADER_PRIORITY, "true");
@@ -91,10 +91,10 @@ public class DevelopmentServer {
         systemEnvironment.setProperty("go.config.repo.gc.check.interval", "10000");
     }
 
-    private static void copyDbFiles() throws IOException {
+    private static void copyDbFiles(SystemEnvironment systemEnvironment) throws IOException {
         FileUtils.copyDirectoryToDirectory(new File("db/migrate/h2deltas"), new File("db/"));
-        if (!new File("db/h2db/cruise.h2.db").exists()) {
-            FileUtils.copyDirectoryToDirectory(new File("db/dbtemplate/h2db"), new File("db/"));
+        if (!new File("db/h2db/" + systemEnvironment.getDbFileName()).exists()) {
+            FileUtils.copyFileToDirectory(new File("db/dbtemplate/h2db/" + systemEnvironment.getDbFileName()), new File("db/"));
         }
     }
 

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -101,7 +101,7 @@ dependencies {
   compile group: 'oro', name: 'oro', version: '2.0.8'
   compile group: 'commons-dbcp', name: 'commons-dbcp', version: '1.4'
   compile group: 'commons-pool', name: 'commons-pool', version: '1.5.6'
-  compile group: 'com.h2database', name: 'h2', version: '1.3.168'
+  compile group: 'com.h2database', name: 'h2', version: '1.4.196'
   compile group: 'net.sf', name: 'dbdeploy', version: '2.11.1'
   compile(group: 'org.hibernate', name: 'hibernate-ehcache', version: '3.3.2.GA') {
     exclude(module: 'ehcache')
@@ -502,7 +502,7 @@ task verifyWar(type: VerifyJarTask) {
       "go-plugin-infra-${project.version}.jar",
       "gson-2.3.1.jar",
       "guava-20.0.jar",
-      "h2-1.3.168.jar",
+      "h2-1.4.196.jar",
       "hibernate-annotations-3.4.0.GA.jar",
       "hibernate-commons-annotations-3.1.0.GA.jar",
       "hibernate-core-3.3.2.GA.jar",

--- a/server/src/com/thoughtworks/go/server/database/CreateChangeLogTableForBlankDb.java
+++ b/server/src/com/thoughtworks/go/server/database/CreateChangeLogTableForBlankDb.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2017 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.server.database;
+
+import com.thoughtworks.go.util.SystemEnvironment;
+import org.apache.commons.dbcp.BasicDataSource;
+import org.apache.log4j.Logger;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import static com.thoughtworks.go.util.ExceptionUtils.bomb;
+
+public class CreateChangeLogTableForBlankDb {
+    private static final Logger LOG = Logger.getLogger(CreateChangeLogTableForBlankDb.class);
+
+    private final BasicDataSource dataSource;
+    private SystemEnvironment env;
+
+    public CreateChangeLogTableForBlankDb(BasicDataSource dataSource, SystemEnvironment env) {
+        this.dataSource = dataSource;
+        this.env = env;
+    }
+
+    public void createChangeLog() {
+        try {
+            String sql = "CREATE TABLE IF NOT EXISTS changelog (" +
+                    "  change_number INTEGER NOT NULL,\n" +
+                    "  delta_set VARCHAR(10) NOT NULL,\n" +
+                    "  start_dt TIMESTAMP NOT NULL,\n" +
+                    "  complete_dt TIMESTAMP NULL,\n" +
+                    "  applied_by VARCHAR(100) NOT NULL,\n" +
+                    "  description VARCHAR(500) NOT NULL\n" +
+                    ");\n" +
+                    "\n" +
+                    "ALTER TABLE changelog ADD CONSTRAINT Pkchangelog PRIMARY KEY (change_number, delta_set);";
+
+            new JdbcTemplate(dataSource).execute(sql);
+
+        } catch (Exception e) {
+            String message = "Unable to create changelog table for database " + dataSource.getUrl() + ". The problem was: " + e.getMessage();
+            if (e.getCause() != null) {
+                message += ". The cause was: " + e.getCause().getMessage();
+            }
+            LOG.error(message, e);
+            throw bomb(message, e);
+        }
+        LOG.info("Created changelog table");
+    }
+
+
+}

--- a/server/src/com/thoughtworks/go/server/database/Migrate.java
+++ b/server/src/com/thoughtworks/go/server/database/Migrate.java
@@ -26,6 +26,7 @@ import java.io.File;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.PrintStream;
+import java.nio.charset.Charset;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.log4j.Logger;
@@ -106,7 +107,7 @@ public class Migrate {
                 "-user", user
         });
         file.renameTo(new File(file.getAbsoluteFile() + ".backup"));
-        RunScript.execute(url, user, password, TEMP_SCRIPT, "UTF-8", true);
+        RunScript.execute(url, user, password, TEMP_SCRIPT, Charset.forName("UTF-8"), true);
         new File(TEMP_SCRIPT).delete();
         LOGGER.info("Migrating the h2db to the new format is complete.");
     }

--- a/server/test/integration/com/thoughtworks/go/server/service/BackupServiceH2IntegrationTest.java
+++ b/server/test/integration/com/thoughtworks/go/server/service/BackupServiceH2IntegrationTest.java
@@ -155,7 +155,7 @@ public class BackupServiceH2IntegrationTest {
 
         String location = tempFiles.createUniqueFolder("foo").getAbsolutePath();
 
-        Restore.execute(dbZip(), location, "cruise", false);
+        Restore.execute(dbZip(), location, "cruise");
 
         BasicDataSource source = constructTestDataSource(new File(location));
         ResultSet resultSet = source.getConnection().prepareStatement("select * from pipelines where id = " + expectedPipeline.getId()).executeQuery();


### PR DESCRIPTION
* upgraded h2 to 1.4.196
* added a flag to allow using mvstore as the storage for h2 instead of default h2.db
* yet to take care of migration from h2.db to mv.db