### PR TITLE
Fix Server Health Messages style on older pages

### DIFF
--- a/server/webapp/WEB-INF/rails/webpack/views/components/server_health_summary/server_health_messages_count_widget.scss
+++ b/server/webapp/WEB-INF/rails/webpack/views/components/server_health_summary/server_health_messages_count_widget.scss
@@ -63,6 +63,7 @@
 }
 
 .server-health-messages-container {
+  @include hover-effect-for-top-menu;
   @include icon-before($fa-var-exclamation-circle, $margin: 0);
   background-color: darken($failed, 20%);
   display:          flex;


### PR DESCRIPTION
Reported here: https://github.com/gocd/gocd/issues/5464#issuecomment-447495967
