### PR TITLE
 #5559 - Fixed ajax-poller causing performance issue

### DIFF
--- a/server/webapp/WEB-INF/rails/webpack/helpers/ajax_poller.ts
+++ b/server/webapp/WEB-INF/rails/webpack/helpers/ajax_poller.ts
@@ -48,16 +48,14 @@ export class AjaxPoller<T> {
   constructor(options: (() => Promise<T>) | Partial<Options<T>>) {
     // @ts-ignore
     this.options = _.assign({}, defaultOptions, "function" === typeof options ? {repeaterFn: options} : options);
-  }
-
-  start(initialInterval = Math.max(this.options.initialIntervalSeconds, 0)) {
-    this.abort = false;
-
-    this.timeout = window.setTimeout(this.fire.bind(this), initialInterval * 1000);
-
     if (doesBrowserSupportPageVisibilityAPI) {
       document.addEventListener("visibilitychange", this.handleVisibilityChange.bind(this), false);
     }
+  }
+
+  start(initialInterval = Math.max(this.options.initialIntervalSeconds, 0)) {
+    this.abort   = false;
+    this.timeout = window.setTimeout(this.fire.bind(this), initialInterval * 1000);
   }
 
   stop() {
@@ -86,9 +84,10 @@ export class AjaxPoller<T> {
 
   private handleVisibilityChange() {
     // we stop and repoll only when the page becomes visible
-    if (!this.abort && !this.isPageHidden()) {
+    if (this.isPageHidden()) {
       this.stop();
-      this.start(0);
+    } else {
+      this.restart();
     }
   }
 


### PR DESCRIPTION
Here https://github.com/gocd/gocd/compare/master...bdpiparva:fixed-ajax-poller?expand=1#diff-b2a4e4f96a6916c0b740381c168cf8fdL59 was adding listener every time when there is a change in tab visibility and registers `handleVisibilityChange`. As a result of that when the next time a user changes the tab it will register it the self. The number of listeners gets doubled on every switch tab operation.

### Verified following scenarios after the change -
- Should poll on specified interval on the page load
- Should abort ongoing request and stop polling when a user changes the tab
- Should resume polling when a user visits the same tab again
- Number of listeners remains same after switching the tab `getEventListeners(document).visibilitychange.length`