### PR TITLE
Fix spaces in template message in quick edit view

### DIFF
--- a/server/webapp/WEB-INF/rails.new/webpack/views/pipeline_configs/pipeline_config_widget.js.msx
+++ b/server/webapp/WEB-INF/rails.new/webpack/views/pipeline_configs/pipeline_config_widget.js.msx
@@ -165,11 +165,10 @@ const PipelineConfigWidget = function (options) {
       const pipelineFlowWidget = function () {
         if (!s.isBlank(vnode.state.pipeline().template())) {
           return (
-            <f.info>{['Pipeline :', "'", vnode.state.pipeline().name(), "'", 'uses template :', "'", vnode.state.pipeline().template(), "'",
-              '. Template editing is not yet supported. '].join(' ')} Click
-              <f.link href={["/go/admin/templates/", vnode.state.pipeline().template(), "/general"].join('')}>here
-              </f.link>
-              to edit template.</f.info>
+            <f.info>
+              {`Pipeline: '${vnode.state.pipeline().name()}' uses template: '${vnode.state.pipeline().template()}'. Template editing is not yet supported. `}
+              Click <f.link href={`/go/admin/templates/${vnode.state.pipeline().template()}/general`}>here</f.link> to edit the template.
+            </f.info>
           );
         }
 


### PR DESCRIPTION
This annoying thing:

![screen shot 2018-05-10 at 16 03 10](https://user-images.githubusercontent.com/6024038/39865788-aaa451ec-546b-11e8-8ba0-97694fd57897.png)
