### PR TITLE
More logging improvements

### DIFF
--- a/agent-process-launcher/src/com/thoughtworks/go/agent/AgentOutputAppender.java
+++ b/agent-process-launcher/src/com/thoughtworks/go/agent/AgentOutputAppender.java
@@ -29,17 +29,18 @@ public class AgentOutputAppender {
     private static final String LOG_DIR = "LOG_DIR";
 
     enum Outstream {
-        STDOUT(ConsoleAppender.SYSTEM_OUT),
-        STDERR(ConsoleAppender.SYSTEM_ERR);
+        STDOUT(ConsoleAppender.SYSTEM_OUT, "stdout"),
+        STDERR(ConsoleAppender.SYSTEM_ERR, "stderr");
 
         private final String name;
+        private final String marker;
 
-        Outstream(String name) {
+        Outstream(String name, String marker) {
             this.name = name;
+            this.marker = marker;
         }
     }
 
-    private static final PatternLayout LAYOUT = new PatternLayout("%m%n");
     private final List<WriterAppender> appenders = new ArrayList<>();
 
     public AgentOutputAppender(String file) throws IOException {
@@ -47,7 +48,7 @@ public class AgentOutputAppender {
     }
 
     public void writeTo(Outstream target) {
-        appenders.add(new ConsoleAppender(LAYOUT, target.name));
+        appenders.add(new ConsoleAppender(new PatternLayout(target.marker + ": %m%n"), target.name));
     }
 
     public void write(String message, Exception throwable) {
@@ -68,7 +69,7 @@ public class AgentOutputAppender {
     }
 
     private RollingFileAppender rollingAppender(String file) throws IOException {
-        RollingFileAppender rollingFileAppender = new RollingFileAppender(LAYOUT, getEffectiveLogDirectory(file), true);
+        RollingFileAppender rollingFileAppender = new RollingFileAppender(new PatternLayout("%m%n"), getEffectiveLogDirectory(file), true);
         rollingFileAppender.setMaxBackupIndex(4);
         rollingFileAppender.setMaxFileSize("5000KB");
         return rollingFileAppender;

--- a/agent-process-launcher/src/com/thoughtworks/go/agent/AgentProcessParentImpl.java
+++ b/agent-process-launcher/src/com/thoughtworks/go/agent/AgentProcessParentImpl.java
@@ -75,7 +75,7 @@ public class AgentProcessParentImpl implements AgentProcessParent {
             AgentOutputAppender agentOutputAppenderForStdErr = new AgentOutputAppender(GO_AGENT_STDERR_LOG);
             AgentOutputAppender agentOutputAppenderForStdOut = new AgentOutputAppender(GO_AGENT_STDOUT_LOG);
 
-            if (new SystemEnvironment().agentConsoleOutToStdout()) {
+            if (new SystemEnvironment().consoleOutToStdout()) {
                 agentOutputAppenderForStdErr.writeTo(AgentOutputAppender.Outstream.STDERR);
                 agentOutputAppenderForStdOut.writeTo(AgentOutputAppender.Outstream.STDOUT);
             }

--- a/base/src/com/thoughtworks/go/util/SystemEnvironment.java
+++ b/base/src/com/thoughtworks/go/util/SystemEnvironment.java
@@ -209,7 +209,7 @@ public class SystemEnvironment implements Serializable, ConfigDirProvider {
     public static GoBooleanSystemProperty REAUTHENTICATION_ENABLED = new GoBooleanSystemProperty("go.security.reauthentication.enabled", true);
     public static GoSystemProperty<Long> REAUTHENTICATION_TIME_INTERVAL = new GoLongSystemProperty("go.security.reauthentication.interval", 1800 * 1000L);
     public static GoSystemProperty<Boolean> INBUILT_LDAP_PASSWORD_AUTH_ENABLED = new GoBooleanSystemProperty("go.security.inbuilt.auth.enabled", false);
-    public static GoSystemProperty<Boolean> AGENT_CONSOLE_OUT_TO_STDOUT = new GoBooleanSystemProperty("go.agent.console.stdout", false);
+    public static GoSystemProperty<Boolean> CONSOLE_OUT_TO_STDOUT = new GoBooleanSystemProperty("go.console.stdout", false);
 
     private final static Map<String, String> GIT_ALLOW_PROTOCOL;
 
@@ -317,8 +317,8 @@ public class SystemEnvironment implements Serializable, ConfigDirProvider {
         return diskSpaceCacheRefresherInterval = Long.parseLong(getPropertyImpl(DISK_SPACE_CACHE_REFRESHER_INTERVAL, "5000"));
     }
 
-    public boolean agentConsoleOutToStdout() {
-        return get(AGENT_CONSOLE_OUT_TO_STDOUT);
+    public boolean consoleOutToStdout() {
+        return get(CONSOLE_OUT_TO_STDOUT);
     }
 
     //Used in Tests

--- a/plugin-infra/go-plugin-infra/src/com/thoughtworks/go/plugin/infra/service/DefaultPluginLoggingService.java
+++ b/plugin-infra/go-plugin-infra/src/com/thoughtworks/go/plugin/infra/service/DefaultPluginLoggingService.java
@@ -18,10 +18,7 @@ package com.thoughtworks.go.plugin.infra.service;
 
 import com.thoughtworks.go.plugin.internal.api.LoggingService;
 import com.thoughtworks.go.util.SystemEnvironment;
-import org.apache.log4j.FileAppender;
-import org.apache.log4j.Logger;
-import org.apache.log4j.PatternLayout;
-import org.apache.log4j.RollingFileAppender;
+import org.apache.log4j.*;
 
 import java.io.File;
 import java.io.IOException;
@@ -101,6 +98,13 @@ public class DefaultPluginLoggingService implements LoggingService {
             logger.setAdditivity(false);
             logger.setLevel(systemEnvironment.pluginLoggingLevel(pluginId));
             logger.addAppender(pluginAppender);
+
+            if (systemEnvironment.consoleOutToStdout()) {
+                ConsoleAppender consoleAppender = new ConsoleAppender(new PatternLayout("%d{ISO8601} %5p [%t] %c{1}:%L [plugin-" + pluginId + "] - %m%n"));
+                logger.setAdditivity(false);
+                logger.setLevel(systemEnvironment.pluginLoggingLevel(pluginId));
+                logger.addAppender(consoleAppender);
+            }
 
             loggingServiceLogger.debug("Plugin with ID: " + pluginId + " will log to: " + pluginAppender.getFile());
         }


### PR DESCRIPTION
* rename `go.agent.console.stdout` to `go.console.stdout` so it can be
  re-used on server as well.
* redirect plugin logs to STDOUT when system property is set. When
  printing plugin logs to console, add the plugin id in the log
  message.
* agent console output is prefixed with `stdout/stderr` to indicate
  where the output is coming from