### PR TITLE
[WIP] Show server in drain mode banner on all GoCD pages (#5190)

### DIFF
--- a/server/src/main/java/com/thoughtworks/go/server/web/GoVelocityView.java
+++ b/server/src/main/java/com/thoughtworks/go/server/web/GoVelocityView.java
@@ -23,6 +23,7 @@ import com.thoughtworks.go.plugin.domain.common.PluginConstants;
 import com.thoughtworks.go.server.newsecurity.models.AuthenticationToken;
 import com.thoughtworks.go.server.newsecurity.utils.SessionUtils;
 import com.thoughtworks.go.server.security.GoAuthority;
+import com.thoughtworks.go.server.service.DrainModeService;
 import com.thoughtworks.go.server.service.RailsAssetsService;
 import com.thoughtworks.go.server.service.VersionInfoService;
 import com.thoughtworks.go.server.service.WebpackAssetsService;
@@ -48,6 +49,7 @@ public class GoVelocityView extends VelocityToolboxView {
     public static final String USE_COMPRESS_JS = "useCompressJS";
     public static final String CONCATENATED_JAVASCRIPT_FILE_PATH = "concatenatedJavascriptFilePath";
     public static final String CONCATENATED_APPLICATION_CSS_FILE_PATH = "concatenatedApplicationCssFilePath";
+    public static final String CONCATENATED_DRAIN_MODE_BANNER_CSS_FILE_PATH = "concatenatedDrainModeBannerCssFilePath";
     public static final String CURRENT_GOCD_VERSION = "currentGoCDVersion";
     public static final String CONCATENATED_VM_APPLICATION_CSS_FILE_PATH = "concatenatedVmApplicationCssFilePath";
     public static final String CONCATENATED_CSS_APPLICATION_CSS_FILE_PATH = "concatenatedCssApplicationCssFilePath";
@@ -60,6 +62,7 @@ public class GoVelocityView extends VelocityToolboxView {
     public static final String GO_UPDATE_CHECK_ENABLED = "goUpdateCheckEnabled";
     public static final String SUPPORTS_ANALYTICS_DASHBOARD = "supportsAnalyticsDashboard";
     public static final String WEBPACK_ASSETS_SERVICE = "webpackAssetsService";
+    public static final String IS_SERVER_IN_DRAIN_MODE = "isServerInDrainMode";
 
     private final SystemEnvironment systemEnvironment;
 
@@ -79,6 +82,10 @@ public class GoVelocityView extends VelocityToolboxView {
         return this.getApplicationContext().getAutowireCapableBeanFactory().getBean(WebpackAssetsService.class);
     }
 
+    DrainModeService drainModeService() {
+        return this.getApplicationContext().getAutowireCapableBeanFactory().getBean(DrainModeService.class);
+    }
+
     VersionInfoService getVersionInfoService() {
         return this.getApplicationContext().getAutowireCapableBeanFactory().getBean(VersionInfoService.class);
     }
@@ -90,6 +97,7 @@ public class GoVelocityView extends VelocityToolboxView {
     protected void exposeHelpers(Context velocityContext, HttpServletRequest request) throws Exception {
         RailsAssetsService railsAssetsService = getRailsAssetsService();
         VersionInfoService versionInfoService = getVersionInfoService();
+
         velocityContext.put(ADMINISTRATOR, true);
         velocityContext.put(GROUP_ADMINISTRATOR, true);
         velocityContext.put(TEMPLATE_ADMINISTRATOR, true);
@@ -104,6 +112,7 @@ public class GoVelocityView extends VelocityToolboxView {
 
         velocityContext.put(CONCATENATED_JAVASCRIPT_FILE_PATH, railsAssetsService.getAssetPath("application.js"));
         velocityContext.put(CONCATENATED_APPLICATION_CSS_FILE_PATH, railsAssetsService.getAssetPath("application.css"));
+        velocityContext.put(CONCATENATED_DRAIN_MODE_BANNER_CSS_FILE_PATH, railsAssetsService.getAssetPath("single_page_apps/drain_mode_banner.css"));
         velocityContext.put(CURRENT_GOCD_VERSION, CurrentGoCDVersion.getInstance());
         velocityContext.put(CONCATENATED_VM_APPLICATION_CSS_FILE_PATH, railsAssetsService.getAssetPath("vm/application.css"));
         velocityContext.put(CONCATENATED_CSS_APPLICATION_CSS_FILE_PATH, railsAssetsService.getAssetPath("css/application.css"));
@@ -118,6 +127,8 @@ public class GoVelocityView extends VelocityToolboxView {
 
         velocityContext.put(SUPPORTS_ANALYTICS_DASHBOARD, supportsAnalyticsDashboard());
         velocityContext.put(WEBPACK_ASSETS_SERVICE, webpackAssetsService());
+        velocityContext.put(IS_SERVER_IN_DRAIN_MODE, drainModeService().isDrainMode());
+
         if (!SessionUtils.hasAuthenticationToken(request)) {
             return;
         }

--- a/server/webapp/WEB-INF/rails/app/assets/new_stylesheets/single_page_apps/drain_mode_banner.scss
+++ b/server/webapp/WEB-INF/rails/app/assets/new_stylesheets/single_page_apps/drain_mode_banner.scss
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2018 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#flash-banner-container {
+  background: #f00;
+  position:   fixed;
+  z-index:    100;
+  left:       0;
+  width:      100%;
+  text-align: center;
+  padding:    10px;
+  top:        90px;
+  font-size:  15px;
+  color:      black;
+}

--- a/server/webapp/WEB-INF/rails/app/helpers/application_helper.rb
+++ b/server/webapp/WEB-INF/rails/app/helpers/application_helper.rb
@@ -541,6 +541,10 @@ module ApplicationHelper
     end
   end
 
+  def is_server_in_drain_mode?
+    drain_mode_service.isDrainMode
+  end
+
   private
   def show_analytics_only_for_admins?
     system_environment.enableAnalyticsOnlyForAdmins

--- a/server/webapp/WEB-INF/rails/app/views/layouts/admin.html.erb
+++ b/server/webapp/WEB-INF/rails/app/views/layouts/admin.html.erb
@@ -7,7 +7,7 @@
   <%- @view_title = @view_title || "Administration" -%>
   <%= render :partial => "shared/head" %>
 </head>
-<body id="<%= page_name %>" class="<%= page_name %>">
+<body id="<%= page_name %>" class="<%= page_name %>" data-is-server-in-drain-mode="<%= is_server_in_drain_mode? %>">
 <div class="page-wrap">
   <div id="body_bg">
     <div id="header">

--- a/server/webapp/WEB-INF/rails/app/views/layouts/agent_detail.html.erb
+++ b/server/webapp/WEB-INF/rails/app/views/layouts/agent_detail.html.erb
@@ -4,7 +4,7 @@
   <%- @view_title ||= "Agents" -%>
   <%= render :partial => "shared/head" %>
 </head>
-<body id="<%= page_name %>" class="<%= page_name %>">
+<body id="<%= page_name %>" class="<%= page_name %>" data-is-server-in-drain-mode="<%= is_server_in_drain_mode? %>">
 <div class="page-wrap">
   <div id="body_bg">
     <div id="header">

--- a/server/webapp/WEB-INF/rails/app/views/layouts/application.html.erb
+++ b/server/webapp/WEB-INF/rails/app/views/layouts/application.html.erb
@@ -5,7 +5,7 @@
 <head>
   <%= render :partial => "shared/head" %>
 </head>
-<body id="<%= page_name %>" class="<%= page_name %>">
+<body id="<%= page_name %>" class="<%= page_name %>" data-is-server-in-drain-mode="<%= is_server_in_drain_mode? %>">
 <div class="page-wrap">
   <div id="body_bg">
     <div id="header">

--- a/server/webapp/WEB-INF/rails/app/views/layouts/comparison.html.erb
+++ b/server/webapp/WEB-INF/rails/app/views/layouts/comparison.html.erb
@@ -4,7 +4,7 @@
     <%- @view_title =  'Compare Pipelines Page' -%>
     <%= render :partial => "shared/head" %>
 </head>
-<body id="<%= page_name %>" class="<%= page_name %>">
+<body id="<%= page_name %>" class="<%= page_name %>" data-is-server-in-drain-mode="<%= is_server_in_drain_mode? %>">
 <div class="page-wrap">
 <div id="body_bg">
     <div id="header">

--- a/server/webapp/WEB-INF/rails/app/views/layouts/my-cruise.html.erb
+++ b/server/webapp/WEB-INF/rails/app/views/layouts/my-cruise.html.erb
@@ -4,7 +4,7 @@
   <%- @view_title = 'Preferences' -%>
   <%= render :partial => "shared/head" %>
 </head>
-<body id="<%= page_name %>" class="<%= page_name %>">
+<body id="<%= page_name %>" class="<%= page_name %>" data-is-server-in-drain-mode="<%= is_server_in_drain_mode? %>">
 <div class="page-wrap">
   <div id="body_bg">
 

--- a/server/webapp/WEB-INF/rails/app/views/layouts/pipeline_admin.html.erb
+++ b/server/webapp/WEB-INF/rails/app/views/layouts/pipeline_admin.html.erb
@@ -3,7 +3,7 @@
 <head>
   <%= render :partial => "shared/head" %>
 </head>
-<body id="<%= page_name %>" class="<%= page_name %>">
+<body id="<%= page_name %>" class="<%= page_name %>" data-is-server-in-drain-mode="<%= is_server_in_drain_mode? %>">
 <div class="page-wrap">
   <div id="body_bg">
     <div id="header">

--- a/server/webapp/WEB-INF/rails/app/views/layouts/pipelines.html.erb
+++ b/server/webapp/WEB-INF/rails/app/views/layouts/pipelines.html.erb
@@ -4,7 +4,7 @@
   <%= render :partial => "shared/head" %>
   <link rel="alternate" type="application/atom+xml" title="<%= @pipeline.getName() %> stages - Atom" href="<%= api_pipeline_stage_feed_path(:name => @pipeline.getName()) -%>"/>
 </head>
-<body id="<%= page_name %>" class="<%= page_name %>">
+<body id="<%= page_name %>" class="<%= page_name %>" data-is-server-in-drain-mode="<%= is_server_in_drain_mode? %>">
 <div class="page-wrap">
   <div id="body_bg">
     <div id="body_bg_highlight">

--- a/server/webapp/WEB-INF/rails/app/views/layouts/pipelines/details.html.erb
+++ b/server/webapp/WEB-INF/rails/app/views/layouts/pipelines/details.html.erb
@@ -5,7 +5,7 @@
   <%- @current_tab_name = "admin" -%>
   <%= render :partial => "shared/head" %>
 </head>
-<body id="<%= page_name %>" class="<%= page_name %>">
+<body id="<%= page_name %>" class="<%= page_name %>" data-is-server-in-drain-mode="<%= is_server_in_drain_mode? %>">
 <div class="page-wrap">
   <div id="body_bg">
 

--- a/server/webapp/WEB-INF/rails/app/views/layouts/pipelines/job.html.erb
+++ b/server/webapp/WEB-INF/rails/app/views/layouts/pipelines/job.html.erb
@@ -5,7 +5,7 @@
 <head>
     <%= render :partial => "shared/head" %>
 </head>
-<body id="<%= page_name %>" class="<%= page_name %>">
+<body id="<%= page_name %>" class="<%= page_name %>" data-is-server-in-drain-mode="<%= is_server_in_drain_mode? %>">
 <div class="page-wrap">
 <div id="body_bg">
     <div id="header">

--- a/server/webapp/WEB-INF/rails/app/views/layouts/pipelines/stage.html.erb
+++ b/server/webapp/WEB-INF/rails/app/views/layouts/pipelines/stage.html.erb
@@ -5,7 +5,7 @@
   <%- @current_tab_name = "admin" -%>
   <%= render :partial => "shared/head" %>
 </head>
-<body id="<%= page_name %>" class="<%= page_name %>">
+<body id="<%= page_name %>" class="<%= page_name %>" data-is-server-in-drain-mode="<%= is_server_in_drain_mode? %>">
 <div class="page-wrap">
   <div id="body_bg">
     <div id="header">

--- a/server/webapp/WEB-INF/rails/app/views/layouts/single_page_app.html.erb
+++ b/server/webapp/WEB-INF/rails/app/views/layouts/single_page_app.html.erb
@@ -14,8 +14,9 @@
   <link rel="shortcut icon" href="<%= asset_path('cruise.ico') %>"/>
   <%= stylesheet_link_tag 'frameworks' %>
   <%= stylesheet_link_tag "single_page_apps/#{controller_name}" %>
+  <%= stylesheet_link_tag "single_page_apps/drain_mode_banner.css" %>
 
-  <% webpack_assets_service.getAssetPathsFor("single_page_apps/#{controller_name}", "single_page_apps/spa_commons").each do |js| %>
+  <% webpack_assets_service.getAssetPathsFor("single_page_apps/#{controller_name}", "single_page_apps/spa_commons", "single_page_apps/drain_mode_banner").each do |js| %>
     <script src=<%= "#{js}" %>></script>
   <% end %>
 
@@ -23,6 +24,7 @@
 </head>
 
 <body data-controller-name="<%= controller_name %>"
+      data-is-server-in-drain-mode="<%= is_server_in_drain_mode? %>"
       data-action-name="<%= action_name %>"
       id="<%= controller_name %>-page">
 <div class="page-wrap">
@@ -31,6 +33,9 @@
       <%= render :partial => 'new_navigation_elements/navigation' %>
     </div>
   </header>
+
+  <div id="flash-banner-container">
+  </div>
 
   <main class="main-container">
     <%= yield %>

--- a/server/webapp/WEB-INF/rails/app/views/layouts/value_stream_map.html.erb
+++ b/server/webapp/WEB-INF/rails/app/views/layouts/value_stream_map.html.erb
@@ -5,7 +5,7 @@
 <head>
   <%= render :partial => "shared/head" %>
 </head>
-<body id="<%= page_name %>" class="<%= page_name %>">
+<body id="<%= page_name %>" class="<%= page_name %>" data-is-server-in-drain-mode="<%= is_server_in_drain_mode? %>">
 <div class="page-wrap">
   <div id="body_bg" class="vsm">
     <div id="header">

--- a/server/webapp/WEB-INF/rails/app/views/shared/_head.html.erb
+++ b/server/webapp/WEB-INF/rails/app/views/shared/_head.html.erb
@@ -5,11 +5,12 @@
 <%= stylesheet_link_tag "application", {media: "all", debug: Rails.env.development? && params[:debug_assets]} %>
 <%= stylesheet_link_tag "patterns/application", {media: "all", debug: Rails.env.development? && params[:debug_assets]} %>
 <%= stylesheet_link_tag "new-theme", {media: "all", debug: Rails.env.development? && params[:debug_assets]} %>
+<%= stylesheet_link_tag "single_page_apps/drain_mode_banner" %>
 
 <%= javascript_include_tag "application", debug: Rails.env.development? && params[:debug_assets] %>
 
 <%- unless(Rails.env.test?) %>
-  <%= javascript_include_tag *webpack_assets_service.getJSAssetPathsFor("single_page_apps/notification_center", "single_page_apps/version_update_checker_for_rails") %>
+  <%= javascript_include_tag *webpack_assets_service.getJSAssetPathsFor("single_page_apps/notification_center", "single_page_apps/version_update_checker_for_rails", "single_page_apps/drain_mode_banner") %>
 <%- end %>
 
 <![if !IE]>

--- a/server/webapp/WEB-INF/rails/app/views/shared/_header.html.erb
+++ b/server/webapp/WEB-INF/rails/app/views/shared/_header.html.erb
@@ -3,4 +3,5 @@
     <a href="<%= url_for_path('pipelines') %>" id="application_logo">&nbsp;</a>
     <%= render :partial => "shared/application_nav" %>
   </div>
+  <div id="flash-banner-container"></div>
 </div>

--- a/server/webapp/WEB-INF/rails/config/initializers/assets.rb
+++ b/server/webapp/WEB-INF/rails/config/initializers/assets.rb
@@ -7,7 +7,7 @@ Rails.application.config.assets.version = '1.0'
 Rails.application.config.assets.paths << Rails.root.join('node_modules')
 
 Rails.application.config.assets.precompile += %w(lib/d3-3.1.5.min.js css/*.css)
-Rails.application.config.assets.precompile += %w(frameworks.css single_page_apps/pipeline_configs.css single_page_apps/agents.css single_page_apps/elastic_profiles.css single_page_apps/artifact_stores.css single_page_apps/preferences.css single_page_apps/analytics.css single_page_apps/auth_configs.css single_page_apps/roles.css single_page_apps/plugins.css single_page_apps/new_dashboard.css single_page_apps/data_sharing_settings.css)
+Rails.application.config.assets.precompile += %w(frameworks.css single_page_apps/pipeline_configs.css single_page_apps/agents.css single_page_apps/elastic_profiles.css single_page_apps/artifact_stores.css single_page_apps/preferences.css single_page_apps/analytics.css single_page_apps/auth_configs.css single_page_apps/roles.css single_page_apps/plugins.css single_page_apps/new_dashboard.css single_page_apps/data_sharing_settings.css single_page_apps/drain_mode_banner.css)
 Rails.application.config.assets.precompile += %w(*.svg *.eot *.woff *.ttf *.gif *.png *.ico)
 Rails.application.config.assets.precompile += %w( new-theme.css )
 

--- a/server/webapp/WEB-INF/rails/lib/services.rb
+++ b/server/webapp/WEB-INF/rails/lib/services.rb
@@ -53,6 +53,7 @@ module Services
     :config_repository,
     :default_plugin_info_finder,
     :default_plugin_manager,
+    :drain_mode_service,
     :elastic_profile_service,
     :entity_hashing_service,
     :environment_config_service,

--- a/server/webapp/WEB-INF/rails/webpack/single_page_apps/drain_mode_banner.js
+++ b/server/webapp/WEB-INF/rails/webpack/single_page_apps/drain_mode_banner.js
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2018 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* eslint-disable */
+
+const m = require('mithril');
+const $ = require('jquery');
+
+$(() => {
+  const body                = $('body');
+  const isServerInDrainMode = body.attr('data-is-server-in-drain-mode');
+
+  if (isServerInDrainMode) {
+    const component = {
+      view() {
+        return "Server is in drain state. Learn more...";
+      }
+    };
+    debugger;
+    m.mount($("#flash-banner-container").get(0), component);
+  }
+});
+
+

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/page.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/page.tsx
@@ -16,6 +16,7 @@
 
 import {MithrilComponent} from "jsx/mithril-component";
 import * as m from "mithril";
+import * as $ from "jquery";
 import {HeaderPanel} from "views/components/header_panel";
 import {PageLoadError} from "views/components/page_load_error";
 import {Spinner} from "views/components/spinner";
@@ -39,6 +40,13 @@ export abstract class Page<Attrs = {}, State = {}> extends MithrilComponent<Attr
   }
 
   view(vnode: m.Vnode<Attrs, State>) {
+    const isServerInDrainMode = $("body").attr("data-is-server-in-drain-mode");
+
+    let drainModeBanner: JSX.Element | null = null;
+    if (isServerInDrainMode) {
+      drainModeBanner = <div id="flash-banner-container">Server is in drain state. Learn more... </div>;
+    }
+
     switch (this.pageState) {
       case PageState.FAILED:
         return <PageLoadError message={`There was a problem fetching ${this.pageName()}`}/>;
@@ -49,6 +57,7 @@ export abstract class Page<Attrs = {}, State = {}> extends MithrilComponent<Attr
         if (component) {
           return <main className="main-container">
             {this.headerPanel(vnode)}
+            {drainModeBanner}
             {component}
           </main>;
         } else {

--- a/server/webapp/WEB-INF/vm/shared/_header.vm
+++ b/server/webapp/WEB-INF/vm/shared/_header.vm
@@ -20,10 +20,9 @@
   <meta http-equiv="content-type" content="text/html; charset=UTF-8"/>
   <link href="$req.getContextPath()/$concatenatedCruiseIconFilePath" rel="shortcut icon"/>
   <link rel="stylesheet" type="text/css" href="$req.getContextPath()/$concatenatedApplicationCssFilePath" media="all"/>
-  <link rel="stylesheet" type="text/css" href="$req.getContextPath()/$concatenatedCssApplicationCssFilePath"
-        media="all"/>
-  <link rel="stylesheet" type="text/css" href="$req.getContextPath()/$concatenatedVmApplicationCssFilePath"
-        media="all"/>
+  <link rel="stylesheet" type="text/css" href="$req.getContextPath()/$concatenatedCssApplicationCssFilePath" media="all"/>
+  <link rel="stylesheet" type="text/css" href="$req.getContextPath()/$concatenatedDrainModeBannerCssFilePath" media="all"/>
+  <link rel="stylesheet" type="text/css" href="$req.getContextPath()/$concatenatedVmApplicationCssFilePath" media="all"/>
 
 ## Some VM pages specify extra CSS files they need.
     #if($extra_css_list)
@@ -37,7 +36,7 @@
   <script type="text/javascript" src="$req.getContextPath()/$concatenatedJavascriptFilePath"></script>
   <script type="text/javascript"> var contextPath = "$req.getContextPath()"; </script>
 
-  #foreach( $js in ${webpackAssetsService.getAssetPathsFor("single_page_apps/notification_center", "single_page_apps/version_update_checker_for_rails")})
+  #foreach( $js in ${webpackAssetsService.getAssetPathsFor("single_page_apps/notification_center","single_page_apps/version_update_checker_for_rails","single_page_apps/drain_mode_banner")})
       <script src="${js}"></script>
   #end
 
@@ -52,7 +51,9 @@
     #if(!$current_tab && $currentTab.name)
         #set($current_tab = $currentTab.name)
     #end
-<body>
+<body data-is-server-in-drain-mode="$isServerInDrainMode">
+<div id="flash-banner-container">
+</div>
 <div class="page-wrap">
   <div id="body_bg">
     <div id="body_bg_highlight">

--- a/spark/spark-spa/src/main/java/com/thoughtworks/go/spark/spa/spring/InitialContextProvider.java
+++ b/spark/spark-spa/src/main/java/com/thoughtworks/go/spark/spa/spring/InitialContextProvider.java
@@ -22,10 +22,7 @@ import com.thoughtworks.go.plugin.domain.analytics.AnalyticsPluginInfo;
 import com.thoughtworks.go.plugin.domain.common.CombinedPluginInfo;
 import com.thoughtworks.go.plugin.domain.common.PluginConstants;
 import com.thoughtworks.go.server.newsecurity.utils.SessionUtils;
-import com.thoughtworks.go.server.service.RailsAssetsService;
-import com.thoughtworks.go.server.service.SecurityService;
-import com.thoughtworks.go.server.service.VersionInfoService;
-import com.thoughtworks.go.server.service.WebpackAssetsService;
+import com.thoughtworks.go.server.service.*;
 import com.thoughtworks.go.server.service.plugins.builder.DefaultPluginInfoFinder;
 import com.thoughtworks.go.server.service.support.toggle.Toggles;
 import com.thoughtworks.go.spark.SparkController;
@@ -46,15 +43,18 @@ public class InitialContextProvider {
     private final WebpackAssetsService webpackAssetsService;
     private final SecurityService securityService;
     private final VersionInfoService versionInfoService;
+    private DrainModeService drainModeService;
     private final DefaultPluginInfoFinder pluginInfoFinder;
 
     @Autowired
     public InitialContextProvider(RailsAssetsService railsAssetsService, WebpackAssetsService webpackAssetsService,
-                                  SecurityService securityService, VersionInfoService versionInfoService, DefaultPluginInfoFinder pluginInfoFinder) {
+                                  SecurityService securityService, VersionInfoService versionInfoService, DrainModeService drainModeService,
+                                  DefaultPluginInfoFinder pluginInfoFinder) {
         this.railsAssetsService = railsAssetsService;
         this.webpackAssetsService = webpackAssetsService;
         this.securityService = securityService;
         this.versionInfoService = versionInfoService;
+        this.drainModeService = drainModeService;
         this.pluginInfoFinder = pluginInfoFinder;
     }
 
@@ -75,6 +75,7 @@ public class InitialContextProvider {
         context.put("spaTimeout", SystemEnvironment.goSpaTimeout());
         context.put("showAnalyticsDashboard", showAnalyticsDashboard());
         context.put("devMode", !new SystemEnvironment().useCompressedJs());
+        context.put("isServerInDrainMode", drainModeService.isDrainMode());
         return new VelocityContext(context);
     }
 

--- a/spark/spark-spa/src/main/resources/velocity/layouts/component_layout.vm
+++ b/spark/spark-spa/src/main/resources/velocity/layouts/component_layout.vm
@@ -29,7 +29,7 @@
     #foreach( $css in ${webpackAssetsService.getCSSAssetPathsFor("single_page_apps/${controllerName}")})
       <link href="${css}" media="screen" rel="stylesheet"/>
     #end
-
+    <link href="/go/${railsAssetsService.getAssetPath("single_page_apps/drain_mode_banner.css")}" media="screen" rel="stylesheet"/>
     #foreach( $js in ${webpackAssetsService.getJSAssetPathsFor("single_page_apps/polyfill", "single_page_apps/${controllerName}")})
       <script src="${js}"></script>
     #end
@@ -50,7 +50,8 @@
       data-version-copyright-year="${currentVersion.copyrightYear()}"
       data-version-formatted="${currentVersion.formatted()}"
       data-version-full="${currentVersion.fullVersion()}"
-      data-config-repo-enabled="${toggles.isToggleOn("config_repos_ui")}">
+      data-config-repo-enabled="${toggles.isToggleOn("config_repos_ui")}"
+      data-is-server-in-drain-mode="${isServerInDrainMode}">
 
     #if(${devMode})
     <script>

--- a/spark/spark-spa/src/main/resources/velocity/layouts/single_page_app.vm
+++ b/spark/spark-spa/src/main/resources/velocity/layouts/single_page_app.vm
@@ -27,6 +27,7 @@
 
   <link rel="shortcut icon" href="/go/${railsAssetsService.getAssetPath('cruise.ico')}"/>
   <link href="/go/${railsAssetsService.getAssetPath('frameworks.css')}" media="screen" rel="stylesheet"/>
+  <link href="/go/${railsAssetsService.getAssetPath("single_page_apps/drain_mode_banner.css")}" media="screen" rel="stylesheet"/>
   #if(${railsAssetsService.getAssetPath("single_page_apps/${controllerName}.css")} != "")
     <link href="/go/${railsAssetsService.getAssetPath("single_page_apps/${controllerName}.css")}" media="screen"
           rel="stylesheet"/>
@@ -36,12 +37,13 @@
     <link href="${css}" media="screen" rel="stylesheet"/>
   #end
 
-  #foreach( $js in ${webpackAssetsService.getJSAssetPathsFor("single_page_apps/polyfill", "single_page_apps/spa_commons", "single_page_apps/${controllerName}")})
+  #foreach( $js in ${webpackAssetsService.getJSAssetPathsFor("single_page_apps/polyfill","single_page_apps/spa_commons","single_page_apps/drain_mode_banner","single_page_apps/${controllerName}")})
     <script src="${js}"></script>
   #end
 </head>
 
 <body data-controller-name="${controllerName}"
+      data-is-server-in-drain-mode="${isServerInDrainMode}"
       id="${controllerName}-page">
 <div class="page-wrap">
   <header class="app-header">
@@ -49,6 +51,9 @@
       #parse('new_navigation_elements/_navigation.vm')
     </div>
   </header>
+
+  <div id="flash-banner-container">
+  </div>
 
   <main class="main-container">
     #parse("${viewName}")


### PR DESCRIPTION
Show drain mode banner on:
	- Java based mithril pages (dashboard, agents page)
	- Ruby based mithril pages (user preferences)
	- Componentized mithril pages (new plugins)
	- Velocity pages (pipeline history)
	- Admin Erb pages (pipelines, cruise-config.xml)
	- Non Admin Erb pages (stage-details, pipeline-compare)

---

Waiting for styles confirmation from @naveenbhaskar 