### PR TITLE
#4417 - Treat pipeline with null config origin as local.

### DIFF
--- a/api/api-dashboard-v2/src/main/java/com/thoughtworks/go/apiv2/dashboard/representers/PipelineRepresenter.java
+++ b/api/api-dashboard-v2/src/main/java/com/thoughtworks/go/apiv2/dashboard/representers/PipelineRepresenter.java
@@ -44,7 +44,7 @@ public class PipelineRepresenter {
             .add("can_administer", model.canBeAdministeredBy(usernameString))
             .add("can_unlock", model.canBeOperatedBy(usernameString))
             .add("can_pause", model.canBeOperatedBy(usernameString))
-            .add("from_config_repo", !model.getOrigin().isLocal());
+            .add("from_config_repo", !model.isLocal());
 
         if (model.getTrackingTool().isPresent()) {
             TrackingTool trackingTool = model.getTrackingTool().get();

--- a/api/api-dashboard-v2/src/test/groovy/com/thoughtworks/go/apiv2/dashboard/representers/PipelineRepresenterTest.groovy
+++ b/api/api-dashboard-v2/src/test/groovy/com/thoughtworks/go/apiv2/dashboard/representers/PipelineRepresenterTest.groovy
@@ -87,6 +87,18 @@ class PipelineRepresenterTest {
     ])
   }
 
+  @Test
+  void 'should consider pipelines with null origin as local'() {
+    def counter = mock(Counter.class)
+    when(counter.getNext()).thenReturn(1l)
+    def permissions = new Permissions(NoOne.INSTANCE, NoOne.INSTANCE, NoOne.INSTANCE, NoOne.INSTANCE)
+    def pipeline = new GoDashboardPipeline(pipeline_model('p1', 'p1l1'), permissions, "grp", counter, null)
+
+    def json = toObject({ PipelineRepresenter.toJSON(it, pipeline, new Username(new CaseInsensitiveString(SecureRandom.hex()))) })
+
+    assertThatJson(json).node("from_config_repo").isEqualTo(false)
+  }
+
   @Nested
   class Authorization {
 

--- a/server/src/main/java/com/thoughtworks/go/server/dashboard/GoDashboardPipeline.java
+++ b/server/src/main/java/com/thoughtworks/go/server/dashboard/GoDashboardPipeline.java
@@ -114,7 +114,7 @@ public class GoDashboardPipeline {
         return result;
     }
 
-    public ConfigOrigin getOrigin() {
-        return origin;
+    public boolean isLocal() {
+        return origin == null || origin.isLocal();
     }
 }


### PR DESCRIPTION
Scenario to trigger this:

1. Quick edit a pipeline.
2. Save.
3. Go to new dashboard.