### PR TITLE
Data sharing additional parameters to report

### DIFF
--- a/api/api-data-sharing-reporting-v1/src/main/java/com/thoughtworks/go/apiv1/datasharing/reporting/UsageStatisticsReportingControllerV1Delegate.java
+++ b/api/api-data-sharing-reporting-v1/src/main/java/com/thoughtworks/go/apiv1/datasharing/reporting/UsageStatisticsReportingControllerV1Delegate.java
@@ -22,7 +22,7 @@ import com.thoughtworks.go.api.ApiVersion;
 import com.thoughtworks.go.api.spring.ApiAuthenticationHelper;
 import com.thoughtworks.go.apiv1.datasharing.reporting.representers.UsageStatisticsReportingRepresenter;
 import com.thoughtworks.go.domain.UsageStatisticsReporting;
-import com.thoughtworks.go.server.service.DataSharingUsageStatisticsReportingService;
+import com.thoughtworks.go.server.service.datasharing.DataSharingUsageStatisticsReportingService;
 import com.thoughtworks.go.server.service.result.HttpLocalizedOperationResult;
 import com.thoughtworks.go.spark.Routes.DataSharing;
 import spark.Request;

--- a/api/api-data-sharing-reporting-v1/src/main/java/com/thoughtworks/go/apiv1/datasharing/reporting/spring/UsageStatisticsReportingV1Controller.java
+++ b/api/api-data-sharing-reporting-v1/src/main/java/com/thoughtworks/go/apiv1/datasharing/reporting/spring/UsageStatisticsReportingV1Controller.java
@@ -18,7 +18,7 @@ package com.thoughtworks.go.apiv1.datasharing.reporting.spring;
 
 import com.thoughtworks.go.api.spring.ApiAuthenticationHelper;
 import com.thoughtworks.go.apiv1.datasharing.reporting.UsageStatisticsReportingControllerV1Delegate;
-import com.thoughtworks.go.server.service.DataSharingUsageStatisticsReportingService;
+import com.thoughtworks.go.server.service.datasharing.DataSharingUsageStatisticsReportingService;
 import com.thoughtworks.go.spark.spring.SparkSpringController;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;

--- a/api/api-data-sharing-reporting-v1/src/test/groovy/com/thoughtworks/go/apiv1/datasharing/reporting/UsageStatisticsReportingControllerV1DelegateTest.groovy
+++ b/api/api-data-sharing-reporting-v1/src/test/groovy/com/thoughtworks/go/apiv1/datasharing/reporting/UsageStatisticsReportingControllerV1DelegateTest.groovy
@@ -20,7 +20,7 @@ import com.thoughtworks.go.api.SecurityTestTrait
 import com.thoughtworks.go.api.spring.ApiAuthenticationHelper
 import com.thoughtworks.go.apiv1.datasharing.reporting.representers.UsageStatisticsReportingRepresenter
 import com.thoughtworks.go.domain.UsageStatisticsReporting
-import com.thoughtworks.go.server.service.DataSharingUsageStatisticsReportingService
+import com.thoughtworks.go.server.service.datasharing.DataSharingUsageStatisticsReportingService
 import com.thoughtworks.go.spark.ControllerTrait
 import com.thoughtworks.go.spark.NormalUserSecurity
 import com.thoughtworks.go.spark.SecurityServiceTrait

--- a/api/api-data-sharing-settings-v1/src/main/java/com/thoughtworks/go/apiv1/datasharing/settings/DataSharingSettingsControllerV1Delegate.java
+++ b/api/api-data-sharing-settings-v1/src/main/java/com/thoughtworks/go/apiv1/datasharing/settings/DataSharingSettingsControllerV1Delegate.java
@@ -26,7 +26,7 @@ import com.thoughtworks.go.api.spring.ApiAuthenticationHelper;
 import com.thoughtworks.go.api.util.GsonTransformer;
 import com.thoughtworks.go.apiv1.datasharing.settings.representers.DataSharingSettingsRepresenter;
 import com.thoughtworks.go.server.domain.DataSharingSettings;
-import com.thoughtworks.go.server.service.DataSharingSettingsService;
+import com.thoughtworks.go.server.service.datasharing.DataSharingSettingsService;
 import com.thoughtworks.go.server.service.EntityHashingService;
 import com.thoughtworks.go.server.service.result.HttpLocalizedOperationResult;
 import com.thoughtworks.go.spark.Routes.DataSharing;

--- a/api/api-data-sharing-settings-v1/src/main/java/com/thoughtworks/go/apiv1/datasharing/settings/spring/DataSharingSettingsV1Controller.java
+++ b/api/api-data-sharing-settings-v1/src/main/java/com/thoughtworks/go/apiv1/datasharing/settings/spring/DataSharingSettingsV1Controller.java
@@ -18,6 +18,7 @@ package com.thoughtworks.go.apiv1.datasharing.settings.spring;
 
 import com.thoughtworks.go.api.spring.ApiAuthenticationHelper;
 import com.thoughtworks.go.apiv1.datasharing.settings.DataSharingSettingsControllerV1Delegate;
+import com.thoughtworks.go.server.service.datasharing.DataSharingNotification;
 import com.thoughtworks.go.server.service.datasharing.DataSharingSettingsService;
 import com.thoughtworks.go.server.service.EntityHashingService;
 import com.thoughtworks.go.spark.spring.SparkSpringController;
