### PR TITLE
Turning off version update and data sharing on prefernces page

### DIFF
--- a/server/webapp/WEB-INF/rails.new/app/views/layouts/single_page_app.html.erb
+++ b/server/webapp/WEB-INF/rails.new/app/views/layouts/single_page_app.html.erb
@@ -14,7 +14,6 @@
   <link rel="shortcut icon" href="<%= asset_path('cruise.ico') %>"/>
   <%= stylesheet_link_tag 'frameworks' %>
   <%= stylesheet_link_tag "single_page_apps/#{controller_name}" %>
-  <%= javascript_include_tag *webpack_assets_service.getAssetPaths("single_page_apps/spa_commons") %>
   <%= javascript_include_tag *webpack_assets_service.getAssetPaths("single_page_apps/#{controller_name}") %>
   <%= csrf_meta_tags %>
 </head>


### PR DESCRIPTION
* https://github.com/gocd/gocd/issues/5117
* The preference page is redrawn infinitely after including the
  data-sharing related javascript. On each redraw multiple ajax calls
  are made to the server which makes the server unresponsive eventually.
* This is a temporary fix, the actual reason for the infinite redraws
  needs to be investigated and the data-sharing should be enabled.