### PR TITLE
Remove 424 check for dashboard API response

### DIFF
--- a/server/webapp/WEB-INF/rails.new/webpack/single_page_apps/new_dashboard.js
+++ b/server/webapp/WEB-INF/rails.new/webpack/single_page_apps/new_dashboard.js
@@ -69,15 +69,6 @@ $(() => {
         return;
       }
 
-      if (jqXHR.status === 424) {
-        const message = {
-          type:    'warning',
-          content: jqXHR.responseJSON.message,
-        };
-        onResponse({}, message);
-        return;
-      }
-
       const message = {
         type:    'warning',
         content: 'There was an unknown error ',


### PR DESCRIPTION
For Dashboard API call, the server would send `424` response in case of dashboard cache is disabled using `QUICKER_DASHBOARD_KEY`. As the `QUICKER_DASHBOARD_KEY` was removed as part of PR https://github.com/gocd/gocd/pull/4793. We don't need to handle `424` response at the client side.