### PR TITLE
Use iframe sandbox for tests, failures and custom tabs.

### DIFF
--- a/base/src/main/java/com/thoughtworks/go/util/SystemEnvironment.java
+++ b/base/src/main/java/com/thoughtworks/go/util/SystemEnvironment.java
@@ -222,6 +222,7 @@ public class SystemEnvironment implements Serializable, ConfigDirProvider {
     private static GoSystemProperty<Boolean> ENABLE_ANALYTICS_ONLY_FOR_ADMINS = new GoBooleanSystemProperty("go.enable.analytics.only.for.admins", false);
     private static final GoSystemProperty<Boolean> DISPLAY_PIPELINE_INSTANCES_ON_ENVIRONMENTS_PAGE = new GoBooleanSystemProperty("gocd.environments.show.pipelines", false);
     private static final GoSystemProperty<Boolean> FAIL_STARTUP_ON_DATA_ERROR = new GoBooleanSystemProperty("gocd.fail.startup.on.data.error", false);
+    private static final GoSystemProperty<Boolean> JOB_DETAILS_USE_IFRAME_SANDBOX = new GoBooleanSystemProperty("gocd.job.details.sandbox", true);
 
     private final static Map<String, String> GIT_ALLOW_PROTOCOL;
 
@@ -881,8 +882,12 @@ public class SystemEnvironment implements Serializable, ConfigDirProvider {
         return ENABLE_ANALYTICS_ONLY_FOR_ADMINS.getValue();
     }
 
-    public boolean shouldFailStartupOnDataError(){
+    public boolean shouldFailStartupOnDataError() {
         return get(FAIL_STARTUP_ON_DATA_ERROR);
+    }
+
+    public boolean useIframeSandbox() {
+        return JOB_DETAILS_USE_IFRAME_SANDBOX.getValue();
     }
 
     public static abstract class GoSystemProperty<T> {

--- a/common/src/test/java/com/thoughtworks/go/util/SystemEnvironmentTest.java
+++ b/common/src/test/java/com/thoughtworks/go/util/SystemEnvironmentTest.java
@@ -87,6 +87,11 @@ public class SystemEnvironmentTest {
     }
 
     @Test
+    public void shouldSetTrueAsDefaultForUseIframeSandbox() {
+        assertThat(systemEnvironment.useIframeSandbox(), is(true));
+    }
+
+    @Test
     public void shouldHaveBaseUrl() {
         assertThat(systemEnvironment.getBaseUrlForShine(), is("http://localhost:8153/go"));
     }

--- a/server/src/main/java/com/thoughtworks/go/server/controller/JobController.java
+++ b/server/src/main/java/com/thoughtworks/go/server/controller/JobController.java
@@ -31,6 +31,7 @@ import com.thoughtworks.go.server.presentation.models.JobStatusJsonPresentationM
 import com.thoughtworks.go.server.service.*;
 import com.thoughtworks.go.server.service.support.toggle.Toggles;
 import com.thoughtworks.go.server.util.ErrorHandler;
+import com.thoughtworks.go.util.SystemEnvironment;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -76,6 +77,7 @@ public class JobController {
     private StageService stageService;
     @Autowired
     private JobAgentMetadataDao jobAgentMetadataDao;
+    private SystemEnvironment systemEnvironment;
     private ElasticAgentMetadataStore elasticAgentMetadataStore = ElasticAgentMetadataStore.instance();
 
 
@@ -86,7 +88,7 @@ public class JobController {
             JobInstanceService jobInstanceService, AgentService agentService, JobInstanceDao jobInstanceDao,
             GoConfigService goConfigService, PipelineService pipelineService, RestfulService restfulService,
             ArtifactsService artifactService, PropertiesService propertiesService, StageService stageService,
-            JobAgentMetadataDao jobAgentMetadataDao) {
+            JobAgentMetadataDao jobAgentMetadataDao, SystemEnvironment systemEnvironment) {
         this.jobInstanceService = jobInstanceService;
         this.agentService = agentService;
         this.jobInstanceDao = jobInstanceDao;
@@ -97,6 +99,7 @@ public class JobController {
         this.propertiesService = propertiesService;
         this.stageService = stageService;
         this.jobAgentMetadataDao = jobAgentMetadataDao;
+        this.systemEnvironment = systemEnvironment;
     }
 
     @RequestMapping(value = "/tab/build/recent", method = RequestMethod.GET)
@@ -123,6 +126,7 @@ public class JobController {
         Map data = new HashMap();
         data.put("presenter", presenter);
         data.put("websocketEnabled", Toggles.isToggleOn(Toggles.BROWSER_CONSOLE_LOG_WS));
+        data.put("useIframeSandbox", systemEnvironment.useIframeSandbox());
         data.put("isEditableViaUI", goConfigService.isPipelineEditable(jobDetail.getPipelineName()));
         data.put("isAgentAlive", goConfigService.hasAgent(jobDetail.getAgentUuid()));
         addElasticAgentInfo(jobDetail, data);

--- a/server/src/test-fast/java/com/thoughtworks/go/server/controller/JobControllerTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/controller/JobControllerTest.java
@@ -23,6 +23,7 @@ import com.thoughtworks.go.server.dao.JobInstanceDao;
 import com.thoughtworks.go.server.domain.Agent;
 import com.thoughtworks.go.server.service.*;
 import com.thoughtworks.go.util.JsonValue;
+import com.thoughtworks.go.util.SystemEnvironment;
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.mock.web.MockHttpServletResponse;
@@ -45,6 +46,7 @@ public class JobControllerTest {
     private AgentService agentService;
     private StageService stageService;
     private MockHttpServletResponse response;
+    private SystemEnvironment systemEnvironment;
 
     @Before
     public void setUp() throws Exception {
@@ -54,7 +56,8 @@ public class JobControllerTest {
         agentService = mock(AgentService.class);
         stageService = mock(StageService.class);
         response = new MockHttpServletResponse();
-        jobController = new JobController(jobInstanceService, agentService, jobInstanceDao, jobConfigService, null, null, null, null, stageService, null);
+        systemEnvironment = mock(SystemEnvironment.class);
+        jobController = new JobController(jobInstanceService, agentService, jobInstanceDao, jobConfigService, null, null, null, null, stageService, null, systemEnvironment);
     }
 
     @Test

--- a/server/src/test-fast/java/com/thoughtworks/go/server/view/velocity/BuildDetailPageVelocityTemplateTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/view/velocity/BuildDetailPageVelocityTemplateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 ThoughtWorks, Inc.
+ * Copyright 2018 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,6 +43,7 @@ import static com.thoughtworks.go.helper.PipelineMother.schedule;
 import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class BuildDetailPageVelocityTemplateTest {
 
@@ -64,6 +65,54 @@ public class BuildDetailPageVelocityTemplateTest {
     public void shouldEscapeBuildCauseInTrimpathTemplate() throws Exception {
         Document actualDoc = Jsoup.parse(getBuildDetailVelocityView(createJobDetailModel()).render());
         assertThat(actualDoc.select("#build-summary-template").last().html(), containsString("modified by Ernest Hemingway &amp;lt;oldman@sea.com&amp;gt;"));
+    }
+
+    @Test
+    public void shouldRenderIframeSandboxByDefaultForTestsTab() {
+        HashMap<String, Object> data = new HashMap<>();
+        JobDetailPresentationModel jobDetailPresentationModel = mock(JobDetailPresentationModel.class);
+        data.put("presenter", jobDetailPresentationModel);
+        data.put("useIframeSandbox", true);
+        when(jobDetailPresentationModel.hasTests()).thenReturn(true);
+        Document actualDoc = Jsoup.parse(getBuildDetailVelocityView(data).render());
+
+        assertThat(actualDoc.select("#tab-content-of-tests").last().html(), containsString("<iframe sandbox=\"allow-scripts\""));
+    }
+
+    @Test
+    public void shouldRenderANormalIframeForTestsTabIfUserHasDisabledSandbox() {
+        HashMap<String, Object> data = new HashMap<>();
+        JobDetailPresentationModel jobDetailPresentationModel = mock(JobDetailPresentationModel.class);
+        data.put("presenter", jobDetailPresentationModel);
+        data.put("useIframeSandbox", false);
+        when(jobDetailPresentationModel.hasTests()).thenReturn(true);
+        Document actualDoc = Jsoup.parse(getBuildDetailVelocityView(data).render());
+
+        assertThat(actualDoc.select("#tab-content-of-tests").last().html(), containsString("<iframe src="));
+    }
+
+    @Test
+    public void shouldRenderIframeSandboxByDefaultForFailuresTab() {
+        HashMap<String, Object> data = new HashMap<>();
+        JobDetailPresentationModel jobDetailPresentationModel = mock(JobDetailPresentationModel.class);
+        data.put("presenter", jobDetailPresentationModel);
+        data.put("useIframeSandbox", true);
+        when(jobDetailPresentationModel.hasFailedTests()).thenReturn(true);
+        Document actualDoc = Jsoup.parse(getBuildDetailVelocityView(data).render());
+
+        assertThat(actualDoc.select("#tab-content-of-failures").last().html(), containsString("<iframe sandbox=\"allow-scripts\""));
+    }
+
+    @Test
+    public void shouldRenderANormalIframeForFailuresTabIfUserHasDisabledSandbox() {
+        HashMap<String, Object> data = new HashMap<>();
+        JobDetailPresentationModel jobDetailPresentationModel = mock(JobDetailPresentationModel.class);
+        data.put("presenter", jobDetailPresentationModel);
+        data.put("useIframeSandbox", false);
+        when(jobDetailPresentationModel.hasFailedTests()).thenReturn(true);
+        Document actualDoc = Jsoup.parse(getBuildDetailVelocityView(data).render());
+
+        assertThat(actualDoc.select("#tab-content-of-failures").last().html(), containsString("<iframe src="));
     }
 
     private HashMap<String, Object> createJobDetailModel() {

--- a/server/src/test-integration/java/com/thoughtworks/go/server/controller/JobControllerIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/controller/JobControllerIntegrationTest.java
@@ -35,6 +35,7 @@ import com.thoughtworks.go.server.service.*;
 import com.thoughtworks.go.server.transaction.TransactionTemplate;
 import com.thoughtworks.go.util.GoConfigFileHelper;
 import com.thoughtworks.go.util.GoConstants;
+import com.thoughtworks.go.util.SystemEnvironment;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -95,6 +96,9 @@ public class JobControllerIntegrationTest {
     private TransactionTemplate transactionTemplate;
     @Autowired
     private JobAgentMetadataDao jobAgentMetadataDao;
+    @Autowired
+    private SystemEnvironment systemEnvironment;
+
     @Rule
     public final TemporaryFolder temporaryFolder = new TemporaryFolder();
 
@@ -112,7 +116,7 @@ public class JobControllerIntegrationTest {
         fixture = new PipelineWithTwoStages(materialRepository, transactionTemplate, temporaryFolder);
         fixture.usingConfigHelper(configHelper).usingDbHelper(dbHelper).onSetUp();
         controller = new JobController(jobInstanceService, agentService, jobInstanceDao,
-                goConfigService, pipelineService, restfulService, artifactService, propertiesService, stageService, jobAgentMetadataDao);
+                goConfigService, pipelineService, restfulService, artifactService, propertiesService, stageService, jobAgentMetadataDao, systemEnvironment);
     }
 
     @After
@@ -167,7 +171,7 @@ public class JobControllerIntegrationTest {
     @Test
     public void shouldCreateJobPresentationModelWithRightStage() throws Exception {
         controller = new JobController(jobInstanceService, agentService, jobInstanceDao,
-                goConfigService, pipelineService, restfulService, artifactService, propertiesService, stageService, jobAgentMetadataDao);
+                goConfigService, pipelineService, restfulService, artifactService, propertiesService, stageService, jobAgentMetadataDao, systemEnvironment);
         fixture.configLabelTemplateUsingMaterialRevision();
         Pipeline pipeline = fixture.createdPipelineWithAllStagesPassed();
         Stage devStage = pipeline.getStages().byName("dev");

--- a/server/webapp/WEB-INF/vm/build_detail/_customized.vm
+++ b/server/webapp/WEB-INF/vm/build_detail/_customized.vm
@@ -23,8 +23,12 @@ window["tab-content-of-${customized_name.toLowerCase()}_callback"] = function() 
     if (innerHTML.include("iframe")) {
         return;
     }
-    $("tab-content-of-${customized_name.toLowerCase()}").innerHTML = '<div><a href="$req.getContextPath()/$presenter.getRestfulUrl($customized_path)">Download ${customized_name}</a></div>' 
-            + '<iframe src="$req.getContextPath()/$presenter.getRestfulUrl($customized_path)" frameborder="0"></iframe>';
+    var iframe = '<iframe sandbox="allow-scripts" src="$req.getContextPath()/$presenter.getRestfulUrl($customized_path)" frameborder="0"></iframe>';
+    #if (!$useIframeSandbox)
+    iframe = '<iframe src="$req.getContextPath()/$presenter.getRestfulUrl($customized_path)" frameborder="0"></iframe>';
+    #end
+  $("tab-content-of-${customized_name.toLowerCase()}").innerHTML = '<div><a href="$req.getContextPath()/$presenter.getRestfulUrl($customized_path)">Download ${customized_name}</a></div>'
+            + iframe;
     $("tab-content-of-${customized_name.toLowerCase()}").show();
 }
 

--- a/server/webapp/WEB-INF/vm/build_detail/_failures.vm
+++ b/server/webapp/WEB-INF/vm/build_detail/_failures.vm
@@ -31,7 +31,11 @@
     #if ($presenter.hasFailedTests())
         <h2 class="subtitle collapsible_title title_message_expanded">Failed tests</h2>
         <div class="collapsible_content">
-            <iframe src="$req.getContextPath()/${presenter.indexPageURL}" width="95%" height="200" frameborder="0"></iframe>
+            #if ($useIframeSandbox)
+                <iframe sandbox="allow-scripts" src="$req.getContextPath()/${presenter.indexPageURL}" width="95%" height="200" frameborder="0"></iframe>
+            #else
+                <iframe src="$req.getContextPath()/${presenter.indexPageURL}" width="95%" height="200" frameborder="0"></iframe>
+            #end
         </div>
         <br/>
     #end

--- a/server/webapp/WEB-INF/vm/build_detail/_tests.vm
+++ b/server/webapp/WEB-INF/vm/build_detail/_tests.vm
@@ -17,7 +17,11 @@
 <div id="tab-content-of-tests" class="widget" $tests_extra_attrs>
     <div class="files">
         #if( $presenter.hasTests())
-           <iframe src="$req.getContextPath()/${presenter.indexPageURL}" width="95%" height="500" frameborder="0"></iframe>
+            #if ($useIframeSandbox)
+                <iframe sandbox="allow-scripts" src="$req.getContextPath()/${presenter.indexPageURL}" width="95%" height="500" frameborder="0"></iframe>
+            #else
+              <iframe src="$req.getContextPath()/${presenter.indexPageURL}" width="95%" height="500" frameborder="0"></iframe>
+            #end
         #else
             #parse("build_detail/_test_output_config.vm")
         #end


### PR DESCRIPTION
* Disable system property gocd.job.details.sandbox to retain the old behaviour.