### PR TITLE
[Agent-Server Websocket] Do not mark agent idle on assignWork

### DIFF
--- a/agent/src/com/thoughtworks/go/agent/AgentWebSocketClientController.java
+++ b/agent/src/com/thoughtworks/go/agent/AgentWebSocketClientController.java
@@ -108,7 +108,6 @@ public class AgentWebSocketClientController extends AgentController {
         }
     }
 
-
     void process(Message message) throws InterruptedException {
         switch (message.getAction()) {
             case cancelBuild:
@@ -133,7 +132,6 @@ public class AgentWebSocketClientController extends AgentController {
                             packageRepositoryExtension, scmExtension,
                             taskExtension);
                 } finally {
-                    getAgentRuntimeInfo().idle();
                     updateServerAgentRuntimeInfo();
                 }
                 break;

--- a/agent/test/unit/com/thoughtworks/go/agent/AgentWebSocketClientControllerTest.java
+++ b/agent/test/unit/com/thoughtworks/go/agent/AgentWebSocketClientControllerTest.java
@@ -163,7 +163,7 @@ public class AgentWebSocketClientControllerTest {
         agentController = createAgentController();
         agentController.init();
         agentController.process(new Message(Action.assignWork, MessageEncoding.encodeWork(new SleepWork("work1", 0))));
-        assertThat(agentController.getAgentRuntimeInfo().getRuntimeStatus(), is(AgentRuntimeStatus.Idle));
+        assertThat(agentController.getAgentRuntimeInfo().getRuntimeStatus(), is(AgentRuntimeStatus.Building));
 
         verify(webSocketSessionHandler, times(1)).sendAndWaitForAcknowledgement(argumentCaptor.capture());
         verify(artifactsManipulator).setProperty(null, new Property("work1_result", "done"));
@@ -172,7 +172,6 @@ public class AgentWebSocketClientControllerTest {
         assertThat(message.getAcknowledgementId(), notNullValue());
         assertThat(message.getAction(), is(Action.ping));
         assertThat(message.getData(), is(MessageEncoding.encodeData(agentController.getAgentRuntimeInfo())));
-
     }
 
     @Test
@@ -184,7 +183,7 @@ public class AgentWebSocketClientControllerTest {
         agentController = createAgentController();
         agentController.init();
         agentController.process(new Message(Action.assignWork, MessageEncoding.encodeWork(new SleepWork("work1", 0))));
-        assertThat(agentController.getAgentRuntimeInfo().getRuntimeStatus(), is(AgentRuntimeStatus.Idle));
+        assertThat(agentController.getAgentRuntimeInfo().getRuntimeStatus(), is(AgentRuntimeStatus.Building));
 
         verify(webSocketSessionHandler, times(2)).sendAndWaitForAcknowledgement(argumentCaptor.capture());
         verify(artifactsManipulator).setProperty(null, new Property("work1_result", "done"));
@@ -367,7 +366,7 @@ public class AgentWebSocketClientControllerTest {
         agentController.process(new Message(Action.cancelBuild));
         buildingThread.join(MAX_WAIT_IN_TEST);
 
-        assertThat(agentController.getAgentRuntimeInfo().getRuntimeStatus(), is(AgentRuntimeStatus.Idle));
+        assertThat(agentController.getAgentRuntimeInfo().getRuntimeStatus(), is(AgentRuntimeStatus.Cancelled));
         verify(artifactsManipulator).setProperty(null, new Property("work1_result", "done_canceled"));
     }
 


### PR DESCRIPTION
* On a job assignment to an agent, do not mark it as idle, as it might start reporting incorrect status (reporting idle) which can cause
  server to assign another work to the same agent.