### PR TITLE
Implement Pipeline Unpause Operation (#4081) (#4254)

### DIFF
--- a/server/webapp/WEB-INF/rails.new/spec/webpack/views/dashboard/model/dashboard_view_model_spec.js
+++ b/server/webapp/WEB-INF/rails.new/spec/webpack/views/dashboard/model/dashboard_view_model_spec.js
@@ -24,7 +24,7 @@ describe("Dashboard View Model", () => {
     it('should initialize dropdown states for all the pipelines', () => {
       dashboardVM = new DashboardVM(pipelineNames);
 
-      expect(dashboardVM.dropdown.size()).toEqual(2);
+      expect(dashboardVM.size()).toEqual(2);
     });
 
     it('should initialize dropdown states as close initially', () => {
@@ -59,6 +59,77 @@ describe("Dashboard View Model", () => {
       expect(dashboardVM.dropdown.isDropDownOpen('up42')).toEqual(true);
       dashboardVM.dropdown.hideAll();
       expect(dashboardVM.dropdown.isDropDownOpen('up42')).toEqual(false);
+    });
+  });
+
+  describe('Operation Messages', () => {
+    const pipelineNames = ['up42', 'up43'];
+
+    beforeEach(() => {
+      jasmine.clock().install();
+    });
+
+    afterEach(() => {
+      jasmine.clock().uninstall();
+    });
+
+    let dashboardVM;
+    it('should initialize pipeline operation messages states for all the pipelines', () => {
+      dashboardVM = new DashboardVM(pipelineNames);
+
+      expect(dashboardVM.size()).toEqual(2);
+    });
+
+    it('should initialize pipeline operation messages states as empty initially', () => {
+      dashboardVM = new DashboardVM(pipelineNames);
+
+      expect(dashboardVM.operationMessages.messageFor('up42')).toEqual(undefined);
+      expect(dashboardVM.operationMessages.messageTypeFor('up42')).toEqual(undefined);
+    });
+
+    it('should set pipeline operation success messages', () => {
+      dashboardVM = new DashboardVM(pipelineNames);
+
+      expect(dashboardVM.operationMessages.messageFor('up42')).toEqual(undefined);
+      expect(dashboardVM.operationMessages.messageTypeFor('up42')).toEqual(undefined);
+
+      const message = 'message';
+      dashboardVM.operationMessages.success('up42', message);
+
+      expect(dashboardVM.operationMessages.messageFor('up42')).toEqual(message);
+      expect(dashboardVM.operationMessages.messageTypeFor('up42')).toEqual('success');
+    });
+
+
+    it('should set pipeline operation failure messages', () => {
+      dashboardVM = new DashboardVM(pipelineNames);
+
+      expect(dashboardVM.operationMessages.messageFor('up42')).toEqual(undefined);
+      expect(dashboardVM.operationMessages.messageTypeFor('up42')).toEqual(undefined);
+
+      const message = 'message';
+      dashboardVM.operationMessages.failure('up42', message);
+
+      expect(dashboardVM.operationMessages.messageFor('up42')).toEqual(message);
+      expect(dashboardVM.operationMessages.messageTypeFor('up42')).toEqual('error');
+    });
+
+    it('should clear message after timeout interval', () => {
+      dashboardVM = new DashboardVM(pipelineNames);
+
+      expect(dashboardVM.operationMessages.messageFor('up42')).toEqual(undefined);
+      expect(dashboardVM.operationMessages.messageTypeFor('up42')).toEqual(undefined);
+
+      const message = 'message';
+      dashboardVM.operationMessages.failure('up42', message);
+
+      expect(dashboardVM.operationMessages.messageFor('up42')).toEqual(message);
+      expect(dashboardVM.operationMessages.messageTypeFor('up42')).toEqual('error');
+
+      jasmine.clock().tick(5001);
+
+      expect(dashboardVM.operationMessages.messageFor('up42')).toEqual(undefined);
+      expect(dashboardVM.operationMessages.messageTypeFor('up42')).toEqual(undefined);
     });
   });
 });

--- a/server/webapp/WEB-INF/rails.new/webpack/helpers/spark_routes.js
+++ b/server/webapp/WEB-INF/rails.new/webpack/helpers/spark_routes.js
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2018 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+module.exports = {
+  pipelinePausePath: (pipelineName) => {
+    return `/go/api/pipelines/${pipelineName}/pause`;
+  },
+
+  pipelineUnpausePath: (pipelineName) => {
+    return `/go/api/pipelines/${pipelineName}/unpause`;
+  }
+};

--- a/server/webapp/WEB-INF/rails.new/webpack/views/dashboard/dashboard_widget.js.msx
+++ b/server/webapp/WEB-INF/rails.new/webpack/views/dashboard/dashboard_widget.js.msx
@@ -39,7 +39,7 @@ const DashboardWidget = {
         return (
           <PipelineWidget pipeline={vnode.attrs.dashboard.findPipeline(pipelineName)}
                           isQuickEditPageEnabled={vnode.attrs.isQuickEditPageEnabled}
-                          dropdown={vnode.attrs.vm.dropdown}/>
+                          vm={vnode.attrs.vm}/>
         );
       });
 

