### PR TITLE
Health check api for agent (#3074)

### DIFF
--- a/agent/build.gradle
+++ b/agent/build.gradle
@@ -33,6 +33,7 @@ dependencies {
   compile group: 'org.bouncycastle', name: 'bcprov-jdk15on', version: '1.47'
   compile group: 'commons-configuration', name: 'commons-configuration', version: '1.10'
   compile group: 'org.eclipse.jetty.websocket', name: 'websocket-client', version: versions.jetty
+  compile group: 'org.nanohttpd', name: 'nanohttpd', version: versions.nanohttpd
 
   testCompile project(path: ':common', configuration: 'testOutput')
   testCompile project(path: ':config-api', configuration: 'testOutput')
@@ -120,6 +121,7 @@ task verifyJar(type: VerifyJarTask) {
       "joda-time-2.3.jar",
       "logback-classic-${project.versions.logback}.jar",
       "logback-core-${project.versions.logback}.jar",
+      "nanohttpd-2.3.1.jar",
       "objenesis-1.2.jar",
       "org.apache.felix.framework-${project.versions.felix}.jar",
       "plugin-metadata-store-${project.version}.jar",

--- a/agent/resources/applicationContext.xml
+++ b/agent/resources/applicationContext.xml
@@ -25,6 +25,7 @@
 
   <import resource="classpath:applicationContext-plugin-infra.xml"/>
   <context:annotation-config/>
+  <context:component-scan base-package="com.thoughtworks.go.agent.statusapi"/>
 
   <!-- Loads the System Properties -->
   <bean id="propertyConfigurer"
@@ -78,6 +79,8 @@
 
   <bean id="agentControllerFactory" class="com.thoughtworks.go.agent.AgentControllerFactory" />
   <bean id="agentController" class="com.thoughtworks.go.agent.AgentController" factory-bean="agentControllerFactory" factory-method="createInstance" />
+
+  <bean id="clock" class="com.thoughtworks.go.util.SystemTimeClock" />
 
   <bean id="agentControllerLooper" class="org.springframework.scheduling.timer.MethodInvokingTimerTaskFactoryBean"
         p:targetObject-ref="agentController"

--- a/agent/src/com/thoughtworks/go/agent/AgentController.java
+++ b/agent/src/com/thoughtworks/go/agent/AgentController.java
@@ -18,6 +18,7 @@ package com.thoughtworks.go.agent;
 
 import com.thoughtworks.go.agent.service.AgentUpgradeService;
 import com.thoughtworks.go.agent.service.SslInfrastructureService;
+import com.thoughtworks.go.agent.statusapi.AgentHealthHolder;
 import com.thoughtworks.go.config.AgentAutoRegistrationProperties;
 import com.thoughtworks.go.config.AgentRegistry;
 import com.thoughtworks.go.domain.AgentRuntimeStatus;
@@ -27,7 +28,10 @@ import com.thoughtworks.go.plugin.infra.PluginManagerReference;
 import com.thoughtworks.go.remote.AgentIdentifier;
 import com.thoughtworks.go.server.service.AgentRuntimeInfo;
 import com.thoughtworks.go.server.service.ElasticAgentRuntimeInfo;
-import com.thoughtworks.go.util.*;
+import com.thoughtworks.go.util.SubprocessLogger;
+import com.thoughtworks.go.util.SystemEnvironment;
+import com.thoughtworks.go.util.SystemUtil;
+import com.thoughtworks.go.util.TimeProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -48,7 +52,8 @@ public abstract class AgentController {
     private AgentRegistry agentRegistry;
     private SubprocessLogger subprocessLogger;
     private AgentUpgradeService agentUpgradeService;
-    protected TimeProvider timeProvider;
+    private final AgentHealthHolder agentHealthHolder;
+    private final TimeProvider timeProvider;
     private final String hostName;
     private final String ipAddress;
 
@@ -56,13 +61,17 @@ public abstract class AgentController {
                            SystemEnvironment systemEnvironment,
                            AgentRegistry agentRegistry,
                            PluginManager pluginManager,
-                           SubprocessLogger subprocessLogger, AgentUpgradeService agentUpgradeService, TimeProvider timeProvider) {
+                           SubprocessLogger subprocessLogger,
+                           AgentUpgradeService agentUpgradeService,
+                           TimeProvider timeProvider,
+                           AgentHealthHolder agentHealthHolder) {
         this.sslInfrastructureService = sslInfrastructureService;
         this.systemEnvironment = systemEnvironment;
         this.agentRegistry = agentRegistry;
         this.subprocessLogger = subprocessLogger;
         this.agentUpgradeService = agentUpgradeService;
         this.timeProvider = timeProvider;
+        this.agentHealthHolder = agentHealthHolder;
         PluginManagerReference.reference().setPluginManager(pluginManager);
         hostName = SystemUtil.getLocalhostNameOrRandomNameIfNotFound();
         ipAddress = SystemUtil.getClientIp(systemEnvironment.getServiceUrl());
@@ -153,6 +162,10 @@ public abstract class AgentController {
         } else {
             agentRuntimeInfo = AgentRuntimeInfo.fromAgent(identifier, AgentStatus.Idle.getRuntimeStatus(), currentWorkingDirectory(), buildCommandProtocolEnabled, timeProvider);
         }
+    }
+
+    void pingSuccess() {
+        agentHealthHolder.pingSuccess();
     }
 
     private void initPipelinesFolder() {

--- a/agent/src/com/thoughtworks/go/agent/AgentControllerFactory.java
+++ b/agent/src/com/thoughtworks/go/agent/AgentControllerFactory.java
@@ -18,6 +18,7 @@ package com.thoughtworks.go.agent;
 
 import com.thoughtworks.go.agent.service.AgentUpgradeService;
 import com.thoughtworks.go.agent.service.SslInfrastructureService;
+import com.thoughtworks.go.agent.statusapi.AgentHealthHolder;
 import com.thoughtworks.go.config.AgentRegistry;
 import com.thoughtworks.go.plugin.access.packagematerial.PackageRepositoryExtension;
 import com.thoughtworks.go.plugin.access.pluggabletask.TaskExtension;
@@ -52,6 +53,7 @@ public class AgentControllerFactory {
     private final WebSocketSessionHandler sessionHandler;
     private TimeProvider timeProvider;
     private static final Logger LOG = LoggerFactory.getLogger(AgentControllerFactory.class);
+    private final AgentHealthHolder agentHealthHolder;
 
     @Autowired
     public AgentControllerFactory(
@@ -69,7 +71,8 @@ public class AgentControllerFactory {
             HttpService httpService,
             WebSocketClientHandler webSocketClientHandler,
             WebSocketSessionHandler sessionHandler,
-            TimeProvider timeProvider) {
+            TimeProvider timeProvider,
+            AgentHealthHolder agentHealthHolder) {
         this.server = server;
         this.manipulator = manipulator;
         this.pluginManager = pluginManager;
@@ -84,6 +87,7 @@ public class AgentControllerFactory {
         this.httpService = httpService;
         this.webSocketClientHandler = webSocketClientHandler;
         this.sessionHandler = sessionHandler;
+        this.agentHealthHolder = agentHealthHolder;
         this.timeProvider = timeProvider;
     }
 
@@ -102,7 +106,11 @@ public class AgentControllerFactory {
                     packageRepositoryExtension,
                     scmExtension,
                     taskExtension,
-                    httpService, webSocketClientHandler, sessionHandler, timeProvider);
+                    httpService,
+                    webSocketClientHandler,
+                    sessionHandler,
+                    timeProvider,
+                    agentHealthHolder);
         } else {
             LOG.info("Connecting to server using HTTP(S)");
             return new AgentHTTPClientController(
@@ -117,7 +125,8 @@ public class AgentControllerFactory {
                     packageRepositoryExtension,
                     scmExtension,
                     taskExtension,
-                    timeProvider);
+                    timeProvider,
+                    agentHealthHolder);
         }
     }
 }

--- a/agent/src/com/thoughtworks/go/agent/AgentHTTPClientController.java
+++ b/agent/src/com/thoughtworks/go/agent/AgentHTTPClientController.java
@@ -18,6 +18,7 @@ package com.thoughtworks.go.agent;
 
 import com.thoughtworks.go.agent.service.AgentUpgradeService;
 import com.thoughtworks.go.agent.service.SslInfrastructureService;
+import com.thoughtworks.go.agent.statusapi.AgentHealthHolder;
 import com.thoughtworks.go.config.AgentRegistry;
 import com.thoughtworks.go.domain.exception.UnregisteredAgentException;
 import com.thoughtworks.go.plugin.access.packagematerial.PackageRepositoryExtension;
@@ -59,8 +60,10 @@ public class AgentHTTPClientController extends AgentController {
                                      PluginManager pluginManager,
                                      PackageRepositoryExtension packageRepositoryExtension,
                                      SCMExtension scmExtension,
-                                     TaskExtension taskExtension, TimeProvider timeProvider) {
-        super(sslInfrastructureService, systemEnvironment, agentRegistry, pluginManager, subprocessLogger, agentUpgradeService, timeProvider);
+                                     TaskExtension taskExtension,
+                                     TimeProvider timeProvider,
+                                     AgentHealthHolder agentHealthHolder) {
+        super(sslInfrastructureService, systemEnvironment, agentRegistry, pluginManager, subprocessLogger, agentUpgradeService, timeProvider, agentHealthHolder);
         this.packageRepositoryExtension = packageRepositoryExtension;
         this.scmExtension = scmExtension;
         this.taskExtension = taskExtension;
@@ -79,6 +82,7 @@ public class AgentHTTPClientController extends AgentController {
                 getAgentRuntimeInfo().refreshUsableSpace();
 
                 agentInstruction = server.ping(getAgentRuntimeInfo());
+                pingSuccess();
                 LOG.trace("{} pinged server [{}]", agent, server);
             }
         } catch (Throwable e) {

--- a/agent/src/com/thoughtworks/go/agent/WebSocketSessionHandler.java
+++ b/agent/src/com/thoughtworks/go/agent/WebSocketSessionHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 ThoughtWorks, Inc.
+ * Copyright 2017 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -83,7 +83,7 @@ public class WebSocketSessionHandler {
         }
     }
 
-    void sendAndWaitForAcknowledgement(Message message) {
+    boolean sendAndWaitForAcknowledgement(Message message) {
         final CountDownLatch wait = new CountDownLatch(1);
         sendWithCallback(message, new MessageCallback() {
             @Override
@@ -92,10 +92,11 @@ public class WebSocketSessionHandler {
             }
         });
         try {
-            wait.await(systemEnvironment.getWebsocketAckMessageTimeout(), TimeUnit.MILLISECONDS);
+            return wait.await(systemEnvironment.getWebsocketAckMessageTimeout(), TimeUnit.MILLISECONDS);
         } catch (InterruptedException e) {
             bomb(e);
         }
+        return false;
     }
 
     private void sendWithCallback(Message message, MessageCallback callback) {

--- a/agent/src/com/thoughtworks/go/agent/statusapi/AgentHealthHolder.java
+++ b/agent/src/com/thoughtworks/go/agent/statusapi/AgentHealthHolder.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2017 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.agent.statusapi;
+
+import com.thoughtworks.go.util.Clock;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class AgentHealthHolder {
+    private final Clock clock;
+    private final long pingInterval;
+    private long lastPingTime;
+
+    @Autowired
+    public AgentHealthHolder(Clock clock, @Value("${agent.ping.interval}") long pingInterval) {
+        this.clock = clock;
+        this.pingInterval = pingInterval;
+    }
+
+    public void pingSuccess() {
+        this.lastPingTime = clock.currentTimeMillis();
+    }
+
+    // assume disconnected if unable to ping for 2 intervals
+    public boolean hasLostContact() {
+        return (clock.currentTimeMillis() - lastPingTime) >= (pingInterval * 2);
+    }
+
+}
+

--- a/agent/src/com/thoughtworks/go/agent/statusapi/AgentStatusHttpd.java
+++ b/agent/src/com/thoughtworks/go/agent/statusapi/AgentStatusHttpd.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2017 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.agent.statusapi;
+
+import com.thoughtworks.go.util.SystemEnvironment;
+import fi.iki.elonen.NanoHTTPD;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import javax.annotation.PostConstruct;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Component
+public class AgentStatusHttpd extends NanoHTTPD {
+
+    private static final Logger LOG = LoggerFactory.getLogger(AgentStatusHttpd.class);
+    private static final String DEFAULT_MIME_TYPE = "text/plain; charset=utf-8";
+    private static final String METHOD_NOT_ALLOWED_MESSAGE = "This method is not allowed. Please use GET or HEAD.";
+    private static final String PAGE_NOT_FOUND_MESSAGE = "The page you requested was not found";
+
+    private final Map<String, HttpHandler> routes = new ConcurrentHashMap<>();
+    private final HttpHandler isConnectedToServer;
+    private final SystemEnvironment environment;
+    private final int port;
+    private final Set<Method> allowedMethods = new HashSet<>(Arrays.asList(Method.GET, Method.PUT));
+
+    @Autowired
+    public AgentStatusHttpd(SystemEnvironment environment,
+                            IsConnectedToServerV1 isConnectedToServerV1) {
+        super(environment.getAgentStatusHostname(), environment.getAgentStatusPort());
+        this.port = environment.getAgentStatusPort();
+        this.environment = environment;
+        this.isConnectedToServer = isConnectedToServerV1;
+        setupRoutes();
+    }
+
+    private void setupRoutes() {
+        routes.put("/health/v1/isConnectedToServer", isConnectedToServer);
+        routes.put("/health/latest/isConnectedToServer", isConnectedToServer);
+    }
+
+    @Override
+    public Response serve(IHTTPSession session) {
+        if (!allowedMethods.contains(session.getMethod())) {
+            return methodNotAllowed();
+        }
+        HttpHandler httpHandler = routes.get(session.getUri());
+        if (httpHandler != null) {
+            return httpHandler.process();
+        } else {
+            return notFound();
+        }
+    }
+
+    private Response methodNotAllowed() {
+        return newFixedLengthResponse(Response.Status.METHOD_NOT_ALLOWED, DEFAULT_MIME_TYPE, METHOD_NOT_ALLOWED_MESSAGE);
+    }
+
+    private Response notFound() {
+        return newFixedLengthResponse(Response.Status.NOT_FOUND, DEFAULT_MIME_TYPE, PAGE_NOT_FOUND_MESSAGE);
+    }
+
+    @PostConstruct
+    public void init() {
+        if (!environment.getAgentStatusEnabled()) {
+            LOG.info("Agent status HTTP API server has been disabled.");
+            return;
+        }
+        try {
+            start();
+            LOG.info("Agent status HTTP API server running on http://{}:{}.", getHostname() == null ? "0.0.0.0" : getHostname(), getListeningPort());
+        } catch (Exception e) {
+            LOG.warn("Could not start agent status HTTP API server on host {}, port {}.", getHostname(), port, e);
+        }
+    }
+}

--- a/agent/src/com/thoughtworks/go/agent/statusapi/HttpHandler.java
+++ b/agent/src/com/thoughtworks/go/agent/statusapi/HttpHandler.java
@@ -14,9 +14,19 @@
  * limitations under the License.
  */
 
-package com.thoughtworks.go.config;
+package com.thoughtworks.go.agent.statusapi;
 
-public interface AgentRegistry {
-    String uuid();
-    String serverBaseUrl();
+import fi.iki.elonen.NanoHTTPD;
+import fi.iki.elonen.NanoHTTPD.Response.Status;
+
+abstract class HttpHandler {
+    NanoHTTPD.Response process() {
+        if (isPassed()) {
+            return NanoHTTPD.newFixedLengthResponse(Status.OK, "text/plain; charset=utf-8", "OK!");
+        } else {
+            return NanoHTTPD.newFixedLengthResponse(Status.SERVICE_UNAVAILABLE, "text/plain; charset=utf-8", "Bad!");
+        }
+    }
+
+    protected abstract boolean isPassed();
 }

--- a/agent/src/com/thoughtworks/go/agent/statusapi/IsConnectedToServerV1.java
+++ b/agent/src/com/thoughtworks/go/agent/statusapi/IsConnectedToServerV1.java
@@ -14,9 +14,23 @@
  * limitations under the License.
  */
 
-package com.thoughtworks.go.config;
+package com.thoughtworks.go.agent.statusapi;
 
-public interface AgentRegistry {
-    String uuid();
-    String serverBaseUrl();
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class IsConnectedToServerV1 extends HttpHandler {
+
+    private final AgentHealthHolder agentHealthHolder;
+
+    @Autowired
+    public IsConnectedToServerV1(AgentHealthHolder agentHealthHolder) {
+        this.agentHealthHolder = agentHealthHolder;
+    }
+
+    @Override
+    protected boolean isPassed() {
+        return !agentHealthHolder.hasLostContact();
+    }
 }

--- a/agent/test/unit/com/thoughtworks/go/agent/AgentHTTPClientControllerTest.java
+++ b/agent/test/unit/com/thoughtworks/go/agent/AgentHTTPClientControllerTest.java
@@ -143,7 +143,7 @@ public class AgentHTTPClientControllerTest {
     public void shouldRegisterSubprocessLoggerAtExit() throws Exception {
         SslInfrastructureService sslInfrastructureService = mock(SslInfrastructureService.class);
         AgentRegistry agentRegistry = mock(AgentRegistry.class);
-        agentController = new AgentHTTPClientController(loopServer, artifactsManipulator, sslInfrastructureService, agentRegistry, agentUpgradeService, subprocessLogger, systemEnvironment, pluginManager, packageRepositoryExtension, scmExtension, taskExtension, timeProvider);
+        agentController = new AgentHTTPClientController(loopServer, artifactsManipulator, sslInfrastructureService, agentRegistry, agentUpgradeService, subprocessLogger, systemEnvironment, pluginManager, packageRepositoryExtension, scmExtension, taskExtension, timeProvider, null);
         agentController.init();
         verify(subprocessLogger).registerAsExitHook("Following processes were alive at shutdown: ");
     }
@@ -171,6 +171,7 @@ public class AgentHTTPClientControllerTest {
     }
 
     private AgentHTTPClientController createAgentController() {
+
         return new AgentHTTPClientController(
                 loopServer,
                 artifactsManipulator,
@@ -182,6 +183,6 @@ public class AgentHTTPClientControllerTest {
                 pluginManager,
                 packageRepositoryExtension,
                 scmExtension,
-                taskExtension, timeProvider);
+                taskExtension, timeProvider, null);
     }
 }

--- a/agent/test/unit/com/thoughtworks/go/agent/AgentWebSocketClientControllerTest.java
+++ b/agent/test/unit/com/thoughtworks/go/agent/AgentWebSocketClientControllerTest.java
@@ -433,7 +433,7 @@ public class AgentWebSocketClientControllerTest {
                 scmExtension,
                 taskExtension,
                 httpService,
-                webSocketClientHandler, webSocketSessionHandler, timeProvider);
+                webSocketClientHandler, webSocketSessionHandler, timeProvider, null);
         return controller;
     }
 }

--- a/agent/test/unit/com/thoughtworks/go/agent/WebSocketClientHandlerTest.java
+++ b/agent/test/unit/com/thoughtworks/go/agent/WebSocketClientHandlerTest.java
@@ -89,7 +89,8 @@ public class WebSocketClientHandlerTest {
                 mock(HttpService.class),
                 mock(WebSocketClientHandler.class),
                 mock(WebSocketSessionHandler.class),
-                mock(TimeProvider.class));
+                mock(TimeProvider.class),
+                null);
     }
 
     class WebSocketClientStub extends WebSocketClient {

--- a/agent/test/unit/com/thoughtworks/go/agent/statusapi/AgentStatusHttpdTest.java
+++ b/agent/test/unit/com/thoughtworks/go/agent/statusapi/AgentStatusHttpdTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2017 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.agent.statusapi;
+
+import com.thoughtworks.go.util.SystemEnvironment;
+import fi.iki.elonen.NanoHTTPD;
+import org.apache.commons.io.IOUtils;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+
+import java.nio.charset.StandardCharsets;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.*;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+public class AgentStatusHttpdTest {
+
+    @Mock
+    private AgentHealthHolder agentHealthHolder;
+    @Mock
+    private SystemEnvironment systemEnvironment;
+    @Mock
+    private NanoHTTPD.IHTTPSession session;
+    private AgentStatusHttpd agentStatusHttpd;
+
+    @Before
+    public void setUp() throws Exception {
+        initMocks(this);
+        this.agentStatusHttpd = new AgentStatusHttpd(systemEnvironment, new IsConnectedToServerV1(agentHealthHolder));
+    }
+
+    @Test
+    public void shouldReturnMethodNotAllowedOnNonGetNonHeadRequests() throws Exception {
+        when(session.getMethod()).thenReturn(NanoHTTPD.Method.POST);
+        NanoHTTPD.Response response = this.agentStatusHttpd.serve(session);
+        assertThat(response.getStatus(), is(NanoHTTPD.Response.Status.METHOD_NOT_ALLOWED));
+        assertThat(response.getMimeType(), is("text/plain; charset=utf-8"));
+        assertThat(IOUtils.toString(response.getData(), StandardCharsets.UTF_8), is("This method is not allowed. Please use GET or HEAD."));
+    }
+
+    @Test
+    public void shouldReturnNotFoundForBadUrl() throws Exception {
+        when(session.getMethod()).thenReturn(NanoHTTPD.Method.GET);
+        when(session.getUri()).thenReturn("/foo");
+
+        NanoHTTPD.Response response = this.agentStatusHttpd.serve(session);
+        assertThat(response.getStatus(), is(NanoHTTPD.Response.Status.NOT_FOUND));
+        assertThat(response.getMimeType(), is("text/plain; charset=utf-8"));
+        assertThat(IOUtils.toString(response.getData(), StandardCharsets.UTF_8), is("The page you requested was not found"));
+    }
+
+    @Test
+    public void shouldRouteToIsConnectedToServerHandler() throws Exception {
+        when(session.getMethod()).thenReturn(NanoHTTPD.Method.GET);
+        when(session.getUri()).thenReturn("/health/latest/isConnectedToServer");
+        when(agentHealthHolder.hasLostContact()).thenReturn(false);
+
+        NanoHTTPD.Response response = this.agentStatusHttpd.serve(session);
+        assertThat(response.getStatus(), is(NanoHTTPD.Response.Status.OK));
+        assertThat(response.getMimeType(), is("text/plain; charset=utf-8"));
+        assertThat(IOUtils.toString(response.getData(), StandardCharsets.UTF_8), is("OK!"));
+    }
+
+    @Test
+    public void shouldRouteToIsConnectedToServerV1Handler() throws Exception {
+        when(session.getMethod()).thenReturn(NanoHTTPD.Method.GET);
+        when(session.getUri()).thenReturn("/health/v1/isConnectedToServer");
+        when(agentHealthHolder.hasLostContact()).thenReturn(false);
+
+        NanoHTTPD.Response response = this.agentStatusHttpd.serve(session);
+        assertThat(response.getStatus(), is(NanoHTTPD.Response.Status.OK));
+        assertThat(response.getMimeType(), is("text/plain; charset=utf-8"));
+        assertThat(IOUtils.toString(response.getData(), StandardCharsets.UTF_8), is("OK!"));
+    }
+
+    @Test
+    public void shouldNotInitializeServerIfSettingIsTurnedOff() throws Exception {
+        when(systemEnvironment.getAgentStatusEnabled()).thenReturn(true);
+        AgentStatusHttpd spy = spy(agentStatusHttpd);
+        doThrow(new RuntimeException("This is not expected to be invoked")).when(spy).start();
+        spy.init();
+    }
+
+    @Test
+    public void shouldInitializeServerIfSettingIsTurnedOn() throws Exception {
+        when(systemEnvironment.getAgentStatusEnabled()).thenReturn(true);
+        AgentStatusHttpd spy = spy(agentStatusHttpd);
+        spy.init();
+        verify(spy).start();
+    }
+
+    @Test
+    public void initShouldNotBlowUpIfServerDoesNotStart() throws Exception {
+        when(systemEnvironment.getAgentStatusEnabled()).thenReturn(true);
+        AgentStatusHttpd spy = spy(agentStatusHttpd);
+        doThrow(new RuntimeException("Server had a problem starting up!")).when(spy).start();
+        try {
+            spy.init();
+        } catch (Exception e) {
+            fail("Did not expect exception!");
+        }
+    }
+}

--- a/agent/test/unit/com/thoughtworks/go/agent/statusapi/IsConnectedToServerV1Test.java
+++ b/agent/test/unit/com/thoughtworks/go/agent/statusapi/IsConnectedToServerV1Test.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2017 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.agent.statusapi;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class IsConnectedToServerV1Test {
+
+    @Test
+    public void shouldReturnFalseIfAgentHasLostContact() throws Exception {
+        AgentHealthHolder mock = mock(AgentHealthHolder.class);
+        when(mock.hasLostContact()).thenReturn(true);
+        IsConnectedToServerV1 handler = new IsConnectedToServerV1(mock);
+        assertFalse(handler.isPassed());
+    }
+
+    @Test
+    public void shouldReturnTrueIfAgentHasNotLostContact() throws Exception {
+        AgentHealthHolder mock = mock(AgentHealthHolder.class);
+        when(mock.hasLostContact()).thenReturn(false);
+        IsConnectedToServerV1 handler = new IsConnectedToServerV1(mock);
+        assertTrue(handler.isPassed());
+    }
+}

--- a/base/src/com/thoughtworks/go/util/SystemEnvironment.java
+++ b/base/src/com/thoughtworks/go/util/SystemEnvironment.java
@@ -30,6 +30,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 
+import static org.apache.commons.lang.StringUtils.isBlank;
+
 public class SystemEnvironment implements Serializable, ConfigDirProvider {
 
     private static final Logger LOG = LoggerFactory.getLogger(SystemEnvironment.class);
@@ -209,6 +211,9 @@ public class SystemEnvironment implements Serializable, ConfigDirProvider {
     public static GoBooleanSystemProperty REAUTHENTICATION_ENABLED = new GoBooleanSystemProperty("go.security.reauthentication.enabled", true);
     public static GoSystemProperty<Long> REAUTHENTICATION_TIME_INTERVAL = new GoLongSystemProperty("go.security.reauthentication.interval", 1800 * 1000L);
     public static GoSystemProperty<Boolean> CONSOLE_OUT_TO_STDOUT = new GoBooleanSystemProperty("go.console.stdout", false);
+    private static GoSystemProperty<Boolean> AGENT_STATUS_API_ENABLED = new GoBooleanSystemProperty("go.agent.status.api.enabled", true);
+    private static GoSystemProperty<String> AGENT_STATUS_API_BIND_HOST = new GoStringSystemProperty("go.agent.status.api.bind.host", "localhost");
+    private static GoSystemProperty<Integer> AGENT_STATUS_API_BIND_PORT = new GoIntSystemProperty("go.agent.status.api.bind.port", 8152);
 
     private final static Map<String, String> GIT_ALLOW_PROTOCOL;
 
@@ -822,6 +827,22 @@ public class SystemEnvironment implements Serializable, ConfigDirProvider {
 
     public long getReAuthenticationTimeInterval() {
         return REAUTHENTICATION_TIME_INTERVAL.getValue();
+    }
+
+    public Boolean getAgentStatusEnabled() {
+        return AGENT_STATUS_API_ENABLED.getValue();
+    }
+
+    public String getAgentStatusHostname() {
+        if (isBlank(AGENT_STATUS_API_BIND_HOST.getValue())) {
+            return null;
+        } else {
+            return AGENT_STATUS_API_BIND_HOST.getValue();
+        }
+    }
+
+    public int getAgentStatusPort() {
+        return AGENT_STATUS_API_BIND_PORT.getValue();
     }
 
     public static abstract class GoSystemProperty<T> {

--- a/build.gradle
+++ b/build.gradle
@@ -333,12 +333,13 @@ task allDependencies {
 }
 
 ext.versions = [
-  slf4j   : '1.7.25',
-  logback : '1.2.3',
-  jetty   : '9.2.18.v20160721',
-  junit   : '4.12',
-  mockito : '1.9.5',
-  hamcrest: '1.3',
-  spring  : '3.1.3.RELEASE',
-  felix   : '5.6.8'
+  slf4j    : '1.7.25',
+  logback  : '1.2.3',
+  jetty    : '9.2.18.v20160721',
+  junit    : '4.12',
+  mockito  : '1.9.5',
+  hamcrest : '1.3',
+  spring   : '3.1.3.RELEASE',
+  felix    : '5.6.8',
+  nanohttpd: '2.3.1',
 ]


### PR DESCRIPTION
This adds 2 endpoints for testing the health of the agent <-> server comm

* Perform a `GET` on `/health/{v1,latest}/isConnectedToServer`, will
  return status `200` along with text `OK!` if the agent is:
  - able to establish HTTP(s) contact
  - is authorized by the server (by an admin, or by auto-registration)
  The endpoint will return status `500` in any other cases.
  Two consecutive failing pings will be treated as having failed healthcheck.

These health checks will (by default) bind to port 8152 on localhost,
but can be configured by the following system properties:

* `go.agent.status.api.enabled`. Defaults to `true`. Set to false to
  disable health check api endpoint
* `go.agent.status.api.bind.host`. Defaults to `localhost`. Set to a
  specific ip address or hostname to bind to that host. Set to `0.0.0.0`
  to bind to all network interfaces.
* `go.agent.status.api.bind.port`. Defaults to `8152`. Set to `0` to
  use an ephemeral port, which will be displayed in a log statement.

In case the http server is unable to bind (usually because of port
conflicts, or multiple agents running on the same macchine), a warning
will be emitted to the console log and agent startup will continue.