### PR TITLE
Suppress css warning for 'delete' classname

### DIFF
--- a/server/webapp/WEB-INF/rails/webpack/views/components/icons/index.scss
+++ b/server/webapp/WEB-INF/rails/webpack/views/components/icons/index.scss
@@ -38,7 +38,9 @@ $global-icon-size: 16px;
   @include icon-before($type: $fa-var-clone);
 }
 
-.delete {
+
+//delete is a keyword, a literal syntax; can't be accessed using styles.delete hence renaming it to remove
+.remove {
   @include icon-before($type: $fa-var-trash);
 }
 

--- a/server/webapp/WEB-INF/rails/webpack/views/components/icons/index.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/components/icons/index.tsx
@@ -59,7 +59,7 @@ export class Clone extends Icon {
 
 export class Delete extends Icon {
   constructor() {
-    super('delete');
+    super('remove');
   }
 }
 


### PR DESCRIPTION
* delete is a keyword in javascript and can't be used on object using styles.delete
* Rename 'delete' class to 'remove'