### PR TITLE
Improve modal ui

### DIFF
--- a/server/webapp/WEB-INF/rails.new/app/assets/new_stylesheets/shared/_modal.scss
+++ b/server/webapp/WEB-INF/rails.new/app/assets/new_stylesheets/shared/_modal.scss
@@ -15,15 +15,20 @@
  */
 
 .reveal {
-  padding: 30px;
-  .modal-title {
+  padding: 0;
+  .modal-header {
     border-bottom:           1px solid #ccc;
-    padding:                 10px 15px;
-    margin:                  -30px -30px 20px;
+    padding:                 10px 10px;
     border-top-left-radius:  $global-border-radius;
     background:              #e0dfdf;
     border-top-right-radius: $global-border-radius;
     font-size:               rem-calc(16px);
+  }
+
+  .modal-body {
+    max-height: 500px;
+    overflow-y: auto;
+    padding:    5px 14px;
   }
 
   thead th, thead td, tfoot th, tfoot td, tbody th, tbody td {
@@ -32,7 +37,7 @@
   }
 
   .modal-buttons {
-    margin-top: 20px;
+    margin: 14px;
     .button {
       margin: 0 1rem 0 0;
       &.in-progress {
@@ -67,7 +72,6 @@
   }
 }
 
-.close-button {
-  right: 13px;
-  top:   5px;
+.fixed {
+  overflow: hidden;
 }

--- a/server/webapp/WEB-INF/rails.new/webpack/views/shared/new_modal.js.msx
+++ b/server/webapp/WEB-INF/rails.new/webpack/views/shared/new_modal.js.msx
@@ -57,24 +57,25 @@ const Modal = function (options) {
       };
     },
 
-    view (vnode) {
+    view(vnode) {
       return (
         <div class="reveal-overlay" style={{display: 'block'}}>
           <div class={`reveal ${  options.size ? options.size : ''}`}
                style={{display: 'block'}}>
 
-            <h4 class='modal-title'>{options.title}</h4>
+            <div class="modal-header">
+              <span class="modal-title">{options.title}</span>
+              <button class="close-button"
+                      aria-label="Close modal"
+                      type="button"
+                      onclick={vnode.state.close.bind(vnode, options.onclose, self.destroy)}>
+                <span aria-hidden="true">&times;</span>
+              </button>
+            </div>
 
             <div class="modal-body">
               {options.body()}
             </div>
-
-            <button class="close-button"
-                    aria-label="Close modal"
-                    type="button"
-                    onclick={vnode.state.close.bind(vnode, options.onclose, self.destroy)}>
-              <span aria-hidden="true">&times;</span>
-            </button>
 
             <f.row class="modal-buttons" collapse>
               {_.map(_.isFunction(options.buttons) ? options.buttons() : options.buttons, (button) => {
@@ -93,11 +94,13 @@ const Modal = function (options) {
 
   this.render = function () {
     allModals[modalId] = this;
+    $('body').addClass("fixed");
     m.redraw();
   };
 
   this.destroy = function () {
     delete allModals[modalId];
+    $('body').removeClass("fixed");
     m.redraw();
   };
 };


### PR DESCRIPTION
It would be good to merge #4296 before this so that I can rebase and incorporate those changes.

Changes in this PR:
* Fix the modal height when the view scrolls
* Made the header sticky when it scrolls
* Make the close button part of the header so that it doesn't scroll out of view

Needs to be tested on different browsers and OSes. I have tested on the latest Chrome, FF and Safari on MacOS.