### PR TITLE
Call onchange() when a tab is activated

### DIFF
--- a/server/webapp/WEB-INF/rails.new/spec/webpack/views/dashboard/model/personalization_vm_spec.js
+++ b/server/webapp/WEB-INF/rails.new/spec/webpack/views/dashboard/model/personalization_vm_spec.js
@@ -49,6 +49,17 @@ describe("Personalization View Model", () => {
     expect(vm.active("Bar")).toBe(false);
   });
 
+  it("activate() should trigger onchange()", () => {
+    const currentView = Stream("Foo");
+    const vm = new PersonalizationVM(currentView);
+    vm.onchange = jasmine.createSpy();
+    vm.names(["Foo", "Bar", "Baz"]);
+
+    vm.activate("Bar");
+    expect(vm.active("Bar")).toBe(true);
+    expect(vm.onchange).toHaveBeenCalled();
+  });
+
   it("hideAllDropdowns() hides all dropdowns", () => {
     const currentView = Stream();
     const vm = new PersonalizationVM(currentView);

--- a/server/webapp/WEB-INF/rails.new/webpack/views/dashboard/models/personalization_vm.js
+++ b/server/webapp/WEB-INF/rails.new/webpack/views/dashboard/models/personalization_vm.js
@@ -89,6 +89,7 @@ function PersonalizationVM(currentView) {
   this.activate = (viewName) => {
     currentView(contains(names(), viewName) ? viewName : "Default");
     tabSettingsDD(false);
+    this.onchange();
   };
 
   this.tabSettingsDropdownVisible = () => tabSettingsDD();


### PR DESCRIPTION
ensureCurrentTabIsInView will be triggered indirectly.

@marques-work Can you take a look? I hope this doesn't cause any unintended behaviour.