### PR TITLE
Pipeline name in analytics modal header

### DIFF
--- a/server/webapp/WEB-INF/rails.new/spec/webpack/views/dashboard/pipeline_widget_spec.js
+++ b/server/webapp/WEB-INF/rails.new/spec/webpack/views/dashboard/pipeline_widget_spec.js
@@ -143,7 +143,7 @@ describe("Dashboard Pipeline Widget", () => {
       expect($('.reveal:visible')).toBeInDOM();
       expect($(".frame-container")).toBeInDOM();
       const modalTitle = $('.modal-title:visible');
-      expect(modalTitle).toHaveText("Analytics");
+      expect(modalTitle).toHaveText("Analytics for pipeline: up42");
     });
 
     it("should not display the analytics icon if the user is not an admin", () => {

--- a/server/webapp/WEB-INF/rails.new/webpack/views/dashboard/pipeline_analytics_widget.js.msx
+++ b/server/webapp/WEB-INF/rails.new/webpack/views/dashboard/pipeline_analytics_widget.js.msx
@@ -35,7 +35,7 @@ function createModal(pluginId, metricId, pipeline) {
 
   const modal = new Modal({
     size:    "analytics-modal",
-    title:   "Analytics",
+    title:   `Analytics for pipeline: ${pipeline.name}`,
     body:    () => (m(AnalyticsiFrameWidget, {model, uid, title: "Pipeline Build Time", pluginId, init})),
     onclose: () => modal.destroy(),
     buttons: []


### PR DESCRIPTION
Screenshot:

<img width="1002" alt="screen shot 2018-07-13 at 10 37 56 am" src="https://user-images.githubusercontent.com/5726224/42705659-df13916e-8688-11e8-8786-6d8915833c60.png">

@maheshp @arvindsv would one of you mind reviewing and merging this? It's a pretty minor change