### PR TITLE
Return before adding the WWW-Authenticate header only for unauthenticated API XHRs. (#4682)

### DIFF
--- a/server/src/main/java/com/thoughtworks/go/server/security/GoExceptionTranslationFilter.java
+++ b/server/src/main/java/com/thoughtworks/go/server/security/GoExceptionTranslationFilter.java
@@ -48,7 +48,7 @@ public class GoExceptionTranslationFilter extends ExceptionTranslationFilter {
         HttpServletResponse httpResponse = (HttpServletResponse) response;
 
         //TODO: This is a hack for bug #3175, we should revisit this code in V2.0
-        if (isJson(httpRequest) || isJsonFormat(httpRequest) || isAnApiRequest(httpRequest)) {
+        if (isJson(httpRequest) || isJsonFormat(httpRequest) || isAnApiXhrRequest(httpRequest)) {
             httpResponse.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
             return;
         }
@@ -74,7 +74,7 @@ public class GoExceptionTranslationFilter extends ExceptionTranslationFilter {
 
     private AuthenticationEntryPoint determineAuthenticationPoint(HttpServletRequest httpRequest) {
         AuthenticationEntryPoint point = getAuthenticationEntryPoint();
-        if (isJsonp(httpRequest)) {
+        if (isJsonp(httpRequest) || isAnApiRequest(httpRequest)) {
             return basicAuthenticationEntryPoint;
         }
         return point;
@@ -82,6 +82,14 @@ public class GoExceptionTranslationFilter extends ExceptionTranslationFilter {
 
     private boolean isAnApiRequest(HttpServletRequest httpRequest) {
         return httpRequest.getRequestURI().startsWith("/go/api/");
+    }
+
+    private boolean isAXhrRequest(HttpServletRequest httpRequest) {
+        return "XMLHttpRequest".equalsIgnoreCase(httpRequest.getHeader("X-Requested-With"));
+    }
+
+    private boolean isAnApiXhrRequest(HttpServletRequest httpRequest) {
+        return isAnApiRequest(httpRequest) && isAXhrRequest(httpRequest);
     }
 
     private boolean isJsonFormat(HttpServletRequest httpRequest) {

--- a/server/src/test-fast/java/com/thoughtworks/go/server/security/GoExceptionTranslationFilterTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/security/GoExceptionTranslationFilterTest.java
@@ -32,8 +32,7 @@ import org.springframework.security.ui.basicauth.BasicProcessingFilterEntryPoint
 
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 
 
 public class GoExceptionTranslationFilterTest {
@@ -71,10 +70,22 @@ public class GoExceptionTranslationFilterTest {
     }
 
     @Test
-    public void shouldSetStatusAs401ForApiRequest() throws ServletException, IOException {
+    public void shouldSetStatusAs401ForApiXhrRequest() throws ServletException, IOException {
+        request.setRequestURI("/go/api/server_health_messages");
+        request.addHeader("X-Requested-With", "XMLHttpRequest");
+
+        filter.sendStartAuthentication(request, response, filterChain, authenticationException);
+
+        assertThat(response.getStatus(), is(HttpServletResponse.SC_UNAUTHORIZED));
+        verify(basicAuth, never()).commence(request, response, authenticationException);
+    }
+
+    @Test
+    public void shouldUseBasicProcessingFilterEntryPointForApiRequests() throws ServletException, IOException {
         request.setRequestURI("/go/api/server_health_messages");
         filter.sendStartAuthentication(request, response, filterChain, authenticationException);
-        assertThat(response.getStatus(), is(HttpServletResponse.SC_UNAUTHORIZED));
+
+        verify(basicAuth).commence(request, response, authenticationException);
     }
 
     @Test


### PR DESCRIPTION
* Use the BasicProcessingFilterEntryPoint to respond for non XHR API requests that are unauthenticated.