### PR TITLE
Do not render custom tabs in an iframe sandbox.

### DIFF
--- a/server/webapp/WEB-INF/vm/build_detail/_customized.vm
+++ b/server/webapp/WEB-INF/vm/build_detail/_customized.vm
@@ -23,10 +23,7 @@ window["tab-content-of-${customized_name.toLowerCase()}_callback"] = function() 
     if (innerHTML.include("iframe")) {
         return;
     }
-    var iframe = '<iframe sandbox="allow-scripts" src="$req.getContextPath()/$presenter.getRestfulUrl($customized_path)" frameborder="0"></iframe>';
-    #if (!$useIframeSandbox)
-    iframe = '<iframe src="$req.getContextPath()/$presenter.getRestfulUrl($customized_path)" frameborder="0"></iframe>';
-    #end
+    var iframe = '<iframe src="$req.getContextPath()/$presenter.getRestfulUrl($customized_path)" frameborder="0"></iframe>';
   $("tab-content-of-${customized_name.toLowerCase()}").innerHTML = '<div><a href="$req.getContextPath()/$presenter.getRestfulUrl($customized_path)">Download ${customized_name}</a></div>'
             + iframe;
     $("tab-content-of-${customized_name.toLowerCase()}").show();


### PR DESCRIPTION
* If third party cookies are blocked in the browser settings, then the request for css and js to be pulled within the sandbox is not passed the cookie header. The response ends up redirecting to /go/auth/login with mime type text/html.
* This is not a problem for tests and failures tab as we construct the single html file to be rendered in the iframe sandbox.