### PR TITLE
Sort pipelines on pipeline and environments pages.

### DIFF
--- a/server/webapp/WEB-INF/rails.new/app/views/environments/_environment.html.erb
+++ b/server/webapp/WEB-INF/rails.new/app/views/environments/_environment.html.erb
@@ -13,7 +13,7 @@
         <% if scope[:pipeline_models].empty? %>
             <span><%= l.string('NO_PIPELINES_CONFIGURED_FOR_ENVIRONMENT')-%></span>
         <% else %>
-            <% scope[:pipeline_models].each do |pipeline_model_in_environment| %>
+            <% scope[:pipeline_models].sort_by { |pipeline| pipeline.getLatestPipelineInstance().getName() }.each do |pipeline_model_in_environment| %>
                 <div id="<%= env_pipeline_dom_id(pipeline_model_in_environment) %>" class="pipeline hidereveal_collapsed">
                     <% unless scope[:omit_pipeline] %>
                         <% cache(view_cache_key.forEnvironmentPipelineBox(pipeline_model_in_environment), {:subkey => "environment_html", :skip_digest => true}) do %>

--- a/server/webapp/WEB-INF/rails.new/app/views/pipelines/_pipeline_group.html.erb
+++ b/server/webapp/WEB-INF/rails.new/app/views/pipelines/_pipeline_group.html.erb
@@ -8,7 +8,7 @@
               <h2 class="entity_title"><%= scope[:pipeline_group].getName() %></h2>
             <% end %>
             <% scope[:pipeline_models] = scope[:pipeline_group].getPipelineModels()
-               scope[:pipeline_models].each_with_index do |pipeline_model_in_pipeline_group, idx_in_pipeline_group| -%>
+               scope[:pipeline_models].sort_by { |pipeline| pipeline.getLatestPipelineInstance().getName() }.each_with_index do |pipeline_model_in_pipeline_group, idx_in_pipeline_group| -%>
 
             <% unless scope[:omit_pipeline] %>
                 <div id="<%= pipelines_pipeline_dom_id(pipeline_model_in_pipeline_group) -%>" class="pipeline">


### PR DESCRIPTION
We are currently working around this with a browser extension, if pipelines are not sorted, things start jumping around when you have lots of pipelines from lots of config-repos (we are using the yaml config plugin).