### PR TITLE
Store and show username of user who cancelled a stage.

### DIFF
--- a/common/src/test/java/com/thoughtworks/go/domain/StageTest.java
+++ b/common/src/test/java/com/thoughtworks/go/domain/StageTest.java
@@ -257,22 +257,22 @@ public class StageTest {
 
     @Test
     public void shouldReturnCreatedDateWhenNoTranstions() throws Exception {
-        stage = new Stage("dev", new JobInstances(), "anonymous", "manual", new TimeProvider());
+        stage = new Stage("dev", new JobInstances(), "anonymous", null, "manual", new TimeProvider());
         assertEquals(new Date(stage.getCreatedTime().getTime()), stage.latestTransitionDate());
     }
 
     @Test
     public void shouldCreateAStageWithAGivenConfigVersion() {
-        Stage stage = new Stage("foo-stage", new JobInstances(), "admin", "manual", false, false, "git-sha", new TimeProvider());
+        Stage stage = new Stage("foo-stage", new JobInstances(), "admin", null,"manual", false, false, "git-sha", new TimeProvider());
         assertThat(stage.getConfigVersion(), is("git-sha"));
 
-        stage = new Stage("foo-stage", new JobInstances(), "admin", "manual", new TimeProvider());
+        stage = new Stage("foo-stage", new JobInstances(), "admin", null, "manual", new TimeProvider());
         assertThat(stage.getConfigVersion(), is(nullValue()));
     }
 
     @Test
     public void shouldSetTheCurrentTimeAsCreationTimeForRerunOfJobs() {
-        Stage stage = new Stage("foo-stage", new JobInstances(), "admin", "manual", false, false, "git-sha", new TimeProvider());
+        Stage stage = new Stage("foo-stage", new JobInstances(), "admin", null,"manual", false, false, "git-sha", new TimeProvider());
         Timestamp createdTimeOfRun1 = stage.getCreatedTime();
         long minuteAfter = DateTimeUtils.currentTimeMillis() + 60000;
         freezeTime(minuteAfter);

--- a/common/src/test/java/com/thoughtworks/go/server/service/InstanceFactoryTest.java
+++ b/common/src/test/java/com/thoughtworks/go/server/service/InstanceFactoryTest.java
@@ -93,7 +93,7 @@ public class InstanceFactoryTest {
         jobInstances.add(new JobInstance("job1", clock));
         jobInstances.add(new JobInstance("job2", clock));
 
-        Stage expectedStage = new Stage("first", jobInstances, "Unknown", Approval.SUCCESS, clock);
+        Stage expectedStage = new Stage("first", jobInstances, "Unknown", null, Approval.SUCCESS, clock);
         assertThat(actualStage, is(expectedStage));
     }
 
@@ -830,7 +830,7 @@ public class InstanceFactoryTest {
     }
 
     private Stage stage(long id, JobInstance... jobs) {
-        Stage stage = new Stage("dev", new JobInstances(jobs), "anonymous", "manual", new TimeProvider());
+        Stage stage = new Stage("dev", new JobInstances(jobs), "anonymous", null, "manual", new TimeProvider());
         stage.setId(id);
         return stage;
     }

--- a/domain/src/main/java/com/thoughtworks/go/domain/NullStage.java
+++ b/domain/src/main/java/com/thoughtworks/go/domain/NullStage.java
@@ -24,7 +24,7 @@ import com.thoughtworks.go.util.TimeProvider;
 public final class NullStage extends Stage {
 
     public NullStage(String stageName, JobInstances nullBuilds) {
-        super(stageName, nullBuilds, null, null, new TimeProvider());
+        super(stageName, nullBuilds, null, null, null, new TimeProvider());
     }
 
     public NullStage(String stageName) {

--- a/domain/src/main/java/com/thoughtworks/go/domain/Stage.java
+++ b/domain/src/main/java/com/thoughtworks/go/domain/Stage.java
@@ -34,6 +34,7 @@ public class Stage extends PersistentObject {
     private String name;
     private JobInstances jobInstances = new JobInstances();
     private String approvedBy;
+    private String cancelledBy;
     private int orderId;
     private Timestamp createdTime;
     private Timestamp lastTransitionedTime;
@@ -57,22 +58,23 @@ public class Stage extends PersistentObject {
     public Stage() {
     }
 
-    public Stage(String name, JobInstances jobInstances, String approvedBy, String approvalType, final Clock clock) {
-        this(name, jobInstances, approvedBy, approvalType, StageConfig.DEFAULT_FETCH_MATERIALS, StageConfig.DEFAULT_CLEAN_WORKING_DIR, clock);
+    public Stage(String name, JobInstances jobInstances, String approvedBy, String cancelledBy, String approvalType, final Clock clock) {
+        this(name, jobInstances, approvedBy, cancelledBy, approvalType, StageConfig.DEFAULT_FETCH_MATERIALS, StageConfig.DEFAULT_CLEAN_WORKING_DIR, clock);
     }
 
-    public Stage(String name, JobInstances jobInstances, String approvedBy, String approvalType, boolean fetchMaterials, boolean cleanWorkingDir, final Clock clock) {
+    public Stage(String name, JobInstances jobInstances, String approvedBy, String cancelledBy, String approvalType, boolean fetchMaterials, boolean cleanWorkingDir, final Clock clock) {
         this.name = name;
         this.jobInstances = jobInstances;
         this.approvedBy = approvedBy;
+        this.cancelledBy = cancelledBy;
         this.approvalType = approvalType;
         this.fetchMaterials = fetchMaterials;
         this.cleanWorkingDir = cleanWorkingDir;
         this.createdTime = new Timestamp(clock.currentTimeMillis());
     }
 
-    public Stage(String name, JobInstances jobInstances, String approvedBy, String approvalType, boolean fetchMaterials, boolean cleanWorkingDir, String configVersion, final Clock clock) {
-        this(name, jobInstances, approvedBy, approvalType, fetchMaterials, cleanWorkingDir, clock);
+    public Stage(String name, JobInstances jobInstances, String approvedBy, String cancelledBy, String approvalType, boolean fetchMaterials, boolean cleanWorkingDir, String configVersion, final Clock clock) {
+        this(name, jobInstances, approvedBy, cancelledBy, approvalType, fetchMaterials, cleanWorkingDir, clock);
         this.configVersion = configVersion;
     }
 
@@ -169,6 +171,14 @@ public class Stage extends PersistentObject {
 
     public void setApprovedBy(String approvedBy) {
         this.approvedBy = approvedBy;
+    }
+
+    public String getCancelledBy() {
+        return cancelledBy;
+    }
+
+    public void setCancelledBy(String cancelledBy) {
+        this.cancelledBy = cancelledBy;
     }
 
     public boolean isApproved() {
@@ -375,6 +385,9 @@ public class Stage extends PersistentObject {
         if (approvedBy != null ? !approvedBy.equals(stage.approvedBy) : stage.approvedBy != null) {
             return false;
         }
+        if (cancelledBy != null ? !cancelledBy.equals(stage.cancelledBy) : stage.cancelledBy != null) {
+            return false;
+        }
         if (createdTime != null ? !createdTime.equals(stage.createdTime) : stage.createdTime != null) {
             return false;
         }
@@ -398,6 +411,7 @@ public class Stage extends PersistentObject {
         result1 = 31 * result1 + (name != null ? name.hashCode() : 0);
         result1 = 31 * result1 + (jobInstances != null ? jobInstances.hashCode() : 0);
         result1 = 31 * result1 + (approvedBy != null ? approvedBy.hashCode() : 0);
+        result1 = 31 * result1 + (cancelledBy != null ? cancelledBy.hashCode() : 0);
         result1 = 31 * result1 + orderId;
         result1 = 31 * result1 + (createdTime != null ? createdTime.hashCode() : 0);
         result1 = 31 * result1 + (approvalType != null ? approvalType.hashCode() : 0);

--- a/domain/src/main/java/com/thoughtworks/go/server/service/InstanceFactory.java
+++ b/domain/src/main/java/com/thoughtworks/go/server/service/InstanceFactory.java
@@ -48,7 +48,7 @@ public class InstanceFactory {
 
     public Stage createStageInstance(StageConfig stageConfig, SchedulingContext context, String md5, Clock clock) {
         return new Stage(CaseInsensitiveString.str(stageConfig.name()), createJobInstances(stageConfig, context, clock),
-                context.getApprovedBy(), stageConfig.approvalType(), stageConfig.isFetchMaterials(), stageConfig.isCleanWorkingDir(), md5, clock);
+                context.getApprovedBy(), null, stageConfig.approvalType(), stageConfig.isFetchMaterials(), stageConfig.isCleanWorkingDir(), md5, clock);
     }
 
     public Stage createStageForRerunOfJobs(Stage stage, List<String> jobNames, SchedulingContext context, StageConfig stageConfig, Clock clock, String latestMd5) {

--- a/domain/src/test/java/com/thoughtworks/go/helper/StageMother.java
+++ b/domain/src/test/java/com/thoughtworks/go/helper/StageMother.java
@@ -45,7 +45,7 @@ public class StageMother {
         JobInstance instance3 = JobInstanceMother.scheduled("scheduledBuild");
         JobInstances instances = new JobInstances(instance1, instance2, instance3);
 
-        Stage stage = new Stage(stageName, instances, DEFAULT_APPROVED_BY, null, new TimeProvider());
+        Stage stage = new Stage(stageName, instances, DEFAULT_APPROVED_BY, null, null, new TimeProvider());
         stage.setId(stageId);
         return stage;
     }
@@ -68,7 +68,7 @@ public class StageMother {
         for (String buildName : buildNames) {
             builds.add(JobInstanceMother.buildEndingWithState(endState, result, buildName));
         }
-        Stage stage = new Stage(stageName, builds, DEFAULT_APPROVED_BY, null, new TimeProvider());
+        Stage stage = new Stage(stageName, builds, DEFAULT_APPROVED_BY, null, null, new TimeProvider());
         stage.calculateResult();
         stage.setCompletedByTransitionId(stage.getJobInstances().last().getTransitions().latestTransitionId());
         return stage;
@@ -210,7 +210,7 @@ public class StageMother {
     }
 
     public static Stage custom(String pipelineName, String stageName, JobInstances instances) {
-        Stage stage = new Stage(stageName, instances, DEFAULT_APPROVED_BY, GoConstants.APPROVAL_SUCCESS, new TimeProvider());
+        Stage stage = new Stage(stageName, instances, DEFAULT_APPROVED_BY, null, GoConstants.APPROVAL_SUCCESS, new TimeProvider());
         stage.setIdentifier(new StageIdentifier(pipelineName, 1, "1", stageName, "1"));
         stage.building();
         return stage;

--- a/server/db/migrate/h2deltas/1901001_add_cancelled_by_to_stages_table.sql
+++ b/server/db/migrate/h2deltas/1901001_add_cancelled_by_to_stages_table.sql
@@ -1,0 +1,24 @@
+
+--
+-- Copyright 2018 ThoughtWorks, Inc.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--    http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+ALTER TABLE stages ADD COLUMN cancelledBy varchar(255);
+
+--//@UNDO
+
+ALTER TABLE stages DROP COLUMN cancelledBy;
+
+

--- a/server/src/main/java/com/thoughtworks/go/domain/feed/stage/StageFeedEntry.java
+++ b/server/src/main/java/com/thoughtworks/go/domain/feed/stage/StageFeedEntry.java
@@ -40,6 +40,7 @@ public class StageFeedEntry implements FeedEntry {
     private List<Author> authors = new ArrayList<>();
     private List<MingleCard> mingleCards = new ArrayList<>();
     private String approvedBy;
+    private String cancelledBy;
     private String approvalType;
 
     protected StageFeedEntry() {
@@ -55,10 +56,11 @@ public class StageFeedEntry implements FeedEntry {
         this.stageResult = result;
     }
 
-    public StageFeedEntry(long id, long pipelineId, StageIdentifier identifier, long entryId, Date updateDate, StageResult result, String approvalType, String approvedBy) {
+    public StageFeedEntry(long id, long pipelineId, StageIdentifier identifier, long entryId, Date updateDate, StageResult result, String approvalType, String approvedBy, String cancelledBy) {
         this(id, pipelineId, identifier, entryId, updateDate, result);
         this.approvalType = approvalType;
         this.approvedBy = approvedBy;
+        this.cancelledBy = cancelledBy;
     }
 
     public String getResult() {
@@ -170,5 +172,9 @@ public class StageFeedEntry implements FeedEntry {
 
     public String getApprovedBy() {
         return approvedBy;
+    }
+
+    public String getCancelledBy() {
+        return cancelledBy;
     }
 }

--- a/server/src/main/java/com/thoughtworks/go/server/dao/StageDao.java
+++ b/server/src/main/java/com/thoughtworks/go/server/dao/StageDao.java
@@ -55,7 +55,7 @@ public interface StageDao extends JobDurationStrategy {
 
     Integer getStageOrderInPipeline(long pipelineId, String stageName);
 
-    void updateResult(Stage stage, StageResult result);
+    void updateResult(Stage stage, StageResult result, String username);
 
     int getMaxStageCounter(long pipelineId, String stageName);
 

--- a/server/src/main/java/com/thoughtworks/go/server/dao/StageSqlMapDao.java
+++ b/server/src/main/java/com/thoughtworks/go/server/dao/StageSqlMapDao.java
@@ -48,7 +48,6 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.DataRetrievalFailureException;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.TransactionStatus;
 import org.springframework.transaction.support.TransactionCallback;
 import org.springframework.transaction.support.TransactionSynchronizationAdapter;
 
@@ -282,7 +281,7 @@ public class StageSqlMapDao extends SqlMapClientDaoSupport implements StageDao, 
         return (Integer) getSqlMapClientTemplate().queryForObject("getStageOrderInPipeline", params);
     }
 
-    public void updateResult(final Stage stage, final StageResult result) {
+    public void updateResult(final Stage stage, final StageResult result, String username) {
         transactionSynchronizationManager.registerSynchronization(new TransactionSynchronizationAdapter() {
             @Override
             public void afterCommit() {
@@ -295,6 +294,7 @@ public class StageSqlMapDao extends SqlMapClientDaoSupport implements StageDao, 
         getSqlMapClientTemplate().update("updateStageStatus", arguments("stageId", stage.getId())
                 .and("result", result.toString())
                 .and("state", stage.getState())
+                .and("cancelledBy", username)
                 .and("completedByTransitionId", stage.getCompletedByTransitionId()).asMap());
 
         upddateLastTransitionedTime(stage);

--- a/server/src/main/java/com/thoughtworks/go/server/service/ScheduleService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/ScheduleService.java
@@ -505,7 +505,7 @@ public class ScheduleService {
             transactionTemplate.executeWithExceptionHandling(new com.thoughtworks.go.server.transaction.TransactionCallbackWithoutResult() {
                 @Override
                 public void doInTransactionWithoutResult(TransactionStatus status) {
-                    stageService.cancelStage(stage);
+                    stageService.cancelStage(stage, user);
                 }
             });
 

--- a/server/src/main/java/com/thoughtworks/go/server/ui/StageSummaryModel.java
+++ b/server/src/main/java/com/thoughtworks/go/server/ui/StageSummaryModel.java
@@ -56,6 +56,10 @@ public class StageSummaryModel {
         return stage.getApprovedBy();
     }
 
+    public String getCancelledBy() {
+        return stage.getCancelledBy();
+    }
+
     public long getId() {
         return stage.getId();
     }

--- a/server/src/main/resources/com/thoughtworks/go/server/dao/maps/Stage.xml
+++ b/server/src/main/resources/com/thoughtworks/go/server/dao/maps/Stage.xml
@@ -20,6 +20,7 @@
         <result property="name" column="stageName"/>
         <result property="pipelineId" column="pipelineId"/>
         <result property="approvedBy" column="approvedBy"/>
+        <result property="cancelledBy" column="cancelledBy"/>
         <result property="createdTime" column="createdTime"/>
         <result property="orderId" column="orderId"/>
         <result property="result" column="stageResult"/>
@@ -87,6 +88,7 @@
         <id property="id" column="stageId"/>
         <result property="name" column="stageName"/>
         <result property="approvedBy" column="approvedBy"/>
+        <result property="cancelledBy" column="cancelledBy"/>
         <result property="approvalType" column="approvalType"/>
         <result property="counter" column="stageCounter"/>
         <result property="result" column="stageResult"/>
@@ -125,7 +127,7 @@
 
     <update id="updateStageStatus">
         UPDATE stages
-        SET result = #{result}, completedByTransitionId = #{completedByTransitionId}, state = #{state}
+        SET result = #{result}, completedByTransitionId = #{completedByTransitionId}, state = #{state}, cancelledBy = #{cancelledBy}
         WHERE stages.id = #{stageId}
     </update>
 
@@ -215,6 +217,7 @@
         stages.counter as stageCounter,
         stages.pipelineId as pipelineId,
         stages.approvedBy,
+        stages.cancelledBy,
         stages.createdTime,
         stages.orderId,
         stages.result as stageResult,
@@ -247,6 +250,7 @@
         <result property="pipelineId" column="pipelineId"/>
         <result property="approvalType" column="approvalType"/>
         <result property="approvedBy" column="approvedBy"/>
+        <result property="cancelledBy" column="cancelledBy"/>
         <collection property="identifier" resultMap="Stage.stageIdentifier"/>
     </resultMap>
 
@@ -259,6 +263,7 @@
             stages.result AS stageResult,
             stages.pipelineid as pipelineId,
             stages.approvedBy,
+            stages.cancelledBy,
             stages.approvalType,
             stages.latestRun,
             stages.fetchMaterials,
@@ -294,6 +299,7 @@
             stages.fetchMaterials,
             stages.cleanWorkingDir,
             stages.approvedBy,
+            stages.cancelledBy,
             stages.approvalType,
             (SELECT stateChangeTime FROM buildstatetransitions WHERE id = stages.completedByTransitionId) updateDate,
             pipelines.name as pipelineName,
@@ -356,6 +362,7 @@
         pipelines.counter as pipelineCounter,
         pipelines.label as pipelineLabel,
         stages.approvedBy,
+        stages.cancelledBy,
         stages.createdTime,
         stages.orderId,
         stages.result as stageResult,

--- a/server/src/test-fast/java/com/thoughtworks/go/server/dao/PipelineSqlMapDaoCachingTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/dao/PipelineSqlMapDaoCachingTest.java
@@ -317,7 +317,7 @@ public class PipelineSqlMapDaoCachingTest {
         // ensure cache is initialized
         pipelineDao.loadActivePipelines();
 
-        Stage stage = new Stage("first", new JobInstances(JobInstanceMother.assigned("job")), "me", "whatever", new TimeProvider());
+        Stage stage = new Stage("first", new JobInstances(JobInstanceMother.assigned("job")), "me", null, "whatever", new TimeProvider());
         stage.fail();
         stage.calculateResult();
         changeStageStatus(stage, 1);

--- a/server/src/test-fast/java/com/thoughtworks/go/server/presentation/models/StageJsonPresentationModelTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/presentation/models/StageJsonPresentationModelTest.java
@@ -238,7 +238,7 @@ public class StageJsonPresentationModelTest {
 
     @Test
     public void shouldEncodeStageLocator() throws Exception {
-        Stage stage1 = new Stage("stage-c%d", new JobInstances(), GoConstants.DEFAULT_APPROVED_BY, "manual", new TimeProvider());
+        Stage stage1 = new Stage("stage-c%d", new JobInstances(), GoConstants.DEFAULT_APPROVED_BY, null, "manual", new TimeProvider());
         stage1.setIdentifier(new StageIdentifier("pipeline-a%b", 1, "label-1", "stage-c%d", "1"));
         StageJsonPresentationModel presenter = new StageJsonPresentationModel(pipeline, stage1, null, agentService);
         Map json = presenter.toJson();
@@ -247,7 +247,7 @@ public class StageJsonPresentationModelTest {
 
     @Test
     public void shouldIncludeStageLocatorForDisplay() throws Exception {
-        Stage stage1 = new Stage("stage-c%d", new JobInstances(), GoConstants.DEFAULT_APPROVED_BY, "manual", new TimeProvider());
+        Stage stage1 = new Stage("stage-c%d", new JobInstances(), GoConstants.DEFAULT_APPROVED_BY, null, "manual", new TimeProvider());
         stage1.setIdentifier(new StageIdentifier("pipeline-a%b", 1, "label-1", "stage-c%d", "1"));
         StageJsonPresentationModel presenter = new StageJsonPresentationModel(pipeline, stage1, null, agentService);
         Map json = presenter.toJson();
@@ -258,7 +258,7 @@ public class StageJsonPresentationModelTest {
     @Test
     public void shouldEncodeBuildLocator() throws Exception {
         JobInstance job = JobInstanceMother.assigned("job-%");
-        Stage stage1 = new Stage("stage-c%d", new JobInstances(job), GoConstants.DEFAULT_APPROVED_BY, "manual", new TimeProvider());
+        Stage stage1 = new Stage("stage-c%d", new JobInstances(job), GoConstants.DEFAULT_APPROVED_BY, null, "manual", new TimeProvider());
         stage1.setIdentifier(new StageIdentifier("pipeline-a%b", 1, "label-1", "stage-c%d", "1"));
         job.setIdentifier(new JobIdentifier("pipeline-a%b", 1, "label-1", "stage-c%d", "1", "job-%", 0L));
         StageJsonPresentationModel presenter = new StageJsonPresentationModel(pipeline, stage1, null, agentService);

--- a/server/src/test-fast/java/com/thoughtworks/go/server/search/PipelineBuilder.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/search/PipelineBuilder.java
@@ -45,7 +45,7 @@ public class PipelineBuilder {
     }
 
     public PipelineBuilder addStage(String stageName) {
-        stages.add(new Stage(stageName, new JobInstances(), null, null, new TimeProvider()));
+        stages.add(new Stage(stageName, new JobInstances(), null, null, null, new TimeProvider()));
         return this;
     }
 

--- a/server/src/test-fast/java/com/thoughtworks/go/server/service/ScheduleServiceTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/service/ScheduleServiceTest.java
@@ -96,7 +96,7 @@ public class ScheduleServiceTest {
         assertThat(result.message(), is("Stage cancelled successfully."));
 
         verify(securityService).hasOperatePermissionForStage(pipeline.getName(), spiedStage.getName(), admin.getUsername().toString());
-        verify(stageService).cancelStage(spiedStage);
+        verify(stageService).cancelStage(spiedStage, admin.getUsername().toString());
         verify(spiedStage).isActive();
     }
 
@@ -156,7 +156,7 @@ public class ScheduleServiceTest {
         assertThat(result.httpCode(), is(SC_FORBIDDEN));
         assertThat(result.isSuccessful(), is(false));
         verify(securityService).hasOperatePermissionForStage(pipeline.getName(), spiedStage.getName(), admin.getUsername().toString());
-        verify(stageService, never()).cancelStage(spiedStage);
+        verify(stageService, never()).cancelStage(spiedStage, admin.getUsername().toString());
         verify(spiedStage).isActive();
     }
 

--- a/server/src/test-fast/java/com/thoughtworks/go/server/service/StageServiceTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/service/StageServiceTest.java
@@ -329,7 +329,7 @@ public class StageServiceTest {
         foundJob.setResult(JobResult.Unknown);
         JobInstances foundJobInstances = new JobInstances(foundJob);
 
-        Stage foundStage = new Stage(STAGE_NAME, foundJobInstances, "jez", "manual", new TimeProvider());
+        Stage foundStage = new Stage(STAGE_NAME, foundJobInstances, "jez", null, "manual", new TimeProvider());
         foundStage.calculateResult();
 
         assertThat(foundStage.getState(), is(not(StageState.Cancelled)));
@@ -346,7 +346,7 @@ public class StageServiceTest {
         assertThat(foundStage.getResult(), is(StageResult.Cancelled));
 
         verify(jobInstanceService).cancelJob(job);
-        verify(stageDao).updateResult(foundStage, StageResult.Cancelled);
+        verify(stageDao).updateResult(foundStage, StageResult.Cancelled, null);
     }
 
     @Test
@@ -510,7 +510,7 @@ public class StageServiceTest {
 
         transactionTemplate.execute(new TransactionCallbackWithoutResult() {
             public void doInTransactionWithoutResult(TransactionStatus status) {
-                service.cancelStage(cancelledStage);
+                service.cancelStage(cancelledStage, null);
             }
         });
 

--- a/server/src/test-fast/java/com/thoughtworks/go/server/service/StageServiceTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/service/StageServiceTest.java
@@ -531,7 +531,7 @@ public class StageServiceTest {
 
         transactionTemplate.execute(new TransactionCallbackWithoutResult() {
             public void doInTransactionWithoutResult(TransactionStatus status) {
-                service.cancelStage(cancelledStage);
+                service.cancelStage(cancelledStage, null);
             }
         });
 

--- a/server/src/test-integration/java/com/thoughtworks/go/server/dao/PipelineSqlMapDaoIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/dao/PipelineSqlMapDaoIntegrationTest.java
@@ -188,7 +188,7 @@ public class PipelineSqlMapDaoIntegrationTest {
 
     @Test
     public void shouldLoadNaturalOrder() throws SQLException {
-        Pipeline pipeline = new Pipeline("Test", BuildCause.createManualForced(), new Stage("dev", new JobInstances(new JobInstance("unit")), "anonymous", "manual", new TimeProvider()));
+        Pipeline pipeline = new Pipeline("Test", BuildCause.createManualForced(), new Stage("dev", new JobInstances(new JobInstance("unit")), "anonymous", null, "manual", new TimeProvider()));
         savePipeline(pipeline);
         dbHelper.updateNaturalOrder(pipeline.getId(), 2.5);
         PipelineInstanceModel loaded = pipelineDao.loadHistory("Test").get(0);
@@ -200,7 +200,7 @@ public class PipelineSqlMapDaoIntegrationTest {
 
     @Test
     public void shouldLoadStageResult() throws SQLException {
-        Stage stage = new Stage("dev", new JobInstances(new JobInstance("unit")), "anonymous", "manual", new TimeProvider());
+        Stage stage = new Stage("dev", new JobInstances(new JobInstance("unit")), "anonymous", null, "manual", new TimeProvider());
         stage.building();
         Pipeline pipeline = new Pipeline("Test", BuildCause.createManualForced(), stage);
         savePipeline(pipeline);
@@ -212,7 +212,7 @@ public class PipelineSqlMapDaoIntegrationTest {
 
     @Test
     public void shouldLoadStageIdentifier() throws SQLException {
-        Stage stage = new Stage("dev", new JobInstances(new JobInstance("unit")), "anonymous", "manual", new TimeProvider());
+        Stage stage = new Stage("dev", new JobInstances(new JobInstance("unit")), "anonymous", null, "manual", new TimeProvider());
         stage.building();
         Pipeline pipeline = new Pipeline("Test", BuildCause.createManualForced(), stage);
         savePipeline(pipeline);

--- a/server/src/test-integration/java/com/thoughtworks/go/server/dao/PipelineStateDaoIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/dao/PipelineStateDaoIntegrationTest.java
@@ -182,7 +182,7 @@ public class PipelineStateDaoIntegrationTest {
         final int[] errors = new int[1];
         for (int i = 0; i < 10; i++) {
             JobInstances jobInstances = new JobInstances(JobInstanceMother.completed("job"));
-            Stage stage = new Stage("stage-1", jobInstances, "shilpa", "auto", new TimeProvider());
+            Stage stage = new Stage("stage-1", jobInstances, "shilpa", null, "auto", new TimeProvider());
             final Pipeline pipeline = PipelineMother.pipeline("mingle", stage);
             pipeline.setCounter(i + 1);
             Thread thread = new Thread(new Runnable() {

--- a/server/src/test-integration/java/com/thoughtworks/go/server/dao/StageSqlMapDaoIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/dao/StageSqlMapDaoIntegrationTest.java
@@ -299,7 +299,7 @@ public class StageSqlMapDaoIntegrationTest {
         when(mockClient.queryForObject("getTotalStageCountForChart", toGet)).thenReturn(3).thenReturn(4);
 
         assertThat(stageDao.getTotalStageCountForChart("maar", "khoon"), is(3));//Should prime the cache
-        Stage stage = new Stage("khoon", new JobInstances(), "foo", "manual", new TimeProvider());
+        Stage stage = new Stage("khoon", new JobInstances(), "foo", null, "manual", new TimeProvider());
         Pipeline pipeline = new Pipeline("maar", "${COUNT}", BuildCause.createWithEmptyModifications(), new EnvironmentVariables(), stage);
         pipeline.setId(1);
         stageDao.save(pipeline, stage);//Should Invalidate the cache
@@ -319,7 +319,7 @@ public class StageSqlMapDaoIntegrationTest {
         when(mockClient.queryForObject("getTotalStageCountForChart", toGet)).thenReturn(3).thenReturn(4);
 
         assertThat(stageDao.getTotalStageCountForChart("maar", "khoon"), is(3));//Should prime the cache
-        Stage stage = new Stage("khoon", new JobInstances(), "foo", "manual", new TimeProvider());
+        Stage stage = new Stage("khoon", new JobInstances(), "foo", null,  "manual", new TimeProvider());
         stage.setIdentifier(new StageIdentifier("maar/2/khoon/1"));
         updateResultInTransaction(stage, StageResult.Cancelled);//Should Invalidate the cache
 
@@ -1940,7 +1940,7 @@ public class StageSqlMapDaoIntegrationTest {
             @Override
             protected void doInTransactionWithoutResult(TransactionStatus status) {
 
-                stageDao.updateResult(stage, result);
+                stageDao.updateResult(stage, result, null);
             }
         });
     }

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/BuildRepositoryServiceIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/BuildRepositoryServiceIntegrationTest.java
@@ -364,7 +364,7 @@ public class BuildRepositoryServiceIntegrationTest {
         final Stage stage = stageDao.mostRecentWithBuilds(CaseInsensitiveString.str(mingle.name()), devStage);
         transactionTemplate.execute(new TransactionCallbackWithoutResult() {
             public void doInTransactionWithoutResult(TransactionStatus status) {
-                stageService.cancelStage(stage);
+                stageService.cancelStage(stage, null);
             }
         });
 

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/GoPropertiesTestTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/GoPropertiesTestTest.java
@@ -94,7 +94,7 @@ public class GoPropertiesTestTest {
         final Stage firstStage = newPipeline.getFirstStage();
         transactionTemplate.execute(new TransactionCallbackWithoutResult() {
             public void doInTransactionWithoutResult(TransactionStatus status) {
-                stageService.cancelStage(stageService.stageById(firstStage.getId()));
+                stageService.cancelStage(stageService.stageById(firstStage.getId()), null);
             }
         });
         Pipeline pipelineFromDb = pipelineDao.mostRecentFullPipelineByName(newPipeline.getName());
@@ -109,7 +109,7 @@ public class GoPropertiesTestTest {
         final Stage firstStage = newPipeline.getFirstStage();
         transactionTemplate.execute(new TransactionCallbackWithoutResult() {
             public void doInTransactionWithoutResult(TransactionStatus status) {
-                stageService.cancelStage(stageService.stageById(firstStage.getId()));
+                stageService.cancelStage(stageService.stageById(firstStage.getId()), null);
             }
         });
 

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/ScheduleServiceRescheduleHungJobsIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/ScheduleServiceRescheduleHungJobsIntegrationTest.java
@@ -121,7 +121,7 @@ public class ScheduleServiceRescheduleHungJobsIntegrationTest {
 
         transactionTemplate.execute(new TransactionCallbackWithoutResult() {
             public void doInTransactionWithoutResult(TransactionStatus status) {
-                stageService.cancelStage(stageOf(pipeline));
+                stageService.cancelStage(stageOf(pipeline), null);
             }
         });
 

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/ScheduleServiceStageTriggerTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/ScheduleServiceStageTriggerTest.java
@@ -252,7 +252,7 @@ public class ScheduleServiceStageTriggerTest {
             public Object answer(InvocationOnMock invocationOnMock) throws Throwable {
                 throw new RuntimeException();
             }
-        }).when(stageService).cancelStage(stage);
+        }).when(stageService).cancelStage(stage, null);
 
         StageOrderService stageOrderService = mock(StageOrderService.class);
         SchedulingPerformanceLogger schedulingPerformanceLogger = mock(SchedulingPerformanceLogger.class);

--- a/server/src/test-shared/java/com/thoughtworks/go/server/dao/DatabaseAccessHelper.java
+++ b/server/src/test-shared/java/com/thoughtworks/go/server/dao/DatabaseAccessHelper.java
@@ -412,7 +412,7 @@ public class DatabaseAccessHelper extends HibernateDaoSupport {
         transactionTemplate.execute(new TransactionCallbackWithoutResult() {
             @Override
             protected void doInTransactionWithoutResult(TransactionStatus status) {
-                stageDao.updateResult(stage, stageResult);
+                stageDao.updateResult(stage, stageResult, null);
             }
         });
     }

--- a/server/webapp/WEB-INF/rails/app/views/api/pipelines/stage_feed.xml.erb
+++ b/server/webapp/WEB-INF/rails/app/views/api/pipelines/stage_feed.xml.erb
@@ -32,6 +32,12 @@
             </author>
             <%- end -%>
 
+            <%- if entry.getCancelledBy() -%>
+            <cancelledBy>
+                 <go:name><%= cdata_section(entry.getCancelledBy()) -%></go:name>
+            </cancelledBy>
+            <%- end -%>
+
             <% stage_link_title = entry.getStageIdentifier().getStageName() + " Stage Detail" %>
             <link title="<%=stage_link_title-%>" href="<%= resource_url(:id => entry.getId()) %>" rel="alternate" type="application/vnd.go+xml"/>
             <link title="<%=stage_link_title-%>" href="<%= page_url(entry.getStageIdentifier().getStageLocator()) %>" rel="alternate" type="text/html"/>

--- a/server/webapp/WEB-INF/rails/app/views/stages/_stage_result.html.erb
+++ b/server/webapp/WEB-INF/rails/app/views/stages/_stage_result.html.erb
@@ -1,2 +1,6 @@
 <div class="color_code <%= scope[:state] %>"></div>
+<% if scope[:cancelledBy] %>
+<span class="message" style="float:right; padding: 0;">Cancelled By: <%= scope[:cancelledBy] %></span>
+<% else %>
 <span class="message" style="float:right; padding: 0;"><%= scope[:state] %></span>
+<% end %>

--- a/server/webapp/WEB-INF/rails/app/views/stages/_stage_result.html.erb
+++ b/server/webapp/WEB-INF/rails/app/views/stages/_stage_result.html.erb
@@ -1,6 +1,6 @@
 <div class="color_code <%= scope[:state] %>"></div>
-<% if scope[:cancelledBy] %>
-<span class="message" style="float:right; padding: 0;">Cancelled By: <%= scope[:cancelledBy] %></span>
+<% if scope[:state].to_s.eql?"Cancelled" %>
+<span class="message" style="float:right; padding: 0;">Cancelled by: <%= scope[:cancelledBy].nil? ? "GoCD" : scope[:cancelledBy] %></span>
 <% else %>
 <span class="message" style="float:right; padding: 0;"><%= scope[:state] %></span>
 <% end %>

--- a/server/webapp/WEB-INF/rails/app/views/stages/_status_bar.html.erb
+++ b/server/webapp/WEB-INF/rails/app/views/stages/_status_bar.html.erb
@@ -11,7 +11,7 @@
     </div>
 
     <div class="result" id="stage_result">
-        <%= render :partial=> "stages/stage_result.html", :locals=>{:scope => {:state => @stage.getState()}}%>
+        <%= render :partial=> "stages/stage_result.html", :locals=>{:scope => {:state => @stage.getState(), :cancelledBy => @stage.getCancelledBy()}}%>
     </div>
 </div>
 

--- a/server/webapp/WEB-INF/rails/app/views/stages/stage.json.erb
+++ b/server/webapp/WEB-INF/rails/app/views/stages/stage.json.erb
@@ -13,7 +13,7 @@
             <%end%>
     <%end%>
     "pipeline_status_bar": {"html": <%== render_json :partial => "pipelines/status_bar.html.erb", :locals => {:scope => {:pipeline => @pipeline, :current_config_version => @current_config_version, :stage_config_version => @stage.getStage().getConfigVersion()}} %>},
-    "stage_result": {"html": <%== render_json :partial => "stage_result.html", :locals => {:scope => {:state => @stage.getState()}} %>},
+    "stage_result": {"html": <%== render_json :partial => "stage_result.html", :locals => {:scope => {:state => @stage.getState(), :cancelledBy => @stage.getCancelledBy()}} %>},
     "stage_run_details": {"html": <%== render_json :partial => "run_details.html", :locals => {:scope => {}} %>},
     "other_stage_runs": {"html": <%== render_json :partial => "other_stage_runs.html", :locals => {:scope => {}}  %>},
     "current_stage_run": {"html": <%== render_json :partial => "current_stage_run.html", :locals => {:scope => {}}  %>},

--- a/server/webapp/WEB-INF/rails/spec/views/api/pipelines/stage_feed_xml_spec.rb
+++ b/server/webapp/WEB-INF/rails/spec/views/api/pipelines/stage_feed_xml_spec.rb
@@ -28,7 +28,7 @@ describe "/api/feeds/index" do
     before(:each) do
       @date = java_date_utc(2004, 12, 25, 12, 0, 0)
       @entry1 = com.thoughtworks.go.domain.feed.stage.StageFeedEntry.new(1, 10,
-                com.thoughtworks.go.domain.StageIdentifier.new("pipeline-name", 1, 'pipeline-label', 'stage-name', 'stage-counter'), 99, @date, StageResult::Passed, "manual", "loser>boozer")
+                com.thoughtworks.go.domain.StageIdentifier.new("pipeline-name", 1, 'pipeline-label', 'stage-name', 'stage-counter'), 99, @date, StageResult::Passed, "manual", "loser>boozer", nil)
 
       @entry1.addAuthor(Author.new("user<loser", "loser@gmail.com"))
       @entry1.addAuthor(Author.new("user>boozer", "boozer@gmail.com"))
@@ -37,7 +37,7 @@ describe "/api/feeds/index" do
       @entry1.addCard(MingleCard.new(MingleConfig.new("https://boast", "project-dead"), "666"))
 
       @entry2 = com.thoughtworks.go.domain.feed.stage.StageFeedEntry.new(2, 11,
-                com.thoughtworks.go.domain.StageIdentifier.new("pipeline-name", 2, 'pipeline-label', 'stage-name', 'stage-counter'), 100, @date, StageResult::Cancelled, "success", "random_guy")
+                com.thoughtworks.go.domain.StageIdentifier.new("pipeline-name", 2, 'pipeline-label', 'stage-name', 'stage-counter'), 100, @date, StageResult::Cancelled, "success", "random_guy", "terminator")
 
       @entry2.addAuthor(Author.new("user anonymous", nil))
       @entry2.addCard(MingleCard.new(MingleConfig.new("https://ghost", "project.happy"), "42"))
@@ -186,6 +186,13 @@ describe "/api/feeds/index" do
 
       root = dom4j_root_for(response.body)
       expect(root.valueOf("//go:author/go:name/.")).to eq("loser>boozer")
+    end
+
+    it "should show cancelledBy if stage was cancelled by a user" do
+      render :template => '/api/pipelines/stage_feed.xml.erb'
+
+      root = dom4j_root_for(response.body)
+      expect(root.valueOf("//go:name/.")).to eq("terminator")
     end
   end
 


### PR DESCRIPTION
There are 3 places where this information should be shown
- [x] View - stage details page
- [x] Stage feed entry - access by /go/api/pipelines/pipeline_name/stages.xml
- [ ] API - https://api.gocd.org/current/#get-stage-instance and https://api.gocd.org/current/#get-stage-history - since these are old APIs, I haven't modified them as its a breaking change. Should I do that? Or should stage instance API and stage history API be converted to spark? 

