### PR TITLE
Fixed a race condition between rescheduleHungJobs and rescheduleAbandonedBuildIfNecessary

### DIFF
--- a/server/src/com/thoughtworks/go/server/service/ScheduleService.java
+++ b/server/src/com/thoughtworks/go/server/service/ScheduleService.java
@@ -629,7 +629,7 @@ public class ScheduleService {
                         LOGGER.warn("[Job Reschedule] Rescheduling and marking old job as ignored: {}", toBeRescheduled);
                         //Reloading it because we want to see the latest committed state after acquiring the mutex.
                         JobInstance oldJob = jobInstanceService.buildById(toBeRescheduled.getId());
-                        if (oldJob.isCompleted()) {
+                        if (oldJob.isCompleted() || oldJob.isRescheduled()) {
                             return;
                         }
                         JobInstance newJob = oldJob.clone();


### PR DESCRIPTION
`ScheduleService#rescheduleHungJobs()` and `ScheduleService#rescheduleAbandonedBuildIfNecessary()` threads invoke rescheduleJob. The threads could have run the queries and gotten the same jobid from the corresponding queries, one of them acquires a lock first and takes care of rescheduling the job. The other thread would wait for its turn, and then enter the sync block and try to do the same causing a rescheduled job to be rescheduled twice. While this can happen for legacy agents too, its seen more often when websocket is turned on