### PR TITLE
PluginSettingsRequestProcessor delegates response building to extensions

### DIFF
--- a/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/authentication/AuthenticationExtension.java
+++ b/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/authentication/AuthenticationExtension.java
@@ -46,14 +46,13 @@ public class AuthenticationExtension extends AbstractExtension {
     public static final String REQUEST_SEARCH_USER = "go.authentication.search-user";
 
     private Map<String, JsonMessageHandler> messageHandlerMap = new HashMap<>();
-    private Map<String, JsonMessageHandlerForRequestProcessor> jsonMessageHandlersForRequestProcessor = new HashMap<>();
 
     @Autowired
     public AuthenticationExtension(PluginManager defaultPluginManager) {
         super(defaultPluginManager, new PluginRequestHelper(defaultPluginManager, goSupportedVersions, EXTENSION_NAME), EXTENSION_NAME);
         this.registerHandler("1.0", new PluginSettingsJsonMessageHandler1_0());
         this.messageHandlerMap.put("1.0", new JsonMessageHandler1_0());
-        jsonMessageHandlersForRequestProcessor.put("1.0", new JsonMessageHandlerForRequestProcessor1_0());
+        registerJsonMessageHandlerForRequestProcessor("1.0", new JsonMessageHandlerForRequestProcessor1_0());
     }
 
     public AuthenticationPluginConfiguration getPluginConfiguration(String pluginId) {
@@ -99,11 +98,6 @@ public class AuthenticationExtension extends AbstractExtension {
 
     Map<String, JsonMessageHandler> getMessageHandlerMap() {
         return messageHandlerMap;
-    }
-
-    @Override
-    protected JsonMessageHandlerForRequestProcessor jsonMessageHandlerForRequestProcessor(String pluginVersion) {
-        return jsonMessageHandlersForRequestProcessor.get(pluginVersion);
     }
 
     @Override

--- a/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/authentication/AuthenticationExtension.java
+++ b/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/authentication/AuthenticationExtension.java
@@ -23,6 +23,8 @@ import com.thoughtworks.go.plugin.access.authentication.models.User;
 import com.thoughtworks.go.plugin.access.common.AbstractExtension;
 import com.thoughtworks.go.plugin.access.common.settings.PluginSettingsJsonMessageHandler;
 import com.thoughtworks.go.plugin.access.common.settings.PluginSettingsJsonMessageHandler1_0;
+import com.thoughtworks.go.plugin.access.common.settings.JsonMessageHandlerForRequestProcessor;
+import com.thoughtworks.go.plugin.access.common.settings.JsonMessageHandlerForRequestProcessor1_0;
 import com.thoughtworks.go.plugin.infra.PluginManager;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -44,12 +46,14 @@ public class AuthenticationExtension extends AbstractExtension {
     public static final String REQUEST_SEARCH_USER = "go.authentication.search-user";
 
     private Map<String, JsonMessageHandler> messageHandlerMap = new HashMap<>();
+    private Map<String, JsonMessageHandlerForRequestProcessor> jsonMessageHandlersForRequestProcessor = new HashMap<>();
 
     @Autowired
     public AuthenticationExtension(PluginManager defaultPluginManager) {
         super(defaultPluginManager, new PluginRequestHelper(defaultPluginManager, goSupportedVersions, EXTENSION_NAME), EXTENSION_NAME);
         this.registerHandler("1.0", new PluginSettingsJsonMessageHandler1_0());
         this.messageHandlerMap.put("1.0", new JsonMessageHandler1_0());
+        jsonMessageHandlersForRequestProcessor.put("1.0", new JsonMessageHandlerForRequestProcessor1_0());
     }
 
     public AuthenticationPluginConfiguration getPluginConfiguration(String pluginId) {
@@ -95,6 +99,11 @@ public class AuthenticationExtension extends AbstractExtension {
 
     Map<String, JsonMessageHandler> getMessageHandlerMap() {
         return messageHandlerMap;
+    }
+
+    @Override
+    protected JsonMessageHandlerForRequestProcessor jsonMessageHandlerForRequestProcessor(String pluginVersion) {
+        return jsonMessageHandlersForRequestProcessor.get(pluginVersion);
     }
 
     @Override

--- a/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/authorization/AuthorizationExtension.java
+++ b/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/authorization/AuthorizationExtension.java
@@ -25,6 +25,7 @@ import com.thoughtworks.go.plugin.access.authorization.models.AuthenticationResp
 import com.thoughtworks.go.plugin.access.common.AbstractExtension;
 import com.thoughtworks.go.plugin.access.common.settings.PluginSettingsJsonMessageHandler;
 import com.thoughtworks.go.plugin.access.common.settings.PluginSettingsJsonMessageHandler1_0;
+import com.thoughtworks.go.plugin.access.common.settings.JsonMessageHandlerForRequestProcessor;
 import com.thoughtworks.go.plugin.api.response.validation.ValidationResult;
 import com.thoughtworks.go.plugin.domain.common.PluginConfiguration;
 import com.thoughtworks.go.plugin.domain.common.VerifyConnectionResponse;
@@ -239,6 +240,11 @@ public class AuthorizationExtension extends AbstractExtension {
                 return getMessageConverter(resolvedExtensionVersion).getAuthorizationServerUrl(responseBody);
             }
         });
+    }
+
+    @Override
+    protected JsonMessageHandlerForRequestProcessor jsonMessageHandlerForRequestProcessor(String pluginVersion) {
+        throw new UnsupportedOperationException("Fetch PluginSettings is not supported by Authorization Endpoint.");
     }
 
     @Override

--- a/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/common/AbstractExtension.java
+++ b/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/common/AbstractExtension.java
@@ -31,6 +31,7 @@ public abstract class AbstractExtension implements GoPluginExtension {
     protected final PluginRequestHelper pluginRequestHelper;
     private final String extensionName;
     protected Map<String, PluginSettingsJsonMessageHandler> pluginSettingsMessageHandlerMap = new HashMap<>();
+    private Map<String, JsonMessageHandlerForRequestProcessor> jsonMessageHandlersForRequestProcessor = new HashMap<>();
 
     protected AbstractExtension(PluginManager pluginManager, PluginRequestHelper pluginRequestHelper, String extensionName) {
         this.pluginManager = pluginManager;
@@ -87,7 +88,13 @@ public abstract class AbstractExtension implements GoPluginExtension {
         return jsonMessageHandlerForRequestProcessor(resolvedExtensionVersion).pluginSettingsToJSON(pluginSettings);
     }
 
-    protected abstract JsonMessageHandlerForRequestProcessor jsonMessageHandlerForRequestProcessor(String pluginVersion);
+    protected void registerJsonMessageHandlerForRequestProcessor(String apiVersion, JsonMessageHandlerForRequestProcessor handler) {
+        jsonMessageHandlersForRequestProcessor.put(apiVersion, handler);
+    }
+
+    protected JsonMessageHandlerForRequestProcessor jsonMessageHandlerForRequestProcessor(String pluginVersion) {
+        return jsonMessageHandlersForRequestProcessor.get(pluginVersion);
+    }
 
     protected abstract List<String> goSupportedVersions();
 

--- a/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/common/AbstractExtension.java
+++ b/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/common/AbstractExtension.java
@@ -81,6 +81,14 @@ public abstract class AbstractExtension implements GoPluginExtension {
         });
     }
 
+    @Override
+    public String pluginSettingsJSON(String pluginId, Map<String, String> pluginSettings) {
+        String resolvedExtensionVersion = pluginManager.resolveExtensionVersion(pluginId, goSupportedVersions());
+        return jsonMessageHandlerForRequestProcessor(resolvedExtensionVersion).pluginSettingsToJSON(pluginSettings);
+    }
+
+    protected abstract JsonMessageHandlerForRequestProcessor jsonMessageHandlerForRequestProcessor(String pluginVersion);
+
     protected abstract List<String> goSupportedVersions();
 
     public ValidationResult validatePluginSettings(String pluginId, final PluginSettingsConfiguration configuration) {

--- a/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/common/settings/JsonMessageHandlerForRequestProcessor.java
+++ b/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/common/settings/JsonMessageHandlerForRequestProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 ThoughtWorks, Inc.
+ * Copyright 2017 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,23 +16,9 @@
 
 package com.thoughtworks.go.plugin.access.common.settings;
 
-import com.thoughtworks.go.plugin.api.response.validation.ValidationResult;
-
 import java.util.Map;
 
-public interface GoPluginExtension {
+public interface JsonMessageHandlerForRequestProcessor {
 
-    boolean canHandlePlugin(String pluginId);
-
-    String extensionName();
-
-    PluginSettingsConfiguration getPluginSettingsConfiguration(String pluginId);
-
-    String getPluginSettingsView(String pluginId);
-
-    ValidationResult validatePluginSettings(String pluginId, PluginSettingsConfiguration configuration);
-
-    void notifyPluginSettingsChange(String pluginId, Map<String, String> pluginSettings);
-
-    String pluginSettingsJSON(String pluginId, Map<String, String> pluginSettings);
+    String pluginSettingsToJSON(Map<String, String> pluginSettings);
 }

--- a/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/common/settings/JsonMessageHandlerForRequestProcessor1_0.java
+++ b/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/common/settings/JsonMessageHandlerForRequestProcessor1_0.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 ThoughtWorks, Inc.
+ * Copyright 2017 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,23 +16,14 @@
 
 package com.thoughtworks.go.plugin.access.common.settings;
 
-import com.thoughtworks.go.plugin.api.response.validation.ValidationResult;
+import com.thoughtworks.go.util.json.JsonHelper;
 
 import java.util.Map;
 
-public interface GoPluginExtension {
+public class JsonMessageHandlerForRequestProcessor1_0 implements JsonMessageHandlerForRequestProcessor {
 
-    boolean canHandlePlugin(String pluginId);
-
-    String extensionName();
-
-    PluginSettingsConfiguration getPluginSettingsConfiguration(String pluginId);
-
-    String getPluginSettingsView(String pluginId);
-
-    ValidationResult validatePluginSettings(String pluginId, PluginSettingsConfiguration configuration);
-
-    void notifyPluginSettingsChange(String pluginId, Map<String, String> pluginSettings);
-
-    String pluginSettingsJSON(String pluginId, Map<String, String> pluginSettings);
+    @Override
+    public String pluginSettingsToJSON(Map<String, String> pluginSettings) {
+        return pluginSettings.isEmpty() ? null : JsonHelper.toJsonString(pluginSettings);
+    }
 }

--- a/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/configrepo/ConfigRepoExtension.java
+++ b/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/configrepo/ConfigRepoExtension.java
@@ -44,14 +44,13 @@ public class ConfigRepoExtension extends AbstractExtension implements ConfigRepo
     private static final List<String> goSupportedVersions = asList("1.0");
 
     private Map<String, JsonMessageHandler> messageHandlerMap = new HashMap<>();
-    private Map<String, JsonMessageHandlerForRequestProcessor> jsonMessageHandlersForRequestProcessor = new HashMap<>();
 
     @Autowired
     public ConfigRepoExtension(PluginManager pluginManager) {
         super(pluginManager, new PluginRequestHelper(pluginManager, goSupportedVersions, EXTENSION_NAME),EXTENSION_NAME);
         registerHandler("1.0", new PluginSettingsJsonMessageHandler1_0());
         messageHandlerMap.put("1.0", new JsonMessageHandler1_0(new GsonCodec(), new ConfigRepoMigrator()));
-        jsonMessageHandlersForRequestProcessor.put("1.0", new JsonMessageHandlerForRequestProcessor1_0());
+        registerJsonMessageHandlerForRequestProcessor("1.0", new JsonMessageHandlerForRequestProcessor1_0());
     }
 
     @Override
@@ -80,11 +79,6 @@ public class ConfigRepoExtension extends AbstractExtension implements ConfigRepo
 
     public boolean isConfigRepoPlugin(String pluginId) {
         return pluginManager.isPluginOfType(ConfigRepoExtension.EXTENSION_NAME, pluginId);
-    }
-
-    @Override
-    protected JsonMessageHandlerForRequestProcessor jsonMessageHandlerForRequestProcessor(String pluginVersion) {
-        return jsonMessageHandlersForRequestProcessor.get(pluginVersion);
     }
 
     @Override

--- a/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/configrepo/ConfigRepoExtension.java
+++ b/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/configrepo/ConfigRepoExtension.java
@@ -20,6 +20,8 @@ import com.thoughtworks.go.plugin.access.DefaultPluginInteractionCallback;
 import com.thoughtworks.go.plugin.access.PluginRequestHelper;
 import com.thoughtworks.go.plugin.access.common.AbstractExtension;
 import com.thoughtworks.go.plugin.access.common.settings.PluginSettingsJsonMessageHandler1_0;
+import com.thoughtworks.go.plugin.access.common.settings.JsonMessageHandlerForRequestProcessor;
+import com.thoughtworks.go.plugin.access.common.settings.JsonMessageHandlerForRequestProcessor1_0;
 import com.thoughtworks.go.plugin.access.configrepo.codec.GsonCodec;
 import com.thoughtworks.go.plugin.access.configrepo.contract.CRConfigurationProperty;
 import com.thoughtworks.go.plugin.access.configrepo.contract.CRParseResult;
@@ -42,12 +44,14 @@ public class ConfigRepoExtension extends AbstractExtension implements ConfigRepo
     private static final List<String> goSupportedVersions = asList("1.0");
 
     private Map<String, JsonMessageHandler> messageHandlerMap = new HashMap<>();
+    private Map<String, JsonMessageHandlerForRequestProcessor> jsonMessageHandlersForRequestProcessor = new HashMap<>();
 
     @Autowired
     public ConfigRepoExtension(PluginManager pluginManager) {
         super(pluginManager, new PluginRequestHelper(pluginManager, goSupportedVersions, EXTENSION_NAME),EXTENSION_NAME);
         registerHandler("1.0", new PluginSettingsJsonMessageHandler1_0());
         messageHandlerMap.put("1.0", new JsonMessageHandler1_0(new GsonCodec(), new ConfigRepoMigrator()));
+        jsonMessageHandlersForRequestProcessor.put("1.0", new JsonMessageHandlerForRequestProcessor1_0());
     }
 
     @Override
@@ -76,6 +80,11 @@ public class ConfigRepoExtension extends AbstractExtension implements ConfigRepo
 
     public boolean isConfigRepoPlugin(String pluginId) {
         return pluginManager.isPluginOfType(ConfigRepoExtension.EXTENSION_NAME, pluginId);
+    }
+
+    @Override
+    protected JsonMessageHandlerForRequestProcessor jsonMessageHandlerForRequestProcessor(String pluginVersion) {
+        return jsonMessageHandlersForRequestProcessor.get(pluginVersion);
     }
 
     @Override

--- a/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/elastic/ElasticAgentExtension.java
+++ b/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/elastic/ElasticAgentExtension.java
@@ -22,6 +22,8 @@ import com.thoughtworks.go.plugin.access.PluginRequestHelper;
 import com.thoughtworks.go.plugin.access.common.AbstractExtension;
 import com.thoughtworks.go.plugin.access.common.settings.PluginSettingsJsonMessageHandler;
 import com.thoughtworks.go.plugin.access.common.settings.PluginSettingsJsonMessageHandler1_0;
+import com.thoughtworks.go.plugin.access.common.settings.JsonMessageHandlerForRequestProcessor;
+import com.thoughtworks.go.plugin.access.common.settings.JsonMessageHandlerForRequestProcessor1_0;
 import com.thoughtworks.go.plugin.access.elastic.models.AgentMetadata;
 import com.thoughtworks.go.plugin.access.elastic.v1.ElasticAgentExtensionConverterV1;
 import com.thoughtworks.go.plugin.access.elastic.v2.ElasticAgentExtensionConverterV2;
@@ -43,12 +45,16 @@ import static java.lang.String.format;
 public class ElasticAgentExtension extends AbstractExtension {
 
     private final HashMap<String, ElasticAgentMessageConverter> messageHandlerMap = new HashMap<>();
+    private Map<String, JsonMessageHandlerForRequestProcessor> jsonMessageHandlersForRequestProcessor = new HashMap<>();
 
     @Autowired
     public ElasticAgentExtension(PluginManager pluginManager) {
         super(pluginManager, new PluginRequestHelper(pluginManager, SUPPORTED_VERSIONS, ElasticAgentPluginConstants.EXTENSION_NAME), ElasticAgentPluginConstants.EXTENSION_NAME);
         addHandler(ElasticAgentExtensionConverterV1.VERSION, new PluginSettingsJsonMessageHandler1_0(), new ElasticAgentExtensionConverterV1());
         addHandler(ElasticAgentExtensionConverterV2.VERSION, new PluginSettingsJsonMessageHandler1_0(), new ElasticAgentExtensionConverterV2());
+
+        jsonMessageHandlersForRequestProcessor.put(ElasticAgentExtensionConverterV1.VERSION, new JsonMessageHandlerForRequestProcessor1_0());
+        jsonMessageHandlersForRequestProcessor.put(ElasticAgentExtensionConverterV2.VERSION, new JsonMessageHandlerForRequestProcessor1_0());
     }
 
     private void addHandler(String version, PluginSettingsJsonMessageHandler messageHandler, ElasticAgentMessageConverter extensionHandler) {
@@ -151,6 +157,11 @@ public class ElasticAgentExtension extends AbstractExtension {
                 return converter.getCapabilitiesFromResponseBody(responseBody);
             }
         });
+    }
+
+    @Override
+    protected JsonMessageHandlerForRequestProcessor jsonMessageHandlerForRequestProcessor(String pluginVersion) {
+        return jsonMessageHandlersForRequestProcessor.get(pluginVersion);
     }
 
     @Override

--- a/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/elastic/ElasticAgentExtension.java
+++ b/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/elastic/ElasticAgentExtension.java
@@ -45,21 +45,19 @@ import static java.lang.String.format;
 public class ElasticAgentExtension extends AbstractExtension {
 
     private final HashMap<String, ElasticAgentMessageConverter> messageHandlerMap = new HashMap<>();
-    private Map<String, JsonMessageHandlerForRequestProcessor> jsonMessageHandlersForRequestProcessor = new HashMap<>();
 
     @Autowired
     public ElasticAgentExtension(PluginManager pluginManager) {
         super(pluginManager, new PluginRequestHelper(pluginManager, SUPPORTED_VERSIONS, ElasticAgentPluginConstants.EXTENSION_NAME), ElasticAgentPluginConstants.EXTENSION_NAME);
-        addHandler(ElasticAgentExtensionConverterV1.VERSION, new PluginSettingsJsonMessageHandler1_0(), new ElasticAgentExtensionConverterV1());
-        addHandler(ElasticAgentExtensionConverterV2.VERSION, new PluginSettingsJsonMessageHandler1_0(), new ElasticAgentExtensionConverterV2());
-
-        jsonMessageHandlersForRequestProcessor.put(ElasticAgentExtensionConverterV1.VERSION, new JsonMessageHandlerForRequestProcessor1_0());
-        jsonMessageHandlersForRequestProcessor.put(ElasticAgentExtensionConverterV2.VERSION, new JsonMessageHandlerForRequestProcessor1_0());
+        addHandler(ElasticAgentExtensionConverterV1.VERSION, new PluginSettingsJsonMessageHandler1_0(), new ElasticAgentExtensionConverterV1(), new JsonMessageHandlerForRequestProcessor1_0());
+        addHandler(ElasticAgentExtensionConverterV2.VERSION, new PluginSettingsJsonMessageHandler1_0(), new ElasticAgentExtensionConverterV2(), new JsonMessageHandlerForRequestProcessor1_0());
     }
 
-    private void addHandler(String version, PluginSettingsJsonMessageHandler messageHandler, ElasticAgentMessageConverter extensionHandler) {
+    private void addHandler(String version, PluginSettingsJsonMessageHandler messageHandler, ElasticAgentMessageConverter extensionHandler,
+                            JsonMessageHandlerForRequestProcessor  jsonMessageHandlerForRequestProcessor) {
         pluginSettingsMessageHandlerMap.put(version, messageHandler);
         messageHandlerMap.put(version, extensionHandler);
+        registerJsonMessageHandlerForRequestProcessor(version, jsonMessageHandlerForRequestProcessor);
     }
 
     public void createAgent(String pluginId, final String autoRegisterKey, final String environment, final Map<String, String> configuration, JobIdentifier jobIdentifier) {
@@ -157,11 +155,6 @@ public class ElasticAgentExtension extends AbstractExtension {
                 return converter.getCapabilitiesFromResponseBody(responseBody);
             }
         });
-    }
-
-    @Override
-    protected JsonMessageHandlerForRequestProcessor jsonMessageHandlerForRequestProcessor(String pluginVersion) {
-        return jsonMessageHandlersForRequestProcessor.get(pluginVersion);
     }
 
     @Override

--- a/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/notification/NotificationExtension.java
+++ b/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/notification/NotificationExtension.java
@@ -19,9 +19,7 @@ package com.thoughtworks.go.plugin.access.notification;
 import com.thoughtworks.go.plugin.access.DefaultPluginInteractionCallback;
 import com.thoughtworks.go.plugin.access.PluginRequestHelper;
 import com.thoughtworks.go.plugin.access.common.AbstractExtension;
-import com.thoughtworks.go.plugin.access.common.settings.PluginSettingsJsonMessageHandler;
-import com.thoughtworks.go.plugin.access.common.settings.PluginSettingsJsonMessageHandler1_0;
-import com.thoughtworks.go.plugin.access.common.settings.PluginSettingsJsonMessageHandler2_0;
+import com.thoughtworks.go.plugin.access.common.settings.*;
 import com.thoughtworks.go.plugin.access.notification.v1.JsonMessageHandler1_0;
 import com.thoughtworks.go.plugin.access.notification.v2.JsonMessageHandler2_0;
 import com.thoughtworks.go.plugin.access.notification.v3.JsonMessageHandler3_0;
@@ -47,6 +45,7 @@ public class NotificationExtension extends AbstractExtension {
     static final List<String> VALID_NOTIFICATION_TYPES = asList(STAGE_STATUS_CHANGE_NOTIFICATION);
 
     private Map<String, JsonMessageHandler> messageHandlerMap = new HashMap<>();
+    private Map<String, JsonMessageHandlerForRequestProcessor> jsonMessageHandlersForRequestProcessor = new HashMap<>();
 
     @Autowired
     public NotificationExtension(PluginManager pluginManager) {
@@ -60,6 +59,10 @@ public class NotificationExtension extends AbstractExtension {
 
         registerHandler("3.0", new PluginSettingsJsonMessageHandler2_0());
         messageHandlerMap.put("3.0", new JsonMessageHandler3_0());
+
+        jsonMessageHandlersForRequestProcessor.put("1.0", new JsonMessageHandlerForRequestProcessor1_0());
+        jsonMessageHandlersForRequestProcessor.put("2.0", new JsonMessageHandlerForRequestProcessor1_0());
+        jsonMessageHandlersForRequestProcessor.put("3.0", new JsonMessageHandlerForRequestProcessor1_0());
     }
 
     public List<String> getNotificationsOfInterestFor(String pluginId) {
@@ -99,5 +102,10 @@ public class NotificationExtension extends AbstractExtension {
     @Override
     protected List<String> goSupportedVersions() {
         return goSupportedVersions;
+    }
+
+    @Override
+    public JsonMessageHandlerForRequestProcessor jsonMessageHandlerForRequestProcessor(String pluginVersion) {
+        return jsonMessageHandlersForRequestProcessor.get(pluginVersion);
     }
 }

--- a/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/notification/NotificationExtension.java
+++ b/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/notification/NotificationExtension.java
@@ -45,7 +45,6 @@ public class NotificationExtension extends AbstractExtension {
     static final List<String> VALID_NOTIFICATION_TYPES = asList(STAGE_STATUS_CHANGE_NOTIFICATION);
 
     private Map<String, JsonMessageHandler> messageHandlerMap = new HashMap<>();
-    private Map<String, JsonMessageHandlerForRequestProcessor> jsonMessageHandlersForRequestProcessor = new HashMap<>();
 
     @Autowired
     public NotificationExtension(PluginManager pluginManager) {
@@ -60,9 +59,9 @@ public class NotificationExtension extends AbstractExtension {
         registerHandler("3.0", new PluginSettingsJsonMessageHandler2_0());
         messageHandlerMap.put("3.0", new JsonMessageHandler3_0());
 
-        jsonMessageHandlersForRequestProcessor.put("1.0", new JsonMessageHandlerForRequestProcessor1_0());
-        jsonMessageHandlersForRequestProcessor.put("2.0", new JsonMessageHandlerForRequestProcessor1_0());
-        jsonMessageHandlersForRequestProcessor.put("3.0", new JsonMessageHandlerForRequestProcessor1_0());
+        registerJsonMessageHandlerForRequestProcessor("1.0", new JsonMessageHandlerForRequestProcessor1_0());
+        registerJsonMessageHandlerForRequestProcessor("2.0", new JsonMessageHandlerForRequestProcessor1_0());
+        registerJsonMessageHandlerForRequestProcessor("3.0", new JsonMessageHandlerForRequestProcessor1_0());
     }
 
     public List<String> getNotificationsOfInterestFor(String pluginId) {
@@ -90,7 +89,6 @@ public class NotificationExtension extends AbstractExtension {
         });
     }
 
-
     Map<String, PluginSettingsJsonMessageHandler> getPluginSettingsMessageHandlerMap() {
         return pluginSettingsMessageHandlerMap;
     }
@@ -102,10 +100,5 @@ public class NotificationExtension extends AbstractExtension {
     @Override
     protected List<String> goSupportedVersions() {
         return goSupportedVersions;
-    }
-
-    @Override
-    public JsonMessageHandlerForRequestProcessor jsonMessageHandlerForRequestProcessor(String pluginVersion) {
-        return jsonMessageHandlersForRequestProcessor.get(pluginVersion);
     }
 }

--- a/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/packagematerial/PackageRepositoryExtension.java
+++ b/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/packagematerial/PackageRepositoryExtension.java
@@ -51,14 +51,13 @@ public class PackageRepositoryExtension extends AbstractExtension {
     public static final String REQUEST_CHECK_REPOSITORY_CONNECTION = "check-repository-connection";
     public static final String REQUEST_CHECK_PACKAGE_CONNECTION = "check-package-connection";
     final Map<String, JsonMessageHandler> messageHandlerMap = new HashMap<>();
-    private Map<String, JsonMessageHandlerForRequestProcessor> jsonMessageHandlersForRequestProcessor = new HashMap<>();
 
     @Autowired
     public PackageRepositoryExtension(PluginManager pluginManager) {
         super(pluginManager, new PluginRequestHelper(pluginManager, goSupportedVersions, EXTENSION_NAME), EXTENSION_NAME);
         registerHandler("1.0", new PluginSettingsJsonMessageHandler1_0());
         messageHandlerMap.put("1.0", new JsonMessageHandler1_0());
-        jsonMessageHandlersForRequestProcessor.put("1.0", new JsonMessageHandlerForRequestProcessor1_0());
+        registerJsonMessageHandlerForRequestProcessor("1.0", new JsonMessageHandlerForRequestProcessor1_0());
     }
 
 
@@ -169,11 +168,6 @@ public class PackageRepositoryExtension extends AbstractExtension {
 
     JsonMessageHandler messageConverter(String resolvedExtensionVersion) {
         return messageHandlerMap.get(resolvedExtensionVersion);
-    }
-
-    @Override
-    protected JsonMessageHandlerForRequestProcessor jsonMessageHandlerForRequestProcessor(String pluginVersion) {
-        return jsonMessageHandlersForRequestProcessor.get(pluginVersion);
     }
 
     @Override

--- a/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/packagematerial/PackageRepositoryExtension.java
+++ b/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/packagematerial/PackageRepositoryExtension.java
@@ -20,6 +20,8 @@ import com.thoughtworks.go.plugin.access.DefaultPluginInteractionCallback;
 import com.thoughtworks.go.plugin.access.PluginRequestHelper;
 import com.thoughtworks.go.plugin.access.common.AbstractExtension;
 import com.thoughtworks.go.plugin.access.common.settings.PluginSettingsJsonMessageHandler1_0;
+import com.thoughtworks.go.plugin.access.common.settings.JsonMessageHandlerForRequestProcessor;
+import com.thoughtworks.go.plugin.access.common.settings.JsonMessageHandlerForRequestProcessor1_0;
 import com.thoughtworks.go.plugin.api.material.packagerepository.PackageRevision;
 import com.thoughtworks.go.plugin.api.material.packagerepository.RepositoryConfiguration;
 import com.thoughtworks.go.plugin.api.response.Result;
@@ -49,12 +51,14 @@ public class PackageRepositoryExtension extends AbstractExtension {
     public static final String REQUEST_CHECK_REPOSITORY_CONNECTION = "check-repository-connection";
     public static final String REQUEST_CHECK_PACKAGE_CONNECTION = "check-package-connection";
     final Map<String, JsonMessageHandler> messageHandlerMap = new HashMap<>();
+    private Map<String, JsonMessageHandlerForRequestProcessor> jsonMessageHandlersForRequestProcessor = new HashMap<>();
 
     @Autowired
     public PackageRepositoryExtension(PluginManager pluginManager) {
         super(pluginManager, new PluginRequestHelper(pluginManager, goSupportedVersions, EXTENSION_NAME), EXTENSION_NAME);
         registerHandler("1.0", new PluginSettingsJsonMessageHandler1_0());
         messageHandlerMap.put("1.0", new JsonMessageHandler1_0());
+        jsonMessageHandlersForRequestProcessor.put("1.0", new JsonMessageHandlerForRequestProcessor1_0());
     }
 
 
@@ -165,6 +169,11 @@ public class PackageRepositoryExtension extends AbstractExtension {
 
     JsonMessageHandler messageConverter(String resolvedExtensionVersion) {
         return messageHandlerMap.get(resolvedExtensionVersion);
+    }
+
+    @Override
+    protected JsonMessageHandlerForRequestProcessor jsonMessageHandlerForRequestProcessor(String pluginVersion) {
+        return jsonMessageHandlersForRequestProcessor.get(pluginVersion);
     }
 
     @Override

--- a/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/pluggabletask/TaskExtension.java
+++ b/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/pluggabletask/TaskExtension.java
@@ -70,7 +70,7 @@ public class TaskExtension extends AbstractExtension {
 
     @Override
     protected JsonMessageHandlerForRequestProcessor jsonMessageHandlerForRequestProcessor(String pluginVersion) {
-        throw new UnsupportedOperationException("Fetch PluginSettings is not supported by Authorization Endpoint.");
+        throw new UnsupportedOperationException("Fetch PluginSettings is not supported by Task Endpoint.");
     }
 
     @Override

--- a/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/pluggabletask/TaskExtension.java
+++ b/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/pluggabletask/TaskExtension.java
@@ -19,6 +19,7 @@ package com.thoughtworks.go.plugin.access.pluggabletask;
 import com.thoughtworks.go.plugin.access.PluginRequestHelper;
 import com.thoughtworks.go.plugin.access.common.AbstractExtension;
 import com.thoughtworks.go.plugin.access.common.settings.PluginSettingsJsonMessageHandler1_0;
+import com.thoughtworks.go.plugin.access.common.settings.JsonMessageHandlerForRequestProcessor;
 import com.thoughtworks.go.plugin.api.response.execution.ExecutionResult;
 import com.thoughtworks.go.plugin.api.response.validation.ValidationResult;
 import com.thoughtworks.go.plugin.api.task.Task;
@@ -65,6 +66,11 @@ public class TaskExtension extends AbstractExtension {
     public ValidationResult validate(String pluginId, TaskConfig taskConfig) {
         JsonBasedPluggableTask task = new JsonBasedPluggableTask(pluginId, pluginRequestHelper, messageHandlerMap);
         return task.validate(taskConfig);
+    }
+
+    @Override
+    protected JsonMessageHandlerForRequestProcessor jsonMessageHandlerForRequestProcessor(String pluginVersion) {
+        throw new UnsupportedOperationException("Fetch PluginSettings is not supported by Authorization Endpoint.");
     }
 
     @Override

--- a/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/scm/SCMExtension.java
+++ b/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/scm/SCMExtension.java
@@ -21,6 +21,8 @@ import com.thoughtworks.go.plugin.access.PluginRequestHelper;
 import com.thoughtworks.go.plugin.access.common.AbstractExtension;
 import com.thoughtworks.go.plugin.access.common.settings.PluginSettingsJsonMessageHandler;
 import com.thoughtworks.go.plugin.access.common.settings.PluginSettingsJsonMessageHandler1_0;
+import com.thoughtworks.go.plugin.access.common.settings.JsonMessageHandlerForRequestProcessor;
+import com.thoughtworks.go.plugin.access.common.settings.JsonMessageHandlerForRequestProcessor1_0;
 import com.thoughtworks.go.plugin.access.scm.material.MaterialPollResult;
 import com.thoughtworks.go.plugin.access.scm.revision.SCMRevision;
 import com.thoughtworks.go.plugin.api.response.Result;
@@ -49,12 +51,14 @@ public class SCMExtension extends AbstractExtension {
     public static final String REQUEST_CHECKOUT = "checkout";
 
     private Map<String, JsonMessageHandler> messageHandlerMap = new HashMap<>();
+    private Map<String, JsonMessageHandlerForRequestProcessor> jsonMessageHandlersForRequestProcessor = new HashMap<>();
 
     @Autowired
     public SCMExtension(PluginManager pluginManager) {
         super(pluginManager, new PluginRequestHelper(pluginManager, goSupportedVersions, EXTENSION_NAME), EXTENSION_NAME);
         registerHandler("1.0", new PluginSettingsJsonMessageHandler1_0());
         messageHandlerMap.put("1.0", new JsonMessageHandler1_0());
+        jsonMessageHandlersForRequestProcessor.put("1.0", new JsonMessageHandlerForRequestProcessor1_0());
     }
 
     public SCMPropertyConfiguration getSCMConfiguration(String pluginId) {
@@ -153,6 +157,11 @@ public class SCMExtension extends AbstractExtension {
 
     Map<String, JsonMessageHandler> getMessageHandlerMap() {
         return messageHandlerMap;
+    }
+
+    @Override
+    protected JsonMessageHandlerForRequestProcessor jsonMessageHandlerForRequestProcessor(String pluginVersion) {
+        return jsonMessageHandlersForRequestProcessor.get(pluginVersion);
     }
 
     @Override

--- a/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/scm/SCMExtension.java
+++ b/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/scm/SCMExtension.java
@@ -51,14 +51,13 @@ public class SCMExtension extends AbstractExtension {
     public static final String REQUEST_CHECKOUT = "checkout";
 
     private Map<String, JsonMessageHandler> messageHandlerMap = new HashMap<>();
-    private Map<String, JsonMessageHandlerForRequestProcessor> jsonMessageHandlersForRequestProcessor = new HashMap<>();
 
     @Autowired
     public SCMExtension(PluginManager pluginManager) {
         super(pluginManager, new PluginRequestHelper(pluginManager, goSupportedVersions, EXTENSION_NAME), EXTENSION_NAME);
         registerHandler("1.0", new PluginSettingsJsonMessageHandler1_0());
         messageHandlerMap.put("1.0", new JsonMessageHandler1_0());
-        jsonMessageHandlersForRequestProcessor.put("1.0", new JsonMessageHandlerForRequestProcessor1_0());
+        registerJsonMessageHandlerForRequestProcessor("1.0", new JsonMessageHandlerForRequestProcessor1_0());
     }
 
     public SCMPropertyConfiguration getSCMConfiguration(String pluginId) {
@@ -157,11 +156,6 @@ public class SCMExtension extends AbstractExtension {
 
     Map<String, JsonMessageHandler> getMessageHandlerMap() {
         return messageHandlerMap;
-    }
-
-    @Override
-    protected JsonMessageHandlerForRequestProcessor jsonMessageHandlerForRequestProcessor(String pluginVersion) {
-        return jsonMessageHandlersForRequestProcessor.get(pluginVersion);
     }
 
     @Override

--- a/plugin-infra/go-plugin-access/test/com/thoughtworks/go/plugin/access/authentication/AuthenticationExtensionTest.java
+++ b/plugin-infra/go-plugin-access/test/com/thoughtworks/go/plugin/access/authentication/AuthenticationExtensionTest.java
@@ -33,12 +33,11 @@ import org.mockito.Mock;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -158,6 +157,20 @@ public class AuthenticationExtensionTest {
         assertRequest(requestArgumentCaptor.getValue(), AuthenticationExtension.EXTENSION_NAME, "1.0", AuthenticationExtension.REQUEST_SEARCH_USER, REQUEST_BODY);
         verify(jsonMessageHandler).responseMessageForSearchUser(RESPONSE_BODY);
         assertSame(response, deserializedResponse);
+    }
+
+    @Test
+    public void shouldSerializePluginSettingsToJSON() throws Exception {
+        String pluginId = "plugin_id";
+        HashMap<String, String> pluginSettings = new HashMap<>();
+        pluginSettings.put("key1", "val1");
+        pluginSettings.put("key2", "val2");
+
+        when(pluginManager.resolveExtensionVersion(pluginId, authenticationExtension.goSupportedVersions())).thenReturn("1.0");
+
+        String pluginSettingsJSON = authenticationExtension.pluginSettingsJSON(pluginId, pluginSettings);
+
+        assertThat(pluginSettingsJSON, is("{\"key1\":\"val1\",\"key2\":\"val2\"}"));
     }
 
     private void assertRequest(GoPluginApiRequest goPluginApiRequest, String extensionName, String version, String requestName, String requestBody) {

--- a/plugin-infra/go-plugin-access/test/com/thoughtworks/go/plugin/access/authorization/AuthorizationExtensionTest.java
+++ b/plugin-infra/go-plugin-access/test/com/thoughtworks/go/plugin/access/authorization/AuthorizationExtensionTest.java
@@ -327,6 +327,15 @@ public class AuthorizationExtensionTest {
         assertThat(authorizationServerRedirectUrl, is("url_to_authorization_server"));
     }
 
+    @Test
+    public void shouldNotSupportFetchingPlugginSettings() throws Exception {
+        thrown.expect(UnsupportedOperationException.class);
+        thrown.expectMessage("Fetch PluginSettings is not supported by Authorization Endpoint.");
+
+        authorizationExtension.pluginSettingsJSON("plugin_id", Collections.emptyMap());
+    }
+
+
     private void assertRequest(GoPluginApiRequest goPluginApiRequest, String extensionName, String version, String requestName, String requestBody) throws JSONException {
         Assert.assertThat(goPluginApiRequest.extension(), Is.is(extensionName));
         Assert.assertThat(goPluginApiRequest.extensionVersion(), Is.is(version));

--- a/plugin-infra/go-plugin-access/test/com/thoughtworks/go/plugin/access/common/AbstractExtensionTest.java
+++ b/plugin-infra/go-plugin-access/test/com/thoughtworks/go/plugin/access/common/AbstractExtensionTest.java
@@ -19,6 +19,7 @@ package com.thoughtworks.go.plugin.access.common;
 import com.thoughtworks.go.plugin.access.PluginRequestHelper;
 import com.thoughtworks.go.plugin.access.common.settings.PluginSettingsJsonMessageHandler1_0;
 import com.thoughtworks.go.plugin.access.common.settings.PluginSettingsJsonMessageHandler2_0;
+import com.thoughtworks.go.plugin.access.common.settings.JsonMessageHandlerForRequestProcessor;
 import com.thoughtworks.go.plugin.api.request.GoPluginApiRequest;
 import com.thoughtworks.go.plugin.api.response.DefaultGoPluginApiResponse;
 import com.thoughtworks.go.plugin.infra.PluginManager;
@@ -31,10 +32,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.skyscreamer.jsonassert.JSONAssert;
 
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import static com.thoughtworks.go.plugin.access.common.settings.PluginSettingsConstants.REQUEST_NOTIFY_PLUGIN_SETTINGS_CHANGE;
 import static com.thoughtworks.go.plugin.api.response.DefaultGoPluginApiResponse.SUCCESS_RESPONSE_CODE;
@@ -60,6 +58,11 @@ public class AbstractExtensionTest {
 
         protected TestExtension(PluginManager pluginManager, PluginRequestHelper pluginRequestHelper, String extensionName) {
             super(pluginManager, pluginRequestHelper, extensionName);
+        }
+
+        @Override
+        protected JsonMessageHandlerForRequestProcessor jsonMessageHandlerForRequestProcessor(String pluginVersion) {
+            return null;
         }
 
         @Override

--- a/plugin-infra/go-plugin-access/test/com/thoughtworks/go/plugin/access/configrepo/ConfigRepoExtensionTest.java
+++ b/plugin-infra/go-plugin-access/test/com/thoughtworks/go/plugin/access/configrepo/ConfigRepoExtensionTest.java
@@ -17,13 +17,17 @@ package com.thoughtworks.go.plugin.access.configrepo;
 
 import com.thoughtworks.go.plugin.access.common.AbstractExtension;
 import com.thoughtworks.go.plugin.access.configrepo.contract.CRParseResult;
+import com.thoughtworks.go.plugin.access.notification.NotificationExtension;
 import com.thoughtworks.go.plugin.api.request.GoPluginApiRequest;
 import com.thoughtworks.go.plugin.api.response.DefaultGoPluginApiResponse;
 import com.thoughtworks.go.plugin.infra.PluginManager;
+import org.hamcrest.CoreMatchers;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
+
+import java.util.HashMap;
 
 import static com.thoughtworks.go.util.ArrayUtil.asList;
 import static org.hamcrest.core.Is.is;
@@ -78,6 +82,20 @@ public class ConfigRepoExtensionTest {
         assertSame(response, deserializedResponse);
     }
 
+    @Test
+    public void shouldSerializePluginSettingsToJSON() throws Exception {
+        String pluginId = "plugin_id";
+        HashMap<String, String> pluginSettings = new HashMap<>();
+        pluginSettings.put("key1", "val1");
+        pluginSettings.put("key2", "val2");
+
+        ConfigRepoExtension configRepoExtension = new ConfigRepoExtension(pluginManager);
+
+        when(pluginManager.resolveExtensionVersion(pluginId, configRepoExtension.goSupportedVersions())).thenReturn("1.0");
+        String pluginSettingsJSON = configRepoExtension.pluginSettingsJSON(pluginId, pluginSettings);
+
+        assertThat(pluginSettingsJSON, CoreMatchers.is("{\"key1\":\"val1\",\"key2\":\"val2\"}"));
+    }
 
     private void assertRequest(GoPluginApiRequest goPluginApiRequest, String extensionName, String version, String requestName, String requestBody) {
         assertThat(goPluginApiRequest.extension(), is(extensionName));

--- a/plugin-infra/go-plugin-access/test/com/thoughtworks/go/plugin/access/elastic/v1/ElasticAgentExtensionConverterV1Test.java
+++ b/plugin-infra/go-plugin-access/test/com/thoughtworks/go/plugin/access/elastic/v1/ElasticAgentExtensionConverterV1Test.java
@@ -16,8 +16,11 @@
 
 package com.thoughtworks.go.plugin.access.elastic.v1;
 
+import com.thoughtworks.go.plugin.access.elastic.ElasticAgentExtension;
 import com.thoughtworks.go.plugin.access.elastic.models.AgentMetadata;
+import com.thoughtworks.go.plugin.access.notification.NotificationExtension;
 import com.thoughtworks.go.plugin.api.response.validation.ValidationResult;
+import com.thoughtworks.go.plugin.infra.PluginManager;
 import org.json.JSONException;
 import org.junit.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
@@ -29,6 +32,8 @@ import java.util.Map;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class ElasticAgentExtensionConverterV1Test {
 
@@ -100,6 +105,22 @@ public class ElasticAgentExtensionConverterV1Test {
         com.thoughtworks.go.plugin.domain.common.Image image = new ElasticAgentExtensionConverterV1().getImageResponseFromBody("{\"content_type\":\"foo\", \"data\":\"bar\"}");
         assertThat(image.getContentType(), is("foo"));
         assertThat(image.getData(), is("bar"));
+    }
+
+    @Test
+    public void shouldSerializePluginSettingsToJSON() throws Exception {
+        String pluginId = "plugin_id";
+        HashMap<String, String> pluginSettings = new HashMap<>();
+        pluginSettings.put("key1", "val1");
+        pluginSettings.put("key2", "val2");
+        PluginManager pluginManager = mock(PluginManager.class);
+
+        ElasticAgentExtension elasticAgentExtension = new ElasticAgentExtension(pluginManager);
+
+        when(pluginManager.resolveExtensionVersion(pluginId, Arrays.asList("1.0", "2.0"))).thenReturn("1.0");
+        String pluginSettingsJSON = elasticAgentExtension.pluginSettingsJSON(pluginId, pluginSettings);
+
+        assertThat(pluginSettingsJSON, is("{\"key1\":\"val1\",\"key2\":\"val2\"}"));
     }
 
     private AgentMetadata elasticAgent() {

--- a/plugin-infra/go-plugin-access/test/com/thoughtworks/go/plugin/access/notification/NotificationExtensionTestBase.java
+++ b/plugin-infra/go-plugin-access/test/com/thoughtworks/go/plugin/access/notification/NotificationExtensionTestBase.java
@@ -33,15 +33,11 @@ import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 
 import static java.util.Arrays.asList;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;

--- a/plugin-infra/go-plugin-access/test/com/thoughtworks/go/plugin/access/notification/NotificationExtensionTestBase.java
+++ b/plugin-infra/go-plugin-access/test/com/thoughtworks/go/plugin/access/notification/NotificationExtensionTestBase.java
@@ -33,6 +33,8 @@ import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 
 import static java.util.Arrays.asList;

--- a/plugin-infra/go-plugin-access/test/com/thoughtworks/go/plugin/access/notification/NotificationExtensionTestForV1.java
+++ b/plugin-infra/go-plugin-access/test/com/thoughtworks/go/plugin/access/notification/NotificationExtensionTestForV1.java
@@ -19,11 +19,19 @@ package com.thoughtworks.go.plugin.access.notification;
 import com.thoughtworks.go.plugin.access.common.settings.PluginSettingsJsonMessageHandler;
 import com.thoughtworks.go.plugin.access.common.settings.PluginSettingsJsonMessageHandler1_0;
 import com.thoughtworks.go.plugin.access.notification.v1.JsonMessageHandler1_0;
+import org.junit.Test;
 import org.mockito.Mock;
+
+import java.util.HashMap;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.when;
 
 public class NotificationExtensionTestForV1 extends NotificationExtensionTestBase {
     @Mock
     private PluginSettingsJsonMessageHandler1_0 pluginSettingsJSONMessageHandlerv1;
+
     @Mock
     private JsonMessageHandler1_0 jsonMessageHandlerv1;
 
@@ -40,5 +48,20 @@ public class NotificationExtensionTestForV1 extends NotificationExtensionTestBas
     @Override
     protected JsonMessageHandler jsonMessageHandler() {
         return jsonMessageHandlerv1;
+    }
+
+    @Test
+    public void shouldSerializePluginSettingsToJSON() throws Exception {
+        String pluginId = "plugin_id";
+        HashMap<String, String> pluginSettings = new HashMap<>();
+        pluginSettings.put("k1", "value1");
+        pluginSettings.put("k2", "value2");
+
+        NotificationExtension notificationExtension = new NotificationExtension(pluginManager);
+
+        when(pluginManager.resolveExtensionVersion(pluginId, notificationExtension.goSupportedVersions())).thenReturn(apiVersion());
+        String pluginSettingsJSON = notificationExtension.pluginSettingsJSON(pluginId, pluginSettings);
+
+        assertThat(pluginSettingsJSON, is("{\"k1\":\"value1\",\"k2\":\"value2\"}"));
     }
 }

--- a/plugin-infra/go-plugin-access/test/com/thoughtworks/go/plugin/access/notification/NotificationExtensionTestForV2.java
+++ b/plugin-infra/go-plugin-access/test/com/thoughtworks/go/plugin/access/notification/NotificationExtensionTestForV2.java
@@ -19,7 +19,14 @@ package com.thoughtworks.go.plugin.access.notification;
 import com.thoughtworks.go.plugin.access.common.settings.PluginSettingsJsonMessageHandler;
 import com.thoughtworks.go.plugin.access.common.settings.PluginSettingsJsonMessageHandler1_0;
 import com.thoughtworks.go.plugin.access.notification.v2.JsonMessageHandler2_0;
+import org.junit.Test;
 import org.mockito.Mock;
+
+import java.util.HashMap;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.when;
 
 public class NotificationExtensionTestForV2 extends NotificationExtensionTestBase {
     @Mock
@@ -40,5 +47,20 @@ public class NotificationExtensionTestForV2 extends NotificationExtensionTestBas
     @Override
     protected JsonMessageHandler jsonMessageHandler() {
         return jsonMessageHandlerv2;
+    }
+
+    @Test
+    public void shouldSerializePluginSettingsToJSON() throws Exception {
+        String pluginId = "plugin_id";
+        HashMap<String, String> pluginSettings = new HashMap<>();
+        pluginSettings.put("key1", "value1");
+        pluginSettings.put("key2", "value2");
+
+        NotificationExtension notificationExtension = new NotificationExtension(pluginManager);
+
+        when(pluginManager.resolveExtensionVersion(pluginId, notificationExtension.goSupportedVersions())).thenReturn(apiVersion());
+        String pluginSettingsJSON = notificationExtension.pluginSettingsJSON(pluginId, pluginSettings);
+
+        assertThat(pluginSettingsJSON, is("{\"key1\":\"value1\",\"key2\":\"value2\"}"));
     }
 }

--- a/plugin-infra/go-plugin-access/test/com/thoughtworks/go/plugin/access/notification/NotificationExtensionTestForV3.java
+++ b/plugin-infra/go-plugin-access/test/com/thoughtworks/go/plugin/access/notification/NotificationExtensionTestForV3.java
@@ -32,10 +32,13 @@ import org.skyscreamer.jsonassert.JSONAssert;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 
 import static com.thoughtworks.go.plugin.access.common.settings.PluginSettingsConstants.REQUEST_NOTIFY_PLUGIN_SETTINGS_CHANGE;
 import static com.thoughtworks.go.plugin.api.response.DefaultGoPluginApiResponse.SUCCESS_RESPONSE_CODE;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.when;
 
@@ -62,7 +65,7 @@ public class NotificationExtensionTestForV3 extends NotificationExtensionTestBas
     }
 
     @Test
-    public void shouldNotifySettingsChangeForPluginWhichSupportsNotification() throws Exception {
+    public void shouldNotifyPluginSettingsChange() throws Exception {
         String supportedVersion = "3.0";
         Map<String, String> settings = Collections.singletonMap("foo", "bar");
         ArgumentCaptor<GoPluginApiRequest> requestArgumentCaptor = ArgumentCaptor.forClass(GoPluginApiRequest.class);
@@ -76,6 +79,21 @@ public class NotificationExtensionTestForV3 extends NotificationExtensionTestBas
 
         assertRequest(requestArgumentCaptor.getValue(), NotificationExtension.EXTENSION_NAME,
                 supportedVersion, REQUEST_NOTIFY_PLUGIN_SETTINGS_CHANGE, "{\"foo\":\"bar\"}");
+    }
+
+    @Test
+    public void shouldSerializePluginSettingsToJSON() throws Exception {
+        String pluginId = "plugin_id";
+        HashMap<String, String> pluginSettings = new HashMap<>();
+        pluginSettings.put("key1", "val1");
+        pluginSettings.put("key2", "val2");
+
+        NotificationExtension notificationExtension = new NotificationExtension(pluginManager);
+
+        when(pluginManager.resolveExtensionVersion(pluginId, notificationExtension.goSupportedVersions())).thenReturn(apiVersion());
+        String pluginSettingsJSON = notificationExtension.pluginSettingsJSON(pluginId, pluginSettings);
+
+        assertThat(pluginSettingsJSON, is("{\"key1\":\"val1\",\"key2\":\"val2\"}"));
     }
 
     private void assertRequest(GoPluginApiRequest goPluginApiRequest, String extensionName, String version, String requestName, String requestBody) throws JSONException {

--- a/plugin-infra/go-plugin-access/test/com/thoughtworks/go/plugin/access/packagematerial/PackageRepositoryExtensionTest.java
+++ b/plugin-infra/go-plugin-access/test/com/thoughtworks/go/plugin/access/packagematerial/PackageRepositoryExtensionTest.java
@@ -20,6 +20,7 @@ import com.thoughtworks.go.plugin.access.common.AbstractExtension;
 import com.thoughtworks.go.plugin.access.common.settings.PluginSettingsConfiguration;
 import com.thoughtworks.go.plugin.access.common.settings.PluginSettingsConstants;
 import com.thoughtworks.go.plugin.access.common.settings.PluginSettingsJsonMessageHandler1_0;
+import com.thoughtworks.go.plugin.access.notification.NotificationExtension;
 import com.thoughtworks.go.plugin.api.config.Property;
 import com.thoughtworks.go.plugin.api.material.packagerepository.PackageMaterialProperty;
 import com.thoughtworks.go.plugin.api.material.packagerepository.PackageRevision;
@@ -30,6 +31,7 @@ import com.thoughtworks.go.plugin.api.response.Result;
 import com.thoughtworks.go.plugin.api.response.validation.ValidationError;
 import com.thoughtworks.go.plugin.api.response.validation.ValidationResult;
 import com.thoughtworks.go.plugin.infra.PluginManager;
+import org.hamcrest.CoreMatchers;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
@@ -37,10 +39,7 @@ import org.mockito.Mock;
 
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.util.Date;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import static com.thoughtworks.go.plugin.access.packagematerial.PackageRepositoryExtension.EXTENSION_NAME;
 import static java.util.Arrays.asList;
@@ -339,6 +338,20 @@ public class PackageRepositoryExtensionTest {
         } catch (Exception e) {
             assertThat(e.getMessage(), is("Interaction with plugin with id 'plugin-id' implementing 'package-repository' extension failed while requesting for 'check-package-connection'. Reason: [exception-from-plugin]"));
         }
+    }
+
+    @Test
+    public void shouldSerializePluginSettingsToJSON() throws Exception {
+        String pluginId = "plugin_id";
+        HashMap<String, String> pluginSettings = new HashMap<>();
+        pluginSettings.put("key1", "value1");
+        pluginSettings.put("key2", "value2");
+
+        when(pluginManager.resolveExtensionVersion(pluginId, extension.goSupportedVersions())).thenReturn("1.0");
+
+        String pluginSettingsJSON = extension.pluginSettingsJSON(pluginId, pluginSettings);
+
+        assertThat(pluginSettingsJSON, is("{\"key1\":\"value1\",\"key2\":\"value2\"}"));
     }
 
     private void assertPropertyConfiguration(PackageMaterialProperty property, String key, String value, boolean partOfIdentity, boolean required, boolean secure, String displayName, int displayOrder) {

--- a/plugin-infra/go-plugin-access/test/com/thoughtworks/go/plugin/access/pluggabletask/TaskExtensionTest.java
+++ b/plugin-infra/go-plugin-access/test/com/thoughtworks/go/plugin/access/pluggabletask/TaskExtensionTest.java
@@ -32,11 +32,14 @@ import com.thoughtworks.go.plugin.infra.ActionWithReturn;
 import com.thoughtworks.go.plugin.infra.PluginManager;
 import com.thoughtworks.go.plugin.infra.plugininfo.GoPluginDescriptor;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 
 import java.util.ArrayList;
+import java.util.Collections;
 
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.*;
@@ -50,6 +53,9 @@ public class TaskExtensionTest {
     private PluginSettingsJsonMessageHandler1_0 pluginSettingsJSONMessageHandler;
     @Mock
     private JsonBasedTaskExtensionHandler jsonMessageHandler;
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
 
     private TaskExtension extension;
     private String pluginId;
@@ -153,6 +159,14 @@ public class TaskExtensionTest {
         extension.doOnTask(pluginId, action);
 
         verify(action).execute(any(JsonBasedPluggableTask.class), eq(descriptor));
+    }
+
+    @Test
+    public void shouldNotSupportFetchingPlugginSettings() throws Exception {
+        thrown.expect(UnsupportedOperationException.class);
+        thrown.expectMessage("Fetch PluginSettings is not supported by Task Endpoint.");
+
+        extension.pluginSettingsJSON("plugin_id", Collections.emptyMap());
     }
 
     @Test

--- a/plugin-infra/go-plugin-access/test/com/thoughtworks/go/plugin/access/scm/SCMExtensionTest.java
+++ b/plugin-infra/go-plugin-access/test/com/thoughtworks/go/plugin/access/scm/SCMExtensionTest.java
@@ -20,6 +20,7 @@ import com.thoughtworks.go.plugin.access.common.AbstractExtension;
 import com.thoughtworks.go.plugin.access.common.settings.PluginSettingsConfiguration;
 import com.thoughtworks.go.plugin.access.common.settings.PluginSettingsConstants;
 import com.thoughtworks.go.plugin.access.common.settings.PluginSettingsJsonMessageHandler1_0;
+import com.thoughtworks.go.plugin.access.notification.NotificationExtension;
 import com.thoughtworks.go.plugin.access.scm.material.MaterialPollResult;
 import com.thoughtworks.go.plugin.access.scm.revision.SCMRevision;
 import com.thoughtworks.go.plugin.api.request.GoPluginApiRequest;
@@ -27,6 +28,7 @@ import com.thoughtworks.go.plugin.api.response.DefaultGoPluginApiResponse;
 import com.thoughtworks.go.plugin.api.response.Result;
 import com.thoughtworks.go.plugin.api.response.validation.ValidationResult;
 import com.thoughtworks.go.plugin.infra.PluginManager;
+import org.hamcrest.CoreMatchers;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
@@ -239,6 +241,19 @@ public class SCMExtensionTest {
         } catch (Exception e) {
             assertThat(e.getMessage(), is("Interaction with plugin with id 'plugin-id' implementing 'scm' extension failed while requesting for 'check-scm-connection'. Reason: [exception-from-plugin]"));
         }
+    }
+
+    @Test
+    public void shouldSerializePluginSettingsToJSON() throws Exception {
+        String pluginId = "plugin_id";
+        HashMap<String, String> pluginSettings = new HashMap<>();
+        pluginSettings.put("key1", "val1");
+        pluginSettings.put("key2", "val2");
+
+        when(pluginManager.resolveExtensionVersion(pluginId, scmExtension.goSupportedVersions())).thenReturn("1.0");
+        String pluginSettingsJSON = scmExtension.pluginSettingsJSON(pluginId, pluginSettings);
+
+        assertThat(pluginSettingsJSON, CoreMatchers.is("{\"key1\":\"val1\",\"key2\":\"val2\"}"));
     }
 
     private void assertRequest(GoPluginApiRequest goPluginApiRequest, String extensionName, String version, String requestName, String requestBody) {

--- a/server/src/com/thoughtworks/go/server/service/plugins/processor/pluginsettings/PluginSettingsRequestProcessor.java
+++ b/server/src/com/thoughtworks/go/server/service/plugins/processor/pluginsettings/PluginSettingsRequestProcessor.java
@@ -58,20 +58,23 @@ public class PluginSettingsRequestProcessor implements GoPluginApiRequestProcess
     @Override
     public GoApiResponse process(GoPluginDescriptor pluginDescriptor, GoApiRequest goPluginApiRequest) {
         try {
-            if (goPluginApiRequest.api().equals(GET_PLUGIN_SETTINGS)) {
-                GoPluginExtension extension = extensionFor(pluginDescriptor.id());
+            GoPluginExtension extension = extensionFor(pluginDescriptor.id());
 
-                PluginSettings pluginSettings = pluginSettingsFor(pluginDescriptor.id());
+            PluginSettings pluginSettings = pluginSettingsFor(pluginDescriptor.id());
 
-                DefaultGoApiResponse response = new DefaultGoApiResponse(200);
-                response.setResponseBody(extension.pluginSettingsJSON(pluginDescriptor.id(), pluginSettings.getSettingsAsKeyValuePair()));
+            DefaultGoApiResponse response = new DefaultGoApiResponse(200);
+            response.setResponseBody(extension.pluginSettingsJSON(pluginDescriptor.id(), pluginSettings.getSettingsAsKeyValuePair()));
 
-                return response;
-            }
+            return response;
         } catch (Exception e) {
             LOGGER.error(format("Error processing PluginSettings request from plugin: %s.", pluginDescriptor.id()), e);
+
+            DefaultGoApiResponse errorResponse = new DefaultGoApiResponse(400);
+            errorResponse.setResponseBody(format("Error while processing get PluginSettings request - %s", e.getMessage()));
+
+            return errorResponse;
         }
-        return new DefaultGoApiResponse(400);
+
     }
 
     private PluginSettings pluginSettingsFor(String pluginId) {


### PR DESCRIPTION

* Moving away from PluginSettingsRequestProcessor handling multiple
  versions of plugin and building the response body.
* Plugin extensions would be responsible to build the plugin settings
  JSON based on the appropriate plugin version.