### PR TITLE
Pipeline label regex fix

### DIFF
--- a/api/api-pipeline-config-v6/src/test/groovy/com/thoughtworks/go/apiv6/admin/pipelineconfig/representers/PipelineConfigRepresenterTest.groovy
+++ b/api/api-pipeline-config-v6/src/test/groovy/com/thoughtworks/go/apiv6/admin/pipelineconfig/representers/PipelineConfigRepresenterTest.groovy
@@ -578,7 +578,7 @@ class PipelineConfigRepresenterTest {
       ]
     ],
     errors: [
-      label_template: ['You have defined a label template in pipeline wunderbar that refers to a material called svn, but no material with this name is defined.']
+      label_template: ["You have defined a label template in pipeline 'wunderbar' that refers to a material called 'svn', but no material with this name is defined."]
     ]
   ]
 

--- a/api/api-pipeline-config-v6/src/test/groovy/com/thoughtworks/go/apiv6/admin/pipelineconfig/representers/PipelineConfigRepresenterTest.groovy
+++ b/api/api-pipeline-config-v6/src/test/groovy/com/thoughtworks/go/apiv6/admin/pipelineconfig/representers/PipelineConfigRepresenterTest.groovy
@@ -73,40 +73,44 @@ class PipelineConfigRepresenterTest {
     }
 
     def pipelineWithTemplateHash =
