### PR TITLE
Support Agent Level Analytics

### DIFF
--- a/server/webapp/WEB-INF/rails.new/app/assets/new_stylesheets/shared/_analytics-common.scss
+++ b/server/webapp/WEB-INF/rails.new/app/assets/new_stylesheets/shared/_analytics-common.scss
@@ -45,3 +45,32 @@
     }
   }
 }
+
+$modal-header-height: 55px;
+$modal-border-adj: 2px;
+
+.reveal.analytics-modal {
+  min-width:  850px;
+  width:      50vw;
+  height:     calc(525px + #{$modal-header-height} + #{$modal-border-adj});
+  overflow-y: hidden;
+
+  .modal-body {
+    padding:    0;
+    max-height: unset;
+    height:     525px;
+    overflow-y: auto;
+  }
+
+  .frame-container {
+    height: 525px;
+    width:  100%;
+
+    iframe {
+      width:  100%;
+      height: 100%;
+      border: 0;
+    }
+  }
+}
+

--- a/server/webapp/WEB-INF/rails.new/app/assets/new_stylesheets/single_page_apps/agents.scss
+++ b/server/webapp/WEB-INF/rails.new/app/assets/new_stylesheets/single_page_apps/agents.scss
@@ -18,6 +18,7 @@
 @import '../shared/modal';
 @import '../shared/header';
 @import '../shared/alert';
+@import 'shared/analytics-common';
 
 .agents {
   transition: all 0.3s ease-in-out;
@@ -419,4 +420,15 @@ $arrow-color: #000;
 
 .spinner-container {
   height: 303px;
+}
+
+.agent-analytics {
+  @include icon-before($type: bar-chart);
+  padding:   0;
+  font-size: 14px;
+  color:     #555;
+  cursor:    pointer;
+  &:hover {
+    color: #000;
+  }
 }

--- a/server/webapp/WEB-INF/rails.new/app/assets/new_stylesheets/single_page_apps/new_dashboard.scss
+++ b/server/webapp/WEB-INF/rails.new/app/assets/new_stylesheets/single_page_apps/new_dashboard.scss
@@ -1237,28 +1237,3 @@ $commits-width: 635px;
     font-size: rem-calc(15px);
   }
 }
-
-.reveal.analytics-modal {
-  min-width: 850px;
-  width:     50vw;
-
-  height: calc(525px + #{$modal-header-height} + #{$modal-border-adj});
-
-  .modal-body {
-    padding:    0;
-    max-height: unset;
-    height:     525px;
-    overflow:   hidden;
-  }
-
-  .frame-container {
-    height: 525px;
-    width:  100%;
-
-    iframe {
-      width:  100%;
-      height: 100%;
-      border: 0;
-    }
-  }
-}

--- a/server/webapp/WEB-INF/rails.new/spec/webpack/models/shared/plugin_infos_spec.js
+++ b/server/webapp/WEB-INF/rails.new/spec/webpack/models/shared/plugin_infos_spec.js
@@ -620,6 +620,7 @@ describe('PluginInfos', () => {
         },
         "capabilities":     {
           "supported_analytics": [
+            {type: "agent", id: "bar"},
             {type: "pipeline", id: "rawr"},
             {type: "dashboard", id: "foo"}
           ]
@@ -985,6 +986,7 @@ describe('PluginInfos', () => {
         "type": "dashboard",
         "id":   "foo"
       }]);
+      expect(extensionInfo.capabilities().supportedAgentAnalytics()).toEqual([{"type": "agent", "id":   "bar"}]);
     });
   });
 

--- a/server/webapp/WEB-INF/rails.new/spec/webpack/views/agents/agent_row_widget_spec.js
+++ b/server/webapp/WEB-INF/rails.new/spec/webpack/views/agents/agent_row_widget_spec.js
@@ -186,6 +186,17 @@ describe("Agent Row Widget", () => {
     expect(buildDetailsLinks).toEqual([buildDetails.pipelineUrl(), buildDetails.stageUrl(), buildDetails.jobUrl()]);
   });
 
