### PR TITLE
Attempting to fix a few flaky tests

### DIFF
--- a/common/src/test/java/com/thoughtworks/go/domain/builder/pluggableTask/PluggableTaskConsoleTest.java
+++ b/common/src/test/java/com/thoughtworks/go/domain/builder/pluggableTask/PluggableTaskConsoleTest.java
@@ -91,8 +91,7 @@ public class PluggableTaskConsoleTest {
 
         doNothing().when(safeOutputStreamConsumer).stdOutput(anyString());
         console.readOutputOf(in);
-        Thread.sleep(100);// may become flaky!! Fingers crossed
-        verify(safeOutputStreamConsumer, times(7)).stdOutput(anyString());
+        verify(safeOutputStreamConsumer, timeout(10000).times(7)).stdOutput(anyString());
     }
 
     @Test
@@ -107,8 +106,7 @@ public class PluggableTaskConsoleTest {
 
         doNothing().when(safeOutputStreamConsumer).errOutput(anyString());
         console.readErrorOf(in);
-        Thread.sleep(100);// may become flaky!! Fingers crossed
-        verify(safeOutputStreamConsumer, times(7)).errOutput(anyString());
+        verify(safeOutputStreamConsumer, timeout(10000).times(7)).errOutput(anyString());
     }
 
 }

