### PR TITLE
Add an (internal) trigger with options view API (#4233)

### DIFF
--- a/api/api-trigger-with-options-view-v1/build.gradle
+++ b/api/api-trigger-with-options-view-v1/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2018 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+apply plugin: 'org.junit.platform.gradle.plugin'
+apply plugin: 'jacoco'
+apply plugin: 'groovy'
+
+apply from: rootProject.file('buildSrc/junit5-support.gradle')
+
+dependencies {
+  compile project(':api:api-base')
+
+  testCompile project(path: ':api:api-base', configuration: 'testOutput')
+}

--- a/api/api-trigger-with-options-view-v1/src/main/java/com/thoughtworks/go/apiv1/triggerwithoptionsview/TriggerWithOptionsViewDelegate.java
+++ b/api/api-trigger-with-options-view-v1/src/main/java/com/thoughtworks/go/apiv1/triggerwithoptionsview/TriggerWithOptionsViewDelegate.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2018 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.apiv1.triggerwithoptionsview;
+
+
+import com.thoughtworks.go.api.ApiController;
+import com.thoughtworks.go.api.ApiVersion;
+import com.thoughtworks.go.api.spring.ApiAuthenticationHelper;
+import com.thoughtworks.go.api.util.GsonTransformer;
+import com.thoughtworks.go.apiv1.triggerwithoptionsview.representers.TriggerOptions;
+import com.thoughtworks.go.apiv1.triggerwithoptionsview.representers.TriggerWithOptionsViewRepresenter;
+import com.thoughtworks.go.config.EnvironmentVariablesConfig;
+import com.thoughtworks.go.config.exceptions.RecordNotFoundException;
+import com.thoughtworks.go.presentation.pipelinehistory.PipelineInstanceModel;
+import com.thoughtworks.go.server.service.GoConfigService;
+import com.thoughtworks.go.server.service.PipelineHistoryService;
+import com.thoughtworks.go.spark.RequestContext;
+import com.thoughtworks.go.spark.Routes;
+import spark.Request;
+import spark.Response;
+
+import java.util.Map;
+
+import static spark.Spark.*;
+
+public class TriggerWithOptionsViewDelegate extends ApiController {
+    private final ApiAuthenticationHelper apiAuthenticationHelper;
+    private final GoConfigService goConfigService;
+    private final PipelineHistoryService pipelineHistoryService;
+
+    public TriggerWithOptionsViewDelegate(ApiAuthenticationHelper apiAuthenticationHelper, GoConfigService goConfigService, PipelineHistoryService pipelineHistoryService) {
+        super(ApiVersion.v1);
+        this.apiAuthenticationHelper = apiAuthenticationHelper;
+        this.goConfigService = goConfigService;
+        this.pipelineHistoryService = pipelineHistoryService;
+    }
+
+    @Override
+    public String controllerBasePath() {
+        return Routes.TriggerWithOptionsView.BASE;
+    }
+
+    @Override
+    public void setupRoutes() {
+        path(controllerBasePath(), () -> {
+            before("", mimeType, this::setContentType);
+            before("/*", mimeType, this::setContentType);
+
+            before("", mimeType, apiAuthenticationHelper::checkUserAnd401);
+            before("/*", mimeType, apiAuthenticationHelper::checkUserAnd401);
+
+            get("/:pipeline_name", this::index, GsonTransformer.getInstance());
+
+            exception(RecordNotFoundException.class, this::notFound);
+        });
+    }
+
+    public Map<String, Object> index(Request request, Response response) {
+        String pipelineName = request.params("pipeline_name");
+
+        EnvironmentVariablesConfig variables = goConfigService.variablesFor(pipelineName);
+        PipelineInstanceModel pipelineInstanceModel = pipelineHistoryService.latest(pipelineName, currentUsername());
+
+        TriggerOptions triggerOptions = new TriggerOptions(variables, pipelineInstanceModel);
+        return TriggerWithOptionsViewRepresenter.toJSON(triggerOptions, RequestContext.requestContext(request));
+    }
+}

--- a/api/api-trigger-with-options-view-v1/src/main/java/com/thoughtworks/go/apiv1/triggerwithoptionsview/representers/TriggerOptions.java
+++ b/api/api-trigger-with-options-view-v1/src/main/java/com/thoughtworks/go/apiv1/triggerwithoptionsview/representers/TriggerOptions.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2018 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.apiv1.triggerwithoptionsview.representers;
+
+import com.thoughtworks.go.config.EnvironmentVariablesConfig;
+import com.thoughtworks.go.presentation.pipelinehistory.PipelineInstanceModel;
+
+public class TriggerOptions {
+    private final EnvironmentVariablesConfig variables;
+    private final PipelineInstanceModel pipelineInstanceModel;
+
+    public TriggerOptions(EnvironmentVariablesConfig variables, PipelineInstanceModel pipelineInstanceModel) {
+        this.variables = variables;
+        this.pipelineInstanceModel = pipelineInstanceModel;
+    }
+
+    public EnvironmentVariablesConfig getVariables() {
+        return variables;
+    }
+
+    public PipelineInstanceModel getPipelineInstanceModel() {
+        return pipelineInstanceModel;
+    }
+}

--- a/api/api-trigger-with-options-view-v1/src/main/java/com/thoughtworks/go/apiv1/triggerwithoptionsview/representers/TriggerWithOptionsViewRepresenter.java
+++ b/api/api-trigger-with-options-view-v1/src/main/java/com/thoughtworks/go/apiv1/triggerwithoptionsview/representers/TriggerWithOptionsViewRepresenter.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2018 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.apiv1.triggerwithoptionsview.representers;
+
+import com.thoughtworks.go.api.representers.JsonWriter;
+import com.thoughtworks.go.config.materials.dependency.DependencyMaterialConfig;
+import com.thoughtworks.go.domain.MaterialRevision;
+import com.thoughtworks.go.domain.materials.MaterialConfig;
+import com.thoughtworks.go.presentation.pipelinehistory.PipelineInstanceModel;
+import com.thoughtworks.go.spark.RequestContext;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class TriggerWithOptionsViewRepresenter {
+    public static Map<String, Object> toJSON(TriggerOptions triggerOptions, RequestContext requestContext) {
+        List<Map<String, Object>> variablesJson = triggerOptions.getVariables().stream().map(env -> new JsonWriter(null)
+                .add("name", env.getName())
+                .add("secure", env.isSecure())
+                .addIfNotNull("value", env.getDisplayValue())
+                .getAsMap()).collect(Collectors.toList());
+
+        return new JsonWriter(requestContext)
+                .add("variables", variablesJson)
+                .add("materials", materials(triggerOptions.getPipelineInstanceModel()))
+                .getAsMap();
+    }
+
+    private static List<Map<String, Object>> materials(PipelineInstanceModel pipelineInstanceModel) {
+        return pipelineInstanceModel.getMaterials().stream().map((MaterialConfig material) -> {
+            MaterialRevision revision = pipelineInstanceModel.findCurrentMaterialRevisionForUI(material);
+            return new JsonWriter(null)
+                    .add("type", material.getTypeForDisplay())
+                    .add("name", material.getDisplayName())
+                    .add("fingerprint", material.getFingerprint())
+                    .addIfNotNull("folder", material.getFolder())
+                    .add("revision", revision(material, revision))
+                    .getAsMap();
+        }).collect(Collectors.toList());
+    }
+
+    private static Map<String, Object> revision(MaterialConfig material, MaterialRevision revision) {
+        if (revision == null) {
+            return Collections.emptyMap();
+        }
+
+        String maybePipelineLabel = null;
+
+        if (material instanceof DependencyMaterialConfig) {
+            maybePipelineLabel = revision.getLatestModification().getPipelineLabel();
+        }
+
+        return new JsonWriter(null)
+                .addIfNotNull("date", revision.getDateOfLatestModification())
+                .addIfNotNull("user", revision.getLatestUser())
+                .addIfNotNull("comment", revision.getLatestComment())
+                .addIfNotNull("last_run_revision", revision.getLatestRevisionString())
+                .addIfNotNull("label", maybePipelineLabel)
+                .getAsMap();
+    }
+}

--- a/api/api-trigger-with-options-view-v1/src/main/java/com/thoughtworks/go/apiv1/triggerwithoptionsview/spring/TriggerWithOptionsViewController.java
+++ b/api/api-trigger-with-options-view-v1/src/main/java/com/thoughtworks/go/apiv1/triggerwithoptionsview/spring/TriggerWithOptionsViewController.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2018 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.apiv1.triggerwithoptionsview.spring;
+
+import com.thoughtworks.go.api.spring.ApiAuthenticationHelper;
+import com.thoughtworks.go.apiv1.triggerwithoptionsview.TriggerWithOptionsViewDelegate;
+import com.thoughtworks.go.server.service.GoConfigService;
+import com.thoughtworks.go.server.service.PipelineHistoryService;
+import com.thoughtworks.go.spark.spring.SparkSpringController;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class TriggerWithOptionsViewController implements SparkSpringController {
+    private final TriggerWithOptionsViewDelegate delegate;
+
+    @Autowired
+    public TriggerWithOptionsViewController(ApiAuthenticationHelper apiAuthenticationHelper, GoConfigService goConfigService, PipelineHistoryService pipelineHistoryService) {
+        delegate = new TriggerWithOptionsViewDelegate(apiAuthenticationHelper, goConfigService, pipelineHistoryService);
+    }
+
+    @Override
+    public void setupRoutes() {
+        delegate.setupRoutes();
+    }
+}

--- a/api/api-trigger-with-options-view-v1/src/test/groovy/com/thoughtworks/go/apiv1/triggerwithoptionsview/TriggerWithOptionsViewDelegateTest.groovy
+++ b/api/api-trigger-with-options-view-v1/src/test/groovy/com/thoughtworks/go/apiv1/triggerwithoptionsview/TriggerWithOptionsViewDelegateTest.groovy
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2018 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.apiv1.triggerwithoptionsview
+
+import com.thoughtworks.go.api.SecurityTestTrait
+import com.thoughtworks.go.api.spring.ApiAuthenticationHelper
+import com.thoughtworks.go.apiv1.triggerwithoptionsview.representers.TriggerOptions
+import com.thoughtworks.go.apiv1.triggerwithoptionsview.representers.TriggerWithOptionsViewRepresenter
+import com.thoughtworks.go.config.EnvironmentVariablesConfig
+import com.thoughtworks.go.config.PipelineNotFoundException
+import com.thoughtworks.go.domain.JobResult
+import com.thoughtworks.go.domain.JobState
+import com.thoughtworks.go.domain.MaterialRevisions
+import com.thoughtworks.go.domain.buildcause.BuildCause
+import com.thoughtworks.go.helper.EnvironmentVariablesConfigMother
+import com.thoughtworks.go.helper.MaterialConfigsMother
+import com.thoughtworks.go.helper.MaterialsMother
+import com.thoughtworks.go.helper.ModificationsMother
+import com.thoughtworks.go.presentation.pipelinehistory.JobHistory
+import com.thoughtworks.go.presentation.pipelinehistory.PipelineInstanceModel
+import com.thoughtworks.go.presentation.pipelinehistory.StageInstanceModels
+import com.thoughtworks.go.server.service.PipelineHistoryService
+import com.thoughtworks.go.spark.ControllerTrait
+import com.thoughtworks.go.spark.SecurityServiceTrait
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+import static com.thoughtworks.go.api.util.HaltApiMessages.notFoundMessage
+import static org.mockito.Mockito.mock
+import static org.mockito.Mockito.when
+
+class TriggerWithOptionsViewDelegateTest implements ControllerTrait<TriggerWithOptionsViewDelegate>, SecurityServiceTrait {
+  PipelineHistoryService pipelineHistoryService = mock(PipelineHistoryService.class)
+
+  @Nested
+  class Index {
+
+    @Nested
+    class Security implements SecurityTestTrait {
+
+      @Test
+      void 'should allow all with security disabled'() {
+        disableSecurity()
+
+        makeHttpCall()
+        assertRequestAuthorized()
+      }
+
+      @Test
+      void "should disallow anonymous users, with security enabled"() {
+        enableSecurity()
+        loginAsAnonymous()
+
+        makeHttpCall()
+
+        assertRequestNotAuthorized()
+      }
+
+      @Test
+      void 'should allow normal users, with security enabled'() {
+        enableSecurity()
+        loginAsUser()
+
+        makeHttpCall()
+        assertRequestAuthorized()
+      }
+
+
+      @Override
+      String getControllerMethodUnderTest() {
+        return "index"
+      }
+
+      @Override
+      void makeHttpCall() {
+        getWithApiHeader(controller.controllerPath("build-linux"))
+      }
+    }
+
+    @Nested
+    class AsAuthorizedUser {
+      @Test
+      void 'should render trigger options'() {
+        MaterialRevisions revisions = ModificationsMother.modifyOneFile(MaterialsMother.defaultSvnMaterialsWithUrl("http://example.com/svn/project"), "revision")
+
+        StageInstanceModels stages = new StageInstanceModels()
+        stages.addStage("unit1", JobHistory.withJob("test", JobState.Completed, JobResult.Passed, new Date()))
+        stages.addFutureStage("unit2", false)
+
+        PipelineInstanceModel model = PipelineInstanceModel.createPipeline("pipeline", -1, "label", BuildCause.createWithModifications(revisions, "bob"), stages)
+        model.setMaterialConfigs(MaterialConfigsMother.defaultSvnMaterialConfigsWithUrl("http://example.com/svn/project"))
+
+        EnvironmentVariablesConfig variables = EnvironmentVariablesConfigMother.environmentVariables()
+
+        when(goConfigService.variablesFor("build-linux")).thenReturn(variables)
+        when(pipelineHistoryService.latest("build-linux", currentUsername())).thenReturn(model)
+
+        getWithApiHeader(controller.controllerPath("build-linux"))
+
+        assertThatResponse()
+          .isOk()
+          .hasContentType(controller.mimeType)
+          .hasJsonBodySerializedWith(new TriggerOptions(variables, model), TriggerWithOptionsViewRepresenter.class)
+      }
+
+      @Test
+      void 'should render 404 if bad pipeline is provided'() {
+        when(goConfigService.variablesFor("pipeline-that-is-not-present")).thenThrow(new PipelineNotFoundException())
+
+        getWithApiHeader(controller.controllerPath("pipeline-that-is-not-present"))
+
+        assertThatResponse()
+          .isNotFound()
+          .hasContentType(controller.mimeType)
+          .hasJsonMessage(notFoundMessage())
+      }
+    }
+  }
+
+  @Override
+  TriggerWithOptionsViewDelegate createControllerInstance() {
+    return new TriggerWithOptionsViewDelegate(new ApiAuthenticationHelper(securityService, goConfigService), goConfigService, pipelineHistoryService)
+  }
+}

--- a/api/api-trigger-with-options-view-v1/src/test/groovy/com/thoughtworks/go/apiv1/triggerwithoptionsview/representers/TriggerWithOptionsViewRepresenterTest.groovy
+++ b/api/api-trigger-with-options-view-v1/src/test/groovy/com/thoughtworks/go/apiv1/triggerwithoptionsview/representers/TriggerWithOptionsViewRepresenterTest.groovy
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2018 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.apiv1.triggerwithoptionsview.representers
+
+import com.thoughtworks.go.config.EnvironmentVariablesConfig
+import com.thoughtworks.go.domain.JobResult
+import com.thoughtworks.go.domain.JobState
+import com.thoughtworks.go.domain.MaterialRevisions
+import com.thoughtworks.go.domain.buildcause.BuildCause
+import com.thoughtworks.go.helper.EnvironmentVariablesConfigMother
+import com.thoughtworks.go.helper.MaterialConfigsMother
+import com.thoughtworks.go.helper.MaterialsMother
+import com.thoughtworks.go.helper.ModificationsMother
+import com.thoughtworks.go.presentation.pipelinehistory.JobHistory
+import com.thoughtworks.go.presentation.pipelinehistory.PipelineInstanceModel
+import com.thoughtworks.go.presentation.pipelinehistory.StageInstanceModels
+import net.javacrumbs.jsonunit.fluent.JsonFluentAssert
+import org.junit.jupiter.api.Test
+
+class TriggerWithOptionsViewRepresenterTest {
+  @Test
+  void 'renders json'() {
+    MaterialRevisions revisions = ModificationsMother.modifyOneFile(MaterialsMother.defaultSvnMaterialsWithUrl("http://example.com/svn/project"), "revision")
+
+    StageInstanceModels stages = new StageInstanceModels()
+    stages.addStage("unit1", JobHistory.withJob("test", JobState.Completed, JobResult.Passed, new Date()))
+    stages.addFutureStage("unit2", false)
+
+    PipelineInstanceModel model = PipelineInstanceModel.createPipeline("pipeline", -1, "label", BuildCause.createWithModifications(revisions, "bob"), stages)
+    model.setMaterialConfigs(MaterialConfigsMother.defaultSvnMaterialConfigsWithUrl("http://example.com/svn/project"))
+
+    EnvironmentVariablesConfig variables = EnvironmentVariablesConfigMother.environmentVariables()
+
+    def actualJson = TriggerWithOptionsViewRepresenter.toJSON(new TriggerOptions(variables, model), null)
+    JsonFluentAssert.assertThatJson(actualJson).isEqualTo([
+      "variables": [
+        ["name": "MULTIPLE_LINES", "secure": true, "value": "****"],
+        ["name": "COMPLEX", "secure": false, "value": "This has very <complex> data"]
+      ],
+      "materials": [
+        [
+          "type"       : "Subversion", "name": "http___example.com_svn_project",
+          "fingerprint": "f5f52bd94f0eaed410d7ca7843e0d8c693b2d6daf91fe037d55b566e862dcdae",
+          "folder"     : "svnDir",
+          "revision"   : [
+            "date"             : ModificationsMother.TWO_DAYS_AGO_CHECKIN,
+            "user"             : "lgao",
+            "comment"          : "Fixing the not checked in files",
+            "last_run_revision": "revision"
+          ]
+        ]
+      ]
+    ])
+  }
+}

--- a/server/webapp/WEB-INF/applicationContext-global.xml
+++ b/server/webapp/WEB-INF/applicationContext-global.xml
@@ -40,6 +40,7 @@
     <context:component-scan base-package="com.thoughtworks.go.apiv1.currentuser.spring"/>
     <context:component-scan base-package="com.thoughtworks.go.apiv1.admin.backups.spring"/>
     <context:component-scan base-package="com.thoughtworks.go.apiv1.serverhealthmessages.spring"/>
+    <context:component-scan base-package="com.thoughtworks.go.apiv1.triggerwithoptionsview.spring"/>
 
     <context:component-scan base-package="com.thoughtworks.go.util"/>
     <context:component-scan base-package="com.thoughtworks.go.serverhealth"/>

--- a/server/webapp/WEB-INF/urlrewrite.xml
+++ b/server/webapp/WEB-INF/urlrewrite.xml
@@ -24,6 +24,12 @@
 -->
 <urlrewrite>
     <rule>
+        <name>Trigger With Options View API</name>
+        <from>^/api/internal/trigger_with_options_view/(.*)$</from>
+        <to last="true">/spark/api/internal/trigger_with_options_view/${escape:$1}</to>
+    </rule>
+
+    <rule>
         <name>Spark Server Health Messages API</name>
         <from>^/api/server_health_messages</from>
         <to last="true">/spark/api/server_health_messages</to>

--- a/settings.gradle
+++ b/settings.gradle
@@ -16,7 +16,7 @@
 
 rootProject.name = 'gocd'
 include ':jar-class-loader'
-include ':api:api-backups-v1', ':api:api-base', ':api:api-current-user-v1', ':api:api-dashboard-v2', ':api:api-encryption-v1', ':api:api-pipeline-operations-v1', ':api:api-plugin-images', ':api:api-roles-config-v1', ':api:api-server-health-messages-v1', ':api:api-user-representers-v1' // this line is managed by the `newApi` task
+include ':api:api-backups-v1', ':api:api-base', ':api:api-current-user-v1', ':api:api-dashboard-v2', ':api:api-encryption-v1', ':api:api-pipeline-operations-v1', ':api:api-plugin-images', ':api:api-roles-config-v1', ':api:api-server-health-messages-v1', ':api:api-trigger-with-options-view-v1', ':api:api-user-representers-v1' // this line is managed by the `newApi` task
 include ':spark:spark-base'
 include ':spark:spark-spa'
 include ':base'

--- a/spark/spark-base/src/main/java/com/thoughtworks/go/spark/RequestContext.java
+++ b/spark/spark-base/src/main/java/com/thoughtworks/go/spark/RequestContext.java
@@ -40,15 +40,14 @@ public class RequestContext {
     }
 
     public Link build(String name, String template, Object... args) {
+        return new Link(name, urlFor(template, args));
+    }
+
+    public String urlFor(String template, Object... args) {
         try {
-            String href = String.format(template, args);
-            return getLink(name, href);
+            return new URL(protocol, host, port, contextPath + String.format(template, args)).toExternalForm();
         } catch (MalformedURLException e) {
             throw new RuntimeException(e);
         }
-    }
-
-    private Link getLink(String name, String href) throws MalformedURLException {
-        return new Link(name, new URL(protocol, host, port, contextPath +  href).toExternalForm());
     }
 }

