### PR TITLE
Revert "fixed the height for trigger options modal when spinner is being shown"

### DIFF
--- a/server/webapp/WEB-INF/rails.new/app/assets/new_stylesheets/single_page_apps/new_dashboard.scss
+++ b/server/webapp/WEB-INF/rails.new/app/assets/new_stylesheets/single_page_apps/new_dashboard.scss
@@ -1031,7 +1031,6 @@ body {
 
 .pipeline-trigger-with-options {
   margin: 5px 0 5px 10px;
-  min-height: 200px;
 
   .last-run-revision .value {
     @include ellipsis();


### PR DESCRIPTION
Reverts gocd/gocd#4582

lint fails -> https://build.gocd.org/go/tab/build/detail/build-linux/2379/build-non-server/1/lint