### PR TITLE
Updating System Admins through API triggers a re-authentication, fixe…

### DIFF
--- a/common/src/main/java/com/thoughtworks/go/listener/SecurityConfigChangeListener.java
+++ b/common/src/main/java/com/thoughtworks/go/listener/SecurityConfigChangeListener.java
@@ -16,6 +16,7 @@
 
 package com.thoughtworks.go.listener;
 
+import com.thoughtworks.go.config.AdminsConfig;
 import com.thoughtworks.go.config.Role;
 import com.thoughtworks.go.config.SecurityAuthConfig;
 
@@ -25,7 +26,8 @@ import java.util.List;
 public abstract class SecurityConfigChangeListener extends EntityConfigChangedListener<Object> {
     private final List<Class<?>> securityConfigClasses = Arrays.asList(
             SecurityAuthConfig.class,
-            Role.class
+            Role.class,
+            AdminsConfig.class
     );
 
     @Override

--- a/common/src/test/java/com/thoughtworks/go/listener/SecurityConfigChangeListenerTest.java
+++ b/common/src/test/java/com/thoughtworks/go/listener/SecurityConfigChangeListenerTest.java
@@ -16,6 +16,7 @@
 
 package com.thoughtworks.go.listener;
 
+import com.thoughtworks.go.config.AdminsConfig;
 import com.thoughtworks.go.config.PluginRoleConfig;
 import com.thoughtworks.go.config.RoleConfig;
 import com.thoughtworks.go.config.SecurityAuthConfig;
@@ -58,6 +59,17 @@ public class SecurityConfigChangeListenerTest {
             }
         };
         assertThat(securityConfigChangeListener.shouldCareAbout(new PluginRoleConfig()), is(true));
+    }
+
+    @Test
+    public void shouldCareAboutAdminsConfigChange() {
+        SecurityConfigChangeListener securityConfigChangeListener = new SecurityConfigChangeListener() {
+            @Override
+            public void onEntityConfigChange(Object entity) {
+
+            }
+        };
+        assertThat(securityConfigChangeListener.shouldCareAbout(new AdminsConfig()), is(true));
     }
 
     @Test


### PR DESCRIPTION
…s #5084

* Change to SecurityConfig should trigger a re-authentication,
  AdminsConfig added to SecurityConfigChangeListener to trigger a
  re-auth.