+  it('should not render analytics plugin icon if no analytics plugin supports agent metric', () => {
+    mount(agents(), model, true);
+    expect($root.find('.agent-analytics')).not.toBeInDOM();
+  });
+
+  it('should render analytics plugin icon if any analytics plugin supports agent metric', () => {
+    elasticAgentPluginInfo.extensions.push(analyticsExtension);
+    mount(agents(), model, true);
+    expect($root.find('.agent-analytics')).toBeInDOM();
+  });
+
   const mount = (agent, model, isUserAdmin, supportsAgentStatusReportPage = false) => {
     elasticAgentPluginInfo.extensions[0]['capabilities']['supports_agent_status_report'] = supportsAgentStatusReportPage;
 
@@ -385,8 +396,7 @@ describe("Agent Row Widget", () => {
           }
         },
         "profile_settings": {
-          "configurations": [
-          ],
+          "configurations": [],
           "view":           {
             "template": 'some cool template!'
           }
@@ -397,5 +407,38 @@ describe("Agent Row Widget", () => {
         }
       }
     ]
+  };
+
+  const analyticsExtension = {
+    "type":             "analytics",
+    "plugin_settings":  {
+      "configurations": [
+        {
+          "key":      "instance_type",
+          "metadata": {
+            "secure":   false,
+            "required": true
+          }
+        }
+      ],
+      "view":           {
+        "template": "analytics plugin settings view"
+      }
+    },
+    "profile_settings": {
+      "configurations": [],
+      "view":           {
+        "template": 'some cool template!'
+      }
+    },
+    "capabilities":     {
+      "supported_analytics": [
+        {
+          "type":  "agent",
+          "id":    "agent utilization",
+          "title": "Agent Utilization"
+        }
+      ]
+    }
   };
 });

