### PR TITLE
Material Search internal API for use on Trigger With Options screen

### DIFF
--- a/api/api-material-search-v1/build.gradle
+++ b/api/api-material-search-v1/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2018 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+apply plugin: 'org.junit.platform.gradle.plugin'
+apply plugin: 'jacoco'
+apply plugin: 'groovy'
+
+apply from: rootProject.file('buildSrc/junit5-support.gradle')
+
+dependencies {
+  compile project(':api:api-base')
+
+  testCompile project(path: ':api:api-base', configuration: 'testOutput')
+}

--- a/api/api-material-search-v1/src/main/java/com/thoughtworks/go/apiv1/materialsearch/MaterialSearchControllerDelegate.java
+++ b/api/api-material-search-v1/src/main/java/com/thoughtworks/go/apiv1/materialsearch/MaterialSearchControllerDelegate.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2018 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.apiv1.materialsearch;
+
+
+import com.thoughtworks.go.api.ApiController;
+import com.thoughtworks.go.api.ApiVersion;
+import com.thoughtworks.go.api.spring.ApiAuthenticationHelper;
+import com.thoughtworks.go.api.util.GsonTransformer;
+import com.thoughtworks.go.apiv1.materialsearch.representers.MatchedRevisionRepresenter;
+import com.thoughtworks.go.domain.materials.MatchedRevision;
+import com.thoughtworks.go.i18n.Localizer;
+import com.thoughtworks.go.server.service.MaterialService;
+import com.thoughtworks.go.server.service.result.HttpLocalizedOperationResult;
+import com.thoughtworks.go.spark.Routes;
+import spark.Request;
+import spark.Response;
+
+import java.util.List;
+
+import static com.thoughtworks.go.spark.RequestContext.requestContext;
+import static spark.Spark.*;
+
+public class MaterialSearchControllerDelegate extends ApiController {
+
+    private final MaterialService materialService;
+    private final ApiAuthenticationHelper apiAuthenticationHelper;
+    private final Localizer localizer;
+
+    public MaterialSearchControllerDelegate(MaterialService materialService, ApiAuthenticationHelper apiAuthenticationHelper, Localizer localizer) {
+        super(ApiVersion.v1);
+        this.materialService = materialService;
+        this.apiAuthenticationHelper = apiAuthenticationHelper;
+        this.localizer = localizer;
+    }
+
+    @Override
+    public String controllerBasePath() {
+        return Routes.MaterialSearch.BASE;
+    }
+
+    @Override
+    public void setupRoutes() {
+        path(controllerBasePath(), () -> {
+            before("", this::setContentType);
+            before("/*", this::setContentType);
+
+            before("", mimeType, apiAuthenticationHelper::checkPipelineGroupOperateUserAnd401);
+            before("/*", mimeType, apiAuthenticationHelper::checkPipelineGroupOperateUserAnd401);
+
+            get("", this::search, GsonTransformer.getInstance());
+            head("", this::search, GsonTransformer.getInstance());
+        });
+    }
+
+    public Object search(Request request, Response response) {
+        String pipelineName = request.queryParams("pipeline_name");
+        String fingerprint = request.queryParams("fingerprint");
+        String searchText = request.queryParamOrDefault("search_text", "");
+        HttpLocalizedOperationResult result = new HttpLocalizedOperationResult();
+        List<MatchedRevision> matchedRevisions = materialService.searchRevisions(pipelineName, fingerprint, searchText, currentUsername(), result);
+        if(result.isSuccessful()) {
+            return MatchedRevisionRepresenter.toJSON(matchedRevisions, requestContext(request));
+        }
+        return renderHTTPOperationResult(result, response, localizer);
+    }
+}

