### PR TITLE
addresses Bug #5471, where auth Token in material is visible in logs

### DIFF
--- a/config/config-api/src/main/java/com/thoughtworks/go/util/command/UrlArgument.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/util/command/UrlArgument.java
@@ -87,14 +87,22 @@ public class UrlArgument extends CommandArgument {
     }
 
     private String clean(String userInfo) {
-        String[] userAndPassword = userInfo.split(":");
-        StringBuilder result = new StringBuilder();
-        result.append(userAndPassword[0]);
-        if (userAndPassword.length > 1) {
-            result.append(":");
-            result.append("******");
+
+        if (userInfo.contains(":"))
+        {
+            String[] userAndPassword = userInfo.split(":");
+            StringBuilder result = new StringBuilder();
+            result.append(userAndPassword[0]);
+            if (userAndPassword.length > 1) {
+                result.append(":");
+                result.append("******");
+            }
+            return result.toString();
         }
-        return result.toString();
+        else if (userInfo.length() <= 32)
+            return userInfo;
+
+        return "******";
     }
 
     public static UrlArgument create(String url) {

--- a/config/config-api/src/test/java/com/thoughtworks/go/util/command/UrlArgumentTest.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/util/command/UrlArgumentTest.java
@@ -133,4 +133,9 @@ public class UrlArgumentTest {
         Assert.assertThat(result, IsNot.not(StringContains.containsString("cce:password")));
     }
 
+    @Test //BUG #5471
+    public void shouldMaskAuthTokenInUrl() {
+        UrlArgument url = new UrlArgument("https://9bf58jhrb32f29ad0c3983a65g594f1464jgf9a3@somewhere");
+        Assert.assertThat(url.forDisplay(), Is.is("https://******@somewhere"));
+    }
 }


### PR DESCRIPTION
https://github.com/gocd/gocd/issues/5471

As of yet, there is no way to effectively differentiate between a normal ssh login as:
    "svn+ssh://user@10.18.7.51:8153";
and auth Token
    ""https://9bf58jhrb32f29ad0c3983a65g594f1464jgf9a3@somewhere"
since both of them would result in the same regex.
For now, I check "logininfo" for character length and if it is larger than 32, I assume an Auth Token.

Also notice UrlArgument class is becoming more complex. I would suggest to refactor the cleaning (masking of credentials) to another class and inject that to url argument, this way separation of concerns can be achieved.