### PR TITLE
Fix origin attribute on pipeline config to show HAL representation of config origin

### DIFF
--- a/server/webapp/WEB-INF/rails.new/app/presenters/api_v5/shared/config_origin/config_repo_origin_representer.rb
+++ b/server/webapp/WEB-INF/rails.new/app/presenters/api_v5/shared/config_origin/config_repo_origin_representer.rb
@@ -18,19 +18,30 @@ module ApiV5
   module Shared
     module ConfigOrigin
       class ConfigRepoOriginRepresenter < BaseRepresenter
-        alias_method :config_repo, :represented
+        alias_method :config_repo_origin, :represented
 
-        property :type, exec_context: :decorator
-        property :repo, exec_context: :decorator
-
-        def type
-          'config repo'
+        link :self do |opts|
+          opts[:url_builder].apiv1_admin_config_repo_url(id: id)
         end
 
-        def repo
-          material = ApiV5::Admin::Pipelines::Materials::MaterialRepresenter.new(config_repo.getMaterial).to_hash(url_builder: self)
-          material[:revision] = config_repo.getRevision()
-          material
+        link :doc do |opts|
+          'https://api.gocd.org/#config-repos'
+        end
+
+        link :find do |opts|
+          opts[:url_builder].apiv1_admin_config_repo_url(id: '__id__').gsub(/__id__/, ':id')
+        end
+
+        property :type, exec_context: :decorator
+        property :id, exec_context: :decorator
+
+
+        def type
+          'config_repo'
+        end
+
+        def id
+          config_repo_origin.getConfigRepo.id
         end
       end
     end

--- a/server/webapp/WEB-INF/rails.new/app/presenters/api_v5/shared/config_origin/config_xml_origin_representer.rb
+++ b/server/webapp/WEB-INF/rails.new/app/presenters/api_v5/shared/config_origin/config_xml_origin_representer.rb
@@ -18,8 +18,6 @@ module ApiV5
   module Shared
     module ConfigOrigin
       class ConfigXmlOriginRepresenter < BaseRepresenter
-        alias_method :config_xml_config, :represented
-
         link :self do |opts|
           opts[:url_builder].config_view_url()
         end

--- a/server/webapp/WEB-INF/rails.new/app/presenters/api_v5/shared/config_origin/config_xml_origin_representer.rb
+++ b/server/webapp/WEB-INF/rails.new/app/presenters/api_v5/shared/config_origin/config_xml_origin_representer.rb
@@ -27,16 +27,10 @@ module ApiV5
         link :doc do |opts|
           'https://api.gocd.org/#get-configuration'
         end
-
         property :type, exec_context: :decorator
-        property :id, exec_context: :decorator
 
         def type
           'gocd'
-        end
-
-        def id
-          config_xml_config.displayName
         end
       end
     end

--- a/server/webapp/WEB-INF/rails.new/app/presenters/api_v5/shared/config_origin/config_xml_origin_representer.rb
+++ b/server/webapp/WEB-INF/rails.new/app/presenters/api_v5/shared/config_origin/config_xml_origin_representer.rb
@@ -18,13 +18,25 @@ module ApiV5
   module Shared
     module ConfigOrigin
       class ConfigXmlOriginRepresenter < BaseRepresenter
-        alias_method :origin, :represented
+        alias_method :config_xml_config, :represented
+
+        link :self do |opts|
+          opts[:url_builder].config_view_url()
+        end
+
+        link :doc do |opts|
+          'https://api.gocd.org/#get-configuration'
+        end
 
         property :type, exec_context: :decorator
-        property :displayName, as: :file
+        property :id, exec_context: :decorator
 
         def type
-          'local'
+          'gocd'
+        end
+
+        def id
+          config_xml_config.displayName
         end
       end
     end

--- a/server/webapp/WEB-INF/rails.new/spec/controllers/api_v5/admin/pipelines_controller_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/controllers/api_v5/admin/pipelines_controller_spec.rb
@@ -676,8 +676,15 @@ describe ApiV5::Admin::PipelinesController do
         materials: [{type: "svn", attributes: {url: "http://some/svn/url", destination: "svnDir", filter: nil, invert_filter: false, name: "http___some_svn_url", auto_update: true, check_externals: false, username: nil}}],
         name: "pipeline1",
         origin: {
-          type: 'local',
-          file: 'cruise-config.xml'
+          _links: {
+            self: {
+              href: 'http://test.host/admin/config_xml'
+            },
+            doc: {
+              href: 'https://api.gocd.org/#get-configuration'
+            }
+          },
+          type: 'gocd'
         },
         environment_variables: [],
         parameters: [],

--- a/server/webapp/WEB-INF/rails.new/spec/presenters/api_v5/admin/pipelines/pipeline_config_representer_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/presenters/api_v5/admin/pipelines/pipeline_config_representer_spec.rb
@@ -45,8 +45,15 @@ describe ApiV5::Admin::Pipelines::PipelineConfigRepresenter do
         lock_behavior: 'none',
         name: 'wunderbar',
         origin: {
-          type: 'local',
-          file: 'cruise-config.xml'
+          _links: {
+            self: {
+              href: 'http://test.host/admin/config_xml'
+            },
+            doc: {
+              href: 'https://api.gocd.org/#get-configuration'
+            }
+          },
+          type: 'gocd'
         },
         template: 'template1',
         parameters: [],
