### PR TITLE
PipelineSelections now serialize to JSON

### DIFF
--- a/api/api-dashboard-v2/src/main/java/com/thoughtworks/go/apiv2/dashboard/DashboardControllerDelegate.java
+++ b/api/api-dashboard-v2/src/main/java/com/thoughtworks/go/apiv2/dashboard/DashboardControllerDelegate.java
@@ -45,6 +45,7 @@ import static spark.Spark.*;
 public class DashboardControllerDelegate extends ApiController {
 
     private static final String BEING_PROCESSED = MessageJson.create("Dashboard is being processed, this may take a few seconds. Please check back later.");
+    private static final String COOKIE_NAME = "selected_pipelines";
 
     private final PipelineSelectionsService pipelineSelectionsService;
     private final GoDashboardService goDashboardService;
@@ -79,7 +80,7 @@ public class DashboardControllerDelegate extends ApiController {
             return BEING_PROCESSED;
         }
 
-        String selectedPipelinesCookie = request.cookie("selected_pipelines");
+        String selectedPipelinesCookie = request.cookie(COOKIE_NAME);
         Long userId = currentUserId(request);
         Username userName = currentUsername();
 

--- a/api/api-dashboard-v2/src/main/java/com/thoughtworks/go/apiv2/dashboard/DashboardControllerDelegate.java
+++ b/api/api-dashboard-v2/src/main/java/com/thoughtworks/go/apiv2/dashboard/DashboardControllerDelegate.java
@@ -31,6 +31,7 @@ import com.thoughtworks.go.server.service.GoDashboardService;
 import com.thoughtworks.go.server.service.PipelineSelectionsService;
 import com.thoughtworks.go.spark.Routes;
 import org.apache.commons.codec.digest.DigestUtils;
+import org.apache.commons.lang3.StringUtils;
 import spark.Request;
 import spark.Response;
 
@@ -38,6 +39,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static com.thoughtworks.go.server.domain.user.Filters.DEFAULT_NAME;
 import static spark.Spark.*;
 
 public class DashboardControllerDelegate extends ApiController {
@@ -83,7 +85,7 @@ public class DashboardControllerDelegate extends ApiController {
 
         PipelineSelections selectedPipelines = pipelineSelectionsService.loadPipelineSelections(selectedPipelinesCookie, userId);
 
-        final String filterName = request.queryParams("viewName");
+        final String filterName = getViewName(request);
         final DashboardFilter filter = selectedPipelines.namedFilter(filterName);
 
         List<GoDashboardPipelineGroup> pipelineGroups = goDashboardService.allPipelineGroupsForDashboard(filter, userName);
@@ -97,5 +99,10 @@ public class DashboardControllerDelegate extends ApiController {
         setEtagHeader(response, etag);
 
         return writerForTopLevelObject(request, response, outputWriter -> PipelineGroupsRepresenter.toJSON(outputWriter, new DashboardFor(pipelineGroups, userName)));
+    }
+
+    private String getViewName(Request request) {
+        final String viewName = request.queryParams("viewName");
+        return StringUtils.isBlank(viewName) ? DEFAULT_NAME : viewName;
     }
 }

--- a/api/api-dashboard-v2/src/main/java/com/thoughtworks/go/apiv2/dashboard/DashboardControllerDelegate.java
+++ b/api/api-dashboard-v2/src/main/java/com/thoughtworks/go/apiv2/dashboard/DashboardControllerDelegate.java
@@ -25,6 +25,7 @@ import com.thoughtworks.go.apiv2.dashboard.representers.DashboardFor;
 import com.thoughtworks.go.apiv2.dashboard.representers.PipelineGroupsRepresenter;
 import com.thoughtworks.go.server.dashboard.GoDashboardPipelineGroup;
 import com.thoughtworks.go.server.domain.Username;
+import com.thoughtworks.go.server.domain.user.DashboardFilter;
 import com.thoughtworks.go.server.domain.user.PipelineSelections;
 import com.thoughtworks.go.server.service.GoDashboardService;
 import com.thoughtworks.go.server.service.PipelineSelectionsService;
@@ -80,8 +81,12 @@ public class DashboardControllerDelegate extends ApiController {
         Long userId = currentUserId(request);
         Username userName = currentUsername();
 
-        PipelineSelections selectedPipelines = pipelineSelectionsService.getPersistedSelectedPipelines(selectedPipelinesCookie, userId);
-        List<GoDashboardPipelineGroup> pipelineGroups = goDashboardService.allPipelineGroupsForDashboard(selectedPipelines, userName);
+        PipelineSelections selectedPipelines = pipelineSelectionsService.loadPipelineSelections(selectedPipelinesCookie, userId);
+
+        final String filterName = request.queryParams("viewName");
+        final DashboardFilter filter = selectedPipelines.namedFilter(filterName);
+
+        List<GoDashboardPipelineGroup> pipelineGroups = goDashboardService.allPipelineGroupsForDashboard(filter, userName);
         String pipelineGroupsEtag = pipelineGroups.stream().map(GoDashboardPipelineGroup::etag).collect(Collectors.joining("/"));
         String etag = DigestUtils.md5Hex(currentUserLoginName().toString() + "/" + pipelineGroupsEtag);
 

--- a/api/api-dashboard-v2/src/main/java/com/thoughtworks/go/apiv2/dashboard/DashboardControllerDelegate.java
+++ b/api/api-dashboard-v2/src/main/java/com/thoughtworks/go/apiv2/dashboard/DashboardControllerDelegate.java
@@ -39,7 +39,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import static com.thoughtworks.go.server.domain.user.Filters.DEFAULT_NAME;
+import static com.thoughtworks.go.server.domain.user.DashboardFilter.DEFAULT_NAME;
 import static spark.Spark.*;
 
 public class DashboardControllerDelegate extends ApiController {

--- a/api/api-pipeline-selection-v1/src/main/java/com/thoughtworks/go/apiv1/pipelineselection/PipelineSelectionControllerDelegate.java
+++ b/api/api-pipeline-selection-v1/src/main/java/com/thoughtworks/go/apiv1/pipelineselection/PipelineSelectionControllerDelegate.java
@@ -19,12 +19,11 @@ package com.thoughtworks.go.apiv1.pipelineselection;
 
 import com.thoughtworks.go.api.ApiController;
 import com.thoughtworks.go.api.ApiVersion;
-import com.thoughtworks.go.api.representers.JsonReader;
 import com.thoughtworks.go.api.spring.ApiAuthenticationHelper;
-import com.thoughtworks.go.api.util.GsonTransformer;
 import com.thoughtworks.go.apiv1.pipelineselection.representers.PipelineSelectionResponse;
 import com.thoughtworks.go.apiv1.pipelineselection.representers.PipelineSelectionsRepresenter;
 import com.thoughtworks.go.config.PipelineConfigs;
+import com.thoughtworks.go.server.domain.user.Filters;
 import com.thoughtworks.go.server.domain.user.PipelineSelections;
 import com.thoughtworks.go.server.service.PipelineConfigService;
 import com.thoughtworks.go.server.service.PipelineSelectionsService;
@@ -76,23 +75,18 @@ public class PipelineSelectionControllerDelegate extends ApiController {
 
     public String show(Request request, Response response) throws IOException {
         String fromCookie = request.cookie("selected_pipelines");
+        List<PipelineConfigs> groups = pipelineConfigService.viewableGroupsFor(currentUsername());
+        PipelineSelections pipelineSelections = pipelineSelectionsService.loadPipelineSelections(fromCookie, currentUserId(request));
 
-        PipelineSelections selectedPipelines = pipelineSelectionsService.getPersistedSelectedPipelines(fromCookie, currentUserId(request));
-        List<PipelineConfigs> pipelineConfigs = pipelineConfigService.viewableGroupsFor(currentUsername());
+        PipelineSelectionResponse pipelineSelectionResponse = new PipelineSelectionResponse(pipelineSelections.viewFilters(), groups);
 
-        PipelineSelectionResponse pipelineSelectionResponse = new PipelineSelectionResponse(selectedPipelines.pipelineList(), selectedPipelines.isBlacklist(), pipelineConfigs);
-
-        return writerForTopLevelObject(request, response, writer -> PipelineSelectionsRepresenter.toJSON(writer, pipelineSelectionResponse));
+        return PipelineSelectionsRepresenter.toJSON(pipelineSelectionResponse);
     }
 
     public String update(Request request, Response response) {
         String fromCookie = request.cookie("selected_pipelines");
-
-        JsonReader jsonReader = GsonTransformer.getInstance().jsonReaderFrom(request.body());
-
-        PipelineSelectionResponse selectionResponse = PipelineSelectionsRepresenter.fromJSON(jsonReader);
-
-        Long recordId = pipelineSelectionsService.persistSelectedPipelines(fromCookie, currentUserId(request), selectionResponse.selections(), selectionResponse.blacklist());
+        Filters filters = Filters.fromJson(request.body());
+        Long recordId = pipelineSelectionsService.persistPipelineSelections(fromCookie, currentUserId(request), filters);
 
         if (!apiAuthenticationHelper.securityEnabled()) {
             response.cookie("/go", "selected_pipelines", String.valueOf(recordId), ONE_YEAR, systemEnvironment.isSessionCookieSecure(), true);

--- a/api/api-pipeline-selection-v1/src/main/java/com/thoughtworks/go/apiv1/pipelineselection/representers/PipelineSelectionResponse.java
+++ b/api/api-pipeline-selection-v1/src/main/java/com/thoughtworks/go/apiv1/pipelineselection/representers/PipelineSelectionResponse.java
@@ -17,26 +17,21 @@
 package com.thoughtworks.go.apiv1.pipelineselection.representers;
 
 import com.thoughtworks.go.config.PipelineConfigs;
+import com.thoughtworks.go.server.domain.user.Filters;
 
 import java.util.List;
 
 public class PipelineSelectionResponse {
-    private final List<String> pipelines;
-    private final boolean blacklist;
+    private final Filters filters;
     private final List<PipelineConfigs> pipelineConfigs;
 
-    public PipelineSelectionResponse(List<String> pipelines, boolean blacklist, List<PipelineConfigs> pipelineConfigs) {
-        this.pipelines = pipelines;
-        this.blacklist = blacklist;
+    public PipelineSelectionResponse(Filters filters, List<PipelineConfigs> pipelineConfigs) {
+        this.filters = filters;
         this.pipelineConfigs = pipelineConfigs;
     }
 
-    public List<String> selections() {
-        return pipelines;
-    }
-
-    public boolean blacklist() {
-        return blacklist;
+    public Filters filters() {
+        return filters;
     }
 
     public List<PipelineConfigs> getPipelineConfigs() {

--- a/api/api-pipeline-selection-v1/src/test/groovy/com/thoughtworks/go/apiv1/pipelineselection/PipelineSelectionControllerDelegateTest.groovy
+++ b/api/api-pipeline-selection-v1/src/test/groovy/com/thoughtworks/go/apiv1/pipelineselection/PipelineSelectionControllerDelegateTest.groovy
@@ -120,7 +120,7 @@ class PipelineSelectionControllerDelegateTest implements SecurityServiceTrait, C
 
         def payload = [
           filters: [
-            [type: 'blacklist', pipelines: ['build-linux', 'build-windows']]
+            [name: 'Default', type: 'blacklist', pipelines: ['build-linux', 'build-windows']]
           ]
         ]
 
@@ -144,7 +144,7 @@ class PipelineSelectionControllerDelegateTest implements SecurityServiceTrait, C
 
         def payload = [
           filters: [
-            [type: 'blacklist', pipelines: ['build-linux', 'build-windows']]
+            [name: 'Default', type: 'blacklist', pipelines: ['build-linux', 'build-windows']]
           ]
         ]
 
@@ -170,7 +170,7 @@ class PipelineSelectionControllerDelegateTest implements SecurityServiceTrait, C
 
         def payload = [
           filters: [
-            [type: 'blacklist', pipelines: ['build-linux', 'build-windows']]
+            [name: 'Default', type: 'blacklist', pipelines: ['build-linux', 'build-windows']]
           ]
         ]
 

--- a/api/api-pipeline-selection-v1/src/test/groovy/com/thoughtworks/go/apiv1/pipelineselection/PipelineSelectionControllerDelegateTest.groovy
+++ b/api/api-pipeline-selection-v1/src/test/groovy/com/thoughtworks/go/apiv1/pipelineselection/PipelineSelectionControllerDelegateTest.groovy
@@ -29,6 +29,7 @@ import com.thoughtworks.go.server.service.PipelineSelectionsService
 import com.thoughtworks.go.spark.ControllerTrait
 import com.thoughtworks.go.spark.SecurityServiceTrait
 import com.thoughtworks.go.spark.util.SecureRandom
+import com.thoughtworks.go.testhelpers.FiltersHelper
 import com.thoughtworks.go.util.SystemEnvironment
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -53,7 +54,7 @@ class PipelineSelectionControllerDelegateTest implements SecurityServiceTrait, C
         enableSecurity()
         loginAsUser()
 
-        def selections = new PipelineSelections(["build-linux", "build-windows"], new Date(), currentUserLoginId(), true)
+        def selections = new PipelineSelections(FiltersHelper.blacklist(["build-linux", "build-windows"]), new Date(), currentUserLoginId())
 
         def group1 = new BasicPipelineConfigs(group: "grp1")
         def group2 = new BasicPipelineConfigs(group: "grp2")
@@ -62,7 +63,7 @@ class PipelineSelectionControllerDelegateTest implements SecurityServiceTrait, C
 
         List<PipelineConfigs> pipelineConfigs = [group1, group2]
 
-        when(pipelineSelectionsService.getPersistedSelectedPipelines(null, currentUserLoginId())).thenReturn(selections)
+        when(pipelineSelectionsService.loadPipelineSelections(null, currentUserLoginId())).thenReturn(selections)
         when(pipelineConfigService.viewableGroupsFor(currentUsername())).thenReturn(pipelineConfigs)
 
         getWithApiHeader(controller.controllerBasePath())
@@ -70,7 +71,7 @@ class PipelineSelectionControllerDelegateTest implements SecurityServiceTrait, C
         assertThatResponse()
           .isOk()
           .hasContentType(controller.mimeType)
-          .hasBodyWithJsonObject(new PipelineSelectionResponse(["build-linux", "build-windows"], true, pipelineConfigs), PipelineSelectionsRepresenter.class)
+          .hasBodyWithJson(PipelineSelectionsRepresenter.toJSON(new PipelineSelectionResponse(selections.viewFilters(), pipelineConfigs)))
       }
     }
 
@@ -81,7 +82,7 @@ class PipelineSelectionControllerDelegateTest implements SecurityServiceTrait, C
         disableSecurity()
         loginAsAnonymous()
 
-        def selections = new PipelineSelections(["build-linux", "build-windows"], new Date(), currentUserLoginId(), true)
+        def selections = new PipelineSelections(FiltersHelper.blacklist(["build-linux", "build-windows"]), new Date(), currentUserLoginId())
 
         def group1 = new BasicPipelineConfigs(group: "grp1")
         def group2 = new BasicPipelineConfigs(group: "grp2")
@@ -92,7 +93,7 @@ class PipelineSelectionControllerDelegateTest implements SecurityServiceTrait, C
 
         String cookieId = SecureRandom.hex()
 
-        when(pipelineSelectionsService.getPersistedSelectedPipelines(cookieId, currentUserLoginId())).thenReturn(selections)
+        when(pipelineSelectionsService.loadPipelineSelections(cookieId, currentUserLoginId())).thenReturn(selections)
         when(pipelineConfigService.viewableGroupsFor(currentUsername())).thenReturn(pipelineConfigs)
 
         httpRequestBuilder.withCookies(new Cookie("selected_pipelines", cookieId))
@@ -101,7 +102,7 @@ class PipelineSelectionControllerDelegateTest implements SecurityServiceTrait, C
         assertThatResponse()
           .isOk()
           .hasContentType(controller.mimeType)
-          .hasBodyWithJsonObject(new PipelineSelectionResponse(["build-linux", "build-windows"], true, pipelineConfigs), PipelineSelectionsRepresenter.class)
+          .hasBodyWithJson(PipelineSelectionsRepresenter.toJSON(new PipelineSelectionResponse(selections.viewFilters(), pipelineConfigs)))
       }
     }
   }
@@ -118,11 +119,12 @@ class PipelineSelectionControllerDelegateTest implements SecurityServiceTrait, C
         loginAsUser()
 
         def payload = [
-          selections: ['build-linux', 'build-windows'],
-          blacklist : true
+          filters: [
+            [type: 'blacklist', pipelines: ['build-linux', 'build-windows']]
+          ]
         ]
 
-        when(pipelineSelectionsService.persistSelectedPipelines(null, currentUserLoginId(), payload.selections, payload.blacklist)).thenReturn(1l)
+        when(pipelineSelectionsService.persistPipelineSelections(null, currentUserLoginId(), FiltersHelper.blacklist(payload.filters.get(0).pipelines))).thenReturn(1l)
 
         putWithApiHeader(controller.controllerBasePath(), payload)
 
@@ -141,12 +143,14 @@ class PipelineSelectionControllerDelegateTest implements SecurityServiceTrait, C
         loginAsAnonymous()
 
         def payload = [
-          selections: ['build-linux', 'build-windows'],
-          blacklist : true
+          filters: [
+            [type: 'blacklist', pipelines: ['build-linux', 'build-windows']]
+          ]
         ]
 
         long recordId = SecureRandom.longNumber()
-        when(pipelineSelectionsService.persistSelectedPipelines(String.valueOf(recordId), currentUserLoginId(), payload.selections, payload.blacklist)).thenReturn(recordId)
+
+        when(pipelineSelectionsService.persistPipelineSelections(String.valueOf(recordId), currentUserLoginId(), FiltersHelper.blacklist(payload.filters.get(0).pipelines))).thenReturn(recordId)
         when(systemEnvironment.isSessionCookieSecure()).thenReturn(false)
 
         httpRequestBuilder.withCookies(new Cookie("selected_pipelines", String.valueOf(recordId)))
@@ -165,12 +169,21 @@ class PipelineSelectionControllerDelegateTest implements SecurityServiceTrait, C
         loginAsAnonymous()
 
         def payload = [
-          selections: ['build-linux', 'build-windows'],
-          blacklist : true
+          filters: [
+            [type: 'blacklist', pipelines: ['build-linux', 'build-windows']]
+          ]
         ]
 
         long recordId = SecureRandom.longNumber()
-        when(pipelineSelectionsService.persistSelectedPipelines(String.valueOf(recordId), currentUserLoginId(), payload.selections, payload.blacklist)).thenReturn(recordId)
+
+        def group1 = new BasicPipelineConfigs(group: "grp")
+        group1.add(new PipelineConfig(name: new CaseInsensitiveString("build-linux")))
+        group1.add(new PipelineConfig(name: new CaseInsensitiveString("build-windows")))
+        group1.add(new PipelineConfig(name: new CaseInsensitiveString("burp")))
+        List<PipelineConfigs> groups = [group1]
+
+        when(pipelineConfigService.viewableGroupsFor(currentUsername())).thenReturn(groups)
+        when(pipelineSelectionsService.persistPipelineSelections(String.valueOf(recordId), currentUserLoginId(), FiltersHelper.blacklist(payload.filters.get(0).pipelines))).thenReturn(recordId)
         when(systemEnvironment.isSessionCookieSecure()).thenReturn(true)
 
         httpRequestBuilder.withCookies(new Cookie("selected_pipelines", String.valueOf(recordId)))

--- a/api/api-pipeline-selection-v1/src/test/groovy/com/thoughtworks/go/apiv1/pipelineselection/representers/PipelineSelectionsRepresenterTest.groovy
+++ b/api/api-pipeline-selection-v1/src/test/groovy/com/thoughtworks/go/apiv1/pipelineselection/representers/PipelineSelectionsRepresenterTest.groovy
@@ -49,7 +49,7 @@ class PipelineSelectionsRepresenterTest {
           grp1: ["pipeline3", "build-linux", "build-windows"],
           grp2: ["pipeline1", "pipeline2"]
         ],
-        filters  : [[type: 'blacklist', pipelines: ['build-linux', 'build-windows']]]
+        filters  : [[name: 'Default', type: 'blacklist', pipelines: ['build-linux', 'build-windows']]]
       ])
     }
 
@@ -71,7 +71,7 @@ class PipelineSelectionsRepresenterTest {
         pipelines: [
           grp2: ["pipeline1", "pipeline2", "build-linux", "build-windows"]
         ],
-        filters  : [[type: 'blacklist', pipelines: ['build-linux', 'build-windows']]]
+        filters  : [[name: 'Default', type: 'blacklist', pipelines: ['build-linux', 'build-windows']]]
       ])
     }
   }

--- a/api/api-pipeline-selection-v1/src/test/groovy/com/thoughtworks/go/apiv1/pipelineselection/representers/PipelineSelectionsRepresenterTest.groovy
+++ b/api/api-pipeline-selection-v1/src/test/groovy/com/thoughtworks/go/apiv1/pipelineselection/representers/PipelineSelectionsRepresenterTest.groovy
@@ -16,23 +16,14 @@
 
 package com.thoughtworks.go.apiv1.pipelineselection.representers
 
