### PR TITLE
Trigger a pipeline on Dashboard (#4081)

### DIFF
--- a/server/webapp/WEB-INF/rails.new/spec/webpack/models/dashboard/pipeline_spec.js
+++ b/server/webapp/WEB-INF/rails.new/spec/webpack/models/dashboard/pipeline_spec.js
@@ -60,7 +60,7 @@ describe("Dashboard", () => {
     });
 
     it("should return counters for pipeline instances", () => {
-      const pipeline       = new Pipeline(pipelineJson);
+      const pipeline         = new Pipeline(pipelineJson);
       const instanceCounters = pipeline.getInstanceCounters();
       expect(instanceCounters.length).toEqual(1);
       expect(instanceCounters).toEqual([1]);
@@ -152,6 +152,33 @@ describe("Dashboard", () => {
           const request = jasmine.Ajax.requests.mostRecent();
           expect(request.method).toBe('POST');
           expect(request.url).toBe(`/go/api/pipelines/${pipelineJson.name}/unlock`);
+          expect(request.requestHeaders['Accept']).toContain('application/vnd.go.cd.v1+json');
+          expect(request.requestHeaders['X-GoCD-Confirm']).toContain('true');
+        });
+      });
+    });
+
+    describe("Trigger", () => {
+      it('should Trigger a pipeline with appropriate headers', () => {
+        jasmine.Ajax.withMock(() => {
+          jasmine.Ajax.stubRequest(`/go/api/pipelines/${pipelineJson.name}/schedule`, undefined, 'POST').andReturn({
+            responseText:    JSON.stringify({"message": `Request to schedule pipeline '${pipelineJson.name}' accepted successfully.`}),
+            responseHeaders: {
+              'Content-Type': 'application/vnd.go.cd.v1+json'
+            },
+            status:          200
+          });
+
+          const successCallback = jasmine.createSpy();
+
+          const pipeline = new Pipeline(pipelineJson);
+          pipeline.trigger().then(successCallback);
+
+          expect(successCallback).toHaveBeenCalled();
+
+          const request = jasmine.Ajax.requests.mostRecent();
+          expect(request.method).toBe('POST');
+          expect(request.url).toBe(`/go/api/pipelines/${pipelineJson.name}/schedule`);
           expect(request.requestHeaders['Accept']).toContain('application/vnd.go.cd.v1+json');
           expect(request.requestHeaders['X-GoCD-Confirm']).toContain('true');
         });

--- a/server/webapp/WEB-INF/rails.new/webpack/helpers/spark_routes.js
+++ b/server/webapp/WEB-INF/rails.new/webpack/helpers/spark_routes.js
@@ -29,6 +29,10 @@ module.exports = {
     return `/go/api/pipelines/${pipelineName}/unlock`;
   },
 
+  pipelineTriggerPath: (pipelineName) => {
+    return `/go/api/pipelines/${pipelineName}/schedule`;
+  },
+
   pipelineTriggerWithOptionsViewPath: (pipelineName) => {
     return `/go/api/pipelines/${pipelineName}/trigger_options`;
   },
@@ -42,7 +46,7 @@ module.exports = {
     return `/go/api/internal/material_search?${queryString}`;
   },
 
-    pipelineSelectionPath: () => {
+  pipelineSelectionPath: () => {
     return '/go/api/internal/pipeline_selection';
   }
 };

--- a/server/webapp/WEB-INF/rails.new/webpack/models/dashboard/pipeline.js
+++ b/server/webapp/WEB-INF/rails.new/webpack/models/dashboard/pipeline.js
@@ -70,6 +70,10 @@ const Pipeline = function (info) {
     return postURL(SparkRoutes.pipelinePausePath(self.name), payload);
   };
 
+  this.trigger = (payload = {}) => {
+    return postURL(SparkRoutes.pipelineTriggerPath(self.name), payload);
+  };
+
   this.getInstanceCounters = () => {
     return _.map(this.instances, (instance) => instance.counter);
   };

--- a/server/webapp/WEB-INF/rails.new/webpack/views/dashboard/pipeline_operations_widget.js.msx
+++ b/server/webapp/WEB-INF/rails.new/webpack/views/dashboard/pipeline_operations_widget.js.msx
@@ -31,6 +31,15 @@ const PipelineOperationsWidget = {
     const operationMessages = vnode.attrs.operationMessages;
     self.pauseMessage       = Stream();
 
+    self.trigger = (pipeline) => {
+      vnode.attrs.doCancelPolling();
+      pipeline.trigger().then((res) => {
+        operationMessages.success(pipeline.name, res.message);
+      }, (res) => {
+        operationMessages.failure(pipeline.name, res.responseJSON.message);
+      }).always(vnode.attrs.doRefreshImmediately);
+    };
+
     self.unpause = (pipeline) => {
       vnode.attrs.doCancelPolling();
       pipeline.unpause().then((res) => {
@@ -162,7 +171,8 @@ const PipelineOperationsWidget = {
         {flashMessage}
         <ul className="pipeline_operations">
           <li>
-            <button class={`pipeline_btn play ${isTriggerDisabled ? 'disabled' : ''}`}/>
+            <button onclick={!isTriggerDisabled && vnode.state.trigger.bind(vnode.state, pipeline)}
+                    class={`pipeline_btn play ${isTriggerDisabled ? 'disabled' : ''}`}/>
           </li>
           <li>
             <button onclick={!isTriggerDisabled && vnode.state.showTriggerWithOptionsPopup.bind(vnode.state, pipeline)}


### PR DESCRIPTION
**Note**: For the time window between clicking schedule button and next ajax refresh, the pipeline operation buttons (trigger and trigger with options) are enabled.

**Pending**: Need to disable the buttons once the request for scheduling the pipeline is accepted successfully.

