### PR TITLE
Icon click fixes

### DIFF
--- a/server/webapp/WEB-INF/rails/app/assets/new_stylesheets/components/_collapse.scss
+++ b/server/webapp/WEB-INF/rails/app/assets/new_stylesheets/components/_collapse.scss
@@ -27,26 +27,12 @@ $collapse-icon-color: #ddd;
   border-radius: $global-border-radius;
   margin-bottom: 10px;
   &.collapsed {
-    @include icon-before($type: angle-right, $color: $collapse-icon-color);
     background: $go-white;
-    &:before {
-      position:  absolute;
-      right:     10px;
-      font-size: 30px;
-      top:       3px;
-    }
   }
   &.expanded {
     @extend %box-shadow;
-    @include icon-before($type: angle-down, $color: $collapse-icon-color);
     .c-collapse_header {
       border-bottom: 1px solid $collapse-border;
-    }
-    &:before {
-      position:  absolute;
-      right:     10px;
-      font-size: 30px;
-      top:       3px;
     }
   }
 }
@@ -55,6 +41,24 @@ $collapse-icon-color: #ddd;
   @include clearfix();
   padding: 10px 50px 10px 30px;
   cursor:  pointer;
+  &.collapsed {
+    @include icon-before($type: angle-right, $color: $collapse-icon-color);
+    &:before {
+      position:  absolute;
+      right:     10px;
+      font-size: 30px;
+      top:       3px;
+    }
+  }
+  &.expanded {
+    @include icon-before($type: angle-down, $color: $collapse-icon-color);
+    &:before {
+      position:  absolute;
+      right:     10px;
+      font-size: 30px;
+      top:       3px;
+    }
+  }
 }
 
 .c-collapse_header_details {

--- a/server/webapp/WEB-INF/rails/spec/webpack/views/shared/dropdown_spec.js
+++ b/server/webapp/WEB-INF/rails/spec/webpack/views/shared/dropdown_spec.js
@@ -86,4 +86,10 @@ describe('Dropdown widget', () => {
     expect($root.find('.c-dropdown')).not.toHaveClass('open');
   });
 
+  it('should open drowndown when down-arrow is clicked', () => {
+    expect($root.find('.c-dropdown')).not.toHaveClass('open');
+    simulateEvent.simulate($root.find('.c-down-arrow').get(0), 'click');
+    expect($root.find('.c-dropdown')).toHaveClass('open');
+  });
+
 });

--- a/server/webapp/WEB-INF/rails/webpack/views/auth_configs/auth_config_widget.js.msx
+++ b/server/webapp/WEB-INF/rails/webpack/views/auth_configs/auth_config_widget.js.msx
@@ -56,7 +56,8 @@ const AuthConfigWidget = {
     }
     return (
       <div class={`c-collapse ${(this.showState() === 'hide') ? 'collapsed' : 'expanded'}`}>
-        <div class="c-collapse_header" onclick={vnode.state.toggleHide.bind(vnode.state)}>
+        <div class={`c-collapse_header ${(this.showState() === 'hide') ? 'collapsed' : 'expanded'}`}
+             onclick={vnode.state.toggleHide.bind(vnode.state)}>
 
           <div class="c-collapse_header_details">
             <span class="c-collapse_icon">

--- a/server/webapp/WEB-INF/rails/webpack/views/plugins/plugin_widget.js.msx
+++ b/server/webapp/WEB-INF/rails/webpack/views/plugins/plugin_widget.js.msx
@@ -37,6 +37,11 @@ const PluginWidget = {
             return this.vmState(vmStateKey)() ? 'show' : 'hide';
         };
     },
