### PR TITLE
Small fix to artifact tab CSS

### DIFF
--- a/server/webapp/WEB-INF/rails.new/app/assets/stylesheets/css/application-old.scss
+++ b/server/webapp/WEB-INF/rails.new/app/assets/stylesheets/css/application-old.scss
@@ -1243,7 +1243,8 @@ a.pagination-next
     margin-left: 1em;
 }
 .artifacts ul.artifacts,
-.artifacts .artifacts li{
+.artifacts .artifacts li,
+.files ul.artifacts li {
     float: none;
 }
 


### PR DESCRIPTION
Before: See [this tab](https://build.gocd.org/go/tab/build/detail/performance/304/benchmark/1/thread_gc_analysis#tab-artifacts).

<img width="721" alt="2018_02_20_12-16-49" src="https://user-images.githubusercontent.com/172235/36438663-92cf8b8e-1638-11e8-8682-6932b7aeb302.png">

After:

<img width="719" alt="2018_02_20_12-16-38" src="https://user-images.githubusercontent.com/172235/36438669-99fceca8-1638-11e8-9595-9c85920b1702.png">
