### PR TITLE
Change Analytics Plugin messages to be more generic

### DIFF
--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/analytics/AnalyticsExtension.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/analytics/AnalyticsExtension.java
@@ -64,6 +64,22 @@ public class AnalyticsExtension extends AbstractExtension {
         });
     }
 
+    public AnalyticsData getAnalytics(String pluginId, String type, String metricId, Map params) {
+        return pluginRequestHelper.submitRequest(pluginId, REQUEST_GET_ANALYTICS, new DefaultPluginInteractionCallback<AnalyticsData>() {
+            @Override
+            public String requestBody(String resolvedExtensionVersion) {
+                return getMessageConverter(resolvedExtensionVersion).getAnalyticsRequestBody(type, metricId, params);
+            }
+
+            @Override
+            public AnalyticsData onSuccess(String responseBody, String resolvedExtensionVersion) {
+                AnalyticsData analyticsData = getMessageConverter(resolvedExtensionVersion).getAnalyticsFromResponseBody(responseBody);
+                analyticsData.setAssetRoot(getCurrentStaticAssetsPath(pluginId));
+                return analyticsData;
+            }
+        });
+    }
+
     public AnalyticsData getPipelineAnalytics(String pluginId, String pipelineName) {
         return pluginRequestHelper.submitRequest(pluginId, REQUEST_GET_ANALYTICS, new DefaultPluginInteractionCallback<AnalyticsData>() {
             @Override

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/analytics/AnalyticsExtension.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/analytics/AnalyticsExtension.java
@@ -80,54 +80,6 @@ public class AnalyticsExtension extends AbstractExtension {
         });
     }
 
-    public AnalyticsData getPipelineAnalytics(String pluginId, String pipelineName) {
-        return pluginRequestHelper.submitRequest(pluginId, REQUEST_GET_ANALYTICS, new DefaultPluginInteractionCallback<AnalyticsData>() {
-            @Override
-            public String requestBody(String resolvedExtensionVersion) {
-                return getMessageConverter(resolvedExtensionVersion).getPipelineAnalyticsRequestBody(pipelineName);
-            }
-
-            @Override
-            public AnalyticsData onSuccess(String responseBody, String resolvedExtensionVersion) {
-                AnalyticsData analyticsData = getMessageConverter(resolvedExtensionVersion).getAnalyticsFromResponseBody(responseBody);
-                analyticsData.setAssetRoot(getCurrentStaticAssetsPath(pluginId));
-                return analyticsData;
-            }
-        });
-    }
-
-    public AnalyticsData getJobAnalytics(String pluginId, Map params) {
-        return pluginRequestHelper.submitRequest(pluginId, REQUEST_GET_ANALYTICS, new DefaultPluginInteractionCallback<AnalyticsData>() {
-            @Override
-            public String requestBody(String resolvedExtensionVersion) {
-                return getMessageConverter(resolvedExtensionVersion).getJobAnalyticsRequestBody(params);
-            }
-
-            @Override
-            public AnalyticsData onSuccess(String responseBody, String resolvedExtensionVersion) {
-                AnalyticsData analyticsData = getMessageConverter(resolvedExtensionVersion).getAnalyticsFromResponseBody(responseBody);
-                analyticsData.setAssetRoot(getCurrentStaticAssetsPath(pluginId));
-                return analyticsData;
-            }
-        });
-    }
-
-    public AnalyticsData getDashboardAnalytics(String pluginId, String metric) {
-        return pluginRequestHelper.submitRequest(pluginId, REQUEST_GET_ANALYTICS, new DefaultPluginInteractionCallback<AnalyticsData>() {
-            @Override
-            public String requestBody(String resolvedExtensionVersion) {
-                return getMessageConverter(resolvedExtensionVersion).getDashboardAnalyticsRequestBody(metric);
-            }
-
-            @Override
-            public AnalyticsData onSuccess(String responseBody, String resolvedExtensionVersion) {
-                AnalyticsData analyticsData = getMessageConverter(resolvedExtensionVersion).getAnalyticsFromResponseBody(responseBody);
-                analyticsData.setAssetRoot(getCurrentStaticAssetsPath(pluginId));
-                return analyticsData;
-            }
-        });
-    }
-
     public Image getIcon(String pluginId) {
         return pluginRequestHelper.submitRequest(pluginId, AnalyticsPluginConstants.REQUEST_GET_PLUGIN_ICON, new DefaultPluginInteractionCallback<com.thoughtworks.go.plugin.domain.common.Image>() {
             @Override

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/analytics/AnalyticsMessageConverter.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/analytics/AnalyticsMessageConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 ThoughtWorks, Inc.
+ * Copyright 2018 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,21 +22,11 @@ import com.thoughtworks.go.plugin.domain.common.Image;
 import java.util.Map;
 
 public interface AnalyticsMessageConverter {
-    String TYPE_PIPELINE = "pipeline";
-    String TYPE_JOB = "job";
-    String TYPE_DASHBOARD = "dashboard";
-
     com.thoughtworks.go.plugin.domain.analytics.Capabilities getCapabilitiesFromResponseBody(String responseBody);
-
-    String getPipelineAnalyticsRequestBody(String pipelineName);
-
-    String getJobAnalyticsRequestBody(Map params);
 
     String getAnalyticsRequestBody(String type, String metricId, Map params);
 
     AnalyticsData getAnalyticsFromResponseBody(String responseBody);
-
-    String getDashboardAnalyticsRequestBody(String metric);
 
     String getStaticAssetsFromResponseBody(String responseBody);
 

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/analytics/AnalyticsMessageConverter.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/analytics/AnalyticsMessageConverter.java
@@ -32,6 +32,8 @@ public interface AnalyticsMessageConverter {
 
     String getJobAnalyticsRequestBody(Map params);
 
+    String getAnalyticsRequestBody(String type, String metricId, Map params);
+
     AnalyticsData getAnalyticsFromResponseBody(String responseBody);
 
     String getDashboardAnalyticsRequestBody(String metric);

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/analytics/AnalyticsMessageConverterV1.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/analytics/AnalyticsMessageConverterV1.java
@@ -23,7 +23,6 @@ import com.thoughtworks.go.plugin.domain.analytics.AnalyticsData;
 import com.thoughtworks.go.plugin.domain.common.Image;
 import org.apache.commons.lang.StringUtils;
 
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -31,36 +30,11 @@ public class AnalyticsMessageConverterV1 implements AnalyticsMessageConverter {
     public static final String VERSION = "1.0";
     private static final Gson GSON = new Gson();
 
-    @Override
-    public String getPipelineAnalyticsRequestBody(String pipelineName) {
-        Map<String, Object> requestMap = new HashMap<>();
-        requestMap.put("type", TYPE_PIPELINE);
-        requestMap.put("data", Collections.singletonMap("pipeline_name", pipelineName));
-
-        return GSON.toJson(requestMap);
-    }
-
-    @Override
-    public String getJobAnalyticsRequestBody(Map params) {
-        Map<String, Object> requestMap = new HashMap<>();
-        requestMap.put("type", TYPE_JOB);
-        requestMap.put("data", params);
-    }
-
     public String getAnalyticsRequestBody(String type, String metricId, Map params) {
         Map<String, Object> requestMap = new HashMap<>();
         requestMap.put("type", type);
         requestMap.put("id", metricId);
         requestMap.put("params", params);
-
-        return GSON.toJson(requestMap);
-    }
-
-    @Override
-    public String getDashboardAnalyticsRequestBody(String metric) {
-        Map<String, Object> requestMap = new HashMap<>();
-        requestMap.put("type", TYPE_DASHBOARD);
-        requestMap.put("data", Collections.singletonMap("metric", metric));
 
         return GSON.toJson(requestMap);
     }

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/analytics/AnalyticsMessageConverterV1.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/analytics/AnalyticsMessageConverterV1.java
@@ -45,6 +45,13 @@ public class AnalyticsMessageConverterV1 implements AnalyticsMessageConverter {
         Map<String, Object> requestMap = new HashMap<>();
         requestMap.put("type", TYPE_JOB);
         requestMap.put("data", params);
+    }
+
+    public String getAnalyticsRequestBody(String type, String metricId, Map params) {
+        Map<String, Object> requestMap = new HashMap<>();
+        requestMap.put("type", type);
+        requestMap.put("id", metricId);
+        requestMap.put("params", params);
 
         return GSON.toJson(requestMap);
     }

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/analytics/models/Capabilities.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/analytics/models/Capabilities.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 ThoughtWorks, Inc.
+ * Copyright 2018 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,34 +21,22 @@ import com.google.gson.GsonBuilder;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 
+import java.util.ArrayList;
 import java.util.List;
 
 public class Capabilities {
     private static final Gson GSON = new GsonBuilder().excludeFieldsWithoutExposeAnnotation().create();
 
     @Expose
-    @SerializedName("supports_pipeline_analytics")
-    private final boolean supportsPipelineAnalytics;
+    @SerializedName("supported_analytics")
+    private List<SupportedAnalytics> supportedAnalytics;
 
-    @Expose
-    @SerializedName("supported_analytics_dashboard_metrics")
-    private final List<String> supportedAnalyticsDashboardMetrics;
-
-    public Capabilities(boolean supportsPipelineAnalytics, List<String> supportedAnalyticsDashboardMetrics) {
-        this.supportsPipelineAnalytics = supportsPipelineAnalytics;
-        this.supportedAnalyticsDashboardMetrics = supportedAnalyticsDashboardMetrics;
+    public List<SupportedAnalytics> getSupportedAnalytics() {
+        return supportedAnalytics;
     }
 
-    public List<String> supportedAnalyticsDashboardMetrics() {
-        return supportedAnalyticsDashboardMetrics;
-    }
-
-    public boolean supportsPipelineAnalytics() {
-        return supportsPipelineAnalytics;
-    }
-
-    public String toJSON() {
-        return GSON.toJson(this);
+    public Capabilities(List<SupportedAnalytics> supportedAnalytics) {
+        this.supportedAnalytics = supportedAnalytics;
     }
 
     public static Capabilities fromJSON(String json) {
@@ -56,6 +44,18 @@ public class Capabilities {
     }
 
     public com.thoughtworks.go.plugin.domain.analytics.Capabilities toCapabilities() {
-        return new com.thoughtworks.go.plugin.domain.analytics.Capabilities(supportsPipelineAnalytics, supportedAnalyticsDashboardMetrics);
+        return new com.thoughtworks.go.plugin.domain.analytics.Capabilities(supportedAnalytics());
+    }
+
+    private List<com.thoughtworks.go.plugin.domain.analytics.SupportedAnalytics> supportedAnalytics() {
+        ArrayList<com.thoughtworks.go.plugin.domain.analytics.SupportedAnalytics> list = new ArrayList<>();
+
+        if (this.supportedAnalytics != null) {
+            for (SupportedAnalytics analytics : this.supportedAnalytics) {
+                list.add(new com.thoughtworks.go.plugin.domain.analytics.SupportedAnalytics(analytics.getType(), analytics.getId(), analytics.getTitle()));
+            }
+        }
+
+        return list;
     }
 }

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/analytics/models/SupportedAnalytics.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/analytics/models/SupportedAnalytics.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2018 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.plugin.access.analytics.models;
+
+import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.SerializedName;
+
+import java.util.Objects;
+
+public class SupportedAnalytics {
+    @Expose
+    @SerializedName("type")
+    private String type;
+
+    @Expose
+    @SerializedName("id")
+    private String id;
+
+    @Expose
+    @SerializedName("title")
+    private String title;
+
+    public SupportedAnalytics(String type, String id, String title) {
+        this.type = type;
+        this.id = id;
+        this.title = title;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof SupportedAnalytics)) return false;
+        SupportedAnalytics that = (SupportedAnalytics) o;
+        return Objects.equals(getType(), that.getType()) &&
+                Objects.equals(getId(), that.getId()) &&
+                Objects.equals(getTitle(), that.getTitle());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getType(), getId(), getTitle());
+    }
+}

--- a/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/analytics/AnalyticsExtensionTest.java
+++ b/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/analytics/AnalyticsExtensionTest.java
@@ -35,6 +35,7 @@ import org.mockito.Mock;
 import org.skyscreamer.jsonassert.JSONAssert;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -136,6 +137,23 @@ public class AnalyticsExtensionTest {
         expected.put("data", "{}");
         expected.put("view_path", "/assets/root/path/to/view");
         assertEquals(expected, jobAnalytics.toMap());
+    }
+
+    @Test
+    public void shouldGetAnalytics() throws Exception {
+        AnalyticsData pipelineAnalytics = analyticsExtension.getAnalytics(PLUGIN_ID, "pipeline", "pipeline_with_highest_wait_time", Collections.singletonMap("pipeline_name", "test_pipeline"));
+
+        String expectedRequestBody = "{" +
+                "\"type\": \"pipeline\"," +
+                "\"id\": \"pipeline_with_highest_wait_time\"," +
+                " \"params\": {\"pipeline_name\": \"test_pipeline\"}}";
+
+        assertRequest(requestArgumentCaptor.getValue(), AnalyticsPluginConstants.EXTENSION_NAME, "1.0", REQUEST_GET_ANALYTICS, expectedRequestBody);
+
+        assertThat(pipelineAnalytics.getViewPath(), is("path/to/view"));
+        assertThat(pipelineAnalytics.getData(), is("{}"));
+        assertThat(pipelineAnalytics.getViewPath(), is("path/to/view"));
+        assertThat(pipelineAnalytics.getFullViewPath(), is("/assets/root/path/to/view"));
     }
 
     @Test

--- a/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/analytics/AnalyticsExtensionTest.java
+++ b/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/analytics/AnalyticsExtensionTest.java
@@ -37,13 +37,11 @@ import org.skyscreamer.jsonassert.JSONAssert;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.Map;
 
 import static com.thoughtworks.go.plugin.access.analytics.AnalyticsPluginConstants.*;
 import static com.thoughtworks.go.plugin.api.response.DefaultGoPluginApiResponse.SUCCESS_RESPONSE_CODE;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.when;
@@ -96,52 +94,18 @@ public class AnalyticsExtensionTest {
     }
 
     @Test
-    public void shouldTalkToPlugin_To_GetPipelineAnalytics() throws Exception {
-        String responseBody = "{ \"view_path\": \"path/to/view\", \"data\": \"{}\" }";
-        when(pluginManager.submitTo(eq(PLUGIN_ID), requestArgumentCaptor.capture())).thenReturn(new DefaultGoPluginApiResponse(SUCCESS_RESPONSE_CODE, responseBody));
-        AnalyticsPluginInfo pluginInfo = new AnalyticsPluginInfo(
-                new GoPluginDescriptor(PLUGIN_ID, null, null, null, null, false),
-                null, null, null);
-        pluginInfo.setStaticAssetsPath("/assets/root");
-        metadataStore.setPluginInfo(pluginInfo);
-
-        AnalyticsData pipelineAnalytics = analyticsExtension.getPipelineAnalytics(PLUGIN_ID, "test_pipeline");
-
-        assertRequest(requestArgumentCaptor.getValue(), AnalyticsPluginConstants.EXTENSION_NAME, "1.0", REQUEST_GET_ANALYTICS, "{\"type\": \"pipeline\", \"data\": {\"pipeline_name\": \"test_pipeline\"}}");
-
-        assertThat(pipelineAnalytics.getViewPath(), is("path/to/view"));
-
-        Map<String, String> expected = new HashMap<>();
-        expected.put("data", "{}");
-        expected.put("view_path", "/assets/root/path/to/view");
-        assertEquals(expected, pipelineAnalytics.toMap());
-    }
-
-    @Test
-    public void shouldTalkToPlugin_To_GetJobAnalytics() throws Exception {
-        String responseBody = "{ \"view_path\": \"path/to/view\", \"data\": \"{}\" }";
-        when(pluginManager.submitTo(eq(PLUGIN_ID), requestArgumentCaptor.capture())).thenReturn(new DefaultGoPluginApiResponse(SUCCESS_RESPONSE_CODE, responseBody));
-        AnalyticsPluginInfo pluginInfo = new AnalyticsPluginInfo(
-                new GoPluginDescriptor(PLUGIN_ID, null, null, null, null, false),
-                null, null, null);
-        pluginInfo.setStaticAssetsPath("/assets/root");
-        metadataStore.setPluginInfo(pluginInfo);
-
-        AnalyticsData jobAnalytics = analyticsExtension.getJobAnalytics(PLUGIN_ID, Collections.EMPTY_MAP);
-
-        assertRequest(requestArgumentCaptor.getValue(), AnalyticsPluginConstants.EXTENSION_NAME, "1.0", REQUEST_GET_ANALYTICS, "{\"type\": \"job\", \"data\": {}}");
-
-        assertThat(jobAnalytics.getViewPath(), is("path/to/view"));
-
-        Map<String, String> expected = new HashMap<>();
-        expected.put("data", "{}");
-        expected.put("view_path", "/assets/root/path/to/view");
-        assertEquals(expected, jobAnalytics.toMap());
-    }
-
-    @Test
     public void shouldGetAnalytics() throws Exception {
-        AnalyticsData pipelineAnalytics = analyticsExtension.getAnalytics(PLUGIN_ID, "pipeline", "pipeline_with_highest_wait_time", Collections.singletonMap("pipeline_name", "test_pipeline"));
+        String responseBody = "{ \"view_path\": \"path/to/view\", \"data\": \"{}\" }";
+
+        AnalyticsPluginInfo pluginInfo = new AnalyticsPluginInfo(
+                new GoPluginDescriptor(PLUGIN_ID, null, null, null, null, false), null, null, null);
+        pluginInfo.setStaticAssetsPath("/assets/root");
+        metadataStore.setPluginInfo(pluginInfo);
+
+        when(pluginManager.submitTo(eq(PLUGIN_ID), requestArgumentCaptor.capture())).thenReturn(new DefaultGoPluginApiResponse(SUCCESS_RESPONSE_CODE, responseBody));
+
+        AnalyticsData pipelineAnalytics = analyticsExtension.getAnalytics(PLUGIN_ID, "pipeline", "pipeline_with_highest_wait_time",
+                Collections.singletonMap("pipeline_name", "test_pipeline"));
 
         String expectedRequestBody = "{" +
                 "\"type\": \"pipeline\"," +
@@ -150,32 +114,9 @@ public class AnalyticsExtensionTest {
 
         assertRequest(requestArgumentCaptor.getValue(), AnalyticsPluginConstants.EXTENSION_NAME, "1.0", REQUEST_GET_ANALYTICS, expectedRequestBody);
 
-        assertThat(pipelineAnalytics.getViewPath(), is("path/to/view"));
         assertThat(pipelineAnalytics.getData(), is("{}"));
         assertThat(pipelineAnalytics.getViewPath(), is("path/to/view"));
         assertThat(pipelineAnalytics.getFullViewPath(), is("/assets/root/path/to/view"));
-    }
-
-    @Test
-    public void shouldTalkToPlugin_To_GetDashboardAnalytics() throws Exception {
-        String responseBody = "{ \"view_path\": \"path/to/view\", \"data\": \"{}\" }";
-        when(pluginManager.submitTo(eq(PLUGIN_ID), requestArgumentCaptor.capture())).thenReturn(new DefaultGoPluginApiResponse(SUCCESS_RESPONSE_CODE, responseBody));
-        AnalyticsPluginInfo pluginInfo = new AnalyticsPluginInfo(
-                new GoPluginDescriptor(PLUGIN_ID, null, null, null, null, false),
-                null, null, null);
-        pluginInfo.setStaticAssetsPath("/assets/root");
-        metadataStore.setPluginInfo(pluginInfo);
-
-        AnalyticsData dashboardAnalytics = analyticsExtension.getDashboardAnalytics(PLUGIN_ID, "metric");
-
-        assertRequest(requestArgumentCaptor.getValue(), AnalyticsPluginConstants.EXTENSION_NAME, "1.0", REQUEST_GET_ANALYTICS, "{\"type\": \"dashboard\", \"data\": {\"metric\": \"metric\"}}");
-
-        assertThat(dashboardAnalytics.getViewPath(), is("path/to/view"));
-
-        Map<String, String> expected = new HashMap<>();
-        expected.put("data", "{}");
-        expected.put("view_path", "/assets/root/path/to/view");
-        assertEquals(expected, dashboardAnalytics.toMap());
     }
 
     @Test

--- a/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/analytics/AnalyticsMessageConverterV1Test.java
+++ b/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/analytics/AnalyticsMessageConverterV1Test.java
@@ -23,6 +23,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -92,5 +93,17 @@ public class AnalyticsMessageConverterV1Test {
         params.put("job_name", "anything");
         Map actual = GSON.fromJson(converter.getJobAnalyticsRequestBody(params), Map.class);
         assertEquals(expected, actual);
+    }
+
+    @Test
+    public void shouldBuildRequestBodyForAnalyticsRequest() throws Exception {
+        String analyticsRequestBody = converter.getAnalyticsRequestBody("pipeline", "pipeline_with_highest_wait_time", Collections.singletonMap("pipeline_name", "test_pipeline"));
+
+        String expectedRequestBody = "{" +
+                "\"type\":\"pipeline\"," +
+                "\"id\":\"pipeline_with_highest_wait_time\"," +
+                " \"params\":{\"pipeline_name\": \"test_pipeline\"}}";
+
+        assertEquals(GSON.fromJson(expectedRequestBody, Map.class), GSON.fromJson(analyticsRequestBody, Map.class));
     }
 }

--- a/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/analytics/AnalyticsMessageConverterV1Test.java
+++ b/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/analytics/AnalyticsMessageConverterV1Test.java
@@ -24,7 +24,6 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
@@ -68,31 +67,6 @@ public class AnalyticsMessageConverterV1Test {
         thrown.expectMessage("Missing \"view_path\" key in analytics payload");
 
         converter.getAnalyticsFromResponseBody(response);
-    }
-
-    @Test
-    public void createsCorrectJSONForDashboardRequest() {
-        Map expected = GSON.fromJson("{\"type\":\"dashboard\", \"data\": {\"metric\": \"anything\"}}", Map.class);
-        Map actual = GSON.fromJson(converter.getDashboardAnalyticsRequestBody("anything"), Map.class);
-        assertEquals(expected, actual);
-    }
-
-    @Test
-    public void createsCorrectJSONForPipelineRequest() {
-        Map expected = GSON.fromJson("{\"type\":\"pipeline\", \"data\": {\"pipeline_name\": \"anything\"}}", Map.class);
-        Map actual = GSON.fromJson(converter.getPipelineAnalyticsRequestBody("anything"), Map.class);
-        assertEquals(expected, actual);
-    }
-
-    @Test
-    public void createsCorrectJSONForJobRequest() {
-        Map expected = GSON.fromJson("{\"type\":\"job\", \"data\": {\"pipeline_name\": \"anything\", \"stage_name\": \"anything\",\"job_name\": \"anything\"}}", Map.class);
-        Map<String, String> params = new HashMap<>();
-        params.put("pipeline_name", "anything");
-        params.put("stage_name", "anything");
-        params.put("job_name", "anything");
-        Map actual = GSON.fromJson(converter.getJobAnalyticsRequestBody(params), Map.class);
-        assertEquals(expected, actual);
     }
 
     @Test

--- a/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/analytics/AnalyticsPluginInfoBuilderTest.java
+++ b/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/analytics/AnalyticsPluginInfoBuilderTest.java
@@ -43,13 +43,13 @@ public class AnalyticsPluginInfoBuilderTest {
     @Before
     public void setUp() throws Exception {
         extension = mock(AnalyticsExtension.class);
-        stub(extension.getCapabilities(any(String.class))).toReturn(new Capabilities( true, Collections.emptyList()));
+        stub(extension.getCapabilities(any(String.class))).toReturn(new Capabilities(Collections.emptyList()));
     }
 
     @Test
-    public void shouldBuildPluginInfoWithCapablities() throws Exception {
+    public void shouldBuildPluginInfoWithCapabilities() throws Exception {
         GoPluginDescriptor descriptor = new GoPluginDescriptor("plugin1", null, null, null, null, false);
-        Capabilities capabilities = new Capabilities(true, Collections.emptyList());
+        Capabilities capabilities = new Capabilities(Collections.emptyList());
 
         when(extension.getCapabilities(descriptor.id())).thenReturn(capabilities);
 

--- a/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/analytics/models/CapabilitiesTest.java
+++ b/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/analytics/models/CapabilitiesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 ThoughtWorks, Inc.
+ * Copyright 2018 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,50 +18,38 @@ package com.thoughtworks.go.plugin.access.analytics.models;
 
 import org.junit.Test;
 
-import java.util.Collections;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.is;
 
 public class CapabilitiesTest {
 
     @Test
     public void shouldDeserializeFromJSON() throws Exception {
-        String json = "" +
-                "{\n" +
-                "  \"supports_pipeline_analytics\": \"true\",\n" +
-                "  \"supported_analytics_dashboard_metrics\": [\"foo\"]\n" +
-                "}";
+        String json = "{\n" +
+                "\"supported_analytics\": [\n" +
+                "  {\"type\": \"dashboard\", \"id\": \"abc\",  \"title\": \"Title 1\"},\n" +
+                "  {\"type\": \"pipeline\", \"id\": \"abc\",  \"title\": \"Title 1\"}\n" +
+                "]}";
 
         Capabilities capabilities = Capabilities.fromJSON(json);
 
-        assertTrue(capabilities.supportsPipelineAnalytics());
-        assertEquals(Collections.singletonList("foo"), capabilities.supportedAnalyticsDashboardMetrics());
+        assertThat(capabilities.getSupportedAnalytics().size(), is(2));
+        assertThat(capabilities.getSupportedAnalytics().get(0), is(new SupportedAnalytics("dashboard", "abc", "Title 1")) );
     }
 
-
     @Test
-    public void shouldCreateEquivalentObjectsForSameJSON() throws Exception {
-        String json = "" +
-                "{\n" +
-                "  \"supports_pipeline_analytics\": \"true\",\n" +
-                "  \"supported_analytics_dashboard_metrics\": [\"foo\"]\n" +
-                "}";
+    public void shouldConvertToDomainCapabilities() throws Exception {
+        String json = "{\n" +
+                "\"supported_analytics\": [\n" +
+                "  {\"type\": \"dashboard\", \"id\": \"abc\",  \"title\": \"Title 1\"},\n" +
+                "  {\"type\": \"pipeline\", \"id\": \"abc\",  \"title\": \"Title 1\"}\n" +
+                "]}";
 
-        com.thoughtworks.go.plugin.domain.analytics.Capabilities a = Capabilities.fromJSON(json).toCapabilities();
-        com.thoughtworks.go.plugin.domain.analytics.Capabilities b = Capabilities.fromJSON(json).toCapabilities();
-        com.thoughtworks.go.plugin.domain.analytics.Capabilities c = Capabilities.fromJSON("{\"supports_pipeline_analytics\": false, \"supported_analytics_dashboard_metrics\": [\"foo\"]}").toCapabilities();
-        com.thoughtworks.go.plugin.domain.analytics.Capabilities d = Capabilities.fromJSON("{\"supports_pipeline_analytics\": true, \"supported_analytics_dashboard_metrics\": [\"bar\"]}").toCapabilities();
+        Capabilities capabilities = Capabilities.fromJSON(json);
+        com.thoughtworks.go.plugin.domain.analytics.Capabilities domain = capabilities.toCapabilities();
 
-        assertEquals(a, b);
-        assertEquals(a.hashCode(), b.hashCode());
-
-        assertNotEquals(a, c);
-        assertNotEquals(a.hashCode(), c.hashCode());
-
-        assertNotEquals(a, d);
-        assertNotEquals(a.hashCode(), d.hashCode());
-
+        assertThat(domain.supportedDashboardAnalytics(), containsInAnyOrder(new com.thoughtworks.go.plugin.domain.analytics.SupportedAnalytics("dashboard", "abc", "Title 1")));
+        assertThat(domain.supportedPipelineAnalytics(), containsInAnyOrder(new com.thoughtworks.go.plugin.domain.analytics.SupportedAnalytics("pipeline", "abc", "Title 1")));
     }
 }

--- a/plugin-infra/go-plugin-domain/src/main/java/com/thoughtworks/go/plugin/domain/analytics/Capabilities.java
+++ b/plugin-infra/go-plugin-domain/src/main/java/com/thoughtworks/go/plugin/domain/analytics/Capabilities.java
@@ -25,7 +25,6 @@ public class Capabilities {
     private static final String DASHBOARD_TYPE = "dashboard";
     private static final String PIPELINE_TYPE = "pipeline";
 
-
     public Capabilities(List<SupportedAnalytics> supportedAnalytics) {
         this.supportedAnalytics = supportedAnalytics;
     }

--- a/plugin-infra/go-plugin-domain/src/main/java/com/thoughtworks/go/plugin/domain/analytics/Capabilities.java
+++ b/plugin-infra/go-plugin-domain/src/main/java/com/thoughtworks/go/plugin/domain/analytics/Capabilities.java
@@ -18,41 +18,43 @@ package com.thoughtworks.go.plugin.domain.analytics;
 
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class Capabilities {
-    private final boolean supportsPipelineAnalytics;
-    private final List<String> supportedAnalyticsDashboardMetrics;
+    private final List<SupportedAnalytics> supportedAnalytics;
+    private static final String DASHBOARD_TYPE = "dashboard";
+    private static final String PIPELINE_TYPE = "pipeline";
 
-    public Capabilities(boolean supportsPipelineAnalytics, List<String> supportedAnalyticsDashboardMetrics) {
-        this.supportsPipelineAnalytics = supportsPipelineAnalytics;
-        this.supportedAnalyticsDashboardMetrics = supportedAnalyticsDashboardMetrics;
+
+    public Capabilities(List<SupportedAnalytics> supportedAnalytics) {
+        this.supportedAnalytics = supportedAnalytics;
+    }
+
+    public List<SupportedAnalytics> getSupportedAnalytics() {
+        return supportedAnalytics;
     }
 
     public boolean supportsPipelineAnalytics() {
-        return supportsPipelineAnalytics;
+        return hasSupportFor(PIPELINE_TYPE);
     }
 
     public boolean supportsDashboardAnalytics() {
-        return this.supportedAnalyticsDashboardMetrics != null && this.supportedAnalyticsDashboardMetrics.size() > 0;
+        return hasSupportFor(DASHBOARD_TYPE);
     }
 
     public List<String> supportedAnalyticsDashboardMetrics() {
-        return supportedAnalyticsDashboardMetrics;
+        return this.supportedAnalytics.stream().filter(s -> DASHBOARD_TYPE.equalsIgnoreCase(s.getType())).map(SupportedAnalytics::getTitle).collect(Collectors.toList());
     }
 
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-
-        Capabilities that = (Capabilities) o;
-
-        return supportsPipelineAnalytics == that.supportsPipelineAnalytics &&
-                supportedAnalyticsDashboardMetrics.equals(that.supportedAnalyticsDashboardMetrics);
+    public List<SupportedAnalytics> supportedDashboardAnalytics() {
+        return this.supportedAnalytics.stream().filter(s -> DASHBOARD_TYPE.equalsIgnoreCase(s.getType())).collect(Collectors.toList());
     }
 
-    @Override
-    public int hashCode() {
-        return (supportedAnalyticsDashboardMetrics.hashCode() << 1) + (supportsPipelineAnalytics ? 1 : 0);
+    public List<SupportedAnalytics> supportedPipelineAnalytics() {
+        return this.supportedAnalytics.stream().filter(s -> PIPELINE_TYPE.equalsIgnoreCase(s.getType())).collect(Collectors.toList());
+    }
+
+    private boolean hasSupportFor(String analyticsType) {
+        return this.supportedAnalytics.stream().anyMatch(s -> analyticsType.equalsIgnoreCase(s.getType()));
     }
 }

--- a/plugin-infra/go-plugin-domain/src/main/java/com/thoughtworks/go/plugin/domain/analytics/SupportedAnalytics.java
+++ b/plugin-infra/go-plugin-domain/src/main/java/com/thoughtworks/go/plugin/domain/analytics/SupportedAnalytics.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2018 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.plugin.domain.analytics;
+
+import java.util.Objects;
+
+public class SupportedAnalytics {
+    private String type;
+    private String id;
+    private String title;
+
+    public SupportedAnalytics(String type, String id, String title) {
+        this.type = type;
+        this.id = id;
+        this.title = title;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof SupportedAnalytics)) return false;
+        SupportedAnalytics that = (SupportedAnalytics) o;
+        return Objects.equals(getType(), that.getType()) &&
+                Objects.equals(getId(), that.getId()) &&
+                Objects.equals(getTitle(), that.getTitle());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getType(), getId(), getTitle());
+    }
+}

--- a/plugin-infra/go-plugin-domain/src/test/java/com/thoughtworks/go/plugin/domain/analytics/CapabilitiesTest.java
+++ b/plugin-infra/go-plugin-domain/src/test/java/com/thoughtworks/go/plugin/domain/analytics/CapabilitiesTest.java
@@ -18,6 +18,7 @@ package com.thoughtworks.go.plugin.domain.analytics;
 
 import org.junit.Test;
 
+import java.util.Arrays;
 import java.util.Collections;
 
 import static org.hamcrest.core.Is.is;
@@ -27,6 +28,7 @@ public class CapabilitiesTest {
     @Test
     public void shouldSupportDashboardAnalyticsIfPluginListsDashboardMetricsAsCapability() throws Exception {
         assertTrue(new Capabilities(Collections.singletonList(new SupportedAnalytics("dashboard", "id", "title"))).supportsDashboardAnalytics());
+        assertTrue(new Capabilities(Collections.singletonList(new SupportedAnalytics("DashBoard", "id", "title"))).supportsDashboardAnalytics());
 
         assertFalse(new Capabilities(Collections.emptyList()).supportsDashboardAnalytics());
     }
@@ -34,31 +36,37 @@ public class CapabilitiesTest {
     @Test
     public void shouldSupportPipelineAnalyticsIfPluginListsPipelineMetricsAsCapability() throws Exception {
         assertTrue(new Capabilities(Collections.singletonList(new SupportedAnalytics("pipeline", "id", "title"))).supportsPipelineAnalytics());
+        assertTrue(new Capabilities(Collections.singletonList(new SupportedAnalytics("PipeLine", "id", "title"))).supportsPipelineAnalytics());
 
         assertFalse(new Capabilities(Collections.emptyList()).supportsPipelineAnalytics());
     }
 
     @Test
     public void shouldListSupportedDashBoardAnalytics() throws Exception {
-        Capabilities capabilities = new Capabilities(Collections.singletonList(new SupportedAnalytics("dashboard", "id", "title")));
+        Capabilities capabilities = new Capabilities(Arrays.asList(new SupportedAnalytics("dashboard", "id1", "title1"),
+                new SupportedAnalytics("DashBoard", "id2", "title2")));
 
-        assertThat(capabilities.supportedAnalyticsDashboardMetrics(), is(Collections.singletonList("title")));
+        assertThat(capabilities.supportedAnalyticsDashboardMetrics(), is(Arrays.asList("title1", "title2")));
         assertTrue(new Capabilities(Collections.emptyList()).supportedAnalyticsDashboardMetrics().isEmpty());
     }
 
     @Test
     public void shouldListSupportedAnalyticsForDashboard() throws Exception {
-        Capabilities capabilities = new Capabilities(Collections.singletonList(new SupportedAnalytics("dashboard", "id", "title")));
+        Capabilities capabilities = new Capabilities(Arrays.asList(new SupportedAnalytics("dashboard", "id1", "title1"),
+                new SupportedAnalytics("DashBoard", "id2", "title2")));
 
-        assertThat(capabilities.supportedDashboardAnalytics(), is(Collections.singletonList(new SupportedAnalytics("dashboard", "id", "title"))));
+        assertThat(capabilities.supportedDashboardAnalytics(), is(Arrays.asList(new SupportedAnalytics("dashboard", "id1", "title1"),
+                new SupportedAnalytics("DashBoard", "id2", "title2"))));
         assertTrue(new Capabilities(Collections.emptyList()).supportedDashboardAnalytics().isEmpty());
     }
 
     @Test
     public void shouldListSupportedAnalyticsForPipelines() throws Exception {
-        Capabilities capabilities = new Capabilities(Collections.singletonList(new SupportedAnalytics("pipeline", "id", "title")));
+        Capabilities capabilities = new Capabilities(Arrays.asList(new SupportedAnalytics("pipeline", "id1", "title1"),
+                new SupportedAnalytics("Pipeline", "id2", "title2")));
 
-        assertThat(capabilities.supportedPipelineAnalytics(), is(Collections.singletonList(new SupportedAnalytics("pipeline", "id", "title"))));
+        assertThat(capabilities.supportedPipelineAnalytics(), is(Arrays.asList(new SupportedAnalytics("pipeline", "id1", "title1"),
+                new SupportedAnalytics("Pipeline", "id2", "title2"))));
         assertTrue(new Capabilities(Collections.emptyList()).supportedPipelineAnalytics().isEmpty());
     }
 }

--- a/plugin-infra/go-plugin-domain/src/test/java/com/thoughtworks/go/plugin/domain/analytics/CapabilitiesTest.java
+++ b/plugin-infra/go-plugin-domain/src/test/java/com/thoughtworks/go/plugin/domain/analytics/CapabilitiesTest.java
@@ -20,32 +20,45 @@ import org.junit.Test;
 
 import java.util.Collections;
 
+import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.*;
 
 public class CapabilitiesTest {
     @Test
-    public void equivalenceBasedOnContent() throws Exception {
-        Capabilities capabilities = new Capabilities(true, Collections.singletonList("foo"));
-        Capabilities capabilities1 = new Capabilities(true, Collections.singletonList("foo"));
+    public void shouldSupportDashboardAnalyticsIfPluginListsDashboardMetricsAsCapability() throws Exception {
+        assertTrue(new Capabilities(Collections.singletonList(new SupportedAnalytics("dashboard", "id", "title"))).supportsDashboardAnalytics());
 
-        assertEquals(capabilities, capabilities1);
-        assertEquals(capabilities.hashCode(), capabilities1.hashCode());
-
-        Capabilities capabilities2 = new Capabilities(true, Collections.singletonList("bar"));
-        assertNotEquals(capabilities, capabilities2);
-        assertNotEquals(capabilities.hashCode(), capabilities2.hashCode());
-
-        Capabilities capabilities3 = new Capabilities(false, Collections.singletonList("foo"));
-        assertNotEquals(capabilities, capabilities3);
-        assertNotEquals(capabilities.hashCode(), capabilities3.hashCode());
+        assertFalse(new Capabilities(Collections.emptyList()).supportsDashboardAnalytics());
     }
 
     @Test
-    public void shouldSupportDashboardAnalyticsIfPluginListsSupportedAnalyticsDashboardMetrics() throws Exception {
-        assertTrue(new Capabilities(true, Collections.singletonList("foo")).supportsDashboardAnalytics());
+    public void shouldSupportPipelineAnalyticsIfPluginListsPipelineMetricsAsCapability() throws Exception {
+        assertTrue(new Capabilities(Collections.singletonList(new SupportedAnalytics("pipeline", "id", "title"))).supportsPipelineAnalytics());
 
-        assertFalse(new Capabilities(true, Collections.emptyList()).supportsDashboardAnalytics());
+        assertFalse(new Capabilities(Collections.emptyList()).supportsPipelineAnalytics());
+    }
 
-        assertFalse(new Capabilities(true, null).supportsDashboardAnalytics());
+    @Test
+    public void shouldListSupportedDashBoardAnalytics() throws Exception {
+        Capabilities capabilities = new Capabilities(Collections.singletonList(new SupportedAnalytics("dashboard", "id", "title")));
+
+        assertThat(capabilities.supportedAnalyticsDashboardMetrics(), is(Collections.singletonList("title")));
+        assertTrue(new Capabilities(Collections.emptyList()).supportedAnalyticsDashboardMetrics().isEmpty());
+    }
+
+    @Test
+    public void shouldListSupportedAnalyticsForDashboard() throws Exception {
+        Capabilities capabilities = new Capabilities(Collections.singletonList(new SupportedAnalytics("dashboard", "id", "title")));
+
+        assertThat(capabilities.supportedDashboardAnalytics(), is(Collections.singletonList(new SupportedAnalytics("dashboard", "id", "title"))));
+        assertTrue(new Capabilities(Collections.emptyList()).supportedDashboardAnalytics().isEmpty());
+    }
+
+    @Test
+    public void shouldListSupportedAnalyticsForPipelines() throws Exception {
+        Capabilities capabilities = new Capabilities(Collections.singletonList(new SupportedAnalytics("pipeline", "id", "title")));
+
+        assertThat(capabilities.supportedPipelineAnalytics(), is(Collections.singletonList(new SupportedAnalytics("pipeline", "id", "title"))));
+        assertTrue(new Capabilities(Collections.emptyList()).supportedPipelineAnalytics().isEmpty());
     }
 }

--- a/server/src/main/java/com/thoughtworks/go/server/web/GoVelocityView.java
+++ b/server/src/main/java/com/thoughtworks/go/server/web/GoVelocityView.java
@@ -111,7 +111,7 @@ public class GoVelocityView extends VelocityToolboxView {
         velocityContext.put(GO_UPDATE, versionInfoService.getGoUpdate());
         velocityContext.put(GO_UPDATE_CHECK_ENABLED, versionInfoService.isGOUpdateCheckEnabled());
 
-        velocityContext.put(SUPPORTS_ANALYTICS_DASHBOARD, isSupportsAnalyticsDashboard());
+        velocityContext.put(SUPPORTS_ANALYTICS_DASHBOARD, supportsAnalyticsDashboard());
 
         SecurityContext securityContext = (SecurityContext) request.getSession().getAttribute(
                 SPRING_SECURITY_CONTEXT_KEY);
@@ -123,7 +123,7 @@ public class GoVelocityView extends VelocityToolboxView {
         setAdmininstratorRole(velocityContext, authentication);
     }
 
-    private boolean isSupportsAnalyticsDashboard() {
+    private boolean supportsAnalyticsDashboard() {
         for (Object obj : getPluginInfoFinder().allPluginInfos(PluginConstants.ANALYTICS_EXTENSION)) {
             AnalyticsPluginInfo info = (AnalyticsPluginInfo) obj;
             if (info.getCapabilities().supportsDashboardAnalytics()) {

--- a/server/src/test-fast/java/com/thoughtworks/go/server/web/GoVelocityViewTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/web/GoVelocityViewTest.java
@@ -19,6 +19,7 @@ package com.thoughtworks.go.server.web;
 import com.thoughtworks.go.ClearSingleton;
 import com.thoughtworks.go.plugin.domain.analytics.AnalyticsPluginInfo;
 import com.thoughtworks.go.plugin.domain.analytics.Capabilities;
+import com.thoughtworks.go.plugin.domain.analytics.SupportedAnalytics;
 import com.thoughtworks.go.server.security.GoAuthority;
 import com.thoughtworks.go.server.service.RailsAssetsService;
 import com.thoughtworks.go.server.service.VersionInfoService;
@@ -43,6 +44,7 @@ import org.springframework.security.userdetails.User;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpSession;
 import java.util.Collections;
+import java.util.List;
 
 import static com.thoughtworks.go.plugin.domain.common.PluginConstants.ANALYTICS_EXTENSION;
 import static org.hamcrest.core.Is.is;
@@ -91,9 +93,13 @@ public class GoVelocityViewTest {
 
     @Test
     public void shouldSetSupportsAnalyticsDashboardIfPluginInstalled() throws Exception {
-        AnalyticsPluginInfo info = new AnalyticsPluginInfo(null, null, new Capabilities(false, Collections.singletonList("foo")), null);
+        List<SupportedAnalytics> supportedAnalytics = Collections.singletonList(new SupportedAnalytics("dashboard", "id", "foo"));
+        AnalyticsPluginInfo info = new AnalyticsPluginInfo(null, null, new Capabilities(supportedAnalytics), null);
+
         when(pluginInfoFinder.allPluginInfos(ANALYTICS_EXTENSION)).thenReturn(Collections.singletonList(info));
+
         view.exposeHelpers(velocityContext, request);
+
         assertThat(velocityContext.get(GoVelocityView.SUPPORTS_ANALYTICS_DASHBOARD), is(true));
     }
 

--- a/server/webapp/WEB-INF/rails.new/app/controllers/analytics_controller.rb
+++ b/server/webapp/WEB-INF/rails.new/app/controllers/analytics_controller.rb
@@ -21,7 +21,6 @@ class AnalyticsController < ApplicationController
 
   before_action :check_admin_user_and_401
   before_action :check_permissions, only: [:show]
-  before_action :check_user_can_see_pipeline, only: [:pipeline]
 
   def index
     @view_title = 'Analytics'
@@ -34,25 +33,6 @@ class AnalyticsController < ApplicationController
 
   def show
     render json: analytics_extension.getAnalytics(params[:plugin_id], params[:type], params[:id], request.query_parameters).toMap().to_h
-  rescue => e
-    render_plugin_error e
-  end
-
-  def dashboard
-    render json: analytics_extension.getDashboardAnalytics(params[:plugin_id], params[:metric]).toMap().to_h
-  rescue => e
-    render_plugin_error e
-  end
-
-  def pipeline
-    render :json => analytics_extension.getPipelineAnalytics(params[:plugin_id], params[:pipeline_name]).toMap().to_h
-  rescue => e
-    render_plugin_error e
-  end
-
-  def job
-    options = params.reject {|k,v| %w(controller action plugin_id).include?(k)}
-    render :json => analytics_extension.getJobAnalytics(params[:plugin_id], options).toMap().to_h
   rescue => e
     render_plugin_error e
   end

--- a/server/webapp/WEB-INF/rails.new/app/helpers/pipelines_helper.rb
+++ b/server/webapp/WEB-INF/rails.new/app/helpers/pipelines_helper.rb
@@ -103,7 +103,9 @@ module PipelinesHelper
 
     default_plugin_info_finder.allPluginInfos(PluginConstants.ANALYTICS_EXTENSION).each do |plugin|
       if plugin.getCapabilities().supportsPipelineAnalytics()
-        yield plugin.getDescriptor().id()
+        supported_analytics = plugin.getCapabilities().supportedPipelineAnalytics().get(0)
+        yield plugin.getDescriptor().id(), supported_analytics.getId()
+        break
       end
     end
   end

--- a/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/plugin/analytics_capabilities_representer.rb
+++ b/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/plugin/analytics_capabilities_representer.rb
@@ -17,13 +17,11 @@
 module ApiV4
   module Plugin
     class AnalyticsCapabilitiesRepresenter < BaseRepresenter
-      alias_method :capabilities, :represented
 
-      property :supports_pipeline_analytics
-      property :supported_dashboard_analytics_metrics, exec_context: :decorator
-
-      def supported_dashboard_analytics_metrics
-        capabilities.supportedAnalyticsDashboardMetrics() || []
+      collection :supported_analytics, class: SupportedAnalytics do
+        property :type
+        property :id
+        property :title
       end
     end
   end

--- a/server/webapp/WEB-INF/rails.new/app/views/shared/_pipeline.html.erb
+++ b/server/webapp/WEB-INF/rails.new/app/views/shared/_pipeline.html.erb
@@ -10,10 +10,10 @@
         end
     %>
     <div class="pipeline_actions">
-      <% with_pipeline_analytics_support do |plugin_id| %>
+      <% with_pipeline_analytics_support do |plugin_id, metric_id| %>
         <%- analytics_label = "Analytics for Pipeline: #{scope[:pipeline_name]}" -%>
         <span class="analytics-link-wrapper">
-          <a onclick='Analytics.modal(<%== {url: show_analytics_path(plugin_id: plugin_id, type: 'pipeline', id: 'pipeline_timeline', pipeline_name: scope[:pipeline_name]), title: analytics_label, key: "analytics.pipeline-chart"}.to_json %>); return false;' title="<%= analytics_label %>"><i class="fa fa-bar-chart pipeline-analytics-icon"></i></a>
+          <a onclick='Analytics.modal(<%== {url: show_analytics_path(plugin_id: plugin_id, type: 'pipeline', id: metric_id, pipeline_name: scope[:pipeline_name]), title: analytics_label, key: "analytics.pipeline-chart"}.to_json %>); return false;' title="<%= analytics_label %>"><i class="fa fa-bar-chart pipeline-analytics-icon"></i></a>
         </span>
       <% end %>
         <%= render :partial => "pipelines/pipeline_locking_blurb.html.erb", :locals => {:scope => {:pipeline_model => scope[:pipeline_model]}} %>

--- a/server/webapp/WEB-INF/rails.new/app/views/shared/_pipeline.html.erb
+++ b/server/webapp/WEB-INF/rails.new/app/views/shared/_pipeline.html.erb
@@ -13,7 +13,7 @@
       <% with_pipeline_analytics_support do |plugin_id| %>
         <%- analytics_label = "Analytics for Pipeline: #{scope[:pipeline_name]}" -%>
         <span class="analytics-link-wrapper">
-          <a onclick='Analytics.modal(<%== {url: pipeline_analytics_path(plugin_id: plugin_id, pipeline_name: scope[:pipeline_name]), title: analytics_label, key: "analytics.pipeline-chart"}.to_json %>); return false;' title="<%= analytics_label %>"><i class="fa fa-bar-chart pipeline-analytics-icon"></i></a>
+          <a onclick='Analytics.modal(<%== {url: show_analytics_path(plugin_id: plugin_id, type: 'pipeline', id: 'pipeline_timeline', pipeline_name: scope[:pipeline_name]), title: analytics_label, key: "analytics.pipeline-chart"}.to_json %>); return false;' title="<%= analytics_label %>"><i class="fa fa-bar-chart pipeline-analytics-icon"></i></a>
         </span>
       <% end %>
         <%= render :partial => "pipelines/pipeline_locking_blurb.html.erb", :locals => {:scope => {:pipeline_model => scope[:pipeline_model]}} %>

--- a/server/webapp/WEB-INF/rails.new/config/routes.rb
+++ b/server/webapp/WEB-INF/rails.new/config/routes.rb
@@ -160,6 +160,7 @@ Go::Application.routes.draw do
   get 'analytics/:plugin_id/dashboard/:metric' => 'analytics#dashboard', constraints: {plugin_id: PLUGIN_ID_FORMAT, metric: ALLOW_DOTS}, as: :dashboard_analytics
   get 'analytics/:plugin_id/pipelines/:pipeline_name' => 'analytics#pipeline', constraints: {plugin_id: PLUGIN_ID_FORMAT, pipeline_name: PIPELINE_NAME_FORMAT}, as: :pipeline_analytics
   get 'analytics/:plugin_id/jobs/:pipeline_name/:stage_name/:job_name' => 'analytics#job', constraints: {plugin_id: PLUGIN_ID_FORMAT, pipeline_name: PIPELINE_NAME_FORMAT, stage_name: PIPELINE_NAME_FORMAT, job_name: PIPELINE_NAME_FORMAT}, as: :job_analytics
+  get 'analytics/:plugin_id/:type/:id' => 'analytics#show', constraints: {plugin_id: PLUGIN_ID_FORMAT, }, as: :show_analytics
 
   scope 'pipelines' do
     defaults :no_layout => true do

--- a/server/webapp/WEB-INF/rails.new/config/routes.rb
+++ b/server/webapp/WEB-INF/rails.new/config/routes.rb
@@ -157,10 +157,7 @@ Go::Application.routes.draw do
   get 'agents/filter_autocomplete/:action' => 'agent_autocomplete#%{action}', constraints: {action: /resource|os|ip|name|status|environment/}, as: :agent_filter_autocomplete
 
   resources :analytics, only: [:index], controller: "analytics"
-  get 'analytics/:plugin_id/dashboard/:metric' => 'analytics#dashboard', constraints: {plugin_id: PLUGIN_ID_FORMAT, metric: ALLOW_DOTS}, as: :dashboard_analytics
-  get 'analytics/:plugin_id/pipelines/:pipeline_name' => 'analytics#pipeline', constraints: {plugin_id: PLUGIN_ID_FORMAT, pipeline_name: PIPELINE_NAME_FORMAT}, as: :pipeline_analytics
-  get 'analytics/:plugin_id/jobs/:pipeline_name/:stage_name/:job_name' => 'analytics#job', constraints: {plugin_id: PLUGIN_ID_FORMAT, pipeline_name: PIPELINE_NAME_FORMAT, stage_name: PIPELINE_NAME_FORMAT, job_name: PIPELINE_NAME_FORMAT}, as: :job_analytics
-  get 'analytics/:plugin_id/:type/:id' => 'analytics#show', constraints: {plugin_id: PLUGIN_ID_FORMAT, }, as: :show_analytics
+  get 'analytics/:plugin_id/:type/:id' => 'analytics#show', constraints: {plugin_id: PLUGIN_ID_FORMAT, id: PIPELINE_NAME_FORMAT}, as: :show_analytics
 
   scope 'pipelines' do
     defaults :no_layout => true do

--- a/server/webapp/WEB-INF/rails.new/lib/java_imports.rb
+++ b/server/webapp/WEB-INF/rails.new/lib/java_imports.rb
@@ -278,5 +278,5 @@ module JavaImports
   java_import com.thoughtworks.go.plugin.access.analytics.AnalyticsExtension unless defined? AnalyticsExtension
   java_import com.thoughtworks.go.plugin.domain.common.PluginConstants
   java_import com.thoughtworks.go.plugin.domain.common.BadPluginInfo unless defined? BadPluginInfo
-  java_import com.thoughtworks.go.plugin.access.analytics.models.SupportedAnalytics unless defined? SupportedAnalytics
+  java_import com.thoughtworks.go.plugin.domain.analytics.SupportedAnalytics unless defined? SupportedAnalytics
 end

--- a/server/webapp/WEB-INF/rails.new/lib/java_imports.rb
+++ b/server/webapp/WEB-INF/rails.new/lib/java_imports.rb
@@ -278,4 +278,5 @@ module JavaImports
   java_import com.thoughtworks.go.plugin.access.analytics.AnalyticsExtension unless defined? AnalyticsExtension
   java_import com.thoughtworks.go.plugin.domain.common.PluginConstants
   java_import com.thoughtworks.go.plugin.domain.common.BadPluginInfo unless defined? BadPluginInfo
+  java_import com.thoughtworks.go.plugin.access.analytics.models.SupportedAnalytics unless defined? SupportedAnalytics
 end

--- a/server/webapp/WEB-INF/rails.new/spec/controllers/analytics_controller_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/controllers/analytics_controller_spec.rb
@@ -20,12 +20,6 @@ describe AnalyticsController do
 
   describe 'routes' do
     it 'should resolve the path' do
-      expect(:get => '/analytics/plugin_id/dashboard/test_metric').to route_to(controller: 'analytics', action: 'dashboard', plugin_id: 'plugin_id', metric: 'test_metric')
-      expect(dashboard_analytics_path(plugin_id: 'test_plugin', metric: 'test_metric')).to eq('/analytics/test_plugin/dashboard/test_metric')
-
-      expect(:get => '/analytics/plugin_id/pipelines/pipeline_name').to route_to(controller: 'analytics', action: 'pipeline', plugin_id: 'plugin_id', pipeline_name: 'pipeline_name')
-      expect(pipeline_analytics_path(plugin_id: 'test_plugin', pipeline_name: 'test_pipeline')).to eq('/analytics/test_plugin/pipelines/test_pipeline')
-
       expect(:get => '/analytics/plugin_id/pipeline/metric_id').to route_to(controller: 'analytics', action: 'show', plugin_id: 'plugin_id', type: 'pipeline', id: 'metric_id')
       expect(show_analytics_path(plugin_id: 'test_plugin', plugin_id: 'plugin_id', type: 'pipeline', id: 'metric_id')).to eq('/analytics/plugin_id/pipeline/metric_id')
     end
@@ -41,7 +35,7 @@ describe AnalyticsController do
       expect(controller).to allow_action(:get, :show, plugin_id: 'com.tw.myplugin', pipeline_name: 'pipeline_name', type: 'pipeline', id: 'metric_id')
 
       allow_current_user_to_not_access_pipeline('pipeline_name')
-      expect(controller).not_to allow_action(:get, :pipeline, plugin_id: 'com.tw.myplugin', pipeline_name: 'pipeline_name', type: 'pipeline', id: 'metric_id')
+      expect(controller).not_to allow_action(:get, :show, plugin_id: 'com.tw.myplugin', pipeline_name: 'pipeline_name', type: 'pipeline', id: 'metric_id')
     end
 
     it 'should allow all users to view analytics of type pipeline if security is disabled' do
@@ -51,48 +45,9 @@ describe AnalyticsController do
       disable_security
       expect(controller).to allow_action(:get, :show, plugin_id: 'com.tw.myplugin', pipeline_name: 'pipeline_name', type: 'pipeline', id: 'metric_id')
     end
-
-    it 'should only allow pipeline viewers to see pipeline analytics' do
-      expect(controller).to allow_action(:get, :pipeline, plugin_id: 'com.tw.myplugin', pipeline_name: 'pipeline_name')
-
-      allow_current_user_to_not_access_pipeline('pipeline_name')
-      expect(controller).not_to allow_action(:get, :pipeline, plugin_id: 'com.tw.myplugin', pipeline_name: 'pipeline_name')
-    end
-
-    it 'should allow all users to view pipeline analytics if security is disabled' do
-      allow_current_user_to_not_access_pipeline('pipeline_name')
-      expect(controller).not_to allow_action(:get, :pipeline, plugin_id: 'com.tw.myplugin', pipeline_name: 'pipeline_name')
-
-      disable_security
-      expect(controller).to allow_action(:get, :pipeline, plugin_id: 'com.tw.myplugin', pipeline_name: 'pipeline_name')
-    end
   end
 
-  describe 'show' do
-    before(:each) do
-      login_as_admin
-      allow_current_user_to_access_pipeline('pipeline_name')
-    end
-
-    it 'should render analytics for a pipeline' do
-      analytics_extension = instance_double('AnalyticsExtension')
-      analytics_data = com.thoughtworks.go.plugin.domain.analytics.AnalyticsData.new('pipeline_analytics', '/path/to/view')
-
-      allow(controller).to receive(:analytics_extension).and_return(analytics_extension)
-      allow(analytics_extension).to receive(:getAnalytics).with('com.tw.myplugin', 'analytics_type', 'metric_id', {pipeline_name: 'pipeline_name', duration: '30 days'}).and_return(analytics_data)
-
-      get :show, plugin_id: 'com.tw.myplugin', type: 'analytics_type', id: 'metric_id', pipeline_name: 'pipeline_name', duration: '30 days'
-
-      expect(response).to be_ok
-
-      response_json = JSON.parse(response.body)
-      expect(response_json['data']).to eq('pipeline_analytics')
-      expect(response_json['view_path']).to eq('/path/to/view')
-      expect(response.content_type).to eq('application/json')
-    end
-  end
-
-  describe 'new_index' do
+  describe 'index' do
     before(:each) do
       login_as_admin
     end
@@ -124,50 +79,7 @@ describe AnalyticsController do
     end
   end
 
-  describe 'analytics dashboard' do
-    before(:each) do
-      login_as_admin
-    end
-
-    xit 'should include the plugin ids in the SPA skeleton' do
-      plugin_info_finder = instance_double('DefaultPluginInfoFinder')
-      cap = instance_double('Capabilities')
-      info = instance_double('AnalyticsPluginInfo')
-      descriptor = com.thoughtworks.go.plugin.infra.plugininfo.GoPluginDescriptor.new("com.tw.myplugin", nil, nil, nil, nil, false);
-
-      allow(info).to receive(:getDescriptor).and_return(descriptor)
-      allow(info).to receive(:getCapabilities).and_return(cap)
-      allow(cap).to receive(:supportsDashboardAnalytics).and_return(true)
-      allow(cap).to receive(:supportedAnalyticsDashboardMetrics).and_return(["foo"])
-
-      allow(controller).to receive(:default_plugin_info_finder).and_return(plugin_info_finder)
-      allow(plugin_info_finder).to receive(:allPluginInfos).with(PluginConstants.ANALYTICS_EXTENSION).and_return([info])
-
-      get :index
-
-      expect(response).to be_ok
-      expect(controller.instance_variable_get(:@supported_dashboard_metrics)).to eq({"com.tw.myplugin" => ["foo"]})
-    end
-
-    it 'should render the analytics data for the dashboard' do
-      analytics_extension = instance_double('AnalyticsExtension')
-      analytics_data = com.thoughtworks.go.plugin.domain.analytics.AnalyticsData.new("dashboard_analytics", "/path/to/view")
-
-      allow(controller).to receive(:analytics_extension).and_return(analytics_extension)
-      allow(analytics_extension).to receive(:getDashboardAnalytics).with('com.tw.myplugin', 'foo').and_return(analytics_data)
-
-      get :dashboard, plugin_id: 'com.tw.myplugin', metric: 'foo'
-
-      expect(response).to be_ok
-
-      response_json = JSON.parse(response.body)
-      expect(response_json['data']).to eq('dashboard_analytics')
-      expect(response_json['view_path']).to eq('/path/to/view')
-      expect(response.content_type).to eq('application/json')
-    end
-  end
-
-  describe 'pipeline' do
+  describe 'show' do
     before(:each) do
       login_as_admin
       allow_current_user_to_access_pipeline('pipeline_name')
@@ -175,39 +87,17 @@ describe AnalyticsController do
 
     it 'should render analytics for a pipeline' do
       analytics_extension = instance_double('AnalyticsExtension')
-      analytics_data = com.thoughtworks.go.plugin.domain.analytics.AnalyticsData.new("pipeline_analytics", "/path/to/view")
+      analytics_data = com.thoughtworks.go.plugin.domain.analytics.AnalyticsData.new('pipeline_analytics', '/path/to/view')
 
       allow(controller).to receive(:analytics_extension).and_return(analytics_extension)
-      allow(analytics_extension).to receive(:getPipelineAnalytics).with('com.tw.myplugin', 'pipeline_name').and_return(analytics_data)
+      allow(analytics_extension).to receive(:getAnalytics).with('com.tw.myplugin', 'analytics_type', 'metric_id', {pipeline_name: 'pipeline_name', duration: '30 days'}).and_return(analytics_data)
 
-      get :pipeline, plugin_id: 'com.tw.myplugin', pipeline_name: 'pipeline_name'
+      get :show, plugin_id: 'com.tw.myplugin', type: 'analytics_type', id: 'metric_id', pipeline_name: 'pipeline_name', duration: '30 days'
 
       expect(response).to be_ok
 
       response_json = JSON.parse(response.body)
       expect(response_json['data']).to eq('pipeline_analytics')
-      expect(response_json['view_path']).to eq('/path/to/view')
-      expect(response.content_type).to eq('application/json')
-    end
-  end
-
-  describe 'job' do
-    before(:each) do
-      login_as_admin
-    end
-
-    it 'should render analytics for job' do
-      analytics_extension = instance_double('AnalyticsExtension')
-      analytics_data = com.thoughtworks.go.plugin.domain.analytics.AnalyticsData.new("job_analytics", "/path/to/view")
-      allow(controller).to receive(:analytics_extension).and_return(analytics_extension)
-      allow(analytics_extension).to receive(:getJobAnalytics).with('com.tw.myplugin', { pipeline_name: "pipeline", stage_name: "stage", job_name: "job" }).and_return(analytics_data);
-
-      get :job, plugin_id: 'com.tw.myplugin', pipeline_name: "pipeline", stage_name: "stage", job_name: "job"
-
-      expect(response).to be_ok
-
-      response_json = JSON.parse(response.body)
-      expect(response_json['data']).to eq('job_analytics')
       expect(response_json['view_path']).to eq('/path/to/view')
       expect(response.content_type).to eq('application/json')
     end
@@ -223,22 +113,12 @@ describe AnalyticsController do
       analytics_extension = instance_double('AnalyticsExtension')
       allow(controller).to receive(:analytics_extension).and_return(analytics_extension)
 
-      allow(analytics_extension).to receive(:getPipelineAnalytics).and_raise(java.lang.Exception.new)
-      allow(analytics_extension).to receive(:getDashboardAnalytics).and_raise(java.lang.Exception.new)
-      allow(analytics_extension).to receive(:getJobAnalytics).and_raise(java.lang.Exception.new)
+      allow(analytics_extension).to receive(:getAnalytics).and_raise(java.lang.Exception.new)
 
-      {
-        pipeline: { pipeline_name: "pipeline" },
-        job: { pipeline_name: "pipeline", stage_name: "stage", job_name: "job" },
-        dashboard: {metric: "foo"}
-      }.each do |action, params|
-        params[:plugin_id] = 'com.tw.myplugin'
-        get action, params
+      get :show, plugin_id: 'com.tw.myplugin', type: 'analytics_type', id: 'metric_id', pipeline_name: 'pipeline_name', duration: '30 days'
 
-
-        expect(response.code).to eq('500')
-        expect(response.body).to eq('Error generating analytics from plugin - com.tw.myplugin')
-      end
+      expect(response.code).to eq('500')
+      expect(response.body).to eq('Error generating analytics from plugin - com.tw.myplugin')
     end
   end
 end

--- a/server/webapp/WEB-INF/rails.new/spec/presenters/api_v4/plugin/plugin_info_representer_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/presenters/api_v4/plugin/plugin_info_representer_spec.rb
@@ -307,7 +307,9 @@ describe ApiV4::Plugin::PluginInfoRepresenter do
       plugin_view = com.thoughtworks.go.plugin.domain.common.PluginView.new('plugin_view_template')
       plugin_metadata = com.thoughtworks.go.plugin.domain.common.Metadata.new(true, false)
       plugin_settings = com.thoughtworks.go.plugin.domain.common.PluggableInstanceSettings.new([com.thoughtworks.go.plugin.domain.common.PluginConfiguration.new('username', plugin_metadata)], plugin_view)
-      capabilities = com.thoughtworks.go.plugin.domain.analytics.Capabilities.new(true, ["top_10_jobs_waiting"])
+      dashboard_analytics = SupportedAnalytics.new('dashboard', 'top_ten_agents_by_utilization', 'Top Ten Agents With Highest Utilization')
+      pipeline_analytics  = SupportedAnalytics.new('pipeline', 'top_ten_pipelines_by_wait_time', 'Top Ten Pipelines With Highest Wait Time')
+      capabilities = com.thoughtworks.go.plugin.domain.analytics.Capabilities.new([dashboard_analytics, pipeline_analytics])
 
       plugin_info = com.thoughtworks.go.plugin.domain.analytics.AnalyticsPluginInfo.new(descriptor, image, capabilities, plugin_settings)
       actual_json = ApiV4::Plugin::PluginInfoRepresenter.new(plugin_info).to_hash(url_builder: UrlBuilder.new)
@@ -325,7 +327,12 @@ describe ApiV4::Plugin::PluginInfoRepresenter do
                                   about: about_json,
                                   extension_info: {
                                     plugin_settings: ApiV4::Plugin::PluggableInstanceSettingsRepresenter.new(plugin_settings).to_hash(url_builder: UrlBuilder.new),
-                                    capabilities: ApiV4::Plugin::AnalyticsCapabilitiesRepresenter.new(capabilities).to_hash(url_builder: UrlBuilder.new)
+                                    capabilities: {
+                                      supported_analytics: [
+                                        {'type'=> 'dashboard', 'id' => 'top_ten_agents_by_utilization', 'title' => 'Top Ten Agents With Highest Utilization'},
+                                        {'type'=> 'pipeline', 'id'=> 'top_ten_pipelines_by_wait_time', 'title'=> 'Top Ten Pipelines With Highest Wait Time'}
+                                      ]
+                                    }
                                   }
                                 })
     end

--- a/server/webapp/WEB-INF/rails.new/webpack/single_page_apps/analytics.js
+++ b/server/webapp/WEB-INF/rails.new/webpack/single_page_apps/analytics.js
@@ -32,12 +32,12 @@
 
   const models = {};
 
-  function ensureModel(uid, pluginId, metric) {
+  function ensureModel(uid, pluginId, type, id) {
     let model = models[uid];
 
     if (!model) {
       model = models[uid] = new Frame(m.redraw);
-      model.url(Routes.dashboardAnalyticsPath({plugin_id: pluginId, metric})); // eslint-disable-line camelcase
+      model.url(Routes.showAnalyticsPath(pluginId, type, id)); // eslint-disable-line camelcase
     }
 
     return model;
@@ -74,10 +74,10 @@
       view() {
         const frames = [];
         frames.push(m(AnalyticsDashboardHeader));
-        $.each($(main).data("supported-dashboard-metrics"), (pluginId, metrics) => {
-          $.each(metrics, (idx, metric) => {
-            const uid = `f-${pluginId}:${metric}:${idx}`,
-              model = ensureModel(uid, pluginId, metric);
+        $.each($(main).data("supported-dashboard-metrics"), (pluginId, supportedAnalytics) => {
+          $.each(supportedAnalytics, (idx, sa) => {
+            const uid = `f-${pluginId}:${sa.id}:${idx}`,
+              model = ensureModel(uid, pluginId, sa.type, sa.id);
 
             frames.push(m(PluginiFrameWidget, {model, pluginId, uid, init: PluginEndpoint.init}));
           });


### PR DESCRIPTION

Changing the Analytics Plugin Messages to be more generic which would allow the plugin authors to support multiple types of analytics. These changes will allow GoCD to show multiple metrics for a given type based on the analytics supported by the plugins.

`get-capabilities` message response

```
{
  supported_analytics: [
    {type: 'dashboard', id: 'abc', title: 'Title 1'},
    {type: 'pipeline', id: 'abcd', title: 'Title 2'}
  ]
}
```

`get-analytics` request body. 

```
{
  type: 'pipeline',
  id: 'top_ten_pipelines_by_wait_time',
  params: {
    pipeline_name: 'foo'
  }
}
```

Generic GoCD endpoint to fetch analytics 

```go/analytics/[:plugin_id]]/[:type]/[:metric_id]?<params>```


