### PR TITLE
Ensure environment variables from jobs have highest priority

### DIFF
--- a/common/src/com/thoughtworks/go/remote/work/BuildWork.java
+++ b/common/src/com/thoughtworks/go/remote/work/BuildWork.java
@@ -84,7 +84,6 @@ public class BuildWork implements Work {
                        EnvironmentVariableContext environmentVariableContext, AgentRuntimeInfo agentRuntimeInfo,
                        PackageRepositoryExtension packageRepositoryExtension, SCMExtension scmExtension, TaskExtension taskExtension) {
         initialize(remoteBuildRepository, goArtifactsManipulator, agentRuntimeInfo, taskExtension);
-        environmentVariableContext.addAll(assignment.initialEnvironmentVariableContext());
         try {
             JobResult result = build(environmentVariableContext, agentIdentifier, packageRepositoryExtension, scmExtension);
             reportCompletion(result);
@@ -190,6 +189,7 @@ public class BuildWork implements Work {
 
     private void setupEnvrionmentContext(EnvironmentVariableContext context) {
         context.setProperty("GO_SERVER_URL", new SystemEnvironment().getPropertyImpl("serviceUrl"), false);
+        context.addAll(assignment.initialEnvironmentVariableContext());
     }
 
     private JobResult buildJob(EnvironmentVariableContext environmentVariableContext) {

--- a/server/test/unit/com/thoughtworks/go/remote/work/BuildWorkTest.java
+++ b/server/test/unit/com/thoughtworks/go/remote/work/BuildWorkTest.java
@@ -184,6 +184,16 @@ public class BuildWorkTest {
             + "  </tasks>\n"
             + "</job>";
 
+    private static final String WITH_GO_SERVER_URL_ENV_VAR = "<job name=\"" + JOB_PLAN_NAME + "\">\n"
+            + "  <environmentvariables>\n"
+            + "    <variable name=\"GO_SERVER_URL\">\n"
+            + "      <value>go_server_url_from_job</value>\n"
+            + "    </variable>\n"
+            + "  </environmentvariables>\n"
+            + "  <tasks>\n"
+            + "    <ant target=\"-help\" />\n"
+            + "  </tasks>\n"
+            + "</job>";
 
     private EnvironmentVariableContext environmentVariableContext;
     private com.thoughtworks.go.remote.work.BuildRepositoryRemoteStub buildRepository;
@@ -648,6 +658,18 @@ public class BuildWorkTest {
         } else {
             assertThat(consoleOut, containsString("[go] overriding environment variable 'PATH' with value '/tmp'"));
         }
+    }
+
+    @Test
+    public void shouldOverrideAgentGO_SERVER_URL_EnvironmentVariableIfDefinedInJob() throws Exception {
+        buildWork = (BuildWork) getWork(WITH_GO_SERVER_URL_ENV_VAR, PIPELINE_NAME);
+
+        buildWork.doWork(agentIdentifier, buildRepository, artifactManipulator, environmentVariableContext, new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", false), packageRepositoryExtension, scmExtension, taskExtension);
+
+        String consoleOut = artifactManipulator.consoleOut();
+
+        assertThat(consoleOut, containsString("[go] setting environment variable 'GO_SERVER_URL' to value 'somewhere-does-not-matter'"));
+        assertThat(consoleOut, containsString("[go] overriding environment variable 'GO_SERVER_URL' with value 'go_server_url_from_job'"));
     }
 
     @Test


### PR DESCRIPTION
* This commit fixes a bug introduced by #4025. Earlier environment
  variables defined in a job took priority over variables defined in
  agent in this case 'GO_SERVER_URL'. That means if a user defines a
  env variable called 'GO_SERVER_URL' in a job, the agent defined
  variable is overridden by one in the job. With #4025 changes, the
  agent variable took priority over the job variables, this commit fixes
  it.