### PR TITLE
Fixed random rspec failures

### DIFF
--- a/plugin-infra/go-plugin-domain/src/main/java/com/thoughtworks/go/plugin/domain/analytics/Capabilities.java
+++ b/plugin-infra/go-plugin-domain/src/main/java/com/thoughtworks/go/plugin/domain/analytics/Capabilities.java
@@ -32,6 +32,10 @@ public class Capabilities {
         return supportsPipelineAnalytics;
     }
 
+    public boolean supportsDashboardAnalytics() {
+        return this.supportedAnalyticsDashboardMetrics != null && this.supportedAnalyticsDashboardMetrics.size() > 0;
+    }
+
     public List<String> supportedAnalyticsDashboardMetrics() {
         return supportedAnalyticsDashboardMetrics;
     }

--- a/plugin-infra/go-plugin-domain/src/test/java/com/thoughtworks/go/plugin/domain/analytics/CapabilitiesTest.java
+++ b/plugin-infra/go-plugin-domain/src/test/java/com/thoughtworks/go/plugin/domain/analytics/CapabilitiesTest.java
@@ -39,4 +39,13 @@ public class CapabilitiesTest {
         assertNotEquals(capabilities, capabilities3);
         assertNotEquals(capabilities.hashCode(), capabilities3.hashCode());
     }
+
+    @Test
+    public void shouldSupportDashboardAnalyticsIfPluginListsSupportedAnalyticsDashboardMetrics() throws Exception {
+        assertTrue(new Capabilities(true, Collections.singletonList("foo")).supportsDashboardAnalytics());
+
+        assertFalse(new Capabilities(true, Collections.emptyList()).supportsDashboardAnalytics());
+
+        assertFalse(new Capabilities(true, null).supportsDashboardAnalytics());
+    }
 }

