### PR TITLE
Dashboard Groups tooltips refactoring

### DIFF
--- a/server/webapp/WEB-INF/rails.new/app/assets/new_stylesheets/single_page_apps/new_dashboard.scss
+++ b/server/webapp/WEB-INF/rails.new/app/assets/new_stylesheets/single_page_apps/new_dashboard.scss
@@ -225,7 +225,7 @@ body {
 
 }
 
-.pipeline_group_name {
+.dashboard-group_name {
   font-size:   18px;
   font-weight: 600;
   line-height: 25px;

--- a/server/webapp/WEB-INF/rails.new/spec/webpack/models/dashboard/dashboard_groups_spec.js
+++ b/server/webapp/WEB-INF/rails.new/spec/webpack/models/dashboard/dashboard_groups_spec.js
@@ -18,13 +18,66 @@ describe("DashboardGroups", () => {
 
   const DashboardGroups = require('models/dashboard/dashboard_groups');
 
-  it("should deserialize from json", () => {
-    const pipelineGroups = DashboardGroups.fromJSON(pipelineGroupsData);
+  it("should deserialize pipeline groups from json", () => {
+    const pipelineGroups = DashboardGroups.fromPipelineGroupsJSON(pipelineGroupsData);
 
     expect(pipelineGroups.groups.length).toBe(1);
     expect(pipelineGroups.groups[0].name).toBe(pipelineGroupsData[0].name);
     expect(pipelineGroups.groups[0].canAdminister).toBe(pipelineGroupsData[0].can_administer);
     expect(pipelineGroups.groups[0].pipelines).toEqual(pipelineGroupsData[0].pipelines);
+  });
+
+  it("should deserialize environment groups from json", () => {
+    const environments = DashboardGroups.fromEnvironmentsJSON(environmentGroupsData);
+
+    expect(environments.groups.length).toBe(1);
+    expect(environments.groups[0].name).toBe(pipelineGroupsData[0].name);
+    expect(environments.groups[0].canAdminister).toBe(pipelineGroupsData[0].can_administer);
+    expect(environments.groups[0].pipelines).toEqual(pipelineGroupsData[0].pipelines);
+  });
+
+  describe('tooltip, title and aria-label', () => {
+
+    it('should set values for a pipeline group when a user can administer it', () => {
+      const pipelineGroups = DashboardGroups.fromPipelineGroupsJSON(pipelineGroupsData);
+      expect(pipelineGroups.groups[0].label()).toBe("Pipeline Group 'first'");
+      expect(pipelineGroups.groups[0].tooltipForEdit()).toBe("");
+      expect(pipelineGroups.groups[0].titleForEdit()).toBe("Edit Pipeline Group 'first'");
+      expect(pipelineGroups.groups[0].ariaLabelForEdit()).toBe("Edit Pipeline Group 'first'");
+    });
+
+    it('should set values for an environment when a user can administer it', () => {
+      const environments = DashboardGroups.fromEnvironmentsJSON(environmentGroupsData);
+      expect(environments.groups[0].label()).toBe("Environment 'first'");
+      expect(environments.groups[0].tooltipForEdit()).toBe("");
+      expect(environments.groups[0].titleForEdit()).toBe("Edit Environment 'first'");
+      expect(environments.groups[0].ariaLabelForEdit()).toBe("Edit Environment 'first'");
+    });
+
+    it('should set values for a pipeline group when a user cannot administer it', () => {
+      const pipelineGroups = DashboardGroups.fromPipelineGroupsJSON([{
+        "name":           "first",
+        "pipelines":      ["up42"],
+        "can_administer": false
+      }]);
+      expect(pipelineGroups.groups[0].label()).toBe("Pipeline Group 'first'");
+      expect(pipelineGroups.groups[0].tooltipForEdit()).toBe("You don't have permission to edit this pipeline group");
+      expect(pipelineGroups.groups[0].titleForEdit()).toBe("");
+      expect(pipelineGroups.groups[0].ariaLabelForEdit()).toBe("You don't have permission to edit this pipeline group");
+    });
+
+    it('should set values for an environment when a user cannot administer it', () => {
+      const environments = DashboardGroups.fromEnvironmentsJSON([{
+        "name":           "first",
+        "pipelines":      ["up42"],
+        "can_administer": false
+      }]);
+      expect(environments.groups[0].label()).toBe("Environment 'first'");
+      expect(environments.groups[0].tooltipForEdit()).toBe("You don't have permission to edit this environment");
+      expect(environments.groups[0].titleForEdit()).toBe("");
+      expect(environments.groups[0].ariaLabelForEdit()).toBe("You don't have permission to edit this environment");
+    });
+
   });
 
   const pipelineGroupsData = [
@@ -35,6 +88,22 @@ describe("DashboardGroups", () => {
         },
         "doc":  {
           "href": "https://api.go.cd/current/#pipeline-groups"
+        }
+      },
+      "name":           "first",
+      "pipelines":      ["up42"],
+      "can_administer": true
+    }
+  ];
+
+  const environmentGroupsData = [
+    {
+      "_links":         {
+        "self": {
+          "href": "http://localhost:8153/go/api/config/environments/first/show"
+        },
+        "doc":  {
+          "href": "https://api.go.cd/current/#environments"
         }
       },
       "name":           "first",

--- a/server/webapp/WEB-INF/rails.new/webpack/models/dashboard/dashboard.js
+++ b/server/webapp/WEB-INF/rails.new/webpack/models/dashboard/dashboard.js
@@ -41,7 +41,7 @@ function Dashboard() {
     const newPipelines      = Pipelines.fromJSON(_.get(json, '_embedded.pipelines', []));
 
     const pipelinesNoEnv = _.difference(Object.keys(newPipelines.pipelines), _.reduce(newEnvironments.groups, (memo, group) => memo.concat(group.pipelines), []));
-    newEnvironments.groups.push(new DashboardGroups.Group({name: null, can_administer: false, pipelines: pipelinesNoEnv})); // eslint-disable-line camelcase
+    newEnvironments.groups.push(new DashboardGroups.Environment({name: null, can_administer: false, pipelines: pipelinesNoEnv})); // eslint-disable-line camelcase
 
     //set it on the current object only on a successful deserialization of both pipeline groups and pipelines
     pipelineGroups = newPipelineGroups;

--- a/server/webapp/WEB-INF/rails.new/webpack/models/dashboard/dashboard.js
+++ b/server/webapp/WEB-INF/rails.new/webpack/models/dashboard/dashboard.js
@@ -23,8 +23,8 @@ const DashboardGroups = require('models/dashboard/dashboard_groups');
 const Pipelines       = require('models/dashboard/pipelines');
 
 function Dashboard() {
-  let pipelineGroups = DashboardGroups.fromJSON([]);
-  let environments   = DashboardGroups.fromJSON([]);
+  let pipelineGroups = DashboardGroups.fromPipelineGroupsJSON([]);
+  let environments   = DashboardGroups.fromEnvironmentsJSON([]);
   let pipelines      = Pipelines.fromJSON([]);
 
   this.message           = Stream();
@@ -36,8 +36,8 @@ function Dashboard() {
   this.findPipeline      = (pipelineName) => pipelines.find(pipelineName);
 
   this.initialize = (json) => {
-    const newPipelineGroups = DashboardGroups.fromJSON(_.get(json, '_embedded.pipeline_groups', []));
-    const newEnvironments   = DashboardGroups.fromJSON(_.get(json, '_embedded.environments', []));
+    const newPipelineGroups = DashboardGroups.fromPipelineGroupsJSON(_.get(json, '_embedded.pipeline_groups', []));
+    const newEnvironments   = DashboardGroups.fromEnvironmentsJSON(_.get(json, '_embedded.environments', []));
     const newPipelines      = Pipelines.fromJSON(_.get(json, '_embedded.pipelines', []));
 
     const pipelinesNoEnv = _.difference(Object.keys(newPipelines.pipelines), _.reduce(newEnvironments.groups, (memo, group) => memo.concat(group.pipelines), []));

--- a/server/webapp/WEB-INF/rails.new/webpack/models/dashboard/dashboard_groups.js
+++ b/server/webapp/WEB-INF/rails.new/webpack/models/dashboard/dashboard_groups.js
@@ -132,6 +132,7 @@ DashboardGroups.fromEnvironmentsJSON = (json) => {
   return new DashboardGroups(_.map(json, (group) => new Environment(group)));
 };
 
+DashboardGroups.PipelineGroup = PipelineGroup;
 DashboardGroups.Environment = Environment;
 
 module.exports = DashboardGroups;

--- a/server/webapp/WEB-INF/rails.new/webpack/models/dashboard/dashboard_groups.js
+++ b/server/webapp/WEB-INF/rails.new/webpack/models/dashboard/dashboard_groups.js
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-const _ = require('lodash');
+const _      = require('lodash');
+const Routes = require("gen/js-routes");
 
 class Group {
 
@@ -26,33 +27,6 @@ class Group {
 
   resolvePipelines(resolver) {
     return _.map(this.pipelines, (pipelineName) => resolver.findPipeline(pipelineName));
-  }
-
-  select(filter) {
-    const pipelines = _.filter(this.pipelines, filter);
-    if (pipelines.length === 0) {
-      return false;
-    }
-    return new Group({name: this.name, can_administer: this.canAdminister, pipelines}); // eslint-disable-line camelcase
-  }
-
-  label() {
-    return "";
-  }
-
-  tooltipForEdit() {
-    return "";
-  }
-
-  ariaLabelForEdit() {
-    return "";
-  }
-
-  titleForEdit() {
-    if (this.canAdminister) {
-      return `Edit ${this.label()}`;
-    }
-    return "";
   }
 }
 
@@ -86,6 +60,16 @@ class PipelineGroup extends Group {
     }
     return new PipelineGroup({name: this.name, can_administer: this.canAdminister, pipelines}); // eslint-disable-line camelcase
   }
+
+  routes() {
+    if (!this.name) {
+      return {};
+    }
+    return {
+      show: `${Routes.pipelineGroupsPath()}#group-${this.name}`,
+      edit: Routes.pipelineGroupEditPath(this.name)
+    };
+  }
 }
 
 class Environment extends Group {
@@ -118,6 +102,16 @@ class Environment extends Group {
     }
     return new Environment({name: this.name, can_administer: this.canAdminister, pipelines}); // eslint-disable-line camelcase
   }
+
+  routes() {
+    if (!this.name) {
+      return {};
+    }
+    return {
+      edit: Routes.environmentShowPath(this.name),
+      show: Routes.environmentShowPath(this.name)
+    };
+  }
 }
 
 function DashboardGroups(groups) {
@@ -138,6 +132,6 @@ DashboardGroups.fromEnvironmentsJSON = (json) => {
   return new DashboardGroups(_.map(json, (group) => new Environment(group)));
 };
 
-DashboardGroups.Group = Group;
+DashboardGroups.Environment = Environment;
 
 module.exports = DashboardGroups;

--- a/server/webapp/WEB-INF/rails.new/webpack/models/dashboard/dashboard_groups.js
+++ b/server/webapp/WEB-INF/rails.new/webpack/models/dashboard/dashboard_groups.js
@@ -16,24 +16,108 @@
 
 const _ = require('lodash');
 
-function Group({name, can_administer, pipelines}) { // eslint-disable-line camelcase
-  const self = this;
+class Group {
 
-  this.name          = name;
-  this.canAdminister = can_administer; // eslint-disable-line camelcase
-  this.pipelines     = pipelines;
+  constructor({name, can_administer, pipelines}) { // eslint-disable-line camelcase
+    this.name          = name;
+    this.canAdminister = can_administer; // eslint-disable-line camelcase
+    this.pipelines     = pipelines;
+  }
 
-  this.resolvePipelines = (resolver) => {
-    return _.map(self.pipelines, (pipelineName) => resolver.findPipeline(pipelineName));
-  };
+  resolvePipelines(resolver) {
+    return _.map(this.pipelines, (pipelineName) => resolver.findPipeline(pipelineName));
+  }
 
-  this.select = (filter) => {
+  select(filter) {
     const pipelines = _.filter(this.pipelines, filter);
     if (pipelines.length === 0) {
       return false;
     }
-    return new Group({name, can_administer, pipelines}); // eslint-disable-line camelcase
-  };
+    return new Group({name: this.name, can_administer: this.canAdminister, pipelines}); // eslint-disable-line camelcase
+  }
+
+  label() {
+    return "";
+  }
+
+  tooltipForEdit() {
+    return "";
+  }
+
+  ariaLabelForEdit() {
+    return "";
+  }
+
+  titleForEdit() {
+    if (this.canAdminister) {
+      return `Edit ${this.label()}`;
+    }
+    return "";
+  }
+}
+
+class PipelineGroup extends Group {
+  label() {
+    return `Pipeline Group '${this.name}'`;
+  }
+
+  tooltipForEdit() {
+    if (!this.canAdminister) {
+      return "You don't have permission to edit this pipeline group";
+    }
+    return "";
+  }
+
+  ariaLabelForEdit() {
+    return this.tooltipForEdit() || `Edit ${this.label()}`;
+  }
+
+  titleForEdit() {
+    if (this.canAdminister) {
+      return `Edit ${this.label()}`;
+    }
+    return "";
+  }
+
+  select(filter) {
+    const pipelines = _.filter(this.pipelines, filter);
+    if (pipelines.length === 0) {
+      return false;
+    }
+    return new PipelineGroup({name: this.name, can_administer: this.canAdminister, pipelines}); // eslint-disable-line camelcase
+  }
+}
+
+class Environment extends Group {
+  label() {
+    return `Environment '${this.name}'`;
+  }
+
+  tooltipForEdit() {
+    if (!this.canAdminister) {
+      return "You don't have permission to edit this environment";
+    }
+    return "";
+  }
+
+  ariaLabelForEdit() {
+    return this.tooltipForEdit() || `Edit ${this.label()}`;
+  }
+
+  titleForEdit() {
+    if (this.canAdminister) {
+      return `Edit ${this.label()}`;
+    }
+    return "";
+  }
+
+  select(filter) {
+    const pipelines = _.filter(this.pipelines, filter);
+    if (pipelines.length === 0) {
+      return false;
+    }
+    return new Environment({name: this.name, can_administer: this.canAdminister, pipelines}); // eslint-disable-line camelcase
+  }
 }
 
 function DashboardGroups(groups) {
@@ -46,8 +130,12 @@ function DashboardGroups(groups) {
   };
 }
 
-DashboardGroups.fromJSON = (json) => {
-  return new DashboardGroups(_.map(json, (group) => new Group(group)));
+DashboardGroups.fromPipelineGroupsJSON = (json) => {
+  return new DashboardGroups(_.map(json, (group) => new PipelineGroup(group)));
+};
+
+DashboardGroups.fromEnvironmentsJSON = (json) => {
+  return new DashboardGroups(_.map(json, (group) => new Environment(group)));
 };
 
 DashboardGroups.Group = Group;

--- a/server/webapp/WEB-INF/rails.new/webpack/views/dashboard/dashboard_groups_widget.js.msx
+++ b/server/webapp/WEB-INF/rails.new/webpack/views/dashboard/dashboard_groups_widget.js.msx
@@ -8,65 +8,33 @@ function routeForScheme(scheme, name) {
   const paths = {};
 
   if (name) {
-    switch(scheme) {
+    switch (scheme) {
       case "pipeline_groups":
-      paths.show = `${Routes.pipelineGroupsPath()}#group-${name}`;
-      paths.edit = Routes.pipelineGroupEditPath(name);
-      break;
+        paths.show = `${Routes.pipelineGroupsPath()}#group-${name}`;
+        paths.edit = Routes.pipelineGroupEditPath(name);
+        break;
       case "environments":
-      paths.edit = paths.show = Routes.environmentShowPath(name);
-      break;
+        paths.edit = paths.show = Routes.environmentShowPath(name);
+        break;
       default:
-      break;
+        break;
     }
   }
 
   return paths;
 }
 
-function labelForScheme(scheme, name) {
-  if (!name || !scheme) {
-    return "";
-  }
-
-  switch (scheme) {
-    case "pipeline_groups":
-      return `Pipeline Group '${name}'`;
-    case "environments":
-      return `Environment '${name}'`;
-  }
-  return name;
-}
-
-function tooltipForEditScheme(scheme) {
-  const defaultTooltip = "You don't have permission to edit this";
-  if (!scheme) {
-    return defaultTooltip;
-  }
-  switch (scheme) {
-    case "pipeline_groups":
-      return "You don't have permission to edit this pipeline group";
-    case "environments":
-      return "You don't have permission to edit this environment";
-  }
-  return defaultTooltip;
-}
-
 const GroupHeading = {
   view(vnode) {
     const vm                = vnode.attrs.vm;
     const scheme            = vnode.attrs.scheme;
-    const tt                = vm.canAdminister ? "" : tooltipForEditScheme(scheme);
     const paths             = routeForScheme(scheme, vm.name);
-    const accessibleHeading = labelForScheme(scheme, vm.name);
-    const editAriaLabel     = tt || `Edit ${labelForScheme(scheme, vm.name)}`;
-    const editTitle         = tt ? "" : editAriaLabel;
 
     return <div class="dashboard-group_title">
       <f.link disabled={!vm.canAdminister} href={paths.show} class="pipeline_group_name"
-              aria-label={accessibleHeading}>{vm.name || "Pipelines not in any Environment"}</f.link>
+              aria-label={vm.label()}>{vm.name || "Pipelines not in any Environment"}</f.link>
       {vm.name && <f.link class="edit_config dashboard-group_edit-config" disabled={!vm.canAdminister} href={paths.edit}
-                          tooltipText={tt} title={editTitle} aria-label={editAriaLabel}/>}
+                          tooltipText={vm.tooltipForEdit()} title={vm.titleForEdit()} aria-label={vm.ariaLabelForEdit()}/>}
     </div>;
   }
 };

--- a/server/webapp/WEB-INF/rails.new/webpack/views/dashboard/dashboard_groups_widget.js.msx
+++ b/server/webapp/WEB-INF/rails.new/webpack/views/dashboard/dashboard_groups_widget.js.msx
@@ -9,7 +9,7 @@ const GroupHeading = {
     const paths = vm.routes();
 
     return <div class="dashboard-group_title">
-      <f.link disabled={!vm.canAdminister} href={paths.show} class="pipeline_group_name"
+      <f.link disabled={!vm.canAdminister} href={paths.show} class="dashboard-group_name"
               aria-label={vm.label()}>{vm.name || "Pipelines not in any Environment"}</f.link>
       {vm.name && <f.link class="edit_config dashboard-group_edit-config" disabled={!vm.canAdminister} href={paths.edit}
                           tooltipText={vm.tooltipForEdit()} title={vm.titleForEdit()} aria-label={vm.ariaLabelForEdit()}/>}

--- a/server/webapp/WEB-INF/rails.new/webpack/views/dashboard/dashboard_groups_widget.js.msx
+++ b/server/webapp/WEB-INF/rails.new/webpack/views/dashboard/dashboard_groups_widget.js.msx
@@ -1,34 +1,12 @@
 const m              = require("mithril");
 const _              = require("lodash");
 const f              = require("helpers/form_helper");
-const Routes         = require("gen/js-routes");
 const PipelineWidget = require("views/dashboard/pipeline_widget");
-
-function routeForScheme(scheme, name) {
-  const paths = {};
-
-  if (name) {
-    switch (scheme) {
-      case "pipeline_groups":
-        paths.show = `${Routes.pipelineGroupsPath()}#group-${name}`;
-        paths.edit = Routes.pipelineGroupEditPath(name);
-        break;
-      case "environments":
-        paths.edit = paths.show = Routes.environmentShowPath(name);
-        break;
-      default:
-        break;
-    }
-  }
-
-  return paths;
-}
 
 const GroupHeading = {
   view(vnode) {
-    const vm                = vnode.attrs.vm;
-    const scheme            = vnode.attrs.scheme;
-    const paths             = routeForScheme(scheme, vm.name);
+    const vm    = vnode.attrs.vm;
+    const paths = vm.routes();
 
     return <div class="dashboard-group_title">
       <f.link disabled={!vm.canAdminister} href={paths.show} class="pipeline_group_name"

--- a/server/webapp/WEB-INF/rails.new/webpack/views/dashboard/dashboard_groups_widget.js.msx
+++ b/server/webapp/WEB-INF/rails.new/webpack/views/dashboard/dashboard_groups_widget.js.msx
@@ -31,24 +31,42 @@ function labelForScheme(scheme, name) {
 
   switch (scheme) {
     case "pipeline_groups":
-      return `Pipeline Group ${name}`;
+      return `Pipeline Group '${name}'`;
     case "environments":
-      return `Environment ${name}`;
+      return `Environment '${name}'`;
   }
   return name;
 }
 
+function tooltipForEditScheme(scheme) {
+  const defaultTooltip = "You don't have permission to edit this";
+  if (!scheme) {
+    return defaultTooltip;
+  }
+  switch (scheme) {
+    case "pipeline_groups":
+      return "You don't have permission to edit this pipeline group";
+    case "environments":
+      return "You don't have permission to edit this environment";
+  }
+  return defaultTooltip;
+}
+
 const GroupHeading = {
   view(vnode) {
-    const vm = vnode.attrs.vm;
-    const scheme = vnode.attrs.scheme;
-    const tt = vm.canAdminister ? "" : "You do not have permission to edit.";
-    const paths = routeForScheme(scheme, vm.name);
-    const accessibleLabel = labelForScheme(scheme, vm.name);
+    const vm                = vnode.attrs.vm;
+    const scheme            = vnode.attrs.scheme;
+    const tt                = vm.canAdminister ? "" : tooltipForEditScheme(scheme);
+    const paths             = routeForScheme(scheme, vm.name);
+    const accessibleHeading = labelForScheme(scheme, vm.name);
+    const editAriaLabel     = tt || `Edit ${labelForScheme(scheme, vm.name)}`;
+    const editTitle         = tt ? "" : editAriaLabel;
 
     return <div class="dashboard-group_title">
-      <f.link disabled={!vm.canAdminister} href={paths.show}  class="pipeline_group_name" aria-label={accessibleLabel}>{vm.name || "Pipelines not in any Environment"}</f.link>
-      {vm.name && <f.link class="edit_config dashboard-group_edit-config" disabled={!vm.canAdminister} href={paths.edit} tooltipText={tt} aria-label={`Edit ${accessibleLabel}`} />}
+      <f.link disabled={!vm.canAdminister} href={paths.show} class="pipeline_group_name"
+              aria-label={accessibleHeading}>{vm.name || "Pipelines not in any Environment"}</f.link>
+      {vm.name && <f.link class="edit_config dashboard-group_edit-config" disabled={!vm.canAdminister} href={paths.edit}
+                          tooltipText={tt} title={editTitle} aria-label={editAriaLabel}/>}
     </div>;
   }
 };


### PR DESCRIPTION
This started off with just improving the text on the tooltips, but ended up with a lot of `switch-case` statements in the view. Instead, I made the Group view model polymorphic.

When the Edit button on the Group is in a disabled state, it shows a custom tooltip with the reason for being disabled. If it also has a `title` attribute in this state, it overlaps the custom tooltip. But we do want the aria-label to be present for accessibility. That's what makes the logic a bit messy.