### PR TITLE
Fix issue with whitespace (#3966)

### DIFF
--- a/installers/go-agent/release/agent.sh
+++ b/installers/go-agent/release/agent.sh
@@ -126,8 +126,11 @@ if [ "$VNC" == "Y" ]; then
     export DISPLAY
 fi
 
-AGENT_STARTUP_ARGS="-Dcruise.console.publish.interval=10 -Xms$AGENT_MEM -Xmx$AGENT_MAX_MEM -Dgocd.agent.log.dir=$GO_AGENT_LOG_DIR $GO_AGENT_SYSTEM_PROPERTIES"
+AGENT_STARTUP_ARGS="-Dcruise.console.publish.interval=10 -Xms$AGENT_MEM -Xmx$AGENT_MAX_MEM $GO_AGENT_SYSTEM_PROPERTIES"
 
+if [ "$1" == "service_mode" ]; then
+  AGENT_STARTUP_ARGS="$AGENT_STARTUP_ARGS -Dgocd.agent.log.dir=$GO_AGENT_LOG_DIR"
+fi
 
 if [ "$TMPDIR" != "" ]; then
     AGENT_STARTUP_ARGS="$AGENT_STARTUP_ARGS -Djava.io.tmpdir=$TMPDIR"


### PR DESCRIPTION
The current implementation of
`AgentProcessParentImpl#agentInvocationCommand` will look at
`AGENT_STARTUP_ARGS` env and split those by a whitespace which causes
an incorrect command line to be assembled.

We now set the log dir in `agent.sh` only in cases where the agent is
invoked via init script. When executed via `./agent.sh`, the default log
dir is `$PWD/logs` and need not be passed in.