### PR TITLE
Fix links pointing to pipeline dependency graph (#5406)

### DIFF
--- a/server/webapp/WEB-INF/rails/app/helpers/pipelines_helper.rb
+++ b/server/webapp/WEB-INF/rails/app/helpers/pipelines_helper.rb
@@ -90,7 +90,7 @@ module PipelinesHelper
   end
 
   def url_for_dmr(dmr)
-    stage_detail_tab_pipeline_path({:pipeline_name => dmr.getPipelineName(), :pipeline_counter => dmr.getPipelineCounter(), :stage_name => dmr.getStageName(), :stage_counter => dmr.getStageCounter()})
+    "/go/pipelines/value_stream_map/#{dmr.getPipelineName()}/#{dmr.getPipelineCounter()}"
   end
 
   def with_pipeline_analytics_support(&block)

--- a/server/webapp/WEB-INF/rails/app/views/shared/_build_cause.html.erb
+++ b/server/webapp/WEB-INF/rails/app/views/shared/_build_cause.html.erb
@@ -25,7 +25,7 @@
                     </div>
                     <div class="label">
                         <dl>
-                            <dt>Instance:</dt>
+                            <dt>VSM:</dt>
                             <dd><%= link_to(scope[:dmr].getPipelineLabel(), url_for_dmr(scope[:dmr])) -%></dd>
                         </dl>
                     </div>

--- a/server/webapp/WEB-INF/rails/spec/helpers/pipelines_helper_spec.rb
+++ b/server/webapp/WEB-INF/rails/spec/helpers/pipelines_helper_spec.rb
@@ -114,7 +114,7 @@ describe PipelinesHelper do
 
   it "should return the url for given DMR" do
     dmr = DependencyMaterialRevision.create("blah-pipeline", 2, "blah-label", "blah-stage", 3)
-    expect(url_for_dmr(dmr)).to eq("/pipelines/blah-pipeline/2/blah-stage/3/pipeline")
+    expect(url_for_dmr(dmr)).to eq("/go/pipelines/value_stream_map/blah-pipeline/2")
   end
 
   it "should return the dom id for a pipeline group" do

--- a/server/webapp/WEB-INF/rails/spec/views/shared/_build_cause_html_spec.rb
+++ b/server/webapp/WEB-INF/rails/spec/views/shared/_build_cause_html_spec.rb
@@ -114,8 +114,8 @@ describe "/shared/_build_cause.html.erb" do
           expect(revision).to have_selector("dd a[href='/pipelines/up_pipeline/10/up_stage/5']", :text => "up_pipeline/10/up_stage/5")
         end
         change.find(".label").tap do |label|
-          expect(label).to have_selector("dt", :text => "Instance:")
-          expect(label).to have_selector("dd a[href='/pipelines/up_pipeline/10/up_stage/5/pipeline']", :text => "label-10")
+          expect(label).to have_selector("dt", :text => "VSM:")
+          expect(label).to have_selector("dd a[href='/go/pipelines/value_stream_map/up_pipeline/10']", :text => "label-10")
         end
         change.find(".completed_at").tap do |completed_at|
           expect(completed_at).to have_selector("dt", "Completed at:")

--- a/server/webapp/WEB-INF/rails/spec/views/shared/_build_cause_popup_html_spec.rb
+++ b/server/webapp/WEB-INF/rails/spec/views/shared/_build_cause_popup_html_spec.rb
@@ -95,7 +95,7 @@ describe "/shared/_build_cause_popup.html.erb" do
       end
       build_cause.find("##{@dependency_material_id}_0.change.changed").tap do |first_dependency_material_modification|
         expect(first_dependency_material_modification).to have_selector(".revision a[href='/pipelines/up_pipeline/10/up_stage/5']", text: "up_pipeline/10/up_stage/5")
-        expect(first_dependency_material_modification).to have_selector(".label a[href='/pipelines/up_pipeline/10/up_stage/5/pipeline']", text: "label-10")
+        expect(first_dependency_material_modification).to have_selector(".label a[href='/go/pipelines/value_stream_map/up_pipeline/10']", text: "label-10")
         expect(first_dependency_material_modification).to have_selector(".completed_at", text: "#{@dependency_revisions.getModification(0).getModifiedTime().iso8601}")
       end
     end

--- a/server/webapp/WEB-INF/rails/spec/webpack/views/dashboard/trigger_with_options/material_revision_widget_spec.js
+++ b/server/webapp/WEB-INF/rails/spec/webpack/views/dashboard/trigger_with_options/material_revision_widget_spec.js
@@ -147,7 +147,7 @@ describe("Dashboard Material Revision Widget", () => {
 
     it('should contain a link to stage details page showing pipeline dependencies of the run of the upstream pipeline run', () => {
       const pipelineDependencyLink = $root.find('.comment a').get(0);
-      expect(pipelineDependencyLink.href.indexOf(`/go/pipelines/${pipelineRevisionJson.modifications[0].revision}/pipeline`)).not.toBe(-1);
+      expect(pipelineDependencyLink.href.indexOf(`/go/pipelines/value_stream_map/up42/2`)).not.toBe(-1);
     });
 
   });

--- a/server/webapp/WEB-INF/rails/webpack/views/dashboard/trigger_with_options/material_revision_widget.js.msx
+++ b/server/webapp/WEB-INF/rails/webpack/views/dashboard/trigger_with_options/material_revision_widget.js.msx
@@ -23,14 +23,16 @@ const CommentWidget = require('views/dashboard/comment_render_widget');
 const PipelineModificationWidget = (modification) => {
   const modifiedAtLocalTime  = TimeFormatter.format(modification.modifiedTime);
   const modifiedAtServerTime = TimeFormatter.formatInServerTime(modification.modifiedTime);
+  const pipelineName         = modification.revision.split('/')[0];
+  const pipelineCounter      = modification.revision.split('/')[1];
 
   return (<div class="modifications">
       <div class="item modified_by">
         <a href={modification.stageDetailsUrl}>{modification.revision}</a>
       </div>
-      <div class="item comment">
-        <a href={`/go/pipelines/${modification.revision}/pipeline`}>{modification.pipelineLabel}</a>
-      </div>
+      <span class="item comment">
+        VSM: <a href={`/go/pipelines/value_stream_map/${pipelineName}/${pipelineCounter}`}>{modification.pipelineLabel}</a>
+      </span>
       <div class="item modified-time" title={modifiedAtServerTime}>{modifiedAtLocalTime}</div>
     </div>
   );


### PR DESCRIPTION
* Change all the links pointing to pipeline-dependency graph to pipeline VSM

#### Fixes:
* Modification popup on dashboard pipeline.
* Stage details page dependency instance link.

#### Screenshots
![screen shot 2018-12-10 at 10 02 05 am](https://user-images.githubusercontent.com/15275847/49711007-ed1e9880-fc62-11e8-9310-87e236235f93.png)
![screen shot 2018-12-10 at 10 02 27 am](https://user-images.githubusercontent.com/15275847/49711008-ed1e9880-fc62-11e8-9069-37bc159d6cfd.png)
