### PR TITLE
Moving ServiceLoader.load(IVProvider.class) to a non-static context s…

### DIFF
--- a/config/config-api/src/main/java/com/thoughtworks/go/security/AESEncrypter.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/security/AESEncrypter.java
@@ -35,7 +35,18 @@ public class AESEncrypter implements Encrypter, Serializable {
 
     private final AESCipherProvider cipherProvider;
 
-    private static IVProvider ivProvider = ServiceLoader.load(IVProvider.class).iterator().next();
+    private static IVProvider ivProvider;
+
+    private IVProvider getIvProviderInstance() {
+        if (ivProvider == null) {
+            synchronized (AESEncrypter.class) {
+                if (ivProvider == null) {
+                    ivProvider = ServiceLoader.load(IVProvider.class).iterator().next();
+                }
+            }
+        }
+        return ivProvider;
+    }
 
     public AESEncrypter(AESCipherProvider cipherProvider) {
         this.cipherProvider = cipherProvider;
@@ -53,7 +64,7 @@ public class AESEncrypter implements Encrypter, Serializable {
     @Override
     public String encrypt(String plainText) throws CryptoException {
         try {
-            byte[] initializationVector = ivProvider.createIV();
+            byte[] initializationVector = getIvProviderInstance().createIV();
             Cipher encryptCipher = Cipher.getInstance("AES/CBC/PKCS5Padding");
             encryptCipher.init(Cipher.ENCRYPT_MODE, createSecretKeySpec(), new IvParameterSpec(initializationVector));
 


### PR DESCRIPTION
…ince the parent classloader for addon CLIs does not have IVProvider and ProductionIVProvider loaded up.

While both IVProvider and ProductionIVProvider were loaded up with the dependencies present inside addon-jar/libs, they are loaded up only by child-class-loader (JarClassLoader). Instantiating the field inline causes ServiceLoader.load(IVProvider.class) to be called in parent class-loader's context which threw up on CLI startup. AESEncrypter.encrypt on the other hand would be invoked in the JarClassLoader's context and as such load up the classes successfully