### PR TITLE
Update windows jre download source URLs

### DIFF
--- a/buildSrc/src/main/groovy/com/thoughtworks/go/build/WindowsPackagingTask.groovy
+++ b/buildSrc/src/main/groovy/com/thoughtworks/go/build/WindowsPackagingTask.groovy
@@ -105,7 +105,7 @@ class WindowsPackagingTask extends DefaultTask {
   }
 
   def defaultJreLocation() {
-    is32Bit ? "http://download.oracle.com/otn-pub/java/jdk/8u102-b14/jre-8u102-windows-i586.tar.gz" : "http://download.oracle.com/otn-pub/java/jdk/8u102-b14/jre-8u102-windows-x64.tar.gz"
+    is32Bit ? "http://download.oracle.com/otn-pub/java/jdk/8u152-b16/aa0333dd3019491ca4f6ddbe78cdb6d0/jre-8u152-windows-i586.tar.gz" : "http://download.oracle.com/otn-pub/java/jdk/8u152-b16/aa0333dd3019491ca4f6ddbe78cdb6d0/jre-8u152-windows-x64.tar.gz"
   }
 
   def specifiedJreLocation() {


### PR DESCRIPTION
These URLs are just a fallback in case when `WINDOWS_*_JRE_URL` is not set. Currently build will fail when running `DISABLE_WIN_INSTALLER_LOGGING=true ORACLE_JRE_LICENSE_AGREE=Y ./gradlew installers:agentWindows64bitExe`.

Cause: The previous links do not work and return 404.

Fix: These are newer download links from http://www.oracle.com/technetwork/java/javase/downloads/jre8-downloads-2133155.html

