### PR TITLE
fix empty environment variables in config repo

### DIFF
--- a/server/src/main/java/com/thoughtworks/go/config/ConfigConverter.java
+++ b/server/src/main/java/com/thoughtworks/go/config/ConfigConverter.java
@@ -119,7 +119,10 @@ public class ConfigConverter {
         if (crEnvironmentVariable.hasEncryptedValue()) {
             return new EnvironmentVariableConfig(cipher, crEnvironmentVariable.getName(), crEnvironmentVariable.getEncryptedValue());
         } else {
-            return new EnvironmentVariableConfig(crEnvironmentVariable.getName(), crEnvironmentVariable.getValue());
+            String value = crEnvironmentVariable.getValue();
+            if(StringUtils.isBlank(value))
+                value = "";
+            return new EnvironmentVariableConfig(crEnvironmentVariable.getName(), value);
         }
     }
 

--- a/server/src/test-fast/java/com/thoughtworks/go/config/ConfigConverterTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/config/ConfigConverterTest.java
@@ -149,6 +149,15 @@ public class ConfigConverterTest {
     }
 
     @Test
+    public void shouldConvertNullEnvironmentVariableWhenNotSecure() {
+        CREnvironmentVariable crEnvironmentVariable = new CREnvironmentVariable("key1", null);
+        EnvironmentVariableConfig result = configConverter.toEnvironmentVariableConfig(crEnvironmentVariable);
+        assertThat(result.getValue(), is(""));
+        assertThat(result.getName(), is("key1"));
+        assertThat(result.isSecure(), is(false));
+    }
+
+    @Test
     public void shouldConvertEnvironmentVariableWhenSecure() {
         CREnvironmentVariable crEnvironmentVariable = new CREnvironmentVariable("key1", null, "encryptedvalue");
         EnvironmentVariableConfig result = configConverter.toEnvironmentVariableConfig(crEnvironmentVariable);


### PR DESCRIPTION
When config repo plugin returns null for value for environment variable we will treat it as empty variable `""`.
Fixes #4673