### PR TITLE
Do not allow creation, modification and deletion of GoCD entities during server drain mode (#5450)

### DIFF
--- a/server/src/main/java/com/thoughtworks/go/server/newsecurity/filters/helpers/ServerUnavailabilityResponse.java
+++ b/server/src/main/java/com/thoughtworks/go/server/newsecurity/filters/helpers/ServerUnavailabilityResponse.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2018 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.server.newsecurity.filters.helpers;
+
+import com.google.gson.JsonObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class ServerUnavailabilityResponse {
+    public final String JSON = "json";
+    public final String XML = "xml";
+
+    private final static Logger LOGGER = LoggerFactory.getLogger(ServerUnavailabilityResponse.class);
+    public static final Pattern PATTERN = Pattern.compile("^((.*/api/.*)|(.*[^/]+\\.(xml|json)(\\?.*)?))$");
+
+    private final HttpServletRequest request;
+    private final HttpServletResponse response;
+    private final String jsonMessage;
+    private final String htmlResponse;
+
+    public ServerUnavailabilityResponse(HttpServletRequest request,
+                                        HttpServletResponse response,
+                                        String jsonMessage,
+                                        String htmlResponse) {
+        this.request = request;
+        this.response = response;
+        this.jsonMessage = jsonMessage;
+        this.htmlResponse = htmlResponse;
+    }
+
+    public void render() {
+        String requestURL = request.getRequestURI();
+
+        response.setHeader("Cache-Control", "private, max-age=0, no-cache");
+        response.setDateHeader("Expires", 0);
+
+        if (isAPIUrl(requestURL) && !isMessagesJson(requestURL)) {
+            generateAPIResponse();
+        } else {
+            generateHTMLResponse();
+        }
+
+        response.setStatus(HttpServletResponse.SC_SERVICE_UNAVAILABLE);
+    }
+
+    private void generateAPIResponse() {
+
+        try {
+            HttpServletRequest httpRequest = request;
+
+            if (requestIsOfType(JSON, httpRequest)) {
+                response.setContentType("application/json");
+                JsonObject jsonObject = new JsonObject();
+                jsonObject.addProperty("message", jsonMessage);
+                response.getWriter().print(jsonObject);
+            } else if (requestIsOfType(XML, httpRequest)) {
+                response.setContentType("application/xml");
+                String xml = String.format("<message> %s </message>", jsonMessage);
+                response.getWriter().print(xml);
+            } else {
+                generateHTMLResponse();
+            }
+
+        } catch (IOException e) {
+            LOGGER.error("General IOException: {}", e.getMessage());
+        }
+    }
+
+    private void generateHTMLResponse() {
+        response.setContentType("text/html");
+        response.setCharacterEncoding("utf-8");
+        try {
+            response.getWriter().print(htmlResponse);
+        } catch (IOException e) {
+            LOGGER.error("General IOException: {}", e.getMessage());
+        }
+    }
+
+    private boolean requestIsOfType(String type, HttpServletRequest request) {
+        String header = request.getHeader("Accept");
+        String contentType = request.getContentType();
+        String url = request.getRequestURI();
+        return header != null && header.contains(type) || url != null && url.endsWith(type) || contentType != null && contentType.contains(type);
+    }
+
+    private boolean isAPIUrl(String url) {
+        Matcher matcher = PATTERN.matcher(url);
+        return matcher.matches();
+    }
+
+    private boolean isMessagesJson(String url) {
+        return "/go/server/messages.json".equals(url);
+    }
+}

--- a/server/src/main/java/com/thoughtworks/go/server/service/DrainModeService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/DrainModeService.java
@@ -41,4 +41,8 @@ public class DrainModeService {
         LOGGER.debug("[Drain Mode] Server drain mode state updated to 'isDrained={}' by '{}' at '{}'.", fromRequest.isDrainMode(), fromRequest.updatedBy(), fromRequest.updatedOn());
         this.drainMode = fromRequest;
     }
+
+    public boolean isDrainMode() {
+        return get().isDrainMode();
+    }
 }

--- a/server/src/main/resources/server_in_drain_mode.html
+++ b/server/src/main/resources/server_in_drain_mode.html
@@ -1,0 +1,91 @@
+﻿<!--
+  ~ Copyright 2018 ThoughtWorks, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+
+<html>
+<head>
+    <title>Drain Mode</title>
+    <style type="text/css">
+        #header {
+            background: url('/go/static/images/bg_header_default.png') repeat-x 0 0 transparent;
+            color: #FFF;
+            font-size: 11px;
+            border-bottom: 1px solid #333;
+            left: 0;
+            position: fixed;
+            z-index: 1001;
+            right: 0;
+            top: 0;
+        }
+
+        #header, #body, #footer {
+            clear: both;
+        }
+
+        #header .header {
+            background: #333333; /* Old browsers */
+            /* IE9 SVG, needs conditional override of 'filter' to 'none' */
+            background: -moz-linear-gradient(top, #333333 0%, #0f0f0f 100%); /* FF3.6+ */
+            background: -webkit-gradient(linear, left top, left bottom, color-stop(0%, #333333), color-stop(100%, #0f0f0f)); /* Chrome,Safari4+ */
+            background: -webkit-linear-gradient(top, #333333 0%, #0f0f0f 100%); /* Chrome10+,Safari5.1+ */
+            background: -o-linear-gradient(top, #333333 0%, #0f0f0f 100%); /* Opera 11.10+ */
+            background: -ms-linear-gradient(top, #333333 0%, #0f0f0f 100%); /* IE10+ */
+            background: linear-gradient(to bottom, #333333 0%, #0f0f0f 100%); /* W3C */
+            padding: 5px 15px;
+        }
+
+        .header #application_logo {
+            background-image: url("/go/static/images/logo_go.png");
+            background-position: 0 4px;
+            background-repeat: no-repeat;
+            float: left;
+            height: 35px;
+            width: 114px;
+        }
+
+        .message {
+            margin: 10px;
+            float: left;
+            font-size: 11px;
+            font-weight: 200;
+            color: #999;
+            font-family: Arial,​ Helvetica,​ sans-serif;
+        }
+
+        .clear_float::after {
+            clear: both;
+            content: ".";
+            display: block;
+            height: 0;
+            visibility: hidden;
+        }
+
+    </style>
+</head>
+<body>
+<div id="body_bg">
+    <div id="header">
+        <div class="header clear_float">
+            <a href="#" id="application_logo">&nbsp;</a>
+
+            <div class="message">GoCD Server is under drain mode. Learn more...</span>'
+            </div>
+        </div>
+    </div>
+</div>
+</body>
+</html>


### PR DESCRIPTION
* Disallow POSTs, PUTs and DELETEs request from ModeAwareFilter if the server is in drain mode
* Allow Stage cancel API during server drain mode.
* Render JSON-503 response for API calls.
* Render HTML-503 response for Page Posts.

---
* Created a `ServerUnavailabilityResponse` Helper to send an HTML or JSON response based on the request (either API or GoCD page).
* Extracted helper, which is used by `BackupFilter` and `ModeAwareFilter` to avoid code duplication.
