### PR TITLE
Fix styling on data sharing settings page

### DIFF
--- a/server/webapp/WEB-INF/rails.new/app/assets/new_stylesheets/single_page_apps/data_sharing_settings.scss
+++ b/server/webapp/WEB-INF/rails.new/app/assets/new_stylesheets/single_page_apps/data_sharing_settings.scss
@@ -32,12 +32,13 @@
 }
 
 .share-box {
-  display:       flex;
-  margin:        30px 0;
+  display: flex;
+  margin:  30px 0;
 }
 
 .show-data {
-  margin-left:   30px;
+  margin-left: 30px;
+  width:       50%;
 }
 
 .updated-by {
@@ -58,7 +59,7 @@
 
 .consent-toggle-wrapper {
   border:        1px solid #ccc;
-  width:         750px;
+  width:         50%;
   border-radius: 3px;
   padding:       10px 20px;
 }


### PR DESCRIPTION
* Render consent-wrapper div and shared-data div with equal widths (50%)

![screen shot 2018-07-04 at 4 10 09 pm](https://user-images.githubusercontent.com/15275847/42273261-4ee0e170-7fa6-11e8-9032-badcc826c6c8.png)
![screen shot 2018-07-04 at 4 10 30 pm](https://user-images.githubusercontent.com/15275847/42273262-4f099390-7fa6-11e8-8726-b6d3d6cf0841.png)
