### PR TITLE
Silence some exceptions on server startup

### DIFF
--- a/config/config-server/src/com/thoughtworks/go/service/ConfigRepository.java
+++ b/config/config-server/src/com/thoughtworks/go/service/ConfigRepository.java
@@ -25,6 +25,7 @@ import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang.NullArgumentException;
 import org.eclipse.jgit.api.*;
 import org.eclipse.jgit.api.errors.GitAPIException;
+import org.eclipse.jgit.api.errors.NoHeadException;
 import org.eclipse.jgit.diff.DiffFormatter;
 import org.eclipse.jgit.errors.IncorrectObjectTypeException;
 import org.eclipse.jgit.errors.MissingObjectException;
@@ -174,6 +175,8 @@ public class ConfigRepository {
                 RevCommit revision;
                 try {
                     revision = getCurrentRevCommit();
+                } catch (NoHeadException e) {
+                    return null;
                 } catch (GitAPIException e) {
                     LOGGER.info("[CONFIG REPOSITORY] Unable retrieve current cruise config revision", e);
                     return null;
@@ -187,6 +190,10 @@ public class ConfigRepository {
     public RevCommit getCurrentRevCommit() throws GitAPIException {
         try {
             return revisions().iterator().next();
+        } catch (NoHeadException e) {
+            // don't log scary exception
+            LOGGER.warn("[CONFIG REPOSITORY] No head exists in the config repository.");
+            throw e;
         } catch (GitAPIException e) {
             LOGGER.error("[CONFIG REPOSITORY] Could not fetch latest commit id", e);
             throw e;

--- a/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/common/PluginInfoBuilder.java
+++ b/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/common/PluginInfoBuilder.java
@@ -52,7 +52,8 @@ public interface PluginInfoBuilder<T extends PluginInfo> {
             }
             pluggableInstanceSettings = new PluggableInstanceSettings(configurations(pluginSettingsConfiguration), new PluginView(pluginSettingsView));
         } catch (Exception e) {
-            LOGGER.warn("Plugin settings configuration and view could not be retrieved. May be because the plugin doesn't have any plugin settings", e);
+            LOGGER.error("Failed to fetch Plugin Settings metadata for plugin {}. Maybe the plugin does not implement plugin settings and view?", descriptor.id());
+            LOGGER.debug(null, e);
         }
         return pluggableInstanceSettings;
     }

--- a/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/common/settings/PluginSettingsMetadataLoader.java
+++ b/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/common/settings/PluginSettingsMetadataLoader.java
@@ -72,7 +72,8 @@ public class PluginSettingsMetadataLoader implements PluginChangeListener {
             }
             metadataStore.addMetadataFor(pluginId, configuration, view);
         } catch (Exception e) {
-            LOGGER.error("Failed to fetch Plugin Settings metadata for plugin : {}", pluginId, e);
+            LOGGER.error("Failed to fetch Plugin Settings metadata for plugin {}. Maybe the plugin does not implement plugin settings and view?", pluginId);
+            LOGGER.debug(null, e);
         }
     }
 }


### PR DESCRIPTION
(Addresses parts of #3754)

On startup the server is sending the plugin settings config and view
messages to all plugins to build plugin info objects. This call blows up
for atleast the task and authorization plugins because these calls are
not supported. Not making these calls will silence some of the
exceptions on startup.