### PR TITLE
Export Pipeline Config to Repo Config Format

### DIFF
--- a/config/config-api/src/main/java/com/thoughtworks/go/config/materials/Filter.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/materials/Filter.java
@@ -16,6 +16,7 @@
 
 package com.thoughtworks.go.config.materials;
 
+import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
 
@@ -49,6 +50,14 @@ public class Filter extends LinkedHashSet<IgnoredFiles> implements Validatable {
             f.add(new IgnoredFiles(file));
         }
         return f;        
+    }
+
+    public List<String> ignoredFileNames() {
+        List<String> files = new ArrayList<>();
+        for (IgnoredFiles ignoredFile : this) {
+            files.add(ignoredFile.getPattern());
+        }
+        return files;
     }
 
     public String getStringForDisplay() {

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/configrepo/ConfigRepoExtension.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/configrepo/ConfigRepoExtension.java
@@ -21,11 +21,17 @@ import com.thoughtworks.go.plugin.access.PluginRequestHelper;
 import com.thoughtworks.go.plugin.access.common.AbstractExtension;
 import com.thoughtworks.go.plugin.access.common.settings.MessageHandlerForPluginSettingsRequestProcessor1_0;
 import com.thoughtworks.go.plugin.access.common.settings.PluginSettingsJsonMessageHandler1_0;
+import com.thoughtworks.go.plugin.access.common.settings.PluginSettingsJsonMessageHandler2_0;
 import com.thoughtworks.go.plugin.access.configrepo.codec.GsonCodec;
 import com.thoughtworks.go.plugin.access.configrepo.contract.CRConfigurationProperty;
 import com.thoughtworks.go.plugin.access.configrepo.contract.CRParseResult;
 import com.thoughtworks.go.plugin.access.configrepo.contract.CRPipeline;
+import com.thoughtworks.go.plugin.access.configrepo.v1.JsonMessageHandler1_0;
+import com.thoughtworks.go.plugin.access.configrepo.v2.JsonMessageHandler2_0;
+import com.thoughtworks.go.plugin.domain.configrepo.Capabilities;
 import com.thoughtworks.go.plugin.infra.PluginManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -36,10 +42,12 @@ import static java.util.Arrays.asList;
 
 @Component
 public class ConfigRepoExtension extends AbstractExtension implements ConfigRepoExtensionContract {
+    private static final Logger LOGGER = LoggerFactory.getLogger(ConfigRepoExtension.class);
     public static final String REQUEST_PARSE_DIRECTORY = "parse-directory";
     public static final String REQUEST_PIPELINE_EXPORT = "pipeline-export";
+    public static final String REQUEST_CAPABILITIES = "get-capabilities";
 
-    private static final List<String> goSupportedVersions = asList("1.0");
+    private static final List<String> goSupportedVersions = asList("1.0", "2.0");
 
     private Map<String, JsonMessageHandler> messageHandlerMap = new HashMap<>();
 
@@ -49,6 +57,10 @@ public class ConfigRepoExtension extends AbstractExtension implements ConfigRepo
         registerHandler("1.0", new PluginSettingsJsonMessageHandler1_0());
         messageHandlerMap.put("1.0", new JsonMessageHandler1_0(new GsonCodec(), new ConfigRepoMigrator()));
         registerMessageHandlerForPluginSettingsRequestProcessor("1.0", new MessageHandlerForPluginSettingsRequestProcessor1_0());
+
+        registerHandler("2.0", new PluginSettingsJsonMessageHandler2_0());
+        messageHandlerMap.put("2.0", new JsonMessageHandler2_0(new GsonCodec(), new ConfigRepoMigrator()));
+        registerMessageHandlerForPluginSettingsRequestProcessor("2.0", new MessageHandlerForPluginSettingsRequestProcessor1_0());
     }
 
     @Override
@@ -69,6 +81,16 @@ public class ConfigRepoExtension extends AbstractExtension implements ConfigRepo
                 return messageHandlerMap.get(resolvedExtensionVersion).responseMessageForPipelineExport(responseBody);
             }
         });
