### PR TITLE
Remove unsupported gocd.environments.show.pipelines flag from server build.gradle

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -214,7 +214,6 @@ project.ext.jrubyexec = { Closure<JavaExecSpec> cl ->
 
 def props = [
   'go.enforce.server.immutability'  : 'N',
-  'gocd.environments.show.pipelines': 'Y',
   'rails.use.compressed.js'         : 'false',
   'go.database.provider'            : 'com.thoughtworks.go.server.database.H2Database',
   'db.host'                         : 'localhost',


### PR DESCRIPTION
* Some parts left removing as part of https://github.com/gocd/gocd/commit/ea8bee89641992db159629f71d194a011fc6dcf0