--- a/plugin-infra/go-plugin-infra/src/test/java/com/thoughtworks/go/plugin/infra/monitor/AbstractDefaultPluginJarLocationMonitorTest.java
+++ b/plugin-infra/go-plugin-infra/src/test/java/com/thoughtworks/go/plugin/infra/monitor/AbstractDefaultPluginJarLocationMonitorTest.java
@@ -30,6 +30,7 @@ import java.net.URISyntaxException;
 import java.net.URL;
 
 public abstract class AbstractDefaultPluginJarLocationMonitorTest {
+    private static final int NO_OF_TRIES_TO_CHECK_MONITOR_RUN = 30;
     @Rule
     public final TemporaryFolder temporaryFolder = new TemporaryFolder();
 
@@ -38,6 +39,16 @@ public abstract class AbstractDefaultPluginJarLocationMonitorTest {
     protected void waitAMoment() throws InterruptedException {
         Thread.yield();
         Thread.sleep(2000);
+    }
+
+    protected void waitUntilNextRun(DefaultPluginJarLocationMonitor monitor) throws InterruptedException {
+        long previousRun = monitor.getLastRun();
+        int numberOfTries = 0;
+        while(previousRun >= monitor.getLastRun() && numberOfTries < NO_OF_TRIES_TO_CHECK_MONITOR_RUN) {
+            Thread.yield();
+            Thread.sleep(500);
+            numberOfTries++;
+        }
     }
 
     protected void copyPluginToThePluginDirectory(File pluginDir, String destinationFilenameOfPlugin) throws IOException, URISyntaxException {

--- a/plugin-infra/go-plugin-infra/src/test/java/com/thoughtworks/go/plugin/infra/monitor/DefaultExternalPluginJarLocationMonitorTest.java
+++ b/plugin-infra/go-plugin-infra/src/test/java/com/thoughtworks/go/plugin/infra/monitor/DefaultExternalPluginJarLocationMonitorTest.java
@@ -97,7 +97,7 @@ public class DefaultExternalPluginJarLocationMonitorTest extends AbstractDefault
         monitor.start();
 
         copyPluginToThePluginDirectory(pluginExternalDir, "descriptor-aware-test-plugin-2.jar");
-        waitAMoment();
+        waitUntilNextRun(monitor);
 
         verify(changeListener).pluginJarAdded(pluginFileDetails(pluginExternalDir, "descriptor-aware-test-plugin-2.jar", false));
         verifyNoMoreInteractions(changeListener);
@@ -109,7 +109,7 @@ public class DefaultExternalPluginJarLocationMonitorTest extends AbstractDefault
         monitor.start();
 
         copyPluginToThePluginDirectory(pluginExternalDir, "descriptor-aware-test-plugin.something-other-than-jar.zip");
-        waitAMoment();
+        waitUntilNextRun(monitor);
 
         verifyNoMoreInteractions(changeListener);
     }
@@ -119,11 +119,11 @@ public class DefaultExternalPluginJarLocationMonitorTest extends AbstractDefault
         monitor.addPluginJarChangeListener(changeListener);
         monitor.start();
         copyPluginToThePluginDirectory(pluginExternalDir, "descriptor-aware-test-plugin-2.jar");
-        waitAMoment();
+        waitUntilNextRun(monitor);
         verify(changeListener).pluginJarAdded(pluginFileDetails(pluginExternalDir, "descriptor-aware-test-plugin-2.jar", false));
 
         FileUtils.deleteQuietly(new File(pluginExternalDir, "descriptor-aware-test-plugin-2.jar"));
-        waitAMoment();
+        waitUntilNextRun(monitor);
 
         verify(changeListener).pluginJarRemoved(pluginFileDetails(pluginExternalDir, "descriptor-aware-test-plugin-2.jar", false));
         verifyNoMoreInteractions(changeListener);
@@ -135,12 +135,12 @@ public class DefaultExternalPluginJarLocationMonitorTest extends AbstractDefault
         monitor.start();
 
         copyPluginToThePluginDirectory(pluginExternalDir, "descriptor-aware-test-external-plugin-1.jar");
-        waitAMoment();
+        waitUntilNextRun(monitor);
         verify(changeListener).pluginJarAdded(pluginFileDetails(pluginExternalDir, "descriptor-aware-test-external-plugin-1.jar", false));
 
         copyPluginToThePluginDirectory(pluginExternalDir, "descriptor-aware-test-external-plugin-2.jar");
         copyPluginToThePluginDirectory(pluginExternalDir, "descriptor-aware-test-external-plugin-3.jar");
-        waitAMoment();
+        waitUntilNextRun(monitor);
         verify(changeListener).pluginJarAdded(pluginFileDetails(pluginExternalDir, "descriptor-aware-test-external-plugin-2.jar", false));
         verify(changeListener).pluginJarAdded(pluginFileDetails(pluginExternalDir, "descriptor-aware-test-external-plugin-3.jar", false));
         verifyNoMoreInteractions(changeListener);
@@ -154,14 +154,14 @@ public class DefaultExternalPluginJarLocationMonitorTest extends AbstractDefault
         copyPluginToThePluginDirectory(pluginExternalDir, "descriptor-aware-test-external-plugin-1.jar");
         copyPluginToThePluginDirectory(pluginExternalDir, "descriptor-aware-test-external-plugin-2.jar");
         copyPluginToThePluginDirectory(pluginExternalDir, "descriptor-aware-test-external-plugin-3.jar");
-        waitAMoment();
+        waitUntilNextRun(monitor);
         verify(changeListener).pluginJarAdded(pluginFileDetails(pluginExternalDir, "descriptor-aware-test-external-plugin-1.jar", false));
         verify(changeListener).pluginJarAdded(pluginFileDetails(pluginExternalDir, "descriptor-aware-test-external-plugin-2.jar", false));
         verify(changeListener).pluginJarAdded(pluginFileDetails(pluginExternalDir, "descriptor-aware-test-external-plugin-3.jar", false));
 
         FileUtils.deleteQuietly(new File(pluginExternalDir, "descriptor-aware-test-external-plugin-1.jar"));
         FileUtils.deleteQuietly(new File(pluginExternalDir, "descriptor-aware-test-external-plugin-2.jar"));
-        waitAMoment();
+        waitUntilNextRun(monitor);
         verify(changeListener).pluginJarRemoved(pluginFileDetails(pluginExternalDir, "descriptor-aware-test-external-plugin-1.jar", false));
         verify(changeListener).pluginJarRemoved(pluginFileDetails(pluginExternalDir, "descriptor-aware-test-external-plugin-2.jar", false));
         verifyNoMoreInteractions(changeListener);
@@ -173,14 +173,14 @@ public class DefaultExternalPluginJarLocationMonitorTest extends AbstractDefault
         monitor.start();
 
         copyPluginToThePluginDirectory(pluginExternalDir, "descriptor-aware-test-external-plugin-1.jar");
-        waitAMoment();
+        waitUntilNextRun(monitor);
         PluginFileDetails orgExternalFile = pluginFileDetails(pluginExternalDir, "descriptor-aware-test-external-plugin-1.jar", false);
         verify(changeListener).pluginJarAdded(orgExternalFile);
 
         PluginFileDetails newExternalFile = pluginFileDetails(pluginExternalDir, "descriptor-aware-test-external-plugin-1-new.jar", false);
         FileUtils.moveFile(orgExternalFile.file(), newExternalFile.file());
 
-        waitAMoment();
+        waitUntilNextRun(monitor);
 
         InOrder inOrder = inOrder(changeListener);
         inOrder.verify(changeListener).pluginJarRemoved(orgExternalFile);
@@ -193,11 +193,11 @@ public class DefaultExternalPluginJarLocationMonitorTest extends AbstractDefault
         monitor.addPluginJarChangeListener(changeListener);
         monitor.start();
         copyPluginToThePluginDirectory(pluginExternalDir, "descriptor-aware-test-external-plugin.jar");
-        waitAMoment();
+        waitUntilNextRun(monitor);
         verify(changeListener).pluginJarAdded(pluginFileDetails(pluginExternalDir, "descriptor-aware-test-external-plugin.jar", false));
 
         updateFileContents(new File(pluginExternalDir, "descriptor-aware-test-external-plugin.jar"));
-        waitAMoment();
+        waitUntilNextRun(monitor);
 
         verify(changeListener).pluginJarUpdated(pluginFileDetails(pluginExternalDir, "descriptor-aware-test-external-plugin.jar", false));
         verifyNoMoreInteractions(changeListener);
@@ -210,7 +210,7 @@ public class DefaultExternalPluginJarLocationMonitorTest extends AbstractDefault
 
         copyPluginToThePluginDirectory(pluginBundledDir, "descriptor-aware-test-bundled-plugin-1.jar");
         copyPluginToThePluginDirectory(pluginExternalDir, "descriptor-aware-test-external-plugin-1.jar");
-        waitAMoment();
+        waitUntilNextRun(monitor);
         InOrder jarAddedOrder = inOrder(changeListener);
         jarAddedOrder.verify(changeListener).pluginJarAdded(pluginFileDetails(pluginBundledDir, "descriptor-aware-test-bundled-plugin-1.jar", true));
         jarAddedOrder.verify(changeListener).pluginJarAdded(pluginFileDetails(pluginExternalDir, "descriptor-aware-test-external-plugin-1.jar", false));
@@ -218,14 +218,14 @@ public class DefaultExternalPluginJarLocationMonitorTest extends AbstractDefault
 
         updateFileContents(new File(pluginBundledDir, "descriptor-aware-test-bundled-plugin-1.jar"));
         updateFileContents(new File(pluginExternalDir, "descriptor-aware-test-external-plugin-1.jar"));
-        waitAMoment();
+        waitUntilNextRun(monitor);
         InOrder jarUpdatedOrder = inOrder(changeListener);
         jarUpdatedOrder.verify(changeListener).pluginJarUpdated(pluginFileDetails(pluginBundledDir, "descriptor-aware-test-bundled-plugin-1.jar", true));
         jarUpdatedOrder.verify(changeListener).pluginJarUpdated(pluginFileDetails(pluginExternalDir, "descriptor-aware-test-external-plugin-1.jar", false));
 
         FileUtils.deleteQuietly(new File(pluginBundledDir, "descriptor-aware-test-bundled-plugin-1.jar"));
         FileUtils.deleteQuietly(new File(pluginExternalDir, "descriptor-aware-test-external-plugin-1.jar"));
-        waitAMoment();
+        waitUntilNextRun(monitor);
         InOrder jarRemovedOrder = inOrder(changeListener);
         jarRemovedOrder.verify(changeListener).pluginJarRemoved(pluginFileDetails(pluginBundledDir, "descriptor-aware-test-bundled-plugin-1.jar", true));
         jarRemovedOrder.verify(changeListener).pluginJarRemoved(pluginFileDetails(pluginExternalDir, "descriptor-aware-test-external-plugin-1.jar", false));
@@ -241,7 +241,7 @@ public class DefaultExternalPluginJarLocationMonitorTest extends AbstractDefault
         copyPluginToThePluginDirectory(pluginBundledDir, "descriptor-aware-test-bundled-plugin-1.jar");
         copyPluginToThePluginDirectory(pluginExternalDir, "descriptor-aware-test-external-plugin-1.jar");
         ArgumentCaptor<PluginFileDetails> pluginFileDetailsArgumentCaptor = ArgumentCaptor.forClass(PluginFileDetails.class);
-        waitAMoment();
+        waitUntilNextRun(monitor);
         verify(changeListener, times(2)).pluginJarAdded(pluginFileDetailsArgumentCaptor.capture());
         assertThat(pluginFileDetailsArgumentCaptor.getAllValues().get(0).isBundledPlugin(), is(true));
         assertThat(pluginFileDetailsArgumentCaptor.getAllValues().get(1).isBundledPlugin(), is(false));

--- a/plugin-infra/go-plugin-infra/src/test/java/com/thoughtworks/go/plugin/infra/monitor/DefaultPluginJarLocationMonitorTest.java
+++ b/plugin-infra/go-plugin-infra/src/test/java/com/thoughtworks/go/plugin/infra/monitor/DefaultPluginJarLocationMonitorTest.java
@@ -88,7 +88,7 @@ public class DefaultPluginJarLocationMonitorTest extends AbstractDefaultPluginJa
         copyPluginToThePluginDirectory(bundledPluginDir, "descriptor-aware-test-plugin.jar");
         monitor.start();
 
-        waitAMoment();
+        waitUntilNextRun(monitor);
 
         verifyNoMoreInteractions(changeListener);
     }
@@ -99,7 +99,7 @@ public class DefaultPluginJarLocationMonitorTest extends AbstractDefaultPluginJa
         monitor.start();
 
         copyPluginToThePluginDirectory(bundledPluginDir, "descriptor-aware-test-plugin.jar");
-        waitAMoment();
+        waitUntilNextRun(monitor);
 
         verify(changeListener).pluginJarAdded(pluginFileDetails(bundledPluginDir, "descriptor-aware-test-plugin.jar", true));
         verifyNoMoreInteractions(changeListener);
@@ -111,7 +111,7 @@ public class DefaultPluginJarLocationMonitorTest extends AbstractDefaultPluginJa
         monitor.start();
 
         copyPluginToThePluginDirectory(bundledPluginDir, "descriptor-aware-test-plugin.something-other-than-jar.zip");
-        waitAMoment();
+        waitUntilNextRun(monitor);
 
         verifyNoMoreInteractions(changeListener);
     }
