### PR TITLE
Fixed dashboard icon alignment issue.

### DIFF
--- a/server/webapp/WEB-INF/rails.new/app/assets/new_stylesheets/single_page_apps/new_dashboard.scss
+++ b/server/webapp/WEB-INF/rails.new/app/assets/new_stylesheets/single_page_apps/new_dashboard.scss
@@ -662,6 +662,7 @@ body {
     position:    relative;
     top:         -3px;
     flex-shrink: 0;
+    right:       0;
   }
 }
 
@@ -674,12 +675,6 @@ body {
 
 .material_info-error {
   margin-left: 12px;
-}
-
-.pipeline_actions {
-  position: absolute;
-  right:    10px;
-  top:      -2px;
 }
 
 .pipeline_locked {


### PR DESCRIPTION
The commit https://github.com/gocd/gocd/commit/cf88d5c2f2338b289af28d81da5038e5edc126da\#diff-65330ebbce5f2023e80a056e69aaad31 cause the issue.


### Alignment after the fix
<img width="282" alt="screen shot 2018-04-16 at 8 01 24 am" src="https://user-images.githubusercontent.com/7871209/38788240-512969b4-4150-11e8-826e-78cd75fbca5c.png">

### Chrome
<img width="1438" alt="screen shot 2018-04-16 at 7 58 42 am" src="https://user-images.githubusercontent.com/7871209/38788536-eecfcb4e-4151-11e8-874e-0adfb0f2fdd9.png">

### Safari
<img width="1440" alt="screen shot 2018-04-16 at 7 59 10 am" src="https://user-images.githubusercontent.com/7871209/38788541-f8f85474-4151-11e8-97d9-363585e5b5a2.png">

### Firefox
<img width="1436" alt="screen shot 2018-04-16 at 8 00 42 am" src="https://user-images.githubusercontent.com/7871209/38788548-fea2887c-4151-11e8-972a-d99b961f6052.png">


