### PR TITLE
Trigger With Options Skeleton (#4234)

### DIFF
--- a/server/webapp/WEB-INF/rails.new/app/assets/new_stylesheets/single_page_apps/new_dashboard.scss
+++ b/server/webapp/WEB-INF/rails.new/app/assets/new_stylesheets/single_page_apps/new_dashboard.scss
@@ -496,3 +496,123 @@ $pipeline_icons_size: 16px;
     }
   }
 }
+
+//trigger with options
+
+$h-tab__head_width: 100%;
+$h-tab__container_width: 500px;
+
+$v-tab__head_width: 125px;
+$v-tab__container_width: 500px;
+
+$border-color: #ccc;
+$border-color-active: #94399e;
+$tab-hover-bg: #f5f5f5;
+$tab-head-color: #333;
+$tab-bg: #e5e5e5;
+$active-tab: #94399e;
+
+.h-tab {
+  display:         flex;
+  flex-direction:  column;
+  justify-content: flex-start;
+}
+
+.h-tab_tab-head {
+  display:        flex;
+  flex-direction: row;
+  margin:         0 0 30px 0;
+  padding:        0;
+  list-style:     none;
+  width:          $h-tab__head_width;
+  li {
+    font-size:     16px;
+    margin:        0 0 1px 0;
+    cursor:        pointer;
+    padding:       0 20px;
+    height:        32px;
+    line-height:   31px;
+    color:         $tab-head-color;
+    border-bottom: 0;
+    overflow:      hidden;
+    position:      relative;
+    &:hover {
+      border-bottom: 3px solid $tab-hover-bg;
+      color:         #000;
+    }
+    &.active {
+      border-bottom:    3px solid $border-color-active;
+      background-color: #fff;
+      color:            $active-tab;
+      display:          block;
+    }
+  }
+
+  .h-tab_container {
+    width:      $h-tab__container_width;
+    min-height: 200px;
+  }
+
+  .h-tab_content {
+    padding: 10px 20px;
+    display: none;
+    > :first-child {
+      margin-top: 0;
+    }
+  }
+}
+
+.v-tab {
+  display: flex;
+}
+
+.v-tab_tab-head {
+  margin:     0;
+  padding:    0;
+  float:      left;
+  list-style: none;
+  height:     32px;
+  width:      $v-tab__head_width;
+  li {
+    // float: left;
+    margin:        0 0 1px 0;
+    cursor:        pointer;
+    padding:       0 10%;
+    height:        32px;
+    line-height:   31px;
+    color:         $tab-head-color;
+    border-bottom: 0;
+    overflow:      hidden;
+    position:      relative;
+    width:         80%;
+    &:hover {
+      background-color: $tab-hover-bg;
+      color:            #000;
+    }
+    &.active {
+      border-right:     3px solid $border-color-active;
+      background-color: #fff;
+      color:            $active-tab;
+      display:          block;
+    }
+  }
+}
+
+.hidden {
+  display: none;
+}
+
+.v-tab_container {
+  border-left: 1px solid $border-color;
+  float:       left;
+  width:       $v-tab__container_width;
+  min-height:  132px;
+}
+
+.v-tab_content {
+  padding: 10px 20px;
+  display: none;
+  > :first-child {
+    margin-top: 0;
+  }
+}

--- a/server/webapp/WEB-INF/rails.new/spec/webpack/models/dashboard/environment_variables_spec.js
+++ b/server/webapp/WEB-INF/rails.new/spec/webpack/models/dashboard/environment_variables_spec.js
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2018 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+describe("Dashboard", () => {
+  describe('Environment Variables Model', () => {
+
+    const EnvironmentVariables = require('models/dashboard/environment_variables');
+
+    it("should deserialize from json", () => {
+      const envVars = EnvironmentVariables.fromJSON(json);
+
+      expect(envVars.length).toBe(json.length);
+
+      expect(envVars[0].name()).toBe(json[0].name);
+      expect(envVars[0].value()).toBe(json[0].value);
+
+      expect(envVars[1].name()).toBe(json[1].name);
+      expect(envVars[1].value()).toBe(json[1].value);
+    });
+
+    const json = [
+      {
+        "name":  "version",
+        "value": "asdf"
+      },
+      {
+        "name":  "foobar",
+        "value": "asdf"
+      }
+    ];
+
+  });
+});

