### PR TITLE
Fix jasmine build on windows

### DIFF
--- a/server/webapp/WEB-INF/rails.new/spec/webpack/views/dashboard/material_revision_widget_spec.js
+++ b/server/webapp/WEB-INF/rails.new/spec/webpack/views/dashboard/material_revision_widget_spec.js
@@ -146,7 +146,7 @@ describe("Dashboard Material Revision Widget", () => {
 
     it('should contain a link to stage details page showing pipeline dependencies of the run of the upstream pipeline run', () => {
       const pipelineDependencyLink = $root.find('.comment a').get(0);
-      expect(pipelineDependencyLink.href.includes(`/go/pipelines/${pipelineRevisionJson.modifications[0].revision}/pipeline`)).toBe(true);
+      expect(pipelineDependencyLink.href.indexOf(`/go/pipelines/${pipelineRevisionJson.modifications[0].revision}/pipeline`)).not.toBe(-1);
     });
 
   });


### PR DESCRIPTION
* IE 11 doesnt support String.prototype.includes method.
* Replace the usage of includes with indexOf