### PR TITLE
Fix is_quick_edit_page_enabled to check for both pipeline_config_single_page_app_key and quick_edit_page_toggle_key toggles

### DIFF
--- a/server/webapp/WEB-INF/rails.new/app/controllers/admin/new_dashboard_controller.rb
+++ b/server/webapp/WEB-INF/rails.new/app/controllers/admin/new_dashboard_controller.rb
@@ -23,7 +23,7 @@ module Admin
 
     def index
       @view_title = 'Dashboard'
-      @is_quick_edit_page_enabled = Toggles.isToggleOn(Toggles.PIPELINE_CONFIG_SINGLE_PAGE_APP) and Toggles.isToggleOn(Toggles.QUICK_EDIT_PAGE_DEFAULT)
+      @is_quick_edit_page_enabled = Toggles.isToggleOn(Toggles.PIPELINE_CONFIG_SINGLE_PAGE_APP) && Toggles.isToggleOn(Toggles.QUICK_EDIT_PAGE_DEFAULT)
     end
   end
 end


### PR DESCRIPTION
…

* Change the conditional check from `and` to `&&`