### PR TITLE
Disable printing system properties on agent startup.

### DIFF
--- a/jar-class-loader/src/main/java/com/thoughtworks/gocd/Boot.java
+++ b/jar-class-loader/src/main/java/com/thoughtworks/gocd/Boot.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 ThoughtWorks, Inc.
+ * Copyright 2018 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -58,7 +58,7 @@ public class Boot {
     }
 
     private static boolean shouldLogJVMArgsAndEnvVars() {
-        String shouldLog = System.getProperty("gocd.log.system.properties.on.startup", "Y");
+        String shouldLog = System.getProperty("gocd.log.system.properties.on.startup");
         return "Y".equalsIgnoreCase(shouldLog) || "true".equalsIgnoreCase(shouldLog);
     }
 


### PR DESCRIPTION
A user can enable this option by specifying agent startup arg 
`-Dgocd.log.system.properties.on.startup=Y`

It will print following properties on agent startup

- JVM arguments
- JVM properties
- Environment Variables