### PR TITLE
Fix rspec failures pipeline config v5

### DIFF
--- a/server/webapp/WEB-INF/rails/app/controllers/api_v1/admin/internal/material_test_controller.rb
+++ b/server/webapp/WEB-INF/rails/app/controllers/api_v1/admin/internal/material_test_controller.rb
@@ -25,10 +25,10 @@ module ApiV1
         before_action :check_admin_user_or_group_admin_user_and_403
 
         def test
-          material_config = ApiV5::Admin::Pipelines::Materials::MaterialRepresenter.new(ApiV5::Admin::Pipelines::Materials::MaterialRepresenter.get_material_type(params[:type]).new).from_hash(params)
+          material_config = ApiV1::Admin::Pipelines::Materials::MaterialRepresenter.new(ApiV1::Admin::Pipelines::Materials::MaterialRepresenter.get_material_type(params[:type]).new).from_hash(params)
           material_config.validateConcreteScmMaterial()
           if material_config.errors.any?
-            json = ApiV5::Admin::Pipelines::Materials::MaterialRepresenter.new(material_config).to_hash(url_builder: self)
+            json = ApiV1::Admin::Pipelines::Materials::MaterialRepresenter.new(material_config).to_hash(url_builder: self)
             return render_message('There was an error with the material configuration!', 422, {data: json})
           end
 

--- a/server/webapp/WEB-INF/rails/app/presenters/api_v1/admin/merged_environments/pipeline_config_summary_representer.rb
+++ b/server/webapp/WEB-INF/rails/app/presenters/api_v1/admin/merged_environments/pipeline_config_summary_representer.rb
@@ -26,7 +26,7 @@ module ApiV1
         end
 
         link :self do |opts|
-          opts[:url_builder].apiv5_admin_pipeline_url(@pipeline.getName())
+          "#{opts[:url_builder].default_url_options[:protocol]}://#{opts[:url_builder].default_url_options[:host]}/api/admin/pipelines/#{@pipeline.getName()}"
         end
 
         link :doc do |opts|
@@ -34,7 +34,7 @@ module ApiV1
         end
 
         link :find do |opts|
-          opts[:url_builder].apiv5_admin_pipeline_url(pipeline_name: '__pipeline_name__').gsub(/__pipeline_name__/, ':pipeline_name')
+          "#{opts[:url_builder].default_url_options[:protocol]}://#{opts[:url_builder].default_url_options[:host]}/api/admin/pipelines/:pipeline_name"
         end
 
         property :name,

--- a/server/webapp/WEB-INF/rails/app/presenters/api_v1/admin/merged_environments/pipeline_config_summary_representer.rb
+++ b/server/webapp/WEB-INF/rails/app/presenters/api_v1/admin/merged_environments/pipeline_config_summary_representer.rb
@@ -26,7 +26,9 @@ module ApiV1
         end
 
         link :self do |opts|
-          "#{opts[:url_builder].default_url_options[:protocol]}://#{opts[:url_builder].default_url_options[:host]}/api/admin/pipelines/#{@pipeline.getName()}"
+          req = opts[:url_builder].request
+          ctx = com.thoughtworks.go.spark.RequestContext.new(req.ssl? ? 'https' : 'http', req.host, req.port, '/go')
+          ctx.urlFor(com.thoughtworks.go.spark.Routes::PipelineConfig.name(@pipeline.name.toString))
         end
 
         link :doc do |opts|
@@ -34,7 +36,9 @@ module ApiV1
         end
 
         link :find do |opts|
-          "#{opts[:url_builder].default_url_options[:protocol]}://#{opts[:url_builder].default_url_options[:host]}/api/admin/pipelines/:pipeline_name"
+          req = opts[:url_builder].request
+          ctx = com.thoughtworks.go.spark.RequestContext.new(req.ssl? ? 'https' : 'http', req.host, req.port, '/go')
+          ctx.urlFor(com.thoughtworks.go.spark.Routes::PipelineConfig.find)
         end
 
         property :name,

--- a/server/webapp/WEB-INF/rails/app/presenters/api_v1/admin/pipelines/materials/dependency_material_representer.rb
+++ b/server/webapp/WEB-INF/rails/app/presenters/api_v1/admin/pipelines/materials/dependency_material_representer.rb
@@ -1,0 +1,32 @@
+##########################################################################
+# Copyright 2017 ThoughtWorks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+
+module ApiV1
+  module Admin
+    module Pipelines
+      module Materials
+        class DependencyMaterialRepresenter < BaseRepresenter
+          alias_method :material_config, :represented
+
+          property :pipeline_name, as: :pipeline, case_insensitive_string: true
+          property :stage_name, as: :stage, case_insensitive_string: true
+          property :name, case_insensitive_string: true
+          property :auto_update
+        end
+      end
+    end
+  end
+end

--- a/server/webapp/WEB-INF/rails/app/presenters/api_v1/admin/pipelines/materials/encrypted_password_support.rb
+++ b/server/webapp/WEB-INF/rails/app/presenters/api_v1/admin/pipelines/materials/encrypted_password_support.rb
@@ -1,0 +1,33 @@
+##########################################################################
+# Copyright 2017 ThoughtWorks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+
+module ApiV1
+  module Admin
+    module Pipelines
+      module Materials
+        module EncryptedPasswordSupport
+          def from_hash(data, options={})
+            super
+            data = data.with_indifferent_access
+            encrypted_password = Services.password_deserializer.deserialize(data[:password], data[:encrypted_password], represented)
+            represented.setEncryptedPassword(encrypted_password)
+            represented
+          end
+        end
+      end
+    end
+  end
+end

--- a/server/webapp/WEB-INF/rails/app/presenters/api_v1/admin/pipelines/materials/filter_representer.rb
+++ b/server/webapp/WEB-INF/rails/app/presenters/api_v1/admin/pipelines/materials/filter_representer.rb
@@ -1,0 +1,39 @@
+##########################################################################
+# Copyright 2017 ThoughtWorks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+
+module ApiV1
+  module Admin
+    module Pipelines
+      module Materials
+        class FilterRepresenter < BaseRepresenter
+          alias_method :filter, :represented
+
+          collection :ignore, exec_context: :decorator
+
+          def to_hash(*options)
+            ignored_files=filter.map { |item| item.getPattern() }
+            {ignore: ignored_files} if !ignored_files.empty?
+          end
+
+          def ignore=(value)
+            filter.clear()
+            value.each { |pattern| filter.add(IgnoredFiles.new(pattern)) }
+          end
+        end
+      end
+    end
+  end
+end

