### PR TITLE
PluginEndpoint.ensure() now requires a version argument

### DIFF
--- a/server/src/main/java/com/thoughtworks/go/server/service/plugins/AnalyticsPluginAssetsService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/plugins/AnalyticsPluginAssetsService.java
@@ -49,6 +49,9 @@ public class AnalyticsPluginAssetsService implements ServletContextAware, Plugin
     private static final Logger LOGGER = LoggerFactory.getLogger(AnalyticsPluginAssetsService.class);
     private static final String PLUGIN_ENDPOINT_JS = "plugin-endpoint.js";
 
+    // TODO: actually rename source file later
+    private static final String DESTINATION_JS = "analytics-endpoint.js";
+
     private AnalyticsExtension analyticsExtension;
     private ServletContext servletContext;
     private ZipUtil zipUtil;
@@ -121,7 +124,7 @@ public class AnalyticsPluginAssetsService implements ServletContextAware, Plugin
 
             zipUtil.unzip(zipInputStream, new File(pluginAssetsRoot));
 
-            Files.write(Paths.get(pluginAssetsRoot, PLUGIN_ENDPOINT_JS), pluginEndpointJsContent);
+            Files.write(Paths.get(pluginAssetsRoot, DESTINATION_JS), pluginEndpointJsContent);
 
             pluginAssetPaths.put(pluginId, Paths.get(pluginStaticAssetsPathRelativeToRailsPublicFolder(pluginId), assetsHash).toString());
         } catch (Exception e) {

--- a/server/src/test-fast/java/com/thoughtworks/go/server/service/plugins/AnalyticsPluginAssetsServiceTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/service/plugins/AnalyticsPluginAssetsServiceTest.java
@@ -169,7 +169,7 @@ public class AnalyticsPluginAssetsServiceTest {
 
         assetsService.onPluginMetadataCreate(PLUGIN_ID);
 
-        Path actualPath = Paths.get(railsRoot.getAbsolutePath(), "public", assetsService.assetPathFor(PLUGIN_ID), "plugin-endpoint.js");
+        Path actualPath = Paths.get(railsRoot.getAbsolutePath(), "public", assetsService.assetPathFor(PLUGIN_ID), "analytics-endpoint.js");
 
         assertTrue(pluginDirPath.toFile().exists());
         assertTrue(actualPath.toFile().exists());

--- a/server/webapp/WEB-INF/rails.new/app/assets/javascripts/analytics.js
+++ b/server/webapp/WEB-INF/rails.new/app/assets/javascripts/analytics.js
@@ -6,7 +6,7 @@
       var div = document.createElement("div");
 
       PluginEndpointRequestHandler.defineLinkHandler();
-      PluginEndpoint.ensure();
+      PluginEndpoint.ensure("v1");
       $(div).addClass("analytics-plugin").dialog({
         title: options.title || "Analytics",
         width: 850,

--- a/server/webapp/WEB-INF/rails.new/spec/webpack/lib/plugin_endpoint_spec.js
+++ b/server/webapp/WEB-INF/rails.new/spec/webpack/lib/plugin_endpoint_spec.js
@@ -45,7 +45,7 @@
       }
     });
 
-    PluginEndpoint.ensure();
+    PluginEndpoint.ensure("v1");
   });
 
   afterEach(() => {
@@ -58,11 +58,11 @@
     let response;
 
     PluginEndpoint.define({
-      "should.receive": (message, trans) => {
+      "go.cd.analytics.v1.should.receive": (message, trans) => {
         messageContent = message.body;
         trans.respond({ data: "correct" });
       },
-      "should.not.receive": (_message, trans) => {
+      "go.cd.analytics.v1.should.not.receive": (_message, trans) => {
         trans.respond({ data: "incorrect" });
       }
     });

--- a/server/webapp/WEB-INF/rails.new/webpack/single_page_apps/analytics.js
+++ b/server/webapp/WEB-INF/rails.new/webpack/single_page_apps/analytics.js
@@ -32,7 +32,7 @@
   const GlobalMetrics            = require('views/analytics/global_metrics');
   const PipelineMetrics          = require('views/analytics/pipeline_metrics');
 
-  PluginEndpoint.ensure();
+  PluginEndpoint.ensure("v1");
 
   document.addEventListener("DOMContentLoaded", () => {
     const main = document.querySelector("[data-supported-dashboard-metrics]");

--- a/server/webapp/WEB-INF/rails.new/webpack/views/dashboard/pipeline_analytics_widget.js.msx
+++ b/server/webapp/WEB-INF/rails.new/webpack/views/dashboard/pipeline_analytics_widget.js.msx
@@ -26,7 +26,7 @@ const Frame                        = require('models/shared/frame');
 
 function createModal(pluginId, metricId, pipeline) {
   PluginEndpointRequestHandler.defineLinkHandler();
-  PluginEndpoint.ensure();
+  PluginEndpoint.ensure("v1");
 
   const model = new Frame(m.redraw);
   model.pluginId(pluginId);


### PR DESCRIPTION
  - `version` argument is **required**
  - Prefixes messages with the correct version number
    - Now, messages look like this: `transport.request("fetch-analytics", params)...`
  - PluginEndpoint is now called AnalyticsEndpoint
    - This is a "cheap" rename -- the file hasn't been renamed, but the global export is available
      at both PluginEndpoint and AnalyticsEndpoint on the window object
    - File hasn't been renamed (yet), but is copied to the plugin as "analytics-endpoint.js"