### PR TITLE
Show pipeline scheduled at information in the readable format (#4254)

### DIFF
--- a/server/webapp/WEB-INF/rails.new/package.json
+++ b/server/webapp/WEB-INF/rails.new/package.json
@@ -19,6 +19,8 @@
     "lodash": "^4.2.1",
     "lodash-inflection": "^1.5.0",
     "mithril": "^1.1.1",
+    "moment": "^2.20.1",
+    "moment-duration-format": "^2.2.1",
     "repeat": "^0.0.6",
     "underscore.string": "^3.3.4"
   },

--- a/server/webapp/WEB-INF/rails.new/spec/webpack/models/dashboard/pipeline_instance_spec.js
+++ b/server/webapp/WEB-INF/rails.new/spec/webpack/models/dashboard/pipeline_instance_spec.js
@@ -23,7 +23,7 @@ describe("Dashboard", () => {
 
       expect(pipelineInstance.label).toBe(pipelineInstanceJson.label);
 
-      expect(pipelineInstance.scheduledAt).toEqual(new Date(pipelineInstanceJson.scheduled_at));
+      expect(pipelineInstance.scheduledAt).toEqual(pipelineInstanceJson.scheduled_at);
       expect(pipelineInstance.triggeredBy).toEqual(pipelineInstanceJson.triggered_by);
 
       expect(pipelineInstance.vsmPath).toEqual(pipelineInstanceJson._links.vsm_url.href);

--- a/server/webapp/WEB-INF/rails.new/spec/webpack/views/dashboard/pipeline_instance_widget_spec.js
+++ b/server/webapp/WEB-INF/rails.new/spec/webpack/views/dashboard/pipeline_instance_widget_spec.js
@@ -121,9 +121,9 @@ describe("Dashboard Pipeline Instance Widget", () => {
     expect($root.find('.pipeline_instance-label')).toContainText('Instance: 1');
   });
 
-  xit("should render triggered by information", () => {
-    expect($root.find('.pipeline_instance-details')).toContainText(`${  pipelineInstanceJson.triggered_by }`);
-    expect($root.find('.pipeline_instance-details')).toContainText(`on ${ new Date(pipelineInstanceJson.scheduled_at).toString()}`);
+  it("should render triggered by information", () => {
+    expect($root.find('.pipeline_instance-details')).toContainText(`${ pipelineInstanceJson.triggered_by }`);
+    expect($root.find('.pipeline_instance-details')).toContainText('on 10 Nov 2017 at 12:55:28 Local Time');
   });
 
   it("should render compare link", () => {

--- a/server/webapp/WEB-INF/rails.new/webpack/models/dashboard/pipeline_instance.js
+++ b/server/webapp/WEB-INF/rails.new/webpack/models/dashboard/pipeline_instance.js
@@ -17,7 +17,7 @@
 const _                = require('lodash');
 const MaterialRevision = require('models/dashboard/material_revision');
 
-const StageInstance    = function (json) {
+const StageInstance = function (json) {
   this.name       = json.name;
   this.status     = json.status;
   this.isBuilding = () => json.status === 'Building';
@@ -25,7 +25,7 @@ const StageInstance    = function (json) {
 
 const PipelineInstance = function (info) {
   this.label       = info.label;
-  this.scheduledAt = new Date(info.scheduled_at);
+  this.scheduledAt = info.scheduled_at;
   this.triggeredBy = info.triggered_by;
 
   this.vsmPath     = info._links.vsm_url.href;

--- a/server/webapp/WEB-INF/rails.new/webpack/views/dashboard/pipeline_instance_widget.js.msx
+++ b/server/webapp/WEB-INF/rails.new/webpack/views/dashboard/pipeline_instance_widget.js.msx
@@ -14,7 +14,9 @@
  * limitations under the License.
  */
 
-const m                     = require('mithril');
+const m      = require('mithril');
+const moment = require("moment");
+require("moment-duration-format");
 const StagesInstanceWidget  = require('views/dashboard/stages_instance_widget');
 const MaterialChangesWidget = require('views/dashboard/material_changes_widget');
 
@@ -36,6 +38,9 @@ const PipelineInstanceWidget = {
     const instance     = vnode.attrs.instance;
     const dropdown     = vnode.attrs.dropdown;
     const pipelineName = vnode.attrs.pipelineName;
+    const scheduledAt  = moment(new Date(instance.scheduledAt))
+      .format('[on] DD MMM YYYY [at] HH:mm:ss [Local Time]');
+
     return (
       <div class="pipeline_instance">
         <label class="pipeline_instance-label">Instance: {instance.label} </label>
@@ -50,7 +55,7 @@ const PipelineInstanceWidget = {
         </div>
         <div class="pipeline_instance-details">
           <div>{instance.triggeredBy}</div>
-          <div>on on 30 Jan 2018 at 09:43:25 Local Time</div>
+          <div>{scheduledAt}</div>
         </div>
         <StagesInstanceWidget stages={instance.stages}/>
       </div>

--- a/server/webapp/WEB-INF/rails.new/yarn.lock
+++ b/server/webapp/WEB-INF/rails.new/yarn.lock
@@ -2950,6 +2950,14 @@ mkdirp@0.5.x, "mkdirp@>=0.5 0", mkdirp@^0.5.1, mkdirp@~0.5.0, mkdirp@~0.5.1:
   dependencies:
     minimist "0.0.8"
 
+moment-duration-format@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/moment-duration-format/-/moment-duration-format-2.2.1.tgz#b9ce5e5051a15282a0a6c361f0c05685c7ead47c"
+
+moment@^2.20.1:
+  version "2.20.1"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.20.1.tgz#d6eb1a46cbcc14a2b2f9434112c1ff8907f313fd"
+
 ms@0.7.1:
   version "0.7.1"
   resolved "https://registry.yarnpkg.com/ms/-/ms-0.7.1.tgz#9cd13c03adbff25b65effde7ce864ee952017098"


### PR DESCRIPTION
**Note**: On the older pipelines page, the `scheduled_at` date formatting is done [here](https://github.com/gocd/gocd/blob/master/server/webapp/WEB-INF/rails.new/app/views/pipelines/index.html.erb#L29) using [moment](https://github.com/gocd/gocd/blob/master/server/webapp/WEB-INF/rails.new/app/assets/javascripts/lib/moment-2.18.1.js) and [moment-duration-format](https://github.com/gocd/gocd/blob/master/server/webapp/WEB-INF/rails.new/app/assets/javascripts/lib/moment-duration-format-1.3.0.js)

* Add `moment` and `moment-duration-format` to package.json.