### PR TITLE
Do not purge pluggable-artifact-metadata folder from the go server.

### DIFF
--- a/config/config-api/src/main/java/com/thoughtworks/go/util/ArtifactLogUtil.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/util/ArtifactLogUtil.java
@@ -22,16 +22,12 @@ import java.io.File;
 
 public class ArtifactLogUtil {
     public static final String CONSOLE_LOG_FILE_NAME = "console.log";
-    public static final String SERVER_FAILURE_PAGE = "server_failure.html";
     public static final String CRUISE_OUTPUT_FOLDER = "cruise-output";
     public static final String MD5_CHECKSUM_FILENAME = "md5.checksum";
+    public static final String PLUGGABLE_ARTIFACT_METADATA_FOLDER = "pluggable-artifact-metadata";
 
     public static String getPath(long buildId) {
         return getPath(buildId, CONSOLE_LOG_FILE_NAME);
-    }
-
-    public static String getOutputFolderAndFileName(String fileName) {
-        return getOutputFolderAndFileName(fileName, File.separator);
     }
 
     public static String getConsoleOutputFolderAndFileNameUrl() {
@@ -40,10 +36,6 @@ public class ArtifactLogUtil {
 
     public static String getConsoleOutputFolderAndFileName() {
         return CRUISE_OUTPUT_FOLDER + "/" + CONSOLE_LOG_FILE_NAME;
-    }
-
-    public static String getConsoleLogOutputFolderAndFileName() {
-        return getOutputFolderAndFileName(ArtifactLogUtil.CONSOLE_LOG_FILE_NAME);
     }
 
     private static String getOutputFolderAndFileName(String fileName, String separator) {

--- a/server/src/main/java/com/thoughtworks/go/server/service/ArtifactsService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/ArtifactsService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 ThoughtWorks, Inc.
+ * Copyright 2018 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -159,7 +159,7 @@ public class ArtifactsService implements ArtifactUrlReader {
             File stageRoot = chooser.findArtifact(stageIdentifier, "");
             File cachedStageRoot = chooser.findCachedArtifact(stageIdentifier);
             deleteFile(cachedStageRoot);
-            boolean didDelete = deleteArtifactsExceptCruiseOutput(stageRoot);
+            boolean didDelete = deleteArtifactsExceptCruiseOutputAndPluggableArtifactMetadata(stageRoot);
 
             if (!didDelete) {
                 LOGGER.error("Artifacts for stage '{}' at path '{}' was not deleted", stageIdentifier.entityLocator(), stageRoot.getAbsolutePath());
@@ -171,7 +171,7 @@ public class ArtifactsService implements ArtifactUrlReader {
         LOGGER.debug("Marked stage '{}' as artifacts deleted.", stageIdentifier.entityLocator());
     }
 
-    private boolean deleteArtifactsExceptCruiseOutput(File stageRoot) throws IOException {
+    private boolean deleteArtifactsExceptCruiseOutputAndPluggableArtifactMetadata(File stageRoot) throws IOException {
         File[] jobs = stageRoot.listFiles();
         if (jobs == null) {  // null if security restricted
             throw new IOException("Failed to list contents of " + stageRoot);
@@ -185,7 +185,7 @@ public class ArtifactsService implements ArtifactUrlReader {
                 throw new IOException("Failed to list contents of " + stageRoot);
             }
             for (File artifact : artifacts) {
-                if (artifact.isDirectory() && artifact.getName().equals(ArtifactLogUtil.CRUISE_OUTPUT_FOLDER)) {
+                if (artifact.isDirectory() && (artifact.getName().equals(ArtifactLogUtil.CRUISE_OUTPUT_FOLDER) || artifact.getName().equals(ArtifactLogUtil.PLUGGABLE_ARTIFACT_METADATA_FOLDER))) {
                     continue;
                 }
                 didDelete &= deleteFile(artifact);


### PR DESCRIPTION
The cruise-output folder doesn't get purged from the go server. Retaining the same behaviour for pluggable artifact metadata.