### PR TITLE
Removed trailing slash from old_dashboard link

### DIFF
--- a/server/webapp/WEB-INF/rails.new/webpack/views/dashboard/dashboard_widget.js.msx
+++ b/server/webapp/WEB-INF/rails.new/webpack/views/dashboard/dashboard_widget.js.msx
@@ -91,7 +91,7 @@ const DashboardWidget = {
                                             vm={vnode.state.pipelineSelectionVM}/>);
     }
 
-    const oldDashboardLink = (<a class="toggle-old-view" href={"/go/old_dashboard/"}>Old Dashboard</a>);
+    const oldDashboardLink = (<a class="toggle-old-view" href={"/go/old_dashboard"}>Old Dashboard</a>);
     return (
       <div class="pipeline_wrapper">
         <div class="page_header" key="page-header">


### PR DESCRIPTION
* Having the trailing slash on the old_dashboard led to wrong root path
  while loading the static analytics page. This would give a 404.