### PR TITLE
Bulk update system admins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,6 +86,9 @@ agent/target/
 api/api-admins-config-v1/logs/
 api/api-admins-config-v1/out/
 api/api-admins-config-v1/target/
+api/api-admins-config-v2/logs/
+api/api-admins-config-v2/out/
+api/api-admins-config-v2/target/
 api/api-artifact-store-config-v1/config/
 api/api-artifact-store-config-v1/logs/
 api/api-artifact-store-config-v1/out/

--- a/api/api-admins-config-v2/build.gradle
+++ b/api/api-admins-config-v2/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+apply plugin: 'jacoco'
+apply plugin: 'groovy'
+
+dependencies {
+  compile project(':api:api-base')
+
+  testCompile project(path: ':api:api-base', configuration: 'testOutput')
+
+  testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: project.versions.junit5
+  testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: project.versions.junit5
+}

--- a/api/api-admins-config-v2/src/main/java/com/thoughtworks/go/apiv2/adminsconfig/AdminControllerV2.java
+++ b/api/api-admins-config-v2/src/main/java/com/thoughtworks/go/apiv2/adminsconfig/AdminControllerV2.java
@@ -103,9 +103,15 @@ public class AdminControllerV2 extends ApiController implements SparkSpringContr
         JsonReader jsonReader = GsonTransformer.getInstance().jsonReaderFrom(request.body());
         BulkUpdateRequest bulkUpdateRequest = BulkUpdateRequestRepresenter.fromJSON(jsonReader);
         HttpLocalizedOperationResult result = new HttpLocalizedOperationResult();
-        adminsConfigService.bulkUpdate(currentUsername(), bulkUpdateRequest.getUsers(), bulkUpdateRequest.getRoles(),
-                bulkUpdateRequest.isAdmin(), etagFor(adminsConfigService.systemAdmins()), result);
-        return renderHTTPOperationResult(result, request, response);
+        adminsConfigService.bulkUpdate(currentUsername(),
+                bulkUpdateRequest.getUsersToAdd(), bulkUpdateRequest.getUsersToRemove(),
+                bulkUpdateRequest.getRolesToAdd(), bulkUpdateRequest.getRolesToRemove(),
+                etagFor(adminsConfigService.systemAdmins()), result);
+        if (result.isSuccessful()) {
+            return writerForTopLevelObject(request, response, jsonWriter(adminsConfigService.systemAdmins()));
+        } else {
+            return renderHTTPOperationResult(result, request, response);
+        }
     }
 
     @Override

--- a/api/api-admins-config-v2/src/main/java/com/thoughtworks/go/apiv2/adminsconfig/AdminControllerV2.java
+++ b/api/api-admins-config-v2/src/main/java/com/thoughtworks/go/apiv2/adminsconfig/AdminControllerV2.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.apiv2.adminsconfig;
+
+import com.thoughtworks.go.api.ApiController;
+import com.thoughtworks.go.api.ApiVersion;
+import com.thoughtworks.go.api.CrudController;
+import com.thoughtworks.go.api.base.OutputWriter;
+import com.thoughtworks.go.api.representers.JsonReader;
+import com.thoughtworks.go.api.spring.ApiAuthenticationHelper;
+import com.thoughtworks.go.api.util.GsonTransformer;
+import com.thoughtworks.go.apiv2.adminsconfig.representers.AdminsConfigRepresenter;
+import com.thoughtworks.go.config.AdminsConfig;
+import com.thoughtworks.go.server.service.AdminsConfigService;
+import com.thoughtworks.go.server.service.EntityHashingService;
+import com.thoughtworks.go.server.service.result.HttpLocalizedOperationResult;
+import com.thoughtworks.go.spark.Routes;
+import com.thoughtworks.go.spark.spring.SparkSpringController;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import spark.Request;
+import spark.Response;
+
+import java.io.IOException;
+import java.util.function.Consumer;
+
+import static com.thoughtworks.go.api.util.HaltApiResponses.haltBecauseEtagDoesNotMatch;
+import static spark.Spark.*;
+
+@Component
+public class AdminControllerV2 extends ApiController implements SparkSpringController, CrudController<AdminsConfig> {
+    private final ApiAuthenticationHelper apiAuthenticationHelper;
+    private final EntityHashingService entityHashingService;
+    private final AdminsConfigService adminsConfigService;
+
+    @Autowired
+    public AdminControllerV2(ApiAuthenticationHelper apiAuthenticationHelper,
+                             EntityHashingService entityHashingService, AdminsConfigService service) {
+        super(ApiVersion.v2);
+        this.apiAuthenticationHelper = apiAuthenticationHelper;
+        this.entityHashingService = entityHashingService;
+        this.adminsConfigService = service;
+    }
+
+    @Override
+    public void setupRoutes() {
+        path(controllerPath(), () -> {
+            before("", mimeType, this::setContentType);
+            before("/*", mimeType, this::setContentType);
+            before("", mimeType, this::verifyContentType);
+            before("/*", mimeType, this::verifyContentType);
+            before("", mimeType, apiAuthenticationHelper::checkAdminUserAnd403);
+            before("/*", mimeType, apiAuthenticationHelper::checkAdminUserAnd403);
+
+            get("", mimeType, this::show);
+            put("", mimeType, this::update);
+        });
+    }
+
+    public String show(Request req, Response res) throws IOException {
+        AdminsConfig adminsConf = adminsConfigService.systemAdmins();
+        if (isGetOrHeadRequestFresh(req, adminsConf)) {
+            return notModified(res);
+        } else {
+            setEtagHeader(adminsConf, res);
+            return writerForTopLevelObject(req, res, jsonWriter(adminsConf));
+        }
+    }
+
+    public String update(Request req, Response res) {
+        AdminsConfig adminsConfigFromRequest = buildEntityFromRequestBody(req);
+        AdminsConfig adminsConfigFromServer = adminsConfigService.systemAdmins();
+
+        if (isPutRequestStale(req, adminsConfigFromServer)) {
+            throw haltBecauseEtagDoesNotMatch();
+        }
+
+        HttpLocalizedOperationResult result = new HttpLocalizedOperationResult();
+
+        adminsConfigService.update(currentUsername(), adminsConfigFromRequest, etagFor(adminsConfigFromServer), result);
+
+        return handleCreateOrUpdateResponse(req, res, adminsConfigFromRequest, result);
+    }
+
+    @Override
+    public String etagFor(AdminsConfig entityFromServer) {
+        return entityHashingService.md5ForEntity(entityFromServer);
+    }
+
+    @Override
+    public AdminsConfig doFetchEntityFromConfig(String name) {
+        throw new RuntimeException("Not implemented. Unlike other entities, AdminsConfig has a single representation in the config.");
+    }
+
+    @Override
+    public AdminsConfig buildEntityFromRequestBody(Request req) {
+        JsonReader jsonReader = GsonTransformer.getInstance().jsonReaderFrom(req.body());
+        return AdminsConfigRepresenter.fromJSON(jsonReader);
+    }
+
+    @Override
+    public Consumer<OutputWriter> jsonWriter(AdminsConfig admins) {
+        return writer -> AdminsConfigRepresenter.toJSON(writer, admins);
+    }
+
+    @Override
+    public String controllerBasePath() {
+        return Routes.SystemAdmins.BASE;
+    }
+
+}

