### PR TITLE
Preventing multiple dashboard cache creation calls during startup - #4457

### DIFF
--- a/common/src/main/java/com/thoughtworks/go/presentation/ConfigForEdit.java
+++ b/common/src/main/java/com/thoughtworks/go/presentation/ConfigForEdit.java
@@ -31,7 +31,7 @@ public class ConfigForEdit<T> {
     }
 
     public ConfigForEdit(T config, GoConfigHolder configHolder) {
-        this(config, configHolder.configForEdit, configHolder.config);
+        this(config, configHolder.getConfigForEdit(), configHolder.config);
     }
 
     public T getConfig() {

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/Approval.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/Approval.java
@@ -16,6 +16,7 @@
 
 package com.thoughtworks.go.config;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -27,7 +28,7 @@ import org.apache.commons.lang3.StringUtils;
 
 @ConfigTag(value = "approval")
 //TODO: ChrisS: Make this a proper enumeration
-public class Approval implements Validatable, ParamsAttributeAware {
+public class Approval implements Validatable, ParamsAttributeAware, Serializable {
     @ConfigSubtag(optional = true)
     private AuthConfig authConfig = new AuthConfig();
 

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/Argument.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/Argument.java
@@ -18,8 +18,10 @@ package com.thoughtworks.go.config;
 
 import com.thoughtworks.go.domain.ConfigErrors;
 
+import java.io.Serializable;
+
 @ConfigTag(value = "arg", label = "arg")
-public class Argument implements Validatable{
+public class Argument implements Validatable, Serializable{
     @ConfigValue @ValidationErrorKey(value = ExecTask.ARG_LIST_STRING) private String value;
     private final ConfigErrors configErrors = new ConfigErrors();
 

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/Authorization.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/Authorization.java
@@ -22,6 +22,7 @@ import com.thoughtworks.go.domain.ConfigErrors;
 import com.thoughtworks.go.domain.config.Admin;
 import org.apache.commons.lang3.StringUtils;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -29,7 +30,7 @@ import java.util.Map;
 import static java.util.Collections.sort;
 
 @ConfigTag("authorization")
-public class Authorization implements Validatable, ParamsAttributeAware, ConfigOriginTraceable {
+public class Authorization implements Validatable, ParamsAttributeAware, ConfigOriginTraceable, Serializable {
     @ConfigSubtag
     private ViewConfig viewConfig = new ViewConfig();
 

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/BasicEnvironmentConfig.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/BasicEnvironmentConfig.java
@@ -16,6 +16,7 @@
 
 package com.thoughtworks.go.config;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -34,7 +35,7 @@ import static com.thoughtworks.go.util.command.EnvironmentVariableContext.GO_ENV
  * @understands the current persistent information related to a logical grouping of machines
  */
 @ConfigTag("environment")
-public class BasicEnvironmentConfig implements EnvironmentConfig {
+public class BasicEnvironmentConfig implements EnvironmentConfig, Serializable {
     @ConfigAttribute(value = NAME_FIELD, optional = false)
     private CaseInsensitiveString name;
     @ConfigSubtag

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/EnvironmentAgentConfig.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/EnvironmentAgentConfig.java
@@ -17,6 +17,8 @@
 package com.thoughtworks.go.config;
 
 import static java.lang.String.format;
+
+import java.io.Serializable;
 import java.util.Set;
 
 import com.thoughtworks.go.domain.ConfigErrors;
@@ -25,7 +27,7 @@ import com.thoughtworks.go.domain.ConfigErrors;
  * @understands a reference to an existing agent that is associated to an Environment
  */
 @ConfigTag("physical")
-public class EnvironmentAgentConfig implements Validatable{
+public class EnvironmentAgentConfig implements Validatable, Serializable{
     @ConfigAttribute(value = "uuid", optional = false) private String uuid;
     private ConfigErrors configErrors = new ConfigErrors();
     public static final String UUID = "uuid";

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/EnvironmentConfig.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/EnvironmentConfig.java
@@ -21,13 +21,14 @@ import com.thoughtworks.go.domain.ConfigErrors;
 import com.thoughtworks.go.domain.EnvironmentPipelineMatcher;
 import com.thoughtworks.go.util.command.EnvironmentVariableContext;
 
+import java.io.Serializable;
 import java.util.List;
 import java.util.Set;
 
 /**
  * @understands the current persistent information related to a logical grouping of machines
  */
-public interface EnvironmentConfig extends ParamsAttributeAware, Validatable, EnvironmentVariableScope, ConfigOriginTraceable {
+public interface EnvironmentConfig extends ParamsAttributeAware, Validatable, EnvironmentVariableScope, ConfigOriginTraceable, Serializable {
 
     static final String NAME_FIELD = "name";
     static final String PIPELINES_FIELD = "pipelines";

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/EnvironmentPipelineConfig.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/EnvironmentPipelineConfig.java
@@ -16,6 +16,7 @@
 
 package com.thoughtworks.go.config;
 
+import java.io.Serializable;
 import java.util.List;
 
 import com.thoughtworks.go.domain.ConfigErrors;
@@ -24,7 +25,7 @@ import com.thoughtworks.go.domain.ConfigErrors;
  * @understands a reference to an existing pipeline that is associated to an Environment
  */
 @ConfigTag("pipeline")
-public class EnvironmentPipelineConfig implements Validatable {
+public class EnvironmentPipelineConfig implements Validatable, Serializable {
     public static final String ORIGIN = "origin";
 
     @ConfigAttribute(value = "name", optional = false)

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/JobConfig.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/JobConfig.java
@@ -26,6 +26,7 @@ import com.thoughtworks.go.util.XmlUtils;
 import org.apache.commons.lang3.StringUtils;
 
 import java.util.List;
+import java.io.Serializable;
 import java.util.Map;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -36,7 +37,7 @@ import static org.apache.commons.lang3.StringUtils.isBlank;
  * @understands configuratin for a job
  */
 @ConfigTag("job")
-public class JobConfig implements Validatable, ParamsAttributeAware, EnvironmentVariableScope {
+public class JobConfig implements Validatable, ParamsAttributeAware, EnvironmentVariableScope, Serializable {
     @SkipParameterResolution
     @ConfigAttribute(value = "name", optional = false)
     private CaseInsensitiveString jobName;

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/MingleConfig.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/MingleConfig.java
@@ -24,6 +24,7 @@ import com.thoughtworks.go.util.XmlUtils;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.http.client.utils.URIBuilder;
 
+import java.io.Serializable;
 import java.net.URISyntaxException;
 import java.util.Map;
 import java.util.regex.Pattern;
@@ -32,7 +33,7 @@ import java.util.regex.Pattern;
  * @understands mingle project for pipeline
  */
 @ConfigTag("mingle")
-public class MingleConfig implements ParamsAttributeAware, Validatable, CommentRenderer {
+public class MingleConfig implements ParamsAttributeAware, Validatable, CommentRenderer, Serializable {
     @ConfigAttribute(value = "baseUrl", optional = false)
     private String baseUrl;
 

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/MqlCriteria.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/MqlCriteria.java
@@ -16,6 +16,7 @@
 
 package com.thoughtworks.go.config;
 
+import java.io.Serializable;
 import java.util.Map;
 
 import com.thoughtworks.go.domain.ConfigErrors;
@@ -26,7 +27,7 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
  * @understands MQL criteria for a mingle config
  */
 @ConfigTag("mqlGroupingConditions")
-public class MqlCriteria implements ParamsAttributeAware, Validatable {
+public class MqlCriteria implements ParamsAttributeAware, Validatable, Serializable {
     @ConfigValue
     private String mql;
 

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/OnCancelConfig.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/OnCancelConfig.java
@@ -16,6 +16,7 @@
 
 package com.thoughtworks.go.config;
 
+import java.io.Serializable;
 import java.util.Map;
 
 import com.thoughtworks.go.domain.ConfigErrors;
@@ -25,7 +26,7 @@ import com.thoughtworks.go.domain.Task;
 import com.thoughtworks.go.service.TaskFactory;
 
 @ConfigTag(value = "oncancel", label = "OnCancel")
-public class OnCancelConfig implements Validatable {
+public class OnCancelConfig implements Validatable, Serializable {
 
     public static final String EXEC_ON_CANCEL = "execOnCancel";
     public static final String ANT_ON_CANCEL = "antOnCancel";

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/ParamConfig.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/ParamConfig.java
@@ -16,6 +16,7 @@
 
 package com.thoughtworks.go.config;
 
+import java.io.Serializable;
 import java.util.Map;
 
 import com.thoughtworks.go.config.validation.NameTypeValidator;
@@ -23,7 +24,7 @@ import com.thoughtworks.go.domain.ConfigErrors;
 import org.apache.commons.lang3.StringUtils;
 
 @ConfigTag("param")
-public class ParamConfig implements Validatable {
+public class ParamConfig implements Validatable, Serializable {
     @ConfigAttribute(value = "name", optional = false) private String name;
     @ConfigValue private String value;
     private final ConfigErrors configErrors = new ConfigErrors();

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/PathFromAncestor.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/PathFromAncestor.java
@@ -16,12 +16,13 @@
 
 package com.thoughtworks.go.config;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
 @ConfigAttributeValue(fieldName = "path", createForNull = false)
-public class PathFromAncestor {
+public class PathFromAncestor implements Serializable {
     public static final String DELIMITER = "/";
     private final CaseInsensitiveString path;
 

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/PipelineConfigs.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/PipelineConfigs.java
@@ -20,11 +20,12 @@ import com.thoughtworks.go.config.remote.ConfigOriginTraceable;
 import com.thoughtworks.go.domain.ConfigErrors;
 import com.thoughtworks.go.domain.PiplineConfigVisitor;
 
+import java.io.Serializable;
 import java.util.List;
 import java.util.Map;
 
 public interface PipelineConfigs extends Iterable<PipelineConfig>, Cloneable, Validatable,
-        ParamsAttributeAware, ConfigOriginTraceable {
+        ParamsAttributeAware, ConfigOriginTraceable, Serializable {
 
     public static final String DEFAULT_GROUP = "defaultGroup";
     public static final String GROUP = "group";

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/StageConfig.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/StageConfig.java
@@ -22,6 +22,7 @@ import com.thoughtworks.go.domain.ConfigErrors;
 import com.thoughtworks.go.service.TaskFactory;
 import com.thoughtworks.go.util.GoConstants;
 
+import java.io.Serializable;
 import java.util.List;
 import java.util.Map;
 
@@ -29,7 +30,7 @@ import java.util.Map;
  * @understands the configuration for a stage
  */
 @ConfigTag("stage")
-public class StageConfig implements Validatable, ParamsAttributeAware, EnvironmentVariableScope {
+public class StageConfig implements Validatable, ParamsAttributeAware, EnvironmentVariableScope, Serializable {
     @SkipParameterResolution
     @ConfigAttribute(value = "name", optional = false)
     private CaseInsensitiveString name;

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/Tab.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/Tab.java
@@ -16,6 +16,7 @@
 
 package com.thoughtworks.go.config;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -24,7 +25,7 @@ import com.thoughtworks.go.domain.ConfigErrors;
 
 
 @ConfigTag("tab")
-public class Tab implements Validatable {
+public class Tab implements Validatable, Serializable {
     @ConfigAttribute(value = "name", optional = false)
     private String name;
     @ConfigAttribute(value = "path", optional = false)

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/TimerConfig.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/TimerConfig.java
@@ -19,6 +19,7 @@ package com.thoughtworks.go.config;
 import com.thoughtworks.go.domain.ConfigErrors;
 import org.quartz.CronExpression;
 
+import java.io.Serializable;
 import java.text.ParseException;
 import java.util.Map;
 
@@ -27,7 +28,7 @@ import java.util.Map;
  * @understands Configuration of a Pipeline cron timer
  */
 @ConfigTag("timer")
-public class TimerConfig implements Validatable {
+public class TimerConfig implements Validatable, Serializable {
     @ConfigAttribute(value = "onlyOnChanges", optional = true, allowNull = true) private Boolean onlyOnChanges = false;
     @ConfigValue private String timerSpec;
 

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/TrackingTool.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/TrackingTool.java
@@ -21,10 +21,11 @@ import com.thoughtworks.go.domain.ConfigErrors;
 import com.thoughtworks.go.domain.DefaultCommentRenderer;
 import org.apache.commons.lang3.StringUtils;
 
+import java.io.Serializable;
 import java.util.Map;
 
 @ConfigTag("trackingtool")
-public class TrackingTool implements ParamsAttributeAware, Validatable, CommentRenderer {
+public class TrackingTool implements ParamsAttributeAware, Validatable, CommentRenderer, Serializable {
     @ConfigAttribute(value = "link", optional = false)
     private String link = "";
     @ConfigAttribute(value = "regex", optional = false)

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/remote/ConfigOrigin.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/remote/ConfigOrigin.java
@@ -1,24 +1,26 @@
-/*************************GO-LICENSE-START*********************************
- * Copyright 2014 ThoughtWorks, Inc.
+/*
+ * Copyright 2018 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *************************GO-LICENSE-END***********************************/
+ */
 package com.thoughtworks.go.config.remote;
+
+import java.io.Serializable;
 
 /**
  * @understands where configuration comes from.
  */
-public interface ConfigOrigin {
+public interface ConfigOrigin extends Serializable {
     /**
      * @return true when configuration source can be modified.
      */

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/remote/ConfigRepoConfig.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/remote/ConfigRepoConfig.java
@@ -24,6 +24,7 @@ import com.thoughtworks.go.domain.config.ConfigurationProperty;
 import com.thoughtworks.go.domain.materials.MaterialConfig;
 import org.apache.commons.lang3.StringUtils;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -34,7 +35,7 @@ import java.util.UUID;
  * This goes to standard static xml configuration.
  */
 @ConfigTag("config-repo")
-public class ConfigRepoConfig implements Validatable {
+public class ConfigRepoConfig implements Validatable, Serializable {
     // defines source of configuration. Any will fit
     @ConfigSubtag(optional = false)
     private MaterialConfig repo;

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/remote/PartialConfig.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/remote/PartialConfig.java
@@ -1,18 +1,18 @@
-/*************************GO-LICENSE-START*********************************
- * Copyright 2014 ThoughtWorks, Inc.
+/*
+ * Copyright 2018 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *************************GO-LICENSE-END***********************************/
+ */
 package com.thoughtworks.go.config.remote;
 
 
@@ -20,13 +20,16 @@ import com.thoughtworks.go.config.*;
 import com.thoughtworks.go.config.preprocessor.SkipParameterResolution;
 import com.thoughtworks.go.domain.ConfigErrors;
 import com.thoughtworks.go.domain.PipelineGroups;
+import com.thoughtworks.go.util.validators.Validation;
+
+import java.io.Serializable;
 
 /**
  * Part of cruise configuration that can be stored outside of main cruise-config.xml.
  * It can be merged with others and main configuration.
  */
 @ConfigTag("cruise")
-public class PartialConfig implements Validatable, ConfigOriginTraceable {
+public class PartialConfig implements Validatable, ConfigOriginTraceable, Serializable {
     // consider to include source of this part.
 
     @ConfigSubtag(label = "groups") private PipelineGroups pipelines = new PipelineGroups();

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/remote/RepoConfigOrigin.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/remote/RepoConfigOrigin.java
@@ -17,10 +17,12 @@ package com.thoughtworks.go.config.remote;
 
 import com.thoughtworks.go.domain.materials.MaterialConfig;
 
+import java.io.Serializable;
+
 /**
  * @understands that configuration is defined in versioned source code repository at particular revision.
  */
-public class RepoConfigOrigin implements ConfigOrigin {
+public class RepoConfigOrigin implements ConfigOrigin, Serializable {
 
     private ConfigRepoConfig configRepo;
     private String revision;

--- a/config/config-api/src/main/java/com/thoughtworks/go/domain/PipelineGroups.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/domain/PipelineGroups.java
@@ -32,8 +32,8 @@ import com.thoughtworks.go.util.Pair;
 @ConfigCollection(value = BasicPipelineConfigs.class)
 public class PipelineGroups extends BaseCollection<PipelineConfigs> implements Validatable {
     private final ConfigErrors configErrors = new ConfigErrors();
-    private Map<String, List<Pair<PipelineConfig, PipelineConfigs>>> packageToPipelineMap;
-    private Map<String, List<Pair<PipelineConfig, PipelineConfigs>>> pluggableSCMMaterialToPipelineMap;
+    private transient Map<String, List<Pair<PipelineConfig, PipelineConfigs>>> packageToPipelineMap;
+    private transient Map<String, List<Pair<PipelineConfig, PipelineConfigs>>> pluggableSCMMaterialToPipelineMap;
 
     public PipelineGroups() {
     }

--- a/config/config-api/src/main/java/com/thoughtworks/go/domain/Task.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/domain/Task.java
@@ -16,6 +16,7 @@
 
 package com.thoughtworks.go.domain;
 
+import java.io.Serializable;
 import java.util.List;
 
 import com.thoughtworks.go.config.ConfigInterface;
@@ -25,7 +26,7 @@ import com.thoughtworks.go.config.ValidationContext;
 import com.thoughtworks.go.service.TaskFactory;
 
 @ConfigInterface
-public interface Task extends ParamsAttributeAware, Validatable {
+public interface Task extends ParamsAttributeAware, Validatable, Serializable {
     public static final String TASK_TYPE = "task_type";
 
     RunIfConfigs getConditions();

--- a/config/config-api/src/main/java/com/thoughtworks/go/util/CachedDigestUtils.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/util/CachedDigestUtils.java
@@ -1,26 +1,28 @@
-/*************************GO-LICENSE-START*********************************
- * Copyright 2014 ThoughtWorks, Inc.
+/*
+ * Copyright 2018 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *************************GO-LICENSE-END***********************************/
+ */
 
 package com.thoughtworks.go.util;
 
 import com.thoughtworks.go.util.pool.DigestObjectPools;
 import org.apache.commons.codec.binary.Hex;
 
-import java.io.IOException;
+import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
+import java.io.ObjectOutputStream;
+import java.security.MessageDigest;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
@@ -46,6 +48,19 @@ public class CachedDigestUtils {
         String digest = compute(string, DigestObjectPools.SHA_256);
         shaDigestCache.putIfAbsent(string, digest);
         return digest;
+    }
+
+    public static String md5Hex(Object serializable) {
+        return objectPools.computeDigest(DigestObjectPools.MD_5, messageDigest -> {
+            try (ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream()) {
+                try (ObjectOutputStream objectOutputStream = new ObjectOutputStream(byteArrayOutputStream)) {
+                    objectOutputStream.writeObject(serializable);
+                    return Hex.encodeHexString(messageDigest.digest(byteArrayOutputStream.toByteArray()));
+                }
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        });
     }
 
     public static String md5Hex(String string) {

--- a/config/config-api/src/test/java/com/thoughtworks/go/config/GoConfigHolderTest.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/config/GoConfigHolderTest.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2018 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.config;
+
+import com.thoughtworks.go.config.remote.ConfigRepoConfig;
+import com.thoughtworks.go.config.remote.PartialConfig;
+import com.thoughtworks.go.config.remote.RepoConfigOrigin;
+import com.thoughtworks.go.helper.PartialConfigMother;
+import com.thoughtworks.go.helper.PipelineConfigMother;
+import com.thoughtworks.go.security.GoCipher;
+import com.thoughtworks.go.util.ReflectionUtil;
+import org.apache.commons.codec.binary.Hex;
+import org.apache.commons.codec.digest.DigestUtils;
+import org.junit.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectOutputStream;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.apache.commons.codec.digest.DigestUtils.md5Hex;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsNull.nullValue;
+import static org.junit.Assert.assertThat;
+
+public class GoConfigHolderTest {
+    @Test
+    public void shouldStoreMd5Checksum() throws Exception {
+        BasicCruiseConfig config = configWithMd5("main-config-md5");
+        GoConfigHolder holder = new GoConfigHolder(config, config, config, partials(config.getConfigRepos().first()));
+
+        assertThat(holder.getChecksum().md5SumOfConfigForEdit, is("main-config-md5"));
+        assertThat(holder.getChecksum().md5SumOfPartials, is(md5(partials(config.getConfigRepos().first()))));
+    }
+
+    @Test
+    public void shouldStoreMd5ChecksumWhenThereIsNotConfigRepo() throws Exception {
+        BasicCruiseConfig config = configWithMd5("main-config-md5");
+        config.getConfigRepos().clear();
+        GoConfigHolder holder = new GoConfigHolder(config, config, null, null);
+
+        assertThat(holder.getChecksum().md5SumOfConfigForEdit, is("main-config-md5"));
+        assertThat(holder.getChecksum().md5SumOfPartials, is(nullValue()));
+    }
+
+    @Test
+    public void updatingMergedConfigShouldUpdateChecksum() throws Exception {
+        BasicCruiseConfig config = configWithMd5("main-config-md5");
+        GoConfigHolder holder = new GoConfigHolder(config, config, null, null);
+
+        assertThat(holder.getChecksum().md5SumOfConfigForEdit, is("main-config-md5"));
+        assertThat(holder.getChecksum().md5SumOfPartials, is(nullValue()));
+
+        holder.setMergedConfigForEdit(new BasicCruiseConfig(), partials(config.getConfigRepos().first()));
+        assertThat(holder.getChecksum().md5SumOfConfigForEdit, is("main-config-md5"));
+        assertThat(holder.getChecksum().md5SumOfPartials, is(md5(partials(config.getConfigRepos().first()))));
+    }
+
+    @Test
+    public void shouldGenerateSameChecksumIfTheObjectsHaventChanged() {
+        BasicCruiseConfig config = configWithMd5("main-config-md5");
+        GoConfigHolder holder1 = new GoConfigHolder(config, config, config, partials(config.getConfigRepos().first()));
+        GoConfigHolder holder2 = new GoConfigHolder(config, config, config, partials(config.getConfigRepos().first()));
+
+        assertThat(holder1.getChecksum().equals(holder2.getChecksum()), is(true));
+    }
+
+    @Test
+    public void checksumsShouldDifferIfThePartialsHaveChanged() {
+        BasicCruiseConfig config = configWithMd5("main-config-md5");
+        GoConfigHolder holder1 = new GoConfigHolder(config, config, config,
+                Arrays.asList(PartialConfigMother.withPipeline("p1"), PartialConfigMother.withEnvironment("e1")));
+        GoConfigHolder holder2 = new GoConfigHolder(config, config, config,
+                Arrays.asList(PartialConfigMother.withPipeline("p2"), PartialConfigMother.withEnvironment("e1")));
+
+        assertThat(holder1.getChecksum().equals(holder2.getChecksum()), is(false));
+    }
+
+    @Test
+    public void checksumsShouldDifferIfTheConfigRepoHasChanged() {
+        BasicCruiseConfig config = configWithMd5("main-config-md5");
+        GoConfigHolder holder1 = new GoConfigHolder(config, config, config, partials(new ConfigRepoConfig()));
+        GoConfigHolder holder2 = new GoConfigHolder(config, config, config, partials(new ConfigRepoConfig()));
+
+        assertThat(holder1.getChecksum().equals(holder2.getChecksum()), is(false));
+    }
+
+    @Test
+    public void checksumsShouldDifferIfTheMainConfigHasChanged() {
+        BasicCruiseConfig config = configWithMd5("main-config-md5");
+        GoConfigHolder holder1 = new GoConfigHolder(config, config, config,
+                Arrays.asList(PartialConfigMother.withPipeline("p1"), PartialConfigMother.withEnvironment("e1")));
+        BasicCruiseConfig config2 = configWithMd5("main-config-md5");
+        GoConfigHolder holder2 = new GoConfigHolder(config2, config2, config2,
+                Arrays.asList(PartialConfigMother.withPipeline("p1"), PartialConfigMother.withEnvironment("e2")));
+
+        assertThat(holder1.getChecksum().equals(holder2.getChecksum()), is(false));
+    }
+
+    private BasicCruiseConfig configWithMd5(String md5) {
+        BasicCruiseConfig basicCruiseConfig = new BasicCruiseConfig();
+        ReflectionUtil.setField(basicCruiseConfig, "md5", md5);
+        basicCruiseConfig.getConfigRepos().add(new ConfigRepoConfig());
+        return basicCruiseConfig;
+    }
+
+    private List<PartialConfig> partials(ConfigRepoConfig configRepo) {
+        PartialConfig environmentWithEnvVars = PartialConfigMother.withEnvironment("e2");
+        environmentWithEnvVars.getEnvironments().first().addEnvironmentVariable(new EnvironmentVariableConfig(new GoCipher(), "plain", "value", false));
+        environmentWithEnvVars.getEnvironments().first().addEnvironmentVariable(new EnvironmentVariableConfig(new GoCipher(), "secure", "encrypted", true));
+        return Arrays.asList(PartialConfigMother.withPipeline("p1"),
+                PartialConfigMother.withEnvironment("e1"),
+                PartialConfigMother.pipelineWithDependencyMaterial("downstream", PipelineConfigMother.pipelineConfig("upstream"), new RepoConfigOrigin(configRepo, "rev1")),
+                environmentWithEnvVars,
+                PartialConfigMother.withPipelineAssociatedWithTemplate("p2", "t1", new RepoConfigOrigin(configRepo, "rev1")),
+                PartialConfigMother.withPipelineInGroup("p3", "g1"),
+                PartialConfigMother.withFullBlownPipeline("p4")
+        );
+    }
+
+    private String md5(Object obj) throws IOException {
+        try (ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream()) {
+            try (ObjectOutputStream objectOutputStream = new ObjectOutputStream(byteArrayOutputStream)) {
+                objectOutputStream.writeObject(obj);
+                return md5Hex(byteArrayOutputStream.toByteArray());
+            }
+        }
+    }
+
+}

--- a/config/config-api/src/test/java/com/thoughtworks/go/config/remote/PartialConfigTest.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/config/remote/PartialConfigTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2018 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.config.remote;
+
+import org.junit.Test;
+import java.io.Serializable;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+
+public class PartialConfigTest {
+    @Test
+    public void ensureAllElementsUnderPartialConfigAreMarkedAsSerializable() {
+        List<Class> walked = new ArrayList<>();
+        assertAllFieldsInTheTreeAreSerializable(walked, PartialConfig.class);
+    }
+
+    private void assertAllFieldsInTheTreeAreSerializable(List<Class> walked, Class clazz) {
+        if (clazz.isPrimitive()) return;
+        assertThat(String.format("'%s' does not implement Serializable", clazz.getName()), Serializable.class.isAssignableFrom(clazz), is(true));
+        if (walked.contains(clazz)) return;
+        walked.add(clazz);
+        System.out.println(String.format("Checking '%s'..", clazz.getName()));
+        handleCollections(walked, clazz);
+
+        for (Field declaredField : clazz.getDeclaredFields()) {
+            if (declaredField.getType().isPrimitive()) continue;
+            if (Modifier.isTransient(declaredField.getModifiers()) || Modifier.isStatic(declaredField.getModifiers()))
+                continue;
+            System.out.println(String.format("Checking '%s.%s'..", declaredField.getDeclaringClass().getName(), declaredField.getName()));
+            assertThat(String.format("'%s.%s' does not implement Serializable", declaredField.getDeclaringClass().getName(), declaredField.getName()),
+                    Serializable.class.isAssignableFrom(declaredField.getType()), is(true));
+
+            assertAllFieldsInTheTreeAreSerializable(walked, declaredField.getType());
+            handleCollections(walked, declaredField.getType());
+        }
+    }
+
+    private void handleCollections(List<Class> walked, Class clazz) {
+        if (clazz.isPrimitive()) return;
+        if (ArrayList.class.isAssignableFrom(clazz) || Iterable.class.isAssignableFrom(clazz)) {
+            if (clazz.getGenericSuperclass() != null && ParameterizedType.class.isAssignableFrom(clazz.getGenericSuperclass().getClass())) {
+                Class genericClassUsedByCollection = (Class) ((ParameterizedType) clazz.getGenericSuperclass()).getActualTypeArguments()[0];
+                assertAllFieldsInTheTreeAreSerializable(walked, genericClassUsedByCollection);
+            }
+            Type[] genericInterfaces = clazz.getGenericInterfaces();
+            for (Type genericInterface : genericInterfaces) {
+                if (!ParameterizedType.class.isAssignableFrom(genericInterface.getClass())) continue;
+                Class genericInterfaceUsedByCollection = (Class) ((ParameterizedType) genericInterface).getActualTypeArguments()[0];
+                assertAllFieldsInTheTreeAreSerializable(walked, genericInterfaceUsedByCollection);
+            }
+        }
+    }
+}

--- a/config/config-api/src/test/java/com/thoughtworks/go/helper/PartialConfigMother.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/helper/PartialConfigMother.java
@@ -36,6 +36,21 @@ public class PartialConfigMother {
         return withPipeline(name, createRepoOrigin());
     }
 
+    public static PartialConfig withFullBlownPipeline(String name) {
+        PartialConfig partialConfig = withPipeline(name, createRepoOrigin());
+        PipelineConfig pipeline = partialConfig.getGroups().first().get(0);
+        pipeline.setTimer(new TimerConfig("spec", true));
+        pipeline.setTrackingTool(new TrackingTool("link", "regex"));
+        pipeline.setParams(new ParamsConfig(new ParamConfig("name", "value")));
+        StageConfig s1 = StageConfigMother.stageConfig("s1");
+        s1.getJobs().add(JobConfigMother.jobConfig());
+        s1.getJobs().add(JobConfigMother.elasticJob("j3", "profileId"));
+        s1.getJobs().add(JobConfigMother.withAllKindsOfTasks("j4"));
+        pipeline.add(s1);
+        pipeline.add(StageConfigMother.stageConfig("s2"));
+        return partialConfig;
+    }
+
     public static PartialConfig pipelineWithDependencyMaterial(String name, PipelineConfig upstream, RepoConfigOrigin repoConfig) {
         PartialConfig partialConfig = withPipeline(name, repoConfig);
         PipelineConfig pipeline = partialConfig.getGroups().first().get(0);

--- a/config/config-api/src/test/java/com/thoughtworks/go/util/CachedDigestUtilsTest.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/util/CachedDigestUtilsTest.java
@@ -16,12 +16,16 @@
 
 package com.thoughtworks.go.util;
 
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.util.Random;
-
+import com.thoughtworks.go.config.remote.PartialConfig;
+import com.thoughtworks.go.helper.PartialConfigMother;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectOutputStream;
+import java.util.Random;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
@@ -64,5 +68,19 @@ public class CachedDigestUtilsTest {
         assertThat(DigestUtils.md5Hex(testData),
                 is(CachedDigestUtils.md5Hex(new ByteArrayInputStream(testData))));
 
+    }
+
+    @Test
+    public void shouldComputeMd5SumOfObjects() throws Exception {
+        PartialConfig serializableObject = PartialConfigMother.withFullBlownPipeline("pipeline");
+        byte[] byteArray;
+
+        try (ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream()) {
+            try (ObjectOutputStream objectOutputStream = new ObjectOutputStream(byteArrayOutputStream)) {
+                objectOutputStream.writeObject(serializableObject);
+                byteArray = byteArrayOutputStream.toByteArray();
+            }
+        }
+        assertThat(DigestUtils.md5Hex(byteArray), is(CachedDigestUtils.md5Hex(serializableObject)));
     }
 }

--- a/config/config-server/src/main/java/com/thoughtworks/go/config/GoConfigMigration.java
+++ b/config/config-server/src/main/java/com/thoughtworks/go/config/GoConfigMigration.java
@@ -130,7 +130,7 @@ public class GoConfigMigration {
 
     private GoConfigHolder reloadedConfig(ByteArrayOutputStream stream, String upgradedXmlString) throws Exception {
         GoConfigHolder configHolder = validateAfterMigrationFinished(upgradedXmlString);
-        new MagicalGoConfigXmlWriter(configCache, registry).write(configHolder.configForEdit, stream, false);
+        new MagicalGoConfigXmlWriter(configCache, registry).write(configHolder.getConfigForEdit(), stream, false);
         return configHolder;
     }
 

--- a/config/config-server/src/test/java/com/thoughtworks/go/config/MagicalGoConfigXmlLoaderTest.java
+++ b/config/config-server/src/test/java/com/thoughtworks/go/config/MagicalGoConfigXmlLoaderTest.java
@@ -296,7 +296,7 @@ public class MagicalGoConfigXmlLoaderTest {
             }
         });
         assertThat(goConfigHolder.config.getOrigin(), Is.<ConfigOrigin>is(new MergeConfigOrigin()));
-        assertThat(goConfigHolder.configForEdit.getOrigin(), Is.<ConfigOrigin>is(new FileConfigOrigin()));
+        assertThat(goConfigHolder.getConfigForEdit().getOrigin(), Is.<ConfigOrigin>is(new FileConfigOrigin()));
     }
 
     @Test
@@ -2433,7 +2433,7 @@ public class MagicalGoConfigXmlLoaderTest {
         assertThat(svnMaterialConfig.getEncryptedPassword(), is(encryptedPassword));
         assertThat(svnMaterialConfig.getPassword(), is(password));
 
-        CruiseConfig configForEdit = configHolder.configForEdit;
+        CruiseConfig configForEdit = configHolder.getConfigForEdit();
         svnMaterialConfig = (SvnMaterialConfig) configForEdit.pipelineConfigByName(new CaseInsensitiveString("pipeline1")).materialConfigs().get(0);
         assertThat(svnMaterialConfig.getEncryptedPassword(), is(encryptedPassword));
         assertThat(svnMaterialConfig.getPassword(), is("abc"));
@@ -3354,7 +3354,7 @@ public class MagicalGoConfigXmlLoaderTest {
                         "       </pipeline>" +
                         "   </templates>" +
                         "</cruise>";
-        CruiseConfig configForEdit = ConfigMigrator.loadWithMigration(configString).configForEdit;
+        CruiseConfig configForEdit = ConfigMigrator.loadWithMigration(configString).getConfigForEdit();
         PipelineTemplateConfig template = configForEdit.getTemplateByName(new CaseInsensitiveString("template-name"));
         Authorization authorization = template.getAuthorization();
         assertThat(authorization, is(not(nullValue())));
@@ -3387,7 +3387,7 @@ public class MagicalGoConfigXmlLoaderTest {
                         + "  </stage>"
                         + "</pipeline></pipelines>"
                         + "</cruise>";
-        CruiseConfig cruiseConfig = ConfigMigrator.loadWithMigration(configString).configForEdit;
+        CruiseConfig cruiseConfig = ConfigMigrator.loadWithMigration(configString).getConfigForEdit();
 
         PipelineConfig pipelineConfig = cruiseConfig.getAllPipelineConfigs().get(0);
         JobConfig jobConfig = pipelineConfig.getFirstStageConfig().getJobs().get(0);
@@ -3618,7 +3618,7 @@ public class MagicalGoConfigXmlLoaderTest {
                         + "</pipelines>\n"
                         + "</cruise>\n";
 
-        CruiseConfig cruiseConfig = ConfigMigrator.loadWithMigration(configWithJobElasticProfileId).configForEdit;
+        CruiseConfig cruiseConfig = ConfigMigrator.loadWithMigration(configWithJobElasticProfileId).getConfigForEdit();
 
         String elasticProfileId = cruiseConfig.pipelineConfigByName(new CaseInsensitiveString("pipeline")).getStage("mingle").jobConfigByConfigName("functional").getElasticProfileId();
 
@@ -3641,7 +3641,7 @@ public class MagicalGoConfigXmlLoaderTest {
                         + "  </elastic>\n"
                         + "</cruise>\n";
 
-        CruiseConfig cruiseConfig = ConfigMigrator.loadWithMigration(configWithElasticProfile).configForEdit;
+        CruiseConfig cruiseConfig = ConfigMigrator.loadWithMigration(configWithElasticProfile).getConfigForEdit();
 
         assertThat(cruiseConfig.getElasticConfig().getJobStarvationTimeout(), is(120000L));
         assertThat(cruiseConfig.getElasticConfig().getProfiles().size(), is(1));
@@ -3675,7 +3675,7 @@ public class MagicalGoConfigXmlLoaderTest {
                         + "</pipelines>\n"
                         + "</cruise>\n";
         try {
-            CruiseConfig cruiseConfig = ConfigMigrator.loadWithMigration(configWithJobElasticProfile).configForEdit;
+            CruiseConfig cruiseConfig = ConfigMigrator.loadWithMigration(configWithJobElasticProfile).getConfigForEdit();
             fail("expected exception!");
         } catch (Exception e) {
             assertThat(e.getCause().getCause(), instanceOf(GoConfigInvalidException.class));
@@ -3892,7 +3892,7 @@ public class MagicalGoConfigXmlLoaderTest {
                 "</artifactStores>" +
                 "</cruise>";
 
-        final CruiseConfig cruiseConfig = ConfigMigrator.loadWithMigration(configXml).configForEdit;
+        final CruiseConfig cruiseConfig = ConfigMigrator.loadWithMigration(configXml).getConfigForEdit();
         assertThat(cruiseConfig.getArtifactStores(), hasSize(2));
         assertThat(cruiseConfig.getArtifactStores(), contains(
                 new ArtifactStore("bar", "foo", create("ACCESS_KEY", false, "dasdas")),
@@ -3989,7 +3989,7 @@ public class MagicalGoConfigXmlLoaderTest {
                 "  </pipelines>" +
                 "</cruise>";
 
-        final CruiseConfig cruiseConfig = ConfigMigrator.loadWithMigration(configXml).configForEdit;
+        final CruiseConfig cruiseConfig = ConfigMigrator.loadWithMigration(configXml).getConfigForEdit();
         final ArtifactConfigs artifactConfigs = cruiseConfig.pipelineConfigByName(
                 new CaseInsensitiveString("up42")).getStage("up42_stage")
                 .getJobs().getJob(new CaseInsensitiveString("up42_job")).artifactConfigs();

--- a/config/config-server/src/test/java/com/thoughtworks/go/config/MagicalGoConfigXmlWriterTest.java
+++ b/config/config-server/src/test/java/com/thoughtworks/go/config/MagicalGoConfigXmlWriterTest.java
@@ -259,7 +259,7 @@ public class MagicalGoConfigXmlWriterTest {
                 + "  </pipeline>\n"
                 + "</templates>\n"
                 + "</cruise>";
-        CruiseConfig config = ConfigMigrator.loadWithMigration(content).configForEdit;
+        CruiseConfig config = ConfigMigrator.loadWithMigration(content).getConfigForEdit();
         xmlWriter.write(config, output, false);
         assertThat(output.toString().replaceAll("\\s+", " "), containsString(
                 "<pipeline name=\"pipeline1\" template=\"abc\">"
@@ -418,7 +418,7 @@ public class MagicalGoConfigXmlWriterTest {
                 + "  </pipeline>\n"
                 + "</templates>\n"
                 + "</cruise>";
-        CruiseConfig config = ConfigMigrator.loadWithMigration(content).configForEdit;
+        CruiseConfig config = ConfigMigrator.loadWithMigration(content).getConfigForEdit();
         xmlWriter.write(config, output, false);
         assertThat(output.toString().replaceAll("\\s+", " "), containsString(
                 "<svn url=\"svnurl\" username=\"foo\" encryptedPassword=\"" + new GoCipher().encrypt("password") + "\" />"));

--- a/config/config-server/src/test/java/com/thoughtworks/go/config/serialization/JobPropertiesTest.java
+++ b/config/config-server/src/test/java/com/thoughtworks/go/config/serialization/JobPropertiesTest.java
@@ -51,7 +51,7 @@ public class JobPropertiesTest {
                 + "    <property name=\"prop2\" src=\"test.xml\" xpath=\"//value\" />\n"
                 + "  </properties>\n"
                 + "</job>";
-        CruiseConfig config = loader.loadConfigHolder(ConfigFileFixture.withJob(jobXml)).configForEdit;
+        CruiseConfig config = loader.loadConfigHolder(ConfigFileFixture.withJob(jobXml)).getConfigForEdit();
         JobConfig jobConfig = config.pipelineConfigByName(new CaseInsensitiveString("pipeline1")).get(1).allBuildPlans().first();
         assertThat(jobConfig.getProperties().first(),
                 is(new ArtifactPropertyConfig("coverage", "reports/emma.html", "//coverage/class")));
@@ -67,7 +67,7 @@ public class JobPropertiesTest {
                 + "    <property name=\"prop2\" src=\"test.xml\" xpath=\"//value\" />\n"
                 + "  </properties>\n"
                 + "</job>";
-        CruiseConfig config = loader.loadConfigHolder(ConfigFileFixture.withJob(jobXml)).configForEdit;
+        CruiseConfig config = loader.loadConfigHolder(ConfigFileFixture.withJob(jobXml)).getConfigForEdit();
         JobConfig jobConfig = config.pipelineConfigByName(new CaseInsensitiveString("pipeline1")).get(1).allBuildPlans().first();
         assertThat(writer.toXmlPartial(jobConfig), is(jobXml));
     }
@@ -125,14 +125,14 @@ public class JobPropertiesTest {
 
     private CruiseConfig cruiseConfigWithProperties(ArtifactPropertyConfig... artifactPropertyConfigs)
             throws Exception {
-        CruiseConfig cruiseConfig = loader.loadConfigHolder(ONE_PIPELINE).configForEdit;
+        CruiseConfig cruiseConfig = loader.loadConfigHolder(ONE_PIPELINE).getConfigForEdit();
         JobConfig jobConfig = BuildPlanMother.withArtifactPropertiesGenerator(artifactPropertyConfigs);
         cruiseConfig.pipelineConfigByName(new CaseInsensitiveString("pipeline1")).first().allBuildPlans().add(jobConfig);
         return cruiseConfig;
     }
 
     private JobConfig loadJobConfig(String jobXml) throws Exception {
-               CruiseConfig config = loader.loadConfigHolder(ConfigFileFixture.withJob(jobXml)).configForEdit;
+               CruiseConfig config = loader.loadConfigHolder(ConfigFileFixture.withJob(jobXml)).getConfigForEdit();
         return config.pipelineConfigByName(new CaseInsensitiveString("pipeline1")).first().allBuildPlans().first();
     }
 

--- a/config/config-server/src/test/java/com/thoughtworks/go/config/serialization/RolesConfigTest.java
+++ b/config/config-server/src/test/java/com/thoughtworks/go/config/serialization/RolesConfigTest.java
@@ -35,7 +35,7 @@ public class RolesConfigTest {
     @Before
     public void setUp() throws Exception {
         config = new MagicalGoConfigXmlLoader(new ConfigCache(), ConfigElementImplementationRegistryMother.withNoPlugins()).loadConfigHolder(
-                ConfigFileFixture.CONFIG).configForEdit;
+                ConfigFileFixture.CONFIG).getConfigForEdit();
     }
 
     @Test

--- a/config/config-server/src/test/java/com/thoughtworks/go/config/serialization/SecurityConfigTest.java
+++ b/config/config-server/src/test/java/com/thoughtworks/go/config/serialization/SecurityConfigTest.java
@@ -30,7 +30,7 @@ public class SecurityConfigTest {
     @Test
     public void shouldAllowUnorderedRoleAndUserInXsd() throws Exception {
         CruiseConfig config = new MagicalGoConfigXmlLoader(new ConfigCache(), ConfigElementImplementationRegistryMother.withNoPlugins()).loadConfigHolder(ConfigMigrator.migrate(
-                ConfigFileFixture.DEFAULT_XML_WITH_2_AGENTS)).configForEdit;
+                ConfigFileFixture.DEFAULT_XML_WITH_2_AGENTS)).getConfigForEdit();
         config.setServerConfig(new ServerConfig("dir", security(null, admins(role("role2"), user("jez"), role("role1")))));
         new MagicalGoConfigXmlWriter(new ConfigCache(), ConfigElementImplementationRegistryMother.withNoPlugins()).write(config, new ByteArrayOutputStream(), false);
     }

--- a/server/src/main/java/com/thoughtworks/go/config/CachedGoConfig.java
+++ b/server/src/main/java/com/thoughtworks/go/config/CachedGoConfig.java
@@ -185,13 +185,18 @@ public class CachedGoConfig {
             this.lastException = null;
             this.configHolder = configHolder;
             this.currentConfig = this.configHolder.config;
-            this.currentConfigForEdit = this.configHolder.configForEdit;
-            this.mergedCurrentConfigForEdit = configHolder.mergedConfigForEdit;
+            this.currentConfigForEdit = this.configHolder.getConfigForEdit();
+            this.mergedCurrentConfigForEdit = configHolder.getMergedConfigForEdit();
             serverHealthService.update(ServerHealthState.success(HealthStateType.invalidConfig()));
         }
     }
 
     private synchronized void saveValidConfigToCacheAndNotifyConfigChangeListeners(GoConfigHolder configHolder) {
+        if (this.configHolder != null && configHolder != null &&
+                this.configHolder.getChecksum().equals(configHolder.getChecksum())) {
+            return;
+        }
+
         saveValidConfigToCache(configHolder);
         if (configHolder != null) {
             notifyListeners(currentConfig);

--- a/server/src/main/java/com/thoughtworks/go/config/FullConfigSaveFlow.java
+++ b/server/src/main/java/com/thoughtworks/go/config/FullConfigSaveFlow.java
@@ -138,9 +138,9 @@ public abstract class FullConfigSaveFlow {
         if (partials.isEmpty()) return;
 
         LOGGER.debug("[Config Save] Updating GoConfigHolder with mergedCruiseConfigForEdit: Starting.");
-        CruiseConfig mergedCruiseConfigForEdit = cloner.deepClone(validatedConfigHolder.configForEdit);
+        CruiseConfig mergedCruiseConfigForEdit = cloner.deepClone(validatedConfigHolder.getConfigForEdit());
         mergedCruiseConfigForEdit.merge(partials, true);
-        validatedConfigHolder.mergedConfigForEdit = mergedCruiseConfigForEdit;
+        validatedConfigHolder.setMergedConfigForEdit(mergedCruiseConfigForEdit, partials);
         LOGGER.debug("[Config Save] Updating GoConfigHolder with mergedCruiseConfigForEdit: Done.");
     }
 }

--- a/server/src/main/java/com/thoughtworks/go/config/FullConfigSaveMergeFlow.java
+++ b/server/src/main/java/com/thoughtworks/go/config/FullConfigSaveMergeFlow.java
@@ -65,7 +65,7 @@ public class FullConfigSaveMergeFlow extends FullConfigSaveFlow{
 
         GoConfigHolder goConfigHolder = reloadConfig(mergedConfig, partials);
 
-        checkinToConfigRepo(currentUser, goConfigHolder.configForEdit, mergedConfig);
+        checkinToConfigRepo(currentUser, goConfigHolder.getConfigForEdit(), mergedConfig);
 
         writeToConfigXml(mergedConfig);
 

--- a/server/src/main/java/com/thoughtworks/go/server/service/GoConfigService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/GoConfigService.java
@@ -164,7 +164,7 @@ public class GoConfigService implements Initializer, CruiseConfigProvider {
         }
         GoConfigHolder configHolder = getConfigHolder();
         configHolder = cloner.deepClone(configHolder);
-        PipelineConfig config = configHolder.configForEdit.pipelineConfigByName(new CaseInsensitiveString(pipelineName));
+        PipelineConfig config = configHolder.getConfigForEdit().pipelineConfigByName(new CaseInsensitiveString(pipelineName));
         return new ConfigForEdit<>(config, configHolder);
     }
 
@@ -234,6 +234,10 @@ public class GoConfigService implements Initializer, CruiseConfigProvider {
 
     CruiseConfig cruiseConfig() {
         return goConfigDao.load();
+    }
+
+    public GoConfigHolder.Checksum combinedMD5() {
+        return goConfigDao.loadConfigHolder() != null ? goConfigDao.loadConfigHolder().getChecksum() : null;
     }
 
     public AgentConfig agentByUuid(String uuid) {
@@ -961,14 +965,14 @@ public class GoConfigService implements Initializer, CruiseConfigProvider {
                                                               Username username,
                                                               HttpLocalizedOperationResult result) {
         GoConfigHolder configForEdit = cloner.deepClone(getConfigHolder());
-        if (!isValidGroup(groupName, configForEdit.configForEdit, result)) {
+        if (!isValidGroup(groupName, configForEdit.getConfigForEdit(), result)) {
             return null;
         }
 
         if (!isAdminOfGroup(groupName, username, result)) {
             return null;
         }
-        PipelineConfigs config = cloner.deepClone(configForEdit.configForEdit.findGroup(groupName));
+        PipelineConfigs config = cloner.deepClone(configForEdit.getConfigForEdit().findGroup(groupName));
         return new ConfigForEdit<>(config, configForEdit);
     }
 

--- a/server/src/main/java/com/thoughtworks/go/server/service/TemplateConfigService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/TemplateConfigService.java
@@ -222,9 +222,9 @@ public class TemplateConfigService {
     }
 
     private PipelineTemplateConfig findTemplate(String templateName, HttpLocalizedOperationResult result, GoConfigHolder configHolder) {
-        if (!doesTemplateExist(templateName, configHolder.configForEdit, result)) {
+        if (!doesTemplateExist(templateName, configHolder.getConfigForEdit(), result)) {
             return null;
         }
-        return configHolder.configForEdit.findTemplate(new CaseInsensitiveString(templateName));
+        return configHolder.getConfigForEdit().findTemplate(new CaseInsensitiveString(templateName));
     }
 }

--- a/server/src/test-fast/java/com/thoughtworks/go/server/dashboard/GoDashboardConfigChangeHandlerTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/dashboard/GoDashboardConfigChangeHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 ThoughtWorks, Inc.
+ * Copyright 2018 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,31 +18,37 @@ package com.thoughtworks.go.server.dashboard;
 
 import com.thoughtworks.go.config.BasicCruiseConfig;
 import com.thoughtworks.go.config.CruiseConfig;
+import com.thoughtworks.go.config.GoConfigHolder;
 import com.thoughtworks.go.config.PipelineConfig;
 import com.thoughtworks.go.helper.GoConfigMother;
+import com.thoughtworks.go.server.service.GoConfigService;
 import com.thoughtworks.go.server.service.GoDashboardService;
+import com.thoughtworks.go.util.ReflectionUtil;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 
-import static com.thoughtworks.go.server.dashboard.GoDashboardPipelineMother.pipeline;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 import static org.mockito.MockitoAnnotations.initMocks;
 
 public class GoDashboardConfigChangeHandlerTest {
     @Mock
     private GoDashboardService cacheUpdateService;
+    @Mock
+    private GoConfigService goConfigService;
 
     private GoDashboardConfigChangeHandler handler;
 
     @Before
     public void setUp() throws Exception {
         initMocks(this);
-        handler = new GoDashboardConfigChangeHandler(cacheUpdateService);
+        when(goConfigService.combinedMD5()).thenReturn(new GoConfigHolder.Checksum("config-md5", "partials-md5"));
+        handler = new GoDashboardConfigChangeHandler(cacheUpdateService, goConfigService);
     }
 
     @Test
     public void shouldReplaceAllEntriesInCacheWithNewEntriesWhenTheWholeConfigHasChanged() throws Exception {
+        when(goConfigService.combinedMD5()).thenReturn(new GoConfigHolder.Checksum("config-md5-1", "partials-md5"));
         CruiseConfig config = GoConfigMother.configWithPipelines("pipeline1", "pipeline2");
 
         handler.call(config);
@@ -58,5 +64,17 @@ public class GoDashboardConfigChangeHandlerTest {
         handler.call(pipelineConfig);
 
         verify(cacheUpdateService).updateCacheForPipeline(pipelineConfig);
+    }
+
+    @Test
+    public void shouldUpdateTheFullConfigOnlyIfTheConfigHasChangedFromLastUpdate(){
+        CruiseConfig config = GoConfigMother.configWithPipelines("pipeline1", "pipeline2");
+        when(goConfigService.combinedMD5()).thenReturn(new GoConfigHolder.Checksum("config-md5-1", "partials-md5"));
+
+        handler.call(config);
+        verify(cacheUpdateService).updateCacheForAllPipelinesIn(config);
+
+        handler.call(config);
+        verifyNoMoreInteractions(cacheUpdateService);
     }
 }

--- a/server/src/test-integration/java/com/thoughtworks/go/config/CachedGoConfigIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/config/CachedGoConfigIntegrationTest.java
@@ -280,6 +280,7 @@ public class CachedGoConfigIntegrationTest {
         cachedGoConfig.writeWithLock(new UpdateConfigCommand() {
             @Override
             public CruiseConfig update(CruiseConfig cruiseConfig) throws Exception {
+                cruiseConfig.addEnvironment(UUID.randomUUID().toString());
                 return cruiseConfig;
             }
         });
@@ -708,7 +709,7 @@ public class CachedGoConfigIntegrationTest {
         hgMaterialConfig = (HgMaterialConfig) byFolder(reloadedPipelineConfig.materialConfigs(), "folder");
         Assert.assertThat(hgMaterialConfig.getUrl(), Matchers.is("http://hg-server/repo-name"));
 
-        reloadedPipelineConfig = configHolder.configForEdit.pipelineConfigByName(new CaseInsensitiveString(pipelineName));
+        reloadedPipelineConfig = configHolder.getConfigForEdit().pipelineConfigByName(new CaseInsensitiveString(pipelineName));
         hgMaterialConfig = (HgMaterialConfig) byFolder(reloadedPipelineConfig.materialConfigs(), "folder");
         Assert.assertThat(hgMaterialConfig.getUrl(), Matchers.is("http://#{foo}/#{bar}"));
     }
@@ -1174,7 +1175,7 @@ public class CachedGoConfigIntegrationTest {
         cachedGoConfig.forceReload();
 
         Configuration ancestorPluggablePublishAftifactConfigAfterEncryption = goConfigDao.loadConfigHolder()
-                .configForEdit.pipelineConfigByName(new CaseInsensitiveString("ancestor"))
+                .getConfigForEdit().pipelineConfigByName(new CaseInsensitiveString("ancestor"))
                 .getExternalArtifactConfigs().get(0).getConfiguration();
         assertThat(ancestorPluggablePublishAftifactConfigAfterEncryption.getProperty("Image").getValue(), is("SECRET"));
         assertThat(ancestorPluggablePublishAftifactConfigAfterEncryption.getProperty("Image").getEncryptedValue(), is(new GoCipher().encrypt("SECRET")));
@@ -1194,7 +1195,7 @@ public class CachedGoConfigIntegrationTest {
 
         cachedGoConfig.forceReload();
 
-        PipelineConfig child = goConfigDao.loadConfigHolder().configForEdit.pipelineConfigByName(new CaseInsensitiveString("child"));
+        PipelineConfig child = goConfigDao.loadConfigHolder().getConfigForEdit().pipelineConfigByName(new CaseInsensitiveString("child"));
         Configuration childFetchConfigAfterEncryption = ((FetchPluggableArtifactTask) child
                 .get(0).getJobs().get(0).tasks().get(0)).getConfiguration();
 

--- a/server/src/test-integration/java/com/thoughtworks/go/config/FullConfigSaveFlowTestBase.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/config/FullConfigSaveFlowTestBase.java
@@ -95,7 +95,7 @@ public abstract class FullConfigSaveFlowTestBase {
         assertThat(ancestorPluggablePublishAftifactConfigBeforeEncryption.getProperty("Image").getConfigValue(), is("SECRET"));
 
         GoConfigHolder configHolder = getImplementer().execute(new FullConfigUpdateCommand(cruiseConfig, goConfigService.configFileMd5()), new ArrayList<>(), "Upgrade");
-        Configuration ancestorPluggablePublishAftifactConfigAfterEncryption = configHolder.configForEdit
+        Configuration ancestorPluggablePublishAftifactConfigAfterEncryption = configHolder.getConfigForEdit()
                 .pipelineConfigByName(new CaseInsensitiveString("ancestor"))
                 .getExternalArtifactConfigs().get(0).getConfiguration();
         assertThat(ancestorPluggablePublishAftifactConfigAfterEncryption.getProperty("Image").getValue(), is("SECRET"));
@@ -116,7 +116,7 @@ public abstract class FullConfigSaveFlowTestBase {
         assertThat(childFetchConfigBeforeEncryption.getProperty("FetchProperty").getConfigValue(), is("SECRET"));
 
         GoConfigHolder configHolder = getImplementer().execute(new FullConfigUpdateCommand(cruiseConfig, goConfigService.configFileMd5()), new ArrayList<>(), "Upgrade");
-        Configuration childFetchConfigAfterEncryption = ((FetchPluggableArtifactTask) configHolder.configForEdit
+        Configuration childFetchConfigAfterEncryption = ((FetchPluggableArtifactTask) configHolder.getConfigForEdit()
                 .pipelineConfigByName(new CaseInsensitiveString("child"))
                 .get(0).getJobs().get(0).tasks().get(0)).getConfiguration();
         assertThat(childFetchConfigAfterEncryption.getProperty("FetchProperty").getValue(), is("SECRET"));

--- a/server/src/test-integration/java/com/thoughtworks/go/config/GoConfigMigrationIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/config/GoConfigMigrationIntegrationTest.java
@@ -913,7 +913,7 @@ public class GoConfigMigrationIntegrationTest {
 
         String migratedContent = migrateXmlString(configString, 69);
         assertThat(migratedContent, containsString("<authorization>"));
-        CruiseConfig configForEdit = loader.loadConfigHolder(migratedContent).configForEdit;
+        CruiseConfig configForEdit = loader.loadConfigHolder(migratedContent).getConfigForEdit();
         PipelineTemplateConfig template = configForEdit.getTemplateByName(new CaseInsensitiveString("template-name"));
         Authorization authorization = template.getAuthorization();
         assertThat(authorization, is(not(nullValue())));

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/GoConfigServiceIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/GoConfigServiceIntegrationTest.java
@@ -813,7 +813,7 @@ public class GoConfigServiceIntegrationTest {
                 Username.ANONYMOUS, new HttpLocalizedOperationResult());
 
         Configuration ancestorPluggablePublishAftifactConfigAfterEncryption = goConfigDao.loadConfigHolder()
-                .configForEdit.pipelineConfigByName(new CaseInsensitiveString("ancestor"))
+                .getConfigForEdit().pipelineConfigByName(new CaseInsensitiveString("ancestor"))
                 .getExternalArtifactConfigs().get(0).getConfiguration();
         assertThat(ancestorPluggablePublishAftifactConfigAfterEncryption.getProperty("Image").getValue(), is("NEW_SECRET"));
         assertThat(ancestorPluggablePublishAftifactConfigAfterEncryption.getProperty("Image").getEncryptedValue(), startsWith("AES:"));
@@ -831,7 +831,7 @@ public class GoConfigServiceIntegrationTest {
                 "defaultStage", "defaultJob", "NEW_SECRET"),
                 md5, Username.ANONYMOUS, new HttpLocalizedOperationResult());
 
-        PipelineConfig child = goConfigDao.loadConfigHolder().configForEdit.pipelineConfigByName(new CaseInsensitiveString("child"));
+        PipelineConfig child = goConfigDao.loadConfigHolder().getConfigForEdit().pipelineConfigByName(new CaseInsensitiveString("child"));
         Configuration childFetchConfigAfterEncryption = ((FetchPluggableArtifactTask) child
                 .get(0).getJobs().get(0).tasks().get(0)).getConfiguration();
 

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/PipelineConfigServiceIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/PipelineConfigServiceIntegrationTest.java
@@ -177,7 +177,7 @@ public class PipelineConfigServiceIntegrationTest {
         assertThat(configRepository.getCurrentRevision().getUsername(), is(user.getDisplayName()));
         assertThat(configRepository.getCurrentRevision().getMd5(), is(not(goConfigHolderBeforeUpdate.config.getMd5())));
         assertThat(configRepository.getCurrentRevision().getMd5(), is(goConfigDao.loadConfigHolder().config.getMd5()));
-        assertThat(configRepository.getCurrentRevision().getMd5(), is(goConfigDao.loadConfigHolder().configForEdit.getMd5()));
+        assertThat(configRepository.getCurrentRevision().getMd5(), is(goConfigDao.loadConfigHolder().getConfigForEdit().getMd5()));
     }
 
     @Test
@@ -203,7 +203,7 @@ public class PipelineConfigServiceIntegrationTest {
         pipelineConfig.setTemplateName(templateName);
         pipelineConfig.addParam(new ParamConfig("SOME_PARAM", "SOME_VALUE"));
 
-        CruiseConfig cruiseConfig = goConfigDao.loadConfigHolder().configForEdit;
+        CruiseConfig cruiseConfig = goConfigDao.loadConfigHolder().getConfigForEdit();
         cruiseConfig.update(groupName, pipelineConfig.name().toString(), pipelineConfig);
         saveConfig(cruiseConfig);
 
@@ -245,7 +245,7 @@ public class PipelineConfigServiceIntegrationTest {
 
         CaseInsensitiveString stage = new CaseInsensitiveString("stage");
         CaseInsensitiveString job = new CaseInsensitiveString("job");
-        CruiseConfig cruiseConfig = goConfigDao.loadConfigHolder().configForEdit;
+        CruiseConfig cruiseConfig = goConfigDao.loadConfigHolder().getConfigForEdit();
         cruiseConfig.update(groupName, pipelineConfig.name().toString(), pipelineConfig);
         saveConfig(cruiseConfig);
 
@@ -530,7 +530,7 @@ public class PipelineConfigServiceIntegrationTest {
         assertThat(result.httpCode(), is(422));
         assertThat(pipelineConfig.errors().on(PipelineConfig.LABEL_TEMPLATE), contains("Invalid label"));
         assertThat(configRepository.getCurrentRevCommit().name(), is(headCommitBeforeUpdate));
-        assertThat(goConfigDao.loadConfigHolder().configForEdit, is(goConfigHolder.configForEdit));
+        assertThat(goConfigDao.loadConfigHolder().getConfigForEdit(), is(goConfigHolder.getConfigForEdit()));
         assertThat(goConfigDao.loadConfigHolder().config, is(goConfigHolder.config));
     }
 
@@ -549,7 +549,7 @@ public class PipelineConfigServiceIntegrationTest {
         assertThat(result.toString(), result.isSuccessful(), is(false));
         assertThat(result.toString(), result.toString().contains("Parameter 'SOME_PARAM' is not defined"), is(true));
         assertThat(configRepository.getCurrentRevCommit().name(), is(headCommitBeforeUpdate));
-        assertThat(goConfigDao.loadConfigHolder().configForEdit, is(goConfigHolder.configForEdit));
+        assertThat(goConfigDao.loadConfigHolder().getConfigForEdit(), is(goConfigHolder.getConfigForEdit()));
         assertThat(goConfigDao.loadConfigHolder().config, is(goConfigHolder.config));
     }
 
@@ -570,7 +570,7 @@ public class PipelineConfigServiceIntegrationTest {
         assertThat(pipelineConfig.errors().on("stages"), is(String.format("Cannot add stages to pipeline '%s' which already references template '%s'", pipelineConfig.name(), templateName)));
         assertThat(pipelineConfig.errors().on("template"), is(String.format("Cannot set template '%s' on pipeline '%s' because it already has stages defined", templateName, pipelineConfig.name())));
         assertThat(configRepository.getCurrentRevCommit().name(), is(headCommitBeforeUpdate));
-        assertThat(goConfigDao.loadConfigHolder().configForEdit, is(goConfigHolder.configForEdit));
+        assertThat(goConfigDao.loadConfigHolder().getConfigForEdit(), is(goConfigHolder.getConfigForEdit()));
         assertThat(goConfigDao.loadConfigHolder().config, is(goConfigHolder.config));
     }
 
@@ -586,7 +586,7 @@ public class PipelineConfigServiceIntegrationTest {
         assertThat(result.toString(), result.httpCode(), is(403));
         assertThat(result.toString(), result.message().equals("Unauthorized to edit '" + pipelineConfig.name() + "' pipeline."), is(true));
         assertThat(configRepository.getCurrentRevCommit().name(), is(headCommitBeforeUpdate));
-        assertThat(goConfigDao.loadConfigHolder().configForEdit, is(goConfigHolderBeforeUpdate.configForEdit));
+        assertThat(goConfigDao.loadConfigHolder().getConfigForEdit(), is(goConfigHolderBeforeUpdate.getConfigForEdit()));
         assertThat(goConfigDao.loadConfigHolder().config, is(goConfigHolderBeforeUpdate.config));
     }
 
@@ -606,7 +606,7 @@ public class PipelineConfigServiceIntegrationTest {
         assertThat(scmMaterialConfig.errors().on(PluggableSCMMaterialConfig.FOLDER), is("Destination directory is required when specifying multiple scm materials"));
         assertThat(scmMaterialConfig.errors().on(PluggableSCMMaterialConfig.SCM_ID), is("Could not find plugin for scm-id: [scmid]."));
         assertThat(configRepository.getCurrentRevCommit().name(), is(headCommitBeforeUpdate));
-        assertThat(goConfigDao.loadConfigHolder().configForEdit, is(goConfigHolder.configForEdit));
+        assertThat(goConfigDao.loadConfigHolder().getConfigForEdit(), is(goConfigHolder.getConfigForEdit()));
         assertThat(goConfigDao.loadConfigHolder().config, is(goConfigHolder.config));
     }
 
@@ -626,7 +626,7 @@ public class PipelineConfigServiceIntegrationTest {
 
         assertThat(packageMaterialConfig.errors().on(PackageMaterialConfig.PACKAGE_ID), is("Could not find repository for given package id:[packageid]"));
         assertThat(configRepository.getCurrentRevCommit().name(), is(headCommitBeforeUpdate));
-        assertThat(goConfigDao.loadConfigHolder().configForEdit, is(goConfigHolder.configForEdit));
+        assertThat(goConfigDao.loadConfigHolder().getConfigForEdit(), is(goConfigHolder.getConfigForEdit()));
         assertThat(goConfigDao.loadConfigHolder().config, is(goConfigHolder.config));
     }
 
@@ -1080,7 +1080,7 @@ public class PipelineConfigServiceIntegrationTest {
         jobConfig.addTask(task);
         jobConfig.addVariable("ENV_VAR", "#{SOME_PARAM}");
         final PipelineTemplateConfig template = new PipelineTemplateConfig(templateName, new StageConfig(new CaseInsensitiveString("stage"), new JobConfigs(jobConfig)));
-        CruiseConfig cruiseConfig = goConfigDao.loadConfigHolder().configForEdit;
+        CruiseConfig cruiseConfig = goConfigDao.loadConfigHolder().getConfigForEdit();
         cruiseConfig.addTemplate(template);
         saveConfig(cruiseConfig);
     }
@@ -1088,7 +1088,7 @@ public class PipelineConfigServiceIntegrationTest {
     private void saveScmMaterialToConfig(String id) throws Exception {
         SCM scm = new SCM(id, new PluginConfiguration(id, "1.0"), new Configuration(new ConfigurationProperty(new ConfigurationKey("key"), new ConfigurationValue("value"))));
         scm.setName(id);
-        CruiseConfig cruiseConfig = goConfigDao.loadConfigHolder().configForEdit;
+        CruiseConfig cruiseConfig = goConfigDao.loadConfigHolder().getConfigForEdit();
         cruiseConfig.getSCMs().add(scm);
         saveConfig(cruiseConfig);
     }

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/PipelineConfigsServiceIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/PipelineConfigsServiceIntegrationTest.java
@@ -98,7 +98,7 @@ public class PipelineConfigsServiceIntegrationTest {
                 new Username("user"), new HttpLocalizedOperationResult());
 
 
-        PipelineConfig ancestor = goConfigDao.loadConfigHolder().configForEdit.pipelineConfigByName(new CaseInsensitiveString("ancestor"));
+        PipelineConfig ancestor = goConfigDao.loadConfigHolder().getConfigForEdit().pipelineConfigByName(new CaseInsensitiveString("ancestor"));
         Configuration ancestorPluggablePublishAftifactConfigAfterEncryption = ancestor
                 .getExternalArtifactConfigs().get(0).getConfiguration();
         assertThat(ancestorPluggablePublishAftifactConfigAfterEncryption.getProperty("Image").getValue(), is("SECRET"));
@@ -113,7 +113,7 @@ public class PipelineConfigsServiceIntegrationTest {
                 new Username("user"), new HttpLocalizedOperationResult());
 
 
-        PipelineConfig child = goConfigDao.loadConfigHolder().configForEdit.pipelineConfigByName(new CaseInsensitiveString("child"));
+        PipelineConfig child = goConfigDao.loadConfigHolder().getConfigForEdit().pipelineConfigByName(new CaseInsensitiveString("child"));
         Configuration childFetchConfigAfterEncryption = ((FetchPluggableArtifactTask) child
                 .get(0).getJobs().get(0).tasks().get(0)).getConfiguration();
 


### PR DESCRIPTION
Dashboard cache was being recreated thrice during server startup - once while registering config-change-listener for GoDashboardActivityListener, then for featureToggleService and finally for CachedGoConfig.onTimer. Making the cache recreation happen only if the config has really changed, using md5 checksum to check the same.


~~PS: Do not merge, found an issue with this.~~
Update: The issue was partials (things configured in config repo) are not taken into account for the MD5 checksum that we store at the configCache level. This meant notifications wouldn't be sent if things were changed in config-repo. The checksum now has 2 components - md5sum of main-config, and the checksum of the partials. Only of the checksum changes that we send a notification. 