+    }
+
+    @Override
+    public Capabilities getCapabilities(String pluginId) {
+       return pluginRequestHelper.submitRequest(pluginId, REQUEST_CAPABILITIES, new DefaultPluginInteractionCallback<Capabilities>() {
+           @Override
+           public Capabilities onSuccess(String responseBody, String resolvedExtensionVersion) {
+               return messageHandlerMap.get(resolvedExtensionVersion).getCapabilitiesFromResponse(responseBody);
+           }
+       });
     }
 
     @Override

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/configrepo/ConfigRepoExtension.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/configrepo/ConfigRepoExtension.java
@@ -42,7 +42,6 @@ import static java.util.Arrays.asList;
 
 @Component
 public class ConfigRepoExtension extends AbstractExtension implements ConfigRepoExtensionContract {
-    private static final Logger LOGGER = LoggerFactory.getLogger(ConfigRepoExtension.class);
     public static final String REQUEST_PARSE_DIRECTORY = "parse-directory";
     public static final String REQUEST_PIPELINE_EXPORT = "pipeline-export";
     public static final String REQUEST_CAPABILITIES = "get-capabilities";
@@ -85,6 +84,10 @@ public class ConfigRepoExtension extends AbstractExtension implements ConfigRepo
 
     @Override
     public Capabilities getCapabilities(String pluginId) {
+        String resolvedExtensionVersion = pluginManager.resolveExtensionVersion(pluginId, CONFIG_REPO_EXTENSION, goSupportedVersions);
+        if (resolvedExtensionVersion.equals("1.0")) {
+            return new Capabilities(false);
+        }
        return pluginRequestHelper.submitRequest(pluginId, REQUEST_CAPABILITIES, new DefaultPluginInteractionCallback<Capabilities>() {
            @Override
            public Capabilities onSuccess(String responseBody, String resolvedExtensionVersion) {

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/configrepo/ConfigRepoExtension.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/configrepo/ConfigRepoExtension.java
@@ -45,7 +45,7 @@ public class ConfigRepoExtension extends AbstractExtension implements ConfigRepo
 
     @Autowired
     public ConfigRepoExtension(PluginManager pluginManager) {
-        super(pluginManager, new PluginRequestHelper(pluginManager, goSupportedVersions, CONFIG_REPO_EXTENSION), REQUEST_PIPELINE_EXPORT);
+        super(pluginManager, new PluginRequestHelper(pluginManager, goSupportedVersions, CONFIG_REPO_EXTENSION), CONFIG_REPO_EXTENSION);
         registerHandler("1.0", new PluginSettingsJsonMessageHandler1_0());
         messageHandlerMap.put("1.0", new JsonMessageHandler1_0(new GsonCodec(), new ConfigRepoMigrator()));
         registerMessageHandlerForPluginSettingsRequestProcessor("1.0", new MessageHandlerForPluginSettingsRequestProcessor1_0());

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/configrepo/ConfigRepoExtension.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/configrepo/ConfigRepoExtension.java
@@ -52,7 +52,7 @@ public class ConfigRepoExtension extends AbstractExtension implements ConfigRepo
     }
 
     @Override
-    public String pipelineConfigToRemoteConfig(final String pluginId, final CRPipeline pipeline) {
+    public String pipelineExport(final String pluginId, final CRPipeline pipeline) {
         return pluginRequestHelper.submitRequest(pluginId, REQUEST_PIPELINE_EXPORT, new DefaultPluginInteractionCallback<String>() {
             @Override
             public String requestBody(String resolvedExtensionVersion) {

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/configrepo/ConfigRepoExtension.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/configrepo/ConfigRepoExtension.java
@@ -24,14 +24,12 @@ import com.thoughtworks.go.plugin.access.common.settings.PluginSettingsJsonMessa
 import com.thoughtworks.go.plugin.access.configrepo.codec.GsonCodec;
 import com.thoughtworks.go.plugin.access.configrepo.contract.CRConfigurationProperty;
 import com.thoughtworks.go.plugin.access.configrepo.contract.CRParseResult;
+import com.thoughtworks.go.plugin.access.configrepo.contract.CRPipeline;
 import com.thoughtworks.go.plugin.infra.PluginManager;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import static com.thoughtworks.go.plugin.domain.common.PluginConstants.CONFIG_REPO_EXTENSION;
 import static java.util.Arrays.asList;
@@ -50,6 +48,12 @@ public class ConfigRepoExtension extends AbstractExtension implements ConfigRepo
         registerHandler("1.0", new PluginSettingsJsonMessageHandler1_0());
         messageHandlerMap.put("1.0", new JsonMessageHandler1_0(new GsonCodec(), new ConfigRepoMigrator()));
         registerMessageHandlerForPluginSettingsRequestProcessor("1.0", new MessageHandlerForPluginSettingsRequestProcessor1_0());
+    }
+
+    @Override
+    public String pipelineConfigToRemoteConfig(final String pluginId, final CRPipeline pipelineConfig) {
+        GsonCodec gsonCodec = new GsonCodec();
+        return gsonCodec.getGson().toJson(pipelineConfig);
     }
 
     @Override

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/configrepo/ConfigRepoExtensionContract.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/configrepo/ConfigRepoExtensionContract.java
@@ -28,5 +28,5 @@ import java.util.Collection;
 public interface ConfigRepoExtensionContract {
 
     CRParseResult parseDirectory(String pluginId, final String destinationFolder, final Collection<CRConfigurationProperty> configurations);
-    String pipelineConfigToRemoteConfig(String pluginId, final CRPipeline pipelineConfig);
+    String pipelineExport(String pluginId, final CRPipeline pipelineConfig);
 }

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/configrepo/ConfigRepoExtensionContract.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/configrepo/ConfigRepoExtensionContract.java
@@ -19,6 +19,7 @@ package com.thoughtworks.go.plugin.access.configrepo;
 import com.thoughtworks.go.plugin.access.configrepo.contract.CRConfigurationProperty;
 import com.thoughtworks.go.plugin.access.configrepo.contract.CRParseResult;
 import com.thoughtworks.go.plugin.access.configrepo.contract.CRPipeline;
+import com.thoughtworks.go.plugin.domain.configrepo.Capabilities;
 
 import java.util.Collection;
 
@@ -29,4 +30,5 @@ public interface ConfigRepoExtensionContract {
 
     CRParseResult parseDirectory(String pluginId, final String destinationFolder, final Collection<CRConfigurationProperty> configurations);
     String pipelineExport(String pluginId, final CRPipeline pipelineConfig);
+    Capabilities getCapabilities(String pluginId);
 }

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/configrepo/ConfigRepoExtensionContract.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/configrepo/ConfigRepoExtensionContract.java
@@ -18,6 +18,7 @@ package com.thoughtworks.go.plugin.access.configrepo;
 
 import com.thoughtworks.go.plugin.access.configrepo.contract.CRConfigurationProperty;
 import com.thoughtworks.go.plugin.access.configrepo.contract.CRParseResult;
+import com.thoughtworks.go.plugin.access.configrepo.contract.CRPipeline;
 
 import java.util.Collection;
 
@@ -27,4 +28,5 @@ import java.util.Collection;
 public interface ConfigRepoExtensionContract {
 
     CRParseResult parseDirectory(String pluginId, final String destinationFolder, final Collection<CRConfigurationProperty> configurations);
+    String pipelineConfigToRemoteConfig(String pluginId, final CRPipeline pipelineConfig);
 }

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/configrepo/ConfigRepoMigrator.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/configrepo/ConfigRepoMigrator.java
@@ -25,7 +25,7 @@ import org.slf4j.LoggerFactory;
 import java.util.Map;
 
 public class ConfigRepoMigrator {
-    private static final Logger LOGGER = LoggerFactory.getLogger(JsonMessageHandler1_0.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(ConfigRepoMigrator.class);
 
     public String migrate(String oldJSON, int targetVersion) {
         LOGGER.debug("Migrating to version {}: {}", targetVersion, oldJSON);

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/configrepo/JsonMessageHandler.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/configrepo/JsonMessageHandler.java
@@ -18,6 +18,7 @@ package com.thoughtworks.go.plugin.access.configrepo;
 import com.thoughtworks.go.plugin.access.configrepo.contract.CRConfigurationProperty;
 import com.thoughtworks.go.plugin.access.configrepo.contract.CRParseResult;
 import com.thoughtworks.go.plugin.access.configrepo.contract.CRPipeline;
+import com.thoughtworks.go.plugin.domain.configrepo.Capabilities;
 
 import java.util.Collection;
 
@@ -29,4 +30,6 @@ public interface JsonMessageHandler {
     String requestMessageForPipelineExport(CRPipeline pipeline);
 
     String responseMessageForPipelineExport(String responseBody);
+
+    Capabilities getCapabilitiesFromResponse(String responseBody);
 }

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/configrepo/JsonMessageHandler.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/configrepo/JsonMessageHandler.java
@@ -17,6 +17,7 @@ package com.thoughtworks.go.plugin.access.configrepo;
 
 import com.thoughtworks.go.plugin.access.configrepo.contract.CRConfigurationProperty;
 import com.thoughtworks.go.plugin.access.configrepo.contract.CRParseResult;
+import com.thoughtworks.go.plugin.access.configrepo.contract.CRPipeline;
 
 import java.util.Collection;
 
@@ -24,4 +25,8 @@ public interface JsonMessageHandler {
     String requestMessageForParseDirectory(String destinationFolder, Collection<CRConfigurationProperty> configurations);
 
     CRParseResult responseMessageForParseDirectory(String responseBody);
+
+    String requestMessageForPipelineExport(CRPipeline pipeline);
+
+    String responseMessageForPipelineExport(String responseBody);
 }

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/configrepo/JsonMessageHandler1_0.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/configrepo/JsonMessageHandler1_0.java
@@ -21,8 +21,11 @@ import com.google.gson.GsonBuilder;
 import com.thoughtworks.go.plugin.access.configrepo.codec.GsonCodec;
 import com.thoughtworks.go.plugin.access.configrepo.contract.CRConfigurationProperty;
 import com.thoughtworks.go.plugin.access.configrepo.contract.CRParseResult;
+import com.thoughtworks.go.plugin.access.configrepo.contract.CRPipeline;
 import com.thoughtworks.go.plugin.access.configrepo.messages.ParseDirectoryMessage;
 import com.thoughtworks.go.plugin.access.configrepo.messages.ParseDirectoryResponseMessage;
+import com.thoughtworks.go.plugin.access.configrepo.messages.PipelineExportMessage;
+import com.thoughtworks.go.plugin.access.configrepo.messages.PipelineExportResponseMessage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -39,6 +42,12 @@ public class JsonMessageHandler1_0 implements JsonMessageHandler {
     public JsonMessageHandler1_0(GsonCodec gsonCodec, ConfigRepoMigrator configRepoMigrator) {
         codec = gsonCodec;
         migrator = configRepoMigrator;
+    }
+
+    @Override
+    public String requestMessageForPipelineExport(CRPipeline pipeline) {
+        PipelineExportMessage requestMessage = new PipelineExportMessage(codec.getGson().toJson(pipeline));
+        return codec.getGson().toJson(requestMessage);
     }
 
     @Override
@@ -61,6 +70,12 @@ public class JsonMessageHandler1_0 implements JsonMessageHandler {
 
     private ResponseScratch parseResponseForMigration(String responseBody) {
         return new GsonBuilder().create().fromJson(responseBody, ResponseScratch.class);
+    }
+
+    @Override
+    public String responseMessageForPipelineExport(String responseBody) {
+        PipelineExportResponseMessage response = codec.getGson().fromJson(responseBody, PipelineExportResponseMessage.class);
+       return response.getPipelineJson();
     }
 
     @Override

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/configrepo/contract/CRApproval.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/configrepo/contract/CRApproval.java
@@ -112,4 +112,8 @@ public class CRApproval extends CRBase {
         String myLocation = getLocation() == null ? parent : getLocation();
         return String.format("%s; Approval",myLocation);
     }
+
+    public void setApprovalCondition(CRApprovalCondition condition) {
+        type = condition;
+    }
 }

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/configrepo/contract/CRJob.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/configrepo/contract/CRJob.java
@@ -210,6 +210,15 @@ public class CRJob extends CRBase {
         this.environment_variables.add(variable);
     }
 
+    public boolean hasEnvironmentVariable(String key) {
+        for (CREnvironmentVariable var: environment_variables) {
+            if (var.getName().equals(key)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     public String getName() {
         return name;
     }

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/configrepo/contract/CRJob.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/configrepo/contract/CRJob.java
@@ -206,6 +206,10 @@ public class CRJob extends CRBase {
         this.environment_variables.add(variable);
     }
 
+    public void addEnvironmentVariable(CREnvironmentVariable variable){
+        this.environment_variables.add(variable);
+    }
+
     public String getName() {
         return name;
     }
@@ -244,6 +248,10 @@ public class CRJob extends CRBase {
 
     public void setArtifacts(Collection<CRArtifact> artifacts) {
         this.artifacts = artifacts;
+    }
+
+    public void addArtifact(CRArtifact artifact) {
+        this.artifacts.add(artifact);
     }
 
     public Collection<CRPropertyGenerator> getArtifactPropertiesGenerators() {

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/configrepo/contract/CRPipeline.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/configrepo/contract/CRPipeline.java
@@ -170,9 +170,17 @@ public class CRPipeline extends CRBase {
         this.stages.add(stage);
     }
 
-    public void addEnvironmentVariable(String key,String value){
+    public void addParameter (CRParameter param) {
+        this.parameters.add(param);
+    }
+
+    public void addEnvironmentVariable(String key,String value) {
         CREnvironmentVariable variable = new CREnvironmentVariable(key);
         variable.setValue(value);
+        this.environment_variables.add(variable);
+    }
+
+    public void addEnvironmentVariable(CREnvironmentVariable variable) {
         this.environment_variables.add(variable);
     }
 
@@ -377,4 +385,11 @@ public class CRPipeline extends CRBase {
         return template != null && !StringUtils.isBlank(template);
     }
 
+    public String getLock_behavior() {
+        return lock_behavior;
+    }
+
+    public void setLock_behavior(String lock_behavior) {
+        this.lock_behavior = lock_behavior;
+    }
 }

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/configrepo/contract/CRPipeline.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/configrepo/contract/CRPipeline.java
@@ -119,6 +119,15 @@ public class CRPipeline extends CRBase {
         this.environment_variables = environmentVariables;
     }
 
+    public boolean hasEnvironmentVariable(String key) {
+        for (CREnvironmentVariable var: environment_variables) {
+            if (var.getName().equals(key)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     public Collection<CRParameter> getParameters() {
         return parameters;
     }

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/configrepo/contract/CRPluggableArtifact.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/configrepo/contract/CRPluggableArtifact.java
@@ -20,6 +20,7 @@ import com.thoughtworks.go.plugin.access.configrepo.ErrorCollection;
 
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.List;
 
 public class CRPluggableArtifact extends CRArtifact {
     private String id;
@@ -31,6 +32,13 @@ public class CRPluggableArtifact extends CRArtifact {
         this.id = id;
         this.store_id = store_id;
         this.configuration = Arrays.asList(configurationProperties);
+    }
+
+    public CRPluggableArtifact(String id, String store_id, List<CRConfigurationProperty> configurationProperties) {
+        super(CRArtifactType.external);
+        this.id = id;
+        this.store_id = store_id;
+        this.configuration = configurationProperties;
     }
 
     public String getId() {

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/configrepo/contract/CRStage.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/configrepo/contract/CRStage.java
@@ -62,6 +62,11 @@ public class CRStage extends CRBase {
         variable.setValue(value);
         this.environment_variables.add(variable);
     }
+
+    public void addEnvironmentVariable(CREnvironmentVariable variable){
+        this.environment_variables.add(variable);
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/configrepo/contract/CRStage.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/configrepo/contract/CRStage.java
@@ -190,6 +190,15 @@ public class CRStage extends CRBase {
         this.environment_variables = environmentVariables;
     }
 
+    public boolean hasEnvironmentVariable(String key) {
+       for (CREnvironmentVariable var: environment_variables) {
+          if (var.getName().equals(key)) {
+              return true;
+          }
+       }
+       return false;
+    }
+
     public Collection<CRJob> getJobs() {
         return jobs;
     }

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/configrepo/contract/material/CRGitMaterial.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/configrepo/contract/material/CRGitMaterial.java
@@ -38,6 +38,14 @@ public class CRGitMaterial extends CRScmMaterial {
         this.branch = branch;
         this.shallow_clone = shallow_clone;
     }
+
+    public CRGitMaterial(String materialName, String folder, boolean autoUpdate,Boolean shallow_clone,String url,String branch,boolean whitelist, List<String> filters) {
+        super(TYPE_NAME, materialName, folder, autoUpdate,whitelist, filters);
+        this.url = url;
+        this.branch = branch;
+        this.shallow_clone = shallow_clone;
+    }
+
     public CRGitMaterial(String name, String folder, boolean autoUpdate,Boolean shallow_clone, List<String> filter,String url,String branch,boolean whitelist) {
         super(name, folder, autoUpdate,whitelist, filter);
         this.url = url;

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/configrepo/contract/material/CRP4Material.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/configrepo/contract/material/CRP4Material.java
@@ -99,6 +99,16 @@ public class CRP4Material extends CRScmMaterial {
         this.view = view;
     }
 
+    public CRP4Material(String materialName, String folder, boolean autoUpdate,String serverAndPort,String view,String userName,String password,
+                        boolean useTickets,boolean whitelist, List<String> filters) {
+        super(TYPE_NAME, materialName, folder, autoUpdate,whitelist, filters);
+        this.port = serverAndPort;
+        this.username = userName;
+        this.password = password;
+        this.use_tickets = useTickets;
+        this.view = view;
+    }
+
     public boolean hasEncryptedPassword()
     {
         return StringUtils.isNotBlank(encrypted_password);

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/configrepo/contract/material/CRSvnMaterial.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/configrepo/contract/material/CRSvnMaterial.java
@@ -46,10 +46,12 @@ public class CRSvnMaterial extends CRScmMaterial {
         type = TYPE_NAME;
     }
 
-    public CRSvnMaterial(String materialName, String folder, boolean autoUpdate,String url,
-                         boolean checkExternals,boolean whitelist,String... filters) {
+    public CRSvnMaterial(String materialName, String folder, boolean autoUpdate,String url,String userName,String password,
+                         boolean checkExternals,boolean whitelist, List<String> filters) {
         super(TYPE_NAME, materialName, folder, autoUpdate,whitelist, filters);
         this.url = url;
+        this.username = userName;
+        this.password = password;
         this.check_externals = checkExternals;
     }
 

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/configrepo/contract/material/CRTfsMaterial.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/configrepo/contract/material/CRTfsMaterial.java
@@ -84,6 +84,18 @@ public class CRTfsMaterial extends CRScmMaterial {
         this.domain = domain;
     }
 
+    public CRTfsMaterial(String materialName, String folder, boolean autoUpdate,String url,String userName,
+                         String password,String encryptedPassword,
+                         String projectPath,String domain,boolean whitelist,List<String> filters) {
+        super(TYPE_NAME, materialName, folder, autoUpdate, whitelist, filters);
+        this.url = url;
+        this.username = userName;
+        this.password = password;
+        this.encrypted_password = encryptedPassword;
+        this.project = projectPath;
+        this.domain = domain;
+    }
+
     @Override
     public String typeName() {
         return TYPE_NAME;

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/configrepo/contract/tasks/CRBuildTask.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/configrepo/contract/tasks/CRBuildTask.java
@@ -60,9 +60,9 @@ public class CRBuildTask extends CRTask {
     {
         return new CRNantTask(NANT_TYPE_NAME,null,null,null,null);
     }
-    public static CRNantTask nant(String nantFile)
+    public static CRNantTask nant(String nantPath)
     {
-        return new CRNantTask(NANT_TYPE_NAME,nantFile,null,null,null);
+        return new CRNantTask(NANT_TYPE_NAME,null,null,null,nantPath);
     }
     public static CRNantTask nant(String nantFile,String target)
     {

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/configrepo/contract/tasks/CRBuildTask.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/configrepo/contract/tasks/CRBuildTask.java
@@ -111,6 +111,18 @@ public class CRBuildTask extends CRTask {
         super.type = type.toString();
     }
 
+    public void setBuild_file(String build_file) {
+        this.build_file = build_file;
+    }
+
+    public void setTarget(String target) {
+        this.target = target;
+    }
+
+    public void setWorking_directory(String working_directory) {
+        this.working_directory = working_directory;
+    }
+
     public String getBuildFile() {
         return build_file;
     }

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/configrepo/contract/tasks/CRFetchPluggableArtifactTask.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/configrepo/contract/tasks/CRFetchPluggableArtifactTask.java
@@ -22,6 +22,7 @@ import com.thoughtworks.go.plugin.access.configrepo.contract.CRConfigurationProp
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.List;
 
 public class CRFetchPluggableArtifactTask extends CRAbstractFetchTask {
     public static final String ARTIFACT_ORIGIN = "external";
@@ -40,6 +41,15 @@ public class CRFetchPluggableArtifactTask extends CRAbstractFetchTask {
         super(stage, job, TYPE_NAME, ArtifactOrigin.external);
         this.artifact_id = artifactId;
         configuration = Arrays.asList(crConfigurationProperties);
+    }
+
+    public CRFetchPluggableArtifactTask(String stage,
+                                        String job,
+                                        String artifactId,
+                                        List<CRConfigurationProperty> crConfigurationProperties) {
+        super(stage, job, TYPE_NAME, ArtifactOrigin.external);
+        this.artifact_id = artifactId;
+        configuration = crConfigurationProperties;
     }
 
     public CRFetchPluggableArtifactTask(CRRunIf runIf, CRTask onCancel,

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/configrepo/contract/tasks/CRPluggableTask.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/configrepo/contract/tasks/CRPluggableTask.java
@@ -23,6 +23,7 @@ import org.apache.commons.collections4.CollectionUtils;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.List;
 
 public class CRPluggableTask extends CRTask {
     public static final java.lang.String TYPE_NAME = "plugin";
@@ -40,6 +41,13 @@ public class CRPluggableTask extends CRTask {
         super(TYPE_NAME);
         this.plugin_configuration = pluginConfiguration;
         this.configuration = Arrays.asList(properties);
+    }
+    public CRPluggableTask(CRPluginConfiguration pluginConfiguration,
+                           List<CRConfigurationProperty> properties)
+    {
+        super(TYPE_NAME);
+        this.plugin_configuration = pluginConfiguration;
+        this.configuration = properties;
     }
     public CRPluggableTask(String id,String version,
                            CRConfigurationProperty... properties)

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/configrepo/contract/tasks/CRTask.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/configrepo/contract/tasks/CRTask.java
@@ -83,4 +83,8 @@ public abstract class CRTask extends CRBase {
     public void setRunIf(CRRunIf runIf) {
         this.run_if = runIf;
     }
+
+    public void setOn_cancel(CRTask on_cancel) {
+        this.on_cancel = on_cancel;
+    }
 }

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/configrepo/messages/PipelineExportMessage.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/configrepo/messages/PipelineExportMessage.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2018 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.plugin.access.configrepo.messages;
+
+public class PipelineExportMessage {
+    private String pipelineJson;
+
+    public PipelineExportMessage(String pipelineJson) {
+        this.pipelineJson = pipelineJson;
+    }
+
+    public String getPipelineJson() {
+        return pipelineJson;
+    }
+
+    public void setPipelineJson(String pipelineJson) {
+        this.pipelineJson = pipelineJson;
+    }
+}

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/configrepo/messages/PipelineExportResponseMessage.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/configrepo/messages/PipelineExportResponseMessage.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2018 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.plugin.access.configrepo.messages;
+
+public class PipelineExportResponseMessage {
+    private String pipelineJson;
+
+    public String getPipelineJson() {
+        return pipelineJson;
+    }
+
+    public void setPipelineJson(String pipelineJson) {
+        this.pipelineJson = pipelineJson;
+    }
+}

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/configrepo/v1/JsonMessageHandler1_0.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/configrepo/v1/JsonMessageHandler1_0.java
@@ -70,7 +70,7 @@ public class JsonMessageHandler1_0 implements JsonMessageHandler {
 
     @Override
     public Capabilities getCapabilitiesFromResponse(String responseBody) {
-        return new Capabilities();
+        return null;
     }
 
     @Override

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/configrepo/v1/JsonMessageHandler1_0.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/configrepo/v1/JsonMessageHandler1_0.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 ThoughtWorks, Inc.
+ * Copyright 2018 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,18 +14,20 @@
  * limitations under the License.
  */
 
-package com.thoughtworks.go.plugin.access.configrepo;
+package com.thoughtworks.go.plugin.access.configrepo.v1;
 
 
 import com.google.gson.GsonBuilder;
+import com.thoughtworks.go.plugin.access.configrepo.ConfigRepoMigrator;
+import com.thoughtworks.go.plugin.access.configrepo.ErrorCollection;
+import com.thoughtworks.go.plugin.access.configrepo.JsonMessageHandler;
 import com.thoughtworks.go.plugin.access.configrepo.codec.GsonCodec;
 import com.thoughtworks.go.plugin.access.configrepo.contract.CRConfigurationProperty;
 import com.thoughtworks.go.plugin.access.configrepo.contract.CRParseResult;
 import com.thoughtworks.go.plugin.access.configrepo.contract.CRPipeline;
-import com.thoughtworks.go.plugin.access.configrepo.messages.ParseDirectoryMessage;
-import com.thoughtworks.go.plugin.access.configrepo.messages.ParseDirectoryResponseMessage;
-import com.thoughtworks.go.plugin.access.configrepo.messages.PipelineExportMessage;
-import com.thoughtworks.go.plugin.access.configrepo.messages.PipelineExportResponseMessage;
+import com.thoughtworks.go.plugin.access.configrepo.v1.messages.ParseDirectoryMessage;
+import com.thoughtworks.go.plugin.access.configrepo.v1.messages.ParseDirectoryResponseMessage;
+import com.thoughtworks.go.plugin.domain.configrepo.Capabilities;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -42,12 +44,6 @@ public class JsonMessageHandler1_0 implements JsonMessageHandler {
     public JsonMessageHandler1_0(GsonCodec gsonCodec, ConfigRepoMigrator configRepoMigrator) {
         codec = gsonCodec;
         migrator = configRepoMigrator;
-    }
-
-    @Override
-    public String requestMessageForPipelineExport(CRPipeline pipeline) {
-        PipelineExportMessage requestMessage = new PipelineExportMessage(codec.getGson().toJson(pipeline));
-        return codec.getGson().toJson(requestMessage);
     }
 
     @Override
@@ -73,9 +69,8 @@ public class JsonMessageHandler1_0 implements JsonMessageHandler {
     }
 
     @Override
-    public String responseMessageForPipelineExport(String responseBody) {
-        PipelineExportResponseMessage response = codec.getGson().fromJson(responseBody, PipelineExportResponseMessage.class);
-       return response.getPipelineJson();
+    public Capabilities getCapabilitiesFromResponse(String responseBody) {
+        return new Capabilities();
     }
 
     @Override
@@ -119,10 +114,21 @@ public class JsonMessageHandler1_0 implements JsonMessageHandler {
         }
     }
 
+    @Override
+    public String requestMessageForPipelineExport(CRPipeline pipeline) {
+        return null;
+    }
+
     private String migrate(String responseBody, int targetVersion) {
         if (targetVersion > CURRENT_CONTRACT_VERSION)
             throw new RuntimeException(String.format("Migration to %s is not supported", targetVersion));
 
         return migrator.migrate(responseBody, targetVersion);
     }
+
+    @Override
+    public String responseMessageForPipelineExport(String responseBody) {
+        return null;
+    }
+
 }

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/configrepo/v1/JsonMessageHandler1_0.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/configrepo/v1/JsonMessageHandler1_0.java
@@ -116,7 +116,7 @@ public class JsonMessageHandler1_0 implements JsonMessageHandler {
 
     @Override
     public String requestMessageForPipelineExport(CRPipeline pipeline) {
-        return null;
+        throw new UnsupportedOperationException("V1 Config Repo plugins don't support pipeline export");
     }
 
     private String migrate(String responseBody, int targetVersion) {
@@ -128,7 +128,7 @@ public class JsonMessageHandler1_0 implements JsonMessageHandler {
 
     @Override
     public String responseMessageForPipelineExport(String responseBody) {
-        return null;
+        throw new UnsupportedOperationException("V1 Config Repo plugins don't support pipeline export");
     }
 
 }

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/configrepo/v1/messages/ParseDirectoryMessage.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/configrepo/v1/messages/ParseDirectoryMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 ThoughtWorks, Inc.
+ * Copyright 2018 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.thoughtworks.go.plugin.access.configrepo.messages;
+package com.thoughtworks.go.plugin.access.configrepo.v1.messages;
 
 import com.thoughtworks.go.plugin.access.configrepo.contract.CRConfigurationProperty;
 

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/configrepo/v1/messages/ParseDirectoryResponseMessage.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/configrepo/v1/messages/ParseDirectoryResponseMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 ThoughtWorks, Inc.
+ * Copyright 2018 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,12 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.thoughtworks.go.plugin.access.configrepo.messages;
+package com.thoughtworks.go.plugin.access.configrepo.v1.messages;
 
+import com.thoughtworks.go.plugin.access.configrepo.ErrorCollection;
 import com.thoughtworks.go.plugin.access.configrepo.contract.CREnvironment;
 import com.thoughtworks.go.plugin.access.configrepo.contract.CRError;
 import com.thoughtworks.go.plugin.access.configrepo.contract.CRPipeline;
-import com.thoughtworks.go.plugin.access.configrepo.ErrorCollection;
 
 import java.util.ArrayList;
 import java.util.Collection;

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/configrepo/v2/JsonMessageHandler2_0.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/configrepo/v2/JsonMessageHandler2_0.java
@@ -53,7 +53,7 @@ public class JsonMessageHandler2_0 implements JsonMessageHandler {
 
     @Override
     public String requestMessageForPipelineExport(CRPipeline pipeline) {
-        PipelineExportMessage requestMessage = new PipelineExportMessage(codec.getGson().toJson(pipeline));
+        PipelineExportMessage requestMessage = new PipelineExportMessage(pipeline);
         return codec.getGson().toJson(requestMessage);
     }
 

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/configrepo/v2/JsonMessageHandler2_0.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/configrepo/v2/JsonMessageHandler2_0.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2018 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.plugin.access.configrepo.v2;
+
+import com.google.gson.GsonBuilder;
+import com.thoughtworks.go.plugin.access.configrepo.ConfigRepoMigrator;
+import com.thoughtworks.go.plugin.access.configrepo.ErrorCollection;
+import com.thoughtworks.go.plugin.access.configrepo.JsonMessageHandler;
+import com.thoughtworks.go.plugin.access.configrepo.codec.GsonCodec;
+import com.thoughtworks.go.plugin.access.configrepo.contract.CRConfigurationProperty;
+import com.thoughtworks.go.plugin.access.configrepo.contract.CRParseResult;
+import com.thoughtworks.go.plugin.access.configrepo.contract.CRPipeline;
+import com.thoughtworks.go.plugin.access.configrepo.v2.messages.ParseDirectoryMessage;
+import com.thoughtworks.go.plugin.access.configrepo.v2.messages.ParseDirectoryResponseMessage;
+import com.thoughtworks.go.plugin.access.configrepo.v2.messages.PipelineExportMessage;
+import com.thoughtworks.go.plugin.access.configrepo.v2.messages.PipelineExportResponseMessage;
+import com.thoughtworks.go.plugin.domain.configrepo.Capabilities;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collection;
+
+public class JsonMessageHandler2_0 implements JsonMessageHandler {
+    private static final Logger LOGGER = LoggerFactory.getLogger(JsonMessageHandler2_0.class);
+    static final int CURRENT_CONTRACT_VERSION = 3;
+
+    private final GsonCodec codec;
+    private final ConfigRepoMigrator migrator;
+
+    public JsonMessageHandler2_0(GsonCodec gsonCodec, ConfigRepoMigrator configRepoMigrator) {
+        codec = gsonCodec;
+        migrator = configRepoMigrator;
+    }
+
+    @Override
+    public Capabilities getCapabilitiesFromResponse(String responseBody) {
+        return codec.getGson().fromJson(responseBody, Capabilities.class);
+    }
+
+    @Override
+    public String requestMessageForPipelineExport(CRPipeline pipeline) {
+        PipelineExportMessage requestMessage = new PipelineExportMessage(codec.getGson().toJson(pipeline));
+        return codec.getGson().toJson(requestMessage);
+    }
+
+    @Override
+    public String requestMessageForParseDirectory(String destinationFolder, Collection<CRConfigurationProperty> configurations) {
+        ParseDirectoryMessage requestMessage = prepareMessage_1(destinationFolder, configurations);
+        return codec.getGson().toJson(requestMessage);
+    }
+
+    private ParseDirectoryMessage prepareMessage_1(String destinationFolder, Collection<CRConfigurationProperty> configurations) {
+        ParseDirectoryMessage requestMessage = new ParseDirectoryMessage(destinationFolder);
+        for (CRConfigurationProperty conf : configurations) {
+            requestMessage.addConfiguration(conf.getKey(), conf.getValue(), conf.getEncryptedValue());
+        }
+        return requestMessage;
+    }
+
+    class ResponseScratch {
+        public Integer target_version;
+    }
+
+    private ResponseScratch parseResponseForMigration(String responseBody) {
+        return new GsonBuilder().create().fromJson(responseBody, ResponseScratch.class);
+    }
+
+    @Override
+    public String responseMessageForPipelineExport(String responseBody) {
+        PipelineExportResponseMessage response = codec.getGson().fromJson(responseBody, PipelineExportResponseMessage.class);
+        return response.getPipelineJson();
+    }
+
+    @Override
+    public CRParseResult responseMessageForParseDirectory(String responseBody) {
+        ErrorCollection errors = new ErrorCollection();
+        try {
+            ResponseScratch responseMap = parseResponseForMigration(responseBody);
+            ParseDirectoryResponseMessage parseDirectoryResponseMessage;
+
+            if (responseMap.target_version == null) {
+                errors.addError("Plugin response message", "missing 'target_version' field");
+                return new CRParseResult(errors);
+            } else if (responseMap.target_version > CURRENT_CONTRACT_VERSION) {
+                String message = String.format("'target_version' is %s but the GoCD Server supports %s",
+                        responseMap.target_version, CURRENT_CONTRACT_VERSION);
+                errors.addError("Plugin response message", message);
+                return new CRParseResult(errors);
+            } else {
+                int version = responseMap.target_version;
+
+                while (version < CURRENT_CONTRACT_VERSION) {
+                    version++;
+                    responseBody = migrate(responseBody, version);
+                }
+                // after migration, json should match contract
+                parseDirectoryResponseMessage = codec.getGson().fromJson(responseBody, ParseDirectoryResponseMessage.class);
+                parseDirectoryResponseMessage.validateResponse(errors);
+
+                errors.addErrors(parseDirectoryResponseMessage.getPluginErrors());
+
+                return new CRParseResult(parseDirectoryResponseMessage.getEnvironments(), parseDirectoryResponseMessage.getPipelines(), errors);
+            }
+        } catch (Exception ex) {
+            StringBuilder builder = new StringBuilder();
+            builder.append("Unexpected error when handling plugin response").append('\n');
+            builder.append(ex);
+            // "location" of error is runtime. This is what user will see in config repo errors list.
+            errors.addError("runtime", builder.toString());
+            LOGGER.error(builder.toString(), ex);
+            return new CRParseResult(errors);
+        }
+    }
+
+    private String migrate(String responseBody, int targetVersion) {
+        if (targetVersion > CURRENT_CONTRACT_VERSION)
+            throw new RuntimeException(String.format("Migration to %s is not supported", targetVersion));
+
+        return migrator.migrate(responseBody, targetVersion);
+    }
+}

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/configrepo/v2/JsonMessageHandler2_0.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/configrepo/v2/JsonMessageHandler2_0.java
@@ -82,7 +82,7 @@ public class JsonMessageHandler2_0 implements JsonMessageHandler {
     @Override
     public String responseMessageForPipelineExport(String responseBody) {
         PipelineExportResponseMessage response = codec.getGson().fromJson(responseBody, PipelineExportResponseMessage.class);
-        return response.getPipelineJson();
+        return response.getPipeline();
     }
 
     @Override

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/configrepo/v2/messages/ParseDirectoryMessage.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/configrepo/v2/messages/ParseDirectoryMessage.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2017 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.plugin.access.configrepo.v2.messages;
+
+import com.thoughtworks.go.plugin.access.configrepo.contract.CRConfigurationProperty;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+public class ParseDirectoryMessage {
+    private String directory;
+    private Collection<CRConfigurationProperty> configurations;
+
+    public ParseDirectoryMessage(String destinationFolder) {
+        this.directory = destinationFolder;
+        this.configurations = new ArrayList<>();
+    }
+    public void addConfiguration(String name,String value,String encryptedValue)
+    {
+        configurations.add(new CRConfigurationProperty(name,value,encryptedValue));
+    }
+
+    public String getDirectory() {
+        return directory;
+    }
+
+    public void setDirectory(String directory) {
+        this.directory = directory;
+    }
+
+    public Collection<CRConfigurationProperty> getConfigurations() {
+        return configurations;
+    }
+
+    public void setConfigurations(Collection<CRConfigurationProperty> configurations) {
+        this.configurations = configurations;
+    }
+}

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/configrepo/v2/messages/ParseDirectoryResponseMessage.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/configrepo/v2/messages/ParseDirectoryResponseMessage.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2017 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.thoughtworks.go.plugin.access.configrepo.v2.messages;
+
+import com.thoughtworks.go.plugin.access.configrepo.contract.CREnvironment;
+import com.thoughtworks.go.plugin.access.configrepo.contract.CRError;
+import com.thoughtworks.go.plugin.access.configrepo.contract.CRPipeline;
+import com.thoughtworks.go.plugin.access.configrepo.ErrorCollection;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+public class ParseDirectoryResponseMessage {
+    private String target_version;
+    private Collection<CREnvironment> environments = new ArrayList<>();
+    private Collection<CRPipeline> pipelines = new ArrayList<>();
+    private List<CRError> errors = new ArrayList<>();
+
+    public boolean hasErrors() {
+        return errors != null && !errors.isEmpty();
+    }
+
+    public String getTargetVersion() {
+        return target_version;
+    }
+
+    public void setTargetVersion(String target_version) {
+        this.target_version = target_version;
+    }
+
+    public void validateResponse(ErrorCollection errors) {
+        String location = "Plugin response message";
+        errors.checkMissing(location,"target_version",target_version);
+        for(CRPipeline pipeline : pipelines)
+        {
+            pipeline.getErrors(errors,location);
+        }
+        for(CREnvironment environment : environments)
+        {
+            environment.getErrors(errors,location);
+        }
+    }
+
+    public Collection<CREnvironment> getEnvironments() {
+        return environments;
+    }
+
+    public void setEnvironments(Collection<CREnvironment> environments) {
+        this.environments = environments;
+    }
+
+    public Collection<CRPipeline> getPipelines() {
+        return pipelines;
+    }
+
+    public void setPipelines(Collection<CRPipeline> pipelines) {
+        this.pipelines = pipelines;
+    }
+
+    public List<CRError> getPluginErrors() {
+        return errors;
+    }
+}

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/configrepo/v2/messages/PipelineExportMessage.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/configrepo/v2/messages/PipelineExportMessage.java
@@ -16,18 +16,20 @@
 
 package com.thoughtworks.go.plugin.access.configrepo.v2.messages;
 
+import com.thoughtworks.go.plugin.access.configrepo.contract.CRPipeline;
+
 public class PipelineExportMessage {
-    private String pipelineJson;
+    private CRPipeline pipeline;
 
-    public PipelineExportMessage(String pipelineJson) {
-        this.pipelineJson = pipelineJson;
+    public PipelineExportMessage(CRPipeline pipeline) {
+        this.pipeline = pipeline;
     }
 
-    public String getPipelineJson() {
-        return pipelineJson;
+    public CRPipeline getPipeline() {
+        return pipeline;
     }
 
-    public void setPipelineJson(String pipelineJson) {
-        this.pipelineJson = pipelineJson;
+    public void setPipeline(CRPipeline pipeline) {
+        this.pipeline = pipeline;
     }
 }

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/configrepo/v2/messages/PipelineExportMessage.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/configrepo/v2/messages/PipelineExportMessage.java
@@ -14,10 +14,14 @@
  * limitations under the License.
  */
 
-package com.thoughtworks.go.plugin.access.configrepo.messages;
+package com.thoughtworks.go.plugin.access.configrepo.v2.messages;
 
-public class PipelineExportResponseMessage {
+public class PipelineExportMessage {
     private String pipelineJson;
+
+    public PipelineExportMessage(String pipelineJson) {
+        this.pipelineJson = pipelineJson;
+    }
 
     public String getPipelineJson() {
         return pipelineJson;

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/configrepo/v2/messages/PipelineExportResponseMessage.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/configrepo/v2/messages/PipelineExportResponseMessage.java
@@ -14,14 +14,10 @@
  * limitations under the License.
  */
 
-package com.thoughtworks.go.plugin.access.configrepo.messages;
+package com.thoughtworks.go.plugin.access.configrepo.v2.messages;
 
-public class PipelineExportMessage {
+public class PipelineExportResponseMessage {
     private String pipelineJson;
-
-    public PipelineExportMessage(String pipelineJson) {
-        this.pipelineJson = pipelineJson;
-    }
 
     public String getPipelineJson() {
         return pipelineJson;

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/configrepo/v2/messages/PipelineExportResponseMessage.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/configrepo/v2/messages/PipelineExportResponseMessage.java
@@ -17,13 +17,13 @@
 package com.thoughtworks.go.plugin.access.configrepo.v2.messages;
 
 public class PipelineExportResponseMessage {
-    private String pipelineJson;
+    private String pipeline;
 
-    public String getPipelineJson() {
-        return pipelineJson;
+    public String getPipeline() {
+        return pipeline;
     }
 
-    public void setPipelineJson(String pipelineJson) {
-        this.pipelineJson = pipelineJson;
+    public void setPipeline(String pipeline) {
+        this.pipeline = pipeline;
     }
 }

--- a/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/configrepo/ConfigRepoExtensionTest.java
+++ b/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/configrepo/ConfigRepoExtensionTest.java
@@ -124,8 +124,6 @@ public class ConfigRepoExtensionTest {
     @Test
     public void shouldRequestCapabilitiesV1() throws Exception {
         Capabilities capabilities = new Capabilities(false);
-        when(jsonMessageHandler2.getCapabilitiesFromResponse(responseBody)).thenReturn(capabilities);
-//        when(pluginManager.resolveExtensionVersion(PLUGIN_ID, CONFIG_REPO_EXTENSION, new ArrayList<>(Arrays.asList("1.0", "2.0")))).thenReturn("1.0");
 
         Capabilities res = extension.getCapabilities(PLUGIN_ID);
 

--- a/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/configrepo/ConfigRepoExtensionTest.java
+++ b/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/configrepo/ConfigRepoExtensionTest.java
@@ -122,6 +122,17 @@ public class ConfigRepoExtensionTest {
     }
 
     @Test
+    public void shouldRequestCapabilitiesV1() throws Exception {
+        Capabilities capabilities = new Capabilities(false);
+        when(jsonMessageHandler2.getCapabilitiesFromResponse(responseBody)).thenReturn(capabilities);
+//        when(pluginManager.resolveExtensionVersion(PLUGIN_ID, CONFIG_REPO_EXTENSION, new ArrayList<>(Arrays.asList("1.0", "2.0")))).thenReturn("1.0");
+
+        Capabilities res = extension.getCapabilities(PLUGIN_ID);
+
+        assertThat(capabilities, is(res));
+    }
+
+    @Test
     public void shouldSerializePluginSettingsToJSON() throws Exception {
         String pluginId = "plugin_id";
         HashMap<String, String> pluginSettings = new HashMap<>();

--- a/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/configrepo/ConfigRepoExtensionTest.java
+++ b/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/configrepo/ConfigRepoExtensionTest.java
@@ -15,12 +15,10 @@
  */
 package com.thoughtworks.go.plugin.access.configrepo;
 
-import com.thoughtworks.go.config.PipelineConfig;
-import com.thoughtworks.go.helper.PipelineConfigMother;
 import com.thoughtworks.go.plugin.access.common.AbstractExtension;
+import com.thoughtworks.go.plugin.access.configrepo.codec.GsonCodec;
 import com.thoughtworks.go.plugin.access.configrepo.contract.CRParseResult;
 import com.thoughtworks.go.plugin.access.configrepo.contract.CRPipeline;
-import com.thoughtworks.go.plugin.access.configrepo.contract.CRStage;
 import com.thoughtworks.go.plugin.api.request.GoPluginApiRequest;
 import com.thoughtworks.go.plugin.api.response.DefaultGoPluginApiResponse;
 import com.thoughtworks.go.plugin.infra.PluginManager;
@@ -86,6 +84,21 @@ public class ConfigRepoExtensionTest {
 
         assertRequest(requestArgumentCaptor.getValue(), CONFIG_REPO_EXTENSION, "1.0", ConfigRepoExtension.REQUEST_PARSE_DIRECTORY, null);
         verify(jsonMessageHandler).responseMessageForParseDirectory(responseBody);
+        assertSame(response, deserializedResponse);
+    }
+
+    @Test
+    public void shouldTalkToPluginToGetPipelineExport() throws Exception {
+        CRPipeline pipeline = new CRPipeline();
+        String deserializedResponse = new GsonCodec().getGson().toJson(pipeline);
+        when(jsonMessageHandler.responseMessageForPipelineExport(responseBody)).thenReturn(deserializedResponse);
+
+
+        String response = extension.pipelineExport(PLUGIN_ID, pipeline);
+
+        assertRequest(requestArgumentCaptor.getValue(), CONFIG_REPO_EXTENSION, "1.0", ConfigRepoExtension.REQUEST_PIPELINE_EXPORT, null);
+
+        verify(jsonMessageHandler).responseMessageForPipelineExport(responseBody);
         assertSame(response, deserializedResponse);
     }
 

--- a/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/configrepo/ConfigRepoExtensionTest.java
+++ b/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/configrepo/ConfigRepoExtensionTest.java
@@ -19,8 +19,11 @@ import com.thoughtworks.go.plugin.access.common.AbstractExtension;
 import com.thoughtworks.go.plugin.access.configrepo.codec.GsonCodec;
 import com.thoughtworks.go.plugin.access.configrepo.contract.CRParseResult;
 import com.thoughtworks.go.plugin.access.configrepo.contract.CRPipeline;
+import com.thoughtworks.go.plugin.access.configrepo.v1.JsonMessageHandler1_0;
+import com.thoughtworks.go.plugin.access.configrepo.v2.JsonMessageHandler2_0;
 import com.thoughtworks.go.plugin.api.request.GoPluginApiRequest;
 import com.thoughtworks.go.plugin.api.response.DefaultGoPluginApiResponse;
+import com.thoughtworks.go.plugin.domain.configrepo.Capabilities;
 import com.thoughtworks.go.plugin.infra.PluginManager;
 import org.hamcrest.CoreMatchers;
 import org.junit.Before;
@@ -48,7 +51,9 @@ public class ConfigRepoExtensionTest {
     @Mock
     private PluginManager pluginManager;
     @Mock
-    private JsonMessageHandler1_0 jsonMessageHandler;
+    private JsonMessageHandler1_0 jsonMessageHandler1;
+    @Mock
+    private JsonMessageHandler2_0 jsonMessageHandler2;
     private ConfigRepoExtension extension;
     private String requestBody = "expected-request";
     private String responseBody = "expected-response";
@@ -61,11 +66,12 @@ public class ConfigRepoExtensionTest {
     public void setUp() throws Exception {
         initMocks(this);
         extension = new ConfigRepoExtension(pluginManager);
-        extension.getMessageHandlerMap().put("1.0", jsonMessageHandler);
+        extension.getMessageHandlerMap().put("1.0", jsonMessageHandler1);
+        extension.getMessageHandlerMap().put("2.0", jsonMessageHandler2);
 
         requestArgumentCaptor = ArgumentCaptor.forClass(GoPluginApiRequest.class);
 
-        when(pluginManager.resolveExtensionVersion(PLUGIN_ID, CONFIG_REPO_EXTENSION, new ArrayList<>(Arrays.asList("1.0")))).thenReturn("1.0");
+        when(pluginManager.resolveExtensionVersion(PLUGIN_ID, CONFIG_REPO_EXTENSION, new ArrayList<>(Arrays.asList("1.0", "2.0")))).thenReturn("1.0");
         when(pluginManager.isPluginOfType(CONFIG_REPO_EXTENSION, PLUGIN_ID)).thenReturn(true);
         when(pluginManager.submitTo(eq(PLUGIN_ID), eq(CONFIG_REPO_EXTENSION), requestArgumentCaptor.capture())).thenReturn(DefaultGoPluginApiResponse.success(responseBody));
     }
@@ -78,12 +84,12 @@ public class ConfigRepoExtensionTest {
     @Test
     public void shouldTalkToPluginToGetParsedDirectory() throws Exception {
         CRParseResult deserializedResponse = new CRParseResult();
-        when(jsonMessageHandler.responseMessageForParseDirectory(responseBody)).thenReturn(deserializedResponse);
+        when(jsonMessageHandler1.responseMessageForParseDirectory(responseBody)).thenReturn(deserializedResponse);
 
         CRParseResult response = extension.parseDirectory(PLUGIN_ID, "dir", null);
 
         assertRequest(requestArgumentCaptor.getValue(), CONFIG_REPO_EXTENSION, "1.0", ConfigRepoExtension.REQUEST_PARSE_DIRECTORY, null);
-        verify(jsonMessageHandler).responseMessageForParseDirectory(responseBody);
+        verify(jsonMessageHandler1).responseMessageForParseDirectory(responseBody);
         assertSame(response, deserializedResponse);
     }
 
@@ -91,15 +97,28 @@ public class ConfigRepoExtensionTest {
     public void shouldTalkToPluginToGetPipelineExport() throws Exception {
         CRPipeline pipeline = new CRPipeline();
         String deserializedResponse = new GsonCodec().getGson().toJson(pipeline);
-        when(jsonMessageHandler.responseMessageForPipelineExport(responseBody)).thenReturn(deserializedResponse);
+        when(jsonMessageHandler2.responseMessageForPipelineExport(responseBody)).thenReturn(deserializedResponse);
+        when(pluginManager.resolveExtensionVersion(PLUGIN_ID, CONFIG_REPO_EXTENSION, new ArrayList<>(Arrays.asList("1.0", "2.0")))).thenReturn("2.0");
 
 
         String response = extension.pipelineExport(PLUGIN_ID, pipeline);
 
-        assertRequest(requestArgumentCaptor.getValue(), CONFIG_REPO_EXTENSION, "1.0", ConfigRepoExtension.REQUEST_PIPELINE_EXPORT, null);
+        assertRequest(requestArgumentCaptor.getValue(), CONFIG_REPO_EXTENSION, "2.0", ConfigRepoExtension.REQUEST_PIPELINE_EXPORT, null);
 
-        verify(jsonMessageHandler).responseMessageForPipelineExport(responseBody);
+        verify(jsonMessageHandler2).responseMessageForPipelineExport(responseBody);
         assertSame(response, deserializedResponse);
+    }
+
+    @Test
+    public void shouldRequestCapabilities() throws Exception {
+        Capabilities capabilities = new Capabilities(true);
+        when(jsonMessageHandler2.getCapabilitiesFromResponse(responseBody)).thenReturn(capabilities);
+        when(pluginManager.resolveExtensionVersion(PLUGIN_ID, CONFIG_REPO_EXTENSION, new ArrayList<>(Arrays.asList("1.0", "2.0")))).thenReturn("2.0");
+
+        Capabilities res = extension.getCapabilities(PLUGIN_ID);
+
+        assertRequest(requestArgumentCaptor.getValue(), CONFIG_REPO_EXTENSION, "2.0", ConfigRepoExtension.REQUEST_CAPABILITIES, null);
+        assertSame(capabilities, res);
     }
 
     @Test

--- a/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/configrepo/ConfigRepoExtensionTest.java
+++ b/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/configrepo/ConfigRepoExtensionTest.java
@@ -15,8 +15,12 @@
  */
 package com.thoughtworks.go.plugin.access.configrepo;
 
+import com.thoughtworks.go.config.PipelineConfig;
+import com.thoughtworks.go.helper.PipelineConfigMother;
 import com.thoughtworks.go.plugin.access.common.AbstractExtension;
 import com.thoughtworks.go.plugin.access.configrepo.contract.CRParseResult;
+import com.thoughtworks.go.plugin.access.configrepo.contract.CRPipeline;
+import com.thoughtworks.go.plugin.access.configrepo.contract.CRStage;
 import com.thoughtworks.go.plugin.api.request.GoPluginApiRequest;
 import com.thoughtworks.go.plugin.api.response.DefaultGoPluginApiResponse;
 import com.thoughtworks.go.plugin.infra.PluginManager;

--- a/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/configrepo/v1/JsonMessageHandler1_0Test.java
+++ b/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/configrepo/v1/JsonMessageHandler1_0Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 ThoughtWorks, Inc.
+ * Copyright 2018 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,11 +14,14 @@
  * limitations under the License.
  */
 
-package com.thoughtworks.go.plugin.access.configrepo;
+package com.thoughtworks.go.plugin.access.configrepo.v1;
 
 
+import com.thoughtworks.go.plugin.access.configrepo.ConfigRepoMigrator;
 import com.thoughtworks.go.plugin.access.configrepo.codec.GsonCodec;
 import com.thoughtworks.go.plugin.access.configrepo.contract.CRParseResult;
+import com.thoughtworks.go.plugin.domain.configrepo.Capabilities;
+import org.hamcrest.CoreMatchers;
 import org.junit.Test;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
@@ -87,6 +90,11 @@ public class JsonMessageHandler1_0Test {
         verify(configRepoMigrator).migrate(anyString(), eq(1));
         verify(configRepoMigrator).migrate(nullable(String.class), eq(2));
         verify(configRepoMigrator, times(JsonMessageHandler1_0.CURRENT_CONTRACT_VERSION)).migrate(nullable(String.class), anyInt());
+    }
+
+    @Test
+    public void shouldReturnAllFalseCapabilities() {
+       assertThat(handler.getCapabilitiesFromResponse(""), CoreMatchers.is(new Capabilities()));
     }
 
     @Test

--- a/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/configrepo/v1/JsonMessageHandler1_0Test.java
+++ b/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/configrepo/v1/JsonMessageHandler1_0Test.java
@@ -93,11 +93,6 @@ public class JsonMessageHandler1_0Test {
     }
 
     @Test
-    public void shouldReturnAllFalseCapabilities() {
-       assertThat(handler.getCapabilitiesFromResponse(""), CoreMatchers.is(new Capabilities()));
-    }
-
-    @Test
     public void shouldErrorWhenTargetVersionOfPluginIsHigher() {
         int targetVersion = JsonMessageHandler1_0.CURRENT_CONTRACT_VERSION + 1;
         String json = "{\n" +

--- a/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/configrepo/v2/JsonMessageHandler2_0Test.java
+++ b/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/configrepo/v2/JsonMessageHandler2_0Test.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2018 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.plugin.access.configrepo.v2;
+
+import com.thoughtworks.go.plugin.access.configrepo.ConfigRepoMigrator;
+import com.thoughtworks.go.plugin.access.configrepo.codec.GsonCodec;
+import com.thoughtworks.go.plugin.domain.configrepo.Capabilities;
+import org.hamcrest.CoreMatchers;
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.mock;
+
+public class JsonMessageHandler2_0Test {
+    private final JsonMessageHandler2_0 handler;
+
+    public JsonMessageHandler2_0Test() {
+        ConfigRepoMigrator configRepoMigrator = mock(ConfigRepoMigrator.class);
+        handler = new JsonMessageHandler2_0(new GsonCodec(), configRepoMigrator);
+    }
+
+    @Test
+    public void shouldReturnAllFalseCapabilities() {
+        assertThat(handler.getCapabilitiesFromResponse("{\"supportsPipelineExport\":\"true\"}"), CoreMatchers.is(new Capabilities(true)));
+    }
+}

--- a/plugin-infra/go-plugin-domain/src/main/java/com/thoughtworks/go/plugin/domain/configrepo/Capabilities.java
+++ b/plugin-infra/go-plugin-domain/src/main/java/com/thoughtworks/go/plugin/domain/configrepo/Capabilities.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2018 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.plugin.domain.configrepo;
+
+import java.util.Objects;
+
+public class Capabilities {
+    private boolean supportsPipelineExport;
+
+    public Capabilities() {
+        this(false);
+    }
+
+    public Capabilities(boolean supportsPipelineExport) {
+        this.supportsPipelineExport = supportsPipelineExport;
+    }
+
+    public boolean isSupportsPipelineExport() {
+        return supportsPipelineExport;
+    }
+
+    public void setSupportsPipelineExport(boolean supportsPipelineExport) {
+        this.supportsPipelineExport = supportsPipelineExport;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Capabilities that = (Capabilities) o;
+        return supportsPipelineExport == that.supportsPipelineExport;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(supportsPipelineExport);
+    }
+}

--- a/server/src/main/java/com/thoughtworks/go/config/ConfigConverter.java
+++ b/server/src/main/java/com/thoughtworks/go/config/ConfigConverter.java
@@ -1002,11 +1002,7 @@ public class ConfigConverter {
     private CRSvnMaterial svnMaterialToCRSvnMaterial(String materialName, SvnMaterialConfig svnMaterial) {
         CRSvnMaterial crSvnMaterial = new CRSvnMaterial(materialName, svnMaterial.getFolder(), svnMaterial.isAutoUpdate(),
                 svnMaterial.getUrl(), svnMaterial.getUserName(), null, svnMaterial.isCheckExternals(), svnMaterial.isInvertFilter(), svnMaterial.filter().ignoredFileNames());
-        if (svnMaterial.getEncryptedPassword() != null) {
-            crSvnMaterial.setEncryptedPassword(svnMaterial.getEncryptedPassword());
-        } else {
-            crSvnMaterial.setPassword(svnMaterial.getPassword());
-        }
+        crSvnMaterial.setEncryptedPassword(svnMaterial.getEncryptedPassword());
         return crSvnMaterial;
     }
 

--- a/server/src/main/java/com/thoughtworks/go/config/ConfigConverter.java
+++ b/server/src/main/java/com/thoughtworks/go/config/ConfigConverter.java
@@ -938,7 +938,7 @@ public class ConfigConverter {
 
         return new CRPluggableScmMaterial(pluggableScmMaterialConfig.getName().toString(),
                 id, pluggableScmMaterialConfig.getFolder(),
-                pluggableScmMaterialConfig.getFilterAsString());
+                pluggableScmMaterialConfig.filter().ignoredFileNames());
     }
 
     private CRPackageMaterial packageMaterialToCRPackageMaterial(PackageMaterialConfig packageMaterialConfig) {
@@ -961,15 +961,15 @@ public class ConfigConverter {
         }
         if (scmMaterialConfig instanceof GitMaterialConfig) {
             GitMaterialConfig git = (GitMaterialConfig) scmMaterialConfig;
-            return new CRGitMaterial(materialName, git.getFolder(), git.isAutoUpdate(), git.isShallowClone(), git.getUrl(), git.getBranch(), git.isInvertFilter(), git.getFilterAsString());
+            return new CRGitMaterial(materialName, git.getFolder(), git.isAutoUpdate(), git.isShallowClone(), git.getUrl(), git.getBranch(), git.isInvertFilter(), git.filter().ignoredFileNames());
         } else if (scmMaterialConfig instanceof HgMaterialConfig) {
             HgMaterialConfig hg = (HgMaterialConfig) scmMaterialConfig;
-            return new CRHgMaterial(materialName, hg.getFolder(), hg.isAutoUpdate(), hg.getUrl(), hg.isInvertFilter(), hg.getFilterAsString());
+            return new CRHgMaterial(materialName, hg.getFolder(), hg.isAutoUpdate(), hg.isInvertFilter(), hg.filter().ignoredFileNames(), hg.getUrl());
         } else if (scmMaterialConfig instanceof P4MaterialConfig) {
             P4MaterialConfig p4MaterialConfig = (P4MaterialConfig) scmMaterialConfig;
 
 
-            CRP4Material crP4Material = new CRP4Material(materialName, p4MaterialConfig.getFolder(), p4MaterialConfig.isAutoUpdate(), p4MaterialConfig.getServerAndPort(), p4MaterialConfig.getView(), p4MaterialConfig.getUserName(), null, p4MaterialConfig.getUseTickets(), p4MaterialConfig.isInvertFilter(), p4MaterialConfig.getFilterAsString());
+            CRP4Material crP4Material = new CRP4Material(materialName, p4MaterialConfig.getFolder(), p4MaterialConfig.isAutoUpdate(), p4MaterialConfig.getServerAndPort(), p4MaterialConfig.getView(), p4MaterialConfig.getUserName(), null, p4MaterialConfig.getUseTickets(), p4MaterialConfig.isInvertFilter(), p4MaterialConfig.filter().ignoredFileNames());
 
             if (p4MaterialConfig.getEncryptedPassword() != null) {
                 crP4Material.setEncryptedPassword(p4MaterialConfig.getEncryptedPassword());
@@ -979,7 +979,7 @@ public class ConfigConverter {
         } else if (scmMaterialConfig instanceof SvnMaterialConfig) {
             SvnMaterialConfig svnMaterial = (SvnMaterialConfig) scmMaterialConfig;
             CRSvnMaterial crSvnMaterial = new CRSvnMaterial(materialName, svnMaterial.getFolder(), svnMaterial.isAutoUpdate(),
-                    svnMaterial.getUrl(), svnMaterial.getUserName(), null, svnMaterial.isCheckExternals(), svnMaterial.isInvertFilter(), svnMaterial.getFilterAsString());
+                    svnMaterial.getUrl(), svnMaterial.getUserName(), null, svnMaterial.isCheckExternals(), svnMaterial.isInvertFilter(), svnMaterial.filter().ignoredFileNames());
             if (svnMaterial.getEncryptedPassword() != null) {
                 crSvnMaterial.setEncryptedPassword(svnMaterial.getEncryptedPassword());
             } else {
@@ -998,7 +998,7 @@ public class ConfigConverter {
                     tfsMaterialConfig.getProjectPath(),
                     tfsMaterialConfig.getDomain(),
                     tfsMaterialConfig.isInvertFilter(),
-                    tfsMaterialConfig.getFilterAsString());
+                    tfsMaterialConfig.filter().ignoredFileNames());
 
             if (tfsMaterialConfig.getEncryptedPassword() != null) {
                 crTfsMaterial.setEncryptedPassword(tfsMaterialConfig.getEncryptedPassword());

--- a/server/src/main/java/com/thoughtworks/go/config/ConfigConverter.java
+++ b/server/src/main/java/com/thoughtworks/go/config/ConfigConverter.java
@@ -641,8 +641,9 @@ public class ConfigConverter {
         return new TrackingTool(crTrackingTool.getLink(), crTrackingTool.getRegex());
     }
 
-    public CRPipeline pipelineConfigToCRPipeline(PipelineConfig pipelineConfig) {
+    public CRPipeline pipelineConfigToCRPipeline(PipelineConfig pipelineConfig, String groupName) {
         CRPipeline crPipeline = new CRPipeline();
+        crPipeline.setGroupName(groupName);
 
         crPipeline.setName(pipelineConfig.name().toString());
         for(StageConfig stage: pipelineConfig.getStages()) {

--- a/server/src/main/java/com/thoughtworks/go/config/ConfigConverter.java
+++ b/server/src/main/java/com/thoughtworks/go/config/ConfigConverter.java
@@ -701,7 +701,7 @@ public class ConfigConverter {
         }
 
         for(AdminRole role: approval.getAuthConfig().getRoles()) {
-            crApproval.addAuthorizedUser(role.getName().toString());
+            crApproval.addAuthorizedRole(role.getName().toString());
         }
 
         if (approval.getType().equals(Approval.SUCCESS)) {

--- a/server/src/main/java/com/thoughtworks/go/config/ConfigConverter.java
+++ b/server/src/main/java/com/thoughtworks/go/config/ConfigConverter.java
@@ -790,7 +790,7 @@ public class ConfigConverter {
 
         fetchTask.setDestination(task.getDest());
         fetchTask.setPipelineName(task.getPipelineName().toString());
-        fetchTask.setSourceIsDirectory(task.isSourceAFile());
+        fetchTask.setSourceIsDirectory(!task.isSourceAFile());
 
         commonCRTaskMembers(fetchTask, task);
         return fetchTask;

--- a/server/src/main/java/com/thoughtworks/go/config/ConfigConverter.java
+++ b/server/src/main/java/com/thoughtworks/go/config/ConfigConverter.java
@@ -954,60 +954,80 @@ public class ConfigConverter {
         return crDependencyMaterial;
     }
 
-    private CRScmMaterial scmMaterialToCRScmMaterial(ScmMaterialConfig scmMaterialConfig) {
-        String materialName = null;
-        if (scmMaterialConfig.getName() != null) {
-            materialName = scmMaterialConfig.getName().toString();
+    private CRScmMaterial scmMaterialToCRScmMaterial(ScmMaterialConfig scmConfig) {
+        String name = null;
+        if (scmConfig.getName() != null) {
+            name = scmConfig.getName().toString();
         }
-        if (scmMaterialConfig instanceof GitMaterialConfig) {
-            GitMaterialConfig git = (GitMaterialConfig) scmMaterialConfig;
-            return new CRGitMaterial(materialName, git.getFolder(), git.isAutoUpdate(), git.isShallowClone(), git.getUrl(), git.getBranch(), git.isInvertFilter(), git.filter().ignoredFileNames());
-        } else if (scmMaterialConfig instanceof HgMaterialConfig) {
-            HgMaterialConfig hg = (HgMaterialConfig) scmMaterialConfig;
-            return new CRHgMaterial(materialName, hg.getFolder(), hg.isAutoUpdate(), hg.isInvertFilter(), hg.filter().ignoredFileNames(), hg.getUrl());
-        } else if (scmMaterialConfig instanceof P4MaterialConfig) {
-            P4MaterialConfig p4MaterialConfig = (P4MaterialConfig) scmMaterialConfig;
 
+        if (scmConfig instanceof GitMaterialConfig)
+            return gitMaterialToCRGitMaterial(name, (GitMaterialConfig) scmConfig);
 
-            CRP4Material crP4Material = new CRP4Material(materialName, p4MaterialConfig.getFolder(), p4MaterialConfig.isAutoUpdate(), p4MaterialConfig.getServerAndPort(), p4MaterialConfig.getView(), p4MaterialConfig.getUserName(), null, p4MaterialConfig.getUseTickets(), p4MaterialConfig.isInvertFilter(), p4MaterialConfig.filter().ignoredFileNames());
+         else if (scmConfig instanceof HgMaterialConfig)
+            return hgMaterialToCRHgMaterial(name, (HgMaterialConfig) scmConfig);
 
-            if (p4MaterialConfig.getEncryptedPassword() != null) {
-                crP4Material.setEncryptedPassword(p4MaterialConfig.getEncryptedPassword());
-            }
+         else if (scmConfig instanceof P4MaterialConfig)
+            return p4MaterialToCRP4Material(name, (P4MaterialConfig) scmConfig);
 
-            return crP4Material;
-        } else if (scmMaterialConfig instanceof SvnMaterialConfig) {
-            SvnMaterialConfig svnMaterial = (SvnMaterialConfig) scmMaterialConfig;
-            CRSvnMaterial crSvnMaterial = new CRSvnMaterial(materialName, svnMaterial.getFolder(), svnMaterial.isAutoUpdate(),
-                    svnMaterial.getUrl(), svnMaterial.getUserName(), null, svnMaterial.isCheckExternals(), svnMaterial.isInvertFilter(), svnMaterial.filter().ignoredFileNames());
-            if (svnMaterial.getEncryptedPassword() != null) {
-                crSvnMaterial.setEncryptedPassword(svnMaterial.getEncryptedPassword());
-            } else {
-                crSvnMaterial.setPassword(svnMaterial.getPassword());
-            }
-            return crSvnMaterial;
-        } else if (scmMaterialConfig instanceof TfsMaterialConfig) {
-            TfsMaterialConfig tfsMaterialConfig = (TfsMaterialConfig) scmMaterialConfig;
-            CRTfsMaterial crTfsMaterial = new CRTfsMaterial(materialName,
-                    tfsMaterialConfig.getFolder(),
-                    tfsMaterialConfig.isAutoUpdate(),
-                    tfsMaterialConfig.getUrl(),
-                    tfsMaterialConfig.getUserName(),
-                    null,
-                    null,
-                    tfsMaterialConfig.getProjectPath(),
-                    tfsMaterialConfig.getDomain(),
-                    tfsMaterialConfig.isInvertFilter(),
-                    tfsMaterialConfig.filter().ignoredFileNames());
+         else if (scmConfig instanceof SvnMaterialConfig)
+            return svnMaterialToCRSvnMaterial(name, (SvnMaterialConfig) scmConfig);
 
-            if (tfsMaterialConfig.getEncryptedPassword() != null) {
-                crTfsMaterial.setEncryptedPassword(tfsMaterialConfig.getEncryptedPassword());
-            }
+         else if (scmConfig instanceof TfsMaterialConfig)
+           return tfsMaterialToCRTfsMaterial(name, (TfsMaterialConfig) scmConfig);
 
-            return crTfsMaterial;
-        } else
+         else
             throw new ConfigConvertionException(
-                    String.format("unknown scm material type '%s'", scmMaterialConfig));
+                    String.format("unknown scm material type '%s'", scmConfig));
+    }
+
+    private CRHgMaterial hgMaterialToCRHgMaterial(String materialName, HgMaterialConfig hgMaterialConfig) {
+        return new CRHgMaterial(materialName, hgMaterialConfig.getFolder(), hgMaterialConfig.isAutoUpdate(), hgMaterialConfig.isInvertFilter(), hgMaterialConfig.filter().ignoredFileNames(), hgMaterialConfig.getUrl());
+    }
+
+    private CRGitMaterial gitMaterialToCRGitMaterial(String materialName, GitMaterialConfig gitMaterialConfig) {
+        return new CRGitMaterial(materialName, gitMaterialConfig.getFolder(), gitMaterialConfig.isAutoUpdate(), gitMaterialConfig.isShallowClone(), gitMaterialConfig.getUrl(), gitMaterialConfig.getBranch(), gitMaterialConfig.isInvertFilter(), gitMaterialConfig.filter().ignoredFileNames());
+
+    }
+
+    private CRP4Material p4MaterialToCRP4Material(String materialName, P4MaterialConfig p4MaterialConfig) {
+        CRP4Material crP4Material = new CRP4Material(materialName, p4MaterialConfig.getFolder(), p4MaterialConfig.isAutoUpdate(), p4MaterialConfig.getServerAndPort(), p4MaterialConfig.getView(), p4MaterialConfig.getUserName(), null, p4MaterialConfig.getUseTickets(), p4MaterialConfig.isInvertFilter(), p4MaterialConfig.filter().ignoredFileNames());
+
+        if (p4MaterialConfig.getEncryptedPassword() != null) {
+            crP4Material.setEncryptedPassword(p4MaterialConfig.getEncryptedPassword());
+        }
+
+        return crP4Material;
+    }
+
+    private CRSvnMaterial svnMaterialToCRSvnMaterial(String materialName, SvnMaterialConfig svnMaterial) {
+        CRSvnMaterial crSvnMaterial = new CRSvnMaterial(materialName, svnMaterial.getFolder(), svnMaterial.isAutoUpdate(),
+                svnMaterial.getUrl(), svnMaterial.getUserName(), null, svnMaterial.isCheckExternals(), svnMaterial.isInvertFilter(), svnMaterial.filter().ignoredFileNames());
+        if (svnMaterial.getEncryptedPassword() != null) {
+            crSvnMaterial.setEncryptedPassword(svnMaterial.getEncryptedPassword());
+        } else {
+            crSvnMaterial.setPassword(svnMaterial.getPassword());
+        }
+        return crSvnMaterial;
+    }
+
+    private CRTfsMaterial tfsMaterialToCRTfsMaterial(String materialName, TfsMaterialConfig tfsMaterialConfig) {
+        CRTfsMaterial crTfsMaterial = new CRTfsMaterial(materialName,
+                tfsMaterialConfig.getFolder(),
+                tfsMaterialConfig.isAutoUpdate(),
+                tfsMaterialConfig.getUrl(),
+                tfsMaterialConfig.getUserName(),
+                null,
+                null,
+                tfsMaterialConfig.getProjectPath(),
+                tfsMaterialConfig.getDomain(),
+                tfsMaterialConfig.isInvertFilter(),
+                tfsMaterialConfig.filter().ignoredFileNames());
+
+        if (tfsMaterialConfig.getEncryptedPassword() != null) {
+            crTfsMaterial.setEncryptedPassword(tfsMaterialConfig.getEncryptedPassword());
+        }
+
+        return crTfsMaterial;
     }
 
     CRMaterial materialToCRMaterial(MaterialConfig materialConfig) {

--- a/server/src/main/java/com/thoughtworks/go/config/ConfigConverter.java
+++ b/server/src/main/java/com/thoughtworks/go/config/ConfigConverter.java
@@ -641,7 +641,7 @@ public class ConfigConverter {
         return new TrackingTool(crTrackingTool.getLink(), crTrackingTool.getRegex());
     }
 
-    public CRPipeline pipelineConfigToCRPipeline(PipelineConfig pipelineConfig, String groupName) {
+    CRPipeline pipelineConfigToCRPipeline(PipelineConfig pipelineConfig, String groupName) {
         CRPipeline crPipeline = new CRPipeline();
         crPipeline.setGroupName(groupName);
 
@@ -675,9 +675,8 @@ public class ConfigConverter {
         return crPipeline;
     }
 
-    public CRStage stageToCRStage(StageConfig stageConfig) {
+    CRStage stageToCRStage(StageConfig stageConfig) {
         CRStage crStage = new CRStage(stageConfig.name().toString());
-        List<CRJob> jobs = new ArrayList();
 
         for(JobConfig job: stageConfig.getJobs()) {
             crStage.addJob(jobToCRJob(job));
@@ -695,7 +694,7 @@ public class ConfigConverter {
         return crStage;
     }
 
-    public CRApproval approvalToCRApproval(Approval approval) {
+    private CRApproval approvalToCRApproval(Approval approval) {
         CRApproval crApproval = new CRApproval();
         for(AdminUser user: approval.getAuthConfig().getUsers()) {
            crApproval.addAuthorizedUser(user.getName().toString());
@@ -715,7 +714,7 @@ public class ConfigConverter {
         return crApproval;
     }
 
-    public CRJob jobToCRJob(JobConfig jobConfig) {
+    CRJob jobToCRJob(JobConfig jobConfig) {
         CRJob job = new CRJob();
         job.setName(jobConfig.name().toString());
 
@@ -754,7 +753,7 @@ public class ConfigConverter {
         return job;
     }
 
-    public CRTask taskToCRTask(Task task) {
+    CRTask taskToCRTask(Task task) {
         if (task == null)
             throw new ConfigConvertionException("task cannot be null");
 
@@ -773,7 +772,7 @@ public class ConfigConverter {
                     String.format("unknown type of task '%s'", task));
     }
 
-    public CRFetchPluggableArtifactTask fetchPluggableArtifactTaskToCRFetchPluggableTask(FetchPluggableArtifactTask task) {
+    private CRFetchPluggableArtifactTask fetchPluggableArtifactTaskToCRFetchPluggableTask(FetchPluggableArtifactTask task) {
         List<CRConfigurationProperty> configuration = configurationToCRConfiguration(task.getConfiguration());
         CRFetchPluggableArtifactTask crTask = new CRFetchPluggableArtifactTask(
                 task.getStage().toString(),
@@ -783,7 +782,7 @@ public class ConfigConverter {
         return crTask;
     }
 
-    public CRFetchArtifactTask fetchTaskToCRFetchTask(FetchTask task) {
+    private CRFetchArtifactTask fetchTaskToCRFetchTask(FetchTask task) {
         CRFetchArtifactTask fetchTask = new CRFetchArtifactTask(
                 task.getStage().toString(),
                 task.getJob().toString(),
@@ -797,7 +796,7 @@ public class ConfigConverter {
         return fetchTask;
     }
 
-    public CRPluggableTask pluggableTaskToCRPluggableTask(PluggableTask pluggableTask) {
+    private CRPluggableTask pluggableTaskToCRPluggableTask(PluggableTask pluggableTask) {
         CRPluginConfiguration pluginConfiguration = new CRPluginConfiguration(pluggableTask.getPluginConfiguration().getId(), pluggableTask.getPluginConfiguration().getVersion());
         List<CRConfigurationProperty> configuration = configurationToCRConfiguration(pluggableTask.getConfiguration());
         CRPluggableTask task = new CRPluggableTask(pluginConfiguration, configuration);
@@ -805,7 +804,7 @@ public class ConfigConverter {
         return task;
     }
 
-    public CRExecTask execTasktoCRExecTask(ExecTask task) {
+    private CRExecTask execTasktoCRExecTask(ExecTask task) {
         CRExecTask crExecTask = new CRExecTask(task.getCommand());
         crExecTask.setTimeout(task.getTimeout());
         crExecTask.setWorkingDirectory(task.workingDirectory());
@@ -818,10 +817,9 @@ public class ConfigConverter {
         return crExecTask;
     }
 
-    public CRBuildTask buildTaskToCRBuildTask(BuildTask buildTask) {
+    private CRBuildTask buildTaskToCRBuildTask(BuildTask buildTask) {
         CRBuildTask crBuildTask;
         if (buildTask instanceof RakeTask) {
-            RakeTask rake = (RakeTask) buildTask;
             crBuildTask = CRBuildTask.rake();
         } else if (buildTask instanceof  AntTask) {
             crBuildTask = CRBuildTask.ant();
@@ -866,17 +864,17 @@ public class ConfigConverter {
         if (config != null) {
             for (ConfigurationProperty p : config) {
                 CRConfigurationProperty crProp = new CRConfigurationProperty(p.getKey().getName());
-                if (p.getValue() != null)
-                    crProp.setValue(p.getValue());
-                else
+                if (p.isSecure())
                     crProp.setEncryptedValue(p.getEncryptedValue());
+                else
+                    crProp.setValue(p.getValue());
                 properties.add(crProp);
             }
         }
         return properties;
     }
 
-    public CRArtifact artifactConfigToCRArtifact(ArtifactConfig artifactConfig) {
+    private CRArtifact artifactConfigToCRArtifact(ArtifactConfig artifactConfig) {
         if (artifactConfig instanceof BuildArtifactConfig) {
             BuildArtifactConfig buildArtifact = (BuildArtifactConfig) artifactConfig;
             return new CRBuiltInArtifact(buildArtifact.getSource(), buildArtifact.getDestination());
@@ -910,7 +908,7 @@ public class ConfigConverter {
         return new CRParameter(paramConfig.getName(), paramConfig.getValue());
     }
 
-    public CRTimer timerConfigToCRTimer(TimerConfig timerConfig) {
+    private CRTimer timerConfigToCRTimer(TimerConfig timerConfig) {
         if (timerConfig == null)
             return null;
         String spec =  timerConfig.getTimerSpec();
@@ -919,7 +917,7 @@ public class ConfigConverter {
         return new CRTimer(spec, timerConfig.shouldTriggerOnlyOnChanges());
     }
 
-    public CREnvironmentVariable environmentVariableConfigToCREnvironmentVariable(EnvironmentVariableConfig environmentVariableConfig) {
+    CREnvironmentVariable environmentVariableConfigToCREnvironmentVariable(EnvironmentVariableConfig environmentVariableConfig) {
         if (environmentVariableConfig.isSecure()) {
             return new CREnvironmentVariable(environmentVariableConfig.getName(), null, environmentVariableConfig.getEncryptedValue());
         } else {
@@ -943,11 +941,11 @@ public class ConfigConverter {
                 pluggableScmMaterialConfig.getFilterAsString());
     }
 
-    public CRPackageMaterial packageMaterialToCRPackageMaterial(PackageMaterialConfig packageMaterialConfig) {
+    private CRPackageMaterial packageMaterialToCRPackageMaterial(PackageMaterialConfig packageMaterialConfig) {
         return new CRPackageMaterial(packageMaterialConfig.getName().toString(), packageMaterialConfig.getPackageId());
     }
 
-    public CRDependencyMaterial dependencyMaterialConfigToCRDependencyMaterial(DependencyMaterialConfig dependencyMaterialConfig) {
+    private CRDependencyMaterial dependencyMaterialConfigToCRDependencyMaterial(DependencyMaterialConfig dependencyMaterialConfig) {
         CRDependencyMaterial crDependencyMaterial = new CRDependencyMaterial(
                 dependencyMaterialConfig.getPipelineName().toString(),
                 dependencyMaterialConfig.getStageName().toString());
@@ -1012,7 +1010,7 @@ public class ConfigConverter {
                     String.format("unknown scm material type '%s'", scmMaterialConfig));
     }
 
-    public CRMaterial materialToCRMaterial(MaterialConfig materialConfig) {
+    CRMaterial materialToCRMaterial(MaterialConfig materialConfig) {
         if (materialConfig == null)
             throw new ConfigConvertionException("material cannot be null");
 

--- a/server/src/main/java/com/thoughtworks/go/config/ConfigConverter.java
+++ b/server/src/main/java/com/thoughtworks/go/config/ConfigConverter.java
@@ -754,7 +754,7 @@ public class ConfigConverter {
         return job;
     }
 
-    private CRTask taskToCRTask(Task task) {
+    public CRTask taskToCRTask(Task task) {
         if (task == null)
             throw new ConfigConvertionException("task cannot be null");
 
@@ -791,10 +791,8 @@ public class ConfigConverter {
 
         fetchTask.setDestination(task.getDest());
         fetchTask.setPipelineName(task.getPipelineName().toString());
+        fetchTask.setSourceIsDirectory(task.isSourceAFile());
 
-        if (!task.isSourceAFile()) {
-            fetchTask.setSourceIsDirectory(true);
-        }
         commonCRTaskMembers(fetchTask, task);
         return fetchTask;
     }
@@ -828,7 +826,7 @@ public class ConfigConverter {
         } else if (buildTask instanceof  AntTask) {
             crBuildTask = CRBuildTask.ant();
         } else if (buildTask instanceof NantTask) {
-            crBuildTask = CRBuildTask.nant();
+            crBuildTask = CRBuildTask.nant(((NantTask) buildTask).getNantPath());
         } else {
             throw new RuntimeException(
                     String.format("unknown type of build task '%s'", buildTask));

--- a/server/src/main/java/com/thoughtworks/go/config/ConfigConverter.java
+++ b/server/src/main/java/com/thoughtworks/go/config/ConfigConverter.java
@@ -923,7 +923,7 @@ public class ConfigConverter {
 
     public CREnvironmentVariable environmentVariableConfigToCREnvironmentVariable(EnvironmentVariableConfig environmentVariableConfig) {
         if (environmentVariableConfig.isSecure()) {
-            return new CREnvironmentVariable(environmentVariableConfig.getName(), environmentVariableConfig.getEncryptedValue());
+            return new CREnvironmentVariable(environmentVariableConfig.getName(), null, environmentVariableConfig.getEncryptedValue());
         } else {
             String value = environmentVariableConfig.getValue();
             if(StringUtils.isBlank(value))

--- a/server/src/main/java/com/thoughtworks/go/config/ConfigConverter.java
+++ b/server/src/main/java/com/thoughtworks/go/config/ConfigConverter.java
@@ -679,7 +679,7 @@ public class ConfigConverter {
         List<CRJob> jobs = new ArrayList();
 
         for(JobConfig job: stageConfig.getJobs()) {
-            jobs.add(jobToCRJob(job));
+            crStage.addJob(jobToCRJob(job));
         }
 
         for (EnvironmentVariableConfig var: stageConfig.getVariables()) {
@@ -687,7 +687,6 @@ public class ConfigConverter {
         }
 
         crStage.setApproval(approvalToCRApproval(stageConfig.getApproval()));
-
         crStage.setFetchMaterials(stageConfig.isFetchMaterials());
         crStage.setArtifactCleanupProhibited(stageConfig.isArtifactCleanupProhibited());
         crStage.setCleanWorkingDir(stageConfig.isCleanWorkingDir());

--- a/server/src/main/java/com/thoughtworks/go/config/ConfigRepoPlugin.java
+++ b/server/src/main/java/com/thoughtworks/go/config/ConfigRepoPlugin.java
@@ -53,8 +53,8 @@ public class ConfigRepoPlugin implements PartialConfigProvider {
         return "Plugin " + this.pluginId;
     }
 
-    public String pipelineExport(PipelineConfig pipelineConfig) {
-        CRPipeline crPipeline = configConverter.pipelineConfigToCRPipeline(pipelineConfig);
+    public String pipelineExport(PipelineConfig pipelineConfig, String groupName) {
+        CRPipeline crPipeline = configConverter.pipelineConfigToCRPipeline(pipelineConfig, groupName);
         return this.crExtension.pipelineExport(this.pluginId, crPipeline);
     }
 

--- a/server/src/main/java/com/thoughtworks/go/config/ConfigRepoPlugin.java
+++ b/server/src/main/java/com/thoughtworks/go/config/ConfigRepoPlugin.java
@@ -23,6 +23,7 @@ import com.thoughtworks.go.plugin.access.configrepo.ConfigRepoExtension;
 import com.thoughtworks.go.plugin.access.configrepo.InvalidPartialConfigException;
 import com.thoughtworks.go.plugin.access.configrepo.contract.CRConfigurationProperty;
 import com.thoughtworks.go.plugin.access.configrepo.contract.CRParseResult;
+import com.thoughtworks.go.plugin.access.configrepo.contract.CRPipeline;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -50,6 +51,11 @@ public class ConfigRepoPlugin implements PartialConfigProvider {
     @Override
     public String displayName() {
         return "Plugin " + this.pluginId;
+    }
+
+    public String pipelineConfigToRemoteConfig(PipelineConfig pipelineConfig) {
+        CRPipeline crPipeline = configConverter.pipelineConfigToCRPipeline(pipelineConfig);
+        return this.crExtension.pipelineConfigToRemoteConfig(this.pluginId, crPipeline);
     }
 
     public CRParseResult parseDirectory(File configRepoCheckoutDirectory, Collection<CRConfigurationProperty> cRconfigurations) {

--- a/server/src/main/java/com/thoughtworks/go/config/ConfigRepoPlugin.java
+++ b/server/src/main/java/com/thoughtworks/go/config/ConfigRepoPlugin.java
@@ -53,9 +53,9 @@ public class ConfigRepoPlugin implements PartialConfigProvider {
         return "Plugin " + this.pluginId;
     }
 
-    public String pipelineConfigToRemoteConfig(PipelineConfig pipelineConfig) {
+    public String pipelineExport(PipelineConfig pipelineConfig) {
         CRPipeline crPipeline = configConverter.pipelineConfigToCRPipeline(pipelineConfig);
-        return this.crExtension.pipelineConfigToRemoteConfig(this.pluginId, crPipeline);
+        return this.crExtension.pipelineExport(this.pluginId, crPipeline);
     }
 
     public CRParseResult parseDirectory(File configRepoCheckoutDirectory, Collection<CRConfigurationProperty> cRconfigurations) {

--- a/server/src/test-fast/java/com/thoughtworks/go/config/ConfigConverterTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/config/ConfigConverterTest.java
@@ -1454,4 +1454,34 @@ public class ConfigConverterTest {
         assertThat(crPackageMaterial.getName(), is("name"));
         assertThat(crPackageMaterial.getPackageId(), is("package-id"));
     }
+
+    @Test
+    public void shouldConvertEnvironmentVariableConfigWhenNotSecure() {
+        EnvironmentVariableConfig environmentVariableConfig = new EnvironmentVariableConfig("key1", "value");
+        CREnvironmentVariable result = configConverter.environmentVariableConfigToCREnvironmentVariable(environmentVariableConfig);
+        assertThat(result.getValue(), is("value"));
+        assertThat(result.getName(), is("key1"));
+        assertThat(result.hasEncryptedValue(), is(false));
+    }
+
+    @Test
+    public void shouldConvertNullEnvironmentVariableConfigWhenNotSecure() {
+        EnvironmentVariableConfig environmentVariableConfig = new EnvironmentVariableConfig("key1", null);
+        CREnvironmentVariable result = configConverter.environmentVariableConfigToCREnvironmentVariable(environmentVariableConfig);
+        assertThat(result.getValue(), is(""));
+        assertThat(result.getName(), is("key1"));
+        assertThat(result.hasEncryptedValue(), is(false));
+    }
+
+    @Test
+    public void shouldConvertEnvironmentVariableConfigWhenSecure() {
+        EnvironmentVariableConfig environmentVariableConfig = new EnvironmentVariableConfig("key1", null);
+        environmentVariableConfig.setIsSecure(true);
+        environmentVariableConfig.setEncryptedValue("encryptedvalue");
+        CREnvironmentVariable result = configConverter.environmentVariableConfigToCREnvironmentVariable(environmentVariableConfig);
+        assertThat(result.hasEncryptedValue(), is(true));
+        assertThat(result.getEncryptedValue(), is("encryptedvalue"));
+        assertNull(result.getValue());
+        assertThat(result.getName(), is("key1"));
+    }
 }

--- a/server/src/test-fast/java/com/thoughtworks/go/config/ConfigConverterTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/config/ConfigConverterTest.java
@@ -1132,6 +1132,7 @@ public class ConfigConverterTest {
         assertThat(crPipeline.getTrackingTool().getLink(), is("link"));
         assertThat(crPipeline.getTimer().getTimerSpec(), is("timer"));
         assertThat(crPipeline.getStages().get(0).getName(), is("build"));
+        assertThat(crPipeline.getStages().get(0).getJobs().size(), is(1));
     }
 
     @Test
@@ -1139,19 +1140,24 @@ public class ConfigConverterTest {
         EnvironmentVariablesConfig envVars = new EnvironmentVariablesConfig();
         envVars.add("testing", "123");
 
+        JobConfig job = new JobConfig();
+        job.setName("buildjob");
+        job.setTasks(new Tasks(new RakeTask()));
+
         StageConfig stage = new StageConfig(new CaseInsensitiveString("stageName"), new JobConfigs(), new Approval());
         stage.setVariables(envVars);
+        stage.setJobs(new JobConfigs(job));
         stage.setCleanWorkingDir(true);
         stage.setArtifactCleanupProhibited(true);
 
-        CRStage stageConfig = configConverter.stageToCRStage(stage);
+        CRStage crStage = configConverter.stageToCRStage(stage);
 
-        assertThat(stageConfig.getName(), is("stageName"));
-        assertThat(stageConfig.isFetchMaterials(), is(true));
-        assertThat(stageConfig.isCleanWorkingDir(), is(true));
-        assertThat(stageConfig.isArtifactCleanupProhibited(), is(true));
-        assertThat(stageConfig.hasEnvironmentVariable("testing"), is(true));
-        assertThat(stageConfig.getJobs().size(), is(0));
+        assertThat(crStage.getName(), is("stageName"));
+        assertThat(crStage.isFetchMaterials(), is(true));
+        assertThat(crStage.isCleanWorkingDir(), is(true));
+        assertThat(crStage.isArtifactCleanupProhibited(), is(true));
+        assertThat(crStage.hasEnvironmentVariable("testing"), is(true));
+        assertThat(crStage.getJobs().size(), is(1));
     }
 
     @Test

--- a/server/src/test-fast/java/com/thoughtworks/go/config/ConfigConverterTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/config/ConfigConverterTest.java
@@ -1634,6 +1634,7 @@ public class ConfigConverterTest {
                "",
                "dest"
         );
+        fetchTask.setSrcdir("src");
         fetchTask.setConditions(new RunIfConfigs(RunIfConfig.FAILED));
 
         CRFetchArtifactTask result = (CRFetchArtifactTask) configConverter.taskToCRTask(fetchTask);
@@ -1642,7 +1643,7 @@ public class ConfigConverterTest {
         assertThat(result.getDestination(), is("dest"));
         assertThat(result.getJob(), is("job"));
         assertThat(result.getPipelineName(), is("upstream"));
-        assertNull(result.getSource());
+        assertThat(result.getSource(), is("src"));
         assertThat(result.sourceIsDirectory(), is(true));
     }
 

--- a/server/src/test-fast/java/com/thoughtworks/go/config/ConfigConverterTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/config/ConfigConverterTest.java
@@ -1093,7 +1093,7 @@ public class ConfigConverterTest {
 
         Collection<CRParameter> parameters = new ArrayList<>();
         parameters.add(new CRParameter("param", "value"));
-        CRPipeline crPipeline = configConverter.pipelineConfigToCRPipeline(pipeline);
+        CRPipeline crPipeline = configConverter.pipelineConfigToCRPipeline(pipeline, "group");
         assertThat(crPipeline.getParameters(), is(parameters));
     }
 
@@ -1123,8 +1123,9 @@ public class ConfigConverterTest {
         mat.setUrl("url");
         pipeline.addMaterialConfig(mat);
 
-        CRPipeline crPipeline = configConverter.pipelineConfigToCRPipeline(pipeline);
+        CRPipeline crPipeline = configConverter.pipelineConfigToCRPipeline(pipeline, "group1");
         assertThat(crPipeline.getName(), is("p1"));
+        assertThat(crPipeline.getGroupName(), is("group1"));
         assertThat(crPipeline.getMaterialByName("mat") instanceof CRSvnMaterial, is(true));
         assertThat(crPipeline.getLabelTemplate(), is(PipelineLabel.COUNT_TEMPLATE));
         assertThat(crPipeline.getMaterials().size(), is(1));

--- a/server/src/test-fast/java/com/thoughtworks/go/config/ConfigConverterTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/config/ConfigConverterTest.java
@@ -1145,7 +1145,12 @@ public class ConfigConverterTest {
         job.setName("buildjob");
         job.setTasks(new Tasks(new RakeTask()));
 
-        StageConfig stage = new StageConfig(new CaseInsensitiveString("stageName"), new JobConfigs(), new Approval());
+        AdminRole role = new AdminRole(new CaseInsensitiveString("a_role"));
+        AdminUser user = new AdminUser(new CaseInsensitiveString("a_user"));
+        Approval approval = new Approval();
+        approval.addAdmin(user, role);
+
+        StageConfig stage = new StageConfig(new CaseInsensitiveString("stageName"), new JobConfigs(), approval);
         stage.setVariables(envVars);
         stage.setJobs(new JobConfigs(job));
         stage.setCleanWorkingDir(true);
@@ -1154,6 +1159,8 @@ public class ConfigConverterTest {
         CRStage crStage = configConverter.stageToCRStage(stage);
 
         assertThat(crStage.getName(), is("stageName"));
+        assertThat(crStage.getApproval().getAuthorizedRoles(), hasItem("a_role"));
+        assertThat(crStage.getApproval().getAuthorizedUsers(), hasItem("a_user"));
         assertThat(crStage.isFetchMaterials(), is(true));
         assertThat(crStage.isCleanWorkingDir(), is(true));
         assertThat(crStage.isArtifactCleanupProhibited(), is(true));

--- a/server/src/test-fast/java/com/thoughtworks/go/config/ConfigConverterTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/config/ConfigConverterTest.java
@@ -1631,7 +1631,7 @@ public class ConfigConverterTest {
                new CaseInsensitiveString("upstream"),
                new CaseInsensitiveString("stage"),
                new CaseInsensitiveString("job"),
-               "src",
+               "",
                "dest"
         );
         fetchTask.setConditions(new RunIfConfigs(RunIfConfig.FAILED));
@@ -1642,7 +1642,7 @@ public class ConfigConverterTest {
         assertThat(result.getDestination(), is("dest"));
         assertThat(result.getJob(), is("job"));
         assertThat(result.getPipelineName(), is("upstream"));
-        assertThat(result.getSource(), is("src"));
+        assertNull(result.getSource());
         assertThat(result.sourceIsDirectory(), is(true));
     }
 
@@ -1652,7 +1652,7 @@ public class ConfigConverterTest {
                 new CaseInsensitiveString("upstream"),
                 new CaseInsensitiveString("stage"),
                 new CaseInsensitiveString("job"),
-                "",
+                "src",
                 "dest"
         );
         fetchTask.setConditions(new RunIfConfigs(RunIfConfig.FAILED));
@@ -1663,7 +1663,7 @@ public class ConfigConverterTest {
         assertThat(result.getDestination(), is("dest"));
         assertThat(result.getJob(), is("job"));
         assertThat(result.getPipelineName(), is("upstream"));
-        assertNull(result.getSource());
+        assertThat(result.getSource(), is("src"));
         assertThat(result.sourceIsDirectory(), is(false));
     }
 


### PR DESCRIPTION
This PR converts the Config model (PipelineConfig, StageConfig, etc) to the CR model (CRPipeline, CRStage, etc), and sends it as JSON to the specified plugin. The idea being that the plugin will return the configuration in the plugins data format.

So, the yaml plugin will convert the JSON into YAML, and send it back to the server. The JSON plugin will just give back the received JSON.

This PR only implements the extension side of things, and is currently unused. We still need to figure out what the interaction will look like from the user's perspective, and we need to wait until  @marques-work and @kierarad are finished reworking the config repo api endpoints right now. 

I'll be opening PRs on the JSON and YAML plugins here soon to implement this functionality. 

@tomzo would you be able to review this PR?