### PR TITLE
Fix config repo material representer

### DIFF
--- a/base/src/com/thoughtworks/go/util/GoConstants.java
+++ b/base/src/com/thoughtworks/go/util/GoConstants.java
@@ -57,7 +57,7 @@ public class GoConstants {
 
     public static final String PRODUCT_NAME = "go";
 
-    public static final int CONFIG_SCHEMA_VERSION = 98;
+    public static final int CONFIG_SCHEMA_VERSION = 99;
 
     public static final String APPROVAL_SUCCESS = "success";
     public static final String APPROVAL_MANUAL = "manual";

--- a/config/config-server/resources/schemas/98_cruise-config.xsd
+++ b/config/config-server/resources/schemas/98_cruise-config.xsd
@@ -18,7 +18,7 @@
 <xsd:schema elementFormDefault="qualified" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
     <xsd:annotation>
         <xsd:documentation xml:lang="en">
-            Configuration schema for Go. Copyright (c) 2017 ThoughtWorks, Inc.
+            Configuration schema for Go. Copyright (c) 2016 ThoughtWorks, Inc.
             www.thoughtworks.com. All rights reserved.
         </xsd:documentation>
     </xsd:annotation>
@@ -77,7 +77,7 @@
                     </xsd:unique>
                 </xsd:element>
             </xsd:sequence>
-            <xsd:attribute name="schemaVersion" type="xsd:int" use="required" fixed="99"/>
+            <xsd:attribute name="schemaVersion" type="xsd:int" use="required" fixed="98"/>
         </xsd:complexType>
         <xsd:unique name="uniquePipelines">
             <xsd:selector xpath="pipelines"/>
@@ -143,63 +143,19 @@
     <xsd:complexType name="configRepoType">
         <xsd:sequence>
             <xsd:choice minOccurs="1" maxOccurs="1">
-                <xsd:element name="svn" type="configRepoSvnType"/>
-                <xsd:element name="p4" type="configRepoP4Type"/>
-                <xsd:element name="git" type="configRepoGitType"/>
-                <xsd:element name="hg" type="configRepoHgType"/>
-                <xsd:element name="tfs" type="configRepoTfsType"/>
-                <xsd:element name="scm" type="configRepoScmReferenceType"/>
+                <xsd:element name="svn" type="svnType"/>
+                <xsd:element name="hg" type="hgType"/>
+                <xsd:element name="p4" type="p4Type"/>
+                <xsd:element name="git" type="gitType"/>
+                <xsd:element name="tfs" type="tfsType"/>
+                <xsd:element name="scm" type="scmReferenceType"/>
             </xsd:choice>
             <xsd:element name="configuration" minOccurs="0" maxOccurs="1" type="configurationType"/>
         </xsd:sequence>
         <xsd:attribute type="nameType" name="id" use="required"/>
         <xsd:attribute type="nameType" name="pluginId" use="optional"/>
     </xsd:complexType>
-    <xsd:complexType name="configRepoSvnType">
-        <xsd:attribute name="url" type="xsd:string" use="required"/>
-        <xsd:attribute name="username" type="xsd:string"/>
-        <xsd:attribute name="password" type="xsd:string"/>
-        <xsd:attribute name="autoUpdate" type="xsd:boolean" use="optional"/>
-        <xsd:attribute name="checkexternals" type="xsd:boolean"/>
-        <xsd:attribute name="encryptedPassword" type="xsd:string"/>
-        <xsd:attribute name="materialName" type="nameType" use="optional"/>
-    </xsd:complexType>
-    <xsd:complexType name="configRepoP4Type">
-        <xsd:sequence>
-            <xsd:element name="view" minOccurs="1" maxOccurs="1"/>
-        </xsd:sequence>
-        <xsd:attribute name="port" type="xsd:string" use="required"/>
-        <xsd:attribute name="username" type="xsd:string"/>
-        <xsd:attribute name="password" type="xsd:string"/>
-        <xsd:attribute name="autoUpdate" type="xsd:boolean" use="optional"/>
-        <xsd:attribute name="encryptedPassword" type="xsd:string"/>
-        <xsd:attribute name="useTickets" type="xsd:boolean" use="optional"/>
-        <xsd:attribute name="materialName" type="nameType" use="optional"/>
-    </xsd:complexType>
-    <xsd:complexType name="configRepoGitType">
-        <xsd:attribute name="url" type="xsd:string" use="required"/>
-        <xsd:attribute name="branch" type="xsd:string" use="optional"/>
-        <xsd:attribute name="autoUpdate" type="xsd:boolean" use="optional"/>
-        <xsd:attribute name="materialName" type="nameType" use="optional"/>
-    </xsd:complexType>
-    <xsd:complexType name="configRepoHgType">
-        <xsd:attribute name="url" type="xsd:string" use="required"/>
-        <xsd:attribute name="materialName" type="nameType" use="optional"/>
-        <xsd:attribute name="autoUpdate" type="xsd:boolean" use="optional"/>
-    </xsd:complexType>
-    <xsd:complexType name="configRepoTfsType">
-        <xsd:attribute name="url" type="xsd:string" use="required"/>
-        <xsd:attribute name="username" type="xsd:string" use="required"/>
-        <xsd:attribute name="domain" type="xsd:string"/>
-        <xsd:attribute name="password" type="xsd:string"/>
-        <xsd:attribute name="autoUpdate" type="xsd:boolean" use="optional"/>
-        <xsd:attribute name="encryptedPassword" type="xsd:string"/>
-        <xsd:attribute name="projectPath" type="xsd:string" use="required"/>
-        <xsd:attribute name="materialName" type="nameType" use="optional"/>
-    </xsd:complexType>
-    <xsd:complexType name="configRepoScmReferenceType">
-        <xsd:attribute name="ref" type="xsd:string" use="required" />
-    </xsd:complexType>
+
     <xsd:complexType name="scmsType">
         <xsd:sequence>
             <xsd:element name="scm" minOccurs="0" maxOccurs="unbounded" type="scmType"/>

--- a/config/config-server/resources/upgrades/99.xsl
+++ b/config/config-server/resources/upgrades/99.xsl
@@ -1,0 +1,62 @@
+<?xml version="1.0"?>
+<!--
+  ~ Copyright 2017 ThoughtWorks, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+    <xsl:template match="/cruise/@schemaVersion">
+        <xsl:attribute name="schemaVersion">99</xsl:attribute>
+    </xsl:template>
+    <!-- Copy everything -->
+    <xsl:template match="@*|node()">
+        <xsl:copy>
+            <xsl:apply-templates select="@*|node()"/>
+        </xsl:copy>
+    </xsl:template>
+
+    <!-- Remove following attributes from config repo git material -->
+    <xsl:template match="/cruise/config-repos/config-repo/git/filter" />
+    <xsl:template match="/cruise/config-repos/config-repo/git/@dest" />
+    <xsl:template match="/cruise/config-repos/config-repo/git/@invertFilter" />
+    <xsl:template match="/cruise/config-repos/config-repo/git/@shallowClone" />
+
+    <!-- Remove following attributes from config repo svn material -->
+    <xsl:template match="/cruise/config-repos/config-repo/svn/filter" />
+    <xsl:template match="/cruise/config-repos/config-repo/svn/@dest" />
+    <xsl:template match="/cruise/config-repos/config-repo/svn/@invertFilter" />
+
+    <!-- Remove following attributes from config repo p4 material -->
+    <xsl:template match="/cruise/config-repos/config-repo/p4/filter" />
+    <xsl:template match="/cruise/config-repos/config-repo/p4/@dest" />
+    <xsl:template match="/cruise/config-repos/config-repo/p4/@invertFilter" />
+
+    <!-- Remove following attributes from config repo hg material -->
+    <xsl:template match="/cruise/config-repos/config-repo/hg/filter" />
+    <xsl:template match="/cruise/config-repos/config-repo/hg/@dest" />
+    <xsl:template match="/cruise/config-repos/config-repo/hg/@invertFilter" />
+
+    <!-- Remove following attributes from config repo tfs material -->
+    <xsl:template match="/cruise/config-repos/config-repo/tfs/filter" />
+    <xsl:template match="/cruise/config-repos/config-repo/tfs/@dest" />
+    <xsl:template match="/cruise/config-repos/config-repo/tfs/@invertFilter" />
+
+    <!-- Remove following attributes from config repo scm material -->
+    <xsl:template match="/cruise/config-repos/config-repo/scm/filter" />
+    <xsl:template match="/cruise/config-repos/config-repo/scm/@dest" />
+
+    <xsl:template match="/cruise/config-repos/config-repo/*/text()">
+        <xsl:value-of select="normalize-space()"/>
+    </xsl:template>
+</xsl:stylesheet>

--- a/server/config/cruise-config.xml
+++ b/server/config/cruise-config.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<cruise xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="cruise-config.xsd" schemaVersion="98">
+<cruise xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="cruise-config.xsd" schemaVersion="99">
   <server artifactsdir="artifacts" agentAutoRegisterKey="041b5c7e-dab2-11e5-a908-13f95f3c6ef6" webhookSecret="5f8b5eac-1148-4145-aa01-7b2934b6e1ab" commandRepositoryLocation="default" serverId="dev-id">
     <security>
       <authConfigs>

--- a/server/webapp/WEB-INF/rails.new/app/presenters/api_v1/config/config_repo/materials/git_material_representer.rb
+++ b/server/webapp/WEB-INF/rails.new/app/presenters/api_v1/config/config_repo/materials/git_material_representer.rb
@@ -27,8 +27,6 @@ module ApiV1
                    setter: lambda { |value, options|
                      value.blank? ? self.setBranch('master') : self.setBranch(value)
                    }
-          property :submodule_folder
-          property :shallow_clone
         end
       end
     end

--- a/server/webapp/WEB-INF/rails.new/app/presenters/api_v1/config/config_repo/materials/material_representer.rb
+++ b/server/webapp/WEB-INF/rails.new/app/presenters/api_v1/config/config_repo/materials/material_representer.rb
@@ -24,7 +24,8 @@ module ApiV1
             'svn' => SvnMaterialConfig,
             'hg' => HgMaterialConfig,
             'p4' => P4MaterialConfig,
-            'tfs' => TfsMaterialConfig
+            'tfs' => TfsMaterialConfig,
+            'plugin' => PluggableSCMMaterialConfig
           }
 
           MATERIAL_TO_TYPE_MAP = TYPE_TO_MATERIAL_MAP.invert
