### PR TITLE
bringing back set_error_flash as templates_controller still uses it. …

### DIFF
--- a/server/webapp/WEB-INF/rails.new/app/controllers/application_controller.rb
+++ b/server/webapp/WEB-INF/rails.new/app/controllers/application_controller.rb
@@ -83,6 +83,10 @@ class ApplicationController < ActionController::Base
     flash_message_service.add(FlashMessageModel.new(msg, klass))
   end
 
+  def set_error_flash(msg, *args)
+    set_flash_message(l.string(msg, args.to_java(java.lang.Object)), "error")
+  end
+
   def local_access_only
     LOCAL_ONLY_ACTIONS[params[:controller]].include?(params[:action]) ? allow_local_only : true
   end


### PR DESCRIPTION
…This was missed while migrating to rails4 and caused the destroy action to be broken in certain cases

Currently a javascript check prevents a user from clicking the delete button if the template is associated with a pipeline. However, if user1 lands on the template page before its associated to a pipleine and clicks on the delete button, lands on the confirmation popup. meanwhile user2 associates a pipeline with this template. Then if user clicks on the proceed button, the application throws up a 500 page.