### PR TITLE
Should get stage from identifier of case in which pipeline and stage name is specified.

### DIFF
--- a/server/src/main/java/com/thoughtworks/go/server/cache/CacheKeyGenerator.java
+++ b/server/src/main/java/com/thoughtworks/go/server/cache/CacheKeyGenerator.java
@@ -38,6 +38,12 @@ public class CacheKeyGenerator {
                 return arg;
             }
             throw new IllegalArgumentException("Type " + arg.getClass() + " is not allowed here!");
+        }).map(arg -> {
+            if (arg instanceof CaseInsensitiveString) {
+                return ((CaseInsensitiveString) arg).toLower();
+            } else {
+                return arg;
+            }
         }).collect(Collectors.toList());
 
         allArgs.add(0, clazz.getName());

--- a/server/src/main/java/com/thoughtworks/go/server/dao/StageSqlMapDao.java
+++ b/server/src/main/java/com/thoughtworks/go/server/dao/StageSqlMapDao.java
@@ -357,7 +357,7 @@ public class StageSqlMapDao extends SqlMapClientDaoSupport implements StageDao, 
     }
 
     String cacheKeyForAllStageOfPipeline(String pipelineName, Integer pipelineCounter, String stageName) {
-        return cacheKeyGenerator.generate("allStageOfPipeline", pipelineName, pipelineCounter, stageName);
+        return cacheKeyGenerator.generate("allStageOfPipeline", pipelineName.toLowerCase(), pipelineCounter, stageName.toLowerCase());
     }
 
     public List<Stage> findStageHistoryForChart(String pipelineName, String stageName, int pageSize, int offset) {
@@ -475,7 +475,7 @@ public class StageSqlMapDao extends SqlMapClientDaoSupport implements StageDao, 
     }
 
     String cacheKeyForStageHistories(String pipelineName, String stageName) {
-        return cacheKeyGenerator.generate("stageHistories", pipelineName, stageName);
+        return cacheKeyGenerator.generate("stageHistories", pipelineName.toLowerCase(), stageName.toLowerCase());
     }
 
     String cacheKeyForDetailedStageHistories(String pipelineName, String stageName) {

--- a/server/src/main/java/com/thoughtworks/go/server/dao/StageSqlMapDao.java
+++ b/server/src/main/java/com/thoughtworks/go/server/dao/StageSqlMapDao.java
@@ -357,7 +357,7 @@ public class StageSqlMapDao extends SqlMapClientDaoSupport implements StageDao, 
     }
 
     String cacheKeyForAllStageOfPipeline(String pipelineName, Integer pipelineCounter, String stageName) {
-        return cacheKeyGenerator.generate("allStageOfPipeline", pipelineName.toLowerCase(), pipelineCounter, stageName.toLowerCase());
+        return cacheKeyGenerator.generate("allStageOfPipeline", new CaseInsensitiveString(pipelineName), pipelineCounter, new CaseInsensitiveString(stageName));
     }
 
     public List<Stage> findStageHistoryForChart(String pipelineName, String stageName, int pageSize, int offset) {
@@ -475,7 +475,7 @@ public class StageSqlMapDao extends SqlMapClientDaoSupport implements StageDao, 
     }
 
     String cacheKeyForStageHistories(String pipelineName, String stageName) {
-        return cacheKeyGenerator.generate("stageHistories", pipelineName.toLowerCase(), stageName.toLowerCase());
+        return cacheKeyGenerator.generate("stageHistories", new CaseInsensitiveString(pipelineName), new CaseInsensitiveString(stageName));
     }
 
     String cacheKeyForDetailedStageHistories(String pipelineName, String stageName) {

--- a/server/src/main/resources/com/thoughtworks/go/server/dao/maps/Stage.xml
+++ b/server/src/main/resources/com/thoughtworks/go/server/dao/maps/Stage.xml
@@ -594,7 +594,7 @@
         pipelines.label as pipelineLabel,
         buildstatetransitions.currentState, buildstatetransitions.statechangetime, buildstatetransitions.id as stateId
         FROM stages
-        JOIN pipelines ON pipelines.id = stages.pipelineId AND CAST(pipelines.name as VARCHAR) = #{pipelineName}
+        JOIN pipelines ON pipelines.id = stages.pipelineId AND pipelines.name = #{pipelineName}
         <if test="pipelineLabel != null">AND
             pipelines.label = #{pipelineLabel}
         </if>

--- a/server/src/test-fast/java/com/thoughtworks/go/server/cache/CacheKeyGeneratorTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/cache/CacheKeyGeneratorTest.java
@@ -53,7 +53,8 @@ class CacheKeyGeneratorTest {
     @Test
     void shouldAlwaysReturnInternedString() {
         final String generatedCacheKey = cacheKeyGenerator.generate("foo", "bar", new CaseInsensitiveString("1"), 1L);
-        assertThat(generatedCacheKey == "com.thoughtworks.go.domain.Pipeline.$foo.$bar.$1.$1").isTrue();
+        assertThat(generatedCacheKey == "com.thoughtworks.go.domain.Pipeline.$foo.$bar.$1.$1")
+                .describedAs("Using '==' to check returned key is interned String").isTrue();
     }
 
     @Test
@@ -74,5 +75,11 @@ class CacheKeyGeneratorTest {
         thrown.expectMessage("Type class java.lang.Object is not allowed here!");
 
         cacheKeyGenerator.generate("foo", "bar", new Object(), 1L);
+    }
+
+    @Test
+    void shouldConvertCaseInsensitiveStringToLowerCase() {
+        final String generatedCacheKey = cacheKeyGenerator.generate("Foo", "bAR", new CaseInsensitiveString("FAST"), 1L);
+        assertThat(generatedCacheKey).isEqualTo("com.thoughtworks.go.domain.Pipeline.$Foo.$bAR.$fast.$1");
     }
 }

--- a/server/src/test-fast/java/com/thoughtworks/go/server/dao/StageSqlMapDaoTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/dao/StageSqlMapDaoTest.java
@@ -361,6 +361,15 @@ class StageSqlMapDaoTest {
         }
 
         @Test
+        void shouldGenerateSameCacheKeyEvenIfPipelineAndStageIsInDifferentLetterCase() {
+            Assertions.assertThat(stageSqlMapDao.cacheKeyForStageHistories("foo", "bar_baz"))
+                    .isEqualTo("com.thoughtworks.go.server.dao.StageSqlMapDao.$stageHistories.$foo.$bar_baz");
+
+            Assertions.assertThat(stageSqlMapDao.cacheKeyForStageHistories("FOO", "BAR_baz"))
+                    .isEqualTo("com.thoughtworks.go.server.dao.StageSqlMapDao.$stageHistories.$foo.$bar_baz");
+        }
+
+        @Test
         void shouldGenerateADifferentCacheKeyWhenPartOfPipelineIsInterchangedWithStageName() {
             Assertions.assertThat(stageSqlMapDao.cacheKeyForStageHistories("foo", "bar_baz"))
                     .isNotEqualTo(stageSqlMapDao.cacheKeyForStageHistories("foo_bar", "baz"));
@@ -375,6 +384,15 @@ class StageSqlMapDaoTest {
         @Test
         void shouldGenerateCacheKey() {
             Assertions.assertThat(stageSqlMapDao.cacheKeyForAllStageOfPipeline("foo", 1, "bar"))
+                    .isEqualTo("com.thoughtworks.go.server.dao.StageSqlMapDao.$allStageOfPipeline.$foo.$1.$bar");
+        }
+
+        @Test
+        void shouldGenerateSameCacheKeyEvenIfPipelineAndStageIsInDifferentLetterCase() {
+            Assertions.assertThat(stageSqlMapDao.cacheKeyForAllStageOfPipeline("foo", 1, "bar"))
+                    .isEqualTo("com.thoughtworks.go.server.dao.StageSqlMapDao.$allStageOfPipeline.$foo.$1.$bar");
+
+            Assertions.assertThat(stageSqlMapDao.cacheKeyForAllStageOfPipeline("FOO", 1, "BAR"))
                     .isEqualTo("com.thoughtworks.go.server.dao.StageSqlMapDao.$allStageOfPipeline.$foo.$1.$bar");
         }
 


### PR DESCRIPTION
The `pipelineName` and `stageName` should be treated as case-insensitive strings when used in caching and retrieving data from the DB. 

Following code always looks up pipeline  from db in specified case which can lead to pipeline not found if specified name is in a different case then the one in db.  

https://github.com/gocd/gocd/blob/f0d1a6e6b46f9c342a698b9e9c0fdd8e8d21e47e/server/src/main/resources/com/thoughtworks/go/server/dao/maps/Stage.xml#L597

To fix above issue we removed casting of pipeline name during the query execution
https://github.com/gocd/gocd/pull/5295/files#diff-eee1825c5ee96e91bc228702bffb2ae9R597