### PR TITLE
Migration for tracking tool link

### DIFF
--- a/base/src/main/java/com/thoughtworks/go/util/GoConstants.java
+++ b/base/src/main/java/com/thoughtworks/go/util/GoConstants.java
@@ -57,7 +57,7 @@ public class GoConstants {
 
     public static final String PRODUCT_NAME = "go";
 
-    public static final int CONFIG_SCHEMA_VERSION = 104;
+    public static final int CONFIG_SCHEMA_VERSION = 105;
 
     public static final String APPROVAL_SUCCESS = "success";
     public static final String APPROVAL_MANUAL = "manual";

--- a/config/config-server/src/main/resources/schemas/104_cruise-config.xsd
+++ b/config/config-server/src/main/resources/schemas/104_cruise-config.xsd
@@ -82,7 +82,7 @@
           </xsd:unique>
         </xsd:element>
       </xsd:sequence>
-      <xsd:attribute name="schemaVersion" type="xsd:int" use="required" fixed="105"/>
+      <xsd:attribute name="schemaVersion" type="xsd:int" use="required" fixed="104"/>
     </xsd:complexType>
     <xsd:unique name="uniquePipelines">
       <xsd:selector xpath="pipelines"/>

--- a/config/config-server/src/main/resources/upgrades/105.xsl
+++ b/config/config-server/src/main/resources/upgrades/105.xsl
@@ -1,0 +1,43 @@
+<?xml version="1.0"?>
+<!--
+  ~ Copyright 2018 ThoughtWorks, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:template match="/cruise/@schemaVersion">
+    <xsl:attribute name="schemaVersion">105</xsl:attribute>
+  </xsl:template>
+  <!-- Copy everything -->
+  <xsl:template match="@*|node()">
+    <xsl:copy>
+      <xsl:apply-templates select="@*|node()"/>
+    </xsl:copy>
+  </xsl:template>
+
+  <xsl:template match="//pipelines/pipeline/trackingtool/@link">
+    <xsl:variable name="currentValue" select="."/>
+    <xsl:choose>
+      <xsl:when test="not((starts-with($currentValue, 'http://')) or starts-with($currentValue, 'https://'))">
+        <xsl:attribute name="link">http://<xsl:value-of select="$currentValue"/>
+        </xsl:attribute>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:attribute name="link">
+          <xsl:value-of select="$currentValue"/>
+        </xsl:attribute>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+</xsl:stylesheet>

--- a/server/helpers.gradle
+++ b/server/helpers.gradle
@@ -19,7 +19,7 @@ task bumpSchemaVersion {
   doFirst {
 
     File goConstantsFile = project(':base').file("src/main/java/com/thoughtworks/go/util/GoConstants.java")
-    def originalXSDFile = project(':config-server').file('src/main/resources/cruise-config.xsd')
+    def originalXSDFile = project(':config:config-server').file('src/main/resources/cruise-config.xsd')
 
     def goConstantsContents = goConstantsFile.getText('utf-8')
     def xsdContents = originalXSDFile.getText('utf-8')
@@ -33,7 +33,7 @@ task bumpSchemaVersion {
 
     copy {
       from originalXSDFile
-      into project(':config-server').file("src/main/resources/schemas")
+      into project(':config:config-server').file("src/main/resources/schemas")
       rename "cruise-config.xsd", "${currentVersion}_cruise-config.xsd"
     }
 
@@ -41,7 +41,7 @@ task bumpSchemaVersion {
       out.println(xsdContents.replaceAll("""<xsd:attribute name="schemaVersion" type="xsd:int" use="required" fixed="${currentVersion}"/>""", """<xsd:attribute name="schemaVersion" type="xsd:int" use="required" fixed="${nextVersion}"/>"""))
     }
 
-    def xslFile = project(':config-server').file("src/main/resources/upgrades/${nextVersion}.xsl")
+    def xslFile = project(':config:config-server').file("src/main/resources/upgrades/${nextVersion}.xsl")
     xslFile.withWriter { out ->
       out.println("""
 <?xml version="1.0"?>


### PR DESCRIPTION
Add an `http://` prefix to links that do not start with `http://` or `https://`.

Also fixed the `bumpSchemaVersion` task.