### PR TITLE
Upgrade typescript

### DIFF
--- a/server/webapp/WEB-INF/rails/tsconfig.common.json
+++ b/server/webapp/WEB-INF/rails/tsconfig.common.json
@@ -21,7 +21,9 @@
     "target": "es5",
     "jsx": "react",
     "jsxFactory": "m",
-    "allowJs": false
+    "allowJs": false,
+    "strictBindCallApply": true,
+    "strictFunctionTypes": true
   },
   "include": [
     "webpack/**/*.ts",

--- a/server/webapp/WEB-INF/rails/webpack/models/config_repos/types.ts
+++ b/server/webapp/WEB-INF/rails/webpack/models/config_repos/types.ts
@@ -149,7 +149,7 @@ export class Material implements ValidatableMixin {
     this.validateAssociated("attributes");
   }
 
-  typeProxy(value?: any) {
+  typeProxy(value?: any): string {
     if (arguments.length > 0) {
       const newType = value;
       if (this.type() !== newType) {
@@ -158,10 +158,9 @@ export class Material implements ValidatableMixin {
                                                          attributes: ({} as MaterialAttributesJSON)
                                                        }));
       }
-      return this.type(newType);
-    } else {
-      return this.type();
+      this.type(newType);
     }
+    return this.type();
   }
 }
 

--- a/server/webapp/WEB-INF/rails/webpack/views/components/buttons/index.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/components/buttons/index.tsx
@@ -30,7 +30,7 @@ export enum ButtonIcon {
 export interface Attrs {
   icon?: ButtonIcon;
   small?: boolean;
-  onclick?: () => void;
+  onclick?: (e: MouseEvent) => void;
   disabled?: boolean;
   classNames?: string;
 }

--- a/server/webapp/WEB-INF/rails/webpack/views/components/icons/index.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/components/icons/index.tsx
@@ -26,7 +26,7 @@ import * as styles from "./index.scss";
 const classnames = bind(styles);
 
 export interface Attrs extends HTMLAttributes {
-  onclick?: () => void;
+  onclick?: (e: MouseEvent) => void;
   disabled?: boolean;
   iconOnly?: boolean;
 }

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/config_repos.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/config_repos.tsx
@@ -125,16 +125,16 @@ export class ConfigReposPage extends Page<null, State> {
       <FlashMessage type={vnode.state.messageType} message={vnode.state.message}/>
       <ConfigReposWidget objects={vnode.state.configRepos}
                          pluginInfos={vnode.state.pluginInfos}
-                         onRefresh={vnode.state.onRefresh.bind(this)}
-                         onEdit={vnode.state.onEdit.bind(this)}
-                         onDelete={vnode.state.onDelete.bind(this)}
+                         onRefresh={vnode.state.onRefresh.bind(vnode.state)}
+                         onEdit={vnode.state.onEdit.bind(vnode.state)}
+                         onDelete={vnode.state.onDelete.bind(vnode.state)}
       />
     </div>;
   }
 
   headerPanel(vnode: m.Vnode<null, State>) {
     const headerButtons = [
-      <Buttons.Primary onclick={vnode.state.onAdd.bind(this)}>Add</Buttons.Primary>
+      <Buttons.Primary onclick={vnode.state.onAdd.bind(vnode.state)}>Add</Buttons.Primary>
     ];
     return <HeaderPanel title="Config repositories" buttons={headerButtons}/>;
   }

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/config_repos/config_repos_widget.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/config_repos/config_repos_widget.tsx
@@ -44,7 +44,7 @@ export interface RequiresPluginInfos {
 }
 
 export interface Attrs<T> extends Operations<T>, RequiresPluginInfos {
-  objects: Stream<T | null>;
+  objects: Stream<T[] | null>;
 }
 
 export interface State extends Operations<ConfigRepo>, SaveOperation, RequiresPluginInfos {
@@ -143,15 +143,15 @@ class ConfigRepoWidget extends MithrilViewComponent<ShowObjectAttrs<ConfigRepo>>
     }, new Map<string, string>());
 
     const refreshButton = (
-      <Refresh data-test-id="config-repo-refresh" onclick={vnode.attrs.onRefresh.bind(vnode.attrs)}/>
+      <Refresh data-test-id="config-repo-refresh" onclick={vnode.attrs.onRefresh.bind(vnode.attrs, vnode.attrs.obj)}/>
     );
 
     const settingsButton = (
-      <Settings data-test-id="config-repo-edit" onclick={vnode.attrs.onEdit.bind(vnode.attrs)}/>
+      <Settings data-test-id="config-repo-edit" onclick={vnode.attrs.onEdit.bind(vnode.attrs, vnode.attrs.obj)}/>
     );
 
     const deleteButton = (
-      <Delete data-test-id="config-repo-delete" onclick={vnode.attrs.onDelete.bind(vnode.attrs)}/>
+      <Delete data-test-id="config-repo-delete" onclick={vnode.attrs.onDelete.bind(vnode.attrs, vnode.attrs.obj)}/>
     );
 
     const actionButtons = <ButtonGroup>