--- a/server/webapp/WEB-INF/rails/app/presenters/api_v1/admin/pipelines/materials/git_material_representer.rb
+++ b/server/webapp/WEB-INF/rails/app/presenters/api_v1/admin/pipelines/materials/git_material_representer.rb
@@ -1,0 +1,36 @@
+##########################################################################
+# Copyright 2017 ThoughtWorks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+
+module ApiV1
+  module Admin
+    module Pipelines
+      module Materials
+        class GitMaterialRepresenter < ScmMaterialRepresenter
+          property :branch,
+                   getter: lambda { |args|
+                     branch = self.getBranch
+                     branch.blank? ? 'master' : branch
+                   },
+                   setter: lambda { |value, options|
+                     value.blank? ? self.setBranch('master') : self.setBranch(value)
+                   }
+          property :submodule_folder
+          property :shallow_clone
+        end
+      end
+    end
+  end
+end

--- a/server/webapp/WEB-INF/rails/app/presenters/api_v1/admin/pipelines/materials/hg_material_representer.rb
+++ b/server/webapp/WEB-INF/rails/app/presenters/api_v1/admin/pipelines/materials/hg_material_representer.rb
@@ -1,0 +1,26 @@
+##########################################################################
+# Copyright 2017 ThoughtWorks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+
+module ApiV1
+  module Admin
+    module Pipelines
+      module Materials
+        class HgMaterialRepresenter < ScmMaterialRepresenter
+        end
+      end
+    end
+  end
+end

--- a/server/webapp/WEB-INF/rails/app/presenters/api_v1/admin/pipelines/materials/material_representer.rb
+++ b/server/webapp/WEB-INF/rails/app/presenters/api_v1/admin/pipelines/materials/material_representer.rb
@@ -1,0 +1,81 @@
+##########################################################################
+# Copyright 2017 ThoughtWorks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+
+module ApiV1
+  module Admin
+    module Pipelines
+      module Materials
+        class MaterialRepresenter < BaseRepresenter
+          TYPE_TO_MATERIAL_MAP = {
+            'git' => GitMaterialConfig,
+            'svn' => SvnMaterialConfig,
+            'hg' => HgMaterialConfig,
+            'p4' => P4MaterialConfig,
+            'tfs' => TfsMaterialConfig,
+            'dependency' => DependencyMaterialConfig,
+            'package' => PackageMaterialConfig,
+            'plugin' => PluggableSCMMaterialConfig
+          }
+
+          MATERIAL_TO_TYPE_MAP = TYPE_TO_MATERIAL_MAP.invert
+
+          MATERIAL_TYPE_TO_REPRESENTER_MAP = {
+            GitMaterialConfig => GitMaterialRepresenter,
+            SvnMaterialConfig => SvnMaterialRepresenter,
+            HgMaterialConfig => HgMaterialRepresenter,
+            P4MaterialConfig => PerforceMaterialRepresenter,
+            TfsMaterialConfig => TfsMaterialRepresenter,
+            DependencyMaterialConfig => DependencyMaterialRepresenter,
+            PackageMaterialConfig => PackageMaterialRepresenter,
+            PluggableSCMMaterialConfig => PluggableScmMaterialRepresenter
+          }
+          alias_method :material_config, :represented
+
+          error_representer({
+                              "materialName" => "name",
+                              "folder" => "destination",
+                              "autoUpdate" => "auto_update",
+                              "filterAsString" => "filter",
+                              "checkexternals" => "check_externals",
+                              "serverAndPort" => "port",
+                              "useTickets" => "use_tickets",
+                              "pipelineName" => "pipeline",
+                              "stageName" => "stage",
+                              "pipelineStageName" => "pipeline",
+                              "packageId" => "ref",
+                              "scmId" => "ref",
+                              "password" => "password",
+                              "encryptedPassword" => "encrypted_password",
+                            }
+          )
+
+          property :type, getter: lambda { |options| MATERIAL_TO_TYPE_MAP[self.class] }, skip_parse: true
+
+          nested :attributes,
+                 decorator: lambda { |material_config, *|
+                   MATERIAL_TYPE_TO_REPRESENTER_MAP[material_config.class]
+                 }
+
+          class << self
+            def get_material_type(type)
+              TYPE_TO_MATERIAL_MAP[type] or (raise UnprocessableEntity, "Invalid material type '#{type}'. It has to be one of '#{TYPE_TO_MATERIAL_MAP.keys.join(' ')}'")
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/server/webapp/WEB-INF/rails/app/presenters/api_v1/admin/pipelines/materials/package_material_representer.rb
+++ b/server/webapp/WEB-INF/rails/app/presenters/api_v1/admin/pipelines/materials/package_material_representer.rb
@@ -1,0 +1,33 @@
+##########################################################################
+# Copyright 2017 ThoughtWorks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+
+module ApiV1
+  module Admin
+    module Pipelines
+      module Materials
+        class PackageMaterialRepresenter < BaseRepresenter
+          alias_method :material_config, :represented
+
+          property :packageId, as: :ref, setter: lambda { |value, options|
+            package_definition = options[:go_config].getPackageRepositories().findPackageDefinitionWith(value)
+            self.setPackageDefinition(package_definition)
+            self.setPackageId(value)
+          }
+        end
+      end
+    end
+  end
+end

--- a/server/webapp/WEB-INF/rails/app/presenters/api_v1/admin/pipelines/materials/perforce_material_representer.rb
+++ b/server/webapp/WEB-INF/rails/app/presenters/api_v1/admin/pipelines/materials/perforce_material_representer.rb
@@ -1,0 +1,39 @@
+##########################################################################
+# Copyright 2017 ThoughtWorks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+
+module ApiV1
+  module Admin
+    module Pipelines
+      module Materials
+        class PerforceMaterialRepresenter < ScmMaterialRepresenter
+          include EncryptedPasswordSupport
+
+          property :url, skip_render: true, skip_parse: true #This is done so as to avoid setting the url property of super class ScmMaterialConfig
+          property :server_and_port, as: :port
+          property :user_name, as: :username
+          property :password,
+                   skip_render: true,
+                   skip_nil: true,
+                   skip_parse: true
+
+          property :encrypted_password, skip_nil: true, skip_parse: true
+          property :use_tickets
+          property :view
+        end
+      end
+    end
+  end
+end

