### PR TITLE
Change `GoConfigRevision` to be backed by `byte[]`

### DIFF
--- a/config/config-api/src/main/java/com/thoughtworks/go/domain/GoConfigRevision.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/domain/GoConfigRevision.java
@@ -28,6 +28,9 @@ import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.apache.commons.lang3.StringUtils.isBlank;
+
 public class GoConfigRevision {
     private static final String DELIMITER_CHAR = "|";
     private static final String DELIMITER = "\\" + DELIMITER_CHAR;
@@ -69,7 +72,8 @@ public class GoConfigRevision {
     private String username;
     private String goVersion;
     private String goEdition;
-    private final String xml;
+    private String xml;
+    private byte[] configXmlBytes;
     private Date time;
     private int schemaVersion;
 	private String commitSHA;
@@ -82,6 +86,11 @@ public class GoConfigRevision {
         this.goEdition = "OpenSource";
         this.time = provider.currentTime();
         this.schemaVersion = GoConstants.CONFIG_SCHEMA_VERSION;
+    }
+
+    public GoConfigRevision(byte[] configXml, String comment) {
+        this((String) null, comment);
+        this.configXmlBytes = configXml;
     }
 
     public GoConfigRevision(String configXml, String comment) {
@@ -101,6 +110,7 @@ public class GoConfigRevision {
 
 
     private GoConfigRevision(String configXml) {
+        this.configXmlBytes = null;
         this.xml = configXml;
     }
 
@@ -109,7 +119,22 @@ public class GoConfigRevision {
     }
 
     public String getContent() {
+        if (isBlank(xml)) {
+            if (ArrayUtils.isEmpty(configXmlBytes)) {
+                xml = "";
+            } else {
+                xml = new String(configXmlBytes, UTF_8);
+            }
+        }
         return xml;
+    }
+
+    public boolean isByteArrayBacked() {
+        return configXmlBytes != null;
+    }
+
+    public byte[] getConfigXmlBytes() {
+        return configXmlBytes;
     }
 
     public String getComment() {

--- a/config/config-api/src/test/java/com/thoughtworks/go/domain/GoConfigRevisionTest.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/domain/GoConfigRevisionTest.java
@@ -21,8 +21,12 @@ import com.thoughtworks.go.util.TimeProvider;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.Arrays;
 import java.util.Date;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.hamcrest.CoreMatchers.hasItems;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
@@ -80,5 +84,21 @@ public class GoConfigRevisionTest {
         GoConfigRevision rev2 = new GoConfigRevision("blah blah", "md5", "loser 2", "2.2.3", new TimeProvider());
 
         assertThat(rev1, is(rev2));
+    }
+
+    @Test
+    public void canAnswerIfRevisionContentIsBackedByByteArrayWhenContentIsString() {
+        GoConfigRevision rev = new GoConfigRevision("blah", "md5", "loser", "2.2.2", new TimeProvider());
+        assertThat(rev.isByteArrayBacked(), is(false));
+        assertThat(rev.getConfigXmlBytes(), is(nullValue()));
+        assertThat(rev.getContent(), is("blah"));
+    }
+
+    @Test
+    public void canAnswerIfRevisionContentIsBackedByByteArrayWhenContentIsAByteArray() {
+        GoConfigRevision rev = new GoConfigRevision("blah".getBytes(UTF_8), String.format("user:los||er|||timestamp:%s|schema_version:%s|go_edition:OpenSource|go_version:100.3.||9.71|||||md5:my-||md5||||", date.getTime(), GoConstants.CONFIG_SCHEMA_VERSION));
+        assertThat(rev.isByteArrayBacked(), is(true));
+        assertThat(Arrays.asList(rev.getConfigXmlBytes()), hasItems("blah".getBytes(UTF_8)));
+        assertThat(rev.getContent(), is("blah"));
     }
 }

--- a/config/config-server/src/main/java/com/thoughtworks/go/service/ConfigRepository.java
+++ b/config/config-server/src/main/java/com/thoughtworks/go/service/ConfigRepository.java
@@ -206,7 +206,7 @@ public class ConfigRepository {
                 LogCommand command = git.log().setMaxCount(pageSize).setSkip(offset);
                 Iterable<RevCommit> revisions = command.call();
                 for (RevCommit revision : revisions) {
-                    GoConfigRevision goConfigRevision = new GoConfigRevision(null, revision.getFullMessage());
+                    GoConfigRevision goConfigRevision = new GoConfigRevision((byte[]) null, revision.getFullMessage());
                     goConfigRevision.setCommitSHA(revision.name());
                     goConfigRevisions.add(goConfigRevision);
                 }
@@ -221,7 +221,7 @@ public class ConfigRepository {
         return new GoConfigRevision(contentFromTree(revision.getTree()), revision.getFullMessage());
     }
 
-    private String contentFromTree(RevTree tree) {
+    private byte[] contentFromTree(RevTree tree) {
         try {
             final ObjectReader reader = gitRepo.newObjectReader();
             CanonicalTreeParser parser = new CanonicalTreeParser();
@@ -240,7 +240,7 @@ public class ConfigRepository {
                 if (path.equals(CRUISE_CONFIG_XML)) {
                     final ObjectId id = parser.getEntryObjectId();
                     final ObjectLoader loader = reader.open(id);
-                    return new String(loader.getBytes());
+                    return loader.getBytes();
                 }
             }
             return null;


### PR DESCRIPTION
`GoConfigRevision` represents a commit in the config repository along
with the contents of the config XML at that revision.

The implementation of `GoConfigRevision` suffers from a performance
issue in that the content of the config XML is currently converted from
a `byte[]` to `String`. This can take a few seconds for larger
configurations. An instance of `GoConfigRevision` is created on every
admin page (for the md5 check), and this conversion is unnecessary when
the content is not really needed. Ideally the content should not be
present in the `GoConfigRevision` and should be loaded only when the
content needs to be rendered. This is probably an optimiation for later.