### PR TITLE
Styling fix for grouping by env or group

### DIFF
--- a/server/webapp/WEB-INF/rails/app/assets/new_stylesheets/single_page_apps/new_dashboard.scss
+++ b/server/webapp/WEB-INF/rails/app/assets/new_stylesheets/single_page_apps/new_dashboard.scss
@@ -161,9 +161,10 @@ body {
 }
 
 .grouping_select {
-  margin:  0 0 0 10px;
-  width:   145px;
-  display: inline-block;
+  margin:              0 0 0 10px;
+  width:               170px;
+  display:             inline-block;
+  background-position: calc(100% - 2px) 17px;
 }
 
 .filter {


### PR DESCRIPTION
Minor ui fix

before (screenshot from build.gocd.org):
<img width="453" alt="screen shot 2018-09-11 at 10 30 11 am" src="https://user-images.githubusercontent.com/5726224/45377148-9693b680-b5ae-11e8-99ce-55e9c88b0255.png">


after:

<img width="489" alt="screen shot 2018-09-11 at 10 30 04 am" src="https://user-images.githubusercontent.com/5726224/45377141-91cf0280-b5ae-11e8-9703-17822878637d.png">
