### PR TITLE
Log required information while agents performing upgrade check

### DIFF
--- a/agent/src/main/java/com/thoughtworks/go/agent/service/AgentUpgradeService.java
+++ b/agent/src/main/java/com/thoughtworks/go/agent/service/AgentUpgradeService.java
@@ -93,6 +93,10 @@ public class AgentUpgradeService {
 
     private void validateMd5(String currentMd5, CloseableHttpResponse response, String agentContentMd5Header, String what) {
         final Header md5Header = response.getFirstHeader(agentContentMd5Header);
+        LOGGER.debug("[Agent Upgrade Validate MD5] validating MD5 for {}, currentMD5:{}, responseMD5:{}, headerKey:{}", what, currentMd5, md5Header, agentContentMd5Header);
+        if (md5Header == null) {
+            LOGGER.debug("[Agent Upgrade Validate MD5] Did not find {} MD5 header in response {}.", agentContentMd5Header, response);
+        }
         if (!"".equals(currentMd5)) {
             if (!currentMd5.equals(md5Header.getValue())) {
                 jvmExitter.jvmExit(what, currentMd5, md5Header.getValue());

--- a/server/src/main/java/com/thoughtworks/go/server/controller/AgentRegistrationController.java
+++ b/server/src/main/java/com/thoughtworks/go/server/controller/AgentRegistrationController.java
@@ -105,6 +105,12 @@ public class AgentRegistrationController {
 
     @RequestMapping(value = "/admin/latest-agent.status", method = {RequestMethod.HEAD, RequestMethod.GET})
     public void checkAgentStatus(HttpServletResponse response) {
+        LOG.info("Processing '/admin/latest-agent.status' request with values [{}:{}], [{}:{}], [{}:{}], [{}:{}]",
+                SystemEnvironment.AGENT_CONTENT_MD5_HEADER, agentChecksum,
+                SystemEnvironment.AGENT_LAUNCHER_CONTENT_MD5_HEADER, agentLauncherChecksum,
+                SystemEnvironment.AGENT_PLUGINS_ZIP_MD5_HEADER, pluginsZip.md5(),
+                SystemEnvironment.AGENT_TFS_SDK_MD5_HEADER, tfsSdkChecksum);
+
         response.setHeader(SystemEnvironment.AGENT_CONTENT_MD5_HEADER, agentChecksum);
         response.setHeader(SystemEnvironment.AGENT_LAUNCHER_CONTENT_MD5_HEADER, agentLauncherChecksum);
         response.setHeader(SystemEnvironment.AGENT_PLUGINS_ZIP_MD5_HEADER, pluginsZip.md5());


### PR DESCRIPTION
* NullPointerException happens during loop thread while performing upgrade check (verifying MD5) which causes agent not to ask for work
* Need more information to debug why NPE are happening.
More information: https://github.com/gocd/gocd/issues/4469