### PR TITLE
Fix plugin settings icon click issue

### DIFF
--- a/server/webapp/WEB-INF/rails/webpack/views/components/icons/index.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/components/icons/index.tsx
@@ -16,7 +16,7 @@
 
 import {HTMLAttributes} from "jsx/dom";
 import * as _ from "lodash";
-import * as m from 'mithril';
+import * as m from "mithril";
 
 import {MithrilViewComponent} from "jsx/mithril-component";
 
@@ -36,14 +36,16 @@ class Icon extends MithrilViewComponent<Attrs> {
 
   protected constructor(name: string, title: string) {
     super();
-    this.name = name;
+    this.name  = name;
     this.title = title;
   }
 
   view(vnode: m.Vnode<Attrs>) {
     return (
-      <button title={this.title} className={(classnames(styles.btnIcon, {disabled: vnode.attrs.disabled}))}>
-        <i {...vnode.attrs} className={classnames(this.name)}/>
+      <button title={this.title}
+              className={(classnames(styles.btnIcon, {disabled: vnode.attrs.disabled}))}
+              {...vnode.attrs}>
+        <i className={classnames(this.name)}/>
       </button>
     );
   }


### PR DESCRIPTION
* Allow clicking on the entire settings icon (icon+wrapper).
* Add the onclick handler on the icon-button wrapper instead of just icon.

Epic: #5232 

