### PR TITLE
According to the HTTP spec, use URI instead of URL to parse referer header

### DIFF
--- a/server/src/main/java/com/thoughtworks/go/server/newsecurity/filters/DenyIfRefererIsNotFilesFilter.java
+++ b/server/src/main/java/com/thoughtworks/go/server/newsecurity/filters/DenyIfRefererIsNotFilesFilter.java
@@ -25,8 +25,8 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
-import java.net.MalformedURLException;
-import java.net.URL;
+import java.net.URI;
+import java.net.URISyntaxException;
 
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
@@ -54,8 +54,12 @@ public class DenyIfRefererIsNotFilesFilter extends OncePerRequestFilter {
         }
     }
 
-    private boolean isRequestFromArtifact(HttpServletRequest request) throws MalformedURLException {
+    private boolean isRequestFromArtifact(HttpServletRequest request) {
         final String referer = request.getHeader("Referer");
-        return isNotBlank(referer) && new URL(referer).getPath().startsWith("/go/files/");
+        try {
+            return isNotBlank(referer) && new URI(referer).getPath().startsWith("/go/files/");
+        } catch (URISyntaxException e) {
+            return false;
+        }
     }
 }

--- a/server/src/test-fast/java/com/thoughtworks/go/server/newsecurity/filters/DenyIfRefererIsNotFilesFilterTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/newsecurity/filters/DenyIfRefererIsNotFilesFilterTest.java
@@ -25,8 +25,11 @@ import org.junit.jupiter.migrationsupport.rules.EnableRuleMigrationSupport;
 import org.junit.rules.ExpectedException;
 
 import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -65,6 +68,15 @@ class DenyIfRefererIsNotFilesFilterTest {
 
         thrown.expect(UnsupportedOperationException.class);
         thrown.expectMessage("Filter should not be invoked for `/files/` urls.");
+
+        new DenyIfRefererIsNotFilesFilter().doFilter(request, response, chain);
+    }
+
+    @Test
+    void shouldNotBailIfRefererParsingFails() throws ServletException, IOException {
+        request = HttpRequestBuilder.GET("/auth/login")
+                .withHeader("Referer", "bad uri//com.Slack")
+                .build();
 
         new DenyIfRefererIsNotFilesFilter().doFilter(request, response, chain);
     }


### PR DESCRIPTION
Fixes #5339