### PR TITLE
[VSM Analytics] Do not trigger onclick handler for disabled 'view analytics' button

### DIFF
--- a/server/webapp/WEB-INF/rails.new/app/assets/javascripts/vsm_analytics_pipeline_panel.js
+++ b/server/webapp/WEB-INF/rails.new/app/assets/javascripts/vsm_analytics_pipeline_panel.js
@@ -46,7 +46,6 @@
     var init = function init() {
       $j(container).find(".analytics-close").click(self.hide);
       $j(container).find(resetAnalyticsButton).click(resetAnalytics);
-      $j(container).find(viewAnalyticsButton).click(viewAnalytics);
     };
 
     this.show = function () {
@@ -66,10 +65,12 @@
 
     var enableViewAnalytics = function enableViewAnalytics() {
       $j(viewAnalyticsButton).removeClass("disabled");
+      $j(container).find(viewAnalyticsButton).click(viewAnalytics);
     };
 
     var disableViewAnalytics = function disableViewAnalytics() {
       $j(viewAnalyticsButton).addClass("disabled");
+      $j(container).find(viewAnalyticsButton).unbind('click');
     };
 
     var updateSource = function (src, isCurrent) {


### PR DESCRIPTION
* Do not allow users to click view analytics button when it is disabled

##### Issue Referene: https://github.com/gocd-private/gocd-analytics-plugin/issues/163

**Copied Here (as gocd-private/gocd-analytics-plugin is a private repo)**
#### Title:
	"View Analytics" button is getting clicked even when its disable
#### Description:
	If user has not selected any pipeline then the "View Analytics" button is disabled which is as working expected but currently its getting clicked and shows the VSM analytics graph from previously viewed VSM analytics.