### PR TITLE
Add a workaround for #4810

### DIFF
--- a/server/src/main/java/com/thoughtworks/go/server/controller/ArtifactsController.java
+++ b/server/src/main/java/com/thoughtworks/go/server/controller/ArtifactsController.java
@@ -126,6 +126,9 @@ public class ArtifactsController {
                                          @RequestParam("filePath") String filePath,
                                          @RequestParam(value = "sha1", required = false) String sha
     ) throws Exception {
+        if (filePath.equals(".zip")) {
+            filePath = "./.zip";
+        }
         return getArtifact(filePath, zipViewFactory, pipelineName, counterOrLabel, stageName, stageCounter, buildName, sha, null);
     }
 


### PR DESCRIPTION
Older versions of gocd would set the filepath to `./.zip` when
requesting directory `./`. After a spring upgrade, and some path
normalization, the filePath is now `.zip`. This is currently a temporary
workaround while we sort out a better way to do this correctly.