### PR TITLE
* Fix enterprise build

### DIFF
--- a/settings-parent.gradle
+++ b/settings-parent.gradle
@@ -1,6 +1,14 @@
 apply from: 'settings.gradle'
 
-rootProject.children.each { project ->
+ext.resolveRelativeProjectDirPath = { project ->
   String relativeProjectPath = project.projectDir.path.replace(settingsDir.path, "")
   project.projectDir = new File("core/$relativeProjectPath")
+
+  project.getChildren().each { children ->
+    ext.resolveRelativeProjectDirPath(children)
+  }
+}
+
+rootProject.children.each { project ->
+  ext.resolveRelativeProjectDirPath(project)
 }


### PR DESCRIPTION
Recursively add all subjectprojects of each children of the rootProject

Example:

enterprise
  |:core
    |:api
      |:api-base
      |:api-roles-config-v1

change the build script to go through all the children (:api) of the project (:core) and
recursively add the subprojects of the children (:api-base, :api-roles-config-v1)