### PR TITLE
Get rid of intermediate config xmls stored while config migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -154,5 +154,3 @@ out/
 config/config-server/warnings.log
 server/dev
 **/.DS_Store
-server/config/go-config-before-migration-91.xml
-server/config/go-config-before-migration-92.xml

--- a/config/config-server/src/com/thoughtworks/go/config/GoConfigMigration.java
+++ b/config/config-server/src/com/thoughtworks/go/config/GoConfigMigration.java
@@ -39,10 +39,8 @@ import javax.xml.transform.stream.StreamResult;
 import javax.xml.transform.stream.StreamSource;
 import java.io.*;
 import java.net.URL;
-import java.nio.charset.Charset;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 import static com.thoughtworks.go.util.ExceptionUtils.bomb;
@@ -64,7 +62,6 @@ public class GoConfigMigration {
     private final ConfigElementImplementationRegistry registry;
 
     public static final String UPGRADE = "Upgrade";
-    private static List<Integer> riskyMigrations = Arrays.asList(91, 92);
 
     @Autowired
     public GoConfigMigration(final ConfigRepository configRepository, final TimeProvider timeProvider, ConfigCache configCache, ConfigElementImplementationRegistry registry, SystemEnvironment systemEnvironment) {
@@ -222,25 +219,11 @@ public class GoConfigMigration {
 
         for (URL upgradeScript : upgradeScripts) {
             validate(content);
-            backupConfigForRiskyMigrations(content, upgradeScript);
             content = upgrade(content, upgradeScript);
         }
         validate(content);
         LOG.info("Finished upgrading config file");
         return content;
-    }
-
-    private void backupConfigForRiskyMigrations(String content, URL upgradeScript) {
-        for (int riskyMigration : riskyMigrations) {
-            File backup = new File(systemEnvironment.configDir(), String.format("go-config-before-migration-%s.xml", riskyMigration));
-            if (upgradeScript.getFile().endsWith(String.format("/%s.xsl", riskyMigration))) {
-                try {
-                    FileUtils.writeStringToFile(backup, content, Charset.forName("UTF-8"));
-                } catch (IOException e) {
-                    LOG.error("Could not backup file: {}, content", backup.getAbsolutePath());
-                }
-            }
-        }
     }
 
     private void validate(String content) {

--- a/config/config-server/src/com/thoughtworks/go/config/GoConfigMigration.java
+++ b/config/config-server/src/com/thoughtworks/go/config/GoConfigMigration.java
@@ -20,7 +20,6 @@ import com.thoughtworks.go.config.registry.ConfigElementImplementationRegistry;
 import com.thoughtworks.go.domain.GoConfigRevision;
 import com.thoughtworks.go.service.ConfigRepository;
 import com.thoughtworks.go.util.CachedDigestUtils;
-import com.thoughtworks.go.util.SystemEnvironment;
 import com.thoughtworks.go.util.TimeProvider;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
@@ -57,14 +56,13 @@ public class GoConfigMigration {
     private final UpgradeFailedHandler upgradeFailed;
     private final ConfigRepository configRepository;
     private final TimeProvider timeProvider;
-    private final SystemEnvironment systemEnvironment;
     private ConfigCache configCache;
     private final ConfigElementImplementationRegistry registry;
 
     public static final String UPGRADE = "Upgrade";
 
     @Autowired
-    public GoConfigMigration(final ConfigRepository configRepository, final TimeProvider timeProvider, ConfigCache configCache, ConfigElementImplementationRegistry registry, SystemEnvironment systemEnvironment) {
+    public GoConfigMigration(final ConfigRepository configRepository, final TimeProvider timeProvider, ConfigCache configCache, ConfigElementImplementationRegistry registry) {
         this(new UpgradeFailedHandler() {
             public void handle(Exception e) {
                 e.printStackTrace();
@@ -80,17 +78,16 @@ public class GoConfigMigration {
                 }).start();
 
             }
-        }, configRepository, timeProvider, configCache, registry, systemEnvironment);
+        }, configRepository, timeProvider, configCache, registry);
     }
 
     GoConfigMigration(UpgradeFailedHandler upgradeFailed, ConfigRepository configRepository, TimeProvider timeProvider,
-                      ConfigCache configCache, ConfigElementImplementationRegistry registry, SystemEnvironment systemEnvironment) {
+                      ConfigCache configCache, ConfigElementImplementationRegistry registry) {
         this.upgradeFailed = upgradeFailed;
         this.configRepository = configRepository;
         this.timeProvider = timeProvider;
         this.configCache = configCache;
         this.registry = registry;
-        this.systemEnvironment = systemEnvironment;
     }
 
     //  This method should be removed once upgrade is done using new com.thoughtworks.go.config.GoConfigMigrator#migrate()

--- a/config/config-server/test/com/thoughtworks/go/config/ConfigMigrator.java
+++ b/config/config-server/test/com/thoughtworks/go/config/ConfigMigrator.java
@@ -38,7 +38,7 @@ public class ConfigMigrator {
                 }
                 throw bomb(e.getMessage() + ": content=\n" + content + "\n" + (e.getCause() == null ? "" : e.getCause().getMessage()), e);
             }
-        }, mock(ConfigRepository.class), new TimeProvider(), new ConfigCache(), registry, new SystemEnvironment()
+        }, mock(ConfigRepository.class), new TimeProvider(), new ConfigCache(), registry
         );
         //TODO: LYH & GL GoConfigMigration should be able to handle stream instead of binding to file
         upgrader.upgradeIfNecessary(configFile, "N/A");

