### PR TITLE
Avoid ajax calls for tests

### DIFF
--- a/server/webapp/WEB-INF/rails/webpack/helpers/constants.js
+++ b/server/webapp/WEB-INF/rails/webpack/helpers/constants.js
@@ -19,8 +19,8 @@ const $    = require('jquery');
 const meta = $("meta[name='gocd-params']");
 
 module.exports = {
-  SERVER_TIMEZONE_UTC_OFFSET: parseInt(meta.attr('data-timezone')),
-  SPA_REQUEST_TIMEOUT:        parseInt(meta.attr('data-page-timeout')),
-  SPA_REFRESH_INTERVAL:       parseInt(meta.attr('data-page-refresh-interval')),
+  SERVER_TIMEZONE_UTC_OFFSET: parseInt(meta.attr('data-timezone') || '0'),
+  SPA_REQUEST_TIMEOUT:        parseInt(meta.attr('data-page-timeout') || '5000'),
+  SPA_REFRESH_INTERVAL:       parseInt(meta.attr('data-page-refresh-interval') || '10000'),
   AUTH_LOGIN_PATH:  '/go/auth/login'
 };

--- a/server/webapp/WEB-INF/rails/webpack/views/components/notification_center/notification_center.js.msx
+++ b/server/webapp/WEB-INF/rails/webpack/views/components/notification_center/notification_center.js.msx
@@ -22,10 +22,24 @@ const DataSharingNotification   = require('models/notifications/data_sharing_not
 const AjaxPoller                = require('helpers/ajax_poller');
 
 
-DataSharingNotification.createIfNotPresent();
 const systemNotifications = Stream(new SystemNotifications());
 
+function createRepeater() {
+  return new AjaxPoller(() => SystemNotifications.all()
+    .then(redraw)
+    .always());
+}
+
+const repeater = Stream(createRepeater());
+
 const NotificationCenter = {
+  oninit() {
+    DataSharingNotification.createIfNotPresent();
+    repeater().start();
+  },
+  onbeforeremove() {
+    repeater().stop();
+  },
   view() {
     return <SystemNotificationsWidget systemNotifications={systemNotifications}/>;
   }
@@ -35,15 +49,5 @@ const redraw = (data) => {
   systemNotifications(new SystemNotifications(data.filterSystemNotification((n) => n.read() === false)));
   m.redraw();
 };
-
-function createRepeater() {
-  return new AjaxPoller(() => SystemNotifications.all()
-    .then(redraw)
-    .always());
-}
-
-const repeater = Stream(createRepeater());
-repeater().start();
-
 
 module.exports = NotificationCenter;

--- a/server/webapp/WEB-INF/rails/webpack/views/components/server_health_summary/server_health_summary.js.msx
+++ b/server/webapp/WEB-INF/rails/webpack/views/components/server_health_summary/server_health_summary.js.msx
@@ -31,9 +31,15 @@ function createRepeater() {
   });
 }
 
-createRepeater().start();
+const repeater = createRepeater();
 
 const ServerHealthSummary = {
+  oninit() {
+    repeater.start();
+  },
+  onbeforeremove() {
+    repeater.stop();
+  },
   view() {
     return m(ServerHealthMessagesCountWidget, {serverHealthMessages});
   }


### PR DESCRIPTION
* Setup constants file with sane defaults, when the dom is lacking the
  attributes. This is typically the case with tests.
* Create the ajax poller in the `oninit` of components. This avoids
  performing ajax calls on a `require` of the said js file.