### PR TITLE
Add `name` attribute to Header Icon and use it for `data-test-id`

### DIFF
--- a/server/webapp/WEB-INF/rails/webpack/views/components/header_icon/index.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/components/header_icon/index.tsx
@@ -17,19 +17,23 @@
 import {MithrilComponent} from "jsx/mithril-component";
 import * as _ from "lodash";
 import * as m from "mithril";
+import * as s from "underscore.string";
 import * as styles from "./index.scss";
 
 interface Attrs {
   imageUrl?: string; //an image URL of the icon
-  dataTestId?: string;
+  name?: string;
 }
 
 export class HeaderIcon extends MithrilComponent<Attrs> {
 
   view(vnode: m.Vnode<Attrs>) {
+    const name = vnode.attrs.name || "Unknown Icon";
+    const dataTestId = s.slugify(name);
+
     if (vnode.attrs.imageUrl) {
       return <div class={styles.headerIcon}>
-        <img data-test-id={vnode.attrs.dataTestId} src={vnode.attrs.imageUrl}/>
+        <img alt={vnode.attrs.name} data-test-id={dataTestId} src={vnode.attrs.imageUrl}/>
       </div>;
     }
     if (vnode.children && !_.isEmpty(vnode.children)) {
@@ -38,7 +42,7 @@ export class HeaderIcon extends MithrilComponent<Attrs> {
       </div>;
     }
     return <div class={styles.headerIcon}>
-      <span className={styles.unknownIcon}/>
+      <span aria-label={name} className={styles.unknownIcon}/>
     </div>;
   }
 

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/config_repos/config_repos_widget.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/config_repos/config_repos_widget.tsx
@@ -76,7 +76,7 @@ class HeaderWidget extends MithrilViewComponent<HeaderWidgetAttrs> {
 
     if (_.isEmpty(vnode.attrs.repo.lastParse())) {
       return (
-        <HeaderIcon>
+        <HeaderIcon name="Never Parsed">
           <span className={styles.neverParsed}
                 title={`This configuration repository was never parsed.`}/>
         </HeaderIcon>
@@ -85,14 +85,14 @@ class HeaderWidget extends MithrilViewComponent<HeaderWidgetAttrs> {
 
     if (vnode.attrs.repo.lastParse().success()) {
       return (
-        <HeaderIcon>
+        <HeaderIcon name="Last Parse Good">
           <span className={styles.goodLastParseIcon}
                 title={`Last parsed with revision ${vnode.attrs.repo.lastParse().revision}`}/>
         </HeaderIcon>
       );
     } else {
       return (
-        <HeaderIcon>
+        <HeaderIcon name="Last Parse Error">
           <span className={styles.lastParseErrorIcon}
                 title={`Last parsed with revision ${vnode.attrs.repo.lastParse().revision}. The error was ${vnode.attrs.repo.lastParse().error}`}/>
         </HeaderIcon>

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/elastic_profiles/elastic_profiles_widget.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/elastic_profiles/elastic_profiles_widget.tsx
@@ -152,7 +152,7 @@ export class ElasticProfilesWidget extends MithrilComponent<Attrs, {}> {
 
   private static createImageTag(pluginInfo: PluginInfo<any> | undefined) {
     if (pluginInfo && pluginInfo.imageUrl) {
-      return <HeaderIcon dataTestId="plugin-icon" imageUrl={pluginInfo.imageUrl}/>;
+      return <HeaderIcon name="Plugin Icon" imageUrl={pluginInfo.imageUrl}/>;
     }
     return <HeaderIcon/>;
   }

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/new_plugins/plugin_widget.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/new_plugins/plugin_widget.tsx
@@ -97,7 +97,7 @@ export class PluginWidget extends MithrilViewComponent<Attrs> {
 
     return (
       <CollapsiblePanel dataTestId="plugin-row"
-                        header={<PluginHeaderWidget image={<HeaderIcon imageUrl={pluginInfo.imageUrl}/>}
+                        header={<PluginHeaderWidget image={<HeaderIcon name="Plugin Icon" imageUrl={pluginInfo.imageUrl}/>}
                                                     pluginName={pluginInfo.about.name}
                                                     pluginVersion={pluginInfo.about.version}
                                                     pluginId={pluginInfo.id}/>}


### PR DESCRIPTION
I've only added the `alt` attribute for accessibility, since screen-readers parse that correctly and `aria-label` would be redundant.