### PR TITLE
Reimplement AjaxPoller with plain setTimeout()

### DIFF
--- a/server/webapp/WEB-INF/rails/package.json
+++ b/server/webapp/WEB-INF/rails/package.json
@@ -28,7 +28,6 @@
     "mithril": "^1.1.1",
     "moment": "^2.20.1",
     "moment-duration-format": "^2.2.1",
-    "repeat": "^0.0.6",
     "underscore.string": "^3.3.4",
     "uuid": "^3.2.1"
   },

--- a/server/webapp/WEB-INF/rails/webpack/helpers/ajax_poller.js
+++ b/server/webapp/WEB-INF/rails/webpack/helpers/ajax_poller.js
@@ -17,7 +17,6 @@
 const _         = require('lodash');
 const m         = require('mithril');
 const Stream    = require('mithril/stream');
-const Repeat    = require('repeat');
 const CONSTANTS = require('helpers/constants.js');
 
 // Set the name of the hidden property and the change event for visibility
@@ -39,72 +38,77 @@ const defaultOptions = {
   visibilityBackoffFactor: 4
 };
 
-const AjaxPoller = function (args = {}) {
-  let options;
-  if (_.isFunction(args)) {
-    options = _.assign({}, defaultOptions, {fn: args});
-  } else {
-    options = _.assign({}, defaultOptions, args);
-  }
-
-
-  const self       = this;
+function AjaxPoller (args={}) {
+  const options = _.assign({}, defaultOptions, "function" === typeof args ? {fn: args} : args);
   const currentXHR = Stream();
-  let repeater;
+  const self = this;
 
-  function createRepeater() {
-    return Repeat((repeatAgain) => {
-      options.fn(currentXHR).always(() => {
-        repeatAgain();
-        currentXHR(null);
-        m.redraw();
-      });
+  let timeout = null;
+  let abort = false;
+
+  function fire() {
+    options.fn(currentXHR).always(() => {
+      currentXHR(null);
+      m.redraw();
+
+      if (!abort && !autoRefreshDisabled()) {
+        timeout = setTimeout(fire, currentPollInterval() * 1000);
+      }
     });
   }
 
-  function currentPollInterval() {
-    if (document[hidden]) {
-      return options.intervalSeconds * options.visibilityBackoffFactor;
-    } else {
-      return options.intervalSeconds;
-    }
-  }
-
-  const handleVisibilityChange = () => {
-    self.stop();
-    repeater = createRepeater();
-    repeater.every(currentPollInterval(), 'sec').start.in(options.inSeconds, 'sec');
-  };
-
-  const doesBrowserSupportPageVisibilityAPI = () => {
-    return (typeof document.hidden !== "undefined");
-  };
-
-  this.start = function () {
-    repeater = createRepeater();
-    repeater.every(currentPollInterval(), 'sec')
-      .times(_.includes(window.location.search, 'auto_refresh=false') ? 1 : Infinity)
-      .start.in(options.inSeconds, 'sec');
+  function start() {
+    abort = false;
 
     if (doesBrowserSupportPageVisibilityAPI()) {
       document.addEventListener(visibilityChange, handleVisibilityChange, false);
     } else {
-      console.warn("Browser doesn't support the Page Visibility API!"); //eslint-disable-line
+      console.warn("Browser doesn't support the Page Visibility API!"); // eslint-disable-line no-console
     }
-    return this;
-  };
 
-  this.stop = () => {
-    repeater.stop();
+    const period = "number" === options.inSeconds && !options.inSeconds < 0 ? options.inSeconds : 0;
+    timeout = setTimeout(fire, period * 1000);
+  }
+
+  function stop() {
+    if ("number" === typeof timeout) {
+      clearTimeout(timeout);
+      abort = true;
+      timeout = null;
+    }
+
+    document.removeEventListener(visibilityChange, handleVisibilityChange);
+
     if (currentXHR()) {
       currentXHR().abort();
     }
-  };
+  }
+
+  function currentPollInterval() {
+    return document[hidden] ?
+      options.intervalSeconds * options.visibilityBackoffFactor :
+      options.intervalSeconds;
+  }
+
+  function handleVisibilityChange() {
+    self.restart();
+  }
+
+  function doesBrowserSupportPageVisibilityAPI() {
+    return "undefined" !== typeof document[hidden];
+  }
+
+  this.stop = stop;
+  this.start = start;
 
   this.restart = () => {
     this.stop();
     this.start();
   };
-};
+}
+
+function autoRefreshDisabled() {
+  return !!~window.location.search.indexOf("auto_refresh=false");
+}
 
 module.exports = AjaxPoller;

--- a/server/webapp/WEB-INF/rails/webpack/helpers/ajax_poller.js
+++ b/server/webapp/WEB-INF/rails/webpack/helpers/ajax_poller.js
@@ -66,7 +66,7 @@ function AjaxPoller (args={}) {
       console.warn("Browser doesn't support the Page Visibility API!"); // eslint-disable-line no-console
     }
 
-    const period = "number" === options.inSeconds && !options.inSeconds < 0 ? options.inSeconds : 0;
+    const period = Math.max("number" === typeof options.inSeconds ? options.inSeconds : 0, 0);
     timeout = setTimeout(fire, period * 1000);
   }
 

--- a/server/webapp/WEB-INF/rails/yarn.lock
+++ b/server/webapp/WEB-INF/rails/yarn.lock
@@ -2282,10 +2282,6 @@ dezalgo@^1.0.0:
     asap "^2.0.0"
     wrappy "1"
 
-dfrrd@latest:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/dfrrd/-/dfrrd-0.2.0.tgz#a69238ecb08c0ebf7bec4a0fc504b913ea8a28ae"
-
 di@^0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/di/-/di-0.0.1.tgz#806649326ceaa7caa3306d75d985ea2748ba913c"
@@ -6009,12 +6005,6 @@ repeat-string@^0.2.2:
 repeat-string@^1.5.2, repeat-string@^1.6.1:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/repeat-string/-/repeat-string-1.6.1.tgz#8dcae470e1c88abc2d600fff4a776286da75e637"
-
-repeat@^0.0.6:
-  version "0.0.6"
-  resolved "https://registry.yarnpkg.com/repeat/-/repeat-0.0.6.tgz#6c9d8133eb8ceaf8e380f06c69b51417b7cb0e8d"
-  dependencies:
-    dfrrd latest
 
 repeating@^2.0.0:
   version "2.0.1"


### PR DESCRIPTION
  - The `repeat` npm module is no longer maintained or developed (since 2012)
  - Repeat objects don't seem to always `stop()` properly (?!?!)
  - Interface is the same, should be a transparent change