### PR TITLE
Making pipeline-name case-insensitive in PipelineScheduleQueue

### DIFF
--- a/server/src/main/java/com/thoughtworks/go/server/controller/PipelineHistoryController.java
+++ b/server/src/main/java/com/thoughtworks/go/server/controller/PipelineHistoryController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 ThoughtWorks, Inc.
+ * Copyright 2018 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -105,13 +105,13 @@ public class PipelineHistoryController {
         }
 
         PipelinePauseInfo pauseInfo = pipelinePauseService.pipelinePauseInfo(pipelineName);
-        boolean hasBuildCauseInBuffer = pipelineScheduleQueue.hasBuildCause(CaseInsensitiveString.str(pipelineConfig.name()));
+        boolean hasBuildCauseInBuffer = pipelineScheduleQueue.hasBuildCause(pipelineConfig.name());
         PipelineInstanceModels pipelineHistory = StringUtils.isBlank(labelFilter) ?
                 pipelineHistoryService.load(pipelineName, pagination, username, true) :
                 pipelineHistoryService.findMatchingPipelineInstances(pipelineName, labelFilter, perPageParam, UserHelper.getUserName(), new HttpLocalizedOperationResult());
 
 
-        boolean hasForcedBuildCause = pipelineScheduleQueue.hasForcedBuildCause(pipelineName);
+        boolean hasForcedBuildCause = pipelineScheduleQueue.hasForcedBuildCause(pipelineConfig.name());
 
         PipelineHistoryJsonPresentationModel historyJsonPresenter = new PipelineHistoryJsonPresentationModel(
                 pauseInfo,

--- a/server/src/main/java/com/thoughtworks/go/server/dashboard/GoDashboardCurrentStateLoader.java
+++ b/server/src/main/java/com/thoughtworks/go/server/dashboard/GoDashboardCurrentStateLoader.java
@@ -203,7 +203,7 @@ public class GoDashboardCurrentStateLoader {
             return pipelinesToShow;
         }
 
-        if (triggerMonitor.isAlreadyTriggered(pipelineName)) {
+        if (triggerMonitor.isAlreadyTriggered(pipelineConfig.name())) {
             return createPipelineInstanceModels(createPreparingToSchedule(pipelineName, new StageInstanceModels()));
         }
 

--- a/server/src/main/java/com/thoughtworks/go/server/perf/SchedulingPerformanceLogger.java
+++ b/server/src/main/java/com/thoughtworks/go/server/perf/SchedulingPerformanceLogger.java
@@ -1,21 +1,22 @@
-/*************************GO-LICENSE-START*********************************
- * Copyright 2014 ThoughtWorks, Inc.
+/*
+ * Copyright 2018 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *************************GO-LICENSE-END***********************************/
+ */
 
 package com.thoughtworks.go.server.perf;
 
+import com.thoughtworks.go.config.CaseInsensitiveString;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -79,7 +80,7 @@ public class SchedulingPerformanceLogger {
         performanceLogger.log("SCH-TO-BE-SCHEDULED-QUEUE-PUT {} {}", trackingId, pipelineName);
     }
 
-    public void scheduledPipeline(String pipelineName, int toBeScheduledQueueSize, long schedulePipelineStartTime, long schedulePipelineEndTime) {
+    public void scheduledPipeline(CaseInsensitiveString pipelineName, int toBeScheduledQueueSize, long schedulePipelineStartTime, long schedulePipelineEndTime) {
         performanceLogger.log("SCH-SCHEDULED {} {} {} {}", pipelineName, toBeScheduledQueueSize, schedulePipelineStartTime, schedulePipelineEndTime);
     }
 }

--- a/server/src/main/java/com/thoughtworks/go/server/scheduling/BuildCauseProducerService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/scheduling/BuildCauseProducerService.java
@@ -158,7 +158,7 @@ public class BuildCauseProducerService {
 
         try {
             MaterialRevisions peggedRevisions = specificMaterialRevisionFactory.create(pipelineName, scheduleOptions.getSpecifiedRevisions());
-            BuildCause previousBuild = pipelineScheduleQueue.mostRecentScheduled(pipelineName);
+            BuildCause previousBuild = pipelineScheduleQueue.mostRecentScheduled(pipelineConfig.name());
 
             Materials materials = materialConfigConverter.toMaterials(pipelineConfig.materialConfigs());
             MaterialConfigs expandedMaterialConfigs = materialExpansionService.expandMaterialConfigsForScheduling(pipelineConfig.materialConfigs());
@@ -197,7 +197,7 @@ public class BuildCauseProducerService {
                 updateChangedRevisions(pipelineConfig.name(), buildCause);
             }
             if (isGoodReasonToSchedule(pipelineConfig, buildCause, buildType, materialConfigurationChanged)) {
-                pipelineScheduleQueue.schedule(pipelineName, buildCause);
+                pipelineScheduleQueue.schedule(pipelineConfig.name(), buildCause);
 
                 schedulingPerformanceLogger.sendingPipelineToTheToBeScheduledQueue(trackingId, pipelineName);
                 LOGGER.debug("scheduling pipeline {} with build-cause {}; config origin {}", pipelineName, buildCause, pipelineConfig.getOrigin());

--- a/server/src/main/java/com/thoughtworks/go/server/scheduling/TriggerMonitor.java
+++ b/server/src/main/java/com/thoughtworks/go/server/scheduling/TriggerMonitor.java
@@ -1,18 +1,18 @@
-/*************************GO-LICENSE-START*********************************
- * Copyright 2014 ThoughtWorks, Inc.
+/*
+ * Copyright 2018 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *************************GO-LICENSE-END***********************************/
+ */
 
 package com.thoughtworks.go.server.scheduling;
 
@@ -27,23 +27,22 @@ import org.springframework.stereotype.Component;
  */
 @Component
 public class TriggerMonitor {
-    ConcurrentSkipListSet<String> triggeredPipelines = new ConcurrentSkipListSet<>();
+    ConcurrentSkipListSet<CaseInsensitiveString> triggeredPipelines = new ConcurrentSkipListSet<>();
 
-    public boolean isAlreadyTriggered(String pipelineName) {
-        return triggeredPipelines.contains(pipelineName.toLowerCase());
+    public boolean isAlreadyTriggered(CaseInsensitiveString pipelineName) {
+        return triggeredPipelines.contains(pipelineName);
     }
 
     public boolean markPipelineAsAlreadyTriggered(PipelineConfig pipelineConfig) {
-        String s = CaseInsensitiveString.str(pipelineConfig.name());
-        return markPipelineAsAlreadyTriggered(s);
+        return markPipelineAsAlreadyTriggered(pipelineConfig.name());
     }
 
-    public boolean markPipelineAsAlreadyTriggered(String pipelineName) {
-        return triggeredPipelines.add(pipelineName.toLowerCase());
+    public boolean markPipelineAsAlreadyTriggered(CaseInsensitiveString pipelineName) {
+        return triggeredPipelines.add(pipelineName);
     }
 
     public void markPipelineAsCanBeTriggered(PipelineConfig pipelineConfig) {
-        triggeredPipelines.remove(pipelineConfig.name().toLower());
+        triggeredPipelines.remove(pipelineConfig.name());
     }
 
     public void clear_for_test() {

--- a/server/src/main/java/com/thoughtworks/go/server/service/AboutToBeTriggeredChecker.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/AboutToBeTriggeredChecker.java
@@ -1,21 +1,22 @@
-/*************************GO-LICENSE-START*********************************
- * Copyright 2014 ThoughtWorks, Inc.
+/*
+ * Copyright 2018 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *************************GO-LICENSE-END***********************************/
+ */
 
 package com.thoughtworks.go.server.service;
 
+import com.thoughtworks.go.config.CaseInsensitiveString;
 import com.thoughtworks.go.server.service.result.OperationResult;
 import com.thoughtworks.go.server.scheduling.TriggerMonitor;
 import com.thoughtworks.go.serverhealth.HealthStateType;
@@ -37,7 +38,7 @@ public class AboutToBeTriggeredChecker implements SchedulingChecker{
 
     public void check(OperationResult result) {
         HealthStateType type = HealthStateType.general(HealthStateScope.forPipeline(pipelineName));
-        if (triggerMonitor.isAlreadyTriggered(pipelineName) || pipelineScheduleQueue.hasForcedBuildCause(pipelineName)) {
+        if (triggerMonitor.isAlreadyTriggered(pipelineName) || pipelineScheduleQueue.hasForcedBuildCause(new CaseInsensitiveString(pipelineName))) {
             result.conflict("Failed to trigger pipeline: " + pipelineName,
                             "Pipeline already triggered",
                             HealthStateType.general(HealthStateScope.forPipeline(pipelineName)));

--- a/server/src/main/java/com/thoughtworks/go/server/service/AboutToBeTriggeredChecker.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/AboutToBeTriggeredChecker.java
@@ -26,22 +26,23 @@ import com.thoughtworks.go.serverhealth.HealthStateScope;
  * ADD_UNDERSTANDS_BLOCK
  */
 public class AboutToBeTriggeredChecker implements SchedulingChecker{
-    private final String pipelineName;
+    private final CaseInsensitiveString pipelineName;
     private final TriggerMonitor triggerMonitor;
     private final PipelineScheduleQueue pipelineScheduleQueue;
 
-    public AboutToBeTriggeredChecker(String pipelineName, TriggerMonitor triggerMonitor, PipelineScheduleQueue pipelineScheduleQueue) {
+    public AboutToBeTriggeredChecker(CaseInsensitiveString pipelineName, TriggerMonitor triggerMonitor, PipelineScheduleQueue pipelineScheduleQueue) {
         this.pipelineName = pipelineName;
         this.triggerMonitor = triggerMonitor;
         this.pipelineScheduleQueue = pipelineScheduleQueue;
     }
 
     public void check(OperationResult result) {
-        HealthStateType type = HealthStateType.general(HealthStateScope.forPipeline(pipelineName));
-        if (triggerMonitor.isAlreadyTriggered(pipelineName) || pipelineScheduleQueue.hasForcedBuildCause(new CaseInsensitiveString(pipelineName))) {
+        String pipelineNameString = CaseInsensitiveString.str(pipelineName);
+        HealthStateType type = HealthStateType.general(HealthStateScope.forPipeline(pipelineNameString));
+        if (triggerMonitor.isAlreadyTriggered(pipelineName) || pipelineScheduleQueue.hasForcedBuildCause(pipelineName)) {
             result.conflict("Failed to trigger pipeline: " + pipelineName,
                             "Pipeline already triggered",
-                            HealthStateType.general(HealthStateScope.forPipeline(pipelineName)));
+                            HealthStateType.general(HealthStateScope.forPipeline(pipelineNameString)));
         } else {
             result.success(type);
         }

--- a/server/src/main/java/com/thoughtworks/go/server/service/CachedCurrentActivityService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/CachedCurrentActivityService.java
@@ -1,18 +1,18 @@
-/*************************GO-LICENSE-START*********************************
- * Copyright 2014 ThoughtWorks, Inc.
+/*
+ * Copyright 2018 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *************************GO-LICENSE-END***********************************/
+ */
 
 package com.thoughtworks.go.server.service;
 
@@ -73,9 +73,9 @@ public class CachedCurrentActivityService implements CurrentActivityService {
     private PipelineJsonPresentationModel pipelineModel(PipelineConfig pipelineConfig) {
         String name = CaseInsensitiveString.str(pipelineConfig.name());
         PipelinePauseInfo pauseInfo = pipelinePauseService.pipelinePauseInfo(name);
-        boolean forcedBuild = pipelineScheduleQueue.hasForcedBuildCause(name);
+        boolean forcedBuild = pipelineScheduleQueue.hasForcedBuildCause(pipelineConfig.name());
         List<StageJsonPresentationModel> stageModels = stagesModel(pipelineConfig);
-        return new PipelineJsonPresentationModel(goConfigService.findGroupNameByPipeline(new CaseInsensitiveString(name)), name, pauseInfo, forcedBuild, stageModels);
+        return new PipelineJsonPresentationModel(goConfigService.findGroupNameByPipeline(pipelineConfig.name()), name, pauseInfo, forcedBuild, stageModels);
     }
 
     private List<StageJsonPresentationModel> stagesModel(PipelineConfig pipelineConfig) {

--- a/server/src/main/java/com/thoughtworks/go/server/service/PipelineHistoryService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/PipelineHistoryService.java
@@ -1,18 +1,18 @@
-/*************************GO-LICENSE-START*********************************
- * Copyright 2017 ThoughtWorks, Inc.
+/*
+ * Copyright 2018 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *************************GO-LICENSE-END***********************************/
+ */
 
 package com.thoughtworks.go.server.service;
 
@@ -277,7 +277,7 @@ public class PipelineHistoryService implements PipelineInstanceLoader {
             return PipelineInstanceModels.createPipelineInstanceModels();
         }
         PipelineInstanceModels pipelineInstanceModels = null;
-        if (triggerMonitor.isAlreadyTriggered(pipelineName)) {
+        if (triggerMonitor.isAlreadyTriggered(new CaseInsensitiveString(pipelineName))) {
 
             StageInstanceModels stageHistory = new StageInstanceModels();
             appendFollowingStagesFromConfig(pipelineName, stageHistory);

--- a/server/src/main/java/com/thoughtworks/go/server/service/ScheduleService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/ScheduleService.java
@@ -149,8 +149,8 @@ public class ScheduleService {
     public void autoSchedulePipelinesFromRequestBuffer() {
         synchronized (autoScheduleMutex) {
             try {
-                for (Entry<String, BuildCause> entry : pipelineScheduleQueue.toBeScheduled().entrySet()) {
-                    String pipelineName = entry.getKey();
+                for (Entry<CaseInsensitiveString, BuildCause> entry : pipelineScheduleQueue.toBeScheduled().entrySet()) {
+                    CaseInsensitiveString pipelineName = entry.getKey();
                     BuildCause buildCause = entry.getValue();
 
                     LOGGER.info("[Pipeline Schedule] Scheduling pipeline {} with build cause {}", pipelineName, buildCause);
@@ -169,14 +169,14 @@ public class ScheduleService {
         }
     }
 
-    Pipeline schedulePipeline(final String pipelineName, final BuildCause buildCause) {
+    Pipeline schedulePipeline(final CaseInsensitiveString pipelineName, final BuildCause buildCause) {
         try {
-            PipelineConfig pipelineConfig = goConfigService.pipelineConfigNamed(new CaseInsensitiveString(pipelineName));
+            PipelineConfig pipelineConfig = goConfigService.pipelineConfigNamed(pipelineName);
 
             if (canSchedule(pipelineConfig)) {
                 final Pipeline pipelineInstance = pipelineScheduleQueue.createPipeline(buildCause, pipelineConfig, schedulingContext(buildCause.getApprover(), pipelineConfig, pipelineConfig.first()),
                         goConfigService.getCurrentConfig().getMd5(), timeProvider);
-                serverHealthService.update(stageSchedulingSuccessfulState(pipelineName, CaseInsensitiveString.str(pipelineConfig.get(0).name())));
+                serverHealthService.update(stageSchedulingSuccessfulState(pipelineName.toString(), CaseInsensitiveString.str(pipelineConfig.get(0).name())));
                 return pipelineInstance;
             }
         } catch (PipelineNotFoundException e) {
@@ -184,7 +184,7 @@ public class ScheduleService {
             pipelineScheduleQueue.clearPipeline(pipelineName);
         } catch (CannotScheduleException e) {
             pipelineScheduleQueue.clearPipeline(pipelineName);
-            serverHealthService.update(stageSchedulingFailedState(pipelineName, e));
+            serverHealthService.update(stageSchedulingFailedState(pipelineName.toString(), e));
         } catch (Exception e) {
             LOGGER.error("Error while scheduling pipeline {}", pipelineName, e);
             pipelineScheduleQueue.clearPipeline(pipelineName);

--- a/server/src/main/java/com/thoughtworks/go/server/service/SchedulingCheckerService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/SchedulingCheckerService.java
@@ -175,7 +175,7 @@ public class SchedulingCheckerService {
         String stageName = CaseInsensitiveString.str(pipelineConfig.getFirstStageConfig().name());
 
         return new CompositeChecker(
-                new AboutToBeTriggeredChecker(pipelineName, triggerMonitor, pipelineScheduleQueue),
+                new AboutToBeTriggeredChecker(pipelineConfig.name(), triggerMonitor, pipelineScheduleQueue),
                 new PipelinePauseChecker(pipelineName, pipelinePauseService),
                 new StageActiveChecker(pipelineName, stageName, activityService),
                 new PipelineLockChecker(pipelineName, pipelineLockService),

--- a/server/src/test-fast/java/com/thoughtworks/go/server/dashboard/GoDashboardCurrentStateLoaderTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/dashboard/GoDashboardCurrentStateLoaderTest.java
@@ -123,7 +123,7 @@ public class GoDashboardCurrentStateLoaderTest {
         goConfigMother.addPipelineWithGroup(config, "group1", "pipeline1", "stage1", "job1");
 
         when(pipelineSqlMapDao.loadHistoryForDashboard(CaseInsensitiveString.toStringList(config.getAllPipelineNames()))).thenReturn(createPipelineInstanceModels());
-        when(triggerMonitor.isAlreadyTriggered("pipeline1")).thenReturn(true);
+        when(triggerMonitor.isAlreadyTriggered(new CaseInsensitiveString("pipeline1"))).thenReturn(true);
 
         List<GoDashboardPipeline> models = loader.allPipelines(config);
         assertThat(models.size(), is(1));
@@ -146,7 +146,7 @@ public class GoDashboardCurrentStateLoaderTest {
     public void shouldFallBackToAnEmptyPipelineInstanceModelIfItCannotBeLoadedEvenFromHistory() throws Exception {
         goConfigMother.addPipelineWithGroup(config, "group1", "pipeline1", "stage1", "job1");
 
-        when(triggerMonitor.isAlreadyTriggered("pipeline1")).thenReturn(false);
+        when(triggerMonitor.isAlreadyTriggered(new CaseInsensitiveString("pipeline1"))).thenReturn(false);
         when(pipelineSqlMapDao.loadHistoryForDashboard(singletonList("pipeline1"))).thenReturn(createPipelineInstanceModels());
 
         List<GoDashboardPipeline> models = loader.allPipelines(config);

--- a/server/src/test-fast/java/com/thoughtworks/go/server/scheduling/BuildCauseProducerServiceTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/scheduling/BuildCauseProducerServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 ThoughtWorks, Inc.
+ * Copyright 2018 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -215,7 +215,7 @@ public class BuildCauseProducerServiceTest {
 
         when(materialConfigConverter.toMaterial(hgMaterialConfig)).thenReturn(hgMaterial);
         when(specificMaterialRevisionFactory.create("pipeline", new HashMap<>())).thenReturn(new MaterialRevisions());
-        when(pipelineScheduleQueue.mostRecentScheduled(CaseInsensitiveString.str(pipelineConfig.name()))).thenReturn(BuildCause.createNeverRun());
+        when(pipelineScheduleQueue.mostRecentScheduled(pipelineConfig.name())).thenReturn(BuildCause.createNeverRun());
         when(materialRepository.findLatestModification(hgMaterial)).thenReturn(new MaterialRevisions(new MaterialRevision(hgMaterial, new ArrayList<>())));
 
         buildCauseProducerService.manualSchedulePipeline(Username.ANONYMOUS, pipelineConfig.name(), new ScheduleOptions(), new ServerHealthStateOperationResult());
@@ -320,7 +320,7 @@ public class BuildCauseProducerServiceTest {
         MaterialRevision specificMaterialRevision = new MaterialRevision(dependencyMaterial, new Modification(new Date(), "upstream-pipeline/2/stage/1", "MOCK_LABEL-12", null));
         when(specificMaterialRevisionFactory.create(eq("pipeline"), eq(Collections.singletonMap(dependencyMaterial.getPipelineUniqueFingerprint(), "upstream-pipeline/2/stage/1"))))
                 .thenReturn(new MaterialRevisions(specificMaterialRevision));
-        when(pipelineScheduleQueue.mostRecentScheduled("pipeline")).thenReturn(BuildCause.createNeverRun());
+        when(pipelineScheduleQueue.mostRecentScheduled(new CaseInsensitiveString("pipeline"))).thenReturn(BuildCause.createNeverRun());
         when(materialRepository.findLatestModification(svnMaterial)).thenReturn(new MaterialRevisions(new MaterialRevision(svnMaterial, svnModifications)));
 
         when(materialConfigConverter.toMaterials(pipelineConfig.materialConfigs())).thenReturn(new Materials(dependencyMaterial, svnMaterial));
@@ -333,7 +333,7 @@ public class BuildCauseProducerServiceTest {
                 new ScheduleOptions(Collections.singletonMap(dependencyMaterial.getPipelineUniqueFingerprint(), "upstream-pipeline/2/stage/1"),
                         stringStringHashMap, new HashMap<>()), new ServerHealthStateOperationResult(), 12345);
 
-        verify(pipelineScheduleQueue).schedule(eq("pipeline"), argThat(containsRevisions(new MaterialRevision(svnMaterial, svnModifications), specificMaterialRevision)));
+        verify(pipelineScheduleQueue).schedule(eq(new CaseInsensitiveString("pipeline")), argThat(containsRevisions(new MaterialRevision(svnMaterial, svnModifications), specificMaterialRevision)));
     }
 
     @Test
@@ -465,7 +465,7 @@ public class BuildCauseProducerServiceTest {
         Materials materials = new Materials(material1, material2);
         when(materialConfigConverter.toMaterials(updatedPipelineConfig.materialConfigs())).thenReturn(materials);
         when(materialExpansionService.expandMaterialConfigsForScheduling(updatedPipelineConfig.materialConfigs())).thenReturn(updatedPipelineConfig.materialConfigs());
-        when(pipelineScheduleQueue.mostRecentScheduled(updatedPipelineConfig.name().toString())).thenReturn(BuildCause.createNeverRun());
+        when(pipelineScheduleQueue.mostRecentScheduled(updatedPipelineConfig.name())).thenReturn(BuildCause.createNeverRun());
         when(materialChecker.findLatestRevisions(any(), eq(materials))).thenReturn(new MaterialRevisions());
         MaterialUpdateStatusListener statusListener = extractMaterialListenerInstanceFromRegisterCall();
         statusListener.onMaterialUpdate(new MaterialUpdateSuccessfulMessage(material1, 0));
@@ -495,7 +495,7 @@ public class BuildCauseProducerServiceTest {
 
         when(pipelineService.getRevisionsBasedOnDependencies(Matchers.<MaterialRevisions>any(), Matchers.<BasicCruiseConfig>any(), Matchers.<CaseInsensitiveString>any())).thenThrow(
                 new NoModificationsPresentForDependentMaterialException("P/1/S/1"));
-        when(pipelineScheduleQueue.mostRecentScheduled(pipelineName)).thenReturn(BuildCause.createNeverRun());
+        when(pipelineScheduleQueue.mostRecentScheduled(new CaseInsensitiveString(pipelineName))).thenReturn(BuildCause.createNeverRun());
         Modification modification = ModificationsMother.checkinWithComment("r", "c", new Date(), "f1");
         when(materialRepository.findLatestModification(svnMaterial)).thenReturn(ModificationsMother.createSvnMaterialWithMultipleRevisions(1, modification));
         when(materialRepository.findLatestModification(dependencyMaterial)).thenReturn(new MaterialRevisions(ModificationsMother.changedDependencyMaterialRevision("up", 1, "1", "s", 1, new Date())));

--- a/server/src/test-fast/java/com/thoughtworks/go/server/scheduling/BuildCauseProducerServiceTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/scheduling/BuildCauseProducerServiceTest.java
@@ -202,7 +202,7 @@ public class BuildCauseProducerServiceTest {
             buildCauseProducerService.manualSchedulePipeline(Username.ANONYMOUS, pipelineConfig.name(), new ScheduleOptions(), operationResult);
             fail("expected exception, got none");
         } catch (Exception e) {
-            assertThat(triggerMonitor.isAlreadyTriggered(CaseInsensitiveString.str(pipelineConfig.name())), is(false));
+            assertThat(triggerMonitor.isAlreadyTriggered(pipelineConfig.name()), is(false));
         }
     }
 
@@ -219,9 +219,9 @@ public class BuildCauseProducerServiceTest {
         when(materialRepository.findLatestModification(hgMaterial)).thenReturn(new MaterialRevisions(new MaterialRevision(hgMaterial, new ArrayList<>())));
 
         buildCauseProducerService.manualSchedulePipeline(Username.ANONYMOUS, pipelineConfig.name(), new ScheduleOptions(), new ServerHealthStateOperationResult());
-        assertThat(triggerMonitor.isAlreadyTriggered(CaseInsensitiveString.str(pipelineConfig.name())), is(true));
+        assertThat(triggerMonitor.isAlreadyTriggered(pipelineConfig.name()), is(true));
         sendMaterialUpdateCompleteMessage(extractMaterialListenerInstanceFromRegisterCall(), hgMaterial);
-        assertThat(triggerMonitor.isAlreadyTriggered(CaseInsensitiveString.str(pipelineConfig.name())), is(false));
+        assertThat(triggerMonitor.isAlreadyTriggered(pipelineConfig.name()), is(false));
     }
 
     @Test
@@ -234,7 +234,7 @@ public class BuildCauseProducerServiceTest {
 
         buildCauseProducerService.manualSchedulePipeline(Username.ANONYMOUS, pipelineConfig.name(), new ScheduleOptions(), new ServerHealthStateOperationResult());
         sendMaterialUpdateFailedMessage(extractMaterialListenerInstanceFromRegisterCall(), hgMaterial);
-        assertThat(triggerMonitor.isAlreadyTriggered(CaseInsensitiveString.str(pipelineConfig.name())), is(false));
+        assertThat(triggerMonitor.isAlreadyTriggered(pipelineConfig.name()), is(false));
     }
 
     private void sendMaterialUpdateCompleteMessage(MaterialUpdateStatusListener materialUpdateStatusListener, HgMaterial material) {

--- a/server/src/test-fast/java/com/thoughtworks/go/server/service/PipelineScheduleQueueTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/service/PipelineScheduleQueueTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2018 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.server.service;
+
+import com.thoughtworks.go.config.CaseInsensitiveString;
+import com.thoughtworks.go.domain.MaterialRevisions;
+import com.thoughtworks.go.domain.Pipeline;
+import com.thoughtworks.go.domain.Stage;
+import com.thoughtworks.go.domain.buildcause.BuildCause;
+import com.thoughtworks.go.helper.PipelineMother;
+import com.thoughtworks.go.server.domain.Username;
+import com.thoughtworks.go.server.transaction.TransactionTemplate;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.*;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+public class PipelineScheduleQueueTest {
+
+    private PipelineScheduleQueue pipelineScheduleQueue;
+
+    @Mock
+    private PipelineService pipelineService;
+    @Mock
+    private TransactionTemplate transactionTemplate;
+    @Mock
+    private InstanceFactory instanceFactory;
+
+    @Before
+    public void setUp() throws Exception {
+        initMocks(this);
+        pipelineScheduleQueue = new PipelineScheduleQueue(pipelineService, transactionTemplate, instanceFactory);
+    }
+
+    @Test
+    public void shouldConsiderPipelineNameToBeCaseInsensitiveWhileScheduling() {
+        CaseInsensitiveString pipelineName = new CaseInsensitiveString("PipelinE");
+        pipelineScheduleQueue.schedule(pipelineName, BuildCause.createWithModifications(new MaterialRevisions(), "u1"));
+        pipelineScheduleQueue.schedule(new CaseInsensitiveString(pipelineName.toLower()), BuildCause.createWithModifications(new MaterialRevisions(), "u2"));
+        pipelineScheduleQueue.schedule(new CaseInsensitiveString(pipelineName.toUpper()), BuildCause.createWithModifications(new MaterialRevisions(), "u3"));
+        assertThat(pipelineScheduleQueue.toBeScheduled().get(pipelineName), is(BuildCause.createWithModifications(new MaterialRevisions(), "u1")));
+        assertThat(pipelineScheduleQueue.toBeScheduled().size(), is(1));
+    }
+
+    @Test
+    public void shouldConsiderPipelineNameToBeCaseInsensitiveWhileCancelingAScheduledBuild() {
+        CaseInsensitiveString pipelineName = new CaseInsensitiveString("PipelinE");
+        pipelineScheduleQueue.schedule(pipelineName, BuildCause.createManualForced());
+        pipelineScheduleQueue.cancelSchedule(new CaseInsensitiveString(pipelineName.toUpper()));
+        assertTrue(pipelineScheduleQueue.toBeScheduled().isEmpty());
+
+        pipelineScheduleQueue.schedule(pipelineName, BuildCause.createManualForced());
+        pipelineScheduleQueue.cancelSchedule(new CaseInsensitiveString(pipelineName.toLower()));
+        assertTrue(pipelineScheduleQueue.toBeScheduled().isEmpty());
+    }
+
+    @Test
+    public void shouldConsiderPipelineNameToBeCaseInsensitive_FinishSchedule() {
+        CaseInsensitiveString pipelineName = new CaseInsensitiveString("PipelinE");
+        BuildCause newBuildCause = BuildCause.createManualForced(new MaterialRevisions(), new Username("u1"));
+        BuildCause originalBuildCause = BuildCause.createManualForced();
+        pipelineScheduleQueue.schedule(pipelineName, originalBuildCause);
+        pipelineScheduleQueue.finishSchedule(pipelineName, originalBuildCause, newBuildCause);
+        assertThat(pipelineScheduleQueue.hasBuildCause(pipelineName), is(false));
+        assertThat(pipelineScheduleQueue.mostRecentScheduled(pipelineName), is(newBuildCause));
+        pipelineScheduleQueue.clear();
+
+
+        pipelineScheduleQueue.schedule(pipelineName, originalBuildCause);
+        pipelineScheduleQueue.finishSchedule(new CaseInsensitiveString(pipelineName.toLower()), originalBuildCause, newBuildCause);
+        assertThat(pipelineScheduleQueue.hasBuildCause(pipelineName), is(false));
+        assertThat(pipelineScheduleQueue.mostRecentScheduled(pipelineName), is(newBuildCause));
+        pipelineScheduleQueue.clear();
+
+        pipelineScheduleQueue.schedule(pipelineName, originalBuildCause);
+        pipelineScheduleQueue.finishSchedule(new CaseInsensitiveString(pipelineName.toUpper()), originalBuildCause, newBuildCause);
+        assertThat(pipelineScheduleQueue.hasBuildCause(pipelineName), is(false));
+        assertThat(pipelineScheduleQueue.mostRecentScheduled(pipelineName), is(newBuildCause));
+        pipelineScheduleQueue.clear();
+    }
+
+    @Test
+    public void shouldConsiderPipelineNameToBeCaseInsensitiveForMostRecentScheduledToAvoidDuplicateEntriesInCache() {
+        CaseInsensitiveString pipelineName = new CaseInsensitiveString("PipelinE");
+        Pipeline pipeline = PipelineMother.pipeline(pipelineName.toString(), new Stage());
+        when(pipelineService.mostRecentFullPipelineByName(pipelineName.toString())).thenReturn(pipeline);
+
+        pipelineScheduleQueue.mostRecentScheduled(pipelineName);
+        pipelineScheduleQueue.mostRecentScheduled(new CaseInsensitiveString(pipelineName.toLower()));
+        pipelineScheduleQueue.mostRecentScheduled(new CaseInsensitiveString(pipelineName.toUpper()));
+
+        assertThat(pipelineScheduleQueue.mostRecentScheduled(pipelineName), is(pipeline.getBuildCause()));
+        verify(pipelineService).mostRecentFullPipelineByName(pipelineName.toString());
+        verifyNoMoreInteractions(pipelineService);
+    }
+}

--- a/server/src/test-fast/java/com/thoughtworks/go/server/service/ScheduleServiceTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/service/ScheduleServiceTest.java
@@ -216,8 +216,8 @@ public class ScheduleServiceTest {
         when(schedulingChecker.canAutoTriggerConsumer(pipelineConfig)).thenReturn(true);
         when(pipelineScheduleQueue.createPipeline(any(BuildCause.class), eq(pipelineConfig), any(SchedulingContext.class), eq("md5-test"), eq(timeProvider))).thenThrow(
                 new CannotScheduleException("foo", "stage-baz"));
-        final HashMap<String, BuildCause> map = new HashMap<>();
-        map.put("pipeline-quux", BuildCause.createManualForced());
+        final HashMap<CaseInsensitiveString, BuildCause> map = new HashMap<>();
+        map.put(new CaseInsensitiveString("pipeline-quux"), BuildCause.createManualForced());
         when(pipelineScheduleQueue.toBeScheduled()).thenReturn(map);
 
         service.autoSchedulePipelinesFromRequestBuffer();
@@ -237,8 +237,8 @@ public class ScheduleServiceTest {
         when(schedulingChecker.canAutoTriggerConsumer(pipelineConfig)).thenReturn(true);
         when(pipelineScheduleQueue.createPipeline(any(BuildCause.class), eq(pipelineConfig), any(SchedulingContext.class), eq("md5-test"), eq(timeProvider))).thenReturn(PipelineMother.schedule(pipelineConfig,
                 BuildCause.createManualForced(new MaterialRevisions(new MaterialRevision(new MaterialConfigConverter().toMaterial(materialConfig), ModificationsMother.aCheckIn("123", "foo.c"))), new Username(new CaseInsensitiveString("loser")))));
-        final HashMap<String, BuildCause> map = new HashMap<>();
-        map.put("pipeline-quux", BuildCause.createManualForced());
+        final HashMap<CaseInsensitiveString, BuildCause> map = new HashMap<>();
+        map.put(new CaseInsensitiveString("pipeline-quux"), BuildCause.createManualForced());
         when(pipelineScheduleQueue.toBeScheduled()).thenReturn(map);
 
         service.autoSchedulePipelinesFromRequestBuffer();

--- a/server/src/test-integration/java/com/thoughtworks/go/fixture/TwoPipelineGroups.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/fixture/TwoPipelineGroups.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 ThoughtWorks, Inc.
+ * Copyright 2018 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -56,11 +56,11 @@ public class TwoPipelineGroups implements PreCondition {
         }
     }
 
-    public String pipelineInFirstGroup() {
-        return CaseInsensitiveString.str(configHelper.currentConfig().getGroups().get(0).get(0).name());
+    public CaseInsensitiveString pipelineInFirstGroup() {
+        return configHelper.currentConfig().getGroups().get(0).get(0).name();
     }
 
-    public String pipelineInSecondGroup() {
-        return CaseInsensitiveString.str(configHelper.currentConfig().getGroups().get(1).get(0).name());
+    public CaseInsensitiveString pipelineInSecondGroup() {
+        return configHelper.currentConfig().getGroups().get(1).get(0).name();
     }
 }

--- a/server/src/test-integration/java/com/thoughtworks/go/server/scheduling/PipelineScheduleQueueIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/scheduling/PipelineScheduleQueueIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 ThoughtWorks, Inc.
+ * Copyright 2018 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -120,81 +120,88 @@ public class PipelineScheduleQueueIntegrationTest {
 
     @Test
     public void shouldReturnNullBuildCauseIfPipelineHasNoHistory() {
-        assertThat(queue.mostRecentScheduled("cruise").hasNeverRun(), is(true));
+        assertThat(queue.mostRecentScheduled(new CaseInsensitiveString("cruise")).hasNeverRun(), is(true));
     }
 
     @Test
     public void shouldReturnMostRecentScheduledBuildCauseIfExists() {
         Pipeline pipeline = fixture.createdPipelineWithAllStagesPassed();
 
-        BuildCause actual = queue.mostRecentScheduled(fixture.pipelineName);
+        BuildCause actual = queue.mostRecentScheduled(new CaseInsensitiveString(fixture.pipelineName));
         assertThat(actual, is(pipeline.getBuildCause()));
     }
 
     @Test
     public void shouldReturnToBeScheduledBuildCauseIfExists() {
-        BuildCause beforeSchedule = queue.toBeScheduled().get(fixture.pipelineName);
+        BuildCause beforeSchedule = queue.toBeScheduled().get(new CaseInsensitiveString(fixture.pipelineName));
         assertThat(beforeSchedule, is(nullValue()));
 
         BuildCause buildCause = BuildCause.createWithEmptyModifications();
-        queue.schedule(fixture.pipelineName, buildCause);
+        queue.schedule(new CaseInsensitiveString(fixture.pipelineName), buildCause);
 
-        BuildCause afterSchedule = queue.toBeScheduled().get(fixture.pipelineName);
+        BuildCause afterSchedule = queue.toBeScheduled().get(new CaseInsensitiveString(fixture.pipelineName));
         assertThat(afterSchedule, is(buildCause));
     }
 
     @Test
     public void shouldChangeToBeScheduledBuildCauseToAlreadyScheduledAfterBeenFinished() throws Exception {
         BuildCause buildCause = BuildCause.createWithEmptyModifications();
-        queue.schedule("cruise", buildCause);
+        CaseInsensitiveString cruise = new CaseInsensitiveString("cruise");
+        queue.schedule(cruise, buildCause);
 
-        queue.finishSchedule("cruise", buildCause, newCause);
+        queue.finishSchedule(cruise, buildCause, newCause);
 
-        assertThat(queue.mostRecentScheduled("cruise"), is(buildCause));
+        assertThat(queue.mostRecentScheduled(cruise), is(buildCause));
         assertThat(queue.toBeScheduled().size(), is(0));
     }
 
     @Test
     public void shouldScheduleBuildCauseConsideringPriority() throws Exception {
         BuildCause buildCause = BuildCause.createWithModifications(multipleModifications(), "");
-        queue.schedule("cruise", buildCause);
+        CaseInsensitiveString cruise = new CaseInsensitiveString("cruise");
+        queue.schedule(cruise, buildCause);
 
-        queue.schedule("cruise", BuildCause.createManualForced());
-        assertThat(queue.toBeScheduled().get("cruise").isForced(), is(true));
+        queue.schedule(cruise, BuildCause.createManualForced());
+        assertThat(queue.toBeScheduled().get(cruise).isForced(), is(true));
     }
 
     @Test
     public void shouldClearToBeScheduledIfPipelineIsDeleted() {
-        queue.schedule("cruise", BuildCause.createWithEmptyModifications());
-        queue.clearPipeline("cruise");
-        assertThat(queue.toBeScheduled().get("cruise"), is(nullValue()));
+        CaseInsensitiveString cruise = new CaseInsensitiveString("cruise");
+        queue.schedule(cruise, BuildCause.createWithEmptyModifications());
+        queue.clearPipeline(cruise);
+        assertThat(queue.toBeScheduled().get(cruise), is(nullValue()));
     }
 
     @Test
     public void shouldClearMostRecentScheduledIfPipelineIsDeleted() {
         BuildCause buildCause = BuildCause.createWithEmptyModifications();
-        queue.schedule("cruise", buildCause);
-        queue.finishSchedule("cruise", buildCause, newCause);
-        queue.clearPipeline("cruise");
-        assertThat(queue.mostRecentScheduled("cruise").hasNeverRun(), is(true));
+        CaseInsensitiveString cruise = new CaseInsensitiveString("cruise");
+        queue.schedule(cruise, buildCause);
+        queue.finishSchedule(cruise, buildCause, newCause);
+        queue.clearPipeline(cruise);
+        assertThat(queue.mostRecentScheduled(cruise).hasNeverRun(), is(true));
     }
 
     @Test
     public void shouldReturnFalseIfThereIsBuildCauseWithoutModifications() throws Exception {
-        queue.schedule("cruise", BuildCause.createWithEmptyModifications());
-        assertThat(queue.hasBuildCause("cruise"), is(false));
+        CaseInsensitiveString cruise = new CaseInsensitiveString("cruise");
+        queue.schedule(cruise, BuildCause.createWithEmptyModifications());
+        assertThat(queue.hasBuildCause(cruise), is(false));
     }
 
     @Test
     public void shouldReturnFalseIfThereIsBuildCause() throws Exception {
-        queue.schedule("cruise", BuildCause.createWithModifications(multipleModifications(), ""));
-        assertThat(queue.hasBuildCause("cruise"), is(true));
+        CaseInsensitiveString cruise = new CaseInsensitiveString("cruise");
+        queue.schedule(cruise, BuildCause.createWithModifications(multipleModifications(), ""));
+        assertThat(queue.hasBuildCause(cruise), is(true));
     }
 
     @Test
     public void shouldReturnTrueIfThereIsForcedBuildCause() throws Exception {
-        queue.schedule("cruise", BuildCause.createManualForced());
-        assertThat(queue.hasForcedBuildCause("cruise"), is(true));
+        CaseInsensitiveString cruise = new CaseInsensitiveString("cruise");
+        queue.schedule(cruise, BuildCause.createManualForced());
+        assertThat(queue.hasForcedBuildCause(cruise), is(true));
     }
 
     @Test
@@ -202,7 +209,7 @@ public class PipelineScheduleQueueIntegrationTest {
         PipelineConfig pipelineConfig = fixture.pipelineConfig();
         BuildCause cause = modifySomeFiles(pipelineConfig);
         saveRev(cause);
-        queue.schedule(fixture.pipelineName, cause);
+        queue.schedule(new CaseInsensitiveString(fixture.pipelineName), cause);
 
         assertThat(queue.createPipeline(cause, pipelineConfig, new DefaultSchedulingContext(cause.getApprover(), new Agents()), "md5-test", new TimeProvider()), is(not(nullValue())));
     }
@@ -221,7 +228,7 @@ public class PipelineScheduleQueueIntegrationTest {
         PipelineConfig pipelineConfig = fixture.pipelineConfig();
         BuildCause cause = modifySomeFilesAndTriggerAs(pipelineConfig, "cruise-developer");
         saveRev(cause);
-        queue.schedule(fixture.pipelineName, cause);
+        queue.schedule(new CaseInsensitiveString(fixture.pipelineName), cause);
 
         Pipeline pipeline = queue.createPipeline(cause, pipelineConfig, new DefaultSchedulingContext(cause.getApprover(), new Agents()), "md5-test", new TimeProvider());
         Stage stage = pipeline.getStages().first();
@@ -232,8 +239,8 @@ public class PipelineScheduleQueueIntegrationTest {
     public void shouldReturnNullIfBuildCauseIsTrumped() throws Exception {
         PipelineConfig pipelineConfig = fixture.pipelineConfig();
         BuildCause cause = modifySomeFiles(pipelineConfig, ModificationsMother.currentRevision());
-        queue.schedule(fixture.pipelineName, cause);
-        queue.finishSchedule(fixture.pipelineName, cause, cause);
+        queue.schedule(new CaseInsensitiveString(fixture.pipelineName), cause);
+        queue.finishSchedule(new CaseInsensitiveString(fixture.pipelineName), cause, cause);
 
         assertThat(queue.createPipeline(cause, pipelineConfig, new DefaultSchedulingContext(cause.getApprover(), new Agents()), "md5-test", new TimeProvider()), is(nullValue()));
     }
@@ -242,25 +249,26 @@ public class PipelineScheduleQueueIntegrationTest {
     public void shouldBeCanceledWhenSameBuildCause() throws Exception {
         PipelineConfig pipelineConfig = fixture.pipelineConfig();
         BuildCause cause = modifySomeFiles(pipelineConfig, ModificationsMother.currentRevision());
-        queue.finishSchedule(fixture.pipelineName, cause, cause);
-        queue.schedule(fixture.pipelineName, cause);
+        queue.finishSchedule(new CaseInsensitiveString(fixture.pipelineName), cause, cause);
+        queue.schedule(new CaseInsensitiveString(fixture.pipelineName), cause);
 
-        assertThat(fixture.pipelineName, is(scheduledOn(queue)));
+        assertThat(new CaseInsensitiveString(fixture.pipelineName), is(scheduledOn(queue)));
         assertThat(queue.createPipeline(cause, pipelineConfig, new DefaultSchedulingContext(cause.getApprover(), new Agents()), "md5-test", new TimeProvider()), is(nullValue()));
-        assertThat(fixture.pipelineName, is(not(scheduledOn(queue))));
+        assertThat(new CaseInsensitiveString(fixture.pipelineName), is(not(scheduledOn(queue))));
     }
 
     @Test
     public void shouldFinishSchedule() throws Exception {
         PipelineConfig pipelineConfig = fixture.pipelineConfig();
         BuildCause cause = modifySomeFiles(pipelineConfig, ModificationsMother.currentRevision());
-        queue.schedule(fixture.pipelineName, cause);
+        CaseInsensitiveString pipelineName = new CaseInsensitiveString(fixture.pipelineName);
+        queue.schedule(pipelineName, cause);
 
         BuildCause newCause = modifySomeFiles(pipelineConfig, "somethingElse");
-        queue.finishSchedule(fixture.pipelineName, cause, newCause);
+        queue.finishSchedule(pipelineName, cause, newCause);
 
-        assertThat(queue.hasBuildCause(fixture.pipelineName), is(false));
-        assertThat(queue.mostRecentScheduled(fixture.pipelineName), is(newCause));
+        assertThat(queue.hasBuildCause(pipelineName), is(false));
+        assertThat(queue.mostRecentScheduled(pipelineName), is(newCause));
     }
 
     @Test
@@ -268,20 +276,21 @@ public class PipelineScheduleQueueIntegrationTest {
         PipelineConfig pipelineConfig = fixture.pipelineConfig();
         BuildCause cause = forceBuild(pipelineConfig);
         saveRev(cause);
+        CaseInsensitiveString pipelineName = new CaseInsensitiveString(fixture.pipelineName);
 
-        queue.finishSchedule(fixture.pipelineName, cause, newCause);
-        queue.schedule(fixture.pipelineName, cause);
+        queue.finishSchedule(pipelineName, cause, newCause);
+        queue.schedule(pipelineName, cause);
 
         assertThat(pipelineDao.mostRecentLabel(fixture.pipelineName), is(nullValue()));
 
-        assertThat(fixture.pipelineName, is(scheduledOn(queue)));
+        assertThat(new CaseInsensitiveString(fixture.pipelineName), is(scheduledOn(queue)));
         assertThat(queue.createPipeline(cause, pipelineConfig, new DefaultSchedulingContext(cause.getApprover(), new Agents()), "md5-test", new TimeProvider()), is(not(nullValue())));
         assertThat(pipelineDao.mostRecentLabel(fixture.pipelineName), is("label-1"));
     }
 
-    private TypeSafeMatcher<String> scheduledOn(final PipelineScheduleQueue queue) {
-        return new TypeSafeMatcher<String>() {
-            public boolean matchesSafely(String item) {
+    private TypeSafeMatcher<CaseInsensitiveString> scheduledOn(final PipelineScheduleQueue queue) {
+        return new TypeSafeMatcher<CaseInsensitiveString>() {
+            public boolean matchesSafely(CaseInsensitiveString item) {
                 return queue.toBeScheduled().containsKey(item);
             }
 
@@ -412,7 +421,7 @@ public class PipelineScheduleQueueIntegrationTest {
         environmentVariables.add(new EnvironmentVariable("blahVariable", "blahOverride"));
         cause.addOverriddenVariables(environmentVariables);
         saveRev(cause);
-        queue.schedule(fixture.pipelineName, cause);
+        queue.schedule(new CaseInsensitiveString(fixture.pipelineName), cause);
         Pipeline pipeline = queue.createPipeline(cause, pipelineConfig, new DefaultSchedulingContext(cause.getApprover(), new Agents()), "md5-test", new TimeProvider());
         assertThat(pipeline.scheduleTimeVariables(), is(new EnvironmentVariables(Arrays.asList(new EnvironmentVariable("blahVariable", "blahOverride")))));
     }
@@ -426,7 +435,7 @@ public class PipelineScheduleQueueIntegrationTest {
         cause.addOverriddenVariables(environmentVariables
         );
         saveRev(cause);
-        queue.schedule(fixture.pipelineName, cause);
+        queue.schedule(new CaseInsensitiveString(fixture.pipelineName), cause);
         Pipeline pipeline = queue.createPipeline(cause, pipelineConfig, new DefaultSchedulingContext(cause.getApprover(), new Agents()), "md5-test", new TimeProvider());
         assertThat(pipeline.getFirstStage().getConfigVersion(), is("md5-test"));
     }
@@ -441,7 +450,7 @@ public class PipelineScheduleQueueIntegrationTest {
         pipelineConfig.setOrigins(new RepoConfigOrigin(
                 new ConfigRepoConfig(materialConfig, "123"), "plug"));
         saveRev(cause);
-        queue.schedule(fixture.pipelineName, cause);
+        queue.schedule(new CaseInsensitiveString(fixture.pipelineName), cause);
         Pipeline pipeline = queue.createPipeline(cause, pipelineConfig, new DefaultSchedulingContext(cause.getApprover(), new Agents()), "md5-test", new TimeProvider());
         assertThat(pipeline, is(nullValue()));
     }

--- a/server/src/test-integration/java/com/thoughtworks/go/server/scheduling/ScheduleHelper.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/scheduling/ScheduleHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 ThoughtWorks, Inc.
+ * Copyright 2018 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -112,9 +112,9 @@ public class ScheduleHelper {
         return result.getServerHealthState();
     }
 
-    public Map<String, BuildCause> waitForAnyScheduled(int seconds) {
+    public Map<CaseInsensitiveString, BuildCause> waitForAnyScheduled(int seconds) {
         int count = 0;
-        Map<String, BuildCause> afterLoad = pipelineScheduleQueue.toBeScheduled();
+        Map<CaseInsensitiveString, BuildCause> afterLoad = pipelineScheduleQueue.toBeScheduled();
         while (afterLoad.isEmpty()) {
             try {
                 Thread.sleep(1000);
@@ -130,19 +130,18 @@ public class ScheduleHelper {
     }
     public void waitForNotScheduled(int seconds,String pipelineName) {
         int count = 0;
-        Map<String, BuildCause> afterLoad = pipelineScheduleQueue.toBeScheduled();
         while (true) {
             try {
                 Thread.sleep(1000);
             } catch (InterruptedException e) {
                 throw new RuntimeException(e);
             }
-            afterLoad = pipelineScheduleQueue.toBeScheduled();
+            Map<CaseInsensitiveString, BuildCause> afterLoad = pipelineScheduleQueue.toBeScheduled();
             if (count++ > seconds) {
                 return ;
             }
 
-            BuildCause cause = afterLoad.get(pipelineName);
+            BuildCause cause = afterLoad.get(new CaseInsensitiveString(pipelineName));
             assertNull(cause);
         }
     }

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/AutoSchedulerIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/AutoSchedulerIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 ThoughtWorks, Inc.
+ * Copyright 2018 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package com.thoughtworks.go.server.service;
 
+import com.thoughtworks.go.config.CaseInsensitiveString;
 import com.thoughtworks.go.config.GoConfigDao;
 import com.thoughtworks.go.fixture.ArtifactsDiskIsFull;
 import com.thoughtworks.go.fixture.ConfigWithFreeEditionLicense;
@@ -88,7 +89,7 @@ public class AutoSchedulerIntegrationTest {
 
     @Test
     public void shouldProduceBuildCauseForFirstGroupPipeline() throws Exception {
-        scheduleHelper.autoSchedulePipelinesWithRealMaterials(twoPipelineGroups.pipelineInFirstGroup());
+        scheduleHelper.autoSchedulePipelinesWithRealMaterials(CaseInsensitiveString.str(twoPipelineGroups.pipelineInFirstGroup()));
         assertThat(pipelineScheduleQueue.hasBuildCause(twoPipelineGroups.pipelineInFirstGroup()), is(true));
     }
 

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/BuildAssignmentServiceIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/BuildAssignmentServiceIntegrationTest.java
@@ -687,7 +687,7 @@ public class BuildAssignmentServiceIntegrationTest {
 
         ScheduleTestUtil.AddedPipeline p1 = u.saveConfigWith("PIPELINE_WHICH_WILL_EVENTUALLY_CHANGE_CASE", u.m(hgMaterial));
         BuildCause buildCause = BuildCause.createWithModifications(u.mrs(u.mr(u.m(hgMaterial).material, true, hgRevs)), "user");
-        Pipeline originalPipelineRun = scheduleService.schedulePipeline(p1.config.name().toString(), buildCause);
+        Pipeline originalPipelineRun = scheduleService.schedulePipeline(p1.config.name(), buildCause);
         ScheduleTestUtil.AddedPipeline renamedPipeline = u.renamePipelineAndFirstStage(p1, "pipeline_which_will_eventually_change_case", "NEW_RANDOM_STAGE_NAME" + UUID.randomUUID());
 
         CruiseConfig cruiseConfig = configHelper.load();
@@ -698,7 +698,7 @@ public class BuildAssignmentServiceIntegrationTest {
 
         u.checkinInOrder(hgMaterial, "h2");
         BuildCause buildCauseForRenamedPipeline = BuildCause.createWithModifications(u.mrs(u.mr(u.m(hgMaterial).material, true, "h2")), "user");
-        Pipeline p1_2 = scheduleService.schedulePipeline(renamedPipeline.config.name().toString(), buildCauseForRenamedPipeline);
+        Pipeline p1_2 = scheduleService.schedulePipeline(renamedPipeline.config.name(), buildCauseForRenamedPipeline);
         Stages allStagesForRenamedPipeline = stageDao.findAllStagesFor(p1_2.getName(), p1_2.getCounter());
         assertThat(allStagesForRenamedPipeline.byName(p1_2.getFirstStage().getName()).getState(), is(StageState.Building));
     }
@@ -711,7 +711,7 @@ public class BuildAssignmentServiceIntegrationTest {
 
         ScheduleTestUtil.AddedPipeline p1 = u.saveConfigWith("ANOTHER_PIPELINE_WHICH_WILL_EVENTUALLY_CHANGE_CASE", "STAGE_WHICH_WILL_EVENTUALLY_CHANGE_CASE",  u.m(hgMaterial));
         BuildCause buildCause = BuildCause.createWithModifications(u.mrs(u.mr(u.m(hgMaterial).material, true, hgRevs)), "user");
-        Pipeline originalPipelineRun = scheduleService.schedulePipeline(p1.config.name().toString(), buildCause);
+        Pipeline originalPipelineRun = scheduleService.schedulePipeline(p1.config.name(), buildCause);
         ScheduleTestUtil.AddedPipeline renamedPipeline = u.renamePipelineAndFirstStage(p1, p1.config.name().toLower(), p1.config.getStages().first().name().toLower());
         CruiseConfig cruiseConfig = configHelper.load();
         buildAssignmentService.onTimer();   // To Reload Job Plans
@@ -722,7 +722,7 @@ public class BuildAssignmentServiceIntegrationTest {
 
         u.checkinInOrder(hgMaterial, "h2");
         BuildCause buildCauseForRenamedPipeline = BuildCause.createWithModifications(u.mrs(u.mr(u.m(hgMaterial).material, true, "h2")), "user");
-        Pipeline p1_2 = scheduleService.schedulePipeline(renamedPipeline.config.name().toString(), buildCauseForRenamedPipeline);
+        Pipeline p1_2 = scheduleService.schedulePipeline(renamedPipeline.config.name(), buildCauseForRenamedPipeline);
         assertThat(p1_2, is(nullValue()));
     }
 

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/BuildCauseProducerServiceConfigRepoIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/BuildCauseProducerServiceConfigRepoIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 ThoughtWorks, Inc.
+ * Copyright 2018 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -204,9 +204,9 @@ public class BuildCauseProducerServiceConfigRepoIntegrationTest {
         buildCauseProducer.manualProduceBuildCauseAndSave(PIPELINE_NAME, Username.ANONYMOUS,
                 new ScheduleOptions(revisions, environmentVariables, new HashMap<>()), new ServerHealthStateOperationResult());
 
-        Map<String, BuildCause> afterLoad = scheduleHelper.waitForAnyScheduled(5);
-        assertThat(afterLoad.keySet(), hasItem(PIPELINE_NAME));
-        BuildCause cause = afterLoad.get(PIPELINE_NAME);
+        Map<CaseInsensitiveString, BuildCause> afterLoad = scheduleHelper.waitForAnyScheduled(5);
+        assertThat(afterLoad.keySet(), hasItem(new CaseInsensitiveString(PIPELINE_NAME)));
+        BuildCause cause = afterLoad.get(new CaseInsensitiveString(PIPELINE_NAME));
         assertThat(cause.getBuildCauseMessage(), containsString("Forced by anonymous"));
     }
 
@@ -217,7 +217,7 @@ public class BuildCauseProducerServiceConfigRepoIntegrationTest {
         waitForMaterialNotInProgress();
 
         buildCauseProducerService.autoSchedulePipeline(PIPELINE_NAME,new ServerHealthStateOperationResult(),123);
-        assertThat(scheduleHelper.waitForAnyScheduled(5).keySet(), hasItem(PIPELINE_NAME));
+        assertThat(scheduleHelper.waitForAnyScheduled(5).keySet(), hasItem(new CaseInsensitiveString(PIPELINE_NAME)));
     }
 
     @Test
@@ -245,9 +245,9 @@ public class BuildCauseProducerServiceConfigRepoIntegrationTest {
         buildCauseProducer.manualProduceBuildCauseAndSave(PIPELINE_NAME, Username.ANONYMOUS,
                 new ScheduleOptions(revisions, environmentVariables, new HashMap<>()), new ServerHealthStateOperationResult());
 
-        Map<String, BuildCause> afterLoad = scheduleHelper.waitForAnyScheduled(5);
-        assertThat(afterLoad.keySet(), hasItem(PIPELINE_NAME));
-        BuildCause cause = afterLoad.get(PIPELINE_NAME);
+        Map<CaseInsensitiveString, BuildCause> afterLoad = scheduleHelper.waitForAnyScheduled(5);
+        assertThat(afterLoad.keySet(), hasItem(new CaseInsensitiveString(PIPELINE_NAME)));
+        BuildCause cause = afterLoad.get(new CaseInsensitiveString(PIPELINE_NAME));
         assertThat(cause.getBuildCauseMessage(), containsString("Forced by anonymous"));
 
         PipelineConfig pipelineConfigAfterSchedule = goConfigService.pipelineConfigNamed(pipelineConfig.name());
@@ -291,9 +291,9 @@ public class BuildCauseProducerServiceConfigRepoIntegrationTest {
         buildCauseProducer.manualProduceBuildCauseAndSave(PIPELINE_NAME, Username.ANONYMOUS,
                 new ScheduleOptions(revisions, environmentVariables, new HashMap<>()), new ServerHealthStateOperationResult());
 
-        Map<String, BuildCause> afterLoad = scheduleHelper.waitForAnyScheduled(5);
-        assertThat(afterLoad.keySet(), hasItem(PIPELINE_NAME));
-        BuildCause cause = afterLoad.get(PIPELINE_NAME);
+        Map<CaseInsensitiveString, BuildCause> afterLoad = scheduleHelper.waitForAnyScheduled(5);
+        assertThat(afterLoad.keySet(), hasItem(new CaseInsensitiveString(PIPELINE_NAME)));
+        BuildCause cause = afterLoad.get(new CaseInsensitiveString(PIPELINE_NAME));
         assertThat(cause.getBuildCauseMessage(), containsString("Forced by anonymous"));
 
         assertThat("buildCauseRevisionShouldMatchLastPushedCommit",
@@ -316,9 +316,9 @@ public class BuildCauseProducerServiceConfigRepoIntegrationTest {
         buildCauseProducer.manualProduceBuildCauseAndSave(PIPELINE_NAME, Username.ANONYMOUS,
                 new ScheduleOptions(revisions, environmentVariables, new HashMap<>()), new ServerHealthStateOperationResult());
 
-        Map<String, BuildCause> afterLoad = scheduleHelper.waitForAnyScheduled(5);
-        assertThat(afterLoad.keySet(), hasItem(PIPELINE_NAME));
-        BuildCause cause = afterLoad.get(PIPELINE_NAME);
+        Map<CaseInsensitiveString, BuildCause> afterLoad = scheduleHelper.waitForAnyScheduled(5);
+        assertThat(afterLoad.keySet(), hasItem(new CaseInsensitiveString(PIPELINE_NAME)));
+        BuildCause cause = afterLoad.get(new CaseInsensitiveString(PIPELINE_NAME));
         assertThat(cause.getBuildCauseMessage(), containsString("Forced by anonymous"));
 
         PipelineConfig pipelineConfigAfterSchedule = goConfigService.pipelineConfigNamed(pipelineConfig.name());
@@ -346,7 +346,7 @@ public class BuildCauseProducerServiceConfigRepoIntegrationTest {
         waitForMaterialNotInProgress();
         // config is correct
         cachedGoConfig.throwExceptionIfExists();
-        assertThat(pipelineScheduleQueue.toBeScheduled().keySet(), IsNot.not(hasItem(PIPELINE_NAME)));
+        assertThat(pipelineScheduleQueue.toBeScheduled().keySet(), IsNot.not(hasItem(new CaseInsensitiveString(PIPELINE_NAME))));
         assertThat(goConfigService.hasPipelineNamed(pipelineConfig.name()),is(false));
     }
 
@@ -376,9 +376,9 @@ public class BuildCauseProducerServiceConfigRepoIntegrationTest {
                 new ScheduleOptions(revisions, environmentVariables, new HashMap<>()), new ServerHealthStateOperationResult());
         cachedGoConfig.throwExceptionIfExists();
 
-        Map<String, BuildCause> afterLoad = scheduleHelper.waitForAnyScheduled(20);
-        assertThat(afterLoad.keySet(), hasItem(PIPELINE_NAME));
-        BuildCause cause = afterLoad.get(PIPELINE_NAME);
+        Map<CaseInsensitiveString, BuildCause> afterLoad = scheduleHelper.waitForAnyScheduled(20);
+        assertThat(afterLoad.keySet(), hasItem(new CaseInsensitiveString(PIPELINE_NAME)));
+        BuildCause cause = afterLoad.get(new CaseInsensitiveString(PIPELINE_NAME));
         assertThat(cause.getBuildCauseMessage(), containsString("Forced by anonymous"));
 
         PipelineConfig pipelineConfigAfterSchedule = goConfigService.pipelineConfigNamed(pipelineConfig.name());
@@ -411,9 +411,9 @@ public class BuildCauseProducerServiceConfigRepoIntegrationTest {
                 new ScheduleOptions(revisions, environmentVariables, new HashMap<>()), new ServerHealthStateOperationResult());
         cachedGoConfig.throwExceptionIfExists();
 
-        Map<String, BuildCause> afterLoad = scheduleHelper.waitForAnyScheduled(5);
-        assertThat(afterLoad.keySet(), hasItem(PIPELINE_NAME));
-        BuildCause cause = afterLoad.get(PIPELINE_NAME);
+        Map<CaseInsensitiveString, BuildCause> afterLoad = scheduleHelper.waitForAnyScheduled(5);
+        assertThat(afterLoad.keySet(), hasItem(new CaseInsensitiveString(PIPELINE_NAME)));
+        BuildCause cause = afterLoad.get(new CaseInsensitiveString(PIPELINE_NAME));
         assertThat(cause.getBuildCauseMessage(), containsString("Forced by anonymous"));
 
         List<Modification> secondBuildModifications = configTestRepo.addCodeToRepositoryAndPush("a.java", "added second code file", "some java code");
@@ -431,8 +431,8 @@ public class BuildCauseProducerServiceConfigRepoIntegrationTest {
         cachedGoConfig.throwExceptionIfExists();
 
         afterLoad = scheduleHelper.waitForAnyScheduled(5);
-        assertThat(afterLoad.keySet(), hasItem(PIPELINE_NAME));
-        cause = afterLoad.get(PIPELINE_NAME);
+        assertThat(afterLoad.keySet(), hasItem(new CaseInsensitiveString(PIPELINE_NAME)));
+        cause = afterLoad.get(new CaseInsensitiveString(PIPELINE_NAME));
         assertThat(cause.getBuildCauseMessage(), containsString("Forced by Admin"));
 
         PipelineConfig pipelineConfigAfterSchedule = goConfigService.pipelineConfigNamed(pipelineConfig.name());
@@ -470,9 +470,9 @@ public class BuildCauseProducerServiceConfigRepoIntegrationTest {
                 new ScheduleOptions(revisions, environmentVariables, new HashMap<>()), new ServerHealthStateOperationResult());
         cachedGoConfig.throwExceptionIfExists();
 
-        Map<String, BuildCause> afterLoad = scheduleHelper.waitForAnyScheduled(5);
-        assertThat(afterLoad.keySet(), hasItem(PIPELINE_NAME));
-        BuildCause cause = afterLoad.get(PIPELINE_NAME);
+        Map<CaseInsensitiveString, BuildCause> afterLoad = scheduleHelper.waitForAnyScheduled(5);
+        assertThat(afterLoad.keySet(), hasItem(new CaseInsensitiveString(PIPELINE_NAME)));
+        BuildCause cause = afterLoad.get(new CaseInsensitiveString(PIPELINE_NAME));
         assertThat(cause.getBuildCauseMessage(), containsString("Forced by anonymous"));
 
         List<Modification> secondBuildModifications = configTestRepo.addCodeToRepositoryAndPush("a.java", "added code file", "some java code");
@@ -489,8 +489,8 @@ public class BuildCauseProducerServiceConfigRepoIntegrationTest {
         cachedGoConfig.throwExceptionIfExists();
 
         afterLoad = scheduleHelper.waitForAnyScheduled(5);
-        assertThat(afterLoad.keySet(), hasItem(PIPELINE_NAME));
-        cause = afterLoad.get(PIPELINE_NAME);
+        assertThat(afterLoad.keySet(), hasItem(new CaseInsensitiveString(PIPELINE_NAME)));
+        cause = afterLoad.get(new CaseInsensitiveString(PIPELINE_NAME));
         assertThat(cause.getBuildCauseMessage(), containsString("Forced by Admin"));
 
         PipelineConfig pipelineConfigAfterSchedule = goConfigService.pipelineConfigNamed(pipelineConfig.name());

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/BuildCauseProducerServiceIntegrationHgTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/BuildCauseProducerServiceIntegrationHgTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 ThoughtWorks, Inc.
+ * Copyright 2018 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package com.thoughtworks.go.server.service;
 
+import com.thoughtworks.go.config.CaseInsensitiveString;
 import com.thoughtworks.go.config.GoConfigDao;
 import com.thoughtworks.go.config.PipelineConfig;
 import com.thoughtworks.go.config.materials.Filter;
@@ -120,11 +121,11 @@ public class BuildCauseProducerServiceIntegrationHgTest {
                 "helper/topics/upgrading_go.xml",
                 "helper/topics/whats_new_in_go.xml");
 
-        Map<String, BuildCause> beforeLoad = pipelineScheduleQueue.toBeScheduled();
+        Map<CaseInsensitiveString, BuildCause> beforeLoad = pipelineScheduleQueue.toBeScheduled();
 
         scheduleHelper.autoSchedulePipelinesWithRealMaterials();
 
-        Map<String, BuildCause> afterLoad = pipelineScheduleQueue.toBeScheduled();
+        Map<CaseInsensitiveString, BuildCause> afterLoad = pipelineScheduleQueue.toBeScheduled();
         assertThat(afterLoad.size(), is(beforeLoad.size()));
 
     }

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/BuildCauseProducerServiceIntegrationSvnTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/BuildCauseProducerServiceIntegrationSvnTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 ThoughtWorks, Inc.
+ * Copyright 2018 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -118,7 +118,7 @@ public class BuildCauseProducerServiceIntegrationSvnTest {
 
         assertThat(result.canContinue(), is(true));
 
-        BuildCause mingleBuildCause = pipelineScheduleQueue.toBeScheduled().get(CaseInsensitiveString.str(mingleConfig.name()));
+        BuildCause mingleBuildCause = pipelineScheduleQueue.toBeScheduled().get(mingleConfig.name());
 
         MaterialRevisions materialRevisions = mingleBuildCause.getMaterialRevisions();
         assertThat(materialRevisions.getRevisions().size(), is(1));
@@ -141,7 +141,7 @@ public class BuildCauseProducerServiceIntegrationSvnTest {
 
         assertThat(result.canContinue(), is(true));
 
-        BuildCause mingleBuildCause = pipelineScheduleQueue.toBeScheduled().get(CaseInsensitiveString.str(mingleConfig.name()));
+        BuildCause mingleBuildCause = pipelineScheduleQueue.toBeScheduled().get(mingleConfig.name());
 
         MaterialRevisions materialRevisions = mingleBuildCause.getMaterialRevisions();
         assertThat(materialRevisions.getRevisions().size(), is(2));

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/BuildCauseProducerServiceIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/BuildCauseProducerServiceIntegrationTest.java
@@ -447,7 +447,7 @@ public class BuildCauseProducerServiceIntegrationTest {
         assertThat(result.isSuccess(), is(true));
         assertThat(result.message(), is(String.format("Request to schedule pipeline %s accepted", manualTriggerPipeline.name())));
         assertThat(materialUpdateStatusNotifier.hasListenerFor(manualTriggerPipeline), is(false));
-        assertThat(triggerMonitor.isAlreadyTriggered(manualTriggerPipeline.name().toString()), Is.is(false));
+        assertThat(triggerMonitor.isAlreadyTriggered(manualTriggerPipeline.name()), Is.is(false));
 
         BuildCause buildCause = pipelineScheduleQueue.toBeScheduled().get(manualTriggerPipeline.name());
         assertNotNull(buildCause);
@@ -479,7 +479,7 @@ public class BuildCauseProducerServiceIntegrationTest {
         assertMDUPendingForMaterial(remotePipeline, configRepoMaterial);
         assertMDUNotPendingForMaterial(remotePipeline, svn);
         assertMDUNotPendingForMaterial(remotePipeline, git);
-        assertThat(triggerMonitor.isAlreadyTriggered(remotePipeline.name().toString()), Is.is(true));
+        assertThat(triggerMonitor.isAlreadyTriggered(remotePipeline.name()), Is.is(true));
         BuildCause buildCause = pipelineScheduleQueue.toBeScheduled().get(remotePipeline.name().toString());
         assertNull(buildCause);
     }
@@ -493,7 +493,7 @@ public class BuildCauseProducerServiceIntegrationTest {
         assertMDUPendingForMaterial(manualTriggerPipeline, materialForManualTriggerPipeline);
         assertThat(result.isSuccess(), is(true));
         assertThat(result.message(), is(String.format("Request to schedule pipeline %s accepted", manualTriggerPipeline.name())));
-        assertThat(triggerMonitor.isAlreadyTriggered(manualTriggerPipeline.name().toString()), Is.is(true));
+        assertThat(triggerMonitor.isAlreadyTriggered(manualTriggerPipeline.name()), Is.is(true));
         BuildCause buildCause = pipelineScheduleQueue.toBeScheduled().get(manualTriggerPipeline.name().toString());
         assertNull(buildCause);
     }

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/BuildCauseProducerServiceIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/BuildCauseProducerServiceIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 ThoughtWorks, Inc.
+ * Copyright 2018 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -209,14 +209,14 @@ public class BuildCauseProducerServiceIntegrationTest {
         String ignoredFile = "a.doc";
         svnRepository.checkInOneFile(ignoredFile);
         scheduleHelper.autoSchedulePipelinesWithRealMaterials(MINGLE_PIPELINE_NAME);
-        assertThat(pipelineScheduleQueue.toBeScheduled().keySet(), not(hasItem(MINGLE_PIPELINE_NAME)));
+        assertThat(pipelineScheduleQueue.toBeScheduled().keySet(), not(hasItem(new CaseInsensitiveString(MINGLE_PIPELINE_NAME))));
     }
 
     @Test
     public void shouldSchedulePipeline() throws Exception {
         checkinFile(SvnMaterial.createSvnMaterialWithMock(repository), "a.java", svnRepository);
         scheduleHelper.autoSchedulePipelinesWithRealMaterials(MINGLE_PIPELINE_NAME);
-        assertThat(pipelineScheduleQueue.toBeScheduled().keySet(), hasItem(MINGLE_PIPELINE_NAME));
+        assertThat(pipelineScheduleQueue.toBeScheduled().keySet(), hasItem(new CaseInsensitiveString(MINGLE_PIPELINE_NAME)));
     }
 
     @Test
@@ -227,7 +227,7 @@ public class BuildCauseProducerServiceIntegrationTest {
         configHelper.addMaterialToPipeline(GO_PIPELINE_NAME, new DependencyMaterialConfig(new CaseInsensitiveString(GO_PIPELINE_UPSTREAM), new CaseInsensitiveString(STAGE_NAME)));
         svnRepository.checkInOneFile("a.java");
         scheduleHelper.autoSchedulePipelinesWithRealMaterials(GO_PIPELINE_NAME);
-        assertThat(pipelineScheduleQueue.toBeScheduled().keySet(), not(hasItem(GO_PIPELINE_NAME)));
+        assertThat(pipelineScheduleQueue.toBeScheduled().keySet(), not(hasItem(new CaseInsensitiveString(GO_PIPELINE_NAME))));
     }
 
 
@@ -236,7 +236,7 @@ public class BuildCauseProducerServiceIntegrationTest {
         configHelper.configureStageAsManualApproval(MINGLE_PIPELINE_NAME, STAGE_NAME);
         svnRepository.checkInOneFile("a.java");
         scheduleHelper.autoSchedulePipelinesWithRealMaterials(MINGLE_PIPELINE_NAME);
-        assertThat(pipelineScheduleQueue.toBeScheduled().keySet(), not(hasItem(MINGLE_PIPELINE_NAME)));
+        assertThat(pipelineScheduleQueue.toBeScheduled().keySet(), not(hasItem(new CaseInsensitiveString(MINGLE_PIPELINE_NAME))));
     }
 
     @Test
@@ -250,9 +250,9 @@ public class BuildCauseProducerServiceIntegrationTest {
         final HashMap<String, String> environmentVariables = new HashMap<>();
         buildCauseProducer.manualProduceBuildCauseAndSave(MINGLE_PIPELINE_NAME, Username.ANONYMOUS, new ScheduleOptions(revisions, environmentVariables, new HashMap<>()), new ServerHealthStateOperationResult());
 
-        Map<String, BuildCause> afterLoad = scheduleHelper.waitForAnyScheduled(5);
-        assertThat(afterLoad.keySet(), hasItem(MINGLE_PIPELINE_NAME));
-        BuildCause cause = afterLoad.get(MINGLE_PIPELINE_NAME);
+        Map<CaseInsensitiveString, BuildCause> afterLoad = scheduleHelper.waitForAnyScheduled(5);
+        assertThat(afterLoad.keySet(), hasItem(new CaseInsensitiveString(MINGLE_PIPELINE_NAME)));
+        BuildCause cause = afterLoad.get(new CaseInsensitiveString(MINGLE_PIPELINE_NAME));
         assertThat(cause.getBuildCauseMessage(), containsString("Forced by anonymous"));
     }
 
@@ -262,7 +262,7 @@ public class BuildCauseProducerServiceIntegrationTest {
         final HashMap<String, String> environmentVariables = new HashMap<>();
         buildCauseProducer.manualProduceBuildCauseAndSave(MINGLE_PIPELINE_NAME, Username.ANONYMOUS, new ScheduleOptions(revisions, environmentVariables, new HashMap<>()),
                 new ServerHealthStateOperationResult());
-        assertThat(scheduleHelper.waitForAnyScheduled(5).keySet(), hasItem(MINGLE_PIPELINE_NAME));
+        assertThat(scheduleHelper.waitForAnyScheduled(5).keySet(), hasItem(new CaseInsensitiveString(MINGLE_PIPELINE_NAME)));
     }
 
     @Test
@@ -273,7 +273,7 @@ public class BuildCauseProducerServiceIntegrationTest {
 
         assertThat(serverHealthService.getLogsAsText(),
                 containsString("GoCD Server has run out of artifacts disk space. Scheduling has been stopped"));
-        assertThat(pipelineScheduleQueue.toBeScheduled().keySet(), not(hasItem(MINGLE_PIPELINE_NAME)));
+        assertThat(pipelineScheduleQueue.toBeScheduled().keySet(), not(hasItem(new CaseInsensitiveString(MINGLE_PIPELINE_NAME))));
     }
 
     @Test
@@ -287,7 +287,7 @@ public class BuildCauseProducerServiceIntegrationTest {
 
         assertThat(serverHealthService.getLogsAsText(),
                 containsString("GoCD Server has run out of artifacts disk space. Scheduling has been stopped"));
-        assertThat(pipelineScheduleQueue.toBeScheduled().keySet(), not(hasItem(MINGLE_PIPELINE_NAME)));
+        assertThat(pipelineScheduleQueue.toBeScheduled().keySet(), not(hasItem(new CaseInsensitiveString(MINGLE_PIPELINE_NAME))));
     }
 
     @Test
@@ -306,8 +306,8 @@ public class BuildCauseProducerServiceIntegrationTest {
         pipelineTimeline.update();
         scheduleHelper.autoSchedulePipelinesWithRealMaterials(mingleDownstreamPipelineName);
 
-        assertThat(pipelineScheduleQueue.toBeScheduled().keySet(), hasItem(mingleDownstreamPipelineName));
-        BuildCause downstreamBuildCause = pipelineScheduleQueue.toBeScheduled().get(mingleDownstreamPipelineName);
+        assertThat(pipelineScheduleQueue.toBeScheduled().keySet(), hasItem(new CaseInsensitiveString(mingleDownstreamPipelineName)));
+        BuildCause downstreamBuildCause = pipelineScheduleQueue.toBeScheduled().get(new CaseInsensitiveString(mingleDownstreamPipelineName));
         for (MaterialRevision materialRevision : downstreamBuildCause.getMaterialRevisions()) {
             assertThat("material revision " + materialRevision + " was marked as not changed", materialRevision.isChanged(), is(true));
         }
@@ -328,8 +328,8 @@ public class BuildCauseProducerServiceIntegrationTest {
         String revisionForFingerPrint = revsAfterBar.findRevisionForFingerPrint(svn.getFingerprint()).getRevision().getRevision();
         scheduleHelper.manuallySchedulePipelineWithRealMaterials(MINGLE_PIPELINE_NAME, new Username(new CaseInsensitiveString("loser")), m(mingleConfig.materialConfigs().get(0).getPipelineUniqueFingerprint(), revisionForFingerPrint));
 
-        assertThat(pipelineScheduleQueue.toBeScheduled().keySet(), hasItem(MINGLE_PIPELINE_NAME));
-        BuildCause bisectAfterBisectBuildCause = pipelineScheduleQueue.toBeScheduled().get(MINGLE_PIPELINE_NAME);
+        assertThat(pipelineScheduleQueue.toBeScheduled().keySet(), hasItem(new CaseInsensitiveString(MINGLE_PIPELINE_NAME)));
+        BuildCause bisectAfterBisectBuildCause = pipelineScheduleQueue.toBeScheduled().get(new CaseInsensitiveString(MINGLE_PIPELINE_NAME));
         for (MaterialRevision materialRevision : bisectAfterBisectBuildCause.getMaterialRevisions()) {
             assertThat("material revision " + materialRevision + " should have been considered not changed.", materialRevision.isChanged(), is(false));
         }
@@ -345,8 +345,8 @@ public class BuildCauseProducerServiceIntegrationTest {
         String revisionForFingerPrint = revsAfterFoo.findRevisionForFingerPrint(svn.getFingerprint()).getRevision().getRevision();
         scheduleHelper.manuallySchedulePipelineWithRealMaterials(MINGLE_PIPELINE_NAME, new Username(new CaseInsensitiveString("loser")), m(new MaterialConfigConverter().toMaterial(mingleConfig.materialConfigs().get(0)).getPipelineUniqueFingerprint(), revisionForFingerPrint));
 
-        assertThat(pipelineScheduleQueue.toBeScheduled().keySet(), hasItem(MINGLE_PIPELINE_NAME));
-        BuildCause bisectAfterBisectBuildCause = pipelineScheduleQueue.toBeScheduled().get(MINGLE_PIPELINE_NAME);
+        assertThat(pipelineScheduleQueue.toBeScheduled().keySet(), hasItem(new CaseInsensitiveString(MINGLE_PIPELINE_NAME)));
+        BuildCause bisectAfterBisectBuildCause = pipelineScheduleQueue.toBeScheduled().get(new CaseInsensitiveString(MINGLE_PIPELINE_NAME));
         for (MaterialRevision materialRevision : bisectAfterBisectBuildCause.getMaterialRevisions()) {
             assertThat("material revision " + materialRevision + " should have been considered changed.", materialRevision.isChanged(), is(true));
         }
@@ -371,8 +371,8 @@ public class BuildCauseProducerServiceIntegrationTest {
 
         scheduleHelper.autoSchedulePipelinesWithRealMaterials(MINGLE_PIPELINE_NAME);
 
-        assertThat(pipelineScheduleQueue.toBeScheduled().keySet(), hasItem(MINGLE_PIPELINE_NAME));
-        BuildCause mingleBuildCause = pipelineScheduleQueue.toBeScheduled().get(MINGLE_PIPELINE_NAME);
+        assertThat(pipelineScheduleQueue.toBeScheduled().keySet(), hasItem(new CaseInsensitiveString(MINGLE_PIPELINE_NAME)));
+        BuildCause mingleBuildCause = pipelineScheduleQueue.toBeScheduled().get(new CaseInsensitiveString(MINGLE_PIPELINE_NAME));
         verifyChanged(svn2, mingleBuildCause, true);
         verifyChanged(svn1, mingleBuildCause, false);//this should not have changed, as foo.c was already built in the previous instance
 
@@ -381,8 +381,8 @@ public class BuildCauseProducerServiceIntegrationTest {
         mingleConfig = configHelper.replaceMaterialForPipeline(MINGLE_PIPELINE_NAME, svn1.config());
         scheduleHelper.autoSchedulePipelinesWithRealMaterials(MINGLE_PIPELINE_NAME);
 
-        assertThat(pipelineScheduleQueue.toBeScheduled().keySet(), hasItem(MINGLE_PIPELINE_NAME));
-        mingleBuildCause = pipelineScheduleQueue.toBeScheduled().get(MINGLE_PIPELINE_NAME);
+        assertThat(pipelineScheduleQueue.toBeScheduled().keySet(), hasItem(new CaseInsensitiveString(MINGLE_PIPELINE_NAME)));
+        mingleBuildCause = pipelineScheduleQueue.toBeScheduled().get(new CaseInsensitiveString(MINGLE_PIPELINE_NAME));
         verifyChanged(svn1, mingleBuildCause, false);//this should not have changed, as foo.c was already built in the previous instance
         runAndPassWith(svn1, "baz.c", svnRepository);
 
@@ -392,8 +392,8 @@ public class BuildCauseProducerServiceIntegrationTest {
 
         scheduleHelper.autoSchedulePipelinesWithRealMaterials(MINGLE_PIPELINE_NAME);
 
-        assertThat(pipelineScheduleQueue.toBeScheduled().keySet(), hasItem(MINGLE_PIPELINE_NAME));
-        mingleBuildCause = pipelineScheduleQueue.toBeScheduled().get(MINGLE_PIPELINE_NAME);
+        assertThat(pipelineScheduleQueue.toBeScheduled().keySet(), hasItem(new CaseInsensitiveString(MINGLE_PIPELINE_NAME)));
+        mingleBuildCause = pipelineScheduleQueue.toBeScheduled().get(new CaseInsensitiveString(MINGLE_PIPELINE_NAME));
         verifyChanged(svn2, mingleBuildCause, false);
         verifyChanged(svn1, mingleBuildCause, true);
     }
@@ -406,7 +406,7 @@ public class BuildCauseProducerServiceIntegrationTest {
 
         scheduleHelper.autoSchedulePipelinesWithRealMaterials(MINGLE_PIPELINE_NAME);
 
-        BuildCause mingleBuildCause = pipelineScheduleQueue.toBeScheduled().get(MINGLE_PIPELINE_NAME);
+        BuildCause mingleBuildCause = pipelineScheduleQueue.toBeScheduled().get(new CaseInsensitiveString(MINGLE_PIPELINE_NAME));
         assertThat(mingleBuildCause, is(nullValue()));
 
         svn1.setFolder("another_repo");
@@ -414,8 +414,8 @@ public class BuildCauseProducerServiceIntegrationTest {
 
         scheduleHelper.autoSchedulePipelinesWithRealMaterials(MINGLE_PIPELINE_NAME);
 
-        assertThat(pipelineScheduleQueue.toBeScheduled().keySet(), hasItem(MINGLE_PIPELINE_NAME));
-        mingleBuildCause = pipelineScheduleQueue.toBeScheduled().get(MINGLE_PIPELINE_NAME);
+        assertThat(pipelineScheduleQueue.toBeScheduled().keySet(), hasItem(new CaseInsensitiveString(MINGLE_PIPELINE_NAME)));
+        mingleBuildCause = pipelineScheduleQueue.toBeScheduled().get(new CaseInsensitiveString(MINGLE_PIPELINE_NAME));
         verifyChanged(svn1, mingleBuildCause, false);//because material configuration changed, and not actual revisions
     }
 
@@ -449,7 +449,7 @@ public class BuildCauseProducerServiceIntegrationTest {
         assertThat(materialUpdateStatusNotifier.hasListenerFor(manualTriggerPipeline), is(false));
         assertThat(triggerMonitor.isAlreadyTriggered(manualTriggerPipeline.name().toString()), Is.is(false));
 
-        BuildCause buildCause = pipelineScheduleQueue.toBeScheduled().get(manualTriggerPipeline.name().toString());
+        BuildCause buildCause = pipelineScheduleQueue.toBeScheduled().get(manualTriggerPipeline.name());
         assertNotNull(buildCause);
         assertThat(buildCause.getApprover(), is(username.getDisplayName()));
         assertThat(buildCause.getMaterialRevisions().numberOfRevisions(), is(1));

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/BuildCauseProducerServiceIntegrationTimerTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/BuildCauseProducerServiceIntegrationTimerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 ThoughtWorks, Inc.
+ * Copyright 2018 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 package com.thoughtworks.go.server.service;
 
 import ch.qos.logback.classic.Level;
+import com.thoughtworks.go.config.CaseInsensitiveString;
 import com.thoughtworks.go.config.GoConfigDao;
 import com.thoughtworks.go.config.materials.git.GitMaterial;
 import com.thoughtworks.go.domain.MaterialRevisions;
@@ -127,7 +128,7 @@ public class BuildCauseProducerServiceIntegrationTimerTest {
         buildCauseProducerService.timerSchedulePipeline(p1.config, new ServerHealthStateOperationResult());
 
         assertThat(piplineScheduleQueue.toBeScheduled().size(), is(1));
-        assertThat(piplineScheduleQueue.toBeScheduled().get(pipelineName).getMaterialRevisions(), isSameMaterialRevisionsAs(u.mrs(u.mr(git1, false, "g12"))));
+        assertThat(piplineScheduleQueue.toBeScheduled().get(new CaseInsensitiveString(pipelineName)).getMaterialRevisions(), isSameMaterialRevisionsAs(u.mrs(u.mr(git1, false, "g12"))));
     }
 
     @Test
@@ -147,18 +148,18 @@ public class BuildCauseProducerServiceIntegrationTimerTest {
         buildCauseProducerService.timerSchedulePipeline(p1.config, new ServerHealthStateOperationResult());
 
         assertThat(piplineScheduleQueue.toBeScheduled().size(), is(1));
-        assertThat(piplineScheduleQueue.toBeScheduled().get(pipelineName).getMaterialRevisions(), isSameMaterialRevisionsAs(u.mrs(u.mr(git1, true, "g11"), u.mr(up1, true, up1_1))));
+        assertThat(piplineScheduleQueue.toBeScheduled().get(new CaseInsensitiveString(pipelineName)).getMaterialRevisions(), isSameMaterialRevisionsAs(u.mrs(u.mr(git1, true, "g11"), u.mr(up1, true, up1_1))));
 
-        BuildCause buildCause = piplineScheduleQueue.toBeScheduled().get(pipelineName);
+        BuildCause buildCause = piplineScheduleQueue.toBeScheduled().get(new CaseInsensitiveString(pipelineName));
         String up1_2 = u.runAndPassWithGivenMDUTimestampAndRevisionStrings(up1, u.d(i++), "g11");
-        piplineScheduleQueue.finishSchedule(pipelineName, buildCause, buildCause);
+        piplineScheduleQueue.finishSchedule(new CaseInsensitiveString(pipelineName), buildCause, buildCause);
 
         try (LogFixture logFixture = logFixtureFor(TimedBuild.class, Level.INFO)) {
             // Timer time comes around again. Will rerun since the new flag (runOnlyOnNewMaterials) is not ON.
             buildCauseProducerService.timerSchedulePipeline(p1.config, new ServerHealthStateOperationResult());
 
             assertThat(piplineScheduleQueue.toBeScheduled().size(), is(1));
-            assertThat(piplineScheduleQueue.toBeScheduled().get(pipelineName).getMaterialRevisions(), is(u.mrs(u.mr(git1, false, "g11"), u.mr(up1, false, up1_2))));
+            assertThat(piplineScheduleQueue.toBeScheduled().get(new CaseInsensitiveString(pipelineName)).getMaterialRevisions(), is(u.mrs(u.mr(git1, false, "g11"), u.mr(up1, false, up1_2))));
             assertThat(logFixture.contains(Level.INFO, "Skipping scheduling of timer-triggered pipeline 'p1' as it has previously run with the latest material(s)."), is(false));
         }
     }
@@ -179,10 +180,10 @@ public class BuildCauseProducerServiceIntegrationTimerTest {
         buildCauseProducerService.timerSchedulePipeline(p1.config, new ServerHealthStateOperationResult());
 
         assertThat(piplineScheduleQueue.toBeScheduled().size(), is(1));
-        assertThat(piplineScheduleQueue.toBeScheduled().get(pipelineName).getMaterialRevisions(), isSameMaterialRevisionsAs(u.mrs(u.mr(git1, true, "g11"), u.mr(git2, true, "g21"))));
+        assertThat(piplineScheduleQueue.toBeScheduled().get(new CaseInsensitiveString(pipelineName)).getMaterialRevisions(), isSameMaterialRevisionsAs(u.mrs(u.mr(git1, true, "g11"), u.mr(git2, true, "g21"))));
 
-        BuildCause buildCause = piplineScheduleQueue.toBeScheduled().get(pipelineName);
-        piplineScheduleQueue.finishSchedule(pipelineName, buildCause, buildCause);
+        BuildCause buildCause = piplineScheduleQueue.toBeScheduled().get(new CaseInsensitiveString(pipelineName));
+        piplineScheduleQueue.finishSchedule(new CaseInsensitiveString(pipelineName), buildCause, buildCause);
 
         try (LogFixture logFixture = logFixtureFor(TimedBuild.class, Level.INFO)) {
             // Timer time comes around again. Will NOT rerun since the new flag (runOnlyOnNewMaterials) is ON.
@@ -213,11 +214,11 @@ public class BuildCauseProducerServiceIntegrationTimerTest {
         buildCauseProducerService.timerSchedulePipeline(p2.config, new ServerHealthStateOperationResult());
 
         assertThat(piplineScheduleQueue.toBeScheduled().size(), is(1));
-        assertThat(piplineScheduleQueue.toBeScheduled().get(pipelineName).getMaterialRevisions(), isSameMaterialRevisionsAs(u.mrs(u.mr(git1, true, "g11"), u.mr(git2, true, "g21"), u.mr(p1, true, p1_1))));
+        assertThat(piplineScheduleQueue.toBeScheduled().get(new CaseInsensitiveString(pipelineName)).getMaterialRevisions(), isSameMaterialRevisionsAs(u.mrs(u.mr(git1, true, "g11"), u.mr(git2, true, "g21"), u.mr(p1, true, p1_1))));
 
-        BuildCause buildCause = piplineScheduleQueue.toBeScheduled().get(pipelineName);
+        BuildCause buildCause = piplineScheduleQueue.toBeScheduled().get(new CaseInsensitiveString(pipelineName));
         u.runAndPassWithGivenMDUTimestampAndRevisionStrings(p2, u.d(i++), "g11", "g21", p1_1);
-        piplineScheduleQueue.finishSchedule(pipelineName, buildCause, buildCause);
+        piplineScheduleQueue.finishSchedule(new CaseInsensitiveString(pipelineName), buildCause, buildCause);
 
         // Check in to git2 and run pipeline P1 once before the timer time. Then, timer happens. Shows those two materials in "yellow" (changed), on the UI.
         u.checkinFile(git2, "g22", temporaryFolder.newFile("blah_g22"), ModifiedAction.added);
@@ -227,7 +228,7 @@ public class BuildCauseProducerServiceIntegrationTimerTest {
             buildCauseProducerService.timerSchedulePipeline(p2.config, new ServerHealthStateOperationResult());
 
             assertThat(piplineScheduleQueue.toBeScheduled().size(), is(1));
-            assertThat(piplineScheduleQueue.toBeScheduled().get(pipelineName).getMaterialRevisions(), isSameMaterialRevisionsAs(u.mrs(u.mr(git1, false, "g11"), u.mr(git2, true, "g22"), u.mr(p1, true, p1_2))));
+            assertThat(piplineScheduleQueue.toBeScheduled().get(new CaseInsensitiveString(pipelineName)).getMaterialRevisions(), isSameMaterialRevisionsAs(u.mrs(u.mr(git1, false, "g11"), u.mr(git2, true, "g22"), u.mr(p1, true, p1_2))));
             assertThat(logFixture.contains(Level.INFO, "Skipping scheduling of timer-triggered pipeline 'p1' as it has previously run with the latest material(s)."), is(false));
         }
     }

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/BuildCauseProducerServiceWithFlipModificationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/BuildCauseProducerServiceWithFlipModificationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 ThoughtWorks, Inc.
+ * Copyright 2018 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -205,7 +205,7 @@ public class BuildCauseProducerServiceWithFlipModificationTest {
     }
 
     private BuildCause buildCauseForPipeline() {
-        BuildCause buildCause = pipelineScheduleQueue.toBeScheduled().get(PIPELINE_NAME);
+        BuildCause buildCause = pipelineScheduleQueue.toBeScheduled().get(new CaseInsensitiveString(PIPELINE_NAME));
         assertThat("Should be scheduled", buildCause, is(not(nullValue())));
         return buildCause;
     }
@@ -227,13 +227,13 @@ public class BuildCauseProducerServiceWithFlipModificationTest {
         return BuildCause.createWithModifications(materialRevisions, "");
     }
 
-    private void verifyBuildCauseHasModificationsWith(Map<String, BuildCause> load, boolean changed) {
+    private void verifyBuildCauseHasModificationsWith(Map<CaseInsensitiveString, BuildCause> load, boolean changed) {
         for (BuildCause buildCause : load.values()) {
             assertBuildCauseWithModificationHasChangedStatus(changed, buildCause);
         }
     }
 
-    private void assertModificationChangedStateBasedOnMaterial(Map<String, BuildCause> load) {
+    private void assertModificationChangedStateBasedOnMaterial(Map<CaseInsensitiveString, BuildCause> load) {
         for (BuildCause buildCause : load.values()) {
             for (MaterialRevision revision : buildCause.getMaterialRevisions()) {
                 if (revision.getMaterial() instanceof HgMaterial) {

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/GoDashboardServiceIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/GoDashboardServiceIntegrationTest.java
@@ -119,7 +119,7 @@ public class GoDashboardServiceIntegrationTest {
                 .getCounter(), Matchers.is(new StageIdentifier(p1_1).getPipelineCounter()));
 
         BuildCause buildCauseForThirdRun = BuildCause.createWithModifications(u.mrs(u.mr(u.m(g1).material, true, "g_2")), "user");
-        Pipeline p1_2 = scheduleService.schedulePipeline(p1.config.name().toString(), buildCauseForThirdRun);
+        Pipeline p1_2 = scheduleService.schedulePipeline(p1.config.name(), buildCauseForThirdRun);
         goDashboardService.updateCacheForPipeline(p1.config);
 
         pipelineGroupsOnDashboard = goDashboardService.allPipelineGroupsForDashboard(PipelineSelections.ALL, new Username("user"));
@@ -151,7 +151,7 @@ public class GoDashboardServiceIntegrationTest {
                 .getCounter(), Matchers.is(new StageIdentifier(p1_1).getPipelineCounter()));
 
         BuildCause buildCauseForThirdRun = BuildCause.createWithModifications(u.mrs(u.mr(u.m(g1).material, true, "g_2")), "user");
-        Pipeline p1_2 = scheduleService.schedulePipeline(addedPipeline.config.name().toString(), buildCauseForThirdRun);
+        Pipeline p1_2 = scheduleService.schedulePipeline(addedPipeline.config.name(), buildCauseForThirdRun);
         goDashboardService.updateCacheForPipeline(addedPipeline.config);
 
         pipelineGroupsOnDashboard = goDashboardService.allPipelineGroupsForDashboard(PipelineSelections.ALL, new Username("user"));

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/MultipleMaterialsWithFilterTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/MultipleMaterialsWithFilterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 ThoughtWorks, Inc.
+ * Copyright 2018 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package com.thoughtworks.go.server.service;
 
+import com.thoughtworks.go.config.CaseInsensitiveString;
 import com.thoughtworks.go.config.GoConfigDao;
 import com.thoughtworks.go.config.materials.Filter;
 import com.thoughtworks.go.config.materials.IgnoredFiles;
@@ -100,7 +101,7 @@ public class MultipleMaterialsWithFilterTest {
         fixture.checkInToFirstMaterial("a.doc");
         fixture.checkInToSecondMaterial("b.java");
         buildCauseProducerService.autoSchedulePipeline(fixture.pipelineName, new ServerHealthStateOperationResult(), 12345);
-        BuildCause buildCause = pipelineScheduleQueue.toBeScheduled().get(fixture.pipelineName);
+        BuildCause buildCause = pipelineScheduleQueue.toBeScheduled().get(new CaseInsensitiveString(fixture.pipelineName));
         assertThat(buildCause, instanceOf(BuildCause.class));
 
         MaterialRevisions actual = buildCause.getMaterialRevisions();
@@ -120,7 +121,7 @@ public class MultipleMaterialsWithFilterTest {
         buildCauseProducerService.autoSchedulePipeline(fixture.pipelineName, new ServerHealthStateOperationResult(), 12345);
 
         assertThat(pipelineScheduleQueue.toBeScheduled().size(), is(size));
-        assertThat(pipelineScheduleQueue.toBeScheduled().get(fixture.pipelineName), is(nullValue()));
+        assertThat(pipelineScheduleQueue.toBeScheduled().get(new CaseInsensitiveString(fixture.pipelineName)), is(nullValue()));
     }
 
     public class PipelineWithMultipleMaterials extends PipelineWithTwoStages {

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/PipelineHistoryServiceIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/PipelineHistoryServiceIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 ThoughtWorks, Inc.
+ * Copyright 2018 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -671,7 +671,7 @@ public class PipelineHistoryServiceIntegrationTest {
 
         configHelper.addPipeline("pipeline-name", "stage-1");
 
-        triggerMonitor.markPipelineAsAlreadyTriggered("pipeline-name");
+        triggerMonitor.markPipelineAsAlreadyTriggered(new CaseInsensitiveString("pipeline-name"));
 
         PipelineInstanceModel instance = pipelineHistoryService.latest("pipeline-name", new Username(new CaseInsensitiveString("admin")));
         assertThat(instance.getName(), is("pipeline-name"));

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/PipelineScheduleServiceTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/PipelineScheduleServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 ThoughtWorks, Inc.
+ * Copyright 2018 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -387,8 +387,8 @@ public class PipelineScheduleServiceTest {
 
     @Test
     public void shouldConsumeAllBuildCausesInServerHealth() throws Exception {
-        pipelineScheduleQueue.schedule("mingle", BuildCause.createManualForced(modifyOneFile(mingleConfig), Username.ANONYMOUS));
-        pipelineScheduleQueue.schedule("evolve", BuildCause.createManualForced(modifyOneFile(evolveConfig), Username.ANONYMOUS));
+        pipelineScheduleQueue.schedule(new CaseInsensitiveString("mingle"), BuildCause.createManualForced(modifyOneFile(mingleConfig), Username.ANONYMOUS));
+        pipelineScheduleQueue.schedule(new CaseInsensitiveString("evolve"), BuildCause.createManualForced(modifyOneFile(evolveConfig), Username.ANONYMOUS));
 
         scheduleService.autoSchedulePipelinesFromRequestBuffer();
         assertThat(pipelineScheduleQueue.toBeScheduled().size(), is(0));

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/PipelineSchedulerIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/PipelineSchedulerIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 ThoughtWorks, Inc.
+ * Copyright 2018 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -149,7 +149,7 @@ public class PipelineSchedulerIntegrationTest {
                 return serverHealthService.filterByScope(HealthStateScope.forPipeline(PIPELINE_MINGLE)).size() == 0;
             }
         });
-        BuildCause buildCause = pipelineScheduleQueue.toBeScheduled().get(PIPELINE_MINGLE);
+        BuildCause buildCause = pipelineScheduleQueue.toBeScheduled().get(new CaseInsensitiveString(PIPELINE_MINGLE));
 
         EnvironmentVariables overriddenVariables = buildCause.getVariables();
         assertThat(overriddenVariables, is(new EnvironmentVariables(Arrays.asList(new EnvironmentVariable("KEY", "value")))));

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/PipelineTriggerServiceIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/PipelineTriggerServiceIntegrationTest.java
@@ -145,7 +145,7 @@ public class PipelineTriggerServiceIntegrationTest {
 
         materialUpdateStatusNotifier.onMessage(new MaterialUpdateSuccessfulMessage(svnMaterial, 1));
 
-        BuildCause buildCause = pipelineScheduleQueue.toBeScheduled().get(pipelineName);
+        BuildCause buildCause = pipelineScheduleQueue.toBeScheduled().get(new CaseInsensitiveString(pipelineName));
         assertNotNull(buildCause);
         assertThat(buildCause.getApprover(), is(CaseInsensitiveString.str(admin.getUsername())));
         assertThat(buildCause.getMaterialRevisions().findRevisionFor(pipelineConfig.materialConfigs().first()).getLatestRevisionString(), is("s3"));
@@ -170,7 +170,7 @@ public class PipelineTriggerServiceIntegrationTest {
 
         materialUpdateStatusNotifier.onMessage(new MaterialUpdateSuccessfulMessage(svnMaterial, 1));
 
-        BuildCause buildCause = pipelineScheduleQueue.toBeScheduled().get(pipelineName);
+        BuildCause buildCause = pipelineScheduleQueue.toBeScheduled().get(new CaseInsensitiveString(pipelineName));
         assertNotNull(buildCause);
         assertThat(buildCause.getApprover(), is(CaseInsensitiveString.str(admin.getUsername())));
         assertThat(buildCause.getMaterialRevisions().findRevisionFor(pipelineConfig.materialConfigs().first()).getLatestRevisionString(), is("s2"));
@@ -193,7 +193,7 @@ public class PipelineTriggerServiceIntegrationTest {
         assertThat(result.fullMessage(), is(String.format("Request to schedule pipeline %s accepted", pipelineName)));
         assertThat(result.httpCode(), is(202));
         assertThat(materialUpdateStatusNotifier.hasListenerFor(pipelineConfig), is(false));
-        BuildCause buildCause = pipelineScheduleQueue.toBeScheduled().get(pipelineName);
+        BuildCause buildCause = pipelineScheduleQueue.toBeScheduled().get(new CaseInsensitiveString(pipelineName));
         assertNotNull(buildCause);
         assertThat(buildCause.getApprover(), is(CaseInsensitiveString.str(admin.getUsername())));
         assertThat(buildCause.getMaterialRevisions().findRevisionFor(pipelineConfig.materialConfigs().first()).getLatestRevisionString(), is("s2"));
@@ -242,7 +242,7 @@ public class PipelineTriggerServiceIntegrationTest {
 
         materialUpdateStatusNotifier.onMessage(new MaterialUpdateSuccessfulMessage(svnMaterial, 1));
 
-        BuildCause buildCause = pipelineScheduleQueue.toBeScheduled().get(pipelineName);
+        BuildCause buildCause = pipelineScheduleQueue.toBeScheduled().get(new CaseInsensitiveString(pipelineName));
         assertNotNull(buildCause);
         assertThat(buildCause.getApprover(), is(CaseInsensitiveString.str(admin.getUsername())));
         assertThat(buildCause.getMaterialRevisions().findRevisionFor(pipelineConfig.materialConfigs().first()).getLatestRevisionString(), is("s3"));
@@ -288,7 +288,7 @@ public class PipelineTriggerServiceIntegrationTest {
         assertThat(result.isSuccess(), is(true));
         materialUpdateStatusNotifier.onMessage(new MaterialUpdateSuccessfulMessage(svnMaterial, 1));
 
-        BuildCause buildCause = pipelineScheduleQueue.toBeScheduled().get(pipelineName);
+        BuildCause buildCause = pipelineScheduleQueue.toBeScheduled().get(new CaseInsensitiveString(pipelineName));
         assertNotNull(buildCause);
         EnvironmentVariable secureVariable = (EnvironmentVariable) CollectionUtils.find(buildCause.getVariables(), new Predicate() {
             @Override

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/ScheduleServiceCachedIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/ScheduleServiceCachedIntegrationTest.java
@@ -192,7 +192,7 @@ public class ScheduleServiceCachedIntegrationTest {
     private Pipeline tryToScheduleAPipeline() {
         BuildCause buildCause = BuildCause.createWithModifications(modifyOneFile(preCondition.pipelineConfig()), "");
         dbHelper.saveMaterials(buildCause.getMaterialRevisions());
-        pipelineScheduleQueue.schedule(preCondition.pipelineName, buildCause);
+        pipelineScheduleQueue.schedule(new CaseInsensitiveString(preCondition.pipelineName), buildCause);
         scheduleService.autoSchedulePipelinesFromRequestBuffer();
         return pipelineService.mostRecentFullPipelineByName(preCondition.pipelineName);
     }

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/ScheduleServiceIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/ScheduleServiceIntegrationTest.java
@@ -450,7 +450,7 @@ public class ScheduleServiceIntegrationTest {
         BuildCause buildCause = ModificationsMother.modifySomeFiles(pipelineConfig);
         dbHelper.saveMaterials(buildCause.getMaterialRevisions());
         String pipelineName = pipelineConfig.name().toString();
-        pipelineScheduleQueue.schedule(pipelineName, buildCause);
+        pipelineScheduleQueue.schedule(pipelineConfig.name(), buildCause);
         scheduleService.autoSchedulePipelinesFromRequestBuffer();
         Pipeline pipeline = pipelineDao.findPipelineByNameAndCounter(pipelineName, counter);
         pipeline = pipelineDao.loadAssociations(pipeline, pipelineName);

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/ScheduleServiceRunOnAllAgentIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/ScheduleServiceRunOnAllAgentIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 ThoughtWorks, Inc.
+ * Copyright 2018 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -137,7 +137,7 @@ public class ScheduleServiceRunOnAllAgentIntegrationTest {
 
     @Test
     public void shouldUpdateServerHealthWhenSchedulePipelineFails() throws Exception {
-        pipelineScheduleQueue.schedule("blahPipeline", saveMaterials(modifySomeFiles(goConfigService.pipelineConfigNamed(new CaseInsensitiveString("blahPipeline")))));
+        pipelineScheduleQueue.schedule(new CaseInsensitiveString("blahPipeline"), saveMaterials(modifySomeFiles(goConfigService.pipelineConfigNamed(new CaseInsensitiveString("blahPipeline")))));
         scheduleService.autoSchedulePipelinesFromRequestBuffer();
         List<ServerHealthState> stateList = serverHealthService.filterByScope(HealthStateScope.forStage("blahPipeline", "blahStage"));
         assertThat(stateList.size(), is(1));

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/SchedulingCheckerServiceIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/SchedulingCheckerServiceIntegrationTest.java
@@ -154,7 +154,7 @@ public class SchedulingCheckerServiceIntegrationTest {
     public void shouldFailCheckingWhenPipelineNotYetScheduledButInTriggerMonitor() throws Exception {
         String pipelineName = "blahPipeline";
         PipelineConfig pipelineConfig = configFileHelper.addPipelineWithGroup("group2", pipelineName, "stage", "job");
-        triggerMonitor.markPipelineAsAlreadyTriggered(pipelineName);
+        triggerMonitor.markPipelineAsAlreadyTriggered(pipelineConfig.name());
 
         HttpOperationResult operationResult = new HttpOperationResult();
         assertThat(schedulingChecker.canManuallyTrigger(pipelineConfig, "blahUser", operationResult), is(false));

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/SchedulingCheckerServiceIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/SchedulingCheckerServiceIntegrationTest.java
@@ -134,7 +134,7 @@ public class SchedulingCheckerServiceIntegrationTest {
     public void shouldFailCheckingWhenPipelineNotYetScheduledButInScheduleQueue() throws Exception {
         String pipelineName = "blahPipeline";
         PipelineConfig pipelineConfig = configFileHelper.addPipelineWithGroup("group2", pipelineName, "stage", "job");
-        pipelineScheduleQueue.schedule(pipelineName, BuildCause.createManualForced());
+        pipelineScheduleQueue.schedule(new CaseInsensitiveString(pipelineName), BuildCause.createManualForced());
         HttpOperationResult operationResult = new HttpOperationResult();
         assertThat(schedulingChecker.canManuallyTrigger(pipelineConfig, "blahUser", operationResult), is(false));
         assertThat(operationResult.canContinue(), is(false));
@@ -146,7 +146,7 @@ public class SchedulingCheckerServiceIntegrationTest {
         String pipelineName = "blahPipeline";
         configFileHelper.addPipelineWithGroup("group2", pipelineName, "stage", "job");
 
-        pipelineScheduleQueue.schedule(pipelineName, BuildCause.createWithEmptyModifications());
+        pipelineScheduleQueue.schedule(new CaseInsensitiveString(pipelineName), BuildCause.createWithEmptyModifications());
         assertThat(schedulingChecker.canManuallyTrigger(pipelineName, new Username(new CaseInsensitiveString("blahUser"))), is(true));
     }
 


### PR DESCRIPTION
else it used to create multiple entries in the maps ( and ) for each of the different case of the string that it got called with, make db call (mostRecentScheduledBuildCause) for the same pipeline again. The mutex used wasn't case-insensititive too.