### PR TITLE
Fixed link to 'Locked by stage' on the stages details page

### DIFF
--- a/server/webapp/WEB-INF/rails/app/helpers/stages_helper.rb
+++ b/server/webapp/WEB-INF/rails/app/helpers/stages_helper.rb
@@ -34,10 +34,6 @@ module StagesHelper
                                     :stage_counter => identifier.getStageCounter()))
   end
 
-  def stage_detail_pipeline_tab_for_identifier identifier
-    tab_aware_path_for_stage identifier, 'pipeline'
-  end
-
   def tab_aware_path_for_stage stage_identifier, tab
     stage_detail_tab_path_for :pipeline_name => stage_identifier.getPipelineName(),
                           :pipeline_counter => stage_identifier.getPipelineCounter(),

--- a/server/webapp/WEB-INF/rails/app/views/pipelines/_pipeline_header.html.erb
+++ b/server/webapp/WEB-INF/rails/app/views/pipelines/_pipeline_header.html.erb
@@ -30,7 +30,7 @@
             <% end %>
         <% else %>
             <div class="locked_instance">
-              (<%= link_to("Locked by #{@lockedPipeline.getPipelineLabel()}" , stage_detail_pipeline_tab_for_identifier(@lockedPipeline)) %>
+              (<%= link_to("Locked by #{@lockedPipeline.getPipelineLabel()}" , stage_detail_path_for_identifier(@lockedPipeline)) %>
               )
             </div>
         <% end %>

--- a/server/webapp/WEB-INF/rails/spec/helpers/stages_helper_spec.rb
+++ b/server/webapp/WEB-INF/rails/spec/helpers/stages_helper_spec.rb
@@ -35,10 +35,6 @@ describe StagesHelper do
     expect(tab_aware_path_for_stage(StageIdentifier.new("pipeline", 10, "stage", "5"), "jobs")).to eq("/pipelines/pipeline/10/stage/5/jobs")
   end
 
-  it "should generate pipeline url when stage identifier is given" do
-    expect(stage_detail_pipeline_tab_for_identifier(StageIdentifier.new("pipeline", 10, "stage", "5"))).to eq("/pipelines/pipeline/10/stage/5/pipeline")
-  end
-
   it "should understand if stage is dummy" do
     expect(placeholder_stage?(@stage_summary)).to be_falsey
     expect(placeholder_stage?(@new_stage_summary)).to be_truthy

--- a/server/webapp/WEB-INF/rails/spec/views/layouts/pipelines_html_spec.rb
+++ b/server/webapp/WEB-INF/rails/spec/views/layouts/pipelines_html_spec.rb
@@ -53,7 +53,7 @@ describe "layouts/pipelines.html.eb" do
     allow(view).to receive(:stage_detail_tab_path_for).with(:pipeline_name => 'pipeline', :pipeline_counter => 1, :stage_name => 'stage-1', :stage_counter => "1", :action => 'overview').and_return("url_to_1")
     allow(view).to receive(:stage_detail_tab_path_for).with(:pipeline_name => "cruise", :pipeline_counter => 1,
                                                 :stage_name => 'dev', :stage_counter => "1", :action => 'overview').and_return("url_to_historical_stage")
-    allow(view).to receive(:stage_detail_tab_path_for).with(:pipeline_name=>"pipeline-name", :pipeline_counter=>1, :stage_name=>"stage-1", :stage_counter=>"1", :action=>"pipeline").and_return("url_to_pipeline")
+    allow(view).to receive(:stage_detail_tab_path_for).with(:pipeline_name=>"pipeline-name", :pipeline_counter=>1, :stage_name=>"stage-1", :stage_counter=>"1").and_return("url_to_pipeline")
     allow(view).to receive(:stage_history_path).and_return("historical_stage_page_number")
     allow(view).to receive(:is_user_an_admin?).and_return(true)
     allow(view).to receive(:config_change_path)
@@ -236,7 +236,7 @@ describe "layouts/pipelines.html.eb" do
         assign(:lockedPipeline,StageIdentifier.new("blah", 1, "cool-bug", "stage", "2"))
         @pim.setCanUnlock(true)
 
-        allow(view).to receive(:stage_detail_tab_path_for).with(:pipeline_name=>"blah", :pipeline_counter=>1, :stage_name=>"stage", :stage_counter=>"2", :action=>"pipeline").and_return("pipeline2")
+        allow(view).to receive(:stage_detail_tab_path_for).with(:pipeline_name=>"blah", :pipeline_counter=>1, :stage_name=>"stage", :stage_counter=>"2").and_return("pipeline2")
 
         render :inline => '<div>content</div>', :layout=>@layout_name
         expect(response.body).to have_selector(".locked .locked_instance a[href='pipeline2']", :text=>"Locked by cool-bug")


### PR DESCRIPTION
* The link 'Locked by' used to link to the pipelines tab on the stage
  details page. The pipelines tab was removed recently and hence the
  link was broken.
* 'Locked by' links to the default overview tab on the stage details
  page now.