### PR TITLE
Add babel-polyfill on new pages

### DIFF
--- a/server/src/main/java/com/thoughtworks/go/server/service/WebpackAssetsService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/WebpackAssetsService.java
@@ -77,13 +77,13 @@ public class WebpackAssetsService implements ServletContextAware {
     public Set<String> getJSAssetPathsFor(String... assetNames) throws IOException {
         return getAssetPathsFor(assetNames).stream()
                 .filter(assetName -> assetName.endsWith(".js"))
-                .collect(Collectors.toSet());
+                .collect(Collectors.toCollection(LinkedHashSet::new));
     }
 
     public Set<String> getCSSAssetPathsFor(String... assetNames) throws IOException {
         return getAssetPathsFor(assetNames).stream()
                 .filter(assetName -> assetName.endsWith(".css"))
-                .collect(Collectors.toSet());
+                .collect(Collectors.toCollection(LinkedHashSet::new));
     }
 
     private Map getManifest() throws IOException {

--- a/server/webapp/WEB-INF/rails/webpack/helpers/spa_base.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/helpers/spa_base.tsx
@@ -24,6 +24,8 @@ import {ModalManager} from "views/components/modal/modal_manager";
 import {Attrs as SiteFooterAttrs, SiteFooter} from "views/pages/partials/site_footer";
 import {Attrs as SiteHeaderAttrs, SiteHeader} from "views/pages/partials/site_header";
 
+const VersionUpdater = require('models/shared/version_updater');
+
 interface Attrs {
   headerData: SiteHeaderAttrs;
   footerData: SiteFooterAttrs;
@@ -65,6 +67,7 @@ export default abstract class Page {
     const page = this;
     window.addEventListener("DOMContentLoaded", () => {
       UsageDataReporter.report();
+      new VersionUpdater().update();
 
       const body: Element = document.querySelector("body") as Element;
 

--- a/server/webapp/WEB-INF/rails/webpack/single_page_apps/polyfill.js
+++ b/server/webapp/WEB-INF/rails/webpack/single_page_apps/polyfill.js
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2018 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+require('babel-polyfill');

--- a/spark/spark-spa/src/main/resources/velocity/layouts/component_layout.vm
+++ b/spark/spark-spa/src/main/resources/velocity/layouts/component_layout.vm
@@ -30,7 +30,7 @@
       <link href="${css}" media="screen" rel="stylesheet"/>
     #end
 
-    #foreach( $js in ${webpackAssetsService.getJSAssetPathsFor("single_page_apps/${controllerName}", "single_page_apps/polyfill")})
+    #foreach( $js in ${webpackAssetsService.getJSAssetPathsFor("single_page_apps/polyfill", "single_page_apps/${controllerName}")})
       <script src="${js}"></script>
     #end
 

--- a/spark/spark-spa/src/main/resources/velocity/layouts/component_layout.vm
+++ b/spark/spark-spa/src/main/resources/velocity/layouts/component_layout.vm
@@ -30,7 +30,7 @@
       <link href="${css}" media="screen" rel="stylesheet"/>
     #end
 
-    #foreach( $js in ${webpackAssetsService.getJSAssetPathsFor("single_page_apps/${controllerName}")})
+    #foreach( $js in ${webpackAssetsService.getJSAssetPathsFor("single_page_apps/${controllerName}", "single_page_apps/polyfill")})
       <script src="${js}"></script>
     #end
 

--- a/spark/spark-spa/src/main/resources/velocity/layouts/single_page_app.vm
+++ b/spark/spark-spa/src/main/resources/velocity/layouts/single_page_app.vm
@@ -36,7 +36,7 @@
     <link href="${css}" media="screen" rel="stylesheet"/>
   #end
 
-  #foreach( $js in ${webpackAssetsService.getJSAssetPathsFor("single_page_apps/${controllerName}", "single_page_apps/spa_commons")})
+  #foreach( $js in ${webpackAssetsService.getJSAssetPathsFor("single_page_apps/spa_commons", "single_page_apps/${controllerName}")})
     <script src="${js}"></script>
   #end
 </head>


### PR DESCRIPTION
* Fixes the issue with the new pages not loading up on IE 11.
* Sets the order of the imports so that polyfill is always included before the app code.

Epic: #5232 
Bug reported in: #5401 