### PR TITLE
Cannot access the stage details page from VSM (resolved)

### DIFF
--- a/server/webapp/WEB-INF/rails.new/app/assets/stylesheets/new-theme.scss
+++ b/server/webapp/WEB-INF/rails.new/app/assets/stylesheets/new-theme.scss
@@ -2809,6 +2809,10 @@ button.check_connection + .connection_test_message pre {
   }
 }
 
+.Failing {
+  position: relative;
+}
+
 .Building, .building-stage {
   height:     12px;
   position:   relative;
@@ -2869,7 +2873,7 @@ button.check_connection + .connection_test_message pre {
 
 }
 
-.Building, .Cancelled {
+.Building, .Cancelled, .Failing {
   a {
     position: absolute;
     left:     0;


### PR DESCRIPTION
1. added fix to show clickable anchor tag on failing stage

https://github.com/gocd/gocd/issues/4909