--- a/config/config-server/test/com/thoughtworks/go/config/GoConfigMigrationTest.java
+++ b/config/config-server/test/com/thoughtworks/go/config/GoConfigMigrationTest.java
@@ -70,7 +70,7 @@ public class GoConfigMigrationTest {
 
         ConfigElementImplementationRegistry registry = ConfigElementImplementationRegistryMother.withNoPlugins();
 
-        goConfigMigration = new GoConfigMigration(configRepo, timeProvider, new ConfigCache(), registry, mock(SystemEnvironment.class));
+        goConfigMigration = new GoConfigMigration(configRepo, timeProvider, new ConfigCache(), registry);
     }
 
     @After

--- a/server/test/integration/com/thoughtworks/go/config/GoConfigMigrationIntegrationTest.java
+++ b/server/test/integration/com/thoughtworks/go/config/GoConfigMigrationIntegrationTest.java
@@ -153,7 +153,7 @@ public class GoConfigMigrationIntegrationTest {
 
     @Test
     public void shouldMigrateConfigContentAsAString() throws Exception {
-        String newContent = new GoConfigMigration(configRepository, new TimeProvider(), configCache, ConfigElementImplementationRegistryMother.withNoPlugins(), systemEnvironment)
+        String newContent = new GoConfigMigration(configRepository, new TimeProvider(), configCache, ConfigElementImplementationRegistryMother.withNoPlugins())
                 .upgradeIfNecessary(ConfigFileFixture.VERSION_0);
         assertThat(newContent, containsString("schemaVersion=\"" + GoConfigSchema.currentSchemaVersion() + "\""));
     }
@@ -161,7 +161,7 @@ public class GoConfigMigrationIntegrationTest {
     @Test
     public void shouldNotMigrateConfigContentAsAStringWhenAlreadyUpToDate() throws Exception {
         GoConfigMigration configMigration = new GoConfigMigration(configRepository, new TimeProvider(), configCache,
-                ConfigElementImplementationRegistryMother.withNoPlugins(), new SystemEnvironment());
+                ConfigElementImplementationRegistryMother.withNoPlugins());
         String newContent = configMigration.upgradeIfNecessary(ConfigFileFixture.VERSION_0);
         assertThat(newContent, is(configMigration.upgradeIfNecessary(newContent)));
     }
@@ -295,7 +295,7 @@ public class GoConfigMigrationIntegrationTest {
                     public void handle(Exception e) {
                         exs.add(e);
                     }
-                }, configRepository, new TimeProvider(), configCache, ConfigElementImplementationRegistryMother.withNoPlugins(), new SystemEnvironment());
+                }, configRepository, new TimeProvider(), configCache, ConfigElementImplementationRegistryMother.withNoPlugins());
         FileUtils.writeStringToFile(configFile, ConfigFileFixture.JOBS_WITH_DIFFERNT_CASE);
 
         upgrader.upgradeIfNecessary(configFile, currentGoServerVersion);
