### PR TITLE
Passing shine testSuiteName and testName as query string instead of path params to fetch failed test stacktrace

### DIFF
--- a/server/webapp/WEB-INF/rails.new/app/controllers/failures_controller.rb
+++ b/server/webapp/WEB-INF/rails.new/app/controllers/failures_controller.rb
@@ -1,5 +1,5 @@
 ##########################GO-LICENSE-START################################
-# Copyright 2014 ThoughtWorks, Inc.
+# Copyright 2018 ThoughtWorks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,7 +18,6 @@ class FailuresController < ApplicationController
   include ParamEncoder
 
   layout false
-  decode_params :suite_name, :test_name, :only => 'show'
 
   def show
     job_id = JobIdentifier.new(StageIdentifier.new(params[:pipeline_name], params[:pipeline_counter].to_i, params[:stage_name], params[:stage_counter]), params[:job_name])

--- a/server/webapp/WEB-INF/rails.new/app/helpers/failures_helper.rb
+++ b/server/webapp/WEB-INF/rails.new/app/helpers/failures_helper.rb
@@ -1,5 +1,5 @@
 ##########################GO-LICENSE-START################################
-# Copyright 2014 ThoughtWorks, Inc.
+# Copyright 2018 ThoughtWorks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -36,6 +36,6 @@ LINK
   def failure_details_path job_id, suite_name, test_name
     failure_details_internal_path(:pipeline_name => job_id.getPipelineName(), :pipeline_counter => job_id.getPipelineCounter(), :stage_name => job_id.getStageName(),
                                   :stage_counter => job_id.getStageCounter(), :job_name => job_id.getBuildName(),
-                                  :suite_name => CGI.escape(enc(suite_name)), :test_name => CGI.escape(enc(test_name)))
+                                  :suite_name => suite_name, :test_name => test_name)
   end
 end

--- a/server/webapp/WEB-INF/rails.new/config/routes.rb
+++ b/server/webapp/WEB-INF/rails.new/config/routes.rb
@@ -1,5 +1,5 @@
 ##########################GO-LICENSE-START################################
-# Copyright 2017 ThoughtWorks, Inc.
+# Copyright 2018 ThoughtWorks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -183,7 +183,7 @@ Go::Application.routes.draw do
     get ':pipeline_name/timeline/:page' => 'comparison#timeline', constraints: {pipeline_name: PIPELINE_NAME_FORMAT}, as: :compare_pipelines_timeline
   end
 
-  get 'failures/:pipeline_name/:pipeline_counter/:stage_name/:stage_counter/:job_name/:suite_name/:test_name' => 'failures#show', constraints: STAGE_LOCATOR_CONSTRAINTS, :no_layout => true, as: :failure_details_internal
+  get 'failures/:pipeline_name/:pipeline_counter/:stage_name/:stage_counter/:job_name' => 'failures#show', constraints: STAGE_LOCATOR_CONSTRAINTS, :no_layout => true, as: :failure_details_internal
 
   get 'server/messages.json' => 'server#messages', :format => "json", as: :global_message
 

--- a/server/webapp/WEB-INF/rails.new/spec/controllers/failures_controller_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/controllers/failures_controller_spec.rb
@@ -1,5 +1,5 @@
 ##########################GO-LICENSE-START################################
-# Copyright 2014 ThoughtWorks, Inc.
+# Copyright 2018 ThoughtWorks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -27,14 +27,14 @@ describe FailuresController do
   end
 
   it "should resolve the route to show action" do
-    expect({:get => "/failures/foo_pipeline/10/bar_stage/5/baz_job/quux_suite/bang_test"}).to route_to(:controller => "failures", :action => "show", :pipeline_name => "foo_pipeline", :pipeline_counter => "10", :stage_name => "bar_stage", :stage_counter => "5", :job_name => "baz_job", :suite_name => "quux_suite", :test_name => "bang_test", :no_layout => true)
+    expect({:get => "/failures/foo_pipeline/10/bar_stage/5/baz_job?suite_name=quux_suite&test_name=bang_test"}).to route_to(:controller => "failures", :action => "show", :pipeline_name => "foo_pipeline", :pipeline_counter => "10", :stage_name => "bar_stage", :stage_counter => "5", :job_name => "baz_job", :suite_name => "quux_suite", :test_name => "bang_test", :no_layout => true)
   end
 
   it "should load failure message and stack trace" do
     expect(@failure_service).to receive(:failureDetailsFor).with(@job_id, 'suite_name', 'test_name', @user, an_instance_of(HttpLocalizedOperationResult)).and_return(@failure_details)
     #suite_name and test_name are ParamEncode#enc'ed because they can potentially have special characters like dot(.) or slash(/) etc.
 
-    get :show, :pipeline_name => "pipeline_foo", :pipeline_counter => "12", :stage_name => "stage_bar", :stage_counter => "34", :job_name => "build_dev", :suite_name => "c3VpdGVfbmFtZQ%3D%3D%0A", :test_name => "dGVzdF9uYW1l%0A", :no_layout => true
+    get :show, :pipeline_name => "pipeline_foo", :pipeline_counter => "12", :stage_name => "stage_bar", :stage_counter => "34", :job_name => "build_dev", :suite_name => "suite_name", :test_name => "test_name", :no_layout => true
 
     expect(assigns[:failure_details]).to eq(@failure_details)
     assert_template layout: false

--- a/server/webapp/WEB-INF/rails.new/spec/helpers/failures_helper_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/helpers/failures_helper_spec.rb
@@ -1,5 +1,5 @@
 ##########################GO-LICENSE-START################################
-# Copyright 2014 ThoughtWorks, Inc.
+# Copyright 2018 ThoughtWorks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -46,7 +46,7 @@ describe FailuresHelper do
 
     it "should render anchor and js for failed_test details" do
       job_id = JobIdentifier.new("pipeline1", 1234, "pip-label-1", "defaultStage", "5678", "defaultJob")
-      expect(failure_details_link(job_id, "cruise.testing.JUnit", "a")).to eq(%Q{<a href='/failures/pipeline1/1234/defaultStage/5678/defaultJob/Y3J1aXNlLnRlc3RpbmcuSlVuaXQ%253D%250A/YQ%253D%253D%250A' id="for_fbh_failure_details_pipeline1/1234/defaultStage/5678/defaultJob_cruise.testing.JUnit_a" class="fbh_failure_detail_button" title='View failure details'>[Trace]</a>\n})
+      expect(failure_details_link(job_id, "cruise.testing.JUnit", "a")).to eq(%Q{<a href='/failures/pipeline1/1234/defaultStage/5678/defaultJob?suite_name=cruise.testing.JUnit&test_name=a' id="for_fbh_failure_details_pipeline1/1234/defaultStage/5678/defaultJob_cruise.testing.JUnit_a" class="fbh_failure_detail_button" title='View failure details'>[Trace]</a>\n})
     end
   end
 end


### PR DESCRIPTION
Link to fetch `stacktrace` for a failed test from a stage-details page as mentioned below

https://github.com/gocd/gocd/blob/660a2d6915e13aca97f7aa1fa89350ab253627bc/server/webapp/WEB-INF/rails.new/app/helpers/failures_helper.rb#L36-L40

Where `CGI.escape(enc(suite_name))` generate the encoded sute_name `Y3J1aXNlLnRlc3RpbmcuSlVuaXQ%253D%250A` which contains "%25"

Spring-4.3.x is not allowing `%25` as a [path param](https://github.com/spring-projects/spring-security/blob/master/web/src/main/java/org/springframework/security/web/firewall/StrictHttpFirewall.java#L104) and fetch `stacktrace` was stated failing.