--- a/server/webapp/WEB-INF/rails.new/webpack/views/dashboard/pipeline_widget.js.msx
+++ b/server/webapp/WEB-INF/rails.new/webpack/views/dashboard/pipeline_widget.js.msx
@@ -19,6 +19,54 @@ const _ = require('lodash');
 
 const PipelineInstanceWidget = require('views/dashboard/pipeline_instance_widget');
 
+const PipelineOperationsWidget = {
+  oninit(vnode) {
+    const self              = vnode.state;
+    const operationMessages = vnode.attrs.operationMessages;
+    const pipeline          = vnode.attrs.pipeline;
+
+    self.unpause = () => {
+      pipeline.unpause().then((res) => {
+        operationMessages.success(pipeline.name, res.message);
+      }, (res) => {
+        operationMessages.failure(pipeline.name, res.responseJSON.message);
+      });
+    };
+  },
+
+  view(vnode) {
+    const pipeline          = vnode.attrs.pipeline;
+    const operationMessages = vnode.attrs.operationMessages;
+
+    let pauseUnpauseButton, pausedMessage;
+    if (pipeline.isPaused) {
+      pauseUnpauseButton = (<button onclick={vnode.state.unpause} className="btn unpause"/>);
+      pausedMessage      = `Paused by ${pipeline.pausedBy} (${pipeline.pausedCause})`;
+    } else {
+      pauseUnpauseButton = (<button className="btn pause"/>);
+    }
+
+    let flashMessage;
+    if (operationMessages.messageFor(pipeline.name)) {
+      flashMessage = (<div class={`pipeline_message ${operationMessages.messageTypeFor(pipeline.name)}`}>
+        <p>{operationMessages.messageFor(pipeline.name)}</p>
+      </div>);
+    }
+
+    return (
+      <div>
+        {flashMessage}
+        <ul className="pipeline_operations">
+          <li><button className="btn play"/></li>
+          <li><button className="btn play_with_options"/></li>
+          <li>{pauseUnpauseButton}</li>
+        </ul>
+        <div className="pipeline_pause-message">{pausedMessage}</div>
+      </div>
+    );
+  }
+};
+
 const PipelineHeaderWidget = {
   view: (vnode) => {
     const pipeline = vnode.attrs.pipeline;
@@ -39,21 +87,9 @@ const PipelineHeaderWidget = {
           {settingsButton}
           <button className="pipeline_locked"/>
         </div>
-        <div class="pipeline_message success">
-          <p>Pipeline up42 paused successfully.</p>
-        </div>
-        <ul className="pipeline_operations">
-          <li>
-            <button className="btn play"></button>
-          </li>
-          <li>
-            <button className="btn play_with_options"></button>
-          </li>
-          <li>
-            <button className="btn pause"></button>
-          </li>
-        </ul>
-        <div className="pipeline_pause-message">Paused by admin (this is paused due to something)</div>
+        <PipelineOperationsWidget pipeline={pipeline}
+                                  operationMessages={vnode.attrs.vm.operationMessages}
+                                  dashboard={vnode.attrs.dashboard}/>
       </div>
     );
   }
@@ -70,7 +106,7 @@ const PipelineWidget = {
     const pipelineInstances = _.map(pipeline.instances, (instance) => {
       return (
         <PipelineInstanceWidget instance={instance}
-                                dropdown={vnode.attrs.dropdown}
+                                dropdown={vnode.attrs.vm.dropdown}
                                 pipelineName={pipeline.name}/>
       );
     });
@@ -79,6 +115,7 @@ const PipelineWidget = {
       <li class="pipeline-group_pipeline">
         <div class="pipeline">
           <PipelineHeaderWidget pipeline={vnode.attrs.pipeline}
+                                vm={vnode.attrs.vm}
                                 isQuickEditPageEnabled={vnode.attrs.isQuickEditPageEnabled}/>
           <div className="pipeline_instances">
             {pipelineInstances}


### PR DESCRIPTION
* Use pipeline operations versioned api to unpause a pipeline
* Store the flashmessage state as part of dashboard vm
* Clear flash message after timeout
* Show pause or unpause button based on the state of pipeline (paused/unpaused)