### PR TITLE
Introduce 'vsm' as a supported analytics

### DIFF
--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/analytics/AnalyticsExtension.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/analytics/AnalyticsExtension.java
@@ -18,6 +18,8 @@ package com.thoughtworks.go.plugin.access.analytics;
 
 import com.thoughtworks.go.plugin.access.DefaultPluginInteractionCallback;
 import com.thoughtworks.go.plugin.access.PluginRequestHelper;
+import com.thoughtworks.go.plugin.access.analytics.V1.AnalyticsMessageConverterV1;
+import com.thoughtworks.go.plugin.access.analytics.V2.AnalyticsMessageConverterV2;
 import com.thoughtworks.go.plugin.access.common.AbstractExtension;
 import com.thoughtworks.go.plugin.access.common.settings.MessageHandlerForPluginSettingsRequestProcessor;
 import com.thoughtworks.go.plugin.access.common.settings.MessageHandlerForPluginSettingsRequestProcessor1_0;
@@ -46,9 +48,11 @@ public class AnalyticsExtension extends AbstractExtension {
         super(pluginManager, new PluginRequestHelper(pluginManager, SUPPORTED_VERSIONS, ANALYTICS_EXTENSION), ANALYTICS_EXTENSION);
         addHandler(AnalyticsMessageConverterV1.VERSION, new PluginSettingsJsonMessageHandler2_0(), new AnalyticsMessageConverterV1(),
                 new MessageHandlerForPluginSettingsRequestProcessor1_0());
+        addHandler(AnalyticsMessageConverterV2.VERSION, new PluginSettingsJsonMessageHandler2_0(), new AnalyticsMessageConverterV2(),
+                new MessageHandlerForPluginSettingsRequestProcessor1_0());
     }
 