@@ -34,27 +35,22 @@ module ApiV1
             SvnMaterialConfig => SvnMaterialRepresenter,
             HgMaterialConfig => HgMaterialRepresenter,
             P4MaterialConfig => PerforceMaterialRepresenter,
-            TfsMaterialConfig => TfsMaterialRepresenter
+            TfsMaterialConfig => TfsMaterialRepresenter,
+            PluggableSCMMaterialConfig => PluggableScmMaterialRepresenter
           }
           alias_method :material_config, :represented
 
           error_representer({
                               "materialName" => "name",
-                              "folder" => "destination",
-                              "autoUpdate" => "auto_update",
-                              "filterAsString" => "filter",
-                              "checkexternals" => "check_externals",
                               "serverAndPort" => "port",
                               "useTickets" => "use_tickets",
-                              "pipelineName" => "pipeline",
-                              "stageName" => "stage",
-                              "pipelineStageName" => "pipeline",
-                              "packageId" => "ref",
-                              "scmId" => "ref",
                               "password" => "password",
                               "encryptedPassword" => "encrypted_password",
-                            }
-          )
+                              "checkexternals" => "check_externals",
+                              "autoUpdate" => "auto_update",
+                              "packageId" => "ref",
+                              "scmId" => "ref"
+                            })
 
           property :type, getter: lambda { |options| MATERIAL_TO_TYPE_MAP[self.class] }, skip_parse: true
 

