### PR TITLE
Skipping the empty pipeline groups from pipeline selection response

### DIFF
--- a/api/api-pipeline-selection-v1/src/main/java/com/thoughtworks/go/apiv1/pipelineselection/representers/PipelineSelectionsRepresenter.java
+++ b/api/api-pipeline-selection-v1/src/main/java/com/thoughtworks/go/apiv1/pipelineselection/representers/PipelineSelectionsRepresenter.java
@@ -33,10 +33,14 @@ public class PipelineSelectionsRepresenter {
             .add("blacklist", pipelineSelectionResponse.getSelectedPipelines().isBlacklist())
             .addChild("pipelines", pipelineGroupsWriter -> {
                 pipelineSelectionResponse.getPipelineConfigs().forEach(pipelineConfigs -> {
-                        List<String> pipelineNames = pipelineConfigs.getPipelines().stream().map(PipelineConfig::getName).map(CaseInsensitiveString::toString).collect(Collectors.toList());
+                    List<String> pipelineNames = pipelineConfigs
+                            .getPipelines().stream()
+                            .map(pipelineConfig -> pipelineConfig.getName().toString())
+                            .collect(Collectors.toList());
+                    if (!pipelineNames.isEmpty()) {
                         pipelineGroupsWriter.addChildList(pipelineConfigs.getGroup(), pipelineNames);
                     }
-                );
+                });
             });
     }
 

--- a/api/api-pipeline-selection-v1/src/test/groovy/com/thoughtworks/go/apiv1/pipelineselection/representers/PipelineSelectionsRepresenterTest.groovy
+++ b/api/api-pipeline-selection-v1/src/test/groovy/com/thoughtworks/go/apiv1/pipelineselection/representers/PipelineSelectionsRepresenterTest.groovy
@@ -44,6 +44,7 @@ class PipelineSelectionsRepresenterTest {
       def group1 = new BasicPipelineConfigs(group: "grp1")
       def group2 = new BasicPipelineConfigs(group: "grp2")
 
+      group1.add(new PipelineConfig(name: new CaseInsensitiveString("pipeline3")))
       group2.add(new PipelineConfig(name: new CaseInsensitiveString("pipeline1")))
       group2.add(new PipelineConfig(name: new CaseInsensitiveString("pipeline2")))
 
@@ -55,7 +56,32 @@ class PipelineSelectionsRepresenterTest {
 
       JsonFluentAssert.assertThatJson(actualJson).isEqualTo([
         pipelines: [
-          grp1: [],
+          grp1: ["pipeline3"],
+          grp2: ["pipeline1", "pipeline2"]
+        ],
+        selections: ['build-linux', 'build-windows'],
+        blacklist: true
+      ])
+    }
+
+    @Test
+    void 'should not serialize empty pipeline groups'() {
+      def selections = new PipelineSelections(["build-linux", "build-windows"], new Date(), 10, true)
+
+      def group1 = new BasicPipelineConfigs(group: "grp1")
+      def group2 = new BasicPipelineConfigs(group: "grp2")
+
+      group2.add(new PipelineConfig(name: new CaseInsensitiveString("pipeline1")))
+      group2.add(new PipelineConfig(name: new CaseInsensitiveString("pipeline2")))
+
+      List<PipelineConfigs> pipelineConfigs = [group1, group2]
+
+      def actualJson = toObjectString({
+        PipelineSelectionsRepresenter.toJSON(it, new PipelineSelectionResponse(selections, pipelineConfigs))
+      })
+
+      JsonFluentAssert.assertThatJson(actualJson).isEqualTo([
+        pipelines: [
           grp2: ["pipeline1", "pipeline2"]
         ],
         selections: ['build-linux', 'build-windows'],


### PR DESCRIPTION
1. Changes made to **PipelineSelectionsRepresenter**

https://github.com/gocd/gocd/issues/4454