### PR TITLE
Ship the windows installer with OpenJDK instead of Oracle's JRE 8

### DIFF
--- a/installers/windows-shared/JavaHome.ini
+++ b/installers/windows-shared/JavaHome.ini
@@ -8,7 +8,7 @@ Right=-5
 Top=10
 Bottom=20
 State=1
-Text=" Use bundled JRE (Oracle JRE 8) "
+Text=" Use bundled Java (OpenJDK)"
 Flags=NOTIFY
 
 [Field 2]

--- a/installers/windows-shared/windows-installer-base.nsi
+++ b/installers/windows-shared/windows-installer-base.nsi
@@ -226,6 +226,7 @@ Section "Install"
     upgrade:
         ; Don't do anything special anymore - upgrade logic is now in code. Do the same as we would for an install.
     RMDir /r $INSTDIR\lib
+    RMDir /r $INSTDIR\jre
 
     install:
         SetOverWrite on

--- a/installers/windows.gradle
+++ b/installers/windows.gradle
@@ -18,21 +18,6 @@
 import com.thoughtworks.go.build.WindowsPackagingTask
 import org.apache.tools.ant.filters.FixCrLfFilter
 
-task agentWindows32bitExe(type: WindowsPackagingTask) {
-  dependsOn configurations.agentBootstrapperJar
-  group project.name
-  description 'Build the go-agent windows installer'
-
-  packageName 'go-agent'
-  version rootProject.goVersion
-  distVersion rootProject.distVersion
-  is32Bit true
-
-  beforePackage {
-    copyAgentSpecificFiles(versionedDir(), buildRoot(), flavour())
-  }
-}
-
 task agentWindows64bitExe(type: WindowsPackagingTask) {
   dependsOn configurations.agentBootstrapperJar
   group project.name
@@ -41,25 +26,9 @@ task agentWindows64bitExe(type: WindowsPackagingTask) {
   packageName 'go-agent'
   version rootProject.goVersion
   distVersion rootProject.distVersion
-  is32Bit false
 
   beforePackage {
     copyAgentSpecificFiles(versionedDir(), buildRoot(), flavour())
-  }
-}
-
-task serverWindows32bitExe(type: WindowsPackagingTask) {
-  dependsOn configurations.serverJar
-  group project.name
-  description 'Build the go-server windows installer'
-
-  packageName 'go-server'
-  version rootProject.goVersion
-  distVersion rootProject.distVersion
-  is32Bit true
-
-  beforePackage {
-    copyServerSpecificFiles(versionedDir(), buildRoot(), flavour())
   }
 }
 
@@ -71,7 +40,6 @@ task serverWindows64bitExe(type: WindowsPackagingTask) {
   packageName 'go-server'
   version rootProject.goVersion
   distVersion rootProject.distVersion
-  is32Bit false
 
   beforePackage {
     copyServerSpecificFiles(versionedDir(), buildRoot(), flavour())
@@ -132,4 +100,4 @@ private void copyCommonFiles(versionedDir, buildRoot, flavour) {
 }
 
 
-assemble.dependsOn(":installers:agentWindows32bitExe", ":installers:agentWindows64bitExe", ":installers:serverWindows32bitExe", ":installers:serverWindows64bitExe")
+assemble.dependsOn(":installers:agentWindows64bitExe", ":installers:serverWindows64bitExe")


### PR DESCRIPTION
* Do not support/fallback to oracle JRE.
* Create only 64-bit installers as openJDK (10 and following) does not ship 32-bit java

Screenshot:
<img width="557" alt="screen shot 2018-11-14 at 11 58 26 am" src="https://user-images.githubusercontent.com/15275847/48464259-fb64ca80-e804-11e8-8b7d-414157983e6b.png">
