### PR TITLE
[New dashboard] Hide pipeline settings and pipeline group settings icon for non admin users

### DIFF
--- a/server/webapp/WEB-INF/rails.new/spec/webpack/views/dashboard/dashboard_widget_spec.js
+++ b/server/webapp/WEB-INF/rails.new/spec/webpack/views/dashboard/dashboard_widget_spec.js
@@ -291,7 +291,7 @@ describe("Dashboard Widget", () => {
     unmount();
     mount(false);
 
-    expect($root.find('.pipeline-group_title a')).toHaveClass('disabled');
+    expect($root.find('.pipeline-group_title a')).not.toBeInDOM();
   });
 
   it("should render pipelines within each pipeline group", () => {

--- a/server/webapp/WEB-INF/rails.new/spec/webpack/views/dashboard/pipeline_widget_spec.js
+++ b/server/webapp/WEB-INF/rails.new/spec/webpack/views/dashboard/pipeline_widget_spec.js
@@ -145,10 +145,10 @@ describe("Dashboard Pipeline Widget", () => {
         expect($root.find('.edit_config')).not.toHaveClass("disabled");
       });
 
-      it("should disable pipeline settings button for non admin users", () => {
+      it("should not show settings icon for users who have no admin rights on a pipeline", () => {
         unmount();
-        mount(true, false);
-        expect($root.find('.edit_config')).toHaveClass("disabled");
+        mount(false, false);
+        expect($root.find('.edit_config')).not.toBeInDOM();
       });
 
       it("should link to pipeline settings quick edit path when toggles are enabled", () => {

--- a/server/webapp/WEB-INF/rails.new/webpack/views/dashboard/dashboard_widget.js.msx
+++ b/server/webapp/WEB-INF/rails.new/webpack/views/dashboard/dashboard_widget.js.msx
@@ -48,9 +48,10 @@ const DashboardWidget = {
         );
       });
 
-      const pipelineGroupSettingsIcon = (pipelineGroup.canAdminister)
-        ? (<a href={pipelineGroup.path} class="edit_config pipeline-group_edit-config"></a>)
-        : (<a href="#" class="edit_config pipeline-group_edit-config disabled"></a>);
+      let pipelineGroupSettingsIcon;
+      if (pipelineGroup.canAdminister) {
+        pipelineGroupSettingsIcon = (<a href={pipelineGroup.path} class="edit_config pipeline-group_edit-config"></a>);
+      }
 
       return (
         <div class="pipeline-group">

--- a/server/webapp/WEB-INF/rails.new/webpack/views/dashboard/pipeline_header_widget.js.msx
+++ b/server/webapp/WEB-INF/rails.new/webpack/views/dashboard/pipeline_header_widget.js.msx
@@ -39,8 +39,6 @@ const PipelineHeaderWidget = {
     if (pipeline.canAdminister) {
       const settingsPath = vnode.attrs.isQuickEditPageEnabled ? pipeline.quickEditPath : pipeline.settingsPath;
       settingsButton     = (<a class={`edit_config`} href={settingsPath}/>);
-    } else {
-      settingsButton = (<a class={`edit_config disabled`}/>);
     }
 
     let pipelineLockButton;


### PR DESCRIPTION
* Showing the settings icon in disabled mode for non admin users makes sense only if it is possible for such users to elevate previleges for themselves. Since this is not possible it doesn't make sense to show the settings icon. Hence, it was removed.