### PR TITLE
Dashboard Personalization UI tweaks

### DIFF
--- a/server/webapp/WEB-INF/rails.new/app/assets/new_stylesheets/single_page_apps/new_dashboard.scss
+++ b/server/webapp/WEB-INF/rails.new/app/assets/new_stylesheets/single_page_apps/new_dashboard.scss
@@ -415,6 +415,7 @@ body {
 .main-container {
   margin:     0;
   background: transparent;
+  overflow: visible;
 }
 
 .dashboard-group_title {

--- a/server/webapp/WEB-INF/rails.new/app/assets/new_stylesheets/single_page_apps/pipeline_configs/_dashboard_view_tabs.scss
+++ b/server/webapp/WEB-INF/rails.new/app/assets/new_stylesheets/single_page_apps/pipeline_configs/_dashboard_view_tabs.scss
@@ -5,6 +5,7 @@ $dashboard-tab-action-button-color: #6b808c;
 $dashboard-tab-height: 50px;
 $dashboard-add-tab-width: 40px;
 $dashboard-tab-list-toggle-width: $dashboard-add-tab-width;
+$dashboard-tabs-padding: 30px;
 $dashboard-tabs-border-color: #e9eeef;
 $dashboard-tabs-border-radius: 0;
 $dashboard-tabs-pager-width: $dashboard-add-tab-width;
@@ -24,7 +25,7 @@ $dashboard-tabs-box-shadow: 0 0 10px rgba(0, 0, 0, 0.21);
   border-radius:    $dashboard-tabs-border-radius;
   line-height:      $dashboard-tab-height;
   height:           $dashboard-tab-height;
-  padding:          0;
+  padding:          0 $dashboard-tabs-padding;
   margin-bottom:    20px;
   box-shadow:       $dashboard-tabs-box-shadow;
 

--- a/server/webapp/WEB-INF/rails.new/app/assets/new_stylesheets/single_page_apps/pipeline_configs/_dashboard_view_tabs.scss
+++ b/server/webapp/WEB-INF/rails.new/app/assets/new_stylesheets/single_page_apps/pipeline_configs/_dashboard_view_tabs.scss
@@ -1,4 +1,3 @@
-$dashboard-tabs-padding: 30px;
 $dashboard-tab-bg: #fff;
 $dashboard-tab-primary-text-color: #943a9e;
 $dashboard-tab-secondary-text-color: #3c5d73;
@@ -19,12 +18,13 @@ $dashboard-tabs-box-shadow: 0 0 10px rgba(0, 0, 0, 0.21);
 .dashboard-tabs {
   @include unselectable;
 
+  display:          flex;
   position:         relative;
   background-color: $dashboard-tab-bg;
   border-radius:    $dashboard-tabs-border-radius;
   line-height:      $dashboard-tab-height;
   height:           $dashboard-tab-height;
-  padding:          0 $dashboard-tabs-padding;
+  padding:          0;
   margin-bottom:    20px;
   box-shadow:       $dashboard-tabs-box-shadow;
 
@@ -65,8 +65,6 @@ $dashboard-tabs-box-shadow: 0 0 10px rgba(0, 0, 0, 0.21);
   }
 
   .add-tab, .tabs-list-dropdown-widget {
-    position:     absolute;
-    top:          0;
     border-left:  1px solid $dashboard-tabs-border-color;
     border-right: 1px solid $dashboard-tabs-border-color;
     padding:      0 10px;
@@ -76,7 +74,8 @@ $dashboard-tabs-box-shadow: 0 0 10px rgba(0, 0, 0, 0.21);
   }
 
   .add-tab {
-    right:      calc(#{$dashboard-tab-list-toggle-width} + #{$dashboard-tabs-padding});
+    margin:     0;
+    padding:    0;
     width:      $dashboard-add-tab-width;
     color:      $dashboard-tab-primary-text-color;
     text-align: center;
@@ -87,19 +86,21 @@ $dashboard-tabs-box-shadow: 0 0 10px rgba(0, 0, 0, 0.21);
   }
 
   .tabs-list-dropdown-widget {
-    top:           0;
-    right:         $dashboard-tabs-padding;
+    margin:        0;
+    padding:       0;
+    display:       none;
     width:         $dashboard-tab-list-toggle-width;
     color:         $dashboard-tab-secondary-text-color;
     border-radius: 0 $dashboard-tabs-border-radius $dashboard-tabs-border-radius 0;
 
+    &.paged {
+      display: block;
+    }
+
     .tabs-list-dropdown-toggle {
-      position: absolute;
-      top:      0;
-      left:     0;
-      width:    100%;
-      height:   100%;
-      outline:  none;
+      width:   100%;
+      height:  100%;
+      outline: none;
 
       .tabs-list-icon {
         @include icon-before($type: chevron-down);
@@ -176,30 +177,21 @@ $dashboard-tabs-box-shadow: 0 0 10px rgba(0, 0, 0, 0.21);
 }
 
 .dashboard-tabs-sortable, .dashboard-tabs-scrollable {
-  position:       relative;
-  margin:         0;
-  padding:        0;
   vertical-align: top;
   white-space:    nowrap;
 }
 
 .dashboard-tabs-sortable {
-  padding-bottom: 100px;
-  width:          100%;
-  overflow-x:     auto;
-  overflow-y:     hidden;
-  outline:        none;
+  overflow: hidden;
+  outline:  none;
 }
 
 .dashboard-tabs-scrollable {
-  padding:  0 $dashboard-tabs-pager-width;
-  width:    calc(100% - #{$dashboard-add-tab-width} - #{$dashboard-tab-list-toggle-width});
   height:   $dashboard-tab-height;
   overflow: hidden; // ensure scrollbars of inner container are hidden from view
+  display:  flex;
 
   .page-prev, .page-next {
-    position:     absolute;
-    top:          0;
 
     border-right: 1px solid $dashboard-tabs-border-color;
     border-left:  1px solid $dashboard-tabs-border-color;
@@ -226,12 +218,10 @@ $dashboard-tabs-box-shadow: 0 0 10px rgba(0, 0, 0, 0.21);
 
   .page-prev {
     @include icon-before($type: angle-left);
-    left: 0;
   }
 
   .page-next {
     @include icon-before($type: angle-right);
-    right: 0;
   }
 }
 
@@ -256,7 +246,9 @@ $dashboard-tabs-box-shadow: 0 0 10px rgba(0, 0, 0, 0.21);
     border-left: 1px solid $dashboard-tabs-border-color;
   }
 
-  > * { vertical-align: top; }
+  > * {
+    vertical-align: top;
+  }
 
   .drag-icon {
     @include sort-cursor;

--- a/server/webapp/WEB-INF/rails.new/app/assets/new_stylesheets/single_page_apps/pipeline_configs/_dashboard_view_tabs.scss
+++ b/server/webapp/WEB-INF/rails.new/app/assets/new_stylesheets/single_page_apps/pipeline_configs/_dashboard_view_tabs.scss
@@ -75,11 +75,13 @@ $dashboard-tabs-box-shadow: 0 0 10px rgba(0, 0, 0, 0.21);
   }
 
   .add-tab {
-    margin:     0;
-    padding:    0;
-    width:      $dashboard-add-tab-width;
-    color:      $dashboard-tab-primary-text-color;
-    text-align: center;
+    margin:      0;
+    padding:     0;
+    width:       $dashboard-add-tab-width;
+    color:       $dashboard-tab-primary-text-color;
+    text-align:  center;
+    flex-grow:   0;
+    flex-shrink: 0;
 
     .add-icon {
       @include icon-before($type: plus);
@@ -93,6 +95,8 @@ $dashboard-tabs-box-shadow: 0 0 10px rgba(0, 0, 0, 0.21);
     width:         $dashboard-tab-list-toggle-width;
     color:         $dashboard-tab-secondary-text-color;
     border-radius: 0 $dashboard-tabs-border-radius $dashboard-tabs-border-radius 0;
+    flex-grow:     0;
+    flex-shrink:   0;
 
     &.paged {
       display: block;
@@ -201,6 +205,8 @@ $dashboard-tabs-box-shadow: 0 0 10px rgba(0, 0, 0, 0.21);
 
     width:        $dashboard-tabs-pager-width;
     height:       $dashboard-tab-height;
+    flex-grow:    0;
+    flex-shrink:  0;
 
     text-align:   center;
     font-size:    21px;

--- a/server/webapp/WEB-INF/rails.new/app/assets/new_stylesheets/single_page_apps/pipeline_configs/_dashboard_view_tabs.scss
+++ b/server/webapp/WEB-INF/rails.new/app/assets/new_stylesheets/single_page_apps/pipeline_configs/_dashboard_view_tabs.scss
@@ -183,8 +183,10 @@ $dashboard-tabs-box-shadow: 0 0 10px rgba(0, 0, 0, 0.21);
 }
 
 .dashboard-tabs-sortable {
-  overflow: hidden;
-  outline:  none;
+  overflow-y:     hidden;
+  overflow-x:     auto;
+  padding-bottom: 100px;
+  outline:        none;
 }
 
 .dashboard-tabs-scrollable {

--- a/server/webapp/WEB-INF/rails.new/app/assets/new_stylesheets/single_page_apps/pipeline_configs/_dashboard_view_tabs.scss
+++ b/server/webapp/WEB-INF/rails.new/app/assets/new_stylesheets/single_page_apps/pipeline_configs/_dashboard_view_tabs.scss
@@ -122,7 +122,6 @@ $dashboard-tabs-box-shadow: 0 0 10px rgba(0, 0, 0, 0.21);
       max-height:    65vh;
       box-shadow:    $dashboard-tabs-box-shadow;
 
-
       li {
         @include truncate-to-width($max: 210px);
 
@@ -213,14 +212,15 @@ $dashboard-tabs-box-shadow: 0 0 10px rgba(0, 0, 0, 0.21);
     font-weight:  600;
     line-height:  $dashboard-tab-height;
 
-    color:        lighten($dashboard-tab-secondary-text-color, 50%);
+    display:      none;
     cursor:       default;
   }
 
   &.paged {
     .page-prev, .page-next {
-      color:  $dashboard-tab-secondary-text-color;
-      cursor: pointer;
+      color:   $dashboard-tab-secondary-text-color;
+      cursor:  pointer;
+      display: block;
     }
   }
 
@@ -253,6 +253,7 @@ $dashboard-tabs-box-shadow: 0 0 10px rgba(0, 0, 0, 0.21);
 
   &:first-of-type {
     margin-left: 0;
+    border-left: 1px solid $dashboard-tabs-border-color;
   }
 
   > * { vertical-align: top; }

--- a/server/webapp/WEB-INF/rails.new/webpack/views/dashboard/scrollable_view_tabs.js.msx
+++ b/server/webapp/WEB-INF/rails.new/webpack/views/dashboard/scrollable_view_tabs.js.msx
@@ -83,13 +83,13 @@ function detectPaging(vnode, padding) {
 function ensureCurrentTabInView(viewable) {
   const scrollable = $(viewable.querySelector(".dashboard-tabs-sortable"));
   const tab = scrollable.find(".current");
-  const padding = 30;
+  const padding = (parseInt($(".dashboard-tabs").css("padding-left"), 10) || 0);
 
   if (tab.length) {
     const L = tab.position().left;
     const R = L + tab.outerWidth(true);
     const I = scrollable.outerWidth(true);
-    const offset = $(viewable.querySelector(".page-prev")).outerWidth() + padding;
+    const offset = $(viewable.querySelector(".page-prev")).outerWidth(true) + padding;
 
     // theoretically we should first test if tab.width() > viewable.width() before anything else,
     // and then center the tab in the viewable area, but our CSS does not allow this situation to happen.

--- a/server/webapp/WEB-INF/rails.new/webpack/views/dashboard/scrollable_view_tabs.js.msx
+++ b/server/webapp/WEB-INF/rails.new/webpack/views/dashboard/scrollable_view_tabs.js.msx
@@ -77,7 +77,7 @@ const ScrollableViewTabs = {
 
 function detectPaging(vnode, padding) {
   const toleranceForIE = 1;
-  return (vnode.dom.querySelector(".dashboard-tabs-sortable").scrollWidth - (vnode.dom.clientWidth - padding)) > toleranceForIE;
+  return (vnode.dom.querySelector(".dashboard-tabs-sortable").scrollWidth - vnode.dom.clientWidth - padding) > toleranceForIE;
 }
 
 function ensureCurrentTabInView(viewable) {

--- a/server/webapp/WEB-INF/rails.new/webpack/views/dashboard/scrollable_view_tabs.js.msx
+++ b/server/webapp/WEB-INF/rails.new/webpack/views/dashboard/scrollable_view_tabs.js.msx
@@ -61,9 +61,7 @@ const ScrollableViewTabs = {
   },
 
   onupdate(vnode) {
-    const el = vnode.dom.querySelector(".dashboard-tabs-sortable");
-    const padding = 2 * (parseInt($(vnode.dom).css("padding-left"), 10) || 0);
-    vnode.attrs.vm.paged(el.scrollWidth > (vnode.dom.clientWidth - padding));
+    vnode.attrs.vm.paged(detectPaging(vnode, 0));
   },
 
   view(vnode) {
@@ -77,7 +75,10 @@ const ScrollableViewTabs = {
   }
 };
 
-function detectPaging(vnode, padding) { return vnode.dom.querySelector(".dashboard-tabs-sortable").scrollWidth > (vnode.dom.clientWidth - padding); }
+function detectPaging(vnode, padding) {
+  const toleranceForIE = 1;
+  return (vnode.dom.querySelector(".dashboard-tabs-sortable").scrollWidth - (vnode.dom.clientWidth - padding)) > toleranceForIE;
+}
 
 function ensureCurrentTabInView(viewable) {
   const scrollable = $(viewable.querySelector(".dashboard-tabs-sortable"));

--- a/server/webapp/WEB-INF/rails.new/webpack/views/dashboard/scrollable_view_tabs.js.msx
+++ b/server/webapp/WEB-INF/rails.new/webpack/views/dashboard/scrollable_view_tabs.js.msx
@@ -23,7 +23,7 @@ const SortableViewTabs = require("views/dashboard/sortable_view_tabs");
 const ScrollableViewTabs = {
   oncreate(vnode) {
     const vm = vnode.attrs.vm;
-    const padding = 2 * (parseInt($(vnode.dom).css("padding-left"), 10) || 0);
+    const padding = 0;
 
     if (!vnode.state.attached) {
       window.addEventListener("resize", raf(() => {
@@ -36,8 +36,8 @@ const ScrollableViewTabs = {
 
     $(vnode.dom).on("click", ".page-prev,.page-next", (e) => {
       if (vm.paged()) {
-        const pageSize = vnode.dom.clientWidth - padding;
         const scrollable = $(vnode.dom.querySelector(".dashboard-tabs-sortable"));
+        const pageSize = scrollable[0].clientWidth - padding;
         const current = scrollable.scrollLeft(), max = scrollable[0].scrollWidth - pageSize;
         const button = $(e.currentTarget);
 
@@ -70,9 +70,9 @@ const ScrollableViewTabs = {
     const vm = vnode.attrs.vm;
 
     return <div class={vm.paged() ? "dashboard-tabs-scrollable paged" : "dashboard-tabs-scrollable"}>
-      <i class="page-prev"></i>
-      <i class="page-next"></i>
+      <i class="page-prev"/>
       <SortableViewTabs {...vnode.attrs} />
+      <i class="page-next"/>
     </div>;
   }
 };

--- a/server/webapp/WEB-INF/rails.new/webpack/views/dashboard/scrollable_view_tabs.js.msx
+++ b/server/webapp/WEB-INF/rails.new/webpack/views/dashboard/scrollable_view_tabs.js.msx
@@ -83,24 +83,26 @@ function detectPaging(vnode, padding) {
 function ensureCurrentTabInView(viewable) {
   const scrollable = $(viewable.querySelector(".dashboard-tabs-sortable"));
   const tab = scrollable.find(".current");
+  const padding = 30;
 
   if (tab.length) {
     const L = tab.position().left;
     const R = L + tab.outerWidth(true);
     const I = scrollable.outerWidth(true);
+    const offset = $(viewable.querySelector(".page-prev")).outerWidth() + padding;
 
     // theoretically we should first test if tab.width() > viewable.width() before anything else,
     // and then center the tab in the viewable area, but our CSS does not allow this situation to happen.
 
     // tab is too far to the right
     if (R > I) {
-      scrollable.animate({ scrollLeft: scrollable.scrollLeft() + R - I }, 250);
+      scrollable.animate({ scrollLeft: scrollable.scrollLeft() + R - I + offset }, 250);
       return;
     }
 
     // tab is too far to the left
     if (L < 0) {
-      scrollable.animate({ scrollLeft: scrollable.scrollLeft() + L }, 250);
+      scrollable.animate({ scrollLeft: scrollable.scrollLeft() + L - offset}, 250);
       return;
     }
   }

--- a/server/webapp/WEB-INF/rails.new/webpack/views/dashboard/tabs_list_dropdown.js.msx
+++ b/server/webapp/WEB-INF/rails.new/webpack/views/dashboard/tabs_list_dropdown.js.msx
@@ -4,7 +4,7 @@ const _ = require("lodash");
 const TabsListDropdown = {
   view(vnode) {
     const vm = vnode.attrs.vm;
-    return <div class="tabs-list-dropdown-widget">
+    return <div class={vm.paged() ? "tabs-list-dropdown-widget paged" : "tabs-list-dropdown-widget"}>
       <ViewTabsDropdownToggle vm={vm}/>
       <AvailableTabs vm={vm} />
     </div>;


### PR DESCRIPTION
Feedback from @naveenbhaskar was that the personalization tabs should behave like the browser tabs in Firefox. Changes made:
- [x]  Hide the arrows when the tabs fit on the screen
- [x]  Bugfix: The tabs dropdown went out of view when no pipelines were present
- [x]  The "+" button should be next to the tabs, similar to Firefox.
- [x] Prevent shrinking of arrow scroll buttons in the flex layout.

