### PR TITLE
Cleanup Cacheable interface

### DIFF
--- a/config/config-api/src/main/java/com/thoughtworks/go/config/Cacheable.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/Cacheable.java
@@ -20,10 +20,6 @@ import static com.thoughtworks.go.util.CachedDigestUtils.sha256Hex;
 
 public interface Cacheable {
     default String etag() {
-        return sha256(Integer.toString(hashCode()));
-    }
-
-    default String sha256(String subject) {
-        return sha256Hex(subject);
+        return sha256Hex(Integer.toString(hashCode()));
     }
 }


### PR DESCRIPTION
No need to expose an overridable `sha256()` method when it already exists as a utility method; just do a static import when necessary.

Followup to #5363.