### PR TITLE
BugFix: KeyValuePair component should render number value properly

### DIFF
--- a/server/webapp/WEB-INF/rails/webpack/views/components/key_value_pair/index.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/components/key_value_pair/index.tsx
@@ -58,6 +58,10 @@ export class KeyValuePair extends MithrilViewComponent<Attrs> {
       return (<pre>{value.toString()}</pre>);
     }
 
+    if (_.isNumber(value)) {
+      return (<pre>{value}</pre>);
+    }
+
     if (_.isNil(value) || _.isEmpty(value)) {
       return this.unspecifiedValue();
     }
@@ -67,7 +71,7 @@ export class KeyValuePair extends MithrilViewComponent<Attrs> {
     }
 
     // performat some "primitive" types
-    if (_.isString(value) || _.isNumber(value)) {
+    if (_.isString(value)) {
       return (<pre>{value}</pre>);
     }
     return value;

--- a/server/webapp/WEB-INF/rails/webpack/views/components/key_value_pair/spec/index_spec.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/components/key_value_pair/spec/index_spec.tsx
@@ -53,6 +53,12 @@ describe("KeyValuePair", () => {
     expect($root.find(`.${styles.keyValuePair} .${styles.value}`).get(8)).toHaveHtml("<em>(Not specified)</em>");
 
     expect($root.find(`.${styles.keyValuePair} .${styles.value}`).get(9)).toHaveHtml("<strong>grrr!</strong>");
+debugger;
+    expect($root.find(`.${styles.keyValuePair} .${styles.key}`).get(10)).toHaveText("Integer");
+    expect($root.find(`.${styles.keyValuePair} .${styles.value}`).get(10)).toHaveText("1");
+
+    expect($root.find(`.${styles.keyValuePair} .${styles.key}`).get(11)).toHaveText("Float");
+    expect($root.find(`.${styles.keyValuePair} .${styles.value}`).get(11)).toHaveText("3.14");
   });
 
   function data() {
@@ -71,6 +77,9 @@ describe("KeyValuePair", () => {
                                          ["This empty array should also be unset", []],
                                          // html
                                          ["This should be bold", (<strong>grrr!</strong>)],
+                                         //numbers
+                                         ["Integer", 1],
+                                         ["Float", 3.14],
                                        ]);
   }
 


### PR DESCRIPTION
- The component was rendering number as '(Not specified)'. Ideally it
  should render the value of type number as it is.

### Before the fix
<img width="1348" alt="screen shot 2018-12-04 at 8 33 03 pm" src="https://user-images.githubusercontent.com/7871209/49450824-d6f87e80-f803-11e8-8f60-21f8c665e088.png">

### After the fix
<img width="1355" alt="screen shot 2018-12-04 at 8 32 21 pm" src="https://user-images.githubusercontent.com/7871209/49450845-e2e44080-f803-11e8-8478-3f76f5f14607.png">
