### PR TITLE
Check if monitor thread has run before retrieving work

### DIFF
--- a/agent/src/main/java/com/thoughtworks/go/agent/AgentControllerFactory.java
+++ b/agent/src/main/java/com/thoughtworks/go/agent/AgentControllerFactory.java
@@ -26,6 +26,7 @@ import com.thoughtworks.go.plugin.access.pluggabletask.TaskExtension;
 import com.thoughtworks.go.plugin.access.scm.SCMExtension;
 import com.thoughtworks.go.plugin.infra.PluginManager;
 import com.thoughtworks.go.plugin.infra.PluginRequestProcessorRegistry;
+import com.thoughtworks.go.plugin.infra.monitor.PluginJarLocationMonitor;
 import com.thoughtworks.go.publishers.GoArtifactsManipulator;
 import com.thoughtworks.go.remote.BuildRepositoryRemote;
 import com.thoughtworks.go.util.HttpService;
@@ -56,6 +57,7 @@ public class AgentControllerFactory {
     private final WebSocketSessionHandler sessionHandler;
     private static final Logger LOG = LoggerFactory.getLogger(AgentControllerFactory.class);
     private final AgentHealthHolder agentHealthHolder;
+    private final PluginJarLocationMonitor pluginJarLocationMonitor;
 
     @Autowired
     public AgentControllerFactory(
@@ -75,7 +77,8 @@ public class AgentControllerFactory {
             HttpService httpService,
             WebSocketClientHandler webSocketClientHandler,
             WebSocketSessionHandler sessionHandler,
-            AgentHealthHolder agentHealthHolder) {
+            AgentHealthHolder agentHealthHolder,
+            PluginJarLocationMonitor pluginJarLocationMonitor) {
         this.server = server;
         this.manipulator = manipulator;
         this.pluginManager = pluginManager;
@@ -93,6 +96,7 @@ public class AgentControllerFactory {
         this.webSocketClientHandler = webSocketClientHandler;
         this.sessionHandler = sessionHandler;
         this.agentHealthHolder = agentHealthHolder;
+        this.pluginJarLocationMonitor = pluginJarLocationMonitor;
     }
 
     public AgentController createInstance() {
@@ -132,7 +136,8 @@ public class AgentControllerFactory {
                     taskExtension,
                     artifactExtension,
                     pluginRequestProcessorRegistry,
-                    agentHealthHolder);
+                    agentHealthHolder,
+                    pluginJarLocationMonitor);
         }
     }
 }

