### PR TITLE
Allow artifact plugins to introduce new env vars

### DIFF
--- a/common/src/main/java/com/thoughtworks/go/remote/work/artifact/ArtifactRequestProcessor.java
+++ b/common/src/main/java/com/thoughtworks/go/remote/work/artifact/ArtifactRequestProcessor.java
@@ -16,6 +16,8 @@
 
 package com.thoughtworks.go.remote.work.artifact;
 
+import com.thoughtworks.go.plugin.access.artifact.ArtifactExtension;
+import com.thoughtworks.go.plugin.access.artifact.ArtifactExtensionConstants;
 import com.thoughtworks.go.plugin.api.request.GoApiRequest;
 import com.thoughtworks.go.plugin.api.response.DefaultGoApiResponse;
 import com.thoughtworks.go.plugin.api.response.GoApiResponse;
@@ -34,7 +36,7 @@ import static java.lang.String.format;
 import static java.util.Arrays.asList;
 
 public class ArtifactRequestProcessor implements GoPluginApiRequestProcessor {
-    private static final List<String> goSupportedVersions = asList("1.0");
+    private static final List<String> goSupportedVersions = ArtifactExtensionConstants.SUPPORTED_VERSIONS;
     private final SafeOutputStreamConsumer safeOutputStreamConsumer;
     private final ProcessType processType;
 

--- a/common/src/test/java/com/thoughtworks/go/remote/work/ArtifactRequestProcessorV1Test.java
+++ b/common/src/test/java/com/thoughtworks/go/remote/work/ArtifactRequestProcessorV1Test.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2018 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.remote.work;
+
+import com.thoughtworks.go.plugin.api.request.GoApiRequest;
+import com.thoughtworks.go.plugin.infra.plugininfo.GoPluginDescriptor;
+import com.thoughtworks.go.remote.work.artifact.ArtifactRequestProcessor;
+import com.thoughtworks.go.util.command.EnvironmentVariableContext;
+import com.thoughtworks.go.util.command.PasswordArgument;
+import com.thoughtworks.go.work.DefaultGoPublisher;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Collections;
+
+import static com.thoughtworks.go.remote.work.artifact.ArtifactRequestProcessor.Request.CONSOLE_LOG;
+import static com.thoughtworks.go.util.command.TaggedStreamConsumer.*;
+import static org.mockito.Mockito.*;
+
+public class ArtifactRequestProcessorV1Test extends ArtifactRequestProcessorTestBase {
+    @Override
+    protected String getRequestPluginVersion() {
+        return "1.0";
+    }
+}

--- a/common/src/test/java/com/thoughtworks/go/remote/work/ArtifactRequestProcessorV2Test.java
+++ b/common/src/test/java/com/thoughtworks/go/remote/work/ArtifactRequestProcessorV2Test.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2018 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.remote.work;
+
+import com.thoughtworks.go.plugin.api.request.GoApiRequest;
+import com.thoughtworks.go.plugin.infra.plugininfo.GoPluginDescriptor;
+import com.thoughtworks.go.remote.work.artifact.ArtifactRequestProcessor;
+import com.thoughtworks.go.util.command.EnvironmentVariableContext;
+import com.thoughtworks.go.util.command.PasswordArgument;
+import com.thoughtworks.go.work.DefaultGoPublisher;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Collections;
+
+import static com.thoughtworks.go.remote.work.artifact.ArtifactRequestProcessor.Request.CONSOLE_LOG;
+import static com.thoughtworks.go.util.command.TaggedStreamConsumer.*;
+import static org.mockito.Mockito.*;
+
+public class ArtifactRequestProcessorV2Test extends ArtifactRequestProcessorTestBase {
+    @Override
+    protected String getRequestPluginVersion() {
+        return "2.0";
+    }
+}

--- a/plugin-infra/go-plugin-access/build.gradle
+++ b/plugin-infra/go-plugin-access/build.gradle
@@ -16,6 +16,8 @@
 
 description = 'APIs to allow GoCD to communicate with GoCD Plugins'
 
+apply plugin: 'groovy'
+
 dependencies {
   compile project(':plugin-infra:go-plugin-infra')
   compile project(':domain')
@@ -25,6 +27,7 @@ dependencies {
 
   compileOnly(group: 'org.bouncycastle', name: 'bcprov-jdk15on', version: project.versions.bouncyCastle)
 
+  testCompile localGroovy()
   testCompile group: 'net.javacrumbs.json-unit', name: 'json-unit-fluent', version: project.versions.jsonUnit
   testCompile project(':test:test-utils')
   testCompile project(path: ':domain', configuration: 'testOutput')

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/artifact/ArtifactExtensionConstants.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/artifact/ArtifactExtensionConstants.java
@@ -20,7 +20,9 @@ import java.util.Arrays;
 import java.util.List;
 
 public interface ArtifactExtensionConstants {
-    List<String> SUPPORTED_VERSIONS = Arrays.asList(ArtifactMessageConverterV1.VERSION);
+    String V1 = "1.0";
+    String V2 = "2.0";
+    List<String> SUPPORTED_VERSIONS = Arrays.asList(V1, V2);
 
     String REQUEST_PREFIX = "cd.go.artifact";
     String REQUEST_GET_CAPABILITIES = REQUEST_PREFIX + ".get-capabilities";

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/artifact/ArtifactMessageConverter.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/artifact/ArtifactMessageConverter.java
@@ -20,6 +20,7 @@ import com.thoughtworks.go.config.ArtifactStore;
 import com.thoughtworks.go.domain.ArtifactPlan;
 import com.thoughtworks.go.domain.config.Configuration;
 import com.thoughtworks.go.plugin.access.artifact.model.PublishArtifactResponse;
+import com.thoughtworks.go.plugin.access.artifact.models.FetchArtifactEnvironmentVariable;
 import com.thoughtworks.go.plugin.api.response.validation.ValidationResult;
 import com.thoughtworks.go.plugin.domain.artifact.Capabilities;
 import com.thoughtworks.go.plugin.domain.common.Image;
@@ -47,4 +48,6 @@ public interface ArtifactMessageConverter {
     Image getImageResponseFromBody(String responseBody);
 
     Capabilities getCapabilitiesFromResponseBody(String responseBody);
+
+    List<FetchArtifactEnvironmentVariable> getFetchArtifactEnvironmentVariablesFromResponseBody(String responseBody);
 }

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/artifact/ArtifactMessageConverterV2.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/artifact/ArtifactMessageConverterV2.java
@@ -18,6 +18,7 @@ package com.thoughtworks.go.plugin.access.artifact;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.google.gson.reflect.TypeToken;
 import com.thoughtworks.go.config.ArtifactStore;
 import com.thoughtworks.go.domain.ArtifactPlan;
 import com.thoughtworks.go.domain.config.Configuration;
@@ -36,8 +37,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-public class ArtifactMessageConverterV1 implements ArtifactMessageConverter {
-    public static final String VERSION = ArtifactExtensionConstants.V1;
+public class ArtifactMessageConverterV2 implements ArtifactMessageConverter {
+    public static final String VERSION = ArtifactExtensionConstants.V2;
     private static final Gson GSON = new GsonBuilder().serializeNulls().create();
 
     @Override
@@ -105,7 +106,7 @@ public class ArtifactMessageConverterV1 implements ArtifactMessageConverter {
 
     @Override
     public List<FetchArtifactEnvironmentVariable> getFetchArtifactEnvironmentVariablesFromResponseBody(String responseBody) {
-        return new ArrayList<>();
+        return new Gson().fromJson(responseBody, new TypeToken<List<FetchArtifactEnvironmentVariable>>() {}.getType());
     }
 
     private String getTemplateFromResponse(String responseBody, String message) {

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/artifact/models/FetchArtifactEnvironmentVariable.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/artifact/models/FetchArtifactEnvironmentVariable.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2018 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.plugin.access.artifact.models;
+
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+
+/* Provided by an artifact plugin, after fetching artifacts. These environment variables should be
+* made available, in context, to the rest of the tasks. */
+public class FetchArtifactEnvironmentVariable {
+    private final String name;
+    private final String value;
+    private final boolean secure;
+
+    public FetchArtifactEnvironmentVariable(String name, String value, boolean secure) {
+        this.name = name;
+        this.value = value;
+        this.secure = secure;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+
+        if (o == null || getClass() != o.getClass()) return false;
+
+        FetchArtifactEnvironmentVariable that = (FetchArtifactEnvironmentVariable) o;
+
+        return new EqualsBuilder()
+                .append(secure, that.secure)
+                .append(name, that.name)
+                .append(value, that.value)
+                .isEquals();
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder(17, 37)
+                .append(name)
+                .append(value)
+                .append(secure)
+                .toHashCode();
+    }
+}

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/artifact/models/FetchArtifactEnvironmentVariable.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/artifact/models/FetchArtifactEnvironmentVariable.java
@@ -16,6 +16,7 @@
 
 package com.thoughtworks.go.plugin.access.artifact.models;
 
+import com.thoughtworks.go.util.command.EnvironmentVariableContext;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 
@@ -30,6 +31,25 @@ public class FetchArtifactEnvironmentVariable {
         this.name = name;
         this.value = value;
         this.secure = secure;
+    }
+
+    public String name() {
+        return name;
+    }
+
+    public String value() {
+        return value;
+    }
+
+    public boolean isSecure() {
+        return secure;
+    }
+
+    public String displayValue() {
+        if (isSecure()) {
+            return EnvironmentVariableContext.EnvironmentVariable.MASK_VALUE;
+        }
+        return value();
     }
 
     @Override

--- a/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/artifact/ArtifactExtensionForV1Test.groovy
+++ b/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/artifact/ArtifactExtensionForV1Test.groovy
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2018 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.plugin.access.artifact;
+
+import com.thoughtworks.go.config.ArtifactStore;
+import com.thoughtworks.go.config.FetchPluggableArtifactTask;
+import com.thoughtworks.go.domain.ArtifactPlan;
+import com.thoughtworks.go.plugin.access.artifact.model.PublishArtifactResponse;
+import com.thoughtworks.go.plugin.access.artifact.models.FetchArtifactEnvironmentVariable;
+import com.thoughtworks.go.plugin.api.request.GoPluginApiRequest;
+import com.thoughtworks.go.plugin.api.response.DefaultGoPluginApiResponse;
+import com.thoughtworks.go.plugin.api.response.validation.ValidationError;
+import com.thoughtworks.go.plugin.api.response.validation.ValidationResult;
+import com.thoughtworks.go.plugin.domain.common.Metadata;
+import com.thoughtworks.go.plugin.domain.common.PluginConfiguration;
+import com.thoughtworks.go.plugin.infra.PluginManager;
+import com.thoughtworks.go.util.command.EnvironmentVariableContext;
+import org.hamcrest.Matchers;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.mockito.ArgumentCaptor;
+
+import java.util.Collections;
+import java.util.List;
+
+import static com.thoughtworks.go.domain.packagerepository.ConfigurationPropertyMother.create;
+import static com.thoughtworks.go.plugin.access.artifact.ArtifactExtensionConstants.*;
+import static com.thoughtworks.go.plugin.api.response.DefaultGoPluginApiResponse.SUCCESS_RESPONSE_CODE;
+import static com.thoughtworks.go.plugin.domain.common.PluginConstants.ARTIFACT_EXTENSION;
+import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.emptyCollectionOf;
+import static org.hamcrest.Matchers.hasEntry;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.*;
+
+class ArtifactExtensionForV1Test extends ArtifactExtensionTestBase {
+    @Override
+    String versionToTestAgainst() {
+        return ArtifactMessageConverterV1.VERSION;
+    }
+
+    @Test
+    void shouldSubmitFetchArtifactRequest() {
+        when(pluginManager.submitTo(eq(PLUGIN_ID), eq(ARTIFACT_EXTENSION), requestArgumentCaptor.capture())).thenReturn(DefaultGoPluginApiResponse.success(""));
+        final FetchPluggableArtifactTask pluggableArtifactTask = new FetchPluggableArtifactTask(null, null, "artifactId", create("Filename", false, "build/libs/foo.jar"));
+
+        List<FetchArtifactEnvironmentVariable> environmentVariables = artifactExtension.fetchArtifact(PLUGIN_ID, new ArtifactStore("s3", "cd.go.s3"), pluggableArtifactTask.getConfiguration(), Collections.singletonMap("Version", "10.12.0"), "/temp");
+
+        final GoPluginApiRequest request = requestArgumentCaptor.getValue();
+
+        def requestHash = [
+          artifact_metadata: [
+            Version: "10.12.0"
+          ],
+          store_configuration: [:],
+          fetch_artifact_configuration: [
+            "Filename": "build/libs/foo.jar"
+          ],
+          "agent_working_directory": "/temp"
+        ]
+
+        assertThat(request.extension(), is(ARTIFACT_EXTENSION));
+        assertThat(request.requestName(), is(REQUEST_FETCH_ARTIFACT));
+        assertThatJson(request.requestBody()).isEqualTo(requestHash);
+
+        assertThat(environmentVariables, is([]))
+    }
+}

--- a/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/artifact/ArtifactExtensionForV2Test.groovy
+++ b/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/artifact/ArtifactExtensionForV2Test.groovy
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2018 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.plugin.access.artifact
+
+import com.google.gson.Gson
+import com.thoughtworks.go.config.ArtifactStore
+import com.thoughtworks.go.config.FetchPluggableArtifactTask
+import com.thoughtworks.go.plugin.access.artifact.models.FetchArtifactEnvironmentVariable
+import com.thoughtworks.go.plugin.api.request.GoPluginApiRequest
+import com.thoughtworks.go.plugin.api.response.DefaultGoPluginApiResponse
+import org.junit.Test
+
+import static com.thoughtworks.go.domain.packagerepository.ConfigurationPropertyMother.create
+import static com.thoughtworks.go.plugin.access.artifact.ArtifactExtensionConstants.REQUEST_FETCH_ARTIFACT
+import static com.thoughtworks.go.plugin.domain.common.PluginConstants.ARTIFACT_EXTENSION
+import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson
+import static org.hamcrest.CoreMatchers.is
+import static org.hamcrest.MatcherAssert.assertThat
+import static org.mockito.ArgumentMatchers.eq
+import static org.mockito.Mockito.when
+
+class ArtifactExtensionForV2Test extends ArtifactExtensionTestBase {
+    @Override
+    String versionToTestAgainst() {
+        return ArtifactMessageConverterV2.VERSION;
+    }
+
+    @Test
+    void shouldSubmitFetchArtifactRequestAndParseEnvironmentVariablesReturned() {
+        def requestHash = [
+          artifact_metadata: [
+            Version: "10.12.0"
+          ],
+          store_configuration: [:],
+          fetch_artifact_configuration: [
+            "Filename": "build/libs/foo.jar"
+          ],
+          "agent_working_directory": "/temp"
+        ]
+
+        def responseHash = [
+          [
+            name  : "VAR1",
+            value : "VALUE1",
+            secure: true
+          ],
+          [
+            name  : "VAR2",
+            value : "VALUE2",
+            secure: false
+          ]
+        ]
+
+        when(pluginManager.submitTo(eq(PLUGIN_ID), eq(ARTIFACT_EXTENSION), requestArgumentCaptor.capture())).thenReturn(DefaultGoPluginApiResponse.success(new Gson().toJson(responseHash)));
+        final FetchPluggableArtifactTask pluggableArtifactTask = new FetchPluggableArtifactTask(null, null, "artifactId", create("Filename", false, "build/libs/foo.jar"));
+
+        List<FetchArtifactEnvironmentVariable> environmentVariables = artifactExtension.fetchArtifact(PLUGIN_ID, new ArtifactStore("s3", "cd.go.s3"), pluggableArtifactTask.getConfiguration(), Collections.singletonMap("Version", "10.12.0"), "/temp");
+
+        final GoPluginApiRequest request = requestArgumentCaptor.getValue();
+
+        assertThat(request.extension(), is(ARTIFACT_EXTENSION));
+        assertThat(request.requestName(), is(REQUEST_FETCH_ARTIFACT));
+        assertThatJson(request.requestBody()).isEqualTo(requestHash);
+
+        assertThat(environmentVariables, is([
+          new FetchArtifactEnvironmentVariable("VAR1", "VALUE1", true),
+          new FetchArtifactEnvironmentVariable("VAR2", "VALUE2", false),
+        ]));
+    }
+}


### PR DESCRIPTION
This allows an artifact plugin to introduce environment variables into the job, after fetching an external artifact. This was planned for earlier versions of the k8s work but was not finished. Without this, you'll need to use external tools to parse the metadata JSON. With this, the plugin can expose environment variables which are then made available to all the tasks following the fetch artifact.

Assume there's a new version of the Docker artifact plugin. Assume a config which contains:

```
Pipeline 1:
    Stage 1:
        Job 1:
            Task 1: Run some tests
            Task 2: Run a docker build

            Specify artifact 1: External artifact (id = X) for the plugin - image1/v${GO_PIPELINE_COUNTER}

Pipeline 2:
    Stage 1:
        Job 1:
            Task 1: Fetch external artifact X from "Pipeline 1 / Stage 1 / Job 1"
            Task 2: Deploy to k8s using helm
            Task 3: Notify about state of deployment
```

At the end of "Task 1" in the second pipeline, the plugin can now set environment variables by returning a JSON such as the one below:

```
[
  {
    "name": "IMAGE_ID",
    "value": "image1/v23",
    "secure": false
  },
  {
    "name": "USERNAME",
    "value": "user1",
    "secure": false
  },
  {
    "name": "PASSWORD",
    "value": "some-password",
    "secure": true
  }
]
```

This will cause:
  1. Log messages in the console log of the fetch artifact task, which explain which environment variables are being set (see [test](https://github.com/gocd/gocd/compare/master...arvindsv:allow-artifact-plugins-to-introduce-new-env-vars#diff-c00abeef577a955db2e67dbf2c2a9079R156) for example messages).
  2. Introduce those environment variables into the job so that Task 2 and Task 3 will now have access to those environment variables when they execute.

Considerations:
  - It's possible for two fetch artifact tasks to overwrite each other's environment variables. Last one wins. It's up to the plugin to accept a prefix which it uses in the environment variable name.

### Test setup:

1. Use plugin built from [this](https://github.com/sheroy/docker-registry-artifact-plugin/tree/e6cce770b6115fb21a82c85e9ef71167d55410d0).

2. Pull docker image used in config below:

    ```
    docker pull sheroy/bulletin-board:1
    ```

3. Use this config XML (below), and replace all instances of `YOUR-DOCKER-HUB-USERNAME-HERE` and `YOUR-DOCKER-HUB-PASSWORD-HERE` with valid credentials:

<details>
    <summary>Show config XML:</summary><p>

```xml
<?xml version="1.0" encoding="utf-8"?>
<cruise xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="cruise-config.xsd" schemaVersion="113">
  <server artifactsdir="artifacts" agentAutoRegisterKey="0bc584a7-e64c-4a33-86e1-8c4fe0a8ac1d" webhookSecret="a3bd1404-d360-4e55-8434-a128411db580" commandRepositoryLocation="default" serverId="7b772e27-cd9a-46d8-bf2b-0cbb5fb9acf2" tokenGenerationKey="611db7c3-f137-44a1-b5f3-10a3f625e308">
    <backup emailOnSuccess="true" emailOnFailure="true" />
  </server>
  <artifactStores>
    <artifactStore id="abc" pluginId="cd.go.artifact.docker.registry">
      <property>
        <key>RegistryURL</key>
        <value>https://index.docker.io/v1/</value>
      </property>
      <property>
        <key>Username</key>
        <value>YOUR-DOCKER-HUB-USERNAME-HERE</value>
      </property>
      <property>
        <key>Password</key>
        <value>YOUR-DOCKER-HUB-PASSWORD-HERE</value>
      </property>
    </artifactStore>
  </artifactStores>
  <pipelines group="defaultGroup">
    <pipeline name="Abc">
      <materials>
        <git url="git@github.com:arvindsv/faketime.git" />
      </materials>
      <stage name="stage1">
        <jobs>
          <job name="job1_stage1">
            <tasks>
              <exec command="bash">
                <arg>-c</arg>
                <arg>docker tag sheroy/bulletin-board:1 YOUR-DOCKER-HUB-USERNAME-HERE/bulletin-board:v${GO_PIPELINE_COUNTER}</arg>
                <runif status="passed" />
              </exec>
            </tasks>
            <artifacts>
              <artifact type="external" id="abcdef" storeId="abc">
                <configuration>
                  <property>
                    <key>BuildFile</key>
                    <value />
                  </property>
                  <property>
                    <key>Image</key>
                    <value>YOUR-DOCKER-HUB-USERNAME-HERE/bulletin-board</value>
                  </property>
                  <property>
                    <key>Tag</key>
                    <value>v${GO_PIPELINE_COUNTER}</value>
                  </property>
                </configuration>
              </artifact>
            </artifacts>
          </job>
        </jobs>
      </stage>
      <stage name="stage2">
        <jobs>
          <job name="job1_stage2">
            <tasks>
              <fetchartifact artifactOrigin="external" artifactId="abcdef" pipeline="Abc" stage="stage1" job="job1_stage1">
                <configuration>
                  <property>
                    <key>EnvironmentVariablePrefix</key>
                    <value>PREFIX1</value>
                  </property>
                </configuration>
                <runif status="passed" />
              </fetchartifact>
              <exec command="/bin/bash">
                <arg>-c</arg>
                <arg>env</arg>
                <runif status="passed" />
              </exec>
            </tasks>
          </job>
        </jobs>
      </stage>
    </pipeline>
  </pipelines>
</cruise>
```
    
</p></details>
&nbsp;

4. Trigger pipeline. In the console of the job, "job1_stage2", you should see something like this:

    ```
     NOTE: Setting new environment variable: PREFIX1_ARTIFACT_IMAGE = YOUR-DOCKER-HUB-USERNAME-HERE/bulletin-board:v1
    ```

    You'll also see in the output of the `env` command that it has the environment variable, `PREFIX1_ARTIFACT_IMAGE`, set.

### Todos:

- [ ] Update [functional spec](https://github.com/gocd/ruby-functional-tests/blob/master/specs/ExternalArtifacts.spec) - Done in: https://github.com/gocd/ruby-functional-tests/pull/172
  - [ ] Update the [test plugin](https://github.com/bdpiparva/dummy-artifact-plugin) - Done in: https://github.com/gocd/go-plugins/pull/69
  - [x] Move the test plugin into the gocd org - Done in: https://github.com/gocd/go-plugins/pull/68
- [ ] Introduce new plugin which uses this version and sets environment variables (@sheroy) - Will come from https://github.com/sheroy/docker-registry-artifact-plugin/commits/master
- [ ] Update [API docs](https://plugin-api.gocd.org/current/artifacts/#fetch-artifact)
- [x] Provide more info in this issue (provide a config XML which shows this being used)

@sheroy has seen this.