### PR TITLE
Eager load a quick request handler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,6 +90,7 @@ development-utility/development-agent/target/
 development-utility/development-server/target/
 installers/target/
 jetty9/target/
+jetty9/logs/
 plugin-infra/go-plugin-access/target/
 plugin-infra/go-plugin-activator/target/
 plugin-infra/go-plugin-api-internal/target/

--- a/development-utility/development-server/build.gradle
+++ b/development-utility/development-server/build.gradle
@@ -29,6 +29,7 @@ dependencies {
   compile group: 'org.eclipse.jetty', name: 'jetty-jmx', version: versions.jetty
   compile group: 'org.eclipse.jetty', name: 'jetty-servlets', version: versions.jetty
   compile group: 'org.eclipse.jetty', name: 'jetty-util', version: versions.jetty
+  compile group: 'org.eclipse.jetty', name: 'jetty-deploy', version: versions.jetty
   compile group: 'org.eclipse.jetty.websocket', name: 'websocket-server', version: versions.jetty
 
   compile group: 'org.eclipse.jgit', name: 'org.eclipse.jgit.http.server', version: '4.7.0.201704051617-r'

--- a/jetty9/build.gradle
+++ b/jetty9/build.gradle
@@ -41,6 +41,7 @@ dependencies {
   compileOnly(group: 'org.eclipse.jetty', name: 'jetty-jmx', version: versions.jetty)
   compileOnly(group: 'org.eclipse.jetty', name: 'jetty-servlets', version: versions.jetty)
   compileOnly(group: 'org.eclipse.jetty', name: 'jetty-util', version: versions.jetty)
+  compileOnly(group: 'org.eclipse.jetty', name: 'jetty-deploy', version: versions.jetty)
   compileOnly(group: 'org.eclipse.jetty.websocket', name: 'websocket-server', version: versions.jetty)
   compileOnly(group: 'org.bouncycastle', name: 'bcprov-jdk15on', version: '1.47')
 

--- a/jetty9/test/com/thoughtworks/go/server/Jetty9ServerTest.java
+++ b/jetty9/test/com/thoughtworks/go/server/Jetty9ServerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 ThoughtWorks, Inc.
+ * Copyright 2017 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,9 +20,11 @@ import com.thoughtworks.go.util.ArrayUtil;
 import com.thoughtworks.go.util.FileUtil;
 import com.thoughtworks.go.util.ReflectionUtil;
 import com.thoughtworks.go.util.SystemEnvironment;
+import org.eclipse.jetty.deploy.App;
+import org.eclipse.jetty.deploy.DeploymentManager;
 import org.eclipse.jetty.jmx.MBeanContainer;
 import org.eclipse.jetty.server.*;
-import org.eclipse.jetty.server.handler.HandlerCollection;
+import org.eclipse.jetty.server.handler.ContextHandler;
 import org.eclipse.jetty.webapp.JettyWebXmlConfiguration;
 import org.eclipse.jetty.webapp.WebAppContext;
 import org.eclipse.jetty.webapp.WebInfConfiguration;
@@ -43,8 +45,10 @@ import javax.servlet.http.HttpServletResponse;
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNot.not;
@@ -60,10 +64,13 @@ public class Jetty9ServerTest {
     @Rule
     public TemporaryFolder temporaryFolder = new TemporaryFolder();
     private File configDir;
+    private DeploymentManager deploymentManager;
+    private ArgumentCaptor<App> appCaptor;
 
     @Before
     public void setUp() throws Exception {
         server = mock(Server.class);
+        deploymentManager = mock(DeploymentManager.class);
 
         Answer<Void> setHandlerMock = new Answer<Void>() {
             @Override
@@ -74,6 +81,9 @@ public class Jetty9ServerTest {
             }
         };
         Mockito.doAnswer(setHandlerMock).when(server).setHandler(any(Handler.class));
+
+        appCaptor = ArgumentCaptor.forClass(App.class);
+        Mockito.doNothing().when(deploymentManager).addApp(appCaptor.capture());
 
         systemEnvironment = mock(SystemEnvironment.class);
         when(systemEnvironment.getServerPort()).thenReturn(1234);
@@ -92,7 +102,7 @@ public class Jetty9ServerTest {
 
         SSLSocketFactory sslSocketFactory = mock(SSLSocketFactory.class);
         when(sslSocketFactory.getSupportedCipherSuites()).thenReturn(new String[]{});
-        jetty9Server = new Jetty9Server(systemEnvironment, "pwd", sslSocketFactory, server);
+        jetty9Server = new Jetty9Server(systemEnvironment, "pwd", sslSocketFactory, server, deploymentManager);
         ReflectionUtil.setStaticField(Jetty9Server.class, "JETTY_XML_LOCATION_IN_JAR", "config");
     }
 
@@ -148,34 +158,27 @@ public class Jetty9ServerTest {
 
     @Test
     public void shouldAddWelcomeRequestHandler() throws Exception {
-        ArgumentCaptor<HandlerCollection> captor = ArgumentCaptor.forClass(HandlerCollection.class);
         jetty9Server.configure();
+        jetty9Server.startHandlers();
 
-        verify(server, times(1)).setHandler(captor.capture());
-        HandlerCollection handlerCollection = captor.getValue();
-        assertThat(handlerCollection.getHandlers().length, is(3));
-        Handler handler = handlerCollection.getHandlers()[0];
-        assertThat(handler instanceof Jetty9Server.GoServerWelcomeFileHandler, is(true));
-
-        Jetty9Server.GoServerWelcomeFileHandler welcomeFileHandler = (Jetty9Server.GoServerWelcomeFileHandler) handler;
+        ContextHandler welcomeFileHandler = getLoadedHandlers().get(Jetty9Server.GoServerWelcomeFileHandler.class);
         assertThat(welcomeFileHandler.getContextPath(), is("/"));
     }
 
     @Test
     public void shouldAddDefaultHeadersForRootContext() throws Exception {
-        ArgumentCaptor<HandlerCollection> captor = ArgumentCaptor.forClass(HandlerCollection.class);
         jetty9Server.configure();
-
-        verify(server, times(1)).setHandler(captor.capture());
-        HandlerCollection handlerCollection = captor.getValue();
-        Jetty9Server.GoServerWelcomeFileHandler handler = (Jetty9Server.GoServerWelcomeFileHandler)handlerCollection.getHandlers()[0];
-        Handler rootPathHandler = handler.getHandler();
+        jetty9Server.startHandlers();
 
         HttpServletResponse response = mock(HttpServletResponse.class);
         when(response.getWriter()).thenReturn(mock(PrintWriter.class));
 
         HttpServletRequest request = mock(HttpServletRequest.class);
         when(request.getPathInfo()).thenReturn("/");
+
+        ContextHandler rootPathHandler = getLoadedHandlers().get(Jetty9Server.GoServerWelcomeFileHandler.class);
+        rootPathHandler.setServer(server);
+        rootPathHandler.start();
 
         rootPathHandler.handle("/", mock(Request.class), request, response);
 
@@ -187,19 +190,18 @@ public class Jetty9ServerTest {
 
     @Test
     public void shouldSkipDefaultHeadersIfContextPathIsGoRootPath() throws Exception {
-        ArgumentCaptor<HandlerCollection> captor = ArgumentCaptor.forClass(HandlerCollection.class);
         jetty9Server.configure();
-
-        verify(server, times(1)).setHandler(captor.capture());
-        HandlerCollection handlerCollection = captor.getValue();
-        Jetty9Server.GoServerWelcomeFileHandler handler = (Jetty9Server.GoServerWelcomeFileHandler)handlerCollection.getHandlers()[0];
-        Handler rootPathHandler = handler.getHandler();
+        jetty9Server.startHandlers();
 
         HttpServletResponse response = mock(HttpServletResponse.class);
         when(response.getWriter()).thenReturn(mock(PrintWriter.class));
 
         HttpServletRequest request = mock(HttpServletRequest.class);
         when(request.getPathInfo()).thenReturn("/go");
+
+        ContextHandler rootPathHandler = getLoadedHandlers().get(Jetty9Server.GoServerWelcomeFileHandler.class);
+        rootPathHandler.setServer(server);
+        rootPathHandler.start();
 
         rootPathHandler.handle("/go", mock(Request.class), request, response);
 
@@ -211,19 +213,18 @@ public class Jetty9ServerTest {
 
     @Test
     public void shouldSkipDefaultHeadersIfContextPathIsAnyOtherUrlWithinGo() throws Exception {
-        ArgumentCaptor<HandlerCollection> captor = ArgumentCaptor.forClass(HandlerCollection.class);
         jetty9Server.configure();
-
-        verify(server, times(1)).setHandler(captor.capture());
-        HandlerCollection handlerCollection = captor.getValue();
-        Jetty9Server.GoServerWelcomeFileHandler handler = (Jetty9Server.GoServerWelcomeFileHandler)handlerCollection.getHandlers()[0];
-        Handler rootPathHandler = handler.getHandler();
+        jetty9Server.startHandlers();
 
         HttpServletResponse response = mock(HttpServletResponse.class);
         when(response.getWriter()).thenReturn(mock(PrintWriter.class));
 
         HttpServletRequest request = mock(HttpServletRequest.class);
         when(request.getPathInfo()).thenReturn("/go/pipelines");
+
+        ContextHandler rootPathHandler = getLoadedHandlers().get(Jetty9Server.GoServerWelcomeFileHandler.class);
+        rootPathHandler.setServer(server);
+        rootPathHandler.start();
 
         rootPathHandler.handle("/go/pipelines", mock(Request.class), request, response);
 
@@ -235,31 +236,20 @@ public class Jetty9ServerTest {
 
     @Test
     public void shouldAddResourceHandlerForAssets() throws Exception {
-        ArgumentCaptor<HandlerCollection> captor = ArgumentCaptor.forClass(HandlerCollection.class);
         jetty9Server.configure();
+        jetty9Server.startHandlers();
 
-        verify(server, times(1)).setHandler(captor.capture());
-        HandlerCollection handlerCollection = captor.getValue();
-        assertThat(handlerCollection.getHandlers().length, is(3));
-
-        Handler handler = handlerCollection.getHandlers()[1];
-        assertThat(handler instanceof AssetsContextHandler, is(true));
-        AssetsContextHandler assetsContextHandler = (AssetsContextHandler) handler;
+        ContextHandler assetsContextHandler = getLoadedHandlers().get(AssetsContextHandler.class);
         assertThat(assetsContextHandler.getContextPath(), is("context/assets"));
     }
 
     @Test
     public void shouldAddWebAppContextHandler() throws Exception {
-        ArgumentCaptor<HandlerCollection> captor = ArgumentCaptor.forClass(HandlerCollection.class);
         jetty9Server.configure();
+        jetty9Server.startHandlers();
 
-        verify(server, times(1)).setHandler(captor.capture());
-        HandlerCollection handlerCollection = captor.getValue();
-        assertThat(handlerCollection.getHandlers().length, is(3));
+        WebAppContext webAppContext = (WebAppContext) getLoadedHandlers().get(WebAppContext.class);
 
-        Handler handler = handlerCollection.getHandlers()[2];
-        assertThat(handler instanceof WebAppContext, is(true));
-        WebAppContext webAppContext = (WebAppContext) handler;
         List<String> configClasses = ArrayUtil.asList(webAppContext.getConfigurationClasses());
         assertThat(configClasses.contains(WebInfConfiguration.class.getCanonicalName()), is(true));
         assertThat(configClasses.contains(WebXmlConfiguration.class.getCanonicalName()), is(true));
@@ -280,15 +270,20 @@ public class Jetty9ServerTest {
     public void shouldAddExtraJarsIntoClassPath() throws Exception {
         jetty9Server.configure();
         jetty9Server.addExtraJarsToClasspath("test-addons/some-addon-dir/addon-1.JAR,test-addons/some-addon-dir/addon-2.jar");
-        assertThat(getWebAppContext(jetty9Server).getExtraClasspath(), is("test-addons/some-addon-dir/addon-1.JAR,test-addons/some-addon-dir/addon-2.jar," + configDir));
+        jetty9Server.startHandlers();
+
+        WebAppContext webAppContext = (WebAppContext) getLoadedHandlers().get(WebAppContext.class);
+        assertThat(webAppContext.getExtraClasspath(), is("test-addons/some-addon-dir/addon-1.JAR,test-addons/some-addon-dir/addon-2.jar," + configDir));
     }
 
     @Test
     public void shouldSetInitParams() throws Exception {
         jetty9Server.configure();
         jetty9Server.setInitParameter("name", "value");
+        jetty9Server.startHandlers();
 
-        assertThat(getWebAppContext(jetty9Server).getInitParameter("name"), CoreMatchers.is("value"));
+        WebAppContext webAppContext = (WebAppContext) getLoadedHandlers().get(WebAppContext.class);
+        assertThat(webAppContext.getInitParameter("name"), CoreMatchers.is("value"));
     }
 
     @Test
@@ -321,21 +316,19 @@ public class Jetty9ServerTest {
 
     @Test
     public void shouldSetErrorHandlerForWebAppContext() throws Exception {
-        ArgumentCaptor<HandlerCollection> captor = ArgumentCaptor.forClass(HandlerCollection.class);
         jetty9Server.configure();
+        jetty9Server.startHandlers();
 
-        verify(server, times(1)).setHandler(captor.capture());
-        HandlerCollection handlerCollection = captor.getValue();
-        assertThat(handlerCollection.getHandlers().length, is(3));
-
-        Handler handler = handlerCollection.getHandlers()[2];
-        assertThat(handler instanceof WebAppContext, is(true));
-        WebAppContext webAppContext = (WebAppContext) handler;
+        ContextHandler webAppContext = getLoadedHandlers().get(WebAppContext.class);
 
         assertThat(webAppContext.getErrorHandler() instanceof JettyCustomErrorPageHandler, is(true));
     }
 
-    private WebAppContext getWebAppContext(Jetty9Server server) {
-        return (WebAppContext) ReflectionUtil.getField(server, "webAppContext");
+    private Map<Class<? extends ContextHandler>, ContextHandler> getLoadedHandlers() throws Exception {
+        Map<Class<? extends ContextHandler>, ContextHandler> handlerTypeToHandler = new HashMap<>();
+        for (App app : appCaptor.getAllValues()) {
+            handlerTypeToHandler.put(app.getContextHandler().getClass(), app.getContextHandler());
+        }
+        return handlerTypeToHandler;
     }
 }

--- a/server-launcher/build.gradle
+++ b/server-launcher/build.gradle
@@ -260,6 +260,7 @@ task verifyFatJar(type: VerifyJarTask) {
       "jetty-plus-${versions.jetty}.jar",
       "jetty-security-${versions.jetty}.jar",
       "jetty-server-${versions.jetty}.jar",
+      "jetty-deploy-${versions.jetty}.jar",
       "jetty-servlet-${versions.jetty}.jar",
       "jetty-servlets-${versions.jetty}.jar",
       "jetty-util-${versions.jetty}.jar",

--- a/test-utils/build.gradle
+++ b/test-utils/build.gradle
@@ -33,6 +33,7 @@ dependencies {
   compile group: 'org.eclipse.jetty', name: 'jetty-plus', version: versions.jetty
   compile group: 'org.eclipse.jetty', name: 'jetty-jmx', version: versions.jetty
   compile group: 'org.eclipse.jetty', name: 'jetty-util', version: versions.jetty
+  compile group: 'org.eclipse.jetty', name: 'jetty-deploy', version: versions.jetty
   compile group: 'com.sun.mail', name: 'mailapi', version: '1.5.6'
   compile group: 'junit', name: 'junit', version: '4.11'
   compile group: 'com.googlecode', name: 'junit-ext', version: '1.0'


### PR DESCRIPTION
The Jetty Server is started empty, with no handlers and that's quick. It takes ports 8153 and 8154 and starts returning 404 for everything. Immediately, the welcome file handler is started. It starts handling /go (redirecting to /go/home) which won't work, because the Spring web app (and Rails) haven't started yet. Once they're up, the redirection works.

Till that time, we can show a message or something more clever, while waiting for the rest of the app to come up.

This is based on how Jetty's hot reloads work. The idea (for this PR) is that there should be no change in behavior due to this. Any scripts which were checking whether 8153/8154 are responding to decide whether the server is up, will need to change.

Need to check:

* Will the server process stop properly if something goes wrong?
    - If config migration fails
    - If some other validation fails