### PR TITLE
Comment out the db migrations for deleting old build related data.

### DIFF
--- a/server/db/migrate/h2deltas/1801003_remove_environment_variables_for_completed_jobs.sql
+++ b/server/db/migrate/h2deltas/1801003_remove_environment_variables_for_completed_jobs.sql
@@ -14,18 +14,21 @@
 -- limitations under the License.
 --
 
-DELETE FROM environmentVariables
-WHERE environmentVariables.id IN (
-  SELECT environmentVariables.id
-  FROM environmentVariables
-  INNER JOIN builds
-  ON
-    builds.id = environmentVariables.entityId
-  WHERE
-      environmentVariables.entityType = 'Job'
-    AND
-      builds.state = 'Completed'
-);
+-- This query turned out to be time consuming on bigger db instances. Commenting it out as we plan to rethink about how we want to remove data from these tables.
+
+
+-- DELETE FROM environmentVariables
+-- WHERE environmentVariables.id IN (
+--   SELECT environmentVariables.id
+--   FROM environmentVariables
+--   INNER JOIN builds
+--   ON
+--     builds.id = environmentVariables.entityId
+--   WHERE
+--       environmentVariables.entityType = 'Job'
+--     AND
+--       builds.state = 'Completed'
+-- );
 
 --//@UNDO
 

--- a/server/db/migrate/h2deltas/1801004_remove_artifact_plans_for_completed_jobs.sql
+++ b/server/db/migrate/h2deltas/1801004_remove_artifact_plans_for_completed_jobs.sql
@@ -14,17 +14,19 @@
 -- limitations under the License.
 --
 
-DELETE FROM artifactPlans
-WHERE artifactPlans.id IN (
-  SELECT artifactPlans.id
-  FROM artifactPlans
-  INNER JOIN builds
-    ON builds.id = artifactPlans.buildId
-  WHERE
-      artifactPlans.artifactType = 'file'
-    AND
-      builds.state = 'Completed'
-);
+-- This query turned out to be time consuming on bigger db instances. Commenting it out as we plan to rethink about how we want to remove data from these tables.
+
+-- DELETE FROM artifactPlans
+-- WHERE artifactPlans.id IN (
+--   SELECT artifactPlans.id
+--   FROM artifactPlans
+--   INNER JOIN builds
+--     ON builds.id = artifactPlans.buildId
+--   WHERE
+--       artifactPlans.artifactType = 'file'
+--     AND
+--       builds.state = 'Completed'
+-- );
 
 
 --//@UNDO

--- a/server/db/migrate/h2deltas/1801005_remove_artifact_properties_generator_for_completed_jobs.sql
+++ b/server/db/migrate/h2deltas/1801005_remove_artifact_properties_generator_for_completed_jobs.sql
@@ -14,15 +14,17 @@
 -- limitations under the License.
 --
 
-DELETE FROM artifactPropertiesGenerator
-WHERE ID IN (
-  SELECT artifactPropertiesGenerator.id
-  FROM artifactPropertiesGenerator
-  INNER JOIN builds
-    ON builds.id = artifactPropertiesGenerator.jobId
-  WHERE
-    builds.state = 'Completed'
-);
+-- This query turned out to be time consuming on bigger db instances. Commenting it out as we plan to rethink about how we want to remove data from these tables.
+
+-- DELETE FROM artifactPropertiesGenerator
+-- WHERE ID IN (
+--   SELECT artifactPropertiesGenerator.id
+--   FROM artifactPropertiesGenerator
+--   INNER JOIN builds
+--     ON builds.id = artifactPropertiesGenerator.jobId
+--   WHERE
+--     builds.state = 'Completed'
+-- );
 
 --//@UNDO
 

--- a/server/db/migrate/h2deltas/1801006_remove_resources_for_completed_jobs.sql
+++ b/server/db/migrate/h2deltas/1801006_remove_resources_for_completed_jobs.sql
@@ -14,15 +14,17 @@
 -- limitations under the License.
 --
 
-DELETE FROM resources
-WHERE resources.id IN (
-  SELECT resources.id
-  FROM resources
-  INNER JOIN builds
-    ON builds.id = resources.buildId
-  WHERE
-    builds.state = 'Completed'
-);
+-- This query turned out to be time consuming on bigger db instances. Commenting it out as we plan to rethink about how we want to remove data from these tables.
+
+-- DELETE FROM resources
+-- WHERE resources.id IN (
+--   SELECT resources.id
+--   FROM resources
+--   INNER JOIN builds
+--     ON builds.id = resources.buildId
+--   WHERE
+--     builds.state = 'Completed'
+-- );
 
 --//@UNDO
 

--- a/server/db/migrate/h2deltas/1801007_remove_job_agent_metadata_for_completed_jobs.sql
+++ b/server/db/migrate/h2deltas/1801007_remove_job_agent_metadata_for_completed_jobs.sql
@@ -14,16 +14,18 @@
 -- limitations under the License.
 --
 
-DELETE FROM jobAgentMetadata
-WHERE jobAgentMetadata.id IN (
-  SELECT jobAgentMetadata.id
-  FROM jobAgentMetadata
-  INNER JOIN builds
-    ON
-      builds.id = jobAgentMetadata.jobId
-  WHERE
-    builds.state = 'Completed'
-);
+-- This query turned out to be time consuming on bigger db instances. Commenting it out as we plan to rethink about how we want to remove data from these tables.
+
+-- DELETE FROM jobAgentMetadata
+-- WHERE jobAgentMetadata.id IN (
+--   SELECT jobAgentMetadata.id
+--   FROM jobAgentMetadata
+--   INNER JOIN builds
+--     ON
+--       builds.id = jobAgentMetadata.jobId
+--   WHERE
+--     builds.state = 'Completed'
+-- );
 
 --//@UNDO
 


### PR DESCRIPTION
These queries turned out to be time consuming on bigger db instances. The environment variable table query on a postgres instance took 2.5 hours. Commenting these queries out as we plan to rethink about how we want to remove data from these tables. Cannot delete these db migration files as on already upgraded instances, the change-log table will already be updated with the migration numbers. For reference and in order to prevent any future migrations making use the same number, the content of the file is commented out and not deleted.  