### PR TITLE
Bugfix: Validation of Build and Test Artifacts with same src and dest

### DIFF
--- a/common/src/test/java/com/thoughtworks/go/domain/ArtifactConfigsTest.java
+++ b/common/src/test/java/com/thoughtworks/go/domain/ArtifactConfigsTest.java
@@ -16,10 +16,7 @@
 
 package com.thoughtworks.go.domain;
 
-import com.thoughtworks.go.config.BuildArtifactConfig;
-import com.thoughtworks.go.config.ArtifactConfigs;
-import com.thoughtworks.go.config.PluggableArtifactConfig;
-import com.thoughtworks.go.config.TestArtifactConfig;
+import com.thoughtworks.go.config.*;
 import com.thoughtworks.go.config.validation.FilePathTypeValidator;
 import org.hamcrest.Matchers;
 import org.junit.Test;
@@ -121,11 +118,11 @@ public class ArtifactConfigsTest {
         artifactConfigs.add(new BuildArtifactConfig("src", "../a"));
 
         artifactConfigs.validateTree(null);
-        assertThat(artifactConfigs.get(0).errors().on(BuildArtifactConfig.DEST), is("Duplicate artifacts defined."));
-        assertThat(artifactConfigs.get(0).errors().on(BuildArtifactConfig.SRC), is("Duplicate artifacts defined."));
-        assertThat(artifactConfigs.get(1).errors().on(BuildArtifactConfig.DEST), is("Duplicate artifacts defined."));
-        assertThat(artifactConfigs.get(1).errors().on(BuildArtifactConfig.SRC), is("Duplicate artifacts defined."));
-        assertThat(artifactConfigs.get(2).errors().on(BuildArtifactConfig.DEST), is("Invalid destination path. Destination path should match the pattern " + FilePathTypeValidator.PATH_PATTERN));
+        assertThat(artifactConfigs.get(0).errors().on(BuiltinArtifactConfig.DEST), is("Duplicate artifacts defined."));
+        assertThat(artifactConfigs.get(0).errors().on(BuiltinArtifactConfig.SRC), is("Duplicate artifacts defined."));
+        assertThat(artifactConfigs.get(1).errors().on(BuiltinArtifactConfig.DEST), is("Duplicate artifacts defined."));
+        assertThat(artifactConfigs.get(1).errors().on(BuiltinArtifactConfig.SRC), is("Duplicate artifacts defined."));
+        assertThat(artifactConfigs.get(2).errors().on(BuiltinArtifactConfig.DEST), is("Invalid destination path. Destination path should match the pattern " + FilePathTypeValidator.PATH_PATTERN));
     }
 
     @Test
