### PR TITLE
Use `RAILS_ROOT/tmp` as the cache dir for webpack compilation.

### DIFF
--- a/server/webapp/WEB-INF/rails.new/config/webpack.config.js
+++ b/server/webapp/WEB-INF/rails.new/config/webpack.config.js
@@ -63,7 +63,12 @@ module.exports = function (env) {
 
   const plugins = [];
   plugins.push(new HappyPack({
-    loaders: ['babel-loader?cacheDirectory=true'],
+    loaders: [{
+      loader: 'babel-loader',
+      options: {
+        cacheDirectory: path.join(__dirname, '..', 'tmp', 'babel-loader')
+      }
+    }],
     threads: 4
   }));
   plugins.push(new StatsPlugin('manifest.json', {
@@ -96,7 +101,7 @@ module.exports = function (env) {
 
   if (production) {
     plugins.push(new UglifyJsPlugin({
-      cache:         true,
+      cache:         path.join(__dirname, '..', 'tmp', 'uglify-js-cache'),
       parallel:      true,
       sourceMap:     true,
       uglifyOptions: {


### PR DESCRIPTION
The default seems to use `node_modules/.cache` as the cache directory,
this seems to mess up with gradle's task output caching, because it
suddenly sees a new file under `node_modules` which did not exist
earlier and wants to clean and run `yarn install` again