--- a/server/webapp/WEB-INF/rails.new/app/presenters/api_v1/config/config_repo/materials/pluggable_scm_material_representer.rb
+++ b/server/webapp/WEB-INF/rails.new/app/presenters/api_v1/config/config_repo/materials/pluggable_scm_material_representer.rb
@@ -18,20 +18,14 @@ module ApiV1
   module Config
     module ConfigRepo
       module Materials
-        class FilterRepresenter < BaseRepresenter
-          alias_method :filter, :represented
+        class PluggableScmMaterialRepresenter < BaseRepresenter
+          alias_method :material_config, :represented
 
-          collection :ignore, exec_context: :decorator
-
-          def to_hash(*options)
-            ignored_files=filter.map { |item| item.getPattern() }
-            {ignore: ignored_files} if !ignored_files.empty?
-          end
-
-          def ignore=(value)
-            filter.clear()
-            value.each { |pattern| filter.add(IgnoredFiles.new(pattern)) }
-          end
+          property :scmId, as: :ref, setter: lambda { |value, options|
+            scm = options[:go_config].getSCMs().find(value)
+            self.setSCMConfig(scm)
+            self.setScmId(value)
+          }
         end
       end
     end

--- a/server/webapp/WEB-INF/rails.new/app/presenters/api_v1/config/config_repo/materials/scm_material_representer.rb
+++ b/server/webapp/WEB-INF/rails.new/app/presenters/api_v1/config/config_repo/materials/scm_material_representer.rb
@@ -22,13 +22,6 @@ module ApiV1
           alias_method :material_config, :represented
 
           property :url
