### PR TITLE
Show settings icon for material plugins on plugins SPA

### DIFF
--- a/config/config-api/src/test/java/com/thoughtworks/go/config/SecurityAuthConfigTest.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/config/SecurityAuthConfigTest.java
@@ -69,7 +69,7 @@ public class SecurityAuthConfigTest {
     @Test
     public void addConfiguration_shouldEncryptASecureVariable() throws Exception {
         PluggableInstanceSettings profileSettings = new PluggableInstanceSettings(Arrays.asList(new PluginConfiguration("password", new Metadata(true, true))));
-        AuthorizationPluginInfo pluginInfo = new AuthorizationPluginInfo(pluginDescriptor("plugin_id"), profileSettings, null, null, null, null);
+        AuthorizationPluginInfo pluginInfo = new AuthorizationPluginInfo(pluginDescriptor("plugin_id"), profileSettings, null, null, null);
 
         store.setPluginInfo(pluginInfo);
         SecurityAuthConfig authConfig = new SecurityAuthConfig("id", "plugin_id");
@@ -81,7 +81,7 @@ public class SecurityAuthConfigTest {
 
     @Test
     public void addConfiguration_shouldIgnoreEncryptionInAbsenceOfCorrespondingConfigurationInStore() throws Exception {
-        AuthorizationPluginInfo pluginInfo = new AuthorizationPluginInfo(pluginDescriptor("plugin_id"), new PluggableInstanceSettings(new ArrayList<>()), null, null, null, null);
+        AuthorizationPluginInfo pluginInfo = new AuthorizationPluginInfo(pluginDescriptor("plugin_id"), new PluggableInstanceSettings(new ArrayList<>()), null, null, null);
 
         store.setPluginInfo(pluginInfo);
         SecurityAuthConfig authConfig = new SecurityAuthConfig("id", "plugin_id");
@@ -95,7 +95,7 @@ public class SecurityAuthConfigTest {
     @Test
     public void postConstruct_shouldEncryptSecureConfigurations() throws Exception {
         PluggableInstanceSettings profileSettings = new PluggableInstanceSettings(Arrays.asList(new PluginConfiguration("password", new Metadata(true, true))));
-        AuthorizationPluginInfo pluginInfo = new AuthorizationPluginInfo(pluginDescriptor("plugin_id"), profileSettings, null, null, null, null);
+        AuthorizationPluginInfo pluginInfo = new AuthorizationPluginInfo(pluginDescriptor("plugin_id"), profileSettings, null, null, null);
 
         store.setPluginInfo(pluginInfo);
         SecurityAuthConfig authConfig = new SecurityAuthConfig("id", "plugin_id", new ConfigurationProperty(new ConfigurationKey("password"), new ConfigurationValue("pass")));

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/authorization/AuthorizationPluginInfoBuilder.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/authorization/AuthorizationPluginInfoBuilder.java
@@ -41,10 +41,9 @@ public class AuthorizationPluginInfoBuilder implements PluginInfoBuilder<Authori
 
         PluggableInstanceSettings authConfigSettings = authConfigSettings(descriptor.id());
         PluggableInstanceSettings roleSettings = roleSettings(descriptor.id(), capabilities);
-        PluggableInstanceSettings pluginSettingsAndView = getPluginSettingsAndView(descriptor, extension);
         Image image = image(descriptor.id());
 
-        return new AuthorizationPluginInfo(descriptor, authConfigSettings, roleSettings, image, capabilities, pluginSettingsAndView);
+        return new AuthorizationPluginInfo(descriptor, authConfigSettings, roleSettings, image, capabilities);
     }
 
     private Capabilities capabilities(String pluginId) {

--- a/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/authorization/AuthorizationMetadataLoaderTest.java
+++ b/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/authorization/AuthorizationMetadataLoaderTest.java
@@ -53,7 +53,7 @@ public class AuthorizationMetadataLoaderTest {
     public void onPluginLoaded_shouldAddPluginInfoToMetadataStore() throws Exception {
         GoPluginDescriptor descriptor =  new GoPluginDescriptor("plugin1", null, null, null, null, false);
         AuthorizationMetadataLoader metadataLoader = new AuthorizationMetadataLoader(pluginManager, metadataStore, infoBuilder, extension);
-        AuthorizationPluginInfo pluginInfo = new AuthorizationPluginInfo(descriptor, null, null, null, null, null);
+        AuthorizationPluginInfo pluginInfo = new AuthorizationPluginInfo(descriptor, null, null, null, null);
 
         when(extension.canHandlePlugin(descriptor.id())).thenReturn(true);
         when(infoBuilder.pluginInfoFor(descriptor)).thenReturn(pluginInfo);
@@ -80,7 +80,7 @@ public class AuthorizationMetadataLoaderTest {
     public void onPluginUnloded_shouldRemoveTheCorrespondingPluginInfoFromStore() throws Exception {
         GoPluginDescriptor descriptor =  new GoPluginDescriptor("plugin1", null, null, null, null, false);
         AuthorizationMetadataLoader metadataLoader = new AuthorizationMetadataLoader(pluginManager, metadataStore, infoBuilder, extension);
-        AuthorizationPluginInfo pluginInfo = new AuthorizationPluginInfo(descriptor, null, null, null, null, null);
+        AuthorizationPluginInfo pluginInfo = new AuthorizationPluginInfo(descriptor, null, null, null, null);
 
         metadataStore.setPluginInfo(pluginInfo);
 

--- a/plugin-infra/go-plugin-domain/src/main/java/com/thoughtworks/go/plugin/domain/authorization/AuthorizationPluginInfo.java
+++ b/plugin-infra/go-plugin-domain/src/main/java/com/thoughtworks/go/plugin/domain/authorization/AuthorizationPluginInfo.java
@@ -28,8 +28,8 @@ public class AuthorizationPluginInfo extends PluginInfo {
     private final Capabilities capabilities;
 
     public AuthorizationPluginInfo(PluginDescriptor descriptor, PluggableInstanceSettings authConfigSettings,
-                                   PluggableInstanceSettings roleSettings, Image image, Capabilities capabilities, PluggableInstanceSettings pluginSettings) {
-        super(descriptor, PluginConstants.AUTHORIZATION_EXTENSION, pluginSettings, image);
+                                   PluggableInstanceSettings roleSettings, Image image, Capabilities capabilities) {
+        super(descriptor, PluginConstants.AUTHORIZATION_EXTENSION, null, image);
         this.authConfigSettings = authConfigSettings;
         this.roleSettings = roleSettings;
         this.capabilities = capabilities;

--- a/server/src/test-fast/java/com/thoughtworks/go/server/security/UserSearchServiceTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/security/UserSearchServiceTest.java
@@ -32,7 +32,6 @@ import com.thoughtworks.go.presentation.UserSourceType;
 import com.thoughtworks.go.server.service.GoConfigService;
 import com.thoughtworks.go.server.service.result.HttpLocalizedOperationResult;
 import org.hamcrest.Matchers;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -128,7 +127,7 @@ public class UserSearchServiceTest  {
     private void addPluginSupportingUserSearch(String pluginId) {
         AuthorizationPluginInfo pluginInfo = new AuthorizationPluginInfo(
                 new GoPluginDescriptor(pluginId, null, null, null, null, false), null, null, null,
-                new Capabilities(SupportedAuthType.Password, true, true), null);
+                new Capabilities(SupportedAuthType.Password, true, true));
         AuthorizationMetadataStore.instance().setPluginInfo(pluginInfo);
     }
 }

--- a/server/src/test-fast/java/com/thoughtworks/go/server/security/providers/PluginAuthenticationProviderTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/security/providers/PluginAuthenticationProviderTest.java
@@ -344,7 +344,7 @@ public class PluginAuthenticationProviderTest {
     private void addPluginSupportingPasswordBasedAuthentication(String pluginId) {
         AuthorizationPluginInfo pluginInfo = new AuthorizationPluginInfo(
                 new GoPluginDescriptor(pluginId, null, null, null, null, false), null, null, null,
-                new Capabilities(SupportedAuthType.Password, true, false), null);
+                new Capabilities(SupportedAuthType.Password, true, false));
         AuthorizationMetadataStore.instance().setPluginInfo(pluginInfo);
     }
 }

--- a/server/src/test-fast/java/com/thoughtworks/go/server/service/SecurityAuthConfigServiceTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/service/SecurityAuthConfigServiceTest.java
@@ -267,6 +267,6 @@ public class SecurityAuthConfigServiceTest {
     private AuthorizationPluginInfo pluginInfo(String githubPluginId, String name, SupportedAuthType supportedAuthType) {
         GoPluginDescriptor.About about = new GoPluginDescriptor.About(name, "1.0", null, null, null, null);
         GoPluginDescriptor descriptor = new GoPluginDescriptor(githubPluginId, "1.0", about, null, null, false);
-        return new AuthorizationPluginInfo(descriptor, null, null, new Image("svg", "data", "hash"), new Capabilities(supportedAuthType, true, true), null);
+        return new AuthorizationPluginInfo(descriptor, null, null, new Image("svg", "data", "hash"), new Capabilities(supportedAuthType, true, true));
     }
 }

--- a/server/src/test-fast/java/com/thoughtworks/go/server/ui/AuthPluginInfoViewModelTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/ui/AuthPluginInfoViewModelTest.java
@@ -33,7 +33,7 @@ public class AuthPluginInfoViewModelTest {
         GoPluginDescriptor.About about = new GoPluginDescriptor.About("GitHub Auth Plugin", "1.0", null, null, null, null);
         String pluginId = "github";
         GoPluginDescriptor descriptor = new GoPluginDescriptor(pluginId, "1.0", about, null, null, false);
-        AuthorizationPluginInfo pluginInfo = new AuthorizationPluginInfo(descriptor, null, null, new Image("svg", "data", "hash"), new Capabilities(SupportedAuthType.Web, true, true), null);
+        AuthorizationPluginInfo pluginInfo = new AuthorizationPluginInfo(descriptor, null, null, new Image("svg", "data", "hash"), new Capabilities(SupportedAuthType.Web, true, true));
         AuthPluginInfoViewModel model = new AuthPluginInfoViewModel(pluginInfo);
         assertThat(model.imageUrl(), is("/go/api/plugin_images/github/hash"));
         assertThat(model.pluginId(), is("github"));

--- a/server/webapp/WEB-INF/rails.new/spec/controllers/api_v3/admin/plugin_infos_controller_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/controllers/api_v3/admin/plugin_infos_controller_spec.rb
@@ -158,7 +158,7 @@ describe ApiV3::Admin::PluginInfosController do
       descriptor = GoPluginDescriptor.new('foo.example', '1.0', about, nil, nil, false)
 
       allPluginInfos = [com.thoughtworks.go.plugin.domain.analytics.AnalyticsPluginInfo.new(descriptor, nil, nil, nil),
-                        com.thoughtworks.go.plugin.domain.authorization.AuthorizationPluginInfo.new(descriptor, nil, nil, nil, nil, nil),
+                        com.thoughtworks.go.plugin.domain.authorization.AuthorizationPluginInfo.new(descriptor, nil, nil, nil, nil),
                         com.thoughtworks.go.plugin.domain.configrepo.ConfigRepoPluginInfo.new(descriptor, @plugin_settings),
                         com.thoughtworks.go.plugin.domain.elastic.ElasticAgentPluginInfo.new(descriptor, nil, nil, nil, nil),
                         com.thoughtworks.go.plugin.domain.notification.NotificationPluginInfo.new(descriptor, @plugin_settings),

--- a/server/webapp/WEB-INF/rails.new/spec/controllers/api_v4/admin/plugin_infos_controller_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/controllers/api_v4/admin/plugin_infos_controller_spec.rb
@@ -158,7 +158,7 @@ describe ApiV4::Admin::PluginInfosController do
       descriptor = GoPluginDescriptor.new('foo.example', '1.0', about, nil, nil, false)
 
       allPluginInfos = [com.thoughtworks.go.plugin.domain.analytics.AnalyticsPluginInfo.new(descriptor, nil, nil, nil),
-                        com.thoughtworks.go.plugin.domain.authorization.AuthorizationPluginInfo.new(descriptor, nil, nil, nil, nil, nil),
+                        com.thoughtworks.go.plugin.domain.authorization.AuthorizationPluginInfo.new(descriptor, nil, nil, nil, nil),
                         com.thoughtworks.go.plugin.domain.configrepo.ConfigRepoPluginInfo.new(descriptor, @plugin_settings),
                         com.thoughtworks.go.plugin.domain.elastic.ElasticAgentPluginInfo.new(descriptor, nil, nil, nil, nil),
                         com.thoughtworks.go.plugin.domain.notification.NotificationPluginInfo.new(descriptor, @plugin_settings),

--- a/server/webapp/WEB-INF/rails.new/spec/presenters/api_v3/plugin/plugin_info_representer_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/presenters/api_v3/plugin/plugin_info_representer_spec.rb
@@ -273,7 +273,7 @@ describe ApiV3::Plugin::PluginInfoRepresenter do
       role_config_settings = com.thoughtworks.go.plugin.domain.common.PluggableInstanceSettings.new([com.thoughtworks.go.plugin.domain.common.PluginConfiguration.new('memberOf', com.thoughtworks.go.plugin.domain.common.Metadata.new(true, false))], role_config_view)
       capabilities = com.thoughtworks.go.plugin.domain.authorization.Capabilities.new(com.thoughtworks.go.plugin.domain.authorization.SupportedAuthType::Password, true, true)
 
-      plugin_info = com.thoughtworks.go.plugin.domain.authorization.AuthorizationPluginInfo.new(descriptor, auth_config_settings, role_config_settings, image, capabilities, nil)
+      plugin_info = com.thoughtworks.go.plugin.domain.authorization.AuthorizationPluginInfo.new(descriptor, auth_config_settings, role_config_settings, image, capabilities)
       actual_json = ApiV3::Plugin::PluginInfoRepresenter.new(plugin_info).to_hash(url_builder: UrlBuilder.new)
       expect(actual_json).to have_link(:image).with_url('http://test.host/api/plugin_images/foo.example/945f43c56990feb8732e7114054fa33cd51ba1f8a208eb5160517033466d4756')
       actual_json.delete(:_links)

--- a/server/webapp/WEB-INF/rails.new/spec/presenters/api_v3/plugin/plugin_infos_representer_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/presenters/api_v3/plugin/plugin_infos_representer_spec.rb
@@ -27,7 +27,7 @@ describe ApiV3::Plugin::PluginInfosRepresenter do
     capabilities = com.thoughtworks.go.plugin.domain.authorization.Capabilities.new(com.thoughtworks.go.plugin.domain.authorization.SupportedAuthType::Web, true, true)
     image = com.thoughtworks.go.plugin.domain.common.Image.new('foo', Base64.strict_encode64('bar'), "945f43c56990feb8732e7114054fa33cd51ba1f8a208eb5160517033466d4756")
 
-    plugin_info = com.thoughtworks.go.plugin.domain.authorization.AuthorizationPluginInfo.new(descriptor, auth_configs, role_configs, image, capabilities, nil)
+    plugin_info = com.thoughtworks.go.plugin.domain.authorization.AuthorizationPluginInfo.new(descriptor, auth_configs, role_configs, image, capabilities)
 
     actual_json = ApiV4::Plugin::PluginInfosRepresenter.new([plugin_info]).to_hash(url_builder: UrlBuilder.new)
 

--- a/server/webapp/WEB-INF/rails.new/spec/presenters/api_v4/plugin/plugin_info_representer_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/presenters/api_v4/plugin/plugin_info_representer_spec.rb
@@ -273,7 +273,7 @@ describe ApiV4::Plugin::PluginInfoRepresenter do
       role_config_settings = com.thoughtworks.go.plugin.domain.common.PluggableInstanceSettings.new([com.thoughtworks.go.plugin.domain.common.PluginConfiguration.new('memberOf', com.thoughtworks.go.plugin.domain.common.Metadata.new(true, false))], role_config_view)
       capabilities = com.thoughtworks.go.plugin.domain.authorization.Capabilities.new(com.thoughtworks.go.plugin.domain.authorization.SupportedAuthType::Password, true, true)
 
-      plugin_info = com.thoughtworks.go.plugin.domain.authorization.AuthorizationPluginInfo.new(descriptor, auth_config_settings, role_config_settings, image, capabilities, nil)
+      plugin_info = com.thoughtworks.go.plugin.domain.authorization.AuthorizationPluginInfo.new(descriptor, auth_config_settings, role_config_settings, image, capabilities)
       actual_json = ApiV4::Plugin::PluginInfoRepresenter.new(plugin_info).to_hash(url_builder: UrlBuilder.new)
       expect(actual_json).to have_link(:image).with_url('http://test.host/api/plugin_images/foo.example/945f43c56990feb8732e7114054fa33cd51ba1f8a208eb5160517033466d4756')
       actual_json.delete(:_links)

--- a/server/webapp/WEB-INF/rails.new/spec/presenters/api_v4/plugin/plugin_infos_representer_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/presenters/api_v4/plugin/plugin_infos_representer_spec.rb
@@ -27,7 +27,7 @@ describe ApiV4::Plugin::PluginInfosRepresenter do
     capabilities = com.thoughtworks.go.plugin.domain.authorization.Capabilities.new(com.thoughtworks.go.plugin.domain.authorization.SupportedAuthType::Web, true, true)
     image = com.thoughtworks.go.plugin.domain.common.Image.new('foo', Base64.strict_encode64('bar'), "945f43c56990feb8732e7114054fa33cd51ba1f8a208eb5160517033466d4756")
 
-    plugin_info = com.thoughtworks.go.plugin.domain.authorization.AuthorizationPluginInfo.new(descriptor, auth_configs, role_configs, image, capabilities, nil)
+    plugin_info = com.thoughtworks.go.plugin.domain.authorization.AuthorizationPluginInfo.new(descriptor, auth_configs, role_configs, image, capabilities)
 
     actual_json = ApiV4::Plugin::PluginInfosRepresenter.new([plugin_info]).to_hash(url_builder: UrlBuilder.new)
 

--- a/server/webapp/WEB-INF/rails.new/spec/webpack/models/shared/plugin_infos_spec.js
+++ b/server/webapp/WEB-INF/rails.new/spec/webpack/models/shared/plugin_infos_spec.js
@@ -45,6 +45,119 @@ describe('PluginInfos', () => {
     expect(pluginInfos.countPluginInfo()).toBe(1);
     expect(pluginInfos.firstPluginInfo().id()).toBe('github.oauth.login');
   });
+
+  it("should check if plugin settings is supported", () => {
+    const withoutExtensionInfo = {
+      "id":               "github.pr",
+      "type":             "scm",
+      "status":           {
+        "state": "active"
+      },
+      "about":        {
+        "name":                     "Github Pull Requests Builder",
+        "version":                  "1.3.0-RC2",
+        "target_go_version":        "15.1.0",
+        "description":              "Plugin that polls a GitHub repository for pull requests and triggers a build for each of them",
+        "target_operating_systems": [],
+        "vendor":                   {
+          "name": "Ashwanth Kumar",
+          "url":  "https://github.com/ashwanthkumar/gocd-build-github-pull-requests"
+        }
+      }
+    };
+
+    const withoutPluginSettingsProperty = {
+      "id":               "github.pr",
+      "type":             "scm",
+      "status":           {
+        "state": "active"
+      },
+      "about":        {
+        "name":                     "Github Pull Requests Builder",
+        "version":                  "1.3.0-RC2",
+        "target_go_version":        "15.1.0",
+        "description":              "Plugin that polls a GitHub repository for pull requests and triggers a build for each of them",
+        "target_operating_systems": [],
+        "vendor":                   {
+          "name": "Ashwanth Kumar",
+          "url":  "https://github.com/ashwanthkumar/gocd-build-github-pull-requests"
+        }
+      },
+      "extension_info": {
+      }
+    };
+
+    const withoutPluginSettingsView = {
+      "id":               "github.pr",
+      "type":             "scm",
+      "status":           {
+        "state": "active"
+      },
+      "about":        {
+        "name":                     "Github Pull Requests Builder",
+        "version":                  "1.3.0-RC2",
+        "target_go_version":        "15.1.0",
+        "description":              "Plugin that polls a GitHub repository for pull requests and triggers a build for each of them",
+        "target_operating_systems": [],
+        "vendor":                   {
+          "name": "Ashwanth Kumar",
+          "url":  "https://github.com/ashwanthkumar/gocd-build-github-pull-requests"
+        }
+      },
+      "extension_info": {
+        "plugin_settings": {
+          "configurations": [
+            {
+              "key": "instance_type",
+              "metadata": {
+                "secure": false,
+                "required": true
+              }
+            }
+          ]
+        }
+      }
+    };
+
+    const withoutPluginSettingsConfiguration = {
+      "id":               "github.pr",
+      "type":             "scm",
+      "status":           {
+        "state": "active"
+      },
+      "about":        {
+        "name":                     "Github Pull Requests Builder",
+        "version":                  "1.3.0-RC2",
+        "target_go_version":        "15.1.0",
+        "description":              "Plugin that polls a GitHub repository for pull requests and triggers a build for each of them",
+        "target_operating_systems": [],
+        "vendor":                   {
+          "name": "Ashwanth Kumar",
+          "url":  "https://github.com/ashwanthkumar/gocd-build-github-pull-requests"
+        }
+      },
+      "extension_info": {
+        "plugin_settings": {
+          "view": {
+            "template": "plugin settings view"
+          }
+        }
+      }
+    };
+
+    const pluginInfoWithoutPluginSettings = PluginInfos.PluginInfo.fromJSON(withoutPluginSettingsProperty);
+    expect(pluginInfoWithoutPluginSettings.supportsPluginSettings()).toBe(false);
+
+    const pluginInfoWithoutExtensionInfo = PluginInfos.PluginInfo.fromJSON(withoutExtensionInfo);
+    expect(pluginInfoWithoutExtensionInfo.supportsPluginSettings()).toBe(false);
+
+    const pluginInfoWithoutPluginSettingsView = PluginInfos.PluginInfo.fromJSON(withoutPluginSettingsView);
+    expect(pluginInfoWithoutPluginSettingsView.supportsPluginSettings()).toBe(false);
+
+    const pluginInfoWithoutPluginSettingsConfiguration = PluginInfos.PluginInfo.fromJSON(withoutPluginSettingsConfiguration);
+    expect(pluginInfoWithoutPluginSettingsConfiguration.supportsPluginSettings()).toBe(false);
+
+  });
   
   describe("ElasticAgent", () => {
     it("should deserialize", () => {
@@ -283,6 +396,20 @@ describe('PluginInfos', () => {
                 }
               }
             ]
+          },
+          "plugin_settings": {
+            "configurations": [
+              {
+                "key": "another-property",
+                "metadata": {
+                  "secure": false,
+                  "required": true
+                }
+              }
+            ],
+            "view": {
+              "template": "Plugin Settings View for package repository plugin"
+            }
           }
         }
       };
@@ -308,6 +435,14 @@ describe('PluginInfos', () => {
         "secure":           false,
         "display_name":     "Repository Url",
         "required":         true
+      });
+
+      expect(pluginInfo.pluginSettings().viewTemplate()).toEqual(json.extension_info.plugin_settings.view.template);
+      expect(pluginInfo.pluginSettings().configurations().countConfiguration()).toEqual(1);
+      expect(pluginInfo.pluginSettings().configurations().collectConfigurationProperty('key')).toEqual(['another-property']);
+      expect(pluginInfo.pluginSettings().configurations().firstConfiguration().metadata()).toEqual({
+        secure:   false,
+        required: true
       });
     });
   });
@@ -438,6 +573,20 @@ describe('PluginInfos', () => {
             "view":           {
               "template": "<div class=\"form_item_block\">\n    <label>URL:<span class=\"asterisk\">*</span></label>\n    <input type=\"text\" ng-model=\"url\" ng-required=\"true\"/>\n    <span class=\"form_error\" ng-show=\"GOINPUTNAME[url].$error.server\">{{ GOINPUTNAME[url].$error.server }}</span>\n</div>\n<div class=\"form_item_block\">\n    <label>Username:</label>\n    <input type=\"text\" ng-model=\"username\" ng-required=\"false\"/>\n    <span class=\"form_error\" ng-show=\"GOINPUTNAME[username].$error.server\">{{ GOINPUTNAME[username].$error.server }}</span>\n</div>\n<div class=\"form_item_block\">\n    <label>Password:</label>\n    <input type=\"password\" ng-model=\"password\" ng-required=\"false\"/>\n    <span class=\"form_error\" ng-show=\"GOINPUTNAME[password].$error.server\">{{ GOINPUTNAME[password].$error.server }}</span>\n</div>"
             }
+          },
+          "plugin_settings": {
+            "configurations": [
+              {
+                "key": "another-property",
+                "metadata": {
+                  "secure": false,
+                  "required": true
+                }
+              }
+            ],
+            "view": {
+              "template": "Plugin Settings View for scm plugin GitHub PR builder"
+            }
           }
         }
       };
@@ -453,6 +602,15 @@ describe('PluginInfos', () => {
         "secure":           false,
         "required":         true
       });
+
+      expect(pluginInfo.pluginSettings().viewTemplate()).toEqual(json.extension_info.plugin_settings.view.template);
+      expect(pluginInfo.pluginSettings().configurations().countConfiguration()).toEqual(1);
+      expect(pluginInfo.pluginSettings().configurations().collectConfigurationProperty('key')).toEqual(['another-property']);
+      expect(pluginInfo.pluginSettings().configurations().firstConfiguration().metadata()).toEqual({
+        secure:   false,
+        required: true
+      });
+
     });
   });
 

--- a/server/webapp/WEB-INF/rails.new/webpack/models/shared/plugin_infos.js
+++ b/server/webapp/WEB-INF/rails.new/webpack/models/shared/plugin_infos.js
@@ -86,7 +86,9 @@ PluginInfos.PluginInfo = function (type, {id, about, pluginSettings, imageUrl, s
 
   this.hasErrors = () => this.status().state() === 'invalid';
 
-  this.suportsPluginSettings = () => !!this.pluginSettings;
+  this.supportsPluginSettings = function () {
+    return !!this.pluginSettings && this.pluginSettings().hasView() && this.pluginSettings().hasConfigurations();
+  };
 };
 
 PluginInfos.PluginInfo.ConfigRepo = function (data) {
@@ -130,6 +132,7 @@ PluginInfos.PluginInfo.PackageRepository.fromJSON = (data = {}) => new PluginInf
   pluginFileLocation: data.plugin_file_location,
   bundledPlugin:      data.bundled_plugin,
   about:              About.fromJSON(data.about),
+  pluginSettings:     PluggableInstanceSettings.fromJSON(data.extension_info && data.extension_info.plugin_settings),
   packageSettings:    PluggableInstanceSettings.fromJSON(_.get(data, "extension_info.package_settings")),
   repositorySettings: PluggableInstanceSettings.fromJSON(_.get(data, "extension_info.repository_settings")),
   imageUrl:           _.get(data, '_links.image.href')
@@ -163,6 +166,7 @@ PluginInfos.PluginInfo.SCM.fromJSON = (data = {}) => new PluginInfos.PluginInfo.
   pluginFileLocation: data.plugin_file_location,
   bundledPlugin:      data.bundled_plugin,
   about:              About.fromJSON(data.about),
+  pluginSettings:     PluggableInstanceSettings.fromJSON(data.extension_info && data.extension_info.plugin_settings),
   scmSettings:        PluggableInstanceSettings.fromJSON(data.extension_info && data.extension_info.scm_settings),
   imageUrl:           _.get(data, '_links.image.href'),
 });

--- a/server/webapp/WEB-INF/rails.new/webpack/models/shared/plugin_infos/pluggable_instance_settings.js
+++ b/server/webapp/WEB-INF/rails.new/webpack/models/shared/plugin_infos/pluggable_instance_settings.js
@@ -21,6 +21,15 @@ const Mixins = require('models/mixins/model_mixins');
 const PluggableInstanceSettings = function({viewTemplate, configurations}) {
   this.viewTemplate   = Stream(viewTemplate);
   this.configurations = Stream(configurations);
+
+  this.hasConfigurations = function () {
+    return !this.configurations().isEmptyConfiguration();
+  };
+
+  this.hasView = function () {
+    return !!this.viewTemplate();
+  };
+
 };
 
 PluggableInstanceSettings.fromJSON = (data = {}) => new PluggableInstanceSettings({

--- a/server/webapp/WEB-INF/rails.new/webpack/views/plugins/plugin_widget.js.msx
+++ b/server/webapp/WEB-INF/rails.new/webpack/views/plugins/plugin_widget.js.msx
@@ -49,7 +49,7 @@ const PluginWidget = {
     }
 
     const statusReport = pluginInfo.capabilities && pluginInfo.capabilities().supportsStatusReport && pluginInfo.capabilities().supportsStatusReport();
-    const settingsIcon = pluginInfo.suportsPluginSettings();
+    const settingsIcon = pluginInfo.supportsPluginSettings();
 
     actionIcons = (<div class="plugin-actions">
     </div>);


### PR DESCRIPTION
* Do not make the get plugin settings call for authorization extension. Authorization extension does not support plugin settings. We haven't documented in https://plugin-api.gocd.org/current/authorization/#requests-from-the-gocd-server that plugin settings will be requested for. 