### PR TITLE
Basic Config Repos SPA Prototype

### DIFF
--- a/server/src/main/java/com/thoughtworks/go/server/service/support/toggle/Toggles.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/support/toggle/Toggles.java
@@ -21,6 +21,7 @@ public class Toggles {
     public static String QUICK_EDIT_PAGE_DEFAULT = "quick_edit_page_toggle_key";
     public static String BROWSER_CONSOLE_LOG_WS = "browser_console_log_ws_key";
     public static String COMPONENTS = "components";
+    public static String CONFIG_REPOS_UI = "config_repos_ui";
 
     private static FeatureToggleService service;
 

--- a/server/src/main/resources/available.toggles
+++ b/server/src/main/resources/available.toggles
@@ -22,6 +22,11 @@
          "value": false
       },
       {
+         "key": "config_repos_ui",
+         "description": "Enables experimental config repos management UI. Default: disabled.",
+         "value": false
+      },
+      {
         "key": "components",
         "description": "Enables pages being refactored to use components and CSS modules. Needs a server restart.",
         "value": false

--- a/server/webapp/WEB-INF/rails/app/helpers/api_etag_helper.rb
+++ b/server/webapp/WEB-INF/rails/app/helpers/api_etag_helper.rb
@@ -1,4 +1,6 @@
 module ApiEtagHelper
+  HttpLocalizedOperationResult = com.thoughtworks.go.server.service.result.HttpLocalizedOperationResult
+
   # this is how rails computes etags
   # copied from ActionDispatch::Http::Cache::Request
   def generate_strong_etag(validators)

--- a/server/webapp/WEB-INF/rails/spec/webpack/helpers/api_helper_spec.js
+++ b/server/webapp/WEB-INF/rails/spec/webpack/helpers/api_helper_spec.js
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2018 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const ApiHelper = require("helpers/api_helper");
+
+describe("ApiHelper", () => {
+  it("should parse ETag from response", (done) => {
+    jasmine.Ajax.withMock(() => {
+      jasmine.Ajax.stubRequest("/hello", undefined, "GET").andReturn({
+        responseText:    JSON.stringify({
+          data: {a: 1, b: 2}
+        }),
+        responseHeaders: {
+          ETag:           `W/"05548388f7ef5042cd39f7fe42e85735--gzip"`,
+          "Content-Type": "application/vnd.go.cd.v1+json"
+        },
+        status:          200
+      });
+
+      ApiHelper.GET({
+        url: "/hello",
+        apiVersion: "v1",
+        etag: "initial"
+      }).then((data, etag) => {
+        expect(data).toEqual({ data: { a: 1, b: 2 }});
+        expect(etag).toEqual(`W/"05548388f7ef5042cd39f7fe42e85735"`);
+        done();
+      }, () => done.fail("response should be successful"));
+    });
+  });
+
+  it("should parse error on failure", (done) => {
+    jasmine.Ajax.withMock(() => {
+      jasmine.Ajax.stubRequest("/hello", undefined, "GET").andReturn({
+        responseHeaders: { "Content-Type": "application/vnd.go.cd.v1+json" },
+        status:          500,
+        responseText:    JSON.stringify({message: "Rejected"})
+      });
+
+      ApiHelper.GET({
+        url: "/hello",
+        apiVersion: "v1",
+        etag: "initial"
+      }).then(() => done.fail("request should not succeed"), (msg) => {
+        expect(msg).toBe("Rejected");
+        done();
+      });
+    });
+  });
+});

--- a/server/webapp/WEB-INF/rails/spec/webpack/models/config_repos/config_repos_spec.js
+++ b/server/webapp/WEB-INF/rails/spec/webpack/models/config_repos/config_repos_spec.js
@@ -17,7 +17,7 @@
 const ConfigRepos = require("models/config_repos/config_repos");
 const Routes      = require("gen/js-routes");
 
-describe("ConfigRepos", () => {
+describe("Config Repo CRUD model", () => {
   it("should parse ETag from response", (done) => {
     jasmine.Ajax.withMock(() => {
       jasmine.Ajax.stubRequest(Routes.apiv1AdminConfigReposPath(), undefined, "GET").andReturn({
@@ -36,6 +36,22 @@ describe("ConfigRepos", () => {
       const configRepos = new ConfigRepos();
       configRepos.all().then(() => {
         expect(configRepos.etag()).toEqual(`W/"05548388f7ef5042cd39f7fe42e85735"`);
+        done();
+      });
+    });
+  });
+
+  it("should parse error on failure", (done) => {
+    jasmine.Ajax.withMock(() => {
+      jasmine.Ajax.stubRequest(Routes.apiv1AdminConfigReposPath(), undefined, "GET").andReturn({
+        responseHeaders: { "Content-Type": "application/vnd.go.cd.v1+json" },
+        status:          500,
+        responseText:    JSON.stringify({message: "Rejected"})
+      });
+
+      const configRepos = new ConfigRepos();
+      configRepos.all().then(() => done.fail("request should not succeed"), (msg) => {
+        expect(msg).toBe("Rejected");
         done();
       });
     });

--- a/server/webapp/WEB-INF/rails/spec/webpack/models/config_repos/config_repos_spec.js
+++ b/server/webapp/WEB-INF/rails/spec/webpack/models/config_repos/config_repos_spec.js
@@ -18,7 +18,7 @@ const ConfigRepos = require("models/config_repos/config_repos");
 const Routes      = require("gen/js-routes");
 
 describe("Config Repo CRUD model", () => {
-  it("should parse ETag from response", (done) => {
+  it("all() should cache etag", (done) => {
     jasmine.Ajax.withMock(() => {
       jasmine.Ajax.stubRequest(Routes.apiv1AdminConfigReposPath(), undefined, "GET").andReturn({
         responseText:    JSON.stringify({
@@ -37,23 +37,7 @@ describe("Config Repo CRUD model", () => {
       configRepos.all().then(() => {
         expect(configRepos.etag()).toEqual(`W/"05548388f7ef5042cd39f7fe42e85735"`);
         done();
-      });
-    });
-  });
-
-  it("should parse error on failure", (done) => {
-    jasmine.Ajax.withMock(() => {
-      jasmine.Ajax.stubRequest(Routes.apiv1AdminConfigReposPath(), undefined, "GET").andReturn({
-        responseHeaders: { "Content-Type": "application/vnd.go.cd.v1+json" },
-        status:          500,
-        responseText:    JSON.stringify({message: "Rejected"})
-      });
-
-      const configRepos = new ConfigRepos();
-      configRepos.all().then(() => done.fail("request should not succeed"), (msg) => {
-        expect(msg).toBe("Rejected");
-        done();
-      });
+      }, () => done.fail("request should be successful"));
     });
   });
 });

--- a/server/webapp/WEB-INF/rails/spec/webpack/models/config_repos/config_repos_spec.js
+++ b/server/webapp/WEB-INF/rails/spec/webpack/models/config_repos/config_repos_spec.js
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2018 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const ConfigRepos = require('models/config_repos/config_repos');
+const Routes      = require('gen/js-routes');
+
+describe("ConfigRepos", () => {
+  it('should parse ETag from response', (done) => {
+    jasmine.Ajax.withMock(() => {
+      jasmine.Ajax.stubRequest(Routes.apiv1AdminConfigReposPath(), undefined, 'GET').andReturn({
+        responseText:    JSON.stringify({
+          "_embedded": {
+            "config_repos": []
+          },
+        }),
+        responseHeaders: {
+          ETag:           'W/"05548388f7ef5042cd39f7fe42e85735--gzip"',
+          'Content-Type': 'application/vnd.go.cd.v1+json'
+        },
+        status:          200
+      });
+
+      const configRepos = new ConfigRepos();
+      configRepos.all().then((data, s, xhr) => {
+        expect(configRepos.etag()).toEqual('W/"05548388f7ef5042cd39f7fe42e85735"');
+        done();
+      });
+    });
+  });
+});

--- a/server/webapp/WEB-INF/rails/spec/webpack/models/config_repos/config_repos_spec.js
+++ b/server/webapp/WEB-INF/rails/spec/webpack/models/config_repos/config_repos_spec.js
@@ -14,28 +14,28 @@
  * limitations under the License.
  */
 
-const ConfigRepos = require('models/config_repos/config_repos');
-const Routes      = require('gen/js-routes');
+const ConfigRepos = require("models/config_repos/config_repos");
+const Routes      = require("gen/js-routes");
 
 describe("ConfigRepos", () => {
-  it('should parse ETag from response', (done) => {
+  it("should parse ETag from response", (done) => {
     jasmine.Ajax.withMock(() => {
-      jasmine.Ajax.stubRequest(Routes.apiv1AdminConfigReposPath(), undefined, 'GET').andReturn({
+      jasmine.Ajax.stubRequest(Routes.apiv1AdminConfigReposPath(), undefined, "GET").andReturn({
         responseText:    JSON.stringify({
           "_embedded": {
             "config_repos": []
           },
         }),
         responseHeaders: {
-          ETag:           'W/"05548388f7ef5042cd39f7fe42e85735--gzip"',
-          'Content-Type': 'application/vnd.go.cd.v1+json'
+          ETag:           `W/"05548388f7ef5042cd39f7fe42e85735--gzip"`,
+          "Content-Type": "application/vnd.go.cd.v1+json"
         },
         status:          200
       });
 
       const configRepos = new ConfigRepos();
-      configRepos.all().then((data, s, xhr) => {
-        expect(configRepos.etag()).toEqual('W/"05548388f7ef5042cd39f7fe42e85735"');
+      configRepos.all().then(() => {
+        expect(configRepos.etag()).toEqual(`W/"05548388f7ef5042cd39f7fe42e85735"`);
         done();
       });
     });

--- a/server/webapp/WEB-INF/rails/spec/webpack/models/config_repos/field_spec.js
+++ b/server/webapp/WEB-INF/rails/spec/webpack/models/config_repos/field_spec.js
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2018 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const Field = require("models/config_repos/field");
+
+describe("Field", () => {
+  it("getter and setter for a key", () => {
+    function TestObj() {
+      Field.call(this, "name");
+    }
+
+    const o = new TestObj();
+    expect(typeof o.name).toBe("function");
+
+    o.name("hello");
+    expect(o.name()).toBe("hello");
+
+    o.name("world");
+    expect(o.name()).toBe("world");
+
+    expect(o.keys).toEqual(["name"]);
+  });
+
+  it("should set options on fields", () => {
+    function TestObj() {
+      Field.call(this, "name", {display: "Great name"});
+      Field.call(this, "password", {type: "secret"});
+    }
+    const o = new TestObj();
+    expect(o.name.display).toBe("Great name");
+    expect(o.name.type).toBe("text"); // default option
+
+    expect(o.password.display).toBe("Password"); // default option
+    expect(o.password.type).toBe("secret");
+  });
+
+  it("init() honors default values", () => {
+    function TestObj() {
+      Field.call(this, "name", {default: "chewbacca"});
+      Field.call(this, "ok", {default: true});
+    }
+
+    const o = new TestObj();
+    expect(o.name.init(null)).toBe("chewbacca");
+    expect(o.name.init(undefined)).toBe("chewbacca");
+    expect(o.name.init("hi")).toBe("hi");
+    expect(o.name.init("")).toBe("");
+
+    expect(o.ok.init(null)).toBe(true);
+    expect(o.ok.init(undefined)).toBe(true);
+    expect(o.ok.init(false)).toBe(false);
+  });
+
+  it("normalizes values according to the specified type", () => {
+    function TestObj() {
+      Field.call(this, "name");
+      Field.call(this, "ok", {type: "boolean"});
+    }
+
+    const o = new TestObj();
+
+    expect(o.name(null)).toBe("");
+    expect(o.name(undefined)).toBe("");
+    expect(o.name(5)).toBe("5");
+    expect(o.name("    hi    ")).toBe("hi");
+
+    expect(o.ok(0)).toBe(false);
+    expect(o.ok(1)).toBe(true);
+  });
+});

--- a/server/webapp/WEB-INF/rails/spec/webpack/models/config_repos/field_spec.js
+++ b/server/webapp/WEB-INF/rails/spec/webpack/models/config_repos/field_spec.js
@@ -16,7 +16,7 @@
 
 const Field = require("models/config_repos/field");
 
-describe("Field", () => {
+describe("Config Repo Field", () => {
   it("getter and setter for a key", () => {
     function TestObj() {
       Field.call(this, "name");
@@ -50,7 +50,7 @@ describe("Field", () => {
   it("init() honors default values", () => {
     function TestObj() {
       Field.call(this, "name", {default: "chewbacca"});
-      Field.call(this, "ok", {default: true});
+      Field.call(this, "ok", {default: true, type: "boolean"});
     }
 
     const o = new TestObj();

--- a/server/webapp/WEB-INF/rails/spec/webpack/models/config_repos/field_spec.js
+++ b/server/webapp/WEB-INF/rails/spec/webpack/models/config_repos/field_spec.js
@@ -39,12 +39,13 @@ describe("Config Repo Field", () => {
       Field.call(this, "name", {display: "Great name"});
       Field.call(this, "password", {type: "secret"});
     }
-    const o = new TestObj();
-    expect(o.name.display).toBe("Great name");
-    expect(o.name.type).toBe("text"); // default option
 
-    expect(o.password.display).toBe("Password"); // default option
-    expect(o.password.type).toBe("secret");
+    const o = new TestObj();
+    expect(o.name.opts("display")).toBe("Great name");
+    expect(o.name.opts("type")).toBe("text"); // defaults to "text" type
+
+    expect(o.password.opts("display")).toBe("Password"); // defaults to title cased name
+    expect(o.password.opts("type")).toBe("secret");
   });
 
   it("init() honors default values", () => {

--- a/server/webapp/WEB-INF/rails/spec/webpack/models/config_repos/materials_spec.js
+++ b/server/webapp/WEB-INF/rails/spec/webpack/models/config_repos/materials_spec.js
@@ -16,7 +16,7 @@
 
 const Materials = require("models/config_repos/materials");
 
-describe("Materials", () => {
+describe("Config Repo Materials", () => {
   it("throws error on unknown material type", () => {
     expect(() => Materials.get("made up type", {})).toThrow(new Error("Unknown material type: made up type"));
   });

--- a/server/webapp/WEB-INF/rails/spec/webpack/models/config_repos/materials_spec.js
+++ b/server/webapp/WEB-INF/rails/spec/webpack/models/config_repos/materials_spec.js
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2018 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const Materials = require("models/config_repos/materials");
+
+describe("Materials", () => {
+  it("throws error on unknown material type", () => {
+    expect(() => Materials.get("made up type", {})).toThrow(new Error("Unknown material type: made up type"));
+  });
+
+  it("should return type requested with appropriate data set", () => {
+    const actual = Materials.get("hg", {
+      material: {
+        attributes: {
+          "name": "My Material",
+          "url": "https://fakeurl.com",
+          "auto_update": false
+        }
+      }
+    });
+
+    const expected = { "name": "My Material", "url": "https://fakeurl.com", "auto_update": false };
+    expect(actual.toJSON()).toEqual(expected);
+  });
+
+  it("instance clone() creates a deep copy", () => {
+    const original = Materials.get("hg", {
+      material: {
+        attributes: {
+          "url": "https://fakeurl.com"
+        }
+      }
+    });
+
+    const copy = original.clone();
+
+    expect(original !== copy).toBe(true);
+    expect(original.toJSON()).toEqual(copy.toJSON());
+
+    copy.url("https://realurl.com");
+    expect(original.url()).toBe("https://fakeurl.com");
+    expect(copy.url()).toBe("https://realurl.com");
+  });
+
+  it("should use default values when value is not set", () => {
+
+  });
+
+});

--- a/server/webapp/WEB-INF/rails/spec/webpack/models/config_repos/materials_spec.js
+++ b/server/webapp/WEB-INF/rails/spec/webpack/models/config_repos/materials_spec.js
@@ -41,7 +41,7 @@ describe("Config Repo Materials", () => {
     o.name("merc");
     o.url("repo.hg");
 
-    expect(o.toJSON()).toEqual({name: "merc", url: "repo.hg", auto_update: true});
+    expect(o.toJSON()).toEqual({name: "merc", url: "repo.hg", auto_update: true}); // eslint-disable-line camelcase
   });
 
   it("instance clone() creates a deep copy", () => {

--- a/server/webapp/WEB-INF/rails/spec/webpack/models/config_repos/materials_spec.js
+++ b/server/webapp/WEB-INF/rails/spec/webpack/models/config_repos/materials_spec.js
@@ -56,7 +56,9 @@ describe("Config Repo Materials", () => {
   });
 
   it("should use default values when value is not set", () => {
-
+    const mat = Materials.get("git", {});
+    expect(mat.branch()).toBe("master");
+    expect(mat.auto_update()).toBe(true);
   });
 
 });

--- a/server/webapp/WEB-INF/rails/spec/webpack/models/config_repos/materials_spec.js
+++ b/server/webapp/WEB-INF/rails/spec/webpack/models/config_repos/materials_spec.js
@@ -36,6 +36,14 @@ describe("Config Repo Materials", () => {
     expect(actual.toJSON()).toEqual(expected);
   });
 
+  it("serializes to plain object with only declared attributes", () => {
+    const o = Materials.get("hg", {});
+    o.name("merc");
+    o.url("repo.hg");
+
+    expect(o.toJSON()).toEqual({name: "merc", url: "repo.hg", auto_update: true});
+  });
+
   it("instance clone() creates a deep copy", () => {
     const original = Materials.get("hg", {
       material: {

--- a/server/webapp/WEB-INF/rails/spec/webpack/models/config_repos/materials_spec.js
+++ b/server/webapp/WEB-INF/rails/spec/webpack/models/config_repos/materials_spec.js
@@ -61,4 +61,36 @@ describe("Config Repo Materials", () => {
     expect(mat.auto_update()).toBe(true);
   });
 
+  it("sets up validation rules based on field configuration", () => {
+    const Field = Materials.Field, Common = Materials.Common;
+
+    function CustomMaterial(data) {
+      Field.call(this, "id", {required: true});
+      Field.call(this, "hostname", {required: true, format: /^[a-z0-9]+(\.[a-z0-9]+)*$/i});
+      Field.call(this, "optional", {required: false});
+
+      Common.call(this, data);
+    }
+
+    const o = new CustomMaterial({});
+    expect(o.isValid()).toBe(false);
+
+    expect(o.errors().errorsForDisplay("id")).toBe("Id must be present.");
+    expect(o.errors().errorsForDisplay("hostname")).toBe("Hostname must be present.");
+    expect(o.errors().hasErrors("optional")).toBe(false);
+
+    o.id("123");
+    o.validate("id");
+
+    expect(o.errors().hasErrors("id")).toBe(false);
+
+    o.hostname("boom!");
+    o.validate("hostname");
+    expect(o.errors().errorsForDisplay("hostname")).toBe("Hostname format is invalid.");
+
+    o.hostname("foo.bar.com");
+
+    expect(o.isValid()).toBe(true);
+    expect(o.errors().hasErrors()).toBe(false);
+  });
 });

--- a/server/webapp/WEB-INF/rails/spec/webpack/views/config_repos/models/config_repo_vm_spec.js
+++ b/server/webapp/WEB-INF/rails/spec/webpack/views/config_repos/models/config_repo_vm_spec.js
@@ -15,3 +15,101 @@
  */
 
 const ConfigRepoVM = require("views/config_repos/models/config_repo_vm");
+
+describe("Config Repo View Model", () => {
+  it("allowSave() runs ALL validations on local and child fields, even if there are failures (does not short-circuit)", () => {
+    const validVm = stubbingValidate(simple());
+
+    expect(validVm.allowSave()).toBe(true);
+    expect(validVm.validate).toHaveBeenCalled();
+    expect(validVm.attributes().validate).toHaveBeenCalled();
+
+    const invalidVm = stubbingValidate(simple(), {id: "ID is uncreative. meh."});
+    expect(invalidVm.allowSave()).toBe(false);
+    expect(invalidVm.validate).toHaveBeenCalled();
+    expect(invalidVm.attributes().validate).toHaveBeenCalled();
+  });
+
+  it("allowSave() result depends on both local and child (material) validations", () => {
+    // basic logical `AND` truth table
+    expect(stubbingIsValid(simple(), true, true).allowSave()).toBe(true);
+    expect(stubbingIsValid(simple(), true, false).allowSave()).toBe(false);
+    expect(stubbingIsValid(simple(), false, true).allowSave()).toBe(false);
+    expect(stubbingIsValid(simple(), false, false).allowSave()).toBe(false);
+  });
+
+  it("should validate fields", () => {
+    const repo = simple();
+    expect(repo.isValid()).toBe(true);
+
+    repo.id(null);
+    repo.pluginId(null);
+    repo.type(null);
+
+    expect(repo.validate().errorsForDisplay("id")).toBe("ID cannot be blank.");
+    expect(repo.validate().errorsForDisplay("pluginId")).toBe("Plugin must be selected.");
+    expect(repo.validate().errorsForDisplay("type")).toBe("Type must be selected.");
+
+    repo.id("I'm invalid");
+    expect(repo.validate().errorsForDisplay("id")).toMatch(/Invalid ID/);
+  });
+
+  it("serializes to plain JSON, suitable as an API payload", () => {
+    expect(simple().toJSON()).toEqual(basicConfig());
+  });
+
+  it("clone() creates a deep copy", () => {
+    const original = simple();
+    const copy = original.clone();
+
+    expect(original === copy).toBe(false);
+    expect(original.toJSON()).toEqual(copy.toJSON());
+
+    // prove these are independent
+    copy.id("carbon-copy");
+    expect(original.toJSON()).not.toEqual(copy.toJSON());
+  });
+});
+
+// utility functions
+
+function stubbingIsValid(vm, resultParent=true, resultChild=true) {
+  vm.isValid = jasmine.createSpy("isValid()").and.returnValue(resultParent);
+  vm.attributes().isValid = jasmine.createSpy("isValid()").and.returnValue(resultChild);
+
+  return vm;
+}
+
+function stubbingValidate(vm, resultParent={}, resultChild={}) {
+  addErrors(vm.errors(), resultParent);
+  addErrors(vm.attributes().errors(), resultChild);
+  vm.validate = jasmine.createSpy("validate()").and.returnValue(vm.errors());
+  vm.attributes().validate = jasmine.createSpy("validate()").and.returnValue(vm.attributes().errors());
+
+  return vm;
+}
+
+function simple() {
+  return new ConfigRepoVM(basicConfig());
+}
+
+function basicConfig() {
+  return {
+    /* eslint-disable camelcase */
+    id: "repo-01",
+    plugin_id: "test.configrepo.plugin",
+    material: {
+      type: "hg",
+      attributes: {
+        name: "my-hg-repo", url: "https://bitnugget.org/unicorns", auto_update: true
+      }
+    },
+    configuration: []
+    /* eslint-enable camelcase */
+  };
+}
+function addErrors(errorsObj, expectedErrors) {
+  for (const attr in expectedErrors) {
+    errorsObj.add(attr, expectedErrors[attr]);
+  }
+}

--- a/server/webapp/WEB-INF/rails/spec/webpack/views/config_repos/models/config_repo_vm_spec.js
+++ b/server/webapp/WEB-INF/rails/spec/webpack/views/config_repos/models/config_repo_vm_spec.js
@@ -15,6 +15,7 @@
  */
 
 const ConfigRepoVM = require("views/config_repos/models/config_repo_vm");
+const Routes       = require("gen/js-routes");
 
 describe("Config Repo View Model", () => {
   it("allowSave() runs ALL validations on local and child fields, even if there are failures (does not short-circuit)", () => {
@@ -68,6 +69,28 @@ describe("Config Repo View Model", () => {
     // prove these are independent
     copy.id("carbon-copy");
     expect(original.toJSON()).not.toEqual(copy.toJSON());
+  });
+
+  it("should be able to test connectivity for url", (done) => {
+    const repo = simple();
+
+    jasmine.Ajax.withMock(() => {
+      jasmine.Ajax.stubRequest(Routes.apiv1AdminInternalMaterialTestPath(), undefined, "POST").andReturn({
+        responseText: JSON.stringify({ message: "Connection OK." }),
+        status: 200,
+        responseHeaders: {
+          "Content-Type": "application/vnd.go.cd.v1+json"
+        }
+      });
+
+      repo.testConnection().then((data) => {
+        const reqParams = JSON.parse(jasmine.Ajax.requests.mostRecent().params);
+        expect(reqParams.attributes.url).toBe("https://bitnugget.org/unicorns");
+        expect(data.message).toBe("Connection OK.");
+        done();
+      }, () => done.fail("request should be successful"));
+    });
+
   });
 });
 

--- a/server/webapp/WEB-INF/rails/spec/webpack/views/config_repos/models/config_repo_vm_spec.js
+++ b/server/webapp/WEB-INF/rails/spec/webpack/views/config_repos/models/config_repo_vm_spec.js
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2018 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const ConfigRepoVM = require("views/config_repos/models/config_repo_vm");

--- a/server/webapp/WEB-INF/rails/spec/webpack/views/config_repos/models/repos_list_vm_spec.js
+++ b/server/webapp/WEB-INF/rails/spec/webpack/views/config_repos/models/repos_list_vm_spec.js
@@ -44,6 +44,19 @@ describe("Config Repo List VM", () => {
     expect(vm.repos().length).toBe(0);
   });
 
+  it("removeRepo() removes the corresponding entry", () => {
+    const model = mockModel();
+    model.delete.and.returnValue(promise({}, null));
+
+    const vm = new ReposListVM(model);
+    vm.repos([cheapRepo(1), cheapRepo(2), cheapRepo(3)]);
+
+    vm.removeRepo(vm.repos()[1]);
+
+    expect(model.delete).toHaveBeenCalledWith(2);
+    expect(vm.repos().map((r) => r.id())).toEqual([1, 3]);
+  });
+
   it("loadPlugins() populates pluginChoices from the server", () => {
     jasmine.Ajax.withMock(() => {
       const url = `${Routes.apiv4AdminPluginInfoIndexPath()}?type=configrepo`;
@@ -91,6 +104,10 @@ function singleRepo(id="repo-01") {
     configuration: []
     /* eslint-enable camelcase */
   };
+}
+
+function cheapRepo(id) {
+  return {id: () => id};
 }
 
 function mockModel() {

--- a/server/webapp/WEB-INF/rails/spec/webpack/views/config_repos/models/repos_list_vm_spec.js
+++ b/server/webapp/WEB-INF/rails/spec/webpack/views/config_repos/models/repos_list_vm_spec.js
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2018 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const ReposListVM = require("views/config_repos/models/repos_list_vm");

--- a/server/webapp/WEB-INF/rails/spec/webpack/views/config_repos/models/repos_list_vm_spec.js
+++ b/server/webapp/WEB-INF/rails/spec/webpack/views/config_repos/models/repos_list_vm_spec.js
@@ -14,4 +14,78 @@
  * limitations under the License.
  */
 
+const _           = require("lodash");
+const Dfr         = require("jquery").Deferred;
 const ReposListVM = require("views/config_repos/models/repos_list_vm");
+
+describe("Config Repo List VM", () => {
+  it("load() fetches data and creates config repo view models", () => {
+    const model = mockModel();
+    const response = fetchAllResponse(singleRepo("repo-01"), singleRepo("repo-02"));
+    model.all.and.returnValue(promise(response));
+
+    const vm = new ReposListVM(model);
+    vm.load();
+
+    expect(vm.repos().length).toBe(2);
+    expect(_.map(vm.repos(), (r) => r.id()).sort()).toEqual(["repo-01", "repo-02"]);
+  });
+
+  it("handles error when load() fails", () => {
+    const model = mockModel();
+    model.all.and.returnValue(promise(null, "boom!"));
+
+    const vm = new ReposListVM(model);
+    expect(vm.errors().length).toBe(0);
+    vm.load();
+
+    expect(vm.errors()).toEqual(["boom!"]);
+    expect(vm.repos().length).toBe(0);
+  });
+});
+
+// utility functions
+
+function fetchAllResponse(_argv /* variable args */) {
+  const repos = arguments.length ? [].slice.call(arguments) : [];
+
+  return {
+    _embedded: { config_repos: repos} // eslint-disable-line camelcase
+  };
+}
+
+function singleRepo(id="repo-01") {
+  return {
+    /* eslint-disable camelcase */
+    id,
+    plugin_id: "test.configrepo.plugin",
+    material: {
+      type: "hg",
+      attributes: {
+        name: "my-hg-repo", url: "https://bitnugget.org/unicorns", auto_update: true
+      }
+    },
+    configuration: []
+    /* eslint-enable camelcase */
+  };
+}
+
+function mockModel() {
+  return {
+    all: jasmine.createSpy("all()"),
+    get: jasmine.createSpy("get()"),
+    create: jasmine.createSpy("create()"),
+    update: jasmine.createSpy("update()"),
+    delete: jasmine.createSpy("delete()")
+  };
+}
+
+function promise(fulfill, reject) {
+  return Dfr(function execute() {
+    if (fulfill) {
+      this.resolve("function" === typeof fulfill ? fulfill() : fulfill);
+    } else {
+      this.reject("function" === typeof reject ? reject() : reject);
+    }
+  }).promise();
+}

--- a/server/webapp/WEB-INF/rails/webpack/helpers/ajax_helper.js
+++ b/server/webapp/WEB-INF/rails/webpack/helpers/ajax_helper.js
@@ -52,26 +52,24 @@ function makeRequest({method, url, apiVersion, type, timeout = mrequest.timeout,
 
 }
 
-module.exports = class AjaxHelper {
-  static GET({url, apiVersion, type, timeout = mrequest.timeout, etag} = {}) {
+module.exports = {
+  GET({url, apiVersion, type, timeout = mrequest.timeout, etag} = {}) {
     return makeRequest({method: 'GET', url, apiVersion, type, timeout, etag});
-  }
+  },
 
-  static PUT({url, apiVersion, timeout = mrequest.timeout, payload, etag, contentType = 'application/json'}) {
+  PUT({url, apiVersion, timeout = mrequest.timeout, payload, etag, contentType = 'application/json'}) {
     return makeRequest({method: 'PUT', url, apiVersion, timeout, payload, etag, contentType});
-  }
+  },
 
-  static POST({url, apiVersion, timeout = mrequest.timeout, payload, etag, type, contentType = 'application/json'}) {
+  POST({url, apiVersion, timeout = mrequest.timeout, payload, etag, type, contentType = 'application/json'}) {
     return makeRequest({method: 'POST', url, apiVersion, timeout, type, payload, etag, contentType});
-  }
+  },
 
-  static PATCH({url, apiVersion, timeout = mrequest.timeout, payload, type, etag, contentType = 'application/json'}) {
+  PATCH({url, apiVersion, timeout = mrequest.timeout, payload, type, etag, contentType = 'application/json'}) {
     return makeRequest({method: 'PATCH', url, apiVersion, timeout, payload, type, etag, contentType});
-  }
+  },
 
-  static DELETE({url, apiVersion, type, timeout = mrequest.timeout, etag} = {}) {
+  DELETE({url, apiVersion, type, timeout = mrequest.timeout, etag} = {}) {
     return makeRequest({method: 'DELETE', url, apiVersion, type, timeout, etag});
   }
 };
-
-

--- a/server/webapp/WEB-INF/rails/webpack/helpers/ajax_helper.js
+++ b/server/webapp/WEB-INF/rails/webpack/helpers/ajax_helper.js
@@ -68,6 +68,10 @@ module.exports = class AjaxHelper {
   static PATCH({url, apiVersion, timeout = mrequest.timeout, payload, type, etag, contentType = 'application/json'}) {
     return makeRequest({method: 'PATCH', url, apiVersion, timeout, payload, type, etag, contentType});
   }
+
+  static DELETE({url, apiVersion, type, timeout = mrequest.timeout, etag} = {}) {
+    return makeRequest({method: 'DELETE', url, apiVersion, type, timeout, etag});
+  }
 };
 
 

--- a/server/webapp/WEB-INF/rails/webpack/helpers/api_helper.js
+++ b/server/webapp/WEB-INF/rails/webpack/helpers/api_helper.js
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2018 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const AjaxHelper = require("helpers/ajax_helper");
+const parseError = require("helpers/mrequest").unwrapErrorExtractMessage;
+const Dfr        = require("jquery").Deferred;
+
+/** This helper parses data, etags, and errors for a convenient API */
+function req(exec) {
+  return Dfr(function ajax() {
+    const success = (data, _s, xhr) => this.resolve(data, parseEtag(xhr), xhr.status);
+    const failure = (xhr) => this.reject(parseError(xhr.responseJSON, xhr));
+
+    exec().then(success, failure);
+  }).promise();
+}
+
+function parseEtag(req) { return (req.getResponseHeader("ETag") || "").replace(/--(gzip|deflate)/, ""); }
+
+const ApiHelper = {};
+
+for (const key in AjaxHelper) {
+  ApiHelper[key] = (config) => req(() => AjaxHelper[key](config));
+}
+
+module.exports = ApiHelper;

--- a/server/webapp/WEB-INF/rails/webpack/models/config_repos/config_repos.js
+++ b/server/webapp/WEB-INF/rails/webpack/models/config_repos/config_repos.js
@@ -20,6 +20,7 @@ const Stream     = require('mithril/stream');
 
 function ConfigRepos() {
   const etag = Stream("");
+  this.etag = etag;
 
   this.all = () => {
     const promise = AjaxHelper.GET({

--- a/server/webapp/WEB-INF/rails/webpack/models/config_repos/config_repos.js
+++ b/server/webapp/WEB-INF/rails/webpack/models/config_repos/config_repos.js
@@ -16,12 +16,12 @@
 
 const AjaxHelper = require('helpers/ajax_helper');
 const Routes     = require('gen/js-routes');
-const Stream     = require('mithril/stream')
+const Stream     = require('mithril/stream');
 
 function ConfigRepos() {
   const etag = Stream("");
 
-  this.load = () => {
+  this.all = () => {
     const promise = AjaxHelper.GET({
       url: Routes.apiv1AdminConfigReposPath(),
       apiVersion: "v1",
@@ -31,12 +31,16 @@ function ConfigRepos() {
     return promise;
   };
 
-  this.getSingle
+  this.get = (etag, id) => AjaxHelper.GET({
+    url: Routes.apiv1AdminConfigRepoPath(id),
+    apiVersion: "v1",
+    etag,
+  });
 
-  this.update = (payload) => AjaxHelper.PUT({
+  this.update = (etag, payload) => AjaxHelper.PUT({
     url: Routes.apiv1AdminConfigRepoPath(payload.id),
     apiVersion: "v1",
-    etag: etag(),
+    etag,
     payload
   });
 }

--- a/server/webapp/WEB-INF/rails/webpack/models/config_repos/config_repos.js
+++ b/server/webapp/WEB-INF/rails/webpack/models/config_repos/config_repos.js
@@ -43,6 +43,11 @@ function ConfigRepos() {
     etag,
     payload
   });
+
+  this.delete = (id) => AjaxHelper.DELETE({
+    url: Routes.apiv1AdminConfigRepoPath(id),
+    apiVersion: "v1"
+  });
 }
 
 function parseEtag(req) { return (req.getResponseHeader("ETag") || "").replace(/--(gzip|deflate)/, ""); }

--- a/server/webapp/WEB-INF/rails/webpack/models/config_repos/config_repos.js
+++ b/server/webapp/WEB-INF/rails/webpack/models/config_repos/config_repos.js
@@ -14,61 +14,48 @@
  * limitations under the License.
  */
 
-const AjaxHelper = require("helpers/ajax_helper");
-const Routes     = require("gen/js-routes");
-const Stream     = require("mithril/stream");
-const parseError = require("helpers/mrequest").unwrapErrorExtractMessage;
-const Dfr        = require("jquery").Deferred;
+const ApiHelper = require("helpers/api_helper");
+const Routes    = require("gen/js-routes");
+const Stream    = require("mithril/stream");
 
 function ConfigRepos() {
   this.etag = Stream("");
 
   this.all = () => {
-    const promise = req(() => AjaxHelper.GET({
+    const promise = ApiHelper.GET({
       url: Routes.apiv1AdminConfigReposPath(),
       apiVersion: "v1",
       etag: this.etag()
-    }));
+    });
 
     promise.then((_d, etag) => this.etag(etag));
 
     return promise;
   };
 
-  this.get = (etag, id) => req(() => AjaxHelper.GET({
+  this.get = (etag, id) => ApiHelper.GET({
     url: Routes.apiv1AdminConfigRepoPath(id),
     apiVersion: "v1",
     etag
-  }));
+  });
 
-  this.update = (etag, payload) => req(() => AjaxHelper.PUT({
+  this.update = (etag, payload) => ApiHelper.PUT({
     url: Routes.apiv1AdminConfigRepoPath(payload.id),
     apiVersion: "v1",
     etag,
     payload
-  }));
+  });
 
-  this.delete = (id) => req(() => AjaxHelper.DELETE({
+  this.delete = (id) => ApiHelper.DELETE({
     url: Routes.apiv1AdminConfigRepoPath(id),
     apiVersion: "v1"
-  }));
+  });
 
-  this.create = (payload) => req(() => AjaxHelper.POST({
+  this.create = (payload) => ApiHelper.POST({
     url: Routes.apiv1AdminConfigReposPath(),
     apiVersion: "v1",
     payload
-  }));
+  });
 }
-
-function req(exec) {
-  return Dfr(function run() {
-    const success = (data, _s, xhr) => this.resolve(data, parseEtag(xhr), xhr.status);
-    const failure = (xhr) => this.reject(parseError(JSON.parse(xhr.responseText), xhr));
-
-    exec().then(success, failure);
-  }).promise();
-}
-
-function parseEtag(req) { return (req.getResponseHeader("ETag") || "").replace(/--(gzip|deflate)/, ""); }
 
 module.exports = ConfigRepos;

--- a/server/webapp/WEB-INF/rails/webpack/models/config_repos/config_repos.js
+++ b/server/webapp/WEB-INF/rails/webpack/models/config_repos/config_repos.js
@@ -14,29 +14,33 @@
  * limitations under the License.
  */
 
-const Stream     = require('mithril/stream');
 const AjaxHelper = require('helpers/ajax_helper');
-const AjaxPoller = require('helpers/ajax_poller');
 const Routes     = require('gen/js-routes');
+const Stream     = require('mithril/stream')
 
 function ConfigRepos() {
-  const repos = Stream([]);
+  const etag = Stream("");
 
-  this.refresh = () => AjaxHelper.GET({
-    url: Routes.apiv1AdminConfigReposPath(),
-    apiVersion: "v1",
-    etag: "blah"
-  }).then((data) => {
-    repos(data._embedded.config_repos);
-  });
-
-  this.repos = repos;
-  const poller = new AjaxPoller(() => this.refresh());
-
-  this.start = () => {
-    poller.start();
-    return this;
+  this.load = () => {
+    const promise = AjaxHelper.GET({
+      url: Routes.apiv1AdminConfigReposPath(),
+      apiVersion: "v1",
+      etag: etag()
+    });
+    promise.then((_d, _s, req) => etag(parseEtag(req)));
+    return promise;
   };
+
+  this.getSingle
+
+  this.update = (payload) => AjaxHelper.PUT({
+    url: Routes.apiv1AdminConfigRepoPath(payload.id),
+    apiVersion: "v1",
+    etag: etag(),
+    payload
+  });
 }
+
+function parseEtag(req) { return (req.getResponseHeader("ETag") || "").replace(/--(gzip|deflate)/, ""); }
 
 module.exports = ConfigRepos;

--- a/server/webapp/WEB-INF/rails/webpack/models/config_repos/config_repos.js
+++ b/server/webapp/WEB-INF/rails/webpack/models/config_repos/config_repos.js
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-const AjaxHelper = require('helpers/ajax_helper');
-const Routes     = require('gen/js-routes');
-const Stream     = require('mithril/stream');
+const AjaxHelper = require("helpers/ajax_helper");
+const Routes     = require("gen/js-routes");
+const Stream     = require("mithril/stream");
 
 function ConfigRepos() {
   const etag = Stream("");

--- a/server/webapp/WEB-INF/rails/webpack/models/config_repos/config_repos.js
+++ b/server/webapp/WEB-INF/rails/webpack/models/config_repos/config_repos.js
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2018 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const Stream     = require('mithril/stream');
+const AjaxHelper = require('helpers/ajax_helper');
+const AjaxPoller = require('helpers/ajax_poller');
+const Routes     = require('gen/js-routes');
+
+function ConfigRepos() {
+  const repos = Stream([]);
+
+  this.refresh = () => AjaxHelper.GET({
+    url: Routes.apiv1AdminConfigReposPath(),
+    apiVersion: "v1",
+    etag: "blah"
+  }).then((data) => {
+    repos(data._embedded.config_repos);
+  });
+
+  this.repos = repos;
+  const poller = new AjaxPoller(() => this.refresh());
+
+  this.start = () => {
+    poller.start();
+    return this;
+  };
+}
+
+module.exports = ConfigRepos;

--- a/server/webapp/WEB-INF/rails/webpack/models/config_repos/config_repos.js
+++ b/server/webapp/WEB-INF/rails/webpack/models/config_repos/config_repos.js
@@ -48,6 +48,13 @@ function ConfigRepos() {
     url: Routes.apiv1AdminConfigRepoPath(id),
     apiVersion: "v1"
   });
+
+  this.create = (payload) => AjaxHelper.POST({
+    url: Routes.apiv1AdminConfigReposPath(),
+    apiVersion: "v1",
+    payload
+  });
+
 }
 
 function parseEtag(req) { return (req.getResponseHeader("ETag") || "").replace(/--(gzip|deflate)/, ""); }

--- a/server/webapp/WEB-INF/rails/webpack/models/config_repos/config_repos.js
+++ b/server/webapp/WEB-INF/rails/webpack/models/config_repos/config_repos.js
@@ -34,7 +34,7 @@ function ConfigRepos() {
   this.get = (etag, id) => AjaxHelper.GET({
     url: Routes.apiv1AdminConfigRepoPath(id),
     apiVersion: "v1",
-    etag,
+    etag
   });
 
   this.update = (etag, payload) => AjaxHelper.PUT({

--- a/server/webapp/WEB-INF/rails/webpack/models/config_repos/field.js
+++ b/server/webapp/WEB-INF/rails/webpack/models/config_repos/field.js
@@ -17,7 +17,7 @@
 const _ = require("lodash");
 
 function Field(name, options={}) {
-  const DEFAULTS = {display: _.startCase(name), type: "text", default: "", readOnly: false};
+  const DEFAULTS = {display: _.startCase(name), type: "text", default: "", required: true, readOnly: false};
   options = _.assign({}, DEFAULTS, options);
 
   this.keys = (this.keys || []);

--- a/server/webapp/WEB-INF/rails/webpack/models/config_repos/field.js
+++ b/server/webapp/WEB-INF/rails/webpack/models/config_repos/field.js
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2018 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const _ = require("lodash");
+
+function Field(name, options={}) {
+  const DEFAULTS = {display: _.startCase(name), type: "text", default: ""};
+  options = _.assign({}, DEFAULTS, options);
+
+  this.keys = (this.keys || []);
+
+  if (contains(this.keys, name)) {
+    this.keys.push(name);
+  } else {
+    console.warn(`The key ${name} has already been defined on this object`); // eslint-disable-line no-console
+  }
+
+  let value;
+
+  function attr(val) {
+    if (arguments.length) {
+      value = normalize(val, options);
+    }
+
+    return value;
+  }
+
+  this[name] = attr;
+
+  attr.init = function (val) {
+    if (options.type === "boolean") {
+      if ("boolean" !== typeof val) {
+        return attr(options.default);
+      }
+    }
+
+    if ("undefined" === typeof val || null === val) {
+      val = options.default;
+    }
+    return attr(val);
+  };
+
+  _.assign(this[name], options);
+}
+
+function contains(arr, el) { return !~arr.indexOf(el); }
+
+function normalize(val, options) {
+  if ("boolean" === options.type) { return !!val; }
+  return String(val || "").trim();
+}
+
+module.exports = Field;

--- a/server/webapp/WEB-INF/rails/webpack/models/config_repos/field.js
+++ b/server/webapp/WEB-INF/rails/webpack/models/config_repos/field.js
@@ -42,14 +42,13 @@ function Field(name, options={}) {
 
   attr.init = function (val) {
     if (options.type === "boolean") {
-      if ("boolean" !== typeof val) {
-        return attr(options.default);
-      }
+      return attr("boolean" === typeof val ? val : options.default);
     }
 
     if ("undefined" === typeof val || null === val) {
       val = options.default;
     }
+
     return attr(`${val}`);
   };
 
@@ -60,7 +59,7 @@ function contains(arr, el) { return !~arr.indexOf(el); }
 
 function normalize(val, options) {
   if ("boolean" === options.type) { return !!val; }
-  return String(val || "").trim();
+  return ("string" === typeof val ? val : String(val || "")).trim();
 }
 
 module.exports = Field;

--- a/server/webapp/WEB-INF/rails/webpack/models/config_repos/field.js
+++ b/server/webapp/WEB-INF/rails/webpack/models/config_repos/field.js
@@ -50,7 +50,7 @@ function Field(name, options={}) {
     if ("undefined" === typeof val || null === val) {
       val = options.default;
     }
-    return attr("" + val);
+    return attr(`${val}`);
   };
 
   _.assign(this[name], options);

--- a/server/webapp/WEB-INF/rails/webpack/models/config_repos/field.js
+++ b/server/webapp/WEB-INF/rails/webpack/models/config_repos/field.js
@@ -50,7 +50,7 @@ function Field(name, options={}) {
     if ("undefined" === typeof val || null === val) {
       val = options.default;
     }
-    return attr(val);
+    return attr("" + val);
   };
 
   _.assign(this[name], options);

--- a/server/webapp/WEB-INF/rails/webpack/models/config_repos/field.js
+++ b/server/webapp/WEB-INF/rails/webpack/models/config_repos/field.js
@@ -17,7 +17,7 @@
 const _ = require("lodash");
 
 function Field(name, options={}) {
-  const DEFAULTS = {display: _.startCase(name), type: "text", default: ""};
+  const DEFAULTS = {display: _.startCase(name), type: "text", default: "", readOnly: false};
   options = _.assign({}, DEFAULTS, options);
 
   this.keys = (this.keys || []);
@@ -52,7 +52,7 @@ function Field(name, options={}) {
     return attr(`${val}`);
   };
 
-  _.assign(this[name], options);
+  attr.opts = (key) => options[key];
 }
 
 function contains(arr, el) { return !~arr.indexOf(el); }

--- a/server/webapp/WEB-INF/rails/webpack/models/config_repos/materials.js
+++ b/server/webapp/WEB-INF/rails/webpack/models/config_repos/materials.js
@@ -17,6 +17,7 @@
 const _           = require("lodash");
 const Field       = require("models/config_repos/field");
 const Validatable = require("models/mixins/validatable_mixin");
+const fmt         = Validatable.DefaultOptions.forId;
 
 const Materials = {
   get(type, data) {
@@ -31,8 +32,6 @@ const Materials = {
         return new P4Material(data);
       case "tfs":
         return new TfsMaterial(data);
-      case "package":
-        return new PackageMaterial(data);
       default:
         throw new Error(`Unknown material type: ${type}`);
     }
@@ -55,7 +54,8 @@ function Common(data) {
       }
 
       if (this[key].opts("format")) {
-        this.validateFormatOf(key, {format: this[key].opts("format")});
+        const format = this[key].opts("format");
+        this.validateFormatOf(key, format instanceof RegExp ? { format } : format);
       }
     });
   };
@@ -71,64 +71,66 @@ function Common(data) {
 }
 
 function GitMaterial(data) {
-  Field.call(this, "name", {display: "Material name", required: false});
+  BaseFields.call(this);
+
   Field.call(this, "url");
   Field.call(this, "branch", {default: "master"});
-  Field.call(this, "auto_update", {display: "Auto-update changes", type: "boolean", default: true});
 
   Common.call(this, data);
 }
 
 function HgMaterial (data) {
-  Field.call(this, "name", {display: "Material name", required: false});
+  BaseFields.call(this);
+
   Field.call(this, "url");
-  Field.call(this, "auto_update", {display: "Auto-update changes", type: "boolean", default: true});
 
   Common.call(this, data);
 }
 
 function SvnMaterial (data) {
-  Field.call(this, "name", {display: "Material name", required: false});
+  BaseFields.call(this);
+
   Field.call(this, "url");
-  Field.call(this, "username", {required: false});
-  Field.call(this, "password", {type: "secret", required: false});
-  Field.call(this, "encrypted_password", {display: "Encrypted password", type: "secret", required: false});
-  Field.call(this, "auto_update", {display: "Auto-update changes", type: "boolean", default: true});
   Field.call(this, "check_externals", {display: "Check externals", type: "boolean", default: true});
+
+  AuthFields.call(this);
 
   Common.call(this, data);
 }
 
 function P4Material (data) {
-  Field.call(this, "name", {display: "Material name", required: false});
+  BaseFields.call(this);
+
   Field.call(this, "port");
   Field.call(this, "use_tickets", {display: "Use tickets", type: "boolean", default: false});
   Field.call(this, "view");
-  Field.call(this, "auto_update", {display: "Auto-update changes", type: "boolean", default: true});
-  Field.call(this, "username", {required: false});
-  Field.call(this, "password", {type: "secret", required: false});
-  Field.call(this, "encrypted_password", {display: "Encrypted Password", type: "secret", required: false});
+
+  AuthFields.call(this);
 
   Common.call(this, data);
 }
 
 function TfsMaterial (data) {
-  Field.call(this, "name", {display: "Material name", required: false});
+  BaseFields.call(this);
+
   Field.call(this, "url");
   Field.call(this, "project_path", {display: "Project path"});
   Field.call(this, "domain");
-  Field.call(this, "auto_update", {display: "Auto-update changes", type: "boolean", default: true});
-  Field.call(this, "username", {required: false});
-  Field.call(this, "password", {type: "secret", required: false});
-  Field.call(this, "encrypted_password", {display: "Encrypted password", type: "secret", required: false});
+
+  AuthFields.call(this);
 
   Common.call(this, data);
 }
 
-function PackageMaterial (data) {
-  Field.call(this, "ref");
+function BaseFields() {
+  Field.call(this, "name", {display: "Material name", required: false, format: fmt("Name")});
+  Field.call(this, "auto_update", {display: "Auto-update changes", type: "boolean", default: true, readOnly: true});
+}
 
-  Common.call(this, data);
+function AuthFields() {
+  Field.call(this, "username", {required: false});
+  Field.call(this, "password", {type: "secret", required: false});
+  Field.call(this, "encrypted_password", {display: "Encrypted password", type: "secret", required: false});
 }
 
 Materials.Field = Field;

--- a/server/webapp/WEB-INF/rails/webpack/models/config_repos/materials.js
+++ b/server/webapp/WEB-INF/rails/webpack/models/config_repos/materials.js
@@ -38,37 +38,7 @@ const Materials = {
   }
 };
 
-function Common(data) {
-  Validatable.call(this, { errors: {} });
-
-  this.keys = (this.keys || []);
-
-  this.initialize = (data) => {
-    data = _.get(data, "material.attributes", {});
-
-    _.each(this.keys, (key) => {
-      this[key].init(data[key]);
-
-      if (this[key].opts("required")) {
-        this.validatePresenceOf(key);
-      }
-
-      if (this[key].opts("format")) {
-        const format = this[key].opts("format");
-        this.validateFormatOf(key, format instanceof RegExp ? { format } : format);
-      }
-    });
-  };
-
-  this.toJSON = () => _.reduce(this.keys, (memo, k) => {
-    memo[k] = this[k]();
-    return memo;
-  }, {});
-
-  this.clone = () => new this.constructor(data);
-
-  this.initialize(data);
-}
+// Instances
 
 function GitMaterial(data) {
   BaseFields.call(this);
@@ -120,6 +90,40 @@ function TfsMaterial (data) {
   AuthFields.call(this);
 
   Common.call(this, data);
+}
+
+// Mixins
+
+function Common(data) {
+  Validatable.call(this, { errors: {} });
+
+  this.keys = (this.keys || []);
+
+  this.initialize = (data) => {
+    data = _.get(data, "material.attributes", {});
+
+    _.each(this.keys, (key) => {
+      this[key].init(data[key]);
+
+      if (this[key].opts("required")) {
+        this.validatePresenceOf(key);
+      }
+
+      if (this[key].opts("format")) {
+        const format = this[key].opts("format");
+        this.validateFormatOf(key, format instanceof RegExp ? { format } : format);
+      }
+    });
+  };
+
+  this.toJSON = () => _.reduce(this.keys, (memo, k) => {
+    memo[k] = this[k]();
+    return memo;
+  }, {});
+
+  this.clone = () => new this.constructor(data);
+
+  this.initialize(data);
 }
 
 function BaseFields() {

--- a/server/webapp/WEB-INF/rails/webpack/models/config_repos/materials.js
+++ b/server/webapp/WEB-INF/rails/webpack/models/config_repos/materials.js
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2018 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const stream = require("mithril/stream");
+const _ = require("lodash");
+
+const Materials = {
+  get(type, data) {
+    switch(type) {
+      case "git":
+        return new GitMaterial(data);
+      case "hg":
+        return new HgMaterial(data);
+    }
+  }
+};
+
+function GitMaterial (data) {
+  const DEFAULTS = {name: "", url: "", auto_update: true, branch: "master"}; // eslint-disable-line camelcase
+  const attrs = _.assign(DEFAULTS, _.get(data, "material.attributes", {}));
+
+  this.name = stream(attrs.name);
+  this.url = stream(attrs.url);
+  this.branch = stream(attrs.branch);
+  this.auto_update = stream(attrs.auto_update); // eslint-disable-line camelcase
+}
+
+function HgMaterial (data) {
+  const DEFAULTS = {name: "", url: "", auto_update: true}; // eslint-disable-line camelcase
+  const attrs = _.assign(DEFAULTS, _.get(data, "material.attributes", {}));
+
+  this.name = stream(attrs.name);
+  this.url = stream(attrs.url);
+  this.auto_update = stream(attrs.auto_update); // eslint-disable-line camelcase
+}
+
+
+module.exports = Materials;

--- a/server/webapp/WEB-INF/rails/webpack/models/config_repos/materials.js
+++ b/server/webapp/WEB-INF/rails/webpack/models/config_repos/materials.js
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-const _ = require("lodash");
+const _     = require("lodash");
+const Field = require("models/config_repos/field");
 
 const Materials = {
   get(type, data) {
@@ -37,42 +38,6 @@ const Materials = {
   }
 };
 
-function Field(name, options={}) {
-  const DEFAULTS = {display: _.startCase(name), required: true, type: "text", default: ""};
-  options = _.assign({}, DEFAULTS, options);
-
-  this.keys = (this.keys || []);
-
-  if (this.keys.indexOf(name) === -1) {
-    this.keys.push(name);
-  } else {
-    console.warn(`The key ${name} has already been defined on this object`); // eslint-disable-line no-console
-  }
-
-  let value;
-
-  this[name] = function attr(val) {
-    if (arguments.length) {
-      if ("undefined" !== typeof val) {
-        if (options.type === "boolean") {
-          val = !!val;
-        }
-
-        value = val;
-      } else {
-        if (options.required) {
-          new Error(`${name} is a required field`);
-        }
-        value = options.default;
-      }
-    }
-
-    return value;
-  };
-
-  _.assign(this[name], options);
-}
-
 function Common(data) {
   this.keys = (this.keys || []);
 
@@ -80,7 +45,7 @@ function Common(data) {
     data = _.get(data, "material.attributes", {});
 
     _.each(this.keys, (key) => {
-      this[key](data[key]);
+      this[key].init(data[key]);
     });
   };
 

--- a/server/webapp/WEB-INF/rails/webpack/models/config_repos/materials.js
+++ b/server/webapp/WEB-INF/rails/webpack/models/config_repos/materials.js
@@ -38,9 +38,8 @@ const Materials = {
 };
 
 function Field(name, options={}) {
-  const DEFAULTS = {required: true, type: "text", default: ""};
+  const DEFAULTS = {display: _.startCase(name), required: true, type: "text", default: ""};
   options = _.assign({}, DEFAULTS, options);
-  options.display = options.display || _.startCase(name);
 
   this.keys = (this.keys || []);
 
@@ -52,7 +51,7 @@ function Field(name, options={}) {
 
   let value;
 
-  function attr(val) {
+  this[name] = function attr(val) {
     if (arguments.length) {
       if ("undefined" !== typeof val) {
         if (options.type === "boolean") {
@@ -69,18 +68,18 @@ function Field(name, options={}) {
     }
 
     return value;
-  }
-
-  this[name] = attr;
+  };
 
   _.assign(this[name], options);
 }
 
 function Common(data) {
-  this.consume = (data) => {
+  this.keys = (this.keys || []);
+
+  this.initialize = (data) => {
     data = _.get(data, "material.attributes", {});
 
-    this.keys.forEach((key) => {
+    _.each(this.keys, (key) => {
       this[key](data[key]);
     });
   };
@@ -90,8 +89,9 @@ function Common(data) {
     return memo;
   }, {});
 
-  this.consume(data);
   this.clone = () => new this.constructor(data);
+
+  this.initialize(data);
 }
 
 function GitMaterial(data) {

--- a/server/webapp/WEB-INF/rails/webpack/models/config_repos/materials.js
+++ b/server/webapp/WEB-INF/rails/webpack/models/config_repos/materials.js
@@ -14,8 +14,9 @@
  * limitations under the License.
  */
 
-const _     = require("lodash");
-const Field = require("models/config_repos/field");
+const _           = require("lodash");
+const Field       = require("models/config_repos/field");
+const Validatable = require("models/mixins/validatable_mixin");
 
 const Materials = {
   get(type, data) {
@@ -39,6 +40,8 @@ const Materials = {
 };
 
 function Common(data) {
+  Validatable.call(this, { errors: {} });
+
   this.keys = (this.keys || []);
 
   this.initialize = (data) => {
@@ -46,6 +49,14 @@ function Common(data) {
 
     _.each(this.keys, (key) => {
       this[key].init(data[key]);
+
+      if (this[key].opts("required")) {
+        this.validatePresenceOf(key);
+      }
+
+      if (this[key].opts("format")) {
+        this.validateFormatOf(key, {format: this[key].opts("format")});
+      }
     });
   };
 
@@ -60,7 +71,7 @@ function Common(data) {
 }
 
 function GitMaterial(data) {
-  Field.call(this, "name", {display: "Material Name"});
+  Field.call(this, "name", {display: "Material name", required: false});
   Field.call(this, "url");
   Field.call(this, "branch", {default: "master"});
   Field.call(this, "auto_update", {display: "Auto-update changes", type: "boolean", default: true});
@@ -69,7 +80,7 @@ function GitMaterial(data) {
 }
 
 function HgMaterial (data) {
-  Field.call(this, "name", {display: "Material Name"});
+  Field.call(this, "name", {display: "Material name", required: false});
   Field.call(this, "url");
   Field.call(this, "auto_update", {display: "Auto-update changes", type: "boolean", default: true});
 
@@ -77,39 +88,39 @@ function HgMaterial (data) {
 }
 
 function SvnMaterial (data) {
-  Field.call(this, "name", {display: "Material Name"});
+  Field.call(this, "name", {display: "Material name", required: false});
   Field.call(this, "url");
-  Field.call(this, "username");
-  Field.call(this, "password", {type: "secret"});
-  Field.call(this, "encrypted_password", {display: "Encrypted Password", type: "secret"});
+  Field.call(this, "username", {required: false});
+  Field.call(this, "password", {type: "secret", required: false});
+  Field.call(this, "encrypted_password", {display: "Encrypted password", type: "secret", required: false});
   Field.call(this, "auto_update", {display: "Auto-update changes", type: "boolean", default: true});
-  Field.call(this, "check_externals", {display: "Check Externals", type: "boolean", default: true});
+  Field.call(this, "check_externals", {display: "Check externals", type: "boolean", default: true});
 
   Common.call(this, data);
 }
 
 function P4Material (data) {
-  Field.call(this, "name", {display: "Material Name"});
+  Field.call(this, "name", {display: "Material name", required: false});
   Field.call(this, "port");
-  Field.call(this, "use_tickets", {display: "Use Tickets", type: "boolean", default: false});
+  Field.call(this, "use_tickets", {display: "Use tickets", type: "boolean", default: false});
   Field.call(this, "view");
   Field.call(this, "auto_update", {display: "Auto-update changes", type: "boolean", default: true});
-  Field.call(this, "username");
-  Field.call(this, "password", {type: "secret"});
-  Field.call(this, "encrypted_password", {display: "Encrypted Password", type: "secret"});
+  Field.call(this, "username", {required: false});
+  Field.call(this, "password", {type: "secret", required: false});
+  Field.call(this, "encrypted_password", {display: "Encrypted Password", type: "secret", required: false});
 
   Common.call(this, data);
 }
 
 function TfsMaterial (data) {
-  Field.call(this, "name", {display: "Material Name"});
+  Field.call(this, "name", {display: "Material name", required: false});
   Field.call(this, "url");
-  Field.call(this, "project_path", {display: "Project Path"});
+  Field.call(this, "project_path", {display: "Project path"});
   Field.call(this, "domain");
   Field.call(this, "auto_update", {display: "Auto-update changes", type: "boolean", default: true});
-  Field.call(this, "username");
-  Field.call(this, "password", {type: "secret"});
-  Field.call(this, "encrypted_password", {display: "Encrypted Password", type: "secret"});
+  Field.call(this, "username", {required: false});
+  Field.call(this, "password", {type: "secret", required: false});
+  Field.call(this, "encrypted_password", {display: "Encrypted password", type: "secret", required: false});
 
   Common.call(this, data);
 }
@@ -119,5 +130,8 @@ function PackageMaterial (data) {
 
   Common.call(this, data);
 }
+
+Materials.Field = Field;
+Materials.Common = Common;
 
 module.exports = Materials;

--- a/server/webapp/WEB-INF/rails/webpack/models/mixins/errors.js
+++ b/server/webapp/WEB-INF/rails/webpack/models/mixins/errors.js
@@ -14,8 +14,9 @@
  * limitations under the License.
  */
 
-const _      = require('lodash');
-const s      = require('string-plus');
+const _ = require("lodash");
+const s = require("string-plus");
+
 const Errors = function(errors = {}) {
   this.add = (attrName, message) => {
     errors[attrName] = errors[attrName] || [];

--- a/server/webapp/WEB-INF/rails/webpack/models/mixins/validatable_mixin.js
+++ b/server/webapp/WEB-INF/rails/webpack/models/mixins/validatable_mixin.js
@@ -63,7 +63,7 @@ const FormatValidator = function({format, message}) {
     }
 
     if (!entity[attr]().match(format)) {
-      entity.errors().add(attr, message || (`${s.humanize(attr)} format is in valid`));
+      entity.errors().add(attr, message || `${s.humanize(attr)} format is invalid`);
     }
   };
 };

--- a/server/webapp/WEB-INF/rails/webpack/models/mixins/validatable_mixin.js
+++ b/server/webapp/WEB-INF/rails/webpack/models/mixins/validatable_mixin.js
@@ -18,31 +18,31 @@ const _                 = require('lodash');
 const s                 = require('string-plus');
 const Errors            = require('models/mixins/errors');
 const Mixins            = require('models/mixins/model_mixins');
-const PresenceValidator = function (options) {
+const PresenceValidator = function ({condition, message}) {
   this.validate = (entity, attr) => {
-    if (options.condition && (!options.condition(entity))) {
+    if (condition && (!condition(entity))) {
       return;
     }
 
     if (s.isBlank(entity[attr]())) {
-      entity.errors().add(attr, Validatable.ErrorMessages.mustBePresent(attr));
+      entity.errors().add(attr, message || Validatable.ErrorMessages.mustBePresent(attr));
     }
   };
 };
 
-const UniquenessValidator = function () {
+const UniquenessValidator = function ({message}) {
   this.validate = (entity, attr) => {
     if (_.isNil(entity.parent()) || s.isBlank(entity[attr]())) {
       return;
     }
 
     if (!entity.parent().isUnique(entity, attr)) {
-      entity.errors().add(attr, Validatable.ErrorMessages.duplicate(attr));
+      entity.errors().add(attr, message || Validatable.ErrorMessages.duplicate(attr));
     }
   };
 };
 
-const UrlPatternValidator = function () {
+const UrlPatternValidator = function ({message}) {
   const URL_REGEX = /^http(s)?:\/\/.+/;
 
   this.validate = (entity, attr) => {
@@ -51,7 +51,7 @@ const UrlPatternValidator = function () {
     }
 
     if (!entity[attr]().match(URL_REGEX)) {
-      entity.errors().add(attr, Validatable.ErrorMessages.mustBeAUrl(attr));
+      entity.errors().add(attr, message || Validatable.ErrorMessages.mustBeAUrl(attr));
     }
   };
 };
@@ -82,20 +82,20 @@ const Validatable = function({errors}) {
     attr ? self.errors().clear(attr) : self.errors().clear();
   };
 
-  self.validatePresenceOf = (attr, options) => {
-    validateWith(new PresenceValidator(options || {}), attr);
+  self.validatePresenceOf = (attr, options={}) => {
+    validateWith(new PresenceValidator(options), attr);
   };
 
-  self.validateUniquenessOf = (attr, options) => {
-    validateWith(new UniquenessValidator(options || {}), attr);
+  self.validateUniquenessOf = (attr, options={}) => {
+    validateWith(new UniquenessValidator(options), attr);
   };
 
-  self.validateFormatOf = (attr, options) => {
-    validateWith(new FormatValidator(options || {}), attr);
+  self.validateFormatOf = (attr, options={}) => {
+    validateWith(new FormatValidator(options), attr);
   };
 
-  self.validateUrlPattern = (attr, options) => {
-    validateWith(new UrlPatternValidator(options || {}), attr);
+  self.validateUrlPattern = (attr, options={}) => {
+    validateWith(new UrlPatternValidator(options), attr);
   };
 
   self.validateWith = (attr, validator) => {

--- a/server/webapp/WEB-INF/rails/webpack/single_page_apps/config_repos.js
+++ b/server/webapp/WEB-INF/rails/webpack/single_page_apps/config_repos.js
@@ -17,12 +17,13 @@
 const m = require("mithril");
 const ReposList = require("views/config_repos/config_repos_list");
 const ReposModel = require("models/config_repos/config_repos");
+const ReposVM = require("views/config_repos/models/config_repos_vm");
 
-const model = new ReposModel().start();
+const vm = new ReposVM(new ReposModel()).fetchReposData();
 
 const ConfigReposPage = {
   view() {
-    return m(ReposList, {model});
+    return m(ReposList, {vm});
   }
 };
 

--- a/server/webapp/WEB-INF/rails/webpack/single_page_apps/config_repos.js
+++ b/server/webapp/WEB-INF/rails/webpack/single_page_apps/config_repos.js
@@ -19,7 +19,7 @@ const ReposList = require("views/config_repos/config_repos_list");
 const ReposModel = require("models/config_repos/config_repos");
 const ReposVM = require("views/config_repos/models/config_repos_vm");
 
-const vm = new ReposVM(new ReposModel()).fetchReposData();
+const vm = new ReposVM(new ReposModel()).load();
 
 const ConfigReposPage = {
   view() {

--- a/server/webapp/WEB-INF/rails/webpack/single_page_apps/config_repos.js
+++ b/server/webapp/WEB-INF/rails/webpack/single_page_apps/config_repos.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-const m = require("mithril");
+const m               = require("mithril");
 const ConfigReposPage = require("views/pages/config_repos");
 
 window.addEventListener("DOMContentLoaded", () => {

--- a/server/webapp/WEB-INF/rails/webpack/views/config_repos/config_repos_list.js.msx
+++ b/server/webapp/WEB-INF/rails/webpack/views/config_repos/config_repos_list.js.msx
@@ -23,7 +23,8 @@ const ReposList = {
     const vm = vnode.attrs.vm;
 
     return <section class="repo-list">
-      <h1>Config Header</h1>
+      <h1>Config Repos</h1>
+      <AddRepo vm={vm}/>
       <ul>
       {
         vm.repos().map((repo) => {
@@ -35,6 +36,43 @@ const ReposList = {
   }
 };
 
+const AddRepo = {
+  view(vnode) {
+    const vm = vnode.attrs.vm;
+
+    if (vm.addMode()) {
+      return <AddForm vm={vm.addModel()}/>;
+    } else {
+      return <div>
+        <f.select model={vm} attrName="typeToAdd" items={vm.availMaterials} />
+        <button onclick={() => vm.enterAddMode()}>Add Repo</button>
+      </div>;
+    }
+  }
+};
+
+const AddForm = {
+  view(vnode) {
+    const vm = vnode.attrs.vm;
+    const pluginChoices = [
+    { id: "json.config.plugin", text: "GoCD JSON Config Plugin" },
+    { id: "yaml.config.plugin", text: "GoCD YAML Config Plugin" }
+    ];
+    return <div>
+    <f.select label="Choose a plugin" model={vm} attrName="pluginId" items={pluginChoices} />
+    <f.input label="Config Repo ID" model={vm} attrName="id"/>
+    {_.map(vm.attributes(), (v, k) =>
+        m("boolean" === typeof v() ? f.checkbox : f.input, {
+          model: vm.attributes(),
+          attrName: k,
+          label: k
+        })
+      )
+    }
+  </div>;
+  }
+};
+
 const ConfigRepo = {
   view(vnode) {
     const vm = vnode.attrs.vm;
@@ -43,7 +81,7 @@ const ConfigRepo = {
       <h3>{vm.type()} repo: {vm.id()}</h3>
       <h5>Plugin: {vm.pluginId()}</h5>
       <ActionBar vm={vm}/>
-      <GitRepo vm={vm}/>
+      <MaterialAttributes vm={vm}/>
     </li>;
   }
 };
@@ -52,14 +90,14 @@ const ActionBar = {
   view(vnode) {
     const vm = vnode.attrs.vm;
     if (vm.editMode()) {
-      return [<button onclick={() => vm.exitEditMode()}>Cancel</button>,<button onclick={() => vm.save()}>Save</button>];
+      return [<button onclick={() => vm.exitEditMode()}>Cancel</button>,<button onclick={() => vm.saveUpdate()}>Save</button>];
     } else {
       return [<button onclick={() => vm.enterEditMode()}>Edit</button>, <button onclick={() => vm.remove()}>Delete</button>];
     }
   }
 };
 
-const GitRepo = {
+const MaterialAttributes = {
   view(vnode) {
     const vm = vnode.attrs.vm;
     if (vm.editModel()) {

--- a/server/webapp/WEB-INF/rails/webpack/views/config_repos/config_repos_list.js.msx
+++ b/server/webapp/WEB-INF/rails/webpack/views/config_repos/config_repos_list.js.msx
@@ -18,7 +18,7 @@ const m = require("mithril");
 const _ = require("lodash");
 const f = require("helpers/form_helper");
 
-const ReposList = {
+const ConfigReposList = {
   view(vnode) {
     const vm = vnode.attrs.vm;
 
@@ -139,4 +139,4 @@ const Field = {
   }
 };
 
-module.exports = ReposList;
+module.exports = ConfigReposList;

--- a/server/webapp/WEB-INF/rails/webpack/views/config_repos/config_repos_list.js.msx
+++ b/server/webapp/WEB-INF/rails/webpack/views/config_repos/config_repos_list.js.msx
@@ -81,8 +81,8 @@ const ConfigRepo = {
     return <li>
       <h3>{repo.type()} repo: {repo.id()}</h3>
       <h5>Plugin: {repo.pluginId()}</h5>
-      <ActionBar vm={vm} repo={repo} isEdit={isEdit} />
       <MaterialAttributes material={repo.attributes()} isEdit={isEdit} />
+      <ActionBar vm={vm} repo={repo} isEdit={isEdit} />
     </li>;
   }
 };
@@ -94,9 +94,9 @@ const ActionBar = {
     const isEdit = vnode.attrs.isEdit;
 
     if (isEdit) {
-      return [<button onclick={() => vm.exitEditMode()}>Cancel</button>, <button onclick={() => vm.updateRepo(repo).then(() => vm.exitEditMode())}>Save</button>];
+      return m("div", {class: "config-repo-actions"}, [<button onclick={() => vm.exitEditMode()}>Cancel</button>, <button onclick={() => vm.updateRepo(repo).then(() => vm.exitEditMode())}>Save</button>]);
     } else {
-      return [<button onclick={() => vm.enterEditMode(repo)}>Edit</button>, <button onclick={() => vm.removeRepo(repo)}>Delete</button>];
+      return m("div", {class: "config-repo-actions"}, [<button onclick={() => vm.enterEditMode(repo)}>Edit</button>, <button onclick={() => vm.removeRepo(repo)}>Delete</button>]);
     }
   }
 };

--- a/server/webapp/WEB-INF/rails/webpack/views/config_repos/config_repos_list.js.msx
+++ b/server/webapp/WEB-INF/rails/webpack/views/config_repos/config_repos_list.js.msx
@@ -69,17 +69,10 @@ const AddForm = {
   view(vnode) {
     const vm = vnode.attrs.vm;
     return <div>
-    <f.select label="Choose a plugin" model={vm} attrName="pluginId" items={this.pluginChoices} />
-    <f.input label="Config Repo ID" model={vm} attrName="id"/>
-    {_.map(vm.attributes(), (v, k) =>
-        m("boolean" === typeof v() ? f.checkbox : f.input, {
-          model: vm.attributes(),
-          attrName: k,
-          label: k
-        })
-      )
-    }
-  </div>;
+      <f.select label="Choose a plugin" model={vm} attrName="pluginId" items={this.pluginChoices} />
+      <f.input label="Config Repo ID" model={vm} attrName="id"/>
+      <MaterialAttributes vm={vm.attributes()} isEdit={true} />
+    </div>;
   }
 };
 
@@ -91,7 +84,7 @@ const ConfigRepo = {
       <h3>{vm.type()} repo: {vm.id()}</h3>
       <h5>Plugin: {vm.pluginId()}</h5>
       <ActionBar vm={vm}/>
-      <MaterialAttributes vm={vm}/>
+      <MaterialAttributes vm={vm.editModel() || vm.attributes()} isEdit={vm.editMode()} />
     </li>;
   }
 };
@@ -110,20 +103,38 @@ const ActionBar = {
 const MaterialAttributes = {
   view(vnode) {
     const vm = vnode.attrs.vm;
-    if (vm.editModel()) {
-      const editModel = vm.editModel();
-      return <div>{_.map(editModel, (v, k) =>
-        m("boolean" === typeof v() ? f.checkbox : f.input, {
-          model: editModel,
-          attrName: k,
-          label: k
-        })
-      )}</div>;
+    const isEdit = vnode.attrs.isEdit;
 
+    if (isEdit) {
+      return <div>{
+        _.map(vm.keys, (k) => <Field model={vm} attrName={k} />)
+      }</div>;
     }
+
     return <table>
-      {_.map(vm.attributes(), (v, k) => <tr><td>{k}</td><td>{v}</td></tr>)}
+      {_.map(vm.keys, (k) => <tr><td>{k}</td><td>{vm[k]()}</td></tr>)}
     </table>;
+  }
+};
+
+const Field = {
+  view(vnode) {
+    const vm = vnode.attrs.model;
+    const k = vnode.attrs.attrName;
+    const field = vm[k];
+    const options = {model: vm, attrName: k, label: field.display};
+
+    switch (field.type) {
+      /* eslint-disable no-fallthrough */
+      case "boolean":
+        return <f.checkbox {...options} />;
+      case "secret":
+        options.type = "password";
+      case "text":
+      default:
+        return <f.input {...options} />;
+      /* eslint-enable no-fallthrough */
+    }
   }
 };
 

--- a/server/webapp/WEB-INF/rails/webpack/views/config_repos/config_repos_list.js.msx
+++ b/server/webapp/WEB-INF/rails/webpack/views/config_repos/config_repos_list.js.msx
@@ -25,6 +25,7 @@ const ConfigReposList = {
     return <section class="repo-list">
       <h1>Config Repos</h1>
       <AddRepo vm={vm}/>
+      <ServerErrors msg={vm.errors().join("; ")} />
       <ul>
       {
         vm.repos().map((repo) => {
@@ -68,6 +69,7 @@ const AddForm = {
       <f.select validate={true} label="Choose a plugin" model={vm} attrName="pluginId" items={availablePlugins} />
       <f.input validate={true} label="Config Repo ID" model={vm} attrName="id"/>
       <MaterialAttributes model={vm} isEdit={true} />
+      <ServerErrors msg={vm.serverErrors()} />
     </div>;
   }
 };
@@ -82,6 +84,7 @@ const ConfigRepo = {
       <h3>{repo.type()} repo: {repo.id()}</h3>
       <h5>Plugin: {repo.pluginId()}</h5>
       <MaterialAttributes model={repo} isEdit={isEdit} />
+      <ServerErrors msg={repo.serverErrors()} />
       <ActionBar vm={vm} repo={repo} isEdit={isEdit} />
     </li>;
   }
@@ -98,6 +101,12 @@ const ActionBar = {
     } else {
       return m("div", {class: "config-repo-actions"}, [<button onclick={() => vm.enterEditMode(repo)}>Edit</button>, <button onclick={() => vm.removeRepo(repo)}>Delete</button>]);
     }
+  }
+};
+
+const ServerErrors = {
+  view(vnode) {
+    return <div class="server-error-messages">{vnode.attrs.msg}</div>;
   }
 };
 

--- a/server/webapp/WEB-INF/rails/webpack/views/config_repos/config_repos_list.js.msx
+++ b/server/webapp/WEB-INF/rails/webpack/views/config_repos/config_repos_list.js.msx
@@ -98,7 +98,7 @@ const ActionBar = {
     const isEdit = vnode.attrs.isEdit;
 
     if (isEdit) {
-      return [<button onclick={() => vm.exitEditMode()}>Cancel</button>,<button onclick={() => vm.updateRepo(repo)}>Save</button>];
+      return [<button onclick={() => vm.exitEditMode()}>Cancel</button>, <button onclick={() => vm.updateRepo(repo).then(() => vm.exitEditMode())}>Save</button>];
     } else {
       return [<button onclick={() => vm.enterEditMode(repo)}>Edit</button>, <button onclick={() => vm.removeRepo(repo)}>Delete</button>];
     }

--- a/server/webapp/WEB-INF/rails/webpack/views/config_repos/config_repos_list.js.msx
+++ b/server/webapp/WEB-INF/rails/webpack/views/config_repos/config_repos_list.js.msx
@@ -48,7 +48,7 @@ const AddRepo = {
       return <div class="add-repo-actions">
         <AddForm vm={vm.addModel()} availablePlugins={vm.pluginChoices()} />
         <button onclick={() => vm.exitAddMode()}>Cancel</button>
-        <button onclick={() => vm.createRepo().then(() => vm.exitAddMode())}>Save</button>
+        <button onclick={() => vm.createRepo(vm.addModel()).then(() => vm.exitAddMode())}>Save</button>
       </div>;
     } else {
       return <div class="add-repo-actions">
@@ -65,8 +65,8 @@ const AddForm = {
     const availablePlugins = vnode.attrs.availablePlugins;
 
     return <div class="add-config-repo-form">
-      <f.select label="Choose a plugin" model={vm} attrName="pluginId" items={availablePlugins} />
-      <f.input label="Config Repo ID" model={vm} attrName="id"/>
+      <f.select validate={true} label="Choose a plugin" model={vm} attrName="pluginId" items={availablePlugins} />
+      <f.input validate={true} label="Config Repo ID" model={vm} attrName="id"/>
       <MaterialAttributes material={vm.attributes()} isEdit={true} />
     </div>;
   }
@@ -123,7 +123,7 @@ const Field = {
     const vm = vnode.attrs.model;
     const k = vnode.attrs.attrName;
     const field = vm[k];
-    const options = {model: vm, attrName: k, label: field.opts("display")};
+    const options = {model: vm, attrName: k, label: field.opts("display"), validate: true};
 
     if (field.opts("readOnly")) { options.disabled = true; }
 

--- a/server/webapp/WEB-INF/rails/webpack/views/config_repos/config_repos_list.js.msx
+++ b/server/webapp/WEB-INF/rails/webpack/views/config_repos/config_repos_list.js.msx
@@ -40,14 +40,18 @@ const AddRepo = {
   view(vnode) {
     const vm = vnode.attrs.vm;
 
+    if (vm.pluginChoices().length === 0) {
+      return <div class="add-repo-actions loading">Gathering Plugins&hellip;</div>;
+    }
+
     if (vm.addMode()) {
-      return <div>
-        <AddForm vm={vm.addModel()}/>
+      return <div class="add-repo-actions">
+        <AddForm vm={vm.addModel()} availablePlugins={vm.pluginChoices()} />
         <button onclick={() => vm.exitAddMode()}>Cancel</button>
         <button onclick={() => vm.createRepo().then(() => vm.exitAddMode())}>Save</button>
       </div>;
     } else {
-      return <div>
+      return <div class="add-repo-actions">
         <f.select model={vm} attrName="typeToAdd" items={vm.availMaterials} />
         <button onclick={() => vm.enterAddMode()}>Add Repo</button>
       </div>;
@@ -56,20 +60,12 @@ const AddRepo = {
 };
 
 const AddForm = {
-  oninit(vnode) {
-    const vm = vnode.attrs.vm;
-    const pluginChoices = this.pluginChoices = [
-      { id: "json.config.plugin", text: "GoCD JSON Config Plugin" },
-      { id: "yaml.config.plugin", text: "GoCD YAML Config Plugin" }
-    ];
-
-    vm.pluginId(pluginChoices[0].id);
-  },
-
   view(vnode) {
     const vm = vnode.attrs.vm;
-    return <div>
-      <f.select label="Choose a plugin" model={vm} attrName="pluginId" items={this.pluginChoices} />
+    const availablePlugins = vnode.attrs.availablePlugins;
+
+    return <div class="add-config-repo-form">
+      <f.select label="Choose a plugin" model={vm} attrName="pluginId" items={availablePlugins} />
       <f.input label="Config Repo ID" model={vm} attrName="id"/>
       <MaterialAttributes material={vm.attributes()} isEdit={true} />
     </div>;

--- a/server/webapp/WEB-INF/rails/webpack/views/config_repos/config_repos_list.js.msx
+++ b/server/webapp/WEB-INF/rails/webpack/views/config_repos/config_repos_list.js.msx
@@ -127,9 +127,9 @@ const Field = {
     const vm = vnode.attrs.model;
     const k = vnode.attrs.attrName;
     const field = vm[k];
-    const options = {model: vm, attrName: k, label: field.display};
+    const options = {model: vm, attrName: k, label: field.opts("display")};
 
-    switch (field.type) {
+    switch (field.opts("type")) {
       /* eslint-disable no-fallthrough */
       case "boolean":
         return <f.checkbox {...options} />;

--- a/server/webapp/WEB-INF/rails/webpack/views/config_repos/config_repos_list.js.msx
+++ b/server/webapp/WEB-INF/rails/webpack/views/config_repos/config_repos_list.js.msx
@@ -52,9 +52,9 @@ const ActionBar = {
   view(vnode) {
     const vm = vnode.attrs.vm;
     if (vm.editMode()) {
-      return [<button onclick={() => vm.exitEditMode()}>Cancel</button>,<button onclick={() => vm.save()}>Save</button>]
+      return [<button onclick={() => vm.exitEditMode()}>Cancel</button>,<button onclick={() => vm.save()}>Save</button>];
     } else {
-      return <button onclick={() => vm.enterEditMode()}>Edit</button>
+      return <button onclick={() => vm.enterEditMode()}>Edit</button>;
     }
   }
 };
@@ -72,13 +72,13 @@ const GitRepo = {
           attrName: k,
           label: k
         })
-      )}</div>
+      )}</div>;
 
     }
     return <table>
       {_.map(vm.attributes(), (v, k) => <tr><td>{k}</td><td>{v}</td></tr>)}
-    </table>
+    </table>;
   }
-}
+};
 
 module.exports = ReposList;

--- a/server/webapp/WEB-INF/rails/webpack/views/config_repos/config_repos_list.js.msx
+++ b/server/webapp/WEB-INF/rails/webpack/views/config_repos/config_repos_list.js.msx
@@ -15,18 +15,29 @@
  */
 
 const m = require("mithril");
-const ReposList = require("views/config_repos/config_repos_list");
-const ReposModel = require("models/config_repos/config_repos");
 
-const model = new ReposModel().start();
+const ReposList = {
+  view(vnode) {
+    const model = vnode.attrs.model;
 
-const ConfigReposPage = {
-  view() {
-    return m(ReposList, {model});
+    return <section class="repo-list">
+      <h1>Config Header</h1>
+      <ul>
+      {
+        model.repos().map((repo) => {
+          return <ConfigRepo model={repo}/>;
+        })
+      }
+      </ul>
+    </section>;
   }
 };
 
-window.addEventListener("DOMContentLoaded", () => {
-  const root = document.getElementById("config-repos");
-  m.mount(root, ConfigReposPage);
-});
+const ConfigRepo = {
+  view(vnode) {
+    const repo = vnode.attrs.model;
+    return <li>{repo.material.attributes.url}</li>;
+  }
+};
+
+module.exports = ReposList;

--- a/server/webapp/WEB-INF/rails/webpack/views/config_repos/config_repos_list.js.msx
+++ b/server/webapp/WEB-INF/rails/webpack/views/config_repos/config_repos_list.js.msx
@@ -41,7 +41,11 @@ const AddRepo = {
     const vm = vnode.attrs.vm;
 
     if (vm.addMode()) {
-      return <AddForm vm={vm.addModel()}/>;
+      return <div>
+        <AddForm vm={vm.addModel()}/>
+        <button onclick={() => vm.exitAddMode()}>Cancel</button>
+        <button onclick={() => vm.addModel().create().then(() => vm.exitAddMode())}>Save</button>
+      </div>;
     } else {
       return <div>
         <f.select model={vm} attrName="typeToAdd" items={vm.availMaterials} />
@@ -52,14 +56,20 @@ const AddRepo = {
 };
 
 const AddForm = {
+  oninit(vnode) {
+    const vm = vnode.attrs.vm;
+    const pluginChoices = this.pluginChoices = [
+      { id: "json.config.plugin", text: "GoCD JSON Config Plugin" },
+      { id: "yaml.config.plugin", text: "GoCD YAML Config Plugin" }
+    ];
+
+    vm.pluginId(pluginChoices[0].id);
+  },
+
   view(vnode) {
     const vm = vnode.attrs.vm;
-    const pluginChoices = [
-    { id: "json.config.plugin", text: "GoCD JSON Config Plugin" },
-    { id: "yaml.config.plugin", text: "GoCD YAML Config Plugin" }
-    ];
     return <div>
-    <f.select label="Choose a plugin" model={vm} attrName="pluginId" items={pluginChoices} />
+    <f.select label="Choose a plugin" model={vm} attrName="pluginId" items={this.pluginChoices} />
     <f.input label="Config Repo ID" model={vm} attrName="id"/>
     {_.map(vm.attributes(), (v, k) =>
         m("boolean" === typeof v() ? f.checkbox : f.input, {

--- a/server/webapp/WEB-INF/rails/webpack/views/config_repos/config_repos_list.js.msx
+++ b/server/webapp/WEB-INF/rails/webpack/views/config_repos/config_repos_list.js.msx
@@ -41,12 +41,12 @@ const ConfigRepo = {
 
     return <li>
       <h3>{vm.type()} repo: {vm.id()}</h3>
+      <h5>Plugin: {vm.pluginId()}</h5>
       <ActionBar vm={vm}/>
       <GitRepo vm={vm}/>
     </li>;
   }
 };
-
 
 const ActionBar = {
   view(vnode) {
@@ -54,12 +54,10 @@ const ActionBar = {
     if (vm.editMode()) {
       return [<button onclick={() => vm.exitEditMode()}>Cancel</button>,<button onclick={() => vm.save()}>Save</button>];
     } else {
-      return <button onclick={() => vm.enterEditMode()}>Edit</button>;
+      return [<button onclick={() => vm.enterEditMode()}>Edit</button>, <button onclick={() => vm.remove()}>Delete</button>];
     }
   }
 };
-
-
 
 const GitRepo = {
   view(vnode) {

--- a/server/webapp/WEB-INF/rails/webpack/views/config_repos/config_repos_list.js.msx
+++ b/server/webapp/WEB-INF/rails/webpack/views/config_repos/config_repos_list.js.msx
@@ -15,17 +15,19 @@
  */
 
 const m = require("mithril");
+const _ = require("lodash");
+const f = require("helpers/form_helper");
 
 const ReposList = {
   view(vnode) {
-    const model = vnode.attrs.model;
+    const vm = vnode.attrs.vm;
 
     return <section class="repo-list">
       <h1>Config Header</h1>
       <ul>
       {
-        model.repos().map((repo) => {
-          return <ConfigRepo model={repo}/>;
+        vm.repos().map((repo) => {
+          return <ConfigRepo vm={repo}/>;
         })
       }
       </ul>
@@ -35,9 +37,48 @@ const ReposList = {
 
 const ConfigRepo = {
   view(vnode) {
-    const repo = vnode.attrs.model;
-    return <li>{repo.material.attributes.url}</li>;
+    const vm = vnode.attrs.vm;
+
+    return <li>
+      <h3>{vm.type()} repo: {vm.id()}</h3>
+      <ActionBar vm={vm}/>
+      <GitRepo vm={vm}/>
+    </li>;
   }
 };
+
+
+const ActionBar = {
+  view(vnode) {
+    const vm = vnode.attrs.vm;
+    if (vm.editMode()) {
+      return [<button onclick={() => vm.exitEditMode()}>Cancel</button>,<button onclick={() => vm.save()}>Save</button>]
+    } else {
+      return <button onclick={() => vm.enterEditMode()}>Edit</button>
+    }
+  }
+};
+
+
+
+const GitRepo = {
+  view(vnode) {
+    const vm = vnode.attrs.vm;
+    if (vm.editModel()) {
+      const editModel = vm.editModel();
+      return <div>{_.map(editModel, (v, k) =>
+        m("boolean" === typeof v() ? f.checkbox : f.input, {
+          model: editModel,
+          attrName: k,
+          label: k
+        })
+      )}</div>
+
+    }
+    return <table>
+      {_.map(vm.attributes(), (v, k) => <tr><td>{k}</td><td>{v}</td></tr>)}
+    </table>
+  }
+}
 
 module.exports = ReposList;

--- a/server/webapp/WEB-INF/rails/webpack/views/config_repos/config_repos_list.js.msx
+++ b/server/webapp/WEB-INF/rails/webpack/views/config_repos/config_repos_list.js.msx
@@ -125,6 +125,8 @@ const Field = {
     const field = vm[k];
     const options = {model: vm, attrName: k, label: field.opts("display")};
 
+    if (field.opts("readOnly")) { options.disabled = true; }
+
     switch (field.opts("type")) {
       /* eslint-disable no-fallthrough */
       case "boolean":

--- a/server/webapp/WEB-INF/rails/webpack/views/config_repos/config_repos_list.js.msx
+++ b/server/webapp/WEB-INF/rails/webpack/views/config_repos/config_repos_list.js.msx
@@ -67,7 +67,7 @@ const AddForm = {
     return <div class="add-config-repo-form">
       <f.select validate={true} label="Choose a plugin" model={vm} attrName="pluginId" items={availablePlugins} />
       <f.input validate={true} label="Config Repo ID" model={vm} attrName="id"/>
-      <MaterialAttributes material={vm.attributes()} isEdit={true} />
+      <MaterialAttributes model={vm} isEdit={true} />
     </div>;
   }
 };
@@ -81,7 +81,7 @@ const ConfigRepo = {
     return <li>
       <h3>{repo.type()} repo: {repo.id()}</h3>
       <h5>Plugin: {repo.pluginId()}</h5>
-      <MaterialAttributes material={repo.attributes()} isEdit={isEdit} />
+      <MaterialAttributes model={repo} isEdit={isEdit} />
       <ActionBar vm={vm} repo={repo} isEdit={isEdit} />
     </li>;
   }
@@ -103,12 +103,13 @@ const ActionBar = {
 
 const MaterialAttributes = {
   view(vnode) {
-    const material = vnode.attrs.material;
+    const vm = vnode.attrs.model;
+    const material = vm.attributes();
     const isEdit = vnode.attrs.isEdit;
 
     if (isEdit) {
       return <div>{
-        _.map(material.keys, (k) => <Field model={material} attrName={k} />)
+        _.map(material.keys, (k) => <Field vm={vm} model={material} attrName={k} />)
       }</div>;
     }
 
@@ -120,12 +121,16 @@ const MaterialAttributes = {
 
 const Field = {
   view(vnode) {
-    const vm = vnode.attrs.model;
+    const vm = vnode.attrs.vm;
+    const model = vnode.attrs.model;
     const k = vnode.attrs.attrName;
-    const field = vm[k];
-    const options = {model: vm, attrName: k, label: field.opts("display"), validate: true};
+    const field = model[k];
+    const options = {model, attrName: k, label: field.opts("display"), validate: true};
 
     if (field.opts("readOnly")) { options.disabled = true; }
+    if ("url" === k) {
+      options.contentAfter = [<CheckConnection vm={vm}/>];
+    }
 
     switch (field.opts("type")) {
       /* eslint-disable no-fallthrough */
@@ -138,6 +143,26 @@ const Field = {
         return <f.input {...options} />;
       /* eslint-enable no-fallthrough */
     }
+  }
+};
+
+const CheckConnection = {
+  oninit(vnode) {
+    vnode.state.result = null;
+  },
+
+  view(vnode) {
+    const vm = vnode.attrs.vm;
+    const success = (data) => { vnode.state.result = data.message; };
+    const failure = (errorMessage) => { vnode.state.result = errorMessage; };
+    const handler = () => {
+      vnode.state.result = null;
+      vm.testConnection().then(success, failure);
+    };
+    return <div class="connection-test">
+      <button onclick={handler}>Check Connection</button>
+      <span class="connection-result">{vnode.state.result}</span>
+    </div>;
   }
 };
 

--- a/server/webapp/WEB-INF/rails/webpack/views/config_repos/config_repos_list.js.msx
+++ b/server/webapp/WEB-INF/rails/webpack/views/config_repos/config_repos_list.js.msx
@@ -28,7 +28,7 @@ const ReposList = {
       <ul>
       {
         vm.repos().map((repo) => {
-          return <ConfigRepo vm={repo}/>;
+          return <ConfigRepo vm={vm} repo={vm.editMode(repo) ? vm.editModel() : repo} />;
         })
       }
       </ul>
@@ -44,7 +44,7 @@ const AddRepo = {
       return <div>
         <AddForm vm={vm.addModel()}/>
         <button onclick={() => vm.exitAddMode()}>Cancel</button>
-        <button onclick={() => vm.addModel().create().then(() => vm.exitAddMode())}>Save</button>
+        <button onclick={() => vm.createRepo().then(() => vm.exitAddMode())}>Save</button>
       </div>;
     } else {
       return <div>
@@ -71,7 +71,7 @@ const AddForm = {
     return <div>
       <f.select label="Choose a plugin" model={vm} attrName="pluginId" items={this.pluginChoices} />
       <f.input label="Config Repo ID" model={vm} attrName="id"/>
-      <MaterialAttributes vm={vm.attributes()} isEdit={true} />
+      <MaterialAttributes material={vm.attributes()} isEdit={true} />
     </div>;
   }
 };
@@ -79,12 +79,14 @@ const AddForm = {
 const ConfigRepo = {
   view(vnode) {
     const vm = vnode.attrs.vm;
+    const repo = vnode.attrs.repo;
+    const isEdit = vm.editMode(repo);
 
     return <li>
-      <h3>{vm.type()} repo: {vm.id()}</h3>
-      <h5>Plugin: {vm.pluginId()}</h5>
-      <ActionBar vm={vm}/>
-      <MaterialAttributes vm={vm.editModel() || vm.attributes()} isEdit={vm.editMode()} />
+      <h3>{repo.type()} repo: {repo.id()}</h3>
+      <h5>Plugin: {repo.pluginId()}</h5>
+      <ActionBar vm={vm} repo={repo} isEdit={isEdit} />
+      <MaterialAttributes material={repo.attributes()} isEdit={isEdit} />
     </li>;
   }
 };
@@ -92,27 +94,30 @@ const ConfigRepo = {
 const ActionBar = {
   view(vnode) {
     const vm = vnode.attrs.vm;
-    if (vm.editMode()) {
-      return [<button onclick={() => vm.exitEditMode()}>Cancel</button>,<button onclick={() => vm.saveUpdate()}>Save</button>];
+    const repo = vnode.attrs.repo;
+    const isEdit = vnode.attrs.isEdit;
+
+    if (isEdit) {
+      return [<button onclick={() => vm.exitEditMode()}>Cancel</button>,<button onclick={() => vm.updateRepo(repo)}>Save</button>];
     } else {
-      return [<button onclick={() => vm.enterEditMode()}>Edit</button>, <button onclick={() => vm.remove()}>Delete</button>];
+      return [<button onclick={() => vm.enterEditMode(repo)}>Edit</button>, <button onclick={() => vm.removeRepo(repo)}>Delete</button>];
     }
   }
 };
 
 const MaterialAttributes = {
   view(vnode) {
-    const vm = vnode.attrs.vm;
+    const material = vnode.attrs.material;
     const isEdit = vnode.attrs.isEdit;
 
     if (isEdit) {
       return <div>{
-        _.map(vm.keys, (k) => <Field model={vm} attrName={k} />)
+        _.map(material.keys, (k) => <Field model={material} attrName={k} />)
       }</div>;
     }
 
     return <table>
-      {_.map(vm.keys, (k) => <tr><td>{k}</td><td>{vm[k]()}</td></tr>)}
+      {_.map(material.keys, (k) => <tr><td>{k}</td><td>{material[k]()}</td></tr>)}
     </table>;
   }
 };

--- a/server/webapp/WEB-INF/rails/webpack/views/config_repos/models/config_repo_vm.js
+++ b/server/webapp/WEB-INF/rails/webpack/views/config_repos/models/config_repo_vm.js
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2018 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const Stream      = require("mithril/stream");
+const _           = require("lodash");
+const Materials   = require("models/config_repos/materials");
+const Validatable = require("models/mixins/validatable_mixin");
+
+function ConfigRepoVM(data) {
+  this.id = Stream();
+  this.pluginId = Stream();
+  this.type = Stream();
+  this.attributes = Stream();
+  this.configuration = Stream();
+  this.etag = Stream(null);
+
+  Validatable.call(this, { errors: {} });
+
+  this.validatePresenceOf("id");
+  this.validatePresenceOf("pluginId");
+  this.validatePresenceOf("type");
+
+  this.allowSave = () => {
+    // intentionally not inlined with `&&` so that we run all validations every time
+    const parentValid = this.isValid();
+    const childValid = this.attributes().isValid();
+    return parentValid && childValid;
+  };
+
+  this.initialize = (data) => {
+    this.id(data.id);
+    this.pluginId(data.plugin_id);
+    this.type(data.material.type);
+    this.attributes(Materials.get(this.type(), data));
+    this.configuration(data.configuration || []);
+  };
+
+  this.initialize(data);
+
+  this.toJSON = () => {
+    return {
+      id: this.id(),
+      plugin_id: this.pluginId(), // eslint-disable-line camelcase
+      material: {
+        type: this.type(),
+        attributes: this.attributes().toJSON()
+      },
+      configuration: _.cloneDeep(this.configuration())
+    };
+  };
+
+  this.clone = () => {
+    const cloned = new ConfigRepoVM(this.toJSON());
+    cloned.etag(this.etag());
+    return cloned;
+  };
+}
+
+module.exports = ConfigRepoVM;

--- a/server/webapp/WEB-INF/rails/webpack/views/config_repos/models/config_repo_vm.js
+++ b/server/webapp/WEB-INF/rails/webpack/views/config_repos/models/config_repo_vm.js
@@ -30,6 +30,7 @@ function ConfigRepoVM(data) {
   Validatable.call(this, { errors: {} });
 
   this.validatePresenceOf("id");
+  this.validateFormatOf("id", Validatable.DefaultOptions.forId("ID"));
   this.validatePresenceOf("pluginId");
   this.validatePresenceOf("type");
 

--- a/server/webapp/WEB-INF/rails/webpack/views/config_repos/models/config_repo_vm.js
+++ b/server/webapp/WEB-INF/rails/webpack/views/config_repos/models/config_repo_vm.js
@@ -18,6 +18,8 @@ const Stream      = require("mithril/stream");
 const _           = require("lodash");
 const Materials   = require("models/config_repos/materials");
 const Validatable = require("models/mixins/validatable_mixin");
+const ApiHelper   = require("helpers/api_helper");
+const Routes      = require("gen/js-routes");
 
 function ConfigRepoVM(data) {
   this.id = Stream();
@@ -68,6 +70,12 @@ function ConfigRepoVM(data) {
     cloned.etag(this.etag());
     return cloned;
   };
+
+  this.testConnection = () => ApiHelper.POST({
+    url: Routes.apiv1AdminInternalMaterialTestPath(),
+    apiVersion: "v1",
+    payload: this.toJSON().material
+  });
 }
 
 module.exports = ConfigRepoVM;

--- a/server/webapp/WEB-INF/rails/webpack/views/config_repos/models/config_repo_vm.js
+++ b/server/webapp/WEB-INF/rails/webpack/views/config_repos/models/config_repo_vm.js
@@ -28,6 +28,7 @@ function ConfigRepoVM(data) {
   this.attributes = Stream();
   this.configuration = Stream();
   this.etag = Stream(null);
+  this.serverErrors = Stream();
 
   Validatable.call(this, { errors: {} });
 

--- a/server/webapp/WEB-INF/rails/webpack/views/config_repos/models/config_repo_vm.js
+++ b/server/webapp/WEB-INF/rails/webpack/views/config_repos/models/config_repo_vm.js
@@ -29,10 +29,10 @@ function ConfigRepoVM(data) {
 
   Validatable.call(this, { errors: {} });
 
-  this.validatePresenceOf("id");
+  this.validatePresenceOf("id", {message: "ID cannot be blank"});
   this.validateFormatOf("id", Validatable.DefaultOptions.forId("ID"));
-  this.validatePresenceOf("pluginId");
-  this.validatePresenceOf("type");
+  this.validatePresenceOf("pluginId", {message: "Plugin must be selected"});
+  this.validatePresenceOf("type", {message: "Type must be selected"});
 
   this.allowSave = () => {
     // intentionally not inlined with `&&` so that we run all validations every time

--- a/server/webapp/WEB-INF/rails/webpack/views/config_repos/models/config_repos_vm.js
+++ b/server/webapp/WEB-INF/rails/webpack/views/config_repos/models/config_repos_vm.js
@@ -14,9 +14,10 @@
  * limitations under the License.
  */
 
-const Stream    = require('mithril/stream');
-const _         = require('lodash');
-const Materials = require('models/config_repos/materials');
+const Stream    = require("mithril/stream");
+const _         = require("lodash");
+const Materials = require("models/config_repos/materials");
+
 
 function ReposListVM(model) {
   const repos = Stream([]);
@@ -77,9 +78,17 @@ function ConfigRepoVM(data) {
 
 // Mixins
 
+const MATERIAL_SELECTIONS = [
+  { id: "git", text: "Git" },
+  { id: "hg", text: "Mercurial" },
+  { id: "svn", text: "Subversion" },
+  { id: "p4", text: "Perforce" },
+  { id: "tfs", text: "Team Foundation Server" },
+  { id: "package", text: "Package" }
+];
+
 function CreateSupport(model, repos) {
-  // API to get these??
-  this.availMaterials = [{ id: "git", text: "Git" }, { id: "hg", text: "Mercurial" }, { id: "svn", text: "Svn" }, { id: "p4", text: "Perforce" }, { id: "tfs", text: "Tfs" }, { id: "package", text: "Package" }];
+  this.availMaterials = MATERIAL_SELECTIONS;
   this.typeToAdd = Stream(this.availMaterials[0].id);
 
   this.addModel = Stream(null);

--- a/server/webapp/WEB-INF/rails/webpack/views/config_repos/models/config_repos_vm.js
+++ b/server/webapp/WEB-INF/rails/webpack/views/config_repos/models/config_repos_vm.js
@@ -15,8 +15,8 @@
  */
 
 
-const Stream = require('mithril/stream');
 const _ = require("lodash");
+const Stream = require('mithril/stream');
 const Materials = require('models/config_repos/materials');
 
 function ReposListVM(model) {
@@ -105,7 +105,7 @@ function ConfigRepoVM(data, model, parent) {
       configuration: this.configuration()
     };
 
-    model.create(payload).then(() => parent.addRepo(this));
+    return model.create(payload).then(() => parent.addRepo(this));
   };
 
   this.saveUpdate = () => {
@@ -116,15 +116,14 @@ function ConfigRepoVM(data, model, parent) {
       }
     });
 
-    model.update(this.etag(), payload).then((data) => {
+    return model.update(this.etag(), payload).then((data) => {
       this.initialize(data);
       this.exitEditMode();
     });
   };
 
   this.remove = () => {
-    model.delete(this.id());
-    parent.removeRepo(this);
+    return model.delete(this.id()).then(() => parent.removeRepo(this));
   };
 }
 

--- a/server/webapp/WEB-INF/rails/webpack/views/config_repos/models/config_repos_vm.js
+++ b/server/webapp/WEB-INF/rails/webpack/views/config_repos/models/config_repos_vm.js
@@ -107,7 +107,11 @@ function CreateSupport(model, repos) {
   };
 
   this.exitAddMode = () => this.addModel(null);
-  this.createRepo = () => model.create(this.addModel()).then(() => repos().push(this.addModel()));
+  this.createRepo = () => model.create(this.addModel()).then((data, _s, xhr) => {
+    const repo = new ConfigRepoVM(data);
+    repo.etag(parseEtag(xhr));
+    repos().push(repo);
+  });
 }
 
 function UpdateSupport(model, repos) {
@@ -135,8 +139,6 @@ function UpdateSupport(model, repos) {
 
       const idxToReplace = _.findIndex(repos(), (r) => r.id() === repo.id()); // should always be found
       repos().splice(idxToReplace, 1, repo);
-
-      this.exitEditMode();
     });
   };
 }

--- a/server/webapp/WEB-INF/rails/webpack/views/config_repos/models/config_repos_vm.js
+++ b/server/webapp/WEB-INF/rails/webpack/views/config_repos/models/config_repos_vm.js
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-
-const _ = require("lodash");
 const Stream = require('mithril/stream');
 const Materials = require('models/config_repos/materials');
 
@@ -23,7 +21,7 @@ function ReposListVM(model) {
   const repos = Stream([]);
   const self = this;
 
-  this.availMaterials = [{ id: "git", text: "Git" }, { id: "hg", text: "Mercurial" }];
+  this.availMaterials = [{ id: "git", text: "Git" }, { id: "hg", text: "Mercurial" }, { id: "svn", text: "Svn" }, { id: "p4", text: "Perforce" }, { id: "tfs", text: "Tfs" }, { id: "package", text: "Package" }];
   this.typeToAdd = Stream("git");
   this.addModel = Stream(null);
   this.addMode = () => !!this.addModel();
@@ -83,12 +81,7 @@ function ConfigRepoVM(data, model, parent) {
 
       if (304 !== xhr.status) { this.initialize(data); }
 
-      this.editModel(
-        _.reduce(this.attributes(), (memo, v, k) => {
-          memo[k] = Stream(v);
-          return memo;
-        }, {})
-      );
+      this.editModel(this.attributes().clone());
     });
   };
 
@@ -109,12 +102,15 @@ function ConfigRepoVM(data, model, parent) {
   };
 
   this.saveUpdate = () => {
-    const payload = _.assign({}, data, {
+    const payload = {
+      id: this.id(),
+      plugin_id: this.pluginId(), // eslint-disable-line camelcase
       material: {
         type: this.type(),
         attributes: this.editModel()
-      }
-    });
+      },
+      configuration: this.configuration()
+    };
 
     return model.update(this.etag(), payload).then((data) => {
       this.initialize(data);

--- a/server/webapp/WEB-INF/rails/webpack/views/config_repos/models/config_repos_vm.js
+++ b/server/webapp/WEB-INF/rails/webpack/views/config_repos/models/config_repos_vm.js
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2018 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+const Stream = require('mithril/stream');
+const _ = require("lodash");
+
+function ReposListVM(model) {
+  const repos = Stream([]);
+
+  this.fetchReposData = () => {
+    this.loading(true);
+    model.load().then((data, status, xhr) => {
+      console.log(data.etag)
+      console.log(xhr)
+      repos(data._embedded.config_repos.map((r) => new ConfigRepoVM(r, model)));
+    }).always(() => this.loading(false));
+
+    return this;
+  };
+
+  this.loading = Stream(false);
+  this.repos = repos;
+}
+
+function ConfigRepoVM(data, model) {
+  this.editModel = Stream(null);
+  this.id = Stream(data.id);
+  this.type = Stream(data.material.type);
+  this.attributes = Stream(data.material.attributes);
+  this.configuration = Stream(data.configuration);
+
+  this.editMode = () => !!this.editModel();
+
+  this.enterEditMode = () => this.editModel(
+    _.reduce(this.attributes(), function(memo, v, k) {
+      memo[k] = Stream(v);
+      return memo;
+    }, {})
+  );
+
+  this.exitEditMode = () => this.editModel(null);
+
+  this.save = () => model.update(_.assign({}, data, {material: {type: this.type(), attributes: this.editModel()}}));
+}
+
+module.exports = ReposListVM;

--- a/server/webapp/WEB-INF/rails/webpack/views/config_repos/models/repos_list_vm.js
+++ b/server/webapp/WEB-INF/rails/webpack/views/config_repos/models/repos_list_vm.js
@@ -64,8 +64,7 @@ const MATERIAL_SELECTIONS = [
   { id: "hg", text: "Mercurial" },
   { id: "svn", text: "Subversion" },
   { id: "p4", text: "Perforce" },
-  { id: "tfs", text: "Team Foundation Server" },
-  { id: "package", text: "Package" }
+  { id: "tfs", text: "Team Foundation Server" }
 ];
 
 function CreateSupport(model, repos) {

--- a/server/webapp/WEB-INF/rails/webpack/views/config_repos/models/repos_list_vm.js
+++ b/server/webapp/WEB-INF/rails/webpack/views/config_repos/models/repos_list_vm.js
@@ -108,7 +108,7 @@ function UpdateSupport(model, repos) {
 
     model.get(repo.etag(), repo.id()).then((data, etag, status) => {
       if (etag) { repo.etag(etag); }
-      if (304 !== status) { repo.initialize(data); }
+      if (304 !== status && data) { repo.initialize(data); }
 
       this.editModel(repo.clone());
     });

--- a/server/webapp/WEB-INF/rails/webpack/views/config_repos/models/repos_list_vm.js
+++ b/server/webapp/WEB-INF/rails/webpack/views/config_repos/models/repos_list_vm.js
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-const Stream      = require("mithril/stream");
-const _           = require("lodash");
-const Materials   = require("models/config_repos/materials");
-const Validatable = require("models/mixins/validatable_mixin");
-const PluginInfos = require("models/shared/plugin_infos");
+const Stream       = require("mithril/stream");
+const _            = require("lodash");
+const Dfr          = require("jquery").Deferred;
+const PluginInfos  = require("models/shared/plugin_infos");
+const ConfigRepoVM = require("views/config_repos/models/config_repo_vm");
 
 function ReposListVM(model) {
   const repos = Stream([]);
@@ -55,56 +55,6 @@ function ReposListVM(model) {
 
   this.errors = Stream([]);
   this.repos = repos;
-}
-
-function ConfigRepoVM(data) {
-  this.id = Stream();
-  this.pluginId = Stream();
-  this.type = Stream();
-  this.attributes = Stream();
-  this.configuration = Stream();
-  this.etag = Stream(null);
-
-  Validatable.call(this, { errors: {} });
-
-  this.validatePresenceOf("id");
-  this.validatePresenceOf("pluginId");
-  this.validatePresenceOf("type");
-
-  this.allowSave = () => {
-    // intentionally not inlined with `&&` so that we run all validations every time
-    const parentValid = this.isValid();
-    const childValid = this.attributes().isValid();
-    return parentValid && childValid;
-  };
-
-  this.initialize = (data) => {
-    this.id(data.id);
-    this.pluginId(data.plugin_id);
-    this.type(data.material.type);
-    this.attributes(Materials.get(this.type(), data));
-    this.configuration(data.configuration || []);
-  };
-
-  this.initialize(data);
-
-  this.toJSON = () => {
-    return {
-      id: this.id(),
-      plugin_id: this.pluginId(), // eslint-disable-line camelcase
-      material: {
-        type: this.type(),
-        attributes: this.attributes().toJSON()
-      },
-      configuration: _.cloneDeep(this.configuration())
-    };
-  };
-
-  this.clone = () => {
-    const cloned = new ConfigRepoVM(this.toJSON());
-    cloned.etag(this.etag());
-    return cloned;
-  };
 }
 
 // Mixins

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/config_repos.js.msx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/config_repos.js.msx
@@ -15,9 +15,16 @@
  */
 
 const m = require("mithril");
-const ConfigReposPage = require("views/pages/config_repos");
+const ReposList = require("views/config_repos/config_repos_list");
+const ReposModel = require("models/config_repos/config_repos");
+const ReposVM = require("views/config_repos/models/config_repos_vm");
 
-window.addEventListener("DOMContentLoaded", () => {
-  const root = document.getElementById("config-repos");
-  m.mount(root, ConfigReposPage);
-});
+module.exports = {
+  oninit() {
+    this.vm = new ReposVM(new ReposModel()).load();
+  },
+
+  view() {
+    return <ReposList vm={this.vm} />;
+  }
+};

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/config_repos.js.msx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/config_repos.js.msx
@@ -14,18 +14,18 @@
  * limitations under the License.
  */
 
-const m = require("mithril");
-const ReposList = require("views/config_repos/config_repos_list");
-const ReposModel = require("models/config_repos/config_repos");
-const ReposVM = require("views/config_repos/models/config_repos_vm");
+const m               = require("mithril");
+const ConfigReposList = require("views/config_repos/config_repos_list");
+const ConfigRepos     = require("models/config_repos/config_repos");
+const ReposListVM     = require("views/config_repos/models/repos_list_vm");
 
 module.exports = {
   oninit() {
-    this.vm = new ReposVM(new ReposModel()).load();
+    this.vm = new ReposListVM(new ConfigRepos()).load();
     this.vm.loadPlugins().then(() => m.redraw());
   },
 
   view() {
-    return <ReposList vm={this.vm} />;
+    return <ConfigReposList vm={this.vm} />;
   }
 };

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/config_repos.js.msx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/config_repos.js.msx
@@ -22,6 +22,7 @@ const ReposVM = require("views/config_repos/models/config_repos_vm");
 module.exports = {
   oninit() {
     this.vm = new ReposVM(new ReposModel()).load();
+    this.vm.loadPlugins().then(() => m.redraw());
   },
 
   view() {

--- a/server/webapp/WEB-INF/urlrewrite.xml
+++ b/server/webapp/WEB-INF/urlrewrite.xml
@@ -100,6 +100,12 @@
     </rule>
 
     <rule>
+        <name>Config Repos SPA</name>
+        <from>^/admin/config_repos(/?)$</from>
+        <to last="true">/spark/admin/config_repos</to>
+    </rule>
+
+    <rule>
         <name>Agents SPA</name>
         <from>^/agents(/?)$</from>
         <to last="true">/spark/agents</to>

--- a/spark/spark-base/src/main/java/com/thoughtworks/go/spark/Routes.java
+++ b/spark/spark-base/src/main/java/com/thoughtworks/go/spark/Routes.java
@@ -49,6 +49,8 @@ public class Routes {
     }
 
     public static class ConfigRepos {
+        public static final String SPA_BASE = "/admin/config_repos";
+
         public static final String BASE = "/api/admin/config_repos";
         public static final String DOC = "https://api.gocd.org/#config-repos";
 

--- a/spark/spark-spa/src/main/java/com/thoughtworks/go/spark/spa/ConfigReposDelegate.java
+++ b/spark/spark-spa/src/main/java/com/thoughtworks/go/spark/spa/ConfigReposDelegate.java
@@ -16,6 +16,8 @@
 
 package com.thoughtworks.go.spark.spa;
 
+import com.thoughtworks.go.server.service.support.toggle.FeatureToggleService;
+import com.thoughtworks.go.server.service.support.toggle.Toggles;
 import com.thoughtworks.go.spark.Routes;
 import com.thoughtworks.go.spark.SparkController;
 import com.thoughtworks.go.spark.spring.SPAAuthenticationHelper;
@@ -31,10 +33,12 @@ import static spark.Spark.*;
 public class ConfigReposDelegate implements SparkController {
     private SPAAuthenticationHelper authenticationHelper;
     private TemplateEngine engine;
+    private FeatureToggleService features;
 
-    public ConfigReposDelegate(SPAAuthenticationHelper authenticationHelper, TemplateEngine engine) {
+    public ConfigReposDelegate(SPAAuthenticationHelper authenticationHelper, TemplateEngine engine, FeatureToggleService features) {
         this.authenticationHelper = authenticationHelper;
         this.engine = engine;
+        this.features = features;
     }
 
     @Override
@@ -46,6 +50,7 @@ public class ConfigReposDelegate implements SparkController {
     public void setupRoutes() {
         path(controllerBasePath(), () -> {
             before("", authenticationHelper::checkAdminUserAnd403);
+            before("", this::featureToggleGuard);
             get("", this::index, engine);
         });
     }
@@ -55,5 +60,11 @@ public class ConfigReposDelegate implements SparkController {
             put("viewTitle", "Config Repos");
         }};
         return new ModelAndView(object, "config_repos/index.vm");
+    }
+
+    private void featureToggleGuard(Request req, Response res) {
+        if (!features.isToggleOn(Toggles.CONFIG_REPOS_UI)) {
+            res.redirect("/");
+        }
     }
 }

--- a/spark/spark-spa/src/main/java/com/thoughtworks/go/spark/spa/ConfigReposDelegate.java
+++ b/spark/spark-spa/src/main/java/com/thoughtworks/go/spark/spa/ConfigReposDelegate.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2018 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.spark.spa;
+
+import com.thoughtworks.go.spark.Routes;
+import com.thoughtworks.go.spark.SparkController;
+import com.thoughtworks.go.spark.spring.SPAAuthenticationHelper;
+import spark.ModelAndView;
+import spark.Request;
+import spark.Response;
+import spark.TemplateEngine;
+
+import java.util.HashMap;
+
+import static spark.Spark.*;
+
+public class ConfigReposDelegate implements SparkController {
+    private SPAAuthenticationHelper authenticationHelper;
+    private TemplateEngine engine;
+
+    public ConfigReposDelegate(SPAAuthenticationHelper authenticationHelper, TemplateEngine engine) {
+        this.authenticationHelper = authenticationHelper;
+        this.engine = engine;
+    }
+
+    @Override
+    public String controllerBasePath() {
+        return Routes.ConfigRepos.SPA_BASE;
+    }
+
+    @Override
+    public void setupRoutes() {
+        path(controllerBasePath(), () -> {
+            before("", authenticationHelper::checkAdminUserAnd403);
+            get("", this::index, engine);
+        });
+    }
+
+    public ModelAndView index(Request request, Response response) {
+        HashMap<Object, Object> object = new HashMap<Object, Object>() {{
+            put("viewTitle", "Config Repos");
+        }};
+        return new ModelAndView(object, "config_repos/index.vm");
+    }
+}

--- a/spark/spark-spa/src/main/java/com/thoughtworks/go/spark/spa/spring/SpaControllers.java
+++ b/spark/spark-spa/src/main/java/com/thoughtworks/go/spark/spa/spring/SpaControllers.java
@@ -56,6 +56,7 @@ public class SpaControllers implements SparkSpringController {
         sparkControllers.add(new ArtifactStoresDelegate(authenticationHelper, templateEngineFactory.create(ArtifactStoresDelegate.class, "layouts/single_page_app.vm")));
         sparkControllers.add(new AnalyticsDelegate(authenticationHelper, templateEngineFactory.create(AnalyticsDelegate.class, "layouts/single_page_app.vm"), systemEnvironment, analyticsExtension, pipelineConfigService));
         sparkControllers.add(new DataSharingSettingsDelegate(authenticationHelper, templateEngineFactory.create(DataSharingSettingsDelegate.class, "layouts/single_page_app.vm")));
+        sparkControllers.add(new ConfigReposDelegate(authenticationHelper, templateEngineFactory.create(ConfigReposDelegate.class, "layouts/single_page_app.vm")));
     }
 
     @Override

--- a/spark/spark-spa/src/main/java/com/thoughtworks/go/spark/spa/spring/SpaControllers.java
+++ b/spark/spark-spa/src/main/java/com/thoughtworks/go/spark/spa/spring/SpaControllers.java
@@ -46,17 +46,13 @@ public class SpaControllers implements SparkSpringController {
         sparkControllers.add(new RolesControllerDelegate(authenticationHelper, templateEngineFactory.create(RolesControllerDelegate.class, "layouts/single_page_app.vm")));
         sparkControllers.add(new AuthConfigsDelegate(authenticationHelper, templateEngineFactory.create(AuthConfigsDelegate.class, "layouts/single_page_app.vm")));
         sparkControllers.add(new AgentsControllerDelegate(authenticationHelper, templateEngineFactory.create(AgentsControllerDelegate.class, "layouts/single_page_app.vm"), securityService, systemEnvironment));
-        if (featureToggleService.isToggleOn(Toggles.COMPONENTS)) {
-            sparkControllers.add(new PluginsDelegate(authenticationHelper, templateEngineFactory.create(PluginsDelegate.class, "layouts/component_layout.vm"), securityService));
-        } else {
-            sparkControllers.add(new PluginsDelegate(authenticationHelper, templateEngineFactory.create(PluginsDelegate.class, "layouts/single_page_app.vm"), securityService));
-        }
+        sparkControllers.add(new PluginsDelegate(authenticationHelper, templateEngineFactory.create(PluginsDelegate.class, layoutTemplate(featureToggleService)), securityService));
         sparkControllers.add(new ElasticProfilesDelegate(authenticationHelper, templateEngineFactory.create(ElasticProfilesDelegate.class, "layouts/single_page_app.vm")));
         sparkControllers.add(new NewDashboardDelegate(authenticationHelper, templateEngineFactory.create(NewDashboardDelegate.class, "layouts/single_page_app.vm"), securityService, systemEnvironment, pipelineConfigService));
         sparkControllers.add(new ArtifactStoresDelegate(authenticationHelper, templateEngineFactory.create(ArtifactStoresDelegate.class, "layouts/single_page_app.vm")));
         sparkControllers.add(new AnalyticsDelegate(authenticationHelper, templateEngineFactory.create(AnalyticsDelegate.class, "layouts/single_page_app.vm"), systemEnvironment, analyticsExtension, pipelineConfigService));
         sparkControllers.add(new DataSharingSettingsDelegate(authenticationHelper, templateEngineFactory.create(DataSharingSettingsDelegate.class, "layouts/single_page_app.vm")));
-        sparkControllers.add(new ConfigReposDelegate(authenticationHelper, templateEngineFactory.create(ConfigReposDelegate.class, "layouts/single_page_app.vm")));
+        sparkControllers.add(new ConfigReposDelegate(authenticationHelper, templateEngineFactory.create(ConfigReposDelegate.class, layoutTemplate(featureToggleService))));
     }
 
     @Override
@@ -64,5 +60,9 @@ public class SpaControllers implements SparkSpringController {
         for (SparkController sparkController : sparkControllers) {
             sparkController.setupRoutes();
         }
+    }
+
+    private String layoutTemplate(FeatureToggleService toggles) {
+        return toggles.isToggleOn(Toggles.COMPONENTS) ? "layouts/component_layout.vm" : "layouts/single_page_app.vm";
     }
 }

--- a/spark/spark-spa/src/main/java/com/thoughtworks/go/spark/spa/spring/SpaControllers.java
+++ b/spark/spark-spa/src/main/java/com/thoughtworks/go/spark/spa/spring/SpaControllers.java
@@ -19,7 +19,6 @@ package com.thoughtworks.go.spark.spa.spring;
 import com.thoughtworks.go.plugin.access.analytics.AnalyticsExtension;
 import com.thoughtworks.go.server.service.PipelineConfigService;
 import com.thoughtworks.go.server.service.SecurityService;
-import com.thoughtworks.go.server.service.support.toggle.FeatureToggleListener;
 import com.thoughtworks.go.server.service.support.toggle.FeatureToggleService;
 import com.thoughtworks.go.server.service.support.toggle.Toggles;
 import com.thoughtworks.go.spark.SparkController;
@@ -52,7 +51,7 @@ public class SpaControllers implements SparkSpringController {
         sparkControllers.add(new ArtifactStoresDelegate(authenticationHelper, templateEngineFactory.create(ArtifactStoresDelegate.class, "layouts/single_page_app.vm")));
         sparkControllers.add(new AnalyticsDelegate(authenticationHelper, templateEngineFactory.create(AnalyticsDelegate.class, "layouts/single_page_app.vm"), systemEnvironment, analyticsExtension, pipelineConfigService));
         sparkControllers.add(new DataSharingSettingsDelegate(authenticationHelper, templateEngineFactory.create(DataSharingSettingsDelegate.class, "layouts/single_page_app.vm")));
-        sparkControllers.add(new ConfigReposDelegate(authenticationHelper, templateEngineFactory.create(ConfigReposDelegate.class, layoutTemplate(featureToggleService))));
+        sparkControllers.add(new ConfigReposDelegate(authenticationHelper, templateEngineFactory.create(ConfigReposDelegate.class, layoutTemplate(featureToggleService)), featureToggleService));
     }
 
     @Override

--- a/spark/spark-spa/src/main/resources/velocity/config_repos/index.vm
+++ b/spark/spark-spa/src/main/resources/velocity/config_repos/index.vm
@@ -1,0 +1,19 @@
+#*
+ * Copyright 2018 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *#
+<div id="config-repos">
+  HELLO
+  <span class="page-spinner"></span>
+</div>

--- a/spark/spark-spa/src/test/groovy/com/thoughtworks/go/spark/spa/ConfigReposDelegateTest.groovy
+++ b/spark/spark-spa/src/test/groovy/com/thoughtworks/go/spark/spa/ConfigReposDelegateTest.groovy
@@ -16,17 +16,24 @@
 
 package com.thoughtworks.go.spark.spa
 
+import com.thoughtworks.go.server.service.support.toggle.FeatureToggleService
+import com.thoughtworks.go.server.service.support.toggle.Toggles
 import com.thoughtworks.go.spark.AdminUserSecurity
 import com.thoughtworks.go.spark.ControllerTrait
 import com.thoughtworks.go.spark.SecurityServiceTrait
 import com.thoughtworks.go.spark.spring.SPAAuthenticationHelper
 import org.junit.jupiter.api.Nested
 
+import static org.mockito.Mockito.mock
+import static org.mockito.Mockito.when
+
 class ConfigReposDelegateTest implements ControllerTrait<ConfigReposDelegate>, SecurityServiceTrait {
 
   @Override
   ConfigReposDelegate createControllerInstance() {
-    return new ConfigReposDelegate(new SPAAuthenticationHelper(securityService, goConfigService), templateEngine)
+    FeatureToggleService features = mock(FeatureToggleService.class)
+    when(features.isToggleOn(Toggles.CONFIG_REPOS_UI)).thenReturn(true)
+    return new ConfigReposDelegate(new SPAAuthenticationHelper(securityService, goConfigService), templateEngine, features)
   }
 
   @Nested

--- a/spark/spark-spa/src/test/groovy/com/thoughtworks/go/spark/spa/ConfigReposDelegateTest.groovy
+++ b/spark/spark-spa/src/test/groovy/com/thoughtworks/go/spark/spa/ConfigReposDelegateTest.groovy
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2018 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.spark.spa
+
+import com.thoughtworks.go.spark.AdminUserSecurity
+import com.thoughtworks.go.spark.ControllerTrait
+import com.thoughtworks.go.spark.SecurityServiceTrait
+import com.thoughtworks.go.spark.spring.SPAAuthenticationHelper
+import org.junit.jupiter.api.Nested
+
+class ConfigReposDelegateTest implements ControllerTrait<ConfigReposDelegate>, SecurityServiceTrait {
+
+  @Override
+  ConfigReposDelegate createControllerInstance() {
+    return new ConfigReposDelegate(new SPAAuthenticationHelper(securityService, goConfigService), templateEngine)
+  }
+
+  @Nested
+  class Index {
+    @Nested
+    class Security implements SecurityTestTrait, AdminUserSecurity {
+
+      @Override
+      String getControllerMethodUnderTest() {
+        return "index"
+      }
+
+      @Override
+      void makeHttpCall() {
+        get(controller.controllerPath())
+      }
+    }
+  }
+
+}

--- a/spark/spark-spa/src/test/groovy/com/thoughtworks/go/spark/spa/ConfigReposDelegateTest.groovy
+++ b/spark/spark-spa/src/test/groovy/com/thoughtworks/go/spark/spa/ConfigReposDelegateTest.groovy
@@ -31,8 +31,12 @@ class ConfigReposDelegateTest implements ControllerTrait<ConfigReposDelegate>, S
 
   @Override
   ConfigReposDelegate createControllerInstance() {
-    FeatureToggleService features = mock(FeatureToggleService.class)
-    when(features.isToggleOn(Toggles.CONFIG_REPOS_UI)).thenReturn(true)
+    FeatureToggleService features = new FeatureToggleService(null, null) {
+      @Override
+      boolean isToggleOn(String key) {
+        return key == Toggles.CONFIG_REPOS_UI;
+      }
+    }
     return new ConfigReposDelegate(new SPAAuthenticationHelper(securityService, goConfigService), templateEngine, features)
   }
 


### PR DESCRIPTION
# Notes
Only implements basic CRUD operations with some validations.

# Usage:

Set the feature toggle `config_repos_ui` to `true` in `go.feature.toggles`.

Navigate to `/go/admin/config_repos`

This SPA is aware/compatible with the `components` toggle. This SPA is completely (and intentionally) unstyled, however.