### PR TITLE
Fix request logging (for #5020)

### DIFF
--- a/jetty9/src/main/java/com/thoughtworks/go/server/Jetty9Server.java
+++ b/jetty9/src/main/java/com/thoughtworks/go/server/Jetty9Server.java
@@ -27,9 +27,11 @@ import org.eclipse.jetty.deploy.DeploymentManager;
 import org.eclipse.jetty.deploy.providers.WebAppProvider;
 import org.eclipse.jetty.jmx.MBeanContainer;
 import org.eclipse.jetty.server.Connector;
+import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.handler.ContextHandler;
 import org.eclipse.jetty.server.handler.ContextHandlerCollection;
+import org.eclipse.jetty.server.handler.HandlerCollection;
 import org.eclipse.jetty.server.handler.gzip.GzipHandler;
 import org.eclipse.jetty.server.session.SessionHandler;
 import org.eclipse.jetty.webapp.JettyWebXmlConfiguration;
@@ -89,7 +91,10 @@ public class Jetty9Server extends AppServer {
         webAppContext.setGzipHandler(gzipHandler());
         server.addBean(errorHandler);
         server.addBean(deploymentManager);
-        server.setHandler(handlers);
+
+        HandlerCollection serverLevelHandlers = new HandlerCollection();
+        serverLevelHandlers.setHandlers(new Handler[]{handlers});
+        server.setHandler(serverLevelHandlers);
 
         performCustomConfiguration();
         server.setStopAtShutdown(true);


### PR DESCRIPTION
Jetty server level handler is now a HandlerCollection which wraps the ContextHandlerCollection used by the DeploymentManager to handle the loading indicator. Since the RequestLogHandler added by jetty.xml will now be at the Jetty server level, both the ContextHandlerCollection and RequestLogHandler will be called (one after the other). So, request logging works.

If the ContextHandlerCollection was not added into the HandlerCollection, the RequestLogHandler would be added into the ContextHandlerCollection. Then, the RequestLogHandler wouldn't be called, since the ContextHandlerCollection is special and calls only the handlers whose context path matches the request.

The test is a little anemic. Due to the nature of this part of the code and how closely it is tied to Jetty, there is no good integration-level test which checks this.

The jetty.xml part which uses this change is [here](https://github.com/gocd/gocd/blob/678db044fb82c22aacaa0f8cab5f19d8be751e69/server/config/jetty.xml#L65-L85). It is the equivalent of calling the code:

```
Server server = jetty9Server.getServer();
((HandlerCollection) server.getHandler()).addHandler(new RequestLogHandler());
```
This change can be tested by adding this snippet to `config/logback-include.xml`:

```xml
<?xml version="1.0" encoding="UTF-8"?>

<included>
  <logger name="org.eclipse.jetty.server.RequestLog" level="INFO" />
</included>
```

In 18.7, this would not log into `go-server.log`. With this change, it logs web requests there. There is no workaround that I know of to get web request logging working for 18.7.

This is for #5020.