### PR TITLE
Clean Shell Scripts

### DIFF
--- a/manual-testing/ant_hg/make-one-change.sh
+++ b/manual-testing/ant_hg/make-one-change.sh
@@ -2,7 +2,7 @@
 if [ "$USER" == '' ]; then
     USER=ManualUser
 fi
-if ["$FOLDER" == '']; then
+if [ "$FOLDER" == '' ]; then
   echo 
   FOLDER=dummy
 fi

--- a/server/webapp/WEB-INF/rails.new/vendor/bundle/jruby/1.9/gems/nokogiri-1.6.6.2-java/test_all
+++ b/server/webapp/WEB-INF/rails.new/vendor/bundle/jruby/1.9/gems/nokogiri-1.6.6.2-java/test_all
@@ -45,18 +45,18 @@ function rvm_use {
 function generate_parser_and_tokenizer {
     old_ruby=$current_ruby
     rvm_use ruby-1.9.3
-    bundle exec rake generate 2>&1 > /dev/null
+    bundle exec rake generate > /dev/null 2>&1
     rvm_use $old_ruby
 }
 
 function clean {
-    bundle exec rake clean clobber 2>&1 > /dev/null
+    bundle exec rake clean clobber > /dev/null 2>&1
 }
 
 function compile {
     echo "** compiling ..."
     # generate_parser_and_tokenizer
-    bundle exec rake compile 2>&1 > /dev/null
+    bundle exec rake compile > /dev/null 2>&1
 }
 
 for ruby in $RUBIES ; do

--- a/tools/rails/bin/jruby
+++ b/tools/rails/bin/jruby
@@ -44,7 +44,7 @@ fi
 
 export JRUBY_OPTS="${JRUBY_OPTS} -J-XX:+TieredCompilation -J-XX:TieredStopAtLevel=1 -J-Djruby.compat.version=2.0 -J-Djruby.compile.invokedynamic=false -J-Djruby.compile.mode=OFF"
 
-jruby_cp=$(echo ${combined_classpath_items[@]} | awk ' !x[$0]++' | tr ' ' ':')
+jruby_cp=$(echo "${combined_classpath_items[@]}" | awk ' !x[$0]++' | tr ' ' ':')
 
 if [ -z "${jruby_cp}" ]; then
     ${JRUBY_BASE}/bin/jruby "${argv[@]}"


### PR DESCRIPTION
You need a space after the `[` and before the `]`.
The order of the `2>&1` and the redirect matters. The `2>&1` has to be last.
Double quote array expansions to avoid re-splitting elements.