### PR TITLE
Serialise lastBuildTime for CCTray in UTC with timezone

### DIFF
--- a/base/src/main/java/com/thoughtworks/go/util/DateUtils.java
+++ b/base/src/main/java/com/thoughtworks/go/util/DateUtils.java
@@ -30,6 +30,7 @@ import static com.thoughtworks.go.util.ExceptionUtils.bomb;
 public class DateUtils {
 
     private static final DateTimeFormatter formatter = ISODateTimeFormat.dateTimeNoMillis();
+    private static final DateTimeFormatter formatterUtc = formatter.withZoneUTC();
     private static final TimeZone UTC = TimeZone.getTimeZone("UTC");
 
     public static String formatISO8601(Date from) {
@@ -40,7 +41,7 @@ public class DateUtils {
         if (date == null) {
             return null;
         }
-        return new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss").format(date);
+        return formatterUtc.print(date.getTime());
     }
 
     public static String formatRFC822(Date date) {

--- a/base/src/test/java/com/thoughtworks/go/util/DateUtilsTest.java
+++ b/base/src/test/java/com/thoughtworks/go/util/DateUtilsTest.java
@@ -32,6 +32,11 @@ public class DateUtilsTest {
         assertThat(date, is(new DateTime("2008-12-09T18:56:14+08:00").toDate()));
     }
 
+    @Test public void shouldSerializeDateForCcTray() {
+        Date date = new DateTime("2008-12-09T18:56:14+08:00").toDate();
+        assertThat(DateUtils.formatIso8601ForCCTray(date), is("2008-12-09T10:56:14Z"));
+    }
+
     @Test
     public void shouldFormatDateToDisplayOnUI() {
         Calendar instance = Calendar.getInstance();

--- a/server/src/test-fast/java/com/thoughtworks/go/domain/activity/ProjectStatusTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/domain/activity/ProjectStatusTest.java
@@ -20,8 +20,11 @@ import com.thoughtworks.go.config.security.users.AllowedUsers;
 import com.thoughtworks.go.config.security.users.Users;
 import com.thoughtworks.go.util.DateUtils;
 import org.jdom2.Element;
+import org.joda.time.format.ISODateTimeFormat;
 import org.junit.Test;
 
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
 import java.util.Collections;
 import java.util.Date;
 
@@ -68,21 +71,21 @@ public class ProjectStatusTest {
     @Test
     public void shouldProvideItsXmlRepresentation_WhenThereAreNoBreakers() throws Exception {
         ProjectStatus status = new ProjectStatus("name", "activity1", "build-status-1", "build-label-1",
-                DateUtils.parseYYYYMMDD("2010-05-23"), "web-url");
+                DateUtils.parseRFC822("Sun, 23 May 2010 10:00:00 +0200"), "web-url");
 
         assertThat(status.xmlRepresentation(),
                 is("<Project name=\"name\" activity=\"activity1\" lastBuildStatus=\"build-status-1\" lastBuildLabel=\"build-label-1\" " +
-                        "lastBuildTime=\"2010-05-23T00:00:00\" webUrl=\"__SITE_URL_PREFIX__/web-url\" />"));
+                        "lastBuildTime=\"2010-05-23T08:00:00Z\" webUrl=\"__SITE_URL_PREFIX__/web-url\" />"));
     }
 
     @Test
     public void shouldProvideItsXmlRepresentation_WhenThereAreBreakers() throws Exception {
         ProjectStatus status = new ProjectStatus("name", "activity1", "build-status-1", "build-label-1",
-                DateUtils.parseYYYYMMDD("2010-05-23"), "web-url", s("breaker1", "breaker2"));
+                DateUtils.parseRFC822("Sun, 23 May 2010 10:00:00 +0200"), "web-url", s("breaker1", "breaker2"));
 
         assertThat(status.xmlRepresentation(),
                 is("<Project name=\"name\" activity=\"activity1\" lastBuildStatus=\"build-status-1\" lastBuildLabel=\"build-label-1\" " +
-                        "lastBuildTime=\"2010-05-23T00:00:00\" webUrl=\"__SITE_URL_PREFIX__/web-url\">" +
+                        "lastBuildTime=\"2010-05-23T08:00:00Z\" webUrl=\"__SITE_URL_PREFIX__/web-url\">" +
                         "<messages><message text=\"breaker1, breaker2\" kind=\"Breakers\" /></messages></Project>"));
     }
 

--- a/server/src/test-fast/java/com/thoughtworks/go/server/service/CcTrayServiceTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/service/CcTrayServiceTest.java
@@ -113,12 +113,12 @@ public class CcTrayServiceTest {
 
         assertThat(xml, is("<?xml version=\"1.0\" encoding=\"utf-8\"?>\n" +
                 "<Projects>\n" +
-                "  <Project name=\"proj1\" activity=\"activity1\" lastBuildStatus=\"build-status-1\" lastBuildLabel=\"build-label-1\" lastBuildTime=\"2010-05-23T00:00:00\" webUrl=\"" + "prefix1" + "/web-url\" />\n" +
+                "  <Project name=\"proj1\" activity=\"activity1\" lastBuildStatus=\"build-status-1\" lastBuildLabel=\"build-label-1\" lastBuildTime=\"2010-05-23T08:00:00Z\" webUrl=\"" + "prefix1" + "/web-url\" />\n" +
                 "</Projects>"));
     }
 
     private ProjectStatus statusFor(String projectName, String... allowedUsers) throws Exception {
-        ProjectStatus status = new ProjectStatus(projectName, "activity1", "build-status-1", "build-label-1", DateUtils.parseYYYYMMDD("2010-05-23"), "web-url");
+        ProjectStatus status = new ProjectStatus(projectName, "activity1", "build-status-1", "build-label-1", DateUtils.parseRFC822("Sun, 23 May 2010 10:00:00 +0200"), "web-url");
         status.updateViewers(viewers(allowedUsers));
         return status;
     }
@@ -126,7 +126,7 @@ public class CcTrayServiceTest {
     private void assertCcTrayXmlFor(String actualXml, final String siteUrlPrefix, final String... projects) {
         StringBuilder expectedXml = new StringBuilder("<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<Projects>\n");
         for (String project : projects) {
-            expectedXml.append("  <Project name=\"").append(project).append("\" activity=\"activity1\" lastBuildStatus=\"build-status-1\" lastBuildLabel=\"build-label-1\" lastBuildTime=\"2010-05-23T00:00:00\" webUrl=\"" + siteUrlPrefix + "/web-url\" />\n");
+            expectedXml.append("  <Project name=\"").append(project).append("\" activity=\"activity1\" lastBuildStatus=\"build-status-1\" lastBuildLabel=\"build-label-1\" lastBuildTime=\"2010-05-23T08:00:00Z\" webUrl=\"" + siteUrlPrefix + "/web-url\" />\n");
         }
         expectedXml.append("</Projects>");
 


### PR DESCRIPTION
When using my build display tool of choice (CCMenu) Go.cd builds show as having run "2 hours ago" although they just finished. This seems to be due to my timezone offset (UTC+2, CEST).

It seems that Go.cd so far has always serialized the lastBuildTime value without timezone information: 'lastBuildTime="2018-04-12T08:05:29"'. For reference, TravisCI will return e.g. 'lastBuildTime="2018-04-10T19:55:16.000+0000"'.

This PR makes sure Go.cd will return build time in UTC, with timezone information.

The code change fixes the new test which with the old behaviour would otherwise fail with
```
    Expected: is "2008-12-09T10:56:14Z"
         but: was "2008-12-09T11:56:14"
```