### PR TITLE
Changes stage cancelled sign color

### DIFF
--- a/server/webapp/WEB-INF/rails.new/app/assets/new_stylesheets/single_page_apps/new_dashboard.scss
+++ b/server/webapp/WEB-INF/rails.new/app/assets/new_stylesheets/single_page_apps/new_dashboard.scss
@@ -846,6 +846,7 @@ body {
     &.cancelled {
       @include icon-before($cancelled-icon, 12px, 0);
       background: $building;
+      color: #333;
     }
   }
 }


### PR DESCRIPTION
After this change cancelled stages look like:
<img width="46" alt="screen shot 2018-02-21 at 12 19 55 pm" src="https://user-images.githubusercontent.com/23699743/36466730-917abc8a-1701-11e8-9c1f-da0640c876b6.png">
instead of:
<img width="36" alt="screen shot 2018-02-21 at 12 20 34 pm" src="https://user-images.githubusercontent.com/23699743/36466746-a695ac60-1701-11e8-888e-4229b613ff9a.png">
