### PR TITLE
Fix 500 Internal server error on non existing environments API get Call (#3812)

### DIFF
--- a/server/webapp/WEB-INF/rails.new/app/controllers/api_v2/admin/environments_controller.rb
+++ b/server/webapp/WEB-INF/rails.new/app/controllers/api_v2/admin/environments_controller.rb
@@ -77,9 +77,8 @@ module ApiV2
 
       def load_environment(environment_name = params[:name])
         @environment_config = environment_config_service.getEnvironmentForEdit(environment_name)
+        raise RecordNotFound if @environment_config.nil?
         @environment_config.setOrigins(com.thoughtworks.go.config.remote.FileConfigOrigin.new)
-      rescue com.thoughtworks.go.config.exceptions.NoSuchEnvironmentException
-        raise ApiV2::RecordNotFound
       end
 
       def get_environment_from_request

--- a/server/webapp/WEB-INF/rails.new/spec/controllers/api_v2/admin/environments_controller_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/controllers/api_v2/admin/environments_controller_spec.rb
@@ -106,7 +106,7 @@ describe ApiV2::Admin::EnvironmentsController do
         login_as_admin
 
         @environment_name = SecureRandom.hex
-        @environment_config_service.stub(:getEnvironmentForEdit).and_raise(com.thoughtworks.go.config.exceptions.NoSuchEnvironmentException.new(CaseInsensitiveString.new('foo-env')))
+        @environment_config_service.stub(:getEnvironmentForEdit).and_return(nil)
         get_with_api_header :show, name: @environment_name
         expect(response).to have_api_message_response(404, 'Either the resource you requested was not found, or you are not authorized to perform this action.')
       end
@@ -222,7 +222,7 @@ describe ApiV2::Admin::EnvironmentsController do
         login_as_admin
 
         @environment_name = SecureRandom.hex
-        @environment_config_service.stub(:getEnvironmentForEdit).and_raise(com.thoughtworks.go.config.exceptions.NoSuchEnvironmentException.new(CaseInsensitiveString.new('foo-env')))
+        @environment_config_service.stub(:getEnvironmentForEdit).and_return(nil)
         put_with_api_header :put, name: @environment_name
         expect(response).to have_api_message_response(404, 'Either the resource you requested was not found, or you are not authorized to perform this action.')
       end
@@ -333,7 +333,7 @@ describe ApiV2::Admin::EnvironmentsController do
 
       it 'should render 404 when a environment does not exist' do
         @environment_name = SecureRandom.hex
-        @environment_config_service.stub(:getEnvironmentForEdit).and_raise(com.thoughtworks.go.config.exceptions.NoSuchEnvironmentException.new(CaseInsensitiveString.new('foo-env')))
+        @environment_config_service.stub(:getEnvironmentForEdit).and_return(nil)
         patch_with_api_header :patch, name: @environment_name
         expect(response).to have_api_message_response(404, 'Either the resource you requested was not found, or you are not authorized to perform this action.')
       end
@@ -424,7 +424,7 @@ describe ApiV2::Admin::EnvironmentsController do
 
       it 'should render 404 when a environment does not exist' do
         @environment_name = SecureRandom.hex
-        @environment_config_service.stub(:getEnvironmentForEdit).and_raise(com.thoughtworks.go.config.exceptions.NoSuchEnvironmentException.new(CaseInsensitiveString.new('foo-env')))
+        @environment_config_service.stub(:getEnvironmentForEdit).and_return(nil)
         delete_with_api_header :destroy, name: @environment_name
         expect(response).to have_api_message_response(404, 'Either the resource you requested was not found, or you are not authorized to perform this action.')
       end


### PR DESCRIPTION
* environment_config_service#getEnvironmentForEdit returns a null instead of throwing an error
  Check for nil object instead of expecting a NoSuchEnvironmentException exception in case of non-existing environments GET API call