### PR TITLE
Fix artifact config page: Show only built in artifacts on the artifact config page even if external artifacts are configured.

### DIFF
--- a/server/webapp/WEB-INF/rails.new/app/views/admin/jobs/artifacts.html.erb
+++ b/server/webapp/WEB-INF/rails.new/app/views/admin/jobs/artifacts.html.erb
@@ -11,7 +11,7 @@
     <%= register_defaultable_list("job>artifactConfigs") %>
 
     <div class="fieldset">
-        <%= render :partial => "artifact_configs.html", :locals => {:scope => {:form => f, :collection => @job.artifactConfigs()}} %>
+        <%= render :partial => "artifact_configs.html", :locals => {:scope => {:form => f, :collection => @job.artifactConfigs().getBuiltInArtifactConfigs()}} %>
     </div>
 
     <%= render :partial => 'shared/convert_tool_tips.html', :locals => {:scope => {}} %>


### PR DESCRIPTION
* Because the extension is not announced, this is a temporary fix for the page.