### PR TITLE
Pass along jobIdentifier as part of get-status-report request to the elastic agent plugins

### DIFF
--- a/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/elastic/ElasticAgentExtension.java
+++ b/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/elastic/ElasticAgentExtension.java
@@ -129,8 +129,13 @@ public class ElasticAgentExtension extends AbstractExtension {
         });
     }
 
-    public String getStatusReport(String pluginId) {
+    public String getStatusReport(String pluginId, JobIdentifier identifier) {
         return pluginRequestHelper.submitRequest(pluginId, REQUEST_STATUS_REPORT, new DefaultPluginInteractionCallback<String>() {
+            @Override
+            public String requestBody(String resolvedExtensionVersion) {
+                return getElasticAgentMessageConverter(resolvedExtensionVersion).statusReportRequestBody(identifier);
+            }
+
             @Override
             public String onSuccess(String responseBody, String resolvedExtensionVersion) {
                 final ElasticAgentExtensionConverterV2 converter = (ElasticAgentExtensionConverterV2) getElasticAgentMessageConverter(resolvedExtensionVersion);

--- a/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/elastic/ElasticAgentMessageConverter.java
+++ b/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/elastic/ElasticAgentMessageConverter.java
@@ -48,4 +48,6 @@ public interface ElasticAgentMessageConverter {
     String validateRequestBody(Map<String, String> configuration);
 
     com.thoughtworks.go.plugin.domain.common.Image getImageResponseFromBody(String responseBody);
+
+    String statusReportRequestBody(JobIdentifier identifier);
 }

--- a/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/elastic/v1/ElasticAgentExtensionConverterV1.java
+++ b/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/elastic/v1/ElasticAgentExtensionConverterV1.java
@@ -103,6 +103,11 @@ public class ElasticAgentExtensionConverterV1 implements ElasticAgentMessageConv
     }
 
     @Override
+    public String statusReportRequestBody(JobIdentifier identifier) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public ValidationResult getValidationResultResponseFromBody(String responseBody) {
         return new JSONResultMessageHandler().toValidationResult(responseBody);
     }

--- a/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/elastic/v2/ElasticAgentExtensionConverterV2.java
+++ b/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/elastic/v2/ElasticAgentExtensionConverterV2.java
@@ -119,6 +119,17 @@ public class ElasticAgentExtensionConverterV2 implements ElasticAgentMessageConv
     }
 
     @Override
+    public String statusReportRequestBody(JobIdentifier identifier) {
+        JsonObject jsonObject = new JsonObject();
+        if (identifier == null) {
+            return GSON.toJson(jsonObject);
+        }
+
+        jsonObject.add("job_identifier", jobIdentifierJson(identifier));
+        return GSON.toJson(jsonObject);
+    }
+
+    @Override
     public ValidationResult getValidationResultResponseFromBody(String responseBody) {
         return new JSONResultMessageHandler().toValidationResult(responseBody);
     }

--- a/plugin-infra/go-plugin-access/test/com/thoughtworks/go/plugin/access/elastic/ElasticAgentExtensionTest.java
+++ b/plugin-infra/go-plugin-access/test/com/thoughtworks/go/plugin/access/elastic/ElasticAgentExtensionTest.java
@@ -64,7 +64,7 @@ public class ElasticAgentExtensionTest {
                 "\"view\": \"foo\"\n" +
                 "}"));
 
-        final String statusReport = new ElasticAgentExtension(pluginManager).getStatusReport("ecs.plugin");
+        final String statusReport = new ElasticAgentExtension(pluginManager).getStatusReport("ecs.plugin", null);
 
         assertThat(statusReport, is("foo"));
         assertThat(requestArgumentCaptor.getValue().extension(), is(ElasticAgentPluginConstants.EXTENSION_NAME));

--- a/plugin-infra/go-plugin-access/test/com/thoughtworks/go/plugin/access/elastic/v2/ElasticAgentExtensionConverterV2Test.java
+++ b/plugin-infra/go-plugin-access/test/com/thoughtworks/go/plugin/access/elastic/v2/ElasticAgentExtensionConverterV2Test.java
@@ -110,6 +110,28 @@ public class ElasticAgentExtensionConverterV2Test {
     }
 
     @Test
+    public void shouldJSONizeStatusReportRequestBody() throws Exception {
+        String json = new ElasticAgentExtensionConverterV2().statusReportRequestBody(jobIdentifier);
+        JSONAssert.assertEquals(json, "{" +
+                "  \"job_identifier\": {\n" +
+                "    \"pipeline_name\": \"test-pipeline\",\n" +
+                "    \"pipeline_counter\": 1,\n" +
+                "    \"pipeline_label\": \"Test Pipeline\",\n" +
+                "    \"stage_name\": \"test-stage\",\n" +
+                "    \"stage_counter\": \"1\",\n" +
+                "    \"job_name\": \"test-job\",\n" +
+                "    \"job_id\": 100\n" +
+                "  }\n" +
+                "}", JSONCompareMode.NON_EXTENSIBLE);
+    }
+
+    @Test
+    public void shouldJSONizeStatusReportRequestBodyForNoJobIdentifier() throws Exception {
+        String json = new ElasticAgentExtensionConverterV2().statusReportRequestBody(null);
+        JSONAssert.assertEquals(json, "{}", JSONCompareMode.NON_EXTENSIBLE);
+    }
+
+    @Test
     public void shouldJSONizesListAgentsResponseBody() throws Exception {
         String json = new ElasticAgentExtensionConverterV2().listAgentsResponseBody(Arrays.asList(new AgentMetadata("42", "AgentState", "BuildState", "ConfigState")));
         JSONAssert.assertEquals(json, "[{\"agent_id\":\"42\",\"agent_state\":\"AgentState\",\"config_state\":\"ConfigState\",\"build_state\":\"BuildState\"}]", JSONCompareMode.NON_EXTENSIBLE);

--- a/server/webapp/WEB-INF/rails.new/app/controllers/admin/status_reports_controller.rb
+++ b/server/webapp/WEB-INF/rails.new/app/controllers/admin/status_reports_controller.rb
@@ -25,7 +25,11 @@ module Admin
     def show
       @view_title = 'Plugin Status Report'
       @page_header = 'Plugin Status Report'
-      @status_report = elastic_agent_extension.getStatusReport(params[:plugin_id])
+      job_identifier = nil
+      if !params[:job_id].nil?
+        job_identifier = job_instance_service.buildById(params[:job_id].to_i).getIdentifier()
+      end
+      @status_report = elastic_agent_extension.getStatusReport(params[:plugin_id], job_identifier)
     rescue java.lang.UnsupportedOperationException => e
       render_error_template "Status Report for plugin with id: #{params[:plugin_id]} is not found.", 404
     rescue java.lang.Exception => e

--- a/server/webapp/WEB-INF/vm/build_detail/_build_detail_summary_jstemplate.vm
+++ b/server/webapp/WEB-INF/vm/build_detail/_build_detail_summary_jstemplate.vm
@@ -29,7 +29,7 @@
     <span>Not yet assigned</span>
   {/if}
   #if ( $elasticProfilePluginId && $userHasAdministratorRights )
-    <a href="$req.getContextPath()/admin/status_reports/$elasticProfilePluginId" class="btn-primary btn-small status-report-btn-small">Check Plugin Status</a>
+    <a href="$req.getContextPath()/admin/status_reports/$elasticProfilePluginId?job_id=${build.id}" class="btn-primary btn-small status-report-btn-small">Check Plugin Status</a>
   #end
 </li>
   <li><span class="header">Completed on: </span><span id="build_completed_date">${% build.build_completed_date %}</span><a  href="#tab-properties" class ="more" target="_blank" onclick="new TabsManager('properties')">more...</a></li>


### PR DESCRIPTION

* JobIdentifier is only passed when the request for  'status report page' made from 'build details page'.
* JobIdentifier wont be passed to the plugin when the request for 'status report page' is made from 'plugin settings page' or 'elastic profile page'.

More information: https://github.com/gocd/gocd/issues/4091#issuecomment-352979314