### PR TITLE
[CSS] Fix css for artifacts tab in job details.

### DIFF
--- a/server/webapp/WEB-INF/rails.new/app/assets/stylesheets/new-theme.scss
+++ b/server/webapp/WEB-INF/rails.new/app/assets/stylesheets/new-theme.scss
@@ -4011,6 +4011,9 @@ ul.entity_title {
   .type_label {
     font-weight: bold;
   }
+  .icon_remove {
+    display: inline-block;
+  }
 }
 
 .plugin_form_background {
@@ -4031,7 +4034,7 @@ ul.entity_title {
 
 .plugin-select-form span {
   margin-bottom: 20px;
-  display: block;
+  display:       block;
 }
 
 .add_new_artifact label {
@@ -4043,10 +4046,14 @@ ul.entity_title {
   display: inline-block;
 }
 
-.plugin_key_value .plugin-config-read-only, .plugin_key_value.plugin-config-read-only  {
+.plugin_key_value .plugin-config-read-only, .plugin_key_value.plugin-config-read-only {
   line-height: 20px;
 }
 
 .plugin_key_value.plugin-config-read-only {
   padding: 10px;
+}
+
+#tab-content-of-artifacts .artifact {
+  padding: 0 0 5px 25px;
 }

--- a/server/webapp/WEB-INF/rails.new/app/views/admin/jobs/_artifact_configs.html.erb
+++ b/server/webapp/WEB-INF/rails.new/app/views/admin/jobs/_artifact_configs.html.erb
@@ -73,6 +73,9 @@
   function addOnChangeListenerForStoreInput(event) {
     var inputElement         = jQuery(this);
     var selectedInput        = event.currentTarget || event.target;
+    if (selectedInput.defaultValue === selectedInput.value) {
+      return;
+    }
     var externalArtifactForm = inputElement.closest('.artifact');
     externalArtifactForm.find(".plugged_artifact_template").addClass('hidden');
     externalArtifactForm.find(".plugin-config-read-only").remove();

--- a/server/webapp/WEB-INF/rails.new/app/views/admin/jobs/_external_artifact_form.html.erb
+++ b/server/webapp/WEB-INF/rails.new/app/views/admin/jobs/_external_artifact_form.html.erb
@@ -9,10 +9,10 @@
       <div class="columns medium-2 large-2"><h4 class="type">Type</h4>
         <span class="contextual_help has_go_tip_right" title="There are 3 types of artifacts - build, test and external. When 'Test Artifact' is selected, Go will use this artifact to generate a test report. Test information is placed in the Failures and Test sub-tabs. Test results from multiple jobs are aggregated on the stage detail pages. This allows you to see the results of tests from both functional and unit tests even if they are run in different jobs. When artifact type external is selected, you can configure the external artifact store to which you can push an artifact."/>
       </div>
-      <div class="columns medium-3 large-3"><h4 class="src">Artifact ID</h4>
+      <div class="columns medium-3 large-3"><h4>ID</h4>
         <span class="contextual_help has_go_tip_right" title="This id is used to identify the artifact that is pushed to an external store. The id is used later in a downstream pipeline to fetch the artifact from the external store."/>
       </div>
-      <div class="columns medium-3 large-3 end"><h4 class="dest">Artifact Store ID</h4>
+      <div class="columns medium-3 large-3 end"><h4>Store ID</h4>
         <span class="contextual_help has_go_tip_right" title="This is a reference to the global artifact store defined in the config. At the time of publishing the artifact to an external store, the plugin makes use of the global properties associated with this store id."/>
       </div>
     </div>


### PR DESCRIPTION
* Inline the delete artifact icon so that it doesn't take up the left over space for the entire row.