### PR TITLE
Change migration file version to 18.8

### DIFF
--- a/server/db/migrate/h2deltas/1808002_add_filters_and_version_to_pipeline_selections.sql
+++ b/server/db/migrate/h2deltas/1808002_add_filters_and_version_to_pipeline_selections.sql
@@ -14,8 +14,8 @@
 -- limitations under the License.
 --
 
-ALTER TABLE PipelineSelections ADD COLUMN filters TEXT;
-ALTER TABLE PipelineSelections ADD COLUMN version INT DEFAULT 0 NOT NULL;
+ALTER TABLE PipelineSelections ADD COLUMN IF NOT EXISTS filters TEXT;
+ALTER TABLE PipelineSelections ADD COLUMN IF NOT EXISTS version INT DEFAULT 0 NOT NULL;
 
 --//@UNDO
 


### PR DESCRIPTION
Migration files are prefixed with the GoCD release version, to identify the migrations for a given release. These changes are done to ensure we follow the convention. 