### PR TITLE
Show server scheduled at time (#4310)

### DIFF
--- a/api/api-dashboard-v2/src/test/groovy/com/thoughtworks/go/apiv2/dashboard/representers/PipelineInstanceRepresenterTest.groovy
+++ b/api/api-dashboard-v2/src/test/groovy/com/thoughtworks/go/apiv2/dashboard/representers/PipelineInstanceRepresenterTest.groovy
@@ -21,6 +21,8 @@ import com.thoughtworks.go.domain.buildcause.BuildCause
 import com.thoughtworks.go.helper.ModificationsMother
 import org.junit.jupiter.api.Test
 
+import java.text.SimpleDateFormat
+
 import static com.thoughtworks.go.api.base.JsonOutputWriter.jsonDate
 import static com.thoughtworks.go.api.base.JsonUtils.toObject
 import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson
@@ -59,14 +61,15 @@ class PipelineInstanceRepresenterTest {
     actualJson.remove("_embedded")
 
     def map = [
-      label       : 'g1', counter: 5, scheduled_at: jsonDate(instance.getScheduledDate()),
-      triggered_by: 'Triggered by Anonymous',
-      build_cause : [approver          : 'anonymous',
-                     is_forced         : true,
-                     trigger_message   : "Forced by anonymous",
-                     material_revisions: []]]
+      label                   : 'g1', counter: 5,
+      scheduled_at            : instance.getScheduledDate().getTime(),
+      scheduled_at_server_time: new SimpleDateFormat(PipelineInstanceRepresenter.SCHEDULED_AT_PATTERN).format(instance.getScheduledDate()),
+      triggered_by            : 'Triggered by Anonymous',
+      build_cause             : [approver          : 'anonymous',
+                                 is_forced         : true,
+                                 trigger_message   : "Forced by anonymous",
+                                 material_revisions: []]]
     assertThatJson(actualJson).isEqualTo(map)
-
   }
 
   @Test
@@ -135,7 +138,13 @@ class PipelineInstanceRepresenterTest {
                               ]
     ]
 
-    assertThatJson(actualJson).isEqualTo(
-      [label: 'g1', counter: 5, scheduled_at: jsonDate(date), triggered_by: 'Triggered by Anonymous', build_cause: expectedBuildCause])
+    assertThatJson(actualJson).isEqualTo([
+      label                   : 'g1',
+      counter                 : 5,
+      scheduled_at            : date.getTime(),
+      scheduled_at_server_time: new SimpleDateFormat(PipelineInstanceRepresenter.SCHEDULED_AT_PATTERN).format(date),
+      triggered_by            : 'Triggered by Anonymous',
+      build_cause             : expectedBuildCause
+    ])
   }
 }

