### PR TITLE
Show the first personalization tab pipelines on dashboard load (#5512)

### DIFF
--- a/server/webapp/WEB-INF/rails/webpack/single_page_apps/new_dashboard.js
+++ b/server/webapp/WEB-INF/rails/webpack/single_page_apps/new_dashboard.js
@@ -23,6 +23,7 @@ const DashboardWidget = require('views/dashboard/dashboard_widget');
 const PluginInfos     = require('models/shared/plugin_infos');
 const AjaxPoller      = require('helpers/ajax_poller').AjaxPoller;
 const PageLoadError   = require('views/shared/page_load_error');
+const Personalization = require("models/dashboard/personalization");
 
 const PersonalizeVM   = require('views/dashboard/models/personalization_vm');
 
@@ -213,7 +214,10 @@ $(() => {
     dashboardVM.searchText(m.route.param('searchedBy') || '');
   };
 
-  repeater().start();
+  Personalization.get().then((personalization) => {
+    currentView(personalization.names()[0]);
+    repeater().start();
+  }, onInitialApiFailure);
 
   const onPluginInfosResponse = (pluginInfos) => {
     pluginInfos.eachPluginInfo((pluginInfo) => {
@@ -226,13 +230,13 @@ $(() => {
     renderView();
   };
 
-  const onPluginInfoApiFailure = (response) => {
+  function onInitialApiFailure (response) {
     m.mount(dashboardElem.get(0), {
       view() {
         return (<PageLoadError message={response}/>);
       }
     });
-  };
+  }
 
-  PluginInfos.all(null, {type: 'analytics'}).then(onPluginInfosResponse, onPluginInfoApiFailure);
+  PluginInfos.all(null, {type: 'analytics'}).then(onPluginInfosResponse, onInitialApiFailure);
 });


### PR DESCRIPTION
* On a dashboard load, personalization, dashboard, plugin-infos calls are made parallely,
  Many of the times, dashboard call is made before fetching the personalization.
  As there is no current-tab information, the entire dashboard is fetched as displayed.

Fix:
* On a dashboard load, firstly, fetch the personalization tabs information, and then make
  a call to get the dashboard information for the first tab.