### PR TITLE
Change http status when not enough disk space is available

### DIFF
--- a/api/api-pipeline-operations-v1/src/main/java/com/thoughtworks/go/apiv1/pipelineoperations/PipelineOperationsControllerV1Delegate.java
+++ b/api/api-pipeline-operations-v1/src/main/java/com/thoughtworks/go/apiv1/pipelineoperations/PipelineOperationsControllerV1Delegate.java
@@ -50,9 +50,9 @@ public class PipelineOperationsControllerV1Delegate extends ApiController {
     private final ApiAuthenticationHelper apiAuthenticationHelper;
     private final Localizer localizer;
     private final PipelineUnlockApiService pipelineUnlockApiService;
-    private PipelineTriggerService pipelineTriggerService;
-    private GoConfigService goConfigService;
-    private PipelineHistoryService pipelineHistoryService;
+    private final PipelineTriggerService pipelineTriggerService;
+    private final GoConfigService goConfigService;
+    private final PipelineHistoryService pipelineHistoryService;
 
     public PipelineOperationsControllerV1Delegate(PipelinePauseService pipelinePauseService, PipelineUnlockApiService pipelineUnlockApiService, PipelineTriggerService pipelineTriggerService, ApiAuthenticationHelper apiAuthenticationHelper, Localizer localizer, GoConfigService goConfigService, PipelineHistoryService pipelineHistoryService) {
         super(ApiVersion.v1);

--- a/api/api-pipeline-operations-v1/src/main/java/com/thoughtworks/go/apiv1/pipelineoperations/spring/PipelineOperationsControllerV1.java
+++ b/api/api-pipeline-operations-v1/src/main/java/com/thoughtworks/go/apiv1/pipelineoperations/spring/PipelineOperationsControllerV1.java
@@ -38,13 +38,13 @@ public class PipelineOperationsControllerV1 implements SparkSpringController {
                                           PipelineHistoryService pipelineHistoryService) {
 
         this.delegate = new PipelineOperationsControllerV1Delegate(
-            pipelinePauseService,
-            pipelineUnlockApiService,
-            pipelineTriggerService,
-            apiAuthenticationHelper,
-            localizer,
-            goConfigService,
-            pipelineHistoryService
+                pipelinePauseService,
+                pipelineUnlockApiService,
+                pipelineTriggerService,
+                apiAuthenticationHelper,
+                localizer,
+                goConfigService,
+                pipelineHistoryService
         );
     }
 

--- a/common/src/main/java/com/thoughtworks/go/server/service/result/HttpOperationResult.java
+++ b/common/src/main/java/com/thoughtworks/go/server/service/result/HttpOperationResult.java
@@ -42,6 +42,13 @@ public class HttpOperationResult implements OperationResult {
         return serverHealthStateOperationResult.error(message, description, type);
     }
 
+    @Override
+    public void insufficientStorage(String message, String description, HealthStateType type) {
+        httpCode = 507;
+        this.message = message;
+        serverHealthStateOperationResult.error(message, description, type);
+    }
+
     public void badRequest(String message, String description, HealthStateType healthStateType) {
         error(message, description, healthStateType);
         httpCode = 400;

--- a/common/src/main/java/com/thoughtworks/go/server/service/result/OperationResult.java
+++ b/common/src/main/java/com/thoughtworks/go/server/service/result/OperationResult.java
@@ -55,6 +55,8 @@ public interface OperationResult {
 
     void internalServerError(String message, final HealthStateType type);
 
+    void insufficientStorage(String message, String description, HealthStateType type);
+
     void badRequest(String message, String description, HealthStateType healthStateType);
 
     void notAcceptable(String message, String description, HealthStateType type);

--- a/common/src/main/java/com/thoughtworks/go/server/service/result/ServerHealthStateOperationResult.java
+++ b/common/src/main/java/com/thoughtworks/go/server/service/result/ServerHealthStateOperationResult.java
@@ -79,6 +79,11 @@ public class ServerHealthStateOperationResult implements OperationResult {
         error(message, "", type);
     }
 
+    @Override
+    public void insufficientStorage(String message, String description, HealthStateType type) {
+        error(message, description, type);
+    }
+
     public void notAcceptable(String message, String description, final HealthStateType type) {
         error(message, description, type);
     }

--- a/server/src/main/java/com/thoughtworks/go/server/service/ArtifactsDiskSpaceFullChecker.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/ArtifactsDiskSpaceFullChecker.java
@@ -36,7 +36,7 @@ public class ArtifactsDiskSpaceFullChecker extends DiskSpaceChecker {
     protected void createFailure(OperationResult result, long size, long availableSpace) {
         String msg = "GoCD has less than " + size + "Mb of disk space available. Scheduling has stopped, and will resume once more than " + size + "Mb is available.";
         LOGGER.error(msg);
-        result.error("GoCD Server has run out of artifacts disk space. Scheduling has been stopped", msg, ARTIFACTS_DISK_FULL_ID);
+        result.insufficientStorage("GoCD Server has run out of artifacts disk space. Scheduling has been stopped", msg, ARTIFACTS_DISK_FULL_ID);
     }
 
     protected SendEmailMessage createEmail() {

--- a/server/src/main/java/com/thoughtworks/go/server/service/DatabaseDiskSpaceFullChecker.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/DatabaseDiskSpaceFullChecker.java
@@ -41,7 +41,7 @@ public class DatabaseDiskSpaceFullChecker extends DiskSpaceChecker {
     protected void createFailure(OperationResult result, long size, long availableSpace) {
         String msg = "GoCD has less than " + size + "Mb of disk space available. Scheduling has stopped, and will resume once more than " + size + "Mb is available.";
         LOGGER.error(msg);
-        result.error("GoCD Server has run out of database disk space. Scheduling has been stopped", msg, DATABASE_DISK_FULL_ID);
+        result.insufficientStorage("GoCD Server has run out of database disk space. Scheduling has been stopped", msg, DATABASE_DISK_FULL_ID);
     }
 
     protected SendEmailMessage createEmail() {

--- a/server/src/main/java/com/thoughtworks/go/server/service/OutOfDiskSpaceChecker.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/OutOfDiskSpaceChecker.java
@@ -22,7 +22,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 @Component
-class OutOfDiskSpaceChecker implements SchedulingChecker {
+public class OutOfDiskSpaceChecker implements SchedulingChecker {
     private final GoDiskSpaceMonitor goDiskSpaceMonitor;
 
     @Autowired

--- a/server/src/main/java/com/thoughtworks/go/server/service/result/DiskSpaceOperationResult.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/result/DiskSpaceOperationResult.java
@@ -93,6 +93,11 @@ public class DiskSpaceOperationResult implements OperationResult {
         throw new RuntimeException("Not yet implemented");
     }
 
+    @Override
+    public void insufficientStorage(String message, String description, HealthStateType type) {
+        error(message, description, type);
+    }
+
     public void notAcceptable(String message, String description, final HealthStateType type) {
         throw new RuntimeException("Not yet implemented");
     }

--- a/server/src/main/java/com/thoughtworks/go/server/service/result/ServerHealthServiceUpdatingOperationResult.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/result/ServerHealthServiceUpdatingOperationResult.java
@@ -94,6 +94,11 @@ public class ServerHealthServiceUpdatingOperationResult implements OperationResu
         throw new RuntimeException("Not yet implemented");
     }
 
+    @Override
+    public void insufficientStorage(String message, String description, HealthStateType type) {
+        error(message, description, type);
+    }
+
     public void notAcceptable(String message, String description, final HealthStateType type) {
         throw new RuntimeException("Not yet implemented");
     }

--- a/spark/spark-base/src/test/groovy/com/thoughtworks/go/api/mocks/MockHttpServletResponseAssert.groovy
+++ b/spark/spark-base/src/test/groovy/com/thoughtworks/go/api/mocks/MockHttpServletResponseAssert.groovy
@@ -209,4 +209,7 @@ class MockHttpServletResponseAssert extends AbstractObjectAssert<MockHttpServlet
     return this
   }
 
+  MockHttpServletResponseAssert isInsufficientStorage() {
+    return hasStatus(507)
+  }
 }


### PR DESCRIPTION
Earlier used to return 400 (bad request), but now returns a
507 (insufficient storage). This is done because a server going out of
disk space is not a user error (4xx), so a 5xx code seems more
appropriate.