### PR TITLE
Upgrade to h2-1.4.197

### DIFF
--- a/server/db/migrate/h2deltas/90_populate_missing_completed_at_transition_id.sql
+++ b/server/db/migrate/h2deltas/90_populate_missing_completed_at_transition_id.sql
@@ -19,7 +19,7 @@
 CREATE TABLE latest_bst AS (SELECT MAX(bst.id) id, bst.buildId, bst.stageId, b.state build_state FROM buildStateTransitions bst inner join builds b on b.id = bst.buildid GROUP BY bst.buildId);
 
 ALTER TABLE latest_bst ADD COLUMN state VARCHAR(255);
-ALTER TABLE latest_bst ADD COLUMN transition_time TIMESTAMP(23, 10);
+ALTER TABLE latest_bst ADD COLUMN transition_time TIMESTAMP;
 
 UPDATE latest_bst SET state = (SELECT currentState FROM buildStateTransitions bst WHERE bst.id = latest_bst.id),
                       transition_time = (select statechangetime from buildstatetransitions bst where bst.id = latest_bst.id);


### PR DESCRIPTION
* Add an option to tweak the lob timeout through system properties.
* The default value for lob timeout is set to 5 minutes as per
   https://www.h2database.com/javadoc/org/h2/engine/DbSettings.html#LOB_TIMEOUT
* Change the default database template to contain an empty db with just
  the "changelog" table. Earlier contained an empty db with "changelog"
  table and SQL migrations 1-85.
