### PR TITLE
Allow script tags to be defined in plugin settings (#4797)

### DIFF
--- a/server/webapp/WEB-INF/rails/webpack/views/shared/angular_plugin.js.msx
+++ b/server/webapp/WEB-INF/rails/webpack/views/shared/angular_plugin.js.msx
@@ -110,24 +110,38 @@ function onUpdate(scope, args) {
   };
 }
 
+const oncreate = function (vnode) {
+  vnode.children.forEach((elem) => {
+    if (!(elem.dom instanceof Element)) {
+      return;
+    }
+
+    elem.dom.querySelectorAll("script").forEach((script) => {
+      const newScript     = document.createElement('script');
+      newScript.innerHTML = script.innerHTML;
+      script.parentNode.replaceChild(newScript, script);
+    });
+  });
+};
+
 const AngularPlugin = {
-  template (template) {
+  template(template) {
     return $('<div></div>').html(template.replace(/GOINPUTNAME\[([^\]]*)\]/g, (_match, name) => {
       return `GOINPUTNAME['${name}']`;
     })).html();
   },
 
-  oninit () {
+  oninit() {
     this.$scope = Stream();
   },
 
-  view (vnode) {
+  view(vnode) {
     return (
       <div class='plugin-view'
            ng-controller={controllerName(vnode.attrs.configuration())}
            oncreate={onCreate(vnode.state.$scope, vnode.attrs)}
            onupdate={onUpdate(vnode.state.$scope, vnode.attrs)}>
-        {pluginTemplate(vnode.attrs.pluginInfoSettings())}
+        {m.fragment({oncreate}, [pluginTemplate(vnode.attrs.pluginInfoSettings())])}
       </div>
     );
   }

--- a/server/webapp/WEB-INF/rails/webpack/views/shared/angular_plugin.js.msx
+++ b/server/webapp/WEB-INF/rails/webpack/views/shared/angular_plugin.js.msx
@@ -116,7 +116,7 @@ const oncreate = function (vnode) {
       return;
     }
 
-    elem.dom.querySelectorAll("script").forEach((script) => {
+    Array.from(elem.dom.querySelectorAll("script")).forEach((script) => {
       const newScript     = document.createElement('script');
       newScript.innerHTML = script.innerHTML;
       script.parentNode.replaceChild(newScript, script);


### PR DESCRIPTION
Add the following script tag in any plugin settings to test:
```
<script>window.onload = alert("Script works");</script>
```

**NOTE:** Script tag needs to be within the main container.

Eg:
```html
<div data-plugin-style-id="kubernetes-plugin">
	<style></styles>
        <div class="row"> plugin settings</div>
        <script>window.onload = alert("Script works");</script>
</div>
```
