### PR TITLE
Do not assign scheduled jobs to agents during server drain mode (#5190)

### DIFF
--- a/server/src/main/java/com/thoughtworks/go/server/service/BuildAssignmentService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/BuildAssignmentService.java
@@ -68,6 +68,7 @@ public class BuildAssignmentService implements ConfigChangedListener {
     private final UpstreamPipelineResolver resolver;
     private final BuilderFactory builderFactory;
     private AgentRemoteHandler agentRemoteHandler;
+    private DrainModeService drainModeService;
     private final ElasticAgentPluginService elasticAgentPluginService;
     private final SystemEnvironment systemEnvironment;
 
@@ -75,7 +76,7 @@ public class BuildAssignmentService implements ConfigChangedListener {
     public BuildAssignmentService(GoConfigService goConfigService, JobInstanceService jobInstanceService, ScheduleService scheduleService,
                                   AgentService agentService, EnvironmentConfigService environmentConfigService,
                                   TransactionTemplate transactionTemplate, ScheduledPipelineLoader scheduledPipelineLoader, PipelineService pipelineService, BuilderFactory builderFactory,
-                                  AgentRemoteHandler agentRemoteHandler,
+                                  AgentRemoteHandler agentRemoteHandler, DrainModeService drainModeService,
                                   ElasticAgentPluginService elasticAgentPluginService, SystemEnvironment systemEnvironment) {
         this.goConfigService = goConfigService;
         this.jobInstanceService = jobInstanceService;
@@ -87,6 +88,7 @@ public class BuildAssignmentService implements ConfigChangedListener {
         this.resolver = pipelineService;
         this.builderFactory = builderFactory;
         this.agentRemoteHandler = agentRemoteHandler;
+        this.drainModeService = drainModeService;
         this.elasticAgentPluginService = elasticAgentPluginService;
         this.systemEnvironment = systemEnvironment;
     }
@@ -198,6 +200,11 @@ public class BuildAssignmentService implements ConfigChangedListener {
     }
 
     public void onTimer() {
+        if (drainModeService.isDrainMode()) {
+            LOGGER.debug("[Drain Mode] GoCD server is in 'drain' mode, skip checking build assignments");
+            return;
+        }
+
         reloadJobPlans();
         matchingJobForRegisteredAgents();
     }

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/BuildAssignmentServiceIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/BuildAssignmentServiceIntegrationTest.java
@@ -45,6 +45,7 @@ import com.thoughtworks.go.server.dao.DatabaseAccessHelper;
 import com.thoughtworks.go.server.dao.JobInstanceDao;
 import com.thoughtworks.go.server.dao.PipelineDao;
 import com.thoughtworks.go.server.dao.StageDao;
+import com.thoughtworks.go.server.domain.ServerDrainMode;
 import com.thoughtworks.go.server.domain.Username;
 import com.thoughtworks.go.server.materials.DependencyMaterialUpdateNotifier;
 import com.thoughtworks.go.server.persistence.MaterialRepository;
@@ -117,6 +118,7 @@ public class BuildAssignmentServiceIntegrationTest {
     @Autowired private PipelineConfigService pipelineConfigService;
     @Autowired private ElasticAgentPluginService elasticAgentPluginService;
     @Autowired private DependencyMaterialUpdateNotifier notifier;
+    @Autowired private DrainModeService drainModeService;
 
     private PipelineConfig evolveConfig;
     private static final String STAGE_NAME = "dev";
@@ -148,6 +150,7 @@ public class BuildAssignmentServiceIntegrationTest {
 
     @Before
     public void setUp() throws Exception {
+        drainModeService.update(new ServerDrainMode(false, "admin", new Date()));
         configCache = new ConfigCache();
         registry = ConfigElementImplementationRegistryMother.withNoPlugins();
         configHelper = new GoConfigFileHelper().usingCruiseConfigDao(goConfigDao);
@@ -392,7 +395,7 @@ public class BuildAssignmentServiceIntegrationTest {
         };
 
         final BuildAssignmentService buildAssignmentServiceUnderTest = new BuildAssignmentService(goConfigService, mockJobInstanceService, scheduleService,
-                agentService, environmentConfigService, transactionTemplate, scheduledPipelineLoader, pipelineService, builderFactory, agentRemoteHandler, elasticAgentPluginService, systemEnvironment);
+                agentService, environmentConfigService, transactionTemplate, scheduledPipelineLoader, pipelineService, builderFactory, agentRemoteHandler, drainModeService, elasticAgentPluginService, systemEnvironment);
 
         final Throwable[] fromThread = new Throwable[1];
         buildAssignmentServiceUnderTest.onTimer();
@@ -435,7 +438,7 @@ public class BuildAssignmentServiceIntegrationTest {
         when(mockGoConfigService.getCurrentConfig()).thenReturn(config);
 
         buildAssignmentService = new BuildAssignmentService(mockGoConfigService, jobInstanceService, scheduleService, agentService, environmentConfigService,
-                transactionTemplate, scheduledPipelineLoader, pipelineService, builderFactory, agentRemoteHandler, elasticAgentPluginService, systemEnvironment);
+                transactionTemplate, scheduledPipelineLoader, pipelineService, builderFactory, agentRemoteHandler, drainModeService, elasticAgentPluginService, systemEnvironment);
         buildAssignmentService.onTimer();
 
         AgentConfig agentConfig = AgentMother.localAgent();
@@ -652,6 +655,32 @@ public class BuildAssignmentServiceIntegrationTest {
 
         assertThat(job.getState(), is(JobState.Assigned));
         assertThat(job.getAgentUuid(), is(agentConfig.getUuid()));
+    }
+
+    @Test
+    public void shouldNotScheduleJobsDuringServerDrainMode() throws Exception {
+        drainModeService.update(new ServerDrainMode(true, "admin", new Date()));
+
+        JobConfig jobConfig = evolveConfig.findBy(new CaseInsensitiveString(STAGE_NAME)).jobConfigByInstanceName("unit", true);
+        jobConfig.addResourceConfig("some-resource");
+
+        scheduleHelper.schedule(evolveConfig, modifySomeFiles(evolveConfig), DEFAULT_APPROVED_BY);
+
+        AgentConfig agentConfig = AgentMother.localAgent();
+        agentConfig.addResourceConfig(new ResourceConfig("some-resource"));
+
+        buildAssignmentService.onTimer();
+        Work work = buildAssignmentService.assignWorkToAgent(agent(agentConfig));
+        assertThat(work, is(BuildAssignmentService.NO_WORK));
+
+        Pipeline pipeline = pipelineDao.mostRecentPipeline(CaseInsensitiveString.str(evolveConfig.name()));
+        JobInstance job = pipeline.findStage(STAGE_NAME).findJob("unit");
+
+        JobPlan loadedPlan = jobInstanceDao.loadPlan(job.getId());
+        assertThat(loadedPlan.getResources().toResourceConfigs(), is(jobConfig.resourceConfigs()));
+
+        assertThat(job.getState(), is(JobState.Scheduled));
+        assertNull(job.getAgentUuid());
     }
 
     @Test


### PR DESCRIPTION
* Disable buildAssignmentService during server drain mode.
* Do not send createAgent requests to elastic agent plugins for elastic jobs.

---
Spoke to @bdpiparva regarding the implementation.

Spring scheduled tasks don't have a way to conditionally run them based on a flag. 
##### Two ways to conditionally run tasks:
  - Check for the condition inside the task function. 
  - Use task schedulers to stop and reinitialize timer tasks based on some condition and listeners.

Stopping and starting spring timer tasks might affect the GoCD services as many tasks have state initialization. Also, it's not a good idea to stop timers and start them again.

Going ahead with checking condition inside the task function.
