### PR TITLE
Making a bunch of APIs to support pipeline-counter instead of both counter and label

### DIFF
--- a/common/src/test/java/com/thoughtworks/go/domain/StageIdentifierTest.java
+++ b/common/src/test/java/com/thoughtworks/go/domain/StageIdentifierTest.java
@@ -1,18 +1,18 @@
-/*************************GO-LICENSE-START*********************************
- * Copyright 2014 ThoughtWorks, Inc.
+/*
+ * Copyright 2018 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *************************GO-LICENSE-END***********************************/
+ */
 
 package com.thoughtworks.go.domain;
 
@@ -41,16 +41,6 @@ public class StageIdentifierTest {
     public void shouldConstructFromStageLocator() {
         StageIdentifier identifier = new StageIdentifier("pipeline-name/10/stage-name/7");
         assertThat(identifier.getPipelineName(), is("pipeline-name"));
-        assertThat(identifier.getStageName(), is("stage-name"));
-        assertThat(identifier.getPipelineCounter(), is(10));
-        assertThat(identifier.getStageCounter(), is("7"));
-    }
-
-    @Test
-    public void shouldConstructFromStageLocatorWithLabel() {
-        StageIdentifier identifier = new StageIdentifier("pipeline-name/10[foo]/stage-name/7");
-        assertThat(identifier.getPipelineName(), is("pipeline-name"));
-        assertThat(identifier.getPipelineLabel(), is("foo"));
         assertThat(identifier.getStageName(), is("stage-name"));
         assertThat(identifier.getPipelineCounter(), is(10));
         assertThat(identifier.getStageCounter(), is("7"));

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/PipelineInstanceNotFoundException.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/PipelineInstanceNotFoundException.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2018 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.config;
+
+import com.thoughtworks.go.config.exceptions.RecordNotFoundException;
+
+public class PipelineInstanceNotFoundException extends RecordNotFoundException {
+    public PipelineInstanceNotFoundException(String pipelineName, Integer counter) {
+        super(String.format("Pipeline instance [%s/%s] not found", pipelineName, counter));
+    }
+}

--- a/domain/src/main/java/com/thoughtworks/go/domain/StageIdentifier.java
+++ b/domain/src/main/java/com/thoughtworks/go/domain/StageIdentifier.java
@@ -59,20 +59,10 @@ public class StageIdentifier implements Serializable, LocatableEntity {
         this(pipelineIdentifier.getName(), pipelineIdentifier.getCounter(), pipelineIdentifier.getLabel(), name, counter);
     }
 
-    /**
-     * @deprecated breaks if the locator has an alphs-numeric label
-     */
     public StageIdentifier(String stageLocator) {
         String[] locatorElements = stageLocator.split("/");
         String counter = locatorElements[1];
-        String label = null;
-        java.util.regex.Matcher matcher = Pattern.compile("(\\d+)\\[(.*?)\\]").matcher(counter);
-        if (matcher.matches()) {
-            counter = matcher.group(1);
-            label = matcher.group(2);
-            this.pipelineLabel = label;
-        }
-        setLocatorAttributes(locatorElements[0], Integer.parseInt(counter), label, locatorElements[2], locatorElements[3]);
+        setLocatorAttributes(locatorElements[0], Integer.parseInt(counter), null, locatorElements[2], locatorElements[3]);
     }
 
     private void setLocatorAttributes(String pipelineName, Integer pipelineCounter, String label, String stageName, String stageCounter) {

--- a/server/src/main/java/com/thoughtworks/go/server/controller/ArtifactsController.java
+++ b/server/src/main/java/com/thoughtworks/go/server/controller/ArtifactsController.java
@@ -231,7 +231,11 @@ public class ArtifactsController {
 
         JobIdentifier jobIdentifier;
         try {
-            jobIdentifier = restfulService.findJob(pipelineName, counterOrLabel, stageName, stageCounter, buildName, buildId);
+            if(buildId == null) {
+                jobIdentifier = restfulService.findJob(pipelineName, counterOrLabel, stageName, stageCounter, buildName, buildId);
+            } else {
+                jobIdentifier = restfulService.findJobForBuildId(pipelineName, Long.parseLong(counterOrLabel), stageName, stageCounter, buildName, buildId);
+            }
         } catch (Exception e) {
             return buildNotFound(pipelineName, counterOrLabel, stageName, stageCounter, buildName);
         }

--- a/server/src/main/java/com/thoughtworks/go/server/controller/ArtifactsController.java
+++ b/server/src/main/java/com/thoughtworks/go/server/controller/ArtifactsController.java
@@ -95,38 +95,38 @@ public class ArtifactsController {
     /* RESTful URLs */
     @RequestMapping(value = "/repository/restful/artifact/GET/html", method = RequestMethod.GET)
     public ModelAndView getArtifactAsHtml(@RequestParam("pipelineName") String pipelineName,
-                                          @RequestParam("pipelineCounter") String counter,
+                                          @RequestParam("pipelineCounter") String pipelineCounter,
                                           @RequestParam("stageName") String stageName,
                                           @RequestParam(value = "stageCounter", required = false) String stageCounter,
                                           @RequestParam("buildName") String buildName,
                                           @RequestParam("filePath") String filePath,
                                           @RequestParam(value = "sha1", required = false) String sha,
                                           @RequestParam(value = "serverAlias", required = false) String serverAlias) throws Exception {
-        return getArtifact(filePath, folderViewFactory, pipelineName, counter, stageName, stageCounter, buildName, sha, serverAlias);
+        return getArtifact(filePath, folderViewFactory, pipelineName, pipelineCounter, stageName, stageCounter, buildName, sha, serverAlias);
     }
 
     @RequestMapping(value = "/repository/restful/artifact/GET/json", method = RequestMethod.GET)
     public ModelAndView getArtifactAsJson(@RequestParam("pipelineName") String pipelineName,
-                                          @RequestParam("pipelineCounter") String counter,
+                                          @RequestParam("pipelineCounter") String pipelineCounter,
                                           @RequestParam("stageName") String stageName,
                                           @RequestParam(value = "stageCounter", required = false) String stageCounter,
                                           @RequestParam("buildName") String buildName,
                                           @RequestParam("filePath") String filePath,
                                           @RequestParam(value = "sha1", required = false) String sha
     ) throws Exception {
-        return getArtifact(filePath, jsonViewFactory, pipelineName, counter, stageName, stageCounter, buildName, sha, null);
+        return getArtifact(filePath, jsonViewFactory, pipelineName, pipelineCounter, stageName, stageCounter, buildName, sha, null);
     }
 
     @RequestMapping(value = "/repository/restful/artifact/GET/zip", method = RequestMethod.GET)
     public ModelAndView getArtifactAsZip(@RequestParam("pipelineName") String pipelineName,
-                                         @RequestParam("pipelineCounter") String counter,
+                                         @RequestParam("pipelineCounter") String pipelineCounter,
                                          @RequestParam("stageName") String stageName,
                                          @RequestParam(value = "stageCounter", required = false) String stageCounter,
                                          @RequestParam("buildName") String buildName,
                                          @RequestParam("filePath") String filePath,
                                          @RequestParam(value = "sha1", required = false) String sha
     ) throws Exception {
-        return getArtifact(filePath, zipViewFactory, pipelineName, counter, stageName, stageCounter, buildName, sha, null);
+        return getArtifact(filePath, zipViewFactory, pipelineName, pipelineCounter, stageName, stageCounter, buildName, sha, null);
     }
 
     @RequestMapping(value = "/repository/restful/artifact/GET/*", method = RequestMethod.GET)
@@ -136,7 +136,7 @@ public class ArtifactsController {
 
     @RequestMapping(value = "/repository/restful/artifact/POST/*", method = RequestMethod.POST)
     public ModelAndView postArtifact(@RequestParam("pipelineName") String pipelineName,
-                                     @RequestParam("pipelineCounter") String counter,
+                                     @RequestParam("pipelineCounter") String pipelineCounter,
                                      @RequestParam("stageName") String stageName,
                                      @RequestParam(value = "stageCounter", required = false) String stageCounter,
                                      @RequestParam("buildName") String buildName,
@@ -149,10 +149,10 @@ public class ArtifactsController {
             return ResponseCodeView.create(HttpServletResponse.SC_BAD_REQUEST, "Missing required header 'Confirm'");
         }
         try {
-            jobIdentifier = restfulService.findJob(pipelineName, counter, stageName, stageCounter,
+            jobIdentifier = restfulService.findJob(pipelineName, pipelineCounter, stageName, stageCounter,
                     buildName, buildId);
         } catch (Exception e) {
-            return buildNotFound(pipelineName, counter, stageName, stageCounter,
+            return buildNotFound(pipelineName, pipelineCounter, stageName, stageCounter,
                     buildName);
         }
 
@@ -216,7 +216,7 @@ public class ArtifactsController {
 
     @RequestMapping(value = "/repository/restful/artifact/PUT/*", method = RequestMethod.PUT)
     public ModelAndView putArtifact(@RequestParam("pipelineName") String pipelineName,
-                                    @RequestParam("pipelineCounter") String counter,
+                                    @RequestParam("pipelineCounter") String pipelineCounter,
                                     @RequestParam("stageName") String stageName,
                                     @RequestParam(value = "stageCounter", required = false) String stageCounter,
                                     @RequestParam("buildName") String buildName,
@@ -231,9 +231,9 @@ public class ArtifactsController {
 
         JobIdentifier jobIdentifier;
         try {
-            jobIdentifier = restfulService.findJob(pipelineName, counter, stageName, stageCounter, buildName, buildId);
+            jobIdentifier = restfulService.findJob(pipelineName, pipelineCounter, stageName, stageCounter, buildName, buildId);
         } catch (Exception e) {
-            return buildNotFound(pipelineName, counter, stageName, stageCounter, buildName);
+            return buildNotFound(pipelineName, pipelineCounter, stageName, stageCounter, buildName);
         }
 
         if (isConsoleOutput(filePath)) {
@@ -247,7 +247,7 @@ public class ArtifactsController {
 
     @RequestMapping(value = "/**/consoleout.json", method = RequestMethod.GET)
     public ModelAndView consoleout(@RequestParam("pipelineName") String pipelineName,
-                                   @RequestParam("pipelineCounter") String counter,
+                                   @RequestParam("pipelineCounter") String pipelineCounter,
                                    @RequestParam("stageName") String stageName,
                                    @RequestParam("buildName") String buildName,
                                    @RequestParam(value = "stageCounter", required = false) String stageCounter,
@@ -256,14 +256,14 @@ public class ArtifactsController {
         start = start == null ? 0L : start;
 
         try {
-            JobIdentifier identifier = restfulService.findJob(pipelineName, counter, stageName, stageCounter, buildName);
+            JobIdentifier identifier = restfulService.findJob(pipelineName, pipelineCounter, stageName, stageCounter, buildName);
             if (jobInstanceDao.isJobCompleted(identifier) && !consoleService.doesLogExist(identifier)) {
                 return logsNotFound(identifier);
             }
             ConsoleConsumer streamer = consoleService.getStreamer(start, identifier);
             return new ModelAndView(new ConsoleOutView(streamer, consoleLogCharset));
         } catch (Exception e) {
-            return buildNotFound(pipelineName, counter, stageName, stageCounter, buildName);
+            return buildNotFound(pipelineName, pipelineCounter, stageName, stageCounter, buildName);
         }
     }
 

--- a/server/src/main/java/com/thoughtworks/go/server/controller/ArtifactsController.java
+++ b/server/src/main/java/com/thoughtworks/go/server/controller/ArtifactsController.java
@@ -95,38 +95,38 @@ public class ArtifactsController {
     /* RESTful URLs */
     @RequestMapping(value = "/repository/restful/artifact/GET/html", method = RequestMethod.GET)
     public ModelAndView getArtifactAsHtml(@RequestParam("pipelineName") String pipelineName,
-                                          @RequestParam("pipelineLabel") String counterOrLabel,
+                                          @RequestParam("pipelineCounter") String counter,
                                           @RequestParam("stageName") String stageName,
                                           @RequestParam(value = "stageCounter", required = false) String stageCounter,
                                           @RequestParam("buildName") String buildName,
                                           @RequestParam("filePath") String filePath,
                                           @RequestParam(value = "sha1", required = false) String sha,
                                           @RequestParam(value = "serverAlias", required = false) String serverAlias) throws Exception {
-        return getArtifact(filePath, folderViewFactory, pipelineName, counterOrLabel, stageName, stageCounter, buildName, sha, serverAlias);
+        return getArtifact(filePath, folderViewFactory, pipelineName, counter, stageName, stageCounter, buildName, sha, serverAlias);
     }
 
     @RequestMapping(value = "/repository/restful/artifact/GET/json", method = RequestMethod.GET)
     public ModelAndView getArtifactAsJson(@RequestParam("pipelineName") String pipelineName,
-                                          @RequestParam("pipelineLabel") String counterOrLabel,
+                                          @RequestParam("pipelineCounter") String counter,
                                           @RequestParam("stageName") String stageName,
                                           @RequestParam(value = "stageCounter", required = false) String stageCounter,
                                           @RequestParam("buildName") String buildName,
                                           @RequestParam("filePath") String filePath,
                                           @RequestParam(value = "sha1", required = false) String sha
     ) throws Exception {
-        return getArtifact(filePath, jsonViewFactory, pipelineName, counterOrLabel, stageName, stageCounter, buildName, sha, null);
+        return getArtifact(filePath, jsonViewFactory, pipelineName, counter, stageName, stageCounter, buildName, sha, null);
     }
 
     @RequestMapping(value = "/repository/restful/artifact/GET/zip", method = RequestMethod.GET)
     public ModelAndView getArtifactAsZip(@RequestParam("pipelineName") String pipelineName,
-                                         @RequestParam("pipelineLabel") String counterOrLabel,
+                                         @RequestParam("pipelineCounter") String counter,
                                          @RequestParam("stageName") String stageName,
                                          @RequestParam(value = "stageCounter", required = false) String stageCounter,
                                          @RequestParam("buildName") String buildName,
                                          @RequestParam("filePath") String filePath,
                                          @RequestParam(value = "sha1", required = false) String sha
     ) throws Exception {
-        return getArtifact(filePath, zipViewFactory, pipelineName, counterOrLabel, stageName, stageCounter, buildName, sha, null);
+        return getArtifact(filePath, zipViewFactory, pipelineName, counter, stageName, stageCounter, buildName, sha, null);
     }
 
     @RequestMapping(value = "/repository/restful/artifact/GET/*", method = RequestMethod.GET)
@@ -136,7 +136,7 @@ public class ArtifactsController {
 
     @RequestMapping(value = "/repository/restful/artifact/POST/*", method = RequestMethod.POST)
     public ModelAndView postArtifact(@RequestParam("pipelineName") String pipelineName,
-                                     @RequestParam("pipelineLabel") String counterOrLabel,
+                                     @RequestParam("pipelineCounter") String counter,
                                      @RequestParam("stageName") String stageName,
                                      @RequestParam(value = "stageCounter", required = false) String stageCounter,
                                      @RequestParam("buildName") String buildName,
@@ -149,10 +149,10 @@ public class ArtifactsController {
             return ResponseCodeView.create(HttpServletResponse.SC_BAD_REQUEST, "Missing required header 'Confirm'");
         }
         try {
-            jobIdentifier = restfulService.findJob(pipelineName, counterOrLabel, stageName, stageCounter,
+            jobIdentifier = restfulService.findJob(pipelineName, counter, stageName, stageCounter,
                     buildName, buildId);
         } catch (Exception e) {
-            return buildNotFound(pipelineName, counterOrLabel, stageName, stageCounter,
+            return buildNotFound(pipelineName, counter, stageName, stageCounter,
                     buildName);
         }
 
@@ -216,7 +216,7 @@ public class ArtifactsController {
 
     @RequestMapping(value = "/repository/restful/artifact/PUT/*", method = RequestMethod.PUT)
     public ModelAndView putArtifact(@RequestParam("pipelineName") String pipelineName,
-                                    @RequestParam("pipelineLabel") String counterOrLabel,
+                                    @RequestParam("pipelineCounter") String counter,
                                     @RequestParam("stageName") String stageName,
                                     @RequestParam(value = "stageCounter", required = false) String stageCounter,
                                     @RequestParam("buildName") String buildName,
@@ -231,13 +231,9 @@ public class ArtifactsController {
 
         JobIdentifier jobIdentifier;
         try {
-            if(buildId == null) {
-                jobIdentifier = restfulService.findJob(pipelineName, counterOrLabel, stageName, stageCounter, buildName, buildId);
-            } else {
-                jobIdentifier = restfulService.findJobForBuildId(pipelineName, Long.parseLong(counterOrLabel), stageName, stageCounter, buildName, buildId);
-            }
+            jobIdentifier = restfulService.findJob(pipelineName, counter, stageName, stageCounter, buildName, buildId);
         } catch (Exception e) {
-            return buildNotFound(pipelineName, counterOrLabel, stageName, stageCounter, buildName);
+            return buildNotFound(pipelineName, counter, stageName, stageCounter, buildName);
         }
 
         if (isConsoleOutput(filePath)) {
@@ -251,7 +247,7 @@ public class ArtifactsController {
 
     @RequestMapping(value = "/**/consoleout.json", method = RequestMethod.GET)
     public ModelAndView consoleout(@RequestParam("pipelineName") String pipelineName,
-                                   @RequestParam("pipelineLabel") String counterOrLabel,
+                                   @RequestParam("pipelineCounter") String counter,
                                    @RequestParam("stageName") String stageName,
                                    @RequestParam("buildName") String buildName,
                                    @RequestParam(value = "stageCounter", required = false) String stageCounter,
@@ -260,14 +256,14 @@ public class ArtifactsController {
         start = start == null ? 0L : start;
 
         try {
-            JobIdentifier identifier = restfulService.findJob(pipelineName, counterOrLabel, stageName, stageCounter, buildName);
+            JobIdentifier identifier = restfulService.findJob(pipelineName, counter, stageName, stageCounter, buildName);
             if (jobInstanceDao.isJobCompleted(identifier) && !consoleService.doesLogExist(identifier)) {
                 return logsNotFound(identifier);
             }
             ConsoleConsumer streamer = consoleService.getStreamer(start, identifier);
             return new ModelAndView(new ConsoleOutView(streamer, consoleLogCharset));
         } catch (Exception e) {
-            return buildNotFound(pipelineName, counterOrLabel, stageName, stageCounter, buildName);
+            return buildNotFound(pipelineName, counter, stageName, stageCounter, buildName);
         }
     }
 

--- a/server/src/main/java/com/thoughtworks/go/server/controller/JobController.java
+++ b/server/src/main/java/com/thoughtworks/go/server/controller/JobController.java
@@ -32,6 +32,7 @@ import com.thoughtworks.go.server.service.*;
 import com.thoughtworks.go.server.service.support.toggle.Toggles;
 import com.thoughtworks.go.server.util.ErrorHandler;
 import com.thoughtworks.go.util.SystemEnvironment;
+import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -110,7 +111,16 @@ public class JobController {
                                   @RequestParam("stageName") String stageName,
                                   @RequestParam("stageCounter") String stageCounter,
                                   @RequestParam("jobName") String jobName) throws Exception {
+        if (!StringUtils.isNumeric(pipelineCounter)) {
+            throw bomb(String.format("Expected numeric pipelineCounter, but received '%s' for [%s/%s/%s/%s/%s]", pipelineCounter, pipelineName, pipelineCounter, stageName,
+                    stageCounter, jobName));
 
+        }
+        if (!StringUtils.isNumeric(stageCounter)) {
+            throw bomb(String.format("Expected numeric stageCounter, but received '%s' for [%s/%s/%s/%s/%s]", stageCounter, pipelineName, pipelineCounter, stageName,
+                    stageCounter, jobName));
+
+        }
         Pipeline pipeline = pipelineService.findPipelineByNameAndCounter(pipelineName, Integer.parseInt(pipelineCounter));
         if (pipeline == null) {
             throw bomb(String.format("Job %s/%s/%s/%s/%s not found", pipelineName, pipelineCounter, stageName,

--- a/server/src/main/java/com/thoughtworks/go/server/controller/JobController.java
+++ b/server/src/main/java/com/thoughtworks/go/server/controller/JobController.java
@@ -106,14 +106,14 @@ public class JobController {
 
     @RequestMapping(value = "/tab/build/recent", method = RequestMethod.GET)
     public ModelAndView jobDetail(@RequestParam("pipelineName") String pipelineName,
-                                  @RequestParam("label") String counterOrLabel,
+                                  @RequestParam("pipelineCounter") String counter,
                                   @RequestParam("stageName") String stageName,
                                   @RequestParam("stageCounter") String stageCounter,
                                   @RequestParam("jobName") String jobName) throws Exception {
 
-        Pipeline pipeline = pipelineService.findPipelineByCounterOrLabel(pipelineName, counterOrLabel);
+        Pipeline pipeline = pipelineService.findPipelineByCounterOrLabel(pipelineName, counter);
         if (pipeline == null) {
-            throw bomb(String.format("Job %s/%s/%s/%s/%s not found", pipelineName, counterOrLabel, stageName,
+            throw bomb(String.format("Job %s/%s/%s/%s/%s not found", pipelineName, counter, stageName,
                     stageCounter, jobName));
         }
 

--- a/server/src/main/java/com/thoughtworks/go/server/controller/JobController.java
+++ b/server/src/main/java/com/thoughtworks/go/server/controller/JobController.java
@@ -106,14 +106,14 @@ public class JobController {
 
     @RequestMapping(value = "/tab/build/recent", method = RequestMethod.GET)
     public ModelAndView jobDetail(@RequestParam("pipelineName") String pipelineName,
-                                  @RequestParam("pipelineCounter") String counter,
+                                  @RequestParam("pipelineCounter") String pipelineCounter,
                                   @RequestParam("stageName") String stageName,
                                   @RequestParam("stageCounter") String stageCounter,
                                   @RequestParam("jobName") String jobName) throws Exception {
 
-        Pipeline pipeline = pipelineService.findPipelineByCounterOrLabel(pipelineName, counter);
+        Pipeline pipeline = pipelineService.findPipelineByCounterOrLabel(pipelineName, pipelineCounter);
         if (pipeline == null) {
-            throw bomb(String.format("Job %s/%s/%s/%s/%s not found", pipelineName, counter, stageName,
+            throw bomb(String.format("Job %s/%s/%s/%s/%s not found", pipelineName, pipelineCounter, stageName,
                     stageCounter, jobName));
         }
 

--- a/server/src/main/java/com/thoughtworks/go/server/controller/JobController.java
+++ b/server/src/main/java/com/thoughtworks/go/server/controller/JobController.java
@@ -111,7 +111,7 @@ public class JobController {
                                   @RequestParam("stageCounter") String stageCounter,
                                   @RequestParam("jobName") String jobName) throws Exception {
 
-        Pipeline pipeline = pipelineService.findPipelineByCounterOrLabel(pipelineName, pipelineCounter);
+        Pipeline pipeline = pipelineService.findPipelineByNameAndCounter(pipelineName, Integer.parseInt(pipelineCounter));
         if (pipeline == null) {
             throw bomb(String.format("Job %s/%s/%s/%s/%s not found", pipelineName, pipelineCounter, stageName,
                     stageCounter, jobName));

--- a/server/src/main/java/com/thoughtworks/go/server/controller/PropertiesController.java
+++ b/server/src/main/java/com/thoughtworks/go/server/controller/PropertiesController.java
@@ -64,7 +64,7 @@ public class PropertiesController {
 
     @RequestMapping(value = "/repository/restful/properties/post", method = RequestMethod.POST)
     public void setProperty(@RequestParam("pipelineName") String pipelineName,
-                            @RequestParam("pipelineLabel") String pipelineLabel,
+                            @RequestParam("pipelineCounter") String pipelineCounter,
                             @RequestParam("stageName") String stageName,
                             @RequestParam("stageCounter") String stageCounter,
                             @RequestParam("jobName") String buildName,
@@ -79,9 +79,9 @@ public class PropertiesController {
 
         JobIdentifier jobIdentifier;
         try {
-            jobIdentifier = restfulService.findJob(pipelineName, pipelineLabel, stageName, stageCounter, buildName);
+            jobIdentifier = restfulService.findJob(pipelineName, pipelineCounter, stageName, stageCounter, buildName);
         } catch (Exception e) {
-            BasicRestfulAction.jobNotFound(new JobIdentifier(pipelineName, -1, pipelineLabel, stageName, stageCounter,
+            BasicRestfulAction.jobNotFound(new JobIdentifier(pipelineName, -1, pipelineCounter, stageName, stageCounter,
                     buildName)).respond(response);
             return;
         }
@@ -129,7 +129,7 @@ public class PropertiesController {
     @RequestMapping("/repository/restful/properties/job/search")
     public ModelAndView jobSearch(
             @RequestParam("pipelineName") String pipelineName,
-            @RequestParam("pipelineLabel") String pipelineLabel,
+            @RequestParam("pipelineCounter") String pipelineCounter,
             @RequestParam("stageName") String stageName,
             @RequestParam("stageCounter") String stageCounter,
             @RequestParam("jobName") String buildName,
@@ -138,11 +138,11 @@ public class PropertiesController {
             HttpServletResponse response) throws Exception {
         JobIdentifier jobIdentifier;
         try {
-            jobIdentifier = restfulService.findJob(pipelineName, pipelineLabel, stageName,
+            jobIdentifier = restfulService.findJob(pipelineName, pipelineCounter, stageName,
                     stageCounter, buildName);
             return propertyService.listPropertiesForJob(jobIdentifier, type, propertyKey).respond(response);
         } catch (Exception e) {
-            return BasicRestfulAction.jobNotFound(new JobIdentifier(pipelineName, -1, pipelineLabel,
+            return BasicRestfulAction.jobNotFound(new JobIdentifier(pipelineName, -1, pipelineCounter,
                     stageName, stageCounter,
                     buildName)).respond(response);
         }

--- a/server/src/main/java/com/thoughtworks/go/server/controller/StageController.java
+++ b/server/src/main/java/com/thoughtworks/go/server/controller/StageController.java
@@ -63,7 +63,7 @@ public class StageController {
 
     @RequestMapping(value = "/admin/rerun", method = RequestMethod.POST)
     public ModelAndView rerunStage(@RequestParam(value = "pipelineName") String pipelineName,
-                                   @RequestParam(value = "pipelineLabel") String counterOrLabel,
+                                   @RequestParam(value = "pipelineCounter") String counter,
                                    @RequestParam(value = "stageName") String stageName,
                                    HttpServletResponse response, HttpServletRequest request) {
 
@@ -72,16 +72,16 @@ public class StageController {
         }
 
         try {
-            scheduleService.rerunStage(pipelineName, counterOrLabel, stageName);
+            scheduleService.rerunStage(pipelineName, counter, stageName);
             return ResponseCodeView.create(HttpServletResponse.SC_OK, "");
 
         } catch (GoUnauthorizedException e) {
             return ResponseCodeView.create(HttpServletResponse.SC_FORBIDDEN, "");
         } catch (StageNotFoundException e) {
-            LOGGER.error("Error while rerunning {}/{}/{}", pipelineName, counterOrLabel, stageName, e);
+            LOGGER.error("Error while rerunning {}/{}/{}", pipelineName, counter, stageName, e);
             return ResponseCodeView.create(HttpServletResponse.SC_NOT_FOUND, e.getMessage());
         } catch (Exception e) {
-            LOGGER.error("Error while rerunning {}/{}/{}", pipelineName, counterOrLabel, stageName, e);
+            LOGGER.error("Error while rerunning {}/{}/{}", pipelineName, counter, stageName, e);
             return ResponseCodeView.create(HttpServletResponse.SC_BAD_REQUEST, e.getMessage());
         }
     }

--- a/server/src/main/java/com/thoughtworks/go/server/controller/StageController.java
+++ b/server/src/main/java/com/thoughtworks/go/server/controller/StageController.java
@@ -63,7 +63,7 @@ public class StageController {
 
     @RequestMapping(value = "/admin/rerun", method = RequestMethod.POST)
     public ModelAndView rerunStage(@RequestParam(value = "pipelineName") String pipelineName,
-                                   @RequestParam(value = "pipelineCounter") String counter,
+                                   @RequestParam(value = "pipelineCounter") String pipelineCounter,
                                    @RequestParam(value = "stageName") String stageName,
                                    HttpServletResponse response, HttpServletRequest request) {
 
@@ -72,16 +72,16 @@ public class StageController {
         }
 
         try {
-            scheduleService.rerunStage(pipelineName, counter, stageName);
+            scheduleService.rerunStage(pipelineName, pipelineCounter, stageName);
             return ResponseCodeView.create(HttpServletResponse.SC_OK, "");
 
         } catch (GoUnauthorizedException e) {
             return ResponseCodeView.create(HttpServletResponse.SC_FORBIDDEN, "");
         } catch (StageNotFoundException e) {
-            LOGGER.error("Error while rerunning {}/{}/{}", pipelineName, counter, stageName, e);
+            LOGGER.error("Error while rerunning {}/{}/{}", pipelineName, pipelineCounter, stageName, e);
             return ResponseCodeView.create(HttpServletResponse.SC_NOT_FOUND, e.getMessage());
         } catch (Exception e) {
-            LOGGER.error("Error while rerunning {}/{}/{}", pipelineName, counter, stageName, e);
+            LOGGER.error("Error while rerunning {}/{}/{}", pipelineName, pipelineCounter, stageName, e);
             return ResponseCodeView.create(HttpServletResponse.SC_BAD_REQUEST, e.getMessage());
         }
     }

--- a/server/src/main/java/com/thoughtworks/go/server/dao/JobInstanceSqlMapDao.java
+++ b/server/src/main/java/com/thoughtworks/go/server/dao/JobInstanceSqlMapDao.java
@@ -281,7 +281,6 @@ public class JobInstanceSqlMapDao extends SqlMapClientDaoSupport implements JobI
                 if (jobIdentifier == null) {
                     Map params = arguments("pipelineName", stageIdentifier.getPipelineName()).
                             and("pipelineCounter", stageIdentifier.getPipelineCounter()).
-                            and("pipelineLabel", stageIdentifier.getPipelineLabel()).
                             and("stageName", stageIdentifier.getStageName()).
                             and("stageCounter", Integer.parseInt(stageIdentifier.getStageCounter())).
                             and("jobName", jobName).asMap();

--- a/server/src/main/java/com/thoughtworks/go/server/dao/PipelineDao.java
+++ b/server/src/main/java/com/thoughtworks/go/server/dao/PipelineDao.java
@@ -68,8 +68,6 @@ public interface PipelineDao {
 
     PipelineInstanceModels loadActivePipelines();
 
-    Pipeline findPipelineByCounterOrLabel(String pipelineName, String counterOrLabel);
-
     PipelineDependencyGraphOld pipelineGraphByNameAndCounter(String pipelineName, int pipelineCounter);
 
     Pipeline findEarlierPipelineThatPassedForStage(String pipelineName, String stageName, double naturalOrder);

--- a/server/src/main/java/com/thoughtworks/go/server/dao/PipelineDao.java
+++ b/server/src/main/java/com/thoughtworks/go/server/dao/PipelineDao.java
@@ -50,7 +50,7 @@ public interface PipelineDao {
     // Please call pipelineService.save(aPipeline) instead
     Pipeline saveWithStages(Pipeline pipeline);
 
-    String mostRecentLabel(String pipelineName);
+    PipelineIdentifier mostRecentPipelineIdentifier(String pipelineName);
 
     Integer getCounterForPipeline(String name);
 

--- a/server/src/main/java/com/thoughtworks/go/server/dao/PipelineSqlMapDao.java
+++ b/server/src/main/java/com/thoughtworks/go/server/dao/PipelineSqlMapDao.java
@@ -318,6 +318,10 @@ public class PipelineSqlMapDao extends SqlMapClientDaoSupport implements Initial
         });
     }
 
+    public PipelineIdentifier mostRecentPipelineIdentifier(String pipelineName) {
+        return (PipelineIdentifier) getSqlMapClientTemplate().queryForObject("mostRecentPipelineIdentifier", pipelineName);
+    }
+
     public Pipeline pipelineByIdWithMods(long pipelineId) {
         Pipeline pipeline = (Pipeline) getSqlMapClientTemplate().queryForObject("pipelineById", pipelineId);
         if (pipeline == null) {

--- a/server/src/main/java/com/thoughtworks/go/server/dao/PipelineSqlMapDao.java
+++ b/server/src/main/java/com/thoughtworks/go/server/dao/PipelineSqlMapDao.java
@@ -300,10 +300,6 @@ public class PipelineSqlMapDao extends SqlMapClientDaoSupport implements Initial
         insertOrUpdatePipelineCounter(pipeline, lastCount, pipeline.getCounter());
     }
 
-    public String mostRecentLabel(String pipelineName) {
-        return (String) getSqlMapClientTemplate().queryForObject("mostRecentLabel", pipelineName);
-    }
-
     public Pipeline pipelineWithMaterialsAndModsByBuildId(long buildId) {
         String cacheKey = this.cacheKeyGenerator.generate("getPipelineByBuildId", buildId);
         return pipelineByBuildIdCache.get(cacheKey, new Supplier<Pipeline>() {
@@ -791,14 +787,6 @@ public class PipelineSqlMapDao extends SqlMapClientDaoSupport implements Initial
             }
         }
         return latestModification != null ? latestModification.getRevision() : null;
-    }
-
-    private String translatePipelineLabel(String pipelineName, String pipelineLabel) {
-        String label = pipelineLabel;
-        if (pipelineLabel.equalsIgnoreCase(JobIdentifier.LATEST)) {
-            label = mostRecentLabel(pipelineName);
-        }
-        return label;
     }
 
     public void pause(String pipelineName, String pauseCause, String pauseBy) {

--- a/server/src/main/java/com/thoughtworks/go/server/dao/PipelineSqlMapDao.java
+++ b/server/src/main/java/com/thoughtworks/go/server/dao/PipelineSqlMapDao.java
@@ -793,22 +793,6 @@ public class PipelineSqlMapDao extends SqlMapClientDaoSupport implements Initial
         return latestModification != null ? latestModification.getRevision() : null;
     }
 
-    public Pipeline findPipelineByCounterOrLabel(String pipelineName, String counterOrLabel) {
-        Pipeline pipeline = null;
-        try {
-            int pipelineCounter = Integer.parseInt(counterOrLabel);
-            pipeline = findPipelineByNameAndCounter(pipelineName, pipelineCounter);
-        } catch (NumberFormatException e) {
-            //it maybe a label
-        }
-
-        if (pipeline == null) {
-            String pipelineLabel = translatePipelineLabel(pipelineName, counterOrLabel);
-            pipeline = findPipelineByNameAndLabel(pipelineName, pipelineLabel);
-        }
-        return pipeline;
-    }
-
     private String translatePipelineLabel(String pipelineName, String pipelineLabel) {
         String label = pipelineLabel;
         if (pipelineLabel.equalsIgnoreCase(JobIdentifier.LATEST)) {

--- a/server/src/main/java/com/thoughtworks/go/server/dao/StageSqlMapDao.java
+++ b/server/src/main/java/com/thoughtworks/go/server/dao/StageSqlMapDao.java
@@ -181,7 +181,7 @@ public class StageSqlMapDao extends SqlMapClientDaoSupport implements StageDao, 
 
     public int findLatestStageCounter(PipelineIdentifier pipeline, String stageName) {
         Map<String, Object> toGet = arguments("pipelineName", pipeline.getName()).and("pipelineCounter",
-                pipeline.getCounter()).and("pipelineLabel", pipeline.getLabel()).and(
+                pipeline.getCounter()).and(
                 "stageName", stageName).asMap();
         Integer maxCounter = (Integer) getSqlMapClientTemplate().queryForObject(
                 "findMaxStageCounter", toGet);

--- a/server/src/main/java/com/thoughtworks/go/server/service/PipelineService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/PipelineService.java
@@ -124,6 +124,10 @@ public class PipelineService implements UpstreamPipelineResolver {
         return pipelineDao.findPipelineByCounterOrLabel(pipelineName, counterOrLabel);
     }
 
+    public Pipeline findPipelineByNameAndCounter(String pipelineName, int pipelineCounter) {
+        return pipelineDao.findPipelineByNameAndCounter(pipelineName, pipelineCounter);
+    }
+
     public Pipeline fullPipelineByCounterOrLabel(String pipelineName, String counterOrLabel) {
         Pipeline pipeline = findPipelineByCounterOrLabel(pipelineName, counterOrLabel);
         pipelineDao.loadAssociations(pipeline, pipelineName);

--- a/server/src/main/java/com/thoughtworks/go/server/service/PipelineService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/PipelineService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 ThoughtWorks, Inc.
+ * Copyright 2018 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -298,5 +298,9 @@ public class PipelineService implements UpstreamPipelineResolver {
 
     public PipelineTimeline getPipelineTimeline() {
         return pipelineTimeline;
+    }
+
+    public PipelineIdentifier mostRecentPipelineIdentifier(String pipelineName) {
+        return pipelineDao.mostRecentPipelineIdentifier(pipelineName);
     }
 }

--- a/server/src/main/java/com/thoughtworks/go/server/service/PipelineService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/PipelineService.java
@@ -119,7 +119,7 @@ public class PipelineService implements UpstreamPipelineResolver {
         pipeline.setStages(new Stages(stageForBuild));
         return pipeline;
     }
-    
+
     public Pipeline findPipelineByNameAndCounter(String pipelineName, int pipelineCounter) {
         return pipelineDao.findPipelineByNameAndCounter(pipelineName, pipelineCounter);
     }

--- a/server/src/main/java/com/thoughtworks/go/server/service/PipelineService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/PipelineService.java
@@ -119,11 +119,7 @@ public class PipelineService implements UpstreamPipelineResolver {
         pipeline.setStages(new Stages(stageForBuild));
         return pipeline;
     }
-
-    public Pipeline findPipelineByCounterOrLabel(String pipelineName, String counterOrLabel) {
-        return pipelineDao.findPipelineByCounterOrLabel(pipelineName, counterOrLabel);
-    }
-
+    
     public Pipeline findPipelineByNameAndCounter(String pipelineName, int pipelineCounter) {
         return pipelineDao.findPipelineByNameAndCounter(pipelineName, pipelineCounter);
     }

--- a/server/src/main/java/com/thoughtworks/go/server/service/PipelineService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/PipelineService.java
@@ -128,8 +128,8 @@ public class PipelineService implements UpstreamPipelineResolver {
         return pipelineDao.findPipelineByNameAndCounter(pipelineName, pipelineCounter);
     }
 
-    public Pipeline fullPipelineByCounterOrLabel(String pipelineName, String counterOrLabel) {
-        Pipeline pipeline = findPipelineByCounterOrLabel(pipelineName, counterOrLabel);
+    public Pipeline fullPipelineByCounter(String pipelineName, Integer pipelineCounter) {
+        Pipeline pipeline = findPipelineByNameAndCounter(pipelineName, pipelineCounter);
         pipelineDao.loadAssociations(pipeline, pipelineName);
         return pipeline;
     }

--- a/server/src/main/java/com/thoughtworks/go/server/service/RestfulService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/RestfulService.java
@@ -38,13 +38,13 @@ public class RestfulService {
      * buildId should only be given when caller is absolutely sure about the job instance
      * (makes sense in agent-uploading artifacts/properties scenario because agent won't run a job if its copied over(it only executes real jobs)) -JJ
      */
-    public JobIdentifier findJob(String pipelineName, String counterOrLabel, String stageName, String stageCounter, String buildName, Long buildId) {
+    public JobIdentifier findJob(String pipelineName, String counter, String stageName, String stageCounter, String buildName, Long buildId) {
         JobConfigIdentifier jobConfig = goConfigService.translateToActualCase(new JobConfigIdentifier(pipelineName, stageName, buildName));
 
-        Pipeline pipeline = pipelineService.findPipelineByCounterOrLabel(jobConfig.getPipelineName(), counterOrLabel);
+        PipelineIdentifier pipelineIdentifier = new PipelineIdentifier(jobConfig.getPipelineName(), Long.parseLong(counter));
 
         stageCounter = StringUtils.isEmpty(stageCounter) ? JobIdentifier.LATEST : stageCounter;
-        StageIdentifier stageIdentifier = translateStageCounter(pipeline.getIdentifier(), jobConfig.getStageName(), stageCounter);
+        StageIdentifier stageIdentifier = translateStageCounter(pipelineIdentifier, jobConfig.getStageName(), stageCounter);
 
         JobIdentifier jobId;
         if (buildId == null) {
@@ -70,13 +70,5 @@ public class RestfulService {
         } else {
             return new StageIdentifier(pipelineIdentifier, stageName, stageCounter);
         }
-    }
-
-    public JobIdentifier findJobForBuildId(String pipelineName, Long counter, String stageName, String stageCounter, String buildName, Long buildId) {
-        JobConfigIdentifier jobConfigIdentifier = goConfigService.translateToActualCase(new JobConfigIdentifier(pipelineName, stageName, buildName));
-
-        PipelineIdentifier pipelineIdentifier = new PipelineIdentifier(jobConfigIdentifier.getPipelineName(), counter);
-        StageIdentifier stageIdentifier = new StageIdentifier(pipelineIdentifier, jobConfigIdentifier.getStageName(), stageCounter);
-        return new JobIdentifier(stageIdentifier, jobConfigIdentifier.getJobName(), buildId);
     }
 }

--- a/server/src/main/java/com/thoughtworks/go/server/service/RestfulService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/RestfulService.java
@@ -59,8 +59,8 @@ public class RestfulService {
         return jobId;
     }
 
-    public JobIdentifier findJob(String pipelineName, String counterOrLabel, String stageName, String stageCounter, String buildName) {
-        return findJob(pipelineName, counterOrLabel, stageName, stageCounter, buildName, null);
+    public JobIdentifier findJob(String pipelineName, String counter, String stageName, String stageCounter, String buildName) {
+        return findJob(pipelineName, counter, stageName, stageCounter, buildName, null);
     }
 
     public StageIdentifier translateStageCounter(PipelineIdentifier pipelineIdentifier, String stageName, String stageCounter) {

--- a/server/src/main/java/com/thoughtworks/go/server/service/RestfulService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/RestfulService.java
@@ -71,4 +71,12 @@ public class RestfulService {
             return new StageIdentifier(pipelineIdentifier, stageName, stageCounter);
         }
     }
+
+    public JobIdentifier findJobForBuildId(String pipelineName, Long counter, String stageName, String stageCounter, String buildName, Long buildId) {
+        JobConfigIdentifier jobConfigIdentifier = goConfigService.translateToActualCase(new JobConfigIdentifier(pipelineName, stageName, buildName));
+
+        PipelineIdentifier pipelineIdentifier = new PipelineIdentifier(jobConfigIdentifier.getPipelineName(), counter);
+        StageIdentifier stageIdentifier = new StageIdentifier(pipelineIdentifier, jobConfigIdentifier.getStageName(), stageCounter);
+        return new JobIdentifier(stageIdentifier, jobConfigIdentifier.getJobName(), buildId);
+    }
 }

--- a/server/src/main/java/com/thoughtworks/go/server/service/ScheduleService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/ScheduleService.java
@@ -251,11 +251,11 @@ public class ScheduleService {
         return schedulingChecker.canAutoTriggerConsumer(pipelineConfig);
     }
 
-    public Stage rerunStage(String pipelineName, String counterOrLabel, String stageName) {
-        return lockAndRerunStage(pipelineName, counterOrLabel, stageName, new NewStageInstanceCreator(goConfigService), new ExceptioningErrorHandler());
+    public Stage rerunStage(String pipelineName, String counter, String stageName) throws Exception {
+        return lockAndRerunStage(pipelineName, counter, stageName, new NewStageInstanceCreator(goConfigService), new ExceptioningErrorHandler());
     }
 
-    private Stage lockAndRerunStage(String pipelineName, String counterOrLabel, String stageName, StageInstanceCreator creator, final ErrorConditionHandler errorHandler) {
+    private Stage lockAndRerunStage(String pipelineName, String counter, String stageName, StageInstanceCreator creator, final ErrorConditionHandler errorHandler) {
         synchronized (mutexForPipeline(pipelineName)) {
             OperationResult result = new ServerHealthStateOperationResult();
             if (!schedulingChecker.canSchedule(result)) {
@@ -266,9 +266,9 @@ public class ScheduleService {
             if (!securityService.hasOperatePermissionForStage(pipelineName, stageName, username)) {
                 errorHandler.noOperatePermission(pipelineName, stageName);
             }
-            Pipeline pipeline = pipelineService.fullPipelineByCounterOrLabel(pipelineName, counterOrLabel);
+            Pipeline pipeline = pipelineService.fullPipelineByCounterOrLabel(pipelineName, counter);
             if (pipeline == null) {
-                errorHandler.nullPipeline(pipelineName, counterOrLabel, stageName);
+                errorHandler.nullPipeline(pipelineName, counter, stageName);
             }
             if (!pipeline.hasStageBeenRun(stageName)) {
                 if (goConfigService.hasPreviousStage(pipelineName, stageName)) {

--- a/server/src/main/java/com/thoughtworks/go/server/service/StageService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/StageService.java
@@ -425,20 +425,6 @@ public class StageService implements StageRunFinder, StageFinder {
         return stageDao.findDetailedStageHistoryByOffset(pipelineName, stageName, pagination);
     }
 
-    public Long findStageIdByLocator(String locator) {
-        String[] parts = locator.split("/");
-        String pipelineName = parts[0];
-        String counterOrLabel = parts[1];
-        if (counterOrLabel.matches(".+\\[.+\\]")) {
-            counterOrLabel = counterOrLabel.substring(0, counterOrLabel.indexOf("["));
-        }
-        String stageName = parts[2];
-        String stageCounter = parts[3];
-
-        Pipeline pipeline = pipelineDao.findPipelineByCounterOrLabel(pipelineName, counterOrLabel);
-        return stageDao.findStageIdByPipelineAndStageNameAndCounter(pipeline.getId(), stageName, stageCounter);
-    }
-
     /**
      * @return Listeners
      * @deprecated Used only in tests

--- a/server/src/main/java/com/thoughtworks/go/server/service/ValueStreamMapService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/ValueStreamMapService.java
@@ -97,7 +97,7 @@ public class ValueStreamMapService {
             result.notFound("Pipeline '" + pipelineName + "' with counter '" + counter + "' not found.", HealthStateType.general(HealthStateScope.forPipeline(pipelineName.toString())));
             return null;
         }
-        String label = pipelineService.findPipelineByCounterOrLabel(pipelineName.toString(), String.valueOf(counter)).getLabel();
+        String label = pipelineService.findPipelineByNameAndCounter(pipelineName.toString(), counter).getLabel();
         ValueStreamMap valueStreamMap = new ValueStreamMap(pipelineName, new PipelineRevision(pipelineName.toString(), counter, label));
         Map<CaseInsensitiveString, List<PipelineConfig>> pipelineToDownstreamMap = cruiseConfig.generatePipelineVsDownstreamMap();
 

--- a/server/src/main/resources/com/thoughtworks/go/server/dao/maps/JobInstance.xml
+++ b/server/src/main/resources/com/thoughtworks/go/server/dao/maps/JobInstance.xml
@@ -105,12 +105,9 @@
 
     <sql id="select-job-id">
         FROM _builds
-        WHERE name = #{jobName} AND ignored != true
-            AND stageName = #{stageName} AND stageCounter = #{stageCounter}
-            AND pipelineName = #{pipelineName} AND pipelineLabel = #{pipelineLabel}
-            <if test="pipelineCounter != null">AND
-                pipelineCounter = #{pipelineCounter}
-            </if>
+        WHERE name = #jobName# AND ignored != true
+            AND stageName = #stageName# AND stageCounter = #stageCounter#
+            AND pipelineName = #pipelineName# AND pipelineCounter = #pipelineCounter#
     </sql>
 
     <select id="findJobId" resultMap="jobIdentifier">

--- a/server/src/main/resources/com/thoughtworks/go/server/dao/maps/Pipeline.xml
+++ b/server/src/main/resources/com/thoughtworks/go/server/dao/maps/Pipeline.xml
@@ -167,11 +167,6 @@
         LIMIT 1
     </select>
 
-
-    <select id="mostRecentLabel" parameterType="java.lang.String" resultType="string">
-        SELECT label  FROM pipelines WHERE name = #{name} ORDER BY id DESC LIMIT 1
-    </select>
-
     <select id="hasPipelineInfoRow" parameterType="java.lang.String" resultType="java.lang.Integer">
         SELECT COUNT(*)
         FROM pipelineLabelCounts

--- a/server/src/main/resources/com/thoughtworks/go/server/dao/maps/Pipeline.xml
+++ b/server/src/main/resources/com/thoughtworks/go/server/dao/maps/Pipeline.xml
@@ -178,6 +178,12 @@
         WHERE caseInsensitivePipelineName = #{value}
     </select>
 
+    <select id="mostRecentPipelineIdentifier" resultMap="select-pipeline-identifier">
+        SELECT pipelines.name as pipelineName, pipelines.label as label, pipelines.counter as pipelineCounter
+        FROM pipelines
+        WHERE pipelines.name = #pipelineName# ORDER BY id DESC LIMIT 1
+    </select>
+
     <select id="getCounterForPipeline" parameterType="java.lang.String" resultType="java.lang.Integer">
         SELECT labelCount
         FROM pipelineLabelCounts

--- a/server/src/main/resources/com/thoughtworks/go/server/dao/maps/Stage.xml
+++ b/server/src/main/resources/com/thoughtworks/go/server/dao/maps/Stage.xml
@@ -556,11 +556,8 @@
     <select id="findMaxStageCounter" resultType="java.lang.Integer">
         SELECT Max(stages.counter) FROM stages
         JOIN pipelines ON pipelines.id = stages.pipelineId
-        AND pipelines.name= #{pipelineName} AND pipelines.label = #{pipelineLabel}
-        <if test="pipelineCounter != null">AND
-            pipelines.counter = #{pipelineCounter}
-        </if>
-        WHERE stages.name= #{stageName}
+        AND pipelines.name= #pipelineName# AND pipelines.counter = #pipelineCounter#
+        WHERE stages.name= #stageName#
     </select>
 
     <select id="getStageOrderInPipeline" resultType="java.lang.Integer">

--- a/server/src/test-fast/java/com/thoughtworks/go/server/controller/JobControllerTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/controller/JobControllerTest.java
@@ -16,12 +16,17 @@
 
 package com.thoughtworks.go.server.controller;
 
-import com.thoughtworks.go.domain.*;
+import com.thoughtworks.go.domain.JobInstance;
+import com.thoughtworks.go.domain.JobResult;
+import com.thoughtworks.go.domain.JobState;
 import com.thoughtworks.go.dto.DurationBean;
 import com.thoughtworks.go.helper.JobInstanceMother;
 import com.thoughtworks.go.server.dao.JobInstanceDao;
 import com.thoughtworks.go.server.domain.Agent;
-import com.thoughtworks.go.server.service.*;
+import com.thoughtworks.go.server.service.AgentService;
+import com.thoughtworks.go.server.service.GoConfigService;
+import com.thoughtworks.go.server.service.JobInstanceService;
+import com.thoughtworks.go.server.service.StageService;
 import com.thoughtworks.go.util.JsonValue;
 import com.thoughtworks.go.util.SystemEnvironment;
 import org.junit.Before;
@@ -35,6 +40,7 @@ import java.util.List;
 import static com.thoughtworks.go.util.JsonUtils.from;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.fail;
 import static org.mockito.Mockito.*;
 
 public class JobControllerTest {
@@ -92,5 +98,25 @@ public class JobControllerTest {
 
         assertThat(buildingInfo.getString("id"), is("2"));
         assertThat(buildingInfo.getString("last_build_duration"), is("5"));
+    }
+
+    @Test
+    public void shouldThrowErrorIfUserPassesANonNumericValueForPipelineCounter() throws Exception {
+        try {
+            jobController.jobDetail("p1", "some-string", "s1", "1", "job");
+            fail("Expected an exception to be thrown");
+        } catch (Exception e) {
+            assertThat(e.getMessage(), is("Expected numeric pipelineCounter, but received 'some-string' for [p1/some-string/s1/1/job]"));
+        }
+    }
+
+    @Test
+    public void shouldThrowErrorIfUserPassesANonNumericValueForStageCounter() throws Exception {
+        try {
+            jobController.jobDetail("p1", "1", "s1", "some-string", "job");
+            fail("Expected an exception to be thrown");
+        } catch (Exception e) {
+            assertThat(e.getMessage(), is("Expected numeric stageCounter, but received 'some-string' for [p1/1/s1/some-string/job]"));
+        }
     }
 }

--- a/server/src/test-fast/java/com/thoughtworks/go/server/service/JobRerunScheduleServiceTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/service/JobRerunScheduleServiceTest.java
@@ -330,7 +330,7 @@ public class JobRerunScheduleServiceTest {
 
         when(securityService.hasOperatePermissionForStage(eq("mingle"), eq(lastStage.getName()), any(String.class))).thenReturn(true);
 
-        when(pipelineService.fullPipelineByCounterOrLabel("mingle", String.valueOf(identifier.getPipelineCounter()))).thenReturn(pipeline);
+        when(pipelineService.fullPipelineByCounter("mingle", identifier.getPipelineCounter())).thenReturn(pipeline);
     }
 
 }

--- a/server/src/test-fast/java/com/thoughtworks/go/server/service/ValueStreamMapServiceTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/service/ValueStreamMapServiceTest.java
@@ -128,7 +128,7 @@ public class ValueStreamMapServiceTest {
 
         when(pipelineService.buildCauseFor(pipelineName, counter)).thenReturn(buildCause);
         when(goConfigService.currentCruiseConfig()).thenReturn(new BasicCruiseConfig(new BasicPipelineConfigs(p1Config)));
-        when(pipelineService.findPipelineByCounterOrLabel(pipelineName, "1")).thenReturn(new Pipeline("MYPIPELINE", "p1-label", buildCause));
+        when(pipelineService.findPipelineByNameAndCounter(pipelineName, 1)).thenReturn(new Pipeline("MYPIPELINE", "p1-label", buildCause));
 
         ValueStreamMapPresentationModel graph = valueStreamMapService.getValueStreamMap(new CaseInsensitiveString("MYPIPELINE"), counter, user, result);
 
@@ -170,7 +170,7 @@ public class ValueStreamMapServiceTest {
 
         when(pipelineService.buildCauseFor(pipelineName, counter)).thenReturn(buildCause);
         when(goConfigService.currentCruiseConfig()).thenReturn(cruiseConfig);
-        when(pipelineService.findPipelineByCounterOrLabel(pipelineName, "1")).thenReturn(new Pipeline(uppercasePipelineName, "p1-label", buildCause));
+        when(pipelineService.findPipelineByNameAndCounter(pipelineName, 1)).thenReturn(new Pipeline(uppercasePipelineName, "p1-label", buildCause));
         MaterialConfig materialConfig = cruiseConfig.getAllUniqueMaterials().iterator().next();
         ValueStreamMapPresentationModel graph = valueStreamMapService.getValueStreamMap(new CaseInsensitiveString(pipelineName.toLowerCase()), 1, user, result);
 
@@ -210,7 +210,7 @@ public class ValueStreamMapServiceTest {
 
         when(pipelineService.buildCauseFor(pipelineName, counter)).thenReturn(buildCause);
         when(goConfigService.currentCruiseConfig()).thenReturn(cruiseConfig);
-        when(pipelineService.findPipelineByCounterOrLabel(pipelineName, "1")).thenReturn(new Pipeline(uppercasePipelineName, "p1-label", buildCause));
+        when(pipelineService.findPipelineByNameAndCounter(pipelineName, 1)).thenReturn(new Pipeline(uppercasePipelineName, "p1-label", buildCause));
         MaterialConfig materialConfig = cruiseConfig.getAllUniqueMaterials().iterator().next();
         MaterialRevision materialRevision = buildCause.getMaterialRevisions().findRevisionFor(materialConfig);
         Material material = materialRevision.getMaterial();
@@ -258,7 +258,7 @@ public class ValueStreamMapServiceTest {
         when(pipelineService.buildCauseFor(pipeline, counter)).thenReturn(buildCause);
         PipelineConfig p1Config = PipelineConfigMother.pipelineConfig(pipeline, new MaterialConfigs(material));
         when(goConfigService.currentCruiseConfig()).thenReturn(new BasicCruiseConfig(new BasicPipelineConfigs(p1Config)));
-        when(pipelineService.findPipelineByCounterOrLabel(pipeline, "1")).thenReturn(new Pipeline(pipeline, "p1-label", buildCause));
+        when(pipelineService.findPipelineByNameAndCounter(pipeline, 1)).thenReturn(new Pipeline(pipeline, "p1-label", buildCause));
 
         ValueStreamMapPresentationModel graph = valueStreamMapService.getValueStreamMap(new CaseInsensitiveString(pipeline), counter, user, result);
         List<List<Node>> nodesAtEachLevel = graph.getNodesAtEachLevel();
@@ -302,7 +302,7 @@ public class ValueStreamMapServiceTest {
         CruiseConfig cruiseConfig = new BasicCruiseConfig(new BasicPipelineConfigs(p1Config, p2Config, p3Config));
 
         when(goConfigService.currentCruiseConfig()).thenReturn(cruiseConfig);
-        when(pipelineService.findPipelineByCounterOrLabel("p3", "1")).thenReturn(new Pipeline("p3", "p3-label", p3buildCause));
+        when(pipelineService.findPipelineByNameAndCounter("p3", 1)).thenReturn(new Pipeline("p3", "p3-label", p3buildCause));
 
         ValueStreamMapPresentationModel graph = valueStreamMapService.getValueStreamMap(new CaseInsensitiveString("p3"), 1, user, result);
         List<List<Node>> nodesAtEachLevel = graph.getNodesAtEachLevel();
@@ -414,7 +414,7 @@ public class ValueStreamMapServiceTest {
                 new MaterialConfigs(new DependencyMaterialConfig(p1Config.name(), p1Config.getFirstStageConfig().name()), new DependencyMaterialConfig(p2Config.name(), p2Config.getFirstStageConfig().name())));
         CruiseConfig cruiseConfig = new BasicCruiseConfig(new BasicPipelineConfigs(p1Config, p2Config, p3Config));
         when(goConfigService.currentCruiseConfig()).thenReturn(cruiseConfig);
-        when(pipelineService.findPipelineByCounterOrLabel("p3", "1")).thenReturn(new Pipeline("p3", "p3-label", p3buildCause));
+        when(pipelineService.findPipelineByNameAndCounter("p3", 1)).thenReturn(new Pipeline("p3", "p3-label", p3buildCause));
 
         ValueStreamMapPresentationModel graph = valueStreamMapService.getValueStreamMap(new CaseInsensitiveString(p3), 1, user, result);
         List<List<Node>> nodesAtEachLevel = graph.getNodesAtEachLevel();
@@ -462,7 +462,7 @@ public class ValueStreamMapServiceTest {
         BuildCause p1buildCause = createBuildCause(new ArrayList<>(), asList(git));
 
         when(pipelineService.buildCauseFor(currentPipeline, 1)).thenReturn(p1buildCause);
-        when(pipelineService.findPipelineByCounterOrLabel(currentPipeline, "1")).thenReturn(new Pipeline(currentPipeline, "p1-label", p1buildCause));
+        when(pipelineService.findPipelineByNameAndCounter(currentPipeline, 1)).thenReturn(new Pipeline(currentPipeline, "p1-label", p1buildCause));
 
         ValueStreamMapPresentationModel graph = valueStreamMapService.getValueStreamMap(new CaseInsensitiveString(currentPipeline), 1, user, result);
         List<List<Node>> nodesAtEachLevel = graph.getNodesAtEachLevel();
@@ -508,7 +508,7 @@ public class ValueStreamMapServiceTest {
         when(pipelineService.buildCauseFor(p1, 1)).thenReturn(p1buildCause);
         when(pipelineService.buildCauseFor(p2, 1)).thenReturn(p2buildCause);
         when(goConfigService.currentCruiseConfig()).thenReturn(cruiseConfig);
-        when(pipelineService.findPipelineByCounterOrLabel(p2, "1")).thenReturn(new Pipeline(p2, "label-p2", p2buildCause));
+        when(pipelineService.findPipelineByNameAndCounter(p2, 1)).thenReturn(new Pipeline(p2, "label-p2", p2buildCause));
 
         ValueStreamMapPresentationModel graph = valueStreamMapService.getValueStreamMap(new CaseInsensitiveString(p2), 1, user, result);
         List<List<Node>> nodesAtEachLevel = graph.getNodesAtEachLevel();
@@ -569,7 +569,7 @@ public class ValueStreamMapServiceTest {
         CruiseConfig cruiseConfig = new BasicCruiseConfig(new BasicPipelineConfigs(p1Config, p2Config, p3Config));
 
         when(goConfigService.currentCruiseConfig()).thenReturn(cruiseConfig);
-        when(pipelineService.findPipelineByCounterOrLabel(p2.toString(), "1")).thenReturn(new Pipeline(p2.toString(), "p2-label", p2buildCause));
+        when(pipelineService.findPipelineByNameAndCounter(p2.toString(), 1)).thenReturn(new Pipeline(p2.toString(), "p2-label", p2buildCause));
 
         ValueStreamMapPresentationModel graph = valueStreamMapService.getValueStreamMap(p2, 1, user, result);
         List<List<Node>> nodesAtEachLevel = graph.getNodesAtEachLevel();
@@ -607,7 +607,7 @@ public class ValueStreamMapServiceTest {
         PipelineConfig p3Config = PipelineConfigMother.pipelineConfig("p3",
                 new MaterialConfigs(new DependencyMaterialConfig(p1Config.name(), p1Config.getFirstStageConfig().name()), new DependencyMaterialConfig(p2Config.name(), p2Config.getFirstStageConfig().name())));
         CruiseConfig cruiseConfig = new BasicCruiseConfig(new BasicPipelineConfigs(p1Config, p2Config, p3Config));
-        when(pipelineService.findPipelineByCounterOrLabel("p3", "1")).thenReturn(new Pipeline("p3", "LABEL-P3", p3buildCause));
+        when(pipelineService.findPipelineByNameAndCounter("p3", 1)).thenReturn(new Pipeline("p3", "LABEL-P3", p3buildCause));
 
         when(goConfigService.currentCruiseConfig()).thenReturn(cruiseConfig);
 
@@ -643,7 +643,7 @@ public class ValueStreamMapServiceTest {
 
         CruiseConfig cruiseConfig = new BasicCruiseConfig(new BasicPipelineConfigs(p1Config, p2Config));
 
-        when(pipelineService.findPipelineByCounterOrLabel("p2", "1")).thenReturn(new Pipeline("p2", "LABEL-P2", p2buildCause));
+        when(pipelineService.findPipelineByNameAndCounter("p2", 1)).thenReturn(new Pipeline("p2", "LABEL-P2", p2buildCause));
 
         when(goConfigService.currentCruiseConfig()).thenReturn(cruiseConfig);
 
@@ -682,7 +682,7 @@ public class ValueStreamMapServiceTest {
 
         CruiseConfig cruiseConfig = new BasicCruiseConfig(new BasicPipelineConfigs(p1Config, p2Config));
 
-        when(pipelineService.findPipelineByCounterOrLabel("p2", "1")).thenReturn(new Pipeline("p2", "LABEL-P2", p2buildCause));
+        when(pipelineService.findPipelineByNameAndCounter("p2", 1)).thenReturn(new Pipeline("p2", "LABEL-P2", p2buildCause));
 
         when(goConfigService.currentCruiseConfig()).thenReturn(cruiseConfig);
 
@@ -723,7 +723,7 @@ public class ValueStreamMapServiceTest {
         PipelineConfig p3Config = PipelineConfigMother.pipelineConfig("p3",
                 new MaterialConfigs(new DependencyMaterialConfig(p1Config.name(), p1Config.getFirstStageConfig().name()), new DependencyMaterialConfig(p2Config.name(), p2Config.getFirstStageConfig().name())));
         CruiseConfig cruiseConfig = new BasicCruiseConfig(new BasicPipelineConfigs(p1Config, p2Config, p3Config));
-        when(pipelineService.findPipelineByCounterOrLabel("p3", "1")).thenReturn(new Pipeline("p3", "LABEL-P3", p3buildCause));
+        when(pipelineService.findPipelineByNameAndCounter("p3", 1)).thenReturn(new Pipeline("p3", "LABEL-P3", p3buildCause));
 
         when(goConfigService.currentCruiseConfig()).thenReturn(cruiseConfig);
 
@@ -763,7 +763,7 @@ public class ValueStreamMapServiceTest {
         PipelineConfig p3Config = PipelineConfigMother.pipelineConfig("p3",
                 new MaterialConfigs(new DependencyMaterialConfig(p1Config.name(), p1Config.getFirstStageConfig().name()), new DependencyMaterialConfig(p2Config.name(), p2Config.getFirstStageConfig().name())));
         CruiseConfig cruiseConfig = new BasicCruiseConfig(new BasicPipelineConfigs(p1Config, p2Config, p3Config));
-        when(pipelineService.findPipelineByCounterOrLabel("p3", "1")).thenReturn(new Pipeline("p3", "LABEL-P3", p3buildCause));
+        when(pipelineService.findPipelineByNameAndCounter("p3", 1)).thenReturn(new Pipeline("p3", "LABEL-P3", p3buildCause));
 
         when(goConfigService.currentCruiseConfig()).thenReturn(cruiseConfig);
 
@@ -786,7 +786,7 @@ public class ValueStreamMapServiceTest {
 
         BuildCause p1buildCause = createBuildCause(new ArrayList<>(), asList(git));
         when(pipelineService.buildCauseFor("p1", 1)).thenReturn(p1buildCause);
-        when(pipelineService.findPipelineByCounterOrLabel(pipelineName, "1")).thenReturn(new Pipeline("p1", "label-1", p1buildCause));
+        when(pipelineService.findPipelineByNameAndCounter(pipelineName, 1)).thenReturn(new Pipeline("p1", "label-1", p1buildCause));
 
         ValueStreamMapPresentationModel graph = valueStreamMapService.getValueStreamMap(new CaseInsensitiveString(pipelineName), 1, user, result);
 
@@ -807,7 +807,7 @@ public class ValueStreamMapServiceTest {
 
         BuildCause p1buildCause = createBuildCause(new ArrayList<>(), asList(git));
         when(pipelineService.buildCauseFor("p1", 1)).thenReturn(p1buildCause);
-        when(pipelineService.findPipelineByCounterOrLabel(pipelineName, "1")).thenReturn(new Pipeline("p1", "label-1", p1buildCause));
+        when(pipelineService.findPipelineByNameAndCounter(pipelineName, 1)).thenReturn(new Pipeline("p1", "label-1", p1buildCause));
 
         Username newUser = new Username(new CaseInsensitiveString("looser"));
         when(securityService.hasViewPermissionForPipeline(newUser, pipelineName)).thenReturn(false);
@@ -837,7 +837,7 @@ public class ValueStreamMapServiceTest {
 
         when(goConfigService.currentCruiseConfig()).thenReturn(cruiseConfig);
         when(goConfigService.hasPipelineNamed(new CaseInsensitiveString("p1"))).thenReturn(false);
-        when(pipelineService.findPipelineByCounterOrLabel("p3", "1")).thenReturn(new Pipeline("p3", "p3-label", p3buildCause));
+        when(pipelineService.findPipelineByNameAndCounter("p3", 1)).thenReturn(new Pipeline("p3", "p3-label", p3buildCause));
 
         ValueStreamMapPresentationModel graph = valueStreamMapService.getValueStreamMap(new CaseInsensitiveString("p3"), 1, user, result);
 
@@ -853,7 +853,7 @@ public class ValueStreamMapServiceTest {
         PipelineConfig pipelineConfig = PipelineConfigMother.pipelineConfig("MYPIPELINE", new MaterialConfigs(new GitMaterialConfig("sampleGit")));
         CruiseConfig cruiseConfig = new BasicCruiseConfig(new BasicPipelineConfigs(pipelineConfig));
 
-        when(pipelineService.findPipelineByCounterOrLabel("MYPIPELINE", "1")).thenThrow(RuntimeException.class);
+        when(pipelineService.findPipelineByNameAndCounter("MYPIPELINE", 1)).thenThrow(RuntimeException.class);
         when(goConfigService.currentCruiseConfig()).thenReturn(cruiseConfig);
 
         ValueStreamMapPresentationModel graph = valueStreamMapService.getValueStreamMap(new CaseInsensitiveString("MYPIPELINE"), 1, user, result);
@@ -886,7 +886,7 @@ public class ValueStreamMapServiceTest {
         when(goConfigService.hasPipelineNamed(any())).thenReturn(true);
         when(goConfigService.canEditPipeline("p1", user)).thenReturn(true);
         when(goConfigService.canEditPipeline("p2", user)).thenReturn(false);
-        when(pipelineService.findPipelineByCounterOrLabel("p2", "1")).thenReturn(new Pipeline("p2", "p2-label", p2buildCause));
+        when(pipelineService.findPipelineByNameAndCounter("p2", 1)).thenReturn(new Pipeline("p2", "p2-label", p2buildCause));
 
         ValueStreamMapPresentationModel graph = valueStreamMapService.getValueStreamMap(new CaseInsensitiveString("p2"), 1, user, result);
 

--- a/server/src/test-integration/java/com/thoughtworks/go/fixture/PipelineWithTwoStages.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/fixture/PipelineWithTwoStages.java
@@ -268,6 +268,10 @@ public class PipelineWithTwoStages implements PreCondition {
         return dbHelper.getPipelineDao().mostRecentPipeline(pipelineName).getLabel();
     }
 
+    public Integer pipelineCounter() {
+        return dbHelper.getPipelineDao().mostRecentPipeline(pipelineName).getCounter();
+    }
+
     public void createPipelineHistory() {
         createdPipelineWithAllStagesPassed();
     }

--- a/server/src/test-integration/java/com/thoughtworks/go/server/controller/ArtifactsControllerIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/controller/ArtifactsControllerIntegrationTest.java
@@ -675,7 +675,7 @@ public class ArtifactsControllerIntegrationTest {
         MockMultipartFile multipartFile = new MockMultipartFile(multipartFilename, stream);
         request.addHeader("Confirm", "true");
         StubMultipartHttpServletRequest multipartRequest = new StubMultipartHttpServletRequest(request, multipartFile);
-        return artifactsController.postArtifact(pipelineName, pipeline.getLabel(), "stage", "LATEST", "build", buildId,
+        return artifactsController.postArtifact(pipelineName, Integer.toString(pipeline.getCounter()), "stage", "LATEST", "build", buildId,
                 requestFilename,
                 null, multipartRequest);
     }

--- a/server/src/test-integration/java/com/thoughtworks/go/server/controller/ArtifactsControllerIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/controller/ArtifactsControllerIntegrationTest.java
@@ -33,6 +33,7 @@ import com.thoughtworks.go.server.web.ResponseCodeView;
 import com.thoughtworks.go.util.GoConfigFileHelper;
 import com.thoughtworks.go.util.TestFileUtil;
 import com.thoughtworks.go.util.ZipUtil;
+import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.io.FileUtils;
 import org.hamcrest.Description;
 import org.hamcrest.TypeSafeMatcher;
@@ -53,6 +54,7 @@ import org.springframework.web.servlet.ModelAndView;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.*;
+import java.nio.charset.Charset;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
@@ -61,6 +63,7 @@ import java.util.zip.Deflater;
 
 import static com.thoughtworks.go.util.GoConstants.RESPONSE_CHARSET;
 import static com.thoughtworks.go.util.GoConstants.RESPONSE_CHARSET_JSON;
+import static java.lang.String.format;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static javax.servlet.http.HttpServletResponse.*;
 import static org.apache.commons.io.FileUtils.deleteDirectory;
@@ -72,6 +75,7 @@ import static org.hamcrest.core.IsNot.not;
 import static org.hamcrest.number.OrderingComparison.lessThan;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -83,13 +87,20 @@ import static org.mockito.Mockito.when;
         "classpath:testPropertyConfigurer.xml"
 })
 public class ArtifactsControllerIntegrationTest {
-    @Autowired private ArtifactsController artifactsController;
-    @Autowired private ArtifactsService artifactService;
-    @Autowired private ConsoleService consoleService;
-    @Autowired private AgentService agentService;
-    @Autowired private ZipUtil zipUtil;
-    @Autowired private GoConfigDao goConfigDao;
-    @Autowired private DatabaseAccessHelper dbHelper;
+    @Autowired
+    private ArtifactsController artifactsController;
+    @Autowired
+    private ArtifactsService artifactService;
+    @Autowired
+    private ConsoleService consoleService;
+    @Autowired
+    private AgentService agentService;
+    @Autowired
+    private ZipUtil zipUtil;
+    @Autowired
+    private GoConfigDao goConfigDao;
+    @Autowired
+    private DatabaseAccessHelper dbHelper;
     private MockHttpServletRequest request;
     private MockHttpServletResponse response;
     private Pipeline pipeline;
@@ -102,7 +113,8 @@ public class ArtifactsControllerIntegrationTest {
     private File consoleLogFile;
 
 
-    @Before public void setup() throws Exception {
+    @Before
+    public void setup() throws Exception {
         configHelper = new GoConfigFileHelper();
         configHelper.onSetUp();
         configHelper.usingCruiseConfigDao(goConfigDao);
@@ -132,7 +144,8 @@ public class ArtifactsControllerIntegrationTest {
         artifactsRoot.mkdirs();
     }
 
-    @After public void teardown() throws Exception {
+    @After
+    public void teardown() throws Exception {
         for (File f : FileUtils.listFiles(artifactsRoot, null, true)) {
             String message = String.format("deleting {}, path: {}", f.getName(), f.getPath());
             System.out.println(message);
@@ -158,7 +171,8 @@ public class ArtifactsControllerIntegrationTest {
         configHelper.onTearDown();
     }
 
-    @Test public void shouldReturn404WhenFileNotFound() throws Exception {
+    @Test
+    public void shouldReturn404WhenFileNotFound() throws Exception {
         ModelAndView mav = getFileAsHtml("/foo.xml");
 
         assertThat(mav.getView().getContentType(), is(RESPONSE_CHARSET));
@@ -230,28 +244,32 @@ public class ArtifactsControllerIntegrationTest {
     }
 
 
-    @Test public void shouldGetArtifactFileRestfully() throws Exception {
+    @Test
+    public void shouldGetArtifactFileRestfully() throws Exception {
         createFile(artifactsRoot, "foo.xml");
 
         ModelAndView mav = getFileAsHtml("/foo.xml");
         assertThat(mav.getViewName(), is("fileView"));
     }
 
-    @Test public void shouldGetDirectoryWithHtmlView() throws Exception {
+    @Test
+    public void shouldGetDirectoryWithHtmlView() throws Exception {
         createFile(artifactsRoot, "directory/foo");
 
         ModelAndView mav = getFileAsHtml("/directory.html");
         assertThat(mav.getViewName(), is("rest/html"));
     }
 
-    @Test public void shouldReturn404WhenFooDotHtmlDoesNotExistButFooFileExists() throws Exception {
+    @Test
+    public void shouldReturn404WhenFooDotHtmlDoesNotExistButFooFileExists() throws Exception {
         createFile(artifactsRoot, "foo");
 
         ModelAndView view = getFileAsHtml("/foo.html");
         assertStatus(view, SC_NOT_FOUND);
     }
 
-    @Test public void shouldChooseFileOverDirectory() throws Exception {
+    @Test
+    public void shouldChooseFileOverDirectory() throws Exception {
         createFile(artifactsRoot, "foo.html");
         createFile(artifactsRoot, "foo/bar.xml");
 
@@ -259,28 +277,32 @@ public class ArtifactsControllerIntegrationTest {
         assertThat(mav.getViewName(), is("fileView"));
     }
 
-    @Test public void shouldReturnFolderInHtmlView() throws Exception {
+    @Test
+    public void shouldReturnFolderInHtmlView() throws Exception {
         createFile(artifactsRoot, "foo/bar.xml");
 
         ModelAndView mav = getFileAsHtml("/foo");
         assertThat(mav.getViewName(), is("rest/html"));
     }
 
-    @Test public void shouldReturnFolderInJsonView() throws Exception {
+    @Test
+    public void shouldReturnFolderInJsonView() throws Exception {
         createFile(artifactsRoot, "foo/bar.xml");
 
         ModelAndView mav = getFolderAsJson("/foo");
         assertEquals(RESPONSE_CHARSET_JSON, mav.getView().getContentType());
     }
 
-    @Test public void shouldReturnFolderInHtmlViewWithPathBasedRepository() throws Exception {
+    @Test
+    public void shouldReturnFolderInHtmlViewWithPathBasedRepository() throws Exception {
         createFile(artifactsRoot, "foo/bar.xml");
 
         ModelAndView mav = getFileAsHtml("/foo");
         assertThat(mav.getViewName(), is("rest/html"));
     }
 
-    @Test public void shouldReturnForbiddenWhenTryingToAccessArtifactsWithDotDot() throws Exception {
+    @Test
+    public void shouldReturnForbiddenWhenTryingToAccessArtifactsWithDotDot() throws Exception {
         createFile(artifactsRoot, "foo/1.xml");
         createFile(artifactsRoot, "bar/2.xml");
 
@@ -289,14 +311,16 @@ public class ArtifactsControllerIntegrationTest {
         // The controller already URL escapes the filePath, so this also works with %2e
     }
 
-    @Test public void shouldTreatSlashSlashAsOne() throws Exception {
+    @Test
+    public void shouldTreatSlashSlashAsOne() throws Exception {
         createFile(artifactsRoot, "tmp/1.xml");
 
         ModelAndView mav = getFileAsHtml("//tmp/1.xml");
         assertThat(mav.getViewName(), is("fileView"));
     }
 
-    @Test public void shouldCreateNewFile() throws Exception {
+    @Test
+    public void shouldCreateNewFile() throws Exception {
         createFile(artifactsRoot, "dir/foo");
 
         ModelAndView mav = postFile("/dir/bar.xml");
@@ -310,13 +334,15 @@ public class ArtifactsControllerIntegrationTest {
         assertStatus(mav, SC_CREATED);
     }
 
-    @Test public void shouldReturn403WhenPostingAlreadyExistingFile() throws Exception {
+    @Test
+    public void shouldReturn403WhenPostingAlreadyExistingFile() throws Exception {
         createFile(artifactsRoot, "dir/foo.txt");
         ModelAndView view = postFile("/dir/foo.txt");
         assertValidContentAndStatus(view, SC_FORBIDDEN, "File /dir/foo.txt already directoryExists.");
     }
 
-    @Test public void shouldCreateAndUnzipNewFileWhenFolderAlreadyExists() throws Exception {
+    @Test
+    public void shouldCreateAndUnzipNewFileWhenFolderAlreadyExists() throws Exception {
         artifactsRoot.mkdir();
         createFile(artifactsRoot, "dir/foo");
 
@@ -332,7 +358,8 @@ public class ArtifactsControllerIntegrationTest {
         assertThat(file(artifactsRoot, "dir/quux.txt"), is(not(directory())));
     }
 
-    @Test public void shouldCreateAndUnzipNewFileWhenFolderDoesNotExists() throws Exception {
+    @Test
+    public void shouldCreateAndUnzipNewFileWhenFolderDoesNotExists() throws Exception {
         createTmpFile(artifactsRoot, "notexists/bar.csv");
         createTmpFile(artifactsRoot, "notexists/quux.tmp");
 
@@ -345,21 +372,24 @@ public class ArtifactsControllerIntegrationTest {
         assertStatus(view, SC_CREATED);
     }
 
-    @Test public void shouldNotAllowPathsOutsideTheArtifactDirectory() throws Exception {
+    @Test
+    public void shouldNotAllowPathsOutsideTheArtifactDirectory() throws Exception {
         ModelAndView mav = postFile("/dir/../../foo/bar.txt");
         assertThat(file(artifactsRoot, "foo/bar.txt"), not(exists()));
         assertThat(file(artifactsRoot, "dir"), not(exists()));
         assertStatus(mav, SC_FORBIDDEN);
     }
 
-    @Test public void shouldEnforceUsingRequiredNameInMultipartRequest() throws Exception {
+    @Test
+    public void shouldEnforceUsingRequiredNameInMultipartRequest() throws Exception {
         ModelAndView mav = postFile("/foo/bar.txt", "badname");
         assertThat(file(artifactsRoot, "foo/bar.txt"), not(exists()));
         assertThat(file(artifactsRoot, "notfoo/bar.txt"), not(exists()));
         assertStatus(mav, SC_BAD_REQUEST);
     }
 
-    @Test public void shouldPutNewFile() throws Exception {
+    @Test
+    public void shouldPutNewFile() throws Exception {
         assertThat(file(artifactsRoot, "foo/bar.txt"), not(exists()));
 
         putFile("/foo/bar.txt");
@@ -545,6 +575,45 @@ public class ArtifactsControllerIntegrationTest {
         assertThat(list.size(), is(2));
         assertThat(list.get(0).toString(), is("oldbaz/foobar.html:BazMD5"));
         assertThat(list.get(1).toString(), is("baz/foobar.html:FooMD5"));
+    }
+
+    @Test
+    public void shouldPutArtifact() throws Exception {
+        request.addHeader("Confirm", "true");
+        String artifactFileContent = "FooBarBaz...";
+        request.setContent(artifactFileContent.getBytes());
+
+        String filePath = "baz/foobar.html";
+        ModelAndView modelAndView = artifactsController.putArtifact(pipelineName.toUpperCase(), Integer.toString(pipeline.getCounter()),
+                stage.getName().toUpperCase(), Integer.toString(stage.getCounter()), job.getName().toUpperCase(), buildId, filePath,
+                null, request);
+        assertValidContentAndStatus(modelAndView, SC_OK, String.format("File %s was appended successfully", filePath));
+
+        JobIdentifier jobIdentifier = new JobIdentifier(pipelineName, pipeline.getCounter(), null, stage.getName(), Integer.toString(stage.getCounter()), job.getName(), job.getId());
+        File artifact = artifactService.findArtifact(jobIdentifier, filePath);
+        assertThat(FileUtils.readFileToString(artifact, "utf-8"), is(artifactFileContent));
+    }
+
+    @Test
+    public void shouldPutConsoleLogAsArtifact() throws Exception {
+        request.addHeader("Confirm", "true");
+        String consoleLogContent = "Job output";
+        request.setContent(consoleLogContent.getBytes());
+
+        ModelAndView modelAndView = artifactsController.putArtifact(pipelineName.toUpperCase(), Integer.toString(pipeline.getCounter()),
+                stage.getName().toUpperCase(), Integer.toString(stage.getCounter()), job.getName().toUpperCase(), buildId, "cruise-output/console.log",
+                null, request);
+
+        String md5Hex = DigestUtils.md5Hex(String.format("%s/1/stage/1/build", pipelineName));
+        String path = new File("data/console/", String.format("%s.log", md5Hex)).getPath();
+        assertValidContentAndStatus(modelAndView, SC_OK, String.format("File %s was appended successfully", path));
+
+        JobIdentifier jobIdentifier = new JobIdentifier(pipelineName, pipeline.getCounter(),
+                null, stage.getName(), Integer.toString(stage.getCounter()),
+                job.getName(), job.getId());
+        assertTrue(consoleService.doesLogExist(jobIdentifier));
+        File consoleLogFile = consoleService.consoleLogFile(jobIdentifier);
+        assertThat(FileUtils.readFileToString(consoleLogFile, "utf-8"), is(consoleLogContent));
     }
 
     private File createFile(File buildIdArtifactRoot, String fileName) throws IOException {

--- a/server/src/test-integration/java/com/thoughtworks/go/server/controller/JobControllerIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/controller/JobControllerIntegrationTest.java
@@ -135,16 +135,6 @@ public class JobControllerIntegrationTest {
     }
 
     @Test
-    public void shouldSupportLatest() throws Exception {
-        Pipeline pipeline = fixture.createdPipelineWithAllStagesPassed();
-        Stage stage = pipeline.getFirstStage();
-        JobInstance job = stage.getFirstJob();
-        ModelAndView modelAndView = controller.jobDetail(pipeline.getName(), JobIdentifier.LATEST,
-                stage.getName(), JobIdentifier.LATEST, job.getName());
-        assertThat(presenter(modelAndView).getBuildLocator(), is(job.getIdentifier().buildLocator()));
-    }
-
-    @Test
     public void shouldReturnErrorMessageWhenFailedToFindJob() throws Exception {
         try {
             controller.jobDetail(fixture.pipelineName, "1", fixture.devStage, "1", "invalid-job");

--- a/server/src/test-integration/java/com/thoughtworks/go/server/controller/PropertiesControllerTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/controller/PropertiesControllerTest.java
@@ -106,12 +106,21 @@ public class PropertiesControllerTest {
     }
 
     @Test
-    public void shouldReportErrorIfSpecifiedWrongCounterOrLabel() throws Exception {
+    public void shouldReportErrorIfSpecifiedWrongCounter() throws Exception {
         Pipeline pipeline1 = createNewPipeline();
         controller.jobsSearch(fixture.pipelineName, fixture.devStage,
                 PipelineWithTwoStages.JOB_FOR_DEV_STAGE, "invalid-label", null, response);
         assertThat(response.getContentAsString(),
-                is("The value [invalid-label] of query parameter 'limitPipeline' is neither a pipeline counter nor label"));
+                is("Expected a numeric value for query parameter 'limitPipeline', but received [invalid-label]"));
+    }
+
+    @Test
+    public void shouldReportErrorIfSpecifiedANonExistentPipelineCounter() throws Exception {
+        Pipeline pipeline1 = createNewPipeline();
+        controller.jobsSearch(fixture.pipelineName, fixture.devStage,
+                PipelineWithTwoStages.JOB_FOR_DEV_STAGE, "9999", null, response);
+        assertThat(response.getContentAsString(),
+                is(String.format("The value [9999] of query parameter 'limitPipeline' is not a valid pipeline counter for pipeline '%s'", pipeline1.getName())));
     }
 
     //Each row is represented as a map, with column name as key, and column value as value

--- a/server/src/test-integration/java/com/thoughtworks/go/server/dao/JobInstanceSqlMapDaoTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/dao/JobInstanceSqlMapDaoTest.java
@@ -167,7 +167,7 @@ public class JobInstanceSqlMapDaoTest {
         expected = jobInstanceDao.save(stageId, expected);
 
         JobInstance actual = jobInstanceDao.mostRecentJobWithTransitions(
-                new JobIdentifier(PIPELINE_NAME, savedPipeline.getLabel(), STAGE_NAME,
+                new JobIdentifier(PIPELINE_NAME, savedPipeline.getCounter(), savedPipeline.getLabel(), STAGE_NAME,
                         String.valueOf(counter), JOB_NAME));
 
         assertThat(actual.getId(), is(expected.getId()));
@@ -182,7 +182,7 @@ public class JobInstanceSqlMapDaoTest {
         expected = jobInstanceDao.save(stageId, expected);
 
         JobInstance actual = jobInstanceDao.mostRecentJobWithTransitions(
-                new JobIdentifier(PIPELINE_NAME, savedPipeline.getLabel(), STAGE_NAME,
+                new JobIdentifier(PIPELINE_NAME, savedPipeline.getCounter(), savedPipeline.getLabel(), STAGE_NAME,
                         String.valueOf(counter), JOB_NAME));
         assertThat("JobInstance should match", actual.getId(), is(expected.getId()));
     }
@@ -231,44 +231,17 @@ public class JobInstanceSqlMapDaoTest {
 
     @Test
     public void shouldFindJobIdByPipelineLabel() throws Exception {
-        long actual = jobInstanceDao.findOriginalJobIdentifier(new StageIdentifier(PIPELINE_NAME, null, savedPipeline.getLabel(), STAGE_NAME, String.valueOf(counter)), JOB_NAME).getBuildId();
+        long actual = jobInstanceDao.findOriginalJobIdentifier(new StageIdentifier(PIPELINE_NAME, savedPipeline.getCounter(), null, STAGE_NAME, String.valueOf(counter)), JOB_NAME).getBuildId();
 
         assertThat(actual, is(savedStage.getJobInstances().getByName(JOB_NAME).getId()));
     }
 
     @Test
     public void findByJobIdShouldBeJobNameCaseAgnostic() throws Exception {
-        long actual = jobInstanceDao.findOriginalJobIdentifier(new StageIdentifier(PIPELINE_NAME, null, savedPipeline.getLabel(), STAGE_NAME, String.valueOf(counter)), JOB_NAME_IN_DIFFERENT_CASE).getBuildId();
+        long actual = jobInstanceDao.findOriginalJobIdentifier(new StageIdentifier(PIPELINE_NAME, savedPipeline.getCounter(),
+                null, STAGE_NAME, String.valueOf(counter)), JOB_NAME_IN_DIFFERENT_CASE).getBuildId();
 
         assertThat(actual, is(savedStage.getJobInstances().getByName(JOB_NAME).getId()));
-    }
-
-    @Test
-    public void shouldCacheJobIdentifierForGivenAttributes() throws Exception {
-        SqlMapClientTemplate template = mock(SqlMapClientTemplate.class);
-        jobInstanceDao.setSqlMapClientTemplate(template);
-
-        Map attrs = m(
-                "pipelineName", PIPELINE_NAME,
-                "pipelineCounter", null,
-                "pipelineLabel", savedPipeline.getLabel(),
-                "stageName", STAGE_NAME,
-                "stageCounter", counter,
-                "jobName", JOB_NAME_IN_DIFFERENT_CASE);
-
-        JobIdentifier jobIdentifier = new JobIdentifier(PIPELINE_NAME, savedPipeline.getCounter(), savedPipeline.getLabel(), STAGE_NAME, String.valueOf(counter), JOB_NAME);
-
-        when(template.queryForObject("findJobId", attrs)).thenReturn(jobIdentifier);
-
-        assertThat(jobInstanceDao.findOriginalJobIdentifier(new StageIdentifier(PIPELINE_NAME, null, savedPipeline.getLabel(), STAGE_NAME, String.valueOf(counter)), JOB_NAME_IN_DIFFERENT_CASE), is(jobIdentifier));
-
-        verify(template).queryForObject("findJobId", attrs);
-
-        assertThat(jobInstanceDao.findOriginalJobIdentifier(new StageIdentifier(PIPELINE_NAME, null, savedPipeline.getLabel(), STAGE_NAME, String.valueOf(counter)), JOB_NAME_IN_DIFFERENT_CASE), not(sameInstance(jobIdentifier)));
-
-        assertThat(jobInstanceDao.findOriginalJobIdentifier(new StageIdentifier(PIPELINE_NAME, null, savedPipeline.getLabel(), STAGE_NAME, String.valueOf(counter)), JOB_NAME), is(jobIdentifier));
-
-        verifyNoMoreInteractions(template);
     }
 
     @Test

--- a/server/src/test-integration/java/com/thoughtworks/go/server/dao/JobInstanceSqlMapDaoTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/dao/JobInstanceSqlMapDaoTest.java
@@ -279,11 +279,11 @@ public class JobInstanceSqlMapDaoTest {
         stageDao.saveWithJobs(savedPipeline, newStage);
         dbHelper.passStage(newStage);
 
-        JobIdentifier oldJobIdentifierThroughOldJob = jobInstanceDao.findOriginalJobIdentifier(new StageIdentifier(PIPELINE_NAME, null, savedPipeline.getLabel(), STAGE_NAME, String.valueOf(counter)), OTHER_JOB_NAME);
+        JobIdentifier oldJobIdentifierThroughOldJob = jobInstanceDao.findOriginalJobIdentifier(new StageIdentifier(PIPELINE_NAME, savedPipeline.getCounter(), null, STAGE_NAME, String.valueOf(counter)), OTHER_JOB_NAME);
 
-        JobIdentifier oldJobIdentifierThroughCopiedNewJob = jobInstanceDao.findOriginalJobIdentifier(new StageIdentifier(PIPELINE_NAME, null, savedPipeline.getLabel(), STAGE_NAME, String.valueOf(newStage.getCounter())), OTHER_JOB_NAME);
+        JobIdentifier oldJobIdentifierThroughCopiedNewJob = jobInstanceDao.findOriginalJobIdentifier(new StageIdentifier(PIPELINE_NAME, savedPipeline.getCounter(), null, STAGE_NAME, String.valueOf(newStage.getCounter())), OTHER_JOB_NAME);
 
-        JobIdentifier newJobIdentifierThroughRerunJob = jobInstanceDao.findOriginalJobIdentifier(new StageIdentifier(PIPELINE_NAME, null, savedPipeline.getLabel(), STAGE_NAME, String.valueOf(newStage.getCounter())), JOB_NAME);
+        JobIdentifier newJobIdentifierThroughRerunJob = jobInstanceDao.findOriginalJobIdentifier(new StageIdentifier(PIPELINE_NAME, savedPipeline.getCounter(), null, STAGE_NAME, String.valueOf(newStage.getCounter())), JOB_NAME);
 
         assertThat(oldJobIdentifierThroughOldJob, is(firstOldStage.getJobInstances().getByName(OTHER_JOB_NAME).getIdentifier()));
         assertThat(oldJobIdentifierThroughCopiedNewJob, is(firstOldStage.getJobInstances().getByName(OTHER_JOB_NAME).getIdentifier()));

--- a/server/src/test-integration/java/com/thoughtworks/go/server/dao/JobInstanceSqlMapDaoTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/dao/JobInstanceSqlMapDaoTest.java
@@ -221,7 +221,7 @@ public class JobInstanceSqlMapDaoTest {
         StageIdentifier stageIdentifier = new StageIdentifier(savedPipeline.getName(), savedPipeline.getCounter(), savedPipeline.getLabel(), savedStage.getName(), Integer.toString(savedStage.getCounter() + 1));
         assertThat(jobInstanceDao.findOriginalJobIdentifier(stageIdentifier, JOB_NAME), is(nullValue()));
         dbHelper.passStage(savedStage);
-        Stage stage = scheduleService.rerunStage(savedPipeline.getName(), savedPipeline.getLabel(), savedStage.getName());
+        Stage stage = scheduleService.rerunStage(savedPipeline.getName(), savedPipeline.getCounter(), savedStage.getName());
 
         JobIdentifier actual = jobInstanceDao.findOriginalJobIdentifier(stageIdentifier, JOB_NAME);
 

--- a/server/src/test-integration/java/com/thoughtworks/go/server/dao/PipelineSqlMapDaoIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/dao/PipelineSqlMapDaoIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 ThoughtWorks, Inc.
+ * Copyright 2018 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -69,7 +69,10 @@ import org.springframework.transaction.support.TransactionCallbackWithoutResult;
 
 import javax.sql.DataSource;
 import java.sql.SQLException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
 
@@ -1638,11 +1641,11 @@ public class PipelineSqlMapDaoIntegrationTest {
 
     @Test
     public void shouldLoadHistoryForDashboard() throws Exception {
-/*
-*   P1 [S1 (J1), S2(J1), S3(J1, J2)]
-*   P2 [S1 (J1)]
-*
-* */
+        /*
+         *   P1 [S1 (J1), S2(J1), S3(J1, J2)]
+         *   P2 [S1 (J1)]
+         *
+         * */
         String pipeline1 = "p1";
         String pipeline2 = "p2";
         PipelineConfig pipelineConfig1 = PipelineConfigMother.pipelineConfig(pipeline1);
@@ -1699,7 +1702,7 @@ public class PipelineSqlMapDaoIntegrationTest {
     }
 
     @Test
-    public void ensureActivePipelineCacheUsedByOldDashboardIsCaseInsensitiveWRTPipelineNames(){
+    public void ensureActivePipelineCacheUsedByOldDashboardIsCaseInsensitiveWRTPipelineNames() {
         GitMaterial g1 = u.wf(new GitMaterial("g1"), "folder3");
         u.checkinInOrder(g1, "g_1");
 
@@ -1746,6 +1749,24 @@ public class PipelineSqlMapDaoIntegrationTest {
                 return pipelineInstanceModel.getName().equalsIgnoreCase(pipeline1.config.name().toString());
             }
         });
+    }
+
+    @Test
+    public void shouldLoadMostRecentPipelineIdentifier() throws Exception {
+        GitMaterial g1 = u.wf(new GitMaterial("g1"), "folder3");
+        u.checkinInOrder(g1, "g_1");
+
+        String pipelineName = "p1";
+        ScheduleTestUtil.AddedPipeline p1 = u.saveConfigWith(pipelineName, "s1", u.m(g1));
+        Pipeline p1_1 = dbHelper.schedulePipeline(p1.config, new TestingClock(new Date()));
+        dbHelper.pass(p1_1);
+        Pipeline p2_1 = dbHelper.schedulePipeline(p1.config, new TestingClock(new Date()));
+        dbHelper.pass(p2_1);
+
+        PipelineIdentifier pipelineIdentifier = pipelineDao.mostRecentPipelineIdentifier(pipelineName);
+        assertThat(pipelineIdentifier.getLabel(), is(p2_1.getLabel()));
+        assertThat(pipelineIdentifier.getName(), is(p2_1.getName()));
+        assertThat(pipelineIdentifier.getCounter(), is(p2_1.getCounter()));
     }
 
     public static MaterialRevisions revisions(boolean changed) {

--- a/server/src/test-integration/java/com/thoughtworks/go/server/dao/PipelineSqlMapDaoIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/dao/PipelineSqlMapDaoIntegrationTest.java
@@ -1631,7 +1631,7 @@ public class PipelineSqlMapDaoIntegrationTest {
         Pipeline p1_1 = dbHelper.schedulePipeline(p1.config, new TestingClock(new Date()));
         dbHelper.pass(p1_1);
         PipelineInstanceModel pim1 = pipelineDao.findPipelineHistoryByNameAndCounter(p1.config.name().toUpper().toString(), 1); //prime cache
-        scheduleService.rerunStage(p1_1.getName(), p1_1.getCounter().toString(), p1_1.getStages().get(0).getName());
+        scheduleService.rerunStage(p1_1.getName(), p1_1.getCounter(), p1_1.getStages().get(0).getName());
 
         PipelineInstanceModel pim2 = pipelineDao.findPipelineHistoryByNameAndCounter(p1.config.name().toUpper().toString(), 1);
 

--- a/server/src/test-integration/java/com/thoughtworks/go/server/dao/PipelineSqlMapDaoIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/dao/PipelineSqlMapDaoIntegrationTest.java
@@ -526,16 +526,6 @@ public class PipelineSqlMapDaoIntegrationTest {
     }
 
     @Test
-    public void shouldLoadMostRecentLabel() throws Exception {
-        String stageName = "dev";
-        PipelineConfig mingleConfig = PipelineMother.twoBuildPlansWithResourcesAndMaterials("mingle", stageName);
-        Pipeline mingle = schedulePipelineWithStages(mingleConfig);
-
-        String label = pipelineDao.mostRecentLabel(mingle.getName());
-        assertThat(label, is(mingle.getLabel()));
-    }
-
-    @Test
     public void shouldLoadMostRecentPipelineWithSingleStage() throws Exception {
         String stageName = "dev";
         PipelineConfig mingleConfig = PipelineMother.twoBuildPlansWithResourcesAndMaterials("mingle", stageName);

--- a/server/src/test-integration/java/com/thoughtworks/go/server/dao/StageSqlMapDaoIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/dao/StageSqlMapDaoIntegrationTest.java
@@ -1106,18 +1106,11 @@ public class StageSqlMapDaoIntegrationTest {
         assertThat(stageDao.getMaxStageCounter(pipeline.getId(), CaseInsensitiveString.str(mingleConfig.first().name())), is(1));
     }
 
-
-    @Test
-    public void shouldReturnMaxStageCounterByPipelineLabel() throws Exception {
-        Pipeline pipeline = dbHelper.schedulePipeline(mingleConfig, new TimeProvider());
-        assertThat(stageDao.findLatestStageCounter(new PipelineIdentifier(pipeline.getName(), pipeline.getCounter(), pipeline.getLabel()), CaseInsensitiveString.str(mingleConfig.first().name())),
-                is(1));
-    }
-
     @Test
     public void shouldReturnMaxStageCounterByPipelineCounter() throws Exception {
         Pipeline pipeline = dbHelper.schedulePipeline(mingleConfig, new TimeProvider());
-        assertThat(stageDao.findLatestStageCounter(pipeline.getIdentifier(), CaseInsensitiveString.str(mingleConfig.first().name())), is(1));
+        PipelineIdentifier pipelineIdentifier = new PipelineIdentifier(pipeline.getName(), pipeline.getCounter());
+        assertThat(stageDao.findLatestStageCounter(pipelineIdentifier, CaseInsensitiveString.str(mingleConfig.first().name())), is(1));
     }
 
     @Test

--- a/server/src/test-integration/java/com/thoughtworks/go/server/dashboard/GoDashboardCurrentStateLoaderIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/dashboard/GoDashboardCurrentStateLoaderIntegrationTest.java
@@ -191,7 +191,7 @@ public class GoDashboardCurrentStateLoaderIntegrationTest {
         Pipeline p1 = dbHelper.newPipelineWithAllStagesPassed(pipelineConfig);
         Pipeline p2 = dbHelper.newPipelineWithAllStagesPassed(pipelineConfig);
 
-        scheduleService.rerunStage(pipelineConfig.getName().toString(), p1.getCounter().toString(), pipelineConfig.getFirstStageConfig().name().toString());
+        scheduleService.rerunStage(pipelineConfig.getName().toString(), p1.getCounter(), pipelineConfig.getFirstStageConfig().name().toString());
 
         List<GoDashboardPipeline> goDashboardPipelines = goDashboardCurrentStateLoader.allPipelines(goConfigService.currentCruiseConfig());
         assertThat(goDashboardPipelines, hasSize(1));

--- a/server/src/test-integration/java/com/thoughtworks/go/server/scheduling/PipelineScheduleQueueIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/scheduling/PipelineScheduleQueueIntegrationTest.java
@@ -280,11 +280,11 @@ public class PipelineScheduleQueueIntegrationTest {
         queue.finishSchedule(pipelineName, cause, newCause);
         queue.schedule(pipelineName, cause);
 
-        assertThat(pipelineDao.mostRecentLabel(fixture.pipelineName), is(nullValue()));
+        assertThat(pipelineDao.mostRecentPipelineIdentifier(fixture.pipelineName), is(nullValue()));
 
         assertThat(new CaseInsensitiveString(fixture.pipelineName), is(scheduledOn(queue)));
         assertThat(queue.createPipeline(cause, pipelineConfig, new DefaultSchedulingContext(cause.getApprover(), new Agents()), "md5-test", new TimeProvider()), is(not(nullValue())));
-        assertThat(pipelineDao.mostRecentLabel(fixture.pipelineName), is("label-1"));
+        assertThat(pipelineDao.mostRecentPipelineIdentifier(fixture.pipelineName).getLabel(), is("label-1"));
     }
 
     private TypeSafeMatcher<CaseInsensitiveString> scheduledOn(final PipelineScheduleQueue queue) {

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/PipelineSchedulerIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/PipelineSchedulerIntegrationTest.java
@@ -185,9 +185,9 @@ public class PipelineSchedulerIntegrationTest {
     public void shouldThrowExceptionIfOtherStageIsRunningInTheSamePipeline() throws Exception {
         Pipeline pipeline = makeCompletedPipeline();
         StageConfig ftStage = goConfigService.stageConfigNamed(PIPELINE_MINGLE, FT_STAGE);
-        scheduleService.rerunStage(PIPELINE_MINGLE, pipeline.getCounter().toString(), FT_STAGE);
+        scheduleService.rerunStage(PIPELINE_MINGLE, pipeline.getCounter(), FT_STAGE);
         try {
-            scheduleService.rerunStage(PIPELINE_MINGLE, pipeline.getCounter().toString(), FT_STAGE);
+            scheduleService.rerunStage(PIPELINE_MINGLE, pipeline.getCounter(), FT_STAGE);
             Assert.fail("Should throw exception if fails to re-run stage");
         } catch (Exception ignored) {
             assertThat(ignored.getMessage(), matches("Cannot schedule: Pipeline.+is still in progress"));
@@ -294,8 +294,7 @@ public class PipelineSchedulerIntegrationTest {
     @Test
     public void shouldReturnFullPipelineByCounter() {
         Pipeline pipeline = createPipelineWithStagesAndMods();
-        Pipeline actual = pipelineService.fullPipelineByCounterOrLabel(pipeline.getName(),
-                pipeline.getCounter().toString());
+        Pipeline actual = pipelineService.fullPipelineByCounter(pipeline.getName(), pipeline.getCounter());
         assertThat(actual.getStages().size(), is(not(0)));
         assertThat(actual.getBuildCause().getMaterialRevisions().getRevisions().size(), is(not(0)));
     }

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/PipelineSchedulerIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/PipelineSchedulerIntegrationTest.java
@@ -19,18 +19,18 @@ package com.thoughtworks.go.server.service;
 
 import com.thoughtworks.go.config.CaseInsensitiveString;
 import com.thoughtworks.go.config.GoConfigDao;
-import com.thoughtworks.go.config.PipelineConfig;
 import com.thoughtworks.go.config.StageConfig;
-import com.thoughtworks.go.domain.*;
+import com.thoughtworks.go.domain.EnvironmentVariable;
+import com.thoughtworks.go.domain.EnvironmentVariables;
+import com.thoughtworks.go.domain.Pipeline;
+import com.thoughtworks.go.domain.PipelinePauseInfo;
 import com.thoughtworks.go.domain.buildcause.BuildCause;
 import com.thoughtworks.go.domain.materials.svn.Subversion;
 import com.thoughtworks.go.domain.materials.svn.SvnCommand;
-import com.thoughtworks.go.helper.PipelineMother;
 import com.thoughtworks.go.helper.SvnTestRepo;
 import com.thoughtworks.go.helper.TestRepo;
 import com.thoughtworks.go.server.cache.GoCache;
 import com.thoughtworks.go.server.dao.DatabaseAccessHelper;
-import com.thoughtworks.go.server.dao.PipelineDao;
 import com.thoughtworks.go.server.domain.Username;
 import com.thoughtworks.go.server.scheduling.ScheduleHelper;
 import com.thoughtworks.go.server.scheduling.ScheduleOptions;
@@ -40,8 +40,6 @@ import com.thoughtworks.go.serverhealth.HealthStateType;
 import com.thoughtworks.go.serverhealth.ServerHealthService;
 import com.thoughtworks.go.serverhealth.ServerHealthState;
 import com.thoughtworks.go.util.GoConfigFileHelper;
-import com.thoughtworks.go.util.GoConstants;
-import com.thoughtworks.go.util.TimeProvider;
 import com.thoughtworks.go.utils.Assertions;
 import com.thoughtworks.go.utils.Timeout;
 import org.junit.*;
@@ -58,11 +56,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.function.BooleanSupplier;
 
-import static com.thoughtworks.go.helper.ModificationsMother.modifySomeFiles;
 import static com.thoughtworks.go.matchers.RegexMatcher.matches;
 import static com.thoughtworks.go.util.GoConfigFileHelper.env;
-import static org.hamcrest.Matchers.greaterThan;
-import static org.hamcrest.Matchers.not;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
 
@@ -85,10 +80,8 @@ public class PipelineSchedulerIntegrationTest {
     @Autowired private PipelineScheduleQueue pipelineScheduleQueue;
     @Autowired private ScheduleHelper scheduleHelper;
     @Autowired private DatabaseAccessHelper dbHelper;
-    @Autowired private PipelineDao pipelineDao;
     @Autowired private GoCache goCache;
     @Autowired private PipelinePauseService pipelinePauseService;
-    @Autowired private InstanceFactory instanceFactory;
 
     private static final String PIPELINE_NAME = "pipeline1";
     private static final String DEV_STAGE = "dev";
@@ -205,20 +198,20 @@ public class PipelineSchedulerIntegrationTest {
 
     @Test
     public void shouldPauseAndUnpausePipeline_identifiedByCaseInsensitiveString() throws Exception {
-
         configHelper.setOperatePermissionForGroup("defaultGroup", "pausedBy");
-        configHelper.addPipeline(PIPELINE_NAME, "stage-name");
+        String pipelineName = PIPELINE_NAME.toUpperCase();
+        configHelper.addPipeline(pipelineName, "stage-name");
 
         Username userName = new Username(new CaseInsensitiveString("pauseBy"));
-        pipelinePauseService.pause(PIPELINE_NAME, "pauseCause", userName);
+        pipelinePauseService.pause(pipelineName, "pauseCause", userName);
 
-        PipelinePauseInfo pauseInfo = pipelinePauseService.pipelinePauseInfo(PIPELINE_NAME);
+        PipelinePauseInfo pauseInfo = pipelinePauseService.pipelinePauseInfo(pipelineName);
         assertThat(pauseInfo.isPaused(), is(true));
         assertThat(pauseInfo.getPauseCause(), is("pauseCause"));
         assertThat(pauseInfo.getPauseBy(), is("pauseBy"));
 
-        pipelinePauseService.unpause(PIPELINE_NAME);
-        pauseInfo = pipelinePauseService.pipelinePauseInfo(PIPELINE_NAME);
+        pipelinePauseService.unpause(pipelineName);
+        pauseInfo = pipelinePauseService.pipelinePauseInfo(pipelineName);
         assertThat(pauseInfo.isPaused(), is(false));
     }
 
@@ -239,79 +232,4 @@ public class PipelineSchedulerIntegrationTest {
         pauseInfo = pipelinePauseService.pipelinePauseInfo(PIPELINE_NAME);
         assertThat(pauseInfo.isPaused(), is(false));
     }
-
-
-    @Test public void returnPipelineForBuildDetailViewShouldContainOnlyMods() throws Exception {
-        Pipeline pipeline = createPipelineWithStagesAndMods();
-        JobInstance job = pipeline.getFirstStage().getJobInstances().first();
-
-        Pipeline slimPipeline = pipelineService.wrapBuildDetails(job);
-        assertThat(slimPipeline.getBuildCause().getMaterialRevisions().totalNumberOfModifications(), is(1));
-        assertThat(slimPipeline.getName(), is(pipeline.getName()));
-        assertThat(slimPipeline.getFirstStage().getJobInstances().size(), is(1));
-    }
-
-    @Test
-    public void shouldApplyLabelFromPreviousPipeline() throws Exception {
-        String oldLabel = createNewPipeline().getLabel();
-        String newLabel = createNewPipeline().getLabel();
-        assertThat(newLabel, is(greaterThan(oldLabel)));
-    }
-
-    private Pipeline createNewPipeline() {
-        if (!goConfigService.hasPipelineNamed(new CaseInsensitiveString("Test"))) {
-            configHelper.addPipeline("Test", "dev");
-        }
-        Pipeline pipeline = new Pipeline("Test", "testing-${COUNT}", BuildCause.createWithEmptyModifications());
-        return pipelineService.save(pipeline);
-    }
-
-    @Test
-    public void shouldIncreaseCounterFromPreviousPipeline() {
-        Pipeline pipeline1 = createNewPipeline();
-        Pipeline pipeline2 = createNewPipeline();
-        assertThat(pipeline2.getCounter(), is(pipeline1.getCounter() + 1));
-    }
-
-    @Test
-    public void shouldFindPipelineByLabel() {
-        Pipeline pipeline = createPipelineWhoseLabelIsNumberAndNotSameWithCounter();
-        Pipeline actual = pipelineService.findPipelineByCounterOrLabel("Test", "10");
-        assertThat(actual.getId(), is(pipeline.getId()));
-        assertThat(actual.getLabel(), is(pipeline.getLabel()));
-        assertThat(actual.getCounter(), is(pipeline.getCounter()));
-    }
-
-    @Test
-    public void shouldFindPipelineByCounter() {
-        Pipeline pipeline = createNewPipeline();
-        Pipeline actual = pipelineService.findPipelineByCounterOrLabel("Test", pipeline.getCounter().toString());
-        assertThat(actual.getId(), is(pipeline.getId()));
-        assertThat(actual.getLabel(), is(pipeline.getLabel()));
-        assertThat(actual.getCounter(), is(pipeline.getCounter()));
-    }
-
-    @Test
-    public void shouldReturnFullPipelineByCounter() {
-        Pipeline pipeline = createPipelineWithStagesAndMods();
-        Pipeline actual = pipelineService.fullPipelineByCounter(pipeline.getName(), pipeline.getCounter());
-        assertThat(actual.getStages().size(), is(not(0)));
-        assertThat(actual.getBuildCause().getMaterialRevisions().getRevisions().size(), is(not(0)));
-    }
-
-    private Pipeline createPipelineWhoseLabelIsNumberAndNotSameWithCounter() {
-        Pipeline pipeline = new Pipeline("Test", "${COUNT}0", BuildCause.createWithEmptyModifications());
-        pipeline.updateCounter(9);
-        pipelineDao.save(pipeline);
-        return pipeline;
-    }
-
-    private Pipeline createPipelineWithStagesAndMods() {
-        PipelineConfig config = PipelineMother.twoBuildPlansWithResourcesAndMaterials("tester", "dev");
-        configHelper.addPipeline(CaseInsensitiveString.str(config.name()), CaseInsensitiveString.str(config.first().name()));
-        Pipeline pipeline = instanceFactory.createPipelineInstance(config, modifySomeFiles(config), new DefaultSchedulingContext(GoConstants.DEFAULT_APPROVED_BY), "md5-test", new TimeProvider());
-        dbHelper.savePipelineWithStagesAndMaterials(pipeline);
-        return pipeline;
-    }
-
 }

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/PipelineServiceIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/PipelineServiceIntegrationTest.java
@@ -1,29 +1,28 @@
-/*************************GO-LICENSE-START*********************************
- * Copyright 2014 ThoughtWorks, Inc.
+/*
+ * Copyright 2018 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *************************GO-LICENSE-END***********************************/
+ */
 
 package com.thoughtworks.go.server.service;
 
-import java.io.File;
-import java.sql.SQLException;
-import java.util.Date;
-
+import com.thoughtworks.go.config.CaseInsensitiveString;
 import com.thoughtworks.go.config.GoConfigDao;
+import com.thoughtworks.go.config.PipelineConfig;
 import com.thoughtworks.go.config.materials.Materials;
 import com.thoughtworks.go.config.materials.mercurial.HgMaterial;
 import com.thoughtworks.go.domain.DefaultSchedulingContext;
+import com.thoughtworks.go.domain.JobInstance;
 import com.thoughtworks.go.domain.MaterialRevisions;
 import com.thoughtworks.go.domain.Pipeline;
 import com.thoughtworks.go.domain.buildcause.BuildCause;
@@ -33,11 +32,14 @@ import com.thoughtworks.go.domain.materials.dependency.DependencyMaterialRevisio
 import com.thoughtworks.go.helper.PipelineMother;
 import com.thoughtworks.go.server.cache.GoCache;
 import com.thoughtworks.go.server.dao.DatabaseAccessHelper;
+import com.thoughtworks.go.server.dao.PipelineDao;
 import com.thoughtworks.go.server.dao.PipelineSqlMapDao;
 import com.thoughtworks.go.server.persistence.MaterialRepository;
 import com.thoughtworks.go.server.transaction.TransactionTemplate;
 import com.thoughtworks.go.util.GoConfigFileHelper;
+import com.thoughtworks.go.util.GoConstants;
 import com.thoughtworks.go.util.TestingClock;
+import com.thoughtworks.go.util.TimeProvider;
 import org.apache.commons.lang3.time.DateUtils;
 import org.junit.After;
 import org.junit.Before;
@@ -47,12 +49,18 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
+import java.io.File;
+import java.sql.SQLException;
+import java.util.Date;
+
+import static com.thoughtworks.go.helper.ModificationsMother.modifySomeFiles;
 import static com.thoughtworks.go.util.DataStructureUtils.a;
 import static com.thoughtworks.go.util.IBatisUtil.arguments;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.not;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(locations = {
@@ -68,6 +76,8 @@ public class PipelineServiceIntegrationTest {
     @Autowired private MaterialRepository materialRepository;
     @Autowired private PipelineSqlMapDao pipelineSqlMapDao;
     @Autowired private TransactionTemplate transactionTemplate;
+    @Autowired private PipelineDao pipelineDao;
+    @Autowired private GoConfigService goConfigService;
     @Autowired private InstanceFactory instanceFactory;
 
     private GoConfigFileHelper configHelper = new GoConfigFileHelper();
@@ -191,6 +201,78 @@ public class PipelineServiceIntegrationTest {
 
         pipelineService.save(pipelineInstance);
         assertThat(pipelineInstance.getCounter(), is(31));
+    }
+
+    @Test public void returnPipelineForBuildDetailViewShouldContainOnlyMods() throws Exception {
+        Pipeline pipeline = createPipelineWithStagesAndMods();
+        JobInstance job = pipeline.getFirstStage().getJobInstances().first();
+
+        Pipeline slimPipeline = pipelineService.wrapBuildDetails(job);
+        assertThat(slimPipeline.getBuildCause().getMaterialRevisions().totalNumberOfModifications(), is(1));
+        assertThat(slimPipeline.getName(), is(pipeline.getName()));
+        assertThat(slimPipeline.getFirstStage().getJobInstances().size(), is(1));
+    }
+
+    @Test
+    public void shouldApplyLabelFromPreviousPipeline() throws Exception {
+        String oldLabel = createNewPipeline().getLabel();
+        String newLabel = createNewPipeline().getLabel();
+        assertThat(newLabel, is(greaterThan(oldLabel)));
+    }
+
+    private Pipeline createNewPipeline() {
+        if (!goConfigService.hasPipelineNamed(new CaseInsensitiveString("Test"))) {
+            configHelper.addPipeline("Test", "dev");
+        }
+        Pipeline pipeline = new Pipeline("Test", "testing-${COUNT}", BuildCause.createWithEmptyModifications());
+        return pipelineService.save(pipeline);
+    }
+
+    @Test
+    public void shouldIncreaseCounterFromPreviousPipeline() {
+        Pipeline pipeline1 = createNewPipeline();
+        Pipeline pipeline2 = createNewPipeline();
+        assertThat(pipeline2.getCounter(), is(pipeline1.getCounter() + 1));
+    }
+
+    @Test
+    public void shouldFindPipelineByLabel() {
+        Pipeline pipeline = createPipelineWhoseLabelIsNumberAndNotSameWithCounter();
+        Pipeline actual = pipelineService.findPipelineByNameAndCounter("Test", 10);
+        assertThat(actual.getId(), is(pipeline.getId()));
+        assertThat(actual.getLabel(), is(pipeline.getLabel()));
+        assertThat(actual.getCounter(), is(pipeline.getCounter()));
+    }
+
+    @Test
+    public void shouldFindPipelineByCounter() {
+        Pipeline pipeline = createNewPipeline();
+        Pipeline actual = pipelineService.findPipelineByNameAndCounter("Test", pipeline.getCounter());
+        assertThat(actual.getId(), is(pipeline.getId()));
+        assertThat(actual.getLabel(), is(pipeline.getLabel()));
+        assertThat(actual.getCounter(), is(pipeline.getCounter()));
+    }
+
+    @Test
+    public void shouldReturnFullPipelineByCounter() {
+        Pipeline pipeline = createPipelineWithStagesAndMods();
+        Pipeline actual = pipelineService.fullPipelineByCounter(pipeline.getName(), pipeline.getCounter());
+        assertThat(actual.getStages().size(), is(not(0)));
+        assertThat(actual.getBuildCause().getMaterialRevisions().getRevisions().size(), is(not(0)));
+    }
+    private Pipeline createPipelineWhoseLabelIsNumberAndNotSameWithCounter() {
+        Pipeline pipeline = new Pipeline("Test", "${COUNT}0", BuildCause.createWithEmptyModifications());
+        pipeline.updateCounter(9);
+        pipelineDao.save(pipeline);
+        return pipeline;
+    }
+
+    private Pipeline createPipelineWithStagesAndMods() {
+        PipelineConfig config = PipelineMother.twoBuildPlansWithResourcesAndMaterials("tester", "dev");
+        configHelper.addPipeline(CaseInsensitiveString.str(config.name()), CaseInsensitiveString.str(config.first().name()));
+        Pipeline pipeline = instanceFactory.createPipelineInstance(config, modifySomeFiles(config), new DefaultSchedulingContext(GoConstants.DEFAULT_APPROVED_BY), "md5-test", new TimeProvider());
+        dbHelper.savePipelineWithStagesAndMaterials(pipeline);
+        return pipeline;
     }
 
 }

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/ScheduleServiceIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/ScheduleServiceIntegrationTest.java
@@ -405,7 +405,7 @@ public class ScheduleServiceIntegrationTest {
         assertThat(jobPlan.getVariables().size(), is(0));
 
         configHelper.addEnvironmentVariableToPipeline(pipelineName, new EnvironmentVariablesConfig(Arrays.asList(new EnvironmentVariableConfig("K1_updated", "V1_updated"))));
-        Stage rerunStage = scheduleService.rerunStage(pipelineConfig.name().toString(), "1", stageName);
+        Stage rerunStage = scheduleService.rerunStage(pipelineConfig.name().toString(), 1, stageName);
         assertThat(rerunStage.getFirstJob().getPlan().getVariables().size(), is(3));
         assertThat(rerunStage.getFirstJob().getPlan().getVariables(), hasItems(new EnvironmentVariable("K1_updated", "V1_updated"), new EnvironmentVariable("K2", "V2"), new EnvironmentVariable("K3", "V3")));
     }

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/ScheduleStageTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/ScheduleStageTest.java
@@ -94,7 +94,7 @@ public class ScheduleStageTest {
         Pipeline pipeline = fixture.createdPipelineWithAllStagesPassed();
         Stage oldStage = pipeline.getStages().byName(fixture.devStage);
 
-        scheduleService.rerunStage(pipeline.getName(), String.valueOf(pipeline.getCounter()), fixture.devStage);
+        scheduleService.rerunStage(pipeline.getName(), pipeline.getCounter(), fixture.devStage);
         Stage stage = dbHelper.getStageDao().mostRecentStage(
                 new StageConfigIdentifier(pipeline.getName(), fixture.devStage));
         assertThat(stage.getCounter(), is(oldStage.getCounter() + 1));
@@ -119,7 +119,7 @@ public class ScheduleStageTest {
         jobVariables.add("jobEnv", "jobBaz");
         configHelper.addEnvironmentVariableToJob(fixture.pipelineName, fixture.devStage, fixture.JOB_FOR_DEV_STAGE, jobVariables);
 
-        Stage stage = scheduleService.rerunStage(pipeline.getName(), String.valueOf(pipeline.getCounter()), fixture.devStage);
+        Stage stage = scheduleService.rerunStage(pipeline.getName(), pipeline.getCounter(), fixture.devStage);
 
         dbHelper.passStage(stage);
 
@@ -168,7 +168,7 @@ public class ScheduleStageTest {
     public void shouldRerunOnlyGivenJobsFromExistingStage() throws Exception {
         Pipeline pipeline = fixture.createdPipelineWithAllStagesPassed();
 
-        Stage stage = scheduleService.rerunStage(pipeline.getName(), String.valueOf(pipeline.getCounter()), fixture.devStage);
+        Stage stage = scheduleService.rerunStage(pipeline.getName(), pipeline.getCounter(), fixture.devStage);
 
         dbHelper.passStage(stage);
 
@@ -213,7 +213,7 @@ public class ScheduleStageTest {
     public void shouldConsiderCopyOfRerunJobACopyAndNotRerun() throws Exception {
         Pipeline pipeline = fixture.createdPipelineWithAllStagesPassed();
 
-        Stage stage = scheduleService.rerunStage(pipeline.getName(), String.valueOf(pipeline.getCounter()), fixture.devStage);
+        Stage stage = scheduleService.rerunStage(pipeline.getName(), pipeline.getCounter(), fixture.devStage);
 
         assertThat(stage.hasRerunJobs(), is(false));
 
@@ -311,7 +311,7 @@ public class ScheduleStageTest {
         Pipeline pipeline = fixture.createPipelineWithFirstStagePassedAndSecondStageHasNotStarted();
         String theThirdStage = fixture.stageName(3);
         try {
-            scheduleService.rerunStage(pipeline.getName(), pipeline.getLabel(), theThirdStage);
+            scheduleService.rerunStage(pipeline.getName(), pipeline.getCounter(), theThirdStage);
         } catch (Exception e) {
             assertThat(e.getMessage(), is(String.format(
                     "Can not run stage [%s] in pipeline [%s] because its previous stage has not been run.",
@@ -338,7 +338,7 @@ public class ScheduleStageTest {
         return new Runnable() {
             public void run() {
                 try {
-                    scheduleService.rerunStage(fixture.pipelineName, fixture.pipelineLabel(), ftStage);
+                    scheduleService.rerunStage(fixture.pipelineName, fixture.pipelineCounter(), ftStage);
                 } catch (Exception e) {
                     exceptions.add(e);
                 }

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/StageServiceIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/StageServiceIntegrationTest.java
@@ -468,19 +468,6 @@ public class StageServiceIntegrationTest {
         verify(listener).stageStatusChanged(stage);
     }
 
-    @Test
-    public void findStageIdByIdentifierShouldConvertStageIdentifierIntoId() throws Exception {
-        dbHelper.execute("UPDATE pipelines SET label = '1.3.4' WHERE id = " + stage.getPipelineId());
-        dbHelper.execute("UPDATE pipelines SET counter = null WHERE id = " + stage.getPipelineId());
-        assertThat(stageService.findStageIdByLocator("mingle/1.3.4/dev/1"), is(stage.getId()));
-    }
-
-    @Test
-    public void findStageIdByIdentifierShouldConvertStageIdentifierWithLabelAndCounterContainingIntoId() throws Exception {
-        dbHelper.execute("UPDATE pipelines SET label = '1.3.4.3345' WHERE id = " + stage.getPipelineId());
-        dbHelper.execute("UPDATE pipelines SET counter = '3345' WHERE id = " + stage.getPipelineId());
-        assertThat(stageService.findStageIdByLocator("mingle/3345[1.3.4.3345]/dev/1"), is(stage.getId()));
-    }
 
     @Test
     public void ensurePipelineSqlMapDaoIsAStageStatusListener() {

--- a/server/src/test-integration/java/com/thoughtworks/go/server/web/UrlRewriterIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/web/UrlRewriterIntegrationTest.java
@@ -138,17 +138,17 @@ public class UrlRewriterIntegrationTest {
     public static ResponseAssertion CONFIG_XML_EDIT = new ResponseAssertion(HTTP_URL + "/go/admin/config_xml/edit", HTTP_URL + "/go/rails/admin/config_xml/edit", METHOD.GET, true);
 
     @DataPoint
-    public static ResponseAssertion ARTIFACT_API_HTML_LISTING = new ResponseAssertion(HTTP_URL + "/go/files/pipeline/1/stage/1/job.html", HTTP_URL + "/go/repository/restful/artifact/GET/html?pipelineName=pipeline&pipelineLabel=1&stageName=stage&stageCounter=1&buildName=job&filePath=", true);
+    public static ResponseAssertion ARTIFACT_API_HTML_LISTING = new ResponseAssertion(HTTP_URL + "/go/files/pipeline/1/stage/1/job.html", HTTP_URL + "/go/repository/restful/artifact/GET/html?pipelineName=pipeline&pipelineCounter=1&stageName=stage&stageCounter=1&buildName=job&filePath=", true);
     @DataPoint
-    public static ResponseAssertion ARTIFACT_API_HTML_LISTING_FILENAME = new ResponseAssertion(HTTP_URL + "/go/files/pipeline/1/stage/1/target/abc%2Bfoo.txt", HTTP_URL + "/go/repository/restful/artifact/GET/?pipelineName=pipeline&pipelineLabel=1&stageName=stage&stageCounter=1&buildName=target&filePath=abc%2Bfoo.txt", true);
+    public static ResponseAssertion ARTIFACT_API_HTML_LISTING_FILENAME = new ResponseAssertion(HTTP_URL + "/go/files/pipeline/1/stage/1/target/abc%2Bfoo.txt", HTTP_URL + "/go/repository/restful/artifact/GET/?pipelineName=pipeline&pipelineCounter=1&stageName=stage&stageCounter=1&buildName=target&filePath=abc%2Bfoo.txt", true);
     @DataPoint
-    public static ResponseAssertion ARTIFACT_API_JSON_LISTING = new ResponseAssertion(HTTP_URL + "/go/files/pipeline/1/stage/1/job.json", HTTP_URL + "/go/repository/restful/artifact/GET/json?pipelineName=pipeline&pipelineLabel=1&stageName=stage&stageCounter=1&buildName=job&filePath=", true);
+    public static ResponseAssertion ARTIFACT_API_JSON_LISTING = new ResponseAssertion(HTTP_URL + "/go/files/pipeline/1/stage/1/job.json", HTTP_URL + "/go/repository/restful/artifact/GET/json?pipelineName=pipeline&pipelineCounter=1&stageName=stage&stageCounter=1&buildName=job&filePath=", true);
     @DataPoint
-    public static ResponseAssertion ARTIFACT_API_GET_FILE = new ResponseAssertion(HTTP_URL + "/go/files/pipeline/1/stage/1/job//tmp/file", HTTP_URL + "/go/repository/restful/artifact/GET/?pipelineName=pipeline&pipelineLabel=1&stageName=stage&stageCounter=1&buildName=job&filePath=%2Ftmp%2Ffile", true);
+    public static ResponseAssertion ARTIFACT_API_GET_FILE = new ResponseAssertion(HTTP_URL + "/go/files/pipeline/1/stage/1/job//tmp/file", HTTP_URL + "/go/repository/restful/artifact/GET/?pipelineName=pipeline&pipelineCounter=1&stageName=stage&stageCounter=1&buildName=job&filePath=%2Ftmp%2Ffile", true);
     @DataPoint
-    public static ResponseAssertion ARTIFACT_API_PUSH_FILE = new ResponseAssertion(HTTP_URL + "/go/files/pipeline/1/stage/1/job//tmp/file", HTTP_URL + "/go/repository/restful/artifact/POST/?pipelineName=pipeline&pipelineLabel=1&stageName=stage&stageCounter=1&buildName=job&filePath=%2Ftmp%2Ffile", METHOD.POST, true);
+    public static ResponseAssertion ARTIFACT_API_PUSH_FILE = new ResponseAssertion(HTTP_URL + "/go/files/pipeline/1/stage/1/job//tmp/file", HTTP_URL + "/go/repository/restful/artifact/POST/?pipelineName=pipeline&pipelineCounter=1&stageName=stage&stageCounter=1&buildName=job&filePath=%2Ftmp%2Ffile", METHOD.POST, true);
     @DataPoint
-    public static ResponseAssertion ARTIFACT_API_CHANGE_FILE = new ResponseAssertion(HTTP_URL + "/go/files/pipeline/1/stage/1/job/file", HTTP_URL + "/go/repository/restful/artifact/PUT/?pipelineName=pipeline&pipelineLabel=1&stageName=stage&stageCounter=1&buildName=job&filePath=file", METHOD.PUT, true);
+    public static ResponseAssertion ARTIFACT_API_CHANGE_FILE = new ResponseAssertion(HTTP_URL + "/go/files/pipeline/1/stage/1/job/file", HTTP_URL + "/go/repository/restful/artifact/PUT/?pipelineName=pipeline&pipelineCounter=1&stageName=stage&stageCounter=1&buildName=job&filePath=file", METHOD.PUT, true);
 
     @DataPoint
     public static ResponseAssertion PIPELINE_DASHBOARD_JSON = new ResponseAssertion(HTTP_URL + "/go/pipelines.json", HTTP_URL + "/go/rails/pipelines.json", METHOD.GET);

--- a/server/webapp/WEB-INF/rails.new/app/controllers/value_stream_map_controller.rb
+++ b/server/webapp/WEB-INF/rails.new/app/controllers/value_stream_map_controller.rb
@@ -1,5 +1,5 @@
 ##########################GO-LICENSE-START################################
-# Copyright 2017 ThoughtWorks, Inc.
+# Copyright 2018 ThoughtWorks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@ class ValueStreamMapController < ApplicationController
 
   def show
     begin
-      @pipeline = pipeline_service.findPipelineByCounterOrLabel(params[:pipeline_name], params[:pipeline_counter])
+      @pipeline = pipeline_service.findPipelineByNameAndCounter(params[:pipeline_name], params[:pipeline_counter].to_i)
     rescue
     end
     respond_to do |format|

--- a/server/webapp/WEB-INF/rails.new/app/helpers/materials_helper.rb
+++ b/server/webapp/WEB-INF/rails.new/app/helpers/materials_helper.rb
@@ -41,10 +41,6 @@ module MaterialsHelper
     material.getType() == "DependencyMaterial"
   end
 
-  def stage_url_from_identifier locator
-    stage_url(:id => stage_service.findStageIdByLocator(locator))
-  end
-
   def render_simple_comment(comment)
     if /\"TYPE\":\"PACKAGE_MATERIAL\"/.match(comment)
       package_comment_map = package_material_display_comment(comment)

--- a/server/webapp/WEB-INF/rails.new/spec/controllers/value_stream_map_controller_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/controllers/value_stream_map_controller_spec.rb
@@ -70,7 +70,7 @@ describe ValueStreamMapController do
       allow(controller).to receive(:is_ie8?).and_return(true)
       allow(controller).to receive(:generate_vsm_json).and_return('some_json')
       expect(@pipeline_history_service).to receive(:findPipelineInstance).never
-      expect(@pipeline_service).to receive(:findPipelineByCounterOrLabel).with('foo', '42').and_return('pipeline')
+      expect(@pipeline_service).to receive(:findPipelineByNameAndCounter).with('foo', 42).and_return('pipeline')
 
       get :show, { pipeline_name: 'foo', pipeline_counter: '42', format: 'json' }
 
@@ -80,7 +80,7 @@ describe ValueStreamMapController do
     it "should not redirect to old pdg page when user is using a browser other than IE8" do
       allow(controller).to receive(:is_ie8?).and_return(false)
       expect(@pipeline_history_service).to receive(:findPipelineInstance).never
-      expect(@pipeline_service).to receive(:findPipelineByCounterOrLabel).with('foo', '42').and_return('pipeline')
+      expect(@pipeline_service).to receive(:findPipelineByNameAndCounter).with('foo', 42).and_return('pipeline')
 
       get :show, { pipeline_name: 'foo', pipeline_counter: '42' }
 
@@ -111,7 +111,7 @@ describe ValueStreamMapController do
 
     it "should show Error message when pipeline name and counter cannot be resolved to a unique instance" do
       pipeline = "foo"
-      allow(@pipeline_service).to receive(:findPipelineByCounterOrLabel).with("foo","1").and_throw(Exception.new());
+      allow(@pipeline_service).to receive(:findPipelineByNameAndCounter).with("foo", 1).and_throw(Exception.new());
       get :show, pipeline_name: pipeline, pipeline_counter: 1
 
       expect(assigns(:pipeline)).to eq(nil)
@@ -120,7 +120,7 @@ describe ValueStreamMapController do
     describe "render json" do
       it "should get the pipeline dependency graph json" do
         pipeline = "P1"
-        allow(@pipeline_service).to receive(:findPipelineByCounterOrLabel).with("P1", "1").and_return(nil)
+        allow(@pipeline_service).to receive(:findPipelineByNameAndCounter).with("P1", 1).and_return(nil)
         vsm = ValueStreamMap.new(CaseInsensitiveString.new(pipeline), nil)
         vsm.addUpstreamNode(PipelineDependencyNode.new(CaseInsensitiveString.new("git"), "git"), nil, CaseInsensitiveString.new(pipeline))
         model = vsm.presentationModel()
@@ -137,7 +137,7 @@ describe ValueStreamMapController do
         allow(controller).to receive(:is_quick_edit_page_default?).and_return(true)
         allow(controller).to receive(:is_pipeline_config_spa_enabled?).and_return(true)
         pipeline = "P1"
-        allow(@pipeline_service).to receive(:findPipelineByCounterOrLabel).with("P1", "1").and_return(nil)
+        allow(@pipeline_service).to receive(:findPipelineByNameAndCounter).with("P1", 1).and_return(nil)
         vsm = ValueStreamMap.new(CaseInsensitiveString.new(pipeline), nil)
         vsm.addUpstreamNode(PipelineDependencyNode.new(CaseInsensitiveString.new("git"), "git"), nil, CaseInsensitiveString.new(pipeline))
         model = vsm.presentationModel()
@@ -151,7 +151,7 @@ describe ValueStreamMapController do
       end
 
       it "should render pipeline dependency graph JSON with pipeline instance and stage details" do
-        allow(@pipeline_service).to receive(:findPipelineByCounterOrLabel).with("current", "1").and_return(nil)
+        allow(@pipeline_service).to receive(:findPipelineByNameAndCounter).with("current", 1).and_return(nil)
         revision_p1_1 = PipelineRevision.new("p1", 1, "label-p1-1")
         revision_p1_1.addStages(Stages.new([StageMother.passedStageInstance("stage-1-for-p1-1", "j1", "p1"), StageMother.passedStageInstance("stage-2-for-p1-1", "j2", "p1")]))
           modification = com.thoughtworks.go.domain.materials.Modification.new("user", "comment", "", java.util.Date.new() , "r1")
@@ -174,7 +174,7 @@ describe ValueStreamMapController do
 
       it "should display error message when the pipeline does not exist" do
         pipeline = "P1"
-        allow(@pipeline_service).to receive(:findPipelineByCounterOrLabel).with("P1", "1").and_return(nil)
+        allow(@pipeline_service).to receive(:findPipelineByNameAndCounter).with("P1", 1).and_return(nil)
 
         expect(@value_stream_map_service).to receive(:getValueStreamMap) do |pipeline, pipeline_counter, user, result|
           allow(result).to receive(:message).and_return("error")
@@ -188,7 +188,7 @@ describe ValueStreamMapController do
 
     describe "render html" do
       it "should render html when html format" do
-        allow(@pipeline_service).to receive(:findPipelineByCounterOrLabel).with("P1", "1").and_return(nil)
+        allow(@pipeline_service).to receive(:findPipelineByNameAndCounter).with("P1", 1).and_return(nil)
         get :show, pipeline_name: "P1", pipeline_counter: 1
         assert_template "show"
       end

--- a/server/webapp/WEB-INF/rails.new/spec/helpers/materials_helper_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/helpers/materials_helper_spec.rb
@@ -72,15 +72,6 @@ describe MaterialsHelper do
     expect(has_modification?(unupdated_material)).to eq(false)
   end
 
-  it "should ask StageService for stage_url_from_identifier" do
-    mock_stage_service = double("stage_service")
-    should_receive(:stage_service).at_least(1).times.and_return(mock_stage_service)
-
-    expect(mock_stage_service).to receive(:findStageIdByLocator).with("p/1/s/1").and_return(10)
-
-    expect(stage_url_from_identifier("p/1/s/1")).to eq("http://test.host/api/stages/10.xml")
-  end
-
   it "should replace tracking tool text with a link" do
     should_receive(:go_config_service).at_least(1).times.and_return(service = double("go config service"))
     expect(service).to receive(:getCommentRendererFor).with("pipeline").and_return(TrackingTool.new("http://pavan/${ID}", "\\d+"))

--- a/server/webapp/WEB-INF/rails.new/spec/views/api/pipelines/pipeline_instance_xml_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/views/api/pipelines/pipeline_instance_xml_spec.rb
@@ -34,8 +34,6 @@ describe "/api/pipelines/pipeline_instance" do
     @dependent_pipeline.setId(12)
     @dependent_pipeline.setMaterialConfigs(@pipeline2_config.materialConfigs())
 
-    allow(view).to receive(:stage_url_from_identifier).with("uat/1/default-stage/1").and_return("url_to_default_stage")
-
     @finder = stage_finder
     @context = XmlWriterContext.new("http://test.host/go", nil, nil, nil, @finder)
     assign(:doc, PipelineXmlViewModel.new(@pipeline).toXml(@context))
@@ -125,8 +123,6 @@ describe "/api/pipelines/pipeline_instance" do
     @dependent_pipeline.setMaterialConfigs(@pipeline2_config.materialConfigs())
 
     assign(:doc, PipelineXmlViewModel.new(@dependent_pipeline).toXml(@context))
-
-    allow(view).to receive(:stage_url_from_identifier).with("ua<t/1/def\"ault<-stage/1").and_return("a_url")
 
     render :template => '/api/pipelines/pipeline_instance.xml.erb'
 

--- a/server/webapp/WEB-INF/urlrewrite.xml
+++ b/server/webapp/WEB-INF/urlrewrite.xml
@@ -454,7 +454,7 @@
     <rule>
         <name>RESTful rerun - Rerun a stage</name>
         <from>^/run/([^/]+)/([^/]+)/([^/]+)$</from>
-        <to type="forward">/admin/rerun?pipelineName=$1&amp;pipelineLabel=$2&amp;stageName=$3</to>
+        <to type="forward">/admin/rerun?pipelineName=$1&amp;pipelineCounter=$2&amp;stageName=$3</to>
     </rule>
 
     <rule>
@@ -488,7 +488,7 @@
 
     <rule>
         <name>RESTful Properties Search for one job</name>
-        <condition type="parameter" name="pipelineLabel"/>
+        <condition type="parameter" name="pipelineCounter"/>
         <from>^/properties/search(\?.*)?$</from>
         <to type="forward">/repository/restful/properties/job/search</to>
     </rule>
@@ -503,19 +503,19 @@
         <name>Post RESTful Property for a job</name>
         <condition type="parameter" name="value"/>
         <from>^/properties/([^/]+)/([^/]+)/([^/]+)/([^/]+)/([^/]+)/(.*?)?$</from>
-        <to type="forward">/repository/restful/properties/post?pipelineName=$1&amp;pipelineLabel=$2&amp;stageName=$3&amp;stageCounter=$4&amp;jobName=$5&amp;property=$6</to>
+        <to type="forward">/repository/restful/properties/post?pipelineName=$1&amp;pipelineCounter=$2&amp;stageName=$3&amp;stageCounter=$4&amp;jobName=$5&amp;property=$6</to>
     </rule>
 
     <rule>
         <name>RESTful Property for a job</name>
         <from>^/properties/([^/]+)/([^/]+)/([^/]+)/([^/]+)/([^/]+)/(.*?)?$</from>
-        <to type="forward">/repository/restful/properties/job/search?pipelineName=$1&amp;pipelineLabel=$2&amp;stageName=$3&amp;stageCounter=$4&amp;jobName=$5&amp;property=$6</to>
+        <to type="forward">/repository/restful/properties/job/search?pipelineName=$1&amp;pipelineCounter=$2&amp;stageName=$3&amp;stageCounter=$4&amp;jobName=$5&amp;property=$6</to>
     </rule>
 
     <rule>
         <name>RESTful Properties for a job</name>
         <from>^/properties/([^/]+)/([^/]+)/([^/]+)/([^/]+)/(.*?)?$</from>
-        <to type="forward">/repository/restful/properties/job/search?pipelineName=$1&amp;pipelineLabel=$2&amp;stageName=$3&amp;stageCounter=$4&amp;jobName=$5</to>
+        <to type="forward">/repository/restful/properties/job/search?pipelineName=$1&amp;pipelineCounter=$2&amp;stageName=$3&amp;stageCounter=$4&amp;jobName=$5</to>
     </rule>
 
     <rule>
@@ -539,7 +539,7 @@
     <rule>
         <name>Specific Build Detail</name>
         <from>/tab/build/detail/([^/]+)/([^/]+)/([^/]+)/([^/]+)/([^/]+)</from>
-        <to type="forward">/tab/build/recent?pipelineName=$1&amp;label=$2&amp;stageName=$3&amp;stageCounter=$4&amp;jobName=$5</to>
+        <to type="forward">/tab/build/recent?pipelineName=$1&amp;pipelineCounter=$2&amp;stageName=$3&amp;stageCounter=$4&amp;jobName=$5</to>
     </rule>
 
 

--- a/server/webapp/WEB-INF/urlrewrite.xml
+++ b/server/webapp/WEB-INF/urlrewrite.xml
@@ -460,14 +460,14 @@
     <rule>
         <name>RESTful Artifacts - List All builds artifacts</name>
         <from>^/files/([^/]+)/([^/]+)/([^/]+)/([^/]+)/([^/]+?)(\.(json|html))?(\?.*)?$</from>
-        <to type="forward">/repository/restful/artifact/%{attribute:_method}/%{attribute:_type}?pipelineName=$1&amp;pipelineLabel=$2&amp;stageName=$3&amp;stageCounter=$4&amp;buildName=$5&amp;filePath=</to>
+        <to type="forward">/repository/restful/artifact/%{attribute:_method}/%{attribute:_type}?pipelineName=$1&amp;pipelineCounter=$2&amp;stageName=$3&amp;stageCounter=$4&amp;buildName=$5&amp;filePath=</to>
     </rule>
 
     <rule>
         <name>RESTful Artifacts with start LineNumber</name>
         <condition type="parameter" name="startLineNumber"/>
         <from>^/files/([^/]+)/([^/]+)/([^/]+)/([^/]+)/([^/]+)/(.*?)(\?.*)?$</from>
-        <to type="forward">/consoleout.json?pipelineName=$1&amp;pipelineLabel=$2&amp;stageName=$3&amp;stageCounter=$4&amp;buildName=$5&amp;filePath=${escape:$6}</to>
+        <to type="forward">/consoleout.json?pipelineName=$1&amp;pipelineCounter=$2&amp;stageName=$3&amp;stageCounter=$4&amp;buildName=$5&amp;filePath=${escape:$6}</to>
         <set name="startLineNumber">{parameter:startLineNumber}</set>
     </rule>
 
@@ -475,7 +475,7 @@
         <name>RESTful Artifacts with SHA1</name>
         <condition type="parameter" name="sha1"/>
         <from>^/files/([^/]+)/([^/]+)/([^/]+)/([^/]+)/([^/]+)/(.*?)(\?.*)?$</from>
-        <to type="forward">/repository/restful/artifact/%{attribute:_method}/%{attribute:_type}?pipelineName=$1&amp;pipelineLabel=$2&amp;stageName=$3&amp;stageCounter=$4&amp;buildName=$5&amp;filePath=${escape:$6}</to>
+        <to type="forward">/repository/restful/artifact/%{attribute:_method}/%{attribute:_type}?pipelineName=$1&amp;pipelineCounter=$2&amp;stageName=$3&amp;stageCounter=$4&amp;buildName=$5&amp;filePath=${escape:$6}</to>
         <set name="sha1">{parameter:sha1}</set>
     </rule>
 
@@ -483,7 +483,7 @@
     <rule>
         <name>RESTful Artifacts</name>
         <from>^/files/([^/]+)/([^/]+)/([^/]+)/([^/]+)/([^/]+)/(.*?)(\?.*)?$</from>
-        <to type="forward">/repository/restful/artifact/%{attribute:_method}/%{attribute:_type}?pipelineName=$1&amp;pipelineLabel=$2&amp;stageName=$3&amp;stageCounter=$4&amp;buildName=$5&amp;filePath=${escape:$6}</to>
+        <to type="forward">/repository/restful/artifact/%{attribute:_method}/%{attribute:_type}?pipelineName=$1&amp;pipelineCounter=$2&amp;stageName=$3&amp;stageCounter=$4&amp;buildName=$5&amp;filePath=${escape:$6}</to>
     </rule>
 
     <rule>


### PR DESCRIPTION
Artifacts, Stage rerun, Properties API supported (but not documented) both pipeline counter and label.
In order to function, these queries required a pipeline-identifier or a stage-identifier. The information passed along in the API was enough to construct these, but since a user could technically send pipeline-label, there was a db lookup done for the pipeline using the label. I think this is un-necessary. 
[RestfulService.findJob](https://github.com/gocd/gocd/blob/98734997e24fb181f8e8a7858fba43a6d04ac207/server/src/main/java/com/thoughtworks/go/server/service/RestfulService.java#L42) takes care of checking for presence of pipeline in the config already. 

More importantly, the logic for this is very buggy. [PipelineSqlMapDao.findPipelineByCounterOrLabel](https://github.com/gocd/gocd/blob/98734997e24fb181f8e8a7858fba43a6d04ac207/server/src/main/java/com/thoughtworks/go/server/dao/PipelineSqlMapDao.java#L788) checks if the passed along string is a number or a string and uses that to decide it its a counter or a label. While this may be okay for a simple enough pipeline, it causes problems in certain cases for example: Consider `Upstream` pipeline with labeltemplate `$COUNTER`. If there is a `Downstream` pipeline which depends on `Upstream` and has labelTemplate = ${UPSTREAM}, then `PipelineSqlMapDao.findPipelineByCounterOrLabel` will always return an incorrect instance of the pipeline. 