-    [
-      _links: [
-        self: [
-          href: 'http://test.host/go/api/admin/pipelines/wunderbar'
-        ],
-        doc: [
-          href: 'https://api.gocd.org/#pipeline-config'
-        ],
-        find: [
-          href: 'http://test.host/go/api/admin/pipelines/:pipeline_name'
-        ]
-      ],
-      label_template: '${COUNT}',
-      lock_behavior: 'none',
-      name: 'wunderbar',
-      template: 'template1',
-      origin: [
-        _links: [
+      [
+        _links               : [
           self: [
-            href: 'http://test.host/go/admin/config_xml'
+            href: 'http://test.host/go/api/admin/pipelines/wunderbar'
           ],
-          doc: [
-            href: 'https://api.gocd.org/current/#get-configuration'
+          doc : [
+            href: 'https://api.gocd.org/#pipeline-config'
+          ],
+          find: [
+            href: 'http://test.host/go/api/admin/pipelines/:pipeline_name'
           ]
         ],
-        type: 'gocd'
-      ],
-      parameters: [],
-      environment_variables: [],
-      materials: pipelineWithTemplate().materialConfigs().collect { eachItem -> toObject({MaterialRepresenter.toJSON(it, eachItem)}) },
-      stages: null,
-      tracking_tool: null,
-      timer: null
-    ]
+        label_template       : '${COUNT}',
+        lock_behavior        : 'none',
+        name                 : 'wunderbar',
+        template             : 'template1',
+        origin               : [
+          _links: [
+            self: [
+              href: 'http://test.host/go/admin/config_xml'
+            ],
+            doc : [
+              href: 'https://api.gocd.org/current/#get-configuration'
+            ]
+          ],
+          type  : 'gocd'
+        ],
+        parameters           : [],
+        environment_variables: [],
+        materials            : pipelineWithTemplate().materialConfigs().collect { eachItem ->
+          toObject({
+            MaterialRepresenter.toJSON(it, eachItem)
+          })
+        },
+        stages               : null,
+        tracking_tool        : null,
+        timer                : null
+      ]
 
     static def pipelineWithTemplate() {
       def pipelineConfig = new PipelineConfig(new CaseInsensitiveString('wunderbar'), '${COUNT}', null, true, MaterialConfigsMother.defaultMaterialConfigs(), new ArrayList())
@@ -120,7 +124,7 @@ class PipelineConfigRepresenterTest {
   class Deserialize {
 
     @Test
-    void 'should convert from minimal json to PipelineConfig' () {
+    void 'should convert from minimal json to PipelineConfig'() {
       def jsonReader = GsonTransformer.instance.jsonReaderFrom(pipelineHashBasic)
       def map = new ConfigHelperOptions(mock(BasicCruiseConfig.class), passwordDeserializer)
       def pipelineConfig = PipelineConfigRepresenter.fromJSON(jsonReader, map)
@@ -131,38 +135,39 @@ class PipelineConfigRepresenterTest {
     }
 
     def pipelineHashBasic =
-    [
-      label_template: 'foo-1.0.${COUNT}-${svn}',
-      lock_behavior: 'none',
-      name: 'wunderbar',
-      materials: [
-        [
-          type: 'svn',
-          attributes: [
-            url: 'http://some/svn/url',
-            destination: 'svnDir',
-            check_externals: false
-          ],
-          name: 'http___some_svn_url',
-          auto_update: true
-        ]
-      ],
-      stages: [
-        [
-          name: 'stage1',
-          fetch_materials: true,
-          clean_working_directory: false,
-          never_cleanup_artifacts: false,
-          jobs: [
-            [
-              name: 'defaultJob',
-              tasks: [
-                [
-                  type: 'ant',
-                  attributes: [
-                    working_dir: 'working-directory',
-                    build_file: 'build-file',
-                    target: 'target'
+      [
+        label_template: 'foo-1.0.${COUNT}-${svn}',
+        lock_behavior : 'none',
+        name          : 'wunderbar',
+        materials     : [
+          [
+            type       : 'svn',
+            attributes : [
+              url            : 'http://some/svn/url',
+              destination    : 'svnDir',
+              check_externals: false
+            ],
+            name       : 'http___some_svn_url',
+            auto_update: true
+          ]
+        ],
+        stages        : [
+          [
+            name                   : 'stage1',
+            fetch_materials        : true,
+            clean_working_directory: false,
+            never_cleanup_artifacts: false,
+            jobs                   : [
+              [
+                name : 'defaultJob',
+                tasks: [
+                  [
+                    type      : 'ant',
+                    attributes: [
+                      working_dir: 'working-directory',
+                      build_file : 'build-file',
+                      target     : 'target'
+                    ]
                   ]
                 ]
               ]
@@ -170,20 +175,19 @@ class PipelineConfigRepresenterTest {
           ]
         ]
       ]
-    ]
 
     @Test
-    void 'should convert pipeline hash with environment variables to PipelineConfig' () {
+    void 'should convert pipeline hash with environment variables to PipelineConfig'() {
 
       def environmentVariables = [
         [
-          name: 'plain',
-          value: 'plain',
+          name  : 'plain',
+          value : 'plain',
           secure: false
         ],
         [
-          secure: true,
-          name: 'secure',
+          secure         : true,
+          name           : 'secure',
           encrypted_value: new GoCipher().encrypt('confidential')
         ]
       ]
@@ -198,7 +202,7 @@ class PipelineConfigRepresenterTest {
     }
 
     @Test
-    void 'should convert pipeline hash with empty environment variables to PipelineConfig' () {
+    void 'should convert pipeline hash with empty environment variables to PipelineConfig'() {
       def jsonReader = GsonTransformer.instance.jsonReaderFrom([
         environment_variables: []
       ])
@@ -208,7 +212,7 @@ class PipelineConfigRepresenterTest {
     }
 
     @Test
-    void 'should convert pipeline hash with parameters to PipelineConfig' () {
+    void 'should convert pipeline hash with parameters to PipelineConfig'() {
       def jsonReader = GsonTransformer.instance.jsonReaderFrom([
         parameters:
           [[
@@ -226,7 +230,7 @@ class PipelineConfigRepresenterTest {
     }
 
     @Test
-    void 'should convert pipeline hash with empty parmas to PipelineConfig' () {
+    void 'should convert pipeline hash with empty parmas to PipelineConfig'() {
       def jsonReader = GsonTransformer.instance.jsonReaderFrom([
         parameters: null
       ])
@@ -236,7 +240,7 @@ class PipelineConfigRepresenterTest {
     }
 
     @Test
-    void  'should convert pipeline hash with materials  to PipelineConfig' () {
+    void 'should convert pipeline hash with materials  to PipelineConfig'() {
       def jsonReader = GsonTransformer.instance.jsonReaderFrom([
         materials:
           [
@@ -286,7 +290,7 @@ class PipelineConfigRepresenterTest {
     }
 
     @Test
-    void  'should convert pipeline hash with empty materials  to PipelineConfig' () {
+    void 'should convert pipeline hash with empty materials  to PipelineConfig'() {
       def jsonReader = GsonTransformer.instance.jsonReaderFrom([
         materials: null
       ])
@@ -296,15 +300,15 @@ class PipelineConfigRepresenterTest {
     }
 
     @Test
-    void  'should raise exception when passing invalid material type' () {
+    void 'should raise exception when passing invalid material type'() {
       def hash = pipelineHashBasic
-      hash ['materials'] = [[
-                               type: 'bad-material-type',
-                               attributes:
+      hash['materials'] = [[
+                             type      : 'bad-material-type',
+                             attributes:
                                [
                                  foo: 'bar'
                                ]
-                             ]]
+                           ]]
       def jsonReader = GsonTransformer.instance.jsonReaderFrom(hash)
 
 
@@ -315,44 +319,44 @@ class PipelineConfigRepresenterTest {
     }
 
     @Test
-    void  'should convert pipeline hash with stages  to PipelineConfig' () {
+    void 'should convert pipeline hash with stages  to PipelineConfig'() {
       def stages = [[
-                  name: 'stage1',
-                  fetch_materials: true,
-                  clean_working_directory: false,
-                  never_cleanup_artifacts: false,
-                  approval:
-                  [
-                    type: 'success',
-                    authorization:
-                    [
-                      roles:
-                      [],
-                      users:
-                      []
-                    ]
-                  ],
-                  environment_variables:
-                  [
-                    [
-                      name: 'plain',
-                      value: 'plain',
-                      secure: false
-                    ],
-                    [
-                      secure: true,
-                      name: 'secure',
-                      encrypted_value: new GoCipher().encrypt('confidential')
-                    ]
-                  ],
-                  jobs:
-                  [[
-                     name: 'some-job',
-                     run_on_all_agents: true,
-                     run_instance_count: '3',
-                     timeout: '100',
-                   ]]
-                ]]
+                      name                   : 'stage1',
+                      fetch_materials        : true,
+                      clean_working_directory: false,
+                      never_cleanup_artifacts: false,
+                      approval               :
+                        [
+                          type         : 'success',
+                          authorization:
+                            [
+                              roles:
+                                [],
+                              users:
+                                []
+                            ]
+                        ],
+                      environment_variables  :
+                        [
+                          [
+                            name  : 'plain',
+                            value : 'plain',
+                            secure: false
+                          ],
+                          [
+                            secure         : true,
+                            name           : 'secure',
+                            encrypted_value: new GoCipher().encrypt('confidential')
+                          ]
+                        ],
+                      jobs                   :
+                        [[
+                           name              : 'some-job',
+                           run_on_all_agents : true,
+                           run_instance_count: '3',
+                           timeout           : '100',
+                         ]]
+                    ]]
 
       def jsonReader = GsonTransformer.instance.jsonReaderFrom([
         stages: stages
@@ -366,7 +370,7 @@ class PipelineConfigRepresenterTest {
     }
 
     @Test
-    void  'should convert pipeline hash with empty stages  to PipelineConfig' () {
+    void 'should convert pipeline hash with empty stages  to PipelineConfig'() {
       def jsonReader = GsonTransformer.instance.jsonReaderFrom([
         stages: null
       ])
@@ -376,7 +380,7 @@ class PipelineConfigRepresenterTest {
     }
 
     @Test
-    void  'should convert pipeline hash with tracking tool  to PipelineConfig' () {
+    void 'should convert pipeline hash with tracking tool  to PipelineConfig'() {
       def jsonReader = GsonTransformer.instance.jsonReaderFrom([
         tracking_tool:
           [
@@ -394,24 +398,26 @@ class PipelineConfigRepresenterTest {
     }
 
     @Test
-    void  'should raise exception when passing invalid tracking tool type' () {
+    void 'should raise exception when passing invalid tracking tool type'() {
       def jsonReader = GsonTransformer.instance.jsonReaderFrom([
         tracking_tool:
-        [
-          type: 'bad-tracking-tool',
-          attributes:
           [
-            link: 'link',
-            regex: 'regex'
+            type      : 'bad-tracking-tool',
+            attributes:
+              [
+                link : 'link',
+                regex: 'regex'
+              ]
           ]
-        ]
       ])
-      def exception = assertThrows(UnprocessableEntityException.class,{ PipelineConfigRepresenter.fromJSON(jsonReader, new ConfigHelperOptions(mock(BasicCruiseConfig.class), passwordDeserializer)) })
-      assertEquals("Invalid Tracking tool type 'bad-tracking-tool'. It has to be one of 'generic, mingle'." , exception.getMessage())
+      def exception = assertThrows(UnprocessableEntityException.class, {
+        PipelineConfigRepresenter.fromJSON(jsonReader, new ConfigHelperOptions(mock(BasicCruiseConfig.class), passwordDeserializer))
+      })
+      assertEquals("Invalid Tracking tool type 'bad-tracking-tool'. It has to be one of 'generic, mingle'.", exception.getMessage())
     }
 
     @Test
-    void  'should convert from full blown document to PipelineConfig' () {
+    void 'should convert from full blown document to PipelineConfig'() {
       def jsonReader = GsonTransformer.instance.jsonReaderFrom(pipelineHash)
       def map = new ConfigHelperOptions(mock(BasicCruiseConfig.class), passwordDeserializer)
       def pipelineConfig = PipelineConfigRepresenter.fromJSON(jsonReader, map)
@@ -420,7 +426,7 @@ class PipelineConfigRepresenterTest {
     }
 
     @Test
-    void  'should convert pipeline hash with timer  to PipelineConfig' () {
+    void 'should convert pipeline hash with timer  to PipelineConfig'() {
       def jsonReader = GsonTransformer.instance.jsonReaderFrom([
         timer:
           [
@@ -434,7 +440,7 @@ class PipelineConfigRepresenterTest {
     }
 
     @Test
-    void  'should convert pipeline hash with lock to PipelineConfig' () {
+    void 'should convert pipeline hash with lock to PipelineConfig'() {
       def jsonReader = GsonTransformer.instance.jsonReaderFrom([
         lock_behavior: PipelineConfig.LOCK_VALUE_LOCK_ON_FAILURE
       ])
@@ -443,7 +449,7 @@ class PipelineConfigRepresenterTest {
     }
 
     @Test
-    void  'should convert a pipeline config with a lock to a hash' () {
+    void 'should convert a pipeline config with a lock to a hash'() {
       def pipelineConfig = new PipelineConfig(new CaseInsensitiveString('wunderbar'), '${COUNT}', null, true, MaterialConfigsMother.defaultMaterialConfigs(), new ArrayList())
       pipelineConfig.setLockBehaviorIfNecessary(PipelineConfig.LOCK_VALUE_UNLOCK_WHEN_FINISHED)
       pipelineConfig.setOrigin(new FileConfigOrigin())
@@ -454,7 +460,7 @@ class PipelineConfigRepresenterTest {
 
 
     @Test
-    void  'should render errors' () {
+    void 'should render errors'() {
       def pipelineConfig = new PipelineConfig(new CaseInsensitiveString('wunderbar'), '', '', true, null, new ArrayList())
       pipelineConfig.setOrigin(new FileConfigOrigin())
       def config = new BasicCruiseConfig(new BasicPipelineConfigs('grp', new Authorization(), pipelineConfig))
@@ -466,7 +472,7 @@ class PipelineConfigRepresenterTest {
     }
 
     @Test
-    void  'should render errors on nested objects' () {
+    void 'should render errors on nested objects'() {
       def pipelineConfig = getInvalidPipelineConfig()
       def config = new BasicCruiseConfig(new BasicPipelineConfigs('grp', new Authorization(), getPipelineConfig()))
       pipelineConfig.validateTree(PipelineConfigSaveValidationContext.forChain(true, 'grp', config, pipelineConfig))
@@ -478,109 +484,109 @@ class PipelineConfigRepresenterTest {
   }
 
   def expectedHashWithErrors =
-  [
-    _links: [
-      self: [
-        href: 'http://test.host/go/api/admin/pipelines/wunderbar'
-      ],
-      doc: [
-        href: 'https://api.gocd.org/#pipeline-config'
-      ],
-      find: [
-        href: 'http://test.host/go/api/admin/pipelines/:pipeline_name'
-      ]
-    ],
-    label_template: '',
-    lock_behavior: 'none',
-    name: 'wunderbar',
-    template: null,
-    origin: [
-      _links: [
+    [
+      _links               : [
         self: [
-          href: 'http://test.host/go/admin/config_xml'
+          href: 'http://test.host/go/api/admin/pipelines/wunderbar'
         ],
-        doc: [
-          href: 'https://api.gocd.org/current/#get-configuration'
+        doc : [
+          href: 'https://api.gocd.org/#pipeline-config'
+        ],
+        find: [
+          href: 'http://test.host/go/api/admin/pipelines/:pipeline_name'
         ]
       ],
-      type: 'gocd'
-    ],
-    parameters: [],
-    environment_variables: [],
-    materials: [],
-    stages: null,
-    tracking_tool: null,
-    timer: [spec: '', only_on_changes: true, errors: [spec: ['Invalid cron syntax: Unexpected end of expression.']]],
-    errors: [
-      materials: ['A pipeline must have at least one material'],
-      pipeline: ["Pipeline 'wunderbar' does not have any stages configured. A pipeline must have at least one stage."],
-      label_template: ["Label cannot be blank. Label should be composed of alphanumeric text, it can contain the build number as \${COUNT}, can contain a material revision as \${<material-name>} of \${<material-name>[:<number>]}, or use params as #{<param-name>}."]
+      label_template       : '',
+      lock_behavior        : 'none',
+      name                 : 'wunderbar',
+      template             : null,
+      origin               : [
+        _links: [
+          self: [
+            href: 'http://test.host/go/admin/config_xml'
+          ],
+          doc : [
+            href: 'https://api.gocd.org/current/#get-configuration'
+          ]
+        ],
+        type  : 'gocd'
+      ],
+      parameters           : [],
+      environment_variables: [],
+      materials            : [],
+      stages               : null,
+      tracking_tool        : null,
+      timer                : [spec: '', only_on_changes: true, errors: [spec: ['Invalid cron syntax: Unexpected end of expression.']]],
+      errors               : [
+        materials     : ['A pipeline must have at least one material'],
+        pipeline      : ["Pipeline 'wunderbar' does not have any stages configured. A pipeline must have at least one stage."],
+        label_template: ["Label cannot be blank. Label should be composed of alphanumeric text, it can contain the build number as \${COUNT}, can contain a material revision as \${<material-name>} of \${<material-name>[:<number>]}, or use params as #{<param-name>}."]
+      ]
     ]
-  ]
 
   def expectedHashWithNestedErrors =
-  [
-    _links: [
-      self: [
-        href: 'http://test.host/go/api/admin/pipelines/wunderbar'
-      ],
-      doc: [
-        href: 'https://api.gocd.org/#pipeline-config'
-      ],
-      find: [
-        href: 'http://test.host/go/api/admin/pipelines/:pipeline_name'
-      ]
-    ],
-    label_template: 'foo-1.0.${COUNT}-${svn}',
-    lock_behavior: 'none',
-    name: 'wunderbar',
-    origin: [
-      _links: [
+    [
+      _links               : [
         self: [
-          href: 'http://test.host/go/admin/config_xml'
+          href: 'http://test.host/go/api/admin/pipelines/wunderbar'
         ],
-        doc: [
-          href: 'https://api.gocd.org/current/#get-configuration'
+        doc : [
+          href: 'https://api.gocd.org/#pipeline-config'
+        ],
+        find: [
+          href: 'http://test.host/go/api/admin/pipelines/:pipeline_name'
         ]
       ],
-      type: 'gocd'
-    ],
-    template: null,
-    parameters: [
-      [
-        name: null, value: 'echo',
-        errors: [
-          name: [
-            "Parameter cannot have an empty name for pipeline 'wunderbar'.",
-            "Invalid parameter name 'null'. This must be alphanumeric and can contain underscores and periods (however, it cannot start with a period). The maximum allowed length is 255 characters."
+      label_template       : 'foo-1.0.${COUNT}-${svn}',
+      lock_behavior        : 'none',
+      name                 : 'wunderbar',
+      origin               : [
+        _links: [
+          self: [
+            href: 'http://test.host/go/admin/config_xml'
+          ],
+          doc : [
+            href: 'https://api.gocd.org/current/#get-configuration'
+          ]
+        ],
+        type  : 'gocd'
+      ],
+      template             : null,
+      parameters           : [
+        [
+          name  : null, value: 'echo',
+          errors: [
+            name: [
+              "Parameter cannot have an empty name for pipeline 'wunderbar'.",
+              "Invalid parameter name 'null'. This must be alphanumeric and can contain underscores and periods (however, it cannot start with a period). The maximum allowed length is 255 characters."
+            ]
           ]
         ]
-      ]
-    ],
-    environment_variables: [[secure: false, name:  '', value: '', errors: [name: ["Environment Variable cannot have an empty name for pipeline 'wunderbar'."]]]],
-    materials: [
-      [
-        type: 'svn', attributes: [url: 'http://some/svn/url', destination: 'svnDir', filter: null, invert_filter: false, name: 'http___some_svn_url', auto_update: true, check_externals: false, username: null]
       ],
-      [
-        type: 'git', attributes: [url: null, destination: null, filter: null, invert_filter: false, name: null, auto_update: true, branch: 'master', submodule_folder: null, shallow_clone: false],
-        errors: [destination: ['Destination directory is required when specifying multiple scm materials'], url: ['URL cannot be blank']]
-      ]
-    ],
-    stages: [[name: 'stage1', fetch_materials: true, clean_working_directory: false, never_cleanup_artifacts: false, approval: [type: 'success', authorization: [roles: [], users: []]], environment_variables: [], jobs: []]],
-    timer: [spec: '0 0 22 ? * MON-FRI', only_on_changes: true],
-    tracking_tool: [
-      type: 'generic', attributes: [url_pattern: '', regex: ''],
-      errors: [
-        regex: ['Regex should be populated'],
-        url_pattern: ['Link should be populated', "Link must be a URL containing '\${ID}'. Go will replace the string '\${ID}' with the first matched group from the regex at run-time.", "Link must be a URL starting with https:// or http://"]
+      environment_variables: [[secure: false, name: '', value: '', errors: [name: ["Environment Variable cannot have an empty name for pipeline 'wunderbar'."]]]],
+      materials            : [
+        [
+          type: 'svn', attributes: [url: 'http://some/svn/url', destination: 'svnDir', filter: null, invert_filter: false, name: 'http___some_svn_url', auto_update: true, check_externals: false, username: null]
+        ],
+        [
+          type  : 'git', attributes: [url: null, destination: null, filter: null, invert_filter: false, name: null, auto_update: true, branch: 'master', submodule_folder: null, shallow_clone: false],
+          errors: [destination: ['Destination directory is required when specifying multiple scm materials'], url: ['URL cannot be blank']]
+        ]
+      ],
+      stages               : [[name: 'stage1', fetch_materials: true, clean_working_directory: false, never_cleanup_artifacts: false, approval: [type: 'success', authorization: [roles: [], users: []]], environment_variables: [], jobs: []]],
+      timer                : [spec: '0 0 22 ? * MON-FRI', only_on_changes: true],
+      tracking_tool        : [
+        type  : 'generic', attributes: [url_pattern: '', regex: ''],
+        errors: [
+          regex      : ['Regex should be populated'],
+          url_pattern: ['Link should be populated', "Link must be a URL containing '\${ID}'. Go will replace the string '\${ID}' with the first matched group from the regex at run-time.", "Link must be a URL starting with https:// or http://"]
 
+        ]
+      ],
+      errors               : [
+        label_template: ["You have defined a label template in pipeline 'wunderbar' that refers to a material called 'svn', but no material with this name is defined."]
       ]
-    ],
-    errors: [
-      label_template: ["You have defined a label template in pipeline 'wunderbar' that refers to a material called 'svn', but no material with this name is defined."]
     ]
-  ]
 
 
   static def getInvalidPipelineConfig() {
@@ -613,39 +619,55 @@ class PipelineConfigRepresenterTest {
   }
 
   def pipelineHash =
-  [
-    _links: [
-      self: [
-        href: 'http://test.host/go/api/admin/pipelines/wunderbar'
-      ],
-      doc: [
-        href: 'https://api.gocd.org/#pipeline-config'
-      ],
-      find: [
-        href: 'http://test.host/go/api/admin/pipelines/:pipeline_name'
-      ]
-    ],
-    label_template: 'foo-1.0.${COUNT}-${svn}',
-    lock_behavior: 'none',
-    name: 'wunderbar',
-    template: null,
-    origin: [
-      _links: [
+    [
+      _links               : [
         self: [
-          href: 'http://test.host/go/admin/config_xml'
+          href: 'http://test.host/go/api/admin/pipelines/wunderbar'
         ],
-        doc: [
-          href: 'https://api.gocd.org/current/#get-configuration'
+        doc : [
+          href: 'https://api.gocd.org/#pipeline-config'
+        ],
+        find: [
+          href: 'http://test.host/go/api/admin/pipelines/:pipeline_name'
         ]
       ],
-      type: 'gocd'
-    ],
-    parameters: getPipelineConfig().getParams().collect { eachItem -> toObject({ParamRepresenter.toJSON(it, eachItem)}) },
-    environment_variables: getPipelineConfig().getVariables().collect { eachItem -> toObject({EnvironmentVariableRepresenter.toJSON(it, eachItem)}) },
-    materials: getPipelineConfig().materialConfigs().collect { eachItem -> toObject({MaterialRepresenter.toJSON(it, eachItem)}) },
-    stages: getPipelineConfig().getStages().collect { eachItem -> toObject({StageRepresenter.toJSON(it, eachItem)}) },
-    tracking_tool: toObject({TrackingToolRepresenter.toJSON(it, getPipelineConfig())}),
-    timer: toObject({TimerRepresenter.toJSON(it, getPipelineConfig().getTimer())})
-  ]
+      label_template       : 'foo-1.0.${COUNT}-${svn}',
+      lock_behavior        : 'none',
+      name                 : 'wunderbar',
+      template             : null,
+      origin               : [
+        _links: [
+          self: [
+            href: 'http://test.host/go/admin/config_xml'
+          ],
+          doc : [
+            href: 'https://api.gocd.org/current/#get-configuration'
+          ]
+        ],
+        type  : 'gocd'
+      ],
+      parameters           : getPipelineConfig().getParams().collect { eachItem ->
+        toObject({
+          ParamRepresenter.toJSON(it, eachItem)
+        })
+      },
+      environment_variables: getPipelineConfig().getVariables().collect { eachItem ->
+        toObject({
+          EnvironmentVariableRepresenter.toJSON(it, eachItem)
+        })
+      },
+      materials            : getPipelineConfig().materialConfigs().collect { eachItem ->
+        toObject({
+          MaterialRepresenter.toJSON(it, eachItem)
+        })
+      },
+      stages               : getPipelineConfig().getStages().collect { eachItem ->
+        toObject({
+          StageRepresenter.toJSON(it, eachItem)
+        })
+      },
+      tracking_tool        : toObject({ TrackingToolRepresenter.toJSON(it, getPipelineConfig()) }),
+      timer                : toObject({ TimerRepresenter.toJSON(it, getPipelineConfig().getTimer()) })
+    ]
 
 }

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/PipelineConfig.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/PipelineConfig.java
@@ -271,6 +271,11 @@ public class PipelineConfig extends BaseCollection<StageConfig> implements Param
     }
 
     private boolean isValidToken(String token) {
+        if (StringUtils.isBlank(token)) {
+            addError("labelTemplate", "Label template variable cannot be blank.");
+            return false;
+        }
+
         if (token.equalsIgnoreCase(COUNT)) {
             return true;
         }
@@ -296,7 +301,7 @@ public class PipelineConfig extends BaseCollection<StageConfig> implements Param
             }
 
             if (!materialConfigs.materialNames().contains(new CaseInsensitiveString(materialName))) {
-                addError("labelTemplate", format("You have defined a label template in pipeline %s that refers to a material called %s, but no material with this name is defined.", name(), materialName));
+                addError("labelTemplate", format("You have defined a label template in pipeline '%s' that refers to a material called '%s', but no material with this name is defined.", name(), materialName));
                 return false;
             }
 

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/PipelineConfig.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/PipelineConfig.java
@@ -70,8 +70,6 @@ public class PipelineConfig extends BaseCollection<StageConfig> implements Param
     public static final String ENVIRONMENT_VARIABLES = "variables";
     public static final String PARAMS = "params";
 
-    private static final Pattern TRUNCATION_PATTERN = Pattern.compile("");
-
     public static final String TEMPLATE_NAME = "templateName";
 
     public static final String LOCK_BEHAVIOR = "lockBehavior";
@@ -135,6 +133,7 @@ public class PipelineConfig extends BaseCollection<StageConfig> implements Param
     public static final String INTEGRATION_TYPE_TRACKING_TOOL = "trackingTool";
     public static final String MATERIALS = "materials";
     public static final String STAGE = "stage";
+    public static final Pattern LABEL_TEMPLATE_TOKEN_PATTERN = Pattern.compile("(?<groupName>[^\\[]*)(\\[:(?<truncationLength>\\d+)\\])?$");
 
     public PipelineConfig() {
     }
@@ -269,7 +268,6 @@ public class PipelineConfig extends BaseCollection<StageConfig> implements Param
                 break;
             }
         }
-
     }
 
     private boolean isValidToken(String token) {
@@ -286,9 +284,8 @@ public class PipelineConfig extends BaseCollection<StageConfig> implements Param
             return true;
         }
 
-        Pattern truncationSpecPattern = Pattern.compile("(?<groupName>[^\\[]*)(\\[:(?<truncationLength>\\d+)\\])?$");
+        Matcher matcher = LABEL_TEMPLATE_TOKEN_PATTERN.matcher(token);
 
-        Matcher matcher = truncationSpecPattern.matcher(token);
         if (matcher.matches()) {
             String materialName = matcher.group("groupName");
             String truncationLength = matcher.group("truncationLength");
@@ -600,7 +597,6 @@ public class PipelineConfig extends BaseCollection<StageConfig> implements Param
         return result;
     }
 
-
     public TimerConfig getTimer() {
         return timer;
     }
@@ -788,7 +784,6 @@ public class PipelineConfig extends BaseCollection<StageConfig> implements Param
         return params;
     }
 
-
     public void setConfigAttributes(Object attributes) {
         setConfigAttributes(attributes, null);
     }
@@ -900,7 +895,6 @@ public class PipelineConfig extends BaseCollection<StageConfig> implements Param
         }
         return CONFIGURATION_TYPE_STAGES;
     }
-
 
     public void incrementIndex(StageConfig stageToBeMoved) {
         moveStage(stageToBeMoved, 1);

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/PipelineConfig.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/PipelineConfig.java
@@ -257,38 +257,38 @@ public class PipelineConfig extends BaseCollection<StageConfig> implements Param
             return;
         }
 
-        String[] allVariableThingies = substringsBetween(labelTemplate, "${", "}");
+        String[] allTokens = substringsBetween(labelTemplate, "${", "}");
 
-        if (allVariableThingies == null) {
+        if (allTokens == null) {
             addError("labelTemplate", String.format(LABEL_TEMPLATE_ERROR_MESSAGE, labelTemplate));
             return;
         }
 
-        for (String variableThingy : allVariableThingies) {
-            if (!isGood(variableThingy)) {
+        for (String token : allTokens) {
+            if (!isValidToken(token)) {
                 break;
             }
         }
 
     }
 
-    private boolean isGood(String thingInParens) {
-        if (thingInParens.equalsIgnoreCase(COUNT)) {
+    private boolean isValidToken(String token) {
+        if (token.equalsIgnoreCase(COUNT)) {
             return true;
         }
 
-        if (thingInParens.equals(ENV_VAR_PREFIX)) {
+        if (token.equals(ENV_VAR_PREFIX)) {
             addError("labelTemplate", "Missing environment variable name.");
             return false;
         }
 
-        if (thingInParens.startsWith(ENV_VAR_PREFIX)) {
+        if (token.startsWith(ENV_VAR_PREFIX)) {
             return true;
         }
 
         Pattern truncationSpecPattern = Pattern.compile("(?<groupName>[^\\[]*)(\\[:(?<truncationLength>\\d+)\\])?$");
 
-        Matcher matcher = truncationSpecPattern.matcher(thingInParens);
+        Matcher matcher = truncationSpecPattern.matcher(token);
         if (matcher.matches()) {
             String materialName = matcher.group("groupName");
             String truncationLength = matcher.group("truncationLength");

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/materials/MaterialConfigs.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/materials/MaterialConfigs.java
@@ -16,8 +16,6 @@
 
 package com.thoughtworks.go.config.materials;
 
-import java.util.*;
-
 import com.thoughtworks.go.config.*;
 import com.thoughtworks.go.config.materials.dependency.DependencyMaterialConfig;
 import com.thoughtworks.go.config.materials.git.GitMaterialConfig;
@@ -33,6 +31,8 @@ import com.thoughtworks.go.security.GoCipher;
 import com.thoughtworks.go.util.ArtifactLogUtil;
 import com.thoughtworks.go.util.command.UrlArgument;
 import org.apache.commons.lang3.StringUtils;
+
+import java.util.*;
 
 @ConfigTag("materials")
 @ConfigCollection(MaterialConfig.class)
@@ -132,7 +132,7 @@ public class MaterialConfigs extends BaseCollection<MaterialConfig> implements V
     }
 
     public boolean validateTree(PipelineConfigSaveValidationContext validationContext) {
-        if (isEmpty()){
+        if (isEmpty()) {
             errors().add("materials", "A pipeline must have at least one material");
         }
         validate(validationContext);
@@ -374,6 +374,17 @@ public class MaterialConfigs extends BaseCollection<MaterialConfig> implements V
         }
         return true;
     }
+
+    public List<CaseInsensitiveString> materialNames() {
+        List<CaseInsensitiveString> names = new ArrayList<>();
+        for (MaterialConfig material : this) {
+            if (!CaseInsensitiveString.isBlank(material.getName())) {
+                names.add(material.getName());
+            }
+        }
+        return names;
+    }
+
 
     private void addMaterialConfig(MaterialConfig materialConfig, Map attributes) {
         materialConfig.setConfigAttributes(attributes);

--- a/config/config-api/src/main/java/com/thoughtworks/go/domain/label/PipelineLabel.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/domain/label/PipelineLabel.java
@@ -45,49 +45,58 @@ public class PipelineLabel implements Serializable {
         return label;
     }
 
-    public static final Pattern PATTERN = Pattern.compile("(?i)\\$\\{([a-zA-Z:]*[a-zA-Z0-9_\\-\\.!~'#:]+)(\\[:(\\d+)\\])?\\}");
+    public static final Pattern PATTERN = Pattern.compile("\\$\\{(?<name>[^}\\[]+)(?:\\[:(?<truncation>\\d+)])?}");
 
-    private String replaceRevisionsInLabel(Map<CaseInsensitiveString, String> materialRevisions) {
+    public void updateLabel(Map<CaseInsensitiveString, String> namedRevisions, int pipelineCounter) {
+        this.label = interpolateLabel(namedRevisions, pipelineCounter);
+        this.label = StringUtils.substring(label, 0, 255);
+    }
+
+    private String interpolateLabel(Map<CaseInsensitiveString, String> materialRevisions, int pipelineCounter) {
         final Matcher matcher = PATTERN.matcher(this.label);
         final StringBuffer buffer = new StringBuffer();
+
         while (matcher.find()) {
-            final String revision = lookupVariable(matcher, materialRevisions);
-            matcher.appendReplacement(buffer, revision);
+            String token = matcher.group("name");
+            String value;
+
+            if (COUNT.equalsIgnoreCase(token)) {
+                value = Integer.toString(pipelineCounter);
+            } else if (token.toLowerCase().startsWith(ENV_VAR_PREFIX)) {
+                value = resolveEnvironmentVariable(token);
+            } else {
+                final String truncate = matcher.group("truncation");
+                value = resolveMaterialRevision(materialRevisions, token, truncate);
+            }
+
+            if (null == value) {
+                value = "\\" + matcher.group(0);
+            }
+
+            matcher.appendReplacement(buffer, value);
         }
+
         matcher.appendTail(buffer);
         return buffer.toString();
     }
 
-    private String lookupVariable(Matcher matcher, Map<CaseInsensitiveString, String> materialRevisions) {
-        final CaseInsensitiveString variable = new CaseInsensitiveString(matcher.group(1));
-
-        String valueForMaterialVariable = materialRevisions.get(variable);
-        String valueForPrefixedVariable = getValueIfVariableHasValidPrefix(variable);
-
-        String result;
-
-        if (valueForMaterialVariable != null) {
-            result = valueForMaterialVariable;
-        } else if (valueForPrefixedVariable != null) {
-            result = valueForPrefixedVariable;
-        } else {
-            return "\\" + matcher.group(0);
-        }
-
-        final String truncationLengthLiteral = matcher.group(3);
-        if (truncationLengthLiteral != null) {
-            int truncationLength = Integer.parseInt(truncationLengthLiteral);
-
-            if (result.length() > truncationLength) {
-                result = result.substring(0, truncationLength);
-            }
-        }
-        return result;
+    private String resolveEnvironmentVariable(String variable) {
+        variable = variable.substring(ENV_VAR_PREFIX.length());
+        return envVars.getInsecureEnvironmentVariableOrDefault(variable, "");
     }
 
-    public void updateLabel(Map<CaseInsensitiveString, String> namedRevisions) {
-        this.label = replaceRevisionsInLabel(namedRevisions);
-        this.label = StringUtils.substring(label, 0, 255);
+    private String resolveMaterialRevision(Map<CaseInsensitiveString, String> knownRevisions, String name, String truncation) {
+        final String revision = knownRevisions.get(new CaseInsensitiveString(name));
+
+        if (StringUtils.isNotBlank(truncation)) {
+            int truncationLength = Integer.parseInt(truncation);
+
+            if (null != revision && revision.length() > truncationLength) {
+                return revision.substring(0, truncationLength);
+            }
+        }
+
+        return revision;
     }
 
     public boolean equals(Object o) {
@@ -100,11 +109,7 @@ public class PipelineLabel implements Serializable {
 
         PipelineLabel label1 = (PipelineLabel) o;
 
-        if (label != null ? !label.equals(label1.label) : label1.label != null) {
-            return false;
-        }
-
-        return true;
+        return label != null ? label.equals(label1.label) : label1.label == null;
     }
 
     public int hashCode() {
@@ -121,14 +126,5 @@ public class PipelineLabel implements Serializable {
 
     public static PipelineLabel defaultLabel() {
         return new PipelineLabel(PipelineLabel.COUNT_TEMPLATE, InsecureEnvironmentVariables.EMPTY_ENV_VARS);
-    }
-
-
-    private String getValueIfVariableHasValidPrefix(CaseInsensitiveString variable) {
-        if (variable.startsWith(ENV_VAR_PREFIX)) {
-            return envVars.getInsecureEnvironmentVariableOrDefault(variable.toString().split(":", 2)[1], "");
-        }
-
-        return null;
     }
 }

--- a/config/config-api/src/main/java/com/thoughtworks/go/domain/label/PipelineLabel.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/domain/label/PipelineLabel.java
@@ -29,7 +29,7 @@ public class PipelineLabel implements Serializable {
     protected String label;
     private InsecureEnvironmentVariables envVars;
     public static final String COUNT = "COUNT";
-    private static final String ENV_VAR_PREFIX = "env:";
+    public static final String ENV_VAR_PREFIX = "env:";
     public static final String COUNT_TEMPLATE = String.format("${%s}", COUNT);
 
     public PipelineLabel(String labelTemplate, InsecureEnvironmentVariables insecureEnvironmentVariables) {
@@ -123,9 +123,6 @@ public class PipelineLabel implements Serializable {
         return new PipelineLabel(PipelineLabel.COUNT_TEMPLATE, InsecureEnvironmentVariables.EMPTY_ENV_VARS);
     }
 
-    public static boolean hasValidPrefix(String value) {
-        return value.toLowerCase().startsWith(ENV_VAR_PREFIX);
-    }
 
     private String getValueIfVariableHasValidPrefix(CaseInsensitiveString variable) {
         if (variable.startsWith(ENV_VAR_PREFIX)) {

--- a/config/config-api/src/test/java/com/thoughtworks/go/config/PipelineConfigTest.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/config/PipelineConfigTest.java
@@ -42,7 +42,6 @@ import java.util.*;
 import static com.thoughtworks.go.util.DataStructureUtils.a;
 import static com.thoughtworks.go.util.DataStructureUtils.m;
 import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.*;
 import static org.hamcrest.Matchers.startsWith;
 import static org.hamcrest.core.Is.is;
@@ -208,19 +207,8 @@ public class PipelineConfigTest {
     }
 
     @Test
-    public void shouldGetAllTemplateVariableNames() {
-        PipelineConfig pipelineConfig = new PipelineConfig(new CaseInsensitiveString("cruise"), new MaterialConfigs());
-        pipelineConfig.setLabelTemplate("pipeline-${COUNT}-${mymaterial}${hi}");
-
-        Set<String> variables = pipelineConfig.getTemplateVariables();
-        assertThat(variables.contains("COUNT"), is(true));
-        assertThat(variables.contains("mymaterial"), is(true));
-        assertThat(variables.contains("hi"), is(true));
-    }
-
-    @Test
     public void shouldValidateCorrectPipelineLabelWithoutAnyMaterial() {
-        PipelineConfig pipelineConfig = new PipelineConfig(new CaseInsensitiveString("cruise"), new MaterialConfigs(),new StageConfig(new CaseInsensitiveString("first"), new JobConfigs()));
+        PipelineConfig pipelineConfig = new PipelineConfig(new CaseInsensitiveString("cruise"), new MaterialConfigs(), new StageConfig(new CaseInsensitiveString("first"), new JobConfigs()));
         pipelineConfig.setLabelTemplate("pipeline-${COUNT}-alpha");
         pipelineConfig.validate(null);
         assertThat(pipelineConfig.errors().isEmpty(), is(true));
@@ -299,35 +287,9 @@ public class PipelineConfigTest {
     public void shouldNotAllowLabelTemplateWithLengthOfZeroInTruncationSyntax2() throws Exception {
         String labelFormat = "pipeline-${COUNT}-${git[:0]}${one[:00]}-alpha";
         PipelineConfig pipelineConfig = createAndValidatePipelineLabel(labelFormat);
-        assertThat(pipelineConfig.errors().on(PipelineConfig.LABEL_TEMPLATE), is(String.format("Length of zero not allowed on label %s defined on pipeline %s.",labelFormat,pipelineConfig.name())));
+        assertThat(pipelineConfig.errors().on(PipelineConfig.LABEL_TEMPLATE), is(String.format("Length of zero not allowed on label %s defined on pipeline %s.", labelFormat, pipelineConfig.name())));
     }
 
-    @Test
-    public void shouldSupportTruncationSyntax() {
-        PipelineConfig pipelineConfig = new PipelineConfig(new CaseInsensitiveString("cruise"), new MaterialConfigs());
-        pipelineConfig.setLabelTemplate("pipeline-${COUNT}-${git[:7]}-alpha");
-
-        Set<String> variables = pipelineConfig.getTemplateVariables();
-        assertThat(variables, contains("COUNT", "git"));
-        assertThat(variables.size(), is(2));
-    }
-
-    @Test
-    public void shouldSupportSpecialCharacters() {
-        PipelineConfig pipelineConfig = new PipelineConfig(new CaseInsensitiveString("cruise"), new MaterialConfigs());
-        pipelineConfig.setLabelTemplate("pipeline-${COUN_T}-${my-material}${h.i}${**}");
-
-        Set<String> variables = pipelineConfig.getTemplateVariables();
-        assertThat(variables, contains("COUN_T", "my-material", "h.i", "**"));
-    }
-
-    @Test
-    public void shouldAllowColonInLabelTemplateVariable() throws Exception {
-        PipelineConfig pipelineConfig = new PipelineConfig(new CaseInsensitiveString("cruise"), new MaterialConfigs());
-        pipelineConfig.setLabelTemplate("pipeline-${COUN_T}:${repo:package}");
-        Set<String> variables = pipelineConfig.getTemplateVariables();
-        assertThat(variables.contains("repo:package"), is(true));
-    }
 
     @Test
     public void shouldSetPipelineConfigFromConfigAttributes() {
@@ -920,17 +882,16 @@ public class PipelineConfigTest {
     }
 
     @Test
-    public void shouldReturnTrueWhenOneOfPipelineMaterialsIsTheSameAsConfigOrigin()
-    {
+    public void shouldReturnTrueWhenOneOfPipelineMaterialsIsTheSameAsConfigOrigin() {
         PipelineConfig pipelineConfig = PipelineConfigMother.createPipelineConfig("pipeline", "stage", "build");
         MaterialConfig material = pipelineConfig.materialConfigs().first();
         pipelineConfig.setOrigin(new RepoConfigOrigin(new ConfigRepoConfig(material, "plugin"), "1233"));
 
-        assertThat(pipelineConfig.isConfigOriginSameAsOneOfMaterials(),is(true));
+        assertThat(pipelineConfig.isConfigOriginSameAsOneOfMaterials(), is(true));
     }
+
     @Test
-    public void shouldReturnTrueWhenOneOfPipelineMaterialsIsTheSameAsConfigOriginButDestinationIsDifferent()
-    {
+    public void shouldReturnTrueWhenOneOfPipelineMaterialsIsTheSameAsConfigOriginButDestinationIsDifferent() {
         PipelineConfig pipelineConfig = PipelineConfigMother.createPipelineConfig("pipeline", "stage", "build");
         pipelineConfig.materialConfigs().clear();
         GitMaterialConfig pipeMaterialConfig = new GitMaterialConfig("http://git");
@@ -939,47 +900,44 @@ public class PipelineConfigTest {
 
         GitMaterialConfig repoMaterialConfig = new GitMaterialConfig("http://git");
 
-        pipelineConfig.setOrigin(new RepoConfigOrigin(new ConfigRepoConfig(repoMaterialConfig,"plugin"),"1233"));
+        pipelineConfig.setOrigin(new RepoConfigOrigin(new ConfigRepoConfig(repoMaterialConfig, "plugin"), "1233"));
 
-        assertThat(pipelineConfig.isConfigOriginSameAsOneOfMaterials(),is(true));
+        assertThat(pipelineConfig.isConfigOriginSameAsOneOfMaterials(), is(true));
     }
 
     @Test
-    public void shouldReturnFalseWhenOneOfPipelineMaterialsIsNotTheSameAsConfigOrigin()
-    {
+    public void shouldReturnFalseWhenOneOfPipelineMaterialsIsNotTheSameAsConfigOrigin() {
         PipelineConfig pipelineConfig = PipelineConfigMother.createPipelineConfig("pipeline", "stage", "build");
         MaterialConfig material = new GitMaterialConfig("http://git");
         pipelineConfig.setOrigin(new RepoConfigOrigin(new ConfigRepoConfig(material, "plugin"), "1233"));
 
-        assertThat(pipelineConfig.isConfigOriginSameAsOneOfMaterials(),is(false));
+        assertThat(pipelineConfig.isConfigOriginSameAsOneOfMaterials(), is(false));
     }
 
     @Test
-    public void shouldReturnFalseIfOneOfPipelineMaterialsIsTheSameAsConfigOrigin_WhenOriginIsFile()
-    {
+    public void shouldReturnFalseIfOneOfPipelineMaterialsIsTheSameAsConfigOrigin_WhenOriginIsFile() {
         PipelineConfig pipelineConfig = PipelineConfigMother.createPipelineConfig("pipeline", "stage", "build");
         pipelineConfig.setOrigin(new FileConfigOrigin());
 
-        assertThat(pipelineConfig.isConfigOriginSameAsOneOfMaterials(),is(false));
+        assertThat(pipelineConfig.isConfigOriginSameAsOneOfMaterials(), is(false));
     }
 
     @Test
-    public void shouldReturnTrueWhenConfigRevisionIsEqualToQuery()
-    {
+    public void shouldReturnTrueWhenConfigRevisionIsEqualToQuery() {
         PipelineConfig pipelineConfig = PipelineConfigMother.createPipelineConfig("pipeline", "stage", "build");
         MaterialConfig material = pipelineConfig.materialConfigs().first();
         pipelineConfig.setOrigin(new RepoConfigOrigin(new ConfigRepoConfig(material, "plugin"), "1233"));
 
-        assertThat(pipelineConfig.isConfigOriginFromRevision("1233"),is(true));
+        assertThat(pipelineConfig.isConfigOriginFromRevision("1233"), is(true));
     }
+
     @Test
-    public void shouldReturnFalseWhenConfigRevisionIsNotEqualToQuery()
-    {
+    public void shouldReturnFalseWhenConfigRevisionIsNotEqualToQuery() {
         PipelineConfig pipelineConfig = PipelineConfigMother.createPipelineConfig("pipeline", "stage", "build");
         MaterialConfig material = pipelineConfig.materialConfigs().first();
         pipelineConfig.setOrigin(new RepoConfigOrigin(new ConfigRepoConfig(material, "plugin"), "1233"));
 
-        assertThat(pipelineConfig.isConfigOriginFromRevision("32"),is(false));
+        assertThat(pipelineConfig.isConfigOriginFromRevision("32"), is(false));
     }
 
     @Test

--- a/config/config-api/src/test/java/com/thoughtworks/go/config/PipelineConfigValidationTest.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/config/PipelineConfigValidationTest.java
@@ -14,23 +14,22 @@
  * limitations under the License.
  */
 
-package com.thoughtworks.go.domain;
+package com.thoughtworks.go.config;
 
 import com.rits.cloning.Cloner;
-import com.thoughtworks.go.config.*;
 import com.thoughtworks.go.config.materials.MaterialConfigs;
 import com.thoughtworks.go.config.materials.PackageMaterialConfig;
 import com.thoughtworks.go.config.materials.ScmMaterialConfig;
 import com.thoughtworks.go.config.materials.dependency.DependencyMaterialConfig;
 import com.thoughtworks.go.config.materials.git.GitMaterialConfig;
 import com.thoughtworks.go.config.materials.perforce.P4MaterialConfig;
+import com.thoughtworks.go.domain.ConfigErrors;
 import com.thoughtworks.go.domain.packagerepository.PackageDefinitionMother;
 import com.thoughtworks.go.helper.GoConfigMother;
 import com.thoughtworks.go.helper.MaterialConfigsMother;
 import org.hamcrest.CoreMatchers;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.Arrays;
@@ -91,7 +90,6 @@ public class PipelineConfigValidationTest {
     }
 
     @Test
-    @Ignore("Will fix this in a few days. See https://github.com/gocd/gocd/issues/5240")
     public void isValid_shouldEnsureLabelTemplateRefersToAMaterialOrCOUNT() {
         pipeline.setLabelTemplate("label-template-without-material-or-count");
 
@@ -299,7 +297,6 @@ public class PipelineConfigValidationTest {
     public void shouldReturnTrueIfAllDescendentsAreValid() {
         StageConfig stageConfig = mock(StageConfig.class);
         MaterialConfigs materialConfigs = mock(MaterialConfigs.class);
-        when(materialConfigs.iterator()).thenReturn(new MaterialConfigs().iterator());
         ParamsConfig paramsConfig = mock(ParamsConfig.class);
         EnvironmentVariablesConfig variables = mock(EnvironmentVariablesConfig.class);
         TrackingTool trackingTool = mock(TrackingTool.class);
@@ -322,7 +319,6 @@ public class PipelineConfigValidationTest {
         boolean isValid = pipelineConfig.validateTree(PipelineConfigSaveValidationContext.forChain(true, "group", new BasicCruiseConfig(new BasicPipelineConfigs("group", new Authorization())), pipelineConfig));
         assertTrue(isValid);
         verify(stageConfig).validateTree(any(PipelineConfigSaveValidationContext.class));
-        verify(materialConfigs, atLeastOnce()).iterator();
         verify(materialConfigs).validateTree(any(PipelineConfigSaveValidationContext.class));
         verify(paramsConfig).validateTree(any(PipelineConfigSaveValidationContext.class));
         verify(variables).validateTree(any(PipelineConfigSaveValidationContext.class));

--- a/config/config-api/src/test/java/com/thoughtworks/go/config/PipelineConfigValidationTest.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/config/PipelineConfigValidationTest.java
@@ -32,24 +32,19 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.util.Arrays;
 import java.util.List;
 
 import static com.thoughtworks.go.util.TestUtils.contains;
-import static junit.framework.Assert.assertFalse;
-import static junit.framework.Assert.assertTrue;
-import static org.hamcrest.Matchers.hasItem;
+import static java.util.Collections.singletonList;
 import static org.hamcrest.Matchers.startsWith;
 import static org.hamcrest.core.Is.is;
-import static org.hamcrest.core.IsNull.nullValue;
-import static org.junit.Assert.assertThat;
+import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
 public class PipelineConfigValidationTest {
     private CruiseConfig config;
     private PipelineConfig pipeline;
     private GoConfigMother goConfigMother;
-    private ValidationContext validationContext;
 
     @Before
     public void setup() {
@@ -66,94 +61,100 @@ public class PipelineConfigValidationTest {
         jobConfig.addTask(new ExecTask("ls", "-la", "tmp"));
         StageConfig stageConfig = new StageConfig(new CaseInsensitiveString("stage"), new JobConfigs(jobConfig));
         pipelineConfig.addStageWithoutValidityAssertion(stageConfig);
-        pipelineConfig.validate(validationContext);
+        pipelineConfig.validate(null);
 
         assertThat(stageConfig.errors().getAllOn("name"),
-                is(Arrays.asList("You have defined multiple stages called 'stage'. Stage names are case-insensitive and must be unique.")));
+                is(singletonList("You have defined multiple stages called 'stage'. Stage names are case-insensitive and must be unique.")));
 
         assertThat(pipelineConfig.get(0).errors().getAllOn("name"),
-                is(Arrays.asList("You have defined multiple stages called 'stage'. Stage names are case-insensitive and must be unique.")));
+                is(singletonList("You have defined multiple stages called 'stage'. Stage names are case-insensitive and must be unique.")));
 
         assertThat(cruiseConfig.validateAfterPreprocess().get(0).getAllOn("name"),
-                is(Arrays.asList("You have defined multiple stages called 'stage'. Stage names are case-insensitive and must be unique.")));
+                is(singletonList("You have defined multiple stages called 'stage'. Stage names are case-insensitive and must be unique.")));
+    }
+
+    @Test
+    public void rejectsMissingMaterial() {
+        assertLabelTemplate("foo-${[:5]}-bar", errors -> {
+            assertEquals(singletonList("You have defined a label template in pipeline 'go' that refers to a material called '', but no material with this name is defined."), errors);
+        });
+    }
+
+    @Test
+    public void rejectsBadTruncation() {
+        assertLabelTemplate("foo-${material[:5}-bar", errors -> {
+            assertEquals(1, errors.size());
+            assertThat(errors.get(0), startsWith("Invalid label"));
+        });
+    }
+
+    @Test
+    public void rejectsBlankToken() {
+        assertLabelTemplate("foo-${}-bar", errors ->
+                assertEquals(singletonList("Label template variable cannot be blank."), errors));
+    }
+
+    @Test
+    public void rejectsMissingEnvironmentVariable() {
+        assertLabelTemplate("foo-${env:}-bar", errors ->
+                assertEquals(singletonList("Missing environment variable name."), errors));
     }
 
     @Test
     public void isValid_shouldEnsureLabelTemplateRefersToValidMaterials() {
-        pipeline.setLabelTemplate("pipeline-${COUNT}-${myGit}");
-
-        pipeline.validate(validationContext);
-        ConfigErrors configErrors = pipeline.errors();
-        List<String> errors = configErrors.getAllOn("labelTemplate");
-        assertThat(errors.size(), is(1));
-        assertThat(errors, hasItem("You have defined a label template in pipeline go that refers to a material called myGit, but no material with this name is defined."));
+        assertLabelTemplate("pipeline-${COUNT}-${myGit}", errors ->
+                assertEquals(singletonList("You have defined a label template in pipeline 'go' that refers to a material called 'myGit', but no material with this name is defined."), errors));
     }
 
     @Test
     public void isValid_shouldEnsureLabelTemplateRefersToAMaterialOrCOUNT() {
-        pipeline.setLabelTemplate("label-template-without-material-or-count");
-
-        pipeline.validate(validationContext);
-        ConfigErrors configErrors = pipeline.errors();
-        List<String> errors = configErrors.getAllOn("labelTemplate");
-        assertThat(errors.size(), is(1));
-        assertThat(errors.get(0), startsWith("Invalid label"));
+        assertLabelTemplate("label-template-without-material-or-count", errors -> {
+            assertEquals(1, errors.size());
+            assertThat(errors.get(0), startsWith("Invalid label"));
+        });
     }
 
     @Test
     public void isValid_shouldEnsureLabelTemplateHasValidVariablePattern() {
-        pipeline.setLabelTemplate("pipeline-${COUNT");
-
-        pipeline.validate(validationContext);
-        ConfigErrors configErrors = pipeline.errors();
-        assertThat(configErrors.isEmpty(), is(false));
-        List<String> errors = configErrors.getAllOn("labelTemplate");
-        assertThat(errors.size(), is(1));
-        assertThat(errors.get(0), startsWith("Invalid label"));
+        assertLabelTemplate("pipeline-${COUNT", errors -> {
+            assertEquals(1, errors.size());
+            assertThat(errors.get(0), startsWith("Invalid label"));
+        });
     }
 
     @Test
     public void isValid_labelTemplateShouldAcceptLabelTemplateWithHashCharacter() {
-        pipeline.setLabelTemplate("foo${COUNT}-tanker#");
-
-        pipeline.validate(validationContext);
-        ConfigErrors configErrors = pipeline.errors();
-        assertThat(configErrors.isEmpty(), is(true));
-        List<String> errors = configErrors.getAllOn("labelTemplate");
-        assertThat(errors, is(nullValue()));
+        assertLabelTemplate("foo${COUNT}-tanker#", Assert::assertNull);
     }
 
     @Test
     public void isValid_shouldMatchMaterialNamesInACaseInsensitiveManner() {
-        pipeline.setLabelTemplate("pipeline-${count}-${myGit}");
-
         ScmMaterialConfig gitMaterialConfig = MaterialConfigsMother.gitMaterialConfig("git://url");
         gitMaterialConfig.setName(new CaseInsensitiveString("mygit"));
         pipeline.addMaterialConfig(gitMaterialConfig);
-        pipeline.validate(validationContext);
-        assertThat(pipeline.errors().isEmpty(), is(true));
-        List<String> errors = pipeline.errors().getAllOn("labelTemplate");
-        assertThat(errors, is(nullValue()));
+
+        assertLabelTemplate("pipeline-${count}-${myGit}", errors -> {
+            assertTrue(pipeline.errors().isEmpty());
+            assertNull(errors);
+        });
     }
 
     @Test
     public void isValid_shouldEnsureReturnsTrueWhenLabelTemplateRefersToValidMaterials() {
-        pipeline.setLabelTemplate("pipeline-${COUNT}-${myGit}");
         GitMaterialConfig gitConfig = MaterialConfigsMother.gitMaterialConfig("git://url");
         gitConfig.setName(new CaseInsensitiveString("myGit"));
         pipeline.addMaterialConfig(gitConfig);
-        pipeline.validate(validationContext);
-        assertThat(pipeline.errors().isEmpty(), is(true));
-        List<String> errors = pipeline.errors().getAllOn("labelTemplate");
-        assertThat(errors, is(nullValue()));
+
+        assertLabelTemplate("pipeline-${COUNT}-${myGit}", errors -> {
+            assertTrue(pipeline.errors().isEmpty());
+            assertNull(errors);
+        });
     }
 
     @Test
-    public void isValid_shouldAllowColonForLabelTemplate() throws Exception {
-        pipeline.setLabelTemplate("pipeline-${COUNT}-${repo:name}");
+    public void isValid_shouldAllowColonForLabelTemplate() {
         pipeline.addMaterialConfig(new PackageMaterialConfig(new CaseInsensitiveString("repo:name"), "package-id", PackageDefinitionMother.create("package-id")));
-        pipeline.validate(validationContext);
-        assertThat(pipeline.errors().getAllOn("labelTemplate"), is(nullValue()));
+        assertLabelTemplate("pipeline-${COUNT}-${repo:name}", Assert::assertNull);
     }
 
     @Test
@@ -169,48 +170,48 @@ public class PipelineConfigValidationTest {
     @Test
     public void validate_shouldEnsureThatPipelineFollowsTheNameType() {
         PipelineConfig config = new PipelineConfig(new CaseInsensitiveString(".name"), new MaterialConfigs());
-        config.validate(validationContext);
+        config.validate(null);
         assertThat(config.errors().isEmpty(), is(false));
         assertThat(config.errors().on(PipelineConfig.NAME), is("Invalid pipeline name '.name'. This must be alphanumeric and can contain underscores and periods (however, it cannot start with a period). The maximum allowed length is 255 characters."));
     }
 
     @Test
-    public void shouldBeValidIfTheReferencedPipelineExists() throws Exception {
+    public void shouldBeValidIfTheReferencedPipelineExists() {
         pipeline.addMaterialConfig(new DependencyMaterialConfig(new CaseInsensitiveString("pipeline2"), new CaseInsensitiveString("stage")));
-        pipeline.validate(validationContext);
+        pipeline.validate(null);
         assertThat(pipeline.errors().isEmpty(), is(true));
     }
 
     @Test
-    public void shouldAllowMultipleDependenciesForDifferentPipelines() throws Exception {
+    public void shouldAllowMultipleDependenciesForDifferentPipelines() {
         pipeline.addMaterialConfig(new DependencyMaterialConfig(new CaseInsensitiveString("pipeline2"), new CaseInsensitiveString("stage")));
         pipeline.addMaterialConfig(new DependencyMaterialConfig(new CaseInsensitiveString("pipeline3"), new CaseInsensitiveString("stage")));
-        pipeline.validate(validationContext);
+        pipeline.validate(null);
         assertThat(pipeline.errors().isEmpty(), is(true));
     }
 
     @Test
-    public void shouldAllowDependenciesFromMultiplePipelinesToTheSamePipeline() throws Exception {
+    public void shouldAllowDependenciesFromMultiplePipelinesToTheSamePipeline() {
         pipeline.addMaterialConfig(new DependencyMaterialConfig(new CaseInsensitiveString("pipeline2"), new CaseInsensitiveString("stage")));
 
         PipelineConfig pipeline3 = config.pipelineConfigByName(new CaseInsensitiveString("pipeline3"));
         pipeline3.addMaterialConfig(new DependencyMaterialConfig(new CaseInsensitiveString("pipeline2"), new CaseInsensitiveString("stage")));
 
-        pipeline.validate(validationContext);
+        pipeline.validate(null);
         assertThat(pipeline.errors().isEmpty(), is(true));
-        pipeline3.validate(validationContext);
+        pipeline3.validate(null);
         assertThat(pipeline3.errors().isEmpty(), is(true));
 
     }
 
     @Test
-    public void shouldNotAllowAnEmptyView() throws Exception {
+    public void shouldNotAllowAnEmptyView() {
         CruiseConfig config = GoConfigMother.configWithPipelines("pipeline1");
         P4MaterialConfig materialConfig = new P4MaterialConfig("localhost:1666", "");
 
         PipelineConfig pipelineConfig = config.pipelineConfigByName(new CaseInsensitiveString("pipeline1"));
         pipelineConfig.addMaterialConfig(materialConfig);
-        materialConfig.validate(validationContext);
+        materialConfig.validate(null);
         assertThat(materialConfig.errors().on("view"), is("P4 view cannot be empty."));
     }
 
@@ -264,7 +265,7 @@ public class PipelineConfigValidationTest {
     }
 
     @Test
-    public void shouldFailValidateWhenUpstreamPipelineForDependencyMaterailDoesNotExist() {
+    public void shouldFailValidateWhenUpstreamPipelineForDependencyMaterialDoesNotExist() {
         String upstreamPipeline = "non-existant";
         PipelineConfig pipelineConfig = GoConfigMother.createPipelineConfigWithMaterialConfig(
                 new DependencyMaterialConfig(new CaseInsensitiveString(upstreamPipeline), new CaseInsensitiveString("non-existant")));
@@ -279,7 +280,7 @@ public class PipelineConfigValidationTest {
     }
 
     @Test
-    public void shouldFailValidateWhenUpstreamStageForDependencyMaterailDoesNotExist() {
+    public void shouldFailValidateWhenUpstreamStageForDependencyMaterialDoesNotExist() {
         String upstreamPipeline = "upstream";
         String upstreamStage = "non-existant";
         PipelineConfig upstream = GoConfigMother.createPipelineConfigWithMaterialConfig(upstreamPipeline, new GitMaterialConfig("url"));
@@ -504,7 +505,7 @@ public class PipelineConfigValidationTest {
         cruiseConfig.addPipeline(groupName, p1);
         p1.validateTree(PipelineConfigSaveValidationContext.forChain(true, groupName, cruiseConfig, p1));
 
-        Assert.assertFalse(p1.errors().isEmpty());
+        assertFalse(p1.errors().isEmpty());
         assertThat(p1.errors().on(PipelineConfigs.GROUP), contains("Invalid group name '%$-with-invalid-characters'"));
     }
 
@@ -520,4 +521,16 @@ public class PipelineConfigValidationTest {
         return new StageConfig(new CaseInsensitiveString(stageName), jobConfigs);
     }
 
+    private void assertLabelTemplate(String labelTemplate, LabelErrorsFn assertions) {
+        pipeline.setLabelTemplate(labelTemplate);
+        pipeline.validate(null);
+        List<String> errors = pipeline.errors().getAllOn("labelTemplate");
+        assertions.asserting(errors);
+    }
+
+    @FunctionalInterface
+    private interface LabelErrorsFn {
+
+        void asserting(List<String> errors);
+    }
 }

--- a/config/config-server/src/main/resources/cruise-config.xsd
+++ b/config/config-server/src/main/resources/cruise-config.xsd
@@ -394,7 +394,7 @@
             <xsd:element minOccurs="0" maxOccurs="unbounded" name="stage" type="stageType"/>
           </xsd:sequence>
           <xsd:attribute name="name" type="nameType" use="required"/>
-          <xsd:attribute name="labeltemplate" type="labelType"/>
+          <xsd:attribute name="labeltemplate" type="nonEmptyString" use="optional"/>
           <xsd:attribute name="lockBehavior">
             <xsd:simpleType>
               <xsd:restriction base="xsd:string">
@@ -843,12 +843,6 @@
   <xsd:simpleType name="nonEmptyString">
     <xsd:restriction base="xsd:string">
       <xsd:pattern value="[\s]*[\S][\s\S]*"/>
-    </xsd:restriction>
-  </xsd:simpleType>
-  <xsd:simpleType name="labelType">
-    <xsd:restriction base="xsd:string">
-      <xsd:pattern
-          value="(([a-zA-Z0-9_\-.!~*'()#:])*[$#]\{[a-zA-Z:]*[a-zA-Z0-9_\-.!~*'()#:]+(\[:(\d+)\])?\}([a-zA-Z0-9_\-.!~*'()#:])*)+"/>
     </xsd:restriction>
   </xsd:simpleType>
   <xsd:simpleType name="jobnameType">

--- a/domain/src/main/java/com/thoughtworks/go/domain/Pipeline.java
+++ b/domain/src/main/java/com/thoughtworks/go/domain/Pipeline.java
@@ -26,8 +26,6 @@ import java.io.File;
 import java.util.Date;
 import java.util.Map;
 
-import static com.thoughtworks.go.domain.label.PipelineLabel.COUNT;
-
 public class Pipeline extends PersistentObject implements PipelineInfo {
 
     private String pipelineName;
@@ -151,7 +149,6 @@ public class Pipeline extends PersistentObject implements PipelineInfo {
 
     private void updateLabel() {
         Map<CaseInsensitiveString, String> namedRevisions = this.getMaterialRevisions().getNamedRevisions();
-        namedRevisions.put(new CaseInsensitiveString(COUNT), counter.toString());
         this.pipelineLabel.updateLabel(namedRevisions, counter);
     }
 

--- a/domain/src/main/java/com/thoughtworks/go/domain/Pipeline.java
+++ b/domain/src/main/java/com/thoughtworks/go/domain/Pipeline.java
@@ -152,7 +152,7 @@ public class Pipeline extends PersistentObject implements PipelineInfo {
     private void updateLabel() {
         Map<CaseInsensitiveString, String> namedRevisions = this.getMaterialRevisions().getNamedRevisions();
         namedRevisions.put(new CaseInsensitiveString(COUNT), counter.toString());
-        this.pipelineLabel.updateLabel(namedRevisions);
+        this.pipelineLabel.updateLabel(namedRevisions, counter);
     }
 
     public boolean isAnyStageActive() {
@@ -200,7 +200,7 @@ public class Pipeline extends PersistentObject implements PipelineInfo {
     }
 
     public boolean isBisect() {
-         return naturalOrderIsNotAnInteger();
+        return naturalOrderIsNotAnInteger();
     }
 
     private boolean naturalOrderIsNotAnInteger() {

--- a/server/webapp/WEB-INF/rails/spec/presenters/api_v5/admin/pipelines/pipeline_config_representer_spec.rb
+++ b/server/webapp/WEB-INF/rails/spec/presenters/api_v5/admin/pipelines/pipeline_config_representer_spec.rb
@@ -450,7 +450,7 @@ describe ApiV5::Admin::Pipelines::PipelineConfigRepresenter do
         }
       },
       errors: {
-        label_template: ['You have defined a label template in pipeline wunderbar that refers to a material called svn, but no material with this name is defined.']
+        label_template: ["You have defined a label template in pipeline 'wunderbar' that refers to a material called 'svn', but no material with this name is defined."]
       }
     }
   end


### PR DESCRIPTION
Simplify PipelineLabel validation and interpolation to prevent long-running regex issues

  - Do not validate in XSD
  - Break up gnarly regex into simple string operations + simpler regexes
    - match COUNT
    - match env:
    - match materials + truncation spec
  - Explicitly interpolate COUNT instead of pretending it's a special material
  - Split out logic for environment variable resolution vs material resolution