### PR TITLE
Provides operate permissions to all users if no permissions are set on pipeline group

### DIFF
--- a/server/src/main/java/com/thoughtworks/go/config/security/GoConfigPipelinePermissionsAuthority.java
+++ b/server/src/main/java/com/thoughtworks/go/config/security/GoConfigPipelinePermissionsAuthority.java
@@ -90,7 +90,7 @@ public class GoConfigPipelinePermissionsAuthority {
                         pipelinesAndTheirPermissions.put(pipeline.name(), new Permissions(Everyone.INSTANCE, Everyone.INSTANCE, Everyone.INSTANCE, Everyone.INSTANCE));
                     } else if (hasNoAuthDefinedAtGroupLevel) {
                         AllowedUsers adminUsers = new AllowedUsers(admins, pipelineGroupAdminRoles);
-                        pipelinesAndTheirPermissions.put(pipeline.name(), new Permissions(Everyone.INSTANCE, Everyone.INSTANCE, adminUsers, adminUsers));
+                        pipelinesAndTheirPermissions.put(pipeline.name(), new Permissions(Everyone.INSTANCE, Everyone.INSTANCE, adminUsers, Everyone.INSTANCE));
                     }else {
                         AllowedUsers pipelineOperators = pipelineOperators(pipeline, admins, new AllowedUsers(operators, pipelineGroupOperatorRoles), rolesToUsers);
                         Permissions permissions = new Permissions(new AllowedUsers(viewers, pipelineGroupViewerRoles), new AllowedUsers(operators, pipelineGroupOperatorRoles), new AllowedUsers(admins, pipelineGroupAdminRoles), pipelineOperators);

--- a/server/src/test-fast/java/com/thoughtworks/go/config/security/GoConfigPipelinePermissionsAuthorityTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/config/security/GoConfigPipelinePermissionsAuthorityTest.java
@@ -132,6 +132,7 @@ public class GoConfigPipelinePermissionsAuthorityTest {
         assertPipelinesInMap(permissions, "pipeline1");
         assertEveryoneIsAPartOf(pipelinePermissions.viewers());
         assertEveryoneIsAPartOf(pipelinePermissions.operators());
+        assertEveryoneIsAPartOf(pipelinePermissions.pipelineOperators());
         assertAdmins(permissions, "pipeline1", Collections.emptySet(), "superadmin1");
     }
 
@@ -148,6 +149,7 @@ public class GoConfigPipelinePermissionsAuthorityTest {
         assertPipelinesInMap(permissions, "pipeline1");
         assertEveryoneIsAPartOf(pipelinePermissions.viewers());
         assertEveryoneIsAPartOf(pipelinePermissions.operators());
+        assertEveryoneIsAPartOf(pipelinePermissions.pipelineOperators());
     }
 
     @Test
@@ -166,6 +168,7 @@ public class GoConfigPipelinePermissionsAuthorityTest {
         assertPipelinesInMap(permissions, "pipeline1");
         assertEveryoneIsAPartOf(pipelinePermissions.viewers());
         assertEveryoneIsAPartOf(pipelinePermissions.operators());
+        assertEveryoneIsAPartOf(pipelinePermissions.pipelineOperators());
         assertAdmins(permissions, "pipeline1", Collections.singleton(admin));
     }
 
@@ -597,6 +600,7 @@ public class GoConfigPipelinePermissionsAuthorityTest {
         Permissions pipelinePermissions = permissions.get(new CaseInsensitiveString("pipeline1"));
         assertEveryoneIsAPartOf(pipelinePermissions.viewers());
         assertEveryoneIsAPartOf(pipelinePermissions.operators());
+        assertEveryoneIsAPartOf(pipelinePermissions.pipelineOperators());
         assertEveryoneIsAPartOf(pipelinePermissions.admins());
     }
 
@@ -618,11 +622,13 @@ public class GoConfigPipelinePermissionsAuthorityTest {
         Permissions pipeline1Permissions = permissions.get(new CaseInsensitiveString("pipeline1"));
         assertEveryoneIsAPartOf(pipeline1Permissions.viewers());
         assertEveryoneIsAPartOf(pipeline1Permissions.operators());
+        assertEveryoneIsAPartOf(pipeline1Permissions.pipelineOperators());
         assertEveryoneIsAPartOf(pipeline1Permissions.admins());
 
         Permissions pipeline2Permissions = permissions.get(new CaseInsensitiveString("pipeline2"));
         assertEveryoneIsAPartOf(pipeline2Permissions.viewers());
         assertEveryoneIsAPartOf(pipeline2Permissions.operators());
+        assertEveryoneIsAPartOf(pipeline2Permissions.pipelineOperators());
         assertEveryoneIsAPartOf(pipeline2Permissions.admins());
     }
 


### PR DESCRIPTION
To maintain consistency with current implementation, if no permissions are set on a pipeline group all users are given operate permissions instead of only pipeline admins.