### PR TITLE
Change tag of console log in ArtifactRequestProcessor to Info and Error

### DIFF
--- a/common/src/main/java/com/thoughtworks/go/remote/work/artifact/ArtifactRequestProcessor.java
+++ b/common/src/main/java/com/thoughtworks/go/remote/work/artifact/ArtifactRequestProcessor.java
@@ -21,12 +21,11 @@ import com.thoughtworks.go.plugin.api.response.DefaultGoApiResponse;
 import com.thoughtworks.go.plugin.api.response.GoApiResponse;
 import com.thoughtworks.go.plugin.infra.GoPluginApiRequestProcessor;
 import com.thoughtworks.go.plugin.infra.plugininfo.GoPluginDescriptor;
+import com.thoughtworks.go.util.command.TaggedStreamConsumer;
 import com.thoughtworks.go.work.GoPublisher;
 
 import java.util.List;
 
-import static com.thoughtworks.go.util.command.TaggedStreamConsumer.PUBLISH;
-import static com.thoughtworks.go.util.command.TaggedStreamConsumer.PUBLISH_ERR;
 import static java.lang.String.format;
 import static java.util.Arrays.asList;
 
@@ -54,10 +53,10 @@ public class ArtifactRequestProcessor implements GoPluginApiRequestProcessor {
         final String message = format("[%s] %s", pluginDescriptor.id(), consoleLogMessage.getMessage());
         switch (consoleLogMessage.getLogLevel()) {
             case INFO:
-                goPublisher.taggedConsumeLine(PUBLISH, message);
+                goPublisher.taggedConsumeLine(TaggedStreamConsumer.OUT, message);
                 break;
             case ERROR:
-                goPublisher.taggedConsumeLine(PUBLISH_ERR, message);
+                goPublisher.taggedConsumeLine(TaggedStreamConsumer.ERR, message);
                 break;
             default:
                 return DefaultGoApiResponse.error(format("Unsupported log level `%s`.", consoleLogMessage.getLogLevel()));

--- a/common/src/test/java/com/thoughtworks/go/remote/work/ArtifactRequestProcessorTest.java
+++ b/common/src/test/java/com/thoughtworks/go/remote/work/ArtifactRequestProcessorTest.java
@@ -24,8 +24,8 @@ import org.junit.Before;
 import org.junit.Test;
 
 import static com.thoughtworks.go.remote.work.artifact.ArtifactRequestProcessor.Request.CONSOLE_LOG;
-import static com.thoughtworks.go.util.command.TaggedStreamConsumer.PUBLISH;
-import static com.thoughtworks.go.util.command.TaggedStreamConsumer.PUBLISH_ERR;
+import static com.thoughtworks.go.util.command.TaggedStreamConsumer.ERR;
+import static com.thoughtworks.go.util.command.TaggedStreamConsumer.OUT;
 import static org.mockito.Mockito.*;
 
 public class ArtifactRequestProcessorTest {
@@ -53,7 +53,7 @@ public class ArtifactRequestProcessorTest {
 
         artifactRequestProcessor.process(descriptor, request);
 
-        verify(goPublisher, times(1)).taggedConsumeLine(PUBLISH_ERR, "[cd.go.artifact.docker] Error while pushing docker image to registry: foo.");
+        verify(goPublisher, times(1)).taggedConsumeLine(ERR, "[cd.go.artifact.docker] Error while pushing docker image to registry: foo.");
     }
 
     @Test
@@ -62,6 +62,6 @@ public class ArtifactRequestProcessorTest {
 
         artifactRequestProcessor.process(descriptor, request);
 
-        verify(goPublisher, times(1)).taggedConsumeLine(PUBLISH, "[cd.go.artifact.docker] Pushing docker image to registry: foo.");
+        verify(goPublisher, times(1)).taggedConsumeLine(OUT, "[cd.go.artifact.docker] Pushing docker image to registry: foo.");
     }
 }


### PR DESCRIPTION
Issue: (#4736)

The request processor is used by the fetch task as well, so it is not appropriate to use the publish tag here.

Screenshot of a sample fetch artifact:
![screen shot 2018-05-14 at 15 53 36](https://user-images.githubusercontent.com/6024038/39992156-80a9dc3c-578f-11e8-8c68-318f97c8725b.png)

Screenshot of a sample publish artifact:
![screen shot 2018-05-14 at 15 53 56](https://user-images.githubusercontent.com/6024038/39992169-873ed778-578f-11e8-8e5e-f51aa3675df0.png)
