### PR TITLE
Links pipeline group name to pipeline group edit page in dashboard SPA

### DIFF
--- a/server/webapp/WEB-INF/rails.new/config/initializers/jsroutes.rb
+++ b/server/webapp/WEB-INF/rails.new/config/initializers/jsroutes.rb
@@ -19,6 +19,7 @@ JsRoutes.setup do |config|
     /^api_internal/,
     /^apiv\d/,
     /^admin_elastic_profile/,
-    /^admin_status_report/
+    /^admin_status_report/,
+    /^pipeline_groups/
   ]
 end

--- a/server/webapp/WEB-INF/rails.new/spec/webpack/models/dashboard/pipeline_groups_spec.js
+++ b/server/webapp/WEB-INF/rails.new/spec/webpack/models/dashboard/pipeline_groups_spec.js
@@ -24,6 +24,7 @@ describe("Dashboard", () => {
 
       expect(pipelineGroups.groups.length).toBe(1);
       expect(pipelineGroups.groups[0].name()).toBe(pipelineGroupsData[0].name);
+      expect(pipelineGroups.groups[0].canAdminister()).toBe(pipelineGroupsData[0].can_administer);
 
       expect(pipelineGroups.groups[0].pipelines()).toEqual(pipelineGroupsData[0].pipelines);
     });
@@ -39,7 +40,8 @@ describe("Dashboard", () => {
           }
         },
         "name":      "first",
-        "pipelines": ["up42"]
+        "pipelines": ["up42"],
+        "can_administer": true
       }
     ];
   });

