### PR TITLE
Fix Dashboard search a pipeline and show changes popup (#4111)

### DIFF
--- a/server/webapp/WEB-INF/rails.new/spec/webpack/views/dashboard/dashboard_widget_spec.js
+++ b/server/webapp/WEB-INF/rails.new/spec/webpack/views/dashboard/dashboard_widget_spec.js
@@ -116,6 +116,43 @@ describe("Dashboard Widget", () => {
     Modal.destroyAll();
   });
 
+  it("should show changes popup for a searched pipeline", () => {
+    const searchField = $root.find('#pipeline_search').get(0);
+    expect($root.find('.pipeline')).toHaveLength(2);
+
+    $(searchField).val('up42');
+    simulateEvent.simulate(searchField, 'input');
+    m.redraw();
+
+    expect($root.find('.pipeline')).toHaveLength(1);
+
+    const up42ChangesLink   = $root.find('.info a').get(1);
+    const up42ChangesWidget = $root.find('.material_changes');
+    expect(up42ChangesWidget).toBeInDOM();
+    expect(up42ChangesWidget).toHaveClass('hide');
+
+    up42ChangesLink.click();
+
+    expect(up42ChangesWidget).toBeInDOM();
+    expect(up42ChangesWidget).toHaveClass('show');
+
+    $(searchField).val('up43');
+    simulateEvent.simulate(searchField, 'input');
+    m.redraw();
+
+    expect($root.find('.pipeline')).toHaveLength(1);
+
+    const up43ChangesLink   = $root.find('.info a').get(1);
+    const up43ChangesWidget = $root.find('.material_changes');
+    expect(up43ChangesWidget).toBeInDOM();
+    expect(up43ChangesWidget).toHaveClass('hide');
+
+    up43ChangesLink.click();
+
+    expect(up43ChangesWidget).toBeInDOM();
+    expect(up43ChangesWidget).toHaveClass('show');
+  });
+
   it("should render pipeline groups", () => {
     const pipelineGroupsCount = dashboardJson._embedded.pipeline_groups.length;
     const pipelineGroups      = $root.find('.pipeline-group');
@@ -217,6 +254,31 @@ describe("Dashboard Widget", () => {
               "paused":       false,
               "paused_by":    null,
               "pause_reason": null
+            },
+            "build_cause":            {
+              "approver":           "",
+              "is_forced":          false,
+              "trigger_message":    "modified by GoCD Test User <devnull@example.com>",
+              "material_revisions": [
+                {
+                  "material_type": "Git",
+                  "material_name": "test-repo",
+                  "changed":       true,
+                  "modifications": [
+                    {
+                      "_links":        {
+                        "vsm": {
+                          "href": "http://localhost:8153/go/materials/value_stream_map/4879d548de8a9d7122ceb71e7809c1f91a0876afa534a4f3ba7ed4a532bc1b02/9c86679eefc3c5c01703e9f1d0e96b265ad25691"
+                        }
+                      },
+                      "user_name":     "GoCD Test User <devnull@example.com>",
+                      "revision":      "9c86679eefc3c5c01703e9f1d0e96b265ad25691",
+                      "modified_time": "2017-12-19T05:30:32.000Z",
+                      "comment":       "Initial commit"
+                    }
+                  ]
+                }
+              ]
             },
             "_embedded":              {
               "instances": [
@@ -324,6 +386,31 @@ describe("Dashboard Widget", () => {
               "paused":       false,
               "paused_by":    null,
               "pause_reason": null
+            },
+            "build_cause":            {
+              "approver":           "",
+              "is_forced":          false,
+              "trigger_message":    "modified by GoCD Test User <devnull@example.com>",
+              "material_revisions": [
+                {
+                  "material_type": "Git",
+                  "material_name": "test-repo",
+                  "changed":       true,
+                  "modifications": [
+                    {
+                      "_links":        {
+                        "vsm": {
+                          "href": "http://localhost:8153/go/materials/value_stream_map/4879d548de8a9d7122ceb71e7809c1f91a0876afa534a4f3ba7ed4a532bc1b02/9c86679eefc3c5c01703e9f1d0e96b265ad25691"
+                        }
+                      },
+                      "user_name":     "GoCD Test User <devnull@example.com>",
+                      "revision":      "9c86679eefc3c5c01703e9f1d0e96b265ad25691",
+                      "modified_time": "2017-12-19T05:30:32.000Z",
+                      "comment":       "Initial commit"
+                    }
+                  ]
+                }
+              ]
             },
             "_embedded":              {
               "instances": [

--- a/server/webapp/WEB-INF/rails.new/webpack/views/dashboard/pipeline_instance_widget.js.msx
+++ b/server/webapp/WEB-INF/rails.new/webpack/views/dashboard/pipeline_instance_widget.js.msx
@@ -21,19 +21,7 @@ const StagesInstanceWidget  = require('views/dashboard/stages_instance_widget');
 const MaterialChangesWidget = require('views/dashboard/material_changes_widget');
 
 const PipelineInstanceWidget = {
-  oninit: (vnode) => {
-    const self = vnode.state;
-
-    self.toggleChanges = (e) => {
-      const dropdown     = vnode.attrs.dropdown;
-      const pipelineName = vnode.attrs.pipelineName;
-      dropdown.toggle(pipelineName);
-      e.stopPropagation();
-    };
-  },
-
   view: (vnode) => {
-    const ctrl         = vnode.state;
     const instance     = vnode.attrs.instance;
     const dropdown     = vnode.attrs.dropdown;
     const pipelineName = vnode.attrs.pipelineName;
@@ -45,7 +33,10 @@ const PipelineInstanceWidget = {
         <div class="more_info">
           <ul class="info">
             <li><a href={instance.comparePath}> Compare </a></li>
-            <li><a onclick={ctrl.toggleChanges}><span class="changes"> Changes</span> </a></li>
+            <li><a onclick={(e) => {
+              dropdown.toggle(pipelineName);
+              e.stopPropagation();
+            }}><span class="changes"> Changes</span> </a></li>
             <li><a href={instance.vsmPath}> VSM </a></li>
           </ul>
           <MaterialChangesWidget materialRevisions={instance.materialRevisions}


### PR DESCRIPTION
* Do not use passed arguments directly inside widget methods.
Description: `oninit` widget method (controller) gets invoked only once when the view is initialized.
Using arguments directly inside the controller method will cause the first passed argument to be always used, even on redraws when arguments changes.

more information: https://github.com/gocd/gocd/issues/4111#issuecomment-362698482

Here is a simple example to demonstrate the problem:

```
const VehicleWidget = {
  oninit(vnode) {
    this.vehicle = vnode.attrs.vehicle;
  },

  view(vnode) {
    return (<div>{this.vehicle.getModel()}</div>);
  }
};
```

After running following code snippet:
```
let car = new Vehicle('BMW');
 <VehicleWidget vehicle={car} />
```
Will generate `<div>BMW</div>` HTML. 

Later when the reference of the car is changed using
```
car = new Vehicle('Ferrari');
```
will still generate `<div>BMW</div>` HTML.  As the `VehicleWidget` controller points to the first reference of the car argument object which was passed at the time of `VehicleWidget` initialization.
Hence even when the model reference is changed, the view will still render stale data.

**Note**: Do not store model state in widget controller.

A better way of writing VehicleWidget:

```
const VehicleWidget = {
  view(vnode) {
    return (<div>{vnode.attrs.vehicle.getModel()}</div>);
  }
};
```

