### PR TITLE
Ensure log4j is properly shut down

### DIFF
--- a/agent-launcher/src/com/thoughtworks/go/agent/launcher/AgentLauncherImpl.java
+++ b/agent-launcher/src/com/thoughtworks/go/agent/launcher/AgentLauncherImpl.java
@@ -57,8 +57,8 @@ public class AgentLauncherImpl implements AgentLauncher {
 
     public int launch(AgentLaunchDescriptor descriptor) {
         Thread shutdownHook = null;
+        LogConfigurator logConfigurator = new LogConfigurator("agent-launcher-log4j.properties");
         try {
-            LogConfigurator logConfigurator = new LogConfigurator("agent-launcher-log4j.properties");
             logConfigurator.initialize();
             int returnValue;
 
@@ -97,6 +97,7 @@ public class AgentLauncherImpl implements AgentLauncher {
             LOG.error("Launch encountered an unknown exception", e);
             return UNKNOWN_EXCEPTION_OCCURRED;
         } finally {
+            logConfigurator.shutdown();
             removeShutDownHook(shutdownHook);
             lockFile.delete();
         }

--- a/base/src/com/thoughtworks/go/logging/LogConfigurator.java
+++ b/base/src/com/thoughtworks/go/logging/LogConfigurator.java
@@ -85,4 +85,8 @@ public class LogConfigurator {
         BasicConfigurator.configure(new ConsoleAppender(new PatternLayout("%d{ISO8601} [%-9t] %-5p %-16c{4}:%L %x- %m%n")));
         Logger.getRootLogger().setLevel(Level.INFO);
     }
+
+    public void shutdown() {
+        LogManager.shutdown();
+    }
 }

--- a/server/src/com/thoughtworks/go/server/LoggingInitializer.java
+++ b/server/src/com/thoughtworks/go/server/LoggingInitializer.java
@@ -25,14 +25,16 @@ import static com.thoughtworks.go.server.util.GoLauncher.DEFAULT_LOG4J_CONFIGURA
 
 public class LoggingInitializer implements ServletContextListener {
 
+    private LogConfigurator logConfigurator;
+
     @Override
     public void contextInitialized(ServletContextEvent sce) {
-        LogConfigurator logConfigurator = new LogConfigurator(DEFAULT_LOG4J_CONFIGURATION_FILE);
+        logConfigurator = new LogConfigurator(DEFAULT_LOG4J_CONFIGURATION_FILE);
         logConfigurator.initialize();
     }
 
     @Override
     public void contextDestroyed(ServletContextEvent sce) {
-
+        logConfigurator.shutdown();
     }
 }


### PR DESCRIPTION
This is to ensure that atleast the agent launcher will cleanup
logging, release any open resources etc, before returning control
back to the agent bootstrapper process.