### PR TITLE
Fix extra whitespace on all modals (#5464)

### DIFF
--- a/server/webapp/WEB-INF/rails/webpack/views/components/modal/index.scss
+++ b/server/webapp/WEB-INF/rails/webpack/views/components/modal/index.scss
@@ -19,7 +19,6 @@ $overlay-bg: rgba(0, 0, 0, 0.8);
 $overlay-header-bg: $go-darkblue;
 $overlay-width: 500px;
 $overlay-height: 500px;
-$minimum-overlay-height: 150px;
 $overlay-border-color: $global-border-color;
 $overlay-header-txt: #fff;
 
@@ -106,7 +105,6 @@ $overlay-header-txt: #fff;
   }
   @media(min-width: $screen-md) {
     max-height: $overlay-height;
-    min-height: $minimum-overlay-height;
   }
 
 }

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/new_plugins/index.scss
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/new_plugins/index.scss
@@ -16,6 +16,7 @@
 @import "../../global/common";
 
 $collapse-icon-size: 25px;
+$spinner-wrapper-height: 175px;
 
 .plugin-header {
   display:     flex;
@@ -32,7 +33,7 @@ $collapse-icon-size: 25px;
     vertical-align: middle;
   }
   @media (min-width: $screen-md) {
-    display: flex;
+    display:     flex;
     align-items: center;
   }
 }
@@ -48,6 +49,7 @@ $collapse-icon-size: 25px;
     font-size: 15px;
   }
 }
+
 .unknown-plugin-icon {
   @include icon-before($type: $fa-var-question, $color: $icon-light-color, $margin: 5px, $size: 25px);
   display: block;
@@ -61,4 +63,8 @@ $collapse-icon-size: 25px;
 
 .plugins-list {
   display: block;
+}
+
+.spinner-wrapper {
+  min-height: $spinner-wrapper-height;
 }

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/new_plugins/index.scss.d.ts
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/new_plugins/index.scss.d.ts
@@ -6,3 +6,4 @@ export const unknownPluginIcon: string;
 export const pluginsPage: string;
 export const keyValuePairInline: string;
 export const pluginsList: string;
+export const spinnerWrapper: string;

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/new_plugins/plugin_settings_modal.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/new_plugins/plugin_settings_modal.tsx
@@ -24,6 +24,7 @@ import {FlashMessage, MessageType} from "views/components/flash_message";
 import {Modal, Size} from "views/components/modal";
 import {Spinner} from "views/components/spinner";
 import * as foundationStyles from "./foundation_hax.scss";
+import * as styles from "./index.scss";
 
 const AngularPluginNew = require("views/shared/angular_plugin_new");
 const Stream           = require("mithril/stream");
@@ -53,7 +54,7 @@ export class PluginSettingsModal extends Modal {
     }
 
     if (!this.pluginSettings) {
-      return <Spinner/>;
+      return <div class={styles.spinnerWrapper}><Spinner/></div>;
     }
 
     return (


### PR DESCRIPTION
* Do not add a minimum height to the modal body.
* If any of the modal-body content requires a minimum height,
  Add a wrapper container around the body and style the wrapper
  element

Issue comment:
https://github.com/gocd/gocd/issues/5464#issuecomment-446593668

##### Fixes
* Extra whitespace on config repo delete popup.
* Spinner styles on plugin settings.

##### Screenshots
![screen shot 2018-12-13 at 11 26 25 am](https://user-images.githubusercontent.com/15275847/49919236-ea72ac00-fecb-11e8-9833-5b3e89173a7b.png)
![screen shot 2018-12-13 at 11 30 06 am](https://user-images.githubusercontent.com/15275847/49919237-eb0b4280-fecb-11e8-9975-50cf30bc9291.png)
