### PR TITLE
Resizing analytics iframes again

### DIFF
--- a/server/webapp/WEB-INF/rails.new/app/assets/new_stylesheets/single_page_apps/analytics.scss
+++ b/server/webapp/WEB-INF/rails.new/app/assets/new_stylesheets/single_page_apps/analytics.scss
@@ -25,9 +25,10 @@
 
 // scss-lint:disable SelectorDepth
 
-$aspect-ratio: 1.3067;
-$analytics-min-width: 685px;
-$analytics-max-height: 869px;
+$aspect-ratio: 1.61803398875; // golden ratio
+$analytics-min-height: 525px;
+$analytics-horz-margin: 34px;
+$analytics-min-support-screen-width: 1366px;
 
 .analytics-container {
   display:         flex;
@@ -111,12 +112,11 @@ $analytics-max-height: 869px;
 
       .frame-container {
         margin:     2px;
-        width:      calc(50vw - 34px);
-        height:     calc(50vw / #{$aspect-ratio} - 34px / #{$aspect-ratio});
+        width:      calc(50vw - #{$analytics-horz-margin});
+        height:     calc(50vw / #{$aspect-ratio} - #{$analytics-horz-margin} / #{$aspect-ratio});
 
-        min-width:  $analytics-min-width;
-        min-height: calc(#{$analytics-min-width} / #{$aspect-ratio});
-        max-height: $analytics-max-height;
+        min-width:  calc(#{$analytics-min-support-screen-width} / 2 - #{$analytics-horz-margin});
+        min-height: $analytics-min-height;
 
         iframe {
           height: 100%;

--- a/server/webapp/WEB-INF/rails.new/app/assets/new_stylesheets/single_page_apps/new_dashboard.scss
+++ b/server/webapp/WEB-INF/rails.new/app/assets/new_stylesheets/single_page_apps/new_dashboard.scss
@@ -37,6 +37,8 @@ $pipeline_icons_size: 16px;
 $border: #ccc;
 $filter-width: 362px;
 $pipeline-list-height: 265px;
+$modal-header-height: 55px;
+$modal-border-adj: 2px;
 
 // ---------------------  common styles ------------------------
 
@@ -1235,12 +1237,27 @@ $commits-width: 635px;
   }
 }
 
-.frame-container {
-  height: 413px;
-  width:  100%;
-  iframe {
-    height: 100%;
+.reveal.analytics-modal {
+  min-width: 850px;
+  width:     50vw;
+
+  height: calc(525px + #{$modal-header-height} + #{$modal-border-adj});
+
+  .modal-body {
+    padding:    0;
+    max-height: unset;
+    height:     525px;
+    overflow:   hidden;
+  }
+
+  .frame-container {
+    height: 525px;
     width:  100%;
-    border: 0;
+
+    iframe {
+      width:  100%;
+      height: 100%;
+      border: 0;
+    }
   }
 }

--- a/server/webapp/WEB-INF/rails.new/webpack/views/dashboard/pipeline_analytics_widget.js.msx
+++ b/server/webapp/WEB-INF/rails.new/webpack/views/dashboard/pipeline_analytics_widget.js.msx
@@ -35,7 +35,7 @@ function createModal(pluginId, metricId, pipeline) {
     key:           "analytics.pipeline-chart"
   }));
   const modal = new Modal({
-    size:    "small",
+    size:    "analytics-modal",
     title:   `Analytics`,
     body:    () => (m(AnalyticsiFrameWidget, {model, pluginId, init: PluginEndpoint.init})),
     onclose: () => modal.destroy(),


### PR DESCRIPTION
- Maintain `525px` min-height per Zeplin on both pipeline-level modal and analytics dashboard
- Set min-width on modal to be `850px`
- Give modal special class `analytics-modal` for isolated sizing changes
- Make analytics dashboard frames support side-by-side layout @ `1366x768` per @tinozza

New modal size:

![image](https://user-images.githubusercontent.com/723642/38835435-33e9d85e-4180-11e8-95ae-53ef4fa570a9.png)

Analytics modal size @ `1366x768` (demonstrates min-width and min-height):

![image](https://user-images.githubusercontent.com/723642/38835597-7fbbbfae-4180-11e8-9107-3e165921ca91.png)

Analytics frame layout @ `1366x768` (supports side-by-side layout):

![image](https://user-images.githubusercontent.com/723642/38835780-f6608784-4180-11e8-9544-8fb7629cec40.png)