### PR TITLE
Allow all users to access plugin info API.

### DIFF
--- a/server/webapp/WEB-INF/applicationContext-acegi-security.xml
+++ b/server/webapp/WEB-INF/applicationContext-acegi-security.xml
@@ -277,7 +277,7 @@
                 /api/admin/scms/**=ROLE_SUPERVISOR, ROLE_GROUP_SUPERVISOR
                 /api/admin/repositories/**=ROLE_SUPERVISOR, ROLE_GROUP_SUPERVISOR
                 /api/admin/packages/**=ROLE_SUPERVISOR, ROLE_GROUP_SUPERVISOR
-                /api/admin/plugin_info/**=ROLE_SUPERVISOR, ROLE_GROUP_SUPERVISOR
+                /api/admin/plugin_info/**=ROLE_USER
                 /api/admin/plugin_settings/**=ROLE_SUPERVISOR
                 /api/admin/agents=ROLE_SUPERVISOR
                 /api/admin/config_repos=ROLE_SUPERVISOR

--- a/server/webapp/WEB-INF/rails.new/app/controllers/api_v4/admin/plugin_infos_controller.rb
+++ b/server/webapp/WEB-INF/rails.new/app/controllers/api_v4/admin/plugin_infos_controller.rb
@@ -30,10 +30,6 @@ module ApiV4
         PluginConstants.ARTIFACT_EXTENSION
       ]
 
-      java_import com.thoughtworks.go.plugin.domain.common.BadPluginInfo
-
-      before_action :check_admin_user_or_group_admin_user_and_401
-
       def index
         plugin_infos = default_plugin_info_finder.allPluginInfos(params[:type]).select do |pi|
           PLUGIN_TYPES_FOR_VERSION.include?(pi.getExtensionName())

--- a/server/webapp/WEB-INF/rails.new/lib/java_imports.rb
+++ b/server/webapp/WEB-INF/rails.new/lib/java_imports.rb
@@ -277,4 +277,5 @@ module JavaImports
   java_import com.thoughtworks.go.config.security.users.NoOne unless defined? NoOne
   java_import com.thoughtworks.go.plugin.access.analytics.AnalyticsExtension unless defined? AnalyticsExtension
   java_import com.thoughtworks.go.plugin.domain.common.PluginConstants
+  java_import com.thoughtworks.go.plugin.domain.common.BadPluginInfo unless defined? BadPluginInfo
 end

--- a/server/webapp/WEB-INF/rails.new/spec/controllers/api_v4/admin/plugin_infos_controller_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/controllers/api_v4/admin/plugin_infos_controller_spec.rb
@@ -32,54 +32,6 @@ describe ApiV4::Admin::PluginInfosController do
 
   end
 
-  describe "security" do
-    describe "show" do
-      it 'should allow anyone, with security disabled' do
-        disable_security
-        expect(controller).to allow_action(:get, :show)
-      end
-
-      it 'should disallow non-admin user, with security enabled' do
-        enable_security
-        login_as_user
-        expect(controller).to disallow_action(:get, :show, {:id => 'plugin_id'}).with(401, 'You are not authorized to perform this action.')
-      end
-
-      it 'should allow admin users, with security enabled' do
-        login_as_admin
-        expect(controller).to allow_action(:get, :show)
-      end
-
-      it 'should allow pipeline group admin users, with security enabled' do
-        login_as_group_admin
-        expect(controller).to allow_action(:get, :show)
-      end
-    end
-
-    describe "index" do
-      it 'should allow anyone, with security disabled' do
-        disable_security
-        expect(controller).to allow_action(:get, :index)
-      end
-
-      it 'should disallow non-admin user, with security enabled' do
-        enable_security
-        login_as_user
-        expect(controller).to disallow_action(:get, :index).with(401, 'You are not authorized to perform this action.')
-      end
-
-      it 'should allow admin users, with security enabled' do
-        login_as_admin
-        expect(controller).to allow_action(:get, :index)
-      end
-
-      it 'should allow pipeline group admin users, with security enabled' do
-        login_as_group_admin
-        expect(controller).to allow_action(:get, :index)
-      end
-    end
-  end
-
   describe "index" do
     before(:each) do
       login_as_group_admin


### PR DESCRIPTION
The plugin info API is accessed from /go/agents page. Agents page is accessible by view users. So, even the plugin info API should be made accessible for view users. 