### PR TITLE
[Analytics Endpoint] Define 'go.cd.analytics.v1.link-to' transport request handler for the plugin

### DIFF
--- a/server/webapp/WEB-INF/rails.new/spec/webpack/views/analytics/helpers/gocd_link_support_spec.js
+++ b/server/webapp/WEB-INF/rails.new/spec/webpack/views/analytics/helpers/gocd_link_support_spec.js
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2018 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+describe("GoCD Link Support", () => {
+  const GoCDLinkSupport = require("views/analytics/helpers/gocd_link_support");
+
+  beforeEach(() => {
+    spyOn(window, 'open');
+  });
+
+  it('should link to job details page', () => {
+    const linkTo = 'job_details_page';
+    const params = {
+      'pipeline_name':    'up42',
+      'pipeline_counter': 1,
+      'stage_name':       'up42_stage',
+      'stage_counter':    1,
+      'job_name':         'up42_job'
+    };
+
+    GoCDLinkSupport[linkTo](params);
+
+    expect(window.open).toHaveBeenCalled();
+    const jobDetailsPagePath = window.open.calls.mostRecent().args[0];
+    expect(jobDetailsPagePath).toBe(`/go/tab/build/detail/${params.pipeline_name}/${params.pipeline_counter}/${params.stage_name}/${params.stage_counter}/${params.job_name}`);
+  });
+});

--- a/server/webapp/WEB-INF/rails.new/webpack/views/analytics/global_metrics.js.msx
+++ b/server/webapp/WEB-INF/rails.new/webpack/views/analytics/global_metrics.js.msx
@@ -14,27 +14,28 @@
  * limitations under the License.
  */
 
-(function() {
+(function () {
   "use strict";
 
   const m = require("mithril");
   const $ = require("jquery");
 
-  const PluginEndpoint           = require('rails-shared/plugin-endpoint');
-  const Frame                    = require('models/shared/frame');
-  const AnalyticsiFrameWidget    = require('views/shared/analytics_iframe_widget');
-  const Routes                   = require('gen/js-routes');
+  const GoCDLinkSupport       = require('views/analytics/helpers/gocd_link_support');
+  const PluginEndpoint        = require('rails-shared/plugin-endpoint');
+  const Frame                 = require('models/shared/frame');
+  const AnalyticsiFrameWidget = require('views/shared/analytics_iframe_widget');
+  const Routes                = require('gen/js-routes');
 
   const models = {};
 
   PluginEndpoint.define({
     "go.cd.analytics.v1.fetch-analytics": (message, trans) => {
-      const meta = message.head,
-           model = models[meta.uid],
+      const meta   = message.head,
+            model  = models[meta.uid],
 
-          params = $.extend({}, message.body),
-            type = params.type,
-          metric = params.metric;
+            params = $.extend({}, message.body),
+            type   = params.type,
+            metric = params.metric;
 
       delete params.type;
       delete params.metric;
@@ -42,6 +43,19 @@
       model.fetch(Routes.showAnalyticsPath(meta.pluginId, type, metric, params), (data, errors) => {
         trans.respond({data, errors});
       });
+    },
+
+    "go.cd.analytics.v1.link-to": (message, trans) => {
+      const params = $.extend({}, message.body);
+      const linkTo = params.link_to;
+      try {
+        GoCDLinkSupport[linkTo](params);
+        const success = `Successfully linked to ${linkTo} for ${JSON.stringify(params, null, 2)}`;
+        trans.respond({success});
+      } catch (e) {
+        const error = `Failed to link to '${linkTo}' for ${JSON.stringify(params, null, 2)}. Reason ${e}!`;
+        trans.respond({error});
+      }
     }
   });
 
@@ -58,15 +72,15 @@
 
   const GlobalMetrics = {
     view(vnode) { // eslint-disable-line no-unused-vars
-        const frames = [];
-        $.each(vnode.attrs.model.data, (pluginId, supportedAnalytics) => {
-          $.each(supportedAnalytics, (idx, sa) => {
-            const uid = `f-${pluginId}:${sa.id}:${idx}`,
-              model = ensureModel(uid, pluginId, sa.type, sa.id);
+      const frames = [];
+      $.each(vnode.attrs.model.data, (pluginId, supportedAnalytics) => {
+        $.each(supportedAnalytics, (idx, sa) => {
+          const uid   = `f-${pluginId}:${sa.id}:${idx}`,
+                model = ensureModel(uid, pluginId, sa.type, sa.id);
 
-            frames.push(m(AnalyticsiFrameWidget, {model, pluginId, uid, init: PluginEndpoint.init}));
-          });
+          frames.push(m(AnalyticsiFrameWidget, {model, pluginId, uid, init: PluginEndpoint.init}));
         });
+      });
       return frames;
     }
   };

--- a/server/webapp/WEB-INF/rails.new/webpack/views/analytics/helpers/gocd_link_support.js
+++ b/server/webapp/WEB-INF/rails.new/webpack/views/analytics/helpers/gocd_link_support.js
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2018 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const PIPELINE_NAME_KEY    = 'pipeline_name';
+const PIPELINE_COUNTER_KEY = 'pipeline_counter';
+const STAGE_NAME_KEY       = 'stage_name';
+const STAGE_COUNTER_KEY    = 'stage_counter';
+const JOB_NAME_KEY         = 'job_name';
+
+//--- FetchFromParams
+const pipelineName    = (params) => params[PIPELINE_NAME_KEY];
+const pipelineCounter = (params) => params[PIPELINE_COUNTER_KEY];
+const stageName       = (params) => params[STAGE_NAME_KEY];
+const stageCounter    = (params) => params[STAGE_COUNTER_KEY];
+const jobName         = (params) => params[JOB_NAME_KEY];
+
+module.exports = {
+  "job_details_page": (params) => {
+    const jobDetailsPagePath = `/go/tab/build/detail/${pipelineName(params)}/${pipelineCounter(params)}/${stageName(params)}/${stageCounter(params)}/${jobName(params)}`;
+    window.open(jobDetailsPagePath, '_blank');
+  }
+};


### PR DESCRIPTION
* Analytics charts can make use of 'go.cd.analytics.v1.link-to' endpoint to send a request to the parent window for any GoCD core link.
* Currently supported link:
    - job_details_page