### PR TITLE
CCtray lists pipelines for users belonging to plugin role #3954

### DIFF
--- a/config/config-api/src/com/thoughtworks/go/config/SecurityConfig.java
+++ b/config/config-api/src/com/thoughtworks/go/config/SecurityConfig.java
@@ -177,4 +177,13 @@ public class SecurityConfig implements Validatable {
         }
         return result;
     }
+
+    public PluginRoleConfig getPluginRole(CaseInsensitiveString roleName) {
+        for (PluginRoleConfig pluginRoleConfig : rolesConfig.getPluginRoleConfigs()) {
+            if (pluginRoleConfig.getName().equals(roleName)) {
+                return pluginRoleConfig;
+            }
+        }
+        return null;
+    }
 }

--- a/config/config-api/test/com/thoughtworks/go/config/SecurityConfigTest.java
+++ b/config/config-api/test/com/thoughtworks/go/config/SecurityConfigTest.java
@@ -197,4 +197,21 @@ public class SecurityConfigTest {
 
         assertThat(pluginRolesConfig, hasSize(0));
     }
+
+    @Test
+    public void getPluginRole_shouldReturnPluginRoleMatchingTheGivenName() throws Exception {
+        PluginRoleConfig role = new PluginRoleConfig("foo", "ldap");
+        SecurityConfig securityConfig = new SecurityConfig();
+
+        securityConfig.addRole(role);
+
+        assertThat(securityConfig.getPluginRole(new CaseInsensitiveString("FOO")), is(role));
+    }
+
+    @Test
+    public void getPluginRole_shouldReturnNullInAbsenceOfPluginRoleForTheGivenName() throws Exception {
+        SecurityConfig securityConfig = new SecurityConfig();
+
+        assertNull(securityConfig.getPluginRole(new CaseInsensitiveString("foo")));
+    }
 }

--- a/config/config-api/test/com/thoughtworks/go/helper/GoConfigMother.java
+++ b/config/config-api/test/com/thoughtworks/go/helper/GoConfigMother.java
@@ -315,4 +315,8 @@ public class GoConfigMother {
         )));
         return cruiseConfig;
     }
+
+    public PluginRoleConfig createPluginRole(String roleName, String pluginId) {
+        return new PluginRoleConfig(roleName, pluginId);
+    }
 }

--- a/server/src/com/thoughtworks/go/domain/cctray/CcTrayViewAuthority.java
+++ b/server/src/com/thoughtworks/go/domain/cctray/CcTrayViewAuthority.java
@@ -61,11 +61,28 @@ public class CcTrayViewAuthority {
                 viewers.addAll(pipelineGroupAdmins);
                 viewers.addAll(pipelineGroupViewers);
 
-                pipelinesAndViewers.put(pipelineConfigs.getGroup(), new AllowedViewers(viewers));
+                Set<PluginRoleConfig> roles = new HashSet<>();
+                roles.addAll(pluginRolesFor(pipelineConfigs.getAuthorization().getAdminsConfig().getRoles()));
+                roles.addAll(pluginRolesFor(pipelineConfigs.getAuthorization().getViewConfig().getRoles()));
+
+                pipelinesAndViewers.put(pipelineConfigs.getGroup(), new AllowedViewers(viewers, roles));
             }
         });
 
         return pipelinesAndViewers;
