### PR TITLE
API to allow triggering `failed` and `selected` jobs from a stage.

### DIFF
--- a/api/api-stage-operations-v1/src/main/java/com/thoughtworks/go/apiv1/stageoperations/StageOperationsControllerV1.java
+++ b/api/api-stage-operations-v1/src/main/java/com/thoughtworks/go/apiv1/stageoperations/StageOperationsControllerV1.java
@@ -169,7 +169,7 @@ public class StageOperationsControllerV1 extends ApiController implements SparkS
         }
 
         if (stage == null || stage instanceof NullStage) {
-            String message = String.format("Stage '%s' not found", stageName);
+            String message = String.format("Stage '%s' with counter '%s' not found. Please make sure specified stage or stage run with specified counter exists.", stageName, stageCounter);
             operationResult.notFound("Not Found", message, HealthStateType.general(HealthStateScope.GLOBAL));
             return Optional.empty();
         }

--- a/api/api-stage-operations-v1/src/test/groovy/com/thoughtworks/go/apiv1/stageoperations/StageOperationsControllerV1Test.groovy
+++ b/api/api-stage-operations-v1/src/test/groovy/com/thoughtworks/go/apiv1/stageoperations/StageOperationsControllerV1Test.groovy
@@ -122,7 +122,7 @@ class StageOperationsControllerV1Test implements SecurityServiceTrait, Controlle
         assertThatResponse()
           .isNotFound()
           .hasContentType(controller.mimeType)
-          .hasJsonMessage("Not Found { Stage 'stage1' not found }")
+          .hasJsonMessage("Not Found { Stage 'stage1' with counter '1' not found. Please make sure specified stage or stage run with specified counter exists. }")
 
         verifyZeroInteractions(scheduleService)
       }
@@ -136,7 +136,7 @@ class StageOperationsControllerV1Test implements SecurityServiceTrait, Controlle
         assertThatResponse()
           .isNotFound()
           .hasContentType(controller.mimeType)
-          .hasJsonMessage("Not Found { Stage 'stage1' not found }")
+          .hasJsonMessage("Not Found { Stage 'stage1' with counter '1' not found. Please make sure specified stage or stage run with specified counter exists. }")
 
         verifyZeroInteractions(scheduleService)
       }
@@ -254,7 +254,7 @@ class StageOperationsControllerV1Test implements SecurityServiceTrait, Controlle
         assertThatResponse()
           .isNotFound()
           .hasContentType(controller.mimeType)
-          .hasJsonMessage("Not Found { Stage 'stage1' not found }")
+          .hasJsonMessage("Not Found { Stage 'stage1' with counter '1' not found. Please make sure specified stage or stage run with specified counter exists. }")
 
         verifyZeroInteractions(scheduleService)
       }
@@ -268,7 +268,7 @@ class StageOperationsControllerV1Test implements SecurityServiceTrait, Controlle
         assertThatResponse()
           .isNotFound()
           .hasContentType(controller.mimeType)
-          .hasJsonMessage("Not Found { Stage 'stage1' not found }")
+          .hasJsonMessage("Not Found { Stage 'stage1' with counter '1' not found. Please make sure specified stage or stage run with specified counter exists. }")
 
         verifyZeroInteractions(scheduleService)
       }

