### PR TITLE
Do not apply basic auth on web hook apis in at filter level

### DIFF
--- a/server/src/main/java/com/thoughtworks/go/server/newsecurity/filterchains/AuthenticationFilterChain.java
+++ b/server/src/main/java/com/thoughtworks/go/server/newsecurity/filterchains/AuthenticationFilterChain.java
@@ -47,6 +47,7 @@ public class AuthenticationFilterChain extends FilterChainProxy {
                 // For API authentication
                 .addFilterChain("/api/config-repository.git/**", invalidateAuthenticationOnSecurityConfigChangeFilter, assumeAnonymousUserFilter, reAuthenticationWithChallenge, basicAuthenticationWithChallengeFilter)
                 .addFilterChain("/cctray.xml", invalidateAuthenticationOnSecurityConfigChangeFilter, reAuthenticationWithChallenge, assumeAnonymousUserFilter, basicAuthenticationWithChallengeFilter)
+                .addFilterChain("/api/webhooks/*/notify", assumeAnonymousUserFilter)
                 .addFilterChain("/api/**", invalidateAuthenticationOnSecurityConfigChangeFilter, reAuthenticationWithChallenge, assumeAnonymousUserFilter, basicAuthenticationWithChallengeFilter)
 
                 .addFilterChain("/api/version", invalidateAuthenticationOnSecurityConfigChangeFilter, reAuthenticationWithRedirectToLoginPage, assumeAnonymousUserFilter, basicAuthenticationWithRedirectToLoginFilter)

--- a/server/src/test-fast/java/com/thoughtworks/go/server/newsecurity/filterchains/AuthenticationFilterChainTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/newsecurity/filterchains/AuthenticationFilterChainTest.java
@@ -192,6 +192,26 @@ public class AuthenticationFilterChainTest {
         }
 
         @ParameterizedTest
+        @ValueSource(strings = {"/api/webhooks/bitbucket/notify", "/api/webhooks/github/notify", "/api/webhooks/foo/notify"})
+        void shouldAllowAnonymousAccessForWebhookApis(String url) throws IOException, ServletException {
+            request = HttpRequestBuilder.GET(url)
+                    .build();
+
+            new AuthenticationFilterChain(null, null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    assumeAnonymousUserFilter)
+                    .doFilter(request, response, filterChain);
+
+            verify(filterChain).doFilter(wrap(request), wrap(response));
+            MockHttpServletResponseAssert.assertThat(response).isOk();
+            assertThat(SessionUtils.getAuthenticationToken(request).getCredentials()).isSameAs(AnonymousCredential.INSTANCE);
+        }
+
+        @ParameterizedTest
         @ValueSource(strings = {"/api/config-repository.git/git-upload-something", "/cctray.xml", "/api/foo", "/blah"})
         void shouldAuthenticateUsingBasicAuthForAllCalls(String url) throws IOException, ServletException {
             request = HttpRequestBuilder.GET(url)


### PR DESCRIPTION
- Authentication for webhook APIs is implemented in the controller (`controllers/api/web_hooks/WEB_HOOK_CONTROLLER`) based on provider.

See issue #4945 for more information.