### PR TITLE
Go Server session timeout is configurable now

### DIFF
--- a/app-server/src/com/thoughtworks/go/server/AppServer.java
+++ b/app-server/src/com/thoughtworks/go/server/AppServer.java
@@ -33,7 +33,7 @@ public abstract class AppServer {
 
     abstract void addExtraJarsToClasspath(String extraClasspath);
 
-    abstract void setCookieExpirePeriod(int cookieExpirePeriod);
+    abstract void setSessionAndCookieExpiryTimeout(int sessionAndCookieExpiryTimeout);
 
     abstract void setInitParameter(String name, String value);
 

--- a/base/src/com/thoughtworks/go/util/SystemEnvironment.java
+++ b/base/src/com/thoughtworks/go/util/SystemEnvironment.java
@@ -136,6 +136,7 @@ public class SystemEnvironment implements Serializable, ConfigDirProvider {
     public static GoSystemProperty<Integer> IDLE_TIMEOUT = new GoIntSystemProperty("idle.timeout", 30000);
     public static GoSystemProperty<Integer> RESPONSE_BUFFER_SIZE = new GoIntSystemProperty("response.buffer.size", 32768);
     public static final GoSystemProperty<Integer> API_REQUEST_IDLE_TIMEOUT_IN_SECONDS = new GoIntSystemProperty("api.request.idle.timeout.seconds", 300);
+    public static final GoSystemProperty<Integer> GO_SERVER_SESSION_TIMEOUT_IN_SECONDS = new GoIntSystemProperty("go.server.session.timeout.seconds", 60 * 60 * 24 * 14);
 
     public static GoSystemProperty<Integer> PLUGIN_NOTIFICATION_LISTENER_COUNT = new CachedProperty<>(new GoIntSystemProperty("plugin.notification.listener.count", 1));
 
@@ -818,6 +819,10 @@ public class SystemEnvironment implements Serializable, ConfigDirProvider {
 
     public boolean optimizeFullConfigSave() {
         return OPTIMIZE_FULL_CONFIG_SAVE.getValue();
+    }
+
+    public int sessionTimeoutInSeconds() {
+        return GO_SERVER_SESSION_TIMEOUT_IN_SECONDS.getValue();
     }
 
     public boolean isProductionMode() {

--- a/jetty9/src/com/thoughtworks/go/server/Jetty9Server.java
+++ b/jetty9/src/com/thoughtworks/go/server/Jetty9Server.java
@@ -27,6 +27,7 @@ import org.eclipse.jetty.jmx.MBeanContainer;
 import org.eclipse.jetty.server.Connector;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.SessionManager;
 import org.eclipse.jetty.server.handler.AbstractHandler;
 import org.eclipse.jetty.server.handler.ContextHandler;
 import org.eclipse.jetty.server.handler.HandlerCollection;
@@ -106,10 +107,12 @@ public class Jetty9Server extends AppServer {
     }
 
     @Override
-    public void setCookieExpirePeriod(int cookieExpirePeriod) {
+    public void setCookieExpirePeriod(int sessionTimeoutInSeconds) {
         SessionCookieConfig cookieConfig = webAppContext.getSessionHandler().getSessionManager().getSessionCookieConfig();
         cookieConfig.setHttpOnly(true);
-        cookieConfig.setMaxAge(cookieExpirePeriod);
+        cookieConfig.setMaxAge(sessionTimeoutInSeconds);
+        SessionManager sessionManager = webAppContext.getSessionHandler().getSessionManager();
+        sessionManager.setMaxInactiveInterval(sessionTimeoutInSeconds);
     }
 
     @Override

--- a/jetty9/src/com/thoughtworks/go/server/Jetty9Server.java
+++ b/jetty9/src/com/thoughtworks/go/server/Jetty9Server.java
@@ -107,12 +107,12 @@ public class Jetty9Server extends AppServer {
     }
 
     @Override
-    public void setCookieExpirePeriod(int sessionTimeoutInSeconds) {
+    public void setSessionAndCookieExpiryTimeout(int sessionAndCookieExpiryTimeout) {
         SessionCookieConfig cookieConfig = webAppContext.getSessionHandler().getSessionManager().getSessionCookieConfig();
         cookieConfig.setHttpOnly(true);
-        cookieConfig.setMaxAge(sessionTimeoutInSeconds);
+        cookieConfig.setMaxAge(sessionAndCookieExpiryTimeout);
         SessionManager sessionManager = webAppContext.getSessionHandler().getSessionManager();
-        sessionManager.setMaxInactiveInterval(sessionTimeoutInSeconds);
+        sessionManager.setMaxInactiveInterval(sessionAndCookieExpiryTimeout);
     }
 
     @Override

--- a/jetty9/test/com/thoughtworks/go/server/Jetty9ServerTest.java
+++ b/jetty9/test/com/thoughtworks/go/server/Jetty9ServerTest.java
@@ -281,7 +281,7 @@ public class Jetty9ServerTest {
         int sessionTimeoutInSeconds = 1234;
 
         jetty9Server.configure();
-        jetty9Server.setCookieExpirePeriod(sessionTimeoutInSeconds);
+        jetty9Server.setSessionAndCookieExpiryTimeout(sessionTimeoutInSeconds);
 
         WebAppContext webAppContext = getWebAppContext(jetty9Server);
         assertThat(webAppContext.getSessionHandler().getSessionManager().getMaxInactiveInterval(), is(1234));

--- a/jetty9/test/com/thoughtworks/go/server/Jetty9ServerTest.java
+++ b/jetty9/test/com/thoughtworks/go/server/Jetty9ServerTest.java
@@ -277,6 +277,17 @@ public class Jetty9ServerTest {
     }
 
     @Test
+    public void shouldSetSessionMaxInactiveInterval() throws Exception {
+        int sessionTimeoutInSeconds = 1234;
+
+        jetty9Server.configure();
+        jetty9Server.setCookieExpirePeriod(sessionTimeoutInSeconds);
+
+        WebAppContext webAppContext = getWebAppContext(jetty9Server);
+        assertThat(webAppContext.getSessionHandler().getSessionManager().getMaxInactiveInterval(), is(1234));
+    }
+
+    @Test
     public void shouldAddExtraJarsIntoClassPath() throws Exception {
         jetty9Server.configure();
         jetty9Server.addExtraJarsToClasspath("test-addons/some-addon-dir/addon-1.JAR,test-addons/some-addon-dir/addon-2.jar");

--- a/server/src/com/thoughtworks/go/server/GoServer.java
+++ b/server/src/com/thoughtworks/go/server/GoServer.java
@@ -83,7 +83,7 @@ public class GoServer {
         AppServer server = ((AppServer) constructor.newInstance(systemEnvironment, password, sslSocketFactory));
         server.configure();
         server.addExtraJarsToClasspath(getExtraJarsToBeAddedToClasspath());
-        server.setCookieExpirePeriod(systemEnvironment.sessionTimeoutInSeconds());
+        server.setSessionAndCookieExpiryTimeout(systemEnvironment.sessionTimeoutInSeconds());
         return server;
     }
 

--- a/server/src/com/thoughtworks/go/server/GoServer.java
+++ b/server/src/com/thoughtworks/go/server/GoServer.java
@@ -83,12 +83,8 @@ public class GoServer {
         AppServer server = ((AppServer) constructor.newInstance(systemEnvironment, password, sslSocketFactory));
         server.configure();
         server.addExtraJarsToClasspath(getExtraJarsToBeAddedToClasspath());
-        server.setCookieExpirePeriod(twoWeeks());
+        server.setCookieExpirePeriod(systemEnvironment.sessionTimeoutInSeconds());
         return server;
-    }
-
-    private int twoWeeks() {
-        return 60 * 60 * 24 * 14;
     }
 
     private String getExtraJarsToBeAddedToClasspath() {

--- a/server/test/unit/com/thoughtworks/go/server/AppServerStub.java
+++ b/server/test/unit/com/thoughtworks/go/server/AppServerStub.java
@@ -35,8 +35,8 @@ public class AppServerStub extends AppServer {
     }
 
     @Override
-    void setCookieExpirePeriod(int cookieExpirePeriod) {
-        calls.put("setCookieExpirePeriod", cookieExpirePeriod);
+    void setSessionAndCookieExpiryTimeout(int sessionAndCookieExpiryTimeout) {
+        calls.put("setSessionAndCookieExpiryTimeout", sessionAndCookieExpiryTimeout);
     }
 
     @Override

--- a/server/test/unit/com/thoughtworks/go/server/GoServerTest.java
+++ b/server/test/unit/com/thoughtworks/go/server/GoServerTest.java
@@ -117,7 +117,7 @@ public class GoServerTest {
         AppServerStub appServerStub = (AppServerStub) appServer;
 
         assertThat(appServerStub.calls.get("addExtraJarsToClasspath"), is(""));
-        assertThat(appServerStub.calls.get("setCookieExpirePeriod"), is(1209600));
+        assertThat(appServerStub.calls.get("setSessionAndCookieExpiryTimeout"), is(1209600));
         assertThat(appServerStub.calls.get("getUnavailableException"), is(true));
         assertThat(appServerStub.calls.get("configure"), is(true));
         assertThat(appServerStub.calls.get("start"), is(true));

--- a/server/webapp/WEB-INF/web.xml
+++ b/server/webapp/WEB-INF/web.xml
@@ -350,9 +350,7 @@
     <mime-type>image/svg+xml</mime-type>
   </mime-mapping>
 
-  <!-- Do not timeout idle/stale sessions for 14 days: 60 * 24 * 14 minutes. -->
   <session-config>
-    <session-timeout>20160</session-timeout>
     <tracking-mode>COOKIE</tracking-mode>
   </session-config>
 </web-app>


### PR DESCRIPTION
* Session `MaxInactiveInterval` can be configured using the system property `go.server.session.timeout.seconds` defaulted to 1209600 seconds(two weeks)