### PR TITLE
Personalize api fix

### DIFF
--- a/server/src/main/java/com/thoughtworks/go/server/service/PipelineSelectionsService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/PipelineSelectionsService.java
@@ -49,7 +49,7 @@ public class PipelineSelectionsService {
     }
 
     public PipelineSelections getSelectedPipelines(String id, Long userId){
-        PipelineSelections persistedPipelineSelections = getPersistedPipelineSelections(id, userId);
+        PipelineSelections persistedPipelineSelections = getPersistedSelectedPipelines(id, userId);
         if(persistedPipelineSelections.isBlacklist()){
             List<String> invertedPipelineSelections = invertSelections(persistedPipelineSelections.pipelineList());
             return new PipelineSelections(invertedPipelineSelections, persistedPipelineSelections.lastUpdated(), persistedPipelineSelections.userId(), persistedPipelineSelections.isBlacklist());

--- a/server/src/test-fast/java/com/thoughtworks/go/server/service/PipelineSelectionsServiceTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/service/PipelineSelectionsServiceTest.java
@@ -300,7 +300,24 @@ public class PipelineSelectionsServiceTest {
 
         when(pipelineRepository.findPipelineSelectionsByUserId(user.getId())).thenReturn(pipelineSelections);
 
-        assertThat(pipelineSelectionsService.getSelectedPipelines("1", user.getId()), is(pipelineSelections));
+
+        PipelineSelections selectedPipelines = pipelineSelectionsService.getSelectedPipelines("1", user.getId());
+        assertThat(selectedPipelines.isBlacklist(), is(true));
+        assertThat(selectedPipelines.pipelineList(), is(Arrays.asList("pipeline1", "pipelineX", "pipeline3")));
+    }
+
+    @Test
+    public void shouldReturnAllPipelinesWhenThereAreNoPreviouslyPersistedPipelineSelections() {
+        User user = getUser("loser", 10L);
+        when(goConfigService.getAllPipelineConfigs()).thenReturn(Arrays.asList(pipelineConfig("pipeline1"), pipelineConfig("pipeline2"), pipelineConfig("pipelineX"), pipelineConfig("pipeline3")));
+        when(goConfigService.isSecurityEnabled()).thenReturn(true);
+        List<String> expectedPipelineList = Arrays.asList("pipeline1", "pipeline2", "pipelineX", "pipeline3");
+
+        when(pipelineRepository.findPipelineSelectionsByUserId(user.getId())).thenReturn(null);
+
+        PipelineSelections selectedPipelines = pipelineSelectionsService.getSelectedPipelines("1", user.getId());
+        List<String> actualPipelineList = selectedPipelines.pipelineList();
+        assertThat(actualPipelineList, is(expectedPipelineList));
     }
 
     private PipelineConfig createPipelineConfig(String pipelineName, String stageName, String... buildNames) {


### PR DESCRIPTION
* If no personalization was previously setup the api currently returns a 500 internal error.
* The api will now return all the pipelines a user can see if blacklist value is true and it returns no pipelines if blacklist value is false, given that personalization wasn't setup for a user earlier.