### PR TITLE
Upgrade gradle-license-report dependency to 1.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,15 +27,13 @@ buildscript {
     maven {
       url "https://plugins.gradle.org/m2/"
     }
-
-    maven { url 'https://jitpack.io' }
   }
 
   dependencies {
     classpath 'org.owasp:dependency-check-gradle:3.1.2'
     classpath 'com.github.ben-manes:gradle-versions-plugin:0.17.0'
     classpath "gradle.plugin.nl.javadude.gradle.plugins:license-gradle-plugin:0.14.0"
-    classpath 'com.github.guenhter:Gradle-License-Report:fix-multi-project-dependency-resolution-problem-SNAPSHOT'
+    classpath 'gradle.plugin.com.github.jk1:gradle-license-report:1.1'
   }
 }
 


### PR DESCRIPTION
* Gradle-License-Report fixed the issue with dependency resolution problem in a multi project as part of release 1.1.
* Previously we were using the plugin built from the PR fork which has the fix for the above mentioned issue.
* More information: https://github.com/gocd/gocd/commit/00e510847469b532070d40f8852826ee9005a57f