### PR TITLE
Show tooltip for the disabled elements on the new dashboard

### DIFF
--- a/server/webapp/WEB-INF/rails.new/app/assets/new_stylesheets/frameworks.scss
+++ b/server/webapp/WEB-INF/rails.new/app/assets/new_stylesheets/frameworks.scss
@@ -23,8 +23,9 @@
 @import 'global';
 @import 'fonts';
 @import 'footer';
-
 @import "shared/server_health_messages";
+
+$tooltip-background-color: #333;
 
 .tooltip-question-mark {
   @include icon-after(question-circle, $size: $form-label-font-size, $color: $form-label-color, $margin: 0, $line-height: $form-label-line-height) {
@@ -75,5 +76,44 @@
   }
   &.large {
     width: 800px;
+  }
+}
+
+.has-tip {
+  border-bottom: transparent;
+  display:       inline;
+}
+
+.tooltip {
+  padding:     6px 10px;
+  line-height: 15px;
+  font-size:   12px;
+  background:  $tooltip-background-color;
+
+  &:before {
+    border-color: transparent transparent $tooltip-background-color;
+  }
+
+  &.top::before {
+    @include css-triangle($tooltip-pip-width, $tooltip-background-color, down);
+    top:    100%;
+    bottom: auto;
+  }
+
+  &.left::before {
+    @include css-triangle($tooltip-pip-width, $tooltip-background-color, right);
+    top:       50%;
+    bottom:    auto;
+    left:      100%;
+    transform: translateY(-50%);
+  }
+
+  &.right::before {
+    @include css-triangle($tooltip-pip-width, $tooltip-background-color, left);
+    top:       50%;
+    right:     100%;
+    bottom:    auto;
+    left:      auto;
+    transform: translateY(-50%);
   }
 }

--- a/server/webapp/WEB-INF/rails.new/app/assets/stylesheets/foundation_and_overrides.scss
+++ b/server/webapp/WEB-INF/rails.new/app/assets/stylesheets/foundation_and_overrides.scss
@@ -42,7 +42,7 @@
 @include foundation-tabs;
 //@include foundation-thumbnail;
 @include foundation-title-bar;
-//@include foundation-tooltip;
+@include foundation-tooltip;
 @include foundation-top-bar;
 
 // If you'd like to include motion-ui, you need to install the motion-ui sass package.

