### PR TITLE
Default personalization filter should not be special

### DIFF
--- a/server/src/main/java/com/thoughtworks/go/server/domain/user/FilterValidator.java
+++ b/server/src/main/java/com/thoughtworks/go/server/domain/user/FilterValidator.java
@@ -43,7 +43,7 @@ class FilterValidator {
     static final String MSG_INVALID_STATES = "An invalid filter state has been provided. Only " + BUILDING_STATE + " and " + FAILED_STATE + " are supported";
 
     static void validateDefaultIsPresent(Map<String, DashboardFilter> current) {
-        if (!current.containsKey(DEFAULT_NAME.toLowerCase())) throw new FilterValidationException(MSG_NO_DEFAULT_FILTER);
+        if (current.isEmpty()) throw new FilterValidationException(MSG_NO_DEFAULT_FILTER);
     }
 
     static void validateFilter(Map<String, DashboardFilter> current, DashboardFilter filter) {

--- a/server/src/main/java/com/thoughtworks/go/server/domain/user/Filters.java
+++ b/server/src/main/java/com/thoughtworks/go/server/domain/user/Filters.java
@@ -66,7 +66,7 @@ public class Filters {
 
     public DashboardFilter named(String name) {
         FilterValidator.validateNamePresent(name);
-        return this.filterMap.getOrDefault(name.toLowerCase(), WILDCARD_FILTER);
+        return this.filterMap.getOrDefault(name.toLowerCase(), filters.get(0));
     }
 
     public List<DashboardFilter> filters() {

--- a/server/src/main/java/com/thoughtworks/go/server/domain/user/Marshaling.java
+++ b/server/src/main/java/com/thoughtworks/go/server/domain/user/Marshaling.java
@@ -23,7 +23,6 @@ import org.apache.commons.lang3.StringUtils;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
 
-import static com.thoughtworks.go.server.domain.user.DashboardFilter.DEFAULT_NAME;
 import static java.lang.String.format;
 
 public class Marshaling {
@@ -82,7 +81,7 @@ public class Marshaling {
                 throw new IllegalArgumentException("Don't know how to handle DashboardFilter implementation: " + src.getClass().getCanonicalName());
             }
 
-            serialized.getAsJsonObject().addProperty(KEY_NAME, normalizeName(src.name()));
+            serialized.getAsJsonObject().addProperty(KEY_NAME, src.name());
 
             return serialized;
         }
@@ -93,7 +92,7 @@ public class Marshaling {
         public DashboardFilter deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
             JsonObject jsonObject = json.getAsJsonObject();
 
-            final String name = normalizeName(defensivelyGetString(jsonObject, KEY_NAME));
+            final String name = defensivelyGetString(jsonObject, KEY_NAME);
             jsonObject.addProperty(KEY_NAME, name);
 
             final String type = defensivelyGetString(jsonObject, KEY_TYPE);
@@ -124,10 +123,6 @@ public class Marshaling {
         public CaseInsensitiveString deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
             return new CaseInsensitiveString(json.getAsString());
         }
-    }
-
-    private static String normalizeName(String name) {
-        return name.equalsIgnoreCase(DEFAULT_NAME) ? DEFAULT_NAME : name;
     }
 
     private static String defensivelyGetString(JsonObject obj, String key) {

--- a/server/src/main/java/com/thoughtworks/go/server/domain/user/PipelineSelections.java
+++ b/server/src/main/java/com/thoughtworks/go/server/domain/user/PipelineSelections.java
@@ -28,8 +28,6 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Date;
 
-import static com.thoughtworks.go.server.domain.user.DashboardFilter.DEFAULT_NAME;
-
 public class PipelineSelections extends PersistentObject implements Serializable {
     public static final int CURRENT_SCHEMA_VERSION = 2;
 
@@ -110,12 +108,17 @@ public class PipelineSelections extends PersistentObject implements Serializable
 
     @Deprecated // TODO: remove when removing old dashboard
     public boolean includesPipeline(CaseInsensitiveString pipelineName) {
-        return namedFilter(DEFAULT_NAME).isPipelineVisible(pipelineName);
+        return defaultFilter().isPipelineVisible(pipelineName);
     }
 
     @Deprecated // TODO: remove when removing old dashboard
     public boolean isBlacklist() {
-        return namedFilter(DEFAULT_NAME) instanceof BlacklistFilter;
+        return defaultFilter() instanceof BlacklistFilter;
+    }
+
+    @Deprecated // TODO: remove when removing old dashboard
+    public DashboardFilter defaultFilter() {
+        return viewFilters.filters().get(0);
     }
 
     public DashboardFilter namedFilter(String name) {

--- a/server/src/main/java/com/thoughtworks/go/server/service/PipelineHistoryService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/PipelineHistoryService.java
@@ -50,8 +50,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
-import static com.thoughtworks.go.server.domain.user.DashboardFilter.DEFAULT_NAME;
-
 @Service
 public class PipelineHistoryService implements PipelineInstanceLoader {
     private PipelineDao pipelineDao;
@@ -395,7 +393,7 @@ public class PipelineHistoryService implements PipelineInstanceLoader {
 
     public List<PipelineGroupModel> allActivePipelineInstances(Username username, PipelineSelections pipelineSelections) {
         PipelineGroupModels groupModels = allPipelineInstances(username);
-        filterSelections(groupModels, pipelineSelections.namedFilter(DEFAULT_NAME));
+        filterSelections(groupModels, pipelineSelections.defaultFilter());
         removeEmptyGroups(groupModels);
         updateGroupAdministrability(username, groupModels);
         return groupModels.asList();

--- a/server/src/test-fast/java/com/thoughtworks/go/server/domain/user/FiltersTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/domain/user/FiltersTest.java
@@ -150,28 +150,19 @@ class FiltersTest {
     }
 
     @Test
-    void validatesPresenceOfDefaultFilterOnConstruction() {
-        Throwable e = assertThrows(FilterValidationException.class, () -> Filters.single(namedBlacklist("foo", "bar")));
+    void validatesPresenceOfAtLeastOneFilterOnConstruction() {
+        assertDoesNotThrow(() -> new Filters(Collections.singletonList(namedWhitelist("foo", "p1"))));
+
+        Throwable e = assertThrows(FilterValidationException.class, () -> new Filters(Collections.emptyList()));
         assertEquals(MSG_NO_DEFAULT_FILTER, e.getMessage());
     }
 
     @Test
-    void validatesPresenceOfDefaultFilterOnDeserialize() {
-        final String json = "{ \"filters\": [" +
-                "  {\"name\": \"foo\", \"type\": \"whitelist\", \"pipelines\": [\"bar\"], \"state\": []}" +
-                "] }";
+    void validatesPresenceOfAtLeastOneFilterOnDeserialize() {
+        assertDoesNotThrow(() -> Filters.fromJson("{ \"filters\": [{\"name\": \"foo\", \"state\":[], \"pipelines\":[], \"type\": \"whitelist\"}] }"));
 
-        Throwable e = assertThrows(FilterValidationException.class, () -> Filters.fromJson(json));
+        Throwable e = assertThrows(FilterValidationException.class, () -> Filters.fromJson("{ \"filters\": [] }"));
         assertEquals(MSG_NO_DEFAULT_FILTER, e.getMessage());
-    }
-
-    @Test
-    void defaultFilterNameIsAlwaysTitleCase() {
-        String json = "{ \"filters\": [{\"name\": \"deFauLt\", \"state\":[], \"type\": \"whitelist\"}] }";
-        assertEquals(DEFAULT_NAME, Filters.fromJson(json).named(DEFAULT_NAME).name());
-
-        String expected = "{\"filters\":[{\"name\":\"" + DEFAULT_NAME + "\",\"state\":[],\"pipelines\":[],\"type\":\"whitelist\"}]}";
-        assertEquals(expected, Filters.toJson(Filters.single(namedWhitelist("defAUlT"))));
     }
 
     @Test

--- a/server/src/test-integration/java/com/thoughtworks/go/server/persistence/PipelineRepositoryIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/persistence/PipelineRepositoryIntegrationTest.java
@@ -164,7 +164,7 @@ public class PipelineRepositoryIntegrationTest {
     }
 
     @Test
-    public void shouldReturnEarliestPMRFor1Material() throws Exception {
+    public void shouldReturnEarliestPMRFor1Material() {
         HgMaterial hgmaterial = MaterialsMother.hgMaterial("first");
 
         PipelineConfig pipelineConfig = createPipelineConfig(PIPELINE_NAME, "stage", "job");
@@ -245,7 +245,7 @@ public class PipelineRepositoryIntegrationTest {
     }
 
     @Test
-    public void shouldReturnEarliestPMRForMultipleMaterial() throws Exception {
+    public void shouldReturnEarliestPMRForMultipleMaterial() {
         final HgMaterial hgmaterial = MaterialsMother.hgMaterial("first");
         final SvnMaterial svnMaterial = MaterialsMother.svnMaterial();
 
@@ -332,7 +332,7 @@ public class PipelineRepositoryIntegrationTest {
         long id = pipelineRepository.saveSelectedPipelines(blacklist(unSelected, null));
         PipelineSelections found = pipelineRepository.findPipelineSelectionsById(id);
 
-        final DashboardFilter filter = found.namedFilter(DEFAULT_NAME);
+        final DashboardFilter filter = found.defaultFilter();
         assertAllowsPipelines(filter, "pipeline3", "pipeline4");
         assertDeniesPipelines(filter, "pipeline1", "pipeline2");
         assertNull(found.userId());

--- a/server/webapp/WEB-INF/rails.new/spec/webpack/models/dashboard/dashboard_filters_spec.js
+++ b/server/webapp/WEB-INF/rails.new/spec/webpack/models/dashboard/dashboard_filters_spec.js
@@ -22,26 +22,11 @@ describe("DashboardFilters", () => {
     expect(filters.names()).toEqual(["Default", "a", "b", "c"]);
   });
 
-  it("defaultFilter() returns a filter matching the default name", () => {
-    const filters = new DashboardFilters([def, a, b, c]);
-    expect(filters.defaultFilter().name).toBe("Default");
-    expect(filters.defaultFilter()).toEqual(def);
-    expect(filters.defaultFilter() === def).toBe(true);
-  });
-
-  it("defaultFilter() creates a new default wildcard filter when a default does not exist", () => {
-    const filters = new DashboardFilters([a]);
-    expect(filters.names()).toEqual(["a"]);
-
-    const newDefault = filters.defaultFilter();
-    expect(filters.names()).toEqual(["Default", "a"]);
-
-    expect(newDefault === def).toBe(false);
-    expect(JSON.stringify(newDefault) !== JSON.stringify(def)).toBe(true); // not structurally equal
-
-    expect(newDefault.name).toBe("Default");
-    expect(newDefault.type).toBe("blacklist");
-    expect(newDefault.pipelines).toEqual([]);
+  it("defaultFilter() returns the first filter", () => {
+    const filters = new DashboardFilters([a, b, c]);
+    expect(filters.defaultFilter().name).toBe("a");
+    expect(filters.defaultFilter()).toEqual(a);
+    expect(filters.defaultFilter() === a).toBe(true);
   });
 
   it("findFilter() finds a filter by name, case-insensitively", () => {
@@ -51,14 +36,14 @@ describe("DashboardFilters", () => {
   });
 
   it("findFilter() falls back to defaultFilter when it cannot resolve a filter by name", () => {
-    expect(new DashboardFilters([def, a]).findFilter("c")).toEqual(def);
+    expect(new DashboardFilters([a, b]).findFilter("c")).toEqual(a);
 
     const filters = new DashboardFilters([a]);
     const found = filters.findFilter("c");
 
-    expect(found.name).toBe("Default");
-    expect(filters.names()).toEqual(["Default", "a"]);
-    expect(found).toEqual({name: "Default", state: [], type: "blacklist", pipelines: []});
+    expect(found.name).toBe("a");
+    expect(filters.names()).toEqual(["a"]);
+    expect(found).toEqual(a);
   });
 
   it("addFilter() appends a filter", () => {

--- a/server/webapp/WEB-INF/rails.new/spec/webpack/views/dashboard/dashboard_widget_spec.js
+++ b/server/webapp/WEB-INF/rails.new/spec/webpack/views/dashboard/dashboard_widget_spec.js
@@ -547,7 +547,7 @@ describe("Dashboard Widget", () => {
 
     dashboard = new Dashboard();
     const personalizeVM = new PersonalizeVM(Stream("Default"));
-    personalizeVM.model(new Personalization([], []));
+    personalizeVM.model(new Personalization([{name: "Default", state: []}], []));
     dashboard.initialize(dashboardJson);
 
     const dashboardViewModel = new DashboardVM(dashboard);

--- a/server/webapp/WEB-INF/rails.new/spec/webpack/views/dashboard/model/personaliza_editor_vm_spec.js
+++ b/server/webapp/WEB-INF/rails.new/spec/webpack/views/dashboard/model/personaliza_editor_vm_spec.js
@@ -20,7 +20,7 @@ describe("Personalization Editor View Model", () => {
   it("blank config yields a wildcard filter", () => {
     const model = new PersonalizeEditorVM({}, {});
 
-    expect(model.asFilter().type).toBe("blacklist");
+    expect(model.asFilter().type).toBe("whitelist");
     expect(model.asFilter().pipelines).toEqual([]);
   });
 

--- a/server/webapp/WEB-INF/rails.new/webpack/models/dashboard/dashboard_filters.js
+++ b/server/webapp/WEB-INF/rails.new/webpack/models/dashboard/dashboard_filters.js
@@ -17,12 +17,6 @@
 const _ = require("lodash");
 
 function DashboardFilters(filters) {
-  const NAME_DEFAULT_FILTER = "Default";
-
-  function defaultDef() {
-    return {name: NAME_DEFAULT_FILTER, state: [], type: "blacklist", pipelines: []};
-  }
-
   this.clone = function clone() {
     return new DashboardFilters(_.map(this.filters, (f) => _.cloneDeep(f)));
   };
@@ -34,11 +28,6 @@ function DashboardFilters(filters) {
 
     if (idx !== -1) {
       this.filters.splice(idx, 1, updatedFilter);
-
-      // make sure there is always a default filter, even if we try to rename it.
-      if (oldName.toLowerCase() === NAME_DEFAULT_FILTER.toLowerCase() && !matchName(NAME_DEFAULT_FILTER)(updatedFilter)) {
-        this.filters.unshift(defaultDef());
-      }
     } else {
       console.error(`Couldn't locate filter named [${oldName}]; this shouldn't happen. Falling back to append().`); // eslint-disable-line no-console
       this.addFilter(updatedFilter);
@@ -60,17 +49,7 @@ function DashboardFilters(filters) {
     move(this.filters, from, to);
   };
 
-  this.defaultFilter = () => {
-    const f = _.find(this.filters, matchName(NAME_DEFAULT_FILTER));
-
-    if (!f) {
-      const blank = defaultDef();
-      this.filters.unshift(blank);
-      return blank;
-    }
-
-    return f;
-  };
+  this.defaultFilter = () => this.filters[0] ;
 
   this.names = () => {
     return _.map(this.filters, "name");

--- a/server/webapp/WEB-INF/rails.new/webpack/single_page_apps/new_dashboard.js
+++ b/server/webapp/WEB-INF/rails.new/webpack/single_page_apps/new_dashboard.js
@@ -74,7 +74,7 @@ $(() => {
    */
   function currentView(viewName, replace=false) {
     const current = queryObject();
-    if (!arguments.length) { return current.viewName || "Default"; }
+    if (!arguments.length) { return current.viewName || personalizeVM.names()[0]; }
 
     const route = window.location.hash.replace(/^#!/, "");
 

--- a/server/webapp/WEB-INF/rails.new/webpack/views/dashboard/edit_tab_dropdown.js.msx
+++ b/server/webapp/WEB-INF/rails.new/webpack/views/dashboard/edit_tab_dropdown.js.msx
@@ -40,7 +40,7 @@ const EditTabDropdown = {
     if (vm.tabSettingsDropdownVisible()) {
       const model = vm.model;
       const current = vm.canonicalCurrentName();
-      const allowDelete = !vm.locked() && !vm.isDefault(current);
+      const allowDelete = !vm.locked() && vm.names().length !== 1;
 
       const edit = vm.actionHandler(() => Editor.open(model().namedFilter(current), model, vm));
       const remove = vm.actionHandler(() => deleteView(current, model, vm));
@@ -69,8 +69,9 @@ function deleteView(name, personalization, model) {
       text: "Yes",
       onclick: () => {
         personalization().removeFilter(name, model.etag()).done((data) => {
-          model.currentView("Default");
-          model.names(personalization().names());
+          const names = personalization().names();
+          model.currentView(names[0]);
+          model.names(names);
           model.checksum(data.contentHash);
 
           Modal.close();

--- a/server/webapp/WEB-INF/rails.new/webpack/views/dashboard/models/personalize_editor_vm.js
+++ b/server/webapp/WEB-INF/rails.new/webpack/views/dashboard/models/personalize_editor_vm.js
@@ -52,7 +52,7 @@ function PersonalizeEditorVM(opts, pipelinesByGroup) { // opts is usually the cu
 
 function normalize(opts) {
   opts.name = opts.name || "";
-  opts.type = opts.type || "blacklist";
+  opts.type = opts.type || "whitelist";
   opts.pipelines = arr(opts.pipelines);
   opts.state = arr(opts.state);
 }

--- a/server/webapp/WEB-INF/rails.new/webpack/views/dashboard/personalization_modal_widget.js.msx
+++ b/server/webapp/WEB-INF/rails.new/webpack/views/dashboard/personalization_modal_widget.js.msx
@@ -19,6 +19,10 @@ const _ = require("lodash");
 const f = require("helpers/form_helper");
 
 const FilterNameInput = {
+  oncreate(vnode) {
+    vnode.dom.querySelector(".view-name").focus();
+  },
+
   view(vnode) {
     const vm = vnode.attrs.vm;
     const submitOnEnter = (e) => {


### PR DESCRIPTION
Currently, the `Default` personalization filter/tab has special treatment. Really though, it's no better than the rest :).

Seriously speaking, the intended changes of this PR are as follows:

- [x] No longer validate that a filter named `Default` must exist
- [x] Instead, validate that at least 1 filter exists, regardless of its name
- [x] De/serialization should not try to normalize the name `default` (enforcing title-case)
- [x] Users can rename and delete this filter, just as with any other filter
- [x] Filter template for adding new filter should be a blank whitelist
- [x] The UI should prevent the last filter from being deleted by disabling the remove button. Add a tooltip indicating such behavior for the last tab.
- [x] The "default" filter (i.e. the one that is active upon first loading the dashboard without specifying a name in the `viewName` param) is the first (read: leftmost) filter.