### PR TITLE
Should allow non-admins to view any analytics other than dashboard an…

### DIFF
--- a/spark/spark-spa/src/main/java/com/thoughtworks/go/spark/spa/AnalyticsDelegate.java
+++ b/spark/spark-spa/src/main/java/com/thoughtworks/go/spark/spa/AnalyticsDelegate.java
@@ -125,10 +125,10 @@ public class AnalyticsDelegate implements SparkController {
 
         if (isPipelineRequest(request)) {
             authenticationHelper.checkPipelineViewPermissionsAnd403(request, response);
-        } else if (isAgentRequest(request) || isVSMRequest(request)) {
-            authenticationHelper.checkUserAnd403(request, response);
-        } else {
+        } else if (isDashboardRequest(request)) {
             authenticationHelper.checkAdminUserAnd403(request, response);
+        } else {
+            authenticationHelper.checkUserAnd403(request, response);
         }
     }
 
@@ -136,12 +136,8 @@ public class AnalyticsDelegate implements SparkController {
         return "pipeline".equals(request.params(":type"));
     }
 
-    private boolean isAgentRequest(Request request) {
-        return "agent".equals(request.params(":type"));
-    }
-
-    private boolean isVSMRequest(Request request) {
-        return "vsm".equalsIgnoreCase(request.params(":type"));
+    private boolean isDashboardRequest(Request request) {
+        return "dashboard".equalsIgnoreCase(request.params(":type"));
     }
 
     private boolean isAnalyticsEnabledOnlyForAdmins() {

--- a/spark/spark-spa/src/test/groovy/com/thoughtworks/go/spark/spa/AnalyticsDelegateTest.groovy
+++ b/spark/spark-spa/src/test/groovy/com/thoughtworks/go/spark/spa/AnalyticsDelegateTest.groovy
@@ -201,6 +201,17 @@ class AnalyticsDelegateTest implements ControllerTrait<AnalyticsDelegate>, Secur
       }
 
       @Test
+      void "should allow all users to view drilldown analytics"() {
+        when(systemEnvironment.enableAnalyticsOnlyForAdmins()).thenReturn(false)
+
+        enableSecurity()
+        loginAsUser()
+
+        get(controller.controllerPath("plugin/drilldown/metric"))
+        assertRequestAllowed()
+      }
+
+      @Test
       void "should return 404 when pipeline does not exist"() {
         when(pipelineConfigService.pipelineConfigNamed(getPipelineName())).thenReturn(null)
         enableSecurity()


### PR DESCRIPTION
…alytics

* This commit would allow non-admins to view all analytics except for
  the analytics targeted for the 'Analytics Dashboard', this includes
  even the drilldown charts.