### PR TITLE
Change message for the tests tab in stage detail page.

### DIFF
--- a/server/webapp/WEB-INF/rails.new/app/views/stages/_non_passing_tests.html.erb
+++ b/server/webapp/WEB-INF/rails.new/app/views/stages/_non_passing_tests.html.erb
@@ -3,7 +3,7 @@
         <span class="error"><%= @failing_tests_error_message %></span>
     <% elsif @failing_tests.numberOfTests() == 0 %>
         <h3>
-            <span class="message">There are tests configured in this stage but could not compute results.</span>
+            <span class="message">There are tests configured in this stage but could not compute results. Check if Shine is enabled.</span>
         </h3>
     <% elsif @stage.getState().equals(com.thoughtworks.go.domain.StageState::Passed) %>
         <h3>

--- a/server/webapp/WEB-INF/rails.new/spec/views/stages/stage_html_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/views/stages/stage_html_spec.rb
@@ -553,7 +553,7 @@ describe 'stages/stage.html.erb' do
         render
 
         Capybara.string(response.body).find(".non_passing_tests").tap do |f|
-          expect(f).to have_selector "h3 .message", :text => "There are tests configured in this stage but could not compute results."
+          expect(f).to have_selector "h3 .message", :text => "There are tests configured in this stage but could not compute results. Check if Shine is enabled."
         end
 
         expect(response).to_not have_selector(".non_passing_tests .failing_pipeline")


### PR DESCRIPTION
* This is to inform users that the tests may not be shown at the stage level if shine is disabled.