### PR TITLE
Allowing configuration of session cookie secure flag

### DIFF
--- a/app-server/src/com/thoughtworks/go/server/AppServer.java
+++ b/app-server/src/com/thoughtworks/go/server/AppServer.java
@@ -33,7 +33,7 @@ public abstract class AppServer {
 
     abstract void addExtraJarsToClasspath(String extraClasspath);
 
-    abstract void setSessionAndCookieExpiryTimeout(int sessionAndCookieExpiryTimeout);
+    abstract void setSessionCookieConfig();
 
     abstract void setInitParameter(String name, String value);
 

--- a/base/src/com/thoughtworks/go/util/SystemEnvironment.java
+++ b/base/src/com/thoughtworks/go/util/SystemEnvironment.java
@@ -139,6 +139,7 @@ public class SystemEnvironment implements Serializable, ConfigDirProvider {
     public static GoSystemProperty<Integer> RESPONSE_BUFFER_SIZE = new GoIntSystemProperty("response.buffer.size", 32768);
     public static final GoSystemProperty<Integer> API_REQUEST_IDLE_TIMEOUT_IN_SECONDS = new GoIntSystemProperty("api.request.idle.timeout.seconds", 300);
     public static final GoSystemProperty<Integer> GO_SERVER_SESSION_TIMEOUT_IN_SECONDS = new GoIntSystemProperty("go.server.session.timeout.seconds", 60 * 60 * 24 * 14);
+    public static final GoSystemProperty<Boolean> GO_SERVER_SESSION_COOKIE_SECURE = new GoBooleanSystemProperty("go.sessioncookie.secure", false);
 
     public static GoSystemProperty<Integer> PLUGIN_NOTIFICATION_LISTENER_COUNT = new CachedProperty<>(new GoIntSystemProperty("plugin.notification.listener.count", 1));
 
@@ -815,6 +816,9 @@ public class SystemEnvironment implements Serializable, ConfigDirProvider {
 
     public int sessionTimeoutInSeconds() {
         return GO_SERVER_SESSION_TIMEOUT_IN_SECONDS.getValue();
+    }
+    public boolean isSessionCookieSecure() {
+        return GO_SERVER_SESSION_COOKIE_SECURE.getValue();
     }
 
     public boolean isProductionMode() {

--- a/jetty9/src/com/thoughtworks/go/server/Jetty9Server.java
+++ b/jetty9/src/com/thoughtworks/go/server/Jetty9Server.java
@@ -109,11 +109,13 @@ public class Jetty9Server extends AppServer {
     }
 
     @Override
-    public void setSessionAndCookieExpiryTimeout(int sessionAndCookieExpiryTimeout) {
-        SessionCookieConfig cookieConfig = webAppContext.getSessionHandler().getSessionManager().getSessionCookieConfig();
-        cookieConfig.setHttpOnly(true);
-        cookieConfig.setMaxAge(sessionAndCookieExpiryTimeout);
+    public void setSessionCookieConfig() {
+        int sessionAndCookieExpiryTimeout = systemEnvironment.sessionTimeoutInSeconds();
         SessionManager sessionManager = webAppContext.getSessionHandler().getSessionManager();
+        SessionCookieConfig sessionCookieConfig = sessionManager.getSessionCookieConfig();
+        sessionCookieConfig.setHttpOnly(true);
+        sessionCookieConfig.setSecure(systemEnvironment.isSessionCookieSecure());
+        sessionCookieConfig.setMaxAge(sessionAndCookieExpiryTimeout);
         sessionManager.setMaxInactiveInterval(sessionAndCookieExpiryTimeout);
     }
 

--- a/server/src/com/thoughtworks/go/server/GoServer.java
+++ b/server/src/com/thoughtworks/go/server/GoServer.java
@@ -83,7 +83,7 @@ public class GoServer {
         AppServer server = ((AppServer) constructor.newInstance(systemEnvironment, password, sslSocketFactory));
         server.configure();
         server.addExtraJarsToClasspath(getExtraJarsToBeAddedToClasspath());
-        server.setSessionAndCookieExpiryTimeout(systemEnvironment.sessionTimeoutInSeconds());
+        server.setSessionCookieConfig();
         return server;
     }
 

--- a/server/test/unit/com/thoughtworks/go/server/AppServerStub.java
+++ b/server/test/unit/com/thoughtworks/go/server/AppServerStub.java
@@ -35,8 +35,8 @@ public class AppServerStub extends AppServer {
     }
 
     @Override
-    void setSessionAndCookieExpiryTimeout(int sessionAndCookieExpiryTimeout) {
-        calls.put("setSessionAndCookieExpiryTimeout", sessionAndCookieExpiryTimeout);
+    void setSessionCookieConfig() {
+        calls.put("setSessionAndCookieExpiryTimeout", 1234);
     }
 
     @Override


### PR DESCRIPTION
* Leaving the default as secure flag to not be set as it could break existing setups, but users should be able to set it using -Dgo.sessioncookie.secure=Y