### PR TITLE
Do not get current revision from config.git within synchronized block.

### DIFF
--- a/config/config-server/src/main/java/com/thoughtworks/go/service/ConfigRepository.java
+++ b/config/config-server/src/main/java/com/thoughtworks/go/service/ConfigRepository.java
@@ -171,19 +171,16 @@ public class ConfigRepository {
     }
 
     public GoConfigRevision getCurrentRevision() {
-        return doLocked(() -> {
-            RevCommit revision;
-            try {
-                revision = getCurrentRevCommit();
-            } catch (NoHeadException e) {
-                return null;
-            } catch (GitAPIException e) {
-                LOGGER.info("[CONFIG REPOSITORY] Unable retrieve current cruise config revision", e);
-                return null;
-            }
-            return getGoConfigRevision(revision);
-        });
-
+        RevCommit revision;
+        try {
+            revision = getCurrentRevCommit();
+        } catch (NoHeadException e) {
+            return null;
+        } catch (GitAPIException e) {
+            LOGGER.info("[CONFIG REPOSITORY] Unable retrieve current cruise config revision", e);
+            return null;
+        }
+        return getGoConfigRevision(revision);
     }
 
     public RevCommit getCurrentRevCommit() throws GitAPIException {


### PR DESCRIPTION
There is no need for this to be a blocking call.

@jyotisingh - do you remember why this was within a lock?