@@ -310,7 +310,7 @@ public class GoConfigMigrationIntegrationTest {
                     public void handle(Exception e) {
                         throw new AssertionError("upgrade failed!!!!!");
                     }
-                }, configRepository, new TimeProvider(), configCache, ConfigElementImplementationRegistryMother.withNoPlugins(), new SystemEnvironment());
+                }, configRepository, new TimeProvider(), configCache, ConfigElementImplementationRegistryMother.withNoPlugins());
         FileUtils.writeStringToFile(configFile, ConfigFileFixture.DEFAULT_XML_WITH_2_AGENTS);
         configRepository.checkin(new GoConfigRevision("dummy-content", "some-md5", "loser", "100.3.1", new TimeProvider()));
 
@@ -474,7 +474,7 @@ public class GoConfigMigrationIntegrationTest {
                     public void handle(Exception e) {
                         exs.add(e);
                     }
-                }, configRepository, new TimeProvider(), configCache, ConfigElementImplementationRegistryMother.withNoPlugins(), new SystemEnvironment());
+                }, configRepository, new TimeProvider(), configCache, ConfigElementImplementationRegistryMother.withNoPlugins());
         String configContent = ConfigFileFixture.configWithPipeline(String.format(
                 "<pipeline name='pipeline1'>"
                         + "    <materials>"
@@ -549,7 +549,7 @@ public class GoConfigMigrationIntegrationTest {
                     public void handle(Exception e) {
                         exs.add(e);
                     }
-                }, configRepository, new TimeProvider(), configCache, ConfigElementImplementationRegistryMother.withNoPlugins(), new SystemEnvironment()
+                }, configRepository, new TimeProvider(), configCache, ConfigElementImplementationRegistryMother.withNoPlugins()
         );
         String configContent = ConfigFileFixture.configWithPipeline(String.format(
                 "<pipeline name='pipeline1'>"
@@ -587,7 +587,7 @@ public class GoConfigMigrationIntegrationTest {
                     public void handle(Exception e) {
                         exs.add(e);
                     }
-                }, configRepository, new TimeProvider(), configCache, ConfigElementImplementationRegistryMother.withNoPlugins(), new SystemEnvironment());
+                }, configRepository, new TimeProvider(), configCache, ConfigElementImplementationRegistryMother.withNoPlugins());
 
         String content = "<cruise schemaVersion='" + 47 + "'>\n"
                 + "<server artifactsdir=\"logs\" siteUrl=\"http://go-server-site-url:8153\" secureSiteUrl=\"https://go-server-site-url:8154\" jobTimeout=\"60\">\n"
@@ -1521,7 +1521,7 @@ public class GoConfigMigrationIntegrationTest {
                         e.printStackTrace();
                         exs.add(e);
                     }
-                }, configRepository, new TimeProvider(), configCache, ConfigElementImplementationRegistryMother.withNoPlugins(), new SystemEnvironment()
+                }, configRepository, new TimeProvider(), configCache, ConfigElementImplementationRegistryMother.withNoPlugins()
         );
         Method upgrade = upgrader.getClass().getDeclaredMethod("upgrade", String.class, Integer.TYPE, Integer.TYPE);
         upgrade.setAccessible(true);
