### PR TITLE
Remove pipeline from dashboard cache if its deleted (#4481)

### DIFF
--- a/server/src/main/java/com/thoughtworks/go/server/service/GoDashboardService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/GoDashboardService.java
@@ -78,8 +78,12 @@ public class GoDashboardService {
 
     public void updateCacheForPipeline(CaseInsensitiveString pipelineName) {
         PipelineConfigs group = goConfigService.findGroupByPipeline(pipelineName);
-        PipelineConfig pipelineConfig = group.findBy(pipelineName);
+        if (group == null) {
+            removePipelineFromCache(pipelineName);
+            return;
+        }
 
+        PipelineConfig pipelineConfig = group.findBy(pipelineName);
         updateCache(group, pipelineConfig);
     }
 
@@ -151,11 +155,15 @@ public class GoDashboardService {
 
     private void updateCache(PipelineConfigs group, PipelineConfig pipelineConfig) {
         if (group == null) {
-            cache.remove(pipelineConfig.name());
-            dashboardCurrentStateLoader.clearEntryFor(pipelineConfig.name());
+            removePipelineFromCache(pipelineConfig.name());
             return;
         }
 
         cache.put(dashboardCurrentStateLoader.pipelineFor(pipelineConfig, group));
+    }
+
+    private void removePipelineFromCache(CaseInsensitiveString pipelineName) {
+        cache.remove(pipelineName);
+        dashboardCurrentStateLoader.clearEntryFor(pipelineName);
     }
 }

--- a/server/src/test-fast/java/com/thoughtworks/go/server/service/GoDashboardServiceTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/service/GoDashboardServiceTest.java
@@ -307,6 +307,20 @@ public class GoDashboardServiceTest {
         verifyZeroInteractions(dashboardCurrentStateLoader);
     }
 
+    @Test
+    public void shouldRemoveExistingPipelineEntryInCacheWhenPipelineIsRemoved() {
+        BasicCruiseConfig config = GoConfigMother.defaultCruiseConfig();
+        PipelineConfig pipelineConfig = new GoConfigMother().addPipeline(config, "pipeline1", "stage1", "job1");
+        config.findGroupOfPipeline(pipelineConfig).remove(pipelineConfig);
+
+        when(goConfigService.findGroupByPipeline(any())).thenReturn(null);
+        // simulate the event
+        service.updateCacheForPipeline(pipelineConfig.name());
+        verify(cache).remove(pipelineConfig.getName());
+        verify(dashboardCurrentStateLoader).clearEntryFor(pipelineConfig.getName());
+        verifyZeroInteractions(dashboardCurrentStateLoader);
+    }
+
     private List<GoDashboardEnvironment> allEnvironmentsForDashboard(DashboardFilter filter, Username username) {
         when(goConfigService.getEnvironments()).thenReturn(config.getEnvironments());
         when(goConfigService.security()).thenReturn(config.server().security());


### PR DESCRIPTION
* When a building pipeline is removed from config,
  dashboardChangeListener will try to update the cached once its completed,
  But as it couldn't find pipeline in the config, it bombs saying NPE

* A part of this issue has been fixed here: https://github.com/gocd/gocd/pull/4707

**NOTE** This PR doesn't take care of CCTray Fixes.

Before the fixes, following stacktrace can be seen in the server logs:
```
java.lang.NullPointerException
	at com.thoughtworks.go.server.service.GoDashboardService.updateCacheForPipeline(GoDashboardService.java:81)
	at com.thoughtworks.go.server.service.GoDashboardServiceTest.shouldRemoveExistingPipelineEntryInCacheWhenPipelineIsRemoved(GoDashboardServiceTest.java:318)

```