### PR TITLE
Create a modal component

### DIFF
--- a/server/webapp/WEB-INF/rails/.webpack-sass-lintrc.json
+++ b/server/webapp/WEB-INF/rails/.webpack-sass-lintrc.json
@@ -81,6 +81,17 @@
     "space-after-colon": 2,
     "space-after-comma": 2,
     "url-quotes": 2,
+    "variable-for-property": [
+      2,
+      {
+        "allowed-functions": [
+          "map_get"
+        ],
+        "properties": [
+          "z-index"
+        ]
+      }
+    ],
     "zero-unit": [
       2,
       {

--- a/server/webapp/WEB-INF/rails/webpack/views/components/buttons/index.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/components/buttons/index.tsx
@@ -23,7 +23,8 @@ const classnames = require('classnames/bind').bind(styles);
 
 export interface Attrs {
   small?: boolean,
-  disabled?: boolean
+  disabled?: boolean;
+  onclick?: Function;
 }
 
 class Button extends MithrilComponent<Attrs> {

--- a/server/webapp/WEB-INF/rails/webpack/views/components/modal/index.scss
+++ b/server/webapp/WEB-INF/rails/webpack/views/components/modal/index.scss
@@ -28,7 +28,7 @@ $white: #fff;
   border:        none;
   border-radius: $overlay-border-radius;
   position:      absolute;
-  z-index:       101;
+  z-index:       map_get($zindex, 'modal-overlay');
   top:           25%;
   left:          50%;
   min-width:     $overlay-width;
@@ -40,7 +40,7 @@ $white: #fff;
   }
 
   &:nth-of-type(1) {
-    z-index: 102;
+    z-index: map_get($zindex, 'modal-overlay-nth');
   }
 
   &:nth-of-type(2) {
@@ -126,5 +126,5 @@ $white: #fff;
   left:       0;
   right:      0;
   bottom:     0;
-  z-index:    map_get($zindex, 'modal-overlay');
+  z-index:    map_get($zindex, 'modal-overlay-bg');
 }

--- a/server/webapp/WEB-INF/rails/webpack/views/components/modal/index.scss
+++ b/server/webapp/WEB-INF/rails/webpack/views/components/modal/index.scss
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2018 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@import "../../global/common";
+
+$overlay-bg: rgba(0, 0, 0, 0.8);
+$overlay-header-bg: #33374f;
+$overlay-width: 500px;
+$overlay-height: 300px;
+$overlay-border-color: #ccc;
+$overlay-border-radius: 3px;
+$white: #fff;
+
+.overlay {
+  display:       none;
+  border:        none;
+  border-radius: $overlay-border-radius;
+  position:      absolute;
+  z-index:       101;
+  top:           25%;
+  left:          50%;
+  min-width:     $overlay-width;
+  transform:     translate(-50%, 0);
+  transition:    opacity 0.5s ease-in-out, transform 0.5s ease-in-out;
+
+  &:nth-of-type(1), &:nth-of-type(2) {
+    display: block;
+  }
+
+  &:nth-of-type(1) {
+    z-index: 102;
+  }
+
+  &:nth-of-type(2) {
+    transform: translate(-50%, 80vh);
+    opacity:   0.7;
+
+    .close-icon {
+      display: none;
+    }
+  }
+}
+
+.overlay-header {
+  background:    $overlay-header-bg;
+  padding:       15px 20px;
+  border-radius: $overlay-border-radius $overlay-border-radius 0 0;
+
+  h3 {
+    font-size:     16.5px;
+    margin:        0;
+    color:         $white;
+    font-weight:   500;
+
+    max-width:     calc(100% - 25px);
+    overflow:      hidden;
+    white-space:   nowrap;
+    text-overflow: ellipsis;
+  }
+}
+
+.overlay-close {
+  position:    absolute;
+  right:       20px;
+  top:         15px;
+  background:  transparent;
+  border:      none;
+  color:       $white;
+  font-size:   16px;
+  font-weight: 500;
+  cursor:      pointer;
+}
+
+.close-icon {
+  @include icon-before($type: $fa-var-close);
+}
+
+.overlay-content {
+  background: $white;
+  position:   relative;
+  padding:    20px 30px;
+  min-height: $overlay-height;
+  max-height: 730px;
+  overflow-y: auto;
+
+  &:last-child {
+    border-bottom-left-radius:  $overlay-border-radius;
+    border-bottom-right-radius: $overlay-border-radius;
+  }
+}
+
+.overlay-footer {
+  background:                 $white;
+  display:                    flex;
+  justify-content:            flex-end;
+  padding:                    10px 30px;
+  border-top:                 1px solid $overlay-border-color;
+  border-bottom-left-radius:  $overlay-border-radius;
+  border-bottom-right-radius: $overlay-border-radius;
+
+  .button {
+    margin: 0;
+  }
+}
+
+.fixed {
+  overflow: hidden;
+}
+
+.overlay-bg {
+  background: $overlay-bg;
+  position:   fixed;
+  top:        0;
+  left:       0;
+  right:      0;
+  bottom:     0;
+  z-index:    map_get($zindex, 'modal-overlay');
+}

--- a/server/webapp/WEB-INF/rails/webpack/views/components/modal/index.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/components/modal/index.tsx
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2018 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {MithrilComponent} from "../../../jsx/mithril-component";
+import * as m from 'mithril';
+import * as _ from 'lodash';
+import * as styles from './index.scss';
+import {ModalManager} from "./modal_manager";
+import * as Buttons from "../buttons";
+
+const uuid4 = require('uuid/v4');
+
+export abstract class Modal extends MithrilComponent<any> {
+  public id: string;
+
+  protected constructor() {
+    super();
+    this.id = `modal-${uuid4()}`;
+  }
+
+  abstract title(): string;
+
+  abstract body(): JSX.Element;
+
+  buttons(): JSX.Element[] {
+    return [<Buttons.Primary onclick={this.close.bind(this)}>OK</Buttons.Primary>];
+  }
+
+  render() {
+    ModalManager.render(this);
+  }
+
+  close() {
+    ModalManager.close(this);
+  }
+
+  handleEscapeKey() {
+    $('body').on(`keydown.${this.id}`, (e) => {
+      if (e.key === "Escape") {
+        this.close();
+      }
+    });
+  }
+
+  oninit() {
+    this.handleEscapeKey();
+  }
+
+  onremove() {
+    $('body').off(`keydown.${this.id}`);
+  }
+
+  view() {
+    return <div className={styles.overlay}>
+      <header className={styles.overlayHeader}>
+        <h3>{this.title()}</h3>
+        <button className={styles.overlayClose} onclick={this.close.bind(this)}><i className={styles.closeIcon}/>
+        </button>
+      </header>
+      <div className={styles.overlayContent}>
+        {this.body()}
+      </div>
+      <footer className={styles.overlayFooter}>
+        {_.forEach(_.reverse(this.buttons()), button => {
+          return button;
+        })}
+      </footer>
+    </div>
+  }
+}

--- a/server/webapp/WEB-INF/rails/webpack/views/components/modal/index.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/components/modal/index.tsx
@@ -47,20 +47,18 @@ export abstract class Modal extends MithrilComponent<any> {
     ModalManager.close(this);
   }
 
-  handleEscapeKey() {
-    $('body').on(`keydown.${this.id}`, (e) => {
-      if (e.key === "Escape") {
-        this.close();
-      }
-    });
+  closeOnEscape(e: KeyboardEvent) {
+    if (e.key === "Escape") {
+      this.close();
+    }
   }
 
   oninit() {
-    this.handleEscapeKey();
+    document.body.addEventListener('keydown', this.closeOnEscape.bind(this));
   }
 
   onremove() {
-    $('body').off(`keydown.${this.id}`);
+    document.body.removeEventListener('keydown', this.closeOnEscape.bind(this));
   }
 
   view() {

--- a/server/webapp/WEB-INF/rails/webpack/views/components/modal/modal_manager.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/components/modal/modal_manager.tsx
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2018 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {Modal} from "./index";
+import * as m from 'mithril';
+import * as _ from 'lodash';
+import {MithrilComponent} from "../../../jsx/mithril-component";
+import * as styles from './index.scss';
+
+export namespace ModalManager {
+
+  type ModalEntry = { key: string, value: Modal }
+  let allModals: ModalEntry[] = [];
+
+  //call this function once when the SPA is loaded
+  export function onPageLoad() {
+    const $body = $('body');
+    const $modalParent = $('<div class="component-modal-container"/>').appendTo($body);
+    $modalParent.data('modals', allModals);
+    const ModalDialogs = class extends MithrilComponent<any> {
+      view() {
+        return (
+          <div>
+            {_.map(allModals, (entry) => {
+              return <div class={styles.overlayBg}>{m(entry.value)}</div>
+            })}
+          </div>
+        );
+      }
+    };
+    m.mount($modalParent.get(0), ModalDialogs);
+  }
+
+  export function render(modal: Modal) {
+    allModals.push({key: modal.id, value: modal});
+    $('body').addClass(styles.fixed);
+    m.redraw();
+  }
+
+  export function close(modal: Modal) {
+    _.remove(allModals, (entry) => entry.key === modal.id);
+    $('body').removeClass(styles.fixed);
+    m.redraw();
+  }
+}

--- a/server/webapp/WEB-INF/rails/webpack/views/components/modal/sample/index.scss
+++ b/server/webapp/WEB-INF/rails/webpack/views/components/modal/sample/index.scss
@@ -14,11 +14,6 @@
  * limitations under the License.
  */
 
-// sass-lint:disable indentation
-$zindex: (
-           modal-overlay: 100,
-           site-header: 15,
-           page-header: 5,
-           menu: 11,
-           submenu: 10
-         );
+.inputText {
+  width: 100px;
+}

--- a/server/webapp/WEB-INF/rails/webpack/views/components/modal/sample/index.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/components/modal/sample/index.tsx
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2018 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {Modal} from "../index";
+import * as m from 'mithril';
+import * as styles from './index.scss';
+import * as Buttons from "../../buttons/";
+import {Sample2} from "./sample2";
+
+export class SampleModal extends Modal {
+
+  secondModal: Modal;
+
+  constructor() {
+    super();
+    this.secondModal = new Sample2();
+  }
+
+  validate() {
+    if ($(`.${styles.inputText}`).val() === 'hello') {
+      this.close();
+    } else {
+      alert("Validation failed");
+    }
+  }
+
+  title() {
+    return "This is a sample modal";
+  }
+
+  body() {
+    return <div>
+      <p> This is the modal body </p>
+      <p> Enter 'hello' in the textbox and click 'ok' </p>
+      <input class={styles.inputText} type="text"/>
+      <br/>
+      <div>
+        <Buttons.Secondary onclick={this.secondModal.render.bind(this.secondModal)}>Open another Modal</Buttons.Secondary>
+      </div>
+    </div>;
+  }
+
+  buttons() {
+    return [
+      <Buttons.Primary onclick={this.validate.bind(this)}>OK</Buttons.Primary>,
+      <Buttons.Cancel onclick={this.close.bind(this)}>Cancel</Buttons.Cancel>
+    ];
+  }
+}

--- a/server/webapp/WEB-INF/rails/webpack/views/components/modal/sample/sample2.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/components/modal/sample/sample2.tsx
@@ -14,11 +14,17 @@
  * limitations under the License.
  */
 
-// sass-lint:disable indentation
-$zindex: (
-           modal-overlay: 100,
-           site-header: 15,
-           page-header: 5,
-           menu: 11,
-           submenu: 10
-         );
+import * as m from 'mithril';
+import {Modal} from "../index";
+
+export class Sample2 extends Modal {
+
+  body(): JSX.Element {
+    return <p>Here's another modal</p>;
+  }
+
+  title(): string {
+    return "Second Modal";
+  }
+
+}

--- a/server/webapp/WEB-INF/rails/webpack/views/components/modal/spec/index_spec.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/components/modal/spec/index_spec.tsx
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2018 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as m from 'mithril';
+import {Modal} from "../index";
+import * as Buttons from "../../buttons";
+import * as styles from '../index.scss';
+import {ModalManager} from "../modal_manager";
+import * as simulateEvent from 'simulate-event';
+
+describe('Modal', () => {
+
+  // @ts-ignore
+  let $root:any, root:any;
+
+  beforeEach(() => {
+    // @ts-ignore
+    [$root, root] = window.createDomElementForTest();
+    ModalManager.onPageLoad();
+  });
+
+  afterEach(unmount);
+  // @ts-ignore
+  afterEach(window.destroyDomElementForTest);
+
+  function unmount() {
+    m.mount(root, null);
+    const modalContainer = '.component-modal-container';
+    $(modalContainer).remove();
+    m.redraw();
+  }
+
+  it('should display a modal', () => {
+    const testModal = new (class TestModal extends Modal {
+      constructor() {
+        super();
+      }
+
+      body(): JSX.Element {
+        return m('p', "Hello World!");
+      }
+
+      title(): string {
+        return "Test Modal";
+      }
+
+      buttons(): JSX.Element[] {
+        return [
+          <Buttons.Primary>OK</Buttons.Primary>,
+          <Buttons.Cancel>Cancel</Buttons.Cancel>
+        ];
+      }
+
+    });
+
+    testModal.render();
+    expect($(`.${styles.overlayHeader} h3`)).toContainText('Test Modal');
+    expect($(`.${styles.overlayContent} p`)).toContainText('Hello World!');
+    const buttonsSelector = `.${styles.overlayFooter} button`;
+    expect($(buttonsSelector).length).toBe(2);
+    expect($(buttonsSelector).get(0)).toContainText('Cancel');
+    expect($(buttonsSelector).get(1)).toContainText('OK');
+    expect($('body')).toHaveClass(styles.fixed);
+    testModal.close();
+    expect($('body')).not.toHaveClass(styles.fixed);
+  });
+
+  it('should close modal when escape key is pressed', () => {
+    const testModal = aModal();
+
+    testModal.render();
+
+    const modalSelector = `.${styles.overlayHeader} h3`;
+    expect($(modalSelector)).toBeInDOM();
+    simulateEvent.simulate($(modalSelector).get(0), 'keydown', {key: "Escape", keyCode: 27});
+    expect($(modalSelector)).not.toBeInDOM();
+    testModal.close();
+  });
+
+  it('should render an OK button by default when no buttons are supplied', () => {
+    const testModal = aModal();
+
+    testModal.render();
+    const buttonsSelector = `.${styles.overlayFooter} button`;
+    expect($(buttonsSelector).length).toBe(1);
+    expect($(buttonsSelector).get(0)).toContainText('OK');
+    testModal.close();
+  });
+
+  function aModal() {
+    return new (class TestModal extends Modal {
+      constructor() {
+        super();
+      }
+
+      body(): JSX.Element {
+        return m('p', "Hello World!");
+      }
+
+      title(): string {
+        return "Test Modal";
+      }
+    });
+  }
+
+});

--- a/server/webapp/WEB-INF/rails/webpack/views/components/server_health_summary/server_health_messages_count_widget.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/components/server_health_summary/server_health_messages_count_widget.tsx
@@ -16,29 +16,9 @@
 
 import * as m from 'mithril';
 import {Stream} from 'mithril/stream';
-
 import * as styles from './server_health_messages_count_widget.scss';
-import {MithrilComponent} from "../../../jsx/mithril-component";
-import {
-  ServerHealthMessage,
-  ServerHealthMessages
-} from "../../../models/shared/server_health_messages/server_health_messages";
-
-const Modal         = require('views/shared/new_modal');
-const TimeFormatter = require('helpers/time_formatter');
-const classnames    = require('classnames/bind').bind(styles);
-
-class HealthMessageWidget extends MithrilComponent<ServerHealthMessage> {
-  view(vnode: m.Vnode<ServerHealthMessage>) {
-    return (
-      <li class={classnames(styles.serverHealthStatus, vnode.attrs.level.toLowerCase())}>
-        <span class={styles.message}>{vnode.attrs.message}</span>
-        <span class={styles.timestamp}>{TimeFormatter.format(vnode.attrs.time)}</span>
-        <p class={styles.detail}>{m.trust(vnode.attrs.detail)}</p>
-      </li>
-    );
-  }
-}
+import {ServerHealthMessages} from "../../../models/shared/server_health_messages/server_health_messages";
+import {ServerHealthMessagesModal} from './server_health_messages_modal'
 
 interface Attrs {
   serverHealthMessages: Stream<ServerHealthMessages>
@@ -53,30 +33,7 @@ export class ServerHealthMessagesCountWidget implements m.Component<Attrs, State
   private __tsx_attrs: Attrs<Header, Actions> & m.Lifecycle<Attrs<Header, Actions>, this> & { key?: string | number };
 
   oninit(vnode: m.Vnode<Attrs, State>) {
-    const modal = new Modal({
-      size:    'large',
-      title:   'Error and warning messages',
-      body:    () => (
-        <ul class="server-health-statuses">
-          {
-            vnode.attrs.serverHealthMessages().collect((msg: ServerHealthMessage) => {
-              return <HealthMessageWidget {...msg}/>;
-            })
-          }
-        </ul>
-      ),
-      onclose: () => modal.destroy(),
-      buttons: [
-        {
-          text:    "OK",
-          class:   'close',
-          onclick: () => {
-            modal.destroy();
-          }
-        }
-      ]
-    });
-
+    const modal = new ServerHealthMessagesModal(vnode.attrs.serverHealthMessages);
     vnode.state.openServerHealthMessagesModal = () => {
       modal.render();
     };

--- a/server/webapp/WEB-INF/rails/webpack/views/components/server_health_summary/server_health_messages_modal.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/components/server_health_summary/server_health_messages_modal.tsx
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2018 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as m from 'mithril';
+import {Modal} from "../modal";
+import {
+  ServerHealthMessage,
+  ServerHealthMessages
+} from "../../../models/shared/server_health_messages/server_health_messages";
+import * as styles from "./server_health_messages_count_widget.scss";
+import {Stream} from 'mithril/stream';
+
+const classnames    = require('classnames/bind').bind(styles);
+const TimeFormatter = require('helpers/time_formatter');
+
+export class ServerHealthMessagesModal extends Modal {
+
+  private readonly messages: Stream<ServerHealthMessages>;
+
+  constructor(messages: Stream<ServerHealthMessages>) {
+    super();
+    this.messages = messages;
+  }
+
+  body(): JSX.Element {
+    return <ul className="server-health-statuses">
+      {
+        this.messages().collect((msg: ServerHealthMessage) => {
+            return this.messageView(msg);
+          }
+        )
+      }
+    </ul>;
+  }
+
+  private messageView(message: ServerHealthMessage) {
+    return <li className={classnames(styles.serverHealthStatus, message.level.toLowerCase())}>
+      <span className={styles.message}>{message.message}</span>
+      <span className={styles.timestamp}>{TimeFormatter.format(message.time)}</span>
+      <p className={styles.detail}>{m.trust(message.detail)}</p>
+    </li>
+  }
+
+  title(): string {
+    return "Error and warning messages";
+  }
+
+}

--- a/server/webapp/WEB-INF/rails/webpack/views/global/zindex.scss
+++ b/server/webapp/WEB-INF/rails/webpack/views/global/zindex.scss
@@ -16,7 +16,9 @@
 
 // sass-lint:disable indentation
 $zindex: (
-           modal-overlay: 100,
+           modal-overlay-nth: 102,
+           modal-overlay: 101,
+           modal-overlay-bg: 100,
            site-header: 15,
            page-header: 5,
            menu: 11,

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/kitchen_sink.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/kitchen_sink.tsx
@@ -17,17 +17,20 @@
 import * as m from 'mithril';
 import * as Icons from "../components/icons/index";
 import * as Buttons from "../components/buttons/index";
-import {KeyValuePair} from "../components/key_value_pair/index";
+import {KeyValuePair} from "../components/key_value_pair";
 import {MithrilComponent} from "../../jsx/mithril-component";
-import {CollapsiblePanel} from "../components/collapsible_panel/index";
-import {ButtonGroup} from "../components/icons/index";
+import {CollapsiblePanel} from "../components/collapsible_panel";
+import {ButtonGroup} from "../components/icons";
 import {AlertFlashMessage, InfoFlashMessage, SuccessFlashMessage, WarnFlashMessage} from "../components/flash_message";
 import {SearchBox} from "../components/search_box";
+import {SampleModal} from "../components/modal/sample";
 
 const HeaderPanel = require('views/components/header_panel');
 
 export = class KitchenSink extends MithrilComponent<null> {
+
   view() {
+    const sampleModal = new SampleModal();
     return (
       <div>
         <HeaderPanel title="Kitchen Sink"/>
@@ -44,8 +47,12 @@ export = class KitchenSink extends MithrilComponent<null> {
         </CollapsiblePanel>
         <hr/>
 
+
         <h3>Search Box</h3>
         <SearchBox width={350} attrName="search" model={null} placeholder="Some placeholder"/>
+
+        <h3>Modal</h3>
+        <Buttons.Primary onclick={sampleModal.render.bind(sampleModal)}>Open Modal</Buttons.Primary>
 
         <h3>Icons</h3>
         <ButtonGroup>

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/main.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/main.tsx
@@ -16,6 +16,7 @@
 
 import * as m from 'mithril';
 import {MithrilComponent} from "../../jsx/mithril-component";
+import {ModalManager} from "../components/modal/modal_manager";
 import {Attrs as SiteFooterAttrs, SiteFooter} from "./partials/site_footer";
 import {Attrs as SiteHeaderAttrs, SiteHeader} from "./partials/site_header";
 
@@ -27,6 +28,10 @@ interface Attrs {
 }
 
 export class MainPage extends MithrilComponent<Attrs> {
+  oninit() {
+    ModalManager.onPageLoad();
+  }
+
   view(vnode: m.Vnode<Attrs>) {
     return (
       <div class={styles.page}>


### PR DESCRIPTION
Epic: #5232 

Implementation of Modal component in TypeScript.
- Used the modal for the errors and warnings popup.
- Styles are pending and theme needs to be standardized
- The `SampleModal` and `SampleModal2` classes are used only in kitchensink
- Handling of the `Enter` key isn't implemented yet
- Modals opening other modals have some issues, this can be fixed later.