### PR TITLE
Fixes custom matcher have_links

### DIFF
--- a/server/webapp/WEB-INF/rails.new/spec/support/custom_matchers.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/support/custom_matchers.rb
@@ -170,11 +170,11 @@ end
 RSpec::Matchers.define :have_links do |*link_names|
 
   failure_message do |hal_json|
-    @matcher.failure_message_for_should
+    @matcher.failure_message
   end
 
   failure_message_when_negated do |hal_json|
-    @matcher.failure_message_for_should_not
+    @matcher.failure_message_when_negated
   end
 
   description do |hal_json|
@@ -182,9 +182,8 @@ RSpec::Matchers.define :have_links do |*link_names|
   end
 
   match do |hal_json|
-    expect((hal_json[:_links] || {}).keys.collect(&:to_sym)).to match_array(link_names.collect(&:to_sym))
-    # @matcher = RSpec::Matchers::BuiltIn::MatchArray.new(link_names.collect(&:to_sym))
-    # @matcher.matches?((hal_json[:_links] || {}).keys.collect(&:to_sym))
+    @matcher = RSpec::Matchers::BuiltIn::ContainExactly.new(link_names.collect(&:to_sym))
+    @matcher.matches?((hal_json[:_links] || {}).keys.collect(&:to_sym))
   end
 end
 


### PR DESCRIPTION
Prior to rspec upgrade, we were using `MatchArray` built in Rspec Matcher in the implementation of  custom matcher `have_links`(https://github.com/gocd/gocd/blob/17.10.0/server/webapp/WEB-INF/rails.new/spec/support/api_spec_helper.rb#L302). This was not present in rspec 3.6.0. This PR uses `ContainExactly` builtin Matcher as a substitute.

Failure output example when one key is missing:
`expect(actual_json).to have_links(:self, :find)`  
```
 Failure/Error: expect(actual_json).to have_links(:self, :find)

       expected collection contained:  [:find, :self]
       actual collection contained:    [:doc, :find, :self]
       the extra elements were:        [:doc]
```
Failure output example when an extra key is specified:
`expect(actual_json).to have_links(:self, :find, :doc, :test)`  
```
Failure/Error: expect(actual_json).to have_links(:self, :find, :doc, :test)

       expected collection contained:  [:doc, :find, :self, :test]
       actual collection contained:    [:doc, :find, :self]
       the missing elements were:      [:test]
```
