### PR TITLE
Do not throw an error if `attributes` is not passed for ant, nant, rake, exec tasks.

### DIFF
--- a/api/api-shared-v6/src/main/java/com/thoughtworks/go/apiv6/shared/representers/stages/tasks/AntTaskRepresenter.java
+++ b/api/api-shared-v6/src/main/java/com/thoughtworks/go/apiv6/shared/representers/stages/tasks/AntTaskRepresenter.java
@@ -24,6 +24,7 @@ import com.thoughtworks.go.config.AntTask;
 import java.util.HashMap;
 
 public class AntTaskRepresenter {
+
     public static void toJSON(OutputWriter jsonWriter, AntTask antTask) {
         BaseTaskRepresenter.toJSON(jsonWriter, antTask);
         jsonWriter.add("working_directory", antTask.workingDirectory());
@@ -33,6 +34,9 @@ public class AntTaskRepresenter {
 
     public static AntTask fromJSON(JsonReader jsonReader) {
         AntTask antTask = new AntTask();
+        if (jsonReader == null) {
+            return antTask;
+        }
         BaseTaskRepresenter.fromJSON(jsonReader, antTask);
         jsonReader.readStringIfPresent("working_directory", antTask::setWorkingDirectory);
         jsonReader.readStringIfPresent("build_file", antTask::setBuildFile);

--- a/api/api-shared-v6/src/main/java/com/thoughtworks/go/apiv6/shared/representers/stages/tasks/ExecTaskRepresenter.java
+++ b/api/api-shared-v6/src/main/java/com/thoughtworks/go/apiv6/shared/representers/stages/tasks/ExecTaskRepresenter.java
@@ -43,6 +43,9 @@ public class ExecTaskRepresenter {
 
     public static ExecTask fromJSON(JsonReader jsonReader) {
         ExecTask execTask = new ExecTask();
+        if (jsonReader == null) {
+            return execTask;
+        }
         BaseTaskRepresenter.fromJSON(jsonReader, execTask);
         jsonReader.readStringIfPresent("command", execTask::setCommand);
         jsonReader.readArrayIfPresent("arguments", arguments -> {

--- a/api/api-shared-v6/src/main/java/com/thoughtworks/go/apiv6/shared/representers/stages/tasks/FetchTaskRepresenter.java
+++ b/api/api-shared-v6/src/main/java/com/thoughtworks/go/apiv6/shared/representers/stages/tasks/FetchTaskRepresenter.java
@@ -42,6 +42,9 @@ public class FetchTaskRepresenter {
 
     public static FetchTask fromJSON(JsonReader jsonReader) {
         FetchTask fetchTask = new FetchTask();
+        if (jsonReader == null) {
+            return fetchTask;
+        }
         BaseTaskRepresenter.fromJSON(jsonReader, fetchTask);
         jsonReader.readCaseInsensitiveStringIfPresent("pipeline", fetchTask::setPipelineName);
         jsonReader.readCaseInsensitiveStringIfPresent("stage", fetchTask::setStage);

--- a/api/api-shared-v6/src/main/java/com/thoughtworks/go/apiv6/shared/representers/stages/tasks/NantTaskRepresenter.java
+++ b/api/api-shared-v6/src/main/java/com/thoughtworks/go/apiv6/shared/representers/stages/tasks/NantTaskRepresenter.java
@@ -34,6 +34,9 @@ public class NantTaskRepresenter extends BaseTaskRepresenter {
 
     public static NantTask fromJSON(JsonReader jsonReader) {
         NantTask nantTask = new NantTask();
+        if (jsonReader == null) {
+            return nantTask;
+        }
         BaseTaskRepresenter.fromJSON(jsonReader, nantTask);
         jsonReader.readStringIfPresent("working_directory", nantTask::setWorkingDirectory);
         jsonReader.readStringIfPresent("build_file", nantTask::setBuildFile);

--- a/api/api-shared-v6/src/main/java/com/thoughtworks/go/apiv6/shared/representers/stages/tasks/PluggableTaskRepresenter.java
+++ b/api/api-shared-v6/src/main/java/com/thoughtworks/go/apiv6/shared/representers/stages/tasks/PluggableTaskRepresenter.java
@@ -36,6 +36,9 @@ public class PluggableTaskRepresenter {
 
     public static PluggableTask fromJSON(JsonReader jsonReader) {
         PluggableTask pluggableTask = new PluggableTask();
+        if (jsonReader == null) {
+            return pluggableTask;
+        }
         BaseTaskRepresenter.fromJSON(jsonReader, pluggableTask);
         PluginConfiguration pluginConfiguration = PluginConfigurationRepresenter.fromJSON(jsonReader.readJsonObject("plugin_configuration"));
         pluggableTask.setPluginConfiguration(pluginConfiguration);

--- a/api/api-shared-v6/src/main/java/com/thoughtworks/go/apiv6/shared/representers/stages/tasks/RakeTaskRepresenter.java
+++ b/api/api-shared-v6/src/main/java/com/thoughtworks/go/apiv6/shared/representers/stages/tasks/RakeTaskRepresenter.java
@@ -33,6 +33,9 @@ public class RakeTaskRepresenter {
 
     public static RakeTask fromJSON(JsonReader jsonReader) {
         RakeTask rakeTask = new RakeTask();
+        if (jsonReader == null) {
+            return rakeTask;
+        }
         BaseTaskRepresenter.fromJSON(jsonReader, rakeTask);
         jsonReader.readStringIfPresent("working_directory", rakeTask::setWorkingDirectory);
         jsonReader.readStringIfPresent("build_file", rakeTask::setBuildFile);

--- a/api/api-shared-v6/src/main/java/com/thoughtworks/go/apiv6/shared/representers/stages/tasks/TaskRepresenter.java
+++ b/api/api-shared-v6/src/main/java/com/thoughtworks/go/apiv6/shared/representers/stages/tasks/TaskRepresenter.java
@@ -26,6 +26,7 @@ import com.thoughtworks.go.config.pluggabletask.PluggableTask;
 import com.thoughtworks.go.domain.Task;
 
 import java.util.HashMap;
+import java.util.Optional;
 
 public class TaskRepresenter {
 
@@ -86,8 +87,12 @@ public class TaskRepresenter {
     }
 
     public static Task fromJSON(JsonReader jsonReader) {
+        JsonReader attributes = null;
         String type = jsonReader.getString("type");
-        JsonReader attributes = jsonReader.readJsonObject("attributes");
+        Optional<JsonReader> attributesObject = jsonReader.optJsonObject("attributes");
+        if (attributesObject.isPresent()) {
+            attributes = attributesObject.get();
+        }
         switch (type) {
             case AntTask.TYPE:
                 return AntTaskRepresenter.fromJSON(attributes);

--- a/api/api-shared-v6/src/test/groovy/com/thoughtworks/go/apiv6/shared/representers/stages/tasks/AntTaskRepresenterTest.groovy
+++ b/api/api-shared-v6/src/test/groovy/com/thoughtworks/go/apiv6/shared/representers/stages/tasks/AntTaskRepresenterTest.groovy
@@ -16,7 +16,11 @@
 
 package com.thoughtworks.go.apiv6.shared.representers.stages.tasks
 
+import com.thoughtworks.go.api.util.GsonTransformer
 import com.thoughtworks.go.config.AntTask
+import org.junit.jupiter.api.Test
+
+import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson
 
 class AntTaskRepresenterTest implements TaskRepresenterTest {
   def existingTask() {
@@ -25,6 +29,10 @@ class AntTaskRepresenterTest implements TaskRepresenterTest {
     task.setTarget("package")
     task.setWorkingDirectory("f/m/l")
     return task
+  }
+
+  def defaultNewTask() {
+    return new AntTask()
   }
 
   def expectedTaskHash =
@@ -49,6 +57,11 @@ class AntTaskRepresenterTest implements TaskRepresenterTest {
       ]
     ]
 
+  def expectedTaskHashWithNoAttributes =
+    [
+      type      : 'ant'
+    ]
+
   def expectedTaskHashWithOnCancelConfig =
     [
       type      : 'ant',
@@ -65,4 +78,13 @@ class AntTaskRepresenterTest implements TaskRepresenterTest {
         ]]
       ]
     ]
+
+  @Test
+  void 'should convert json with no attributes to Task'() {
+    def jsonReader = GsonTransformer.instance.jsonReaderFrom(expectedTaskHashWithNoAttributes)
+    def task = TaskRepresenter.fromJSON(jsonReader)
+
+    def expectedTask = defaultNewTask()
+    assertThatJson(task).isEqualTo(expectedTask)
+  }
 }

--- a/api/api-shared-v6/src/test/groovy/com/thoughtworks/go/apiv6/shared/representers/stages/tasks/ExecTaskRepresenterTest.groovy
+++ b/api/api-shared-v6/src/test/groovy/com/thoughtworks/go/apiv6/shared/representers/stages/tasks/ExecTaskRepresenterTest.groovy
@@ -16,7 +16,11 @@
 
 package com.thoughtworks.go.apiv6.shared.representers.stages.tasks
 
+import com.thoughtworks.go.api.util.GsonTransformer
 import com.thoughtworks.go.config.ExecTask
+import org.junit.jupiter.api.Test
+
+import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson
 
 class ExecTaskRepresenterTest implements TaskRepresenterTest {
   def existingTask() {
@@ -25,6 +29,10 @@ class ExecTaskRepresenterTest implements TaskRepresenterTest {
     task.setArgsList("300")
     task.setWorkingDirectory("f/m/l")
     return task
+  }
+
+  def defaultNewTask() {
+    return new ExecTask()
   }
 
   def expectedTaskHash =
@@ -49,6 +57,11 @@ class ExecTaskRepresenterTest implements TaskRepresenterTest {
       ]
     ]
 
+  def expectedTaskHashWithNoAttributes =
+    [
+      type      : 'exec'
+    ]
+
   def expectedTaskHashWithOnCancelConfig =
     [
       type      : 'exec',
@@ -65,4 +78,13 @@ class ExecTaskRepresenterTest implements TaskRepresenterTest {
         ]]
       ]
     ]
+
+  @Test
+  void 'should convert json with no attributes to Task'() {
+    def jsonReader = GsonTransformer.instance.jsonReaderFrom(expectedTaskHashWithNoAttributes)
+    def task = TaskRepresenter.fromJSON(jsonReader)
+
+    def expectedTask = defaultNewTask()
+    assertThatJson(task).isEqualTo(expectedTask)
+  }
 }

--- a/api/api-shared-v6/src/test/groovy/com/thoughtworks/go/apiv6/shared/representers/stages/tasks/NantTaskRepresenterTest.groovy
+++ b/api/api-shared-v6/src/test/groovy/com/thoughtworks/go/apiv6/shared/representers/stages/tasks/NantTaskRepresenterTest.groovy
@@ -16,7 +16,11 @@
 
 package com.thoughtworks.go.apiv6.shared.representers.stages.tasks
 
+import com.thoughtworks.go.api.util.GsonTransformer
 import com.thoughtworks.go.config.NantTask
+import org.junit.jupiter.api.Test
+
+import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson
 
 class NantTaskRepresenterTest implements TaskRepresenterTest {
   def existingTask() {
@@ -25,6 +29,10 @@ class NantTaskRepresenterTest implements TaskRepresenterTest {
     task.setTarget("package")
     task.setWorkingDirectory("f/m/l")
     return task
+  }
+
+  def defaultNewTask() {
+    return new NantTask()
   }
 
   def expectedTaskHash =
@@ -49,6 +57,11 @@ class NantTaskRepresenterTest implements TaskRepresenterTest {
       ]
     ]
 
+  def expectedTaskHashWithNoAttributes =
+    [
+      type      : 'nant'
+    ]
+
   def expectedTaskHashWithOnCancelConfig =
     [
       type      : 'nant',
@@ -65,4 +78,13 @@ class NantTaskRepresenterTest implements TaskRepresenterTest {
         ]]
       ]
     ]
+
+  @Test
+  void 'should convert json with no attributes to Task'() {
+    def jsonReader = GsonTransformer.instance.jsonReaderFrom(expectedTaskHashWithNoAttributes)
+    def task = TaskRepresenter.fromJSON(jsonReader)
+
+    def expectedTask = defaultNewTask()
+    assertThatJson(task).isEqualTo(expectedTask)
+  }
 }

--- a/api/api-shared-v6/src/test/groovy/com/thoughtworks/go/apiv6/shared/representers/stages/tasks/RakeTaskRepresenterTest.groovy
+++ b/api/api-shared-v6/src/test/groovy/com/thoughtworks/go/apiv6/shared/representers/stages/tasks/RakeTaskRepresenterTest.groovy
@@ -16,7 +16,11 @@
 
 package com.thoughtworks.go.apiv6.shared.representers.stages.tasks
 
+import com.thoughtworks.go.api.util.GsonTransformer
 import com.thoughtworks.go.config.RakeTask
+import org.junit.jupiter.api.Test
+
+import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson
 
 class RakeTaskRepresenterTest implements TaskRepresenterTest {
   def existingTask() {
@@ -25,6 +29,10 @@ class RakeTaskRepresenterTest implements TaskRepresenterTest {
     task.setTarget("package")
     task.setWorkingDirectory("f/m/l")
     return task
+  }
+
+  def defaultNewTask() {
+    return new RakeTask()
   }
 
   def expectedTaskHash =
@@ -49,6 +57,11 @@ class RakeTaskRepresenterTest implements TaskRepresenterTest {
       ]
     ]
 
+  def expectedTaskHashWithNoAttributes =
+    [
+      type      : 'rake'
+    ]
+
   def expectedTaskHashWithOnCancelConfig =
     [
       type      : 'rake',
@@ -66,4 +79,12 @@ class RakeTaskRepresenterTest implements TaskRepresenterTest {
       ]
     ]
 
+  @Test
+  void 'should convert json with no attributes to Task'() {
+    def jsonReader = GsonTransformer.instance.jsonReaderFrom(expectedTaskHashWithNoAttributes)
+    def task = TaskRepresenter.fromJSON(jsonReader)
+
+    def expectedTask = defaultNewTask()
+    assertThatJson(task).isEqualTo(expectedTask)
+  }
 }


### PR DESCRIPTION
* The ant, nant, rake task need not be provided with any attributes.
* This behaviour is consistent with the pipeline config api v5 in rails.

Edit: If there is a validation error, that gets shown. The error that I am referring to is the json parse error that gets thrown if a property is not present. That should not be thrown for the `attributes` property