### PR TITLE
Fix data sharing

### DIFF
--- a/server/webapp/WEB-INF/rails/webpack/models/shared/usage_data_reporter.ts
+++ b/server/webapp/WEB-INF/rails/webpack/models/shared/usage_data_reporter.ts
@@ -28,7 +28,7 @@ const fetchEncryptionKeysFromDataSharingServer = (url: string) => {
 };
 
 const reportToGoCDDataSharingServer = (url: string, payload: EncryptedData) => {
-  return ApiRequestBuilder.POST(url, undefined, {payload, headers: {contentType: "application/octet-stream"}})
+  return ApiRequestBuilder.POST(url, undefined, {payload})
     .then((result: ApiResult<string>) => result.getOrThrow());
 };
 


### PR DESCRIPTION
* Content Type header was sent as 'contentType' instead of 'content-type',
  which cause the preflight check to fail.
  As on usage-data-collector-app, the whitelisted headers are 'content-type',
  'if-match', 'if-none-match' and 'x-gocd-confirm'.
  Any other request header will cause the preflight check to fail.

* Secondly, 'content-type' of the POST request should be 'application/json'
  instead of 'application/octet-stream'. As '/v2/usagedata' endpoint accepts
  json payload.
  This was broken after moving to ApiRequestBuilder from AJAXHelper.
  AjaxHelper used to send the request header as 'application/json' if the
  request payload is provided (regardless of externally passed headers).
  Whereas, ApiRequestBuilder honors the user provided request headers.

More Information:
	https://github.com/gocd-private/usage-data-collector-app/blob/master/template.yaml#L11
