### PR TITLE
[Analytics Plugin Endpoint] Rename transport request

### DIFF
--- a/server/webapp/WEB-INF/rails.new/webpack/views/analytics/global_metrics.js.msx
+++ b/server/webapp/WEB-INF/rails.new/webpack/views/analytics/global_metrics.js.msx
@@ -28,7 +28,7 @@
   const models = {};
 
   PluginEndpoint.define({
-    "api.analytics.v1": (message, trans) => {
+    "go.cd.analytics.v1.fetch-analytics": (message, trans) => {
       const meta = message.head,
            model = models[meta.uid],
 


### PR DESCRIPTION
* rename drilldown request name from 'api.analytics.v1' to 'go.cd.analytics.v1.fetch-analytics.
