### PR TITLE
Support turning off automatic page refresh using query param

### DIFF
--- a/server/webapp/WEB-INF/rails.new/webpack/helpers/ajax_poller.js
+++ b/server/webapp/WEB-INF/rails.new/webpack/helpers/ajax_poller.js
@@ -77,8 +77,10 @@ const AjaxPoller = function (args = {}) {
 
   this.start = function () {
     repeater = createRepeater();
+    repeater.every(currentPollInterval(), 'sec')
+      .times(_.includes(window.location.search, 'auto_refresh=false') ? 1 : Infinity)
+      .start.in(options.inSeconds, 'sec');
 
-    repeater.every(currentPollInterval(), 'sec').start.in(options.inSeconds, 'sec');
     if (doesBrowserSupportPageVisibilityAPI()) {
       document.addEventListener(visibilityChange, handleVisibilityChange, false);
     } else {


### PR DESCRIPTION
* More information: https://github.com/gocd/gocd/issues/4081\#issuecomment-363313065
* To turn off auto refresh on the page, provide 'auto_refresh=false' query param
* Turning off auto refresh is supported for:
	- New Dashboard SPA (/go/dashboard)
	- New Agents SPA (/go/agents)