@@ -137,16 +134,16 @@ public class ArtifactConfigsTest {
         artifactConfigs.validate(null);
 
         assertFalse(artifactConfigs.get(0).errors().isEmpty());
-        assertThat(artifactConfigs.get(0).errors().on(BuildArtifactConfig.SRC), Matchers.is("Duplicate artifacts defined."));
-        assertThat(artifactConfigs.get(0).errors().on(BuildArtifactConfig.DEST), Matchers.is("Duplicate artifacts defined."));
+        assertThat(artifactConfigs.get(0).errors().on(BuiltinArtifactConfig.SRC), Matchers.is("Duplicate artifacts defined."));
+        assertThat(artifactConfigs.get(0).errors().on(BuiltinArtifactConfig.DEST), Matchers.is("Duplicate artifacts defined."));
 
         assertFalse(artifactConfigs.get(1).errors().isEmpty());
-        assertThat(artifactConfigs.get(1).errors().on(BuildArtifactConfig.SRC), Matchers.is("Duplicate artifacts defined."));
-        assertThat(artifactConfigs.get(1).errors().on(BuildArtifactConfig.DEST), Matchers.is("Duplicate artifacts defined."));
+        assertThat(artifactConfigs.get(1).errors().on(BuiltinArtifactConfig.SRC), Matchers.is("Duplicate artifacts defined."));
+        assertThat(artifactConfigs.get(1).errors().on(BuiltinArtifactConfig.DEST), Matchers.is("Duplicate artifacts defined."));
 
         assertFalse(artifactConfigs.get(2).errors().isEmpty());
-        assertThat(artifactConfigs.get(2).errors().on(BuildArtifactConfig.SRC), Matchers.is("Duplicate artifacts defined."));
-        assertThat(artifactConfigs.get(2).errors().on(BuildArtifactConfig.DEST), Matchers.is("Duplicate artifacts defined."));
+        assertThat(artifactConfigs.get(2).errors().on(BuiltinArtifactConfig.SRC), Matchers.is("Duplicate artifacts defined."));
+        assertThat(artifactConfigs.get(2).errors().on(BuiltinArtifactConfig.DEST), Matchers.is("Duplicate artifacts defined."));
     }
 
     @Test

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/ArtifactConfigs.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/ArtifactConfigs.java
@@ -80,8 +80,8 @@ public class ArtifactConfigs extends BaseCollection<ArtifactConfig> implements V
         }
         List<Map> attrList = (List<Map>) attributes;
         for (Map attrMap : attrList) {
-            String source = (String) attrMap.get(BuildArtifactConfig.SRC);
-            String destination = (String) attrMap.get(BuildArtifactConfig.DEST);
+            String source = (String) attrMap.get(BuiltinArtifactConfig.SRC);
+            String destination = (String) attrMap.get(BuiltinArtifactConfig.DEST);
             if (source.trim().isEmpty() && destination.trim().isEmpty()) {
                 continue;
             }

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/BuildArtifactConfig.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/BuildArtifactConfig.java
@@ -120,6 +120,9 @@ public class BuildArtifactConfig implements ArtifactConfig {
         if (!(o instanceof BuildArtifactConfig)) return false;
 
         BuildArtifactConfig that = (BuildArtifactConfig) o;
+        if (!that.getArtifactType().equals(this.getArtifactType())) {
+            return false;
+        }
 
         if (source != null ? !source.equals(that.source) : that.source != null) return false;
         return destination != null ? destination.equals(that.destination) : that.destination == null;

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/BuildArtifactConfig.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/BuildArtifactConfig.java
@@ -16,29 +16,13 @@
 
 package com.thoughtworks.go.config;
 
-import com.thoughtworks.go.config.validation.FilePathTypeValidator;
 import com.thoughtworks.go.domain.ArtifactType;
-import com.thoughtworks.go.domain.ConfigErrors;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang.StringUtils;
 
-import java.io.File;
-import java.text.MessageFormat;
-import java.util.List;
-
 @AttributeAwareConfigTag(value = "artifact", attribute = "type", attributeValue = "build")
-public class BuildArtifactConfig implements ArtifactConfig {
+public class BuildArtifactConfig extends BuiltinArtifactConfig {
     public static final String ARTIFACT_PLAN_DISPLAY_NAME = "Build Artifact";
-    public static final File DEFAULT_ROOT = new File("");
-    public static final String SRC = "source";
-    public static final String DEST = "destination";
-
-    @ConfigAttribute(value = "src", optional = false)
-    private String source;
-    @ConfigAttribute("dest")
-    private String destination = DEFAULT_ROOT.getPath();
-
-    private ConfigErrors errors = new ConfigErrors();
 
     public BuildArtifactConfig() {
     }
@@ -48,24 +32,9 @@ public class BuildArtifactConfig implements ArtifactConfig {
         setDestination(destination);
     }
 
+    @Override
     public String getDestination() {
         return StringUtils.isBlank(destination) ? DEFAULT_ROOT.getPath() : FilenameUtils.separatorsToUnix(destination);
-    }
-
-    public void setSource(String source) {
-        this.source = StringUtils.trim(source);
-    }
-
-    public String getSource() {
-        return FilenameUtils.separatorsToUnix(source);
-    }
-
-    public void setDestination(String destination) {
-        this.destination = StringUtils.trim(destination);
-    }
-
-    public String toString() {
-        return MessageFormat.format("Artifact of type {0} copies from {1} to {2}", getArtifactType(), source, destination);
     }
 
     public ArtifactType getArtifactType() {
@@ -74,64 +43,5 @@ public class BuildArtifactConfig implements ArtifactConfig {
 
     public String getArtifactTypeValue() {
         return ARTIFACT_PLAN_DISPLAY_NAME;
-    }
-
-    @Override
-    public boolean validateTree(ValidationContext validationContext) {
-        validate(validationContext);
-        return errors().isEmpty();
-    }
-
-    public void validate(ValidationContext validationContext) {
-        if (!StringUtils.isBlank(destination) && (!(destination.equals(DEFAULT_ROOT.getPath()) || new FilePathTypeValidator().isPathValid(destination)))) {
-            addError(DEST, "Invalid destination path. Destination path should match the pattern " + FilePathTypeValidator.PATH_PATTERN);
-        }
-        if (StringUtils.isBlank(source)) {
-            addError(SRC, String.format("Job '%s' has an artifact with an empty source", validationContext.getJob().name()));
-        }
-    }
-
-    public ConfigErrors errors() {
-        return errors;
-    }
-
-    public void addError(String fieldName, String message) {
-        errors.add(fieldName, message);
-    }
-
-    @Override
-    public void validateUniqueness(List<ArtifactConfig> existingArtifactConfigList) {
-        for (ArtifactConfig existingPlan : existingArtifactConfigList) {
-            if (this.equals(existingPlan)) {
-                addError(SRC, "Duplicate artifacts defined.");
-                addError(DEST, "Duplicate artifacts defined.");
-
-                existingPlan.addError(SRC, "Duplicate artifacts defined.");
-                existingPlan.addError(DEST, "Duplicate artifacts defined.");
-                return;
-            }
-        }
-        existingArtifactConfigList.add(this);
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof BuildArtifactConfig)) return false;
-
-        BuildArtifactConfig that = (BuildArtifactConfig) o;
-        if (!that.getArtifactType().equals(this.getArtifactType())) {
-            return false;
-        }
-
-        if (source != null ? !source.equals(that.source) : that.source != null) return false;
-        return destination != null ? destination.equals(that.destination) : that.destination == null;
-    }
-
-    @Override
-    public int hashCode() {
-        int result = source != null ? source.hashCode() : 0;
-        result = 31 * result + (destination != null ? destination.hashCode() : 0);
-        return result;
     }
 }

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/BuiltinArtifactConfig.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/BuiltinArtifactConfig.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2018 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.config;
+
+import com.thoughtworks.go.config.validation.FilePathTypeValidator;
+import com.thoughtworks.go.domain.ConfigErrors;
+import org.apache.commons.io.FilenameUtils;
+import org.apache.commons.lang.StringUtils;
+
+import java.io.File;
+import java.text.MessageFormat;
+import java.util.List;
+import java.util.Objects;
+
+public abstract class BuiltinArtifactConfig implements ArtifactConfig {
+
+    public static final String SRC = "source";
+    public static final String DEST = "destination";
+    static final File DEFAULT_ROOT = new File("");
+
+    @ConfigAttribute(value = "src", optional = false)
+    protected String source;
+    @ConfigAttribute("dest")
+    protected String destination = DEFAULT_ROOT.getPath();
+
+    protected ConfigErrors errors = new ConfigErrors();
+
+    public abstract String getDestination();
+
+    @Override
+    public boolean validateTree(ValidationContext validationContext) {
+        validate(validationContext);
+        return errors().isEmpty();
+    }
+
+    public void validate(ValidationContext validationContext) {
+        if (!StringUtils.isBlank(destination) && (!(destination.equals(DEFAULT_ROOT.getPath()) || new FilePathTypeValidator().isPathValid(destination)))) {
+            addError(DEST, "Invalid destination path. Destination path should match the pattern " + FilePathTypeValidator.PATH_PATTERN);
+        }
+        if (StringUtils.isBlank(source)) {
+            addError(SRC, String.format("Job '%s' has an artifact with an empty source", validationContext.getJob().name()));
+        }
+    }
+
+    @Override
+    public void validateUniqueness(List<ArtifactConfig> existingArtifactConfigList) {
+        for (ArtifactConfig existingPlan : existingArtifactConfigList) {
+            if (this.equals(existingPlan)) {
+                addError(SRC, "Duplicate artifacts defined.");
+                addError(DEST, "Duplicate artifacts defined.");
+
+                existingPlan.addError(SRC, "Duplicate artifacts defined.");
+                existingPlan.addError(DEST, "Duplicate artifacts defined.");
+                return;
+            }
+        }
+        existingArtifactConfigList.add(this);
+    }
+
+    public ConfigErrors errors() {
+        return errors;
+    }
+
+    public void addError(String fieldName, String message) {
+        errors.add(fieldName, message);
+    }
+
+    public void setSource(String source) {
+        this.source = StringUtils.trim(source);
+    }
+
+    public String getSource() {
+        return FilenameUtils.separatorsToUnix(source);
+    }
+
+    public void setDestination(String destination) {
+        this.destination = StringUtils.trim(destination);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        BuiltinArtifactConfig that = (BuiltinArtifactConfig) o;
+        return Objects.equals(source, that.source) &&
+                Objects.equals(destination, that.destination);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(source, destination);
+    }
+
+    @Override
+    public String toString() {
+        return MessageFormat.format("Artifact of type {0} copies from {1} to {2}", getArtifactType(), source, destination);
+    }
+}

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/TestArtifactConfig.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/TestArtifactConfig.java
@@ -21,7 +21,7 @@ import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang.StringUtils;
 
 @AttributeAwareConfigTag(value = "artifact", attribute = "type", attributeValue = "test")
-public class TestArtifactConfig extends BuildArtifactConfig {
+public class TestArtifactConfig extends BuiltinArtifactConfig {
     public static final String TEST_PLAN_DISPLAY_NAME = "Test Artifact";
     public static final String TEST_OUTPUT_FOLDER = "testoutput";
 
@@ -29,7 +29,8 @@ public class TestArtifactConfig extends BuildArtifactConfig {
     }
 
     public TestArtifactConfig(String src, String dest) {
-        super(src, dest);
+        setSource(src);
+        setDestination(dest);
     }
 
     @Override
@@ -44,6 +45,6 @@ public class TestArtifactConfig extends BuildArtifactConfig {
 
     @Override
     public String getDestination() {
-        return StringUtils.isBlank(super.getDestination()) ? TEST_OUTPUT_FOLDER : FilenameUtils.separatorsToUnix(super.getDestination());
+        return StringUtils.isBlank(destination) ? TEST_OUTPUT_FOLDER : FilenameUtils.separatorsToUnix(destination);
     }
 }

--- a/config/config-api/src/test/java/com/thoughtworks/go/config/BuildArtifactConfigTest.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/config/BuildArtifactConfigTest.java
@@ -63,4 +63,16 @@ public class BuildArtifactConfigTest {
         assertThat(existingPlan.errors().on(BuildArtifactConfig.SRC), is("Duplicate artifacts defined."));
         assertThat(existingPlan.errors().on(BuildArtifactConfig.DEST), is("Duplicate artifacts defined."));
     }
+
+    @Test
+    public void validate_shouldNotFailWhenComparingBuildAndTestArtifacts() {
+        List<ArtifactConfig> plans = new ArrayList<>();
+        TestArtifactConfig testArtifactConfig = new TestArtifactConfig("src", "dest");
+        plans.add(testArtifactConfig);
+        BuildArtifactConfig buildArtifactConfig = new BuildArtifactConfig("src", "dest");
+
+        buildArtifactConfig.validateUniqueness(plans);
+
+        assertThat(buildArtifactConfig.errors().isEmpty(), is(true));
+    }
 }

--- a/config/config-api/src/test/java/com/thoughtworks/go/config/BuildArtifactConfigTest.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/config/BuildArtifactConfigTest.java
@@ -29,14 +29,14 @@ public class BuildArtifactConfigTest {
     public void validate_shouldFailIfSourceIsEmpty() {
         BuildArtifactConfig artifactPlan = new BuildArtifactConfig(null, "bar");
         artifactPlan.validate(ConfigSaveValidationContext.forChain(new JobConfig("jobname")));
-        assertThat(artifactPlan.errors().on(BuildArtifactConfig.SRC), is("Job 'jobname' has an artifact with an empty source"));
+        assertThat(artifactPlan.errors().on(BuiltinArtifactConfig.SRC), is("Job 'jobname' has an artifact with an empty source"));
     }
 
     @Test
     public void validate_shouldFailIfDestDoesNotMatchAFilePattern() {
         BuildArtifactConfig artifactPlan = new BuildArtifactConfig("foo/bar", "..");
         artifactPlan.validate(null);
-        assertThat(artifactPlan.errors().on(BuildArtifactConfig.DEST), is("Invalid destination path. Destination path should match the pattern (([.]\\/)?[.][^. ]+)|([^. ].+[^. ])|([^. ][^. ])|([^. ])"));
+        assertThat(artifactPlan.errors().on(BuiltinArtifactConfig.DEST), is("Invalid destination path. Destination path should match the pattern (([.]\\/)?[.][^. ]+)|([^. ].+[^. ])|([^. ][^. ])|([^. ])"));
     }
 
     @Test
@@ -57,11 +57,11 @@ public class BuildArtifactConfigTest {
         artifactPlan.validateUniqueness(plans);
 
         assertThat(artifactPlan.errors().isEmpty(), is(false));
-        assertThat(artifactPlan.errors().on(BuildArtifactConfig.SRC), is("Duplicate artifacts defined."));
-        assertThat(artifactPlan.errors().on(BuildArtifactConfig.DEST), is("Duplicate artifacts defined."));
+        assertThat(artifactPlan.errors().on(BuiltinArtifactConfig.SRC), is("Duplicate artifacts defined."));
+        assertThat(artifactPlan.errors().on(BuiltinArtifactConfig.DEST), is("Duplicate artifacts defined."));
         assertThat(existingPlan.errors().isEmpty(), is(false));
-        assertThat(existingPlan.errors().on(BuildArtifactConfig.SRC), is("Duplicate artifacts defined."));
-        assertThat(existingPlan.errors().on(BuildArtifactConfig.DEST), is("Duplicate artifacts defined."));
+        assertThat(existingPlan.errors().on(BuiltinArtifactConfig.SRC), is("Duplicate artifacts defined."));
+        assertThat(existingPlan.errors().on(BuiltinArtifactConfig.DEST), is("Duplicate artifacts defined."));
     }
 
     @Test

--- a/domain/src/main/java/com/thoughtworks/go/domain/ArtifactPlan.java
+++ b/domain/src/main/java/com/thoughtworks/go/domain/ArtifactPlan.java
@@ -18,10 +18,7 @@ package com.thoughtworks.go.domain;
 
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
-import com.thoughtworks.go.config.ArtifactConfig;
-import com.thoughtworks.go.config.BuildArtifactConfig;
-import com.thoughtworks.go.config.ArtifactConfigs;
-import com.thoughtworks.go.config.PluggableArtifactConfig;
+import com.thoughtworks.go.config.*;
 import com.thoughtworks.go.util.FileUtil;
 import com.thoughtworks.go.work.GoPublisher;
 import org.apache.commons.io.FileUtils;
@@ -61,7 +58,7 @@ public class ArtifactPlan extends PersistentObject {
         if (artifactConfig instanceof PluggableArtifactConfig) {
             this.pluggableArtifactConfigJson = ((PluggableArtifactConfig) artifactConfig).toJSON();
         } else {
-            BuildArtifactConfig buildArtifactConfig = (BuildArtifactConfig) artifactConfig;
+            BuiltinArtifactConfig buildArtifactConfig = (BuiltinArtifactConfig) artifactConfig;
             setSrc(buildArtifactConfig.getSource());
             setDest(buildArtifactConfig.getDestination());
         }

--- a/server/src/test-fast/java/com/thoughtworks/go/config/ConfigConverterTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/config/ConfigConverterTest.java
@@ -791,8 +791,8 @@ public class ConfigConverterTest {
 
     @Test
     public void shouldConvertTestArtifactConfigWhenDestinationIsNull() {
-        BuildArtifactConfig buildArtifactConfig = (BuildArtifactConfig) configConverter.toArtifactConfig(new CRBuiltInArtifact("src", null, CRArtifactType.test));
-        assertThat(buildArtifactConfig.getDestination(), is("testoutput"));
+        TestArtifactConfig testArtifactConfig = (TestArtifactConfig) configConverter.toArtifactConfig(new CRBuiltInArtifact("src", null, CRArtifactType.test));
+        assertThat(testArtifactConfig.getDestination(), is("testoutput"));
     }
 
     @Test

--- a/server/webapp/WEB-INF/rails.new/spec/presenters/api_v1/admin/authorization/authorization_config_representer_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/presenters/api_v1/admin/authorization/authorization_config_representer_spec.rb
@@ -15,7 +15,7 @@
 ##########################################################################
 
 
-require 'spec_helper'
+require 'rails_helper'
 
 describe ApiV1::Admin::Authorization::AuthorizationConfigRepresenter do
 


### PR DESCRIPTION
If a Build and Test artifact had the same source and destination, the validation function would show an error, even though it should be allowed.

E.g: (Snippet from Pipeline Config POST API)
```
"artifacts": [
              {
                "source": "#{tests}/reports",
                "destination": "Reports",
                "type": "build"
              },
              {
                "source": "#{tests}/reports",
                "destination": "Reports",
                "type": "test"
              }
            ]
```

I've changed the object hierarchy of Build and Test artifacts to simplify and fix the validation function.