### PR TITLE
Handle boolean and numeric value as a string from JSON to ConfigurationValue.java deserialization

### DIFF
--- a/common/test/unit/com/thoughtworks/go/domain/config/ConfigurationValueTest.java
+++ b/common/test/unit/com/thoughtworks/go/domain/config/ConfigurationValueTest.java
@@ -28,4 +28,28 @@ public class ConfigurationValueTest {
         ConfigurationValue configurationValue = new ConfigurationValue(ConfigurationValue.VALUE);
         assertThat(configurationValue, is(new ConfigurationValue(ConfigurationValue.VALUE)));
     }
+
+    @Test
+    public void shouldHandleBooleanValueAsAString() throws Exception {
+        final ConfigurationValue configurationValue = new ConfigurationValue(true);
+        assertThat(configurationValue.getValue(), is("true"));
+    }
+
+    @Test
+    public void shouldHandleIntegerValueAsAString() throws Exception {
+        final ConfigurationValue configurationValue = new ConfigurationValue(1);
+        assertThat(configurationValue.getValue(), is("1"));
+    }
+
+    @Test
+    public void shouldHandleLongValueAsAString() throws Exception {
+        final ConfigurationValue configurationValue = new ConfigurationValue(5L);
+        assertThat(configurationValue.getValue(), is("5"));
+    }
+
+    @Test
+    public void shouldHandleDoubleValueAsAString() throws Exception {
+        final ConfigurationValue configurationValue = new ConfigurationValue(3.1428571429D);
+        assertThat(configurationValue.getValue(), is("3.1428571429"));
+    }
 }

--- a/config/config-api/src/com/thoughtworks/go/domain/config/ConfigurationValue.java
+++ b/config/config-api/src/com/thoughtworks/go/domain/config/ConfigurationValue.java
@@ -16,9 +16,6 @@
 
 package com.thoughtworks.go.domain.config;
 
-import java.io.Serializable;
-import java.util.Map;
-
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 import com.thoughtworks.go.config.ConfigTag;
@@ -26,6 +23,9 @@ import com.thoughtworks.go.config.ConfigValue;
 import com.thoughtworks.go.config.Validatable;
 import com.thoughtworks.go.config.ValidationContext;
 import com.thoughtworks.go.domain.ConfigErrors;
+
+import java.io.Serializable;
+import java.util.Map;
 
 @ConfigTag("value")
 public class ConfigurationValue implements Serializable, Validatable {
@@ -40,6 +40,14 @@ public class ConfigurationValue implements Serializable, Validatable {
 
     public ConfigurationValue(String value) {
         this.value = value;
+    }
+
+    public ConfigurationValue(boolean value) {
+        this(String.valueOf(value));
+    }
+
+    public ConfigurationValue(Number value) {
+        this(String.valueOf(value));
     }
 
     public ConfigurationValue() {


### PR DESCRIPTION
Handle boolean and numeric value as a string ,which allows to design UI for a plugin  with following html elements

* Html element having numeric value e.g. `<input type=number/>`
* Html element having boolean value e.g. `<input type=checkbox/>`

Previously, it was failing to deserialize JSON to `ConfigurationValue` object with following error:

```
NameError (no constructor for arguments (org.jruby.RubyBoolean.True) on
Java::ComThoughtworksGoDomainConfig::ConfigurationValue):
  app/presenters/api_v1/config/plugin_configuration_property_representer.rb:42:in
`value='
  app/presenters/api_v1/base_representer.rb:104:in `from_hash'
  app/presenters/api_v1/base_representer.rb:104:in `from_hash'
  app/helpers/api_v1/profiles_controller_actions.rb:43:in `create'
  lib/jetty_weak_etag_middleware.rb:35:in `call'
  lib/catch_json_parse_errors.rb:8:in `call'

```