### PR TITLE
Refactor 'selectStagesWithIdentifier' to remove the left join with the resources table.

### DIFF
--- a/server/src/main/resources/com/thoughtworks/go/server/dao/maps/Stage.xml
+++ b/server/src/main/resources/com/thoughtworks/go/server/dao/maps/Stage.xml
@@ -435,13 +435,11 @@
         stages.configVersion,
         stages.lastTransitionedTime,
         builds.*, builds.id as buildId,
-        resources.name as resourceName,
         buildstatetransitions.currentState,
         buildstatetransitions.statechangetime, buildstatetransitions.id as stateId
         FROM stages
         INNER JOIN pipelines ON pipelines.id = stages.pipelineId AND pipelines.name = #pipelineName#
         INNER JOIN builds ON stages.id = builds.stageId AND builds.ignored != true
-        LEFT JOIN resources ON builds.id = resources.buildId
         LEFT JOIN buildstatetransitions ON builds.id = buildstatetransitions.buildId
         WHERE stages.id in
     </sql>

--- a/server/src/main/resources/com/thoughtworks/go/server/dao/maps/Stage.xml
+++ b/server/src/main/resources/com/thoughtworks/go/server/dao/maps/Stage.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- *************************GO-LICENSE-START******************************
- * Copyright 2014 ThoughtWorks, Inc.
+ * Copyright 2018 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -277,7 +277,6 @@
         stages.artifactsDeleted,
         stages.configVersion,
         stages.lastTransitionedTime,
-        resources.name as resourceName,
         buildstatetransitions.currentState,
         buildstatetransitions.statechangetime, buildstatetransitions.id as stateId,
         pipelines.name as pipelineName,
@@ -286,7 +285,6 @@
         FROM stages
         INNER JOIN pipelines ON pipelines.id = stages.pipelineId
         INNER JOIN builds ON stages.id = builds.stageId AND builds.ignored != true
-        LEFT JOIN resources ON builds.id = resources.buildId
         LEFT JOIN buildstatetransitions ON builds.id = buildstatetransitions.buildId
     </sql>
 


### PR DESCRIPTION
* This is used in the queries: getStagesByPipelineId, getStagesByPipelineNameAndCounter, getAllRunsOfStageForPipelineInstance, getStageById. The resultMap of all these queries is 'select-stage-with-identifier-jobs' and the result map does not make use of resource name. So, there is no point in doing a left join with the resources table.