### PR TITLE
Config show show parse info

### DIFF
--- a/api/api-config-repos-v1/src/main/java/com/thoughtworks/go/apiv1/configrepos/representers/ConfigRepoWithResultRepresenter.java
+++ b/api/api-config-repos-v1/src/main/java/com/thoughtworks/go/apiv1/configrepos/representers/ConfigRepoWithResultRepresenter.java
@@ -35,7 +35,7 @@ public class ConfigRepoWithResultRepresenter {
         json.addChild("material", w -> MaterialRepresenter.toJSON(w, repo.getMaterialConfig()));
         attachConfigurations(json, repo);
 
-        json.addChild("last_parse", w -> PartialConfigParseResultRepresenter.toJSON(w, result));
+        json.addChild("parse_info", w -> PartialConfigParseResultRepresenter.toJSON(w, result));
     }
 
     private static void attachLinks(OutputWriter json, ConfigRepoConfig repo) {

--- a/api/api-config-repos-v1/src/main/java/com/thoughtworks/go/apiv1/configrepos/representers/PartialConfigParseResultRepresenter.java
+++ b/api/api-config-repos-v1/src/main/java/com/thoughtworks/go/apiv1/configrepos/representers/PartialConfigParseResultRepresenter.java
@@ -25,8 +25,26 @@ public class PartialConfigParseResultRepresenter {
             return;
         }
 
-        json.add("revision", result.getRevision());
-        json.add("success", result.isSuccessful());
+        json.addChild("latest_parsed_modification", outputWriter -> {
+            outputWriter.add("username", result.getLatestParsedModification().getUserName());
+            outputWriter.add("email_address", result.getLatestParsedModification().getEmailAddress());
+            outputWriter.add("revision", result.getLatestParsedModification().getRevision());
+            outputWriter.add("comment", result.getLatestParsedModification().getComment());
+            outputWriter.add("modified_time", result.getLatestParsedModification().getModifiedTime());
+        });
+
+        if (result.getGoodModification() != null) {
+            json.addChild("good_modification", outputWriter -> {
+                outputWriter.add("username", result.getGoodModification().getUserName());
+                outputWriter.add("email_address", result.getGoodModification().getEmailAddress());
+                outputWriter.add("revision", result.getGoodModification().getRevision());
+                outputWriter.add("comment", result.getGoodModification().getComment());
+                outputWriter.add("modified_time", result.getGoodModification().getModifiedTime());
+            });
+        } else {
+            json.add("good_modification", (String) null);
+        }
+
         json.add("error", result.isSuccessful() ? null : result.getLastFailure().getMessage());
     }
 }

--- a/server/src/main/java/com/thoughtworks/go/config/ConfigReposMaterialParseResultManager.java
+++ b/server/src/main/java/com/thoughtworks/go/config/ConfigReposMaterialParseResultManager.java
@@ -50,7 +50,7 @@ public class ConfigReposMaterialParseResultManager {
         } else {
             PartialConfigParseResult newResult = PartialConfigParseResult.parseFailed(modification, exception);
             newResult.setGoodModification(existingResult.getGoodModification());
-            newResult.setPartialConfig(existingResult.getPartialConfig());
+            newResult.setPartialConfig(existingResult.lastGoodPartialConfig());
             return fingerprintOfPartialToParseResultMap.put(fingerprint, newResult);
         }
     }

--- a/server/src/main/java/com/thoughtworks/go/config/ConfigReposMaterialParseResultManager.java
+++ b/server/src/main/java/com/thoughtworks/go/config/ConfigReposMaterialParseResultManager.java
@@ -22,6 +22,7 @@ package com.thoughtworks.go.config;
 
 
 import com.thoughtworks.go.config.remote.PartialConfig;
+import com.thoughtworks.go.domain.materials.Modification;
 
 import java.util.Map;
 import java.util.Set;
@@ -42,11 +43,21 @@ public class ConfigReposMaterialParseResultManager {
         fingerprintOfPartialToParseResultMap.remove(fingerprint);
     }
 
