### PR TITLE
Change contract of API calls for error handling

### DIFF
--- a/server/webapp/WEB-INF/rails/spec/webpack/models/config_repos/config_repos_spec.js
+++ b/server/webapp/WEB-INF/rails/spec/webpack/models/config_repos/config_repos_spec.js
@@ -20,7 +20,7 @@ import {ConfigReposCRUD as ConfigReposCrud} from "models/config_repos/config_rep
 describe("Config Repo CRUD model", () => {
   it("all() should cache etag", (done) => {
     jasmine.Ajax.withMock(() => {
-      jasmine.Ajax.stubRequest(SparkRoutes.ApiConfigReposListPath(), undefined, "GET").andReturn({
+      jasmine.Ajax.stubRequest(SparkRoutes.apiConfigReposInternalPath(), undefined, "GET").andReturn({
         responseText:    JSON.stringify({
           "_embedded": {
             "config_repos": []

--- a/server/webapp/WEB-INF/rails/webpack/helpers/api_request_builder.ts
+++ b/server/webapp/WEB-INF/rails/webpack/helpers/api_request_builder.ts
@@ -19,9 +19,110 @@ import * as m from "mithril";
 
 export enum ApiVersion {v1, v2, v3, v4, v5, v6, v7, v8}
 
-export interface HttpResponseWithEtag<T> {
+export interface ObjectWithEtag<T> {
   etag: string;
   object: T;
+}
+
+export interface SuccessResponse<T> {
+  body: T;
+}
+
+export interface ErrorResponse {
+  message: string; //more fields can be added if needed
+}
+
+export class ApiResult<T> {
+  private readonly successResponse?: SuccessResponse<T>;
+  private readonly errorResponse?: ErrorResponse;
+  private readonly statusCode?: number;
+  private readonly etag: string | null;
+
+  private constructor(successResponse?: SuccessResponse<T>,
+                      errorResponse?: ErrorResponse,
+                      statusCode?: number,
+                      etag?: string | null) {
+    this.successResponse = successResponse;
+    this.errorResponse   = errorResponse;
+    this.statusCode      = statusCode;
+    this.etag            = etag ? etag : null;
+  }
+
+  static from(xhr: XMLHttpRequest) {
+    return this.parseResponse(xhr);
+  }
+
+  static success(body: string, statusCode: number, etag: string | null) {
+    return new ApiResult<string>({body}, undefined, statusCode, etag);
+  }
+
+  static error(message: string, statusCode?: number) {
+    return new ApiResult<string>(undefined, {message}, statusCode);
+  }
+
+  getStatusCode(): number {
+    if (this.statusCode) {
+      return this.statusCode;
+    }
+    return -1;
+  }
+
+  getEtag(): string | null {
+    return this.etag;
+  }
+
+  map<U>(func: (x: T) => U): ApiResult<U> {
+    if (this.successResponse) {
+      const transformedBody = func(this.successResponse.body);
+      return new ApiResult<U>({body: transformedBody}, this.errorResponse, this.statusCode, this.etag);
+    } else {
+      return new ApiResult<U>(this.successResponse, this.errorResponse, this.statusCode, this.etag);
+    }
+  }
+
+  do(onSuccess: (successResponse: SuccessResponse<T>) => any, onError: (errorResponse: ErrorResponse) => any) {
+    if (this.successResponse) {
+      onSuccess(this.successResponse);
+    } else if (this.errorResponse) {
+      onError(this.errorResponse);
+    }
+  }
+
+  unwrap() {
+    if (this.successResponse) {
+      return this.successResponse;
+    } else {
+      return this.errorResponse;
+    }
+  }
+
+  getOrThrow() {
+    if (this.successResponse) {
+      return this.successResponse.body;
+    } else if (this.errorResponse) {
+      throw new Error(this.errorResponse.message);
+    } else {
+      throw new Error();
+    }
+  }
+
+  private static parseResponse(xhr: XMLHttpRequest): ApiResult<string> {
+    switch (xhr.status) {
+      case 200:
+      case 201:
+        return ApiResult.success(xhr.responseText, xhr.status, xhr.getResponseHeader("etag"));
+      case 422:
+        return ApiResult.error(this.parseMessage(xhr), xhr.status);
+    }
+    return ApiResult.error(`There was an unknown error performing the operation. Possible reason (${xhr.statusText})`, xhr.status);
+  }
+
+  private static parseMessage(xhr: XMLHttpRequest) {
+    if (xhr.response.data && xhr.response.data.message) {
+      return xhr.response.data.message;
+    }
+    return `There was an unknown error performing the operation. Possible reason (${xhr.statusText})`;
+  }
 }
 
 interface Headers {
@@ -54,7 +155,7 @@ export class ApiRequestBuilder {
                              apiVersion?: ApiVersion,
                              etag?: string,
                              payload?: any,
-                             headers?: Headers) {
+                             headers?: Headers): Promise<ApiResult<string>> {
     headers = _.assign({}, headers);
 
     if (apiVersion !== null) {
@@ -72,6 +173,14 @@ export class ApiRequestBuilder {
       data: payload,
       extract: _.identity,
       deserialize: _.identity
+    }).then((xhr: XMLHttpRequest) => {
+      return ApiResult.from(xhr);
+    }).catch((reason) => {
+      try {
+        return ApiResult.error(JSON.parse(reason.message).data.message, reason.status);
+      } catch {
+        return ApiResult.error("There was an unknown error performing the operation.", reason.status);
+      }
     });
   }
 

--- a/server/webapp/WEB-INF/rails/webpack/helpers/spark_routes.ts
+++ b/server/webapp/WEB-INF/rails/webpack/helpers/spark_routes.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as m from 'mithril';
+import * as m from "mithril";
 
 export default class {
   static adminPipelineConfigPath(pipelineName: string): string {
@@ -45,17 +45,17 @@ export default class {
     const queryString = m.buildQueryString({
       fingerprint,
       pipeline_name: pipelineName,
-      search_text:   searchText
+      search_text: searchText
     });
     return `/go/api/internal/material_search?${queryString}`;
   }
 
   static pipelineSelectionPath(): string {
-    return '/go/api/internal/pipeline_selection';
+    return "/go/api/internal/pipeline_selection";
   }
 
   static pipelineSelectionPipelinesDataPath(): string {
-    return '/go/api/internal/pipeline_selection/pipelines_data';
+    return "/go/api/internal/pipeline_selection/pipelines_data";
   }
 
   static buildCausePath(pipelineName: string, pipelineCounter: string): string {
@@ -71,27 +71,27 @@ export default class {
   }
 
   static DataSharingSettingsPath(): string {
-    return '/go/api/data_sharing/settings';
+    return "/go/api/data_sharing/settings";
   }
 
   static DataSharingUsageDataPath(): string {
-    return '/go/api/internal/data_sharing/usagedata';
+    return "/go/api/internal/data_sharing/usagedata";
   }
 
   static DataSharingUsageDataEncryptedPath(): string {
-    return '/go/api/internal/data_sharing/usagedata/encrypted';
+    return "/go/api/internal/data_sharing/usagedata/encrypted";
   }
 
   static DataReportingInfoPath(): string {
-    return '/go/api/internal/data_sharing/reporting/info';
+    return "/go/api/internal/data_sharing/reporting/info";
   }
 
   static DataReportingStartReportingPath(): string {
-    return '/go/api/internal/data_sharing/reporting/start';
+    return "/go/api/internal/data_sharing/reporting/start";
   }
 
   static DataReportingCompleteReportingPath(): string {
-    return '/go/api/internal/data_sharing/reporting/complete';
+    return "/go/api/internal/data_sharing/reporting/complete";
   }
 
   static ApiConfigReposListPath(): string {

--- a/server/webapp/WEB-INF/rails/webpack/helpers/spec/api_request_builder_spec.ts
+++ b/server/webapp/WEB-INF/rails/webpack/helpers/spec/api_request_builder_spec.ts
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2018 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {ApiRequestBuilder, ApiVersion} from "helpers/api_request_builder";
+
+describe("ApiResult", () => {
+
+  const contentType = "application/vnd.go.cd.v1+json";
+
+  beforeEach(() => {
+    jasmine.Ajax.install();
+  });
+
+  afterEach(() => {
+    jasmine.Ajax.uninstall();
+  });
+
+  it("should create ApiResult from a successful request", (done) => {
+    mockSuccessfulRequest();
+    ApiRequestBuilder.GET("/foo", ApiVersion.v1).then((result) => {
+      // @ts-ignore
+      expect(result.unwrap().body).toEqual(JSON.stringify({foo: "bar"}));
+      expect(result.getEtag()).toEqual("etag-value");
+      expect(result.getStatusCode()).toEqual(200);
+      done();
+    }, () => {
+      done.fail("should have passed");
+    });
+  });
+
+  it("should create ApiResult from a successful POST request", (done) => {
+    mockSuccessfulCreatedRequest();
+    ApiRequestBuilder.POST("/foo", ApiVersion.v1).then((result) => {
+      // @ts-ignore
+      expect(result.unwrap().body).toEqual(JSON.stringify({foo: "bar"}));
+      expect(result.getEtag()).toEqual("etag-value");
+      expect(result.getStatusCode()).toEqual(201);
+      done();
+    }, () => {
+      done.fail("should have passed");
+    });
+  });
+
+  it("should create ApiResult for request failing validation", (done) => {
+    mockValidationFailedRequest();
+    ApiRequestBuilder.PUT("/foo", ApiVersion.v1).then((result) => {
+      // @ts-ignore
+      expect(result.unwrap().message).toEqual("validation failed");
+      expect(result.getEtag()).toBeNull();
+      expect(result.getStatusCode()).toEqual(422);
+      done();
+    }, () => {
+      done.fail("should have passed");
+    });
+  });
+
+  it("should create ApiResult for request failing with an internal server error", (done) => {
+    mockInternalServerError();
+    ApiRequestBuilder.GET("/foo", ApiVersion.v1).then((result) => {
+      // @ts-ignore
+      expect(result.unwrap().message).toEqual("There was an unknown error performing the operation.");
+      expect(result.getEtag()).toBeNull();
+      expect(result.getStatusCode()).toEqual(500);
+      done();
+    }, () => {
+      done.fail("should have passed");
+    });
+  });
+
+  it("should map a successful response", (done) => {
+    mockSuccessfulRequest();
+    ApiRequestBuilder.GET("/foo", ApiVersion.v1)
+      .then((result) => {
+        return result.map((success) => JSON.parse(success));
+      }, () => done.fail("should have passed"))
+      .then((value) => {
+        // @ts-ignore
+        expect(value.unwrap().body.foo).toEqual("bar");
+        done();
+      }, () => done.fail("should have passed"));
+  });
+
+  it("should getOrThrow()", (done) => {
+    mockSuccessfulRequest();
+    ApiRequestBuilder.GET("/foo", ApiVersion.v1)
+      .then((value) => {
+        expect(value.getOrThrow()).toEqual(JSON.stringify({foo: "bar"}));
+        done();
+      }, () => done.fail("should have passed"));
+
+    mockInternalServerError();
+    ApiRequestBuilder.GET("/foo", ApiVersion.v1)
+      .then((result) => result.getOrThrow(), () => done.fail("should have passed"))
+      .then(() => done.fail("should have failed"), () => done());
+  });
+
+  function mockSuccessfulRequest() {
+    return jasmine.Ajax.stubRequest("/foo", undefined, "GET").andReturn({
+      responseText: JSON.stringify({foo: "bar"}),
+      status: 200,
+      responseHeaders: {
+        "Content-Type": contentType,
+        "Etag": "etag-value"
+      }
+    });
+  }
+
+  function mockSuccessfulCreatedRequest() {
+    return jasmine.Ajax.stubRequest("/foo", undefined, "POST").andReturn({
+      responseText: JSON.stringify({foo: "bar"}),
+      status: 201,
+      responseHeaders: {
+        "Content-Type": contentType,
+        "Etag": "etag-value"
+      }
+    });
+  }
+
+  function mockValidationFailedRequest() {
+    return jasmine.Ajax.stubRequest("/foo", undefined, "PUT").andReturn({
+      responseText: JSON.stringify({data: {message: "validation failed"}}),
+      status: 422,
+      responseHeaders: {
+        "Content-Type": contentType,
+      }
+    });
+  }
+
+  function mockInternalServerError() {
+    return jasmine.Ajax.stubRequest("/foo", undefined, "GET").andReturn({
+      responseText: "Message from nginx",
+      status: 500,
+      responseHeaders: {
+        "Content-Type": "text/html",
+      }
+    });
+  }
+});

--- a/server/webapp/WEB-INF/rails/webpack/models/config_repos/config_repos_crud.ts
+++ b/server/webapp/WEB-INF/rails/webpack/models/config_repos/config_repos_crud.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {ApiRequestBuilder, ApiVersion, HttpResponseWithEtag} from "helpers/api_request_builder";
+import {ApiRequestBuilder, ApiResult, ApiVersion, ObjectWithEtag} from "helpers/api_request_builder";
 import SparkRoutes from "helpers/spark_routes";
 import {ConfigRepo, ConfigRepos} from "./types";
 
@@ -23,34 +23,34 @@ export class ConfigReposCRUD {
 
   static all() {
     return ApiRequestBuilder.GET(SparkRoutes.apiConfigReposInternalPath(), this.API_VERSION_HEADER)
-      .then((xhr: XMLHttpRequest) => JSON.parse(xhr.responseText) as ConfigRepos);
+      .then((result: ApiResult<string>) => result.map((body) => JSON.parse(body) as ConfigRepos));
   }
 
   static get(id: string) {
     return ApiRequestBuilder.GET(SparkRoutes.ApiConfigRepoPath(id), this.API_VERSION_HEADER)
-      .then(this.extractResponseWithEtag());
+      .then(this.extractObjectWithEtag());
   }
 
-  static update(response: HttpResponseWithEtag<ConfigRepo>) {
+  static update(response: ObjectWithEtag<ConfigRepo>) {
     return ApiRequestBuilder.PUT(SparkRoutes.ApiConfigRepoPath(response.object.id), this.API_VERSION_HEADER, response.object, response.etag)
-      .then(this.extractResponseWithEtag());
+      .then(this.extractObjectWithEtag());
   }
 
   static delete(repo: ConfigRepo) {
     return ApiRequestBuilder.DELETE(SparkRoutes.ApiConfigRepoPath(repo.id), this.API_VERSION_HEADER)
-      .then((xhr: XMLHttpRequest) => JSON.parse(xhr.responseText));
+      .then((result: ApiResult<string>) => result.map((body) => JSON.parse(body)));
   }
 
   static create(repo: ConfigRepo) {
-    return ApiRequestBuilder.POST(SparkRoutes.ApiConfigReposListPath(), this.API_VERSION_HEADER, repo).then(this.extractResponseWithEtag());
+    return ApiRequestBuilder.POST(SparkRoutes.ApiConfigReposListPath(), this.API_VERSION_HEADER, repo).then(this.extractObjectWithEtag());
   }
 
-  private static extractResponseWithEtag() {
-    return (xhr: XMLHttpRequest) => {
-      return {
-        object: JSON.parse(xhr.responseText) as ConfigRepo,
-        etag: xhr.getResponseHeader("etag")
-      } as HttpResponseWithEtag<ConfigRepo>;
+  private static extractObjectWithEtag() {
+    return (result: ApiResult<string>) => {
+      return result.map((body) => {
+        const configRepo = JSON.parse(body) as ConfigRepo;
+        return {object: configRepo, etag: result.getEtag()} as ObjectWithEtag<ConfigRepo>;
+      });
     };
   }
 }

--- a/server/webapp/WEB-INF/rails/webpack/models/shared/plugin_infos_new/plugin_info_crud.ts
+++ b/server/webapp/WEB-INF/rails/webpack/models/shared/plugin_infos_new/plugin_info_crud.ts
@@ -15,7 +15,7 @@
  */
 
 import * as Routes from "gen/ts-routes";
-import {ApiRequestBuilder, ApiVersion} from "helpers/api_request_builder";
+import {ApiRequestBuilder, ApiResult, ApiVersion} from "helpers/api_request_builder";
 import {ExtensionType} from "models/shared/plugin_infos_new/extension_type";
 import {Extension} from "models/shared/plugin_infos_new/extensions";
 import {PluginInfo} from "models/shared/plugin_infos_new/plugin_info";
@@ -28,11 +28,13 @@ export interface PluginInfoQuery {
 export class PluginInfoCRUD {
   private static API_VERSION_HEADER = ApiVersion.v4;
 
-  static all(options: PluginInfoQuery): Promise<Array<PluginInfo<Extension>>> {
+  static all(options: PluginInfoQuery): Promise<ApiResult<Array<PluginInfo<Extension>>>> {
     return ApiRequestBuilder.GET(Routes.apiv4AdminPluginInfoIndexPath(options), this.API_VERSION_HEADER)
-      .then((xhr: XMLHttpRequest) => {
-        const data = JSON.parse(xhr.responseText);
-        return data._embedded.plugin_info.map((pluginInfo: any) => PluginInfo.fromJSON(pluginInfo, pluginInfo._links));
+      .then((result: ApiResult<string>) => {
+        return result.map((str) => {
+          const data = JSON.parse(str);
+          return data._embedded.plugin_info.map((pluginInfo: any) => PluginInfo.fromJSON(pluginInfo, pluginInfo._links));
+        });
       });
   }
 }

--- a/server/webapp/WEB-INF/rails/webpack/models/shared/usage_data_reporter.ts
+++ b/server/webapp/WEB-INF/rails/webpack/models/shared/usage_data_reporter.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {ApiRequestBuilder} from "helpers/api_request_builder";
+import {ApiRequestBuilder, ApiResult} from "helpers/api_request_builder";
 import * as _ from "lodash";
 import {DataReporting} from "./data_sharing/data_reporting";
 import {EncryptedData, EncryptionKeys, UsageData} from "./data_sharing/usage_data";
@@ -22,13 +22,14 @@ import {EncryptedData, EncryptionKeys, UsageData} from "./data_sharing/usage_dat
 const USAGE_DATA_LAST_REPORTED_TIME_KEY = "last_usage_data_reporting_check_time";
 
 const fetchEncryptionKeysFromDataSharingServer = (url: string) => {
-  return ApiRequestBuilder.GET(url).then((xhr: XMLHttpRequest) => {
-    return JSON.parse(xhr.responseText) as EncryptionKeys;
+  return ApiRequestBuilder.GET(url).then((result: ApiResult<string>) => {
+    return result.map((text) => JSON.parse(text) as EncryptionKeys).getOrThrow();
   });
 };
 
 const reportToGoCDDataSharingServer = (url: string, payload: EncryptedData) => {
-  return ApiRequestBuilder.POST(url, undefined, payload, {contentType: "application/octet-stream"});
+  return ApiRequestBuilder.POST(url, undefined, payload, {contentType: "application/octet-stream"})
+    .then((result: ApiResult<string>) => result.getOrThrow());
 };
 
 const canTryToReportingUsageData = (): boolean => {

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/page.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/page.tsx
@@ -20,13 +20,13 @@ import {HeaderPanel} from "views/components/header_panel";
 import {PageLoadError} from "views/components/page_load_error";
 import {Spinner} from "views/components/spinner";
 
-enum PageState {
+export enum PageState {
   LOADING, OK, FAILED
 }
 
 export abstract class Page<Attrs = {}, State = {}> extends MithrilComponent<Attrs, State> {
 
-  private pageState: PageState = PageState.LOADING;
+  protected pageState: PageState = PageState.LOADING;
 
   abstract componentToDisplay(vnode: m.Vnode<Attrs, State>): JSX.Element | undefined;
 
@@ -60,6 +60,10 @@ export abstract class Page<Attrs = {}, State = {}> extends MithrilComponent<Attr
 
   protected headerPanel(vnode: m.Vnode<Attrs, State>) {
     return <HeaderPanel title={this.pageName()}/>;
+  }
+
+  protected setErrorState() {
+    this.pageState = PageState.FAILED;
   }
 
   private _onSuccess() {

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/plugins.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/plugins.tsx
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import {ApiResult} from "helpers/api_request_builder";
 import * as m from "mithril";
 import {Extension} from "models/shared/plugin_infos_new/extensions";
 import {PluginInfo} from "models/shared/plugin_infos_new/plugin_info";
@@ -40,7 +41,10 @@ export class PluginsPage extends Page {
     return PluginInfoCRUD.all({include_bad: true}).then(this.onSuccess.bind(this));
   }
 
-  private onSuccess(pluginInfos: Array<PluginInfo<Extension>>) {
-    this.pluginInfos = pluginInfos;
+  private onSuccess(pluginInfos: ApiResult<Array<PluginInfo<Extension>>>) {
+    pluginInfos.do(
+      (successResponse) => this.pluginInfos = successResponse.body,
+      () => this.setErrorState()
+    );
   }
 }


### PR DESCRIPTION
Epic #5232 

This changes the contract of the API calls to always return a `Promise<ApiResult<T>>`. The ApiResult can either be a success or error. If the Promise is rejected, the `catch` block in the `ApiRequestBuilder` will handle it, and as such, consumers of the `ApiRequestBuilder` can assume that they don't need to add a `catch` of their own in most circumstances.

The `ApiResult` class exposes a functional interface, similar to `Either` and `Result` used in FP.