### PR TITLE
Fix build on debian stretch and openjdk docker images

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -177,6 +177,7 @@ project.ext.railsSystemProperties = [
   'plugins.work.path'             : project.rails.testPluginsWorkDir,
   'rails.use.compressed.js'       : false,
   'go.enforce.server.immutability': 'N',
+  'jdk.net.URLClassPath.disableClassPathURLCheck': true
 ]
 
 project.ext.railsTasksDefaultDependsOn = [


### PR DESCRIPTION
There was a patch update in debian which broke a few things, see
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=911925
In essence they make a new default
`jdk.net.URLClassPath.disableClassPathURLCheck=false` which breaks the build when we start java with pathing jar.

From what I read in the issue, this affects jdk 8, 9, 10, but not 11.

## Before
`:server:generateJSRoutes` would fail in openjdk docker image, which is `debian:stretch` based.

```
> Task :server:generateJSRoutes
Using environment variables
  GEM_HOME='/ide/work/server/webapp/WEB-INF/rails/gems/jruby/2.5.0' \
  GEM_PATH='/ide/work/server/webapp/WEB-INF/rails/gems/jruby/2.5.0' \
OUTPUT_DIR='/ide/work/server/webapp/WEB-INF/rails/webpack/gen' \
      PATH='/ide/work/server/scripts:/ide/work/server/webapp/WEB-INF/rails/gems/jruby/2.5.0/bin:/usr/local/bin:/usr/bin:/bin:/usr/local/games:/usr/games' \
 RAILS_ENV='production' \
      RUBY='/ide/work/server/scripts/jruby' \
[/ide/work/server/webapp/WEB-INF/rails]$ /usr/lib/jvm/java-8-openjdk-amd64/bin/java -Dalways.reload.config.file=true -Dcruise.config.dir=/ide/work/server/target/railsTests/config -Dcruise.database.dir=/ide/work/server/target/railsTests/db/h2db -Dcruise.i18n.cache.life=0 -Dgo.enforce.server.immutability=N -Djruby.home=uri:classloader://META-INF/jruby.home -Dplugins.external.provided.path=/ide/work/server/target/railsTests/plugins/external -Dplugins.go.provided.path=/ide/work/server/target/railsTests/plugins/bundled -Dplugins.work.path=/ide/work/server/target/railsTests/plugins/work -Drails.use.compressed.js=false -XX:+TieredCompilation -XX:TieredStopAtLevel=1 -Xss2048k -client -Dfile.encoding=UTF-8 -Duser.country -Duser.language=en -Duser.variant -cp /ide/work/server/target/libs/server-18.12.0-2-pathing.jar:/home/ide/.gradle/caches/modules-2/files-2.1/org.jruby/jruby-complete/9.2.0.0/d27e806a0f4ab3c7fe8d04ff4619bd849390af58/jruby-complete-9.2.0.0.jar org.jruby.Main -S rake --trace generated_js

> Task :api:api-roles-config-v1:generateLicenseReport
> Task :api:api-server-drain-mode-v1:generateLicenseReport
> Task :api:api-server-health-messages-v1:generateLicenseReport
> Task :api:api-server-health-v1:generateLicenseReport
> Task :api:api-shared-v4:generateLicenseReport
> Task :api:api-shared-v6:generateLicenseReport
> Task :api:api-template-config-v4:generateLicenseReport
> Task :api:api-stage-operations-v1:generateLicenseReport
rake aborted!

> Task :server:generateJSRoutes
NameError: missing class name (`com.thoughtworks.go.config.CaseInsensitiveString')
org/jruby/javasupport/JavaPackage.java:258:in `method_missing'
/ide/work/server/webapp/WEB-INF/rails/lib/extensions/case_insensitive_string.rb:17:in `<main>'
org/jruby/RubyKernel.java:970:in `require'
uri:classloader:/jruby/kernel/kernel.rb:1:in `(root)'
uri:classloader:/jruby/kernel/kernel.rb:13:in `<main>'
org/jruby/RubyKernel.java:970:in `require'
/ide/work/server/webapp/WEB-INF/rails/lib/all_libs.rb:20:in `(root)'
uri:classloader:/jruby/kernel/kernel.rb:1:in `<class:(root)>'
uri:classloader:/jruby/kernel/kernel.rb:13:in `<module:require_relative>'
/ide/work/server/webapp/WEB-INF/rails/config/application.rb:16:in `<main>'
org/jruby/RubyKernel.java:970:in `require'
/ide/work/server/webapp/WEB-INF/rails/config/application.rb:13:in `Go'
/ide/work/server/webapp/WEB-INF/rails/config/application.rb:12:in `<main>'
org/jruby/RubyKernel.java:994:in `load'
uri:classloader:/jruby/kernel/kernel.rb:1:in `(root)'
uri:classloader:/jruby/kernel/kernel.rb:13:in `require_relative'
/ide/work/server/webapp/WEB-INF/rails/Rakefile:13:in `block in (root)'
/ide/work/server/webapp/WEB-INF/rails/gems/jruby/2.5.0/gems/rake-12.3.1/lib/rake/rake_module.rb:1:in `(root)'
/ide/work/server/webapp/WEB-INF/rails/gems/jruby/2.5.0/gems/rake-12.3.1/lib/rake/rake_module.rb:29:in `load_rakefile'
/ide/work/server/webapp/WEB-INF/rails/gems/jruby/2.5.0/gems/rake-12.3.1/lib/rake/application.rb:703:in `block in raw_load_rakefile'
/ide/work/server/webapp/WEB-INF/rails/gems/jruby/2.5.0/gems/rake-12.3.1/lib/rake/application.rb:104:in `load_rakefile'
/ide/work/server/webapp/WEB-INF/rails/gems/jruby/2.5.0/gems/rake-12.3.1/lib/rake/application.rb:186:in `standard_exception_handling'
/ide/work/server/webapp/WEB-INF/rails/gems/jruby/2.5.0/gems/rake-12.3.1/lib/rake/application.rb:103:in `<main>'
org/jruby/RubyKernel.java:994:in `load'
uri:classloader:/META-INF/jruby.home/bin/rake:23:in `<main>'
```

## Now

The build passes, because PR added `-Djdk.net.URLClassPath.disableClassPathURLCheck=true `
```
> Task :server:generateJSRoutes
Using environment variables
  GEM_HOME='/ide/work/server/webapp/WEB-INF/rails/gems/jruby/2.5.0' \
  GEM_PATH='/ide/work/server/webapp/WEB-INF/rails/gems/jruby/2.5.0' \
OUTPUT_DIR='/ide/work/server/webapp/WEB-INF/rails/webpack/gen' \
      PATH='/ide/work/server/scripts:/ide/work/server/webapp/WEB-INF/rails/gems/jruby/2.5.0/bin:/usr/local/bin:/usr/bin:/bin:/usr/local/games:/usr/games' \
 RAILS_ENV='production' \
      RUBY='/ide/work/server/scripts/jruby' \
[/ide/work/server/webapp/WEB-INF/rails]$ /usr/lib/jvm/java-10-openjdk-amd64/bin/java -Dalways.reload.config.file=true -Dcruise.config.dir=/ide/work/server/target/railsTests/config -Dcruise.database.dir=/ide/work/server/target/railsTests/db/h2db -Dcruise.i18n.cache.life=0 -Dgo.enforce.server.immutability=N -Djdk.net.URLClassPath.disableClassPathURLCheck=true -Djruby.home=uri:classloader://META-INF/jruby.home -Dplugins.external.provided.path=/ide/work/server/target/railsTests/plugins/external -Dplugins.go.provided.path=/ide/work/server/target/railsTests/plugins/bundled -Dplugins.work.path=/ide/work/server/target/railsTests/plugins/work -Drails.use.compressed.js=false -XX:+TieredCompilation -XX:TieredStopAtLevel=1 -Xss2048k -client -Dfile.encoding=UTF-8 -Duser.country -Duser.language=en -Duser.variant -cp /ide/work/server/target/libs/server-18.12.0-8089-pathing.jar:/home/ide/.gradle/caches/modules-2/files-2.1/org.jruby/jruby-complete/9.2.0.0/d27e806a0f4ab3c7fe8d04ff4619bd849390af58/jruby-complete-9.2.0.0.jar org.jruby.Main -S rake --trace generated_js
WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by org.jruby.ext.openssl.SecurityHelper (file:/tmp/jruby-1548/jruby806117340153873626jopenssl.jar) to constructor java.security.cert.CertificateFactory(java.security.cert.CertificateFactorySpi,java.security.Provider,java.lang.String)
WARNING: Please consider reporting this to the maintainers of org.jruby.ext.openssl.SecurityHelper
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release
** Invoke generated_js (first_time)
** Invoke environment (first_time)
** Execute environment
** Execute generated_js
rm -rf /ide/work/server/webapp/WEB-INF/rails/webpack/gen
mkdir -p /ide/work/server/webapp/WEB-INF/rails/webpack/gen
```

# Notes
  * build.gocd.org is using centos, where the default is `true` anyway so this should have no effect there.
 * For the record the discussion ends somewhere [here](https://gitter.im/gocd/gocd?at=5c065ca5c4af6856da84e002)
 * @arvindsv reproduction of the issue https://github.com/arvindsv/pathing-check
