### PR TITLE
Make plugin-initiated requests from plugin-endpoint.js send a generic message key based on API version

### DIFF
--- a/scripts/clean-workingdir.sh
+++ b/scripts/clean-workingdir.sh
@@ -6,6 +6,6 @@ WORKING_DIR=$(cd `dirname $0`/.. && pwd)
 
 cd $WORKING_DIR
 
-rm -rf agent/config agent/pipelines server/pipelines server/db/config.git
+rm -rf server/test-repo agent/config agent/pipelines server/pipelines server/db/config.git
 ls -A -1 | grep -vF .idea | grep -vF .git | xargs git clean -fdx --
 

--- a/server/webapp/WEB-INF/rails.new/webpack/views/analytics/global_metrics.js.msx
+++ b/server/webapp/WEB-INF/rails.new/webpack/views/analytics/global_metrics.js.msx
@@ -18,34 +18,30 @@
   "use strict";
 
   const m = require("mithril");
-  const $ = require('jquery');
+  const $ = require("jquery");
 
-  const PluginEndpoint           = require('rails-shared/plugin-endpoint');
-  const Frame                    = require('models/analytics/frame');
-  const PluginiFrameWidget       = require('views/analytics/plugin_iframe_widget');
-  const Routes                   = require('gen/js-routes');
+  const PluginEndpoint           = require("rails-shared/plugin-endpoint");
+  const Frame                    = require("models/analytics/frame");
+  const PluginiFrameWidget       = require("views/analytics/plugin_iframe_widget");
+  const Routes                   = require("gen/js-routes");
 
   const models = {};
 
   PluginEndpoint.define({
-    "analytics.job.history": (message, trans) => {
-      const meta = message.head;
-      const model = models[meta.uid];
-      const params = $.extend({plugin_id: meta.pluginId}, message.body); // eslint-disable-line camelcase
+    "api.analytics.v1": (message, trans) => {
+      const meta = message.head,
+           model = models[meta.uid],
 
-      params.start = JSON.stringify(params.start).replace(/"/g, "");
-      params.end = JSON.stringify(params.end).replace(/"/g, "");
+          params = $.extend({}, message.body),
+            type = params.type,
+          metric = params.metric;
 
-      model.fetch(Routes.jobAnalyticsPath(params), (data, errors) => {
+      delete params.type;
+      delete params.metric;
+
+      model.fetch(Routes.showAnalyticsPath(meta.pluginId, type, metric, params), (data, errors) => {
         trans.respond({data, errors});
       });
-    },
-
-    "analytics.pipeline": (message, reply) => { // eslint-disable-line no-unused-vars
-      const meta = message.head;
-      const model = models[meta.uid];
-      model.url(Routes.pipelineAnalyticsPath({plugin_id: meta.pluginId, pipeline_name: message.body.pipelineName})); // eslint-disable-line camelcase
-      model.load();
     }
   });
 


### PR DESCRIPTION
The idea here is that we can send a generic request/message key from the plugin to the parent page. This is a good fit to the generic routing done by @maheshp and @jyotisingh. Params are passed through to the model, and eventually the actual AJAX request to the static route.

I also made the key versioned: `api.analytics.v1`

I was thinking that this would be convenient if we wanted to support multiple API versions as one would just add new handlers for each version.