### PR TITLE
Fix dashboard pipeline status filtering

### DIFF
--- a/server/webapp/WEB-INF/rails.new/webpack/models/dashboard/dashboard_filter.js
+++ b/server/webapp/WEB-INF/rails.new/webpack/models/dashboard/dashboard_filter.js
@@ -20,8 +20,9 @@ function DashboardFilter(config) {
   this.acceptsStatusOf = (pipeline) => {
     const latestStage = pipeline.latestStage();
 
-    if (latestStage && config.state.length) {
-      if (latestStage.isBuilding()) { return _.includes(config.state, "building"); }
+    if (config.state.length) {
+      if (!latestStage) { return false; }
+      if (latestStage.isBuilding() || latestStage.isFailing()) { return _.includes(config.state, "building"); }
       if (latestStage.isFailed()) { return _.includes(config.state, "failing"); }
       return false;
     }

--- a/server/webapp/WEB-INF/rails.new/webpack/models/dashboard/pipeline_instance.js
+++ b/server/webapp/WEB-INF/rails.new/webpack/models/dashboard/pipeline_instance.js
@@ -26,6 +26,7 @@ const StageInstance = function (json, pipelineName, pipelineCounter) {
   this.status                = json.status;
   this.stageDetailTabPath    = Routes.stageDetailTabPath(pipelineName, pipelineCounter, json.name, json.counter);
   this.isBuilding            = () => json.status === 'Building';
+  this.isFailing             = () => json.status === 'Failing';
   this.isFailed              = () => json.status === 'Failed';
   this.isBuildingOrCompleted = () => json.status !== 'Unknown';
 };


### PR DESCRIPTION
  - "building" status filter should match pipelines that are in the "failing" state (but not "Failed")
  - Should ignore pipelines that have never run yet

Fixes #5074 and #5075 