### PR TITLE
[VSM Analytics] Fix vsm analytics mode for pipeline having multiple instances

### DIFF
--- a/server/webapp/WEB-INF/rails.new/app/assets/javascripts/vsm_renderer.js
+++ b/server/webapp/WEB-INF/rails.new/app/assets/javascripts/vsm_renderer.js
@@ -129,6 +129,7 @@ Graph_Renderer = function (container) {
       $j('.vsm-entity.pipeline').click(selectPipeline);
 
       $j('.vsm-entity.pipeline').addClass("vsm-pipeline-node");
+      $j('.vsm-entity.pipeline').removeClass("expanded");
       $j('.vsm-entity.pipeline h3 a').addClass("vsm-pipeline-unclickable-name");
       $j('.vsm-entity.pipeline .pipeline_actions').addClass("hidden");
       $j('.vsm-entity.pipeline .instances .instance .vsm_link_wrapper').addClass("hidden");
@@ -149,6 +150,7 @@ Graph_Renderer = function (container) {
       $j('.vsm-entity.pipeline').unbind('click', selectPipeline);
 
       $j('.vsm-entity.pipeline').removeClass("vsm-pipeline-node");
+      $j('div.show-more:contains("less...")').parent().addClass('expanded');
       $j('.vsm-entity.pipeline h3 a').removeClass("vsm-pipeline-unclickable-name");
       $j('.vsm-entity.pipeline .pipeline_actions').removeClass("hidden");
       $j('.vsm-entity.pipeline .instances .instance .vsm_link_wrapper').removeClass("hidden");


### PR DESCRIPTION
* Do not show multiple pipeline instances in vsm analytics mode
* Collapse expanded pipeline instances in vsm analytics mode and
  Expand them again after coming out of analytics mode

![pipeline-instance](https://user-images.githubusercontent.com/15275847/45201951-df88f980-b294-11e8-989a-b386c5318353.gif)