--- a/api/api-material-search-v1/src/main/java/com/thoughtworks/go/apiv1/materialsearch/representers/MatchedRevisionRepresenter.java
+++ b/api/api-material-search-v1/src/main/java/com/thoughtworks/go/apiv1/materialsearch/representers/MatchedRevisionRepresenter.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2018 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.apiv1.materialsearch.representers;
+
+import com.thoughtworks.go.api.representers.JsonWriter;
+import com.thoughtworks.go.domain.materials.MatchedRevision;
+import com.thoughtworks.go.spark.RequestContext;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class MatchedRevisionRepresenter {
+
+    public static List<Map> toJSON(List<MatchedRevision> matchedRevisions, RequestContext requestContext) {
+        return matchedRevisions.stream()
+                .map(matchedRevision -> MatchedRevisionRepresenter.toJSON(matchedRevision, requestContext))
+                .collect(Collectors.toList());
+    }
+
+    public static Map toJSON(MatchedRevision matchedRevision, RequestContext requestContext) {
+        return new JsonWriter(requestContext)
+                .add("revision", matchedRevision.getLongRevision())
+                .addIfNotNull("user", matchedRevision.getUser())
+                .addIfNotNull("date", matchedRevision.getCheckinTime())
+                .add("comment", matchedRevision.getComment())
+                .getAsMap();
+    }
+
+}

--- a/api/api-material-search-v1/src/main/java/com/thoughtworks/go/apiv1/materialsearch/spring/MaterialSearchController.java
+++ b/api/api-material-search-v1/src/main/java/com/thoughtworks/go/apiv1/materialsearch/spring/MaterialSearchController.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2018 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.apiv1.materialsearch.spring;
+
+import com.thoughtworks.go.api.spring.ApiAuthenticationHelper;
+import com.thoughtworks.go.apiv1.materialsearch.MaterialSearchControllerDelegate;
+import com.thoughtworks.go.i18n.Localizer;
+import com.thoughtworks.go.server.service.MaterialService;
+import com.thoughtworks.go.spark.spring.SparkSpringController;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class MaterialSearchController implements SparkSpringController {
+    private final MaterialSearchControllerDelegate delegate;
+
+    @Autowired
+    public MaterialSearchController(MaterialService materialService, ApiAuthenticationHelper apiAuthenticationHelper, Localizer localizer) {
+        delegate = new MaterialSearchControllerDelegate(materialService, apiAuthenticationHelper, localizer);
+    }
+
+    @Override
+    public void setupRoutes() {
+        delegate.setupRoutes();
+    }
+}

