### PR TITLE
Update server side validation to not use file system -#3984

### DIFF
--- a/base/src/com/thoughtworks/go/util/FileUtil.java
+++ b/base/src/com/thoughtworks/go/util/FileUtil.java
@@ -21,22 +21,11 @@ import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
+import java.io.*;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.net.URI;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.Stack;
-import java.util.StringTokenizer;
-import java.util.UUID;
+import java.util.*;
 
 import static java.lang.System.getProperty;
 
@@ -423,21 +412,6 @@ public class FileUtil {
             throw new RuntimeException("FileUtil#createTempFolder - Could not create temp folder");
         }
         return dir;
-    }
-
-    public static boolean isFolderInsideSandbox(String path) {
-        File fileAtPath = new File(path);
-        if (fileAtPath.isAbsolute()) {
-            return false;
-        }
-        try {
-            if (!FileUtil.isSubdirectoryOf(new File("."), fileAtPath)) {
-                return false;
-            }
-        } catch (IOException e) {
-            ExceptionUtils.bomb("Dest folder specification is not valid. " + e.getMessage());
-        }
-        return true;
     }
 
     public static void writeToFile(InputStream stream, File dest) throws IOException {

--- a/base/src/com/thoughtworks/go/util/FilenameUtil.java
+++ b/base/src/com/thoughtworks/go/util/FilenameUtil.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2017 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.util;
+
+import org.apache.commons.io.FilenameUtils;
+import org.apache.commons.lang.StringUtils;
+
+import java.io.File;
+import java.io.IOException;
+
+public class FilenameUtil {
+    public static boolean isNormalizedDirectoryPathInsideNormalizedParentDirectory(String parent, String subdirectory) throws IOException {
+        final String normalizedParentPath = FilenameUtils.normalize(parent + File.separator);
+        final String normalizedSubDirPath = FilenameUtils.normalize(subdirectory + File.separator);
+        return StringUtils.isNotBlank(normalizedParentPath) && StringUtils.isNotBlank(normalizedSubDirPath) && normalizedSubDirPath.startsWith(normalizedParentPath);
+    }
+    public static boolean isNormalizedPathOutsideWorkingDir(String path) {
+        final String normalize = FilenameUtils.normalize(path);
+        final String prefix = FilenameUtils.getPrefix(normalize);
+        return (normalize != null && StringUtils.isBlank(prefix));
+    }
+}
+
+

--- a/base/test/com/thoughtworks/go/util/FilenameUtilTest.java
+++ b/base/test/com/thoughtworks/go/util/FilenameUtilTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2017 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.util;
+
+import org.junit.Test;
+
+import java.io.File;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+public class FilenameUtilTest {
+
+    @Test
+    public void shouldReturnFalseIfGivenFolderIsAbsolute() {
+        assertThat(FilenameUtil.isNormalizedPathOutsideWorkingDir("c:\\foo"), is(false));
+    }
+
+    @Test
+    public void shouldReturnFalseIfGivenFolderIsAbsoluteUnderLinux() {
+        assertThat(FilenameUtil.isNormalizedPathOutsideWorkingDir("/tmp"), is(false));
+    }
+
+    @Test
+    public void shouldReturnFalseIfGivenFolderWithRelativeTakesYouOutOfSandbox() {
+        assertThat(FilenameUtil.isNormalizedPathOutsideWorkingDir("../tmp"), is(false));
+        assertThat(FilenameUtil.isNormalizedPathOutsideWorkingDir("tmp/../../../pavan"), is(false));
+    }
+
+    @Test
+    public void shouldReturnTrueIfGivenFolderWithRelativeKeepsYouInsideSandbox() {
+        assertThat(FilenameUtil.isNormalizedPathOutsideWorkingDir("tmp/../home/cruise"), is(true));
+    }
+
+
+    @Test
+    public void shouldReturnFalseEvenIfAnAbsolutePathKeepsYouInsideSandbox() {
+        File file = new File("somethingInsideCurrentFolder");
+        assertThat(FilenameUtil.isNormalizedPathOutsideWorkingDir(file.getAbsolutePath()), is(false));
+    }
+
+    @Test
+    public void shouldReturnFalseIfDirectoryNameIsSameAsParentDirectoryButNotASubdirectory() throws Exception {
+        assertFalse(FilenameUtil.isNormalizedDirectoryPathInsideNormalizedParentDirectory("config", "artifacts/config"));
+    }
+
+    @Test
+    public void shouldReturnTrueIfDirectoryIsSubdirectoryOfParent() throws Exception {
+        assertTrue(FilenameUtil.isNormalizedDirectoryPathInsideNormalizedParentDirectory("artifacts", "artifacts/config"));
+    }
+}

--- a/common/test/unit/com/thoughtworks/go/util/FileUtilTest.java
+++ b/common/test/unit/com/thoughtworks/go/util/FileUtilTest.java
@@ -57,7 +57,7 @@ public class FileUtilTest {
     }
 
     @After
-    public void tearDown() {
+    public void tearDown() throws Exception {
         temporaryFolder.delete();
     }
 
@@ -259,12 +259,6 @@ public class FileUtilTest {
 
     @Test
     @RunIf(value = EnhancedOSChecker.class, arguments = {EnhancedOSChecker.WINDOWS})
-    public void shouldReturnFalseIfGivenFolderIsAbsolute() {
-        assertThat(FileUtil.isFolderInsideSandbox("c:\\foo"), is(false));
-    }
-
-    @Test
-    @RunIf(value = EnhancedOSChecker.class, arguments = {EnhancedOSChecker.WINDOWS})
     public void shouldReturnFalseForInvalidWindowsUNCFilePath() {
         assertThat(FileUtil.isAbsolutePath("\\\\host\\"), is(false));
         assertThat(FileUtil.isAbsolutePath("\\\\host"), is(false));
@@ -275,29 +269,6 @@ public class FileUtilTest {
     public void shouldReturnTrueForValidWindowsUNCFilePath() {
         assertThat(FileUtil.isAbsolutePath("\\\\host\\share"), is(true));
         assertThat(FileUtil.isAbsolutePath("\\\\host\\share\\dir"), is(true));
-    }
-
-    @Test
-    @RunIf(value = EnhancedOSChecker.class, arguments = {DO_NOT_RUN_ON, WINDOWS})
-    public void shouldReturnFalseIfGivenFolderIsAbsoluteUnderLinux() {
-        assertThat(FileUtil.isFolderInsideSandbox("/tmp"), is(false));
-    }
-
-    @Test
-    public void shouldReturnFalseIfGivenFolderWithRelativeTakesYouOutOfSandbox() {
-        assertThat(FileUtil.isFolderInsideSandbox("../tmp"), is(false));
-        assertThat(FileUtil.isFolderInsideSandbox("tmp/../../../pavan"), is(false));
-    }
-
-    @Test
-    public void shouldReturnTrueIfGivenFolderWithRelativeKeepsYouInsideSandbox() {
-        assertThat(FileUtil.isFolderInsideSandbox("tmp/../home/cruise"), is(true));
-    }
-
-    @Test
-    public void shouldReturnFalseEvenIfAnAbsolutePathKeepsYouInsideSandbox() {
-        File file = new File("somethingInsideCurrentFolder");
-        assertThat(FileUtil.isFolderInsideSandbox(file.getAbsolutePath()), is(false));
     }
 
     @Test

--- a/config/config-api/src/com/thoughtworks/go/config/BuildTask.java
+++ b/config/config-api/src/com/thoughtworks/go/config/BuildTask.java
@@ -17,7 +17,7 @@
 package com.thoughtworks.go.config;
 
 import com.thoughtworks.go.domain.TaskProperty;
-import com.thoughtworks.go.util.FileUtil;
+import com.thoughtworks.go.util.FilenameUtil;
 import com.thoughtworks.go.util.StringUtil;
 import org.apache.commons.lang.StringUtils;
 
@@ -105,7 +105,7 @@ public abstract class BuildTask extends AbstractTask implements CommandTask {
     }
 
     private void validateWorkingDirectory(ValidationContext validationContext, String stageParentType, Object stageParentName) {
-        if (workingDirectory != null && !FileUtil.isFolderInsideSandbox(workingDirectory)) {
+        if (workingDirectory != null && !FilenameUtil.isNormalizedPathOutsideWorkingDir(workingDirectory)) {
             errors.add(WORKING_DIRECTORY, String.format("Task of job '%s' in stage '%s' of %s '%s' has path '%s' which is outside the working directory.", validationContext.getJob().name(),
                     validationContext.getStage().name(), stageParentType, stageParentName, workingDirectory));
         }

--- a/config/config-api/src/com/thoughtworks/go/config/ExecTask.java
+++ b/config/config-api/src/com/thoughtworks/go/config/ExecTask.java
@@ -19,7 +19,7 @@ package com.thoughtworks.go.config;
 import com.thoughtworks.go.domain.TaskProperty;
 import com.thoughtworks.go.domain.config.Arguments;
 import com.thoughtworks.go.util.ArrayUtil;
-import com.thoughtworks.go.util.FileUtil;
+import com.thoughtworks.go.util.FilenameUtil;
 import com.thoughtworks.go.util.StringUtil;
 import com.thoughtworks.go.utils.CommandUtils;
 
@@ -149,7 +149,7 @@ public class ExecTask extends AbstractTask implements CommandTask {
             errors.add(ARGS, EXEC_CONFIG_ERROR);
             errors.add(ARG_LIST_STRING, EXEC_CONFIG_ERROR);
         }
-        if (workingDirectory != null && !FileUtil.isFolderInsideSandbox(workingDirectory)) {
+        if (workingDirectory != null && !FilenameUtil.isNormalizedPathOutsideWorkingDir(workingDirectory)) {
             if (ctx.isWithinPipelines()) {
                 errors.add(WORKING_DIR,
                         String.format("The path of the working directory for the custom command in job '%s' in stage '%s' of pipeline '%s' is outside the agent sandbox.", ctx.getJob().name(),

--- a/config/config-api/src/com/thoughtworks/go/config/FetchTask.java
+++ b/config/config-api/src/com/thoughtworks/go/config/FetchTask.java
@@ -20,6 +20,7 @@ import com.thoughtworks.go.config.materials.dependency.DependencyMaterialConfig;
 import com.thoughtworks.go.config.remote.ConfigOrigin;
 import com.thoughtworks.go.domain.TaskProperty;
 import com.thoughtworks.go.util.FileUtil;
+import com.thoughtworks.go.util.FilenameUtil;
 import com.thoughtworks.go.util.ListUtil;
 import com.thoughtworks.go.util.StringUtil;
 import org.apache.commons.lang.StringUtils;
@@ -318,7 +319,7 @@ public class FetchTask extends AbstractTask implements Serializable {
         if (path == null) {
             return;
         }
-        if (!FileUtil.isFolderInsideSandbox(path)) {
+        if (!FilenameUtil.isNormalizedPathOutsideWorkingDir(path)) {
             String parentType = validationContext.isWithinPipelines() ? "pipeline" : "template";
             CaseInsensitiveString parentName = validationContext.isWithinPipelines() ? validationContext.getPipeline().name() : validationContext.getTemplate().name();
             String message = String.format("Task of job '%s' in stage '%s' of %s '%s' has %s path '%s' which is outside the working directory.",

--- a/config/config-api/src/com/thoughtworks/go/config/materials/PluggableSCMMaterialConfig.java
+++ b/config/config-api/src/com/thoughtworks/go/config/materials/PluggableSCMMaterialConfig.java
@@ -20,7 +20,7 @@ import com.thoughtworks.go.config.*;
 import com.thoughtworks.go.config.validation.FilePathTypeValidator;
 import com.thoughtworks.go.domain.scm.SCM;
 import com.thoughtworks.go.plugin.access.scm.SCMMetadataStore;
-import com.thoughtworks.go.util.FileUtil;
+import com.thoughtworks.go.util.FilenameUtil;
 import com.thoughtworks.go.util.StringUtil;
 import org.apache.commons.lang.StringUtils;
 
@@ -280,7 +280,7 @@ public class PluggableSCMMaterialConfig extends AbstractMaterialConfig {
         if (dest == null) {
             return;
         }
-        if (!(FileUtil.isFolderInsideSandbox(dest))) {
+        if (!(FilenameUtil.isNormalizedPathOutsideWorkingDir(dest))) {
             addError(FOLDER, String.format("Dest folder '%s' is not valid. It must be a sub-directory of the working folder.", dest));
         }
     }
@@ -290,10 +290,8 @@ public class PluggableSCMMaterialConfig extends AbstractMaterialConfig {
         if (myDirPath == null || otherSCMMaterialFolder == null) {
             return;
         }
-        File myDir = new File(myDirPath);
-        File otherDir = new File(otherSCMMaterialFolder);
         try {
-            if (FileUtil.isSubdirectoryOf(myDir, otherDir)) {
+            if (FilenameUtil.isNormalizedDirectoryPathInsideNormalizedParentDirectory(myDirPath, otherSCMMaterialFolder)) {
                 addError(FOLDER, "Invalid Destination Directory. Every material needs a different destination directory and the directories should not be nested.");
             }
         } catch (IOException e) {

--- a/config/config-api/src/com/thoughtworks/go/config/materials/ScmMaterialConfig.java
+++ b/config/config-api/src/com/thoughtworks/go/config/materials/ScmMaterialConfig.java
@@ -20,7 +20,7 @@ import com.thoughtworks.go.config.*;
 import com.thoughtworks.go.config.validation.FilePathTypeValidator;
 import com.thoughtworks.go.domain.ConfigErrors;
 import com.thoughtworks.go.domain.materials.MaterialConfig;
-import com.thoughtworks.go.util.FileUtil;
+import com.thoughtworks.go.util.FilenameUtil;
 import com.thoughtworks.go.util.StringUtil;
 import com.thoughtworks.go.util.command.UrlArgument;
 import org.apache.commons.lang.StringUtils;
@@ -264,10 +264,8 @@ public abstract class ScmMaterialConfig extends AbstractMaterialConfig implement
         if (myDirPath == null || otherSCMMaterialFolder == null) {
             return;
         }
-        File myDir = new File(myDirPath);
-        File otherDir = new File(otherSCMMaterialFolder);
         try {
-            if (FileUtil.isSubdirectoryOf(myDir, otherDir)) {
+            if (FilenameUtil.isNormalizedDirectoryPathInsideNormalizedParentDirectory(myDirPath, otherSCMMaterialFolder)) {
                 addError(FOLDER, "Invalid Destination Directory. Every material needs a different destination directory and the directories should not be nested.");
             }
         } catch (IOException e) {
@@ -286,7 +284,7 @@ public abstract class ScmMaterialConfig extends AbstractMaterialConfig implement
         if (dest == null) {
             return;
         }
-        if (!(FileUtil.isFolderInsideSandbox(dest))) {
+        if (!(FilenameUtil.isNormalizedPathOutsideWorkingDir(dest))) {
             setDestinationFolderError(String.format("Dest folder '%s' is not valid. It must be a sub-directory of the working folder.", dest));
         }
     }

--- a/config/config-api/test/com/thoughtworks/go/config/materials/ScmMaterialConfigTest.java
+++ b/config/config-api/test/com/thoughtworks/go/config/materials/ScmMaterialConfigTest.java
@@ -16,21 +16,37 @@
 
 package com.thoughtworks.go.config.materials;
 
+import com.thoughtworks.go.config.ConfigSaveValidationContext;
+import org.apache.commons.collections.map.SingletonMap;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.HashMap;
 
-import com.thoughtworks.go.config.ConfigSaveValidationContext;
-import org.apache.commons.collections.map.SingletonMap;
-import org.junit.Test;
-
 import static com.thoughtworks.go.config.materials.ScmMaterialConfig.AUTO_UPDATE;
+import static com.thoughtworks.go.config.materials.ScmMaterialConfig.FOLDER;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNot.not;
 import static org.hamcrest.core.IsNull.nullValue;
-import static org.junit.Assert.assertThat;
+import static org.junit.Assert.*;
 
 public class ScmMaterialConfigTest {
-    DummyMaterialConfig material = new DummyMaterialConfig();
+    private DummyMaterialConfig material;
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    @Before
+    public void setUp() throws Exception {
+        material = new DummyMaterialConfig();
+    }
 
     @Test
     public void shouldSetFilterToNullWhenBlank() {
@@ -48,17 +64,17 @@ public class ScmMaterialConfigTest {
 
     @Test
     public void shouldNotValidateEmptyDestinationFolder() {
-        material.setConfigAttributes(Collections.singletonMap(ScmMaterialConfig.FOLDER, ""));
+        material.setConfigAttributes(Collections.singletonMap(FOLDER, ""));
         material.validate(new ConfigSaveValidationContext(null));
         assertThat(material.errors.isEmpty(), is(true));
     }
 
     @Test
     public void shouldSetFolderToNullWhenBlank() {
-        material.setConfigAttributes(Collections.singletonMap(ScmMaterialConfig.FOLDER, "foo"));
+        material.setConfigAttributes(Collections.singletonMap(FOLDER, "foo"));
         assertThat(material.getFolder(), is(not(nullValue())));
 
-        material.setConfigAttributes(new SingletonMap(ScmMaterialConfig.FOLDER, ""));
+        material.setConfigAttributes(new SingletonMap(FOLDER, ""));
         assertThat(material.getFolder(), is(nullValue()));
     }
 
@@ -76,5 +92,50 @@ public class ScmMaterialConfigTest {
         assertThat(material.isAutoUpdate(), is(false));
         material.setConfigAttributes(new SingletonMap(AUTO_UPDATE, "random-stuff"));
         assertThat(material.isAutoUpdate(), is(false));
+    }
+
+    @Test
+    public void shouldFailValidationIfDestinationDirectoryIsNested() {
+        material.setFolder("f1");
+        material.validateNotSubdirectoryOf("f1/f2");
+        assertFalse(material.errors().isEmpty());
+        assertThat(material.errors().on(FOLDER), is("Invalid Destination Directory. Every material needs a different destination directory and the directories should not be nested."));
+    }
+
+    @Test
+    public void shouldNotFailValidationIfDestinationDirectoryIsMultilevelButNotNested() {
+        material.setFolder("f1/f2/f3");
+        material.validateNotSubdirectoryOf("f1/f2/f");
+
+        assertNull(material.errors().getAllOn(FOLDER));
+    }
+
+    @Test
+    public void shouldFailValidationIfDestinationDirectoryIsOutsideCurrentWorkingDirectoryAfterNormalization() {
+        material.setFolder("f1/../../f3");
+
+        material.validateConcreteMaterial(null);
+        assertThat(material.errors().on(FOLDER), is("Dest folder 'f1/../../f3' is not valid. It must be a sub-directory of the working folder."));
+    }
+
+    @Test
+    public void shouldFailValidationIfDestinationDirectoryIsNestedAfterNormalization() {
+        material.setFolder("f1/f2/../../f3");
+        material.validateNotSubdirectoryOf("f3/f4");
+        assertThat(material.errors().on(FOLDER), is("Invalid Destination Directory. Every material needs a different destination directory and the directories should not be nested."));
+    }
+
+    @Test
+    public void shouldNotValidateNestingOfMaterialDirectoriesBasedOnServerSideFileSystem() throws IOException {
+        final File workingDir = temporaryFolder.newFolder("go-working-dir");
+        final File material1 = new File(workingDir, "material1");
+        material1.mkdirs();
+
+        final Path material2 = Files.createSymbolicLink(Paths.get(new File(workingDir, "material2").getPath()), Paths.get(material1.getPath()));
+
+        material.setFolder(material1.getAbsolutePath());
+        material.validateNotSubdirectoryOf(material2.toAbsolutePath().toString());
+
+        assertNull(material.errors().getAllOn(FOLDER));
     }
 }


### PR DESCRIPTION
* See https://github.com/gocd/gocd/issues/3984\#issuecomment-342476130 for more information.
* Using filenames to check for nesting and allowed directory
configurations instead of the filesystem as the checks on the server's
filesystem wouldn't apply on the agent side which is where the Task
working directory and material destination directory would be used.