### PR TITLE
Add the blacklist textarea to other scm materials in the pipeline creation wizard.

### DIFF
--- a/server/webapp/WEB-INF/rails.new/app/helpers/admin/material_helper.rb
+++ b/server/webapp/WEB-INF/rails.new/app/helpers/admin/material_helper.rb
@@ -19,8 +19,8 @@ module Admin
     include JavaImports
 
     def material_options
-      {l.string("SUBVERSION") => SvnMaterialConfig::TYPE,
-       l.string("GIT") => GitMaterialConfig::TYPE,
+      {l.string("GIT") => GitMaterialConfig::TYPE,
+       l.string("SUBVERSION") => SvnMaterialConfig::TYPE,
        l.string("MERCURIAL") => HgMaterialConfig::TYPE,
        l.string("P4") => P4MaterialConfig::TYPE,
        l.string("TFS") => com.thoughtworks.go.config.materials.tfs.TfsMaterialConfig::TYPE,

--- a/server/webapp/WEB-INF/rails.new/app/views/admin/materials/index.html.erb
+++ b/server/webapp/WEB-INF/rails.new/app/views/admin/materials/index.html.erb
@@ -59,8 +59,8 @@
             <div id="new_material_popup" class="hidden enhanced_dropdown">
                 <ul>
                     <% if @pipeline.materialConfigs().scmMaterialsHaveDestination() %>
-                        <li><%= link_to l.string("SUBVERSION"), '#', :onclick => "Modalbox.show('#{admin_svn_new_path(:controller => "admin/materials/svn", :action => "new")}', {overlayClose: false, title: '#{l.string("ADD_MATERIAL")} - #{l.string("SUBVERSION")}'})" -%></li>
                         <li><%= link_to l.string("GIT"), '#', :onclick => "Modalbox.show('#{admin_git_new_path}', {overlayClose: false, title: '#{l.string("ADD_MATERIAL")} - #{l.string("GIT")}'})" -%></li>
+                        <li><%= link_to l.string("SUBVERSION"), '#', :onclick => "Modalbox.show('#{admin_svn_new_path(:controller => "admin/materials/svn", :action => "new")}', {overlayClose: false, title: '#{l.string("ADD_MATERIAL")} - #{l.string("SUBVERSION")}'})" -%></li>
                         <li><%= link_to l.string("MERCURIAL"), '#', :onclick => "Modalbox.show('#{admin_hg_new_path}', {overlayClose: false, title: '#{l.string("ADD_MATERIAL")} - #{l.string("MERCURIAL")}'})" -%></li>
                         <li><%= link_to l.string("P4"), '#', :onclick => "Modalbox.show('#{admin_p4_new_path}', {overlayClose: false, title: '#{l.string("ADD_MATERIAL")} - #{l.string("P4")}'})" -%></li>
                         <li><%= link_to l.string("TFS"), '#', :onclick => "Modalbox.show('#{admin_tfs_new_path}', {overlayClose: false, title: '#{l.string("ADD_MATERIAL")} - #{l.string("TFS")}'})" -%></li>
@@ -72,8 +72,8 @@
                             <% end %>
                         <% end %>
                     <% else %>
-                        <li><%= link_to l.string("SUBVERSION"), '#', :onclick => "Modalbox.show(jQuery('.light_box_content')[0], {overlayClose: false, title: '#{l.string("ADD_MATERIAL")} - #{l.string("SUBVERSION")}'})" -%></li>
                         <li><%= link_to l.string("GIT"), '#', :onclick => "Modalbox.show(jQuery('.light_box_content')[0], {overlayClose: false, title: '#{l.string("ADD_MATERIAL")} - #{l.string("GIT")}'})" -%></li>
+                        <li><%= link_to l.string("SUBVERSION"), '#', :onclick => "Modalbox.show(jQuery('.light_box_content')[0], {overlayClose: false, title: '#{l.string("ADD_MATERIAL")} - #{l.string("SUBVERSION")}'})" -%></li>
                         <li><%= link_to l.string("MERCURIAL"), '#', :onclick => "Modalbox.show(jQuery('.light_box_content')[0], {overlayClose: false, title: '#{l.string("ADD_MATERIAL")} - #{l.string("MERCURIAL")}'})" -%></li>
                         <li><%= link_to l.string("P4"), '#', :onclick => "Modalbox.show(jQuery('.light_box_content')[0], {overlayClose: false, title: '#{l.string("ADD_MATERIAL")} - #{l.string("P4")}'})" -%></li>
                         <li><%= link_to l.string("TFS"), '#', :onclick => "Modalbox.show(jQuery('.light_box_content')[0], {overlayClose: false, title: '#{l.string("ADD_MATERIAL")} - #{l.string("TFS")}'})" -%></li>

--- a/server/webapp/WEB-INF/rails.new/app/views/admin/pipelines/materials/_hg_form.html.erb
+++ b/server/webapp/WEB-INF/rails.new/app/views/admin/pipelines/materials/_hg_form.html.erb
@@ -6,6 +6,7 @@
 
 <%= render :partial => "admin/materials/shared/dest_folder", :locals => {:scope => {:form => scope[:form]}}%>
 <%= render :partial => "admin/materials/shared/options", :locals => {:scope => {:form => scope[:form]}} %>
+<%= render :partial => "admin/materials/shared/filter", :locals => {:scope => {:form => scope[:form]}} %>
 <%= render :partial => 'admin/materials/shared/check_connection', :locals => {:scope => {:url => ".hg_url", :type => "hg"}} %>
 
 <%= render :partial => 'shared/convert_tool_tips.html', :locals => {:scope => {}} %>

--- a/server/webapp/WEB-INF/rails.new/app/views/admin/pipelines/materials/_p4_form.html.erb
+++ b/server/webapp/WEB-INF/rails.new/app/views/admin/pipelines/materials/_p4_form.html.erb
@@ -30,6 +30,7 @@
 </div>
 <%= render :partial => "admin/materials/shared/dest_folder", :locals => {:scope => {:form => scope[:form]}}%>
 <%= render :partial => "admin/materials/shared/options", :locals => {:scope => {:form => scope[:form]}} %>
+<%= render :partial => "admin/materials/shared/filter", :locals => {:scope => {:form => scope[:form]}} %>
 <%= render :partial => 'admin/materials/shared/check_connection', :locals => {:scope => {:username => ".p4_username", :password => ".p4_password", :port => ".p4_url", :type => "p4", :encrypted_password => "false", :view => ".p4_view"}} %>
 
 <%= render :partial => 'shared/convert_tool_tips.html', :locals => {:scope => {}} %>

--- a/server/webapp/WEB-INF/rails.new/app/views/admin/pipelines/materials/_svn_material_form.html.erb
+++ b/server/webapp/WEB-INF/rails.new/app/views/admin/pipelines/materials/_svn_material_form.html.erb
@@ -15,6 +15,7 @@
 
   <%= render :partial => "admin/materials/shared/dest_folder", :locals => {:scope => {:form => scope[:form]}} %>
   <%= render :partial => "admin/materials/shared/options", :locals => {:scope => {:form => scope[:form]}} %>
+  <%= render :partial => "admin/materials/shared/filter", :locals => {:scope => {:form => scope[:form]}} %>
 
   <%= render :partial => 'admin/materials/shared/check_connection', :locals => {:scope => {:username => ".svn_username", :password => ".svn_password", :url => ".svn_url", :type => "svn", :encrypted_password => "false"}} %>
   <div class="clear"></div>

--- a/server/webapp/WEB-INF/rails.new/app/views/admin/pipelines/materials/_tfs_form.html.erb
+++ b/server/webapp/WEB-INF/rails.new/app/views/admin/pipelines/materials/_tfs_form.html.erb
@@ -26,6 +26,7 @@
 
 <%= render :partial => "admin/materials/shared/dest_folder", :locals => {:scope => {:form => scope[:form]}} %>
 <%= render :partial => "admin/materials/shared/options", :locals => {:scope => {:form => scope[:form]}} %>
+<%= render :partial => "admin/materials/shared/filter", :locals => {:scope => {:form => scope[:form]}} %>
 
 <%= render :partial => 'admin/materials/shared/check_connection', :locals => {:scope => {:url => ".tfs_url", :type => "tfs", :username => ".tfs_username", :password => ".tfs_password",
                                                                                          :encrypted_password => "false", :password_changed => "false", :project_path => ".tfs_project_path", :domain => ".tfs_domain"}} %>

--- a/server/webapp/WEB-INF/rails.new/spec/helpers/admin/material_helper_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/helpers/admin/material_helper_spec.rb
@@ -24,6 +24,7 @@ describe Admin::MaterialHelper do
     it "should populate options correctly" do
       material_options_map = material_options
       expect(material_options_map.size).to eq(7)
+      expect(material_options_map.first).to eq(["Git", "GitMaterial"])
       expect(material_options_map["Subversion"]).to eq(SvnMaterialConfig::TYPE)
       expect(material_options_map["Git"]).to eq(GitMaterialConfig::TYPE)
       expect(material_options_map["Mercurial"]).to eq(HgMaterialConfig::TYPE)

--- a/server/webapp/WEB-INF/rails.new/spec/views/admin/materials/index_html_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/views/admin/materials/index_html_spec.rb
@@ -115,8 +115,8 @@ describe "admin/materials/index.html.erb" do
     end
     Capybara.string(response.body).find('div.enhanced_dropdown ul').tap do |ul|
       ul.all("li a[href='#']").tap do |lis|
-        expect(lis[0]['onclick']).to eq("Modalbox.show(jQuery('.light_box_content')[0], {overlayClose: false, title: 'Add Material - Subversion'})")
-        expect(lis[1]['onclick']).to eq("Modalbox.show(jQuery('.light_box_content')[0], {overlayClose: false, title: 'Add Material - Git'})")
+        expect(lis[0]['onclick']).to eq("Modalbox.show(jQuery('.light_box_content')[0], {overlayClose: false, title: 'Add Material - Git'})")
+        expect(lis[1]['onclick']).to eq("Modalbox.show(jQuery('.light_box_content')[0], {overlayClose: false, title: 'Add Material - Subversion'})")
         expect(lis[2]['onclick']).to eq("Modalbox.show(jQuery('.light_box_content')[0], {overlayClose: false, title: 'Add Material - Mercurial'})")
         expect(lis[3]['onclick']).to eq("Modalbox.show(jQuery('.light_box_content')[0], {overlayClose: false, title: 'Add Material - Perforce'})")
         expect(lis[4]['onclick']).to eq("Modalbox.show(jQuery('.light_box_content')[0], {overlayClose: false, title: 'Add Material - Team Foundation Server'})")

--- a/server/webapp/WEB-INF/rails.new/spec/views/admin/pipelines/material_form_html_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/views/admin/pipelines/material_form_html_spec.rb
@@ -101,6 +101,7 @@ describe "admin/pipelines/new.html.erb" do
 
           expect(form).to have_selector("label", :text => "Poll for new changes")
           expect(form).to have_selector("input[type='checkbox'][name='pipeline_group[pipeline][materials][#{com.thoughtworks.go.config.materials.svn.SvnMaterialConfig::TYPE}][#{com.thoughtworks.go.config.materials.ScmMaterialConfig::AUTO_UPDATE}]'][checked='checked']")
+          expect(form).to have_selector("textarea[name='pipeline_group[pipeline][materials][#{com.thoughtworks.go.config.materials.svn.SvnMaterialConfig::TYPE}][#{ScmMaterialConfig::FILTER}]']")
         end
       end
 
@@ -153,6 +154,8 @@ describe "admin/pipelines/new.html.erb" do
 
           expect(form).to have_selector("label", :text => "Shallow clone (recommended for large repositories)")
           expect(form).to have_selector("input[type='checkbox'][name='pipeline_group[pipeline][materials][#{com.thoughtworks.go.config.materials.git.GitMaterialConfig::TYPE}][#{com.thoughtworks.go.config.materials.git.GitMaterialConfig::SHALLOW_CLONE}]']")
+
+          expect(form).to have_selector("textarea[name='pipeline_group[pipeline][materials][#{com.thoughtworks.go.config.materials.git.GitMaterialConfig::TYPE}][#{ScmMaterialConfig::FILTER}]']")
         end
       end
     end
@@ -169,6 +172,7 @@ describe "admin/pipelines/new.html.erb" do
 
           expect(form).to have_selector("label", :text => "Poll for new changes")
           expect(form).to have_selector("input[type='checkbox'][name='pipeline_group[pipeline][materials][#{com.thoughtworks.go.config.materials.mercurial.HgMaterialConfig::TYPE}][#{com.thoughtworks.go.config.materials.ScmMaterialConfig::AUTO_UPDATE}]'][checked='checked']")
+          expect(form).to have_selector("textarea[name='pipeline_group[pipeline][materials][#{com.thoughtworks.go.config.materials.mercurial.HgMaterialConfig::TYPE}][#{ScmMaterialConfig::FILTER}]']")
         end
       end
     end
@@ -188,6 +192,7 @@ describe "admin/pipelines/new.html.erb" do
 
           expect(form).to have_selector("label", :text => "Poll for new changes")
           expect(form).to have_selector("input[type='checkbox'][name='pipeline_group[pipeline][materials][#{com.thoughtworks.go.config.materials.tfs.TfsMaterialConfig::TYPE}][#{com.thoughtworks.go.config.materials.ScmMaterialConfig::AUTO_UPDATE}]'][checked='checked']")
+          expect(form).to have_selector("textarea[name='pipeline_group[pipeline][materials][#{com.thoughtworks.go.config.materials.tfs.TfsMaterialConfig::TYPE}][#{ScmMaterialConfig::FILTER}]']")
 
           expect(form).not_to have_selector("input[type='text'][name='pipeline_group[pipeline][materials][#{com.thoughtworks.go.config.materials.tfs.TfsMaterialConfig::TYPE}][workspaceOwner]']")
           expect(form).not_to have_selector("input[type='text'][name='pipeline_group[pipeline][materials][#{com.thoughtworks.go.config.materials.tfs.TfsMaterialConfig::TYPE}][workspace]']")
@@ -213,6 +218,7 @@ describe "admin/pipelines/new.html.erb" do
 
           expect(form).to have_selector("label", :text => "View*")
           expect(form).to have_selector("textarea[name='pipeline_group[pipeline][materials][#{com.thoughtworks.go.config.materials.perforce.P4MaterialConfig::TYPE}][#{com.thoughtworks.go.config.materials.perforce.P4MaterialConfig::VIEW}]']")
+          expect(form).to have_selector("textarea[name='pipeline_group[pipeline][materials][#{com.thoughtworks.go.config.materials.perforce.P4MaterialConfig::TYPE}][#{ScmMaterialConfig::FILTER}]']")
 
           expect(form).to have_selector("label[for='material_useTickets']", :text => "Use tickets")
           expect(form).to have_selector("input[id='material_useTickets'][type='checkbox'][name='pipeline_group[pipeline][materials][#{com.thoughtworks.go.config.materials.perforce.P4MaterialConfig::TYPE}][#{com.thoughtworks.go.config.materials.perforce.P4MaterialConfig::USE_TICKETS}]']")


### PR DESCRIPTION
Change the order of materials in the dropdowns to be consistent with the quick edit page.