### PR TITLE
[VSM Analytics] Show onhover 'select pipeline' panel always infront

### DIFF
--- a/server/webapp/WEB-INF/rails.new/app/assets/stylesheets/_vsm.scss
+++ b/server/webapp/WEB-INF/rails.new/app/assets/stylesheets/_vsm.scss
@@ -99,6 +99,7 @@ $btn-default: #d6d5d5;
   border:        2px solid $secondary-color;
   box-shadow:    0 0 2px 2px #ccc;
   color:         #000;
+  z-index:       1;
 
   .plus-symbol {
     padding-top: 20px;


### PR DESCRIPTION
* Cancelled stage icon was displayed in front of the hover panel, add z-index to onhover div for displaying always in front

#### Before fix
![screen shot 2018-09-04 at 10 16 41 am](https://user-images.githubusercontent.com/15275847/45010559-e6610380-b02b-11e8-8f4d-1470f6db24a4.png)

#### After fix
![screen shot 2018-09-04 at 10 17 13 am](https://user-images.githubusercontent.com/15275847/45010565-f0830200-b02b-11e8-8856-3813ad96fb4d.png)
