### PR TITLE
Configure tsconfig.json to treat <rails.root>/webpack as the module root

### DIFF
--- a/server/webapp/WEB-INF/rails/config/webpack-base.config.js
+++ b/server/webapp/WEB-INF/rails/config/webpack-base.config.js
@@ -101,7 +101,7 @@ module.exports = function (env) {
               {
                 loader:  'awesome-typescript-loader',
                 options: {
-                  configFile:  path.join(__dirname, '..', 'tsconfig.json')
+                  configFileName:  path.join(__dirname, '..', 'tsconfig.common.json')
                 }
               },
 

--- a/server/webapp/WEB-INF/rails/spec/tsconfig.json
+++ b/server/webapp/WEB-INF/rails/spec/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "extends": "../tsconfig.common.json",
+  "compilerOptions": {
+    "baseUrl": "..",
+    "paths": {
+      "*": [
+        "webpack/*",
+        "spec/webpack/*",
+        "spec/*"
+      ]
+    }
+  },
+  "include": [
+    "webpack/**/*.ts",
+    "webpack/**/*.tsx",
+    "spec/webpack/**/*.ts"
+  ]
+}

--- a/server/webapp/WEB-INF/rails/spec/webpack/models/dashboard/material_spec.js
+++ b/server/webapp/WEB-INF/rails/spec/webpack/models/dashboard/material_spec.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import sparkRoutes from '../../../../webpack/helpers/spark_routes';
+import sparkRoutes from "helpers/spark_routes";
 
 describe("Dashboard", () => {
   describe('Material Model', () => {

--- a/server/webapp/WEB-INF/rails/spec/webpack/models/dashboard/personalization_spec.js
+++ b/server/webapp/WEB-INF/rails/spec/webpack/models/dashboard/personalization_spec.js
@@ -15,7 +15,7 @@
  */
 
 const Personalization = require("models/dashboard/personalization");
-import SparkRoutes from '../../../../webpack/helpers/spark_routes';
+import SparkRoutes from "helpers/spark_routes";
 
 describe("Personalization", () => {
   it('should fetch previously selected pipelines with appropriate headers', () => {

--- a/server/webapp/WEB-INF/rails/spec/webpack/models/dashboard/pipeline_instance_spec.js
+++ b/server/webapp/WEB-INF/rails/spec/webpack/models/dashboard/pipeline_instance_spec.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import sparkRoutes from '../../../../webpack/helpers/spark_routes';
+import sparkRoutes from "helpers/spark_routes";
 
 describe("Dashboard", () => {
   describe('Pipeline Instance Model', () => {

--- a/server/webapp/WEB-INF/rails/spec/webpack/models/shared/data_sharing/data_reporting_spec.ts
+++ b/server/webapp/WEB-INF/rails/spec/webpack/models/shared/data_sharing/data_reporting_spec.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {DataReporting} from "../../../../../webpack/models/shared/data_sharing/data_reporting";
+import {DataReporting} from "models/shared/data_sharing/data_reporting";
 
 describe('Data Reporting', () => {
   const DataReportingInfoURL              = '/go/api/internal/data_sharing/reporting/info';

--- a/server/webapp/WEB-INF/rails/spec/webpack/models/shared/data_sharing/data_sharing_settings_spec.ts
+++ b/server/webapp/WEB-INF/rails/spec/webpack/models/shared/data_sharing/data_sharing_settings_spec.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {DataSharingSettings} from "../../../../../webpack/models/shared/data_sharing/data_sharing_settings";
+import {DataSharingSettings} from "models/shared/data_sharing/data_sharing_settings";
 
 describe('Data Sharing Settings Model', () => {
   const TimeFormatter          = require('helpers/time_formatter');

--- a/server/webapp/WEB-INF/rails/spec/webpack/models/shared/data_sharing/usage_data_spec.ts
+++ b/server/webapp/WEB-INF/rails/spec/webpack/models/shared/data_sharing/usage_data_spec.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {EncryptionKeys, UsageData, UsageDataJSON} from "../../../../../webpack/models/shared/data_sharing/usage_data";
+import {EncryptionKeys, UsageData, UsageDataJSON} from "models/shared/data_sharing/usage_data";
 
 describe('Data Sharing Usage Data', () => {
   const dataSharingUsageDataURL          = '/go/api/internal/data_sharing/usagedata';

--- a/server/webapp/WEB-INF/rails/spec/webpack/models/shared/usage_data_reporter_spec.ts
+++ b/server/webapp/WEB-INF/rails/spec/webpack/models/shared/usage_data_reporter_spec.ts
@@ -15,8 +15,8 @@
  */
 
 
-import {UsageDataReporter} from "../../../../webpack/models/shared/usage_data_reporter";
-import {EncryptionKeys} from "../../../../webpack/models/shared/data_sharing/usage_data";
+import {UsageDataReporter} from "models/shared/usage_data_reporter";
+import {EncryptionKeys} from "models/shared/data_sharing/usage_data";
 
 require('jasmine-ajax');
 

--- a/server/webapp/WEB-INF/rails/spec/webpack/views/config_repos/models/revision_vm_spec.js
+++ b/server/webapp/WEB-INF/rails/spec/webpack/views/config_repos/models/revision_vm_spec.js
@@ -16,7 +16,7 @@
 
 const RevisionVM = require("views/config_repos/models/revision_vm");
 
-import SparkRoutes from '../../../../../webpack/helpers/spark_routes';
+import SparkRoutes from "helpers/spark_routes";
 
 const ID = "this-repo-sucks-001";
 

--- a/server/webapp/WEB-INF/rails/spec/webpack/views/dashboard/dashboard_widget_spec.js
+++ b/server/webapp/WEB-INF/rails/spec/webpack/views/dashboard/dashboard_widget_spec.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import SparkRoutes from '../../../../webpack/helpers/spark_routes';
+import SparkRoutes from "helpers/spark_routes";
 
 describe("Dashboard Widget", () => {
   const m               = require("mithril");

--- a/server/webapp/WEB-INF/rails/spec/webpack/views/dashboard/model/material_search_vm_spec.js
+++ b/server/webapp/WEB-INF/rails/spec/webpack/views/dashboard/model/material_search_vm_spec.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import SparkRoutes from '../../../../../webpack/helpers/spark_routes';
+import SparkRoutes from "helpers/spark_routes";
 
 describe("Dashboard Material Search State Model", () => {
 

--- a/server/webapp/WEB-INF/rails/spec/webpack/views/dashboard/model/personalization_vm_spec.js
+++ b/server/webapp/WEB-INF/rails/spec/webpack/views/dashboard/model/personalization_vm_spec.js
@@ -18,7 +18,7 @@ const Stream            = require("mithril/stream");
 const DashboardFilters  = require("models/dashboard/dashboard_filters");
 const PersonalizationVM = require("views/dashboard/models/personalization_vm");
 
-import SparkRoutes from '../../../../../webpack/helpers/spark_routes';
+import SparkRoutes from "helpers/spark_routes";
 
 describe("Personalization View Model", () => {
   it("active() tests if a view name matches the current view case-insensitively", () => {

--- a/server/webapp/WEB-INF/rails/spec/webpack/views/dashboard/pipeline_instance_widget_spec.js
+++ b/server/webapp/WEB-INF/rails/spec/webpack/views/dashboard/pipeline_instance_widget_spec.js
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import SparkRoutes from '../../../../webpack/helpers/spark_routes';
+import SparkRoutes from "helpers/spark_routes";
 
 describe("Dashboard Pipeline Instance Widget", () => {
 

--- a/server/webapp/WEB-INF/rails/spec/webpack/views/dashboard/trigger_with_options/modal_body_spec.js
+++ b/server/webapp/WEB-INF/rails/spec/webpack/views/dashboard/trigger_with_options/modal_body_spec.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import SparkRoutes from '../../../../../webpack/helpers/spark_routes';
+import SparkRoutes from "helpers/spark_routes";
 
 describe("Dashboard Pipeline Trigger With Options Modal Body", () => {
   const m                           = require("mithril");

--- a/server/webapp/WEB-INF/rails/spec/webpack/views/data_sharing_settings/data_sharing_settings_widget_spec.js
+++ b/server/webapp/WEB-INF/rails/spec/webpack/views/data_sharing_settings/data_sharing_settings_widget_spec.js
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import {UsageData} from "../../../../webpack/models/shared/data_sharing/usage_data";
-import {DataSharingSettings} from "../../../../webpack/models/shared/data_sharing/data_sharing_settings";
+import {UsageData} from "models/shared/data_sharing/usage_data";
+import {DataSharingSettings} from "models/shared/data_sharing/data_sharing_settings";
 
 describe("Data Sharing Settings Widget", () => {
   const $             = require("jquery");

--- a/server/webapp/WEB-INF/rails/tsconfig.common.json
+++ b/server/webapp/WEB-INF/rails/tsconfig.common.json
@@ -1,6 +1,10 @@
 {
   "compileOnSave": true,
   "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "*": ["webpack/*"]
+    },
     "outDir": "./tmp/typescript-out/",
     "lib": [
       "es2015",

--- a/server/webapp/WEB-INF/rails/webpack/helpers/spa_base.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/helpers/spa_base.tsx
@@ -17,12 +17,12 @@
 import * as m from 'mithril';
 import * as styles from './spa_base.scss';
 
-import {UsageDataReporter} from "../models/shared/usage_data_reporter";
+import {UsageDataReporter} from "models/shared/usage_data_reporter";
 
-import {MithrilViewComponent} from "../jsx/mithril-component";
-import {ModalManager} from "../views/components/modal/modal_manager";
-import {Attrs as SiteFooterAttrs, SiteFooter} from "../views/pages/partials/site_footer";
-import {Attrs as SiteHeaderAttrs, SiteHeader} from "../views/pages/partials/site_header";
+import {MithrilViewComponent} from "jsx/mithril-component";
+import {ModalManager} from "views/components/modal/modal_manager";
+import {Attrs as SiteFooterAttrs, SiteFooter} from "views/pages/partials/site_footer";
+import {Attrs as SiteHeaderAttrs, SiteHeader} from "views/pages/partials/site_header";
 
 interface Attrs {
   headerData: SiteHeaderAttrs;

--- a/server/webapp/WEB-INF/rails/webpack/models/artifact_stores/artifact_stores.js
+++ b/server/webapp/WEB-INF/rails/webpack/models/artifact_stores/artifact_stores.js
@@ -21,7 +21,7 @@ const PluginConfigurations = require('models/shared/plugin_configurations');
 const Validatable          = require('models/mixins/validatable_mixin');
 const CrudMixins           = require('models/mixins/crud_mixins');
 
-import SparkRoutes from '../../helpers/spark_routes';
+import SparkRoutes from "helpers/spark_routes";
 
 const ArtifactStores = function (data) {
   Mixins.HasMany.call(this, {

--- a/server/webapp/WEB-INF/rails/webpack/models/dashboard/material.js
+++ b/server/webapp/WEB-INF/rails/webpack/models/dashboard/material.js
@@ -19,7 +19,7 @@ const m           = require('mithril');
 const Stream      = require('mithril/stream');
 const AjaxHelper  = require('helpers/ajax_helper');
 
-import sparkRoutes from '../../helpers/spark_routes';
+import sparkRoutes from "helpers/spark_routes";
 
 class Material {
   selectRevision     = (revision) => {

--- a/server/webapp/WEB-INF/rails/webpack/models/dashboard/personalization.js
+++ b/server/webapp/WEB-INF/rails/webpack/models/dashboard/personalization.js
@@ -18,7 +18,7 @@ const Stream           = require('mithril/stream');
 const DashboardFilters = require('models/dashboard/dashboard_filters');
 const AjaxHelper       = require('helpers/ajax_helper');
 
-import SparkRoutes from '../../helpers/spark_routes';
+import SparkRoutes from "helpers/spark_routes";
 
 function Personalization(filters) {
   let filterSet       = new DashboardFilters(filters);

--- a/server/webapp/WEB-INF/rails/webpack/models/dashboard/pipeline.js
+++ b/server/webapp/WEB-INF/rails/webpack/models/dashboard/pipeline.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import SparkRoutes from '../../helpers/spark_routes';
+import SparkRoutes from "helpers/spark_routes";
 
 const _           = require('lodash');
 const Stream      = require('mithril/stream');

--- a/server/webapp/WEB-INF/rails/webpack/models/dashboard/pipeline_instance.js
+++ b/server/webapp/WEB-INF/rails/webpack/models/dashboard/pipeline_instance.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import sparkRoutes from '../../helpers/spark_routes';
+import sparkRoutes from "helpers/spark_routes";
 
 const _                = require('lodash');
 const Routes           = require('gen/js-routes');

--- a/server/webapp/WEB-INF/rails/webpack/models/dashboard/trigger_with_options_info.js
+++ b/server/webapp/WEB-INF/rails/webpack/models/dashboard/trigger_with_options_info.js
@@ -20,7 +20,7 @@ const AjaxHelper           = require('helpers/ajax_helper');
 const Material             = require('models/dashboard/material');
 const EnvironmentVariables = require('models/dashboard/environment_variables');
 
-import sparkRoutes from '../../helpers/spark_routes';
+import sparkRoutes from "helpers/spark_routes";
 
 const TriggerWithOptionsInfo = function (materials, plainTextVariables, secureVariables) {
   const self = this;

--- a/server/webapp/WEB-INF/rails/webpack/models/elastic_profiles/elastic_profiles.js
+++ b/server/webapp/WEB-INF/rails/webpack/models/elastic_profiles/elastic_profiles.js
@@ -21,7 +21,7 @@ const PluginConfigurations = require('models/shared/plugin_configurations');
 const Validatable          = require('models/mixins/validatable_mixin');
 const CrudMixins           = require('models/mixins/crud_mixins');
 
-import SparkRoutes from '../../helpers/spark_routes';
+import SparkRoutes from "helpers/spark_routes";
 
 const ElasticProfiles = function (data) {
   Mixins.HasMany.call(this, {

--- a/server/webapp/WEB-INF/rails/webpack/models/pipeline_configs/pipeline.js
+++ b/server/webapp/WEB-INF/rails/webpack/models/pipeline_configs/pipeline.js
@@ -28,7 +28,7 @@ const mrequest             = require('helpers/mrequest');
 const Validatable          = require('models/mixins/validatable_mixin');
 const $                    = require('jquery');
 
-import SparkRoutes from '../../helpers/spark_routes';
+import SparkRoutes from "helpers/spark_routes";
 
 const Pipeline = function (data) {
   this.constructor.modelType = 'pipeline';

--- a/server/webapp/WEB-INF/rails/webpack/models/shared/data_sharing/data_reporting.ts
+++ b/server/webapp/WEB-INF/rails/webpack/models/shared/data_sharing/data_reporting.ts
@@ -15,7 +15,7 @@
  */
 
 import {Stream} from 'mithril/stream';
-import SparkRoutes from '../../../helpers/spark_routes';
+import SparkRoutes from "helpers/spark_routes";
 
 const stream     = require('mithril/stream');
 const AjaxHelper = require('helpers/ajax_helper');

--- a/server/webapp/WEB-INF/rails/webpack/models/shared/data_sharing/data_sharing_settings.ts
+++ b/server/webapp/WEB-INF/rails/webpack/models/shared/data_sharing/data_sharing_settings.ts
@@ -15,7 +15,7 @@
  */
 
 import {Stream} from 'mithril/stream';
-import SparkRoutes from '../../../helpers/spark_routes';
+import SparkRoutes from "helpers/spark_routes";
 
 const stream        = require('mithril/stream');
 const AjaxHelper    = require('helpers/ajax_helper');

--- a/server/webapp/WEB-INF/rails/webpack/models/shared/data_sharing/usage_data.ts
+++ b/server/webapp/WEB-INF/rails/webpack/models/shared/data_sharing/usage_data.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import SparkRoutes from '../../../helpers/spark_routes';
+import SparkRoutes from 'helpers/spark_routes';
 
 const AjaxHelper = require('helpers/ajax_helper');
 

--- a/server/webapp/WEB-INF/rails/webpack/single_page_apps/config_repos.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/single_page_apps/config_repos.tsx
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import Page from "../helpers/spa_base";
-import {ConfigReposPage} from "../views/pages/config_repos";
+import Page from "helpers/spa_base";
+import {ConfigReposPage} from "views/pages/config_repos";
 
 export class ConfigReposSPA extends Page {
   constructor() {

--- a/server/webapp/WEB-INF/rails/webpack/single_page_apps/data_sharing_settings.js
+++ b/server/webapp/WEB-INF/rails/webpack/single_page_apps/data_sharing_settings.js
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import {UsageData as DataSharingUsageData} from "../models/shared/data_sharing/usage_data";
-import {DataSharingSettings} from "../models/shared/data_sharing/data_sharing_settings";
+import {UsageData as DataSharingUsageData} from "models/shared/data_sharing/usage_data";
+import {DataSharingSettings} from "models/shared/data_sharing/data_sharing_settings";
 
 const $ = require('jquery');
 const m = require('mithril');

--- a/server/webapp/WEB-INF/rails/webpack/single_page_apps/kitchen_sink.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/single_page_apps/kitchen_sink.tsx
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import Page from "../helpers/spa_base";
-import {KitchenSink} from "../views/pages/kitchen_sink";
+import Page from "helpers/spa_base";
+import {KitchenSink} from "views/pages/kitchen_sink";
 
 export class KitchenSinkSPA extends Page {
   constructor() {

--- a/server/webapp/WEB-INF/rails/webpack/single_page_apps/plugins.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/single_page_apps/plugins.tsx
@@ -16,8 +16,8 @@
 
 //fixme: this page which renders either old-plugins page or components-based plugins page based on the toggle
 
-import Page from "../helpers/spa_base";
-import {PluginsPage} from "../views/pages/plugins";
+import Page from "helpers/spa_base";
+import {PluginsPage} from "views/pages/plugins";
 
 import * as $ from "jquery";
 import * as m from "mithril";

--- a/server/webapp/WEB-INF/rails/webpack/single_page_apps/spa_commons.js
+++ b/server/webapp/WEB-INF/rails/webpack/single_page_apps/spa_commons.js
@@ -17,7 +17,7 @@
 const $              = require('jquery');
 const VersionUpdater = require('models/shared/version_updater');
 
-import {UsageDataReporter} from "../models/shared/usage_data_reporter";
+import {UsageDataReporter} from "models/shared/usage_data_reporter";
 
 require('babel-polyfill');
 require('single_page_apps/notification_center');

--- a/server/webapp/WEB-INF/rails/webpack/tsconfig.json
+++ b/server/webapp/WEB-INF/rails/webpack/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../tsconfig.common.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "*": ["*"]
+    }
+  },
+  "include": [
+    "**/*.ts",
+    "**/*.tsx"
+  ]
+}

--- a/server/webapp/WEB-INF/rails/webpack/views/components/buttons/index.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/components/buttons/index.tsx
@@ -15,7 +15,7 @@
  */
 
 
-import {MithrilViewComponent} from "../../../jsx/mithril-component";
+import {MithrilViewComponent} from "jsx/mithril-component";
 import * as m from 'mithril';
 
 import * as styles from './index.scss';

--- a/server/webapp/WEB-INF/rails/webpack/views/components/collapsible_panel/index.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/components/collapsible_panel/index.tsx
@@ -18,7 +18,7 @@ import * as m from 'mithril';
 import * as stream from 'mithril/stream';
 import {Stream} from 'mithril/stream';
 import * as styles from './index.scss';
-import {MithrilComponent} from "../../../jsx/mithril-component";
+import {MithrilComponent} from "jsx/mithril-component";
 
 const classnames = require('classnames/bind').bind(styles);
 

--- a/server/webapp/WEB-INF/rails/webpack/views/components/collapsible_panel/spec/index_spec.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/components/collapsible_panel/spec/index_spec.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as styles from '../index.scss';
+import * as styles from "../index.scss";
 import {CollapsiblePanel} from "../index";
 
 describe("Collapsible Panel Component", () => {

--- a/server/webapp/WEB-INF/rails/webpack/views/components/flash_message/index.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/components/flash_message/index.tsx
@@ -16,7 +16,7 @@
 
 import * as m from 'mithril';
 import * as Icons from "../icons";
-import {MithrilComponent} from "../../../jsx/mithril-component";
+import {MithrilComponent} from "jsx/mithril-component";
 
 import * as styles from './index.scss';
 import {bind} from 'classnames/bind';

--- a/server/webapp/WEB-INF/rails/webpack/views/components/header_panel/index.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/components/header_panel/index.tsx
@@ -18,9 +18,8 @@
 import * as m from "mithril";
 import * as _ from "lodash";
 
-import {MithrilViewComponent} from "../../../jsx/mithril-component";
-
-import * as style from './index.scss';
+import {MithrilViewComponent} from "jsx/mithril-component";
+import * as style from "./index.scss";
 
 export interface Attrs {
   title: string | JSX.Element;

--- a/server/webapp/WEB-INF/rails/webpack/views/components/icons/index.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/components/icons/index.tsx
@@ -17,10 +17,10 @@
 import * as m from 'mithril';
 import * as _ from "lodash";
 
-import {MithrilViewComponent} from "../../../jsx/mithril-component";
+import {MithrilViewComponent} from "jsx/mithril-component";
 
-import * as styles from './index.scss';
-import {bind} from 'classnames/bind';
+import * as styles from "./index.scss";
+import {bind} from "classnames/bind";
 
 const classnames = bind(styles);
 

--- a/server/webapp/WEB-INF/rails/webpack/views/components/key_value_pair/index.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/components/key_value_pair/index.tsx
@@ -16,8 +16,8 @@
 
 import * as m from 'mithril';
 import * as _ from 'lodash';
-import * as styles from './index.scss';
-import {MithrilViewComponent} from "../../../jsx/mithril-component";
+import * as styles from "./index.scss";
+import {MithrilViewComponent} from "jsx/mithril-component";
 
 const classnames = require('classnames/bind').bind(styles);
 

--- a/server/webapp/WEB-INF/rails/webpack/views/components/modal/index.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/components/modal/index.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {MithrilViewComponent} from "../../../jsx/mithril-component";
+import {MithrilViewComponent} from "jsx/mithril-component";
 import * as m from 'mithril';
 import * as _ from 'lodash';
 import * as styles from './index.scss';

--- a/server/webapp/WEB-INF/rails/webpack/views/components/modal/modal_manager.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/components/modal/modal_manager.tsx
@@ -17,7 +17,7 @@
 import {Modal} from "./index";
 import * as m from 'mithril';
 import * as _ from 'lodash';
-import {MithrilViewComponent} from "../../../jsx/mithril-component";
+import {MithrilViewComponent} from "jsx/mithril-component";
 import * as styles from './index.scss';
 
 export namespace ModalManager {

--- a/server/webapp/WEB-INF/rails/webpack/views/components/modal/sample/index.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/components/modal/sample/index.tsx
@@ -17,7 +17,7 @@
 import {Modal, Size} from "../index";
 import * as m from 'mithril';
 import * as styles from './index.scss';
-import * as Buttons from "../../buttons/";
+import * as Buttons from "../../buttons";
 import {Sample2} from "./sample2";
 
 export class SampleModal extends Modal {

--- a/server/webapp/WEB-INF/rails/webpack/views/components/modal/spec/index_spec.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/components/modal/spec/index_spec.tsx
@@ -17,7 +17,7 @@
 import * as m from 'mithril';
 import {Modal} from "../index";
 import * as Buttons from "../../buttons";
-import * as styles from '../index.scss';
+import * as styles from "../index.scss";
 import {ModalManager} from "../modal_manager";
 import * as simulateEvent from 'simulate-event';
 

--- a/server/webapp/WEB-INF/rails/webpack/views/components/search_box/index.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/components/search_box/index.tsx
@@ -17,7 +17,7 @@
 
 import * as m from 'mithril';
 import * as style from './index.scss';
-import {MithrilViewComponent} from "../../../jsx/mithril-component";
+import {MithrilViewComponent} from "jsx/mithril-component";
 
 const f = require("helpers/form_helper");
 

--- a/server/webapp/WEB-INF/rails/webpack/views/components/server_health_summary/server_health_messages_count_widget.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/components/server_health_summary/server_health_messages_count_widget.tsx
@@ -17,9 +17,9 @@
 import * as m from 'mithril';
 import {Stream} from 'mithril/stream';
 import * as styles from './server_health_messages_count_widget.scss';
-import {ServerHealthMessages} from "../../../models/shared/server_health_messages/server_health_messages";
+import {ServerHealthMessages} from "models/shared/server_health_messages/server_health_messages";
 import {ServerHealthMessagesModal} from './server_health_messages_modal'
-import {MithrilComponent} from "../../../jsx/mithril-component";
+import {MithrilComponent} from "jsx/mithril-component";
 
 interface Attrs {
   serverHealthMessages: Stream<ServerHealthMessages>

--- a/server/webapp/WEB-INF/rails/webpack/views/components/server_health_summary/server_health_summary.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/components/server_health_summary/server_health_summary.tsx
@@ -17,7 +17,7 @@
 import * as m from "mithril";
 import * as stream from 'mithril/stream';
 
-import {ServerHealthMessages} from "../../../models/shared/server_health_messages/server_health_messages";
+import {ServerHealthMessages} from "models/shared/server_health_messages/server_health_messages";
 import {ServerHealthMessagesCountWidget} from "./server_health_messages_count_widget";
 
 const AjaxPoller = require('helpers/ajax_poller');

--- a/server/webapp/WEB-INF/rails/webpack/views/components/site_menu/index.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/components/site_menu/index.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {MithrilViewComponent} from "../../../jsx/mithril-component";
+import {MithrilViewComponent} from "jsx/mithril-component";
 
 import * as m from 'mithril';
 import * as styles from "./index.scss";

--- a/server/webapp/WEB-INF/rails/webpack/views/components/spinner/index.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/components/spinner/index.tsx
@@ -21,7 +21,7 @@ import {bind} from 'classnames/bind';
 
 const classnames = bind(styles);
 
-import {MithrilViewComponent} from "../../../jsx/mithril-component";
+import {MithrilViewComponent} from "jsx/mithril-component";
 
 export interface Attrs {
   small?: boolean;

--- a/server/webapp/WEB-INF/rails/webpack/views/config_repos/models/revision_vm.js
+++ b/server/webapp/WEB-INF/rails/webpack/views/config_repos/models/revision_vm.js
@@ -3,7 +3,7 @@ const Stream      = require("mithril/stream");
 const ApiHelper   = require("helpers/api_helper");
 const AjaxPoller  = require("helpers/ajax_poller");
 
-import SparkRoutes from '../../../helpers/spark_routes';
+import SparkRoutes from "helpers/spark_routes";
 
 const apiVersion = "v1";
 

--- a/server/webapp/WEB-INF/rails/webpack/views/dashboard/dashboard_widget.js.msx
+++ b/server/webapp/WEB-INF/rails/webpack/views/dashboard/dashboard_widget.js.msx
@@ -22,7 +22,7 @@ const DashboardGroupsWidget   = require('views/dashboard/dashboard_groups_widget
 const PersonalizedViewsWidget = require('views/dashboard/personalized_views_widget');
 const Dropdown                = require('views/shared/dropdown');
 
-import {SearchBox} from "../components/search_box";
+import {SearchBox} from "views/components/search_box";
 
 const GroupingSwitch = {
   view(vnode) {

--- a/server/webapp/WEB-INF/rails/webpack/views/dashboard/models/material_search_vm.js
+++ b/server/webapp/WEB-INF/rails/webpack/views/dashboard/models/material_search_vm.js
@@ -18,7 +18,7 @@ const _      = require('lodash');
 const m      = require('mithril');
 const Stream = require('mithril/stream');
 
-import sparkRoutes from '../../../helpers/spark_routes';
+import sparkRoutes from "helpers/spark_routes";
 const AjaxHelper  = require('helpers/ajax_helper');
 
 const SearchVM = function (pipelineName, materials) {

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/config_repos.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/config_repos.tsx
@@ -15,7 +15,7 @@
  */
 
 import * as m from 'mithril';
-import {MithrilComponent} from "../../jsx/mithril-component";
+import {MithrilComponent} from "jsx/mithril-component";
 const ConfigReposList = require("views/config_repos/config_repos_list");
 const ConfigRepos     = require("models/config_repos/config_repos");
 const ReposListVM     = require("views/config_repos/models/repos_list_vm");

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/kitchen_sink.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/kitchen_sink.tsx
@@ -15,16 +15,16 @@
  */
 
 import * as m from 'mithril';
-import * as Icons from "../components/icons/index";
-import * as Buttons from "../components/buttons/index";
-import {KeyValuePair} from "../components/key_value_pair";
-import {MithrilViewComponent} from "../../jsx/mithril-component";
-import {CollapsiblePanel} from "../components/collapsible_panel";
-import {ButtonGroup} from "../components/icons";
-import {AlertFlashMessage, InfoFlashMessage, SuccessFlashMessage, WarnFlashMessage} from "../components/flash_message";
-import {SearchBox} from "../components/search_box";
-import {SampleModal} from "../components/modal/sample";
-import {Size} from "../components/modal";
+import * as Icons from "views/components/icons/index";
+import * as Buttons from "views/components/buttons/index";
+import {KeyValuePair} from "views/components/key_value_pair";
+import {MithrilViewComponent} from "jsx/mithril-component";
+import {CollapsiblePanel} from "views/components/collapsible_panel";
+import {ButtonGroup} from "views/components/icons";
+import {AlertFlashMessage, InfoFlashMessage, SuccessFlashMessage, WarnFlashMessage} from "views/components/flash_message";
+import {SearchBox} from "views/components/search_box";
+import {SampleModal} from "views/components/modal/sample";
+import {Size} from "views/components/modal";
 
 const HeaderPanel = require('views/components/header_panel');
 

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/new_plugins/plugin_settings_modal.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/new_plugins/plugin_settings_modal.tsx
@@ -15,11 +15,11 @@
  */
 
 import * as m from 'mithril';
-import {Modal, Size} from "../../components/modal";
-import {Spinner} from "../../components/spinner";
-import {AlertFlashMessage} from "../../components/flash_message";
+import {Modal, Size} from "views/components/modal";
+import {Spinner} from "views/components/spinner";
+import {AlertFlashMessage} from "views/components/flash_message";
 import * as foundationStyles from './foundation_hax.scss';
-import * as Buttons from "../../components/buttons";
+import * as Buttons from "views/components/buttons";
 
 const PluginSetting = require('models/plugins/plugin_setting');
 const AngularPlugin = require('views/shared/angular_plugin');

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/new_plugins/plugin_widget.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/new_plugins/plugin_widget.tsx
@@ -17,11 +17,11 @@
 import * as m from "mithril";
 import * as _ from "lodash";
 
-import {MithrilViewComponent} from "../../../jsx/mithril-component";
-import {CollapsiblePanel} from "../../components/collapsible_panel";
-import {KeyValuePair} from "../../components/key_value_pair";
-import * as Buttons from "../../components/buttons";
-import * as Icons from "../../components/icons";
+import {MithrilViewComponent} from "jsx/mithril-component";
+import {CollapsiblePanel} from "views/components/collapsible_panel";
+import {KeyValuePair} from "views/components/key_value_pair";
+import * as Buttons from "views/components/buttons";
+import * as Icons from "views/components/icons";
 
 const Routes     = require('gen/js-routes');
 const styles     = require('./index.scss');

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/new_plugins/plugins_widget.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/new_plugins/plugins_widget.tsx
@@ -18,10 +18,10 @@
 import * as m from "mithril";
 
 import {PluginWidget} from "./plugin_widget";
-import {Spinner} from "../../components/spinner";
-import {MithrilComponent} from "../../../jsx/mithril-component";
+import {Spinner} from "views/components/spinner";
+import {MithrilComponent} from "jsx/mithril-component";
 import {PluginSettingsModal} from "./plugin_settings_modal";
-import {SuccessFlashMessage} from "../../components/flash_message";
+import {SuccessFlashMessage} from "views/components/flash_message";
 
 //todo: change this to pluginInfos:PluginInfos
 export interface Attrs {

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/partials/site_footer.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/partials/site_footer.tsx
@@ -15,7 +15,7 @@
  */
 
 import * as m from "mithril";
-import {MithrilViewComponent} from "../../../jsx/mithril-component";
+import {MithrilViewComponent} from "jsx/mithril-component";
 import * as styles from './site_footer.scss';
 
 export interface Attrs {

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/partials/site_header.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/partials/site_header.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {MithrilViewComponent} from "../../../jsx/mithril-component";
+import {MithrilViewComponent} from "jsx/mithril-component";
 
 import * as m from 'mithril';
 import * as styles from './site_header.scss';
@@ -24,7 +24,7 @@ const classnames = require('classnames/bind').bind(styles);
 const NotificationCenter  = require('views/components/notification_center');
 const ServerHealthSummary = require('views/components/server_health_summary/server_health_summary');
 
-import SiteMenu from "../../components/site_menu";
+import SiteMenu from "views/components/site_menu";
 
 export interface Attrs {
   isAnonymous: boolean;


### PR DESCRIPTION
  - This lets us do things like `import SparkRoutes from "helpers/spark_routes"`
    instead of `import SparkRoutes from "../../../helpers/spark_routes"` in your
    editor (e.g., VS Code) without it yelling at you.
  - Changes <rails.root>/tsconfig.json => <rails.root>/tsconfig.common.json
  - spec/ and webpack/ now have their own tsconfig.json files, which extend
    tsconfig.common.json to enable this behavior
  - Webpack config to awesome-typescript-loader still uses the cononical config (just
    renamed to tsconfig.common.json) so there should be no change in behavior for
    `webpack-dev` or `webpack-prod` yarn tasks; this should be a safe change.