### PR TITLE
Do not perform disk space check for every pipeline

### DIFF
--- a/server/src/main/java/com/thoughtworks/go/server/service/ArtifactsDiskSpaceFullChecker.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/ArtifactsDiskSpaceFullChecker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 ThoughtWorks, Inc.
+ * Copyright 2018 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,16 +33,10 @@ public class ArtifactsDiskSpaceFullChecker extends DiskSpaceChecker {
         super(sender, systemEnvironment, goConfigService.artifactsDir(), goConfigService, ARTIFACTS_DISK_FULL_ID, diskSpaceChecker);
     }
 
-    //for constructing SchedulingChecker
-    public ArtifactsDiskSpaceFullChecker(SystemEnvironment systemEnvironment,
-                                         GoConfigService goConfigService) {
-        this(systemEnvironment, null, goConfigService, new SystemDiskSpaceChecker());
-    }
-
     protected void createFailure(OperationResult result, long size, long availableSpace) {
-        String msg = "Go has less than " + size + "Mb of disk space available. Scheduling has stopped, and will resume once more than " + size + "Mb is available.";
+        String msg = "GoCD has less than " + size + "Mb of disk space available. Scheduling has stopped, and will resume once more than " + size + "Mb is available.";
         LOGGER.error(msg);
-        result.error("Go Server has run out of artifacts disk space. Scheduling has been stopped", msg, ARTIFACTS_DISK_FULL_ID);
+        result.error("GoCD Server has run out of artifacts disk space. Scheduling has been stopped", msg, ARTIFACTS_DISK_FULL_ID);
     }
 
     protected SendEmailMessage createEmail() {

--- a/server/src/main/java/com/thoughtworks/go/server/service/ArtifactsDiskSpaceWarningChecker.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/ArtifactsDiskSpaceWarningChecker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 ThoughtWorks, Inc.
+ * Copyright 2018 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,10 +42,9 @@ public class ArtifactsDiskSpaceWarningChecker extends DiskSpaceChecker {
     }
 
     protected void createFailure(OperationResult result, long size, long availableSpace) {
-        String msg = "Go has less than " + size + "M of disk space available to it.";
+        String msg = "GoCD has less than " + size + "M of disk space available to it.";
         LOGGER.warn(msg);
-        LOGGER.warn(msg);
-        result.warning("Go Server's artifact repository is running low on disk space", msg, ARTIFACTS_DISK_FULL_ID);
+        result.warning("GoCD Server's artifact repository is running low on disk space", msg, ARTIFACTS_DISK_FULL_ID);
     }
 
     protected SendEmailMessage createEmail() {

--- a/server/src/main/java/com/thoughtworks/go/server/service/DatabaseDiskSpaceFullChecker.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/DatabaseDiskSpaceFullChecker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 ThoughtWorks, Inc.
+ * Copyright 2018 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,19 +34,14 @@ public class DatabaseDiskSpaceFullChecker extends DiskSpaceChecker {
         super(sender, systemEnvironment, systemEnvironment.getDbFolder(), goConfigService, DATABASE_DISK_FULL_ID, diskSpaceChecker);
     }
 
-    //for constructing SchedulingChecker
-    public DatabaseDiskSpaceFullChecker(SystemEnvironment systemEnvironment, GoConfigService goConfigService) {
-        this(null, systemEnvironment, goConfigService, new SystemDiskSpaceChecker());
-    }
-
     protected long limitInMb() {
         return systemEnvironment.getDatabaseDiskSpaceFullLimit();
     }
 
     protected void createFailure(OperationResult result, long size, long availableSpace) {
-        String msg = "Go has less than " + size + "Mb of disk space available. Scheduling has stopped, and will resume once more than " + size + "Mb is available.";
+        String msg = "GoCD has less than " + size + "Mb of disk space available. Scheduling has stopped, and will resume once more than " + size + "Mb is available.";
         LOGGER.error(msg);
-        result.error("Go Server has run out of database disk space. Scheduling has been stopped", msg, DATABASE_DISK_FULL_ID);
+        result.error("GoCD Server has run out of database disk space. Scheduling has been stopped", msg, DATABASE_DISK_FULL_ID);
     }
 
     protected SendEmailMessage createEmail() {

--- a/server/src/main/java/com/thoughtworks/go/server/service/DatabaseDiskSpaceWarningChecker.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/DatabaseDiskSpaceWarningChecker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 ThoughtWorks, Inc.
+ * Copyright 2018 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,9 +42,9 @@ public class DatabaseDiskSpaceWarningChecker extends DiskSpaceChecker {
     }
 
     protected void createFailure(OperationResult result, long size, long availableSpace) {
-        String msg = "Go has less than " + size + "M of disk space available to it.";
+        String msg = "GoCD has less than " + size + "M of disk space available to it.";
         LOGGER.warn(msg);
-        result.warning("Go Server's database is running on low disk space", msg, DATABASE_DISK_FULL_ID);
+        result.warning("GoCD Server's database is running on low disk space", msg, DATABASE_DISK_FULL_ID);
     }
 
     protected SendEmailMessage createEmail() {

--- a/server/src/main/java/com/thoughtworks/go/server/service/OutOfDiskSpaceChecker.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/OutOfDiskSpaceChecker.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2018 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.server.service;
+
+import com.thoughtworks.go.server.cronjob.GoDiskSpaceMonitor;
+import com.thoughtworks.go.server.service.result.OperationResult;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+class OutOfDiskSpaceChecker implements SchedulingChecker {
+    private final GoDiskSpaceMonitor goDiskSpaceMonitor;
+
+    @Autowired
+    public OutOfDiskSpaceChecker(GoDiskSpaceMonitor goDiskSpaceMonitor) {
+        this.goDiskSpaceMonitor = goDiskSpaceMonitor;
+    }
+
+    @Override
+    public void check(OperationResult result) {
+        goDiskSpaceMonitor.checkIfOutOfDisk(result);
+    }
+}

--- a/server/src/main/java/com/thoughtworks/go/server/service/SchedulingCheckerService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/SchedulingCheckerService.java
@@ -1,33 +1,33 @@
-/*************************GO-LICENSE-START*********************************
- * Copyright 2017 ThoughtWorks, Inc.
+/*
+ * Copyright 2018 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *************************GO-LICENSE-END***********************************/
+ */
 
 package com.thoughtworks.go.server.service;
-
-import java.util.List;
 
 import com.thoughtworks.go.config.CaseInsensitiveString;
 import com.thoughtworks.go.config.PipelineConfig;
 import com.thoughtworks.go.domain.PipelineIdentifier;
 import com.thoughtworks.go.server.domain.Username;
 import com.thoughtworks.go.server.scheduling.TriggerMonitor;
-import com.thoughtworks.go.server.service.result.*;
-import com.thoughtworks.go.util.SystemEnvironment;
-import com.thoughtworks.go.serverhealth.ServerHealthService;
+import com.thoughtworks.go.server.service.result.HttpOperationResult;
+import com.thoughtworks.go.server.service.result.OperationResult;
+import com.thoughtworks.go.server.service.result.ServerHealthStateOperationResult;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 import static java.util.Arrays.asList;
 
@@ -35,29 +35,28 @@ import static java.util.Arrays.asList;
 public class SchedulingCheckerService {
     private final GoConfigService goConfigService;
     private final CurrentActivityService activityService;
-    private final SystemEnvironment systemEnvironment;
     private final SecurityService securityService;
     private final PipelineLockService pipelineLockService;
     private final TriggerMonitor triggerMonitor;
     private final PipelineScheduleQueue pipelineScheduleQueue;
+    private final OutOfDiskSpaceChecker outOfDiskSpaceChecker;
     private PipelinePauseService pipelinePauseService;
 
     @Autowired
     public SchedulingCheckerService(GoConfigService goConfigService,
                                     CurrentActivityService activityService,
-                                    SystemEnvironment systemEnvironment,
                                     SecurityService securityService,
                                     PipelineLockService pipelineLockService,
                                     TriggerMonitor triggerMonitor, PipelineScheduleQueue pipelineScheduleQueue,
-                                    PipelinePauseService pipelinePauseService) {
+                                    PipelinePauseService pipelinePauseService, OutOfDiskSpaceChecker outOfDiskSpaceChecker) {
         this.goConfigService = goConfigService;
         this.activityService = activityService;
-        this.systemEnvironment = systemEnvironment;
         this.securityService = securityService;
         this.pipelineLockService = pipelineLockService;
         this.triggerMonitor = triggerMonitor;
         this.pipelineScheduleQueue = pipelineScheduleQueue;
         this.pipelinePauseService = pipelinePauseService;
+        this.outOfDiskSpaceChecker = outOfDiskSpaceChecker;
     }
 
     public boolean canTriggerManualPipeline(String pipelineName, String username, OperationResult result) {
@@ -184,13 +183,7 @@ public class SchedulingCheckerService {
     }
 
     private SchedulingChecker diskCheckers() {
-        ArtifactsDiskSpaceFullChecker artifactsDiskSpaceFullChecker =
-                new ArtifactsDiskSpaceFullChecker(systemEnvironment, goConfigService);
-
-        DatabaseDiskSpaceFullChecker databaseDiskSpaceFullChecker = new DatabaseDiskSpaceFullChecker(
-                systemEnvironment, goConfigService);
-
-        return new CompositeChecker(artifactsDiskSpaceFullChecker, databaseDiskSpaceFullChecker);
+        return outOfDiskSpaceChecker;
     }
 
 }

--- a/server/src/test-fast/java/com/thoughtworks/go/server/service/SchedulingCheckerServiceUnitTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/service/SchedulingCheckerServiceUnitTest.java
@@ -1,18 +1,18 @@
-/*************************GO-LICENSE-START*********************************
- * Copyright 2017 ThoughtWorks, Inc.
+/*
+ * Copyright 2018 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *************************GO-LICENSE-END***********************************/
+ */
 
 package com.thoughtworks.go.server.service;
 
@@ -23,7 +23,6 @@ import com.thoughtworks.go.server.service.result.OperationResult;
 import com.thoughtworks.go.serverhealth.HealthStateScope;
 import com.thoughtworks.go.serverhealth.HealthStateType;
 import com.thoughtworks.go.serverhealth.ServerHealthState;
-import com.thoughtworks.go.util.SystemEnvironment;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
@@ -50,13 +49,12 @@ public class SchedulingCheckerServiceUnitTest {
     @Before
     public void setUp() throws Exception {
         initMocks(this);
-        schedulingChecker = spy(new SchedulingCheckerService(mock(GoConfigService.class), mock(CurrentActivityService.class), mock(SystemEnvironment.class),
+        schedulingChecker = spy(new SchedulingCheckerService(mock(GoConfigService.class), mock(CurrentActivityService.class),
                 mock(SecurityService.class), mock(PipelineLockService.class), mock(TriggerMonitor.class), mock(PipelineScheduleQueue.class),
-                mock(PipelinePauseService.class)));
+                mock(PipelinePauseService.class), mock(OutOfDiskSpaceChecker.class)));
 
         compositeChecker = mock(CompositeChecker.class);
         operationResult = mock(OperationResult.class);
-
 
         doReturn(compositeChecker).when(schedulingChecker).buildScheduleCheckers(Matchers.<List<SchedulingChecker>>any());
         when(operationResult.getServerHealthState()).thenReturn(ServerHealthState.success(HealthStateType.general(HealthStateScope.GLOBAL)));

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/SchedulingCheckerServiceIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/SchedulingCheckerServiceIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 ThoughtWorks, Inc.
+ * Copyright 2018 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -315,7 +315,7 @@ public class SchedulingCheckerServiceIntegrationTest {
 
         assertThat(schedulingChecker.canManuallyTrigger(pipelineFixture.pipelineConfig(), APPROVED_USER, result), is(false));
         assertThat(result.getServerHealthState().getDescription(),
-                containsString(String.format("Go has less than %sb of disk space", limit)));
+                containsString(String.format("GoCD has less than %sb of disk space", limit)));
     }
 
     @Test
@@ -330,7 +330,7 @@ public class SchedulingCheckerServiceIntegrationTest {
 
         assertThat(schedulingChecker.canScheduleStage(new PipelineIdentifier(s, 1, label), stageName, username, result), is(false));
         assertThat(result.getServerHealthState().getDescription(),
-                containsString(String.format("Go has less than %sb of disk space", limit)));
+                containsString(String.format("GoCD has less than %sb of disk space", limit)));
     }
 
     @Test
@@ -340,7 +340,7 @@ public class SchedulingCheckerServiceIntegrationTest {
         ServerHealthStateOperationResult result = new ServerHealthStateOperationResult();
         assertThat(schedulingChecker.canSchedule(result), is(false));
         assertThat(result.getServerHealthState().getDescription(),
-                containsString(String.format("Go has less than %sb of disk space", limit)));
+                containsString(String.format("GoCD has less than %sb of disk space", limit)));
     }
 
     @Test


### PR DESCRIPTION
In order to disable the trigger buttons, a disk check was being
performed for every pipeline on the dashboard and that was impacting
performance of the dashboard. Both old and new dashboards were being
impacted.