### PR TITLE
Make PluginEndpoint request/response and define analytics.jobs contract

### DIFF
--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/analytics/AnalyticsExtension.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/analytics/AnalyticsExtension.java
@@ -32,6 +32,7 @@ import org.springframework.stereotype.Component;
 
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import static com.thoughtworks.go.plugin.access.analytics.AnalyticsPluginConstants.*;
 
@@ -68,6 +69,22 @@ public class AnalyticsExtension extends AbstractExtension {
             @Override
             public String requestBody(String resolvedExtensionVersion) {
                 return getMessageConverter(resolvedExtensionVersion).getPipelineAnalyticsRequestBody(pipelineName);
+            }
+
+            @Override
+            public AnalyticsData onSuccess(String responseBody, String resolvedExtensionVersion) {
+                AnalyticsData analyticsData = getMessageConverter(resolvedExtensionVersion).getAnalyticsFromResponseBody(responseBody);
+                analyticsData.setAssetRoot(getCurrentStaticAssetsPath(pluginId));
+                return analyticsData;
+            }
+        });
+    }
+
+    public AnalyticsData getJobAnalytics(String pluginId, Map params) {
+        return pluginRequestHelper.submitRequest(pluginId, REQUEST_GET_ANALYTICS, new DefaultPluginInteractionCallback<AnalyticsData>() {
+            @Override
+            public String requestBody(String resolvedExtensionVersion) {
+                return getMessageConverter(resolvedExtensionVersion).getJobAnalyticsRequestBody(params);
             }
 
             @Override

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/analytics/AnalyticsMessageConverter.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/analytics/AnalyticsMessageConverter.java
@@ -19,13 +19,18 @@ package com.thoughtworks.go.plugin.access.analytics;
 import com.thoughtworks.go.plugin.domain.analytics.AnalyticsData;
 import com.thoughtworks.go.plugin.domain.common.Image;
 
+import java.util.Map;
+
 public interface AnalyticsMessageConverter {
     String TYPE_PIPELINE = "pipeline";
+    String TYPE_JOB = "job";
     String TYPE_DASHBOARD = "dashboard";
 
     com.thoughtworks.go.plugin.domain.analytics.Capabilities getCapabilitiesFromResponseBody(String responseBody);
 
     String getPipelineAnalyticsRequestBody(String pipelineName);
+
+    String getJobAnalyticsRequestBody(Map params);
 
     AnalyticsData getAnalyticsFromResponseBody(String responseBody);
 

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/analytics/AnalyticsMessageConverterV1.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/analytics/AnalyticsMessageConverterV1.java
@@ -41,6 +41,15 @@ public class AnalyticsMessageConverterV1 implements AnalyticsMessageConverter {
     }
 
     @Override
+    public String getJobAnalyticsRequestBody(Map params) {
+        Map<String, Object> requestMap = new HashMap<>();
+        requestMap.put("type", TYPE_JOB);
+        requestMap.put("data", params);
+
+        return GSON.toJson(requestMap);
+    }
+
+    @Override
     public String getDashboardAnalyticsRequestBody(String metric) {
         Map<String, Object> requestMap = new HashMap<>();
         requestMap.put("type", TYPE_DASHBOARD);

--- a/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/analytics/AnalyticsExtensionTest.java
+++ b/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/analytics/AnalyticsExtensionTest.java
@@ -112,6 +112,28 @@ public class AnalyticsExtensionTest {
     }
 
     @Test
+    public void shouldTalkToPlugin_To_GetJobAnalytics() throws Exception {
+        String responseBody = "{ \"view_path\": \"path/to/view\", \"data\": \"{}\" }";
+        when(pluginManager.submitTo(eq(PLUGIN_ID), requestArgumentCaptor.capture())).thenReturn(new DefaultGoPluginApiResponse(SUCCESS_RESPONSE_CODE, responseBody));
+        AnalyticsPluginInfo pluginInfo = new AnalyticsPluginInfo(
+                new GoPluginDescriptor(PLUGIN_ID, null, null, null, null, false),
+                null, null, null);
+        pluginInfo.setStaticAssetsPath("/assets/root");
+        metadataStore.setPluginInfo(pluginInfo);
+
+        AnalyticsData jobAnalytics = analyticsExtension.getJobAnalytics(PLUGIN_ID, Collections.EMPTY_MAP);
+
+        assertRequest(requestArgumentCaptor.getValue(), AnalyticsPluginConstants.EXTENSION_NAME, "1.0", REQUEST_GET_ANALYTICS, "{\"type\": \"job\", \"data\": {}}");
+
+        assertThat(jobAnalytics.getViewPath(), is("path/to/view"));
+
+        Map<String, String> expected = new HashMap<>();
+        expected.put("data", "{}");
+        expected.put("view_path", "/assets/root/path/to/view");
+        assertEquals(expected, jobAnalytics.toMap());
+    }
+
+    @Test
     public void shouldTalkToPlugin_To_GetDashboardAnalytics() throws Exception {
         String responseBody = "{ \"view_path\": \"path/to/view\", \"data\": \"{}\" }";
         when(pluginManager.submitTo(eq(PLUGIN_ID), requestArgumentCaptor.capture())).thenReturn(new DefaultGoPluginApiResponse(SUCCESS_RESPONSE_CODE, responseBody));

--- a/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/analytics/AnalyticsMessageConverterV1Test.java
+++ b/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/analytics/AnalyticsMessageConverterV1Test.java
@@ -23,6 +23,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
+import java.util.HashMap;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
@@ -79,6 +80,17 @@ public class AnalyticsMessageConverterV1Test {
     public void createsCorrectJSONForPipelineRequest() {
         Map expected = GSON.fromJson("{\"type\":\"pipeline\", \"data\": {\"pipeline_name\": \"anything\"}}", Map.class);
         Map actual = GSON.fromJson(converter.getPipelineAnalyticsRequestBody("anything"), Map.class);
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void createsCorrectJSONForJobRequest() {
+        Map expected = GSON.fromJson("{\"type\":\"job\", \"data\": {\"pipeline_name\": \"anything\", \"stage_name\": \"anything\",\"job_name\": \"anything\"}}", Map.class);
+        Map<String, String> params = new HashMap<>();
+        params.put("pipeline_name", "anything");
+        params.put("stage_name", "anything");
+        params.put("job_name", "anything");
+        Map actual = GSON.fromJson(converter.getJobAnalyticsRequestBody(params), Map.class);
         assertEquals(expected, actual);
     }
 }

--- a/server/webapp/WEB-INF/rails.new/app/assets/javascripts/analytics.js
+++ b/server/webapp/WEB-INF/rails.new/app/assets/javascripts/analytics.js
@@ -25,7 +25,7 @@
         frame.sandbox = "allow-scripts";
 
         frame.onload = function(e) {
-          PluginEndpoint.init(frame.contentWindow, {data: r.data })
+          PluginEndpoint.init(frame.contentWindow, {initialData: r.data})
         };
 
         div.appendChild(frame);

--- a/server/webapp/WEB-INF/rails.new/app/assets/new_stylesheets/single_page_apps/analytics.scss
+++ b/server/webapp/WEB-INF/rails.new/app/assets/new_stylesheets/single_page_apps/analytics.scss
@@ -37,7 +37,7 @@
   .frame-container {
     flex-grow:  1;
     flex-basis: auto;
-    min-width:  calc(44vh * 5 / 3);
+    min-width:  500px;
     min-height: 44vh;
     max-width:  calc(60vh * 5 / 3);
 

--- a/server/webapp/WEB-INF/rails.new/app/controllers/analytics_controller.rb
+++ b/server/webapp/WEB-INF/rails.new/app/controllers/analytics_controller.rb
@@ -43,6 +43,13 @@ class AnalyticsController < ApplicationController
     render_plugin_error e
   end
 
+  def job
+    options = params.reject {|k,v| %w(controller action plugin_id).include?(k)}
+    render :json => analytics_extension.getJobAnalytics(params[:plugin_id], options).toMap().to_h
+  rescue => e
+    render_plugin_error e
+  end
+
   private
 
   def render_plugin_error e

--- a/server/webapp/WEB-INF/rails.new/config/routes.rb
+++ b/server/webapp/WEB-INF/rails.new/config/routes.rb
@@ -164,6 +164,7 @@ Go::Application.routes.draw do
   resources :analytics, only: [:index], controller: "analytics"
   get 'analytics/:plugin_id/dashboard/:metric' => 'analytics#dashboard', constraints: {plugin_id: PLUGIN_ID_FORMAT, metric: ALLOW_DOTS}, as: :dashboard_analytics
   get 'analytics/:plugin_id/pipelines/:pipeline_name' => 'analytics#pipeline', constraints: {plugin_id: PLUGIN_ID_FORMAT, pipeline_name: PIPELINE_NAME_FORMAT}, as: :pipeline_analytics
+  get 'analytics/:plugin_id/jobs/:pipeline_name/:stage_name/:job_name' => 'analytics#job', constraints: {plugin_id: PLUGIN_ID_FORMAT, pipeline_name: PIPELINE_NAME_FORMAT, stage_name: PIPELINE_NAME_FORMAT, job_name: PIPELINE_NAME_FORMAT}, as: :job_analytics
 
   scope 'pipelines' do
     defaults :no_layout => true do

--- a/server/webapp/WEB-INF/rails.new/spec/webpack/lib/plugin_endpoint_spec.js
+++ b/server/webapp/WEB-INF/rails.new/spec/webpack/lib/plugin_endpoint_spec.js
@@ -39,9 +39,11 @@
       }
     };
 
-    window.postMessage = function(message, _origin) {
-      dispatch(mockEvent(message));
-    };
+    Object.defineProperty(window, "postMessage", {
+      value: function(message, _origin) {
+        dispatch(mockEvent(message));
+      }
+    });
 
     PluginEndpoint.ensure();
   });

--- a/server/webapp/WEB-INF/rails.new/spec/webpack/lib/plugin_endpoint_spec.js
+++ b/server/webapp/WEB-INF/rails.new/spec/webpack/lib/plugin_endpoint_spec.js
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2018 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+ describe("PluginEndpoint", () => {
+
+  const PluginEndpoint = require('rails-shared/plugin-endpoint');
+  const origPostMessage = window.postMessage;
+  const origListener = window.addEventListener;
+
+  let dispatch;
+
+  function mockEvent(message) {
+    const event = {};
+    event.source = window;
+    event.origin = window.origin;
+    event.data = message;
+    return event;
+  }
+
+  beforeEach(() => {
+    window.addEventListener = function(name, fn, bool) {
+      if ("message" === name) {
+        dispatch = fn;
+      } else {
+        origListener(name, fn, bool);
+      }
+    };
+
+    window.postMessage = function(message, _origin) {
+      dispatch(mockEvent(message));
+    };
+
+    PluginEndpoint.ensure();
+  });
+
+  afterEach(() => {
+    window.postMessage = origPostMessage;
+    window.addEventListener = origListener;
+  });
+
+  it("should send response for matching request", (done) => {
+    let messageContent;
+    let response;
+
+    PluginEndpoint.define({
+      "should.receive": (message, trans) => {
+        messageContent = message.body;
+        trans.respond({ data: "correct" });
+      },
+      "should.not.receive": (_message, trans) => {
+        trans.respond({ data: "incorrect" });
+      }
+    });
+
+    PluginEndpoint.onInit((_data, trans) => {
+      trans.request("should.receive", "foo").done((data) => {
+        response = data;
+      }).fail((_error) => {
+        fail(); // eslint-disable-line no-undef
+      }).always(() => {
+        expect(response).toBe("correct");
+        expect(messageContent).toBe("foo");
+        done();
+      });
+    });
+
+    PluginEndpoint.init(window, "initialized");
+  });
+});

--- a/server/webapp/WEB-INF/rails.new/spec/webpack/lib/plugin_endpoint_spec.js
+++ b/server/webapp/WEB-INF/rails.new/spec/webpack/lib/plugin_endpoint_spec.js
@@ -25,7 +25,7 @@
   function mockEvent(message) {
     const event = {};
     event.source = window;
-    event.origin = window.origin;
+    event.origin = "null";
     event.data = message;
     return event;
   }

--- a/server/webapp/WEB-INF/rails.new/spec/webpack/lib/plugin_endpoint_spec.js
+++ b/server/webapp/WEB-INF/rails.new/spec/webpack/lib/plugin_endpoint_spec.js
@@ -40,7 +40,7 @@
     };
 
     Object.defineProperty(window, "postMessage", {
-      value: function(message, _origin) {
+      value: (message, _origin) =>  {
         dispatch(mockEvent(message));
       }
     });

--- a/server/webapp/WEB-INF/rails.new/spec/webpack/views/analytics/plugin_iframe_widget_spec.js
+++ b/server/webapp/WEB-INF/rails.new/spec/webpack/views/analytics/plugin_iframe_widget_spec.js
@@ -82,7 +82,7 @@ describe("Plugin iFrame Widget", () => {
     const expectedMessage = JSON.stringify({
       uid: "some-uid",
       pluginId: "some-plugin",
-      data: "model data"
+      initialData: "model data"
     });
     expect(actualMessage).toBe(expectedMessage);
   });

--- a/server/webapp/WEB-INF/rails.new/webpack/models/analytics/frame.js
+++ b/server/webapp/WEB-INF/rails.new/webpack/models/analytics/frame.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-(function() {
+ (function() {
   "use strict";
 
   const Stream = require("mithril/stream");
@@ -43,7 +43,22 @@
       });
     }
 
-    return {url, view, data, load, errors};
+    function fetch(url, handler) {
+      errors(null);
+
+      $.ajax({
+        url,
+        type: "GET",
+        dataType: "json"
+      }).done((r) => {
+        handler(r.data, null);
+      }).fail((xhr) => {
+        errors(xhr.responseText);
+        handler(null, errors());
+      });
+    }
+
+    (Object.assign || $.extend)(this, {url, view, data, load, fetch, errors});
   }
 
   module.exports = Frame;

--- a/server/webapp/WEB-INF/rails.new/webpack/rails-shared/plugin-endpoint.js
+++ b/server/webapp/WEB-INF/rails.new/webpack/rails-shared/plugin-endpoint.js
@@ -17,14 +17,37 @@
 (function() {
   "use strict";
 
-  // these are intentionally private variables, hidden via closure
-  /* eslint-disable no-var */
-  // disabling no-var because this is also shared with rails
-  var handlers = {};
+  // This file is shared between new and old pages, so we can't use ES6 syntax as the file
+  // isn't guaranteed to be compiled
+
+  /* eslint-disable no-var,prefer-template,object-shorthand,prefer-arrow-callback */
+  var HANDLERS = {};
   var attached = false;
   var uid;
   var pluginId;
-  /* eslint-enable no-var */
+
+  var REQUEST_ID_SEQ = 0;
+  var PENDING_REQUESTS = new RequestTable();
+
+  function RequestTable() {
+    var requests = {};
+
+    this.register = function register(id, request) {
+      requests[id] = request;
+    };
+
+    this.pop = function getRequest(id) {
+      var req = requests[id];
+
+      if (!req) {
+        throw new Error("No request with id: " + id);
+      }
+
+      delete requests[id];
+
+      return req;
+    };
+  }
 
   function err() {
     if (window.console && "function" === typeof window.console.error) {
@@ -32,61 +55,153 @@
     }
   }
 
-  function init(win, message) {
-    send(win, "init", message);
+  function init(win, data) {
+    new Transport(win).request("init", data);
   }
 
-  /** constructs a message from key and body, and sends it to the target window */
-  function send(win, key, message) {
-    if (uid) { message.uid = uid; }
-    if (pluginId) { message.pluginId = pluginId; }
+  /** constructs a message from metadata and payload, and sends it to the target window */
+  function send(win, data, metadata) {
+    metadata = metadata || {};
 
-    if (win && key && message) {
-      message.key = key;
+    if (uid) { metadata.uid = uid; }
+    if (pluginId) { metadata.pluginId = pluginId; }
 
+    if (win && data) {
       // origin of target window is inaccessible when iframe sandbox is enforced, so
       // cannot check origin (no need to anyway), so just use "*"
-      win.postMessage(message, "*");
-
+      win.postMessage({ head: metadata, body: data }, "*");
     } else {
-      err("Failed to send", key, "=>", message, "to window:", win);
+      err("Failed to send", data, "with metadata", metadata, "to window:", win);
     }
   }
 
   /** main function to delegate messages to appropriate handlers */
   function dispatch(ev) {
+    var message = ev.data;
+
     if ("null" !== ev.origin && ev.origin !== window.location.origin) {
-      err("Disregarding message", ev.data, "because origin", ev.origin, "does not match", window.location.origin);
+      err("Disregarding message", message, "because origin", ev.origin, "does not match", window.location.origin);
       return;
     }
 
     // We always expect data to be an object; this also has the nice
     // side effect of ignoring bootstrap's test for window.postMessage()
-    if ("object" !== typeof ev.data) {
+    if ("object" !== typeof message) {
       return;
     }
 
-    if (!(ev.data && ev.data.key)) {
-      err("Message is missing key; debug:", JSON.stringify(ev.data));
+    if ("object" !== typeof message.head) {
+      err("Missing message metadata! debug:", message);
       return;
     }
 
-    if ("function" !== typeof handlers[ev.data.key]) {
-      err("Don't know how to handle message key:", ev.data.key);
+    if ("string" !== typeof message.head.type) {
+      err("Missing transport type! debug:", message);
       return;
     }
 
-    function reply(key, data) {
-      var message = { data: data }; // eslint-disable-line no-var, object-shorthand
-      send(ev.source, key, message);
+    if ("number" !== typeof message.head.reqId) {
+      err("Missing request id! debug:", message);
+      return;
     }
 
-    // a handler is a function that will receive the message payload and a reply()
-    // function to *optionally* allow the handler to send a response back.
-    handlers[ev.data.key](ev.data, reply);
+    handleRequestResponse(ev.source, message);
   }
 
-  var PluginEndpoint = { // eslint-disable-line no-var
+  function messageKey(message) {
+    return message && message.head && ("string" === typeof message.head.key) ?
+      message.head.key : null;
+  }
+
+  function handleRequestResponse(source, message) {
+    var reqId = message.head.reqId,
+         type = message.head.type;
+
+    switch (type) {
+      case "request":
+        var key = messageKey(message);
+
+        if (!key) {
+          err("Request is missing key; debug:", JSON.stringify(message));
+          return;
+        }
+
+        if ("function" !== typeof HANDLERS[key]) {
+          err("Don't know how to handle request key:", key);
+          return;
+        }
+
+        HANDLERS[key](message, new Transport(source));
+        break;
+      case "response":
+        var req = PENDING_REQUESTS.pop(reqId);
+        req.onComplete(message.body.data, message.body.errors);
+        break;
+      default:
+        err("Don't know how to handle type", type, "; debug:", message);
+        break;
+    }
+  }
+
+  function nextReqId() { return REQUEST_ID_SEQ++; }
+
+  function Transport(win) {
+    this.request = function sendRequest(key, data) {
+      var reqId = nextReqId();
+      var req = new PluginRequest(reqId);
+
+      PENDING_REQUESTS.register(reqId, req);
+      send(win, data, {reqId: reqId, type: "request", key: key});
+      return req;
+    };
+
+    this.respond = function sendResponse(reqId, data) {
+      send(win, data, {reqId: reqId, type: "response"});
+    };
+  }
+
+  function PluginRequest() {
+    function noop() {}
+
+    var handlers = {
+      done: noop,
+      fail: noop,
+      always: noop
+    };
+
+    function addCallbackSetter(obj, name) {
+      obj[name] = function(fn) {
+        if ("function" === typeof fn) {
+          handlers[name] = fn;
+        }
+
+        return obj;
+      };
+    }
+
+    addCallbackSetter(this, "done");
+    addCallbackSetter(this, "fail");
+    addCallbackSetter(this, "always");
+
+
+    this.onComplete = function (data, errors) {
+      if (!errors) {
+        if ("function" === typeof handlers.done) {
+          handlers.done(data);
+        }
+      } else {
+        if ("function" === typeof handlers.fail) {
+          handlers.fail(errors);
+        }
+      }
+
+      if ("function" === typeof handlers.always) {
+        handlers.always();
+      }
+    };
+  }
+
+  var PluginEndpoint = {
     ensure: function ensure() {
       if (!attached) {
         window.addEventListener("message", dispatch, false);
@@ -96,22 +211,23 @@
     },
     /** define a handler for a single key */
     on: function addOne(key, handlerFn) {
-      handlers[key] = handlerFn;
+      HANDLERS[key] = handlerFn;
     },
     /** define an api, i.e. a set of handlers for one or more keys */
     define: function addMany(api) {
-      for (var i = 0, keys = Object.keys(api), len = keys.length; i < len; ++i) { // eslint-disable-line no-var
+      for (var i = 0, keys = Object.keys(api), len = keys.length; i < len; ++i) {
         if ("function" === typeof api[keys[i]]) {
-          handlers[keys[i]] = api[keys[i]];
+          HANDLERS[keys[i]] = api[keys[i]];
         }
       }
     },
-    init: init, // eslint-disable-line object-shorthand
+    init: init,
     onInit: function onInit(initializerFn) {
-      PluginEndpoint.on("init", function handleInit(message, reply) { // eslint-disable-line prefer-arrow-callback
-        uid = message.uid;
-        pluginId = message.pluginId;
-        initializerFn(message, reply);
+      PluginEndpoint.on("init", function handleInit(message, transport) {
+        var body = message.body;
+        uid = body.uid;
+        pluginId = body.pluginId;
+        initializerFn(body.initialData, transport);
       });
     }
   };

--- a/server/webapp/WEB-INF/rails.new/webpack/rails-shared/plugin-endpoint.js
+++ b/server/webapp/WEB-INF/rails.new/webpack/rails-shared/plugin-endpoint.js
@@ -82,6 +82,13 @@
       err("Disregarding message", message, "because origin", ev.origin, "does not match", window.location.origin);
       return;
     }
+
+    // We always expect data to be an object; this also has the nice
+    // side effect of ignoring bootstrap's test for window.postMessage()
+    if ("object" !== typeof message) {
+      return;
+    }
+
     var error = validateMessage(message);
     if (error) {
       err(error + " debug:", message);
@@ -92,12 +99,6 @@
   }
 
   function validateMessage(message) {
-    // We always expect data to be an object; this also has the nice
-    // side effect of ignoring bootstrap's test for window.postMessage()
-    if ("object" !== typeof message) {
-      return "Message is not an object.";
-    }
-
     if ("object" !== typeof message.head) {
       return "Missing message metadata!";
     }

--- a/server/webapp/WEB-INF/rails.new/webpack/single_page_apps/analytics.js
+++ b/server/webapp/WEB-INF/rails.new/webpack/single_page_apps/analytics.js
@@ -50,6 +50,16 @@
       const model = models[message.uid];
       model.url(Routes.pipelineAnalyticsPath({plugin_id: message.pluginId, pipeline_name: message.data.pipelineName})); // eslint-disable-line camelcase
       model.load();
+    },
+
+    "analytics.jobs": (message, reply) => { // eslint-disable-line no-unused-vars
+      const model = models[message.uid];
+      const params = $.extend({plugin_id: message.pluginId}, message.data); // eslint-disable-line camelcase
+      params.start = JSON.stringify(params.start).replace(/"/g, "");
+      params.end = JSON.stringify(params.end).replace(/"/g, "");
+
+      model.url(Routes.jobAnalyticsPath(params));
+      model.load();
     }
   });
 

--- a/server/webapp/WEB-INF/rails.new/webpack/single_page_apps/analytics.js
+++ b/server/webapp/WEB-INF/rails.new/webpack/single_page_apps/analytics.js
@@ -55,7 +55,7 @@
       params.end = JSON.stringify(params.end).replace(/"/g, "");
 
       model.fetch(Routes.jobAnalyticsPath(params), (data, errors) => {
-        trans.respond(meta.reqId, {data, errors});
+        trans.respond({data, errors});
       });
     },
 

--- a/server/webapp/WEB-INF/rails.new/webpack/single_page_apps/analytics.js
+++ b/server/webapp/WEB-INF/rails.new/webpack/single_page_apps/analytics.js
@@ -46,19 +46,23 @@
   PluginEndpoint.ensure();
 
   PluginEndpoint.define({
-    "analytics.pipeline": (message, reply) => { // eslint-disable-line no-unused-vars
-      const model = models[message.uid];
-      model.url(Routes.pipelineAnalyticsPath({plugin_id: message.pluginId, pipeline_name: message.data.pipelineName})); // eslint-disable-line camelcase
-      model.load();
-    },
+    "analytics.job.history": (message, trans) => {
+      const meta = message.head;
+      const model = models[meta.uid];
+      const params = $.extend({plugin_id: meta.pluginId}, message.body); // eslint-disable-line camelcase
 
-    "analytics.jobs": (message, reply) => { // eslint-disable-line no-unused-vars
-      const model = models[message.uid];
-      const params = $.extend({plugin_id: message.pluginId}, message.data); // eslint-disable-line camelcase
       params.start = JSON.stringify(params.start).replace(/"/g, "");
       params.end = JSON.stringify(params.end).replace(/"/g, "");
 
-      model.url(Routes.jobAnalyticsPath(params));
+      model.fetch(Routes.jobAnalyticsPath(params), (data, errors) => {
+        trans.respond(meta.reqId, {data, errors});
+      });
+    },
+
+    "analytics.pipeline": (message, reply) => { // eslint-disable-line no-unused-vars
+      const meta = message.head;
+      const model = models[meta.uid];
+      model.url(Routes.pipelineAnalyticsPath({plugin_id: meta.pluginId, pipeline_name: message.body.pipelineName})); // eslint-disable-line camelcase
       model.load();
     }
   });

--- a/server/webapp/WEB-INF/rails.new/webpack/views/analytics/plugin_iframe_widget.js.msx
+++ b/server/webapp/WEB-INF/rails.new/webpack/views/analytics/plugin_iframe_widget.js.msx
@@ -27,7 +27,7 @@
         vnode.attrs.init(iframe.contentWindow, {
           uid: vnode.attrs.uid,
           pluginId: vnode.attrs.pluginId,
-          data: vnode.attrs.model.data()
+          initialData: vnode.attrs.model.data()
         });
       };
 


### PR DESCRIPTION
**PluginEndpoint now implements and request-response approach only.**

This is a breaking API change.

Now all defined listeners (including onInit) receive a transport object instead of a reply() fn.

The transport object has 2 methods: request() and respond(); Plugin authors may use the transport
object to make requests and add response callbacks:

PluginEndpoint.onInit(initialData, transport) {

  // some code here
  // ...

  transport.request("analytics.job.history", myParams).
    done(function success() { /* do something */}).
    fail(function error() { /* handle errors */).
    always(function onComplete() { /* cleanup */);
});

And on GoCD server pages, we register listeners to handle the response back:

PluginEndpoint.define({

  "analytics.job.history": function(message, transport) {
    // do some processing

    // currently, response() requires a request ID passed through the message
    // so that the plugin-side scripts can associate responses with requests
    transport.respond(message.head.reqId, responseData);
  }

});

As one can see, the API resembles jQuery.ajax() requests.

**The analytics jobs endpoint allows us to get the data for a job history chart.** 