-    public void parseFailed(String fingerprint, String revision, Exception exception) {
-        fingerprintOfPartialToParseResultMap.put(fingerprint, new PartialConfigParseResult(revision, exception));
+    public PartialConfigParseResult parseFailed(String fingerprint, Modification modification, Exception exception) {
+        PartialConfigParseResult existingResult = get(fingerprint);
+        if (existingResult == null) { //if no result exists in the map, create a new one
+            return fingerprintOfPartialToParseResultMap.put(fingerprint, PartialConfigParseResult.parseFailed(modification, exception));
+        } else {
+            PartialConfigParseResult newResult = PartialConfigParseResult.parseFailed(modification, exception);
+            newResult.setGoodModification(existingResult.getGoodModification());
+            newResult.setPartialConfig(existingResult.getPartialConfig());
+            return fingerprintOfPartialToParseResultMap.put(fingerprint, newResult);
+        }
     }
 
-    public void parseSuccess(String fingerprint, String revision, PartialConfig newPart) {
-        fingerprintOfPartialToParseResultMap.put(fingerprint, new PartialConfigParseResult(revision, newPart));
+    public PartialConfigParseResult parseSuccess(String fingerprint, Modification modification, PartialConfig newPart) {
+        //if no result exists in the map, create a new one
+        //if already a result exists in the map, override the result, as the latest modification is successful. regardless of the result being successful or failed
+        return fingerprintOfPartialToParseResultMap.put(fingerprint, PartialConfigParseResult.parseSuccess(modification, newPart));
     }
 }

--- a/server/src/main/java/com/thoughtworks/go/config/ConfigReposMaterialParseResultManager.java
+++ b/server/src/main/java/com/thoughtworks/go/config/ConfigReposMaterialParseResultManager.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.config;
+
+/*  @description
+ * Keeps track all config repo parsing states
+ */
+
+
+import com.thoughtworks.go.config.remote.PartialConfig;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class ConfigReposMaterialParseResultManager {
+    private Map<String, PartialConfigParseResult> fingerprintOfPartialToParseResultMap = new ConcurrentHashMap<>();
+
+    public PartialConfigParseResult get(String fingerprint) {
+        return fingerprintOfPartialToParseResultMap.get(fingerprint);
+    }
+
+    public Set<String> allFingerprints() {
+        return fingerprintOfPartialToParseResultMap.keySet();
+    }
+
+    public void remove(String fingerprint) {
+        fingerprintOfPartialToParseResultMap.remove(fingerprint);
+    }
+
+    public void parseFailed(String fingerprint, String revision, Exception exception) {
+        fingerprintOfPartialToParseResultMap.put(fingerprint, new PartialConfigParseResult(revision, exception));
+    }
+
+    public void parseSuccess(String fingerprint, String revision, PartialConfig newPart) {
+        fingerprintOfPartialToParseResultMap.put(fingerprint, new PartialConfigParseResult(revision, newPart));
+    }
+}

--- a/server/src/main/java/com/thoughtworks/go/config/GoRepoConfigDataSource.java
+++ b/server/src/main/java/com/thoughtworks/go/config/GoRepoConfigDataSource.java
@@ -84,7 +84,7 @@ public class GoRepoConfigDataSource implements ChangedRepoConfigWatchListListene
         if (!result.isSuccessful())
             throw result.getLastFailure();
 
-        return result.getPartialConfig();
+        return result.lastGoodPartialConfig();
     }
 
     @Override

--- a/server/src/main/java/com/thoughtworks/go/config/PartialConfigParseResult.java
+++ b/server/src/main/java/com/thoughtworks/go/config/PartialConfigParseResult.java
@@ -59,7 +59,7 @@ public class PartialConfigParseResult {
         return goodModification;
     }
 
