### PR TITLE
Fixed VSM rendering for local pipelines

### DIFF
--- a/server/src/com/thoughtworks/go/server/service/GoConfigService.java
+++ b/server/src/com/thoughtworks/go/server/service/GoConfigService.java
@@ -154,7 +154,7 @@ public class GoConfigService implements Initializer, CruiseConfigProvider {
         } catch (PipelineNotFoundException e) {
             return false;
         }
-        return pipelineConfig != null && pipelineConfig.getOrigin().canEdit() && isUserAdminOfGroup(username.getUsername(), findGroupNameByPipeline(pipelineConfig.name()));
+        return pipelineConfig != null && pipelineConfig.isLocal() && isUserAdminOfGroup(username.getUsername(), findGroupNameByPipeline(pipelineConfig.name()));
     }
 
     public boolean canEditPipeline(String pipelineName, Username username, LocalizedOperationResult result, String groupName) {

--- a/server/test/unit/com/thoughtworks/go/server/service/GoConfigServiceTest.java
+++ b/server/test/unit/com/thoughtworks/go/server/service/GoConfigServiceTest.java
@@ -1211,13 +1211,13 @@ public class GoConfigServiceTest {
     }
 
     @Test
-    public void shouldBeAbleToEditAExistentPipelineWithAdminPrivileges() throws Exception {
+    public void shouldBeAbleToEditAnExistentLocalPipelineWithAdminPrivileges() throws Exception {
         CruiseConfig cruiseConfig = mock(CruiseConfig.class);
+        PipelineConfig pipeline = new PipelineConfig();
+        pipeline.setName("pipeline1");
+        pipeline.setOrigin(null);
 
         when(goConfigDao.load()).thenReturn(cruiseConfig);
-        PipelineConfig pipeline = new PipelineConfig();
-        pipeline.setOrigin(new FileConfigOrigin());
-        pipeline.setName("pipeline1");
         when(cruiseConfig.pipelineConfigByName(new CaseInsensitiveString("pipeline1"))).thenReturn(pipeline);
         when(cruiseConfig.getGroups()).thenReturn(new GoConfigMother().cruiseConfigWithOnePipelineGroup().getGroups());
         when(cruiseConfig.isAdministrator("admin_user")).thenReturn(true);
@@ -1238,11 +1238,10 @@ public class GoConfigServiceTest {
     @Test
     public void shouldNotBeAbleToEditPipelineIfUserDoesNotHaveSufficientPermissions() throws Exception {
         CruiseConfig cruiseConfig = mock(CruiseConfig.class);
+        PipelineConfig pipeline = new PipelineConfig();
+        pipeline.setName("pipeline1");
 
         when(goConfigDao.load()).thenReturn(cruiseConfig);
-        PipelineConfig pipeline = new PipelineConfig();
-        pipeline.setOrigin(new FileConfigOrigin());
-        pipeline.setName("pipeline1");
         when(cruiseConfig.pipelineConfigByName(new CaseInsensitiveString("pipeline1"))).thenReturn(pipeline);
         BasicCruiseConfig basicCruiseConfig = new GoConfigMother().cruiseConfigWithOnePipelineGroup();
         when(cruiseConfig.getGroups()).thenReturn(basicCruiseConfig.getGroups());


### PR DESCRIPTION
* As part of 'canEditPipeline' pipeline_config orgin was used to make a
  local check. For pipeline defined in cruise_config.xml origin could be
  null and hence the request would throw a null pointer exception. Using
  the isLocal() method on PipelineConfig which handles null origins.