### PR TITLE
Fixed (#4649)

### DIFF
--- a/api/api-build_cause-v1/src/test/groovy/com/thoughtworks/go/apiv1/buildcause/BuildCauseControllerDelegateTest.groovy
+++ b/api/api-build_cause-v1/src/test/groovy/com/thoughtworks/go/apiv1/buildcause/BuildCauseControllerDelegateTest.groovy
@@ -65,7 +65,7 @@ class BuildCauseControllerDelegateTest implements ControllerTrait<BuildCauseCont
 
       @BeforeEach
       void setUp() {
-        when(goConfigService.hasPipelineNamed(new CaseInsensitiveString("foo"))).thenReturn(true)
+        when(goConfigService.hasPipelineNamed(new CaseInsensitiveString(getPipelineName()))).thenReturn(true)
       }
 
       @Override
@@ -75,7 +75,12 @@ class BuildCauseControllerDelegateTest implements ControllerTrait<BuildCauseCont
 
       @Override
       void makeHttpCall() {
-        getWithApiHeader(controller.controllerPath('/foo/2'))
+        getWithApiHeader(controller.controllerPath("/${getPipelineName()}/2"))
+      }
+
+      @Override
+      String getPipelineName() {
+        return "foo"
       }
     }
 

--- a/api/api-material-search-v1/src/test/groovy/com/thoughtworks/go/apiv1/materialsearch/MaterialSearchControllerDelegateTest.groovy
+++ b/api/api-material-search-v1/src/test/groovy/com/thoughtworks/go/apiv1/materialsearch/MaterialSearchControllerDelegateTest.groovy
@@ -68,7 +68,12 @@ class MaterialSearchControllerDelegateTest implements ControllerTrait<MaterialSe
 
     @Override
     void makeHttpCall() {
-      getWithApiHeader(controller.controllerPath([fingerprint: 'foo', pipeline_name: 'some-pipeline', search_text: 'abc']))
+      getWithApiHeader(controller.controllerPath([fingerprint: 'foo', pipeline_name: getPipelineName(), search_text: 'abc']))
+    }
+
+    @Override
+    String getPipelineName() {
+      return 'some-pipeline'
     }
   }
 

--- a/api/api-pipeline-operations-v1/src/test/groovy/com/thoughtworks/go/apiv1/pipelineoperations/PipelineOperationsControllerV1DelegateTest.groovy
+++ b/api/api-pipeline-operations-v1/src/test/groovy/com/thoughtworks/go/apiv1/pipelineoperations/PipelineOperationsControllerV1DelegateTest.groovy
@@ -48,6 +48,7 @@ import com.thoughtworks.go.spark.ControllerTrait
 import com.thoughtworks.go.spark.PipelineGroupOperateUserSecurity
 import com.thoughtworks.go.spark.Routes
 import com.thoughtworks.go.spark.SecurityServiceTrait
+import org.aspectj.lang.reflect.UnlockSignature
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -94,6 +95,11 @@ class PipelineOperationsControllerV1DelegateTest implements SecurityServiceTrait
       @Override
       void makeHttpCall() {
         postWithApiHeader(controller.controllerPath(pipelineName, 'pause'), [:])
+      }
+
+      @Override
+      String getPipelineName() {
+        return Pause.this.pipelineName
       }
     }
 
@@ -173,6 +179,11 @@ class PipelineOperationsControllerV1DelegateTest implements SecurityServiceTrait
       void makeHttpCall() {
         postWithApiHeader(controller.controllerPath(pipelineName, 'unpause'), [:])
       }
+
+      @Override
+      String getPipelineName() {
+        return Unpause.this.pipelineName
+      }
     }
 
     @Nested
@@ -234,6 +245,11 @@ class PipelineOperationsControllerV1DelegateTest implements SecurityServiceTrait
       void makeHttpCall() {
         postWithApiHeader(controller.controllerPath(pipelineName, 'unlock'), [:])
       }
+
+      @Override
+      String getPipelineName() {
+        return Unlock.this.pipelineName
+      }
     }
 
     @Nested
@@ -293,6 +309,11 @@ class PipelineOperationsControllerV1DelegateTest implements SecurityServiceTrait
       void makeHttpCall() {
         getWithApiHeader(Routes.Pipeline.triggerOptions('build-linux'))
       }
