### PR TITLE
Remove 'QUICKER_DASHBOARD_KEY' toggle

### DIFF
--- a/api/api-dashboard-v2/src/main/java/com/thoughtworks/go/apiv2/dashboard/DashboardControllerDelegate.java
+++ b/api/api-dashboard-v2/src/main/java/com/thoughtworks/go/apiv2/dashboard/DashboardControllerDelegate.java
@@ -42,7 +42,6 @@ import static spark.Spark.*;
 public class DashboardControllerDelegate extends ApiController {
 
     private static final String BEING_PROCESSED = MessageJson.create("Dashboard is being processed, this may take a few seconds. Please check back later.");
-    private static final String FEATURE_NOT_ENABLED = MessageJson.create("The quicker dashboard feature has not been enabled!");
 
     private final PipelineSelectionsService pipelineSelectionsService;
     private final GoDashboardService goDashboardService;
@@ -72,10 +71,6 @@ public class DashboardControllerDelegate extends ApiController {
     }
 
     public Object index(Request request, Response response) throws IOException {
-        if (goDashboardService.isFeatureToggleDisabled()) {
-            response.status(424);
-            return FEATURE_NOT_ENABLED;
-        }
         if (!goDashboardService.hasEverLoadedCurrentState()) {
             response.status(202);
             return BEING_PROCESSED;

--- a/api/api-dashboard-v2/src/test/groovy/com/thoughtworks/go/apiv2/dashboard/DashboardControllerDelegateTest.groovy
+++ b/api/api-dashboard-v2/src/test/groovy/com/thoughtworks/go/apiv2/dashboard/DashboardControllerDelegateTest.groovy
@@ -138,13 +138,11 @@ class DashboardControllerDelegateTest implements SecurityServiceTrait, Controlle
 
       @Test
       void 'should return 202 no content when dashboard is not processed (on server start)'() {
-        when(goDashboardService.isFeatureToggleDisabled()).thenReturn(false)
         when(goDashboardService.hasEverLoadedCurrentState()).thenReturn(false)
 
         loginAsUser()
         getWithApiHeader(controller.controllerPath())
 
-        verify(goDashboardService).isFeatureToggleDisabled()
         verify(goDashboardService).hasEverLoadedCurrentState()
         verifyNoMoreInteractions(pipelineSelectionsService, goDashboardService)
 
@@ -152,21 +150,6 @@ class DashboardControllerDelegateTest implements SecurityServiceTrait, Controlle
           .isAccepted()
           .hasContentType(controller.mimeType)
           .hasJsonMessage("Dashboard is being processed, this may take a few seconds. Please check back later.")
-      }
-
-      @Test
-      void 'should return 424 when dashboard is disabled'() {
-        when(goDashboardService.isFeatureToggleDisabled()).thenReturn(true)
-
-        loginAsUser()
-        getWithApiHeader(controller.controllerPath())
-        verify(goDashboardService).isFeatureToggleDisabled()
-        verifyNoMoreInteractions(pipelineSelectionsService, goDashboardService)
-
-        assertThatResponse()
-          .isFailedDependency()
-          .hasContentType(controller.mimeType)
-          .hasJsonMessage("The quicker dashboard feature has not been enabled!")
       }
     }
 

--- a/server/src/main/java/com/thoughtworks/go/server/SparkOrRailsToggle.java
+++ b/server/src/main/java/com/thoughtworks/go/server/SparkOrRailsToggle.java
@@ -24,8 +24,7 @@ import javax.servlet.http.HttpServletResponse;
 public class SparkOrRailsToggle {
 
     public void oldOrNewDashboard(HttpServletRequest request, HttpServletResponse response) {
-
-        if (Toggles.isToggleOn(Toggles.QUICKER_DASHBOARD_KEY) && Toggles.isToggleOn(Toggles.NEW_DASHBOARD_PAGE_DEFAULT)) {
+        if (Toggles.isToggleOn(Toggles.NEW_DASHBOARD_PAGE_DEFAULT)) {
             request.setAttribute("newUrl", "/spark/dashboard");
         } else {
             request.setAttribute("newUrl", "/rails/pipelines");

--- a/server/src/main/java/com/thoughtworks/go/server/dashboard/GoDashboardActivityListener.java
+++ b/server/src/main/java/com/thoughtworks/go/server/dashboard/GoDashboardActivityListener.java
@@ -53,7 +53,6 @@ public class GoDashboardActivityListener implements Initializer, ConfigChangedLi
     private final GoDashboardPipelinePauseStatusChangeHandler pauseStatusChangeHandler;
     private final GoDashboardPipelineLockStatusChangeHandler lockStatusChangeHandler;
     private final GoDashboardTemplateConfigChangeHandler templateConfigChangeHandler;
-    private final FeatureToggleService featureToggleService;
 
     private final MultiplexingQueueProcessor processor;
 
@@ -66,8 +65,7 @@ public class GoDashboardActivityListener implements Initializer, ConfigChangedLi
                                        GoDashboardConfigChangeHandler configChangeHandler,
                                        GoDashboardPipelinePauseStatusChangeHandler pauseStatusChangeHandler,
                                        GoDashboardPipelineLockStatusChangeHandler lockStatusChangeHandler,
-                                       GoDashboardTemplateConfigChangeHandler templateConfigChangeHandler,
-                                       FeatureToggleService featureToggleService) {
+                                       GoDashboardTemplateConfigChangeHandler templateConfigChangeHandler) {
         this.goConfigService = goConfigService;
         this.stageService = stageService;
         this.pipelinePauseService = pipelinePauseService;
@@ -78,7 +76,6 @@ public class GoDashboardActivityListener implements Initializer, ConfigChangedLi
         this.pauseStatusChangeHandler = pauseStatusChangeHandler;
         this.lockStatusChangeHandler = lockStatusChangeHandler;
         this.templateConfigChangeHandler = templateConfigChangeHandler;
-        this.featureToggleService = featureToggleService;
 
         this.processor = new MultiplexingQueueProcessor("Dashboard");
     }
@@ -92,16 +89,6 @@ public class GoDashboardActivityListener implements Initializer, ConfigChangedLi
         stageService.addStageStatusListener(stageStatusChangedListener());
         pipelinePauseService.registerListener(this);
         pipelineLockService.registerListener(this);
-        featureToggleService.registerListener(Toggles.QUICKER_DASHBOARD_KEY, quickDashboardFeatureToggleListener());
-    }
-
-    private FeatureToggleListener quickDashboardFeatureToggleListener() {
-        return newValue -> {
-            if (newValue) {
-                // pretend like the config changed
-                onConfigChange(goConfigService.currentCruiseConfig());
-            }
-        };
     }
 
     @Override

--- a/server/src/main/java/com/thoughtworks/go/server/service/GoDashboardService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/GoDashboardService.java
@@ -60,9 +60,6 @@ public class GoDashboardService {
     }
 
     public void updateCacheForPipeline(CaseInsensitiveString pipelineName) {
-        if (isFeatureToggleDisabled()) {
-            return;
-        }
         PipelineConfigs group = goConfigService.findGroupByPipeline(pipelineName);
         PipelineConfig pipelineConfig = group.findBy(pipelineName);
 
@@ -70,20 +67,10 @@ public class GoDashboardService {
     }
 
     public void updateCacheForPipeline(PipelineConfig pipelineConfig) {
-        if (isFeatureToggleDisabled()) {
-            return;
-        }
         updateCache(goConfigService.findGroupByPipeline(pipelineConfig.name()), pipelineConfig);
     }
 
-    public boolean isFeatureToggleDisabled() {
-        return !Toggles.isToggleOn(Toggles.QUICKER_DASHBOARD_KEY);
-    }
-
     public void updateCacheForAllPipelinesIn(CruiseConfig config) {
-        if (isFeatureToggleDisabled()) {
-            return;
-        }
         cache.replaceAllEntriesInCacheWith(dashboardCurrentStateLoader.allPipelines(config));
     }
 

--- a/server/src/main/java/com/thoughtworks/go/server/service/support/toggle/Toggles.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/support/toggle/Toggles.java
@@ -20,7 +20,6 @@ public class Toggles {
     public static String PIPELINE_CONFIG_SINGLE_PAGE_APP = "pipeline_config_single_page_app_key";
     public static String QUICK_EDIT_PAGE_DEFAULT = "quick_edit_page_toggle_key";
     public static String BROWSER_CONSOLE_LOG_WS = "browser_console_log_ws_key";
-    public static String QUICKER_DASHBOARD_KEY = "quicker_dashboard_key";
     public static String ARTIFACT_EXTENSION_KEY = "artifact_extension_key";
     public static String NEW_DASHBOARD_PAGE_DEFAULT = "new_dashboard_page_default";
 

--- a/server/src/main/resources/available.toggles
+++ b/server/src/main/resources/available.toggles
@@ -27,11 +27,6 @@
          "value": false
       },
       {
-        "key": "quicker_dashboard_key",
-        "description": "To disable caching of dashboard information until the dashboard API goes live",
-        "value": true
-      },
-      {
         "key": "artifact_extension_key",
         "description": "Disable artifact extension (implicit) by disabling the pluggable artifact specific config elements",
         "value": false

--- a/server/src/test-fast/java/com/thoughtworks/go/server/SparkOrRailsToggleTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/SparkOrRailsToggleTest.java
@@ -40,20 +40,8 @@ public class SparkOrRailsToggleTest {
     }
 
     @Test
-    public void shouldForwardToRailsIfQuickerDashboardToggleIsDisabled() {
-        SparkOrRailsToggle sparkOrRailsToggle = new SparkOrRailsToggle();
-        when(featureToggleService.isToggleOn(Toggles.QUICKER_DASHBOARD_KEY)).thenReturn(false);
-
-        sparkOrRailsToggle.oldOrNewDashboard(request, null);
-
-        verify(request).setAttribute("newUrl", "/rails/pipelines");
-        verify(request).setAttribute("rails_bound", true);
-    }
-
-    @Test
     public void shouldForwardToRailsIfNewDashboardPageDefaultToggleIsDisabled() {
         SparkOrRailsToggle sparkOrRailsToggle = new SparkOrRailsToggle();
-        when(featureToggleService.isToggleOn(Toggles.QUICKER_DASHBOARD_KEY)).thenReturn(true);
         when(featureToggleService.isToggleOn(Toggles.NEW_DASHBOARD_PAGE_DEFAULT)).thenReturn(false);
 
         sparkOrRailsToggle.oldOrNewDashboard(request, null);
@@ -63,9 +51,8 @@ public class SparkOrRailsToggleTest {
     }
 
     @Test
-    public void shouldForwardToSparkIfBothDashboardTogglesAreEnabled() {
+    public void shouldForwardToSparkIfNewDashboardPageDefaultToggleIsEnabled() {
         SparkOrRailsToggle sparkOrRailsToggle = new SparkOrRailsToggle();
-        when(featureToggleService.isToggleOn(Toggles.QUICKER_DASHBOARD_KEY)).thenReturn(true);
         when(featureToggleService.isToggleOn(Toggles.NEW_DASHBOARD_PAGE_DEFAULT)).thenReturn(true);
 
         sparkOrRailsToggle.oldOrNewDashboard(request, null);

--- a/server/src/test-fast/java/com/thoughtworks/go/server/dashboard/GoDashboardActivityListenerTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/dashboard/GoDashboardActivityListenerTest.java
@@ -52,7 +52,6 @@ public class GoDashboardActivityListenerTest {
     private PipelinePauseService pipelinePauseService;
     @Mock
     private PipelineLockService pipelineLockService;
-    @Mock private FeatureToggleService featureToggleService;
 
     @Before
     public void setUp() throws Exception {
@@ -60,30 +59,9 @@ public class GoDashboardActivityListenerTest {
     }
 
     @Test
-    public void shouldRegisterForFeatureToggleService_whichCallsOnConfigChange() throws InterruptedException {
-        CruiseConfig aConfig = GoConfigMother.defaultCruiseConfig();
-        GoDashboardConfigChangeHandler handler = mock(GoDashboardConfigChangeHandler.class);
-
-        ArgumentCaptor<FeatureToggleListener> captor = ArgumentCaptor.forClass(FeatureToggleListener.class);
-        doNothing().when(featureToggleService).registerListener(eq(Toggles.QUICKER_DASHBOARD_KEY), captor.capture());
-        when(goConfigService.currentCruiseConfig()).thenReturn(aConfig);
-
-        GoDashboardActivityListener listener = spy(new GoDashboardActivityListener(goConfigService, stageService, pipelinePauseService, pipelineLockService,
-                null, handler, null, null, null, featureToggleService));
-
-        listener.initialize();
-        listener.startDaemon();
-        verify(featureToggleService).registerListener(Toggles.QUICKER_DASHBOARD_KEY, captor.getValue());
-
-        captor.getValue().toggleChanged(true);
-        waitForProcessingToHappen();
-        verify(listener).onConfigChange(aConfig);
-    }
-
-    @Test
     public void shouldRegisterSelfForConfigChangeHandlingOnInitialization() throws Exception {
         GoDashboardActivityListener listener = new GoDashboardActivityListener(goConfigService, stageService, pipelinePauseService, pipelineLockService,
-                null, null, null, null, null, featureToggleService);
+                null, null, null, null, null);
 
         listener.initialize();
 
@@ -99,7 +77,7 @@ public class GoDashboardActivityListenerTest {
         doNothing().when(stageService).addStageStatusListener(captor.capture());
 
         GoDashboardActivityListener listener = new GoDashboardActivityListener(goConfigService, stageService, pipelinePauseService, pipelineLockService,
-                handler, null, null, null, null, featureToggleService);
+                handler, null, null, null, null);
 
         listener.initialize();
         listener.startDaemon();
@@ -117,7 +95,7 @@ public class GoDashboardActivityListenerTest {
         CruiseConfig aConfig = GoConfigMother.defaultCruiseConfig();
         GoDashboardConfigChangeHandler handler = mock(GoDashboardConfigChangeHandler.class);
         GoDashboardActivityListener listener = new GoDashboardActivityListener(goConfigService, stageService, pipelinePauseService, pipelineLockService,
-                null, handler, null, null, null, featureToggleService);
+                null, handler, null, null, null);
 
         listener.initialize();
         listener.startDaemon();
@@ -137,7 +115,7 @@ public class GoDashboardActivityListenerTest {
         doNothing().when(goConfigService).register(captor.capture());
 
         GoDashboardActivityListener listener = new GoDashboardActivityListener(goConfigService, stageService, pipelinePauseService, pipelineLockService,
-                null, handler, null, null, null, featureToggleService);
+                null, handler, null, null, null);
         listener.initialize();
         listener.startDaemon();
 
@@ -157,7 +135,7 @@ public class GoDashboardActivityListenerTest {
         when(goConfigService.currentCruiseConfig()).thenReturn(aConfig);
 
         GoDashboardActivityListener listener = new GoDashboardActivityListener(goConfigService, stageService, pipelinePauseService, pipelineLockService,
-                null, handler, null, null, null, featureToggleService);
+                null, handler, null, null, null);
 
         listener.initialize();
         listener.startDaemon();
@@ -177,7 +155,7 @@ public class GoDashboardActivityListenerTest {
         doNothing().when(goConfigService).register(captor.capture());
 
         GoDashboardActivityListener listener = new GoDashboardActivityListener(goConfigService, stageService, pipelinePauseService, pipelineLockService,
-                null, null, null, null, handler, featureToggleService);
+                null, null, null, null, handler);
         listener.initialize();
         listener.startDaemon();
 
@@ -190,7 +168,7 @@ public class GoDashboardActivityListenerTest {
     @Test
     public void shouldRegisterSelfForPipelineStatusChangeHandlingOnInitialization() throws Exception {
         GoDashboardActivityListener listener = new GoDashboardActivityListener(goConfigService, stageService, pipelinePauseService, pipelineLockService,
-                null, null, null, null, null, featureToggleService);
+                null, null, null, null, null);
 
         listener.initialize();
 
@@ -201,7 +179,7 @@ public class GoDashboardActivityListenerTest {
     public void shouldInvokePipelinePauseStatusChangeHandlerWhenPipelinePauseEventOccurs() throws Exception {
         GoDashboardPipelinePauseStatusChangeHandler handler = mock(GoDashboardPipelinePauseStatusChangeHandler.class);
         GoDashboardActivityListener listener = new GoDashboardActivityListener(goConfigService, stageService, pipelinePauseService, pipelineLockService,
-                null, null, handler, null, null, featureToggleService);
+                null, null, handler, null, null);
 
         PipelinePauseChangeListener.Event pauseEvent = PipelinePauseChangeListener.Event.pause("pipeline1", Username.valueOf("user1"));
 
@@ -217,7 +195,7 @@ public class GoDashboardActivityListenerTest {
     @Test
     public void shouldRegisterSelfForPipelineLockStatusChangeHandlingOnInitialization() throws Exception {
         GoDashboardActivityListener listener = new GoDashboardActivityListener(goConfigService, stageService, pipelinePauseService, pipelineLockService,
-                null, null, null, null, null, featureToggleService);
+                null, null, null, null, null);
 
         listener.initialize();
 
@@ -228,7 +206,7 @@ public class GoDashboardActivityListenerTest {
     public void shouldInvokePipelineLockStatusChangeHandlerWhenPipelineLockEventOccurs() throws Exception {
         GoDashboardPipelineLockStatusChangeHandler handler = mock(GoDashboardPipelineLockStatusChangeHandler.class);
         GoDashboardActivityListener listener = new GoDashboardActivityListener(goConfigService, stageService, pipelinePauseService, pipelineLockService,
-                null, null, null, handler, null, featureToggleService);
+                null, null, null, handler, null);
 
         PipelineLockStatusChangeListener.Event lockEvent = PipelineLockStatusChangeListener.Event.lock("pipeline1");
 

--- a/server/src/test-fast/java/com/thoughtworks/go/server/service/GoDashboardServiceTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/service/GoDashboardServiceTest.java
@@ -67,7 +67,6 @@ public class GoDashboardServiceTest {
         configMother = new GoConfigMother();
         config = configMother.defaultCruiseConfig();
         Toggles.initializeWith(featureToggleService);
-        when(featureToggleService.isToggleOn(Toggles.QUICKER_DASHBOARD_KEY)).thenReturn(true);
         when(cache.allEntries()).thenReturn(this.pipelines);
         service = new GoDashboardService(cache, dashboardCurrentStateLoader, goConfigService);
     }

--- a/server/webapp/WEB-INF/rails.new/app/helpers/application_helper.rb
+++ b/server/webapp/WEB-INF/rails.new/app/helpers/application_helper.rb
@@ -493,10 +493,6 @@ module ApplicationHelper
     Toggles.isToggleOn(Toggles.PIPELINE_CONFIG_SINGLE_PAGE_APP)
   end
 
-  def is_quicker_dashboard_toggle_enabled?
-    Toggles.isToggleOn(Toggles.QUICKER_DASHBOARD_KEY)
-  end
-
   def artifact_stores_enabled?
     Toggles.isToggleOn(Toggles.ARTIFACT_EXTENSION_KEY)
   end

--- a/server/webapp/WEB-INF/rails.new/app/views/pipelines/index.html.erb
+++ b/server/webapp/WEB-INF/rails.new/app/views/pipelines/index.html.erb
@@ -1,11 +1,7 @@
 <% @view_title = "Pipelines" -%>
 
-<% @page_header = '<h1 class="entity_title">Pipelines</h1>'
-   if is_quicker_dashboard_toggle_enabled?
-     @page_header += '<a href="/go/dashboard" class="toggle-new-view">New Dashboard</a>'
-   end
+<% @page_header = '<h1 class="entity_title">Pipelines</h1><a href="/go/dashboard" class="toggle-new-view">New Dashboard</a>'
    @show_pipeline_selector = true -%>
-
 
 <div class="dashboard_microcontent_popup dashboard_build_cause_like_microcontent_popups">
   <div class="hidden changes enhanced_dropdown" id="dashboard_build_cause_content">&nbsp;</div>


### PR DESCRIPTION
* quicker_dashboard_key toggle was introduced for not caching the dashboard information until the new dashboard becomes the default. The new dashboard was released out of beta and being the default as part of GoCD release 18.3.0. Hence there is no need of quicker_dashboard_key toggle now.
* Leave behind the feature toggle listener code
* Always show the 'New Dashboard' button which takes to the new dashboard, on the old pipelines page.