### PR TITLE
Fix plugin settings edit page-spinner

### DIFF
--- a/server/webapp/WEB-INF/rails/webpack/views/components/modal/index.scss
+++ b/server/webapp/WEB-INF/rails/webpack/views/components/modal/index.scss
@@ -19,6 +19,7 @@ $overlay-bg: rgba(0, 0, 0, 0.8);
 $overlay-header-bg: $go-darkblue;
 $overlay-width: 500px;
 $overlay-height: 500px;
+$minimum-overlay-height: 150px;
 $overlay-border-color: $global-border-color;
 $overlay-header-txt: #fff;
 
@@ -102,13 +103,10 @@ $overlay-header-txt: #fff;
   overflow-y: auto;
   @media(max-width: $screen-md-min) {
     max-height: calc(100vh - 168px);
-
   }
   @media(min-width: $screen-md) {
-    //TODO Fix this
     max-height: $overlay-height;
-    //min-height: $overlay-height;
-    //max-height: 730px;
+    min-height: $minimum-overlay-height;
   }
 
 }


### PR DESCRIPTION
* Show page spinner in the overlay before contents are loaded.

Screenshot:
![screen shot 2018-12-10 at 2 18 39 pm](https://user-images.githubusercontent.com/15275847/49720706-87440800-fc86-11e8-98d5-a696972ae897.png)

### **NOTE** Though, With this fix, we might face some whitespace issues, on the plugin settings modal.

#### Eg: YAML config repo plugin
##### Before fix:
![screen shot 2018-12-10 at 2 12 15 pm](https://user-images.githubusercontent.com/15275847/49720839-c4a89580-fc86-11e8-8188-d83d3b24c937.png)

##### After fix:
![screen shot 2018-12-10 at 2 17 59 pm](https://user-images.githubusercontent.com/15275847/49720847-cd996700-fc86-11e8-961a-534d1b363378.png)

If we are OK to live with this whitespace issue (only for plugins with one property), this PR can be merged.
\cc: @akshaydewan @ketan @naveenbhaskar @adityasood 