--- a/api/api-stage-operations-v1/src/test/groovy/com/thoughtworks/go/apiv1/stageoperations/StageOperationsControllerV1Test.groovy
+++ b/api/api-stage-operations-v1/src/test/groovy/com/thoughtworks/go/apiv1/stageoperations/StageOperationsControllerV1Test.groovy
@@ -177,11 +177,6 @@ class StageOperationsControllerV1Test implements SecurityServiceTrait, Controlle
 
       @Test
       void 'rerunSelectedJobs reports errors'() {
-        List<String> jobs = ["download", "build", "upload"]
-        String requestBody = "{\n" +
-          "  \"jobs\": [\"download\"]\n" +
-          "}"
-
         def pipeline = mock(Pipeline)
         def stage = mock(Stage)
 
@@ -201,7 +196,7 @@ class StageOperationsControllerV1Test implements SecurityServiceTrait, Controlle
         doAnswer({ InvocationOnMock invocation -> invocation.callRealMethod() }).
           when(scheduleService).rerunSelectedJobs(eq(pipelineName), eq(pipelineCounter), eq(stageName), anyList(), any() as HttpOperationResult)
 
-        postWithApiHeader(controller.controllerPath(pipelineName, pipelineCounter, stageName, 'run-selected-jobs'), requestBody)
+        postWithApiHeader(controller.controllerPath(pipelineName, pipelineCounter, stageName, 'run-selected-jobs'), ["jobs": ["download"]])
 
         assertThatResponse()
           .isInternalServerError()
@@ -216,9 +211,6 @@ class StageOperationsControllerV1Test implements SecurityServiceTrait, Controlle
         HttpOperationResult result
 
         List<String> jobs = ["download", "build", "upload"]
-        String requestBody = "{\n" +
-          "  \"jobs\": [\"download\", \"build\", \"upload\"]\n" +
-          "}"
 
         doAnswer({ InvocationOnMock invocation ->
           result = invocation.getArgument(4)
@@ -226,7 +218,7 @@ class StageOperationsControllerV1Test implements SecurityServiceTrait, Controlle
           return mock(Stage)
         }).when(scheduleService).rerunSelectedJobs(eq(pipelineName), eq(pipelineCounter), eq(stageName), eq(jobs), any() as HttpOperationResult)
 
-        postWithApiHeader(controller.controllerPath(pipelineName, pipelineCounter, stageName, 'run-selected-jobs'), requestBody)
+        postWithApiHeader(controller.controllerPath(pipelineName, pipelineCounter, stageName, 'run-selected-jobs'), ["jobs": ["download", "build", "upload"]])
 
         assertThatResponse()
           .isAccepted()
@@ -238,22 +230,14 @@ class StageOperationsControllerV1Test implements SecurityServiceTrait, Controlle
 
       @Test
       void 'rerunSelectedJobs reports error on invalid request body'() {
-        String acceptanceMessage = "Request to rerun job(s) is accepted"
-        HttpOperationResult result
-
-        List<String> jobs = ["download", "build", "upload"]
-        String requestBody = "{\n" +
-          "  \"jobss\": [\"download\", \"build\", \"upload\"]\n" +
-          "}"
-
-        postWithApiHeader(controller.controllerPath(pipelineName, pipelineCounter, stageName, 'run-selected-jobs'), requestBody)
+        postWithApiHeader(controller.controllerPath(pipelineName, pipelineCounter, stageName, 'run-selected-jobs'), ["jobss": ["download", "build", "uploads"]])
 
         assertThatResponse()
           .isUnprocessableEntity()
           .hasContentType(controller.mimeType)
           .hasJsonMessage("Could not read property 'jobs' in request body")
 
-        verify(scheduleService, times(0)).rerunSelectedJobs(pipelineName, pipelineCounter, stageName, jobs, result)
+        verify(scheduleService, times(0)).rerunSelectedJobs(any(), any(), any(), any(), any() as HttpOperationResult)
       }
 
     }

--- a/api/api-stage-operations-v1/src/test/groovy/com/thoughtworks/go/apiv1/stageoperations/StageOperationsControllerV1Test.groovy
+++ b/api/api-stage-operations-v1/src/test/groovy/com/thoughtworks/go/apiv1/stageoperations/StageOperationsControllerV1Test.groovy
@@ -105,8 +105,7 @@ class StageOperationsControllerV1Test implements SecurityServiceTrait, Controlle
 
       @Override
       void makeHttpCall() {
-        String requestBody = "{\"jobs\": [\"job1\"]}"
-        postWithApiHeader(controller.controllerPath(pipelineName, pipelineCounter, stageName, 'run-selected-jobs'), requestBody)
+        postWithApiHeader(controller.controllerPath(pipelineName, pipelineCounter, stageName, 'run-selected-jobs'), ["jobs": ["job1"]])
       }
 
       @Override
@@ -241,7 +240,7 @@ class StageOperationsControllerV1Test implements SecurityServiceTrait, Controlle
           .hasContentType(controller.mimeType)
           .hasJsonMessage("Could not read property 'jobs' in request body")
 
