### PR TITLE
Use Map for KeyValuePair data, and remove style class from attribute.

### DIFF
--- a/server/webapp/WEB-INF/rails/webpack/models/shared/plugin_infos_new/about.ts
+++ b/server/webapp/WEB-INF/rails/webpack/models/shared/plugin_infos_new/about.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import * as _ from "lodash";
+
 export class About {
   name: string;
   version: string;
@@ -22,7 +24,12 @@ export class About {
   targetOperatingSystems: string[];
   vendor: Vendor;
 
-  constructor(name: string, version: string, targetGoVersion: string, description: string, targetOperationSystems: string[], vendor: Vendor) {
+  constructor(name: string,
+              version: string,
+              targetGoVersion: string,
+              description: string,
+              targetOperationSystems: string[],
+              vendor: Vendor) {
     this.name                   = name;
     this.version                = version;
     this.targetGoVersion        = targetGoVersion;
@@ -34,6 +41,13 @@ export class About {
   static fromJSON(data: any) {
     return new About(data.name, data.version, data.target_go_version, data.description, data.target_operating_systems,
       Vendor.fromJSON(data.vendor));
+  }
+
+  targetOperatingSystemsDisplayValue(): string {
+    if (_.isEmpty(this.targetOperatingSystems)) {
+      return "No restrictions";
+    }
+    return _.join(this.targetOperatingSystems, ",");
   }
 }
 

--- a/server/webapp/WEB-INF/rails/webpack/models/shared/plugin_infos_new/plugin_info.ts
+++ b/server/webapp/WEB-INF/rails/webpack/models/shared/plugin_infos_new/plugin_info.ts
@@ -96,4 +96,13 @@ export class PluginInfo<T extends Extension> {
     }
     return "";
   }
+
+  supportsStatusReport() {
+    if (this.extensions) {
+      const elasticAgentExtensionInfo = this.extensionOfType(ExtensionType.ELASTIC_AGENTS);
+      // @ts-ignore
+      return elasticAgentExtensionInfo && elasticAgentExtensionInfo.capabilities && elasticAgentExtensionInfo.capabilities.supportsStatusReport;
+    }
+    return false;
+  }
 }

--- a/server/webapp/WEB-INF/rails/webpack/views/components/key_value_pair/index.scss
+++ b/server/webapp/WEB-INF/rails/webpack/views/components/key_value_pair/index.scss
@@ -21,7 +21,9 @@ $key-value-pair-width: 150px;
   padding:         0;
   margin:          0 0 $global-margin-bottom 0;
   list-style-type: none;
-
+  :last-child {
+    width: auto;
+  }
 }
 
 .key {
@@ -97,6 +99,7 @@ $key-value-pair-width: 150px;
   margin-right: 20px;
   border:       none;
   padding:      0;
+  width:        25vw;
   .key {
     width: auto;
   }

--- a/server/webapp/WEB-INF/rails/webpack/views/components/key_value_pair/index.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/components/key_value_pair/index.tsx
@@ -23,35 +23,24 @@ import * as styles from "./index.scss";
 const classnames = bind(styles);
 
 export interface Attrs {
-  // pass in an object if you do not care about order, pass an array of key-value pairs if you care about order
-  data: { [key: string]: m.Children } | m.Children[];
+  data: Map<string, string | JSX.Element>;
   inline?: boolean;
-  keyValuePairItemClass?: string;
 }
 
 export class KeyValuePair extends MithrilViewComponent<Attrs> {
   view(vnode: m.Vnode<Attrs>) {
     const isInline = vnode.attrs.inline;
+    const elements: JSX.Element[] = [];
+    vnode.attrs.data.forEach((value, key) => {
+      elements.push(<li className={classnames(styles.keyValueItem, {[styles.keyValueInlineItem]: isInline})} key={key}>
+        <label data-test-id={`key-value-key-${key}`} className={styles.key}>{key}</label>
+        <span data-test-id={`key-value-value-${key}`}
+              className={styles.value}>{KeyValuePair.renderedValue(value)}</span>
+      </li>);
+    });
     return (
       <ul className={classnames(styles.keyValuePair, {[styles.keyValuePairInline]: isInline})}>
-        {
-          _.map(vnode.attrs.data, (...args) => {
-            let value, key;
-            if (_.isArray(vnode.attrs.data)) {
-              [key, value] = args[0] as any[];
-            } else {
-              [value, key] = args;
-            }
-            return [
-              <li className={classnames(styles.keyValueItem, {[styles.keyValueInlineItem]: isInline}, vnode.attrs.keyValuePairItemClass)}
-                  key={key as string}>
-                <label data-test-id={`key-value-key-${key as string}`} className={styles.key}>{key}</label>
-                <span data-test-id={`key-value-value-${key as string}`}
-                      className={styles.value}>{KeyValuePair.renderedValue(value)}</span>
-              </li>
-            ];
-          })
-        }
+        {elements}
       </ul>
     );
   }

--- a/server/webapp/WEB-INF/rails/webpack/views/components/key_value_pair/spec/index_spec.js
+++ b/server/webapp/WEB-INF/rails/webpack/views/components/key_value_pair/spec/index_spec.js
@@ -47,11 +47,11 @@ describe("Key Value Pair Component", () => {
     m.mount(root, {
       view() {
         return m(KeyValuePair, {
-          data: {
-            'First Name': 'Jon',
-            'Last Name':  'Doe',
-            'email':      'jdoe@example.com',
-          }
+          data: new Map([
+            ['First Name', 'Jon'],
+            ['Last Name', 'Doe'],
+            ['email', 'jdoe@example.com'],
+          ])
         });
       }
     });

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/config_repos/config_repos_widget.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/config_repos/config_repos_widget.tsx
@@ -73,10 +73,10 @@ class HeaderWidget extends MithrilViewComponent<HeaderWidgetAttrs> {
     return [
       this.statusIcon(vnode),
       (
-        <KeyValuePair inline={true} data={[
+        <KeyValuePair inline={true} data={new Map([
           ["Id", vnode.attrs.repo.id],
           ["Plugin ID", vnode.attrs.repo.plugin_id]
-        ]}/>
+        ])}/>
       )
     ];
   }
@@ -115,7 +115,7 @@ class HeaderWidget extends MithrilViewComponent<HeaderWidgetAttrs> {
 class ConfigRepoWidget extends MithrilViewComponent<ShowObjectAttrs<ConfigRepo>> {
   view(vnode: m.Vnode<ShowObjectAttrs<ConfigRepo>>): m.Children | void | null {
 
-    const filteredAttributes = _.reduce(vnode.attrs.obj.material.attributes, (accumulator: any,
+    const filteredAttributes = _.reduce(vnode.attrs.obj.material.attributes, (accumulator: Map<string, string>,
                                                                               value: any,
                                                                               key: string) => {
       let renderedValue = value;
@@ -125,10 +125,9 @@ class ConfigRepoWidget extends MithrilViewComponent<ShowObjectAttrs<ConfigRepo>>
       if (_.isString(value) && value.startsWith("AES:")) {
         renderedValue = "******";
       }
-
-      accumulator[renderedKey] = renderedValue;
+      accumulator.set(renderedKey, renderedValue);
       return accumulator;
-    }, {});
+    }, new Map<string, string>());
 
     const refreshButton = (
       <Refresh data-test-id="config-repo-refresh" onclick={vnode.attrs.onRefresh.bind(vnode.attrs)}/>

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/kitchen_sink.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/kitchen_sink.tsx
@@ -117,21 +117,23 @@ export class KitchenSink extends MithrilViewComponent<null> {
         <h3>Some examples of accordions</h3>
 
         <h3>Some examples of key value pairs</h3>
-        <KeyValuePair data={
-          {
-            "First Name": "Jon",
-            "Last Name": "Doe",
-            "email": "jdoe@example.com",
-            "some really really really really really long key": "This is really really really really really really really really really really long junk value"
-          }
+        <KeyValuePair data={new Map(
+          [
+            ["First Name", "Jon"],
+            ["Last Name", "Doe"],
+            ["email", "jdoe@example.com"],
+            ["some really really really really really long key", "This is really really really really really really really really really really long junk value"]
+          ])
         }/>
 
         <h3>Some examples of inline key value pairs</h3>
-        <KeyValuePair inline={true} data={
-          {
-            "Plugin": "my-fancy-plugin-name",
-            "some really really really really really long key": "This is really really really really really really really really really really long junk value"
-          }
+        <KeyValuePair inline={true} data={new Map(
+          [
+            ["Plugin", "my-fancy-plugin-name"],
+            ["some really really really really really long key", "This is really really really really really really really really really really long junk value"],
+            ["Instructions", "Run a manual sweep of anomalous airborne or electromagnetic readings. Radiation levels in our atmosphere have increased by 3,000 percent."],
+            ["Version", "3.11 for workgroups"]
+          ])
         }/>
 
         <h3>Forms</h3>

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/new_plugins/index.scss
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/new_plugins/index.scss
@@ -67,8 +67,3 @@ $plugin-row-element-width: 350px;
 .plugins-list {
   display: block;
 }
-
-.plugin-metadata-header {
-  max-width: $plugin-row-element-width;
-  min-width: $plugin-row-element-width;
-}

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/new_plugins/index.scss.d.ts
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/new_plugins/index.scss.d.ts
@@ -7,4 +7,3 @@ export const unknownPluginIcon: string;
 export const pluginsPage: string;
 export const keyValuePairInline: string;
 export const pluginsList: string;
-export const pluginMetadataHeader: string;

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/new_plugins/spec/plugins_widget_spec.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/new_plugins/spec/plugins_widget_spec.tsx
@@ -19,8 +19,8 @@ import {PluginInfo} from "models/shared/plugin_infos_new/plugin_info";
 import * as styles from "../index.scss";
 import {PluginsWidget} from "../plugins_widget";
 
-import * as collapsiblePanelStyles from "../../../components/collapsible_panel/index.scss";
-import * as keyValuePairStyles from "../../../components/key_value_pair/index.scss";
+import * as collapsiblePanelStyles from "views/components/collapsible_panel/index.scss";
+import * as keyValuePairStyles from "views/components/key_value_pair/index.scss";
 
 describe("New Plugins Widget", () => {
   const simulateEvent = require("simulate-event");


### PR DESCRIPTION
Changed the KeyValuePair data to use a [Map](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map) object, to make it consistent. Maps retain the insertion order while iterating.

Changed the alignment to use a viewport width measurement, instead of injecting the style from the outside. We can possibly use a Grid layout in the future if we make one.