### PR TITLE
Do not schedule timer triggered pipelines on an inactive server

### DIFF
--- a/server/src/main/java/com/thoughtworks/go/server/service/TimerScheduler.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/TimerScheduler.java
@@ -28,6 +28,7 @@ import com.thoughtworks.go.serverhealth.HealthStateScope;
 import com.thoughtworks.go.serverhealth.HealthStateType;
 import com.thoughtworks.go.serverhealth.ServerHealthService;
 import com.thoughtworks.go.serverhealth.ServerHealthState;
+import com.thoughtworks.go.util.SystemEnvironment;
 import org.quartz.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -55,6 +56,7 @@ public class TimerScheduler implements ConfigChangedListener {
     private GoConfigService goConfigService;
     private BuildCauseProducerService buildCauseProducerService;
     private ServerHealthService serverHealthService;
+    private SystemEnvironment systemEnvironment;
     private Scheduler quartzScheduler;
     protected static final String PIPELINE_TRIGGGER_TIMER_GROUP = "PIPELINE_TRIGGGER_TIMER_GROUP";
     protected static final String BUILD_CAUSE_PRODUCER_SERVICE = "BuildCauseProducerService";
@@ -62,14 +64,18 @@ public class TimerScheduler implements ConfigChangedListener {
 
     @Autowired
     public TimerScheduler(Scheduler scheduler, GoConfigService goConfigService,
-                          BuildCauseProducerService buildCauseProducerService, ServerHealthService serverHealthService) {
+                          BuildCauseProducerService buildCauseProducerService, ServerHealthService serverHealthService,
+                          SystemEnvironment systemEnvironment) {
         this.goConfigService = goConfigService;
         this.buildCauseProducerService = buildCauseProducerService;
         this.quartzScheduler = scheduler;
         this.serverHealthService = serverHealthService;
+        this.systemEnvironment = systemEnvironment;
     }
 
     public void initialize() {
+        if (!systemEnvironment.isServerActive()) return;
+
         scheduleAllJobs(goConfigService.getAllPipelineConfigs());
         goConfigService.register(this);
         goConfigService.register(pipelineConfigChangedListener());

--- a/server/src/test-fast/java/com/thoughtworks/go/server/service/TimerSchedulerQuartzIntegrationTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/service/TimerSchedulerQuartzIntegrationTest.java
@@ -27,6 +27,7 @@ import com.thoughtworks.go.config.PipelineConfig;
 import static com.thoughtworks.go.helper.PipelineConfigMother.pipelineConfigWithTimer;
 import com.thoughtworks.go.server.scheduling.BuildCauseProducerService;
 import com.thoughtworks.go.server.service.result.ServerHealthStateOperationResult;
+import com.thoughtworks.go.util.SystemEnvironment;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -44,11 +45,13 @@ import org.quartz.impl.StdSchedulerFactory;
 public class TimerSchedulerQuartzIntegrationTest {
     private StdSchedulerFactory quartzSchedulerFactory;
     private Scheduler scheduler;
+    private SystemEnvironment systemEnvironment;
 
     @Before
     public void setUp() throws Exception {
         quartzSchedulerFactory = new StdSchedulerFactory();
         scheduler = quartzSchedulerFactory.getScheduler();
+        systemEnvironment = new SystemEnvironment();
         scheduler.start();
     }
 
@@ -68,7 +71,7 @@ public class TimerSchedulerQuartzIntegrationTest {
 
         BuildCauseProducerService buildCauseProducerService = mock(BuildCauseProducerService.class);
 
-        TimerScheduler timerScheduler = new TimerScheduler(scheduler, goConfigService, buildCauseProducerService, null);
+        TimerScheduler timerScheduler = new TimerScheduler(scheduler, goConfigService, buildCauseProducerService, null, systemEnvironment);
         timerScheduler.initialize();
 
         pauseForScheduling();
@@ -88,7 +91,7 @@ public class TimerSchedulerQuartzIntegrationTest {
 
         BuildCauseProducerService buildCauseProducerService = mock(BuildCauseProducerService.class);
 
-        TimerScheduler timerScheduler = new TimerScheduler(scheduler, goConfigService, buildCauseProducerService, null);
+        TimerScheduler timerScheduler = new TimerScheduler(scheduler, goConfigService, buildCauseProducerService, null, systemEnvironment);
         timerScheduler.initialize();
 
         CruiseConfig cruiseConfig = new BasicCruiseConfig();


### PR DESCRIPTION
* Currently on an inactive server MDU, Scheduling etc are turned off.
  All non-GET requests are not allowed. This commit ensures even the
  timer triggered pipelines are not scheduled.