### PR TITLE
Move plugin validations outside of the syncronised block for entity updates.

### DIFF
--- a/config/config-api/src/main/java/com/thoughtworks/go/config/PluginProfile.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/PluginProfile.java
@@ -73,6 +73,11 @@ public abstract class PluginProfile extends Configuration implements Validatable
         errors().add(fieldName, message);
     }
 
+    public void validateTree(ValidationContext validationContext) {
+        validate(validationContext);
+        super.validateTree();
+    }
+
     @Override
     public void validate(ValidationContext validationContext) {
         validateUniqueness(getObjectDescription() + " " + (isBlank(id) ? "(noname)" : "'" + id + "'"));

--- a/server/src/main/java/com/thoughtworks/go/config/update/ElasticAgentProfileCommand.java
+++ b/server/src/main/java/com/thoughtworks/go/config/update/ElasticAgentProfileCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 ThoughtWorks, Inc.
+ * Copyright 2018 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,7 +29,7 @@ import com.thoughtworks.go.serverhealth.HealthStateType;
 
 import java.util.Map;
 
-abstract class ElasticAgentProfileCommand extends PluginProfileCommand<ElasticProfile, ElasticProfiles> {
+public abstract class ElasticAgentProfileCommand extends PluginProfileCommand<ElasticProfile, ElasticProfiles> {
 
     private final ElasticAgentExtension extension;
 
@@ -44,7 +44,7 @@ abstract class ElasticAgentProfileCommand extends PluginProfileCommand<ElasticPr
     }
 
     @Override
-    protected ValidationResult validateUsingExtension(String pluginId, Map<String, String> configuration) {
+    public ValidationResult validateUsingExtension(String pluginId, Map<String, String> configuration) {
         return extension.validate(pluginId, configuration);
     }
 

--- a/server/src/main/java/com/thoughtworks/go/config/update/SecurityAuthConfigCommand.java
+++ b/server/src/main/java/com/thoughtworks/go/config/update/SecurityAuthConfigCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 ThoughtWorks, Inc.
+ * Copyright 2018 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,7 +29,7 @@ import com.thoughtworks.go.serverhealth.HealthStateType;
 
 import java.util.Map;
 
-abstract class SecurityAuthConfigCommand extends PluginProfileCommand<SecurityAuthConfig, SecurityAuthConfigs> {
+public abstract class SecurityAuthConfigCommand extends PluginProfileCommand<SecurityAuthConfig, SecurityAuthConfigs> {
     protected final AuthorizationExtension extension;
 
     public SecurityAuthConfigCommand(GoConfigService goConfigService, SecurityAuthConfig newSecurityAuthConfig, AuthorizationExtension extension, Username currentUser, LocalizedOperationResult result) {
@@ -43,7 +43,7 @@ abstract class SecurityAuthConfigCommand extends PluginProfileCommand<SecurityAu
     }
 
     @Override
-    protected ValidationResult validateUsingExtension(String pluginId, Map<String, String> configuration) {
+    public ValidationResult validateUsingExtension(String pluginId, Map<String, String> configuration) {
         return extension.validateAuthConfig(pluginId, configuration);
     }
 

--- a/server/src/main/java/com/thoughtworks/go/server/service/ElasticProfileService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/ElasticProfileService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 ThoughtWorks, Inc.
+ * Copyright 2018 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,7 +44,8 @@ public class ElasticProfileService extends PluginProfilesService<ElasticProfile>
     }
 
     public void update(Username currentUser, String md5, ElasticProfile newProfile, LocalizedOperationResult result) {
-        update(currentUser, newProfile, result, new ElasticAgentProfileUpdateCommand(goConfigService, newProfile, elasticAgentExtension, currentUser, result, hashingService, md5));
+        ElasticAgentProfileUpdateCommand command = new ElasticAgentProfileUpdateCommand(goConfigService, newProfile, elasticAgentExtension, currentUser, result, hashingService, md5);
+        update(currentUser, newProfile, result, command);
     }
 
     public void delete(Username currentUser, ElasticProfile elasticProfile, LocalizedOperationResult result) {
@@ -55,6 +56,7 @@ public class ElasticProfileService extends PluginProfilesService<ElasticProfile>
     }
 
     public void create(Username currentUser, ElasticProfile elasticProfile, LocalizedOperationResult result) {
-        update(currentUser, elasticProfile, result, new ElasticAgentProfileCreateCommand(goConfigService, elasticProfile, elasticAgentExtension, currentUser, result));
+        ElasticAgentProfileCreateCommand command = new ElasticAgentProfileCreateCommand(goConfigService, elasticProfile, elasticAgentExtension, currentUser, result);
+        update(currentUser, elasticProfile, result, command);
     }
 }

--- a/server/src/main/java/com/thoughtworks/go/server/service/SecurityAuthConfigService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/SecurityAuthConfigService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 ThoughtWorks, Inc.
+ * Copyright 2018 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package com.thoughtworks.go.server.service;
 
 import com.thoughtworks.go.config.SecurityAuthConfig;
 import com.thoughtworks.go.config.SecurityAuthConfigs;
+import com.thoughtworks.go.config.update.SecurityAuthConfigCommand;
 import com.thoughtworks.go.config.update.SecurityAuthConfigCreateCommand;
 import com.thoughtworks.go.config.update.SecurityAuthConfigDeleteCommand;
 import com.thoughtworks.go.config.update.SecurityAuthConfigUpdateCommand;
@@ -25,6 +26,7 @@ import com.thoughtworks.go.domain.config.ConfigurationProperty;
 import com.thoughtworks.go.plugin.access.PluginNotFoundException;
 import com.thoughtworks.go.plugin.access.authorization.AuthorizationExtension;
 import com.thoughtworks.go.plugin.access.authorization.AuthorizationMetadataStore;
+import com.thoughtworks.go.plugin.api.response.validation.ValidationResult;
 import com.thoughtworks.go.plugin.domain.authorization.AuthorizationPluginInfo;
 import com.thoughtworks.go.plugin.domain.common.ValidationError;
 import com.thoughtworks.go.plugin.domain.common.VerifyConnectionResponse;
@@ -58,12 +60,15 @@ public class SecurityAuthConfigService extends PluginProfilesService<SecurityAut
     }
 
     protected SecurityAuthConfigs getPluginProfiles() {
-        return goConfigService.serverConfig().security().securityAuthConfigs();
+        return goConfigService.security().securityAuthConfigs();
     }
 
     public void update(Username currentUser, String md5, SecurityAuthConfig newSecurityAuthConfig, LocalizedOperationResult result) {
-        update(currentUser, newSecurityAuthConfig, result, new SecurityAuthConfigUpdateCommand(goConfigService, newSecurityAuthConfig, authorizationExtension, currentUser, result, hashingService, md5));
+        SecurityAuthConfigUpdateCommand command = new SecurityAuthConfigUpdateCommand(goConfigService, newSecurityAuthConfig, authorizationExtension, currentUser, result, hashingService, md5);
+        update(currentUser, newSecurityAuthConfig, result, command);
     }
+
+
 
     public void delete(Username currentUser, SecurityAuthConfig newSecurityAuthConfig, LocalizedOperationResult result) {
         update(currentUser, newSecurityAuthConfig, result, new SecurityAuthConfigDeleteCommand(goConfigService, newSecurityAuthConfig, authorizationExtension, currentUser, result));
@@ -73,7 +78,8 @@ public class SecurityAuthConfigService extends PluginProfilesService<SecurityAut
     }
 
     public void create(Username currentUser, SecurityAuthConfig securityAuthConfig, LocalizedOperationResult result) {
-        update(currentUser, securityAuthConfig, result, new SecurityAuthConfigCreateCommand(goConfigService, securityAuthConfig, authorizationExtension, currentUser, result));
+        SecurityAuthConfigCreateCommand command = new SecurityAuthConfigCreateCommand(goConfigService, securityAuthConfig, authorizationExtension, currentUser, result);
+        update(currentUser, securityAuthConfig, result, command);
     }
 
     public VerifyConnectionResponse verifyConnection(SecurityAuthConfig securityAuthConfig) {

--- a/server/src/test-fast/java/com/thoughtworks/go/config/update/PluginProfileCommandTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/config/update/PluginProfileCommandTest.java
@@ -130,7 +130,7 @@ public class PluginProfileCommandTest {
         }
 
         @Override
-        protected ValidationResult validateUsingExtension(String pluginId, Map<String, String> configuration) {
+        public ValidationResult validateUsingExtension(String pluginId, Map<String, String> configuration) {
             return null;
         }
 

--- a/server/src/test-fast/java/com/thoughtworks/go/server/service/ElasticProfileServiceTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/service/ElasticProfileServiceTest.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright 2018 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.server.service;
+
+import com.thoughtworks.go.config.elastic.ElasticConfig;
+import com.thoughtworks.go.config.elastic.ElasticProfile;
+import com.thoughtworks.go.config.update.ElasticAgentProfileCreateCommand;
+import com.thoughtworks.go.config.update.ElasticAgentProfileDeleteCommand;
+import com.thoughtworks.go.config.update.ElasticAgentProfileUpdateCommand;
+import com.thoughtworks.go.plugin.access.PluginNotFoundException;
+import com.thoughtworks.go.plugin.access.elastic.ElasticAgentExtension;
+import com.thoughtworks.go.server.domain.Username;
+import com.thoughtworks.go.server.service.result.HttpLocalizedOperationResult;
+import org.hamcrest.Matchers;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static com.thoughtworks.go.domain.packagerepository.ConfigurationPropertyMother.create;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.*;
+
+public class ElasticProfileServiceTest {
+    private GoConfigService goConfigService;
+    private ElasticProfileService elasticProfileService;
+    private ElasticAgentExtension elasticAgentExtension;
+
+    @Before
+    public void setUp() throws Exception {
+        elasticAgentExtension = mock(ElasticAgentExtension.class);
+        EntityHashingService hashingService = mock(EntityHashingService.class);
+        goConfigService = mock(GoConfigService.class);
+        elasticProfileService = new ElasticProfileService(goConfigService, hashingService, elasticAgentExtension);
+    }
+
+    @Test
+    public void shouldReturnAnEmptyMapIfNoElasticProfiles() throws Exception {
+        ElasticConfig elasticConfig = new ElasticConfig();
+
+        when(goConfigService.getElasticConfig()).thenReturn(elasticConfig);
+
+        assertThat(elasticProfileService.listAll().isEmpty(), is(true));
+    }
+
+    @Test
+    public void shouldReturnAMapOfElasticProfiles() {
+        ElasticConfig elasticConfig = new ElasticConfig();
+        ElasticProfile elasticProfile = new ElasticProfile("ecs", "cd.go.elatic.ecs");
+        elasticConfig.getProfiles().add(elasticProfile);
+
+        when(goConfigService.getElasticConfig()).thenReturn(elasticConfig);
+
+        HashMap<String, ElasticProfile> expectedMap = new HashMap<>();
+        expectedMap.put("ecs", elasticProfile);
+        Map<String, ElasticProfile> elasticProfiles = elasticProfileService.listAll();
+        assertThat(elasticProfiles.size(), is(1));
+        assertThat(elasticProfiles, is(expectedMap));
+    }
+
+    @Test
+    public void shouldReturnNullWhenProfileWithGivenIdDoesNotExist() throws Exception {
+        when(goConfigService.getElasticConfig()).thenReturn(new ElasticConfig());
+
+        assertNull(elasticProfileService.findProfile("non-existent-id"));
+    }
+
+    @Test
+    public void shouldReturnElasticProfileWithGivenIdWhenPresent() throws Exception {
+        ElasticConfig elasticConfig = new ElasticConfig();
+        ElasticProfile elasticProfile = new ElasticProfile("ecs", "cd.go.elatic.ecs");
+        elasticConfig.getProfiles().add(elasticProfile);
+
+        when(goConfigService.getElasticConfig()).thenReturn(elasticConfig);
+
+        assertThat(elasticProfileService.findProfile("ecs"), is(elasticProfile));
+    }
+
+    @Test
+    public void shouldAddElasticProfileToConfig() {
+        ElasticProfile elasticProfile = new ElasticProfile("ldap", "cd.go.ldap");
+
+        Username username = new Username("username");
+        elasticProfileService.create(username, elasticProfile, new HttpLocalizedOperationResult());
+
+        verify(goConfigService).updateConfig(any(ElasticAgentProfileCreateCommand.class), eq(username));
+    }
+
+    @Test
+    public void shouldPerformPluginValidationsBeforeAddingElasticProfile() {
+        ElasticProfile elasticProfile = new ElasticProfile("ldap", "cd.go.ldap", create("key", false, "value"));
+
+        Username username = new Username("username");
+        elasticProfileService.create(username, elasticProfile, new HttpLocalizedOperationResult());
+
+        verify(elasticAgentExtension).validate(elasticProfile.getPluginId(), elasticProfile.getConfigurationAsMap(true));
+    }
+
+    @Test
+    public void shouldAddPluginNotFoundErrorOnConfigForANonExistentPluginIdWhileCreating() throws Exception {
+        ElasticProfile elasticProfile = new ElasticProfile("some-id", "non-existent-plugin", create("key", false, "value"));
+
+        Username username = new Username("username");
+        when(elasticAgentExtension.validate(elasticProfile.getPluginId(), elasticProfile.getConfigurationAsMap(true))).thenThrow(new PluginNotFoundException("some error"));
+
+        elasticProfileService.create(username, elasticProfile, new HttpLocalizedOperationResult());
+
+        assertThat(elasticProfile.errors().isEmpty(), Matchers.is(false));
+        assertThat(elasticProfile.errors().on("pluginId"), Matchers.is("Plugin with id `non-existent-plugin` is not found."));
+    }
+
+    @Test
+    public void shouldUpdateExistingElasticProfileInConfig() {
+        ElasticProfile elasticProfile = new ElasticProfile("ldap", "cd.go.ldap");
+
+        Username username = new Username("username");
+        elasticProfileService.update(username, "md5", elasticProfile, new HttpLocalizedOperationResult());
+
+        verify(goConfigService).updateConfig(any(ElasticAgentProfileUpdateCommand.class), eq(username));
+    }
+
+    @Test
+    public void shouldPerformPluginValidationsBeforeUpdatingElasticProfile() {
+        ElasticProfile elasticProfile = new ElasticProfile("ldap", "cd.go.ldap", create("key", false, "value"));
+
+        Username username = new Username("username");
+        elasticProfileService.update(username, "md5", elasticProfile, new HttpLocalizedOperationResult());
+
+        verify(elasticAgentExtension).validate(elasticProfile.getPluginId(), elasticProfile.getConfigurationAsMap(true));
+    }
+
+    @Test
+    public void shouldAddPluginNotFoundErrorOnConfigForANonExistentPluginIdWhileUpdating() throws Exception {
+        ElasticProfile elasticProfile = new ElasticProfile("some-id", "non-existent-plugin", create("key", false, "value"));
+
+        Username username = new Username("username");
+        when(elasticAgentExtension.validate(elasticProfile.getPluginId(), elasticProfile.getConfigurationAsMap(true))).thenThrow(new PluginNotFoundException("some error"));
+
+        elasticProfileService.update(username, "md5", elasticProfile, new HttpLocalizedOperationResult());
+
+        assertThat(elasticProfile.errors().isEmpty(), Matchers.is(false));
+        assertThat(elasticProfile.errors().on("pluginId"), Matchers.is("Plugin with id `non-existent-plugin` is not found."));
+    }
+
+    @Test
+    public void shouldDeleteExistingElasticProfileInConfig() {
+        ElasticProfile elasticProfile = new ElasticProfile("ldap", "cd.go.ldap");
+
+        Username username = new Username("username");
+        elasticProfileService.delete(username, elasticProfile, new HttpLocalizedOperationResult());
+
+        verify(goConfigService).updateConfig(any(ElasticAgentProfileDeleteCommand.class), eq(username));
+    }
+}
+


### PR DESCRIPTION
* Use validateTree method for validating entity during the entity updates.
* Show an error when encrypted value for a config property is invalid.