### PR TITLE
Allow agent to re-registration only if agent is having auto registration key.

### DIFF
--- a/server/src/com/thoughtworks/go/server/controller/AgentRegistrationController.java
+++ b/server/src/com/thoughtworks/go/server/controller/AgentRegistrationController.java
@@ -54,8 +54,7 @@ import java.io.InputStream;
 import java.util.List;
 import java.util.Map;
 
-import static org.apache.commons.lang.StringUtils.isBlank;
-import static org.apache.commons.lang.StringUtils.isNotBlank;
+import static org.apache.commons.lang.StringUtils.*;
 
 @Controller
 public class AgentRegistrationController {
@@ -192,36 +191,26 @@ public class AgentRegistrationController {
         final String ipAddress = request.getRemoteAddr();
         LOG.debug("Processing registration request from agent [{}/{}]", hostname, ipAddress);
         Registration keyEntry;
-        String preferredHostname = hostname;
 
         try {
-            if (goConfigService.serverConfig().shouldAutoRegisterAgentWith(agentAutoRegisterKey)) {
-                preferredHostname = getPreferredHostname(agentAutoRegisterHostname, hostname);
-                LOG.info("[Agent Auto Registration] Auto registering agent with uuid {} ", uuid);
-            } else {
-                if (elasticAgentAutoregistrationInfoPresent(elasticAgentId, elasticPluginId)) {
-                    throw new RuntimeException(String.format("Elastic agent registration requires an auto-register agent key to be setup on the server. Agent-id: [%s], Plugin-id: [%s]", elasticAgentId, elasticPluginId));
-                }
-            }
+            final boolean shouldAutoRegisterAgent = goConfigService.serverConfig().shouldAutoRegisterAgentWith(agentAutoRegisterKey);
+
+            validateAgentRegistrationRequest(uuid, shouldAutoRegisterAgent, elasticAgentId, elasticPluginId);
+
+            final String preferredHostname = getPreferredHostname(agentAutoRegisterHostname, hostname);
 
             AgentConfig agentConfig = new AgentConfig(uuid, preferredHostname, ipAddress);
+            agentConfig.setElasticAgentId(stripToNull(elasticAgentId));
+            agentConfig.setElasticPluginId(stripToNull(elasticPluginId));
 
-            if (partialElasticAgentAutoregistrationInfo(elasticAgentId, elasticPluginId)) {
-                throw new RuntimeException("Elastic agents must submit both elasticAgentId and elasticPluginId");
-            }
-
-            if (elasticAgentAutoregistrationInfoPresent(elasticAgentId, elasticPluginId)) {
-                agentConfig.setElasticAgentId(elasticAgentId);
-                agentConfig.setElasticPluginId(elasticPluginId);
-            }
-
-            if (goConfigService.serverConfig().shouldAutoRegisterAgentWith(agentAutoRegisterKey)) {
+            if (shouldAutoRegisterAgent) {
                 LOG.info("[Agent Auto Registration] Auto registering agent with uuid {} ", uuid);
                 GoConfigDao.CompositeConfigCommand compositeConfigCommand = new GoConfigDao.CompositeConfigCommand(
                         new AgentConfigService.AddAgentCommand(agentConfig),
                         new UpdateResourceCommand(uuid, agentAutoRegisterResources),
                         new UpdateEnvironmentsCommand(uuid, agentAutoRegisterEnvironments)
                 );
+
                 HttpOperationResult result = new HttpOperationResult();
                 agentConfig = agentConfigService.updateAgent(compositeConfigCommand, uuid, result, agentService.agentUsername(uuid, ipAddress, preferredHostname));
                 if (!result.isSuccess()) {
@@ -235,22 +224,41 @@ public class AgentRegistrationController {
                 }
             }
 
-            boolean registeredAlready = goConfigService.hasAgent(uuid);
-            long usablespace = Long.parseLong(usablespaceAsString);
+            final long usableSpace = Long.parseLong(usablespaceAsString);
 
-            AgentRuntimeInfo agentRuntimeInfo = AgentRuntimeInfo.fromServer(agentConfig, registeredAlready, location, usablespace, operatingSystem, supportsBuildCommandProtocol, timeProvider);
+            AgentRuntimeInfo agentRuntimeInfo = AgentRuntimeInfo.fromServer(agentConfig, goConfigService.hasAgent(uuid), location, usableSpace, operatingSystem, supportsBuildCommandProtocol, timeProvider);
 
-            if (elasticAgentAutoregistrationInfoPresent(elasticAgentId, elasticPluginId)) {
+            if (isElasticAgent(elasticAgentId, elasticPluginId)) {
                 agentRuntimeInfo = ElasticAgentRuntimeInfo.fromServer(agentRuntimeInfo, elasticAgentId, elasticPluginId, timeProvider);
             }
 
             keyEntry = agentService.requestRegistration(agentService.agentUsername(uuid, ipAddress, preferredHostname), agentRuntimeInfo);
         } catch (Exception e) {
             keyEntry = Registration.createNullPrivateKeyEntry();
-            LOG.error("Error occured during agent registration process: ", e);
+            LOG.error("Error occurred during agent registration process: ", e);
         }
 
         return render(keyEntry);
+    }
+
+    private void validateAgentRegistrationRequest(String agentUUID, boolean shouldAutoRegisterAgent, String elasticAgentId, String elasticPluginId) {
+
+        if (goConfigService.hasAgent(agentUUID) && !shouldAutoRegisterAgent) {
+            throw new RuntimeException(String.format("Agent [%s] is already registered with server. Agent registration requires an auto-register key and it must match the auto-register key setup on the server.", agentUUID));
+        }
+
+        if (isElasticAgent(elasticAgentId, elasticPluginId) && !shouldAutoRegisterAgent) {
+            throw new RuntimeException(String.format("Elastic agent registration requires an auto-register key and it must match the auto-register key setup on the server. Agent-id: [%s], Plugin-id: [%s]", elasticAgentId, elasticPluginId));
+        }
+
+        if (partialElasticAgentInfo(elasticAgentId, elasticAgentId)) {
+            throw new RuntimeException("Elastic agents must submit both elasticAgentId and elasticPluginId");
+        }
+
+    }
+
+    private boolean isElasticAgent(String elasticAgentId, String elasticPluginId) {
+        return isNotBlank(elasticAgentId) || isNotBlank(elasticPluginId);
     }
 
     private ModelAndView render(final Registration registration) {
@@ -276,12 +284,8 @@ public class AgentRegistrationController {
         }
     }
 
-    private boolean partialElasticAgentAutoregistrationInfo(String elasticAgentId, String elasticPluginId) {
+    private boolean partialElasticAgentInfo(String elasticAgentId, String elasticPluginId) {
         return (isBlank(elasticAgentId) && isNotBlank(elasticPluginId)) || (isNotBlank(elasticAgentId) && isBlank(elasticPluginId));
-    }
-
-    private boolean elasticAgentAutoregistrationInfoPresent(String elasticAgentId, String elasticPluginId) {
-        return isNotBlank(elasticAgentId) && isNotBlank(elasticPluginId);
     }
 
     private String getPreferredHostname(String agentAutoRegisterHostname, String hostname) {

--- a/server/src/com/thoughtworks/go/server/service/AgentConfigService.java
+++ b/server/src/com/thoughtworks/go/server/service/AgentConfigService.java
@@ -240,15 +240,14 @@ public class AgentConfigService {
         EntityConfigUpdateCommand<Agents> agentsEntityConfigUpdateCommand = new AgentsEntityConfigUpdateCommand(agentInstances, username, result, uuids, environmentsToAdd, environmentsToRemove, enable, resourcesToAdd, resourcesToRemove, goConfigService);
         try {
             goConfigService.updateConfig(agentsEntityConfigUpdateCommand, username);
-            if(result.isSuccessful()){
+            if (result.isSuccessful()) {
                 result.setMessage(successMessage);
             }
         } catch (Exception e) {
             LOGGER.error("There was an error bulk updating agents", e);
-            if(e instanceof GoConfigInvalidException && !result.hasMessage()) {
+            if (e instanceof GoConfigInvalidException && !result.hasMessage()) {
                 result.unprocessableEntity(LocalizedMessage.string("ENTITY_CONFIG_VALIDATION_FAILED", Agents.class.getAnnotation(ConfigTag.class).value(), uuids, e.getMessage()));
-            }
-            else if(!result.hasMessage()) {
+            } else if (!result.hasMessage()) {
                 result.internalServerError(LocalizedMessage.string("INTERNAL_SERVER_ERROR"));
             }
         }

--- a/server/test/integration/com/thoughtworks/go/server/controller/AgentRegistrationControllerIntegrationTest.java
+++ b/server/test/integration/com/thoughtworks/go/server/controller/AgentRegistrationControllerIntegrationTest.java
@@ -16,19 +16,34 @@
 
 package com.thoughtworks.go.server.controller;
 
+import com.rits.cloning.Cloner;
 import com.thoughtworks.go.config.AgentConfig;
+import com.thoughtworks.go.domain.AgentConfigStatus;
+import com.thoughtworks.go.domain.AgentRuntimeStatus;
+import com.thoughtworks.go.security.Registration;
+import com.thoughtworks.go.security.RegistrationJSONizer;
+import com.thoughtworks.go.server.service.AgentRuntimeInfo;
+import com.thoughtworks.go.server.service.AgentService;
 import com.thoughtworks.go.server.service.GoConfigService;
+import com.thoughtworks.go.util.SystemEnvironment;
+import com.thoughtworks.go.util.TimeProvider;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.web.servlet.ModelAndView;
 
+import java.io.IOException;
+import java.util.Properties;
 import java.util.UUID;
 
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
+import static org.junit.Assert.*;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(locations = {
@@ -38,24 +53,143 @@ import static org.junit.Assert.assertThat;
         "classpath:WEB-INF/spring-pages-servlet.xml"
 })
 public class AgentRegistrationControllerIntegrationTest {
-    @Autowired private AgentRegistrationController controller;
-    @Autowired private GoConfigService goConfigService;
+    @Autowired
+    private AgentRegistrationController controller;
+    @Autowired
+    private GoConfigService goConfigService;
+    @Autowired
+    private AgentService agentService;
+    @Autowired
+    private TimeProvider timeProvider;
+
+    static final Cloner CLONER = new Cloner();
+    private Properties original;
+
+    @Before
+    public void before() {
+        original = CLONER.deepClone(System.getProperties());
+    }
+
+    @After
+    public void after() {
+        System.setProperties(original);
+    }
 
     @Test
-    public void shouldRegisterAgent() throws Exception {
-        String uuid = UUID.randomUUID().toString();
-        MockHttpServletRequest request = new MockHttpServletRequest();
-        controller.agentRequest("hostname", uuid, "sandbox", "100", null, null, null, null, null, null, null, false, request);
-        AgentConfig agentConfig = goConfigService.agentByUuid(uuid);
-        assertThat(agentConfig.getHostname(), is("hostname"));
+    public void shouldRegisterAgentInPendingStateWhenLocalAgentAutoRegistrationIsDisabled() throws Exception {
+        System.setProperty(SystemEnvironment.AUTO_REGISTER_LOCAL_AGENT_ENABLED.propertyName(), "false");
+        final MockHttpServletRequest request = new MockHttpServletRequest();
+        final String uuid = UUID.randomUUID().toString();
+
+        final ModelAndView modelAndView = controller.agentRequest("hostname", uuid, "sandbox", "100", null, null, "", "", null, null, null, false, request);
+
+        final MockHttpServletResponse response = new MockHttpServletResponse();
+        modelAndView.getView().render(null, null, response);
+
+        assertFalse(goConfigService.hasAgent(uuid));
+        assertThat(response.getStatus(), is(202));
+        assertThat(response.getContentAsString(), is(RegistrationJSONizer.toJson(Registration.createNullPrivateKeyEntry())));
+        assertTrue(agentService.findAgent(uuid).getStatus().getConfigStatus() == AgentConfigStatus.Pending);
+    }
+
+    @Test
+    public void shouldRegisterAgentInEnabledStateWhenLocalAgentAutoRegistrationIsEnabled() throws Exception {
+        System.setProperty(SystemEnvironment.AUTO_REGISTER_LOCAL_AGENT_ENABLED.propertyName(), "true");
+        final MockHttpServletRequest request = new MockHttpServletRequest();
+        final String uuid = UUID.randomUUID().toString();
+
+        final ModelAndView modelAndView = controller.agentRequest("hostname", uuid, "sandbox", "100", null, null, "", "", null, null, null, false, request);
+
+        final MockHttpServletResponse response = new MockHttpServletResponse();
+        modelAndView.getView().render(null, null, response);
+
+        assertTrue(goConfigService.hasAgent(uuid));
+        assertThat(response.getStatus(), is(200));
+        assertTrue(RegistrationJSONizer.fromJson(response.getContentAsString()).isValid());
+        assertTrue(agentService.findAgent(uuid).getStatus().getConfigStatus() == AgentConfigStatus.Enabled);
     }
 
     @Test
     public void shouldNotRegisterAgentWhenValidationFails() throws Exception {
-        MockHttpServletRequest request = new MockHttpServletRequest();
-        int totalAgentsBeforeRegistrationRequest = goConfigService.agents().size();
-        controller.agentRequest("hostname", null, "sandbox", "100", null, null, null, null, null, null, null, false, request);
-        int totalAgentsAfterRegistrationRequest = goConfigService.agents().size();
+        final MockHttpServletRequest request = new MockHttpServletRequest();
+        final int totalAgentsBeforeRegistrationRequest = goConfigService.agents().size();
+
+        final ModelAndView modelAndView = controller.agentRequest("hostname", null, "sandbox", "100", null, null, null, null, null, null, null, false, request);
+
+        final int totalAgentsAfterRegistrationRequest = goConfigService.agents().size();
         assertThat(totalAgentsBeforeRegistrationRequest, is(totalAgentsAfterRegistrationRequest));
+
+        final MockHttpServletResponse response = new MockHttpServletResponse();
+        modelAndView.getView().render(null, null, response);
+
+        assertThat(response.getStatus(), is(202));
+        assertThat(response.getContentAsString(), is(RegistrationJSONizer.toJson(Registration.createNullPrivateKeyEntry())));
+
+    }
+
+    @Test
+    public void shouldAutoRegisterAgentWhenAutoRegisterKeyIsProvided() throws Exception {
+        final String uuid = UUID.randomUUID().toString();
+        final MockHttpServletRequest request = new MockHttpServletRequest();
+
+        final ModelAndView modelAndView = controller.agentRequest("hostname", uuid, "sandbox", "100", null, goConfigService.serverConfig().getAgentAutoRegisterKey(), "", "", null, null, null, false, request);
+
+        final MockHttpServletResponse response = new MockHttpServletResponse();
+        modelAndView.getView().render(null, null, response);
+
+        assertTrue(goConfigService.hasAgent(uuid));
+        assertThat(response.getStatus(), is(200));
+        assertTrue(RegistrationJSONizer.fromJson(response.getContentAsString()).isValid());
+        assertTrue(agentService.findAgent(uuid).getStatus().getRuntimeStatus().agentState() == AgentRuntimeStatus.Idle);
+    }
+
+    @Test
+    public void shouldRegisterAgentWithoutAddingAgentConfigToConfigXML_forAlreadyRegisteredAgent() throws Exception {
+        final MockHttpServletRequest request = new MockHttpServletRequest();
+        final MockHttpServletResponse response = new MockHttpServletResponse();
+        final String uuid = registerAgentWithAgentRuntimeStatus(AgentRuntimeStatus.LostContact);
+
+        final ModelAndView modelAndView = controller.agentRequest("hostname", uuid, "sandbox", "100", null, goConfigService.serverConfig().getAgentAutoRegisterKey(), "", "", null, null, null, false, request);
+
+        modelAndView.getView().render(null, null, response);
+
+        assertTrue(goConfigService.hasAgent(uuid));
+        assertThat(response.getStatus(), is(200));
+        assertTrue(RegistrationJSONizer.fromJson(response.getContentAsString()).isValid());
+        assertTrue(agentService.findAgent(uuid).getStatus().getRuntimeStatus().agentState() == AgentRuntimeStatus.Idle);
+    }
+
+    @Test
+    public void shouldNotProcessRegistrationRequestWhenAutoRegisterKeyIsNotProvided_forAlreadyRegisteredAgent() throws Exception {
+        final MockHttpServletRequest request = new MockHttpServletRequest();
+        final MockHttpServletResponse response = new MockHttpServletResponse();
+        final String uuid = registerAgentWithAgentRuntimeStatus(AgentRuntimeStatus.LostContact);
+
+        final ModelAndView modelAndView = controller.agentRequest("hostname", uuid, "sandbox", "100", null, null, "", "", null, null, null, false, request);
+
+        modelAndView.getView().render(null, null, response);
+        assertTrue(goConfigService.hasAgent(uuid));
+        assertThat(response.getStatus(), is(202));
+        assertThat(response.getContentAsString(), is(RegistrationJSONizer.toJson(Registration.createNullPrivateKeyEntry())));
+        assertTrue(agentService.findAgent(uuid).getStatus().getRuntimeStatus().agentState() == AgentRuntimeStatus.LostContact);
+    }
+
+    private String registerAgentWithAgentRuntimeStatus(AgentRuntimeStatus agentRuntimeStatus) throws IOException {
+        final MockHttpServletRequest request = new MockHttpServletRequest();
+        final String uuid = UUID.randomUUID().toString();
+
+        controller.agentRequest("hostname", uuid, "sandbox", "100", null, null, "", "", null, null, null, false, request);
+        AgentConfig agentConfig = goConfigService.agentByUuid(uuid);
+
+        assertTrue(agentService.findAgent(uuid).getStatus().getRuntimeStatus().agentState() == AgentRuntimeStatus.Idle);
+        assertTrue(goConfigService.hasAgent(uuid));
+
+        agentService.updateRuntimeInfo(new AgentRuntimeInfo(
+                agentConfig.getAgentIdentifier(), agentRuntimeStatus, "sandbox", "foo", false, timeProvider)
+        );
+
+        assertTrue(agentService.findAgent(uuid).getStatus().getRuntimeStatus().agentState() == agentRuntimeStatus);
+
+        return uuid;
     }
 }

--- a/server/test/unit/com/thoughtworks/go/server/controller/AgentRegistrationControllerTest.java
+++ b/server/test/unit/com/thoughtworks/go/server/controller/AgentRegistrationControllerTest.java
@@ -251,7 +251,7 @@ public class AgentRegistrationControllerTest {
     }
 
     @Test
-    public void shouldNotReRegisterAgentIfAgentAutoRegistrationKeyIsNotProvided() throws Exception {
+    public void shouldNotRegisterAgentIfAutoRegistrationKeyIsNotProvided_forAlreadyRegisteredAgent() throws Exception {
         final String uuid = "uuid";
         final ServerConfig serverConfig = mock(ServerConfig.class);
 
@@ -267,22 +267,21 @@ public class AgentRegistrationControllerTest {
     }
 
     @Test
-    public void shouldReRegisterAgentIfAgentAutoRegistrationKeyIsProvided() throws Exception {
+    public void shouldProcessAgentRegistrationIfAgentAutoRegistrationKeyIsProvided_forAlreadyRegisteredAgent() throws Exception {
         final String uuid = "uuid";
         final ServerConfig serverConfig = mock(ServerConfig.class);
+        final Username username = new Username("some-agent-login-name");
 
         when(goConfigService.hasAgent(uuid)).thenReturn(true);
         when(goConfigService.serverConfig()).thenReturn(serverConfig);
         when(serverConfig.shouldAutoRegisterAgentWith("some-key")).thenReturn(true);
-        when(agentService.agentUsername(uuid, request.getRemoteAddr(), "host")).thenReturn(new Username("some-agent-login-name"));
-        when(agentConfigService.updateAgent(any(UpdateConfigCommand.class), eq(uuid), any(HttpOperationResult.class), eq(new Username("some-agent-login-name"))))
-                .thenReturn(new AgentConfig(uuid, "host", request.getRemoteAddr()));
+        when(agentService.agentUsername(uuid, request.getRemoteAddr(), "host")).thenReturn(username);
 
         controller.agentRequest("host", uuid, "location", "233232",
                 "osx", "some-key", "", "",
                 "", "", "", false, request);
 
-        verify(agentService).requestRegistration(new Username("some-agent-login-name"), AgentRuntimeInfo.fromServer(new AgentConfig(uuid, "host", request.getRemoteAddr()), false, "location", 233232L, "osx", false, timeProvider));
-        verify(agentConfigService).updateAgent(any(UpdateConfigCommand.class), eq(uuid), any(HttpOperationResult.class), eq(new Username("some-agent-login-name")));
+        verify(agentService).requestRegistration(username, AgentRuntimeInfo.fromServer(new AgentConfig(uuid, "host", request.getRemoteAddr()), false, "location", 233232L, "osx", false, timeProvider));
+        verify(agentConfigService, times(0)).updateAgent(any(UpdateConfigCommand.class), eq(uuid), any(HttpOperationResult.class), eq(username));
     }
 }

--- a/server/test/unit/com/thoughtworks/go/server/controller/AgentRegistrationControllerTest.java
+++ b/server/test/unit/com/thoughtworks/go/server/controller/AgentRegistrationControllerTest.java
@@ -249,4 +249,40 @@ public class AgentRegistrationControllerTest {
             assertTrue(Arrays.equals(IOUtils.toByteArray(is), response.getContentAsByteArray()));
         }
     }
+
+    @Test
+    public void shouldNotReRegisterAgentIfAgentAutoRegistrationKeyIsNotProvided() throws Exception {
+        final String uuid = "uuid";
+        final ServerConfig serverConfig = mock(ServerConfig.class);
+
+        when(goConfigService.hasAgent(uuid)).thenReturn(true);
+        when(goConfigService.serverConfig()).thenReturn(serverConfig);
+        when(serverConfig.shouldAutoRegisterAgentWith(anyString())).thenReturn(false);
+
+        controller.agentRequest("host", uuid, "location", "233232", "osx", "", "", "", "", "", "", false, request);
+
+        verify(goConfigService, never()).updateConfig(any(UpdateConfigCommand.class));
+        verifyZeroInteractions(agentConfigService);
+        verifyZeroInteractions(agentService);
+    }
+
+    @Test
+    public void shouldReRegisterAgentIfAgentAutoRegistrationKeyIsProvided() throws Exception {
+        final String uuid = "uuid";
+        final ServerConfig serverConfig = mock(ServerConfig.class);
+
+        when(goConfigService.hasAgent(uuid)).thenReturn(true);
+        when(goConfigService.serverConfig()).thenReturn(serverConfig);
+        when(serverConfig.shouldAutoRegisterAgentWith("some-key")).thenReturn(true);
+        when(agentService.agentUsername(uuid, request.getRemoteAddr(), "host")).thenReturn(new Username("some-agent-login-name"));
+        when(agentConfigService.updateAgent(any(UpdateConfigCommand.class), eq(uuid), any(HttpOperationResult.class), eq(new Username("some-agent-login-name"))))
+                .thenReturn(new AgentConfig(uuid, "host", request.getRemoteAddr()));
+
+        controller.agentRequest("host", uuid, "location", "233232",
+                "osx", "some-key", "", "",
+                "", "", "", false, request);
+
+        verify(agentService).requestRegistration(new Username("some-agent-login-name"), AgentRuntimeInfo.fromServer(new AgentConfig(uuid, "host", request.getRemoteAddr()), false, "location", 233232L, "osx", false, timeProvider));
+        verify(agentConfigService).updateAgent(any(UpdateConfigCommand.class), eq(uuid), any(HttpOperationResult.class), eq(new Username("some-agent-login-name")));
+    }
 }


### PR DESCRIPTION
This PR make sure that agent can not re-register it self in absence of auto-register key.

## Use cases

### For a new agent
Server should register agent in pending state(in memory). When someone `approves` an agent then update the config.xml with agent information

### Re registration of an agent(in case of migration, server or agent restart)

#### Agent/Server restart 
* Agent already have the `certs` and `uuid` and it will not make an registration request to server. 
* What if agent is not having valid `certs` ?
  - In such case, SSL handshake between server and agent will fail and as a result agent will delete the invalid `certs` from disk. After removing `certs` it will make a registration request to server with following possibilities

    1)  Registration request with `uuid` and a valid `auto-register` key
        - In case of valid `auto-register` key server will process the registration request.
    2) Registration request with `uuid` *OR* Registration request with `uuid` and invalid `auto-register`
       - If autoregister key is provided or not valid then server won't allow such a agent and ignores the registration request with appropriate `error-message`


