### PR TITLE
Run eslintold on old javascript test too

### DIFF
--- a/server/lint.gradle
+++ b/server/lint.gradle
@@ -48,6 +48,8 @@ task eslintold(type: YarnRunTask) {
 
   yarnCommand = ['eslintold']
   source(project.file("${project.railsRoot}/app/assets/javascripts"))
+  source(project.file("${project.railsRoot}/.eslintrc-old.json"))
+  source(project.file("${project.railsRoot}/spec/javascripts"))
 }
 
 task eslint(type: YarnRunTask) {

--- a/server/webapp/WEB-INF/rails.new/package.json
+++ b/server/webapp/WEB-INF/rails.new/package.json
@@ -9,7 +9,7 @@
     "jasmine-ci": "karma start --single-run",
     "karma": "karma start",
     "eslint": "eslint --color --ext .js --ext .msx --format stylish webpack/ spec/webpack/ --ignore-pattern gen/",
-    "eslintold": "eslint --no-eslintrc --config .eslintrc-old.json --color --ext .js  --format stylish app/assets/javascripts/"
+    "eslintold": "eslint --no-eslintrc --config .eslintrc-old.json --color --ext .js  --format stylish app/assets/javascripts/ spec/javascripts/"
   },
   "dependencies": {
     "@shopify/draggable": "^1.0.0-beta.7",

--- a/server/webapp/WEB-INF/rails.new/spec/javascripts/vsm_graph_spec.js
+++ b/server/webapp/WEB-INF/rails.new/spec/javascripts/vsm_graph_spec.js
@@ -18,7 +18,7 @@ describe("vsm_graph", function () {
 
   describe("fromJSON", function () {
     it("should de-serialize graph from JSON", function () {
-      const vsmGraph = VSMGraph.fromJSON(vsmGraphJSON());
+      var vsmGraph = VSMGraph.fromJSON(vsmGraphJSON());
 
       expect(vsmGraph.current_pipeline).toBe("P4");
       expect(vsmGraph.levels.size()).toBe(4);
@@ -65,7 +65,7 @@ describe("vsm_graph", function () {
     });
 
     it("should leave the original JSON intact", function () {
-      const graph = vsmGraphJSON();
+      var graph = vsmGraphJSON();
 
       VSMGraph.fromJSON(graph);
 
@@ -75,17 +75,17 @@ describe("vsm_graph", function () {
 
   describe("toJSON", function () {
     it("should serialize a vsm graph to JSON", function () {
-      const vsmGraph = VSMGraph.fromJSON(vsmGraphJSON());
+      var vsmGraph = VSMGraph.fromJSON(vsmGraphJSON());
 
-      const jsonString = JSON.stringify(vsmGraph);
-      const json       = JSON.parse(jsonString);
+      var jsonString = JSON.stringify(vsmGraph);
+      var json       = JSON.parse(jsonString);
 
       expect(json['current_pipeline']).toBe("P4");
       expect(json).toEqual(vsmGraphForAnalytics);
     });
   });
 
-  const vsmGraphForAnalytics = {
+  var vsmGraphForAnalytics = {
     "current_pipeline": "P4",
     "levels":           [
       {
@@ -246,7 +246,7 @@ describe("vsm_graph", function () {
     ]
   };
 
-  const vsmGraphJSON = function () {
+  var vsmGraphJSON = function () {
     new PrototypeOverrides().overrideJSONStringify();
     return JSON.parse(JSON.stringify({
       "current_pipeline"


### PR DESCRIPTION
* IE11 allows ES6 binding feature (const, let) but none of the other ES6 features.
* Using const in the code gives a false impression of ES6 support, Hence, do not use any ES6 features in the old code.

ES6 compatibility map: https://kangax.github.io/compat-table/es6/