### PR TITLE
Do not set default destination directory to null when none specified (#5342)

### DIFF
--- a/config/config-api/src/main/java/com/thoughtworks/go/config/BuiltinArtifactConfig.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/BuiltinArtifactConfig.java
@@ -88,7 +88,9 @@ public abstract class BuiltinArtifactConfig implements ArtifactConfig {
     }
 
     public void setDestination(String destination) {
-        this.destination = StringUtils.trim(destination);
+        if (StringUtils.isNotBlank(destination)) {
+            this.destination = StringUtils.trim(destination);
+        }
     }
 
     @Override
@@ -107,6 +109,6 @@ public abstract class BuiltinArtifactConfig implements ArtifactConfig {
 
     @Override
     public String toString() {
-        return MessageFormat.format("Artifact of type {0} copies from {1} to {2}", getArtifactType(), source, destination);
+        return MessageFormat.format("Artifact of type {0} copies from {1} to {2}", getArtifactType(), getSource(), getDestination());
     }
 }

--- a/config/config-api/src/test/java/com/thoughtworks/go/config/BuildArtifactConfigTest.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/config/BuildArtifactConfigTest.java
@@ -23,6 +23,7 @@ import java.util.List;
 
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 public class BuildArtifactConfigTest {
     @Test
@@ -74,5 +75,23 @@ public class BuildArtifactConfigTest {
         buildArtifactConfig.validateUniqueness(plans);
 
         assertThat(buildArtifactConfig.errors().isEmpty(), is(true));
+    }
+
+    @Test
+    public void shouldAllowOverridingDefaultArtifactDestination() {
+        BuildArtifactConfig artifactConfig = new BuildArtifactConfig("src", "dest");
+        assertThat(artifactConfig.getDestination(), is("dest"));
+
+        TestArtifactConfig testArtifactConfig = new TestArtifactConfig("src", "destination");
+        assertThat(testArtifactConfig.getDestination(), is("destination"));
+    }
+
+    @Test
+    public void shouldNotOverrideDefaultArtifactDestinationWhenNotSpecified() {
+        BuildArtifactConfig artifactConfig = new BuildArtifactConfig("src", null);
+        assertThat(artifactConfig.getDestination(), is(""));
+
+        TestArtifactConfig testArtifactConfig = new TestArtifactConfig("src", null);
+        assertThat(testArtifactConfig.getDestination(), is("testoutput"));
     }
 }


### PR DESCRIPTION
#### Fix Summary

While converting CRArtifact to BuiltInArtifact, [this](https://github.com/gocd/gocd/blob/master/server/src/main/java/com/thoughtworks/go/config/ConfigConverter.java#L521) constructor used to override the defualts from `BuiltInArtifact` class and set it to `null`.
Override the defaults only if destination is specified.


#### Tested with following YAML pipeline config:
```yaml
format_version: 3
pipelines:
  TestGoPipelineAPI:
    group: DevOps
    materials:
      mygit:
        git: https://github.com/gocd-contrib/getting-started-repo.git
    stages:
    - Build:
        jobs:
          build:
            tasks:
            - exec:
                command: mkdir
                arguments:
                - "surefire-reports"
            artifacts:
            - test:
                source: surefire-reports
            - build:
                source: surefire-reports
```

#### console log
![screen shot 2018-10-29 at 7 43 17 pm](https://user-images.githubusercontent.com/15275847/47655392-ee17d100-dbb2-11e8-88bc-7a603061945b.png)

#### Artifacts
![screen shot 2018-10-29 at 7 43 58 pm](https://user-images.githubusercontent.com/15275847/47655427-02f46480-dbb3-11e8-932d-0a91e6229b6a.png)

#### API Response
```
curl --fail --user admin:badger http://localhost:8153/go/api/admin/pipelines/TestGoPipelineAPI -H 'Accept: application/vnd.go.cd.v6+json'
```
```json
{
  "_links" : {
    "self" : {
      "href" : "http://localhost:8153/go/api/admin/pipelines/TestGoPipelineAPI"
    },
    "doc" : {
      "href" : "https://api.gocd.org/#pipeline-config"
    },
    "find" : {
      "href" : "http://localhost:8153/go/api/admin/pipelines/:pipeline_name"
    }
  },
  "label_template" : "${COUNT}",
  "lock_behavior" : "none",
  "name" : "TestGoPipelineAPI",
  "template" : null,
  "origin" : {
    "_links" : {
      "self" : {
        "href" : "http://localhost:8153/go/api/admin/config_repos/foobar"
      },
      "doc" : {
        "href" : "https://api.gocd.org/#config-repos"
      },
      "find" : {
        "href" : "http://localhost:8153/go/api/admin/config_repos/:id"
      }
    },
    "type" : "config_repo",
    "id" : "foobar"
  },
  "parameters" : [ ],
  "environment_variables" : [ ],
  "materials" : [ {
    "type" : "git",
    "attributes" : {
      "url" : "https://github.com/gocd-contrib/getting-started-repo.git",
      "destination" : null,
      "filter" : null,
      "invert_filter" : false,
      "name" : "mygit",
      "auto_update" : true,
      "branch" : "master",
      "submodule_folder" : null,
      "shallow_clone" : false
    }
  } ],
  "stages" : [ {
    "name" : "Build",
    "fetch_materials" : true,
    "clean_working_directory" : false,
    "never_cleanup_artifacts" : false,
    "approval" : {
      "type" : "success",
      "authorization" : {
        "roles" : [ ],
        "users" : [ ]
      }
    },
    "environment_variables" : [ ],
    "jobs" : [ {
      "name" : "build",
      "run_instance_count" : null,
      "timeout" : null,
      "environment_variables" : [ ],
      "resources" : [ ],
      "tasks" : [ {
        "type" : "exec",
        "attributes" : {
          "run_if" : [ "passed" ],
          "command" : "mkdir",
          "arguments" : [ "surefire-reports" ]
        }
      } ],
      "tabs" : [ ],
      "artifacts" : [ {
        "type" : "test",
        "source" : "surefire-reports",
        "destination" : "testoutput"
      }, {
        "type" : "build",
        "source" : "surefire-reports",
        "destination" : ""
      } ],
      "properties" : null
    } ]
  } ],
  "tracking_tool" : null,
  "timer" : null
}
```