### PR TITLE
Show Pipeline analytics on each pipeline only when analytics plugin supports at least one pipeline level analytics

### DIFF
--- a/server/webapp/WEB-INF/rails.new/webpack/single_page_apps/new_dashboard.js
+++ b/server/webapp/WEB-INF/rails.new/webpack/single_page_apps/new_dashboard.js
@@ -127,8 +127,12 @@ $(() => {
 
   const onPluginInfosResponse = (pluginInfos) => {
     pluginInfos.eachPluginInfo((pluginInfo) => {
-      pluginsSupportingAnalytics[pluginInfo.id()] = pluginInfo.extensions().analytics.capabilities().supportedPipelineAnalytics()[0].id;
+      const supportedPipelineAnalytics = pluginInfo.extensions().analytics.capabilities().supportedPipelineAnalytics();
+      if(supportedPipelineAnalytics.length > 0) {
+        pluginsSupportingAnalytics[pluginInfo.id()] = supportedPipelineAnalytics[0].id;
+      }
     });
+
     renderView();
   };
 


### PR DESCRIPTION
* Currently the dashboard breaks if analytics plugin does not support pipeline level analytics.
More information: https://twstudios.mingle-staging.thoughtworks.com/projects/sf_dev_team/cards/284