@@ -369,8 +376,15 @@ describe ApiV5::Admin::Pipelines::PipelineConfigRepresenter do
       lock_behavior: 'none',
       name: 'wunderbar',
       origin: {
-        type: 'local',
-        file: 'cruise-config.xml'
+        _links: {
+          self: {
+            href: 'http://test.host/admin/config_xml'
+          },
+          doc: {
+            href: 'https://api.gocd.org/#get-configuration'
+          }
+        },
+        type: 'gocd'
       },
       template: nil,
       parameters: [],
@@ -393,8 +407,15 @@ describe ApiV5::Admin::Pipelines::PipelineConfigRepresenter do
       lock_behavior: 'none',
       name: 'wunderbar',
       origin: {
-        type: 'local',
-        file: 'cruise-config.xml'
+        _links: {
+          self: {
+            href: 'http://test.host/admin/config_xml'
+          },
+          doc: {
+            href: 'https://api.gocd.org/#get-configuration'
+          }
+        },
+        type: 'gocd'
       },
       template: nil,
       parameters: [
@@ -468,8 +489,15 @@ describe ApiV5::Admin::Pipelines::PipelineConfigRepresenter do
       lock_behavior: 'none',
       name: 'wunderbar',
       origin: {
-        type: 'local',
-        file: 'cruise-config.xml'
+        _links: {
+          self: {
+            href: 'http://test.host/admin/config_xml'
+          },
+          doc: {
+            href: 'https://api.gocd.org/#get-configuration'
+          }
+        },
+        type: 'gocd'
       },
       template: nil,
       parameters: get_pipeline_config.getParams().collect { |j| ApiV5::Admin::Pipelines::ParamRepresenter.new(j).to_hash(url_builder: UrlBuilder.new) },

--- a/server/webapp/WEB-INF/rails.new/spec/presenters/api_v5/shared/config_origin/config_repo_origin_representer_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/presenters/api_v5/shared/config_origin/config_repo_origin_representer_spec.rb
@@ -19,32 +19,27 @@ require 'rails_helper'
 describe ApiV5::Shared::ConfigOrigin::ConfigRepoOriginRepresenter do
   it 'should render remote config origin' do
     git_material = GitMaterialConfig.new('https://github.com/config-repos/repo', 'master')
-    config_repo = RepoConfigOrigin.new(ConfigRepoConfig.new(git_material, 'json-plugin'), 'revision1')
-
+    config_repo = RepoConfigOrigin.new(ConfigRepoConfig.new(git_material, 'json-plugin', 'repo1'), 'revision1')
     actual_json = ApiV5::Shared::ConfigOrigin::ConfigRepoOriginRepresenter.new(config_repo).to_hash(url_builder: UrlBuilder.new)
-    material_json = ApiV5::Admin::Pipelines::Materials::GitMaterialRepresenter.new(git_material).to_hash(url_builder: UrlBuilder.new)
 
     expect(actual_json).to eq(expected_json)
   end
 
   def expected_json
     {
-      type: 'config repo',
-      repo: {
-        type: 'git',
-        attributes: {
-          url: 'https://github.com/config-repos/repo',
-          destination: nil,
-          filter: nil,
-          invert_filter: false,
-          name: nil,
-          auto_update: true,
-          branch: 'master',
-          submodule_folder: nil,
-          shallow_clone: false
+      type: 'config_repo',
+      _links: {
+        self: {
+          href: 'http://test.host/api/admin/config_repos/repo1'
         },
-        revision: 'revision1'
-      }
+        doc: {
+          href: 'https://api.gocd.org/#config-repos'
+        },
+        find: {
+          href: 'http://test.host/api/admin/config_repos/:id'
+        }
+      },
+      id: 'repo1'
     }
   end
 end

--- a/server/webapp/WEB-INF/rails.new/spec/presenters/api_v5/shared/config_origin/config_xml_origin_representer_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/presenters/api_v5/shared/config_origin/config_xml_origin_representer_spec.rb
@@ -37,8 +37,7 @@ describe ApiV5::Shared::ConfigOrigin::ConfigXmlOriginRepresenter do
         doc: {
           href: 'https://api.gocd.org/#get-configuration'
         }
-      },
-      id: 'cruise-config.xml'
+      }
     }
   end
 end

--- a/server/webapp/WEB-INF/rails.new/spec/presenters/api_v5/shared/config_origin/config_xml_origin_representer_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/presenters/api_v5/shared/config_origin/config_xml_origin_representer_spec.rb
@@ -29,8 +29,16 @@ describe ApiV5::Shared::ConfigOrigin::ConfigXmlOriginRepresenter do
 
   def expected_json
     {
-      type: 'local',
-      file: 'cruise-config.xml'
+      type: 'gocd',
+      _links: {
+        self: {
+          href: 'http://test.host/admin/config_xml'
+        },
+        doc: {
+          href: 'https://api.gocd.org/#get-configuration'
+        }
+      },
+      id: 'cruise-config.xml'
     }
   end
 end


### PR DESCRIPTION
* Change config origin attribute representation as per documented in #3301

### Origin attribute for pipelines defined in `cruise-config.xml`
```json
"origin": {
    "_links": {
      "self": {
        "href": "http://localhost:8153/go/admin/config_xml"
      },
      "doc": {
        "href": "https://api.gocd.org/#get-configuration"
      }
    },
    "type": "gocd"
  }
```

### Origin attribute for pipelines defined in `config repo`
```json
"origin": {
    "_links": {
      "self": {
        "href": "http://localhost:8153/go/api/admin/config_repos/repo1"
      },
      "doc": {
        "href": "https://api.gocd.org/#config-repos"
      },
      "find": {
        "href": "http://localhost:8153/go/api/admin/config_repos/:id"
      }
    },
    "type": "config_repo",
    "id": "repo1"
  }
```
