### PR TITLE
Add option to enable pipeline analytics only for admins

### DIFF
--- a/base/src/main/java/com/thoughtworks/go/util/SystemEnvironment.java
+++ b/base/src/main/java/com/thoughtworks/go/util/SystemEnvironment.java
@@ -219,6 +219,7 @@ public class SystemEnvironment implements Serializable, ConfigDirProvider {
     private static GoSystemProperty<Integer> GO_SPA_TIMEOUT = new GoIntSystemProperty("go.spa.timeout", 60000);
     private static GoSystemProperty<Integer> GO_SPA_REFRESH_INTERVAL = new GoIntSystemProperty("go.spa.refresh.interval", 10000);
 
+    private static GoSystemProperty<Boolean> ENABLE_PIPELINE_ANALYTICS_ONLY_FOR_ADMINS = new GoBooleanSystemProperty("go.enable.pipeline.analytics.only.for.admins", false);
     private final static Map<String, String> GIT_ALLOW_PROTOCOL;
 
     static {
@@ -872,6 +873,10 @@ public class SystemEnvironment implements Serializable, ConfigDirProvider {
 
     public Integer getNotificationListenerCountForPlugin(String pluginId) {
         return Integer.parseInt(getPropertyImpl("plugin." + pluginId + ".notifications.listener.count", "1"));
+    }
+
+    public boolean enablePipelineAnalyticsOnlyForAdmins() {
+        return ENABLE_PIPELINE_ANALYTICS_ONLY_FOR_ADMINS.getValue();
     }
 
     public static abstract class GoSystemProperty<T> {

--- a/server/webapp/WEB-INF/rails.new/app/controllers/analytics_controller.rb
+++ b/server/webapp/WEB-INF/rails.new/app/controllers/analytics_controller.rb
@@ -51,7 +51,9 @@ class AnalyticsController < ApplicationController
   end
 
   def check_permissions
-    check_user_can_see_pipeline if params[:type] == 'pipeline'
+    if params[:type] == 'pipeline'
+      isPipelineAnalyticsEnabledOnlyForAdmins? ? check_admin_user_and_401 : check_user_can_see_pipeline
+    end
   end
 
   def render_plugin_error e
@@ -64,5 +66,9 @@ class AnalyticsController < ApplicationController
     stack_trace = com.google.common.base.Throwables.getStackTraceAsString(e)
 
     Rails.logger.error "#{cause}:\n\n#{stack_trace}"
+  end
+
+  def isPipelineAnalyticsEnabledOnlyForAdmins?
+    system_environment.enablePipelineAnalyticsOnlyForAdmins
   end
 end

--- a/server/webapp/WEB-INF/rails.new/app/helpers/pipelines_helper.rb
+++ b/server/webapp/WEB-INF/rails.new/app/helpers/pipelines_helper.rb
@@ -101,6 +101,8 @@ module PipelinesHelper
   def with_pipeline_analytics_support(&block)
     return unless block_given?
 
+    return if show_pipeline_analytics_only_for_admins? && !is_user_an_admin?
+
     default_plugin_info_finder.allPluginInfos(PluginConstants.ANALYTICS_EXTENSION).each do |combined_plugin_info|
       extension_info = combined_plugin_info.extensionFor(PluginConstants.ANALYTICS_EXTENSION)
       if extension_info.getCapabilities().supportsPipelineAnalytics()
@@ -109,5 +111,9 @@ module PipelinesHelper
         break
       end
     end
+  end
+
+  def show_pipeline_analytics_only_for_admins?
+    system_environment.enablePipelineAnalyticsOnlyForAdmins
   end
 end

--- a/server/webapp/WEB-INF/rails.new/spec/webpack/views/dashboard/pipeline_widget_spec.js
+++ b/server/webapp/WEB-INF/rails.new/spec/webpack/views/dashboard/pipeline_widget_spec.js
@@ -149,6 +149,12 @@ describe("Dashboard Pipeline Widget", () => {
       const modalTitle = $('.modal-title:visible');
       expect(modalTitle).toHaveText("Analytics");
     });
+
+    it("should not display the analytics icon if the user is not an admin", () => {
+      unmount();
+      mount(false, false, {}, {}, true, true, false, {"plugin-x": "pipeline_duration"}, false);
+      expect($root.find('.pipeline-analytics')).not.toBeInDOM();
+    });
   });
 
   describe("Pipeline Operations", () => {
@@ -854,7 +860,7 @@ describe("Dashboard Pipeline Widget", () => {
     });
   });
 
-  function mount(isQuickEditPageEnabled = false, canAdminister = true, pauseInfo = {}, lockInfo = {}, canPause = true, canOperate = true, fromConfigRepo = false, pluginsSupportingAnalytics = {}) {
+  function mount(isQuickEditPageEnabled = false, canAdminister = true, pauseInfo = {}, lockInfo = {}, canPause = true, canOperate = true, fromConfigRepo = false, pluginsSupportingAnalytics = {}, shouldShowAnalyticsIcon = false) {
     pipelinesJson = [{
       "_links":                 {
         "self":                 {
@@ -931,6 +937,7 @@ describe("Dashboard Pipeline Widget", () => {
           pipeline,
           isQuickEditPageEnabled,
           pluginsSupportingAnalytics,
+          shouldShowAnalyticsIcon,
           doCancelPolling,
           doRefreshImmediately,
           vm: dashboardViewModel

--- a/server/webapp/WEB-INF/rails.new/webpack/single_page_apps/new_dashboard.js
+++ b/server/webapp/WEB-INF/rails.new/webpack/single_page_apps/new_dashboard.js
@@ -34,6 +34,7 @@ $(() => {
 
   const dashboardVM                = new DashboardVM();
   const isQuickEditPageEnabled     = JSON.parse(dashboardElem.attr('data-is-quick-edit-page-enabled'));
+  const shouldShowAnalyticsIcon    = JSON.parse(dashboardElem.attr('data-should-show-analytics-icon'));
   const isNewDashboardPageDefault  = JSON.parse(dashboardElem.attr('data-is-new-dashboard-page-default'));
   const pluginsSupportingAnalytics = {};
 
@@ -105,6 +106,7 @@ $(() => {
           isQuickEditPageEnabled,
           isNewDashboardPageDefault,
           pluginsSupportingAnalytics,
+          shouldShowAnalyticsIcon,
           vm:                   dashboardVM,
           doCancelPolling:      () => repeater().stop(),
           doRefreshImmediately: () => {

--- a/server/webapp/WEB-INF/rails.new/webpack/views/dashboard/dashboard_widget.js.msx
+++ b/server/webapp/WEB-INF/rails.new/webpack/views/dashboard/dashboard_widget.js.msx
@@ -139,6 +139,7 @@ const DashboardWidget = {
                                       doRefreshImmediately={vnode.attrs.doRefreshImmediately}
                                       isQuickEditPageEnabled={vnode.attrs.isQuickEditPageEnabled}
                                       pluginsSupportingAnalytics={vnode.attrs.pluginsSupportingAnalytics}
+                                      shouldShowAnalyticsIcon={vnode.attrs.shouldShowAnalyticsIcon}
                                       key={pipelineName}
                                       vm={vnode.attrs.vm}/>
                     );

--- a/server/webapp/WEB-INF/rails.new/webpack/views/dashboard/pipeline_header_widget.js.msx
+++ b/server/webapp/WEB-INF/rails.new/webpack/views/dashboard/pipeline_header_widget.js.msx
@@ -39,6 +39,7 @@ const PipelineHeaderWidget = {
   view: (vnode) => {
     const pipeline                   = vnode.attrs.pipeline;
     const pluginsSupportingAnalytics = vnode.attrs.pluginsSupportingAnalytics;
+    const shouldShowAnalyticsIcon    = vnode.attrs.shouldShowAnalyticsIcon;
 
     let settingsButton;
     const analyticsIcons = [];
@@ -50,9 +51,11 @@ const PipelineHeaderWidget = {
                                 tooltipText={pipeline.getSettingsDisabledTooltipText()}/>);
     }
 
-    $.each(pluginsSupportingAnalytics, (pluginId, metricId) => {
-      analyticsIcons.push(<PipelineAnalyticsWidget pipeline={pipeline} pluginId={pluginId} metricId={metricId}/>);
-    });
+    if (shouldShowAnalyticsIcon) {
+      $.each(pluginsSupportingAnalytics, (pluginId, metricId) => {
+        analyticsIcons.push(<PipelineAnalyticsWidget pipeline={pipeline} pluginId={pluginId} metricId={metricId}/>);
+      });
+    }
 
     let pipelineLockButton;
     if (pipeline.isLocked) {

--- a/server/webapp/WEB-INF/rails.new/webpack/views/dashboard/pipeline_widget.js.msx
+++ b/server/webapp/WEB-INF/rails.new/webpack/views/dashboard/pipeline_widget.js.msx
@@ -49,6 +49,7 @@ const PipelineWidget = {
                                 doCancelPolling={vnode.attrs.doCancelPolling}
                                 doRefreshImmediately={vnode.attrs.doRefreshImmediately}
                                 pluginsSupportingAnalytics={vnode.attrs.pluginsSupportingAnalytics}
+                                shouldShowAnalyticsIcon={vnode.attrs.shouldShowAnalyticsIcon}
                                 vm={vnode.attrs.vm}
                                 isQuickEditPageEnabled={vnode.attrs.isQuickEditPageEnabled}/>
           <div className="pipeline_instances">

--- a/spark/spark-base/src/test/groovy/com/thoughtworks/go/spark/SecurityServiceTrait.groovy
+++ b/spark/spark-base/src/test/groovy/com/thoughtworks/go/spark/SecurityServiceTrait.groovy
@@ -23,6 +23,7 @@ import com.thoughtworks.go.server.security.userdetail.GoUserPrinciple
 import com.thoughtworks.go.server.service.GoConfigService
 import com.thoughtworks.go.server.service.SecurityService
 import com.thoughtworks.go.spark.util.SecureRandom
+import com.thoughtworks.go.util.SystemEnvironment
 import org.junit.jupiter.api.AfterEach
 import org.springframework.security.GrantedAuthority
 import org.springframework.security.context.SecurityContextHolder
@@ -36,6 +37,7 @@ import static org.mockito.Mockito.when
 trait SecurityServiceTrait {
   SecurityService securityService = mock(SecurityService.class)
   GoConfigService goConfigService = mock(GoConfigService.class)
+  SystemEnvironment systemEnvironment = mock(SystemEnvironment.class);
 
   void loginAsAdmin() {
     Username username = loginAsRandomUser()

--- a/spark/spark-spa/src/main/java/com/thoughtworks/go/spark/spa/NewDashboardDelegate.java
+++ b/spark/spark-spa/src/main/java/com/thoughtworks/go/spark/spa/NewDashboardDelegate.java
@@ -21,6 +21,7 @@ import com.thoughtworks.go.server.service.support.toggle.Toggles;
 import com.thoughtworks.go.spark.Routes;
 import com.thoughtworks.go.spark.SparkController;
 import com.thoughtworks.go.spark.spring.SPAAuthenticationHelper;
+import com.thoughtworks.go.util.SystemEnvironment;
 import spark.ModelAndView;
 import spark.Request;
 import spark.Response;
@@ -34,11 +35,14 @@ public class NewDashboardDelegate implements SparkController {
     private final SPAAuthenticationHelper authenticationHelper;
     private final TemplateEngine engine;
     private final SecurityService securityService;
+    private SystemEnvironment systemEnvironment;
 
-    public NewDashboardDelegate(SPAAuthenticationHelper authenticationHelper, TemplateEngine engine, SecurityService securityService) {
+    public NewDashboardDelegate(SPAAuthenticationHelper authenticationHelper, TemplateEngine engine, SecurityService securityService,
+                                SystemEnvironment systemEnvironment) {
         this.authenticationHelper = authenticationHelper;
         this.engine = engine;
         this.securityService = securityService;
+        this.systemEnvironment = systemEnvironment;
     }
 
 
@@ -60,7 +64,14 @@ public class NewDashboardDelegate implements SparkController {
             put("viewTitle", "Dashboard");
             put("isQuickEditPageEnabled", Toggles.isToggleOn(Toggles.PIPELINE_CONFIG_SINGLE_PAGE_APP) && Toggles.isToggleOn(Toggles.QUICK_EDIT_PAGE_DEFAULT));
             put("isNewDashboardPageEnabled", Toggles.isToggleOn(Toggles.NEW_DASHBOARD_PAGE_DEFAULT));
+            put("shouldShowAnalyticsIcon", showAnalyticsIcon());
         }};
         return new ModelAndView(object, "new_dashboard/index.vm");
+    }
+
+    private boolean showAnalyticsIcon() {
+        return systemEnvironment.enablePipelineAnalyticsOnlyForAdmins()
+                ? securityService.isUserAdmin(currentUsername())
+                : true;
     }
 }

--- a/spark/spark-spa/src/main/java/com/thoughtworks/go/spark/spa/spring/SpaControllers.java
+++ b/spark/spark-spa/src/main/java/com/thoughtworks/go/spark/spa/spring/SpaControllers.java
@@ -21,6 +21,7 @@ import com.thoughtworks.go.spark.SparkController;
 import com.thoughtworks.go.spark.spa.*;
 import com.thoughtworks.go.spark.spring.SPAAuthenticationHelper;
 import com.thoughtworks.go.spark.spring.SparkSpringController;
+import com.thoughtworks.go.util.SystemEnvironment;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -32,13 +33,13 @@ public class SpaControllers implements SparkSpringController {
     private final List<SparkController> sparkControllers = new ArrayList<>();
 
     @Autowired
-    public SpaControllers(SPAAuthenticationHelper authenticationHelper, VelocityTemplateEngineFactory templateEngineFactory, SecurityService securityService) {
+    public SpaControllers(SPAAuthenticationHelper authenticationHelper, VelocityTemplateEngineFactory templateEngineFactory, SecurityService securityService, SystemEnvironment systemEnvironment) {
         sparkControllers.add(new RolesControllerDelegate(authenticationHelper, templateEngineFactory.create(RolesControllerDelegate.class, "layouts/single_page_app.vm")));
         sparkControllers.add(new AuthConfigsDelegate(authenticationHelper, templateEngineFactory.create(AuthConfigsDelegate.class, "layouts/single_page_app.vm")));
         sparkControllers.add(new AgentsControllerDelegate(authenticationHelper, templateEngineFactory.create(AgentsControllerDelegate.class, "layouts/single_page_app.vm"), securityService));
         sparkControllers.add(new PluginsDelegate(authenticationHelper, templateEngineFactory.create(PluginsDelegate.class, "layouts/single_page_app.vm"), securityService));
         sparkControllers.add(new ElasticProfilesDelegate(authenticationHelper, templateEngineFactory.create(ElasticProfilesDelegate.class, "layouts/single_page_app.vm")));
-        sparkControllers.add(new NewDashboardDelegate(authenticationHelper, templateEngineFactory.create(NewDashboardDelegate.class, "layouts/single_page_app.vm"), securityService));
+        sparkControllers.add(new NewDashboardDelegate(authenticationHelper, templateEngineFactory.create(NewDashboardDelegate.class, "layouts/single_page_app.vm"), securityService, systemEnvironment));
     }
 
     @Override

--- a/spark/spark-spa/src/main/resources/velocity/new_dashboard/index.vm
+++ b/spark/spark-spa/src/main/resources/velocity/new_dashboard/index.vm
@@ -13,6 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *#
-<div id="dashboard" data-is-quick-edit-page-enabled="${isQuickEditPageEnabled}" data-is-new-dashboard-page-default="${isNewDashboardPageEnabled}">
+<div id="dashboard" data-is-quick-edit-page-enabled="${isQuickEditPageEnabled}" data-is-new-dashboard-page-default="${isNewDashboardPageEnabled}" data-should-show-analytics-icon="${shouldShowAnalyticsIcon}">
   <span class="page-spinner"/>
 </div>

--- a/spark/spark-spa/src/test/groovy/com/thoughtworks/go/spark/spa/NewDashboardDelegateTest.groovy
+++ b/spark/spark-spa/src/test/groovy/com/thoughtworks/go/spark/spa/NewDashboardDelegateTest.groovy
@@ -28,7 +28,7 @@ import static org.mockito.MockitoAnnotations.initMocks
 class NewDashboardDelegateTest implements ControllerTrait<NewDashboardDelegate>, SecurityServiceTrait {
   @Override
   NewDashboardDelegate createControllerInstance() {
-    return new NewDashboardDelegate(new SPAAuthenticationHelper(securityService, goConfigService), templateEngine, securityService)
+    return new NewDashboardDelegate(new SPAAuthenticationHelper(securityService, goConfigService), templateEngine, securityService, systemEnvironment)
   }
 
   @Nested


### PR DESCRIPTION

* System property `go.enable.pipeline.analytics.only.for.admins` would
  allow controlling non_admins from viewing the pipeline analytics.