### PR TITLE
Release 18.12 fixes

### DIFF
--- a/server/webapp/WEB-INF/rails/webpack/views/components/collapsible_panel/index.scss
+++ b/server/webapp/WEB-INF/rails/webpack/views/components/collapsible_panel/index.scss
@@ -16,8 +16,8 @@
 @import "../../global/common";
 
 $page-item-padding: 30px;
-$header-padding: 10px 50px 10px 30px;
-$collapsible-header-height: 35px;
+$header-padding: 0 50px 0 30px;
+$collapsible-header-height: 50px;
 
 .collapse {
   background:    $element-bg;
@@ -43,7 +43,7 @@ $collapsible-header-height: 35px;
   flex-direction: column;
   padding:        $header-padding;
   cursor:         pointer;
-  height:         $collapsible-header-height;
+  min-height:     $collapsible-header-height;
   @media (min-width: $screen-md) {
     justify-content: space-between;
   }

--- a/server/webapp/WEB-INF/rails/webpack/views/components/collapsible_panel/index.scss
+++ b/server/webapp/WEB-INF/rails/webpack/views/components/collapsible_panel/index.scss
@@ -17,6 +17,7 @@
 
 $page-item-padding: 30px;
 $header-padding: 10px 50px 10px 30px;
+$collapsible-header-height: 35px;
 
 .collapse {
   background:    $element-bg;
@@ -42,6 +43,7 @@ $header-padding: 10px 50px 10px 30px;
   flex-direction: column;
   padding:        $header-padding;
   cursor:         pointer;
+  height:         $collapsible-header-height;
   @media (min-width: $screen-md) {
     justify-content: space-between;
   }

--- a/server/webapp/WEB-INF/rails/webpack/views/components/modal/index.scss
+++ b/server/webapp/WEB-INF/rails/webpack/views/components/modal/index.scss
@@ -61,6 +61,11 @@ $overlay-header-txt: #fff;
   width: 1050px;
 }
 
+.extra-large-hack-for-EA-profiles {
+  width:     90%;
+  max-width: 1300px;
+}
+
 .overlay-header {
   background:    $overlay-header-bg;
   padding:       15px 20px;

--- a/server/webapp/WEB-INF/rails/webpack/views/components/modal/index.scss.d.ts
+++ b/server/webapp/WEB-INF/rails/webpack/views/components/modal/index.scss.d.ts
@@ -4,6 +4,7 @@ export const overlay: string;
 export const small: string;
 export const medium: string;
 export const large: string;
+export const extraLargeHackForEaProfiles: string;
 export const overlayHeader: string;
 export const overlayClose: string;
 export const closeIcon: string;

--- a/server/webapp/WEB-INF/rails/webpack/views/components/modal/index.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/components/modal/index.tsx
@@ -26,7 +26,8 @@ const uuid4 = require("uuid/v4");
 
 const classnames = bind(styles);
 
-export enum Size {small, medium, large}
+//todo: Remove extraLargeHackForEAProfiles once we fix plugins view to provide the modal container dimensions
+export enum Size {small, medium, large, extraLargeHackForEaProfiles}
 
 export abstract class Modal extends MithrilViewComponent<any> {
   public id: string;

--- a/server/webapp/WEB-INF/rails/webpack/views/components/server_health_summary/server_health_messages_modal.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/components/server_health_summary/server_health_messages_modal.tsx
@@ -21,7 +21,7 @@ import {
   ServerHealthMessage,
   ServerHealthMessages
 } from "models/shared/server_health_messages/server_health_messages";
-import {Modal} from "../modal";
+import {Modal, Size} from "../modal";
 import * as styles from "./server_health_messages_count_widget.scss";
 
 const classnames    = bind(styles);
@@ -32,7 +32,7 @@ export class ServerHealthMessagesModal extends Modal {
   private readonly messages: Stream<ServerHealthMessages>;
 
   constructor(messages: Stream<ServerHealthMessages>) {
-    super();
+    super(Size.large);
     this.messages = messages;
   }
 

--- a/server/webapp/WEB-INF/rails/webpack/views/global/_mixins.scss
+++ b/server/webapp/WEB-INF/rails/webpack/views/global/_mixins.scss
@@ -15,6 +15,8 @@
  */
 @import '~bourbon/core/bourbon';
 
+$spinner-wrapper-height: 175px;
+
 @mixin hover-effect-for-top-menu {
   color:           $subnav-link-color;
   transition:      all 0.3s ease-in-out;
@@ -34,4 +36,8 @@
     font-size:   13px;
     font-weight: 600;
   }
+}
+
+@mixin spinner-for-modal {
+  min-height: $spinner-wrapper-height;
 }

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/config_repos.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/config_repos.tsx
@@ -143,7 +143,7 @@ export class ConfigReposPage extends Page<null, State> {
     const headerButtons = [
       <Buttons.Primary onclick={vnode.state.onAdd.bind(vnode.state)}>Add</Buttons.Primary>
     ];
-    return <HeaderPanel title="Config repositories" buttons={headerButtons}/>;
+    return <HeaderPanel title="Config Repositories" buttons={headerButtons}/>;
   }
 
   fetchData(vnode: m.Vnode<null, State>) {

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/config_repos/index.scss
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/config_repos/index.scss
@@ -62,3 +62,7 @@ code {
   word-break:  break-all;
   word-wrap:   break-word;
 }
+
+.spinner-wrapper {
+  @include spinner-for-modal;
+}

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/config_repos/index.scss.d.ts
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/config_repos/index.scss.d.ts
@@ -7,3 +7,4 @@ export const missingPluginIcon: string;
 export const lastRevision: string;
 export const lastRevisionValue: string;
 export const statusIcon: string;
+export const spinnerWrapper: string;

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/config_repos/modals.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/config_repos/modals.tsx
@@ -291,7 +291,10 @@ abstract class ConfigRepoModal extends Modal {
   }
 
   buttons(): JSX.Element[] {
-    return [<Buttons.Primary data-test-id="button-ok" onclick={this.performSave.bind(this)}>OK</Buttons.Primary>];
+    return [
+      <Buttons.Primary data-test-id="button-ok" onclick={this.performSave.bind(this)}>Save</Buttons.Primary>,
+      <Buttons.Cancel data-test-id="button-cancel" onclick={this.close.bind(this)}>Cancel</Buttons.Cancel>
+    ];
   }
 
   abstract performSave(): void;

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/config_repos/modals.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/config_repos/modals.tsx
@@ -44,6 +44,7 @@ import {
 } from "views/components/forms/input_fields";
 import {Modal, Size} from "views/components/modal";
 import {Spinner} from "views/components/spinner";
+import * as styles from "views/pages/config_repos/index.scss";
 import {RequiresPluginInfos, SaveOperation} from "views/pages/page_operations";
 
 type EditableMaterial = SaveOperation & { repo: ConfigRepo } & { isNew: boolean } & RequiresPluginInfos;
@@ -269,7 +270,7 @@ abstract class ConfigRepoModal extends Modal {
     }
 
     if (!this.getRepo()) {
-      return <Spinner/>;
+      return <div class={styles.spinnerWrapper}><Spinner/></div>;
     }
     let materialtocomponentmapElement;
 

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/elastic_profiles/elastic_profiles_widget.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/elastic_profiles/elastic_profiles_widget.tsx
@@ -55,7 +55,7 @@ class ElasticProfilesHeaderWidget extends MithrilComponent<HeaderAttrs> {
                        image={vnode.attrs.image}/>
       ),
       (<KeyValuePair inline={true} data={new Map([
-                                                   ["Plugin ID", vnode.attrs.pluginId]
+                                                   ["Plugin Id", vnode.attrs.pluginId]
                                                  ])}/>)
     ];
   }
@@ -183,7 +183,7 @@ export class ElasticProfileWidget extends MithrilComponent<ProfileAttrs> {
 
   static profileHeader(profileId: string) {
     return (<KeyValuePair inline={true} data={new Map([
-                                                        ["Profile ID", profileId]
+                                                        ["Profile Id", profileId]
                                                       ])}/>);
   }
 

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/elastic_profiles/modals.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/elastic_profiles/modals.tsx
@@ -293,6 +293,6 @@ export class UsageElasticProfileModal extends Modal {
       link = `/go/admin/templates/${usage.templateName()}/stages/${usage.stageName()}/job/${usage.jobName()}/settings`;
     }
 
-    return <span class={styles.jobSettingsLink}><a href={link}>Go to job settings</a></span>;
+    return <span class={styles.jobSettingsLink}><a href={link}>Job Settings</a></span>;
   }
 }

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/elastic_profiles/modals.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/elastic_profiles/modals.tsx
@@ -52,7 +52,7 @@ abstract class BaseElasticProfileModal extends Modal {
   protected constructor(elasticProfile: ElasticProfile,
                         pluginInfos: Array<PluginInfo<Extension>>,
                         type: ModalType) {
-    super(Size.large);
+    super(Size.extraLargeHackForEaProfiles);
     this.elasticProfile = stream(elasticProfile);
     this.pluginInfos    = pluginInfos;
     this.pluginInfo     = stream(pluginInfos.find(

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/elastic_profiles/modals.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/elastic_profiles/modals.tsx
@@ -79,8 +79,10 @@ abstract class BaseElasticProfileModal extends Modal {
   }
 
   buttons() {
-    return [<Buttons.Primary data-test-id="button-ok"
-                             onclick={this.validateAndPerformSave.bind(this)}>Save</Buttons.Primary>];
+    return [
+      <Buttons.Primary data-test-id="button-ok" onclick={this.validateAndPerformSave.bind(this)}>Save</Buttons.Primary>,
+      <Buttons.Cancel data-test-id="button-cancel" onclick={this.close.bind(this)}>Cancel</Buttons.Cancel>,
+    ];
   }
 
   body() {

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/elastic_profiles/spec/elastic_profile_widget_spec.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/elastic_profiles/spec/elastic_profile_widget_spec.tsx
@@ -44,7 +44,7 @@ describe("New Elastic Profile Widget", () => {
 
   it("should render elastic profile id", () => {
     const profileHeader = $root.find(`.${keyValuePairStyles.keyValuePair}`).get(0);
-    expect(profileHeader).toContainText("Profile ID");
+    expect(profileHeader).toContainText("Profile Id");
     expect(profileHeader).toContainText(TestData.DockerElasticProfile().id);
   });
 

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/new_plugins/index.scss
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/new_plugins/index.scss
@@ -16,7 +16,6 @@
 @import "../../global/common";
 
 $collapse-icon-size: 25px;
-$spinner-wrapper-height: 175px;
 
 .plugin-header {
   display:     flex;
@@ -66,5 +65,5 @@ $spinner-wrapper-height: 175px;
 }
 
 .spinner-wrapper {
-  min-height: $spinner-wrapper-height;
+  @include spinner-for-modal;
 }

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/new_plugins/plugin_settings_modal.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/new_plugins/plugin_settings_modal.tsx
@@ -71,7 +71,7 @@ export class PluginSettingsModal extends Modal {
 
   buttons(): JSX.Element[] {
     return [
-      <Buttons.Primary onclick={this.performSave.bind(this)}>OK</Buttons.Primary>,
+      <Buttons.Primary onclick={this.performSave.bind(this)}>Save</Buttons.Primary>,
       <Buttons.Cancel onclick={this.close.bind(this)}>Cancel</Buttons.Cancel>
     ];
   }

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/new_plugins/plugin_widget.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/new_plugins/plugin_widget.tsx
@@ -51,7 +51,6 @@ class PluginHeaderWidget extends MithrilViewComponent<PluginHeaderAttrs> {
 export interface Attrs {
   pluginInfo: PluginInfo<any>;
   isUserAnAdmin: boolean;
-  index: number;
   onEdit: (e: MouseEvent) => void;
 }
 
@@ -104,7 +103,7 @@ export class PluginWidget extends MithrilViewComponent<Attrs> {
                                                     pluginId={pluginInfo.id}/>}
                         actions={[statusReportButton, settingsButton]}
                         error={pluginInfo.hasErrors()}
-                        expanded={pluginInfo.status.isInvalid() || vnode.attrs.index === 0}>
+                        expanded={pluginInfo.status.isInvalid()}>
         <KeyValuePair data={pluginData}/>
       </CollapsiblePanel>
     );

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/new_plugins/plugins_widget.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/new_plugins/plugins_widget.tsx
@@ -68,13 +68,12 @@ export class PluginsWidget extends MithrilComponent<Attrs, State> {
     return (
       <div data-test-id="plugins-list">
         <FlashMessage type={MessageType.success} message={vnode.state.successMessage}/>
-        {_.sortBy(vnode.attrs.pluginInfos, (pluginInfo) => pluginInfo.id).map((pluginInfo: PluginInfo<any>, index) => {
+        {_.sortBy(vnode.attrs.pluginInfos, (pluginInfo) => pluginInfo.id).map((pluginInfo: PluginInfo<any>) => {
           return (
             <PluginWidget key={pluginInfo.id}
                           pluginInfo={pluginInfo}
                           onEdit={vnode.state.edit.bind(vnode.state, pluginInfo)}
-                          isUserAnAdmin={vnode.attrs.isUserAnAdmin}
-                          index={index}/>
+                          isUserAnAdmin={vnode.attrs.isUserAnAdmin}/>
           );
         })}
       </div>

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/new_plugins/spec/plugins_widget_spec.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/new_plugins/spec/plugins_widget_spec.tsx
@@ -67,16 +67,6 @@ describe("New Plugins Widget", () => {
     expect(notificationPluginHeader).toContainText(getNotificationPluginInfo().about.version);
   });
 
-  it("should render first plugin info expanded and all other valid plugin infos collapsed", () => {
-    expect(find("plugins-list").get(0).children).toHaveLength(4);
-
-    const EAPluginInfo           = $root.find(`.${collapsiblePanelStyles.collapse}`).get(0);
-    const NotificationPluginInfo = $root.find(`.${collapsiblePanelStyles.collapse}`).get(1);
-
-    expect(EAPluginInfo).toHaveClass(collapsiblePanelStyles.expanded);
-    expect(NotificationPluginInfo).not.toHaveClass(collapsiblePanelStyles.expanded);
-  });
-
   it("should render all invalid plugin infos expanded", () => {
     expect(find("plugins-list").get(0).children).toHaveLength(4);
 
@@ -90,21 +80,21 @@ describe("New Plugins Widget", () => {
     const EAPluginInfoHeader           = find("collapse-header").get(0);
     const NotificationPluginInfoHeader = find("collapse-header").get(1);
 
-    expect(EAPluginInfoHeader).toHaveClass(collapsiblePanelStyles.expanded);
+    expect(EAPluginInfoHeader).not.toHaveClass(collapsiblePanelStyles.expanded);
     expect(NotificationPluginInfoHeader).not.toHaveClass(collapsiblePanelStyles.expanded);
 
     //expand ea plugin info
     simulateEvent.simulate(EAPluginInfoHeader, "click");
     m.redraw();
 
-    expect(EAPluginInfoHeader).not.toHaveClass(collapsiblePanelStyles.expanded);
+    expect(EAPluginInfoHeader).toHaveClass(collapsiblePanelStyles.expanded);
     expect(NotificationPluginInfoHeader).not.toHaveClass(collapsiblePanelStyles.expanded);
 
     //expand notification plugin info
     simulateEvent.simulate(NotificationPluginInfoHeader, "click");
     m.redraw();
 
-    expect(EAPluginInfoHeader).not.toHaveClass(collapsiblePanelStyles.expanded);
+    expect(EAPluginInfoHeader).toHaveClass(collapsiblePanelStyles.expanded);
     expect(NotificationPluginInfoHeader).toHaveClass(collapsiblePanelStyles.expanded);
 
     //collapse both ea and notification plugin info
@@ -112,7 +102,7 @@ describe("New Plugins Widget", () => {
     simulateEvent.simulate(NotificationPluginInfoHeader, "click");
     m.redraw();
 
-    expect(EAPluginInfoHeader).toHaveClass(collapsiblePanelStyles.expanded);
+    expect(EAPluginInfoHeader).not.toHaveClass(collapsiblePanelStyles.expanded);
     expect(NotificationPluginInfoHeader).not.toHaveClass(collapsiblePanelStyles.expanded);
   });
 

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/partials/site_footer.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/partials/site_footer.tsx
@@ -38,11 +38,11 @@ export class SiteFooter extends MithrilViewComponent<Attrs> {
           <a href="https://www.apache.org/licenses/LICENSE-2.0" target="_blank">
             Apache License, Version 2.0
           </a>.
-          Go includes&nbsp;
+          GoCD includes&nbsp;
           <a href={`/go/assets/dependency-license-report-${vnode.attrs.fullVersion}`} target="_blank">
             third-party software
           </a>.
-          Go Version: {vnode.attrs.formattedVersion}.
+          <div>GoCD Version: {vnode.attrs.formattedVersion}.</div>
         </p>
       </div>
       <div class={styles.right}>

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/partials/spec/site_footer_spec.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/partials/spec/site_footer_spec.tsx
@@ -62,7 +62,7 @@ describe("SiteFooter", () => {
 
     expect($root).toContainHtml("Copyright &copy; 2000");
     expect($root).toContainElement(`a[href="/go/assets/dependency-license-report-${attrs.fullVersion}"]`);
-    expect($root).toContainText(`Go Version: ${attrs.formattedVersion}`);
+    expect($root).toContainText(`GoCD Version: ${attrs.formattedVersion}`);
     expect($root).not.toContainText("drain");
     expect(find("drain-mode-banner")).not.toBeInDOM();
     expect($root).not.toContainText('unsupported browser');


### PR DESCRIPTION
#### Fixes:

  - [x] Change Errors & Warnings modal size to large.
  - [x] Collapse all plugins on Plugins SPA
  - [x] Fix Collapsible Panel size for Plugins, Elastic Profiles and Config Repo page (fixed it to 50px)
  - [x] Change config repo header from 'Config repositories' to 'Config Repositories'
  - [x] Change 'Plugin ID' -> 'Plugin Id'
  - [x] Change 'Profile ID' -> 'Profile Id'
  - [x] All modals have a save and cancel button.
  - [x] GoCD footer - SHA on new line, change Go to GoCD
  - [x] Config repo edit spinner height
  - [x] horizontal scroll on elastic profiles page (for ECS plugin)