### PR TITLE
Fixes css for gear icon in vsm

### DIFF
--- a/server/webapp/WEB-INF/rails.new/app/assets/stylesheets/module.scss
+++ b/server/webapp/WEB-INF/rails.new/app/assets/stylesheets/module.scss
@@ -2612,7 +2612,7 @@ li.task_property {
 
 .vsm-entity h3 {
     background: image_url('andare/ico-16x16.png') no-repeat scroll 0px 0px transparent;
-    padding: 0px 0px 8px 12px;
+    padding: 0px 20px 8px 12px;
     border-bottom: 1px dotted #999;
     font-size: 13px;
     line-height: 16px;


### PR DESCRIPTION
Before 
<img width="582" alt="screen shot 2017-08-29 at 2 02 25 pm" src="https://user-images.githubusercontent.com/23699743/29812128-3a87771a-8cc3-11e7-9a7e-36b33efd0a9c.png">

After
<img width="610" alt="screen shot 2017-08-29 at 2 02 49 pm" src="https://user-images.githubusercontent.com/23699743/29812139-44e50a6a-8cc3-11e7-884a-c1b0644b07bf.png">