-import com.google.gson.JsonArray
-import com.google.gson.JsonObject
-import com.thoughtworks.go.api.util.GsonTransformer
-import com.thoughtworks.go.api.util.MessageJson
 import com.thoughtworks.go.config.BasicPipelineConfigs
 import com.thoughtworks.go.config.CaseInsensitiveString
 import com.thoughtworks.go.config.PipelineConfig
 import com.thoughtworks.go.config.PipelineConfigs
+import com.thoughtworks.go.testhelpers.FiltersHelper
 import net.javacrumbs.jsonunit.fluent.JsonFluentAssert
-import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import spark.HaltException
-
-import static com.thoughtworks.go.api.base.JsonUtils.toObjectString
-import static com.thoughtworks.go.api.util.HaltApiMessages.propertyIsNotAJsonBoolean
-import static com.thoughtworks.go.api.util.HaltApiMessages.propertyIsNotAJsonStringArray
 
 class PipelineSelectionsRepresenterTest {
 
@@ -44,22 +35,21 @@ class PipelineSelectionsRepresenterTest {
       def group2 = new BasicPipelineConfigs(group: "grp2")
 
       group1.add(new PipelineConfig(name: new CaseInsensitiveString("pipeline3")))
+      group1.add(new PipelineConfig(name: new CaseInsensitiveString("build-linux")))
+      group1.add(new PipelineConfig(name: new CaseInsensitiveString("build-windows")))
       group2.add(new PipelineConfig(name: new CaseInsensitiveString("pipeline1")))
       group2.add(new PipelineConfig(name: new CaseInsensitiveString("pipeline2")))
 
       List<PipelineConfigs> pipelineConfigs = [group1, group2]
 
-      def actualJson = toObjectString({
-        PipelineSelectionsRepresenter.toJSON(it, new PipelineSelectionResponse(['build-linux', 'build-windows'], true, pipelineConfigs))
-      })
+      String actualJson = PipelineSelectionsRepresenter.toJSON(new PipelineSelectionResponse(FiltersHelper.blacklist(['build-linux', 'build-windows']), pipelineConfigs))
 
       JsonFluentAssert.assertThatJson(actualJson).isEqualTo([
-        pipelines : [
-          grp1: ["pipeline3"],
+        pipelines: [
+          grp1: ["pipeline3", "build-linux", "build-windows"],
           grp2: ["pipeline1", "pipeline2"]
         ],
-        selections: ['build-linux', 'build-windows'],
-        blacklist : true
+        filters  : [[type: 'blacklist', pipelines: ['build-linux', 'build-windows']]]
       ])
     }
 
@@ -70,62 +60,19 @@ class PipelineSelectionsRepresenterTest {
 
       group2.add(new PipelineConfig(name: new CaseInsensitiveString("pipeline1")))
       group2.add(new PipelineConfig(name: new CaseInsensitiveString("pipeline2")))
+      group2.add(new PipelineConfig(name: new CaseInsensitiveString("build-linux")))
+      group2.add(new PipelineConfig(name: new CaseInsensitiveString("build-windows")))
 
       List<PipelineConfigs> pipelineConfigs = [group1, group2]
 
-      def actualJson = toObjectString({
-        PipelineSelectionsRepresenter.toJSON(it, new PipelineSelectionResponse(['build-linux', 'build-windows'], true, pipelineConfigs))
-      })
+      String actualJson = PipelineSelectionsRepresenter.toJSON(new PipelineSelectionResponse(FiltersHelper.blacklist(['build-linux', 'build-windows']), pipelineConfigs))
 
       JsonFluentAssert.assertThatJson(actualJson).isEqualTo([
-        pipelines : [
-          grp2: ["pipeline1", "pipeline2"]
+        pipelines: [
+          grp2: ["pipeline1", "pipeline2", "build-linux", "build-windows"]
         ],
-        selections: ['build-linux', 'build-windows'],
-        blacklist : true
+        filters  : [[type: 'blacklist', pipelines: ['build-linux', 'build-windows']]]
       ])
     }
   }
-
-  @Nested
-  class Deserialize {
-    @Test
-    void 'should deserialize'() {
-      def json = [
-        selections: ['build-linux', 'build-windows'],
-        blacklist : true
-      ]
-
-      PipelineSelectionResponse response = PipelineSelectionsRepresenter.fromJSON(GsonTransformer.getInstance().jsonReaderFrom(json))
-      Assertions.assertThat(response.selections()).isEqualTo(["build-linux", "build-windows"])
-      Assertions.assertThat(response.blacklist()).isTrue()
-    }
-
-    @Test
-    void 'should blow up on bad blacklist type'() {
-      def jsonObject = new JsonObject()
-      jsonObject.add("blacklist", new JsonObject())
-
-      Assertions.assertThatCode({
-        PipelineSelectionsRepresenter.fromJSON(GsonTransformer.getInstance().jsonReaderFrom([blacklist: [:]]))
-      }).isInstanceOf(HaltException)
-        .hasFieldOrPropertyWithValue("statusCode", 422)
-        .hasFieldOrPropertyWithValue("body", MessageJson.create(propertyIsNotAJsonBoolean("blacklist", jsonObject)))
-    }
-
-    @Test
-    void 'should blow up on bad selection type'() {
-      def jsonObject = new JsonObject()
-      def array = new JsonArray()
-      array.add(new JsonObject())
-
-      jsonObject.add("selections", array)
-      Assertions.assertThatCode({
-        PipelineSelectionsRepresenter.fromJSON(GsonTransformer.getInstance().jsonReaderFrom([selections: [[:]]]))
-      }).isInstanceOf(HaltException)
-        .hasFieldOrPropertyWithValue("statusCode", 422)
-        .hasFieldOrPropertyWithValue("body", MessageJson.create(propertyIsNotAJsonStringArray("selections", jsonObject)))
-    }
-  }
 }
-

--- a/api/api-pipeline-selection-v1/src/test/groovy/com/thoughtworks/go/testhelpers/FiltersHelper.groovy
+++ b/api/api-pipeline-selection-v1/src/test/groovy/com/thoughtworks/go/testhelpers/FiltersHelper.groovy
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2018 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.testhelpers
+
+import com.thoughtworks.go.config.CaseInsensitiveString
+import com.thoughtworks.go.server.domain.user.BlacklistFilter
+import com.thoughtworks.go.server.domain.user.Filters
+
+class FiltersHelper {
+  static Filters blacklist(List<String> pipelines) {
+    return Filters.single(new BlacklistFilter(null, CaseInsensitiveString.list(pipelines)))
+  }
+}

--- a/api/api-pipeline-selection-v1/src/test/groovy/com/thoughtworks/go/testhelpers/FiltersHelper.groovy
+++ b/api/api-pipeline-selection-v1/src/test/groovy/com/thoughtworks/go/testhelpers/FiltersHelper.groovy
@@ -20,8 +20,10 @@ import com.thoughtworks.go.config.CaseInsensitiveString
 import com.thoughtworks.go.server.domain.user.BlacklistFilter
 import com.thoughtworks.go.server.domain.user.Filters
 
+import static com.thoughtworks.go.server.domain.user.Filters.DEFAULT_NAME
+
 class FiltersHelper {
   static Filters blacklist(List<String> pipelines) {
-    return Filters.single(new BlacklistFilter(null, CaseInsensitiveString.list(pipelines)))
+    return Filters.single(new BlacklistFilter(DEFAULT_NAME, CaseInsensitiveString.list(pipelines)))
   }
 }

--- a/api/api-pipeline-selection-v1/src/test/groovy/com/thoughtworks/go/testhelpers/FiltersHelper.groovy
+++ b/api/api-pipeline-selection-v1/src/test/groovy/com/thoughtworks/go/testhelpers/FiltersHelper.groovy
@@ -20,7 +20,7 @@ import com.thoughtworks.go.config.CaseInsensitiveString
 import com.thoughtworks.go.server.domain.user.BlacklistFilter
 import com.thoughtworks.go.server.domain.user.Filters
 
-import static com.thoughtworks.go.server.domain.user.Filters.DEFAULT_NAME
+import static com.thoughtworks.go.server.domain.user.DashboardFilter.DEFAULT_NAME
 
 class FiltersHelper {
   static Filters blacklist(List<String> pipelines) {

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/CaseInsensitiveString.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/CaseInsensitiveString.java
@@ -30,7 +30,7 @@ import java.util.stream.Stream;
 public class CaseInsensitiveString implements Comparable<CaseInsensitiveString>, Serializable {
 
     private final String name;
-    private final String lowerCaseName;//used only for comparison
+    private final String lowerCaseName; //used only for comparison
 
     public CaseInsensitiveString(String name) {
         this.name = name;
@@ -42,16 +42,16 @@ public class CaseInsensitiveString implements Comparable<CaseInsensitiveString>,
         return name;
     }
 
+    public String toLower() {
+        return lowerCaseName;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         CaseInsensitiveString that = (CaseInsensitiveString) o;
         return Objects.equals(lowerCaseName, that.lowerCaseName);
-    }
-
-    public String toLower() {
-        return lowerCaseName;
     }
 
     @Override

--- a/server/db/migrate/h2deltas/1807003_add_filters_and_version_to_pipeline_selections.sql
+++ b/server/db/migrate/h2deltas/1807003_add_filters_and_version_to_pipeline_selections.sql
@@ -1,0 +1,23 @@
+--
+-- Copyright 2018 ThoughtWorks, Inc.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--    http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+ALTER TABLE PipelineSelections ADD COLUMN filters CLOB;
+ALTER TABLE PipelineSelections ADD COLUMN version INT DEFAULT 0 NOT NULL;
+
+--//@UNDO
+
+ALTER TABLE PipelineSelections DROP COLUMN version;
+ALTER TABLE PipelineSelections DROP COLUMN filters;

--- a/server/src/main/java/com/thoughtworks/go/server/datamigration/DataMigrationRunner.java
+++ b/server/src/main/java/com/thoughtworks/go/server/datamigration/DataMigrationRunner.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2018 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.server.datamigration;
+
+import javax.sql.DataSource;
+import java.sql.Connection;
+import java.sql.SQLException;
+
+public class DataMigrationRunner {
+    private DataMigrationRunner() {
+    }
+
+    public static void run(DataSource ds) throws SQLException {
+        System.out.println("Running data migrations...");
+
+        try (Connection cxn = ds.getConnection()) {
+            exec(cxn, M001.convertPipelineSelectionsToFilters());
+        }
+
+        System.out.println("Data migrations completed.");
+    }
+
+    private static void exec(Connection cxn, Migration migration) throws SQLException {
+        cxn.setAutoCommit(false);
+
+        try {
+            migration.run(cxn);
+            cxn.commit();
+        } catch (SQLException e) {
+            System.err.println("Migration failed!");
+            cxn.rollback();
+            throw e;
+        }
+    }
+}

--- a/server/src/main/java/com/thoughtworks/go/server/datamigration/M001.java
+++ b/server/src/main/java/com/thoughtworks/go/server/datamigration/M001.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2018 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.server.datamigration;
+
+import com.google.gson.Gson;
+import org.apache.commons.lang3.StringUtils;
+
+import java.sql.*;
+
+class M001 {
+    private static final String ID = "id";
+    private static final String SELECTIONS = "selections";
+    private static final String BLACKLIST = "isblacklist";
+    private static final int SCHEMA = 1;
+    private static final Gson GSON = new Gson();
+
+    static Migration convertPipelineSelectionsToFilters() {
+        return (cxn) -> {
+            if (!required(cxn)) return;
+
+            try (Statement s = cxn.createStatement()) {
+                final ResultSet rs = s.executeQuery("SELECT id, selections, isblacklist FROM pipelineselections WHERE version = 0");
+                while (rs.next()) {
+                    perform(cxn, rs.getLong(ID), rs.getString(SELECTIONS), rs.getBoolean(BLACKLIST));
+                }
+            }
+        };
+    }
+
+    static void perform(Connection cxn, long id, String selections, boolean isBlacklist) throws SQLException {
+        try (PreparedStatement ps = cxn.prepareStatement("UPDATE pipelineselections SET selections = NULL, version = ?, filters = ? WHERE id = ?")) {
+            ps.setInt(1, SCHEMA);
+            ps.setString(2, asJson(selections, isBlacklist));
+            ps.setLong(3, id);
+            ps.executeUpdate();
+        }
+    }
+
+    static String asJson(String selections, boolean isBlacklist) {
+        return GSON.toJson(new FilterSet(selections, isBlacklist));
+    }
+
+    static boolean required(Connection cxn) throws SQLException {
+        try (Statement s = cxn.createStatement()) {
+            final ResultSet rs = s.executeQuery("SELECT COUNT(*) as remaining FROM pipelineselections WHERE version = 0");
+            rs.next();
+
+            return rs.getInt("remaining") > 0;
+        }
+    }
+
+    private static class FilterSet {
+        Filter[] filters;
+
+        public FilterSet(String selections, boolean isBlacklist) {
+            this.filters = new Filter[]{new Filter(selections, isBlacklist)};
+        }
+    }
+
+    private static class Filter {
+        String name;
+        String type;
+        String[] pipelines;
+
+        public Filter(String selections, boolean isBlacklist) {
+            name = null;
+            pipelines = StringUtils.isBlank(selections) ? new String[]{} : StringUtils.split(selections, ",");
+            type = isBlacklist ? "blacklist" : "whitelist";
+        }
+    }
+}

--- a/server/src/main/java/com/thoughtworks/go/server/datamigration/M001.java
+++ b/server/src/main/java/com/thoughtworks/go/server/datamigration/M001.java
@@ -77,7 +77,7 @@ class M001 {
         String[] pipelines;
 
         public Filter(String selections, boolean isBlacklist) {
-            name = null;
+            name = "Default";
             pipelines = StringUtils.isBlank(selections) ? new String[]{} : StringUtils.split(selections, ",");
             type = isBlacklist ? "blacklist" : "whitelist";
         }

--- a/server/src/main/java/com/thoughtworks/go/server/datamigration/Migration.java
+++ b/server/src/main/java/com/thoughtworks/go/server/datamigration/Migration.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2018 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.server.datamigration;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+
+@FunctionalInterface
+public interface Migration {
+    void run(Connection cxn) throws SQLException;
+}

--- a/server/src/main/java/com/thoughtworks/go/server/domain/user/BlacklistFilter.java
+++ b/server/src/main/java/com/thoughtworks/go/server/domain/user/BlacklistFilter.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2018 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.server.domain.user;
+
+import com.thoughtworks.go.config.CaseInsensitiveString;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+public class BlacklistFilter implements DashboardFilter {
+    private final String name;
+    private final List<CaseInsensitiveString> pipelines;
+
+    public BlacklistFilter(String name, List<CaseInsensitiveString> pipelines) {
+        this.name = name;
+        this.pipelines = pipelines;
+    }
+
+    public List<CaseInsensitiveString> pipelines() {
+        return Collections.unmodifiableList(pipelines);
+    }
+
+    @Override
+    public String name() {
+        return name;
+    }
+
+    @Override
+    public boolean isPipelineVisible(CaseInsensitiveString pipeline) {
+        return null == pipelines || !pipelines.contains(pipeline);
+    }
+
+    @Override
+    public boolean allowPipeline(CaseInsensitiveString pipeline) {
+        return pipelines.remove(pipeline);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        BlacklistFilter that = (BlacklistFilter) o;
+        return Objects.equals(name, that.name) &&
+                Objects.equals(pipelines, that.pipelines);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, pipelines);
+    }
+}

--- a/server/src/main/java/com/thoughtworks/go/server/domain/user/BlacklistFilter.java
+++ b/server/src/main/java/com/thoughtworks/go/server/domain/user/BlacklistFilter.java
@@ -21,7 +21,6 @@ import com.thoughtworks.go.config.CaseInsensitiveString;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
-import java.util.stream.Collectors;
 
 public class BlacklistFilter implements DashboardFilter {
     private final String name;
@@ -29,7 +28,7 @@ public class BlacklistFilter implements DashboardFilter {
 
     public BlacklistFilter(String name, List<CaseInsensitiveString> pipelines) {
         this.name = name;
-        this.pipelines = pipelines;
+        this.pipelines = DashboardFilter.enforceList(pipelines);
     }
 
     public List<CaseInsensitiveString> pipelines() {
@@ -43,7 +42,7 @@ public class BlacklistFilter implements DashboardFilter {
 
     @Override
     public boolean isPipelineVisible(CaseInsensitiveString pipeline) {
-        return null == pipelines || !pipelines.contains(pipeline);
+        return null == pipelines || pipelines.isEmpty() || !pipelines.contains(pipeline);
     }
 
     @Override

--- a/server/src/main/java/com/thoughtworks/go/server/domain/user/DashboardFilter.java
+++ b/server/src/main/java/com/thoughtworks/go/server/domain/user/DashboardFilter.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2018 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.server.domain.user;
+
+import com.thoughtworks.go.config.CaseInsensitiveString;
+
+public interface DashboardFilter {
+    String name();
+
+    boolean isPipelineVisible(CaseInsensitiveString pipeline);
+
+    /**
+     * Idempotent operation on filter to allow a specified pipeline to be visible
+     *
+     * @param pipeline - the name of the pipeline
+     * @return true if the filter was modified, false if unchanged
+     */
+    boolean allowPipeline(CaseInsensitiveString pipeline);
+}

--- a/server/src/main/java/com/thoughtworks/go/server/domain/user/DashboardFilter.java
+++ b/server/src/main/java/com/thoughtworks/go/server/domain/user/DashboardFilter.java
@@ -18,7 +18,17 @@ package com.thoughtworks.go.server.domain.user;
 
 import com.thoughtworks.go.config.CaseInsensitiveString;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
 public interface DashboardFilter {
+    static <T> List<T> enforceList(List<T> list) {
+        return Optional.ofNullable(list).orElse(new ArrayList<>());
+    }
+
+    String DEFAULT_NAME = "Default";
+
     String name();
 
     boolean isPipelineVisible(CaseInsensitiveString pipeline);

--- a/server/src/main/java/com/thoughtworks/go/server/domain/user/FilterValidationException.java
+++ b/server/src/main/java/com/thoughtworks/go/server/domain/user/FilterValidationException.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2018 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.server.domain.user;
+
+public class FilterValidationException extends RuntimeException {
+    FilterValidationException(String message) {
+        super(message);
+    }
+}

--- a/server/src/main/java/com/thoughtworks/go/server/domain/user/FilterValidator.java
+++ b/server/src/main/java/com/thoughtworks/go/server/domain/user/FilterValidator.java
@@ -21,6 +21,8 @@ import org.apache.commons.lang3.StringUtils;
 import java.util.Map;
 import java.util.regex.Pattern;
 
+import static com.thoughtworks.go.server.domain.user.DashboardFilter.DEFAULT_NAME;
+
 class FilterValidator {
 
     private static final Pattern LEAD_TRAIL_WHITESPACE = Pattern.compile("^\\s+.*|.*\\s+$");
@@ -36,6 +38,11 @@ class FilterValidator {
     static final String MSG_MAX_LENGTH = "Filter name cannot be more than " + MAX_NAME_LENGTH + " characters";
     static final String MSG_NAME_FORMAT = "Filter name is only allowed to contain letters, numbers, spaces, and punctuation marks";
     static final String MSG_MISSING_NAME = "Missing filter name";
+    static final String MSG_NO_DEFAULT_FILTER = "Missing default filter";
+
+    static void validateDefaultIsPresent(Map<String, DashboardFilter> current) {
+        if (!current.containsKey(DEFAULT_NAME.toLowerCase())) throw new FilterValidationException(MSG_NO_DEFAULT_FILTER);
+    }
 
     static void validateFilter(Map<String, DashboardFilter> current, DashboardFilter filter) {
         final String name = filter.name();

--- a/server/src/main/java/com/thoughtworks/go/server/domain/user/FilterValidator.java
+++ b/server/src/main/java/com/thoughtworks/go/server/domain/user/FilterValidator.java
@@ -69,9 +69,4 @@ class FilterValidator {
         if (StringUtils.isBlank(name)) throw new FilterValidationException(MSG_MISSING_NAME);
     }
 
-    static class FilterValidationException extends RuntimeException {
-        FilterValidationException(String message) {
-            super(message);
-        }
-    }
 }

--- a/server/src/main/java/com/thoughtworks/go/server/domain/user/FilterValidator.java
+++ b/server/src/main/java/com/thoughtworks/go/server/domain/user/FilterValidator.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2018 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.server.domain.user;
+
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.Map;
+import java.util.regex.Pattern;
+
+class FilterValidator {
+
+    private static final Pattern LEAD_TRAIL_WHITESPACE = Pattern.compile("^\\s+.*|.*\\s+$");
+
+    // translation: letters, numbers, spaces, and punctuation (i.e. the ASCII printable
+    private static final Pattern NAME_FORMAT = Pattern.compile("^(?! )[\\x20-\\x7E]+(?<! )$");
+    // down that road as this is liberal enough.
+
+    // chars); must not start or end with spaces. sorry, no unicode chars -- not going
+    private static final int MAX_NAME_LENGTH = 64;
+
+    static final String MSG_NO_LEADING_TRAILING_SPACES = "Filter name must not have leading or trailing whitespaces";
+    static final String MSG_MAX_LENGTH = "Filter name cannot be more than " + MAX_NAME_LENGTH + " characters";
+    static final String MSG_NAME_FORMAT = "Filter name is only allowed to contain letters, numbers, spaces, and punctuation marks";
+    static final String MSG_MISSING_NAME = "Missing filter name";
+
+    static void validateFilter(Map<String, DashboardFilter> current, DashboardFilter filter) {
+        final String name = filter.name();
+        validateNamePresent(name);
+        validateNameFormat(name);
+        validateNameIsUnique(current, name);
+    }
+
+    static void validateNameFormat(String name) {
+        if (LEAD_TRAIL_WHITESPACE.matcher(name).matches())
+            throw new FilterValidationException(MSG_NO_LEADING_TRAILING_SPACES);
+        if (!NAME_FORMAT.matcher(name).matches())
+            throw new FilterValidationException(MSG_NAME_FORMAT);
+        if (MAX_NAME_LENGTH < name.length())
+            throw new FilterValidationException(MSG_MAX_LENGTH);
+    }
+
+    static void validateNameIsUnique(Map<String, DashboardFilter> current, String name) {
+        if (current.containsKey(name.toLowerCase()))
+            throw new FilterValidationException("Duplicate filter name: " + name);
+    }
+
+    static void validateNamePresent(String name) {
+        if (StringUtils.isBlank(name)) throw new FilterValidationException(MSG_MISSING_NAME);
+    }
+
+    static class FilterValidationException extends RuntimeException {
+        FilterValidationException(String message) {
+            super(message);
+        }
+    }
+}

--- a/server/src/main/java/com/thoughtworks/go/server/domain/user/Filters.java
+++ b/server/src/main/java/com/thoughtworks/go/server/domain/user/Filters.java
@@ -79,6 +79,8 @@ public class Filters {
             FilterValidator.validateFilter(filterMap, f);
             filterMap.put(f.name().toLowerCase(), f);
         });
+
+        FilterValidator.validateDefaultIsPresent(filterMap);
     }
 
     @Override

--- a/server/src/main/java/com/thoughtworks/go/server/domain/user/Filters.java
+++ b/server/src/main/java/com/thoughtworks/go/server/domain/user/Filters.java
@@ -34,7 +34,8 @@ public class Filters {
             registerTypeAdapter(CaseInsensitiveString.class, new CaseInsensitiveStringSerializer()).
             create();
 
-    public static final DashboardFilter WILDCARD_FILTER = new BlacklistFilter(null, Collections.emptyList()) {
+    public static final String DEFAULT_NAME = "Default";
+    public static final DashboardFilter WILDCARD_FILTER = new BlacklistFilter(DEFAULT_NAME, Collections.emptyList()) {
         @Override
         public boolean isPipelineVisible(CaseInsensitiveString pipeline) {
             return true; // optimization
@@ -60,6 +61,7 @@ public class Filters {
     }
 
     private List<DashboardFilter> filters;
+
     private Map<String, DashboardFilter> filterMap; // optimize for find by name
 
     public Filters(List<DashboardFilter> filters) {
@@ -68,8 +70,8 @@ public class Filters {
     }
 
     public DashboardFilter named(String name) {
-        if (null == name) name = "";
-        return this.filterMap.getOrDefault(name, WILDCARD_FILTER);
+        if (null == name) name = DEFAULT_NAME;
+        return this.filterMap.getOrDefault(name.toLowerCase(), WILDCARD_FILTER);
     }
 
     public List<DashboardFilter> filters() {
@@ -78,7 +80,7 @@ public class Filters {
 
     private void updateIndex() {
         this.filterMap = new HashMap<>();
-        this.filters.forEach((f) -> filterMap.put(null != f.name() ? f.name() : "", f));
+        this.filters.forEach((f) -> filterMap.put(f.name().toLowerCase(), f));
     }
 
     @Override

--- a/server/src/main/java/com/thoughtworks/go/server/domain/user/Filters.java
+++ b/server/src/main/java/com/thoughtworks/go/server/domain/user/Filters.java
@@ -22,6 +22,7 @@ import com.thoughtworks.go.config.CaseInsensitiveString;
 
 import java.util.*;
 
+import static com.thoughtworks.go.server.domain.user.DashboardFilter.DEFAULT_NAME;
 import static com.thoughtworks.go.server.domain.user.Marshaling.*;
 
 public class Filters {
@@ -34,13 +35,7 @@ public class Filters {
             registerTypeAdapter(CaseInsensitiveString.class, new CaseInsensitiveStringSerializer()).
             create();
 
-    public static final String DEFAULT_NAME = "Default";
-    public static final DashboardFilter WILDCARD_FILTER = new BlacklistFilter(DEFAULT_NAME, Collections.emptyList()) {
-        @Override
-        public boolean isPipelineVisible(CaseInsensitiveString pipeline) {
-            return true; // optimization
-        }
-    };
+    public static final DashboardFilter WILDCARD_FILTER = new BlacklistFilter(DEFAULT_NAME, Collections.emptyList());
 
     public static Filters fromJson(String json) {
         final Filters filters = GSON.fromJson(json, Filters.class);

--- a/server/src/main/java/com/thoughtworks/go/server/domain/user/Filters.java
+++ b/server/src/main/java/com/thoughtworks/go/server/domain/user/Filters.java
@@ -70,7 +70,7 @@ public class Filters {
     }
 
     public DashboardFilter named(String name) {
-        if (null == name) name = DEFAULT_NAME;
+        FilterValidator.validateNamePresent(name);
         return this.filterMap.getOrDefault(name.toLowerCase(), WILDCARD_FILTER);
     }
 
@@ -80,7 +80,10 @@ public class Filters {
 
     private void updateIndex() {
         this.filterMap = new HashMap<>();
-        this.filters.forEach((f) -> filterMap.put(f.name().toLowerCase(), f));
+        this.filters.forEach((f) -> {
+            FilterValidator.validateFilter(filterMap, f);
+            filterMap.put(f.name().toLowerCase(), f);
+        });
     }
 
     @Override

--- a/server/src/main/java/com/thoughtworks/go/server/domain/user/Filters.java
+++ b/server/src/main/java/com/thoughtworks/go/server/domain/user/Filters.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2018 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.server.domain.user;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.thoughtworks.go.config.CaseInsensitiveString;
+
+import java.util.*;
+
+import static com.thoughtworks.go.server.domain.user.Marshaling.*;
+
+public class Filters {
+    private static final Gson GSON = new GsonBuilder().
+            registerTypeAdapter(Filters.class, new FiltersDeserializer()).
+            registerTypeAdapter(Filters.class, new FiltersSerializer()).
+            registerTypeAdapter(DashboardFilter.class, new DashboardFilterDeserializer()).
+            registerTypeAdapter(DashboardFilter.class, new DashboardFilterSerializer()).
+            registerTypeAdapter(CaseInsensitiveString.class, new CaseInsensitiveStringDeserializer()).
+            registerTypeAdapter(CaseInsensitiveString.class, new CaseInsensitiveStringSerializer()).
+            create();
+
+    public static final DashboardFilter WILDCARD_FILTER = new BlacklistFilter(null, Collections.emptyList()) {
+        @Override
+        public boolean isPipelineVisible(CaseInsensitiveString pipeline) {
+            return true; // optimization
+        }
+    };
+
+    public static Filters fromJson(String json) {
+        final Filters filters = GSON.fromJson(json, Filters.class);
+        filters.updateIndex();
+        return filters;
+    }
+
+    public static String toJson(Filters filters) {
+        return GSON.toJson(filters);
+    }
+
+    public static Filters single(DashboardFilter filter) {
+        return new Filters(Collections.singletonList(filter));
+    }
+
+    public static Filters defaults() {
+        return single(WILDCARD_FILTER);
+    }
+
+    private List<DashboardFilter> filters;
+    private Map<String, DashboardFilter> filterMap; // optimize for find by name
+
+    public Filters(List<DashboardFilter> filters) {
+        this.filters = filters;
+        updateIndex();
+    }
+
+    public DashboardFilter named(String name) {
+        if (null == name) name = "";
+        return this.filterMap.getOrDefault(name, WILDCARD_FILTER);
+    }
+
+    public List<DashboardFilter> filters() {
+        return Collections.unmodifiableList(filters);
+    }
+
+    private void updateIndex() {
+        this.filterMap = new HashMap<>();
+        this.filters.forEach((f) -> filterMap.put(null != f.name() ? f.name() : "", f));
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Filters that = (Filters) o;
+        return Objects.equals(filters, that.filters);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(filters);
+    }
+}

--- a/server/src/main/java/com/thoughtworks/go/server/domain/user/Marshaling.java
+++ b/server/src/main/java/com/thoughtworks/go/server/domain/user/Marshaling.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2018 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.server.domain.user;
+
+import com.google.gson.*;
+import com.thoughtworks.go.config.CaseInsensitiveString;
+
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+
+public class Marshaling {
+
+    public static class FiltersSerializer implements JsonSerializer<Filters> {
+        @Override
+        public JsonElement serialize(Filters src, Type typeOfSrc, JsonSerializationContext context) {
+            final JsonObject result = new JsonObject();
+            final JsonArray viewFilters = new JsonArray();
+
+            for (DashboardFilter f : src.filters()) {
+                viewFilters.add(context.serialize(f, DashboardFilter.class));
+            }
+            result.add("filters", viewFilters);
+            return result;
+        }
+    }
+
+    public static class FiltersDeserializer implements JsonDeserializer<Filters> {
+        @Override
+        public Filters deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
+            final JsonObject j = json.getAsJsonObject();
+            final JsonElement f = j.get("filters");
+
+            if (null == f) {
+                throw new JsonParseException("Missing filters array!");
+            }
+
+            final ArrayList<DashboardFilter> viewFilters = new ArrayList<>();
+
+            f.getAsJsonArray().forEach((filt) -> {
+                viewFilters.add(context.deserialize(filt, DashboardFilter.class));
+            });
+
+            return new Filters(viewFilters);
+        }
+    }
+
+    public static class DashboardFilterSerializer implements JsonSerializer<DashboardFilter> {
+        @Override
+        public JsonElement serialize(DashboardFilter src, Type typeOfSrc, JsonSerializationContext context) {
+            final JsonElement serialized;
+
+            if (src instanceof WhitelistFilter) {
+                serialized = context.serialize(src, WhitelistFilter.class);
+                serialized.getAsJsonObject().addProperty("type", "whitelist");
+            } else if (src instanceof BlacklistFilter) {
+                serialized = context.serialize(src, BlacklistFilter.class);
+                serialized.getAsJsonObject().addProperty("type", "blacklist");
+            } else {
+                throw new IllegalArgumentException("Don't know how to handle DashboardFilter implementation: " + src.getClass().getCanonicalName());
+            }
+
+            return serialized;
+        }
+    }
+
+    public static class DashboardFilterDeserializer implements JsonDeserializer<DashboardFilter> {
+        @Override
+        public DashboardFilter deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
+            JsonObject jsonObject = json.getAsJsonObject();
+            JsonElement type = jsonObject.get("type");
+
+            if (type != null) {
+                switch (type.getAsString()) {
+                    case "whitelist":
+                        return context.deserialize(jsonObject,
+                                WhitelistFilter.class);
+                    case "blacklist":
+                        return context.deserialize(jsonObject,
+                                BlacklistFilter.class);
+                    default:
+                        throw new JsonParseException("Don't know how to deserialize filter type:" + type.getAsString());
+                }
+            }
+
+            throw new JsonParseException("Missing filter type!");
+        }
+    }
+
+    public static class CaseInsensitiveStringSerializer implements JsonSerializer<CaseInsensitiveString> {
+        @Override
+        public JsonElement serialize(CaseInsensitiveString src, Type typeOfSrc, JsonSerializationContext context) {
+            return new JsonPrimitive(src.toString());
+        }
+    }
+
+    public static class CaseInsensitiveStringDeserializer implements JsonDeserializer<CaseInsensitiveString> {
+        @Override
+        public CaseInsensitiveString deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
+            return new CaseInsensitiveString(json.getAsString());
+        }
+    }
+}

--- a/server/src/main/java/com/thoughtworks/go/server/domain/user/Marshaling.java
+++ b/server/src/main/java/com/thoughtworks/go/server/domain/user/Marshaling.java
@@ -22,6 +22,8 @@ import com.thoughtworks.go.config.CaseInsensitiveString;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
 
+import static com.thoughtworks.go.server.domain.user.DashboardFilter.DEFAULT_NAME;
+
 public class Marshaling {
 
     public static class FiltersSerializer implements JsonSerializer<Filters> {
@@ -73,6 +75,8 @@ public class Marshaling {
                 throw new IllegalArgumentException("Don't know how to handle DashboardFilter implementation: " + src.getClass().getCanonicalName());
             }
 
+            serialized.getAsJsonObject().addProperty("name", normalizeName(src.name()));
+
             return serialized;
         }
     }
@@ -81,6 +85,10 @@ public class Marshaling {
         @Override
         public DashboardFilter deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
             JsonObject jsonObject = json.getAsJsonObject();
+
+            final String name = normalizeName(jsonObject.getAsJsonPrimitive("name").getAsString());
+            jsonObject.addProperty("name", name);
+
             JsonElement type = jsonObject.get("type");
 
             if (type != null) {
@@ -112,5 +120,9 @@ public class Marshaling {
         public CaseInsensitiveString deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
             return new CaseInsensitiveString(json.getAsString());
         }
+    }
+
+    private static String normalizeName(String name) {
+        return name.equalsIgnoreCase(DEFAULT_NAME) ? DEFAULT_NAME : name;
     }
 }

--- a/server/src/main/java/com/thoughtworks/go/server/domain/user/PipelineSelections.java
+++ b/server/src/main/java/com/thoughtworks/go/server/domain/user/PipelineSelections.java
@@ -25,6 +25,8 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
 import java.io.Serializable;
 import java.util.Date;
 
+import static com.thoughtworks.go.server.domain.user.Filters.DEFAULT_NAME;
+
 public class PipelineSelections extends PersistentObject implements Serializable {
     public static final int CURRENT_SCHEMA_VERSION = 1;
 
@@ -92,12 +94,12 @@ public class PipelineSelections extends PersistentObject implements Serializable
 
     @Deprecated // TODO: remove when removing old dashboard
     public boolean includesPipeline(CaseInsensitiveString pipelineName) {
-        return namedFilter(null).isPipelineVisible(pipelineName);
+        return namedFilter(DEFAULT_NAME).isPipelineVisible(pipelineName);
     }
 
     @Deprecated // TODO: remove when removing old dashboard
     public boolean isBlacklist() {
-        return namedFilter(null) instanceof BlacklistFilter;
+        return namedFilter(DEFAULT_NAME) instanceof BlacklistFilter;
     }
 
     public DashboardFilter namedFilter(String name) {

--- a/server/src/main/java/com/thoughtworks/go/server/domain/user/PipelineSelections.java
+++ b/server/src/main/java/com/thoughtworks/go/server/domain/user/PipelineSelections.java
@@ -95,6 +95,11 @@ public class PipelineSelections extends PersistentObject implements Serializable
         return namedFilter(null).isPipelineVisible(pipelineName);
     }
 
+    @Deprecated // TODO: remove when removing old dashboard
+    public boolean isBlacklist() {
+        return namedFilter(null) instanceof BlacklistFilter;
+    }
+
     public DashboardFilter namedFilter(String name) {
         return viewFilters.named(name);
     }

--- a/server/src/main/java/com/thoughtworks/go/server/domain/user/PipelineSelections.java
+++ b/server/src/main/java/com/thoughtworks/go/server/domain/user/PipelineSelections.java
@@ -25,7 +25,7 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
 import java.io.Serializable;
 import java.util.Date;
 
-import static com.thoughtworks.go.server.domain.user.Filters.DEFAULT_NAME;
+import static com.thoughtworks.go.server.domain.user.DashboardFilter.DEFAULT_NAME;
 
 public class PipelineSelections extends PersistentObject implements Serializable {
     public static final int CURRENT_SCHEMA_VERSION = 1;

--- a/server/src/main/java/com/thoughtworks/go/server/domain/user/WhitelistFilter.java
+++ b/server/src/main/java/com/thoughtworks/go/server/domain/user/WhitelistFilter.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2018 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.server.domain.user;
+
+import com.thoughtworks.go.config.CaseInsensitiveString;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+public class WhitelistFilter implements DashboardFilter {
+    private final String name;
+    private final List<CaseInsensitiveString> pipelines;
+
+    public WhitelistFilter(String name, List<CaseInsensitiveString> pipelines) {
+        this.name = name;
+        this.pipelines = pipelines;
+    }
+
+    public List<CaseInsensitiveString> pipelines() {
+        return Collections.unmodifiableList(pipelines);
+    }
+
+    @Override
+    public String name() {
+        return name;
+    }
+
+    @Override
+    public boolean isPipelineVisible(CaseInsensitiveString pipeline) {
+        return null != pipelines && pipelines.contains(pipeline);
+    }
+
+    @Override
+    public boolean allowPipeline(CaseInsensitiveString pipeline) {
+        return !pipelines.contains(pipeline) && pipelines.add(pipeline);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        WhitelistFilter that = (WhitelistFilter) o;
+        return Objects.equals(name, that.name) &&
+                Objects.equals(pipelines, that.pipelines);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, pipelines);
+    }
+}

--- a/server/src/main/java/com/thoughtworks/go/server/domain/user/WhitelistFilter.java
+++ b/server/src/main/java/com/thoughtworks/go/server/domain/user/WhitelistFilter.java
@@ -21,7 +21,6 @@ import com.thoughtworks.go.config.CaseInsensitiveString;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
-import java.util.stream.Collectors;
 
 public class WhitelistFilter implements DashboardFilter {
     private final String name;
@@ -29,7 +28,7 @@ public class WhitelistFilter implements DashboardFilter {
 
     public WhitelistFilter(String name, List<CaseInsensitiveString> pipelines) {
         this.name = name;
-        this.pipelines = pipelines;
+        this.pipelines = DashboardFilter.enforceList(pipelines);
     }
 
     public List<CaseInsensitiveString> pipelines() {
@@ -43,7 +42,7 @@ public class WhitelistFilter implements DashboardFilter {
 
     @Override
     public boolean isPipelineVisible(CaseInsensitiveString pipeline) {
-        return null != pipelines && pipelines.contains(pipeline);
+        return null != pipelines && !pipelines.isEmpty() && pipelines.contains(pipeline);
     }
 
     @Override

--- a/server/src/main/java/com/thoughtworks/go/server/persistence/PipelineRepository.java
+++ b/server/src/main/java/com/thoughtworks/go/server/persistence/PipelineRepository.java
@@ -238,15 +238,23 @@ public class PipelineRepository extends HibernateDaoSupport {
     public PipelineSelections findPipelineSelectionsById(long id) {
         PipelineSelections pipelineSelections;
         String key = pipelineSelectionForCookieKey(id);
+
         if (goCache.isKeyInCache(key)) {
             return (PipelineSelections) goCache.get(key);
         }
+
         synchronized (key) {
             if (goCache.isKeyInCache(key)) {
                 return (PipelineSelections) goCache.get(key);
             }
+
             pipelineSelections = getHibernateTemplate().get(PipelineSelections.class, id);
-            goCache.put(key, pipelineSelections);
+
+            if (null != pipelineSelections) {
+                getHibernateTemplate().saveOrUpdate(pipelineSelections);
+                goCache.put(key, pipelineSelections);
+            }
+
             return pipelineSelections;
         }
     }
@@ -276,7 +284,10 @@ public class PipelineRepository extends HibernateDaoSupport {
                 pipelineSelections = null;
             } else {
                 pipelineSelections = (PipelineSelections) list.get(0);
+
+                getHibernateTemplate().saveOrUpdate(pipelineSelections);
             }
+
             goCache.put(key, pipelineSelections);
             return pipelineSelections;
         }

--- a/server/src/main/java/com/thoughtworks/go/server/service/GoDashboardService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/GoDashboardService.java
@@ -23,8 +23,7 @@ import com.thoughtworks.go.config.PipelineConfigs;
 import com.thoughtworks.go.config.security.Permissions;
 import com.thoughtworks.go.server.dashboard.*;
 import com.thoughtworks.go.server.domain.Username;
-import com.thoughtworks.go.server.domain.user.PipelineSelections;
-import com.thoughtworks.go.server.service.support.toggle.Toggles;
+import com.thoughtworks.go.server.domain.user.DashboardFilter;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -45,12 +44,12 @@ public class GoDashboardService {
         this.goConfigService = goConfigService;
     }
 
-    public List<GoDashboardPipelineGroup> allPipelineGroupsForDashboard(PipelineSelections pipelineSelections, Username user) {
+    public List<GoDashboardPipelineGroup> allPipelineGroupsForDashboard(DashboardFilter filter, Username user) {
         GoDashboardPipelines allPipelines = cache.allEntries();
         List<GoDashboardPipelineGroup> pipelineGroups = new ArrayList<>();
 
         goConfigService.groups().accept(group -> {
-            GoDashboardPipelineGroup dashboardPipelineGroup = dashboardPipelineGroupFor(group, pipelineSelections, user, allPipelines);
+            GoDashboardPipelineGroup dashboardPipelineGroup = dashboardPipelineGroupFor(group, filter, user, allPipelines);
             if (dashboardPipelineGroup.hasPipelines()) {
                 pipelineGroups.add(dashboardPipelineGroup);
             }
@@ -78,12 +77,12 @@ public class GoDashboardService {
         return dashboardCurrentStateLoader.hasEverLoadedCurrentState();
     }
 
-    private GoDashboardPipelineGroup dashboardPipelineGroupFor(PipelineConfigs pipelineGroup, PipelineSelections pipelineSelections, Username user, GoDashboardPipelines allPipelines) {
+    private GoDashboardPipelineGroup dashboardPipelineGroupFor(PipelineConfigs pipelineGroup, DashboardFilter filter, Username user, GoDashboardPipelines allPipelines) {
         GoDashboardPipelineGroup goDashboardPipelineGroup = new GoDashboardPipelineGroup(pipelineGroup.getGroup(), resolvePermissionsForPipelineGroup(pipelineGroup, allPipelines));
 
         if (goDashboardPipelineGroup.hasPermissions() && goDashboardPipelineGroup.canBeViewedBy(user.getUsername().toString())) {
             pipelineGroup.accept(pipelineConfig -> {
-                if (pipelineSelections.includesPipeline(pipelineConfig)) {
+                if (filter.isPipelineVisible(pipelineConfig.name())) {
                     goDashboardPipelineGroup.addPipeline(allPipelines.find(pipelineConfig.getName()));
                 }
             });

--- a/server/src/main/java/com/thoughtworks/go/server/service/PipelineHistoryService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/PipelineHistoryService.java
@@ -16,7 +16,10 @@
 
 package com.thoughtworks.go.server.service;
 
-import com.thoughtworks.go.config.*;
+import com.thoughtworks.go.config.CaseInsensitiveString;
+import com.thoughtworks.go.config.CruiseConfig;
+import com.thoughtworks.go.config.PipelineConfig;
+import com.thoughtworks.go.config.PipelineConfigs;
 import com.thoughtworks.go.domain.PipelineDependencyGraphOld;
 import com.thoughtworks.go.domain.PipelineGroups;
 import com.thoughtworks.go.domain.PipelinePauseInfo;
@@ -30,6 +33,7 @@ import com.thoughtworks.go.server.dao.StageDao;
 import com.thoughtworks.go.server.domain.JobDurationStrategy;
 import com.thoughtworks.go.server.domain.PipelineTimeline;
 import com.thoughtworks.go.server.domain.Username;
+import com.thoughtworks.go.server.domain.user.DashboardFilter;
 import com.thoughtworks.go.server.domain.user.PipelineSelections;
 import com.thoughtworks.go.server.persistence.MaterialRepository;
 import com.thoughtworks.go.server.scheduling.TriggerMonitor;
@@ -396,7 +400,7 @@ public class PipelineHistoryService implements PipelineInstanceLoader {
 
     public List<PipelineGroupModel> allActivePipelineInstances(Username username, PipelineSelections pipelineSelections) {
         PipelineGroupModels groupModels = allPipelineInstances(username);
-        filterSelections(groupModels,pipelineSelections);
+        filterSelections(groupModels, pipelineSelections.namedFilter(null));
         removeEmptyGroups(groupModels);
         updateGroupAdministrability(username, groupModels);
         return groupModels.asList();
@@ -404,7 +408,7 @@ public class PipelineHistoryService implements PipelineInstanceLoader {
 
     public List<PipelineGroupModel> getActivePipelineInstance(Username username, String pipeline) {
         PipelineGroupModels models = allPipelineInstances(username);
-        filterSelections(models, PipelineSelections.singleSelection(pipeline));
+        filterSelections(models, singlePipelineFilter(pipeline));
         removeEmptyGroups(models);
         return models.asList();
     }
@@ -442,11 +446,11 @@ public class PipelineHistoryService implements PipelineInstanceLoader {
         return groupModels;
     }
 
-    private void filterSelections(PipelineGroupModels groupModels, PipelineSelections pipelineSelections) {
+    private void filterSelections(PipelineGroupModels groupModels, DashboardFilter filter) {
         for (PipelineGroupModel groupModel : groupModels.asList()) {
             for (PipelineModel pipelineModel : groupModel.getPipelineModels()) {
-                if(!pipelineSelections.includesPipeline(pipelineModel.getName())){
-                    groupModels.removePipeline(groupModel,pipelineModel);
+                if (!filter.isPipelineVisible(new CaseInsensitiveString(pipelineModel.getName()))) {
+                    groupModels.removePipeline(groupModel, pipelineModel);
                 }
             }
         }
@@ -580,6 +584,25 @@ public class PipelineHistoryService implements PipelineInstanceLoader {
         } else {
             result.forbidden("You do not have operate permissions for pipeline '" + pipelineName + "'.", HealthStateType.general(HealthStateScope.forPipeline(pipelineName)));
         }
+    }
+
+    private DashboardFilter singlePipelineFilter(String pipeline) {
+        return new DashboardFilter() {
+            @Override
+            public String name() {
+                return null;
+            }
+
+            @Override
+            public boolean isPipelineVisible(CaseInsensitiveString pipelineName) {
+                return pipeline.equalsIgnoreCase(CaseInsensitiveString.str(pipelineName));
+            }
+
+            @Override
+            public boolean allowPipeline(CaseInsensitiveString pipeline) {
+                return false;
+            }
+        };
     }
 
     private static class PipelineGroupModels {

--- a/server/src/main/java/com/thoughtworks/go/server/service/PipelineHistoryService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/PipelineHistoryService.java
@@ -51,7 +51,7 @@ import org.springframework.stereotype.Service;
 import java.util.ArrayList;
 import java.util.List;
 
-import static com.thoughtworks.go.server.domain.user.Filters.DEFAULT_NAME;
+import static com.thoughtworks.go.server.domain.user.DashboardFilter.DEFAULT_NAME;
 
 @Service
 public class PipelineHistoryService implements PipelineInstanceLoader {

--- a/server/src/main/java/com/thoughtworks/go/server/service/PipelineHistoryService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/PipelineHistoryService.java
@@ -51,6 +51,8 @@ import org.springframework.stereotype.Service;
 import java.util.ArrayList;
 import java.util.List;
 
+import static com.thoughtworks.go.server.domain.user.Filters.DEFAULT_NAME;
+
 @Service
 public class PipelineHistoryService implements PipelineInstanceLoader {
     private PipelineDao pipelineDao;
@@ -400,7 +402,7 @@ public class PipelineHistoryService implements PipelineInstanceLoader {
 
     public List<PipelineGroupModel> allActivePipelineInstances(Username username, PipelineSelections pipelineSelections) {
         PipelineGroupModels groupModels = allPipelineInstances(username);
-        filterSelections(groupModels, pipelineSelections.namedFilter(null));
+        filterSelections(groupModels, pipelineSelections.namedFilter(DEFAULT_NAME));
         removeEmptyGroups(groupModels);
         updateGroupAdministrability(username, groupModels);
         return groupModels.asList();

--- a/server/src/main/java/com/thoughtworks/go/server/service/PipelineSelectionsService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/PipelineSelectionsService.java
@@ -17,14 +17,12 @@
 package com.thoughtworks.go.server.service;
 
 import com.thoughtworks.go.config.CaseInsensitiveString;
+import com.thoughtworks.go.server.domain.user.Filters;
 import com.thoughtworks.go.server.domain.user.PipelineSelections;
 import com.thoughtworks.go.server.persistence.PipelineRepository;
 import com.thoughtworks.go.util.Clock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
-
-import java.util.ArrayList;
-import java.util.List;
 
 @Service
 public class PipelineSelectionsService {
@@ -39,7 +37,7 @@ public class PipelineSelectionsService {
         this.clock = clock;
     }
 
-    public PipelineSelections getPersistedSelectedPipelines(String id, Long userId) {
+    public PipelineSelections loadPipelineSelections(String id, Long userId) {
         PipelineSelections pipelineSelections = loadByIdOrUserId(id, userId);
 
         if (pipelineSelections == null) {
@@ -49,9 +47,11 @@ public class PipelineSelectionsService {
         return pipelineSelections;
     }
 
-    public long persistSelectedPipelines(String id, Long userId, List<String> selectedPipelines, boolean isBlacklist) {
+    public long persistPipelineSelections(String id, Long userId, Filters filters) {
+
         PipelineSelections pipelineSelections = findOrCreateCurrentPipelineSelectionsFor(id, userId);
-        pipelineSelections.update(selectedPipelines, clock.currentTime(), userId, isBlacklist);
+        pipelineSelections.update(filters, clock.currentTime(), userId);
+
         return pipelineRepository.saveSelectedPipelines(pipelineSelections);
     }
 
@@ -59,7 +59,7 @@ public class PipelineSelectionsService {
         PipelineSelections pipelineSelections = loadByIdOrUserId(id, userId);
 
         if (pipelineSelections == null) {
-            return new PipelineSelections(new ArrayList<>(), clock.currentTime(), userId, true);
+            return new PipelineSelections(Filters.defaults(), clock.currentTime(), userId);
         }
 
         return pipelineSelections;

--- a/server/src/main/java/com/thoughtworks/go/server/util/DatabaseUpgraderDataSourceFactory.java
+++ b/server/src/main/java/com/thoughtworks/go/server/util/DatabaseUpgraderDataSourceFactory.java
@@ -16,13 +16,14 @@
 
 package com.thoughtworks.go.server.util;
 
-import java.sql.SQLException;
+import com.thoughtworks.go.database.Database;
+import com.thoughtworks.go.server.datamigration.DataMigrationRunner;
+import org.springframework.beans.factory.annotation.Autowired;
+
 import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
 import javax.sql.DataSource;
-
-import com.thoughtworks.go.database.Database;
-import org.springframework.beans.factory.annotation.Autowired;
+import java.sql.SQLException;
 
 /**
  * @understands data source creation
@@ -48,6 +49,7 @@ public class DatabaseUpgraderDataSourceFactory {
     @PostConstruct
     public void upgradeDb() throws SQLException {
         database.upgrade();
+        DataMigrationRunner.run(dataSource());
     }
 
     @PreDestroy

--- a/server/src/main/resources/hibernate-mappings/PipelineSelections.hbm.xml
+++ b/server/src/main/resources/hibernate-mappings/PipelineSelections.hbm.xml
@@ -23,9 +23,9 @@
         <id name="id" column="id">
             <generator class="identity"/>
         </id>
-        <property name="selections" access="property"/>
         <property name="userId" access="field"/>
         <property name="lastUpdate"/>
-        <property name="isBlacklist" access="field"/>
+        <property name="filters" access="property"/>
+        <property name="version" access="field"/>
     </class>
 </hibernate-mapping>

--- a/server/src/test-fast/java/com/thoughtworks/go/server/domain/user/BlacklistFilterTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/domain/user/BlacklistFilterTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2018 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.server.domain.user;
+
+import com.thoughtworks.go.config.CaseInsensitiveString;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class BlacklistFilterTest {
+    @Test
+    void isPipelineVisible() {
+        final BlacklistFilter f = new BlacklistFilter(null, CaseInsensitiveString.list("p1"));
+        assertFalse(f.isPipelineVisible(new CaseInsensitiveString("p1")));
+        assertTrue(f.isPipelineVisible(new CaseInsensitiveString("p0")));
+    }
+
+    @Test
+    void allowPipeline() {
+        final BlacklistFilter f = new BlacklistFilter(null, CaseInsensitiveString.list("p1"));
+        assertFalse(f.isPipelineVisible(new CaseInsensitiveString("p1")));
+        assertTrue(f.isPipelineVisible(new CaseInsensitiveString("p0")));
+
+        f.allowPipeline(new CaseInsensitiveString("p1"));
+        assertTrue(f.isPipelineVisible(new CaseInsensitiveString("p1")));
+    }
+
+    @Test
+    void equals() {
+        final BlacklistFilter a = new BlacklistFilter(null, CaseInsensitiveString.list("p1"));
+        final BlacklistFilter b = new BlacklistFilter(null, CaseInsensitiveString.list("p1"));
+        final BlacklistFilter c = new BlacklistFilter(null, CaseInsensitiveString.list("p0"));
+        assertEquals(a, b);
+        assertNotEquals(a, c);
+    }
+}

--- a/server/src/test-fast/java/com/thoughtworks/go/server/domain/user/FiltersTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/domain/user/FiltersTest.java
@@ -20,11 +20,9 @@ import com.thoughtworks.go.config.CaseInsensitiveString;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 class FiltersTest {
 
@@ -43,11 +41,20 @@ class FiltersTest {
     @Test
     void toJson() {
         List<DashboardFilter> views = new ArrayList<>();
-        final List<CaseInsensitiveString> pipelines = Collections.singletonList(new CaseInsensitiveString("Pipely McPipe"));
-        final BlacklistFilter first = new BlacklistFilter("Cool Pipelines", null, pipelines);
+        final List<CaseInsensitiveString> pipelines = CaseInsensitiveString.list("Pipely McPipe");
+        final BlacklistFilter first = new BlacklistFilter("Cool Pipelines", pipelines);
         views.add(first);
         final Filters filters = new Filters(views);
 
         assertEquals("{\"filters\":[{\"name\":\"Cool Pipelines\",\"pipelines\":[\"Pipely McPipe\"],\"type\":\"blacklist\"}]}", Filters.toJson(filters));
+    }
+
+    @Test
+    void equalsIsStructuralEquality() {
+        final Filters a = Filters.single(new BlacklistFilter("foo", CaseInsensitiveString.list("p1", "p2")));
+        final Filters b = Filters.single(new BlacklistFilter("foo", CaseInsensitiveString.list("p1", "p2")));
+        final Filters c = Filters.single(new BlacklistFilter("foo", CaseInsensitiveString.list("p1", "p3")));
+        assertEquals(a, b);
+        assertNotEquals(a, c);
     }
 }

--- a/server/src/test-fast/java/com/thoughtworks/go/server/domain/user/FiltersTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/domain/user/FiltersTest.java
@@ -25,7 +25,9 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+import static com.thoughtworks.go.server.domain.user.DashboardFilter.DEFAULT_NAME;
 import static com.thoughtworks.go.server.domain.user.FilterValidator.*;
+import static com.thoughtworks.go.server.domain.user.Filters.WILDCARD_FILTER;
 import static org.junit.jupiter.api.Assertions.*;
 
 
@@ -36,22 +38,22 @@ class FiltersTest {
 
     @Test
     void validatesNameFormatOnConstruction() {
-        DashboardFilter a = new WhitelistFilter("¯\\_(ツ)_/¯", Collections.emptyList());
+        DashboardFilter a = namedWhitelist("¯\\_(ツ)_/¯");
 
         Throwable e = assertThrows(FilterValidationException.class, () -> new Filters(Collections.singletonList(a)));
         assertEquals(MSG_NAME_FORMAT, e.getMessage());
 
-        DashboardFilter b = new WhitelistFilter(" filter", Collections.emptyList());
+        DashboardFilter b = namedWhitelist(" filter");
 
         e = assertThrows(FilterValidationException.class, () -> new Filters(Collections.singletonList(b)));
         assertEquals(MSG_NO_LEADING_TRAILING_SPACES, e.getMessage());
 
-        DashboardFilter c = new WhitelistFilter("filter ", Collections.emptyList());
+        DashboardFilter c = namedWhitelist("filter ");
 
         e = assertThrows(FilterValidationException.class, () -> new Filters(Collections.singletonList(c)));
         assertEquals(MSG_NO_LEADING_TRAILING_SPACES, e.getMessage());
 
-        DashboardFilter d = new WhitelistFilter(NAME_TOO_LONG, Collections.emptyList());
+        DashboardFilter d = namedWhitelist(NAME_TOO_LONG);
         e = assertThrows(FilterValidationException.class, () -> new Filters(Collections.singletonList(d)));
         assertEquals(MSG_MAX_LENGTH, e.getMessage());
     }
@@ -85,17 +87,17 @@ class FiltersTest {
 
     @Test
     void validatesNamePresenceOnConstruction() {
-        DashboardFilter a = new WhitelistFilter("", Collections.emptyList());
+        DashboardFilter a = namedWhitelist("");
 
         Throwable e = assertThrows(FilterValidationException.class, () -> new Filters(Collections.singletonList(a)));
         assertEquals(MSG_MISSING_NAME, e.getMessage());
 
-        DashboardFilter b = new WhitelistFilter(" ", Collections.emptyList());
+        DashboardFilter b = namedWhitelist(" ");
 
         e = assertThrows(FilterValidationException.class, () -> new Filters(Collections.singletonList(b)));
         assertEquals(MSG_MISSING_NAME, e.getMessage());
 
-        DashboardFilter c = new WhitelistFilter(null, Collections.emptyList());
+        DashboardFilter c = namedWhitelist(null);
 
         e = assertThrows(FilterValidationException.class, () -> new Filters(Collections.singletonList(c)));
         assertEquals(MSG_MISSING_NAME, e.getMessage());
@@ -124,8 +126,8 @@ class FiltersTest {
 
     @Test
     void validatesDuplicateNamesOnConstruction() {
-        DashboardFilter a = new WhitelistFilter("one", Collections.emptyList());
-        DashboardFilter b = new BlacklistFilter("one", Collections.emptyList());
+        DashboardFilter a = namedWhitelist("one");
+        DashboardFilter b = namedBlacklist("one");
 
         Throwable e = assertThrows(FilterValidationException.class, () -> new Filters(Arrays.asList(a, b)));
         assertEquals("Duplicate filter name: one", e.getMessage());
@@ -143,11 +145,11 @@ class FiltersTest {
 
     @Test
     void fromJson() {
-        String json = "{ \"filters\": [{\"name\": \"My Filter\", \"type\": \"whitelist\", \"pipelines\": [\"p1\"]}] }";
+        String json = "{ \"filters\": [{\"name\": \"Default\", \"type\": \"whitelist\", \"pipelines\": [\"p1\"]}] }";
         final Filters filters = Filters.fromJson(json);
         assertEquals(1, filters.filters().size());
         final DashboardFilter first = filters.filters().get(0);
-        assertEquals(first.name(), "My Filter");
+        assertEquals(first.name(), DEFAULT_NAME);
         assertTrue(first instanceof WhitelistFilter);
         assertEquals(1, ((WhitelistFilter) first).pipelines().size());
         assertTrue(((WhitelistFilter) first).pipelines().contains(new CaseInsensitiveString("p1")));
@@ -156,20 +158,51 @@ class FiltersTest {
     @Test
     void toJson() {
         List<DashboardFilter> views = new ArrayList<>();
-        final List<CaseInsensitiveString> pipelines = CaseInsensitiveString.list("Pipely McPipe");
-        final BlacklistFilter first = new BlacklistFilter("Cool Pipelines", pipelines);
-        views.add(first);
+        views.add(WILDCARD_FILTER);
+        views.add(namedBlacklist("Cool Pipelines", "Pipely McPipe"));
         final Filters filters = new Filters(views);
 
-        assertEquals("{\"filters\":[{\"name\":\"Cool Pipelines\",\"pipelines\":[\"Pipely McPipe\"],\"type\":\"blacklist\"}]}", Filters.toJson(filters));
+        assertEquals("{\"filters\":[" +
+                "{\"name\":\"" + DEFAULT_NAME + "\",\"pipelines\":[],\"type\":\"blacklist\"}," +
+                "{\"name\":\"Cool Pipelines\",\"pipelines\":[\"Pipely McPipe\"],\"type\":\"blacklist\"}" +
+                "]}", Filters.toJson(filters));
     }
 
     @Test
     void equalsIsStructuralEquality() {
-        final Filters a = Filters.single(new BlacklistFilter("foo", CaseInsensitiveString.list("p1", "p2")));
-        final Filters b = Filters.single(new BlacklistFilter("foo", CaseInsensitiveString.list("p1", "p2")));
-        final Filters c = Filters.single(new BlacklistFilter("foo", CaseInsensitiveString.list("p1", "p3")));
+        final Filters a = Filters.single(blacklist("p1", "p2"));
+        final Filters b = Filters.single(blacklist("p1", "p2"));
+        final Filters c = Filters.single(blacklist("p1", "p3"));
+
         assertEquals(a, b);
         assertNotEquals(a, c);
+
+        final Filters d = Filters.single(whitelist("p1", "p2"));
+        final Filters e = Filters.single(whitelist("p1", "p2"));
+        final Filters f = Filters.single(whitelist("p1", "p3"));
+
+        assertEquals(d, e);
+        assertNotEquals(d, f);
+
+        assertNotEquals(a, d);
+
+        assertEquals(Filters.defaults(), Filters.single(blacklist()));
+    }
+
+
+    private DashboardFilter namedWhitelist(String name, String... pipelines) {
+        return new WhitelistFilter(name, CaseInsensitiveString.list(pipelines));
+    }
+
+    private DashboardFilter whitelist(String... pipelines) {
+        return namedWhitelist(DEFAULT_NAME, pipelines);
+    }
+
+    private DashboardFilter namedBlacklist(String name, String... pipelines) {
+        return new BlacklistFilter(name, CaseInsensitiveString.list(pipelines));
+    }
+
+    private DashboardFilter blacklist(String... pipelines) {
+        return namedBlacklist(DEFAULT_NAME, pipelines);
     }
 }

--- a/server/src/test-fast/java/com/thoughtworks/go/server/domain/user/FiltersTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/domain/user/FiltersTest.java
@@ -160,6 +160,15 @@ class FiltersTest {
     }
 
     @Test
+    void defaultFilterNameIsAlwaysTitleCase() {
+        String json = "{ \"filters\": [{\"name\": \"deFauLt\", \"type\": \"whitelist\"}] }";
+        assertEquals(DEFAULT_NAME, Filters.fromJson(json).named(DEFAULT_NAME).name());
+
+        String expected = "{\"filters\":[{\"name\":\"" + DEFAULT_NAME + "\",\"pipelines\":[],\"type\":\"whitelist\"}]}";
+        assertEquals(expected, Filters.toJson(Filters.single(namedWhitelist("defAUlT"))));
+    }
+
+    @Test
     void fromJson() {
         String json = "{ \"filters\": [{\"name\": \"Default\", \"type\": \"whitelist\", \"pipelines\": [\"p1\"]}] }";
         final Filters filters = Filters.fromJson(json);

--- a/server/src/test-fast/java/com/thoughtworks/go/server/domain/user/FiltersTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/domain/user/FiltersTest.java
@@ -144,6 +144,22 @@ class FiltersTest {
     }
 
     @Test
+    void validatesPresenceOfDefaultFilterOnConstruction() {
+        Throwable e = assertThrows(FilterValidationException.class, () -> Filters.single(namedBlacklist("foo", "bar")));
+        assertEquals(MSG_NO_DEFAULT_FILTER, e.getMessage());
+    }
+
+    @Test
+    void validatesPresenceOfDefaultFilterOnDeserialize() {
+        final String json = "{ \"filters\": [" +
+                "  {\"name\": \"foo\", \"type\": \"whitelist\", \"pipelines\": [\"bar\"]}" +
+                "] }";
+
+        Throwable e = assertThrows(FilterValidationException.class, () -> Filters.fromJson(json));
+        assertEquals(MSG_NO_DEFAULT_FILTER, e.getMessage());
+    }
+
+    @Test
     void fromJson() {
         String json = "{ \"filters\": [{\"name\": \"Default\", \"type\": \"whitelist\", \"pipelines\": [\"p1\"]}] }";
         final Filters filters = Filters.fromJson(json);

--- a/server/src/test-fast/java/com/thoughtworks/go/server/domain/user/FiltersTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/domain/user/FiltersTest.java
@@ -17,7 +17,6 @@
 package com.thoughtworks.go.server.domain.user;
 
 import com.thoughtworks.go.config.CaseInsensitiveString;
-import com.thoughtworks.go.server.domain.user.FilterValidator.*;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;

--- a/server/src/test-fast/java/com/thoughtworks/go/server/domain/user/PipelineSelectionsHelper.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/domain/user/PipelineSelectionsHelper.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2018 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.server.domain.user;
+
+import com.thoughtworks.go.config.CaseInsensitiveString;
+
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+
+public class PipelineSelectionsHelper {
+    public static PipelineSelections with(List<String> pipelines, Date date, Long userId, boolean blacklist) {
+        List<CaseInsensitiveString> params = CaseInsensitiveString.list(pipelines);
+        DashboardFilter filter = blacklist ? new BlacklistFilter(null, params) : new WhitelistFilter(null, params);
+        return new PipelineSelections(new Filters(Collections.singletonList(filter)), date, userId);
+    }
+
+    public static PipelineSelections with(List<String> pipelines) {
+        return with(pipelines, new Date(), null, true);
+    }
+}

--- a/server/src/test-fast/java/com/thoughtworks/go/server/domain/user/PipelineSelectionsHelper.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/domain/user/PipelineSelectionsHelper.java
@@ -22,10 +22,12 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 
+import static com.thoughtworks.go.server.domain.user.Filters.DEFAULT_NAME;
+
 public class PipelineSelectionsHelper {
     public static PipelineSelections with(List<String> pipelines, Date date, Long userId, boolean blacklist) {
         List<CaseInsensitiveString> params = CaseInsensitiveString.list(pipelines);
-        DashboardFilter filter = blacklist ? new BlacklistFilter(null, params) : new WhitelistFilter(null, params);
+        DashboardFilter filter = blacklist ? new BlacklistFilter(DEFAULT_NAME, params) : new WhitelistFilter(DEFAULT_NAME, params);
         return new PipelineSelections(new Filters(Collections.singletonList(filter)), date, userId);
     }
 

--- a/server/src/test-fast/java/com/thoughtworks/go/server/domain/user/PipelineSelectionsHelper.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/domain/user/PipelineSelectionsHelper.java
@@ -22,7 +22,7 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 
-import static com.thoughtworks.go.server.domain.user.Filters.DEFAULT_NAME;
+import static com.thoughtworks.go.server.domain.user.DashboardFilter.DEFAULT_NAME;
 
 public class PipelineSelectionsHelper {
     public static PipelineSelections with(List<String> pipelines, Date date, Long userId, boolean blacklist) {

--- a/server/src/test-fast/java/com/thoughtworks/go/server/domain/user/PipelineSelectionsTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/domain/user/PipelineSelectionsTest.java
@@ -16,56 +16,43 @@
 
 package com.thoughtworks.go.server.domain.user;
 
-import java.util.Arrays;
-
 import com.thoughtworks.go.config.CaseInsensitiveString;
 import org.junit.Test;
 
-import static org.junit.Assert.assertThat;
-import static org.hamcrest.core.Is.is;
+import java.util.Arrays;
+
 import static com.thoughtworks.go.helper.PipelineConfigMother.createGroup;
 import static com.thoughtworks.go.helper.PipelineConfigMother.pipelineConfig;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
 
 public class PipelineSelectionsTest {
     @Test
-    public void shouldIncludePipelineWhenGroupIsIncluded_whenBlacklistIsEnabled() {
-        PipelineSelections pipelineSelections = new PipelineSelections(Arrays.asList("pipeline1"));
+    public void DEPRECATED_shouldIncludePipelineWhenGroupIsIncluded_whenBlacklistIsEnabled() {
+        PipelineSelections pipelineSelections = PipelineSelectionsHelper.with(Arrays.asList("pipeline1"));
         assertThat(pipelineSelections.includesGroup(createGroup("group1", pipelineConfig("pipelineX"))), is(true));
         assertThat(pipelineSelections.includesGroup(createGroup("group2", pipelineConfig("pipeline2"), pipelineConfig("pipeline1"))), is(false));
-        assertThat(pipelineSelections.includesPipeline(pipelineConfig("pipeline1")), is(false));
-        assertThat(pipelineSelections.includesPipeline(pipelineConfig("pipeline2")), is(true));
+        assertThat(pipelineSelections.includesPipeline(new CaseInsensitiveString("pipeline1")), is(false));
+        assertThat(pipelineSelections.includesPipeline(new CaseInsensitiveString("pipeline2")), is(true));
     }
 
     @Test
-    public void shouldIncludePipelinesCaseInsensitively_whenBlacklistIsEnabled() {
-        PipelineSelections pipelineSelections = new PipelineSelections(Arrays.asList("pipeline1"));
+    public void DEPRECATED_shouldIncludePipelinesCaseInsensitively_whenBlacklistIsEnabled() {
+        PipelineSelections pipelineSelections = PipelineSelectionsHelper.with(Arrays.asList("pipeline1"));
         assertThat(pipelineSelections.includesPipeline(new CaseInsensitiveString("pipeline1")), is(false));
         assertThat(pipelineSelections.includesPipeline(new CaseInsensitiveString("Pipeline1")), is(false));
     }
 
     @Test
-    public void shouldReturnASelectionForASinglePipeline_whenBlacklistIsEnabled() {
-        PipelineSelections selections = PipelineSelections.singleSelection("pipeline");
-        assertThat(selections.includesPipeline("pipeline"), is(true));
-        assertThat(selections.includesPipeline(pipelineConfig("pipeline")), is(true));
-
-        assertThat(selections.includesPipeline("PIPELINE"), is(true));
-        assertThat(selections.includesPipeline(pipelineConfig("PIPELINE")), is(true));
-
-        assertThat(selections.includesPipeline("foo"), is(false));
-        assertThat(selections.includesPipeline(pipelineConfig("foo")), is(false));
-    }
-
-    @Test
-    public void shouldIncludePipelineWhenGroupIsIncluded_whenWhitelistIsEnabled() {
-        PipelineSelections pipelineSelections = new PipelineSelections(Arrays.asList("pipeline1", "pipelineY"), null, null, false);
+    public void DEPRECATED_shouldIncludePipelineWhenGroupIsIncluded_whenWhitelistIsEnabled() {
+        PipelineSelections pipelineSelections = PipelineSelectionsHelper.with(Arrays.asList("pipeline1", "pipelineY"), null, null, false);
         assertThat(pipelineSelections.includesGroup(createGroup("group1", pipelineConfig("pipelineX"))), is(false));
         assertThat(pipelineSelections.includesGroup(createGroup("group2", pipelineConfig("pipeline2"), pipelineConfig("pipeline1"))), is(false));
         assertThat(pipelineSelections.includesGroup(createGroup("group3", pipelineConfig("pipeline2"), pipelineConfig("pipelineY"), pipelineConfig("pipeline1"))), is(false));
         assertThat(pipelineSelections.includesGroup(createGroup("group4", pipelineConfig("pipeline1"))), is(true));
         assertThat(pipelineSelections.includesGroup(createGroup("group5", pipelineConfig("pipeline1"), pipelineConfig("pipelineY"))), is(true));
 
-        assertThat(pipelineSelections.includesPipeline(pipelineConfig("pipeline1")), is(true));
-        assertThat(pipelineSelections.includesPipeline(pipelineConfig("pipeline2")), is(false));
+        assertThat(pipelineSelections.includesPipeline(new CaseInsensitiveString("pipeline1")), is(true));
+        assertThat(pipelineSelections.includesPipeline(new CaseInsensitiveString("pipeline2")), is(false));
     }
 }

--- a/server/src/test-fast/java/com/thoughtworks/go/server/domain/user/WhitelistFilterTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/domain/user/WhitelistFilterTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2018 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.server.domain.user;
+
+import com.thoughtworks.go.config.CaseInsensitiveString;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class WhitelistFilterTest {
+    @Test
+    void isPipelineVisible() {
+        final WhitelistFilter f = new WhitelistFilter(null, CaseInsensitiveString.list("p1"));
+        assertTrue(f.isPipelineVisible(new CaseInsensitiveString("p1")));
+        assertFalse(f.isPipelineVisible(new CaseInsensitiveString("p0")));
+    }
+
+    @Test
+    void allowPipeline() {
+        final WhitelistFilter f = new WhitelistFilter(null, CaseInsensitiveString.list("p1"));
+        assertTrue(f.isPipelineVisible(new CaseInsensitiveString("p1")));
+        assertFalse(f.isPipelineVisible(new CaseInsensitiveString("p0")));
+
+        f.allowPipeline(new CaseInsensitiveString("p0"));
+        assertTrue(f.isPipelineVisible(new CaseInsensitiveString("p0")));
+    }
+
+    @Test
+    void equals() {
+        final WhitelistFilter a = new WhitelistFilter(null, CaseInsensitiveString.list("p1"));
+        final WhitelistFilter b = new WhitelistFilter(null, CaseInsensitiveString.list("p1"));
+        final WhitelistFilter c = new WhitelistFilter(null, CaseInsensitiveString.list("p0"));
+        assertEquals(a, b);
+        assertNotEquals(a, c);
+    }
+}

--- a/server/src/test-fast/java/com/thoughtworks/go/server/persistence/PipelineRepositoryTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/persistence/PipelineRepositoryTest.java
@@ -23,6 +23,7 @@ import com.thoughtworks.go.domain.PipelineTimelineEntry;
 import com.thoughtworks.go.server.cache.GoCache;
 import com.thoughtworks.go.server.database.DatabaseStrategy;
 import com.thoughtworks.go.server.domain.PipelineTimeline;
+import com.thoughtworks.go.server.domain.user.Filters;
 import com.thoughtworks.go.server.domain.user.PipelineSelections;
 import com.thoughtworks.go.server.transaction.TransactionSynchronizationManager;
 import com.thoughtworks.go.server.transaction.TransactionTemplate;
@@ -80,7 +81,7 @@ public class PipelineRepositoryTest {
     @Test
     public void shouldCachePipelineSelectionForGivenUserId() throws Exception {
         String queryString = "FROM PipelineSelections WHERE userId = ?";
-        PipelineSelections pipelineSelections = new PipelineSelections();
+        PipelineSelections pipelineSelections = makePipelineSelections();
         long userId = 1L;
 
         when(hibernateTemplate.find(queryString, new Object[]{userId})).thenReturn((List) Arrays.asList(pipelineSelections));
@@ -94,9 +95,13 @@ public class PipelineRepositoryTest {
         verify(goCache).put(pipelineRepository.pipelineSelectionForUserIdKey(userId), pipelineSelections);
     }
 
+    private PipelineSelections makePipelineSelections() {
+        return new PipelineSelections(Filters.defaults(), null, null);
+    }
+
     @Test
     public void shouldCachePipelineSelectionForGivenId() throws Exception {
-        PipelineSelections pipelineSelections = new PipelineSelections();
+        PipelineSelections pipelineSelections = makePipelineSelections();
         long id = 1L;
 
         when(hibernateTemplate.get(PipelineSelections.class, id)).thenReturn(pipelineSelections);
@@ -112,9 +117,9 @@ public class PipelineRepositoryTest {
 
     @Test
     public void shouldInvalidatePipelineSelectionCacheOnSaveOrUpdate() throws Exception {
-        PipelineSelections pipelineSelections = new PipelineSelections();
+        PipelineSelections pipelineSelections = makePipelineSelections();
         pipelineSelections.setId(1);
-        pipelineSelections.update(new ArrayList<>(), new Date(), 2L, true);
+        pipelineSelections.update(Filters.defaults(), new Date(), 2L);
         pipelineRepository.saveSelectedPipelines(pipelineSelections);
 
         verify(goCache).remove(pipelineRepository.pipelineSelectionForCookieKey(1L));

--- a/server/src/test-fast/java/com/thoughtworks/go/server/service/PipelineHistoryServiceTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/service/PipelineHistoryServiceTest.java
@@ -31,6 +31,7 @@ import com.thoughtworks.go.server.domain.JobDurationStrategy;
 import com.thoughtworks.go.server.domain.PipelineTimeline;
 import com.thoughtworks.go.server.domain.Username;
 import com.thoughtworks.go.server.domain.user.PipelineSelections;
+import com.thoughtworks.go.server.domain.user.PipelineSelectionsHelper;
 import com.thoughtworks.go.server.persistence.MaterialRepository;
 import com.thoughtworks.go.server.scheduling.TriggerMonitor;
 import com.thoughtworks.go.server.service.result.HttpLocalizedOperationResult;
@@ -223,17 +224,17 @@ public class PipelineHistoryServiceTest {
 
         PipelineModel pipelineModel1 = group.getPipelineModels().get(0);
         PipelineInstanceModel firstPipelinePIM = pipelineModel1.getActivePipelineInstances().get(0);
-        assertThat(firstPipelinePIM.isLockable(), is (true));
+        assertThat(firstPipelinePIM.isLockable(), is(true));
         assertThat(firstPipelinePIM.isCurrentlyLocked(), is(true));
 
         PipelineModel pipelineModel2 = group.getPipelineModels().get(1);
         PipelineInstanceModel secondPipeline = pipelineModel2.getActivePipelineInstances().get(0);
-        assertThat(secondPipeline.isLockable(), is (true));
+        assertThat(secondPipeline.isLockable(), is(true));
         assertThat(secondPipeline.isCurrentlyLocked(), is(false));
 
         PipelineModel pipelineModel3 = group.getPipelineModels().get(2);
         PipelineInstanceModel thirdPipeline = pipelineModel3.getActivePipelineInstances().get(0);
-        assertThat(thirdPipeline.isLockable(), is (false));
+        assertThat(thirdPipeline.isLockable(), is(false));
         assertThat(thirdPipeline.isCurrentlyLocked(), is(false));
     }
 
@@ -387,21 +388,21 @@ public class PipelineHistoryServiceTest {
         );
         for (String pipeline : new String[]{"pipeline1", "pipeline2", "pipeline3", "pipeline4", "non-operatable-pipeline"}) {
             stubPermisssionsForActivePipeline(foo, cruiseConfig, pipeline, true, true);
-            when(pipelineDao.loadHistory(pipeline,1,0)).thenReturn(createPipelineInstanceModels());
+            when(pipelineDao.loadHistory(pipeline, 1, 0)).thenReturn(createPipelineInstanceModels());
         }
         when(pipelineDao.loadActivePipelines()).thenReturn(activePipelineInstances);
 
 
         when(goConfigService.hasPipelineNamed(new CaseInsensitiveString(any(String.class)))).thenReturn(true);
-        List<PipelineGroupModel> groups = pipelineHistoryService.allActivePipelineInstances(foo, new PipelineSelections(Arrays.asList("pipeline1","pipeline2")));
-        assertThat(groups.size(),is(2));
-        assertThat(groups.get(0).getName(),is("defaultGroup"));
-        assertThat(groups.get(0).containsPipeline("pipeline1"),is(false));
-        assertThat(groups.get(0).containsPipeline("pipeline2"),is(false));
-        assertThat(groups.get(0).containsPipeline("pipeline3"),is(true));
-        assertThat(groups.get(0).containsPipeline("pipeline4"),is(true));
-        assertThat(groups.get(1).getName(),is("foo"));
-        assertThat(groups.get(1).containsPipeline("non-operatable-pipeline"),is(true));
+        List<PipelineGroupModel> groups = pipelineHistoryService.allActivePipelineInstances(foo, PipelineSelectionsHelper.with(Arrays.asList("pipeline1", "pipeline2")));
+        assertThat(groups.size(), is(2));
+        assertThat(groups.get(0).getName(), is("defaultGroup"));
+        assertThat(groups.get(0).containsPipeline("pipeline1"), is(false));
+        assertThat(groups.get(0).containsPipeline("pipeline2"), is(false));
+        assertThat(groups.get(0).containsPipeline("pipeline3"), is(true));
+        assertThat(groups.get(0).containsPipeline("pipeline4"), is(true));
+        assertThat(groups.get(1).getName(), is("foo"));
+        assertThat(groups.get(1).containsPipeline("non-operatable-pipeline"), is(true));
     }
 
     @Test
@@ -414,7 +415,7 @@ public class PipelineHistoryServiceTest {
 
         List<PipelineGroupModel> groups = pipelineHistoryService.allActivePipelineInstances(bar, new PipelineSelections());
 
-        assertThat(groups.isEmpty(),is(true));
+        assertThat(groups.isEmpty(), is(true));
     }
 
     @Test
@@ -449,7 +450,7 @@ public class PipelineHistoryServiceTest {
         when(pipelineDao.loadActivePipelines()).thenReturn(createPipelineInstanceModels());
         when(goConfigService.hasPipelineNamed(new CaseInsensitiveString(any(String.class)))).thenReturn(true);
         List<PipelineGroupModel> groups = pipelineHistoryService.getActivePipelineInstance(foo, "pipeline1");
-        assertThat(groups.isEmpty(),is(true));
+        assertThat(groups.isEmpty(), is(true));
     }
 
     @Test
@@ -465,17 +466,17 @@ public class PipelineHistoryServiceTest {
         );
         for (String pipeline : new String[]{"pipeline1", "pipeline2", "pipeline3", "pipeline4", "non-operatable-pipeline"}) {
             stubPermisssionsForActivePipeline(foo, cruiseConfig, pipeline, true, true);
-            when(pipelineDao.loadHistory(pipeline,1,0)).thenReturn(createPipelineInstanceModels());
+            when(pipelineDao.loadHistory(pipeline, 1, 0)).thenReturn(createPipelineInstanceModels());
         }
         when(pipelineDao.loadActivePipelines()).thenReturn(activePipelineInstances);
 
 
         when(goConfigService.hasPipelineNamed(new CaseInsensitiveString(any(String.class)))).thenReturn(true);
-        List<PipelineGroupModel> groups = pipelineHistoryService.allActivePipelineInstances(foo, new PipelineSelections(Arrays.asList("non-operatable-pipeline")));
+        List<PipelineGroupModel> groups = pipelineHistoryService.allActivePipelineInstances(foo, PipelineSelectionsHelper.with(Arrays.asList("non-operatable-pipeline")));
         assertThat(groups.size(), is(1));
         assertThat(groups.get(0).getName(), is("defaultGroup"));
         assertThat(groups.get(0).containsPipeline("pipeline1"), is(true));
-        assertThat(groups.get(0).containsPipeline("pipeline2"),is(true));
+        assertThat(groups.get(0).containsPipeline("pipeline2"), is(true));
         assertThat(groups.get(0).containsPipeline("pipeline3"), is(true));
         assertThat(groups.get(0).containsPipeline("pipeline4"), is(true));
     }
@@ -582,7 +583,8 @@ public class PipelineHistoryServiceTest {
         assertThat(pipelineInstance.isLockable(), is(true));
     }
 
-    @Test public void shouldPopulateWetherStageAndPipelineCanBeRunAccordingToOperatePermissions() throws Exception {
+    @Test
+    public void shouldPopulateWetherStageAndPipelineCanBeRunAccordingToOperatePermissions() throws Exception {
         ensureConfigHasPipeline("pipeline");
         ensureHasPermission(Username.ANONYMOUS, "pipeline");
         StageInstanceModels stages = new StageInstanceModels();
@@ -610,7 +612,8 @@ public class PipelineHistoryServiceTest {
         assertThat(models.get(1).hasOperatePermission(), is(false));
     }
 
-    @Test public void shouldPopulatePipelineInstanceModelWithTheBeforeAndAfterForTheGivenPipeline() throws Exception {
+    @Test
+    public void shouldPopulatePipelineInstanceModelWithTheBeforeAndAfterForTheGivenPipeline() throws Exception {
         DateTime now = new DateTime();
         PipelineTimelineEntry first = PipelineMaterialModificationMother.modification(Arrays.asList("first"), 1, "123", now);
         PipelineTimelineEntry second = PipelineMaterialModificationMother.modification(Arrays.asList("first"), 1, "123", now);
@@ -824,97 +827,97 @@ public class PipelineHistoryServiceTest {
         assertThat(pipelineHistoryService.getPageNumberForCounter("some-pipeline", 100, 10), is(1));
     }
 
-	@Test
-	public void shouldPopulateDataCorrectly_getPipelineStatus() {
-		CruiseConfig cruiseConfig = mock(BasicCruiseConfig.class);
-		PipelineConfig pipelineConfig = new PipelineConfig();
-        PipelinePauseInfo pipelinePauseInfo = new PipelinePauseInfo(true,"pausing pipeline for some-reason", "some-one");
-		when(cruiseConfig.getPipelineConfigByName(new CaseInsensitiveString("pipeline-name"))).thenReturn(pipelineConfig);
-		when(goConfigService.currentCruiseConfig()).thenReturn(cruiseConfig);
-		when(securityService.hasViewPermissionForPipeline(Username.valueOf("user-name"), "pipeline-name")).thenReturn(true);
-		when(pipelinePauseService.pipelinePauseInfo("pipeline-name")).thenReturn(pipelinePauseInfo);
-		when(pipelineLockService.isLocked("pipeline-name")).thenReturn(true);
-		when(schedulingCheckerService.canManuallyTrigger(eq(pipelineConfig), eq("user-name"), any(ServerHealthStateOperationResult.class))).thenReturn(true);
+    @Test
+    public void shouldPopulateDataCorrectly_getPipelineStatus() {
+        CruiseConfig cruiseConfig = mock(BasicCruiseConfig.class);
+        PipelineConfig pipelineConfig = new PipelineConfig();
+        PipelinePauseInfo pipelinePauseInfo = new PipelinePauseInfo(true, "pausing pipeline for some-reason", "some-one");
+        when(cruiseConfig.getPipelineConfigByName(new CaseInsensitiveString("pipeline-name"))).thenReturn(pipelineConfig);
+        when(goConfigService.currentCruiseConfig()).thenReturn(cruiseConfig);
+        when(securityService.hasViewPermissionForPipeline(Username.valueOf("user-name"), "pipeline-name")).thenReturn(true);
+        when(pipelinePauseService.pipelinePauseInfo("pipeline-name")).thenReturn(pipelinePauseInfo);
+        when(pipelineLockService.isLocked("pipeline-name")).thenReturn(true);
+        when(schedulingCheckerService.canManuallyTrigger(eq(pipelineConfig), eq("user-name"), any(ServerHealthStateOperationResult.class))).thenReturn(true);
 
-		PipelineStatusModel pipelineStatus = pipelineHistoryService.getPipelineStatus("pipeline-name", "user-name", new HttpOperationResult());
+        PipelineStatusModel pipelineStatus = pipelineHistoryService.getPipelineStatus("pipeline-name", "user-name", new HttpOperationResult());
 
-		assertThat(pipelineStatus.isPaused(), is(true));
-		assertThat(pipelineStatus.pausedCause(), is("pausing pipeline for some-reason"));
-		assertThat(pipelineStatus.pausedBy(), is("some-one"));
-		assertThat(pipelineStatus.isLocked(), is(true));
-		assertThat(pipelineStatus.isSchedulable(), is(true));
-	}
+        assertThat(pipelineStatus.isPaused(), is(true));
+        assertThat(pipelineStatus.pausedCause(), is("pausing pipeline for some-reason"));
+        assertThat(pipelineStatus.pausedBy(), is("some-one"));
+        assertThat(pipelineStatus.isLocked(), is(true));
+        assertThat(pipelineStatus.isSchedulable(), is(true));
+    }
 
-	@Test
-	public void shouldPopulateResultAsNotFound_getPipelineStatus() {
-		CruiseConfig cruiseConfig = mock(BasicCruiseConfig.class);
-		when(cruiseConfig.getPipelineConfigByName(new CaseInsensitiveString("pipeline-name"))).thenReturn(null);
-		when(goConfigService.currentCruiseConfig()).thenReturn(cruiseConfig);
+    @Test
+    public void shouldPopulateResultAsNotFound_getPipelineStatus() {
+        CruiseConfig cruiseConfig = mock(BasicCruiseConfig.class);
+        when(cruiseConfig.getPipelineConfigByName(new CaseInsensitiveString("pipeline-name"))).thenReturn(null);
+        when(goConfigService.currentCruiseConfig()).thenReturn(cruiseConfig);
 
-		HttpOperationResult result = new HttpOperationResult();
-		PipelineStatusModel pipelineStatus = pipelineHistoryService.getPipelineStatus("pipeline-name", "user-name", result);
+        HttpOperationResult result = new HttpOperationResult();
+        PipelineStatusModel pipelineStatus = pipelineHistoryService.getPipelineStatus("pipeline-name", "user-name", result);
 
-		assertThat(pipelineStatus, is(nullValue()));
-		assertThat(result.httpCode(), is(404));
-	}
+        assertThat(pipelineStatus, is(nullValue()));
+        assertThat(result.httpCode(), is(404));
+    }
 
-	@Test
-	public void shouldPopulateResultAsUnauthorized_getPipelineStatus() {
-		CruiseConfig cruiseConfig = mock(BasicCruiseConfig.class);
-		PipelineConfig pipelineConfig = new PipelineConfig();
-		when(cruiseConfig.getPipelineConfigByName(new CaseInsensitiveString("pipeline-name"))).thenReturn(pipelineConfig);
-		when(goConfigService.currentCruiseConfig()).thenReturn(cruiseConfig);
-		when(securityService.hasViewPermissionForPipeline(Username.valueOf("user-name"), "pipeline-name")).thenReturn(false);
+    @Test
+    public void shouldPopulateResultAsUnauthorized_getPipelineStatus() {
+        CruiseConfig cruiseConfig = mock(BasicCruiseConfig.class);
+        PipelineConfig pipelineConfig = new PipelineConfig();
+        when(cruiseConfig.getPipelineConfigByName(new CaseInsensitiveString("pipeline-name"))).thenReturn(pipelineConfig);
+        when(goConfigService.currentCruiseConfig()).thenReturn(cruiseConfig);
+        when(securityService.hasViewPermissionForPipeline(Username.valueOf("user-name"), "pipeline-name")).thenReturn(false);
 
-		HttpOperationResult result = new HttpOperationResult();
-		PipelineStatusModel pipelineStatus = pipelineHistoryService.getPipelineStatus("pipeline-name", "user-name", result);
+        HttpOperationResult result = new HttpOperationResult();
+        PipelineStatusModel pipelineStatus = pipelineHistoryService.getPipelineStatus("pipeline-name", "user-name", result);
 
-		assertThat(pipelineStatus, is(nullValue()));
-		assertThat(result.httpCode(), is(403));
-	}
+        assertThat(pipelineStatus, is(nullValue()));
+        assertThat(result.httpCode(), is(403));
+    }
 
-	@Test
-	public void shouldPopulateResultAsNotFoundWhenPipelineNotFound_loadMinimalData() {
-		String pipelineName = "unknown-pipeline";
-		CruiseConfig cruiseConfig = mock(BasicCruiseConfig.class);
-		when(cruiseConfig.hasPipelineNamed(new CaseInsensitiveString(pipelineName))).thenReturn(false);
-		when(goConfigService.currentCruiseConfig()).thenReturn(cruiseConfig);
+    @Test
+    public void shouldPopulateResultAsNotFoundWhenPipelineNotFound_loadMinimalData() {
+        String pipelineName = "unknown-pipeline";
+        CruiseConfig cruiseConfig = mock(BasicCruiseConfig.class);
+        when(cruiseConfig.hasPipelineNamed(new CaseInsensitiveString(pipelineName))).thenReturn(false);
+        when(goConfigService.currentCruiseConfig()).thenReturn(cruiseConfig);
 
-		HttpOperationResult result = new HttpOperationResult();
-		PipelineInstanceModels pipelineInstanceModels = pipelineHistoryService.loadMinimalData(pipelineName,
+        HttpOperationResult result = new HttpOperationResult();
+        PipelineInstanceModels pipelineInstanceModels = pipelineHistoryService.loadMinimalData(pipelineName,
                 Pagination.pageFor(0, 0, 10), new Username(new CaseInsensitiveString("looser")), result);
 
-		assertThat(pipelineInstanceModels, is(nullValue()));
-		assertThat(result.httpCode(), is(404));
-		assertThat(result.detailedMessage(), is("Not Found { Pipeline " + pipelineName + " not found }\n"));
-	}
+        assertThat(pipelineInstanceModels, is(nullValue()));
+        assertThat(result.httpCode(), is(404));
+        assertThat(result.detailedMessage(), is("Not Found { Pipeline " + pipelineName + " not found }\n"));
+    }
 
-	@Test
-	public void shouldPopulateResultAsUnauthorizedWhenUserNotAllowedToViewPipeline_loadMinimalData() {
-		Username noAccessUserName = new Username(new CaseInsensitiveString("foo"));
-		Username withAccessUserName = new Username(new CaseInsensitiveString("admin"));
-		String pipelineName = "no-access-pipeline";
-		CruiseConfig cruiseConfig = mock(BasicCruiseConfig.class);
-		when(cruiseConfig.hasPipelineNamed(new CaseInsensitiveString(pipelineName))).thenReturn(true);
-		when(goConfigService.currentCruiseConfig()).thenReturn(cruiseConfig);
+    @Test
+    public void shouldPopulateResultAsUnauthorizedWhenUserNotAllowedToViewPipeline_loadMinimalData() {
+        Username noAccessUserName = new Username(new CaseInsensitiveString("foo"));
+        Username withAccessUserName = new Username(new CaseInsensitiveString("admin"));
+        String pipelineName = "no-access-pipeline";
+        CruiseConfig cruiseConfig = mock(BasicCruiseConfig.class);
+        when(cruiseConfig.hasPipelineNamed(new CaseInsensitiveString(pipelineName))).thenReturn(true);
+        when(goConfigService.currentCruiseConfig()).thenReturn(cruiseConfig);
 
-		when(securityService.hasViewPermissionForPipeline(noAccessUserName, pipelineName)).thenReturn(false);
-		when(securityService.hasViewPermissionForPipeline(withAccessUserName, pipelineName)).thenReturn(true);
+        when(securityService.hasViewPermissionForPipeline(noAccessUserName, pipelineName)).thenReturn(false);
+        when(securityService.hasViewPermissionForPipeline(withAccessUserName, pipelineName)).thenReturn(true);
 
-		when(pipelineDao.loadHistory(pipelineName, 10, 0)).thenReturn(PipelineInstanceModels.createPipelineInstanceModels());
+        when(pipelineDao.loadHistory(pipelineName, 10, 0)).thenReturn(PipelineInstanceModels.createPipelineInstanceModels());
 
-		HttpOperationResult result = new HttpOperationResult();
-		PipelineInstanceModels pipelineInstanceModels = pipelineHistoryService.loadMinimalData(pipelineName, Pagination.pageFor(0, 1, 10), noAccessUserName, result);
+        HttpOperationResult result = new HttpOperationResult();
+        PipelineInstanceModels pipelineInstanceModels = pipelineHistoryService.loadMinimalData(pipelineName, Pagination.pageFor(0, 1, 10), noAccessUserName, result);
 
-		assertThat(pipelineInstanceModels, is(nullValue()));
-		assertThat(result.httpCode(), is(403));
+        assertThat(pipelineInstanceModels, is(nullValue()));
+        assertThat(result.httpCode(), is(403));
 
-		result = new HttpOperationResult();
-		pipelineInstanceModels = pipelineHistoryService.loadMinimalData(pipelineName, Pagination.pageFor(0, 1, 10), withAccessUserName, result);
+        result = new HttpOperationResult();
+        pipelineInstanceModels = pipelineHistoryService.loadMinimalData(pipelineName, Pagination.pageFor(0, 1, 10), withAccessUserName, result);
 
-		assertThat(pipelineInstanceModels, is(not(nullValue())));
-		assertThat(result.canContinue(), is(true));
-	}
+        assertThat(pipelineInstanceModels, is(not(nullValue())));
+        assertThat(result.canContinue(), is(true));
+    }
 
     @Test
     public void shouldUpdateCommentUsingPipelineDao() {

--- a/server/src/test-fast/java/com/thoughtworks/go/server/service/PipelineSelectionsServiceTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/service/PipelineSelectionsServiceTest.java
@@ -32,6 +32,7 @@ import java.util.Collections;
 import java.util.Date;
 
 import static com.thoughtworks.go.helper.ConfigFileFixture.configWith;
+import static com.thoughtworks.go.server.domain.user.Filters.DEFAULT_NAME;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.mockito.ArgumentMatchers.argThat;
@@ -213,11 +214,11 @@ public class PipelineSelectionsServiceTest {
     }
 
     private DashboardFilter blacklist(String... pipelines) {
-        return new BlacklistFilter(null, CaseInsensitiveString.list(pipelines));
+        return new BlacklistFilter(DEFAULT_NAME, CaseInsensitiveString.list(pipelines));
     }
 
     private DashboardFilter whitelist(String... pipelines) {
-        return new WhitelistFilter(null, CaseInsensitiveString.list(pipelines));
+        return new WhitelistFilter(DEFAULT_NAME, CaseInsensitiveString.list(pipelines));
     }
 
     private void expectLoad(final CruiseConfig result) throws Exception {

--- a/server/src/test-fast/java/com/thoughtworks/go/server/service/PipelineSelectionsServiceTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/service/PipelineSelectionsServiceTest.java
@@ -32,7 +32,7 @@ import java.util.Collections;
 import java.util.Date;
 
 import static com.thoughtworks.go.helper.ConfigFileFixture.configWith;
-import static com.thoughtworks.go.server.domain.user.Filters.DEFAULT_NAME;
+import static com.thoughtworks.go.server.domain.user.DashboardFilter.DEFAULT_NAME;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.mockito.ArgumentMatchers.argThat;

--- a/server/src/test-integration/java/com/thoughtworks/go/server/persistence/PipelineRepositoryIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/persistence/PipelineRepositoryIntegrationTest.java
@@ -56,7 +56,7 @@ import java.util.*;
 
 import static com.thoughtworks.go.helper.ModificationsMother.oneModifiedFile;
 import static com.thoughtworks.go.helper.PipelineConfigMother.createPipelineConfig;
-import static com.thoughtworks.go.server.domain.user.Filters.DEFAULT_NAME;
+import static com.thoughtworks.go.server.domain.user.DashboardFilter.DEFAULT_NAME;
 import static com.thoughtworks.go.util.DataStructureUtils.a;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.core.Is.is;

--- a/server/src/test-integration/java/com/thoughtworks/go/server/persistence/PipelineRepositoryIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/persistence/PipelineRepositoryIntegrationTest.java
@@ -56,6 +56,7 @@ import java.util.*;
 
 import static com.thoughtworks.go.helper.ModificationsMother.oneModifiedFile;
 import static com.thoughtworks.go.helper.PipelineConfigMother.createPipelineConfig;
+import static com.thoughtworks.go.server.domain.user.Filters.DEFAULT_NAME;
 import static com.thoughtworks.go.util.DataStructureUtils.a;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.core.Is.is;
@@ -326,17 +327,15 @@ public class PipelineRepositoryIntegrationTest {
 
     @Test
     public void shouldSaveSelectedPipelinesWithoutUserId() {
-        Date date = new Date();
         List<String> unSelected = Arrays.asList("pipeline1", "pipeline2");
 
         long id = pipelineRepository.saveSelectedPipelines(blacklist(unSelected, null));
         PipelineSelections found = pipelineRepository.findPipelineSelectionsById(id);
 
-        final DashboardFilter filter = found.namedFilter(null);
+        final DashboardFilter filter = found.namedFilter(DEFAULT_NAME);
         assertAllowsPipelines(filter, "pipeline3", "pipeline4");
         assertDeniesPipelines(filter, "pipeline1", "pipeline2");
         assertNull(found.userId());
-        assertEquals(date, found.lastUpdated());
     }
 
     @Test
@@ -406,13 +405,13 @@ public class PipelineRepositoryIntegrationTest {
 
     private PipelineSelections blacklist(List<String> pipelines, Long userId) {
         final List<CaseInsensitiveString> pipelineNames = CaseInsensitiveString.list(pipelines);
-        Filters filters = new Filters(Collections.singletonList(new BlacklistFilter(null, pipelineNames)));
+        Filters filters = new Filters(Collections.singletonList(new BlacklistFilter(DEFAULT_NAME, pipelineNames)));
         return new PipelineSelections(filters, new Date(), userId);
     }
 
     private PipelineSelections whitelist(List<String> pipelines, Long userId) {
         final List<CaseInsensitiveString> pipelineNames = CaseInsensitiveString.list(pipelines);
-        Filters filters = new Filters(Collections.singletonList(new WhitelistFilter(null, pipelineNames)));
+        Filters filters = new Filters(Collections.singletonList(new WhitelistFilter(DEFAULT_NAME, pipelineNames)));
         return new PipelineSelections(filters, new Date(), userId);
     }
 }

--- a/server/src/test-integration/java/com/thoughtworks/go/server/persistence/PipelineRepositoryIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/persistence/PipelineRepositoryIntegrationTest.java
@@ -17,6 +17,7 @@
 package com.thoughtworks.go.server.persistence;
 
 import com.rits.cloning.Cloner;
+import com.thoughtworks.go.config.CaseInsensitiveString;
 import com.thoughtworks.go.config.CruiseConfig;
 import com.thoughtworks.go.config.GoConfigDao;
 import com.thoughtworks.go.config.PipelineConfig;
@@ -33,7 +34,7 @@ import com.thoughtworks.go.server.dao.DatabaseAccessHelper;
 import com.thoughtworks.go.server.dao.PipelineSqlMapDao;
 import com.thoughtworks.go.server.dao.UserSqlMapDao;
 import com.thoughtworks.go.server.domain.PipelineTimeline;
-import com.thoughtworks.go.server.domain.user.PipelineSelections;
+import com.thoughtworks.go.server.domain.user.*;
 import com.thoughtworks.go.server.service.InstanceFactory;
 import com.thoughtworks.go.server.service.ScheduleTestUtil;
 import com.thoughtworks.go.server.transaction.TransactionSynchronizationManager;
@@ -55,12 +56,12 @@ import java.util.*;
 
 import static com.thoughtworks.go.helper.ModificationsMother.oneModifiedFile;
 import static com.thoughtworks.go.helper.PipelineConfigMother.createPipelineConfig;
-import static com.thoughtworks.go.helper.PipelineConfigMother.pipelineConfig;
 import static com.thoughtworks.go.util.DataStructureUtils.a;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNull.nullValue;
 import static org.junit.Assert.*;
+
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(locations = {
         "classpath:WEB-INF/applicationContext-global.xml",
@@ -71,14 +72,22 @@ public class PipelineRepositoryIntegrationTest {
 
     @Autowired
     PipelineSqlMapDao pipelineSqlMapDao;
-    @Autowired DatabaseAccessHelper dbHelper;
-    @Autowired PipelineRepository pipelineRepository;
-    @Autowired MaterialRepository materialRepository;
-    @Autowired UserSqlMapDao userSqlMapDao;
-    @Autowired private TransactionTemplate transactionTemplate;
-    @Autowired private TransactionSynchronizationManager transactionSynchronizationManager;
-    @Autowired private GoConfigDao goConfigDao;
-    @Autowired private InstanceFactory instanceFactory;
+    @Autowired
+    DatabaseAccessHelper dbHelper;
+    @Autowired
+    PipelineRepository pipelineRepository;
+    @Autowired
+    MaterialRepository materialRepository;
+    @Autowired
+    UserSqlMapDao userSqlMapDao;
+    @Autowired
+    private TransactionTemplate transactionTemplate;
+    @Autowired
+    private TransactionSynchronizationManager transactionSynchronizationManager;
+    @Autowired
+    private GoConfigDao goConfigDao;
+    @Autowired
+    private InstanceFactory instanceFactory;
 
     private GoConfigFileHelper configHelper = new GoConfigFileHelper();
     private static final String PIPELINE_NAME = "pipeline";
@@ -320,12 +329,13 @@ public class PipelineRepositoryIntegrationTest {
         Date date = new Date();
         List<String> unSelected = Arrays.asList("pipeline1", "pipeline2");
 
-        long id = pipelineRepository.saveSelectedPipelines(new PipelineSelections(unSelected, date, null, true));
+        long id = pipelineRepository.saveSelectedPipelines(blacklist(unSelected, null));
         PipelineSelections found = pipelineRepository.findPipelineSelectionsById(id);
 
-        assertHasPipelines(found, new String[]{"pipeline3", "pipeline4"});
-        assertHasPipelines(found, new String[]{"pipeline1", "pipeline2"}, false);
-        assertThat(found.userId(), is(nullValue()));
+        final DashboardFilter filter = found.namedFilter(null);
+        assertAllowsPipelines(filter, "pipeline3", "pipeline4");
+        assertDeniesPipelines(filter, "pipeline1", "pipeline2");
+        assertNull(found.userId());
         assertEquals(date, found.lastUpdated());
     }
 
@@ -334,7 +344,7 @@ public class PipelineRepositoryIntegrationTest {
         User user = createUser();
 
         List<String> unSelected = Arrays.asList("pipeline1", "pipeline2");
-        long id = pipelineRepository.saveSelectedPipelines(new PipelineSelections(unSelected, new Date(), user.getId(), true));
+        long id = pipelineRepository.saveSelectedPipelines(blacklist(unSelected, user.getId()));
         assertThat(pipelineRepository.findPipelineSelectionsById(id).userId(), is(user.getId()));
     }
 
@@ -342,9 +352,10 @@ public class PipelineRepositoryIntegrationTest {
     public void shouldSaveSelectedPipelinesWithBlacklistPreferenceFalse() {
         User user = createUser();
 
-        List<String> unSelected = Arrays.asList("pipeline1", "pipeline2");
-        long id = pipelineRepository.saveSelectedPipelines(new PipelineSelections(unSelected, new Date(), user.getId(), false));
-        assertThat(pipelineRepository.findPipelineSelectionsById(id).isBlacklist(), is(false));
+        List<String> selected = Arrays.asList("pipeline1", "pipeline2");
+        final PipelineSelections whitelist = whitelist(selected, user.getId());
+        long id = pipelineRepository.saveSelectedPipelines(whitelist);
+        assertEquals(whitelist, pipelineRepository.findPipelineSelectionsById(id));
     }
 
     @Test
@@ -352,8 +363,9 @@ public class PipelineRepositoryIntegrationTest {
         User user = createUser();
 
         List<String> unSelected = Arrays.asList("pipeline1", "pipeline2");
-        long id = pipelineRepository.saveSelectedPipelines(new PipelineSelections(unSelected, new Date(), user.getId(), true));
-        assertThat(pipelineRepository.findPipelineSelectionsById(id).isBlacklist(), is(true));
+        final PipelineSelections blacklist = blacklist(unSelected, user.getId());
+        long id = pipelineRepository.saveSelectedPipelines(blacklist);
+        assertEquals(blacklist, pipelineRepository.findPipelineSelectionsById(id));
     }
 
     @Test
@@ -361,7 +373,7 @@ public class PipelineRepositoryIntegrationTest {
         User user = createUser();
 
         List<String> unSelected = Arrays.asList("pipeline1", "pipeline2");
-        long id = pipelineRepository.saveSelectedPipelines(new PipelineSelections(unSelected, new Date(), user.getId(), true));
+        long id = pipelineRepository.saveSelectedPipelines(blacklist(unSelected, user.getId()));
         assertThat(pipelineRepository.findPipelineSelectionsByUserId(user.getId()).getId(), is(id));
     }
 
@@ -380,13 +392,27 @@ public class PipelineRepositoryIntegrationTest {
         return userSqlMapDao.findUser("loser");
     }
 
-    private void assertHasPipelines(PipelineSelections pipelineSelections, String[] pipelines) {
-        assertHasPipelines(pipelineSelections, pipelines, true);
+    private void assertAllowsPipelines(DashboardFilter filter, String... pipelines) {
+        for (String pipeline : pipelines) {
+            assertTrue(filter.isPipelineVisible(new CaseInsensitiveString(pipeline)));
+        }
     }
 
-    private void assertHasPipelines(PipelineSelections pipelineSelections, String[] pipelines, boolean has) {
+    private void assertDeniesPipelines(DashboardFilter filter, String... pipelines) {
         for (String pipeline : pipelines) {
-            assertThat(pipelineSelections.includesPipeline(pipelineConfig(pipeline)),is(has));
+            assertFalse(filter.isPipelineVisible(new CaseInsensitiveString(pipeline)));
         }
+    }
+
+    private PipelineSelections blacklist(List<String> pipelines, Long userId) {
+        final List<CaseInsensitiveString> pipelineNames = CaseInsensitiveString.list(pipelines);
+        Filters filters = new Filters(Collections.singletonList(new BlacklistFilter(null, pipelineNames)));
+        return new PipelineSelections(filters, new Date(), userId);
+    }
+
+    private PipelineSelections whitelist(List<String> pipelines, Long userId) {
+        final List<CaseInsensitiveString> pipelineNames = CaseInsensitiveString.list(pipelines);
+        Filters filters = new Filters(Collections.singletonList(new WhitelistFilter(null, pipelineNames)));
+        return new PipelineSelections(filters, new Date(), userId);
     }
 }

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/GoDashboardServiceIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/GoDashboardServiceIntegrationTest.java
@@ -31,7 +31,7 @@ import com.thoughtworks.go.server.dao.DatabaseAccessHelper;
 import com.thoughtworks.go.server.dao.StageSqlMapDao;
 import com.thoughtworks.go.server.dashboard.*;
 import com.thoughtworks.go.server.domain.Username;
-import com.thoughtworks.go.server.domain.user.PipelineSelections;
+import com.thoughtworks.go.server.domain.user.Filters;
 import com.thoughtworks.go.server.persistence.MaterialRepository;
 import com.thoughtworks.go.server.service.result.DefaultLocalizedOperationResult;
 import com.thoughtworks.go.server.transaction.TransactionTemplate;
@@ -122,7 +122,7 @@ public class GoDashboardServiceIntegrationTest {
         String p1_1 = u.runAndPass(p1, "g_1");
 
         goDashboardService.updateCacheForAllPipelinesIn(goConfigService.cruiseConfig());
-        List<GoDashboardPipelineGroup> pipelineGroupsOnDashboard = goDashboardService.allPipelineGroupsForDashboard(PipelineSelections.ALL, new Username("user"));
+        List<GoDashboardPipelineGroup> pipelineGroupsOnDashboard = goDashboardService.allPipelineGroupsForDashboard(Filters.WILDCARD_FILTER, new Username("user"));
         assertThat(pipelineGroupsOnDashboard, hasSize(1));
         assertThat(pipelineGroupsOnDashboard.get(0).allPipelines().size(), is(1));
         assertThat(pipelineGroupsOnDashboard.get(0).allPipelines().iterator().next().model().getLatestPipelineInstance()
@@ -132,7 +132,7 @@ public class GoDashboardServiceIntegrationTest {
         Pipeline p1_2 = scheduleService.schedulePipeline(p1.config.name(), buildCauseForThirdRun);
         goDashboardService.updateCacheForPipeline(p1.config);
 
-        pipelineGroupsOnDashboard = goDashboardService.allPipelineGroupsForDashboard(PipelineSelections.ALL, new Username("user"));
+        pipelineGroupsOnDashboard = goDashboardService.allPipelineGroupsForDashboard(Filters.WILDCARD_FILTER, new Username("user"));
         assertThat(pipelineGroupsOnDashboard, hasSize(1));
         assertThat(pipelineGroupsOnDashboard.get(0).allPipelines().size(), is(1));
         assertThat(pipelineGroupsOnDashboard.get(0).allPipelines().iterator().next().model().getLatestPipelineInstance().getId(), Matchers.is(p1_2.getId()));
@@ -140,7 +140,7 @@ public class GoDashboardServiceIntegrationTest {
         goConfigService.addEnvironment(new BasicEnvironmentConfig(new CaseInsensitiveString("environment")));
         goDashboardService.updateCacheForAllPipelinesIn(goConfigService.cruiseConfig());
 
-        pipelineGroupsOnDashboard = goDashboardService.allPipelineGroupsForDashboard(PipelineSelections.ALL, new Username("user"));
+        pipelineGroupsOnDashboard = goDashboardService.allPipelineGroupsForDashboard(Filters.WILDCARD_FILTER, new Username("user"));
         assertThat(pipelineGroupsOnDashboard, hasSize(1));
         assertThat(pipelineGroupsOnDashboard.get(0).allPipelines().size(), is(1));
         assertThat(pipelineGroupsOnDashboard.get(0).allPipelines().iterator().next().model().getLatestPipelineInstance().getId(), Matchers.is(p1_2.getId()));
@@ -154,7 +154,7 @@ public class GoDashboardServiceIntegrationTest {
         String p1_1 = u.runAndPass(addedPipeline, "g_1");
 
         goDashboardService.updateCacheForAllPipelinesIn(goConfigService.cruiseConfig());
-        List<GoDashboardPipelineGroup> pipelineGroupsOnDashboard = goDashboardService.allPipelineGroupsForDashboard(PipelineSelections.ALL, new Username("user"));
+        List<GoDashboardPipelineGroup> pipelineGroupsOnDashboard = goDashboardService.allPipelineGroupsForDashboard(Filters.WILDCARD_FILTER, new Username("user"));
         assertThat(pipelineGroupsOnDashboard, hasSize(1));
         assertThat(pipelineGroupsOnDashboard.get(0).allPipelines().size(), is(1));
         assertThat(pipelineGroupsOnDashboard.get(0).allPipelines().iterator().next().model().getLatestPipelineInstance()
@@ -164,7 +164,7 @@ public class GoDashboardServiceIntegrationTest {
         Pipeline p1_2 = scheduleService.schedulePipeline(addedPipeline.config.name(), buildCauseForThirdRun);
         goDashboardService.updateCacheForPipeline(addedPipeline.config);
 
-        pipelineGroupsOnDashboard = goDashboardService.allPipelineGroupsForDashboard(PipelineSelections.ALL, new Username("user"));
+        pipelineGroupsOnDashboard = goDashboardService.allPipelineGroupsForDashboard(Filters.WILDCARD_FILTER, new Username("user"));
         assertThat(pipelineGroupsOnDashboard, hasSize(1));
         assertThat(pipelineGroupsOnDashboard.get(0).allPipelines().size(), is(1));
         assertThat(pipelineGroupsOnDashboard.get(0).allPipelines().iterator().next().model().getLatestPipelineInstance().getId(), Matchers.is(p1_2.getId()));
@@ -172,13 +172,13 @@ public class GoDashboardServiceIntegrationTest {
         pipelineConfigService.deletePipelineConfig(new Username("user"), addedPipeline.config, new DefaultLocalizedOperationResult());
         goDashboardService.updateCacheForPipeline(addedPipeline.config);
 
-        pipelineGroupsOnDashboard = goDashboardService.allPipelineGroupsForDashboard(PipelineSelections.ALL, new Username("user"));
+        pipelineGroupsOnDashboard = goDashboardService.allPipelineGroupsForDashboard(Filters.WILDCARD_FILTER, new Username("user"));
         assertThat(pipelineGroupsOnDashboard, hasSize(0));
 
         goConfigService.addEnvironment(new BasicEnvironmentConfig(new CaseInsensitiveString("environment")));
         goDashboardService.updateCacheForAllPipelinesIn(goConfigService.cruiseConfig());
 
-        pipelineGroupsOnDashboard = goDashboardService.allPipelineGroupsForDashboard(PipelineSelections.ALL, new Username("user"));
+        pipelineGroupsOnDashboard = goDashboardService.allPipelineGroupsForDashboard(Filters.WILDCARD_FILTER, new Username("user"));
         assertThat(pipelineGroupsOnDashboard, hasSize(0));
     }
 
@@ -191,7 +191,7 @@ public class GoDashboardServiceIntegrationTest {
 
         goDashboardConfigChangeHandler.call(goConfigService.cruiseConfig());
 
-        List<GoDashboardPipelineGroup> originalDashboard = goDashboardService.allPipelineGroupsForDashboard(PipelineSelections.ALL, user);
+        List<GoDashboardPipelineGroup> originalDashboard = goDashboardService.allPipelineGroupsForDashboard(Filters.WILDCARD_FILTER, user);
         assertThat(originalDashboard, hasSize(1));
         assertThat(originalDashboard.get(0).allPipelines(), hasSize(1));
         assertThat(originalDashboard.get(0).allPipelines().iterator().next().model().getActivePipelineInstances(), hasSize(1));
@@ -200,17 +200,17 @@ public class GoDashboardServiceIntegrationTest {
         pipelineConfigService.createPipelineConfig(user, newPipeline, new DefaultLocalizedOperationResult(), goConfigService.cruiseConfig().getGroups().first().getGroup());
         goDashboardConfigChangeHandler.call(goConfigService.cruiseConfig().pipelineConfigByName(newPipeline.name()));
 
-        assertThereIsExactlyOneInstanceOfEachPipelineOnDashboard(goDashboardService.allPipelineGroupsForDashboard(PipelineSelections.ALL, user));
+        assertThereIsExactlyOneInstanceOfEachPipelineOnDashboard(goDashboardService.allPipelineGroupsForDashboard(Filters.WILDCARD_FILTER, user));
 
         String newPipelineCounter1 = u.runAndPass(new ScheduleTestUtil.AddedPipeline(newPipeline, new DependencyMaterial(newPipeline.name(), newPipeline.first().name())), "g_1");
         goDashboardStageStatusChangeHandler.call(stageSqlMapDao.mostRecentPassed(newPipeline.name().toString(), newPipeline.first().name().toString()));
 
-        assertThereIsExactlyOneInstanceOfEachPipelineOnDashboard(goDashboardService.allPipelineGroupsForDashboard(PipelineSelections.ALL, user));
+        assertThereIsExactlyOneInstanceOfEachPipelineOnDashboard(goDashboardService.allPipelineGroupsForDashboard(Filters.WILDCARD_FILTER, user));
 
         goConfigService.addEnvironment(new BasicEnvironmentConfig(new CaseInsensitiveString("new-environment")));
         goDashboardConfigChangeHandler.call(goConfigService.cruiseConfig());
 
-        assertThereIsExactlyOneInstanceOfEachPipelineOnDashboard(goDashboardService.allPipelineGroupsForDashboard(PipelineSelections.ALL, user));
+        assertThereIsExactlyOneInstanceOfEachPipelineOnDashboard(goDashboardService.allPipelineGroupsForDashboard(Filters.WILDCARD_FILTER, user));
     }
 
     private void assertThereIsExactlyOneInstanceOfEachPipelineOnDashboard(List<GoDashboardPipelineGroup> dashboardAfterPipelineCreationViaApi) {

--- a/server/src/test/java/com/thoughtworks/go/server/domain/user/FiltersTest.java
+++ b/server/src/test/java/com/thoughtworks/go/server/domain/user/FiltersTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2018 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.server.domain.user;
+
+import com.thoughtworks.go.config.CaseInsensitiveString;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class FiltersTest {
+
+    @Test
+    void fromJson() {
+        String json = "{ \"filters\": [{\"name\": \"My Filter\", \"type\": \"whitelist\", \"pipelines\": [\"p1\"]}] }";
+        final Filters filters = Filters.fromJson(json);
+        assertEquals(1, filters.filters().size());
+        final DashboardFilter first = filters.filters().get(0);
+        assertEquals(first.name(), "My Filter");
+        assertTrue(first instanceof WhitelistFilter);
+        assertEquals(1, ((WhitelistFilter) first).pipelines().size());
+        assertTrue(((WhitelistFilter) first).pipelines().contains(new CaseInsensitiveString("p1")));
+    }
+
+    @Test
+    void toJson() {
+        List<DashboardFilter> views = new ArrayList<>();
+        final List<CaseInsensitiveString> pipelines = Collections.singletonList(new CaseInsensitiveString("Pipely McPipe"));
+        final BlacklistFilter first = new BlacklistFilter("Cool Pipelines", null, pipelines);
+        views.add(first);
+        final Filters filters = new Filters(views);
+
+        assertEquals("{\"filters\":[{\"name\":\"Cool Pipelines\",\"pipelines\":[\"Pipely McPipe\"],\"type\":\"blacklist\"}]}", Filters.toJson(filters));
+    }
+}

--- a/server/webapp/WEB-INF/rails.new/app/views/pipelines/_pipeline_selector_pipelines.html.erb
+++ b/server/webapp/WEB-INF/rails.new/app/views/pipelines/_pipeline_selector_pipelines.html.erb
@@ -17,7 +17,7 @@
       %>
           <div id='selector_pipeline_<%= scope[:pipeline_name] %>' class="selector_pipeline">
             <input type="checkbox" id="<%= scope[:pipeline_id] %>" name="selector[pipeline][]" value="<%= scope[:pipeline_name] %>"
-                   <% if scope[:group_selected] || @pipeline_selections.includesPipeline(pipeline_in_pipeline_selector) %>
+                   <% if scope[:group_selected] || @pipeline_selections.includesPipeline(pipeline_in_pipeline_selector.name()) %>
                    checked="checked"
                    <% end %>
                    />

--- a/server/webapp/WEB-INF/rails.new/spec/views/pipelines/_pipelines_selector_html_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/views/pipelines/_pipelines_selector_html_spec.rb
@@ -54,7 +54,7 @@ describe "/pipelines/_pipelines_selector.html.erb" do
     end
 
     it "should have the 'show new pipelines' box checked if blacklisting pipelines is enabled for the user" do
-      assign(:pipeline_selections, PipelineSelections.new([], nil, nil, true))
+      assign(:pipeline_selections, PipelineSelections.new())
 
       render
 

--- a/server/webapp/WEB-INF/rails.new/spec/views/pipelines/_pipelines_selector_pipelines_html_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/views/pipelines/_pipelines_selector_pipelines_html_spec.rb
@@ -18,8 +18,9 @@ require 'rails_helper'
 
 def blacklist(*args)
   pipes = CaseInsensitiveString.list(*args)
+  name = com.thoughtworks.go.server.domain.user.Filters::DEFAULT_NAME
   filters = com.thoughtworks.go.server.domain.user.Filters.single(
-    com.thoughtworks.go.server.domain.user.BlacklistFilter.new(nil, pipes)
+    com.thoughtworks.go.server.domain.user.BlacklistFilter.new(name, pipes)
   )
   PipelineSelections.new(filters, nil, nil)
 end

--- a/server/webapp/WEB-INF/rails.new/spec/views/pipelines/_pipelines_selector_pipelines_html_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/views/pipelines/_pipelines_selector_pipelines_html_spec.rb
@@ -16,6 +16,14 @@
 
 require 'rails_helper'
 
+def blacklist(*args)
+  pipes = CaseInsensitiveString.list(*args)
+  filters = com.thoughtworks.go.server.domain.user.Filters.single(
+    com.thoughtworks.go.server.domain.user.BlacklistFilter.new(nil, pipes)
+  )
+  PipelineSelections.new(filters, nil, nil)
+end
+
 describe "/pipelines/_pipeline_selector_pipelines.html.erb" do
   include PipelineModelMother
 
@@ -59,7 +67,7 @@ describe "/pipelines/_pipeline_selector_pipelines.html.erb" do
     end
 
     it "should check checkboxes that are selected" do
-      assign(:pipeline_selections, PipelineSelections.new(["pipeline-x3", "pipeline-x4"]))
+      assign(:pipeline_selections, blacklist("pipeline-x3", "pipeline-x4"))
 
       render :partial => "pipelines/pipeline_selector_pipelines", :locals => {:scope => {}}
 

--- a/server/webapp/WEB-INF/rails.new/spec/views/pipelines/_pipelines_selector_pipelines_html_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/views/pipelines/_pipelines_selector_pipelines_html_spec.rb
@@ -18,7 +18,7 @@ require 'rails_helper'
 
 def blacklist(*args)
   pipes = CaseInsensitiveString.list(*args)
-  name = com.thoughtworks.go.server.domain.user.Filters::DEFAULT_NAME
+  name = com.thoughtworks.go.server.domain.user.DashboardFilter::DEFAULT_NAME
   filters = com.thoughtworks.go.server.domain.user.Filters.single(
     com.thoughtworks.go.server.domain.user.BlacklistFilter.new(name, pipes)
   )

--- a/server/webapp/WEB-INF/rails.new/spec/views/pipelines/index_html_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/views/pipelines/index_html_spec.rb
@@ -18,8 +18,9 @@ require 'rails_helper'
 
 def blacklist(*args)
   pipes = CaseInsensitiveString.list(*args)
+  name = com.thoughtworks.go.server.domain.user.Filters::DEFAULT_NAME
   filters = com.thoughtworks.go.server.domain.user.Filters.single(
-    com.thoughtworks.go.server.domain.user.BlacklistFilter.new(nil, pipes)
+    com.thoughtworks.go.server.domain.user.BlacklistFilter.new(name, pipes)
   )
   PipelineSelections.new(filters, nil, nil)
 end

--- a/server/webapp/WEB-INF/rails.new/spec/views/pipelines/index_html_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/views/pipelines/index_html_spec.rb
@@ -16,6 +16,14 @@
 
 require 'rails_helper'
 
+def blacklist(*args)
+  pipes = CaseInsensitiveString.list(*args)
+  filters = com.thoughtworks.go.server.domain.user.Filters.single(
+    com.thoughtworks.go.server.domain.user.BlacklistFilter.new(nil, pipes)
+  )
+  PipelineSelections.new(filters, nil, nil)
+end
+
 describe "pipelines/index.html.erb" do
   include PipelineModelMother
 
@@ -37,7 +45,7 @@ describe "pipelines/index.html.erb" do
     assign(:pipeline_groups, [@pipeline_group_model, @pipeline_group_model_other, @pipeline_group_model_empty])
     assign(:pipeline_configs, BasicPipelineConfigs.new)
     view.extend StagesHelper
-    
+
     @security_service = stub_service(:security_service, view)
     allow(@security_service).to receive(:isUserAdmin).and_return(true)
   end
@@ -222,7 +230,7 @@ describe "pipelines/index.html.erb" do
                                                                    [PipelineConfigMother.pipelineConfig("pipeline-11"),
                                                                     PipelineConfigMother.pipelineConfig("pipeline-12"),
                                                                    ].to_java(PipelineConfig))])
-    assign(:pipeline_selections, PipelineSelections.new(["pipeline-22"]))
+    assign(:pipeline_selections, blacklist("pipeline-22"))
 
     render :partial => 'pipelines/pipelines_selector'
 

--- a/server/webapp/WEB-INF/rails.new/spec/views/pipelines/index_html_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/views/pipelines/index_html_spec.rb
@@ -18,7 +18,7 @@ require 'rails_helper'
 
 def blacklist(*args)
   pipes = CaseInsensitiveString.list(*args)
-  name = com.thoughtworks.go.server.domain.user.Filters::DEFAULT_NAME
+  name = com.thoughtworks.go.server.domain.user.DashboardFilter::DEFAULT_NAME
   filters = com.thoughtworks.go.server.domain.user.Filters.single(
     com.thoughtworks.go.server.domain.user.BlacklistFilter.new(name, pipes)
   )

--- a/server/webapp/WEB-INF/rails.new/spec/webpack/models/dashboard/pipeline_selection_spec.js
+++ b/server/webapp/WEB-INF/rails.new/spec/webpack/models/dashboard/pipeline_selection_spec.js
@@ -76,11 +76,15 @@ describe("Dashboard", () => {
     });
 
     const pipelineSelectionData = {
-      "selections": [
-        "up42",
-        "test"
+      "filters": [
+        {
+          "pipelines": [
+            "up42",
+            "test"
+          ],
+          "type": "blacklist"
+        }
       ],
-      "blacklist":  true,
       "pipelines":  {
         "first":  [
           "up42",
@@ -95,11 +99,15 @@ describe("Dashboard", () => {
     };
 
     const pipelineSelectionPostData = {
-      "selections": [
-        "up42",
-        "test"
+      "filters": [
+        {
+          "pipelines": [
+            "up42",
+            "test"
+          ],
+          "type": "blacklist"
+        }
       ],
-      "blacklist":  true
     };
 
   });

--- a/server/webapp/WEB-INF/rails.new/spec/webpack/models/dashboard/pipeline_selection_spec.js
+++ b/server/webapp/WEB-INF/rails.new/spec/webpack/models/dashboard/pipeline_selection_spec.js
@@ -78,6 +78,7 @@ describe("Dashboard", () => {
     const pipelineSelectionData = {
       "filters": [
         {
+          "name": "Default",
           "pipelines": [
             "up42",
             "test"
@@ -101,6 +102,7 @@ describe("Dashboard", () => {
     const pipelineSelectionPostData = {
       "filters": [
         {
+          "name": "Default",
           "pipelines": [
             "up42",
             "test"

--- a/server/webapp/WEB-INF/rails.new/spec/webpack/views/dashboard/dashboard_widget_spec.js
+++ b/server/webapp/WEB-INF/rails.new/spec/webpack/views/dashboard/dashboard_widget_spec.js
@@ -25,12 +25,11 @@ describe("Dashboard Widget", () => {
   const Modal           = require('views/shared/new_modal');
   const SparkRoutes     = require("helpers/spark_routes");
 
-  let $root, root, dashboard, dashboardJson, buildCauseJson, doCancelPolling, doRefreshImmediately;
+  let $root, root, dashboard, dashboardJson, buildCauseJson, doCancelPolling, doRefreshImmediately, personalizeData;
   const originalDebounce = _.debounce;
   beforeEach(() => {
     doCancelPolling      = jasmine.createSpy();
     doRefreshImmediately = jasmine.createSpy();
-
     //override debounce function for tests to be called synchronously
     spyOn(_, 'debounce').and.callFake((func) => {
       return function () {
@@ -87,38 +86,52 @@ describe("Dashboard Widget", () => {
     expect($root.find('.callout.alert .dashboard-message')).toContainText('some error message');
   });
 
-  it("should show personalize view", () => {
-    jasmine.Ajax.withMock(() => {
-      jasmine.Ajax.stubRequest('/go/api/internal/pipeline_selection', undefined, 'GET').andReturn({
-        responseText:    JSON.stringify({}),
-        responseHeaders: {
-          ETag:           'etag',
-          'Content-Type': 'application/vnd.go.cd.v2+json'
-        },
-        status:          200
-      });
-
-      expect($root.find('.filter_options')).not.toBeInDOM();
-      $root.find('.filter_btn').click();
-      expect($root.find('.filter_options')).toBeInDOM();
+  describe("personalize view", () => {
+    beforeEach(() => {
+      personalizeData = {
+        filters: [
+          {
+            pipelines: [],
+            type: 'blacklist'
+          }
+        ],
+        pipelines: []
+      };
     });
-  });
 
-  it("should close an open personalize view dropdown on clicking anywhere on the screen", () => {
-    jasmine.Ajax.withMock(() => {
-      jasmine.Ajax.stubRequest('/go/api/internal/pipeline_selection', undefined, 'GET').andReturn({
-        responseText:    JSON.stringify({}),
-        responseHeaders: {
-          ETag:           'etag',
-          'Content-Type': 'application/vnd.go.cd.v2+json'
-        },
-        status:          200
+    it("should show personalize view", () => {
+      jasmine.Ajax.withMock(() => {
+        jasmine.Ajax.stubRequest('/go/api/internal/pipeline_selection', undefined, 'GET').andReturn({
+          responseText:    JSON.stringify(personalizeData),
+          responseHeaders: {
+            ETag:           'etag',
+            'Content-Type': 'application/vnd.go.cd.v2+json'
+          },
+          status:          200
+        });
+
+        expect($root.find('.filter_options')).not.toBeInDOM();
+        $root.find('.filter_btn').click();
+        expect($root.find('.filter_options')).toBeInDOM();
       });
+    });
 
-      $root.find('.filter_btn').click();
-      expect($root.find('.filter_options')).toBeInDOM();
-      $('body').click();
-      expect($root.find('.filter_options')).not.toBeInDOM();
+    it("should close an open personalize view dropdown on clicking anywhere on the screen", () => {
+      jasmine.Ajax.withMock(() => {
+        jasmine.Ajax.stubRequest('/go/api/internal/pipeline_selection', undefined, 'GET').andReturn({
+          responseText:    JSON.stringify(personalizeData),
+          responseHeaders: {
+            ETag:           'etag',
+            'Content-Type': 'application/vnd.go.cd.v2+json'
+          },
+          status:          200
+        });
+
+        $root.find('.filter_btn').click();
+        expect($root.find('.filter_options')).toBeInDOM();
+        $('body').click();
+        expect($root.find('.filter_options')).not.toBeInDOM();
+      });
     });
   });
 

--- a/server/webapp/WEB-INF/rails.new/spec/webpack/views/dashboard/dashboard_widget_spec.js
+++ b/server/webapp/WEB-INF/rails.new/spec/webpack/views/dashboard/dashboard_widget_spec.js
@@ -91,6 +91,7 @@ describe("Dashboard Widget", () => {
       personalizeData = {
         filters: [
           {
+            name: "Default",
             pipelines: [],
             type: 'blacklist'
           }

--- a/server/webapp/WEB-INF/rails.new/spec/webpack/views/dashboard/personalize_widget_spec.js
+++ b/server/webapp/WEB-INF/rails.new/spec/webpack/views/dashboard/personalize_widget_spec.js
@@ -35,8 +35,10 @@ describe("Dashboard Personalize Widget", () => {
       "first":  ["up42"],
       "second": ["up43", "up44"]
     },
-    "selections": ["up42", "up44"],
-    "blacklist":  true
+    "filters": [{
+        "pipelines": ["up42", "up44"],
+        "type": "blacklist"
+      }]
   };
 
   let pipelineSelection, vm;

--- a/server/webapp/WEB-INF/rails.new/spec/webpack/views/dashboard/personalize_widget_spec.js
+++ b/server/webapp/WEB-INF/rails.new/spec/webpack/views/dashboard/personalize_widget_spec.js
@@ -36,6 +36,7 @@ describe("Dashboard Personalize Widget", () => {
       "second": ["up43", "up44"]
     },
     "filters": [{
+        "name": "Default",
         "pipelines": ["up42", "up44"],
         "type": "blacklist"
       }]

--- a/server/webapp/WEB-INF/rails.new/webpack/models/dashboard/dashboard_filter.js
+++ b/server/webapp/WEB-INF/rails.new/webpack/models/dashboard/dashboard_filter.js
@@ -1,0 +1,70 @@
+
+/*
+ * Copyright 2018 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const _      = require('lodash');
+const Stream = require('mithril/stream');
+
+const DashboardFilter = function (name, pipelines, type) {
+  const WHITELIST_TYPE = "whitelist";
+  const BLACKLIST_TYPE = "blacklist";
+  this.name      = name;
+  this.pipelines = pipelines;
+  this.type      = type;
+
+  this.isBlacklist = () => {
+    return this.type === BLACKLIST_TYPE;
+  };
+
+  this.toggleType = () => {
+    this.type = this.isBlacklist() ? WHITELIST_TYPE : BLACKLIST_TYPE;
+  };
+
+  this.removePipeline = (pipelineName) => {
+      this.pipelines = _.reject(this.pipelines, (p) => {
+        return p === pipelineName;
+      });
+  };
+
+  this.addPipeline = (pipelineName) => {
+    this.pipelines.push(pipelineName);
+  };
+
+  this.clearPipelines = () => {
+    this.pipelines = [];
+  };
+
+  this.findSelections = (pipelineGroups) => {
+    const selections = {};
+    _.each(_.keys(pipelineGroups), (group) => {
+      _.each(pipelineGroups[group], (pipeline) => {
+        selections[pipeline] = Stream(!!(this.isBlacklist() ^ _.includes(this.pipelines, pipeline)));
+      });
+    });
+    return selections;
+  };
+
+  this.invertPipelines = (allPipelines) => {
+    this.clearPipelines();
+    _.each(allPipelines, (selection, pipelineName) => {
+      if (this.isBlacklist() ^ selection()) {
+        this.addPipeline(pipelineName);
+      }
+    });
+  };
+};
+
+module.exports = DashboardFilter;

--- a/server/webapp/WEB-INF/rails.new/webpack/models/dashboard/dashboard_filters.js
+++ b/server/webapp/WEB-INF/rails.new/webpack/models/dashboard/dashboard_filters.js
@@ -23,7 +23,7 @@ const DashboardFilters = function (filters) {
   });
 
   this.getFilterNamed = (name) => {
-    return _.find(this.filters, (filter) => { return filter.name === name; });
+    return _.find(this.filters, (filter) => { return filter.name.toLowerCase() === name.toLowerCase(); });
   };
 };
 

--- a/server/webapp/WEB-INF/rails.new/webpack/models/dashboard/dashboard_filters.js
+++ b/server/webapp/WEB-INF/rails.new/webpack/models/dashboard/dashboard_filters.js
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2018 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const _               = require('lodash');
+const DashboardFilter = require('models/dashboard/dashboard_filter');
+
+const DashboardFilters = function (filters) {
+  this.filters = _.map(filters, (filter) => {
+    return new DashboardFilter(filter.name, filter.pipelines, filter.type);
+  });
+
+  this.getFilterNamed = (name) => {
+    return _.find(this.filters, (filter) => { return filter.name === name; });
+  };
+};
+
+module.exports = DashboardFilters;

--- a/server/webapp/WEB-INF/rails.new/webpack/models/dashboard/pipeline_selection.js
+++ b/server/webapp/WEB-INF/rails.new/webpack/models/dashboard/pipeline_selection.js
@@ -20,12 +20,14 @@ const DashboardFilters = require('models/dashboard/dashboard_filters');
 const AjaxHelper       = require('helpers/ajax_helper');
 const SparkRoutes      = require('helpers/spark_routes');
 
+const NAME_DEFAULT_FILTER = "Default";
+
 const PipelineSelection = function (pipelineGroups, filters) {
   const self = this;
 
   this.pipelineGroups = pipelineGroups;
   this.filters        = filters;
-  this.currentFilter  = this.filters.getFilterNamed(undefined);
+  this.currentFilter  = this.filters.getFilterNamed(NAME_DEFAULT_FILTER);
   this.selections     = this.currentFilter.findSelections(this.pipelineGroups());
 
   this.isPipelineSelected = (pipelineName) => self.selections[pipelineName]();

--- a/server/webapp/WEB-INF/rails.new/webpack/models/dashboard/pipeline_selection.js
+++ b/server/webapp/WEB-INF/rails.new/webpack/models/dashboard/pipeline_selection.js
@@ -14,58 +14,93 @@
  * limitations under the License.
  */
 
-const _           = require('lodash');
-const Stream      = require('mithril/stream');
-const AjaxHelper  = require('helpers/ajax_helper');
-const SparkRoutes = require('helpers/spark_routes');
+const _                = require('lodash');
+const Stream           = require('mithril/stream');
+const DashboardFilters = require('models/dashboard/dashboard_filters');
+const AjaxHelper       = require('helpers/ajax_helper');
+const SparkRoutes      = require('helpers/spark_routes');
 
-const PipelineSelection = function (pipelineGroups, selections, blacklist) {
+const PipelineSelection = function (pipelineGroups, filters) {
   const self = this;
 
   this.pipelineGroups = pipelineGroups;
-  this.selections     = selections;
-  this.blacklist      = blacklist;
+  this.filters        = filters;
+  this.currentFilter  = this.filters.getFilterNamed(undefined);
+  this.selections     = this.currentFilter.findSelections(this.pipelineGroups());
 
   this.isPipelineSelected = (pipelineName) => self.selections[pipelineName]();
 
   this.toggleBlacklist = () => {
-    self.blacklist(!self.blacklist);
+    this.currentFilter.toggleType();
+    this.currentFilter.invertPipelines(this.selections);
+  };
+
+  this.blacklist = () => {
+    return this.currentFilter.isBlacklist();
+  };
+
+  this.addSelection = (pipelineName) => {
+    if (this.blacklist()) {
+      this.currentFilter.removePipeline(pipelineName);
+    } else {
+      this.currentFilter.pipelines.push(pipelineName);
+    }
+    this.selections[pipelineName](true);
+  };
+
+  this.removeSelection = (pipelineName) => {
+    if (!this.blacklist()) {
+      this.currentFilter.removePipeline(pipelineName);
+    } else {
+      this.currentFilter.pipelines.push(pipelineName);
+    }
+    this.selections[pipelineName](false);
+  };
+
+  this.toggleSelection = (pipelineName) => {
+    if (_.includes(this.currentFilter.pipelines, pipelineName)) {
+      this.currentFilter.removePipeline(pipelineName);
+    } else {
+      this.currentFilter.pipelines.push(pipelineName);
+    }
+    this.selections[pipelineName](!this.selections[pipelineName]());
+  };
+
+  this.selectAll = () => {
+    if (this.blacklist()) {
+      this.currentFilter.clearPipelines();
+    } else {
+      this.currentFilter.pipelines = _.keys(this.selections);
+    }
+    _.each(_.keys(this.selections), (pipelineName) => {
+      this.selections[pipelineName](true);
+    });
+  };
+
+  this.unselectAll = () => {
+    if (this.blacklist()) {
+      this.currentFilter.pipelines = _.keys(this.selections);
+    } else {
+      this.currentFilter.clearPipelines();
+    }
+    _.each(_.keys(this.selections), (pipelineName) => {
+      this.selections[pipelineName](false);
+    });
   };
 
   this.update = () => {
-    const allPipelines = self.selections;
-    const selections   = [];
-
-    _.each(allPipelines, (selection, pipelineName) => {
-      if (self.blacklist() ^ selection()) {
-        selections.push(pipelineName);
-      }
-    });
-
-    const payload = {
-      selections,
-      "blacklist": self.blacklist()
-    };
-
     return AjaxHelper.PUT({
       url:        SparkRoutes.pipelineSelectionPath(),
       apiVersion: 'v1',
-      payload
+      payload:     this.filters
     });
   };
 };
 
 PipelineSelection.fromJSON = (json) => {
   const pipelineGroups = json.pipelines;
-  const selections     = {};
-  const blacklist      = json.blacklist;
-  _.each(_.keys(pipelineGroups), (group) => {
-    _.each(pipelineGroups[group], (pipeline) => {
-      selections[pipeline] = Stream(!!(blacklist ^ _.includes(json.selections, pipeline)));
-    });
-  });
-
-  return new PipelineSelection(Stream(pipelineGroups), selections, Stream(blacklist));
+  const filters        = new DashboardFilters(json.filters);
+  return new PipelineSelection(Stream(pipelineGroups), filters);
 };
 
 PipelineSelection.get = () => {

--- a/server/webapp/WEB-INF/rails.new/webpack/views/dashboard/personalize_widget.js.msx
+++ b/server/webapp/WEB-INF/rails.new/webpack/views/dashboard/personalize_widget.js.msx
@@ -22,10 +22,11 @@ const PersonalizeWidget = {
     const self = vnode.state;
 
     const setSelectionForAllPipelines = (isSelected) => {
-      const selections = vnode.attrs.pipelineSelection().selections;
-      _.each(_.keys(selections), (pipelineName) => {
-        selections[pipelineName](isSelected);
-      });
+      if (isSelected) {
+        vnode.attrs.pipelineSelection().selectAll();
+      } else {
+        vnode.attrs.pipelineSelection().unselectAll();
+      }
     };
 
     self.selectAll = () => {
@@ -45,17 +46,19 @@ const PersonalizeWidget = {
 
 
     self.toggleBlacklist = () => {
-      const blacklist = vnode.attrs.pipelineSelection().blacklist;
-      blacklist(!blacklist());
+       vnode.attrs.pipelineSelection().toggleBlacklist();
     };
 
     self.togglePipelineSelection = (pipelineName) => {
-      const selection = vnode.attrs.pipelineSelection().selections[pipelineName];
-      selection(!selection());
+      vnode.attrs.pipelineSelection().toggleSelection(pipelineName);
     };
 
     const setPipelineSelection = (pipelineName, isSelected) => {
-      vnode.attrs.pipelineSelection().selections[pipelineName](isSelected);
+      if (isSelected) {
+        vnode.attrs.pipelineSelection().addSelection(pipelineName);
+      } else {
+        vnode.attrs.pipelineSelection().removeSelection(pipelineName);
+      }
     };
 
     self.togglePipelineGroupSelection = (groupName) => {

--- a/spark/spark-base/src/test/groovy/com/thoughtworks/go/api/mocks/MockHttpServletResponseAssert.groovy
+++ b/spark/spark-base/src/test/groovy/com/thoughtworks/go/api/mocks/MockHttpServletResponseAssert.groovy
@@ -32,6 +32,11 @@ class MockHttpServletResponseAssert extends com.thoughtworks.go.http.mocks.MockH
     return new MockHttpServletResponseAssert(actual, MockHttpServletResponseAssert.class)
   }
 
+  MockHttpServletResponseAssert hasBodyWithJson(String expectedJson) {
+    JsonFluentAssert.assertThatJson(actual.getContentAsString()).isEqualTo(expectedJson)
+    return this
+  }
+
   MockHttpServletResponseAssert hasBodyWithJsonObject(Object expected, Class representer) throws UnsupportedEncodingException {
     def expectedJson = toObjectString({ representer.toJSON(it , expected) })
 


### PR DESCRIPTION
The main goal of this effort is to build support for managing multiple personalization settings per user entirely into the frontend. With the frontend managing most of the logic, the backend is basically a hard disk, metaphorically; its responsibility is reduced to the simple task of de/serializing JSON to and from the database, leaving all other logic to be contained in the UI.

The main benefits probably won't be fully appreciated until we build the ability to name and define multiple filters on the UI, which will be in PR #4864.

`PipelineSelections` now holds a `Filters` object, which is just a fancy holder for a list of `DashboardFilter` objects that either act as blacklist or whitelist filters.

The `Filters` object serializes to JSON and back.

`DashboardFilter` implements a `isPipelineVisible(pipelineName)` method to determine whether or not a given pipeline be shown. The idea here is that `PipelineSelections#includesPipeline()` will delegate to this method on the currently selected `DashboardFilter` (which is the analog to a named view tab in the UI).

The `DashboardControllerDelegate` accepts a `viewName` query parameter, indicating the name of the view filter, and selects the named filter from the user's filter set to generate the filtered set of pipelines. Currently, this bit is a dark launch, but maintains existing functionality in the absence of the parameter.

Currently, the filters JSON structure looks something like this:

```json
{
  "filters": [
    {"name": "my filter", "pipelines": ["p1", "p2"], "type": "whitelist" },
    {"name": null, "pipelines": [], "type": "blacklist" }
  ]
}
```