### PR TITLE
Update usage data remote server url

### DIFF
--- a/base/src/main/java/com/thoughtworks/go/util/SystemEnvironment.java
+++ b/base/src/main/java/com/thoughtworks/go/util/SystemEnvironment.java
@@ -183,7 +183,7 @@ public class SystemEnvironment implements Serializable, ConfigDirProvider {
     public static GoSystemProperty<String> GO_UPDATE_SERVER_URL = new GoStringSystemProperty("go.update.server.url", "https://update.gocd.org/channels/supported/latest.json");
     public static GoSystemProperty<Boolean> GO_CHECK_UPDATES = new GoBooleanSystemProperty("go.check.updates", true);
 
-    public static GoSystemProperty<String> GO_DATA_SHARING_SERVER_URL = new GoStringSystemProperty("go.datasharing.server.url", "https://datasharing.gocd.org/v1");
+    public static GoSystemProperty<String> GO_DATA_SHARING_SERVER_URL = new GoStringSystemProperty("go.datasharing.server.url", "https://datasharing.gocd.org/usagedata");
 
     public static GoSystemProperty<Integer> GO_ELASTIC_PLUGIN_CREATE_AGENT_THREADS = new GoIntSystemProperty("go.elasticplugin.createagent.threads", 5);
     public static GoSystemProperty<Integer> GO_ELASTIC_PLUGIN_SERVER_PING_THREADS = new GoIntSystemProperty("go.elasticplugin.serverping.threads", 1);


### PR DESCRIPTION
Change Usage data remote server URL to https://datasharing.gocd.org/usagedata