### PR TITLE
Revert "Render bad request if the representer throws an exception while serializing or deserializing unsupported properties for resources.(#4608)"

### DIFF
--- a/server/webapp/WEB-INF/rails.new/app/presenters/api_v1/base_representer.rb
+++ b/server/webapp/WEB-INF/rails.new/app/presenters/api_v1/base_representer.rb
@@ -96,26 +96,12 @@ module ApiV1
 
     end
 
-    def message
-      "There is something wrong with your request. This would usually happen if - \n* There is a API version mismatch. Version 1 of the API does not how to handle your specific request. Are you sure you're using an API version?\n* You submitted an incorrect data-type for one or more elements.\nPlease check the go server logs for more information."
-    end
-
     def to_hash(*options)
-      begin
-        super.deep_symbolize_keys
-      rescue Exception => e
-        Rails.logger.error(e)
-        raise ApiV1::BadRequest, message
-      end
+      super.deep_symbolize_keys
     end
 
     def from_hash(data, options={})
-      begin
-        super(with_default_values(data), options)
-      rescue Exception => e
-        Rails.logger.error(e)
-        raise ApiV1::BadRequest, message
-      end
+      super(with_default_values(data), options)
     end
 
     private

--- a/server/webapp/WEB-INF/rails.new/app/presenters/api_v2/base_representer.rb
+++ b/server/webapp/WEB-INF/rails.new/app/presenters/api_v2/base_representer.rb
@@ -96,26 +96,12 @@ module ApiV2
 
     end
 
-    def message
-      "There is something wrong with your request. This would usually happen if - \n* There is a API version mismatch. Version 2 of the API does not how to handle your specific request. Are you sure you're using an API version?\n* You submitted an incorrect data-type for one or more elements.\nPlease check the go server logs for more information."
-    end
-
     def to_hash(*options)
-      begin
-        super.deep_symbolize_keys
-      rescue Exception => e
-        Rails.logger.error(e)
-        raise ApiV2::BadRequest, message
-      end
+      super.deep_symbolize_keys unless @represented.nil?
     end
 
     def from_hash(data, options={})
-      begin
-        super(with_default_values(data), options)
-      rescue Exception => e
-        Rails.logger.error(e)
-        raise ApiV2::BadRequest, message
-      end
+      super(with_default_values(data), options)
     end
 
     private

--- a/server/webapp/WEB-INF/rails.new/app/presenters/api_v3/base_representer.rb
+++ b/server/webapp/WEB-INF/rails.new/app/presenters/api_v3/base_representer.rb
@@ -98,26 +98,12 @@ module ApiV3
 
     end
 
-    def message
-      "There is something wrong with your request. This would usually happen if - \n* There is a API version mismatch. Version 3 of the API does not how to handle your specific request. Are you sure you're using an API version?\n* You submitted an incorrect data-type for one or more elements.\nPlease check the go server logs for more information."
-    end
-
     def to_hash(*options)
-      begin
-        super.deep_symbolize_keys
-      rescue Exception => e
-        Rails.logger.error(e)
-        raise ApiV3::BadRequest, message
-      end
+      super.deep_symbolize_keys unless @represented.nil?
     end
 
     def from_hash(data, options={})
-      begin
-        super(with_default_values(data), options)
-      rescue Exception => e
-        Rails.logger.error(e)
-        raise ApiV3::BadRequest, message
-      end
+      super(with_default_values(data), options)
     end
 
     private

--- a/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/base_representer.rb
+++ b/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/base_representer.rb
@@ -98,27 +98,12 @@ module ApiV4
 
     end
 
-    def message
-      "There is something wrong with your request. This would usually happen if - \n* There is a API version mismatch. Version 4 of the API does not how to handle your specific request. Are you sure you're using an API version?\n* You submitted an incorrect data-type for one or more elements.\nPlease check the go server logs for more information."
-    end
-
     def to_hash(*options)
-      begin
-        super.deep_symbolize_keys
-      rescue Exception => e
-        Rails.logger.error(e)
-        raise ApiV4::BadRequest, message
-      end
-
+      super.deep_symbolize_keys unless @represented.nil?
     end
 
     def from_hash(data, options={})
-      begin
-        super(with_default_values(data), options)
-      rescue Exception => e
-        Rails.logger.error(e)
-        raise ApiV4::BadRequest, message
-      end
+      super(with_default_values(data), options)
     end
 
     private

--- a/server/webapp/WEB-INF/rails.new/app/presenters/api_v5/base_representer.rb
+++ b/server/webapp/WEB-INF/rails.new/app/presenters/api_v5/base_representer.rb
@@ -98,26 +98,12 @@ module ApiV5
 
     end
 
-    def message
-      "There is something wrong with your request. This would usually happen if - \n* There is a API version mismatch. Version 5 of the API does not how to handle your specific request. Are you sure you're using an API version?\n* You submitted an incorrect data-type for one or more elements.\nPlease check the go server logs for more information."
-    end
-
     def to_hash(*options)
-      begin
-        super.deep_symbolize_keys
-      rescue Exception => e
-        Rails.logger.error(e)
-        raise ApiV5::BadRequest, message
-      end
+      super.deep_symbolize_keys unless @represented.nil?
     end
 
     def from_hash(data, options={})
-      begin
-        super(with_default_values(data), options)
-      rescue Exception => e
-        Rails.logger.error(e)
-        raise ApiV5::BadRequest, message
-      end
+      super(with_default_values(data), options)
     end
 
     private


### PR DESCRIPTION
Reverts gocd/gocd#4615