### PR TITLE
Remove If-Match header check for data sharing PATCH API (#5162)

### DIFF
--- a/api/api-data-sharing-settings-v1/src/main/java/com/thoughtworks/go/apiv1/datasharing/settings/DataSharingSettingsControllerV1.java
+++ b/api/api-data-sharing-settings-v1/src/main/java/com/thoughtworks/go/apiv1/datasharing/settings/DataSharingSettingsControllerV1.java
@@ -100,9 +100,6 @@ public class DataSharingSettingsControllerV1 extends ApiController implements Sp
     }
 
     public String patchDataSharingSettings(Request request, Response response) throws Exception {
-        if (!isPutRequestFresh(request, dataSharingSettingsService.get())) {
-            throw haltBecauseEtagDoesNotMatch();
-        }
         HttpLocalizedOperationResult result = new HttpLocalizedOperationResult();
         dataSharingSettingsService.createOrUpdate(getEntityFromRequestBody(request));
         return handleCreateOrUpdateResponse(request, response, dataSharingSettingsService.get(), result);

--- a/api/api-data-sharing-settings-v1/src/test/groovy/com/thoughtworks/go/apiv1/datasharing/settings/DataSharingSettingsControllerV1Test.groovy
+++ b/api/api-data-sharing-settings-v1/src/test/groovy/com/thoughtworks/go/apiv1/datasharing/settings/DataSharingSettingsControllerV1Test.groovy
@@ -177,11 +177,9 @@ class DataSharingSettingsControllerV1Test implements SecurityServiceTrait, Contr
                 def captor = ArgumentCaptor.forClass(DataSharingSettings.class)
                 doNothing().when(dataSharingSettingsService).createOrUpdate(any())
                 doReturn(settings).when(dataSharingSettingsService).get()
-                when(entityHashingService.md5ForEntity(settings)).thenReturn("cached-md5")
 
                 def headers = [
                   'accept'      : controller.mimeType,
-                  'If-Match'    : 'cached-md5',
                   'content-type': 'application/json'
                 ]
 
@@ -208,11 +206,9 @@ class DataSharingSettingsControllerV1Test implements SecurityServiceTrait, Contr
                 def captor = ArgumentCaptor.forClass(DataSharingSettings.class)
                 doNothing().when(dataSharingSettingsService).createOrUpdate(any())
                 doReturn(settings).when(dataSharingSettingsService).get()
-                when(entityHashingService.md5ForEntity(settings)).thenReturn("cached-md5")
 
                 def headers = [
                   'accept'      : controller.mimeType,
-                  'If-Match'    : 'cached-md5',
                   'content-type': 'application/json'
                 ]
 
@@ -228,26 +224,6 @@ class DataSharingSettingsControllerV1Test implements SecurityServiceTrait, Contr
                 assertEquals(settingsBeingSaved.allowSharing(), settings.allowSharing())
                 assertEquals(settingsBeingSaved.updatedBy(), currentUsername().getUsername().toString())
             }
-
-            @Test
-            void 'should reject update if old etag is provided'() {
-                def data = [allow: true]
-                def settings = new DataSharingSettings()
-                doReturn(settings).when(dataSharingSettingsService).get()
-                when(entityHashingService.md5ForEntity(settings)).thenReturn("new-md5")
-                def headers = [
-                  'accept'      : controller.mimeType,
-                  'If-Match'    : 'old-md5',
-                  'content-type': 'application/json'
-                ]
-
-                patchWithApiHeader(controller.controllerBasePath(), headers, data)
-                assertThatResponse()
-                  .isPreconditionFailed()
-                  .hasJsonMessage("Someone has modified the entity. Please update your copy with the changes and try again.")
-                verify(dataSharingSettingsService, never()).createOrUpdate(any())
-            }
         }
     }
 }
-


### PR DESCRIPTION
This PR fixes the API to not require `If-Match` Header.

I will be sending another PR to fix the same ETag being returned even when data sharing consent is changed.