### PR TITLE
Fix infinite redraws on preferences page (#5117) (#5121)

### DIFF
--- a/server/webapp/WEB-INF/rails.new/app/views/layouts/single_page_app.html.erb
+++ b/server/webapp/WEB-INF/rails.new/app/views/layouts/single_page_app.html.erb
@@ -14,7 +14,11 @@
   <link rel="shortcut icon" href="<%= asset_path('cruise.ico') %>"/>
   <%= stylesheet_link_tag 'frameworks' %>
   <%= stylesheet_link_tag "single_page_apps/#{controller_name}" %>
-  <%= javascript_include_tag *webpack_assets_service.getAssetPaths("single_page_apps/#{controller_name}") %>
+
+  <% webpack_assets_service.getAssetPathsFor("single_page_apps/#{controller_name}", "single_page_apps/spa_commons").each do |js| %>
+    <script src=<%= "#{js}" %>></script>
+  <% end %>
+
   <%= csrf_meta_tags %>
 </head>
 


### PR DESCRIPTION
* On preferences page, vendor-and-helpers.chunk.js file was included twice, which ended up invoking oninit twice which intern caused infinite redraws on the page
* Include all JS on the page only once