### PR TITLE
Fix broken analytics drilldown mechanism by namespacing models and managing them in one place

### DIFF
--- a/server/webapp/WEB-INF/rails.new/spec/webpack/lib/plugin_endpoint_spec.js
+++ b/server/webapp/WEB-INF/rails.new/spec/webpack/lib/plugin_endpoint_spec.js
@@ -51,6 +51,7 @@
   afterEach(() => {
     window.postMessage = origPostMessage;
     window.addEventListener = origListener;
+    PluginEndpoint.reset();
   });
 
   it("should send response for matching request", (done) => {

--- a/server/webapp/WEB-INF/rails.new/spec/webpack/models/shared/analytics_interaction_manager_spec.js
+++ b/server/webapp/WEB-INF/rails.new/spec/webpack/models/shared/analytics_interaction_manager_spec.js
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2018 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+function noop() {}
+
+function mockEvent(message) {
+  const event = {};
+  event.source = window;
+  event.origin = "null";
+  event.data = message;
+  return event;
+}
+
+function fakeReq(key, body) {
+  return {head: {type: "request", reqId: 0, key}, body};
+}
+
+const _                 = require("lodash");
+const AnalyticsEndpoint = require("rails-shared/plugin-endpoint");
+const Interactions      = require("models/shared/analytics_interaction_manager");
+
+const BASE64_RE         = /^[A-Za-z0-9/+]+(?:[=]{1,2})?$/;
+
+describe("AnalyticsInteractionManager", () => {
+  beforeEach(() => {
+    AnalyticsEndpoint.reset();
+    Interactions.purge();
+  });
+
+  afterEach(() => {
+    Interactions.purge();
+    AnalyticsEndpoint.reset();
+  });
+
+  it("ensure() should set up request handlers", () => {
+    let fireEvent;
+
+    spyOn(window, "open").and.returnValue({focus: noop});
+
+    spyOn(window, "addEventListener").and.callFake((name, fn, _bool) => {
+      if ("message" === name) { fireEvent = fn; }
+    });
+
+    spyOn(window, "postMessage").and.callFake((message, _origin) => {
+      fireEvent(mockEvent(message));
+    });
+
+    Interactions.ensure();
+    AnalyticsEndpoint.ensure("v1");
+
+    window.postMessage(fakeReq("go.cd.analytics.v1.link-external", {url: "https://google.com"}));
+    expect(window.open).toHaveBeenCalledWith("https://google.com", "_blank");
+  });
+
+  describe("Namespaces", () => {
+    it("group() reports the namespace", () => {
+      const Models = Interactions.ns("Namespacely");
+      expect(Models.group()).toBe("Namespacely");
+    });
+
+    it("uid() generates a predictable, unique value based on content", () => {
+      const Models = Interactions.ns("Namespacely");
+      const ordinal = 5, plugin = "ohai", type = "lolcat", id = "canhas";
+      const uid = Models.uid(ordinal, plugin, type, id);
+
+      expect(typeof uid).toBe("string", "uid() should always output a string");
+      expect(uid.startsWith("Namespacely:")).toBe(true, "uids should be namespaced");
+      expect(uid.replace(/^Namespacely:/, "").match(BASE64_RE)).not.toBe(null, "the uid body is a base64 output");
+    });
+
+    it("unpack() reverses uid() to its source data", () => {
+      const Models = Interactions.ns("Namespacely");
+      const ordinal = 5, plugin = "ohai", type = "lolcat", id = "canhas";
+      const uid = Models.uid(ordinal, plugin, type, id);
+
+      expect(Models.unpack(uid)).toEqual({ordinal, plugin, type, id}, "unpack() returns an object with original source values");
+    });
+
+    it("toUrl() constructs an analytics URL based on uid", () => {
+      const Models = Interactions.ns("Namespacely");
+      const ordinal = 5, plugin = "ohai", type = "lolcat", id = "canhas";
+      const uid = Models.uid(ordinal, plugin, type, id);
+
+      expect(Models.toUrl(uid)).toBe("/go/analytics/ohai/lolcat/canhas");
+      expect(Models.toUrl(uid, {chzbrgr: "absolutely"})).toBe("/go/analytics/ohai/lolcat/canhas?chzbrgr=absolutely", "toUrl() converts extra params to query paramters");
+    });
+
+    it("toUrl() constructs an analytics URL based on uid", () => {
+      const Models = Interactions.ns("Namespacely");
+      const ordinal = 5, plugin = "ohai", type = "lolcat", id = "canhas";
+      const uid = Models.uid(ordinal, plugin, type, id);
+
+      expect(Models.toUrl(uid)).toBe("/go/analytics/ohai/lolcat/canhas");
+      expect(Models.toUrl(uid, {chzbrgr: "absolutely"})).toBe("/go/analytics/ohai/lolcat/canhas?chzbrgr=absolutely", "toUrl() converts extra params to query paramters");
+    });
+
+    it("modelFor() idempotently ensures a model exists for a given uid", () => {
+      const Models = Interactions.ns("Namespacely");
+      const ordinal = 5, plugin = "ohai", type = "lolcat", id = "canhas";
+      const uid = Models.uid(ordinal, plugin, type, id);
+
+      const model = Models.modelFor(uid);
+      expect(model.url()).toBe(Models.toUrl(uid), "modelFor() returns a model preconfigured to a specific analytics plugin frame");
+      expect(Models.modelFor(uid)).toEqual(model, "modelFor() should be return the existing model for a given uid");
+    });
+
+    it("modelFor() takes an optional params arg to append to the url", () => {
+      const Models = Interactions.ns("Namespacely");
+      const ordinal = 5, plugin = "ohai", type = "lolcat", id = "canhas";
+      const uid = Models.uid(ordinal, plugin, type, id);
+
+      const model = Models.modelFor(uid, {hi: "there"});
+      expect(model.url()).toBe(Models.toUrl(uid, {hi: "there"}), "modelFor() should append query params");
+      expect(Models.modelFor(uid, {shouldNot: "change"}).url()).toBe(Models.toUrl(uid, {hi: "there"}), "subsequent calls to modelFor() do not alter query params of url once model has been constructed");
+    });
+
+    it("all() returns models pertaining only to a given namespace", () => {
+      const M1 = Interactions.ns("Alpha");
+      const M2 = Interactions.ns("Beta");
+      const plugin = "ohai", type = "lolcat", id = "canhas";
+      const table = [
+        [M1, 0, plugin, type, id],
+        [M1, 1, plugin, type, id],
+        [M2, 0, plugin, type, id],
+        [M2, 1, plugin, type, id]
+      ];
+
+      const world = {};
+
+      for (let i = 0, len = table.length; i < len; i++) {
+        const ns = table[i][0], args = table[i].slice(1);
+        const uid = ns.uid.apply(null, args);
+        world[uid] = ns.modelFor(uid);
+      }
+
+      const expectedAlpha = _.reduce(world, (m, v, k) => { if (k.startsWith("Alpha")) {m[k] = v;} return m; }, {});
+      const expectedBeta = _.reduce(world, (m, v, k) => { if (k.startsWith("Beta")) {m[k] = v;} return m; }, {});
+
+      expect(Object.keys(M1.all()).length).toBe(2, "all() returned wrong number of models returned from the Alpha namespace");
+      expect(M1.all()).toEqual(expectedAlpha, "all() should return the entire subset of models under the Alpha namespace");
+
+      expect(Object.keys(M2.all()).length).toBe(2, "all() returned wrong number of models returned from the Beta namespace");
+      expect(M2.all()).toEqual(expectedBeta, "all() should return the entire subset of models under the Beta namespace");
+
+      expect(Interactions.all()).toEqual(world, "AnalyticsInteractionManager.all() returns the global set");
+    });
+  });
+});

--- a/server/webapp/WEB-INF/rails.new/spec/webpack/models/shared/frame_spec.js
+++ b/server/webapp/WEB-INF/rails.new/spec/webpack/models/shared/frame_spec.js
@@ -23,8 +23,6 @@ function FakeWindow() {
   };
 }
 
-function noop() {}
-
 const TEST_URL = "http://test.tld/path";
 
 describe("Frame", () => {
@@ -34,7 +32,7 @@ describe("Frame", () => {
     it("should only pass through ui=test query parameter", () => {
 
       const mockWindow = new FakeWindow();
-      const f = new Frame(noop, mockWindow);
+      const f = new Frame(mockWindow);
       f.view(TEST_URL);
 
       mockWindow.withQuery("?ui");

--- a/server/webapp/WEB-INF/rails.new/spec/webpack/views/analytics/pipeline_metrics_spec.js
+++ b/server/webapp/WEB-INF/rails.new/spec/webpack/views/analytics/pipeline_metrics_spec.js
@@ -21,7 +21,11 @@ describe("Pipeline Dashboard Metrics", () => {
   const PipelineMetrics = require('views/analytics/pipeline_metrics');
 
   let $root, root;
-  const supportedMetrics = ["plugin-id-x", "plugin-id-y"];
+  const supportedMetrics = {
+    "plugin-id-x": [{type: "pipeline", id: "metric-1"}],
+    "plugin-id-y": [{type: "pipeline", id: "metric-1"}]
+  };
+
   const pipelineList = ["p1", "p2", "p3"];
 
   beforeEach(() => {
@@ -51,8 +55,8 @@ describe("Pipeline Dashboard Metrics", () => {
 
     const requests = jasmine.Ajax.requests;
     expect(requests.count()).toBe(2);
-    expect(requests.at(0).url).toBe('/go/analytics/plugin-id-x/dashboard/pipeline_duration?pipeline_name=p1&context=dashboard');
-    expect(requests.at(1).url).toBe('/go/analytics/plugin-id-y/dashboard/pipeline_duration?pipeline_name=p1&context=dashboard');
+    expect(requests.at(0).url).toBe('/go/analytics/plugin-id-x/pipeline/metric-1?pipeline_name=p1&context=dashboard');
+    expect(requests.at(1).url).toBe('/go/analytics/plugin-id-y/pipeline/metric-1?pipeline_name=p1&context=dashboard');
   });
 
   it('should change displayed graphs when new pipeline is selected', () => {
@@ -61,16 +65,16 @@ describe("Pipeline Dashboard Metrics", () => {
     $root.find("select").val("p2").trigger("change");
     const requests = jasmine.Ajax.requests;
     expect(requests.count()).toBe(4);
-    expect(requests.at(2).url).toBe('/go/analytics/plugin-id-x/dashboard/pipeline_duration?pipeline_name=p2&context=dashboard');
-    expect(requests.at(3).url).toBe('/go/analytics/plugin-id-y/dashboard/pipeline_duration?pipeline_name=p2&context=dashboard');
+    expect(requests.at(2).url).toBe('/go/analytics/plugin-id-x/pipeline/metric-1?pipeline_name=p2&context=dashboard');
+    expect(requests.at(3).url).toBe('/go/analytics/plugin-id-y/pipeline/metric-1?pipeline_name=p2&context=dashboard');
   });
 
-  const mount = (pipelines, plugins) => {
+  const mount = (pipelines, metrics) => {
     m.mount(root, {
       view() {
         return m(PipelineMetrics, {
           pipelines,
-          plugins
+          metrics
         });
       }
     });

--- a/server/webapp/WEB-INF/rails.new/webpack/models/shared/analytics_interaction_manager.js
+++ b/server/webapp/WEB-INF/rails.new/webpack/models/shared/analytics_interaction_manager.js
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2018 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+(function () {
+  "use strict";
+
+  const Requests = require("rails-shared/plugin-endpoint-request-handler");
+  const Frame    = require("models/shared/frame");
+  const Routes   = require("gen/js-routes");
+
+  function Namespace(models, name) {
+    const prefix = `${encodeURIComponent(name)}:`;
+
+    function withPrefix(u) {
+      return prefix + u;
+    }
+
+    function withoutPrefix(u) {
+      return u.split(":").pop();
+    }
+
+    function encodeUID(i, p, t, id) {
+      return withPrefix(btoa(JSON.stringify({plugin: p, type: t, id, ordinal: i})));
+    }
+
+    function decodeUID(uid) {
+      return JSON.parse(atob(withoutPrefix(uid)));
+    }
+
+    this.uid = encodeUID;
+    this.unpack = decodeUID;
+
+    this.group = function group() {
+      return name;
+    };
+
+    this.all = function allModelsInNamespace() {
+      const result = {};
+      for (const k in models) {
+        if (k.startsWith(prefix)) { result[k] = models[k]; }
+      }
+      return result;
+    };
+
+    function toUrl(uid, params={}) {
+      const c = decodeUID(uid);
+      return Routes.showAnalyticsPath(c.plugin, c.type, c.id, params);
+    }
+
+    this.toUrl = toUrl;
+
+    this.modelFor = function modelFor(uid, extraParams={}) {
+      let model = models[uid];
+
+      if (!model) {
+        model = models[uid] = new Frame();
+        model.url(toUrl(uid, extraParams));
+      }
+
+      return model;
+    };
+  }
+
+  /**
+   * AnalyticsInteractionManager should be a singleton that handles
+   * the bootstrapping of parent page communication channel, which
+   * includings things like listener definitions and Frame model
+   * management.
+   */
+  function AnalyticsInteractionManager() {
+    const models = {};
+
+    this.purge = function destroyAll() {
+      for (const k in models) {
+        delete models[k];
+      }
+    };
+
+    this.all = function allModels() {
+      // returns the whole world.
+      //
+      // shallow copy prevents unauthorized writes to
+      // `models` internal structure
+      return Object.assign({}, models);
+    };
+
+    this.ns = function namespace(name) {
+      return new Namespace(models, name);
+    };
+
+    this.ensure = function ensure() {
+      Requests.defineLinkHandler();
+      Requests.defineFetchAnalyticsHandler(models);
+      return this;
+    };
+  }
+
+  module.exports = new AnalyticsInteractionManager();
+})();

--- a/server/webapp/WEB-INF/rails.new/webpack/models/shared/frame.js
+++ b/server/webapp/WEB-INF/rails.new/webpack/models/shared/frame.js
@@ -43,27 +43,29 @@
     return url;
   }
 
-  function Frame(callback, self=window) {
+  function Frame(self=window) {
     const url = Stream();
     const view = Stream();
     const data = Stream();
-    const pluginId = Stream();
     const errors = Stream();
 
-    function load() {
+    function load(before, after) {
       errors(null);
 
       $.ajax({
         url: url(),
         type: "GET",
-        dataType: "json"
+        dataType: "json",
+        beforeSend: "function" === typeof before && before
       }).done((r) => {
         data(r.data);
         view(r.view_path);
       }).fail((xhr) => {
         errors(xhr);
       }).always(() => {
-        callback();
+        if ("function" === typeof after) {
+          after();
+        }
       });
     }
 
@@ -91,7 +93,7 @@
       return view(value);
     }
 
-    (Object.assign || $.extend)(this, {url, view: viewWithToggles, data, load, fetch, pluginId, errors});
+    (Object.assign || $.extend)(this, {url, view: viewWithToggles, data, load, fetch, errors});
   }
 
   module.exports = Frame;

--- a/server/webapp/WEB-INF/rails.new/webpack/rails-shared/plugin-endpoint.js
+++ b/server/webapp/WEB-INF/rails.new/webpack/rails-shared/plugin-endpoint.js
@@ -247,6 +247,17 @@
   }
 
   var AnalyticsEndpoint = {
+    reset: function reset() {
+      HANDLERS = {},
+      attached = false,
+      uid = undefined,
+      pluginId = undefined,
+
+      REQUEST_ID_SEQ = 0,
+      PENDING_REQUESTS = new RequestTable();
+
+      window.removeEventListener("message", dispatch);
+    },
     ensure: function ensure(version) {
       VERSION = validateVersion(version);
 

--- a/server/webapp/WEB-INF/rails.new/webpack/views/analytics/analytics_widget.js.msx
+++ b/server/webapp/WEB-INF/rails.new/webpack/views/analytics/analytics_widget.js.msx
@@ -20,23 +20,17 @@ const TabsVM          = require('views/analytics/models/tabs_view_model');
 const GlobalMetrics   = require('views/analytics/global_metrics');
 const PipelineMetrics = require('views/analytics/pipeline_metrics');
 
-
 const AnalyticsWidget = {
   oninit(vnode) {
-    const self = vnode.state;
-    self.vm    = new TabsVM();
+    vnode.state.vm = new TabsVM();
   },
 
   view(vnode) {
-    const self = vnode.state;
-    const vm   = self.vm;
+    const vm = vnode.state.vm;
 
-    let analyticsMetric;
-    if (vm.isGlobalTabSelected()) {
-      analyticsMetric = (<GlobalMetrics metrics={vnode.attrs.metrics}/>);
-    } else {
-      analyticsMetric = (<PipelineMetrics pipelines={vnode.attrs.pipelines} plugins={vnode.attrs.plugins}/>);
-    }
+    const analyticsMetric = vm.isGlobalTabSelected() ?
+      <GlobalMetrics metrics={vnode.attrs.globalMetrics}/> :
+      <PipelineMetrics pipelines={vnode.attrs.pipelines} metrics={vnode.attrs.pipelineMetrics}/>;
 
     return (<div class="analytics-main-container">
       <div class="header-panel">

--- a/server/webapp/WEB-INF/rails.new/webpack/views/analytics/global_metrics.js.msx
+++ b/server/webapp/WEB-INF/rails.new/webpack/views/analytics/global_metrics.js.msx
@@ -20,41 +20,24 @@
   const m = require("mithril");
   const $ = require("jquery");
 
-  const PluginEndpointRequestHandler = require('rails-shared/plugin-endpoint-request-handler');
-  const PluginEndpoint               = require('rails-shared/plugin-endpoint');
-  const Frame                        = require('models/shared/frame');
-  const AnalyticsiFrameWidget        = require('views/shared/analytics_iframe_widget');
-  const Routes                       = require('gen/js-routes');
-
-  const models = {};
-
-  PluginEndpointRequestHandler.defineLinkHandler();
-  PluginEndpointRequestHandler.defineFetchAnalyticsHandler(models);
-
-  function ensureModel(uid, pluginId, type, id) {
-    let model = models[uid];
-
-    if (!model) {
-      model = models[uid] = new Frame(m.redraw);
-      model.url(Routes.showAnalyticsPath(pluginId, type, id)); // eslint-disable-line camelcase
-    }
-
-    return model;
-  }
+  const init                  = require("rails-shared/plugin-endpoint").init;
+  const AnalyticsiFrameWidget = require("views/shared/analytics_iframe_widget");
+  const Interactions          = require("models/shared/analytics_interaction_manager");
+  const Models                = Interactions.ensure().ns("GlobalMetrics");
 
   const GlobalMetrics = {
-    view(vnode) { // eslint-disable-line no-unused-vars
-      const frames = [];
+    view(vnode) {
+      const elements = [];
       $.each(vnode.attrs.metrics, (pluginId, supportedAnalytics) => {
         $.each(supportedAnalytics, (idx, sa) => {
-          const uid   = `f-${pluginId}:${sa.id}:${idx}`,
+          const uid   = Models.uid(idx, pluginId, sa.type, sa.id),
                 title = sa.title,
-                model = ensureModel(uid, pluginId, sa.type, sa.id);
+                model = Models.modelFor(uid);
 
-          frames.push(m(AnalyticsiFrameWidget, {model, pluginId, uid, title, init: PluginEndpoint.init}));
+          elements.push(m(AnalyticsiFrameWidget, {model, pluginId, uid, title, init}));
         });
       });
-      return frames;
+      return elements;
     }
   };
 

--- a/server/webapp/WEB-INF/rails.new/webpack/views/analytics/pipeline_metrics.js.msx
+++ b/server/webapp/WEB-INF/rails.new/webpack/views/analytics/pipeline_metrics.js.msx
@@ -21,72 +21,64 @@
   const $ = require("jquery");
   const _ = require('lodash');
 
-  const PluginEndpointRequestHandler = require('rails-shared/plugin-endpoint-request-handler');
-  const PluginEndpoint               = require('rails-shared/plugin-endpoint');
-  const AnalyticsiFrameWidget        = require('views/shared/analytics_iframe_widget');
-  const Frame                        = require('models/shared/frame');
-  const Routes                       = require('gen/js-routes');
+  const Interactions          = require("models/shared/analytics_interaction_manager");
+  const Models                = Interactions.ensure().ns("PipelineMetrics");
+  const init                  = require("rails-shared/plugin-endpoint").init;
 
-  const models = {};
+  const AnalyticsiFrameWidget = require('views/shared/analytics_iframe_widget');
+
+  function pipelineParams(pipeline) {
+    return {pipeline_name: pipeline, context: "dashboard"}; // eslint-disable-line camelcase
+  }
+
   let currentPipeline = null;
 
-  PluginEndpointRequestHandler.defineFetchAnalyticsHandler(models);
-
-  const PipelineMetrics = function() {
-    let data = null;
-
-    function oninit(vnode) {
-      data = vnode.attrs;
+  const PipelineDropdown = {
+    oninit(vnode) {
       if (!currentPipeline) {
         currentPipeline = vnode.attrs.pipelines[0];
       }
-    }
+    },
 
-    function newFrame(pluginId) {
-      const frame = new Frame(m.redraw);
-      frame.pluginId(pluginId);
-      frame.url(Routes.showAnalyticsPath(pluginId, "dashboard", "pipeline_duration", {pipeline_name: currentPipeline, context: "dashboard"})); // eslint-disable-line camelcase
-      return frame;
-    }
-
-    function dropdown() {
-      const pipelineOptions = _.map(data.pipelines, (pipeline) => {
-        if (pipeline === currentPipeline) {
-          return (<option selected>{pipeline}</option>);
-        } else {
-          return (<option>{pipeline}</option>);
-        }
+    view(vnode) {
+      const pipelineOptions = _.map(vnode.attrs.pipelines, (pipeline) => {
+        return <option selected={pipeline === currentPipeline}>{pipeline}</option>;
       });
 
       const select = m("select", {
-        onchange: function() { // eslint-disable-line object-shorthand
+        onchange() {
           currentPipeline = $(this).val();
-          $.each(models, (uid, model) => {
-            models[uid] = newFrame(model.pluginId());
+          $.each(Models.all(), (uid, m) => {
+            m.url(Models.toUrl(uid, pipelineParams(currentPipeline)));
           });
         }
       }, pipelineOptions);
 
-      return (<div class="chart-pipeline-selector">Analytics For Pipeline: {select} </div>);
+      return <div class="chart-pipeline-selector">Analytics For Pipeline: {select}</div>;
     }
+  };
 
-    function view(vnode) { // eslint-disable-line no-unused-vars
-      const pageItems = [];
-      pageItems.push(dropdown());
+  const PipelineMetrics = {
+    oninit(vnode) {
+      if (!currentPipeline) {
+        currentPipeline = vnode.attrs.pipelines[0];
+      }
+    },
 
-      $.each(data.plugins, (idx, pluginId) => { // eslint-disable-line no-unused-vars
-        const uid = `f-${pluginId}:pipeline:${idx}`;
-        let model = models[uid];
-        if (!model) {
-          model = models[uid] = newFrame(pluginId);
-        }
+    view(vnode) {
+      const elements = [<PipelineDropdown pipelines={vnode.attrs.pipelines}/>];
 
-        pageItems.push(m(AnalyticsiFrameWidget, {model, pluginId, uid, title: "Pipeline Build Time", init: PluginEndpoint.init}));
+      $.each(vnode.attrs.metrics, (pluginId, supportedAnalytics) => {
+        $.each(supportedAnalytics, (idx, sa) => {
+          const uid   = Models.uid(idx, pluginId, sa.type, sa.id),
+                title = sa.title,
+                model = Models.modelFor(uid, pipelineParams(currentPipeline));
+
+          elements.push(m(AnalyticsiFrameWidget, {model, pluginId, uid, title, init}));
+        });
       });
-
-      return pageItems;
+      return elements;
     }
-    return {view, oninit};
   };
 
   module.exports = PipelineMetrics;

--- a/server/webapp/WEB-INF/rails.new/webpack/views/dashboard/pipeline_analytics_widget.js.msx
+++ b/server/webapp/WEB-INF/rails.new/webpack/views/dashboard/pipeline_analytics_widget.js.msx
@@ -16,44 +16,40 @@
 
 const m = require('mithril');
 
-const PluginEndpoint               = require('rails-shared/plugin-endpoint');
-const Modal                        = require('views/shared/new_modal');
-const Routes                       = require('gen/js-routes');
-const AnalyticsiFrameWidget        = require('views/shared/analytics_iframe_widget');
-const PluginEndpointRequestHandler = require('rails-shared/plugin-endpoint-request-handler');
-const Frame                        = require('models/shared/frame');
 
+const Interactions          = require("models/shared/analytics_interaction_manager");
+const Models                = Interactions.ensure().ns("PipelineMetrics");
+const init                  = require("rails-shared/plugin-endpoint").init;
 
-const models = {};
-PluginEndpointRequestHandler.defineLinkHandler();
-PluginEndpointRequestHandler.defineFetchAnalyticsHandler(models);
+const Modal                 = require("views/shared/new_modal");
+const AnalyticsiFrameWidget = require("views/shared/analytics_iframe_widget");
+const AnalyticsEndpoint     = require("rails-shared/plugin-endpoint");
 
 function createModal(pluginId, metricId, pipeline) {
-  const model = new Frame(m.redraw),
-    uid = `f-${pluginId}:pipeline:0`;
-  models[uid] = model;
-  PluginEndpoint.ensure("v1");
+  const uid = Models.uid(0, pluginId, "pipeline", metricId),
+      model = Models.modelFor(uid),
+     params = { pipeline_name: pipeline.name }; // eslint-disable-line camelcase
 
-  model.pluginId(pluginId);
-  model.url(Routes.showAnalyticsPath(pluginId, "pipeline", metricId, {
-    pipeline_name: pipeline.name,  // eslint-disable-line camelcase
-    key:           "analytics.pipeline-chart"
-  }));
+  model.url(Models.toUrl(uid, params));
+
+  AnalyticsEndpoint.ensure("v1");
+
   const modal = new Modal({
     size:    "analytics-modal",
-    title:   `Analytics`,
-    body:    () => (m(AnalyticsiFrameWidget, {model, uid, title: "Pipeline Build Time", pluginId, init: PluginEndpoint.init})),
+    title:   "Analytics",
+    body:    () => (m(AnalyticsiFrameWidget, {model, uid, title: "Pipeline Build Time", pluginId, init})),
     onclose: () => modal.destroy(),
     buttons: []
   });
+
   modal.render();
 }
 
 const PipelineAnalyticsWidget = {
-  view: (vnode) => {
+  view(vnode) {
     return m("a", {
-      class:   "pipeline-analytics",
-      onclick: () => {
+      class: "pipeline-analytics",
+      onclick() {
         createModal(vnode.attrs.pluginId, vnode.attrs.metricId, vnode.attrs.pipeline);
       }
     });

--- a/server/webapp/WEB-INF/rails.new/webpack/views/shared/analytics_iframe_widget.js.msx
+++ b/server/webapp/WEB-INF/rails.new/webpack/views/shared/analytics_iframe_widget.js.msx
@@ -19,7 +19,6 @@
 
   const m = require("mithril");
 
-
   const AnalyticsiFrameWidget = function () {
     let currentUrl = null;
 
@@ -27,8 +26,16 @@
       const iframe = vnode.dom.querySelector("iframe"),
          container = vnode.dom;
 
+      function beforeLoad() {
+        container.classList.add("loading-analytics");
+      }
+
+      function afterLoad() {
+        container.classList.remove("loading-analytics");
+        m.redraw();
+      }
+
       iframe.onload = function initContent() {
-        vnode.dom.classList.remove("loading-analytics");
         vnode.attrs.init(iframe.contentWindow, {
           uid:         vnode.attrs.uid,
           pluginId:    vnode.attrs.pluginId,
@@ -38,8 +45,7 @@
 
       currentUrl = vnode.attrs.model.url();
 
-      container.classList.add("loading-analytics");
-      vnode.attrs.model.load();
+      vnode.attrs.model.load(beforeLoad, afterLoad);
     }
 
     function oncreate(vnode) {


### PR DESCRIPTION
### Context: (i.e. why such a big change to fix this?)

`PluginEndpointRequestHandler.defineFetchAnalyticsHandler(models)` was being called twice in a page; while this is not bad in and of itself, it was called with a different `models` reference, which ended up clobbering the model cache, thereby causing model lookups to fail when serving `fetch-analytics`.

Sure, I could have just removed the second invocation, and called it a day. However, I felt this was a deeper problem with the design.

The `defineFetchAnalytics()` method was called within the context of a widget/component that dealt with rendering charts for the analytics dashboard. Naturally, one would want to ensure all dependent mechanisms were set up, so it's understandable that one would think to bootstrap all of this within that widget. It's not obvious that this would cause failures everywhere else.

My point is, the design of how these components talk to each other, and where responsibilities are split lended itself to breaking the app, and we should fix the design so that things like this don't happen so easily.

Now that that's out of the way, here are the changes:

1. Introduce `AnalyticsInteractionManager`
    - Responsible for:
        - Setting up listeners: `AnalyticsInteractionManager.ensure()`
        - Managing models within a page.
    - Model management is hidden and centralized so there is no way to accidentally overwrite the cache. However, it is also namespaceable so that widgets only need concern themselves with the models they manage. A good example is the analytics dashboard; global charts don't concern themselves with pipeline charts, and vice-versa.

        > `AnalyticsInteractionManager.ns("SomeName")` yields a `Namespace` object.

    - Model/iframe `uid`s are now standardized, and the `Namespace` objects will generate them for you.
        - `uid`s are predictable and deterministic (calculable from the given parameters). In fact, they can be decoded back into the source information, which makes it convenient to build URLs and do other tasks that are specific to a plugin.
        - `Namespace` abstract model construction via the `modelFor()` method. It returns a preconfigured model for a particular iframe.
2. Split out `PipelineDropdown` component from `PipelineMetrics`
3. `Frame` no longer takes a callback during construction. `Frame.load(before, after)` now takes hooks to fire before and after data load, which is convenient for managing things like spinners and calls to `m.redraw()`.