### PR TITLE
#4008 - Fixed bug

### DIFF
--- a/config/config-api/src/main/java/com/thoughtworks/go/config/GoConfigHolder.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/GoConfigHolder.java
@@ -1,18 +1,18 @@
-/*************************GO-LICENSE-START*********************************
- * Copyright 2014 ThoughtWorks, Inc.
+/*
+ * Copyright 2018 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *************************GO-LICENSE-END***********************************/
+ */
 
 package com.thoughtworks.go.config;
 
@@ -24,5 +24,10 @@ public class GoConfigHolder {
     public GoConfigHolder(CruiseConfig config, CruiseConfig configForEdit) {
         this.config = config;
         this.configForEdit = configForEdit;
+    }
+
+    public GoConfigHolder(CruiseConfig config, CruiseConfig configForEdit, CruiseConfig mergedConfigForEdit) {
+        this(config, configForEdit);
+        this.mergedConfigForEdit = mergedConfigForEdit;
     }
 }

--- a/server/src/main/java/com/thoughtworks/go/config/GoFileConfigDataSource.java
+++ b/server/src/main/java/com/thoughtworks/go/config/GoFileConfigDataSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 ThoughtWorks, Inc.
+ * Copyright 2018 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -312,7 +312,14 @@ public class GoFileConfigDataSource {
                 writeToConfigXmlFile(configAsXml);
                 checkinConfigToGitRepo(partials, preprocessedConfig, configAsXml, md5, currentUser.getUsername().toString());
                 LOGGER.debug("[Config Save] Done writing with lock");
-                return new EntityConfigSaveResult(updatingCommand.getPreprocessedEntityConfig(), new GoConfigHolder(preprocessedConfig, modifiedConfig));
+                CruiseConfig mergedCruiseConfigForEdit = modifiedConfig;
+                if (!partials.isEmpty()) {
+                    LOGGER.debug("[Config Save] Updating GoConfigHolder with mergedCruiseConfigForEdit: Starting.");
+                    mergedCruiseConfigForEdit = cloner.deepClone(modifiedConfig);
+                    mergedCruiseConfigForEdit.merge(partials, true);
+                    LOGGER.debug("[Config Save] Updating GoConfigHolder with mergedCruiseConfigForEdit: Done.");
+                }
+                return new EntityConfigSaveResult(updatingCommand.getPreprocessedEntityConfig(), new GoConfigHolder(preprocessedConfig, modifiedConfig, mergedCruiseConfigForEdit));
             } catch (Exception e) {
                 throw new RuntimeException("failed to save : " + e.getMessage());
             }


### PR DESCRIPTION
mergedConfigForEdit in CachedGoConfig wasn't being updated when using entity-save commands
This caused the pipeline-config APIs to behave inconsistently with the pipelines defined in config-repo. The same would happen to environments API for remote environments