--- a/server/webapp/WEB-INF/rails/app/presenters/api_v1/admin/pipelines/materials/pluggable_scm_material_representer.rb
+++ b/server/webapp/WEB-INF/rails/app/presenters/api_v1/admin/pipelines/materials/pluggable_scm_material_representer.rb
@@ -1,0 +1,39 @@
+##########################################################################
+# Copyright 2017 ThoughtWorks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+
+module ApiV1
+  module Admin
+    module Pipelines
+      module Materials
+        class PluggableScmMaterialRepresenter < BaseRepresenter
+          alias_method :material_config, :represented
+
+          property :scmId, as: :ref, setter: lambda { |value, options|
+            scm = options[:go_config].getSCMs().find(value)
+            self.setSCMConfig(scm)
+            self.setScmId(value)
+          }
+
+          property :filter,
+                   decorator: FilterRepresenter,
+                   class: com.thoughtworks.go.config.materials.Filter,
+                   skip_parse: SkipParseOnBlank
+          property :folder, as: :destination, skip_parse: SkipParseOnBlank
+        end
+      end
+    end
+  end
+end

--- a/server/webapp/WEB-INF/rails/app/presenters/api_v1/admin/pipelines/materials/scm_material_representer.rb
+++ b/server/webapp/WEB-INF/rails/app/presenters/api_v1/admin/pipelines/materials/scm_material_representer.rb
@@ -1,0 +1,39 @@
+##########################################################################
+# Copyright 2017 ThoughtWorks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+
+module ApiV1
+  module Admin
+    module Pipelines
+      module Materials
+        class ScmMaterialRepresenter < BaseRepresenter
+          alias_method :material_config, :represented
+
+          property :url
+          property :folder, as: :destination, skip_parse: SkipParseOnBlank
+          property :filter,
+                   decorator: FilterRepresenter,
+                   class: com.thoughtworks.go.config.materials.Filter,
+                   skip_parse: SkipParseOnBlank
+          property :invert_filter,
+                   skip_parse: SkipParseOnBlank
+          property :name, case_insensitive_string: true, skip_parse: SkipParseOnBlank
+          property :auto_update
+
+        end
+      end
+    end
+  end
+end

--- a/server/webapp/WEB-INF/rails/app/presenters/api_v1/admin/pipelines/materials/svn_material_representer.rb
+++ b/server/webapp/WEB-INF/rails/app/presenters/api_v1/admin/pipelines/materials/svn_material_representer.rb
@@ -1,0 +1,38 @@
+##########################################################################
+# Copyright 2017 ThoughtWorks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+
+module ApiV1
+  module Admin
+    module Pipelines
+      module Materials
+        class SvnMaterialRepresenter < ScmMaterialRepresenter
+          include EncryptedPasswordSupport
+
+          property :check_externals
+          property :user_name, as: :username
+          property :password,
+                   skip_render: true,
+                   skip_nil: true,
+                   skip_parse: true
+
+          property :encrypted_password, skip_nil: true, skip_parse: true
+
+        end
+
+      end
+    end
+  end
+end

--- a/server/webapp/WEB-INF/rails/app/presenters/api_v1/admin/pipelines/materials/tfs_material_representer.rb
+++ b/server/webapp/WEB-INF/rails/app/presenters/api_v1/admin/pipelines/materials/tfs_material_representer.rb
@@ -1,0 +1,39 @@
+##########################################################################
+# Copyright 2017 ThoughtWorks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+
+module ApiV1
+  module Admin
+    module Pipelines
+      module Materials
+        class TfsMaterialRepresenter < ScmMaterialRepresenter
+          include EncryptedPasswordSupport
+
+          property :domain
+          property :user_name, as: :username
+          property :password,
+                   skip_render: true,
+                   skip_nil: true,
+                   skip_parse: true
+
+          property :encrypted_password, skip_nil: true, skip_parse: true
+
+          property :project_path
+
+        end
+      end
+    end
+  end
+end

--- a/server/webapp/WEB-INF/rails/app/presenters/api_v1/config/pipeline_config_with_minimal_attributes_representer.rb
+++ b/server/webapp/WEB-INF/rails/app/presenters/api_v1/config/pipeline_config_with_minimal_attributes_representer.rb
@@ -20,7 +20,7 @@ module ApiV1
       alias_method :pipeline, :represented
 
       link :self do |opts|
-        opts[:url_builder].apiv5_admin_pipeline_url(pipeline_name: pipeline.name)
+        "#{opts[:url_builder].default_url_options[:protocol]}://#{opts[:url_builder].default_url_options[:host]}/api/admin/pipelines/#{pipeline.name}"
       end
 
       property   :name, exec_context: :decorator

--- a/server/webapp/WEB-INF/rails/app/presenters/api_v1/config/pipeline_config_with_minimal_attributes_representer.rb
+++ b/server/webapp/WEB-INF/rails/app/presenters/api_v1/config/pipeline_config_with_minimal_attributes_representer.rb
@@ -20,7 +20,9 @@ module ApiV1
       alias_method :pipeline, :represented
 
       link :self do |opts|
-        "#{opts[:url_builder].default_url_options[:protocol]}://#{opts[:url_builder].default_url_options[:host]}/api/admin/pipelines/#{pipeline.name}"
+        req = opts[:url_builder].request
+        ctx = com.thoughtworks.go.spark.RequestContext.new(req.ssl? ? 'https' : 'http', req.host, req.port, '/go')
+        ctx.urlFor(com.thoughtworks.go.spark.Routes::PipelineConfig.name(pipeline.name.toString))
       end
 
       property   :name, exec_context: :decorator

--- a/server/webapp/WEB-INF/rails/app/presenters/api_v2/config/pipeline_config_summary_representer.rb
+++ b/server/webapp/WEB-INF/rails/app/presenters/api_v2/config/pipeline_config_summary_representer.rb
@@ -20,7 +20,9 @@ module ApiV2
       alias_method :pipeline, :represented
 
       link :self do |opts|