+    }
+
+    private Set<PluginRoleConfig> pluginRolesFor(List<AdminRole> roles) {
+        Set<PluginRoleConfig> pluginRoleConfigs = new HashSet<>();
+
+        for (AdminRole role : roles) {
+            PluginRoleConfig pluginRole = goConfigService.security().getPluginRole(role.getName());
+            if (pluginRole != null) {
+                pluginRoleConfigs.add(pluginRole);
+            }
+        }
+
+        return pluginRoleConfigs;
     }
 
     private Set<String> namesOf(AdminsConfig adminsConfig, Map<String, Collection<String>> rolesToUsers) {

--- a/server/src/com/thoughtworks/go/domain/cctray/viewers/AllowedViewers.java
+++ b/server/src/com/thoughtworks/go/domain/cctray/viewers/AllowedViewers.java
@@ -16,6 +16,9 @@
 
 package com.thoughtworks.go.domain.cctray.viewers;
 
+import com.thoughtworks.go.config.CaseInsensitiveString;
+import com.thoughtworks.go.config.PluginRoleConfig;
+import com.thoughtworks.go.config.RoleUser;
 import org.apache.commons.lang.builder.ToStringBuilder;
 
 import java.util.HashSet;
@@ -23,9 +26,11 @@ import java.util.Set;
 
 /* Understands: The set of viewers it has. */
 public class AllowedViewers implements Viewers {
+    private final Set<PluginRoleConfig> allowedRoles;
     private Set<String> allowedUsers = new HashSet<>();
 
-    public AllowedViewers(Set<String> allowedUsers) {
+    public AllowedViewers(Set<String> allowedUsers, Set<PluginRoleConfig> allowedRoles) {
+        this.allowedRoles = allowedRoles;
         for (String user : allowedUsers) {
             this.allowedUsers.add(user.toLowerCase());
         }
@@ -33,7 +38,17 @@ public class AllowedViewers implements Viewers {
 
     @Override
     public boolean contains(String username) {
-        return allowedUsers.contains(username.toLowerCase());
+        return allowedUsers.contains(username.toLowerCase()) || containsInRole(username);
+    }
+
+    private boolean containsInRole(String username) {
+        for (PluginRoleConfig role : allowedRoles) {
+            for (RoleUser r : role.getUsers()) {
+                if (r.getName().equals(new CaseInsensitiveString(username)))
+                    return true;
+            }
+        }
+        return false;
     }
 
     @Override

--- a/server/src/com/thoughtworks/go/domain/cctray/viewers/AllowedViewers.java
+++ b/server/src/com/thoughtworks/go/domain/cctray/viewers/AllowedViewers.java
@@ -58,12 +58,15 @@ public class AllowedViewers implements Viewers {
 
         AllowedViewers that = (AllowedViewers) o;
 
-        return allowedUsers.equals(that.allowedUsers);
+        if (allowedRoles != null ? !allowedRoles.equals(that.allowedRoles) : that.allowedRoles != null) return false;
+        return allowedUsers != null ? allowedUsers.equals(that.allowedUsers) : that.allowedUsers == null;
     }
 
     @Override
     public int hashCode() {
-        return allowedUsers.hashCode();
+        int result = allowedRoles != null ? allowedRoles.hashCode() : 0;
+        result = 31 * result + (allowedUsers != null ? allowedUsers.hashCode() : 0);
+        return result;
     }
 
     @Override

--- a/server/test/unit/com/thoughtworks/go/domain/activity/ProjectStatusTest.java
+++ b/server/test/unit/com/thoughtworks/go/domain/activity/ProjectStatusTest.java
@@ -22,6 +22,7 @@ import com.thoughtworks.go.util.DateUtils;
 import org.jdom2.Element;
 import org.junit.Test;
 
+import java.util.Collections;
 import java.util.Date;
 
 import static com.thoughtworks.go.util.DataStructureUtils.s;
@@ -98,7 +99,7 @@ public class ProjectStatusTest {
         assertThat(status.canBeViewedBy("abc"), is(false));
         assertThat(status.canBeViewedBy("def"), is(false));
 
-        status.updateViewers(new AllowedViewers(s("abc", "ghi")));
+        status.updateViewers(new AllowedViewers(s("abc", "ghi"), Collections.emptySet()));
 
         assertThat(status.canBeViewedBy("abc"), is(true));
         assertThat(status.canBeViewedBy("def"), is(false));

--- a/server/test/unit/com/thoughtworks/go/domain/cctray/CcTrayJobStatusChangeHandlerTest.java
+++ b/server/test/unit/com/thoughtworks/go/domain/cctray/CcTrayJobStatusChangeHandlerTest.java
@@ -16,6 +16,7 @@
 
 package com.thoughtworks.go.domain.cctray;
 
+import com.thoughtworks.go.config.PluginRoleConfig;
 import com.thoughtworks.go.domain.JobInstance;
 import com.thoughtworks.go.domain.activity.ProjectStatus;
 import com.thoughtworks.go.domain.cctray.viewers.AllowedViewers;
@@ -107,7 +108,7 @@ public class CcTrayJobStatusChangeHandlerTest {
 
     @Test
     public void shouldReuseViewersListFromExistingStatusWhenCreatingNewStatus() throws Exception {
-        Viewers viewers = new AllowedViewers(s("viewer1", "viewer2"));
+        Viewers viewers = new AllowedViewers(s("viewer1", "viewer2"), Collections.singleton(new PluginRoleConfig("admin", "ldap")));
 
         ProjectStatus oldStatusInCache = new ProjectStatus(projectNameFor("job1"), "OldActivity", "OldStatus", "OldLabel", new Date(), webUrlFor("job1"));
         oldStatusInCache.updateViewers(viewers);

--- a/server/test/unit/com/thoughtworks/go/domain/cctray/CcTrayStageStatusChangeHandlerTest.java
+++ b/server/test/unit/com/thoughtworks/go/domain/cctray/CcTrayStageStatusChangeHandlerTest.java
@@ -16,6 +16,7 @@
 
 package com.thoughtworks.go.domain.cctray;
 
+import com.thoughtworks.go.config.PluginRoleConfig;
 import com.thoughtworks.go.domain.JobInstance;
 import com.thoughtworks.go.domain.NullStage;
 import com.thoughtworks.go.domain.Stage;
@@ -30,9 +31,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
 
-import java.util.Date;
-import java.util.HashSet;
-import java.util.List;
+import java.util.*;
 
 import static com.thoughtworks.go.util.DataStructureUtils.s;
 import static org.hamcrest.CoreMatchers.is;
@@ -155,7 +154,7 @@ public class CcTrayStageStatusChangeHandlerTest {
 
     @Test
     public void shouldReuseViewersListFromExistingStatusWhenCreatingNewStatus() throws Exception {
-        Viewers viewers = viewers("viewer1", "viewer2");
+        Viewers viewers = viewers(Collections.singleton(new PluginRoleConfig("admin", "ldap")),"viewer1", "viewer2");
 
         String projectName = "pipeline :: stage1";
         ProjectStatus existingStageStatus = new ProjectStatus(projectName, "OldActivity", "OldStatus", "OldLabel", new Date(), webUrlFor("stage1"));
@@ -209,7 +208,7 @@ public class CcTrayStageStatusChangeHandlerTest {
         return "some-path/pipelines/pipeline/1/" + stageName + "/1";
     }
 
-    private Viewers viewers(String... users) {
-        return new AllowedViewers(s(users));
+    private Viewers viewers(Set<PluginRoleConfig> roles, String... users) {
+        return new AllowedViewers(s(users), roles);
     }
 }

--- a/server/test/unit/com/thoughtworks/go/server/service/CcTrayServiceTest.java
+++ b/server/test/unit/com/thoughtworks/go/server/service/CcTrayServiceTest.java
@@ -25,6 +25,8 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 
+import java.util.Collections;
+
 import static com.thoughtworks.go.fixture.IntegrationTestsFixture.login;
 import static com.thoughtworks.go.fixture.IntegrationTestsFixture.resetSecurityContext;
 import static com.thoughtworks.go.util.DataStructureUtils.s;
@@ -133,6 +135,6 @@ public class CcTrayServiceTest {
     }
 
     private Viewers viewers(String... users) {
-        return new AllowedViewers(s(users));
+        return new AllowedViewers(s(users), Collections.emptySet());
     }
 }


### PR DESCRIPTION
* If a 'pluginRole' is authorized to view a pipeline_group, during
  generating the CcTray cache AllowedViewers for a pipeline would list
  users of a pluginRole with a active session. Thereby any users for
  this role who would login after the cache is generated would not be
  able to list these pipelines. With this commit, AllowedViewers would
  have a list of PluginRoleConfigs, which would give an accurate list of
  users at any given point of time.
* Changes to any SecurityAuthConfig(Role And AuthConfig) through the API
  would now refresh the CCTrayCache.
* If super admins are defined only through a 'role' or 'pluginRole' CCTrayViewAuthority considers
  it as presence of superAdmins. This would be true even if the configured roles do not have users
  defined. This is consitent with how dashboard behaves.
* CCTrayViewAuthority considers all super admins defined using
  pluginRole as viewers of pipeline_group.
* ViewAuthority for users belonging to pluginRole was cached earlier,
  with this commit it is resloved during access of ccTray.