--- a/server/webapp/WEB-INF/rails.new/spec/webpack/models/dashboard/materials_spec.js
+++ b/server/webapp/WEB-INF/rails.new/spec/webpack/models/dashboard/materials_spec.js
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2018 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+describe("Dashboard", () => {
+  describe('Materials Model', () => {
+
+    const Materials = require('models/dashboard/materials');
+
+    it("should deserialize from json", () => {
+      const materials = Materials.fromJSON(json);
+
+      expect(materials.length).toBe(json.length);
+
+      expect(materials[0].name).toBe(json[0].name);
+      expect(materials[0].type).toBe(json[0].type);
+      expect(materials[0].fingerprint).toBe(json[0].fingerprint);
+
+      expect(materials[0].revision.date).toBe(json[0].revision.date);
+      expect(materials[0].revision.user).toBe(json[0].revision.user);
+      expect(materials[0].revision.comment).toBe(json[0].revision.comment);
+      expect(materials[0].revision.lastRunRevision).toBe(json[0].revision.last_run_revision);
+    });
+
+    const json = [
+      {
+        "type":        "Git",
+        "name":        "https://github.com/ganeshspatil/gocd",
+        "fingerprint": "3dcc10e7943de637211a4742342fe456ffbe832577bb377173007499434fd819",
+        "revision":    {
+          "date":              "2018-02-08T04:32:11Z",
+          "user":              "Ganesh S Patil <ganeshpl@thoughtworks.com>",
+          "comment":           "Refactor Pipeline Widget (#4311)\n\n* Extract out PipelineHeaderWidget and PipelineOperationsWidget into seperate msx files",
+          "last_run_revision": "a2d23c5505ac571d9512bdf08d6287e47dcb52d5"
+        }
+      }
+    ];
+
+  });
+});

--- a/server/webapp/WEB-INF/rails.new/spec/webpack/models/dashboard/trigger_with_options_info_spec.js
+++ b/server/webapp/WEB-INF/rails.new/spec/webpack/models/dashboard/trigger_with_options_info_spec.js
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2018 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+describe("Dashboard", () => {
+  describe('Trigger With Option Information Model', () => {
+
+    const TriggerWithOptionsInfo = require('models/dashboard/trigger_with_options_info');
+
+    it("should deserialize from json", () => {
+      const info = TriggerWithOptionsInfo.fromJSON(json);
+
+      expect(info.materials.length).toBe(json.materials.length);
+      expect(info.plainTextVariables.length).toBe(json.environment_variables.length);
+      expect(info.secureVariables.length).toBe(json.secure_environment_variables.length);
+    });
+
+    const json = {
+      "environment_variables":        [
+        {
+          "name":  "version",
+          "value": "asdf"
+        },
+        {
+          "name":  "foobar",
+          "value": "asdf"
+        }
+      ],
+      "secure_environment_variables": [
+        {
+          "name":  "secure1",
+          "value": "****"
+        },
+        {
+          "name":  "highly secure",
+          "value": "****"
+        }
+      ],
+
+      "materials": [
+        {
+          "type":        "Git",
+          "name":        "https://github.com/ganeshspatil/gocd",
+          "fingerprint": "3dcc10e7943de637211a4742342fe456ffbe832577bb377173007499434fd819",
+          "revision":    {
+            "date":              "2018-02-08T04:32:11Z",
+            "user":              "Ganesh S Patil <ganeshpl@thoughtworks.com>",
+            "comment":           "Refactor Pipeline Widget (#4311)\n\n* Extract out PipelineHeaderWidget and PipelineOperationsWidget into seperate msx files",
+            "last_run_revision": "a2d23c5505ac571d9512bdf08d6287e47dcb52d5"
+          }
+        }
+      ]
+    };
+  });
+});

