### PR TITLE
Add oldEslint gradlew (and yarn) task to run lint on old javascript

### DIFF
--- a/server/lint.gradle
+++ b/server/lint.gradle
@@ -40,6 +40,16 @@ task scssLint(type: Exec) {
   }
 }
 
+task eslintold(type: YarnRunTask) {
+  description "Run ESLint for old javascript code"
+  dependsOn 'yarnInstall'
+
+  workingDir = project.railsRoot
+
+  yarnCommand = ['eslintold']
+  source(project.file("${project.railsRoot}/app/assets/javascripts"))
+}
+
 task eslint(type: YarnRunTask) {
   description "Run ESLint"
   dependsOn 'yarnInstall'
@@ -53,5 +63,5 @@ task eslint(type: YarnRunTask) {
 
 task lint {
   description 'Run all lint tools'
-  dependsOn scssLint, eslint
+  dependsOn eslintold, scssLint, eslint
 }

--- a/server/webapp/WEB-INF/rails.new/.eslintrc-old.json
+++ b/server/webapp/WEB-INF/rails.new/.eslintrc-old.json
@@ -1,0 +1,24 @@
+{
+  "plugins": [
+    "es5"
+  ],
+  "rules": {
+    "es5/no-arrow-functions": "error",
+    "es5/no-binary-and-octal-literals": "error",
+    "es5/no-block-scoping": "error",
+    "es5/no-classes": "error",
+    "es5/no-computed-properties": "error",
+    "es5/no-default-parameters": "error",
+    "es5/no-destructuring": "error",
+    "es5/no-exponentiation-operator": "error",
+    "es5/no-for-of": "error",
+    "es5/no-generators": "error",
+    "es5/no-modules": "error",
+    "es5/no-object-super": "error",
+    "es5/no-rest-parameters": "error",
+    "es5/no-shorthand-properties": "error",
+    "es5/no-spread": "error",
+    "es5/no-template-literals": "error",
+    "es5/no-unicode-code-point-escape": "error"
+  }
+}

--- a/server/webapp/WEB-INF/rails.new/package.json
+++ b/server/webapp/WEB-INF/rails.new/package.json
@@ -8,7 +8,8 @@
     "webpack-prod": "webpack --config config/webpack.config.js --env.production=true",
     "jasmine-ci": "karma start --single-run",
     "karma": "karma start",
-    "eslint": "eslint --color --ext .js --ext .msx --format stylish webpack/ spec/webpack/ --ignore-pattern gen/"
+    "eslint": "eslint --color --ext .js --ext .msx --format stylish webpack/ spec/webpack/ --ignore-pattern gen/",
+    "eslintold": "eslint --no-eslintrc --config .eslintrc-old.json --color --ext .js  --format stylish app/assets/javascripts/"
   },
   "dependencies": {
     "@shopify/draggable": "^1.0.0-beta.7",
@@ -39,6 +40,7 @@
     "babel-preset-env": "^1.7.0",
     "babel-preset-stage-2": "^6.24.1",
     "eslint": "^4.19.1",
+    "eslint-plugin-es5": "^1.3.1",
     "eslint-plugin-react": "^7.10.0",
     "fs-extra": "^6.0.1",
     "happypack": "^4.0.1",

--- a/server/webapp/WEB-INF/rails.new/yarn.lock
+++ b/server/webapp/WEB-INF/rails.new/yarn.lock
@@ -2395,6 +2395,10 @@ escope@^3.6.0:
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
 
+eslint-plugin-es5@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-es5/-/eslint-plugin-es5-1.3.1.tgz#4938431abdd585005db9cf67b42b64463c0acd18"
+
 eslint-plugin-react@^7.10.0:
   version "7.10.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.10.0.tgz#af5c1fef31c4704db02098f9be18202993828b50"


### PR DESCRIPTION
* We don't have a transpiler to transpile the code from ES6 to ES5
* IE11 does not support ES6 code which kept failing for ES6 code.
* Add ESLint task to verify no ES6 features are used in old javascript