-        "#{opts[:url_builder].default_url_options[:protocol]}://#{opts[:url_builder].default_url_options[:host]}/api/admin/pipelines/#{pipeline.getName()}"
+        req = opts[:url_builder].request
+        ctx = com.thoughtworks.go.spark.RequestContext.new(req.ssl? ? 'https' : 'http', req.host, req.port, '/go')
+        ctx.urlFor(com.thoughtworks.go.spark.Routes::PipelineConfig.name(pipeline.name.toString))
       end
 
       link :doc do |opts|
@@ -28,7 +30,9 @@ module ApiV2
       end
 
       link :find do |opts|
-        "#{opts[:url_builder].default_url_options[:protocol]}://#{opts[:url_builder].default_url_options[:host]}/api/admin/pipelines/:pipeline_name"
+        req = opts[:url_builder].request
+        ctx = com.thoughtworks.go.spark.RequestContext.new(req.ssl? ? 'https' : 'http', req.host, req.port, '/go')
+        ctx.urlFor(com.thoughtworks.go.spark.Routes::PipelineConfig.find)
       end
 
       property :name, case_insensitive_string: true

--- a/server/webapp/WEB-INF/rails/app/presenters/api_v2/config/pipeline_config_summary_representer.rb
+++ b/server/webapp/WEB-INF/rails/app/presenters/api_v2/config/pipeline_config_summary_representer.rb
@@ -20,7 +20,7 @@ module ApiV2
       alias_method :pipeline, :represented
 
       link :self do |opts|
-        opts[:url_builder].apiv5_admin_pipeline_url(pipeline.getName())
+        "#{opts[:url_builder].default_url_options[:protocol]}://#{opts[:url_builder].default_url_options[:host]}/api/admin/pipelines/#{pipeline.getName()}"
       end
 
       link :doc do |opts|
@@ -28,7 +28,7 @@ module ApiV2
       end
 
       link :find do |opts|
-        opts[:url_builder].apiv5_admin_pipeline_url(pipeline_name: '__pipeline_name__').gsub(/__pipeline_name__/, ':pipeline_name')
+        "#{opts[:url_builder].default_url_options[:protocol]}://#{opts[:url_builder].default_url_options[:host]}/api/admin/pipelines/:pipeline_name"
       end
 
       property :name, case_insensitive_string: true

--- a/server/webapp/WEB-INF/rails/spec/presenters/api_v1/admin/merged_environments/pipeline_config_summary_representer_spec.rb
+++ b/server/webapp/WEB-INF/rails/spec/presenters/api_v1/admin/merged_environments/pipeline_config_summary_representer_spec.rb
@@ -25,8 +25,8 @@ describe ApiV1::Admin::MergedEnvironments::PipelineConfigSummaryRepresenter do
 
     expect(actual_json).to have_links(:self, :find, :doc)
 
-    expect(actual_json).to have_link(:self).with_url('http://test.host/api/admin/pipelines/pipeline1')
-    expect(actual_json).to have_link(:find).with_url('http://test.host/api/admin/pipelines/:pipeline_name')
+    expect(actual_json).to have_link(:self).with_url('http://test.host/go/api/admin/pipelines/pipeline1')
+    expect(actual_json).to have_link(:find).with_url('http://test.host/go/api/admin/pipelines/:pipeline_name')
     expect(actual_json).to have_link(:doc).with_url('https://api.gocd.org/#pipeline-config')
 
     actual_json.delete(:_links)

--- a/server/webapp/WEB-INF/rails/spec/presenters/api_v1/admin/pipelines/materials/filter_representer_spec.rb
+++ b/server/webapp/WEB-INF/rails/spec/presenters/api_v1/admin/pipelines/materials/filter_representer_spec.rb
@@ -1,0 +1,60 @@
+##########################################################################
+# Copyright 2017 ThoughtWorks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+
+require 'rails_helper'
+
+describe ApiV1::Admin::Pipelines::Materials::FilterRepresenter do
+  it 'should serialize' do
+    filter      = com.thoughtworks.go.config.materials.Filter.new(IgnoredFiles.new('**/*.html'), IgnoredFiles.new('**/foobar/'))
+    presenter   = ApiV1::Admin::Pipelines::Materials::FilterRepresenter.prepare(filter)
+    actual_json = presenter.to_hash(url_builder: UrlBuilder.new)
+    expect(actual_json).to eq(filter_hash)
+  end
+
+  it 'should deserialize' do
+    expected_filter = com.thoughtworks.go.config.materials.Filter.new(IgnoredFiles.new('**/*.html'), IgnoredFiles.new('**/foobar/'))
+    actual_filter   = com.thoughtworks.go.config.materials.Filter.new
+    presenter       = ApiV1::Admin::Pipelines::Materials::FilterRepresenter.prepare(actual_filter)
+    presenter.from_hash(filter_hash)
+    expect(actual_filter).to eq(expected_filter)
+  end
+  it 'should serialize to nil when ignored is empty' do
+    filter      = com.thoughtworks.go.config.materials.Filter.new()
+    presenter   = ApiV1::Admin::Pipelines::Materials::FilterRepresenter.prepare(filter)
+    actual_json = presenter.to_hash(url_builder: UrlBuilder.new)
+    expect(actual_json).to eq(nil)
+  end
+
+  it 'should deserialize to nil when no ignored files' do
+    actual_filter   = com.thoughtworks.go.config.materials.Filter.new
+    presenter       = ApiV1::Admin::Pipelines::Materials::FilterRepresenter.prepare(actual_filter)
+    presenter.from_hash(empty_filter_hash)
+    expect(actual_filter).to eq(com.thoughtworks.go.config.materials.Filter.new)
+  end
+
+  def filter_hash
+    {
+      ignore: %w(**/*.html **/foobar/)
+    }
+  end
+
+  def empty_filter_hash
+    {
+      ignore: []
+    }
+  end
+
+end

