### PR TITLE
Show VSM differently in analytics mode

### DIFF
--- a/server/webapp/WEB-INF/rails.new/app/assets/javascripts/vsm_renderer.js
+++ b/server/webapp/WEB-INF/rails.new/app/assets/javascripts/vsm_renderer.js
@@ -15,7 +15,7 @@
  *************************GO-LICENSE-END**********************************/
 
 Graph_Renderer = function (container) {
-    'use strict'
+    'use strict';
     var container = $j(container);
     var width = 200; // Default width of a node
     var height = 110; // Default height of a node
@@ -65,6 +65,13 @@ Graph_Renderer = function (container) {
       $j('.vsm-entity.pipeline a').css({ "pointer-events": "none" });
       $j('.vsm-entity.material').click(selectMaterial);
       $j('.vsm-entity.pipeline').click(selectPipeline);
+
+      $j('.vsm-entity.pipeline').addClass("vsm-pipeline-node");
+      $j('.vsm-entity.pipeline h3 a').addClass("vsm-pipeline-unclickable-name");
+      $j('.vsm-entity.pipeline .pipeline_actions').addClass("hidden");
+      $j('.vsm-entity.pipeline .instances .instance .vsm_link_wrapper').addClass("hidden");
+      $j('.vsm-entity.pipeline .instances .instance .duration').addClass("hidden");
+
       highlightCurrentNode();
     };
 
@@ -74,6 +81,13 @@ Graph_Renderer = function (container) {
       $j('.vsm-entity.material').css({ "pointer-events": "auto" });
       $j('.vsm-entity.material').unbind('click', selectMaterial);
       $j('.vsm-entity.pipeline').unbind('click', selectPipeline);
+
+      $j('.vsm-entity.pipeline').removeClass("vsm-pipeline-node");
+      $j('.vsm-entity.pipeline h3 a').removeClass("vsm-pipeline-unclickable-name");
+      $j('.vsm-entity.pipeline .pipeline_actions').removeClass("hidden");
+      $j('.vsm-entity.pipeline .instances .instance .vsm_link_wrapper').removeClass("hidden");
+      $j('.vsm-entity.pipeline .instances .instance .duration').removeClass("hidden");
+
       removeNodeSelection();
     };
 

--- a/server/webapp/WEB-INF/rails.new/app/assets/stylesheets/_vsm.scss
+++ b/server/webapp/WEB-INF/rails.new/app/assets/stylesheets/_vsm.scss
@@ -74,6 +74,14 @@ $btn-default: #d6d5d5;
   }
 }
 
+.vsm-entity.vsm-pipeline-node {
+  cursor: pointer;
+}
+
+.vsm-entity.vsm-pipeline-node .vsm-pipeline-unclickable-name {
+  color: black;
+}
+
 .vsm-other-node {
   @extend %node-selection;
   &:before {


### PR DESCRIPTION
* Remove unnecessary elements from vsm-pipeline when user enters into analytics mode
* A different representation of pipeline will help user to identify analytics mode
* Changes on pipeline tile when analytics mode is ON:
    - Do not show pipeline settings icon
    - Change pipeline name from a link to normal text
    - Do not show vsm link
    - Do not show pipeline duration
    - Make all links unclickable

Normal VSM:
![screen shot 2018-08-29 at 4 47 37 pm](https://user-images.githubusercontent.com/15275847/44784770-5c88e480-abac-11e8-9216-c358057cb6e6.png)

Analytics Mode VSM:
![screen shot 2018-08-29 at 4 47 27 pm](https://user-images.githubusercontent.com/15275847/44784790-6874a680-abac-11e8-978c-e9745a51e37c.png)

