### PR TITLE
Add a feature toggle for spark routing

### DIFF
--- a/api/api-v1/src/main/java/com/thoughtworks/go/apiv1/admin/security/RolesControllerV1Delegate.java
+++ b/api/api-v1/src/main/java/com/thoughtworks/go/apiv1/admin/security/RolesControllerV1Delegate.java
@@ -26,7 +26,6 @@ import com.thoughtworks.go.server.service.EntityHashingService;
 import com.thoughtworks.go.server.service.RoleConfigService;
 import com.thoughtworks.go.server.service.result.HttpLocalizedOperationResult;
 import com.thoughtworks.go.server.util.UserHelper;
-import com.thoughtworks.go.util.SystemEnvironment;
 import gen.com.thoughtworks.go.config.representers.RoleMapper;
 import gen.com.thoughtworks.go.config.representers.RolesMapper;
 import org.springframework.http.HttpStatus;
@@ -37,7 +36,6 @@ import java.util.Collections;
 import java.util.Map;
 
 import static com.thoughtworks.go.server.api.HaltResponses.*;
-import static com.thoughtworks.go.util.SystemEnvironment.GO_SPARK_ROUTER_ENABLED;
 import static spark.Spark.*;
 
 public class RolesControllerV1Delegate extends BaseController implements CrudController<Role> {
@@ -57,9 +55,6 @@ public class RolesControllerV1Delegate extends BaseController implements CrudCon
 
     @Override
     public void setupRoutes() {
-        if (!new SystemEnvironment().get(GO_SPARK_ROUTER_ENABLED)) {
-            return;
-        }
         path(controllerPath(), () -> {
             before("", mimeType, this::setContentType);
             before("/*", mimeType, this::setContentType);

--- a/api/api-v1/src/test/groovy/com/thoughtworks/go/apiv1/admin/security/RolesControllerV1DelegateTest.groovy
+++ b/api/api-v1/src/test/groovy/com/thoughtworks/go/apiv1/admin/security/RolesControllerV1DelegateTest.groovy
@@ -50,16 +50,6 @@ class RolesControllerV1DelegateTest implements SecurityServiceTrait, ControllerT
     initMocks(this)
   }
 
-  @BeforeAll
-  static void setupRouting() {
-    SystemEnvironment.GO_SPARK_ROUTER_ENABLED.defaultValue = true
-  }
-
-  @AfterAll
-  static void disableRouting() {
-    SystemEnvironment.GO_SPARK_ROUTER_ENABLED.defaultValue = false
-  }
-
   @Mock
   private RoleConfigService roleConfigService
   @Mock

--- a/api/api/src/main/java/com/thoughtworks/go/server/api/SparkPreFilter.java
+++ b/api/api/src/main/java/com/thoughtworks/go/server/api/SparkPreFilter.java
@@ -17,6 +17,7 @@
 package com.thoughtworks.go.server.api;
 
 import com.thoughtworks.go.server.api.spring.Application;
+import com.thoughtworks.go.server.service.support.toggle.Toggles;
 import com.thoughtworks.go.server.util.ServletHelper;
 import org.springframework.web.context.WebApplicationContext;
 import org.springframework.web.context.support.WebApplicationContextUtils;
@@ -38,9 +39,15 @@ public class SparkPreFilter extends SparkFilter {
     @Override
     public void doFilter(ServletRequest req, ServletResponse resp, FilterChain chain) throws ServletException, IOException {
         HttpServletRequest request = (HttpServletRequest) req;
-        String url = request.getRequestURI().replaceAll("^/go/spark/", "/go/");
-        servletHelper.getRequest(request).setRequestURI(url);
-        super.doFilter(req, resp, chain);
+        if (Toggles.isToggleOn(Toggles.SPARK_ROUTER_ENABLED_KEY)) {
+            String url = request.getRequestURI().replaceAll("^/go/spark/", "/go/");
+            servletHelper.getRequest(request).setRequestURI(url);
+            super.doFilter(req, resp, chain);
+        } else {
+            String url = request.getRequestURI().replaceAll("^/go/spark/", "/rails/");
+            req.setAttribute("rails_bound", true);
+            req.getRequestDispatcher(url).forward(req, resp);
+        }
     }
 
     @Override

--- a/base/src/main/java/com/thoughtworks/go/util/SystemEnvironment.java
+++ b/base/src/main/java/com/thoughtworks/go/util/SystemEnvironment.java
@@ -205,7 +205,6 @@ public class SystemEnvironment implements Serializable, ConfigDirProvider {
     private static final GoSystemProperty<Boolean> GO_AGENT_USE_SSL_CONTEXT = new GoBooleanSystemProperty("go.agent.reuse.ssl.context", true);
     public static final GoSystemProperty<Boolean> ENABLE_BUILD_COMMAND_PROTOCOL = new GoBooleanSystemProperty("go.agent.enableBuildCommandProtocol", false);
     public static final GoSystemProperty<Boolean> GO_DIAGNOSTICS_MODE = new GoBooleanSystemProperty("go.diagnostics.mode", false);
-    public static final GoSystemProperty<Boolean> GO_SPARK_ROUTER_ENABLED = new GoBooleanSystemProperty("go.spark.router.enable", false);
 
     public static GoIntSystemProperty DEPENDENCY_MATERIAL_UPDATE_LISTENERS = new GoIntSystemProperty("dependency.material.check.threads", 3);
 

--- a/server/src/main/java/com/thoughtworks/go/server/service/support/toggle/Toggles.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/support/toggle/Toggles.java
@@ -23,6 +23,7 @@ public class Toggles {
     public static String PLUGIN_SPA_TOGGLE_KEY = "plugin_spa_toggle_key";
     public static String QUICKER_DASHBOARD_KEY = "quicker_dashboard_key";
     public static String ARTIFACT_EXTENSION_KEY = "artifact_extension_key";
+    public static String SPARK_ROUTER_ENABLED_KEY = "spark_router_enabled_key";
 
     private static FeatureToggleService service;
 

--- a/server/src/main/resources/available.toggles
+++ b/server/src/main/resources/available.toggles
@@ -35,6 +35,11 @@
         "key": "artifact_extension_key",
         "description": "Disable artifact extension (implicit) by disabling the pluggable artifact specific config elements",
         "value": false
+      },
+      {
+        "key": "spark_router_enabled_key",
+        "description": "Whether the spark router should be enabled",
+        "value": false
       }
   ]
 }

--- a/server/webapp/WEB-INF/urlrewrite.xml
+++ b/server/webapp/WEB-INF/urlrewrite.xml
@@ -25,16 +25,14 @@
 <urlrewrite>
     <rule>
         <name>Spark Security Auth Configs API Index API</name>
-        <from>^/api/admin/security/foo</from>
-        <set name="spark_bound">true</set>
-        <to last="true">/spark/api/admin/security/foo</to>
+        <from>^/api/admin/security/roles</from>
+        <to last="true">/spark/api/admin/security/roles</to>
     </rule>
 
     <rule>
         <name>Spark Security Auth Configs API</name>
-        <from>^/api/admin/security/foo/(.*)$</from>
-        <set name="spark_bound">true</set>
-        <to last="true">/spark/api/admin/security/foo/${escape:$1}</to>
+        <from>^/api/admin/security/roles/(.*)$</from>
+        <to last="true">/spark/api/admin/security/roles/${escape:$1}</to>
     </rule>
 
     <rule>


### PR DESCRIPTION
This adds a feature toggle that will help mitigate the risk of migrating
the roles controller from rails to spark. If the toggle is turned on,
the request will be sent to spark, else it'll be sent to rails.