### PR TITLE
Gracefully handle an empty `IN` sql clause

### DIFF
--- a/server/src/main/resources/com/thoughtworks/go/server/dao/maps/Pipeline.xml
+++ b/server/src/main/resources/com/thoughtworks/go/server/dao/maps/Pipeline.xml
@@ -291,6 +291,26 @@
         ORDER BY pipelines.id DESC, stages.orderId ASC
     </select>
 
+    <select id="getPipelineForDashboard" resultMap="select-pipeline-history">
+        <include refid="getPipelineHistory" />
+        WHERE pipelines.id IN (
+          (
+              SELECT stages.pipelineId
+              FROM stages
+              WHERE stages.state = 'Building' AND latestRun = true
+          )
+        UNION
+          (
+              SELECT max(pipelines.id)
+              FROM pipelines
+              WHERE pipelines.name = #pipelineName#
+              GROUP BY pipelines.name
+          )
+        )
+        AND pipelines.name = #pipelineName#
+        ORDER BY pipelines.id DESC, stages.orderId ASC
+    </select>
+
     <!-- TODO: ketan pkr unused query?-->
     <select id="getPipelineHistoryForIds" resultMap="select-pipeline-history">
         <include refid="getPipelineHistory" />

--- a/server/src/test-integration/java/com/thoughtworks/go/server/dashboard/GoDashboardCurrentStateLoaderIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/dashboard/GoDashboardCurrentStateLoaderIntegrationTest.java
@@ -98,6 +98,14 @@ public class GoDashboardCurrentStateLoaderIntegrationTest {
     }
 
     @Test
+    public void shouldReturnEmptyWhenNoPipelinesArePresentInConfig() throws Exception {
+        goConfigService.forceNotifyListeners();
+        assertThat(goConfigService.getAllPipelineConfigs(), is(empty()));
+        List<GoDashboardPipeline> goDashboardPipelines = goDashboardCurrentStateLoader.allPipelines(goConfigService.currentCruiseConfig());
+        assertThat(goDashboardPipelines, is(empty()));
+    }
+
+    @Test
     public void shouldReturnSingleDashboardForSingleCompletedGreenPipelineInstance() throws Exception {
         PipelineConfig pipelineConfig = configHelper.addPipeline(PipelineConfigMother.createPipelineConfigWithStages("a-pipeline", "a-stage"));
         goConfigService.forceNotifyListeners();


### PR DESCRIPTION
This improves the `loadHistoryForDashboard` call for the following:

* 0 pipeline names passed in - return empty
* 1 pipeline name passed in - use an optimized SQL clause without an
  `IN` clause
* >1 pipeline names passed in - use the optimized SQL clause with an
  `IN` clause