--- a/server/webapp/WEB-INF/rails.new/spec/webpack/views/dashboard/model/trigger_with_options_vm_spec.js
+++ b/server/webapp/WEB-INF/rails.new/spec/webpack/views/dashboard/model/trigger_with_options_vm_spec.js
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2018 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+describe("Dashboard Trigger With Options View Model", () => {
+  const TriggerWithOptionsVM   = require("views/dashboard/models/trigger_with_options_vm");
+  const TriggerWithOptionsInfo = require('models/dashboard/trigger_with_options_info');
+
+  describe('initialize', () => {
+    let vm;
+    beforeEach(() => {
+      vm = new TriggerWithOptionsVM();
+      vm.initialize(TriggerWithOptionsInfo.fromJSON(json));
+    });
+
+    it('should contain tab keys on the vm', () => {
+      expect(vm.MATERIALS_TAB_KEY).toBe('materials');
+      expect(vm.ENVIRONMENT_VARIABLES_TAB_KEY).toBe('environment-variables');
+      expect(vm.SECURE_ENVIRONMENT_VARIABLES_TAB_KEY).toBe('secure-environment-variables');
+    });
+
+    it('should initialize VM with tab states', () => {
+      expect(vm.isTabSelected(vm.MATERIALS_TAB_KEY)).toBe(true);
+      expect(vm.isTabSelected(vm.ENVIRONMENT_VARIABLES_TAB_KEY)).toBe(false);
+      expect(vm.isTabSelected(vm.SECURE_ENVIRONMENT_VARIABLES_TAB_KEY)).toBe(false);
+    });
+
+    it("should select the materials tab by default", () => {
+      expect(vm.isTabSelected(vm.MATERIALS_TAB_KEY)).toBe(true);
+    });
+
+    it("should select a tab", () => {
+      expect(vm.isTabSelected(vm.MATERIALS_TAB_KEY)).toBe(true);
+      expect(vm.isTabSelected(vm.ENVIRONMENT_VARIABLES_TAB_KEY)).toBe(false);
+      expect(vm.isTabSelected(vm.SECURE_ENVIRONMENT_VARIABLES_TAB_KEY)).toBe(false);
+
+      vm.selectTab(vm.ENVIRONMENT_VARIABLES_TAB_KEY);
+
+      expect(vm.isTabSelected(vm.MATERIALS_TAB_KEY)).toBe(false);
+      expect(vm.isTabSelected(vm.ENVIRONMENT_VARIABLES_TAB_KEY)).toBe(true);
+      expect(vm.isTabSelected(vm.SECURE_ENVIRONMENT_VARIABLES_TAB_KEY)).toBe(false);
+    });
+  });
+
+  const json = {
+    "environment_variables":        [
+      {
+        "name":  "version",
+        "value": "asdf"
+      },
+      {
+        "name":  "foobar",
+        "value": "asdf"
+      }
+    ],
+    "secure_environment_variables": [
+      {
+        "name":  "secure1",
+        "value": "****"
+      },
+      {
+        "name":  "highly secure",
+        "value": "****"
+      }
+    ],
+
+    "materials": [
+      {
+        "type":        "Git",
+        "name":        "https://github.com/ganeshspatil/gocd",
+        "fingerprint": "3dcc10e7943de637211a4742342fe456ffbe832577bb377173007499434fd819",
+        "revision":    {
+          "date":              "2018-02-08T04:32:11Z",
+          "user":              "Ganesh S Patil <ganeshpl@thoughtworks.com>",
+          "comment":           "Refactor Pipeline Widget (#4311)\n\n* Extract out PipelineHeaderWidget and PipelineOperationsWidget into seperate msx files",
+          "last_run_revision": "a2d23c5505ac571d9512bdf08d6287e47dcb52d5"
+        }
+      }
+    ]
+  };
+});

