### PR TITLE
Make should assign call only when an agent and elastic profile belongs to the same plugin

### DIFF
--- a/server/src/main/java/com/thoughtworks/go/server/service/ElasticAgentPluginService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/ElasticAgentPluginService.java
@@ -39,6 +39,7 @@ import com.thoughtworks.go.serverhealth.HealthStateType;
 import com.thoughtworks.go.serverhealth.ServerHealthService;
 import com.thoughtworks.go.serverhealth.ServerHealthState;
 import com.thoughtworks.go.util.TimeProvider;
+import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -190,8 +191,12 @@ public class ElasticAgentPluginService implements JobStatusListener {
     public boolean shouldAssignWork(ElasticAgentMetadata metadata, String environment, ElasticProfile elasticProfile, JobIdentifier identifier) {
         GoPluginDescriptor pluginDescriptor = pluginManager.getPluginDescriptorFor(metadata.elasticPluginId());
         Map<String, String> configuration = elasticProfile.getConfigurationAsMap(true);
-        boolean shouldAssignWork = elasticAgentPluginRegistry.shouldAssignWork(pluginDescriptor, toAgentMetadata(metadata), environment, configuration, identifier);
-        return elasticProfile.getPluginId().equals(metadata.elasticPluginId()) && shouldAssignWork;
+
+        if (!StringUtils.equals(elasticProfile.getPluginId(), metadata.elasticPluginId())) {
+            return false;
+        }
+
+        return elasticAgentPluginRegistry.shouldAssignWork(pluginDescriptor, toAgentMetadata(metadata), environment, configuration, identifier);
     }
 
     public String getPluginStatusReport(String pluginId) {

--- a/server/src/test-fast/java/com/thoughtworks/go/server/service/ElasticAgentPluginServiceTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/service/ElasticAgentPluginServiceTest.java
@@ -254,9 +254,9 @@ public class ElasticAgentPluginServiceTest {
         String uuid = UUID.randomUUID().toString();
         ElasticAgentMetadata agentMetadata = new ElasticAgentMetadata(uuid, uuid, "plugin-1", AgentRuntimeStatus.Idle, AgentConfigStatus.Enabled);
         ElasticProfile elasticProfile = new ElasticProfile("1", "plugin-2");
-        when(registry.shouldAssignWork(any(), any(), any(), any(), any())).thenReturn(true);
 
         assertThat(service.shouldAssignWork(agentMetadata, null, elasticProfile, null), is(false));
+        verifyNoMoreInteractions(registry);
     }
 
     @Test


### PR DESCRIPTION
This behavior was changed in https://github.com/gocd/gocd/pull/4094. Make a `shouldAssignWork` call only if elastic profile and agent both are having same plugin id.

These changes will ensure that the plugin_id is same in elastic_profile and agents metadata before making a plugin call to assignWork