### PR TITLE
Upgrade jgit to 4.9.0.201710071750-r

### DIFF
--- a/config/config-server/build.gradle
+++ b/config/config-server/build.gradle
@@ -19,7 +19,7 @@ description = 'API to configure/access cruise-config.xml'
 dependencies {
   compile project(':config-api')
   compile project(':common')
-  compile(group: 'org.eclipse.jgit', name: 'org.eclipse.jgit', version: '4.7.0.201704051617-r') {
+  compile(group: 'org.eclipse.jgit', name: 'org.eclipse.jgit', version: '4.9.0.201710071750-r') {
     exclude(group: 'org.apache.httpcomponents')
   }
   compile group: 'org.slf4j', name: 'slf4j-api', version: project.versions.slf4j

--- a/development-utility/development-server/build.gradle
+++ b/development-utility/development-server/build.gradle
@@ -31,7 +31,7 @@ dependencies {
   compile group: 'org.eclipse.jetty', name: 'jetty-util', version: versions.jetty
   compile group: 'org.eclipse.jetty.websocket', name: 'websocket-server', version: versions.jetty
 
-  compile group: 'org.eclipse.jgit', name: 'org.eclipse.jgit.http.server', version: '4.7.0.201704051617-r'
+  compile group: 'org.eclipse.jgit', name: 'org.eclipse.jgit.http.server', version: '4.9.0.201710071750-r'
   compile project(':jetty9')
   compile group: 'javax.servlet', name: 'javax.servlet-api', version: '3.1.0'
   compile group: 'org.jruby', name: 'jruby-complete', version: '1.7.26'

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -577,7 +577,7 @@ task verifyWar(type: VerifyJarTask) {
       "objenesis-1.2.jar",
       "org.apache.felix.framework-${project.versions.felix}.jar",
       "org.eclipse.jgit-4.7.0.201704051617-r.jar",
-      "org.eclipse.jgit.http.server-4.7.0.201704051617-r.jar",
+      "org.eclipse.jgit.http.server-4.9.0.201710071750-r.jar",
       "oscache-2.4.1.jar",
       "plugin-metadata-store-${project.version}.jar",
       "quartz-1.6.5.jar",


### PR DESCRIPTION
Checked that the gc method will be called after the merge command, but since we have `gc.auto 0` in the config, jgit gc will not actually run after every merge. 
Also checked that after the merge operation, the number of loose objects will increase and this will only reduce while we run `garbageCollect()` via the cron.  