### PR TITLE
Make Profile Usage modal large size

### DIFF
--- a/server/webapp/WEB-INF/rails/webpack/views/pages/elastic_profiles/index.scss
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/elastic_profiles/index.scss
@@ -25,7 +25,6 @@ $icon-light-color: #e6e6e6;
   display: block;
 }
 
-
 .plugin-icon {
   display:        none;
   vertical-align: middle;
@@ -68,5 +67,17 @@ $icon-light-color: #e6e6e6;
 
 .elastic-profile-modal-form-body {
   padding: 0 30px;
+}
+
+.table-cell {
+  width:     263px;
+  display:   block;
+  word-wrap: break-word;
+}
+
+.job-settings-link {
+  width:     121px;
+  word-wrap: break-word;
+  display:   block;
 }
 

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/elastic_profiles/index.scss.d.ts
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/elastic_profiles/index.scss.d.ts
@@ -6,3 +6,5 @@ export const pluginNotInstalled: string;
 export const keyValuePair: string;
 export const pluginInfoSelect: string;
 export const elasticProfileModalFormBody: string;
+export const tableCell: string;
+export const jobSettingsLink: string;

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/elastic_profiles/modals.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/elastic_profiles/modals.tsx
@@ -261,7 +261,7 @@ export class UsageElasticProfileModal extends Modal {
   private readonly profileId: string;
 
   constructor(profileId: string, usages: ProfileUsage[]) {
-    super(Size.medium);
+    super(Size.large);
     this.usages    = usages;
     this.profileId = profileId;
   }
@@ -272,9 +272,9 @@ export class UsageElasticProfileModal extends Modal {
     }
 
     const data = this.usages.map((usage) => [
-      usage.pipelineName(),
-      usage.stageName(),
-      usage.jobName(),
+      <span className={styles.tableCell}>{usage.pipelineName()}</span>,
+      <span className={styles.tableCell}>{usage.stageName()}</span>,
+      <span className={styles.tableCell}>{usage.jobName()}</span>,
       UsageElasticProfileModal.anchorToSettings(usage)
     ]);
     return (<Table headers={["Pipeline", "Stage", "Job", " "]} data={data}/>);
@@ -291,6 +291,6 @@ export class UsageElasticProfileModal extends Modal {
       link = `/go/admin/templates/${usage.templateName()}/stages/${usage.stageName()}/job/${usage.jobName()}/settings`;
     }
 
-    return <a href={link}>Go to job settings</a>;
+    return <span class={styles.jobSettingsLink}><a href={link}>Go to job settings</a></span>;
   }
 }


### PR DESCRIPTION
- Modal size set to `Large`
- Wrap contents of all cells to avoid horizontal scroll

Result:
<img width="1142" alt="screen shot 2018-12-17 at 4 07 28 pm" src="https://user-images.githubusercontent.com/24635164/50082151-4021be00-0216-11e9-887b-ed4efacd4d39.png">