@@ -1543,7 +1543,7 @@ public class GoConfigMigrationIntegrationTest {
                 }
                 throw bomb(e.getMessage() + ": content=\n" + content, e);
             }
-        }, configRepository, new TimeProvider(), configCache, registry, new SystemEnvironment()
+        }, configRepository, new TimeProvider(), configCache, registry
         );
         SystemEnvironment sysEnv = new SystemEnvironment();
         FullConfigSaveNormalFlow normalFlow = new FullConfigSaveNormalFlow(configCache, registry, sysEnv, serverVersion, new TimeProvider(), configRepository, cachedGoPartials);

--- a/server/test/integration/com/thoughtworks/go/config/GoFileConfigDataSourceTest.java
+++ b/server/test/integration/com/thoughtworks/go/config/GoFileConfigDataSourceTest.java
@@ -109,7 +109,7 @@ public class GoFileConfigDataSourceTest {
             public void handle(Exception e) {
                 throw new RuntimeException(e);
             }
-        }, configRepository, new TimeProvider(), configCache, registry, systemEnvironment),
+        }, configRepository, new TimeProvider(), configCache, registry),
                 configRepository, systemEnvironment, timeProvider, configCache, serverVersion, registry, mock(ServerHealthService.class),
                 cachedGoPartials, fullConfigSaveMergeFlow, fullConfigSaveNormalFlow);
 

--- a/server/test/unit/com/thoughtworks/go/config/DoNotUpgrade.java
+++ b/server/test/unit/com/thoughtworks/go/config/DoNotUpgrade.java
@@ -17,14 +17,13 @@
 package com.thoughtworks.go.config;
 
 import com.thoughtworks.go.util.ConfigElementImplementationRegistryMother;
-import com.thoughtworks.go.util.SystemEnvironment;
 import com.thoughtworks.go.util.TimeProvider;
 
 import java.io.File;
 
 public class DoNotUpgrade extends GoConfigMigration {
     public DoNotUpgrade() {
-        super(null, new TimeProvider(), null, ConfigElementImplementationRegistryMother.withNoPlugins(),new SystemEnvironment());
+        super(null, new TimeProvider(), null, ConfigElementImplementationRegistryMother.withNoPlugins());
     }
 
     public GoConfigMigrationResult upgradeIfNecessary(File configFile, final String currentGoServerVersion) {

--- a/server/test/unit/com/thoughtworks/go/server/service/GoConfigServiceTest.java
+++ b/server/test/unit/com/thoughtworks/go/server/service/GoConfigServiceTest.java
@@ -25,7 +25,6 @@ import com.thoughtworks.go.config.materials.PluggableSCMMaterialConfig;
 import com.thoughtworks.go.config.materials.dependency.DependencyMaterialConfig;
 import com.thoughtworks.go.config.materials.svn.SvnMaterialConfig;
 import com.thoughtworks.go.config.registry.ConfigElementImplementationRegistry;
-import com.thoughtworks.go.config.remote.FileConfigOrigin;
 import com.thoughtworks.go.config.remote.RepoConfigOrigin;
 import com.thoughtworks.go.config.update.ConfigUpdateResponse;
 import com.thoughtworks.go.config.update.FullConfigUpdateCommand;
@@ -117,7 +116,7 @@ public class GoConfigServiceTest {
 
         ConfigElementImplementationRegistry registry = ConfigElementImplementationRegistryMother.withNoPlugins();
         goConfigService = new GoConfigService(goConfigDao, pipelineRepository, this.clock, new GoConfigMigration(configRepo, new TimeProvider(), new ConfigCache(),
-                registry, systemEnvironment), goCache, configRepo, registry,
+                registry), goCache, configRepo, registry,
                 instanceFactory, mock(CachedGoPartials.class), systemEnvironment);
     }
 


### PR DESCRIPTION
Removed migration backup code. https://github.com/gocd/gocd/issues/3854