### PR TITLE
Make first collapsible panel expanded by default for consistency

### DIFF
--- a/server/webapp/WEB-INF/rails/webpack/views/pages/config_repos/config_repos_widget.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/config_repos/config_repos_widget.tsx
@@ -48,6 +48,7 @@ export interface Attrs<T> extends Operations<T>, RequiresPluginInfos {
 
 interface ShowObjectAttrs<T> extends Operations<T>, RequiresPluginInfos {
   obj: T;
+  index: number;
 }
 
 interface HeaderWidgetAttrs extends RequiresPluginInfos {
@@ -170,7 +171,7 @@ class ConfigRepoWidget extends MithrilViewComponent<ShowObjectAttrs<ConfigRepo>>
 
     return (
       <CollapsiblePanel header={<HeaderWidget repo={vnode.attrs.obj} pluginInfos={vnode.attrs.pluginInfos}/>}
-                        actions={actionButtons}>
+                        actions={actionButtons} expanded={vnode.attrs.index === 0}>
         {maybeWarning}
         {lastParseRevision}
         <KeyValuePair data={allAttributes}/>
@@ -254,11 +255,12 @@ export class ConfigReposWidget extends MithrilViewComponent<Attrs<ConfigRepo>> {
 
     return (
       <div>
-        {configRepos.map((configRepo) => {
+        {configRepos.map((configRepo, index) => {
           return (
             <ConfigRepoWidget key={configRepo.id()}
                               obj={configRepo}
                               pluginInfos={vnode.attrs.pluginInfos}
+                              index={index}
                               onEdit={(configRepo, e) => vnode.attrs.onEdit(configRepo, e)}
                               onRefresh={(configRepo, e) => vnode.attrs.onRefresh(configRepo, e)}
                               onDelete={(configRepo, e) => vnode.attrs.onDelete(configRepo, e)}

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/new_plugins/plugin_widget.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/new_plugins/plugin_widget.tsx
@@ -51,6 +51,7 @@ class PluginHeaderWidget extends MithrilViewComponent<PluginHeaderAttrs> {
 export interface Attrs {
   pluginInfo: PluginInfo<any>;
   isUserAnAdmin: boolean;
+  index: number;
   onEdit: (e: MouseEvent) => void;
 }
 
@@ -103,7 +104,7 @@ export class PluginWidget extends MithrilViewComponent<Attrs> {
                                                     pluginId={pluginInfo.id}/>}
                         actions={[statusReportButton, settingsButton]}
                         error={pluginInfo.hasErrors()}
-                        expanded={pluginInfo.status.isInvalid()}>
+                        expanded={pluginInfo.status.isInvalid() || vnode.attrs.index === 0}>
         <KeyValuePair data={pluginData}/>
       </CollapsiblePanel>
     );

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/new_plugins/plugins_widget.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/new_plugins/plugins_widget.tsx
@@ -68,12 +68,13 @@ export class PluginsWidget extends MithrilComponent<Attrs, State> {
     return (
       <div data-test-id="plugins-list">
         <FlashMessage type={MessageType.success} message={vnode.state.successMessage}/>
-        {_.sortBy(vnode.attrs.pluginInfos, (pluginInfo) => pluginInfo.id).map((pluginInfo: PluginInfo<any>) => {
+        {_.sortBy(vnode.attrs.pluginInfos, (pluginInfo) => pluginInfo.id).map((pluginInfo: PluginInfo<any>, index) => {
           return (
             <PluginWidget key={pluginInfo.id}
                           pluginInfo={pluginInfo}
                           onEdit={vnode.state.edit.bind(vnode.state, pluginInfo)}
-                          isUserAnAdmin={vnode.attrs.isUserAnAdmin}/>
+                          isUserAnAdmin={vnode.attrs.isUserAnAdmin}
+                          index={index}/>
           );
         })}
       </div>

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/new_plugins/spec/plugins_widget_spec.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/new_plugins/spec/plugins_widget_spec.tsx
@@ -67,13 +67,13 @@ describe("New Plugins Widget", () => {
     expect(notificationPluginHeader).toContainText(getNotificationPluginInfo().about.version);
   });
 
-  it("should render all valid plugin infos collapsed", () => {
+  it("should render first plugin info expanded and all other valid plugin infos collapsed", () => {
     expect(find("plugins-list").get(0).children).toHaveLength(4);
 
     const EAPluginInfo           = $root.find(`.${collapsiblePanelStyles.collapse}`).get(0);
     const NotificationPluginInfo = $root.find(`.${collapsiblePanelStyles.collapse}`).get(1);
 
-    expect(EAPluginInfo).not.toHaveClass(collapsiblePanelStyles.expanded);
+    expect(EAPluginInfo).toHaveClass(collapsiblePanelStyles.expanded);
     expect(NotificationPluginInfo).not.toHaveClass(collapsiblePanelStyles.expanded);
   });
 
@@ -90,21 +90,21 @@ describe("New Plugins Widget", () => {
     const EAPluginInfoHeader           = find("collapse-header").get(0);
     const NotificationPluginInfoHeader = find("collapse-header").get(1);
 
-    expect(EAPluginInfoHeader).not.toHaveClass(collapsiblePanelStyles.expanded);
+    expect(EAPluginInfoHeader).toHaveClass(collapsiblePanelStyles.expanded);
     expect(NotificationPluginInfoHeader).not.toHaveClass(collapsiblePanelStyles.expanded);
 
     //expand ea plugin info
     simulateEvent.simulate(EAPluginInfoHeader, "click");
     m.redraw();
 
-    expect(EAPluginInfoHeader).toHaveClass(collapsiblePanelStyles.expanded);
+    expect(EAPluginInfoHeader).not.toHaveClass(collapsiblePanelStyles.expanded);
     expect(NotificationPluginInfoHeader).not.toHaveClass(collapsiblePanelStyles.expanded);
 
     //expand notification plugin info
     simulateEvent.simulate(NotificationPluginInfoHeader, "click");
     m.redraw();
 
-    expect(EAPluginInfoHeader).toHaveClass(collapsiblePanelStyles.expanded);
+    expect(EAPluginInfoHeader).not.toHaveClass(collapsiblePanelStyles.expanded);
     expect(NotificationPluginInfoHeader).toHaveClass(collapsiblePanelStyles.expanded);
 
     //collapse both ea and notification plugin info
@@ -112,7 +112,7 @@ describe("New Plugins Widget", () => {
     simulateEvent.simulate(NotificationPluginInfoHeader, "click");
     m.redraw();
 
-    expect(EAPluginInfoHeader).not.toHaveClass(collapsiblePanelStyles.expanded);
+    expect(EAPluginInfoHeader).toHaveClass(collapsiblePanelStyles.expanded);
     expect(NotificationPluginInfoHeader).not.toHaveClass(collapsiblePanelStyles.expanded);
   });
 


### PR DESCRIPTION
I was trying to pull out this logic in a common place, like a wrapper component e.g. `<CollapsiblePanels>`, but was unable to do so. Would appreciate if anyone else can give it a try.

For the plugins page, the first plugin and all plugins in invalid state will be expanded.