### PR TITLE
Remove unnecessary IE8 check from VSM controller

### DIFF
--- a/server/webapp/WEB-INF/rails/app/controllers/value_stream_map_controller.rb
+++ b/server/webapp/WEB-INF/rails/app/controllers/value_stream_map_controller.rb
@@ -18,8 +18,6 @@ class ValueStreamMapController < ApplicationController
   include ApplicationHelper, PipelinesHelper
   layout "value_stream_map"
 
-  before_action :redirect_to_stage_pdg_if_ie8, :only => [:show]
-
   def show
     begin
       @pipeline = pipeline_service.findPipelineByNameAndCounter(params[:pipeline_name], params[:pipeline_counter].to_i)
@@ -65,16 +63,6 @@ class ValueStreamMapController < ApplicationController
     end
     pipeline_edit_path_proc = proc {|pipeline_name| edit_path_for_pipeline(pipeline_name)}
     ValueStreamMapModel.new(vsm, result.message(), vsm_path_partial, vsm_material_path_partial, stage_detail_path_partial, pipeline_edit_path_proc).to_json
-  end
-
-  def redirect_to_stage_pdg_if_ie8
-    format = params[:format]
-    user_agent = request.env["HTTP_USER_AGENT"]
-    if (is_ie8?(user_agent) and (format.blank? || format == :html))
-      result = HttpOperationResult.new
-      pim = pipeline_history_service.findPipelineInstance(params[:pipeline_name], params[:pipeline_counter].to_i, current_user, result)
-      redirect_to url_for_pipeline_instance(pim)
-    end
   end
 
 end

--- a/server/webapp/WEB-INF/rails/app/helpers/pipelines_helper.rb
+++ b/server/webapp/WEB-INF/rails/app/helpers/pipelines_helper.rb
@@ -85,11 +85,6 @@ module PipelinesHelper
     "#{prefix}for_pipeline_#{counter}"
   end
 
-  def url_for_pipeline_instance(pipeline, options = {})
-    stage = pipeline.latestStage()
-    stage_detail_tab_pipeline_path(options.merge({:pipeline_name => pipeline.getName(), :pipeline_counter => pipeline.getCounter(), :stage_name => stage.getName(), :stage_counter => stage.getCounter()}))
-  end
-
   def url_for_pipeline_value_stream_map(pipeline, options = {})
     vsm_show_path(options.merge({:pipeline_name => pipeline.getName(), :pipeline_counter => pipeline.getCounter(), :action => "show"}))
   end

--- a/server/webapp/WEB-INF/rails/spec/controllers/value_stream_map_controller_spec.rb
+++ b/server/webapp/WEB-INF/rails/spec/controllers/value_stream_map_controller_spec.rb
@@ -48,46 +48,6 @@ describe ValueStreamMapController do
     @pipeline_edit_path_quick_edit = proc { |pipeline_name | edit_admin_pipeline_config_path(:pipeline_name => pipeline_name) }
   end
 
-  describe "redirect_to_stage_pdg_if_ie8" do
-    before :each do
-      @pipeline_history_service = double('pipeline history service')
-      allow(controller).to receive(:pipeline_history_service).and_return(@pipeline_history_service)
-    end
-
-    it "should redirect to old pdg page when user is accessing via IE8" do
-      allow(controller).to receive(:is_ie8?).and_return(true)
-      pim = double('PIM')
-      expect(@pipeline_history_service).to receive(:findPipelineInstance).with('foo', 42, @user, an_instance_of(HttpOperationResult)).and_return(pim)
-      allow(controller).to receive(:url_for_pipeline_instance).with(pim).and_return('/some_funky_url')
-
-      get :show, params:{ pipeline_name: 'foo', pipeline_counter: '42' }
-
-      expect(response.status).to eq(302)
-      expect(response).to redirect_to("/some_funky_url")
-    end
-
-    it "should not redirect to old pdg page when user is accessing via IE8 but requesting format is not HTML" do
-      allow(controller).to receive(:is_ie8?).and_return(true)
-      allow(controller).to receive(:generate_vsm_json).and_return('some_json')
-      expect(@pipeline_history_service).to receive(:findPipelineInstance).never
-      expect(@pipeline_service).to receive(:findPipelineByNameAndCounter).with('foo', 42).and_return('pipeline')
-
-      get :show, params:{ pipeline_name: 'foo', pipeline_counter: '42', format: 'json' }
-
-      expect(response.status).to eq(200)
-    end
-
-    it "should not redirect to old pdg page when user is using a browser other than IE8" do
-      allow(controller).to receive(:is_ie8?).and_return(false)
-      expect(@pipeline_history_service).to receive(:findPipelineInstance).never
-      expect(@pipeline_service).to receive(:findPipelineByNameAndCounter).with('foo', 42).and_return('pipeline')
-
-      get :show, params:{ pipeline_name: 'foo', pipeline_counter: '42' }
-
-      expect(response.status).to eq(200)
-    end
-  end
-
   describe "show" do
     it "should route to pdg show path" do
       expect(controller.send(:vsm_show_path, { pipeline_name: "P", pipeline_counter: 1, format: "json" })).to eq("/pipelines/value_stream_map/P/1.json")

--- a/server/webapp/WEB-INF/rails/spec/helpers/pipelines_helper_spec.rb
+++ b/server/webapp/WEB-INF/rails/spec/helpers/pipelines_helper_spec.rb
@@ -102,11 +102,6 @@ describe PipelinesHelper do
     expect(material_type(MaterialsMother.dependencyMaterial("blah_pipeline", "blah_stage"))).to eq "dependency"
   end
 
-  it "should return the url for given pipeline instance" do
-    pim = pipeline_model("blah-pipeline", "blah-label", false, false, "working with agent", false).getLatestPipelineInstance()
-    expect(url_for_pipeline_instance(pim)).to eq "/pipelines/blah-pipeline/5/cruise/10/pipeline"
-  end
-
   it "should return the url for value stream map of given pipeline instance" do
     pim = pipeline_model("blah-pipeline", "blah-label", false, false, "working with agent", false).getLatestPipelineInstance()
     expect(url_for_pipeline_value_stream_map(pim)).to eq("/pipelines/value_stream_map/blah-pipeline/5")


### PR DESCRIPTION
* VSM page redirects to pipeline-dependency page if loaded on IE8
* Remove explicit IE8 check because:
	- IE8 is an unsupported browser.
	- A generic unsupported browser message is shown on all pages
	  if application is loaded on IE.