### PR TITLE
Drain mode SPA perf fixes (#5627)

### DIFF
--- a/api/api-server-drain-mode-v1/src/main/java/com/thoughtworks/go/apiv1/serverdrainmode/representers/DrainModeInfoRepresenter.java
+++ b/api/api-server-drain-mode-v1/src/main/java/com/thoughtworks/go/apiv1/serverdrainmode/representers/DrainModeInfoRepresenter.java
@@ -36,15 +36,20 @@ public class DrainModeInfoRepresenter {
                         .addAbsoluteLink("doc", Routes.DrainMode.INFO_DOC))
                 .addChild("_embedded", childWriter -> {
                     childWriter.add("is_drain_mode", serverDrainMode.isDrainMode());
-                    childWriter.add("is_completely_drained", isServerCompletelyDrained);
                     childWriter.addChild("metadata", metadataChildWriter -> {
                         metadataChildWriter.add("updated_by", serverDrainMode.updatedBy());
                         metadataChildWriter.add("updated_on", serverDrainMode.updatedOn());
                     });
-                    childWriter.addChild("running_systems", runningSystemsChildWriter -> {
-                        runningSystemsChildWriter.addChildList("mdu", runningMDUsToJSON(runningMDUs));
-                        runningSystemsChildWriter.addChildList("jobs", runningJobsToJSON(jobInstances));
-                    });
+
+                    if (serverDrainMode.isDrainMode()) {
+                        childWriter.addChild("attributes", attributesWriter -> {
+                            attributesWriter.add("is_completely_drained", isServerCompletelyDrained);
+                            attributesWriter.addChild("running_systems", runningSystemsChildWriter -> {
+                                runningSystemsChildWriter.addChildList("mdu", runningMDUsToJSON(runningMDUs));
+                                runningSystemsChildWriter.addChildList("jobs", runningJobsToJSON(jobInstances));
+                            });
+                        });
+                    }
                 });
     }
 