-    public PartialConfig getPartialConfig() {
+    public PartialConfig lastGoodPartialConfig() {
         return partialConfig;
     }
 

--- a/server/src/main/java/com/thoughtworks/go/config/PartialConfigParseResult.java
+++ b/server/src/main/java/com/thoughtworks/go/config/PartialConfigParseResult.java
@@ -17,38 +17,82 @@
 package com.thoughtworks.go.config;
 
 import com.thoughtworks.go.config.remote.PartialConfig;
+import com.thoughtworks.go.domain.materials.Modification;
 
 import java.util.Objects;
 
+/*
+    Understands the parse results of a config repo materials
+
+    @field latestParsedModification Modification
+    Latest parsed modification represents the latest known commit from the config repo material
+
+    @field goodModification Modification
+    Good modification represents the last commit from which the partials configurations were fetched successfully.
+
+    @field partialConfig PartialConfig
+    partial config represents pipelines and environments fetched from the good modification
+
+    @field exception Exception
+    Any expect occurred while parsing config repository.
+*/
+
+
 public class PartialConfigParseResult {
-    private final String revision;
-    private PartialConfig lastSuccess;
-    private Exception lastFailure;
+    private Modification latestParsedModification;
+    private Modification goodModification;
+    private PartialConfig partialConfig;
+    private Exception exception;
 
-    public PartialConfigParseResult(String revision, PartialConfig newPart) {
-        this.revision = revision;
-        this.lastSuccess = newPart;
+    public PartialConfigParseResult(Modification latestParsedModification, Modification goodModification, PartialConfig partialConfig, Exception exception) {
+        this.latestParsedModification = latestParsedModification;
+        this.goodModification = goodModification;
+        this.partialConfig = partialConfig;
+        this.exception = exception;
     }
 
-    public PartialConfigParseResult(String revision, Exception ex) {
-        this.revision = revision;
-        this.lastFailure = ex;
+    public Modification getLatestParsedModification() {
+        return latestParsedModification;
     }
 
-    public boolean isSuccessful() {
-        return null == getLastFailure();
+    public Modification getGoodModification() {
+        return goodModification;
     }
 
-    public PartialConfig getLastSuccess() {
-        return lastSuccess;
+    public PartialConfig getPartialConfig() {
+        return partialConfig;
     }
 
     public Exception getLastFailure() {
-        return lastFailure;
+        return exception;
     }
 
-    public String getRevision() {
-        return revision;
+    public void setLatestParsedModification(Modification latestParsedModification) {
+        this.latestParsedModification = latestParsedModification;
+    }
+
+    public void setGoodModification(Modification goodModification) {
+        this.goodModification = goodModification;
+    }
+
+    public void setPartialConfig(PartialConfig partialConfig) {
+        this.partialConfig = partialConfig;
+    }
+
+    public void setException(Exception exception) {
+        this.exception = exception;
+    }
+
+    public boolean isSuccessful() {
+        return this.exception == null;
+    }
+
+    public static PartialConfigParseResult parseFailed(Modification modification, Exception exception) {
+        return new PartialConfigParseResult(modification, null, null, exception);
+    }
+
+    public static PartialConfigParseResult parseSuccess(Modification modification, PartialConfig partialConfig) {
+        return new PartialConfigParseResult(modification, modification, partialConfig, null);
     }
 
     @Override
@@ -56,13 +100,14 @@ public class PartialConfigParseResult {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         PartialConfigParseResult that = (PartialConfigParseResult) o;
-        return Objects.equals(revision, that.revision) &&
-                Objects.equals(lastSuccess, that.lastSuccess) &&
-                Objects.equals(lastFailure, that.lastFailure);
+        return Objects.equals(latestParsedModification, that.latestParsedModification) &&
+                Objects.equals(goodModification, that.goodModification) &&
+                Objects.equals(partialConfig, that.partialConfig) &&
+                Objects.equals(exception, that.exception);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(revision, lastSuccess, lastFailure);
+        return Objects.hash(latestParsedModification, goodModification, partialConfig, exception);
     }
 }

--- a/server/src/test-fast/java/com/thoughtworks/go/config/ConfigReposMaterialParseResultManagerTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/config/ConfigReposMaterialParseResultManagerTest.java
@@ -88,7 +88,7 @@ class ConfigReposMaterialParseResultManagerTest {
         assertThat(parseResult.isSuccessful(), is(false));
         assertThat(parseResult.getLatestParsedModification(), is(modification2));
         assertThat(parseResult.getGoodModification(), is(modification));
-        assertThat(parseResult.getPartialConfig(), is(partialConfig));
+        assertThat(parseResult.lastGoodPartialConfig(), is(partialConfig));
         assertThat(parseResult.getLastFailure(), is(exception));
     }
 
@@ -115,7 +115,7 @@ class ConfigReposMaterialParseResultManagerTest {
         assertThat(parseResult.isSuccessful(), is(true));
         assertThat(parseResult.getLatestParsedModification(), is(modification2));
         assertThat(parseResult.getGoodModification(), is(modification2));
-        assertThat(parseResult.getPartialConfig(), is(partialConfig));
+        assertThat(parseResult.lastGoodPartialConfig(), is(partialConfig));
         assertThat(parseResult.getLastFailure(), is(nullValue()));
     }
 

--- a/server/src/test-fast/java/com/thoughtworks/go/config/ConfigReposMaterialParseResultManagerTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/config/ConfigReposMaterialParseResultManagerTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.config;
+
+import com.thoughtworks.go.config.remote.PartialConfig;
+import com.thoughtworks.go.domain.materials.Modification;
+import com.thoughtworks.go.helper.ModificationsMother;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertThat;
+
+class ConfigReposMaterialParseResultManagerTest {
+    @Test
+    void shouldAddResultForAConfigRepoMaterialUponSuccessfulParse() {
+        String fingerprint = "repo1";
+
+        ConfigReposMaterialParseResultManager manager = new ConfigReposMaterialParseResultManager();
+        Modification modification = modificationFor("rev1");
+        PartialConfig partialConfig = new PartialConfig();
+        manager.parseSuccess(fingerprint, modification, partialConfig);
+
+        PartialConfigParseResult expectedParseResult = PartialConfigParseResult.parseSuccess(modification, partialConfig);
+
+        assertThat(manager.get(fingerprint), is(expectedParseResult));
+        assertThat(manager.get(fingerprint).isSuccessful(), is(true));
+    }
+
+    @Test
+    void shouldAddResultForAConfigRepoMaterialUponUnsuccessfulParse() {
+        String fingerprint = "repo1";
+
+        ConfigReposMaterialParseResultManager manager = new ConfigReposMaterialParseResultManager();
+        Modification modification = modificationFor("rev1");
+        Exception exception = new Exception("Boom!");
+        manager.parseFailed(fingerprint, modification, exception);
+
+        PartialConfigParseResult expectedParseResult = PartialConfigParseResult.parseFailed(modification, exception);
+
+        assertThat(manager.get(fingerprint), is(expectedParseResult));
+        assertThat(manager.get(fingerprint).isSuccessful(), is(false));
+    }
+
+    @Test
+    void shouldReturnNullIfManagerDoesNotContainResultForProvidedConfigRepoMaterialFingerprint() {
+        String fingerprint = "repo1";
+
+        ConfigReposMaterialParseResultManager manager = new ConfigReposMaterialParseResultManager();
+        assertThat(manager.get(fingerprint), is(nullValue()));
+    }
+
+    @Test
+    void shouldUpdateTheResultForAConfigRepoMaterialIfResultAlreadyExists_WhenMaterialParseFails() {
+        String fingerprint = "repo1";
+
+        ConfigReposMaterialParseResultManager manager = new ConfigReposMaterialParseResultManager();
+        Modification modification = modificationFor("rev1");
+        PartialConfig partialConfig = new PartialConfig();
+        manager.parseSuccess(fingerprint, modification, partialConfig);
+
+        PartialConfigParseResult expectedParseResult = PartialConfigParseResult.parseSuccess(modification, partialConfig);
+
+        assertThat(manager.get(fingerprint), is(expectedParseResult));
+        assertThat(manager.get(fingerprint).isSuccessful(), is(true));
+
+        Modification modification2 = modificationFor("rev2");
+        Exception exception = new Exception("Boom!");
+        manager.parseFailed(fingerprint, modification2, exception);
+
+
+        PartialConfigParseResult parseResult = manager.get(fingerprint);
+
+        assertThat(parseResult.isSuccessful(), is(false));
+        assertThat(parseResult.getLatestParsedModification(), is(modification2));
+        assertThat(parseResult.getGoodModification(), is(modification));
+        assertThat(parseResult.getPartialConfig(), is(partialConfig));
+        assertThat(parseResult.getLastFailure(), is(exception));
+    }
+
+    @Test
+    void shouldUpdateTheResultForAConfigRepoMaterialIfResultAlreadyExists_WhenMaterialParseIsFixed() {
+        String fingerprint = "repo1";
+
+        ConfigReposMaterialParseResultManager manager = new ConfigReposMaterialParseResultManager();
+        Modification modification = modificationFor("rev1");
+        Exception exception = new Exception("Boom!");
+        manager.parseFailed(fingerprint, modification, exception);
+
+        PartialConfigParseResult expectedParseResult = PartialConfigParseResult.parseFailed(modification, exception);
+
+        assertThat(manager.get(fingerprint), is(expectedParseResult));
+        assertThat(manager.get(fingerprint).isSuccessful(), is(false));
+
+        Modification modification2 = modificationFor("rev2");
+        PartialConfig partialConfig = new PartialConfig();
+        manager.parseSuccess(fingerprint, modification2, partialConfig);
+
+        PartialConfigParseResult parseResult = manager.get(fingerprint);
+
+        assertThat(parseResult.isSuccessful(), is(true));
+        assertThat(parseResult.getLatestParsedModification(), is(modification2));
+        assertThat(parseResult.getGoodModification(), is(modification2));
+        assertThat(parseResult.getPartialConfig(), is(partialConfig));
+        assertThat(parseResult.getLastFailure(), is(nullValue()));
+    }
+
+    private Modification modificationFor(String revision) {
+        return ModificationsMother.oneModifiedFile(revision);
+    }
+}

--- a/server/src/test-integration/java/com/thoughtworks/go/config/GoRepoConfigDataSourceIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/config/GoRepoConfigDataSourceIntegrationTest.java
@@ -18,6 +18,7 @@ package com.thoughtworks.go.config;
 
 import com.thoughtworks.go.config.materials.git.GitMaterialConfig;
 import com.thoughtworks.go.config.remote.ConfigRepoConfig;
+import com.thoughtworks.go.domain.materials.Modification;
 import com.thoughtworks.go.server.service.GoConfigService;
 import com.thoughtworks.go.serverhealth.ServerHealthService;
 import com.thoughtworks.go.util.GoConfigFileHelper;
@@ -85,7 +86,9 @@ public class GoRepoConfigDataSourceIntegrationTest {
         configHelper.addConfigRepo(configRepoConfig);
 
         goConfigService.forceNotifyListeners();
-        repoConfigDataSource.onCheckoutComplete(configRepoConfig.getMaterialConfig(), templateConfigRepo, latestRevision);
+        Modification modification = new Modification();
+        modification.setRevision(latestRevision);
+        repoConfigDataSource.onCheckoutComplete(configRepoConfig.getMaterialConfig(), templateConfigRepo, modification);
 
     }
 


### PR DESCRIPTION
* Config Repos API now returns `parse_info` field as part of config repo GET API response.
* `parse_info` represents the configRepoMaterialParseResult.
  - latest_parsed_modification: Modification representation for the latest parsed commit
  - good_modification: Modification representation for the last good commit
  - error: String representation of config repo errror.

