### PR TITLE
Changed config_xml link for group admins #000

### DIFF
--- a/server/webapp/WEB-INF/rails/webpack/views/components/site_menu/index.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/components/site_menu/index.tsx
@@ -172,7 +172,7 @@ export default class SiteMenu extends MithrilViewComponent<Attrs> {
               <SiteSubNavItem href="/go/admin/pipelines" text="Pipelines"/>
               <SiteSubNavItem href="/go/admin/templates" text="Templates"/>
               <SiteSubNavItem href="/go/admin/elastic_profiles" text="Elastic Agent Profiles"/>
-              <SiteSubNavItem href="/go/admin/config_xml" text="Config XML"/>
+              <SiteSubNavItem href="/go/admin/pipelines/snippet" text="Config XML"/>
               <SiteSubNavItem href="/go/admin/plugins" text="Plugins"/>
               <SiteSubNavItem href="/go/admin/package_repositories/new" text="Package Repositories"/>
             </SiteSubNav>

--- a/server/webapp/WEB-INF/rails/webpack/views/components/site_menu/spec/index_spec.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/components/site_menu/spec/index_spec.tsx
@@ -128,7 +128,7 @@ describe("Site Menu", () => {
     expect(findMenuItem("/go/admin/config_repos")).not.toBeInDOM();
     expect(findMenuItem("/go/admin/templates")).toHaveText("Templates");
     expect(findMenuItem("/go/admin/elastic_profiles")).toHaveText("Elastic Agent Profiles");
-    expect(findMenuItem("/go/admin/config_xml")).toHaveText("Config XML");
+    expect(findMenuItem("/go/admin/pipelines/snippet")).toHaveText("Config XML");
     expect(findMenuItem("/go/admin/config/server")).not.toBeInDOM();
     expect(findMenuItem("/go/admin/users")).not.toBeInDOM();
     expect(findMenuItem("/go/admin/backup")).not.toBeInDOM();


### PR DESCRIPTION
* Group Admins can view a snippet of the config_xml over the entire
  config. The config_xml was incorrectly linked to show the entire config,
  changed to pipeline snippets.