### PR TITLE
Fix broken data sharing page

### DIFF
--- a/server/webapp/WEB-INF/rails/spec/webpack/models/shared/data_sharing/usage_data_spec.ts
+++ b/server/webapp/WEB-INF/rails/spec/webpack/models/shared/data_sharing/usage_data_spec.ts
@@ -31,8 +31,8 @@ describe('Data Sharing Usage Data', () => {
     }
   } as UsageDataJSON;
 
-  it('should use API version v2', () => {
-    expect(UsageData.API_VERSION).toBe('v2');
+  it('should use API version v3', () => {
+    expect(UsageData.API_VERSION).toBe('v3');
   });
 
   it('should deserialize data sharing usage data from JSON', () => {

--- a/server/webapp/WEB-INF/rails/webpack/models/shared/data_sharing/usage_data.ts
+++ b/server/webapp/WEB-INF/rails/webpack/models/shared/data_sharing/usage_data.ts
@@ -58,7 +58,7 @@ export class UsageData {
     this.represent = () => JSON.stringify(this.message(), null, 4);
   }
 
-  static API_VERSION: string = 'v2';
+  static API_VERSION: string = 'v3';
 
   static fromJSON = function (json: UsageDataJSON) {
     return new UsageData(json);


### PR DESCRIPTION
* Use Data sharing API v3 instead of v2
* The controllerDelegate was renamed to v3 but the mimeType was still pointing to v2,
  mineType was changed as part of [ed9413113bc4801aa42186b30d154e17e3259e8b](https://github.com/gocd/gocd/commit/ed9413113bc4801aa42186b30d154e17e3259e8b) commit.
* Change the frontend API calls to use v3 endpoint.