--- a/server/webapp/WEB-INF/rails.new/spec/webpack/views/dashboard/pipeline_trigger_with_options_modal_body_spec.js
+++ b/server/webapp/WEB-INF/rails.new/spec/webpack/views/dashboard/pipeline_trigger_with_options_modal_body_spec.js
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2018 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+describe("Dashboard Pipeline Trigger With Options Modal Body", () => {
+  const m                           = require("mithril");
+  const Stream                      = require("mithril/stream");
+  const Modal                       = require('views/shared/new_modal');
+  const TriggerWithOptionsModalBody = require("views/dashboard/pipeline_trigger_with_options_modal_body");
+
+  const TriggerWithOptionsVM   = require('views/dashboard/models/trigger_with_options_vm');
+  const TriggerWithOptionsInfo = require("models/dashboard/trigger_with_options_info");
+
+  let $root, root;
+  beforeEach(() => {
+    [$root, root] = window.createDomElementForTest();
+  });
+  afterEach(window.destroyDomElementForTest);
+
+  let triggerWithOptionsInfo, vm;
+
+  beforeEach(mount);
+
+  afterEach(unmount);
+
+  it("should render pipeline trigger with options information", () => {
+    expect($root.find('.pipeline_trigger-with-options')).toBeInDOM();
+  });
+
+  it("shoould render tab headings", () => {
+    const headings = $root.find('.pipeline_options-heading li');
+
+    expect(headings.length).toBe(3);
+    expect(headings.get(0)).toContainText('Materials');
+    expect(headings.get(1)).toContainText('Environment variables');
+    expect(headings.get(2)).toContainText('Secure Environment variables');
+  });
+
+  it("should render materials section", () => {
+    expect($root.find('#pipeline_materials-section')).toBeInDOM();
+  });
+
+  it("should render environment variables section", () => {
+    expect($root.find('#pipeline_envvars-section')).toBeInDOM();
+  });
+
+  it("should render secure environment variables section", () => {
+    expect($root.find('#pipeline_secure-envvars-section')).toBeInDOM();
+  });
+
+  it("should show select materials tab by default", () => {
+    expect($root.find('.pipeline_options-heading li').get(0)).toHaveClass('active');
+
+    expect($root.find('#pipeline_materials-section')).not.toHaveClass('hidden');
+    expect($root.find('#pipeline_envvars-section')).toHaveClass('hidden');
+    expect($root.find('#pipeline_secure-envvars-section')).toHaveClass('hidden');
+  });
+
+  it("should show appropriate content based on tab selected", () => {
+    expect($root.find('.pipeline_options-heading li').get(0)).toHaveClass('active');
+    expect($root.find('#pipeline_materials-section')).not.toHaveClass('hidden');
+    expect($root.find('#pipeline_envvars-section')).toHaveClass('hidden');
+    expect($root.find('#pipeline_secure-envvars-section')).toHaveClass('hidden');
+
+    $root.find('.pipeline_options-heading li').get(1).click();
+
+    expect($root.find('.pipeline_options-heading li').get(1)).toHaveClass('active');
+
+    expect($root.find('#pipeline_materials-section')).toHaveClass('hidden');
+    expect($root.find('#pipeline_envvars-section')).not.toHaveClass('hidden');
+    expect($root.find('#pipeline_secure-envvars-section')).toHaveClass('hidden');
+  });
+
+  function mount() {
+    triggerWithOptionsInfo = TriggerWithOptionsInfo.fromJSON(json);
+    vm                     = new TriggerWithOptionsVM();
+    vm.initialize(triggerWithOptionsInfo);
+
+    m.mount(root, {
+      view() {
+        return m(TriggerWithOptionsModalBody, {
+          triggerWithOptionsInfo: Stream(triggerWithOptionsInfo),
+          vm:                     Stream(vm)
+        });
+      }
+    });
+    m.redraw(true);
+  }
+
+  function unmount() {
+    Modal.destroyAll();
+    m.mount(root, null);
+    m.redraw();
+  }
+
+  const json = {
+    "environment_variables":        [
+      {
+        "name":  "version",
+        "value": "asdf"
+      },
+      {
+        "name":  "foobar",
+        "value": "asdf"
+      }
+    ],
+    "secure_environment_variables": [
+      {
+        "name":  "secure1",
+        "value": "****"
+      },
+      {
+        "name":  "highly secure",
+        "value": "****"
+      }
+    ],
+
+    "materials": [
+      {
+        "type":        "Git",
+        "name":        "https://github.com/ganeshspatil/gocd",
+        "fingerprint": "3dcc10e7943de637211a4742342fe456ffbe832577bb377173007499434fd819",
+        "revision":    {
+          "date":              "2018-02-08T04:32:11Z",
+          "user":              "Ganesh S Patil <ganeshpl@thoughtworks.com>",
+          "comment":           "Refactor Pipeline Widget (#4311)\n\n* Extract out PipelineHeaderWidget and PipelineOperationsWidget into seperate msx files",
+          "last_run_revision": "a2d23c5505ac571d9512bdf08d6287e47dcb52d5"
+        }
+      }
+    ]
+  };
+});

--- a/server/webapp/WEB-INF/rails.new/webpack/models/dashboard/environment_variables.js
+++ b/server/webapp/WEB-INF/rails.new/webpack/models/dashboard/environment_variables.js
@@ -14,20 +14,21 @@
  * limitations under the License.
  */
 
