### PR TITLE
Do not expose GoDashboardCache internal data structure for access (#4121)

### DIFF
--- a/server/src/main/java/com/thoughtworks/go/domain/cctray/CcTrayCache.java
+++ b/server/src/main/java/com/thoughtworks/go/domain/cctray/CcTrayCache.java
@@ -19,7 +19,10 @@ package com.thoughtworks.go.domain.cctray;
 import com.thoughtworks.go.domain.activity.ProjectStatus;
 import org.springframework.stereotype.Component;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 
 /* Understands how to cache CcTray statuses, for every stage and job (project). */
 @Component
@@ -38,7 +41,7 @@ public class CcTrayCache {
         this.orderedEntries = new ArrayList<>();
     }
 
-    public ProjectStatus get(String projectName) {
+    ProjectStatus get(String projectName) {
         return cache.get(projectName);
     }
 
@@ -52,7 +55,7 @@ public class CcTrayCache {
         cacheHasChanged();
     }
 
-    public void replaceAllEntriesInCacheWith(List<ProjectStatus> projectStatuses) {
+    void replaceAllEntriesInCacheWith(List<ProjectStatus> projectStatuses) {
         this.cache.clear();
         this.cache.putAll(createReplacementItems(projectStatuses));
         cacheHasChanged();

--- a/server/src/main/java/com/thoughtworks/go/server/dashboard/GoDashboardCache.java
+++ b/server/src/main/java/com/thoughtworks/go/server/dashboard/GoDashboardCache.java
@@ -20,7 +20,10 @@ import com.thoughtworks.go.config.CaseInsensitiveString;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
-import java.util.*;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 
 /* Understands how to cache dashboard statuses, for every pipeline. */
 @Component
@@ -39,11 +42,7 @@ public class GoDashboardCache {
     public GoDashboardCache(TimeStampBasedCounter timeStampBasedCounter) {
         this.timeStampBasedCounter = timeStampBasedCounter;
         cache = new LinkedHashMap<>();
-        dashboardPipelines = new GoDashboardPipelines(new ArrayList<>(), timeStampBasedCounter);
-    }
-
-    public GoDashboardPipeline get(CaseInsensitiveString pipelineName) {
-        return cache.get(pipelineName);
+        dashboardPipelines = new GoDashboardPipelines(new HashMap<>(), timeStampBasedCounter);
     }
 
     public void put(GoDashboardPipeline pipeline) {
@@ -57,12 +56,12 @@ public class GoDashboardCache {
         cacheHasChanged();
     }
 
-    public GoDashboardPipelines allEntriesInOrder() {
+    public GoDashboardPipelines allEntries() {
         return dashboardPipelines;
     }
 
     private void cacheHasChanged() {
-        dashboardPipelines = new GoDashboardPipelines(new ArrayList<>(cache.values()), timeStampBasedCounter);
+        dashboardPipelines = new GoDashboardPipelines(new HashMap<>(cache), timeStampBasedCounter);
     }
 
     private Map<CaseInsensitiveString, GoDashboardPipeline> createMapFor(List<GoDashboardPipeline> pipelines) {

--- a/server/src/main/java/com/thoughtworks/go/server/dashboard/GoDashboardPipelines.java
+++ b/server/src/main/java/com/thoughtworks/go/server/dashboard/GoDashboardPipelines.java
@@ -16,23 +16,25 @@
 
 package com.thoughtworks.go.server.dashboard;
 
-import java.util.List;
+import com.thoughtworks.go.config.CaseInsensitiveString;
+
+import java.util.HashMap;
 
 public class GoDashboardPipelines {
-    private List<GoDashboardPipeline> orderedEntries;
+    private HashMap<CaseInsensitiveString, GoDashboardPipeline> pipelines;
     private long lastUpdatedTimeStamp;
 
-    public GoDashboardPipelines(List<GoDashboardPipeline> orderedEntries, TimeStampBasedCounter timeStampBasedCounter) {
-        this.orderedEntries = orderedEntries;
+    public GoDashboardPipelines(HashMap<CaseInsensitiveString, GoDashboardPipeline> pipelines, TimeStampBasedCounter timeStampBasedCounter) {
+        this.pipelines = pipelines;
         this.lastUpdatedTimeStamp = timeStampBasedCounter.getNext();
-    }
-
-    public List<GoDashboardPipeline> orderedEntries() {
-        return orderedEntries;
     }
 
     public long lastUpdatedTimeStamp() {
         return lastUpdatedTimeStamp;
+    }
+
+    public GoDashboardPipeline find(CaseInsensitiveString name) {
+        return pipelines.get(name);
     }
 }
 

--- a/server/src/test-fast/java/com/thoughtworks/go/server/dashboard/GoDashboardCacheTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/dashboard/GoDashboardCacheTest.java
@@ -20,8 +20,6 @@ import com.thoughtworks.go.config.CaseInsensitiveString;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.util.List;
-
 import static com.thoughtworks.go.server.dashboard.GoDashboardPipelineMother.pipeline;
 import static java.util.Arrays.asList;
 import static org.hamcrest.core.Is.is;
@@ -40,34 +38,34 @@ public class GoDashboardCacheTest {
     }
 
     @Test
-    public void shouldNotBeAbleToGetAPipelineWhichDoesNotExist() throws Exception {
-        assertNull(cache.get(cis("pipeline1")));
+    public void shouldNotBeAbleToGetAPipelineWhichDoesNotExist() {
+        assertNull(cache.allEntries().find(cis("pipeline1")));
     }
 
     @Test
-    public void shouldBeAbleToPutAndGetAPipeline() throws Exception {
+    public void shouldBeAbleToPutAndGetAPipeline() {
         GoDashboardPipeline expectedPipeline = pipeline("pipeline1");
 
         cache.put(expectedPipeline);
-        GoDashboardPipeline actualPipeline = cache.get(cis("pipeline1"));
+        GoDashboardPipeline actualPipeline = cache.allEntries().find(cis("pipeline1"));
 
         assertThat(expectedPipeline, is(sameInstance(actualPipeline)));
     }
 
     @Test
-    public void shouldBeAbleToReplaceAnItemInCache() throws Exception {
+    public void shouldBeAbleToReplaceAnItemInCache() {
         GoDashboardPipeline somePipelineWhichWillBeReplaced = pipeline("pipeline1");
         GoDashboardPipeline expectedPipeline = pipeline("pipeline1");
 
         cache.put(somePipelineWhichWillBeReplaced);
         cache.put(expectedPipeline);
-        GoDashboardPipeline actualPipeline = cache.get(cis("pipeline1"));
+        GoDashboardPipeline actualPipeline = cache.allEntries().find(cis("pipeline1"));
 
         assertThat(expectedPipeline, is(sameInstance(actualPipeline)));
     }
 
     @Test
-    public void shouldBeAbleToClearExistingCacheAndReplaceAllItemsInIt() throws Exception {
+    public void shouldBeAbleToClearExistingCacheAndReplaceAllItemsInIt() {
         GoDashboardPipeline pipeline1 = pipeline("pipeline1");
         GoDashboardPipeline pipeline2 = pipeline("pipeline2");
         GoDashboardPipeline pipeline3 = pipeline("pipeline3");
@@ -82,46 +80,11 @@ public class GoDashboardCacheTest {
 
         cache.replaceAllEntriesInCacheWith(asList(pipeline3, newPipeline4, pipeline5));
 
-        assertThat(cache.get(cis("pipeline1")), is(nullValue()));
-        assertThat(cache.get(cis("pipeline2")), is(nullValue()));
-        assertThat(cache.get(cis("pipeline3")), is(sameInstance(pipeline3)));
-        assertThat(cache.get(cis("pipeline4")), is(sameInstance(newPipeline4)));
-        assertThat(cache.get(cis("pipeline5")), is(sameInstance(pipeline5)));
-    }
-
-    @Test
-    public void shouldProvideAnOrderedListOfAllItemsInCache() throws Exception {
-        GoDashboardPipeline pipeline1 = pipeline("pipeline1");
-        GoDashboardPipeline pipeline2 = pipeline("pipeline2");
-        GoDashboardPipeline pipeline3 = pipeline("pipeline3");
-
-        cache.replaceAllEntriesInCacheWith(asList(pipeline1, pipeline2, pipeline3));
-        List<GoDashboardPipeline> allPipelines = cache.allEntriesInOrder().orderedEntries();
-
-        assertThat(allPipelines.size(), is(3));
-        assertThat(allPipelines.get(0), is(sameInstance(pipeline1)));
-        assertThat(allPipelines.get(1), is(sameInstance(pipeline2)));
-        assertThat(allPipelines.get(2), is(sameInstance(pipeline3)));
-    }
-
-    @Test
-    public void shouldContainChangedEntryInOrderedListAfterAPut() throws Exception {
-        GoDashboardPipeline pipeline1 = pipeline("pipeline1");
-        GoDashboardPipeline pipeline2 = pipeline("pipeline2", "group1");
-        GoDashboardPipeline newPipeline2 = pipeline("pipeline2", "group2");
-        GoDashboardPipeline pipeline3 = pipeline("pipeline3");
-
-        cache.replaceAllEntriesInCacheWith(asList(pipeline1, pipeline2, pipeline3));
-        List<GoDashboardPipeline> allPipelinesBeforePut = cache.allEntriesInOrder().orderedEntries();
-        assertThat(allPipelinesBeforePut.get(1), is(sameInstance(pipeline2)));
-
-        cache.put(newPipeline2);
-        List<GoDashboardPipeline> allPipelinesAfterPut = cache.allEntriesInOrder().orderedEntries();
-
-        assertThat(allPipelinesAfterPut.size(), is(3));
-        assertThat(allPipelinesAfterPut.get(0), is(sameInstance(pipeline1)));
-        assertThat(allPipelinesAfterPut.get(1), is(sameInstance(newPipeline2)));
-        assertThat(allPipelinesAfterPut.get(2), is(sameInstance(pipeline3)));
+        assertThat(cache.allEntries().find(cis("pipeline1")), is(nullValue()));
+        assertThat(cache.allEntries().find(cis("pipeline2")), is(nullValue()));
+        assertThat(cache.allEntries().find(cis("pipeline3")), is(sameInstance(pipeline3)));
+        assertThat(cache.allEntries().find(cis("pipeline4")), is(sameInstance(newPipeline4)));
+        assertThat(cache.allEntries().find(cis("pipeline5")), is(sameInstance(pipeline5)));
     }
 
     private CaseInsensitiveString cis(String value) {

--- a/server/src/test-fast/java/com/thoughtworks/go/server/dashboard/GoDashboardPipelinesTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/dashboard/GoDashboardPipelinesTest.java
@@ -19,6 +19,7 @@ package com.thoughtworks.go.server.dashboard;
 import org.junit.Test;
 
 import java.util.Arrays;
+import java.util.HashMap;
 
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.*;
@@ -30,7 +31,7 @@ public class GoDashboardPipelinesTest {
     public void shouldSetLastUpdatedTime() {
         TimeStampBasedCounter provider = mock(TimeStampBasedCounter.class);
         when(provider.getNext()).thenReturn(100L);
-        GoDashboardPipelines goDashboardPipelines = new GoDashboardPipelines(Arrays.asList(), provider);
+        GoDashboardPipelines goDashboardPipelines = new GoDashboardPipelines(new HashMap<>(), provider);
         assertThat(goDashboardPipelines.lastUpdatedTimeStamp(), is(100L));
     }
 }

--- a/server/src/test-fast/java/com/thoughtworks/go/server/service/GoDashboardServiceTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/service/GoDashboardServiceTest.java
@@ -30,26 +30,20 @@ import com.thoughtworks.go.server.domain.Username;
 import com.thoughtworks.go.server.domain.user.PipelineSelections;
 import com.thoughtworks.go.server.service.support.toggle.FeatureToggleService;
 import com.thoughtworks.go.server.service.support.toggle.Toggles;
-import com.thoughtworks.go.util.Clock;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 
 import static com.thoughtworks.go.server.dashboard.GoDashboardPipelineMother.pipeline;
 import static java.util.Arrays.asList;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 import static org.mockito.MockitoAnnotations.initMocks;
 
 public class GoDashboardServiceTest {
@@ -61,6 +55,8 @@ public class GoDashboardServiceTest {
     private GoConfigService goConfigService;
     @Mock
     private FeatureToggleService featureToggleService;
+    @Mock
+    private GoDashboardPipelines pipelines;
 
     private GoDashboardService service;
 
@@ -75,6 +71,7 @@ public class GoDashboardServiceTest {
         config = configMother.defaultCruiseConfig();
         Toggles.initializeWith(featureToggleService);
         when(featureToggleService.isToggleOn(Toggles.QUICKER_DASHBOARD_KEY)).thenReturn(true);
+        when(cache.allEntries()).thenReturn(this.pipelines);
         service = new GoDashboardService(cache, dashboardCurrentStateLoader, goConfigService);
     }
 
@@ -235,7 +232,7 @@ public class GoDashboardServiceTest {
 
     private void addPipelinesToCache(GoDashboardPipeline... pipelines) {
         for (GoDashboardPipeline pipeline : pipelines) {
-            when(cache.get(pipeline.name())).thenReturn(pipeline);
+            when(this.pipelines.find(pipeline.name())).thenReturn(pipeline);
         }
     }
 }


### PR DESCRIPTION
* Use 'allEntries' method instead of 'cache.get' to get all the entries safely from the cache

More information: https://github.com/gocd/gocd/issues/4121#issuecomment-360196822