### PR TITLE
Don't need overflow-y on content container as we want the entire page to scroll as content grows

### DIFF
--- a/server/webapp/WEB-INF/rails.new/app/assets/new_stylesheets/single_page_apps/analytics.scss
+++ b/server/webapp/WEB-INF/rails.new/app/assets/new_stylesheets/single_page_apps/analytics.scss
@@ -33,8 +33,6 @@ $analytics-max-height: 869px;
   display:         flex;
   flex-wrap:       wrap;
   justify-content: center;
-  overflow-y:      scroll;
-  overflow-x:      hidden;
   margin-top:      50px;
 
   h1 {


### PR DESCRIPTION
Before

![image](https://user-images.githubusercontent.com/723642/38515999-c80588da-3bea-11e8-9937-8a01c05361a1.png)

After

![image](https://user-images.githubusercontent.com/723642/38516069-f44a2a7c-3bea-11e8-897d-6a749ad0dd9c.png)
