### PR TITLE
Represent only the builtin artifacts and fetch of builtin artifacts in pipeline config API v3, v4, v5

### DIFF
--- a/common/src/test/java/com/thoughtworks/go/domain/ArtifactConfigsTest.java
+++ b/common/src/test/java/com/thoughtworks/go/domain/ArtifactConfigsTest.java
@@ -154,7 +154,7 @@ public class ArtifactConfigsTest {
         allConfigs.add(new PluggableArtifactConfig("s3", "cd.go.s3"));
         allConfigs.add(new PluggableArtifactConfig("docker", "cd.go.docker"));
 
-        final List<BuildArtifactConfig> artifactConfigs = allConfigs.getArtifactConfigs();
+        final List<BuiltinArtifactConfig> artifactConfigs = allConfigs.getBuiltInArtifactConfigs();
 
         assertThat(artifactConfigs, hasSize(2));
         assertThat(artifactConfigs, containsInAnyOrder(

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/ArtifactConfigs.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/ArtifactConfigs.java
@@ -105,11 +105,11 @@ public class ArtifactConfigs extends BaseCollection<ArtifactConfig> implements V
         }
     }
 
-    public List<BuildArtifactConfig> getArtifactConfigs() {
-        final List<BuildArtifactConfig> artifactConfigs = new ArrayList<>();
+    public List<BuiltinArtifactConfig> getBuiltInArtifactConfigs() {
+        final List<BuiltinArtifactConfig> artifactConfigs = new ArrayList<>();
         for (ArtifactConfig artifactConfig : this) {
-            if (artifactConfig instanceof BuildArtifactConfig) {
-                artifactConfigs.add((BuildArtifactConfig) artifactConfig);
+            if (artifactConfig instanceof BuiltinArtifactConfig) {
+                artifactConfigs.add((BuiltinArtifactConfig) artifactConfig);
             }
         }
         return artifactConfigs;

--- a/config/config-server/src/test/java/com/thoughtworks/go/config/MagicalGoConfigXmlLoaderTest.java
+++ b/config/config-server/src/test/java/com/thoughtworks/go/config/MagicalGoConfigXmlLoaderTest.java
@@ -365,7 +365,7 @@ public class MagicalGoConfigXmlLoaderTest {
         GoConfigHolder holder = ConfigMigrator.loadWithMigration(toInputStream(configWithArtifactSourceAs("")));
         CruiseConfig cruiseConfig = holder.config;
         JobConfig plan = cruiseConfig.jobConfigByName("pipeline", "stage", "job", true);
-        assertThat(plan.artifactConfigs().getArtifactConfigs().get(0).getSource(), is("*"));
+        assertThat(plan.artifactConfigs().getBuiltInArtifactConfigs().get(0).getSource(), is("*"));
     }
 
     @Test
@@ -373,7 +373,7 @@ public class MagicalGoConfigXmlLoaderTest {
         GoConfigHolder holder = ConfigMigrator.loadWithMigration(toInputStream(configWithArtifactSourceAs(" \t ")));
         CruiseConfig cruiseConfig = holder.config;
         JobConfig plan = cruiseConfig.jobConfigByName("pipeline", "stage", "job", true);
-        assertThat(plan.artifactConfigs().getArtifactConfigs().get(0).getSource(), is("*"));
+        assertThat(plan.artifactConfigs().getBuiltInArtifactConfigs().get(0).getSource(), is("*"));
     }
 
     @Test
@@ -381,7 +381,7 @@ public class MagicalGoConfigXmlLoaderTest {
         GoConfigHolder holder = ConfigMigrator.loadWithMigration(toInputStream(configWithArtifactSourceAs("t ")));
         CruiseConfig cruiseConfig = holder.config;
         JobConfig plan = cruiseConfig.jobConfigByName("pipeline", "stage", "job", true);
-        assertThat(plan.artifactConfigs().getArtifactConfigs().get(0).getSource(), is("t "));
+        assertThat(plan.artifactConfigs().getBuiltInArtifactConfigs().get(0).getSource(), is("t "));
     }
 
     @Test

--- a/server/src/test-integration/java/com/thoughtworks/go/config/GoConfigMigrationIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/config/GoConfigMigrationIntegrationTest.java
@@ -52,7 +52,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
-import org.mockito.Matchers;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
@@ -403,14 +402,14 @@ public class GoConfigMigrationIntegrationTest {
         ArtifactConfigs artifactConfigs = cruiseConfig.getAllPipelineConfigs().get(0).getStage(new CaseInsensitiveString("mingle")).getJobs().getJob(
                 new CaseInsensitiveString("bluemonkeybutt")).artifactConfigs();
 
-        assertEquals("from1", artifactConfigs.getArtifactConfigs().get(0).getSource());
-        assertEquals(artifactConfigs.getArtifactConfigs().get(0).getDestination(), "");
-        assertEquals("from2", artifactConfigs.getArtifactConfigs().get(1).getSource());
-        assertEquals("to2", artifactConfigs.getArtifactConfigs().get(1).getDestination());
-        assertEquals("from3", artifactConfigs.getArtifactConfigs().get(2).getSource());
-        assertEquals(artifactConfigs.getArtifactConfigs().get(2).getDestination(), "");
-        assertEquals("from4", artifactConfigs.getArtifactConfigs().get(3).getSource());
-        assertEquals("to4", artifactConfigs.getArtifactConfigs().get(3).getDestination());
+        assertEquals("from1", artifactConfigs.getBuiltInArtifactConfigs().get(0).getSource());
+        assertEquals(artifactConfigs.getBuiltInArtifactConfigs().get(0).getDestination(), "");
+        assertEquals("from2", artifactConfigs.getBuiltInArtifactConfigs().get(1).getSource());
+        assertEquals("to2", artifactConfigs.getBuiltInArtifactConfigs().get(1).getDestination());
+        assertEquals("from3", artifactConfigs.getBuiltInArtifactConfigs().get(2).getSource());
+        assertEquals(artifactConfigs.getBuiltInArtifactConfigs().get(2).getDestination(), "");
+        assertEquals("from4", artifactConfigs.getBuiltInArtifactConfigs().get(3).getSource());
+        assertEquals("to4", artifactConfigs.getBuiltInArtifactConfigs().get(3).getDestination());
     }
 
 

--- a/server/webapp/WEB-INF/rails.new/app/presenters/api_v3/shared/stages/job_representer.rb
+++ b/server/webapp/WEB-INF/rails.new/app/presenters/api_v3/shared/stages/job_representer.rb
@@ -102,7 +102,7 @@ module ApiV3
         end
 
         def artifacts
-          job.artifactConfigs
+          job.artifactConfigs.getBuiltInArtifactConfigs()
         end
 
         def artifacts=(value)

--- a/server/webapp/WEB-INF/rails.new/app/presenters/api_v3/shared/stages/job_representer.rb
+++ b/server/webapp/WEB-INF/rails.new/app/presenters/api_v3/shared/stages/job_representer.rb
@@ -126,7 +126,7 @@ module ApiV3
         end
 
         def tasks
-          job.getTasks
+          job.getTasks.select {|task| !task.instance_of? FetchPluggableArtifactTask}
         end
 
         def tasks=(value)

--- a/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/shared/stages/job_representer.rb
+++ b/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/shared/stages/job_representer.rb
@@ -102,7 +102,7 @@ module ApiV4
         end
 
         def artifacts
-          job.artifactConfigs
+          job.artifactConfigs.getBuiltInArtifactConfigs()
         end
 
         def artifacts=(value)

--- a/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/shared/stages/job_representer.rb
+++ b/server/webapp/WEB-INF/rails.new/app/presenters/api_v4/shared/stages/job_representer.rb
@@ -126,7 +126,7 @@ module ApiV4
         end
 
         def tasks
-          job.getTasks
+          job.getTasks.select {|task| !task.instance_of? FetchPluggableArtifactTask}
         end
 
         def tasks=(value)

--- a/server/webapp/WEB-INF/rails.new/app/presenters/api_v5/shared/stages/job_representer.rb
+++ b/server/webapp/WEB-INF/rails.new/app/presenters/api_v5/shared/stages/job_representer.rb
@@ -126,7 +126,7 @@ module ApiV5
         end
 
         def tasks
-          job.getTasks
+          job.getTasks.select {|task| !task.instance_of? FetchPluggableArtifactTask}
         end
 
         def tasks=(value)

--- a/server/webapp/WEB-INF/rails.new/app/presenters/api_v5/shared/stages/job_representer.rb
+++ b/server/webapp/WEB-INF/rails.new/app/presenters/api_v5/shared/stages/job_representer.rb
@@ -102,7 +102,7 @@ module ApiV5
         end
 
         def artifacts
-          job.artifactConfigs
+          job.artifactConfigs.getBuiltInArtifactConfigs()
         end
 
         def artifacts=(value)


### PR DESCRIPTION
These versions of the API broke while accessing a pipeline which was configured to publish or fetch external artifacts.  (https://github.com/gocd/gocd/issues/4608)

The changes made in v3 and v4 for job representer is applicable to template config API v3 and v4.  