### PR TITLE
Upgrade h2 to 1.4.197.

### DIFF
--- a/base/src/main/java/com/thoughtworks/go/util/SystemEnvironment.java
+++ b/base/src/main/java/com/thoughtworks/go/util/SystemEnvironment.java
@@ -111,8 +111,9 @@ public class SystemEnvironment implements Serializable, ConfigDirProvider {
     public static GoSystemProperty<Integer> RESOLVE_FANIN_MAX_BACK_TRACK_LIMIT = new CachedProperty<>(new GoIntSystemProperty("resolve.fanin.max.backtrack.limit", 100));
     public static GoSystemProperty<Integer> MATERIAL_UPDATE_INACTIVE_TIMEOUT = new CachedProperty<>(new GoIntSystemProperty("material.update.inactive.timeout", 15));
 
-    public static GoSystemProperty<Integer> H2_DB_TRACE_LEVEL = new GoIntSystemProperty("h2.trace.level", 1);
+    public static GoSystemProperty<Integer> H2_DB_TRACE_LEVEL = new GoIntSystemProperty("h2.trace.level", 3);
     public static GoSystemProperty<Integer> H2_DB_TRACE_FILE_SIZE_MB = new GoIntSystemProperty("h2.trace.file.size.mb", 16);
+    public static GoSystemProperty<Integer> H2_DB_LOB_TIMEOUT_MINUTES = new GoIntSystemProperty("h2.lob.timeout.minutes", 5);
     private static GoSystemProperty<String> CRUISE_DATABASE_DIR = new GoStringSystemProperty("cruise.database.dir", DB_DEFAULT_PATH);
 
     public static final String MATERIAL_UPDATE_IDLE_INTERVAL_PROPERTY = "material.update.idle.interval";
@@ -690,6 +691,10 @@ public class SystemEnvironment implements Serializable, ConfigDirProvider {
 
     public int getCruiseDbTraceFileSize() {
         return H2_DB_TRACE_FILE_SIZE_MB.getValue();
+    }
+
+    public int getLobTimeoutInMilliSeconds() {
+        return (H2_DB_LOB_TIMEOUT_MINUTES.getValue() * 60 * 1000);
     }
 
     public Level pluginLoggingLevel(String pluginId) {

--- a/buildSrc/src/main/groovy/com/thoughtworks/go/build/LicenseReport.groovy
+++ b/buildSrc/src/main/groovy/com/thoughtworks/go/build/LicenseReport.groovy
@@ -36,7 +36,7 @@ class LicenseReport {
     'dom4j BSD license',
     'Public Domain',
     'Similar to Apache License but with the acknowledgment clause removed',
-    'The H2 License, Version 1.0',
+    'MPL 2.0 or EPL 1.0',
     'The OpenSymphony Software License 1.1',
   ]
 

--- a/buildSrc/src/main/groovy/com/thoughtworks/go/build/SpdxLicense.groovy
+++ b/buildSrc/src/main/groovy/com/thoughtworks/go/build/SpdxLicense.groovy
@@ -129,7 +129,7 @@ enum SpdxLicense {
   DOTSEQN("Dotseqn", "Dotseqn License"),
   DSDP("DSDP", "DSDP License"),
   DVIPDFM("dvipdfm", "dvipdfm License"),
-  EPL_1_0("EPL-1.0", "Eclipse Public License 1.0", "Eclipse Public License - v 1.0", "Eclipse Public License - Version 1.0"),
+  EPL_1_0("EPL-1.0", "Eclipse Public License 1.0", "Eclipse Public License - v 1.0", "Eclipse Public License - Version 1.0", "EPL 1.0"),
   ECL_1_0("ECL-1.0", "Educational Community License v1.0"),
   ECL_2_0("ECL-2.0", "Educational Community License v2.0"),
   EGENIX("eGenix", "eGenix.com Public License 1.1.0"),

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -135,7 +135,7 @@ dependencies {
   copyOnlyTestData project(':test:test-agent')
 
   compile group: 'commons-dbcp', name: 'commons-dbcp', version: '1.4'
-  compile group: 'com.h2database', name: 'h2', version: '1.3.168'
+  compile group: 'com.h2database', name: 'h2', version: '1.4.197'
   compile group: 'net.sf', name: 'dbdeploy', version: '2.11.1'
   compile(group: 'org.hibernate', name: 'hibernate-ehcache', version: project.versions.hibernate) {
     exclude(module: 'ehcache-core')
@@ -668,7 +668,7 @@ task verifyWar(type: VerifyJarTask) {
         "go-plugin-infra-${project.version}.jar",
         "gson-${project.versions.gson}.jar",
         "guava-${project.versions.guava}.jar",
-        "h2-1.3.168.jar",
+        "h2-1.4.197.jar",
         "hibernate-commons-annotations-3.2.0.Final.jar",
         "hibernate-core-${project.versions.hibernate}.jar",
         "hibernate-ehcache-${project.versions.hibernate}.jar",

--- a/server/src/main/java/com/thoughtworks/go/server/database/H2Database.java
+++ b/server/src/main/java/com/thoughtworks/go/server/database/H2Database.java
@@ -135,13 +135,15 @@ public class H2Database implements Database {
     }
 
     private String dburl(Boolean mvccEnabled) {
-        return "jdbc:h2:" + systemEnvironment.getDbPath() + "/" + configuration.getName()
+        return "jdbc:h2:" + systemEnvironment.getDbPath().getAbsolutePath() + "/" + configuration.getName()
                 + ";DB_CLOSE_DELAY=-1"
                 + ";DB_CLOSE_ON_EXIT=FALSE"
                 + ";MVCC=" + mvccEnabled.toString().toUpperCase()
+                + ";MV_STORE=FALSE"
                 + ";CACHE_SIZE=" + systemEnvironment.getCruiseDbCacheSize()
                 + ";TRACE_LEVEL_FILE=" + systemEnvironment.getCruiseDbTraceLevel()
                 + ";TRACE_MAX_FILE_SIZE=" + systemEnvironment.getCruiseDbTraceFileSize()
+                + ";LOB_TIMEOUT=" + systemEnvironment.getLobTimeoutInMilliSeconds()
 //                Commented out until H2 fix their bug
 //                + ";CACHE_TYPE=SOFT_LRU" //See http://www.h2database.com/html/changelog.html
                 + ";DATABASE_EVENT_LISTENER='" + H2EventListener.class.getName() + "'";

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/BackupServiceH2IntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/BackupServiceH2IntegrationTest.java
@@ -155,7 +155,7 @@ public class BackupServiceH2IntegrationTest {
 
         String location = temporaryFolder.newFolder().getAbsolutePath();
 
-        Restore.execute(dbZip(), location, "cruise", false);
+        Restore.execute(dbZip(), location, "cruise");
 
         BasicDataSource source = constructTestDataSource(new File(location));
         ResultSet resultSet = source.getConnection().prepareStatement("select * from pipelines where id = " + expectedPipeline.getId()).executeQuery();


### PR DESCRIPTION
Disable MV_STORE. @jyotisingh's PR - https://github.com/gocd/gocd/pull/3730 will take care of making use of mvstore. 