--- a/api/api-server-drain-mode-v1/src/test/groovy/com/thoughtworks/go/apiv1/serverdrainmode/representers/DrainModeInfoRepresenterTest.groovy
+++ b/api/api-server-drain-mode-v1/src/test/groovy/com/thoughtworks/go/apiv1/serverdrainmode/representers/DrainModeInfoRepresenterTest.groovy
@@ -80,81 +80,108 @@ class DrainModeInfoRepresenterTest {
         doc : [href: 'https://api.gocd.org/current/#drain-mode-info']
       ],
       _embedded: [
-        "is_drain_mode"        : true,
-        "is_completely_drained": true,
-        "metadata"             : [
+        "is_drain_mode": true,
+        "metadata"     : [
           "updated_by": drainModeService.get().updatedBy(),
           "updated_on": jsonDate(drainModeService.get().updatedOn())
         ],
-        "running_systems"      : [
-          "mdu": [
-            [
-              "type"          : "git",
-              "attributes"    : [
-                "url"             : "foo/bar",
-                "destination"     : null,
-                "filter"          : null,
-                "invert_filter"   : false,
-                "name"            : null,
-                "auto_update"     : true,
-                "branch"          : "master",
-                "submodule_folder": null,
-                "shallow_clone"   : false
-              ],
-              "mdu_start_time": "1970-01-01T02:46:40Z"
-            ],
-            [
-              "type"          : "hg",
-              "attributes"    : [
-                "url"          : "hg-url",
-                "destination"  : null,
-                "filter"       : null,
-                "invert_filter": false,
-                "name"         : null,
-                "auto_update"  : true
-              ],
-              "mdu_start_time": "1970-01-01T05:33:20Z"
-            ],
-            [
-              "type"          : "svn",
-              "attributes"    : [
-                "url"               : "url",
-                "destination"       : "svnDir",
-                "filter"            : [
-                  "ignore": ["*.doc"]
+        "attributes"   : [
+          "is_completely_drained": true,
+          "running_systems"      : [
+            "mdu": [
+              [
+                "type"          : "git",
+                "attributes"    : [
+                  "url"             : "foo/bar",
+                  "destination"     : null,
+                  "filter"          : null,
+                  "invert_filter"   : false,
+                  "name"            : null,
+                  "auto_update"     : true,
+                  "branch"          : "master",
+                  "submodule_folder": null,
+                  "shallow_clone"   : false
                 ],
-                "invert_filter"     : false,
-                "name"              : null,
-                "auto_update"       : true,
-                "check_externals"   : true,
-                "username"          : "user",
-                "encrypted_password": svnMaterial.encryptedPassword
+                "mdu_start_time": "1970-01-01T02:46:40Z"
               ],
-              "mdu_start_time": "1970-01-01T08:20:00Z"
-            ]
-          ],
-          jobs : [
-            [
-              pipeline_name   : scheduled.pipelineName,
-              pipeline_counter: scheduled.pipelineCounter,
-              stage_name      : scheduled.stageName,
-              stage_counter   : scheduled.stageCounter,
-              name            : scheduled.name,
-              state           : scheduled.state,
-              scheduled_date  : jsonDate(new Timestamp(scheduled.getScheduledDate().getTime())),
-              agent_uuid      : scheduled.getAgentUuid()
+              [
+                "type"          : "hg",
+                "attributes"    : [
+                  "url"          : "hg-url",
+                  "destination"  : null,
+                  "filter"       : null,
+                  "invert_filter": false,
+                  "name"         : null,
+                  "auto_update"  : true
+                ],
+                "mdu_start_time": "1970-01-01T05:33:20Z"
+              ],
+              [
+                "type"          : "svn",
+                "attributes"    : [
+                  "url"               : "url",
+                  "destination"       : "svnDir",
+                  "filter"            : [
+                    "ignore": ["*.doc"]
+                  ],
+                  "invert_filter"     : false,
+                  "name"              : null,
+                  "auto_update"       : true,
+                  "check_externals"   : true,
+                  "username"          : "user",
+                  "encrypted_password": svnMaterial.encryptedPassword
+                ],
+                "mdu_start_time": "1970-01-01T08:20:00Z"
+              ]
             ],
-            [
-              pipeline_name   : building.pipelineName,
-              pipeline_counter: building.pipelineCounter,
-              stage_name      : building.stageName,
-              stage_counter   : building.stageCounter,
-              name            : building.name,
-              state           : building.state,
-              scheduled_date  : jsonDate(new Timestamp(building.getScheduledDate().getTime())),
-              agent_uuid      : building.getAgentUuid()
+            jobs : [
+              [
+                pipeline_name   : scheduled.pipelineName,
+                pipeline_counter: scheduled.pipelineCounter,
+                stage_name      : scheduled.stageName,
+                stage_counter   : scheduled.stageCounter,
+                name            : scheduled.name,
+                state           : scheduled.state,
+                scheduled_date  : jsonDate(new Timestamp(scheduled.getScheduledDate().getTime())),
+                agent_uuid      : scheduled.getAgentUuid()
+              ],
+              [
+                pipeline_name   : building.pipelineName,
+                pipeline_counter: building.pipelineCounter,
+                stage_name      : building.stageName,
+                stage_counter   : building.stageCounter,
+                name            : building.name,
+                state           : building.state,
+                scheduled_date  : jsonDate(new Timestamp(building.getScheduledDate().getTime())),
+                agent_uuid      : building.getAgentUuid()
+              ]
             ]
           ]
+        ]
+      ]
+    ]
+
+    assertThatJson(actualJson).isEqualTo(expectedJson)
+  }
+
+  @Test
+  void 'should not add attributes if server is not in drain mode'() {
+    def drainModeService = new DrainModeService(timeProvider)
+
+    def actualJson = toObjectString({
+      DrainModeInfoRepresenter.toJSON(it, drainModeService.get(), false, null, null)
+    })
+
+    def expectedJson = [
+      _links   : [
+        self: [href: 'http://test.host/go/api/admin/drain_mode/info'],
+        doc : [href: 'https://api.gocd.org/current/#drain-mode-info']
+      ],
+      _embedded: [
+        "is_drain_mode": false,
+        "metadata"     : [
+          "updated_by": drainModeService.get().updatedBy(),
+          "updated_on": jsonDate(drainModeService.get().updatedOn())
         ]
       ]
     ]

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/drain_mode.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/drain_mode.tsx
@@ -88,7 +88,13 @@ export class DrainModePage extends Page<null, State> {
       vnode.state.message = new Message(MessageType.alert, errorResponse.message);
     };
 
-    new AjaxPoller(() => this.fetchData(vnode)).start();
+    const options = {
+      repeaterFn: () => this.fetchData(vnode),
+      intervalSeconds: 30,
+      initialIntervalSeconds: 30
+    };
+
+    new AjaxPoller(options).start();
   }
 
   componentToDisplay(vnode: m.Vnode<null, State>): JSX.Element | undefined {

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/drain_mode/disabled_susbsystems_widget.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/drain_mode/disabled_susbsystems_widget.tsx
@@ -19,7 +19,7 @@ import * as Icons from "views/components/icons";
 import * as styles from "./index.scss";
 
 import {MithrilViewComponent} from "jsx/mithril-component";
-import {DrainModeInfo} from "models/drain_mode/types";
+import {DrainModeInfo, RunningSystem} from "models/drain_mode/types";
 
 interface Attrs {
   drainModeInfo: DrainModeInfo;
@@ -82,13 +82,14 @@ class SubsystemInfoWithIconWidget extends MithrilViewComponent<RunningSystemAttr
 
 class InformationWhenInDrainMode extends MithrilViewComponent<Attrs> {
   view(vnode: m.Vnode<Attrs>) {
-    const mduRunningSystem = vnode.attrs.drainModeInfo.runningSystem.mdu.count() === 0
+    const runningSystem    = vnode.attrs.drainModeInfo.runningSystem as RunningSystem;
+    const mduRunningSystem = runningSystem.mdu.count() === 0
       ? <SubsystemInfoWithIconWidget inProgress={false} dataTestId={"mdu-stopped"}
                                      text={"Stopped material subsystem."}/>
       : <SubsystemInfoWithIconWidget inProgress={true} dataTestId={"mdu-in-progress"}
                                      text={"Waiting for material subsystem to stop.."}/>;
 
-    const buildingJobsSystem = vnode.attrs.drainModeInfo.runningSystem.stages.length === 0
+    const buildingJobsSystem = runningSystem.stages.length === 0
       ? <SubsystemInfoWithIconWidget inProgress={false} dataTestId={"scheduling-system-stopped"}
                                      text={"Stopped scheduling subsystem."}/>
       : <SubsystemInfoWithIconWidget inProgress={true} dataTestId={"scheduling-system-in-progress"}

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/drain_mode/drain_mode_widget.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/drain_mode/drain_mode_widget.tsx
@@ -16,7 +16,7 @@
 
 import {MithrilViewComponent} from "jsx/mithril-component";
 import * as m from "mithril";
-import {DrainModeInfo, StageLocator} from "models/drain_mode/types";
+import {DrainModeInfo, RunningSystem, StageLocator} from "models/drain_mode/types";
 import {SwitchBtn} from "views/components/switch";
 import {DisabledSubsystemsWidget} from "views/pages/drain_mode/disabled_susbsystems_widget";
 import {JobInfoWidget} from "views/pages/drain_mode/running_jobs_widget.tsx";
@@ -88,9 +88,9 @@ interface InfoAttrs {
 export class DrainModeInfoWidget extends MithrilViewComponent<InfoAttrs> {
   view(vnode: m.Vnode<InfoAttrs>): m.Children {
     return [
-      <JobInfoWidget stages={vnode.attrs.drainModeInfo.runningSystem.stages}
+      <JobInfoWidget stages={(vnode.attrs.drainModeInfo.runningSystem as RunningSystem).stages}
                      onCancelStage={vnode.attrs.onCancelStage}/>,
-      <MDUInfoWidget materials={vnode.attrs.drainModeInfo.runningSystem.mdu}/>
+      <MDUInfoWidget materials={(vnode.attrs.drainModeInfo.runningSystem as RunningSystem).mdu}/>
     ] as m.ChildArray;
   }
 }

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/drain_mode/spec/test_data.ts
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/drain_mode/spec/test_data.ts
@@ -29,14 +29,16 @@ export class TestData {
     return {
       _embedded: {
         is_drain_mode: true,
-        is_completely_drained: true,
         metadata: {
           updated_by: "Admin",
           updated_on: "2018-12-10T04:19:31Z"
         },
-        running_systems: {
-          mdu: [],
-          jobs: []
+        attributes: {
+          is_completely_drained: true,
+          running_systems: {
+            mdu: [],
+            jobs: []
+          }
         }
       }
     };
@@ -46,15 +48,18 @@ export class TestData {
     return {
       _embedded: {
         is_drain_mode: isDrainMode,
-        is_completely_drained: false,
         metadata: {
           updated_by: "Admin",
           updated_on: "2018-12-10T04:19:31Z"
         },
-        running_systems: {
-          mdu: this.getMdu(),
-          jobs: this.getJobs()
+        attributes: {
+          is_completely_drained: false,
+          running_systems: {
+            mdu: this.getMdu(),
+            jobs: this.getJobs()
+          }
         }
+
       }
     };
   }


### PR DESCRIPTION
* Do not fetch & send running subsystems info when server is not in drain mode
* Increase AJAX poller interval time from 10 secs to 30 secs