### PR TITLE
Fix VSM pipeline error message styles (#5514)

### DIFF
--- a/server/webapp/WEB-INF/rails/app/assets/javascripts/vsm_renderer.js
+++ b/server/webapp/WEB-INF/rails/app/assets/javascripts/vsm_renderer.js
@@ -426,7 +426,8 @@ Graph_Renderer = function (container) {
         if (node.instances != null && node.instances != undefined) {
             gui += '<h3 title="' + node.name + '"><a href="' + node.locator + '">' + node.name + '</a></h3>';
             if(node.can_edit) {
-                gui += '<div class="pipeline_actions"> <a class="icon16 setting" href="'+ node.edit_path + '"></a> </div>'
+              var hasWarningClass = (node.view_type === 'WARNING') ? 'has-warning': '';
+              gui += '<div class="pipeline_actions '+ hasWarningClass +'"> <a class="icon16 setting" href="'+ node.edit_path + '"></a> </div>'
             }
             if (node.instances != undefined && node.instances.length > 0 && node.instances[0].stages) {
                 gui += '<ul class="instances">';

--- a/server/webapp/WEB-INF/rails/app/assets/stylesheets/module.scss
+++ b/server/webapp/WEB-INF/rails/app/assets/stylesheets/module.scss
@@ -2501,10 +2501,10 @@ li.task_property {
 .vsm-entity .warning {
     background: image_url('g9/icons/icon_warning_16.png') no-repeat 0 0;
     color: red;
-    padding-bottom: inherit;
+    padding-bottom: 10px;
     font-weight: bold;
     padding-left: 21px;
-    line-height: 20px;
+    line-height: 17px;
 }
 
 .vsm-entity.conflicts {
@@ -2829,6 +2829,10 @@ li.task_property {
     position: absolute;
     right:    -4px;
     top:      9px;
+}
+
+.pipeline_actions.has-warning {
+  top: 39px;
 }
 
 .usercomment{


### PR DESCRIPTION
Screenshots:
![screen shot 2018-12-06 at 3 02 02 pm](https://user-images.githubusercontent.com/15275847/49575745-7420f780-f969-11e8-8816-4f14899d5aea.png)

![screen shot 2018-12-06 at 3 11 54 pm](https://user-images.githubusercontent.com/15275847/49575750-784d1500-f969-11e8-9d1c-03911544edb5.png)

---

Added an extra class to not disturb the existing styles.

---

These styles were broken due commit: 1c1f2fe0d4ebda46ddfe0766ce50d580039a3f77. When we introduced allowing pipeline edits through VSM