### PR TITLE
confirepos fix artifact_origin default to gocd

### DIFF
--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/configrepo/codec/TypeAdapter.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/configrepo/codec/TypeAdapter.java
@@ -33,7 +33,7 @@ public abstract class TypeAdapter {
         JsonPrimitive originField = (JsonPrimitive) jsonObject.get(origin);
         String typeName = prim.getAsString();
 
-        Class<?> klass = classForName(typeName, originField == null ? null : originField.getAsString());
+        Class<?> klass = classForName(typeName, originField == null ? "gocd" : originField.getAsString());
         return context.deserialize(jsonObject, klass);
     }
 

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/configrepo/contract/tasks/CRAbstractFetchTask.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/configrepo/contract/tasks/CRAbstractFetchTask.java
@@ -30,8 +30,9 @@ public abstract class CRAbstractFetchTask extends CRTask {
     protected ArtifactOrigin artifactOrigin;
 
     public CRAbstractFetchTask(String type,
-                               ArtifactOrigin gocd) {
+                               ArtifactOrigin artifactOrigin) {
         super(type);
+        this.artifactOrigin = artifactOrigin;
     }
 
     protected CRAbstractFetchTask(String pipeline, String stage, String job, String type) {

--- a/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/configrepo/contract/tasks/CRFetchArtifactTest.java
+++ b/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/configrepo/contract/tasks/CRFetchArtifactTest.java
@@ -94,5 +94,29 @@ public class CRFetchArtifactTest extends CRBaseTest<CRFetchArtifactTask> {
         assertThat(deserializedValue.getRunIf(),is(CRRunIf.passed));
         assertNull(deserializedValue.getDestination());
         assertThat(deserializedValue.sourceIsDirectory(),is(true));
+        assertThat(deserializedValue.getArtifactOrigin(), is(CRAbstractFetchTask.ArtifactOrigin.gocd));
+    }
+
+    @Test
+    public void shouldDeserializeWhenArtifactOriginIsNull()
+    {
+        String json = "{\n" +
+                "              \"type\" : \"fetch\",\n" +
+                "              \"pipeline\" : \"pip\",\n" +
+                "              \"stage\" : \"build1\",\n" +
+                "              \"job\" : \"build\",\n" +
+                "              \"source\" : \"bin\",\n" +
+                "              \"run_if\" : \"passed\"\n" +
+                "            }";
+        CRFetchArtifactTask deserializedValue = (CRFetchArtifactTask)gson.fromJson(json,CRTask.class);
+
+        assertThat(deserializedValue.getPipelineName(),is("pip"));
+        assertThat(deserializedValue.getJob(),is("build"));
+        assertThat(deserializedValue.getStage(),is("build1"));
+        assertThat(deserializedValue.getSource(),is("bin"));
+        assertThat(deserializedValue.getRunIf(),is(CRRunIf.passed));
+        assertNull(deserializedValue.getDestination());
+        assertThat(deserializedValue.sourceIsDirectory(),is(true));
+        assertThat(deserializedValue.getArtifactOrigin(), is(CRAbstractFetchTask.ArtifactOrigin.gocd));
     }
 }


### PR DESCRIPTION
Concerns fetch tasks defined in configrepos.
The original intentions were that when `artifact_origin` is not returned by plugin then its value should be considered as 'gocd'.
This is isn't really a bug, because if plugin is using anything below `format_version: 3` then lack of `artifact_origin` in fetch tasks is migrated and set to `gocd`.
But if any user like me, has been migrating each configrepo in advance to `format_version: 3` without really adding `artifact_origin`, then after upgrade there is a surprise of quite a lot of invalid repositories.
I see no reason why `artifact_origin` should not default to `gocd`. I think this what @varshavaradarajan indented in https://github.com/gocd/gocd/pull/4888 but we missed a few points during review which were supposed to do it.

## Effect
In YAML we can write:
```yaml
format_version: 3
# ...
fetch:
  run_if: any
  pipeline: pipe2
  stage: upstream_stage
  job: upstream_job
  destination: test
```
And expect it to be equivalent of
```yaml
format_version: 3
# ...
fetch:
  run_if: any
  artifact_origin: gocd
  pipeline: pipe2
  stage: upstream_stage
  job: upstream_job
  destination: test
```