### PR TITLE
Use powershell to delete edge browser history

### DIFF
--- a/server/webapp/WEB-INF/rails/karma.conf.js
+++ b/server/webapp/WEB-INF/rails/karma.conf.js
@@ -32,7 +32,7 @@ if (process.platform === 'darwin') {
   childProcess.spawnSync('taskkill', ['/F', '/IM', 'MicrosoftEdge.exe', '/T']);
 
   // Clear Edge history so that it doesn't re-open tabs after getting killed
-  childProcess.spawnSync('Remove-Item', ["C:\\Users\\" +  os.userInfo().username + "\\AppData\\Local\\Packages\\Microsoft.MicrosoftEdge_8wekyb3d8bbwe\\AC\\*", '-Force', '-Recurse']);
+  childProcess.spawnSync('powershell', ['-Command', "Remove-Item $env:USERPROFILE/AppData/Local/Packages/Microsoft.MicrosoftEdge_8wekyb3d8bbwe/AC/* -Force -Recurse"]);
 
   browsers = ['Edge'];
 } else {


### PR DESCRIPTION
  - Remove dependency on os module
  - Use powershell env variable to figure out user home path
  - Removing history ensures that while running jasmine tests,
    edge doesn't try to restore old jasmine test tabs and cause error
    in karma-html-reporter.