### PR TITLE
Remove the quick edit button.

### DIFF
--- a/server/src/main/resources/available.toggles
+++ b/server/src/main/resources/available.toggles
@@ -9,7 +9,7 @@
       {
          "key": "pipeline_config_single_page_app_key",
          "description": "Enables the pipeline config single page application. Default: enabled.",
-         "value": true
+         "value": false
       },
       {
          "key": "quick_edit_page_toggle_key",

--- a/server/webapp/WEB-INF/rails.new/app/views/layouts/pipelines/details.html.erb
+++ b/server/webapp/WEB-INF/rails.new/app/views/layouts/pipelines/details.html.erb
@@ -32,9 +32,6 @@
               <h3 class="title entity_title">
                 <%= link_to @pipeline.name(), pipeline_edit_path(:pipeline_name => params[:pipeline_name], :current_tab => 'general'), :class => 'wrapped_word' %>
               </h3>
-              <% if is_pipeline_config_spa_enabled? %>
-                  <%= link_to 'Quick Edit', edit_admin_pipeline_config_path(:pipeline_name => params[:pipeline_name]), :class => 'toggle-new-view' %>
-              <% end %>
             </div>
             <div class="sub_tabs_container <%= params[:current_tab] -%>">
               <%= render :partial => "admin/pipelines/pipeline_navigation", :locals => {:scope => {:pipeline => @pipeline}} %>

--- a/server/webapp/WEB-INF/rails.new/spec/controllers/admin/pipeline_configs_controller_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/controllers/admin/pipeline_configs_controller_spec.rb
@@ -95,6 +95,7 @@ describe Admin::PipelineConfigsController do
       allow(@user_service).to receive(:allUsernames)
       allow(@user_service).to receive(:allRoleNames)
       allow(controller).to receive(:populate_config_validity)
+      allow(controller).to receive(:check_feature_toggle)
       allow(controller).to receive(:check_pipeline_group_admin_user_and_403)
       allow(@go_config_service).to receive(:getAllResources).and_return([])
     end


### PR DESCRIPTION
* For most places, the link to the quick edit page is based on 2 toggles - pipeline_config_single_page_app_key and quick_edit_page_toggle_key. Since quick_edit_page_toggle_key has been false, quick edit page has never been shown by default.
* Disabled the pipeline_config_single_page_app_key.

@gocd/committers - For build.go.cd, this toggle can be enabled. 