### PR TITLE
Stage and job related warnings should not be logged for a rerun stage/job

### DIFF
--- a/domain/src/com/thoughtworks/go/domain/Stage.java
+++ b/domain/src/com/thoughtworks/go/domain/Stage.java
@@ -428,7 +428,7 @@ public class Stage extends PersistentObject {
     }
 
     public void building() {
-        if (state != null) {
+        if (state != null && !isReRun()) {
             LOG.warn("Expected stage [{}] to have no state, but was {}", identifier, state, new Exception().fillInStackTrace());
         }
         state = StageState.Building;

--- a/server/src/com/thoughtworks/go/server/dao/JobInstanceSqlMapDao.java
+++ b/server/src/com/thoughtworks/go/server/dao/JobInstanceSqlMapDao.java
@@ -335,7 +335,7 @@ public class JobInstanceSqlMapDao extends SqlMapClientDaoSupport implements JobI
 
     private void logIfJobIsCompleted(JobInstance jobInstance) {
         JobState currentState = getCurrentState(jobInstance.getId());
-        if (currentState.isCompleted()) {
+        if (currentState.isCompleted() && !jobInstance.isCopy()) {
             String message = String.format(
                     "State change for a completed Job is not allowed. Job %s is currently State=%s, Result=%s",
                     jobInstance.getIdentifier(), jobInstance.getState(), jobInstance.getResult());


### PR DESCRIPTION
A rerun stage would already contain state from the previous run. Currently every rerun of a job/stage adds a lot of unnecessary noise to the server logs