-    private void addHandler(String version, PluginSettingsJsonMessageHandler messageHandler, AnalyticsMessageConverterV1 extensionHandler,
+    private void addHandler(String version, PluginSettingsJsonMessageHandler messageHandler, AnalyticsMessageConverter extensionHandler,
                             MessageHandlerForPluginSettingsRequestProcessor messageHandlerForPluginSettingsRequestProcessor) {
         pluginSettingsMessageHandlerMap.put(version, messageHandler);
         messageHandlerMap.put(version, extensionHandler);

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/analytics/AnalyticsPluginConstants.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/analytics/AnalyticsPluginConstants.java
@@ -16,6 +16,8 @@
 
 package com.thoughtworks.go.plugin.access.analytics;
 
+import com.thoughtworks.go.plugin.access.analytics.V1.AnalyticsMessageConverterV1;
+
 import java.util.Arrays;
 import java.util.List;
 

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/analytics/V1/AnalyticsMessageConverterV1.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/analytics/V1/AnalyticsMessageConverterV1.java
@@ -14,10 +14,11 @@
  * limitations under the License.
  */
 
-package com.thoughtworks.go.plugin.access.analytics;
+package com.thoughtworks.go.plugin.access.analytics.V1;
 
 import com.google.gson.Gson;
-import com.thoughtworks.go.plugin.access.analytics.models.Capabilities;
+import com.thoughtworks.go.plugin.access.analytics.AnalyticsMessageConverter;
+import com.thoughtworks.go.plugin.access.analytics.V1.models.Capabilities;
 import com.thoughtworks.go.plugin.access.common.models.ImageDeserializer;
 import com.thoughtworks.go.plugin.domain.analytics.AnalyticsData;
 import com.thoughtworks.go.plugin.domain.common.Image;
@@ -46,7 +47,7 @@ public class AnalyticsMessageConverterV1 implements AnalyticsMessageConverter {
 
     @Override
     public AnalyticsData getAnalyticsFromResponseBody(String responseBody) {
-        com.thoughtworks.go.plugin.access.analytics.models.AnalyticsData analyticsData = com.thoughtworks.go.plugin.access.analytics.models.AnalyticsData.fromJSON(responseBody);
+        com.thoughtworks.go.plugin.access.analytics.V1.models.AnalyticsData analyticsData = com.thoughtworks.go.plugin.access.analytics.V1.models.AnalyticsData.fromJSON(responseBody);
 
         analyticsData.validate();
 

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/analytics/V1/models/AnalyticsData.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/analytics/V1/models/AnalyticsData.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2018 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.plugin.access.analytics.V1.models;
+
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.SerializedName;
+import org.apache.commons.lang3.StringUtils;
+
+public class AnalyticsData {
+    private static final Gson GSON = new GsonBuilder().excludeFieldsWithoutExposeAnnotation().create();
+
+    public static class MissingRequiredKeyException extends RuntimeException {
+        MissingRequiredKeyException(String message) {
+            super(message);
+        }
+    }
+
+    @Expose
+    @SerializedName("data")
+    String data;
+
+    @Expose
+    @SerializedName("view_path")
+    String viewPath;
+
+    public String getData() {
+        return data;
+    }
+
+    public String getViewPath() {
+        return viewPath;
+    }
+
+    public static AnalyticsData fromJSON(String json) {
+        return GSON.fromJson(json, AnalyticsData.class);
+    }
+
+    public com.thoughtworks.go.plugin.domain.analytics.AnalyticsData toAnalyticsData() {
+        return new com.thoughtworks.go.plugin.domain.analytics.AnalyticsData(data, viewPath);
+    }
+
+    public void validate() {
+        if (StringUtils.isBlank(data)) {
+            throw new MissingRequiredKeyException("Missing \"data\" key in analytics payload");
+        }
+
+        if (StringUtils.isBlank(viewPath)) {
+            throw new MissingRequiredKeyException("Missing \"view_path\" key in analytics payload");
+        }
+    }
+}

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/analytics/V1/models/Capabilities.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/analytics/V1/models/Capabilities.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2018 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.plugin.access.analytics.V1.models;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.SerializedName;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class Capabilities {
+    private static final Gson GSON = new GsonBuilder().excludeFieldsWithoutExposeAnnotation().create();
+
+    @Expose
+    @SerializedName("supported_analytics")
+    private List<SupportedAnalytics> supportedAnalytics;
+
+    public List<SupportedAnalytics> getSupportedAnalytics() {
+        return supportedAnalytics;
+    }
+
+    public Capabilities(List<SupportedAnalytics> supportedAnalytics) {
+        this.supportedAnalytics = supportedAnalytics;
+    }
+
+    public static Capabilities fromJSON(String json) {
+        return GSON.fromJson(json, Capabilities.class);
+    }
+
+    public com.thoughtworks.go.plugin.domain.analytics.Capabilities toCapabilities() {
+        return new com.thoughtworks.go.plugin.domain.analytics.Capabilities(supportedAnalytics());
+    }
+
+    private List<com.thoughtworks.go.plugin.domain.analytics.SupportedAnalytics> supportedAnalytics() {
+        ArrayList<com.thoughtworks.go.plugin.domain.analytics.SupportedAnalytics> list = new ArrayList<>();
+
+        if (this.supportedAnalytics != null) {
+            for (SupportedAnalytics analytics : this.supportedAnalytics) {
+                list.add(new com.thoughtworks.go.plugin.domain.analytics.SupportedAnalytics(analytics.getType(),
+                        analytics.getId(), analytics.getTitle()));
+            }
+        }
+
+        return list;
+    }
+}

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/analytics/V1/models/SupportedAnalytics.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/analytics/V1/models/SupportedAnalytics.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.thoughtworks.go.plugin.access.analytics.models;
+package com.thoughtworks.go.plugin.access.analytics.V1.models;
 
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/analytics/V2/AnalyticsMessageConverterV2.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/analytics/V2/AnalyticsMessageConverterV2.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2018 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.plugin.access.analytics.V2;
+
+import com.google.gson.Gson;
+import com.thoughtworks.go.plugin.access.analytics.AnalyticsMessageConverter;
+import com.thoughtworks.go.plugin.access.analytics.V2.models.Capabilities;
+import com.thoughtworks.go.plugin.access.common.models.ImageDeserializer;
+import com.thoughtworks.go.plugin.domain.analytics.AnalyticsData;
+import com.thoughtworks.go.plugin.domain.common.Image;
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class AnalyticsMessageConverterV2 implements AnalyticsMessageConverter {
+    public static final String VERSION = "2.0";
+    private static final Gson GSON = new Gson();
+
+    public String getAnalyticsRequestBody(String type, String metricId, Map params) {
+        Map<String, Object> requestMap = new HashMap<>();
+        requestMap.put("type", type);
+        requestMap.put("id", metricId);
+        requestMap.put("params", params);
+
+        return GSON.toJson(requestMap);
+    }
+
+    @Override
+    public com.thoughtworks.go.plugin.domain.analytics.Capabilities getCapabilitiesFromResponseBody(String responseBody) {
+        return Capabilities.fromJSON(responseBody).toCapabilities();
+    }
+
+    @Override
+    public AnalyticsData getAnalyticsFromResponseBody(String responseBody) {
+        com.thoughtworks.go.plugin.access.analytics.V2.models.AnalyticsData analyticsData = com.thoughtworks.go.plugin.access.analytics.V2.models.AnalyticsData.fromJSON(responseBody);
+
+        analyticsData.validate();
+
+        return analyticsData.toAnalyticsData();
+    }
+
+    @Override
+    public String getStaticAssetsFromResponseBody(String responseBody) {
+        String assets = (String) new Gson().fromJson(responseBody, Map.class).get("assets");
+
+        if (StringUtils.isBlank(assets)) {
+            throw new RuntimeException("No assets defined!");
+        }
+
+        return assets;
+    }
+
+    @Override
+    public Image getImageFromResponseBody(String responseBody) {
+        return new ImageDeserializer().fromJSON(responseBody);
+    }
+}

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/analytics/V2/models/AnalyticsData.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/analytics/V2/models/AnalyticsData.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.thoughtworks.go.plugin.access.analytics.models;
+package com.thoughtworks.go.plugin.access.analytics.V2.models;
 
 
 import com.google.gson.Gson;

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/analytics/V2/models/Capabilities.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/analytics/V2/models/Capabilities.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.thoughtworks.go.plugin.access.analytics.models;
+package com.thoughtworks.go.plugin.access.analytics.V2.models;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/analytics/V2/models/SupportedAnalytics.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/analytics/V2/models/SupportedAnalytics.java
@@ -14,13 +14,24 @@
  * limitations under the License.
  */
 
-package com.thoughtworks.go.plugin.domain.analytics;
+package com.thoughtworks.go.plugin.access.analytics.V2.models;
+
+import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.SerializedName;
 
 import java.util.Objects;
 
 public class SupportedAnalytics {
+    @Expose
+    @SerializedName("type")
     private String type;
+
+    @Expose
+    @SerializedName("id")
     private String id;
+
+    @Expose
+    @SerializedName("title")
     private String title;
 
     public SupportedAnalytics(String type, String id, String title) {

--- a/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/analytics/AnalyticsMessageConverterV1Test.java
+++ b/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/analytics/AnalyticsMessageConverterV1Test.java
@@ -17,6 +17,7 @@
 package com.thoughtworks.go.plugin.access.analytics;
 
 import com.google.gson.Gson;
+import com.thoughtworks.go.plugin.access.analytics.V1.AnalyticsMessageConverterV1;
 import com.thoughtworks.go.plugin.domain.analytics.AnalyticsData;
 import org.junit.Before;
 import org.junit.Rule;
@@ -54,7 +55,7 @@ public class AnalyticsMessageConverterV1Test {
     @Test
     public void shouldThrowExceptionIfDataKeyIsMissing() {
         String response = "{\"foo\": \"bar\"}";
-        thrown.expect(com.thoughtworks.go.plugin.access.analytics.models.AnalyticsData.MissingRequiredKeyException.class);
+        thrown.expect(com.thoughtworks.go.plugin.access.analytics.V1.models.AnalyticsData.MissingRequiredKeyException.class);
         thrown.expectMessage("Missing \"data\" key in analytics payload");
 
         converter.getAnalyticsFromResponseBody(response);
@@ -63,7 +64,7 @@ public class AnalyticsMessageConverterV1Test {
     @Test
     public void shouldThrowExceptionIfViewPathKeyIsMissing() {
         String response = "{\"data\": \"hi\", \"foo\": \"bar\"}";
-        thrown.expect(com.thoughtworks.go.plugin.access.analytics.models.AnalyticsData.MissingRequiredKeyException.class);
+        thrown.expect(com.thoughtworks.go.plugin.access.analytics.V1.models.AnalyticsData.MissingRequiredKeyException.class);
         thrown.expectMessage("Missing \"view_path\" key in analytics payload");
 
         converter.getAnalyticsFromResponseBody(response);

--- a/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/analytics/V1/models/CapabilitiesTest.java
+++ b/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/analytics/V1/models/CapabilitiesTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2018 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.plugin.access.analytics.V1.models;
+
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.is;
+
+public class CapabilitiesTest {
+
+    @Test
+    public void shouldDeserializeFromJSON() throws Exception {
+        String json = "{\n" +
+                "\"supported_analytics\": [\n" +
+                "  {\"type\": \"dashboard\", \"id\": \"abc\",  \"title\": \"Title 1\"},\n" +
+                "  {\"type\": \"pipeline\", \"id\": \"abc\",  \"title\": \"Title 1\"}\n" +
+                "]}";
+
+        Capabilities capabilities = Capabilities.fromJSON(json);
+
+        assertThat(capabilities.getSupportedAnalytics().size(), is(2));
+        assertThat(capabilities.getSupportedAnalytics().get(0), is(new SupportedAnalytics("dashboard", "abc", "Title 1")) );
+    }
+
+    @Test
+    public void shouldConvertToDomainCapabilities() throws Exception {
+        String json = "{\n" +
+                "\"supported_analytics\": [\n" +
+                "  {\"type\": \"dashboard\", \"id\": \"abc\",  \"title\": \"Title 1\"},\n" +
+                "  {\"type\": \"pipeline\", \"id\": \"abc\",  \"title\": \"Title 1\"}\n" +
+                "]}";
+
+        Capabilities capabilities = Capabilities.fromJSON(json);
+        com.thoughtworks.go.plugin.domain.analytics.Capabilities domain = capabilities.toCapabilities();
+
+        assertThat(domain.supportedDashboardAnalytics(), containsInAnyOrder(new com.thoughtworks.go.plugin.domain.analytics.SupportedAnalytics("dashboard", "abc", "Title 1")));
+        assertThat(domain.supportedPipelineAnalytics(), containsInAnyOrder(new com.thoughtworks.go.plugin.domain.analytics.SupportedAnalytics("pipeline", "abc", "Title 1")));
+    }
+}

--- a/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/analytics/V2/models/CapabilitiesTest.java
+++ b/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/analytics/V2/models/CapabilitiesTest.java
@@ -14,9 +14,11 @@
  * limitations under the License.
  */
 
-package com.thoughtworks.go.plugin.access.analytics.models;
+package com.thoughtworks.go.plugin.access.analytics.V2.models;
 
 import org.junit.Test;
+
+import java.util.Arrays;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -29,13 +31,16 @@ public class CapabilitiesTest {
         String json = "{\n" +
                 "\"supported_analytics\": [\n" +
                 "  {\"type\": \"dashboard\", \"id\": \"abc\",  \"title\": \"Title 1\"},\n" +
-                "  {\"type\": \"pipeline\", \"id\": \"abc\",  \"title\": \"Title 1\"}\n" +
+                "  {\"type\": \"pipeline\", \"id\": \"abc\",  \"title\": \"Title 2\"},\n" +
+                "  {\"type\": \"vsm\", \"id\": \"abc\",  \"title\": \"Title 3\", \"required_params\": [\"param1\", \"param2\"]}\n" +
                 "]}";
 
         Capabilities capabilities = Capabilities.fromJSON(json);
 
-        assertThat(capabilities.getSupportedAnalytics().size(), is(2));
+        assertThat(capabilities.getSupportedAnalytics().size(), is(3));
         assertThat(capabilities.getSupportedAnalytics().get(0), is(new SupportedAnalytics("dashboard", "abc", "Title 1")) );
+        assertThat(capabilities.getSupportedAnalytics().get(1), is(new SupportedAnalytics("pipeline", "abc", "Title 2")) );
+        assertThat(capabilities.getSupportedAnalytics().get(2), is(new SupportedAnalytics("vsm", "abc", "Title 3")) );
     }
 
     @Test
@@ -43,13 +48,15 @@ public class CapabilitiesTest {
         String json = "{\n" +
                 "\"supported_analytics\": [\n" +
                 "  {\"type\": \"dashboard\", \"id\": \"abc\",  \"title\": \"Title 1\"},\n" +
-                "  {\"type\": \"pipeline\", \"id\": \"abc\",  \"title\": \"Title 1\"}\n" +
+                "  {\"type\": \"pipeline\", \"id\": \"abc\",  \"title\": \"Title 2\"},\n" +
+                "  {\"type\": \"vsm\", \"id\": \"abc\",  \"title\": \"Title 3\", \"required_params\": [\"param1\", \"param2\"]}\n" +
                 "]}";
 
         Capabilities capabilities = Capabilities.fromJSON(json);
         com.thoughtworks.go.plugin.domain.analytics.Capabilities domain = capabilities.toCapabilities();
 
         assertThat(domain.supportedDashboardAnalytics(), containsInAnyOrder(new com.thoughtworks.go.plugin.domain.analytics.SupportedAnalytics("dashboard", "abc", "Title 1")));
-        assertThat(domain.supportedPipelineAnalytics(), containsInAnyOrder(new com.thoughtworks.go.plugin.domain.analytics.SupportedAnalytics("pipeline", "abc", "Title 1")));
+        assertThat(domain.supportedPipelineAnalytics(), containsInAnyOrder(new com.thoughtworks.go.plugin.domain.analytics.SupportedAnalytics("pipeline", "abc", "Title 2")));
+        assertThat(domain.supportedVSMAnalytics(), containsInAnyOrder(new com.thoughtworks.go.plugin.domain.analytics.SupportedAnalytics("vsm", "abc", "Title 3")));
     }
 }

--- a/plugin-infra/go-plugin-domain/src/main/java/com/thoughtworks/go/plugin/domain/analytics/Capabilities.java
+++ b/plugin-infra/go-plugin-domain/src/main/java/com/thoughtworks/go/plugin/domain/analytics/Capabilities.java
@@ -24,6 +24,7 @@ public class Capabilities {
     private final List<SupportedAnalytics> supportedAnalytics;
     private static final String DASHBOARD_TYPE = "dashboard";
     private static final String PIPELINE_TYPE = "pipeline";
+    private static final String VSM_TYPE = "vsm";
 
     public Capabilities(List<SupportedAnalytics> supportedAnalytics) {
         this.supportedAnalytics = supportedAnalytics;
@@ -41,6 +42,10 @@ public class Capabilities {
         return hasSupportFor(DASHBOARD_TYPE);
     }
 
+    public boolean supportsVSMAnalytics() {
+        return hasSupportFor(VSM_TYPE);
+    }
+
     public List<String> supportedAnalyticsDashboardMetrics() {
         return this.supportedAnalytics.stream().filter(s -> DASHBOARD_TYPE.equalsIgnoreCase(s.getType())).map(SupportedAnalytics::getTitle).collect(Collectors.toList());
     }
@@ -51,6 +56,10 @@ public class Capabilities {
 
     public List<SupportedAnalytics> supportedPipelineAnalytics() {
         return this.supportedAnalytics.stream().filter(s -> PIPELINE_TYPE.equalsIgnoreCase(s.getType())).collect(Collectors.toList());
+    }
+
+    public List<SupportedAnalytics> supportedVSMAnalytics() {
+        return this.supportedAnalytics.stream().filter(s -> VSM_TYPE.equalsIgnoreCase(s.getType())).collect(Collectors.toList());
     }
 
     private boolean hasSupportFor(String analyticsType) {

--- a/plugin-infra/go-plugin-domain/src/test/java/com/thoughtworks/go/plugin/domain/analytics/CapabilitiesTest.java
+++ b/plugin-infra/go-plugin-domain/src/test/java/com/thoughtworks/go/plugin/domain/analytics/CapabilitiesTest.java
@@ -26,7 +26,7 @@ import static org.junit.Assert.*;
 
 public class CapabilitiesTest {
     @Test
-    public void shouldSupportDashboardAnalyticsIfPluginListsDashboardMetricsAsCapability() throws Exception {
+    public void shouldSupportDashboardAnalyticsIfPluginListsDashboardMetricsAsCapability() {
         assertTrue(new Capabilities(Collections.singletonList(new SupportedAnalytics("dashboard", "id", "title"))).supportsDashboardAnalytics());
         assertTrue(new Capabilities(Collections.singletonList(new SupportedAnalytics("DashBoard", "id", "title"))).supportsDashboardAnalytics());
 
@@ -34,7 +34,7 @@ public class CapabilitiesTest {
     }
 
     @Test
-    public void shouldSupportPipelineAnalyticsIfPluginListsPipelineMetricsAsCapability() throws Exception {
+    public void shouldSupportPipelineAnalyticsIfPluginListsPipelineMetricsAsCapability() {
         assertTrue(new Capabilities(Collections.singletonList(new SupportedAnalytics("pipeline", "id", "title"))).supportsPipelineAnalytics());
         assertTrue(new Capabilities(Collections.singletonList(new SupportedAnalytics("PipeLine", "id", "title"))).supportsPipelineAnalytics());
 
@@ -42,31 +42,49 @@ public class CapabilitiesTest {
     }
 
     @Test
-    public void shouldListSupportedDashBoardAnalytics() throws Exception {
-        Capabilities capabilities = new Capabilities(Arrays.asList(new SupportedAnalytics("dashboard", "id1", "title1"),
-                new SupportedAnalytics("DashBoard", "id2", "title2")));
+    public void shouldSupportVSMAnalyticsIfPluginListsVSMMetricsAsCapability() {
+        assertTrue(new Capabilities(Collections.singletonList(new SupportedAnalytics("vsm", "id", "title" ))).supportsVSMAnalytics());
+        assertTrue(new Capabilities(Collections.singletonList(new SupportedAnalytics("VsM", "id", "title" ))).supportsVSMAnalytics());
+
+        assertFalse(new Capabilities(Collections.emptyList()).supportsPipelineAnalytics());
+    }
+
+    @Test
+    public void shouldListSupportedDashBoardAnalytics() {
+        Capabilities capabilities = new Capabilities(Arrays.asList(new SupportedAnalytics("dashboard", "id1", "title1" ),
+                new SupportedAnalytics("DashBoard", "id2", "title2" )));
 
         assertThat(capabilities.supportedAnalyticsDashboardMetrics(), is(Arrays.asList("title1", "title2")));
         assertTrue(new Capabilities(Collections.emptyList()).supportedAnalyticsDashboardMetrics().isEmpty());
     }
 
     @Test
-    public void shouldListSupportedAnalyticsForDashboard() throws Exception {
-        Capabilities capabilities = new Capabilities(Arrays.asList(new SupportedAnalytics("dashboard", "id1", "title1"),
-                new SupportedAnalytics("DashBoard", "id2", "title2")));
+    public void shouldListSupportedAnalyticsForDashboard() {
+        Capabilities capabilities = new Capabilities(Arrays.asList(new SupportedAnalytics("dashboard", "id1", "title1" ),
+                new SupportedAnalytics("DashBoard", "id2", "title2" )));
 
-        assertThat(capabilities.supportedDashboardAnalytics(), is(Arrays.asList(new SupportedAnalytics("dashboard", "id1", "title1"),
-                new SupportedAnalytics("DashBoard", "id2", "title2"))));
+        assertThat(capabilities.supportedDashboardAnalytics(), is(Arrays.asList(new SupportedAnalytics("dashboard", "id1", "title1" ),
+                new SupportedAnalytics("DashBoard", "id2", "title2" ))));
         assertTrue(new Capabilities(Collections.emptyList()).supportedDashboardAnalytics().isEmpty());
     }
 
     @Test
-    public void shouldListSupportedAnalyticsForPipelines() throws Exception {
-        Capabilities capabilities = new Capabilities(Arrays.asList(new SupportedAnalytics("pipeline", "id1", "title1"),
-                new SupportedAnalytics("Pipeline", "id2", "title2")));
+    public void shouldListSupportedAnalyticsForPipelines() {
+        Capabilities capabilities = new Capabilities(Arrays.asList(new SupportedAnalytics("pipeline", "id1", "title1" ),
+                new SupportedAnalytics("Pipeline", "id2", "title2" )));
 
-        assertThat(capabilities.supportedPipelineAnalytics(), is(Arrays.asList(new SupportedAnalytics("pipeline", "id1", "title1"),
-                new SupportedAnalytics("Pipeline", "id2", "title2"))));
+        assertThat(capabilities.supportedPipelineAnalytics(), is(Arrays.asList(new SupportedAnalytics("pipeline", "id1", "title1" ),
+                new SupportedAnalytics("Pipeline", "id2", "title2" ))));
         assertTrue(new Capabilities(Collections.emptyList()).supportedPipelineAnalytics().isEmpty());
+    }
+
+    @Test
+    public void shouldListSupportedAnalyticsForVSM() {
+        Capabilities capabilities = new Capabilities(Arrays.asList(new SupportedAnalytics("vsm", "id1", "title1" ),
+                new SupportedAnalytics("VsM", "id2", "title2" )));
+
+        assertThat(capabilities.supportedVSMAnalytics(), is(Arrays.asList(new SupportedAnalytics("vsm", "id1", "title1" ),
+                new SupportedAnalytics("VsM", "id2", "title2" ))));
+        assertTrue(new Capabilities(Collections.emptyList()).supportedVSMAnalytics().isEmpty());
     }
 }

--- a/server/webapp/WEB-INF/rails.new/app/assets/javascripts/analytics.js
+++ b/server/webapp/WEB-INF/rails.new/app/assets/javascripts/analytics.js
@@ -20,7 +20,8 @@
       $.ajax({
         url: options.url,
         dataType: "json",
-        type: "GET"
+        data: options.data,
+        type: options.type || "GET"
       }).done(function(r) {
         var frame = document.createElement("iframe");
         frame.sandbox = "allow-scripts";

--- a/server/webapp/WEB-INF/rails.new/app/assets/javascripts/prototype_overrides.js
+++ b/server/webapp/WEB-INF/rails.new/app/assets/javascripts/prototype_overrides.js
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2018 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+(function () {
+  "use strict";
+
+  var PrototypeOverrides = function PrototypeOverrides() {
+    this.overrideJSONStringify = function () {
+      var _json_stringify = JSON.stringify;
+      JSON.stringify = function (value) {
+        var _array_tojson = Array.prototype.toJSON;
+        delete Array.prototype.toJSON;
+        var r = _json_stringify(value);
+        Array.prototype.toJSON = _array_tojson;
+        return r;
+      };
+    };
+  };
+
+  if ("undefined" !== typeof module) {
+    module.exports = PrototypeOverrides;
+  } else {
+    window.PrototypeOverrides = PrototypeOverrides;
+  }
+})();

--- a/server/webapp/WEB-INF/rails.new/app/assets/javascripts/vsm.js
+++ b/server/webapp/WEB-INF/rails.new/app/assets/javascripts/vsm.js
@@ -34,7 +34,4 @@ VSM = function(data, container, renderer, preloader){
             preloader.hide();
         }
     }
-
-
-
 };

--- a/server/webapp/WEB-INF/rails.new/app/assets/javascripts/vsm_analytics.js
+++ b/server/webapp/WEB-INF/rails.new/app/assets/javascripts/vsm_analytics.js
@@ -1,0 +1,172 @@
+/*
+ * Copyright 2018 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+(function () {
+  "use strict";
+
+  var currentNodeIndex = function currentNodeIndex(vsmGraph) {
+    if (vsmGraph.current_material) return 0;
+
+    return _.findIndex(vsmGraph.levels, function (level) {
+      return _.find(level.nodes, function (node) {
+        return node.id === vsmGraph.current_pipeline;
+      });
+    });
+  };
+
+  var Node = function Node(type, id, index) {
+    this.id    = id;
+    this.type  = type;
+    this.index = index;
+  };
+
+  var MaterialNode = function MaterialNode(fingerprint, name, index) {
+    Node.call(this, 'material', fingerprint, index);
+    this.name = name;
+  };
+
+  var PipelineNode = function PipelineNode(name, index) {
+    Node.call(this, 'pipeline', name, index);
+    this.name = name;
+  };
+
+  var currentNode = function currentNode(vsmGraph) {
+    if ($j.trim(vsmGraph.current_pipeline)) {
+      return new PipelineNode(vsmGraph.current_pipeline, currentNodeIndex(vsmGraph));
+    } else {
+      return new MaterialNode(vsmGraph.current_material, vsmGraph.current_material, currentNodeIndex(vsmGraph));
+    }
+  };
+
+  var showAnalytics = function showAnalytics(options) {
+    var div = document.createElement("div");
+
+    PluginEndpointRequestHandler.defineLinkHandler();
+    PluginEndpoint.ensure("v1");
+    $j(div).addClass("vsm_modal");
+    $j("#analytics-overlay").append(div);
+
+    $j.ajax({
+      url:      options.url,
+      dataType: "json",
+      data:     options.data,
+      type:     options.type || "GET"
+    }).done(function (r) {
+      var frame     = document.createElement("iframe");
+      frame.sandbox = "allow-scripts";
+
+      frame.onload = function (e) {
+        PluginEndpoint.init(frame.contentWindow, {initialData: r.data});
+      };
+
+      div.appendChild(frame);
+      frame.setAttribute("src", "/go/" + r.view_path);
+    }).fail(function (xhr) {
+      if (xhr.getResponseHeader("content-type").indexOf("text/html") !== -1) {
+        var frame = document.createElement("iframe");
+        frame.src = "data:text/html;charset=utf-8," + xhr.responseText;
+        div.appendChild(frame);
+        return;
+      }
+      var errorEl = document.createElement("div");
+      $(errorEl).addClass("error");
+      errorEl.textContent = xhr.responseText;
+      div.appendChild(errorEl);
+    });
+  };
+
+  var VSMAnalytics = function VSMAnalytics(data, graphRenderer, showAnalyticsPath, analyticsPanel, analyticsButton) {
+    var self              = this;
+    var panel             = analyticsPanel;
+    var analyticsButton   = analyticsButton;
+    var vsmGraph          = VSMGraph.fromJSON(data);
+    var current           = currentNode(vsmGraph);
+    var graphRenderer     = graphRenderer;
+    var showAnalyticsPath = showAnalyticsPath;
+
+    var otherNode;
+
+    var source = function source() {
+      return current.index < otherNode.index ? current.id : otherNode.id;
+    };
+
+    var destination = function destination() {
+      return otherNode.index > current.index ? otherNode.id : current.id;
+    };
+
+    var renderAnalytics = function renderAnalytics() {
+      $j("#analytics-overlay").removeClass("hide");
+      $j("body").addClass("noscroll");
+      showAnalytics({
+        url:  showAnalyticsPath,
+        type: 'POST',
+        data: self.jsonData()
+      });
+    };
+
+    this.jsonData = function () {
+      return {
+        source:      source().toString(),
+        destination: destination().toString(),
+        vsm_graph:   JSON.stringify(vsmGraph)
+      };
+    };
+
+    this.init = function () {
+      new PrototypeOverrides().overrideJSONStringify();
+      graphRenderer.registerSelectPipelineCallback(this.selectPipeline);
+      graphRenderer.registerSelectMaterialCallback(this.selectMaterial);
+
+      panel.registerCloseCallback(this.disableAnalytics);
+      panel.registerViewAnalyticsCallback(renderAnalytics);
+
+      $j(analyticsButton).click(this.enableAnalytics);
+    };
+
+    this.enableAnalytics = function () {
+      panel.show();
+      graphRenderer.enableAnalyticsMode();
+    };
+
+    this.disableAnalytics = function () {
+      $j("#analytics-overlay").addClass("hide");
+      $j("#analytics-overlay").empty();
+      graphRenderer.disableAnalyticsMode();
+    };
+
+    this.selectPipeline = function (pipelineName, level) {
+      if (!pipelineName) return;
+
+      otherNode = new PipelineNode(pipelineName, level);
+
+      level < current.index ? panel.upstream(pipelineName) : panel.downstream(pipelineName);
+    };
+
+    this.selectMaterial = function (materialName, fingerprint, level) {
+      if ("material" === current.type) return;
+
+      otherNode = new MaterialNode(fingerprint, materialName, level);
+
+      panel.material(materialName);
+    };
+  };
+
+  if ("undefined" !== typeof module) {
+    module.exports = VSMAnalytics;
+  } else {
+    window.VSMAnalytics = VSMAnalytics;
+  }
+})();

--- a/server/webapp/WEB-INF/rails.new/app/assets/javascripts/vsm_analytics_pipeline_panel.js
+++ b/server/webapp/WEB-INF/rails.new/app/assets/javascripts/vsm_analytics_pipeline_panel.js
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2018 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+(function () {
+  "use strict";
+
+  var VSMAnalyticsPipelinePanel = function VSMAnalyticsPipelinePanel(cont) {
+    var self = this;
+    var container = cont;
+    var selectedPipelines = "#selected-pipelines";
+    var selectPipelines = "#select-pipelines";
+    var viewAnalyticsButton = ".view-vsm-analytics";
+
+    var closeCallback = void 0;
+
+    var init = function init() {
+      $j(container).find(".analytics-close").click(self.hide);
+    };
+
+    this.show = function () {
+      $j(container).show();
+    };
+
+    var showSelected = function showSelected() {
+      $j(selectedPipelines).removeClass("hide");
+      $j(selectPipelines).addClass("hide");
+      enableViewAnalytics();
+    };
+
+    var showSelectionInfo = function showSelectionInfo() {
+      $j(selectPipelines).removeClass("hide");
+      $j(selectedPipelines).addClass("hide");
+    };
+
+    var enableViewAnalytics = function enableViewAnalytics() {
+      $j(viewAnalyticsButton).removeClass("disabled");
+    };
+
+    var disableViewAnalytics = function disableViewAnalytics() {
+      $j(viewAnalyticsButton).addClass("disabled");
+    };
+
+    this.reset = function () {
+      showSelectionInfo();
+      disableViewAnalytics();
+      $j(selectedPipelines).find(".analytics_downstream").show();
+      $j(selectedPipelines).find(".analytics-upstream .selected-name").text("");
+      $j(selectedPipelines).find(".analytics-upstream").show();
+      $j(selectedPipelines).find(".analytics-downstream .selected-name").text("");
+    };
+
+    this.hide = function () {
+      $j(container).hide();
+      closeCallback();
+      self.reset();
+    };
+
+    this.upstream = function (pipelineName) {
+      $j(selectedPipelines).find(".analytics-downstream").hide();
+      $j(selectedPipelines).find(".analytics-upstream .selected-name").text(pipelineName);
+      $j(selectedPipelines).find(".analytics-upstream").show();
+      showSelected();
+    };
+
+    this.downstream = function (pipelineName) {
+      $j(selectedPipelines).find(".analytics-upstream").hide();
+      $j(selectedPipelines).find(".analytics-downstream .selected-name").text(pipelineName);
+      $j(selectedPipelines).find(".analytics-downstream").show();
+      showSelected();
+    };
+
+    this.material = function (materialName) {
+      self.upstream(materialName);
+    };
+
+    this.registerCloseCallback = function (callback) {
+      closeCallback = callback;
+    };
+
+    this.registerViewAnalyticsCallback = function (callback) {
+      $j(container).find(".view-vsm-analytics").click(callback);
+    };
+
+    init();
+  };
+
+  if ("undefined" !== typeof module) {
+    module.exports = VSMAnalyticsPipelinePanel;
+  } else {
+    window.VSMAnalyticsPipelinePanel = VSMAnalyticsPipelinePanel;
+  }
+})();

--- a/server/webapp/WEB-INF/rails.new/app/assets/javascripts/vsm_graph.js
+++ b/server/webapp/WEB-INF/rails.new/app/assets/javascripts/vsm_graph.js
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2018 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+"use strict";
+
+(function () {
+  "use strict";
+
+  var VSMGraph = function VSMGraph(data) {
+    this.current_pipeline = data.current_pipeline;
+    this.current_material = data.current_material;
+    this.levels           = data.levels;
+
+    var dummyNodeMap = {};
+
+    data.levels.forEach(function (level) {
+      level.nodes.forEach(function (node) {
+        if (node.type === "DUMMY") dummyNodeMap[node.id] = node;
+      });
+    });
+
+    var dummyNodeIds = Object.keys(dummyNodeMap);
+
+    var resolveDummyDependents = function resolveDummyDependents(levels) {
+      levels.forEach(function (level) {
+        level.nodes.forEach(function (node) {
+          dummyDependentsFor(node).forEach(function (dummyDependent) {
+            node.dependents[node.dependents.indexOf(dummyDependent)] = actualDependentNodeFor(dummyDependent);
+          });
+        });
+      });
+    };
+
+    var resolveDummyParents = function resolveDummyParents(levels) {
+      levels.forEach(function (level) {
+        level.nodes.forEach(function (node) {
+          dummyParentsFor(node).forEach(function (dep) {
+            node.parents[node.parents.indexOf(dep)] = actualParentNodeFor(dep);
+          });
+        });
+      });
+    };
+
+    var dummyDependentsFor = function dummyDependentsFor(node) {
+      return node.dependents.filter(function (dependentNodeId) {
+        return dummyNodeIds.indexOf(dependentNodeId) >= 0;
+      });
+    };
+
+    var dummyParentsFor = function dummyParentsFor(node) {
+      return node.parents.filter(function (parentNodeId) {
+        return dummyNodeIds.indexOf(parentNodeId) >= 0;
+      });
+    };
+
+    var actualDependentNodeFor = function actualDependentNodeFor(dep) {
+      var node = dummyNodeMap[dep];
+      if (dummyNodeIds.indexOf(node.dependents[0]) === -1) {
+        return node.dependents[0];
+      }
+      return actualDependentNodeFor(node.dependents[0]);
+    };
+
+    var actualParentNodeFor = function actualParentNodeFor(dep) {
+      var node = dummyNodeMap[dep];
+      if (dummyNodeIds.indexOf(node.parents[0]) === -1) {
+        return node.parents[0];
+      }
+      return actualParentNodeFor(node.parents[0]);
+    };
+
+    var removeDummyNodes = function removeDummyNodes(levels) {
+      levels.forEach(function (level) {
+        level.nodes = level.nodes.filter(function (node) {
+          return node.type !== "DUMMY";
+        });
+      });
+    };
+
+    resolveDummyDependents(this.levels);
+    resolveDummyParents(this.levels);
+    removeDummyNodes(this.levels);
+  };
+
+  VSMGraph.fromJSON = function (json) {
+    return new VSMGraph({
+      current_pipeline: json.current_pipeline,
+      current_material: json.current_material,
+      levels:           json.levels.map(function (level) {
+        return VSMGraph.Level.fromJSON(level);
+      })
+    });
+  };
+
+  VSMGraph.Level = function (data) {
+    this.nodes = data.nodes;
+  };
+
+  VSMGraph.Level.fromJSON = function (json) {
+    return new VSMGraph.Level({
+      nodes: json.nodes.map(function (node) {
+        if (node.node_type === "PIPELINE") return PipelineDependencyNode.fromJSON(node);
+        if (node.node_type === "DUMMY") return DummyNode.fromJSON(node);
+        return SCMDependencyNode.fromJSON(node);
+      })
+    });
+  };
+
+  if ("undefined" !== typeof module) {
+    module.exports = VSMGraph;
+  } else {
+    window.VSMGraph = VSMGraph;
+  }
+})();

--- a/server/webapp/WEB-INF/rails.new/app/assets/javascripts/vsm_node.js
+++ b/server/webapp/WEB-INF/rails.new/app/assets/javascripts/vsm_node.js
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2018 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+(function () {
+  "use strict";
+
+  var PipelineDependencyNode = function PipelineDependencyNode(data) {
+    this.id         = data.id;
+    this.name       = data.name;
+    this.parents    = data.parents || [];
+    this.dependents = data.dependents || [];
+    this.type       = data.type;
+    this.instances  = data.instances;
+  };
+
+  PipelineDependencyNode.fromJSON = function (json) {
+    return new PipelineDependencyNode({
+      id:         json.id,
+      name:       json.name,
+      type:       json.node_type,
+      parents:    json.parents ? json.parents.slice(0) : [],
+      dependents: json.dependents ? json.dependents.slice(0) : [],
+      instances:  json.instances.map(function (instance) {
+        return PipelineDependencyNode.Instance.fromJSON(instance);
+      }).filter(function (i) {
+        return i;
+      })
+    });
+  };
+
+  PipelineDependencyNode.Instance = function (data) {
+    this.counter = data.counter;
+    this.label   = data.label;
+    this.stages  = data.stages;
+  };
+
+  PipelineDependencyNode.Instance.fromJSON = function (json) {
+    if (json.counter == 0) {
+      return null;
+    }
+
+    return new PipelineDependencyNode.Instance({
+      counter: json.counter,
+      label:   json.label,
+      stages:  json.stages.map(function (stage) {
+        return PipelineDependencyNode.Instance.Stage.fromJSON(stage);
+      })
+    });
+  };
+
+  PipelineDependencyNode.Instance.Stage = function (data) {
+    this.name     = data.name;
+    this.status   = data.status;
+    this.counter  = data.counter;
+    this.duration = data.duration;
+  };
+
+  PipelineDependencyNode.Instance.Stage.fromJSON = function (json) {
+    return new PipelineDependencyNode.Instance.Stage({
+      name:     json.name,
+      status:   json.status,
+      counter:  parseInt(json.locator.split("/").last()),
+      duration: json.duration
+    });
+  };
+
+  var SCMDependencyNode = function SCMDependencyNode(data) {
+    this.id                 = data.id;
+    this.name               = data.name;
+    this.parents            = data.parents;
+    this.dependents         = data.dependents;
+    this.type               = data.type;
+    this.material_revisions = data.material_revisions;
+  };
+
+  SCMDependencyNode.fromJSON = function (json) {
+    return new SCMDependencyNode({
+      id:                 json.id,
+      name:               json.name,
+      type:               json.node_type,
+      parents:            json.parents ? json.parents.slice(0) : [],
+      dependents:         json.dependents ? json.dependents.slice(0) : [],
+      material_revisions: json.material_revisions.map(function (mr) {
+        return SCMDependencyNode.MaterialRevision.fromJSON(mr);
+      })
+    });
+  };
+
+  SCMDependencyNode.MaterialRevision = function (data) {
+    this.modifications = data.modifications;
+  };
+
+  SCMDependencyNode.MaterialRevision.fromJSON = function (json) {
+    return new SCMDependencyNode.MaterialRevision({
+      modifications: json.modifications.map(function (m) {
+        return new SCMDependencyNode.MaterialRevision.Modification.fromJSON(m);
+      })
+    });
+  };
+
+  SCMDependencyNode.MaterialRevision.Modification = function (data) {
+    this.revision = data.revision;
+  };
+
+  SCMDependencyNode.MaterialRevision.Modification.fromJSON = function (json) {
+    return new SCMDependencyNode.MaterialRevision.Modification({
+      revision: json.revision
+    });
+  };
+
+  var DummyNode = function DummyNode(data) {
+    this.id         = data.id;
+    this.parents    = data.parents;
+    this.dependents = data.dependents;
+    this.type       = data.type;
+  };
+
+  DummyNode.fromJSON = function (json) {
+    return new SCMDependencyNode({
+      id:         json.id,
+      type:       json.node_type,
+      parents:    json.parents ? json.parents.slice(0) : [],
+      dependents: json.dependents ? json.dependents.slice(0) : []
+    });
+  };
+
+  if ("undefined" !== typeof module) {
+    module.exports = PipelineDependencyNode;
+    module.exports = SCMDependencyNode;
+    module.exports = DummyNode;
+  } else {
+    window.PipelineDependencyNode = PipelineDependencyNode;
+    window.SCMDependencyNode = SCMDependencyNode;
+    window.DummyNode = DummyNode;
+  }
+})();

--- a/server/webapp/WEB-INF/rails.new/app/assets/stylesheets/_vsm.scss
+++ b/server/webapp/WEB-INF/rails.new/app/assets/stylesheets/_vsm.scss
@@ -1,0 +1,268 @@
+/*!
+ * Copyright 2018 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@import "../new_stylesheets/shared/mixins";
+
+//Variables
+
+$border-color: #ccc;
+$anaytics-header-bg: #fff;
+$primary-color: #b66fc2;
+$secondary-color: #2db1c1;
+$global-border-radius: 3px;
+
+//buttons
+
+$btn-primary: #943a9e;
+$btn-secondary: #666;
+$btn-default: #d6d5d5;
+
+%btn {
+  border:        1px solid transparent;
+  padding:       7px 20px;
+  border-radius: 3px;
+  font-weight:   600;
+  font-size:     16px;
+  margin:        0 10px;
+}
+
+.noscroll {
+  overflow: hidden;
+}
+
+%node-selection {
+  @include icon-before('check-circle', $margin: 0, $size: 16px);
+  &:before {
+    color:         $primary-color;
+    font-size:     25px;
+    margin-right:  5px;
+    position:      absolute;
+    left:          -11px;
+    top:           -12px;
+    background:    #fff;
+    width:         19px;
+    border-radius: 50%;
+    height:        19px;
+  }
+
+}
+
+.vsm-entity.current.vsm-current-node {
+  @extend %node-selection;
+  &:before {
+    color: $primary-color;
+  }
+  border: 2px solid $primary-color;
+  &.material{
+    &:before {
+      left: 50%;
+      top: -12px;
+      transform: translateX(-50%);
+    }
+  }
+}
+
+.vsm-other-node {
+  @extend %node-selection;
+  &:before {
+    color: $secondary-color;
+  }
+  border: 2px solid $secondary-color;
+  box-shadow: 0 0 2px 2px #CCCCCC;
+  &.material{
+    &:before {
+      left: 50%;
+      top: -12px;
+      transform: translateX(-50%);
+    }
+  }
+}
+
+.analytics-overlay {
+  position:   fixed;
+  top:        148px;
+  left:       0;
+  right:      0;
+  height:     100vh;
+  z-index:    1000;
+  bottom:     0;
+  width:      100%;
+  background: #fff;
+  transition: all 0.3s ease-in-out;
+  &.hide {
+    height:     0;
+    transition: all 0.3s ease-in-out;
+    display:    block;
+  }
+}
+
+.vsm_modal {
+  width:    800px;
+  height:   480px;
+  top:      6%;
+  margin:   0 auto;
+  border:   1px solid #ccc;
+  position: relative;
+  iframe {
+    width:  100%;
+    height: 100%;
+  }
+}
+
+.btn-primary {
+  &.disabled {
+    opacity: 0.3;
+    cursor:  not-allowed;
+  }
+}
+
+.btn-secondary {
+  @extend %btn;
+  background:   $btn-secondary;
+  border-color: $btn-secondary;
+  color:        #fff;
+  &:focus, &:active {
+    outline: 0;
+  }
+  &.disabled {
+    opacity: 0.3;
+    cursor:  not-allowed;
+  }
+}
+
+//vsm analytics
+
+.enable-analytics {
+  font-size: 16px;
+  margin:    4px 0 0 50px;
+  border:    1px solid $border-color;
+  padding:   5px;
+}
+
+.vsm-analytics-panel {
+  @include clearfix;
+  background: $anaytics-header-bg;
+  padding:    10px;
+  position:   relative;
+  display:    none;
+}
+
+.analytics-close {
+  @include icon-before('close', $margin: 10, $size: 20px);
+  @extend %btn;
+}
+
+%sel-item {
+  font-size:   16px;
+  font-weight: 600;
+  display:     flex;
+  align-items: center;
+}
+
+%stream_sel {
+  @extend %sel-item;
+  &.empty {
+    border:        1px dotted $primary-color;
+    width:         140px;
+    height:        35px;
+    border-radius: $global-border-radius;
+  }
+}
+
+.selected-name {
+  @include icon-before('check-circle', $margin: 0, $size: 16px);
+  &:before {
+    color:        $secondary-color;
+    font-size:    20px;
+    margin-right: 5px;
+  }
+}
+
+.vsm-analytics-selection {
+  float:     left;
+  position:  relative;
+  transform: translateX(-50%);
+  left:      calc(50% - 150px);
+}
+
+.hide {
+  display: none;
+}
+
+.select_streams {
+  display:       flex;
+  justify-items: center;
+  li {
+    display:  flex;
+    position: relative;
+  }
+}
+
+.no-close .ui-dialog-titlebar-close {
+  display: none;
+}
+
+.vsm-analytics-help {
+  text-align: center;
+  display:    block;
+  margin-top: 5px;
+}
+
+.analytics-current {
+  @include icon-before('check-circle', $margin: 0, $size: 16px);
+  font-size:   14px;
+  color:       #000;
+  font-weight: 700;
+  display:     flex;
+  align-items: center;
+  &:before {
+    color:        $primary-color;
+    font-size:    20px;
+    margin-right: 5px;
+    margin-left:  5px;
+  }
+}
+
+.analytics-upstream {
+  @extend %stream_sel;
+  margin-right: 110px;
+  &:after {
+    content:    "";
+    border-top: 1px dotted $primary-color;
+    display:    block;
+    width:      95px;
+    position:   absolute;
+    left:       105%;
+  }
+}
+
+.analytics-downstream {
+  @extend %stream_sel;
+  margin-left: 110px;
+  &:before {
+    content:    "";
+    border-top: 1px dotted $primary-color;
+    display:    block;
+    width:      95px;
+    position:   absolute;
+    right:      105%;
+  }
+}
+
+.vsm-analytics-actions {
+  float:   right;
+  display: flex;
+}
+

--- a/server/webapp/WEB-INF/rails.new/app/assets/stylesheets/application.scss
+++ b/server/webapp/WEB-INF/rails.new/app/assets/stylesheets/application.scss
@@ -39,6 +39,7 @@
  *= require_tree ./views
  *= require 'new-css/about'
  *= require '_new-footer-with-old-css'
+ *= require '_vsm'
  */
 
 @import "font-awesome-sprockets";

--- a/server/webapp/WEB-INF/rails.new/app/assets/stylesheets/module.scss
+++ b/server/webapp/WEB-INF/rails.new/app/assets/stylesheets/module.scss
@@ -2901,7 +2901,6 @@ li.task_property {
     border-radius: 70px;
     height: 140px;
     width: 140px;
-    overflow: hidden;
     box-sizing: border-box;
     z-index: 1;
 }
@@ -2923,9 +2922,8 @@ li.task_property {
     line-height: 0.4em;
     overflow: hidden;
     text-align: center;
-    margin-left: -20px;
-    margin-right: -20px;
     margin-bottom: 5px;
+    border-radius: 20px;
 }
 
 .vsm-entity.material .more:hover {

--- a/server/webapp/WEB-INF/rails.new/app/helpers/application_helper.rb
+++ b/server/webapp/WEB-INF/rails.new/app/helpers/application_helper.rb
@@ -517,13 +517,39 @@ module ApplicationHelper
     end.nil?
   end
 
+  def supports_vsm_analytics?
+    return false unless is_user_an_admin?
+    !default_plugin_info_finder.allPluginInfos(PluginConstants.ANALYTICS_EXTENSION).detect do |combined_plugin_info|
+      combined_plugin_info.extensionFor(PluginConstants.ANALYTICS_EXTENSION).getCapabilities().supportsVSMAnalytics()
+    end.nil?
+  end
+
   def with_analytics_dashboard_support(&block)
     return unless block_given? && is_user_an_admin?
 
     yield if supports_analytics_dashboard?
   end
 
+  def show_vsm_analytics_path
+    plugin_info = first_plugin_which_supports_vsm_analytics
+    if (plugin_info)
+      supported_analytics = plugin_info.getCapabilities().supportedVSMAnalytics().get(0)
+      show_analytics_path({plugin_id: plugin_info.getDescriptor().id(), type: 'vsm', id: supported_analytics.getId()})
+    end
+  end
+
   private
+  def show_analytics_only_for_admins?
+    system_environment.enableAnalyticsOnlyForAdmins
+  end
+
+  def first_plugin_which_supports_vsm_analytics
+    default_plugin_info_finder.allPluginInfos(PluginConstants.ANALYTICS_EXTENSION).each do |combined_plugin_info|
+      extension_info = combined_plugin_info.extensionFor(PluginConstants.ANALYTICS_EXTENSION)
+      return extension_info if extension_info.getCapabilities().supportsVSMAnalytics()
+    end
+  end
+
   def form_remote_tag(options = {})
     options[:form] = true
 

--- a/server/webapp/WEB-INF/rails.new/app/views/value_stream_map/_analytics_panel.html.erb
+++ b/server/webapp/WEB-INF/rails.new/app/views/value_stream_map/_analytics_panel.html.erb
@@ -1,0 +1,41 @@
+<div class="vsm-analytics-panel" id="vsm-analytics-panel">
+  <div id="select-pipelines" class="vsm-analytics-selection">
+    <ul class="select_streams">
+      <% if scope[:is_vsm_for_pipeline] %>
+        <li class="analytics-upstream empty"/>
+      <% end %>
+      <li>
+          <span class="analytics-current">
+            <%= scope[:current] %>
+          </span>
+      </li>
+      <li class="analytics-downstream empty"/>
+    </ul>
+    <span class="vsm-analytics-help">Select a pipeline/material to view analytics</span>
+  </div>
+
+  <div id="selected-pipelines" class="vsm-analytics-selection hide">
+    <ul class="select_streams">
+      <% if scope[:is_vsm_for_pipeline] %>
+        <li class="analytics-upstream">
+          <span class="selected-name"></span>
+        </li>
+      <% end %>
+      <li>
+          <span class="analytics-current">
+            <%= scope[:current] %>
+          </span>
+      </li>
+      <li class="analytics-downstream">
+        <span class="selected-name"></span>
+      </li>
+    </ul>
+  </div>
+  <div class="vsm-analytics-actions">
+    <button title="View Analytics" class="view-vsm-analytics btn-primary disabled">
+      View Analytics
+    </button>
+    <button class="analytics-close"></button>
+  </div>
+  <div id="analytics-overlay" class="analytics-overlay hide"></div>
+</div>

--- a/server/webapp/WEB-INF/rails.new/app/views/value_stream_map/show.html.erb
+++ b/server/webapp/WEB-INF/rails.new/app/views/value_stream_map/show.html.erb
@@ -8,11 +8,18 @@
           <%=link_to params[:pipeline_name], url_for_pipeline(params[:pipeline_name]) %></li>
         <li class="last">
           <span class="label">Instance</span>
-          <h1><%= @pipeline!=nil ? @pipeline.getLabel() : params[:pipeline_counter] %> </h1></li>
+          <h1><%= @pipeline!=nil ? @pipeline.getLabel() : params[:pipeline_counter] %> </h1>
+        </li>
     </ul>
+    <% if (supports_vsm_analytics?) %>
+      <button class="fa fa-bar-chart enable-analytics"/>
+    <% end %>
 </div>
 
 <div class="content">
+  <% if supports_vsm_analytics? %>
+    <%= render :partial => "analytics_panel.html", :locals => {:scope => {:is_vsm_for_pipeline => true, :current => params[:pipeline_name]}} -%>
+  <% end %>
   <div id="vsm-container">
   </div>
   <div id="vsm-overlay">
@@ -25,7 +32,7 @@
 
         resizeMapContainer();
         function resizeMapContainer() {
-            $j( "#vsm-container").height($j(window).height() - 160);
+            $j("#vsm-container").height($j(window).height() - 160);
         }
         $j(window).resize(function() {
             resizeMapContainer();
@@ -36,7 +43,15 @@
         jQuery.ajax({
             url: "<%= vsm_show_path(:pipeline_name => params[:pipeline_name], :pipeline_counter => params[:pipeline_counter], :format => 'json')%>"
         }).done(function (data) {
-            vsm = new VSM(data, "#vsm-container", new Graph_Renderer("#vsm-container"), "#pre-loader-overlay").render();
+          graphRenderer = new Graph_Renderer("#vsm-container");
+
+          if (data.error == null && <%= supports_vsm_analytics? %>) {
+            vsmAnalyticsPipelinePanel = new VSMAnalyticsPipelinePanel(".vsm-analytics-panel");
+            vsm_analytics             = new VSMAnalytics(data, graphRenderer, "<%= show_vsm_analytics_path %>", vsmAnalyticsPipelinePanel, ".enable-analytics");
+            vsm_analytics.init();
+          }
+
+          vsm = new VSM(data, "#vsm-container", graphRenderer, "#pre-loader-overlay").render();
         })
 
     })

--- a/server/webapp/WEB-INF/rails.new/app/views/value_stream_map/show_material.html.erb
+++ b/server/webapp/WEB-INF/rails.new/app/views/value_stream_map/show_material.html.erb
@@ -10,9 +10,15 @@
       <span class="label">Revision</span>
       <h1><%= params[:revision] %> </h1></li>
   </ul>
+  <% if (supports_vsm_analytics?) %>
+    <button class="fa fa-bar-chart enable-analytics"/>
+  <% end %>
 </div>
 
 <div class="content">
+  <% if supports_vsm_analytics? %>
+    <%= render :partial => "analytics_panel.html", :locals => {:scope => {:is_vsm_for_pipeline => false, :current => @material_display_name}} -%>
+  <% end %>
   <div id="vsm-container">
   </div>
   <div id="vsm-overlay">
@@ -36,7 +42,15 @@
         jQuery.ajax({
             url: "<%= vsm_show_material_path(:material_fingerprint => params[:material_fingerprint], :revision => params[:revision], :format => 'json')%>"
         }).done(function (data) {
-            vsm = new VSM(data, "#vsm-container", new Graph_Renderer("#vsm-container"), "#pre-loader-overlay").render();
+          graphRenderer = new Graph_Renderer("#vsm-container");
+
+          if (data.error == null && <%= supports_vsm_analytics? %>) {
+            vsmAnalyticsPipelinePanel = new VSMAnalyticsPipelinePanel(".vsm-analytics-panel");
+            vsm_analytics             = new VSMAnalytics(data, graphRenderer, "<%= show_vsm_analytics_path %>", vsmAnalyticsPipelinePanel, ".enable-analytics");
+            vsm_analytics.init();
+          }
+
+          vsm = new VSM(data, "#vsm-container", graphRenderer, "#pre-loader-overlay").render();
         })
 
     })

--- a/server/webapp/WEB-INF/rails.new/lib/java_imports.rb
+++ b/server/webapp/WEB-INF/rails.new/lib/java_imports.rb
@@ -272,7 +272,6 @@ module JavaImports
   java_import com.thoughtworks.go.config.security.Permissions unless defined? Permissions
   java_import com.thoughtworks.go.config.security.users.Everyone unless defined? Everyone
   java_import com.thoughtworks.go.config.security.users.NoOne unless defined? NoOne
-  java_import com.thoughtworks.go.plugin.access.analytics.AnalyticsExtension unless defined? AnalyticsExtension
   java_import com.thoughtworks.go.plugin.domain.common.PluginConstants unless defined? PluginConstants
   java_import com.thoughtworks.go.plugin.domain.common.BadPluginInfo unless defined? BadPluginInfo
   java_import com.thoughtworks.go.plugin.domain.analytics.SupportedAnalytics unless defined? SupportedAnalytics

--- a/server/webapp/WEB-INF/rails.new/lib/services.rb
+++ b/server/webapp/WEB-INF/rails.new/lib/services.rb
@@ -44,7 +44,6 @@ module Services
   services(
     :admin_service,
     :agent_service,
-    :analytics_extension,
     :artifacts_dir_holder,
     :backup_service,
     :cc_tray_service,

--- a/server/webapp/WEB-INF/rails.new/spec/helpers/pipelines_helper_spec.rb
+++ b/server/webapp/WEB-INF/rails.new/spec/helpers/pipelines_helper_spec.rb
@@ -173,6 +173,7 @@ describe PipelinesHelper do
       @plugin_info4 = CombinedPluginInfo.new(AnalyticsPluginInfo.new(descriptor.call('plugin3'), nil, supports_analytics.call(false, false), nil))
 
     end
+
     it "should find the first plugin where pipeline analytics are supported" do
       def default_plugin_info_finder; @default_plugin_info_finder; end
       def is_user_an_admin?; true; end

--- a/server/webapp/WEB-INF/rails.new/spec/javascripts/value_stream_map_renderer_spec.js
+++ b/server/webapp/WEB-INF/rails.new/spec/javascripts/value_stream_map_renderer_spec.js
@@ -468,7 +468,7 @@ describe("value_stream_map_renderer", function () {
         assertEquals("pipeline should show all instance details.", "1 less...", jQuery("#downstream .show-more").find("a").text());
     });
 
-    it("shouldShowThePipelineRunDurationForACompeltedPipeline", function() {
+    it("shouldShowThePipelineRunDurationForACompletedPipeline", function() {
       var completedPipeline = '{"stages": [{"locator": "/go/pipelines/current/1/defaultStage/1","status": "Passed","name": "defaultStage", "duration": 63},' +
         '{"locator": "/go/pipelines/current/1/NextStage/1","status": "Failed","name": "NextStage", "duration": 63},' +
         '{"locator": "/go/pipelines/current/1/ManualStage/1","status": "Unknown","name": "manualStage", "duration": null}],' +

--- a/server/webapp/WEB-INF/rails.new/spec/javascripts/vsm_analytics_spec.js
+++ b/server/webapp/WEB-INF/rails.new/spec/javascripts/vsm_analytics_spec.js
@@ -1,0 +1,252 @@
+/*
+ * Copyright 2018 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+describe("vsm_analytics", function () {
+
+  function VSMRenderer() {}
+
+  AnalyticsPanel = {
+    downstream: function downstream(name) {},
+    upstream: function upstream(name) {},
+    material: function material(name) {}
+  };
+
+  describe("selectPipeline", function () {
+    it("should have current pipeline as source if the a downstream pipeline is selected", function () {
+      var graph = jQuery.extend({ "current_pipeline": "P3" }, vsmGraphJSON());
+      var vsmAnalytics = new VSMAnalytics(graph, new VSMRenderer(), "analytics_path", AnalyticsPanel, "button");
+      spyOn(AnalyticsPanel, "downstream");
+
+      vsmAnalytics.selectPipeline("P4", 3);
+
+      expect(vsmAnalytics.jsonData()["source"]).toBe("P3");
+      expect(vsmAnalytics.jsonData()["destination"]).toBe("P4");
+      expect(AnalyticsPanel.downstream).toHaveBeenCalledWith("P4");
+    });
+
+    it("should have current_pipeline as destination if an upstream node is selected", function () {
+      var graph = jQuery.extend({ "current_pipeline": "P3" }, vsmGraphJSON());
+      var vsmAnalytics = new VSMAnalytics(graph, new VSMRenderer(), "analytics_path", AnalyticsPanel, "button");
+      spyOn(AnalyticsPanel, "upstream");
+
+      vsmAnalytics.selectPipeline("P1", 1);
+
+      expect(vsmAnalytics.jsonData()["source"]).toBe("P1");
+      expect(vsmAnalytics.jsonData()["destination"]).toBe("P3");
+      expect(AnalyticsPanel.upstream).toHaveBeenCalledWith("P1");
+    });
+
+    it("should have current_material as source and downstream pipeline as destination", function () {
+      var graph = jQuery.extend({ "current_material": "3795dca7e793e62cfde2e8e2898efee05bde08c99700cff0ec96d68ad4522629" }, vsmGraphJSON());
+      var vsmAnalytics = new VSMAnalytics(graph, new VSMRenderer(), "analytics_path", AnalyticsPanel, "button");
+      spyOn(AnalyticsPanel, "downstream");
+
+      vsmAnalytics.selectPipeline("P1", 1);
+
+      expect(vsmAnalytics.jsonData()["source"]).toBe("3795dca7e793e62cfde2e8e2898efee05bde08c99700cff0ec96d68ad4522629");
+      expect(vsmAnalytics.jsonData()["destination"]).toBe("P1");
+      expect(AnalyticsPanel.downstream).toHaveBeenCalledWith("P1");
+    });
+
+    it("should do nothing in absence of pipeline name", function () {
+      var graph = jQuery.extend({ "current_pipeline": "P3" }, vsmGraphJSON());
+      var vsmAnalytics = new VSMAnalytics(graph, new VSMRenderer(), "analytics_path", AnalyticsPanel, "button");
+      spyOn(AnalyticsPanel, "upstream");
+      spyOn(AnalyticsPanel, "downstream");
+
+      vsmAnalytics.selectPipeline(undefined, 1);
+
+      expect(AnalyticsPanel.upstream).not.toHaveBeenCalled();
+      expect(AnalyticsPanel.downstream).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("selectMaterial", function () {
+    it("should have current_pipeline as destination node if a scm node is selected", function () {
+      var graph = jQuery.extend({ "current_pipeline": "P3" }, vsmGraphJSON());
+      var vsmAnalytics = new VSMAnalytics(graph, new VSMRenderer(), "analytics_path", AnalyticsPanel, "button");
+      spyOn(AnalyticsPanel, "material");
+
+      vsmAnalytics.selectMaterial("name", "3795dca7e793e62cfde2e8e2898efee05bde08c99700cff0ec96d68ad4522629", 0);
+
+      expect(vsmAnalytics.jsonData()["source"]).toBe("3795dca7e793e62cfde2e8e2898efee05bde08c99700cff0ec96d68ad4522629");
+      expect(vsmAnalytics.jsonData()["destination"]).toBe("P3");
+      expect(AnalyticsPanel.material).toHaveBeenCalledWith("name");
+    });
+
+    it("should do nothing if showing vsm for material", function () {
+      var graph = jQuery.extend({ "current_material": "3795dca7e793e62cfde2e8e2898efee05bde08c99700cff0ec96d68ad4522629" }, vsmGraphJSON());
+      var vsmAnalytics = new VSMAnalytics(graph, new VSMRenderer(), "analytics_path", AnalyticsPanel, "button");
+      spyOn(AnalyticsPanel, "material");
+
+      vsmAnalytics.selectMaterial("name", "3795dca7e793e62cfde2e8e2898efee05bde08c99700cff0ec96d68ad4522629", 0);
+
+      expect(AnalyticsPanel.material).not.toHaveBeenCalled();
+    });
+  });
+
+  var vsmGraphJSON = function vsmGraphJSON() {
+    return {
+      "levels": [{
+        "nodes": [{
+          "dependents": ["P1", "P2", "8fe9bcb1-3d58-4e1a-89ce-83709609a8d9"],
+          "depth": 1,
+          "id": "3795dca7e793e62cfde2e8e2898efee05bde08c99700cff0ec96d68ad4522629",
+          "instances": [],
+          "locator": "",
+          "material_revisions": [{
+            "modifications": [{
+              "comment": "rm lkjsdf",
+              "locator": "/go/materials/value_stream_map/3795dca7e793e62cfde2e8e2898efee05bde08c99700cff0ec96d68ad4522629/2a13c2e8cf1661d905099e7297dba3c5b58bce7c",
+              "modified_time": "6 days ago",
+              "revision": "2a13c2e8cf1661d905099e7297dba3c5b58bce7c",
+              "user": "user_name"
+            }]
+          }],
+          "name": "material_name",
+          "node_type": "GIT",
+          "parents": []
+        }]
+      }, {
+        "nodes": [{
+          "can_edit": true,
+          "dependents": ["P3"],
+          "depth": 1,
+          "edit_path": "/go/admin/pipelines/P1/general",
+          "id": "P1",
+          "instances": [{
+            "counter": 1,
+            "label": "1",
+            "locator": "/go/pipelines/value_stream_map/P1/1",
+            "stages": [{
+              "duration": 30,
+              "locator": "/go/pipelines/P1/1/defaultStage/1",
+              "name": "defaultStage",
+              "status": "Passed"
+            }]
+          }],
+          "locator": "/go/tab/pipeline/history/P1",
+          "name": "P1",
+          "node_type": "PIPELINE",
+          "parents": ["3795dca7e793e62cfde2e8e2898efee05bde08c99700cff0ec96d68ad4522629"]
+        }, {
+          "can_edit": true,
+          "dependents": ["P3"],
+          "depth": 2,
+          "edit_path": "/go/admin/pipelines/P2/general",
+          "id": "P2",
+          "instances": [{
+            "counter": 1,
+            "label": "1",
+            "locator": "/go/pipelines/value_stream_map/P2/1",
+            "stages": [{
+              "duration": 52,
+              "locator": "/go/pipelines/P2/1/defaultStage/1",
+              "name": "defaultStage",
+              "status": "Passed"
+            }]
+          }],
+          "locator": "/go/tab/pipeline/history/P2",
+          "name": "P2",
+          "node_type": "PIPELINE",
+          "parents": ["3795dca7e793e62cfde2e8e2898efee05bde08c99700cff0ec96d68ad4522629"]
+        }, {
+          "dependents": ["a5adb455-6f0a-4100-ae2b-c2bf0b863ca8"],
+          "depth": 3,
+          "id": "8fe9bcb1-3d58-4e1a-89ce-83709609a8d9",
+          "instances": [],
+          "locator": "",
+          "name": "dummy-8fe9bcb1-3d58-4e1a-89ce-83709609a8d9",
+          "node_type": "DUMMY",
+          "parents": ["3795dca7e793e62cfde2e8e2898efee05bde08c99700cff0ec96d68ad4522629"]
+        }]
+      }, {
+        "nodes": [{
+          "can_edit": true,
+          "dependents": ["P4"],
+          "depth": 1,
+          "edit_path": "/go/admin/pipelines/P3/general",
+          "id": "P3",
+          "instances": [{
+            "counter": 1,
+            "label": "1",
+            "locator": "/go/pipelines/value_stream_map/P3/1",
+            "stages": [{
+              "duration": 13,
+              "locator": "/go/pipelines/P3/1/defaultStage/1",
+              "name": "defaultStage",
+              "status": "Passed"
+            }]
+          }],
+          "locator": "/go/tab/pipeline/history/P3",
+          "name": "P3",
+          "node_type": "PIPELINE",
+          "parents": ["P1", "P2"]
+        }, {
+          "dependents": ["P4"],
+          "depth": 2,
+          "id": "9e02d1ae843b55f2cf77af4dbaba38e2dfaf8f86d4ca4c890a4ba9396bfc26c8",
+          "instances": [],
+          "locator": "",
+          "material_revisions": [{
+            "modifications": [{
+              "comment": "add asd",
+              "locator": "/go/materials/value_stream_map/9e02d1ae843b55f2cf77af4dbaba38e2dfaf8f86d4ca4c890a4ba9396bfc26c8/ad67c8a52dd0ed18e722ef526b7818ad0959df19",
+              "modified_time": "8 days ago",
+              "revision": "ad67c8a52dd0ed18e722ef526b7818ad0959df19",
+              "user": "user_name"
+            }]
+          }],
+          "name": "/Users/maheshp/work/go/test_repo",
+          "node_type": "GIT",
+          "parents": []
+        }, {
+          "dependents": ["P4"],
+          "depth": 3,
+          "id": "a5adb455-6f0a-4100-ae2b-c2bf0b863ca8",
+          "instances": [],
+          "locator": "",
+          "name": "dummy-a5adb455-6f0a-4100-ae2b-c2bf0b863ca8",
+          "node_type": "DUMMY",
+          "parents": ["8fe9bcb1-3d58-4e1a-89ce-83709609a8d9"]
+        }]
+      }, {
+        "nodes": [{
+          "can_edit": true,
+          "dependents": [],
+          "depth": 1,
+          "edit_path": "/go/admin/pipelines/P4/general",
+          "id": "P4",
+          "instances": [{
+            "counter": 3,
+            "label": "3",
+            "locator": "/go/pipelines/value_stream_map/P4/3",
+            "stages": [{
+              "duration": 17,
+              "locator": "/go/pipelines/P4/3/defaultStage/1",
+              "name": "defaultStage",
+              "status": "Passed"
+            }]
+          }],
+          "locator": "/go/tab/pipeline/history/P4",
+          "name": "P4",
+          "node_type": "PIPELINE",
+          "parents": ["P3", "a5adb455-6f0a-4100-ae2b-c2bf0b863ca8", "9e02d1ae843b55f2cf77af4dbaba38e2dfaf8f86d4ca4c890a4ba9396bfc26c8"]
+        }]
+      }]
+    };
+  };
+});

--- a/server/webapp/WEB-INF/rails.new/spec/javascripts/vsm_graph_spec.js
+++ b/server/webapp/WEB-INF/rails.new/spec/javascripts/vsm_graph_spec.js
@@ -1,0 +1,479 @@
+/*
+ * Copyright 2018 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+describe("vsm_graph", function () {
+
+  describe("fromJSON", function () {
+    it("should de-serialize graph from JSON", function () {
+      const vsmGraph = VSMGraph.fromJSON(vsmGraphJSON());
+
+      expect(vsmGraph.current_pipeline).toBe("P4");
+      expect(vsmGraph.levels.size()).toBe(4);
+
+      expect(vsmGraph.levels[0].nodes.size()).toBe(1);
+      expect(vsmGraph.levels[0].nodes[0].id).toBe("3795dca7e793e62cfde2e8e2898efee05bde08c99700cff0ec96d68ad4522629");
+      expect(vsmGraph.levels[0].nodes[0].dependents.size()).toBe(3);
+      expect(vsmGraph.levels[0].nodes[0].dependents).toContain("P1");
+      expect(vsmGraph.levels[0].nodes[0].dependents).toContain("P2");
+      expect(vsmGraph.levels[0].nodes[0].dependents).toContain("P4");
+      expect(vsmGraph.levels[0].nodes[0].parents.size()).toBe(0);
+
+      expect(vsmGraph.levels[1].nodes.size()).toBe(2);
+      expect(vsmGraph.levels[1].nodes[0].id).toBe("P1");
+      expect(vsmGraph.levels[1].nodes[0].parents.size()).toBe(1);
+      expect(vsmGraph.levels[1].nodes[0].parents).toContain("3795dca7e793e62cfde2e8e2898efee05bde08c99700cff0ec96d68ad4522629");
+      expect(vsmGraph.levels[1].nodes[0].dependents.size()).toBe(1);
+      expect(vsmGraph.levels[1].nodes[0].dependents).toContain("P3");
+      expect(vsmGraph.levels[1].nodes[1].id).toBe("P2");
+      expect(vsmGraph.levels[1].nodes[1].parents.size()).toBe(1);
+      expect(vsmGraph.levels[1].nodes[1].parents).toContain("3795dca7e793e62cfde2e8e2898efee05bde08c99700cff0ec96d68ad4522629");
+      expect(vsmGraph.levels[1].nodes[1].dependents.size()).toBe(1);
+      expect(vsmGraph.levels[1].nodes[1].dependents).toContain("P3");
+
+      expect(vsmGraph.levels[2].nodes.size()).toBe(2);
+      expect(vsmGraph.levels[2].nodes[0].id).toBe("P3");
+      expect(vsmGraph.levels[2].nodes[0].parents.size()).toBe(2);
+      expect(vsmGraph.levels[2].nodes[0].parents).toContain("P1");
+      expect(vsmGraph.levels[2].nodes[0].parents).toContain("P2");
+      expect(vsmGraph.levels[2].nodes[0].dependents.size()).toBe(1);
+      expect(vsmGraph.levels[2].nodes[0].dependents).toContain("P4");
+      expect(vsmGraph.levels[2].nodes[1].id).toBe("9e02d1ae843b55f2cf77af4dbaba38e2dfaf8f86d4ca4c890a4ba9396bfc26c8");
+      expect(vsmGraph.levels[2].nodes[1].parents.size()).toBe(0);
+      expect(vsmGraph.levels[2].nodes[1].dependents.size()).toBe(1);
+      expect(vsmGraph.levels[2].nodes[1].dependents).toContain("P4");
+
+      expect(vsmGraph.levels[3].nodes.size()).toBe(1);
+      expect(vsmGraph.levels[3].nodes[0].id).toBe("P4");
+      expect(vsmGraph.levels[3].nodes[0].parents.size()).toBe(3);
+      expect(vsmGraph.levels[3].nodes[0].parents).toContain("P3");
+      expect(vsmGraph.levels[3].nodes[0].parents).toContain("3795dca7e793e62cfde2e8e2898efee05bde08c99700cff0ec96d68ad4522629");
+      expect(vsmGraph.levels[3].nodes[0].parents).toContain("9e02d1ae843b55f2cf77af4dbaba38e2dfaf8f86d4ca4c890a4ba9396bfc26c8");
+      expect(vsmGraph.levels[3].nodes[0].dependents.size()).toBe(0);
+    });
+
+    it("should leave the original JSON intact", function () {
+      const graph = vsmGraphJSON();
+
+      VSMGraph.fromJSON(graph);
+
+      expect(vsmGraphJSON()).toEqual(graph);
+    });
+  });
+
+  describe("toJSON", function () {
+    it("should serialize a vsm graph to JSON", function () {
+      const vsmGraph = VSMGraph.fromJSON(vsmGraphJSON());
+
+      const jsonString = JSON.stringify(vsmGraph);
+      const json       = JSON.parse(jsonString);
+
+      expect(json['current_pipeline']).toBe("P4");
+      expect(json).toEqual(vsmGraphForAnalytics);
+    });
+  });
+
+  const vsmGraphForAnalytics = {
+    "current_pipeline": "P4",
+    "levels":           [
+      {
+        "nodes": [
+          {
+            "id":                 "3795dca7e793e62cfde2e8e2898efee05bde08c99700cff0ec96d68ad4522629",
+            "name":               "material_name",
+            "parents":            [],
+            "dependents":         [
+              "P1",
+              "P2",
+              "P4"
+            ],
+            "type":               "GIT",
+            "material_revisions": [
+              {
+                "modifications": [
+                  {
+                    "revision": "2a13c2e8cf1661d905099e7297dba3c5b58bce7c",
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "nodes": [
+          {
+            "dependents": [
+              "P3"
+            ],
+            "id":         "P1",
+            "instances":  [
+              {
+                "counter": 1,
+                "label":   "1",
+                "stages":  [
+                  {
+                    "duration": 30,
+                    "name":     "defaultStage",
+                    "status":   "Passed",
+                    "counter":  1
+                  }
+                ]
+              }
+            ],
+            "name":       "P1",
+            "type":       "PIPELINE",
+            "parents":    [
+              "3795dca7e793e62cfde2e8e2898efee05bde08c99700cff0ec96d68ad4522629"
+            ]
+          },
+          {
+            "dependents": [
+              "P3"
+            ],
+            "id":         "P2",
+            "instances":  [
+              {
+                "counter": 1,
+                "label":   "1",
+                "stages":  [
+                  {
+                    "duration": 52,
+                    "name":     "defaultStage",
+                    "status":   "Passed",
+                    "counter":  1
+                  }
+                ]
+              }
+            ],
+            "name":       "P2",
+            "type":       "PIPELINE",
+            "parents":    [
+              "3795dca7e793e62cfde2e8e2898efee05bde08c99700cff0ec96d68ad4522629"
+            ]
+          },
+        ]
+      },
+      {
+        "nodes": [
+          {
+            "dependents": [
+              "P4"
+            ],
+            "id":         "P3",
+            "instances":  [
+              {
+                "counter": 1,
+                "label":   "1",
+                "stages":  [
+                  {
+                    "duration": 13,
+                    "name":     "defaultStage",
+                    "status":   "Passed",
+                    "counter":  1
+                  }
+                ]
+              }
+            ],
+            "name":       "P3",
+            "type":       "PIPELINE",
+            "parents":    [
+              "P1",
+              "P2"
+            ]
+          },
+          {
+            "dependents":         [
+              "P4"
+            ],
+            "id":                 "9e02d1ae843b55f2cf77af4dbaba38e2dfaf8f86d4ca4c890a4ba9396bfc26c8",
+            "material_revisions": [
+              {
+                "modifications": [
+                  {
+                    "revision": "ad67c8a52dd0ed18e722ef526b7818ad0959df19",
+                  }
+                ]
+              }
+            ],
+            "name":               "/Users/maheshp/work/go/test_repo",
+            "type":               "GIT",
+            "parents":            []
+          }
+        ]
+      },
+      {
+        "nodes": [
+          {
+            "dependents": [],
+            "id":         "P4",
+            "instances":  [
+              {
+                "counter": 3,
+                "label":   "3",
+                "stages":  [
+                  {
+                    "duration": 17,
+                    "name":     "defaultStage",
+                    "status":   "Passed",
+                    "counter":  1
+                  }
+                ]
+              }
+            ],
+            "name":       "P4",
+            "type":       "PIPELINE",
+            "parents":    [
+              "P3",
+              "3795dca7e793e62cfde2e8e2898efee05bde08c99700cff0ec96d68ad4522629",
+              "9e02d1ae843b55f2cf77af4dbaba38e2dfaf8f86d4ca4c890a4ba9396bfc26c8"
+            ]
+          }
+        ]
+      }
+    ]
+  };
+
+  const vsmGraphJSON = function () {
+    new PrototypeOverrides().overrideJSONStringify();
+    return JSON.parse(JSON.stringify({
+      "current_pipeline"
+    :
+      "P4",
+        "levels"
+    :
+      [
+        {
+          "nodes": [
+            {
+              "dependents":         [
+                "P1",
+                "P2",
+                "8fe9bcb1-3d58-4e1a-89ce-83709609a8d9"
+              ],
+              "depth":              1,
+              "id":                 "3795dca7e793e62cfde2e8e2898efee05bde08c99700cff0ec96d68ad4522629",
+              "instances":          [],
+              "locator":            "",
+              "material_revisions": [
+                {
+                  "modifications": [
+                    {
+                      "comment":       "rm lkjsdf",
+                      "locator":       "/go/materials/value_stream_map/3795dca7e793e62cfde2e8e2898efee05bde08c99700cff0ec96d68ad4522629/2a13c2e8cf1661d905099e7297dba3c5b58bce7c",
+                      "modified_time": "6 days ago",
+                      "revision":      "2a13c2e8cf1661d905099e7297dba3c5b58bce7c",
+                      "user":          "user_name"
+                    }
+                  ]
+                }
+              ],
+              "name":               "material_name",
+              "node_type":          "GIT",
+              "parents":            []
+            }
+          ]
+        },
+        {
+          "nodes": [
+            {
+              "can_edit":   true,
+              "dependents": [
+                "P3"
+              ],
+              "depth":      1,
+              "edit_path":  "/go/admin/pipelines/P1/general",
+              "id":         "P1",
+              "instances":  [
+                {
+                  "counter": 1,
+                  "label":   "1",
+                  "locator": "/go/pipelines/value_stream_map/P1/1",
+                  "stages":  [
+                    {
+                      "duration": 30,
+                      "locator":  "/go/pipelines/P1/1/defaultStage/1",
+                      "name":     "defaultStage",
+                      "status":   "Passed"
+                    }
+                  ]
+                }
+              ],
+              "locator":    "/go/tab/pipeline/history/P1",
+              "name":       "P1",
+              "node_type":  "PIPELINE",
+              "parents":    [
+                "3795dca7e793e62cfde2e8e2898efee05bde08c99700cff0ec96d68ad4522629"
+              ]
+            },
+            {
+              "can_edit":   true,
+              "dependents": [
+                "P3"
+              ],
+              "depth":      2,
+              "edit_path":  "/go/admin/pipelines/P2/general",
+              "id":         "P2",
+              "instances":  [
+                {
+                  "counter": 1,
+                  "label":   "1",
+                  "locator": "/go/pipelines/value_stream_map/P2/1",
+                  "stages":  [
+                    {
+                      "duration": 52,
+                      "locator":  "/go/pipelines/P2/1/defaultStage/1",
+                      "name":     "defaultStage",
+                      "status":   "Passed"
+                    }
+                  ]
+                }
+              ],
+              "locator":    "/go/tab/pipeline/history/P2",
+              "name":       "P2",
+              "node_type":  "PIPELINE",
+              "parents":    [
+                "3795dca7e793e62cfde2e8e2898efee05bde08c99700cff0ec96d68ad4522629"
+              ]
+            },
+            {
+              "dependents": [
+                "a5adb455-6f0a-4100-ae2b-c2bf0b863ca8"
+              ],
+              "depth":      3,
+              "id":         "8fe9bcb1-3d58-4e1a-89ce-83709609a8d9",
+              "instances":  [],
+              "locator":    "",
+              "name":       "dummy-8fe9bcb1-3d58-4e1a-89ce-83709609a8d9",
+              "node_type":  "DUMMY",
+              "parents":    [
+                "3795dca7e793e62cfde2e8e2898efee05bde08c99700cff0ec96d68ad4522629"
+              ]
+            }
+          ]
+        },
+        {
+          "nodes": [
+            {
+              "can_edit":   true,
+              "dependents": [
+                "P4"
+              ],
+              "depth":      1,
+              "edit_path":  "/go/admin/pipelines/P3/general",
+              "id":         "P3",
+              "instances":  [
+                {
+                  "counter": 1,
+                  "label":   "1",
+                  "locator": "/go/pipelines/value_stream_map/P3/1",
+                  "stages":  [
+                    {
+                      "duration": 13,
+                      "locator":  "/go/pipelines/P3/1/defaultStage/1",
+                      "name":     "defaultStage",
+                      "status":   "Passed"
+                    }
+                  ]
+                }
+              ],
+              "locator":    "/go/tab/pipeline/history/P3",
+              "name":       "P3",
+              "node_type":  "PIPELINE",
+              "parents":    [
+                "P1",
+                "P2"
+              ]
+            },
+            {
+              "dependents":         [
+                "P4"
+              ],
+              "depth":              2,
+              "id":                 "9e02d1ae843b55f2cf77af4dbaba38e2dfaf8f86d4ca4c890a4ba9396bfc26c8",
+              "instances":          [],
+              "locator":            "",
+              "material_revisions": [
+                {
+                  "modifications": [
+                    {
+                      "comment":       "add asd",
+                      "locator":       "/go/materials/value_stream_map/9e02d1ae843b55f2cf77af4dbaba38e2dfaf8f86d4ca4c890a4ba9396bfc26c8/ad67c8a52dd0ed18e722ef526b7818ad0959df19",
+                      "modified_time": "8 days ago",
+                      "revision":      "ad67c8a52dd0ed18e722ef526b7818ad0959df19",
+                      "user":          "user_name"
+                    }
+                  ]
+                }
+              ],
+              "name":               "/Users/maheshp/work/go/test_repo",
+              "node_type":          "GIT",
+              "parents":            []
+            },
+            {
+              "dependents": [
+                "P4"
+              ],
+              "depth":      3,
+              "id":         "a5adb455-6f0a-4100-ae2b-c2bf0b863ca8",
+              "instances":  [],
+              "locator":    "",
+              "name":       "dummy-a5adb455-6f0a-4100-ae2b-c2bf0b863ca8",
+              "node_type":  "DUMMY",
+              "parents":    [
+                "8fe9bcb1-3d58-4e1a-89ce-83709609a8d9"
+              ]
+            }
+          ]
+        },
+        {
+          "nodes": [
+            {
+              "can_edit":   true,
+              "dependents": [],
+              "depth":      1,
+              "edit_path":  "/go/admin/pipelines/P4/general",
+              "id":         "P4",
+              "instances":  [
+                {
+                  "counter": 3,
+                  "label":   "3",
+                  "locator": "/go/pipelines/value_stream_map/P4/3",
+                  "stages":  [
+                    {
+                      "duration": 17,
+                      "locator":  "/go/pipelines/P4/3/defaultStage/1",
+                      "name":     "defaultStage",
+                      "status":   "Passed"
+                    }
+                  ]
+                }
+              ],
+              "locator":    "/go/tab/pipeline/history/P4",
+              "name":       "P4",
+              "node_type":  "PIPELINE",
+              "parents":    [
+                "P3",
+                "a5adb455-6f0a-4100-ae2b-c2bf0b863ca8",
+                "9e02d1ae843b55f2cf77af4dbaba38e2dfaf8f86d4ca4c890a4ba9396bfc26c8"
+              ]
+            }
+          ]
+        }
+      ]
+    }));
+  }
+
+});

--- a/server/webapp/WEB-INF/rails.new/spec/javascripts/vsm_node_spec.js
+++ b/server/webapp/WEB-INF/rails.new/spec/javascripts/vsm_node_spec.js
@@ -1,0 +1,209 @@
+/*
+ * Copyright 2018 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+describe("vsm_node", function () {
+
+  describe("fromJSON", function () {
+    it("should deserialize a pipeline dependency node from JSON", function () {
+      var node = PipelineDependencyNode.fromJSON(nodeJSON);
+
+      expect(node.id).toBe("build-linux");
+      expect(node.name).toBe("build-linux");
+      expect(node.type).toBe("PIPELINE");
+      expect(node.parents).toContain("21f6ea93b7");
+      expect(node.dependents).toContain("plugins");
+
+      expect(node.instances.size()).toBe(1);
+      expect(node.instances[0].counter).toBe(2590);
+      expect(node.instances[0].label).toBe("2590");
+
+      expect(node.instances[0].stages.size()).toBe(2);
+      expect(node.instances[0].stages[0].name).toBe("build-non-server");
+      expect(node.instances[0].stages[0].status).toBe("Passed");
+      expect(node.instances[0].stages[0].counter).toBe(2);
+      expect(node.instances[0].stages[0].duration).toBe(326);
+
+      expect(node.instances[0].stages[1].name).toBe("build-server");
+      expect(node.instances[0].stages[1].status).toBe("Passed");
+      expect(node.instances[0].stages[1].counter).toBe(1);
+      expect(node.instances[0].stages[1].duration).toBe(1239);
+    });
+
+    it("should deserialize a pipeline dependency node with no instances from JSON", function () {
+      var node = PipelineDependencyNode.fromJSON(no_run);
+
+      expect(node.id).toBe("post-release-github-activities");
+      expect(node.name).toBe("post-release-github-activities");
+      expect(node.type).toBe("PIPELINE");
+      expect(node.parents).toContain("PublishStableRelease");
+      expect(node.dependents.size()).toBe(0);
+      expect(node.instances.size()).toBe(0);
+    });
+
+    it("should deserialize a scm material node from JSON", function () {
+      var node = SCMDependencyNode.fromJSON(materialJSON);
+
+      expect(node.id).toBe("21f6ea93b72144560a90ad9398e67c5c9f0f7c6cdf03e022a7fc2445bd8a3f2b");
+      expect(node.name).toBe("https://mirrors.gocd.org/git/gocd/gocd");
+      expect(node.type).toBe("GIT");
+      expect(node.dependents).toContain("519591c7-74ef-458d-b094-d4c15a80c0ab");
+      expect(node.dependents).toContain("build-linux");
+
+      expect(node.material_revisions.size()).toBe(2);
+      expect(node.material_revisions[0].modifications.size()).toBe(1);
+      expect(node.material_revisions[0].modifications[0].revision).toContain("878f029dd4fe4f9d36b575152a5086c2e0b1fc93");
+
+      expect(node.material_revisions[1].modifications.size()).toBe(1);
+      expect(node.material_revisions[1].modifications[0].revision).toContain("10b2c55bfc06c4c465447a5986f27a1d83570206");
+    });
+
+    it("should deserialize a dummy node from JSON", function () {
+      var node = DummyNode.fromJSON(dummyJSON);
+
+      expect(node.id).toBe("b667d782-64b0-475e-9bf2-d8db9a8c3b2c");
+      expect(node.type).toBe("DUMMY");
+
+      expect(node.dependents.size()).toBe(1);
+      expect(node.dependents).toContain("e9448492-0d94-4c24-a7c4-a139e92dadff");
+
+      expect(node.parents.size()).toBe(1);
+      expect(node.parents).toContain("21f6ea93b72144560a90ad9398e67c5c9f0f7c6cdf03e022a7fc2445bd8a3f2b");
+    });
+  });
+
+  var nodeJSON = {
+        "can_edit": true,
+        "dependents": [
+          "plugins"
+        ],
+        "depth": 1,
+        "edit_path": "/go/admin/pipelines/build-linux/edit",
+        "id": "build-linux",
+        "instances": [
+          {
+            "counter": 2590,
+            "label": "2590",
+            "locator": "/go/pipelines/value_stream_map/build-linux/2590",
+            "stages": [
+              {
+                "duration": 326,
+                "locator": "/go/pipelines/build-linux/2590/build-non-server/2",
+                "name": "build-non-server",
+                "status": "Passed"
+              },
+              {
+                "duration": 1239,
+                "locator": "/go/pipelines/build-linux/2590/build-server/1",
+                "name": "build-server",
+                "status": "Passed"
+              }
+            ]
+          }
+        ],
+        "locator": "/go/tab/pipeline/history/build-linux",
+        "name": "build-linux",
+        "node_type": "PIPELINE",
+        "parents": [
+          "21f6ea93b7"
+        ]
+      };
+
+  var no_run =                 {
+    "can_edit": true,
+    "dependents": [],
+    "depth": 3,
+    "edit_path": "/go/admin/pipelines/post-release-github-activities/edit",
+    "id": "post-release-github-activities",
+    "instances": [
+      {
+        "counter": 0,
+        "label": "",
+        "locator": "",
+        "stages": [
+          {
+            "duration": null,
+            "locator": "",
+            "name": "draft-release",
+            "status": "Unknown"
+          }
+        ]
+      }
+    ],
+    "locator": "/go/tab/pipeline/history/post-release-github-activities",
+    "name": "post-release-github-activities",
+    "node_type": "PIPELINE",
+    "parents": [
+      "PublishStableRelease"
+    ]
+  };
+
+  var materialJSON =                 {
+    "dependents": [
+      "519591c7-74ef-458d-b094-d4c15a80c0ab",
+      "build-linux"
+    ],
+    "depth": 1,
+    "id": "21f6ea93b72144560a90ad9398e67c5c9f0f7c6cdf03e022a7fc2445bd8a3f2b",
+    "instances": [],
+    "locator": "",
+    "material_names": [
+      "gocd"
+    ],
+    "material_revisions": [
+      {
+        "modifications": [
+          {
+            "comment": "Remove plugin info api v3",
+            "locator": "/go/materials/value_stream_map/21f6ea93b72144560a90ad9398e67c5c9f0f7c6cdf03e022a7fc2445bd8a3f2b/878f029dd4fe4f9d36b575152a5086c2e0b1fc93",
+            "modified_time": "5 days ago",
+            "revision": "878f029dd4fe4f9d36b575152a5086c2e0b1fc93",
+            "user": "Ketan Padegaonkar <KetanPadegaonkar@gmail.com>"
+          }
+        ]
+      },
+      {
+        "modifications": [
+          {
+            "comment": "Removed unused javascript (#4834)",
+            "locator": "/go/materials/value_stream_map/21f6ea93b72144560a90ad9398e67c5c9f0f7c6cdf03e022a7fc2445bd8a3f2b/10b2c55bfc06c4c465447a5986f27a1d83570206",
+            "modified_time": "about 22 hours ago",
+            "revision": "10b2c55bfc06c4c465447a5986f27a1d83570206",
+            "user": "Bhupendra <bdpiparva@gmail.com>"
+          }
+        ]
+      }
+    ],
+    "name": "https://mirrors.gocd.org/git/gocd/gocd",
+    "node_type": "GIT",
+    "parents": []
+  };
+
+  var dummyJSON =                 {
+    "dependents": [
+      "e9448492-0d94-4c24-a7c4-a139e92dadff"
+    ],
+    "depth": 5,
+    "id": "b667d782-64b0-475e-9bf2-d8db9a8c3b2c",
+    "instances": [],
+    "locator": "",
+    "name": "dummy-b667d782-64b0-475e-9bf2-d8db9a8c3b2c",
+    "node_type": "DUMMY",
+    "parents": [
+      "21f6ea93b72144560a90ad9398e67c5c9f0f7c6cdf03e022a7fc2445bd8a3f2b"
+    ]
+  }
+
+});

--- a/server/webapp/WEB-INF/urlrewrite.xml
+++ b/server/webapp/WEB-INF/urlrewrite.xml
@@ -302,14 +302,6 @@
     </rule>
 
     <rule>
-        <name>Rails Analytics API</name>
-        <from>^/analytics/(.*)$</from>
-        <to last="true">/rails/analytics/$1</to>
-        <set name="rails_bound">true</set>
-    </rule>
-
-
-    <rule>
         <name>Rails Users Show and Delete API</name>
         <from>^/api/users/(.*)$</from>
         <to last="true">/rails/api/users/${escape:$1}</to>

--- a/spark/spark-spa/src/main/java/com/thoughtworks/go/spark/spa/AnalyticsDelegate.java
+++ b/spark/spark-spa/src/main/java/com/thoughtworks/go/spark/spa/AnalyticsDelegate.java
@@ -75,6 +75,7 @@ public class AnalyticsDelegate implements SparkController {
             before("", this::checkPipelineExists, this::checkPermissions);
             before("/*", this::checkPipelineExists, this::checkPermissions);
             get("", this::showAnalytics);
+            post("", this::showAnalytics);
         });
     }
 

--- a/spark/spark-spa/src/test/groovy/com/thoughtworks/go/spark/spa/AnalyticsDelegateTest.groovy
+++ b/spark/spark-spa/src/test/groovy/com/thoughtworks/go/spark/spa/AnalyticsDelegateTest.groovy
@@ -110,6 +110,17 @@ class AnalyticsDelegateTest implements ControllerTrait<AnalyticsDelegate>, Secur
         assertThatResponse().isOk().hasJsonBody(expected.toMap())
       }
 
+      @Test
+      void "should fetch analytics on a post request"() {
+        AnalyticsData expected = new AnalyticsData(GSON.toJson([1, 2, 3]), "/path/to/template")
+
+        when(analyticsExtension.getAnalytics("pluginId", "vsm", "metric", Collections.emptyMap())).thenReturn(expected)
+
+        post(controller.controllerPath("pluginId", "vsm", "metric"), Collections.emptyMap())
+
+        assertThatResponse().isOk().hasJsonBody(expected.toMap())
+      }
+
       String getPipelineName() {
         return "testPipeline"
       }


### PR DESCRIPTION
* Cleaning up analytics refrences in rails as the controller is moved to spark
* Introduced V2 of Analytics extension endpoint to support 'vsm'
analytics
* Can view VSM analytics on the vsm page if the plugin supports
  vsm analytics.