### PR TITLE
New dashboard did not list pipeline instances with failing stages

### DIFF
--- a/server/src/main/resources/com/thoughtworks/go/server/dao/maps/Pipeline.xml
+++ b/server/src/main/resources/com/thoughtworks/go/server/dao/maps/Pipeline.xml
@@ -270,7 +270,7 @@
           (
               SELECT stages.pipelineId
               FROM stages
-              WHERE stages.state = 'Building' AND latestRun = true
+              WHERE stages.state IN('Building', 'Failing') AND latestRun = true
           )
         UNION
           (
@@ -290,7 +290,7 @@
           (
               SELECT stages.pipelineId
               FROM stages
-              WHERE stages.state = 'Building' AND latestRun = true
+              WHERE stages.state IN('Building', 'Failing') AND latestRun = true
           )
         UNION
           (

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/ScheduleTestUtil.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/ScheduleTestUtil.java
@@ -366,6 +366,10 @@ public class ScheduleTestUtil {
         return saveConfigWith(DEFAULT_GROUP, pipelineName, stageName, materialDecls);
     }
 
+    public AddedPipeline saveConfigWith(PipelineConfig pipelineConfig) {
+        return new AddedPipeline(configHelper.addPipeline(DEFAULT_GROUP, pipelineConfig), null);
+    }
+
     public AddedPipeline saveConfigWith(String pipelineName, String stageName, MaterialDeclaration materialDeclaration, String[] builds) {
         MaterialConfigs materialConfigs = new MaterialConfigs();
         MaterialConfig materialConfig = AutoTriggerDependencyResolutionTest.CLONER.deepClone(materialDeclaration.material.config());

--- a/server/src/test-shared/java/com/thoughtworks/go/server/dao/DatabaseAccessHelper.java
+++ b/server/src/test-shared/java/com/thoughtworks/go/server/dao/DatabaseAccessHelper.java
@@ -479,6 +479,14 @@ public class DatabaseAccessHelper extends HibernateDaoSupport {
         jobInstanceDao.updateStateAndResult(second);
     }
 
+    public void failJob(Stage stage, JobInstance instance) {
+        instance.completing(Failed);
+        instance.completed(new Date());
+        jobInstanceDao.updateStateAndResult(instance);
+        stage.calculateResult();
+        updateResultInTransaction(stage, stage.getResult());
+    }
+
     public void cancelStage(Stage stage) {
         for (JobInstance job : stage.getJobInstances()) {
             job.cancel();

--- a/server/src/test-shared/java/com/thoughtworks/go/util/GoConfigFileHelper.java
+++ b/server/src/test-shared/java/com/thoughtworks/go/util/GoConfigFileHelper.java
@@ -298,6 +298,13 @@ public class GoConfigFileHelper {
         return pipelineConfig;
     }
 
+    public PipelineConfig addPipeline(String groupName, PipelineConfig pipelineConfig) {
+        CruiseConfig cruiseConfig = loadForEdit();
+        cruiseConfig.addPipeline(groupName, pipelineConfig);
+        writeConfigFile(cruiseConfig);
+        return pipelineConfig;
+    }
+
     public void addSecurityAuthConfig(SecurityAuthConfig securityAuthConfig) {
         CruiseConfig config = loadForEdit();
         config.server().security().securityAuthConfigs().add(securityAuthConfig);


### PR DESCRIPTION
A stage is marked as failing when all the jobs were building/scheduled and one of those jobs fails.
The query for the older dashboard doesnot load up such stages too, however, it does show up pipeline instances with failing stages if the failure happened after the server was brought up (some cache data magic). If the server was restarted with db being in such a stage, even the old dashboard did not list such instances.
This is an issue since a running stage prevents running of the same stage in a different pipeline instance. Without the pipeline instance being visible, its difficult to spot these kind of situations. Even if this behavior changes in future, it is important to see all running instances on the dashboard.