### PR TITLE
Fix for ConfigRepo API update, fixes #5394

### DIFF
--- a/server/src/main/java/com/thoughtworks/go/server/service/ConfigRepoService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/ConfigRepoService.java
@@ -87,13 +87,8 @@ public class ConfigRepoService {
         update(username, configRepo.getId(), result, command);
     }
 
-    public void updateConfigRepo(String repoId, ConfigRepoConfig repo, Username user, HttpLocalizedOperationResult result) {
-        String md5 = entityHashingService.md5ForEntity(repo);
-        updateConfigRepo(repoId, repo, md5, user, result);
-    }
-
-    public void updateConfigRepo(String repoIdToUpdate, ConfigRepoConfig newConfigRepo, String md5, Username username, HttpLocalizedOperationResult result) {
-        UpdateConfigRepoCommand command = new UpdateConfigRepoCommand(securityService, entityHashingService, repoIdToUpdate, newConfigRepo, md5, username, result);
+    public void updateConfigRepo(String repoIdToUpdate, ConfigRepoConfig newConfigRepo, String md5OfExistingConfigRepo, Username username, HttpLocalizedOperationResult result) {
+        UpdateConfigRepoCommand command = new UpdateConfigRepoCommand(securityService, entityHashingService, repoIdToUpdate, newConfigRepo, md5OfExistingConfigRepo, username, result);
 
         update(username, newConfigRepo.getId(), result, command);
         if (result.isSuccessful()) {


### PR DESCRIPTION
* Moved to using ConfigRepo md5 as etag, to keep it consitent with
  other implementation.