### PR TITLE
Render the dashboard again after server comes out of maintainance mode (#5391)

### DIFF
--- a/server/webapp/WEB-INF/rails/webpack/single_page_apps/new_dashboard.js
+++ b/server/webapp/WEB-INF/rails/webpack/single_page_apps/new_dashboard.js
@@ -145,6 +145,13 @@ $(() => {
     };
 
     const onerror   = (jqXHR, textStatus, errorThrown) => {
+      // fix for issue #5391
+      //forcefully remove the ETag if server backup is in progress,
+      //so that on next dashboard request, the server will send a 200 and re-render the page
+      if (jqXHR.status === 503) {
+        dashboardVM.etag(null);
+      }
+
       if (textStatus === 'parsererror') {
         const message = {
           type:    "alert",


### PR DESCRIPTION
* Forcefully clear the dashboard cache if the server sends 503,
  so that on the next successful dashboard api response, the page can be re-rendered.