-          property :folder, as: :destination, skip_parse: SkipParseOnBlank
-          property :filter,
-                   decorator: FilterRepresenter,
-                   class: com.thoughtworks.go.config.materials.Filter,
-                   skip_parse: SkipParseOnBlank
-          property :invert_filter,
-                   skip_parse: SkipParseOnBlank
           property :name, case_insensitive_string: true, skip_parse: SkipParseOnBlank
           property :auto_update
 

--- a/server/webapp/WEB-INF/rails.new/app/presenters/api_v1/config/config_repo/materials/svn_material_representer.rb
+++ b/server/webapp/WEB-INF/rails.new/app/presenters/api_v1/config/config_repo/materials/svn_material_representer.rb
@@ -29,9 +29,7 @@ module ApiV1
                    skip_parse: true
 
           property :encrypted_password, skip_nil: true, skip_parse: true
-
         end
-
       end
     end
   end

--- a/server/webapp/WEB-INF/rails.new/app/presenters/api_v1/config/config_repo/materials/tfs_material_representer.rb
+++ b/server/webapp/WEB-INF/rails.new/app/presenters/api_v1/config/config_repo/materials/tfs_material_representer.rb
@@ -31,7 +31,6 @@ module ApiV1
           property :encrypted_password, skip_nil: true, skip_parse: true
 
           property :project_path
-
         end
       end
     end

--- a/server/webapp/WEB-INF/rails.new/spec/presenters/api_v1/config/config_repo_representer_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/presenters/api_v1/config/config_repo_representer_spec.rb
@@ -37,14 +37,9 @@ describe ApiV1::Config::ConfigRepoRepresenter do
           :type => 'git',
           :attributes => {
             :url => 'git://foo',
-            :destination => nil,
-            :filter => nil,
-            :invert_filter => false,
             :name => nil,
-            :auto_update => true,
             :branch => 'master',
-            :submodule_folder => nil,
-            :shallow_clone => false
+            :auto_update => true
           }
         },
         :configuration => []


### PR DESCRIPTION
* Remove attributes from config repo materials which are not required. 
* Modify XML schema definition to not support unnecessary attributes.
* Add an XSL Translation to wipe out unnecessary attributes from the materials tag.

### Supported Attributes for materials
#### Git
* `url`
* `branch`
* `materialName`

#### hg
* `url`
* `materialName`

#### tfs
* `url`
* `username`
* `domain`
* `password`
* `encryptedPassword`
* `projectPath`
* `materialName`

#### p4
* `view`
* `port`
* `username`
* `password`
* `encryptedPassword`
* `materialName`

#### svn
* `url`
* `username`
* `password`
* `encryptedPassword`
* `materialName`

