### PR TITLE
The config dir should be configured to be in $SERVER_WORK_DIR if it is not specified.

### DIFF
--- a/installers/go-server/release/server.sh
+++ b/installers/go-server/release/server.sh
@@ -106,7 +106,7 @@ if [ -z "${GO_CONFIG_DIR}" ]; then
   if [ -d /etc/go ]; then
     GO_CONFIG_DIR=/etc/go
   else
-    GO_CONFIG_DIR=$SERVER_DIR/config
+    GO_CONFIG_DIR=$SERVER_WORK_DIR/config
   fi
 fi
 


### PR DESCRIPTION
@jyotisingh - You'd asked me to make the same change for https://github.com/gocd/gocd/blob/93d4ce286d8fe0cf8905abe30b571fe85f340bd1/installers/go-server/release/server.sh#L138. But, $SERVER_WORK_DIR != $SERVER_DIR if installed on linux as a service. 
`$SERVER_DIR` points to `/usr/share/go-server` where `go.jar` exists,
`$SERVER_WORK_DIR` points to `/var/lib/go-server` as specified in `/etc/default/go-server`
Only for zip, the two variables point to the current working directory where go.jar exists. So, I won't be making that change. 