### PR TITLE
Redirecting stderror and stdout to stdout_log_file

### DIFF
--- a/installers/go-agent/release/agent.sh
+++ b/installers/go-agent/release/agent.sh
@@ -153,7 +153,7 @@ RUN_CMD=("$(autoDetectJavaExecutable)" "${AGENT_BOOTSTRAPPER_JVM_ARGS[@]}" "-jar
 cd "$AGENT_WORK_DIR"
 
 if [ "$DAEMON" == "Y" ]; then
-    exec nohup "${RUN_CMD[@]}" &
+    exec nohup "${RUN_CMD[@]}" >> "$STDOUT_LOG_FILE" 2>&1 &
     disown $!
     echo $! >"$PID_FILE"
 else

--- a/installers/go-server/release/server.sh
+++ b/installers/go-server/release/server.sh
@@ -140,7 +140,7 @@ RUN_CMD=("$(autoDetectJavaExecutable)" "${SERVER_STARTUP_ARGS[@]}" "-jar" "$SERV
 cd "$SERVER_WORK_DIR"
 
 if [ "$DAEMON" == "Y" ]; then
-    exec nohup "${RUN_CMD[@]}" &
+    exec nohup "${RUN_CMD[@]}" >>"$STDOUT_LOG_FILE" 2>&1 &
     disown $!
     echo $! >"$PID_FILE"
 else


### PR DESCRIPTION
* 891ef50fa23e5fc0da51c181f64ae835f3133e8a removed explicit redirection
  of stdout and stderr for server and agent process and configured the
  out file in the application. Since the java processes are nohuped a
  nohup.out file is created and all JVM related to stdout and stderror
  gets logged to this file. Even thread dumps taken are logged to
  nohup.out. With this users will have to look at multiple log files,
  hence explictly redirecting std streams to std_out log file.