+
+    stopPropagation(event) {
+        event.stopPropagation();
+    },
+
     view(vnode) {
         const pluginInfo = vnode.attrs.pluginInfo;
 
@@ -59,8 +64,8 @@ const PluginWidget = {
             if (statusReport && vnode.attrs.isUserAnAdmin()) {
                 const statusReportHref = Routes.adminStatusReportPath(pluginInfo.id());
                 statusReportLink = (
-                    <f.anchor href={statusReportHref} class='btn-primary btn-small status-report-btn'>Status
-                        Report</f.anchor>
+                    <f.anchor href={statusReportHref} class='btn-primary btn-small status-report-btn'
+                              onclick={this.stopPropagation.bind(this)}>Status Report</f.anchor>
                 );
             } else if (statusReport) {
                 statusReportLink = (
@@ -71,7 +76,7 @@ const PluginWidget = {
             }
 
             if (settingsIcon && vnode.attrs.isUserAnAdmin()) {
-                editPluginSettingsLink = (<f.link class='edit-plugin' onclick={vnode.attrs.onEdit}/>);
+                editPluginSettingsLink = (<f.link class='edit-plugin' onclick={vnode.attrs.onEdit.bind(this)}/>);
             } else if (settingsIcon) {
                 editPluginSettingsLink = (
                     <f.link class='edit-plugin disabled' title="Not allowed to edit plugin settings"/>);
@@ -95,7 +100,8 @@ const PluginWidget = {
         return (
             <div
                 class={`c-collapse plugin ${pluginInfo.isActive() ? 'active' : 'disabled'} ${(this.showState() === 'hide') ? 'collapsed' : 'expanded'}`}>
-                <div class="c-collapse_header plugin-header" onclick={vnode.state.toggleHide.bind(vnode.state)}>
+                <div class={`c-collapse_header plugin-header ${(this.showState() === 'hide') ? 'collapsed' : 'expanded'}`}
+                     onclick={vnode.state.toggleHide.bind(vnode.state)}>
                     <div className="c-collapse_header_details">
                         <span class="c-collapse_icon plugin-icon">
                           {image}

--- a/server/webapp/WEB-INF/rails/webpack/views/plugins/plugins_widget.js.msx
+++ b/server/webapp/WEB-INF/rails/webpack/views/plugins/plugins_widget.js.msx
@@ -89,7 +89,9 @@ const PluginsWidget = {
       return modal;
     };
 
-    this.edit = function (pluginInfo) {
+    this.edit = function (pluginInfo, event) {
+      event.stopPropagation();
+
       const newPluginSetting   = Stream();
       const errorMessage = Stream();
       ctrl.clearMessage();

--- a/server/webapp/WEB-INF/rails/webpack/views/roles/gocd_role_widget.js.msx
+++ b/server/webapp/WEB-INF/rails/webpack/views/roles/gocd_role_widget.js.msx
@@ -44,7 +44,8 @@ const RoleWidget = {
 
       <div class={`c-collapse ${(this.showState() === 'hide') ? 'collapsed' : 'expanded'}`}>
 
-        <div class="c-collapse_header" onclick={vnode.state.toggleHide.bind(vnode.state)}>
+        <div class={`c-collapse_header ${(this.showState() === 'hide') ? 'collapsed' : 'expanded'}`}
+             onclick={vnode.state.toggleHide.bind(vnode.state)}>
           <div className="c-collapse_header_details">
               <span class="c-collapse_icon">
                   <span class="gocd-role-icon"></span>

--- a/server/webapp/WEB-INF/rails/webpack/views/shared/dropdown.js.msx
+++ b/server/webapp/WEB-INF/rails/webpack/views/shared/dropdown.js.msx
@@ -76,7 +76,7 @@ class Dropdown {
       <div class={`c-dropdown ${isOpen(vnode.state)}`}>
         <a aria-label={`Group by ${selectedText}`} tabindex="0" class="c-dropdown_head"
            onclick={toggleDropdown.bind(this, vnode.state)}>{selectedText}</a>
-        <i role="presentation" class="c-down-arrow" onclick={toggleDropdown.bind(this, model)}/>
+        <i role="presentation" class="c-down-arrow" onclick={toggleDropdown.bind(this, vnode.state)}/>
         <div className="c-dropdown_body">
           {dropdownHtml}
         </div>

--- a/server/webapp/WEB-INF/rails/webpack/views/shared/plugin_config/plugin_collapsible_list.js.msx
+++ b/server/webapp/WEB-INF/rails/webpack/views/shared/plugin_config/plugin_collapsible_list.js.msx
@@ -41,7 +41,7 @@ class PluginCollapsibleList {
     const actionButtons = vnode.attrs.actionButtons;
     return (
       <div class={`c-collapse ${(this.showState() === 'hide') ? 'collapsed' : 'expanded'}`}>
-        <div class="c-collapse_header" onclick={this.toggleHide.bind(this)}>
+        <div class={`c-collapse_header ${(this.showState() === 'hide') ? 'collapsed' : 'expanded'}`} onclick={this.toggleHide.bind(this)}>
           <div class="c-collapse_header_details">
             <dl class="key-value-pair key-value-pair-header plugin-id">
               <dt class="key">{headerKey} </dt>


### PR DESCRIPTION
- Click on arrow of dropdown
- Expand/Collapse on click of arrow on panel
- Prevent expand/collapse when clicking on status report or settings