### PR TITLE
Assigns a class to `body` to set styles

### DIFF
--- a/server/webapp/WEB-INF/rails/webpack/views/pages/main.scss
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/main.scss
@@ -17,7 +17,7 @@
 @import "../global/common";
 @import "../global/typography";
 
-body {
+:global(.component-layout-body) {
   margin:           0;
   font-family:      $font-family-base;
   font-size:        $font-size-base;
@@ -26,7 +26,6 @@ body {
   color:            $body-color;
   text-align:       left;
   background-color: $body-bg;
-
 }
 
 @include font-face($font-family: 'FontAwesome',

--- a/spark/spark-spa/src/main/resources/velocity/layouts/component_layout.vm
+++ b/spark/spark-spa/src/main/resources/velocity/layouts/component_layout.vm
@@ -36,7 +36,7 @@
 
 </head>
 
-<body id="${controllerName}-page"
+<body id="${controllerName}-page" class="component-layout-body"
       data-controller-name="${controllerName}"
       data-is-user-admin="${securityService.isUserAdmin(${currentUser})}"
       data-can-user-view-admin="${securityService.canViewAdminPage(${currentUser})}"


### PR DESCRIPTION
So as to not interfere with the `body` style on other pages. The problem occurred in prod mode (when using `mini-css-extract` plugin). 

Fixes the issue that caused older pages' UI to break on build.gocd.

Epic: #5232 

(Ran lint locally)