### PR TITLE
Perform AJAX polling only when user is on the current tab

### DIFF
--- a/server/webapp/WEB-INF/rails.new/webpack/single_page_apps/agents.js
+++ b/server/webapp/WEB-INF/rails.new/webpack/single_page_apps/agents.js
@@ -57,7 +57,7 @@ $(() => {
   const currentRepeater  = Stream(createRepeater());
   const sortOrder        = Stream(new SortOrder());
 
-  const onResponse        = (pluginInfos) => {
+  const onResponse = (pluginInfos) => {
     const component = {
       view() {
         return m(AgentsWidget, {
@@ -67,11 +67,11 @@ $(() => {
           permanentMessage,
           showSpinner,
           sortOrder,
-          pluginInfos: typeof pluginInfos === "string" ? Stream() : Stream(pluginInfos.filterByType('elastic-agent')),
+          pluginInfos:          typeof pluginInfos === "string" ? Stream() : Stream(pluginInfos.filterByType('elastic-agent')),
           doCancelPolling:      () => currentRepeater().stop(),
           doRefreshImmediately: () => {
             currentRepeater().stop();
-            currentRepeater(createRepeater().start());
+            currentRepeater().start();
           }
         });
       }

--- a/server/webapp/WEB-INF/rails.new/webpack/single_page_apps/new_dashboard.js
+++ b/server/webapp/WEB-INF/rails.new/webpack/single_page_apps/new_dashboard.js
@@ -60,7 +60,7 @@ $(() => {
           doCancelPolling:      () => repeater().stop(),
           doRefreshImmediately: () => {
             repeater().stop();
-            repeater(createRepeater().start());
+            repeater().start();
           }
         });
       }


### PR DESCRIPTION
* Use PageVisibility API to determine whether user is on the current page or not.

More information: https://developer.mozilla.org/en-US/docs/Web/API/Page_Visibility_API