### PR TITLE
Fix urlrewrite for the dashboard routes. (#4524)

### DIFF
--- a/server/src/main/java/com/thoughtworks/go/server/SparkOrRailsToggle.java
+++ b/server/src/main/java/com/thoughtworks/go/server/SparkOrRailsToggle.java
@@ -24,12 +24,12 @@ import javax.servlet.http.HttpServletResponse;
 public class SparkOrRailsToggle {
 
     public void oldOrNewDashboard(HttpServletRequest request, HttpServletResponse response) {
-        request.setAttribute("rails_bound", true);
 
-        if (Toggles.isToggleOn(Toggles.NEW_DASHBOARD_PAGE_DEFAULT)) {
+        if (Toggles.isToggleOn(Toggles.QUICKER_DASHBOARD_KEY) && Toggles.isToggleOn(Toggles.NEW_DASHBOARD_PAGE_DEFAULT)) {
             request.setAttribute("newUrl", "/spark/dashboard");
         } else {
             request.setAttribute("newUrl", "/rails/pipelines");
+            request.setAttribute("rails_bound", true);
         }
     }
 }

--- a/server/src/test-fast/java/com/thoughtworks/go/server/SparkOrRailsToggleTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/SparkOrRailsToggleTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2018 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.server;
+
+import com.thoughtworks.go.server.service.support.toggle.FeatureToggleService;
+import com.thoughtworks.go.server.service.support.toggle.Toggles;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.servlet.http.HttpServletRequest;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class SparkOrRailsToggleTest {
+
+    private FeatureToggleService featureToggleService;
+    private HttpServletRequest request;
+
+    @Before
+    public void setUp() throws Exception {
+        featureToggleService = mock(FeatureToggleService.class);
+        Toggles.initializeWith(featureToggleService);
+        request = mock(HttpServletRequest.class);
+    }
+
+    @Test
+    public void shouldForwardToRailsIfQuickerDashboardToggleIsDisabled() {
+        SparkOrRailsToggle sparkOrRailsToggle = new SparkOrRailsToggle();
+        when(featureToggleService.isToggleOn(Toggles.QUICKER_DASHBOARD_KEY)).thenReturn(false);
+
+        sparkOrRailsToggle.oldOrNewDashboard(request, null);
+
+        verify(request).setAttribute("newUrl", "/rails/pipelines");
+        verify(request).setAttribute("rails_bound", true);
+    }
+
+    @Test
+    public void shouldForwardToRailsIfNewDashboardPageDefaultToggleIsDisabled() {
+        SparkOrRailsToggle sparkOrRailsToggle = new SparkOrRailsToggle();
+        when(featureToggleService.isToggleOn(Toggles.QUICKER_DASHBOARD_KEY)).thenReturn(true);
+        when(featureToggleService.isToggleOn(Toggles.NEW_DASHBOARD_PAGE_DEFAULT)).thenReturn(false);
+
+        sparkOrRailsToggle.oldOrNewDashboard(request, null);
+
+        verify(request).setAttribute("newUrl", "/rails/pipelines");
+        verify(request).setAttribute("rails_bound", true);
+    }
+
+    @Test
+    public void shouldForwardToSparkIfBothDashboardTogglesAreEnabled() {
+        SparkOrRailsToggle sparkOrRailsToggle = new SparkOrRailsToggle();
+        when(featureToggleService.isToggleOn(Toggles.QUICKER_DASHBOARD_KEY)).thenReturn(true);
+        when(featureToggleService.isToggleOn(Toggles.NEW_DASHBOARD_PAGE_DEFAULT)).thenReturn(true);
+
+        sparkOrRailsToggle.oldOrNewDashboard(request, null);
+
+        verify(request).setAttribute("newUrl", "/spark/dashboard");
+    }
+}

--- a/server/webapp/WEB-INF/rails.new/spec/webpack/views/dashboard/dashboard_widget_spec.js
+++ b/server/webapp/WEB-INF/rails.new/spec/webpack/views/dashboard/dashboard_widget_spec.js
@@ -58,6 +58,7 @@ describe("Dashboard Widget", () => {
 
   it("should render Old dashboard button", () => {
     expect($root.find("a.toggle-old-view")).toContainText("Old Dashboard");
+    expect($root.find("a.toggle-old-view").attr('href')).toEqual("/go/old_dashboard/");
   });
 
   it("should render personalize view button", () => {

--- a/server/webapp/WEB-INF/rails.new/webpack/views/dashboard/dashboard_widget.js.msx
+++ b/server/webapp/WEB-INF/rails.new/webpack/views/dashboard/dashboard_widget.js.msx
@@ -85,10 +85,7 @@ const DashboardWidget = {
                                             vm={vnode.state.pipelineSelectionVM}/>);
     }
 
-    let oldDashboardLink;
-    if (!vnode.attrs.isNewDashboardPageDefault) {
-      oldDashboardLink = (<a class="toggle-old-view" href={"/go/pipelines/"}>Old Dashboard</a>);
-    }
+    const oldDashboardLink = (<a class="toggle-old-view" href={"/go/old_dashboard/"}>Old Dashboard</a>);
     return (
       <div class="pipeline_wrapper">
         <div class="page_header" key="page-header">

--- a/server/webapp/WEB-INF/urlrewrite.xml
+++ b/server/webapp/WEB-INF/urlrewrite.xml
@@ -175,14 +175,13 @@
 
     <rule>
         <name>Dashboard UI</name>
-        <from>^/dashboard$</from>
-        <to last="true">/rails/new_dashboard</to>
-        <set name="rails_bound">true</set>
+        <from>^/dashboard(/?)$</from>
+        <to last="true">/spark/dashboard</to>
     </rule>
 
     <rule>
         <name>Dashboard UI</name>
-        <from>^/old_dashboard$</from>
+        <from>^/old_dashboard(/?)$</from>
         <to last="true">/rails/pipelines</to>
         <set name="rails_bound">true</set>
     </rule>


### PR DESCRIPTION
* /go/dashboard points to the new dashboard
* /go/old_dashboard points to the old dashboard
* /go/pipelines points to either the new or the old dashboard based on the toggle 'new_dashboard_page_default'
* urlrewrite handles the routes to dashboard with a trailing slash
* Add the old dashboard button on the new dashboard.