### PR TITLE
Allow logged in users to access plugin infos api.

### DIFF
--- a/server/webapp/WEB-INF/rails.new/app/controllers/api_v3/admin/plugin_infos_controller.rb
+++ b/server/webapp/WEB-INF/rails.new/app/controllers/api_v3/admin/plugin_infos_controller.rb
@@ -18,6 +18,8 @@ module ApiV3
   module Admin
     class PluginInfosController < BaseController
 
+      before_action :check_user_and_401
+
       PLUGIN_TYPES_FOR_VERSION = [
         PluginConstants.AUTHORIZATION_EXTENSION,
         PluginConstants.ELASTIC_AGENT_EXTENSION,
@@ -27,8 +29,6 @@ module ApiV3
         PluginConstants.PACKAGE_MATERIAL_EXTENSION,
         PluginConstants.CONFIG_REPO_EXTENSION
       ]
-
-      before_action :check_admin_user_or_group_admin_user_and_401
 
       def index
         plugin_infos = default_plugin_info_finder.allPluginInfos(params[:type]).reject do |combined_plugin_info|

--- a/server/webapp/WEB-INF/rails.new/app/controllers/api_v4/admin/plugin_infos_controller.rb
+++ b/server/webapp/WEB-INF/rails.new/app/controllers/api_v4/admin/plugin_infos_controller.rb
@@ -18,6 +18,8 @@ module ApiV4
   module Admin
     class PluginInfosController < BaseController
 
+      before_action :check_user_and_401
+
       PLUGIN_TYPES_FOR_VERSION = [
         PluginConstants.AUTHORIZATION_EXTENSION,
         PluginConstants.ELASTIC_AGENT_EXTENSION,

--- a/server/webapp/WEB-INF/rails.new/spec/controllers/api_v3/admin/plugin_infos_controller_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/controllers/api_v3/admin/plugin_infos_controller_spec.rb
@@ -39,19 +39,14 @@ describe ApiV3::Admin::PluginInfosController do
         expect(controller).to allow_action(:get, :show)
       end
 
-      it 'should disallow non-admin user, with security enabled' do
+      it 'should allow non-admin user, with security enabled' do
         enable_security
         login_as_user
-        expect(controller).to disallow_action(:get, :show, {:id => 'plugin_id'}).with(401, 'You are not authorized to perform this action.')
+        expect(controller).to allow_action(:get, :show, {:id => 'plugin_id'})
       end
 
       it 'should allow admin users, with security enabled' do
         login_as_admin
-        expect(controller).to allow_action(:get, :show)
-      end
-
-      it 'should allow pipeline group admin users, with security enabled' do
-        login_as_group_admin
         expect(controller).to allow_action(:get, :show)
       end
     end
@@ -62,19 +57,14 @@ describe ApiV3::Admin::PluginInfosController do
         expect(controller).to allow_action(:get, :index)
       end
 
-      it 'should disallow non-admin user, with security enabled' do
+      it 'should allow non-admin user, with security enabled' do
         enable_security
         login_as_user
-        expect(controller).to disallow_action(:get, :index).with(401, 'You are not authorized to perform this action.')
+        expect(controller).to allow_action(:get, :index)
       end
 
       it 'should allow admin users, with security enabled' do
         login_as_admin
-        expect(controller).to allow_action(:get, :index)
-      end
-
-      it 'should allow pipeline group admin users, with security enabled' do
-        login_as_group_admin
         expect(controller).to allow_action(:get, :index)
       end
     end

--- a/server/webapp/WEB-INF/rails.new/spec/controllers/api_v4/admin/plugin_infos_controller_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/controllers/api_v4/admin/plugin_infos_controller_spec.rb
@@ -32,6 +32,44 @@ describe ApiV4::Admin::PluginInfosController do
 
   end
 
+  describe "security" do
+    describe "show" do
+      it 'should allow anyone, with security disabled' do
+        disable_security
+        expect(controller).to allow_action(:get, :show)
+      end
+
+      it 'should allow non-admin user, with security enabled' do
+        enable_security
+        login_as_user
+        expect(controller).to allow_action(:get, :show, {:id => 'plugin_id'})
+      end
+
+      it 'should allow admin users, with security enabled' do
+        login_as_admin
+        expect(controller).to allow_action(:get, :show)
+      end
+    end
+
+    describe "index" do
+      it 'should allow anyone, with security disabled' do
+        disable_security
+        expect(controller).to allow_action(:get, :index)
+      end
+
+      it 'should allow non-admin user, with security enabled' do
+        enable_security
+        login_as_user
+        expect(controller).to allow_action(:get, :index)
+      end
+
+      it 'should allow admin users, with security enabled' do
+        login_as_admin
+        expect(controller).to allow_action(:get, :index)
+      end
+    end
+  end
+
   describe "index" do
     before(:each) do
       login_as_group_admin


### PR DESCRIPTION
This is done because it serves as a means to get plugin images and other
stuff that's needed on the agents page and other pages where plugin
icons are needed.