+
+      @Override
+      String getPipelineName() {
+        return 'build-linux'
+      }
     }
 
     @Nested
@@ -350,6 +371,11 @@ class PipelineOperationsControllerV1DelegateTest implements SecurityServiceTrait
       void makeHttpCall() {
         postWithApiHeader(controller.controllerPath(pipelineName, 'schedule'), [:])
       }
+
+      @Override
+      String getPipelineName() {
+        return Schedule.this.pipelineName
+      }
     }
 
     @Nested
@@ -357,7 +383,7 @@ class PipelineOperationsControllerV1DelegateTest implements SecurityServiceTrait
       @BeforeEach
       void setUp() {
         enableSecurity()
-        loginAsGroupOperateUser()
+        loginAsGroupOperateUser(pipelineName)
       }
 
       @Test

--- a/spark/spark-base/src/main/java/com/thoughtworks/go/spark/spring/AbstractAuthenticationHelper.java
+++ b/spark/spark-base/src/main/java/com/thoughtworks/go/spark/spring/AbstractAuthenticationHelper.java
@@ -131,9 +131,17 @@ public abstract class AbstractAuthenticationHelper {
     private String findPipelineGroupName(Request request) {
         String groupName = request.params("group");
         if (StringUtils.isBlank(groupName)) {
-            groupName = goConfigService.findGroupNameByPipeline(new CaseInsensitiveString(request.params("pipeline_name")));
+            groupName = goConfigService.findGroupNameByPipeline(getPipelineNameFromRequest(request));
         }
         return groupName;
+    }
+
+    private CaseInsensitiveString getPipelineNameFromRequest(Request request) {
+        String pipelineName = request.params("pipeline_name");
+        if (StringUtils.isBlank(pipelineName)) {
+            pipelineName = request.queryParams("pipeline_name");
+        }
+        return new CaseInsensitiveString(pipelineName);
     }
 
     private Username currentUsername() {

--- a/spark/spark-base/src/test/groovy/com/thoughtworks/go/spark/PipelineAccessSecurity.groovy
+++ b/spark/spark-base/src/test/groovy/com/thoughtworks/go/spark/PipelineAccessSecurity.groovy
@@ -59,11 +59,13 @@ trait PipelineAccessSecurity {
   @Test
   void "should allow pipeline view users, with security enabled"() {
     enableSecurity()
-    loginAsPipelineViewUser()
+    loginAsPipelineViewUser(pipelineName)
 
     makeHttpCall()
 
     assertRequestAuthorized()
   }
+
+  abstract String getPipelineName()
 
 }

--- a/spark/spark-base/src/test/groovy/com/thoughtworks/go/spark/PipelineGroupOperateUserSecurity.groovy
+++ b/spark/spark-base/src/test/groovy/com/thoughtworks/go/spark/PipelineGroupOperateUserSecurity.groovy
@@ -59,7 +59,7 @@ trait PipelineGroupOperateUserSecurity {
   @Test
   void 'should allow pipeline group admin users, with security enabled'() {
     enableSecurity()
-    loginAsGroupAdmin()
+    loginAsGroupAdmin(pipelineName)
 
     makeHttpCall()
     assertRequestAuthorized()
@@ -68,7 +68,7 @@ trait PipelineGroupOperateUserSecurity {
   @Test
   void "should disallow pipeline view users, with security enabled"() {
     enableSecurity()
-    loginAsPipelineViewUser()
+    loginAsPipelineViewUser(pipelineName)
 
     makeHttpCall()
 
@@ -78,10 +78,12 @@ trait PipelineGroupOperateUserSecurity {
   @Test
   void 'should allow pipeline group operate users, with security enabled'() {
     enableSecurity()
-    loginAsGroupOperateUser()
+    loginAsGroupOperateUser(pipelineName)
 
     makeHttpCall()
     assertRequestAuthorized()
   }
+
+  abstract String getPipelineName()
 
 }

--- a/spark/spark-base/src/test/groovy/com/thoughtworks/go/spark/SecurityServiceTrait.groovy
+++ b/spark/spark-base/src/test/groovy/com/thoughtworks/go/spark/SecurityServiceTrait.groovy
@@ -78,30 +78,34 @@ trait SecurityServiceTrait {
     when(securityService.isSecurityEnabled()).thenReturn(true)
   }
 
-  void loginAsGroupAdmin() {
+  void loginAsGroupAdmin(String pipelineName) {
     Username username = loginAsRandomUser()
+    String groupName = generateGroupName()
 
     when(securityService.isUserAdmin(username)).thenReturn(false)
     when(securityService.isUserGroupAdmin(username)).thenReturn(true)
-    when(securityService.isUserAdminOfGroup(eq(username.username) as CaseInsensitiveString, any() as String)).thenReturn(true)
+    when(securityService.isUserAdminOfGroup(eq(username.username) as CaseInsensitiveString, eq(groupName))).thenReturn(true)
 
     PipelineGroups groups = mock(PipelineGroups.class)
     when(goConfigService.groups()).thenReturn(groups)
-    when(groups.hasGroup(any() as String)).thenReturn(true)
-    when(securityService.hasOperatePermissionForGroup(any() as CaseInsensitiveString, any() as String)).thenReturn(true)
+    when(groups.hasGroup(groupName)).thenReturn(true)
+    when(securityService.hasOperatePermissionForGroup(username.username, groupName)).thenReturn(true)
+    when(goConfigService.findGroupNameByPipeline(new CaseInsensitiveString(pipelineName))).thenReturn(groupName)
   }
 
-  void loginAsGroupOperateUser() {
+  void loginAsGroupOperateUser(String pipelineName) {
     Username username = loginAsRandomUser()
+    String groupName = generateGroupName()
 
     when(securityService.isUserAdmin(username)).thenReturn(false)
     when(securityService.isUserGroupAdmin(username)).thenReturn(false)
-    when(securityService.isUserAdminOfGroup(eq(username.username) as CaseInsensitiveString, any() as String)).thenReturn(false)
+    when(securityService.isUserAdminOfGroup(eq(username.username) as CaseInsensitiveString, eq(groupName))).thenReturn(false)
 
     PipelineGroups groups = mock(PipelineGroups.class)
     when(goConfigService.groups()).thenReturn(groups)
-    when(groups.hasGroup(any() as String)).thenReturn(true)
-    when(securityService.hasOperatePermissionForGroup(any() as CaseInsensitiveString, any() as String)).thenReturn(true)
+    when(groups.hasGroup(groupName)).thenReturn(true)
+    when(securityService.hasOperatePermissionForGroup(eq(username.username), eq(groupName))).thenReturn(true)
+    when(goConfigService.findGroupNameByPipeline(new CaseInsensitiveString(pipelineName))).thenReturn(groupName)
   }
 
   void disableSecurity() {
@@ -121,8 +125,9 @@ trait SecurityServiceTrait {
     when(securityService.isAuthorizedToViewTemplates(username)).thenReturn(true)
   }
 
-  void loginAsPipelineViewUser() {
+  void loginAsPipelineViewUser(String pipelineName) {
     Username username = loginAsRandomUser()
+    String groupName = generateGroupName()
 
     when(securityService.isUserAdmin(username)).thenReturn(false)
     when(securityService.isUserGroupAdmin(username)).thenReturn(false)
@@ -133,7 +138,8 @@ trait SecurityServiceTrait {
     when(securityService.isAuthorizedToViewTemplate(any() as CaseInsensitiveString, eq(username))).thenReturn(false)
     when(securityService.isAuthorizedToViewTemplates(eq(username))).thenReturn(false)
     when(goConfigService.groups()).thenReturn(new PipelineGroups())
-    when(securityService.hasViewPermissionForPipeline(eq(username), any() as String)).thenReturn(true)
+    when(securityService.hasViewPermissionForPipeline(eq(username), eq(pipelineName))).thenReturn(true)
+    when(goConfigService.findGroupNameByPipeline(new CaseInsensitiveString(pipelineName))).thenReturn(groupName)
   }
 
   private Username loginAsRandomUser() {
@@ -145,6 +151,10 @@ trait SecurityServiceTrait {
     TestingAuthenticationToken authentication = new TestingAuthenticationToken(principal, null, null)
     SecurityContextHolder.getContext().setAuthentication(authentication)
     username
+  }
+
+  private String generateGroupName() {
+    "group-" + SecureRandom.hex(20)
   }
 
   @AfterEach


### PR DESCRIPTION
Fixed following issues
1. Reading pipeline_name from Request Queryparam if not found in path.
2. Fixed incorrect testcases which were matching against `any()` instead of specific values