--- a/spark/spark-base/src/main/java/com/thoughtworks/go/spark/Routes.java
+++ b/spark/spark-base/src/main/java/com/thoughtworks/go/spark/Routes.java
@@ -163,4 +163,8 @@ public class Routes {
     public class ServerHealthMessages {
         public static final String BASE = "/api/server_health_messages";
     }
+
+    public class TriggerWithOptionsView {
+        public static final String BASE = "/api/internal/trigger_with_options_view";
+    }
 }


### PR DESCRIPTION
```bash
curl 'http://localhost:8153/go/api/internal/trigger_with_options_view/installers' \
     -H 'Accept: application/vnd.go.cd.v1+json' 
```

```json
{
  "variables": [
    {
      "name": "TZ",
      "secure": false,
      "value": "Asia/Calcutta"
    },
    {
      "name": "COMMAND_REPO_USER",
      "secure": true,
      "value": "****"
    }
  ],
  "materials": [
    {
      "type": "Git",
      "name": "gocd",
      "fingerprint": "21f6ea93b72144560a90ad9398e67c5c9f0f7c6cdf03e022a7fc2445bd8a3f2b",
      "revision": {
        "date": "2017-11-30T21:43:36Z",
        "user": "Ketan Padegaonkar <KetanPadegaonkar@example.com>",
        "comment": "Remove dead code",
        "last_run_revision": "a6ab0a1d67176cbacde21a29f9b9b778c655e88c"
      }
    },
    {
      "type": "Pipeline",
      "name": "go-plugins",
      "fingerprint": "27d90165af38fb34741346ed91245b3ef1095af66ca81bffdc297ace1c0420f5",
      "revision": {
        "date": "2017-12-01T05:29:17Z",
        "user": "anonymous",
        "last_run_revision": "plugins/1407/build/1",
        "label": "1407"
      }
    }
  ]
}
```