### PR TITLE
Timer triggered pipelines are not scheduled on a standby server

### DIFF
--- a/base/src/main/java/com/thoughtworks/go/util/SystemEnvironment.java
+++ b/base/src/main/java/com/thoughtworks/go/util/SystemEnvironment.java
@@ -857,6 +857,10 @@ public class SystemEnvironment implements Serializable, ConfigDirProvider {
         return GO_SERVER_MODE.getValue().equalsIgnoreCase("production");
     }
 
+    public boolean isServerInStandbyMode() {
+        return GO_SERVER_MODE.getValue().equalsIgnoreCase("standby");
+    }
+
     public boolean isReAuthenticationEnabled() {
         return REAUTHENTICATION_ENABLED.getValue();
     }

--- a/common/src/test/java/com/thoughtworks/go/util/SystemEnvironmentTest.java
+++ b/common/src/test/java/com/thoughtworks/go/util/SystemEnvironmentTest.java
@@ -522,4 +522,13 @@ public class SystemEnvironmentTest {
         System.setProperty("go.config.repo.gc.periodic", "some-value");
         assertThat(new SystemEnvironment().get(SystemEnvironment.GO_CONFIG_REPO_PERIODIC_GC), is(false));
     }
+
+    @Test
+    public void shouldBeInStandByModeIfGoServerModeIsSetToStandby() {
+        assertFalse(new SystemEnvironment().isServerInStandbyMode());
+
+        System.setProperty("go.server.mode", "StandBy");
+
+        assertTrue(new SystemEnvironment().isServerInStandbyMode());
+    }
 }

--- a/server/src/main/java/com/thoughtworks/go/server/service/TimerScheduler.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/TimerScheduler.java
@@ -74,7 +74,10 @@ public class TimerScheduler implements ConfigChangedListener {
     }
 
     public void initialize() {
-        if (!systemEnvironment.isServerActive()) return;
+        if (systemEnvironment.isServerInStandbyMode()) {
+            LOG.info("GoCD server in 'standby' mode, skipping scheduling timer triggered pipelines.");
+            return;
+        }
 
         scheduleAllJobs(goConfigService.getAllPipelineConfigs());
         goConfigService.register(this);

--- a/server/src/test-fast/java/com/thoughtworks/go/server/service/TimerSchedulerTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/service/TimerSchedulerTest.java
@@ -188,10 +188,10 @@ public class TimerSchedulerTest {
     }
 
     @Test
-    public void shouldNotScheduleJobsOnAnInactiveServer() {
+    public void shouldNotScheduleJobsForAServerInStandbyMode() {
         TimerScheduler timerScheduler = new TimerScheduler(scheduler, goConfigService, null, null, systemEnvironment);
 
-        when(systemEnvironment.isServerActive()).thenReturn(false);
+        when(systemEnvironment.isServerInStandbyMode()).thenReturn(true);
 
         timerScheduler.initialize();
 


### PR DESCRIPTION
* This commit fixes an issue with
  https://github.com/gocd/gocd/pull/5220 which expected the server to be
  active before scheduling the timer triggered pipelines. With BC addon
  remains active on startup and on TimerSchduler initialization and
  later turns inactive on load of the BC jar.
* Turning of scheduling timer triggered pipelines for standby server by relying
  on the SystemEnvironment 'go.server.mode'.