### PR TITLE
Remove filter params from code that gathers pipeline groups and environments

### DIFF
--- a/api/api-dashboard-v2/src/main/java/com/thoughtworks/go/apiv2/dashboard/DashboardControllerDelegate.java
+++ b/api/api-dashboard-v2/src/main/java/com/thoughtworks/go/apiv2/dashboard/DashboardControllerDelegate.java
@@ -27,7 +27,6 @@ import com.thoughtworks.go.server.dashboard.GoDashboardEnvironment;
 import com.thoughtworks.go.server.dashboard.GoDashboardPipeline;
 import com.thoughtworks.go.server.dashboard.GoDashboardPipelineGroup;
 import com.thoughtworks.go.server.domain.Username;
-import com.thoughtworks.go.server.domain.user.DashboardFilter;
 import com.thoughtworks.go.server.domain.user.PipelineSelections;
 import com.thoughtworks.go.server.service.GoDashboardService;
 import com.thoughtworks.go.server.service.PipelineSelectionsService;
@@ -41,7 +40,6 @@ import java.io.IOException;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import static com.thoughtworks.go.server.domain.user.DashboardFilter.DEFAULT_NAME;
 import static spark.Spark.*;
 
 public class DashboardControllerDelegate extends ApiController {
@@ -51,7 +49,6 @@ public class DashboardControllerDelegate extends ApiController {
 
     private static final String COOKIE_NAME = "selected_pipelines";
     private static final String SEP_CHAR = "/";
-    private static final String VIEW_NAME = "viewName";
 
     private final PipelineSelectionsService pipelineSelectionsService;
     private final GoDashboardService goDashboardService;
@@ -90,10 +87,9 @@ public class DashboardControllerDelegate extends ApiController {
         final Long userId = currentUserId(request);
         final Username userName = currentUsername();
         final PipelineSelections personalization = pipelineSelectionsService.load(personalizationCookie, userId);
-        final DashboardFilter filter = personalization.namedFilter(getViewName(request));
 
-        List<GoDashboardPipelineGroup> pipelineGroups = goDashboardService.allPipelineGroupsForDashboard(filter, userName);
-        List<GoDashboardEnvironment> environments = goDashboardService.allEnvironmentsForDashboard(filter, userName);
+        List<GoDashboardPipelineGroup> pipelineGroups = goDashboardService.allPipelineGroupsForDashboard(userName);
+        List<GoDashboardEnvironment> environments = goDashboardService.allEnvironmentsForDashboard(userName);
 
         String etag = calcEtag(userName, pipelineGroups, environments);
 
@@ -118,10 +114,5 @@ public class DashboardControllerDelegate extends ApiController {
         final String environmentSegment = environments.stream().
                 map(GoDashboardEnvironment::etag).collect(Collectors.joining(SEP_CHAR));
         return DigestUtils.md5Hex(StringUtils.joinWith(SEP_CHAR, username.getUsername(), pipelineSegment, environmentSegment));
-    }
-
-    private String getViewName(Request request) {
-        final String viewName = request.queryParams(VIEW_NAME);
-        return StringUtils.isBlank(viewName) ? DEFAULT_NAME : viewName;
     }
 }

--- a/api/api-dashboard-v2/src/test/groovy/com/thoughtworks/go/apiv2/dashboard/DashboardControllerDelegateTest.groovy
+++ b/api/api-dashboard-v2/src/test/groovy/com/thoughtworks/go/apiv2/dashboard/DashboardControllerDelegateTest.groovy
@@ -91,8 +91,8 @@ class DashboardControllerDelegateTest implements SecurityServiceTrait, Controlle
 
         when(pipelineSelectionsService.load((String) isNull(), any(Long.class))).thenReturn(PipelineSelections.ALL)
         when(goDashboardService.hasEverLoadedCurrentState()).thenReturn(true)
-        when(goDashboardService.allPipelineGroupsForDashboard(eq(Filters.WILDCARD_FILTER), eq(currentUsername()))).thenReturn([group])
-        when(goDashboardService.allEnvironmentsForDashboard(eq(Filters.WILDCARD_FILTER), eq(currentUsername()))).thenReturn([env])
+        when(goDashboardService.allPipelineGroupsForDashboard(eq(currentUsername()))).thenReturn([group])
+        when(goDashboardService.allEnvironmentsForDashboard(eq(currentUsername()))).thenReturn([env])
 
         getWithApiHeader(controller.controllerPath())
 
@@ -112,8 +112,8 @@ class DashboardControllerDelegateTest implements SecurityServiceTrait, Controlle
 
         when(pipelineSelectionsService.load((String) isNull(), any(Long.class))).thenReturn(PipelineSelections.ALL)
         when(goDashboardService.hasEverLoadedCurrentState()).thenReturn(true)
-        when(goDashboardService.allPipelineGroupsForDashboard(eq(Filters.WILDCARD_FILTER), eq(currentUsername()))).thenReturn([group])
-        when(goDashboardService.allEnvironmentsForDashboard(eq(Filters.WILDCARD_FILTER), eq(currentUsername()))).thenReturn([env])
+        when(goDashboardService.allPipelineGroupsForDashboard(eq(currentUsername()))).thenReturn([group])
+        when(goDashboardService.allEnvironmentsForDashboard(eq(currentUsername()))).thenReturn([env])
 
         def etag = computeEtag([group], [env])
         getWithApiHeader(controller.controllerBasePath(), ['if-none-match': etag])
@@ -128,8 +128,8 @@ class DashboardControllerDelegateTest implements SecurityServiceTrait, Controlle
       void 'should get empty json when dashboard is empty'() {
         def pipelineSelections = PipelineSelections.ALL
         when(pipelineSelectionsService.load((String) isNull(), any(Long.class))).thenReturn(pipelineSelections)
-        when(goDashboardService.allPipelineGroupsForDashboard(eq(Filters.WILDCARD_FILTER), eq(currentUsername()))).thenReturn([])
-        when(goDashboardService.allEnvironmentsForDashboard(eq(Filters.WILDCARD_FILTER), eq(currentUsername()))).thenReturn([])
+        when(goDashboardService.allPipelineGroupsForDashboard(eq(currentUsername()))).thenReturn([])
+        when(goDashboardService.allEnvironmentsForDashboard(eq(currentUsername()))).thenReturn([])
         when(goDashboardService.hasEverLoadedCurrentState()).thenReturn(true)
 
         loginAsUser()
@@ -171,7 +171,7 @@ class DashboardControllerDelegateTest implements SecurityServiceTrait, Controlle
         when(pipelineSelectionsService.load((String) isNull(), any(Long.class))).thenReturn(pipelineSelections)
         when(goDashboardService.hasEverLoadedCurrentState()).thenReturn(true)
         def pipelineGroups = [pipelineGroup]
-        when(goDashboardService.allPipelineGroupsForDashboard(eq(Filters.WILDCARD_FILTER), eq(currentUsername()))).thenReturn(pipelineGroups)
+        when(goDashboardService.allPipelineGroupsForDashboard(eq(currentUsername()))).thenReturn(pipelineGroups)
 
         String etag = computeEtag(pipelineGroups, [])
         getWithApiHeader(controller.controllerBasePath(), ['if-none-match': etag])
@@ -182,7 +182,7 @@ class DashboardControllerDelegateTest implements SecurityServiceTrait, Controlle
 
         loginAsPipelineViewUser()
 
-        when(goDashboardService.allPipelineGroupsForDashboard(eq(Filters.WILDCARD_FILTER), eq(currentUsername()))).thenReturn(pipelineGroups)
+        when(goDashboardService.allPipelineGroupsForDashboard(eq(currentUsername()))).thenReturn(pipelineGroups)
         getWithApiHeader(controller.controllerBasePath(), ['if-none-match': etag])
         assertThatResponse()
           .isOk()

--- a/server/src/main/java/com/thoughtworks/go/server/service/GoDashboardService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/GoDashboardService.java
@@ -23,7 +23,6 @@ import com.thoughtworks.go.config.security.users.Everyone;
 import com.thoughtworks.go.config.security.users.Users;
 import com.thoughtworks.go.server.dashboard.*;
 import com.thoughtworks.go.server.domain.Username;
-import com.thoughtworks.go.server.domain.user.DashboardFilter;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -45,14 +44,14 @@ public class GoDashboardService {
         this.goConfigService = goConfigService;
     }
 
-    public List<GoDashboardEnvironment> allEnvironmentsForDashboard(DashboardFilter filter, Username user) {
+    public List<GoDashboardEnvironment> allEnvironmentsForDashboard(Username user) {
         GoDashboardPipelines allPipelines = cache.allEntries();
         List<GoDashboardEnvironment> environments = new ArrayList<>();
 
         final Users admins = superAdmins();
 
         goConfigService.getEnvironments().forEach(environment -> {
-            GoDashboardEnvironment env = dashboardEnvironmentFor(environment, filter, user, admins, allPipelines);
+            GoDashboardEnvironment env = dashboardEnvironmentFor(environment, user, admins, allPipelines);
 
             if (env.hasPipelines()) {
                 environments.add(env);
@@ -62,12 +61,12 @@ public class GoDashboardService {
         return environments;
     }
 
-    public List<GoDashboardPipelineGroup> allPipelineGroupsForDashboard(DashboardFilter filter, Username user) {
+    public List<GoDashboardPipelineGroup> allPipelineGroupsForDashboard(Username user) {
         GoDashboardPipelines allPipelines = cache.allEntries();
         List<GoDashboardPipelineGroup> pipelineGroups = new ArrayList<>();
 
         goConfigService.groups().accept(group -> {
-            GoDashboardPipelineGroup dashboardPipelineGroup = dashboardPipelineGroupFor(group, filter, user, allPipelines);
+            GoDashboardPipelineGroup dashboardPipelineGroup = dashboardPipelineGroupFor(group, user, allPipelines);
             if (dashboardPipelineGroup.hasPipelines()) {
                 pipelineGroups.add(dashboardPipelineGroup);
             }
@@ -95,7 +94,7 @@ public class GoDashboardService {
         return dashboardCurrentStateLoader.hasEverLoadedCurrentState();
     }
 
-    private GoDashboardEnvironment dashboardEnvironmentFor(EnvironmentConfig environment, DashboardFilter filter, Username user, Users allowedUsers, GoDashboardPipelines allPipelines) {
+    private GoDashboardEnvironment dashboardEnvironmentFor(EnvironmentConfig environment, Username user, Users allowedUsers, GoDashboardPipelines allPipelines) {
         GoDashboardEnvironment env = new GoDashboardEnvironment(environment.name().toString(), allowedUsers);
 
         environment.getPipelineNames().forEach(pipelineName -> {
@@ -109,7 +108,7 @@ public class GoDashboardService {
         return env;
     }
 
-    private GoDashboardPipelineGroup dashboardPipelineGroupFor(PipelineConfigs pipelineGroup, DashboardFilter filter, Username user, GoDashboardPipelines allPipelines) {
+    private GoDashboardPipelineGroup dashboardPipelineGroupFor(PipelineConfigs pipelineGroup, Username user, GoDashboardPipelines allPipelines) {
         GoDashboardPipelineGroup goDashboardPipelineGroup = new GoDashboardPipelineGroup(pipelineGroup.getGroup(), resolvePermissionsForPipelineGroup(pipelineGroup, allPipelines));
 
         if (goDashboardPipelineGroup.hasPermissions() && goDashboardPipelineGroup.canBeViewedBy(user)) {

--- a/server/src/test-fast/java/com/thoughtworks/go/server/service/GoDashboardServiceTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/service/GoDashboardServiceTest.java
@@ -24,8 +24,6 @@ import com.thoughtworks.go.config.security.users.NoOne;
 import com.thoughtworks.go.helper.GoConfigMother;
 import com.thoughtworks.go.server.dashboard.*;
 import com.thoughtworks.go.server.domain.Username;
-import com.thoughtworks.go.server.domain.user.DashboardFilter;
-import com.thoughtworks.go.server.domain.user.Filters;
 import com.thoughtworks.go.server.service.support.toggle.FeatureToggleService;
 import com.thoughtworks.go.server.service.support.toggle.Toggles;
 import org.junit.Before;
@@ -124,7 +122,7 @@ public class GoDashboardServiceTest {
 
         addPipelinesToCache(pipeline1, pipeline2);
 
-        List<GoDashboardPipelineGroup> pipelineGroups = allPipelineGroupsForDashboard(Filters.WILDCARD_FILTER, new Username("user1"));
+        List<GoDashboardPipelineGroup> pipelineGroups = allPipelineGroupsForDashboard(new Username("user1"));
 
         assertThat(pipelineGroups.size(), is(1));
         assertThat(pipelineGroups.get(0).pipelines(), contains("pipeline1", "pipeline2"));
@@ -142,7 +140,7 @@ public class GoDashboardServiceTest {
         addPipelinesToCache(pipeline1, pipeline2);
 
         configMother.addEnvironmentConfig(config, "env1", "pipeline1", "pipeline2");
-        List<GoDashboardEnvironment> envs = allEnvironmentsForDashboard(Filters.WILDCARD_FILTER, new Username("user1"));
+        List<GoDashboardEnvironment> envs = allEnvironmentsForDashboard(new Username("user1"));
 
         assertThat(envs.size(), is(1));
         assertThat(envs.get(0).pipelines(), contains("pipeline1", "pipeline2"));
@@ -159,7 +157,7 @@ public class GoDashboardServiceTest {
 
         addPipelinesToCache(pipeline1, pipeline2);
 
-        List<GoDashboardPipelineGroup> pipelineGroups = allPipelineGroupsForDashboard(Filters.WILDCARD_FILTER, new Username("user1"));
+        List<GoDashboardPipelineGroup> pipelineGroups = allPipelineGroupsForDashboard(new Username("user1"));
 
         assertThat(pipelineGroups.size(), is(1));
         assertThat(pipelineGroups.get(0).pipelines(), contains("pipeline1"));
@@ -177,7 +175,7 @@ public class GoDashboardServiceTest {
         addPipelinesToCache(pipeline1, pipeline2);
 
         configMother.addEnvironmentConfig(config, "env1", "pipeline1", "pipeline2");
-        List<GoDashboardEnvironment> envs = allEnvironmentsForDashboard(Filters.WILDCARD_FILTER, new Username("user1"));
+        List<GoDashboardEnvironment> envs = allEnvironmentsForDashboard(new Username("user1"));
 
         assertThat(envs.size(), is(1));
         assertThat(envs.get(0).pipelines(), contains("pipeline1"));
@@ -188,7 +186,7 @@ public class GoDashboardServiceTest {
         configMother.addPipelineWithGroup(config, "group1", "pipeline1", "stage1A", "job1A1");
         addPipelinesToCache(pipeline("pipeline1", "group1", new Permissions(NoOne.INSTANCE, NoOne.INSTANCE, NoOne.INSTANCE, NoOne.INSTANCE)));
 
-        List<GoDashboardPipelineGroup> pipelineGroups = allPipelineGroupsForDashboard(Filters.WILDCARD_FILTER, new Username("user1"));
+        List<GoDashboardPipelineGroup> pipelineGroups = allPipelineGroupsForDashboard(new Username("user1"));
 
         assertThat(pipelineGroups.size(), is(0));
     }
@@ -199,7 +197,7 @@ public class GoDashboardServiceTest {
         addPipelinesToCache(pipeline("pipeline1", "group1", new Permissions(NoOne.INSTANCE, NoOne.INSTANCE, NoOne.INSTANCE, NoOne.INSTANCE)));
 
         configMother.addEnvironmentConfig(config, "env1", "pipeline1");
-        List<GoDashboardEnvironment> pipelineGroups = allEnvironmentsForDashboard(Filters.WILDCARD_FILTER, new Username("user1"));
+        List<GoDashboardEnvironment> pipelineGroups = allEnvironmentsForDashboard(new Username("user1"));
 
         assertThat(pipelineGroups.size(), is(0));
     }
@@ -214,7 +212,7 @@ public class GoDashboardServiceTest {
 
         addPipelinesToCache(pipeline1);
 
-        List<GoDashboardPipelineGroup> pipelineGroups = allPipelineGroupsForDashboard(Filters.WILDCARD_FILTER, new Username("user1"));
+        List<GoDashboardPipelineGroup> pipelineGroups = allPipelineGroupsForDashboard(new Username("user1"));
 
         assertThat(pipelineGroups.size(), is(1));
         assertThat(pipelineGroups.get(0).pipelines(), contains("pipeline1"));
@@ -232,7 +230,7 @@ public class GoDashboardServiceTest {
         addPipelinesToCache(pipeline1);
         configMother.addEnvironmentConfig(config, "env1", "pipeline1", "pipeline2");
 
-        List<GoDashboardEnvironment> envs = allEnvironmentsForDashboard(Filters.WILDCARD_FILTER, new Username("user1"));
+        List<GoDashboardEnvironment> envs = allEnvironmentsForDashboard(new Username("user1"));
 
         assertThat(envs.size(), is(1));
         assertThat(envs.get(0).pipelines(), contains("pipeline1"));
@@ -253,17 +251,17 @@ public class GoDashboardServiceTest {
         verifyZeroInteractions(dashboardCurrentStateLoader);
     }
 
-    private List<GoDashboardEnvironment> allEnvironmentsForDashboard(DashboardFilter filter, Username username) {
+    private List<GoDashboardEnvironment> allEnvironmentsForDashboard(Username username) {
         when(goConfigService.getEnvironments()).thenReturn(config.getEnvironments());
         when(goConfigService.security()).thenReturn(config.server().security());
 
-        return service.allEnvironmentsForDashboard(filter, username);
+        return service.allEnvironmentsForDashboard(username);
     }
 
-    private List<GoDashboardPipelineGroup> allPipelineGroupsForDashboard(DashboardFilter filter, Username username) {
+    private List<GoDashboardPipelineGroup> allPipelineGroupsForDashboard(Username username) {
         when(goConfigService.groups()).thenReturn(config.getGroups());
 
-        return service.allPipelineGroupsForDashboard(filter, username);
+        return service.allPipelineGroupsForDashboard(username);
     }
 
     private void addPipelinesToCache(GoDashboardPipeline... pipelines) {

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/GoDashboardServiceIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/GoDashboardServiceIntegrationTest.java
@@ -31,7 +31,6 @@ import com.thoughtworks.go.server.dao.DatabaseAccessHelper;
 import com.thoughtworks.go.server.dao.StageSqlMapDao;
 import com.thoughtworks.go.server.dashboard.*;
 import com.thoughtworks.go.server.domain.Username;
-import com.thoughtworks.go.server.domain.user.Filters;
 import com.thoughtworks.go.server.persistence.MaterialRepository;
 import com.thoughtworks.go.server.service.result.DefaultLocalizedOperationResult;
 import com.thoughtworks.go.server.transaction.TransactionTemplate;
@@ -47,7 +46,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
-import java.util.Iterator;
 import java.util.List;
 import java.util.UUID;
 
@@ -115,14 +113,14 @@ public class GoDashboardServiceIntegrationTest {
     }
 
     @Test
-    public void shouldShowTheLatestStatusOfPipelineInstanceIfAFullConfigSaveIsPerformed() throws Exception {
+    public void shouldShowTheLatestStatusOfPipelineInstanceIfAFullConfigSaveIsPerformed() {
         GitMaterial g1 = u.wf(new GitMaterial("g1"), "folder3");
         u.checkinInOrder(g1, "g_1", "g_2");
         ScheduleTestUtil.AddedPipeline p1 = u.saveConfigWith("p1", u.m(g1));
         String p1_1 = u.runAndPass(p1, "g_1");
 
         goDashboardService.updateCacheForAllPipelinesIn(goConfigService.cruiseConfig());
-        List<GoDashboardPipelineGroup> pipelineGroupsOnDashboard = goDashboardService.allPipelineGroupsForDashboard(Filters.WILDCARD_FILTER, new Username("user"));
+        List<GoDashboardPipelineGroup> pipelineGroupsOnDashboard = goDashboardService.allPipelineGroupsForDashboard(new Username("user"));
         assertThat(pipelineGroupsOnDashboard, hasSize(1));
         assertThat(pipelineGroupsOnDashboard.get(0).allPipelines().size(), is(1));
         assertThat(pipelineGroupsOnDashboard.get(0).allPipelines().iterator().next().model().getLatestPipelineInstance()
@@ -132,7 +130,7 @@ public class GoDashboardServiceIntegrationTest {
         Pipeline p1_2 = scheduleService.schedulePipeline(p1.config.name(), buildCauseForThirdRun);
         goDashboardService.updateCacheForPipeline(p1.config);
 
-        pipelineGroupsOnDashboard = goDashboardService.allPipelineGroupsForDashboard(Filters.WILDCARD_FILTER, new Username("user"));
+        pipelineGroupsOnDashboard = goDashboardService.allPipelineGroupsForDashboard(new Username("user"));
         assertThat(pipelineGroupsOnDashboard, hasSize(1));
         assertThat(pipelineGroupsOnDashboard.get(0).allPipelines().size(), is(1));
         assertThat(pipelineGroupsOnDashboard.get(0).allPipelines().iterator().next().model().getLatestPipelineInstance().getId(), Matchers.is(p1_2.getId()));
@@ -140,21 +138,21 @@ public class GoDashboardServiceIntegrationTest {
         goConfigService.addEnvironment(new BasicEnvironmentConfig(new CaseInsensitiveString("environment")));
         goDashboardService.updateCacheForAllPipelinesIn(goConfigService.cruiseConfig());
 
-        pipelineGroupsOnDashboard = goDashboardService.allPipelineGroupsForDashboard(Filters.WILDCARD_FILTER, new Username("user"));
+        pipelineGroupsOnDashboard = goDashboardService.allPipelineGroupsForDashboard(new Username("user"));
         assertThat(pipelineGroupsOnDashboard, hasSize(1));
         assertThat(pipelineGroupsOnDashboard.get(0).allPipelines().size(), is(1));
         assertThat(pipelineGroupsOnDashboard.get(0).allPipelines().iterator().next().model().getLatestPipelineInstance().getId(), Matchers.is(p1_2.getId()));
     }
 
     @Test
-    public void shouldNotReturnDeletedPipelineAsPartOfDashboard() throws Exception {
+    public void shouldNotReturnDeletedPipelineAsPartOfDashboard() {
         GitMaterial g1 = u.wf(new GitMaterial("g1"), "folder3");
         u.checkinInOrder(g1, "g_1", "g_2");
         ScheduleTestUtil.AddedPipeline addedPipeline = u.saveConfigWith(UUID.randomUUID().toString(), u.m(g1));
         String p1_1 = u.runAndPass(addedPipeline, "g_1");
 
         goDashboardService.updateCacheForAllPipelinesIn(goConfigService.cruiseConfig());
-        List<GoDashboardPipelineGroup> pipelineGroupsOnDashboard = goDashboardService.allPipelineGroupsForDashboard(Filters.WILDCARD_FILTER, new Username("user"));
+        List<GoDashboardPipelineGroup> pipelineGroupsOnDashboard = goDashboardService.allPipelineGroupsForDashboard(new Username("user"));
         assertThat(pipelineGroupsOnDashboard, hasSize(1));
         assertThat(pipelineGroupsOnDashboard.get(0).allPipelines().size(), is(1));
         assertThat(pipelineGroupsOnDashboard.get(0).allPipelines().iterator().next().model().getLatestPipelineInstance()
@@ -164,7 +162,7 @@ public class GoDashboardServiceIntegrationTest {
         Pipeline p1_2 = scheduleService.schedulePipeline(addedPipeline.config.name(), buildCauseForThirdRun);
         goDashboardService.updateCacheForPipeline(addedPipeline.config);
 
-        pipelineGroupsOnDashboard = goDashboardService.allPipelineGroupsForDashboard(Filters.WILDCARD_FILTER, new Username("user"));
+        pipelineGroupsOnDashboard = goDashboardService.allPipelineGroupsForDashboard(new Username("user"));
         assertThat(pipelineGroupsOnDashboard, hasSize(1));
         assertThat(pipelineGroupsOnDashboard.get(0).allPipelines().size(), is(1));
         assertThat(pipelineGroupsOnDashboard.get(0).allPipelines().iterator().next().model().getLatestPipelineInstance().getId(), Matchers.is(p1_2.getId()));
@@ -172,13 +170,13 @@ public class GoDashboardServiceIntegrationTest {
         pipelineConfigService.deletePipelineConfig(new Username("user"), addedPipeline.config, new DefaultLocalizedOperationResult());
         goDashboardService.updateCacheForPipeline(addedPipeline.config);
 
-        pipelineGroupsOnDashboard = goDashboardService.allPipelineGroupsForDashboard(Filters.WILDCARD_FILTER, new Username("user"));
+        pipelineGroupsOnDashboard = goDashboardService.allPipelineGroupsForDashboard(new Username("user"));
         assertThat(pipelineGroupsOnDashboard, hasSize(0));
 
         goConfigService.addEnvironment(new BasicEnvironmentConfig(new CaseInsensitiveString("environment")));
         goDashboardService.updateCacheForAllPipelinesIn(goConfigService.cruiseConfig());
 
-        pipelineGroupsOnDashboard = goDashboardService.allPipelineGroupsForDashboard(Filters.WILDCARD_FILTER, new Username("user"));
+        pipelineGroupsOnDashboard = goDashboardService.allPipelineGroupsForDashboard(new Username("user"));
         assertThat(pipelineGroupsOnDashboard, hasSize(0));
     }
 
@@ -191,7 +189,7 @@ public class GoDashboardServiceIntegrationTest {
 
         goDashboardConfigChangeHandler.call(goConfigService.cruiseConfig());
 
-        List<GoDashboardPipelineGroup> originalDashboard = goDashboardService.allPipelineGroupsForDashboard(Filters.WILDCARD_FILTER, user);
+        List<GoDashboardPipelineGroup> originalDashboard = goDashboardService.allPipelineGroupsForDashboard(user);
         assertThat(originalDashboard, hasSize(1));
         assertThat(originalDashboard.get(0).allPipelines(), hasSize(1));
         assertThat(originalDashboard.get(0).allPipelines().iterator().next().model().getActivePipelineInstances(), hasSize(1));
@@ -200,25 +198,23 @@ public class GoDashboardServiceIntegrationTest {
         pipelineConfigService.createPipelineConfig(user, newPipeline, new DefaultLocalizedOperationResult(), goConfigService.cruiseConfig().getGroups().first().getGroup());
         goDashboardConfigChangeHandler.call(goConfigService.cruiseConfig().pipelineConfigByName(newPipeline.name()));
 
-        assertThereIsExactlyOneInstanceOfEachPipelineOnDashboard(goDashboardService.allPipelineGroupsForDashboard(Filters.WILDCARD_FILTER, user));
+        assertThereIsExactlyOneInstanceOfEachPipelineOnDashboard(goDashboardService.allPipelineGroupsForDashboard(user));
 
         String newPipelineCounter1 = u.runAndPass(new ScheduleTestUtil.AddedPipeline(newPipeline, new DependencyMaterial(newPipeline.name(), newPipeline.first().name())), "g_1");
         goDashboardStageStatusChangeHandler.call(stageSqlMapDao.mostRecentPassed(newPipeline.name().toString(), newPipeline.first().name().toString()));
 
-        assertThereIsExactlyOneInstanceOfEachPipelineOnDashboard(goDashboardService.allPipelineGroupsForDashboard(Filters.WILDCARD_FILTER, user));
+        assertThereIsExactlyOneInstanceOfEachPipelineOnDashboard(goDashboardService.allPipelineGroupsForDashboard(user));
 
         goConfigService.addEnvironment(new BasicEnvironmentConfig(new CaseInsensitiveString("new-environment")));
         goDashboardConfigChangeHandler.call(goConfigService.cruiseConfig());
 
-        assertThereIsExactlyOneInstanceOfEachPipelineOnDashboard(goDashboardService.allPipelineGroupsForDashboard(Filters.WILDCARD_FILTER, user));
+        assertThereIsExactlyOneInstanceOfEachPipelineOnDashboard(goDashboardService.allPipelineGroupsForDashboard(user));
     }
 
     private void assertThereIsExactlyOneInstanceOfEachPipelineOnDashboard(List<GoDashboardPipelineGroup> dashboardAfterPipelineCreationViaApi) {
-        assertThat(dashboardAfterPipelineCreationViaApi, hasSize(1));//pipeline group
+        assertThat(dashboardAfterPipelineCreationViaApi, hasSize(1)); //pipeline group
         assertThat(dashboardAfterPipelineCreationViaApi.get(0).allPipelines(), hasSize(goConfigService.cruiseConfig().getAllPipelineNames().size()));
-        Iterator<GoDashboardPipeline> iterator = dashboardAfterPipelineCreationViaApi.get(0).allPipelines().iterator();
-        while (iterator.hasNext()){
-            GoDashboardPipeline dashboardPipeline = iterator.next();
+        for (GoDashboardPipeline dashboardPipeline : dashboardAfterPipelineCreationViaApi.get(0).allPipelines()) {
             assertThat(dashboardPipeline.model().getName(), dashboardPipeline.model().getActivePipelineInstances(), hasSize(1));
         }
     }


### PR DESCRIPTION
Also, don't even process the viewName param on the Dashboard. We don't do anything with the filter once it's resolved.

This was missed in PR #5026.