### PR TITLE
Explicitly add config origin on the submitted pipeline config for the Update Pipeline Config API request

### DIFF
--- a/server/webapp/WEB-INF/rails.new/app/controllers/api_v3/admin/pipelines_controller.rb
+++ b/server/webapp/WEB-INF/rails.new/app/controllers/api_v3/admin/pipelines_controller.rb
@@ -59,6 +59,8 @@ module ApiV3
         @pipeline_config_from_request ||= PipelineConfig.new.tap do |config|
           ApiV3::Admin::Pipelines::PipelineConfigRepresenter.new(config).from_hash(params[:pipeline], {go_config: go_config_service.getCurrentConfig()})
         end
+
+        @pipeline_config_from_request.setOrigin(FileConfigOrigin.new)
       end
 
       def handle_config_save_or_update_result(result, pipeline_name = params[:pipeline_name])

--- a/server/webapp/WEB-INF/rails.new/app/controllers/api_v4/admin/pipelines_controller.rb
+++ b/server/webapp/WEB-INF/rails.new/app/controllers/api_v4/admin/pipelines_controller.rb
@@ -59,6 +59,8 @@ module ApiV4
         @pipeline_config_from_request ||= PipelineConfig.new.tap do |config|
           Admin::Pipelines::PipelineConfigRepresenter.new(config).from_hash(params[:pipeline], {go_config: go_config_service.getCurrentConfig()})
         end
+
+        @pipeline_config_from_request.setOrigin(FileConfigOrigin.new)
       end
 
       def handle_config_save_or_update_result(result, pipeline_name = params[:pipeline_name])

--- a/server/webapp/WEB-INF/rails.new/app/controllers/api_v5/admin/pipelines_controller.rb
+++ b/server/webapp/WEB-INF/rails.new/app/controllers/api_v5/admin/pipelines_controller.rb
@@ -59,6 +59,8 @@ module ApiV5
         @pipeline_config_from_request ||= PipelineConfig.new.tap do |config|
           Admin::Pipelines::PipelineConfigRepresenter.new(config).from_hash(params[:pipeline], {go_config: go_config_service.getCurrentConfig()})
         end
+
+        @pipeline_config_from_request.setOrigin(FileConfigOrigin.new)
       end
 
       def handle_config_save_or_update_result(result, pipeline_name = params[:pipeline_name])

--- a/server/webapp/WEB-INF/rails.new/spec/controllers/api_v3/admin/pipelines_controller_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/controllers/api_v3/admin/pipelines_controller_spec.rb
@@ -283,7 +283,9 @@ describe ApiV3::Admin::PipelinesController do
       it "should update pipeline config for an admin" do
         expect(@entity_hashing_service).to receive(:md5ForEntity).with(@pipeline).and_return(@pipeline_md5)
         expect(@pipeline_config_service).to receive(:getPipelineConfig).twice.with(@pipeline_name).and_return(@pipeline)
-        expect(@pipeline_config_service).to receive(:updatePipelineConfig).with(anything(), anything(), @pipeline_md5, anything())
+        expect(@pipeline_config_service).to receive(:updatePipelineConfig).with(anything(), anything(), @pipeline_md5, anything()) do |_user, pipeline|
+          expect(pipeline.getOrigin).to eq(FileConfigOrigin.new)
+        end
 
         controller.request.env['HTTP_IF_MATCH'] = "\"#{Digest::MD5.hexdigest(@pipeline_md5)}\""
 

--- a/server/webapp/WEB-INF/rails.new/spec/controllers/api_v4/admin/pipelines_controller_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/controllers/api_v4/admin/pipelines_controller_spec.rb
@@ -284,7 +284,9 @@ describe ApiV4::Admin::PipelinesController do
       it "should update pipeline config for an admin" do
         expect(@entity_hashing_service).to receive(:md5ForEntity).with(@pipeline).and_return(@pipeline_md5)
         expect(@pipeline_config_service).to receive(:getPipelineConfig).twice.with(@pipeline_name).and_return(@pipeline)
-        expect(@pipeline_config_service).to receive(:updatePipelineConfig).with(anything(), anything(), @pipeline_md5, anything())
+        expect(@pipeline_config_service).to receive(:updatePipelineConfig).with(anything(), anything(), @pipeline_md5, anything()) do |_user, pipeline|
+          expect(pipeline.getOrigin).to eq(FileConfigOrigin.new)
+        end
 
         controller.request.env['HTTP_IF_MATCH'] = "\"#{Digest::MD5.hexdigest(@pipeline_md5)}\""
 

--- a/server/webapp/WEB-INF/rails.new/spec/controllers/api_v5/admin/pipelines_controller_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/controllers/api_v5/admin/pipelines_controller_spec.rb
@@ -284,7 +284,9 @@ describe ApiV5::Admin::PipelinesController do
       it "should update pipeline config for an admin" do
         expect(@entity_hashing_service).to receive(:md5ForEntity).with(@pipeline).and_return(@pipeline_md5)
         expect(@pipeline_config_service).to receive(:getPipelineConfig).twice.with(@pipeline_name).and_return(@pipeline)
-        expect(@pipeline_config_service).to receive(:updatePipelineConfig).with(anything(), anything(), @pipeline_md5, anything())
+        expect(@pipeline_config_service).to receive(:updatePipelineConfig).with(anything(), anything(), @pipeline_md5, anything()) do |_user, pipeline|
+          expect(pipeline.getOrigin).to eq(FileConfigOrigin.new)
+        end
 
         controller.request.env['HTTP_IF_MATCH'] = "\"#{Digest::MD5.hexdigest(@pipeline_md5)}\""
 


### PR DESCRIPTION
The User submitted pipeline config JSON is deserialized using [PipelineConfigRepresenter](https://github.com/gocd/gocd/blob/master/server/webapp/WEB-INF/rails.new/app/presenters/api_v5/admin/pipelines/pipeline_config_representer.rb).

As the origin attribute is not required while updating/creating the pipeline config, the deserialized pipeline config object does not have a config origin attribute on it.

Explicitly add the [FileConfigOrigin](https://github.com/gocd/gocd/blob/master/config/config-api/src/main/java/com/thoughtworks/go/config/remote/FileConfigOrigin.java) origin on the user submitted pipeline config object.

It is safer to expect that all the deserialized pipeline config objects are defined in config.xml as the check for remotely defined pipeline is performed prior to deserialization [here](https://github.com/gocd/gocd/blob/master/server/webapp/WEB-INF/rails.new/app/controllers/api_v5/admin/pipelines_controller.rb#L22)