### PR TITLE
Prevent hardcoded color values in sass lint.

### DIFF
--- a/server/webapp/WEB-INF/rails/.webpack-sass-lintrc.json
+++ b/server/webapp/WEB-INF/rails/.webpack-sass-lintrc.json
@@ -61,7 +61,7 @@
       }
     ],
     "no-color-keywords": 2,
-    "no-color-literals": 0,
+    "no-color-literals": 2,
     "no-css-comments": 0,
     "no-duplicate-properties": 2,
     "no-empty-rulesets": 2,

--- a/server/webapp/WEB-INF/rails/webpack/views/components/collapsible_panel/index.scss
+++ b/server/webapp/WEB-INF/rails/webpack/views/components/collapsible_panel/index.scss
@@ -27,7 +27,7 @@ $page-item-padding: 30px;
     background: $page-header-bg;
   }
   &.expanded {
-    box-shadow: 0 0 10px rgba(0, 0, 0, 0.21);
+    box-shadow: 0 0 10px $box-shadow-color;
     .c-collapse_header {
       border-bottom: 1px solid $border-color;
     }

--- a/server/webapp/WEB-INF/rails/webpack/views/components/header_panel/index.scss
+++ b/server/webapp/WEB-INF/rails/webpack/views/components/header_panel/index.scss
@@ -37,7 +37,7 @@ $page-item-padding: 30px;
   padding-left:    $page-item-padding;
   padding-right:   $page-item-padding;
   z-index:         map_get($zindex, 'page-header');
-  box-shadow:      0 0 10px rgba(0, 0, 0, 0.21);
+  box-shadow:      0 0 10px $box-shadow-color;
 }
 
 .title {

--- a/server/webapp/WEB-INF/rails/webpack/views/components/search_box/search_box.scss
+++ b/server/webapp/WEB-INF/rails/webpack/views/components/search_box/search_box.scss
@@ -39,11 +39,11 @@ $border-color: #ccc;
   line-height:        40px;
   padding:            0 10px 0 40px;
   margin:             0;
-  border:             1px solid #d6e0e2;
+  border:             1px solid $border-color;
   -webkit-appearance: none;
   box-shadow:         none;
   border-radius:      3px;
-  background:         #fff;
+  background:         $white-opaque;
 
   &::placeholder {
     font-size: 13px;

--- a/server/webapp/WEB-INF/rails/webpack/views/components/site_header_link/index.scss
+++ b/server/webapp/WEB-INF/rails/webpack/views/components/site_header_link/index.scss
@@ -20,7 +20,7 @@
   transition:      all 0.3s ease-in-out;
   text-decoration: none;
   &:hover {
-    color:      #fff;
+    color:      $white-opaque;
     transition: all 0.3s ease-in-out;
   }
   @media(min-width: $screen-md) {

--- a/server/webapp/WEB-INF/rails/webpack/views/components/site_menu/index.scss
+++ b/server/webapp/WEB-INF/rails/webpack/views/components/site_menu/index.scss
@@ -15,6 +15,8 @@
  */
 @import "../../global/common";
 
+$subnav-link-color: #bbb;
+
 .main-menu {
   display: block;
 }
@@ -89,7 +91,7 @@
   }
   .caret_down_icon {
     @include icon-before($fa-var-caret-down);
-    color:     #a5a5a5;
+    color:     $icon-color;
     font-size: 13px;
     display:   none;
     @media(min-width: $screen-md) {
@@ -123,7 +125,7 @@
     padding:     30px 20px;
     display:     none;
     line-height: normal;
-    box-shadow:  0 3px 10px rgba(0, 0, 0, 0.21);
+    box-shadow:  0 3px 10px $box-shadow-color;
     z-index:     map_get($zindex, submenu);
   }
 }
@@ -152,7 +154,7 @@
 }
 
 .site-sub-nav_link {
-  color:           #bbb;
+  color:           $subnav-link-color;
   text-decoration: none;
   padding:         5px 0;
   display:         inline-block;

--- a/server/webapp/WEB-INF/rails/webpack/views/global/theme.scss
+++ b/server/webapp/WEB-INF/rails/webpack/views/global/theme.scss
@@ -33,4 +33,9 @@ $footer-fg: #647984;
 
 $page-header-bg: #fff;
 
-$icon-color: #a5a5a5
+$icon-color: #a5a5a5;
+
+//rgba values - NEED TO BE RENAMED/REORGANIZED
+$box-shadow-color: rgba(0, 0, 0, 0.21);
+$white-opaque: rgba(255, 255, 255, 1);
+$white-transparent: rgba(255, 255, 255, 0);

--- a/server/webapp/WEB-INF/rails/webpack/views/notifications/system_notifications.scss
+++ b/server/webapp/WEB-INF/rails/webpack/views/notifications/system_notifications.scss
@@ -52,7 +52,7 @@ $icon-background: #e0dede;
   border-radius: 5px;
   box-sizing:    border-box;
   font-size:     13px;
-  box-shadow:    3px 3px 5px 0 rgba(0, 0, 0, 0.2);
+  box-shadow:    3px 3px 5px 0 $box-shadow-color;
   z-index:       map_get($zindex, 'menu');
   @media(max-width: $screen-md-min) {
     width: 100%;
@@ -69,7 +69,7 @@ $icon-background: #e0dede;
       width:               0;
       position:            absolute;
       pointer-events:      none;
-      border:              6px rgba(255, 255, 255, 0);
+      border:              6px $white-transparent;
       border-bottom-color: $line-color;
     }
   }

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/partials/site_header.scss
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/partials/site_header.scss
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 @import "../../global/common";
-@import "../../global/zindex";
-@import "../../global/measures";
 
 .site-header {
   background: $site-header;
@@ -119,10 +117,10 @@ $bar-spacing: 7px;
 .bar {
   position:   relative;
   transform:  translateY($bar-spacing);
-  background: rgba(255, 255, 255, 1);
+  background: $white-opaque;
   transition: all 0ms 300ms;
   &.animate {
-    background: rgba(255, 255, 255, 0);
+    background: $white-transparent;
   }
 }
 
@@ -131,7 +129,7 @@ $bar-spacing: 7px;
   position:   absolute;
   left:       0;
   bottom:     $bar-spacing;
-  background: rgba(255, 255, 255, 1);
+  background: $white-opaque;
   transition: bottom 300ms 300ms cubic-bezier(0.23, 1, 0.32, 1), transform 300ms cubic-bezier(0.23, 1, 0.32, 1);
 }
 
@@ -140,7 +138,7 @@ $bar-spacing: 7px;
   position:   absolute;
   left:       0;
   top:        $bar-spacing;
-  background: rgba(255, 255, 255, 1);
+  background: $white-opaque;
   transition: top 300ms 300ms cubic-bezier(0.23, 1, 0.32, 1), transform 300ms cubic-bezier(0.23, 1, 0.32, 1);
 }
 
@@ -235,7 +233,7 @@ $bar-spacing: 7px;
     top:        40px;
     right:      0;
     background: $sub-navigation-bg;
-    box-shadow: 0 3px 10px rgba(0, 0, 0, 0.21);
+    box-shadow: 0 3px 10px $box-shadow-color;
   }
 }
 


### PR DESCRIPTION
All color values should either be delared in the global theme, or on top of the file in case it is component specific.

Some reorganizing of the variables is needed, but I'm merging this now to avoid conflicts.

/cc: @ketan @naveenbhaskar @GaneshSPatil 