### PR TITLE
Allow URL query parameter pass through to analytics iframes

### DIFF
--- a/server/webapp/WEB-INF/rails.new/spec/webpack/models/shared/frame_spec.js
+++ b/server/webapp/WEB-INF/rails.new/spec/webpack/models/shared/frame_spec.js
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2018 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+function FakeWindow() {
+  const location = {search: ""};
+  this.location = location;
+
+  this.withQuery = function withQuery(query) {
+    location.search = query;
+  };
+}
+
+function noop() {}
+
+const TEST_URL = "http://test.tld/path";
+
+describe("Frame", () => {
+  const Frame = require("models/shared/frame");
+
+  describe("url()", () => {
+    it("should only pass through ui=test query parameter", () => {
+
+      const mockWindow = new FakeWindow();
+      const f = new Frame(noop, mockWindow);
+      f.view(TEST_URL);
+
+      mockWindow.withQuery("?ui");
+      expect(f.view()).toEqual(TEST_URL);
+
+      mockWindow.withQuery("?ui-test=true");
+      expect(f.view()).toEqual(TEST_URL);
+
+      mockWindow.withQuery("?ui=test");
+      expect(f.view()).toEqual(`${TEST_URL}?ui=test`);
+
+      mockWindow.withQuery("?foo=bar&ui=test");
+      expect(f.view()).toEqual(`${TEST_URL}?ui=test`);
+
+      mockWindow.withQuery("?baz&ui=test");
+      expect(f.view()).toEqual(`${TEST_URL}?ui=test`);
+
+      mockWindow.withQuery("?baz&ui=other");
+      expect(f.view()).toEqual(TEST_URL);
+    });
+  });
+});

--- a/server/webapp/WEB-INF/rails.new/webpack/models/shared/frame.js
+++ b/server/webapp/WEB-INF/rails.new/webpack/models/shared/frame.js
@@ -19,6 +19,29 @@
 
   const Stream = require("mithril/stream");
   const      $ = require("jquery");
+  const    esr = require("escape-string-regexp");
+  const    enc = encodeURIComponent;
+
+  function paramPresent(key, val) {
+    const s = window.location.search,
+         re = new RegExp("undefined" !== typeof val ?
+            `[&?]${esr(enc(key))}=${esr(enc(val))}\\b` :
+            `[&?]${esr(enc(key))}\\b`);
+    return "" !== s && s.match(re);
+  }
+
+  function withParam(url, key, val) {
+    const p = "undefined" !== typeof val ? `${enc(key)}=${enc(val)}` : enc(key);
+    return url + (url.match(/[&?]/) ? "&" : "?") + p;
+  }
+
+  function passThruParams(url, params=[]) {
+    for (let i = 0, len = params.length; i < len; ++i) {
+      const key = params[i].key, val = params[i].val;
+      url = paramPresent(key, val) ? withParam(url, key, val) : url;
+    }
+    return url;
+  }
 
   function Frame(callback) {
     const url = Stream();
@@ -36,7 +59,7 @@
         dataType: "json"
       }).done((r) => {
         data(r.data);
-        view(r.view_path);
+        view(passThruParams(r.view_path, [{key: "ui", val: "test"}]));
       }).fail((xhr) => {
         errors(xhr);
       }).always(() => {

--- a/server/webapp/WEB-INF/rails.new/webpack/views/shared/analytics_iframe_widget.js.msx
+++ b/server/webapp/WEB-INF/rails.new/webpack/views/shared/analytics_iframe_widget.js.msx
@@ -19,16 +19,16 @@
 
   const m = require("mithril");
 
+
   const AnalyticsiFrameWidget = function () {
     let currentUrl = null;
 
-    function oncreate(vnode) {
+    function loadFrameContent(vnode) {
       const iframe = vnode.dom.querySelector("iframe"),
          container = vnode.dom;
 
-      iframe.onload = () => {
+      iframe.onload = function initContent() {
         vnode.dom.classList.remove("loading-analytics");
-
         vnode.attrs.init(iframe.contentWindow, {
           uid:         vnode.attrs.uid,
           pluginId:    vnode.attrs.pluginId,
@@ -42,27 +42,13 @@
       vnode.attrs.model.load();
     }
 
+    function oncreate(vnode) {
+      loadFrameContent.apply(this, [vnode]);
+    }
+
     function onupdate(vnode) {
-      const iframe = vnode.dom.querySelector("iframe"),
-         container = vnode.dom;
-
-      if (vnode.attrs && vnode.attrs.model) {
-        if (currentUrl !== vnode.attrs.model.url()) {
-          iframe.onload = () => {
-            vnode.dom.classList.remove("loading-analytics");
-
-            vnode.attrs.init(iframe.contentWindow, {
-              uid:         vnode.attrs.uid,
-              pluginId:    vnode.attrs.pluginId,
-              initialData: vnode.attrs.model.data()
-            });
-          };
-
-          currentUrl = vnode.attrs.model.url();
-
-          container.classList.add("loading-analytics");
-          vnode.attrs.model.load();
-        }
+      if (vnode.attrs && vnode.attrs.model && currentUrl !== vnode.attrs.model.url()) {
+        loadFrameContent.apply(this, [vnode]);
       }
     }
 


### PR DESCRIPTION
  - Only passes through a white list of key-val pairs (or optionally just key)
  - Currently pass through ?ui=test to toggle the ui variant feature
  - Also clean up iframe widget (DRY)