### PR TITLE
Rename 'Go' to 'GoCD' in plugins details

### DIFF
--- a/server/webapp/WEB-INF/rails/webpack/views/pages/new_plugins/plugin_widget.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/new_plugins/plugin_widget.tsx
@@ -89,7 +89,7 @@ export class PluginWidget extends MithrilViewComponent<Attrs> {
       ["Supported operating systems", pluginInfo.about.targetOperatingSystemsDisplayValue()],
       ["Plugin file location", pluginInfo.pluginFileLocation],
       ["Bundled", pluginInfo.bundledPlugin ? "Yes" : "No"],
-      ["Target Go Version", pluginInfo.about.targetGoVersion],
+      ["Target GoCD Version", pluginInfo.about.targetGoVersion],
     ]);
     if (pluginInfo.hasErrors()) {
       pluginData = pluginData.set("There were errors loading the plugin", pluginInfo.getErrors());

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/new_plugins/spec/plugins_widget_spec.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/new_plugins/spec/plugins_widget_spec.tsx
@@ -131,7 +131,7 @@ describe("New Plugins Widget", () => {
     expect(EAPluginInfoBody).toContainText("Bundled");
     expect(EAPluginInfoBody).toContainText("No");
 
-    expect(EAPluginInfoBody).toContainText("Target Go Version");
+    expect(EAPluginInfoBody).toContainText("Target GoCD Version");
     expect(EAPluginInfoBody).toContainText("16.12.0");
 
     const NotificationPluginInfoBody = find("collapse-body").get(1);
@@ -148,7 +148,7 @@ describe("New Plugins Widget", () => {
     expect(NotificationPluginInfoBody).toContainText("Bundled");
     expect(NotificationPluginInfoBody).toContainText("No");
 
-    expect(NotificationPluginInfoBody).toContainText("Target Go Version");
+    expect(NotificationPluginInfoBody).toContainText("Target GoCD Version");
     expect(NotificationPluginInfoBody).toContainText("15.1.0");
   });
 


### PR DESCRIPTION
- UI issue for 19.1.0 #5585