### PR TITLE
Fix path of logback-include.xml

### DIFF
--- a/server/properties/src/config/logback.xml
+++ b/server/properties/src/config/logback.xml
@@ -102,5 +102,5 @@
   <logger name="com.thoughtworks.go.server.Rails" level="WARN"/>
 
   <!-- make sure this is the last line in the config -->
-  <include optional="true" file="${cruise.config.file/..:-config}/logback-include.xml"/>
+  <include optional="true" file="${cruise.config.dir:-config}/logback-include.xml"/>
 </configuration>


### PR DESCRIPTION
`${cruise.config.file/..:-config}` always resolves to "config".

Even: `${cruise.config.file:-config}/..` resolves to "/etc/go/cruise-config.xml/.." which is not a valid directory.

Brought up in: https://groups.google.com/d/msg/go-cd/4cunYHhZJSE/-VclOOK2AAAJ