### PR TITLE
Revert shine enabled check and message on the tests tab.

### DIFF
--- a/server/src/test-integration/java/com/thoughtworks/go/server/dao/sparql/ShineDaoIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/dao/sparql/ShineDaoIntegrationTest.java
@@ -88,9 +88,6 @@ public class ShineDaoIntegrationTest {
     @Rule
     public final TemporaryFolder temporaryFolder = new TemporaryFolder();
 
-    @Rule
-    public final EnvironmentVariables environmentVariables = new EnvironmentVariables();
-
     private StubGoURLRepository goURLRepository;
 
     private GoConfigFileHelper configHelper = new GoConfigFileHelper();
@@ -108,12 +105,11 @@ public class ShineDaoIntegrationTest {
 
         String artifactsRoot = tempFolder.getAbsolutePath();
         stageStorage.clear();
-        environmentVariables.set("SHINE_ENABLED", "Y");
         StageResourceImporter importer = new StageResourceImporter(artifactsRoot, xmlApiService, stageService, pipelineHistoryService,systemEnvironment);
 
         LazyStageGraphLoader graphLoader = new LazyStageGraphLoader(importer, stageStorage);
         StagesQuery stagesQuery = new StagesQuery(graphLoader, stagesQueryCache);
-        shineDao = new ShineDao(stagesQuery, stageService, systemEnvironment);
+        shineDao = new ShineDao(stagesQuery, stageService);
         goURLRepository = new StubGoURLRepository(artifactsRoot);
 
         failureSetup = new TestFailureSetup(materialRepository, dbHelper, pipelineTimeline, configHelper, transactionTemplate);
@@ -124,7 +120,6 @@ public class ShineDaoIntegrationTest {
     }
 
     @After public void tearDown() throws Exception {
-        environmentVariables.set("SHINE_ENABLED", null);
         stagesQueryCache.clear();
         dbHelper.onTearDown();
     }

--- a/server/webapp/WEB-INF/applicationContext-shine-server.xml
+++ b/server/webapp/WEB-INF/applicationContext-shine-server.xml
@@ -43,7 +43,6 @@
     <bean id="shineDao" class="com.thoughtworks.go.server.dao.sparql.ShineDao" lazy-init="false">
         <constructor-arg ref="stagesQuery" index="0"/>
         <constructor-arg ref="stageService" index="1"/>
-        <constructor-arg ref="systemEnvironment" index="2"/>
     </bean>
 
 

--- a/server/webapp/WEB-INF/rails.new/app/views/stages/_non_passing_tests.html.erb
+++ b/server/webapp/WEB-INF/rails.new/app/views/stages/_non_passing_tests.html.erb
@@ -3,7 +3,7 @@
         <span class="error"><%= @failing_tests_error_message %></span>
     <% elsif @failing_tests.numberOfTests() == 0 %>
         <h3>
-            <span class="message">There are tests configured in this stage but could not compute results. Check if Shine is enabled.</span>
+            <span class="message">There are tests configured in this stage but could not compute results.</span>
         </h3>
     <% elsif @stage.getState().equals(com.thoughtworks.go.domain.StageState::Passed) %>
         <h3>

--- a/server/webapp/WEB-INF/rails.new/spec/views/stages/stage_html_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/views/stages/stage_html_spec.rb
@@ -553,7 +553,7 @@ describe 'stages/stage.html.erb' do
         render
 
         Capybara.string(response.body).find(".non_passing_tests").tap do |f|
-          expect(f).to have_selector "h3 .message", :text => "There are tests configured in this stage but could not compute results. Check if Shine is enabled."
+          expect(f).to have_selector "h3 .message", :text => "There are tests configured in this stage but could not compute results."
         end
 
         expect(response).to_not have_selector(".non_passing_tests .failing_pipeline")


### PR DESCRIPTION
* Upon clicking the Tests tab on the stage detail page, shine computes the test results etc via the LazyStageGraphLoader.
* This behaviour is left as is intentionally as the SHINE_ENABLED check was introduced only for checking whether the shine db must be updated on stage change notification alone.