### PR TITLE
Use gradle-license-report-plugin from the branch which fixes dependency resolution problem in a multi project

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,13 +27,15 @@ buildscript {
     maven {
       url "https://plugins.gradle.org/m2/"
     }
+
+    maven { url 'https://jitpack.io' }
   }
 
   dependencies {
     classpath 'org.owasp:dependency-check-gradle:3.1.2'
     classpath 'com.github.ben-manes:gradle-versions-plugin:0.17.0'
     classpath "gradle.plugin.nl.javadude.gradle.plugins:license-gradle-plugin:0.14.0"
-    classpath 'gradle.plugin.com.github.jk1:gradle-license-report:1.0'
+    classpath 'com.github.guenhter:Gradle-License-Report:fix-multi-project-dependency-resolution-problem-SNAPSHOT'
   }
 }
 


### PR DESCRIPTION

* Gradle-License-Report project has issue with generating the license report with multi-project build.
     issue link: https://github.com/jk1/Gradle-License-Report/issues/82
* Above mentioned issue has been fixed as part of PR: https://github.com/jk1/Gradle-License-Report/pull/80

Need to use the Gradle-License-Report generated from the PR fork as of now to avoid flaky builds on build.gocd.org

Note: These changes should be reverted once the PR is merged and next release of Gradle-License-Report is available maven repo