### PR TITLE
Fix broken agents page due to change in the plugin infos (multiple extension support)

### DIFF
--- a/server/webapp/WEB-INF/rails.new/webpack/views/agents/agent_row_widget.js.msx
+++ b/server/webapp/WEB-INF/rails.new/webpack/views/agents/agent_row_widget.js.msx
@@ -49,7 +49,7 @@ const supportsAgentStatusReport = function (pluginInfos, pluginId) {
 
   const pluginInfo = pluginInfos().findById(pluginId);
   if (pluginInfo) {
-    return pluginInfo.capabilities().supportsAgentStatusReport();
+    return pluginInfo.extensions()['elastic-agent'].capabilities().supportsAgentStatusReport();
   }
 
   return false;


### PR DESCRIPTION
* Plugins can now support multiple extensions, hence look only for elastic agent capabilities for a given plugin