--- a/api/api-admins-config-v2/src/main/java/com/thoughtworks/go/apiv2/adminsconfig/AdminControllerV2.java
+++ b/api/api-admins-config-v2/src/main/java/com/thoughtworks/go/apiv2/adminsconfig/AdminControllerV2.java
@@ -23,7 +23,9 @@ import com.thoughtworks.go.api.base.OutputWriter;
 import com.thoughtworks.go.api.representers.JsonReader;
 import com.thoughtworks.go.api.spring.ApiAuthenticationHelper;
 import com.thoughtworks.go.api.util.GsonTransformer;
+import com.thoughtworks.go.apiv2.adminsconfig.models.BulkUpdateRequest;
 import com.thoughtworks.go.apiv2.adminsconfig.representers.AdminsConfigRepresenter;
+import com.thoughtworks.go.apiv2.adminsconfig.representers.BulkUpdateRequestRepresenter;
 import com.thoughtworks.go.config.AdminsConfig;
 import com.thoughtworks.go.server.service.AdminsConfigService;
 import com.thoughtworks.go.server.service.EntityHashingService;
@@ -68,6 +70,7 @@ public class AdminControllerV2 extends ApiController implements SparkSpringContr
 
             get("", mimeType, this::show);
             put("", mimeType, this::update);
+            patch("", mimeType, this::bulkUpdate);
         });
     }
 
@@ -94,6 +97,15 @@ public class AdminControllerV2 extends ApiController implements SparkSpringContr
         adminsConfigService.update(currentUsername(), adminsConfigFromRequest, etagFor(adminsConfigFromServer), result);
 
         return handleCreateOrUpdateResponse(req, res, adminsConfigFromRequest, result);
+    }
+
+    public String bulkUpdate(Request request, Response response) throws IOException {
+        JsonReader jsonReader = GsonTransformer.getInstance().jsonReaderFrom(request.body());
+        BulkUpdateRequest bulkUpdateRequest = BulkUpdateRequestRepresenter.fromJSON(jsonReader);
+        HttpLocalizedOperationResult result = new HttpLocalizedOperationResult();
+        adminsConfigService.bulkUpdate(currentUsername(), bulkUpdateRequest.getUsers(), bulkUpdateRequest.getRoles(),
+                bulkUpdateRequest.isAdmin(), etagFor(adminsConfigService.systemAdmins()), result);
+        return renderHTTPOperationResult(result, request, response);
     }
 
     @Override

