### PR TITLE
Fixing flaky plugin jar monitor tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -158,3 +158,4 @@ out/
 config/config-server/warnings.log
 server/dev
 **/.DS_Store
+plugin-infra/go-plugin-infra/*.log

--- a/plugin-infra/go-plugin-infra/src/test/java/com/thoughtworks/go/plugin/infra/monitor/AbstractDefaultPluginJarLocationMonitorTest.java
+++ b/plugin-infra/go-plugin-infra/src/test/java/com/thoughtworks/go/plugin/infra/monitor/AbstractDefaultPluginJarLocationMonitorTest.java
@@ -30,6 +30,7 @@ import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
 
 public abstract class AbstractDefaultPluginJarLocationMonitorTest {
     public static final File TEMP_SOURCE = new File("temp-file-in-plugin-monitor-test");
+    protected File trashDirectory;
 
     protected void waitAMoment() throws InterruptedException {
         Thread.yield();
@@ -66,5 +67,9 @@ public abstract class AbstractDefaultPluginJarLocationMonitorTest {
 
     public void tearDown() throws Exception {
         FileUtils.deleteQuietly(TEMP_SOURCE);
+    }
+
+    protected void simulatePluginDeletion(File plugin) throws IOException {
+        FileUtils.moveFileToDirectory(plugin, trashDirectory, false);
     }
 }

--- a/plugin-infra/go-plugin-infra/src/test/java/com/thoughtworks/go/plugin/infra/monitor/DefaultPluginJarLocationMonitorTest.java
+++ b/plugin-infra/go-plugin-infra/src/test/java/com/thoughtworks/go/plugin/infra/monitor/DefaultPluginJarLocationMonitorTest.java
@@ -33,6 +33,7 @@ import org.mockito.Matchers;
 import org.mockito.Mock;
 
 import java.io.File;
+import java.io.IOException;
 
 import static com.thoughtworks.go.junitext.EnhancedOSChecker.DO_NOT_RUN_ON;
 import static com.thoughtworks.go.util.SystemEnvironment.*;
@@ -66,6 +67,7 @@ public class DefaultPluginJarLocationMonitorTest extends AbstractDefaultPluginJa
         bundledPluginDir = temporaryFolder.newFolder("bundled-plugins");
 
         pluginExternalDir = temporaryFolder.newFolder("external-plugins");
+        trashDirectory = temporaryFolder.newFolder("trash");
 
         when(systemEnvironment.get(PLUGIN_LOCATION_MONITOR_INTERVAL_IN_SECONDS)).thenReturn(1);
         when(systemEnvironment.get(PLUGIN_GO_PROVIDED_PATH)).thenReturn(bundledPluginDir.getAbsolutePath());
@@ -130,7 +132,7 @@ public class DefaultPluginJarLocationMonitorTest extends AbstractDefaultPluginJa
         monitor.start();
 
         waitAMoment();
-        FileUtils.deleteQuietly(new File(bundledPluginDir, "descriptor-aware-test-plugin.jar"));
+        simulatePluginDeletion(new File(bundledPluginDir, "descriptor-aware-test-plugin.jar"));
         waitAMoment();
 
         verify(changeListener).pluginJarAdded(pluginFileDetails(bundledPluginDir, "descriptor-aware-test-plugin.jar", true));
@@ -145,12 +147,13 @@ public class DefaultPluginJarLocationMonitorTest extends AbstractDefaultPluginJa
         waitAMoment();
         verify(changeListener).pluginJarAdded(pluginFileDetails(bundledPluginDir, "descriptor-aware-test-plugin.jar", true));
 
-        FileUtils.deleteQuietly(new File(bundledPluginDir, "descriptor-aware-test-plugin.jar"));
+        simulatePluginDeletion(new File(bundledPluginDir, "descriptor-aware-test-plugin.jar"));
         waitAMoment();
 
         verify(changeListener).pluginJarRemoved(pluginFileDetails(bundledPluginDir, "descriptor-aware-test-plugin.jar", true));
         verifyNoMoreInteractions(changeListener);
     }
+
 
     @Test
     public void shouldNotifyListenerOfMultiplePluginFilesAdded() throws Exception {
@@ -208,8 +211,8 @@ public class DefaultPluginJarLocationMonitorTest extends AbstractDefaultPluginJa
         verify(changeListener).pluginJarAdded(pluginFileDetails(bundledPluginDir, "descriptor-aware-test-plugin-2.jar", true));
         verify(changeListener).pluginJarAdded(pluginFileDetails(bundledPluginDir, "descriptor-aware-test-plugin-3.jar", true));
 
-        FileUtils.deleteQuietly(new File(bundledPluginDir, "descriptor-aware-test-plugin-1.jar"));
-        FileUtils.deleteQuietly(new File(bundledPluginDir, "descriptor-aware-test-plugin-2.jar"));
+        simulatePluginDeletion(new File(bundledPluginDir, "descriptor-aware-test-plugin-1.jar"));
+        simulatePluginDeletion(new File(bundledPluginDir, "descriptor-aware-test-plugin-2.jar"));
         waitAMoment();
 
         verify(changeListener).pluginJarRemoved(pluginFileDetails(bundledPluginDir, "descriptor-aware-test-plugin-1.jar", true));
@@ -271,7 +274,7 @@ public class DefaultPluginJarLocationMonitorTest extends AbstractDefaultPluginJa
         waitAMoment();
         verify(changeListener).pluginJarAdded(pluginFileDetails(bundledPluginDir, pluginJar, true));
 
-        FileUtils.deleteQuietly(new File(bundledPluginDir, pluginJar));
+        simulatePluginDeletion(new File(bundledPluginDir, pluginJar));
         waitAMoment();
         verify(changeListener).pluginJarRemoved(pluginFileDetails(bundledPluginDir, pluginJar, true));
     }


### PR DESCRIPTION
These tests used to fail randomly because the deletion of the plugin jar was sometimes slow and if the jar-change-listener-monitor got invoked in the middle of deletion, it would invoke the pluginJarUpdated handler which caused the verifications to fail. Using File move which is faster to simulate deletion.