### PR TITLE
Personalized Views Filtering by Pipeline State

### DIFF
--- a/api/api-pipeline-selection-v1/src/test/groovy/com/thoughtworks/go/apiv1/pipelineselection/PipelineSelectionControllerDelegateTest.groovy
+++ b/api/api-pipeline-selection-v1/src/test/groovy/com/thoughtworks/go/apiv1/pipelineselection/PipelineSelectionControllerDelegateTest.groovy
@@ -121,7 +121,7 @@ class PipelineSelectionControllerDelegateTest implements SecurityServiceTrait, C
 
         def payload = [
           filters: [
-            [name: 'Default', type: 'blacklist', pipelines: ['build-linux', 'build-windows']]
+            [name: 'Default', state: [], type: 'blacklist', pipelines: ['build-linux', 'build-windows']]
           ]
         ]
 
@@ -150,7 +150,7 @@ class PipelineSelectionControllerDelegateTest implements SecurityServiceTrait, C
 
         def payload = [
           filters: [
-            [name: 'Default', type: 'blacklist', pipelines: ['build-linux', 'build-windows']]
+            [name: 'Default', state: [], type: 'blacklist', pipelines: ['build-linux', 'build-windows']]
           ]
         ]
 
@@ -182,7 +182,7 @@ class PipelineSelectionControllerDelegateTest implements SecurityServiceTrait, C
 
         def payload = [
           filters: [
-            [name: 'Default', type: 'blacklist', pipelines: ['build-linux', 'build-windows']]
+            [name: 'Default', state: [], type: 'blacklist', pipelines: ['build-linux', 'build-windows']]
           ]
         ]
 

--- a/api/api-pipeline-selection-v1/src/test/groovy/com/thoughtworks/go/apiv1/pipelineselection/representers/PipelineSelectionsRepresenterTest.groovy
+++ b/api/api-pipeline-selection-v1/src/test/groovy/com/thoughtworks/go/apiv1/pipelineselection/representers/PipelineSelectionsRepresenterTest.groovy
@@ -49,7 +49,7 @@ class PipelineSelectionsRepresenterTest {
           grp1: ["pipeline3", "build-linux", "build-windows"],
           grp2: ["pipeline1", "pipeline2"]
         ],
-        filters  : [[name: 'Default', type: 'blacklist', pipelines: ['build-linux', 'build-windows']]]
+        filters  : [[name: 'Default', state:[], type: 'blacklist', pipelines: ['build-linux', 'build-windows']]]
       ])
     }
 
@@ -71,7 +71,7 @@ class PipelineSelectionsRepresenterTest {
         pipelines: [
           grp2: ["pipeline1", "pipeline2", "build-linux", "build-windows"]
         ],
-        filters  : [[name: 'Default', type: 'blacklist', pipelines: ['build-linux', 'build-windows']]]
+        filters  : [[name: 'Default', state: [], type: 'blacklist', pipelines: ['build-linux', 'build-windows']]]
       ])
     }
   }

--- a/api/api-pipeline-selection-v1/src/test/groovy/com/thoughtworks/go/testhelpers/FiltersHelper.groovy
+++ b/api/api-pipeline-selection-v1/src/test/groovy/com/thoughtworks/go/testhelpers/FiltersHelper.groovy
@@ -24,6 +24,6 @@ import static com.thoughtworks.go.server.domain.user.DashboardFilter.DEFAULT_NAM
 
 class FiltersHelper {
   static Filters blacklist(List<String> pipelines) {
-    return Filters.single(new BlacklistFilter(DEFAULT_NAME, CaseInsensitiveString.list(pipelines), null))
+    return Filters.single(new BlacklistFilter(DEFAULT_NAME, CaseInsensitiveString.list(pipelines), new HashSet<>()))
   }
 }

--- a/api/api-pipeline-selection-v1/src/test/groovy/com/thoughtworks/go/testhelpers/FiltersHelper.groovy
+++ b/api/api-pipeline-selection-v1/src/test/groovy/com/thoughtworks/go/testhelpers/FiltersHelper.groovy
@@ -24,6 +24,6 @@ import static com.thoughtworks.go.server.domain.user.DashboardFilter.DEFAULT_NAM
 
 class FiltersHelper {
   static Filters blacklist(List<String> pipelines) {
-    return Filters.single(new BlacklistFilter(DEFAULT_NAME, CaseInsensitiveString.list(pipelines)))
+    return Filters.single(new BlacklistFilter(DEFAULT_NAME, CaseInsensitiveString.list(pipelines), null))
   }
 }

--- a/domain/src/main/java/com/thoughtworks/go/presentation/pipelinehistory/JobHistoryItem.java
+++ b/domain/src/main/java/com/thoughtworks/go/presentation/pipelinehistory/JobHistoryItem.java
@@ -88,6 +88,10 @@ public class JobHistoryItem implements BuildStateAware {
         return result == JobResult.Passed;
     }
 
+    public boolean hasFailed() {
+        return result.isFailed();
+    }
+
     public boolean isRunning() {
         return state == JobState.Assigned || state == JobState.Preparing || state == JobState.Building || state == JobState.Completing || state == JobState.Scheduled;
     }

--- a/domain/src/main/java/com/thoughtworks/go/presentation/pipelinehistory/StageInstanceModel.java
+++ b/domain/src/main/java/com/thoughtworks/go/presentation/pipelinehistory/StageInstanceModel.java
@@ -229,6 +229,13 @@ public class StageInstanceModel implements StageConfigurationModel {
         return true;
     }
 
