### PR TITLE
Do not allow agent to register with duplicate elastic agent id (#3828)

### DIFF
--- a/base/src/com/thoughtworks/go/util/GoConstants.java
+++ b/base/src/com/thoughtworks/go/util/GoConstants.java
@@ -57,7 +57,7 @@ public class GoConstants {
 
     public static final String PRODUCT_NAME = "go";
 
-    public static final int CONFIG_SCHEMA_VERSION = 102;
+    public static final int CONFIG_SCHEMA_VERSION = 103;
 
     public static final String APPROVAL_SUCCESS = "success";
     public static final String APPROVAL_MANUAL = "manual";

--- a/config/config-server/resources/schemas/102_cruise-config.xsd
+++ b/config/config-server/resources/schemas/102_cruise-config.xsd
@@ -82,7 +82,7 @@
           </xsd:unique>
         </xsd:element>
       </xsd:sequence>
-      <xsd:attribute name="schemaVersion" type="xsd:int" use="required" fixed="103"/>
+      <xsd:attribute name="schemaVersion" type="xsd:int" use="required" fixed="102"/>
     </xsd:complexType>
     <xsd:unique name="uniquePipelines">
       <xsd:selector xpath="pipelines"/>
@@ -1083,7 +1083,6 @@
     <xsd:attribute name="secure" type="xsd:boolean"/>
   </xsd:complexType>
 </xsd:schema>
-
 
 
 

--- a/config/config-server/resources/upgrades/103.xsl
+++ b/config/config-server/resources/upgrades/103.xsl
@@ -1,0 +1,30 @@
+<?xml version="1.0"?>
+<!--
+  ~ Copyright 2017 ThoughtWorks, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+    <xsl:template match="/cruise/@schemaVersion">
+        <xsl:attribute name="schemaVersion">103</xsl:attribute>
+    </xsl:template>
+    <!-- Copy everything -->
+    <xsl:template match="@*|node()">
+        <xsl:copy>
+            <xsl:apply-templates select="@*|node()"/>
+        </xsl:copy>
+    </xsl:template>
+
+    <xsl:template match="agent[@elasticAgentId = preceding-sibling::agent/@elasticAgentId]"/>
+</xsl:stylesheet>

--- a/server/config/cruise-config.xml
+++ b/server/config/cruise-config.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<cruise xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="cruise-config.xsd" schemaVersion="102">
+<cruise xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="cruise-config.xsd" schemaVersion="103">
   <server artifactsdir="artifacts" agentAutoRegisterKey="323040d4-f2e4-4b8a-8394-7a2d122054d1" webhookSecret="3d5cd2f5-7fe7-43c0-ba34-7e01678ba8b6" commandRepositoryLocation="default" serverId="60f5f682-5248-4ba9-bb35-72c92841bd75" tokenGenerationKey="8c3c8dc9-08bf-4cd7-ac80-cecb3e7ae86c">
     <security>
       <authConfigs>

--- a/server/src/com/thoughtworks/go/server/controller/AgentRegistrationController.java
+++ b/server/src/com/thoughtworks/go/server/controller/AgentRegistrationController.java
@@ -233,6 +233,10 @@ public class AgentRegistrationController {
                 return new ResponseEntity<>("Elastic agents must submit both elasticAgentId and elasticPluginId.", UNPROCESSABLE_ENTITY);
             }
 
+            if (elasticAgentIdAlreadyRegistered(elasticAgentId, elasticPluginId)) {
+                return new ResponseEntity<>("Duplicate Elastic agent Id used to register elastic agent.", UNPROCESSABLE_ENTITY);
+            }
+
             if (elasticAgentAutoregistrationInfoPresent(elasticAgentId, elasticPluginId)) {
                 agentConfig.setElasticAgentId(elasticAgentId);
                 agentConfig.setElasticPluginId(elasticPluginId);
@@ -276,6 +280,10 @@ public class AgentRegistrationController {
             LOG.error("Error occurred during agent registration process: ", e);
             return new ResponseEntity<>(String.format("Error occurred during agent registration process: %s", getErrorMessage(e)), UNPROCESSABLE_ENTITY);
         }
+    }
+
+    private boolean elasticAgentIdAlreadyRegistered(String elasticAgentId, String elasticPluginId) {
+        return agentService.findElasticAgent(elasticAgentId, elasticPluginId) != null;
     }
 
     private String getErrorMessage(Exception e) {

--- a/server/test/integration/com/thoughtworks/go/config/GoConfigMigrationIntegrationTest.java
+++ b/server/test/integration/com/thoughtworks/go/config/GoConfigMigrationIntegrationTest.java
@@ -1856,18 +1856,34 @@ public class GoConfigMigrationIntegrationTest {
 
 
     @Test
-    public void shouldRemoveAgentWithDuplicateElasticAgentId_asPartOf102To103Migration() throws NoSuchMethodException, IllegalAccessException, InvocationTargetException {
+    public void shouldRemoveAgentWithDuplicateElasticAgentId_asPartOf102To103Migration() throws Exception {
         String configXml = "<cruise schemaVersion='102'>" +
                 "<agents>\n" +
                 "    <agent hostname=\"hostname\" ipaddress=\"127.0.0.1\" uuid=\"c46a08a7-921c-4e77-b748-6128975a3e7d\" elasticAgentId=\"16649813-4cb3-4682-8702-8e202824dd73\" elasticPluginId=\"elastic-plugin-id\" />\n" +
                 "    <agent hostname=\"hostname\" ipaddress=\"127.0.0.1\" uuid=\"c46a08a7-921c-4e77-b748-6128975a3e7e\" elasticAgentId=\"16649813-4cb3-4682-8702-8e202824dd73\" elasticPluginId=\"elastic-plugin-id\" />\n" +
                 "    <agent hostname=\"hostname\" ipaddress=\"127.0.0.1\" uuid=\"537d36f9-bf4b-48b2-8d09-5d20357d4f16\" elasticAgentId=\"a38d2559-0703-4e69-a30d-a21245d740af\" elasticPluginId=\"elastic-plugin-id\" />\n" +
+                "    <agent hostname=\"hostname\" ipaddress=\"127.0.0.1\" uuid=\"c46a08a7-921c-4e77-b748-6128975a3e7f\" elasticAgentId=\"16649813-4cb3-4682-8702-8e202824dd73\" elasticPluginId=\"elastic-plugin-id\" />\n" +
+                "    <agent hostname=\"hostname\" ipaddress=\"127.0.0.1\" uuid=\"537d36f9-bf4b-48b2-8d09-5d20357d4f17\" elasticAgentId=\"a38d2559-0703-4e69-a30d-a21245d740af\" elasticPluginId=\"elastic-plugin-id\" />\n" +
                 "  </agents>" +
                 "</cruise>";
 
+        //before migration should contain 5 elastic agents 3 duplicates
+        assertThat(configXml, containsString("c46a08a7-921c-4e77-b748-6128975a3e7d"));
+        assertThat(configXml, containsString("537d36f9-bf4b-48b2-8d09-5d20357d4f16"));
         assertThat(configXml, containsString("c46a08a7-921c-4e77-b748-6128975a3e7e"));
+        assertThat(configXml, containsString("c46a08a7-921c-4e77-b748-6128975a3e7f"));
+        assertThat(configXml, containsString("537d36f9-bf4b-48b2-8d09-5d20357d4f17"));
+
         String migratedContent = migrateXmlString(configXml, 102);
+
+        //after migration should contain 2 unique elastic agents
+        assertThat(configXml, containsString("c46a08a7-921c-4e77-b748-6128975a3e7d"));
+        assertThat(configXml, containsString("537d36f9-bf4b-48b2-8d09-5d20357d4f16"));
+
+        //after migration should remove 3 duplicate elastic agents
         assertThat(migratedContent, not(containsString("c46a08a7-921c-4e77-b748-6128975a3e7e")));
+        assertThat(migratedContent, not(containsString("c46a08a7-921c-4e77-b748-6128975a3e7f")));
+        assertThat(migratedContent, not(containsString("537d36f9-bf4b-48b2-8d09-5d20357d4f17")));
     }
 
     private void assertStringsIgnoringCarriageReturnAreEqual(String expected, String actual) {

--- a/server/test/integration/com/thoughtworks/go/config/GoConfigMigrationIntegrationTest.java
+++ b/server/test/integration/com/thoughtworks/go/config/GoConfigMigrationIntegrationTest.java
@@ -1854,6 +1854,22 @@ public class GoConfigMigrationIntegrationTest {
         );
     }
 
+
+    @Test
+    public void shouldRemoveAgentWithDuplicateElasticAgentId_asPartOf102To103Migration() throws NoSuchMethodException, IllegalAccessException, InvocationTargetException {
+        String configXml = "<cruise schemaVersion='102'>" +
+                "<agents>\n" +
+                "    <agent hostname=\"hostname\" ipaddress=\"127.0.0.1\" uuid=\"c46a08a7-921c-4e77-b748-6128975a3e7d\" elasticAgentId=\"16649813-4cb3-4682-8702-8e202824dd73\" elasticPluginId=\"elastic-plugin-id\" />\n" +
+                "    <agent hostname=\"hostname\" ipaddress=\"127.0.0.1\" uuid=\"c46a08a7-921c-4e77-b748-6128975a3e7e\" elasticAgentId=\"16649813-4cb3-4682-8702-8e202824dd73\" elasticPluginId=\"elastic-plugin-id\" />\n" +
+                "    <agent hostname=\"hostname\" ipaddress=\"127.0.0.1\" uuid=\"537d36f9-bf4b-48b2-8d09-5d20357d4f16\" elasticAgentId=\"a38d2559-0703-4e69-a30d-a21245d740af\" elasticPluginId=\"elastic-plugin-id\" />\n" +
+                "  </agents>" +
+                "</cruise>";
+
+        assertThat(configXml, containsString("c46a08a7-921c-4e77-b748-6128975a3e7e"));
+        String migratedContent = migrateXmlString(configXml, 102);
+        assertThat(migratedContent, not(containsString("c46a08a7-921c-4e77-b748-6128975a3e7e")));
+    }
+
     private void assertStringsIgnoringCarriageReturnAreEqual(String expected, String actual) {
         assertEquals(expected.replaceAll("\\r", ""), actual.replaceAll("\\r", ""));
     }


### PR DESCRIPTION
[Agent Registration] Do not allow agent registration if agent with same elastic agent id already exists
[XSL Migration] Add a xslt transformation to remove an agent with duplicate elastic agent id.