### PR TITLE
Reverting agent registration changes done in PR #3935 and #3918

### DIFF
--- a/server/src/com/thoughtworks/go/server/controller/AgentRegistrationController.java
+++ b/server/src/com/thoughtworks/go/server/controller/AgentRegistrationController.java
@@ -53,7 +53,8 @@ import java.io.InputStream;
 import java.util.List;
 import java.util.Map;
 
-import static org.apache.commons.lang.StringUtils.*;
+import static org.apache.commons.lang.StringUtils.isBlank;
+import static org.apache.commons.lang.StringUtils.isNotBlank;
 
 @Controller
 public class AgentRegistrationController {
@@ -188,26 +189,36 @@ public class AgentRegistrationController {
         final String ipAddress = request.getRemoteAddr();
         LOG.debug("Processing registration request from agent [{}/{}]", hostname, ipAddress);
         Registration keyEntry;
+        String preferredHostname = hostname;
 
         try {
-            final boolean shouldAutoRegisterAgent = goConfigService.serverConfig().shouldAutoRegisterAgentWith(agentAutoRegisterKey);
-
-            validateAgentRegistrationRequest(uuid, shouldAutoRegisterAgent, elasticAgentId, elasticPluginId);
-
-            final String preferredHostname = getPreferredHostname(agentAutoRegisterHostname, hostname);
+            if (goConfigService.serverConfig().shouldAutoRegisterAgentWith(agentAutoRegisterKey)) {
+                preferredHostname = getPreferredHostname(agentAutoRegisterHostname, hostname);
+                LOG.info("[Agent Auto Registration] Auto registering agent with uuid {} ", uuid);
+            } else {
+                if (elasticAgentAutoregistrationInfoPresent(elasticAgentId, elasticPluginId)) {
+                    throw new RuntimeException(String.format("Elastic agent registration requires an auto-register agent key to be setup on the server. Agent-id: [%s], Plugin-id: [%s]", elasticAgentId, elasticPluginId));
+                }
+            }
 
             AgentConfig agentConfig = new AgentConfig(uuid, preferredHostname, ipAddress);
-            agentConfig.setElasticAgentId(stripToNull(elasticAgentId));
-            agentConfig.setElasticPluginId(stripToNull(elasticPluginId));
 
-            if (shouldAutoRegisterAgent) {
+            if (partialElasticAgentAutoregistrationInfo(elasticAgentId, elasticPluginId)) {
+                throw new RuntimeException("Elastic agents must submit both elasticAgentId and elasticPluginId");
+            }
+
+            if (elasticAgentAutoregistrationInfoPresent(elasticAgentId, elasticPluginId)) {
+                agentConfig.setElasticAgentId(elasticAgentId);
+                agentConfig.setElasticPluginId(elasticPluginId);
+            }
+
+            if (goConfigService.serverConfig().shouldAutoRegisterAgentWith(agentAutoRegisterKey)) {
                 LOG.info("[Agent Auto Registration] Auto registering agent with uuid {} ", uuid);
                 GoConfigDao.CompositeConfigCommand compositeConfigCommand = new GoConfigDao.CompositeConfigCommand(
                         new AgentConfigService.AddAgentCommand(agentConfig),
                         new UpdateResourceCommand(uuid, agentAutoRegisterResources),
                         new UpdateEnvironmentsCommand(uuid, agentAutoRegisterEnvironments)
                 );
-
                 HttpOperationResult result = new HttpOperationResult();
                 agentConfig = agentConfigService.updateAgent(compositeConfigCommand, uuid, result, agentService.agentUsername(uuid, ipAddress, preferredHostname));
                 if (!result.isSuccess()) {
@@ -221,41 +232,22 @@ public class AgentRegistrationController {
                 }
             }
 
-            final long usableSpace = Long.parseLong(usablespaceAsString);
+            boolean registeredAlready = goConfigService.hasAgent(uuid);
+            long usableSpace = Long.parseLong(usablespaceAsString);
 
-            AgentRuntimeInfo agentRuntimeInfo = AgentRuntimeInfo.fromServer(agentConfig, goConfigService.hasAgent(uuid), location, usableSpace, operatingSystem, supportsBuildCommandProtocol);
+            AgentRuntimeInfo agentRuntimeInfo = AgentRuntimeInfo.fromServer(agentConfig, registeredAlready, location, usableSpace, operatingSystem, supportsBuildCommandProtocol);
 
-            if (isElasticAgent(elasticAgentId, elasticPluginId)) {
+            if (elasticAgentAutoregistrationInfoPresent(elasticAgentId, elasticPluginId)) {
                 agentRuntimeInfo = ElasticAgentRuntimeInfo.fromServer(agentRuntimeInfo, elasticAgentId, elasticPluginId);
             }
 
             keyEntry = agentService.requestRegistration(agentService.agentUsername(uuid, ipAddress, preferredHostname), agentRuntimeInfo);
         } catch (Exception e) {
             keyEntry = Registration.createNullPrivateKeyEntry();
-            LOG.error("Error occurred during agent registration process: ", e);
+            LOG.error("Error occured during agent registration process: ", e);
         }
 
         return render(keyEntry);
-    }
-
-    private void validateAgentRegistrationRequest(String agentUUID, boolean shouldAutoRegisterAgent, String elasticAgentId, String elasticPluginId) {
-
-        if (goConfigService.hasAgent(agentUUID) && !shouldAutoRegisterAgent) {
-            throw new RuntimeException(String.format("Agent [%s] is already registered with server. Agent registration requires an auto-register key and it must match the auto-register key setup on the server.", agentUUID));
-        }
-
-        if (isElasticAgent(elasticAgentId, elasticPluginId) && !shouldAutoRegisterAgent) {
-            throw new RuntimeException(String.format("Elastic agent registration requires an auto-register key and it must match the auto-register key setup on the server. Agent-id: [%s], Plugin-id: [%s]", elasticAgentId, elasticPluginId));
-        }
-
-        if (partialElasticAgentInfo(elasticAgentId, elasticAgentId)) {
-            throw new RuntimeException("Elastic agents must submit both elasticAgentId and elasticPluginId");
-        }
-
-    }
-
-    private boolean isElasticAgent(String elasticAgentId, String elasticPluginId) {
-        return isNotBlank(elasticAgentId) || isNotBlank(elasticPluginId);
     }
 
     private ModelAndView render(final Registration registration) {
@@ -281,8 +273,12 @@ public class AgentRegistrationController {
         }
     }
 
-    private boolean partialElasticAgentInfo(String elasticAgentId, String elasticPluginId) {
+    private boolean partialElasticAgentAutoregistrationInfo(String elasticAgentId, String elasticPluginId) {
         return (isBlank(elasticAgentId) && isNotBlank(elasticPluginId)) || (isNotBlank(elasticAgentId) && isBlank(elasticPluginId));
+    }
+
+    private boolean elasticAgentAutoregistrationInfoPresent(String elasticAgentId, String elasticPluginId) {
+        return isNotBlank(elasticAgentId) && isNotBlank(elasticPluginId);
     }
 
     private String getPreferredHostname(String agentAutoRegisterHostname, String hostname) {

--- a/server/src/com/thoughtworks/go/server/controller/AgentRegistrationController.java
+++ b/server/src/com/thoughtworks/go/server/controller/AgentRegistrationController.java
@@ -53,8 +53,7 @@ import java.io.InputStream;
 import java.util.List;
 import java.util.Map;
 
-import static org.apache.commons.lang.StringUtils.isBlank;
-import static org.apache.commons.lang.StringUtils.isNotBlank;
+import static org.apache.commons.lang.StringUtils.*;
 
 @Controller
 public class AgentRegistrationController {
@@ -192,19 +191,16 @@ public class AgentRegistrationController {
 
         try {
             final boolean shouldAutoRegisterAgent = goConfigService.serverConfig().shouldAutoRegisterAgentWith(agentAutoRegisterKey);
-            final boolean registeredAlready = goConfigService.hasAgent(uuid);
 
-            validateAgentRegistrationRequest(uuid, shouldAutoRegisterAgent, registeredAlready, elasticAgentId, elasticPluginId);
+            validateAgentRegistrationRequest(uuid, shouldAutoRegisterAgent, elasticAgentId, elasticPluginId);
 
             final String preferredHostname = getPreferredHostname(agentAutoRegisterHostname, hostname);
 
             AgentConfig agentConfig = new AgentConfig(uuid, preferredHostname, ipAddress);
-            if (isElasticAgent(elasticAgentId, elasticPluginId)) {
-                agentConfig.setElasticAgentId(elasticAgentId);
-                agentConfig.setElasticPluginId(elasticPluginId);
-            }
+            agentConfig.setElasticAgentId(stripToNull(elasticAgentId));
+            agentConfig.setElasticPluginId(stripToNull(elasticPluginId));
 
-            if (shouldAutoRegisterAgent && !registeredAlready) {
+            if (shouldAutoRegisterAgent) {
                 LOG.info("[Agent Auto Registration] Auto registering agent with uuid {} ", uuid);
                 GoConfigDao.CompositeConfigCommand compositeConfigCommand = new GoConfigDao.CompositeConfigCommand(
                         new AgentConfigService.AddAgentCommand(agentConfig),
@@ -242,23 +238,24 @@ public class AgentRegistrationController {
         return render(keyEntry);
     }
 
-    private void validateAgentRegistrationRequest(String agentUUID, boolean shouldAutoRegisterAgent, boolean registeredAlready, String elasticAgentId, String elasticPluginId) {
+    private void validateAgentRegistrationRequest(String agentUUID, boolean shouldAutoRegisterAgent, String elasticAgentId, String elasticPluginId) {
 
-        if (registeredAlready && !shouldAutoRegisterAgent) {
+        if (goConfigService.hasAgent(agentUUID) && !shouldAutoRegisterAgent) {
             throw new RuntimeException(String.format("Agent [%s] is already registered with server. Agent registration requires an auto-register key and it must match the auto-register key setup on the server.", agentUUID));
+        }
+
+        if (isElasticAgent(elasticAgentId, elasticPluginId) && !shouldAutoRegisterAgent) {
+            throw new RuntimeException(String.format("Elastic agent registration requires an auto-register key and it must match the auto-register key setup on the server. Agent-id: [%s], Plugin-id: [%s]", elasticAgentId, elasticPluginId));
         }
 
         if (partialElasticAgentInfo(elasticAgentId, elasticAgentId)) {
             throw new RuntimeException("Elastic agents must submit both elasticAgentId and elasticPluginId");
         }
 
-        if (isElasticAgent(elasticAgentId, elasticPluginId) && !shouldAutoRegisterAgent) {
-            throw new RuntimeException(String.format("Elastic agent registration requires an auto-register key and it must match the auto-register key setup on the server. Agent-id: [%s], Plugin-id: [%s]", elasticAgentId, elasticPluginId));
-        }
     }
 
     private boolean isElasticAgent(String elasticAgentId, String elasticPluginId) {
-        return isNotBlank(elasticAgentId) && isNotBlank(elasticPluginId);
+        return isNotBlank(elasticAgentId) || isNotBlank(elasticPluginId);
     }
 
     private ModelAndView render(final Registration registration) {

--- a/server/src/com/thoughtworks/go/server/service/AgentConfigService.java
+++ b/server/src/com/thoughtworks/go/server/service/AgentConfigService.java
@@ -240,14 +240,15 @@ public class AgentConfigService {
         EntityConfigUpdateCommand<Agents> agentsEntityConfigUpdateCommand = new AgentsEntityConfigUpdateCommand(agentInstances, username, result, uuids, environmentsToAdd, environmentsToRemove, enable, resourcesToAdd, resourcesToRemove, goConfigService);
         try {
             goConfigService.updateConfig(agentsEntityConfigUpdateCommand, username);
-            if (result.isSuccessful()) {
+            if(result.isSuccessful()){
                 result.setMessage(successMessage);
             }
         } catch (Exception e) {
             LOGGER.error("There was an error bulk updating agents", e);
-            if (e instanceof GoConfigInvalidException && !result.hasMessage()) {
+            if(e instanceof GoConfigInvalidException && !result.hasMessage()) {
                 result.unprocessableEntity(LocalizedMessage.string("ENTITY_CONFIG_VALIDATION_FAILED", Agents.class.getAnnotation(ConfigTag.class).value(), uuids, e.getMessage()));
-            } else if (!result.hasMessage()) {
+            }
+            else if(!result.hasMessage()) {
                 result.internalServerError(LocalizedMessage.string("INTERNAL_SERVER_ERROR"));
             }
         }

--- a/server/test/integration/com/thoughtworks/go/server/controller/AgentRegistrationControllerIntegrationTest.java
+++ b/server/test/integration/com/thoughtworks/go/server/controller/AgentRegistrationControllerIntegrationTest.java
@@ -19,7 +19,6 @@ package com.thoughtworks.go.server.controller;
 import com.rits.cloning.Cloner;
 import com.thoughtworks.go.config.AgentConfig;
 import com.thoughtworks.go.domain.AgentConfigStatus;
-import com.thoughtworks.go.domain.AgentInstance;
 import com.thoughtworks.go.domain.AgentRuntimeStatus;
 import com.thoughtworks.go.security.Registration;
 import com.thoughtworks.go.security.RegistrationJSONizer;
@@ -173,24 +172,6 @@ public class AgentRegistrationControllerIntegrationTest {
         assertThat(response.getStatus(), is(202));
         assertThat(response.getContentAsString(), is(RegistrationJSONizer.toJson(Registration.createNullPrivateKeyEntry())));
         assertTrue(agentService.findAgent(uuid).getStatus().getRuntimeStatus().agentState() == AgentRuntimeStatus.LostContact);
-    }
-
-    @Test
-    public void shouldRegisterElasticAgent() throws Exception {
-        final MockHttpServletRequest request = new MockHttpServletRequest();
-        final MockHttpServletResponse response = new MockHttpServletResponse();
-        final String uuid = UUID.randomUUID().toString();
-
-        final ModelAndView modelAndView = controller.agentRequest("hostname", uuid, "sandbox", "100", null, goConfigService.serverConfig().getAgentAutoRegisterKey(), "", "", null, "1a2dffb-4832-4fdf-b9e4-5d598cc48c8e", "cd.go.contrib.docker-swarm", false, request);
-
-        modelAndView.getView().render(null, null, response);
-        assertTrue(goConfigService.hasAgent(uuid));
-        assertThat(response.getStatus(), is(200));
-        assertTrue(RegistrationJSONizer.fromJson(response.getContentAsString()).isValid());
-
-        final AgentInstance agentInstance = agentService.findAgent(uuid);
-        assertTrue(agentInstance.isElastic());
-        assertTrue(agentInstance.getStatus().getRuntimeStatus().agentState() == AgentRuntimeStatus.Idle);
     }
 
     private String registerAgentWithAgentRuntimeStatus(AgentRuntimeStatus agentRuntimeStatus) throws IOException {

--- a/server/test/integration/com/thoughtworks/go/server/controller/AgentRegistrationControllerIntegrationTest.java
+++ b/server/test/integration/com/thoughtworks/go/server/controller/AgentRegistrationControllerIntegrationTest.java
@@ -16,34 +16,19 @@
 
 package com.thoughtworks.go.server.controller;
 
-import com.rits.cloning.Cloner;
 import com.thoughtworks.go.config.AgentConfig;
-import com.thoughtworks.go.domain.AgentConfigStatus;
-import com.thoughtworks.go.domain.AgentRuntimeStatus;
-import com.thoughtworks.go.security.Registration;
-import com.thoughtworks.go.security.RegistrationJSONizer;
-import com.thoughtworks.go.server.service.AgentRuntimeInfo;
-import com.thoughtworks.go.server.service.AgentService;
 import com.thoughtworks.go.server.service.GoConfigService;
-import com.thoughtworks.go.util.SystemEnvironment;
-import com.thoughtworks.go.util.TimeProvider;
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.mock.web.MockHttpServletRequest;
-import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
-import org.springframework.web.servlet.ModelAndView;
 
-import java.io.IOException;
-import java.util.Properties;
 import java.util.UUID;
 
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertThat;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(locations = {
@@ -53,143 +38,24 @@ import static org.junit.Assert.*;
         "classpath:WEB-INF/spring-pages-servlet.xml"
 })
 public class AgentRegistrationControllerIntegrationTest {
-    @Autowired
-    private AgentRegistrationController controller;
-    @Autowired
-    private GoConfigService goConfigService;
-    @Autowired
-    private AgentService agentService;
-    @Autowired
-    private TimeProvider timeProvider;
-
-    static final Cloner CLONER = new Cloner();
-    private Properties original;
-
-    @Before
-    public void before() {
-        original = CLONER.deepClone(System.getProperties());
-    }
-
-    @After
-    public void after() {
-        System.setProperties(original);
-    }
+    @Autowired private AgentRegistrationController controller;
+    @Autowired private GoConfigService goConfigService;
 
     @Test
-    public void shouldRegisterAgentInPendingStateWhenLocalAgentAutoRegistrationIsDisabled() throws Exception {
-        System.setProperty(SystemEnvironment.AUTO_REGISTER_LOCAL_AGENT_ENABLED.propertyName(), "false");
-        final MockHttpServletRequest request = new MockHttpServletRequest();
-        final String uuid = UUID.randomUUID().toString();
-
-        final ModelAndView modelAndView = controller.agentRequest("hostname", uuid, "sandbox", "100", null, null, "", "", null, null, null, false, request);
-
-        final MockHttpServletResponse response = new MockHttpServletResponse();
-        modelAndView.getView().render(null, null, response);
-
-        assertFalse(goConfigService.hasAgent(uuid));
-        assertThat(response.getStatus(), is(202));
-        assertThat(response.getContentAsString(), is(RegistrationJSONizer.toJson(Registration.createNullPrivateKeyEntry())));
-        assertTrue(agentService.findAgent(uuid).getStatus().getConfigStatus() == AgentConfigStatus.Pending);
-    }
-
-    @Test
-    public void shouldRegisterAgentInEnabledStateWhenLocalAgentAutoRegistrationIsEnabled() throws Exception {
-        System.setProperty(SystemEnvironment.AUTO_REGISTER_LOCAL_AGENT_ENABLED.propertyName(), "true");
-        final MockHttpServletRequest request = new MockHttpServletRequest();
-        final String uuid = UUID.randomUUID().toString();
-
-        final ModelAndView modelAndView = controller.agentRequest("hostname", uuid, "sandbox", "100", null, null, "", "", null, null, null, false, request);
-
-        final MockHttpServletResponse response = new MockHttpServletResponse();
-        modelAndView.getView().render(null, null, response);
-
-        assertTrue(goConfigService.hasAgent(uuid));
-        assertThat(response.getStatus(), is(200));
-        assertTrue(RegistrationJSONizer.fromJson(response.getContentAsString()).isValid());
-        assertTrue(agentService.findAgent(uuid).getStatus().getConfigStatus() == AgentConfigStatus.Enabled);
+    public void shouldRegisterAgent() throws Exception {
+        String uuid = UUID.randomUUID().toString();
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        controller.agentRequest("hostname", uuid, "sandbox", "100", null, null, null, null, null, null, null, false, request);
+        AgentConfig agentConfig = goConfigService.agentByUuid(uuid);
+        assertThat(agentConfig.getHostname(), is("hostname"));
     }
 
     @Test
     public void shouldNotRegisterAgentWhenValidationFails() throws Exception {
-        final MockHttpServletRequest request = new MockHttpServletRequest();
-        final int totalAgentsBeforeRegistrationRequest = goConfigService.agents().size();
-
-        final ModelAndView modelAndView = controller.agentRequest("hostname", null, "sandbox", "100", null, null, null, null, null, null, null, false, request);
-
-        final int totalAgentsAfterRegistrationRequest = goConfigService.agents().size();
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        int totalAgentsBeforeRegistrationRequest = goConfigService.agents().size();
+        controller.agentRequest("hostname", null, "sandbox", "100", null, null, null, null, null, null, null, false, request);
+        int totalAgentsAfterRegistrationRequest = goConfigService.agents().size();
         assertThat(totalAgentsBeforeRegistrationRequest, is(totalAgentsAfterRegistrationRequest));
-
-        final MockHttpServletResponse response = new MockHttpServletResponse();
-        modelAndView.getView().render(null, null, response);
-
-        assertThat(response.getStatus(), is(202));
-        assertThat(response.getContentAsString(), is(RegistrationJSONizer.toJson(Registration.createNullPrivateKeyEntry())));
-
-    }
-
-    @Test
-    public void shouldAutoRegisterAgentWhenAutoRegisterKeyIsProvided() throws Exception {
-        final String uuid = UUID.randomUUID().toString();
-        final MockHttpServletRequest request = new MockHttpServletRequest();
-
-        final ModelAndView modelAndView = controller.agentRequest("hostname", uuid, "sandbox", "100", null, goConfigService.serverConfig().getAgentAutoRegisterKey(), "", "", null, null, null, false, request);
-
-        final MockHttpServletResponse response = new MockHttpServletResponse();
-        modelAndView.getView().render(null, null, response);
-
-        assertTrue(goConfigService.hasAgent(uuid));
-        assertThat(response.getStatus(), is(200));
-        assertTrue(RegistrationJSONizer.fromJson(response.getContentAsString()).isValid());
-        assertTrue(agentService.findAgent(uuid).getStatus().getRuntimeStatus().agentState() == AgentRuntimeStatus.Idle);
-    }
-
-    @Test
-    public void shouldRegisterAgentWithoutAddingAgentConfigToConfigXML_forAlreadyRegisteredAgent() throws Exception {
-        final MockHttpServletRequest request = new MockHttpServletRequest();
-        final MockHttpServletResponse response = new MockHttpServletResponse();
-        final String uuid = registerAgentWithAgentRuntimeStatus(AgentRuntimeStatus.LostContact);
-
-        final ModelAndView modelAndView = controller.agentRequest("hostname", uuid, "sandbox", "100", null, goConfigService.serverConfig().getAgentAutoRegisterKey(), "", "", null, null, null, false, request);
-
-        modelAndView.getView().render(null, null, response);
-
-        assertTrue(goConfigService.hasAgent(uuid));
-        assertThat(response.getStatus(), is(200));
-        assertTrue(RegistrationJSONizer.fromJson(response.getContentAsString()).isValid());
-        assertTrue(agentService.findAgent(uuid).getStatus().getRuntimeStatus().agentState() == AgentRuntimeStatus.Idle);
-    }
-
-    @Test
-    public void shouldNotProcessRegistrationRequestWhenAutoRegisterKeyIsNotProvided_forAlreadyRegisteredAgent() throws Exception {
-        final MockHttpServletRequest request = new MockHttpServletRequest();
-        final MockHttpServletResponse response = new MockHttpServletResponse();
-        final String uuid = registerAgentWithAgentRuntimeStatus(AgentRuntimeStatus.LostContact);
-
-        final ModelAndView modelAndView = controller.agentRequest("hostname", uuid, "sandbox", "100", null, null, "", "", null, null, null, false, request);
-
-        modelAndView.getView().render(null, null, response);
-        assertTrue(goConfigService.hasAgent(uuid));
-        assertThat(response.getStatus(), is(202));
-        assertThat(response.getContentAsString(), is(RegistrationJSONizer.toJson(Registration.createNullPrivateKeyEntry())));
-        assertTrue(agentService.findAgent(uuid).getStatus().getRuntimeStatus().agentState() == AgentRuntimeStatus.LostContact);
-    }
-
-    private String registerAgentWithAgentRuntimeStatus(AgentRuntimeStatus agentRuntimeStatus) throws IOException {
-        final MockHttpServletRequest request = new MockHttpServletRequest();
-        final String uuid = UUID.randomUUID().toString();
-
-        controller.agentRequest("hostname", uuid, "sandbox", "100", null, null, "", "", null, null, null, false, request);
-        AgentConfig agentConfig = goConfigService.agentByUuid(uuid);
-
-        assertTrue(agentService.findAgent(uuid).getStatus().getRuntimeStatus().agentState() == AgentRuntimeStatus.Idle);
-        assertTrue(goConfigService.hasAgent(uuid));
-
-        agentService.updateRuntimeInfo(new AgentRuntimeInfo(
-                agentConfig.getAgentIdentifier(), agentRuntimeStatus, "sandbox", "foo", false)
-        );
-
-        assertTrue(agentService.findAgent(uuid).getStatus().getRuntimeStatus().agentState() == agentRuntimeStatus);
-
-        return uuid;
     }
 }

--- a/server/test/unit/com/thoughtworks/go/server/controller/AgentRegistrationControllerTest.java
+++ b/server/test/unit/com/thoughtworks/go/server/controller/AgentRegistrationControllerTest.java
@@ -23,10 +23,7 @@ import com.thoughtworks.go.config.UpdateConfigCommand;
 import com.thoughtworks.go.domain.materials.tfs.TFSJarDetector;
 import com.thoughtworks.go.plugin.infra.commons.PluginsZip;
 import com.thoughtworks.go.server.domain.Username;
-import com.thoughtworks.go.server.service.AgentConfigService;
-import com.thoughtworks.go.server.service.AgentRuntimeInfo;
-import com.thoughtworks.go.server.service.AgentService;
-import com.thoughtworks.go.server.service.GoConfigService;
+import com.thoughtworks.go.server.service.*;
 import com.thoughtworks.go.server.service.result.HttpOperationResult;
 import com.thoughtworks.go.util.SystemEnvironment;
 import com.thoughtworks.go.util.TestFileUtil;
@@ -35,6 +32,7 @@ import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.web.servlet.ModelAndView;
@@ -245,40 +243,5 @@ public class AgentRegistrationControllerTest {
         try (InputStream is = new TFSJarDetector.DevelopmentServerTFSJarDetector(systemEnvironment).getJarURL().openStream()) {
             assertTrue(Arrays.equals(IOUtils.toByteArray(is), response.getContentAsByteArray()));
         }
-    }
-
-    @Test
-    public void shouldNotRegisterAgentIfAutoRegistrationKeyIsNotProvided_forAlreadyRegisteredAgent() throws Exception {
-        final String uuid = "uuid";
-        final ServerConfig serverConfig = mock(ServerConfig.class);
-
-        when(goConfigService.hasAgent(uuid)).thenReturn(true);
-        when(goConfigService.serverConfig()).thenReturn(serverConfig);
-        when(serverConfig.shouldAutoRegisterAgentWith(anyString())).thenReturn(false);
-
-        controller.agentRequest("host", uuid, "location", "233232", "osx", "", "", "", "", "", "", false, request);
-
-        verify(goConfigService, never()).updateConfig(any(UpdateConfigCommand.class));
-        verifyZeroInteractions(agentConfigService);
-        verifyZeroInteractions(agentService);
-    }
-
-    @Test
-    public void shouldProcessAgentRegistrationIfAgentAutoRegistrationKeyIsProvided_forAlreadyRegisteredAgent() throws Exception {
-        final String uuid = "uuid";
-        final ServerConfig serverConfig = mock(ServerConfig.class);
-        final Username username = new Username("some-agent-login-name");
-
-        when(goConfigService.hasAgent(uuid)).thenReturn(true);
-        when(goConfigService.serverConfig()).thenReturn(serverConfig);
-        when(serverConfig.shouldAutoRegisterAgentWith("some-key")).thenReturn(true);
-        when(agentService.agentUsername(uuid, request.getRemoteAddr(), "host")).thenReturn(username);
-
-        controller.agentRequest("host", uuid, "location", "233232",
-                "osx", "some-key", "", "",
-                "", "", "", false, request);
-
-        verify(agentService).requestRegistration(username, AgentRuntimeInfo.fromServer(new AgentConfig(uuid, "host", request.getRemoteAddr()), false, "location", 233232L, "osx", false));
-        verify(agentConfigService, times(0)).updateAgent(any(UpdateConfigCommand.class), eq(uuid), any(HttpOperationResult.class), eq(username));
     }
 }

--- a/server/test/unit/com/thoughtworks/go/server/controller/AgentRegistrationControllerTest.java
+++ b/server/test/unit/com/thoughtworks/go/server/controller/AgentRegistrationControllerTest.java
@@ -23,7 +23,10 @@ import com.thoughtworks.go.config.UpdateConfigCommand;
 import com.thoughtworks.go.domain.materials.tfs.TFSJarDetector;
 import com.thoughtworks.go.plugin.infra.commons.PluginsZip;
 import com.thoughtworks.go.server.domain.Username;
-import com.thoughtworks.go.server.service.*;
+import com.thoughtworks.go.server.service.AgentConfigService;
+import com.thoughtworks.go.server.service.AgentRuntimeInfo;
+import com.thoughtworks.go.server.service.AgentService;
+import com.thoughtworks.go.server.service.GoConfigService;
 import com.thoughtworks.go.server.service.result.HttpOperationResult;
 import com.thoughtworks.go.util.SystemEnvironment;
 import com.thoughtworks.go.util.TestFileUtil;
@@ -32,7 +35,6 @@ import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.ArgumentCaptor;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.web.servlet.ModelAndView;
@@ -278,30 +280,5 @@ public class AgentRegistrationControllerTest {
 
         verify(agentService).requestRegistration(username, AgentRuntimeInfo.fromServer(new AgentConfig(uuid, "host", request.getRemoteAddr()), false, "location", 233232L, "osx", false));
         verify(agentConfigService, times(0)).updateAgent(any(UpdateConfigCommand.class), eq(uuid), any(HttpOperationResult.class), eq(username));
-    }
-
-    @Test
-    public void shouldRegisterElasticAgent() throws Exception {
-        final String uuid = "uuid";
-        final ServerConfig serverConfig = mock(ServerConfig.class);
-        final Username username = new Username("some-agent-login-name");
-
-        when(goConfigService.hasAgent(uuid)).thenReturn(true);
-        when(goConfigService.serverConfig()).thenReturn(serverConfig);
-        when(serverConfig.shouldAutoRegisterAgentWith("some-key")).thenReturn(true);
-        when(agentService.agentUsername(uuid, request.getRemoteAddr(), "host")).thenReturn(username);
-
-        controller.agentRequest("host", uuid, "location", "233232",
-                "osx", "some-key", "", "",
-                "", "1a2dffb-4832-4fdf-b9e4-5d598cc48c8e", "cd.go.contrib.docker-swarm", false, request);
-
-        final ArgumentCaptor<ElasticAgentRuntimeInfo> argumentCaptor = ArgumentCaptor.forClass(ElasticAgentRuntimeInfo.class);
-
-        verify(agentService).requestRegistration(eq(username), argumentCaptor.capture());
-        verify(agentConfigService, times(0)).updateAgent(any(UpdateConfigCommand.class), eq(uuid), any(HttpOperationResult.class), eq(username));
-
-        final ElasticAgentRuntimeInfo agentRuntimeInfo = argumentCaptor.getValue();
-        assertThat(agentRuntimeInfo.getElasticAgentId(), is("1a2dffb-4832-4fdf-b9e4-5d598cc48c8e"));
-        assertThat(agentRuntimeInfo.getElasticPluginId(), is("cd.go.contrib.docker-swarm"));
     }
 }


### PR DESCRIPTION

### Manual registration of agent is broken due to this PRs https://github.com/gocd/gocd/pull/3918 and https://github.com/gocd/gocd/pull/3935

#### Step to reproduce
1. Register a agent with GoCD server without auto-register key
2. Server registers the agent in `pending` state and returns an empty
certs to agent. Agent will periodically in a loop to obtain a valid certs from
server
3. Approve agent from agents SPA. This will add the agent config to
config xml.
4. Agent will ask server for certificates. Since agent is already in
config server denies certificates saying agent is already register with
server