### PR TITLE
Checkbox selections should honor modal pipeline search

### DIFF
--- a/server/webapp/WEB-INF/rails.new/app/assets/new_stylesheets/single_page_apps/pipeline_configs/_personalize_views_editor.scss
+++ b/server/webapp/WEB-INF/rails.new/app/assets/new_stylesheets/single_page_apps/pipeline_configs/_personalize_views_editor.scss
@@ -216,6 +216,10 @@ $icon-color: #647984;
   padding:       20px;
   border-radius: $global-border-radius;
 
+  &.pipeline-search-in-progress .selected-pipelines_group_checkbox {
+    display: none;
+  }
+
   [type="checkbox"] {
     margin-bottom: 0.75rem;
   }

--- a/server/webapp/WEB-INF/rails.new/spec/webpack/views/dashboard/model/pipeline_list_vm_spec.js
+++ b/server/webapp/WEB-INF/rails.new/spec/webpack/views/dashboard/model/pipeline_list_vm_spec.js
@@ -85,6 +85,19 @@ describe("Pipeline List View Model", () => {
     expect(model.hasAnySelections()).toBe(true);
   });
 
+  it("hasSearch() detects presence of search term", () => {
+    const model = new PipelineListVM({}, {});
+
+    model.searchTerm("");
+    expect(model.hasSearch()).toBe(false);
+
+    model.searchTerm("   ");
+    expect(model.hasSearch()).toBe(false);
+
+    model.searchTerm("foo");
+    expect(model.hasSearch()).toBe(true);
+  });
+
   it('hasAllSelected() should report true if all pipelines are selected', () => {
     const all = { group1: "abc".split(""), group2: "def".split("") };
     const sel = _st({ a: true, b: true, c: true, d: true, e: true, f: true });

--- a/server/webapp/WEB-INF/rails.new/spec/webpack/views/dashboard/model/pipeline_list_vm_spec.js
+++ b/server/webapp/WEB-INF/rails.new/spec/webpack/views/dashboard/model/pipeline_list_vm_spec.js
@@ -132,6 +132,28 @@ describe("Pipeline List View Model", () => {
     expect(_.every(sel, (s) => !s())).toBe(true);
   });
 
+  it("selectAll() should honor search term", () => {
+    const all = { group1: "aa,ab,c".split(","), group2: "d,ae,af".split(",") };
+    const sel = _st({ aa: false, ab: false, c: false, d: false, ae: false, af: false });
+
+    const model = new PipelineListVM(all, sel);
+    model.searchTerm("a");
+    model.selectAll();
+
+    expect(selectedPipelineNames(sel)).toEqual(["aa", "ab", "ae", "af"]);
+  });
+
+  it("selectNone() should honor search term", () => {
+    const all = { group1: "aa,ab,c".split(","), group2: "d,ae,af".split(",") };
+    const sel = _st({ aa: true, ab: true, c: true, d: true, ae: true, af: true });
+
+    const model = new PipelineListVM(all, sel);
+    model.searchTerm("a");
+    model.selectNone();
+
+    expect(selectedPipelineNames(sel)).toEqual(["c", "d"]);
+  });
+
   it("selecting at least one pipeline should set group indeterminate state", () => {
     const all = { group1: "abc".split(""), group2: "def".split(""), group3: "g" };
     const sel = _st({ a: true, b: false, c: false, d: true, e: true, f: true, g: false });
@@ -208,6 +230,10 @@ function uncheck(stream) {
 
 function _st(obj) {
   return _.reduce(obj, (m, v, k) => { m[k] = v instanceof Stream ? v : Stream(v); return m; }, {});
+}
+
+function selectedPipelineNames(sel) {
+  return _.reduce(sel, (m, v, k) => { if (v()) { m.push(k); } return m; }, []).sort();
 }
 
 function collectExpandedGroups(groups) {

--- a/server/webapp/WEB-INF/rails.new/webpack/views/dashboard/models/personalize_editor_vm.js
+++ b/server/webapp/WEB-INF/rails.new/webpack/views/dashboard/models/personalize_editor_vm.js
@@ -54,7 +54,7 @@ function PersonalizeEditorVM(opts) { // opts is usually the current filter
     return {name: name(), type: type(), pipelines, state: state()};
   };
 
-  this.hasSearch = () => !!(this.selectionVM() && this.selectionVM().searchTerm().trim());
+  this.hasSearch = () => !!(this.selectionVM() && this.selectionVM().hasSearch());
   this.hasPipelinesSelected = () => !!(this.selectionVM() && this.selectionVM().hasAnySelections());
 }
 

--- a/server/webapp/WEB-INF/rails.new/webpack/views/dashboard/models/personalize_editor_vm.js
+++ b/server/webapp/WEB-INF/rails.new/webpack/views/dashboard/models/personalize_editor_vm.js
@@ -54,6 +54,7 @@ function PersonalizeEditorVM(opts) { // opts is usually the current filter
     return {name: name(), type: type(), pipelines, state: state()};
   };
 
+  this.hasSearch = () => !!(this.selectionVM() && this.selectionVM().searchTerm().trim());
   this.hasPipelinesSelected = () => !!(this.selectionVM() && this.selectionVM().hasAnySelections());
 }
 

--- a/server/webapp/WEB-INF/rails.new/webpack/views/dashboard/models/pipeline_list_vm.js
+++ b/server/webapp/WEB-INF/rails.new/webpack/views/dashboard/models/pipeline_list_vm.js
@@ -15,7 +15,7 @@
  */
 
 const _      = require("lodash");
-const s      = require("underscore.string");
+const _s      = require("underscore.string");
 const Stream = require("mithril/stream");
 
 function PipelineListVM(pipelinesByGroup, currentSelection) {
@@ -58,7 +58,7 @@ function PipelineListVM(pipelinesByGroup, currentSelection) {
     if (!search) { return fullPipelineList; }
 
     return _.reduce(fullPipelineList, (memo, groupModel, groupName) => {
-      const pipelines = _.filter(groupModel.pipelines, (p) => s.include(p.name.toLowerCase(), search));
+      const pipelines = _.filter(groupModel.pipelines, (p) => _s.include(p.name.toLowerCase(), search));
 
       if (pipelines.length) {
         memo[groupName] = _.assign({}, groupModel, { pipelines });
@@ -74,8 +74,13 @@ function PipelineListVM(pipelinesByGroup, currentSelection) {
     }, []);
   };
 
-  this.selectAll = function selectAll() { _.each(currentSelection, (s, _n) => { s(true); }); };
-  this.selectNone = function selectNone() { _.each(currentSelection, (s, _n) => { s(false); }); };
+  function setAllSelectionsTo(bool) {
+    const search = searchTerm().trim().toLowerCase();
+    _.each(currentSelection, (s, n) => { _s.include(n.toLowerCase(), search) && s(bool); });
+  }
+
+  this.selectAll = () => setAllSelectionsTo(true);
+  this.selectNone = () => setAllSelectionsTo(false);
 
   this.hasAnySelections = () => !!_.find(currentSelection, (s, _n) => s());
   this.hasAllSelected = () => _.every(currentSelection, (s) => s());

--- a/server/webapp/WEB-INF/rails.new/webpack/views/dashboard/models/pipeline_list_vm.js
+++ b/server/webapp/WEB-INF/rails.new/webpack/views/dashboard/models/pipeline_list_vm.js
@@ -22,6 +22,8 @@ function PipelineListVM(pipelinesByGroup, currentSelection) {
 
   const searchTerm = Stream("");
 
+  const hasSearch = () => !!searchTerm().trim();
+
   this.searchTerm = searchTerm;
 
   const fullPipelineList = _.reduce(pipelinesByGroup, (memo, pipelines, group) => {
@@ -46,6 +48,7 @@ function PipelineListVM(pipelinesByGroup, currentSelection) {
     memo[group] = {
       expanded,
       selected: groupSelection(currentSelection, pipelines),
+      disabled: hasSearch,
       indeterminate: indeterminate(currentSelection, pipelines),
       pipelines: _.map(pipelines, (p) => { return {name: p, selected: boolByName(currentSelection, p)}; })
     };
@@ -82,6 +85,7 @@ function PipelineListVM(pipelinesByGroup, currentSelection) {
   this.selectAll = () => setAllSelectionsTo(true);
   this.selectNone = () => setAllSelectionsTo(false);
 
+  this.hasSearch = hasSearch;
   this.hasAnySelections = () => !!_.find(currentSelection, (s, _n) => s());
   this.hasAllSelected = () => _.every(currentSelection, (s) => s());
   this.hasNoneSelected = () => _.every(currentSelection, (s) => !s());

--- a/server/webapp/WEB-INF/rails.new/webpack/views/dashboard/personalization_modal_widget.js.msx
+++ b/server/webapp/WEB-INF/rails.new/webpack/views/dashboard/personalization_modal_widget.js.msx
@@ -85,7 +85,7 @@ const PipelineGroupSelection = {
     const vm = vnode.attrs.vm, name = vnode.attrs.name;
     return <li class={`selected-pipelines_group ${(vm.expanded() ? "expanded" : "collapsed")}`}>
       <i class="pipeline-list-toggle" onclick={() => vm.expanded(!vm.expanded())} />
-      <f.checkbox model={vm} attrName="selected" indeterminate={vm.indeterminate()} class="selected-pipelines_group_checkbox" label={name}/>
+      <f.checkbox model={vm} attrName="selected" indeterminate={vm.indeterminate()} disabled={vm.disabled()} class="selected-pipelines_group_checkbox" label={name}/>
       <PipelineSelectors pipelines={vm.pipelines} />
     </li>;
   }

--- a/server/webapp/WEB-INF/rails.new/webpack/views/dashboard/personalization_modal_widget.js.msx
+++ b/server/webapp/WEB-INF/rails.new/webpack/views/dashboard/personalization_modal_widget.js.msx
@@ -85,7 +85,7 @@ const PipelineGroupSelection = {
     const vm = vnode.attrs.vm, name = vnode.attrs.name;
     return <li class={`selected-pipelines_group ${(vm.expanded() ? "expanded" : "collapsed")}`}>
       <i class="pipeline-list-toggle" onclick={() => vm.expanded(!vm.expanded())} />
-      <f.checkbox model={vm} attrName="selected" indeterminate={vm.indeterminate()} label={name}/>
+      <f.checkbox model={vm} attrName="selected" indeterminate={vm.indeterminate()} class="selected-pipelines_group_checkbox" label={name}/>
       <PipelineSelectors pipelines={vm.pipelines} />
     </li>;
   }
@@ -137,11 +137,11 @@ const PersonalizationModalWidget = {
       </div>
 
       <div class="pipeline-search-container">
-          <BlanketSelector vm={vm.selectionVM()} />
+        <BlanketSelector vm={vm.selectionVM()} />
         <PipelineNameSearch vm={vm.selectionVM()} />
       </div>
 
-      <div class="pipeline-selections">
+      <div class={vm.hasSearch() ? "pipeline-selections pipeline-search-in-progress" : "pipeline-selections"}>
         <SelectedPipelineList vm={vm.selectionVM()} />
       </div>
     </div>;


### PR DESCRIPTION
This makes the select all/none buttons operate on only the visible pipelines matching the search term.

Additionally, the group checkboxes are hidden when a search term is in place.