### PR TITLE
Show onhover overlay for pipeline/material for selection

### DIFF
--- a/server/webapp/WEB-INF/rails.new/app/assets/javascripts/vsm_renderer.js
+++ b/server/webapp/WEB-INF/rails.new/app/assets/javascripts/vsm_renderer.js
@@ -60,6 +60,40 @@ Graph_Renderer = function (container) {
       $j(".other-node").removeClass("vsm-other-node");
     };
 
+    var addPipelineOnHoverSelectStyles = function () {
+      $j("<div class=\"onhover-pipeline-overlay hidden\">" +
+        "   <div class=\"plus-symbol\">+</div><div class=\"click-text\">Click to select pipeline</div>" +
+        "</div>").appendTo('.vsm-entity.pipeline');
+
+      var hoverOnPipeline = function () {
+        var isSelected = $j(this).hasClass("vsm-other-node");
+        !isSelected && $j(this).find('.onhover-pipeline-overlay').removeClass("hidden");
+      };
+
+      var hoverOutPipeline = function () {
+        $j(this).find('.onhover-pipeline-overlay').addClass("hidden");
+      };
+
+      $j(".vsm-entity.pipeline.other-node").hover(hoverOnPipeline, hoverOutPipeline);
+    };
+
+  var addMaterialOnHoverSelectStyles = function () {
+    $j("<div class=\"onhover-material-overlay hidden\">" +
+      "    <div class=\"plus-symbol\">+</div><div class=\"click-text\">select material</div>" +
+      "</div>").appendTo('.vsm-entity.material');
+
+    var hoverOnMaterial = function () {
+      var isSelected = $j(this).hasClass("vsm-other-node");
+      !isSelected && $j(this).find('.onhover-material-overlay').removeClass("hidden");
+    };
+
+    var hoverOutMaterial = function () {
+      $j(this).find('.onhover-material-overlay').addClass("hidden");
+    };
+
+    $j(".vsm-entity.material.other-node").hover(hoverOnMaterial, hoverOutMaterial);
+  };
+
     Graph_Renderer.prototype.enableAnalyticsMode = function () {
       analyticsModeEnabled = true;
       $j('.vsm-entity.pipeline a').css({ "pointer-events": "none" });
@@ -71,6 +105,9 @@ Graph_Renderer = function (container) {
       $j('.vsm-entity.pipeline .pipeline_actions').addClass("hidden");
       $j('.vsm-entity.pipeline .instances .instance .vsm_link_wrapper').addClass("hidden");
       $j('.vsm-entity.pipeline .instances .instance .duration').addClass("hidden");
+
+      addPipelineOnHoverSelectStyles();
+      addMaterialOnHoverSelectStyles();
 
       highlightCurrentNode();
     };
@@ -108,6 +145,7 @@ Graph_Renderer = function (container) {
       var vsmEntity = $j(this).closest('.vsm-entity');
       $j(".other-node").removeClass("vsm-other-node");
       $j(vsmEntity).addClass("vsm-other-node");
+      $j(vsmEntity).find('.onhover-material-overlay').addClass("hidden");
       selectMaterialCallback(vsmEntity.data("material-name"), vsmEntity.data("fingerprint").substr(1), vsmEntity.data("level"));
     };
 
@@ -118,6 +156,7 @@ Graph_Renderer = function (container) {
       }
       $j(".other-node").removeClass("vsm-other-node");
       $j(vsmEntity).addClass("vsm-other-node");
+      $j(vsmEntity).find('.onhover-pipeline-overlay').addClass("hidden");
       selectPipelineCallback(vsmEntity.data("pipeline-name"), vsmEntity.data("level"));
     };
 

--- a/server/webapp/WEB-INF/rails.new/app/assets/stylesheets/_vsm.scss
+++ b/server/webapp/WEB-INF/rails.new/app/assets/stylesheets/_vsm.scss
@@ -20,7 +20,7 @@
 $border-color: #ccc;
 $anaytics-header-bg: #fff;
 $primary-color: #b66fc2;
-$secondary-color: #2db1c1;
+$secondary-color: #01bfc0;
 $global-border-radius: 3px;
 
 //buttons
@@ -77,12 +77,73 @@ $btn-default: #d6d5d5;
   }
 }
 
-.vsm-entity.vsm-pipeline-node {
+.vsm-entity.other-node.vsm-pipeline-node {
   cursor: pointer;
+  &:hover {
+    border: none
+  }
 }
 
 .vsm-entity.vsm-pipeline-node .vsm-pipeline-unclickable-name {
   color: black;
+}
+
+.onhover-pipeline-overlay {
+  position: relative;
+  top: -103px;
+  left: -10px;
+  width: 210px;
+  height: 150px;
+  background: #f2f2f2;
+  opacity: 0.85;
+  border-radius: 4px;
+  border: 2px solid $secondary-color;
+  box-shadow: 0 0 2px 2px #CCCCCC;
+  color: #000;
+
+  .plus-symbol {
+    padding-top: 20px;
+    font-size: 55px;
+    font-weight: 300;
+    text-align: center;
+  }
+
+  .click-text {
+    padding-top: 10px;
+    font-size: 18px;
+    text-align: center;
+  }
+}
+
+.onhover-material-overlay {
+  position: relative;
+  top: -103px;
+  left: -10px;
+  width: 135px;
+  height: 135px;
+  z-index: 2;
+  border-radius: 70px !important;
+  background: #f2f2f2;
+  opacity: 0.85;
+  border: 2px solid $secondary-color;
+  box-shadow: 0 0 2px 2px #CCCCCC;
+  color: #000;
+
+  .plus-symbol {
+    padding-top: 15px;
+    font-size: 55px;
+    font-weight: 300;
+    text-align: center;
+  }
+
+  .click-text {
+    font-size: 18px;
+    text-align: center;
+  }
+}
+
+.vsm-pipeline-node.vsm-other-node, .material.vsm-other-node {
+  cursor: auto !important;
 }
 
 .vsm-other-node {


### PR DESCRIPTION
* In analytics mode, to indicate that another pipeline or material can be selected to view anlytics,
  show onhover overlay with text saying:
    - 'Click to select pipeline' for pipeline tiles
    - 'Select Material' for material

![screen shot 2018-08-30 at 11 24 09 am](https://user-images.githubusercontent.com/15275847/44832217-8fcc8180-ac47-11e8-9582-6a83acc2cb85.png)
![screen shot 2018-08-30 at 11 24 15 am](https://user-images.githubusercontent.com/15275847/44832219-922edb80-ac47-11e8-82bc-f79cc2142b4d.png)
![screen shot 2018-08-30 at 11 24 32 am](https://user-images.githubusercontent.com/15275847/44832220-9529cc00-ac47-11e8-9981-99a38f1dd5b7.png)
![screen shot 2018-08-30 at 11 24 35 am](https://user-images.githubusercontent.com/15275847/44832222-9824bc80-ac47-11e8-84af-b7e7ada302c0.png)
