### PR TITLE
Handle NullPointerException under GoCache

### DIFF
--- a/server/src/com/thoughtworks/go/server/cache/GoCache.java
+++ b/server/src/com/thoughtworks/go/server/cache/GoCache.java
@@ -241,6 +241,9 @@ public class GoCache {
     public void remove(String key, String subKey) {
         synchronized (key.intern()) {
             KeyList subKeys = subKeyFamily(key);
+            if(subKeys == null) {
+                return;
+            }
             subKeys.remove(subKey);
             remove(compositeKey(key, subKey));
         }

--- a/server/test/integration/com/thoughtworks/go/server/cache/GoCacheTest.java
+++ b/server/test/integration/com/thoughtworks/go/server/cache/GoCacheTest.java
@@ -242,6 +242,12 @@ public class GoCacheTest {
     }
 
     @Test
+    public void delete_shouldNotThrowAnExceptionWhenNoFamilySubKeysAreFound() {
+        goCache.remove("foo", "baz");
+        assertThat(goCache.get("foo", "baz"), nullValue());
+    }
+
+    @Test
     public void delete_shouldDeleteAllSubValuesForParentKey() {
         goCache.put("foo", "bar", "baz");
         goCache.put("foo", "baz", "quux");


### PR DESCRIPTION
* First create call to any entity using API fails due to 'entity cache removal' request throwing a null pointer exception
  This happens due no no parent key GO_ETAG_CACHE present in the GoCache.
  Check for the parent GO_ETAG_CACHE key before removal of the entity subkey