### PR TITLE
Dashboard SPA Improvements (#4081)

### DIFF
--- a/server/webapp/WEB-INF/rails.new/spec/webpack/models/dashboard/pipeline_instance_spec.js
+++ b/server/webapp/WEB-INF/rails.new/spec/webpack/models/dashboard/pipeline_instance_spec.js
@@ -41,21 +41,10 @@ describe("Dashboard", () => {
       expect(pipelineInstance.stages[0].stageDetailTabPath).toEqual(path);
       expect(pipelineInstance.stages[0].isBuilding()).toEqual(false);
 
+      expect(pipelineInstance.stages[0].isBuildingOrCompleted()).toEqual(true);
+      expect(pipelineInstance.stages[1].isBuildingOrCompleted()).toEqual(false);
+
       expect(pipelineInstance.materialRevisions.length).toEqual(1);
-    });
-
-    it("it should get latest stage information", () => {
-      const pipelineInstance = new PipelineInstance(pipelineInstanceJson, pipelineName);
-      const stage            = pipelineInstanceJson._embedded.stages[0];
-
-      expect(pipelineInstance.latestStageInfo()).toBe(`${stage.status}: ${stage.name}`);
-    });
-
-    it("it should get latest stage information for building pipeline", () => {
-      const pipelineInstance = new PipelineInstance(runningPipelineInstanceJson, pipelineName);
-      const stage            = runningPipelineInstanceJson._embedded.stages[0];
-
-      expect(pipelineInstance.latestStageInfo()).toBe(`${stage.status}: ${stage.name}`);
     });
 
     const pipelineInstanceJson = {
@@ -124,76 +113,22 @@ describe("Dashboard", () => {
             "status":       "Failed",
             "approved_by":  "changes",
             "scheduled_at": "2017-11-10T07:25:28.539Z"
-          }
-        ]
-      }
-    };
-
-    const runningPipelineInstanceJson = {
-      "_links":      {
-        "self":            {
-          "href": "http://localhost:8153/go/api/pipelines/up42/instance/1"
-        },
-        "doc":             {
-          "href": "https://api.go.cd/current/#get-pipeline-instance"
-        },
-        "history_url":     {
-          "href": "http://localhost:8153/go/api/pipelines/up42/history"
-        },
-        "vsm_url":         {
-          "href": "http://localhost:8153/go/pipelines/value_stream_map/up42/1"
-        },
-        "compare_url":     {
-          "href": "http://localhost:8153/go/compare/up42/0/with/1"
-        },
-        "build_cause_url": {
-          "href": "http://localhost:8153/go/pipelines/up42/1/build_cause"
-        }
-      },
-      "build_cause": {
-        "approver":           "",
-        "is_forced":          false,
-        "trigger_message":    "modified by GoCD Test User <devnull@example.com>",
-        "material_revisions": [
-          {
-            "material_type": "Git",
-            "material_name": "test-repo",
-            "changed":       true,
-            "modifications": [
-              {
-                "_links":        {
-                  "vsm": {
-                    "href": "http://localhost:8153/go/materials/value_stream_map/4879d548de8a9d7122ceb71e7809c1f91a0876afa534a4f3ba7ed4a532bc1b02/9c86679eefc3c5c01703e9f1d0e96b265ad25691"
-                  }
-                },
-                "user_name":     "GoCD Test User <devnull@example.com>",
-                "revision":      "9c86679eefc3c5c01703e9f1d0e96b265ad25691",
-                "modified_time": "2017-12-19T05:30:32.000Z",
-                "comment":       "Initial commit"
-              }
-            ]
-          }
-        ]
-      },
-      "label":       "1",
-      "counter":     "1",
-      "_embedded":   {
-        "stages": [
-          {
-            "name":         "up42_stage_1",
-            "counter":      "1",
-            "status":       "Building",
-            "approved_by":  "changes",
-            "scheduled_at": "2017-11-10T07:25:28.539Z"
           },
           {
-            "name":         "up42_stage_2",
+            "_links":       {
+              "self": {
+                "href": "http://localhost:8153/go/api/stages/up42/1/up42_stage/1"
+              },
+              "doc":  {
+                "href": "https://api.go.cd/current/#get-stage-instance"
+              }
+            },
+            "name":         "up42_stage",
             "counter":      "1",
             "status":       "Unknown",
             "approved_by":  "changes",
             "scheduled_at": "2017-11-10T07:25:28.539Z"
           }
-
         ]
       }
     };

--- a/server/webapp/WEB-INF/rails.new/spec/webpack/views/dashboard/pipeline_widget_spec.js
+++ b/server/webapp/WEB-INF/rails.new/spec/webpack/views/dashboard/pipeline_widget_spec.js
@@ -197,6 +197,18 @@ describe("Dashboard Pipeline Widget", () => {
         expect($root.find('.pipeline_pause-message')).toContainText('Paused by admin (under construction)');
       });
 