--- a/server/webapp/WEB-INF/rails.new/spec/webpack/models/dashboard/pipeline_spec.js
+++ b/server/webapp/WEB-INF/rails.new/spec/webpack/models/dashboard/pipeline_spec.js
@@ -18,14 +18,14 @@ describe("Dashboard", () => {
   const Pipeline = require('models/dashboard/pipeline');
   require('jasmine-jquery');
 
-  let pipelineJson;
+  let pipelineJson, defaultPauseInfo;
   beforeEach(() => {
-    const defaultPipelineJson = {
+    defaultPauseInfo = {
       "paused":       true,
       "paused_by":    "admin",
       "pause_reason": "under construction"
     };
-    pipelineJson              = pipelineJsonFor(defaultPipelineJson);
+    pipelineJson     = pipelineJsonFor(defaultPauseInfo);
   });
   describe('Pipeline Model', () => {
 
@@ -51,7 +51,7 @@ describe("Dashboard", () => {
       expect(pipeline.isLocked).toBe(false);
       expect(pipeline.canUnlock).toBe(true);
 
-      expect(pipeline.isDefinedInConfigRepo()).toBe(true);
+      expect(pipeline.isDefinedInConfigRepo()).toBe(false);
 
       expect(pipeline.trackingTool).toEqual({
         "regex": "#(\\d+)",
@@ -98,6 +98,86 @@ describe("Dashboard", () => {
       const instanceCounters = pipeline.getInstanceCounters();
       expect(instanceCounters.length).toEqual(1);
       expect(instanceCounters).toEqual([1]);
+    });
+
+    it("should return the trigger tooltip text when first stage is building", () => {
+      pipelineJson.pause_info.paused                                 = false;
+      pipelineJson._embedded.instances[0]._embedded.stages[0].status = "Building";
+      const pipeline                                                 = new Pipeline(pipelineJson);
+      expect(pipeline.getDisabledTooltipText()).toEqual("Cannot trigger pipeline - First stage is still in progress.");
+    });
+
+    it("should return first stage building trigger tooltip text if first stage is building and pipeline is also locked", () => {
+      pipelineJson.pause_info.paused                                 = false;
+      pipelineJson._embedded.instances[0]._embedded.stages[0].status = "Building";
+      pipelineJson.locked                                            = true;
+      const pipeline                                                 = new Pipeline(pipelineJson);
+
+      expect(pipeline.getDisabledTooltipText()).toEqual("Cannot trigger pipeline - First stage is still in progress.");
+    });
+
+    it("should return first stage building tooltip text if the first stage is building and pipeline is also paused", () => {
+      pipelineJson.pause_info.paused                                 = false;
+      pipelineJson._embedded.instances[0]._embedded.stages[0].status = "Building";
+
+      const pipeline = new Pipeline(pipelineJson);
+
+      expect(pipeline.getDisabledTooltipText()).toEqual("Cannot trigger pipeline - First stage is still in progress.");
+    });
+
+    it("should return empty tooltip trigger text if the trigger button isn't disabled", () => {
+      pipelineJson.pause_info.paused = false;
+      const pipeline                 = new Pipeline(pipelineJson);
+      expect(pipeline.getDisabledTooltipText()).toEqual(undefined);
+    });
+
+    it("should return pipeline paused trigger tooltip text when pipeline is paused", () => {
+      const pipeline = new Pipeline(pipelineJson);
+      expect(pipeline.getDisabledTooltipText()).toEqual("Cannot trigger pipeline - Pipeline is currently paused.");
+    });
+
+    it("should return pipeline paused trigger tooltip text when pipeline is paused and also locked", () => {
+      pipelineJson.locked = true;
+      const pipeline      = new Pipeline(pipelineJson);
+      expect(pipeline.getDisabledTooltipText()).toEqual("Cannot trigger pipeline - Pipeline is currently paused.");
+    });
+
+    it("should return pipeline locked trigger tooltip text when pipeline is locked", () => {
+      pipelineJson.locked            = true;
+      pipelineJson.pause_info.paused = false;
+      const pipeline                 = new Pipeline(pipelineJson);
+      expect(pipeline.getDisabledTooltipText()).toEqual("Cannot trigger pipeline - Pipeline is currently locked.");
+    });
+
+    it("should return no permissions trigger tooltip text when user doesn't have permission to operate the pipeline", () => {
+      pipelineJson = pipelineJsonFor(defaultPauseInfo, false, false);
+
+      const pipeline = new Pipeline(pipelineJson);
+      expect(pipeline.getDisabledTooltipText()).toEqual("You do not have permission to trigger the pipeline");
+    });
+
+    it("should return no permission to pause pipeline text if users don't have permission to pause the pipeline", () => {
+      pipelineJson   = pipelineJsonFor({}, false);
+      const pipeline = new Pipeline(pipelineJson);
+      expect(pipeline.getPauseDisabledTooltipText()).toEqual("You do not have permission to pause the pipeline.");
+    });
+
+    it("should return no permission to unpause pipeline text if users don't have permission to unpause the pipeline", () => {
+      pipelineJson   = pipelineJsonFor(defaultPauseInfo, false);
+      const pipeline = new Pipeline(pipelineJson);
+      expect(pipeline.getPauseDisabledTooltipText()).toEqual("You do not have permission to unpause the pipeline.");
+    });
+
+    it("should return pipeline config repo tooltip text for config repo pipelines", () => {
+      pipelineJson   = pipelineJsonFor(defaultPauseInfo, true, true, true);
+      const pipeline = new Pipeline(pipelineJson);
+      expect(pipeline.getSettingsDisabledTooltipText()).toEqual("Cannot edit pipeline defined in config repository.");
+    });
+
+    it("should return no permission tooltip text as default", () => {
+      pipelineJson   = pipelineJsonFor(defaultPauseInfo, true, true, false);
+      const pipeline = new Pipeline(pipelineJson);
+      expect(pipeline.getSettingsDisabledTooltipText()).toEqual("You do not have permission to edit the pipeline.");
     });
   });
 
@@ -220,7 +300,7 @@ describe("Dashboard", () => {
     });
   });
 
-  const pipelineJsonFor = (pauseInfo) => {
+  const pipelineJsonFor = (pauseInfo, canPause = true, canOperate = true, fromConfigRepo = false) => {
     return {
       "_links":                 {
         "self":                 {
@@ -251,9 +331,9 @@ describe("Dashboard", () => {
       "can_unlock":             true,
       "pause_info":             pauseInfo,
       "can_administer":         true,
-      "can_operate":            true,
-      "can_pause":              true,
-      "from_config_repo":       true,
+      "can_operate":            canOperate,
+      "can_pause":              canPause,
+      "from_config_repo":       fromConfigRepo,
       "tracking_tool":          {
         "regex": "#(\\d+)",
         "link":  "http://example.com/${ID}/"

--- a/server/webapp/WEB-INF/rails.new/spec/webpack/views/dashboard/dashboard_widget_spec.js
+++ b/server/webapp/WEB-INF/rails.new/spec/webpack/views/dashboard/dashboard_widget_spec.js
@@ -343,11 +343,12 @@ describe("Dashboard Widget", () => {
     expect(title.href.indexOf(`/go/admin/pipeline_group/${pipelineGroupJSON.name}/edit`)).not.toEqual(-1);
   });
 
-  it("should show disabled pipeline group settings icon for non admin users", () => {
+  it("should show disabled pipeline group settings icon showing tooltip for non admin users", () => {
     unmount();
     mount(false);
 
     expect($root.find('.pipeline-group_title a')).toHaveClass('disabled');
+    expect($root.find('.pipeline-group_title a')).toHaveAttr('data-tooltip');
   });
 
   it("should show plain text pipeline group name without link for non admin users", () => {

--- a/server/webapp/WEB-INF/rails.new/spec/webpack/views/dashboard/pipeline_widget_spec.js
+++ b/server/webapp/WEB-INF/rails.new/spec/webpack/views/dashboard/pipeline_widget_spec.js
@@ -109,12 +109,13 @@ describe("Dashboard Pipeline Widget", () => {
       expect($root.find('.edit_config').get(0).href.indexOf(expectedPath)).not.toEqual(-1);
     });
 
-    it('should disable pipeline settings for non admin users', () => {
+    it('should disable pipeline settings showing tooltip information for non admin users', () => {
       unmount();
       mount(false, false, {}, {}, true, true);
 
       expect(pipeline.canAdminister).toBe(false);
       expect($root.find('.edit_config')).toHaveClass('disabled');
+      expect($root.find('.edit_config')).toHaveAttr('data-tooltip');
     });
 
     it('should disable pipeline settings for config repo pipelines', () => {
@@ -445,6 +446,14 @@ describe("Dashboard Pipeline Widget", () => {
         expect(pausePopupTextBox).toHaveValue("");
       });
 
+      it("should have tooltip for pause button when it is disabled", () => {
+        unmount();
+        mount(false, true, pauseInfo, {}, false);
+        const pauseButton = $root.find('.pause');
+        expect(pauseButton).toHaveAttr('title');
+        expect(pauseButton).toHaveAttr('data-tooltip');
+      });
+
     });
 
     describe("Unlock", () => {
@@ -638,6 +647,14 @@ describe("Dashboard Pipeline Widget", () => {
         expect($root.find('.pipeline_message')).toContainText(responseMessage);
         expect($root.find('.pipeline_message')).toHaveClass("error");
       });
+
+      it("should have tooltips for trigger buttons when it is disabled", () => {
+        unmount();
+        mount(false, true, {}, {}, true, false);
+        const playButton = $root.find('.pipeline_operations .play');
+        expect(playButton).toHaveAttr('title');
+        expect(playButton).toHaveAttr('data-tooltip');
+      });
     });
 
     describe("Trigger With Options", () => {
@@ -807,6 +824,14 @@ describe("Dashboard Pipeline Widget", () => {
 
         expect($root.find('.pipeline_message')).toContainText(responseMessage);
         expect($root.find('.pipeline_message')).toHaveClass("error");
+      });
+
+      it("should have tooltips when it is disabled", () => {
+        unmount();
+        mount(false, true, {}, {}, true, false);
+        const playButton = $root.find('.pipeline_operations .play_with_options');
+        expect(playButton).toHaveAttr('title');
+        expect(playButton).toHaveAttr('data-tooltip');
       });
     });
   });

--- a/server/webapp/WEB-INF/rails.new/webpack/helpers/form_helper.js.msx
+++ b/server/webapp/WEB-INF/rails.new/webpack/helpers/form_helper.js.msx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-const m       = require('mithril');
+const m     = require('mithril');
 const $     = require('jquery');
 const _     = require('lodash');
 const s     = require('string-plus');
@@ -443,20 +443,82 @@ const f = {
     }
   },
 
+  buttonWithTooltip: {
+    oncreate (vnode) {
+      new window.Foundation.Tooltip($(vnode.dom), {tipText: vnode.attrs.tooltipText});
+    },
+
+    onupdate (vnode) {
+      //an elements data.zfPlugin.template gives the tooltip element
+      $(vnode.dom).data().zfPlugin.template.text(vnode.attrs.tooltipText);
+    },
+
+    onremove (vnode) {
+      $(vnode.dom).foundation('destroy');
+    },
+
+    view (vnode) {
+      const args = vnode.attrs;
+      return (<button type="button"
+                      class={compactClasses(args, 'button')}
+                      {...args}
+                      data-hover-delay={100}>
+        {vnode.children}
+      </button>);
+    }
+  },
+
   button: {
     view (vnode) {
+      const args        = vnode.attrs;
+      const tooltipText = deleteKeyAndReturnValue(args, "tooltipText");
+
+      if (!_.isEmpty(tooltipText)) {
+        return (<f.buttonWithTooltip tooltipText={tooltipText}
+                                     class={compactClasses(args, 'button')}
+                                     {...args}/>);
+      }
       return (
-        <button type="button"
-                class={compactClasses(vnode.attrs, 'button')}
-                {...vnode.attrs}>
-          {vnode.children}
-        </button>
+          <button type="button"
+                  class={compactClasses(args, 'button')}
+                  {...args}>
+            {vnode.children}
+          </button>
       );
+    }
+  },
+
+  linkWithTooltip: {
+    oncreate(vnode) {
+      new window.Foundation.Tooltip($(vnode.dom), {tipText: vnode.attrs.tooltipText});
+    },
+
+    onupdate(vnode) {
+      //Update tooltip text
+      $(vnode.dom).data().zfPlugin.template.text(vnode.attrs.tooltipText);
+    },
+
+    onremove(vnode) {
+      $(vnode.dom).foundation('destroy');
+    },
+
+    view(vnode) {
+      return (<a href="javascript:void(0)"
+                 class={compactClasses(vnode.attrs)} {...vnode.attrs}
+                 data-hover-delay={100}>
+        {vnode.children}
+      </a>);
     }
   },
 
   link: {
     view (vnode) {
+      const tooltipText = vnode.attrs.tooltipText;
+
+      if (!_.isEmpty(tooltipText)) {
+        return (<f.linkWithTooltip class={compactClasses(vnode.attrs)} {...vnode.attrs}/>);
+      }
+
       if (vnode.attrs.target === '_blank') {
         if (s.isBlank(vnode.attrs.rel)) {
           vnode.attrs.rel = 'noopener noreferrer';
@@ -464,7 +526,9 @@ const f = {
           vnode.attrs.rel += " noopener noreferrer";
         }
       }
-      return (<a href="javascript:void(0)" class={compactClasses(vnode.attrs)} {...vnode.attrs}>{vnode.children}</a>);
+      return (<a href="javascript:void(0)"
+                 class={compactClasses(vnode.attrs)} {...vnode.attrs}>{vnode.children}
+      </a>);
     }
   },
 

--- a/server/webapp/WEB-INF/rails.new/webpack/models/dashboard/pipeline.js
+++ b/server/webapp/WEB-INF/rails.new/webpack/models/dashboard/pipeline.js
@@ -86,6 +86,53 @@ const Pipeline = function (info) {
   this.getInstanceCounters = () => {
     return _.map(this.instances, (instance) => instance.counter);
   };
+
+  this.getDisabledTooltipText = () => {
+    if (!self.canOperate) {
+      return TooltipText.NO_OPERATE_PERMISSION;
+    }
+    if (self.isFirstStageInProgress()) {
+      return TooltipText.FIRST_STAGE_IN_PROGRESS;
+    }
+    if (self.isPaused) {
+      return TooltipText.PIPELINE_PAUSED;
+    }
+    if (self.isLocked) {
+      return TooltipText.PIPELINE_LOCKED;
+    }
+  };
+
+  this.getPauseDisabledTooltipText = () => {
+    if (!self.canPause) {
+      if (self.isPaused) {
+        return TooltipText.NO_UNPAUSE_PERMISSION;
+      }
+      return TooltipText.NO_PAUSE_PERMISSION;
+    }
+  };
+
+  this.getLockDisabledTooltipText = () => {
+    return TooltipText.NO_UNLOCK_PERMISSION;
+  };
+
+  this.getSettingsDisabledTooltipText = () => {
+    if (self.isDefinedInConfigRepo()) {
+      return TooltipText.CONFIG_REPO_PIPELINE;
+    }
+    return TooltipText.NO_EDIT_PERMISSION;
+  };
+
+  const TooltipText = {
+    NO_OPERATE_PERMISSION:   "You do not have permission to trigger the pipeline",
+    PIPELINE_PAUSED:         "Cannot trigger pipeline - Pipeline is currently paused.",
+    PIPELINE_LOCKED:         "Cannot trigger pipeline - Pipeline is currently locked.",
+    FIRST_STAGE_IN_PROGRESS: "Cannot trigger pipeline - First stage is still in progress.",
+    CONFIG_REPO_PIPELINE:    "Cannot edit pipeline defined in config repository.",
+    NO_EDIT_PERMISSION:      "You do not have permission to edit the pipeline.",
+    NO_UNLOCK_PERMISSION:    "You do not have permission to unlock the pipeline.",
+    NO_PAUSE_PERMISSION:     "You do not have permission to pause the pipeline.",
+    NO_UNPAUSE_PERMISSION:   "You do not have permission to unpause the pipeline."
+  };
 };
 
 module.exports = Pipeline;

--- a/server/webapp/WEB-INF/rails.new/webpack/views/dashboard/dashboard_widget.js.msx
+++ b/server/webapp/WEB-INF/rails.new/webpack/views/dashboard/dashboard_widget.js.msx
@@ -66,8 +66,9 @@ const DashboardWidget = {
   },
 
   view(vnode) {
-    const args = vnode.attrs;
-    const vm = args.vm;
+    const args             = vnode.attrs;
+    const vm               = args.vm;
+    const noPermissionText = "You do not have permission to edit the pipeline group.";
 
     if (args.showSpinner()) {
       return (<span class="page-spinner"/>);
@@ -119,7 +120,8 @@ const DashboardWidget = {
               settingsIcon = (<a href={pipelineGroup.editPath} class="edit_config pipeline-group_edit-config"/>);
             } else {
               name         = pipelineGroup.name;
-              settingsIcon = (<a href="#" class="edit_config pipeline-group_edit-config disabled"/>);
+              settingsIcon = (<f.link class="edit_config pipeline-group_edit-config disabled"
+                                                 tooltipText={noPermissionText}/>);
             }
 
             return (

--- a/server/webapp/WEB-INF/rails.new/webpack/views/dashboard/pipeline_header_widget.js.msx
+++ b/server/webapp/WEB-INF/rails.new/webpack/views/dashboard/pipeline_header_widget.js.msx
@@ -16,6 +16,7 @@
 
 const m = require('mithril');
 const $ = require('jquery');
+const f = require('helpers/form_helper');
 
 const PipelineOperationsWidget = require('views/dashboard/pipeline_operations_widget');
 const PipelineAnalyticsWidget  = require('views/dashboard/pipeline_analytics_widget');
@@ -46,7 +47,8 @@ const PipelineHeaderWidget = {
       const settingsPath = vnode.attrs.isQuickEditPageEnabled ? pipeline.quickEditPath : pipeline.settingsPath;
       settingsButton     = (<a class={`edit_config`} href={settingsPath}/>);
     } else {
-      settingsButton = (<a class={`edit_config disabled`}/>);
+      settingsButton = (<f.link class="edit_config disabled"
+                                tooltipText={pipeline.getSettingsDisabledTooltipText()}/>);
     }
 
     if (shouldShowAnalyticsIcon) {
@@ -59,7 +61,8 @@ const PipelineHeaderWidget = {
     if (pipeline.isLocked) {
       pipelineLockButton = pipeline.canUnlock
         ? (<button onclick={vnode.state.unlock.bind(vnode.state, pipeline)} className="pipeline_locked"/>)
-        : (<button className="pipeline_locked disabled"/>);
+        : (<f.button className="pipeline_locked disabled"
+                     tooltipText={pipeline.getLockDisabledTooltipText()}/>);
     }
 
     return (

--- a/server/webapp/WEB-INF/rails.new/webpack/views/dashboard/pipeline_operations_widget.js.msx
+++ b/server/webapp/WEB-INF/rails.new/webpack/views/dashboard/pipeline_operations_widget.js.msx
@@ -16,6 +16,7 @@
 
 const m      = require('mithril');
 const Stream = require('mithril/stream');
+const f      = require('helpers/form_helper');
 
 const TriggerWithOptionsInfo = require('models/dashboard/trigger_with_options_info');
 
@@ -161,6 +162,8 @@ const PipelineOperationsWidget = {
     if (flash) {
       flashMessage = (<div class={`pipeline_message ${flash.type}`}><p>{flash.message}</p></div>);
     }
+    const triggerButtonsTooltipText = pipeline.getDisabledTooltipText();
+    const pauseTooltipText = pipeline.getPauseDisabledTooltipText();
 
     let pipelinePauseMessage;
     if (pipeline.isPaused) {
@@ -172,16 +175,18 @@ const PipelineOperationsWidget = {
         {flashMessage}
         <ul className="pipeline_operations">
           <li>
-            <button onclick={!pipeline.triggerDisabled() && vnode.state.trigger.bind(vnode.state, pipeline)}
-                    class={`pipeline_btn play ${(pipeline.triggerDisabled() ? 'disabled' : '')}`}/>
+            <f.button onclick={!pipeline.triggerDisabled() && vnode.state.trigger.bind(vnode.state, pipeline)}
+                      class={`pipeline_btn play ${(pipeline.triggerDisabled() ? 'disabled' : '')}`}
+                      tooltipText={triggerButtonsTooltipText}/>
           </li>
           <li>
-            <button
+            <f.button
               onclick={!pipeline.triggerDisabled() && vnode.state.showTriggerWithOptionsPopup.bind(vnode.state, pipeline)}
-              class={`pipeline_btn play_with_options ${(pipeline.triggerDisabled() ? 'disabled' : '')}`}/>
+              class={`pipeline_btn play_with_options ${(pipeline.triggerDisabled() ? 'disabled' : '')}`}
+              tooltipText={triggerButtonsTooltipText}/>
           </li>
           <li>
-            <button onclick={onPauseUnpauseClick} class={pauseUnpauseClass}/>
+            <f.button onclick={onPauseUnpauseClick} class={pauseUnpauseClass} tooltipText={pauseTooltipText}/>
           </li>
         </ul>
         <a href={pipeline.historyPath} class="pipeline_history">History</a>


### PR DESCRIPTION
In the new dashboard elements such as trigger buttons, pause buttons, pipeline settings and pipeline group settings are disabled due to a range of different reasons as mentioned in #4225. This PR introduces tooltips for such elements when they are disabled to show the reason behind them being disabled.