### PR TITLE
Fix dismissible flash message close button (#5232)

### DIFF
--- a/server/webapp/WEB-INF/rails/webpack/views/components/flash_message/index.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/components/flash_message/index.tsx
@@ -64,7 +64,7 @@ export class FlashMessage extends MithrilComponent<Attrs, State> {
     if (isDismissible) {
       closeButton = (
         <button className={classnames(styles.closeCallout)}>
-          <Icons.Close onclick={vnode.state.onDismiss}/>
+          <Icons.Close iconOnly={true} onclick={vnode.state.onDismiss}/>
         </button>
       );
     }

--- a/server/webapp/WEB-INF/rails/webpack/views/components/icons/index.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/components/icons/index.tsx
@@ -28,6 +28,7 @@ const classnames = bind(styles);
 export interface Attrs extends HTMLAttributes {
   onclick?: () => void;
   disabled?: boolean;
+  iconOnly?: boolean;
 }
 
 class Icon extends MithrilViewComponent<Attrs> {
@@ -41,6 +42,13 @@ class Icon extends MithrilViewComponent<Attrs> {
   }
 
   view(vnode: m.Vnode<Attrs>) {
+    if (vnode.attrs.iconOnly) {
+      return (
+        <i {...vnode.attrs} title={this.title}
+           className={classnames(this.name, {disabled: vnode.attrs.disabled})}/>
+      );
+    }
+
     return (
       <button title={this.title}
               className={(classnames(styles.btnIcon, {disabled: vnode.attrs.disabled}))}


### PR DESCRIPTION
* Render iconOnly instead of wrapping an icon inside a button

![screen shot 2018-11-19 at 2 08 02 pm](https://user-images.githubusercontent.com/15275847/48695210-90503500-ec04-11e8-885f-c59f0f91c7ac.png)