--- a/api/api-material-search-v1/src/test/groovy/com/thoughtworks/go/apiv1/materialsearch/MaterialSearchControllerDelegateTest.groovy
+++ b/api/api-material-search-v1/src/test/groovy/com/thoughtworks/go/apiv1/materialsearch/MaterialSearchControllerDelegateTest.groovy
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2018 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.apiv1.materialsearch
+
+import com.thoughtworks.go.api.SecurityTestTrait
+import com.thoughtworks.go.api.spring.ApiAuthenticationHelper
+import com.thoughtworks.go.apiv1.materialsearch.representers.MatchedRevisionRepresenter
+import com.thoughtworks.go.domain.materials.MatchedRevision
+import com.thoughtworks.go.i18n.LocalizedKeyValueMessage
+import com.thoughtworks.go.i18n.LocalizedMessage
+import com.thoughtworks.go.server.domain.Username
+import com.thoughtworks.go.server.service.MaterialService
+import com.thoughtworks.go.server.service.result.HttpLocalizedOperationResult
+import com.thoughtworks.go.server.service.result.LocalizedOperationResult
+import com.thoughtworks.go.serverhealth.HealthStateScope
+import com.thoughtworks.go.serverhealth.HealthStateType
+import com.thoughtworks.go.spark.ControllerTrait
+import com.thoughtworks.go.spark.PipelineGroupOperateUserSecurity
+import com.thoughtworks.go.spark.SecurityServiceTrait
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.mockito.ArgumentMatchers
+import org.mockito.Mock
+import org.mockito.invocation.InvocationOnMock
+
+import static org.mockito.ArgumentMatchers.any
+import static org.mockito.ArgumentMatchers.eq
+import static org.mockito.Mockito.when
+import static org.mockito.MockitoAnnotations.initMocks
+
+class MaterialSearchControllerDelegateTest implements ControllerTrait<MaterialSearchControllerDelegate>, SecurityServiceTrait {
+
+  @Mock
+  MaterialService materialService;
+
+  @BeforeEach
+  void setup() {
+    initMocks(this);
+  }
+
+  @Override
+  MaterialSearchControllerDelegate createControllerInstance() {
+    return new MaterialSearchControllerDelegate(materialService, new ApiAuthenticationHelper(securityService, goConfigService), localizer);
+  }
+
+  @Nested
+  class Security implements SecurityTestTrait, PipelineGroupOperateUserSecurity {
+
+    @Override
+    String getControllerMethodUnderTest() {
+      return "search"
+    }
+
+    @Override
+    void makeHttpCall() {
+      getWithApiHeader(controller.controllerPath([fingerprint: 'foo', pipeline_name: 'some-pipeline', search_text: 'abc']))
+    }
+  }
+
+  @Nested
+  class Search {
+
+    @Test
+    void 'should show search results'() {
+      def matchedRevisions = [new MatchedRevision("abc", "9ea1cf", "9ea1cf0ae04be6088242a5b6275ed36eadfcf205", "username", commitDate, "commit message"),
+                              new MatchedRevision("abc", "pipeline/1/stage/1", pipelineDate, "label")]
+      when(materialService.searchRevisions(eq("some-pipeline") as String, eq("foo") as String, eq("abc") as String,
+        ArgumentMatchers.any() as Username, ArgumentMatchers.any() as LocalizedOperationResult))
+        .thenReturn(matchedRevisions)
+
+      getWithApiHeader(controller.controllerPath([fingerprint: 'foo', pipeline_name: 'some-pipeline', search_text: 'abc']))
+
+      assertThatResponse()
+        .isOk()
+        .hasContentType(controller.mimeType)
+        .hasJsonBodySerializedWith(matchedRevisions, MatchedRevisionRepresenter.class)
+    }
+  }
+
+  @Test
+  void 'should render result when not found'() {
+    when(materialService.searchRevisions(any(), any(), any(), any(), any())).then({ InvocationOnMock invocation ->
+      HttpLocalizedOperationResult result = invocation.getArguments().last()
+      result.notFound(LocalizedMessage.materialWithFingerPrintNotFound("pipeline-name", "fingerprint"),
+        HealthStateType.general(HealthStateScope.forPipeline("pipeline-name")))
+    })
+    when(localizer.localize(LocalizedKeyValueMessage.MATERIAL_WITH_FINGERPRINT_NOT_FOUND, "pipeline-name", "fingerprint"))
+      .thenReturn("No results")
+
+    getWithApiHeader(controller.controllerPath([fingerprint: 'foo', pipeline_name: 'some-pipeline', search_text: 'abc']))
+
+    assertThatResponse()
+      .isNotFound()
+      .hasContentType(controller.mimeType)
+      .hasJsonMessage("No results")
+  }
+}

--- a/api/api-material-search-v1/src/test/groovy/com/thoughtworks/go/apiv1/materialsearch/representers/MatchedRevisionRepresenterTest.groovy
+++ b/api/api-material-search-v1/src/test/groovy/com/thoughtworks/go/apiv1/materialsearch/representers/MatchedRevisionRepresenterTest.groovy
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2018 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.apiv1.materialsearch.representers
+
+import com.thoughtworks.go.domain.materials.MatchedRevision
+import com.thoughtworks.go.spark.mocks.TestRequestContext
+import org.junit.jupiter.api.Test
+
+import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson
+
+class MatchedRevisionRepresenterTest {
+
+  @Test
+  void 'should create json'() {
+    def commitDate = new Date()
+    def pipelineDate = new Date();
+    def matchedRevisions = [
+      new MatchedRevision("abc", "9ea1cf", "9ea1cf0ae04be6088242a5b6275ed36eadfcf205", "username", commitDate, "commit message"),
+      new MatchedRevision("abc", "pipeline/1/stage/1", pipelineDate, "label")
+    ]
+    def actualJson = MatchedRevisionRepresenter.toJSON(matchedRevisions, new TestRequestContext());
+
+    assertThatJson(actualJson).isEqualTo([
+      [
+        "revision": "9ea1cf0ae04be6088242a5b6275ed36eadfcf205",
+        "user"    : "username",
+        "date"    : commitDate,
+        "comment" : "commit message"
+      ],
+      [
+        "revision": "pipeline/1/stage/1",
+        "date"    : pipelineDate,
+        "comment" : "label"
+      ]
+    ])
+  }
+
+}

