### PR TITLE
Pipeline case insensitivity part2

### DIFF
--- a/common/src/main/java/com/thoughtworks/go/serverhealth/HealthStateScope.java
+++ b/common/src/main/java/com/thoughtworks/go/serverhealth/HealthStateScope.java
@@ -42,19 +42,21 @@ public class HealthStateScope implements Comparable<HealthStateScope> {
     }
 
     public static HealthStateScope forPipeline(String pipelineName) {
-        return new HealthStateScope(ScopeType.PIPELINE, pipelineName);
+        return new HealthStateScope(ScopeType.PIPELINE, pipelineName.toLowerCase());
     }
 
     public static HealthStateScope forFanin(String pipelineName) {
-        return new HealthStateScope(ScopeType.FANIN, pipelineName);
+        return new HealthStateScope(ScopeType.FANIN, pipelineName.toLowerCase());
     }
 
     public static HealthStateScope forStage(String pipelineName, String stageName) {
-        return new HealthStateScope(ScopeType.STAGE, pipelineName + "/" + stageName);
+        String scope = pipelineName + "/" + stageName;
+        return new HealthStateScope(ScopeType.STAGE, scope.toLowerCase());
     }
 
     public static HealthStateScope forJob(String pipelineName, String stageName, String jobName) {
-        return new HealthStateScope(ScopeType.JOB, pipelineName + "/" + stageName + "/" + jobName);
+        String scope = pipelineName + "/" + stageName + "/" + jobName;
+        return new HealthStateScope(ScopeType.JOB, scope.toLowerCase());
     }
 
     public static HealthStateScope forMaterial(Material material) {

--- a/common/src/test/java/com/thoughtworks/go/domain/JobIdentifierTest.java
+++ b/common/src/test/java/com/thoughtworks/go/domain/JobIdentifierTest.java
@@ -1,18 +1,18 @@
-/*************************GO-LICENSE-START*********************************
- * Copyright 2014 ThoughtWorks, Inc.
+/*
+ * Copyright 2018 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *************************GO-LICENSE-END***********************************/
+ */
 
 package com.thoughtworks.go.domain;
 
@@ -53,7 +53,7 @@ public class JobIdentifierTest {
         assertThat(id.artifactLocator("consoleoutput/log.xml"),
                 is("cruise/1234/dev/1/linux-firefox-1/consoleoutput/log.xml"));
     }
-    
+
     @Test
     public void shouldFixFilePathWithPrecedingSlash() {
         JobIdentifier id = new JobIdentifier("cruise", 1234, "1.0.1234", "dev", "1", "linux-firefox-1", 100L);
@@ -102,4 +102,12 @@ public class JobIdentifierTest {
 
         assertThat(context.hasProperty("GO_RERUN_OF_STAGE_COUNTER"), is(true));
     }
+
+    @Test
+    public void equalsShouldBeCaseInsensitive() {
+        JobIdentifier jobIdentifier1 = new JobIdentifier("pipeline-name", 10, "label-10", "stage-name", "2", "build-name");
+        JobIdentifier jobIdentifier2 = new JobIdentifier("PIPELINE-NAME", 10, "label-10", "STAGE-NAME", "2", "BUILD-NAME");
+        assertThat(jobIdentifier1, is(jobIdentifier2));
+    }
+
 }

--- a/common/src/test/java/com/thoughtworks/go/domain/PipelineIdentifierTest.java
+++ b/common/src/test/java/com/thoughtworks/go/domain/PipelineIdentifierTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 ThoughtWorks, Inc.
+ * Copyright 2018 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,5 +39,10 @@ public class PipelineIdentifierTest {
     public void shouldReturnURN() throws Exception {
         PipelineIdentifier identifier = new PipelineIdentifier("cruise", 1, "label-1");
         assertThat(identifier.asURN(), is("urn:x-go.studios.thoughtworks.com:job-id:cruise:1"));
+    }
+
+    @Test
+    public void equalsShouldBeCaseInsensitive(){
+        assertThat(new PipelineIdentifier("pipeline", 1, "label-1"), is(new PipelineIdentifier("PIPELINE", 1, "label-1")));
     }
 }

--- a/common/src/test/java/com/thoughtworks/go/domain/StageIdentifierTest.java
+++ b/common/src/test/java/com/thoughtworks/go/domain/StageIdentifierTest.java
@@ -1,27 +1,28 @@
-/*************************GO-LICENSE-START*********************************
- * Copyright 2014 ThoughtWorks, Inc.
+/*
+ * Copyright 2018 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *************************GO-LICENSE-END***********************************/
+ */
 
 package com.thoughtworks.go.domain;
 
+import org.junit.Assert;
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.not;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
-import static org.hamcrest.Matchers.not;
-import org.junit.Assert;
 import static org.junit.Assert.assertThat;
-import org.junit.Test;
 
 public class StageIdentifierTest {
 
@@ -74,10 +75,10 @@ public class StageIdentifierTest {
         StageIdentifier stage3 = new StageIdentifier("blahPipeline", 1, "blahStage", "1");
         StageIdentifier stage4 = new StageIdentifier("blahPipeline", 1, "blahStage", "2");
 
-        assertThat(stage1,is(stage2));
-        assertThat(stage1,is(stage3));
-        assertThat(stage2,is(stage3));
-        assertThat(stage2,is(not(stage4)));
+        assertThat(stage1, is(stage2));
+        assertThat(stage1, is(stage3));
+        assertThat(stage2, is(stage3));
+        assertThat(stage2, is(not(stage4)));
     }
 
 
@@ -85,5 +86,10 @@ public class StageIdentifierTest {
     public void shouldReturnURN() throws Exception {
         StageIdentifier id = new StageIdentifier("cruise", 1, "dev", "1");
         assertThat(id.asURN(), is("urn:x-go.studios.thoughtworks.com:stage-id:cruise:1:dev:1"));
+    }
+
+    @Test
+    public void equalsShouldBeCaseInsensitive() {
+        assertThat(new StageIdentifier("pipeline", 1, "stage", "1"), is(new StageIdentifier("PIPELINE", 1, "STAGE", "1")));
     }
 }

--- a/common/src/test/java/com/thoughtworks/go/serverhealth/HealthStateScopeTest.java
+++ b/common/src/test/java/com/thoughtworks/go/serverhealth/HealthStateScopeTest.java
@@ -33,27 +33,68 @@ public class HealthStateScopeTest {
     private static final SvnMaterial MATERIAL1 = MaterialsMother.svnMaterial("url1");
     private static final SvnMaterial MATERIAL2 = MaterialsMother.svnMaterial("url2");
 
-    @Test public void shouldHaveAUniqueScopeForEachMaterial() throws Exception {
+    @Test
+    public void shouldHaveAUniqueScopeForEachMaterial() throws Exception {
         HealthStateScope scope1 = HealthStateScope.forMaterial(MATERIAL1);
         HealthStateScope scope2 = HealthStateScope.forMaterial(MATERIAL1);
         assertThat(scope1, is(scope2));
     }
 
-    @Test public void shouldHaveDifferentScopeForDifferentMaterials() throws Exception {
+    @Test
+    public void shouldHaveDifferentScopeForDifferentMaterials() throws Exception {
         HealthStateScope scope1 = HealthStateScope.forMaterial(MATERIAL1);
         HealthStateScope scope2 = HealthStateScope.forMaterial(MATERIAL2);
         assertThat(scope1, not(scope2));
     }
 
-    @Test public void shouldHaveUniqueScopeForStages() throws Exception {
-        HealthStateScope scope1 = HealthStateScope.forStage("blahPipeline","blahStage");
-        HealthStateScope scope2 = HealthStateScope.forStage("blahPipeline","blahStage");
-        HealthStateScope scope25 = HealthStateScope.forStage("blahPipeline","blahOtherStage");
-        HealthStateScope scope3 = HealthStateScope.forStage("blahOtherPipeline","blahOtherStage");
+    @Test
+    public void shouldHaveUniqueScopeForStages() throws Exception {
+        HealthStateScope scope1 = HealthStateScope.forStage("blahPipeline", "blahStage");
+        HealthStateScope scope2 = HealthStateScope.forStage("blahPipeline", "blahStage");
+        HealthStateScope scope25 = HealthStateScope.forStage("blahPipeline", "blahOtherStage");
+        HealthStateScope scope3 = HealthStateScope.forStage("blahOtherPipeline", "blahOtherStage");
+        HealthStateScope scope4 = HealthStateScope.forStage("BLAHPIPELINE", "BLAHSTAGE");
 
         assertThat(scope1, is(scope2));
+        assertThat(scope1, is(scope4));
         assertThat(scope1, not(scope25));
         assertThat(scope1, not(scope3));
+    }
+
+    @Test
+    public void shouldHaveUniqueScopeForPipeline() throws Exception {
+        HealthStateScope scope1 = HealthStateScope.forPipeline("blahPipeline");
+        HealthStateScope scope2 = HealthStateScope.forPipeline("blahpipeline");
+        HealthStateScope scope3 = HealthStateScope.forPipeline("BLAHPIPELINE");
+        HealthStateScope scope4 = HealthStateScope.forPipeline("something-else");
+
+        assertThat(scope1, is(scope2));
+        assertThat(scope1, is(scope3));
+        assertThat(scope1, not(scope4));
+    }
+
+    @Test
+    public void shouldHaveUniqueScopeForFanin() throws Exception {
+        HealthStateScope scope1 = HealthStateScope.forFanin("blahPipeline");
+        HealthStateScope scope2 = HealthStateScope.forFanin("blahpipeline");
+        HealthStateScope scope3 = HealthStateScope.forFanin("BLAHPIPELINE");
+        HealthStateScope scope4 = HealthStateScope.forFanin("something-else");
+
+        assertThat(scope1, is(scope2));
+        assertThat(scope1, is(scope3));
+        assertThat(scope1, not(scope4));
+    }
+
+    @Test
+    public void shouldHaveUniqueScopeForJon() throws Exception {
+        HealthStateScope scope1 = HealthStateScope.forJob("Blah", "Stage", "Job");
+        HealthStateScope scope2 = HealthStateScope.forJob("blah", "stage", "job");
+        HealthStateScope scope3 = HealthStateScope.forJob("BLAH", "STAGE", "JOB");
+        HealthStateScope scope4 = HealthStateScope.forJob("something-else", "something-else", "something-else");
+
+        assertThat(scope1, is(scope2));
+        assertThat(scope1, is(scope3));
+        assertThat(scope1, not(scope4));
     }
 
     @Test
@@ -61,28 +102,27 @@ public class HealthStateScopeTest {
         HgMaterialConfig hgMaterialConfig = MaterialConfigsMother.hgMaterialConfig();
         CruiseConfig config = GoConfigMother.pipelineHavingJob("blahPipeline", "blahStage", "blahJob", "fii", "baz");
         config.pipelineConfigByName(new CaseInsensitiveString("blahPipeline")).addMaterialConfig(hgMaterialConfig);
-        assertThat(HealthStateScope.forMaterialConfig(hgMaterialConfig).isRemovedFromConfig(config),is(false));
-        assertThat(HealthStateScope.forMaterial(MaterialsMother.svnMaterial("file:///bar")).isRemovedFromConfig(config),is(true));
+        assertThat(HealthStateScope.forMaterialConfig(hgMaterialConfig).isRemovedFromConfig(config), is(false));
+        assertThat(HealthStateScope.forMaterial(MaterialsMother.svnMaterial("file:///bar")).isRemovedFromConfig(config), is(true));
     }
 
     @Test
     public void shouldRemoveScopeWhenStageIsRemovedFromConfig() throws Exception {
         CruiseConfig config = GoConfigMother.pipelineHavingJob("blahPipeline", "blahStage", "blahJob", "fii", "baz");
-        assertThat(HealthStateScope.forPipeline("fooPipeline").isRemovedFromConfig(config),is(true));
-        assertThat(HealthStateScope.forPipeline("blahPipeline").isRemovedFromConfig(config),is(false));
+        assertThat(HealthStateScope.forPipeline("fooPipeline").isRemovedFromConfig(config), is(true));
+        assertThat(HealthStateScope.forPipeline("blahPipeline").isRemovedFromConfig(config), is(false));
 
-        assertThat(HealthStateScope.forStage("fooPipeline","blahStage").isRemovedFromConfig(config),is(true));
-        assertThat(HealthStateScope.forStage("blahPipeline","blahStageRemoved").isRemovedFromConfig(config),is(true));
-        assertThat(HealthStateScope.forStage("blahPipeline","blahStage").isRemovedFromConfig(config),is(false));
-
+        assertThat(HealthStateScope.forStage("fooPipeline", "blahStage").isRemovedFromConfig(config), is(true));
+        assertThat(HealthStateScope.forStage("blahPipeline", "blahStageRemoved").isRemovedFromConfig(config), is(true));
+        assertThat(HealthStateScope.forStage("blahPipeline", "blahStage").isRemovedFromConfig(config), is(false));
     }
 
     @Test
     public void shouldRemoveScopeWhenJobIsRemovedFromConfig() throws Exception {
         CruiseConfig config = GoConfigMother.pipelineHavingJob("blahPipeline", "blahStage", "blahJob", "fii", "baz");
 
-        assertThat(HealthStateScope.forJob("fooPipeline","blahStage", "barJob").isRemovedFromConfig(config),is(true));
-        assertThat(HealthStateScope.forJob("blahPipeline", "blahStage", "blahJob").isRemovedFromConfig(config),is(false));
+        assertThat(HealthStateScope.forJob("fooPipeline", "blahStage", "barJob").isRemovedFromConfig(config), is(true));
+        assertThat(HealthStateScope.forJob("blahPipeline", "blahStage", "blahJob").isRemovedFromConfig(config), is(false));
     }
 
     @Test

--- a/domain/src/main/java/com/thoughtworks/go/domain/JobIdentifier.java
+++ b/domain/src/main/java/com/thoughtworks/go/domain/JobIdentifier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 ThoughtWorks, Inc.
+ * Copyright 2018 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -172,7 +172,7 @@ public class JobIdentifier implements Serializable, LocatableEntity {
         if (buildId != null ? !buildId.equals(that.buildId) : that.buildId != null) {
             return false;
         }
-        if (buildName != null ? !buildName.equals(that.buildName) : that.buildName != null) {
+        if (buildName != null ? !buildName.equalsIgnoreCase(that.buildName) : that.buildName != null) {
             return false;
         }
         if (pipelineCounter != null ? !pipelineCounter.equals(that.pipelineCounter) : that.pipelineCounter != null) {
@@ -181,13 +181,13 @@ public class JobIdentifier implements Serializable, LocatableEntity {
         if (pipelineLabel != null ? !pipelineLabel.equals(that.pipelineLabel) : that.pipelineLabel != null) {
             return false;
         }
-        if (pipelineName != null ? !pipelineName.equals(that.pipelineName) : that.pipelineName != null) {
+        if (pipelineName != null ? !pipelineName.equalsIgnoreCase(that.pipelineName) : that.pipelineName != null) {
             return false;
         }
         if (stageCounter != null ? !stageCounter.equals(that.stageCounter) : that.stageCounter != null) {
             return false;
         }
-        if (stageName != null ? !stageName.equals(that.stageName) : that.stageName != null) {
+        if (stageName != null ? !stageName.equalsIgnoreCase(that.stageName) : that.stageName != null) {
             return false;
         }
 

--- a/domain/src/main/java/com/thoughtworks/go/domain/PipelineIdentifier.java
+++ b/domain/src/main/java/com/thoughtworks/go/domain/PipelineIdentifier.java
@@ -1,18 +1,18 @@
-/*************************GO-LICENSE-START*********************************
- * Copyright 2014 ThoughtWorks, Inc.
+/*
+ * Copyright 2018 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *************************GO-LICENSE-END***********************************/
+ */
 
 package com.thoughtworks.go.domain;
 
@@ -92,7 +92,7 @@ public class PipelineIdentifier implements Serializable {
         if (label != null ? !label.equals(that.label) : that.label != null) {
             return false;
         }
-        if (name != null ? !name.equals(that.name) : that.name != null) {
+        if (name != null ? !name.equalsIgnoreCase(that.name) : that.name != null) {
             return false;
         }
 

--- a/domain/src/main/java/com/thoughtworks/go/domain/StageIdentifier.java
+++ b/domain/src/main/java/com/thoughtworks/go/domain/StageIdentifier.java
@@ -134,13 +134,13 @@ public class StageIdentifier implements Serializable, LocatableEntity {
         if (pipelineCounter != null ? !pipelineCounter.equals(that.pipelineCounter) : that.pipelineCounter != null) {
             return false;
         }
-        if (pipelineName != null ? !pipelineName.equals(that.pipelineName) : that.pipelineName != null) {
+        if (pipelineName != null ? !pipelineName.equalsIgnoreCase(that.pipelineName) : that.pipelineName != null) {
             return false;
         }
         if (stageCounter != null ? !stageCounter.equals(that.stageCounter) : that.stageCounter != null) {
             return false;
         }
-        if (stageName != null ? !stageName.equals(that.stageName) : that.stageName != null) {
+        if (stageName != null ? !stageName.equalsIgnoreCase(that.stageName) : that.stageName != null) {
             return false;
         }
 

--- a/domain/src/main/java/com/thoughtworks/go/domain/Stages.java
+++ b/domain/src/main/java/com/thoughtworks/go/domain/Stages.java
@@ -64,7 +64,7 @@ public class Stages extends BaseCollection<Stage> implements StageContainer {
 
     public Stage byName(String name) {
         for (Stage stage : this) {
-            if (name.equals(stage.getName())) {
+            if (name.equalsIgnoreCase(stage.getName())) {
                 return stage;
             }
         }

--- a/server/src/main/java/com/thoughtworks/go/server/dao/PipelineSqlMapDao.java
+++ b/server/src/main/java/com/thoughtworks/go/server/dao/PipelineSqlMapDao.java
@@ -229,7 +229,7 @@ public class PipelineSqlMapDao extends SqlMapClientDaoSupport implements Initial
     }
 
     private String latestSuccessfulStageCacheKey(String pipelineName, String stageName) {
-        return (PipelineSqlMapDao.class.getName() + "_latestSuccessfulStage_" + pipelineName + "-" + stageName).intern();
+        return (PipelineSqlMapDao.class.getName() + "_latestSuccessfulStage_" + pipelineName + "-" + stageName).toLowerCase().intern();
     }
 
     public void updatePauseInfo(Pipeline pipeline) {

--- a/server/src/main/java/com/thoughtworks/go/server/dao/StageSqlMapDao.java
+++ b/server/src/main/java/com/thoughtworks/go/server/dao/StageSqlMapDao.java
@@ -164,8 +164,8 @@ public class StageSqlMapDao extends SqlMapClientDaoSupport implements StageDao, 
     }
 
 
-    private String cacheKeyForStageCount(String pipelineName, String stageName) {
-        return String.format("%s_numberOfStages_%s_<>_%s", getClass().getName(), pipelineName, stageName).intern();
+    protected String cacheKeyForStageCount(String pipelineName, String stageName) {
+        return String.format("%s_numberOfStages_%s_<>_%s", getClass().getName(), pipelineName, stageName).toLowerCase().intern();
     }
 
     public Stages getStagesByPipelineId(long pipelineId) {
@@ -209,12 +209,12 @@ public class StageSqlMapDao extends SqlMapClientDaoSupport implements StageDao, 
 
     private String cacheKeyForListOfStageIdentifiers(StageIdentifier stageIdentifier) {
         return String.format("%s_stageRunIdentifier_%s_%s_%s", getClass().getName(), stageIdentifier.getPipelineName(), stageIdentifier.getPipelineCounter(),
-                stageIdentifier.getStageName()).intern();
+                stageIdentifier.getStageName()).toLowerCase().intern();
     }
 
     private String cacheKeyForStageIdentifier(StageIdentifier stageIdentifier) {
         return String.format("%s_stageIdentifier_%s_%s_%s_%s", getClass().getName(), stageIdentifier.getPipelineName(), stageIdentifier.getPipelineCounter(),
-                stageIdentifier.getStageName(), stageIdentifier.getStageCounter()).intern();
+                stageIdentifier.getStageName(), stageIdentifier.getStageCounter()).toLowerCase().intern();
     }
 
     public long getExpectedDurationMillis(String pipelineName, String stageName, JobInstance job) {
@@ -349,7 +349,7 @@ public class StageSqlMapDao extends SqlMapClientDaoSupport implements StageDao, 
     }
 
     private String cacheKeyForAllStageOfPipeline(String pipelineName, Integer pipelineCounter, String stageName) {
-        return String.format(getClass().getName() + "_allStageOfPipeline_%s_%s_%s", pipelineName, pipelineCounter, stageName).intern();
+        return String.format(getClass().getName() + "_allStageOfPipeline_%s_%s_%s", pipelineName, pipelineCounter, stageName).toLowerCase().intern();
     }
 
     public List<Stage> findStageHistoryForChart(String pipelineName, String stageName, int pageSize, int offset) {
@@ -460,15 +460,15 @@ public class StageSqlMapDao extends SqlMapClientDaoSupport implements StageDao, 
     }
 
     private String mutexForStageHistory(String pipelineName, String stageName) {
-        return String.format("%s_stageHistoryMutex_%s_<>_%s", getClass().getName(), pipelineName, stageName).intern();
+        return String.format("%s_stageHistoryMutex_%s_<>_%s", getClass().getName(), pipelineName, stageName).toLowerCase().intern();
     }
 
     private String cacheKeyForStageHistories(String pipelineName, String stageName) {
-        return String.format("%s_stageHistories_%s_<>_%s", getClass().getName(), pipelineName, stageName).intern();
+        return String.format("%s_stageHistories_%s_<>_%s", getClass().getName(), pipelineName, stageName).toLowerCase().intern();
     }
 
     private String cacheKeyForDetailedStageHistories(String pipelineName, String stageName) {
-        return String.format("%s_detailedStageHistories_%s_<>_%s", getClass().getName(), pipelineName, stageName).intern();
+        return String.format("%s_detailedStageHistories_%s_<>_%s", getClass().getName(), pipelineName, stageName).toLowerCase().intern();
     }
 
     public Long findStageIdByPipelineAndStageNameAndCounter(long pipelineId, String name, String counter) {
@@ -523,7 +523,7 @@ public class StageSqlMapDao extends SqlMapClientDaoSupport implements StageDao, 
     }
 
     private String cacheKeyForStageOffset(Stage stage) {
-        return String.format("%s_stageOffsetMap_%s_<>_%s", getClass().getName(), stage.getIdentifier().getPipelineName(), stage.getIdentifier().getStageName()).intern();
+        return String.format("%s_stageOffsetMap_%s_<>_%s", getClass().getName(), stage.getIdentifier().getPipelineName(), stage.getIdentifier().getStageName()).toLowerCase().intern();
     }
 
     private List<StageFeedEntry> findForFeed(String baseQuery, FeedModifier modifier, long transitionId, int pageSize) {
@@ -668,7 +668,7 @@ public class StageSqlMapDao extends SqlMapClientDaoSupport implements StageDao, 
     }
 
     private String cacheKeyForPipelineAndStage(String pipelineName, String stageName) {
-        return String.format("%s_isStageActive_%s_%s", StageSqlMapDao.class.getName(), pipelineName.toLowerCase(), stageName.toLowerCase()).intern();
+        return String.format("%s_isStageActive_%s_%s", StageSqlMapDao.class.getName(), pipelineName, stageName).toLowerCase().intern();
     }
 
     public Stages findAllStagesFor(String pipelineName, int counter) {
@@ -696,7 +696,7 @@ public class StageSqlMapDao extends SqlMapClientDaoSupport implements StageDao, 
     }
 
     private String cacheKeyForPipelineAndCounter(String pipelineName, int counter) {
-        String key = StageSqlMapDao.class.getName() + "_allStagesOfPipelineInstance_" + pipelineName + "_" + counter;
+        String key = StageSqlMapDao.class.getName() + "_allStagesOfPipelineInstance_" + pipelineName.toLowerCase() + "_" + counter;
         return key.intern();
     }
 
@@ -716,7 +716,7 @@ public class StageSqlMapDao extends SqlMapClientDaoSupport implements StageDao, 
     }
 
     private String cacheKeyForStageCountForGraph(String pipelineName, String stageName) {
-        return String.format("%s_totalStageCountForChart_%s_%s", getClass().getName(), pipelineName, stageName).intern();
+        return String.format("%s_totalStageCountForChart_%s_%s", getClass().getName(), pipelineName, stageName).toLowerCase().intern();
     }
 
     private void removeFromCache(String key) {
@@ -727,7 +727,7 @@ public class StageSqlMapDao extends SqlMapClientDaoSupport implements StageDao, 
 
 
     String cacheKeyForMostRecentId(String pipelineName, String stageName) {
-        return String.format("%s_mostRecentId_%s_%s", getClass().getName(), pipelineName, stageName).intern();
+        return String.format("%s_mostRecentId_%s_%s", getClass().getName(), pipelineName, stageName).toLowerCase().intern();
     }
 
     private Stage stageByIdWithBuildsWithNoAssociations(long id) {

--- a/server/src/main/java/com/thoughtworks/go/server/persistence/MaterialRepository.java
+++ b/server/src/main/java/com/thoughtworks/go/server/persistence/MaterialRepository.java
@@ -939,8 +939,8 @@ public class MaterialRepository extends HibernateDaoSupport {
         });
     }
 
-    private String cacheKeyForHasPipelineEverRunWithModification(Object pipelineName, long materialId, long modificationId) {
-        return String.format("%s_hasPipelineEverRunWithModification_%s_%s_%s", getClass().getName(), pipelineName, materialId, modificationId).intern();
+    protected String cacheKeyForHasPipelineEverRunWithModification(String pipelineName, long materialId, long modificationId) {
+        return String.format("%s_hasPipelineEverRunWithModification_%s_%s_%s", getClass().getName(), pipelineName.toLowerCase(), materialId, modificationId).intern();
     }
 
     @SuppressWarnings("unchecked")
@@ -1074,11 +1074,6 @@ public class MaterialRepository extends HibernateDaoSupport {
 
     private String cacheKeyForLatestPmrForPipelineKey(long materialId, final String lowerCasePipelineName) {
         return String.format("%s_latestPmrForPipeline_%s_andMaterial_%s", getClass().getName(), lowerCasePipelineName, materialId).intern();
-    }
-
-    String cacheKeyForNthLatestModification(int n, DependencyMaterial dependencyMaterial, PipelineIdentifier pipelineIdentifier) {
-        return String.format("%s_nthLatestModificationFor_%s_forMaterial_%s_withIdentifier_%s", getClass().getName(), n, dependencyMaterial.getFingerprint(),
-                pipelineIdentifier.pipelineLocator()).intern();
     }
 
     String cacheKeyForModificationWithRevision(long materialId, String revision) {

--- a/server/src/main/java/com/thoughtworks/go/server/service/PipelinePauseService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/PipelinePauseService.java
@@ -167,7 +167,7 @@ public class PipelinePauseService {
      * updateCounter() and pause() are trying to insert pipeline row if one doesn't exist
      */
     public static String mutexForPausePipeline(String pipelineName) {
-        return (PipelineSqlMapDao.class.getName() + "_mutexForPausePipeline_" + pipelineName).intern();
+        return (PipelineSqlMapDao.class.getName() + "_mutexForPausePipeline_" + pipelineName.toLowerCase()).intern();
     }
 
     private void notifyListeners(PipelinePauseChangeListener.Event event) {

--- a/server/src/main/java/com/thoughtworks/go/server/service/ScheduleService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/ScheduleService.java
@@ -346,8 +346,7 @@ public class ScheduleService {
     }
 
     private String mutexForPipeline(String pipelineName) {
-        String s = String.format("%s_forPipeline_%s", getClass().getName(), pipelineName);
-        return s.intern(); // interned because we synchronize on it
+        return String.format("%s_forPipeline_%s", getClass().getName(), pipelineName.toLowerCase()).intern(); // interned because we synchronize on it
     }
 
     private void triggerNextStageInPipeline(Pipeline pipeline, String stageName, String approvedBy) {
@@ -564,8 +563,7 @@ public class ScheduleService {
     }
 
     private String mutexForStageInstance(String pipelineName, Integer pipelineCounter, String stageName, String stageCounter) {
-        String s = String.format("%s_forStageInstance_%s_%s_%s_%s", getClass().getName(), pipelineName, pipelineCounter, stageName, stageCounter);
-        return s.intern(); // interned because we synchronize on it
+        return String.format("%s_forStageInstance_%s_%s_%s_%s", getClass().getName(), pipelineName, pipelineCounter, stageName, stageCounter).toLowerCase().intern(); // interned because we synchronize on it
     }
 
     //Note: This is called from a Spring timer
@@ -695,7 +693,7 @@ public class ScheduleService {
     }
 
     public String mutexForJob(JobIdentifier jobIdentifier) {
-        return String.format("%s_forJobInstance_%s", getClass().getName(), jobIdentifier.buildLocator()).intern();
+        return String.format("%s_forJobInstance_%s", getClass().getName(), jobIdentifier.buildLocator().toLowerCase()).intern();
     }
 
     public void cancelJob(JobIdentifier jobIdentifier) {

--- a/server/src/test-fast/java/com/thoughtworks/go/server/dao/StageSqlMapDaoTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/dao/StageSqlMapDaoTest.java
@@ -39,10 +39,7 @@ import org.mockito.stubbing.Answer;
 import org.springframework.orm.ibatis.SqlMapClientTemplate;
 
 import java.sql.SQLException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
+import java.util.*;
 import java.util.function.Supplier;
 
 import static org.hamcrest.CoreMatchers.is;
@@ -158,5 +155,15 @@ public class StageSqlMapDaoTest {
         verify(topOfThisPage).getId();
         verify(topOfThisPage).getIdentifier();
         verify(sqlMapClientTemplate).queryForObject("findStageHistoryEntryBefore", args);
+    }
+
+    @Test
+    public void ensureCacheKeyForStageHistoryCountOfAPipelineIsCaseInsensitive(){
+        when(sqlMapClientTemplate.queryForObject(eq("getStageHistoryCount"), any(Map.class))).thenReturn(10);
+        assertThat(stageSqlMapDao.getCount("Pipeline-Name", "Stage-Name"), is(10));
+        assertThat(stageSqlMapDao.getCount("pipeline-name", "stage-name"), is(10));
+        assertThat(stageSqlMapDao.getCount("PIPELINE-NAME", "STAGE-NAME"), is(10));
+
+        verify(sqlMapClientTemplate, times(1)).queryForObject(eq("getStageHistoryCount"), any(Map.class));
     }
 }

--- a/server/src/test-integration/java/com/thoughtworks/go/server/dao/StageSqlMapDaoIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/dao/StageSqlMapDaoIntegrationTest.java
@@ -33,10 +33,13 @@ import com.thoughtworks.go.server.persistence.MaterialRepository;
 import com.thoughtworks.go.server.service.InstanceFactory;
 import com.thoughtworks.go.server.service.ScheduleService;
 import com.thoughtworks.go.server.service.ScheduleTestUtil;
+import com.thoughtworks.go.server.service.StageService;
 import com.thoughtworks.go.server.service.result.HttpOperationResult;
 import com.thoughtworks.go.server.transaction.TransactionTemplate;
 import com.thoughtworks.go.server.util.Pagination;
-import com.thoughtworks.go.util.*;
+import com.thoughtworks.go.util.Clock;
+import com.thoughtworks.go.util.TimeProvider;
+import com.thoughtworks.go.util.GoConfigFileHelper;
 import org.hamcrest.Matchers;
 import org.hamcrest.core.Is;
 import org.junit.After;
@@ -89,6 +92,7 @@ public class StageSqlMapDaoIntegrationTest {
     @Autowired private TransactionTemplate transactionTemplate;
     @Autowired private MaterialRepository materialRepository;
     @Autowired private InstanceFactory instanceFactory;
+    @Autowired private StageService stageService;
 
     private GoConfigFileHelper configHelper = new GoConfigFileHelper();
     private static final String STAGE_DEV = "dev";
@@ -995,6 +999,7 @@ public class StageSqlMapDaoIntegrationTest {
         Pipeline completed = pipelines[0];
 
         assertThat(stageDao.getCount(completed.getName(), STAGE_DEV), is(2));
+        assertThat(stageDao.getCount(completed.getName().toUpperCase(), STAGE_DEV.toUpperCase()), is(2));
     }
 
     @Test
@@ -1871,6 +1876,200 @@ public class StageSqlMapDaoIntegrationTest {
         pagination = Pagination.pageStartingAt(1, 7, 4);
         stageInstanceModels = stageDao.findDetailedStageHistoryByOffset(pipelineName, stageName, pagination);
         assertStageModels(stageInstanceModels, run6, run5, run4, run3);
+    }
+
+    @Test
+    public void ensureCachingForGetAllRunsOfStageForPipelineInstanceIgnoresCaseChangesWhileAccessing() throws Exception {
+        String stageName = "stage-1";
+        String pipelineName = "pipeline-1";
+        PipelineConfig pipelineConfig = configHelper.addPipeline(pipelineName, stageName);
+        configHelper.turnOffSecurity();
+        Pipeline pipeline = dbHelper.schedulePipelineWithAllStages(pipelineConfig, ModificationsMother.modifySomeFiles(pipelineConfig));
+        dbHelper.pass(pipeline);
+
+        Stage stageCounter2 = scheduleService.rerunStage(pipelineName, Integer.toString(pipeline.getCounter()), stageName);
+
+        Stages allRunsOfStageForPipelineInstanceAfterCounter2 = stageDao.getAllRunsOfStageForPipelineInstance(pipelineName.toUpperCase(), pipeline.getCounter(), stageName.toUpperCase());
+        assertThat(allRunsOfStageForPipelineInstanceAfterCounter2.size(), is(2));
+        assertNotNull(allRunsOfStageForPipelineInstanceAfterCounter2.byId(pipeline.getFirstStage().getId()));
+        assertNotNull(allRunsOfStageForPipelineInstanceAfterCounter2.byId(stageCounter2.getId()));
+
+        transactionTemplate.execute(new TransactionCallbackWithoutResult() {
+            @Override
+            protected void doInTransactionWithoutResult(TransactionStatus status) {
+                stageService.cancelStage(stageCounter2);
+            }
+        });
+
+        Stage stageCounter3 = scheduleService.rerunStage(pipelineName, Integer.toString(pipeline.getCounter()), stageName);
+
+        Stages allRunsOfStageForPipelineInstanceAfterCounter3 = stageDao.getAllRunsOfStageForPipelineInstance(pipelineName.toUpperCase(), pipeline.getCounter(), stageName.toUpperCase());
+        assertThat(allRunsOfStageForPipelineInstanceAfterCounter3.size(), is(3));
+        assertNotNull(allRunsOfStageForPipelineInstanceAfterCounter3.byId(pipeline.getFirstStage().getId()));
+        assertNotNull(allRunsOfStageForPipelineInstanceAfterCounter3.byId(stageCounter2.getId()));
+        assertNotNull(allRunsOfStageForPipelineInstanceAfterCounter3.byId(stageCounter3.getId()));
+    }
+
+    @Test
+    public void ensureCachingForFindAllStagesForPipelineIgnoresCaseChangesWhileAccessing() throws Exception {
+        String stageName = "stage-1";
+        String pipelineName = "pipeline-1";
+        PipelineConfig pipelineConfig = configHelper.addPipeline(pipelineName, stageName);
+        configHelper.turnOffSecurity();
+        Pipeline pipeline = dbHelper.schedulePipelineWithAllStages(pipelineConfig, ModificationsMother.modifySomeFiles(pipelineConfig));
+        dbHelper.pass(pipeline);
+
+        Stage stageCounter2 = scheduleService.rerunStage(pipelineName, Integer.toString(pipeline.getCounter()), stageName);
+
+        Stages allRunsOfStageForPipelineCounter1AfterStageCounter2 = stageDao.findAllStagesFor(pipelineName.toUpperCase(), pipeline.getCounter());
+        assertThat(allRunsOfStageForPipelineCounter1AfterStageCounter2.size(), is(2));
+        assertNotNull(allRunsOfStageForPipelineCounter1AfterStageCounter2.byId(pipeline.getFirstStage().getId()));
+        assertNotNull(allRunsOfStageForPipelineCounter1AfterStageCounter2.byId(stageCounter2.getId()));
+
+        transactionTemplate.execute(new TransactionCallbackWithoutResult() {
+            @Override
+            protected void doInTransactionWithoutResult(TransactionStatus status) {
+                stageService.cancelStage(stageCounter2);
+            }
+        });
+
+        Stage stageCounter3 = scheduleService.rerunStage(pipelineName, Integer.toString(pipeline.getCounter()), stageName);
+
+        Stages allRunsOfStageForPipelineCounter1AfterStageCounter3 = stageDao.findAllStagesFor(pipelineName.toUpperCase(), pipeline.getCounter());
+        assertThat(allRunsOfStageForPipelineCounter1AfterStageCounter3.size(), is(3));
+        assertNotNull(allRunsOfStageForPipelineCounter1AfterStageCounter3.byId(pipeline.getFirstStage().getId()));
+        assertNotNull(allRunsOfStageForPipelineCounter1AfterStageCounter3.byId(stageCounter2.getId()));
+        assertNotNull(allRunsOfStageForPipelineCounter1AfterStageCounter3.byId(stageCounter3.getId()));
+    }
+
+    @Test
+    public void ensureCachingForMostRecentWithBuildsIgnoresCaseChangesWhileAccessing() throws Exception {
+        String stageName = "stage-1";
+        String pipelineName = "pipeline-1";
+        PipelineConfig pipelineConfig = configHelper.addPipeline(pipelineName, stageName);
+        configHelper.turnOffSecurity();
+        Pipeline pipeline = dbHelper.schedulePipelineWithAllStages(pipelineConfig, ModificationsMother.modifySomeFiles(pipelineConfig));
+        dbHelper.pass(pipeline);
+
+        Stage stageCounter2 = scheduleService.rerunStage(pipelineName, Integer.toString(pipeline.getCounter()), stageName);
+
+        List<JobInstance> jobInstances = stageDao.mostRecentJobsForStage(pipelineName.toUpperCase(), stageName.toUpperCase());
+        assertThat(jobInstances, hasSize(2));
+        assertThat(jobInstances.get(0).getStageId(), is(stageCounter2.getId()));
+        assertThat(jobInstances.get(1).getStageId(), is(stageCounter2.getId()));
+
+        transactionTemplate.execute(new TransactionCallbackWithoutResult() {
+            @Override
+            protected void doInTransactionWithoutResult(TransactionStatus status) {
+                stageService.cancelStage(stageCounter2);
+            }
+        });
+
+        Stage stageCounter3 = scheduleService.rerunStage(pipelineName, Integer.toString(pipeline.getCounter()), stageName);
+
+        List<JobInstance> jobInstancesForCounter3 = stageDao.mostRecentJobsForStage(pipelineName.toUpperCase(), stageName.toUpperCase());
+        assertThat(jobInstancesForCounter3, hasSize(2));
+        assertThat(jobInstancesForCounter3.get(0).getStageId(), is(stageCounter3.getId()));
+        assertThat(jobInstancesForCounter3.get(1).getStageId(), is(stageCounter3.getId()));
+    }
+
+    @Test
+    public void ensureCachingForStageHistoryPageIgnoresCaseChangesWhileAccessing() throws Exception {
+        String stageName = "stage-1";
+        String pipelineName = "pipeline-1";
+        PipelineConfig pipelineConfig = configHelper.addPipeline(pipelineName, stageName);
+        configHelper.turnOffSecurity();
+        Pipeline pipeline = dbHelper.schedulePipelineWithAllStages(pipelineConfig, ModificationsMother.modifySomeFiles(pipelineConfig));
+        dbHelper.pass(pipeline);
+
+        Stage stageCounter2 = scheduleService.rerunStage(pipelineName, Integer.toString(pipeline.getCounter()), stageName);
+
+        StageHistoryPage stageHistoryPageAfterCounter2 = stageDao.findStageHistoryPage(pipelineName.toUpperCase(), stageName.toUpperCase(), paginationSupplier());
+        assertThat(stageHistoryPageAfterCounter2.getStages(), hasSize(2));
+        assertThat(stageHistoryPageAfterCounter2.getStages().get(0).getId(), is(stageCounter2.getId()));
+        assertThat(stageHistoryPageAfterCounter2.getStages().get(1).getId(), is(pipeline.getFirstStage().getId()));
+
+        transactionTemplate.execute(new TransactionCallbackWithoutResult() {
+            @Override
+            protected void doInTransactionWithoutResult(TransactionStatus status) {
+                stageService.cancelStage(stageCounter2);
+            }
+        });
+
+        Stage stageCounter3 = scheduleService.rerunStage(pipelineName.toUpperCase(), Integer.toString(pipeline.getCounter()), stageName.toUpperCase());
+        transactionTemplate.execute(new TransactionCallbackWithoutResult() {
+            @Override
+            protected void doInTransactionWithoutResult(TransactionStatus status) {
+                stageService.cancelStage(stageCounter3);
+            }
+        });
+        Stage stageCounter4 = scheduleService.rerunStage(pipelineName.toUpperCase(), Integer.toString(pipeline.getCounter()), stageName.toUpperCase());
+
+        StageHistoryPage stageHistoryPageAfterCounter4 = stageDao.findStageHistoryPage(pipelineName.toUpperCase(), stageName.toUpperCase(), paginationSupplier());
+        assertThat(stageHistoryPageAfterCounter4.getStages(), hasSize(4));
+        assertThat(stageHistoryPageAfterCounter4.getStages().get(0).getId(), is(stageCounter4.getId()));
+        assertThat(stageHistoryPageAfterCounter4.getStages().get(1).getId(), is(stageCounter3.getId()));
+        assertThat(stageHistoryPageAfterCounter4.getStages().get(2).getId(), is(stageCounter2.getId()));
+        assertThat(stageHistoryPageAfterCounter4.getStages().get(3).getId(), is(pipeline.getFirstStage().getId()));
+    }
+
+    private Supplier<Pagination> paginationSupplier() {
+        return new Supplier<Pagination>() {
+            @Override
+            public Pagination get() {
+                return Pagination.pageStartingAt(0, 10, 10);
+            }
+        };
+    }
+
+    @Test
+    public void ensureCachingForFindDetailedStageHistoryByOffsetIgnoresCaseChangesWhileAccessing() throws Exception {
+        String stageName = "stage-1";
+        String pipelineName = "pipeline-1";
+        PipelineConfig pipelineConfig = configHelper.addPipeline(pipelineName, stageName);
+        configHelper.turnOffSecurity();
+        Pipeline pipeline = dbHelper.schedulePipelineWithAllStages(pipelineConfig, ModificationsMother.modifySomeFiles(pipelineConfig));
+        dbHelper.pass(pipeline);
+        Stage stageCounter2 = scheduleService.rerunStage(pipelineName, Integer.toString(pipeline.getCounter()), stageName);
+
+        StageInstanceModels historyAfterCounter2 = stageDao.findDetailedStageHistoryByOffset(pipelineName.toUpperCase(), stageName.toUpperCase(), Pagination.pageStartingAt(0, 10, 10));
+        assertThat(historyAfterCounter2, hasSize(2));
+        assertThat(historyAfterCounter2.get(0).getId(), is(stageCounter2.getId()));
+        assertThat(historyAfterCounter2.get(1).getId(), is(pipeline.getFirstStage().getId()));
+        transactionTemplate.execute(new TransactionCallbackWithoutResult() {
+            @Override
+            protected void doInTransactionWithoutResult(TransactionStatus status) {
+                stageService.cancelStage(stageCounter2);
+            }
+        });
+        Stage stageCounter3 = scheduleService.rerunStage(pipelineName.toUpperCase(), Integer.toString(pipeline.getCounter()), stageName.toUpperCase());
+
+        StageInstanceModels historyAfterCounter3 = stageDao.findDetailedStageHistoryByOffset(pipelineName.toUpperCase(), stageName.toUpperCase(), Pagination.pageStartingAt(0, 10, 10));
+        assertThat(historyAfterCounter3, hasSize(3));
+        assertThat(historyAfterCounter3.get(0).getId(), is(stageCounter3.getId()));
+        assertThat(historyAfterCounter3.get(1).getId(), is(stageCounter2.getId()));
+        assertThat(historyAfterCounter3.get(2).getId(), is(pipeline.getFirstStage().getId()));
+    }
+
+    @Test
+    public void ensureCachingForStageCountForGraphIgnoresCaseChangesWhileAccessing() throws Exception {
+        String stageName = "stage-1";
+        String pipelineName = "pipeline-1";
+        PipelineConfig pipelineConfig = configHelper.addPipeline(pipelineName, stageName);
+        configHelper.turnOffSecurity();
+        Pipeline pipeline = dbHelper.schedulePipelineWithAllStages(pipelineConfig, ModificationsMother.modifySomeFiles(pipelineConfig));
+        dbHelper.pass(pipeline);
+
+        Pipeline pipelineCounter2 = dbHelper.schedulePipelineWithAllStages(pipelineConfig, ModificationsMother.modifySomeFiles(pipelineConfig));
+        dbHelper.pass(pipelineCounter2);
+
+        int totalStageCountUntilCounter2 = stageDao.getTotalStageCountForChart(pipelineName.toUpperCase(), stageName.toUpperCase());
+        assertThat(totalStageCountUntilCounter2, is(2));
+
+        scheduleService.rerunStage(pipelineName, Integer.toString(pipelineCounter2.getCounter()), stageName);
+
+        int totalStageCountUntil = stageDao.getTotalStageCountForChart(pipelineName.toUpperCase(), stageName.toUpperCase());
+        assertThat(totalStageCountUntil, is(3));
     }
 
     private void assertStageModels(StageInstanceModels stageInstanceModels, String... runIdentifiers) {

--- a/server/src/test-integration/java/com/thoughtworks/go/server/persistence/MaterialRepositoryIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/persistence/MaterialRepositoryIntegrationTest.java
@@ -505,6 +505,7 @@ public class MaterialRepositoryIntegrationTest {
 
         MaterialRevisions revisions = new MaterialRevisions(new MaterialRevision(hgMaterial, materialRevision.getLatestModification()));
         assertThat(repo.hasPipelineEverRunWith("mingle", revisions), is(true));
+        assertThat(repo.hasPipelineEverRunWith("MINGLE", revisions), is(true));
     }
 
     @Test
@@ -523,6 +524,7 @@ public class MaterialRepositoryIntegrationTest {
 
         MaterialRevisions revisions = new MaterialRevisions(new MaterialRevision(hgMaterial, notBuiltRevision.getLatestModification()));
         assertThat(repo.hasPipelineEverRunWith("mingle", revisions), is(false));
+        assertThat(repo.hasPipelineEverRunWith("MINGLE", revisions), is(false));
     }
 
     @Test
@@ -541,6 +543,7 @@ public class MaterialRepositoryIntegrationTest {
         MaterialRevisions revisions = new MaterialRevisions(new MaterialRevision(depMaterial, depMaterialRevision.getLatestModification()),
                 new MaterialRevision(hgMaterial, hgMaterialRevision.getLatestModification()));
         assertThat(repo.hasPipelineEverRunWith("mingle", revisions), is(true));
+        assertThat(repo.hasPipelineEverRunWith("MINGLE", revisions), is(true));
     }
 
     @Test
@@ -567,6 +570,7 @@ public class MaterialRepositoryIntegrationTest {
         MaterialRevisions revisions = new MaterialRevisions(new MaterialRevision(depMaterial1, depMaterialRevision1.getLatestModification()),
                 new MaterialRevision(hgMaterial2, hgMaterialRevision2.getLatestModification()));
         assertThat(repo.hasPipelineEverRunWith("mingle", revisions), is(true));
+        assertThat(repo.hasPipelineEverRunWith("MINGLE", revisions), is(true));
     }
 
     private Pipeline savePipeline(Pipeline pipeline) {
@@ -593,6 +597,7 @@ public class MaterialRepositoryIntegrationTest {
 
         MaterialRevisions newRevisions = new MaterialRevisions(depMaterialRevision, laterRevision);
         assertThat(repo.hasPipelineEverRunWith("mingle", newRevisions), is(false));
+        assertThat(repo.hasPipelineEverRunWith("MINGLE", newRevisions), is(false));
     }
 
     @Test
@@ -614,6 +619,7 @@ public class MaterialRepositoryIntegrationTest {
                 new TimeProvider()));
 
         assertThat(repo.hasPipelineEverRunWith("mingle", new MaterialRevisions(first2, second2)), is(true));
+        assertThat(repo.hasPipelineEverRunWith("MINGLE", new MaterialRevisions(first2, second2)), is(true));
     }
 
     @Test


### PR DESCRIPTION
Making some cache-keys case-insensitive. Cache-keys were created based on the case provided by end-user (which need not always match the one used in config), however cache invalidation would happen for the same case as used by the config. So there were many cases of stale cached information being displayed if a pipeline was accessed via API or UI with a different case from the one in config.

Changes in this commit affects the following
* materialRepository.hasPipelineEverRunWith (scheduling - to decide if the pipeline should be triggered or not)
* stageSqlMapDao.getCount case-insensitive (get-stage-history api)
* StageSqlMapDao.getAllRunsOfStageForPipelineInstance (Stage details page)
* stageSqlMapDao.findStageHistoryForChart (stage details graph)
* stageSqlMapDao.findAllStagesFor (for preparing VSM, stage-active-checker used by unlock-api, dashboard etc)
* stageSqlMapDao.mostRecentJobsForStage (get-pipeline-status api, )
* stageDao.findStageHistoryPage, stageDao.findDetailedStageHistoryByOffset (Stage history pagination)
* pipelineDao.findLastSuccessfulStageIdentifier (get-pipeline-status api)
* Making pipeline, stage and job identifiers case insensitive
* Mutex for pipeline, stage, jobs should apply immaterial of case of names defined in config or passed along by user
* HealthState scope for pipeline, stage, job need to be case-insensitive