### PR TITLE
Prevent attempt to re-add a pre-registered agent to config

### DIFF
--- a/server/src/main/java/com/thoughtworks/go/server/controller/AgentRegistrationController.java
+++ b/server/src/main/java/com/thoughtworks/go/server/controller/AgentRegistrationController.java
@@ -258,7 +258,7 @@ public class AgentRegistrationController {
                 agentConfig.setElasticPluginId(elasticPluginId);
             }
 
-            if (goConfigService.serverConfig().shouldAutoRegisterAgentWith(agentAutoRegisterKey)) {
+            if (goConfigService.serverConfig().shouldAutoRegisterAgentWith(agentAutoRegisterKey) && !goConfigService.hasAgent(uuid)) {
                 LOG.info("[Agent Auto Registration] Auto registering agent with uuid {} ", uuid);
                 GoConfigDao.CompositeConfigCommand compositeConfigCommand = new GoConfigDao.CompositeConfigCommand(
                         new AgentConfigService.AddAgentCommand(agentConfig),


### PR DESCRIPTION
If a pre-registered agent with auto-register keys setup makes an attempt to register with the server (in case the keys on the agent side were deleted), the server would try to add such an agent to config all over again, and fail much later during the xsd validation stating that a duplicate entry was being inserted into the config file. Since the agent attempting registration has access to both the uuid and the right token that was issued to it, its alright to send over keys to this agent. Avoiding re-adding of this agent to config.xml