### PR TITLE
Improve API related error messages.

### DIFF
--- a/api/api-base/src/main/java/com/thoughtworks/go/api/representers/JsonReader.java
+++ b/api/api-base/src/main/java/com/thoughtworks/go/api/representers/JsonReader.java
@@ -41,7 +41,7 @@ public class JsonReader {
 
     public String getString(String property) {
         return optString(property)
-            .orElseThrow(() -> haltBecauseMissingJsonProperty(property));
+            .orElseThrow(() -> haltBecauseMissingJsonProperty(property, jsonObject));
     }
 
     public Optional<Long> optLong(String property) {
@@ -49,7 +49,7 @@ public class JsonReader {
             try {
                 return Optional.ofNullable(jsonObject.get(property).getAsLong());
             } catch (Exception e) {
-                throw haltBecausePropertyIsNotAJsonString(property);
+                throw haltBecausePropertyIsNotAJsonString(property, jsonObject);
             }
         }
         return Optional.empty();
@@ -60,7 +60,7 @@ public class JsonReader {
             try {
                 return Optional.ofNullable(jsonObject.get(property).getAsString());
             } catch (Exception e) {
-                throw haltBecausePropertyIsNotAJsonString(property);
+                throw haltBecausePropertyIsNotAJsonString(property, jsonObject);
             }
         }
         return Optional.empty();
@@ -71,7 +71,7 @@ public class JsonReader {
             try {
                 return Optional.of(new CaseInsensitiveString(jsonObject.get(property).getAsString()));
             } catch (Exception e) {
-                throw haltBecausePropertyIsNotAJsonString(property);
+                throw haltBecausePropertyIsNotAJsonString(property, jsonObject);
             }
         }
         return Optional.empty();
@@ -82,7 +82,7 @@ public class JsonReader {
             try {
                 return Optional.ofNullable(jsonObject.getAsJsonArray(property));
             } catch (Exception e) {
-                throw haltBecausePropertyIsNotAJsonArray(property);
+                throw haltBecausePropertyIsNotAJsonArray(property, jsonObject);
             }
         }
         return Optional.empty();
@@ -93,7 +93,7 @@ public class JsonReader {
             try {
                 return Optional.of(jsonObject.getAsJsonPrimitive(property).getAsBoolean());
             } catch (Exception e) {
-                throw haltBecausePropertyIsNotAJsonBoolean(property);
+                throw haltBecausePropertyIsNotAJsonBoolean(property, jsonObject);
             }
         }
         return Optional.empty();
@@ -104,7 +104,7 @@ public class JsonReader {
             try {
                 return Optional.of(new JsonReader(jsonObject.getAsJsonObject(property)));
             } catch (Exception e) {
-                throw haltBecausePropertyIsNotAJsonObject(property);
+                throw haltBecausePropertyIsNotAJsonObject(property, jsonObject);
             }
         }
         return Optional.empty();
@@ -112,7 +112,7 @@ public class JsonReader {
 
     public JsonReader readJsonObject(String property) {
         return optJsonObject(property)
-            .orElseThrow(() -> haltBecauseMissingJsonProperty(property));
+            .orElseThrow(() -> haltBecauseMissingJsonProperty(property, jsonObject));
     }
 
     public boolean hasJsonObject(String property) {
@@ -140,7 +140,7 @@ public class JsonReader {
                         .map(JsonElement::getAsString)
                         .collect(Collectors.toList()));
             } catch (Exception e) {
-                throw haltBecausePropertyIsNotAJsonStringArray(property);
+                throw haltBecausePropertyIsNotAJsonStringArray(property, jsonObject);
             }
         }
 

--- a/api/api-base/src/main/java/com/thoughtworks/go/api/util/HaltApiMessages.java
+++ b/api/api-base/src/main/java/com/thoughtworks/go/api/util/HaltApiMessages.java
@@ -16,6 +16,7 @@
 
 package com.thoughtworks.go.api.util;
 
+import com.google.gson.JsonObject;
 import com.thoughtworks.go.config.CaseInsensitiveString;
 
 import static java.lang.String.format;
@@ -47,7 +48,7 @@ public abstract class HaltApiMessages {
     }
 
     public static String rateLimitExceeded() {
-        return "Rate Limit Exceeded";
+        return "Rate Limit Exceeded.";
     }
 
     public static String errorWhileEncryptingMessage() {
@@ -66,27 +67,27 @@ public abstract class HaltApiMessages {
         return "Missing required header 'X-GoCD-Confirm' with value 'true'";
     }
 
-    public static String propertyIsNotAJsonString(String property) {
-        return String.format("Could not read property '%s' as a String", property);
+    public static String propertyIsNotAJsonString(String property, JsonObject jsonObject) {
+        return String.format("Could not read property '%s' as a String in json `%s` ", property, jsonObject);
     }
 
-    public static String propertyIsNotAJsonObject(String property) {
-        return String.format("Could not read property '%s' as a JsonObject", property);
+    public static String propertyIsNotAJsonObject(String property, JsonObject jsonObject) {
+        return String.format("Could not read property '%s' as a JsonObject in json `%s`", property, jsonObject);
     }
 
-    public static String propertyIsNotAJsonStringArray(String property) {
-        return String.format("Could not read property '%s' as a JsonArray containing string", property);
+    public static String propertyIsNotAJsonStringArray(String property, JsonObject jsonObject) {
+        return String.format("Could not read property '%s' as a JsonArray containing string in `%s`", property, jsonObject);
     }
 
-    public static String propertyIsNotAJsonArray(String property) {
-        return String.format("Could not read property '%s' as a JsonArray", property);
+    public static String propertyIsNotAJsonArray(String property, JsonObject jsonObject) {
+        return String.format("Could not read property '%s' as a JsonArray in json `%s`", property, jsonObject);
     }
 
-    public static String propertyIsNotAJsonBoolean(String property) {
-        return String.format("Could not read property '%s' as a Boolean", property);
+    public static String propertyIsNotAJsonBoolean(String property, JsonObject jsonObject) {
+        return String.format("Could not read property '%s' as a Boolean in json `%s` ", property, jsonObject);
     }
 
-    public static String missingJsonProperty(String property) {
-        return format("Json does not contain property '%s'", property);
+    public static String missingJsonProperty(String property, JsonObject jsonObject) {
+        return format("Json `%s` does not contain property '%s'", jsonObject, property);
     }
 }

--- a/api/api-base/src/main/java/com/thoughtworks/go/api/util/HaltApiResponses.java
+++ b/api/api-base/src/main/java/com/thoughtworks/go/api/util/HaltApiResponses.java
@@ -17,6 +17,7 @@
 package com.thoughtworks.go.api.util;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.google.gson.JsonObject;
 import com.thoughtworks.go.config.CaseInsensitiveString;
 import org.springframework.http.HttpStatus;
 import spark.HaltException;
@@ -65,28 +66,28 @@ public abstract class HaltApiResponses {
         return halt(HttpStatus.BAD_REQUEST.value(), MessageJson.create(deprecatedConfirmHeaderMissing()));
     }
 
-    public static HaltException haltBecausePropertyIsNotAJsonString(String property) {
-        return halt(HttpStatus.UNPROCESSABLE_ENTITY.value(), MessageJson.create(propertyIsNotAJsonString(property)));
+    public static HaltException haltBecausePropertyIsNotAJsonString(String property, JsonObject jsonObject) {
+        return halt(HttpStatus.UNPROCESSABLE_ENTITY.value(), MessageJson.create(propertyIsNotAJsonString(property, jsonObject)));
     }
 
-    public static HaltException haltBecausePropertyIsNotAJsonArray(String property) {
-        return halt(HttpStatus.UNPROCESSABLE_ENTITY.value(), MessageJson.create(propertyIsNotAJsonArray(property)));
+    public static HaltException haltBecausePropertyIsNotAJsonArray(String property, JsonObject jsonObject) {
+        return halt(HttpStatus.UNPROCESSABLE_ENTITY.value(), MessageJson.create(propertyIsNotAJsonArray(property, jsonObject)));
     }
 
-    public static HaltException haltBecausePropertyIsNotAJsonBoolean(String property) {
-        return halt(HttpStatus.UNPROCESSABLE_ENTITY.value(), MessageJson.create(propertyIsNotAJsonBoolean(property)));
+    public static HaltException haltBecausePropertyIsNotAJsonBoolean(String property, JsonObject jsonObject) {
+        return halt(HttpStatus.UNPROCESSABLE_ENTITY.value(), MessageJson.create(propertyIsNotAJsonBoolean(property, jsonObject)));
     }
 
-    public static HaltException haltBecausePropertyIsNotAJsonObject(String property) {
-        return halt(HttpStatus.UNPROCESSABLE_ENTITY.value(), MessageJson.create(propertyIsNotAJsonObject(property)));
+    public static HaltException haltBecausePropertyIsNotAJsonObject(String property, JsonObject jsonObject) {
+        return halt(HttpStatus.UNPROCESSABLE_ENTITY.value(), MessageJson.create(propertyIsNotAJsonObject(property, jsonObject)));
     }
 
-    public static HaltException haltBecausePropertyIsNotAJsonStringArray(String property) {
-        return halt(HttpStatus.UNPROCESSABLE_ENTITY.value(), MessageJson.create(propertyIsNotAJsonStringArray(property)));
+    public static HaltException haltBecausePropertyIsNotAJsonStringArray(String property, JsonObject jsonObject) {
+        return halt(HttpStatus.UNPROCESSABLE_ENTITY.value(), MessageJson.create(propertyIsNotAJsonStringArray(property, jsonObject)));
     }
 
-    public static HaltException haltBecauseMissingJsonProperty(String property) {
-        return halt(HttpStatus.UNPROCESSABLE_ENTITY.value(), MessageJson.create(missingJsonProperty(property)));
+    public static HaltException haltBecauseMissingJsonProperty(String property, JsonObject jsonObject) {
+        return halt(HttpStatus.UNPROCESSABLE_ENTITY.value(), MessageJson.create(missingJsonProperty(property, jsonObject)));
     }
 
     public static HaltException haltBecauseOfReason(String message) {

--- a/api/api-encryption-v1/src/test/groovy/com/thoughtworks/go/apiv1/admin/encryption/EncryptionControllerDelegateTest.groovy
+++ b/api/api-encryption-v1/src/test/groovy/com/thoughtworks/go/apiv1/admin/encryption/EncryptionControllerDelegateTest.groovy
@@ -30,7 +30,8 @@ import org.junit.jupiter.api.Test
 
 import java.util.concurrent.TimeUnit
 
-import static com.thoughtworks.go.api.util.HaltApiMessages.*
+import static com.thoughtworks.go.api.util.HaltApiMessages.errorWhileEncryptingMessage
+import static com.thoughtworks.go.api.util.HaltApiMessages.rateLimitExceeded
 import static org.mockito.Mockito.doThrow
 import static org.mockito.Mockito.spy
 
@@ -93,7 +94,7 @@ class EncryptionControllerDelegateTest implements SecurityServiceTrait, Controll
         assertThatResponse()
           .isUnprocessableEntity()
           .hasContentType(controller.mimeType)
-          .hasJsonMessage(missingJsonProperty("value"))
+          .hasJsonMessage("Json `{\\\"foo\\\":\\\"bar\\\"}` does not contain property 'value'")
       }
 
       @Nested

--- a/api/api-pipeline-selection-v1/src/test/groovy/com/thoughtworks/go/apiv1/pipelineselection/representers/PipelineSelectionsRepresenterTest.groovy
+++ b/api/api-pipeline-selection-v1/src/test/groovy/com/thoughtworks/go/apiv1/pipelineselection/representers/PipelineSelectionsRepresenterTest.groovy
@@ -16,6 +16,8 @@
 
 package com.thoughtworks.go.apiv1.pipelineselection.representers
 
+import com.google.gson.JsonArray
+import com.google.gson.JsonObject
 import com.thoughtworks.go.api.util.GsonTransformer
 import com.thoughtworks.go.api.util.MessageJson
 import com.thoughtworks.go.config.BasicPipelineConfigs
@@ -101,20 +103,28 @@ class PipelineSelectionsRepresenterTest {
 
     @Test
     void 'should blow up on bad blacklist type'() {
+      def jsonObject = new JsonObject()
+      jsonObject.add("blacklist", new JsonObject())
+
       Assertions.assertThatCode({
         PipelineSelectionsRepresenter.fromJSON(GsonTransformer.getInstance().jsonReaderFrom([blacklist: [:]]))
       }).isInstanceOf(HaltException)
         .hasFieldOrPropertyWithValue("statusCode", 422)
-        .hasFieldOrPropertyWithValue("body", MessageJson.create(propertyIsNotAJsonBoolean("blacklist")))
+        .hasFieldOrPropertyWithValue("body", MessageJson.create(propertyIsNotAJsonBoolean("blacklist", jsonObject)))
     }
 
     @Test
     void 'should blow up on bad selection type'() {
+      def jsonObject = new JsonObject()
+      def array = new JsonArray()
+      array.add(new JsonObject())
+
+      jsonObject.add("selections", array)
       Assertions.assertThatCode({
         PipelineSelectionsRepresenter.fromJSON(GsonTransformer.getInstance().jsonReaderFrom([selections: [[:]]]))
       }).isInstanceOf(HaltException)
         .hasFieldOrPropertyWithValue("statusCode", 422)
-        .hasFieldOrPropertyWithValue("body", MessageJson.create(propertyIsNotAJsonStringArray("selections")))
+        .hasFieldOrPropertyWithValue("body", MessageJson.create(propertyIsNotAJsonStringArray("selections", jsonObject)))
     }
   }
 }


### PR DESCRIPTION
If a mandatory property is not provided by a user, the error message currently reads

`"Json does not contain property 'origin'"`

Since the above message does not indicate which part of the API had to contain the mandatory property, adding that info makes sense. With this PR, the error message now reads

`"Json {\"pipeline\":\"\",\"stage\":\"defaultStage\",\"job\":\"defaultJob\",\"artifact_id\":\"helpless-quinoa\",\"configuration\":[{\"key\":\"fetch_property\",\"value\":\"foo\"}]} does not contain property 'origin'"`

@ketan - if this is alright, I'll do the same for all the other messages in `HaltApiMessages.java`.