### PR TITLE
Introduce SparkUrlAware module to abstract url building for Spark controllers

### DIFF
--- a/server/webapp/WEB-INF/rails/app/presenters/api_v1/admin/merged_environments/pipeline_config_summary_representer.rb
+++ b/server/webapp/WEB-INF/rails/app/presenters/api_v1/admin/merged_environments/pipeline_config_summary_representer.rb
@@ -26,7 +26,7 @@ module ApiV1
         end
 
         link :self do |opts|
-          spark_url_aware(opts, SparkRoutes::PipelineConfig.name(@pipeline.name.toString))
+          spark_url_for(opts, SparkRoutes::PipelineConfig.name(@pipeline.name.toString))
         end
 
         link :doc do |opts|
@@ -34,7 +34,7 @@ module ApiV1
         end
 
         link :find do |opts|
-          spark_url_aware(opts, SparkRoutes::PipelineConfig.find)
+          spark_url_for(opts, SparkRoutes::PipelineConfig.find)
         end
 
         property :name,

--- a/server/webapp/WEB-INF/rails/app/presenters/api_v1/admin/merged_environments/pipeline_config_summary_representer.rb
+++ b/server/webapp/WEB-INF/rails/app/presenters/api_v1/admin/merged_environments/pipeline_config_summary_representer.rb
@@ -26,9 +26,7 @@ module ApiV1
         end
 
         link :self do |opts|
-          req = opts[:url_builder].request
-          ctx = com.thoughtworks.go.spark.RequestContext.new(req.ssl? ? 'https' : 'http', req.host, req.port, '/go')
-          ctx.urlFor(com.thoughtworks.go.spark.Routes::PipelineConfig.name(@pipeline.name.toString))
+          spark_url_aware(opts, SparkRoutes::PipelineConfig.name(@pipeline.name.toString))
         end
 
         link :doc do |opts|
@@ -36,9 +34,7 @@ module ApiV1
         end
 
         link :find do |opts|
-          req = opts[:url_builder].request
-          ctx = com.thoughtworks.go.spark.RequestContext.new(req.ssl? ? 'https' : 'http', req.host, req.port, '/go')
-          ctx.urlFor(com.thoughtworks.go.spark.Routes::PipelineConfig.find)
+          spark_url_aware(opts, SparkRoutes::PipelineConfig.find)
         end
 
         property :name,

--- a/server/webapp/WEB-INF/rails/app/presenters/api_v1/base_representer.rb
+++ b/server/webapp/WEB-INF/rails/app/presenters/api_v1/base_representer.rb
@@ -18,6 +18,8 @@ require 'roar/decorator'
 require 'roar/json'
 require 'roar/json/hal'
 
+require_relative '../shared/spark_url_aware'
+
 module ApiV1
   class BaseRepresenter < Roar::Decorator
     include Representable::Hash
@@ -25,6 +27,7 @@ module ApiV1
 
     include Roar::JSON::HAL
     include JavaImports
