### PR TITLE
Ensure cancelled stage has lastTransitionedTime

### DIFF
--- a/server/src/main/java/com/thoughtworks/go/server/dao/StageSqlMapDao.java
+++ b/server/src/main/java/com/thoughtworks/go/server/dao/StageSqlMapDao.java
@@ -51,6 +51,7 @@ import org.springframework.transaction.TransactionStatus;
 import org.springframework.transaction.support.TransactionCallback;
 import org.springframework.transaction.support.TransactionSynchronizationAdapter;
 
+import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -287,6 +288,13 @@ public class StageSqlMapDao extends SqlMapClientDaoSupport implements StageDao, 
                 .and("result", result.toString())
                 .and("state", stage.getState())
                 .and("completedByTransitionId", stage.getCompletedByTransitionId()).asMap());
+
+        upddateLastTransitionedTime(stage);
+    }
+
+    private void upddateLastTransitionedTime(Stage stage) {
+        Timestamp lastTransitionedTime = (Timestamp) getSqlMapClientTemplate().queryForObject("getLastTransitionedTimeByStageId", stage.getId());
+        stage.setLastTransitionedTime(lastTransitionedTime);
     }
 
     public Stage mostRecentCompleted(StageConfigIdentifier identifier) {

--- a/server/src/main/resources/com/thoughtworks/go/server/dao/maps/Stage.xml
+++ b/server/src/main/resources/com/thoughtworks/go/server/dao/maps/Stage.xml
@@ -615,6 +615,10 @@
         SELECT name FROM stages WHERE id = #value#
     </select>
 
+    <select id="getLastTransitionedTimeByStageId" parameterClass="long" resultClass="java.sql.Timestamp" >
+        SELECT lastTransitionedTime FROM stages WHERE id = #value#
+    </select>
+
     <!--
     TODO: This takes over 500 ms and could be changed to use the stage state e.g.
         SELECT count(1)

--- a/server/src/test-integration/java/com/thoughtworks/go/server/dao/StageSqlMapDaoIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/dao/StageSqlMapDaoIntegrationTest.java
@@ -125,6 +125,18 @@ public class StageSqlMapDaoIntegrationTest {
         assertThat(reloaded.getCompletedByTransitionId(), greaterThan(0l));
     }
 
+    @Test
+    public void onStageUpdateShouldSetTheLastTransitionedTimeOnTheUpdateStageSinceTheTimeIsGeneratedByADatabaseTrigger() throws Exception {
+        Pipeline pipeline = pipelineWithFirstStageRunning(mingleConfig);
+        Stage stage = pipeline.getStages().get(0);
+
+        assertNull(stage.getLastTransitionedTime());
+
+        updateResultInTransaction(stage, StageResult.Passed);
+
+        assertNotNull(stage.getLastTransitionedTime());
+    }
+
     @Test public void shouldUpdateStageStateWhenUpdatingResult() throws Exception {
         Pipeline pipeline = pipelineWithOnePassedAndOneCurrentlyRunning(mingleConfig)[1];
         Stage stage = pipeline.getStages().get(0);


### PR DESCRIPTION
* The lastTransitionedTime on a stage is set using a database trigger
  upon insert of buildStateTransitions. As part of normal stage
  transition in ScheduleService#updateJobStatus the stage object in
  cache is invalidated and reloaded which will have the
  lastTransitionedTime. But in case a stage is cancelled through
  ScheduleService#cancelAndTriggerRelevantStages a stage being cancelled
  is not synced with db to get the lastTransitionTime and hence
  StageStatus notifications have a null lastTransitionedTime.