--- a/server/src/main/java/com/thoughtworks/go/server/web/GoVelocityView.java
+++ b/server/src/main/java/com/thoughtworks/go/server/web/GoVelocityView.java
@@ -127,7 +127,7 @@ public class GoVelocityView extends VelocityToolboxView {
     private boolean isSupportsAnalyticsDashboard() {
         for (Object obj : getPluginInfoFinder().allPluginInfos(PluginConstants.ANALYTICS_EXTENSION)) {
             AnalyticsPluginInfo info = (AnalyticsPluginInfo) obj;
-            if (info.getCapabilities().supportedAnalyticsDashboardMetrics().size() > 0) {
+            if (info.getCapabilities().supportsDashboardAnalytics()) {
                 return true;
             }
         }

--- a/server/webapp/WEB-INF/rails.new/app/controllers/analytics_controller.rb
+++ b/server/webapp/WEB-INF/rails.new/app/controllers/analytics_controller.rb
@@ -24,9 +24,9 @@ class AnalyticsController < ApplicationController
 
   def index
     @view_title = 'Analytics'
-    @plugin_ids = default_plugin_info_finder.allPluginInfos(PluginConstants.ANALYTICS_EXTENSION).inject({})do |memo, plugin|
+    @supported_dashboard_metrics = default_plugin_info_finder.allPluginInfos(PluginConstants.ANALYTICS_EXTENSION).inject({})do |memo, plugin|
       key = plugin.getDescriptor().id()
-      memo[key] = plugin.getCapabilities().supportedAnalyticsDashboardMetrics() if plugin.getCapabilities().supportedAnalyticsDashboardMetrics().size() > 0
+      memo[key] = plugin.getCapabilities().supportedAnalyticsDashboardMetrics() if plugin.getCapabilities().supportsDashboardAnalytics()
       memo
     end
   end

--- a/server/webapp/WEB-INF/rails.new/app/helpers/application_helper.rb
+++ b/server/webapp/WEB-INF/rails.new/app/helpers/application_helper.rb
@@ -505,7 +505,7 @@ module ApplicationHelper
 
   def supports_analytics_dashboard?
     !default_plugin_info_finder.allPluginInfos(PluginConstants.ANALYTICS_EXTENSION).detect do |plugin|
-      plugin.getCapabilities().supportedAnalyticsDashboardMetrics().size() > 0
+      plugin.getCapabilities().supportsDashboardAnalytics()
     end.nil?
   end
 

--- a/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/plugin/analytics_capabilities_representer.rb
+++ b/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/plugin/analytics_capabilities_representer.rb
@@ -20,7 +20,11 @@ module ApiV4
       alias_method :capabilities, :represented
 
       property :supports_pipeline_analytics
+      property :supported_dashboard_analytics_metrics, exec_context: :decorator
 
+      def supported_dashboard_analytics_metrics
+        capabilities.supportedAnalyticsDashboardMetrics() || []
+      end
     end
   end
 end

--- a/server/webapp/WEB-INF/rails.new/app/views/analytics/index.html.erb
+++ b/server/webapp/WEB-INF/rails.new/app/views/analytics/index.html.erb
@@ -1,1 +1,1 @@
-<div class="analytics-container" data-plugin-ids="<%= @plugin_ids.to_json %>"></div>
+<div class="analytics-container" data-supported-dashboard-metrics="<%= @supported_dashboard_metrics.to_json %>"></div>

--- a/server/webapp/WEB-INF/rails.new/spec/controllers/analytics_controller_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/controllers/analytics_controller_spec.rb
@@ -63,6 +63,7 @@ describe AnalyticsController do
 
       allow(info).to receive(:getDescriptor).and_return(descriptor)
       allow(info).to receive(:getCapabilities).and_return(cap)
+      allow(cap).to receive(:supportsDashboardAnalytics).and_return(true)
       allow(cap).to receive(:supportedAnalyticsDashboardMetrics).and_return(["foo"])
 
       allow(controller).to receive(:default_plugin_info_finder).and_return(plugin_info_finder)
@@ -71,7 +72,7 @@ describe AnalyticsController do
       get :index
 
       expect(response).to be_ok
-      expect(controller.instance_variable_get(:@plugin_ids)).to eq({"com.tw.myplugin" => ["foo"]})
+      expect(controller.instance_variable_get(:@supported_dashboard_metrics)).to eq({"com.tw.myplugin" => ["foo"]})
     end
 
     it 'should render the analytics data for the dashboard' do

--- a/server/webapp/WEB-INF/rails.new/spec/presenters/api_v4/plugin/plugin_info_representer_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/presenters/api_v4/plugin/plugin_info_representer_spec.rb
@@ -308,7 +308,7 @@ describe ApiV4::Plugin::PluginInfoRepresenter do
       plugin_view = com.thoughtworks.go.plugin.domain.common.PluginView.new('plugin_view_template')
       plugin_metadata = com.thoughtworks.go.plugin.domain.common.Metadata.new(true, false)
       plugin_settings = com.thoughtworks.go.plugin.domain.common.PluggableInstanceSettings.new([com.thoughtworks.go.plugin.domain.common.PluginConfiguration.new('username', plugin_metadata)], plugin_view)
-      capabilities = com.thoughtworks.go.plugin.domain.analytics.Capabilities.new(true, true)
+      capabilities = com.thoughtworks.go.plugin.domain.analytics.Capabilities.new(true, ["top_10_jobs_waiting"])
 
       plugin_info = com.thoughtworks.go.plugin.domain.analytics.AnalyticsPluginInfo.new(descriptor, image, capabilities, plugin_settings)
       actual_json = ApiV4::Plugin::PluginInfoRepresenter.new(plugin_info).to_hash(url_builder: UrlBuilder.new)

--- a/server/webapp/WEB-INF/rails.new/webpack/single_page_apps/analytics.js
+++ b/server/webapp/WEB-INF/rails.new/webpack/single_page_apps/analytics.js
@@ -42,12 +42,12 @@
   });
 
   document.addEventListener("DOMContentLoaded", () => {
-    const main = document.querySelector("[data-plugin-ids]");
+    const main = document.querySelector("[data-supported-dashboard-metrics]");
 
     m.mount(main, {
       view() {
         const frames = [];
-        $.each($(main).data("plugin-ids"), (pluginId, metrics) => {
+        $.each($(main).data("supported-dashboard-metrics"), (pluginId, metrics) => {
           $.each(metrics, (idx, metric) => {
             const uid = `f-${pluginId}:${metric}:${idx}`;
 


### PR DESCRIPTION
* Analytics capabilities constructor was changed from from (boolean,
  boolean) to (boolean, list). The plugin info representer spec
  continued to pass (boolean, boolean). Due to this, the 'TrueClass' was
  extended to include Enumerable and List modules. This led to issues
  when flattening a array with boolean value 'true' during asset compile.
* Some minor refactoring.