### PR TITLE
Show backup in progress on the analytics charts

### DIFF
--- a/server/webapp/WEB-INF/rails.new/app/assets/javascripts/analytics.js
+++ b/server/webapp/WEB-INF/rails.new/app/assets/javascripts/analytics.js
@@ -32,6 +32,12 @@
         div.appendChild(frame);
         frame.setAttribute("src", r.view_path);
       }).fail(function(xhr) {
+        if (xhr.getResponseHeader("content-type").indexOf("text/html") !== -1) {
+          var frame = document.createElement("iframe");
+          frame.src = "data:text/html;charset=utf-8," + xhr.responseText;
+          div.appendChild(frame);
+          return;
+        }
         var errorEl = document.createElement("div");
         $(errorEl).addClass("error");
         errorEl.textContent = xhr.responseText;

--- a/server/webapp/WEB-INF/rails.new/spec/webpack/views/shared/analytics_iframe_widget_spec.js
+++ b/server/webapp/WEB-INF/rails.new/spec/webpack/views/shared/analytics_iframe_widget_spec.js
@@ -21,18 +21,21 @@ describe("Analytics iFrame Widget", () => {
   const AnalyticsiFrameWidget = require('views/shared/analytics_iframe_widget');
 
   function newModel(loadedData, loadedView) {
-    const data = Stream(),
-          view = Stream(),
-          url  = Stream(),
-        errors = Stream();
+    const data   = Stream(),
+          view   = Stream(),
+          url    = Stream(),
+          errors = Stream();
 
-    return {url, data, view, errors, load: () => {
-      data(loadedData);
-      view(loadedView);
-    }};
+    return {
+      url, data, view, errors, load: () => {
+        data(loadedData);
+        view(loadedView);
+      }
+    };
   }
 
-  const noop = () => {};
+  const noop = () => {
+  };
 
   let $root, root;
 
@@ -46,9 +49,11 @@ describe("Analytics iFrame Widget", () => {
   });
 
   it('should load model oncreate', () => {
-    let called = false;
+    let called  = false;
     const model = newModel(null, null);
-    model.load = () => { called = true; };
+    model.load  = () => {
+      called = true;
+    };
 
     mount(model, noop);
     expect(called).toBe(true);
@@ -64,10 +69,23 @@ describe("Analytics iFrame Widget", () => {
 
   it('should show errors if any', () => {
     const model = newModel(null, null);
-    model.errors("here is an error");
+    model.errors({
+      getResponseHeader: () => "text/plainText",
+      responseText:      "here is an error"
+    });
     mount(model, noop);
     expect($root.find(".frame-container")[0].getAttribute("data-error-text")).toBe("here is an error");
+  });
 
+  it('should render html error if any', () => {
+    const model         = newModel(null, null);
+    const htmlErrorString = "<html><body>Boom!</body></html>";
+    model.errors({
+      getResponseHeader: () => "text/html",
+      responseText:      htmlErrorString
+    });
+    mount(model, noop);
+    expect($root.find("iframe")[0].getAttribute("src")).toBe(`data:text/html;charset=utf-8,${htmlErrorString}`);
   });
 
   it('should initialize iframe oncreate', () => {
@@ -81,8 +99,8 @@ describe("Analytics iFrame Widget", () => {
     iframe.onload();
 
     const expectedMessage = JSON.stringify({
-      uid: "some-uid",
-      pluginId: "some-plugin",
+      uid:         "some-uid",
+      pluginId:    "some-plugin",
       initialData: "model data"
     });
     expect(actualMessage).toBe(expectedMessage);

--- a/server/webapp/WEB-INF/rails.new/webpack/models/shared/frame.js
+++ b/server/webapp/WEB-INF/rails.new/webpack/models/shared/frame.js
@@ -38,7 +38,7 @@
         data(r.data);
         view(r.view_path);
       }).fail((xhr) => {
-        errors(xhr.responseText);
+        errors(xhr);
       }).always(() => {
         callback();
       });
@@ -54,7 +54,7 @@
       }).done((r) => {
         handler(r.data, null);
       }).fail((xhr) => {
-        errors(xhr.responseText);
+        errors(xhr);
         handler(null, errors());
       });
     }

--- a/server/webapp/WEB-INF/rails.new/webpack/views/shared/analytics_iframe_widget.js.msx
+++ b/server/webapp/WEB-INF/rails.new/webpack/views/shared/analytics_iframe_widget.js.msx
@@ -14,20 +14,21 @@
  * limitations under the License.
  */
 
-(function() {
+(function () {
   "use strict";
 
   const m = require("mithril");
 
-  const AnalyticsiFrameWidget = function() {
+  const AnalyticsiFrameWidget = function () {
     let currentUrl = null;
+
     function oncreate(vnode) {
       const iframe = vnode.dom.firstChild;
 
       iframe.onload = () => {
         vnode.attrs.init(iframe.contentWindow, {
-          uid: vnode.attrs.uid,
-          pluginId: vnode.attrs.pluginId,
+          uid:         vnode.attrs.uid,
+          pluginId:    vnode.attrs.pluginId,
           initialData: vnode.attrs.model.data()
         });
       };
@@ -43,8 +44,8 @@
         if (currentUrl !== vnode.attrs.model.url()) {
           iframe.onload = () => {
             vnode.attrs.init(iframe.contentWindow, {
-              uid: vnode.attrs.uid,
-              pluginId: vnode.attrs.pluginId,
+              uid:         vnode.attrs.uid,
+              pluginId:    vnode.attrs.pluginId,
               initialData: vnode.attrs.model.data()
             });
           };
@@ -57,10 +58,17 @@
     }
 
     function view(vnode) {
-      const model = vnode.attrs.model,
-        attrs = { src: model.view(), scrolling: "no" },
-        errorAttrs = model.errors() ? { "data-error-text": model.errors() } : {};
+      const model    = vnode.attrs.model;
+      const attrs    = {src: model.view(), scrolling: "no"};
+      const errorXHR = model.errors();
 
+      if (errorXHR && errorXHR.getResponseHeader("content-type").indexOf("text/html") !== -1) {
+        return (<div class="frame-container">
+          <iframe src={`data:text/html;charset=utf-8,${errorXHR.responseText}`}/>
+        </div>);
+      }
+
+      const errorAttrs = errorXHR ? {"data-error-text": errorXHR.responseText} : {};
       return <div class="frame-container" {...errorAttrs}>
         <iframe sandbox="allow-scripts" {...attrs}/>
       </div>;


### PR DESCRIPTION
* Render the httpResponseText as html in case of server sending an html response for any of the requests
* Handle backup in progress on:
  - Pipeline level analytics on old dashboard
![screen shot 2018-04-04 at 2 27 24 pm](https://user-images.githubusercontent.com/15275847/38298264-8d4af6aa-3814-11e8-9417-91d64eade7dd.png)


  - Pipeline level analytics on new dashboard
![screen shot 2018-04-04 at 2 09 48 pm](https://user-images.githubusercontent.com/15275847/38298269-8f6b4e30-3814-11e8-90a0-0ae5be031c51.png)


  - Analytics tab
![screen shot 2018-04-04 at 2 28 40 pm](https://user-images.githubusercontent.com/15275847/38298273-933d1c0a-3814-11e8-8f86-fbd48b6437df.png)

