### PR TITLE
Fix for jobs cancelled when job time exceeded Job Timeout, fixes #5325 

### DIFF
--- a/server/src/main/java/com/thoughtworks/go/server/service/RestfulService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/RestfulService.java
@@ -45,12 +45,13 @@ public class RestfulService {
      */
     public JobIdentifier findJob(String pipelineName, String pipelineCounter, String stageName, String stageCounter, String buildName, Long buildId) {
         JobConfigIdentifier jobConfigIdentifier = goConfigService.translateToActualCase(new JobConfigIdentifier(pipelineName, stageName, buildName));
+
         PipelineIdentifier pipelineIdentifier;
 
         if (JobIdentifier.LATEST.equalsIgnoreCase(pipelineCounter)) {
             pipelineIdentifier = pipelineService.mostRecentPipelineIdentifier(jobConfigIdentifier.getPipelineName());
         } else if (StringUtils.isNumeric(pipelineCounter)) {
-            pipelineIdentifier = new PipelineIdentifier(jobConfigIdentifier.getPipelineName(), Integer.parseInt(pipelineCounter), null);
+            pipelineIdentifier = pipelineService.findPipelineByNameAndCounter(pipelineName, Integer.parseInt(pipelineCounter)).getIdentifier();
         } else {
             throw new RuntimeException("Expected numeric pipeline counter but received '%s'" + pipelineCounter);
         }
@@ -80,7 +81,7 @@ public class RestfulService {
             int latestCounter = stageDao.findLatestStageCounter(pipelineIdentifier, stageName);
             return new StageIdentifier(pipelineIdentifier, stageName, String.valueOf(latestCounter));
         } else {
-            return new StageIdentifier(pipelineIdentifier.getName(), pipelineIdentifier.getCounter(), stageName, stageCounter);
+            return new StageIdentifier(pipelineIdentifier, stageName, stageCounter);
         }
     }
 }

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/RestfulServiceTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/RestfulServiceTest.java
@@ -137,7 +137,6 @@ public class RestfulServiceTest {
 
         JobIdentifier result = restfulService.findJob(pipeline.getName(), String.valueOf(pipeline.getCounter()), stage.getName(), String.valueOf(stage.getCounter()), job.getName(), job.getId());
         JobIdentifier expect = new JobIdentifier(pipeline, stage, job);
-        expect.setPipelineLabel(null);
         assertThat(result, is(expect));
     }
 
@@ -168,10 +167,7 @@ public class RestfulServiceTest {
         result = restfulService.findJob(pipeline.getName(), String.valueOf(pipeline.getCounter()), stage.getName(),
                 String.valueOf(rerunStage.getCounter()), job.getName(), copiedJobId);
         assertThat(result, is(not(expect)));//since caller knows the buildId, honor it(caller knows what she is doing)
-        StageIdentifier stageIdentifier = rerunStage.getIdentifier();
-        assertThat(result, is(new JobIdentifier(stageIdentifier.getPipelineName(), stageIdentifier.getPipelineCounter(),
-                null, stageIdentifier.getStageName(), stageIdentifier.getStageCounter(), job.getName(),
-                copiedJobId)));
+        assertThat(result, is(new JobIdentifier(rerunStage.getIdentifier(), job.getName(), copiedJobId)));
     }
 
     @Test
@@ -198,7 +194,6 @@ public class RestfulServiceTest {
         JobIdentifier result = restfulService.findJob(pipeline.getName(), pipeline.getCounter().toString(),
                 stage.getName(), String.valueOf(stage.getCounter()), job.getName(), job.getId());
         JobIdentifier expect = new JobIdentifier(pipeline, stage, job);
-        expect.setPipelineLabel(null);
         assertThat(result, is(expect));
     }
 


### PR DESCRIPTION
* As part of https://github.com/gocd/gocd/pull/5256 support for pipeline
  label was removed for a bunch of API calls.
* The ConsoleActivityMonitor maintains a map of active JobIdentifies vs
  the timestamp of last console activity, the timestamp is updated on
  every console update for a job. Jobs are cancelled if the there is no
  console activity for a given Job Timeout threshold.
* With https://github.com/gocd/gocd/pull/5256 the JobIdentifier in
  ConsoleActivityMonitor did not match the one from ArtifactsController
  as pipeline label was not populated hence the console activity
  timestamp was not updated inspite of running job.
* This commit ensures the JobIdentifier is populated with the attributes
  which are same as one from the db.