### PR TITLE
Reduce spacing between pipeline name and pipeline operation buttons and underline pipeline instance links (#4081) (#4254)

### DIFF
--- a/server/webapp/WEB-INF/rails.new/app/assets/new_stylesheets/single_page_apps/new_dashboard.scss
+++ b/server/webapp/WEB-INF/rails.new/app/assets/new_stylesheets/single_page_apps/new_dashboard.scss
@@ -266,10 +266,11 @@ $pipeline_icons_size: 16px;
       }
     }
     a {
-      display:     block;
-      padding:     0 7px;
-      font-size:   13px;
-      line-height: 13px;
+      display:         block;
+      padding:         0 7px;
+      font-size:       13px;
+      line-height:     13px;
+      text-decoration: underline;
     }
   }
 }
@@ -401,7 +402,7 @@ $pipeline_icons_size: 16px;
 
 .pipeline_operations {
   list-style-type: none;
-  margin:          10px 0 0 0;
+  margin:          5px 0 0 0;
   padding:         0;
   float:           left;
   li {


### PR DESCRIPTION
![screen shot 2018-02-13 at 7 00 56 pm](https://user-images.githubusercontent.com/15275847/36152226-4c804c92-10f0-11e8-94bd-a908816e4020.png)
