### PR TITLE
Fix TriggeredBy and TriggeredAt information (#4081):

### DIFF
--- a/server/webapp/WEB-INF/rails.new/spec/webpack/models/dashboard/dashboard_spec.js
+++ b/server/webapp/WEB-INF/rails.new/spec/webpack/models/dashboard/dashboard_spec.js
@@ -149,7 +149,7 @@ describe("Dashboard", () => {
                     }
                   },
                   "label":        "1",
-                  "schedule_at":  "2017-11-10T07:25:28.539Z",
+                  "scheduled_at":  "2017-11-10T07:25:28.539Z",
                   "triggered_by": "changes",
                   "_embedded":    {
                     "stages": [

--- a/server/webapp/WEB-INF/rails.new/spec/webpack/models/dashboard/pipeline_instance_spec.js
+++ b/server/webapp/WEB-INF/rails.new/spec/webpack/models/dashboard/pipeline_instance_spec.js
@@ -23,7 +23,7 @@ describe("Dashboard", () => {
 
       expect(pipelineInstance.label()).toBe(pipelineInstanceJson.label);
 
-      expect(pipelineInstance.scheduledAt()).toEqual(new Date(pipelineInstanceJson.schedule_at));
+      expect(pipelineInstance.scheduledAt()).toEqual(new Date(pipelineInstanceJson.scheduled_at));
       expect(pipelineInstance.triggeredBy()).toEqual(pipelineInstanceJson.triggered_by);
 
       expect(pipelineInstance.vsmPath()).toEqual(pipelineInstanceJson._links.vsm_url.href);
@@ -71,7 +71,7 @@ describe("Dashboard", () => {
         }
       },
       "label":        "1",
-      "schedule_at":  "2017-11-10T07:25:28.539Z",
+      "scheduled_at":  "2017-11-10T07:25:28.539Z",
       "triggered_by": "changes",
       "_embedded":    {
         "stages": [

--- a/server/webapp/WEB-INF/rails.new/spec/webpack/models/dashboard/pipeline_spec.js
+++ b/server/webapp/WEB-INF/rails.new/spec/webpack/models/dashboard/pipeline_spec.js
@@ -83,7 +83,7 @@ describe("Dashboard", () => {
               }
             },
             "label":        "1",
-            "schedule_at":  "2017-11-10T07:25:28.539Z",
+            "scheduled_at":  "2017-11-10T07:25:28.539Z",
             "triggered_by": "changes",
             "_embedded":    {
               "stages": [

--- a/server/webapp/WEB-INF/rails.new/spec/webpack/models/dashboard/pipelines_spec.js
+++ b/server/webapp/WEB-INF/rails.new/spec/webpack/models/dashboard/pipelines_spec.js
@@ -92,7 +92,7 @@ describe("Dashboard", () => {
                 }
               },
               "label":        "1",
-              "schedule_at":  "2017-11-10T07:25:28.539Z",
+              "scheduled_at":  "2017-11-10T07:25:28.539Z",
               "triggered_by": "changes",
               "_embedded":    {
                 "stages": [

--- a/server/webapp/WEB-INF/rails.new/spec/webpack/views/dashboard/dashboard_widget_spec.js
+++ b/server/webapp/WEB-INF/rails.new/spec/webpack/views/dashboard/dashboard_widget_spec.js
@@ -99,7 +99,7 @@ describe("Dashboard Widget", () => {
                   }
                 },
                 "label":        "1",
-                "schedule_at":  "2017-11-10T07:25:28.539Z",
+                "scheduled_at":  "2017-11-10T07:25:28.539Z",
                 "triggered_by": "changes",
                 "_embedded":    {
                   "stages": [

--- a/server/webapp/WEB-INF/rails.new/spec/webpack/views/dashboard/pipeline_instance_widget_spec.js
+++ b/server/webapp/WEB-INF/rails.new/spec/webpack/views/dashboard/pipeline_instance_widget_spec.js
@@ -48,7 +48,7 @@ describe("Dashboard Pipeline Instance Widget", () => {
       }
     },
     "label":        "1",
-    "schedule_at":  "2017-11-10T07:25:28.539Z",
+    "scheduled_at":  "2017-11-10T07:25:28.539Z",
     "triggered_by": "changes",
     "_embedded":    {
       "stages": [
@@ -93,8 +93,8 @@ describe("Dashboard Pipeline Instance Widget", () => {
   });
 
   it("should render triggered by information", () => {
-    expect($root.find('.instance-details')).toContainText(`Triggered by ${  pipelineInstanceJson.triggered_by }`);
-    expect($root.find('.instance-details')).toContainText(`on ${  new Date(pipelineInstanceJson.schedule_at).toString()}`);
+    expect($root.find('.instance-details')).toContainText(`${  pipelineInstanceJson.triggered_by }`);
+    expect($root.find('.instance-details')).toContainText(`on ${ new Date(pipelineInstanceJson.scheduled_at).toString()}`);
   });
 
   it("should render compare link", () => {

--- a/server/webapp/WEB-INF/rails.new/spec/webpack/views/dashboard/pipeline_widget_spec.js
+++ b/server/webapp/WEB-INF/rails.new/spec/webpack/views/dashboard/pipeline_widget_spec.js
@@ -82,7 +82,7 @@ describe("Dashboard Pipeline Widget", () => {
             }
           },
           "label":        "1",
-          "schedule_at":  "2017-11-10T07:25:28.539Z",
+          "scheduled_at":  "2017-11-10T07:25:28.539Z",
           "triggered_by": "changes",
           "_embedded":    {
             "stages": [

--- a/server/webapp/WEB-INF/rails.new/spec/webpack/views/dashboard/stages_instance_widget_spec.js
+++ b/server/webapp/WEB-INF/rails.new/spec/webpack/views/dashboard/stages_instance_widget_spec.js
@@ -47,7 +47,7 @@ describe("Dashboard Stages Instance Widget", () => {
       }
     },
     "label":        "1",
-    "schedule_at":  "2017-11-10T07:25:28.539Z",
+    "scheduled_at":  "2017-11-10T07:25:28.539Z",
     "triggered_by": "changes",
     "_embedded":    {
       "stages": [

--- a/server/webapp/WEB-INF/rails.new/webpack/models/dashboard/pipeline_instance.js
+++ b/server/webapp/WEB-INF/rails.new/webpack/models/dashboard/pipeline_instance.js
@@ -25,7 +25,7 @@ const StageInstance = function (json) {
 
 const PipelineInstance = function (info) {
   this.label       = Stream(info.label);
-  this.scheduledAt = Stream(new Date(info.schedule_at));
+  this.scheduledAt = Stream(new Date(info.scheduled_at));
   this.triggeredBy = Stream(info.triggered_by);
 
   this.vsmPath     = Stream(info._links.vsm_url.href);

--- a/server/webapp/WEB-INF/rails.new/webpack/views/dashboard/pipeline_instance_widget.js.msx
+++ b/server/webapp/WEB-INF/rails.new/webpack/views/dashboard/pipeline_instance_widget.js.msx
@@ -31,7 +31,7 @@ const PipelineInstanceWidget = {
           <span><a href={instance.vsmPath()}> VSM </a></span>
         </div>
         <div class="instance-details">
-          <div>Triggered by {instance.triggeredBy()}</div>
+          <div>{instance.triggeredBy()}</div>
           <div>on {instance.scheduledAt().toString()}</div>
         </div>
         <div class="latest-stage">


### PR DESCRIPTION
* Do not render extra 'triggered by' text as triggered_by field already contains it
* Change 'schedule_at' field to 'scheduled at'