### PR TITLE
Show spinner while loading Edit/Clone modal on Elastic Profiles SPA

### DIFF
--- a/server/webapp/WEB-INF/rails/webpack/views/pages/elastic_profiles.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/elastic_profiles.tsx
@@ -99,18 +99,8 @@ export class ElasticProfilesPage extends Page<null, State> {
         clearTimeout(timeoutID);
       }
 
-      ElasticProfilesCRUD
-        .get(elasticProfile.id())
-        .then((result) => {
-          result.do(
-            (successResponse) => {
-              new CloneElasticProfileModal(successResponse.body.object,
-                                           vnode.state.pluginInfos(),
-                                           vnode.state.onSuccessfulSave).render();
-            },
-            onOperationError
-          );
-        });
+      new CloneElasticProfileModal(elasticProfile.id(), vnode.state.pluginInfos(),
+                                   vnode.state.onSuccessfulSave).render();
     };
 
     vnode.state.onEdit = (elasticProfile: ElasticProfile, event: MouseEvent) => {
@@ -119,18 +109,9 @@ export class ElasticProfilesPage extends Page<null, State> {
         clearTimeout(timeoutID);
       }
 
-      ElasticProfilesCRUD
-        .get(elasticProfile.id())
-        .then((result) => {
-          result.do(
-            (successResponse) => {
-              new EditElasticProfileModal(successResponse.body,
-                                          vnode.state.pluginInfos(),
-                                          vnode.state.onSuccessfulSave).render();
-            },
-            onOperationError
-          );
-        });
+      new EditElasticProfileModal(elasticProfile.id(),
+                                  vnode.state.pluginInfos(),
+                                  vnode.state.onSuccessfulSave).render();
     };
 
     vnode.state.onDelete = (id: string, event: MouseEvent) => {

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/elastic_profiles/index.scss
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/elastic_profiles/index.scss
@@ -81,3 +81,6 @@ $icon-light-color: #e6e6e6;
   display:   block;
 }
 
+.spinner-wrapper {
+  @include spinner-for-modal;
+}

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/elastic_profiles/index.scss.d.ts
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/elastic_profiles/index.scss.d.ts
@@ -8,3 +8,4 @@ export const pluginInfoSelect: string;
 export const elasticProfileModalFormBody: string;
 export const tableCell: string;
 export const jobSettingsLink: string;
+export const spinnerWrapper: string;


### PR DESCRIPTION
Moved `GET` calls inside the modal loading part, a spinner is showed until the get call finishes.