--- a/server/webapp/WEB-INF/rails/spec/presenters/api_v1/admin/pipelines/materials/material_representer_spec.rb
+++ b/server/webapp/WEB-INF/rails/spec/presenters/api_v1/admin/pipelines/materials/material_representer_spec.rb
@@ -1,0 +1,649 @@
+##########################################################################
+# Copyright 2017 ThoughtWorks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+
+require 'rails_helper'
+default_branch = 'master'
+describe ApiV1::Admin::Pipelines::Materials::MaterialRepresenter do
+  shared_examples_for 'materials' do
+
+    describe :serialize do
+      it 'should render material with hal representation' do
+        presenter = ApiV1::Admin::Pipelines::Materials::MaterialRepresenter.new(existing_material)
+        actual_json = presenter.to_hash(url_builder: UrlBuilder.new)
+        expected_material_hash = material_hash
+        expect(actual_json).to eq(expected_material_hash)
+      end
+
+      it "should render errors" do
+        presenter = ApiV1::Admin::Pipelines::Materials::MaterialRepresenter.new(existing_material_with_errors)
+        actual_json = presenter.to_hash(url_builder: UrlBuilder.new)
+        expected_material_hash = expected_material_hash_with_errors
+        expect(actual_json).to eq(expected_material_hash)
+      end
+    end
+
+    describe :deserialize do
+      it 'should convert hash to Material' do
+        new_material = material_type.new
+        presenter = ApiV1::Admin::Pipelines::Materials::MaterialRepresenter.new(new_material)
+        presenter.from_hash(ApiV1::Admin::Pipelines::Materials::MaterialRepresenter.new(existing_material).to_hash(url_builder: UrlBuilder.new))
+        expect(new_material.autoUpdate).to eq(existing_material.autoUpdate)
+        expect(new_material.name).to eq(existing_material.name)
+        expect(new_material).to eq(existing_material)
+      end
+    end
+
+  end
+
+  describe :git do
+    it_should_behave_like 'materials'
+
+    def existing_material
+      MaterialConfigsMother.gitMaterialConfig
+    end
+
+    def material_type
+      GitMaterialConfig
+    end
+
+    def existing_material_with_errors
+      git_config = GitMaterialConfig.new(UrlArgument.new(''), '', '', true, nil, false, '', CaseInsensitiveString.new('!nV@l!d'), false)
+      dup_git_material = GitMaterialConfig.new(UrlArgument.new(''), '', '', true, nil, false, '', CaseInsensitiveString.new('!nV@l!d'), false)
+      material_configs = MaterialConfigs.new(git_config);
+      material_configs.add(dup_git_material)
+
+      material_configs.validateTree(PipelineConfigSaveValidationContext.forChain(true, "group", BasicCruiseConfig.new(), PipelineConfig.new()))
+      material_configs.get(0)
+    end
+
+    it "should serialize material without name" do
+      presenter = ApiV1::Admin::Pipelines::Materials::MaterialRepresenter.prepare(GitMaterialConfig.new("http://user:password@funk.com/blank"))
+      actual_json = presenter.to_hash(url_builder: UrlBuilder.new)
+      expect(actual_json).to eq(git_material_basic_hash)
+    end
+
+
+    it "should serialize material with blank branch" do
+      presenter = ApiV1::Admin::Pipelines::Materials::MaterialRepresenter.prepare(GitMaterialConfig.new("http://user:password@funk.com/blank", ""))
+      actual_json = presenter.to_hash(url_builder: UrlBuilder.new)
+      expect(actual_json).to eq(git_material_basic_hash)
+    end
+
+    it "should deserialize material without name" do
+      presenter = ApiV1::Admin::Pipelines::Materials::MaterialRepresenter.new(GitMaterialConfig.new)
+      deserialized_object = presenter.from_hash({
+                                                  type: 'git',
+                                                  attributes: {
+                                                    url: "http://user:password@funk.com/blank",
+                                                    branch: "master",
+                                                    auto_update: true,
+                                                    name: nil
+                                                  }
+                                                })
+      expected = GitMaterialConfig.new("http://user:password@funk.com/blank")
+      expect(deserialized_object.autoUpdate).to eq(expected.autoUpdate)
+      expect(deserialized_object.name.to_s).to eq("")
+      expect(deserialized_object).to eq(expected)
+    end
+
+    it "should deserialize material without invert_filter" do
+      presenter = ApiV1::Admin::Pipelines::Materials::MaterialRepresenter.new(GitMaterialConfig.new)
+      deserialized_object = presenter.from_hash({
+                                                  type: 'git',
+                                                  attributes: {
+                                                    url: "http://user:password@funk.com/blank",
+                                                    branch: "master",
+                                                    auto_update: true,
+                                                    name: nil,
+                                                    invert_filter: nil
+                                                  }
+                                                })
+      expected = GitMaterialConfig.new("http://user:password@funk.com/blank")
+      expect(deserialized_object.invertFilter).to eq(expected.invertFilter)
+      expect(deserialized_object).to eq(expected)
+    end
+
+    it "should deserialize material with invert_filter" do
+      presenter = ApiV1::Admin::Pipelines::Materials::MaterialRepresenter.new(GitMaterialConfig.new)
+      deserialized_object = presenter.from_hash({
+                                                  type: 'git',
+                                                  attributes: {
+                                                    url: "http://user:password@funk.com/blank",
+                                                    branch: "master",
+                                                    auto_update: true,
+                                                    name: nil,
+                                                    invert_filter: true
+                                                  }
+                                                })
+      expected = GitMaterialConfig.new("http://user:password@funk.com/blank")
+      expected.setInvertFilter(true)
+      expect(deserialized_object.invertFilter).to eq(expected.invertFilter)
+      expect(deserialized_object).to eq(expected)
+    end
+
+    it "should deserialize material with blank branch" do
+      presenter = ApiV1::Admin::Pipelines::Materials::MaterialRepresenter.new(GitMaterialConfig.new)
+      deserialized_object = presenter.from_hash({
+                                                  type: 'git',
+                                                  attributes: {
+                                                    url: "http://user:password@funk.com/blank",
+                                                    branch: "",
+                                                    auto_update: true,
+                                                    name: nil
+                                                  }
+                                                })
+      expect(deserialized_object.branch.to_s).to eq(default_branch)
+    end
+
+    def material_hash
+      {
+        type: 'git',
+        attributes: {
+          url: "http://user:password@funk.com/blank",
+          destination: "destination",
+          filter: {
+            ignore: %w(**/*.html **/foobar/)
+          },
+          invert_filter: false,
+          branch: 'branch',
+          submodule_folder: 'sub_module_folder',
+          shallow_clone: true,
+          name: 'AwesomeGitMaterial',
+          auto_update: false
+        }
+      }
+    end
+
+    def git_material_basic_hash
+      {
+        type: 'git',
+        attributes: {
+          url: "http://user:password@funk.com/blank",
+          destination: nil,
+          filter: nil,
+          invert_filter: false,
+          name: nil,
+          auto_update: true,
+          branch: "master",
+          submodule_folder: nil,
+          shallow_clone: false
+        }
+      }
+    end
+
+    def expected_material_hash_with_errors
+      {
+        type: "git",
+        attributes: {
+          url: "",
+          destination: "",
+          filter: nil,
+          invert_filter: false,
+          name: "!nV@l!d",
+          auto_update: true,
+          branch: "master",
+          submodule_folder: "",
+          shallow_clone: false
+        },
+        errors: {
+          name: ["You have defined multiple materials called '!nV@l!d'. Material names are case-insensitive and must be unique. Note that for dependency materials the default materialName is the name of the upstream pipeline. You can override this by setting the materialName explicitly for the upstream pipeline.", "Invalid material name '!nV@l!d'. This must be alphanumeric and can contain underscores and periods (however, it cannot start with a period). The maximum allowed length is 255 characters."],
+          destination: ["Destination directory is required when specifying multiple scm materials"],
+          url: ["URL cannot be blank"]
+        }
+      }
+    end
+
+  end
+
+  describe :svn do
+    it_should_behave_like 'materials'
+
+    def existing_material
+      MaterialConfigsMother.svnMaterialConfig
+    end
+
+    def material_type
+      SvnMaterialConfig
+    end
+
+    def existing_material_with_errors
+      svn_config = SvnMaterialConfig.new(UrlArgument.new(''), '', '', true, GoCipher.new, true, nil, false, '', CaseInsensitiveString.new('!nV@l!d'))
+      material_configs = MaterialConfigs.new(svn_config);
+      material_configs.validateTree(PipelineConfigSaveValidationContext.forChain(true, "group", BasicCruiseConfig.new(), PipelineConfig.new()))
+      material_configs.get(0)
+    end
+
+    def material_hash
+      {
+        type: 'svn',
+        attributes: {
+          url: "url",
+          destination: "svnDir",
+          filter: {
+            ignore: [
+              "*.doc"
+            ]
+          },
+          invert_filter: false,
+          name: "svn-material",
+          auto_update: false,
+          check_externals: true,
+          username: "user",
+          encrypted_password: GoCipher.new.encrypt("pass")
+        }
+      }
+    end
+
+    def expected_material_hash_with_errors
+      {
+        type: "svn",
+        attributes: {
+          url: "",
+          destination: "",
+          filter: nil,
+          invert_filter: false,
+          name: "!nV@l!d",
+          auto_update: true,
+          check_externals: true,
+          username: ""
+        },
+        errors: {
+          name: ["Invalid material name '!nV@l!d'. This must be alphanumeric and can contain underscores and periods (however, it cannot start with a period). The maximum allowed length is 255 characters."],
+          url: ["URL cannot be blank"]
+        }
+      }
+    end
+  end
+
+  describe :hg do
+    it_should_behave_like 'materials'
+
+    def existing_material
+      MaterialConfigsMother.hgMaterialConfigFull
+    end
+
+    def material_type
+      HgMaterialConfig
+    end
+
+    def existing_material_with_errors
+      hg_config = HgMaterialConfig.new(com.thoughtworks.go.util.command::HgUrlArgument.new(''), true, nil, false, '/dest/', CaseInsensitiveString.new('!nV@l!d'))
+      material_configs = MaterialConfigs.new(hg_config);
+      material_configs.validateTree(PipelineConfigSaveValidationContext.forChain(true, "group", BasicCruiseConfig.new(), PipelineConfig.new()))
+      material_configs.get(0)
+    end
+
+    def material_hash
+      {
+        type: 'hg',
+        attributes: {
+          url: "http://user:pass@domain/path##branch",
+          destination: "dest-folder",
+          filter: {
+            ignore: %w(**/*.html **/foobar/)
+          },
+          invert_filter: false,
+          name: "hg-material",
+          auto_update: true
+        }
+      }
+    end
+
+    def expected_material_hash_with_errors
+      {
+        type: "hg",
+        attributes: {
+          url: "",
+          destination: "/dest/",
+          filter: nil,
+          invert_filter: false,
+          name: "!nV@l!d",
+          auto_update: true
+        },
+        errors: {
+          name: ["Invalid material name '!nV@l!d'. This must be alphanumeric and can contain underscores and periods (however, it cannot start with a period). The maximum allowed length is 255 characters."],
+          destination: ["Dest folder '/dest/' is not valid. It must be a sub-directory of the working folder."],
+          url: ["URL cannot be blank"]
+        }
+      }
+    end
+
+  end
+
+  describe :tfs do
+    it_should_behave_like 'materials'
+
+    def existing_material
+      MaterialConfigsMother.tfsMaterialConfig
+    end
+
+    def material_type
+      TfsMaterialConfig
+    end
+
+    def existing_material_with_errors
+      tfs_config = TfsMaterialConfig.new(GoCipher.new, com.thoughtworks.go.util.command::HgUrlArgument.new(''), '', '', '', '/some-path/')
+      material_configs = MaterialConfigs.new(tfs_config);
+      material_configs.validateTree(PipelineConfigSaveValidationContext.forChain(true, "group", BasicCruiseConfig.new(), PipelineConfig.new()))
+      material_configs.first()
+    end
+
+    def material_hash
+      {
+        type: 'tfs',
+        attributes: {
+          url: "http://10.4.4.101:8080/tfs/Sample",
+          destination: "dest-folder",
+          filter: {
+            ignore: %w(**/*.html **/foobar/)
+          },
+          invert_filter: false,
+          domain: "some_domain",
+          username: "loser",
+          encrypted_password: com.thoughtworks.go.security.GoCipher.new.encrypt("passwd"),
+          project_path: "walk_this_path",
+          name: "tfs-material",
+          auto_update: true
+        }
+      }
+    end
+
+    def expected_material_hash_with_errors
+      {
+        :type => "tfs",
+        :attributes => {
+          url: "",
+          destination: nil,
+          filter: nil,
+          invert_filter: false,
+          name: nil,
+          auto_update: true,
+          domain: "",
+          username: "",
+          project_path: "/some-path/"
+        },
+        errors:
+          {
+            url: ["URL cannot be blank"],
+            username: ["Username cannot be blank"]
+          }
+      }
+    end
+
+  end
+
+  describe :p4 do
+    it_should_behave_like 'materials'
+
+    def existing_material
+      MaterialConfigsMother.p4MaterialConfigFull
+    end
+
+    def material_type
+      P4MaterialConfig
+    end
+
+    def existing_material_with_errors
+      p4_config = P4MaterialConfig.new('', '', '', false, '', GoCipher.new, CaseInsensitiveString.new(''), true, nil, false, '/dest/')
+      material_configs = MaterialConfigs.new(p4_config);
+      material_configs.validateTree(PipelineConfigSaveValidationContext.forChain(true, "group", BasicCruiseConfig.new(), PipelineConfig.new()))
+      material_configs.first()
+    end
+
+    def material_hash
+      {
+        type: 'p4',
+        attributes: {
+          destination: "dest-folder",
+          filter: {
+            ignore: %w(**/*.html **/foobar/)
+          },
+          invert_filter: false,
+          port: "host:9876",
+          username: "user",
+          encrypted_password: GoCipher.new.encrypt("password"),
+          use_tickets: true,
+          view: "view",
+          name: "p4-material",
+          auto_update: true
+        }
+      }
+    end
+
+    def expected_material_hash_with_errors
+      {
+        type: "p4",
+        attributes: {
+          destination: "/dest/",
+          filter: nil,
+          invert_filter: false,
+          name: "",
+          auto_update: true,
+          port: "",
+          username: "",
+          use_tickets: false,
+          view: ""
+        },
+        errors: {
+          view: ["P4 view cannot be empty."],
+          destination: ["Dest folder '/dest/' is not valid. It must be a sub-directory of the working folder."],
+          port: ["P4 port cannot be empty."]
+        }
+      }
+    end
+
+  end
+
+  describe :dependency do
+    it_should_behave_like 'materials'
+
+    def existing_material
+      MaterialConfigsMother.dependencyMaterialConfig
+    end
+
+    def material_type
+      DependencyMaterialConfig
+    end
+
+    def existing_material_with_errors
+      dependency_config = DependencyMaterialConfig.new(CaseInsensitiveString.new(''), CaseInsensitiveString.new(''))
+      material_configs = MaterialConfigs.new(dependency_config);
+      pipeline = PipelineConfig.new(CaseInsensitiveString.new("p"), material_configs)
+      pipeline.setOrigins(com.thoughtworks.go.config.remote.FileConfigOrigin.new)
+      material_configs.validateTree(PipelineConfigSaveValidationContext.forChain(true, "group", BasicCruiseConfig.new(), pipeline))
+      material_configs.first()
+    end
+
+    def material_hash
+      {
+        type: 'dependency',
+        attributes: {
+          pipeline: "pipeline-name",
+          stage: "stage-name",
+          name: "pipeline-name",
+          auto_update: true
+        }
+      }
+    end
+
+    def expected_material_hash_with_errors
+      {
+        type: "dependency",
+        attributes:
+          {
+            pipeline: "",
+            stage: "",
+            name: "",
+            auto_update: true
+          },
+        errors: {
+          pipeline: ["Pipeline with name '' does not exist, it is defined as a dependency for pipeline 'p' (cruise-config.xml)"]
+        }
+      }
+    end
+
+  end
+
+  describe :package do
+    it "should represent a package material" do
+      presenter = ApiV1::Admin::Pipelines::Materials::MaterialRepresenter.prepare(MaterialConfigsMother.packageMaterialConfig())
+      actual_json = presenter.to_hash(url_builder: UrlBuilder.new)
+      expect(actual_json).to eq(package_material_hash)
+    end
+
+    it "should deserialize" do
+      presenter = ApiV1::Admin::Pipelines::Materials::MaterialRepresenter.prepare(PackageMaterialConfig.new)
+      go_config = BasicCruiseConfig.new
+      repo = PackageRepositoryMother.create("repoid")
+      go_config.getPackageRepositories().add(repo)
+
+      deserialized_object = presenter.from_hash(package_material_hash("package-name"), {go_config: go_config})
+      expect(deserialized_object.getPackageId).to eq("package-name")
+      expect(deserialized_object.getPackageDefinition).to eq(repo.findPackage("package-name"))
+    end
+
+    it "should set packageId during deserialisation if matching package definition is not present in config" do
+      presenter = ApiV1::Admin::Pipelines::Materials::MaterialRepresenter.prepare(PackageMaterialConfig.new)
+      go_config = BasicCruiseConfig.new
+
+      deserialized_object = presenter.from_hash(package_material_hash("package-name"), {go_config: go_config})
+      expect(deserialized_object.getPackageId).to eq("package-name")
+      expect(deserialized_object.getPackageDefinition).to eq(nil)
+    end
+
+    it "should render errors" do
+      package_config = PackageMaterialConfig.new(CaseInsensitiveString.new(''), '', nil)
+      material_configs = MaterialConfigs.new(package_config);
+      material_configs.validateTree(PipelineConfigSaveValidationContext.forChain(true, "group", BasicCruiseConfig.new(), PipelineConfig.new()))
+
+      presenter = ApiV1::Admin::Pipelines::Materials::MaterialRepresenter.new(material_configs.first())
+      actual_json = presenter.to_hash(url_builder: UrlBuilder.new)
+      expected_material_hash = expected_material_hash_with_errors
+      expect(actual_json).to eq(expected_material_hash)
+    end
+
+
+    def package_material_hash(package_id = "p-id")
+      {
+        type: 'package',
+        attributes: {
+          ref: package_id
+        }
+      }
+    end
+
+    def expected_material_hash_with_errors
+      {
+        type: "package",
+        attributes: {
+          ref: ""
+        },
+        errors: {
+          ref: ["Please select a repository and package"]
+        }
+      }
+    end
+  end
+
+  describe :pluggable do
+    before :each do
+      @go_config = BasicCruiseConfig.new
+
+    end
+    it "should represent a pluggable scm material" do
+      pluggable_scm_material = MaterialConfigsMother.pluggableSCMMaterialConfig()
+      presenter = ApiV1::Admin::Pipelines::Materials::MaterialRepresenter.prepare(pluggable_scm_material)
+      actual_json = presenter.to_hash(url_builder: UrlBuilder.new)
+      expect(actual_json).to eq(pluggable_scm_material_hash)
+    end
+
+    it "should deserialize" do
+      scm= SCMMother.create("scm-id")
+      @go_config.getSCMs().add(scm)
+
+      presenter = ApiV1::Admin::Pipelines::Materials::MaterialRepresenter.new(PluggableSCMMaterialConfig.new)
+      deserialized_object = presenter.from_hash(pluggable_scm_material_hash, {go_config: @go_config})
+      expect(deserialized_object.getScmId).to eq("scm-id")
+      expect(deserialized_object.getSCMConfig).to eq(scm)
+      expect(deserialized_object.getFolder).to eq("des-folder")
+      expect(deserialized_object.filter.getStringForDisplay).to eq("**/*.html,**/foobar/")
+    end
+
+    it "should set scmId during deserialisation if matching package definition is not present in config" do
+      presenter = ApiV1::Admin::Pipelines::Materials::MaterialRepresenter.new(PluggableSCMMaterialConfig.new)
+
+      deserialized_object = presenter.from_hash(pluggable_scm_material_hash, {go_config: @go_config})
+      expect(deserialized_object.getScmId).to eq("scm-id")
+      expect(deserialized_object.getSCMConfig).to eq(nil)
+    end
+
+    it "should deserialize pluggable scm material with nulls" do
+      presenter = ApiV1::Admin::Pipelines::Materials::MaterialRepresenter.new(PluggableSCMMaterialConfig.new)
+      deserialized_object = presenter.from_hash({
+                                                  type: "plugin",
+                                                  attributes: {
+                                                    ref: "23a28171-3d5a-4912-9f36-d4e1536281b0",
+                                                    filter: nil,
+                                                    destination: nil
+                                                  }
+                                                }, {go_config: @go_config})
+      expect(deserialized_object.name.to_s).to eq("")
+      expect(deserialized_object.getScmId).to eq("23a28171-3d5a-4912-9f36-d4e1536281b0")
+      expect(deserialized_object.getFolder).to be_nil
+      expect(ReflectionUtil::getField(deserialized_object, "filter")).to be_nil
+    end
+
+    it "should render errors" do
+      pluggable_scm_material = PluggableSCMMaterialConfig.new(CaseInsensitiveString.new(''), nil, '/dest', nil)
+      material_configs = MaterialConfigs.new(pluggable_scm_material);
+      material_configs.validateTree(PipelineConfigSaveValidationContext.forChain(true, "group", BasicCruiseConfig.new(), PipelineConfig.new()))
+
+      presenter = ApiV1::Admin::Pipelines::Materials::MaterialRepresenter.new(material_configs.first())
+      actual_json = presenter.to_hash(url_builder: UrlBuilder.new)
+      expected_material_hash = expected_material_hash_with_errors
+      expect(actual_json).to eq(expected_material_hash)
+    end
+
+    def pluggable_scm_material_hash
+      {
+        type: 'plugin',
+        attributes: {
+          ref: "scm-id",
+          filter: {
+            ignore: %w(**/*.html **/foobar/)
+          },
+          destination: 'des-folder'
+        }
+      }
+    end
+
+    def expected_material_hash_with_errors
+      {
+        type: "plugin",
+        attributes: {
+          ref: nil,
+          filter: nil,
+          destination: "/dest"
+        },
+        errors: {
+          destination: ["Dest folder '/dest' is not valid. It must be a sub-directory of the working folder."],
+          ref: ["Please select a SCM"]
+        }
+      }
+    end
+
+  end
+end