@@ -137,11 +137,11 @@ public class DefaultPluginJarLocationMonitorTest extends AbstractDefaultPluginJa
         monitor.addPluginJarChangeListener(changeListener);
         monitor.start();
         copyPluginToThePluginDirectory(bundledPluginDir, "descriptor-aware-test-plugin.jar");
-        waitAMoment();
+        waitUntilNextRun(monitor);
         verify(changeListener).pluginJarAdded(pluginFileDetails(bundledPluginDir, "descriptor-aware-test-plugin.jar", true));
 
         FileUtils.deleteQuietly(new File(bundledPluginDir, "descriptor-aware-test-plugin.jar"));
-        waitAMoment();
+        waitUntilNextRun(monitor);
 
         verify(changeListener).pluginJarRemoved(pluginFileDetails(bundledPluginDir, "descriptor-aware-test-plugin.jar", true));
         verifyNoMoreInteractions(changeListener);
@@ -153,12 +153,12 @@ public class DefaultPluginJarLocationMonitorTest extends AbstractDefaultPluginJa
         monitor.start();
 
         copyPluginToThePluginDirectory(bundledPluginDir, "descriptor-aware-test-plugin-1.jar");
-        waitAMoment();
+        waitUntilNextRun(monitor);
         verify(changeListener).pluginJarAdded(pluginFileDetails(bundledPluginDir, "descriptor-aware-test-plugin-1.jar", true));
 
         copyPluginToThePluginDirectory(bundledPluginDir, "descriptor-aware-test-plugin-2.jar");
         copyPluginToThePluginDirectory(bundledPluginDir, "descriptor-aware-test-plugin-3.jar");
