### PR TITLE
Fix some styling

### DIFF
--- a/server/webapp/WEB-INF/rails.new/app/assets/new_stylesheets/shared/_common.scss
+++ b/server/webapp/WEB-INF/rails.new/app/assets/new_stylesheets/shared/_common.scss
@@ -273,6 +273,7 @@ select {
 
 [type='text'], [type='password'], [type='date'], [type='datetime'], [type='datetime-local'], [type='month'], [type='week'], [type='email'], [type='number'], [type='search'], [type='tel'], [type='time'], [type='url'], [type='color'], textarea {
   transition: all 0.3s ease-in-out;
+  padding: 0 0.5rem;
   &:focus {
     background-color: rgba(182, 111, 194, 0.14);
     box-shadow:       none;

--- a/server/webapp/WEB-INF/rails.new/webpack/views/plugins/plugins_widget.js.msx
+++ b/server/webapp/WEB-INF/rails.new/webpack/views/plugins/plugins_widget.js.msx
@@ -94,7 +94,7 @@ const PluginsWidget = {
       const modal = this.createModal({
         newPluginSetting,
         pluginInfo,
-        modalTitle: `Edit plugin Settings`,
+        modalTitle: `Edit plugin settings`,
         errorMessage,
         callback:   () => {
           if (newPluginSetting().etag()) {


### PR DESCRIPTION
Foundation, for some weird reason defaults to `padding: 0.5rem` for text boxes. This changes the top and bottom padding to 0. Also changes modal box title.

### OLD:

##### Textbox with g's and y's cut off:
<img width="283" alt="old_textbox" src="https://user-images.githubusercontent.com/172235/36617408-529f340e-18b5-11e8-9871-2d3762999b64.png">


### NEW:

##### Proper textbox:
<img width="301" alt="new_textbox" src="https://user-images.githubusercontent.com/172235/36617420-6196d2c8-18b5-11e8-8fbf-bf76b69fa0ab.png">
