### PR TITLE
Do not send JobPlans to agents

### DIFF
--- a/agent/test/unit/com/thoughtworks/go/agent/JobRunnerTest.java
+++ b/agent/test/unit/com/thoughtworks/go/agent/JobRunnerTest.java
@@ -101,25 +101,6 @@ public class JobRunnerTest {
         verifyNoMoreInteractions(resolver);
     }
 
-    private BuildWork getWork(JobConfig jobConfig) {
-        CruiseConfig config = new BasicCruiseConfig();
-        config.server().setArtifactsDir("logs");
-        String stageName = "mingle";
-        String pipelineName = "pipeline1";
-        config.addPipeline(BasicPipelineConfigs.DEFAULT_GROUP, new PipelineConfig(new CaseInsensitiveString(pipelineName), new MaterialConfigs(), new StageConfig(
-                new CaseInsensitiveString(stageName), new JobConfigs(jobConfig))));
-
-        String pipelineLabel = "100";
-        JobPlan jobPlan = JobInstanceMother.createJobPlan(jobConfig, new JobIdentifier(pipelineName, -2, pipelineLabel, stageName, "100", JOB_PLAN_NAME, 0L), new DefaultSchedulingContext());
-        jobPlan.setFetchMaterials(true);
-        jobPlan.setCleanWorkingDir(false);
-
-        List<Builder> builder = BuilderMother.createBuildersAssumingAllExecTasks(config, pipelineName, stageName, JOB_PLAN_NAME);
-
-        BuildAssignment buildAssignment = BuildAssignment.create(jobPlan, BuildCause.createWithEmptyModifications(), builder, new File(CruiseConfig.WORKING_BASE_DIR + pipelineName));
-        return new BuildWork(buildAssignment);
-    }
-
     @Test
     public void shouldDoNothingWhenJobIsNotCancelled() {
         runner.setWork(work);

--- a/common/src/com/thoughtworks/go/remote/work/ArtifactsPublisher.java
+++ b/common/src/com/thoughtworks/go/remote/work/ArtifactsPublisher.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2017 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.remote.work;
+
+import com.thoughtworks.go.config.ArtifactPlan;
+import com.thoughtworks.go.config.ArtifactPlans;
+import com.thoughtworks.go.config.TestArtifactPlan;
+import com.thoughtworks.go.util.GoConstants;
+import com.thoughtworks.go.work.GoPublisher;
+
+import java.io.File;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+
+public class ArtifactsPublisher implements Serializable {
+    public void publishArtifacts(GoPublisher goPublisher, File workingDirectory, List<ArtifactPlan> assignment) {
+        ArtifactPlans mergedPlans = mergePlansForTest(assignment);
+
+        List<ArtifactPlan> failedArtifact = new ArrayList<>();
+        for (ArtifactPlan artifactPlan : mergedPlans) {
+            try {
+                artifactPlan.publish(goPublisher, workingDirectory);
+            } catch (Exception e) {
+                failedArtifact.add(artifactPlan);
+            }
+        }
+        if (!failedArtifact.isEmpty()) {
+            StringBuilder builder = new StringBuilder();
+            for (ArtifactPlan artifactPlan : failedArtifact) {
+                artifactPlan.printSrc(builder);
+            }
+            throw new RuntimeException(String.format("[%s] Uploading finished. Failed to upload %s", GoConstants.PRODUCT_NAME, builder));
+        }
+    }
+
+    private ArtifactPlans mergePlansForTest(List<ArtifactPlan> artifactPlans) {
+        TestArtifactPlan testArtifactPlan = null;
+        final ArtifactPlans mergedPlans = new ArtifactPlans();
+        for (ArtifactPlan artifactPlan : artifactPlans) {
+            if (artifactPlan.getArtifactType().isTest()) {
+                if (testArtifactPlan == null) {
+                    testArtifactPlan = new TestArtifactPlan(artifactPlan);
+                    mergedPlans.add(testArtifactPlan);
+                } else {
+                    testArtifactPlan.add(artifactPlan);
+                }
+            } else {
+                mergedPlans.add(artifactPlan);
+            }
+        }
+        return mergedPlans;
+    }
+}

--- a/common/src/com/thoughtworks/go/remote/work/BuildAssignment.java
+++ b/common/src/com/thoughtworks/go/remote/work/BuildAssignment.java
@@ -16,31 +16,44 @@
 
 package com.thoughtworks.go.remote.work;
 
+import com.thoughtworks.go.config.ArtifactPlan;
+import com.thoughtworks.go.config.ArtifactPropertiesGenerator;
+import com.thoughtworks.go.domain.JobIdentifier;
+import com.thoughtworks.go.domain.JobPlan;
+import com.thoughtworks.go.domain.MaterialRevision;
+import com.thoughtworks.go.domain.MaterialRevisions;
+import com.thoughtworks.go.domain.buildcause.BuildCause;
+import com.thoughtworks.go.domain.builder.Builder;
+import com.thoughtworks.go.domain.materials.Modification;
+import com.thoughtworks.go.util.command.EnvironmentVariableContext;
+
 import java.io.File;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.thoughtworks.go.domain.MaterialRevision;
-import com.thoughtworks.go.domain.builder.Builder;
-import com.thoughtworks.go.domain.JobPlan;
-import com.thoughtworks.go.domain.MaterialRevisions;
-import com.thoughtworks.go.domain.buildcause.BuildCause;
-import com.thoughtworks.go.domain.materials.Modification;
-import com.thoughtworks.go.util.command.EnvironmentVariableContext;
-
 public class BuildAssignment implements Serializable {
-    private final File buildWorkingDirectory;
+    private final boolean fetchMaterials;
+    private final boolean cleanWorkingDirectory;
     private final List<Builder> builders;
-    private final JobPlan plan;
+    private final List<ArtifactPlan> artifactPlans;
+    private final List<ArtifactPropertiesGenerator> propertyGenerators;
+    private final File buildWorkingDirectory;
+    private final JobIdentifier jobIdentifier;
     private final EnvironmentVariableContext initialContext = new EnvironmentVariableContext();
     private final MaterialRevisions materialRevisions = new MaterialRevisions();
     private final String approver;
 
-    private BuildAssignment(BuildCause buildCause, File buildWorkingDirectory, List<Builder> builder, JobPlan plan) {
+    private BuildAssignment(BuildCause buildCause, File buildWorkingDirectory, List<Builder> builder, JobIdentifier jobIdentifier,
+                            boolean fetchMaterials, boolean cleanWorkingDirectory, List<ArtifactPlan> artifactPlans,
+                            List<ArtifactPropertiesGenerator> propertyGenerators) {
         this.buildWorkingDirectory = buildWorkingDirectory;
         this.builders = builder;
-        this.plan = plan;
+        this.jobIdentifier = jobIdentifier;
+        this.fetchMaterials = fetchMaterials;
+        this.cleanWorkingDirectory = cleanWorkingDirectory;
+        this.artifactPlans = artifactPlans;
+        this.propertyGenerators = propertyGenerators;
         for (MaterialRevision materialRevision : buildCause.getMaterialRevisions()) {
             ArrayList<Modification> modifications = new ArrayList<>();
             for (Modification modification : materialRevision.getModifications()) {
@@ -54,59 +67,29 @@ public class BuildAssignment implements Serializable {
     @Override
     public String toString() {
         return "BuildAssignment{" +
-                "plan=" + plan +
+                "jobIdentifier=" + jobIdentifier +
                 ", materialRevisions=" + materialRevisions +
                 ", approver='" + approver + '\'' +
                 '}';
     }
 
-    public JobPlan getPlan() {
-        return plan;
-    }
+    public static BuildAssignment create(JobPlan plan, BuildCause buildCause, List<Builder> builders, File buildWorkingDirectory, EnvironmentVariableContext contextFromEnvironment) {
+        BuildAssignment buildAssignment = new BuildAssignment(buildCause, buildWorkingDirectory, builders, plan.getIdentifier(), plan.shouldFetchMaterials(),
+                plan.shouldCleanWorkingDir(), plan.getArtifactPlans(), plan.getPropertyGenerators());
 
-    public static BuildAssignment create(JobPlan plan, BuildCause buildCause, List<Builder> builder, File file) {
-        return new BuildAssignment(buildCause, file, builder, plan);
+        if (contextFromEnvironment != null) {
+            buildAssignment.initialEnvironmentVariableContext().addAll(contextFromEnvironment);
+        }
+
+        plan.applyTo(buildAssignment.initialEnvironmentVariableContext());
+
+        return buildAssignment;
     }
 
     public MaterialRevisions materialRevisions() {
         return materialRevisions;
     }
 
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-
-        BuildAssignment that = (BuildAssignment) o;
-
-        if (materialRevisions != null ? !materialRevisions.equals(that.materialRevisions) : that.materialRevisions != null) {
-            return false;
-        }
-        if (approver != null ? !approver.equals(that.approver) : that.approver != null) {
-            return false;
-        }
-        if (plan != null ? !plan.equals(that.plan) : that.plan != null) {
-            return false;
-        }
-        if (buildWorkingDirectory != null ? !buildWorkingDirectory.equals(
-                that.buildWorkingDirectory) : that.buildWorkingDirectory != null) {
-            return false;
-        }
-
-        return true;
-    }
-
-    public int hashCode() {
-        int result;
-        result = (plan != null ? plan.hashCode() : 0);
-        result = 31 * result + (buildWorkingDirectory != null ? buildWorkingDirectory.hashCode() : 0);
-        result = 31 * result + (materialRevisions != null ? materialRevisions.hashCode() : 0);
-        result = 31 * result + (approver != null ? approver.hashCode() : 0);
-        return result;
-    }
 
     public File getWorkingDirectory() {
         return buildWorkingDirectory;
@@ -116,15 +99,71 @@ public class BuildAssignment implements Serializable {
         return builders;
     }
 
-    public void enhanceEnvironmentVariables(EnvironmentVariableContext context) {
-        initialContext.addAll(context);
-    }
-
     public EnvironmentVariableContext initialEnvironmentVariableContext() {
         return initialContext;
     }
 
     public String getBuildApprover(){
         return approver;
+    }
+
+    public JobIdentifier getJobIdentifier() {
+        return jobIdentifier;
+    }
+
+    public List<ArtifactPropertiesGenerator> getPropertyGenerators() {
+        return propertyGenerators;
+    }
+
+    public boolean shouldFetchMaterials() {
+        return fetchMaterials;
+    }
+
+    public boolean shouldCleanWorkingDir() {
+        return cleanWorkingDirectory;
+    }
+
+    public List<ArtifactPlan> getArtifactPlans() {
+        return artifactPlans;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        BuildAssignment that = (BuildAssignment) o;
+
+        if (fetchMaterials != that.fetchMaterials) return false;
+        if (cleanWorkingDirectory != that.cleanWorkingDirectory) return false;
+        if (builders != null ? !builders.equals(that.builders) : that.builders != null) return false;
+        if (artifactPlans != null ? !artifactPlans.equals(that.artifactPlans) : that.artifactPlans != null)
+            return false;
+        if (propertyGenerators != null ? !propertyGenerators.equals(that.propertyGenerators) : that.propertyGenerators != null)
+            return false;
+        if (buildWorkingDirectory != null ? !buildWorkingDirectory.equals(that.buildWorkingDirectory) : that.buildWorkingDirectory != null)
+            return false;
+        if (jobIdentifier != null ? !jobIdentifier.equals(that.jobIdentifier) : that.jobIdentifier != null)
+            return false;
+        if (initialContext != null ? !initialContext.equals(that.initialContext) : that.initialContext != null)
+            return false;
+        if (materialRevisions != null ? !materialRevisions.equals(that.materialRevisions) : that.materialRevisions != null)
+            return false;
+        return approver != null ? approver.equals(that.approver) : that.approver == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = (fetchMaterials ? 1 : 0);
+        result = 31 * result + (cleanWorkingDirectory ? 1 : 0);
+        result = 31 * result + (builders != null ? builders.hashCode() : 0);
+        result = 31 * result + (artifactPlans != null ? artifactPlans.hashCode() : 0);
+        result = 31 * result + (propertyGenerators != null ? propertyGenerators.hashCode() : 0);
+        result = 31 * result + (buildWorkingDirectory != null ? buildWorkingDirectory.hashCode() : 0);
+        result = 31 * result + (jobIdentifier != null ? jobIdentifier.hashCode() : 0);
+        result = 31 * result + (initialContext != null ? initialContext.hashCode() : 0);
+        result = 31 * result + (materialRevisions != null ? materialRevisions.hashCode() : 0);
+        result = 31 * result + (approver != null ? approver.hashCode() : 0);
+        return result;
     }
 }

--- a/common/src/com/thoughtworks/go/remote/work/BuildAssignment.java
+++ b/common/src/com/thoughtworks/go/remote/work/BuildAssignment.java
@@ -81,8 +81,10 @@ public class BuildAssignment implements Serializable {
             buildAssignment.initialEnvironmentVariableContext().addAll(contextFromEnvironment);
         }
 
+        buildAssignment.initialEnvironmentVariableContext().setProperty("GO_TRIGGER_USER", buildAssignment.getBuildApprover(), false);
+        buildAssignment.getJobIdentifier().populateEnvironmentVariables(buildAssignment.initialEnvironmentVariableContext());
+        buildAssignment.materialRevisions().populateEnvironmentVariables(buildAssignment.initialEnvironmentVariableContext(), buildWorkingDirectory);
         plan.applyTo(buildAssignment.initialEnvironmentVariableContext());
-
         return buildAssignment;
     }
 

--- a/common/src/com/thoughtworks/go/remote/work/BuildWork.java
+++ b/common/src/com/thoughtworks/go/remote/work/BuildWork.java
@@ -188,12 +188,8 @@ public class BuildWork implements Work {
         return new ProcessOutputStreamConsumer<>(goPublisher, goPublisher);
     }
 
-    private EnvironmentVariableContext setupEnvrionmentContext(EnvironmentVariableContext context) {
+    private void setupEnvrionmentContext(EnvironmentVariableContext context) {
         context.setProperty("GO_SERVER_URL", new SystemEnvironment().getPropertyImpl("serviceUrl"), false);
-        context.setProperty("GO_TRIGGER_USER", assignment.getBuildApprover(), false);
-        assignment.getJobIdentifier().populateEnvironmentVariables(context);
-        materialRevisions.populateEnvironmentVariables(context, workingDirectory);
-        return context;
     }
 
     private JobResult buildJob(EnvironmentVariableContext environmentVariableContext) {

--- a/common/test/unit/com/thoughtworks/go/agent/testhelpers/DefaultWorkCreator.java
+++ b/common/test/unit/com/thoughtworks/go/agent/testhelpers/DefaultWorkCreator.java
@@ -34,6 +34,7 @@ import com.thoughtworks.go.remote.work.BuildWork;
 import com.thoughtworks.go.remote.work.Work;
 import com.thoughtworks.go.util.SystemEnvironment;
 import com.thoughtworks.go.util.TestFileUtil;
+import com.thoughtworks.go.util.command.EnvironmentVariableContext;
 
 import static com.thoughtworks.go.util.ExceptionUtils.bomb;
 
@@ -91,7 +92,7 @@ public class DefaultWorkCreator implements WorkCreator {
         try {
             CruiseConfig config = GoConfigMother.pipelineHavingJob(PIPELINE_NAME, STAGE_NAME, JOB_PLAN_NAME, ARTIFACT_FILE.getAbsolutePath(), ARTIFACT_FOLDER.getAbsolutePath());
             BuildCause buildCause = BuildCause.createWithEmptyModifications();
-            BuildAssignment buildAssignment = BuildAssignment.create(toPlan(config), buildCause, new ArrayList<>(), new File("testdata/" + CruiseConfig.WORKING_BASE_DIR + STAGE_NAME));
+            BuildAssignment buildAssignment = BuildAssignment.create(toPlan(config), buildCause, new ArrayList<>(), new File("testdata/" + CruiseConfig.WORKING_BASE_DIR + STAGE_NAME), new EnvironmentVariableContext());
             return new BuildWork(buildAssignment);
         } catch (Exception e) {
             throw bomb(e);

--- a/common/test/unit/com/thoughtworks/go/agent/testhelpers/LongWorkCreator.java
+++ b/common/test/unit/com/thoughtworks/go/agent/testhelpers/LongWorkCreator.java
@@ -105,7 +105,7 @@ public class LongWorkCreator implements WorkCreator {
                     instance,
                     buildCause,
                     builder,
-                    new File(CruiseConfig.WORKING_BASE_DIR + PIPELINE_NAME));
+                    new File(CruiseConfig.WORKING_BASE_DIR + PIPELINE_NAME), null);
             return new BuildWork(buildAssignment);
         } catch (Exception e) {
             throw bomb(e);

--- a/common/test/unit/com/thoughtworks/go/domain/DefaultJobPlanTest.java
+++ b/common/test/unit/com/thoughtworks/go/domain/DefaultJobPlanTest.java
@@ -27,12 +27,9 @@ import org.junit.Test;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
 
 import static com.thoughtworks.go.helper.EnvironmentVariablesConfigMother.env;
 import static com.thoughtworks.go.utils.SerializationTester.serializeAndDeserialize;
-import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNull.nullValue;
 import static org.junit.Assert.*;
@@ -90,92 +87,6 @@ public class DefaultJobPlanTest {
     }
 
     @Test
-    public void shouldMergeTestReportFilesAndUploadResult() throws Exception {
-        ArtifactPlans artifactPlans = new ArtifactPlans();
-        DefaultJobPlan plan = new DefaultJobPlan(new Resources(), artifactPlans, new ArtifactPropertiesGenerators(), -1, null, null, new EnvironmentVariablesConfig(), new EnvironmentVariablesConfig(), null);
-        artifactPlans.add(new TestArtifactPlan("test1", "test"));
-        artifactPlans.add(new TestArtifactPlan("test2", "test"));
-
-        final File firstTestFolder = prepareTestFolder(workingFolder, "test1");
-        final File secondTestFolder = prepareTestFolder(workingFolder, "test2");
-
-        StubGoPublisher publisher = new StubGoPublisher();
-        plan.publishArtifacts(publisher, workingFolder);
-
-        publisher.assertPublished(firstTestFolder.getAbsolutePath(), "test");
-        publisher.assertPublished(secondTestFolder.getAbsolutePath(), "test");
-        publisher.assertPublished("result", "testoutput");
-        publisher.assertPublished("result" + File.separator + "index.html", "testoutput");
-    }
-
-    @Test
-    public void shouldReportErrorWithTestArtifactSrcWhenUploadFails() throws Exception {
-        ArtifactPlans artifactPlans = new ArtifactPlans();
-        DefaultJobPlan plan = new DefaultJobPlan(new Resources(), artifactPlans, new ArtifactPropertiesGenerators(), -1, null, null, new EnvironmentVariablesConfig(), new EnvironmentVariablesConfig(), null);
-        artifactPlans.add(new TestArtifactPlan("test1", "test"));
-        artifactPlans.add(new TestArtifactPlan("test2", "test"));
-
-        prepareTestFolder(workingFolder, "test1");
-        prepareTestFolder(workingFolder, "test2");
-
-        StubGoPublisher publisherThatShouldFail = new StubGoPublisher(true);
-        try {
-            plan.publishArtifacts(publisherThatShouldFail, workingFolder);
-        } catch (Exception e) {
-            assertThat(e.getMessage(), containsString("Failed to upload [test1, test2]"));
-        }
-    }
-
-    @Test
-    public void shouldUploadFilesCorrectly() throws Exception {
-        ArtifactPlans artifactPlans = new ArtifactPlans();
-        final File src1 = TestFileUtil.createTestFolder(workingFolder, "src1");
-        TestFileUtil.createTestFile(src1, "test.txt");
-        artifactPlans.add(new ArtifactPlan(src1.getName(), "dest"));
-        final File src2 = TestFileUtil.createTestFolder(workingFolder, "src2");
-        TestFileUtil.createTestFile(src1, "test.txt");
-
-        artifactPlans.add(new ArtifactPlan(src2.getName(), "test"));
-        StubGoPublisher publisher = new StubGoPublisher();
-        DefaultJobPlan plan = new DefaultJobPlan(new Resources(), artifactPlans, new ArtifactPropertiesGenerators(), -1, null, null, new EnvironmentVariablesConfig(), new EnvironmentVariablesConfig(), null);
-
-
-        plan.publishArtifacts(publisher, workingFolder);
-
-        Map<File, String> expectedFiles = new HashMap<File, String>() {
-            {
-                put(src1, "dest");
-                put(src2, "test");
-            }
-        };
-        assertThat(publisher.publishedFiles(), is(expectedFiles));
-    }
-
-    @Test
-    public void shouldUploadFilesWhichMathedWildCard() throws Exception {
-        ArtifactPlans artifactPlans = new ArtifactPlans();
-        final File src1 = TestFileUtil.createTestFolder(workingFolder, "src1");
-        final File testFile1 = TestFileUtil.createTestFile(src1, "test1.txt");
-        final File testFile2 = TestFileUtil.createTestFile(src1, "test2.txt");
-        final File testFile3 = TestFileUtil.createTestFile(src1, "readme.pdf");
-        artifactPlans.add(new ArtifactPlan(src1.getName() + "/*", "dest"));
-        StubGoPublisher publisher = new StubGoPublisher();
-
-        DefaultJobPlan plan = new DefaultJobPlan(new Resources(), artifactPlans, new ArtifactPropertiesGenerators(), -1, null, null, new EnvironmentVariablesConfig(), new EnvironmentVariablesConfig(), null);
-
-        plan.publishArtifacts(publisher, workingFolder);
-
-        Map<File, String> expectedFiles = new HashMap<File, String>() {
-            {
-                put(testFile1, "dest");
-                put(testFile2, "dest");
-                put(testFile3, "dest");
-            }
-        };
-        assertThat(publisher.publishedFiles(), is(expectedFiles));
-    }
-
-    @Test
     public void shouldApplyEnvironmentVariablesWhenRunningTheJob() {
         EnvironmentVariablesConfig variables = new EnvironmentVariablesConfig();
         variables.add("VARIABLE_NAME", "variable value");
@@ -185,25 +96,6 @@ public class DefaultJobPlanTest {
         EnvironmentVariableContext variableContext = new EnvironmentVariableContext();
         plan.applyTo(variableContext);
         assertThat(variableContext.getProperty("VARIABLE_NAME"), is("variable value"));
-    }
-
-    private File prepareTestFolder(File workingFolder, String folderName) throws Exception {
-        File testFolder = TestFileUtil.createTestFolder(workingFolder, folderName);
-        File testFile = TestFileUtil.createTestFile(testFolder, "testFile.xml");
-        String content = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
-                + "<testsuite errors=\"0\" failures=\"0\" tests=\"7\" time=\"0.429\" >\n"
-                + "<testcase/>\n"
-                + "</testsuite>\n";
-        FileUtil.writeContentToFile(content, testFile);
-        return testFolder;
-    }
-
-    @Test
-    public void shouldBeAbleToSerializeAndDeserialize() throws ClassNotFoundException, IOException {
-        DefaultJobPlan original = new DefaultJobPlan(new Resources(), new ArtifactPlans(),
-                new ArtifactPropertiesGenerators(), 0, new JobIdentifier(), "uuid", new EnvironmentVariablesConfig(), new EnvironmentVariablesConfig(), null);
-        DefaultJobPlan clone = (DefaultJobPlan) serializeAndDeserialize(original);
-        assertThat(clone,is(original));
     }
 
     @Test
@@ -217,5 +109,13 @@ public class DefaultJobPlanTest {
         assertThat(variableContext.getProperty("foo"),is("bar"));
         //becuase its a security issue to let operator set values for unconfigured variables
         assertThat(variableContext.getProperty("another"),is(nullValue()));
+    }
+
+    @Test
+    public void shouldBeAbleToSerializeAndDeserialize() throws ClassNotFoundException, IOException {
+        DefaultJobPlan original = new DefaultJobPlan(new Resources(), new ArtifactPlans(),
+                new ArtifactPropertiesGenerators(), 0, new JobIdentifier(), "uuid", new EnvironmentVariablesConfig(), new EnvironmentVariablesConfig(), null);
+        DefaultJobPlan clone = (DefaultJobPlan) serializeAndDeserialize(original);
+        assertThat(clone, is(original));
     }
 }

--- a/common/test/unit/com/thoughtworks/go/helper/JobIdentifierMother.java
+++ b/common/test/unit/com/thoughtworks/go/helper/JobIdentifierMother.java
@@ -28,4 +28,8 @@ public class JobIdentifierMother {
     public static JobIdentifier jobIdentifier(String pipelineName, Integer pipelineCounter, String stageName, String stageCounter, String jobName) {
         return new JobIdentifier(new StageIdentifier(pipelineName, pipelineCounter, "LABEL-1", stageName, stageCounter), jobName);
     }
+
+    public static JobIdentifier jobIdentifier(String pipelineName) {
+        return new JobIdentifier(pipelineName, "lastgood", "stageName", "LATEST", "buildName", 1L);
+    }
 }

--- a/common/test/unit/com/thoughtworks/go/remote/work/BuildAssignmentTest.java
+++ b/common/test/unit/com/thoughtworks/go/remote/work/BuildAssignmentTest.java
@@ -17,27 +17,74 @@
 package com.thoughtworks.go.remote.work;
 
 import com.google.gson.Gson;
-import com.thoughtworks.go.config.ArtifactPlans;
-import com.thoughtworks.go.config.ArtifactPropertiesGenerators;
-import com.thoughtworks.go.config.EnvironmentVariablesConfig;
-import com.thoughtworks.go.config.Resources;
-import com.thoughtworks.go.domain.DefaultJobPlan;
-import com.thoughtworks.go.domain.JobIdentifier;
-import com.thoughtworks.go.domain.MaterialRevision;
-import com.thoughtworks.go.domain.MaterialRevisions;
+import com.thoughtworks.go.config.*;
+import com.thoughtworks.go.config.materials.dependency.DependencyMaterial;
+import com.thoughtworks.go.config.materials.mercurial.HgMaterial;
+import com.thoughtworks.go.config.materials.svn.SvnMaterial;
+import com.thoughtworks.go.domain.*;
 import com.thoughtworks.go.domain.buildcause.BuildCause;
+import com.thoughtworks.go.domain.builder.Builder;
+import com.thoughtworks.go.domain.builder.CommandBuilder;
+import com.thoughtworks.go.domain.builder.NullBuilder;
 import com.thoughtworks.go.domain.materials.Modification;
+import com.thoughtworks.go.domain.materials.svn.SvnCommand;
+import com.thoughtworks.go.helper.HgTestRepo;
 import com.thoughtworks.go.helper.MaterialsMother;
 import com.thoughtworks.go.helper.ModificationsMother;
+import com.thoughtworks.go.helper.TestRepo;
+import com.thoughtworks.go.util.FileUtil;
+import com.thoughtworks.go.util.SystemEnvironment;
 import com.thoughtworks.go.util.command.EnvironmentVariableContext;
+import com.thoughtworks.go.utils.SvnRepoFixture;
+import org.hamcrest.Matchers;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 
+import java.io.File;
+import java.io.IOException;
 import java.util.*;
 
+import static com.thoughtworks.go.config.materials.svn.SvnMaterial.createSvnMaterialWithMock;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
+import static org.mockito.MockitoAnnotations.initMocks;
 
 public class BuildAssignmentTest {
+    private static final String JOB_NAME = "one";
+    private static final String STAGE_NAME = "first";
+    private static final String PIPELINE_NAME = "cruise";
+    private static final String TRIGGERED_BY_USER = "approver";
+    private File dir;
+    private SvnCommand command;
+    private HgTestRepo hgTestRepo;
+    private HgMaterial hgMaterial;
+    private SvnMaterial svnMaterial;
+    private DependencyMaterial dependencyMaterial;
+    private DependencyMaterial dependencyMaterialWithName;
+    private SvnRepoFixture svnRepoFixture;
+
+    @Before
+    public void setUp() throws IOException {
+        initMocks(this);
+        dir = new File("someFolder");
+        svnRepoFixture = new SvnRepoFixture("../common/test-resources/unit/data/svnrepo");
+        svnRepoFixture.createRepository();
+        command = new SvnCommand(null, svnRepoFixture.getEnd2EndRepoUrl());
+        svnMaterial = createSvnMaterialWithMock(command);
+        dependencyMaterial = new DependencyMaterial(new CaseInsensitiveString("upstream1"), new CaseInsensitiveString(STAGE_NAME));
+        dependencyMaterialWithName = new DependencyMaterial(new CaseInsensitiveString("upstream2"), new CaseInsensitiveString(STAGE_NAME));
+        dependencyMaterialWithName.setName(new CaseInsensitiveString("dependency_material_name"));
+        setupHgRepo();
+    }
+
+    @After
+    public void teardown() throws Exception {
+        TestRepo.internalTearDown();
+        hgTestRepo.tearDown();
+        FileUtil.deleteFolder(dir);
+    }
+
     @Test
     public void shouldInitializeEnvironmentContextFromJobPlan() throws Exception {
         DefaultJobPlan defaultJobPlan = jobForPipeline("foo");
@@ -51,7 +98,7 @@ public class BuildAssignmentTest {
         BuildAssignment buildAssignment = BuildAssignment.create(defaultJobPlan, BuildCause.createManualForced(), new ArrayList<>(), null, null);
         EnvironmentVariableContext context = buildAssignment.initialEnvironmentVariableContext();
 
-        assertThat(context.getProperties().size(), is(2));
+        assertThat(context.getProperties().size(), is(9));
         assertThat(context.getProperty("key1"), is("value1"));
         assertThat(context.getProperty("key2"), is("value2"));
     }
@@ -73,7 +120,7 @@ public class BuildAssignmentTest {
         BuildAssignment buildAssignment = BuildAssignment.create(defaultJobPlan, BuildCause.createManualForced(), new ArrayList<>(), null, null);
         EnvironmentVariableContext context = buildAssignment.initialEnvironmentVariableContext();
 
-        assertThat(context.getProperties().size(), is(2));
+        assertThat(context.getProperties().size(), is(9));
         assertThat(context.getProperty("key1"), is("override"));
         assertThat(context.getProperty("key2"), is("value2"));
     }
@@ -94,7 +141,7 @@ public class BuildAssignmentTest {
         BuildAssignment buildAssignment = BuildAssignment.create(defaultJobPlan, BuildCause.createManualForced(), new ArrayList<>(), null, contextFromEnvironment);
         EnvironmentVariableContext context = buildAssignment.initialEnvironmentVariableContext();
 
-        assertThat(context.getProperties().size(), is(3));
+        assertThat(context.getProperties().size(), is(10));
         assertThat(context.getProperty("key1"), is("value_from_job_plan"));
         assertThat(context.getProperty("key2"), is("value2"));
         assertThat(context.getProperty("key3"), is("value3"));
@@ -138,6 +185,56 @@ public class BuildAssignmentTest {
         assertThat(actualModification.getAdditionalDataMap(), is(additionalData));
     }
 
+    @Test
+    public void shouldSetUpGoGeneratedEnvironmentContextCorrectly() throws Exception {
+        new SystemEnvironment().setProperty("serviceUrl", "some_random_place");
+        BuildAssignment buildAssigment = createAssignment(null);
+        EnvironmentVariableContext environmentVariableContext = buildAssigment.initialEnvironmentVariableContext();
+        assertThat(environmentVariableContext.getProperty("GO_REVISION"), Matchers.is("3"));
+        assertThat(environmentVariableContext.getProperty("GO_PIPELINE_NAME"), Matchers.is(PIPELINE_NAME));
+        assertThat(environmentVariableContext.getProperty("GO_PIPELINE_LABEL"), Matchers.is("1"));
+        assertThat(environmentVariableContext.getProperty("GO_STAGE_NAME"), Matchers.is(STAGE_NAME));
+        assertThat(environmentVariableContext.getProperty("GO_STAGE_COUNTER"), Matchers.is("1"));
+        assertThat(environmentVariableContext.getProperty("GO_JOB_NAME"), Matchers.is(JOB_NAME));
+        assertThat(environmentVariableContext.getProperty("GO_TRIGGER_USER"), Matchers.is(TRIGGERED_BY_USER));
+    }
+
+    private BuildAssignment createAssignment(EnvironmentVariableContext environmentVariableContext) {
+        JobPlan plan = new DefaultJobPlan(new Resources(), new ArtifactPlans(), new ArtifactPropertiesGenerators(), -1, new JobIdentifier(PIPELINE_NAME, 1, "1", STAGE_NAME, "1", JOB_NAME, 123L), null, new EnvironmentVariablesConfig(), new EnvironmentVariablesConfig(), null);
+        MaterialRevisions materialRevisions = materialRevisions();
+        BuildCause buildCause = BuildCause.createWithModifications(materialRevisions, TRIGGERED_BY_USER);
+        List<Builder> builders = new ArrayList<>();
+        builders.add(new CommandBuilder("ls", "", dir, new RunIfConfigs(), new NullBuilder(), ""));
+        return BuildAssignment.create(plan, buildCause, builders, dir, environmentVariableContext);
+    }
+
+    private MaterialRevisions materialRevisions() {
+        MaterialRevision svnRevision = new MaterialRevision(this.svnMaterial,
+                ModificationsMother.oneModifiedFile(
+                        svnRepoFixture.getHeadRevision(svnRepoFixture.getEnd2EndRepoUrl())));
+
+        SvnMaterial svnMaterialForExternal = createSvnMaterialWithMock(new SvnCommand(null, svnRepoFixture.getExternalRepoUrl()));
+        String folder = this.svnMaterial.getFolder() == null ? "external" : this.svnMaterial.getFolder() + "/" + "external";
+        svnMaterialForExternal.setFolder(folder);
+        MaterialRevision svnExternalRevision = new MaterialRevision(svnMaterialForExternal,
+                ModificationsMother.oneModifiedFile(
+                        svnRepoFixture.getHeadRevision(svnRepoFixture.getExternalRepoUrl())));
+
+        MaterialRevision hgRevision = new MaterialRevision(hgMaterial,
+                ModificationsMother.oneModifiedFile(hgTestRepo.latestModifications().get(0).getRevision()));
+
+        MaterialRevision dependencyRevision1 = ModificationsMother.dependencyMaterialRevision(0,
+                dependencyMaterial.getPipelineName() + "-label", 1,
+                dependencyMaterial, new Date());
+        MaterialRevision dependencyRevisionWithName = ModificationsMother.dependencyMaterialRevision(0,
+                dependencyMaterialWithName.getPipelineName() + "-label", 1,
+                dependencyMaterialWithName, new Date());
+
+        return new MaterialRevisions(svnRevision, svnExternalRevision, hgRevision, dependencyRevision1,
+                dependencyRevisionWithName);
+    }
+
+
     private void assertRevisions(BuildAssignment buildAssignment, MaterialRevision expectedRevision) {
         MaterialRevision actualRevision = buildAssignment.materialRevisions().findRevisionFor(expectedRevision.getMaterial());
         assertThat(actualRevision.getMaterial(), is(expectedRevision.getMaterial()));
@@ -154,4 +251,10 @@ public class BuildAssignmentTest {
         JobIdentifier jobIdentifier = new JobIdentifier(pipelineName, 1, "1", "defaultStage", "1", "job1", 100L);
         return new DefaultJobPlan(new Resources(), new ArtifactPlans(), new ArtifactPropertiesGenerators(), 1L, jobIdentifier, null, new EnvironmentVariablesConfig(), new EnvironmentVariablesConfig(), null);
     }
+
+    private void setupHgRepo() throws IOException {
+        hgTestRepo = new HgTestRepo("hgTestRepo1");
+        hgMaterial = MaterialsMother.hgMaterial(hgTestRepo.projectRepositoryUrl(), "hg_Dir");
+    }
+
 }

--- a/common/test/unit/com/thoughtworks/go/remote/work/BuildWorkArtifactUploadingTest.java
+++ b/common/test/unit/com/thoughtworks/go/remote/work/BuildWorkArtifactUploadingTest.java
@@ -332,7 +332,7 @@ public class BuildWorkArtifactUploadingTest {
         List<Builder> builders = new ArrayList<>();
         builders.add(new CreateFileBuilder(fileToCreate));
         DefaultJobPlan plan = new DefaultJobPlan(new Resources(), artifactPlans, new ArtifactPropertiesGenerators(), -1, new JobIdentifier(PIPELINE_NAME, -2, "1", STAGE_NAME, "1", JOB_NAME), null, new EnvironmentVariablesConfig(), new EnvironmentVariablesConfig(), null);
-        return BuildAssignment.create(plan, buildCause, builders, buildWorkingDirectory);
+        return BuildAssignment.create(plan, buildCause, builders, buildWorkingDirectory, new EnvironmentVariableContext());
     }
 
 

--- a/common/test/unit/com/thoughtworks/go/remote/work/BuildWorkEnvironmentVariablesTest.java
+++ b/common/test/unit/com/thoughtworks/go/remote/work/BuildWorkEnvironmentVariablesTest.java
@@ -122,9 +122,8 @@ public class BuildWorkEnvironmentVariablesTest {
     @Test public void shouldMergeEnvironmentVariablesFromInitialContext() throws Exception {
         pipelineConfig.setMaterialConfigs(new MaterialConfigs());
 
-        BuildAssignment buildAssigment = createAssignment();
-        buildAssigment.enhanceEnvironmentVariables(new EnvironmentVariableContext("foo", "bar"));
-        BuildWork work = new BuildWork(buildAssigment);
+        BuildAssignment buildAssignment = createAssignment(new EnvironmentVariableContext("foo", "bar"));
+        BuildWork work = new BuildWork(buildAssignment);
         EnvironmentVariableContext environmentContext = new EnvironmentVariableContext();
 
         AgentIdentifier agentIdentifier = new AgentIdentifier("somename", "127.0.0.1", AGENT_UUID);
@@ -163,7 +162,7 @@ public class BuildWorkEnvironmentVariablesTest {
         svnMaterial.setName(new CaseInsensitiveString("Cruise"));
         pipelineConfig.setMaterialConfigs(new MaterialConfigs(svnMaterial.config()));
 
-        BuildAssignment buildAssigment = createAssignment();
+        BuildAssignment buildAssigment = createAssignment(null);
         BuildWork work = new BuildWork(buildAssigment);
         EnvironmentVariableContext environmentVariableContext = new EnvironmentVariableContext();
 
@@ -189,7 +188,7 @@ public class BuildWorkEnvironmentVariablesTest {
 
     @Test
     public void shouldOutputEnvironmentVariablesIntoConsoleOut() throws Exception {
-        BuildAssignment buildAssigment = createAssignment();
+        BuildAssignment buildAssigment = createAssignment(null);
         BuildWork work = new BuildWork(buildAssigment);
         GoArtifactsManipulatorStub manipulator = new GoArtifactsManipulatorStub();
         new SystemEnvironment().setProperty("serviceUrl", "some_random_place");
@@ -223,13 +222,13 @@ public class BuildWorkEnvironmentVariablesTest {
         assertThat(environmentVariableContext.getProperty("GO_REVISION_SVN_DIR_EXTERNAL"), is("4"));
     }
 
-    private BuildAssignment createAssignment() {
+    private BuildAssignment createAssignment(EnvironmentVariableContext environmentVariableContext) {
         JobPlan plan = new DefaultJobPlan(new Resources(), new ArtifactPlans(), new ArtifactPropertiesGenerators(), -1, new JobIdentifier(PIPELINE_NAME, 1, "1", STAGE_NAME, "1", JOB_NAME, 123L), null, new EnvironmentVariablesConfig(), new EnvironmentVariablesConfig(), null);
         MaterialRevisions materialRevisions = materialRevisions();
         BuildCause buildCause = BuildCause.createWithModifications(materialRevisions, TRIGGERED_BY_USER);
         List<Builder> builders = new ArrayList<>();
         builders.add(new CommandBuilder("ant", "", dir, new RunIfConfigs(), new NullBuilder(), ""));
-        return BuildAssignment.create(plan, buildCause, builders, dir);
+        return BuildAssignment.create(plan, buildCause, builders, dir, environmentVariableContext);
     }
 
     private void setupHgRepo() throws IOException {
@@ -266,7 +265,7 @@ public class BuildWorkEnvironmentVariablesTest {
     private EnvironmentVariableContext doWorkWithMaterials(Materials materials) {
         pipelineConfig.setMaterialConfigs(materials.convertToConfigs());
 
-        BuildAssignment buildAssigment = createAssignment();
+        BuildAssignment buildAssigment = createAssignment(null);
         BuildWork work = new BuildWork(buildAssigment);
         EnvironmentVariableContext environmentVariableContext = new EnvironmentVariableContext();
 

--- a/common/test/unit/com/thoughtworks/go/websocket/MessageTest.java
+++ b/common/test/unit/com/thoughtworks/go/websocket/MessageTest.java
@@ -28,6 +28,7 @@ import com.thoughtworks.go.remote.AgentIdentifier;
 import com.thoughtworks.go.remote.work.BuildAssignment;
 import com.thoughtworks.go.remote.work.BuildWork;
 import com.thoughtworks.go.server.service.AgentRuntimeInfo;
+import com.thoughtworks.go.util.command.EnvironmentVariableContext;
 import org.junit.Test;
 
 import java.io.ByteArrayInputStream;
@@ -81,13 +82,13 @@ public class MessageTest {
         builder.add(new FetchArtifactBuilder(new RunIfConfigs(), new NullBuilder(), "desc", jobPlan().getIdentifier(), "srcdir", "dest",
                 new FileHandler(workingDir, "src"),
                 new ChecksumFileHandler(workingDir)));
-        BuildAssignment assignment = BuildAssignment.create(jobPlan(), buildCause, builder, workingDir);
+        BuildAssignment assignment = BuildAssignment.create(jobPlan(), buildCause, builder, workingDir, new EnvironmentVariableContext());
 
         BuildWork work = new BuildWork(assignment);
         byte[] msg = MessageEncoding.encodeMessage(new Message(Action.assignWork, MessageEncoding.encodeWork(work)));
         Message decodedMsg = MessageEncoding.decodeMessage(new ByteArrayInputStream(msg));
         BuildWork decodedWork = (BuildWork) MessageEncoding.decodeWork(decodedMsg.getData());
-        assertThat(decodedWork.getAssignment().getPlan().getPipelineName(), is("pipelineName"));
+        assertThat(decodedWork.getAssignment().getJobIdentifier().getPipelineName(), is("pipelineName"));
     }
 
 

--- a/config/config-api/test/com/thoughtworks/go/helper/EnvironmentConfigMother.java
+++ b/config/config-api/test/com/thoughtworks/go/helper/EnvironmentConfigMother.java
@@ -19,6 +19,8 @@ package com.thoughtworks.go.helper;
 import com.thoughtworks.go.config.BasicEnvironmentConfig;
 import com.thoughtworks.go.config.CaseInsensitiveString;
 import com.thoughtworks.go.config.EnvironmentsConfig;
+import com.thoughtworks.go.config.remote.ConfigRepoConfig;
+import com.thoughtworks.go.config.remote.RepoConfigOrigin;
 
 public class EnvironmentConfigMother {
     public static final String OMNIPRESENT_AGENT = "omnipresent-agent";
@@ -35,6 +37,11 @@ public class EnvironmentConfigMother {
         return new BasicEnvironmentConfig(new CaseInsensitiveString(name));
     }
 
+    public static BasicEnvironmentConfig remote(String name) {
+        BasicEnvironmentConfig env = environment(name);
+        env.setOrigins(new RepoConfigOrigin());
+        return env;
+    }
     public static BasicEnvironmentConfig environment(String name) {
         BasicEnvironmentConfig uat = new BasicEnvironmentConfig(new CaseInsensitiveString(name));
         uat.addPipeline(new CaseInsensitiveString(name + "-pipeline"));

--- a/domain/src/com/thoughtworks/go/domain/DefaultJobPlan.java
+++ b/domain/src/com/thoughtworks/go/domain/DefaultJobPlan.java
@@ -47,9 +47,9 @@ public class DefaultJobPlan implements JobPlan {
     protected DefaultJobPlan() {
     }
 
-    public DefaultJobPlan(Resources resources, ArtifactPlans plans,
-                          ArtifactPropertiesGenerators generators, long jobId,
-                          JobIdentifier identifier, String agentUuid, EnvironmentVariablesConfig variables, EnvironmentVariablesConfig triggerTimeVariables, ElasticProfile elasticProfile) {
+    public DefaultJobPlan(Resources resources, ArtifactPlans plans, ArtifactPropertiesGenerators generators, long jobId,
+                          JobIdentifier identifier, String agentUuid, EnvironmentVariablesConfig variables,
+                          EnvironmentVariablesConfig triggerTimeVariables, ElasticProfile elasticProfile) {
         this.jobId = jobId;
         this.identifier = identifier;
         this.resources = resources;
@@ -83,44 +83,6 @@ public class DefaultJobPlan implements JobPlan {
 
     public JobIdentifier getIdentifier() {
         return identifier;
-    }
-
-    public void publishArtifacts(GoPublisher goPublisher, File workingDirectory) {
-        ArtifactPlans mergedPlans = mergePlansForTest();
-
-        List<ArtifactPlan> failedArtifact = new ArrayList<>();
-        for (ArtifactPlan artifactPlan : mergedPlans) {
-            try {
-                artifactPlan.publish(goPublisher, workingDirectory);
-            } catch (Exception e) {
-                failedArtifact.add(artifactPlan);
-            }
-        }
-        if (!failedArtifact.isEmpty()) {
-            StringBuilder builder = new StringBuilder();
-            for (ArtifactPlan artifactPlan : failedArtifact) {
-                artifactPlan.printSrc(builder);
-            }
-            throw new RuntimeException(String.format("[%s] Uploading finished. Failed to upload %s", GoConstants.PRODUCT_NAME, builder));
-        }
-    }
-
-    private ArtifactPlans mergePlansForTest() {
-        TestArtifactPlan testArtifactPlan = null;
-        final ArtifactPlans mergedPlans = new ArtifactPlans();
-        for (ArtifactPlan artifactPlan : plans) {
-            if (artifactPlan.getArtifactType().isTest()) {
-                if (testArtifactPlan == null) {
-                    testArtifactPlan = new TestArtifactPlan(artifactPlan);
-                    mergedPlans.add(testArtifactPlan);
-                } else {
-                    testArtifactPlan.add(artifactPlan);
-                }
-            } else {
-                mergedPlans.add(artifactPlan);
-            }
-        }
-        return mergedPlans;
     }
 
     public List<ArtifactPropertiesGenerator> getPropertyGenerators() {

--- a/domain/src/com/thoughtworks/go/domain/JobPlan.java
+++ b/domain/src/com/thoughtworks/go/domain/JobPlan.java
@@ -22,9 +22,7 @@ import com.thoughtworks.go.config.EnvironmentVariablesConfig;
 import com.thoughtworks.go.config.Resource;
 import com.thoughtworks.go.config.elastic.ElasticProfile;
 import com.thoughtworks.go.util.command.EnvironmentVariableContext;
-import com.thoughtworks.go.work.GoPublisher;
 
-import java.io.File;
 import java.io.Serializable;
 import java.util.List;
 
@@ -38,14 +36,11 @@ public interface JobPlan extends Serializable {
 
     String getName();
 
-
     boolean match(List<Resource> resources);
 
     long getJobId();
 
     JobIdentifier getIdentifier();
-
-    void publishArtifacts(GoPublisher goPublisher, File workingDirectory);
 
     List<ArtifactPropertiesGenerator> getPropertyGenerators();
 

--- a/server/src/com/thoughtworks/go/server/domain/BuildComposer.java
+++ b/server/src/com/thoughtworks/go/server/domain/BuildComposer.java
@@ -201,12 +201,7 @@ public class BuildComposer {
 
     private EnvironmentVariableContext environmentVariableContext() {
         EnvironmentVariableContext context = new EnvironmentVariableContext();
-
         context.addAll(assignment.initialEnvironmentVariableContext());
-        context.setProperty("GO_TRIGGER_USER", assignment.getBuildApprover() , false);
-        getJobIdentifier().populateEnvironmentVariables(context);
-        assignment.materialRevisions().populateEnvironmentVariables(context, new File(workingDirectory()));
-
         return context;
     }
 }

--- a/server/src/com/thoughtworks/go/server/domain/BuildComposer.java
+++ b/server/src/com/thoughtworks/go/server/domain/BuildComposer.java
@@ -73,7 +73,7 @@ public class BuildComposer {
 
 
     private BuildCommand harvestProperties() {
-        List<ArtifactPropertiesGenerator> generators = assignment.getPlan().getPropertyGenerators();
+        List<ArtifactPropertiesGenerator> generators = assignment.getPropertyGenerators();
         List<BuildCommand> commands = new ArrayList<>();
 
         for (ArtifactPropertiesGenerator generator : generators) {
@@ -117,7 +117,7 @@ public class BuildComposer {
 
     private BuildCommand uploadArtifacts() {
         List<BuildCommand> commands = new ArrayList<>();
-        for (ArtifactPlan ap : assignment.getPlan().getArtifactPlans()) {
+        for (ArtifactPlan ap : assignment.getArtifactPlans()) {
             commands.add(uploadArtifact(ap.getSrc(), ap.getDest(), ap.getArtifactType().isTest())
                     .setWorkingDirectory(workingDirectory()));
         }
@@ -130,7 +130,7 @@ public class BuildComposer {
 
     private BuildCommand generateTestReport() {
         List<String> srcs = new ArrayList<>();
-        for (ArtifactPlan ap : assignment.getPlan().getArtifactPlans()) {
+        for (ArtifactPlan ap : assignment.getArtifactPlans()) {
             if (ap.getArtifactType() == ArtifactType.unit) {
                 srcs.add(ap.getSrc());
             }
@@ -163,7 +163,7 @@ public class BuildComposer {
     }
 
     private BuildCommand updateMaterials() {
-        if (!assignment.getPlan().shouldFetchMaterials()) {
+        if (!assignment.shouldFetchMaterials()) {
             return echoWithPrefix("Skipping material update since stage is configured not to fetch materials");
         }
 
@@ -182,7 +182,7 @@ public class BuildComposer {
     }
 
     private BuildCommand cleanWorkingDir() {
-        if (!assignment.getPlan().shouldCleanWorkingDir()) {
+        if (!assignment.shouldCleanWorkingDir()) {
             return noop();
         }
         return BuildCommand.compose(
@@ -196,18 +196,17 @@ public class BuildComposer {
     }
 
     private JobIdentifier getJobIdentifier() {
-        return assignment.getPlan().getIdentifier();
+        return assignment.getJobIdentifier();
     }
 
     private EnvironmentVariableContext environmentVariableContext() {
-        JobPlan plan = assignment.getPlan();
         EnvironmentVariableContext context = new EnvironmentVariableContext();
 
         context.addAll(assignment.initialEnvironmentVariableContext());
         context.setProperty("GO_TRIGGER_USER", assignment.getBuildApprover() , false);
         getJobIdentifier().populateEnvironmentVariables(context);
         assignment.materialRevisions().populateEnvironmentVariables(context, new File(workingDirectory()));
-        plan.applyTo(context);
+
         return context;
     }
 }

--- a/server/src/com/thoughtworks/go/server/service/EnvironmentConfigService.java
+++ b/server/src/com/thoughtworks/go/server/service/EnvironmentConfigService.java
@@ -35,6 +35,7 @@ import com.thoughtworks.go.presentation.environment.EnvironmentPipelineModel;
 import com.thoughtworks.go.remote.work.BuildAssignment;
 import com.thoughtworks.go.server.domain.Username;
 import com.thoughtworks.go.server.service.result.HttpLocalizedOperationResult;
+import com.thoughtworks.go.util.command.EnvironmentVariableContext;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -108,11 +109,13 @@ public class EnvironmentConfigService implements ConfigChangedListener {
         return null;
     }
 
-    public void enhanceEnvironmentVariables(BuildAssignment assignment) {
-        EnvironmentConfig environment = environments.findEnvironmentForPipeline(new CaseInsensitiveString(assignment.getPlan().getPipelineName()));
+    public EnvironmentVariableContext environmentVariableContextFor(String pipelineName) {
+        EnvironmentConfig environment = environments.findEnvironmentForPipeline(new CaseInsensitiveString(pipelineName));
         if (environment != null) {
-            assignment.enhanceEnvironmentVariables(environment.createEnvironmentContext());
+            return environment.createEnvironmentContext();
         }
+
+        return null;
     }
 
     public Agents agentsForPipeline(final CaseInsensitiveString pipelineName) {

--- a/server/test/integration/com/thoughtworks/go/server/service/BuildAssignmentServiceIntegrationTest.java
+++ b/server/test/integration/com/thoughtworks/go/server/service/BuildAssignmentServiceIntegrationTest.java
@@ -442,7 +442,7 @@ public class BuildAssignmentServiceIntegrationTest {
         buildAssignmentService.onTimer();
         BuildWork work = (BuildWork) buildAssignmentService.assignWorkToAgent(agent(AgentMother.localAgent()));
 
-        assertThat("should have set fetchMaterials on assignment", work.getAssignment().getPlan().shouldFetchMaterials(), is(true));
+        assertThat("should have set fetchMaterials on assignment", work.getAssignment().shouldFetchMaterials(), is(true));
     }
 
     /**

--- a/server/test/integration/com/thoughtworks/go/server/websocket/JobInstanceStatusMonitorTest.java
+++ b/server/test/integration/com/thoughtworks/go/server/websocket/JobInstanceStatusMonitorTest.java
@@ -27,6 +27,7 @@ import com.thoughtworks.go.fixture.PipelineWithTwoStages;
 import com.thoughtworks.go.helper.AgentMother;
 import com.thoughtworks.go.helper.SvnTestRepo;
 import com.thoughtworks.go.helper.TestRepo;
+import com.thoughtworks.go.remote.work.BuildAssignment;
 import com.thoughtworks.go.remote.work.BuildWork;
 import com.thoughtworks.go.remote.work.Work;
 import com.thoughtworks.go.server.cache.GoCache;
@@ -132,8 +133,8 @@ public class JobInstanceStatusMonitorTest {
         assertThat(agent.messages.size(), is(1));
         Work work = MessageEncoding.decodeWork(agent.messages.get(0).getData());
         assertThat(work, instanceOf(BuildWork.class));
-        JobPlan jobPlan = ((BuildWork) work).getAssignment().getPlan();
-        final JobInstance instance = jobInstanceService.buildByIdWithTransitions(jobPlan.getJobId());
+        BuildAssignment assignment = ((BuildWork) work).getAssignment();
+        final JobInstance instance = jobInstanceService.buildByIdWithTransitions(assignment.getJobIdentifier().getBuildId());
         transactionTemplate.execute(new TransactionCallbackWithoutResult() {
             @Override
             protected void doInTransactionWithoutResult(TransactionStatus status) {
@@ -159,8 +160,8 @@ public class JobInstanceStatusMonitorTest {
         assertThat(agent.messages.size(), is(1));
         assertThat(MessageEncoding.decodeWork(agent.messages.get(0).getData()), instanceOf(BuildWork.class));
         BuildWork work = (BuildWork) MessageEncoding.decodeWork(agent.messages.get(0).getData());
-        JobPlan jobPlan = work.getAssignment().getPlan();
-        final JobInstance instance = jobInstanceService.buildByIdWithTransitions(jobPlan.getJobId());
+        BuildAssignment assignment = work.getAssignment();
+        final JobInstance instance = jobInstanceService.buildByIdWithTransitions(assignment.getJobIdentifier().getBuildId());
         scheduleService.rescheduleJob(instance);
 
         assertThat(agent.messages.size(), is(2));

--- a/server/test/unit/com/thoughtworks/go/domain/BuildComposerTest.java
+++ b/server/test/unit/com/thoughtworks/go/domain/BuildComposerTest.java
@@ -590,7 +590,7 @@ public class BuildComposerTest extends BuildSessionBasedTestCase {
 
         return BuildAssignment.create(jobPlan,
                 BuildCause.createWithEmptyModifications(),
-                builder, pipeline.defaultWorkingFolder()
-        );
+                builder, pipeline.defaultWorkingFolder(),
+                null);
     }
 }

--- a/server/test/unit/com/thoughtworks/go/remote/work/ArtifactsPublisherTest.java
+++ b/server/test/unit/com/thoughtworks/go/remote/work/ArtifactsPublisherTest.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2017 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.remote.work;
+
+import com.thoughtworks.go.config.*;
+import com.thoughtworks.go.domain.DefaultJobPlan;
+import com.thoughtworks.go.domain.StubGoPublisher;
+import com.thoughtworks.go.util.FileUtil;
+import com.thoughtworks.go.util.TestFileUtil;
+import org.apache.commons.io.FileUtils;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+
+public class ArtifactsPublisherTest {
+
+    private File workingFolder;
+    private File toClean;
+    private ArtifactsPublisher artifactsPublisher;
+
+    @Before
+    public void setUp() throws IOException {
+        artifactsPublisher = new ArtifactsPublisher();
+        workingFolder = TestFileUtil.createTempFolder("workingFolder");
+        File file = new File(workingFolder, "cruise-output/log.xml");
+        file.getParentFile().mkdirs();
+        file.createNewFile();
+    }
+
+    @After
+    public void tearDown() {
+        FileUtil.deleteFolder(workingFolder);
+        FileUtils.deleteQuietly(toClean);
+    }
+
+    @Test
+    public void shouldMergeTestReportFilesAndUploadResult() throws Exception {
+        ArtifactPlans artifactPlans = new ArtifactPlans();
+        DefaultJobPlan plan = new DefaultJobPlan(new Resources(), artifactPlans, new ArtifactPropertiesGenerators(), -1, null, null, new EnvironmentVariablesConfig(), new EnvironmentVariablesConfig(), null);
+        artifactPlans.add(new TestArtifactPlan("test1", "test"));
+        artifactPlans.add(new TestArtifactPlan("test2", "test"));
+
+        final File firstTestFolder = prepareTestFolder(workingFolder, "test1");
+        final File secondTestFolder = prepareTestFolder(workingFolder, "test2");
+
+        StubGoPublisher publisher = new StubGoPublisher();
+        artifactsPublisher.publishArtifacts(publisher, workingFolder, artifactPlans);
+
+        publisher.assertPublished(firstTestFolder.getAbsolutePath(), "test");
+        publisher.assertPublished(secondTestFolder.getAbsolutePath(), "test");
+        publisher.assertPublished("result", "testoutput");
+        publisher.assertPublished("result" + File.separator + "index.html", "testoutput");
+    }
+
+    @Test
+    public void shouldReportErrorWithTestArtifactSrcWhenUploadFails() throws Exception {
+        ArtifactPlans artifactPlans = new ArtifactPlans();
+        DefaultJobPlan plan = new DefaultJobPlan(new Resources(), artifactPlans, new ArtifactPropertiesGenerators(), -1, null, null, new EnvironmentVariablesConfig(), new EnvironmentVariablesConfig(), null);
+        artifactPlans.add(new TestArtifactPlan("test1", "test"));
+        artifactPlans.add(new TestArtifactPlan("test2", "test"));
+
+        prepareTestFolder(workingFolder, "test1");
+        prepareTestFolder(workingFolder, "test2");
+
+        StubGoPublisher publisherThatShouldFail = new StubGoPublisher(true);
+        try {
+            artifactsPublisher.publishArtifacts(publisherThatShouldFail, workingFolder, artifactPlans);
+        } catch (Exception e) {
+            assertThat(e.getMessage(), containsString("Failed to upload [test1, test2]"));
+        }
+    }
+
+    @Test
+    public void shouldUploadFilesCorrectly() throws Exception {
+        ArtifactPlans artifactPlans = new ArtifactPlans();
+        final File src1 = TestFileUtil.createTestFolder(workingFolder, "src1");
+        TestFileUtil.createTestFile(src1, "test.txt");
+        artifactPlans.add(new ArtifactPlan(src1.getName(), "dest"));
+        final File src2 = TestFileUtil.createTestFolder(workingFolder, "src2");
+        TestFileUtil.createTestFile(src1, "test.txt");
+
+        artifactPlans.add(new ArtifactPlan(src2.getName(), "test"));
+        StubGoPublisher publisher = new StubGoPublisher();
+
+        artifactsPublisher.publishArtifacts(publisher, workingFolder, artifactPlans);
+
+        Map<File, String> expectedFiles = new HashMap<File, String>() {
+            {
+                put(src1, "dest");
+                put(src2, "test");
+            }
+        };
+        assertThat(publisher.publishedFiles(), is(expectedFiles));
+    }
+
+    @Test
+    public void shouldUploadFilesWhichMathedWildCard() throws Exception {
+        ArtifactPlans artifactPlans = new ArtifactPlans();
+        final File src1 = TestFileUtil.createTestFolder(workingFolder, "src1");
+        final File testFile1 = TestFileUtil.createTestFile(src1, "test1.txt");
+        final File testFile2 = TestFileUtil.createTestFile(src1, "test2.txt");
+        final File testFile3 = TestFileUtil.createTestFile(src1, "readme.pdf");
+        artifactPlans.add(new ArtifactPlan(src1.getName() + "/*", "dest"));
+        StubGoPublisher publisher = new StubGoPublisher();
+
+        artifactsPublisher.publishArtifacts(publisher, workingFolder, artifactPlans);
+
+        Map<File, String> expectedFiles = new HashMap<File, String>() {
+            {
+                put(testFile1, "dest");
+                put(testFile2, "dest");
+                put(testFile3, "dest");
+            }
+        };
+        assertThat(publisher.publishedFiles(), is(expectedFiles));
+    }
+
+    private File prepareTestFolder(File workingFolder, String folderName) throws Exception {
+        File testFolder = TestFileUtil.createTestFolder(workingFolder, folderName);
+        File testFile = TestFileUtil.createTestFile(testFolder, "testFile.xml");
+        String content = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+                + "<testsuite errors=\"0\" failures=\"0\" tests=\"7\" time=\"0.429\" >\n"
+                + "<testcase/>\n"
+                + "</testsuite>\n";
+        FileUtil.writeContentToFile(content, testFile);
+        return testFolder;
+    }
+}

--- a/server/test/unit/com/thoughtworks/go/remote/work/BuildWorkTest.java
+++ b/server/test/unit/com/thoughtworks/go/remote/work/BuildWorkTest.java
@@ -371,11 +371,13 @@ public class BuildWorkTest {
 
     @Test
     public void shouldSendAResultStatusToServerWhenAThrowableErrorIsThrown() throws Exception {
-        JobPlan jobPlan = mock(JobPlan.class);
-        when(jobPlan.shouldFetchMaterials()).thenThrow(new AssertionError());
-        when(jobPlan.getIdentifier()).thenReturn(JOB_IDENTIFIER);
+        BuildAssignment buildAssignment = mock(BuildAssignment.class);
+        when(buildAssignment.shouldFetchMaterials()).thenThrow(new AssertionError());
+        when(buildAssignment.initialEnvironmentVariableContext()).thenReturn(new EnvironmentVariableContext());
+        when(buildAssignment.getWorkingDirectory()).thenReturn(new File("current"));
+        when(buildAssignment.getJobIdentifier()).thenReturn(JOB_IDENTIFIER);
 
-        createBuildWorkWithJobPlan(jobPlan);
+        buildWork = new BuildWork(buildAssignment);
 
         try {
             buildWork.doWork(agentIdentifier, buildRepository, artifactManipulator, environmentVariableContext, new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", false), packageRepositoryExtension, scmExtension, taskExtension);
@@ -389,11 +391,13 @@ public class BuildWorkTest {
 
     @Test
     public void shouldSendAResultStatusToServerWhenAnExceptionIsThrown() throws Exception {
-        JobPlan jobPlan = mock(JobPlan.class);
-        when(jobPlan.shouldFetchMaterials()).thenThrow(new RuntimeException());
-        when(jobPlan.getIdentifier()).thenReturn(JOB_IDENTIFIER);
+        BuildAssignment buildAssignment = mock(BuildAssignment.class);
+        when(buildAssignment.shouldFetchMaterials()).thenThrow(new RuntimeException());
+        when(buildAssignment.initialEnvironmentVariableContext()).thenReturn(new EnvironmentVariableContext());
+        when(buildAssignment.getWorkingDirectory()).thenReturn(new File("current"));
+        when(buildAssignment.getJobIdentifier()).thenReturn(JOB_IDENTIFIER);
 
-        createBuildWorkWithJobPlan(jobPlan);
+        buildWork = new BuildWork(buildAssignment);
 
         try {
             buildWork.doWork(agentIdentifier, buildRepository, artifactManipulator, environmentVariableContext, new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", false), packageRepositoryExtension, scmExtension, taskExtension);
@@ -617,25 +621,9 @@ public class BuildWorkTest {
 
         BuildAssignment buildAssignment = BuildAssignment.create(jobPlan,
                 BuildCause.createWithEmptyModifications(),
-                builder, pipeline.defaultWorkingFolder()
-        );
+                builder, pipeline.defaultWorkingFolder(),
+                null);
         return new BuildWork(buildAssignment);
-    }
-
-    private void createBuildWorkWithJobPlan(JobPlan jobPlan) throws Exception {
-        CruiseConfig cruiseConfig = new MagicalGoConfigXmlLoader(new ConfigCache(), ConfigElementImplementationRegistryMother.withNoPlugins()).loadConfigHolder(FileUtil.readToEnd(IOUtils.toInputStream(ConfigFileFixture.withJob(CMD_NOT_EXIST)))).config;
-        JobConfig jobConfig = cruiseConfig.jobConfigByName(PIPELINE_NAME, STAGE_NAME, JOB_PLAN_NAME, true);
-
-        final Stage stage = StageMother.custom(STAGE_NAME, new JobInstance(JOB_PLAN_NAME));
-        BuildCause buildCause = BuildCause.createWithEmptyModifications();
-        final Pipeline pipeline = new Pipeline(PIPELINE_NAME, buildCause, stage);
-        List<Builder> builder = builderFactory.buildersForTasks(pipeline, jobConfig.getTasks(), resolver);
-
-        BuildAssignment buildAssignment = BuildAssignment.create(jobPlan,
-                BuildCause.createWithEmptyModifications(),
-                builder, pipeline.defaultWorkingFolder()
-        );
-        buildWork = new BuildWork(buildAssignment);
     }
 
     @Test


### PR DESCRIPTION
 * Currently the BuildAssignment object serialized and sent to agent consists of DefaultJobPlan, the JobPlan object is something internal to server and should not be passed to agent.
* BuildAssignment is a DTO passed to agent with all the necessary information for agent to 
execute a job.
* Moved publish artifcats behaviour from JobPlan to ArtifactsPublisher
* Ensure build assignment has the required environment_variables resolved from JobPlan and 
   Environment. The env variables are resolved in the following order
   1. apply -> variables_for_an_environment
   2. apply and override -> variables_for_job_derived_from_job_plan
   3. apply and override -> trigger_variables_for_a_job.