### PR TITLE
upgrading objenesis

### DIFF
--- a/agent/build.gradle
+++ b/agent/build.gradle
@@ -29,7 +29,7 @@ testSets {
 dependencies {
   compile project(':agent-common')
   compile project(':common')
-  compile group: 'org.objenesis', name: 'objenesis', version: '1.2'
+  compile group: 'org.objenesis', name: 'objenesis', version: project.versions.objenesis
   compile group: 'org.bouncycastle', name: 'bcprov-jdk15on', version: '1.47'
   compile group: 'commons-configuration', name: 'commons-configuration', version: '1.10'
   compile group: 'org.eclipse.jetty.websocket', name: 'websocket-client', version: versions.jetty
@@ -134,7 +134,7 @@ task verifyJar(type: VerifyJarTask) {
       "logback-classic-${project.versions.logback}.jar",
       "logback-core-${project.versions.logback}.jar",
       "nanohttpd-2.3.1.jar",
-      "objenesis-1.2.jar",
+      "objenesis-${project.versions.objenesis}.jar",
       "org.apache.felix.framework-${project.versions.felix}.jar",
       "plugin-metadata-store-${project.version}.jar",
       "quartz-1.6.5.jar",

--- a/build.gradle
+++ b/build.gradle
@@ -170,6 +170,7 @@ rootProject.ext.versions = [
   mockito2            : '2.13.0',
   nanohttpd           : '2.3.1',
   oro                 : '2.0.8',
+  objenesis           : '2.6',
   rack                : '1.1.21',
   rhino               : '1.7.7.2',
   slf4j               : '1.7.25',

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -183,7 +183,7 @@ dependencies {
   compile group: 'com.google.guava', name: 'guava', version: '20.0'
   compile group: 'com.sun.mail', name: 'mailapi', version: project.versions.mail
   compile group: 'com.sun.mail', name: 'smtp', version: project.versions.mail
-  compile group: 'org.objenesis', name: 'objenesis', version: '1.2'
+  compile group: 'org.objenesis', name: 'objenesis', version: project.versions.objenesis
 
   // needed by jdom2 for some XPATH stuff
   compile(group: 'jaxen', name: 'jaxen', version: '1.1.6') {
@@ -683,7 +683,7 @@ task verifyWar(type: VerifyJarTask) {
         "jta-1.1.jar",
         "kahadb-5.5.0.jar",
         "mailapi-${project.versions.mail}.jar",
-        "objenesis-1.2.jar",
+        "objenesis-${project.versions.objenesis}.jar",
         "org.apache.felix.framework-${project.versions.felix}.jar",
         "org.eclipse.jgit-${project.versions.jgit}.jar",
         "org.eclipse.jgit.http.server-${project.versions.jgit}.jar",


### PR DESCRIPTION
Noticed about 150 threads blocked at `synchronized` method `ObjenesisBase.getInstantiatorOf` in objenesis v1.2 for one of the performance runs. This issue was resolved in v2.0 (method is not synchronized anymore), but upgrading to latest available (v2.6) as of now. The least we need is 2.0, so if we notice an issue with 2.6, we could try downgrading to 2.0