--- a/server/webapp/WEB-INF/rails/spec/presenters/api_v1/config/pipeline_config_with_minimal_attributes_representer_spec.rb
+++ b/server/webapp/WEB-INF/rails/spec/presenters/api_v1/config/pipeline_config_with_minimal_attributes_representer_spec.rb
@@ -23,7 +23,7 @@ describe ApiV1::Config::PipelineConfigWithMinimalAttributesRepresenter do
 
       actual_json = ApiV1::Config::PipelineConfigWithMinimalAttributesRepresenter.new(pipeline_config).to_hash(url_builder: UrlBuilder.new)
 
-      expect(actual_json).to have_link(:self).with_url('http://test.host/api/admin/pipelines/regression')
+      expect(actual_json).to have_link(:self).with_url('http://test.host/go/api/admin/pipelines/regression')
       actual_json.delete(:_links)
       expect(actual_json).to eq({name: 'regression', stages: [{:name=>'fetch', :jobs=>['dev']}, {:name=>'run', :jobs=>['dev']}]})
     end

--- a/server/webapp/WEB-INF/rails/spec/presenters/api_v2/config/pipeline_config_summary_representer_spec.rb
+++ b/server/webapp/WEB-INF/rails/spec/presenters/api_v2/config/pipeline_config_summary_representer_spec.rb
@@ -25,8 +25,8 @@ describe ApiV2::Config::PipelineConfigSummaryRepresenter do
 
     expect(actual_json).to have_links(:self, :find, :doc)
 
-    expect(actual_json).to have_link(:self).with_url('http://test.host/api/admin/pipelines/pipeline1')
-    expect(actual_json).to have_link(:find).with_url('http://test.host/api/admin/pipelines/:pipeline_name')
+    expect(actual_json).to have_link(:self).with_url('http://test.host/go/api/admin/pipelines/pipeline1')
+    expect(actual_json).to have_link(:find).with_url('http://test.host/go/api/admin/pipelines/:pipeline_name')
     expect(actual_json).to have_link(:doc).with_url('https://api.gocd.org/#pipeline-config')
 
     actual_json.delete(:_links)


### PR DESCRIPTION
* Replace all the occurrences of apiv5_admin_pipeline_url with spark pipeline config v6 url.
* Do not refer to representers from other modules.