-module.exports = {
-  pipelinePausePath: (pipelineName) => {
-    return `/go/api/pipelines/${pipelineName}/pause`;
-  },
+const _      = require('lodash');
+const Stream = require('mithril/stream');
 
-  pipelineUnpausePath: (pipelineName) => {
-    return `/go/api/pipelines/${pipelineName}/unpause`;
-  },
-
-  pipelineUnlockPath: (pipelineName) => {
-    return `/go/api/pipelines/${pipelineName}/unlock`;
-  },
-
-  pipelineTriggerWithOptionsViewPath: (pipelineName) => {
-    return `/go/api/internal/trigger_with_options_view/${pipelineName}`;
-  }
+const EnvironmentVariable = function (name, value) {
+  this.name  = Stream(name);
+  this.value = Stream(value);
 };
+
+EnvironmentVariable.fromJSON = (json) => {
+  return new EnvironmentVariable(json.name, json.value);
+};
+
+const EnvironmentVariables    = {};
+EnvironmentVariables.fromJSON = (json) => {
+  return _.map(json, (variable) => EnvironmentVariable.fromJSON(variable));
+};
+
+module.exports = EnvironmentVariables;

--- a/server/webapp/WEB-INF/rails.new/webpack/models/dashboard/materials.js
+++ b/server/webapp/WEB-INF/rails.new/webpack/models/dashboard/materials.js
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2018 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const _ = require('lodash');
+
+const MaterialRevision = function (date, user, comment, lastRunRevision) {
+  this.date            = date;
+  this.user            = user;
+  this.comment         = comment;
+  this.lastRunRevision = lastRunRevision;
+};
+
+MaterialRevision.fromJSON = (json) => {
+  return new MaterialRevision(json.date, json.user, json.comment, json.last_run_revision);
+};
+
+//todo: Handle Different type of materials too
+//GaneshSPatil should fix this;
+
+const Material = function (name, type, fingerprint, revision) {
+  this.name        = name;
+  this.type        = type;
+  this.fingerprint = fingerprint;
+  this.revision    = revision;
+};
+
+Material.fromJSON = (json) => {
+  const revision = MaterialRevision.fromJSON(json.revision);
+  return new Material(json.name, json.type, json.fingerprint, revision);
+};
+
+const Materials    = {};
+Materials.fromJSON = (json) => {
+  return _.map(json, (material) => Material.fromJSON(material));
+};
+
+module.exports = Materials;

--- a/server/webapp/WEB-INF/rails.new/webpack/models/dashboard/pipeline.js
+++ b/server/webapp/WEB-INF/rails.new/webpack/models/dashboard/pipeline.js
@@ -22,7 +22,8 @@ const VMRoutes    = require('helpers/vm_routes');
 const SparkRoutes = require('helpers/spark_routes');
 const Routes      = require('gen/js-routes');
 
-const PipelineInstance = require('models/dashboard/pipeline_instance');
+const PipelineInstance       = require('models/dashboard/pipeline_instance');
+const TriggerWithOptionsInfo = require('models/dashboard/trigger_with_options_info');
 
 const Pipeline = function (info) {
   const self = this;
@@ -42,6 +43,8 @@ const Pipeline = function (info) {
 
   this.isLocked  = info.locked;
   this.canUnlock = info.can_unlock;
+
+  this.canOperate = info.can_operate;
 
   const config = (xhr) => {
     xhr.setRequestHeader("X-GoCD-Confirm", "true");
@@ -82,6 +85,25 @@ const Pipeline = function (info) {
 
   this.pause = (payload) => {
     return postURL(SparkRoutes.pipelinePausePath(self.name), payload);
+  };
+
+  this.viewInformationForTriggerWithOptions = () => {
+    return $.Deferred(function () {
+      const deferred = this;
+
+      const jqXHR = $.ajax({
+        method:     'GET',
+        url:        SparkRoutes.pipelineTriggerWithOptionsViewPath(self.name),
+        timeout:    mrequest.timeout,
+        beforeSend: config
+      });
+
+      jqXHR.then((data) => {
+        deferred.resolve(TriggerWithOptionsInfo.fromJSON(data));
+      });
+
+      jqXHR.always(m.redraw);
+    }).promise();
   };
 };
 

--- a/server/webapp/WEB-INF/rails.new/webpack/models/dashboard/trigger_with_options_info.js
+++ b/server/webapp/WEB-INF/rails.new/webpack/models/dashboard/trigger_with_options_info.js
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2018 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const Materials            = require('models/dashboard/materials');
+const EnvironmentVariables = require('models/dashboard/environment_variables');
+
+//todo: Mock data should be removed once the API reponse changes are merged
+//GaneshSPatil did this;
+
+const json = {
+  "environment_variables":        [
+    {
+      "name":  "version",
+      "value": "asdf"
+    },
+    {
+      "name":  "foobar",
+      "value": "asdf"
+    }
+  ],
+  "secure_environment_variables": [
+    {
+      "name":  "secure1",
+      "value": "****"
+    },
+    {
+      "name":  "highly secure",
+      "value": "****"
+    }
+  ],
+
+  "materials": [
+    {
+      "type":        "Git",
+      "name":        "https://github.com/ganeshspatil/gocd",
+      "fingerprint": "3dcc10e7943de637211a4742342fe456ffbe832577bb377173007499434fd819",
+      "revision":    {
+        "date":              "2018-02-08T04:32:11Z",
+        "user":              "Ganesh S Patil <ganeshpl@thoughtworks.com>",
+        "comment":           "Refactor Pipeline Widget (#4311)\n\n* Extract out PipelineHeaderWidget and PipelineOperationsWidget into seperate msx files",
+        "last_run_revision": "a2d23c5505ac571d9512bdf08d6287e47dcb52d5"
+      }
+    }
+  ]
+};
+
+const TriggerWithOptionsInfo = function (materials, plainTextVariables, secureVariables) {
+  this.materials          = materials;
+  this.plainTextVariables = plainTextVariables;
+  this.secureVariables    = secureVariables;
+};
+
+TriggerWithOptionsInfo.fromJSON = (_json) => {
+  const materials                     = Materials.fromJSON(json.materials);
+  const plainTextEnvironmentVariables = EnvironmentVariables.fromJSON(json.environment_variables);
+  const secureEnvironmentVariables    = EnvironmentVariables.fromJSON(json.secure_environment_variables);
+
+  return new TriggerWithOptionsInfo(materials, plainTextEnvironmentVariables, secureEnvironmentVariables);
+};
+
+module.exports = TriggerWithOptionsInfo;

--- a/server/webapp/WEB-INF/rails.new/webpack/views/dashboard/materials_for_trigger_widget.js.msx
+++ b/server/webapp/WEB-INF/rails.new/webpack/views/dashboard/materials_for_trigger_widget.js.msx
@@ -14,20 +14,14 @@
  * limitations under the License.
  */
 
-module.exports = {
-  pipelinePausePath: (pipelineName) => {
-    return `/go/api/pipelines/${pipelineName}/pause`;
-  },
 
-  pipelineUnpausePath: (pipelineName) => {
-    return `/go/api/pipelines/${pipelineName}/unpause`;
-  },
+const m = require('mithril');
 
-  pipelineUnlockPath: (pipelineName) => {
-    return `/go/api/pipelines/${pipelineName}/unlock`;
-  },
-
-  pipelineTriggerWithOptionsViewPath: (pipelineName) => {
-    return `/go/api/internal/trigger_with_options_view/${pipelineName}`;
+const MaterialsForTriggerWidget = {
+  view(_vnode) {
+    return (<div>Materials Section</div>);
   }
 };
+
+module.exports = MaterialsForTriggerWidget;
+

--- a/server/webapp/WEB-INF/rails.new/webpack/views/dashboard/models/trigger_with_options_vm.js
+++ b/server/webapp/WEB-INF/rails.new/webpack/views/dashboard/models/trigger_with_options_vm.js
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2018 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const _      = require('lodash');
+const Stream = require('mithril/stream');
+
+const TriggerWitHOptionsVM = function () {
+  const materialsState = {};
+  const tabsState      = {};
+
+  const viewModel = {
+    MATERIALS_TAB_KEY:                    'materials',
+    ENVIRONMENT_VARIABLES_TAB_KEY:        'environment-variables',
+    SECURE_ENVIRONMENT_VARIABLES_TAB_KEY: 'secure-environment-variables',
+
+    isTabSelected: (tabKey) => tabsState[tabKey](),
+
+    selectTab: (tabKey) => {
+      _.each(_.keys(tabsState), (tab) => {
+        (tab === tabKey) ? tabsState[tab](true) : tabsState[tab](false);
+      });
+    },
+
+    initialize: (triggerWithOptionsInfo) => {
+      tabsState[viewModel.MATERIALS_TAB_KEY]                    = Stream(true);
+      tabsState[viewModel.ENVIRONMENT_VARIABLES_TAB_KEY]        = Stream(false);
+      tabsState[viewModel.SECURE_ENVIRONMENT_VARIABLES_TAB_KEY] = Stream(false);
+
+      _.each(triggerWithOptionsInfo.materials, (material) => {
+        materialsState[material] = Stream(false);
+      });
+
+      materialsState[triggerWithOptionsInfo.materials[0]](true);
+    }
+  };
+
+
+  return viewModel;
+};
+
+
+module.exports = TriggerWitHOptionsVM;

--- a/server/webapp/WEB-INF/rails.new/webpack/views/dashboard/pipeline_operations_widget.js.msx
+++ b/server/webapp/WEB-INF/rails.new/webpack/views/dashboard/pipeline_operations_widget.js.msx
@@ -14,10 +14,12 @@
  * limitations under the License.
  */
 
-const m                      = require('mithril');
-const Stream                 = require('mithril/stream');
-const Modal                  = require('views/shared/new_modal');
-const PipelinePauseModalBody = require('views/dashboard/pipeline_pause_modal_body');
+const m                                   = require('mithril');
+const Stream                              = require('mithril/stream');
+const Modal                               = require('views/shared/new_modal');
+const PipelinePauseModalBody              = require('views/dashboard/pipeline_pause_modal_body');
+const TriggerWithOptionsVM                = require('views/dashboard/models/trigger_with_options_vm');
+const PipelineTriggerWithOptionsModalBody = require('views/dashboard/pipeline_trigger_with_options_modal_body');
 
 const PipelineOperationsWidget = {
   oninit(vnode) {
@@ -43,7 +45,7 @@ const PipelineOperationsWidget = {
       }).always(vnode.attrs.doRefreshImmediately);
     };
 
-    self.showPopup = (pipeline) => {
+    self.showPausePopup = (pipeline) => {
       const modal = new Modal({
         size:    'medium',
         title:   `Pause pipeline ${pipeline.name}`,
@@ -69,6 +71,47 @@ const PipelineOperationsWidget = {
       });
       modal.render();
     };
+
+    self.triggerWithOptionsVM   = Stream(new TriggerWithOptionsVM());
+    self.triggerWithOptionsInfo = Stream();
+
+    self.showTriggerWithOptionsPopup = (pipeline) => {
+      pipeline.viewInformationForTriggerWithOptions().then((info) => {
+        self.triggerWithOptionsInfo(info);
+        self.triggerWithOptionsVM().initialize(info);
+      }).then(m.redraw);
+
+      const modal = new Modal({
+        size:    'small',
+        title:   `${pipeline.name} - Trigger`,
+        body:    () => (<PipelineTriggerWithOptionsModalBody vm={self.triggerWithOptionsVM}
+                                                             triggerWithOptionsInfo={self.triggerWithOptionsInfo}/>),
+        onclose: () => modal.destroy(),
+        buttons: () => {
+          return [
+            {
+              text:    "Trigger Pipeline",
+              class:   'save primary',
+              onclick: () => {
+                self.triggerWithOptionsInfo(undefined);
+                self.triggerWithOptionsVM(new TriggerWithOptionsVM());
+                modal.destroy();
+              }
+            },
+            {
+              text:    "CLOSE",
+              class:   'save secondary',
+              onclick: () => {
+                self.triggerWithOptionsInfo(undefined);
+                self.triggerWithOptionsVM(new TriggerWithOptionsVM());
+                modal.destroy();
+              }
+            }
+          ];
+        }
+      });
+      modal.render();
+    };
   },
 
   view(vnode) {
@@ -82,7 +125,7 @@ const PipelineOperationsWidget = {
       onPauseUnpauseClick = (pipeline.canPause) && vnode.state.unpause.bind(vnode.state, pipeline);
     } else {
       pauseUnpauseClass   = `btn pause ${(pipeline.canPause) ? '' : 'disabled' }`;
-      onPauseUnpauseClick = (pipeline.canPause) && vnode.state.showPopup.bind(vnode.state, pipeline);
+      onPauseUnpauseClick = (pipeline.canPause) && vnode.state.showPausePopup.bind(vnode.state, pipeline);
     }
 
     let flashMessage;
@@ -92,15 +135,21 @@ const PipelineOperationsWidget = {
       </div>);
     }
 
+    let canOperateClass = '';
+    if (!pipeline.canOperate) {
+      canOperateClass = 'disabled';
+    }
+
     return (
       <div>
         {flashMessage}
         <ul className="pipeline_operations">
           <li>
-            <button className="btn play"/>
+            <button class={`btn play ${canOperateClass}`}/>
           </li>
           <li>
-            <button className="btn play_with_options"/>
+            <button onclick={pipeline.canOperate && vnode.state.showTriggerWithOptionsPopup.bind(vnode.state, pipeline)}
+                    class={`btn play_with_options ${canOperateClass}`}/>
           </li>
           <li>
             <button onclick={onPauseUnpauseClick} class={pauseUnpauseClass}/>

--- a/server/webapp/WEB-INF/rails.new/webpack/views/dashboard/pipeline_trigger_with_options_modal_body.js.msx
+++ b/server/webapp/WEB-INF/rails.new/webpack/views/dashboard/pipeline_trigger_with_options_modal_body.js.msx
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2018 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const m = require('mithril');
+
+const MaterialsForTriggerWidget = require('views/dashboard/materials_for_trigger_widget');
+
+const PipelineTriggerWithOptionsModalBody = {
+  oninit(vnode) {
+    const self = vnode.state;
+
+    self.visibilityClassForTab = (tabKey) => {
+      return vnode.attrs.vm().isTabSelected(tabKey) ? 'active' : '';
+    };
+
+    self.visibilityClassForContent = (tabKey) => {
+      return vnode.attrs.vm().isTabSelected(tabKey) ? '' : 'hidden';
+    };
+  },
+
+
+  view(vnode) {
+    const self = vnode.state;
+    const vm   = vnode.attrs.vm();
+    const info = vnode.attrs.triggerWithOptionsInfo;
+
+    if (!info()) {
+      return (<div class="page-spinner"/>);
+    }
+
+    const materialsKey = vm.MATERIALS_TAB_KEY;
+    const envKey       = vm.ENVIRONMENT_VARIABLES_TAB_KEY;
+    const secureEnvKey = vm.SECURE_ENVIRONMENT_VARIABLES_TAB_KEY;
+
+    return (
+      <div class="h-tab pipeline_trigger-with-options">
+        <ul class="h-tab_tab-head pipeline_options-heading">
+          <li class={self.visibilityClassForTab(materialsKey)}
+              onclick={vm.selectTab.bind(vm, materialsKey)} rel="pipeline_materials-section">
+            Materials
+          </li>
+          <li class={self.visibilityClassForTab(envKey)}
+              onclick={vm.selectTab.bind(vm, envKey)} rel="pipeline_envvars-section">
+            Environment variables
+          </li>
+          <li class={self.visibilityClassForTab(secureEnvKey)}
+              onclick={vm.selectTab.bind(vm, secureEnvKey)} rel="pipeline_secure-envvars-section">
+            Secure Environment variables
+          </li>
+        </ul>
+
+        <div class="h-tab_container pipeline_options-body">
+          <div id="pipeline_materials-section" class={`h-tab_content ${self.visibilityClassForContent(materialsKey)}`}>
+            <MaterialsForTriggerWidget/>
+          </div>
+          <div id="pipeline_envvars-section"
+               class={`h-tab_content ${self.visibilityClassForContent(envKey)}`}>
+            <p>Environment Variables Section</p>
+          </div>
+          <div id="pipeline_secure-envvars-section"
+               class={`h-tab_content ${self.visibilityClassForContent(secureEnvKey)}`}>
+            <p>Secure Environment Variables Section</p>
+          </div>
+        </div>
+      </div>
+    );
+  }
+};
+
+module.exports = PipelineTriggerWithOptionsModalBody;


### PR DESCRIPTION
Create models to store the trigger with options view information
* TriggerWithOptionsInfo model
* Materials model
* EnvironmentVariables model

	- Support other materials apart from git
	- remove mock data once the api responce of trigger_with_options_view api changes

Create Trigger With Options view model to store the state of current tab and contents

Implement Tabs for Pipeline Trigger with options view