### PR TITLE
Fix Material Search result positioning (#4451)

### DIFF
--- a/server/webapp/WEB-INF/rails.new/webpack/views/dashboard/trigger_with_options/material_info_widget.js.msx
+++ b/server/webapp/WEB-INF/rails.new/webpack/views/dashboard/trigger_with_options/material_info_widget.js.msx
@@ -34,10 +34,12 @@ const MaterialInfoWidget = {
     if (commits.length) {
       const searchInput = $(vnode.dom).find('.material-revision-search');
       if (searchInput.length) {
-        const offset = searchInput.offset();
-        offset.top   = offset.top + searchInput.height() + 10;
-        commits.css(offset);
-        commits.css({'max-height': `${winHeight - offset.top - 10}px`});
+        const inputCoordinates = searchInput.get(0).getBoundingClientRect();
+        commits.css({
+          top:          Math.round(inputCoordinates.top + inputCoordinates.height),
+          left:         inputCoordinates.left,
+          'max-height': `${winHeight - searchInput.offset().top + searchInput.height()}px`
+        });
       }
     }
   },


### PR DESCRIPTION
* Use 'getBoundingClientRect' method to get the page relative position and offset of the DOM element