--- a/agent/src/main/java/com/thoughtworks/go/agent/AgentHTTPClientController.java
+++ b/agent/src/main/java/com/thoughtworks/go/agent/AgentHTTPClientController.java
@@ -111,7 +111,7 @@ public class AgentHTTPClientController extends AgentController {
     @Override
     public void work() {
         LOG.debug("[Agent Loop] Trying to retrieve work.");
-        if (pluginJarLocationMonitor.getLastRun() > 0) {
+        if (pluginJarLocationMonitor.hasRunAtLeastOnce()) {
             retrieveCookieIfNecessary();
             retrieveWork();
             LOG.debug("[Agent Loop] Successfully retrieved work.");

--- a/agent/src/test/java/com/thoughtworks/go/agent/AgentHTTPClientControllerTest.java
+++ b/agent/src/test/java/com/thoughtworks/go/agent/AgentHTTPClientControllerTest.java
@@ -109,7 +109,7 @@ public class AgentHTTPClientControllerTest {
     public void shouldRetrieveWorkFromServerAndDoIt() throws Exception {
         when(loopServer.getWork(any(AgentRuntimeInfo.class))).thenReturn(work);
         when(agentRegistry.uuid()).thenReturn(agentUuid);
-        when(pluginJarLocationMonitor.getLastRun()).thenReturn(System.currentTimeMillis());
+        when(pluginJarLocationMonitor.hasRunAtLeastOnce()).thenReturn(true);
         agentController = createAgentController();
         agentController.init();
         agentController.ping();
@@ -121,7 +121,7 @@ public class AgentHTTPClientControllerTest {
     @Test
     public void shouldNotRetrieveWorkIfPluginMonitorHasNotRun() throws IOException {
         when(agentRegistry.uuid()).thenReturn(agentUuid);
-        when(pluginJarLocationMonitor.getLastRun()).thenReturn(0L);
+        when(pluginJarLocationMonitor.hasRunAtLeastOnce()).thenReturn(false);
         agentController = createAgentController();
         agentController.init();
         agentController.ping();
@@ -138,7 +138,7 @@ public class AgentHTTPClientControllerTest {
         when(sslInfrastructureService.isRegistered()).thenReturn(true);
         when(loopServer.getWork(agentController.getAgentRuntimeInfo())).thenReturn(work);
         when(agentRegistry.uuid()).thenReturn(agentUuid);
-        when(pluginJarLocationMonitor.getLastRun()).thenReturn(System.currentTimeMillis());
+        when(pluginJarLocationMonitor.hasRunAtLeastOnce()).thenReturn(true);
         agentController.loop();
         verify(work).doWork(any(EnvironmentVariableContext.class), any(AgentWorkContext.class));
     }

--- a/plugin-infra/go-plugin-infra/src/main/java/com/thoughtworks/go/plugin/infra/monitor/DefaultPluginJarLocationMonitor.java
+++ b/plugin-infra/go-plugin-infra/src/main/java/com/thoughtworks/go/plugin/infra/monitor/DefaultPluginJarLocationMonitor.java
@@ -80,7 +80,8 @@ public class DefaultPluginJarLocationMonitor implements PluginJarLocationMonitor
         monitorThread.start();
     }
 
-    long getLastRun() {
+    @Override
+    public long getLastRun() {
         if (monitorThread == null) {
             return 0;
         }
@@ -186,8 +187,6 @@ public class DefaultPluginJarLocationMonitor implements PluginJarLocationMonitor
 
         //Added synchronized because the compiler can change the order of instructions, meaning that the lastRun can be
         //updated before the listeners are notified.
-        //lastRun is needed only for tests. It may be a bit excessive to synchronize methods just for tests. So this can
-        //definitely be improved in the future
         public synchronized void oneShot() {
             knownBundledPluginFileDetails = loadAndNotifyPluginsFrom(bundledPluginDirectory, knownBundledPluginFileDetails, true);
             knownExternalPluginFileDetails = loadAndNotifyPluginsFrom(externalPluginDirectory, knownExternalPluginFileDetails, false);

--- a/plugin-infra/go-plugin-infra/src/main/java/com/thoughtworks/go/plugin/infra/monitor/DefaultPluginJarLocationMonitor.java
+++ b/plugin-infra/go-plugin-infra/src/main/java/com/thoughtworks/go/plugin/infra/monitor/DefaultPluginJarLocationMonitor.java
@@ -81,7 +81,11 @@ public class DefaultPluginJarLocationMonitor implements PluginJarLocationMonitor
     }
 
     @Override
-    public long getLastRun() {
+    public boolean hasRunAtLeastOnce() {
+        return getLastRun() > 0;
+    }
+
+    long getLastRun() {
         if (monitorThread == null) {
             return 0;
         }

--- a/plugin-infra/go-plugin-infra/src/main/java/com/thoughtworks/go/plugin/infra/monitor/PluginJarLocationMonitor.java
+++ b/plugin-infra/go-plugin-infra/src/main/java/com/thoughtworks/go/plugin/infra/monitor/PluginJarLocationMonitor.java
@@ -28,5 +28,5 @@ public interface PluginJarLocationMonitor {
 
     void oneShot();
 
-    long getLastRun();
+    boolean hasRunAtLeastOnce();
 }

--- a/plugin-infra/go-plugin-infra/src/main/java/com/thoughtworks/go/plugin/infra/monitor/PluginJarLocationMonitor.java
+++ b/plugin-infra/go-plugin-infra/src/main/java/com/thoughtworks/go/plugin/infra/monitor/PluginJarLocationMonitor.java
@@ -27,4 +27,6 @@ public interface PluginJarLocationMonitor {
     void stop();
 
     void oneShot();
+
+    long getLastRun();
 }


### PR DESCRIPTION
Fixes #5169 

The `getLastRun()` method was added to the monitorThread to fix a flaky test. (Whether that test has been fixed remains to be seen). I thought of leveraging the same thing to fix #5169. I don't know if this is a safe or good fix, but at least locally, I was able to see that the issue is solved from the logs:

```
2018-09-27 17:36:14,913 DEBUG [scheduler-1] AgentController:82 - [Agent Loop] Trying to retrieve work.
2018-09-27 17:36:14,914 DEBUG [scheduler-1] AgentHTTPClientController:113 - [Agent Loop] Trying to retrieve work.
2018-09-27 17:36:14,914 DEBUG [scheduler-1] AgentHTTPClientController:119 - [Agent Loop] PluginLocationMonitor has not yet run. Not retrieving work since plugins may not be initialized.
2018-09-27 17:36:14,914 DEBUG [scheduler-1] AgentController:86 - [Agent Loop] Successfully retrieved work.
2018-09-27 17:36:24,917 DEBUG [scheduler-3] AgentController:82 - [Agent Loop] Trying to retrieve work.
2018-09-27 17:36:24,918 DEBUG [scheduler-3] AgentHTTPClientController:113 - [Agent Loop] Trying to retrieve work.
2018-09-27 17:36:24,919 DEBUG [scheduler-3] AgentHTTPClientController:119 - [Agent Loop] PluginLocationMonitor has not yet run. Not retrieving work since plugins may not be initialized.
2018-09-27 17:36:24,919 DEBUG [scheduler-3] AgentController:86 - [Agent Loop] Successfully retrieved work.
2018-09-27 17:36:34,922 DEBUG [scheduler-3] AgentController:82 - [Agent Loop] Trying to retrieve work.
2018-09-27 17:36:34,923 DEBUG [scheduler-3] AgentHTTPClientController:113 - [Agent Loop] Trying to retrieve work.
2018-09-27 17:36:34,923 DEBUG [scheduler-3] AgentHTTPClientController:119 - [Agent Loop] PluginLocationMonitor has not yet run. Not retrieving work since plugins may not be initialized.
2018-09-27 17:36:34,923 DEBUG [scheduler-3] AgentController:86 - [Agent Loop] Successfully retrieved work.
2018-09-27 17:36:44,927 DEBUG [scheduler-3] AgentController:82 - [Agent Loop] Trying to retrieve work.
2018-09-27 17:36:44,928 DEBUG [scheduler-3] AgentHTTPClientController:113 - [Agent Loop] Trying to retrieve work.
2018-09-27 17:36:44,940 DEBUG [scheduler-3] AgentHTTPClientController:134 - [Agent Loop] Agent [in-akshaydewan.local, 127.0.0.1, be7c4e86-77b1-4663-a61f-e911b53b2def] is checking for work from Go
2018-09-27 17:36:44,949 DEBUG [scheduler-3] AgentHTTPClientController:117 - [Agent Loop] Successfully retrieved work.
2018-09-27 17:36:44,949 DEBUG [scheduler-3] AgentController:86 - [Agent Loop] Successfully retrieved work.
```

I had added a delay using `Thread.sleep` to `DefaultPluginJarLocationMonitor.oneShot()` to consistently recreate the issue on a fresh agent.