### PR TITLE
Plugin SPA minor fixes

### DIFF
--- a/server/webapp/WEB-INF/applicationContext-acegi-security.xml
+++ b/server/webapp/WEB-INF/applicationContext-acegi-security.xml
@@ -278,7 +278,7 @@
                 /api/admin/config_repos=ROLE_SUPERVISOR
                 /api/elastic/profiles/**=ROLE_SUPERVISOR, ROLE_GROUP_SUPERVISOR
                 /admin/elastic_profiles/**=ROLE_SUPERVISOR, ROLE_GROUP_SUPERVISOR
-                /admin/new_plugins/**=ROLE_SUPERVISOR
+                /admin/new_plugins/**=ROLE_SUPERVISOR, ROLE_GROUP_SUPERVISOR
                 /api/admin/templates/**=ROLE_USER
                 /api/admin/**=ROLE_SUPERVISOR
                 /api/config-repository.git/**=ROLE_SUPERVISOR

--- a/server/webapp/WEB-INF/rails.new/app/assets/new_stylesheets/single_page_apps/plugins.scss
+++ b/server/webapp/WEB-INF/rails.new/app/assets/new_stylesheets/single_page_apps/plugins.scss
@@ -35,6 +35,10 @@ $elastic-profile-icon-hover-color: #000;
   position: relative;
   top:      -2px;
   right:    8px;
+
+  &.disabled {
+    background: $light-grey;
+  }
 }
 
 .plugin {
@@ -145,4 +149,11 @@ $elastic-profile-icon-hover-color: #000;
   &:before {
     margin: 0;
   }
+}
+
+.unknown-plugin-icon-bundled, .unknown-plugin-icon-default {
+  width:          $elastic-profile-plugin-icon-size;
+  height:         $elastic-profile-plugin-icon-size;
+  display:        inline-block;
+  vertical-align: middle;
 }

--- a/server/webapp/WEB-INF/rails.new/app/controllers/admin/plugins_controller.rb
+++ b/server/webapp/WEB-INF/rails.new/app/controllers/admin/plugins_controller.rb
@@ -16,13 +16,14 @@
 
 module Admin
   class PluginsController < ::ApplicationController
-    include AuthenticationHelper
+    include AuthenticationHelper, ApplicationHelper
 
     layout 'single_page_app'
-    before_action :check_admin_user_and_401
+    before_action :check_admin_user_or_group_admin_user_and_401
 
     def index
       @view_title = 'Plugins'
+      @is_user_an_admin = is_user_an_admin?
     end
   end
 end

--- a/server/webapp/WEB-INF/rails.new/app/views/admin/plugins/index.html.erb
+++ b/server/webapp/WEB-INF/rails.new/app/views/admin/plugins/index.html.erb
@@ -1,3 +1,5 @@
-<div id="plugins">
+<div id="plugins"
+     is-user_an_admin="<%= @is_user_an_admin %>"
+>
   <span class="page-spinner"></span>
 </div>

--- a/server/webapp/WEB-INF/rails.new/spec/webpack/views/plugins/plugins_widget_spec.js
+++ b/server/webapp/WEB-INF/rails.new/spec/webpack/views/plugins/plugins_widget_spec.js
@@ -157,16 +157,18 @@ describe("PluginsWidget", () => {
   };
 
   const allPluginInfosJSON = [githubAuthPluginInfoJSON, githubScmPluginInfoJSON, yumPluginInfoJSON];
-  const allPluginInfos     = Stream(PluginInfos.fromJSON([]));
+  const pluginInfos     = Stream(PluginInfos.fromJSON([]));
+  const isUserAnAdmin      = Stream('true' === 'true');
 
   beforeEach(() => {
     jasmine.Ajax.install();
-    allPluginInfos(PluginInfos.fromJSON(allPluginInfosJSON));
+    pluginInfos(PluginInfos.fromJSON(allPluginInfosJSON));
 
     m.mount(root, {
       view() {
         return m(PluginsWidget, {
-          pluginInfos: allPluginInfos
+          pluginInfos,
+          isUserAnAdmin
         });
       }
     });

--- a/server/webapp/WEB-INF/rails.new/webpack/models/shared/plugin_infos.js
+++ b/server/webapp/WEB-INF/rails.new/webpack/models/shared/plugin_infos.js
@@ -81,6 +81,8 @@ PluginInfos.PluginInfo = function (type, {id, about, pluginSettings, imageUrl, s
 
   this.isActive = () => this.status().state() === 'active';
 
+  this.isBundled = () =>  this.bundledPlugin() === true;
+
   this.hasErrors = () => this.status().state() === 'invalid';
 
   this.suportsPluginSettings = () => !!this.pluginSettings;

--- a/server/webapp/WEB-INF/rails.new/webpack/single_page_apps/plugins.js
+++ b/server/webapp/WEB-INF/rails.new/webpack/single_page_apps/plugins.js
@@ -24,13 +24,16 @@ require('foundation-sites');
 
 $(() => {
   $(document).foundation();
+  const pluginElement = $('#plugins');
+  const isUserAnAdmin = pluginElement.attr('is-user-an-admin');
   new VersionUpdater().update();
 
   const onSuccess = (pluginInfos) => {
     const component = {
       view() {
         return m(PluginsWidget, {
-          pluginInfos: Stream(pluginInfos)
+          pluginInfos: Stream(pluginInfos),
+          isUserAnAdmin: Stream(isUserAnAdmin === 'true')
         });
       }
     };

--- a/server/webapp/WEB-INF/rails.new/webpack/views/plugins/plugin_widget.js.msx
+++ b/server/webapp/WEB-INF/rails.new/webpack/views/plugins/plugin_widget.js.msx
@@ -27,7 +27,7 @@ const PluginWidget = {
     ComponentMixins.HasViewModel.call(this);
     const vmStateKey = `show-${vnode.attrs.pluginInfo.id()}`;
 
-    this.vmState(vmStateKey, Stream(false));
+    this.vmState(vmStateKey, Stream(!vnode.attrs.pluginInfo.isActive()));
 
     this.toggleHide = function () {
       this.vmState(vmStateKey)(!this.vmState(vmStateKey)());
@@ -44,29 +44,40 @@ const PluginWidget = {
 
     if (pluginInfo.imageUrl()) {
       image = <img src={pluginInfo.imageUrl()}/>;
+    } else if (pluginInfo.isBundled()) {
+      image = <img src="../assets/andare/icon-plugin-default-bundled.png" class="unknown-plugin-icon-bundled"/>;
     } else {
-      image = <span class="unknown-plugin-icon"/>;
+      image = <img src="../assets/andare/icon-plugin-default.png" class="unknown-plugin-icon-default"/>;
     }
 
-    if (pluginInfo.capabilities && pluginInfo.capabilities().supportsStatusReport && pluginInfo.capabilities().supportsStatusReport()) {
-      const statusReportHref = Routes.adminStatusReportPath(pluginInfo.id());
-      statusReportLink = (
+    const statusReport = pluginInfo.capabilities && pluginInfo.capabilities().supportsStatusReport && pluginInfo.capabilities().supportsStatusReport();
+
+    actionIcons = (<div class="plugin-actions">
+    </div>);
+
+    const editPluginSettingsLink = vnode.attrs.isUserAnAdmin() ? (
+      <f.link class='edit-plugin' onclick={vnode.attrs.onEdit}/>) : (
+      <f.link class='edit-plugin disabled' title="Not allowed to edit plugin settings"/>);
+
+
+    if (pluginInfo.isActive()) {
+      if (statusReport && vnode.attrs.isUserAnAdmin()) {
+        const statusReportHref = Routes.adminStatusReportPath(pluginInfo.id());
+        statusReportLink       = (
           <f.anchor href={statusReportHref} class='btn-primary btn-small status-report-btn'>Status Report</f.anchor>
-      );
-    }
-    actionIcons = (
-      <div class="plugin-actions">
-        {statusReportLink}
-        <f.link class='edit-plugin' onclick={vnode.attrs.onEdit}/>
-      </div>
-    );
+        );
+      }
+      else if (statusReport) {
+        statusReportLink = (
+          <span class='btn-primary btn-small status-report-btn disabled' title="Not allowed to view status report">
+            Status Report</span>
+        );
+      }
 
-    if (!pluginInfo.isActive() || !pluginInfo.suportsPluginSettings()) {
-      actionIcons = (
-        <div class="plugin-actions">
-          {statusReportLink}
-        </div>
-      );
+      actionIcons = (<div class="plugin-actions">
+        {statusReportLink}
+        {editPluginSettingsLink}
+      </div>);
     }
 
     if (pluginInfo.hasErrors()) {

--- a/server/webapp/WEB-INF/rails.new/webpack/views/plugins/plugins_widget.js.msx
+++ b/server/webapp/WEB-INF/rails.new/webpack/views/plugins/plugins_widget.js.msx
@@ -183,6 +183,7 @@ const PluginsWidget = {
                   key={pluginInfo.id()}
                   vm={vnode.state.vmState(pluginInfo.id())}
                   onEdit={vnode.state.edit.bind(vnode.state, pluginInfo)}
+                  isUserAnAdmin={vnode.attrs.isUserAnAdmin}
                 />
               );
             })}


### PR DESCRIPTION
* Allow group admins to access the plugins SPA, but not to edit settings.
* Expand accordion of invalid plugin by default, change icons to differentiate between bundled plugins and unknown plugins.