@@ -30,8 +31,11 @@ public class DataSharingSettingsV1Controller implements SparkSpringController {
     private final DataSharingSettingsControllerV1Delegate delegate;
 
     @Autowired
-    public DataSharingSettingsV1Controller(DataSharingSettingsService dataSharingUsageReportingService, ApiAuthenticationHelper apiAuthenticationHelper, EntityHashingService entityHashingService, TimeProvider timeProvider) {
-        delegate = new DataSharingSettingsControllerV1Delegate(apiAuthenticationHelper, dataSharingUsageReportingService, entityHashingService, timeProvider);
+    public DataSharingSettingsV1Controller(DataSharingSettingsService dataSharingUsageReportingService,
+                                           ApiAuthenticationHelper apiAuthenticationHelper, EntityHashingService entityHashingService,
+                                           TimeProvider timeProvider, DataSharingNotification dataSharingNotification) {
+        delegate = new DataSharingSettingsControllerV1Delegate(apiAuthenticationHelper, dataSharingUsageReportingService,
+                entityHashingService, timeProvider, dataSharingNotification);
     }
 
     @Override

--- a/api/api-data-sharing-settings-v1/src/main/java/com/thoughtworks/go/apiv1/datasharing/settings/spring/DataSharingSettingsV1Controller.java
+++ b/api/api-data-sharing-settings-v1/src/main/java/com/thoughtworks/go/apiv1/datasharing/settings/spring/DataSharingSettingsV1Controller.java
@@ -18,7 +18,7 @@ package com.thoughtworks.go.apiv1.datasharing.settings.spring;
 
 import com.thoughtworks.go.api.spring.ApiAuthenticationHelper;
 import com.thoughtworks.go.apiv1.datasharing.settings.DataSharingSettingsControllerV1Delegate;
-import com.thoughtworks.go.server.service.DataSharingSettingsService;
+import com.thoughtworks.go.server.service.datasharing.DataSharingSettingsService;
 import com.thoughtworks.go.server.service.EntityHashingService;
 import com.thoughtworks.go.spark.spring.SparkSpringController;
 import com.thoughtworks.go.util.TimeProvider;

--- a/api/api-data-sharing-settings-v1/src/test/groovy/com/thoughtworks/go/apiv1/datasharing/settings/DataSharingSettingsControllerV1DelegateTest.groovy
+++ b/api/api-data-sharing-settings-v1/src/test/groovy/com/thoughtworks/go/apiv1/datasharing/settings/DataSharingSettingsControllerV1DelegateTest.groovy
@@ -20,6 +20,7 @@ import com.thoughtworks.go.api.SecurityTestTrait
 import com.thoughtworks.go.api.spring.ApiAuthenticationHelper
 import com.thoughtworks.go.apiv1.datasharing.settings.representers.DataSharingSettingsRepresenter
 import com.thoughtworks.go.server.domain.DataSharingSettings
+import com.thoughtworks.go.server.service.datasharing.DataSharingNotification
 import com.thoughtworks.go.server.service.datasharing.DataSharingSettingsService
 import com.thoughtworks.go.server.service.EntityHashingService
 import com.thoughtworks.go.spark.AdminUserSecurity
@@ -50,10 +51,13 @@ class DataSharingSettingsControllerV1DelegateTest implements SecurityServiceTrai
     EntityHashingService entityHashingService
     @Mock
     TimeProvider timeProvider
+    @Mock
+    DataSharingNotification dataSharingNotification
 
     @Override
     DataSharingSettingsControllerV1Delegate createControllerInstance() {
-        new DataSharingSettingsControllerV1Delegate(new ApiAuthenticationHelper(securityService, goConfigService), dataSharingSettingsService, entityHashingService, timeProvider)
+        new DataSharingSettingsControllerV1Delegate(new ApiAuthenticationHelper(securityService, goConfigService),
+                dataSharingSettingsService, entityHashingService, timeProvider, dataSharingNotification)
     }
 
     @Nested
@@ -95,6 +99,43 @@ class DataSharingSettingsControllerV1DelegateTest implements SecurityServiceTrai
                   .hasContentType(controller.mimeType)
                   .hasEtag('"' + etag + '"')
                   .hasBodyWithJsonObject(dataSharingSettings, DataSharingSettingsRepresenter.class)
+            }
+        }
+    }
+
+    @Nested
+    class getDataSharingNotificationForCurrentUser {
+        @Nested
+        class Security implements SecurityTestTrait, NormalUserSecurity {
+
+            @Override
+            String getControllerMethodUnderTest() {
+                return "getDataSharingNotificationForCurrentUser"
+            }
+
+            @Override
+            void makeHttpCall() {
+                getWithApiHeader(controller.controllerPath('/notification_auth'))
+            }
+        }
+
+        @Nested
+        class AsNormalUser {
+            @BeforeEach
+            void setUp() {
+                enableSecurity()
+                loginAsUser()
+            }
+
+            @Test
+            void 'get data sharing settings notification'() {
+                when(dataSharingNotification.allowNotificationFor(currentUsername())).thenReturn(true);
+                getWithApiHeader(controller.controllerPath('/notification_auth'));
+
+                assertThatResponse()
+                  .isOk()
+                  .hasContentType(controller.mimeType)
+                  .hasJsonBody("{\"show_notification\" : true }");
             }
         }
     }

--- a/api/api-data-sharing-settings-v1/src/test/groovy/com/thoughtworks/go/apiv1/datasharing/settings/DataSharingSettingsControllerV1DelegateTest.groovy
+++ b/api/api-data-sharing-settings-v1/src/test/groovy/com/thoughtworks/go/apiv1/datasharing/settings/DataSharingSettingsControllerV1DelegateTest.groovy
@@ -20,7 +20,7 @@ import com.thoughtworks.go.api.SecurityTestTrait
 import com.thoughtworks.go.api.spring.ApiAuthenticationHelper
 import com.thoughtworks.go.apiv1.datasharing.settings.representers.DataSharingSettingsRepresenter
 import com.thoughtworks.go.server.domain.DataSharingSettings
-import com.thoughtworks.go.server.service.DataSharingSettingsService
+import com.thoughtworks.go.server.service.datasharing.DataSharingSettingsService
 import com.thoughtworks.go.server.service.EntityHashingService
 import com.thoughtworks.go.spark.AdminUserSecurity
 import com.thoughtworks.go.spark.ControllerTrait

--- a/api/api-data-sharing-usage-data-v1/src/main/java/com/thoughtworks/go/apiv1/datasharing/usagedata/UsageStatisticsControllerV1Delegate.java
+++ b/api/api-data-sharing-usage-data-v1/src/main/java/com/thoughtworks/go/apiv1/datasharing/usagedata/UsageStatisticsControllerV1Delegate.java
@@ -21,7 +21,7 @@ import com.thoughtworks.go.api.ApiVersion;
 import com.thoughtworks.go.api.spring.ApiAuthenticationHelper;
 import com.thoughtworks.go.apiv1.datasharing.usagedata.representers.UsageStatisticsRepresenter;
 import com.thoughtworks.go.server.domain.UsageStatistics;
