### PR TITLE
Add new_dashboard_page_default toggle to make dashboard SPA the defau…

### DIFF
--- a/server/src/main/java/com/thoughtworks/go/server/SparkOrRailsToggle.java
+++ b/server/src/main/java/com/thoughtworks/go/server/SparkOrRailsToggle.java
@@ -42,6 +42,16 @@ public class SparkOrRailsToggle {
         basedOnToggle(Toggles.SPARK_PLUGIN_IMAGES_ENABLED_KEY, request);
     }
 
+    public void oldOrNewDashboard(HttpServletRequest request, HttpServletResponse response) {
+        request.setAttribute("rails_bound", true);
+
+        if (Toggles.isToggleOn(Toggles.NEW_DASHBOARD_PAGE_DEFAULT)) {
+            request.setAttribute("newUrl", "/rails/new_dashboard");
+        } else {
+            request.setAttribute("newUrl", "/rails/pipelines");
+        }
+    }
+
     private void basedOnToggle(String toggle, HttpServletRequest request) {
         if (Toggles.isToggleOn(toggle)) {
             request.setAttribute("sparkOrRails", "spark");

--- a/server/src/main/java/com/thoughtworks/go/server/service/support/toggle/Toggles.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/support/toggle/Toggles.java
@@ -27,6 +27,7 @@ public class Toggles {
     public static String SPARK_ENCRYPTION_ENABLED_KEY = "spark_encryption_enabled_key";
     public static String SPARK_ROLE_CONFIG_ENABLED_KEY = "spark_role_config_enabled_key";
     public static String SPARK_PLUGIN_IMAGES_ENABLED_KEY = "spark_plugin_images_enabled_key";
+    public static String NEW_DASHBOARD_PAGE_DEFAULT = "new_dashboard_page_default";
 
     private static FeatureToggleService service;
 

--- a/server/src/main/resources/available.toggles
+++ b/server/src/main/resources/available.toggles
@@ -17,6 +17,11 @@
          "value": false
       },
       {
+         "key": "new_dashboard_page_default",
+         "description": "Enables the new dashboard page to be the default page. Default: disabled.",
+         "value": false
+      },
+      {
          "key": "browser_console_log_ws_key",
          "description": "Enables rendering console logs via websockets. Default: disabled.",
          "value": false

--- a/server/webapp/WEB-INF/rails.new/app/controllers/admin/new_dashboard_controller.rb
+++ b/server/webapp/WEB-INF/rails.new/app/controllers/admin/new_dashboard_controller.rb
@@ -24,6 +24,7 @@ module Admin
     def index
       @view_title = 'Dashboard'
       @is_quick_edit_page_enabled = Toggles.isToggleOn(Toggles.PIPELINE_CONFIG_SINGLE_PAGE_APP) && Toggles.isToggleOn(Toggles.QUICK_EDIT_PAGE_DEFAULT)
+      @is_new_dashboard_page_default = Toggles.isToggleOn(Toggles.NEW_DASHBOARD_PAGE_DEFAULT)
     end
   end
 end

--- a/server/webapp/WEB-INF/rails.new/app/views/admin/new_dashboard/index.html.erb
+++ b/server/webapp/WEB-INF/rails.new/app/views/admin/new_dashboard/index.html.erb
@@ -1,3 +1,3 @@
-<div id="dashboard" data-is-quick-edit-page-enabled="<%= @is_quick_edit_page_enabled %>">
+<div id="dashboard" data-is-quick-edit-page-enabled="<%= @is_quick_edit_page_enabled %>" data-is-new-dashboard-page-default="<%= @is_new_dashboard_page_default %>">
   <span class="page-spinner"/>
 </div>

--- a/server/webapp/WEB-INF/rails.new/webpack/single_page_apps/new_dashboard.js
+++ b/server/webapp/WEB-INF/rails.new/webpack/single_page_apps/new_dashboard.js
@@ -33,6 +33,7 @@ $(() => {
 
   const dashboardVM            = new DashboardVM();
   const isQuickEditPageEnabled = JSON.parse(dashboardElem.attr('data-is-quick-edit-page-enabled'));
+  const isNewDashboardPageDefault = JSON.parse(dashboardElem.attr('data-is-new-dashboard-page-default'));
 
   $(document).foundation();
 
@@ -94,6 +95,7 @@ $(() => {
         return m(DashboardWidget, {
           dashboard,
           isQuickEditPageEnabled,
+          isNewDashboardPageDefault,
           vm:                   dashboardVM,
           doCancelPolling:      () => repeater().stop(),
           doRefreshImmediately: () => {

--- a/server/webapp/WEB-INF/rails.new/webpack/views/dashboard/dashboard_widget.js.msx
+++ b/server/webapp/WEB-INF/rails.new/webpack/views/dashboard/dashboard_widget.js.msx
@@ -84,19 +84,22 @@ const DashboardWidget = {
                                             hideSelectionDropdown={vm.personalizeView.hide}
                                             vm={vnode.state.pipelineSelectionVM}/>);
     }
+
+    let oldDashboardLink;
+    if (!vnode.attrs.isNewDashboardPageDefault) {
+      oldDashboardLink = (<a class="toggle-old-view" href={"/go/pipelines/"}>Old Dashboard</a>);
+    }
     return (
       <div class="pipeline_wrapper">
         <div class="page_header" key="page-header">
-          <h1 class="page_title">Pipelines
-            <a class="toggle-old-view" href={"/go/pipelines/"}>Old Dashboard</a>
-          </h1>
+          <h1 class="page_title">Pipelines{oldDashboardLink}</h1>
           <div class="filter">
             <input type="text"
                    class="pipeline-search"
                    value={vnode.attrs.dashboard.searchText()}
                    oninput={vnode.state.searchTextUpdated.bind(vnode.state)}
                    placeholder="Search for pipeline"/>
-              <button class="filter_btn"
+            <button class="filter_btn"
                     onclick={vnode.state.togglePersonalizeDropdown.bind(vnode.state)}>
               Filter View <i class="fa fa-filter"/>
             </button>

--- a/server/webapp/WEB-INF/urlrewrite.xml
+++ b/server/webapp/WEB-INF/urlrewrite.xml
@@ -170,6 +170,20 @@
     </rule>
 
     <rule>
+        <name>Dashboard UI</name>
+        <from>^/old_dashboard$</from>
+        <to last="true">/rails/pipelines</to>
+        <set name="rails_bound">true</set>
+    </rule>
+
+    <rule>
+        <name>Default dashboard, based on toggle</name>
+        <from>^/pipelines(/.*)?$</from>
+        <run class="com.thoughtworks.go.server.SparkOrRailsToggle" method="oldOrNewDashboard"/>
+        <to last="true">%{attribute:newUrl}</to>
+    </rule>
+
+    <rule>
         <name>Rails Security Auth Config UI</name>
         <from>^/admin/security/auth_configs$</from>
         <to last="true">/rails/admin/security/auth_configs</to>


### PR DESCRIPTION
…lt page

Introduce a couple of additional URLs:

- /go/pipelines (current URL) will render the old, or new dashboard
  based on the feature toggle
- /go/old_dashboard - will always show the old dashboard
- /go/dashboard - will always show the new dashboard