### PR TITLE
GO_P4_CLIENT environment variable needs to be generated on the agent …

### DIFF
--- a/common/src/com/thoughtworks/go/remote/work/BuildWork.java
+++ b/common/src/com/thoughtworks/go/remote/work/BuildWork.java
@@ -190,6 +190,7 @@ public class BuildWork implements Work {
     private void setupEnvrionmentContext(EnvironmentVariableContext context) {
         context.setProperty("GO_SERVER_URL", new SystemEnvironment().getPropertyImpl("serviceUrl"), false);
         context.addAll(assignment.initialEnvironmentVariableContext());
+        materialRevisions.populateAgentSideEnvironmentVariables(context, workingDirectory);
     }
 
     private JobResult buildJob(EnvironmentVariableContext environmentVariableContext) {

--- a/common/test/unit/com/thoughtworks/go/remote/work/BuildWorkEnvironmentVariablesTest.java
+++ b/common/test/unit/com/thoughtworks/go/remote/work/BuildWorkEnvironmentVariablesTest.java
@@ -22,12 +22,16 @@ import com.thoughtworks.go.config.materials.MaterialConfigs;
 import com.thoughtworks.go.config.materials.Materials;
 import com.thoughtworks.go.config.materials.dependency.DependencyMaterial;
 import com.thoughtworks.go.config.materials.mercurial.HgMaterial;
+import com.thoughtworks.go.config.materials.perforce.P4Material;
 import com.thoughtworks.go.config.materials.svn.SvnMaterial;
 import com.thoughtworks.go.domain.*;
 import com.thoughtworks.go.domain.buildcause.BuildCause;
 import com.thoughtworks.go.domain.builder.Builder;
 import com.thoughtworks.go.domain.builder.CommandBuilder;
 import com.thoughtworks.go.domain.builder.NullBuilder;
+import com.thoughtworks.go.domain.materials.Modification;
+import com.thoughtworks.go.domain.materials.perforce.P4Client;
+import com.thoughtworks.go.domain.materials.perforce.P4Fixture;
 import com.thoughtworks.go.domain.materials.svn.SvnCommand;
 import com.thoughtworks.go.helper.*;
 import com.thoughtworks.go.plugin.access.packagematerial.PackageRepositoryExtension;
@@ -42,7 +46,9 @@ import com.thoughtworks.go.utils.SvnRepoFixture;
 import org.hamcrest.Matcher;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import org.mockito.Mock;
 
 import java.io.File;
@@ -79,11 +85,13 @@ public class BuildWorkEnvironmentVariablesTest {
     private SCMExtension scmExtension;
     @Mock
     private TaskExtension taskExtension;
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
 
     @Before
-    public void setUp() throws IOException {
+    public void setUp() throws Exception {
         initMocks(this);
-        dir = new File("someFolder");
+        dir = temporaryFolder.newFolder("someFolder");
         environmentVariableContext = new EnvironmentVariableContext();
         svnRepoFixture = new SvnRepoFixture("../common/test-resources/unit/data/svnrepo");
         svnRepoFixture.createRepository();
@@ -117,6 +125,47 @@ public class BuildWorkEnvironmentVariablesTest {
         assertThat(environmentVariableContext.getProperty("GO_STAGE_COUNTER"), is("1"));
         assertThat(environmentVariableContext.getProperty("GO_JOB_NAME"), is(JOB_NAME));
         assertThat(environmentVariableContext.getProperty("GO_TRIGGER_USER"), is(TRIGGERED_BY_USER));
+    }
+
+    @Test
+    public void shouldSetUpP4ClientEnvironmentVariableEnvironmentContextCorrectly() throws Exception {
+        new SystemEnvironment().setProperty("serviceUrl", "some_random_place");
+        P4Material p4Material = getP4Material();
+        BuildWork work = getBuildWorkWithP4MaterialRevision(p4Material);
+        EnvironmentVariableContext environmentVariableContext = new EnvironmentVariableContext();
+
+        AgentIdentifier agentIdentifier = new AgentIdentifier("somename", "127.0.0.1", AGENT_UUID);
+
+        work.doWork(agentIdentifier, new FakeBuildRepositoryRemote(),
+                new GoArtifactsManipulatorStub(),
+                environmentVariableContext, new AgentRuntimeInfo(agentIdentifier, AgentRuntimeStatus.Idle, currentWorkingDirectory(), "cookie", false), packageRepositoryExtension, scmExtension, taskExtension);
+
+
+        assertThat(environmentVariableContext.getProperty("GO_REVISION"), is("10"));
+        assertThat(environmentVariableContext.getProperty("GO_SERVER_URL"), is("some_random_place"));
+        assertThat(environmentVariableContext.getProperty("GO_TRIGGER_USER"), is(TRIGGERED_BY_USER));
+        assertThat(environmentVariableContext.getProperty("GO_P4_CLIENT"), is(p4Material.clientName(dir)));
+    }
+
+    private BuildWork getBuildWorkWithP4MaterialRevision(P4Material p4Material) {
+        pipelineConfig.setMaterialConfigs(new Materials(p4Material).convertToConfigs());
+        JobPlan plan = new DefaultJobPlan(new Resources(), new ArtifactPlans(), new ArtifactPropertiesGenerators(), -1, new JobIdentifier(PIPELINE_NAME, 1, "1", STAGE_NAME, "1", JOB_NAME, 123L), null, new EnvironmentVariablesConfig(), new EnvironmentVariablesConfig(), null);
+        MaterialRevisions materialRevisions = new MaterialRevisions(new MaterialRevision(p4Material, new Modification("user", "comment", "a@b.com", new Date(), "10")));
+        BuildCause buildCause = BuildCause.createWithModifications(materialRevisions, TRIGGERED_BY_USER);
+        List<Builder> builders = new ArrayList<>();
+        builders.add(new CommandBuilder("ant", "", dir, new RunIfConfigs(), new NullBuilder(), ""));
+        BuildAssignment assignment = BuildAssignment.create(plan, buildCause, builders, dir, environmentVariableContext);
+        return new BuildWork(assignment);
+    }
+
+    private P4Material getP4Material() throws Exception {
+        String view = "//depot/... //something/...";
+        P4Fixture p4Fixture = new P4Fixture();
+        P4TestRepo repo = P4TestRepo.createP4TestRepo();
+        repo.onSetup();
+        p4Fixture.setRepo(repo);
+        p4Fixture.createClient();
+        return p4Fixture.material(view);
     }
 
     @Test public void shouldMergeEnvironmentVariablesFromInitialContext() throws Exception {

--- a/common/test/unit/com/thoughtworks/go/remote/work/BuildWorkEnvironmentVariablesTest.java
+++ b/common/test/unit/com/thoughtworks/go/remote/work/BuildWorkEnvironmentVariablesTest.java
@@ -87,6 +87,9 @@ public class BuildWorkEnvironmentVariablesTest {
     private TaskExtension taskExtension;
     @Rule
     public TemporaryFolder temporaryFolder = new TemporaryFolder();
+    private P4Material p4Material;
+    private P4Fixture p4Fixture;
+    private P4Client p4Client;
 
     @Before
     public void setUp() throws Exception {
@@ -103,10 +106,13 @@ public class BuildWorkEnvironmentVariablesTest {
         dependencyMaterialWithName = new DependencyMaterial(new CaseInsensitiveString("upstream2"), new CaseInsensitiveString(STAGE_NAME));
         dependencyMaterialWithName.setName(new CaseInsensitiveString("dependency_material_name"));
         setupHgRepo();
+        p4Fixture = new P4Fixture();
+        p4Material = getP4Material();
     }
 
     @After
     public void teardown() throws Exception {
+        p4Fixture.stop(p4Client);
         TestRepo.internalTearDown();
         hgTestRepo.tearDown();
         FileUtil.deleteFolder(dir);
@@ -130,7 +136,6 @@ public class BuildWorkEnvironmentVariablesTest {
     @Test
     public void shouldSetUpP4ClientEnvironmentVariableEnvironmentContextCorrectly() throws Exception {
         new SystemEnvironment().setProperty("serviceUrl", "some_random_place");
-        P4Material p4Material = getP4Material();
         BuildWork work = getBuildWorkWithP4MaterialRevision(p4Material);
         EnvironmentVariableContext environmentVariableContext = new EnvironmentVariableContext();
 
@@ -160,11 +165,10 @@ public class BuildWorkEnvironmentVariablesTest {
 
     private P4Material getP4Material() throws Exception {
         String view = "//depot/... //something/...";
-        P4Fixture p4Fixture = new P4Fixture();
         P4TestRepo repo = P4TestRepo.createP4TestRepo();
         repo.onSetup();
         p4Fixture.setRepo(repo);
-        p4Fixture.createClient();
+        p4Client = p4Fixture.createClient();
         return p4Fixture.material(view);
     }
 

--- a/domain/src/com/thoughtworks/go/config/materials/AbstractMaterial.java
+++ b/domain/src/com/thoughtworks/go/config/materials/AbstractMaterial.java
@@ -23,7 +23,9 @@ import com.thoughtworks.go.domain.materials.MaterialConfig;
 import com.thoughtworks.go.util.CachedDigestUtils;
 import com.thoughtworks.go.util.ListUtil;
 import com.thoughtworks.go.util.StringUtil;
+import com.thoughtworks.go.util.command.EnvironmentVariableContext;
 
+import java.io.File;
 import java.util.*;
 
 /**
@@ -199,5 +201,8 @@ public abstract class AbstractMaterial extends PersistentObject implements Mater
             PasswordAwareMaterial passwordConfig = (PasswordAwareMaterial) materialConfig;
             ((PasswordAwareMaterial) this).setPassword(passwordConfig.getPassword());
         }
+    }
+
+    public void populateAgentSideEnvironmentContext(EnvironmentVariableContext context, File workingDir) {
     }
 }

--- a/domain/src/com/thoughtworks/go/config/materials/perforce/P4Material.java
+++ b/domain/src/com/thoughtworks/go/config/materials/perforce/P4Material.java
@@ -22,7 +22,6 @@ import com.thoughtworks.go.config.materials.ScmMaterial;
 import com.thoughtworks.go.config.materials.ScmMaterialConfig;
 import com.thoughtworks.go.config.materials.SubprocessExecutionContext;
 import com.thoughtworks.go.domain.MaterialInstance;
-import com.thoughtworks.go.domain.MaterialRevision;
 import com.thoughtworks.go.domain.materials.*;
 import com.thoughtworks.go.domain.materials.perforce.P4Client;
 import com.thoughtworks.go.domain.materials.perforce.P4MaterialInstance;
@@ -223,10 +222,9 @@ public class P4Material extends ScmMaterial implements PasswordEncrypter, Passwo
         return P4Client.fromServerAndPort(getFingerprint(), serverAndPort, userName, getPassword(), clientName,this.useTickets, workDir, p4view(clientName), consumer, failOnError);
     }
 
-    @Override
-    public void populateEnvironmentContext(EnvironmentVariableContext environmentVariableContext, MaterialRevision materialRevision, final File baseDir) {
-        super.populateEnvironmentContext(environmentVariableContext, materialRevision, baseDir);
-        setVariableWithName(environmentVariableContext, clientName(baseDir), "GO_P4_CLIENT");
+    public void populateAgentSideEnvironmentContext(EnvironmentVariableContext environmentVariableContext, File baseDir) {
+        super.populateAgentSideEnvironmentContext(environmentVariableContext, baseDir);
+        setVariableWithName(environmentVariableContext, clientName(workingdir(baseDir)), "GO_P4_CLIENT");
     }
 
     @Override
@@ -301,11 +299,10 @@ public class P4Material extends ScmMaterial implements PasswordEncrypter, Passwo
         return view.viewUsing(clientName);
     }
 
-    public String clientName(File baseDir) {
-        File workingdir = workingdir(baseDir);
-        String hash = FileUtil.filesystemSafeFileHash(workingdir);
+    public String clientName(File workingDir) {
+        String hash = FileUtil.filesystemSafeFileHash(workingDir);
         return "cruise-" + SystemUtil.getLocalhostName()
-                + "-" + workingdir.getName()
+                + "-" + workingDir.getName()
                 + "-" + hash;
     }
 

--- a/domain/src/com/thoughtworks/go/domain/MaterialRevision.java
+++ b/domain/src/com/thoughtworks/go/domain/MaterialRevision.java
@@ -243,6 +243,10 @@ public class MaterialRevision implements Serializable {
         material.populateEnvironmentContext(context, this, workingDir);
     }
 
+    public void populateAgentSideEnvironmentVariables(EnvironmentVariableContext context, File workingDir) {
+        material.populateAgentSideEnvironmentContext(context, workingDir);
+    }
+
     public String getMaterialName() {
         return material.getDisplayName();
     }

--- a/domain/src/com/thoughtworks/go/domain/MaterialRevisions.java
+++ b/domain/src/com/thoughtworks/go/domain/MaterialRevisions.java
@@ -323,6 +323,11 @@ public class MaterialRevisions implements Serializable, Iterable<MaterialRevisio
             revision.populateEnvironmentVariables(context, workingDir);
         }
     }
+    public void populateAgentSideEnvironmentVariables(EnvironmentVariableContext context, File workingDir) {
+        for (MaterialRevision revision : this) {
+            revision.populateAgentSideEnvironmentVariables(context, workingDir);
+        }
+    }
 
     public Modifications getModifications(Material material) {
         for (MaterialRevision revision : revisions) {

--- a/domain/src/com/thoughtworks/go/domain/materials/Material.java
+++ b/domain/src/com/thoughtworks/go/domain/materials/Material.java
@@ -67,6 +67,8 @@ public interface Material extends Serializable {
 
     void populateEnvironmentContext(EnvironmentVariableContext context, MaterialRevision materialRevision, File workingDir);
 
+    void populateAgentSideEnvironmentContext(EnvironmentVariableContext context, File workingDir);
+
     String getDisplayName();
 
     String getType();


### PR DESCRIPTION
…side as it contains the hostname of the agent which would be used to access the repo when the agent checks out the material. This got broken when we moved the setting of all Go generated environment variables over to the server side - #3926

* Also fixed a bug where the GO_P4_CLIENT environment variable would mismatch the actual client being used by the agent when a destination directory was specified for the p4 material