### PR TITLE
Rename usage_data_last_reported_time to last_usage_data_reporting_check_time

### DIFF
--- a/server/webapp/WEB-INF/rails.new/spec/webpack/models/shared/usage_data_reporter_spec.js
+++ b/server/webapp/WEB-INF/rails.new/spec/webpack/models/shared/usage_data_reporter_spec.js
@@ -18,7 +18,7 @@
 describe('Usage Data Reporter', () => {
   const UsageDataReporter = require('models/shared/usage_data_reporter');
 
-  const USAGE_DATA_LAST_REPORTED_TIME_KEY = "usage_data_last_reported_time";
+  const USAGE_DATA_LAST_REPORTED_TIME_KEY = "last_usage_data_reporting_check_time";
 
   const encryptedUsageDataURL     = '/go/api/internal/data_sharing/usagedata/encrypted';
   const usageReportingGetURL      = '/go/api/internal/data_sharing/reporting/info';

--- a/server/webapp/WEB-INF/rails.new/webpack/models/shared/usage_data_reporter.js
+++ b/server/webapp/WEB-INF/rails.new/webpack/models/shared/usage_data_reporter.js
@@ -20,7 +20,7 @@ const AjaxHelper = require('helpers/ajax_helper');
 const UsageData     = require('models/shared/data_sharing/usage_data');
 const DataReporting = require('models/shared/data_sharing/data_reporting');
 
-const USAGE_DATA_LAST_REPORTED_TIME_KEY = "usage_data_last_reported_time";
+const USAGE_DATA_LAST_REPORTED_TIME_KEY = "last_usage_data_reporting_check_time";
 
 const reportToGoCDDataSharingServer = function (url, data) {
   return AjaxHelper.POST({url, data, contentType: 'application/octet-stream'});


### PR DESCRIPTION
The local storage variable last_usage_data_reporting_check_time denotes when was the last time browser client tried reporting usage data to the remote server