### PR TITLE
Fix smoke tests (at least partially)

### DIFF
--- a/api/api-dashboard-v2/src/main/java/com/thoughtworks/go/apiv2/dashboard/DashboardControllerDelegate.java
+++ b/api/api-dashboard-v2/src/main/java/com/thoughtworks/go/apiv2/dashboard/DashboardControllerDelegate.java
@@ -84,7 +84,7 @@ public class DashboardControllerDelegate extends ApiController {
         Long userId = currentUserId(request);
         Username userName = currentUsername();
 
-        PipelineSelections selectedPipelines = pipelineSelectionsService.loadPipelineSelections(selectedPipelinesCookie, userId);
+        PipelineSelections selectedPipelines = pipelineSelectionsService.load(selectedPipelinesCookie, userId);
 
         final String filterName = getViewName(request);
         final DashboardFilter filter = selectedPipelines.namedFilter(filterName);

--- a/api/api-dashboard-v2/src/test/groovy/com/thoughtworks/go/apiv2/dashboard/DashboardControllerDelegateTest.groovy
+++ b/api/api-dashboard-v2/src/test/groovy/com/thoughtworks/go/apiv2/dashboard/DashboardControllerDelegateTest.groovy
@@ -87,7 +87,7 @@ class DashboardControllerDelegateTest implements SecurityServiceTrait, Controlle
         def pipelineGroup = new GoDashboardPipelineGroup('group1', new Permissions(Everyone.INSTANCE, Everyone.INSTANCE, Everyone.INSTANCE, Everyone.INSTANCE))
         pipelineGroup.addPipeline(dashboardPipeline('pipeline1'))
         pipelineGroup.addPipeline(dashboardPipeline('pipeline2'))
-        when(pipelineSelectionsService.loadPipelineSelections((String) isNull(), any(Long.class))).thenReturn(pipelineSelections)
+        when(pipelineSelectionsService.load((String) isNull(), any(Long.class))).thenReturn(pipelineSelections)
         when(goDashboardService.hasEverLoadedCurrentState()).thenReturn(true)
         when(goDashboardService.allPipelineGroupsForDashboard(eq(Filters.WILDCARD_FILTER), eq(currentUsername()))).thenReturn([pipelineGroup])
 
@@ -106,7 +106,7 @@ class DashboardControllerDelegateTest implements SecurityServiceTrait, Controlle
         def pipelineGroup = new GoDashboardPipelineGroup('group1', new Permissions(Everyone.INSTANCE, Everyone.INSTANCE, Everyone.INSTANCE, Everyone.INSTANCE))
         pipelineGroup.addPipeline(dashboardPipeline('pipeline1'))
         pipelineGroup.addPipeline(dashboardPipeline('pipeline2'))
-        when(pipelineSelectionsService.loadPipelineSelections((String) isNull(), any(Long.class))).thenReturn(pipelineSelections)
+        when(pipelineSelectionsService.load((String) isNull(), any(Long.class))).thenReturn(pipelineSelections)
         when(goDashboardService.hasEverLoadedCurrentState()).thenReturn(true)
         def pipelineGroups = [pipelineGroup]
         when(goDashboardService.allPipelineGroupsForDashboard(eq(Filters.WILDCARD_FILTER), eq(currentUsername()))).thenReturn(pipelineGroups)
@@ -125,7 +125,7 @@ class DashboardControllerDelegateTest implements SecurityServiceTrait, Controlle
       void 'should get empty json when dashboard is empty'() {
         def noPipelineGroups = []
         def pipelineSelections = PipelineSelections.ALL
-        when(pipelineSelectionsService.loadPipelineSelections((String) isNull(), any(Long.class))).thenReturn(pipelineSelections)
+        when(pipelineSelectionsService.load((String) isNull(), any(Long.class))).thenReturn(pipelineSelections)
         when(goDashboardService.allPipelineGroupsForDashboard(eq(Filters.WILDCARD_FILTER), eq(currentUsername()))).thenReturn(noPipelineGroups)
         when(goDashboardService.hasEverLoadedCurrentState()).thenReturn(true)
 
@@ -165,7 +165,7 @@ class DashboardControllerDelegateTest implements SecurityServiceTrait, Controlle
         def pipelineGroup = new GoDashboardPipelineGroup('group1', new Permissions(Everyone.INSTANCE, Everyone.INSTANCE, Everyone.INSTANCE, Everyone.INSTANCE))
         pipelineGroup.addPipeline(dashboardPipeline('pipeline1'))
         pipelineGroup.addPipeline(dashboardPipeline('pipeline2'))
-        when(pipelineSelectionsService.loadPipelineSelections((String) isNull(), any(Long.class))).thenReturn(pipelineSelections)
+        when(pipelineSelectionsService.load((String) isNull(), any(Long.class))).thenReturn(pipelineSelections)
         when(goDashboardService.hasEverLoadedCurrentState()).thenReturn(true)
         def pipelineGroups = [pipelineGroup]
         when(goDashboardService.allPipelineGroupsForDashboard(eq(Filters.WILDCARD_FILTER), eq(currentUsername()))).thenReturn(pipelineGroups)

--- a/api/api-pipeline-selection-v1/src/main/java/com/thoughtworks/go/apiv1/pipelineselection/PipelineSelectionControllerDelegate.java
+++ b/api/api-pipeline-selection-v1/src/main/java/com/thoughtworks/go/apiv1/pipelineselection/PipelineSelectionControllerDelegate.java
@@ -83,7 +83,7 @@ public class PipelineSelectionControllerDelegate extends ApiController {
     public String show(Request request, Response response) {
         String fromCookie = request.cookie(COOKIE_NAME);
         List<PipelineConfigs> groups = pipelineConfigService.viewableGroupsFor(currentUsername());
-        PipelineSelections pipelineSelections = pipelineSelectionsService.loadPipelineSelections(fromCookie, currentUserId(request));
+        PipelineSelections pipelineSelections = pipelineSelectionsService.load(fromCookie, currentUserId(request));
 
         PipelineSelectionResponse pipelineSelectionResponse = new PipelineSelectionResponse(pipelineSelections.viewFilters(), groups);
 
@@ -102,7 +102,7 @@ public class PipelineSelectionControllerDelegate extends ApiController {
             return e.getMessage();
         }
 
-        Long recordId = pipelineSelectionsService.persistPipelineSelections(fromCookie, currentUserId(request), filters);
+        Long recordId = pipelineSelectionsService.save(fromCookie, currentUserId(request), filters);
 
         if (!apiAuthenticationHelper.securityEnabled()) {
             response.cookie("/go", COOKIE_NAME, String.valueOf(recordId), ONE_YEAR, systemEnvironment.isSessionCookieSecure(), true);

--- a/api/api-pipeline-selection-v1/src/test/groovy/com/thoughtworks/go/apiv1/pipelineselection/PipelineSelectionControllerDelegateTest.groovy
+++ b/api/api-pipeline-selection-v1/src/test/groovy/com/thoughtworks/go/apiv1/pipelineselection/PipelineSelectionControllerDelegateTest.groovy
@@ -63,7 +63,7 @@ class PipelineSelectionControllerDelegateTest implements SecurityServiceTrait, C
 
         List<PipelineConfigs> pipelineConfigs = [group1, group2]
 
-        when(pipelineSelectionsService.loadPipelineSelections(null, currentUserLoginId())).thenReturn(selections)
+        when(pipelineSelectionsService.load(null, currentUserLoginId())).thenReturn(selections)
         when(pipelineConfigService.viewableGroupsFor(currentUsername())).thenReturn(pipelineConfigs)
 
         getWithApiHeader(controller.controllerBasePath())
@@ -93,7 +93,7 @@ class PipelineSelectionControllerDelegateTest implements SecurityServiceTrait, C
 
         String cookieId = SecureRandom.hex()
 
-        when(pipelineSelectionsService.loadPipelineSelections(cookieId, currentUserLoginId())).thenReturn(selections)
+        when(pipelineSelectionsService.load(cookieId, currentUserLoginId())).thenReturn(selections)
         when(pipelineConfigService.viewableGroupsFor(currentUsername())).thenReturn(pipelineConfigs)
 
         httpRequestBuilder.withCookies(new Cookie("selected_pipelines", cookieId))
@@ -124,7 +124,7 @@ class PipelineSelectionControllerDelegateTest implements SecurityServiceTrait, C
           ]
         ]
 
-        when(pipelineSelectionsService.persistPipelineSelections(null, currentUserLoginId(), FiltersHelper.blacklist(payload.filters.get(0).pipelines))).thenReturn(1l)
+        when(pipelineSelectionsService.save(null, currentUserLoginId(), FiltersHelper.blacklist(payload.filters.get(0).pipelines))).thenReturn(1l)
 
         putWithApiHeader(controller.controllerBasePath(), payload)
 
@@ -150,7 +150,7 @@ class PipelineSelectionControllerDelegateTest implements SecurityServiceTrait, C
 
         long recordId = SecureRandom.longNumber()
 
-        when(pipelineSelectionsService.persistPipelineSelections(String.valueOf(recordId), currentUserLoginId(), FiltersHelper.blacklist(payload.filters.get(0).pipelines))).thenReturn(recordId)
+        when(pipelineSelectionsService.save(String.valueOf(recordId), currentUserLoginId(), FiltersHelper.blacklist(payload.filters.get(0).pipelines))).thenReturn(recordId)
         when(systemEnvironment.isSessionCookieSecure()).thenReturn(false)
 
         httpRequestBuilder.withCookies(new Cookie("selected_pipelines", String.valueOf(recordId)))
@@ -183,7 +183,7 @@ class PipelineSelectionControllerDelegateTest implements SecurityServiceTrait, C
         List<PipelineConfigs> groups = [group1]
 
         when(pipelineConfigService.viewableGroupsFor(currentUsername())).thenReturn(groups)
-        when(pipelineSelectionsService.persistPipelineSelections(String.valueOf(recordId), currentUserLoginId(), FiltersHelper.blacklist(payload.filters.get(0).pipelines))).thenReturn(recordId)
+        when(pipelineSelectionsService.save(String.valueOf(recordId), currentUserLoginId(), FiltersHelper.blacklist(payload.filters.get(0).pipelines))).thenReturn(recordId)
         when(systemEnvironment.isSessionCookieSecure()).thenReturn(true)
 
         httpRequestBuilder.withCookies(new Cookie("selected_pipelines", String.valueOf(recordId)))

--- a/server/src/test-fast/java/com/thoughtworks/go/server/service/PipelineSelectionsServiceTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/service/PipelineSelectionsServiceTest.java
@@ -72,7 +72,7 @@ public class PipelineSelectionsServiceTest {
         disableSecurity();
         final Filters filters = Filters.single(whitelist("pipeline1"));
         when(pipelineRepository.saveSelectedPipelines(pipelineSelectionsWithFilters(filters))).thenReturn(2L);
-        assertEquals(2L, pipelineSelectionsService.persistPipelineSelections(null, null, filters));
+        assertEquals(2L, pipelineSelectionsService.save(null, null, filters));
         verify(pipelineRepository).saveSelectedPipelines(pipelineSelectionsWithFilters(filters));
     }
 
@@ -86,7 +86,7 @@ public class PipelineSelectionsServiceTest {
         when(pipelineRepository.findPipelineSelectionsByUserId(user.getId())).thenReturn(null);
         when(pipelineRepository.saveSelectedPipelines(pipelineSelectionsWithFilters(filters))).thenReturn(2L);
 
-        long pipelineSelectionsId = pipelineSelectionsService.persistPipelineSelections("1", user.getId(), filters);
+        long pipelineSelectionsId = pipelineSelectionsService.save("1", user.getId(), filters);
 
         assertEquals(2L, pipelineSelectionsId);
         verify(pipelineRepository).findPipelineSelectionsByUserId(user.getId());
@@ -104,7 +104,7 @@ public class PipelineSelectionsServiceTest {
         when(pipelineRepository.saveSelectedPipelines(pipelineSelections)).thenReturn(2L);
 
         final Filters newFilters = Filters.single(blacklist("pipelineX", "pipeline3"));
-        long pipelineSelectionId = pipelineSelectionsService.persistPipelineSelections("1", user.getId(), newFilters);
+        long pipelineSelectionId = pipelineSelectionsService.save("1", user.getId(), newFilters);
 
         assertEquals(2L, pipelineSelectionId);
         assertEquals(newFilters, pipelineSelections.viewFilters());
@@ -123,7 +123,7 @@ public class PipelineSelectionsServiceTest {
         final Filters newFilters = Filters.single(blacklist("pipelineX", "pipeline3"));
         assertNotEquals(newFilters, pipelineSelections.viewFilters()); // sanity check
 
-        pipelineSelectionsService.persistPipelineSelections("123", null, newFilters);
+        pipelineSelectionsService.save("123", null, newFilters);
 
         assertEquals(FIXED_DATE, pipelineSelections.lastUpdated());
         verify(pipelineRepository).findPipelineSelectionsById("123");
@@ -135,7 +135,7 @@ public class PipelineSelectionsServiceTest {
         enableSecurity();
         when(pipelineRepository.findPipelineSelectionsByUserId(2L)).thenReturn(PipelineSelections.ALL);
 
-        pipelineSelectionsService.updateUserPipelineSelections(null, 2L, new CaseInsensitiveString("newly-created-pipeline"));
+        pipelineSelectionsService.update(null, 2L, new CaseInsensitiveString("newly-created-pipeline"));
 
         verify(pipelineRepository, never()).saveSelectedPipelines(any(PipelineSelections.class));
     }
@@ -147,10 +147,10 @@ public class PipelineSelectionsServiceTest {
         PipelineSelections pipelineSelections = PipelineSelectionsHelper.with(Collections.singletonList("pip1"));
         when(pipelineRepository.findPipelineSelectionsById("123")).thenReturn(pipelineSelections);
 
-        assertEquals(pipelineSelections, pipelineSelectionsService.loadPipelineSelections("123", null));
+        assertEquals(pipelineSelections, pipelineSelectionsService.load("123", null));
 
         // control case
-        assertEquals(PipelineSelections.ALL, pipelineSelectionsService.loadPipelineSelections("345", null));
+        assertEquals(PipelineSelections.ALL, pipelineSelectionsService.load("345", null));
     }
 
     @Test
@@ -162,7 +162,7 @@ public class PipelineSelectionsServiceTest {
 
         when(pipelineRepository.findPipelineSelectionsByUserId(loser.getId())).thenReturn(pipelineSelections);
 
-        assertEquals(pipelineSelections, pipelineSelectionsService.loadPipelineSelections(null, loser.getId()));
+        assertEquals(pipelineSelections, pipelineSelectionsService.load(null, loser.getId()));
     }
 
     @Test
@@ -172,7 +172,7 @@ public class PipelineSelectionsServiceTest {
         User user = getUser("loser");
         when(pipelineRepository.findPipelineSelectionsByUserId(user.getId())).thenReturn(null);
 
-        assertEquals(PipelineSelections.ALL, pipelineSelectionsService.loadPipelineSelections(null, user.getId()));
+        assertEquals(PipelineSelections.ALL, pipelineSelectionsService.load(null, user.getId()));
     }
 
     @Test
@@ -181,7 +181,7 @@ public class PipelineSelectionsServiceTest {
 
         when(pipelineRepository.findPipelineSelectionsById("5")).thenReturn(null);
 
-        PipelineSelections selectedPipelines = pipelineSelectionsService.loadPipelineSelections("5", null);
+        PipelineSelections selectedPipelines = pipelineSelectionsService.load("5", null);
         assertEquals(PipelineSelections.ALL, selectedPipelines);
     }
 

--- a/server/webapp/WEB-INF/rails.new/app/controllers/admin/pipelines_controller.rb
+++ b/server/webapp/WEB-INF/rails.new/app/controllers/admin/pipelines_controller.rb
@@ -117,7 +117,7 @@ module Admin
         pipeline_pause_service.pause(@pipeline.name().to_s, "Under construction", current_user) if @update_result.isSuccessful() #The if check is important now as we want consistency across config and db save. If config save fails, we do not want to insert it in the DB.
 
         if @update_result.isSuccessful()
-          pipeline_selections_service.updateUserPipelineSelections(cookies[:selected_pipelines], current_user_entity_id, @pipeline.name())
+          pipeline_selections_service.update(cookies[:selected_pipelines], current_user_entity_id, @pipeline.name())
         end
 
         @original_cruise_config = @cruise_config
@@ -192,7 +192,7 @@ module Admin
         pipeline_pause_service.pause(@pipeline.name().to_s, "Under construction", current_user) if @update_result.isSuccessful()
 
         if @update_result.isSuccessful()
-          pipeline_selections_service.updateUserPipelineSelections(cookies[:selected_pipelines], current_user_entity_id, @pipeline.name())
+          pipeline_selections_service.update(cookies[:selected_pipelines], current_user_entity_id, @pipeline.name())
         end
       end
     end

--- a/server/webapp/WEB-INF/rails.new/app/controllers/api_v1/dashboard_controller.rb
+++ b/server/webapp/WEB-INF/rails.new/app/controllers/api_v1/dashboard_controller.rb
@@ -20,7 +20,7 @@ module ApiV1
 
     def dashboard
       # TODO: What happens when there is no cookie!
-      pipeline_selections = pipeline_selections_service.getPersistedSelectedPipelines(cookies[:selected_pipelines], current_user_entity_id)
+      pipeline_selections = pipeline_selections_service.load(cookies[:selected_pipelines], current_user_entity_id)
       pipeline_groups     = pipeline_history_service.allActivePipelineInstances(current_user, pipeline_selections)
       presenters          = Dashboard::PipelineGroupsRepresenter.new(pipeline_groups)
 

--- a/server/webapp/WEB-INF/rails.new/app/controllers/pipelines_controller.rb
+++ b/server/webapp/WEB-INF/rails.new/app/controllers/pipelines_controller.rb
@@ -59,7 +59,7 @@ class PipelinesController < ApplicationController
   end
 
   def select_pipelines
-    pipeline_selections_id = pipeline_selections_service.persistSelectedPipelines(cookies[:selected_pipelines], current_user_entity_id, ((params[:selector]||{})[:pipeline]||[]), !params[:show_new_pipelines].nil?)
+    pipeline_selections_id = pipeline_selections_service.save(cookies[:selected_pipelines], current_user_entity_id, ((params[:selector]||{})[:pipeline]||[]), !params[:show_new_pipelines].nil?)
     cookies[:selected_pipelines] = {:value => pipeline_selections_id, :expires => 1.year.from_now.beginning_of_day} if !mycruise_available?
     render :nothing => true
   end
@@ -88,7 +88,7 @@ class PipelinesController < ApplicationController
   end
 
   def load_pipeline_related_information
-    @pipeline_selections = pipeline_selections_service.getPersistedSelectedPipelines(cookies[:selected_pipelines], current_user_entity_id)
+    @pipeline_selections = pipeline_selections_service.load(cookies[:selected_pipelines], current_user_entity_id)
     @pipeline_groups = pipeline_history_service.allActivePipelineInstances(current_user, @pipeline_selections)
     @pipeline_configs = pipeline_config_service.viewableGroupsFor(current_user)
   end

--- a/server/webapp/WEB-INF/rails.new/spec/controllers/admin/pipelines_controller_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/controllers/admin/pipelines_controller_spec.rb
@@ -419,7 +419,7 @@ describe Admin::PipelinesController do
       @pause_info = PipelinePauseInfo.paused("just for fun", "loser")
       allow(@pipeline_pause_service).to receive(:pipelinePauseInfo).with("new-pip").and_return(@pause_info)
 
-      allow(@pipeline_selections_service).to receive(:updateUserPipelineSelections)
+      allow(@pipeline_selections_service).to receive(:update)
       allow(controller).to receive(:cookies).and_return({})
       allow(@security_service).to receive(:modifiableGroupsForUser).with(@user).and_return(["group1", "group2"])
     end
@@ -468,7 +468,7 @@ describe Admin::PipelinesController do
 
       expect(@go_config_service).to receive(:getCurrentConfig).twice.and_return(GoConfigCloner.new().deepClone(@cruise_config))
       expect(@pipeline_pause_service).to receive(:pause).with("new-pip", "Under construction", @user)
-      expect(@pipeline_selections_service).to receive(:updateUserPipelineSelections).with(selected_pipeline_id, current_user_entity_id, CaseInsensitiveString.new(pipeline_name))
+      expect(@pipeline_selections_service).to receive(:update).with(selected_pipeline_id, current_user_entity_id, CaseInsensitiveString.new(pipeline_name))
 
       stub_save_for_success
       post :create, :config_md5 => "1234abcd", :pipeline_group => {:group => "new-group", :pipeline => {:name => pipeline_name}}
@@ -484,7 +484,7 @@ describe Admin::PipelinesController do
       pipeline_name = "new-pip"
 
       expect(@go_config_service).to receive(:getCurrentConfig).twice.and_return(GoConfigCloner.new().deepClone(@cruise_config))
-      expect(@pipeline_selections_service).not_to receive(:updateUserPipelineSelections)
+      expect(@pipeline_selections_service).not_to receive(:update)
 
       stub_save_for_validation_error do |result, _, _|
         result.forbidden("unauthorized", nil)
@@ -753,7 +753,7 @@ describe Admin::PipelinesController do
     describe "save_clone" do
       before :each do
         allow(@pipeline_pause_service).to receive(:pause)
-        allow(@pipeline_selections_service).to receive(:updateUserPipelineSelections)
+        allow(@pipeline_selections_service).to receive(:update)
       end
 
       it "should save cloned pipeline successfully" do
@@ -813,7 +813,7 @@ describe Admin::PipelinesController do
         selected_pipeline_id = "456"
         allow(controller).to receive(:cookies).and_return(cookiejar={:selected_pipelines => selected_pipeline_id})
 
-        expect(@pipeline_selections_service).to receive(:updateUserPipelineSelections).with(selected_pipeline_id, current_user_entity_id, CaseInsensitiveString.new("new-pip"))
+        expect(@pipeline_selections_service).to receive(:update).with(selected_pipeline_id, current_user_entity_id, CaseInsensitiveString.new("new-pip"))
 
         post :save_clone, :config_md5 => "1234abcd", :pipeline_group => {:group => "group1", :pipeline => {:name => "new-pip"}}, :pipeline_name => @pipeline.name().to_s
       end
@@ -825,7 +825,7 @@ describe Admin::PipelinesController do
 
         post :save_clone, :config_md5 => "1234abcd", :pipeline_group => {:group => "group1", :pipeline => {:name => "new-pip"}}, :pipeline_name => @pipeline.name().to_s
 
-        expect(@pipeline_selections_service).to_not receive(:updateUserPipelineSelections)
+        expect(@pipeline_selections_service).to_not receive(:update)
       end
     end
   end

--- a/server/webapp/WEB-INF/rails.new/spec/controllers/api_v1/dashboard_controller_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/controllers/api_v1/dashboard_controller_spec.rb
@@ -33,7 +33,7 @@ describe ApiV1::DashboardController do
   describe "dashboard" do
     it 'should get dashboard json' do
       @pipeline_group_models.add(PipelineGroupModel.new("bla"))
-      expect(@pipeline_selections_service).to receive(:getPersistedSelectedPipelines).with(@selected_pipeline_id, @user_id).and_return(selections=PipelineSelections.new)
+      expect(@pipeline_selections_service).to receive(:load).with(@selected_pipeline_id, @user_id).and_return(selections=PipelineSelections.new)
       expect(@pipeline_history_service).to receive(:allActivePipelineInstances).with(@user, selections).and_return(@pipeline_group_models)
 
       get_with_api_header :dashboard
@@ -43,7 +43,7 @@ describe ApiV1::DashboardController do
     end
 
     it 'should get empty json when dashboard is empty' do
-      expect(@pipeline_selections_service).to receive(:getPersistedSelectedPipelines).with(@selected_pipeline_id, @user_id).and_return(selections=PipelineSelections.new)
+      expect(@pipeline_selections_service).to receive(:load).with(@selected_pipeline_id, @user_id).and_return(selections=PipelineSelections.new)
       expect(@pipeline_history_service).to receive(:allActivePipelineInstances).with(@user, selections).and_return(@pipeline_group_models)
 
       get_with_api_header :dashboard

--- a/server/webapp/WEB-INF/rails.new/spec/controllers/pipelines_controller_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/controllers/pipelines_controller_spec.rb
@@ -88,7 +88,7 @@ describe PipelinesController do
 
     it "should load the dashboard" do
 
-      expect(@pipeline_selections_service).to receive(:getPersistedSelectedPipelines).with(@selected_pipeline_id,@user_id).and_return(selections=PipelineSelections.new)
+      expect(@pipeline_selections_service).to receive(:load).with(@selected_pipeline_id,@user_id).and_return(selections=PipelineSelections.new)
       expect(@pipeline_history_service).to receive(:allActivePipelineInstances).with(@user,selections).and_return(:pipeline_group_models)
       expect(@pipeline_config_service).to receive(:viewableGroupsFor).with(@user).and_return(viewable_groups=BasicPipelineConfigs.new)
       expect(@security_service).to receive(:canCreatePipelines).with(@user).and_return(true)
@@ -109,7 +109,7 @@ describe PipelinesController do
       pipeline_group_models = java.util.ArrayList.new
       pipeline_group_models.add(PipelineGroupModel.new("bla"))
 
-      expect(@pipeline_selections_service).to receive(:getPersistedSelectedPipelines).with(@selected_pipeline_id,@user_id).and_return(selections=PipelineSelections.new)
+      expect(@pipeline_selections_service).to receive(:load).with(@selected_pipeline_id,@user_id).and_return(selections=PipelineSelections.new)
       expect(@pipeline_history_service).to receive(:allActivePipelineInstances).with(@user,selections).and_return(pipeline_group_models)
       expect(@pipeline_config_service).to receive(:viewableGroupsFor).with(@user).and_return(viewable_groups=BasicPipelineConfigs.new())
       expect(@security_service).to receive(:canCreatePipelines).with(@user).and_return(true)
@@ -123,7 +123,7 @@ describe PipelinesController do
       pipeline_group_models = java.util.ArrayList.new
       pipeline_group_models.add(PipelineGroupModel.new("bla"))
 
-      expect(@pipeline_selections_service).to receive(:getPersistedSelectedPipelines).with(@selected_pipeline_id, @user_id).and_return(selections=PipelineSelections.new)
+      expect(@pipeline_selections_service).to receive(:load).with(@selected_pipeline_id, @user_id).and_return(selections=PipelineSelections.new)
       expect(@pipeline_history_service).to receive(:allActivePipelineInstances).with(@user,selections).and_return(pipeline_group_models)
       expect(@security_service).to receive(:canCreatePipelines).with(@user).and_return(false)
       expect(@pipeline_config_service).to receive(:viewableGroupsFor).with(@user).and_return(viewable_groups=BasicPipelineConfigs.new())
@@ -138,7 +138,7 @@ describe PipelinesController do
       pipeline_group_models.add(PipelineGroupModel.new("bla"))
       viewable_groups = PipelineConfigMother::createGroup("blah", [PipelineConfigMother::createPipelineConfig("pip1", "stage1", ["job1"].to_java(:string))].to_java('com.thoughtworks.go.config.PipelineConfig'))
 
-      expect(@pipeline_selections_service).to receive(:getPersistedSelectedPipelines).with(@selected_pipeline_id,@user_id).and_return(selections=PipelineSelections.new)
+      expect(@pipeline_selections_service).to receive(:load).with(@selected_pipeline_id,@user_id).and_return(selections=PipelineSelections.new)
       expect(@pipeline_history_service).to receive(:allActivePipelineInstances).with(@user, selections).and_return(pipeline_group_models)
       expect(@pipeline_config_service).to receive(:viewableGroupsFor).with(@user).and_return(viewable_groups)
 
@@ -262,7 +262,7 @@ describe PipelinesController do
     end
 
     it "should set cookies for a selected pipelines" do
-      expect(@pipeline_selections_service).to receive(:persistSelectedPipelines).with("456", @user_id, ["pipeline1", "pipeline2"], true).and_return(1234)
+      expect(@pipeline_selections_service).to receive(:save).with("456", @user_id, ["pipeline1", "pipeline2"], true).and_return(1234)
       allow(controller).to receive(:cookies).and_return(cookiejar={:selected_pipelines => "456"})
 
       post "select_pipelines", "selector" => {:pipeline=>["pipeline1", "pipeline2"]}, show_new_pipelines: "true"
@@ -271,7 +271,7 @@ describe PipelinesController do
     end
 
     it "should set cookies when no pipelines selected" do
-      expect(@pipeline_selections_service).to receive(:persistSelectedPipelines).with("456", @user_id, [], true).and_return(1234)
+      expect(@pipeline_selections_service).to receive(:save).with("456", @user_id, [], true).and_return(1234)
       allow(controller).to receive(:cookies).and_return(cookiejar={:selected_pipelines => "456"})
 
       post "select_pipelines", "selector" => {}, show_new_pipelines: "true"
@@ -280,7 +280,7 @@ describe PipelinesController do
     end
 
     it "should set cookies when no pipelines or groups selected" do
-      expect(@pipeline_selections_service).to receive(:persistSelectedPipelines).with("456", @user_id, [], true).and_return(1234)
+      expect(@pipeline_selections_service).to receive(:save).with("456", @user_id, [], true).and_return(1234)
       allow(controller).to receive(:cookies).and_return(cookiejar={:selected_pipelines => "456"})
 
       post "select_pipelines", show_new_pipelines: "true"
@@ -290,14 +290,14 @@ describe PipelinesController do
 
     it "should persist the value of 'show_new_pipelines' when it is true" do
       allow(controller).to receive(:cookies).and_return(cookiejar={:selected_pipelines => "456"})
-      expect(@pipeline_selections_service).to receive(:persistSelectedPipelines).with("456", @user_id, ["pipeline1", "pipeline2"], true).and_return(1234)
+      expect(@pipeline_selections_service).to receive(:save).with("456", @user_id, ["pipeline1", "pipeline2"], true).and_return(1234)
 
       post "select_pipelines", "selector" => { pipeline: ["pipeline1", "pipeline2"]}, show_new_pipelines: "true"
     end
 
     it "should persist the value of 'show_new_pipelines' when it is false" do
       allow(controller).to receive(:cookies).and_return(cookiejar={:selected_pipelines => "456"})
-      expect(@pipeline_selections_service).to receive(:persistSelectedPipelines).with("456", @user_id, ["pipeline1", "pipeline2"], false).and_return(1234)
+      expect(@pipeline_selections_service).to receive(:save).with("456", @user_id, ["pipeline1", "pipeline2"], false).and_return(1234)
 
       post "select_pipelines", "selector" => { pipeline: ["pipeline1", "pipeline2"]}
     end
@@ -309,7 +309,7 @@ describe PipelinesController do
     end
 
     it "should not update set cookies for selected pipelines when security enabled" do
-      expect(@pipeline_selections_service).to receive(:persistSelectedPipelines).with("456", @user_id, ["pipeline1", "pipeline2"], true).and_return(1234)
+      expect(@pipeline_selections_service).to receive(:save).with("456", @user_id, ["pipeline1", "pipeline2"], true).and_return(1234)
       allow(controller).to receive(:cookies).and_return(cookiejar={:selected_pipelines => "456"})
 
       post "select_pipelines", "selector" => {:pipeline=>["pipeline1", "pipeline2"]}, show_new_pipelines: "true"
@@ -318,7 +318,7 @@ describe PipelinesController do
     end
 
     it "should not set cookies when selected pipeline cookie is absent when security enabled" do
-      expect(@pipeline_selections_service).to receive(:persistSelectedPipelines).with(nil, @user_id, [], true).and_return(1234)
+      expect(@pipeline_selections_service).to receive(:save).with(nil, @user_id, [], true).and_return(1234)
       allow(controller).to receive(:cookies).and_return(cookiejar = {})
 
       post "select_pipelines", "selector" => {}, show_new_pipelines: "true"
@@ -329,7 +329,7 @@ describe PipelinesController do
 
   describe "set_tab_name" do
     it "should set tab name" do
-      expect(@pipeline_selections_service).to receive(:getPersistedSelectedPipelines).with(@selected_pipeline_id,@user_id).and_return(selections=PipelineSelections.new)
+      expect(@pipeline_selections_service).to receive(:load).with(@selected_pipeline_id,@user_id).and_return(selections=PipelineSelections.new)
       expect(@pipeline_history_service).to receive(:allActivePipelineInstances).with(@user,selections).and_return(:pipeline_group_models)
       expect(@pipeline_config_service).to receive(:viewableGroupsFor).with(@user).and_return(viewable_groups=BasicPipelineConfigs.new)
       expect(@security_service).to receive(:canCreatePipelines).with(@user).and_return(true)


### PR DESCRIPTION
Missed some old method name references in ruby code from #4922 that prevents the smoke tests from loading the dashboard (I assume the _old_ dashboard as the new one seems to work just fine).

So, in addition to fixing old refs, I also renamed the methods to simpler, more concise names. Let's see what tests break after this.