### PR TITLE
Materials should be same if fingerprints match

### DIFF
--- a/domain/src/main/java/com/thoughtworks/go/config/materials/git/GitMaterial.java
+++ b/domain/src/main/java/com/thoughtworks/go/config/materials/git/GitMaterial.java
@@ -324,13 +324,10 @@ public class GitMaterial extends ScmMaterial {
 
         GitMaterial that = (GitMaterial) o;
 
-        if (branch != null ? !branch.equals(that.branch) : that.branch != null) {
+        if (getFingerprint() != null ? !getFingerprint().equals(that.getFingerprint()) : that.getFingerprint() != null) {
             return false;
         }
         if (submoduleFolder != null ? !submoduleFolder.equals(that.submoduleFolder) : that.submoduleFolder != null) {
-            return false;
-        }
-        if (url != null ? !url.equals(that.url) : that.url != null) {
             return false;
         }
 

--- a/domain/src/main/java/com/thoughtworks/go/config/materials/mercurial/HgMaterial.java
+++ b/domain/src/main/java/com/thoughtworks/go/config/materials/mercurial/HgMaterial.java
@@ -271,7 +271,7 @@ public class HgMaterial extends ScmMaterial {
 
         HgMaterial that = (HgMaterial) o;
 
-        if (url != null ? !url.equals(that.url) : that.url != null) {
+        if (getFingerprint() != null ? !getFingerprint().equals(that.getFingerprint()) : that.getFingerprint() != null) {
             return false;
         }
 

--- a/domain/src/main/java/com/thoughtworks/go/config/materials/perforce/P4Material.java
+++ b/domain/src/main/java/com/thoughtworks/go/config/materials/perforce/P4Material.java
@@ -267,16 +267,11 @@ public class P4Material extends ScmMaterial implements PasswordEncrypter, Passwo
 
         P4Material that = (P4Material) o;
 
-        if (serverAndPort != null ? !serverAndPort.equals(that.serverAndPort) : that.serverAndPort != null) {
+        if (getFingerprint() != null ? !getFingerprint().equals(that.getFingerprint()) : that.getFingerprint() != null) {
             return false;
         }
+
         if (useTickets != null ? !useTickets.equals(that.useTickets) : that.useTickets != null) {
-            return false;
-        }
-        if (userName != null ? !userName.equals(that.userName) : that.userName != null) {
-            return false;
-        }
-        if (view != null ? !view.equals(that.view) : that.view != null) {
             return false;
         }
 

--- a/domain/src/main/java/com/thoughtworks/go/config/materials/svn/SvnMaterial.java
+++ b/domain/src/main/java/com/thoughtworks/go/config/materials/svn/SvnMaterial.java
@@ -203,13 +203,7 @@ public class SvnMaterial extends ScmMaterial implements PasswordEncrypter, Passw
 
         SvnMaterial that = (SvnMaterial) o;
 
-        if (checkExternals != that.checkExternals) {
-            return false;
-        }
-        if (url != null ? !url.equals(that.url) : that.url != null) {
-            return false;
-        }
-        if (userName != null ? !userName.equals(that.userName) : that.userName != null) {
+        if (getFingerprint() != null ? !getFingerprint().equals(that.getFingerprint()) : that.getFingerprint() != null) {
             return false;
         }
 

--- a/domain/src/main/java/com/thoughtworks/go/config/materials/tfs/TfsMaterial.java
+++ b/domain/src/main/java/com/thoughtworks/go/config/materials/tfs/TfsMaterial.java
@@ -235,18 +235,10 @@ public class TfsMaterial extends ScmMaterial implements PasswordAwareMaterial, P
 
         TfsMaterial material = (TfsMaterial) o;
 
-        if (projectPath != null ? !projectPath.equals(material.projectPath) : material.projectPath != null) {
+        if (getFingerprint() != null ? !getFingerprint().equals(material.getFingerprint()) : material.getFingerprint() != null) {
             return false;
         }
-        if (url != null ? !url.equals(material.url) : material.url != null) {
-            return false;
-        }
-        if (userName != null ? !userName.equals(material.userName) : material.userName != null) {
-            return false;
-        }
-        if (domain != null ? !domain.equals(material.domain) : material.domain != null) {
-            return false;
-        }
+
         return true;
     }
 


### PR DESCRIPTION
* Fixes https://github.com/gocd/gocd/issues/4836
* E.g  Consider two Git materials with URL - 'https://github.com/gocd/gocd' and
  'https://github.com/gocd/gocd/'. The two materials are considered different since
  fingerprint differs as one of them has a trailing slash.
  On the other hand GitMaterial#equals considers both to be same as the
  fingerprint was not used for comparision, rather the 'url' of the type
  'UrlArgument' is used to compare. 'UrlArgument' ignores the trailing
  slash while comparing the URL's