### PR TITLE
Removed additional margin from flash message.

### DIFF
--- a/server/webapp/WEB-INF/rails/webpack/views/components/flash_message/index.scss
+++ b/server/webapp/WEB-INF/rails/webpack/views/components/flash_message/index.scss
@@ -21,7 +21,7 @@
   padding:       7px 40px 7px 10px;
   border:        1px solid transparent;
   border-radius: $global-border-radius;
-  margin:        10px 30px;
+  margin:        10px 0;
   position:      relative;
 
   p {


### PR DESCRIPTION
### Before
<img width="721" alt="screen shot 2018-12-04 at 10 09 20 am" src="https://user-images.githubusercontent.com/7871209/49419462-ea2c2f80-f7ac-11e8-9883-be9eedfd309c.png">


### After removing the margin

<img width="1439" alt="screen shot 2018-12-04 at 10 09 48 am" src="https://user-images.githubusercontent.com/7871209/49419467-f0baa700-f7ac-11e8-8d88-926755c204c0.png">
