### PR TITLE
Separating out JVM arg used for session cookie max-age from session max-inactive interval

### DIFF
--- a/app-server/src/com/thoughtworks/go/server/AppServer.java
+++ b/app-server/src/com/thoughtworks/go/server/AppServer.java
@@ -33,7 +33,7 @@ public abstract class AppServer {
 
     abstract void addExtraJarsToClasspath(String extraClasspath);
 
-    abstract void setSessionCookieConfig();
+    abstract void setSessionConfig();
 
     abstract void setInitParameter(String name, String value);
 

--- a/base/src/com/thoughtworks/go/util/SystemEnvironment.java
+++ b/base/src/com/thoughtworks/go/util/SystemEnvironment.java
@@ -139,6 +139,7 @@ public class SystemEnvironment implements Serializable, ConfigDirProvider {
     public static GoSystemProperty<Integer> RESPONSE_BUFFER_SIZE = new GoIntSystemProperty("response.buffer.size", 32768);
     public static final GoSystemProperty<Integer> API_REQUEST_IDLE_TIMEOUT_IN_SECONDS = new GoIntSystemProperty("api.request.idle.timeout.seconds", 300);
     public static final GoSystemProperty<Integer> GO_SERVER_SESSION_TIMEOUT_IN_SECONDS = new GoIntSystemProperty("go.server.session.timeout.seconds", 60 * 60 * 24 * 14);
+    public static final GoSystemProperty<Integer> GO_SERVER_SESSION_COOKIE_MAX_AGE_IN_SECONDS = new GoIntSystemProperty("go.sessioncookie.maxage.seconds", 60 * 60 * 24 * 14);
     public static final GoSystemProperty<Boolean> GO_SERVER_SESSION_COOKIE_SECURE = new GoBooleanSystemProperty("go.sessioncookie.secure", false);
 
     public static GoSystemProperty<Integer> PLUGIN_NOTIFICATION_LISTENER_COUNT = new CachedProperty<>(new GoIntSystemProperty("plugin.notification.listener.count", 1));
@@ -816,6 +817,9 @@ public class SystemEnvironment implements Serializable, ConfigDirProvider {
 
     public int sessionTimeoutInSeconds() {
         return GO_SERVER_SESSION_TIMEOUT_IN_SECONDS.getValue();
+    }
+    public int sessionCookieMaxAgeInSeconds() {
+        return GO_SERVER_SESSION_COOKIE_MAX_AGE_IN_SECONDS.getValue();
     }
     public boolean isSessionCookieSecure() {
         return GO_SERVER_SESSION_COOKIE_SECURE.getValue();

--- a/jetty9/src/com/thoughtworks/go/server/Jetty9Server.java
+++ b/jetty9/src/com/thoughtworks/go/server/Jetty9Server.java
@@ -109,14 +109,13 @@ public class Jetty9Server extends AppServer {
     }
 
     @Override
-    public void setSessionCookieConfig() {
-        int sessionAndCookieExpiryTimeout = systemEnvironment.sessionTimeoutInSeconds();
+    public void setSessionConfig() {
         SessionManager sessionManager = webAppContext.getSessionHandler().getSessionManager();
         SessionCookieConfig sessionCookieConfig = sessionManager.getSessionCookieConfig();
         sessionCookieConfig.setHttpOnly(true);
         sessionCookieConfig.setSecure(systemEnvironment.isSessionCookieSecure());
-        sessionCookieConfig.setMaxAge(sessionAndCookieExpiryTimeout);
-        sessionManager.setMaxInactiveInterval(sessionAndCookieExpiryTimeout);
+        sessionCookieConfig.setMaxAge(systemEnvironment.sessionCookieMaxAgeInSeconds());
+        sessionManager.setMaxInactiveInterval(systemEnvironment.sessionTimeoutInSeconds());
     }
 
     @Override

--- a/jetty9/test/com/thoughtworks/go/server/Jetty9ServerTest.java
+++ b/jetty9/test/com/thoughtworks/go/server/Jetty9ServerTest.java
@@ -93,6 +93,7 @@ public class Jetty9ServerTest {
         when(systemEnvironment.getJettyConfigFile()).thenReturn(new File("foo"));
         when(systemEnvironment.isSessionCookieSecure()).thenReturn(false);
         when(systemEnvironment.sessionTimeoutInSeconds()).thenReturn(1234);
+        when(systemEnvironment.sessionCookieMaxAgeInSeconds()).thenReturn(5678);
 
 
         SSLSocketFactory sslSocketFactory = mock(SSLSocketFactory.class);
@@ -284,7 +285,7 @@ public class Jetty9ServerTest {
     @Test
     public void shouldSetSessionMaxInactiveInterval() throws Exception {
         jetty9Server.configure();
-        jetty9Server.setSessionCookieConfig();
+        jetty9Server.setSessionConfig();
 
         WebAppContext webAppContext = getWebAppContext(jetty9Server);
         assertThat(webAppContext.getSessionHandler().getSessionManager().getMaxInactiveInterval(), is(1234));
@@ -294,16 +295,16 @@ public class Jetty9ServerTest {
     public void shouldSetSessionCookieConfig() throws Exception {
         when(systemEnvironment.isSessionCookieSecure()).thenReturn(true);
         jetty9Server.configure();
-        jetty9Server.setSessionCookieConfig();
+        jetty9Server.setSessionConfig();
 
         WebAppContext webAppContext = getWebAppContext(jetty9Server);
         SessionCookieConfig sessionCookieConfig = webAppContext.getSessionHandler().getSessionManager().getSessionCookieConfig();
         assertThat(sessionCookieConfig.isHttpOnly(), is(true));
         assertThat(sessionCookieConfig.isSecure(), is(true));
-        assertThat(sessionCookieConfig.getMaxAge(), is(1234));
+        assertThat(sessionCookieConfig.getMaxAge(), is(5678));
 
         when(systemEnvironment.isSessionCookieSecure()).thenReturn(false);
-        jetty9Server.setSessionCookieConfig();
+        jetty9Server.setSessionConfig();
         assertThat(sessionCookieConfig.isSecure(), is(false));
     }
 

--- a/server/src/com/thoughtworks/go/server/GoServer.java
+++ b/server/src/com/thoughtworks/go/server/GoServer.java
@@ -83,7 +83,7 @@ public class GoServer {
         AppServer server = ((AppServer) constructor.newInstance(systemEnvironment, password, sslSocketFactory));
         server.configure();
         server.addExtraJarsToClasspath(getExtraJarsToBeAddedToClasspath());
-        server.setSessionCookieConfig();
+        server.setSessionConfig();
         return server;
     }
 

--- a/server/test/unit/com/thoughtworks/go/server/AppServerStub.java
+++ b/server/test/unit/com/thoughtworks/go/server/AppServerStub.java
@@ -35,7 +35,7 @@ public class AppServerStub extends AppServer {
     }
 
     @Override
-    void setSessionCookieConfig() {
+    void setSessionConfig() {
         calls.put("setSessionCookieConfig", "something");
     }
 


### PR DESCRIPTION
Now that both of these are configurable via the same jvm arg (ie. go.server.session.timeout.seconds), an enduser could potentially set cookie's max-age to `-1` to make the cookie expire as soon as the browser was closed - which is good. But this leads to (mostly unintentionally) setting the session's max inactive interval to `-1` which causes a session to never expire. So, even if upon a cookie expiry a new session gets created for the user, the old session remains on the server adding a memory overhead.

Added a separate JVM arg to configure session cookie's  max age using `go.sessioncookie.maxage.seconds`.  This defaults to `2 weeks`, could be set to `-1` to expire the cookie on browser close. Should not be set to `0` else the cookie will expire immediately - ie. users would be unable to login.

No changes done to `go.server.session.timeout.seconds`. Users must never set this to `-1`, unless ofcourse they know the repercussions.

Submitted a PR for docs too -> https://github.com/gocd/docs.go.cd/pull/133