### PR TITLE
Remove default plugin id for config_repo #5430

### DIFF
--- a/config/config-api/src/main/java/com/thoughtworks/go/config/remote/ConfigRepoConfig.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/remote/ConfigRepoConfig.java
@@ -26,6 +26,7 @@ import org.apache.commons.lang3.StringUtils;
 import java.util.*;
 
 import static java.lang.String.format;
+import static org.apache.commons.lang3.StringUtils.isBlank;
 
 /**
  * Defines single source of remote configuration and name of plugin to interpet it.
@@ -43,7 +44,7 @@ public class ConfigRepoConfig implements Validatable, Cacheable {
     // TODO something must instantiate this name into proper implementation of ConfigProvider
     // which can be a plugin or embedded class
     @ConfigAttribute(value = "pluginId", allowNull = false)
-    private String pluginId = "gocd-xml";
+    private String pluginId;
     // plugin-name which will process the repository tree to return configuration.
     // as in https://github.com/gocd/gocd/issues/1133#issuecomment-109014208
     // then pattern-based plugin is just one option
@@ -85,13 +86,13 @@ public class ConfigRepoConfig implements Validatable, Cacheable {
     }
 
     public void setId(String id) {
-        if (StringUtils.isBlank(id))
+        if (isBlank(id))
             id = null;
         this.id = id;
     }
 
     public void setPluginId(String pluginId) {
-        if (StringUtils.isBlank(pluginId))
+        if (isBlank(pluginId))
             pluginId = null;
         this.pluginId = pluginId;
     }
@@ -115,6 +116,7 @@ public class ConfigRepoConfig implements Validatable, Cacheable {
     @Override
     public void validate(ValidationContext validationContext) {
         this.validatePresenceOfId();
+        this.validatePresenceOfPluginId();
         this.validateUniquenessOfId(validationContext);
         this.validateRepoIsSet();
         this.validateMaterial(validationContext);
@@ -195,8 +197,14 @@ public class ConfigRepoConfig implements Validatable, Cacheable {
     }
 
     private void validatePresenceOfId() {
-        if (this.getId() == null) {
+        if (isBlank(this.getId())) {
             this.errors.add(ID, "Configuration repository id not specified");
+        }
+    }
+
+    private void validatePresenceOfPluginId() {
+        if (isBlank(this.getPluginId())) {
+            this.errors.add("plugin_id", "Configuration repository plugin_id not specified");
         }
     }
 

--- a/config/config-api/src/test/java/com/thoughtworks/go/config/remote/ConfigRepoConfigTest.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/config/remote/ConfigRepoConfigTest.java
@@ -36,6 +36,7 @@ public class ConfigRepoConfigTest {
         config.setPluginId("myplugin");
         assertThat(config.getPluginId(),is("myplugin"));
     }
+
     @Test
     public void shouldReturnNullPluginNameWhenEmpty() {
         ConfigRepoConfig config = new ConfigRepoConfig();
@@ -75,6 +76,18 @@ public class ConfigRepoConfigTest {
         assertThat(configRepoConfig1.errors().isEmpty(),is(false));
         assertThat(configRepoConfig1.errors().on("id"),
                 is("You have defined multiple configuration repositories with the same id - 'id_1'."));
+    }
+
+    @Test
+    public void validate_shouldCheckPresenceOfPluginId() {
+        ConfigSaveValidationContext validationContext = ConfigSaveValidationContext.forChain(new BasicCruiseConfig());
+
+        ConfigRepoConfig configRepo = new ConfigRepoConfig(null,null, "id_1");
+        configRepo.validate(validationContext);
+
+        assertThat(configRepo.errors().isEmpty(),is(false));
+        assertThat(configRepo.errors().on("plugin_id"),
+                is("Configuration repository plugin_id not specified"));
     }
 
     @Test

--- a/server/src/main/java/com/thoughtworks/go/config/update/ConfigRepoCommand.java
+++ b/server/src/main/java/com/thoughtworks/go/config/update/ConfigRepoCommand.java
@@ -25,6 +25,7 @@ import com.thoughtworks.go.plugin.access.configrepo.ConfigRepoExtension;
 import com.thoughtworks.go.server.domain.Username;
 import com.thoughtworks.go.server.service.SecurityService;
 import com.thoughtworks.go.server.service.result.HttpLocalizedOperationResult;
+import org.apache.commons.lang3.StringUtils;
 
 import static com.thoughtworks.go.i18n.LocalizedMessage.forbiddenToEdit;
 import static com.thoughtworks.go.serverhealth.HealthStateType.forbidden;
@@ -79,8 +80,8 @@ abstract class ConfigRepoCommand implements EntityConfigUpdateCommand<ConfigRepo
     }
 
     private void validateConfigRepoPluginId(ConfigRepoConfig configRepo) {
-        if (!configRepoExtension.canHandlePlugin(configRepo.getPluginId())) {
-            configRepo.addError("plugin_id", format("Invalid plugin id: %s", configRepo.getPluginId()));
+        if (isNotBlank(configRepo.getPluginId()) && !configRepoExtension.canHandlePlugin(configRepo.getPluginId())) {
+            this.configRepo.addError("plugin_id", format("Invalid plugin id: %s", configRepo.getPluginId()));
         }
     }
 


### PR DESCRIPTION
* Removing the default plugin id 'gocd_xml' as the ConfigRepo
  is required to have a valid plugin id.