### PR TITLE
Fix ETag computation for DataSharing Settings API (#5162)

### DIFF
--- a/common/src/main/java/com/thoughtworks/go/listener/DataSharingSettingsChangeListener.java
+++ b/common/src/main/java/com/thoughtworks/go/listener/DataSharingSettingsChangeListener.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2018 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.listener;
+
+import com.thoughtworks.go.server.domain.DataSharingSettings;
+
+public interface DataSharingSettingsChangeListener {
+    void onDataSharingSettingsChange(DataSharingSettings updatedSettings);
+}

--- a/server/src/main/java/com/thoughtworks/go/server/service/EntityHashingService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/EntityHashingService.java
@@ -28,6 +28,7 @@ import com.thoughtworks.go.domain.packagerepository.PackageDefinition;
 import com.thoughtworks.go.domain.packagerepository.PackageRepository;
 import com.thoughtworks.go.domain.scm.SCM;
 import com.thoughtworks.go.listener.ConfigChangedListener;
+import com.thoughtworks.go.listener.DataSharingSettingsChangeListener;
 import com.thoughtworks.go.listener.EntityConfigChangedListener;
 import com.thoughtworks.go.server.cache.GoCache;
 import com.thoughtworks.go.server.domain.DataSharingSettings;
@@ -78,7 +79,7 @@ public class EntityHashingService implements ConfigChangedListener, Initializer 
     @Override
     public void startDaemon() {
     }
-    
+
     @Override
     public void onConfigChange(CruiseConfig newCruiseConfig) {
         goCache.remove(ETAG_CACHE_KEY);
@@ -217,7 +218,7 @@ public class EntityHashingService implements ConfigChangedListener, Initializer 
     }
 
     public String md5ForEntity(DataSharingSettings dataSharingSettings) {
-        String cacheKey = cacheKey(dataSharingSettings, Long.toString(dataSharingSettings.getId()));
+        String cacheKey = cacheKey(dataSharingSettings, "data_sharing_settings");
         return getFromCache(cacheKey, dataSharingSettings);
     }
 
@@ -324,6 +325,7 @@ public class EntityHashingService implements ConfigChangedListener, Initializer 
             removeFromCache(pipelineConfigs, pipelineConfigs.getGroup());
         }
     }
+
     private class MergePipelineConfigsChangedListener extends EntityConfigChangedListener<MergePipelineConfigs> {
         @Override
         public void onEntityConfigChange(MergePipelineConfigs pipelineConfigs) {

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/datasharing/DataSharingSettingsServiceIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/datasharing/DataSharingSettingsServiceIntegrationTest.java
@@ -132,6 +132,17 @@ public class DataSharingSettingsServiceIntegrationTest {
     }
 
     @Test
+    public void shouldFlushEtagCacheForDataSharingSettingsOnUpdate() {
+        DataSharingSettings existing = dataSharingSettingsService.get();
+        String settingsEtagCacheKey = existing.getClass().getName() + "." + "data_sharing_settings";
+        goCache.put("GO_ETAG_CACHE", settingsEtagCacheKey, "existing-etag-in-cache");
+
+        assertNotNull(goCache.get("GO_ETAG_CACHE", settingsEtagCacheKey));
+        dataSharingSettingsService.createOrUpdate(new DataSharingSettings(false, "Bob", new Date()));
+        assertNull(goCache.get("GO_ETAG_CACHE", settingsEtagCacheKey));
+    }
+
+    @Test
     public void shouldUpdateMd5SumOfDataSharingSettingsUponSave() {
         DataSharingSettings loaded = dataSharingSettingsService.get();
 


### PR DESCRIPTION
* Clear DataSharingSettings ETAG Cache from GoCache on every update of DataSharingSettings
* Keep ETag implementation for DataSharingSettings GET API as it will be used by browsers for caching

Issue reference: https://github.com/gocd/gocd/issues/5162#issuecomment-422667256