### PR TITLE
Use new auth config SPA as a default.

### DIFF
--- a/server/src/main/java/com/thoughtworks/go/server/service/support/toggle/Toggles.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/support/toggle/Toggles.java
@@ -21,7 +21,7 @@ public class Toggles {
     public static String QUICK_EDIT_PAGE_DEFAULT = "quick_edit_page_toggle_key";
     public static String BROWSER_CONSOLE_LOG_WS = "browser_console_log_ws_key";
     public static String AGENT_APIS_OVER_RAILS = "agent_apis_over_rails";
-    public static String USE_NEW_AUTH_CONFIG_SPA = "use_new_auth_config_spa";
+    public static String USE_OLD_AUTH_CONFIG_SPA = "use_old_auth_config_spa";
     public static String USERS_PAGE_USING_RAILS = "users_page_using_rails";
     public static String USE_OLD_ARTIFACT_STORES_SPA = "use_old_artifact_stores_spa";
 

--- a/server/src/main/resources/available.toggles
+++ b/server/src/main/resources/available.toggles
@@ -27,8 +27,8 @@
         "value": false
       },
       {
-        "key": "use_new_auth_config_spa",
-        "description": "Switch authorization configuration spa to use new spa.",
+        "key": "use_old_auth_config_spa",
+        "description": "Switch to old authorization configuration spa. Default is new spa.",
         "value": false
       },
       {

--- a/spark/spark-spa/src/main/java/com/thoughtworks/go/spark/spa/spring/SpaControllers.java
+++ b/spark/spark-spa/src/main/java/com/thoughtworks/go/spark/spa/spring/SpaControllers.java
@@ -49,7 +49,7 @@ public class SpaControllers implements SparkSpringController {
         LayoutTemplateProvider componentTemplate = () -> COMPONENT_LAYOUT_PATH;
 
         sparkControllers.add(new ArtifactStoresController(authenticationHelper, templateEngineFactory.create(ArtifactStoresController.class, () -> featureToggleService.isToggleOn(Toggles.USE_OLD_ARTIFACT_STORES_SPA) ? DEFAULT_LAYOUT_PATH : COMPONENT_LAYOUT_PATH)));
-        sparkControllers.add(new AuthConfigsController(authenticationHelper, templateEngineFactory.create(AuthConfigsController.class, () -> featureToggleService.isToggleOn(Toggles.USE_NEW_AUTH_CONFIG_SPA) ? COMPONENT_LAYOUT_PATH : DEFAULT_LAYOUT_PATH)));
+        sparkControllers.add(new AuthConfigsController(authenticationHelper, templateEngineFactory.create(AuthConfigsController.class, () -> featureToggleService.isToggleOn(Toggles.USE_OLD_AUTH_CONFIG_SPA) ? DEFAULT_LAYOUT_PATH : COMPONENT_LAYOUT_PATH)));
         sparkControllers.add(new UsersController(authenticationHelper, templateEngineFactory.create(UsersController.class, () -> COMPONENT_LAYOUT_PATH)));
         sparkControllers.add(new RolesController(authenticationHelper, templateEngineFactory.create(RolesController.class, defaultTemplate)));
         sparkControllers.add(new AgentsControllerController(authenticationHelper, templateEngineFactory.create(AgentsControllerController.class, defaultTemplate), securityService, systemEnvironment));


### PR DESCRIPTION
Use toggle `use_old_auth_config_spa` to use old spa - 

```bash
curl -H 'Confirm:true' \
       -u 'username:password' \ 
       http://example.ci.com/go/api/admin/feature_toggles/use_old_auth_config_spa \
       -d toggle_value=on
```
