### PR TITLE
Fixing few case-insensitivity bugs with pipeline-name

### DIFF
--- a/common/src/main/java/com/thoughtworks/go/presentation/pipelinehistory/PipelineInstanceModels.java
+++ b/common/src/main/java/com/thoughtworks/go/presentation/pipelinehistory/PipelineInstanceModels.java
@@ -48,7 +48,7 @@ public class PipelineInstanceModels extends BaseCollection<PipelineInstanceModel
     public PipelineInstanceModels findAll(String pipelineName) {
         PipelineInstanceModels found = PipelineInstanceModels.createPipelineInstanceModels();
         for (PipelineInstanceModel pipelineInstanceModel : this) {
-            if(pipelineInstanceModel.getName().equals(pipelineName)){
+            if(pipelineInstanceModel.getName().equalsIgnoreCase(pipelineName)){
                 found.add(pipelineInstanceModel);
             }
         }

--- a/server/db/migrate/h2deltas/1804001_add_case_insensitive_pipelinename_column_to_pipelinelabelcounts.sql
+++ b/server/db/migrate/h2deltas/1804001_add_case_insensitive_pipelinename_column_to_pipelinelabelcounts.sql
@@ -1,0 +1,26 @@
+
+--
+-- Copyright 2018 ThoughtWorks, Inc.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--    http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+ALTER TABLE PIPELINELABELCOUNTS ADD COLUMN caseInsensitivePipelineName varchar_ignorecase(255);
+UPDATE PIPELINELABELCOUNTS set caseInsensitivePipelineName = pipelinename;
+CREATE INDEX idx_pipelinelabelcounts_caseinsensitivepipelinename ON PIPELINELABELCOUNTS(caseInsensitivePipelineName);
+
+--//@UNDO
+
+DROP INDEX idx_pipelinelabelcounts_caseinsensitivepipelinename;
+ALTER TABLE PIPELINELABELCOUNTS DROP COLUMN caseInsensitivePipelineName;
+

--- a/server/src/main/java/com/thoughtworks/go/server/dao/PipelineDao.java
+++ b/server/src/main/java/com/thoughtworks/go/server/dao/PipelineDao.java
@@ -16,6 +16,7 @@
 
 package com.thoughtworks.go.server.dao;
 
+import com.thoughtworks.go.config.CaseInsensitiveString;
 import com.thoughtworks.go.domain.*;
 import com.thoughtworks.go.domain.buildcause.BuildCause;
 import com.thoughtworks.go.presentation.pipelinehistory.PipelineInstanceModel;
@@ -83,7 +84,7 @@ public interface PipelineDao {
 
     Pipeline findEarlierPipelineThatPassedForStage(String pipelineName, String stageName, double naturalOrder);
 
-    PipelineInstanceModels loadActivePipelineInstancesFor(String pipelineName);
+    PipelineInstanceModels loadActivePipelineInstancesFor(CaseInsensitiveString pipelineName);
 
     PipelineInstanceModel loadHistoryByIdWithBuildCause(Long id);
 

--- a/server/src/main/java/com/thoughtworks/go/server/dao/PipelineSqlMapDao.java
+++ b/server/src/main/java/com/thoughtworks/go/server/dao/PipelineSqlMapDao.java
@@ -39,6 +39,7 @@ import com.thoughtworks.go.server.transaction.TransactionTemplate;
 import com.thoughtworks.go.server.util.Pagination;
 import com.thoughtworks.go.server.util.SqlUtil;
 import com.thoughtworks.go.util.SystemEnvironment;
+import org.apache.commons.lang.StringUtils;
 import org.hibernate.SessionFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -134,6 +135,18 @@ public class PipelineSqlMapDao extends SqlMapClientDaoSupport implements Initial
     public Integer getCounterForPipeline(String name) {
         Integer counter = (Integer) getSqlMapClientTemplate().queryForObject("getCounterForPipeline", name);
         return counter == null ? 0 : counter;
+    }
+
+    public List<String> getPipelineNamesWithMultipleEntriesForLabelCount() {
+        List<String> pipelinenames = getSqlMapClientTemplate().queryForList("getPipelineNamesWithMultipleEntriesForLabelCount");
+        if(pipelinenames.size() > 0 && StringUtils.isBlank(pipelinenames.get(0)))
+            return new ArrayList<>();
+        return pipelinenames;
+    }
+
+    public void deleteOldPipelineLabelCountForPipeline(String pipelineName) {
+        Map<String, Object> args = arguments("pipelineName", pipelineName).asMap();
+        getSqlMapClientTemplate().delete("deleteOldPipelineLabelCountForPipeline", args);
     }
 
     public void insertOrUpdatePipelineCounter(Pipeline pipeline, Integer lastCount, Integer newCount) {

--- a/server/src/main/java/com/thoughtworks/go/server/dao/StageSqlMapDao.java
+++ b/server/src/main/java/com/thoughtworks/go/server/dao/StageSqlMapDao.java
@@ -668,7 +668,7 @@ public class StageSqlMapDao extends SqlMapClientDaoSupport implements StageDao, 
     }
 
     private String cacheKeyForPipelineAndStage(String pipelineName, String stageName) {
-        return String.format("%s_isStageActive_%s_%s", StageSqlMapDao.class.getName(), pipelineName, stageName).intern();
+        return String.format("%s_isStageActive_%s_%s", StageSqlMapDao.class.getName(), pipelineName.toLowerCase(), stageName.toLowerCase()).intern();
     }
 
     public Stages findAllStagesFor(String pipelineName, int counter) {

--- a/server/src/main/java/com/thoughtworks/go/server/initializers/ApplicationInitializer.java
+++ b/server/src/main/java/com/thoughtworks/go/server/initializers/ApplicationInitializer.java
@@ -85,6 +85,7 @@ public class ApplicationInitializer implements ApplicationListener<ContextRefres
     @Autowired private DependencyMaterialUpdateNotifier dependencyMaterialUpdateNotifier;
     @Autowired private SCMMaterialSource scmMaterialSource;
     @Autowired private ResourceMonitoring resourceMonitoring;
+    @Autowired private PipelineLabelCorrector pipelineLabelCorrector;
     @Value("${cruise.daemons.enabled}")
     private boolean daemonsEnabled;
 
@@ -123,6 +124,7 @@ public class ApplicationInitializer implements ApplicationListener<ContextRefres
             pipelineLockService.initialize();
             buildAssignmentService.initialize();
             materialUpdateService.initialize();
+            pipelineLabelCorrector.correctPipelineLabelCountEntries();
             pipelineScheduler.initialize();
             removeAdminPermissionFilter.initialize();
 

--- a/server/src/main/java/com/thoughtworks/go/server/service/PipelineLabelCorrector.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/PipelineLabelCorrector.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2018 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.server.service;
+
+import com.thoughtworks.go.config.PipelineConfig;
+import com.thoughtworks.go.server.dao.PipelineSqlMapDao;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+
+@Service
+public class PipelineLabelCorrector {
+    private GoConfigService goConfigService;
+    private PipelineSqlMapDao pipelineSqlMapDao;
+
+    @Autowired
+    public PipelineLabelCorrector(GoConfigService goConfigService, PipelineSqlMapDao pipelineSqlMapDao) {
+        this.goConfigService = goConfigService;
+        this.pipelineSqlMapDao = pipelineSqlMapDao;
+    }
+
+    public void correctPipelineLabelCountEntries() {
+        List<String> pipelinesWithMultipleEntriesForLabelCount = pipelineSqlMapDao.getPipelineNamesWithMultipleEntriesForLabelCount();
+        if (pipelinesWithMultipleEntriesForLabelCount.isEmpty()) return;
+
+        List<PipelineConfig> allPipelineConfigs = goConfigService.getAllPipelineConfigs();
+
+        pipelinesWithMultipleEntriesForLabelCount.stream().forEach(new Consumer<String>() {
+            @Override
+            public void accept(String pipelineWithIssue) {
+                allPipelineConfigs.stream().filter(new Predicate<PipelineConfig>() {
+                    @Override
+                    public boolean test(PipelineConfig pipelineConfig) {
+                        return pipelineConfig.name().toString().equalsIgnoreCase(pipelineWithIssue);
+                    }
+                }).forEach(new Consumer<PipelineConfig>() {
+                    @Override
+                    public void accept(PipelineConfig pipelineConfig) {
+                        String pipelineNameAsSavedInConfig = pipelineConfig.name().toString();
+                        pipelineSqlMapDao.deleteOldPipelineLabelCountForPipeline(pipelineNameAsSavedInConfig);
+                    }
+                });
+            }
+        });
+    }
+}

--- a/server/src/main/java/com/thoughtworks/go/server/service/ScheduleService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/ScheduleService.java
@@ -169,7 +169,7 @@ public class ScheduleService {
         }
     }
 
-    private Pipeline schedulePipeline(final String pipelineName, final BuildCause buildCause) {
+    Pipeline schedulePipeline(final String pipelineName, final BuildCause buildCause) {
         try {
             PipelineConfig pipelineConfig = goConfigService.pipelineConfigNamed(new CaseInsensitiveString(pipelineName));
 

--- a/server/src/main/resources/com/thoughtworks/go/server/dao/maps/Pipeline.xml
+++ b/server/src/main/resources/com/thoughtworks/go/server/dao/maps/Pipeline.xml
@@ -96,15 +96,27 @@
     </insert>
 
     <insert id="insertPipelineLabelCounter">
-        INSERT INTO pipelineLabelCounts (pipelineName, labelCount)
-        VALUES (#pipelineName#, #count#)
+        INSERT INTO pipelineLabelCounts (pipelineName, labelCount, caseInsensitivePipelineName)
+        VALUES (#pipelineName#, #count#, #pipelineName#)
     </insert>
 
     <update id="updatePipelineLabelCounter">
         UPDATE pipelineLabelCounts
         SET labelCount = #count#
-        WHERE pipelineName = #pipelineName#
+        WHERE caseInsensitivePipelineName = #pipelineName#
     </update>
+
+
+    <select id="getPipelineNamesWithMultipleEntriesForLabelCount" resultClass="java.lang.String">
+        SELECT caseInsensitivePipelineName FROM PIPELINELABELCOUNTS GROUP BY caseInsensitivePipelineName HAVING COUNT(*) > 1;
+    </select>
+
+    <delete id="deleteOldPipelineLabelCountForPipeline">
+        DELETE FROM PIPELINELABELCOUNTS
+        WHERE
+        caseInsensitivePipelineName = #pipelineName#
+        AND pipelinename != #pipelineName#
+    </delete>
 
     <update id="updatePipelineComment">
         UPDATE pipelines
@@ -164,31 +176,31 @@
     <select id="hasPipelineInfoRow" parameterClass="java.lang.String" resultClass="java.lang.Integer">
         SELECT COUNT(*)
         FROM pipelineLabelCounts
-        WHERE pipelineName = #value#
+        WHERE caseInsensitivePipelineName = #value#
     </select>
 
     <select id="getCounterForPipeline" parameterClass="java.lang.String" resultClass="java.lang.Integer">
         SELECT labelCount
         FROM pipelineLabelCounts
-        WHERE pipelineName = #value#
+        WHERE caseInsensitivePipelineName = #value#
         ORDER BY id DESC
     </select>
 
     <select id="getPipelinePauseState" resultMap="select-pipeline-pause-info">
         SELECT pause_cause, pause_by, paused
         FROM pipelineLabelCounts
-        WHERE pipelineName = #value#
+        WHERE caseInsensitivePipelineName = #value#
     </select>
 
     <insert id="insertPipelinePauseState">
-        INSERT INTO pipelineLabelCounts (pipelineName, pause_cause, pause_by, paused)
-        VALUES (#pipelineName#, #pauseCause#, #pauseBy#, true)
+        INSERT INTO pipelineLabelCounts (pipelineName, pause_cause, pause_by, paused, caseInsensitivePipelineName)
+        VALUES (#pipelineName#, #pauseCause#, #pauseBy#, true, #pipelineName#)
     </insert>
 
     <update id="updatePipelinePauseState">
         UPDATE pipelineLabelCounts
         SET pause_cause = #pauseCause#, pause_by = #pauseBy#, paused = #paused#
-        WHERE pipelineName = #pipelineName#
+        WHERE caseInsensitivePipelineName = #pipelineName#
     </update>
 
     <cacheModel id="pipeline-by-buildId" type="MEMORY" readOnly="true">

--- a/server/src/test-fast/java/com/thoughtworks/go/server/dao/PipelineSqlMapDaoTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/dao/PipelineSqlMapDaoTest.java
@@ -16,6 +16,7 @@
 
 package com.thoughtworks.go.server.dao;
 
+import com.thoughtworks.go.config.CaseInsensitiveString;
 import com.thoughtworks.go.config.GoConfigDao;
 import com.thoughtworks.go.database.Database;
 import com.thoughtworks.go.domain.Pipeline;
@@ -151,7 +152,7 @@ public class PipelineSqlMapDaoTest {
         when(configFileDao.load()).thenReturn(GoConfigMother.configWithPipelines(pipelineName));
         when(sqlMapClientTemplate.queryForList("allActivePipelines")).thenReturn(new ArrayList<PipelineInstanceModel>());
 
-        PipelineInstanceModels models = pipelineSqlMapDao.loadActivePipelineInstancesFor(pipelineName);
+        PipelineInstanceModels models = pipelineSqlMapDao.loadActivePipelineInstancesFor(new CaseInsensitiveString(pipelineName));
 
         assertTrue(models.isEmpty());
     }
@@ -169,7 +170,7 @@ public class PipelineSqlMapDaoTest {
         when(sqlMapClientTemplate.queryForObject("getPipelineHistoryById", m("id", pimForP1_1.getId()))).thenReturn(pimForP1_1);
         when(sqlMapClientTemplate.queryForObject("getPipelineHistoryById", m("id", pimForP1_2.getId()))).thenReturn(pimForP1_2);
 
-        PipelineInstanceModels models = pipelineSqlMapDao.loadActivePipelineInstancesFor(p1);
+        PipelineInstanceModels models = pipelineSqlMapDao.loadActivePipelineInstancesFor(new CaseInsensitiveString(p1));
 
         assertThat(models.size(), is(2));
 

--- a/server/src/test-fast/java/com/thoughtworks/go/server/initializers/ApplicationInitializerTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/initializers/ApplicationInitializerTest.java
@@ -133,6 +133,8 @@ public class ApplicationInitializerTest {
     private SCMMaterialSource scmMaterialSource;
     @Mock
     private ResourceMonitoring resourceMonitoring;
+    @Mock
+    private PipelineLabelCorrector pipelineLabelCorrector;
     @InjectMocks
     ApplicationInitializer initializer = new ApplicationInitializer();
 

--- a/server/src/test-integration/java/com/thoughtworks/go/server/dao/PipelineSqlMapDaoIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/dao/PipelineSqlMapDaoIntegrationTest.java
@@ -78,6 +78,7 @@ import static com.thoughtworks.go.helper.MaterialsMother.svnMaterial;
 import static com.thoughtworks.go.helper.ModificationsMother.*;
 import static com.thoughtworks.go.server.dao.PersistentObjectMatchers.hasSameId;
 import static com.thoughtworks.go.util.GoConstants.DEFAULT_APPROVED_BY;
+import static com.thoughtworks.go.util.IBatisUtil.arguments;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.Matchers.*;
 import static org.hamcrest.core.Is.is;
@@ -85,6 +86,7 @@ import static org.hamcrest.core.IsCollectionContaining.hasItem;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
 import static org.hamcrest.core.IsNot.not;
 import static org.junit.Assert.*;
+
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(locations = {
@@ -1391,12 +1393,38 @@ public class PipelineSqlMapDaoIntegrationTest {
     }
 
     @Test
+    public void shouldPauseExistingPipelineCaseInsensitive() throws Exception {
+        PipelineConfig mingleConfig = PipelineMother.twoBuildPlansWithResourcesAndMaterials("some-pipeline", "dev");
+        schedulePipelineWithStages(mingleConfig);
+
+        pipelineDao.pause(mingleConfig.name().toString(), "cause", "by");
+
+        PipelinePauseInfo actual = pipelineDao.pauseState(mingleConfig.name().toString().toUpperCase());
+        PipelinePauseInfo expected = new PipelinePauseInfo(true, "cause", "by");
+
+        assertThat(actual, is(expected));
+    }
+
+    @Test
     public void shouldUnPauseAPausedPipeline() throws Exception {
         PipelineConfig mingleConfig = PipelineMother.twoBuildPlansWithResourcesAndMaterials("some-pipeline", "dev");
         schedulePipelineWithStages(mingleConfig);
         pipelineDao.pause(mingleConfig.name().toString(), "cause", "by");
 
         pipelineDao.unpause(mingleConfig.name().toString());
+
+        PipelinePauseInfo actual = pipelineDao.pauseState(mingleConfig.name().toString());
+        PipelinePauseInfo expected = new PipelinePauseInfo(false, null, null);
+        assertThat(actual, is(expected));
+    }
+
+    @Test
+    public void shouldUnPauseAPausedPipelineCaseInsensitive() throws Exception {
+        PipelineConfig mingleConfig = PipelineMother.twoBuildPlansWithResourcesAndMaterials("some-pipeline", "dev");
+        schedulePipelineWithStages(mingleConfig);
+        pipelineDao.pause(mingleConfig.name().toString(), "cause", "by");
+
+        pipelineDao.unpause(mingleConfig.name().toString().toUpperCase());
 
         PipelinePauseInfo actual = pipelineDao.pauseState(mingleConfig.name().toString());
         PipelinePauseInfo expected = new PipelinePauseInfo(false, null, null);
@@ -1426,6 +1454,17 @@ public class PipelineSqlMapDaoIntegrationTest {
     }
 
     @Test
+    public void shouldReturnCurrentPauseStateOfPipelineCaseInsensitive() throws Exception {
+        PipelineConfig mingleConfig = PipelineMother.twoBuildPlansWithResourcesAndMaterials("some-pipeline", "dev");
+        schedulePipelineWithStages(mingleConfig);
+
+        pipelineDao.pause(mingleConfig.name().toString(), "really good reason", "me");
+
+        PipelinePauseInfo actual = pipelineDao.pauseState(mingleConfig.name().toString().toUpperCase());
+        assertThat(actual, is(new PipelinePauseInfo(true, "really good reason", "me")));
+    }
+
+    @Test
     public void shouldUpdateCounter_WhenPipelineRowIsPresentWhichWasInsertedByPauseAction() {
         String pipelineName = "some-pipeline";
         PipelineConfig pipelineConfig = PipelineConfigMother.pipelineConfig(pipelineName);
@@ -1446,7 +1485,7 @@ public class PipelineSqlMapDaoIntegrationTest {
         Pipeline pipeline = dbHelper.newPipelineWithAllStagesPassed(pipelineConfig); // Counter is 1
         dbHelper.newPipelineWithAllStagesPassed(pipelineConfig); // Counter should be incremented
 
-        assertThat(pipelineDao.getCounterForPipeline(pipeline.getName()), is(pipeline.getCounter() + 1));
+        assertThat(pipelineDao.getCounterForPipeline(pipeline.getName().toUpperCase()), is(pipeline.getCounter() + 1));
     }
 
     @Test
@@ -1609,7 +1648,7 @@ public class PipelineSqlMapDaoIntegrationTest {
     }
 
     @Test
-            /* THIS IS A BUG IN VSM. STAGE RERUNS ARE NOT SUPPORTED AND DOWNSTREAMS SHOW THE RUNS MADE OUT OF PREVIOUS STAGE RUN. CHANGE TEST EXPECTATION WHEN BUG IS FIXED POST 13.2 [Mingle #7385] (DUCK & SACHIN) */
+    /* THIS IS A BUG IN VSM. STAGE RERUNS ARE NOT SUPPORTED AND DOWNSTREAMS SHOW THE RUNS MADE OUT OF PREVIOUS STAGE RUN. CHANGE TEST EXPECTATION WHEN BUG IS FIXED POST 13.2 [Mingle #7385] (DUCK & SACHIN) */
     public void shouldReturnListOfDownstreamPipelineIdentifiersForARunOfUpstreamPipeline_AlthoughUpstreamHasHadAStageReRun() throws Exception {
         GitMaterial g1 = u.wf(new GitMaterial("g1"), "folder3");
         u.checkinInOrder(g1, "g_1");
@@ -1728,6 +1767,23 @@ public class PipelineSqlMapDaoIntegrationTest {
 
         assertThat(getActivePipelinesForPipelineName(p1ReincarnatedWithDifferentCase).count(), is(1L));
         assertThat(getActivePipelinesForPipelineName(p1ReincarnatedWithDifferentCase).findFirst().get().getName(), is(p1ReincarnatedWithDifferentCase.config.name().toString()));
+    }
+
+    @Test
+    public void shouldRemoveDuplicateEntriesForPipelineCounterFromDbForAGivenPipelineName() throws SQLException {
+        String pipelineName = "Pipeline-Name";
+        configHelper.addPipeline(pipelineName, "stage-name");
+        pipelineDao.getSqlMapClient().insert("insertPipelineLabelCounter", arguments("pipelineName", pipelineName.toLowerCase()).and("count", 10).asMap());
+        pipelineDao.getSqlMapClient().insert("insertPipelineLabelCounter", arguments("pipelineName", pipelineName.toUpperCase()).and("count", 20).asMap());
+        pipelineDao.getSqlMapClient().insert("insertPipelineLabelCounter", arguments("pipelineName", pipelineName).and("count", 30).asMap());
+        assertThat(pipelineDao.getPipelineNamesWithMultipleEntriesForLabelCount().size(), is(1));
+        assertThat(pipelineDao.getPipelineNamesWithMultipleEntriesForLabelCount().get(0).equalsIgnoreCase(pipelineName), is(true));
+
+        pipelineDao.deleteOldPipelineLabelCountForPipeline(pipelineName);
+        assertThat(pipelineDao.getPipelineNamesWithMultipleEntriesForLabelCount().isEmpty(), is(true));
+        assertThat(pipelineDao.getCounterForPipeline(pipelineName), is(30));
+        assertThat(pipelineDao.getCounterForPipeline(pipelineName.toLowerCase()), is(30));
+        assertThat(pipelineDao.getCounterForPipeline(pipelineName.toUpperCase()), is(30));
     }
 
     private Stream<PipelineInstanceModel> getActivePipelinesForPipelineName(ScheduleTestUtil.AddedPipeline pipeline1) {

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/CachedCurrentActivityServiceIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/CachedCurrentActivityServiceIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 ThoughtWorks, Inc.
+ * Copyright 2018 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,6 +36,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
+
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(locations = {
         "classpath:WEB-INF/applicationContext-global.xml",
@@ -45,11 +46,16 @@ import static org.junit.Assert.assertThat;
 })
 public class CachedCurrentActivityServiceIntegrationTest {
 
-    @Autowired private CachedCurrentActivityService cachedCurrentActivityService;
-    @Autowired private MaterialRepository materialRepository;
-    @Autowired private GoConfigDao goConfigDao;
-    @Autowired private DatabaseAccessHelper dbHelper;
-    @Autowired private TransactionTemplate transactionTemplate;
+    @Autowired
+    private CachedCurrentActivityService cachedCurrentActivityService;
+    @Autowired
+    private MaterialRepository materialRepository;
+    @Autowired
+    private GoConfigDao goConfigDao;
+    @Autowired
+    private DatabaseAccessHelper dbHelper;
+    @Autowired
+    private TransactionTemplate transactionTemplate;
     @Rule
     public final TemporaryFolder temporaryFolder = new TemporaryFolder();
 
@@ -96,4 +102,9 @@ public class CachedCurrentActivityServiceIntegrationTest {
         assertThat(cachedCurrentActivityService.isStageActive(pipeline.getName(), "ft"), is(true));
     }
 
+    @Test
+    public void testShouldReturnTrueIfAStageIsActive_CaseInsensitive() {
+        Pipeline pipeline = fixture.createPipelineWithFirstStagePassedAndSecondStageRunning();
+        assertThat(cachedCurrentActivityService.isStageActive(pipeline.getName().toUpperCase(), "FT"), is(true));
+    }
 }

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/PipelineLabelCorrectorIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/PipelineLabelCorrectorIntegrationTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2018 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.server.service;
+
+import com.thoughtworks.go.config.GoConfigDao;
+import com.thoughtworks.go.server.cache.GoCache;
+import com.thoughtworks.go.server.dao.DatabaseAccessHelper;
+import com.thoughtworks.go.server.dao.PipelineSqlMapDao;
+import com.thoughtworks.go.server.persistence.MaterialRepository;
+import com.thoughtworks.go.util.GoConfigFileHelper;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import java.sql.SQLException;
+
+import static com.thoughtworks.go.util.IBatisUtil.arguments;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(locations = {
+        "classpath:WEB-INF/applicationContext-global.xml",
+        "classpath:WEB-INF/applicationContext-dataLocalAccess.xml",
+        "classpath:WEB-INF/applicationContext-acegi-security.xml",
+        "classpath:testPropertyConfigurer.xml"
+})
+public class PipelineLabelCorrectorIntegrationTest {
+    @Autowired private DatabaseAccessHelper dbHelper;
+    @Autowired private GoConfigDao goConfigDao;
+    @Autowired private PipelineSqlMapDao pipelineSqlMapDao;
+    @Autowired private PipelineLabelCorrector pipelineLabelCorrector;
+
+    private GoConfigFileHelper configHelper = new GoConfigFileHelper();
+
+    @Before
+    public void setUp() throws Exception {
+        configHelper.usingCruiseConfigDao(goConfigDao);
+        configHelper.onSetUp();
+        dbHelper.onSetUp();
+    }
+
+    @After
+    public void teardown() throws Exception {
+        dbHelper.onTearDown();
+        configHelper.onTearDown();
+    }
+
+    @Test
+    public void shouldRemoveDuplicateEntriesForPipelineCounterFromDbAndKeepTheOneMatchingPipelineNameCaseInConfig() throws SQLException {
+        String pipelineName = "Pipeline-Name";
+        configHelper.addPipeline(pipelineName, "stage-name");
+        pipelineSqlMapDao.getSqlMapClient().insert("insertPipelineLabelCounter", arguments("pipelineName", pipelineName.toLowerCase()).and("count", 10).asMap());
+        pipelineSqlMapDao.getSqlMapClient().insert("insertPipelineLabelCounter", arguments("pipelineName", pipelineName.toUpperCase()).and("count", 20).asMap());
+        pipelineSqlMapDao.getSqlMapClient().insert("insertPipelineLabelCounter", arguments("pipelineName", pipelineName).and("count", 30).asMap());
+        assertThat(pipelineSqlMapDao.getPipelineNamesWithMultipleEntriesForLabelCount().size(), is(1));
+        assertThat(pipelineSqlMapDao.getPipelineNamesWithMultipleEntriesForLabelCount().get(0).equalsIgnoreCase(pipelineName), is(true));
+
+        pipelineLabelCorrector.correctPipelineLabelCountEntries();
+        assertThat(pipelineSqlMapDao.getPipelineNamesWithMultipleEntriesForLabelCount().isEmpty(), is(true));
+        assertThat(pipelineSqlMapDao.getCounterForPipeline(pipelineName), is(30));
+        assertThat(pipelineSqlMapDao.getCounterForPipeline(pipelineName.toLowerCase()), is(30));
+        assertThat(pipelineSqlMapDao.getCounterForPipeline(pipelineName.toUpperCase()), is(30));
+    }
+}


### PR DESCRIPTION
For the context of this PR - renames are limited to renaming with a different case of the pipeline/stage/job. 

Issues fixed:
* Making old dashboard cache case-insensitive to make sure duplicate entries for pipeline-model are not being inserted into the cache if the pipeline is renamed
* Stage active check is performed before a pipeline can be triggered, making it case-insensitive else renaming a building pipeline did not make use of the same cache.
* Pipeline counter doesn't get reset upon change of case of pipeline-name
* Renaming(changing case) of a building pipeline used to show up as never-run on new-dashboard. It shows the existing state now.
* #1471, #3055 - These wouldn't happen again. Although the PR doesn't do anything to fix the data for existing pipeline runs. The issue wouldn't happen for future runs
* Fixed bug with pause/unpause API wherein it would incorrectly report that the pipeline has been paused/unpaused but wouldn't really change the stage in db it if this was invoked with a different case