### PR TITLE
Update JSON Message Handler to v2.0 so supports plugin settings change notifications for analytics plugins

### DIFF
--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/analytics/AnalyticsExtension.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/analytics/AnalyticsExtension.java
@@ -22,7 +22,7 @@ import com.thoughtworks.go.plugin.access.common.AbstractExtension;
 import com.thoughtworks.go.plugin.access.common.settings.MessageHandlerForPluginSettingsRequestProcessor;
 import com.thoughtworks.go.plugin.access.common.settings.MessageHandlerForPluginSettingsRequestProcessor1_0;
 import com.thoughtworks.go.plugin.access.common.settings.PluginSettingsJsonMessageHandler;
-import com.thoughtworks.go.plugin.access.common.settings.PluginSettingsJsonMessageHandler1_0;
+import com.thoughtworks.go.plugin.access.common.settings.PluginSettingsJsonMessageHandler2_0;
 import com.thoughtworks.go.plugin.domain.analytics.AnalyticsData;
 import com.thoughtworks.go.plugin.domain.analytics.Capabilities;
 import com.thoughtworks.go.plugin.domain.common.Image;
@@ -43,7 +43,7 @@ public class AnalyticsExtension extends AbstractExtension {
     @Autowired
     public AnalyticsExtension(PluginManager pluginManager) {
         super(pluginManager, new PluginRequestHelper(pluginManager, SUPPORTED_VERSIONS, EXTENSION_NAME), EXTENSION_NAME);
-        addHandler(AnalyticsMessageConverterV1.VERSION, new PluginSettingsJsonMessageHandler1_0(), new AnalyticsMessageConverterV1(),
+        addHandler(AnalyticsMessageConverterV1.VERSION, new PluginSettingsJsonMessageHandler2_0(), new AnalyticsMessageConverterV1(),
                 new MessageHandlerForPluginSettingsRequestProcessor1_0());
     }
 


### PR DESCRIPTION
Analytics plugins weren't reinitializing SessionFactory after the plugin settings were updated because they were never receiving the notification.