### PR TITLE
Fix test failures caused due to #4094

### DIFF
--- a/server/test/unit/com/thoughtworks/go/server/service/ElasticAgentPluginServiceTest.java
+++ b/server/test/unit/com/thoughtworks/go/server/service/ElasticAgentPluginServiceTest.java
@@ -217,7 +217,7 @@ public class ElasticAgentPluginServiceTest {
         ElasticAgentMetadata agentMetadata = new ElasticAgentMetadata(uuid, uuid, elasticPluginId, AgentRuntimeStatus.Idle, AgentConfigStatus.Enabled);
         ElasticProfile elasticProfile = new ElasticProfile("1", elasticPluginId);
 
-        when(registry.shouldAssignWork(any(), any(), any(), any(), null)).thenReturn(true);
+        when(registry.shouldAssignWork(any(), any(), any(), any(), any())).thenReturn(true);
         assertThat(service.shouldAssignWork(agentMetadata, null, elasticProfile, null), is(true));
     }
 
@@ -227,7 +227,7 @@ public class ElasticAgentPluginServiceTest {
         String elasticPluginId = "plugin-1";
         ElasticAgentMetadata agentMetadata = new ElasticAgentMetadata(uuid, uuid, elasticPluginId, AgentRuntimeStatus.Idle, AgentConfigStatus.Enabled);
         ElasticProfile elasticProfile = new ElasticProfile("1", elasticPluginId);
-        when(registry.shouldAssignWork(any(), any(), any(), any(), null)).thenReturn(false);
+        when(registry.shouldAssignWork(any(), any(), any(), any(), any())).thenReturn(false);
 
         assertThat(service.shouldAssignWork(agentMetadata, null, elasticProfile, null), is(false));
     }
@@ -237,7 +237,7 @@ public class ElasticAgentPluginServiceTest {
         String uuid = UUID.randomUUID().toString();
         ElasticAgentMetadata agentMetadata = new ElasticAgentMetadata(uuid, uuid, "plugin-1", AgentRuntimeStatus.Idle, AgentConfigStatus.Enabled);
         ElasticProfile elasticProfile = new ElasticProfile("1", "plugin-2");
-        when(registry.shouldAssignWork(any(), any(), any(), any(), null)).thenReturn(true);
+        when(registry.shouldAssignWork(any(), any(), any(), any(), any())).thenReturn(true);
 
         assertThat(service.shouldAssignWork(agentMetadata, null, elasticProfile, null), is(false));
     }


### PR DESCRIPTION
* Pass Matchers.any() matcher instead of null for a stub method in tests