### PR TITLE
Optimization of `GoDashboardCurrentStateLoader`

### DIFF
--- a/common/src/main/java/com/thoughtworks/go/presentation/pipelinehistory/PipelineInstanceModels.java
+++ b/common/src/main/java/com/thoughtworks/go/presentation/pipelinehistory/PipelineInstanceModels.java
@@ -16,20 +16,16 @@
 
 package com.thoughtworks.go.presentation.pipelinehistory;
 
-import java.util.List;
-
 import com.thoughtworks.go.domain.BaseCollection;
 import com.thoughtworks.go.server.util.Pagination;
+
+import java.util.List;
 
 public class PipelineInstanceModels extends BaseCollection<PipelineInstanceModel> {
     private Pagination pagination;
 
-    private PipelineInstanceModels(PipelineInstanceModel[] instances) {
+    private PipelineInstanceModels(PipelineInstanceModel... instances) {
         super(instances);
-    }
-
-    public static PipelineInstanceModels createPipelineInstanceModels() {
-        return new PipelineInstanceModels(new PipelineInstanceModel[]{});
     }
 
     public static PipelineInstanceModels createPipelineInstanceModels(PipelineInstanceModel... instances) {

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/CaseInsensitiveString.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/CaseInsensitiveString.java
@@ -20,6 +20,7 @@ import org.apache.commons.lang.StringUtils;
 
 import java.io.Serializable;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -111,7 +112,7 @@ public class CaseInsensitiveString implements Comparable<CaseInsensitiveString>,
         return caseInsensitiveStrings(Arrays.asList(roles));
     }
 
-    public static List<String> toStringList(List<CaseInsensitiveString> strings) {
+    public static List<String> toStringList(Collection<CaseInsensitiveString> strings) {
         return toStringList(strings.stream());
     }
 

--- a/server/src/test-fast/java/com/thoughtworks/go/server/dashboard/GoDashboardCurrentStateLoaderTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/dashboard/GoDashboardCurrentStateLoaderTest.java
@@ -408,6 +408,20 @@ public class GoDashboardCurrentStateLoaderTest {
         assertThat(model.getTrackingTool(), is(Optional.of(mingleConfig.asTrackingTool())));
     }
 
+    @Test
+    public void shouldNotReloadFromDBIfListOfPipelinesHasNotChanged() {
+        PipelineConfig p1Config = goConfigMother.addPipelineWithGroup(config, "group1", "pipeline1", "stage1", "job1");
+        PipelineInstanceModel pimForP1 = pim(p1Config);
+
+        when(pipelineSqlMapDao.loadHistoryForDashboard(CaseInsensitiveString.toStringList(p1Config.getName()))).thenReturn(createPipelineInstanceModels(pimForP1));
+
+        loader.allPipelines(config);
+        goConfigMother.addStageToPipeline(config, p1Config.getName().toString(), "someStage", "someJob");
+        loader.allPipelines(config);
+
+        verify(pipelineSqlMapDao, times(1)).loadHistoryForDashboard(CaseInsensitiveString.toStringList(p1Config.getName()));
+    }
+
     private void assertModel(GoDashboardPipeline pipeline, String group, PipelineInstanceModel... pims) {
         assertThat(pipeline.groupName(), is(group));
         assertThat(pipeline.model().getName(), is(pims[0].getName()));

--- a/server/src/test-integration/java/com/thoughtworks/go/server/dashboard/GoDashboardCurrentStateLoaderIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/dashboard/GoDashboardCurrentStateLoaderIntegrationTest.java
@@ -24,6 +24,7 @@ import com.thoughtworks.go.domain.StageState;
 import com.thoughtworks.go.helper.PipelineConfigMother;
 import com.thoughtworks.go.presentation.pipelinehistory.EmptyPipelineInstanceModel;
 import com.thoughtworks.go.presentation.pipelinehistory.NullStageHistoryItem;
+import com.thoughtworks.go.presentation.pipelinehistory.PipelineInstanceModels;
 import com.thoughtworks.go.server.dao.DatabaseAccessHelper;
 import com.thoughtworks.go.server.dao.PipelineDao;
 import com.thoughtworks.go.server.service.GoConfigService;
@@ -89,6 +90,7 @@ public class GoDashboardCurrentStateLoaderIntegrationTest {
         configHelper.onSetUp();
 
         goConfigService.forceNotifyListeners();
+        goDashboardCurrentStateLoader.reset();
     }
 
     @After


### PR DESCRIPTION
Do not perform the DB query to load pipelines if list of pipelines has
not changed.

A further optimization would be to load from the DB, only the pipelines
that have been newly added. Pipelines that have been removed do not
require a DB call, and we can simply purge those from the
`historyForDashboard` instance variable.