### PR TITLE
Updating analytics modal title, and new modal update

### DIFF
--- a/server/webapp/WEB-INF/rails.new/spec/webpack/views/dashboard/pipeline_widget_spec.js
+++ b/server/webapp/WEB-INF/rails.new/spec/webpack/views/dashboard/pipeline_widget_spec.js
@@ -146,7 +146,7 @@ describe("Dashboard Pipeline Widget", () => {
       expect($('.reveal:visible')).toBeInDOM();
       expect($(".frame-container")).toBeInDOM();
       const modalTitle = $('.modal-title:visible');
-      expect(modalTitle).toHaveText(`Analytics for Pipeline: ${pipeline.name}`);
+      expect(modalTitle).toHaveText("Analytics");
     });
 
     it("should not display the analytics icon if the user is not an admin", () => {

--- a/server/webapp/WEB-INF/rails.new/webpack/views/dashboard/pipeline_analytics_widget.js.msx
+++ b/server/webapp/WEB-INF/rails.new/webpack/views/dashboard/pipeline_analytics_widget.js.msx
@@ -36,7 +36,7 @@ function createModal(pluginId, metricId, pipeline) {
   }));
   const modal = new Modal({
     size:    "small",
-    title:   `Analytics for Pipeline: ${pipeline.name}`,
+    title:   `Analytics`,
     body:    () => (m(AnalyticsiFrameWidget, {model, pluginId, init: PluginEndpoint.init})),
     onclose: () => modal.destroy(),
     buttons: []

--- a/server/webapp/WEB-INF/rails.new/webpack/views/shared/new_modal.js.msx
+++ b/server/webapp/WEB-INF/rails.new/webpack/views/shared/new_modal.js.msx
@@ -85,8 +85,8 @@ const Modal = function (options) {
       const buttons = _.map(_.isFunction(options.buttons) ? options.buttons() : options.buttons, (button) => {
         return (
           <f.button disabled={button.disabled ? button.disabled() : false}
-          onclick={button.onclick}
-          class={button.class}>{button.text}</f.button>
+                    onclick={button.onclick}
+                    class={button.class}>{button.text}</f.button>
         );
       });
       const buttonHtml = (<f.row class="modal-buttons" collapse> {buttons} </f.row>);

--- a/server/webapp/WEB-INF/rails.new/webpack/views/shared/new_modal.js.msx
+++ b/server/webapp/WEB-INF/rails.new/webpack/views/shared/new_modal.js.msx
@@ -82,6 +82,14 @@ const Modal = function (options) {
     },
 
     view(vnode) {
+      const buttons = _.map(_.isFunction(options.buttons) ? options.buttons() : options.buttons, (button) => {
+        return (
+          <f.button disabled={button.disabled ? button.disabled() : false}
+          onclick={button.onclick}
+          class={button.class}>{button.text}</f.button>
+        );
+      });
+      const buttonHtml = (<f.row class="modal-buttons" collapse> {buttons} </f.row>);
       return (
         <div class="reveal-overlay" style={{display: 'block'}} onkeydown={vnode.state.handleEnterKey}>
           <div class={`reveal ${options.size ? options.size : ''}`}
@@ -101,15 +109,8 @@ const Modal = function (options) {
               {options.body()}
             </div>
 
-            <f.row class="modal-buttons" collapse>
-              {_.map(_.isFunction(options.buttons) ? options.buttons() : options.buttons, (button) => {
-                return (
-                  <f.button disabled={button.disabled ? button.disabled() : false}
-                            onclick={button.onclick}
-                            class={button.class}>{button.text}</f.button>
-                );
-              })}
-            </f.row>
+            {buttons.length === 0 ? "" : buttonHtml}
+
           </div>
         </div>
       );


### PR DESCRIPTION
* only include the modal's button div if there're any buttons for the
modal

Before:
<img width="845" alt="screen shot 2018-04-06 at 1 57 49 pm" src="https://user-images.githubusercontent.com/5726224/38444031-9fbfa26a-39a2-11e8-8dd1-feecb0f1c6e0.png">

Buttons div adding extra space (also before):

<img width="997" alt="screen shot 2018-04-06 at 1 57 51 pm" src="https://user-images.githubusercontent.com/5726224/38444046-b0cf9e70-39a2-11e8-9828-668f3e874810.png">

After:

<img width="948" alt="screen shot 2018-04-06 at 1 57 42 pm" src="https://user-images.githubusercontent.com/5726224/38444055-b836343a-39a2-11e8-8670-87ad8714cfb2.png">





