### PR TITLE
Update mail sender with mailhost config every time while performing backup.

### DIFF
--- a/server/src/main/java/com/thoughtworks/go/server/initializers/ApplicationInitializer.java
+++ b/server/src/main/java/com/thoughtworks/go/server/initializers/ApplicationInitializer.java
@@ -133,7 +133,6 @@ public class ApplicationInitializer implements ApplicationListener<ContextRefres
             timerScheduler.initialize();
             stageResourceImporter.initialize();
             goDiskSpaceMonitor.initialize();
-            backupService.initialize();
             railsAssetsService.initialize();
             ccTrayActivityListener.initialize();
             dashboardActivityListener.initialize();

--- a/server/src/main/java/com/thoughtworks/go/server/service/BackupService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/BackupService.java
@@ -76,7 +76,6 @@ public class BackupService implements BackupStatusProvider {
     private final ConfigRepository configRepository;
     private final Database databaseStrategy;
 
-    private GoMailSender mailSender;
     private volatile DateTime backupRunningSince;
     private volatile String backupStartedBy;
 
@@ -99,15 +98,12 @@ public class BackupService implements BackupStatusProvider {
         this.timeProvider = timeProvider;
     }
 
-    public void initialize() {
-        mailSender = goConfigService.getMailSender();
-    }
-
     public ServerBackup startBackup(Username username, HttpLocalizedOperationResult result) {
         if (!goConfigService.isUserAdmin(username)) {
             result.unauthorized(LocalizedMessage.string("UNAUTHORIZED_TO_BACKUP"), HealthStateType.unauthorised());
             return null;
         }
+        GoMailSender mailSender = goConfigService.getMailSender();
         synchronized (BACKUP_MUTEX) {
             DateTime now = timeProvider.currentDateTime();
             final File destDir = new File(backupLocation(), BACKUP + now.toString("YYYYMMdd-HHmmss"));

--- a/server/src/test-fast/java/com/thoughtworks/go/server/service/BackupServiceTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/service/BackupServiceTest.java
@@ -65,7 +65,6 @@ public class BackupServiceTest {
         when(artifactsDirHolder.getBackupsDir()).thenReturn(new File(location));
 
         BackupService backupService = new BackupService(null, artifactsDirHolder, mock(GoConfigService.class), null, null, systemEnvironment, serverVersion, configRepo, databaseStrategy);
-        backupService.initialize();
         assertThat(backupService.backupLocation(), is(new File(location).getAbsolutePath()));
     }
 
@@ -75,7 +74,6 @@ public class BackupServiceTest {
         Date serverBackupTime = new Date();
         when(repo.lastBackup()).thenReturn(new ServerBackup("file_path", serverBackupTime, "user"));
         BackupService backupService = new BackupService(null, null, mock(GoConfigService.class), null, repo, systemEnvironment, serverVersion, configRepo, databaseStrategy);
-        backupService.initialize();
 
         Date date = backupService.lastBackupTime();
         assertThat(date, is(serverBackupTime));
@@ -86,7 +84,6 @@ public class BackupServiceTest {
         ServerBackupRepository repo = mock(ServerBackupRepository.class);
         when(repo.lastBackup()).thenReturn(null);
         BackupService backupService = new BackupService(null, null, mock(GoConfigService.class), null, repo, systemEnvironment, serverVersion, configRepo, databaseStrategy);
-        backupService.initialize();
 
         assertThat(backupService.lastBackupTime(), is(nullValue()));
     }
@@ -95,7 +92,6 @@ public class BackupServiceTest {
         ServerBackupRepository repo = mock(ServerBackupRepository.class);
         when(repo.lastBackup()).thenReturn(new ServerBackup("file_path", new Date(), "loser"));
         BackupService backupService = new BackupService(null, null, mock(GoConfigService.class), null, repo, systemEnvironment, serverVersion, configRepo, databaseStrategy);
-        backupService.initialize();
 
         String username = backupService.lastBackupUser();
         assertThat(username, is("loser"));
@@ -106,7 +102,6 @@ public class BackupServiceTest {
         ServerBackupRepository repo = mock(ServerBackupRepository.class);
         when(repo.lastBackup()).thenReturn(null);
         BackupService backupService = new BackupService(null, null, mock(GoConfigService.class), null, repo, systemEnvironment, serverVersion, configRepo, databaseStrategy);
-        backupService.initialize();
 
         assertThat(backupService.lastBackupUser(), is(nullValue()));
     }
@@ -118,7 +113,6 @@ public class BackupServiceTest {
         when(artifactsDirHolder.getArtifactsDir()).thenReturn(artifactDirectory);
         when(artifactDirectory.getUsableSpace()).thenReturn(42424242L);
         BackupService backupService = new BackupService(null, artifactsDirHolder, mock(GoConfigService.class), null, null, systemEnvironment, serverVersion, configRepo, databaseStrategy);
-        backupService.initialize();
 
         assertThat(backupService.availableDiskSpace(), is("40 MB"));
 

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/BackupServiceH2IntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/BackupServiceH2IntegrationTest.java
@@ -137,7 +137,6 @@ public class BackupServiceH2IntegrationTest {
 
         BackupService service = new BackupService(dataSource, artifactsDirHolder, goConfigService, timeProvider, backupInfoRepository, systemEnvironment, serverVersion, configRepository,
                 databaseStrategy);
-        service.initialize();
         service.startBackup(admin, result);
 
         assertThat(result.isSuccessful(), is(true));

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/BackupServiceIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/BackupServiceIntegrationTest.java
@@ -208,7 +208,6 @@ public class BackupServiceIntegrationTest {
         ServerVersion serverVersion = mock(ServerVersion.class);
         when(serverVersion.version()).thenReturn("some-test-version-007");
         BackupService backupService = new BackupService(dataSource, artifactsDirHolder, goConfigService, timeProvider, backupInfoRepository, systemEnvironment, serverVersion, configRepository, databaseStrategy);
-        backupService.initialize();
         backupService.startBackup(admin, result);
         assertThat(result.isSuccessful(), is(true));
         assertThat(result.message(localizer), is("Backup completed successfully."));
@@ -230,7 +229,6 @@ public class BackupServiceIntegrationTest {
 
         BackupService service = new BackupService(dataSource, artifactsDirHolder, configService, timeProvider, backupInfoRepository, systemEnvironment, serverVersion, configRepository,
                 databaseStrategy);
-        service.initialize();
         service.startBackup(admin, new HttpLocalizedOperationResult());
 
         String ipAddress = SystemUtil.getFirstLocalNonLoopbackIpAddress();
@@ -259,7 +257,6 @@ public class BackupServiceIntegrationTest {
         doThrow(new RuntimeException("Oh no!")).when(databaseStrategyMock).backup(any(File.class));
         BackupService service = new BackupService(dataSource, artifactsDirHolder, configService, timeProvider, backupInfoRepository, systemEnvironment, serverVersion, configRepository,
                 databaseStrategyMock);
-        service.initialize();
         service.startBackup(admin, result);
 
         String ipAddress = SystemUtil.getFirstLocalNonLoopbackIpAddress();


### PR DESCRIPTION
The mailhost config that was present at server startup was used all the time to send mails. However, if the mailhost config changed and the backup was initiated, the old mailhost config was still used. 