### PR TITLE
Send request headers to plugin 

### DIFF
--- a/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/PluginRequestHelper.java
+++ b/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/PluginRequestHelper.java
@@ -29,8 +29,9 @@ public class PluginRequestHelper {
             DefaultGoPluginApiRequest apiRequest = new DefaultGoPluginApiRequest(extensionName, resolvedExtensionVersion, requestName);
             apiRequest.setRequestBody(pluginInteractionCallback.requestBody(resolvedExtensionVersion));
             apiRequest.setRequestParams(pluginInteractionCallback.requestParams(resolvedExtensionVersion));
+            apiRequest.setRequestHeaders(pluginInteractionCallback.requestHeaders(resolvedExtensionVersion));
             GoPluginApiResponse response = pluginManager.submitTo(pluginId, apiRequest);
-            if(response == null){
+            if (response == null) {
                 throw new RuntimeException("The plugin sent a null response");
             }
             if (DefaultGoApiResponse.SUCCESS_RESPONSE_CODE == response.responseCode()) {

--- a/plugin-infra/go-plugin-access/test/com/thoughtworks/go/plugin/access/PluginRequestHelperTest.java
+++ b/plugin-infra/go-plugin-access/test/com/thoughtworks/go/plugin/access/PluginRequestHelperTest.java
@@ -168,4 +168,49 @@ public class PluginRequestHelperTest {
         assertThat(generatedRequest[0].requestParameters().get("p1"), is("v1"));
         assertThat(generatedRequest[0].requestParameters().get("p2"), is("v2"));
     }
+
+    @Test
+    public void shouldConstructTheRequestWithRequestHeaders() {
+        final String requestBody = "request_body";
+        when(response.responseCode()).thenReturn(DefaultGoApiResponse.SUCCESS_RESPONSE_CODE);
+
+        final GoPluginApiRequest[] generatedRequest = {null};
+        doAnswer(invocationOnMock -> {
+            generatedRequest[0] = (GoPluginApiRequest) invocationOnMock.getArguments()[1];
+            return response;
+        }).when(pluginManager).submitTo(eq(pluginId), any(GoPluginApiRequest.class));
+
+
+        helper.submitRequest(pluginId, requestName, new PluginInteractionCallback<Object>() {
+            @Override
+            public String requestBody(String resolvedExtensionVersion) {
+                return requestBody;
+            }
+
+            @Override
+            public Map<String, String> requestParams(String resolvedExtensionVersion) {
+                return null;
+            }
+
+            @Override
+            public Map<String, String> requestHeaders(String resolvedExtensionVersion) {
+                final Map<String, String> headers = new HashMap();
+                headers.put("HEADER-1", "HEADER-VALUE-1");
+                headers.put("HEADER-2", "HEADER-VALUE-2");
+                return headers;
+            }
+
+            @Override
+            public Object onSuccess(String responseBody, String resolvedExtensionVersion) {
+                return null;
+            }
+        });
+
+        assertThat(generatedRequest[0].requestBody(), is(requestBody));
+        assertThat(generatedRequest[0].extension(), is(extensionName));
+        assertThat(generatedRequest[0].requestName(), is(requestName));
+        assertThat(generatedRequest[0].requestHeaders().size(), is(2));
+        assertThat(generatedRequest[0].requestHeaders().get("HEADER-1"), is("HEADER-VALUE-1"));
+        assertThat(generatedRequest[0].requestHeaders().get("HEADER-2"), is("HEADER-VALUE-2"));
+    }
 }

--- a/plugin-infra/go-plugin-api/src/com/thoughtworks/go/plugin/api/request/DefaultGoPluginApiRequest.java
+++ b/plugin-infra/go-plugin-api/src/com/thoughtworks/go/plugin/api/request/DefaultGoPluginApiRequest.java
@@ -145,4 +145,10 @@ public class DefaultGoPluginApiRequest extends GoPluginApiRequest {
             this.requestParameters = params;
         }
     }
+
+    public void setRequestHeaders(Map<String, String> headers) {
+        if (headers != null) {
+            this.requestHeaders = headers;
+        }
+    }
 }

--- a/plugin-infra/go-plugin-api/test/com/thoughtworks/go/plugin/api/request/DefaultGoPluginApiRequestTest.java
+++ b/plugin-infra/go-plugin-api/test/com/thoughtworks/go/plugin/api/request/DefaultGoPluginApiRequestTest.java
@@ -2,9 +2,11 @@ package com.thoughtworks.go.plugin.api.request;
 
 import org.junit.Test;
 
+import java.util.HashMap;
 import java.util.Map;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
@@ -12,7 +14,7 @@ import static org.junit.Assert.fail;
 public class DefaultGoPluginApiRequestTest {
 
     @Test
-    public void shouldBeInstanceOfGoPluginApiRequest(){
+    public void shouldBeInstanceOfGoPluginApiRequest() {
         DefaultGoPluginApiRequest request = new DefaultGoPluginApiRequest("extension", "1.0", "request-name");
         assertThat(request, instanceOf(GoPluginApiRequest.class));
     }
@@ -64,8 +66,22 @@ public class DefaultGoPluginApiRequestTest {
         String version = "1.0";
         String requestName = "request-name";
         DefaultGoPluginApiRequest request = new DefaultGoPluginApiRequest(extension, version, requestName);
-        assertThat(request.extension(),is(extension));
-        assertThat(request.extensionVersion(),is(version));
-        assertThat(request.requestName(),is(requestName));
+        assertThat(request.extension(), is(extension));
+        assertThat(request.extensionVersion(), is(version));
+        assertThat(request.requestName(), is(requestName));
+    }
+
+    @Test
+    public void shouldAbleToSetRequestHeaders() throws Exception {
+        final DefaultGoPluginApiRequest request = new DefaultGoPluginApiRequest("extension", "1.0", "request-name");
+
+        final Map<String, String> headers = new HashMap();
+        headers.put("HEADER-1", "HEADER-VALUE-1");
+        headers.put("HEADER-2", "HEADER-VALUE-2");
+
+        request.setRequestHeaders(headers);
+
+        assertThat(request.requestHeaders(), hasEntry("HEADER-1", "HEADER-VALUE-1"));
+        assertThat(request.requestHeaders(), hasEntry("HEADER-2", "HEADER-VALUE-2"));
     }
 }


### PR DESCRIPTION
Fixed `PluginRequestHelper` to pass request headers to a plugin. 