-        waitAMoment();
+        waitUntilNextRun(monitor);
 
         verify(changeListener).pluginJarAdded(pluginFileDetails(bundledPluginDir, "descriptor-aware-test-plugin-2.jar", true));
         verify(changeListener).pluginJarAdded(pluginFileDetails(bundledPluginDir, "descriptor-aware-test-plugin-3.jar", true));
@@ -174,13 +174,13 @@ public class DefaultPluginJarLocationMonitorTest extends AbstractDefaultPluginJa
         monitor.start();
 
         copyPluginToThePluginDirectory(bundledPluginDir, "descriptor-aware-test-plugin-1.jar");
-        waitAMoment();
+        waitUntilNextRun(monitor);
         verify(changeListener).pluginJarAdded(pluginFileDetails(bundledPluginDir, "descriptor-aware-test-plugin-1.jar", true));
         verify(exceptionRasingListener).pluginJarAdded(pluginFileDetails(bundledPluginDir, "descriptor-aware-test-plugin-1.jar", true));
 
         copyPluginToThePluginDirectory(bundledPluginDir, "descriptor-aware-test-plugin-2.jar");
         copyPluginToThePluginDirectory(bundledPluginDir, "descriptor-aware-test-plugin-3.jar");
-        waitAMoment();
+        waitUntilNextRun(monitor);
 
         verify(changeListener).pluginJarAdded(pluginFileDetails(bundledPluginDir, "descriptor-aware-test-plugin-2.jar", true));
         verify(exceptionRasingListener).pluginJarAdded(pluginFileDetails(bundledPluginDir, "descriptor-aware-test-plugin-2.jar", true));
