### PR TITLE
PluginAssetsLoader is a service now

### DIFF
--- a/server/src/com/thoughtworks/go/server/service/plugins/PluginAssetsService.java
+++ b/server/src/com/thoughtworks/go/server/service/plugins/PluginAssetsService.java
@@ -19,34 +19,45 @@ package com.thoughtworks.go.server.service.plugins;
 import com.thoughtworks.go.plugin.access.analytics.AnalyticsExtension;
 import com.thoughtworks.go.plugin.infra.PluginChangeListener;
 import com.thoughtworks.go.plugin.infra.plugininfo.GoPluginDescriptor;
+import com.thoughtworks.go.util.ExceptionUtils;
 import com.thoughtworks.go.util.FileUtil;
 import com.thoughtworks.go.util.StringUtil;
 import com.thoughtworks.go.util.ZipUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
 import org.springframework.web.context.ServletContextAware;
 
 import javax.servlet.ServletContext;
+import javax.xml.bind.DatatypeConverter;
 import java.io.ByteArrayInputStream;
 import java.io.File;
-import java.io.IOException;
 import java.nio.file.Paths;
+import java.security.MessageDigest;
 import java.util.Base64;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.zip.ZipInputStream;
 
-@Component
-public class PluginAssetsLoader implements ServletContextAware, PluginChangeListener {
-    private static final Logger LOGGER = LoggerFactory.getLogger(PluginAssetsLoader.class);
+@Service
+public class PluginAssetsService implements ServletContextAware, PluginChangeListener {
+    private static final Logger LOGGER = LoggerFactory.getLogger(PluginAssetsService.class);
+    public static final String HASH_ALGORITHM = "SHA-256";
     private AnalyticsExtension analyticsExtension;
     private ServletContext servletContext;
     private ZipUtil zipUtil;
+    private Map<String, String> pluginAssetPaths;
 
     @Autowired
-    public PluginAssetsLoader(AnalyticsExtension analyticsExtension) {
+    public PluginAssetsService(AnalyticsExtension analyticsExtension) {
         this.zipUtil = new ZipUtil();
         this.analyticsExtension = analyticsExtension;
+        this.pluginAssetPaths = new HashMap<>();
+    }
+
+    public String assetPathFor(String pluginId) {
+        return pluginAssetPaths.get(pluginId);
     }
 
     @Override
@@ -69,7 +80,11 @@ public class PluginAssetsLoader implements ServletContextAware, PluginChangeList
         }
     }
 
-    private String pluginStaticAssetsDirPath(String pluginId) {
+    private String currentAssetPath(String pluginId, String hash) {
+        return Paths.get(pluginStaticAssetsRootDir(pluginId), hash).toString();
+    }
+
+    private String pluginStaticAssetsRootDir(String pluginId) {
         return Paths.get(servletContext.getRealPath(servletContext.getInitParameter("rails.root")), "public", "assets", "plugins", pluginId).toString();
     }
 
@@ -83,20 +98,45 @@ public class PluginAssetsLoader implements ServletContextAware, PluginChangeList
         }
 
         try {
-            ZipInputStream zipInputStream = new ZipInputStream(new ByteArrayInputStream(Base64.getDecoder().decode(data.getBytes())));
+            byte[] payload = Base64.getDecoder().decode(data.getBytes());
+            ZipInputStream zipInputStream = new ZipInputStream(new ByteArrayInputStream(payload));
 
-            zipUtil.unzip(zipInputStream, new File(pluginStaticAssetsDirPath(pluginId)));
-        } catch (IOException e) {
+            String pluginAssetsRoot = currentAssetPath(pluginId, calculateHash(payload));
+            zipUtil.unzip(zipInputStream, new File(pluginAssetsRoot));
+
+            pluginAssetPaths.put(pluginId, pluginAssetsRoot);
+        } catch (Exception e) {
             LOGGER.error("Failed to extract static assets from plugin: {}", pluginId, e);
+            ExceptionUtils.bomb(e);
         }
+    }
+
+    private String calculateHash(byte[] data) {
+        return sha2Digest(data);
+    }
+
+    private String sha2Digest(byte[] bytes) {
+        try {
+            MessageDigest md = MessageDigest.getInstance(HASH_ALGORITHM);
+            return DatatypeConverter.printHexBinary(md.digest(bytes));
+        } catch (Exception e) {
+            LOGGER.error("Error generating {} hash", HASH_ALGORITHM, e);
+            ExceptionUtils.bomb(e);
+        }
+
+        return null;
     }
 
     private void deleteExistingAssets(String pluginId) {
         LOGGER.info("Deleting cached static assets for plugin: {}", pluginId);
         try {
-            FileUtil.deleteDirectoryNoisily(new File(pluginStaticAssetsDirPath(pluginId)));
-        } catch (IOException e) {
+            FileUtil.deleteDirectoryNoisily(new File(pluginStaticAssetsRootDir(pluginId)));
+            if (pluginAssetPaths.containsKey(pluginId)) {
+                pluginAssetPaths.remove(pluginId);
+            }
+        } catch (Exception e) {
             LOGGER.error("Failed to delete cached static assets for plugin: {}", pluginId, e);
+            ExceptionUtils.bomb(e);
         }
     }
 }


### PR DESCRIPTION
* Cached static assets path are now appended with SHA-256 fingerprints.
* Fingerprints are calculated from the actual plugin zip streams.
* Errors while caching assets are bubbled up, this would ensure plugin
  would be unloaded since the plugin would not be functional in absence
  of assets.