### PR TITLE
Enable the quick dashboard when the toggle is turned on

### DIFF
--- a/server/src/main/java/com/thoughtworks/go/server/service/GoDashboardService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/GoDashboardService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 ThoughtWorks, Inc.
+ * Copyright 2018 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -65,7 +65,7 @@ public class GoDashboardService {
     }
 
     public void updateCacheForPipeline(CaseInsensitiveString pipelineName) {
-        if (!Toggles.isToggleOn(Toggles.QUICKER_DASHBOARD_KEY)) {
+        if (featureToggleDisabled()) {
             return;
         }
         PipelineConfigs group = goConfigService.findGroupByPipeline(pipelineName);
@@ -75,14 +75,18 @@ public class GoDashboardService {
     }
 
     public void updateCacheForPipeline(PipelineConfig pipelineConfig) {
-        if (!Toggles.isToggleOn(Toggles.QUICKER_DASHBOARD_KEY)) {
+        if (featureToggleDisabled()) {
             return;
         }
         updateCache(goConfigService.findGroupByPipeline(pipelineConfig.name()), pipelineConfig);
     }
 
+    public boolean featureToggleDisabled() {
+        return !Toggles.isToggleOn(Toggles.QUICKER_DASHBOARD_KEY);
+    }
+
     public void updateCacheForAllPipelinesIn(CruiseConfig config) {
-        if (!Toggles.isToggleOn(Toggles.QUICKER_DASHBOARD_KEY)) {
+        if (featureToggleDisabled()) {
             return;
         }
         cache.replaceAllEntriesInCacheWith(dashboardCurrentStateLoader.allPipelines(config));

--- a/server/src/main/java/com/thoughtworks/go/server/service/support/toggle/FeatureToggleListener.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/support/toggle/FeatureToggleListener.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2018 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.server.service.support.toggle;
+
+public interface FeatureToggleListener {
+    void toggleChanged(boolean newValue);
+}

--- a/server/src/main/java/com/thoughtworks/go/server/service/support/toggle/FeatureToggleService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/support/toggle/FeatureToggleService.java
@@ -1,21 +1,23 @@
-/*************************GO-LICENSE-START*********************************
- * Copyright 2014 ThoughtWorks, Inc.
+/*
+ * Copyright 2018 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *************************GO-LICENSE-END***********************************/
+ */
 
 package com.thoughtworks.go.server.service.support.toggle;
 
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.Multimap;
 import com.thoughtworks.go.server.cache.GoCache;
 import com.thoughtworks.go.server.domain.support.toggle.FeatureToggle;
 import com.thoughtworks.go.server.domain.support.toggle.FeatureToggles;
@@ -23,12 +25,14 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.text.MessageFormat;
+import java.util.Collection;
 
 @Service
 public class FeatureToggleService {
-    public static final String USER_TOGGLES_CACHE_KEY = "FeatureToggleService_USER_TOGGLES";
+    private static final String USER_TOGGLES_CACHE_KEY = "FeatureToggleService_USER_TOGGLES";
     private FeatureToggleRepository repository;
     private GoCache goCache;
+    private final Multimap<String, FeatureToggleListener> listeners = HashMultimap.create();
 
     @Autowired
     public FeatureToggleService(FeatureToggleRepository repository, GoCache goCache) {
@@ -69,6 +73,18 @@ public class FeatureToggleService {
         synchronized (USER_TOGGLES_CACHE_KEY) {
             repository.changeValueOfToggle(key, newValue);
             goCache.remove(USER_TOGGLES_CACHE_KEY);
+
+            if (listeners.containsKey(key)) {
+                Collection<FeatureToggleListener> featureToggleListeners = listeners.get(key);
+                for (FeatureToggleListener listener : featureToggleListeners) {
+                    listener.toggleChanged(newValue);
+                }
+            }
         }
+    }
+
+    public void registerListener(String key, FeatureToggleListener listener) {
+        listeners.put(key, listener);
+        listener.toggleChanged(isToggleOn(key));
     }
 }

--- a/spark/spark-base/src/test/groovy/com/thoughtworks/go/api/mocks/MockHttpServletResponseAssert.groovy
+++ b/spark/spark-base/src/test/groovy/com/thoughtworks/go/api/mocks/MockHttpServletResponseAssert.groovy
@@ -182,9 +182,14 @@ class MockHttpServletResponseAssert extends AbstractObjectAssert<MockHttpServlet
     return hasStatus(500)
   }
 
-  def isAccepted() {
+  MockHttpServletResponseAssert isAccepted() {
     return hasStatus(202)
   }
+
+  MockHttpServletResponseAssert isFailedDependency() {
+    return hasStatus(424)
+  }
+
 
   MockHttpServletResponseAssert hasCookie(String path, String name, String value, int maxAge, boolean secured, boolean httpOnly) {
     def actualCookie = actual.getCookie(name)
@@ -203,4 +208,5 @@ class MockHttpServletResponseAssert extends AbstractObjectAssert<MockHttpServlet
     }
     return this
   }
+
 }


### PR DESCRIPTION
Hook in a listener in the `FeatureToggleService` which notifies
when the toggle is turned on, and pretends like a full config save happened

Fixes #4450