@@ -198,14 +198,14 @@ public class DefaultPluginJarLocationMonitorTest extends AbstractDefaultPluginJa
         copyPluginToThePluginDirectory(bundledPluginDir, "descriptor-aware-test-plugin-1.jar");
         copyPluginToThePluginDirectory(bundledPluginDir, "descriptor-aware-test-plugin-2.jar");
         copyPluginToThePluginDirectory(bundledPluginDir, "descriptor-aware-test-plugin-3.jar");
-        waitAMoment();
+        waitUntilNextRun(monitor);
         verify(changeListener).pluginJarAdded(pluginFileDetails(bundledPluginDir, "descriptor-aware-test-plugin-1.jar", true));
         verify(changeListener).pluginJarAdded(pluginFileDetails(bundledPluginDir, "descriptor-aware-test-plugin-2.jar", true));
         verify(changeListener).pluginJarAdded(pluginFileDetails(bundledPluginDir, "descriptor-aware-test-plugin-3.jar", true));
 
         FileUtils.deleteQuietly(new File(bundledPluginDir, "descriptor-aware-test-plugin-1.jar"));
         FileUtils.deleteQuietly(new File(bundledPluginDir, "descriptor-aware-test-plugin-2.jar"));
-        waitAMoment();
+        waitUntilNextRun(monitor);
 
         verify(changeListener, atMost(1)).pluginJarUpdated(pluginFileDetails(bundledPluginDir, "descriptor-aware-test-plugin-1.jar", true));
         verify(changeListener, atMost(1)).pluginJarUpdated(pluginFileDetails(bundledPluginDir, "descriptor-aware-test-plugin-2.jar", true));
@@ -221,14 +221,14 @@ public class DefaultPluginJarLocationMonitorTest extends AbstractDefaultPluginJa
         monitor.start();
 
         copyPluginToThePluginDirectory(bundledPluginDir, "descriptor-aware-test-plugin-1.jar");
-        waitAMoment();
+        waitUntilNextRun(monitor);
         PluginFileDetails orgFile = pluginFileDetails(bundledPluginDir, "descriptor-aware-test-plugin-1.jar", true);
         verify(changeListener).pluginJarAdded(orgFile);
 
         PluginFileDetails newFile = pluginFileDetails(bundledPluginDir, "descriptor-aware-test-plugin-1-new.jar", true);
         FileUtils.moveFile(orgFile.file(), newFile.file());
 
-        waitAMoment();
+        waitUntilNextRun(monitor);
 
         InOrder inOrder = inOrder(changeListener);
         inOrder.verify(changeListener).pluginJarRemoved(orgFile);
@@ -241,11 +241,11 @@ public class DefaultPluginJarLocationMonitorTest extends AbstractDefaultPluginJa
         monitor.addPluginJarChangeListener(changeListener);
         monitor.start();
         copyPluginToThePluginDirectory(bundledPluginDir, "descriptor-aware-test-plugin.jar");
