### PR TITLE
Fix issue on Safari with checkboxes for personalization editing

### DIFF
--- a/server/webapp/WEB-INF/rails.new/spec/webpack/views/dashboard/model/personaliza_editor_vm_spec.js
+++ b/server/webapp/WEB-INF/rails.new/spec/webpack/views/dashboard/model/personaliza_editor_vm_spec.js
@@ -74,9 +74,9 @@ describe("Personalization Editor View Model", () => {
 });
 
 function check(stream) {
-  stream(false); // seems backwards, but the stream expects the previous value of onchange
+  stream(true);
 }
 
 function uncheck(stream) {
-  stream(true); // seems backwards, but the stream expects the previous value of onchange
+  stream(false);
 }

--- a/server/webapp/WEB-INF/rails.new/spec/webpack/views/dashboard/model/pipeline_list_vm_spec.js
+++ b/server/webapp/WEB-INF/rails.new/spec/webpack/views/dashboard/model/pipeline_list_vm_spec.js
@@ -106,11 +106,11 @@ describe("Pipeline List View Model", () => {
 });
 
 function check(stream) {
-  stream(false); // seems backwards, but the stream expects the previous value of onchange
+  stream(true);
 }
 
 function uncheck(stream) {
-  stream(true); // seems backwards, but the stream expects the previous value of onchange
+  stream(false);
 }
 
 function _st(obj) {

--- a/server/webapp/WEB-INF/rails.new/webpack/helpers/form_helper.js.msx
+++ b/server/webapp/WEB-INF/rails.new/webpack/helpers/form_helper.js.msx
@@ -214,8 +214,10 @@ const f = {
   checkbox: {
     view(vnode) {
       const args = _.assign({}, vnode.attrs); // copy attrs instead of modifying in-place
+      const prop = deleteKeyAndReturnValue(args, "prop", "checked");
+      const listen = deleteKeyAndReturnValue(args, "listen", "onchange");
 
-      wireUpModel(args, "checked");
+      wireUpModel(args, prop, listen);
 
       const label        = coerceArray(deleteKeyAndReturnValue(args, "label", []), wrapTextInSpan), // label can be a string or an array
             inputElement = <input type="checkbox" {...args} />;

--- a/server/webapp/WEB-INF/rails.new/webpack/views/dashboard/dashboard_widget.js.msx
+++ b/server/webapp/WEB-INF/rails.new/webpack/views/dashboard/dashboard_widget.js.msx
@@ -40,7 +40,15 @@ const DashboardWidget = {
       body.click(() => {
         vnode.attrs.vm.dropdown.hide();
         vnode.attrs.personalizeVM.hideAllDropdowns();
-        m.redraw();
+
+        /**
+         * The reason we need to do the redraw asynchronously is for checkboxes. When you click
+         * a checkbox the click event propogates to the body. But the model backing the checkboxes
+         * has not had time to update to the new value (so the redraw overrides the value with the
+         * original state). Using setTimeout() to make m.redraw() asynchronous allows mithril to
+         * flush the new checkbox state to the DOM beforehand.
+         */
+        setTimeout(m.redraw, 0);
       });
     };
 

--- a/server/webapp/WEB-INF/rails.new/webpack/views/dashboard/models/personalize_editor_vm.js
+++ b/server/webapp/WEB-INF/rails.new/webpack/views/dashboard/models/personalize_editor_vm.js
@@ -66,11 +66,11 @@ function arr(val) { // ensure value is an array
 // allows a boolean to control the presence of a value in
 // a list within a m.Stream
 function boolToList(model, stream, attr) {
-  model[attr] = function(boolPreviousValue) {
+  model[attr] = function(value) {
     const r = stream();
     if (!arguments.length) { return _.includes(r, attr); }
 
-    if (!boolPreviousValue) {
+    if (value) {
       r.push(attr); // toggle to `true` => add to list
     } else {
       r.splice(r.indexOf(attr), 1); // toggle to `false` => remove from list

--- a/server/webapp/WEB-INF/rails.new/webpack/views/dashboard/models/personalize_editor_vm.js
+++ b/server/webapp/WEB-INF/rails.new/webpack/views/dashboard/models/personalize_editor_vm.js
@@ -38,8 +38,9 @@ function PersonalizeEditorVM(opts, pipelinesByGroup) { // opts is usually the cu
   boolToList(this, state, "failing");
 
   this.includeNewPipelines = function (boolPreviousValue) {
+    console.log(boolPreviousValue);
     if (!arguments.length) { return inverted(); }
-    type(!boolPreviousValue ? "blacklist" : "whitelist");
+    type(boolPreviousValue ? "blacklist" : "whitelist");
   };
 
   this.errorResponse = Stream();

--- a/server/webapp/WEB-INF/rails.new/webpack/views/dashboard/models/personalize_editor_vm.js
+++ b/server/webapp/WEB-INF/rails.new/webpack/views/dashboard/models/personalize_editor_vm.js
@@ -37,9 +37,9 @@ function PersonalizeEditorVM(opts, pipelinesByGroup) { // opts is usually the cu
   boolToList(this, state, "building");
   boolToList(this, state, "failing");
 
-  this.includeNewPipelines = function (boolPreviousValue) {
+  this.includeNewPipelines = function (value) {
     if (!arguments.length) { return inverted(); }
-    type(boolPreviousValue ? "blacklist" : "whitelist");
+    type(value ? "blacklist" : "whitelist");
   };
 
   this.errorResponse = Stream();

--- a/server/webapp/WEB-INF/rails.new/webpack/views/dashboard/models/personalize_editor_vm.js
+++ b/server/webapp/WEB-INF/rails.new/webpack/views/dashboard/models/personalize_editor_vm.js
@@ -38,7 +38,6 @@ function PersonalizeEditorVM(opts, pipelinesByGroup) { // opts is usually the cu
   boolToList(this, state, "failing");
 
   this.includeNewPipelines = function (boolPreviousValue) {
-    console.log(boolPreviousValue);
     if (!arguments.length) { return inverted(); }
     type(boolPreviousValue ? "blacklist" : "whitelist");
   };

--- a/server/webapp/WEB-INF/rails.new/webpack/views/dashboard/models/pipeline_list_vm.js
+++ b/server/webapp/WEB-INF/rails.new/webpack/views/dashboard/models/pipeline_list_vm.js
@@ -42,9 +42,9 @@ function PipelineListVM(pipelinesByGroup, currentSelection) {
 }
 
 function boolByName(s, name) {
-  return function boundToName(boolPreviousValue) {
+  return function boundToName(value) {
     if (!arguments.length) { return s[name](); }
-    s[name](!boolPreviousValue);
+    s[name](value);
   };
 }
 
@@ -52,9 +52,9 @@ function groupSelection(s, pipelines) {
   const streams = _.map(pipelines, (p) => s[p]);
   const allSelected = Stream.combine(() => _.every(streams, (st) => st()), streams);
 
-  return function(boolPreviousValue) {
+  return function(value) {
     if (!arguments.length) { return allSelected(); }
-    _.each(streams, (st) => { st(!boolPreviousValue); });
+    _.each(streams, (st) => { st(value); });
   };
 }
 

--- a/server/webapp/WEB-INF/rails.new/webpack/views/dashboard/personalization_modal_widget.js.msx
+++ b/server/webapp/WEB-INF/rails.new/webpack/views/dashboard/personalization_modal_widget.js.msx
@@ -60,7 +60,7 @@ const PipelineSelectors = {
   view(vnode) {
     const pipelines = vnode.attrs.pipelines;
     return m("ul", {class: "selected-pipelines-pipeline-list"},
-      _.map(pipelines, (p) => <li><f.checkbox model={p} attrName="selected" listen="onclick" label={p.name} /></li>)
+      _.map(pipelines, (p) => <li><f.checkbox model={p} attrName="selected" label={p.name} /></li>)
     );
   }
 };
@@ -70,7 +70,7 @@ const PipelineGroupSelection = {
     const vm = vnode.attrs.vm, name = vnode.attrs.name;
     return <li class={`selected-pipelines-group-${(vm.expanded() ? "expanded" : "collapsed")}`}>
       <i class="pipeline-list-toggle" onclick={() => vm.expanded(!vm.expanded())} />
-      <f.checkbox model={vm} attrName="selected" listen="onclick" label={name}/>
+      <f.checkbox model={vm} attrName="selected" label={name}/>
       <PipelineSelectors pipelines={vm.pipelines} />
     </li>;
   }
@@ -114,7 +114,7 @@ const PersonalizationModalWidget = {
       <FilterNameInput {...vnode.attrs} />
       <section class="filter-options">
         <BlanketSelector vm={vm.selectionVM} />
-        <f.checkbox name="include-new-pipelines" model={vm} attrName="includeNewPipelines" listen="onclick" label="Show newly created pipelines" />
+        <f.checkbox name="include-new-pipelines" model={vm} attrName="includeNewPipelines" label="Show newly created pipelines" />
       </section>
       <section class="pipeline-selections">
         <SelectedPipelineList vm={vm.selectionVM} />

--- a/server/webapp/WEB-INF/rails.new/webpack/views/dashboard/personalization_modal_widget.js.msx
+++ b/server/webapp/WEB-INF/rails.new/webpack/views/dashboard/personalization_modal_widget.js.msx
@@ -60,7 +60,7 @@ const PipelineSelectors = {
   view(vnode) {
     const pipelines = vnode.attrs.pipelines;
     return m("ul", {class: "selected-pipelines-pipeline-list"},
-      _.map(pipelines, (p) => <li><f.checkbox model={p} attrName="selected" label={p.name} /></li>)
+      _.map(pipelines, (p) => <li><f.checkbox model={p} attrName="selected" listen="onclick" label={p.name} /></li>)
     );
   }
 };
@@ -70,7 +70,7 @@ const PipelineGroupSelection = {
     const vm = vnode.attrs.vm, name = vnode.attrs.name;
     return <li class={`selected-pipelines-group-${(vm.expanded() ? "expanded" : "collapsed")}`}>
       <i class="pipeline-list-toggle" onclick={() => vm.expanded(!vm.expanded())} />
-      <f.checkbox model={vm} attrName="selected" label={name}/>
+      <f.checkbox model={vm} attrName="selected" listen="onclick" label={name}/>
       <PipelineSelectors pipelines={vm.pipelines} />
     </li>;
   }
@@ -114,7 +114,7 @@ const PersonalizationModalWidget = {
       <FilterNameInput {...vnode.attrs} />
       <section class="filter-options">
         <BlanketSelector vm={vm.selectionVM} />
-        <f.checkbox name="include-new-pipelines" model={vm} attrName="includeNewPipelines" label="Show newly created pipelines" />
+        <f.checkbox name="include-new-pipelines" model={vm} attrName="includeNewPipelines" listen="onclick" label="Show newly created pipelines" />
       </section>
       <section class="pipeline-selections">
         <SelectedPipelineList vm={vm.selectionVM} />


### PR DESCRIPTION
- Safari and Chrome handle values for onchange differently
- Using onclick for consistent behavior between browsers