### PR TITLE
Continue OAuth flow when security is disabled and OAuth credentials provided in request.

### DIFF
--- a/server/src/main/java/com/thoughtworks/go/server/newsecurity/filters/OauthAuthenticationFilter.java
+++ b/server/src/main/java/com/thoughtworks/go/server/newsecurity/filters/OauthAuthenticationFilter.java
@@ -65,7 +65,7 @@ public class OauthAuthenticationFilter extends OncePerRequestFilter {
                 filterWhenSecurityEnabled(request, response, filterChain, oAuthCredentials);
             } else {
                 LOGGER.debug("Security is disabled.");
-                filterWhenSecurityDisabled(request, response, filterChain, oAuthCredentials);
+                filterChain.doFilter(request, response);
             }
         } catch (AuthenticationException e) {
             onAuthenticationFailure(request, response, e.getMessage());
@@ -95,17 +95,6 @@ public class OauthAuthenticationFilter extends OncePerRequestFilter {
                                  String errorMessage) throws IOException {
         response.setStatus(401);
         response.getOutputStream().print(errorMessage);
-    }
-
-    private void filterWhenSecurityDisabled(HttpServletRequest request,
-                                            HttpServletResponse response,
-                                            FilterChain filterChain,
-                                            OAuthCredentials oAuthCredentials) throws IOException, ServletException {
-        if (oAuthCredentials != null) {
-            onAuthenticationFailure(request, response, "OAuth access token is not required, since security has been disabled on this server.");
-        } else {
-            filterChain.doFilter(request, response);
-        }
     }
 
     private OAuthCredentials extractOAuthToken(HttpServletRequest request) {

--- a/server/src/test-fast/java/com/thoughtworks/go/server/newsecurity/filters/OauthAuthenticationFilterTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/newsecurity/filters/OauthAuthenticationFilterTest.java
@@ -88,7 +88,7 @@ class OauthAuthenticationFilterTest {
         }
 
         @Test
-        void shouldErrorOutWhenCredentialsAreProvided() throws ServletException, IOException {
+        void shouldContinueWhenCredentialsAreProvided() throws ServletException, IOException {
             request = HttpRequestBuilder.GET("/")
                     .withOAuth("valid-token")
                     .build();
@@ -97,16 +97,14 @@ class OauthAuthenticationFilterTest {
             assertThat(SessionUtils.getAuthenticationToken(request)).isNull();
 
             filter.doFilter(request, response, filterChain);
-
-            verifyZeroInteractions(filterChain);
-
+            
             assertThat(SessionUtils.getAuthenticationToken(request)).isNull();
             MockHttpServletRequestAssert.assertThat(request)
                     .hasSameSession(originalSession);
 
             MockHttpServletResponseAssert.assertThat(response)
-                    .isUnauthorized()
-                    .hasBody("OAuth access token is not required, since security has been disabled on this server.");
+                    .isOk()
+                    .hasNoBody();
         }
     }
 


### PR DESCRIPTION
#### GoCD version 18.5.0
We allowed OAuth request to continue when security is disabled and OAuth
credentials are provided in the request.

#### After spring security upgrade
When security is disabled [this](https://github.com/gocd/gocd/blob/1013a67ccf0cda9c87e6361286708b584be42338/server/src/main/java/com/thoughtworks/go/server/newsecurity/filters/OauthAuthenticationFilter.java#L105)
will block the user if OAuth credentials are present in the request.

BC addons use OAuth flow for to sync data from the primary server and
above change will affect the BC add-on workflow.

When security is disabled BC acquires an OAuth token from the primary server and uses it to make sync requests. The primary server rejects it as OAuth token present in the request.

Primary server should note generate OAuth token when security is disabled because OAuth token is for a user and without security, there will not be any user. I am leaning towards not allowing BC to work when security is disabled. WDYT @arvindsv, @gocd/committers?