+    public boolean hasFailed() {
+        for (JobHistoryItem jobHistoryItem : jobHistory) {
+            if(jobHistoryItem.hasFailed()) return true;
+        }
+        return false;
+    }
+
     public boolean isRunning() {
         for (JobHistoryItem jobHistoryItem : jobHistory) {
             if(jobHistoryItem.isRunning()) return true;

--- a/server/src/main/java/com/thoughtworks/go/server/dashboard/GoDashboardPipeline.java
+++ b/server/src/main/java/com/thoughtworks/go/server/dashboard/GoDashboardPipeline.java
@@ -20,7 +20,9 @@ import com.thoughtworks.go.config.CaseInsensitiveString;
 import com.thoughtworks.go.config.TrackingTool;
 import com.thoughtworks.go.config.remote.ConfigOrigin;
 import com.thoughtworks.go.config.security.Permissions;
+import com.thoughtworks.go.presentation.pipelinehistory.PipelineInstanceModel;
 import com.thoughtworks.go.presentation.pipelinehistory.PipelineModel;
+import com.thoughtworks.go.presentation.pipelinehistory.StageInstanceModel;
 
 import java.util.Optional;
 
@@ -60,6 +62,14 @@ public class GoDashboardPipeline {
 
     public Optional<TrackingTool> getTrackingTool() {
         return Optional.ofNullable(trackingTool);
+    }
+
+    public StageInstanceModel getLatestStage() {
+        PipelineInstanceModel latestPipelineInstance = pipelineModel.getLatestPipelineInstance();
+        if (latestPipelineInstance == null) {
+            return null;
+        }
+        return latestPipelineInstance.latestStage();
     }
 
     public CaseInsensitiveString name() {

--- a/server/src/main/java/com/thoughtworks/go/server/datamigration/DataMigrationRunner.java
+++ b/server/src/main/java/com/thoughtworks/go/server/datamigration/DataMigrationRunner.java
@@ -29,6 +29,7 @@ public class DataMigrationRunner {
 
         try (Connection cxn = ds.getConnection()) {
             exec(cxn, M001.convertPipelineSelectionsToFilters());
+            exec(cxn, M002.ensureFilterStateIsNotNull());
         }
 
         System.out.println("Data migrations completed.");

--- a/server/src/main/java/com/thoughtworks/go/server/datamigration/M002.java
+++ b/server/src/main/java/com/thoughtworks/go/server/datamigration/M002.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2018 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.server.datamigration;
+
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+
+import java.lang.reflect.Type;
+import java.sql.*;
+import java.util.HashMap;
+import java.util.List;
+
+public class M002 {
+    private static final Type FILTERS_TYPE = new TypeToken<HashMap<String, List<Filter>>>() {}.getType();
+    private static final String ID = "id";
+    private static final String FILTERS = "filters";
+    private static final int SCHEMA = 2;
+    private static final Gson GSON = new Gson();
+
+    static Migration ensureFilterStateIsNotNull() {
+        return (cxn) -> {
+            if (!required(cxn)) return;
+
+            try (Statement s = cxn.createStatement()) {
+                final ResultSet rs = s.executeQuery("SELECT id, filters FROM pipelineselections WHERE version = 1");
+                while (rs.next()) {
+                    perform(cxn, rs.getLong(ID), rs.getString(FILTERS));
+                }
+            }
+        };
+    }
+
+    static void perform(Connection cxn, long id, String filters) throws SQLException {
+        try (PreparedStatement ps = cxn.prepareStatement("UPDATE pipelineselections SET version = ?, filters = ? WHERE id = ?")) {
+            ps.setInt(1, SCHEMA);
+            ps.setString(2, addStateIfNull(filters));
+            ps.setLong(3, id);
+            ps.executeUpdate();
+        }
+    }
+
+    static String addStateIfNull(String rawFilters) {
+        HashMap<String, List<Filter>> filters = GSON.fromJson(rawFilters, FILTERS_TYPE);
+
+        for (Filter filter : filters.get("filters")) {
+            filter.setStateIfNull();
+        }
+
+        return GSON.toJson(filters);
+    }
+
+    static boolean required(Connection cxn) throws SQLException {
+        try (Statement s = cxn.createStatement()) {
+            final ResultSet rs = s.executeQuery("SELECT COUNT(*) as remaining FROM pipelineselections WHERE version = 1");
+            rs.next();
+
+            return rs.getInt("remaining") > 0;
+        }
+    }
+
+    private static class Filter {
+        String name;
+        String type;
+        String[] pipelines;
+        String[] state;
+
+        public void setStateIfNull() {
+            if (state == null) {
+                state = new String[]{};
+            }
+        }
+    }
+}

--- a/server/src/main/java/com/thoughtworks/go/server/domain/user/BlacklistFilter.java
+++ b/server/src/main/java/com/thoughtworks/go/server/domain/user/BlacklistFilter.java
@@ -17,18 +17,20 @@
 package com.thoughtworks.go.server.domain.user;
 
 import com.thoughtworks.go.config.CaseInsensitiveString;
+import com.thoughtworks.go.presentation.pipelinehistory.StageInstanceModel;
 
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 
-public class BlacklistFilter implements DashboardFilter {
+public class BlacklistFilter extends PipelinesFilter implements DashboardFilter {
     private final String name;
-    private final List<CaseInsensitiveString> pipelines;
 
-    public BlacklistFilter(String name, List<CaseInsensitiveString> pipelines) {
+
+    public BlacklistFilter(String name, List<CaseInsensitiveString> pipelines, Set<String> state) {
+        super(state, pipelines);
         this.name = name;
-        this.pipelines = DashboardFilter.enforceList(pipelines);
     }
 
     public List<CaseInsensitiveString> pipelines() {
@@ -41,8 +43,13 @@ public class BlacklistFilter implements DashboardFilter {
     }
 
     @Override
-    public boolean isPipelineVisible(CaseInsensitiveString pipeline) {
-        return null == pipelines || pipelines.isEmpty() || !pipelines.contains(pipeline);
+    public Set<String> state() {
+        return state;
+    }
+
+    @Override
+    public boolean isPipelineVisible(CaseInsensitiveString pipeline, StageInstanceModel stage) {
+        return !filterByPipelineList(pipeline) && filterByState(stage);
     }
 
     @Override

--- a/server/src/main/java/com/thoughtworks/go/server/domain/user/DashboardFilter.java
+++ b/server/src/main/java/com/thoughtworks/go/server/domain/user/DashboardFilter.java
@@ -17,10 +17,9 @@
 package com.thoughtworks.go.server.domain.user;
 
 import com.thoughtworks.go.config.CaseInsensitiveString;
+import com.thoughtworks.go.presentation.pipelinehistory.StageInstanceModel;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
 
 public interface DashboardFilter {
     static <T> List<T> enforceList(List<T> list) {
@@ -28,10 +27,14 @@ public interface DashboardFilter {
     }
 
     String DEFAULT_NAME = "Default";
-
+    String BUILDING_STATE = "building";
+    String FAILED_STATE = "failing";
+    Set<String> VALID_STATES = new HashSet<String>(Arrays.asList(BUILDING_STATE, FAILED_STATE));
     String name();
 
-    boolean isPipelineVisible(CaseInsensitiveString pipeline);
+    Set<String> state();
+
+    boolean isPipelineVisible(CaseInsensitiveString pipeline, StageInstanceModel goDashboardPipeline);
 
     /**
      * Idempotent operation on filter to allow a specified pipeline to be visible

--- a/server/src/main/java/com/thoughtworks/go/server/domain/user/DashboardFilter.java
+++ b/server/src/main/java/com/thoughtworks/go/server/domain/user/DashboardFilter.java
@@ -29,7 +29,7 @@ public interface DashboardFilter {
     String DEFAULT_NAME = "Default";
     String BUILDING_STATE = "building";
     String FAILED_STATE = "failing";
-    Set<String> VALID_STATES = new HashSet<String>(Arrays.asList(BUILDING_STATE, FAILED_STATE));
+    Set<String> VALID_STATES = new HashSet<>(Arrays.asList(BUILDING_STATE, FAILED_STATE));
     String name();
 
     Set<String> state();

--- a/server/src/main/java/com/thoughtworks/go/server/domain/user/FilterValidator.java
+++ b/server/src/main/java/com/thoughtworks/go/server/domain/user/FilterValidator.java
@@ -18,7 +18,8 @@ package com.thoughtworks.go.server.domain.user;
 
 import org.apache.commons.lang3.StringUtils;
 
-import java.util.*;
+import java.util.Map;
+import java.util.Set;
 import java.util.regex.Pattern;
 
 import static com.thoughtworks.go.server.domain.user.DashboardFilter.*;
@@ -54,10 +55,10 @@ class FilterValidator {
     }
 
     private static void validateState(Set<String> state) {
-        if (state != null) {
-            if (!VALID_STATES.containsAll(state))
-                throw new FilterValidationException(MSG_INVALID_STATES);
-        }
+        if (state == null)
+            throw new FilterValidationException("Filter state should never be NULL");
+        if (!state.isEmpty() && !VALID_STATES.containsAll(state))
+            throw new FilterValidationException(MSG_INVALID_STATES);
     }
 
     static void validateNameFormat(String name) {

--- a/server/src/main/java/com/thoughtworks/go/server/domain/user/FilterValidator.java
+++ b/server/src/main/java/com/thoughtworks/go/server/domain/user/FilterValidator.java
@@ -18,10 +18,10 @@ package com.thoughtworks.go.server.domain.user;
 
 import org.apache.commons.lang3.StringUtils;
 
-import java.util.Map;
+import java.util.*;
 import java.util.regex.Pattern;
 
-import static com.thoughtworks.go.server.domain.user.DashboardFilter.DEFAULT_NAME;
+import static com.thoughtworks.go.server.domain.user.DashboardFilter.*;
 
 class FilterValidator {
 
@@ -39,6 +39,7 @@ class FilterValidator {
     static final String MSG_NAME_FORMAT = "Filter name is only allowed to contain letters, numbers, spaces, and punctuation marks";
     static final String MSG_MISSING_NAME = "Missing filter name";
     static final String MSG_NO_DEFAULT_FILTER = "Missing default filter";
+    static final String MSG_INVALID_STATES = "An invalid filter state has been provided. Only " + BUILDING_STATE + " and " + FAILED_STATE + " are supported";
 
     static void validateDefaultIsPresent(Map<String, DashboardFilter> current) {
         if (!current.containsKey(DEFAULT_NAME.toLowerCase())) throw new FilterValidationException(MSG_NO_DEFAULT_FILTER);
@@ -49,6 +50,14 @@ class FilterValidator {
         validateNamePresent(name);
         validateNameFormat(name);
         validateNameIsUnique(current, name);
+        validateState(filter.state());
+    }
+
+    private static void validateState(Set<String> state) {
+        if (state != null) {
+            if (!VALID_STATES.containsAll(state))
+                throw new FilterValidationException(MSG_INVALID_STATES);
+        }
     }
 
     static void validateNameFormat(String name) {

--- a/server/src/main/java/com/thoughtworks/go/server/domain/user/Filters.java
+++ b/server/src/main/java/com/thoughtworks/go/server/domain/user/Filters.java
@@ -35,7 +35,7 @@ public class Filters {
             registerTypeAdapter(CaseInsensitiveString.class, new CaseInsensitiveStringSerializer()).
             create();
 
-    public static final DashboardFilter WILDCARD_FILTER = new BlacklistFilter(DEFAULT_NAME, Collections.emptyList(), null);
+    public static final DashboardFilter WILDCARD_FILTER = new BlacklistFilter(DEFAULT_NAME, Collections.emptyList(), new HashSet<>());
 
     public static Filters fromJson(String json) {
         final Filters filters = GSON.fromJson(json, Filters.class);

--- a/server/src/main/java/com/thoughtworks/go/server/domain/user/Filters.java
+++ b/server/src/main/java/com/thoughtworks/go/server/domain/user/Filters.java
@@ -35,7 +35,7 @@ public class Filters {
             registerTypeAdapter(CaseInsensitiveString.class, new CaseInsensitiveStringSerializer()).
             create();
 
-    public static final DashboardFilter WILDCARD_FILTER = new BlacklistFilter(DEFAULT_NAME, Collections.emptyList());
+    public static final DashboardFilter WILDCARD_FILTER = new BlacklistFilter(DEFAULT_NAME, Collections.emptyList(), null);
 
     public static Filters fromJson(String json) {
         final Filters filters = GSON.fromJson(json, Filters.class);

--- a/server/src/main/java/com/thoughtworks/go/server/domain/user/PipelineSelections.java
+++ b/server/src/main/java/com/thoughtworks/go/server/domain/user/PipelineSelections.java
@@ -110,7 +110,7 @@ public class PipelineSelections extends PersistentObject implements Serializable
 
     @Deprecated // TODO: remove when removing old dashboard
     public boolean includesPipeline(CaseInsensitiveString pipelineName) {
-        return namedFilter(DEFAULT_NAME).isPipelineVisible(pipelineName);
+        return namedFilter(DEFAULT_NAME).isPipelineVisible(pipelineName, null);
     }
 
     @Deprecated // TODO: remove when removing old dashboard

--- a/server/src/main/java/com/thoughtworks/go/server/domain/user/PipelineSelections.java
+++ b/server/src/main/java/com/thoughtworks/go/server/domain/user/PipelineSelections.java
@@ -31,7 +31,7 @@ import java.util.Date;
 import static com.thoughtworks.go.server.domain.user.DashboardFilter.DEFAULT_NAME;
 
 public class PipelineSelections extends PersistentObject implements Serializable {
-    public static final int CURRENT_SCHEMA_VERSION = 1;
+    public static final int CURRENT_SCHEMA_VERSION = 2;
 
     public static final PipelineSelections ALL = new PipelineSelections(Filters.defaults(), null, null) {
         @Override

--- a/server/src/main/java/com/thoughtworks/go/server/domain/user/PipelinesFilter.java
+++ b/server/src/main/java/com/thoughtworks/go/server/domain/user/PipelinesFilter.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2018 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.server.domain.user;
+
+import com.thoughtworks.go.config.CaseInsensitiveString;
+import com.thoughtworks.go.presentation.pipelinehistory.StageInstanceModel;
+
+import java.util.List;
+import java.util.Set;
+
+import static com.thoughtworks.go.server.domain.user.DashboardFilter.BUILDING_STATE;
+import static com.thoughtworks.go.server.domain.user.DashboardFilter.FAILED_STATE;
+
+public class PipelinesFilter {
+    final Set<String> state;
+    final List<CaseInsensitiveString> pipelines;
+
+    PipelinesFilter(Set<String> state, List<CaseInsensitiveString> pipelines) {
+        this.state = state;
+        this.pipelines = DashboardFilter.enforceList(pipelines);
+    }
+
+    boolean filterByPipelineList(CaseInsensitiveString pipelineName) {
+        return null != pipelines && !pipelines.isEmpty() && pipelines.contains(pipelineName);
+    }
+
+    boolean filterByState(StageInstanceModel stage) {
+        if (state == null || stage == null)
+            return true;
+
+        if (state.contains(BUILDING_STATE) && state.contains(FAILED_STATE)) {
+            return stage.isRunning() || stage.hasFailed();
+        } else if (state.contains(BUILDING_STATE)) {
+            return stage.isRunning();
+        } else if (state.contains(FAILED_STATE)) {
+            return stage.hasFailed();
+        }
+        return true;
+    }
+}

--- a/server/src/main/java/com/thoughtworks/go/server/domain/user/PipelinesFilter.java
+++ b/server/src/main/java/com/thoughtworks/go/server/domain/user/PipelinesFilter.java
@@ -39,10 +39,9 @@ public class PipelinesFilter {
     }
 
     boolean filterByState(StageInstanceModel stage) {
-        if (state == null || stage == null)
+        if (stage == null) {
             return true;
-
-        if (state.contains(BUILDING_STATE) && state.contains(FAILED_STATE)) {
+        } else if (state.contains(BUILDING_STATE) && state.contains(FAILED_STATE)) {
             return stage.isRunning() || stage.hasFailed();
         } else if (state.contains(BUILDING_STATE)) {
             return stage.isRunning();

--- a/server/src/main/java/com/thoughtworks/go/server/domain/user/WhitelistFilter.java
+++ b/server/src/main/java/com/thoughtworks/go/server/domain/user/WhitelistFilter.java
@@ -17,18 +17,19 @@
 package com.thoughtworks.go.server.domain.user;
 
 import com.thoughtworks.go.config.CaseInsensitiveString;
+import com.thoughtworks.go.presentation.pipelinehistory.StageInstanceModel;
 
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 
-public class WhitelistFilter implements DashboardFilter {
+public class WhitelistFilter extends PipelinesFilter implements DashboardFilter {
     private final String name;
-    private final List<CaseInsensitiveString> pipelines;
 
-    public WhitelistFilter(String name, List<CaseInsensitiveString> pipelines) {
+    public WhitelistFilter(String name, List<CaseInsensitiveString> pipelines, Set<String> state) {
+        super(state, pipelines);
         this.name = name;
-        this.pipelines = DashboardFilter.enforceList(pipelines);
     }
 
     public List<CaseInsensitiveString> pipelines() {
@@ -41,8 +42,13 @@ public class WhitelistFilter implements DashboardFilter {
     }
 
     @Override
-    public boolean isPipelineVisible(CaseInsensitiveString pipeline) {
-        return null != pipelines && !pipelines.isEmpty() && pipelines.contains(pipeline);
+    public Set<String> state() {
+        return state;
+    }
+
+    @Override
+    public boolean isPipelineVisible(CaseInsensitiveString pipeline, StageInstanceModel stage) {
+        return filterByPipelineList(pipeline) && filterByState(stage);
     }
 
     @Override

--- a/server/src/main/java/com/thoughtworks/go/server/service/GoDashboardService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/GoDashboardService.java
@@ -82,8 +82,11 @@ public class GoDashboardService {
 
         if (goDashboardPipelineGroup.hasPermissions() && goDashboardPipelineGroup.canBeViewedBy(user.getUsername().toString())) {
             pipelineGroup.accept(pipelineConfig -> {
-                if (filter.isPipelineVisible(pipelineConfig.name())) {
-                    goDashboardPipelineGroup.addPipeline(allPipelines.find(pipelineConfig.getName()));
+                GoDashboardPipeline pipeline = allPipelines.find(pipelineConfig.getName());
+                if (pipeline != null) {
+                    if (filter.isPipelineVisible(pipelineConfig.name(), pipeline.getLatestStage())) {
+                        goDashboardPipelineGroup.addPipeline(pipeline);
+                    }
                 }
             });
         }

--- a/server/src/main/java/com/thoughtworks/go/server/service/PipelineHistoryService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/PipelineHistoryService.java
@@ -50,6 +50,7 @@ import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 
 import static com.thoughtworks.go.server.domain.user.DashboardFilter.DEFAULT_NAME;
 
@@ -451,7 +452,7 @@ public class PipelineHistoryService implements PipelineInstanceLoader {
     private void filterSelections(PipelineGroupModels groupModels, DashboardFilter filter) {
         for (PipelineGroupModel groupModel : groupModels.asList()) {
             for (PipelineModel pipelineModel : groupModel.getPipelineModels()) {
-                if (!filter.isPipelineVisible(new CaseInsensitiveString(pipelineModel.getName()))) {
+                if (!filter.isPipelineVisible(new CaseInsensitiveString(pipelineModel.getName()), null)) {
                     groupModels.removePipeline(groupModel, pipelineModel);
                 }
             }
@@ -596,7 +597,12 @@ public class PipelineHistoryService implements PipelineInstanceLoader {
             }
 
             @Override
-            public boolean isPipelineVisible(CaseInsensitiveString pipelineName) {
+            public Set<String> state() {
+                return null;
+            }
+
+            @Override
+            public boolean isPipelineVisible(CaseInsensitiveString pipelineName, StageInstanceModel goDashboardPipeline) {
                 return pipeline.equalsIgnoreCase(CaseInsensitiveString.str(pipelineName));
             }
 

--- a/server/src/test-fast/java/com/thoughtworks/go/server/domain/user/BlacklistFilterTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/domain/user/BlacklistFilterTest.java
@@ -24,26 +24,26 @@ import static org.junit.jupiter.api.Assertions.*;
 class BlacklistFilterTest {
     @Test
     void isPipelineVisible() {
-        final BlacklistFilter f = new BlacklistFilter(null, CaseInsensitiveString.list("p1"));
-        assertFalse(f.isPipelineVisible(new CaseInsensitiveString("p1")));
-        assertTrue(f.isPipelineVisible(new CaseInsensitiveString("p0")));
+        final BlacklistFilter f = new BlacklistFilter(null, CaseInsensitiveString.list("p1"), null);
+        assertFalse(f.isPipelineVisible(new CaseInsensitiveString("p1"), null));
+        assertTrue(f.isPipelineVisible(new CaseInsensitiveString("p0"), null));
     }
 
     @Test
     void allowPipeline() {
-        final BlacklistFilter f = new BlacklistFilter(null, CaseInsensitiveString.list("p1"));
-        assertFalse(f.isPipelineVisible(new CaseInsensitiveString("p1")));
-        assertTrue(f.isPipelineVisible(new CaseInsensitiveString("p0")));
+        final BlacklistFilter f = new BlacklistFilter(null, CaseInsensitiveString.list("p1"), null);
+        assertFalse(f.isPipelineVisible(new CaseInsensitiveString("p1"), null));
+        assertTrue(f.isPipelineVisible(new CaseInsensitiveString("p0"), null));
 
         f.allowPipeline(new CaseInsensitiveString("p1"));
-        assertTrue(f.isPipelineVisible(new CaseInsensitiveString("p1")));
+        assertTrue(f.isPipelineVisible(new CaseInsensitiveString("p1"), null));
     }
 
     @Test
     void equals() {
-        final BlacklistFilter a = new BlacklistFilter(null, CaseInsensitiveString.list("p1"));
-        final BlacklistFilter b = new BlacklistFilter(null, CaseInsensitiveString.list("p1"));
-        final BlacklistFilter c = new BlacklistFilter(null, CaseInsensitiveString.list("p0"));
+        final BlacklistFilter a = new BlacklistFilter(null, CaseInsensitiveString.list("p1"), null);
+        final BlacklistFilter b = new BlacklistFilter(null, CaseInsensitiveString.list("p1"), null);
+        final BlacklistFilter c = new BlacklistFilter(null, CaseInsensitiveString.list("p0"), null);
         assertEquals(a, b);
         assertNotEquals(a, c);
     }

--- a/server/src/test-fast/java/com/thoughtworks/go/server/domain/user/FiltersTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/domain/user/FiltersTest.java
@@ -19,10 +19,7 @@ package com.thoughtworks.go.server.domain.user;
 import com.thoughtworks.go.config.CaseInsensitiveString;
 import org.junit.jupiter.api.Test;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
+import java.util.*;
 
 import static com.thoughtworks.go.server.domain.user.DashboardFilter.DEFAULT_NAME;
 import static com.thoughtworks.go.server.domain.user.FilterValidator.*;
@@ -135,8 +132,8 @@ class FiltersTest {
     @Test
     void validatesDuplicateNamesOnDeserialize() {
         String json = "{ \"filters\": [" +
-                "  {\"name\": \"one\", \"type\": \"whitelist\", \"pipelines\": []}," +
-                "  {\"name\": \"one\", \"type\": \"whitelist\", \"pipelines\": []}" +
+                "  {\"name\": \"one\", \"type\": \"whitelist\", \"pipelines\": [], \"state\": []}," +
+                "  {\"name\": \"one\", \"type\": \"whitelist\", \"pipelines\": [], \"state\": []}" +
                 "] }";
         Throwable e = assertThrows(FilterValidationException.class, () -> Filters.fromJson(json));
         assertEquals("Duplicate filter name: one", e.getMessage());
@@ -146,7 +143,7 @@ class FiltersTest {
     void validatesStateOnDeserialize() {
         String json = "{ \"filters\": [" +
                 "  {\"name\": \"one\", \"type\": \"whitelist\", \"pipelines\": [], \"state\": [\"pi\", \"failing\"]}," +
-                "  {\"name\": \"default\", \"type\": \"whitelist\", \"pipelines\": []}" +
+                "  {\"name\": \"default\", \"type\": \"whitelist\", \"pipelines\": [], \"state\": []}" +
                 "] }";
         Throwable e = assertThrows(FilterValidationException.class, () -> Filters.fromJson(json));
         assertEquals(MSG_INVALID_STATES, e.getMessage());
@@ -161,7 +158,7 @@ class FiltersTest {
     @Test
     void validatesPresenceOfDefaultFilterOnDeserialize() {
         final String json = "{ \"filters\": [" +
-                "  {\"name\": \"foo\", \"type\": \"whitelist\", \"pipelines\": [\"bar\"]}" +
+                "  {\"name\": \"foo\", \"type\": \"whitelist\", \"pipelines\": [\"bar\"], \"state\": []}" +
                 "] }";
 
         Throwable e = assertThrows(FilterValidationException.class, () -> Filters.fromJson(json));
@@ -170,16 +167,16 @@ class FiltersTest {
 
     @Test
     void defaultFilterNameIsAlwaysTitleCase() {
-        String json = "{ \"filters\": [{\"name\": \"deFauLt\", \"type\": \"whitelist\"}] }";
+        String json = "{ \"filters\": [{\"name\": \"deFauLt\", \"state\":[], \"type\": \"whitelist\"}] }";
         assertEquals(DEFAULT_NAME, Filters.fromJson(json).named(DEFAULT_NAME).name());
 
-        String expected = "{\"filters\":[{\"name\":\"" + DEFAULT_NAME + "\",\"pipelines\":[],\"type\":\"whitelist\"}]}";
+        String expected = "{\"filters\":[{\"name\":\"" + DEFAULT_NAME + "\",\"state\":[],\"pipelines\":[],\"type\":\"whitelist\"}]}";
         assertEquals(expected, Filters.toJson(Filters.single(namedWhitelist("defAUlT"))));
     }
 
     @Test
     void fromJson() {
-        String json = "{ \"filters\": [{\"name\": \"Default\", \"type\": \"whitelist\", \"pipelines\": [\"p1\"]}] }";
+        String json = "{ \"filters\": [{\"name\": \"Default\", \"type\": \"whitelist\", \"pipelines\": [\"p1\"], \"state\": []}] }";
         final Filters filters = Filters.fromJson(json);
         assertEquals(1, filters.filters().size());
         final DashboardFilter first = filters.filters().get(0);
@@ -197,8 +194,8 @@ class FiltersTest {
         final Filters filters = new Filters(views);
 
         assertEquals("{\"filters\":[" +
-                "{\"name\":\"" + DEFAULT_NAME + "\",\"pipelines\":[],\"type\":\"blacklist\"}," +
-                "{\"name\":\"Cool Pipelines\",\"pipelines\":[\"Pipely McPipe\"],\"type\":\"blacklist\"}" +
+                "{\"name\":\"" + DEFAULT_NAME + "\",\"state\":[],\"pipelines\":[],\"type\":\"blacklist\"}," +
+                "{\"name\":\"Cool Pipelines\",\"state\":[],\"pipelines\":[\"Pipely McPipe\"],\"type\":\"blacklist\"}" +
                 "]}", Filters.toJson(filters));
     }
 
@@ -225,7 +222,7 @@ class FiltersTest {
 
 
     private DashboardFilter namedWhitelist(String name, String... pipelines) {
-        return new WhitelistFilter(name, CaseInsensitiveString.list(pipelines), null);
+        return new WhitelistFilter(name, CaseInsensitiveString.list(pipelines), new HashSet<>());
     }
 
     private DashboardFilter whitelist(String... pipelines) {
@@ -233,7 +230,7 @@ class FiltersTest {
     }
 
     private DashboardFilter namedBlacklist(String name, String... pipelines) {
-        return new BlacklistFilter(name, CaseInsensitiveString.list(pipelines), null);
+        return new BlacklistFilter(name, CaseInsensitiveString.list(pipelines), new HashSet<>());
     }
 
     private DashboardFilter blacklist(String... pipelines) {

--- a/server/src/test-fast/java/com/thoughtworks/go/server/domain/user/FiltersTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/domain/user/FiltersTest.java
@@ -143,6 +143,16 @@ class FiltersTest {
     }
 
     @Test
+    void validatesStateOnDeserialize() {
+        String json = "{ \"filters\": [" +
+                "  {\"name\": \"one\", \"type\": \"whitelist\", \"pipelines\": [], \"state\": [\"pi\", \"failing\"]}," +
+                "  {\"name\": \"default\", \"type\": \"whitelist\", \"pipelines\": []}" +
+                "] }";
+        Throwable e = assertThrows(FilterValidationException.class, () -> Filters.fromJson(json));
+        assertEquals(MSG_INVALID_STATES, e.getMessage());
+    }
+
+    @Test
     void validatesPresenceOfDefaultFilterOnConstruction() {
         Throwable e = assertThrows(FilterValidationException.class, () -> Filters.single(namedBlacklist("foo", "bar")));
         assertEquals(MSG_NO_DEFAULT_FILTER, e.getMessage());
@@ -215,7 +225,7 @@ class FiltersTest {
 
 
     private DashboardFilter namedWhitelist(String name, String... pipelines) {
-        return new WhitelistFilter(name, CaseInsensitiveString.list(pipelines));
+        return new WhitelistFilter(name, CaseInsensitiveString.list(pipelines), null);
     }
 
     private DashboardFilter whitelist(String... pipelines) {
@@ -223,7 +233,7 @@ class FiltersTest {
     }
 
     private DashboardFilter namedBlacklist(String name, String... pipelines) {
-        return new BlacklistFilter(name, CaseInsensitiveString.list(pipelines));
+        return new BlacklistFilter(name, CaseInsensitiveString.list(pipelines), null);
     }
 
     private DashboardFilter blacklist(String... pipelines) {

--- a/server/src/test-fast/java/com/thoughtworks/go/server/domain/user/PipelineSelectionsHelper.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/domain/user/PipelineSelectionsHelper.java
@@ -20,6 +20,7 @@ import com.thoughtworks.go.config.CaseInsensitiveString;
 
 import java.util.Collections;
 import java.util.Date;
+import java.util.HashSet;
 import java.util.List;
 
 import static com.thoughtworks.go.server.domain.user.DashboardFilter.DEFAULT_NAME;
@@ -27,7 +28,7 @@ import static com.thoughtworks.go.server.domain.user.DashboardFilter.DEFAULT_NAM
 public class PipelineSelectionsHelper {
     public static PipelineSelections with(List<String> pipelines, Date date, Long userId, boolean blacklist) {
         List<CaseInsensitiveString> params = CaseInsensitiveString.list(pipelines);
-        DashboardFilter filter = blacklist ? new BlacklistFilter(DEFAULT_NAME, params, null) : new WhitelistFilter(DEFAULT_NAME, params, null);
+        DashboardFilter filter = blacklist ? new BlacklistFilter(DEFAULT_NAME, params, new HashSet<>()) : new WhitelistFilter(DEFAULT_NAME, params, new HashSet<>());
         return new PipelineSelections(new Filters(Collections.singletonList(filter)), date, userId);
     }
 

--- a/server/src/test-fast/java/com/thoughtworks/go/server/domain/user/PipelineSelectionsHelper.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/domain/user/PipelineSelectionsHelper.java
@@ -27,7 +27,7 @@ import static com.thoughtworks.go.server.domain.user.DashboardFilter.DEFAULT_NAM
 public class PipelineSelectionsHelper {
     public static PipelineSelections with(List<String> pipelines, Date date, Long userId, boolean blacklist) {
         List<CaseInsensitiveString> params = CaseInsensitiveString.list(pipelines);
-        DashboardFilter filter = blacklist ? new BlacklistFilter(DEFAULT_NAME, params) : new WhitelistFilter(DEFAULT_NAME, params);
+        DashboardFilter filter = blacklist ? new BlacklistFilter(DEFAULT_NAME, params, null) : new WhitelistFilter(DEFAULT_NAME, params, null);
         return new PipelineSelections(new Filters(Collections.singletonList(filter)), date, userId);
     }
 

--- a/server/src/test-fast/java/com/thoughtworks/go/server/domain/user/PipelineSelectionsTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/domain/user/PipelineSelectionsTest.java
@@ -20,6 +20,7 @@ import com.thoughtworks.go.config.CaseInsensitiveString;
 import org.junit.Test;
 
 import java.util.Arrays;
+import java.util.HashSet;
 
 import static com.thoughtworks.go.helper.PipelineConfigMother.createGroup;
 import static com.thoughtworks.go.helper.PipelineConfigMother.pipelineConfig;
@@ -33,16 +34,16 @@ public class PipelineSelectionsTest {
     @Test
     public void etagBasedOnFilterContent() {
         PipelineSelections ps = PipelineSelectionsHelper.with(Arrays.asList("p1", "p2"));
-        assertEquals("E8435DD87D7E62616157CF2F71A5FCB7DAE9224A6EBE4F47CF20D0583D5897C5", ps.etag());
+        assertEquals("148C3FDE87AD2AC597262975FECE58E64036A79CED54351A700232AC6FDA90B0", ps.etag());
 
         ps.update(Filters.defaults(), null, null);
-        assertEquals("1269CFEF75B2DA5D73263B78BE4EA8EA9663104992327642B44F28A5C66E36F2", ps.etag());
+        assertEquals("2356E5D4241F22987D8F8CB8920913FDA237385B423BD7EEC7E97B2A9EB1BE1A", ps.etag());
 
-        ps.update(Filters.single(new WhitelistFilter(DEFAULT_NAME, CaseInsensitiveString.list("p1"), null)), null, null);
-        assertEquals("852D88B3C5D6A9CFC481DE35FB4A90A79E5A96A10A80947F7EFC8D345C10024E", ps.etag());
+        ps.update(Filters.single(new WhitelistFilter(DEFAULT_NAME, CaseInsensitiveString.list("p1"), new HashSet<>())), null, null);
+        assertEquals("9FFA0B91A0100DAC243E4A4F47303057B888E1E0B25CDB26AAF05C019F8E71EE", ps.etag());
 
-        ps.setFilters(format("{\"filters\": [{\"name\": \"%s\", \"type\": \"blacklist\", \"pipelines\": [\"foobar\"]}]}", DEFAULT_NAME));
-        assertEquals("87CDD48CD9C281C6D5B8C28D4FD0F61E1F18D280D8B247B9CAC96161978D2580", ps.etag());
+        ps.setFilters(format("{\"filters\": [{\"name\": \"%s\", \"type\": \"blacklist\", \"state\": [], \"pipelines\": [\"foobar\"]}]}", DEFAULT_NAME));
+        assertEquals("224C1949538A5A278C061A99C40797BF3849D13FCA7F3AEB249171851F2A384E", ps.etag());
     }
 
     @Test

--- a/server/src/test-fast/java/com/thoughtworks/go/server/domain/user/PipelineSelectionsTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/domain/user/PipelineSelectionsTest.java
@@ -38,7 +38,7 @@ public class PipelineSelectionsTest {
         ps.update(Filters.defaults(), null, null);
         assertEquals("1269CFEF75B2DA5D73263B78BE4EA8EA9663104992327642B44F28A5C66E36F2", ps.etag());
 
-        ps.update(Filters.single(new WhitelistFilter(DEFAULT_NAME, CaseInsensitiveString.list("p1"))), null, null);
+        ps.update(Filters.single(new WhitelistFilter(DEFAULT_NAME, CaseInsensitiveString.list("p1"), null)), null, null);
         assertEquals("852D88B3C5D6A9CFC481DE35FB4A90A79E5A96A10A80947F7EFC8D345C10024E", ps.etag());
 
         ps.setFilters(format("{\"filters\": [{\"name\": \"%s\", \"type\": \"blacklist\", \"pipelines\": [\"foobar\"]}]}", DEFAULT_NAME));

--- a/server/src/test-fast/java/com/thoughtworks/go/server/domain/user/PipelinesFilterTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/domain/user/PipelinesFilterTest.java
@@ -88,19 +88,20 @@ public class PipelinesFilterTest {
     }
 
     @Test
-    public void shouldReturnTrueIfStateIsNull() {
-        StageInstanceModel stage = mock(StageInstanceModel.class);
-        when(stage.hasFailed()).thenReturn(false);
-        when(stage.isRunning()).thenReturn(true);
-        assertTrue(new PipelinesFilter(null, null).filterByState(stage));
-    }
-
-    @Test
     public void shouldReturnTrueIfStateIsEmpty() {
         StageInstanceModel stage = mock(StageInstanceModel.class);
         when(stage.hasFailed()).thenReturn(false);
         when(stage.isRunning()).thenReturn(true);
         Set<String> state = new HashSet<>();
         assertTrue(new PipelinesFilter(state, null).filterByState(stage));
+    }
+
+    @Test
+    public void shouldReturnTrueIfStageIsNull() {
+        StageInstanceModel stage = mock(StageInstanceModel.class);
+        when(stage.hasFailed()).thenReturn(false);
+        when(stage.isRunning()).thenReturn(true);
+        Set<String> state = new HashSet<>();
+        assertTrue(new PipelinesFilter(state, null).filterByState(null));
     }
 }

--- a/server/src/test-fast/java/com/thoughtworks/go/server/domain/user/PipelinesFilterTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/domain/user/PipelinesFilterTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2018 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.server.domain.user;
+
+import com.thoughtworks.go.presentation.pipelinehistory.StageInstanceModel;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static com.thoughtworks.go.server.domain.user.DashboardFilter.BUILDING_STATE;
+import static com.thoughtworks.go.server.domain.user.DashboardFilter.FAILED_STATE;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class PipelinesFilterTest {
+    @Test
+    public void shouldReturnTrueIfStageIsBuildingWhenFilteringByBuilding() {
+        StageInstanceModel stage = mock(StageInstanceModel.class);
+        when(stage.isRunning()).thenReturn(true);
+        Set<String> state = new HashSet<>();
+        state.add(BUILDING_STATE);
+        assertTrue(new PipelinesFilter(state, null).filterByState(stage));
+    }
+
+    @Test
+    public void shouldReturnFalseIfStageIsBuildingWhenFilteringByBuilding() {
+        StageInstanceModel stage = mock(StageInstanceModel.class);
+        when(stage.isRunning()).thenReturn(false);
+        Set<String> state = new HashSet<>();
+        state.add(BUILDING_STATE);
+        assertFalse(new PipelinesFilter(state, null).filterByState(stage));
+    }
+
+    @Test
+    public void shouldReturnTrueIfStageIsFailingWhenFilteringByFailing() {
+        StageInstanceModel stage = mock(StageInstanceModel.class);
+        when(stage.hasFailed()).thenReturn(true);
+        Set<String> state = new HashSet<>();
+        state.add(FAILED_STATE);
+        assertTrue(new PipelinesFilter(state, null).filterByState(stage));
+    }
+
+    @Test
+    public void shouldReturnFalseIfStageIsFailingWhenFilteringByFailing() {
+        StageInstanceModel stage = mock(StageInstanceModel.class);
+        when(stage.hasFailed()).thenReturn(false);
+        Set<String> state = new HashSet<>();
+        state.add(FAILED_STATE);
+        assertFalse(new PipelinesFilter(state, null).filterByState(stage));
+    }
+
+    @Test
+    public void shouldReturnTrueIfStageIsEitherBuildingOrFailedWhenFilteringByBothStates() {
+        StageInstanceModel stage = mock(StageInstanceModel.class);
+        when(stage.hasFailed()).thenReturn(false);
+        when(stage.isRunning()).thenReturn(true);
+        Set<String> state = new HashSet<>();
+        state.add(FAILED_STATE);
+        state.add(BUILDING_STATE);
+        assertTrue(new PipelinesFilter(state, null).filterByState(stage));
+
+        when(stage.hasFailed()).thenReturn(true);
+        when(stage.isRunning()).thenReturn(false);
+        assertTrue(new PipelinesFilter(state, null).filterByState(stage));
+
+        when(stage.hasFailed()).thenReturn(true);
+        when(stage.isRunning()).thenReturn(true);
+        assertTrue(new PipelinesFilter(state, null).filterByState(stage));
+    }
+
+    @Test
+    public void shouldReturnTrueIfStateIsNull() {
+        StageInstanceModel stage = mock(StageInstanceModel.class);
+        when(stage.hasFailed()).thenReturn(false);
+        when(stage.isRunning()).thenReturn(true);
+        assertTrue(new PipelinesFilter(null, null).filterByState(stage));
+    }
+
+    @Test
+    public void shouldReturnTrueIfStateIsEmpty() {
+        StageInstanceModel stage = mock(StageInstanceModel.class);
+        when(stage.hasFailed()).thenReturn(false);
+        when(stage.isRunning()).thenReturn(true);
+        Set<String> state = new HashSet<>();
+        assertTrue(new PipelinesFilter(state, null).filterByState(stage));
+    }
+}

--- a/server/src/test-fast/java/com/thoughtworks/go/server/domain/user/WhitelistFilterTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/domain/user/WhitelistFilterTest.java
@@ -24,26 +24,26 @@ import static org.junit.jupiter.api.Assertions.*;
 class WhitelistFilterTest {
     @Test
     void isPipelineVisible() {
-        final WhitelistFilter f = new WhitelistFilter(null, CaseInsensitiveString.list("p1"));
-        assertTrue(f.isPipelineVisible(new CaseInsensitiveString("p1")));
-        assertFalse(f.isPipelineVisible(new CaseInsensitiveString("p0")));
+        final WhitelistFilter f = new WhitelistFilter(null, CaseInsensitiveString.list("p1"), null);
+        assertTrue(f.isPipelineVisible(new CaseInsensitiveString("p1"), null));
+        assertFalse(f.isPipelineVisible(new CaseInsensitiveString("p0"), null));
     }
 
     @Test
     void allowPipeline() {
-        final WhitelistFilter f = new WhitelistFilter(null, CaseInsensitiveString.list("p1"));
-        assertTrue(f.isPipelineVisible(new CaseInsensitiveString("p1")));
-        assertFalse(f.isPipelineVisible(new CaseInsensitiveString("p0")));
+        final WhitelistFilter f = new WhitelistFilter(null, CaseInsensitiveString.list("p1"), null);
+        assertTrue(f.isPipelineVisible(new CaseInsensitiveString("p1"), null));
+        assertFalse(f.isPipelineVisible(new CaseInsensitiveString("p0"), null));
 
         f.allowPipeline(new CaseInsensitiveString("p0"));
-        assertTrue(f.isPipelineVisible(new CaseInsensitiveString("p0")));
+        assertTrue(f.isPipelineVisible(new CaseInsensitiveString("p0"), null));
     }
 
     @Test
     void equals() {
-        final WhitelistFilter a = new WhitelistFilter(null, CaseInsensitiveString.list("p1"));
-        final WhitelistFilter b = new WhitelistFilter(null, CaseInsensitiveString.list("p1"));
-        final WhitelistFilter c = new WhitelistFilter(null, CaseInsensitiveString.list("p0"));
+        final WhitelistFilter a = new WhitelistFilter(null, CaseInsensitiveString.list("p1"), null);
+        final WhitelistFilter b = new WhitelistFilter(null, CaseInsensitiveString.list("p1"), null);
+        final WhitelistFilter c = new WhitelistFilter(null, CaseInsensitiveString.list("p0"), null);
         assertEquals(a, b);
         assertNotEquals(a, c);
     }

--- a/server/src/test-fast/java/com/thoughtworks/go/server/service/GoDashboardServiceTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/service/GoDashboardServiceTest.java
@@ -125,7 +125,7 @@ public class GoDashboardServiceTest {
         GoDashboardPipeline pipeline1 = pipeline("pipeline1", "group1");
 
         addPipelinesToCache(pipeline1, pipeline2);
-        when(filter.isPipelineVisible(any(CaseInsensitiveString.class))).thenReturn(true);
+        when(filter.isPipelineVisible(any(CaseInsensitiveString.class), any())).thenReturn(true);
 
         List<GoDashboardPipelineGroup> pipelineGroups = allPipelineGroupsForDashboard(filter, new Username("user1"));
 
@@ -151,10 +151,10 @@ public class GoDashboardServiceTest {
         GoDashboardPipeline pipeline1 = pipeline("pipeline1", "group1");
 
         addPipelinesToCache(pipeline1, pipeline2, pipeline3, pipeline4);
-        when(filter.isPipelineVisible(pipelineConfig1.name())).thenReturn(true);
-        when(filter.isPipelineVisible(pipelineConfig2.name())).thenReturn(false);
-        when(filter.isPipelineVisible(pipelineConfig3.name())).thenReturn(true);
-        when(filter.isPipelineVisible(pipelineConfig4.name())).thenReturn(false);
+        when(filter.isPipelineVisible(pipelineConfig1.name(), null)).thenReturn(true);
+        when(filter.isPipelineVisible(pipelineConfig2.name(), null)).thenReturn(false);
+        when(filter.isPipelineVisible(pipelineConfig3.name(), null)).thenReturn(true);
+        when(filter.isPipelineVisible(pipelineConfig4.name(), null)).thenReturn(false);
 
         List<GoDashboardPipelineGroup> pipelineGroups = allPipelineGroupsForDashboard(filter, new Username("user1"));
 
@@ -178,7 +178,7 @@ public class GoDashboardServiceTest {
         GoDashboardPipeline pipeline2 = pipeline("pipeline2", "group2", new Permissions(NoOne.INSTANCE, NoOne.INSTANCE, NoOne.INSTANCE, NoOne.INSTANCE));
 
         addPipelinesToCache(pipeline1, pipeline2);
-        when(filter.isPipelineVisible(any(CaseInsensitiveString.class))).thenReturn(true);
+        when(filter.isPipelineVisible(any(CaseInsensitiveString.class), any())).thenReturn(true);
 
         List<GoDashboardPipelineGroup> pipelineGroups = allPipelineGroupsForDashboard(filter, new Username("user1"));
 
@@ -192,7 +192,7 @@ public class GoDashboardServiceTest {
         DashboardFilter filter = mock(DashboardFilter.class);
         configMother.addPipelineWithGroup(config, "group1", "pipeline1", "stage1A", "job1A1");
 
-        when(filter.isPipelineVisible(any(CaseInsensitiveString.class))).thenReturn(true);
+        when(filter.isPipelineVisible(any(CaseInsensitiveString.class), any())).thenReturn(true);
 
         List<GoDashboardPipelineGroup> pipelineGroups = allPipelineGroupsForDashboard(filter, new Username("user1"));
 
@@ -210,7 +210,7 @@ public class GoDashboardServiceTest {
                 Everyone.INSTANCE, Everyone.INSTANCE, Everyone.INSTANCE));
 
         addPipelinesToCache(pipeline1);
-        when(filter.isPipelineVisible(any(CaseInsensitiveString.class))).thenReturn(true);
+        when(filter.isPipelineVisible(any(CaseInsensitiveString.class), any())).thenReturn(true);
 
         List<GoDashboardPipelineGroup> pipelineGroups = allPipelineGroupsForDashboard(filter, new Username("user1"));
 

--- a/server/src/test-fast/java/com/thoughtworks/go/server/service/PipelineSelectionsServiceTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/service/PipelineSelectionsServiceTest.java
@@ -214,11 +214,11 @@ public class PipelineSelectionsServiceTest {
     }
 
     private DashboardFilter blacklist(String... pipelines) {
-        return new BlacklistFilter(DEFAULT_NAME, CaseInsensitiveString.list(pipelines));
+        return new BlacklistFilter(DEFAULT_NAME, CaseInsensitiveString.list(pipelines), null);
     }
 
     private DashboardFilter whitelist(String... pipelines) {
-        return new WhitelistFilter(DEFAULT_NAME, CaseInsensitiveString.list(pipelines));
+        return new WhitelistFilter(DEFAULT_NAME, CaseInsensitiveString.list(pipelines), null);
     }
 
     private void expectLoad(final CruiseConfig result) throws Exception {

--- a/server/src/test-fast/java/com/thoughtworks/go/server/service/PipelineSelectionsServiceTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/service/PipelineSelectionsServiceTest.java
@@ -30,6 +30,7 @@ import org.junit.Test;
 
 import java.util.Collections;
 import java.util.Date;
+import java.util.HashSet;
 
 import static com.thoughtworks.go.helper.ConfigFileFixture.configWith;
 import static com.thoughtworks.go.server.domain.user.DashboardFilter.DEFAULT_NAME;
@@ -214,11 +215,11 @@ public class PipelineSelectionsServiceTest {
     }
 
     private DashboardFilter blacklist(String... pipelines) {
-        return new BlacklistFilter(DEFAULT_NAME, CaseInsensitiveString.list(pipelines), null);
+        return new BlacklistFilter(DEFAULT_NAME, CaseInsensitiveString.list(pipelines), new HashSet<>());
     }
 
     private DashboardFilter whitelist(String... pipelines) {
-        return new WhitelistFilter(DEFAULT_NAME, CaseInsensitiveString.list(pipelines), null);
+        return new WhitelistFilter(DEFAULT_NAME, CaseInsensitiveString.list(pipelines), new HashSet<>());
     }
 
     private void expectLoad(final CruiseConfig result) throws Exception {

--- a/server/src/test-integration/java/com/thoughtworks/go/server/persistence/PipelineRepositoryIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/persistence/PipelineRepositoryIntegrationTest.java
@@ -405,13 +405,13 @@ public class PipelineRepositoryIntegrationTest {
 
     private PipelineSelections blacklist(List<String> pipelines, Long userId) {
         final List<CaseInsensitiveString> pipelineNames = CaseInsensitiveString.list(pipelines);
-        Filters filters = new Filters(Collections.singletonList(new BlacklistFilter(DEFAULT_NAME, pipelineNames, null)));
+        Filters filters = new Filters(Collections.singletonList(new BlacklistFilter(DEFAULT_NAME, pipelineNames, new HashSet<>())));
         return new PipelineSelections(filters, new Date(), userId);
     }
 
     private PipelineSelections whitelist(List<String> pipelines, Long userId) {
         final List<CaseInsensitiveString> pipelineNames = CaseInsensitiveString.list(pipelines);
-        Filters filters = new Filters(Collections.singletonList(new WhitelistFilter(DEFAULT_NAME, pipelineNames, null)));
+        Filters filters = new Filters(Collections.singletonList(new WhitelistFilter(DEFAULT_NAME, pipelineNames, new HashSet<>())));
         return new PipelineSelections(filters, new Date(), userId);
     }
 }

--- a/server/src/test-integration/java/com/thoughtworks/go/server/persistence/PipelineRepositoryIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/persistence/PipelineRepositoryIntegrationTest.java
@@ -393,25 +393,25 @@ public class PipelineRepositoryIntegrationTest {
 
     private void assertAllowsPipelines(DashboardFilter filter, String... pipelines) {
         for (String pipeline : pipelines) {
-            assertTrue(filter.isPipelineVisible(new CaseInsensitiveString(pipeline)));
+            assertTrue(filter.isPipelineVisible(new CaseInsensitiveString(pipeline), null));
         }
     }
 
     private void assertDeniesPipelines(DashboardFilter filter, String... pipelines) {
         for (String pipeline : pipelines) {
-            assertFalse(filter.isPipelineVisible(new CaseInsensitiveString(pipeline)));
+            assertFalse(filter.isPipelineVisible(new CaseInsensitiveString(pipeline), null));
         }
     }
 
     private PipelineSelections blacklist(List<String> pipelines, Long userId) {
         final List<CaseInsensitiveString> pipelineNames = CaseInsensitiveString.list(pipelines);
-        Filters filters = new Filters(Collections.singletonList(new BlacklistFilter(DEFAULT_NAME, pipelineNames)));
+        Filters filters = new Filters(Collections.singletonList(new BlacklistFilter(DEFAULT_NAME, pipelineNames, null)));
         return new PipelineSelections(filters, new Date(), userId);
     }
 
     private PipelineSelections whitelist(List<String> pipelines, Long userId) {
         final List<CaseInsensitiveString> pipelineNames = CaseInsensitiveString.list(pipelines);
-        Filters filters = new Filters(Collections.singletonList(new WhitelistFilter(DEFAULT_NAME, pipelineNames)));
+        Filters filters = new Filters(Collections.singletonList(new WhitelistFilter(DEFAULT_NAME, pipelineNames, null)));
         return new PipelineSelections(filters, new Date(), userId);
     }
 }

--- a/server/webapp/WEB-INF/rails.new/spec/views/pipelines/_pipelines_selector_pipelines_html_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/views/pipelines/_pipelines_selector_pipelines_html_spec.rb
@@ -20,7 +20,7 @@ def blacklist(*args)
   pipes = CaseInsensitiveString.list(*args)
   name = com.thoughtworks.go.server.domain.user.DashboardFilter::DEFAULT_NAME
   filters = com.thoughtworks.go.server.domain.user.Filters.single(
-    com.thoughtworks.go.server.domain.user.BlacklistFilter.new(name, pipes)
+    com.thoughtworks.go.server.domain.user.BlacklistFilter.new(name, pipes, nil)
   )
   PipelineSelections.new(filters, nil, nil)
 end

--- a/server/webapp/WEB-INF/rails.new/spec/views/pipelines/_pipelines_selector_pipelines_html_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/views/pipelines/_pipelines_selector_pipelines_html_spec.rb
@@ -20,7 +20,7 @@ def blacklist(*args)
   pipes = CaseInsensitiveString.list(*args)
   name = com.thoughtworks.go.server.domain.user.DashboardFilter::DEFAULT_NAME
   filters = com.thoughtworks.go.server.domain.user.Filters.single(
-    com.thoughtworks.go.server.domain.user.BlacklistFilter.new(name, pipes, nil)
+                                                               com.thoughtworks.go.server.domain.user.BlacklistFilter.new(name, pipes, HashSet.new())
   )
   PipelineSelections.new(filters, nil, nil)
 end

--- a/server/webapp/WEB-INF/rails.new/spec/views/pipelines/index_html_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/views/pipelines/index_html_spec.rb
@@ -20,7 +20,7 @@ def blacklist(*args)
   pipes = CaseInsensitiveString.list(*args)
   name = com.thoughtworks.go.server.domain.user.DashboardFilter::DEFAULT_NAME
   filters = com.thoughtworks.go.server.domain.user.Filters.single(
-    com.thoughtworks.go.server.domain.user.BlacklistFilter.new(name, pipes)
+    com.thoughtworks.go.server.domain.user.BlacklistFilter.new(name, pipes, nil)
   )
   PipelineSelections.new(filters, nil, nil)
 end

--- a/server/webapp/WEB-INF/rails.new/spec/views/pipelines/index_html_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/views/pipelines/index_html_spec.rb
@@ -20,7 +20,7 @@ def blacklist(*args)
   pipes = CaseInsensitiveString.list(*args)
   name = com.thoughtworks.go.server.domain.user.DashboardFilter::DEFAULT_NAME
   filters = com.thoughtworks.go.server.domain.user.Filters.single(
-    com.thoughtworks.go.server.domain.user.BlacklistFilter.new(name, pipes, nil)
+                                                               com.thoughtworks.go.server.domain.user.BlacklistFilter.new(name, pipes, HashSet.new())
   )
   PipelineSelections.new(filters, nil, nil)
 end

--- a/server/webapp/WEB-INF/rails.new/webpack/views/dashboard/personalization_modal_widget.js.msx
+++ b/server/webapp/WEB-INF/rails.new/webpack/views/dashboard/personalization_modal_widget.js.msx
@@ -115,6 +115,7 @@ const PersonalizationModalWidget = {
       <section class="filter-options">
         <BlanketSelector vm={vm.selectionVM} />
         <f.checkbox name="include-new-pipelines" model={vm} attrName="includeNewPipelines" label="Show newly created pipelines" />
+        <StageStateCriteria vm={vm} />
       </section>
       <section class="pipeline-selections">
         <SelectedPipelineList vm={vm.selectionVM} />

--- a/server/webapp/WEB-INF/rails.new/webpack/views/dashboard/personalization_modal_widget.js.msx
+++ b/server/webapp/WEB-INF/rails.new/webpack/views/dashboard/personalization_modal_widget.js.msx
@@ -50,7 +50,7 @@ const StageStateCriteria = { //eslint-disable-line no-unused-vars
   view(vnode) {
     const vm = vnode.attrs.vm;
     return <div class="stage-state-selector">
-      <f.checkbox name="state" model={vm} attrName="failing" label="Failed" />,
+      <f.checkbox name="state" model={vm} attrName="failing" label="Failed" />
       <f.checkbox name="state" model={vm} attrName="building" label="Building" />
     </div>;
   }


### PR DESCRIPTION
Allows for personalized views to only show pipelines that match the selected state(s). For example, you can have a tab that only shows building pipelines, and another that shows pipelines that have failed.

Screenshot of the ui component:
<img width="516" alt="screen shot 2018-08-07 at 1 04 34 pm" src="https://user-images.githubusercontent.com/5726224/43799484-84a26624-9a42-11e8-9499-2eb73e181290.png">
