### PR TITLE
Include pipeline stages as part of stage status notification

### DIFF
--- a/domain/src/main/java/com/thoughtworks/go/domain/notificationdata/StageNotificationData.java
+++ b/domain/src/main/java/com/thoughtworks/go/domain/notificationdata/StageNotificationData.java
@@ -20,16 +20,19 @@ import com.thoughtworks.go.domain.Stage;
 import com.thoughtworks.go.domain.buildcause.BuildCause;
 
 import java.io.Serializable;
+import java.util.List;
 
 public class StageNotificationData implements Serializable {
     private Stage stage;
     private BuildCause buildCause;
     private String pipelineGroup;
+    private List<String> stages;
 
-    public StageNotificationData(Stage stage, BuildCause buildCause, String pipelineGroup) {
+    public StageNotificationData(Stage stage, BuildCause buildCause, String pipelineGroup, List<String> stages) {
         this.stage = stage;
         this.buildCause = buildCause;
         this.pipelineGroup = pipelineGroup;
+        this.stages = stages;
     }
 
     public Stage getStage() {
@@ -42,5 +45,9 @@ public class StageNotificationData implements Serializable {
 
     public String getPipelineGroup() {
         return pipelineGroup;
+    }
+
+    public List<String> getStages() {
+        return stages;
     }
 }

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/notification/v3/StageConverter.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/notification/v3/StageConverter.java
@@ -25,6 +25,7 @@ import com.thoughtworks.go.domain.notificationdata.StageNotificationData;
 import com.thoughtworks.go.plugin.access.notification.DataConverter;
 
 import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 
 public class StageConverter extends DataConverter<StageNotificationDTO> {
@@ -32,11 +33,13 @@ public class StageConverter extends DataConverter<StageNotificationDTO> {
     private Stage stage;
     private final String pipelineGroup;
     private final BuildCause buildCause;
+    private final List<String> stages;
 
     public StageConverter(StageNotificationData stageNotificationData) {
         this.stage = stageNotificationData.getStage();
         this.pipelineGroup = stageNotificationData.getPipelineGroup();
         this.buildCause = stageNotificationData.getBuildCause();
+        stages = stageNotificationData.getStages();
     }
 
     @Override
@@ -44,7 +47,7 @@ public class StageConverter extends DataConverter<StageNotificationDTO> {
         String pipelineName = stage.getIdentifier().getPipelineName();
         Integer pipelineCounter = stage.getIdentifier().getPipelineCounter();
         String pipelineLabel = stage.getIdentifier().getPipelineLabel();
-        StageNotificationDTO.PipelineDTO pipeline = new StageNotificationDTO.PipelineDTO(pipelineName, pipelineCounter, pipelineLabel, pipelineGroup, createBuildCause(buildCause), createStageDTO());
+        StageNotificationDTO.PipelineDTO pipeline = new StageNotificationDTO.PipelineDTO(pipelineName, pipelineCounter, pipelineLabel, pipelineGroup, createBuildCause(buildCause), createStageDTO(), stages);
         return new StageNotificationDTO(pipeline);
     }
 

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/notification/v3/StageNotificationDTO.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/notification/v3/StageNotificationDTO.java
@@ -56,16 +56,20 @@ public class StageNotificationDTO {
         @SerializedName("build-cause")
         private List<MaterialRevisionDTO> buildCause;
         @Expose
+        @SerializedName("stages")
+        private List<String> stages;
+        @Expose
         @SerializedName("stage")
         private StageDTO stage;
 
-        public PipelineDTO(String name, Integer counter, String pipelineLabel, String group, List<MaterialRevisionDTO> buildCause, StageDTO stage) {
+        public PipelineDTO(String name, Integer counter, String pipelineLabel, String group, List<MaterialRevisionDTO> buildCause, StageDTO stage, List<String> stages) {
             this.name = name;
             this.counter = counter.toString();
             this.pipelineLabel = pipelineLabel;
             this.group = group;
             this.buildCause = buildCause;
             this.stage = stage;
+            this.stages = stages;
         }
     }
 

--- a/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/notification/NotificationExtensionTestBase.java
+++ b/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/notification/NotificationExtensionTestBase.java
@@ -137,7 +137,7 @@ public abstract class NotificationExtensionTestBase {
         Result response = new Result();
         String notificationName = "notification-name";
         String jsonResponse = "json-response";
-        StageNotificationData stageNotificationData = new StageNotificationData(new Stage(), BuildCause.createWithEmptyModifications(), "group");
+        StageNotificationData stageNotificationData = new StageNotificationData(new Stage(), BuildCause.createWithEmptyModifications(), "group", null);
         when(jsonMessageHandler().requestMessageForNotify(stageNotificationData)).thenReturn(jsonResponse);
         when(jsonMessageHandler().responseMessageForNotify(RESPONSE_BODY)).thenReturn(response);
 

--- a/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/notification/v1/JsonMessageHandler1_0_Test.java
+++ b/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/notification/v1/JsonMessageHandler1_0_Test.java
@@ -255,7 +255,7 @@ public class JsonMessageHandler1_0_Test {
                 "\t}\n" +
                 "}";
 
-        String request = messageHandler.requestMessageForNotify(new StageNotificationData(pipeline.getFirstStage(), pipeline.getBuildCause(), "pipeline-group"));
+        String request = messageHandler.requestMessageForNotify(new StageNotificationData(pipeline.getFirstStage(), pipeline.getBuildCause(), "pipeline-group", null));
         JSONAssert.assertEquals(expected, request, JSONCompareMode.NON_EXTENSIBLE);
     }
 

--- a/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/notification/v2/JsonMessageHandler2_0_Test.java
+++ b/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/notification/v2/JsonMessageHandler2_0_Test.java
@@ -259,7 +259,7 @@ public class JsonMessageHandler2_0_Test {
                 "\t}\n" +
                 "}";
 
-        String request = messageHandler.requestMessageForNotify(new StageNotificationData(pipeline.getFirstStage(), pipeline.getBuildCause(), "pipeline-group"));
+        String request = messageHandler.requestMessageForNotify(new StageNotificationData(pipeline.getFirstStage(), pipeline.getBuildCause(), "pipeline-group", null));
         JSONAssert.assertEquals(expected, request, JSONCompareMode.NON_EXTENSIBLE);
     }
 

--- a/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/notification/v3/JsonMessageHandler3_0_Test.java
+++ b/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/notification/v3/JsonMessageHandler3_0_Test.java
@@ -23,7 +23,6 @@ import com.thoughtworks.go.domain.notificationdata.StageNotificationData;
 import com.thoughtworks.go.domain.packagerepository.PackageDefinition;
 import com.thoughtworks.go.domain.scm.SCM;
 import com.thoughtworks.go.helper.PipelineMother;
-import com.thoughtworks.go.plugin.access.notification.v2.JsonMessageHandler2_0;
 import com.thoughtworks.go.plugin.api.response.Result;
 import org.junit.Before;
 import org.junit.Rule;
@@ -34,10 +33,7 @@ import org.skyscreamer.jsonassert.JSONCompareMode;
 
 import java.sql.Timestamp;
 import java.text.SimpleDateFormat;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Date;
-import java.util.List;
+import java.util.*;
 
 import static com.thoughtworks.go.plugin.access.notification.v2.StageConverter.DATE_PATTERN;
 import static java.util.Arrays.asList;
@@ -238,6 +234,7 @@ public class JsonMessageHandler3_0_Test {
                 "\t\t\t\t\"data\": {}\n" +
                 "\t\t\t}]\n" +
                 "\t\t}],\n" +
+                "\"stages\": [\"stage-name\"],\n" +
                 "\t\t\"stage\": {\n" +
                 "\t\t\t\"name\": \"stage-name\",\n" +
                 "\t\t\t\"counter\": \"1\",\n" +
@@ -260,7 +257,7 @@ public class JsonMessageHandler3_0_Test {
                 "\t}\n" +
                 "}";
 
-        String request = messageHandler.requestMessageForNotify(new StageNotificationData(pipeline.getFirstStage(), pipeline.getBuildCause(), "pipeline-group"));
+        String request = messageHandler.requestMessageForNotify(new StageNotificationData(pipeline.getFirstStage(), pipeline.getBuildCause(), "pipeline-group", Collections.singletonList("stage-name")));
         JSONAssert.assertEquals(expected, request, JSONCompareMode.NON_EXTENSIBLE);
     }
 

--- a/server/src/test-fast/java/com/thoughtworks/go/server/messaging/plugin/StageStatusPluginNotifierTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/messaging/plugin/StageStatusPluginNotifierTest.java
@@ -17,9 +17,11 @@
 package com.thoughtworks.go.server.messaging.plugin;
 
 import com.thoughtworks.go.config.CaseInsensitiveString;
+import com.thoughtworks.go.config.PipelineConfig;
 import com.thoughtworks.go.domain.*;
 import com.thoughtworks.go.domain.buildcause.BuildCause;
 import com.thoughtworks.go.domain.notificationdata.StageNotificationData;
+import com.thoughtworks.go.helper.PipelineConfigMother;
 import com.thoughtworks.go.plugin.access.notification.NotificationExtension;
 import com.thoughtworks.go.plugin.access.notification.NotificationPluginRegistry;
 import com.thoughtworks.go.server.dao.PipelineSqlMapDao;
@@ -28,6 +30,8 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
+
+import java.util.Collections;
 
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
@@ -89,6 +93,7 @@ public class StageStatusPluginNotifierTest {
         when(stage.getIdentifier()).thenReturn(new StageIdentifier(pipelineName, 1, "stage", "1"));
         when(goConfigService.findGroupNameByPipeline(new CaseInsensitiveString(pipelineName))).thenReturn("group1");
         when(pipelineSqlMapDao.findBuildCauseOfPipelineByNameAndCounter(pipelineName, stage.getIdentifier().getPipelineCounter())).thenReturn(BuildCause.createManualForced());
+        when(goConfigService.pipelineConfigNamed(new CaseInsensitiveString("pipeline-name"))).thenReturn(PipelineConfigMother.createPipelineConfigWithStage(pipelineName, "stage"));
         stageStatusPluginNotifier.stageStatusChanged(stage);
 
         verify(pluginNotificationQueue).post(captor.capture());
@@ -97,6 +102,7 @@ public class StageStatusPluginNotifierTest {
         assertThat(data.getStage(), is(stage));
         assertThat(data.getBuildCause(), is(BuildCause.createManualForced()));
         assertThat(data.getPipelineGroup(), is("group1"));
+        assertThat(data.getStages(), is(Collections.singletonList("stage")));
     }
 
     @Test
@@ -106,6 +112,7 @@ public class StageStatusPluginNotifierTest {
         when(stage.isReRun()).thenReturn(true);
         when(stage.getState()).thenReturn(StageState.Unknown);
         when(stage.getIdentifier()).thenReturn(new StageIdentifier("pipeline-name", 1, "stage", "1"));
+        when(goConfigService.pipelineConfigNamed(new CaseInsensitiveString("pipeline-name"))).thenReturn(new PipelineConfig());
 
         stageStatusPluginNotifier.stageStatusChanged(stage);
 
@@ -119,6 +126,7 @@ public class StageStatusPluginNotifierTest {
         when(stage.isReRun()).thenReturn(false);
         when(stage.getState()).thenReturn(StageState.Passed);
         when(stage.getIdentifier()).thenReturn(new StageIdentifier("pipeline-name", 1, "stage", "1"));
+        when(goConfigService.pipelineConfigNamed(new CaseInsensitiveString("pipeline-name"))).thenReturn(new PipelineConfig());
 
         stageStatusPluginNotifier.stageStatusChanged(stage);
 


### PR DESCRIPTION
* With the current stage status notification message, the plugin gets
  data only for a specific stage of the pipeline. This information might
  not suffice for plugins which might collate data at a pipeline level,
  e.g analytics plugin.
* With this commit, the stage status notification message consists of
  the pipeline stage names.