-import com.thoughtworks.go.server.service.DataSharingUsageDataService;
+import com.thoughtworks.go.server.service.datasharing.DataSharingUsageDataService;
 import com.thoughtworks.go.server.util.RSAEncryptionHelper;
 import com.thoughtworks.go.spark.Routes.DataSharing;
 import com.thoughtworks.go.util.SystemEnvironment;

--- a/api/api-data-sharing-usage-data-v1/src/main/java/com/thoughtworks/go/apiv1/datasharing/usagedata/representers/UsageStatisticsRepresenter.java
+++ b/api/api-data-sharing-usage-data-v1/src/main/java/com/thoughtworks/go/apiv1/datasharing/usagedata/representers/UsageStatisticsRepresenter.java
@@ -21,14 +21,17 @@ import com.thoughtworks.go.server.domain.UsageStatistics;
 import com.thoughtworks.go.spark.Routes.DataSharing;
 
 public class UsageStatisticsRepresenter {
+    private static final int MESSAGE_SCHEMA_VERSION = 1;
     public static void toJSON(OutputWriter outputWriter, UsageStatistics usageStatistics) {
         outputWriter
-                .addLinks(linksWriter -> linksWriter.addLink("self", DataSharing.USAGE_DATA_PATH))
-                .addChild("_embedded", childWriter -> {
+                .add("server_id", usageStatistics.serverId())
+                .add("message_version", MESSAGE_SCHEMA_VERSION)
+                .addChild("data", childWriter -> {
                     childWriter
                             .add("pipeline_count", usageStatistics.pipelineCount())
                             .add("agent_count", usageStatistics.agentCount())
-                            .add("oldest_pipeline_execution_time", usageStatistics.oldestPipelineExecutionTime());
+                            .add("oldest_pipeline_execution_time", usageStatistics.oldestPipelineExecutionTime())
+                            .add("gocd_version", usageStatistics.gocdVersion());
                 });
     }
 

--- a/api/api-data-sharing-usage-data-v1/src/main/java/com/thoughtworks/go/apiv1/datasharing/usagedata/spring/UsageStatisticsControllerV1.java
+++ b/api/api-data-sharing-usage-data-v1/src/main/java/com/thoughtworks/go/apiv1/datasharing/usagedata/spring/UsageStatisticsControllerV1.java
@@ -18,7 +18,7 @@ package com.thoughtworks.go.apiv1.datasharing.usagedata.spring;
 
 import com.thoughtworks.go.api.spring.ApiAuthenticationHelper;
 import com.thoughtworks.go.apiv1.datasharing.usagedata.UsageStatisticsControllerV1Delegate;
-import com.thoughtworks.go.server.service.DataSharingUsageDataService;
+import com.thoughtworks.go.server.service.datasharing.DataSharingUsageDataService;
 import com.thoughtworks.go.spark.spring.SparkSpringController;
 import com.thoughtworks.go.util.SystemEnvironment;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/api/api-data-sharing-usage-data-v1/src/test/groovy/com/thoughtworks/go/apiv1/datasharing/usagedata/UsageStatisticsControllerV1DelegateTest.groovy
+++ b/api/api-data-sharing-usage-data-v1/src/test/groovy/com/thoughtworks/go/apiv1/datasharing/usagedata/UsageStatisticsControllerV1DelegateTest.groovy
@@ -20,7 +20,7 @@ import com.thoughtworks.go.api.SecurityTestTrait
 import com.thoughtworks.go.api.spring.ApiAuthenticationHelper
 import com.thoughtworks.go.apiv1.datasharing.usagedata.representers.UsageStatisticsRepresenter
 import com.thoughtworks.go.server.domain.UsageStatistics
-import com.thoughtworks.go.server.service.DataSharingUsageDataService
+import com.thoughtworks.go.server.service.datasharing.DataSharingUsageDataService
 import com.thoughtworks.go.server.util.RSAEncryptionHelper
 import com.thoughtworks.go.spark.AdminUserSecurity
 import com.thoughtworks.go.spark.ControllerTrait

--- a/api/api-data-sharing-usage-data-v1/src/test/groovy/com/thoughtworks/go/apiv1/datasharing/usagedata/UsageStatisticsControllerV1DelegateTest.groovy
+++ b/api/api-data-sharing-usage-data-v1/src/test/groovy/com/thoughtworks/go/apiv1/datasharing/usagedata/UsageStatisticsControllerV1DelegateTest.groovy
@@ -79,7 +79,7 @@ class UsageStatisticsControllerV1DelegateTest implements SecurityServiceTrait, C
 
       @Test
       void 'get usage statistics'() {
-        def metrics = new UsageStatistics(10l, 20l, 1527244129553)
+        def metrics = new UsageStatistics(10l, 20l, 1527244129553, serverId, gocdVersion)
         when(dataSharingService.get()).thenReturn(metrics)
 
         getWithApiHeader(controller.controllerPath())
@@ -117,7 +117,7 @@ class UsageStatisticsControllerV1DelegateTest implements SecurityServiceTrait, C
 
       @Test
       void 'get encrypted usage statistics'() {
-        def metrics = new UsageStatistics(10l, 20l, 1527244129553)
+        def metrics = new UsageStatistics(10l, 20l, 1527244129553, serverId, gocdVersion)
         File privateKeyFile = new File(getClass().getClassLoader().getResource("private_key.pem").getFile())
         File publicKeyFile = new File(getClass().getClassLoader().getResource("public_key.pem").getFile())
 

--- a/api/api-data-sharing-usage-data-v1/src/test/groovy/com/thoughtworks/go/apiv1/datasharing/usagedata/representers/UsageStatisticsRepresenterTest.groovy
+++ b/api/api-data-sharing-usage-data-v1/src/test/groovy/com/thoughtworks/go/apiv1/datasharing/usagedata/representers/UsageStatisticsRepresenterTest.groovy
@@ -26,32 +26,32 @@ class UsageStatisticsRepresenterTest {
 
   @Test
   void  "should represent usage statistics"() {
-    def actualJson = toObjectString({ UsageStatisticsRepresenter.toJSON(it, new UsageStatistics(100l, 10l, 1527244129553)) })
+    def actualJson = toObjectString({ UsageStatisticsRepresenter.toJSON(it, new UsageStatistics(100l, 10l, 1527244129553, "server-id", "18.7.0")) })
     def expectedJson = [
-      _links        : [
-        self: [href: 'http://test.host/go/api/internal/data_sharing/usagedata']
-      ],
-      "_embedded": [
-        pipeline_count:         100,
-        agent_count:       10,
-        oldest_pipeline_execution_time: 1527244129553
-      ]
+            "server_id"     : "server-id",
+            "message_version": 1,
+            "data"        : [
+                    pipeline_count                : 100,
+                    agent_count                   : 10,
+                    oldest_pipeline_execution_time: 1527244129553,
+                    gocd_version: "18.7.0"
+            ]
     ]
     assertThatJson(actualJson).isEqualTo(expectedJson)
   }
 
   @Test
   void  "should handle null oldest_pipeline_execution_time"() {
-    def actualJson = toObjectString({ UsageStatisticsRepresenter.toJSON(it, new UsageStatistics(100l, 10l, null)) })
+    def actualJson = toObjectString({ UsageStatisticsRepresenter.toJSON(it, new UsageStatistics(100l, 10l, null, "server-id", "18.7.0")) })
     def expectedJson = [
-      _links        : [
-        self: [href: 'http://test.host/go/api/internal/data_sharing/usagedata']
-      ],
-      "_embedded": [
-        pipeline_count:         100,
-        agent_count:       10,
-        oldest_pipeline_execution_time: 0
-      ]
+            "server_id"     : "server-id",
+            "message_version": 1,
+            "data"        : [
+                    pipeline_count                : 100,
+                    agent_count                   : 10,
+                    oldest_pipeline_execution_time: 0,
+                    gocd_version: "18.7.0"
+            ]
     ]
     assertThatJson(actualJson).isEqualTo(expectedJson)
   }

--- a/server/src/main/java/com/thoughtworks/go/server/domain/UsageStatistics.java
+++ b/server/src/main/java/com/thoughtworks/go/server/domain/UsageStatistics.java
@@ -20,11 +20,23 @@ public class UsageStatistics {
     private final long pipelineCount;
     private final long agentCount;
     private final Long oldestPipelineExecutionTime;
+    private final String serverId;
+    private final String gocdVersion;
 
-    public UsageStatistics(Long pipelineCount, Long agentCount, Long oldestPipelineExecutionTime) {
+    public UsageStatistics(Long pipelineCount, Long agentCount, Long oldestPipelineExecutionTime, String serverId, String gocdVersion) {
         this.pipelineCount = pipelineCount;
         this.agentCount = agentCount;
         this.oldestPipelineExecutionTime = oldestPipelineExecutionTime != null ? oldestPipelineExecutionTime : 0l;
+        this.serverId = serverId;
+        this.gocdVersion = gocdVersion;
+    }
+
+    public String serverId() {
+        return serverId;
+    }
+
+    public String gocdVersion() {
+        return gocdVersion;
     }
 
     public long pipelineCount() {

--- a/server/src/main/java/com/thoughtworks/go/server/initializers/ApplicationInitializer.java
+++ b/server/src/main/java/com/thoughtworks/go/server/initializers/ApplicationInitializer.java
@@ -33,6 +33,8 @@ import com.thoughtworks.go.server.materials.MaterialUpdateService;
 import com.thoughtworks.go.server.materials.SCMMaterialSource;
 import com.thoughtworks.go.server.newsecurity.filters.InvalidateAuthenticationOnSecurityConfigChangeFilter;
 import com.thoughtworks.go.server.service.*;
+import com.thoughtworks.go.server.service.datasharing.DataSharingSettingsService;
+import com.thoughtworks.go.server.service.datasharing.DataSharingUsageStatisticsReportingService;
 import com.thoughtworks.go.server.service.support.ResourceMonitoring;
 import com.thoughtworks.go.server.service.support.toggle.FeatureToggleService;
 import com.thoughtworks.go.server.service.support.toggle.Toggles;

--- a/server/src/main/java/com/thoughtworks/go/server/service/datasharing/DataSharingNotification.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/datasharing/DataSharingNotification.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2018 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.server.service.datasharing;
+
+import com.thoughtworks.go.server.domain.Username;
+import com.thoughtworks.go.server.service.SecurityService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class DataSharingNotification {
+    private final SecurityService securityService;
+
+    @Autowired
+    public DataSharingNotification(SecurityService securityService) {
+        this.securityService = securityService;
+    }
+
+    public boolean allowNotificationFor(Username username) {
+        return securityService.isUserAdmin(username);
+    }
+}

--- a/server/src/main/java/com/thoughtworks/go/server/service/datasharing/DataSharingSettingsService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/datasharing/DataSharingSettingsService.java
@@ -14,10 +14,13 @@
  * limitations under the License.
  */
 
-package com.thoughtworks.go.server.service;
+package com.thoughtworks.go.server.service.datasharing;
 
 import com.thoughtworks.go.server.domain.DataSharingSettings;
 import com.thoughtworks.go.server.dao.DataSharingSettingsSqlMapDao;
+import com.thoughtworks.go.server.domain.Username;
+import com.thoughtworks.go.server.service.EntityHashingService;
+import com.thoughtworks.go.server.service.SecurityService;
 import com.thoughtworks.go.server.transaction.TransactionSynchronizationManager;
 import com.thoughtworks.go.server.transaction.TransactionTemplate;
 import com.thoughtworks.go.util.SystemEnvironment;

--- a/server/src/main/java/com/thoughtworks/go/server/service/datasharing/DataSharingUsageDataService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/datasharing/DataSharingUsageDataService.java
@@ -14,13 +14,15 @@
  * limitations under the License.
  */
 
-package com.thoughtworks.go.server.service;
+package com.thoughtworks.go.server.service.datasharing;
 
 import com.thoughtworks.go.CurrentGoCDVersion;
 import com.thoughtworks.go.config.CruiseConfig;
 import com.thoughtworks.go.domain.JobStateTransition;
 import com.thoughtworks.go.server.dao.JobInstanceSqlMapDao;
 import com.thoughtworks.go.server.domain.UsageStatistics;
+import com.thoughtworks.go.server.service.GoConfigService;
+import com.thoughtworks.go.server.service.datasharing.DataSharingUsageStatisticsReportingService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -40,7 +42,7 @@ public class DataSharingUsageDataService {
     }
 
     public UsageStatistics get() {
-        CruiseConfig config = goConfigService.cruiseConfig();
+        CruiseConfig config = goConfigService.getCurrentConfig();
         JobStateTransition jobStateTransition = jobInstanceSqlMapDao.oldestBuild();
         Long oldestPipelineExecutionTime = jobStateTransition == null ? null : jobStateTransition.getStateChangeTime().getTime();
         long nonElasticAgentCount = config.agents().parallelStream().filter(agentConfig -> !agentConfig.isElastic()).count();

--- a/server/src/main/java/com/thoughtworks/go/server/service/datasharing/DataSharingUsageStatisticsReportingService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/datasharing/DataSharingUsageStatisticsReportingService.java
@@ -14,10 +14,11 @@
  * limitations under the License.
  */
 
-package com.thoughtworks.go.server.service;
+package com.thoughtworks.go.server.service.datasharing;
 
 import com.thoughtworks.go.domain.UsageStatisticsReporting;
 import com.thoughtworks.go.server.dao.UsageStatisticsReportingSqlMapDao;
+import com.thoughtworks.go.server.service.datasharing.DataSharingSettingsService;
 import com.thoughtworks.go.server.service.result.HttpLocalizedOperationResult;
 import com.thoughtworks.go.util.Clock;
 import com.thoughtworks.go.util.SystemEnvironment;

--- a/server/src/test-fast/java/com/thoughtworks/go/server/initializers/ApplicationInitializerTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/initializers/ApplicationInitializerTest.java
@@ -33,6 +33,8 @@ import com.thoughtworks.go.server.materials.MaterialUpdateService;
 import com.thoughtworks.go.server.materials.SCMMaterialSource;
 import com.thoughtworks.go.server.newsecurity.filters.InvalidateAuthenticationOnSecurityConfigChangeFilter;
 import com.thoughtworks.go.server.service.*;
+import com.thoughtworks.go.server.service.datasharing.DataSharingSettingsService;
+import com.thoughtworks.go.server.service.datasharing.DataSharingUsageStatisticsReportingService;
 import com.thoughtworks.go.server.service.support.ResourceMonitoring;
 import com.thoughtworks.go.server.service.support.toggle.FeatureToggleService;
 import com.thoughtworks.go.server.service.support.toggle.Toggles;

--- a/server/src/test-fast/java/com/thoughtworks/go/server/service/DataSharingUsageDataServiceTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/service/DataSharingUsageDataServiceTest.java
@@ -16,10 +16,12 @@
 
 package com.thoughtworks.go.server.service;
 
+import com.thoughtworks.go.CurrentGoCDVersion;
 import com.thoughtworks.go.config.AgentConfig;
 import com.thoughtworks.go.config.BasicCruiseConfig;
 import com.thoughtworks.go.domain.JobState;
 import com.thoughtworks.go.domain.JobStateTransition;
+import com.thoughtworks.go.domain.UsageStatisticsReporting;
 import com.thoughtworks.go.helper.AgentMother;
 import com.thoughtworks.go.helper.GoConfigMother;
 import com.thoughtworks.go.server.dao.JobInstanceSqlMapDao;
@@ -44,16 +46,19 @@ public class DataSharingUsageDataServiceTest {
 
     private BasicCruiseConfig goConfig;
     private JobStateTransition oldestBuild;
+    @Mock
+    private DataSharingUsageStatisticsReportingService dataSharingUsageStatisticsReportingService;
 
     @Before
     public void setUp() throws Exception {
         initMocks(this);
-        service = new DataSharingUsageDataService(goConfigService, jobInstanceSqlMapDao);
+        service = new DataSharingUsageDataService(goConfigService, jobInstanceSqlMapDao, dataSharingUsageStatisticsReportingService);
         goConfig = GoConfigMother.configWithPipelines("p1", "p2");
         goConfig.agents().add(new AgentConfig("agent1"));
         when(goConfigService.cruiseConfig()).thenReturn(goConfig);
         oldestBuild = new JobStateTransition(JobState.Scheduled, new Date());
         when(jobInstanceSqlMapDao.oldestBuild()).thenReturn(oldestBuild);
+        when(dataSharingUsageStatisticsReportingService.get()).thenReturn(new UsageStatisticsReporting("server-id", new Date()));
     }
 
     @Test
@@ -62,6 +67,8 @@ public class DataSharingUsageDataServiceTest {
         assertThat(usageStatistics.pipelineCount(), is(2l));
         assertThat(usageStatistics.agentCount(), is(1l));
         assertThat(usageStatistics.oldestPipelineExecutionTime(), is(oldestBuild.getStateChangeTime().getTime()));
+        assertThat(usageStatistics.serverId(), is("server-id"));
+        assertThat(usageStatistics.gocdVersion(), is(CurrentGoCDVersion.getInstance().goVersion()));
     }
 
     @Test

--- a/server/src/test-fast/java/com/thoughtworks/go/server/service/datasharing/DataSharingNotificationTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/service/datasharing/DataSharingNotificationTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2018 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.server.service.datasharing;
+
+import com.thoughtworks.go.server.domain.Username;
+import com.thoughtworks.go.server.service.SecurityService;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+public class DataSharingNotificationTest {
+    @Mock
+    private SecurityService securityService;
+    private DataSharingNotification dataSharingNotification;
+
+    @Before
+    public void setUp() throws Exception {
+        initMocks(this);
+        dataSharingNotification = new DataSharingNotification(securityService);
+    }
+
+    @Test
+    public void shouldAllowDataSharingNotificationForAdmins() {
+        Username username = new Username("foo");
+        when(securityService.isUserAdmin(username)).thenReturn(true);
+
+        assertTrue(dataSharingNotification.allowNotificationFor(username));
+    }
+
+    @Test
+    public void shouldDisAllowDataSharingNotificationForNonAdmins() throws Exception {
+        Username username = new Username("foo");
+        when(securityService.isUserAdmin(username)).thenReturn(false);
+
+        assertFalse(dataSharingNotification.allowNotificationFor(username));
+    }
+
+}

--- a/server/src/test-fast/java/com/thoughtworks/go/server/service/datasharing/DataSharingSettingsServiceTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/service/datasharing/DataSharingSettingsServiceTest.java
@@ -14,10 +14,11 @@
  * limitations under the License.
  */
 
-package com.thoughtworks.go.server.service;
+package com.thoughtworks.go.server.service.datasharing;
 
-import com.thoughtworks.go.server.domain.DataSharingSettings;
 import com.thoughtworks.go.server.dao.DataSharingSettingsSqlMapDao;
+import com.thoughtworks.go.server.domain.DataSharingSettings;
+import com.thoughtworks.go.server.service.EntityHashingService;
 import com.thoughtworks.go.server.transaction.TransactionSynchronizationManager;
 import com.thoughtworks.go.server.transaction.TransactionTemplate;
 import org.junit.Before;
@@ -50,7 +51,8 @@ public class DataSharingSettingsServiceTest {
     @Before
     public void setUp() throws Exception {
         initMocks(this);
-        sharingSettingsService = new DataSharingSettingsService(dataSharingSettingsSqlMapDao, transactionTemplate, transactionSynchronizationManager, entityHashingService);
+        sharingSettingsService = new DataSharingSettingsService(dataSharingSettingsSqlMapDao, transactionTemplate,
+                transactionSynchronizationManager, entityHashingService);
     }
 
     @Test
@@ -72,4 +74,5 @@ public class DataSharingSettingsServiceTest {
         assertThat(updatedDataSharingSettings.allowSharing(), is(newConsent));
         assertThat(updatedDataSharingSettings.updatedBy(), is(consentedBy));
     }
+
 }

--- a/server/src/test-fast/java/com/thoughtworks/go/server/service/datasharing/DataSharingUsageDataServiceTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/service/datasharing/DataSharingUsageDataServiceTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.thoughtworks.go.server.service;
+package com.thoughtworks.go.server.service.datasharing;
 
 import com.thoughtworks.go.CurrentGoCDVersion;
 import com.thoughtworks.go.config.AgentConfig;
@@ -26,6 +26,7 @@ import com.thoughtworks.go.helper.AgentMother;
 import com.thoughtworks.go.helper.GoConfigMother;
 import com.thoughtworks.go.server.dao.JobInstanceSqlMapDao;
 import com.thoughtworks.go.server.domain.UsageStatistics;
+import com.thoughtworks.go.server.service.GoConfigService;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -55,7 +56,7 @@ public class DataSharingUsageDataServiceTest {
         service = new DataSharingUsageDataService(goConfigService, jobInstanceSqlMapDao, dataSharingUsageStatisticsReportingService);
         goConfig = GoConfigMother.configWithPipelines("p1", "p2");
         goConfig.agents().add(new AgentConfig("agent1"));
-        when(goConfigService.cruiseConfig()).thenReturn(goConfig);
+        when(goConfigService.getCurrentConfig()).thenReturn(goConfig);
         oldestBuild = new JobStateTransition(JobState.Scheduled, new Date());
         when(jobInstanceSqlMapDao.oldestBuild()).thenReturn(oldestBuild);
         when(dataSharingUsageStatisticsReportingService.get()).thenReturn(new UsageStatisticsReporting("server-id", new Date()));

--- a/server/src/test-fast/java/com/thoughtworks/go/server/service/datasharing/DataSharingUsageStatisticsReportingServiceTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/service/datasharing/DataSharingUsageStatisticsReportingServiceTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.thoughtworks.go.server.service;
+package com.thoughtworks.go.server.service.datasharing;
 
 import com.thoughtworks.go.server.domain.DataSharingSettings;
 import com.thoughtworks.go.domain.UsageStatisticsReporting;

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/datasharing/DataSharingSettingsServiceIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/datasharing/DataSharingSettingsServiceIntegrationTest.java
@@ -14,10 +14,11 @@
  * limitations under the License.
  */
 
-package com.thoughtworks.go.server.service;
+package com.thoughtworks.go.server.service.datasharing;
 
 import com.thoughtworks.go.server.domain.DataSharingSettings;
 import com.thoughtworks.go.server.dao.DataSharingSettingsSqlMapDao;
+import com.thoughtworks.go.server.service.EntityHashingService;
 import com.thoughtworks.go.server.service.result.HttpLocalizedOperationResult;
 import org.junit.*;
 import org.junit.rules.ExpectedException;
@@ -28,7 +29,6 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import java.sql.Timestamp;
 import java.util.Date;
-
 import com.thoughtworks.go.server.dao.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.isA;

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/datasharing/DataSharingUsageStatisticsReportingServiceIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/datasharing/DataSharingUsageStatisticsReportingServiceIntegrationTest.java
@@ -14,10 +14,12 @@
  * limitations under the License.
  */
 
-package com.thoughtworks.go.server.service;
+package com.thoughtworks.go.server.service.datasharing;
 
 import com.thoughtworks.go.domain.UsageStatisticsReporting;
 import com.thoughtworks.go.server.dao.UsageStatisticsReportingSqlMapDao;
+import com.thoughtworks.go.server.service.datasharing.DataSharingSettingsService;
+import com.thoughtworks.go.server.service.datasharing.DataSharingUsageStatisticsReportingService;
 import com.thoughtworks.go.server.service.result.HttpLocalizedOperationResult;
 import org.junit.After;
 import org.junit.Before;
@@ -27,7 +29,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import com.thoughtworks.go.server.dao.*;
-
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.core.Is.is;

--- a/server/webapp/WEB-INF/rails.new/spec/webpack/models/shared/data_sharing/usage_data_spec.js
+++ b/server/webapp/WEB-INF/rails.new/spec/webpack/models/shared/data_sharing/usage_data_spec.js
@@ -20,45 +20,24 @@ describe('Data Sharing Usage Data', () => {
   const dataSharingEncryptedUsageDataURL = '/go/api/internal/data_sharing/usagedata/encrypted';
 
   const dataSharingUsageJSON = {
-    "_embedded": {
+    "server_id": "some-random-string",
+    "message_version": 2,
+    "data": {
       "pipeline_count":                 1,
       "agent_count":                    0,
-      "oldest_pipeline_execution_time": 1528887811275
+      "oldest_pipeline_execution_time": 1528887811275,
+      "gocd_version": "18.9.0"
     }
   };
 
   it('should deserialize data sharing usage data from JSON', () => {
     const usageData = UsageData.fromJSON(dataSharingUsageJSON);
-
-    expect(usageData.pipelineCount()).toBe(dataSharingUsageJSON._embedded.pipeline_count);
-    expect(usageData.agentCount()).toBe(dataSharingUsageJSON._embedded.agent_count);
-    expect(usageData.oldestPipelineExecutionTime()).toBe(dataSharingUsageJSON._embedded.oldest_pipeline_execution_time);
+    expect(usageData.message()).toBe(dataSharingUsageJSON);
   });
 
   it('should represent pretty formatted data', () => {
     const usageData = UsageData.fromJSON(dataSharingUsageJSON);
-    expect(usageData.represent()).toBe(JSON.stringify(dataSharingUsageJSON._embedded, null, 4));
-  });
-
-  it('should fetch data sharing usage data', () => {
-    jasmine.Ajax.withMock(() => {
-      jasmine.Ajax.stubRequest(dataSharingUsageDataURL).andReturn({
-        responseText:    JSON.stringify(dataSharingUsageJSON),
-        status:          200,
-        responseHeaders: {
-          'Content-Type': 'application/vnd.go.cd.v1+json'
-        }
-      });
-
-      const successCallback = jasmine.createSpy().and.callFake((usageData) => {
-        expect(usageData.pipelineCount()).toBe(dataSharingUsageJSON._embedded.pipeline_count);
-        expect(usageData.agentCount()).toBe(dataSharingUsageJSON._embedded.agent_count);
-        expect(usageData.oldestPipelineExecutionTime()).toBe(dataSharingUsageJSON._embedded.oldest_pipeline_execution_time);
-      });
-
-      UsageData.get().then(successCallback);
-      expect(successCallback).toHaveBeenCalled();
-    });
+    expect(usageData.represent()).toBe(JSON.stringify(dataSharingUsageJSON, null, 4));
   });
 
   it('should fetch data sharing encrypted usage data', () => {

--- a/server/webapp/WEB-INF/rails.new/spec/webpack/models/shared/data_sharing/usage_data_spec.js
+++ b/server/webapp/WEB-INF/rails.new/spec/webpack/models/shared/data_sharing/usage_data_spec.js
@@ -40,6 +40,25 @@ describe('Data Sharing Usage Data', () => {
     expect(usageData.represent()).toBe(JSON.stringify(dataSharingUsageJSON, null, 4));
   });
 
+  it('should fetch data sharing usage data', () => {
+    jasmine.Ajax.withMock(() => {
+      jasmine.Ajax.stubRequest(dataSharingUsageDataURL).andReturn({
+        responseText:    JSON.stringify(dataSharingUsageJSON),
+        status:          200,
+        responseHeaders: {
+          'Content-Type': 'application/vnd.go.cd.v1+json'
+        }
+      });
+
+      const successCallback = jasmine.createSpy().and.callFake((usageData) => {
+        expect(usageData.represent()).toBe(JSON.stringify(dataSharingUsageJSON, null, 4));
+      });
+
+      UsageData.get().then(successCallback);
+      expect(successCallback).toHaveBeenCalled();
+    });
+  });
+
   it('should fetch data sharing encrypted usage data', () => {
     const encryptedData = "Something really secret";
 

--- a/server/webapp/WEB-INF/rails.new/spec/webpack/views/data_sharing_settings/data_sharing_settings_widget_spec.js
+++ b/server/webapp/WEB-INF/rails.new/spec/webpack/views/data_sharing_settings/data_sharing_settings_widget_spec.js
@@ -124,16 +124,16 @@ describe("Data Sharing Settings Widget", () => {
   });
 
   it('should show the consent for collected metrics list', () => {
-    expect($root.find('.consent-for-wrapper .consent-for')).toHaveLength(3);
+    expect($root.find('.consent-for-wrapper .consent-for')).toHaveLength(6);
     const consentFor = $root.find('.consent-for-wrapper .consent-for');
 
-    const pipelineConsentKey         = 'Number of pipelines';
+    const pipelineConsentKey         = 'Number of pipelines (pipeline_count)';
     const pipelineConsentDescription = 'This allows the calculation of the average number of pipelines a GoCD instance has. Knowing the average number of pipelines helps us optimize the GoCD experience.';
 
-    const agentConsentKey          = 'Number of agents';
+    const agentConsentKey          = 'Number of agents (agent_count)';
     const agentsConsentDescription = 'This allows the calculation of the average number of agents a GoCD instance has. This will help us ensure GoCD can handle a reasonable number of requests from the average number of agents.';
 
-    const oldestPipelineRuntimeKey         = 'Oldest pipeline run time';
+    const oldestPipelineRuntimeKey         = 'Oldest pipeline run time (oldest_pipeline_execution_time)';
     const oldestPipelineRuntimeDescription = 'This provides data around the age of the GoCD instance. Along with the number of pipelines data point, it helps establish an expected growth in the number of pipelines. With performance related data which might be shared later (with your permission), this will help to see whether a GoCD instance becomes slower over time, as more pipelines and pipeline runs happen';
 
     expect($(consentFor.get(0))).toContainText(pipelineConsentKey);
@@ -144,6 +144,15 @@ describe("Data Sharing Settings Widget", () => {
 
     expect($(consentFor.get(2))).toContainText(oldestPipelineRuntimeKey);
     expect($(consentFor.get(2))).toContainText(oldestPipelineRuntimeDescription);
+
+    expect($(consentFor.get(3))).toContainText("GoCD Version (gocd_version)");
+    expect($(consentFor.get(3))).toContainText("This provides us the version of GoCD the server is on.");
+
+    expect($(consentFor.get(4))).toContainText("Server ID (server_id)");
+    expect($(consentFor.get(4))).toContainText("An identifier for this instance of GoCD to help us correlate the data sent across.");
+
+    expect($(consentFor.get(5))).toContainText("Message Version (message_version)");
+    expect($(consentFor.get(5))).toContainText("Schema version number for this message. This will help us with migrations should the message schema change in future.");
   });
 
   it('should show what data will be sent when GoCD data sharing is allowed', () => {

--- a/server/webapp/WEB-INF/rails.new/webpack/models/notifications/data_sharing_notification.js
+++ b/server/webapp/WEB-INF/rails.new/webpack/models/notifications/data_sharing_notification.js
@@ -16,11 +16,13 @@
 
 const $              = require('jquery');
 const SystemNotifications = require('models/notifications/system_notifications');
+const DataSharingNotificationPermission = require('models/notifications/data_sharing_notification_permissions');
 
 const DataSharingNotification = function () {
 };
+
 DataSharingNotification.createIfNotPresent = () => $.Deferred(function () {
-    SystemNotifications.all().then((allNotifications) => {
+     SystemNotifications.all().then((allNotifications) => {
         const dataSharingNotification = allNotifications.findSystemNotification((m) => {
             return m.type() === 'DataSharing';
         });
@@ -28,12 +30,17 @@ DataSharingNotification.createIfNotPresent = () => $.Deferred(function () {
         if (dataSharingNotification !== undefined) {
             return;
         }
-        const message = "GoCD shares data so that it can be improved.";
-        const link = "/go/admin/data_sharing/settings";
-        const type = "DataSharing";
-        SystemNotifications.notifyNewMessage(type, message, link, "Learn more ...");
-        this.resolve({});
+        DataSharingNotificationPermission.get().then((permissions) => {
+            if (permissions.showNotification()) {
+                const message = "GoCD shares data so that it can be improved.";
+                const link = "/go/admin/data_sharing/settings";
+                const type = "DataSharing";
+                SystemNotifications.notifyNewMessage(type, message, link, "Learn more ...");
+            }
+            this.resolve({});
+        });
     });
 }).promise();
 
 module.exports = DataSharingNotification;
+

--- a/server/webapp/WEB-INF/rails.new/webpack/models/notifications/data_sharing_notification_permissions.js
+++ b/server/webapp/WEB-INF/rails.new/webpack/models/notifications/data_sharing_notification_permissions.js
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2018 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const AjaxHelper = require('helpers/ajax_helper');
+const Stream = require('mithril/stream');
+
+const DataSharingNotificationPermission = function (permission) {
+    this.showNotification = Stream(permission.show_notification);
+};
+DataSharingNotificationPermission.API_VERSION = 'v1';
+
+DataSharingNotificationPermission.get = () => {
+    return AjaxHelper.GET({
+        url:        "/go/api/data_sharing/settings/notification_auth",
+        apiVersion: DataSharingNotificationPermission.API_VERSION
+    }).then((data) => {
+        return new DataSharingNotificationPermission(JSON.parse(data));
+    });
+};
+
+module.exports = DataSharingNotificationPermission;

--- a/server/webapp/WEB-INF/rails.new/webpack/models/shared/data_sharing/usage_data.js
+++ b/server/webapp/WEB-INF/rails.new/webpack/models/shared/data_sharing/usage_data.js
@@ -17,14 +17,9 @@
 const AjaxHelper  = require('helpers/ajax_helper');
 const SparkRoutes = require("helpers/spark_routes");
 
-const UsageData = function (initialData) {
-  const data = initialData._embedded;
-
-  this.agentCount                  = () => data.agent_count;
-  this.pipelineCount               = () => data.pipeline_count;
-  this.oldestPipelineExecutionTime = () => data.oldest_pipeline_execution_time;
-
-  this.represent = () => JSON.stringify(data, null, 4);
+const UsageData = function (data) {
+  this.message                  = () => data;
+  this.represent = () => JSON.stringify(this.message(), null, 4);
 };
 
 UsageData.fromJSON = function (json) {

--- a/server/webapp/WEB-INF/rails.new/webpack/views/data_sharing_settings/toggle_consent_widget.js.msx
+++ b/server/webapp/WEB-INF/rails.new/webpack/views/data_sharing_settings/toggle_consent_widget.js.msx
@@ -49,20 +49,32 @@ const ToggleConsentWidget = {
 
       <div class="consent-for-wrapper">
         <div class="consent-for">
-          <span class="key">Number of pipelines:</span>
+          <span class="key">Number of pipelines (pipeline_count):</span>
           This allows the calculation of the average number of pipelines a GoCD instance has. Knowing the average number
           of pipelines helps us optimize the GoCD experience.
         </div>
         <div class="consent-for">
-          <span class="key">Number of agents:</span>
+          <span class="key">Number of agents (agent_count):</span>
           This allows the calculation of the average number of agents a GoCD instance has. This
           will help us ensure GoCD can handle a reasonable number of requests from the average number of agents.
         </div>
         <div class="consent-for">
-          <span class="key">Oldest pipeline run time:</span>
+          <span class="key">Oldest pipeline run time (oldest_pipeline_execution_time):</span>
           This provides data around the age of the GoCD instance.
           Along with the number of pipelines data point, it helps establish an expected growth in the number of pipelines.
           With performance related data which might be shared later (with your permission), this will help to see whether a GoCD instance becomes slower over time, as more pipelines and pipeline runs happen.
+        </div>
+        <div class="consent-for">
+          <span class="key">GoCD Version (gocd_version):</span>
+          This provides us the version of GoCD the server is on.
+        </div>
+        <div class="consent-for">
+          <span class="key">Server ID (server_id):</span>
+          An identifier for this instance of GoCD to help us correlate the data sent across.
+        </div>
+        <div class="consent-for">
+          <span class="key">Message Version (message_version):</span>
+          Schema version number for this message. This will help us with migrations should the message schema change in future.
         </div>
       </div>
     </div>;


### PR DESCRIPTION
Data that would be sent would look like this now:
``` json
{
  "server_id" : "651d81bd-8bf8-4a37-a7b1-6f4f826e5ef1",
  "message_version" : 1,
  "data" : {
    "pipeline_count" : 1,
    "agent_count" : 0,
    "oldest_pipeline_execution_time" : 1530680632695,
    "gocd_version" : "18.7.0"
  }
}
```

The data sharing notification is shown to admins alone.