### PR TITLE
Remove encryption of secure plugin properties in setConfigAttributes.

### DIFF
--- a/config/config-api/src/test/java/com/thoughtworks/go/config/ArtifactConfigsTest.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/config/ArtifactConfigsTest.java
@@ -112,7 +112,7 @@ public class ArtifactConfigsTest {
     }
 
     @Test
-    public void setConfigAttributes_shouldSetExternalArtifact() throws CryptoException {
+    public void setConfigAttributes_shouldSetExternalArtifactWithPlainTextValuesIfPluginIdIsProvided() {
         ArtifactPluginInfo artifactPluginInfo = mock(ArtifactPluginInfo.class);
         PluginDescriptor pluginDescriptor = mock(PluginDescriptor.class);
         when(artifactPluginInfo.getDescriptor()).thenReturn(pluginDescriptor);
@@ -149,7 +149,7 @@ public class ArtifactConfigsTest {
         assertThat(artifactConfig.getArtifactType(), is(ArtifactType.external));
         assertThat(artifactConfig.getId(), is("artifactId"));
         assertThat(artifactConfig.getStoreId(), is("storeId"));
-        assertThat(artifactConfig.getConfiguration().getProperty("Image").isSecure(), is(true));
+        assertThat(artifactConfig.getConfiguration().getProperty("Image").isSecure(), is(false));
     }
 
     @Test


### PR DESCRIPTION
* The encryptSecureProperties method that gets invoked for a full config save will take care of encrypting the secure values of properties. 

No need to perform this operation twice. Especially since the encryptSecureProperties will be called after preprocessing and takes care of params. The one that's been removed as part of this PR did not take care of preprocessing params.

Verified by entering a value for a secure property for a plugin and checking that the config xml stored the encrypted value. 

cc @bdpiparva 

