### PR TITLE
Config Repo Plugin Configuration

### DIFF
--- a/server/webapp/WEB-INF/rails/webpack/models/config_repos/config_repos_crud.ts
+++ b/server/webapp/WEB-INF/rails/webpack/models/config_repos/config_repos_crud.ts
@@ -21,9 +21,15 @@ import {ConfigRepo, ConfigRepos} from "models/config_repos/types";
 
 const s = require("helpers/string-plus");
 
-function toSnakeCaseJSON(o: any) {
-  const text = JSON.stringify(o, s.snakeCaser);
-  return JSON.parse(text);
+export function toSnakeCaseJSON(o: ConfigRepo) {
+  let configuration = [] as any[];
+  if (o.configuration && o.configuration()) {
+    configuration = o.configuration().map((config) => config.toJSON());
+  }
+  const text         = JSON.stringify(o, s.snakeCaser);
+  const json         = JSON.parse(text);
+  json.configuration = configuration;
+  return json;
 }
 
 export class ConfigReposCRUD {

--- a/server/webapp/WEB-INF/rails/webpack/models/config_repos/config_repos_crud.ts
+++ b/server/webapp/WEB-INF/rails/webpack/models/config_repos/config_repos_crud.ts
@@ -22,13 +22,10 @@ import {ConfigRepo, ConfigRepos} from "models/config_repos/types";
 const s = require("helpers/string-plus");
 
 export function toSnakeCaseJSON(o: ConfigRepo) {
-  let configuration = [] as any[];
-  if (o.configuration && o.configuration()) {
-    configuration = o.configuration().map((config) => config.toJSON());
-  }
+  const configurations = o.createConfigurationsFromText();
   const text         = JSON.stringify(o, s.snakeCaser);
   const json         = JSON.parse(text);
-  json.configuration = configuration;
+  json.configuration = configurations.map((config) => config.toJSON());
   return json;
 }
 

--- a/server/webapp/WEB-INF/rails/webpack/models/config_repos/spec/config_repos_crud_spec.ts
+++ b/server/webapp/WEB-INF/rails/webpack/models/config_repos/spec/config_repos_crud_spec.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2018 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {toSnakeCaseJSON} from "models/config_repos/config_repos_crud";
+import {ConfigRepo, GitMaterialAttributes, Material} from "models/config_repos/types";
+import {Configuration, PlainTextValue} from "models/shared/plugin_infos_new/plugin_settings/plugin_settings";
+
+describe("Serialization", () => {
+  it("should serialize configuration properties", () => {
+    const configuration1 = new Configuration("test-key-1", new PlainTextValue("test-value-1"));
+    const configuration2 = new Configuration("test-key-2", new PlainTextValue("test-value-2"));
+    const configRepo     = new ConfigRepo("test",
+                                          "test",
+                                          new Material("git",
+                                                       new GitMaterialAttributes("test",
+                                                                                 false,
+                                                                                 "https://example.com")),
+                                          [configuration1, configuration2]);
+    const json           = toSnakeCaseJSON(configRepo);
+    expect(json.configuration)
+      .toEqual([{key: "test-key-1", value: "test-value-1"}, {key: "test-key-2", value: "test-value-2"}]);
+  });
+
+  it("should not serialize configuration properties when not present", () => {
+    const configRepo     = new ConfigRepo("test",
+                                          "test",
+                                          new Material("git",
+                                                       new GitMaterialAttributes("test",
+                                                                                 false,
+                                                                                 "https://example.com")));
+    const json           = toSnakeCaseJSON(configRepo);
+    expect(json.configuration).toHaveLength(0);
+  });
+});

--- a/server/webapp/WEB-INF/rails/webpack/models/config_repos/spec/config_repos_crud_spec.ts
+++ b/server/webapp/WEB-INF/rails/webpack/models/config_repos/spec/config_repos_crud_spec.ts
@@ -19,11 +19,11 @@ import {ConfigRepo, GitMaterialAttributes, Material} from "models/config_repos/t
 import {Configuration, PlainTextValue} from "models/shared/plugin_infos_new/plugin_settings/plugin_settings";
 
 describe("Serialization", () => {
-  it("should serialize configuration properties", () => {
-    const configuration1 = new Configuration("test-key-1", new PlainTextValue("test-value-1"));
-    const configuration2 = new Configuration("test-key-2", new PlainTextValue("test-value-2"));
+  it("should serialize configuration properties for JSON plugin", () => {
+    const configuration1 = new Configuration("pipeline_pattern", new PlainTextValue("test-value-1"));
+    const configuration2 = new Configuration("environment_pattern", new PlainTextValue("test-value-2"));
     const configRepo     = new ConfigRepo("test",
-                                          "test",
+                                          ConfigRepo.JSON_PLUGIN_ID,
                                           new Material("git",
                                                        new GitMaterialAttributes("test",
                                                                                  false,
@@ -31,17 +31,30 @@ describe("Serialization", () => {
                                           [configuration1, configuration2]);
     const json           = toSnakeCaseJSON(configRepo);
     expect(json.configuration)
-      .toEqual([{key: "test-key-1", value: "test-value-1"}, {key: "test-key-2", value: "test-value-2"}]);
+      .toEqual([{key: "pipeline_pattern", value: "test-value-1"}, {key: "environment_pattern", value: "test-value-2"}]);
   });
 
-  it("should not serialize configuration properties when not present", () => {
+  it("should serialize configuration properties for YAML plugin", () => {
+    const configuration1 = new Configuration("file_pattern", new PlainTextValue("test-value-1"));
     const configRepo     = new ConfigRepo("test",
-                                          "test",
+                                          ConfigRepo.YAML_PLUGIN_ID,
                                           new Material("git",
                                                        new GitMaterialAttributes("test",
                                                                                  false,
-                                                                                 "https://example.com")));
+                                                                                 "https://example.com")),
+                                          [configuration1]);
     const json           = toSnakeCaseJSON(configRepo);
+    expect(json.configuration).toEqual([{key: "file_pattern", value: "test-value-1"}]);
+  });
+
+  it("should not serialize configuration properties when not present", () => {
+    const configRepo = new ConfigRepo("test",
+                                      "test",
+                                      new Material("git",
+                                                   new GitMaterialAttributes("test",
+                                                                             false,
+                                                                             "https://example.com")));
+    const json       = toSnakeCaseJSON(configRepo);
     expect(json.configuration).toHaveLength(0);
   });
 });

--- a/server/webapp/WEB-INF/rails/webpack/models/config_repos/spec/config_repos_crud_spec.ts
+++ b/server/webapp/WEB-INF/rails/webpack/models/config_repos/spec/config_repos_crud_spec.ts
@@ -18,7 +18,7 @@ import {toSnakeCaseJSON} from "models/config_repos/config_repos_crud";
 import {ConfigRepo, GitMaterialAttributes, Material} from "models/config_repos/types";
 import {Configuration, PlainTextValue} from "models/shared/plugin_infos_new/plugin_settings/plugin_settings";
 
-describe("Serialization", () => {
+describe("Config Repo Serialization", () => {
   it("should serialize configuration properties for JSON plugin", () => {
     const configuration1 = new Configuration("pipeline_pattern", new PlainTextValue("test-value-1"));
     const configuration2 = new Configuration("environment_pattern", new PlainTextValue("test-value-2"));

--- a/server/webapp/WEB-INF/rails/webpack/models/config_repos/types.ts
+++ b/server/webapp/WEB-INF/rails/webpack/models/config_repos/types.ts
@@ -27,6 +27,7 @@ import {Errors} from "models/mixins/errors";
 import {applyMixins} from "models/mixins/mixins";
 import {ValidatableMixin} from "models/mixins/new_validatable_mixin";
 import {ErrorMessages} from "models/mixins/validatable";
+import {Configuration} from "models/shared/plugin_infos_new/plugin_settings/plugin_settings";
 import {EncryptedValue} from "views/components/forms/encrypted_value";
 
 const s = require("helpers/string-plus");
@@ -71,13 +72,13 @@ export class ConfigRepo implements ValidatableMixin {
   id: Stream<string>;
   pluginId: Stream<string>;
   material: Stream<Material>;
-  configuration: Stream<any[]>;
+  configuration: Stream<Configuration[]>;
   lastParse: Stream<LastParse>;
 
   constructor(id?: string,
               pluginId?: string,
               material?: Material,
-              configuration?: any[],
+              configuration?: Configuration[],
               lastParse?: LastParse) {
     this.id            = stream(id);
     this.pluginId      = stream(pluginId);
@@ -91,11 +92,12 @@ export class ConfigRepo implements ValidatableMixin {
   }
 
   static fromJSON(json: ConfigRepoJSON) {
-    const configRepo = new ConfigRepo(json.id,
-                                      json.plugin_id,
-                                      Materials.fromJSON(json.material),
-                                      json.configuration,
-                                      LastParse.fromJSON(json.last_parse));
+    const configurations = json.configuration.map((config) => Configuration.fromJSON(config));
+    const configRepo     = new ConfigRepo(json.id,
+                                          json.plugin_id,
+                                          Materials.fromJSON(json.material),
+                                          configurations,
+                                          LastParse.fromJSON(json.last_parse));
     configRepo.errors(new Errors(json.errors));
     return configRepo;
   }

--- a/server/webapp/WEB-INF/rails/webpack/models/config_repos/types.ts
+++ b/server/webapp/WEB-INF/rails/webpack/models/config_repos/types.ts
@@ -27,7 +27,7 @@ import {Errors} from "models/mixins/errors";
 import {applyMixins} from "models/mixins/mixins";
 import {ValidatableMixin} from "models/mixins/new_validatable_mixin";
 import {ErrorMessages} from "models/mixins/validatable";
-import {Configuration} from "models/shared/plugin_infos_new/plugin_settings/plugin_settings";
+import {Configuration, PlainTextValue} from "models/shared/plugin_infos_new/plugin_settings/plugin_settings";
 import {EncryptedValue} from "views/components/forms/encrypted_value";
 
 const s = require("helpers/string-plus");
@@ -69,11 +69,19 @@ export interface TfsMaterialAttributes extends ValidatableMixin {
 }
 
 export class ConfigRepo implements ValidatableMixin {
+  static readonly PIPELINE_PATTERN             = "pipeline_pattern";
+  static readonly ENVIRONMENT_PATTERN          = "environment_pattern";
+  static readonly FILE_PATTERN                 = "file_pattern";
+  static readonly JSON_PLUGIN_ID               = "json.config.plugin";
+  static readonly YAML_PLUGIN_ID               = "yaml.config.plugin";
   id: Stream<string>;
   pluginId: Stream<string>;
   material: Stream<Material>;
   configuration: Stream<Configuration[]>;
   lastParse: Stream<LastParse>;
+  __jsonPluginPipelinesPattern: Stream<string> = stream("");
+  __jsonPluginEnvPattern: Stream<string>       = stream("");
+  __yamlPluginPattern: Stream<string>          = stream("");
 
   constructor(id?: string,
               pluginId?: string,
@@ -85,10 +93,23 @@ export class ConfigRepo implements ValidatableMixin {
     this.material      = stream(material);
     this.configuration = stream(configuration);
     this.lastParse     = stream(lastParse);
+    if (configuration) {
+      this.__jsonPluginPipelinesPattern = stream(ConfigRepo.findConfigurationValue(configuration,
+                                                                                   ConfigRepo.PIPELINE_PATTERN));
+      this.__jsonPluginEnvPattern       = stream(ConfigRepo.findConfigurationValue(configuration,
+                                                                                   ConfigRepo.ENVIRONMENT_PATTERN));
+      this.__yamlPluginPattern          = stream(ConfigRepo.findConfigurationValue(configuration,
+                                                                                   ConfigRepo.FILE_PATTERN));
+    }
     ValidatableMixin.call(this);
     this.validatePresenceOf("id");
     this.validatePresenceOf("pluginId");
     this.validateAssociated("material");
+  }
+
+  static findConfigurationValue(configuration: Configuration[], key: string) {
+    const config = configuration.find((config) => config.key === key);
+    return config ? config.value : "";
   }
 
   static fromJSON(json: ConfigRepoJSON) {
@@ -100,6 +121,24 @@ export class ConfigRepo implements ValidatableMixin {
                                           LastParse.fromJSON(json.last_parse));
     configRepo.errors(new Errors(json.errors));
     return configRepo;
+  }
+
+  createConfigurationsFromText() {
+    const configurations = [];
+    if (this.pluginId() === ConfigRepo.YAML_PLUGIN_ID && this.__yamlPluginPattern().length > 0) {
+      configurations.push(new Configuration(ConfigRepo.FILE_PATTERN, new PlainTextValue(this.__yamlPluginPattern())));
+    }
+    if (this.pluginId() === ConfigRepo.JSON_PLUGIN_ID) {
+      if (this.__jsonPluginPipelinesPattern().length > 0) {
+        configurations.push(new Configuration(ConfigRepo.PIPELINE_PATTERN,
+                                              new PlainTextValue(this.__jsonPluginPipelinesPattern())));
+      }
+      if (this.__jsonPluginEnvPattern().length > 0) {
+        configurations.push(new Configuration(ConfigRepo.ENVIRONMENT_PATTERN,
+                                              new PlainTextValue(this.__jsonPluginEnvPattern())));
+      }
+    }
+    return configurations;
   }
 }
 

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/config_repos/modals.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/config_repos/modals.tsx
@@ -58,16 +58,16 @@ class MaterialEditWidget extends MithrilViewComponent<EditableMaterial> {
       pluginConfig = [
         <FormItem>
           <TextField property={vnode.attrs.repo.__jsonPluginPipelinesPattern}
-                     label={"GoCD pipeline files global pattern"}/>
+                     label="GoCD pipeline files pattern"/>
         </FormItem>,
         <FormItem>
           <TextField property={vnode.attrs.repo.__jsonPluginEnvPattern}
-                     label={"GoCD environment files global pattern"}/>
+                     label="GoCD environment files pattern"/>
         </FormItem>
       ];
     } else if (ConfigRepo.YAML_PLUGIN_ID === vnode.attrs.repo.pluginId()) {
       pluginConfig = <FormItem>
-        <TextField property={vnode.attrs.repo.__yamlPluginPattern} label={"Go YAML files global pattern"}/>
+        <TextField property={vnode.attrs.repo.__yamlPluginPattern} label="GoCD YAML files pattern"/>
       </FormItem>;
     }
 

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/config_repos/modals.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/config_repos/modals.tsx
@@ -53,23 +53,6 @@ class MaterialEditWidget extends MithrilViewComponent<EditableMaterial> {
     const pluginList = _.map(vnode.attrs.pluginInfos(), (pluginInfo: PluginInfo<any>) => {
       return {id: pluginInfo.id, text: pluginInfo.about.name};
     });
-    let pluginConfig = null;
-    if (ConfigRepo.JSON_PLUGIN_ID === vnode.attrs.repo.pluginId()) {
-      pluginConfig = [
-        <FormItem>
-          <TextField property={vnode.attrs.repo.__jsonPluginPipelinesPattern}
-                     label="GoCD pipeline files pattern"/>
-        </FormItem>,
-        <FormItem>
-          <TextField property={vnode.attrs.repo.__jsonPluginEnvPattern}
-                     label="GoCD environment files pattern"/>
-        </FormItem>
-      ];
-    } else if (ConfigRepo.YAML_PLUGIN_ID === vnode.attrs.repo.pluginId()) {
-      pluginConfig = <FormItem>
-        <TextField property={vnode.attrs.repo.__yamlPluginPattern} label="GoCD YAML files pattern"/>
-      </FormItem>;
-    }
 
     return (
       [
@@ -109,13 +92,34 @@ class MaterialEditWidget extends MithrilViewComponent<EditableMaterial> {
             <Form>
               {vnode.children}
             </Form>
-            <Form>
-              {pluginConfig}
-            </Form>
+            {this.pluginConfigView(vnode)}
           </FormBody>
         )
       ]
     );
+  }
+
+  private pluginConfigView(vnode: m.Vnode<EditableMaterial>): m.Children {
+    let pluginConfig = null;
+    if (ConfigRepo.JSON_PLUGIN_ID === vnode.attrs.repo.pluginId()) {
+      pluginConfig = <Form>
+        <FormItem>
+          <TextField property={vnode.attrs.repo.__jsonPluginPipelinesPattern}
+                     label="GoCD pipeline files pattern"/>
+        </FormItem>
+        <FormItem>
+          <TextField property={vnode.attrs.repo.__jsonPluginEnvPattern}
+                     label="GoCD environment files pattern"/>
+        </FormItem>
+      </Form>;
+    } else if (ConfigRepo.YAML_PLUGIN_ID === vnode.attrs.repo.pluginId()) {
+      pluginConfig = <Form>
+        <FormItem>
+          <TextField property={vnode.attrs.repo.__yamlPluginPattern} label="GoCD YAML files pattern"/>
+        </FormItem>
+      </Form>;
+    }
+    return pluginConfig;
   }
 
   private materialSelectOptions(): Option[] {

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/config_repos/modals.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/config_repos/modals.tsx
@@ -53,6 +53,23 @@ class MaterialEditWidget extends MithrilViewComponent<EditableMaterial> {
     const pluginList = _.map(vnode.attrs.pluginInfos(), (pluginInfo: PluginInfo<any>) => {
       return {id: pluginInfo.id, text: pluginInfo.about.name};
     });
+    let pluginConfig = null;
+    if (ConfigRepo.JSON_PLUGIN_ID === vnode.attrs.repo.pluginId()) {
+      pluginConfig = [
+        <FormItem>
+          <TextField property={vnode.attrs.repo.__jsonPluginPipelinesPattern}
+                     label={"GoCD pipeline files global pattern"}/>
+        </FormItem>,
+        <FormItem>
+          <TextField property={vnode.attrs.repo.__jsonPluginEnvPattern}
+                     label={"GoCD environment files global pattern"}/>
+        </FormItem>
+      ];
+    } else if (ConfigRepo.YAML_PLUGIN_ID === vnode.attrs.repo.pluginId()) {
+      pluginConfig = <FormItem>
+        <TextField property={vnode.attrs.repo.__yamlPluginPattern} label={"Go YAML files global pattern"}/>
+      </FormItem>;
+    }
 
     return (
       [
@@ -91,6 +108,9 @@ class MaterialEditWidget extends MithrilViewComponent<EditableMaterial> {
           <FormBody>
             <Form>
               {vnode.children}
+            </Form>
+            <Form>
+              {pluginConfig}
             </Form>
           </FormBody>
         )


### PR DESCRIPTION
Implementing a hack to show plugin settings on the config repo modal. This should be reverted or changed once the plugin capabilities are upgraded (After #5478 is implemented)

![screen shot 2018-12-04 at 13 59 29](https://user-images.githubusercontent.com/6024038/49429315-376cc900-f7ce-11e8-89da-8f0a5fdf6cf0.png)
![screen shot 2018-12-04 at 13 59 36](https://user-images.githubusercontent.com/6024038/49429331-3b005000-f7ce-11e8-8250-a3938f63cbb7.png)
