### PR TITLE
Add running jobs information to drain mode info API (#5190)

### DIFF
--- a/server/src/main/java/com/thoughtworks/go/server/dao/JobInstanceDao.java
+++ b/server/src/main/java/com/thoughtworks/go/server/dao/JobInstanceDao.java
@@ -68,4 +68,6 @@ public interface JobInstanceDao {
     int totalCompletedJobsOnAgent(String uuid);
 
     boolean isJobCompleted(JobIdentifier jobIdentifier);
+
+    List<JobInstance> getRunningJobs();
 }

--- a/server/src/main/java/com/thoughtworks/go/server/dao/JobInstanceSqlMapDao.java
+++ b/server/src/main/java/com/thoughtworks/go/server/dao/JobInstanceSqlMapDao.java
@@ -306,6 +306,10 @@ public class JobInstanceSqlMapDao extends SqlMapClientDaoSupport implements JobI
         return buildingJobs(getActiveJobIds());
     }
 
+    public List<JobInstance> getRunningJobs() {
+        return  getSqlMapClientTemplate().queryForList("getRunningJobs");
+    }
+
     public List<JobInstance> completedJobsOnAgent(String uuid,
                                                   JobInstanceService.JobHistoryColumns jobHistoryColumns,
                                                   SortOrder order,

--- a/server/src/main/java/com/thoughtworks/go/server/service/JobInstanceService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/JobInstanceService.java
@@ -236,6 +236,10 @@ public class JobInstanceService implements JobPlanLoader, ConfigChangedListener 
         return jobInstanceDao.getBuildingJobs();
     }
 
+    public List<JobInstance> allRunningJobs() {
+        return jobInstanceDao.getRunningJobs();
+    }
+
     public void registerJobStateChangeListener(JobStatusListener jobStatusListener) {
         synchronized (LISTENERS_MODIFICATION_MUTEX) {
             listeners.add(jobStatusListener);

--- a/server/src/main/resources/com/thoughtworks/go/server/dao/maps/JobInstance.xml
+++ b/server/src/main/resources/com/thoughtworks/go/server/dao/maps/JobInstance.xml
@@ -281,6 +281,11 @@
         AND builds.state in ('Scheduled', 'Assigned', 'Preparing', 'Building', 'Completing')
     </select>
 
+    <select id="getRunningJobs" resultMap="select-build-with-identifier">
+        <include refid="select-builds-with-identifier"/>
+        WHERE state in ('Scheduled', 'Assigned', 'Preparing', 'Building', 'Completing')
+    </select>
+
     <select id="completedJobsOnAgent" resultMap="select-build-with-identifier-transitions">
         SELECT
         joined.id,

--- a/server/src/main/resources/com/thoughtworks/go/server/dao/maps/JobInstance.xml
+++ b/server/src/main/resources/com/thoughtworks/go/server/dao/maps/JobInstance.xml
@@ -283,7 +283,7 @@
 
     <select id="getRunningJobs" resultMap="select-build-with-identifier">
         <include refid="select-builds-with-identifier"/>
-        WHERE state in ('Scheduled', 'Assigned', 'Preparing', 'Building', 'Completing')
+        WHERE state != 'Completed'
     </select>
 
     <select id="completedJobsOnAgent" resultMap="select-build-with-identifier-transitions">

--- a/server/src/test-fast/java/com/thoughtworks/go/server/service/JobInstanceServiceTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/service/JobInstanceServiceTest.java
@@ -52,6 +52,8 @@ import org.springframework.transaction.support.TransactionCallbackWithoutResult;
 
 import java.sql.SQLException;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 import static com.thoughtworks.go.helper.JobInstanceMother.completed;
 import static com.thoughtworks.go.helper.JobInstanceMother.scheduled;
@@ -415,5 +417,19 @@ public class JobInstanceServiceTest {
         pipelineConfigChangedListener.onEntityConfigChange(PipelineConfigMother.pipelineConfig("p1", "s_new", new MaterialConfigs(), "j1"));
         assertThat(serverHealthService.logs().errorCount(), is(1));
         assertThat(serverHealthService.logs().get(0).getType().getScope().getScope(), is("p2/s2/j2"));
+    }
+
+    @Test
+    public void shouldGetRunningJobsFromJobInstanceDao() {
+        List<JobInstance> expectedRunningJobs = Arrays.asList(job);
+        when(jobInstanceDao.getRunningJobs()).thenReturn(expectedRunningJobs);
+
+        JobInstanceService jobService = new JobInstanceService(jobInstanceDao, null, null, jobStatusCache, transactionTemplate, transactionSynchronizationManager, null, null, goConfigService,
+                null, pluginManager, serverHealthService);
+
+        List<JobInstance> jobInstances = jobService.allRunningJobs();
+
+        assertThat(jobInstances, is(expectedRunningJobs));
+        verify(jobInstanceDao).getRunningJobs();
     }
 }


### PR DESCRIPTION
* Show the information of running (scheduled+building) jobs along with assigned agent information

Response JSON:
```
{
  "_links" : {
    "self" : {
      "href" : "http://localhost:8153/go/api/admin/drain_mode/info"
    },
    "doc" : {
      "href" : "https://api.gocd.org/current/#drain-mode-info"
    }
  },
  "_embedded" : {
    "is_completely_drained" : false,
    "running_systems" : {
      "mdu" : [ ],
      "jobs" : [ {
        "pipeline_name" : "up42",
        "pipeline_counter" : 10,
        "stage_name" : "up42_stage",
        "stage_counter" : "1",
        "name" : "up42_job",
        "state" : "Scheduled",
        "scheduled_date" : "2018-12-06T08:28:37Z",
        "agent_uuid" : null
      } ]
    }
  }
}
```