### PR TITLE
    Use FilenameUtils.separatorsToUnix to convert all the '\\' to '/' which is a valid name seperator character in the URI (#4923)

### DIFF
--- a/plugin-infra/go-plugin-domain/build.gradle
+++ b/plugin-infra/go-plugin-domain/build.gradle
@@ -18,6 +18,7 @@ description = 'GoCD Plugins Domain'
 
 dependencies {
   compile project(':plugin-infra:go-plugin-api')
+  compile group: 'commons-io', name: 'commons-io', version: project.versions.commonsIO
   compile group: 'org.apache.commons', name: 'commons-lang3', version: project.versions.commonsLang3
   testCompile group: 'org.skyscreamer', name: 'jsonassert', version: project.versions.jsonAssert
   testCompile project(':test:test-utils')

--- a/plugin-infra/go-plugin-domain/src/main/java/com/thoughtworks/go/plugin/domain/analytics/AnalyticsData.java
+++ b/plugin-infra/go-plugin-domain/src/main/java/com/thoughtworks/go/plugin/domain/analytics/AnalyticsData.java
@@ -16,8 +16,11 @@
 
 package com.thoughtworks.go.plugin.domain.analytics;
 
+import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.StringUtils;
+
 import java.net.URI;
+import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -43,7 +46,8 @@ public class AnalyticsData {
         if (StringUtils.isBlank(assetRoot)) {
             return viewPath;
         }
-        return URI.create(assetRoot + "/" + viewPath).normalize().toString();
+
+        return URI.create(FilenameUtils.separatorsToUnix(Paths.get( assetRoot, viewPath).toString())).normalize().toString();
     }
 
     public Map<String, String> toMap() {

--- a/plugin-infra/go-plugin-domain/src/test/java/com/thoughtworks/go/plugin/domain/analytics/AnalyticsDataTest.java
+++ b/plugin-infra/go-plugin-domain/src/test/java/com/thoughtworks/go/plugin/domain/analytics/AnalyticsDataTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2018 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.plugin.domain.analytics;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+class AnalyticsDataTest {
+    private String viewPath;
+    private AnalyticsData analyticsData;
+
+    @BeforeEach
+    void setUp() {
+    }
+
+    @Test
+    void shouldGetFullViewPathForLinuxOperatingSystem() {
+        String assetRoot = "/assets/root";
+        viewPath = "agents/agents.html";
+        analyticsData = new AnalyticsData("{}", viewPath);
+        analyticsData.setAssetRoot(assetRoot);
+
+        assertThat(analyticsData.getFullViewPath(), is(assetRoot + '/' + viewPath));
+    }
+
+    @Test
+    void shouldGetFullViewPathForWindowsOperatingSystem() {
+        String assetRoot = "\\assets\\root";
+        viewPath = "agents\\agents.html";
+        analyticsData = new AnalyticsData("{}", viewPath);
+        analyticsData.setAssetRoot(assetRoot);
+
+        assertThat(analyticsData.getFullViewPath(), is("/assets/root/agents/agents.html"));
+    }
+}


### PR DESCRIPTION
Use FilenameUtils.separatorsToUnix to convert all the '\\' to '/' which is a valid name seperator character in the URI (#4923)
    * The URI path creation fails on windows due to unsupported character '\\' being used in the URI.
    * Convert all the name separator character to the Unix name separator '/' before creating the URI from the file path.