--- a/server/webapp/WEB-INF/applicationContext-global.xml
+++ b/server/webapp/WEB-INF/applicationContext-global.xml
@@ -41,6 +41,7 @@
     <context:component-scan base-package="com.thoughtworks.go.apiv1.admin.backups.spring"/>
     <context:component-scan base-package="com.thoughtworks.go.apiv1.serverhealthmessages.spring"/>
     <context:component-scan base-package="com.thoughtworks.go.apiv1.triggerwithoptionsview.spring"/>
+    <context:component-scan base-package="com.thoughtworks.go.apiv1.materialsearch.spring"/>
 
     <context:component-scan base-package="com.thoughtworks.go.util"/>
     <context:component-scan base-package="com.thoughtworks.go.serverhealth"/>

--- a/server/webapp/WEB-INF/urlrewrite.xml
+++ b/server/webapp/WEB-INF/urlrewrite.xml
@@ -24,6 +24,12 @@
 -->
 <urlrewrite>
     <rule>
+        <name>Material Search API</name>
+        <from>^/api/internal/material_search$</from>
+        <to last="true">/spark/api/internal/material_search</to>
+    </rule>
+
+    <rule>
         <name>Trigger With Options View API</name>
         <from>^/api/internal/trigger_with_options_view/(.*)$</from>
         <to last="true">/spark/api/internal/trigger_with_options_view/${escape:$1}</to>

--- a/settings.gradle
+++ b/settings.gradle
@@ -16,7 +16,7 @@
 
 rootProject.name = 'gocd'
 include ':jar-class-loader'
-include ':api:api-backups-v1', ':api:api-base', ':api:api-current-user-v1', ':api:api-dashboard-v2', ':api:api-encryption-v1', ':api:api-pipeline-operations-v1', ':api:api-plugin-images', ':api:api-roles-config-v1', ':api:api-server-health-messages-v1', ':api:api-trigger-with-options-view-v1', ':api:api-user-representers-v1' // this line is managed by the `newApi` task
+include ':api:api-backups-v1', ':api:api-base', ':api:api-current-user-v1', ':api:api-dashboard-v2', ':api:api-encryption-v1', ':api:api-material-search-v1', ':api:api-pipeline-operations-v1', ':api:api-plugin-images', ':api:api-roles-config-v1', ':api:api-server-health-messages-v1', ':api:api-trigger-with-options-view-v1', ':api:api-user-representers-v1' // this line is managed by the `newApi` task
 include ':spark:spark-base'
 include ':spark:spark-spa'
 include ':base'

--- a/spark/spark-base/src/main/java/com/thoughtworks/go/spark/Routes.java
+++ b/spark/spark-base/src/main/java/com/thoughtworks/go/spark/Routes.java
@@ -167,4 +167,8 @@ public class Routes {
     public class TriggerWithOptionsView {
         public static final String BASE = "/api/internal/trigger_with_options_view";
     }
+
+    public class MaterialSearch {
+        public static final String BASE = "/api/internal/material_search";
+    }
 }


### PR DESCRIPTION
```
curl http://localhost:8153/go/api/internal/material_search?pipeline_name=up42&fingerprint=cd0c88fc85a2e4e377e83e31e3e0538a7386768e0de2653f56b5b45474165845&search_text=something -H 'Accept: application/vnd.go.cd.v1+json'
```

```
[
  {
    "revision": "92385c780e7d89db9a3aaeae573b1756fbe6c6b2",
    "user": "Akshay Dewan <akudewan@gmail.com>",
    "date": "2014-07-08T14:16:26Z",
    "comment": "Adding visualizer and knock sensor"
  }
]
```

```
[
  {
    "revision": "up42/3/up42_stage/1",
    "date": "2018-02-02T09:19:37Z",
    "comment": "3"
  }
]
```