### PR TITLE
Fix agent reposting job completion twice

### DIFF
--- a/common/src/main/java/com/thoughtworks/go/work/DefaultGoPublisher.java
+++ b/common/src/main/java/com/thoughtworks/go/work/DefaultGoPublisher.java
@@ -105,16 +105,17 @@ public class DefaultGoPublisher implements GoPublisher {
     public void reportCompleted(JobResult result) {
         if (result != null) {
             LOG.info("{} is reporting build result [{}] to Go Server for {}", agentIdentifier, result, jobIdentifier.toFullString());
+            reportCompletedAction();
             consoleOutputTransmitter.flushToServer();
             remoteBuildRepository.reportCompleted(agentRuntimeInfo, jobIdentifier, result);
+        } else {
+            reportCompletedAction();
+            reportCurrentStatus(Completed);
         }
-
-        reportCompletedAction();
     }
 
     private void reportCompletedAction() {
         reportAction(COMPLETED, "Job completed");
-        reportCurrentStatus(Completed);
     }
 
     public boolean isIgnored() {


### PR DESCRIPTION
* This fixes an issue where agent happened to report job
  completion twice. This issue was introduced while fixing an
  issue with console logs being swallowed #5335