### PR TITLE
Fixes for plugin_settings

### DIFF
--- a/server/webapp/WEB-INF/rails/webpack/models/shared/plugin_infos_new/plugin_settings/plugin_settings.ts
+++ b/server/webapp/WEB-INF/rails/webpack/models/shared/plugin_infos_new/plugin_settings/plugin_settings.ts
@@ -19,7 +19,9 @@ import {Validatable} from "models/mixins/validatable";
 
 export interface ConfigValue {
   getValue(): string;
+
   setValue(value: string): void;
+
   isEncrypted(): boolean;
 }
 
@@ -98,6 +100,9 @@ export class Configuration {
   }
 
   set value(val: string) {
+    if (val === this._value.getValue()) {
+      return;
+    }
     this._value = new PlainTextValue(val);
   }
 

--- a/server/webapp/WEB-INF/rails/webpack/models/shared/plugin_infos_new/plugin_settings/plugin_settings_crud.ts
+++ b/server/webapp/WEB-INF/rails/webpack/models/shared/plugin_infos_new/plugin_settings/plugin_settings_crud.ts
@@ -32,7 +32,7 @@ export class PluginSettingsCRUD {
   }
 
   static create(pluginSettings: PluginSettings) {
-    return ApiRequestBuilder.POST(Routes.apiv1AdminPluginSettingsPath(), this.API_VERSION_HEADER, pluginSettings.toJSON())
+    return ApiRequestBuilder.POST(Routes.apiv1AdminPluginSettingsPath(), this.API_VERSION_HEADER, {payload: pluginSettings.toJSON()})
       .then(this.extractObjectWithEtag());
   }
 

--- a/server/webapp/WEB-INF/rails/webpack/models/shared/plugin_infos_new/plugin_settings/spec/plugin_settings_spec.ts
+++ b/server/webapp/WEB-INF/rails/webpack/models/shared/plugin_infos_new/plugin_settings/spec/plugin_settings_spec.ts
@@ -122,11 +122,12 @@ describe("Plugin Settings", () => {
     });
   });
 
-  it("should send 'encrypted_value' as the key when the value hasn't changed", () => {
+  it("should send 'encrypted_value' as the key when the value hasn't changed, even if the setter is called", () => {
     const configuration  = [
       new Configuration("secret", new EncryptedValue("hidden-value"))
     ];
     const pluginSettings = new PluginSettings("com.thoughtworks.gocd.test", configuration);
+    pluginSettings.configuration[0].value = "hidden-value";
     expect(pluginSettings.toJSON()).toEqual({
       plugin_id: "com.thoughtworks.gocd.test",
       configuration: [


### PR DESCRIPTION
Fix plugin_settings POST payload. Send encrypted value only when it is changed.

Fixes #5424