### PR TITLE
Shows auto suggestions in trigger with options modal even when exact SHA is pasted.

### DIFF
--- a/server/webapp/WEB-INF/rails.new/webpack/views/dashboard/trigger_with_options/material_search_results_widget.js.msx
+++ b/server/webapp/WEB-INF/rails.new/webpack/views/dashboard/trigger_with_options/material_search_results_widget.js.msx
@@ -34,10 +34,6 @@ const MaterialSearchResultsWidget = {
       return null;
     }
 
-    if (searchVM.isRevisionSelected()) {
-      return null;
-    }
-
     if (_.isEmpty(results)) {
       resultMessage = <span class="helper">No revisions found matching '{searchText}'</span>;
     } else if (_.isEmpty(searchText)) {


### PR DESCRIPTION
* In such cases when the pipeline is triggered without the user cliking on the selection, the pipeline runs with the revision associated with the SHA.
* Related to #4562 