### PR TITLE
Remove animations completely for stacking modals 

### DIFF
--- a/server/webapp/WEB-INF/rails.new/app/assets/new_stylesheets/shared/_schmodal.scss
+++ b/server/webapp/WEB-INF/rails.new/app/assets/new_stylesheets/shared/_schmodal.scss
@@ -5,30 +5,6 @@ $overlay-height:        300px;
 $overlay-border-color:  #ccc;
 $overlay-border-radius: 3px;
 
-@include keyframes(modalIn) {
-  0% {
-    opacity:   0;
-    transform: translate(-50%, -150%);
-  }
-
-  100% {
-    opacity:   1;
-    transform: translate(-50%, 0);
-  }
-}
-
-@include keyframes(modalOut) {
-  0% {
-    opacity:   1;
-    transform: translate(-50%, 0);
-  }
-
-  100% {
-    opacity:   0;
-    transform: translate(-50%, -150%);
-  }
-}
-
 .overlay-bg {
   display:    none;
   background: $overlay-bg;
@@ -58,31 +34,9 @@ $overlay-border-radius: 3px;
   left:          50%;
   min-width:     $overlay-width;
   transform:     translate(-50%, 0);
-  transition:    opacity 0.5s ease-in-out, transform 0.5s ease-in-out;
-
-  &.adding {
-    @include animation(modalIn 0.5s ease-out);
-  }
-
-  &.removing {
-    @include animation(modalOut 0.25s ease-out);
-  }
-
-  &:nth-of-type(1), &:nth-of-type(2) {
-    display: block;
-  }
 
   &:nth-of-type(1) {
-    z-index: 102;
-  }
-
-  &:nth-of-type(2) {
-    transform: translate(-50%, 80vh);
-    opacity:   0.7;
-
-    .close-icon {
-      display: none;
-    }
+    display: block;
   }
 }
 

--- a/server/webapp/WEB-INF/rails.new/webpack/views/shared/schmodal.js.msx
+++ b/server/webapp/WEB-INF/rails.new/webpack/views/shared/schmodal.js.msx
@@ -45,29 +45,6 @@ const Footer = {
 };
 
 const Dialog = {
-  oncreate(vnode) {
-    function removeAnimation() {
-        vnode.dom.classList.remove("adding");
-        vnode.dom.removeEventListener("animationend", removeAnimation);
-    }
-    vnode.dom.classList.add("adding");
-    vnode.dom.addEventListener("animationend", removeAnimation);
-  },
-
-  onbeforeremove(vnode) {
-    return new Promise((resolve) => {
-      if (null === vnode.dom.offsetParent) { //short-circuit for hidden modals
-        resolve();
-        return;
-      }
-
-      vnode.dom.classList.add("removing");
-      vnode.dom.addEventListener("animationend", () => {
-        resolve();
-      });
-    });
-  },
-
   view(vnode) {
     const buttons = val(vnode.attrs.buttons) || [];
     const children = [


### PR DESCRIPTION
The animations as part of the modal for Personalization were causing a "bounce" effect. This removes all the animations completely. 

I tried to remove just the animation on the modal open (which was experiencing the bounce) but that caused the modal to flicker when reopened (after cancelling).

I think effort would be better spent either fixing the bounce than trying to fix the flicker issue. We can revisit adding the animations back in the future.