### PR TITLE
Analytics endpoint to fetch analytics is generic

### DIFF
--- a/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/analytics/AnalyticsExtension.java
+++ b/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/analytics/AnalyticsExtension.java
@@ -59,7 +59,7 @@ public class AnalyticsExtension extends AbstractExtension {
     }
 
     public AnalyticsData getPipelineAnalytics(String pluginId, String pipelineName) {
-        return pluginRequestHelper.submitRequest(pluginId, REQUEST_GET_PIPELINE_ANALYTICS, new DefaultPluginInteractionCallback<AnalyticsData>() {
+        return pluginRequestHelper.submitRequest(pluginId, REQUEST_GET_ANALYTICS, new DefaultPluginInteractionCallback<AnalyticsData>() {
             @Override
             public String requestBody(String resolvedExtensionVersion) {
                 return getMessageConverter(resolvedExtensionVersion).getPipelineAnalyticsRequestBody(pipelineName);

--- a/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/analytics/AnalyticsMessageConverterV1.java
+++ b/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/analytics/AnalyticsMessageConverterV1.java
@@ -23,6 +23,7 @@ import com.thoughtworks.go.plugin.domain.analytics.AnalyticsData;
 import com.thoughtworks.go.plugin.domain.common.Image;
 import org.apache.commons.lang.StringUtils;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -38,7 +39,8 @@ public class AnalyticsMessageConverterV1 implements AnalyticsMessageConverter {
     @Override
     public String getPipelineAnalyticsRequestBody(String pipelineName) {
         Map<String, Object> requestMap = new HashMap<>();
-        requestMap.put("pipeline_name", pipelineName );
+        requestMap.put("type", "pipeline");
+        requestMap.put("data", Collections.singletonMap("pipeline_name", pipelineName));
 
         return GSON.toJson(requestMap);
     }

--- a/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/analytics/AnalyticsPluginConstants.java
+++ b/plugin-infra/go-plugin-access/src/com/thoughtworks/go/plugin/access/analytics/AnalyticsPluginConstants.java
@@ -27,6 +27,6 @@ public interface AnalyticsPluginConstants {
     String REQUEST_PREFIX = "go.cd.analytics";
     String REQUEST_GET_PLUGIN_ICON = REQUEST_PREFIX + ".get-icon";
     String REQUEST_GET_CAPABILITIES = REQUEST_PREFIX + ".get-capabilities";
-    String REQUEST_GET_PIPELINE_ANALYTICS = REQUEST_PREFIX + ".get-pipeline-analytics";
+    String REQUEST_GET_ANALYTICS = REQUEST_PREFIX + ".get-analytics";
     String REQUEST_GET_STATIC_ASSETS = REQUEST_PREFIX + ".get-static-assets";
 }

--- a/plugin-infra/go-plugin-access/test/com/thoughtworks/go/plugin/access/analytics/AnalyticsExtensionTest.java
+++ b/plugin-infra/go-plugin-access/test/com/thoughtworks/go/plugin/access/analytics/AnalyticsExtensionTest.java
@@ -80,7 +80,7 @@ public class AnalyticsExtensionTest {
 
         AnalyticsData pipelineAnalytics = analyticsExtension.getPipelineAnalytics(PLUGIN_ID, "test_pipeline");
 
-        assertRequest(requestArgumentCaptor.getValue(), AnalyticsPluginConstants.EXTENSION_NAME, "1.0", REQUEST_GET_PIPELINE_ANALYTICS, "{\"pipeline_name\": \"test_pipeline\"}");
+        assertRequest(requestArgumentCaptor.getValue(), AnalyticsPluginConstants.EXTENSION_NAME, "1.0", REQUEST_GET_ANALYTICS, "{\"type\": \"pipeline\", \"data\": {\"pipeline_name\": \"test_pipeline\"}}");
 
         assertThat(pipelineAnalytics.getViewPath(), is("path/to/view"));
         assertThat(pipelineAnalytics.getData(), is("{}"));


### PR DESCRIPTION
* Changed analytics endpoint message '.get-pipeline-analytics' to
  '.get-analytics'. This would make the message generic to support
  different type of analytics.
* The request body would require the 'type' of analytics and the
  corresponding data.