### PR TITLE
Fix saving of dashboard filters

### DIFF
--- a/server/webapp/WEB-INF/rails.new/spec/webpack/views/dashboard/model/personalize_editor_vm_spec.js
+++ b/server/webapp/WEB-INF/rails.new/spec/webpack/views/dashboard/model/personalize_editor_vm_spec.js
@@ -24,6 +24,24 @@ describe("Personalization Editor View Model", () => {
     expect(model.asFilter().pipelines).toEqual([]);
   });
 
+  it("builds the filter pipeline list from the internal model", () => {
+    const model = vm({});
+    model.selectionVM(null);
+
+    expect(model.asFilter().type).toBe("whitelist");
+    expect(model.asFilter().pipelines).toEqual([]);
+
+    model.selectionVM({ pipelines: (inv) => inv ? ["c", "d"] : ["a", "b"] });
+
+    uncheck(model.includeNewPipelines);
+    expect(model.asFilter().type).toBe("whitelist");
+    expect(model.asFilter().pipelines).toEqual(["a", "b"]);
+
+    check(model.includeNewPipelines);
+    expect(model.asFilter().type).toBe("blacklist");
+    expect(model.asFilter().pipelines).toEqual(["c", "d"]);
+  });
+
   it("checking the includeNewPipelines() sets the filter type", () => {
     const model = vm({});
 

--- a/server/webapp/WEB-INF/rails.new/webpack/views/dashboard/models/personalize_editor_vm.js
+++ b/server/webapp/WEB-INF/rails.new/webpack/views/dashboard/models/personalize_editor_vm.js
@@ -50,7 +50,7 @@ function PersonalizeEditorVM(opts) { // opts is usually the current filter
   this.errorResponse = Stream();
 
   this.asFilter = () => {
-    const pipelines = selectionVM() ? [] : selectionVM().pipelines(inverted());
+    const pipelines = selectionVM() ? selectionVM().pipelines(inverted()) : [];
     return {name: name(), type: type(), pipelines, state: state()};
   };
 }


### PR DESCRIPTION
@marques-work , the dashboard filters are getting saved as an empty array regardless of the selection. Can you check if this fix is correct? I also tried adding a unit test, but couldn't figure out how to set up the data for selected pipelines.