--- a/server/webapp/WEB-INF/rails.new/spec/webpack/models/dashboard/pipeline_instance_spec.js
+++ b/server/webapp/WEB-INF/rails.new/spec/webpack/models/dashboard/pipeline_instance_spec.js
@@ -25,7 +25,7 @@ describe("Dashboard", () => {
       expect(pipelineInstance.label).toBe(pipelineInstanceJson.label);
       expect(pipelineInstance.counter).toBe(pipelineInstanceJson.counter);
 
-      expect(pipelineInstance.scheduledAt).toEqual(pipelineInstanceJson.scheduled_at);
+      expect(pipelineInstance.scheduledAt).toEqual(new Date(+pipelineInstanceJson.scheduled_at));
       expect(pipelineInstance.triggeredBy).toEqual(pipelineInstanceJson.triggered_by);
 
       expect(pipelineInstance.vsmPath).toEqual(pipelineInstanceJson._links.vsm_url.href);
@@ -50,7 +50,7 @@ describe("Dashboard", () => {
     });
 
     const pipelineInstanceJson = {
-      "_links":       {
+      "_links":                   {
         "self":            {
           "href": "http://localhost:8153/go/api/pipelines/up42/instance/1"
         },
@@ -70,11 +70,12 @@ describe("Dashboard", () => {
           "href": "http://localhost:8153/go/pipelines/up42/1/build_cause"
         }
       },
-      "label":        "1",
-      "counter":      "1",
-      "scheduled_at": "2017-11-10T07:25:28.539Z",
-      "triggered_by": "changes",
-      "build_cause":  {
+      "label":                    "1",
+      "counter":                  "1",
+      "scheduled_at":             "1519015244393",
+      "scheduled_at_server_time": "2017-11-10T07:25:28.539Z",
+      "triggered_by":             "changes",
+      "build_cause":              {
         "approver":           "",
         "is_forced":          false,
         "trigger_message":    "modified by GoCD Test User <devnull@example.com>",
@@ -99,7 +100,7 @@ describe("Dashboard", () => {
           }
         ]
       },
-      "_embedded":    {
+      "_embedded":                {
         "stages": [
           {
             "_links":       {

--- a/server/webapp/WEB-INF/rails.new/spec/webpack/views/dashboard/pipeline_instance_widget_spec.js
+++ b/server/webapp/WEB-INF/rails.new/spec/webpack/views/dashboard/pipeline_instance_widget_spec.js
@@ -28,7 +28,7 @@ describe("Dashboard Pipeline Instance Widget", () => {
   afterEach(window.destroyDomElementForTest);
 
   const pipelineInstanceJson = {
-    "_links":       {
+    "_links":                   {
       "self":            {
         "href": "http://localhost:8153/go/api/pipelines/up42/instance/1"
       },
@@ -48,11 +48,12 @@ describe("Dashboard Pipeline Instance Widget", () => {
         "href": "http://localhost:8153/go/pipelines/up42/1/build_cause"
       }
     },
-    "label":        "1",
-    "counter":      "1",
-    "scheduled_at": "2017-11-10T07:25:28.539Z",
-    "triggered_by": "changes",
-    "build_cause":  {
+    "label":                    "1",
+    "counter":                  "1",
+    "scheduled_at":             "1519015244393",
+    "scheduled_at_server_time": "2017-11-10T07:25:28.539Z",
+    "triggered_by":             "changes",
+    "build_cause":              {
       "approver":           "",
       "is_forced":          false,
       "trigger_message":    "modified by GoCD Test User <devnull@example.com>",
@@ -77,7 +78,7 @@ describe("Dashboard Pipeline Instance Widget", () => {
         }
       ]
     },
-    "_embedded":    {
+    "_embedded":                {
       "stages": [
         {
           "_links":       {
@@ -110,7 +111,7 @@ describe("Dashboard Pipeline Instance Widget", () => {
       view() {
         return m(PipelineInstanceWidget, {
           instance,
-          dropdown: dashboardViewModel.dropdown,
+          dropdown:     dashboardViewModel.dropdown,
           trackingTool: {link: "http://example.com/${ID}", regex: "#(\\d+)"},
           pipelineName
         });
@@ -130,13 +131,12 @@ describe("Dashboard Pipeline Instance Widget", () => {
 
   it("should render triggered by information", () => {
     expect($root.find('.pipeline_instance-details div:nth-child(1)').text()).toEqual(`${ pipelineInstanceJson.triggered_by }`);
-    const expectedTime = moment(new Date(pipelineInstanceJson.scheduled_at)).format('[on] DD MMM YYYY [at] HH:mm:ss [Local Time]');
+    const expectedTime = moment(new Date(+pipelineInstanceJson.scheduled_at)).format('[on] DD MMM YYYY [at] HH:mm:ss [Local Time]');
     expect($root.find('.pipeline_instance-details div:nth-child(2)').text()).toEqual(expectedTime);
   });
 
   it("should show server triggered by information on hover", () => {
-    const expectedTime = moment(new Date(pipelineInstanceJson.scheduled_at)).format("[Server Time:] DD MMM, YYYY [at] HH:mm:ss Z");
-    expect($root.find('.pipeline_instance-details div:nth-child(2)').get(0).title).toEqual(expectedTime);
+    expect($root.find('.pipeline_instance-details div:nth-child(2)').get(0).title).toEqual(`Server Time: ${pipelineInstanceJson.scheduled_at_server_time}`);
   });
 
   it("should render compare link", () => {

--- a/server/webapp/WEB-INF/rails.new/webpack/models/dashboard/pipeline_instance.js
+++ b/server/webapp/WEB-INF/rails.new/webpack/models/dashboard/pipeline_instance.js
@@ -30,11 +30,12 @@ const StageInstance = function (json, pipelineName, pipelineCounter) {
 const PipelineInstance = function (info, pipelineName) {
   const self = this;
 
-  this.pipelineName = pipelineName;
-  this.label        = info.label;
-  this.counter      = info.counter;
-  this.scheduledAt  = info.scheduled_at;
-  this.triggeredBy  = info.triggered_by;
+  this.pipelineName          = pipelineName;
+  this.label                 = info.label;
+  this.counter               = info.counter;
+  this.scheduledAt           = new Date(+info.scheduled_at);
+  this.scheduledAtServerTime = info.scheduled_at_server_time;
+  this.triggeredBy           = info.triggered_by;
 
   this.vsmPath     = info._links.vsm_url.href;
   this.comparePath = info._links.compare_url.href;

--- a/server/webapp/WEB-INF/rails.new/webpack/views/dashboard/pipeline_instance_widget.js.msx
+++ b/server/webapp/WEB-INF/rails.new/webpack/views/dashboard/pipeline_instance_widget.js.msx
@@ -14,10 +14,9 @@
  * limitations under the License.
  */
 
-const m      = require('mithril');
-const _      = require('lodash');
-const moment = require("moment");
-require("moment-duration-format");
+const m                      = require('mithril');
+const _                      = require('lodash');
+const timeFormatter          = require('helpers/time_formatter');
 const StagesInstanceWidget   = require('views/dashboard/stages_instance_widget');
 const MaterialRevisionWidget = require('views/dashboard/trigger_with_options/material_revision_widget');
 
@@ -26,7 +25,7 @@ const PipelineInstanceWidget = {
     this.adjustPositionOfPopup = () => {
       const widthOfWindow           = window.innerWidth;
       const popup                   = vnode.dom.querySelector('.material_changes');
-      const rightCoordinateOfWidget = popup? popup.getBoundingClientRect().right: 0;
+      const rightCoordinateOfWidget = popup ? popup.getBoundingClientRect().right : 0;
       if (rightCoordinateOfWidget > widthOfWindow) {
         popup.style.right = '0px';
       }
@@ -40,11 +39,10 @@ const PipelineInstanceWidget = {
     const dropdown     = vnode.attrs.dropdown;
     const pipelineName = vnode.attrs.pipelineName;
 
-    const scheduledAt           = moment(new Date(instance.scheduledAt));
-    const scheduledAtLocalTime  = scheduledAt.format('[on] DD MMM YYYY [at] HH:mm:ss [Local Time]');
-    const scheduledAtServerTime = scheduledAt.format("[Server Time:] DD MMM, YYYY [at] HH:mm:ss Z");
-    let dropdownWidget;
+    const scheduledAtLocalTime  = `on ${timeFormatter(instance.scheduledAt)}`;
+    const scheduledAtServerTime = `Server Time: ${instance.scheduledAtServerTime}`;
 
+    let dropdownWidget;
     if (dropdown.isDropDownOpen(pipelineName)) {
       dropdownWidget = <div class="material_changes" onclick={(e) => e.stopPropagation()}>
         {_.map(instance.materialRevisions, (revision) => {


### PR DESCRIPTION
* Add 'scheduled_at_server_time' field in go dashboard API response
* Show server scheduled at time on hover of scheduled at local time
* Use time_formatter lib at client side for a common date format at one place