-        verify(scheduleService, times(0)).rerunSelectedJobs(any(), any(), any(), any(), any() as HttpOperationResult)
+        verify(scheduleService, never()).rerunSelectedJobs(anyString(), anyString(), anyString(), anyList(), any() as HttpOperationResult)
       }
 
     }

--- a/server/src/main/java/com/thoughtworks/go/server/service/ScheduleService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/ScheduleService.java
@@ -756,7 +756,7 @@ public class ScheduleService {
                 .collect(Collectors.toList());
 
         if (unknownJobs.size() > 0) {
-            String msg = String.format("Jobs %s does not exist in stage %s.", unknownJobs, stage.getIdentifier());
+            String msg = String.format("Jobs %s does not exist in stage '%s'.", unknownJobs, stage.getIdentifier().getStageLocator());
             LOGGER.error(msg);
             result.notFound(msg, "", healthStateType);
             return;

--- a/server/src/main/java/com/thoughtworks/go/server/service/ScheduleService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/ScheduleService.java
@@ -347,7 +347,7 @@ public class ScheduleService {
             if (result.canContinue()) {
                 String message = String.format("Job rerun request for job(s) [%s] could not be completed because of unexpected failure. Cause: %s", StringUtils.join(jobNames.toArray(), ", "),
                         e.getMessage());
-                result.internalServerError(message, healthStateForStage);//make this 500 while moving this to LocalizedOR.
+                result.internalServerError(message, healthStateForStage); 
                 LOGGER.error(message, e);
             }
             return null;
@@ -738,21 +738,23 @@ public class ScheduleService {
      */
     public void rerunFailedJobs(String pipelineName, String counterOrLabel, String stageName, HttpOperationResult result) {
         Pipeline pipeline = pipelineService.fullPipelineByCounterOrLabel(pipelineName, counterOrLabel);
-        if (pipelineDoesNotExist(pipelineName, counterOrLabel, result, pipeline)) return;
 
-        Stage stage = pipeline.findStage(stageName);
-        if (stageDoesNotExist(pipelineName, counterOrLabel, stageName, result, stage)) return;
+        if (pipelineDoesNotExist(pipelineName, counterOrLabel, result, pipeline)
+                || stageDoesNotExist(pipelineName, counterOrLabel, stageName, result, pipeline.findStage(stageName))) {
+            return;
+        }
 
-        rerunFailedJobs(stage, result);
+        rerunFailedJobs(pipeline.findStage(stageName), result);
     }
 
     public void rerunSelectedJobs(String pipelineName, String counterOrLabel, String stageName, List<String> requestedJobs, HttpOperationResult result) {
         Pipeline pipeline = pipelineService.fullPipelineByCounterOrLabel(pipelineName, counterOrLabel);
-        if (pipelineDoesNotExist(pipelineName, counterOrLabel, result, pipeline)) return;
+        if (pipelineDoesNotExist(pipelineName, counterOrLabel, result, pipeline)
+                || stageDoesNotExist(pipelineName, counterOrLabel, stageName, result, pipeline.findStage(stageName))) {
+            return;
+        }
 
         Stage stage = pipeline.findStage(stageName);
-        if (stageDoesNotExist(pipelineName, counterOrLabel, stageName, result, stage)) return;
-
         List<String> jobsToTrigger = stage.getJobInstances()
                 .stream()
                 .map(JobInstance::getName)

--- a/server/src/test-fast/java/com/thoughtworks/go/server/service/JobRerunScheduleServiceTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/service/JobRerunScheduleServiceTest.java
@@ -16,6 +16,7 @@
 
 package com.thoughtworks.go.server.service;
 
+import ch.qos.logback.classic.Level;
 import com.thoughtworks.go.config.*;
 import com.thoughtworks.go.domain.*;
 import com.thoughtworks.go.domain.activity.AgentAssignment;
@@ -33,16 +34,12 @@ import com.thoughtworks.go.server.transaction.TestTransactionTemplate;
 import com.thoughtworks.go.serverhealth.ServerHealthService;
 import com.thoughtworks.go.util.LogFixture;
 import com.thoughtworks.go.util.TimeProvider;
-import ch.qos.logback.classic.Level;
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.ArgumentMatchers;
 import org.springframework.transaction.support.TransactionCallback;
 
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.Date;
-import java.util.List;
 import java.util.concurrent.Semaphore;
 
 import static com.thoughtworks.go.util.DataStructureUtils.a;
@@ -341,57 +338,6 @@ public class JobRerunScheduleServiceTest {
 
         assertThat(result.httpCode(), is(400));
         assertThat(result.message(), is("There are no failed jobs in the stage that could be re-run"));
-        verify(scheduleServiceSpy, never()).rerunJobs(any(Stage.class), anyList(), any(HttpOperationResult.class));
-    }
-
-
-    @Test
-    public void shouldRerunSelectedJobs() {
-        Stage stage = mock(Stage.class);
-        HttpOperationResult result = new HttpOperationResult();
-        List<String> jobs = Arrays.asList("job1");
-
-        when(stage.getIdentifier()).thenReturn(new StageIdentifier("up42/1/stage1/1"));
-        when(stage.getJobInstances()).thenReturn(new JobInstances(new JobInstance("job1"), new JobInstance("job2")));
-
-        ScheduleService scheduleServiceSpy = spy(service);
-        scheduleServiceSpy.rerunSelectedJobs(stage, jobs, result);
-
-        verify(scheduleServiceSpy).rerunJobs(stage, Arrays.asList("job1"), result);
-    }
-
-    @Test
-    public void shouldNotRerunWhenThereAreNoRequestedJobs() {
-        Stage stage = mock(Stage.class);
-        HttpOperationResult result = new HttpOperationResult();
-
-        when(stage.getIdentifier()).thenReturn(new StageIdentifier("up42/1/stage1/1"));
-
-        ScheduleService scheduleServiceSpy = spy(service);
-        scheduleServiceSpy.rerunSelectedJobs(stage, Collections.emptyList(), result);
-
-        assertThat(result.httpCode(), is(400));
-        assertThat(result.message(), is("No job was selected to re-run."));
-
-        verify(scheduleServiceSpy, never()).rerunJobs(any(Stage.class), anyList(), any(HttpOperationResult.class));
-    }
-
-
-    @Test
-    public void shouldNotRerunWhenAnyOfTheRequestedJobsDoesNotExistInStage() {
-        Stage stage = mock(Stage.class);
-        HttpOperationResult result = new HttpOperationResult();
-        List<String> jobs = Arrays.asList("job0", "job1");
-
-        when(stage.getIdentifier()).thenReturn(new StageIdentifier("up42/1/stage1/1"));
-        when(stage.getJobInstances()).thenReturn(new JobInstances(new JobInstance("job1"), new JobInstance("job2")));
-
-        ScheduleService scheduleServiceSpy = spy(service);
-        scheduleServiceSpy.rerunSelectedJobs(stage, jobs, result);
-
-        assertThat(result.httpCode(), is(404));
-        assertThat(result.message(), is("Jobs [job0] does not exist in stage 'up42/1/stage1/1'."));
-
         verify(scheduleServiceSpy, never()).rerunJobs(any(Stage.class), anyList(), any(HttpOperationResult.class));
     }
 

--- a/server/src/test-fast/java/com/thoughtworks/go/server/service/JobRerunScheduleServiceTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/service/JobRerunScheduleServiceTest.java
@@ -390,7 +390,7 @@ public class JobRerunScheduleServiceTest {
         scheduleServiceSpy.rerunSelectedJobs(stage, jobs, result);
 
         assertThat(result.httpCode(), is(404));
-        assertThat(result.message(), is("Jobs [job0] does not exist in stage StageIdentifier[up42, 1, null, stage1, 1]."));
+        assertThat(result.message(), is("Jobs [job0] does not exist in stage 'up42/1/stage1/1'."));
 
         verify(scheduleServiceSpy, never()).rerunJobs(any(Stage.class), anyList(), any(HttpOperationResult.class));
     }

--- a/server/src/test-fast/java/com/thoughtworks/go/server/service/JobRerunScheduleServiceTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/service/JobRerunScheduleServiceTest.java
@@ -146,7 +146,7 @@ public class JobRerunScheduleServiceTest {
             Stage stage = service.rerunJobs(firstStage, a("unit"), result);
             assertThat(logFixture.contains(Level.ERROR, "Job rerun request for job(s) [unit] could not be completed because of unexpected failure. Cause: The whole world is a big null."), is(true));
             assertThat(stage, is(nullValue()));
-            assertThat(result.httpCode(), is(400));
+            assertThat(result.httpCode(), is(500));
             assertThat(result.message(), is("Job rerun request for job(s) [unit] could not be completed because of unexpected failure. Cause: The whole world is a big null."));
         }
 

--- a/server/webapp/WEB-INF/urlrewrite.xml
+++ b/server/webapp/WEB-INF/urlrewrite.xml
@@ -235,6 +235,27 @@
   </rule>
 
   <rule>
+    <name>Spark Stage Rerun Failed Jobs Operations API</name>
+    <condition type="header" name="Accept">application\/vnd\.go\.cd\.v1\+json</condition>
+    <from>^/api/stages/([^/]+)/([^/]+)/([^/]+)/run-failed-jobs(/?)</from>
+    <to last="true">/spark/api/stages/${escape:$1}/${escape:$2}/${escape:$3}/run-failed-jobs</to>
+  </rule>
+
+  <rule>
+    <name>Spark Stage Rerun Selected Jobs Operations API</name>
+    <condition type="header" name="Accept">application\/vnd\.go\.cd\.v1\+json</condition>
+    <from>^/api/stages/([^/]+)/([^/]+)/([^/]+)/run-selected-jobs(/?)</from>
+    <to last="true">/spark/api/stages/${escape:$1}/${escape:$2}/${escape:$3}/run-selected-jobs</to>
+  </rule>
+
+  <rule>
+    <name>Spark pipeline pause/unpause/unlock/trigger_view API/schedule API</name>
+    <condition type="header" name="Accept">application\/vnd\.go\.cd\.v1\+json</condition>
+    <from>^/api/pipelines/([^/]+)/(pause|unpause|unlock|trigger_options|schedule)</from>
+    <to last="true">/spark/api/pipelines/${escape:$1}/${escape:$2}</to>
+  </rule>
+
+  <rule>
     <name>Plugin Images</name>
     <from>^/api/plugin_images/(.*)$</from>
     <to last="true">/spark/api/plugin_images/$1</to>

--- a/server/webapp/WEB-INF/urlrewrite.xml
+++ b/server/webapp/WEB-INF/urlrewrite.xml
@@ -249,6 +249,13 @@
   </rule>
 
   <rule>
+    <name>Spark Stage Operations APIs for re-rerun</name>
+    <condition type="header" name="Accept">application\/vnd\.go\.cd\.v1\+json</condition>
+    <from>^/api/stages/([^/]+)/([^/]+)/([^/]+)/([^/]+)/(run-failed-jobs|run-selected-jobs)(/?)</from>
+    <to last="true">/spark/api/stages/${escape:$1}/${escape:$2}/${escape:$3}/${escape:$4}/${escape:$5}</to>
+  </rule>
+
+  <rule>
     <name>Spark pipeline pause/unpause/unlock/trigger_view API/schedule API</name>
     <condition type="header" name="Accept">application\/vnd\.go\.cd\.v1\+json</condition>
     <from>^/api/pipelines/([^/]+)/(pause|unpause|unlock|trigger_options|schedule)</from>

--- a/server/webapp/WEB-INF/urlrewrite.xml
+++ b/server/webapp/WEB-INF/urlrewrite.xml
@@ -235,31 +235,10 @@
   </rule>
 
   <rule>
-    <name>Spark Stage Rerun Failed Jobs Operations API</name>
-    <condition type="header" name="Accept">application\/vnd\.go\.cd\.v1\+json</condition>
-    <from>^/api/stages/([^/]+)/([^/]+)/([^/]+)/run-failed-jobs(/?)</from>
-    <to last="true">/spark/api/stages/${escape:$1}/${escape:$2}/${escape:$3}/run-failed-jobs</to>
-  </rule>
-
-  <rule>
-    <name>Spark Stage Rerun Selected Jobs Operations API</name>
-    <condition type="header" name="Accept">application\/vnd\.go\.cd\.v1\+json</condition>
-    <from>^/api/stages/([^/]+)/([^/]+)/([^/]+)/run-selected-jobs(/?)</from>
-    <to last="true">/spark/api/stages/${escape:$1}/${escape:$2}/${escape:$3}/run-selected-jobs</to>
-  </rule>
-
-  <rule>
     <name>Spark Stage Operations APIs for re-rerun</name>
     <condition type="header" name="Accept">application\/vnd\.go\.cd\.v1\+json</condition>
     <from>^/api/stages/([^/]+)/([^/]+)/([^/]+)/([^/]+)/(run-failed-jobs|run-selected-jobs)(/?)</from>
     <to last="true">/spark/api/stages/${escape:$1}/${escape:$2}/${escape:$3}/${escape:$4}/${escape:$5}</to>
-  </rule>
-
-  <rule>
-    <name>Spark pipeline pause/unpause/unlock/trigger_view API/schedule API</name>
-    <condition type="header" name="Accept">application\/vnd\.go\.cd\.v1\+json</condition>
-    <from>^/api/pipelines/([^/]+)/(pause|unpause|unlock|trigger_options|schedule)</from>
-    <to last="true">/spark/api/pipelines/${escape:$1}/${escape:$2}</to>
   </rule>
 
   <rule>

--- a/spark/spark-base/src/main/java/com/thoughtworks/go/spark/Routes.java
+++ b/spark/spark-base/src/main/java/com/thoughtworks/go/spark/Routes.java
@@ -197,8 +197,8 @@ public class Routes {
     public static class Stage {
         public static final String BASE = "/api/stages";
         public static final String TRIGGER_STAGE_PATH = "/:pipeline_name/:pipeline_counter/:stage_name/run";
-        public static final String TRIGGER_FAILED_JOBS_PATH = "/:pipeline_name/:pipeline_counter/:stage_name/run-failed-jobs";
-        public static final String TRIGGER_SELECTED_JOBS_PATH = "/:pipeline_name/:pipeline_counter/:stage_name/run-selected-jobs";
+        public static final String TRIGGER_FAILED_JOBS_PATH = "/:pipeline_name/:pipeline_counter/:stage_name/:stage_counter/run-failed-jobs";
+        public static final String TRIGGER_SELECTED_JOBS_PATH = "/:pipeline_name/:pipeline_counter/:stage_name/:stage_counter/run-selected-jobs";
 
         public static String self(String pipelineName, String pipelineCounter, String stageName, String stageCounter) {
             return StrSubstitutor.replace("/api/stages/${pipeline_name}/${pipeline_counter}/${stage_name}/${stage_counter}", of(

--- a/spark/spark-base/src/main/java/com/thoughtworks/go/spark/Routes.java
+++ b/spark/spark-base/src/main/java/com/thoughtworks/go/spark/Routes.java
@@ -196,7 +196,9 @@ public class Routes {
 
     public static class Stage {
         public static final String BASE = "/api/stages";
-        public static final String TRIGGER_PATH = "/:pipeline_name/:pipeline_counter/:stage_name/run";
+        public static final String TRIGGER_STAGE_PATH = "/:pipeline_name/:pipeline_counter/:stage_name/run";
+        public static final String TRIGGER_FAILED_JOBS_PATH = "/:pipeline_name/:pipeline_counter/:stage_name/run-failed-jobs";
+        public static final String TRIGGER_SELECTED_JOBS_PATH = "/:pipeline_name/:pipeline_counter/:stage_name/run-selected-jobs";
 
         public static String self(String pipelineName, String pipelineCounter, String stageName, String stageCounter) {
             return StrSubstitutor.replace("/api/stages/${pipeline_name}/${pipeline_counter}/${stage_name}/${stage_counter}", of(


### PR DESCRIPTION
### Endpoints:

#### Triggering failed jobs: 
URL: `../go/api/stages/:pipeline_name/:pipeline_counter/:stage_name/:stage_counter/run-failed-jobs`


#### Triggering selected jobs: 
URL: `../go/api/stages/:pipeline_name/:pipeline_counter/:stage_name/:stage_counter/run-selected-jobs`

Request body:
```
{
    "jobs" : ["fastTest1", "fastTest2"]
}
```
