### PR TITLE
Trim the contents of the cipher file to eliminate any newlines

### DIFF
--- a/config/config-api/src/main/java/com/thoughtworks/go/security/AESCipherProvider.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/security/AESCipherProvider.java
@@ -54,7 +54,7 @@ public class AESCipherProvider implements Serializable {
                 if (cachedKey == null) {
                     try {
                         if (cipherFile.exists()) {
-                            cachedKey = decodeHex(FileUtils.readFileToString(cipherFile, UTF_8));
+                            cachedKey = decodeHex(FileUtils.readFileToString(cipherFile, UTF_8).trim());
                             return;
                         }
                         byte[] newKey = generateKey();

--- a/config/config-api/src/main/java/com/thoughtworks/go/security/DESCipherProvider.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/security/DESCipherProvider.java
@@ -58,7 +58,7 @@ public class DESCipherProvider implements Serializable {
                 if (cachedKey == null) {
                     try {
                         if (cipherFile.exists()) {
-                            cachedKey = decodeHex(FileUtils.readFileToString(cipherFile, UTF_8));
+                            cachedKey = decodeHex(FileUtils.readFileToString(cipherFile, UTF_8).trim());
                             return;
                         }
                         byte[] newKey = generateKey();


### PR DESCRIPTION
This is to avoid any decoding exceptions from `decodeHex`