### PR TITLE
Changing status code for all apis and authentication filters

### DIFF
--- a/api/api-artifact-store-config-v1/src/main/java/com/thoughtworks/go/apiv1/artifactstoreconfig/ArtifactStoreConfigControllerDelegate.java
+++ b/api/api-artifact-store-config-v1/src/main/java/com/thoughtworks/go/apiv1/artifactstoreconfig/ArtifactStoreConfigControllerDelegate.java
@@ -94,8 +94,8 @@ public class ArtifactStoreConfigControllerDelegate extends ApiController impleme
             before("", this::setContentType);
             before("/*", this::setContentType);
 
-            before("", mimeType, apiAuthenticationHelper::checkAdminUserAnd401);
-            before("/*", mimeType, apiAuthenticationHelper::checkAdminUserAnd401);
+            before("", mimeType, apiAuthenticationHelper::checkAdminUserAnd403);
+            before("/*", mimeType, apiAuthenticationHelper::checkAdminUserAnd403);
 
             get("", this::index);
             get(Routes.ArtifactStoreConfig.ID, this::show);

--- a/api/api-backups-v1/src/main/java/com/thoughtworks/go/apiv1/admin/backups/BackupsControllerDelegate.java
+++ b/api/api-backups-v1/src/main/java/com/thoughtworks/go/apiv1/admin/backups/BackupsControllerDelegate.java
@@ -61,8 +61,8 @@ public class BackupsControllerDelegate extends ApiController {
             before("", this::verifyConfirmHeader);
             before("/*", this::verifyConfirmHeader);
 
-            before("", mimeType, apiAuthenticationHelper::checkAdminUserAnd401);
-            before("/*", mimeType, apiAuthenticationHelper::checkAdminUserAnd401);
+            before("", mimeType, apiAuthenticationHelper::checkAdminUserAnd403);
+            before("/*", mimeType, apiAuthenticationHelper::checkAdminUserAnd403);
 
             post("", mimeType, this::create);
         });

--- a/api/api-base/src/main/java/com/thoughtworks/go/api/spring/ApiAuthenticationHelper.java
+++ b/api/api-base/src/main/java/com/thoughtworks/go/api/spring/ApiAuthenticationHelper.java
@@ -33,9 +33,9 @@ public class ApiAuthenticationHelper extends AbstractAuthenticationHelper {
     }
 
     @Override
-    protected HaltException renderUnauthorizedResponse() throws HaltException {
+    protected HaltException renderForbiddenResponse() throws HaltException {
         LOG.info("User {} attempted to perform an unauthorized action!", currentUserLoginName());
-        return HaltApiResponses.haltBecauseUnauthorized();
+        return HaltApiResponses.haltBecauseForbidden();
     }
 
 }

--- a/api/api-base/src/main/java/com/thoughtworks/go/api/util/HaltApiMessages.java
+++ b/api/api-base/src/main/java/com/thoughtworks/go/api/util/HaltApiMessages.java
@@ -26,7 +26,7 @@ public abstract class HaltApiMessages {
         return "Either the resource you requested was not found, or you are not authorized to perform this action.";
     }
 
-    public static String unauthorizedMessage() {
+    public static String forbiddenMessage() {
         return "You are not authorized to perform this action.";
     }
 

--- a/api/api-base/src/main/java/com/thoughtworks/go/api/util/HaltApiResponses.java
+++ b/api/api-base/src/main/java/com/thoughtworks/go/api/util/HaltApiResponses.java
@@ -26,8 +26,8 @@ import static spark.Spark.halt;
 
 public abstract class HaltApiResponses {
 
-    public static HaltException haltBecauseUnauthorized() {
-        return halt(HttpStatus.UNAUTHORIZED.value(), MessageJson.create(unauthorizedMessage()));
+    public static HaltException haltBecauseForbidden() {
+        return halt(HttpStatus.FORBIDDEN.value(), MessageJson.create(forbiddenMessage()));
     }
 
     public static HaltException haltBecauseEntityAlreadyExists(JsonNode jsonInRequestBody, String entityType, Object existingName) {

--- a/api/api-base/src/test/groovy/com/thoughtworks/go/api/SecurityTestTrait.groovy
+++ b/api/api-base/src/test/groovy/com/thoughtworks/go/api/SecurityTestTrait.groovy
@@ -46,7 +46,7 @@ trait SecurityTestTrait {
 
   abstract void makeHttpCall()
 
-  def assertRequestAuthorized() {
+  def assertRequestAllowed() {
     verify(controller)."${controllerMethodUnderTest}"(any(), any())
 
     ((MockHttpServletResponseAssert) assertThatResponse())
@@ -55,12 +55,12 @@ trait SecurityTestTrait {
       .hasJsonBody([message: reachedControllerMessage])
   }
 
-  def assertRequestNotAuthorized() {
+  def assertRequestForbidden() {
     verify(controller, never())."${controllerMethodUnderTest}"(any(), any())
 
     ((MockHttpServletResponseAssert) assertThatResponse())
       .hasContentType(controller.mimeType)
-      .hasStatus(401)
-      .hasJsonMessage(HaltApiMessages.unauthorizedMessage())
+      .hasStatus(403)
+      .hasJsonMessage(HaltApiMessages.forbiddenMessage())
   }
 }

--- a/api/api-build_cause-v1/src/main/java/com/thoughtworks/go/apiv1/buildcause/BuildCauseControllerDelegate.java
+++ b/api/api-build_cause-v1/src/main/java/com/thoughtworks/go/apiv1/buildcause/BuildCauseControllerDelegate.java
@@ -54,8 +54,8 @@ public class BuildCauseControllerDelegate extends ApiController {
             before("", mimeType, this::setContentType);
             before("/*", mimeType, this::setContentType);
 
-            before("", mimeType, apiAuthenticationHelper::checkPipelineViewPermissionsAnd401);
-            before("/*", mimeType, apiAuthenticationHelper::checkPipelineViewPermissionsAnd401);
+            before("", mimeType, apiAuthenticationHelper::checkPipelineViewPermissionsAnd403);
+            before("/*", mimeType, apiAuthenticationHelper::checkPipelineViewPermissionsAnd403);
 
             before("", this::verifyContentType);
             before("/*", this::verifyContentType);

--- a/api/api-dashboard-v2/src/main/java/com/thoughtworks/go/apiv2/dashboard/DashboardControllerDelegate.java
+++ b/api/api-dashboard-v2/src/main/java/com/thoughtworks/go/apiv2/dashboard/DashboardControllerDelegate.java
@@ -65,7 +65,7 @@ public class DashboardControllerDelegate extends ApiController {
         path(controllerPath(), () -> {
             before("", mimeType, this::setContentType);
             before("", this::verifyContentType);
-            before("", apiAuthenticationHelper::checkUserAnd401);
+            before("", apiAuthenticationHelper::checkUserAnd403);
 
             get("", this::index);
         });

--- a/api/api-encryption-v1/src/main/java/com/thoughtworks/go/apiv1/admin/encryption/EncryptionControllerDelegate.java
+++ b/api/api-encryption-v1/src/main/java/com/thoughtworks/go/apiv1/admin/encryption/EncryptionControllerDelegate.java
@@ -79,8 +79,8 @@ public class EncryptionControllerDelegate extends ApiController {
             before("", this::verifyContentType);
             before("/*", this::verifyContentType);
 
-            before("", mimeType, apiAuthenticationHelper::checkAnyAdminUserAnd401);
-            before("/*", mimeType, apiAuthenticationHelper::checkAnyAdminUserAnd401);
+            before("", mimeType, apiAuthenticationHelper::checkAnyAdminUserAnd403);
+            before("/*", mimeType, apiAuthenticationHelper::checkAnyAdminUserAnd403);
 
             before("", mimeType, this::checkRateLimitAvailable);
 

--- a/api/api-material-search-v1/src/main/java/com/thoughtworks/go/apiv1/materialsearch/MaterialSearchControllerDelegate.java
+++ b/api/api-material-search-v1/src/main/java/com/thoughtworks/go/apiv1/materialsearch/MaterialSearchControllerDelegate.java
@@ -55,8 +55,8 @@ public class MaterialSearchControllerDelegate extends ApiController {
             before("", this::setContentType);
             before("/*", this::setContentType);
 
-            before("", mimeType, apiAuthenticationHelper::checkPipelineGroupOperateUserAnd401);
-            before("/*", mimeType, apiAuthenticationHelper::checkPipelineGroupOperateUserAnd401);
+            before("", mimeType, apiAuthenticationHelper::checkPipelineGroupOperateUserAnd403);
+            before("/*", mimeType, apiAuthenticationHelper::checkPipelineGroupOperateUserAnd403);
 
             get("", this::search);
             head("", this::search);

--- a/api/api-pipeline-operations-v1/src/main/java/com/thoughtworks/go/apiv1/pipelineoperations/PipelineOperationsControllerV1Delegate.java
+++ b/api/api-pipeline-operations-v1/src/main/java/com/thoughtworks/go/apiv1/pipelineoperations/PipelineOperationsControllerV1Delegate.java
@@ -75,11 +75,11 @@ public class PipelineOperationsControllerV1Delegate extends ApiController {
             before("", this::verifyContentType);
             before("/*", this::verifyContentType);
 
-            before(Routes.Pipeline.PAUSE_PATH, mimeType, apiAuthenticationHelper::checkPipelineGroupOperateUserAnd401);
-            before(Routes.Pipeline.UNPAUSE_PATH, mimeType, apiAuthenticationHelper::checkPipelineGroupOperateUserAnd401);
-            before(Routes.Pipeline.UNLOCK_PATH, mimeType, apiAuthenticationHelper::checkPipelineGroupOperateUserAnd401);
-            before(Routes.Pipeline.TRIGGER_OPTIONS_PATH, mimeType, apiAuthenticationHelper::checkPipelineGroupOperateUserAnd401);
-            before(Routes.Pipeline.SCHEDULE_PATH, mimeType, apiAuthenticationHelper::checkPipelineGroupOperateUserAnd401);
+            before(Routes.Pipeline.PAUSE_PATH, mimeType, apiAuthenticationHelper::checkPipelineGroupOperateUserAnd403);
+            before(Routes.Pipeline.UNPAUSE_PATH, mimeType, apiAuthenticationHelper::checkPipelineGroupOperateUserAnd403);
+            before(Routes.Pipeline.UNLOCK_PATH, mimeType, apiAuthenticationHelper::checkPipelineGroupOperateUserAnd403);
+            before(Routes.Pipeline.TRIGGER_OPTIONS_PATH, mimeType, apiAuthenticationHelper::checkPipelineGroupOperateUserAnd403);
+            before(Routes.Pipeline.SCHEDULE_PATH, mimeType, apiAuthenticationHelper::checkPipelineGroupOperateUserAnd403);
 
             post(Routes.Pipeline.PAUSE_PATH, mimeType, this::pause);
             post(Routes.Pipeline.UNPAUSE_PATH, mimeType, this::unpause);

--- a/api/api-roles-config-v1/src/main/java/com/thoughtworks/go/apiv1/admin/security/RolesControllerV1Delegate.java
+++ b/api/api-roles-config-v1/src/main/java/com/thoughtworks/go/apiv1/admin/security/RolesControllerV1Delegate.java
@@ -64,8 +64,8 @@ public class RolesControllerV1Delegate extends ApiController implements CrudCont
             before("/*", mimeType, this::setContentType);
             before("", this::verifyContentType);
             before("/*", this::verifyContentType);
-            before("", mimeType, apiAuthenticationHelper::checkAdminUserAnd401);
-            before("/*", mimeType, apiAuthenticationHelper::checkAdminUserAnd401);
+            before("", mimeType, apiAuthenticationHelper::checkAdminUserAnd403);
+            before("/*", mimeType, apiAuthenticationHelper::checkAdminUserAnd403);
 
             get("", mimeType, this::index);
             post("", mimeType, this::create);

--- a/api/api-server-health-messages-v1/src/main/java/com/thoughtworks/go/apiv1/serverhealthmessages/ServerHealthMessagesControllerDelegate.java
+++ b/api/api-server-health-messages-v1/src/main/java/com/thoughtworks/go/apiv1/serverhealthmessages/ServerHealthMessagesControllerDelegate.java
@@ -50,8 +50,8 @@ public class ServerHealthMessagesControllerDelegate extends ApiController {
             before("", this::setContentType);
             before("/*", this::setContentType);
 
-            before("", apiAuthenticationHelper::checkUserAnd401);
-            before("/*", apiAuthenticationHelper::checkUserAnd401);
+            before("", apiAuthenticationHelper::checkUserAnd403);
+            before("/*", apiAuthenticationHelper::checkUserAnd403);
 
             get("", this::show);
             head("", this::show);

--- a/common/src/main/java/com/thoughtworks/go/i18n/LocalizedMessage.java
+++ b/common/src/main/java/com/thoughtworks/go/i18n/LocalizedMessage.java
@@ -1,18 +1,18 @@
-/*************************GO-LICENSE-START*********************************
- * Copyright 2014 ThoughtWorks, Inc.
+/*
+ * Copyright 2018 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *************************GO-LICENSE-END***********************************/
+ */
 
 package com.thoughtworks.go.i18n;
 
@@ -35,11 +35,11 @@ public abstract class LocalizedMessage {
         return "Cannot delete the " + resourceTypeBeingDeleted + " '" + resourceNameBeingDeleted + "' as it is used by pipeline(s): '" + join(dependentPipelines, ", ") + "'";
     }
 
-    public static String unauthorizedToDelete(String resourceType, CaseInsensitiveString resourceName) {
-        return unauthorizedToDelete(resourceType, resourceName.toString());
+    public static String forbiddenToDelete(String resourceType, CaseInsensitiveString resourceName) {
+        return forbiddenToDelete(resourceType, resourceName.toString());
     }
 
-    public static String unauthorizedToDelete(String resourceType, String resourceName) {
+    public static String forbiddenToDelete(String resourceType, String resourceName) {
         return "Unauthorized to delete " + resourceType + "' " + resourceName + "'";
     }
 
@@ -51,11 +51,11 @@ public abstract class LocalizedMessage {
         return staleResourceConfig(resourceType, resourceName.toString());
     }
 
-    public static String unauthorizedToViewPipeline(CaseInsensitiveString pipelineName) {
-        return unauthorizedToViewPipeline(pipelineName.toString());
+    public static String forbiddenToViewPipeline(CaseInsensitiveString pipelineName) {
+        return forbiddenToViewPipeline(pipelineName.toString());
     }
 
-    public static String unauthorizedToViewPipeline(String pipelineName) {
+    public static String forbiddenToViewPipeline(String pipelineName) {
         return "You do not have view permissions for pipeline '" + pipelineName + "'.";
     }
 
@@ -71,28 +71,28 @@ public abstract class LocalizedMessage {
         return resourceNotFound(resourceType, resourceName.toString());
     }
 
-    public static String unauthorizedToEditGroup(String groupName) {
+    public static String forbiddenToEditGroup(String groupName) {
         return "Unauthorized to edit '" + groupName + "' group.";
     }
 
-    public static String unauthorizedToEdit() {
+    public static String forbiddenToEdit() {
         return "Unauthorized to edit.";
     }
 
-    public static String unauthorizedToEditPipeline(String pipelineName) {
+    public static String forbiddenToEditPipeline(String pipelineName) {
         return "Unauthorized to edit '" + pipelineName + "' pipeline.";
     }
 
-    public static String unauthorizedToEditPipeline(CaseInsensitiveString pipelineName) {
-        return unauthorizedToEditPipeline(pipelineName.toString());
+    public static String forbiddenToEditPipeline(CaseInsensitiveString pipelineName) {
+        return forbiddenToEditPipeline(pipelineName.toString());
     }
 
-    public static String unauthorizedToEditResource(String resourceType, String resourceName, String username) {
+    public static String forbiddenToEditResource(String resourceType, String resourceName, String username) {
         return String.format("Failed to access %s '%s'. User '%s' does not have permission to access %s.", resourceType, resourceName, username, resourceType);
     }
 
-    public static String unauthorizedToEditResource(String resourceType, CaseInsensitiveString resourceName, String username) {
-        return unauthorizedToEditResource(resourceType, resourceName.toString(), username);
+    public static String forbiddenToEditResource(String resourceType, CaseInsensitiveString resourceName, String username) {
+        return forbiddenToEditResource(resourceType, resourceName.toString(), username);
     }
 
     public static String resourceAlreadyExists(String resourceType, String resourceName) {

--- a/common/src/main/java/com/thoughtworks/go/server/service/result/DefaultLocalizedOperationResult.java
+++ b/common/src/main/java/com/thoughtworks/go/server/service/result/DefaultLocalizedOperationResult.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2015 ThoughtWorks, Inc.
+ * Copyright 2018 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -22,7 +22,7 @@ import com.thoughtworks.go.serverhealth.HealthStateType;
 public class DefaultLocalizedOperationResult implements LocalizedOperationResult {
 
     @Override
-    public void unauthorized(String message, HealthStateType id) {
+    public void forbidden(String message, HealthStateType healthStateType) {
 
     }
 

--- a/common/src/main/java/com/thoughtworks/go/server/service/result/HttpLocalizedOperationResult.java
+++ b/common/src/main/java/com/thoughtworks/go/server/service/result/HttpLocalizedOperationResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 ThoughtWorks, Inc.
+ * Copyright 2018 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,8 @@ package com.thoughtworks.go.server.service.result;
 
 import com.thoughtworks.go.serverhealth.HealthStateType;
 import org.apache.http.HttpStatus;
+
+import static org.apache.http.HttpStatus.SC_FORBIDDEN;
 
 /**
  * @understands localized operation result for http
@@ -57,10 +59,10 @@ public class HttpLocalizedOperationResult implements LocalizedOperationResult {
     }
 
     @Override
-    public void unauthorized(String message, HealthStateType healthStateType) {
+    public void forbidden(String message, HealthStateType healthStateType) {
         this.message = message;
         this.healthStateType = healthStateType;
-        httpCode = HttpStatus.SC_UNAUTHORIZED;
+        httpCode = SC_FORBIDDEN;
     }
 
     @Override

--- a/common/src/main/java/com/thoughtworks/go/server/service/result/HttpOperationResult.java
+++ b/common/src/main/java/com/thoughtworks/go/server/service/result/HttpOperationResult.java
@@ -20,6 +20,8 @@ import com.thoughtworks.go.serverhealth.HealthStateType;
 import com.thoughtworks.go.serverhealth.ServerHealthState;
 import org.apache.commons.lang.StringUtils;
 
+import static org.apache.http.HttpStatus.SC_FORBIDDEN;
+
 /**
  * @understands how to turn the problems that can occur during api calls into human-readable form and http codes
  * @deprecated Use LocalizedOperationResult interface instead
@@ -81,10 +83,10 @@ public class HttpOperationResult implements OperationResult {
         return serverHealthStateOperationResult.paymentRequired(message, description, type);
     }
 
-    public ServerHealthState unauthorized(String message, String description, HealthStateType id) {
+    public ServerHealthState forbidden(String message, String description, HealthStateType id) {
         this.message = message;
-        httpCode = 401;
-        return serverHealthStateOperationResult.unauthorized(message, description, id);
+        httpCode = SC_FORBIDDEN;
+        return serverHealthStateOperationResult.forbidden(message, description, id);
     }
 
     public void conflict(String message, String description, HealthStateType healthStateType) {

--- a/common/src/main/java/com/thoughtworks/go/server/service/result/LocalizedOperationResult.java
+++ b/common/src/main/java/com/thoughtworks/go/server/service/result/LocalizedOperationResult.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2015 ThoughtWorks, Inc.
+ * Copyright 2018 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -23,7 +23,7 @@ import com.thoughtworks.go.serverhealth.HealthStateType;
  */
 public interface LocalizedOperationResult {
 
-    void unauthorized(String message, HealthStateType id);
+    void forbidden(String message, HealthStateType healthStateType);
 
     void stale(String message);
 

--- a/common/src/main/java/com/thoughtworks/go/server/service/result/OperationResult.java
+++ b/common/src/main/java/com/thoughtworks/go/server/service/result/OperationResult.java
@@ -41,7 +41,7 @@ public interface OperationResult {
 
     ServerHealthState paymentRequired(String message, String description, HealthStateType type);
 
-    ServerHealthState unauthorized(String message, String description, HealthStateType id);
+    ServerHealthState forbidden(String message, String description, HealthStateType id);
 
     void conflict(String message, String description, HealthStateType healthStateType);
 

--- a/common/src/main/java/com/thoughtworks/go/server/service/result/ServerHealthStateOperationResult.java
+++ b/common/src/main/java/com/thoughtworks/go/server/service/result/ServerHealthStateOperationResult.java
@@ -1,5 +1,5 @@
 /*************************GO-LICENSE-START*********************************
- * Copyright 2014 ThoughtWorks, Inc.
+ * Copyright 2018 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -50,7 +50,8 @@ public class ServerHealthStateOperationResult implements OperationResult {
         return error(message, description, type);
     }
 
-    public ServerHealthState unauthorized(String message, String description, HealthStateType id) {
+    @Override
+    public ServerHealthState forbidden(String message, String description, HealthStateType id) {
         return error(message, description, id);
     }
 

--- a/common/src/main/java/com/thoughtworks/go/serverhealth/HealthStateType.java
+++ b/common/src/main/java/com/thoughtworks/go/serverhealth/HealthStateType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 ThoughtWorks, Inc.
+ * Copyright 2018 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -54,16 +54,16 @@ public class HealthStateType implements Comparable<HealthStateType> {
         return new HealthStateType("INVALID_CONFIG_MERGE", 406, HealthStateScope.GLOBAL, null);
     }
 
-    public static HealthStateType unauthorisedForPipeline(String pipelineName) {
-        return new HealthStateType("UNAUTHORIZED", 401, HealthStateScope.forPipeline(pipelineName), null);
+    public static HealthStateType forbiddenForPipeline(String pipelineName) {
+        return new HealthStateType("FORBIDDEN", 403, HealthStateScope.forPipeline(pipelineName), null);
     }
 
-    public static HealthStateType unauthorisedForGroup(String groupName) {
-        return new HealthStateType("UNAUTHORIZED", 401, HealthStateScope.forGroup(groupName), null);
+    public static HealthStateType forbiddenForGroup(String groupName) {
+        return new HealthStateType("FORBIDDEN", 403, HealthStateScope.forGroup(groupName), null);
     }
 
-    public static HealthStateType unauthorised() {
-        return new HealthStateType("UNAUTHORIZED", 401, HealthStateScope.GLOBAL, null);
+    public static HealthStateType forbidden() {
+        return new HealthStateType("FORBIDDEN", 403, HealthStateScope.GLOBAL, null);
     }
 
     public static HealthStateType invalidLicense(HealthStateScope scope) {

--- a/common/src/test/java/com/thoughtworks/go/server/service/result/HttpLocalizedOperationResultTest.java
+++ b/common/src/test/java/com/thoughtworks/go/server/service/result/HttpLocalizedOperationResultTest.java
@@ -1,18 +1,18 @@
-/*************************GO-LICENSE-START*********************************
- * Copyright 2014 ThoughtWorks, Inc.
+/*
+ * Copyright 2018 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *************************GO-LICENSE-END***********************************/
+ */
 
 package com.thoughtworks.go.server.service.result;
 
@@ -21,7 +21,6 @@ import com.thoughtworks.go.serverhealth.HealthStateScope;
 import com.thoughtworks.go.serverhealth.HealthStateType;
 import org.junit.Test;
 
-import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.*;
@@ -38,14 +37,14 @@ public class HttpLocalizedOperationResultTest {
     @Test
     public void shouldNotReturnSuccessfulIfUnauthorized() {
         LocalizedOperationResult result = new HttpLocalizedOperationResult();
-        result.unauthorized(LocalizedMessage.unauthorizedToViewPipeline("whateva"), HealthStateType.general(HealthStateScope.GLOBAL));
+        result.forbidden(LocalizedMessage.forbiddenToViewPipeline("whateva"), HealthStateType.general(HealthStateScope.GLOBAL));
         assertThat(result.isSuccessful(), is(false));
     }
 
     @Test
     public void shouldNotReturnSuccessfulIfNotFound() {
         LocalizedOperationResult result = new HttpLocalizedOperationResult();
-        result.notFound(LocalizedMessage.unauthorizedToViewPipeline("whateva"), HealthStateType.general(HealthStateScope.GLOBAL));
+        result.notFound(LocalizedMessage.forbiddenToViewPipeline("whateva"), HealthStateType.general(HealthStateScope.GLOBAL));
         assertThat(result.isSuccessful(), is(false));
     }
 
@@ -59,12 +58,12 @@ public class HttpLocalizedOperationResultTest {
     }
 
     @Test
-    public void shouldReturn401WhenNotAuthorized() {
-        String message = LocalizedMessage.unauthorizedToViewPipeline("whateva");
+    public void shouldReturn403WhenUserDoesNotHavePermissionToAccessResource() {
+        String message = LocalizedMessage.forbiddenToViewPipeline("whateva");
         HttpLocalizedOperationResult result = new HttpLocalizedOperationResult();
-        result.unauthorized(message, HealthStateType.general(HealthStateScope.GLOBAL));
+        result.forbidden(message, HealthStateType.general(HealthStateScope.GLOBAL));
 
-        assertThat(result.httpCode(), is(401));
+        assertThat(result.httpCode(), is(403));
     }
 
     @Test
@@ -88,28 +87,6 @@ public class HttpLocalizedOperationResultTest {
     public void shouldNotFailWhenNoMessageSet() {
         HttpLocalizedOperationResult result = new HttpLocalizedOperationResult();
         assertThat(result.message(), is(nullValue()));
-    }
-
-    @Test
-    public void shouldTestEquality() throws Exception {
-        HttpLocalizedOperationResult result = new HttpLocalizedOperationResult();
-        result.unauthorized("foo", HealthStateType.general(HealthStateScope.GLOBAL));
-
-        HttpLocalizedOperationResult equalResult = new HttpLocalizedOperationResult();
-        equalResult.unauthorized("foo", HealthStateType.general(HealthStateScope.GLOBAL));
-
-        assertThat(result, is(equalResult));
-    }
-
-    @Test
-    public void shouldTestInEquality() throws Exception {
-        HttpLocalizedOperationResult result = new HttpLocalizedOperationResult();
-        result.unauthorized("foo", HealthStateType.general(HealthStateScope.GLOBAL));
-
-        HttpLocalizedOperationResult equalResult = new HttpLocalizedOperationResult();
-        equalResult.unauthorized("bar", HealthStateType.general(HealthStateScope.GLOBAL));
-
-        assertThat(result, is(not(equalResult)));
     }
 
     @Test

--- a/common/src/test/java/com/thoughtworks/go/server/service/result/HttpOperationResultTest.java
+++ b/common/src/test/java/com/thoughtworks/go/server/service/result/HttpOperationResultTest.java
@@ -1,5 +1,5 @@
 /*************************GO-LICENSE-START*********************************
- * Copyright 2014 ThoughtWorks, Inc.
+ * Copyright 2018 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,13 +29,6 @@ public class HttpOperationResultTest {
 
     @Before public void setUp() {
         httpOperationResult = new HttpOperationResult();
-    }
-    
-    @Test public void shouldReturn401ForInsufficientPermissions() throws Exception {
-        httpOperationResult.unauthorized("permission denied","blah blah", HealthStateType.general(HealthStateScope.forPipeline("baboon")));
-        assertThat(httpOperationResult.httpCode(), is(401));
-        assertThat(httpOperationResult.canContinue(), is(false));
-        assertThat(httpOperationResult.message(), is("permission denied"));
     }
 
     @Test public void shouldReturn202IfEverythingWorks() throws Exception {

--- a/server/src/main/java/com/thoughtworks/go/config/update/AgentsEntityConfigUpdateCommand.java
+++ b/server/src/main/java/com/thoughtworks/go/config/update/AgentsEntityConfigUpdateCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 ThoughtWorks, Inc.
+ * Copyright 2018 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,8 +37,8 @@ import java.util.List;
 import java.util.Set;
 
 import static com.thoughtworks.go.i18n.LocalizedMessage.resourceNotFound;
-import static com.thoughtworks.go.i18n.LocalizedMessage.unauthorizedToEdit;
-import static com.thoughtworks.go.serverhealth.HealthStateType.unauthorised;
+import static com.thoughtworks.go.i18n.LocalizedMessage.forbiddenToEdit;
+import static com.thoughtworks.go.serverhealth.HealthStateType.forbidden;
 
 public class AgentsEntityConfigUpdateCommand implements EntityConfigUpdateCommand<Agents> {
     private AgentInstances agentInstances;
@@ -160,7 +160,7 @@ public class AgentsEntityConfigUpdateCommand implements EntityConfigUpdateComman
         if (goConfigService.isAdministrator(username.getUsername())) {
             return true;
         }
-        result.unauthorized(unauthorizedToEdit(), unauthorised());
+        result.forbidden(forbiddenToEdit(), forbidden());
         return false;
     }
 

--- a/server/src/main/java/com/thoughtworks/go/config/update/ArtifactStoreConfigCommand.java
+++ b/server/src/main/java/com/thoughtworks/go/config/update/ArtifactStoreConfigCommand.java
@@ -19,18 +19,16 @@ package com.thoughtworks.go.config.update;
 import com.thoughtworks.go.config.ArtifactStore;
 import com.thoughtworks.go.config.ArtifactStores;
 import com.thoughtworks.go.config.CruiseConfig;
-import com.thoughtworks.go.i18n.LocalizedMessage;
 import com.thoughtworks.go.plugin.access.artifact.ArtifactExtension;
 import com.thoughtworks.go.plugin.api.response.validation.ValidationResult;
 import com.thoughtworks.go.server.domain.Username;
 import com.thoughtworks.go.server.service.GoConfigService;
 import com.thoughtworks.go.server.service.result.LocalizedOperationResult;
-import com.thoughtworks.go.serverhealth.HealthStateType;
 
 import java.util.Map;
 
-import static com.thoughtworks.go.i18n.LocalizedMessage.unauthorizedToEdit;
-import static com.thoughtworks.go.serverhealth.HealthStateType.unauthorised;
+import static com.thoughtworks.go.i18n.LocalizedMessage.forbiddenToEdit;
+import static com.thoughtworks.go.serverhealth.HealthStateType.forbidden;
 
 abstract class ArtifactStoreConfigCommand extends PluginProfileCommand<ArtifactStore, ArtifactStores> {
     protected final ArtifactExtension extension;
@@ -59,7 +57,7 @@ abstract class ArtifactStoreConfigCommand extends PluginProfileCommand<ArtifactS
         if (goConfigService.isUserAdmin(currentUser)) {
             return true;
         }
-        result.unauthorized(unauthorizedToEdit(), unauthorised());
+        result.forbidden(forbiddenToEdit(), forbidden());
         return false;
     }
 

--- a/server/src/main/java/com/thoughtworks/go/config/update/ConfigRepoCommand.java
+++ b/server/src/main/java/com/thoughtworks/go/config/update/ConfigRepoCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 ThoughtWorks, Inc.
+ * Copyright 2018 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,8 +26,8 @@ import com.thoughtworks.go.server.domain.Username;
 import com.thoughtworks.go.server.service.SecurityService;
 import com.thoughtworks.go.server.service.result.HttpLocalizedOperationResult;
 
-import static com.thoughtworks.go.i18n.LocalizedMessage.unauthorizedToEdit;
-import static com.thoughtworks.go.serverhealth.HealthStateType.unauthorised;
+import static com.thoughtworks.go.i18n.LocalizedMessage.forbiddenToEdit;
+import static com.thoughtworks.go.serverhealth.HealthStateType.forbidden;
 
 public class ConfigRepoCommand {
 
@@ -78,7 +78,7 @@ public class ConfigRepoCommand {
 
     public boolean isUserAuthorized() {
         if (!securityService.isUserAdmin(username)) {
-            result.unauthorized(unauthorizedToEdit(), unauthorised());
+            result.forbidden(forbiddenToEdit(), forbidden());
             return false;
         }
         return true;

--- a/server/src/main/java/com/thoughtworks/go/config/update/CreatePipelineConfigCommand.java
+++ b/server/src/main/java/com/thoughtworks/go/config/update/CreatePipelineConfigCommand.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2016 ThoughtWorks, Inc.
+ * Copyright 2018 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -26,8 +26,8 @@ import com.thoughtworks.go.server.service.GoConfigService;
 import com.thoughtworks.go.server.service.result.LocalizedOperationResult;
 
 import static com.thoughtworks.go.config.update.PipelineConfigErrorCopier.copyErrors;
-import static com.thoughtworks.go.i18n.LocalizedMessage.unauthorizedToEditGroup;
-import static com.thoughtworks.go.serverhealth.HealthStateType.unauthorised;
+import static com.thoughtworks.go.i18n.LocalizedMessage.forbiddenToEditGroup;
+import static com.thoughtworks.go.serverhealth.HealthStateType.forbidden;
 
 public class CreatePipelineConfigCommand implements EntityConfigUpdateCommand<PipelineConfig> {
     private final GoConfigService goConfigService;
@@ -76,7 +76,7 @@ public class CreatePipelineConfigCommand implements EntityConfigUpdateCommand<Pi
     @Override
     public boolean canContinue(CruiseConfig cruiseConfig) {
         if (goConfigService.groups().hasGroup(groupName) && !goConfigService.isUserAdminOfGroup(currentUser.getUsername(), groupName)) {
-            result.unauthorized(unauthorizedToEditGroup(groupName), unauthorised());
+            result.forbidden(forbiddenToEditGroup(groupName), forbidden());
             return false;
         }
         return true;

--- a/server/src/main/java/com/thoughtworks/go/config/update/CreateTemplateConfigCommand.java
+++ b/server/src/main/java/com/thoughtworks/go/config/update/CreateTemplateConfigCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 ThoughtWorks, Inc.
+ * Copyright 2018 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,14 +17,12 @@
 package com.thoughtworks.go.config.update;
 
 import com.thoughtworks.go.config.*;
-import com.thoughtworks.go.i18n.LocalizedMessage;
 import com.thoughtworks.go.server.domain.Username;
 import com.thoughtworks.go.server.service.SecurityService;
 import com.thoughtworks.go.server.service.result.LocalizedOperationResult;
-import com.thoughtworks.go.serverhealth.HealthStateType;
 
-import static com.thoughtworks.go.i18n.LocalizedMessage.unauthorizedToEdit;
-import static com.thoughtworks.go.serverhealth.HealthStateType.unauthorised;
+import static com.thoughtworks.go.i18n.LocalizedMessage.forbiddenToEdit;
+import static com.thoughtworks.go.serverhealth.HealthStateType.forbidden;
 
 
 public class CreateTemplateConfigCommand extends TemplateConfigCommand {
@@ -52,7 +50,7 @@ public class CreateTemplateConfigCommand extends TemplateConfigCommand {
     @Override
     public boolean canContinue(CruiseConfig cruiseConfig) {
         if (!(securityService.isUserAdmin(currentUser) || securityService.isUserGroupAdmin(currentUser))) {
-            result.unauthorized(unauthorizedToEdit(), unauthorised());
+            result.forbidden(forbiddenToEdit(), forbidden());
             return false;
         }
         return true;

--- a/server/src/main/java/com/thoughtworks/go/config/update/DeleteConfigRepoCommand.java
+++ b/server/src/main/java/com/thoughtworks/go/config/update/DeleteConfigRepoCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 ThoughtWorks, Inc.
+ * Copyright 2018 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,15 +20,12 @@ import com.thoughtworks.go.config.CruiseConfig;
 import com.thoughtworks.go.config.commands.EntityConfigUpdateCommand;
 import com.thoughtworks.go.config.remote.ConfigRepoConfig;
 import com.thoughtworks.go.config.remote.ConfigReposConfig;
-import com.thoughtworks.go.i18n.LocalizedMessage;
 import com.thoughtworks.go.server.domain.Username;
-import com.thoughtworks.go.server.service.GoConfigService;
 import com.thoughtworks.go.server.service.SecurityService;
 import com.thoughtworks.go.server.service.result.HttpLocalizedOperationResult;
-import com.thoughtworks.go.serverhealth.HealthStateType;
 
-import static com.thoughtworks.go.i18n.LocalizedMessage.unauthorizedToEdit;
-import static com.thoughtworks.go.serverhealth.HealthStateType.unauthorised;
+import static com.thoughtworks.go.i18n.LocalizedMessage.forbiddenToEdit;
+import static com.thoughtworks.go.serverhealth.HealthStateType.forbidden;
 
 public class DeleteConfigRepoCommand implements EntityConfigUpdateCommand<ConfigRepoConfig> {
     private ConfigRepoConfig preprocessedConfigRepo;
@@ -76,7 +73,7 @@ public class DeleteConfigRepoCommand implements EntityConfigUpdateCommand<Config
 
     public boolean isUserAuthorized() {
         if (!securityService.isUserAdmin(username)) {
-            result.unauthorized(unauthorizedToEdit(), unauthorised());
+            result.forbidden(forbiddenToEdit(), forbidden());
             return false;
         }
         return true;

--- a/server/src/main/java/com/thoughtworks/go/config/update/DeletePackageConfigCommand.java
+++ b/server/src/main/java/com/thoughtworks/go/config/update/DeletePackageConfigCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 ThoughtWorks, Inc.
+ * Copyright 2018 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,8 +33,8 @@ import java.util.List;
 import java.util.Map;
 
 import static com.thoughtworks.go.i18n.LocalizedMessage.cannotDeleteResourceBecauseOfDependentPipelines;
-import static com.thoughtworks.go.i18n.LocalizedMessage.unauthorizedToEdit;
-import static com.thoughtworks.go.serverhealth.HealthStateType.unauthorised;
+import static com.thoughtworks.go.i18n.LocalizedMessage.forbiddenToEdit;
+import static com.thoughtworks.go.serverhealth.HealthStateType.forbidden;
 
 public class DeletePackageConfigCommand implements EntityConfigUpdateCommand<PackageDefinition> {
     private final GoConfigService goConfigService;
@@ -95,7 +95,7 @@ public class DeletePackageConfigCommand implements EntityConfigUpdateCommand<Pac
 
     private boolean isAuthorized() {
         if (!(goConfigService.isUserAdmin(username) || goConfigService.isGroupAdministrator(username.getUsername()))) {
-            result.unauthorized(unauthorizedToEdit(), unauthorised());
+            result.forbidden(forbiddenToEdit(), forbidden());
             return false;
         }
         return true;

--- a/server/src/main/java/com/thoughtworks/go/config/update/DeletePackageRepositoryCommand.java
+++ b/server/src/main/java/com/thoughtworks/go/config/update/DeletePackageRepositoryCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 ThoughtWorks, Inc.
+ * Copyright 2018 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,8 +33,8 @@ import java.util.List;
 import java.util.Map;
 
 import static com.thoughtworks.go.i18n.LocalizedMessage.cannotDeleteResourceBecauseOfDependentPipelines;
-import static com.thoughtworks.go.i18n.LocalizedMessage.unauthorizedToEdit;
-import static com.thoughtworks.go.serverhealth.HealthStateType.unauthorised;
+import static com.thoughtworks.go.i18n.LocalizedMessage.forbiddenToEdit;
+import static com.thoughtworks.go.serverhealth.HealthStateType.forbidden;
 
 public class DeletePackageRepositoryCommand implements EntityConfigUpdateCommand<PackageRepository> {
     private final GoConfigService goConfigService;
@@ -97,7 +97,7 @@ public class DeletePackageRepositoryCommand implements EntityConfigUpdateCommand
 
     private boolean isAuthorized() {
         if (!(goConfigService.isUserAdmin(username) || goConfigService.isGroupAdministrator(username.getUsername()))) {
-            result.unauthorized(unauthorizedToEdit(), unauthorised());
+            result.forbidden(forbiddenToEdit(), forbidden());
             return false;
         }
         return true;

--- a/server/src/main/java/com/thoughtworks/go/config/update/DeletePipelineConfigCommand.java
+++ b/server/src/main/java/com/thoughtworks/go/config/update/DeletePipelineConfigCommand.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2016 ThoughtWorks, Inc.
+ * Copyright 2018 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -81,7 +81,7 @@ public class DeletePipelineConfigCommand implements EntityConfigUpdateCommand<Pi
     public boolean canContinue(CruiseConfig cruiseConfig) {
         String groupName = goConfigService.findGroupNameByPipeline(pipelineConfig.name());
         if (goConfigService.groups().hasGroup(groupName) && !goConfigService.isUserAdminOfGroup(currentUser.getUsername(), groupName)) {
-            result.unauthorized(LocalizedMessage.unauthorizedToDelete("Pipeline", pipelineConfig.getName()), HealthStateType.unauthorised());
+            result.forbidden(LocalizedMessage.forbiddenToDelete("Pipeline", pipelineConfig.getName()), HealthStateType.forbidden());
             return false;
         }
         return true;

--- a/server/src/main/java/com/thoughtworks/go/config/update/DeleteTemplateConfigCommand.java
+++ b/server/src/main/java/com/thoughtworks/go/config/update/DeleteTemplateConfigCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 ThoughtWorks, Inc.
+ * Copyright 2018 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,8 +28,8 @@ import com.thoughtworks.go.server.service.result.LocalizedOperationResult;
 import java.util.List;
 
 import static com.thoughtworks.go.i18n.LocalizedMessage.cannotDeleteResourceBecauseOfDependentPipelines;
-import static com.thoughtworks.go.i18n.LocalizedMessage.unauthorizedToEdit;
-import static com.thoughtworks.go.serverhealth.HealthStateType.unauthorised;
+import static com.thoughtworks.go.i18n.LocalizedMessage.forbiddenToEdit;
+import static com.thoughtworks.go.serverhealth.HealthStateType.forbidden;
 
 public class DeleteTemplateConfigCommand extends TemplateConfigCommand {
 
@@ -65,7 +65,7 @@ public class DeleteTemplateConfigCommand extends TemplateConfigCommand {
 
     private boolean isUserAuthorized() {
         if (!securityService.isAuthorizedToEditTemplate(templateConfig.name(), currentUser)) {
-            result.unauthorized(unauthorizedToEdit(), unauthorised());
+            result.forbidden(forbiddenToEdit(), forbidden());
             return false;
         }
         return true;

--- a/server/src/main/java/com/thoughtworks/go/config/update/ElasticAgentProfileCommand.java
+++ b/server/src/main/java/com/thoughtworks/go/config/update/ElasticAgentProfileCommand.java
@@ -19,18 +19,16 @@ package com.thoughtworks.go.config.update;
 import com.thoughtworks.go.config.CruiseConfig;
 import com.thoughtworks.go.config.elastic.ElasticProfile;
 import com.thoughtworks.go.config.elastic.ElasticProfiles;
-import com.thoughtworks.go.i18n.LocalizedMessage;
 import com.thoughtworks.go.plugin.access.elastic.ElasticAgentExtension;
 import com.thoughtworks.go.plugin.api.response.validation.ValidationResult;
 import com.thoughtworks.go.server.domain.Username;
 import com.thoughtworks.go.server.service.GoConfigService;
 import com.thoughtworks.go.server.service.result.LocalizedOperationResult;
-import com.thoughtworks.go.serverhealth.HealthStateType;
 
 import java.util.Map;
 
-import static com.thoughtworks.go.i18n.LocalizedMessage.unauthorizedToEdit;
-import static com.thoughtworks.go.serverhealth.HealthStateType.unauthorised;
+import static com.thoughtworks.go.i18n.LocalizedMessage.forbiddenToEdit;
+import static com.thoughtworks.go.serverhealth.HealthStateType.forbidden;
 
 public abstract class ElasticAgentProfileCommand extends PluginProfileCommand<ElasticProfile, ElasticProfiles> {
 
@@ -58,7 +56,7 @@ public abstract class ElasticAgentProfileCommand extends PluginProfileCommand<El
 
     protected final boolean isAuthorized() {
         if (!(goConfigService.isUserAdmin(currentUser) || goConfigService.isGroupAdministrator(currentUser.getUsername()))) {
-            result.unauthorized(unauthorizedToEdit(), unauthorised());
+            result.forbidden(forbiddenToEdit(), forbidden());
             return false;
         }
         return true;

--- a/server/src/main/java/com/thoughtworks/go/config/update/EnvironmentCommand.java
+++ b/server/src/main/java/com/thoughtworks/go/config/update/EnvironmentCommand.java
@@ -64,7 +64,7 @@ public abstract class EnvironmentCommand implements EntityConfigUpdateCommand<En
     @Override
     public boolean canContinue(CruiseConfig cruiseConfig) {
         if (!goConfigService.isAdministrator(username.getUsername())) {
-            result.unauthorized(LocalizedMessage.unauthorizedToEditResource("environment", environmentConfig.name(), username.getDisplayName()), HealthStateType.unauthorised());
+            result.forbidden(LocalizedMessage.forbiddenToEditResource("environment", environmentConfig.name(), username.getDisplayName()), HealthStateType.forbidden());
             return false;
         }
         return true;

--- a/server/src/main/java/com/thoughtworks/go/config/update/PackageConfigCommand.java
+++ b/server/src/main/java/com/thoughtworks/go/config/update/PackageConfigCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 ThoughtWorks, Inc.
+ * Copyright 2018 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,21 +16,20 @@
 
 package com.thoughtworks.go.config.update;
 
-import com.thoughtworks.go.config.*;
+import com.thoughtworks.go.config.BasicCruiseConfig;
+import com.thoughtworks.go.config.CruiseConfig;
 import com.thoughtworks.go.config.commands.EntityConfigUpdateCommand;
 import com.thoughtworks.go.domain.packagerepository.PackageDefinition;
 import com.thoughtworks.go.domain.packagerepository.PackageRepositories;
 import com.thoughtworks.go.domain.packagerepository.PackageRepository;
 import com.thoughtworks.go.domain.packagerepository.Packages;
-import com.thoughtworks.go.i18n.LocalizedMessage;
 import com.thoughtworks.go.server.domain.Username;
 import com.thoughtworks.go.server.service.GoConfigService;
 import com.thoughtworks.go.server.service.materials.PackageDefinitionService;
 import com.thoughtworks.go.server.service.result.HttpLocalizedOperationResult;
-import com.thoughtworks.go.serverhealth.HealthStateType;
 
-import static com.thoughtworks.go.i18n.LocalizedMessage.unauthorizedToEdit;
-import static com.thoughtworks.go.serverhealth.HealthStateType.unauthorised;
+import static com.thoughtworks.go.i18n.LocalizedMessage.forbiddenToEdit;
+import static com.thoughtworks.go.serverhealth.HealthStateType.forbidden;
 
 abstract class PackageConfigCommand implements EntityConfigUpdateCommand<PackageDefinition> {
     private final PackageDefinition packageDefinition;
@@ -67,7 +66,7 @@ abstract class PackageConfigCommand implements EntityConfigUpdateCommand<Package
 
     protected boolean isAuthorized() {
         if (!(goConfigService.isUserAdmin(username) || goConfigService.isGroupAdministrator(username.getUsername()))) {
-            result.unauthorized(unauthorizedToEdit(), unauthorised());
+            result.forbidden(forbiddenToEdit(), forbidden());
             return false;
         }
         return true;

--- a/server/src/main/java/com/thoughtworks/go/config/update/PackageRepositoryCommand.java
+++ b/server/src/main/java/com/thoughtworks/go/config/update/PackageRepositoryCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 ThoughtWorks, Inc.
+ * Copyright 2018 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,16 +21,14 @@ import com.thoughtworks.go.config.CruiseConfig;
 import com.thoughtworks.go.config.commands.EntityConfigUpdateCommand;
 import com.thoughtworks.go.domain.packagerepository.PackageRepositories;
 import com.thoughtworks.go.domain.packagerepository.PackageRepository;
-import com.thoughtworks.go.i18n.LocalizedMessage;
 import com.thoughtworks.go.server.domain.Username;
 import com.thoughtworks.go.server.service.GoConfigService;
 import com.thoughtworks.go.server.service.materials.PackageRepositoryService;
 import com.thoughtworks.go.server.service.result.HttpLocalizedOperationResult;
-import com.thoughtworks.go.serverhealth.HealthStateType;
 
 import static com.thoughtworks.go.config.ErrorCollector.getAllErrors;
-import static com.thoughtworks.go.i18n.LocalizedMessage.unauthorizedToEdit;
-import static com.thoughtworks.go.serverhealth.HealthStateType.unauthorised;
+import static com.thoughtworks.go.i18n.LocalizedMessage.forbiddenToEdit;
+import static com.thoughtworks.go.serverhealth.HealthStateType.forbidden;
 
 public abstract class PackageRepositoryCommand implements EntityConfigUpdateCommand<PackageRepository> {
     private PackageRepositoryService packageRepositoryService;
@@ -76,7 +74,7 @@ public abstract class PackageRepositoryCommand implements EntityConfigUpdateComm
 
     private boolean isAuthorized() {
         if (!(goConfigService.isUserAdmin(username) || goConfigService.isGroupAdministrator(username.getUsername()))) {
-            result.unauthorized(unauthorizedToEdit(), unauthorised());
+            result.forbidden(forbiddenToEdit(), forbidden());
             return false;
         }
         return true;

--- a/server/src/main/java/com/thoughtworks/go/config/update/RoleConfigCommand.java
+++ b/server/src/main/java/com/thoughtworks/go/config/update/RoleConfigCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 ThoughtWorks, Inc.
+ * Copyright 2018 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,8 +26,8 @@ import com.thoughtworks.go.server.domain.Username;
 import com.thoughtworks.go.server.service.GoConfigService;
 import com.thoughtworks.go.server.service.result.LocalizedOperationResult;
 
-import static com.thoughtworks.go.i18n.LocalizedMessage.unauthorizedToEdit;
-import static com.thoughtworks.go.serverhealth.HealthStateType.unauthorised;
+import static com.thoughtworks.go.i18n.LocalizedMessage.forbiddenToEdit;
+import static com.thoughtworks.go.serverhealth.HealthStateType.forbidden;
 
 abstract class RoleConfigCommand implements EntityConfigUpdateCommand<Role> {
     protected final GoConfigService goConfigService;
@@ -187,7 +187,7 @@ abstract class RoleConfigCommand implements EntityConfigUpdateCommand<Role> {
         if (goConfigService.isUserAdmin(currentUser)) {
             return true;
         }
-        result.unauthorized(unauthorizedToEdit(), unauthorised());
+        result.forbidden(forbiddenToEdit(), forbidden());
         return false;
     }
 

--- a/server/src/main/java/com/thoughtworks/go/config/update/SCMConfigCommand.java
+++ b/server/src/main/java/com/thoughtworks/go/config/update/SCMConfigCommand.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2016 ThoughtWorks, Inc.
+ * Copyright 2018 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -21,15 +21,13 @@ import com.thoughtworks.go.config.CruiseConfig;
 import com.thoughtworks.go.config.commands.EntityConfigUpdateCommand;
 import com.thoughtworks.go.domain.scm.SCM;
 import com.thoughtworks.go.domain.scm.SCMs;
-import com.thoughtworks.go.i18n.LocalizedMessage;
 import com.thoughtworks.go.server.domain.Username;
 import com.thoughtworks.go.server.service.GoConfigService;
 import com.thoughtworks.go.server.service.materials.PluggableScmService;
 import com.thoughtworks.go.server.service.result.LocalizedOperationResult;
-import com.thoughtworks.go.serverhealth.HealthStateType;
 
-import static com.thoughtworks.go.i18n.LocalizedMessage.unauthorizedToEdit;
-import static com.thoughtworks.go.serverhealth.HealthStateType.unauthorised;
+import static com.thoughtworks.go.i18n.LocalizedMessage.forbiddenToEdit;
+import static com.thoughtworks.go.serverhealth.HealthStateType.forbidden;
 
 public abstract class SCMConfigCommand implements EntityConfigUpdateCommand<SCM> {
     protected final SCM globalScmConfig;
@@ -79,7 +77,7 @@ public abstract class SCMConfigCommand implements EntityConfigUpdateCommand<SCM>
 
     private boolean isAuthorized() {
         if (!(goConfigService.isUserAdmin(currentUser) || goConfigService.isGroupAdministrator(currentUser.getUsername()))) {
-            result.unauthorized(unauthorizedToEdit(), unauthorised());
+            result.forbidden(forbiddenToEdit(), forbidden());
             return false;
         }
         return true;

--- a/server/src/main/java/com/thoughtworks/go/config/update/SecurityAuthConfigCommand.java
+++ b/server/src/main/java/com/thoughtworks/go/config/update/SecurityAuthConfigCommand.java
@@ -19,18 +19,16 @@ package com.thoughtworks.go.config.update;
 import com.thoughtworks.go.config.CruiseConfig;
 import com.thoughtworks.go.config.SecurityAuthConfig;
 import com.thoughtworks.go.config.SecurityAuthConfigs;
-import com.thoughtworks.go.i18n.LocalizedMessage;
 import com.thoughtworks.go.plugin.access.authorization.AuthorizationExtension;
 import com.thoughtworks.go.plugin.api.response.validation.ValidationResult;
 import com.thoughtworks.go.server.domain.Username;
 import com.thoughtworks.go.server.service.GoConfigService;
 import com.thoughtworks.go.server.service.result.LocalizedOperationResult;
-import com.thoughtworks.go.serverhealth.HealthStateType;
 
 import java.util.Map;
 
-import static com.thoughtworks.go.i18n.LocalizedMessage.unauthorizedToEdit;
-import static com.thoughtworks.go.serverhealth.HealthStateType.unauthorised;
+import static com.thoughtworks.go.i18n.LocalizedMessage.forbiddenToEdit;
+import static com.thoughtworks.go.serverhealth.HealthStateType.forbidden;
 
 public abstract class SecurityAuthConfigCommand extends PluginProfileCommand<SecurityAuthConfig, SecurityAuthConfigs> {
     protected final AuthorizationExtension extension;
@@ -59,7 +57,7 @@ public abstract class SecurityAuthConfigCommand extends PluginProfileCommand<Sec
         if (goConfigService.isUserAdmin(currentUser)) {
             return true;
         }
-        result.unauthorized(unauthorizedToEdit(), unauthorised());
+        result.forbidden(forbiddenToEdit(), forbidden());
         return false;
     }
 

--- a/server/src/main/java/com/thoughtworks/go/config/update/UpdateTemplateConfigCommand.java
+++ b/server/src/main/java/com/thoughtworks/go/config/update/UpdateTemplateConfigCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 ThoughtWorks, Inc.
+ * Copyright 2018 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,8 +25,8 @@ import com.thoughtworks.go.server.service.SecurityService;
 import com.thoughtworks.go.server.service.result.LocalizedOperationResult;
 
 import static com.thoughtworks.go.i18n.LocalizedMessage.staleResourceConfig;
-import static com.thoughtworks.go.i18n.LocalizedMessage.unauthorizedToEdit;
-import static com.thoughtworks.go.serverhealth.HealthStateType.unauthorised;
+import static com.thoughtworks.go.i18n.LocalizedMessage.forbiddenToEdit;
+import static com.thoughtworks.go.serverhealth.HealthStateType.forbidden;
 
 
 public class UpdateTemplateConfigCommand extends TemplateConfigCommand {
@@ -34,7 +34,12 @@ public class UpdateTemplateConfigCommand extends TemplateConfigCommand {
     private String md5;
     private EntityHashingService entityHashingService;
 
-    public UpdateTemplateConfigCommand(PipelineTemplateConfig templateConfig, Username currentUser, SecurityService securityService, LocalizedOperationResult result, String md5, EntityHashingService entityHashingService) {
+    public UpdateTemplateConfigCommand(PipelineTemplateConfig templateConfig,
+                                       Username currentUser,
+                                       SecurityService securityService,
+                                       LocalizedOperationResult result,
+                                       String md5,
+                                       EntityHashingService entityHashingService) {
         super(templateConfig, result, currentUser);
         this.securityService = securityService;
         this.md5 = md5;
@@ -63,7 +68,7 @@ public class UpdateTemplateConfigCommand extends TemplateConfigCommand {
 
     private boolean isUserAuthorized() {
         if (!securityService.isAuthorizedToEditTemplate(templateConfig.name(), currentUser)) {
-            result.unauthorized(unauthorizedToEdit(), unauthorised());
+            result.forbidden(forbiddenToEdit(), forbidden());
             return false;
         }
         return true;

--- a/server/src/main/java/com/thoughtworks/go/server/controller/GoConfigAdministrationController.java
+++ b/server/src/main/java/com/thoughtworks/go/server/controller/GoConfigAdministrationController.java
@@ -81,10 +81,10 @@ public class GoConfigAdministrationController {
 
     private RestfulAction getXmlPartial(String groupName, String oldMd5, GoConfigService.XmlPartialSaver xmlPartialSaver) {
         if (!isTemplate(groupName) && !isCurrentUserAdminOfGroup(groupName)) {
-            return XmlAction.xmlUnAuthorized(errorMessageForGroup(groupName));
+            return XmlAction.xmlForbidden(errorMessageForGroup(groupName));
         }
         if (isTemplate(groupName) && !isCurrentUserAdmin()) {
-            return XmlAction.xmlUnAuthorized(errorMessageForTemplates());
+            return XmlAction.xmlForbidden(errorMessageForTemplates());
         }
         String xml;
         try {
@@ -122,17 +122,17 @@ public class GoConfigAdministrationController {
         }
 
         if (!isCurrentUserAdmin()) {
-            return JsonAction.jsonUnauthorized().respond(response);
+            return JsonAction.jsonForbidden().respond(response);
         }
         return postXmlPartial(null, goConfigService.fileSaver(false), xmlFile, "File changed successfully.", md5).respond(response);
     }
 
     private RestfulAction postXmlPartial(String groupName, GoConfigService.XmlPartialSaver xmlPartialSaver, String xmlPartial, String successMessage, String expectedMd5) {
         if (!isTemplate(groupName) && !isCurrentUserAdminOfGroup(groupName)) {
-            return JsonAction.jsonUnauthorized(errorMessageForGroup(groupName));
+            return JsonAction.jsonForbidden(errorMessageForGroup(groupName));
         }
         if (isTemplate(groupName) && !isCurrentUserAdmin()) {
-            return JsonAction.jsonUnauthorized();
+            return JsonAction.jsonForbidden();
         }
         GoConfigValidity configValidity = xmlPartialSaver.saveXml(xmlPartial, expectedMd5);
         if (configValidity.isValid()) {

--- a/server/src/main/java/com/thoughtworks/go/server/controller/StageController.java
+++ b/server/src/main/java/com/thoughtworks/go/server/controller/StageController.java
@@ -76,7 +76,7 @@ public class StageController {
             return ResponseCodeView.create(HttpServletResponse.SC_OK, "");
 
         } catch (GoUnauthorizedException e) {
-            return ResponseCodeView.create(HttpServletResponse.SC_UNAUTHORIZED, "");
+            return ResponseCodeView.create(HttpServletResponse.SC_FORBIDDEN, "");
         } catch (StageNotFoundException e) {
             LOGGER.error("Error while rerunning {}/{}/{}", pipelineName, counterOrLabel, stageName, e);
             return ResponseCodeView.create(HttpServletResponse.SC_NOT_FOUND, e.getMessage());
@@ -98,15 +98,15 @@ public class StageController {
             scheduleService.cancelAndTriggerRelevantStages(stageId, SessionUtils.currentUsername(), cancelResult);
             return handleResult(cancelResult, response);
         } catch (GoUnauthorizedException e) {
-            return ResponseCodeView.create(HttpServletResponse.SC_UNAUTHORIZED, e.getMessage());
+            return ResponseCodeView.create(HttpServletResponse.SC_FORBIDDEN, e.getMessage());
         } catch (Exception e) {
             return ResponseCodeView.create(HttpServletResponse.SC_NOT_ACCEPTABLE, e.getMessage());
         }
     }
 
     private ModelAndView handleResult(HttpLocalizedOperationResult cancelResult, HttpServletResponse response) {
-        if (cancelResult.httpCode() == HttpServletResponse.SC_UNAUTHORIZED) {
-            return ResponseCodeView.create(HttpServletResponse.SC_UNAUTHORIZED, cancelResult.message());
+        if (cancelResult.httpCode() == HttpServletResponse.SC_FORBIDDEN) {
+            return ResponseCodeView.create(HttpServletResponse.SC_FORBIDDEN, cancelResult.message());
         }
         return jsonOK().respond(response);
     }

--- a/server/src/main/java/com/thoughtworks/go/server/controller/actions/JsonAction.java
+++ b/server/src/main/java/com/thoughtworks/go/server/controller/actions/JsonAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 ThoughtWorks, Inc.
+ * Copyright 2018 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -65,18 +65,18 @@ public class JsonAction implements RestfulAction {
         return new JsonAction(SC_NOT_ACCEPTABLE, json);
     }
 
-    public static JsonAction jsonUnauthorized() {
-        return new JsonAction(SC_UNAUTHORIZED, new LinkedHashMap());
+    public static JsonAction jsonForbidden() {
+        return new JsonAction(SC_FORBIDDEN, new LinkedHashMap());
     }
 
-    public static JsonAction jsonUnauthorized(String message) {
+    public static JsonAction jsonForbidden(String message) {
         Map<String, Object> map = new LinkedHashMap<>();
         map.put(ERROR_FOR_JSON, message);
-        return new JsonAction(SC_UNAUTHORIZED, map);
+        return new JsonAction(SC_FORBIDDEN, map);
     }
 
-    public static JsonAction jsonUnauthorized(Exception e) {
-        return jsonUnauthorized(e.getMessage());
+    public static JsonAction jsonForbidden(Exception e) {
+        return jsonForbidden(e.getMessage());
     }
 
     public static JsonAction jsonBadRequest(Object json) {

--- a/server/src/main/java/com/thoughtworks/go/server/controller/actions/XmlAction.java
+++ b/server/src/main/java/com/thoughtworks/go/server/controller/actions/XmlAction.java
@@ -1,5 +1,5 @@
 /*************************GO-LICENSE-START*********************************
- * Copyright 2014 ThoughtWorks, Inc.
+ * Copyright 2018 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,14 +16,14 @@
 
 package com.thoughtworks.go.server.controller.actions;
 
-import javax.servlet.http.HttpServletResponse;
-
 import org.springframework.web.servlet.ModelAndView;
+
+import javax.servlet.http.HttpServletResponse;
 
 import static com.thoughtworks.go.util.GoConstants.RESPONSE_CHARSET;
 import static javax.servlet.http.HttpServletResponse.SC_CONFLICT;
 import static javax.servlet.http.HttpServletResponse.SC_OK;
-import static javax.servlet.http.HttpServletResponse.SC_UNAUTHORIZED;
+import static org.apache.http.HttpStatus.SC_FORBIDDEN;
 
 public class XmlAction extends BasicRestfulAction {
     private final String md5;
@@ -65,7 +65,7 @@ public class XmlAction extends BasicRestfulAction {
         return super.respond(response);
     }
 
-    public static RestfulAction xmlUnAuthorized(String message) {
-       return new XmlAction(SC_UNAUTHORIZED, message); 
+    public static RestfulAction xmlForbidden(String message) {
+       return new XmlAction(SC_FORBIDDEN, message);
     }
 }

--- a/server/src/main/java/com/thoughtworks/go/server/materials/MaterialUpdateService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/materials/MaterialUpdateService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 ThoughtWorks, Inc.
+ * Copyright 2018 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -118,7 +118,7 @@ public class MaterialUpdateService implements GoMessageListener<MaterialUpdateCo
 
     public void notifyMaterialsForUpdate(Username username, Object params, HttpLocalizedOperationResult result) {
         if (!goConfigService.isUserAdmin(username)) {
-            result.unauthorized("Unauthorized to access this API.", HealthStateType.unauthorised());
+            result.forbidden("Unauthorized to access this API.", HealthStateType.forbidden());
             return;
         }
         final Map attributes = (Map) params;

--- a/server/src/main/java/com/thoughtworks/go/server/service/AgentService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/AgentService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 ThoughtWorks, Inc.
+ * Copyright 2018 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -157,7 +157,7 @@ public class AgentService {
     private boolean hasOperatePermission(Username username, OperationResult operationResult) {
         if (!securityService.hasOperatePermissionForAgents(username)) {
             String message = "Unauthorized to operate on agent";
-            operationResult.unauthorized(message, message, HealthStateType.general(HealthStateScope.GLOBAL));
+            operationResult.forbidden(message, message, HealthStateType.general(HealthStateScope.GLOBAL));
             return false;
         }
         return true;

--- a/server/src/main/java/com/thoughtworks/go/server/service/BackupService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/BackupService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 ThoughtWorks, Inc.
+ * Copyright 2018 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -94,7 +94,7 @@ public class BackupService implements BackupStatusProvider {
 
     public ServerBackup startBackup(Username username, HttpLocalizedOperationResult result) {
         if (!goConfigService.isUserAdmin(username)) {
-            result.unauthorized("Unauthorized to initiate Go backup as you are not a Go administrator", HealthStateType.unauthorised());
+            result.forbidden("Unauthorized to initiate Go backup as you are not a Go administrator", HealthStateType.forbidden());
             return null;
         }
         GoMailSender mailSender = goConfigService.getMailSender();

--- a/server/src/main/java/com/thoughtworks/go/server/service/ChangesetService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/ChangesetService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 ThoughtWorks, Inc.
+ * Copyright 2018 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -74,7 +74,7 @@ public class ChangesetService {
     public List<MaterialRevision> revisionsBetween(String pipelineName, Integer fromCounter, Integer toCounter, Username username, HttpLocalizedOperationResult result, boolean skipCheckForMingle,
                                                    boolean showBisect) {
         if (!securityService.hasViewPermissionForPipeline(username, pipelineName)) {
-            result.unauthorized(LocalizedMessage.unauthorizedToViewPipeline(pipelineName), HealthStateType.general(HealthStateScope.forPipeline(pipelineName)));
+            result.forbidden(LocalizedMessage.forbiddenToViewPipeline(pipelineName), HealthStateType.general(HealthStateScope.forPipeline(pipelineName)));
             return new ArrayList<>();
         }
 

--- a/server/src/main/java/com/thoughtworks/go/server/service/FailureService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/FailureService.java
@@ -1,18 +1,18 @@
-/*************************GO-LICENSE-START*********************************
- * Copyright 2014 ThoughtWorks, Inc.
+/*
+ * Copyright 2018 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *************************GO-LICENSE-END***********************************/
+ */
 
 package com.thoughtworks.go.server.service;
 
@@ -48,7 +48,7 @@ public class FailureService {
         if (securityService.hasViewPermissionForPipeline(username, pipelineName)) {
             return shineDao.failureDetailsForTest(jobIdentifier, suiteName, testName, result);
         }
-        result.unauthorized("User '" + CaseInsensitiveString.str(username.getUsername()) + "' does not have view permission on pipeline '" + pipelineName + "'", HealthStateType.unauthorisedForPipeline(pipelineName));
+        result.forbidden("User '" + CaseInsensitiveString.str(username.getUsername()) + "' does not have view permission on pipeline '" + pipelineName + "'", HealthStateType.forbiddenForPipeline(pipelineName));
         return FailureDetails.nullFailureDetails();
     }
 }

--- a/server/src/main/java/com/thoughtworks/go/server/service/GoConfigService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/GoConfigService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 ThoughtWorks, Inc.
+ * Copyright 2018 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -170,7 +170,7 @@ public class GoConfigService implements Initializer, CruiseConfigProvider {
             return false;
         }
         if (!isUserAdminOfGroup(username.getUsername(), groupName)) {
-            result.unauthorized(unauthorizedToEditPipeline(pipelineName), unauthorisedForPipeline(pipelineName));
+            result.forbidden(forbiddenToEditPipeline(pipelineName), forbiddenForPipeline(pipelineName));
             return false;
         }
         return true;
@@ -892,7 +892,7 @@ public class GoConfigService implements Initializer, CruiseConfigProvider {
 
     private boolean isAdminOfGroup(String toGroupName, Username username, HttpLocalizedOperationResult result) {
         if (!isUserAdminOfGroup(username.getUsername(), toGroupName)) {
-            result.unauthorized(unauthorizedToEditGroup(toGroupName), unauthorised());
+            result.forbidden(forbiddenToEditGroup(toGroupName), forbidden());
             return false;
         }
         return true;
@@ -906,7 +906,7 @@ public class GoConfigService implements Initializer, CruiseConfigProvider {
     @Deprecated()
     public CruiseConfig loadCruiseConfigForEdit(Username username, HttpLocalizedOperationResult result) {
         if (!isUserAdmin(username) && !isUserTemplateAdmin(username)) {
-            result.unauthorized(LocalizedMessage.unauthorizedToEdit(), HealthStateType.unauthorised());
+            result.forbidden(LocalizedMessage.forbiddenToEdit(), HealthStateType.forbidden());
         }
         return clonedConfigForEdit();
     }

--- a/server/src/main/java/com/thoughtworks/go/server/service/JobInstanceService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/JobInstanceService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 ThoughtWorks, Inc.
+ * Copyright 2018 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -102,7 +102,7 @@ public class JobInstanceService implements JobPlanLoader, ConfigChangedListener 
             return null;
         }
         if (!securityService.hasViewPermissionForPipeline(Username.valueOf(username), pipelineName)) {
-            result.unauthorized("Unauthorized", NOT_AUTHORIZED_TO_VIEW_PIPELINE, HealthStateType.general(HealthStateScope.forPipeline(pipelineName)));
+            result.forbidden("Unauthorized", NOT_AUTHORIZED_TO_VIEW_PIPELINE, HealthStateType.general(HealthStateScope.forPipeline(pipelineName)));
             return null;
         }
 

--- a/server/src/main/java/com/thoughtworks/go/server/service/MaterialConfigService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/MaterialConfigService.java
@@ -1,5 +1,5 @@
 /*************************GO-LICENSE-START*********************************
- * Copyright 2014 ThoughtWorks, Inc.
+ * Copyright 2018 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -84,7 +84,7 @@ public class MaterialConfigService {
 		}
 
 		if (!hasViewPermissionForMaterial) {
-			result.unauthorized("Unauthorized", "Do not have view permission to this material", HealthStateType.general(HealthStateScope.GLOBAL));
+			result.forbidden("Unauthorized", "Do not have view permission to this material", HealthStateType.general(HealthStateScope.GLOBAL));
 			return null;
 		}
 

--- a/server/src/main/java/com/thoughtworks/go/server/service/MaterialService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/MaterialService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 ThoughtWorks, Inc.
+ * Copyright 2018 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -61,8 +61,12 @@ public class MaterialService {
     private Map<Class, MaterialPoller> materialPollerMap = new HashMap<>();
 
     @Autowired
-    public MaterialService(MaterialRepository materialRepository, GoConfigService goConfigService, SecurityService securityService,
-                           PackageRepositoryExtension packageRepositoryExtension, SCMExtension scmExtension, TransactionTemplate transactionTemplate) {
+    public MaterialService(MaterialRepository materialRepository,
+                           GoConfigService goConfigService,
+                           SecurityService securityService,
+                           PackageRepositoryExtension packageRepositoryExtension,
+                           SCMExtension scmExtension,
+                           TransactionTemplate transactionTemplate) {
         this.materialRepository = materialRepository;
         this.goConfigService = goConfigService;
         this.securityService = securityService;
@@ -87,9 +91,13 @@ public class MaterialService {
         return !materialRepository.findLatestModification(material).isEmpty();
     }
 
-    public List<MatchedRevision> searchRevisions(String pipelineName, String fingerprint, String searchString, Username username, LocalizedOperationResult result) {
+    public List<MatchedRevision> searchRevisions(String pipelineName,
+                                                 String fingerprint,
+                                                 String searchString,
+                                                 Username username,
+                                                 LocalizedOperationResult result) {
         if (!securityService.hasViewPermissionForPipeline(username, pipelineName)) {
-            result.unauthorized(LocalizedMessage.unauthorizedToViewPipeline(pipelineName), HealthStateType.general(HealthStateScope.forPipeline(pipelineName)));
+            result.forbidden(LocalizedMessage.forbiddenToViewPipeline(pipelineName), HealthStateType.general(HealthStateScope.forPipeline(pipelineName)));
             return new ArrayList<>();
         }
         try {
@@ -101,11 +109,16 @@ public class MaterialService {
         }
     }
 
-    public List<Modification> latestModification(Material material, File baseDir, final SubprocessExecutionContext execCtx) {
+    public List<Modification> latestModification(Material material,
+                                                 File baseDir,
+                                                 final SubprocessExecutionContext execCtx) {
         return getPollerImplementation(material).latestModification(material, baseDir, execCtx);
     }
 
-    public List<Modification> modificationsSince(Material material, File baseDir, Revision revision, final SubprocessExecutionContext execCtx) {
+    public List<Modification> modificationsSince(Material material,
+                                                 File baseDir,
+                                                 Revision revision,
+                                                 final SubprocessExecutionContext execCtx) {
         return getPollerImplementation(material).modificationsSince(material, baseDir, revision, execCtx);
     }
 
@@ -114,17 +127,17 @@ public class MaterialService {
         return materialPoller == null ? new NoOpPoller() : materialPoller;
     }
 
-	public Long getTotalModificationsFor(MaterialConfig materialConfig) {
-		MaterialInstance materialInstance = materialRepository.findMaterialInstance(materialConfig);
+    public Long getTotalModificationsFor(MaterialConfig materialConfig) {
+        MaterialInstance materialInstance = materialRepository.findMaterialInstance(materialConfig);
 
-		return materialRepository.getTotalModificationsFor(materialInstance);
-	}
+        return materialRepository.getTotalModificationsFor(materialInstance);
+    }
 
-	public Modifications getModificationsFor(MaterialConfig materialConfig, Pagination pagination) {
-		MaterialInstance materialInstance = materialRepository.findMaterialInstance(materialConfig);
+    public Modifications getModificationsFor(MaterialConfig materialConfig, Pagination pagination) {
+        MaterialInstance materialInstance = materialRepository.findMaterialInstance(materialConfig);
 
-		return materialRepository.getModificationsFor(materialInstance, pagination);
-	}
+        return materialRepository.getModificationsFor(materialInstance, pagination);
+    }
 
     Class<? extends Material> getMaterialClass(Material material) {
         return material.getClass();

--- a/server/src/main/java/com/thoughtworks/go/server/service/MingleConfigService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/MingleConfigService.java
@@ -1,18 +1,18 @@
-/*************************GO-LICENSE-START*********************************
- * Copyright 2014 ThoughtWorks, Inc.
+/*
+ * Copyright 2018 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *************************GO-LICENSE-END***********************************/
+ */
 
 package com.thoughtworks.go.server.service;
 
@@ -42,7 +42,7 @@ public class MingleConfigService {
 
     public MingleConfig mingleConfigForPipelineNamed(String pipelineName, Username user, HttpLocalizedOperationResult result) {
         if (!securityService.hasViewPermissionForPipeline(user, pipelineName)) {
-            result.unauthorized(LocalizedMessage.unauthorizedToViewPipeline(pipelineName), HealthStateType.unauthorisedForPipeline(pipelineName));
+            result.forbidden(LocalizedMessage.forbiddenToViewPipeline(pipelineName), HealthStateType.forbiddenForPipeline(pipelineName));
             return null;
         }
         PipelineConfig pipelineConfig = goConfigService.pipelineConfigNamed(new CaseInsensitiveString(pipelineName));

--- a/server/src/main/java/com/thoughtworks/go/server/service/PipelineConfigsService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/PipelineConfigsService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 ThoughtWorks, Inc.
+ * Copyright 2018 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,8 +31,8 @@ import org.springframework.stereotype.Service;
 import java.util.ArrayList;
 import java.util.List;
 
-import static com.thoughtworks.go.i18n.LocalizedMessage.unauthorizedToEditGroup;
-import static com.thoughtworks.go.serverhealth.HealthStateType.unauthorisedForGroup;
+import static com.thoughtworks.go.i18n.LocalizedMessage.forbiddenToEditGroup;
+import static com.thoughtworks.go.serverhealth.HealthStateType.forbiddenForGroup;
 
 @Service
 public class PipelineConfigsService {
@@ -101,7 +101,7 @@ public class PipelineConfigsService {
     private boolean userHasPermissions(Username username, String groupName, HttpLocalizedOperationResult result) {
         try {
             if (!securityService.isUserAdminOfGroup(username.getUsername(), groupName)) {
-                result.unauthorized(unauthorizedToEditGroup(groupName), unauthorisedForGroup(groupName));
+                result.forbidden(forbiddenToEditGroup(groupName), forbiddenForGroup(groupName));
                 return false;
             }
         } catch (Exception e) {

--- a/server/src/main/java/com/thoughtworks/go/server/service/PipelineHistoryService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/PipelineHistoryService.java
@@ -104,7 +104,7 @@ public class PipelineHistoryService implements PipelineInstanceLoader {
         }
         PipelineConfig pipelineConfig = goConfigService.currentCruiseConfig().pipelineConfigByName(new CaseInsensitiveString(pipeline.getName()));
         if (!securityService.hasViewPermissionForPipeline(username, pipeline.getName())) {
-            result.unauthorized("Unauthorized", NOT_AUTHORIZED_TO_VIEW_PIPELINE, HealthStateType.general(HealthStateScope.forPipeline(pipeline.getName())));
+            result.forbidden("Forbidden", NOT_AUTHORIZED_TO_VIEW_PIPELINE, HealthStateType.general(HealthStateScope.forPipeline(pipeline.getName())));
             return null;
         }
         populatePipelineInstanceModel(username, false, pipelineConfig, pipeline);
@@ -141,7 +141,7 @@ public class PipelineHistoryService implements PipelineInstanceLoader {
 			return null;
 		}
 		if (!securityService.hasViewPermissionForPipeline(username, pipelineName)) {
-			result.unauthorized("Unauthorized", NOT_AUTHORIZED_TO_VIEW_PIPELINE, HealthStateType.general(HealthStateScope.forPipeline(pipelineName)));
+			result.forbidden("Forbidden", NOT_AUTHORIZED_TO_VIEW_PIPELINE, HealthStateType.general(HealthStateScope.forPipeline(pipelineName)));
 			return null;
 		}
 
@@ -165,7 +165,7 @@ public class PipelineHistoryService implements PipelineInstanceLoader {
 			return null;
 		}
 		if (!securityService.hasViewPermissionForPipeline(Username.valueOf(username), pipelineName)) {
-			result.unauthorized("Unauthorized", NOT_AUTHORIZED_TO_VIEW_PIPELINE, HealthStateType.general(HealthStateScope.forPipeline(pipelineName)));
+			result.forbidden("Forbidden", NOT_AUTHORIZED_TO_VIEW_PIPELINE, HealthStateType.general(HealthStateScope.forPipeline(pipelineName)));
 			return null;
 		}
 
@@ -323,7 +323,7 @@ public class PipelineHistoryService implements PipelineInstanceLoader {
             return false;
         }
         if (!securityService.hasViewPermissionForPipeline(username, pipelineName)) {
-            result.unauthorized(NOT_AUTHORIZED_TO_VIEW_PIPELINE, NOT_AUTHORIZED_TO_VIEW_PIPELINE, HealthStateType.general(HealthStateScope.forPipeline(pipelineName)));
+            result.forbidden(NOT_AUTHORIZED_TO_VIEW_PIPELINE, NOT_AUTHORIZED_TO_VIEW_PIPELINE, HealthStateType.general(HealthStateScope.forPipeline(pipelineName)));
             return false;
         }
         return true;
@@ -576,7 +576,7 @@ public class PipelineHistoryService implements PipelineInstanceLoader {
     public PipelineInstanceModels findMatchingPipelineInstances(String pipelineName, String pattern, int limit, Username userName, HttpLocalizedOperationResult result) {
         pattern = escapeWildCardsAndTrim(pattern.trim());
         if (!securityService.hasViewPermissionForPipeline(userName, pipelineName)) {
-            result.unauthorized(LocalizedMessage.unauthorizedToViewPipeline(pipelineName), HealthStateType.general(HealthStateScope.forPipeline(pipelineName)));
+            result.forbidden(LocalizedMessage.forbiddenToViewPipeline(pipelineName), HealthStateType.general(HealthStateScope.forPipeline(pipelineName)));
             return PipelineInstanceModels.createPipelineInstanceModels();
         }
         PipelineInstanceModels models = pipelineDao.findMatchingPipelineInstances(pipelineName, pattern, limitForPipeline(pipelineName, limit));
@@ -609,7 +609,7 @@ public class PipelineHistoryService implements PipelineInstanceLoader {
         if (securityService.hasOperatePermissionForPipeline(username.getUsername(), pipelineName)) {
             pipelineDao.updateComment(pipelineName, pipelineCounter, comment);
         } else {
-            result.unauthorized("You do not have operate permissions for pipeline '" + pipelineName + "'.", HealthStateType.general(HealthStateScope.forPipeline(pipelineName)));
+            result.forbidden("You do not have operate permissions for pipeline '" + pipelineName + "'.", HealthStateType.general(HealthStateScope.forPipeline(pipelineName)));
         }
     }
 

--- a/server/src/main/java/com/thoughtworks/go/server/service/PipelinePauseService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/PipelinePauseService.java
@@ -20,6 +20,7 @@ import com.thoughtworks.go.config.CaseInsensitiveString;
 import com.thoughtworks.go.config.CruiseConfig;
 import com.thoughtworks.go.config.PipelineConfig;
 import com.thoughtworks.go.domain.PipelinePauseInfo;
+import com.thoughtworks.go.i18n.LocalizedMessage;
 import com.thoughtworks.go.server.dao.PipelineSqlMapDao;
 import com.thoughtworks.go.server.domain.PipelinePauseChangeListener;
 import com.thoughtworks.go.server.domain.Username;
@@ -36,10 +37,10 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static com.thoughtworks.go.i18n.LocalizedMessage.resourceNotFound;
-import static com.thoughtworks.go.i18n.LocalizedMessage.unauthorizedToEditPipeline;
+import static com.thoughtworks.go.i18n.LocalizedMessage.forbiddenToEditPipeline;
 import static com.thoughtworks.go.serverhealth.HealthStateScope.forPipeline;
 import static com.thoughtworks.go.serverhealth.HealthStateType.general;
-import static com.thoughtworks.go.serverhealth.HealthStateType.unauthorisedForPipeline;
+import static com.thoughtworks.go.serverhealth.HealthStateType.forbiddenForPipeline;
 
 @Service
 public class PipelinePauseService {
@@ -140,7 +141,7 @@ public class PipelinePauseService {
         if (securityService.hasOperatePermissionForGroup(new CaseInsensitiveString(pauseBy), cruiseConfig.findGroupOfPipeline(pipelineConfig).getGroup())) {
             return false;
         }
-        result.unauthorized(unauthorizedToEditPipeline(pipelineName), unauthorisedForPipeline(pipelineName));
+        result.forbidden(LocalizedMessage.forbiddenToEditPipeline(pipelineName), forbiddenForPipeline(pipelineName));
         return true;
     }
 

--- a/server/src/main/java/com/thoughtworks/go/server/service/PipelineStagesFeedService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/PipelineStagesFeedService.java
@@ -1,18 +1,18 @@
-/*************************GO-LICENSE-START*********************************
- * Copyright 2014 ThoughtWorks, Inc.
+/*
+ * Copyright 2018 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *************************GO-LICENSE-END***********************************/
+ */
 
 package com.thoughtworks.go.server.service;
 
@@ -23,7 +23,7 @@ import com.thoughtworks.go.server.service.result.LocalizedOperationResult;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-import static com.thoughtworks.go.serverhealth.HealthStateType.unauthorisedForPipeline;
+import static com.thoughtworks.go.serverhealth.HealthStateType.forbiddenForPipeline;
 
 @Service
 public class PipelineStagesFeedService {
@@ -57,7 +57,7 @@ public class PipelineStagesFeedService {
 
         private boolean userDoesNotHaveViewPermission(Username user, LocalizedOperationResult operationResult) {
             if (!securityService.hasViewPermissionForPipeline(user, pipelineName)) {
-                operationResult.unauthorized("User '" + CaseInsensitiveString.str(user.getUsername()) + "' does not have view permission on pipeline '" + pipelineName + "'", unauthorisedForPipeline(pipelineName));
+                operationResult.forbidden("User '" + CaseInsensitiveString.str(user.getUsername()) + "' does not have view permission on pipeline '" + pipelineName + "'", forbiddenForPipeline(pipelineName));
                 return true;
             }
             return false;

--- a/server/src/main/java/com/thoughtworks/go/server/service/PipelineUnlockApiService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/PipelineUnlockApiService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 ThoughtWorks, Inc.
+ * Copyright 2018 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -68,7 +68,7 @@ public class PipelineUnlockApiService {
         }
         if (!securityService.hasOperatePermissionForPipeline(username.getUsername(), pipelineName)) {
             String msg = "user does not have operate permission on the pipeline";
-            result.unauthorized(msg, msg, HealthStateType.general(HealthStateScope.forPipeline(pipelineName)));
+            result.forbidden(msg, msg, HealthStateType.general(HealthStateScope.forPipeline(pipelineName)));
             return false;
         }
         return isUnlockable(pipelineName, result);

--- a/server/src/main/java/com/thoughtworks/go/server/service/PluginService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/PluginService.java
@@ -216,7 +216,7 @@ public class PluginService {
             return true;
         }
 
-        result.unauthorized(LocalizedMessage.unauthorizedToEdit(), HealthStateType.unauthorised());
+        result.forbidden(LocalizedMessage.forbiddenToEdit(), HealthStateType.forbidden());
         return false;
     }
 }

--- a/server/src/main/java/com/thoughtworks/go/server/service/ScheduleService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/ScheduleService.java
@@ -471,7 +471,7 @@ public class ScheduleService {
             String user = username == null ? null : username.getUsername().toString();
 
             if (!securityService.hasOperatePermissionForStage(pipelineName, stageName, user)) {
-                opResult.unauthorized("Unauthorized to operate stage named " + stageName, HealthStateType.unauthorised());
+                opResult.forbidden("Unauthorized to operate stage named " + stageName, HealthStateType.forbidden());
                 return null;
             }
 
@@ -802,7 +802,7 @@ public class ScheduleService {
         @Override
         public void noOperatePermission(String pipelineName, String stageName) {
             String message = noOperatePermissionMessage(pipelineName, stageName);
-            result.unauthorized(message, message, stageScopedHealthState(pipelineName, stageName));
+            result.forbidden(message, message, stageScopedHealthState(pipelineName, stageName));
             super.noOperatePermission(pipelineName, stageName);
         }
 

--- a/server/src/main/java/com/thoughtworks/go/server/service/StageAuthorizationChecker.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/StageAuthorizationChecker.java
@@ -1,5 +1,5 @@
 /*************************GO-LICENSE-START*********************************
- * Copyright 2014 ThoughtWorks, Inc.
+ * Copyright 2018 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,7 +38,7 @@ public class StageAuthorizationChecker implements SchedulingChecker {
         HealthStateType id = HealthStateType.general(HealthStateScope.forPipeline(pipelineName));
         if (!securityService.hasOperatePermissionForStage(pipelineName, stageName, username)) {
             String message = String.format("Failed to trigger pipeline [%s]", pipelineName);
-            result.unauthorized(message,
+            result.forbidden(message,
                     "User " + username + " does not have permission to schedule " + pipelineName + "/" + stageName,
                     id);
         } else {

--- a/server/src/main/java/com/thoughtworks/go/server/service/StageService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/StageService.java
@@ -82,9 +82,17 @@ public class StageService implements StageRunFinder, StageFinder {
     private static final String NOT_AUTHORIZED_TO_VIEW_PIPELINE = "Not authorized to view pipeline";
 
     @Autowired
-    public StageService(StageDao stageDao, JobInstanceService jobInstanceService, StageStatusTopic stageStatusTopic, StageStatusCache stageStatusCache,
-                        SecurityService securityService, PipelineDao pipelineDao, ChangesetService changesetService, GoConfigService goConfigService,
-                        TransactionTemplate transactionTemplate, TransactionSynchronizationManager transactionSynchronizationManager, GoCache goCache,
+    public StageService(StageDao stageDao,
+                        JobInstanceService jobInstanceService,
+                        StageStatusTopic stageStatusTopic,
+                        StageStatusCache stageStatusCache,
+                        SecurityService securityService,
+                        PipelineDao pipelineDao,
+                        ChangesetService changesetService,
+                        GoConfigService goConfigService,
+                        TransactionTemplate transactionTemplate,
+                        TransactionSynchronizationManager transactionSynchronizationManager,
+                        GoCache goCache,
                         StageStatusListener... stageStatusListeners) {
         this.stageDao = stageDao;
         this.jobInstanceService = jobInstanceService;
@@ -124,13 +132,18 @@ public class StageService implements StageRunFinder, StageFinder {
         return stageDao.stageByIdWithBuilds(id);
     }
 
-    public Stage findStageWithIdentifier(String pipelineName, int pipelineCounter, String stageName, String stageCounter, String username, OperationResult result) {
+    public Stage findStageWithIdentifier(String pipelineName,
+                                         int pipelineCounter,
+                                         String stageName,
+                                         String stageCounter,
+                                         String username,
+                                         OperationResult result) {
         if (!goConfigService.currentCruiseConfig().hasPipelineNamed(new CaseInsensitiveString(pipelineName))) {
             result.notFound("Not Found", "Pipeline not found", HealthStateType.general(HealthStateScope.GLOBAL));
             return null;
         }
         if (!securityService.hasViewPermissionForPipeline(Username.valueOf(username), pipelineName)) {
-            result.unauthorized("Unauthorized", NOT_AUTHORIZED_TO_VIEW_PIPELINE, HealthStateType.general(HealthStateScope.forPipeline(pipelineName)));
+            result.forbidden("Unauthorized", NOT_AUTHORIZED_TO_VIEW_PIPELINE, HealthStateType.general(HealthStateScope.forPipeline(pipelineName)));
             return null;
         }
 
@@ -141,9 +154,11 @@ public class StageService implements StageRunFinder, StageFinder {
         return stageDao.findStageWithIdentifier(identifier);
     }
 
-    public StageSummaryModel findStageSummaryByIdentifier(StageIdentifier stageId, Username username, LocalizedOperationResult result) {
+    public StageSummaryModel findStageSummaryByIdentifier(StageIdentifier stageId,
+                                                          Username username,
+                                                          LocalizedOperationResult result) {
         if (!securityService.hasViewPermissionForPipeline(username, stageId.getPipelineName())) {
-            result.unauthorized(LocalizedMessage.unauthorizedToViewPipeline(stageId.getPipelineName()), HealthStateType.general(HealthStateScope.forPipeline(stageId.getPipelineName())));
+            result.forbidden(LocalizedMessage.forbiddenToViewPipeline(stageId.getPipelineName()), HealthStateType.general(HealthStateScope.forPipeline(stageId.getPipelineName())));
             return null;
         }
         Stages stages = stageDao.getAllRunsOfStageForPipelineInstance(stageId.getPipelineName(), stageId.getPipelineCounter(), stageId.getStageName());
@@ -351,7 +366,9 @@ public class StageService implements StageRunFinder, StageFinder {
         return new FeedEntries(new ArrayList<>(stageEntries));
     }
 
-    private void populateAuthorsAndMingleCards(List<StageFeedEntry> stageEntries, String pipelineName, Username username) {
+    private void populateAuthorsAndMingleCards(List<StageFeedEntry> stageEntries,
+                                               String pipelineName,
+                                               Username username) {
         List<Long> pipelineIds = new ArrayList<>();
         for (StageFeedEntry stageEntry : stageEntries) {
             pipelineIds.add(stageEntry.getPipelineId());
@@ -383,7 +400,11 @@ public class StageService implements StageRunFinder, StageFinder {
         }
     }
 
-    public StageSummaryModels findStageHistoryForChart(String pipelineName, String stageName, int pageNumber, int pageSize, Username username) {
+    public StageSummaryModels findStageHistoryForChart(String pipelineName,
+                                                       String stageName,
+                                                       int pageNumber,
+                                                       int pageSize,
+                                                       Username username) {
         int total = stageDao.getTotalStageCountForChart(pipelineName, stageName);
 
         Pagination pagination = Pagination.pageByNumber(pageNumber, total, pageSize);
@@ -406,17 +427,24 @@ public class StageService implements StageRunFinder, StageFinder {
         return stageDao.findStageHistoryPage(stage, pageSize);
     }
 
-    public StageHistoryPage findStageHistoryPageByNumber(String pipelineName, String stageName, int pageNumber, int pageSize) {
+    public StageHistoryPage findStageHistoryPageByNumber(String pipelineName,
+                                                         String stageName,
+                                                         int pageNumber,
+                                                         int pageSize) {
         return stageDao.findStageHistoryPageByNumber(pipelineName, stageName, pageNumber, pageSize);
     }
 
-    public StageInstanceModels findDetailedStageHistoryByOffset(String pipelineName, String stageName, Pagination pagination, String username, OperationResult result) {
+    public StageInstanceModels findDetailedStageHistoryByOffset(String pipelineName,
+                                                                String stageName,
+                                                                Pagination pagination,
+                                                                String username,
+                                                                OperationResult result) {
         if (!goConfigService.currentCruiseConfig().hasPipelineNamed(new CaseInsensitiveString(pipelineName))) {
             result.notFound("Not Found", "Pipeline not found", HealthStateType.general(HealthStateScope.GLOBAL));
             return null;
         }
         if (!securityService.hasViewPermissionForPipeline(Username.valueOf(username), pipelineName)) {
-            result.unauthorized("Unauthorized", NOT_AUTHORIZED_TO_VIEW_PIPELINE, HealthStateType.general(HealthStateScope.forPipeline(pipelineName)));
+            result.forbidden("Unauthorized", NOT_AUTHORIZED_TO_VIEW_PIPELINE, HealthStateType.general(HealthStateScope.forPipeline(pipelineName)));
             return null;
         }
 

--- a/server/src/main/java/com/thoughtworks/go/server/service/TemplateConfigService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/TemplateConfigService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 ThoughtWorks, Inc.
+ * Copyright 2018 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -170,7 +170,7 @@ public class TemplateConfigService {
 
     public ConfigForEdit<PipelineTemplateConfig> loadForEdit(String templateName, Username username, HttpLocalizedOperationResult result) {
         if (!securityService.isAuthorizedToEditTemplate(new CaseInsensitiveString(templateName), username)) {
-            result.unauthorized("Unauthorized to edit '" + templateName + "' template.", HealthStateType.unauthorised());
+            result.forbidden("Unauthorized to edit '" + templateName + "' template.", HealthStateType.forbidden());
             return null;
         }
         GoConfigHolder configHolder = goConfigService.getConfigHolder();
@@ -195,7 +195,7 @@ public class TemplateConfigService {
 
     public List<PipelineConfig> allPipelinesNotUsingTemplates(Username username, LocalizedOperationResult result) {
         if (!(securityService.isUserAdmin(username) || securityService.isUserGroupAdmin(username))) {
-            result.unauthorized(LocalizedMessage.unauthorizedToEdit(), HealthStateType.unauthorised());
+            result.forbidden(LocalizedMessage.forbiddenToEdit(), HealthStateType.forbidden());
             return null;
         }
         List<PipelineConfig> allPipelineConfigs = goConfigService.getAllPipelineConfigsForEditForUser(username);

--- a/server/src/main/java/com/thoughtworks/go/server/service/ValueStreamMapService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/ValueStreamMapService.java
@@ -72,7 +72,7 @@ public class ValueStreamMapService {
     public ValueStreamMapPresentationModel getValueStreamMap(CaseInsensitiveString pipelineName, int counter, Username username, LocalizedOperationResult result) {
         try {
             if (!securityService.hasViewPermissionForPipeline(username, pipelineName.toString())) {
-                result.unauthorized(LocalizedMessage.unauthorizedToViewPipeline(pipelineName), HealthStateType.general(HealthStateScope.forPipeline(pipelineName.toString())));
+                result.forbidden(LocalizedMessage.forbiddenToViewPipeline(pipelineName), HealthStateType.general(HealthStateScope.forPipeline(pipelineName.toString())));
                 return null;
             }
             ValueStreamMap valueStreamMap = buildValueStreamMap(pipelineName, counter, username, result);
@@ -147,7 +147,7 @@ public class ValueStreamMapService {
             }
 
             if (!hasViewPermissionForMaterial) {
-                result.unauthorized("You do not have view permissions for material with fingerprint '" + materialFingerprint + "'.", HealthStateType.general(HealthStateScope.forMaterialConfig(materialConfig)));
+                result.forbidden("You do not have view permissions for material with fingerprint '" + materialFingerprint + "'.", HealthStateType.general(HealthStateScope.forMaterialConfig(materialConfig)));
                 return null;
             }
 

--- a/server/src/main/java/com/thoughtworks/go/server/service/materials/PackageRepositoryService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/materials/PackageRepositoryService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 ThoughtWorks, Inc.
+ * Copyright 2018 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -185,7 +185,7 @@ public class PackageRepositoryService {
             @Override
             public void checkPermission(CruiseConfig cruiseConfig, LocalizedOperationResult result) {
                 if (!securityService.canViewAdminPage(username)) {
-                    result.unauthorized(LocalizedMessage.unauthorizedToEdit(), null);
+                    result.forbidden(LocalizedMessage.forbiddenToEdit(), null);
                 }
             }
 

--- a/server/src/main/java/com/thoughtworks/go/server/service/materials/commands/PackageMaterialSaveCommand.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/materials/commands/PackageMaterialSaveCommand.java
@@ -1,5 +1,5 @@
 /*************************GO-LICENSE-START*********************************
- * Copyright 2014 ThoughtWorks, Inc.
+ * Copyright 2018 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -49,7 +49,7 @@ public abstract class PackageMaterialSaveCommand implements UpdateConfigFromUI {
     public void checkPermission(CruiseConfig cruiseConfig, LocalizedOperationResult result) {
         String groupName = cruiseConfig.getGroups().findGroupNameByPipeline(new CaseInsensitiveString(pipeline));
         if (!securityService.isUserAdminOfGroup(username.getUsername(), groupName)) {
-            result.unauthorized(LocalizedMessage.unauthorizedToEdit(), null);
+            result.forbidden(LocalizedMessage.forbiddenToEdit(), null);
         }
     }
 

--- a/server/src/main/java/com/thoughtworks/go/server/service/result/DiskSpaceOperationResult.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/result/DiskSpaceOperationResult.java
@@ -1,5 +1,5 @@
 /*************************GO-LICENSE-START*********************************
- * Copyright 2014 ThoughtWorks, Inc.
+ * Copyright 2018 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -65,6 +65,11 @@ public class DiskSpaceOperationResult implements OperationResult {
     }
 
     public ServerHealthState unauthorized(String message, String description, HealthStateType id) {
+        throw new RuntimeException("Not yet implemented");
+    }
+
+    @Override
+    public ServerHealthState forbidden(String message, String description, HealthStateType id) {
         throw new RuntimeException("Not yet implemented");
     }
 

--- a/server/src/main/java/com/thoughtworks/go/server/service/result/ServerHealthServiceUpdatingOperationResult.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/result/ServerHealthServiceUpdatingOperationResult.java
@@ -1,5 +1,5 @@
 /*************************GO-LICENSE-START*********************************
- * Copyright 2014 ThoughtWorks, Inc.
+ * Copyright 2018 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -66,6 +66,11 @@ public class ServerHealthServiceUpdatingOperationResult implements OperationResu
     }
 
     public ServerHealthState unauthorized(String message, String description, HealthStateType id) {
+        throw new RuntimeException("Not yet implemented");
+    }
+
+    @Override
+    public ServerHealthState forbidden(String message, String description, HealthStateType id) {
         throw new RuntimeException("Not yet implemented");
     }
 

--- a/server/src/main/java/com/thoughtworks/go/server/service/support/ServerStatusService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/support/ServerStatusService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 ThoughtWorks, Inc.
+ * Copyright 2018 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -62,7 +62,7 @@ public class ServerStatusService {
 
     public Map<String, Object> asJson(Username username, LocalizedOperationResult result) {
         if (!securityService.isUserAdmin(username)) {
-            result.unauthorized(LocalizedMessage.unauthorizedToEdit(), HealthStateType.unauthorised());
+            result.forbidden(LocalizedMessage.forbiddenToEdit(), HealthStateType.forbidden());
             return null;
         }
 

--- a/server/src/main/java/com/thoughtworks/go/server/web/AuthorizationInterceptor.java
+++ b/server/src/main/java/com/thoughtworks/go/server/web/AuthorizationInterceptor.java
@@ -28,7 +28,7 @@ import org.springframework.web.servlet.ModelAndView;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import static javax.servlet.http.HttpServletResponse.SC_UNAUTHORIZED;
+import static org.apache.http.HttpStatus.SC_FORBIDDEN;
 
 @Controller
 public class AuthorizationInterceptor implements HandlerInterceptor {
@@ -51,7 +51,7 @@ public class AuthorizationInterceptor implements HandlerInterceptor {
             String name = CaseInsensitiveString.str(username.getUsername());
             if (request.getMethod().equalsIgnoreCase("get")) {
                 if (!securityService.hasViewPermissionForPipeline(username, pipelineName)) {
-                    response.sendError(SC_UNAUTHORIZED);
+                    response.sendError(SC_FORBIDDEN);
                     return false;
                 }
             } else if (request.getMethod().equalsIgnoreCase("post") || request.getMethod().equalsIgnoreCase("put")) {
@@ -62,12 +62,12 @@ public class AuthorizationInterceptor implements HandlerInterceptor {
                 String stageName = request.getParameter("stageName");
                 if (stageName != null) {
                     if (!securityService.hasOperatePermissionForStage(pipelineName, stageName, name)) {
-                        response.sendError(SC_UNAUTHORIZED);
+                        response.sendError(SC_FORBIDDEN);
                         return false;
                     }
                 } else {
                     if (!securityService.hasOperatePermissionForPipeline(username.getUsername(), pipelineName)) {
-                        response.sendError(SC_UNAUTHORIZED);
+                        response.sendError(SC_FORBIDDEN);
                         return false;
                     }
                 }

--- a/server/src/main/java/com/thoughtworks/go/server/websocket/ConsoleLogSocketServlet.java
+++ b/server/src/main/java/com/thoughtworks/go/server/websocket/ConsoleLogSocketServlet.java
@@ -29,6 +29,8 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
+import static org.apache.http.HttpStatus.SC_FORBIDDEN;
+
 /**
  * Handles upgrade request for console log WebSocket connections. Validates that user is authorized to
  * view the pipeline.
@@ -63,7 +65,7 @@ public class ConsoleLogSocketServlet extends WebSocketServlet {
             return;
         }
 
-        response.sendError(HttpServletResponse.SC_UNAUTHORIZED, String.format("%s is not authorized to view the pipeline %s", userName.getDisplayName(), pipeline));
+        response.sendError(SC_FORBIDDEN, String.format("%s is not authorized to view the pipeline %s", userName.getDisplayName(), pipeline));
     }
 
     private boolean authorizedToViewPipeline(Username username, String pipelineName) {

--- a/server/src/test-fast/java/com/thoughtworks/go/config/update/AddEnvironmentCommandTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/config/update/AddEnvironmentCommandTest.java
@@ -19,7 +19,6 @@ package com.thoughtworks.go.config.update;
 import com.thoughtworks.go.config.BasicCruiseConfig;
 import com.thoughtworks.go.config.BasicEnvironmentConfig;
 import com.thoughtworks.go.config.CaseInsensitiveString;
-import com.thoughtworks.go.domain.AllConfigErrors;
 import com.thoughtworks.go.helper.GoConfigMother;
 import com.thoughtworks.go.server.domain.Username;
 import com.thoughtworks.go.server.service.GoConfigService;
@@ -108,7 +107,7 @@ public class AddEnvironmentCommandTest {
         AddEnvironmentCommand command = new AddEnvironmentCommand(goConfigService, environmentConfig, currentUser, actionFailed, result);
         when(goConfigService.isUserAdmin(currentUser)).thenReturn(false);
         HttpLocalizedOperationResult expectedResult = new HttpLocalizedOperationResult();
-        expectedResult.unauthorized("Failed to access environment 'Dev'. User 'user' does not have permission to access environment.", HealthStateType.unauthorised());
+        expectedResult.forbidden("Failed to access environment 'Dev'. User 'user' does not have permission to access environment.", HealthStateType.forbidden());
 
         assertThat(command.canContinue(cruiseConfig), is(false));
         assertThat(result, is(expectedResult));

--- a/server/src/test-fast/java/com/thoughtworks/go/config/update/AgentsEntityConfigUpdateCommandTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/config/update/AgentsEntityConfigUpdateCommandTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 ThoughtWorks, Inc.
+ * Copyright 2018 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,8 +41,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import static com.thoughtworks.go.i18n.LocalizedMessage.unauthorizedToEdit;
-import static com.thoughtworks.go.serverhealth.HealthStateType.unauthorised;
+import static com.thoughtworks.go.i18n.LocalizedMessage.forbiddenToEdit;
+import static com.thoughtworks.go.serverhealth.HealthStateType.forbidden;
 import static junit.framework.TestCase.assertFalse;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
@@ -114,7 +114,7 @@ public class AgentsEntityConfigUpdateCommandTest {
         when(goConfigService.isAdministrator(currentUser.getUsername())).thenReturn(false);
         assertFalse(command.canContinue(cruiseConfig));
         HttpLocalizedOperationResult expectedResult = new HttpLocalizedOperationResult();
-        expectedResult.unauthorized(unauthorizedToEdit(), unauthorised());
+        expectedResult.forbidden(forbiddenToEdit(), forbidden());
         assertThat(result, is(expectedResult));
     }
 

--- a/server/src/test-fast/java/com/thoughtworks/go/config/update/CreateConfigRepoCommandTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/config/update/CreateConfigRepoCommandTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 ThoughtWorks, Inc.
+ * Copyright 2018 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,8 +28,8 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 
-import static com.thoughtworks.go.i18n.LocalizedMessage.unauthorizedToEdit;
-import static com.thoughtworks.go.serverhealth.HealthStateType.unauthorised;
+import static com.thoughtworks.go.i18n.LocalizedMessage.forbiddenToEdit;
+import static com.thoughtworks.go.serverhealth.HealthStateType.forbidden;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.when;
@@ -71,7 +71,7 @@ public class CreateConfigRepoCommandTest {
         CreateConfigRepoCommand command = new CreateConfigRepoCommand(securityService, configRepo, actionFailed, currentUser, result);
         when(securityService.isUserAdmin(currentUser)).thenReturn(false);
         HttpLocalizedOperationResult expectedResult = new HttpLocalizedOperationResult();
-        expectedResult.unauthorized(unauthorizedToEdit(), unauthorised());
+        expectedResult.forbidden(forbiddenToEdit(), forbidden());
 
         assertThat(command.canContinue(cruiseConfig), is(false));
         assertThat(result, is(expectedResult));

--- a/server/src/test-fast/java/com/thoughtworks/go/config/update/CreatePackageConfigCommandTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/config/update/CreatePackageConfigCommandTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 ThoughtWorks, Inc.
+ * Copyright 2018 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,21 +23,19 @@ import com.thoughtworks.go.domain.packagerepository.PackageDefinition;
 import com.thoughtworks.go.domain.packagerepository.PackageRepositories;
 import com.thoughtworks.go.domain.packagerepository.PackageRepository;
 import com.thoughtworks.go.helper.GoConfigMother;
-import com.thoughtworks.go.i18n.LocalizedMessage;
 import com.thoughtworks.go.server.domain.Username;
 import com.thoughtworks.go.server.service.GoConfigService;
 import com.thoughtworks.go.server.service.materials.PackageDefinitionService;
 import com.thoughtworks.go.server.service.result.HttpLocalizedOperationResult;
-import com.thoughtworks.go.serverhealth.HealthStateType;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 
 import java.util.Arrays;
 
-import static com.thoughtworks.go.i18n.LocalizedMessage.unauthorizedToEdit;
 import static com.thoughtworks.go.i18n.LocalizedMessage.resourceNotFound;
-import static com.thoughtworks.go.serverhealth.HealthStateType.unauthorised;
+import static com.thoughtworks.go.i18n.LocalizedMessage.forbiddenToEdit;
+import static com.thoughtworks.go.serverhealth.HealthStateType.forbidden;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.*;
@@ -97,7 +95,7 @@ public class CreatePackageConfigCommandTest {
         CreatePackageConfigCommand command = new CreatePackageConfigCommand(goConfigService, packageDefinition, repoId, currentUser, result, packageDefinitionService);
         when(goConfigService.isUserAdmin(currentUser)).thenReturn(false);
         HttpLocalizedOperationResult expectedResult = new HttpLocalizedOperationResult();
-        expectedResult.unauthorized(unauthorizedToEdit(), unauthorised());
+        expectedResult.forbidden(forbiddenToEdit(), forbidden());
 
         assertThat(command.canContinue(cruiseConfig), is(false));
         assertThat(result, is(expectedResult));

--- a/server/src/test-fast/java/com/thoughtworks/go/config/update/CreatePackageRepositoryCommandTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/config/update/CreatePackageRepositoryCommandTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 ThoughtWorks, Inc.
+ * Copyright 2018 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,22 +16,21 @@
 
 package com.thoughtworks.go.config.update;
 
-import com.thoughtworks.go.config.*;
+import com.thoughtworks.go.config.BasicCruiseConfig;
+import com.thoughtworks.go.config.CaseInsensitiveString;
 import com.thoughtworks.go.domain.config.*;
 import com.thoughtworks.go.domain.packagerepository.PackageRepository;
 import com.thoughtworks.go.helper.GoConfigMother;
-import com.thoughtworks.go.i18n.LocalizedMessage;
 import com.thoughtworks.go.server.domain.Username;
 import com.thoughtworks.go.server.service.GoConfigService;
 import com.thoughtworks.go.server.service.materials.PackageRepositoryService;
 import com.thoughtworks.go.server.service.result.HttpLocalizedOperationResult;
-import com.thoughtworks.go.serverhealth.HealthStateType;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 
-import static com.thoughtworks.go.i18n.LocalizedMessage.unauthorizedToEdit;
-import static com.thoughtworks.go.serverhealth.HealthStateType.unauthorised;
+import static com.thoughtworks.go.i18n.LocalizedMessage.forbiddenToEdit;
+import static com.thoughtworks.go.serverhealth.HealthStateType.forbidden;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.when;
@@ -114,7 +113,7 @@ public class CreatePackageRepositoryCommandTest {
         CreatePackageRepositoryCommand command = new CreatePackageRepositoryCommand(goConfigService, packageRepositoryService, packageRepository, currentUser, result);
 
         HttpLocalizedOperationResult expectedResult = new HttpLocalizedOperationResult();
-        expectedResult.unauthorized(unauthorizedToEdit(), unauthorised());
+        expectedResult.forbidden(forbiddenToEdit(), forbidden());
 
         assertThat(command.canContinue(cruiseConfig), is(false));
         assertThat(result, is(expectedResult));

--- a/server/src/test-fast/java/com/thoughtworks/go/config/update/DeleteConfigRepoCommandTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/config/update/DeleteConfigRepoCommandTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 ThoughtWorks, Inc.
+ * Copyright 2018 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -74,7 +74,7 @@ public class DeleteConfigRepoCommandTest {
         when(goConfigService.isUserAdmin(currentUser)).thenReturn(false);
         assertThat(command.canContinue(cruiseConfig), is(false));
         assertFalse(result.isSuccessful());
-        assertThat(result.httpCode(), is(401));
+        assertThat(result.httpCode(), is(403));
         assertThat(result.message(), equalTo("Unauthorized to edit."));
     }
 

--- a/server/src/test-fast/java/com/thoughtworks/go/config/update/DeleteEnvironmentCommandTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/config/update/DeleteEnvironmentCommandTest.java
@@ -70,7 +70,7 @@ public class DeleteEnvironmentCommandTest {
         when(goConfigService.isUserAdmin(currentUser)).thenReturn(false);
         assertThat(command.canContinue(cruiseConfig), is(false));
         assertFalse(result.isSuccessful());
-        assertThat(result.httpCode(), is(401));
+        assertThat(result.httpCode(), is(403));
         assertThat(result.message(), containsString("Failed to access environment 'Dev'. User 'user' does not have permission to access environment."));
     }
 }

--- a/server/src/test-fast/java/com/thoughtworks/go/config/update/DeletePackageConfigCommandTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/config/update/DeletePackageConfigCommandTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 ThoughtWorks, Inc.
+ * Copyright 2018 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,7 +31,6 @@ import com.thoughtworks.go.domain.packagerepository.PackageRepositories;
 import com.thoughtworks.go.domain.packagerepository.PackageRepository;
 import com.thoughtworks.go.helper.GoConfigMother;
 import com.thoughtworks.go.helper.PipelineConfigMother;
-import com.thoughtworks.go.i18n.LocalizedMessage;
 import com.thoughtworks.go.server.domain.Username;
 import com.thoughtworks.go.server.service.GoConfigService;
 import com.thoughtworks.go.server.service.result.HttpLocalizedOperationResult;
@@ -46,8 +45,8 @@ import java.util.List;
 import java.util.Map;
 
 import static com.thoughtworks.go.i18n.LocalizedMessage.cannotDeleteResourceBecauseOfDependentPipelines;
-import static com.thoughtworks.go.i18n.LocalizedMessage.unauthorizedToEdit;
-import static com.thoughtworks.go.serverhealth.HealthStateType.unauthorised;
+import static com.thoughtworks.go.i18n.LocalizedMessage.forbiddenToEdit;
+import static com.thoughtworks.go.serverhealth.HealthStateType.forbidden;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.when;
@@ -120,7 +119,7 @@ public class DeletePackageConfigCommandTest {
         assertThat(command.canContinue(cruiseConfig), is(false));
 
         HttpLocalizedOperationResult expectedResult = new HttpLocalizedOperationResult();
-        expectedResult.unauthorized(unauthorizedToEdit(), unauthorised());
+        expectedResult.forbidden(forbiddenToEdit(), forbidden());
         assertThat(result, is(expectedResult));
     }
 

--- a/server/src/test-fast/java/com/thoughtworks/go/config/update/DeletePackageRepositoryCommandTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/config/update/DeletePackageRepositoryCommandTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 ThoughtWorks, Inc.
+ * Copyright 2018 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,17 +25,15 @@ import com.thoughtworks.go.domain.packagerepository.PackageDefinition;
 import com.thoughtworks.go.domain.packagerepository.PackageRepositories;
 import com.thoughtworks.go.domain.packagerepository.PackageRepository;
 import com.thoughtworks.go.helper.GoConfigMother;
-import com.thoughtworks.go.i18n.LocalizedMessage;
 import com.thoughtworks.go.server.domain.Username;
 import com.thoughtworks.go.server.service.GoConfigService;
 import com.thoughtworks.go.server.service.result.HttpLocalizedOperationResult;
-import com.thoughtworks.go.serverhealth.HealthStateType;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 
-import static com.thoughtworks.go.i18n.LocalizedMessage.unauthorizedToEdit;
-import static com.thoughtworks.go.serverhealth.HealthStateType.unauthorised;
+import static com.thoughtworks.go.i18n.LocalizedMessage.forbiddenToEdit;
+import static com.thoughtworks.go.serverhealth.HealthStateType.forbidden;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.when;
@@ -93,7 +91,7 @@ public class DeletePackageRepositoryCommandTest {
     @Test
     public void shouldNotContinueIfTheUserIsNotAdmin() throws Exception {
         HttpLocalizedOperationResult expectedResult = new HttpLocalizedOperationResult();
-        expectedResult.unauthorized(unauthorizedToEdit(), unauthorised());
+        expectedResult.forbidden(forbiddenToEdit(), forbidden());
         when(goConfigService.isUserAdmin(currentUser)).thenReturn(false);
         DeletePackageRepositoryCommand command = new DeletePackageRepositoryCommand(goConfigService, packageRepository, currentUser, result);
 

--- a/server/src/test-fast/java/com/thoughtworks/go/config/update/PatchEnvironmentCommandTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/config/update/PatchEnvironmentCommandTest.java
@@ -336,7 +336,7 @@ public class PatchEnvironmentCommandTest {
         when(goConfigService.isAdministrator(currentUser.getUsername())).thenReturn(false);
         assertThat(command.canContinue(cruiseConfig), is(false));
         HttpLocalizedOperationResult expectResult = new HttpLocalizedOperationResult();
-        expectResult.unauthorized("Failed to access environment 'Dev'. User 'user' does not have permission to access environment.", HealthStateType.unauthorised());
+        expectResult.forbidden("Failed to access environment 'Dev'. User 'user' does not have permission to access environment.", HealthStateType.forbidden());
         assertThat(result, is(expectResult));
     }
 }

--- a/server/src/test-fast/java/com/thoughtworks/go/config/update/PluginProfileCommandTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/config/update/PluginProfileCommandTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 ThoughtWorks, Inc.
+ * Copyright 2018 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,8 +36,8 @@ import org.junit.rules.ExpectedException;
 
 import java.util.Map;
 
-import static com.thoughtworks.go.i18n.LocalizedMessage.unauthorizedToEdit;
-import static com.thoughtworks.go.serverhealth.HealthStateType.unauthorised;
+import static com.thoughtworks.go.i18n.LocalizedMessage.forbiddenToEdit;
+import static com.thoughtworks.go.serverhealth.HealthStateType.forbidden;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.mockito.Mockito.mock;
@@ -143,7 +143,7 @@ public class PluginProfileCommandTest {
             if (goConfigService.isUserAdmin(currentUser)) {
                 return true;
             }
-            result.unauthorized(unauthorizedToEdit(), unauthorised());
+            result.forbidden(forbiddenToEdit(), forbidden());
             return false;
         }
     }

--- a/server/src/test-fast/java/com/thoughtworks/go/config/update/RoleConfigCreateCommandTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/config/update/RoleConfigCreateCommandTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 ThoughtWorks, Inc.
+ * Copyright 2018 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -50,7 +50,7 @@ public class RoleConfigCreateCommandTest {
 
         assertFalse(command.canContinue(null));
         assertFalse(result.isSuccessful());
-        assertThat(result.httpCode(), is(401));
+        assertThat(result.httpCode(), is(403));
     }
 
     @Test

--- a/server/src/test-fast/java/com/thoughtworks/go/config/update/RoleConfigDeleteCommandTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/config/update/RoleConfigDeleteCommandTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 ThoughtWorks, Inc.
+ * Copyright 2018 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -68,7 +68,7 @@ public class RoleConfigDeleteCommandTest {
 
         assertFalse(command.canContinue(cruiseConfig));
         assertFalse(result.isSuccessful());
-        assertThat(result.httpCode(), is(401));
+        assertThat(result.httpCode(), is(403));
     }
 
     @Test

--- a/server/src/test-fast/java/com/thoughtworks/go/config/update/RoleConfigUpdateCommandTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/config/update/RoleConfigUpdateCommandTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 ThoughtWorks, Inc.
+ * Copyright 2018 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -74,7 +74,7 @@ public class RoleConfigUpdateCommandTest {
 
         assertFalse(command.canContinue(null));
         assertFalse(result.isSuccessful());
-        assertThat(result.httpCode(), is(401));
+        assertThat(result.httpCode(), is(403));
     }
 
     @Test

--- a/server/src/test-fast/java/com/thoughtworks/go/config/update/UpdateConfigRepoCommandTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/config/update/UpdateConfigRepoCommandTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 ThoughtWorks, Inc.
+ * Copyright 2018 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,8 +30,8 @@ import org.junit.Test;
 import org.mockito.Mock;
 
 import static com.thoughtworks.go.i18n.LocalizedMessage.staleResourceConfig;
-import static com.thoughtworks.go.i18n.LocalizedMessage.unauthorizedToEdit;
-import static com.thoughtworks.go.serverhealth.HealthStateType.unauthorised;
+import static com.thoughtworks.go.i18n.LocalizedMessage.forbiddenToEdit;
+import static com.thoughtworks.go.serverhealth.HealthStateType.forbidden;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.when;
@@ -84,7 +84,7 @@ public class UpdateConfigRepoCommandTest {
         when(securityService.isUserAdmin(currentUser)).thenReturn(false);
         when(entityHashingService.md5ForEntity(oldConfigRepo)).thenReturn(md5);
         HttpLocalizedOperationResult expectedResult = new HttpLocalizedOperationResult();
-        expectedResult.unauthorized(unauthorizedToEdit(), unauthorised());
+        expectedResult.forbidden(forbiddenToEdit(), forbidden());
 
         assertThat(command.canContinue(cruiseConfig), is(false));
         assertThat(result, is(expectedResult));

--- a/server/src/test-fast/java/com/thoughtworks/go/config/update/UpdateEnvironmentCommandTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/config/update/UpdateEnvironmentCommandTest.java
@@ -123,7 +123,7 @@ public class UpdateEnvironmentCommandTest {
         when(goConfigService.isAdministrator(currentUser.getUsername())).thenReturn(false);
         assertThat(command.canContinue(cruiseConfig), is(false));
         HttpLocalizedOperationResult expectResult = new HttpLocalizedOperationResult();
-        expectResult.unauthorized("Failed to access environment 'Test'. User 'user' does not have permission to access environment.", HealthStateType.unauthorised());
+        expectResult.forbidden("Failed to access environment 'Test'. User 'user' does not have permission to access environment.", HealthStateType.forbidden());
 
         assertThat(result, is(expectResult));
     }

--- a/server/src/test-fast/java/com/thoughtworks/go/config/update/UpdatePackageConfigCommandTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/config/update/UpdatePackageConfigCommandTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 ThoughtWorks, Inc.
+ * Copyright 2018 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,7 +33,7 @@ import org.junit.Test;
 import org.mockito.Mock;
 
 import static com.thoughtworks.go.i18n.LocalizedMessage.*;
-import static com.thoughtworks.go.serverhealth.HealthStateType.unauthorised;
+import static com.thoughtworks.go.serverhealth.HealthStateType.forbidden;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertFalse;
@@ -98,7 +98,7 @@ public class UpdatePackageConfigCommandTest {
         when(goConfigService.isUserAdmin(currentUser)).thenReturn(false);
         when(entityHashingService.md5ForEntity(oldPackageDefinition)).thenReturn("md5");
         HttpLocalizedOperationResult expectedResult = new HttpLocalizedOperationResult();
-        expectedResult.unauthorized(unauthorizedToEdit(), unauthorised());
+        expectedResult.forbidden(forbiddenToEdit(), forbidden());
 
         assertThat(command.canContinue(cruiseConfig), is(false));
         assertThat(result, is(expectedResult));

--- a/server/src/test-fast/java/com/thoughtworks/go/config/update/UpdatePackageRepositoryCommandTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/config/update/UpdatePackageRepositoryCommandTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 ThoughtWorks, Inc.
+ * Copyright 2018 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,8 +34,8 @@ import org.junit.Test;
 import org.mockito.Mock;
 
 import static com.thoughtworks.go.i18n.LocalizedMessage.staleResourceConfig;
-import static com.thoughtworks.go.i18n.LocalizedMessage.unauthorizedToEdit;
-import static com.thoughtworks.go.serverhealth.HealthStateType.unauthorised;
+import static com.thoughtworks.go.i18n.LocalizedMessage.forbiddenToEdit;
+import static com.thoughtworks.go.serverhealth.HealthStateType.forbidden;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
@@ -151,7 +151,7 @@ public class UpdatePackageRepositoryCommandTest {
         UpdatePackageRepositoryCommand command = new UpdatePackageRepositoryCommand(goConfigService, packageRepositoryService, newPackageRepo, currentUser, "md5", entityHashingService, result, repoId);
 
         HttpLocalizedOperationResult expectedResult = new HttpLocalizedOperationResult();
-        expectedResult.unauthorized(unauthorizedToEdit(), unauthorised());
+        expectedResult.forbidden(forbiddenToEdit(), forbidden());
 
         assertThat(command.canContinue(cruiseConfig), is(false));
         assertThat(result, is(expectedResult));

--- a/server/src/test-fast/java/com/thoughtworks/go/server/materials/MaterialUpdateServiceTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/materials/MaterialUpdateServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 ThoughtWorks, Inc.
+ * Copyright 2018 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,7 +27,6 @@ import com.thoughtworks.go.domain.materials.MaterialConfig;
 import com.thoughtworks.go.helper.MaterialConfigsMother;
 import com.thoughtworks.go.helper.MaterialsMother;
 import com.thoughtworks.go.helper.PipelineConfigMother;
-import com.thoughtworks.go.i18n.LocalizedMessage;
 import com.thoughtworks.go.server.domain.Username;
 import com.thoughtworks.go.server.materials.postcommit.PostCommitHookImplementer;
 import com.thoughtworks.go.server.materials.postcommit.PostCommitHookMaterialType;
@@ -234,10 +233,10 @@ public class MaterialUpdateServiceTest {
         when(goConfigService.isUserAdmin(username)).thenReturn(false);
         service.notifyMaterialsForUpdate(username, new HashMap(), result);
 
-        HttpLocalizedOperationResult unauthorizedResult = new HttpLocalizedOperationResult();
-        unauthorizedResult.unauthorized("Unauthorized to access this API.", HealthStateType.unauthorised());
+        HttpLocalizedOperationResult forbiddenResult = new HttpLocalizedOperationResult();
+        forbiddenResult.forbidden("Unauthorized to access this API.", HealthStateType.forbidden());
 
-        assertThat(result, is(unauthorizedResult));
+        assertThat(result, is(forbiddenResult));
 
         verify(goConfigService).isUserAdmin(username);
     }

--- a/server/src/test-fast/java/com/thoughtworks/go/server/service/FailureServiceTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/service/FailureServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 ThoughtWorks, Inc.
+ * Copyright 2018 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -74,7 +74,7 @@ public class FailureServiceTest {
     public void shouldFailWhenUserIsNotPermittedToFetchFailureDetails() {
         when(securityService.hasViewPermissionForPipeline(username, "pipeline")).thenReturn(false);
         assertThat(failureService.failureDetailsFor(jobIdentifier, "suite_name", "test_name", username, result), is(nullFailureDetails()));
-        assertThat(result.httpCode(), is(401));
+        assertThat(result.httpCode(), is(403));
         assertThat(result.hasMessage(), is(true));
         assertThat(getField(result, "message"), is("User '" + "foo" + "' does not have view permission on pipeline '" + "pipeline" + "'"));
     }

--- a/server/src/test-fast/java/com/thoughtworks/go/server/service/JobRerunScheduleServiceTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/service/JobRerunScheduleServiceTest.java
@@ -180,7 +180,7 @@ public class JobRerunScheduleServiceTest {
 
         when(securityService.hasOperatePermissionForStage(eq("mingle"), eq(firstStage.getName()), any(String.class))).thenReturn(false);
 
-        assertScheduleFailure("unit", firstStage, "User does not have operate permissions for stage [build] of pipeline [mingle]", 401);
+        assertScheduleFailure("unit", firstStage, "User does not have operate permissions for stage [build] of pipeline [mingle]", 403);
     }
 
     @Test

--- a/server/src/test-fast/java/com/thoughtworks/go/server/service/MaterialConfigServiceTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/service/MaterialConfigServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 ThoughtWorks, Inc.
+ * Copyright 2018 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -116,6 +116,6 @@ public class MaterialConfigServiceTest {
 		MaterialConfig materialConfig = materialConfigService.getMaterialConfig(user, gitMaterialConfig.getFingerprint(), result);
 
 		assertThat(materialConfig, is(nullValue()));
-		assertThat(result.httpCode(), is(401));
+		assertThat(result.httpCode(), is(403));
 	}
 }

--- a/server/src/test-fast/java/com/thoughtworks/go/server/service/MaterialServiceTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/service/MaterialServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 ThoughtWorks, Inc.
+ * Copyright 2018 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -115,7 +115,7 @@ public class MaterialServiceTest {
         when(securityService.hasViewPermissionForPipeline(pavan, "pipeline")).thenReturn(false);
         LocalizedOperationResult operationResult = mock(LocalizedOperationResult.class);
         materialService.searchRevisions("pipeline", "sha", "search-string", pavan, operationResult);
-        verify(operationResult).unauthorized(LocalizedMessage.unauthorizedToViewPipeline("pipeline"), HealthStateType.general(HealthStateScope.forPipeline("pipeline")));
+        verify(operationResult).forbidden(LocalizedMessage.forbiddenToViewPipeline("pipeline"), HealthStateType.general(HealthStateScope.forPipeline("pipeline")));
     }
 
     @Test

--- a/server/src/test-fast/java/com/thoughtworks/go/server/service/PipelineConfigsServiceTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/service/PipelineConfigsServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 ThoughtWorks, Inc.
+ * Copyright 2018 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -103,7 +103,7 @@ public class PipelineConfigsServiceTest {
         String actual = service.getXml(groupName, invalidUser, result);
 
         assertThat(actual, is(nullValue()));
-        assertThat(result.httpCode(), is(401));
+        assertThat(result.httpCode(), is(403));
         assertThat(result.isSuccessful(), is(false));
         assertThat(result.message(), is("Unauthorized to edit 'some-secret-group' group."));
         verify(goConfigService, never()).getConfigForEditing();
@@ -188,7 +188,7 @@ public class PipelineConfigsServiceTest {
         GoConfigValidity validity = actual.getValidity();
 
         assertThat(configElement, is(nullValue()));
-        assertThat(result.httpCode(), is(401));
+        assertThat(result.httpCode(), is(403));
         assertThat(result.isSuccessful(), is(false));
         assertThat(result.message(), is("Unauthorized to edit 'some-secret-group' group."));
         assertThat(validity.isValid(), is(true));

--- a/server/src/test-fast/java/com/thoughtworks/go/server/service/PipelineHistoryServiceTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/service/PipelineHistoryServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 ThoughtWorks, Inc.
+ * Copyright 2018 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -870,7 +870,7 @@ public class PipelineHistoryServiceTest {
 		PipelineStatusModel pipelineStatus = pipelineHistoryService.getPipelineStatus("pipeline-name", "user-name", result);
 
 		assertThat(pipelineStatus, is(nullValue()));
-		assertThat(result.httpCode(), is(401));
+		assertThat(result.httpCode(), is(403));
 	}
 
 	@Test
@@ -907,7 +907,7 @@ public class PipelineHistoryServiceTest {
 		PipelineInstanceModels pipelineInstanceModels = pipelineHistoryService.loadMinimalData(pipelineName, Pagination.pageFor(0, 1, 10), noAccessUserName, result);
 
 		assertThat(pipelineInstanceModels, is(nullValue()));
-		assertThat(result.httpCode(), is(401));
+		assertThat(result.httpCode(), is(403));
 
 		result = new HttpOperationResult();
 		pipelineInstanceModels = pipelineHistoryService.loadMinimalData(pipelineName, Pagination.pageFor(0, 1, 10), withAccessUserName, result);
@@ -938,7 +938,7 @@ public class PipelineHistoryServiceTest {
         pipelineHistoryService.updateComment(pipelineName, 1, "test comment", new Username(unauthorizedUser), result);
 
         verify(pipelineDao, never()).updateComment(pipelineName, 1, "test comment");
-        verify(result, times(1)).unauthorized("You do not have operate permissions for pipeline '" + pipelineName + "'.", HealthStateType.general(HealthStateScope.forPipeline(pipelineName)));
+        verify(result, times(1)).forbidden("You do not have operate permissions for pipeline '" + pipelineName + "'.", HealthStateType.general(HealthStateScope.forPipeline(pipelineName)));
     }
 
     @Test

--- a/server/src/test-fast/java/com/thoughtworks/go/server/service/PipelinePauseServiceTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/service/PipelinePauseServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 ThoughtWorks, Inc.
+ * Copyright 2018 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -180,7 +180,7 @@ public class PipelinePauseServiceTest {
     }
 
     @Test
-    public void shouldPopulateHttpResult401WhenPipelineIsNotAuthorizedForPausing() throws Exception {
+    public void shouldPopulateHttpResult403WhenPipelineIsNotAuthorizedForPausing() throws Exception {
         setUpValidPipelineWithInvalidAuth();
 
         HttpLocalizedOperationResult result = new HttpLocalizedOperationResult();
@@ -188,12 +188,12 @@ public class PipelinePauseServiceTest {
         pipelinePauseService.pause(VALID_PIPELINE, "cause", INVALID_USER, result);
 
         assertThat(result.isSuccessful(), is(false));
-        assertThat(result.httpCode(), is(SC_UNAUTHORIZED));
+        assertThat(result.httpCode(), is(SC_FORBIDDEN));
         verify(pipelineDao, never()).pause(VALID_PIPELINE, "cause", "admin");
     }
 
     @Test
-    public void shouldPopulateHttpResult401WhenPipelineIsNotAuthorizedForUnPausing() throws Exception {
+    public void shouldPopulateHttpResult403WhenPipelineIsNotAuthorizedForUnPausing() throws Exception {
         setUpValidPipelineWithInvalidAuth();
 
         HttpLocalizedOperationResult result = new HttpLocalizedOperationResult();
@@ -201,7 +201,7 @@ public class PipelinePauseServiceTest {
         pipelinePauseService.unpause(VALID_PIPELINE, INVALID_USER, result);
 
         assertThat(result.isSuccessful(), is(false));
-        assertThat(result.httpCode(), is(SC_UNAUTHORIZED));
+        assertThat(result.httpCode(), is(SC_FORBIDDEN));
         verify(pipelineDao, never()).unpause(VALID_PIPELINE);
     }
 

--- a/server/src/test-fast/java/com/thoughtworks/go/server/service/PipelineStagesFeedServiceTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/service/PipelineStagesFeedServiceTest.java
@@ -1,5 +1,5 @@
 /*************************GO-LICENSE-START*********************************
- * Copyright 2014 ThoughtWorks, Inc.
+ * Copyright 2018 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -84,7 +84,7 @@ public class PipelineStagesFeedServiceTest {
 
     private void verifyThatUserIsUnauthorized() {
         assertThat(operationResult.isSuccessful(), is(false));
-        assertThat(operationResult.httpCode(), is(401));//verify we are unauthorized
+        assertThat(operationResult.httpCode(), is(403));//verify we are unauthorized
 
         operationResult.message();
     }

--- a/server/src/test-fast/java/com/thoughtworks/go/server/service/PipelineUnlockApiServiceTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/service/PipelineUnlockApiServiceTest.java
@@ -1,5 +1,5 @@
 /*************************GO-LICENSE-START*********************************
- * Copyright 2017 ThoughtWorks, Inc.
+ * Copyright 2018 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -132,7 +132,7 @@ public class PipelineUnlockApiServiceTest {
         HttpOperationResult result = new HttpOperationResult();
         pipelineUnlockApiService.unlock(pipelineName, new Username(new CaseInsensitiveString("username")), result);
 
-        assertThat(result.httpCode(), is(401));
+        assertThat(result.httpCode(), is(403));
         assertThat(result.message(), is("user does not have operate permission on the pipeline"));
     }
 

--- a/server/src/test-fast/java/com/thoughtworks/go/server/service/PluginServiceTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/service/PluginServiceTest.java
@@ -336,7 +336,7 @@ public class PluginServiceTest {
 
         verify(pluginDao, times(0)).saveOrUpdate(any());
         verify(authorizationExtension, times(0)).notifyPluginSettingsChange(eq(authorizationPluginId), anyMap());
-        verify(result, times(1)).unauthorized(eq(LocalizedMessage.unauthorizedToEdit()), eq(HealthStateType.unauthorised()));
+        verify(result, times(1)).forbidden(eq(LocalizedMessage.forbiddenToEdit()), eq(HealthStateType.forbidden()));
         verifyNoMoreInteractions(result);
     }
 
@@ -396,7 +396,7 @@ public class PluginServiceTest {
 
         verify(pluginDao, times(0)).saveOrUpdate(any());
         verify(authorizationExtension, times(0)).notifyPluginSettingsChange(eq(authorizationPluginId), anyMap());
-        verify(result, times(1)).unauthorized(eq(LocalizedMessage.unauthorizedToEdit()), eq(HealthStateType.unauthorised()));
+        verify(result, times(1)).forbidden(eq(LocalizedMessage.forbiddenToEdit()), eq(HealthStateType.forbidden()));
         verifyNoMoreInteractions(result);
 
     }

--- a/server/src/test-fast/java/com/thoughtworks/go/server/service/ScheduleServiceTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/service/ScheduleServiceTest.java
@@ -44,7 +44,7 @@ import static com.thoughtworks.go.domain.JobResult.*;
 import static com.thoughtworks.go.domain.JobState.Building;
 import static com.thoughtworks.go.domain.JobState.Completed;
 import static javax.servlet.http.HttpServletResponse.SC_OK;
-import static javax.servlet.http.HttpServletResponse.SC_UNAUTHORIZED;
+import static org.apache.http.HttpStatus.SC_FORBIDDEN;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNull.nullValue;
 import static org.junit.Assert.assertThat;
@@ -153,7 +153,7 @@ public class ScheduleServiceTest {
         Stage resultStage = service.cancelAndTriggerRelevantStages(stageId, admin, result);
 
         assertThat(resultStage, is(nullValue()));
-        assertThat(result.httpCode(), is(SC_UNAUTHORIZED));
+        assertThat(result.httpCode(), is(SC_FORBIDDEN));
         assertThat(result.isSuccessful(), is(false));
         verify(securityService).hasOperatePermissionForStage(pipeline.getName(), spiedStage.getName(), admin.getUsername().toString());
         verify(stageService, never()).cancelStage(spiedStage);

--- a/server/src/test-fast/java/com/thoughtworks/go/server/service/StageServiceTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/service/StageServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 ThoughtWorks, Inc.
+ * Copyright 2018 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -255,7 +255,7 @@ public class StageServiceTest {
     }
 
     @Test
-    public void findStageSummaryByIdentifierShouldRespondWith401WhenUserDoesNotHavePermissionToViewThePipeline() throws Exception {
+    public void findStageSummaryByIdentifierShouldRespondWith403WhenUserDoesNotHavePermissionToViewThePipeline() throws Exception {
         SecurityService securityService = mock(SecurityService.class);
         when(securityService.hasViewPermissionForPipeline(ALWAYS_ALLOW_USER, "pipeline_name")).thenReturn(false);
         TransactionSynchronizationManager transactionSynchronizationManager = mock(TransactionSynchronizationManager.class);
@@ -265,7 +265,7 @@ public class StageServiceTest {
 
         StageSummaryModel model = service.findStageSummaryByIdentifier(new StageIdentifier("pipeline_name/10/stage_name/1"), ALWAYS_ALLOW_USER, result);
 
-        assertThat(result.httpCode(), is(401));
+        assertThat(result.httpCode(), is(403));
         assertThat(model, is(nullValue()));
     }
 
@@ -591,7 +591,7 @@ public class StageServiceTest {
 		StageInstanceModels stageInstanceModels = stageService.findDetailedStageHistoryByOffset("pipeline", "stage", pagination, "looser", result);
 
 		assertThat(stageInstanceModels, is(Matchers.nullValue()));
-        assertThat(result.httpCode(), is(401));
+        assertThat(result.httpCode(), is(403));
 	}
 
     @Test
@@ -623,6 +623,6 @@ public class StageServiceTest {
         Stage stage = stageService.findStageWithIdentifier("pipeline", 1, "stage", "1", "looser", result);
 
         assertThat(stage, is(Matchers.nullValue()));
-        assertThat(result.httpCode(), is(401));
+        assertThat(result.httpCode(), is(403));
     }
 }

--- a/server/src/test-fast/java/com/thoughtworks/go/server/service/TemplateConfigServiceTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/service/TemplateConfigServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 ThoughtWorks, Inc.
+ * Copyright 2018 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -339,7 +339,7 @@ public class TemplateConfigServiceTest {
 
         assertThat(configForEdit, is(nullValue()));
         assertThat(result.isSuccessful(), is(false));
-        assertThat(result.httpCode(), is(401));
+        assertThat(result.httpCode(), is(403));
         assertThat(result.message(), is("Unauthorized to edit 'templateName' template."));
     }
 

--- a/server/src/test-fast/java/com/thoughtworks/go/server/service/ValueStreamMapServiceTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/service/ValueStreamMapServiceTest.java
@@ -814,7 +814,7 @@ public class ValueStreamMapServiceTest {
 
         valueStreamMapService.getValueStreamMap(new CaseInsensitiveString(pipelineName), 1, newUser, result);
 
-		assertResult(SC_UNAUTHORIZED, "You do not have view permissions for pipeline 'p1'.");
+		assertResult(SC_FORBIDDEN, "You do not have view permissions for pipeline 'p1'.");
     }
 
     @Test
@@ -923,7 +923,7 @@ public class ValueStreamMapServiceTest {
 		// unauthorized
 		valueStreamMapService.getValueStreamMap(gitMaterial.getFingerprint(), "r1", new Username(new CaseInsensitiveString(userName)), result);
 
-        assertResult(SC_UNAUTHORIZED, "You do not have view permissions for material with fingerprint '" + gitConfig.getFingerprint() + "'.");
+        assertResult(SC_FORBIDDEN, "You do not have view permissions for material with fingerprint '" + gitConfig.getFingerprint() + "'.");
 
 		// material config exists but no material instance
 		when(securityService.hasViewPermissionForGroup(userName, groupName)).thenReturn(true);

--- a/server/src/test-fast/java/com/thoughtworks/go/server/service/materials/PackageRepositoryServiceTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/service/materials/PackageRepositoryServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 ThoughtWorks, Inc.
+ * Copyright 2018 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -163,7 +163,7 @@ public class PackageRepositoryServiceTest {
         updateCommand.checkPermission(GoConfigMother.configWithPipelines("sample"), result);
 
         assertThat(result.isSuccessful(), is(false));
-        assertThat(result.httpCode(), is(401));
+        assertThat(result.httpCode(), is(403));
         verify(securityService).canViewAdminPage(username);
     }
 

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/AgentServiceIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/AgentServiceIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 ThoughtWorks, Inc.
+ * Copyright 2018 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -232,7 +232,7 @@ public class AgentServiceIntegrationTest {
         CONFIG_HELPER.enableSecurity();
         CONFIG_HELPER.addAdmins("admin1");
         agentService.modifyEnvironments(new Username(new CaseInsensitiveString("not-admin")), operationResult, Arrays.asList(UUID), Arrays.asList(new TriStateSelection("uat", TriStateSelection.Action.remove)));
-        assertThat(operationResult.httpCode(), is(401));
+        assertThat(operationResult.httpCode(), is(403));
         assertThat(operationResult.message(), is("Unauthorized to operate on agent"));
     }
 
@@ -557,7 +557,7 @@ public class AgentServiceIntegrationTest {
         CONFIG_HELPER.enableSecurity();
         CONFIG_HELPER.addAdmins("admin1");
         agentService.disableAgents(new Username(new CaseInsensitiveString("not-admin")), operationResult, Arrays.asList(agentId));
-        assertThat(operationResult.httpCode(), is(401));
+        assertThat(operationResult.httpCode(), is(403));
         assertThat(operationResult.message(), is("Unauthorized to operate on agent"));
     }
 
@@ -568,7 +568,7 @@ public class AgentServiceIntegrationTest {
         HttpOperationResult operationResult = new HttpOperationResult();
         CONFIG_HELPER.addAdmins("admin1");
         agentService.modifyResources(new Username(new CaseInsensitiveString("not-admin")), operationResult, Arrays.asList(agentId), Arrays.asList(new TriStateSelection("dont-care", TriStateSelection.Action.add)));
-        assertThat(operationResult.httpCode(), is(401));
+        assertThat(operationResult.httpCode(), is(403));
         assertThat(operationResult.message(), is("Unauthorized to operate on agent"));
     }
 
@@ -643,13 +643,13 @@ public class AgentServiceIntegrationTest {
     }
 
     @Test
-    public void shouldReturn401WhenAUnauthorizedUserTriesToEnable() throws IOException {
+    public void shouldReturn403WhenAUnauthorizedUserTriesToEnable() throws IOException {
         String agentId = "agent-id";
         CONFIG_HELPER.enableSecurity();
         HttpOperationResult operationResult = new HttpOperationResult();
         CONFIG_HELPER.addAdmins("admin1");
         agentService.enableAgents(new Username(new CaseInsensitiveString("not-admin")), operationResult, Arrays.asList(agentId));
-        assertThat(operationResult.httpCode(), is(401));
+        assertThat(operationResult.httpCode(), is(403));
         assertThat(operationResult.message(), is("Unauthorized to operate on agent"));
     }
 
@@ -761,12 +761,12 @@ public class AgentServiceIntegrationTest {
     }
 
     @Test
-    public void shouldReturn401WhenAUnauthorizedUserTriesToDelete() throws IOException {
+    public void shouldReturn403WhenAUnauthorizedUserTriesToDelete() throws IOException {
         CONFIG_HELPER.enableSecurity();
         HttpOperationResult operationResult = new HttpOperationResult();
         CONFIG_HELPER.addAdmins("admin1");
         agentService.deleteAgents(new Username(new CaseInsensitiveString("not-admin")), operationResult, Arrays.asList(UUID));
-        assertThat(operationResult.httpCode(), is(401));
+        assertThat(operationResult.httpCode(), is(403));
         assertThat(operationResult.message(), is("Unauthorized to operate on agent"));
     }
 
@@ -813,12 +813,12 @@ public class AgentServiceIntegrationTest {
     }
 
     @Test
-    public void shouldReturn401WhenAUnauthorizedUserTriesToDeleteAgents() throws IOException {
+    public void shouldReturn403WhenAUnauthorizedUserTriesToDeleteAgents() throws IOException {
         CONFIG_HELPER.enableSecurity();
         HttpOperationResult operationResult = new HttpOperationResult();
         CONFIG_HELPER.addAdmins("admin1");
         agentService.deleteAgents(new Username(new CaseInsensitiveString("not-admin")), operationResult, Arrays.asList(UUID));
-        assertThat(operationResult.httpCode(), is(401));
+        assertThat(operationResult.httpCode(), is(403));
         assertThat(operationResult.message(), is("Unauthorized to operate on agent"));
     }
 

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/ChangesetServiceIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/ChangesetServiceIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 ThoughtWorks, Inc.
+ * Copyright 2018 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -273,7 +273,7 @@ public class ChangesetServiceIntegrationTest {
         changesetService.revisionsBetween("foo", 1, 3, new Username(new CaseInsensitiveString("some_loser")), result, true, false);
         assertThat(result.isSuccessful(), is(false));
         assertThat(result.message(), is("You do not have view permissions for pipeline 'foo'."));
-        assertThat(result.httpCode(), is(401));
+        assertThat(result.httpCode(), is(403));
     }
 
     @Test

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/GoConfigServiceIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/GoConfigServiceIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 ThoughtWorks, Inc.
+ * Copyright 2018 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,7 +45,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 
-import static com.thoughtworks.go.i18n.LocalizedMessage.unauthorizedToEditGroup;
+import static com.thoughtworks.go.i18n.LocalizedMessage.forbiddenToEditGroup;
 import static javax.servlet.http.HttpServletResponse.SC_CONFLICT;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.sameInstance;
@@ -109,7 +109,7 @@ public class GoConfigServiceIntegrationTest {
         HttpLocalizedOperationResult result = new HttpLocalizedOperationResult();
         ConfigForEdit configForEdit = goConfigService.loadForEdit("my-pipeline", new Username(new CaseInsensitiveString("loser")), result);
         assertThat(configForEdit, is(nullValue()));
-        assertThat(result.httpCode(), is(401));
+        assertThat(result.httpCode(), is(403));
         assertThat(result.message(), is("Unauthorized to edit 'my-pipeline' pipeline."));
 
         result = new HttpLocalizedOperationResult();
@@ -169,7 +169,7 @@ public class GoConfigServiceIntegrationTest {
     }
 
     @Test
-    public void shouldReturn401WhenAUserIsNotAnAdmin() throws IOException {
+    public void shouldReturn403WhenAUserIsNotAnAdmin() throws IOException {
         configHelper.enableSecurity();
         configHelper.addAdmins("hero");
 
@@ -181,7 +181,7 @@ public class GoConfigServiceIntegrationTest {
         goConfigService.loadCruiseConfigForEdit(new Username(new CaseInsensitiveString("loser")), result);
 
         assertThat(result.isSuccessful(), is(false));
-        assertThat(result.httpCode(), is(401));
+        assertThat(result.httpCode(), is(403));
         assertThat(result.message(), is("Unauthorized to edit."));
     }
 
@@ -477,7 +477,7 @@ public class GoConfigServiceIntegrationTest {
         final CruiseConfig[] configObtainedInCheckPermissions = new CruiseConfig[1];
         ConfigUpdateResponse response = goConfigService.updateConfigFromUI(new AddStageToPipelineCommand("secondStage") {
             public void checkPermission(CruiseConfig cruiseConfig, LocalizedOperationResult result) {
-                result.unauthorized(unauthorizedToEditGroup("groupName"), null);
+                result.forbidden(forbiddenToEditGroup("groupName"), null);
                 configObtainedInCheckPermissions[0] = cruiseConfig;
             }
         }, md5, Username.ANONYMOUS, result);
@@ -492,7 +492,7 @@ public class GoConfigServiceIntegrationTest {
         assertThat(response.getCruiseConfig(), is(goConfigService.getConfigForEditing()));
         assertThat(response.getNode(), is(pipelineConfig));
         assertThat(result.isSuccessful(), is(false));
-        assertThat(result.httpCode(), is(401));
+        assertThat(result.httpCode(), is(403));
         assertThat(result.message(), is("Unauthorized to edit 'groupName' group."));
     }
 

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/MingleConfigServiceIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/MingleConfigServiceIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 ThoughtWorks, Inc.
+ * Copyright 2018 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -91,7 +91,7 @@ public class MingleConfigServiceIntegrationTest {
         assertThat(mingleConfig, is(nullValue()));
         assertThat(result.isSuccessful(), is(false));
         assertThat(result.message(), is("You do not have view permissions for pipeline 'foo'."));
-        assertThat(result.httpCode(), is(401));
+        assertThat(result.httpCode(), is(403));
     }
 
     @Test

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/PipelineConfigServiceIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/PipelineConfigServiceIntegrationTest.java
@@ -583,7 +583,7 @@ public class PipelineConfigServiceIntegrationTest {
         pipelineConfigService.updatePipelineConfig(new Username(new CaseInsensitiveString("unauthorized_user")), pipelineConfig, null, result);
 
         assertThat(result.toString(), result.isSuccessful(), is(false));
-        assertThat(result.toString(), result.httpCode(), is(401));
+        assertThat(result.toString(), result.httpCode(), is(403));
         assertThat(result.toString(), result.message().equals("Unauthorized to edit '" + pipelineConfig.name() + "' pipeline."), is(true));
         assertThat(configRepository.getCurrentRevCommit().name(), is(headCommitBeforeUpdate));
         assertThat(goConfigDao.loadConfigHolder().configForEdit, is(goConfigHolderBeforeUpdate.configForEdit));
@@ -654,8 +654,8 @@ public class PipelineConfigServiceIntegrationTest {
         pipelineConfigService.deletePipelineConfig(new Username(new CaseInsensitiveString("unauthorized-user")), pipelineConfig, result);
 
         assertFalse(result.isSuccessful());
-        assertThat(result.message(), is(LocalizedMessage.unauthorizedToDelete("Pipeline", pipelineConfig.name())));
-        assertThat(result.httpCode(), is(401));
+        assertThat(result.message(), is(LocalizedMessage.forbiddenToDelete("Pipeline", pipelineConfig.name())));
+        assertThat(result.httpCode(), is(403));
         int pipelineCountAfter = goConfigService.getAllPipelineConfigs().size();
         assertThat(pipelineCountAfter, is(pipelineCountBefore));
         assertTrue(goConfigService.hasPipelineNamed(pipelineConfig.name()));

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/PipelineHistoryServiceIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/PipelineHistoryServiceIntegrationTest.java
@@ -580,7 +580,7 @@ public class PipelineHistoryServiceIntegrationTest {
         HttpOperationResult result = new HttpOperationResult();
         PipelineInstanceModel pipelineInstance = pipelineHistoryService.load(pipeline.getId(), new Username(new CaseInsensitiveString("foo")), result);
         assertThat(pipelineInstance, is(nullValue()));
-        assertThat(result.httpCode(), is(401));
+        assertThat(result.httpCode(), is(403));
 
         result = new HttpOperationResult();
         pipelineInstance = pipelineHistoryService.load(pipeline.getId(), new Username(new CaseInsensitiveString("admin")), result);
@@ -649,7 +649,7 @@ public class PipelineHistoryServiceIntegrationTest {
         HttpOperationResult result = new HttpOperationResult();
         PipelineInstanceModels pipelineInstances = pipelineHistoryService.findAllPipelineInstances(pipeline.getName(), new Username(new CaseInsensitiveString("foo")), result);
         assertThat(pipelineInstances, is(nullValue()));
-        assertThat(result.httpCode(), is(401));
+        assertThat(result.httpCode(), is(403));
         assertThat(result.message(), is("Not authorized to view pipeline"));
         pipelineInstances = pipelineHistoryService.findAllPipelineInstances(pipeline.getName(), new Username(new CaseInsensitiveString("admin")), new HttpOperationResult());
         assertThat(pipelineInstances.size(), is(1));
@@ -711,7 +711,7 @@ public class PipelineHistoryServiceIntegrationTest {
         HttpOperationResult result = new HttpOperationResult();
         PipelineInstanceModel pipelineInstance = pipelineHistoryService.findPipelineInstance(pipeline.getName(), pipeline.getCounter(), new Username(new CaseInsensitiveString("foo")), result);
         assertThat(pipelineInstance, is(nullValue()));
-        assertThat(result.httpCode(), is(401));
+        assertThat(result.httpCode(), is(403));
         assertThat(result.message(), is("Not authorized to view pipeline"));
         pipelineInstance = pipelineHistoryService.findPipelineInstance(pipeline.getName(), pipeline.getCounter(), new Username(new CaseInsensitiveString("admin")), new HttpOperationResult());
         assertThat(pipelineInstance, is(not(nullValue())));
@@ -969,7 +969,7 @@ public class PipelineHistoryServiceIntegrationTest {
         PipelineInstanceModels pipelineInstances = pipelineHistoryService.findMatchingPipelineInstances("pipeline_name", "ABCD", 1000, new Username(new CaseInsensitiveString("fraud-user")), result);
         assertThat(pipelineInstances.size(), is(0));
         assertThat(result.isSuccessful(), is(false));
-        assertThat(result.httpCode(), is(401));
+        assertThat(result.httpCode(), is(403));
     }
 
     @Test
@@ -1003,7 +1003,7 @@ public class PipelineHistoryServiceIntegrationTest {
         PipelineInstanceModel pim = dbHelper.getPipelineDao().findPipelineHistoryByNameAndCounter("pipeline_name", 1);
 
         assertThat(pim.getComment(), is(nullValue()));
-        assertThat(result.httpCode(), is(401));
+        assertThat(result.httpCode(), is(403));
         assertThat(result.message(), is("You do not have operate permissions for pipeline 'pipeline_name'."));
     }
 

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/PipelineTriggerServiceIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/PipelineTriggerServiceIntegrationTest.java
@@ -409,7 +409,7 @@ public class PipelineTriggerServiceIntegrationTest {
         assertThat(result.isSuccess(), is(false));
         assertThat(result.fullMessage(), is(String.format("Failed to trigger pipeline [%s] { User foo does not have permission to schedule %s/%s }", pipelineName, pipelineName, stageName)));
         assertThat(result.getServerHealthState().getDescription(), is(String.format("User foo does not have permission to schedule %s/%s", pipelineName, pipelineConfig.first().name())));
-        assertThat(result.httpCode(), is(401));
+        assertThat(result.httpCode(), is(403));
         assertThat(triggerMonitor.isAlreadyTriggered(pipelineNameCaseInsensitive), is(false));
     }
 

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/ScheduleServiceSecurityTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/ScheduleServiceSecurityTest.java
@@ -90,7 +90,7 @@ public class ScheduleServiceSecurityTest {
 
         assertThat(resultStage, is(nullValue()));
         assertThat(operationResult.isSuccessful(), is(false));
-        assertThat(operationResult.httpCode(), is(SC_UNAUTHORIZED));
+        assertThat(operationResult.httpCode(), is(SC_FORBIDDEN));
     }
 
     @Test

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/materials/PackageRepositoryServiceIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/materials/PackageRepositoryServiceIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 ThoughtWorks, Inc.
+ * Copyright 2018 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,10 +26,8 @@ import com.thoughtworks.go.plugin.infra.plugininfo.GoPluginDescriptor;
 import com.thoughtworks.go.presentation.TriStateSelection;
 import com.thoughtworks.go.server.dao.PluginSqlMapDao;
 import com.thoughtworks.go.server.domain.Username;
-import com.thoughtworks.go.server.service.EntityHashingService;
 import com.thoughtworks.go.server.service.GoConfigService;
 import com.thoughtworks.go.server.service.result.HttpLocalizedOperationResult;
-import com.thoughtworks.go.serverhealth.HealthStateType;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -39,8 +37,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
-import static com.thoughtworks.go.i18n.LocalizedMessage.unauthorizedToEdit;
-import static com.thoughtworks.go.serverhealth.HealthStateType.unauthorised;
+import static com.thoughtworks.go.i18n.LocalizedMessage.forbiddenToEdit;
+import static com.thoughtworks.go.serverhealth.HealthStateType.forbidden;
 import static java.util.Arrays.asList;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.*;
@@ -110,7 +108,7 @@ public class PackageRepositoryServiceIntegrationTest {
         npmRepo.setId(repoId);
         goConfigService.getConfigForEditing().setPackageRepositories(new PackageRepositories(npmRepo));
         HttpLocalizedOperationResult expectedResult = new HttpLocalizedOperationResult();
-        expectedResult.unauthorized(unauthorizedToEdit(), unauthorised());
+        expectedResult.forbidden(forbiddenToEdit(), forbidden());
 
         assertThat(goConfigService.getConfigForEditing().getPackageRepositories().size(), is(1));
         assertThat(goConfigService.getConfigForEditing().getPackageRepositories().find(repoId), is(npmRepo));
@@ -130,7 +128,7 @@ public class PackageRepositoryServiceIntegrationTest {
         npmRepo.setId(repoId);
         goConfigService.getConfigForEditing().setPackageRepositories(new PackageRepositories(npmRepo));
         HttpLocalizedOperationResult expectedResult = new HttpLocalizedOperationResult();
-        expectedResult.unauthorized(unauthorizedToEdit(), unauthorised());
+        expectedResult.forbidden(forbiddenToEdit(), forbidden());
 
         assertThat(goConfigService.getConfigForEditing().getPackageRepositories().size(), is(1));
         assertThat(goConfigService.getConfigForEditing().getPackageRepositories().find(repoId), is(npmRepo));
@@ -146,7 +144,7 @@ public class PackageRepositoryServiceIntegrationTest {
     @Test
     public void shouldReturnTheExactLocalizeMessageIfItFailsToUpdatePackageRepository() throws Exception {
         HttpLocalizedOperationResult expectedResult = new HttpLocalizedOperationResult();
-        expectedResult.unauthorized(unauthorizedToEdit(), unauthorised());
+        expectedResult.forbidden(forbiddenToEdit(), forbidden());
 
         HttpLocalizedOperationResult result = new HttpLocalizedOperationResult();
         String oldRepoId = "npmOrg";

--- a/server/webapp/WEB-INF/rails.new/app/controllers/admin/pipeline_configs_controller.rb
+++ b/server/webapp/WEB-INF/rails.new/app/controllers/admin/pipeline_configs_controller.rb
@@ -1,5 +1,5 @@
 ##########################GO-LICENSE-START################################
-# Copyright 2014 ThoughtWorks, Inc.
+# Copyright 2018 ThoughtWorks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@ module Admin
 
     layout 'single_page_app'
     before_action :check_feature_toggle
-    before_action :check_pipeline_group_admin_user_and_401
+    before_action :check_pipeline_group_admin_user_and_403
     before_action :load_pipeline
 
     def edit

--- a/server/webapp/WEB-INF/rails.new/app/controllers/admin/status_reports_controller.rb
+++ b/server/webapp/WEB-INF/rails.new/app/controllers/admin/status_reports_controller.rb
@@ -19,7 +19,7 @@ module Admin
     include AuthenticationHelper
 
     layout 'plugin'
-    before_action :check_admin_user_and_401
+    before_action :check_admin_user_and_403
     before_action :load_plugin_info
 
     def plugin_status

--- a/server/webapp/WEB-INF/rails.new/app/controllers/admin/templates_controller.rb
+++ b/server/webapp/WEB-INF/rails.new/app/controllers/admin/templates_controller.rb
@@ -1,5 +1,5 @@
 ##########################################################################
-# Copyright 2017 ThoughtWorks, Inc.
+# Copyright 2018 ThoughtWorks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,9 +17,9 @@
 class Admin::TemplatesController < AdminController
   helper Admin::TemplatesHelper
 
-  before_filter :check_admin_user_and_401, only: [:edit_permissions, :update_permissions]
-  before_filter :check_admin_user_or_group_admin_user_and_401, only: [:new, :create]
-  before_filter :check_admin_or_template_admin_and_401, only: [:edit, :destroy, :update]
+  before_filter :check_admin_user_and_403, only: [:edit_permissions, :update_permissions]
+  before_filter :check_admin_user_or_group_admin_user_and_403, only: [:new, :create]
+  before_filter :check_admin_or_template_admin_and_403, only: [:edit, :destroy, :update]
   before_filter :load_templates_from_service, :only => :index
   before_filter :load_cruise_config, :only => [:new, :edit, :index, :destroy, :edit_permissions]
   before_filter :autocomplete_for_permissions, :only => [:edit_permissions]

--- a/server/webapp/WEB-INF/rails.new/app/controllers/analytics_controller.rb
+++ b/server/webapp/WEB-INF/rails.new/app/controllers/analytics_controller.rb
@@ -19,7 +19,7 @@ class AnalyticsController < ApplicationController
 
   layout 'single_page_app', only: [:index]
 
-  before_action :check_admin_user_and_401, only: [:index]
+  before_action :check_admin_user_and_403, only: [:index]
   before_action :check_pipeline_exists, only: [:show]
   before_action :check_permissions, only: [:show]
 
@@ -40,9 +40,9 @@ class AnalyticsController < ApplicationController
 
   def check_permissions
     if is_request_for_pipeline_analytics?
-      is_pipeline_analytics_enabled_only_for_admins? ? check_admin_user_and_401 : check_user_can_see_pipeline
+      is_pipeline_analytics_enabled_only_for_admins? ? check_admin_user_and_403 : check_user_can_see_pipeline
     else
-      check_admin_user_and_401
+      check_admin_user_and_403
     end
   end
 

--- a/server/webapp/WEB-INF/rails.new/app/controllers/api/agents_controller.rb
+++ b/server/webapp/WEB-INF/rails.new/app/controllers/api/agents_controller.rb
@@ -1,5 +1,5 @@
 ##########################GO-LICENSE-START################################
-# Copyright 2014 ThoughtWorks, Inc.
+# Copyright 2018 ThoughtWorks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@ class Api::AgentsController < Api::ApiController
   include AuthenticationHelper
 
   before_action :check_user_and_404
-  before_action :check_admin_user_and_401, except: [:index, :show, :job_run_history]
+  before_action :check_admin_user_and_403, except: [:index, :show, :job_run_history]
 
   JobHistoryColumns = com.thoughtworks.go.server.service.JobInstanceService::JobHistoryColumns
 

--- a/server/webapp/WEB-INF/rails.new/app/controllers/api/configuration_controller.rb
+++ b/server/webapp/WEB-INF/rails.new/app/controllers/api/configuration_controller.rb
@@ -1,5 +1,5 @@
 ##########################GO-LICENSE-START################################
-# Copyright 2014 ThoughtWorks, Inc.
+# Copyright 2018 ThoughtWorks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -28,7 +28,7 @@ class Api::ConfigurationController < Api::ApiController
       end
       render json: config_revision_api_models
     else
-      render_error_response('Unauthorized to access this API.', 401, true)
+      render_error_response('Unauthorized to access this API.', 403, true)
     end
   end
 
@@ -40,7 +40,7 @@ class Api::ConfigurationController < Api::ApiController
       config_diff = config_repository.configChangesForCommits(from_revision, to_revision)
       render text: config_diff, content_type: 'text/plain'
     else
-      render_error_response('Unauthorized to access this API.', 401, true)
+      render_error_response('Unauthorized to access this API.', 403, true)
     end
   end
 end

--- a/server/webapp/WEB-INF/rails.new/app/controllers/api_v1/admin/config_repos_controller.rb
+++ b/server/webapp/WEB-INF/rails.new/app/controllers/api_v1/admin/config_repos_controller.rb
@@ -1,5 +1,5 @@
 ##########################################################################
-# Copyright 2017 ThoughtWorks, Inc.
+# Copyright 2018 ThoughtWorks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@
 module ApiV1
   module Admin
     class ConfigReposController < ApiV1::BaseController
-      before_action :check_admin_user_and_401
+      before_action :check_admin_user_and_403
       before_action :load_config_repo, only: [:show, :destroy, :update]
       before_action :check_for_stale_request, only: [:update]
 

--- a/server/webapp/WEB-INF/rails.new/app/controllers/api_v1/admin/internal/command_snippets_controller.rb
+++ b/server/webapp/WEB-INF/rails.new/app/controllers/api_v1/admin/internal/command_snippets_controller.rb
@@ -1,5 +1,5 @@
 ##########################################################################
-# Copyright 2016 ThoughtWorks, Inc.
+# Copyright 2018 ThoughtWorks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@ module ApiV1
   module Admin
     module Internal
       class CommandSnippetsController < ApiV1::BaseController
-        before_action :check_admin_user_and_401
+        before_action :check_admin_user_and_403
 
         def index
           command_snippets = command_repository_service.lookupCommand(params[:prefix])

--- a/server/webapp/WEB-INF/rails.new/app/controllers/api_v1/admin/internal/environments_controller.rb
+++ b/server/webapp/WEB-INF/rails.new/app/controllers/api_v1/admin/internal/environments_controller.rb
@@ -1,5 +1,5 @@
 ##########################################################################
-# Copyright 2016 ThoughtWorks, Inc.
+# Copyright 2018 ThoughtWorks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@ module ApiV1
   module Admin
     module Internal
       class EnvironmentsController < ApiV1::BaseController
-        before_action :check_admin_user_and_401
+        before_action :check_admin_user_and_403
 
         def index
           environment_list = environment_config_service.environmentNames()

--- a/server/webapp/WEB-INF/rails.new/app/controllers/api_v1/admin/internal/material_test_controller.rb
+++ b/server/webapp/WEB-INF/rails.new/app/controllers/api_v1/admin/internal/material_test_controller.rb
@@ -1,5 +1,5 @@
 ##########################################################################
-# Copyright 2016 ThoughtWorks, Inc.
+# Copyright 2018 ThoughtWorks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@ module ApiV1
         include_package 'com.thoughtworks.go.config.preprocessor'
         java_import com.thoughtworks.go.config.PipelineNotFoundException
 
-        before_action :check_admin_user_or_group_admin_user_and_401
+        before_action :check_admin_user_or_group_admin_user_and_403
 
         def test
           material_config = ApiV3::Admin::Pipelines::Materials::MaterialRepresenter.new(ApiV3::Admin::Pipelines::Materials::MaterialRepresenter.get_material_type(params[:type]).new).from_hash(params)

--- a/server/webapp/WEB-INF/rails.new/app/controllers/api_v1/admin/internal/package_repository_check_connection_controller.rb
+++ b/server/webapp/WEB-INF/rails.new/app/controllers/api_v1/admin/internal/package_repository_check_connection_controller.rb
@@ -1,5 +1,5 @@
 ##########################################################################
-# Copyright 2016 ThoughtWorks, Inc.
+# Copyright 2018 ThoughtWorks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@ module ApiV1
   module Admin
     module Internal
       class PackageRepositoryCheckConnectionController < ::ApiV1::BaseController
-        before_action :check_admin_user_or_group_admin_user_and_401
+        before_action :check_admin_user_or_group_admin_user_and_403
 
         def repository_check_connection
           package_repository = PackageRepository.new

--- a/server/webapp/WEB-INF/rails.new/app/controllers/api_v1/admin/internal/pipelines_controller.rb
+++ b/server/webapp/WEB-INF/rails.new/app/controllers/api_v1/admin/internal/pipelines_controller.rb
@@ -1,5 +1,5 @@
 ##########################################################################
-# Copyright 2016 ThoughtWorks, Inc.
+# Copyright 2018 ThoughtWorks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@ module ApiV1
   module Admin
     module Internal
       class PipelinesController < ApiV1::BaseController
-        before_action :check_admin_user_or_group_admin_user_and_401
+        before_action :check_admin_user_or_group_admin_user_and_403
 
         def index
           pipelines = pipeline_config_service.viewableOrOperatableGroupsFor(current_user)

--- a/server/webapp/WEB-INF/rails.new/app/controllers/api_v1/admin/internal/resources_controller.rb
+++ b/server/webapp/WEB-INF/rails.new/app/controllers/api_v1/admin/internal/resources_controller.rb
@@ -1,5 +1,5 @@
 ##########################################################################
-# Copyright 2016 ThoughtWorks, Inc.
+# Copyright 2018 ThoughtWorks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@ module ApiV1
   module Admin
     module Internal
       class ResourcesController < ApiV1::BaseController
-        before_action :check_admin_user_and_401
+        before_action :check_admin_user_and_403
 
         def index
           resource_list = go_config_service.getResourceList()

--- a/server/webapp/WEB-INF/rails.new/app/controllers/api_v1/admin/merged_environments_controller.rb
+++ b/server/webapp/WEB-INF/rails.new/app/controllers/api_v1/admin/merged_environments_controller.rb
@@ -1,5 +1,5 @@
 ##########################################################################
-# Copyright 2017 ThoughtWorks, Inc.
+# Copyright 2018 ThoughtWorks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@
 module ApiV1
   module Admin
     class MergedEnvironmentsController < ApiV1::BaseController
-      before_action :check_admin_user_and_401
+      before_action :check_admin_user_and_403
 
       def index
         render DEFAULT_FORMAT => Admin::MergedEnvironments::MergedEnvironmentsConfigRepresenter.new(environment_config_service.getAllMergedEnvironments()).to_hash(url_builder: self)

--- a/server/webapp/WEB-INF/rails.new/app/controllers/api_v1/admin/packages_controller.rb
+++ b/server/webapp/WEB-INF/rails.new/app/controllers/api_v1/admin/packages_controller.rb
@@ -1,5 +1,5 @@
 ##########################################################################
-# Copyright 2016 ThoughtWorks, Inc.
+# Copyright 2018 ThoughtWorks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@
 module ApiV1
   module Admin
     class PackagesController < ApiV1::BaseController
-      before_action :check_admin_user_or_group_admin_user_and_401
+      before_action :check_admin_user_or_group_admin_user_and_403
       before_action :load_package, only: [:show, :destroy, :update]
       before_action :check_for_stale_request, only: [:update]
       before_action :check_for_repository, only: [:create, :update]

--- a/server/webapp/WEB-INF/rails.new/app/controllers/api_v1/admin/pluggable_scms_controller.rb
+++ b/server/webapp/WEB-INF/rails.new/app/controllers/api_v1/admin/pluggable_scms_controller.rb
@@ -1,5 +1,5 @@
 ##########################################################################
-# Copyright 2016 ThoughtWorks, Inc.
+# Copyright 2018 ThoughtWorks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@
 module ApiV1
   module Admin
     class PluggableScmsController < ApiV1::BaseController
-      before_action :check_admin_user_or_group_admin_user_and_401
+      before_action :check_admin_user_or_group_admin_user_and_403
       before_action :check_for_stale_request, :check_for_scm_rename, only: [:update]
 
 

--- a/server/webapp/WEB-INF/rails.new/app/controllers/api_v1/admin/plugin_settings_controller.rb
+++ b/server/webapp/WEB-INF/rails.new/app/controllers/api_v1/admin/plugin_settings_controller.rb
@@ -1,5 +1,5 @@
 ##########################################################################
-# Copyright 2017 ThoughtWorks, Inc.
+# Copyright 2018 ThoughtWorks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@
 module ApiV1
   module Admin
     class PluginSettingsController < ApiV1::BaseController
-      before_action :check_admin_user_and_401
+      before_action :check_admin_user_and_403
       before_action :load_plugin_settings, only: [:show, :update]
       before_action :check_for_stale_request, only: [:update]
 

--- a/server/webapp/WEB-INF/rails.new/app/controllers/api_v1/admin/repositories_controller.rb
+++ b/server/webapp/WEB-INF/rails.new/app/controllers/api_v1/admin/repositories_controller.rb
@@ -1,5 +1,5 @@
 ##########################################################################
-# Copyright 2016 ThoughtWorks, Inc.
+# Copyright 2018 ThoughtWorks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@
 module ApiV1
   module Admin
     class RepositoriesController < ApiV1::BaseController
-      before_action :check_admin_user_or_group_admin_user_and_401
+      before_action :check_admin_user_or_group_admin_user_and_403
       before_action :load_package_repository, only: [:show, :destroy, :update]
       before_action :check_for_stale_request, only: [:update]
 

--- a/server/webapp/WEB-INF/rails.new/app/controllers/api_v1/admin/security/auth_configs_controller.rb
+++ b/server/webapp/WEB-INF/rails.new/app/controllers/api_v1/admin/security/auth_configs_controller.rb
@@ -1,5 +1,5 @@
 ##########################################################################
-# Copyright 2017 ThoughtWorks, Inc.
+# Copyright 2018 ThoughtWorks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@ module ApiV1
   module Admin
     module Security
       class AuthConfigsController < BaseController
-        before_filter :check_admin_user_and_401
+        before_filter :check_admin_user_and_403
         before_action :check_for_stale_request, :check_for_attempted_rename, only: [:update]
 
         include ProfilesControllerActions

--- a/server/webapp/WEB-INF/rails.new/app/controllers/api_v1/admin/templates/authorization_controller.rb
+++ b/server/webapp/WEB-INF/rails.new/app/controllers/api_v1/admin/templates/authorization_controller.rb
@@ -1,5 +1,5 @@
 ##########################################################################
-# Copyright 2017 ThoughtWorks, Inc.
+# Copyright 2018 ThoughtWorks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@ module ApiV1
     module Templates
       class AuthorizationController < BaseController
 
-        before_action :check_admin_user_and_401
+        before_action :check_admin_user_and_403
         before_action :load_template, only: [:show, :update]
         before_action :check_for_stale_request, only: [:update]
 

--- a/server/webapp/WEB-INF/rails.new/app/controllers/api_v1/elastic/profiles_controller.rb
+++ b/server/webapp/WEB-INF/rails.new/app/controllers/api_v1/elastic/profiles_controller.rb
@@ -1,5 +1,5 @@
 ##########################################################################
-# Copyright 2016 ThoughtWorks, Inc.
+# Copyright 2018 ThoughtWorks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@
 module ApiV1
   module Elastic
     class ProfilesController < ::ApiV1::BaseController
-      before_filter :check_admin_user_or_group_admin_user_and_401
+      before_filter :check_admin_user_or_group_admin_user_and_403
       before_action :check_for_stale_request, :check_for_attempted_rename, only: [:update]
 
       include ProfilesControllerActions

--- a/server/webapp/WEB-INF/rails.new/app/controllers/api_v2/admin/environments_controller.rb
+++ b/server/webapp/WEB-INF/rails.new/app/controllers/api_v2/admin/environments_controller.rb
@@ -1,5 +1,5 @@
 ##########################################################################
-# Copyright 2016 ThoughtWorks, Inc.
+# Copyright 2018 ThoughtWorks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@
 module ApiV2
   module Admin
     class EnvironmentsController < ApiV2::BaseController
-      before_action :check_admin_user_and_401
+      before_action :check_admin_user_and_403
       before_action :load_environment, only: [:show, :put, :patch, :destroy]
       before_action :check_for_stale_request, only: [:put]
 

--- a/server/webapp/WEB-INF/rails.new/app/controllers/api_v2/users_controller.rb
+++ b/server/webapp/WEB-INF/rails.new/app/controllers/api_v2/users_controller.rb
@@ -1,5 +1,5 @@
 ##########################################################################
-# Copyright 2017 ThoughtWorks, Inc.
+# Copyright 2018 ThoughtWorks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@ module ApiV2
   class UsersController < ApiV2::BaseController
     include ApiV2::UsersHelper
 
-    before_action :check_admin_user_and_401
+    before_action :check_admin_user_and_403
     before_action :load_user, only: [:show, :update, :destroy]
 
     def index

--- a/server/webapp/WEB-INF/rails.new/app/controllers/api_v3/admin/pipelines_controller.rb
+++ b/server/webapp/WEB-INF/rails.new/app/controllers/api_v3/admin/pipelines_controller.rb
@@ -1,5 +1,5 @@
 ##########################################################################
-# Copyright 2016 ThoughtWorks, Inc.
+# Copyright 2018 ThoughtWorks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@
 module ApiV3
   module Admin
     class PipelinesController < ApiV3::BaseController
-      before_action :check_pipeline_group_admin_user_and_401
+      before_action :check_pipeline_group_admin_user_and_403
       before_action :load_pipeline, only: [:show, :update, :destroy]
       before_action :check_if_pipeline_is_defined_remotely, only: [:update, :destroy]
       before_action :check_if_pipeline_by_same_name_already_exists, :check_group_not_blank, only: [:create]

--- a/server/webapp/WEB-INF/rails.new/app/controllers/api_v3/admin/plugin_infos_controller.rb
+++ b/server/webapp/WEB-INF/rails.new/app/controllers/api_v3/admin/plugin_infos_controller.rb
@@ -18,7 +18,7 @@ module ApiV3
   module Admin
     class PluginInfosController < BaseController
 
-      before_action :check_user_and_401
+      before_action :check_user_and_403
 
       PLUGIN_TYPES_FOR_VERSION = [
         PluginConstants.AUTHORIZATION_EXTENSION,

--- a/server/webapp/WEB-INF/rails.new/app/controllers/api_v3/admin/templates_controller.rb
+++ b/server/webapp/WEB-INF/rails.new/app/controllers/api_v3/admin/templates_controller.rb
@@ -1,5 +1,5 @@
 ##########################################################################
-# Copyright 2017 ThoughtWorks, Inc.
+# Copyright 2018 ThoughtWorks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,9 +18,9 @@ module ApiV3
   module Admin
     class TemplatesController < ApiV3::BaseController
       before_action :load_template, only: [:show, :update, :destroy]
-      before_action :check_admin_user_or_group_admin_user_and_401, only: [:create]
-      before_action :check_admin_or_template_admin_and_401, only: [:destroy, :update]
-      before_action :check_view_access_to_template_and_401, only: [:show, :index]
+      before_action :check_admin_user_or_group_admin_user_and_403, only: [:create]
+      before_action :check_admin_or_template_admin_and_403, only: [:destroy, :update]
+      before_action :check_view_access_to_template_and_403, only: [:show, :index]
       before_action :check_for_stale_request, :check_for_attempted_template_rename, only: [:update]
 
       def index

--- a/server/webapp/WEB-INF/rails.new/app/controllers/api_v4/admin/pipelines_controller.rb
+++ b/server/webapp/WEB-INF/rails.new/app/controllers/api_v4/admin/pipelines_controller.rb
@@ -1,5 +1,5 @@
 ##########################################################################
-# Copyright 2017 ThoughtWorks, Inc.
+# Copyright 2018 ThoughtWorks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@
 module ApiV4
   module Admin
     class PipelinesController < BaseController
-      before_action :check_pipeline_group_admin_user_and_401
+      before_action :check_pipeline_group_admin_user_and_403
       before_action :load_pipeline, only: [:show, :update, :destroy]
       before_action :check_if_pipeline_is_defined_remotely, only: [:update, :destroy]
       before_action :check_if_pipeline_by_same_name_already_exists, :check_group_not_blank, only: [:create]

--- a/server/webapp/WEB-INF/rails.new/app/controllers/api_v4/admin/plugin_infos_controller.rb
+++ b/server/webapp/WEB-INF/rails.new/app/controllers/api_v4/admin/plugin_infos_controller.rb
@@ -18,7 +18,7 @@ module ApiV4
   module Admin
     class PluginInfosController < BaseController
 
-      before_action :check_user_and_401
+      before_action :check_user_and_403
 
       PLUGIN_TYPES_FOR_VERSION = [
         PluginConstants.AUTHORIZATION_EXTENSION,

--- a/server/webapp/WEB-INF/rails.new/app/controllers/api_v4/admin/templates_controller.rb
+++ b/server/webapp/WEB-INF/rails.new/app/controllers/api_v4/admin/templates_controller.rb
@@ -1,5 +1,5 @@
 ##########################################################################
-# Copyright 2017 ThoughtWorks, Inc.
+# Copyright 2018 ThoughtWorks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,9 +18,9 @@ module ApiV4
   module Admin
     class TemplatesController < ApiV4::BaseController
       before_action :load_template, only: [:show, :update, :destroy]
-      before_action :check_admin_user_or_group_admin_user_and_401, only: [:create]
-      before_action :check_admin_or_template_admin_and_401, only: [:destroy, :update]
-      before_action :check_view_access_to_template_and_401, only: [:show, :index]
+      before_action :check_admin_user_or_group_admin_user_and_403, only: [:create]
+      before_action :check_admin_or_template_admin_and_403, only: [:destroy, :update]
+      before_action :check_view_access_to_template_and_403, only: [:show, :index]
       before_action :check_for_stale_request, :check_for_attempted_template_rename, only: [:update]
 
       def index

--- a/server/webapp/WEB-INF/rails.new/app/controllers/api_v4/agents_controller.rb
+++ b/server/webapp/WEB-INF/rails.new/app/controllers/api_v4/agents_controller.rb
@@ -1,5 +1,5 @@
 ##########################################################################
-# Copyright 2016 ThoughtWorks, Inc.
+# Copyright 2018 ThoughtWorks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@ module ApiV4
   class AgentsController < ApiV4::BaseController
 
     before_action :check_user_and_404
-    before_action :check_admin_user_and_401, except: [:index, :show]
+    before_action :check_admin_user_and_403, except: [:index, :show]
     before_action :set_default_values_if_not_present, only: [:bulk_update]
     before_action :load_agent, only: [:show, :edit, :update, :destroy, :enable, :disable]
 

--- a/server/webapp/WEB-INF/rails.new/app/controllers/api_v5/admin/pipelines_controller.rb
+++ b/server/webapp/WEB-INF/rails.new/app/controllers/api_v5/admin/pipelines_controller.rb
@@ -1,5 +1,5 @@
 ##########################################################################
-# Copyright 2017 ThoughtWorks, Inc.
+# Copyright 2018 ThoughtWorks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@
 module ApiV5
   module Admin
     class PipelinesController < BaseController
-      before_action :check_pipeline_group_admin_user_and_401
+      before_action :check_pipeline_group_admin_user_and_403
       before_action :load_pipeline, only: [:show, :update, :destroy]
       before_action :check_if_pipeline_is_defined_remotely, only: [:update, :destroy]
       before_action :check_if_pipeline_by_same_name_already_exists, :check_group_not_blank, only: [:create]

--- a/server/webapp/WEB-INF/rails.new/app/controllers/application_controller.rb
+++ b/server/webapp/WEB-INF/rails.new/app/controllers/application_controller.rb
@@ -89,7 +89,7 @@ class ApplicationController < ActionController::Base
 
   def allow_local_only
     return true if request_from_localhost?
-    render_if_error("Unauthorized", 401)
+    render_if_error("Forbidden", 403)
     false
   end
 

--- a/server/webapp/WEB-INF/rails.new/app/controllers/config_view/templates_controller.rb
+++ b/server/webapp/WEB-INF/rails.new/app/controllers/config_view/templates_controller.rb
@@ -1,5 +1,5 @@
 ##########################################################################
-# Copyright 2017 ThoughtWorks, Inc.
+# Copyright 2018 ThoughtWorks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@
 module ConfigView
   class TemplatesController < ConfigView::ConfigViewController
     include Admin::AuthorizationHelper
-    before_action :check_view_access_to_template_and_401
+    before_action :check_view_access_to_template_and_403
 
     def show
       result = HttpLocalizedOperationResult.new

--- a/server/webapp/WEB-INF/rails.new/app/controllers/preferences_controller.rb
+++ b/server/webapp/WEB-INF/rails.new/app/controllers/preferences_controller.rb
@@ -1,5 +1,5 @@
 ##########################################################################
-# Copyright 2017 ThoughtWorks, Inc.
+# Copyright 2018 ThoughtWorks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@
 class PreferencesController < ApplicationController
   include AuthenticationHelper
 
-  before_action :check_user_and_401, :load_pipelines
+  before_action :check_user_and_403, :load_pipelines
 
   layout "single_page_app"
 

--- a/server/webapp/WEB-INF/rails.new/app/helpers/application_helper.rb
+++ b/server/webapp/WEB-INF/rails.new/app/helpers/application_helper.rb
@@ -1,5 +1,5 @@
 ##########################################################################
-# Copyright 2017 ThoughtWorks, Inc.
+# Copyright 2018 ThoughtWorks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -431,8 +431,8 @@ module ApplicationHelper
     hidden_field_tag('cruise_config_md5', cruise_config_md5)
   end
 
-  def unauthorized_access
-    @status == 401
+  def access_forbidden
+    @status == 403
   end
 
   def required_label(form, name, text)

--- a/server/webapp/WEB-INF/rails.new/app/helpers/authentication_helper.rb
+++ b/server/webapp/WEB-INF/rails.new/app/helpers/authentication_helper.rb
@@ -1,5 +1,5 @@
 ##########################################################################
-# Copyright 2017 ThoughtWorks, Inc.
+# Copyright 2018 ThoughtWorks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -23,11 +23,11 @@ module AuthenticationHelper
     end
   end
 
-  def check_user_and_401
+  def check_user_and_403
     return unless security_service.isSecurityEnabled()
     if current_user.try(:isAnonymous)
       Rails.logger.info("User '#{current_user.getUsername}' attempted to perform an unauthorized action!")
-      render_unauthorized_error
+      render_forbidden_error
     end
   end
 
@@ -35,67 +35,67 @@ module AuthenticationHelper
     return unless security_service.isSecurityEnabled()
     unless security_service.hasViewPermissionForPipeline(current_user, params[:pipeline_name])
       Rails.logger.info("User '#{current_user.getUsername}' attempted to perform an unauthorized action!")
-      render_unauthorized_error
+      render_forbidden_error
     end
   end
 
-  def check_admin_user_and_401
+  def check_admin_user_and_403
     return unless security_service.isSecurityEnabled()
     unless security_service.isUserAdmin(current_user)
       Rails.logger.info("User '#{current_user.getUsername}' attempted to perform an unauthorized action!")
-      render_unauthorized_error
+      render_forbidden_error
     end
   end
 
-  def check_admin_or_template_admin_and_401
+  def check_admin_or_template_admin_and_403
     template_name = params[:template_name]
     return unless security_service.isSecurityEnabled
 
     if template_name.blank? && !(security_service.isUserAdmin(current_user) || security_service.isAuthorizedToViewAndEditTemplates(current_user))
       Rails.logger.info("User '#{current_user.getUsername}' attempted to perform an unauthorized action!")
-      render_unauthorized_error
+      render_forbidden_error
     end
     if !template_name.blank? && !security_service.isAuthorizedToEditTemplate(com.thoughtworks.go.config.CaseInsensitiveString.new(template_name), current_user)
       Rails.logger.info("User '#{current_user.getUsername}' attempted to perform an unauthorized action!")
-      render_unauthorized_error
+      render_forbidden_error
     end
   end
 
-  def check_view_access_to_template_and_401
+  def check_view_access_to_template_and_403
     return unless security_service.isSecurityEnabled
     template_name = params[:template_name]
     if !template_name.blank? && !security_service.isAuthorizedToViewTemplate(com.thoughtworks.go.config.CaseInsensitiveString.new(template_name), current_user)
       Rails.logger.info("User '#{current_user.getUsername}' attempted to perform an unauthorized action!")
-      render_unauthorized_error
+      render_forbidden_error
     end
     if template_name.blank? && !security_service.isAuthorizedToViewTemplates(current_user)
       Rails.logger.info("User '#{current_user.getUsername}' attempted to perform an unauthorized action!")
-      render_unauthorized_error
+      render_forbidden_error
     end
   end
 
-  def check_admin_user_or_group_admin_user_and_401
+  def check_admin_user_or_group_admin_user_and_403
     return unless security_service.isSecurityEnabled()
     if !(security_service.isUserAdmin(current_user) || security_service.isUserGroupAdmin(current_user))
       Rails.logger.info("User '#{current_user.getUsername}' attempted to perform an unauthorized action!")
-      render_unauthorized_error
+      render_forbidden_error
     end
   end
 
-  def check_any_admin_user_and_401
+  def check_any_admin_user_and_403
     return unless security_service.isSecurityEnabled()
     if !(security_service.isUserAdmin(current_user) || security_service.isUserGroupAdmin(current_user) || security_service.isAuthorizedToViewAndEditTemplates(current_user))
       Rails.logger.info("User '#{current_user.getUsername}' attempted to perform an unauthorized action!")
-      render_unauthorized_error
+      render_forbidden_error
     end
   end
 
-  def check_pipeline_group_admin_user_and_401
+  def check_pipeline_group_admin_user_and_403
     groupName = params[:group] || go_config_service.findGroupNameByPipeline(com.thoughtworks.go.config.CaseInsensitiveString.new(params[:pipeline_name]))
     return unless security_service.isSecurityEnabled()
     unless is_user_an_admin_for_group?(current_user, groupName)
       Rails.logger.info("User '#{current_user.getUsername}' attempted to perform an unauthorized action!")
-      render_unauthorized_error
+      render_forbidden_error
     end
   end
 
@@ -113,8 +113,8 @@ module AuthenticationHelper
     render_message("Your request could not be processed. #{exception.message}", 400)
   end
 
-  def render_unauthorized_error
-    render_message('You are not authorized to perform this action.', 401)
+  def render_forbidden_error
+    render_message('You are not authorized to perform this action.', 403)
   end
 
   private

--- a/server/webapp/WEB-INF/rails.new/app/views/shared/config_error.html.erb
+++ b/server/webapp/WEB-INF/rails.new/app/views/shared/config_error.html.erb
@@ -5,7 +5,7 @@
         <div class='biggest'>:(</div>
         <h3><%= @message -%></h3>
     </div>
-    <% unless unauthorized_access -%>
+    <% unless access_forbidden -%>
         <div class="error-child-like-margin">
             <span>Jump To:</span>
             <%= link_to 'Pipelines', pipeline_groups_path -%>

--- a/server/webapp/WEB-INF/rails.new/lib/admin/authorization_helper.rb
+++ b/server/webapp/WEB-INF/rails.new/lib/admin/authorization_helper.rb
@@ -1,5 +1,5 @@
 ##########################GO-LICENSE-START################################
-# Copyright 2017 ThoughtWorks, Inc.
+# Copyright 2018 ThoughtWorks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,38 +15,38 @@
 ##########################GO-LICENSE-END##################################
 module Admin
   module AuthorizationHelper
-    def check_admin_user_and_401
+    def check_admin_user_and_403
       return unless security_service.isSecurityEnabled()
       unless security_service.isUserAdmin(current_user)
         Rails.logger.info("User '#{current_user.getUsername}' attempted to perform an unauthorized action!")
-        render 'shared/config_error', status: 401
+        render 'shared/config_error', status: 403
       end
     end
 
-    def check_admin_or_template_admin_and_401
+    def check_admin_or_template_admin_and_403
       template_name = params[:pipeline_name]
       return unless security_service.isSecurityEnabled
 
       if !security_service.isUserAdmin(current_user) && !security_service.isAuthorizedToEditTemplate(com.thoughtworks.go.config.CaseInsensitiveString.new(template_name), current_user)
         Rails.logger.info("User '#{current_user.getUsername}' attempted to perform an unauthorized action!")
-        render 'shared/config_error', status: 401
+        render 'shared/config_error', status: 403
       end
     end
 
-    def check_view_access_to_template_and_401
+    def check_view_access_to_template_and_403
       return unless security_service.isSecurityEnabled
       template_name = params[:template_name] || params[:name]
       unless security_service.isAuthorizedToViewTemplate(com.thoughtworks.go.config.CaseInsensitiveString.new(template_name), current_user)
         Rails.logger.info("User '#{current_user.getUsername}' attempted to perform an unauthorized action!")
-        render 'shared/config_error', status: 401
+        render 'shared/config_error', status: 403
       end
     end
 
-    def check_admin_user_or_group_admin_user_and_401
+    def check_admin_user_or_group_admin_user_and_403
       return unless security_service.isSecurityEnabled()
       unless security_service.isUserAdmin(current_user) || security_service.isUserGroupAdmin(current_user)
         Rails.logger.info("User '#{current_user.getUsername}' attempted to perform an unauthorized action!")
-        render 'shared/config_error', status: 401
+        render 'shared/config_error', status: 403
       end
     end
   end

--- a/server/webapp/WEB-INF/rails.new/lib/config_update/check_can_create_pipeline.rb
+++ b/server/webapp/WEB-INF/rails.new/lib/config_update/check_can_create_pipeline.rb
@@ -1,5 +1,5 @@
 ##########################GO-LICENSE-START################################
-# Copyright 2014 ThoughtWorks, Inc.
+# Copyright 2018 ThoughtWorks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -28,7 +28,7 @@ module ConfigUpdate
     def checkPermission(cruise_config, result)
       return if has_permission(cruise_config)
 
-      result.unauthorized("Unauthorized to create pipeline.", nil)
+      result.forbidden("Unauthorized to create pipeline.", nil)
     end
   end
 end

--- a/server/webapp/WEB-INF/rails.new/lib/config_update/check_can_edit_pipeline.rb
+++ b/server/webapp/WEB-INF/rails.new/lib/config_update/check_can_edit_pipeline.rb
@@ -1,5 +1,5 @@
 ##########################GO-LICENSE-START################################
-# Copyright 2014 ThoughtWorks, Inc.
+# Copyright 2018 ThoughtWorks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -26,11 +26,11 @@ module ConfigUpdate
     def checkPermission(cruise_config, result)
       return if has_permission(cruise_config)
 
-      message = com.thoughtworks.go.i18n.LocalizedMessage.unauthorizedToEdit()
-      message = com.thoughtworks.go.i18n.LocalizedMessage.unauthorizedToEditGroup(pipeline_group_name) if !pipeline_group_name.nil?
-      message = com.thoughtworks.go.i18n.LocalizedMessage.unauthorizedToEditPipeline(pipeline_name) if !pipeline_name.isBlank()
+      message = com.thoughtworks.go.i18n.LocalizedMessage.forbiddenToEdit()
+      message = com.thoughtworks.go.i18n.LocalizedMessage.forbiddenToEditGroup(pipeline_group_name) if !pipeline_group_name.nil?
+      message = com.thoughtworks.go.i18n.LocalizedMessage.forbiddenToEditPipeline(pipeline_name) if !pipeline_name.isBlank()
 
-      result.unauthorized(message, nil)
+      result.forbidden(message, nil)
     end
   end
 end

--- a/server/webapp/WEB-INF/rails.new/lib/config_update/check_can_edit_pipeline_or_template.rb
+++ b/server/webapp/WEB-INF/rails.new/lib/config_update/check_can_edit_pipeline_or_template.rb
@@ -30,11 +30,11 @@ module ConfigUpdate
     def checkPermission(cruise_config, result)
       return if has_permission(cruise_config)
 
-      message = com.thoughtworks.go.i18n.LocalizedMessage.unauthorizedToEdit()
-      message = com.thoughtworks.go.i18n.LocalizedMessage.unauthorizedToEditGroup(pipeline_group_name) if !pipeline_group_name.nil?
-      message = com.thoughtworks.go.i18n.LocalizedMessage.unauthorizedToEditPipeline(pipeline_name) if !pipeline_name.isBlank()
+      message = com.thoughtworks.go.i18n.LocalizedMessage.forbiddenToEdit()
+      message = com.thoughtworks.go.i18n.LocalizedMessage.forbiddenToEditGroup(pipeline_group_name) if !pipeline_group_name.nil?
+      message = com.thoughtworks.go.i18n.LocalizedMessage.forbiddenToEditPipeline(pipeline_name) if !pipeline_name.isBlank()
 
-      result.unauthorized(message, nil)
+      result.forbidden(message, nil)
     end
   end
 end

--- a/server/webapp/WEB-INF/rails.new/lib/config_update/check_is_group_admin.rb
+++ b/server/webapp/WEB-INF/rails.new/lib/config_update/check_is_group_admin.rb
@@ -1,5 +1,5 @@
 ##########################GO-LICENSE-START################################
-# Copyright 2014 ThoughtWorks, Inc.
+# Copyright 2018 ThoughtWorks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -22,8 +22,8 @@ module ConfigUpdate
     def checkPermission(cruise_config, result)
       return if (@security_service.isUserGroupAdmin(@user) || @security_service.isUserAdmin(@user))
       
-      message = com.thoughtworks.go.i18n.LocalizedMessage.unauthorizedToEdit()
-      result.unauthorized(message, nil)
+      message = com.thoughtworks.go.i18n.LocalizedMessage.forbiddenToEdit()
+      result.forbidden(message, nil)
     end
   end
 end

--- a/server/webapp/WEB-INF/rails.new/lib/config_update/check_is_super_admin.rb
+++ b/server/webapp/WEB-INF/rails.new/lib/config_update/check_is_super_admin.rb
@@ -1,5 +1,5 @@
 ##########################GO-LICENSE-START################################
-# Copyright 2014 ThoughtWorks, Inc.
+# Copyright 2018 ThoughtWorks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -22,8 +22,8 @@ module ConfigUpdate
     def checkPermission(cruise_config, result)
       return if @security_service.isUserAdmin(@user)
       
-      message = com.thoughtworks.go.i18n.LocalizedMessage.unauthorizedToEdit()
-      result.unauthorized(message, nil)
+      message = com.thoughtworks.go.i18n.LocalizedMessage.forbiddenToEdit()
+      result.forbidden(message, nil)
     end
   end
 end

--- a/server/webapp/WEB-INF/rails.new/lib/config_update/check_is_template_admin.rb
+++ b/server/webapp/WEB-INF/rails.new/lib/config_update/check_is_template_admin.rb
@@ -22,8 +22,8 @@ module ConfigUpdate
     def checkPermission(cruise_config, result)
       return if @security_service.isAuthorizedToEditTemplate(com.thoughtworks.go.config.CaseInsensitiveString.new(template_name), SessionUtils::currentUsername())
 
-      message = com.thoughtworks.go.i18n.LocalizedMessage.unauthorizedToEdit()
-      result.unauthorized(message, nil)
+      message = com.thoughtworks.go.i18n.LocalizedMessage.forbiddenToEdit()
+      result.forbidden(message, nil)
     end
   end
 end

--- a/server/webapp/WEB-INF/rails.new/spec/controllers/admin/jobs_controller_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/controllers/admin/jobs_controller_spec.rb
@@ -1,5 +1,5 @@
 ##########################GO-LICENSE-START################################
-# Copyright 2014 ThoughtWorks, Inc.
+# Copyright 2018 ThoughtWorks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -217,7 +217,7 @@ describe Admin::JobsController do
 
       it "should not redirect when update fails" do
         stub_save_for_validation_error do |result, *_|
-          result.unauthorized('some message', HealthStateType.unauthorisedForPipeline("pipeline-name"))
+          result.forbidden('some message', HealthStateType.forbiddenForPipeline("pipeline-name"))
         end
         expect(@pipeline_pause_service).to receive(:pipelinePauseInfo).with("pipeline-name").and_return(@pause_info)
 
@@ -227,12 +227,12 @@ describe Admin::JobsController do
         expect(response.location).to be_nil
         assert_template "settings"
         assert_template layout: false
-        expect(response.status).to eq(401)
+        expect(response.status).to eq(403)
       end
 
       it "should load resources for autocomplete even when update fails" do
         stub_save_for_validation_error do |result, *_|
-          result.unauthorized('some message', HealthStateType.unauthorisedForPipeline("pipeline-name"))
+          result.forbidden('some message', HealthStateType.forbiddenForPipeline("pipeline-name"))
         end
         expect(@pipeline_pause_service).to receive(:pipelinePauseInfo).with("pipeline-name").and_return(@pause_info)
         add_resource("job-2","anything")
@@ -246,7 +246,7 @@ describe Admin::JobsController do
 
       it "should not load new config on save failure (validation / merge conflict)" do
         stub_save_for_validation_error do |result, *_|
-          result.unauthorized('some message', HealthStateType.unauthorisedForPipeline("pipeline-name"))
+          result.forbidden('some message', HealthStateType.forbiddenForPipeline("pipeline-name"))
         end
         expect(@pipeline_pause_service).to receive(:pipelinePauseInfo).with("pipeline-name").and_return(@pause_info)
         add_resource("job-2","anything")
@@ -380,14 +380,14 @@ describe Admin::JobsController do
         expect(@task_view_service).to receive(:getTaskViewModelsWith).with(execTask).and_return(@tvms = [TaskViewModel.new(AntTask.new(), "new"), TaskViewModel.new(execTask, "new")].to_java(TaskViewModel))
         expect(@pipeline_pause_service).to receive(:pipelinePauseInfo).with("pipeline-name").and_return(@pause_info)
         stub_save_for_validation_error do |result, *_|
-          result.unauthorized('some message', HealthStateType.unauthorisedForPipeline("pipeline-name"))
+          result.forbidden('some message', HealthStateType.forbiddenForPipeline("pipeline-name"))
         end
 
         post :create, :pipeline_name => "pipeline-name", :stage_name => "stage-name", :job => {:name => "new_job", :tasks => {:taskOptions => "exec", "exec" => {:command => "ls", :workingDirectory => 'work'}}},  :config_md5 => "1234abcd", :stage_parent => "pipelines"
 
         assert_template "new"
         assert_template layout: false
-        expect(response.status).to eq(401)
+        expect(response.status).to eq(403)
       end
 
       it "should load jobs page with resource when creation fails" do

--- a/server/webapp/WEB-INF/rails.new/spec/controllers/admin/pipeline_configs_controller_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/controllers/admin/pipeline_configs_controller_spec.rb
@@ -1,5 +1,5 @@
 ##########################GO-LICENSE-START################################
-# Copyright 2016 ThoughtWorks, Inc.
+# Copyright 2018 ThoughtWorks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -95,7 +95,7 @@ describe Admin::PipelineConfigsController do
       allow(@user_service).to receive(:allUsernames)
       allow(@user_service).to receive(:allRoleNames)
       allow(controller).to receive(:populate_config_validity)
-      allow(controller).to receive(:check_pipeline_group_admin_user_and_401)
+      allow(controller).to receive(:check_pipeline_group_admin_user_and_403)
       allow(@go_config_service).to receive(:getAllResources).and_return([])
     end
 

--- a/server/webapp/WEB-INF/rails.new/spec/controllers/admin/pipelines_controller_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/controllers/admin/pipelines_controller_spec.rb
@@ -1,5 +1,5 @@
 ##########################GO-LICENSE-START################################
-# Copyright 2014 ThoughtWorks, Inc.
+# Copyright 2018 ThoughtWorks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -152,14 +152,14 @@ describe Admin::PipelinesController do
 
       it "should error out when user is unauthorized" do
         expect(@go_config_service).to receive(:loadForEdit).with('HelloWorld', anything(), anything()) do |_, _, result|
-          result.unauthorized('Unauthorized to edit HelloWorld pipeline.', HealthStateType.unauthorised_for_pipeline("HelloWorld"))
+          result.forbidden('Unauthorized to edit HelloWorld pipeline.', HealthStateType.unauthorised_for_pipeline("HelloWorld"))
           nil
         end
 
         get :edit, :pipeline_name => "HelloWorld", :current_tab => 'general', :stage_parent=>"pipelines"
 
         expect(assigns[:pipeline]).to be_nil
-        expect(response.status).to eq(401)
+        expect(response.status).to eq(403)
         expect(response.body).to have_selector("h3", :text => "Unauthorized to edit HelloWorld pipeline.")
       end
     end
@@ -487,7 +487,7 @@ describe Admin::PipelinesController do
       expect(@pipeline_selections_service).not_to receive(:updateUserPipelineSelections)
 
       stub_save_for_validation_error do |result, _, _|
-        result.unauthorized("unauthorized", nil)
+        result.forbidden("unauthorized", nil)
       end
       post :create, :config_md5 => "1234abcd", :pipeline_group => {:group => "new-group", :pipeline => {:name => pipeline_name}}
     end
@@ -600,7 +600,7 @@ describe Admin::PipelinesController do
       expect(@go_config_service).to receive(:getCurrentConfig).twice.and_return(Cloner.new().deepClone(@cruise_config))
 
       stub_save_for_validation_error do |result, cruise_config, node|
-        result.unauthorized("unauthorized", nil)
+        result.forbidden("unauthorized", nil)
       end
 
       job = {:name => "job", :tasks => {:taskOptions => "ant", "ant" => {}}}
@@ -655,7 +655,7 @@ describe Admin::PipelinesController do
       expect(@go_config_service).to receive(:getCurrentConfig).twice.and_return(Cloner.new().deepClone(@cruise_config))
 
       stub_save_for_validation_error do |result, cruise_config, node|
-        result.unauthorized("unauthorized", nil)
+        result.forbidden("unauthorized", nil)
       end
 
       allow(@pipeline_pause_service).to receive(:pipelinePauseInfo).with("pipeline2").and_return(@pause_info)

--- a/server/webapp/WEB-INF/rails.new/spec/controllers/admin/pipelines_snippet_controller_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/controllers/admin/pipelines_snippet_controller_spec.rb
@@ -1,5 +1,5 @@
 ##########################GO-LICENSE-START################################
-# Copyright 2014 ThoughtWorks, Inc.
+# Copyright 2018 ThoughtWorks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -94,7 +94,7 @@ describe Admin::PipelinesSnippetController do
 
       it "should return unauthorized error if the user does not have access to the group" do
         expect(@result).to receive(:isSuccessful).and_return(false)
-        expect(@result).to receive(:httpCode).and_return(401)
+        expect(@result).to receive(:httpCode).and_return(403)
         expect(@result).to receive(:message).and_return("Unauthorized")
         @config = BasicCruiseConfig.new
         group = "valid_group"
@@ -102,7 +102,7 @@ describe Admin::PipelinesSnippetController do
         get :show, {:group_name => group}
 
         expect(response).to render_template 'shared/config_error'
-        assert_response 401
+        assert_response 403
       end
     end
 
@@ -133,7 +133,7 @@ describe Admin::PipelinesSnippetController do
 
       it "should return unauthorized error if the user does not have access to the group" do
         expect(@result).to receive(:isSuccessful).and_return(false)
-        expect(@result).to receive(:httpCode).and_return(401)
+        expect(@result).to receive(:httpCode).and_return(403)
         expect(@result).to receive(:message).and_return("Unauthorized")
         @config = BasicCruiseConfig.new
         group = "valid_group"
@@ -142,7 +142,7 @@ describe Admin::PipelinesSnippetController do
         get :edit, {:group_name => group}
 
         expect(response).to render_template 'shared/config_error'
-        assert_response 401
+        assert_response 403
       end
 
     end

--- a/server/webapp/WEB-INF/rails.new/spec/controllers/admin/stages_controller_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/controllers/admin/stages_controller_spec.rb
@@ -1,5 +1,5 @@
 ##########################GO-LICENSE-START################################
-# Copyright 2014 ThoughtWorks, Inc.
+# Copyright 2018 ThoughtWorks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -295,7 +295,7 @@ describe Admin::StagesController do
         expect(@task_view_service).to receive(:taskInstanceFor).with("exec").and_return(ExecTask.new())
         expect(@task_view_service).to receive(:getTaskViewModelsWith).with(ExecTask.new('ls','','work')).and_return(tvms = [TaskViewModel.new(AntTask.new(), "new"), TaskViewModel.new(NantTask.new(), "new")].to_java(TaskViewModel))
         stub_save_for_validation_error do |result, config, node|
-          result.unauthorized('some message', HealthStateType.unauthorisedForPipeline("pipeline-name"))
+          result.forbidden('some message', HealthStateType.forbiddenForPipeline("pipeline-name"))
         end
 
         post :create, :stage_parent => "pipelines", :pipeline_name => "pipeline-name", :config_md5 => "1234abcd", :stage => {:name =>  "stage", :type => "cruise", :jobs => [{:name => "123", :tasks => {:taskOptions => "exec", "exec" => {:command => "ls", :workingDirectory => 'work'}}}]}
@@ -304,7 +304,7 @@ describe Admin::StagesController do
         expect(assigns[:task_view_models]).to eq(tvms)
         assert_template "new"
         assert_template layout: false
-        expect(response.status).to eq(401)
+        expect(response.status).to eq(403)
       end
 
       it "should assign config_errors for display when save fails due to validation errors" do

--- a/server/webapp/WEB-INF/rails.new/spec/controllers/admin/status_reports_controller_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/controllers/admin/status_reports_controller_spec.rb
@@ -47,6 +47,7 @@ describe Admin::StatusReportsController do
         login_as_group_admin
 
         expect(controller).to disallow_action(:get, :plugin_status, :plugin_id => elastic_plugin_id)
+                                .with(403, 'You are not authorized to perform this action.')
       end
 
       it 'should be accessible by all if security is disabled' do
@@ -126,6 +127,7 @@ describe Admin::StatusReportsController do
         login_as_group_admin
 
         expect(controller).to disallow_action(:get, :agent_status, :plugin_id => elastic_plugin_id, :elastic_agent_id => 'unassigned', :job_id => '100')
+                                .with(403, 'You are not authorized to perform this action.')
       end
 
       it 'should be accessible by all if security is disabled' do
@@ -253,6 +255,7 @@ describe Admin::StatusReportsController do
         login_as_group_admin
 
         expect(controller).to disallow_action(:get, :agent_status, :plugin_id => elastic_plugin_id, :elastic_agent_id => 'agent1')
+                                .with(403, 'You are not authorized to perform this action.')
       end
 
       it 'should be accessible by all if security is disabled' do

--- a/server/webapp/WEB-INF/rails.new/spec/controllers/admin/templates_controller_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/controllers/admin/templates_controller_spec.rb
@@ -1,5 +1,5 @@
 ##########################GO-LICENSE-START################################
-# Copyright 2014 ThoughtWorks, Inc.
+# Copyright 2018 ThoughtWorks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -273,7 +273,7 @@ describe Admin::TemplatesController do
 
     describe "create" do
       before :each do
-        allow(controller).to receive(:check_admin_user_or_group_admin_user_and_401).and_return(nil)
+        allow(controller).to receive(:check_admin_user_or_group_admin_user_and_403).and_return(nil)
         @security_service = stub_service(:security_service)
         expect(@security_service).to receive(:isUserGroupAdmin).and_return(false)
       end
@@ -347,7 +347,7 @@ describe Admin::TemplatesController do
           @cruise_config.errors().add("base", "someError")
           @cruise_config.getTemplates().get(0).addError("name", "foo")
           @cruise_config.getTemplates().get(1).addError("name", "foo")
-          result.badRequest(com.thoughtworks.go.i18n.LocalizedMessage::unauthorizedToEdit())
+          result.badRequest(com.thoughtworks.go.i18n.LocalizedMessage::forbiddenToEdit())
         end
         pipeline2 = PipelineConfigMother.pipeline_config("pipeline.2")
         @cruise_config.addPipeline('default', pipeline2)

--- a/server/webapp/WEB-INF/rails.new/spec/controllers/api/configuration_controller_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/controllers/api/configuration_controller_spec.rb
@@ -1,5 +1,5 @@
 ##########################GO-LICENSE-START################################
-# Copyright 2014 ThoughtWorks, Inc.
+# Copyright 2018 ThoughtWorks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -48,7 +48,7 @@ describe Api::ConfigurationController do
 
       get :config_revisions, :no_layout => true
 
-      expect(response.status).to eq(401)
+      expect(response.status).to eq(403)
       expect(response.body).to eq("Unauthorized to access this API.\n")
     end
   end
@@ -77,7 +77,7 @@ describe Api::ConfigurationController do
 
       get :config_diff, :from_revision => 'a', :to_revision => 'b', :no_layout => true
 
-      expect(response.status).to eq(401)
+      expect(response.status).to eq(403)
       expect(response.body).to eq("Unauthorized to access this API.\n")
     end
   end

--- a/server/webapp/WEB-INF/rails.new/spec/controllers/api/materials_controller_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/controllers/api/materials_controller_spec.rb
@@ -1,5 +1,5 @@
 ##########################GO-LICENSE-START################################
-# Copyright 2014 ThoughtWorks, Inc.
+# Copyright 2018 ThoughtWorks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -28,12 +28,12 @@ describe Api::MaterialsController do
       @params = {:post_commit_hook_material_type => 'svn', :no_layout => true, :payload => {}}
     end
 
-    it "should return 401 when user is not an admin" do
+    it "should return 403 when user is not an admin" do
       expect(@material_update_service).to receive(:notifyMaterialsForUpdate).with(@user, an_instance_of(ActionController::Parameters), an_instance_of(HttpLocalizedOperationResult)) do |user, params, result|
-        result.unauthorized("Unauthorized to access this API.", HealthStateType.unauthorised())
+        result.forbidden("Unauthorized to access this API.", HealthStateType.forbidden())
       end
       post :notify, @params
-      expect(response.status).to eq(401)
+      expect(response.status).to eq(403)
       expect(response.body).to eq("Unauthorized to access this API.\n")
     end
 

--- a/server/webapp/WEB-INF/rails.new/spec/controllers/api/pipelines_controller_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/controllers/api/pipelines_controller_spec.rb
@@ -1,5 +1,5 @@
 ##########################GO-LICENSE-START################################
-# Copyright 2016 ThoughtWorks, Inc.
+# Copyright 2018 ThoughtWorks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -401,13 +401,13 @@ describe Api::PipelinesController do
       expect(response.status).to eq(404)
     end
 
-    it "should respond with 401 when user does not have view permission" do
+    it "should respond with 403 when user does not have view permission" do
       expect(@status).to receive(:canContinue).and_return(false)
       expect(@status).to receive(:detailedMessage).and_return("Unauthorized")
-      allow(@status).to receive(:httpCode).and_return(401)
+      allow(@status).to receive(:httpCode).and_return(403)
       expect(@pipeline_history_service).to receive(:load).with(10, "user", anything).and_return(nil)
       get :pipeline_instance, :id => '10', :format => "xml", :name => "pipeline", :no_layout => true
-      expect(response.status).to eq(401)
+      expect(response.status).to eq(403)
     end
 
     it "should resolve url to action" do

--- a/server/webapp/WEB-INF/rails.new/spec/controllers/api_v1/admin/config_repos_controller_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/controllers/api_v1/admin/config_repos_controller_spec.rb
@@ -1,5 +1,5 @@
 ##########################################################################
-# Copyright 2017 ThoughtWorks, Inc.
+# Copyright 2018 ThoughtWorks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -70,12 +70,12 @@ describe ApiV1::Admin::ConfigReposController do
       it 'should disallow anonymous users, with security enabled' do
         enable_security
         login_as_anonymous
-        expect(controller).to disallow_action(:get, :show, id: @config_repo_id).with(401, 'You are not authorized to perform this action.')
+        expect(controller).to disallow_action(:get, :show, id: @config_repo_id).with(403, 'You are not authorized to perform this action.')
       end
 
       it 'should disallow normal users, with security enabled' do
         login_as_user
-        expect(controller).to disallow_action(:get, :show, id: @config_repo_id).with(401, 'You are not authorized to perform this action.')
+        expect(controller).to disallow_action(:get, :show, id: @config_repo_id).with(403, 'You are not authorized to perform this action.')
       end
 
       it 'should allow admin users, with security enabled' do
@@ -132,12 +132,12 @@ describe ApiV1::Admin::ConfigReposController do
       it 'should disallow anonymous users, with security enabled' do
         enable_security
         login_as_anonymous
-        expect(controller).to disallow_action(:get, :index).with(401, 'You are not authorized to perform this action.')
+        expect(controller).to disallow_action(:get, :index).with(403, 'You are not authorized to perform this action.')
       end
 
       it 'should disallow normal users, with security enabled' do
         login_as_user
-        expect(controller).to disallow_action(:get, :index).with(401, 'You are not authorized to perform this action.')
+        expect(controller).to disallow_action(:get, :index).with(403, 'You are not authorized to perform this action.')
       end
 
       it 'should allow admin users, with security enabled' do
@@ -203,12 +203,12 @@ describe ApiV1::Admin::ConfigReposController do
       it 'should disallow anonymous users, with security enabled' do
         enable_security
         login_as_anonymous
-        expect(controller).to disallow_action(:delete, :destroy, id: @config_repo_id).with(401, 'You are not authorized to perform this action.')
+        expect(controller).to disallow_action(:delete, :destroy, id: @config_repo_id).with(403, 'You are not authorized to perform this action.')
       end
 
       it 'should disallow normal users, with security enabled' do
         login_as_user
-        expect(controller).to disallow_action(:delete, :destroy, id: @config_repo_id).with(401, 'You are not authorized to perform this action.')
+        expect(controller).to disallow_action(:delete, :destroy, id: @config_repo_id).with(403, 'You are not authorized to perform this action.')
       end
 
       it 'should allow admin users, with security enabled' do
@@ -275,12 +275,12 @@ describe ApiV1::Admin::ConfigReposController do
       it 'should disallow anonymous users, with security enabled' do
         enable_security
         login_as_anonymous
-        expect(controller).to disallow_action(:post, :create).with(401, 'You are not authorized to perform this action.')
+        expect(controller).to disallow_action(:post, :create).with(403, 'You are not authorized to perform this action.')
       end
 
       it 'should disallow normal users, with security enabled' do
         login_as_user
-        expect(controller).to disallow_action(:post, :create).with(401, 'You are not authorized to perform this action.')
+        expect(controller).to disallow_action(:post, :create).with(403, 'You are not authorized to perform this action.')
       end
 
       it 'should allow admin users, with security enabled' do
@@ -370,12 +370,12 @@ describe ApiV1::Admin::ConfigReposController do
       it 'should disallow anonymous users, with security enabled' do
         enable_security
         login_as_anonymous
-        expect(controller).to disallow_action(:put, :update, id: @config_repo_id).with(401, 'You are not authorized to perform this action.')
+        expect(controller).to disallow_action(:put, :update, id: @config_repo_id).with(403, 'You are not authorized to perform this action.')
       end
 
       it 'should disallow normal users, with security enabled' do
         login_as_user
-        expect(controller).to disallow_action(:put, :update, id: @config_repo_id).with(401, 'You are not authorized to perform this action.')
+        expect(controller).to disallow_action(:put, :update, id: @config_repo_id).with(403, 'You are not authorized to perform this action.')
       end
 
       it 'should allow admin users, with security enabled' do

--- a/server/webapp/WEB-INF/rails.new/spec/controllers/api_v1/admin/internal/command_snippets_controller_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/controllers/api_v1/admin/internal/command_snippets_controller_spec.rb
@@ -1,5 +1,5 @@
 ##########################################################################
-# Copyright 2016 ThoughtWorks, Inc.
+# Copyright 2018 ThoughtWorks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -36,14 +36,14 @@ describe ApiV1::Admin::Internal::CommandSnippetsController do
         enable_security
         login_as_anonymous
 
-        expect(controller).to disallow_action(:get, :index).with(401, 'You are not authorized to perform this action.')
+        expect(controller).to disallow_action(:get, :index).with(403, 'You are not authorized to perform this action.')
       end
 
       it 'should disallow normal users, with security enabled' do
         enable_security
         login_as_user
 
-        expect(controller).to disallow_action(:get, :index).with(401, 'You are not authorized to perform this action.')
+        expect(controller).to disallow_action(:get, :index).with(403, 'You are not authorized to perform this action.')
       end
 
       it 'should allow admin, with security enabled' do

--- a/server/webapp/WEB-INF/rails.new/spec/controllers/api_v1/admin/internal/environments_controller_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/controllers/api_v1/admin/internal/environments_controller_spec.rb
@@ -1,5 +1,5 @@
 ##########################################################################
-# Copyright 2016 ThoughtWorks, Inc.
+# Copyright 2018 ThoughtWorks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -38,7 +38,7 @@ describe ApiV1::Admin::Internal::EnvironmentsController do
         enable_security
         login_as_user
 
-        expect(controller).to disallow_action(:get, :index).with(401, 'You are not authorized to perform this action.')
+        expect(controller).to disallow_action(:get, :index).with(403, 'You are not authorized to perform this action.')
       end
 
       it 'should allow admin users, with security enabled' do

--- a/server/webapp/WEB-INF/rails.new/spec/controllers/api_v1/admin/internal/material_test_controller_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/controllers/api_v1/admin/internal/material_test_controller_spec.rb
@@ -1,5 +1,5 @@
 ##########################################################################
-# Copyright 2016 ThoughtWorks, Inc.
+# Copyright 2018 ThoughtWorks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -30,7 +30,7 @@ describe ApiV1::Admin::Internal::MaterialTestController do
       it 'should disallow anonymous users, with security enabled' do
         enable_security
         login_as_anonymous
-        expect(controller).to disallow_action(:post, :test).with(401, 'You are not authorized to perform this action.')
+        expect(controller).to disallow_action(:post, :test).with(403, 'You are not authorized to perform this action.')
       end
 
       it 'should disallow normal users, with security enabled' do

--- a/server/webapp/WEB-INF/rails.new/spec/controllers/api_v1/admin/internal/package_repository_check_connection_controller_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/controllers/api_v1/admin/internal/package_repository_check_connection_controller_spec.rb
@@ -1,5 +1,5 @@
 ##########################################################################
-# Copyright 2016 ThoughtWorks, Inc.
+# Copyright 2018 ThoughtWorks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -38,12 +38,12 @@ describe ApiV1::Admin::Internal::PackageRepositoryCheckConnectionController do
       it 'should disallow anonymous users, with security enabled' do
         enable_security
         login_as_anonymous
-        expect(controller).to disallow_action(:post, :repository_check_connection).with(401, 'You are not authorized to perform this action.')
+        expect(controller).to disallow_action(:post, :repository_check_connection).with(403, 'You are not authorized to perform this action.')
       end
 
       it 'should disallow normal users, with security enabled' do
         login_as_user
-        expect(controller).to disallow_action(:post, :repository_check_connection).with(401, 'You are not authorized to perform this action.')
+        expect(controller).to disallow_action(:post, :repository_check_connection).with(403, 'You are not authorized to perform this action.')
       end
 
       it 'should allow admin users, with security enabled' do
@@ -112,7 +112,7 @@ describe ApiV1::Admin::Internal::PackageRepositoryCheckConnectionController do
       it 'should disallow anonymous users, with security enabled' do
         enable_security
         login_as_anonymous
-        expect(controller).to disallow_action(:post, :package_check_connection).with(401, 'You are not authorized to perform this action.')
+        expect(controller).to disallow_action(:post, :package_check_connection).with(403, 'You are not authorized to perform this action.')
       end
 
       it 'should disallow normal users, with security enabled' do

--- a/server/webapp/WEB-INF/rails.new/spec/controllers/api_v1/admin/internal/pipelines_controller_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/controllers/api_v1/admin/internal/pipelines_controller_spec.rb
@@ -1,5 +1,5 @@
 ##########################################################################
-# Copyright 2016 ThoughtWorks, Inc.
+# Copyright 2018 ThoughtWorks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -37,7 +37,7 @@ describe ApiV1::Admin::Internal::PipelinesController do
         enable_security
         login_as_user
 
-        expect(controller).to disallow_action(:get, :index).with(401, 'You are not authorized to perform this action.')
+        expect(controller).to disallow_action(:get, :index).with(403, 'You are not authorized to perform this action.')
       end
 
       it 'should allow admin users, with security enabled' do

--- a/server/webapp/WEB-INF/rails.new/spec/controllers/api_v1/admin/internal/resources_controller_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/controllers/api_v1/admin/internal/resources_controller_spec.rb
@@ -1,5 +1,5 @@
 ##########################################################################
-# Copyright 2016 ThoughtWorks, Inc.
+# Copyright 2018 ThoughtWorks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -39,7 +39,7 @@ describe ApiV1::Admin::Internal::ResourcesController do
         enable_security
         login_as_user
 
-        expect(controller).to disallow_action(:get, :index).with(401, 'You are not authorized to perform this action.')
+        expect(controller).to disallow_action(:get, :index).with(403, 'You are not authorized to perform this action.')
       end
 
       it 'should allow admin users, with security enabled' do

--- a/server/webapp/WEB-INF/rails.new/spec/controllers/api_v1/admin/merged_environments_controller_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/controllers/api_v1/admin/merged_environments_controller_spec.rb
@@ -1,5 +1,5 @@
 ##########################################################################
-# Copyright 2017 ThoughtWorks, Inc.
+# Copyright 2018 ThoughtWorks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -48,12 +48,12 @@ describe ApiV1::Admin::MergedEnvironmentsController do
       it 'should disallow anonymous users, with security enabled' do
         enable_security
         login_as_anonymous
-        expect(controller).to disallow_action(:get, :index).with(401, 'You are not authorized to perform this action.')
+        expect(controller).to disallow_action(:get, :index).with(403, 'You are not authorized to perform this action.')
       end
 
       it 'should disallow normal users, with security enabled' do
         login_as_user
-        expect(controller).to disallow_action(:get, :index).with(401, 'You are not authorized to perform this action.')
+        expect(controller).to disallow_action(:get, :index).with(403, 'You are not authorized to perform this action.')
       end
 
       it 'should allow admin users, with security enabled' do
@@ -63,7 +63,7 @@ describe ApiV1::Admin::MergedEnvironmentsController do
 
       it 'should disallow pipeline group admin users, with security enabled' do
         login_as_group_admin
-        expect(controller).to disallow_action(:get, :index).with(401, 'You are not authorized to perform this action.')
+        expect(controller).to disallow_action(:get, :index).with(403, 'You are not authorized to perform this action.')
       end
     end
 
@@ -124,12 +124,12 @@ describe ApiV1::Admin::MergedEnvironmentsController do
       it 'should disallow anonymous users, with security enabled' do
         enable_security
         login_as_anonymous
-        expect(controller).to disallow_action(:get, :show, environment_name: @environment_name).with(401, 'You are not authorized to perform this action.')
+        expect(controller).to disallow_action(:get, :show, environment_name: @environment_name).with(403, 'You are not authorized to perform this action.')
       end
 
       it 'should disallow normal users, with security enabled' do
         login_as_user
-        expect(controller).to disallow_action(:get, :show, environment_name: @environment_name).with(401, 'You are not authorized to perform this action.')
+        expect(controller).to disallow_action(:get, :show, environment_name: @environment_name).with(403, 'You are not authorized to perform this action.')
       end
 
       it 'should allow admin users, with security enabled' do
@@ -139,7 +139,7 @@ describe ApiV1::Admin::MergedEnvironmentsController do
 
       it 'should disallow pipeline group admin users, with security enabled' do
         login_as_group_admin
-        expect(controller).to disallow_action(:get, :show, environment_name: @environment_name).with(401, 'You are not authorized to perform this action.')
+        expect(controller).to disallow_action(:get, :show, environment_name: @environment_name).with(403, 'You are not authorized to perform this action.')
       end
     end
 

--- a/server/webapp/WEB-INF/rails.new/spec/controllers/api_v1/admin/packages_controller_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/controllers/api_v1/admin/packages_controller_spec.rb
@@ -1,5 +1,5 @@
 ##########################################################################
-# Copyright 2016 ThoughtWorks, Inc.
+# Copyright 2018 ThoughtWorks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -63,12 +63,12 @@ describe ApiV1::Admin::PackagesController do
       it 'should disallow anonymous users, with security enabled' do
         enable_security
         login_as_anonymous
-        expect(controller).to disallow_action(:get, :index).with(401, 'You are not authorized to perform this action.')
+        expect(controller).to disallow_action(:get, :index).with(403, 'You are not authorized to perform this action.')
       end
 
       it 'should disallow normal users, with security enabled' do
         login_as_user
-        expect(controller).to disallow_action(:get, :index).with(401, 'You are not authorized to perform this action.')
+        expect(controller).to disallow_action(:get, :index).with(403, 'You are not authorized to perform this action.')
       end
 
       it 'should allow admin users, with security enabled' do
@@ -134,12 +134,12 @@ describe ApiV1::Admin::PackagesController do
       it 'should disallow anonymous users, with security enabled' do
         enable_security
         login_as_anonymous
-        expect(controller).to disallow_action(:get, :show, package_id: @package_id).with(401, 'You are not authorized to perform this action.')
+        expect(controller).to disallow_action(:get, :show, package_id: @package_id).with(403, 'You are not authorized to perform this action.')
       end
 
       it 'should disallow normal users, with security enabled' do
         login_as_user
-        expect(controller).to disallow_action(:get, :show, package_id: @package_id).with(401, 'You are not authorized to perform this action.')
+        expect(controller).to disallow_action(:get, :show, package_id: @package_id).with(403, 'You are not authorized to perform this action.')
       end
 
       it 'should allow admin users, with security enabled' do
@@ -211,12 +211,12 @@ describe ApiV1::Admin::PackagesController do
       it 'should disallow anonymous users, with security enabled' do
         enable_security
         login_as_anonymous
-        expect(controller).to disallow_action(:delete, :destroy, package_id: @package_id).with(401, 'You are not authorized to perform this action.')
+        expect(controller).to disallow_action(:delete, :destroy, package_id: @package_id).with(403, 'You are not authorized to perform this action.')
       end
 
       it 'should disallow normal users, with security enabled' do
         login_as_user
-        expect(controller).to disallow_action(:delete, :destroy, package_id: @package_id).with(401, 'You are not authorized to perform this action.')
+        expect(controller).to disallow_action(:delete, :destroy, package_id: @package_id).with(403, 'You are not authorized to perform this action.')
       end
 
       it 'should allow admin users, with security enabled' do
@@ -310,12 +310,12 @@ describe ApiV1::Admin::PackagesController do
       it 'should disallow anonymous users, with security enabled' do
         enable_security
         login_as_anonymous
-        expect(controller).to disallow_action(:post, :create).with(401, 'You are not authorized to perform this action.')
+        expect(controller).to disallow_action(:post, :create).with(403, 'You are not authorized to perform this action.')
       end
 
       it 'should disallow normal users, with security enabled' do
         login_as_user
-        expect(controller).to disallow_action(:post, :create).with(401, 'You are not authorized to perform this action.')
+        expect(controller).to disallow_action(:post, :create).with(403, 'You are not authorized to perform this action.')
       end
 
       it 'should allow admin users, with security enabled' do
@@ -429,12 +429,12 @@ describe ApiV1::Admin::PackagesController do
       it 'should disallow anonymous users, with security enabled' do
         enable_security
         login_as_anonymous
-        expect(controller).to disallow_action(:put, :update, package_id: @package_id).with(401, 'You are not authorized to perform this action.')
+        expect(controller).to disallow_action(:put, :update, package_id: @package_id).with(403, 'You are not authorized to perform this action.')
       end
 
       it 'should disallow normal users, with security enabled' do
         login_as_user
-        expect(controller).to disallow_action(:put, :update, package_id: @package_id).with(401, 'You are not authorized to perform this action.')
+        expect(controller).to disallow_action(:put, :update, package_id: @package_id).with(403, 'You are not authorized to perform this action.')
       end
 
       it 'should allow admin users, with security enabled' do

--- a/server/webapp/WEB-INF/rails.new/spec/controllers/api_v1/admin/pluggable_scms_controller_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/controllers/api_v1/admin/pluggable_scms_controller_spec.rb
@@ -1,5 +1,5 @@
 ##########################################################################
-# Copyright 2016 ThoughtWorks, Inc.
+# Copyright 2018 ThoughtWorks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -42,14 +42,14 @@ describe ApiV1::Admin::PluggableScmsController do
         enable_security
         login_as_anonymous
 
-        expect(controller).to disallow_action(:get, :index).with(401, 'You are not authorized to perform this action.')
+        expect(controller).to disallow_action(:get, :index).with(403, 'You are not authorized to perform this action.')
       end
 
       it 'should disallow normal users, with security enabled' do
         enable_security
         login_as_user
 
-        expect(controller).to disallow_action(:get, :index).with(401, 'You are not authorized to perform this action.')
+        expect(controller).to disallow_action(:get, :index).with(403, 'You are not authorized to perform this action.')
       end
 
       it 'should allow admin, with security enabled' do
@@ -107,14 +107,14 @@ describe ApiV1::Admin::PluggableScmsController do
         enable_security
         login_as_anonymous
 
-        expect(controller).to disallow_action(:get, :show, material_name: 'foo').with(401, 'You are not authorized to perform this action.')
+        expect(controller).to disallow_action(:get, :show, material_name: 'foo').with(403, 'You are not authorized to perform this action.')
       end
 
       it 'should disallow normal users, with security enabled' do
         enable_security
         login_as_user
 
-        expect(controller).to disallow_action(:get, :show, material_name: 'foo').with(401, 'You are not authorized to perform this action.')
+        expect(controller).to disallow_action(:get, :show, material_name: 'foo').with(403, 'You are not authorized to perform this action.')
       end
 
       it 'should allow admin, with security enabled' do
@@ -186,14 +186,14 @@ describe ApiV1::Admin::PluggableScmsController do
         enable_security
         login_as_anonymous
 
-        expect(controller).to disallow_action(:post, :create).with(401, 'You are not authorized to perform this action.')
+        expect(controller).to disallow_action(:post, :create).with(403, 'You are not authorized to perform this action.')
       end
 
       it 'should disallow normal users, with security enabled' do
         enable_security
         login_as_user
 
-        expect(controller).to disallow_action(:post, :create).with(401, 'You are not authorized to perform this action.')
+        expect(controller).to disallow_action(:post, :create).with(403, 'You are not authorized to perform this action.')
       end
 
       it 'should allow admin, with security enabled' do
@@ -284,14 +284,14 @@ describe ApiV1::Admin::PluggableScmsController do
         enable_security
         login_as_anonymous
 
-        expect(controller).to disallow_action(:put, :update, material_name: 'foo').with(401, 'You are not authorized to perform this action.')
+        expect(controller).to disallow_action(:put, :update, material_name: 'foo').with(403, 'You are not authorized to perform this action.')
       end
 
       it 'should disallow normal users, with security enabled' do
         enable_security
         login_as_user
 
-        expect(controller).to disallow_action(:put, :update, material_name: 'foo').with(401, 'You are not authorized to perform this action.')
+        expect(controller).to disallow_action(:put, :update, material_name: 'foo').with(403, 'You are not authorized to perform this action.')
       end
 
       it 'should allow admin, with security enabled' do

--- a/server/webapp/WEB-INF/rails.new/spec/controllers/api_v1/admin/plugin_settings_controller_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/controllers/api_v1/admin/plugin_settings_controller_spec.rb
@@ -1,5 +1,5 @@
 ##########################################################################
-# Copyright 2017 ThoughtWorks, Inc.
+# Copyright 2018 ThoughtWorks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -46,28 +46,28 @@ describe ApiV1::Admin::PluginSettingsController do
         enable_security
         login_as_anonymous
 
-        expect(controller).to disallow_action(:get, :show, plugin_id: 'foo').with(401, 'You are not authorized to perform this action.')
+        expect(controller).to disallow_action(:get, :show, plugin_id: 'foo').with(403, 'You are not authorized to perform this action.')
       end
 
       it 'should disallow normal users, with security enabled' do
         enable_security
         login_as_user
 
-        expect(controller).to disallow_action(:get, :show, plugin_id: 'foo').with(401, 'You are not authorized to perform this action.')
+        expect(controller).to disallow_action(:get, :show, plugin_id: 'foo').with(403, 'You are not authorized to perform this action.')
       end
 
       it 'should disallow group admin users, with security enabled' do
         enable_security
         login_as_group_admin
 
-        expect(controller).to disallow_action(:get, :show, plugin_id: 'foo').with(401, 'You are not authorized to perform this action.')
+        expect(controller).to disallow_action(:get, :show, plugin_id: 'foo').with(403, 'You are not authorized to perform this action.')
       end
 
       it 'should disallow template users, with security enabled' do
         enable_security
         login_as_template_admin
 
-        expect(controller).to disallow_action(:get, :show, plugin_id: 'foo').with(401, 'You are not authorized to perform this action.')
+        expect(controller).to disallow_action(:get, :show, plugin_id: 'foo').with(403, 'You are not authorized to perform this action.')
       end
 
       it 'should allow admin, with security enabled' do
@@ -145,28 +145,28 @@ describe ApiV1::Admin::PluginSettingsController do
         enable_security
         login_as_anonymous
 
-        expect(controller).to disallow_action(:post, :create).with(401, 'You are not authorized to perform this action.')
+        expect(controller).to disallow_action(:post, :create).with(403, 'You are not authorized to perform this action.')
       end
 
       it 'should disallow normal users, with security enabled' do
         enable_security
         login_as_user
 
-        expect(controller).to disallow_action(:post, :create).with(401, 'You are not authorized to perform this action.')
+        expect(controller).to disallow_action(:post, :create).with(403, 'You are not authorized to perform this action.')
       end
 
       it 'should disallow group admin users, with security enabled' do
         enable_security
         login_as_group_admin
 
-        expect(controller).to disallow_action(:post, :create).with(401, 'You are not authorized to perform this action.')
+        expect(controller).to disallow_action(:post, :create).with(403, 'You are not authorized to perform this action.')
       end
 
       it 'should disallow template users, with security enabled' do
         enable_security
         login_as_template_admin
 
-        expect(controller).to disallow_action(:post, :create).with(401, 'You are not authorized to perform this action.')
+        expect(controller).to disallow_action(:post, :create).with(403, 'You are not authorized to perform this action.')
       end
 
       it 'should allow admin, with security enabled' do
@@ -266,28 +266,28 @@ describe ApiV1::Admin::PluginSettingsController do
         enable_security
         login_as_anonymous
 
-        expect(controller).to disallow_action(:put, :update, plugin_id: 'foo').with(401, 'You are not authorized to perform this action.')
+        expect(controller).to disallow_action(:put, :update, plugin_id: 'foo').with(403, 'You are not authorized to perform this action.')
       end
 
       it 'should disallow normal users, with security enabled' do
         enable_security
         login_as_user
 
-        expect(controller).to disallow_action(:put, :update, plugin_id: 'foo').with(401, 'You are not authorized to perform this action.')
+        expect(controller).to disallow_action(:put, :update, plugin_id: 'foo').with(403, 'You are not authorized to perform this action.')
       end
 
       it 'should disallow group admin users, with security enabled' do
         enable_security
         login_as_group_admin
 
-        expect(controller).to disallow_action(:put, :update, plugin_id: 'foo').with(401, 'You are not authorized to perform this action.')
+        expect(controller).to disallow_action(:put, :update, plugin_id: 'foo').with(403, 'You are not authorized to perform this action.')
       end
 
       it 'should disallow template users, with security enabled' do
         enable_security
         login_as_template_admin
 
-        expect(controller).to disallow_action(:put, :update, plugin_id: 'foo').with(401, 'You are not authorized to perform this action.')
+        expect(controller).to disallow_action(:put, :update, plugin_id: 'foo').with(403, 'You are not authorized to perform this action.')
       end
 
       it 'should allow admin, with security enabled' do

--- a/server/webapp/WEB-INF/rails.new/spec/controllers/api_v1/admin/repositories_controller_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/controllers/api_v1/admin/repositories_controller_spec.rb
@@ -1,5 +1,5 @@
 ##########################################################################
-# Copyright 2016 ThoughtWorks, Inc.
+# Copyright 2018 ThoughtWorks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -51,12 +51,12 @@ describe ApiV1::Admin::RepositoriesController do
       it 'should disallow anonymous users, with security enabled' do
         enable_security
         login_as_anonymous
-        expect(controller).to disallow_action(:get, :index).with(401, 'You are not authorized to perform this action.')
+        expect(controller).to disallow_action(:get, :index).with(403, 'You are not authorized to perform this action.')
       end
 
       it 'should disallow normal users, with security enabled' do
         login_as_user
-        expect(controller).to disallow_action(:get, :index).with(401, 'You are not authorized to perform this action.')
+        expect(controller).to disallow_action(:get, :index).with(403, 'You are not authorized to perform this action.')
       end
 
       it 'should allow admin users, with security enabled' do
@@ -123,12 +123,12 @@ describe ApiV1::Admin::RepositoriesController do
       it 'should disallow anonymous users, with security enabled' do
         enable_security
         login_as_anonymous
-        expect(controller).to disallow_action(:get, :show, repo_id: @repo_id).with(401, 'You are not authorized to perform this action.')
+        expect(controller).to disallow_action(:get, :show, repo_id: @repo_id).with(403, 'You are not authorized to perform this action.')
       end
 
       it 'should disallow normal users, with security enabled' do
         login_as_user
-        expect(controller).to disallow_action(:get, :show, repo_id: @repo_id).with(401, 'You are not authorized to perform this action.')
+        expect(controller).to disallow_action(:get, :show, repo_id: @repo_id).with(403, 'You are not authorized to perform this action.')
       end
 
       it 'should allow admin users, with security enabled' do
@@ -204,12 +204,12 @@ describe ApiV1::Admin::RepositoriesController do
       it 'should disallow anonymous users, with security enabled' do
         enable_security
         login_as_anonymous
-        expect(controller).to disallow_action(:delete, :destroy, repo_id: @repo_id).with(401, 'You are not authorized to perform this action.')
+        expect(controller).to disallow_action(:delete, :destroy, repo_id: @repo_id).with(403, 'You are not authorized to perform this action.')
       end
 
       it 'should disallow normal users, with security enabled' do
         login_as_user
-        expect(controller).to disallow_action(:delete, :destroy, repo_id: @repo_id).with(401, 'You are not authorized to perform this action.')
+        expect(controller).to disallow_action(:delete, :destroy, repo_id: @repo_id).with(403, 'You are not authorized to perform this action.')
       end
 
       it 'should allow admin users, with security enabled' do
@@ -288,12 +288,12 @@ describe ApiV1::Admin::RepositoriesController do
       it 'should disallow anonymous users, with security enabled' do
         enable_security
         login_as_anonymous
-        expect(controller).to disallow_action(:post, :create).with(401, 'You are not authorized to perform this action.')
+        expect(controller).to disallow_action(:post, :create).with(403, 'You are not authorized to perform this action.')
       end
 
       it 'should disallow normal users, with security enabled' do
         login_as_user
-        expect(controller).to disallow_action(:post, :create).with(401, 'You are not authorized to perform this action.')
+        expect(controller).to disallow_action(:post, :create).with(403, 'You are not authorized to perform this action.')
       end
 
       it 'should allow admin users, with security enabled' do
@@ -396,12 +396,12 @@ describe ApiV1::Admin::RepositoriesController do
       it 'should disallow anonymous users, with security enabled' do
         enable_security
         login_as_anonymous
-        expect(controller).to disallow_action(:put, :update, repo_id: @repo_id).with(401, 'You are not authorized to perform this action.')
+        expect(controller).to disallow_action(:put, :update, repo_id: @repo_id).with(403, 'You are not authorized to perform this action.')
       end
 
       it 'should disallow normal users, with security enabled' do
         login_as_user
-        expect(controller).to disallow_action(:put, :update, repo_id: @repo_id).with(401, 'You are not authorized to perform this action.')
+        expect(controller).to disallow_action(:put, :update, repo_id: @repo_id).with(403, 'You are not authorized to perform this action.')
       end
 
       it 'should allow admin users, with security enabled' do

--- a/server/webapp/WEB-INF/rails.new/spec/controllers/api_v1/admin/templates/authorization_controller_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/controllers/api_v1/admin/templates/authorization_controller_spec.rb
@@ -1,5 +1,5 @@
 ##########################################################################
-# Copyright 2017 ThoughtWorks, Inc.
+# Copyright 2018 ThoughtWorks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -46,14 +46,14 @@ describe ApiV1::Admin::Templates::AuthorizationController do
         enable_security
         login_as_anonymous
 
-        expect(controller).to disallow_action(:get, :show, template_name: 'foo').with(401, 'You are not authorized to perform this action.')
+        expect(controller).to disallow_action(:get, :show, template_name: 'foo').with(403, 'You are not authorized to perform this action.')
       end
 
       it 'should disallow normal users, with security enabled' do
         enable_security
         login_as_user
 
-        expect(controller).to disallow_action(:get, :show, template_name: 'foo').with(401, 'You are not authorized to perform this action.')
+        expect(controller).to disallow_action(:get, :show, template_name: 'foo').with(403, 'You are not authorized to perform this action.')
       end
 
       it 'should allow admin, with security enabled' do
@@ -144,14 +144,14 @@ describe ApiV1::Admin::Templates::AuthorizationController do
         enable_security
         login_as_anonymous
 
-        expect(controller).to disallow_action(:put, :update, template_name: 'foo').with(401, 'You are not authorized to perform this action.')
+        expect(controller).to disallow_action(:put, :update, template_name: 'foo').with(403, 'You are not authorized to perform this action.')
       end
 
       it 'should disallow normal users, with security enabled' do
         enable_security
         login_as_user
 
-        expect(controller).to disallow_action(:put, :update, template_name: 'foo').with(401, 'You are not authorized to perform this action.')
+        expect(controller).to disallow_action(:put, :update, template_name: 'foo').with(403, 'You are not authorized to perform this action.')
       end
 
       it 'should allow admin, with security enabled' do

--- a/server/webapp/WEB-INF/rails.new/spec/controllers/api_v1/elastic/profiles_controller_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/controllers/api_v1/elastic/profiles_controller_spec.rb
@@ -1,5 +1,5 @@
 ##########################################################################
-# Copyright 2017 ThoughtWorks, Inc.
+# Copyright 2018 ThoughtWorks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -39,14 +39,14 @@ describe ApiV1::Elastic::ProfilesController do
         enable_security
         login_as_anonymous
 
-        expect(controller).to disallow_action(:get, :index).with(401, 'You are not authorized to perform this action.')
+        expect(controller).to disallow_action(:get, :index).with(403, 'You are not authorized to perform this action.')
       end
 
       it 'should disallow normal users, with security enabled' do
         enable_security
         login_as_user
 
-        expect(controller).to disallow_action(:get, :index).with(401, 'You are not authorized to perform this action.')
+        expect(controller).to disallow_action(:get, :index).with(403, 'You are not authorized to perform this action.')
       end
 
       it 'should allow admin, with security enabled' do
@@ -114,14 +114,14 @@ describe ApiV1::Elastic::ProfilesController do
         enable_security
         login_as_anonymous
 
-        expect(controller).to disallow_action(:get, :show, profile_id: 'foo').with(401, 'You are not authorized to perform this action.')
+        expect(controller).to disallow_action(:get, :show, profile_id: 'foo').with(403, 'You are not authorized to perform this action.')
       end
 
       it 'should disallow normal users, with security enabled' do
         enable_security
         login_as_user
 
-        expect(controller).to disallow_action(:get, :show, profile_id: 'foo').with(401, 'You are not authorized to perform this action.')
+        expect(controller).to disallow_action(:get, :show, profile_id: 'foo').with(403, 'You are not authorized to perform this action.')
       end
 
       it 'should allow admin, with security enabled' do
@@ -212,14 +212,14 @@ describe ApiV1::Elastic::ProfilesController do
         enable_security
         login_as_anonymous
 
-        expect(controller).to disallow_action(:post, :create).with(401, 'You are not authorized to perform this action.')
+        expect(controller).to disallow_action(:post, :create).with(403, 'You are not authorized to perform this action.')
       end
 
       it 'should disallow normal users, with security enabled' do
         enable_security
         login_as_user
 
-        expect(controller).to disallow_action(:post, :create).with(401, 'You are not authorized to perform this action.')
+        expect(controller).to disallow_action(:post, :create).with(403, 'You are not authorized to perform this action.')
       end
 
       it 'should allow admin, with security enabled' do
@@ -298,14 +298,14 @@ describe ApiV1::Elastic::ProfilesController do
         enable_security
         login_as_anonymous
 
-        expect(controller).to disallow_action(:put, :update, profile_id: 'foo').with(401, 'You are not authorized to perform this action.')
+        expect(controller).to disallow_action(:put, :update, profile_id: 'foo').with(403, 'You are not authorized to perform this action.')
       end
 
       it 'should disallow normal users, with security enabled' do
         enable_security
         login_as_user
 
-        expect(controller).to disallow_action(:put, :update, profile_id: 'foo').with(401, 'You are not authorized to perform this action.')
+        expect(controller).to disallow_action(:put, :update, profile_id: 'foo').with(403, 'You are not authorized to perform this action.')
       end
 
       it 'should allow admin, with security enabled' do
@@ -411,14 +411,14 @@ describe ApiV1::Elastic::ProfilesController do
         enable_security
         login_as_anonymous
 
-        expect(controller).to disallow_action(:delete, :destroy, profile_id: 'foo').with(401, 'You are not authorized to perform this action.')
+        expect(controller).to disallow_action(:delete, :destroy, profile_id: 'foo').with(403, 'You are not authorized to perform this action.')
       end
 
       it 'should disallow normal users, with security enabled' do
         enable_security
         login_as_user
 
-        expect(controller).to disallow_action(:delete, :destroy, profile_id: 'foo').with(401, 'You are not authorized to perform this action.')
+        expect(controller).to disallow_action(:delete, :destroy, profile_id: 'foo').with(403, 'You are not authorized to perform this action.')
       end
 
       it 'should allow admin, with security enabled' do

--- a/server/webapp/WEB-INF/rails.new/spec/controllers/api_v1/security/auth_configs_controller_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/controllers/api_v1/security/auth_configs_controller_spec.rb
@@ -1,5 +1,5 @@
 ##########################################################################
-# Copyright 2017 ThoughtWorks, Inc.
+# Copyright 2018 ThoughtWorks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -38,14 +38,14 @@ describe ApiV1::Admin::Security::AuthConfigsController do
         enable_security
         login_as_anonymous
 
-        expect(controller).to disallow_action(:get, :index).with(401, 'You are not authorized to perform this action.')
+        expect(controller).to disallow_action(:get, :index).with(403, 'You are not authorized to perform this action.')
       end
 
       it 'should disallow normal users, with security enabled' do
         enable_security
         login_as_user
 
-        expect(controller).to disallow_action(:get, :index).with(401, 'You are not authorized to perform this action.')
+        expect(controller).to disallow_action(:get, :index).with(403, 'You are not authorized to perform this action.')
       end
 
       it 'should allow admin, with security enabled' do
@@ -114,14 +114,14 @@ describe ApiV1::Admin::Security::AuthConfigsController do
         enable_security
         login_as_anonymous
 
-        expect(controller).to disallow_action(:get, :show, auth_config_id: 'foo').with(401, 'You are not authorized to perform this action.')
+        expect(controller).to disallow_action(:get, :show, auth_config_id: 'foo').with(403, 'You are not authorized to perform this action.')
       end
 
       it 'should disallow normal users, with security enabled' do
         enable_security
         login_as_user
 
-        expect(controller).to disallow_action(:get, :show, auth_config_id: 'foo').with(401, 'You are not authorized to perform this action.')
+        expect(controller).to disallow_action(:get, :show, auth_config_id: 'foo').with(403, 'You are not authorized to perform this action.')
       end
 
       it 'should allow admin, with security enabled' do
@@ -212,14 +212,14 @@ describe ApiV1::Admin::Security::AuthConfigsController do
         enable_security
         login_as_anonymous
 
-        expect(controller).to disallow_action(:post, :create).with(401, 'You are not authorized to perform this action.')
+        expect(controller).to disallow_action(:post, :create).with(403, 'You are not authorized to perform this action.')
       end
 
       it 'should disallow normal users, with security enabled' do
         enable_security
         login_as_user
 
-        expect(controller).to disallow_action(:post, :create).with(401, 'You are not authorized to perform this action.')
+        expect(controller).to disallow_action(:post, :create).with(403, 'You are not authorized to perform this action.')
       end
 
       it 'should allow admin, with security enabled' do
@@ -298,14 +298,14 @@ describe ApiV1::Admin::Security::AuthConfigsController do
         enable_security
         login_as_anonymous
 
-        expect(controller).to disallow_action(:put, :update, auth_config_id: 'foo').with(401, 'You are not authorized to perform this action.')
+        expect(controller).to disallow_action(:put, :update, auth_config_id: 'foo').with(403, 'You are not authorized to perform this action.')
       end
 
       it 'should disallow normal users, with security enabled' do
         enable_security
         login_as_user
 
-        expect(controller).to disallow_action(:put, :update, auth_config_id: 'foo').with(401, 'You are not authorized to perform this action.')
+        expect(controller).to disallow_action(:put, :update, auth_config_id: 'foo').with(403, 'You are not authorized to perform this action.')
       end
 
       it 'should allow admin, with security enabled' do
@@ -408,12 +408,12 @@ describe ApiV1::Admin::Security::AuthConfigsController do
         enable_security
         login_as_anonymous
 
-        expect(controller).to disallow_action(:delete, :destroy, auth_config_id: 'foo').with(401, 'You are not authorized to perform this action.')
+        expect(controller).to disallow_action(:delete, :destroy, auth_config_id: 'foo').with(403, 'You are not authorized to perform this action.')
       end
 
       it 'should disallow normal users, with security enabled' do
         login_as_user
-        expect(controller).to disallow_action(:delete, :destroy, auth_config_id: 'foo').with(401, 'You are not authorized to perform this action.')
+        expect(controller).to disallow_action(:delete, :destroy, auth_config_id: 'foo').with(403, 'You are not authorized to perform this action.')
       end
 
       it 'should allow admin, with security enabled' do
@@ -424,7 +424,7 @@ describe ApiV1::Admin::Security::AuthConfigsController do
 
       it 'should disallow pipeline group admin users, with security enabled' do
         login_as_group_admin
-        expect(controller).to disallow_action(:delete, :destroy, auth_config_id: 'foo').with(401, 'You are not authorized to perform this action.')
+        expect(controller).to disallow_action(:delete, :destroy, auth_config_id: 'foo').with(403, 'You are not authorized to perform this action.')
       end
     end
     describe 'admin' do
@@ -514,14 +514,14 @@ describe ApiV1::Admin::Security::AuthConfigsController do
         enable_security
         login_as_anonymous
 
-        expect(controller).to disallow_action(:post, :verify_connection).with(401, 'You are not authorized to perform this action.')
+        expect(controller).to disallow_action(:post, :verify_connection).with(403, 'You are not authorized to perform this action.')
       end
 
       it 'should disallow normal users, with security enabled' do
         enable_security
         login_as_user
 
-        expect(controller).to disallow_action(:post, :verify_connection).with(401, 'You are not authorized to perform this action.')
+        expect(controller).to disallow_action(:post, :verify_connection).with(403, 'You are not authorized to perform this action.')
       end
 
       it 'should allow admin, with security enabled' do

--- a/server/webapp/WEB-INF/rails.new/spec/controllers/api_v2/admin/environments_controller_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/controllers/api_v2/admin/environments_controller_spec.rb
@@ -1,5 +1,5 @@
 ##########################################################################
-# Copyright 2016 ThoughtWorks, Inc.
+# Copyright 2018 ThoughtWorks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -48,12 +48,12 @@ describe ApiV2::Admin::EnvironmentsController do
       it 'should disallow anonymous users, with security enabled' do
         enable_security
         login_as_anonymous
-        expect(controller).to disallow_action(:get, :index).with(401, 'You are not authorized to perform this action.')
+        expect(controller).to disallow_action(:get, :index).with(403, 'You are not authorized to perform this action.')
       end
 
       it 'should disallow normal users, with security enabled' do
         login_as_user
-        expect(controller).to disallow_action(:get, :index).with(401, 'You are not authorized to perform this action.')
+        expect(controller).to disallow_action(:get, :index).with(403, 'You are not authorized to perform this action.')
       end
 
       it 'should allow admin users, with security enabled' do
@@ -63,7 +63,7 @@ describe ApiV2::Admin::EnvironmentsController do
 
       it 'should disallow pipeline group admin users, with security enabled' do
         login_as_group_admin
-        expect(controller).to disallow_action(:get, :index).with(401, 'You are not authorized to perform this action.')
+        expect(controller).to disallow_action(:get, :index).with(403, 'You are not authorized to perform this action.')
       end
     end
 
@@ -122,12 +122,12 @@ describe ApiV2::Admin::EnvironmentsController do
       it 'should disallow anonymous users, with security enabled' do
         enable_security
         login_as_anonymous
-        expect(controller).to disallow_action(:get, :show, name: @environment_name).with(401, 'You are not authorized to perform this action.')
+        expect(controller).to disallow_action(:get, :show, name: @environment_name).with(403, 'You are not authorized to perform this action.')
       end
 
       it 'should disallow normal users, with security enabled' do
         login_as_user
-        expect(controller).to disallow_action(:get, :show, name: @environment_name).with(401, 'You are not authorized to perform this action.')
+        expect(controller).to disallow_action(:get, :show, name: @environment_name).with(403, 'You are not authorized to perform this action.')
       end
 
       it 'should allow admin users, with security enabled' do
@@ -137,7 +137,7 @@ describe ApiV2::Admin::EnvironmentsController do
 
       it 'should disallow pipeline group admin users, with security enabled' do
         login_as_group_admin
-        expect(controller).to disallow_action(:get, :show, name: @environment_name).with(401, 'You are not authorized to perform this action.')
+        expect(controller).to disallow_action(:get, :show, name: @environment_name).with(403, 'You are not authorized to perform this action.')
       end
     end
 
@@ -242,12 +242,12 @@ describe ApiV2::Admin::EnvironmentsController do
       it 'should disallow anonymous users, with security enabled' do
         enable_security
         login_as_anonymous
-        expect(controller).to disallow_action(:put, :put, name: @environment_name).with(401, 'You are not authorized to perform this action.')
+        expect(controller).to disallow_action(:put, :put, name: @environment_name).with(403, 'You are not authorized to perform this action.')
       end
 
       it 'should disallow normal users, with security enabled' do
         login_as_user
-        expect(controller).to disallow_action(:put, :put, name: @environment_name).with(401, 'You are not authorized to perform this action.')
+        expect(controller).to disallow_action(:put, :put, name: @environment_name).with(403, 'You are not authorized to perform this action.')
       end
 
       it 'should allow admin users, with security enabled' do
@@ -257,7 +257,7 @@ describe ApiV2::Admin::EnvironmentsController do
 
       it 'should disallow pipeline group admin users, with security enabled' do
         login_as_group_admin
-        expect(controller).to disallow_action(:put, :put, name: @environment_name).with(401, 'You are not authorized to perform this action.')
+        expect(controller).to disallow_action(:put, :put, name: @environment_name).with(403, 'You are not authorized to perform this action.')
       end
     end
 
@@ -349,12 +349,12 @@ describe ApiV2::Admin::EnvironmentsController do
       it 'should disallow anonymous users, with security enabled' do
         enable_security
         login_as_anonymous
-        expect(controller).to disallow_action(:patch, :patch, name: @environment_name).with(401, 'You are not authorized to perform this action.')
+        expect(controller).to disallow_action(:patch, :patch, name: @environment_name).with(403, 'You are not authorized to perform this action.')
       end
 
       it 'should disallow normal users, with security enabled' do
         login_as_user
-        expect(controller).to disallow_action(:patch, :patch, name: @environment_name).with(401, 'You are not authorized to perform this action.')
+        expect(controller).to disallow_action(:patch, :patch, name: @environment_name).with(403, 'You are not authorized to perform this action.')
       end
 
       it 'should allow admin users, with security enabled' do
@@ -364,7 +364,7 @@ describe ApiV2::Admin::EnvironmentsController do
 
       it 'should disallow pipeline group admin users, with security enabled' do
         login_as_group_admin
-        expect(controller).to disallow_action(:patch, :patch, name: @environment_name).with(401, 'You are not authorized to perform this action.')
+        expect(controller).to disallow_action(:patch, :patch, name: @environment_name).with(403, 'You are not authorized to perform this action.')
       end
 
     end
@@ -440,12 +440,12 @@ describe ApiV2::Admin::EnvironmentsController do
       it 'should disallow anonymous users, with security enabled' do
         enable_security
         login_as_anonymous
-        expect(controller).to disallow_action(:delete, :destroy, name: @environment_name).with(401, 'You are not authorized to perform this action.')
+        expect(controller).to disallow_action(:delete, :destroy, name: @environment_name).with(403, 'You are not authorized to perform this action.')
       end
 
       it 'should disallow normal users, with security enabled' do
         login_as_user
-        expect(controller).to disallow_action(:delete, :destroy, name: @environment_name).with(401, 'You are not authorized to perform this action.')
+        expect(controller).to disallow_action(:delete, :destroy, name: @environment_name).with(403, 'You are not authorized to perform this action.')
       end
 
       it 'should allow admin users, with security enabled' do
@@ -455,7 +455,7 @@ describe ApiV2::Admin::EnvironmentsController do
 
       it 'should disallow pipeline group admin users, with security enabled' do
         login_as_group_admin
-        expect(controller).to disallow_action(:delete, :destroy, name: @environment_name).with(401, 'You are not authorized to perform this action.')
+        expect(controller).to disallow_action(:delete, :destroy, name: @environment_name).with(403, 'You are not authorized to perform this action.')
       end
 
     end
@@ -534,12 +534,12 @@ describe ApiV2::Admin::EnvironmentsController do
       it 'should disallow anonymous users, with security enabled' do
         enable_security
         login_as_anonymous
-        expect(controller).to disallow_action(:post, :create).with(401, 'You are not authorized to perform this action.')
+        expect(controller).to disallow_action(:post, :create).with(403, 'You are not authorized to perform this action.')
       end
 
       it 'should disallow normal users, with security enabled' do
         login_as_user
-        expect(controller).to disallow_action(:post, :create).with(401, 'You are not authorized to perform this action.')
+        expect(controller).to disallow_action(:post, :create).with(403, 'You are not authorized to perform this action.')
       end
 
       it 'should allow admin users, with security enabled' do
@@ -549,7 +549,7 @@ describe ApiV2::Admin::EnvironmentsController do
 
       it 'should disallow pipeline group admin users, with security enabled' do
         login_as_group_admin
-        expect(controller).to disallow_action(:post, :create).with(401, 'You are not authorized to perform this action.')
+        expect(controller).to disallow_action(:post, :create).with(403, 'You are not authorized to perform this action.')
       end
 
     end

--- a/server/webapp/WEB-INF/rails.new/spec/controllers/api_v2/users_controller_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/controllers/api_v2/users_controller_spec.rb
@@ -1,5 +1,5 @@
 ##########################################################################
-# Copyright 2016 ThoughtWorks, Inc.
+# Copyright 2018 ThoughtWorks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -48,12 +48,12 @@ describe ApiV2::UsersController do
       it 'should disallow anonymous users, with security enabled' do
         enable_security
         login_as_anonymous
-        expect(controller).to disallow_action(:get, :index).with(401, 'You are not authorized to perform this action.')
+        expect(controller).to disallow_action(:get, :index).with(403, 'You are not authorized to perform this action.')
       end
 
       it 'should disallow normal users, with security enabled' do
         login_as_user
-        expect(controller).to disallow_action(:get, :index).with(401, 'You are not authorized to perform this action.')
+        expect(controller).to disallow_action(:get, :index).with(403, 'You are not authorized to perform this action.')
       end
     end
 
@@ -112,12 +112,12 @@ describe ApiV2::UsersController do
       it 'should disallow anonymous users, with security enabled' do
         enable_security
         login_as_anonymous
-        expect(controller).to disallow_action(:get, :show, login_name: @john.name).with(401, 'You are not authorized to perform this action.')
+        expect(controller).to disallow_action(:get, :show, login_name: @john.name).with(403, 'You are not authorized to perform this action.')
       end
 
       it 'should disallow normal users, with security enabled' do
         login_as_user
-        expect(controller).to disallow_action(:get, :show, login_name: @john.name).with(401, 'You are not authorized to perform this action.')
+        expect(controller).to disallow_action(:get, :show, login_name: @john.name).with(403, 'You are not authorized to perform this action.')
       end
     end
     describe "route" do
@@ -193,12 +193,12 @@ describe ApiV2::UsersController do
       it 'should disallow anonymous users, with security enabled' do
         enable_security
         login_as_anonymous
-        expect(controller).to disallow_action(:delete, :destroy, login_name: @john.name).with(401, 'You are not authorized to perform this action.')
+        expect(controller).to disallow_action(:delete, :destroy, login_name: @john.name).with(403, 'You are not authorized to perform this action.')
       end
 
       it 'should disallow normal users, with security enabled' do
         login_as_user
-        expect(controller).to disallow_action(:delete, :destroy, login_name: @john.name).with(401, 'You are not authorized to perform this action.')
+        expect(controller).to disallow_action(:delete, :destroy, login_name: @john.name).with(403, 'You are not authorized to perform this action.')
       end
     end
 
@@ -368,12 +368,12 @@ describe ApiV2::UsersController do
       it 'should disallow anonymous users, with security enabled' do
         enable_security
         login_as_anonymous
-        expect(controller).to disallow_action(:patch, :update, login_name: @john.name).with(401, 'You are not authorized to perform this action.')
+        expect(controller).to disallow_action(:patch, :update, login_name: @john.name).with(403, 'You are not authorized to perform this action.')
       end
 
       it 'should disallow normal users, with security enabled' do
         login_as_user
-        expect(controller).to disallow_action(:patch, :update, login_name: @john.name).with(401, 'You are not authorized to perform this action.')
+        expect(controller).to disallow_action(:patch, :update, login_name: @john.name).with(403, 'You are not authorized to perform this action.')
       end
     end
 
@@ -449,12 +449,12 @@ describe ApiV2::UsersController do
       it 'should disallow anonymous users, with security enabled' do
         enable_security
         login_as_anonymous
-        expect(controller).to disallow_action(:post, :create).with(401, 'You are not authorized to perform this action.')
+        expect(controller).to disallow_action(:post, :create).with(403, 'You are not authorized to perform this action.')
       end
 
       it 'should disallow normal users, with security enabled' do
         login_as_user
-        expect(controller).to disallow_action(:post, :create).with(401, 'You are not authorized to perform this action.')
+        expect(controller).to disallow_action(:post, :create).with(403, 'You are not authorized to perform this action.')
       end
     end
 

--- a/server/webapp/WEB-INF/rails.new/spec/controllers/api_v3/admin/pipelines_controller_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/controllers/api_v3/admin/pipelines_controller_spec.rb
@@ -1,5 +1,5 @@
 ##########################################################################
-# Copyright 2016 ThoughtWorks, Inc.
+# Copyright 2018 ThoughtWorks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -65,7 +65,7 @@ describe ApiV3::Admin::PipelinesController do
         enable_security
         login_as_pipeline_group_Non_Admin_user
         allow(@security_service).to receive(:hasViewPermissionForPipeline).and_return(false)
-        expect(controller).to disallow_action(:get, :show, {:pipeline_name => "pipeline1"}).with(401, "You are not authorized to perform this action.")
+        expect(controller).to disallow_action(:get, :show, {:pipeline_name => "pipeline1"}).with(403, "You are not authorized to perform this action.")
       end
 
       it 'should allow admin users, with security enabled' do
@@ -86,7 +86,7 @@ describe ApiV3::Admin::PipelinesController do
       it 'should disallow non-admin user, with security enabled' do
         enable_security
         login_as_pipeline_group_Non_Admin_user
-        expect(controller).to disallow_action(:put, :update, {:pipeline_name => "pipeline1"}).with(401, "You are not authorized to perform this action.")
+        expect(controller).to disallow_action(:put, :update, {:pipeline_name => "pipeline1"}).with(403, "You are not authorized to perform this action.")
       end
 
       it 'should allow admin users, with security enabled' do
@@ -111,7 +111,7 @@ describe ApiV3::Admin::PipelinesController do
       it 'should disallow non-admin user, with security enabled' do
         enable_security
         login_as_pipeline_group_Non_Admin_user
-        expect(controller).to disallow_action(:post, :create, :pipeline => {:name => "pipeline1"}, :group => @group).with(401, "You are not authorized to perform this action.")
+        expect(controller).to disallow_action(:post, :create, :pipeline => {:name => "pipeline1"}, :group => @group).with(403, "You are not authorized to perform this action.")
       end
 
       it 'should allow admin users, with security enabled' do
@@ -133,13 +133,13 @@ describe ApiV3::Admin::PipelinesController do
         enable_security
         login_as_anonymous
         allow(@security_service).to receive(:isUserAdminOfGroup).and_return(false)
-        expect(controller).to disallow_action(:delete, :destroy, :pipeline_name => "pipeline1").with(401, 'You are not authorized to perform this action.')
+        expect(controller).to disallow_action(:delete, :destroy, :pipeline_name => "pipeline1").with(403, 'You are not authorized to perform this action.')
       end
 
       it 'should disallow normal users, with security enabled' do
         login_as_user
         allow(@security_service).to receive(:isUserAdminOfGroup).and_return(false)
-        expect(controller).to disallow_action(:delete, :destroy, :pipeline_name => "pipeline1").with(401, 'You are not authorized to perform this action.')
+        expect(controller).to disallow_action(:delete, :destroy, :pipeline_name => "pipeline1").with(403, 'You are not authorized to perform this action.')
       end
 
       it 'should allow admin users, with security enabled' do
@@ -165,7 +165,7 @@ describe ApiV3::Admin::PipelinesController do
 
         get_with_api_header :show, :pipeline_name => @pipeline_name
 
-        expect(response.code).to eq("401")
+        expect(response.code).to eq("403")
         json = JSON.parse(response.body).deep_symbolize_keys
         expect(json[:message]).to eq("You are not authorized to perform this action.")
       end
@@ -274,7 +274,7 @@ describe ApiV3::Admin::PipelinesController do
         allow(@security_service).to receive(:isUserAdminOfGroup).and_return(false)
         put_with_api_header :update, pipeline_name: @pipeline_name, :pipeline => pipeline
 
-        # expect(response.code).to eq("401")
+        # expect(response.code).to eq("403")
 
         json = JSON.parse(response.body).deep_symbolize_keys
         expect(json[:message]).to eq("You are not authorized to perform this action.")
@@ -432,7 +432,7 @@ describe ApiV3::Admin::PipelinesController do
         login_as_pipeline_group_Non_Admin_user
         post_with_api_header :create, :pipeline => pipeline, :group => "new_grp"
 
-        expect(response.code).to eq("401")
+        expect(response.code).to eq("403")
 
         json = JSON.parse(response.body).deep_symbolize_keys
         expect(json[:message]).to eq("You are not authorized to perform this action.")
@@ -447,7 +447,7 @@ describe ApiV3::Admin::PipelinesController do
 
         post_with_api_header :create, :pipeline => pipeline, :group => "another_group"
 
-        expect(response.code).to eq("401")
+        expect(response.code).to eq("403")
 
         json = JSON.parse(response.body).deep_symbolize_keys
         expect(json[:message]).to eq("You are not authorized to perform this action.")

--- a/server/webapp/WEB-INF/rails.new/spec/controllers/api_v3/admin/plugin_infos_controller_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/controllers/api_v3/admin/plugin_infos_controller_spec.rb
@@ -39,6 +39,13 @@ describe ApiV3::Admin::PluginInfosController do
         expect(controller).to allow_action(:get, :show)
       end
 
+      it 'should disallow anonymous users, with security enabled' do
+        enable_security
+        login_as_anonymous
+
+        expect(controller).to disallow_action(:get, :show, {:id => 'plugin_id'}).with(403, 'You are not authorized to perform this action.')
+      end
+
       it 'should allow non-admin user, with security enabled' do
         enable_security
         login_as_user
@@ -55,6 +62,13 @@ describe ApiV3::Admin::PluginInfosController do
       it 'should allow anyone, with security disabled' do
         disable_security
         expect(controller).to allow_action(:get, :index)
+      end
+
+      it 'should disallow anonymous users, with security enabled' do
+        enable_security
+        login_as_anonymous
+
+        expect(controller).to disallow_action(:get, :index).with(403, 'You are not authorized to perform this action.')
       end
 
       it 'should allow non-admin user, with security enabled' do

--- a/server/webapp/WEB-INF/rails.new/spec/controllers/api_v3/admin/templates_controller_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/controllers/api_v3/admin/templates_controller_spec.rb
@@ -1,5 +1,5 @@
 ##########################################################################
-# Copyright 2016 ThoughtWorks, Inc.
+# Copyright 2018 ThoughtWorks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -42,14 +42,14 @@ describe ApiV3::Admin::TemplatesController do
         enable_security
         login_as_anonymous
 
-        expect(controller).to disallow_action(:get, :index).with(401, 'You are not authorized to perform this action.')
+        expect(controller).to disallow_action(:get, :index).with(403, 'You are not authorized to perform this action.')
       end
 
       it 'should disallow normal users, with security enabled' do
         enable_security
         login_as_user
 
-        expect(controller).to disallow_action(:get, :index).with(401, 'You are not authorized to perform this action.')
+        expect(controller).to disallow_action(:get, :index).with(403, 'You are not authorized to perform this action.')
       end
 
       it 'should allow admin, with security enabled' do
@@ -123,14 +123,14 @@ describe ApiV3::Admin::TemplatesController do
         enable_security
         login_as_anonymous
 
-        expect(controller).to disallow_action(:get, :show, template_name: 'foo').with(401, 'You are not authorized to perform this action.')
+        expect(controller).to disallow_action(:get, :show, template_name: 'foo').with(403, 'You are not authorized to perform this action.')
       end
 
       it 'should disallow normal users, with security enabled' do
         enable_security
         login_as_user
 
-        expect(controller).to disallow_action(:get, :show, template_name: 'foo').with(401, 'You are not authorized to perform this action.')
+        expect(controller).to disallow_action(:get, :show, template_name: 'foo').with(403, 'You are not authorized to perform this action.')
       end
 
       it 'should allow admin, with security enabled' do
@@ -228,14 +228,14 @@ describe ApiV3::Admin::TemplatesController do
         enable_security
         login_as_anonymous
 
-        expect(controller).to disallow_action(:post, :create).with(401, 'You are not authorized to perform this action.')
+        expect(controller).to disallow_action(:post, :create).with(403, 'You are not authorized to perform this action.')
       end
 
       it 'should disallow normal users, with security enabled' do
         enable_security
         login_as_user
 
-        expect(controller).to disallow_action(:post, :create).with(401, 'You are not authorized to perform this action.')
+        expect(controller).to disallow_action(:post, :create).with(403, 'You are not authorized to perform this action.')
       end
 
       it 'should allow admin, with security enabled' do
@@ -321,14 +321,14 @@ describe ApiV3::Admin::TemplatesController do
         enable_security
         login_as_anonymous
 
-        expect(controller).to disallow_action(:put, :update, template_name: 'foo').with(401, 'You are not authorized to perform this action.')
+        expect(controller).to disallow_action(:put, :update, template_name: 'foo').with(403, 'You are not authorized to perform this action.')
       end
 
       it 'should disallow normal users, with security enabled' do
         enable_security
         login_as_user
 
-        expect(controller).to disallow_action(:put, :update, template_name: 'foo').with(401, 'You are not authorized to perform this action.')
+        expect(controller).to disallow_action(:put, :update, template_name: 'foo').with(403, 'You are not authorized to perform this action.')
       end
 
       it 'should allow admin, with security enabled' do
@@ -463,14 +463,14 @@ describe ApiV3::Admin::TemplatesController do
         enable_security
         login_as_anonymous
 
-        expect(controller).to disallow_action(:delete, :destroy, template_name: 'foo').with(401, 'You are not authorized to perform this action.')
+        expect(controller).to disallow_action(:delete, :destroy, template_name: 'foo').with(403, 'You are not authorized to perform this action.')
       end
 
       it 'should disallow normal users, with security enabled' do
         enable_security
         login_as_user
 
-        expect(controller).to disallow_action(:delete, :destroy, template_name: 'foo').with(401, 'You are not authorized to perform this action.')
+        expect(controller).to disallow_action(:delete, :destroy, template_name: 'foo').with(403, 'You are not authorized to perform this action.')
       end
 
       it 'should allow admin, with security enabled' do

--- a/server/webapp/WEB-INF/rails.new/spec/controllers/api_v4/admin/pipelines_controller_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/controllers/api_v4/admin/pipelines_controller_spec.rb
@@ -1,5 +1,5 @@
 ##########################################################################
-# Copyright 2017 ThoughtWorks, Inc.
+# Copyright 2018 ThoughtWorks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -65,7 +65,7 @@ describe ApiV4::Admin::PipelinesController do
         enable_security
         login_as_pipeline_group_Non_Admin_user
         allow(@security_service).to receive(:hasViewPermissionForPipeline).and_return(false)
-        expect(controller).to disallow_action(:get, :show, {:pipeline_name => "pipeline1"}).with(401, "You are not authorized to perform this action.")
+        expect(controller).to disallow_action(:get, :show, {:pipeline_name => "pipeline1"}).with(403, "You are not authorized to perform this action.")
       end
 
       it 'should allow admin users, with security enabled' do
@@ -86,7 +86,7 @@ describe ApiV4::Admin::PipelinesController do
       it 'should disallow non-admin user, with security enabled' do
         enable_security
         login_as_pipeline_group_Non_Admin_user
-        expect(controller).to disallow_action(:put, :update, {:pipeline_name => "pipeline1"}).with(401, "You are not authorized to perform this action.")
+        expect(controller).to disallow_action(:put, :update, {:pipeline_name => "pipeline1"}).with(403, "You are not authorized to perform this action.")
       end
 
       it 'should allow admin users, with security enabled' do
@@ -111,7 +111,7 @@ describe ApiV4::Admin::PipelinesController do
       it 'should disallow non-admin user, with security enabled' do
         enable_security
         login_as_pipeline_group_Non_Admin_user
-        expect(controller).to disallow_action(:post, :create, :pipeline => {:name => "pipeline1"}, :group => @group).with(401, "You are not authorized to perform this action.")
+        expect(controller).to disallow_action(:post, :create, :pipeline => {:name => "pipeline1"}, :group => @group).with(403, "You are not authorized to perform this action.")
       end
 
       it 'should allow admin users, with security enabled' do
@@ -133,13 +133,13 @@ describe ApiV4::Admin::PipelinesController do
         enable_security
         login_as_anonymous
         allow(@security_service).to receive(:isUserAdminOfGroup).and_return(false)
-        expect(controller).to disallow_action(:delete, :destroy, :pipeline_name => "pipeline1").with(401, 'You are not authorized to perform this action.')
+        expect(controller).to disallow_action(:delete, :destroy, :pipeline_name => "pipeline1").with(403, 'You are not authorized to perform this action.')
       end
 
       it 'should disallow normal users, with security enabled' do
         login_as_user
         allow(@security_service).to receive(:isUserAdminOfGroup).and_return(false)
-        expect(controller).to disallow_action(:delete, :destroy, :pipeline_name => "pipeline1").with(401, 'You are not authorized to perform this action.')
+        expect(controller).to disallow_action(:delete, :destroy, :pipeline_name => "pipeline1").with(403, 'You are not authorized to perform this action.')
       end
 
       it 'should allow admin users, with security enabled' do
@@ -165,7 +165,7 @@ describe ApiV4::Admin::PipelinesController do
 
         get_with_api_header :show, :pipeline_name => @pipeline_name
 
-        expect(response.code).to eq("401")
+        expect(response.code).to eq("403")
         json = JSON.parse(response.body).deep_symbolize_keys
         expect(json[:message]).to eq("You are not authorized to perform this action.")
       end
@@ -275,7 +275,7 @@ describe ApiV4::Admin::PipelinesController do
         allow(@security_service).to receive(:isUserAdminOfGroup).and_return(false)
         put_with_api_header :update, pipeline_name: @pipeline_name, :pipeline => pipeline
 
-        # expect(response.code).to eq("401")
+        # expect(response.code).to eq("403")
 
         json = JSON.parse(response.body).deep_symbolize_keys
         expect(json[:message]).to eq("You are not authorized to perform this action.")
@@ -434,7 +434,7 @@ describe ApiV4::Admin::PipelinesController do
         login_as_pipeline_group_Non_Admin_user
         post_with_api_header :create, :pipeline => pipeline, :group => "new_grp"
 
-        expect(response.code).to eq("401")
+        expect(response.code).to eq("403")
 
         json = JSON.parse(response.body).deep_symbolize_keys
         expect(json[:message]).to eq("You are not authorized to perform this action.")
@@ -449,7 +449,7 @@ describe ApiV4::Admin::PipelinesController do
 
         post_with_api_header :create, :pipeline => pipeline, :group => "another_group"
 
-        expect(response.code).to eq("401")
+        expect(response.code).to eq("403")
 
         json = JSON.parse(response.body).deep_symbolize_keys
         expect(json[:message]).to eq("You are not authorized to perform this action.")

--- a/server/webapp/WEB-INF/rails.new/spec/controllers/api_v4/admin/plugin_infos_controller_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/controllers/api_v4/admin/plugin_infos_controller_spec.rb
@@ -39,6 +39,13 @@ describe ApiV4::Admin::PluginInfosController do
         expect(controller).to allow_action(:get, :show)
       end
 
+      it 'should disallow anonymous users, with security enabled' do
+        enable_security
+        login_as_anonymous
+
+        expect(controller).to disallow_action(:get, :show, {:id => 'plugin_id'}).with(403, 'You are not authorized to perform this action.')
+      end
+
       it 'should allow non-admin user, with security enabled' do
         enable_security
         login_as_user
@@ -55,6 +62,13 @@ describe ApiV4::Admin::PluginInfosController do
       it 'should allow anyone, with security disabled' do
         disable_security
         expect(controller).to allow_action(:get, :index)
+      end
+
+      it 'should disallow anonymous users, with security enabled' do
+        enable_security
+        login_as_anonymous
+
+        expect(controller).to disallow_action(:get, :index).with(403, 'You are not authorized to perform this action.')
       end
 
       it 'should allow non-admin user, with security enabled' do

--- a/server/webapp/WEB-INF/rails.new/spec/controllers/api_v4/admin/templates_controller_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/controllers/api_v4/admin/templates_controller_spec.rb
@@ -1,5 +1,5 @@
 ##########################################################################
-# Copyright 2016 ThoughtWorks, Inc.
+# Copyright 2018 ThoughtWorks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -42,14 +42,14 @@ describe ApiV4::Admin::TemplatesController do
         enable_security
         login_as_anonymous
 
-        expect(controller).to disallow_action(:get, :index).with(401, 'You are not authorized to perform this action.')
+        expect(controller).to disallow_action(:get, :index).with(403, 'You are not authorized to perform this action.')
       end
 
       it 'should disallow normal users, with security enabled' do
         enable_security
         login_as_user
 
-        expect(controller).to disallow_action(:get, :index).with(401, 'You are not authorized to perform this action.')
+        expect(controller).to disallow_action(:get, :index).with(403, 'You are not authorized to perform this action.')
       end
 
       it 'should allow admin, with security enabled' do
@@ -123,14 +123,14 @@ describe ApiV4::Admin::TemplatesController do
         enable_security
         login_as_anonymous
 
-        expect(controller).to disallow_action(:get, :show, template_name: 'foo').with(401, 'You are not authorized to perform this action.')
+        expect(controller).to disallow_action(:get, :show, template_name: 'foo').with(403, 'You are not authorized to perform this action.')
       end
 
       it 'should disallow normal users, with security enabled' do
         enable_security
         login_as_user
 
-        expect(controller).to disallow_action(:get, :show, template_name: 'foo').with(401, 'You are not authorized to perform this action.')
+        expect(controller).to disallow_action(:get, :show, template_name: 'foo').with(403, 'You are not authorized to perform this action.')
       end
 
       it 'should allow admin, with security enabled' do
@@ -228,14 +228,14 @@ describe ApiV4::Admin::TemplatesController do
         enable_security
         login_as_anonymous
 
-        expect(controller).to disallow_action(:post, :create).with(401, 'You are not authorized to perform this action.')
+        expect(controller).to disallow_action(:post, :create).with(403, 'You are not authorized to perform this action.')
       end
 
       it 'should disallow normal users, with security enabled' do
         enable_security
         login_as_user
 
-        expect(controller).to disallow_action(:post, :create).with(401, 'You are not authorized to perform this action.')
+        expect(controller).to disallow_action(:post, :create).with(403, 'You are not authorized to perform this action.')
       end
 
       it 'should allow admin, with security enabled' do
@@ -321,14 +321,14 @@ describe ApiV4::Admin::TemplatesController do
         enable_security
         login_as_anonymous
 
-        expect(controller).to disallow_action(:put, :update, template_name: 'foo').with(401, 'You are not authorized to perform this action.')
+        expect(controller).to disallow_action(:put, :update, template_name: 'foo').with(403, 'You are not authorized to perform this action.')
       end
 
       it 'should disallow normal users, with security enabled' do
         enable_security
         login_as_user
 
-        expect(controller).to disallow_action(:put, :update, template_name: 'foo').with(401, 'You are not authorized to perform this action.')
+        expect(controller).to disallow_action(:put, :update, template_name: 'foo').with(403, 'You are not authorized to perform this action.')
       end
 
       it 'should allow admin, with security enabled' do
@@ -463,14 +463,14 @@ describe ApiV4::Admin::TemplatesController do
         enable_security
         login_as_anonymous
 
-        expect(controller).to disallow_action(:delete, :destroy, template_name: 'foo').with(401, 'You are not authorized to perform this action.')
+        expect(controller).to disallow_action(:delete, :destroy, template_name: 'foo').with(403, 'You are not authorized to perform this action.')
       end
 
       it 'should disallow normal users, with security enabled' do
         enable_security
         login_as_user
 
-        expect(controller).to disallow_action(:delete, :destroy, template_name: 'foo').with(401, 'You are not authorized to perform this action.')
+        expect(controller).to disallow_action(:delete, :destroy, template_name: 'foo').with(403, 'You are not authorized to perform this action.')
       end
 
       it 'should allow admin, with security enabled' do

--- a/server/webapp/WEB-INF/rails.new/spec/controllers/api_v4/agents_controller_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/controllers/api_v4/agents_controller_spec.rb
@@ -1,5 +1,5 @@
 ##########################################################################
-# Copyright 2016 ThoughtWorks, Inc.
+# Copyright 2018 ThoughtWorks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -186,7 +186,7 @@ describe ApiV4::AgentsController do
 
       it 'should not allow normal users, with security enabled' do
         login_as_user
-        expect(controller).to disallow_action(:delete, :destroy, uuid: @agent.getUuid()).with(401, 'You are not authorized to perform this action.')
+        expect(controller).to disallow_action(:delete, :destroy, uuid: @agent.getUuid()).with(403, 'You are not authorized to perform this action.')
       end
     end
 
@@ -267,7 +267,7 @@ describe ApiV4::AgentsController do
 
       it 'should not allow normal users, with security enabled' do
         login_as_user
-        expect(controller).to disallow_action(:patch, :update, uuid: @agent.getUuid(), hostname: 'some-hostname').with(401, 'You are not authorized to perform this action.')
+        expect(controller).to disallow_action(:patch, :update, uuid: @agent.getUuid(), hostname: 'some-hostname').with(403, 'You are not authorized to perform this action.')
       end
     end
 
@@ -452,7 +452,7 @@ describe ApiV4::AgentsController do
         login_as_user
 
         delete_with_api_header :bulk_destroy, :uuids => ['foo']
-        expect(response).to have_api_message_response(401, 'You are not authorized to perform this action.')
+        expect(response).to have_api_message_response(403, 'You are not authorized to perform this action.')
       end
     end
 
@@ -535,7 +535,7 @@ describe ApiV4::AgentsController do
         login_as_user
 
         patch_with_api_header :bulk_update, :uuids => ['foo']
-        expect(response).to have_api_message_response(401, 'You are not authorized to perform this action.')
+        expect(response).to have_api_message_response(403, 'You are not authorized to perform this action.')
       end
     end
 

--- a/server/webapp/WEB-INF/rails.new/spec/controllers/api_v5/admin/pipelines_controller_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/controllers/api_v5/admin/pipelines_controller_spec.rb
@@ -1,5 +1,5 @@
 ##########################################################################
-# Copyright 2017 ThoughtWorks, Inc.
+# Copyright 2018 ThoughtWorks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -65,7 +65,7 @@ describe ApiV5::Admin::PipelinesController do
         enable_security
         login_as_pipeline_group_Non_Admin_user
         allow(@security_service).to receive(:hasViewPermissionForPipeline).and_return(false)
-        expect(controller).to disallow_action(:get, :show, {:pipeline_name => "pipeline1"}).with(401, "You are not authorized to perform this action.")
+        expect(controller).to disallow_action(:get, :show, {:pipeline_name => "pipeline1"}).with(403, "You are not authorized to perform this action.")
       end
 
       it 'should allow admin users, with security enabled' do
@@ -86,7 +86,7 @@ describe ApiV5::Admin::PipelinesController do
       it 'should disallow non-admin user, with security enabled' do
         enable_security
         login_as_pipeline_group_Non_Admin_user
-        expect(controller).to disallow_action(:put, :update, {:pipeline_name => "pipeline1"}).with(401, "You are not authorized to perform this action.")
+        expect(controller).to disallow_action(:put, :update, {:pipeline_name => "pipeline1"}).with(403, "You are not authorized to perform this action.")
       end
 
       it 'should allow admin users, with security enabled' do
@@ -111,7 +111,7 @@ describe ApiV5::Admin::PipelinesController do
       it 'should disallow non-admin user, with security enabled' do
         enable_security
         login_as_pipeline_group_Non_Admin_user
-        expect(controller).to disallow_action(:post, :create, :pipeline => {:name => "pipeline1"}, :group => @group).with(401, "You are not authorized to perform this action.")
+        expect(controller).to disallow_action(:post, :create, :pipeline => {:name => "pipeline1"}, :group => @group).with(403, "You are not authorized to perform this action.")
       end
 
       it 'should allow admin users, with security enabled' do
@@ -133,13 +133,13 @@ describe ApiV5::Admin::PipelinesController do
         enable_security
         login_as_anonymous
         allow(@security_service).to receive(:isUserAdminOfGroup).and_return(false)
-        expect(controller).to disallow_action(:delete, :destroy, :pipeline_name => "pipeline1").with(401, 'You are not authorized to perform this action.')
+        expect(controller).to disallow_action(:delete, :destroy, :pipeline_name => "pipeline1").with(403, 'You are not authorized to perform this action.')
       end
 
       it 'should disallow normal users, with security enabled' do
         login_as_user
         allow(@security_service).to receive(:isUserAdminOfGroup).and_return(false)
-        expect(controller).to disallow_action(:delete, :destroy, :pipeline_name => "pipeline1").with(401, 'You are not authorized to perform this action.')
+        expect(controller).to disallow_action(:delete, :destroy, :pipeline_name => "pipeline1").with(403, 'You are not authorized to perform this action.')
       end
 
       it 'should allow admin users, with security enabled' do
@@ -165,7 +165,7 @@ describe ApiV5::Admin::PipelinesController do
 
         get_with_api_header :show, :pipeline_name => @pipeline_name
 
-        expect(response.code).to eq("401")
+        expect(response.code).to eq("403")
         json = JSON.parse(response.body).deep_symbolize_keys
         expect(json[:message]).to eq("You are not authorized to perform this action.")
       end
@@ -275,7 +275,7 @@ describe ApiV5::Admin::PipelinesController do
         allow(@security_service).to receive(:isUserAdminOfGroup).and_return(false)
         put_with_api_header :update, pipeline_name: @pipeline_name, :pipeline => pipeline
 
-        # expect(response.code).to eq("401")
+        # expect(response.code).to eq("403")
 
         json = JSON.parse(response.body).deep_symbolize_keys
         expect(json[:message]).to eq("You are not authorized to perform this action.")
@@ -434,7 +434,7 @@ describe ApiV5::Admin::PipelinesController do
         login_as_pipeline_group_Non_Admin_user
         post_with_api_header :create, :pipeline => pipeline, :group => "new_grp"
 
-        expect(response.code).to eq("401")
+        expect(response.code).to eq("403")
 
         json = JSON.parse(response.body).deep_symbolize_keys
         expect(json[:message]).to eq("You are not authorized to perform this action.")
@@ -449,7 +449,7 @@ describe ApiV5::Admin::PipelinesController do
 
         post_with_api_header :create, :pipeline => pipeline, :group => "another_group"
 
-        expect(response.code).to eq("401")
+        expect(response.code).to eq("403")
 
         json = JSON.parse(response.body).deep_symbolize_keys
         expect(json[:message]).to eq("You are not authorized to perform this action.")

--- a/server/webapp/WEB-INF/rails.new/spec/controllers/application_controller_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/controllers/application_controller_spec.rb
@@ -268,8 +268,8 @@ describe ApplicationController do
 
     it "should render_operation_result_if_failure" do
       result = HttpOperationResult.new
-      result.unauthorized("Unauthorized", "the real cause", nil)
-      expect(controller).to receive(:render_if_error).with("Unauthorized { the real cause }\n", 401).and_return(true)
+      result.forbidden("Unauthorized", "the real cause", nil)
+      expect(controller).to receive(:render_if_error).with("Unauthorized { the real cause }\n", 403).and_return(true)
 
       controller.render_operation_result_if_failure(result)
     end

--- a/server/webapp/WEB-INF/rails.new/spec/controllers/application_controller_view_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/controllers/application_controller_view_spec.rb
@@ -1,5 +1,5 @@
 ##########################GO-LICENSE-START################################
-# Copyright 2014 ThoughtWorks, Inc.
+# Copyright 2018 ThoughtWorks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -94,9 +94,9 @@ describe Api::TestController do
       expect(response.body).to eq("it was not found { description }\n")
     end
 
-    it "should render 401 responses in error template" do
+    it "should render 403 responses in error template" do
       get :unauthorized_action, :no_layout=>true
-      expect(response.status).to eq(401)
+      expect(response.status).to eq(403)
       expect(response.body).to eq("you are not allowed { description }\n")
     end
   end

--- a/server/webapp/WEB-INF/rails.new/spec/controllers/comparison_controller_view_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/controllers/comparison_controller_view_spec.rb
@@ -1,5 +1,5 @@
 ##########################GO-LICENSE-START################################
-# Copyright 2014 ThoughtWorks, Inc.
+# Copyright 2018 ThoughtWorks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -81,7 +81,7 @@ describe ComparisonController, "view" do
       expect(controller).to receive(:mingle_config_service).and_return(service = double('MingleConfigService'))
       result = HttpLocalizedOperationResult.new
       allow(HttpLocalizedOperationResult).to receive(:new).and_return(result)
-      result.unauthorized(com.thoughtworks.go.i18n.LocalizedMessage::unauthorizedToViewPipeline("some_pipeline"), HealthStateType.unauthorisedForPipeline("some_pipeline"))
+      result.forbidden(com.thoughtworks.go.i18n.LocalizedMessage::forbiddenToViewPipeline("some_pipeline"), HealthStateType.forbiddenForPipeline("some_pipeline"))
 
       expect(service).to receive(:mingleConfigForPipelineNamed).with('some_pipeline', @loser, result).and_return(nil)
 
@@ -96,13 +96,13 @@ describe ComparisonController, "view" do
         end
       end
       expect(response.body).to include("<h3>You do not have view permissions for pipeline &#39;some_pipeline&#39;.</h3>")
-      expect(response.status).to eq(401)
+      expect(response.status).to eq(403)
     end
 
     it "should show error if pipelines don't exist" do
       allow(controller).to receive(:pipeline_history_service).and_return(phs = double('PipelineHistoryService'))
 
-      @result.unauthorized("You do not have view permissions for pipeline 'admin_only'.", "too bad for you!", HealthStateType.unauthorisedForPipeline("admin_only"))
+      @result.forbidden("You do not have view permissions for pipeline 'admin_only'.", "too bad for you!", HealthStateType.forbiddenForPipeline("admin_only"))
 
       expect(HttpOperationResult).to receive(:new).and_return(@result)
       expect(phs).to receive(:findPipelineInstance).with("admin_only", 17, @loser, @result).and_return(nil)
@@ -119,7 +119,7 @@ describe ComparisonController, "view" do
         end
       end
       expect(response.body).to include("<h3>You do not have view permissions for pipeline &#39;admin_only&#39;. { too bad for you! }\n</h3>")
-      expect(response.status).to eq(401)
+      expect(response.status).to eq(403)
     end
 
     it "should render Checkins between the given pipeline instances" do

--- a/server/webapp/WEB-INF/rails.new/spec/controllers/pipelines_controller_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/controllers/pipelines_controller_spec.rb
@@ -1,5 +1,5 @@
 ##########################GO-LICENSE-START################################
-# Copyright 2014 ThoughtWorks, Inc.
+# Copyright 2018 ThoughtWorks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -225,20 +225,20 @@ describe PipelinesController do
 
   it "should show error message if the user is not authorized to view the pipeline" do
     expect(@material_service).to receive(:searchRevisions).with('pipeline', 'sha', 'search', @user, anything()) do |p, sha, search, user, result|
-      result.unauthorized(com.thoughtworks.go.i18n.LocalizedMessage::unauthorizedToViewPipeline("pipeline"), nil)
+      result.forbidden(com.thoughtworks.go.i18n.LocalizedMessage::forbiddenToViewPipeline("pipeline"), nil)
     end
 
     get :material_search, :pipeline_name => 'pipeline', :fingerprint => 'sha', :search => 'search', :no_layout => true
-    expect(response.status).to eq(401)
+    expect(response.status).to eq(403)
   end
 
   it "should show error message if the user is not authorized to view the pipeline - with POST" do
     expect(@material_service).to receive(:searchRevisions).with('pipeline', 'sha', 'search', @user, anything()) do |p, sha, search, user, result|
-      result.unauthorized(com.thoughtworks.go.i18n.LocalizedMessage::unauthorizedToViewPipeline("pipeline"), nil)
+      result.forbidden(com.thoughtworks.go.i18n.LocalizedMessage::forbiddenToViewPipeline("pipeline"), nil)
     end
 
     post :material_search, :pipeline_name => 'pipeline', :fingerprint => 'sha', :search => 'search', :no_layout => true
-    expect(response.status).to eq(401)
+    expect(response.status).to eq(403)
     assert_template layout: false
   end
 
@@ -358,13 +358,13 @@ describe PipelinesController do
     end
 
     context 'when the update is unauthorized' do
-      it 'it returns 401' do
+      it 'it returns 403' do
         allow(@pipeline_history_service).to receive(:updateComment).with('pipeline_name', 1, 'test comment', current_user, @localized_result) do |_, _, _, _, result|
-          result.unauthorized('some message', nil)
+          result.forbidden('some message', nil)
         end
 
         post :update_comment, pipeline_name: 'pipeline_name', pipeline_counter: 1, comment: 'test comment', format: :json
-        assert_response(401)
+        assert_response(403)
       end
 
     end

--- a/server/webapp/WEB-INF/rails.new/spec/controllers/stages_controller_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/controllers/stages_controller_spec.rb
@@ -1,5 +1,5 @@
 ##########################GO-LICENSE-START################################
-# Copyright 2016 ThoughtWorks, Inc.
+# Copyright 2018 ThoughtWorks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -151,10 +151,10 @@ describe StagesController do
       expect(@stage_service).to receive(:findStageSummaryByIdentifier).with(stage_identifier, @user, @localized_result).and_return(@stage_summary_model)
       expect(@status).to receive(:canContinue).and_return(true)
       expect(@localized_result).to receive(:isSuccessful).and_return(false)
-      allow(@localized_result).to receive(:httpCode).and_return(401)
+      allow(@localized_result).to receive(:httpCode).and_return(403)
       allow(@localized_result).to receive(:message).and_return("no view permission")
       get :overview, :pipeline_name => "pipeline", :pipeline_counter => "2", :stage_name => "stage", :stage_counter => "3"
-      expect(response.status).to eq 401
+      expect(response.status).to eq 403
     end
 
     it "should render response code returned by the api result" do
@@ -232,10 +232,10 @@ describe StagesController do
 
     it "should render response code returned by the api result for pipeline" do
       expect(@status).to receive(:canContinue).and_return(false)
-      allow(@status).to receive(:httpCode).and_return(401)
+      allow(@status).to receive(:httpCode).and_return(403)
       allow(@status).to receive(:detailedMessage).and_return("no view permission")
       get :overview, :pipeline_name => "pipeline", :pipeline_counter => "2", :stage_name => "stage", :stage_counter => "3"
-      expect(response.status).to eq 401
+      expect(response.status).to eq 403
     end
 
     it "should assign locked instance" do
@@ -332,9 +332,9 @@ describe StagesController do
         expect(@pipeline_history_service).to receive(:pipelineDependencyGraph).with("pipeline", 99, @user, result).and_return(:doesnt_matter)
         expect(result).to receive(:canContinue).and_return(false)
         allow(result).to receive(:detailedMessage).and_return("no view permission")
-        allow(result).to receive(:httpCode).and_return(401)
+        allow(result).to receive(:httpCode).and_return(403)
         get :pipeline, :pipeline_name => "pipeline", :pipeline_counter => "99", :stage_name => "stage", :stage_counter => "3"
-        expect(response.status).to eq 401
+        expect(response.status).to eq 403
       end
     end
 

--- a/server/webapp/WEB-INF/rails.new/spec/helpers/application_helper_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/helpers/application_helper_spec.rb
@@ -1,5 +1,5 @@
 ##########################GO-LICENSE-START################################
-# Copyright 2016 ThoughtWorks, Inc.
+# Copyright 2018 ThoughtWorks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -245,7 +245,7 @@ describe ApplicationHelper do
       expect(actual).to eq(expected)
     end
 
-    it "should append 401 handler to form" do
+    it "should append 403 handler to form" do
       expected = %q|<form accept-charset="UTF-8" action="url" method="post" onsubmit="AjaxRefreshers.disableAjax();; new Ajax.Request('url', {asynchronous:true, evalScripts:true, on401:function(request){redirectToLoginPage('/auth/login');}, onComplete:function(request){AjaxRefreshers.enableAjax();}, parameters:Form.serialize(this)}); return false;"><div style="margin:0;padding:0;display:inline"><input name="utf8" type="hidden" value="&#x2713;" /></div>|
 
       actual = blocking_form_remote_tag(:url => "url")
@@ -447,13 +447,13 @@ describe ApplicationHelper do
 
   describe "unauthorized_access" do
 
-    it "should return true if status is 401" do
-      @status = 401
-      expect(unauthorized_access).to eq(true)
+    it "should return true if status is 403" do
+      @status = 403
+      expect(access_forbidden).to eq(true)
     end
     it "should return false if status is not true" do
       @status = 200
-      expect(unauthorized_access).to eq(false)
+      expect(access_forbidden).to eq(false)
     end
 
   end

--- a/server/webapp/WEB-INF/rails.new/spec/lib/config_update/check_can_create_pipeline_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/lib/config_update/check_can_create_pipeline_spec.rb
@@ -1,5 +1,5 @@
 ##########################GO-LICENSE-START################################
-# Copyright 2014 ThoughtWorks, Inc.
+# Copyright 2018 ThoughtWorks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -29,7 +29,7 @@ describe ConfigUpdate::CheckCanCreatePipeline, :type => :helper do
     @user = Username.new(CaseInsensitiveString.new('loser')) #Instance variable because the module expects this to be defined
   end
 
-  it "should return 401 if user is not a group admin" do
+  it "should return 403 if user is not a group admin" do
     cruise_config = GoConfigMother.configWithPipelines(["his-pipeline", "my-pipeline", "her-pipeline"].to_java(java.lang.String))
     result = HttpLocalizedOperationResult.new
     def params
@@ -40,11 +40,11 @@ describe ConfigUpdate::CheckCanCreatePipeline, :type => :helper do
     checkPermission(cruise_config, result)
 
     expect(result.isSuccessful()).to be_falsey
-    expect(result.httpCode()).to eq(401)
+    expect(result.httpCode()).to eq(403)
     expect(result.message()).to eq("Unauthorized to create pipeline.")
     end
 
-  it "should return 401 if user is a normal user and group does not exist" do
+  it "should return 403 if user is a normal user and group does not exist" do
     cruise_config = GoConfigMother.configWithPipelines(["his-pipeline", "my-pipeline", "her-pipeline"].to_java(java.lang.String))
     result = HttpLocalizedOperationResult.new
     @params = {:pipeline_group => {:group => "some_junk_group"}}
@@ -54,11 +54,11 @@ describe ConfigUpdate::CheckCanCreatePipeline, :type => :helper do
     checkPermission(cruise_config, result)
 
     expect(result.isSuccessful()).to be_falsey
-    expect(result.httpCode()).to eq(401)
+    expect(result.httpCode()).to eq(403)
     expect(result.message()).to eq("Unauthorized to create pipeline.")
   end
 
-  it "should return 401 if user is an admin but no group_name given(happens when using community edition)" do
+  it "should return 403 if user is an admin but no group_name given(happens when using community edition)" do
     cruise_config = GoConfigMother.configWithPipelines(["his-pipeline", "my-pipeline", "her-pipeline"].to_java(java.lang.String))
     result = HttpLocalizedOperationResult.new
     expect(@security_service).to receive(:isUserAdminOfGroup).with(CaseInsensitiveString.new("loser"), PipelineConfigs::DEFAULT_GROUP).and_return(false)
@@ -66,11 +66,11 @@ describe ConfigUpdate::CheckCanCreatePipeline, :type => :helper do
     checkPermission(cruise_config, result)
 
     expect(result.isSuccessful()).to be_falsey
-    expect(result.httpCode()).to eq(401)
+    expect(result.httpCode()).to eq(403)
     expect(result.message()).to eq("Unauthorized to create pipeline.")
   end
 
-  it "should return 401 if user is not a group admin for 'defaultGroup' and group name is empty" do
+  it "should return 403 if user is not a group admin for 'defaultGroup' and group name is empty" do
     cruise_config = GoConfigMother.configWithPipelines(["his-pipeline", "my-pipeline", "her-pipeline"].to_java(java.lang.String))
     result = HttpLocalizedOperationResult.new
     @params = {:pipeline_group => {:group => ""}}
@@ -79,11 +79,11 @@ describe ConfigUpdate::CheckCanCreatePipeline, :type => :helper do
     checkPermission(cruise_config, result)
 
     expect(result.isSuccessful()).to be_falsey
-    expect(result.httpCode()).to eq(401)
+    expect(result.httpCode()).to eq(403)
     expect(result.message()).to eq("Unauthorized to create pipeline.")
   end
 
-  it "should return 401 if user tries to create 'defaultGroup' and is not an admin" do
+  it "should return 403 if user tries to create 'defaultGroup' and is not an admin" do
     cruise_config = GoConfigMother.new.cruiseConfigWithPipelineUsingTwoMaterials()
     result = HttpLocalizedOperationResult.new
     @params = {:pipeline_group => {:group => ""}}
@@ -92,7 +92,7 @@ describe ConfigUpdate::CheckCanCreatePipeline, :type => :helper do
     checkPermission(cruise_config, result)
 
     expect(result.isSuccessful()).to be_falsey
-    expect(result.httpCode()).to eq(401)
+    expect(result.httpCode()).to eq(403)
     expect(result.message()).to eq("Unauthorized to create pipeline.")
   end
 

--- a/server/webapp/WEB-INF/rails.new/spec/lib/config_update/check_can_edit_pipeline_or_template_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/lib/config_update/check_can_edit_pipeline_or_template_spec.rb
@@ -1,5 +1,5 @@
 ##########################GO-LICENSE-START################################
-# Copyright 2014 ThoughtWorks, Inc.
+# Copyright 2018 ThoughtWorks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -39,7 +39,7 @@ describe ConfigUpdate::CheckCanEditPipelineOrTemplate do
     checkPermission(cruise_config, result)
 
     expect(result.isSuccessful()).to be_falsey
-    expect(result.httpCode()).to eq(401)
+    expect(result.httpCode()).to eq(403)
     expect(result.message()).to eq("Unauthorized to edit 'my-pipeline' pipeline.")
   end
 
@@ -77,7 +77,7 @@ describe ConfigUpdate::CheckCanEditPipelineOrTemplate do
     checkPermission(cruise_config, result)
 
     expect(result.isSuccessful()).to be_falsey
-    expect(result.httpCode()).to eq(401)
+    expect(result.httpCode()).to eq(403)
     expect(result.message()).to eq("Unauthorized to edit 'my-pipeline' pipeline.")
   end
 
@@ -90,7 +90,7 @@ describe ConfigUpdate::CheckCanEditPipelineOrTemplate do
     checkPermission(cruise_config, result)
 
     expect(result.isSuccessful()).to be_falsey
-    expect(result.httpCode()).to eq(401)
+    expect(result.httpCode()).to eq(403)
     expect(result.message()).to eq("Unauthorized to edit.")
   end
 
@@ -104,7 +104,7 @@ describe ConfigUpdate::CheckCanEditPipelineOrTemplate do
     checkPermission(cruise_config, result)
 
     expect(result.isSuccessful()).to be_falsey
-    expect(result.httpCode()).to eq(401)
+    expect(result.httpCode()).to eq(403)
     expect(result.message()).to eq("Unauthorized to edit 'my-pipeline-group' group.")
   end
 end

--- a/server/webapp/WEB-INF/rails.new/spec/lib/config_update/check_is_super_admin_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/lib/config_update/check_is_super_admin_spec.rb
@@ -1,5 +1,5 @@
 ##########################GO-LICENSE-START################################
-# Copyright 2014 ThoughtWorks, Inc.
+# Copyright 2018 ThoughtWorks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -36,7 +36,7 @@ describe ConfigUpdate::CheckIsSuperAdmin do
     checkPermission(cruise_config, result)
 
     expect(result.isSuccessful()).to be_falsey
-    expect(result.httpCode()).to eq(401)
+    expect(result.httpCode()).to eq(403)
     expect(result.message()).to eq("Unauthorized to edit.")
   end
 

--- a/server/webapp/WEB-INF/rails.new/spec/support/util/test_controller.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/support/util/test_controller.rb
@@ -1,5 +1,5 @@
 ##########################GO-LICENSE-START################################
-# Copyright 2014 ThoughtWorks, Inc.
+# Copyright 2018 ThoughtWorks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -63,7 +63,7 @@ class NonApiController < ApplicationController
 
   def localized_not_found_action
     hor = HttpLocalizedOperationResult.new()
-    hor.notFound(com.thoughtworks.go.i18n.LocalizedMessage::unauthorizedToViewPipeline("mingle"), HealthStateType.general(HealthStateScope::GLOBAL))
+    hor.notFound(com.thoughtworks.go.i18n.LocalizedMessage::forbiddenToViewPipeline("mingle"), HealthStateType.general(HealthStateScope::GLOBAL))
     render_localized_operation_result(hor)
   end
 
@@ -101,13 +101,13 @@ module Api
 
     def unauthorized_action
       hor = HttpOperationResult.new()
-      hor.unauthorized("you are not allowed", 'description', HealthStateType.general(HealthStateScope::GLOBAL))
+      hor.forbidden("you are not allowed", 'description', HealthStateType.general(HealthStateScope::GLOBAL))
       render_operation_result(hor)
     end
 
     def localized_not_found_action
       hor = HttpLocalizedOperationResult.new()
-      hor.notFound(com.thoughtworks.go.i18n.LocalizedMessage::unauthorizedToViewPipeline("mingle"), HealthStateType.general(HealthStateScope::GLOBAL))
+      hor.notFound(com.thoughtworks.go.i18n.LocalizedMessage::forbiddenToViewPipeline("mingle"), HealthStateType.general(HealthStateScope::GLOBAL))
       render_localized_operation_result(hor)
     end
 

--- a/spark/spark-base/src/main/java/com/thoughtworks/go/spark/spring/AbstractAuthenticationHelper.java
+++ b/spark/spark-base/src/main/java/com/thoughtworks/go/spark/spring/AbstractAuthenticationHelper.java
@@ -39,9 +39,9 @@ public abstract class AbstractAuthenticationHelper {
         this.goConfigService = goConfigService;
     }
 
-    protected abstract HaltException renderUnauthorizedResponse();
+    protected abstract HaltException renderForbiddenResponse();
 
-    public void checkUserAnd401(Request req, Response res) {
+    public void checkUserAnd403(Request req, Response res) {
         if (!securityService.isSecurityEnabled()) {
             return;
         }
@@ -51,58 +51,58 @@ public abstract class AbstractAuthenticationHelper {
 
     public void checkNonAnonymousUser(Request req, Response res) {
         if (currentUsername().isAnonymous()) {
-            throw renderUnauthorizedResponse();
+            throw renderForbiddenResponse();
         }
     }
 
-    public void checkAdminUserAnd401(Request req, Response res) {
+    public void checkAdminUserAnd403(Request req, Response res) {
         if (!securityService.isUserAdmin(currentUsername())) {
-            throw renderUnauthorizedResponse();
+            throw renderForbiddenResponse();
         }
     }
 
-    public void checkPipelineGroupOperateUserAnd401(Request request, Response response) {
+    public void checkPipelineGroupOperateUserAnd403(Request request, Response response) {
         if (!securityService.isSecurityEnabled() || securityService.isUserAdmin(currentUsername())) {
             return;
         }
         String groupName = findPipelineGroupName(request);
         if (!securityService.hasOperatePermissionForGroup(currentUserLoginName(), groupName)) {
-            throw renderUnauthorizedResponse();
+            throw renderForbiddenResponse();
         }
     }
 
-    public void checkPipelineGroupAdminUserAnd401(Request request, Response response) {
+    public void checkPipelineGroupAdminUserAnd403(Request request, Response response) {
         if (!securityService.isSecurityEnabled() || securityService.isUserAdmin(currentUsername())) {
             return;
         }
         String groupName = findPipelineGroupName(request);
         if (!securityService.isUserAdminOfGroup(currentUsername(), groupName)) {
-            throw renderUnauthorizedResponse();
+            throw renderForbiddenResponse();
         }
     }
 
-    public void checkAdminUserOrGroupAdminUserAnd401(Request request, Response response) {
+    public void checkAdminUserOrGroupAdminUserAnd403(Request request, Response response) {
         if (!securityService.isSecurityEnabled()) {
             return;
         }
 
         if (!(securityService.isUserAdmin(currentUsername()) || securityService.isUserGroupAdmin(currentUsername()))) {
-            throw renderUnauthorizedResponse();
+            throw renderForbiddenResponse();
         }
 
     }
 
-    public void checkAnyAdminUserAnd401(Request request, Response response) {
+    public void checkAnyAdminUserAnd403(Request request, Response response) {
         if (!securityService.isSecurityEnabled()) {
             return;
         }
 
         if (!(securityService.isUserAdmin(currentUsername()) || securityService.isUserGroupAdmin(currentUsername()) || securityService.isAuthorizedToViewAndEditTemplates(currentUsername()))) {
-            throw renderUnauthorizedResponse();
+            throw renderForbiddenResponse();
         }
     }
 
-    public void checkPipelineViewPermissionsAnd401(Request request, Response response) {
+    public void checkPipelineViewPermissionsAnd403(Request request, Response response) {
         if (!securityService.isSecurityEnabled()) {
             return;
         }
@@ -110,7 +110,7 @@ public abstract class AbstractAuthenticationHelper {
         String pipelineName = request.params("pipeline_name");
 
         if (!hasViewPermissionWorkaroundForNonExistantPipelineBug_4477(pipelineName, currentUsername())) {
-            throw renderUnauthorizedResponse();
+            throw renderForbiddenResponse();
         }
     }
 

--- a/spark/spark-base/src/main/java/com/thoughtworks/go/spark/spring/SPAAuthenticationHelper.java
+++ b/spark/spark-base/src/main/java/com/thoughtworks/go/spark/spring/SPAAuthenticationHelper.java
@@ -37,8 +37,8 @@ public class SPAAuthenticationHelper extends AbstractAuthenticationHelper {
     }
 
     @Override
-    protected HaltException renderUnauthorizedResponse() {
-        return halt(401, HtmlErrorPage.errorPage(401, "Unauthorized"));
+    protected HaltException renderForbiddenResponse() {
+        return halt(403, HtmlErrorPage.errorPage(403, "Forbidden"));
     }
 
 }

--- a/spark/spark-base/src/test/groovy/com/thoughtworks/go/spark/AdminUserSecurity.groovy
+++ b/spark/spark-base/src/test/groovy/com/thoughtworks/go/spark/AdminUserSecurity.groovy
@@ -25,7 +25,7 @@ trait AdminUserSecurity {
     disableSecurity()
 
     makeHttpCall()
-    assertRequestAuthorized()
+    assertRequestAllowed()
   }
 
   @Test
@@ -35,7 +35,7 @@ trait AdminUserSecurity {
 
     makeHttpCall()
 
-    assertRequestNotAuthorized()
+    assertRequestForbidden()
   }
 
   @Test
@@ -44,7 +44,7 @@ trait AdminUserSecurity {
     loginAsUser()
 
     makeHttpCall()
-    assertRequestNotAuthorized()
+    assertRequestForbidden()
   }
 
   @Test
@@ -53,7 +53,7 @@ trait AdminUserSecurity {
     loginAsAdmin()
 
     makeHttpCall()
-    assertRequestAuthorized()
+    assertRequestAllowed()
   }
 
   @Test
@@ -62,6 +62,6 @@ trait AdminUserSecurity {
     loginAsGroupAdmin()
 
     makeHttpCall()
-    assertRequestNotAuthorized()
+    assertRequestForbidden()
   }
 }

--- a/spark/spark-base/src/test/groovy/com/thoughtworks/go/spark/AnyAdminUserSecurity.groovy
+++ b/spark/spark-base/src/test/groovy/com/thoughtworks/go/spark/AnyAdminUserSecurity.groovy
@@ -25,7 +25,7 @@ trait AnyAdminUserSecurity {
     disableSecurity()
 
     makeHttpCall()
-    assertRequestAuthorized()
+    assertRequestAllowed()
   }
 
   @Test
@@ -35,7 +35,7 @@ trait AnyAdminUserSecurity {
 
     makeHttpCall()
 
-    assertRequestNotAuthorized()
+    assertRequestForbidden()
   }
 
   @Test
@@ -44,7 +44,7 @@ trait AnyAdminUserSecurity {
     loginAsUser()
 
     makeHttpCall()
-    assertRequestNotAuthorized()
+    assertRequestForbidden()
   }
 
   @Test
@@ -53,7 +53,7 @@ trait AnyAdminUserSecurity {
     loginAsAdmin()
 
     makeHttpCall()
-    assertRequestAuthorized()
+    assertRequestAllowed()
   }
 
   @Test
@@ -62,7 +62,7 @@ trait AnyAdminUserSecurity {
     loginAsGroupAdmin()
 
     makeHttpCall()
-    assertRequestAuthorized()
+    assertRequestAllowed()
   }
 
   @Test
@@ -71,6 +71,6 @@ trait AnyAdminUserSecurity {
     loginAsTemplateAdmin()
 
     makeHttpCall()
-    assertRequestAuthorized()
+    assertRequestAllowed()
   }
 }

--- a/spark/spark-base/src/test/groovy/com/thoughtworks/go/spark/GroupAdminUserSecurity.groovy
+++ b/spark/spark-base/src/test/groovy/com/thoughtworks/go/spark/GroupAdminUserSecurity.groovy
@@ -25,7 +25,7 @@ trait GroupAdminUserSecurity {
     disableSecurity()
 
     makeHttpCall()
-    assertRequestAuthorized()
+    assertRequestAllowed()
   }
 
   @Test
@@ -35,7 +35,7 @@ trait GroupAdminUserSecurity {
 
     makeHttpCall()
 
-    assertRequestNotAuthorized()
+    assertRequestForbidden()
   }
 
   @Test
@@ -44,7 +44,7 @@ trait GroupAdminUserSecurity {
     loginAsUser()
 
     makeHttpCall()
-    assertRequestNotAuthorized()
+    assertRequestForbidden()
   }
 
   @Test
@@ -53,7 +53,7 @@ trait GroupAdminUserSecurity {
     loginAsAdmin()
 
     makeHttpCall()
-    assertRequestAuthorized()
+    assertRequestAllowed()
   }
 
   @Test
@@ -62,7 +62,7 @@ trait GroupAdminUserSecurity {
     loginAsGroupAdmin()
 
     makeHttpCall()
-    assertRequestAuthorized()
+    assertRequestAllowed()
   }
 
   @Test
@@ -71,6 +71,6 @@ trait GroupAdminUserSecurity {
     loginAsTemplateAdmin()
 
     makeHttpCall()
-    assertRequestNotAuthorized()
+    assertRequestForbidden()
   }
 }

--- a/spark/spark-base/src/test/groovy/com/thoughtworks/go/spark/NonAnonymousUserSecurity.groovy
+++ b/spark/spark-base/src/test/groovy/com/thoughtworks/go/spark/NonAnonymousUserSecurity.groovy
@@ -24,7 +24,7 @@ trait NonAnonymousUserSecurity {
     disableSecurity()
 
     makeHttpCall()
-    assertRequestNotAuthorized()
+    assertRequestForbidden()
   }
 
   @Test
@@ -33,7 +33,7 @@ trait NonAnonymousUserSecurity {
     loginAsAnonymous()
 
     makeHttpCall()
-    assertRequestNotAuthorized()
+    assertRequestForbidden()
   }
 
   @Test
@@ -42,7 +42,7 @@ trait NonAnonymousUserSecurity {
     loginAsAdmin()
 
     makeHttpCall()
-    assertRequestAuthorized()
+    assertRequestAllowed()
   }
 
   @Test
@@ -51,7 +51,7 @@ trait NonAnonymousUserSecurity {
     loginAsUser()
 
     makeHttpCall()
-    assertRequestAuthorized()
+    assertRequestAllowed()
   }
 
 }

--- a/spark/spark-base/src/test/groovy/com/thoughtworks/go/spark/NormalUserSecurity.groovy
+++ b/spark/spark-base/src/test/groovy/com/thoughtworks/go/spark/NormalUserSecurity.groovy
@@ -25,7 +25,7 @@ trait NormalUserSecurity {
     disableSecurity()
 
     makeHttpCall()
-    assertRequestAuthorized()
+    assertRequestAllowed()
   }
 
   @Test
@@ -35,7 +35,7 @@ trait NormalUserSecurity {
 
     makeHttpCall()
 
-    assertRequestNotAuthorized()
+    assertRequestForbidden()
   }
 
   @Test
@@ -44,7 +44,7 @@ trait NormalUserSecurity {
     loginAsUser()
 
     makeHttpCall()
-    assertRequestAuthorized()
+    assertRequestAllowed()
   }
 
 }

--- a/spark/spark-base/src/test/groovy/com/thoughtworks/go/spark/PipelineAccessSecurity.groovy
+++ b/spark/spark-base/src/test/groovy/com/thoughtworks/go/spark/PipelineAccessSecurity.groovy
@@ -25,7 +25,7 @@ trait PipelineAccessSecurity {
     disableSecurity()
 
     makeHttpCall()
-    assertRequestAuthorized()
+    assertRequestAllowed()
   }
 
   @Test
@@ -35,7 +35,7 @@ trait PipelineAccessSecurity {
 
     makeHttpCall()
 
-    assertRequestNotAuthorized()
+    assertRequestForbidden()
   }
 
   @Test
@@ -44,7 +44,7 @@ trait PipelineAccessSecurity {
     loginAsUser()
 
     makeHttpCall()
-    assertRequestNotAuthorized()
+    assertRequestForbidden()
   }
 
   @Test
@@ -53,7 +53,7 @@ trait PipelineAccessSecurity {
     loginAsAdmin()
 
     makeHttpCall()
-    assertRequestAuthorized()
+    assertRequestAllowed()
   }
 
   @Test
@@ -63,7 +63,7 @@ trait PipelineAccessSecurity {
 
     makeHttpCall()
 
-    assertRequestAuthorized()
+    assertRequestAllowed()
   }
 
   abstract String getPipelineName()

--- a/spark/spark-base/src/test/groovy/com/thoughtworks/go/spark/PipelineGroupOperateUserSecurity.groovy
+++ b/spark/spark-base/src/test/groovy/com/thoughtworks/go/spark/PipelineGroupOperateUserSecurity.groovy
@@ -25,7 +25,7 @@ trait PipelineGroupOperateUserSecurity {
     disableSecurity()
 
     makeHttpCall()
-    assertRequestAuthorized()
+    assertRequestAllowed()
   }
 
   @Test
@@ -35,7 +35,7 @@ trait PipelineGroupOperateUserSecurity {
 
     makeHttpCall()
 
-    assertRequestNotAuthorized()
+    assertRequestForbidden()
   }
 
   @Test
@@ -44,7 +44,7 @@ trait PipelineGroupOperateUserSecurity {
     loginAsUser()
 
     makeHttpCall()
-    assertRequestNotAuthorized()
+    assertRequestForbidden()
   }
 
   @Test
@@ -53,7 +53,7 @@ trait PipelineGroupOperateUserSecurity {
     loginAsAdmin()
 
     makeHttpCall()
-    assertRequestAuthorized()
+    assertRequestAllowed()
   }
 
   @Test
@@ -62,7 +62,7 @@ trait PipelineGroupOperateUserSecurity {
     loginAsGroupAdmin(pipelineName)
 
     makeHttpCall()
-    assertRequestAuthorized()
+    assertRequestAllowed()
   }
 
   @Test
@@ -72,7 +72,7 @@ trait PipelineGroupOperateUserSecurity {
 
     makeHttpCall()
 
-    assertRequestNotAuthorized()
+    assertRequestForbidden()
   }
 
   @Test
@@ -81,7 +81,7 @@ trait PipelineGroupOperateUserSecurity {
     loginAsGroupOperateUser(pipelineName)
 
     makeHttpCall()
-    assertRequestAuthorized()
+    assertRequestAllowed()
   }
 
   abstract String getPipelineName()

--- a/spark/spark-spa/src/main/java/com/thoughtworks/go/spark/spa/AgentsControllerDelegate.java
+++ b/spark/spark-spa/src/main/java/com/thoughtworks/go/spark/spa/AgentsControllerDelegate.java
@@ -49,7 +49,7 @@ public class AgentsControllerDelegate implements SparkController {
     @Override
     public void setupRoutes() {
         path(controllerBasePath(), () -> {
-            before("", authenticationHelper::checkUserAnd401);
+            before("", authenticationHelper::checkUserAnd403);
             get("", this::index, engine);
         });
     }

--- a/spark/spark-spa/src/main/java/com/thoughtworks/go/spark/spa/ArtifactStoresDelegate.java
+++ b/spark/spark-spa/src/main/java/com/thoughtworks/go/spark/spa/ArtifactStoresDelegate.java
@@ -48,7 +48,7 @@ public class ArtifactStoresDelegate implements SparkController {
     @Override
     public void setupRoutes() {
         path(controllerBasePath(), () -> {
-            before("", authenticationHelper::checkAdminUserAnd401);
+            before("", authenticationHelper::checkAdminUserAnd403);
             get("", this::index, templateEngine);
         });
     }

--- a/spark/spark-spa/src/main/java/com/thoughtworks/go/spark/spa/AuthConfigsDelegate.java
+++ b/spark/spark-spa/src/main/java/com/thoughtworks/go/spark/spa/AuthConfigsDelegate.java
@@ -46,7 +46,7 @@ public class AuthConfigsDelegate implements SparkController {
     @Override
     public void setupRoutes() {
         path(controllerBasePath(), () -> {
-            before("", authenticationHelper::checkAdminUserAnd401);
+            before("", authenticationHelper::checkAdminUserAnd403);
             get("", this::index, engine);
         });
     }

--- a/spark/spark-spa/src/main/java/com/thoughtworks/go/spark/spa/ElasticProfilesDelegate.java
+++ b/spark/spark-spa/src/main/java/com/thoughtworks/go/spark/spa/ElasticProfilesDelegate.java
@@ -46,7 +46,7 @@ public class ElasticProfilesDelegate implements SparkController {
     @Override
     public void setupRoutes() {
         path(controllerBasePath(), () -> {
-            before("", authenticationHelper::checkAdminUserOrGroupAdminUserAnd401);
+            before("", authenticationHelper::checkAdminUserOrGroupAdminUserAnd403);
             get("", this::index, engine);
         });
     }

--- a/spark/spark-spa/src/main/java/com/thoughtworks/go/spark/spa/NewDashboardDelegate.java
+++ b/spark/spark-spa/src/main/java/com/thoughtworks/go/spark/spa/NewDashboardDelegate.java
@@ -58,7 +58,7 @@ public class NewDashboardDelegate implements SparkController {
     @Override
     public void setupRoutes() {
         path(controllerBasePath(), () -> {
-            before("", authenticationHelper::checkUserAnd401);
+            before("", authenticationHelper::checkUserAnd403);
             get("", this::index, engine);
         });
     }

--- a/spark/spark-spa/src/main/java/com/thoughtworks/go/spark/spa/PluginsDelegate.java
+++ b/spark/spark-spa/src/main/java/com/thoughtworks/go/spark/spa/PluginsDelegate.java
@@ -49,7 +49,7 @@ public class PluginsDelegate implements SparkController {
     @Override
     public void setupRoutes() {
         path(controllerBasePath(), () -> {
-            before("", authenticationHelper::checkAdminUserOrGroupAdminUserAnd401);
+            before("", authenticationHelper::checkAdminUserOrGroupAdminUserAnd403);
             get("", this::index, engine);
         });
     }

--- a/spark/spark-spa/src/main/java/com/thoughtworks/go/spark/spa/RolesControllerDelegate.java
+++ b/spark/spark-spa/src/main/java/com/thoughtworks/go/spark/spa/RolesControllerDelegate.java
@@ -46,7 +46,7 @@ public class RolesControllerDelegate implements SparkController {
     @Override
     public void setupRoutes() {
         path(controllerBasePath(), () -> {
-            before("", authenticationHelper::checkAdminUserAnd401);
+            before("", authenticationHelper::checkAdminUserAnd403);
             get("", this::index, engine);
         });
     }

--- a/spark/spark-spa/src/test/groovy/com/thoughtworks/go/spark/spa/SecurityTestTrait.groovy
+++ b/spark/spark-spa/src/test/groovy/com/thoughtworks/go/spark/spa/SecurityTestTrait.groovy
@@ -46,7 +46,7 @@ trait SecurityTestTrait {
 
   abstract void makeHttpCall()
 
-  def assertRequestAuthorized() {
+  def assertRequestAllowed() {
     verify(controller)."${controllerMethodUnderTest}"(any(), any())
 
     ((MockHttpServletResponseAssert) assertThatResponse())
@@ -55,12 +55,12 @@ trait SecurityTestTrait {
       .hasBody("rendered - foo/bar.vm with message ${reachedControllerMessage}")
   }
 
-  def assertRequestNotAuthorized() {
+  def assertRequestForbidden() {
     verify(controller, never())."${controllerMethodUnderTest}"(any(), any())
 
     ((MockHttpServletResponseAssert) assertThatResponse())
       .hasContentType("text/html")
-      .hasStatus(401)
-      .hasBody(HtmlErrorPage.errorPage(401, "Unauthorized"))
+      .hasStatus(403)
+      .hasBody(HtmlErrorPage.errorPage(403, "Forbidden"))
   }
 }


### PR DESCRIPTION
1. Authentication failure
All authentication filter will return `401(UNAUTHORIZED)` in case of any failure while authenticating user.
Read more [RFC#401](https://tools.ietf.org/html/rfc7235#section-3.1)

2. User permission check at controller level and in (`AuthorizeFilterChain`)
All controller will now return `403(FORBIDDEN)` in case of a user is not authorized to access the specified resource
Read more [RFC#403](https://tools.ietf.org/html/rfc7231#section-6.5.3)