--- a/server/webapp/WEB-INF/rails.new/spec/webpack/models/dashboard/pipeline_groups_spec.js
+++ b/server/webapp/WEB-INF/rails.new/spec/webpack/models/dashboard/pipeline_groups_spec.js
@@ -18,20 +18,23 @@ describe("Dashboard", () => {
   describe('Pipeline Group Model', () => {
 
     const PipelineGroups = require('models/dashboard/pipeline_groups');
+    const Routes         = require('gen/js-routes');
 
     it("should deserialize from json", () => {
       const pipelineGroups = new PipelineGroups(pipelineGroupsData);
 
       expect(pipelineGroups.groups.length).toBe(1);
-      expect(pipelineGroups.groups[0].name()).toBe(pipelineGroupsData[0].name);
+      const firstPipelineGroupName = pipelineGroupsData[0].name;
+      expect(pipelineGroups.groups[0].name()).toBe(firstPipelineGroupName);
       expect(pipelineGroups.groups[0].canAdminister()).toBe(pipelineGroupsData[0].can_administer);
+      expect(pipelineGroups.groups[0].editLink).toBe(`${Routes.pipelineGroupsPath()}#group-${firstPipelineGroupName}`);
 
       expect(pipelineGroups.groups[0].pipelines()).toEqual(pipelineGroupsData[0].pipelines);
     });
 
     const pipelineGroupsData = [
       {
-        "_links":    {
+        "_links":         {
           "self": {
             "href": "http://localhost:8153/go/api/config/pipeline_groups/first"
           },
@@ -39,8 +42,8 @@ describe("Dashboard", () => {
             "href": "https://api.go.cd/current/#pipeline-groups"
           }
         },
-        "name":      "first",
-        "pipelines": ["up42"],
+        "name":           "first",
+        "pipelines":      ["up42"],
         "can_administer": true
       }
     ];

--- a/server/webapp/WEB-INF/rails.new/spec/webpack/views/dashboard/dashboard_widget_spec.js
+++ b/server/webapp/WEB-INF/rails.new/spec/webpack/views/dashboard/dashboard_widget_spec.js
@@ -16,6 +16,7 @@
 describe("Dashboard Widget", () => {
   const m      = require("mithril");
   const Stream = require("mithril/stream");
+  const Routes = require('gen/js-routes');
 
   const DashboardWidget = require("views/dashboard/dashboard_widget");
   const Dashboard       = require('models/dashboard/dashboard');
@@ -26,143 +27,287 @@ describe("Dashboard Widget", () => {
   });
   afterEach(window.destroyDomElementForTest);
 
-  const dashboardJson = {
-    "_embedded": {
-      "pipeline_groups": [
-        {
-          "_links":    {
-            "self": {
-              "href": "http://localhost:8153/go/api/config/pipeline_groups/first"
-            },
-            "doc":  {
-              "href": "https://api.go.cd/current/#pipeline-groups"
-            }
-          },
-          "name":      "first",
-          "pipelines": ["up42"]
-        }
-      ],
-      "pipelines":       [
-        {
-          "_links":                 {
-            "self":                 {
-              "href": "http://localhost:8153/go/api/pipelines/up42/history"
-            },
-            "doc":                  {
-              "href": "https://api.go.cd/current/#pipelines"
-            },
-            "settings_path":        {
-              "href": "http://localhost:8153/go/admin/pipelines/up42/general"
-            },
-            "trigger":              {
-              "href": "http://localhost:8153/go/api/pipelines/up42/schedule"
-            },
-            "trigger_with_options": {
-              "href": "http://localhost:8153/go/api/pipelines/up42/schedule"
-            },
-            "pause":                {
-              "href": "http://localhost:8153/go/api/pipelines/up42/pause"
-            },
-            "unpause":              {
-              "href": "http://localhost:8153/go/api/pipelines/up42/unpause"
-            }
-          },
-          "name":                   "up42",
-          "last_updated_timestamp": 1510299695473,
-          "locked":                 false,
-          "pause_info":             {
-            "paused":       false,
-            "paused_by":    null,
-            "pause_reason": null
-          },
-          "_embedded":              {
-            "instances": [
-              {
-                "_links":       {
-                  "self":            {
-                    "href": "http://localhost:8153/go/api/pipelines/up42/instance/1"
-                  },
-                  "doc":             {
-                    "href": "https://api.go.cd/current/#get-pipeline-instance"
-                  },
-                  "history_url":     {
-                    "href": "http://localhost:8153/go/api/pipelines/up42/history"
-                  },
-                  "vsm_url":         {
-                    "href": "http://localhost:8153/go/pipelines/value_stream_map/up42/1"
-                  },
-                  "compare_url":     {
-                    "href": "http://localhost:8153/go/compare/up42/0/with/1"
-                  },
-                  "build_cause_url": {
-                    "href": "http://localhost:8153/go/pipelines/up42/1/build_cause"
-                  }
-                },
-                "label":        "1",
-                "scheduled_at":  "2017-11-10T07:25:28.539Z",
-                "triggered_by": "changes",
-                "_embedded":    {
-                  "stages": [
-                    {
-                      "_links":       {
-                        "self": {
-                          "href": "http://localhost:8153/go/api/stages/up42/1/up42_stage/1"
-                        },
-                        "doc":  {
-                          "href": "https://api.go.cd/current/#get-stage-instance"
-                        }
-                      },
-                      "name":         "up42_stage",
-                      "status":       "Failed",
-                      "approved_by":  "changes",
-                      "scheduled_at": "2017-11-10T07:25:28.539Z"
-                    }
-                  ]
-                }
+  describe("Pipeline group with administration permissions", () => {
+
+    const dashboardJson = {
+      "_embedded": {
+        "pipeline_groups": [
+          {
+            "_links":         {
+              "self": {
+                "href": "http://localhost:8153/go/api/config/pipeline_groups/first"
+              },
+              "doc":  {
+                "href": "https://api.go.cd/current/#pipeline-groups"
               }
-            ]
+            },
+            "name":           "first",
+            "pipelines":      ["up42"],
+            "can_administer": true
           }
-        }
-      ]
-    }
-  };
-
-  const dashboard = Stream(new Dashboard(dashboardJson));
-
-  beforeEach(() => {
-    m.mount(root, {
-      view() {
-        return m(DashboardWidget, {
-          dashboard
-        });
+        ],
+        "pipelines":       [
+          {
+            "_links":                 {
+              "self":                 {
+                "href": "http://localhost:8153/go/api/pipelines/up42/history"
+              },
+              "doc":                  {
+                "href": "https://api.go.cd/current/#pipelines"
+              },
+              "settings_path":        {
+                "href": "http://localhost:8153/go/admin/pipelines/up42/general"
+              },
+              "trigger":              {
+                "href": "http://localhost:8153/go/api/pipelines/up42/schedule"
+              },
+              "trigger_with_options": {
+                "href": "http://localhost:8153/go/api/pipelines/up42/schedule"
+              },
+              "pause":                {
+                "href": "http://localhost:8153/go/api/pipelines/up42/pause"
+              },
+              "unpause":              {
+                "href": "http://localhost:8153/go/api/pipelines/up42/unpause"
+              }
+            },
+            "name":                   "up42",
+            "last_updated_timestamp": 1510299695473,
+            "locked":                 false,
+            "pause_info":             {
+              "paused":       false,
+              "paused_by":    null,
+              "pause_reason": null
+            },
+            "_embedded":              {
+              "instances": [
+                {
+                  "_links":       {
+                    "self":            {
+                      "href": "http://localhost:8153/go/api/pipelines/up42/instance/1"
+                    },
+                    "doc":             {
+                      "href": "https://api.go.cd/current/#get-pipeline-instance"
+                    },
+                    "history_url":     {
+                      "href": "http://localhost:8153/go/api/pipelines/up42/history"
+                    },
+                    "vsm_url":         {
+                      "href": "http://localhost:8153/go/pipelines/value_stream_map/up42/1"
+                    },
+                    "compare_url":     {
+                      "href": "http://localhost:8153/go/compare/up42/0/with/1"
+                    },
+                    "build_cause_url": {
+                      "href": "http://localhost:8153/go/pipelines/up42/1/build_cause"
+                    }
+                  },
+                  "label":        "1",
+                  "scheduled_at": "2017-11-10T07:25:28.539Z",
+                  "triggered_by": "changes",
+                  "_embedded":    {
+                    "stages": [
+                      {
+                        "_links":       {
+                          "self": {
+                            "href": "http://localhost:8153/go/api/stages/up42/1/up42_stage/1"
+                          },
+                          "doc":  {
+                            "href": "https://api.go.cd/current/#get-stage-instance"
+                          }
+                        },
+                        "name":         "up42_stage",
+                        "status":       "Failed",
+                        "approved_by":  "changes",
+                        "scheduled_at": "2017-11-10T07:25:28.539Z"
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          }
+        ]
       }
+    };
+
+    const dashboard = Stream(new Dashboard(dashboardJson));
+
+    beforeEach(() => {
+      m.mount(root, {
+        view() {
+          return m(DashboardWidget, {
+            dashboard
+          });
+        }
+      });
+      m.redraw(true);
     });
-    m.redraw(true);
+
+    afterEach(() => {
+      m.mount(root, null);
+      m.redraw();
+    });
+
+    it("should render dashboard pipelines header", () => {
+      expect($root.find('.page-header')).toContainText('Pipelines');
+    });
+
+    it("should render pipeline groups", () => {
+      const pipelineGroupsCount = dashboardJson._embedded.pipeline_groups.length;
+      const pipelineGroups      = $root.find('.pipeline-group');
+
+      expect(pipelineGroups.size()).toEqual(pipelineGroupsCount);
+      expect(pipelineGroups.get(0)).toContainText(dashboardJson._embedded.pipeline_groups[0].name);
+    });
+
+    it("should render pipelines within each pipeline group", () => {
+      const pipelineName                      = dashboardJson._embedded.pipeline_groups[0].pipelines[0];
+      const pipelinesWithinPipelineGroupCount = dashboardJson._embedded.pipeline_groups[0].pipelines.length;
+      const pipelinesWithinPipelineGroup      = $root.find('.pipeline-group .pipeline');
+
+      expect(pipelinesWithinPipelineGroup.size()).toEqual(pipelinesWithinPipelineGroupCount);
+      expect(pipelinesWithinPipelineGroup).toContainText(pipelineName);
+    });
+
+    it("should link pipeline group name to pipeline group edit page", () => {
+      const pipelineGroup     = $root.find('h2 a');
+      const pipelineGroupName = dashboardJson._embedded.pipeline_groups[0].name;
+
+      expect(pipelineGroup).toExist();
+      expect(pipelineGroup).toHaveText(pipelineGroupName);
+      expect(pipelineGroup).toHaveAttr("href", `${Routes.pipelineGroupsPath()}#group-${pipelineGroupName}`);
+    });
   });
 
-  afterEach(() => {
-    m.mount(root, null);
-    m.redraw();
+  describe('Pipeline groups without admin permissions', () => {
+    const dashboardJSONWithoutAdminPermissions = {
+      "_embedded": {
+        "pipeline_groups": [
+          {
+            "_links":         {
+              "self": {
+                "href": "http://localhost:8153/go/api/config/pipeline_groups/first"
+              },
+              "doc":  {
+                "href": "https://api.go.cd/current/#pipeline-groups"
+              }
+            },
+            "name":           "NoAdminPermission",
+            "pipelines":      ["up42"],
+            "can_administer": false
+          }
+        ],
+        "pipelines":       [
+          {
+            "_links":                 {
+              "self":                 {
+                "href": "http://localhost:8153/go/api/pipelines/up42/history"
+              },
+              "doc":                  {
+                "href": "https://api.go.cd/current/#pipelines"
+              },
+              "settings_path":        {
+                "href": "http://localhost:8153/go/admin/pipelines/up42/general"
+              },
+              "trigger":              {
+                "href": "http://localhost:8153/go/api/pipelines/up42/schedule"
+              },
+              "trigger_with_options": {
+                "href": "http://localhost:8153/go/api/pipelines/up42/schedule"
+              },
+              "pause":                {
+                "href": "http://localhost:8153/go/api/pipelines/up42/pause"
+              },
+              "unpause":              {
+                "href": "http://localhost:8153/go/api/pipelines/up42/unpause"
+              }
+            },
+            "name":                   "up42",
+            "last_updated_timestamp": 1510299695473,
+            "locked":                 false,
+            "pause_info":             {
+              "paused":       false,
+              "paused_by":    null,
+              "pause_reason": null
+            },
+            "_embedded":              {
+              "instances": [
+                {
+                  "_links":       {
+                    "self":            {
+                      "href": "http://localhost:8153/go/api/pipelines/up42/instance/1"
+                    },
+                    "doc":             {
+                      "href": "https://api.go.cd/current/#get-pipeline-instance"
+                    },
+                    "history_url":     {
+                      "href": "http://localhost:8153/go/api/pipelines/up42/history"
+                    },
+                    "vsm_url":         {
+                      "href": "http://localhost:8153/go/pipelines/value_stream_map/up42/1"
+                    },
+                    "compare_url":     {
+                      "href": "http://localhost:8153/go/compare/up42/0/with/1"
+                    },
+                    "build_cause_url": {
+                      "href": "http://localhost:8153/go/pipelines/up42/1/build_cause"
+                    }
+                  },
+                  "label":        "1",
+                  "scheduled_at": "2017-11-10T07:25:28.539Z",
+                  "triggered_by": "changes",
+                  "_embedded":    {
+                    "stages": [
+                      {
+                        "_links":       {
+                          "self": {
+                            "href": "http://localhost:8153/go/api/stages/up42/1/up42_stage/1"
+                          },
+                          "doc":  {
+                            "href": "https://api.go.cd/current/#get-stage-instance"
+                          }
+                        },
+                        "name":         "up42_stage",
+                        "status":       "Failed",
+                        "approved_by":  "changes",
+                        "scheduled_at": "2017-11-10T07:25:28.539Z"
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    };
+
+    const dashboard = Stream(new Dashboard(dashboardJSONWithoutAdminPermissions));
+
+    beforeEach(() => {
+      m.mount(root, {
+        view() {
+          return m(DashboardWidget, {
+            dashboard
+          });
+        }
+      });
+      m.redraw(true);
+    });
+
+    afterEach(() => {
+      m.mount(root, null);
+      m.redraw();
+    });
+
+    it("should not link pipeline group name to pipeline group edit page", () => {
+      const pipelineGroupTitle     = $root.find('.pipeline-group-title');
+      const pipelineGroupName = dashboardJSONWithoutAdminPermissions._embedded.pipeline_groups[0].name;
+
+      expect(pipelineGroupTitle).toHaveText(pipelineGroupName);
+      expect(pipelineGroupTitle).not.toContainElement('a');
+    });
   });
 
-  it("should render dashboard pipelines header", () => {
-    expect($root.find('.page-header')).toContainText('Pipelines');
-  });
-
-  it("should render pipeline groups", () => {
-    const pipelineGroupsCount = dashboardJson._embedded.pipeline_groups.length;
-    const pipelineGroups      = $root.find('.pipeline-group');
-
-    expect(pipelineGroups.size()).toEqual(pipelineGroupsCount);
-    expect(pipelineGroups.get(0)).toContainText(dashboardJson._embedded.pipeline_groups[0].name);
-  });
-
-  it("should render pipelines within each pipeline group", () => {
-    const pipelineName                      = dashboardJson._embedded.pipeline_groups[0].pipelines[0];
-    const pipelinesWithinPipelineGroupCount = dashboardJson._embedded.pipeline_groups[0].pipelines.length;
-    const pipelinesWithinPipelineGroup      = $root.find('.pipeline-group .pipeline');
-
-    expect(pipelinesWithinPipelineGroup.size()).toEqual(pipelinesWithinPipelineGroupCount);
-    expect(pipelinesWithinPipelineGroup).toContainText(pipelineName);
-  });
 });

--- a/server/webapp/WEB-INF/rails.new/webpack/models/dashboard/pipeline_groups.js
+++ b/server/webapp/WEB-INF/rails.new/webpack/models/dashboard/pipeline_groups.js
@@ -16,11 +16,13 @@
 
 const _      = require('lodash');
 const Stream = require('mithril/stream');
+const Routes = require('gen/js-routes');
 
 const PipelineGroup = function (info) {
   this.name          = Stream(info.name);
   this.pipelines     = Stream(info.pipelines);
   this.canAdminister = Stream(info.can_administer);
+  this.editLink      = `${Routes.pipelineGroupsPath()}#group-${this.name}`;
 };
 
 const PipelineGroups = function (groups) {

--- a/server/webapp/WEB-INF/rails.new/webpack/models/dashboard/pipeline_groups.js
+++ b/server/webapp/WEB-INF/rails.new/webpack/models/dashboard/pipeline_groups.js
@@ -18,8 +18,9 @@ const _      = require('lodash');
 const Stream = require('mithril/stream');
 
 const PipelineGroup = function (info) {
-  this.name      = Stream(info.name);
-  this.pipelines = Stream(info.pipelines);
+  this.name          = Stream(info.name);
+  this.pipelines     = Stream(info.pipelines);
+  this.canAdminister = Stream(info.can_administer);
 };
 
 const PipelineGroups = function (groups) {

--- a/server/webapp/WEB-INF/rails.new/webpack/views/dashboard/dashboard_widget.js.msx
+++ b/server/webapp/WEB-INF/rails.new/webpack/views/dashboard/dashboard_widget.js.msx
@@ -17,7 +17,6 @@
 const m               = require('mithril');
 const _               = require('lodash');
 const f               = require('helpers/form_helper');
-const Routes          = require('gen/js-routes');
 const Stream          = require('mithril/stream');
 const ComponentMixins = require('helpers/mithril_component_mixins');
 const PipelineWidget  = require('views/dashboard/pipeline_widget');
@@ -33,13 +32,12 @@ const DashboardWidget = {
         );
       });
 
-      const pipelineGroupEditPath = `${Routes.pipelineGroupsPath()}#group-${pipelineGroup.name()}`;
-
       return (
         <div class="pipeline-group-wrapper">
           <div class="pipeline-group">
             <h2 class="pipeline-group-title">
-              {pipelineGroup.canAdminister() ? <a href={pipelineGroupEditPath}>{pipelineGroup.name()}</a> : pipelineGroup.name()}
+              {pipelineGroup.canAdminister() ?
+                <a href={pipelineGroup.editLink}>{pipelineGroup.name()}</a> : pipelineGroup.name()}
             </h2>
             <div>
               {pipelines}

--- a/server/webapp/WEB-INF/rails.new/webpack/views/dashboard/dashboard_widget.js.msx
+++ b/server/webapp/WEB-INF/rails.new/webpack/views/dashboard/dashboard_widget.js.msx
@@ -17,6 +17,7 @@
 const m               = require('mithril');
 const _               = require('lodash');
 const f               = require('helpers/form_helper');
+const Routes          = require('gen/js-routes');
 const Stream          = require('mithril/stream');
 const ComponentMixins = require('helpers/mithril_component_mixins');
 const PipelineWidget  = require('views/dashboard/pipeline_widget');
@@ -32,10 +33,14 @@ const DashboardWidget = {
         );
       });
 
+      const pipelineGroupEditPath = `${Routes.pipelineGroupsPath()}#group-${pipelineGroup.name()}`;
+
       return (
         <div class="pipeline-group-wrapper">
           <div class="pipeline-group">
-            <h2 class="pipeline-group-title"> {pipelineGroup.name()}</h2>
+            <h2 class="pipeline-group-title">
+              {pipelineGroup.canAdminister() ? <a href={pipelineGroupEditPath}>{pipelineGroup.name()}</a> : pipelineGroup.name()}
+            </h2>
             <div>
               {pipelines}
             </div>


### PR DESCRIPTION
Pipeline group name is linked to pipeline group edit page if user has appropriate permissions, i.e., if user is a super admin or pipeline group admin.