-        waitAMoment();
+        waitUntilNextRun(monitor);
         verify(changeListener).pluginJarAdded(pluginFileDetails(bundledPluginDir, "descriptor-aware-test-plugin.jar", true));
 
         updateFileContents(new File(bundledPluginDir, "descriptor-aware-test-plugin.jar"));
-        waitAMoment();
+        waitUntilNextRun(monitor);
 
         verify(changeListener).pluginJarUpdated(pluginFileDetails(bundledPluginDir, "descriptor-aware-test-plugin.jar", true));
         verifyNoMoreInteractions(changeListener);
@@ -256,7 +256,7 @@ public class DefaultPluginJarLocationMonitorTest extends AbstractDefaultPluginJa
         monitor.addPluginJarChangeListener(changeListener);
         monitor.start();
         copyPluginToThePluginDirectory(bundledPluginDir, "descriptor-aware-test-plugin.jar");
-        waitAMoment();
+        waitUntilNextRun(monitor);
         verify(changeListener).pluginJarAdded(pluginFileDetails(bundledPluginDir, "descriptor-aware-test-plugin.jar", true));
     }
 
@@ -266,11 +266,11 @@ public class DefaultPluginJarLocationMonitorTest extends AbstractDefaultPluginJa
         monitor.start();
         String pluginJar = "descriptor-aware-test-plugin.jar";
         copyPluginToThePluginDirectory(bundledPluginDir, pluginJar);
-        waitAMoment();
+        waitUntilNextRun(monitor);
         verify(changeListener).pluginJarAdded(pluginFileDetails(bundledPluginDir, pluginJar, true));
 
         FileUtils.deleteQuietly(new File(bundledPluginDir, pluginJar));
-        waitAMoment();
+        waitUntilNextRun(monitor);
         verify(changeListener).pluginJarRemoved(pluginFileDetails(bundledPluginDir, pluginJar, true));
     }
 
@@ -280,20 +280,20 @@ public class DefaultPluginJarLocationMonitorTest extends AbstractDefaultPluginJa
         monitor.start();
 
         copyPluginToThePluginDirectory(bundledPluginDir, "descriptor-aware-test-plugin-1.jar");
-        waitAMoment();
+        waitUntilNextRun(monitor);
         PluginFileDetails orgFile = pluginFileDetails(bundledPluginDir, "descriptor-aware-test-plugin-1.jar", true);
         verify(changeListener).pluginJarAdded(orgFile);
 
         PluginFileDetails newFile = pluginFileDetails(bundledPluginDir, "descriptor-aware-test-plugin-1-new.jar", true);
         FileUtils.moveFile(orgFile.file(), newFile.file());
-        waitAMoment();
+        waitUntilNextRun(monitor);
     }
 
     @Test
     public void shouldNotCreatePluginZipIfPluginJarIsNeitherUpdatedNorAddedOrRemoved() throws Exception {
         monitor.addPluginJarChangeListener(changeListener);
         monitor.start();
-        waitAMoment();
+        waitUntilNextRun(monitor);
     }
 
     @Test
@@ -301,12 +301,12 @@ public class DefaultPluginJarLocationMonitorTest extends AbstractDefaultPluginJa
         monitor.addPluginJarChangeListener(changeListener);
         monitor.start();
         copyPluginToThePluginDirectory(bundledPluginDir, "descriptor-aware-test-plugin-1.jar");
-        waitAMoment();
+        waitUntilNextRun(monitor);
         verify(changeListener).pluginJarAdded(pluginFileDetails(bundledPluginDir, "descriptor-aware-test-plugin-1.jar", true));
 
         monitor.removePluginJarChangeListener(changeListener);
         copyPluginToThePluginDirectory(bundledPluginDir, "descriptor-aware-test-plugin-2.jar");
-        waitAMoment();
+        waitUntilNextRun(monitor);
 
         verifyNoMoreInteractions(changeListener);
     }


### PR DESCRIPTION
- Added a `lastRun` time to the `DefaultPluginJarMonitor` thread to ensure that the test continues on the next run of the monitor thread.

The code changes are only for tests, which is not ideal, but still better than having flaky tests IMO.

~~- Changed the contract of `StreamPumper.pump()` to return a Future~~
~~- Separated out instance creation into a `get` method~~
(Removed the StreamPumper commit, since it will need some more work)
