### PR TITLE
Fix typo

### DIFF
--- a/server/webapp/WEB-INF/rails.new/spec/webpack/views/pipeline_configs/pipeline_config_widget_spec.js
+++ b/server/webapp/WEB-INF/rails.new/spec/webpack/views/pipeline_configs/pipeline_config_widget_spec.js
@@ -103,7 +103,7 @@ describe("PipelineConfigWidget", () => {
   });
 
   it("should render the pipeline name", () => {
-    expect($root.find('.pipeline .heading h1')).toHaveText('Pipeline configuation for pipeline yourproject');
+    expect($root.find('.pipeline .heading h1')).toHaveText('Pipeline configuration for pipeline yourproject');
   });
 
   it('should disable button and page edits while pipeline config save is in progress', () => {

--- a/server/webapp/WEB-INF/rails.new/webpack/views/pipeline_configs/pipeline_config_widget.js.msx
+++ b/server/webapp/WEB-INF/rails.new/webpack/views/pipeline_configs/pipeline_config_widget.js.msx
@@ -143,7 +143,7 @@ const PipelineConfigWidget = function (options) {
             <f.row class="heading">
               <f.column size={10} largeSize={10}>
                 <h1>
-                  Pipeline configuation for pipeline
+                  Pipeline configuration for pipeline
                   {' '}
                   {pipeline.name()}
                 </h1>


### PR DESCRIPTION
Hi!

I noticed a typo on the pipeline configuration page:

<img width="549" alt="screen shot 2017-08-09 at 15 55 38" src="https://user-images.githubusercontent.com/151290/29128253-4099dda8-7d1b-11e7-839c-e246d480de51.png">

Hope this fixes it.

Thanks,

