### PR TITLE
Pin vsm analytics overlay at the top while scrolling vertically (#5136)

### DIFF
--- a/server/webapp/WEB-INF/rails.new/app/assets/stylesheets/_vsm.scss
+++ b/server/webapp/WEB-INF/rails.new/app/assets/stylesheets/_vsm.scss
@@ -29,6 +29,10 @@ $btn-primary: #943a9e;
 $btn-secondary: #666;
 $btn-default: #d6d5d5;
 
+#value_stream_map {
+  overflow-y: hidden;
+}
+
 %btn {
   border:        1px solid transparent;
   padding:       7px 20px;

--- a/server/webapp/WEB-INF/rails.new/app/assets/stylesheets/module.scss
+++ b/server/webapp/WEB-INF/rails.new/app/assets/stylesheets/module.scss
@@ -2560,7 +2560,7 @@ li.task_property {
     position: relative;
     background: #EEE;
     overflow: auto;
-    margin: 55px 5px 5px 5px;
+    margin: 0 5px 5px 5px;
 }
 
 #vsm-container a {


### PR DESCRIPTION
* Avoid multiple vertical scrolls on vsm page. Allow scrolling only the vsm div not the entire page
* Remove unnecessary top margin