--- a/server/webapp/WEB-INF/rails.new/spec/webpack/views/agents/agents_widget_spec.js
+++ b/server/webapp/WEB-INF/rails.new/spec/webpack/views/agents/agents_widget_spec.js
@@ -111,7 +111,7 @@ describe("Agents Widget", () => {
   it('should contain the agent row information', () => {
     const agentInfo      = $root.find('table tbody tr')[0];
     const firstAgentInfo = $(agentInfo).find('td');
-    expect(firstAgentInfo).toHaveLength(10);
+    expect(firstAgentInfo).toHaveLength(11);
     expect($(firstAgentInfo[0]).find(':checkbox')).toExist();
     expect($(firstAgentInfo[2]).find('.content')).toHaveText('host-1');
     expect($(firstAgentInfo[3]).find('.content')).toHaveText('usr/local/foo');

--- a/server/webapp/WEB-INF/rails.new/webpack/models/shared/plugin_infos/analytics_plugin_capabilities.js
+++ b/server/webapp/WEB-INF/rails.new/webpack/models/shared/plugin_infos/analytics_plugin_capabilities.js
@@ -18,12 +18,14 @@ const Stream = require('mithril/stream');
 const _      = require('lodash');
 
 const Capabilities = function (data) {
-  this.supportedAnalyticsDashboardMetrics  = Stream(data.supportedAnalyticsDashboardMetrics);
-  this.supportedPipelineAnalytics          = Stream(data.supportedPipelineAnalytics);
+  this.supportedAgentAnalytics            = Stream(data.supportedAgentAnalytics);
+  this.supportedPipelineAnalytics         = Stream(data.supportedPipelineAnalytics);
+  this.supportedAnalyticsDashboardMetrics = Stream(data.supportedAnalyticsDashboardMetrics);
 };
 
 Capabilities.fromJSON = (data = {}) => new Capabilities({
-  supportedPipelineAnalytics: _.filter(data, {type: 'pipeline'}),
+  supportedAgentAnalytics:            _.filter(data, {type: 'agent'}),
+  supportedPipelineAnalytics:         _.filter(data, {type: 'pipeline'}),
   supportedAnalyticsDashboardMetrics: _.filter(data, {type: 'dashboard'})
 });
 

--- a/server/webapp/WEB-INF/rails.new/webpack/single_page_apps/agents.js
+++ b/server/webapp/WEB-INF/rails.new/webpack/single_page_apps/agents.js
@@ -58,6 +58,13 @@ $(() => {
   const currentRepeater  = Stream(createRepeater());
 
   const onResponse = (pluginInfos) => {
+    const EAPluginInfos  = pluginInfos.filterByType('elastic-agent');
+    const allPluginInfos = pluginInfos.filterByType('analytics');
+
+    EAPluginInfos.eachPluginInfo((pluginInfo) => {
+      allPluginInfos.addPluginInfo(pluginInfo);
+    });
+
     const component = {
       view() {
         return m(AgentsWidget, {
@@ -67,7 +74,7 @@ $(() => {
           permanentMessage,
           showSpinner,
           sortOrder,
-          pluginInfos:          typeof pluginInfos === "string" ? Stream() : Stream(pluginInfos.filterByType('elastic-agent')),
+          pluginInfos:          typeof pluginInfos === "string" ? Stream() : Stream(allPluginInfos),
           doCancelPolling:      () => currentRepeater().stop(),
           doRefreshImmediately: () => {
             currentRepeater().stop();
@@ -89,7 +96,7 @@ $(() => {
     sortOrder().initialize();
   };
 
-  PluginInfos.all(null, {type: 'elastic-agent'}).then(onResponse, onResponse);
+  PluginInfos.all().then(onResponse, onResponse);
 })
 ;
 

--- a/server/webapp/WEB-INF/rails.new/webpack/views/agents/agent_analytics_widget.js.msx
+++ b/server/webapp/WEB-INF/rails.new/webpack/views/agents/agent_analytics_widget.js.msx
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2018 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const _ = require('lodash');
+const m = require('mithril');
+
+const Interactions                 = require("models/shared/analytics_interaction_manager");
+const Models                       = Interactions.ensure().ns("AgentMetrics");
+const PluginEndpoint               = require('rails-shared/plugin-endpoint');
+const Modal                        = require('views/shared/new_modal');
+const AnalyticsiFrameWidget        = require('views/shared/analytics_iframe_widget');
+const PluginEndpointRequestHandler = require('rails-shared/plugin-endpoint-request-handler');
+
+function createModel(index, pluginId, metric, agent) {
+  const uid    = Models.uid(index, pluginId, "agent", metric),
+        model  = Models.modelFor(uid),
+        params = {
+          'agent_uuid':     agent.uuid(),
+          'agent_hostname': agent.hostname(),
+          key:              "analytics.agent-chart"
+        };
+
+  model.url(Models.toUrl(uid, params));
+
+  model.pluginId = pluginId;
+  model.title    = metric.title;
+
+  return model;
+}
+
+function createModal(supportedAnalytics, agent) {
+  PluginEndpointRequestHandler.defineLinkHandler();
+  PluginEndpoint.ensure("v1");
+
+  const models = [];
+  _.each(supportedAnalytics, (agentAnalytics, pluginId) => {
+    _.each(agentAnalytics, (metric, i) => {
+      models.push(createModel(i, pluginId, metric, agent));
+    });
+  });
+
+  const modal = new Modal({
+    size:    "analytics-modal",
+    title:   `Analytics`,
+    body:    () => models.map((model) => m(AnalyticsiFrameWidget, {
+      model,
+      pluginId: model.pluginId,
+      title:    model.title,
+      init:     PluginEndpoint.init
+    })),
+    onclose: () => modal.destroy(),
+    buttons: []
+  });
+  modal.render();
+}
+
+
+const AgentAnalyticsWidget = {
+  view: (vnode) => {
+    return m("a", {
+      class:   "agent-analytics",
+      onclick: () => {
+        createModal(vnode.attrs.supportedAnalytics, vnode.attrs.agent);
+      }
+    });
+  }
+};
+
+module.exports = AgentAnalyticsWidget;

--- a/server/webapp/WEB-INF/rails.new/webpack/views/agents/agent_row_widget.js.msx
+++ b/server/webapp/WEB-INF/rails.new/webpack/views/agents/agent_row_widget.js.msx
@@ -14,9 +14,11 @@
  * limitations under the License.
  */
 
-const m                  = require('mithril');
-const f                  = require('helpers/form_helper');
-const BuildDetailsWidget = require('views/agents/build_details_widget');
+const _                    = require('lodash');
+const m                    = require('mithril');
+const f                    = require('helpers/form_helper');
+const BuildDetailsWidget   = require('views/agents/build_details_widget');
+const AgentAnalyticsWidget = require('views/agents/agent_analytics_widget');
 
 
 const joinOrNoneSpecified = function (things) {
@@ -82,6 +84,25 @@ const AgentRowWidget = {
     this.dropdownClass = function (name) {
       return args.dropdown.isDropDownOpen(name) ? "is-open" : '';
     };
+
+    this.getPluginSupportingAgentAnalytics = function (pluginInfos) {
+      const agentAnalyticsPlugins = {};
+
+      if (!pluginInfos || !pluginInfos()) {
+        return agentAnalyticsPlugins;
+      }
+
+      pluginInfos().eachPluginInfo((p) => {
+        if (p.extensions().analytics) {
+          const agentAnalytics = p.extensions().analytics.capabilities().supportedAgentAnalytics();
+          if (agentAnalytics.length > 0) {
+            agentAnalyticsPlugins[p.id] = agentAnalytics;
+          }
+        }
+      });
+
+      return agentAnalyticsPlugins;
+    };
   },
 
   view(vnode) {
@@ -121,6 +142,12 @@ const AgentRowWidget = {
                checked={args.checkBoxModel()}
                onclick={m.withAttr('checked', args.checkBoxModel)}/>
       );
+    }
+
+    let analyticsIcon;
+    const agentAnalytics = vnode.state.getPluginSupportingAgentAnalytics(pluginInfos);
+    if (!_.isEmpty(agentAnalytics)) {
+      analyticsIcon = (<AgentAnalyticsWidget agent={agent} supportedAnalytics={agentAnalytics}/>);
     }
 
     return (
@@ -166,6 +193,9 @@ const AgentRowWidget = {
         <td key="environments">
           <label class="hide-for-large">Environments</label>
           <span class="content">{environments}</span>
+        </td>
+        <td key="analyticsIcon">
+          <span class="show-for-large">{analyticsIcon}</span>
         </td>
       </tr>
     );

--- a/server/webapp/WEB-INF/rails.new/webpack/views/agents/agent_table_header.js.msx
+++ b/server/webapp/WEB-INF/rails.new/webpack/views/agents/agent_table_header.js.msx
@@ -104,6 +104,7 @@ const AgentsTableHeader = {
                             sortOrder={vnode.attrs.sortOrder}
                             sortClass={vnode.state.sortClass}/>
         </th>
+        <th></th>
       </tr>
       </thead>
     );

--- a/server/webapp/WEB-INF/rails.new/webpack/views/dashboard/pipeline_analytics_widget.js.msx
+++ b/server/webapp/WEB-INF/rails.new/webpack/views/dashboard/pipeline_analytics_widget.js.msx
@@ -16,7 +16,6 @@
 
 const m = require('mithril');
 
-
 const Interactions          = require("models/shared/analytics_interaction_manager");
 const Models                = Interactions.ensure().ns("PipelineMetrics");
 const init                  = require("rails-shared/plugin-endpoint").init;


### PR DESCRIPTION
* Show analytics icon at each agent row if any of the analytics plugin support agent analytics.
* Render Agent analytics in the modal.
* Agent analytics modal can render all the agent level analytics supported by all the analytics plugins.

More information: https://twstudios.mingle-staging.thoughtworks.com/projects/sf_dev_team/cards/296