### PR TITLE
PluginAssetsService is a metadata change listener

### DIFF
--- a/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/common/MetadataLoader.java
+++ b/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/common/MetadataLoader.java
@@ -24,8 +24,8 @@ import com.thoughtworks.go.plugin.infra.plugininfo.GoPluginDescriptor;
 
 public abstract class MetadataLoader<T extends PluginInfo> implements PluginChangeListener {
     private final PluginInfoBuilder<T> builder;
-    private final MetadataStore<T> metadataStore;
-    private final AbstractExtension extension;
+    protected final MetadataStore<T> metadataStore;
+    protected final AbstractExtension extension;
 
     public MetadataLoader(PluginManager pluginManager, PluginInfoBuilder<T> builder, MetadataStore<T> metadataStore, AbstractExtension extension) {
         this.builder = builder;

--- a/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/common/PluginMetadataChangeListener.java
+++ b/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/common/PluginMetadataChangeListener.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2017 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.plugin.access.common;
+
+public interface PluginMetadataChangeListener {
+    void onPluginMetadataCreate(String pluginId);
+    void onPluginMetadataRemove(String pluginId);
+}

--- a/plugin-infra/go-plugin-domain/src/com/thoughtworks/go/plugin/domain/analytics/AnalyticsPluginInfo.java
+++ b/plugin-infra/go-plugin-domain/src/com/thoughtworks/go/plugin/domain/analytics/AnalyticsPluginInfo.java
@@ -26,6 +26,7 @@ import com.thoughtworks.go.plugin.domain.common.PluginInfo;
 public class AnalyticsPluginInfo extends PluginInfo {
     private final Image image;
     private final Capabilities capabilities;
+    private String staticAssetsPath;
 
     public AnalyticsPluginInfo(PluginDescriptor descriptor, Image image, Capabilities capabilities,
                                PluggableInstanceSettings pluginSettings) {
@@ -33,7 +34,6 @@ public class AnalyticsPluginInfo extends PluginInfo {
         this.image = image;
         this.capabilities = capabilities;
     }
-
 
     public Image getImage() {
         return image;
@@ -43,4 +43,11 @@ public class AnalyticsPluginInfo extends PluginInfo {
         return capabilities;
     }
 
+    public String getStaticAssetsPath() {
+        return staticAssetsPath;
+    }
+
+    public void setStaticAssetsPath(String staticAssetsPath) {
+        this.staticAssetsPath = staticAssetsPath;
+    }
 }

--- a/plugin-infra/plugin-metadata-store/src/com/thoughtworks/go/plugin/access/analytics/AnalyticsMetadataStore.java
+++ b/plugin-infra/plugin-metadata-store/src/com/thoughtworks/go/plugin/access/analytics/AnalyticsMetadataStore.java
@@ -34,4 +34,10 @@ public class AnalyticsMetadataStore extends MetadataStore<AnalyticsPluginInfo> {
         return store;
     }
 
+    public void updateAssetsPath(String pluginId, String assetPath) {
+        AnalyticsPluginInfo pluginInfo = getPluginInfo(pluginId);
+        if (pluginInfo != null) {
+            pluginInfo.setStaticAssetsPath(assetPath);
+        }
+    }
 }

--- a/plugin-infra/plugin-metadata-store/src/com/thoughtworks/go/plugin/access/analytics/AnalyticsMetadataStore.java
+++ b/plugin-infra/plugin-metadata-store/src/com/thoughtworks/go/plugin/access/analytics/AnalyticsMetadataStore.java
@@ -18,11 +18,6 @@ package com.thoughtworks.go.plugin.access.analytics;
 
 import com.thoughtworks.go.plugin.access.common.MetadataStore;
 import com.thoughtworks.go.plugin.domain.analytics.AnalyticsPluginInfo;
-import com.thoughtworks.go.plugin.domain.authorization.AuthorizationPluginInfo;
-import com.thoughtworks.go.plugin.domain.authorization.SupportedAuthType;
-
-import java.util.HashSet;
-import java.util.Set;
 
 public class AnalyticsMetadataStore extends MetadataStore<AnalyticsPluginInfo> {
     private static final AnalyticsMetadataStore store = new AnalyticsMetadataStore();
@@ -36,8 +31,7 @@ public class AnalyticsMetadataStore extends MetadataStore<AnalyticsPluginInfo> {
 
     public void updateAssetsPath(String pluginId, String assetPath) {
         AnalyticsPluginInfo pluginInfo = getPluginInfo(pluginId);
-        if (pluginInfo != null) {
-            pluginInfo.setStaticAssetsPath(assetPath);
-        }
+        
+        pluginInfo.setStaticAssetsPath(assetPath);
     }
 }

--- a/plugin-infra/plugin-metadata-store/test/com/thoughtworks/go/plugin/access/analytics/AnalyticsMetadataStoreTest.java
+++ b/plugin-infra/plugin-metadata-store/test/com/thoughtworks/go/plugin/access/analytics/AnalyticsMetadataStoreTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2017 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.plugin.access.analytics;
+
+import com.thoughtworks.go.plugin.api.info.PluginDescriptor;
+import com.thoughtworks.go.plugin.domain.analytics.AnalyticsPluginInfo;
+import org.junit.After;
+import org.junit.Test;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class AnalyticsMetadataStoreTest {
+
+    private AnalyticsMetadataStore store = AnalyticsMetadataStore.instance();
+
+    @After
+    public void tearDown() throws Exception {
+        store.clear();
+    }
+
+    @Test
+    public void shouldHandleUpdateAssetsPath() throws Exception {
+        PluginDescriptor pluginDescriptor = mock(PluginDescriptor.class);
+        AnalyticsPluginInfo pluginInfo = new AnalyticsPluginInfo(pluginDescriptor, null, null, null);
+
+        when(pluginDescriptor.id()).thenReturn("plugin_id");
+        store.setPluginInfo(pluginInfo);
+
+        store.updateAssetsPath("plugin_id", "static_assets_path");
+
+        assertThat(pluginInfo.getStaticAssetsPath(), is("static_assets_path"));
+    }
+}


### PR DESCRIPTION
* Renamed PluginAssetsService to AnalyticsPluginAssetsService since it
  is specific to Analytics Plugin.
* AnalyticsPluginAssetsService is a metadata load listener, once a
  analytics plugin_info is built the static assets are cached in GoCD.
* AssetsService updates the analytics plugin_info with the assets path.
* Cleaned up usages of `FileUtil` and `StringUtil`