### PR TITLE
Fixes width of personalize dropdown

### DIFF
--- a/server/webapp/WEB-INF/rails.new/app/assets/new_stylesheets/single_page_apps/new_dashboard.scss
+++ b/server/webapp/WEB-INF/rails.new/app/assets/new_stylesheets/single_page_apps/new_dashboard.scss
@@ -35,7 +35,7 @@ $building: #fed34e;
 $pipeline_icons_size: 16px;
 
 $border: #ccc;
-$filter-width: 367px;
+$filter-width: 362px;
 $pipeline-list-height: 265px;
 
 // ---------------------  common styles ------------------------


### PR DESCRIPTION
### Before:
![screen shot 2018-03-30 at 10 54 40 am](https://user-images.githubusercontent.com/23699743/38125664-d0872dcc-3408-11e8-8786-796d539a7ccd.png)

The LHS of the dropdown exceeded the LHS of the search bar.
### After fix:
![screen shot 2018-03-30 at 10 54 15 am](https://user-images.githubusercontent.com/23699743/38125671-db3f6978-3408-11e8-823c-e759c4f7890d.png)
LHS of dropdown aligns with the LHS of the search bar.