### PR TITLE
#4466 - Make JSON output invalid on error

### DIFF
--- a/spark/spark-base/src/main/java/com/thoughtworks/go/api/base/JsonOutputWriter.java
+++ b/spark/spark-base/src/main/java/com/thoughtworks/go/api/base/JsonOutputWriter.java
@@ -200,17 +200,35 @@ public class JsonOutputWriter {
         }
 
         private void forTopLevelObject(Consumer<OutputWriter> consumer) {
-            withExceptionHandling(writer -> {
-                writer.writeStartObject();
-                consumer.accept(this);
-                writer.writeEndObject();
-            });
+            try {
+                withExceptionHandling(writer -> {
+                    writer.writeStartObject();
+                    consumer.accept(this);
+                    writer.writeEndObject();
+                });
+            } catch (Exception e) {
+                makeOutputAnInvalidJSON();
+                throw e;
+            }
         }
 
         private void forTopLevelArray(Consumer<OutputListWriter> consumer) {
-            withExceptionHandling(writer -> {
-                new JsonOutputListWriter(this).startArrayWithoutName(consumer);
-            });
+            try {
+                withExceptionHandling(writer -> {
+                    new JsonOutputListWriter(this).startArrayWithoutName(consumer);
+                });
+            } catch (Exception e) {
+                makeOutputAnInvalidJSON();
+                throw e;
+            }
+        }
+
+        private void makeOutputAnInvalidJSON() {
+            try {
+                this.jacksonWriter.writeStartObject();
+                this.jacksonWriter.writeString("Failed due to an exception. Please check the logs.");
+            } catch (IOException ignored) {
+            }
         }
 
         @Override


### PR DESCRIPTION
When an exception is thrown during JSON creation, the output written to the writer should be
made an invalid JSON so that clients can realize that there is a problem.

For: #4466 

With this change, the dashboard shows a big message which says something went wrong, since the JSON is syntactically invalid. Without this, it shows a spinner which never stops, since the JSON is syntactically valid but possibly, semantically invalid.

The actual error continues to be logged in the server logs.