@@ -163,7 +163,8 @@ class ConfigRepoWidget extends MithrilViewComponent<ShowObjectAttrs<ConfigRepo>>
     let lastParseRevision: m.Children;
 
     if (vnode.attrs.obj.lastParse() && vnode.attrs.obj.lastParse().revision()) {
-      lastParseRevision = <p class={styles.lastRevision}>Last seen revision: <code>{vnode.attrs.obj.lastParse().revision()}</code></p>;
+      lastParseRevision =
+        <p class={styles.lastRevision}>Last seen revision: <code>{vnode.attrs.obj.lastParse().revision()}</code></p>;
     }
 
     let maybeWarning: m.Children;
@@ -201,8 +202,8 @@ class ConfigRepoWidget extends MithrilViewComponent<ShowObjectAttrs<ConfigRepo>>
   }
 }
 
-export class ConfigReposWidget extends MithrilViewComponent<Attrs<ConfigRepo[]>> {
-  view(vnode: m.Vnode<Attrs<ConfigRepo[]>>): m.Children | void | null {
+export class ConfigReposWidget extends MithrilViewComponent<Attrs<ConfigRepo>> {
+  view(vnode: m.Vnode<Attrs<ConfigRepo>>): m.Children | void | null {
     if (!vnode.attrs.objects()) {
       return <Spinner/>;
     }
@@ -222,9 +223,9 @@ export class ConfigReposWidget extends MithrilViewComponent<Attrs<ConfigRepo[]>>
             <ConfigRepoWidget key={configRepo.id()}
                               obj={configRepo}
                               pluginInfos={vnode.attrs.pluginInfos}
-                              onEdit={vnode.attrs.onEdit.bind(vnode.state, configRepo)}
-                              onRefresh={vnode.attrs.onRefresh.bind(vnode.state, configRepo)}
-                              onDelete={vnode.attrs.onDelete.bind(vnode.state, configRepo)}
+                              onEdit={(configRepo, e) => vnode.attrs.onEdit(configRepo, e)}
+                              onRefresh={(configRepo, e) => vnode.attrs.onRefresh(configRepo, e)}
+                              onDelete={(configRepo, e) => vnode.attrs.onDelete(configRepo, e)}
             />
           );
         })}

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/config_repos/config_repos_widget_spec.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/config_repos/config_repos_widget_spec.tsx
@@ -28,7 +28,7 @@ import * as styles from "views/pages/config_repos/index.scss";
 
 describe("ConfigReposWidget", () => {
   let $root: any, root: any;
-  let attrs: Attrs<ConfigRepo[]>;
+  let attrs: Attrs<ConfigRepo>;
   let onDelete: jasmine.Spy;
   let onEdit: jasmine.Spy;
   let onRefresh: jasmine.Spy;

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/new_plugins/plugin_widget.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/new_plugins/plugin_widget.tsx
@@ -56,7 +56,7 @@ class PluginHeaderWidget extends MithrilViewComponent<PluginHeaderAttrs> {
 export interface Attrs {
   pluginInfo: PluginInfo<any>;
   isUserAnAdmin: boolean;
-  onEdit: () => void;
+  onEdit: (e: MouseEvent) => void;
 }
 
 type OptionalElement = m.Children;
@@ -84,7 +84,7 @@ export class PluginWidget extends MithrilViewComponent<Attrs> {
     if (pluginInfo.supportsPluginSettings()) {
       settingsButton = <Icons.Settings data-test-id="edit-plugin-settings"
                                        disabled={!isUserAnAdmin}
-                                       onclick={vnode.attrs.onEdit}/>;
+                                       onclick={vnode.attrs.onEdit.bind(vnode.attrs)}/>;
     }
 
     let pluginData = new Map<string, string | JSX.Element>([

--- a/server/webapp/WEB-INF/rails/yarn.lock
+++ b/server/webapp/WEB-INF/rails/yarn.lock
@@ -8863,9 +8863,9 @@ typedarray@^0.0.6:
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
 typescript@^3.1.6:
-  version "3.1.6"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.1.6.tgz#b6543a83cfc8c2befb3f4c8fba6896f5b0c9be68"
-  integrity sha512-tDMYfVtvpb96msS1lDX9MEdHrW4yOuZ4Kdc4Him9oU796XldPYF/t2+uKoX0BBa0hXXwDlqYQbXY5Rzjzc5hBA==
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.2.1.tgz#0b7a04b8cf3868188de914d9568bd030f0c56192"
+  integrity sha512-jw7P2z/h6aPT4AENXDGjcfHTu5CSqzsbZc6YlUIebTyBAq8XaKp78x7VcSh30xwSCcsu5irZkYZUSFP1MrAMbg==
 
 typings-for-css-modules-loader@^1.7.0:
   version "1.7.0"


### PR DESCRIPTION
Fixes a bunch of "unsafe" `bind` calls, which were exposed because of
`strictBindCallApply` and `strictFunctionTypes` options.