### PR TITLE
Check if agent is disabled before job assignment

### DIFF
--- a/common/src/com/thoughtworks/go/domain/AgentInstance.java
+++ b/common/src/com/thoughtworks/go/domain/AgentInstance.java
@@ -168,7 +168,7 @@ public class AgentInstance implements Comparable<AgentInstance> {
     }
 
     public void refresh(final AgentRuntimeStatus.ChangeListener changeListener) {
-        if (agentConfigStatus == AgentConfigStatus.Pending || agentConfigStatus == AgentConfigStatus.Disabled) {
+        if (agentConfigStatus == AgentConfigStatus.Pending) {
             return;
         }
         if (lastHeardTime == null) {

--- a/common/test/unit/com/thoughtworks/go/domain/AgentInstanceTest.java
+++ b/common/test/unit/com/thoughtworks/go/domain/AgentInstanceTest.java
@@ -322,16 +322,19 @@ public class AgentInstanceTest {
     }
 
     @Test
-    public void shouldNotRefreshDeniedAgent() throws Exception {
+    public void shouldRefreshDisabledAgent() throws Exception {
         agentConfig.disable();
         AgentInstance instance = AgentInstance.createFromConfig(agentConfig, new SystemEnvironment() {
             public int getAgentConnectionTimeout() {
                 return -1;
             }
         });
-        instance.update(new AgentRuntimeInfo(agentConfig.getAgentIdentifier(), AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", false));
+        instance.update(new AgentRuntimeInfo(agentConfig.getAgentIdentifier(), AgentRuntimeStatus.Building, currentWorkingDirectory(), "cookie", false));
+
         instance.refresh(null);
-        assertThat(instance.getStatus().getRuntimeStatus(), is(not(AgentRuntimeStatus.LostContact)));
+
+        assertThat(instance.getRuntimeStatus(), is(AgentRuntimeStatus.LostContact));
+        assertThat(instance.getStatus(), is(AgentStatus.Disabled));
     }
 
     @Test

--- a/server/src/com/thoughtworks/go/server/service/BuildAssignmentService.java
+++ b/server/src/com/thoughtworks/go/server/service/BuildAssignmentService.java
@@ -143,6 +143,10 @@ public class BuildAssignmentService implements ConfigChangedListener {
         }
 
         synchronized (this) {
+//          check to ensure agent is not disabled after entering the synchronized block
+            if (agent.isDisabled()) {
+                return new DeniedAgentWork(agent.getUuid());
+            }
             //check if agent already has assigned build, if so, reschedule it
             scheduleService.rescheduleAbandonedBuildIfNecessary(agent.getAgentIdentifier());
             final JobPlan job = findMatchingJob(agent);


### PR DESCRIPTION


* Fix for #3747 
* BuildAssignmentService#assignWorkToAgent has a check to verify if an
  agent is disabled. The actual assignment happens in a synchronized
  block, by the time a thread enters the block the agent could be
  disabled. This commit ensures that an agent is not disabled within the
  synchronized block.
* Disabled agents are refreshed now, this ensures if a disabled agent is
  running a job and loses contact the job can be reschuduled.