### PR TITLE
Attempt to fix flaky test DefaultPluginJarLocationMonitorTest#shouldNotifyListenerOfMultiplePluginFilesRemoved.

### DIFF
--- a/plugin-infra/go-plugin-infra/src/main/java/com/thoughtworks/go/plugin/infra/FelixGoPluginOSGiFramework.java
+++ b/plugin-infra/go-plugin-infra/src/main/java/com/thoughtworks/go/plugin/infra/FelixGoPluginOSGiFramework.java
@@ -164,7 +164,7 @@ public class FelixGoPluginOSGiFramework implements GoPluginOSGiFramework {
         return frameworkFactories.get(0).newFramework(generateOSGiFrameworkConfig());
     }
 
-    private HashMap<String, String> generateOSGiFrameworkConfig() {
+    protected HashMap<String, String> generateOSGiFrameworkConfig() {
         String osgiFrameworkPackage = Bundle.class.getPackage().getName();
         String goPluginApiPackage = GoPluginApiMarker.class.getPackage().getName();
         String subPackagesOfGoPluginApiPackage = goPluginApiPackage + ".*";

--- a/plugin-infra/go-plugin-infra/src/test/java/com/thoughtworks/go/plugin/activation/DefaultGoPluginActivatorIntegrationTest.java
+++ b/plugin-infra/go-plugin-infra/src/test/java/com/thoughtworks/go/plugin/activation/DefaultGoPluginActivatorIntegrationTest.java
@@ -33,6 +33,7 @@ import com.thoughtworks.go.util.ZipUtil;
 import lib.test.DummyTestPluginInLibDirectory;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
+import org.apache.felix.framework.util.FelixConstants;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -46,6 +47,7 @@ import org.osgi.framework.*;
 import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.zip.ZipInputStream;
 
 import static org.hamcrest.CoreMatchers.is;
@@ -67,7 +69,14 @@ public class DefaultGoPluginActivatorIntegrationTest {
     public void setUp() throws IOException {
         tmpDir = temporaryFolder.newFolder();
         registry = new StubOfDefaultPluginRegistry();
-        framework = new FelixGoPluginOSGiFramework(registry, new SystemEnvironment());
+        framework = new FelixGoPluginOSGiFramework(registry, new SystemEnvironment()) {
+            @Override
+            protected HashMap<String, String> generateOSGiFrameworkConfig() {
+                HashMap<String, String> config = super.generateOSGiFrameworkConfig();
+                config.put(FelixConstants.RESOLVER_PARALLELISM, "1");
+                return config;
+            }
+        };
         framework.start();
     }
 

--- a/plugin-infra/go-plugin-infra/src/test/java/com/thoughtworks/go/plugin/infra/FelixGoPluginOSGiFrameworkIntegrationTest.java
+++ b/plugin-infra/go-plugin-infra/src/test/java/com/thoughtworks/go/plugin/infra/FelixGoPluginOSGiFrameworkIntegrationTest.java
@@ -23,6 +23,7 @@ import com.thoughtworks.go.util.ReflectionUtil;
 import com.thoughtworks.go.util.SystemEnvironment;
 import com.thoughtworks.go.util.ZipUtil;
 import org.apache.commons.io.FileUtils;
+import org.apache.felix.framework.util.FelixConstants;
 import org.junit.*;
 import org.junit.contrib.java.lang.system.RestoreSystemProperties;
 import org.junit.rules.TemporaryFolder;
@@ -34,6 +35,7 @@ import org.osgi.framework.ServiceReference;
 import java.io.File;
 import java.io.IOException;
 import java.net.URISyntaxException;
+import java.util.HashMap;
 import java.util.zip.ZipInputStream;
 
 import static org.hamcrest.CoreMatchers.is;
@@ -59,7 +61,14 @@ public class FelixGoPluginOSGiFrameworkIntegrationTest {
     @Before
     public void setUp() throws Exception {
         registry = new DefaultPluginRegistry();
-        pluginOSGiFramework = new FelixGoPluginOSGiFramework(registry, new SystemEnvironment());
+        pluginOSGiFramework = new FelixGoPluginOSGiFramework(registry, new SystemEnvironment()) {
+            @Override
+            protected HashMap<String, String> generateOSGiFrameworkConfig() {
+                HashMap<String, String> config = super.generateOSGiFrameworkConfig();
+                config.put(FelixConstants.RESOLVER_PARALLELISM, "1");
+                return config;
+            }
+        };
         pluginOSGiFramework.start();
 
         try (ZipInputStream zippedOSGiBundleFile = new ZipInputStream(FileUtils.openInputStream(pathOfFileInDefaultFiles("descriptor-aware-test-plugin.osgi.jar")))) {

--- a/plugin-infra/go-plugin-infra/src/test/java/com/thoughtworks/go/plugin/infra/FelixGoPluginOSGiFrameworkTest.java
+++ b/plugin-infra/go-plugin-infra/src/test/java/com/thoughtworks/go/plugin/infra/FelixGoPluginOSGiFrameworkTest.java
@@ -23,6 +23,7 @@ import com.thoughtworks.go.plugin.infra.service.DefaultPluginLoggingService;
 import com.thoughtworks.go.plugin.internal.api.LoggingService;
 import com.thoughtworks.go.plugin.internal.api.PluginHealthService;
 import com.thoughtworks.go.util.SystemEnvironment;
+import org.apache.felix.framework.util.FelixConstants;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -32,10 +33,7 @@ import org.osgi.framework.*;
 import org.osgi.framework.launch.Framework;
 
 import java.io.File;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Dictionary;
+import java.util.*;
 
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.*;
@@ -58,7 +56,14 @@ public class FelixGoPluginOSGiFrameworkTest {
     @Before
     public void setUp() {
         initMocks(this);
-        FelixGoPluginOSGiFramework goPluginOSGiFramwork = new FelixGoPluginOSGiFramework(registry, systemEnvironment);
+        FelixGoPluginOSGiFramework goPluginOSGiFramwork = new FelixGoPluginOSGiFramework(registry, systemEnvironment) {
+            @Override
+            protected HashMap<String, String> generateOSGiFrameworkConfig() {
+                HashMap<String, String> config = super.generateOSGiFrameworkConfig();
+                config.put(FelixConstants.RESOLVER_PARALLELISM, "1");
+                return config;
+            }
+        };
 
         spy = spy(goPluginOSGiFramwork);
         when(framework.getBundleContext()).thenReturn(bundleContext);

--- a/plugin-infra/go-plugin-infra/src/test/java/com/thoughtworks/go/plugin/infra/monitor/DefaultPluginJarLocationMonitorTest.java
+++ b/plugin-infra/go-plugin-infra/src/test/java/com/thoughtworks/go/plugin/infra/monitor/DefaultPluginJarLocationMonitorTest.java
@@ -209,6 +209,8 @@ public class DefaultPluginJarLocationMonitorTest extends AbstractDefaultPluginJa
         FileUtils.deleteQuietly(new File(bundledPluginDir, "descriptor-aware-test-plugin-2.jar"));
         waitAMoment();
 
+        verify(changeListener, atMost(1)).pluginJarUpdated(pluginFileDetails(bundledPluginDir, "descriptor-aware-test-plugin-1.jar", true));
+        verify(changeListener, atMost(1)).pluginJarUpdated(pluginFileDetails(bundledPluginDir, "descriptor-aware-test-plugin-2.jar", true));
         verify(changeListener).pluginJarRemoved(pluginFileDetails(bundledPluginDir, "descriptor-aware-test-plugin-1.jar", true));
         verify(changeListener).pluginJarRemoved(pluginFileDetails(bundledPluginDir, "descriptor-aware-test-plugin-2.jar", true));
         verifyNoMoreInteractions(changeListener);


### PR DESCRIPTION
The flakiness is due to the fact that the delete of the multiple plugin jars takes a while. If the change listener is invoked before the deletion is complete, the pluginJarUpdated method could be called.