### PR TITLE
Default to port 443 in go agent

### DIFF
--- a/base/src/main/java/com/thoughtworks/go/util/SystemUtil.java
+++ b/base/src/main/java/com/thoughtworks/go/util/SystemUtil.java
@@ -179,7 +179,11 @@ public class SystemUtil {
     public static String getClientIp(String serviceUrl) {
         try {
             URL url = new URL(serviceUrl);
-            try (Socket socket = new Socket(url.getHost(), url.getPort())) {
+            int port = url.getPort();
+            if (port == -1) {
+                port = url.getDefaultPort();
+            }
+            try (Socket socket = new Socket(url.getHost(), port)) {
                 return socket.getLocalAddress().getHostAddress();
             }
         } catch (Exception e) {


### PR DESCRIPTION
I had the issue that setting in `/etc/default/go-agent` `GO_SERVER_URL=https://gocdhostname/go` did not work with the error "Failed to get non-loopback local ip address". Using `GO_SERVER_URL=https://gocdhostname:443/go` (note the port number) fixes that issue.

The reason is that if you don't supply a port number, `url.getPort()` returns `-1`, which you obviously cannot connect to, hence that URL was rejected.

This PR defaults to port 443 if no port is given. That is good enough for gocd agent, which can only use https if I observed correctly. Still, this code might want to look at the protocol and default to port 80 if the protocol is "http" for other use cases (and keep -1 for unknown protocols).

Let me know if this change seems acceptable.

I would like to add tests as well but am unsure how to proceed. This function is currently not tested directly. Please advise.