+    include SparkUrlAware
 
     SkipParseOnBlank = lambda { |fragment, *args|
       fragment.blank?

--- a/server/webapp/WEB-INF/rails/app/presenters/api_v1/config/pipeline_config_with_minimal_attributes_representer.rb
+++ b/server/webapp/WEB-INF/rails/app/presenters/api_v1/config/pipeline_config_with_minimal_attributes_representer.rb
@@ -20,9 +20,7 @@ module ApiV1
       alias_method :pipeline, :represented
 
       link :self do |opts|
-        req = opts[:url_builder].request
-        ctx = com.thoughtworks.go.spark.RequestContext.new(req.ssl? ? 'https' : 'http', req.host, req.port, '/go')
-        ctx.urlFor(com.thoughtworks.go.spark.Routes::PipelineConfig.name(pipeline.name.toString))
+        spark_url_aware(opts, SparkRoutes::PipelineConfig.name(pipeline.name.toString))
       end
 
       property   :name, exec_context: :decorator

--- a/server/webapp/WEB-INF/rails/app/presenters/api_v1/config/pipeline_config_with_minimal_attributes_representer.rb
+++ b/server/webapp/WEB-INF/rails/app/presenters/api_v1/config/pipeline_config_with_minimal_attributes_representer.rb
@@ -20,7 +20,7 @@ module ApiV1
       alias_method :pipeline, :represented
 
       link :self do |opts|
-        spark_url_aware(opts, SparkRoutes::PipelineConfig.name(pipeline.name.toString))
+        spark_url_for(opts, SparkRoutes::PipelineConfig.name(pipeline.name.toString))
       end
 
       property   :name, exec_context: :decorator

--- a/server/webapp/WEB-INF/rails/app/presenters/api_v1/dashboard/pipeline_representer.rb
+++ b/server/webapp/WEB-INF/rails/app/presenters/api_v1/dashboard/pipeline_representer.rb
@@ -32,19 +32,19 @@ module ApiV1
       end
 
       link :trigger do |opts|
-        spark_url_aware(opts, SparkRoutes::Pipeline.schedule(pipeline.getName()))
+        spark_url_for(opts, SparkRoutes::Pipeline.schedule(pipeline.getName()))
       end
 
       link :trigger_with_options do |opts|
-        spark_url_aware(opts, SparkRoutes::Pipeline.schedule(pipeline.getName()))
+        spark_url_for(opts, SparkRoutes::Pipeline.schedule(pipeline.getName()))
       end
 
       link :pause do |opts|
-        spark_url_aware(opts, SparkRoutes::Pipeline.pause(pipeline.getName()))
+        spark_url_for(opts, SparkRoutes::Pipeline.pause(pipeline.getName()))
       end
 
       link :unpause do |opts|
-        spark_url_aware(opts, SparkRoutes::Pipeline.unpause(pipeline.getName()))
+        spark_url_for(opts, SparkRoutes::Pipeline.unpause(pipeline.getName()))
       end
 
       property :getName, as: :name

--- a/server/webapp/WEB-INF/rails/app/presenters/api_v1/dashboard/pipeline_representer.rb
+++ b/server/webapp/WEB-INF/rails/app/presenters/api_v1/dashboard/pipeline_representer.rb
@@ -32,27 +32,19 @@ module ApiV1
       end
 
       link :trigger do |opts|
-        req = opts[:url_builder].request
-        ctx = com.thoughtworks.go.spark.RequestContext.new(req.ssl? ? 'https' : 'http', req.host, req.port, '/go')
-        ctx.urlFor(com.thoughtworks.go.spark.Routes::Pipeline.schedule(pipeline.getName()))
+        spark_url_aware(opts, SparkRoutes::Pipeline.schedule(pipeline.getName()))
       end
 
       link :trigger_with_options do |opts|
-        req = opts[:url_builder].request
-        ctx = com.thoughtworks.go.spark.RequestContext.new(req.ssl? ? 'https' : 'http', req.host, req.port, '/go')
-        ctx.urlFor(com.thoughtworks.go.spark.Routes::Pipeline.schedule(pipeline.getName()))
+        spark_url_aware(opts, SparkRoutes::Pipeline.schedule(pipeline.getName()))
       end
 
       link :pause do |opts|
-        req = opts[:url_builder].request
-        ctx = com.thoughtworks.go.spark.RequestContext.new(req.ssl? ? 'https' : 'http', req.host, req.port, '/go')
-        ctx.urlFor(com.thoughtworks.go.spark.Routes::Pipeline.pause(pipeline.getName()))
+        spark_url_aware(opts, SparkRoutes::Pipeline.pause(pipeline.getName()))
       end
 
       link :unpause do |opts|
-        req = opts[:url_builder].request
-        ctx = com.thoughtworks.go.spark.RequestContext.new(req.ssl? ? 'https' : 'http', req.host, req.port, '/go')
-        ctx.urlFor(com.thoughtworks.go.spark.Routes::Pipeline.unpause(pipeline.getName()))
+        spark_url_aware(opts, SparkRoutes::Pipeline.unpause(pipeline.getName()))
       end
 
       property :getName, as: :name

--- a/server/webapp/WEB-INF/rails/app/presenters/api_v1/shared/config_origin/config_repo_summary_representer.rb
+++ b/server/webapp/WEB-INF/rails/app/presenters/api_v1/shared/config_origin/config_repo_summary_representer.rb
@@ -20,14 +20,8 @@ module ApiV1
       class ConfigRepoSummaryRepresenter < BaseRepresenter
         alias_method :config_repo, :represented
 
-        def urlFor(url_builder, path)
-          req = url_builder.request
-          ctx = com.thoughtworks.go.spark.RequestContext.new(req.ssl? ? 'https' : 'http', req.host, req.port, '/go')
-          ctx.urlFor(path)
-        end
-
         link :self do |opts|
-          urlFor(opts[:url_builder], Routes::ConfigRepos::id(config_repo.getId()))
+          spark_url_for(opts, SparkRoutes::ConfigRepos::id(config_repo.getId()))
         end
 
         link :doc do |opts|
@@ -35,7 +29,7 @@ module ApiV1
         end
 
         link :find do |opts|
-          urlFor(opts[:url_builder], Routes::ConfigRepos::find())
+          spark_url_for(opts, SparkRoutes::ConfigRepos::find())
         end
 
         property :id

--- a/server/webapp/WEB-INF/rails/app/presenters/api_v2/base_representer.rb
+++ b/server/webapp/WEB-INF/rails/app/presenters/api_v2/base_representer.rb
@@ -18,6 +18,8 @@ require 'roar/decorator'
 require 'roar/json'
 require 'roar/json/hal'
 
+require_relative '../shared/spark_url_aware'
+
 module ApiV2
   class BaseRepresenter < Roar::Decorator
     include Representable::Hash
@@ -25,6 +27,7 @@ module ApiV2
 
     include Roar::JSON::HAL
     include JavaImports
+    include SparkUrlAware
 
     SkipParseOnBlank = lambda { |fragment, *args|
       fragment.blank?

--- a/server/webapp/WEB-INF/rails/app/presenters/api_v2/config/pipeline_config_summary_representer.rb
+++ b/server/webapp/WEB-INF/rails/app/presenters/api_v2/config/pipeline_config_summary_representer.rb
@@ -20,9 +20,7 @@ module ApiV2
       alias_method :pipeline, :represented
 
       link :self do |opts|
-        req = opts[:url_builder].request
-        ctx = com.thoughtworks.go.spark.RequestContext.new(req.ssl? ? 'https' : 'http', req.host, req.port, '/go')
-        ctx.urlFor(com.thoughtworks.go.spark.Routes::PipelineConfig.name(pipeline.name.toString))
+        spark_url_aware(opts, SparkRoutes::PipelineConfig.name(pipeline.name.toString))
       end
 
       link :doc do |opts|
@@ -30,9 +28,7 @@ module ApiV2
       end
 
       link :find do |opts|
-        req = opts[:url_builder].request
-        ctx = com.thoughtworks.go.spark.RequestContext.new(req.ssl? ? 'https' : 'http', req.host, req.port, '/go')
-        ctx.urlFor(com.thoughtworks.go.spark.Routes::PipelineConfig.find)
+        spark_url_aware(opts, SparkRoutes::PipelineConfig.find)
       end
 
       property :name, case_insensitive_string: true

--- a/server/webapp/WEB-INF/rails/app/presenters/api_v2/config/pipeline_config_summary_representer.rb
+++ b/server/webapp/WEB-INF/rails/app/presenters/api_v2/config/pipeline_config_summary_representer.rb
@@ -20,7 +20,7 @@ module ApiV2
       alias_method :pipeline, :represented
 
       link :self do |opts|
-        spark_url_aware(opts, SparkRoutes::PipelineConfig.name(pipeline.name.toString))
+        spark_url_for(opts, SparkRoutes::PipelineConfig.name(pipeline.name.toString))
       end
 
       link :doc do |opts|
@@ -28,7 +28,7 @@ module ApiV2
       end
 
       link :find do |opts|
-        spark_url_aware(opts, SparkRoutes::PipelineConfig.find)
+        spark_url_for(opts, SparkRoutes::PipelineConfig.find)
       end
 
       property :name, case_insensitive_string: true

--- a/server/webapp/WEB-INF/rails/app/presenters/api_v4/base_representer.rb
+++ b/server/webapp/WEB-INF/rails/app/presenters/api_v4/base_representer.rb
@@ -18,6 +18,8 @@ require 'roar/decorator'
 require 'roar/json'
 require 'roar/json/hal'
 
+require_relative '../shared/spark_url_aware'
+
 module ApiV4
   class BaseRepresenter < Roar::Decorator
     include Representable::Hash
@@ -25,6 +27,7 @@ module ApiV4
 
     include Roar::JSON::HAL
     include JavaImports
+    include SparkUrlAware
 
     SkipParseOnBlank = lambda { |fragment, *args|
       fragment.blank?
@@ -85,9 +88,9 @@ module ApiV4
 
             translation_map ||= {}
 
-            error_obj = if respond_to?(:error_object) 
+            error_obj = if respond_to?(:error_object)
                           error_object
-                        elsif represented.respond_to?(:errors) 
+                        elsif represented.respond_to?(:errors)
                           represented.errors
                         end
             error_obj ||= {}

--- a/server/webapp/WEB-INF/rails/app/presenters/api_v4/plugin/plugin_info_representer.rb
+++ b/server/webapp/WEB-INF/rails/app/presenters/api_v4/plugin/plugin_info_representer.rb
@@ -46,8 +46,7 @@ module ApiV4
 
       link :image do |opts|
         if plugin.image
-          ctx = com.thoughtworks.go.spark.RequestContext.new(opts[:url_builder].request.scheme, opts[:url_builder].request.host, opts[:url_builder].request.port, '/go')
-          ctx.urlFor(com.thoughtworks.go.spark.Routes::PluginImages::pluginImage(plugin.descriptor.id, plugin.getImage.getHash()))
+          spark_url_aware(opts, SparkRoutes::PluginImages::pluginImage(plugin.descriptor.id, plugin.getImage.getHash()))
         end
       end
 

--- a/server/webapp/WEB-INF/rails/app/presenters/api_v4/plugin/plugin_info_representer.rb
+++ b/server/webapp/WEB-INF/rails/app/presenters/api_v4/plugin/plugin_info_representer.rb
@@ -46,7 +46,7 @@ module ApiV4
 
       link :image do |opts|
         if plugin.image
-          spark_url_aware(opts, SparkRoutes::PluginImages::pluginImage(plugin.descriptor.id, plugin.getImage.getHash()))
+          spark_url_for(opts, SparkRoutes::PluginImages::pluginImage(plugin.descriptor.id, plugin.getImage.getHash()))
         end
       end
 

--- a/server/webapp/WEB-INF/rails/app/presenters/shared/spark_url_aware.rb
+++ b/server/webapp/WEB-INF/rails/app/presenters/shared/spark_url_aware.rb
@@ -1,0 +1,12 @@
+module SparkUrlAware
+  def spark_url_for(opts, path)
+    request_context(opts).urlFor(path)
+  end
+
+  private
+
+  def request_context(opts)
+    r = opts[:url_builder].request
+    com.thoughtworks.go.spark.RequestContext.new(r.ssl? ? "https" : "http", r.host, r.port, "/go")
+  end
+end

--- a/server/webapp/WEB-INF/rails/lib/java_imports.rb
+++ b/server/webapp/WEB-INF/rails/lib/java_imports.rb
@@ -287,5 +287,5 @@ module JavaImports
   java_import com.thoughtworks.go.plugin.domain.common.CombinedPluginInfo unless defined? CombinedPluginInfo
   java_import com.thoughtworks.go.server.service.WebpackAssetsService unless defined? WebpackAssetsService
   java_import com.thoughtworks.go.config.GoConfigCloner unless defined? GoConfigCloner
-  java_import com.thoughtworks.go.spark.Routes unless defined? Routes
+  (::SparkRoutes = com.thoughtworks.go.spark.Routes) unless defined? ::SparkRoutes
 end


### PR DESCRIPTION
Usage: the following method is available in all api presenters

`spark_url_for(opts, SparkRoutes::ConfigRepos::id("foo"))`

Followup to #5363.