+      it("should not render null in case of no pipeline pause message", () => {
+        unmount();
+        pauseInfo = {
+          "paused":       true,
+          "paused_by":    "admin",
+          "pause_reason": null
+        };
+
+        mount(false, true, pauseInfo, undefined, false);
+        expect($root.find('.pipeline_pause-message')).toContainText('Paused by admin ()');
+      });
+
       it("should not render the pipeline flash message", () => {
         expect($root.find('.pipeline_message')).not.toBeInDOM();
         expect($root.find('.pipeline_message .success')).not.toBeInDOM();

--- a/server/webapp/WEB-INF/rails.new/spec/webpack/views/dashboard/stages_instance_widget_spec.js
+++ b/server/webapp/WEB-INF/rails.new/spec/webpack/views/dashboard/stages_instance_widget_spec.js
@@ -103,7 +103,7 @@ describe("Dashboard Stages Instance Widget", () => {
           },
           "name":         "up42_stage2",
           "counter":      "1",
-          "status":       "Building",
+          "status":       "Unknown",
           "approved_by":  "changes",
           "scheduled_at": "2017-11-10T07:25:28.539Z"
         }
@@ -134,14 +134,18 @@ describe("Dashboard Stages Instance Widget", () => {
     const stagesInstance = $root.find('.pipeline_stage');
 
     expect(stagesInstance.get(0)).toHaveClass('failed');
-    expect(stagesInstance.get(1)).toHaveClass('building');
+    expect(stagesInstance.get(1)).toHaveClass('unknown');
   });
 
   it("should link to stage details page", () => {
     const stagesInstance = $root.find('.pipeline_stage');
 
     expect(stagesInstance.get(0).href.indexOf(`/go/pipelines/up42/1/up42_stage/1`)).not.toEqual(-1);
-    expect(stagesInstance.get(1).href.indexOf(`/go/pipelines/up42/1/up42_stage2/1`)).not.toEqual(-1);
+  });
+
+  it("should not link to stage details page for stages with no run", () => {
+    expect($root.find('span.pipeline_stage')).toBeInDOM();
+    expect($root.find('span.pipeline_stage')).toHaveClass('unknown');
   });
 
   it("should show stage status on hover", () => {

--- a/server/webapp/WEB-INF/rails.new/webpack/models/dashboard/pipeline_instance.js
+++ b/server/webapp/WEB-INF/rails.new/webpack/models/dashboard/pipeline_instance.js
@@ -19,11 +19,12 @@ const Routes           = require('gen/js-routes');
 const MaterialRevision = require('models/dashboard/material_revision');
 
 const StageInstance = function (json, pipelineName, pipelineCounter) {
-  this.name               = json.name;
-  this.counter            = json.counter;
-  this.status             = json.status;
-  this.stageDetailTabPath = Routes.stageDetailTabPath(pipelineName, pipelineCounter, json.name, json.counter);
-  this.isBuilding         = () => json.status === 'Building';
+  this.name                  = json.name;
+  this.counter               = json.counter;
+  this.status                = json.status;
+  this.stageDetailTabPath    = Routes.stageDetailTabPath(pipelineName, pipelineCounter, json.name, json.counter);
+  this.isBuilding            = () => json.status === 'Building';
+  this.isBuildingOrCompleted = () => json.status !== 'Unknown';
 };
 
 const PipelineInstance = function (info, pipelineName) {
@@ -39,19 +40,6 @@ const PipelineInstance = function (info, pipelineName) {
   this.stages = _.map(info._embedded.stages, (stage) => new StageInstance(stage, this.pipelineName, this.counter));
 
   this.materialRevisions = _.map(info.build_cause.material_revisions, (revision) => new MaterialRevision(revision));
-
-  this.latestStageInfo = () => {
-    const stages = this.stages;
-
-    for (let i = 0; i < stages.length; i++) {
-      if (stages[i].isBuilding()) {
-        return `${stages[i].status}: ${stages[i].name}`;
-      }
-    }
-
-    const lastStage = stages[stages.length - 1];
-    return `${lastStage.status}: ${lastStage.name}`;
-  };
 };
 
 module.exports = PipelineInstance;

--- a/server/webapp/WEB-INF/rails.new/webpack/views/dashboard/pipeline_widget.js.msx
+++ b/server/webapp/WEB-INF/rails.new/webpack/views/dashboard/pipeline_widget.js.msx
@@ -81,7 +81,7 @@ const PipelineOperationsWidget = {
     let pausedMessage, pauseUnpauseClass, onPauseUnpauseClick;
     if (pipeline.isPaused) {
       pauseUnpauseClass   = `btn unpause ${(pipeline.canPause) ? '' : 'disabled' }`;
-      pausedMessage       = `Paused by ${pipeline.pausedBy} (${pipeline.pausedCause})`;
+      pausedMessage       = `Paused by ${pipeline.pausedBy} (${pipeline.pausedCause || ''})`;
       onPauseUnpauseClick = (pipeline.canPause) && vnode.state.unpause.bind(vnode.state, pipeline);
     } else {
       pauseUnpauseClass   = `btn pause ${(pipeline.canPause) ? '' : 'disabled' }`;

--- a/server/webapp/WEB-INF/rails.new/webpack/views/dashboard/stages_instance_widget.js.msx
+++ b/server/webapp/WEB-INF/rails.new/webpack/views/dashboard/stages_instance_widget.js.msx
@@ -22,11 +22,17 @@ const StagesInstanceWidget = {
     const stages        = vnode.attrs.stages;
     const stageInstance = _.map(stages, (stage) => {
       const stageStatus = `${stage.name} (${stage.status})`;
-      return (<a href={stage.stageDetailTabPath}
-                 class={`pipeline_stage ${  stage.status.toLowerCase() }`}
-                 title={stageStatus}>
-        <span><span></span></span>
-      </a>);
+
+      if (stage.isBuildingOrCompleted()) {
+        return (<a href={stage.stageDetailTabPath}
+                   class={`pipeline_stage ${  stage.status.toLowerCase() }`}
+                   title={stageStatus}>
+          <span><span></span></span>
+        </a>);
+      }
+
+      return (<span class={`pipeline_stage ${  stage.status.toLowerCase() }`}
+                    title={stageStatus}/>);
     });
 
     return (


### PR DESCRIPTION
* [Fix Bug] Do not show 'null' as pipeline pause cause in case of no pause message.
* [Fix Bug] Do not link to stage details tab in case of no stage run.
* Remove unused 'PipelineInstance.latestStageInfo' method and related tests.