### PR TITLE
SvnMaterialConfig validate handles 'null' url #000

### DIFF
--- a/config/config-api/src/main/java/com/thoughtworks/go/config/materials/svn/SvnMaterialConfig.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/materials/svn/SvnMaterialConfig.java
@@ -32,6 +32,7 @@ import java.util.Map;
 import static com.thoughtworks.go.util.ExceptionUtils.bomb;
 import static com.thoughtworks.go.util.ExceptionUtils.bombIfNull;
 import static java.lang.String.format;
+import static org.apache.commons.lang3.StringUtils.*;
 import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 
 @ConfigTag(value = "svn", label = "Subversion")
@@ -124,15 +125,15 @@ public class SvnMaterialConfig extends ScmMaterialConfig implements ParamsAttrib
     }
 
     private void resetPassword(String passwordToSet) {
-        if (StringUtils.isBlank(passwordToSet)) {
+        if (isBlank(passwordToSet)) {
             encryptedPassword = null;
         }
         setPasswordIfNotBlank(passwordToSet);
     }
 
     private void setPasswordIfNotBlank(String password) {
-        this.password = StringUtils.stripToNull(password);
-        this.encryptedPassword = StringUtils.stripToNull(encryptedPassword);
+        this.password = stripToNull(password);
+        this.encryptedPassword = stripToNull(encryptedPassword);
 
         if (this.password == null) {
             return;
@@ -162,7 +163,7 @@ public class SvnMaterialConfig extends ScmMaterialConfig implements ParamsAttrib
 
     public String currentPassword() {
         try {
-            return StringUtils.isBlank(encryptedPassword) ? null : this.goCipher.decrypt(encryptedPassword);
+            return isBlank(encryptedPassword) ? null : this.goCipher.decrypt(encryptedPassword);
         } catch (Exception e) {
             throw new RuntimeException("Could not decrypt the password to get the real password", e);
         }
@@ -180,7 +181,7 @@ public class SvnMaterialConfig extends ScmMaterialConfig implements ParamsAttrib
     @PostConstruct
     @Override
     public void ensureEncrypted() {
-        this.userName = StringUtils.stripToNull(this.userName);
+        this.userName = stripToNull(this.userName);
         setPasswordIfNotBlank(password);
 
         if (encryptedPassword != null) {
@@ -217,7 +218,7 @@ public class SvnMaterialConfig extends ScmMaterialConfig implements ParamsAttrib
 
     @Override
     public void validateConcreteScmMaterial() {
-        if (StringUtils.isBlank(url.forDisplay())) {
+        if (url == null || isBlank(url.forDisplay())) {
             errors().add(URL, "URL cannot be blank");
         }
         if (isNotEmpty(this.password) && isNotEmpty(this.encryptedPassword)) {

--- a/config/config-api/src/test/java/com/thoughtworks/go/config/materials/svn/SvnMaterialConfigTest.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/config/materials/svn/SvnMaterialConfigTest.java
@@ -76,6 +76,16 @@ public class SvnMaterialConfigTest {
     }
 
     @Test
+    public void validate_shouldEnsureUrlIsNotNull() {
+        SvnMaterialConfig svnMaterialConfig = new SvnMaterialConfig();
+        svnMaterialConfig.setUrl(null);
+
+        svnMaterialConfig.validate(new ConfigSaveValidationContext(null));
+
+        assertThat(svnMaterialConfig.errors().on(SvnMaterialConfig.URL), is("URL cannot be blank"));
+    }
+
+    @Test
     public void validate_shouldEnsureMaterialNameIsValid() {
         SvnMaterialConfig svnMaterialConfig = new SvnMaterialConfig("/foo", "", "", false);
         svnMaterialConfig.validate(new ConfigSaveValidationContext(null));


### PR DESCRIPTION
* Ensuring the SvnMaterialConfig#validateConcreteScmMaterial handles a null
  url, to avoid NPE during validation.