### PR TITLE
Set secure flag of selected_piplines cookie as per session cookie config

### DIFF
--- a/api/api-pipeline-selection-v1/src/main/java/com/thoughtworks/go/apiv1/pipelineselection/PipelineSelectionControllerDelegate.java
+++ b/api/api-pipeline-selection-v1/src/main/java/com/thoughtworks/go/apiv1/pipelineselection/PipelineSelectionControllerDelegate.java
@@ -29,6 +29,7 @@ import com.thoughtworks.go.server.domain.user.PipelineSelections;
 import com.thoughtworks.go.server.service.PipelineConfigService;
 import com.thoughtworks.go.server.service.PipelineSelectionsService;
 import com.thoughtworks.go.spark.Routes;
+import com.thoughtworks.go.util.SystemEnvironment;
 import spark.Request;
 import spark.Response;
 
@@ -42,12 +43,17 @@ public class PipelineSelectionControllerDelegate extends ApiController {
     private final ApiAuthenticationHelper apiAuthenticationHelper;
     private final PipelineSelectionsService pipelineSelectionsService;
     private final PipelineConfigService pipelineConfigService;
+    private final SystemEnvironment systemEnvironment;
 
-    public PipelineSelectionControllerDelegate(ApiAuthenticationHelper apiAuthenticationHelper, PipelineSelectionsService pipelineSelectionsService, PipelineConfigService pipelineConfigService) {
+    public PipelineSelectionControllerDelegate(ApiAuthenticationHelper apiAuthenticationHelper,
+                                               PipelineSelectionsService pipelineSelectionsService,
+                                               PipelineConfigService pipelineConfigService,
+                                               SystemEnvironment systemEnvironment) {
         super(ApiVersion.v1);
         this.apiAuthenticationHelper = apiAuthenticationHelper;
         this.pipelineSelectionsService = pipelineSelectionsService;
         this.pipelineConfigService = pipelineConfigService;
+        this.systemEnvironment = systemEnvironment;
     }
 
     @Override
@@ -89,7 +95,7 @@ public class PipelineSelectionControllerDelegate extends ApiController {
         Long recordId = pipelineSelectionsService.persistSelectedPipelines(fromCookie, currentUserId(request), selectionResponse.getSelectedPipelines().pipelineList(), selectionResponse.getSelectedPipelines().isBlacklist());
 
         if (!apiAuthenticationHelper.securityEnabled()) {
-            response.cookie("/go", "selected_pipelines", String.valueOf(recordId), ONE_YEAR, true, true);
+            response.cookie("/go", "selected_pipelines", String.valueOf(recordId), ONE_YEAR, systemEnvironment.isSessionCookieSecure(), true);
         }
 
         response.status(204);

--- a/api/api-pipeline-selection-v1/src/main/java/com/thoughtworks/go/apiv1/pipelineselection/spring/PipelineSelectionController.java
+++ b/api/api-pipeline-selection-v1/src/main/java/com/thoughtworks/go/apiv1/pipelineselection/spring/PipelineSelectionController.java
@@ -21,6 +21,7 @@ import com.thoughtworks.go.apiv1.pipelineselection.PipelineSelectionControllerDe
 import com.thoughtworks.go.server.service.PipelineConfigService;
 import com.thoughtworks.go.server.service.PipelineSelectionsService;
 import com.thoughtworks.go.spark.spring.SparkSpringController;
+import com.thoughtworks.go.util.SystemEnvironment;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -29,8 +30,12 @@ public class PipelineSelectionController implements SparkSpringController {
     private final PipelineSelectionControllerDelegate delegate;
 
     @Autowired
-    public PipelineSelectionController(ApiAuthenticationHelper apiAuthenticationHelper, PipelineSelectionsService pipelineSelectionsService, PipelineConfigService pipelineConfigService) {
-        delegate = new PipelineSelectionControllerDelegate(apiAuthenticationHelper, pipelineSelectionsService, pipelineConfigService);
+    public PipelineSelectionController(ApiAuthenticationHelper apiAuthenticationHelper,
+                                       PipelineSelectionsService pipelineSelectionsService,
+                                       PipelineConfigService pipelineConfigService,
+                                       SystemEnvironment systemEnvironment) {
+        delegate = new PipelineSelectionControllerDelegate(apiAuthenticationHelper, pipelineSelectionsService,
+                pipelineConfigService, systemEnvironment);
     }
 
     @Override


### PR DESCRIPTION
When security is disabled secure flag is set to the value of `systemEnvironment.isSessionCookieSecure()`. If this is set to true, the selection will work only on https URLs.

When security is enabled, things will work as-is, because no cookie is set.