### PR TITLE
Updated web_hook_controller.rb to include gitlab@ urls

### DIFF
--- a/server/webapp/WEB-INF/rails.new/app/controllers/api/web_hooks/git_lab_controller.rb
+++ b/server/webapp/WEB-INF/rails.new/app/controllers/api/web_hooks/git_lab_controller.rb
@@ -1,5 +1,5 @@
 ##########################################################################
-# Copyright 2017 ThoughtWorks, Inc.
+# Copyright 2018 ThoughtWorks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -22,6 +22,15 @@ module Api
       before_action :verify_payload
 
       protected
+
+      def possible_urls
+        super + %W(
+          gitlab@#{repo_host_name}:#{repo_full_name}
+          gitlab@#{repo_host_name}:#{repo_full_name}/
+          gitlab@#{repo_host_name}:#{repo_full_name}.git
+          gitlab@#{repo_host_name}:#{repo_full_name}.git/
+        )
+      end
 
       def repo_branch
         payload['ref'].gsub('refs/heads/', '')

--- a/server/webapp/WEB-INF/rails.new/spec/controllers/api/web_hooks/git_lab_controller_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/controllers/api/web_hooks/git_lab_controller_spec.rb
@@ -1,5 +1,5 @@
 ##########################################################################
-# Copyright 2017 ThoughtWorks, Inc.
+# Copyright 2018 ThoughtWorks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -73,7 +73,11 @@ describe Api::WebHooks::GitLabController do
                             git@gitlab.example.com:org/repo
                             git@gitlab.example.com:org/repo/
                             git@gitlab.example.com:org/repo.git
-                            git@gitlab.example.com:org/repo.git/)
+                            git@gitlab.example.com:org/repo.git/
+                            gitlab@gitlab.example.com:org/repo
+                            gitlab@gitlab.example.com:org/repo/
+                            gitlab@gitlab.example.com:org/repo.git
+                            gitlab@gitlab.example.com:org/repo.git/)
 
         expect(@material_update_service)
           .to receive(:updateGitMaterial)


### PR DESCRIPTION
Many Gitlab installations use gitlab@ as a git user.  this was once a default user for gitlab installs.  
Due to this the urls for ssh connections from gitlab can include this user.  
Changing the user is a non trivial event.

This adds gitlab to this list so that it can be used in gocd.