### PR TITLE
Fix tooltip and checkbox layout when scroll bar appears

### DIFF
--- a/server/webapp/WEB-INF/rails.new/app/assets/new_stylesheets/single_page_apps/pipeline_configs/_personalize_views_editor.scss
+++ b/server/webapp/WEB-INF/rails.new/app/assets/new_stylesheets/single_page_apps/pipeline_configs/_personalize_views_editor.scss
@@ -74,8 +74,6 @@ $icon-color: #647984;
   }
 }
 
-
-
 .personalize-editor-error-response {
   position:      fixed;
   top:           53px;
@@ -220,6 +218,11 @@ $icon-color: #647984;
   label {
     margin-left: 25px;
   }
+}
+
+.checkbox-help, .checkbox-help label {
+  display:     flex;
+  align-items: center;
 }
 
 .pipeline-search-container {

--- a/server/webapp/WEB-INF/rails.new/webpack/views/dashboard/personalization_modal_widget.js.msx
+++ b/server/webapp/WEB-INF/rails.new/webpack/views/dashboard/personalization_modal_widget.js.msx
@@ -66,10 +66,16 @@ const StageStateCriteria = {
     const vm = vnode.attrs.vm;
 
     return <div class="stage-state-selector">
-      <f.checkbox name="state" model={vm} attrName="failing" label="Failed" />
-      <Tooltip vm={vm} name="failed-pipelines">Show only pipelines whose last run stage has failed, among pipelines selected for this view</Tooltip>
-      <f.checkbox name="state" model={vm} attrName="building" label="Building" />
-      <Tooltip vm={vm} name="building-pipelines">Show only pipelines with jobs which are scheduled or building, among pipelines chosen for this view</Tooltip>
+      <div class="checkbox-help">
+        <f.checkbox name="state" model={vm} attrName="failing" label="Failed"/>
+        <Tooltip vm={vm} name="failed-pipelines">Show only pipelines whose last run stage has failed, among pipelines
+          selected for this view</Tooltip>
+      </div>
+      <div class="checkbox-help">
+        <f.checkbox name="state" model={vm} attrName="building" label="Building"/>
+        <Tooltip vm={vm} name="building-pipelines">Show only pipelines with jobs which are scheduled or building, among
+          pipelines chosen for this view</Tooltip>
+      </div>
     </div>;
   }
 };
@@ -167,18 +173,22 @@ const PersonalizationModalWidget = {
 
     return <div class="personalize-editor-controls">
       <div className="view-top">
-        <AlertContainer vm={vm} />
+        <AlertContainer vm={vm}/>
         <FilterNameInput {...vnode.attrs} />
         <div className="show-pipelines">
           <span class="section-label">Show pipelines:</span>
-          <f.checkbox name="include-new-pipelines" model={vm} attrName="includeNewPipelines" label="New" />
-          <Tooltip vm={vm} name="include-new-pipelines">
-            {"Include pipelines created since this view was last updated "}
-            <f.link href="https://docs.gocd.org/current/navigation/pipelines_dashboard_page.html#personalize-pipelines-view" target="_blank">
-              More&hellip;
-            </f.link>
-          </Tooltip>
-          <StageStateCriteria vm={vm} />
+          <div class="checkbox-help">
+            <f.checkbox name="include-new-pipelines" model={vm} attrName="includeNewPipelines" label="New"/>
+            <Tooltip vm={vm} name="include-new-pipelines">
+              {"Include pipelines created since this view was last updated "}
+              <f.link
+                href="https://docs.gocd.org/current/navigation/pipelines_dashboard_page.html#personalize-pipelines-view"
+                target="_blank">
+                More&hellip;
+              </f.link>
+            </Tooltip>
+          </div>
+          <StageStateCriteria vm={vm}/>
         </div>
       </div>
 


### PR DESCRIPTION
Fixes #5119

Ideally, we need a way to pass a class attribute to the label while using form-helper, without creating a nested element inside the `<label>`. This would help avoid the `.checkbox-help label` style and make it more generic. We can make this improvement later. This is a quick fix for the release.