### PR TITLE
[New Dashboard] Do not truncate longer pipeline name (#4698)

### DIFF
--- a/server/webapp/WEB-INF/rails.new/app/assets/new_stylesheets/single_page_apps/new_dashboard.scss
+++ b/server/webapp/WEB-INF/rails.new/app/assets/new_stylesheets/single_page_apps/new_dashboard.scss
@@ -647,12 +647,10 @@ body {
 }
 
 .pipeline_name {
-  font-size:     14px;
-  font-weight:   600;
-  margin:        0 5px 5px 0;
-  white-space:   nowrap;
-  overflow:      hidden;
-  text-overflow: ellipsis;
+  font-size:   14px;
+  font-weight: 600;
+  margin:      0 5px 5px 0;
+  word-break:  break-all;
 }
 
 .pipeline_sub_header {

--- a/server/webapp/WEB-INF/rails.new/spec/webpack/views/dashboard/pipeline_widget_spec.js
+++ b/server/webapp/WEB-INF/rails.new/spec/webpack/views/dashboard/pipeline_widget_spec.js
@@ -94,10 +94,6 @@ describe("Dashboard Pipeline Widget", () => {
       expect($root.find('.pipeline_name')).toContainText('up42');
     });
 
-    it("should show pipeline name on hover", () => {
-      expect($root.find('.pipeline_name').get(0).title).toEqual('up42');
-    });
-
     it("should link history to pipeline history page", () => {
       expect($root.find('.pipeline_header>div>a')).toContainText('History');
       const expectedPath = `/go/tab/pipeline/history/${pipelinesJson[0].name}`;

--- a/server/webapp/WEB-INF/rails.new/webpack/views/dashboard/pipeline_header_widget.js.msx
+++ b/server/webapp/WEB-INF/rails.new/webpack/views/dashboard/pipeline_header_widget.js.msx
@@ -68,7 +68,7 @@ const PipelineHeaderWidget = {
     return (
       <div class="pipeline_header">
         <div class="pipeline_sub_header">
-          <h3 className="pipeline_name" title={pipeline.name}> {pipeline.name} </h3>
+          <h3 className="pipeline_name">{pipeline.name}</h3>
           <div className="pipeline_actions">
             {analyticsIcons}
             {settingsButton}


### PR DESCRIPTION
* Show the entire pipeline name with wrapped words.
* Remove onhover pipeline name tooltip as the entire pipeline name is visible

![screen shot 2018-05-07 at 10 31 58 am](https://user-images.githubusercontent.com/15275847/39685663-cffefe24-51e1-11e8-98fd-472ca6c8fb8e.png)
