### PR TITLE
Allow env prefix case-insensitive matching while validating pipeline label templates

### DIFF
--- a/config/config-api/src/main/java/com/thoughtworks/go/config/PipelineConfig.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/PipelineConfig.java
@@ -280,12 +280,12 @@ public class PipelineConfig extends BaseCollection<StageConfig> implements Param
             return true;
         }
 
-        if (token.equals(ENV_VAR_PREFIX)) {
+        if (token.equalsIgnoreCase(ENV_VAR_PREFIX)) {
             addError("labelTemplate", "Missing environment variable name.");
             return false;
         }
 
-        if (token.startsWith(ENV_VAR_PREFIX)) {
+        if (token.toLowerCase().startsWith(ENV_VAR_PREFIX)) {
             return true;
         }
 

--- a/config/config-api/src/test/java/com/thoughtworks/go/config/PipelineConfigValidationTest.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/config/PipelineConfigValidationTest.java
@@ -74,14 +74,14 @@ public class PipelineConfigValidationTest {
     }
 
     @Test
-    public void rejectsMissingMaterial() {
+    public void rejectsLabelTemplateWithMissingMaterial() {
         assertLabelTemplate("foo-${[:5]}-bar", errors -> {
             assertEquals(singletonList("You have defined a label template in pipeline 'go' that refers to a material called '', but no material with this name is defined."), errors);
         });
     }
 
     @Test
-    public void rejectsBadTruncation() {
+    public void rejectsLabelTemplateWithBadTruncation() {
         assertLabelTemplate("foo-${material[:5}-bar", errors -> {
             assertEquals(1, errors.size());
             assertThat(errors.get(0), startsWith("Invalid label"));
@@ -89,15 +89,24 @@ public class PipelineConfigValidationTest {
     }
 
     @Test
-    public void rejectsBlankToken() {
+    public void rejectsLabelTemplateWithBlankToken() {
         assertLabelTemplate("foo-${}-bar", errors ->
                 assertEquals(singletonList("Label template variable cannot be blank."), errors));
     }
 
     @Test
-    public void rejectsMissingEnvironmentVariable() {
+    public void rejectsLabelTemplateWithMissingEnvironmentVariable() {
         assertLabelTemplate("foo-${env:}-bar", errors ->
                 assertEquals(singletonList("Missing environment variable name."), errors));
+
+        assertLabelTemplate("foo-${ENV:}-bar", errors ->
+                assertEquals(singletonList("Missing environment variable name."), errors));
+    }
+
+    @Test
+    public void acceptsLabelTemplateWithEnvironmentVariables() {
+        assertLabelTemplate("release-${ENV:TEST}-${COUNT}", Assert::assertNull);
+        assertLabelTemplate("release-${env:TeSt}-${COUNT}", Assert::assertNull);
     }
 
     @Test


### PR DESCRIPTION
Validation should allow `env:`, `ENV:`,`eNv:`, etc.