### PR TITLE
Revert "Package installers with java 10."

### DIFF
--- a/buildSrc/src/main/groovy/com/thoughtworks/go/build/WindowsPackagingTask.groovy
+++ b/buildSrc/src/main/groovy/com/thoughtworks/go/build/WindowsPackagingTask.groovy
@@ -30,6 +30,8 @@ class WindowsPackagingTask extends DefaultTask {
   String version
   @Input
   String distVersion
+  @Input
+  Boolean is32Bit = false
 
   Closure<Task> beforePackage
 
@@ -103,7 +105,7 @@ class WindowsPackagingTask extends DefaultTask {
   }
 
   def defaultJreLocation() {
-    "http://download.oracle.com/otn-pub/java/jdk/10.0.2+13/19aef61b38124481863b1413dce1855f/jre-10.0.2_windows-x64_bin.tar.gz"
+    is32Bit ? "http://download.oracle.com/otn-pub/java/jdk/8u152-b16/aa0333dd3019491ca4f6ddbe78cdb6d0/jre-8u152-windows-i586.tar.gz" : "http://download.oracle.com/otn-pub/java/jdk/8u152-b16/aa0333dd3019491ca4f6ddbe78cdb6d0/jre-8u152-windows-x64.tar.gz"
   }
 
   def specifiedJreLocation() {
@@ -111,7 +113,7 @@ class WindowsPackagingTask extends DefaultTask {
   }
 
   def flavour() {
-    "64bit"
+    is32Bit ? "32bit" : "64bit"
   }
 
   def buildPackage() {

--- a/installers/windows-shared/JavaHome.ini
+++ b/installers/windows-shared/JavaHome.ini
@@ -8,7 +8,7 @@ Right=-5
 Top=10
 Bottom=20
 State=1
-Text=" Use bundled JRE (Oracle JRE 10) "
+Text=" Use bundled JRE (Oracle JRE 8) "
 Flags=NOTIFY
 
 [Field 2]

--- a/installers/windows.gradle
+++ b/installers/windows.gradle
@@ -18,6 +18,21 @@
 import com.thoughtworks.go.build.WindowsPackagingTask
 import org.apache.tools.ant.filters.FixCrLfFilter
 
+task agentWindows32bitExe(type: WindowsPackagingTask) {
+  dependsOn configurations.agentBootstrapperJar
+  group project.name
+  description 'Build the go-agent windows installer'
+
+  packageName 'go-agent'
+  version rootProject.goVersion
+  distVersion rootProject.distVersion
+  is32Bit true
+
+  beforePackage {
+    copyAgentSpecificFiles(versionedDir(), buildRoot(), flavour())
+  }
+}
+
 task agentWindows64bitExe(type: WindowsPackagingTask) {
   dependsOn configurations.agentBootstrapperJar
   group project.name
@@ -26,9 +41,25 @@ task agentWindows64bitExe(type: WindowsPackagingTask) {
   packageName 'go-agent'
   version rootProject.goVersion
   distVersion rootProject.distVersion
+  is32Bit false
 
   beforePackage {
     copyAgentSpecificFiles(versionedDir(), buildRoot(), flavour())
+  }
+}
+
+task serverWindows32bitExe(type: WindowsPackagingTask) {
+  dependsOn configurations.serverJar
+  group project.name
+  description 'Build the go-server windows installer'
+
+  packageName 'go-server'
+  version rootProject.goVersion
+  distVersion rootProject.distVersion
+  is32Bit true
+
+  beforePackage {
+    copyServerSpecificFiles(versionedDir(), buildRoot(), flavour())
   }
 }
 
@@ -40,6 +71,7 @@ task serverWindows64bitExe(type: WindowsPackagingTask) {
   packageName 'go-server'
   version rootProject.goVersion
   distVersion rootProject.distVersion
+  is32Bit false
 
   beforePackage {
     copyServerSpecificFiles(versionedDir(), buildRoot(), flavour())
@@ -100,4 +132,4 @@ private void copyCommonFiles(versionedDir, buildRoot, flavour) {
 }
 
 
-assemble.dependsOn(":installers:agentWindows64bitExe", ":installers:serverWindows64bitExe")
+assemble.dependsOn(":installers:agentWindows32bitExe", ":installers:agentWindows64bitExe", ":installers:serverWindows32bitExe", ":installers:serverWindows64bitExe")


### PR DESCRIPTION
* Moving back to packaging JRE 8 with windows installers for GoCD 18.10.0
  as we wait for clarity on Java licenses.

This reverts commit 7cadf58812d0600d0192988c0bf5446db6a78888.