--- a/api/api-admins-config-v2/src/main/java/com/thoughtworks/go/apiv2/adminsconfig/models/BulkUpdateRequest.java
+++ b/api/api-admins-config-v2/src/main/java/com/thoughtworks/go/apiv2/adminsconfig/models/BulkUpdateRequest.java
@@ -20,25 +20,31 @@ import java.util.List;
 
 public class BulkUpdateRequest {
 
-    private List<String> users;
-    private List<String> roles;
-    private boolean isAdmin;
+    private List<String> usersToAdd;
+    private List<String> usersToRemove;
+    private List<String> rolesToAdd;
+    private List<String> rolesToRemove;
 
-    public BulkUpdateRequest(List<String> users, List<String> roles, boolean isAdmin) {
-        this.users = users;
-        this.roles = roles;
-        this.isAdmin = isAdmin;
+    public BulkUpdateRequest(List<String> usersToAdd, List<String> usersToRemove, List<String> rolesToAdd, List<String> rolesToRemove) {
+        this.usersToAdd = usersToAdd;
+        this.usersToRemove = usersToRemove;
+        this.rolesToAdd = rolesToAdd;
+        this.rolesToRemove = rolesToRemove;
     }
 
-    public List<String> getUsers() {
-        return users;
+    public List<String> getUsersToAdd() {
+        return usersToAdd;
     }
 
-    public List<String> getRoles() {
-        return roles;
+    public List<String> getUsersToRemove() {
+        return usersToRemove;
     }
 
-    public boolean isAdmin() {
-        return isAdmin;
+    public List<String> getRolesToAdd() {
+        return rolesToAdd;
+    }
+
+    public List<String> getRolesToRemove() {
+        return rolesToRemove;
     }
 }

--- a/api/api-admins-config-v2/src/main/java/com/thoughtworks/go/apiv2/adminsconfig/models/BulkUpdateRequest.java
+++ b/api/api-admins-config-v2/src/main/java/com/thoughtworks/go/apiv2/adminsconfig/models/BulkUpdateRequest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.apiv2.adminsconfig.models;
+
+import java.util.List;
+
+public class BulkUpdateRequest {
+
+    private List<String> users;
+    private List<String> roles;
+    private boolean isAdmin;
+
+    public BulkUpdateRequest(List<String> users, List<String> roles, boolean isAdmin) {
+        this.users = users;
+        this.roles = roles;
+        this.isAdmin = isAdmin;
+    }
+
+    public List<String> getUsers() {
+        return users;
+    }
+
+    public List<String> getRoles() {
+        return roles;
+    }
+
+    public boolean isAdmin() {
+        return isAdmin;
+    }
+}

--- a/api/api-admins-config-v2/src/main/java/com/thoughtworks/go/apiv2/adminsconfig/representers/AdminsConfigRepresenter.java
+++ b/api/api-admins-config-v2/src/main/java/com/thoughtworks/go/apiv2/adminsconfig/representers/AdminsConfigRepresenter.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.apiv2.adminsconfig.representers;
+
+import com.thoughtworks.go.api.base.OutputWriter;
+import com.thoughtworks.go.api.representers.ErrorGetter;
+import com.thoughtworks.go.api.representers.JsonReader;
+import com.thoughtworks.go.config.AdminRole;
+import com.thoughtworks.go.config.AdminUser;
+import com.thoughtworks.go.config.AdminsConfig;
+import com.thoughtworks.go.config.CaseInsensitiveString;
+import com.thoughtworks.go.spark.Routes;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class AdminsConfigRepresenter {
+    public static void toJSON(OutputWriter jsonWriter, AdminsConfig admin) {
+        jsonWriter.addLinks(
+                outputLinkWriter -> outputLinkWriter.addAbsoluteLink("doc", Routes.SystemAdmins.DOC)
+                        .addLink("self", Routes.SystemAdmins.BASE));
+        jsonWriter.addChildList("roles", rolesAsString(admin.getRoles()));
+        jsonWriter.addChildList("users", userAsString(admin.getUsers()));
+        if (admin.hasErrors()) {
+            jsonWriter.addChild("errors", errorWriter -> new ErrorGetter(Collections.singletonMap("SystemAdmin", "system_admin"))
+                    .toJSON(errorWriter, admin));
+        }
+    }
+
+    public static AdminsConfig fromJSON(JsonReader jsonReader) {
+        AdminsConfig adminsConfig = new AdminsConfig();
+
+        jsonReader.readArrayIfPresent("users", users -> {
+            users.forEach(user -> adminsConfig.add(new AdminUser(new CaseInsensitiveString(user.getAsString()))));
+        });
+
+        jsonReader.readArrayIfPresent("roles", roles -> {
+            roles.forEach(role -> adminsConfig.add(new AdminRole(new CaseInsensitiveString(role.getAsString()))));
+        });
+
+        return adminsConfig;
+    }
+
+    private static List<String> rolesAsString(List<AdminRole> roles) {
+        return roles.stream().map(role -> role.getName().toString()).collect(Collectors.toList());
+    }
+
+    private static List<String> userAsString(List<AdminUser> users) {
+        return users.stream().map(user -> user.getName().toString()).collect(Collectors.toList());
+    }
+}

--- a/api/api-admins-config-v2/src/main/java/com/thoughtworks/go/apiv2/adminsconfig/representers/BulkUpdateRequestRepresenter.java
+++ b/api/api-admins-config-v2/src/main/java/com/thoughtworks/go/apiv2/adminsconfig/representers/BulkUpdateRequestRepresenter.java
@@ -19,16 +19,29 @@ package com.thoughtworks.go.apiv2.adminsconfig.representers;
 import com.thoughtworks.go.api.representers.JsonReader;
 import com.thoughtworks.go.apiv2.adminsconfig.models.BulkUpdateRequest;
 
-import java.util.Collections;
+import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
+
+import static java.util.Collections.emptyList;
 
 public class BulkUpdateRequestRepresenter {
 
     public static BulkUpdateRequest fromJSON(JsonReader jsonReader) {
-        Optional<List<String>> users = jsonReader.readStringArrayIfPresent("users");
-        Optional<List<String>> roles = jsonReader.readStringArrayIfPresent("roles");
-        boolean isAdmin = jsonReader.readJsonObject("operations").getBoolean("isAdmin");
-        return new BulkUpdateRequest(users.orElse(Collections.emptyList()), roles.orElse(Collections.emptyList()), isAdmin);
+        JsonReader operations = jsonReader.readJsonObject("operations");
+        List<String> usersToAdd = new ArrayList<>();
+        List<String> usersToRemove = new ArrayList<>();
+        List<String> rolesToAdd = new ArrayList<>();
+        List<String> rolesToRemove = new ArrayList<>();
+
+        operations.optJsonObject("users").ifPresent(reader -> {
+            usersToAdd.addAll(reader.readStringArrayIfPresent("add").orElse(emptyList()));
+            usersToRemove.addAll(reader.readStringArrayIfPresent("remove").orElse(emptyList()));
+        });
+
+        operations.optJsonObject("roles").ifPresent(reader -> {
+            rolesToAdd.addAll(reader.readStringArrayIfPresent("add").orElse(emptyList()));
+            rolesToRemove.addAll(reader.readStringArrayIfPresent("remove").orElse(emptyList()));
+        });
+        return new BulkUpdateRequest(usersToAdd, usersToRemove, rolesToAdd, rolesToRemove);
     }
 }

--- a/api/api-admins-config-v2/src/main/java/com/thoughtworks/go/apiv2/adminsconfig/representers/BulkUpdateRequestRepresenter.java
+++ b/api/api-admins-config-v2/src/main/java/com/thoughtworks/go/apiv2/adminsconfig/representers/BulkUpdateRequestRepresenter.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.apiv2.adminsconfig.representers;
+
+import com.thoughtworks.go.api.representers.JsonReader;
+import com.thoughtworks.go.apiv2.adminsconfig.models.BulkUpdateRequest;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+public class BulkUpdateRequestRepresenter {
+
+    public static BulkUpdateRequest fromJSON(JsonReader jsonReader) {
+        Optional<List<String>> users = jsonReader.readStringArrayIfPresent("users");
+        Optional<List<String>> roles = jsonReader.readStringArrayIfPresent("roles");
+        boolean isAdmin = jsonReader.readJsonObject("operations").getBoolean("isAdmin");
+        return new BulkUpdateRequest(users.orElse(Collections.emptyList()), roles.orElse(Collections.emptyList()), isAdmin);
+    }
+}

--- a/api/api-admins-config-v2/src/test/groovy/com/thoughtworks/go/apiv2/adminsconfig/AdminControllerV2Test.groovy
+++ b/api/api-admins-config-v2/src/test/groovy/com/thoughtworks/go/apiv2/adminsconfig/AdminControllerV2Test.groovy
@@ -1,0 +1,237 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.apiv2.adminsconfig
+
+import com.thoughtworks.go.api.SecurityTestTrait
+import com.thoughtworks.go.api.spring.ApiAuthenticationHelper
+import com.thoughtworks.go.apiv2.adminsconfig.representers.AdminsConfigRepresenter
+import com.thoughtworks.go.config.AdminRole
+import com.thoughtworks.go.config.AdminUser
+import com.thoughtworks.go.config.AdminsConfig
+import com.thoughtworks.go.config.CaseInsensitiveString
+import com.thoughtworks.go.server.service.AdminsConfigService
+import com.thoughtworks.go.server.service.EntityHashingService
+import com.thoughtworks.go.server.service.result.HttpLocalizedOperationResult
+import com.thoughtworks.go.spark.AdminUserSecurity
+import com.thoughtworks.go.spark.ControllerTrait
+import com.thoughtworks.go.spark.SecurityServiceTrait
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.mockito.Mock
+import org.mockito.Mockito
+import org.mockito.invocation.InvocationOnMock
+
+import static com.thoughtworks.go.api.base.JsonUtils.toObjectString
+import static org.mockito.ArgumentMatchers.any
+import static org.mockito.ArgumentMatchers.eq
+import static org.mockito.Mockito.verify
+import static org.mockito.Mockito.when
+import static org.mockito.MockitoAnnotations.initMocks
+
+class AdminControllerV2Test implements ControllerTrait<AdminControllerV2>, SecurityServiceTrait {
+  @Mock
+  private AdminsConfigService adminsConfigService
+  @Mock
+  private EntityHashingService entityHashingService
+
+  @BeforeEach
+  void setUp() {
+    initMocks(this)
+  }
+
+  @Override
+  AdminControllerV2 createControllerInstance() {
+    return new AdminControllerV2(new ApiAuthenticationHelper(securityService, goConfigService), entityHashingService, adminsConfigService)
+  }
+
+  @Nested
+  class Show {
+    @Nested
+    class Security implements SecurityTestTrait, AdminUserSecurity {
+      @BeforeEach
+      void setUp() {
+        AdminsConfig config = new AdminsConfig(new AdminUser(new CaseInsensitiveString("admin")))
+        when(adminsConfigService.systemAdmins()).thenReturn(config)
+      }
+
+      @Override
+      String getControllerMethodUnderTest() {
+        return "show"
+      }
+
+      @Override
+      void makeHttpCall() {
+        getWithApiHeader(controller.controllerPath())
+      }
+    }
+
+    @Nested
+    class AsAdmin {
+      HttpLocalizedOperationResult result
+
+      @BeforeEach
+      void setUp() {
+        enableSecurity()
+        loginAsAdmin()
+        this.result = new HttpLocalizedOperationResult()
+      }
+
+      @Test
+      void 'should render the security admins config'() {
+        AdminsConfig config = new AdminsConfig(new AdminUser(new CaseInsensitiveString("admin")))
+        when(entityHashingService.md5ForEntity(config)).thenReturn('md5')
+        when(adminsConfigService.systemAdmins()).thenReturn(config)
+
+        getWithApiHeader(controller.controllerPath())
+
+        assertThatResponse()
+          .isOk()
+          .hasEtag('"md5"')
+          .hasContentType(controller.mimeType)
+          .hasBodyWithJsonObject(config, AdminsConfigRepresenter)
+      }
+
+      @Test
+      void 'should render 304 if etag matches'() {
+        def config = new AdminsConfig(new AdminUser(new CaseInsensitiveString("admin")))
+        when(entityHashingService.md5ForEntity(config)).thenReturn('md5')
+        when(adminsConfigService.systemAdmins()).thenReturn(config)
+        getWithApiHeader(controller.controllerPath(), ['if-none-match': '"md5"'])
+
+        assertThatResponse()
+          .isNotModified()
+          .hasContentType(controller.mimeType)
+      }
+
+      @Test
+      void 'should render 200 if etag does not match'() {
+        def config = new AdminsConfig(new AdminUser(new CaseInsensitiveString("admin-new")))
+        when(entityHashingService.md5ForEntity(config)).thenReturn('md5')
+        when(adminsConfigService.systemAdmins()).thenReturn(config)
+        getWithApiHeader(controller.controllerPath(), ['if-none-match': '"junk"'])
+
+        assertThatResponse()
+          .isOk()
+          .hasEtag('"md5"')
+          .hasContentType(controller.mimeType)
+          .hasBodyWithJsonObject(config, AdminsConfigRepresenter)
+      }
+    }
+  }
+
+
+  @Nested
+  class Update {
+    @Nested
+    class Security implements SecurityTestTrait, AdminUserSecurity {
+      AdminsConfig config
+
+      @BeforeEach
+      void setUp() {
+        config = new AdminsConfig(new AdminUser(new CaseInsensitiveString("admin")))
+        when(adminsConfigService.systemAdmins()).thenReturn(config)
+        when(entityHashingService.md5ForEntity(config)).thenReturn('cached-md5')
+      }
+
+      @Override
+      String getControllerMethodUnderTest() {
+        return "update"
+      }
+
+      @Override
+      void makeHttpCall() {
+        sendRequest('put', controller.controllerPath(), [
+          'accept'      : controller.mimeType,
+          'If-Match'    : 'cached-md5',
+          'content-type': 'application/json'
+        ], toObjectString({ AdminsConfigRepresenter.toJSON(it, this.config) }))
+      }
+    }
+
+    @Nested
+    class AsAdmin {
+      @BeforeEach
+      void setUp() {
+        enableSecurity()
+        loginAsAdmin()
+      }
+
+      @Test
+      void 'should update the system admins'() {
+        AdminsConfig configInServer = new AdminsConfig(new AdminUser(new CaseInsensitiveString("admin")))
+        AdminsConfig configFromRequest = new AdminsConfig(new AdminUser(new CaseInsensitiveString("admin")),
+          new AdminUser(new CaseInsensitiveString("new_admin")))
+
+        when(adminsConfigService.systemAdmins()).thenReturn(configInServer)
+        when(entityHashingService.md5ForEntity(configInServer)).thenReturn("cached-md5")
+
+        putWithApiHeader(controller.controllerPath(), ['if-match': 'cached-md5'], toObjectString({
+          AdminsConfigRepresenter.toJSON(it, configFromRequest)
+        }))
+
+        verify(adminsConfigService).update(any(), eq(configFromRequest), eq("cached-md5"), any(HttpLocalizedOperationResult.class))
+        assertThatResponse()
+          .isOk()
+          .hasContentType(controller.mimeType)
+          .hasBodyWithJsonObject(configFromRequest, AdminsConfigRepresenter)
+      }
+
+      @Test
+      void 'should return a response with errors if update fails'() {
+        AdminsConfig configInServer = new AdminsConfig(new AdminUser(new CaseInsensitiveString("admin")))
+        AdminsConfig configFromRequest = new AdminsConfig(new AdminUser(new CaseInsensitiveString("admin")),
+          new AdminUser(new CaseInsensitiveString("new_admin")))
+
+
+        when(adminsConfigService.systemAdmins()).thenReturn(configInServer)
+        when(entityHashingService.md5ForEntity(configInServer)).thenReturn("cached-md5")
+        when(adminsConfigService.update(any(), eq(configFromRequest), eq("cached-md5"), any(HttpLocalizedOperationResult.class))).then({ InvocationOnMock invocation ->
+          HttpLocalizedOperationResult result = invocation.getArguments().last()
+          result.unprocessableEntity("validation failed")
+        })
+
+        putWithApiHeader(controller.controllerPath(), ['if-match': 'cached-md5'], toObjectString({
+          AdminsConfigRepresenter.toJSON(it, configFromRequest)
+        }))
+
+        assertThatResponse()
+          .isUnprocessableEntity()
+          .hasContentType(controller.mimeType)
+          .hasJsonMessage("validation failed")
+      }
+
+      @Test
+      void 'should not update a stale system admins request'() {
+        AdminsConfig systemAdminsRequest = new AdminsConfig(new AdminRole(new CaseInsensitiveString("admin")))
+        AdminsConfig systemAdminsInServer = new AdminsConfig(new AdminRole(new CaseInsensitiveString("role1")))
+
+        when(adminsConfigService.systemAdmins()).thenReturn(systemAdminsInServer)
+        when(entityHashingService.md5ForEntity(systemAdminsInServer)).thenReturn('cached-md5')
+
+        putWithApiHeader(controller.controllerPath(), ['if-match': 'some-string'], toObjectString({
+          AdminsConfigRepresenter.toJSON(it, systemAdminsRequest)
+        }))
+
+        verify(adminsConfigService, Mockito.never()).update(any(), any(), any(), any())
+        assertThatResponse().isPreconditionFailed()
+          .hasContentType(controller.mimeType)
+          .hasJsonMessage("Someone has modified the entity. Please update your copy with the changes and try again.")
+      }
+    }
+  }
+}

--- a/api/api-admins-config-v2/src/test/groovy/com/thoughtworks/go/apiv2/adminsconfig/representers/AdminsConfigRepresenterTest.groovy
+++ b/api/api-admins-config-v2/src/test/groovy/com/thoughtworks/go/apiv2/adminsconfig/representers/AdminsConfigRepresenterTest.groovy
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.apiv2.adminsconfig.representers
+
+import com.thoughtworks.go.api.representers.JsonReader
+import com.thoughtworks.go.api.util.GsonTransformer
+import com.thoughtworks.go.config.AdminRole
+import com.thoughtworks.go.config.AdminUser
+import com.thoughtworks.go.config.AdminsConfig
+import com.thoughtworks.go.config.CaseInsensitiveString
+import org.junit.jupiter.api.Test
+
+import static com.thoughtworks.go.api.base.JsonUtils.toObjectString
+import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson
+import static org.hamcrest.MatcherAssert.assertThat
+import static org.hamcrest.Matchers.is
+
+class AdminsConfigRepresenterTest {
+  @Test
+  void shouldSerializeToJSON() {
+    AdminsConfig config = new AdminsConfig(new AdminUser(new CaseInsensitiveString("admin")), new AdminRole(new CaseInsensitiveString("xyz")))
+
+    def actualJson = toObjectString({ AdminsConfigRepresenter.toJSON(it, config) })
+
+    final LinkedHashMap<String, Object> expected = ["_links": ["doc": ["href": "https://api.gocd.org/#system_admins"], "self": ["href": "http://test.host/go/api/admin/security/system_admins"]], "roles": ["xyz"], "users": ["admin"]]
+    assertThatJson(actualJson).isEqualTo(expected)
+  }
+
+  @Test
+  void shouldSerializeToJSONWithErrors() {
+    AdminsConfig config = new AdminsConfig(new AdminUser(new CaseInsensitiveString("admin")), new AdminRole(new CaseInsensitiveString("xyz")))
+
+    config.addError("users", "User name cannot be blank")
+    config.addError("users", "User name cannot be blank")
+    config.addError("roles", "Role does not exist")
+
+    def actualJson = toObjectString({ AdminsConfigRepresenter.toJSON(it, config) })
+
+    final LinkedHashMap<String, Object> expected = ["_links": ["doc": ["href": "https://api.gocd.org/#system_admins"], "self": ["href": "http://test.host/go/api/admin/security/system_admins"]], "roles": ["xyz"], "users": ["admin"], "errors": ["roles": ["Role does not exist"], "users": ["User name cannot be blank"]]]
+    assertThatJson(actualJson).isEqualTo(expected);
+  }
+
+  @Test
+  void shouldDeSerializeAdminsConfigFromJSON() {
+    def requestJSON = [
+      'roles': ['qa', 'dev'],
+      'users': ['user1', 'user2']
+    ]
+
+    JsonReader jsonReader = GsonTransformer.getInstance().jsonReaderFrom(requestJSON);
+    AdminsConfig adminsConfig = AdminsConfigRepresenter.fromJSON(jsonReader);
+
+    def expected = new AdminsConfig(
+      new AdminUser(new CaseInsensitiveString("user1")),
+      new AdminUser(new CaseInsensitiveString("user2")),
+      new AdminRole(new CaseInsensitiveString("qa")),
+      new AdminRole(new CaseInsensitiveString("dev")),
+    )
+    assertThat(adminsConfig, is(expected))
+  }
+}

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/AdminRole.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/AdminRole.java
@@ -39,6 +39,10 @@ public class AdminRole implements Admin {
         this(role.getName());
     }
 
+    public AdminRole(final String name) {
+        this.name = new CaseInsensitiveString(name);
+    }
+
     public boolean isSameAs(Admin admin, List<Role> memberRoles) {
         if (this.name == null || memberRoles == null) {
             return false;

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/AdminUser.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/AdminUser.java
@@ -37,6 +37,10 @@ public class AdminUser implements Admin {
         this.name = name;
     }
 
+    public AdminUser(String name) {
+        this.name = new CaseInsensitiveString(name);
+    }
+
     public void validate(ValidationContext validationContext) {
         if (name == null || name.isBlank())
             addError("User cannot be blank.");

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/AdminsConfig.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/AdminsConfig.java
@@ -18,6 +18,7 @@ package com.thoughtworks.go.config;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 
 import com.thoughtworks.go.domain.BaseCollection;
 import com.thoughtworks.go.domain.ConfigErrors;
@@ -35,6 +36,10 @@ public class AdminsConfig extends BaseCollection<Admin> implements Validatable {
 
     public AdminsConfig(Admin... admins) {
         addAll(asList(admins));
+    }
+
+    public AdminsConfig(Set<Admin> admins) {
+        addAll(admins);
     }
 
     public boolean isAdmin(Admin username, List<Role> memberRoles) {

--- a/config/config-api/src/test/java/com/thoughtworks/go/config/AdminUserTest.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/config/AdminUserTest.java
@@ -25,7 +25,7 @@ public class AdminUserTest {
 
     @Test
     public void shouldNotValidateBlankUsers() {
-        AdminUser adminUser = new AdminUser(null);
+        AdminUser adminUser = new AdminUser("");
         adminUser.validate(null);
         assertThat(adminUser.errors().on(AdminUser.NAME), is("User cannot be blank."));
     }

--- a/config/config-api/src/test/java/com/thoughtworks/go/domain/config/AdminsConfigTest.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/domain/config/AdminsConfigTest.java
@@ -80,7 +80,7 @@ public class AdminsConfigTest {
 
     @Test
     public void shouldValidatePresenceOfUserName() {
-        AdminsConfig adminsConfig = new AdminsConfig(new AdminUser(null));
+        AdminsConfig adminsConfig = new AdminsConfig(new AdminUser(""));
         ValidationContext validationContext = mock(ValidationContext.class);
 
         assertFalse(adminsConfig.validateTree(validationContext));

--- a/server/src/main/java/com/thoughtworks/go/server/service/AdminsConfigService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/AdminsConfigService.java
@@ -69,20 +69,20 @@ public class AdminsConfigService {
         }
     }
 
-    public void bulkUpdate(Username currentUser, List<String> users, List<String> roles, boolean isAdmin, String md5, LocalizedOperationResult result) {
+    public void bulkUpdate(Username currentUser,
+                           List<String> usersToAdd,
+                           List<String> usersToRemove,
+                           List<String> rolesToAdd,
+                           List<String> rolesToRemove,
+                           String md5, LocalizedOperationResult result) {
         Set<Admin> admins = new HashSet<>(systemAdmins());
-        if (isAdmin) {
-            users.forEach(user -> admins.add(new AdminUser(user)));
-            roles.forEach(role -> admins.add(new AdminRole(role)));
-        } else {
-            users.forEach(user -> admins.remove(new AdminUser(new CaseInsensitiveString(user))));
-            roles.forEach(role -> admins.remove(new AdminRole(new CaseInsensitiveString(role))));
-        }
-        AdminsConfigUpdateCommand command = new AdminsConfigUpdateCommand(goConfigService, new AdminsConfig(admins), currentUser, result, entityHashingService, md5);
+        usersToAdd.forEach(user -> admins.add(new AdminUser(user)));
+        rolesToAdd.forEach(role -> admins.add(new AdminRole(role)));
+        usersToRemove.forEach(user -> admins.remove(new AdminUser(new CaseInsensitiveString(user))));
+        rolesToRemove.forEach(role -> admins.remove(new AdminRole(new CaseInsensitiveString(role))));
+        AdminsConfigUpdateCommand command = new AdminsConfigUpdateCommand(goConfigService, new AdminsConfig(admins),
+                currentUser, result, entityHashingService, md5);
         updateConfig(currentUser, result, command);
-        if (result.isSuccessful()) {
-            result.setMessage("Admins updated successfully");
-        }
     }
 }
 

--- a/server/src/main/java/com/thoughtworks/go/server/service/AdminsConfigService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/AdminsConfigService.java
@@ -16,15 +16,20 @@
 
 package com.thoughtworks.go.server.service;
 
-import com.thoughtworks.go.config.AdminsConfig;
+import com.thoughtworks.go.config.*;
 import com.thoughtworks.go.config.commands.EntityConfigUpdateCommand;
 import com.thoughtworks.go.config.exceptions.GoConfigInvalidException;
 import com.thoughtworks.go.config.update.AdminsConfigUpdateCommand;
+import com.thoughtworks.go.domain.config.Admin;
 import com.thoughtworks.go.server.domain.Username;
 import com.thoughtworks.go.server.service.result.LocalizedOperationResult;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 import static com.thoughtworks.go.i18n.LocalizedMessage.saveFailedWithReason;
 
@@ -61,6 +66,22 @@ public class AdminsConfigService {
                     result.internalServerError(saveFailedWithReason("An error occurred while updating the System Admins. Please check the logs for more information."));
                 }
             }
+        }
+    }
+
+    public void bulkUpdate(Username currentUser, List<String> users, List<String> roles, boolean isAdmin, String md5, LocalizedOperationResult result) {
+        Set<Admin> admins = new HashSet<>(systemAdmins());
+        if (isAdmin) {
+            users.forEach(user -> admins.add(new AdminUser(user)));
+            roles.forEach(role -> admins.add(new AdminRole(role)));
+        } else {
+            users.forEach(user -> admins.remove(new AdminUser(new CaseInsensitiveString(user))));
+            roles.forEach(role -> admins.remove(new AdminRole(new CaseInsensitiveString(role))));
+        }
+        AdminsConfigUpdateCommand command = new AdminsConfigUpdateCommand(goConfigService, new AdminsConfig(admins), currentUser, result, entityHashingService, md5);
+        updateConfig(currentUser, result, command);
+        if (result.isSuccessful()) {
+            result.setMessage("Admins updated successfully");
         }
     }
 }

--- a/server/src/test-fast/java/com/thoughtworks/go/server/service/AdminsConfigServiceTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/service/AdminsConfigServiceTest.java
@@ -29,6 +29,7 @@ import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 
+import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.hasSize;
@@ -81,7 +82,7 @@ public class AdminsConfigServiceTest {
         Username user = new Username("user");
         HttpLocalizedOperationResult result = new HttpLocalizedOperationResult();
 
-        adminsConfigService.bulkUpdate(user, singletonList("newUser1"), singletonList("newRole1"), true, "md5", result);
+        adminsConfigService.bulkUpdate(user, singletonList("newUser1"), emptyList(), singletonList("newRole1"), emptyList(), "md5", result);
 
         ArgumentCaptor<AdminsConfigUpdateCommand> captor = ArgumentCaptor.forClass(AdminsConfigUpdateCommand.class);
         verify(goConfigService).updateConfig(captor.capture(), eq(user));
@@ -105,7 +106,7 @@ public class AdminsConfigServiceTest {
         Username user = new Username("user");
         HttpLocalizedOperationResult result = new HttpLocalizedOperationResult();
 
-        adminsConfigService.bulkUpdate(user, singletonList("adminUser1"), singletonList("adminRole1"), false, "md5", result);
+        adminsConfigService.bulkUpdate(user, emptyList(), singletonList("adminUser1"), emptyList(), singletonList("adminRole1"), "md5", result);
 
         ArgumentCaptor<AdminsConfigUpdateCommand> captor = ArgumentCaptor.forClass(AdminsConfigUpdateCommand.class);
         verify(goConfigService).updateConfig(captor.capture(), eq(user));

--- a/server/src/test-fast/java/com/thoughtworks/go/server/service/AdminsConfigServiceTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/service/AdminsConfigServiceTest.java
@@ -16,6 +16,8 @@
 
 package com.thoughtworks.go.server.service;
 
+import com.thoughtworks.go.config.AdminRole;
+import com.thoughtworks.go.config.AdminUser;
 import com.thoughtworks.go.config.AdminsConfig;
 import com.thoughtworks.go.config.BasicCruiseConfig;
 import com.thoughtworks.go.config.update.AdminsConfigUpdateCommand;
@@ -24,17 +26,23 @@ import com.thoughtworks.go.server.domain.Username;
 import com.thoughtworks.go.server.service.result.HttpLocalizedOperationResult;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 
+import static java.util.Collections.singletonList;
+import static org.hamcrest.Matchers.hasItems;
+import static org.hamcrest.Matchers.hasSize;
+import static org.junit.Assert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 
 public class AdminsConfigServiceTest {
 
     @Mock
-    private GoConfigService configService;
+    private GoConfigService goConfigService;
 
     private BasicCruiseConfig cruiseConfig;
 
@@ -48,8 +56,8 @@ public class AdminsConfigServiceTest {
         initMocks(this);
 
         cruiseConfig = GoConfigMother.defaultCruiseConfig();
-        when(configService.cruiseConfig()).thenReturn(cruiseConfig);
-        adminsConfigService = new AdminsConfigService(configService, entityHashingService);
+        when(goConfigService.cruiseConfig()).thenReturn(cruiseConfig);
+        adminsConfigService = new AdminsConfigService(goConfigService, entityHashingService);
     }
 
     @Test
@@ -60,6 +68,53 @@ public class AdminsConfigServiceTest {
 
         adminsConfigService.update(admin, config, "md5", result);
 
-        verify(configService).updateConfig(any(AdminsConfigUpdateCommand.class), eq(admin));
+        verify(goConfigService).updateConfig(any(AdminsConfigUpdateCommand.class), eq(admin));
+    }
+
+    @Test
+    public void shouldBulkUpdateToAddAdminsToConfig() {
+        AdminsConfig config = new AdminsConfig(new AdminUser("existingAdminUser"), new AdminRole("existingAdminRole"));
+        cruiseConfig = GoConfigMother.defaultCruiseConfig();
+        cruiseConfig.server().security().setAdminsConfig(config);
+        when(goConfigService.serverConfig()).thenReturn(cruiseConfig.server());
+
+        Username user = new Username("user");
+        HttpLocalizedOperationResult result = new HttpLocalizedOperationResult();
+
+        adminsConfigService.bulkUpdate(user, singletonList("newUser1"), singletonList("newRole1"), true, "md5", result);
+
+        ArgumentCaptor<AdminsConfigUpdateCommand> captor = ArgumentCaptor.forClass(AdminsConfigUpdateCommand.class);
+        verify(goConfigService).updateConfig(captor.capture(), eq(user));
+        AdminsConfigUpdateCommand updateCommand = captor.getValue();
+
+        AdminsConfig adminsConfig = updateCommand.getPreprocessedEntityConfig();
+        assertThat(adminsConfig.getUsers(), hasSize(2));
+        assertThat(adminsConfig.getUsers(), hasItems(new AdminUser("existingAdminUser"), new AdminUser("newUser1")));
+        assertThat(adminsConfig.getRoles(), hasSize(2));
+        assertThat(adminsConfig.getRoles(), hasItems(new AdminRole("existingAdminRole"), new AdminRole("newRole1")));
+    }
+
+    @Test
+    public void shouldBulkUpdateToRemoveAdminsFromConfig() {
+        AdminsConfig config = new AdminsConfig(new AdminUser("adminUser1"), new AdminUser("adminUser2"),
+                new AdminRole("adminRole1"), new AdminRole("adminRole2"));
+        cruiseConfig = GoConfigMother.defaultCruiseConfig();
+        cruiseConfig.server().security().setAdminsConfig(config);
+        when(goConfigService.serverConfig()).thenReturn(cruiseConfig.server());
+
+        Username user = new Username("user");
+        HttpLocalizedOperationResult result = new HttpLocalizedOperationResult();
+
+        adminsConfigService.bulkUpdate(user, singletonList("adminUser1"), singletonList("adminRole1"), false, "md5", result);
+
+        ArgumentCaptor<AdminsConfigUpdateCommand> captor = ArgumentCaptor.forClass(AdminsConfigUpdateCommand.class);
+        verify(goConfigService).updateConfig(captor.capture(), eq(user));
+        AdminsConfigUpdateCommand updateCommand = captor.getValue();
+
+        AdminsConfig adminsConfig = updateCommand.getPreprocessedEntityConfig();
+        assertThat(adminsConfig.getUsers(), hasSize(1));
+        assertThat(adminsConfig.getUsers(), hasItems(new AdminUser("adminUser2")));
+        assertThat(adminsConfig.getRoles(), hasSize(1));
+        assertThat(adminsConfig.getRoles(), hasItems(new AdminRole("adminRole2")));
     }
 }

--- a/server/webapp/WEB-INF/applicationContext-global.xml
+++ b/server/webapp/WEB-INF/applicationContext-global.xml
@@ -27,6 +27,7 @@
 
   <context:annotation-config/>
 
+  <context:component-scan base-package="com.thoughtworks.go.apiv2.adminsconfig"/>
   <context:component-scan base-package="com.thoughtworks.go.apiv3.users"/>
   <context:component-scan base-package="com.thoughtworks.go.apiv3.dashboard"/>
   <context:component-scan base-package="com.thoughtworks.go.apiv1.export"/>

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 ThoughtWorks, Inc.
+ * Copyright 2019 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ include ':agent-common'
 include ':agent-launcher'
 include ':agent-process-launcher'
 include ':api:api-admins-config-v1'
+include ':api:api-admins-config-v2'
 include ':api:api-agents-v4'
 include ':api:api-api-shared-v1'
 include ':api:api-artifact-store-config-v1'


### PR DESCRIPTION
Bumped up Admins Config API to v2
Added `PATCH` endpoint to update System Admins
There's no validation performed right now -- any string can can be passed, even if it doesn't exist as a user. I can implement this subsequently

Example:
```bash
curl -X PATCH \
  http://localhost:8153/go/api/admin/security/system_admins \
  -H 'Accept: application/vnd.go.cd.v2+json' \
  -H 'Content-Type: application/json' \
  -d '{
     "operations": {
     	"users": {
     		"add": ["meeow", "foo"],
     		"remove": ["admin"]
     	},
     	"roles": {
     		"add": ["xyz"]
     	}
     }
}'
```

```json
Response:
200 OK
{
    "_links": {
        "doc": {
            "href": "https://api.gocd.org/#system_admins"
        },
        "self": {
            "href": "http://localhost:8153/go/api/admin/security/system_admins"
        }
    },
    "roles": [
        "xyz"
    ],
    "users": [
        "foo",
        "meeow"
    ]
}
```