### PR TITLE
Agent side toggles controlled by the server

### DIFF
--- a/agent-common/src/main/java/com/thoughtworks/go/agent/common/util/HeaderUtil.java
+++ b/agent-common/src/main/java/com/thoughtworks/go/agent/common/util/HeaderUtil.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.agent.common.util;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.http.Header;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class HeaderUtil {
+    private static Logger LOGGER = LoggerFactory.getLogger(HeaderUtil.class);
+
+    public static Map<String, String> parseExtraProperties(Header extraPropertiesHeader) {
+        if (extraPropertiesHeader == null || StringUtils.isBlank(extraPropertiesHeader.getValue())) {
+            return new HashMap<>();
+        }
+
+        try {
+            return Arrays.stream(extraPropertiesHeader.getValue().trim().split(" +"))
+                    .map(property -> property.split("="))
+                    .collect(Collectors.toMap(
+                            keyAndValue -> keyAndValue[0].replaceAll("%20", " "),
+                            keyAndValue -> keyAndValue[1].replaceAll("%20", " "),
+                            (value1, value2) -> value1,
+                            LinkedHashMap::new));
+        } catch (Exception e) {
+            LOGGER.warn("Failed to parse extra properties header value: {}", extraPropertiesHeader.getValue(), e);
+            return new HashMap<>();
+        }
+    }
+
+}

--- a/agent-common/src/main/java/com/thoughtworks/go/agent/common/util/HeaderUtil.java
+++ b/agent-common/src/main/java/com/thoughtworks/go/agent/common/util/HeaderUtil.java
@@ -16,6 +16,7 @@
 
 package com.thoughtworks.go.agent.common.util;
 
+import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.Header;
 import org.slf4j.Logger;
@@ -27,6 +28,8 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 public class HeaderUtil {
     private static Logger LOGGER = LoggerFactory.getLogger(HeaderUtil.class);
 
@@ -36,7 +39,13 @@ public class HeaderUtil {
         }
 
         try {
-            return Arrays.stream(extraPropertiesHeader.getValue().trim().split(" +"))
+            final String headerValue = new String(Base64.decodeBase64(extraPropertiesHeader.getValue()), UTF_8);
+
+            if (StringUtils.isBlank(headerValue)) {
+                return new HashMap<>();
+            }
+
+            return Arrays.stream(headerValue.trim().split(" +"))
                     .map(property -> property.split("="))
                     .collect(Collectors.toMap(
                             keyAndValue -> keyAndValue[0].replaceAll("%20", " "),

--- a/agent-common/src/test/java/com/thoughtworks/go/agent/common/util/HeaderUtilTest.java
+++ b/agent-common/src/test/java/com/thoughtworks/go/agent/common/util/HeaderUtilTest.java
@@ -16,19 +16,22 @@
 
 package com.thoughtworks.go.agent.common.util;
 
+import org.apache.commons.codec.binary.Base64;
 import org.apache.http.message.BasicHeader;
 import org.junit.Test;
 
 import java.util.HashMap;
 import java.util.Map;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
 public class HeaderUtilTest {
     @Test
     public void shouldGetExtraPropertiesFromHeader() {
-        assertExtraProperties(null, new HashMap<>());
+        assertExtraPropertiesWithoutBase64(null, new HashMap<>());
+        assertExtraPropertiesWithoutBase64("", new HashMap<>());
         assertExtraProperties("", new HashMap<>());
 
         assertExtraProperties("Key1=Value1 key2=value2", new HashMap<String, String>() {{
@@ -57,10 +60,14 @@ public class HeaderUtilTest {
         assertExtraProperties("abc", new HashMap<>());
     }
 
-    private void assertExtraProperties(String actualHeaderValue, Map<String, String> expectedProperties) {
-        final Map<String, String> actualResult = HeaderUtil.parseExtraProperties(new BasicHeader("some-key", actualHeaderValue));
-        assertThat(actualResult, is(expectedProperties));
+    private void assertExtraProperties(String actualHeaderValueBeforeBase64, Map<String, String> expectedProperties) {
+        String headerValueInBase64 = Base64.encodeBase64String(actualHeaderValueBeforeBase64.getBytes(UTF_8));
+        assertExtraPropertiesWithoutBase64(headerValueInBase64, expectedProperties);
+    }
 
+    private void assertExtraPropertiesWithoutBase64(String actualHeaderValue, Map<String, String> expectedProperties) {
+        Map<String, String> actualResult = HeaderUtil.parseExtraProperties(new BasicHeader("some-key", actualHeaderValue));
+        assertThat(actualResult, is(expectedProperties));
     }
 
 }

--- a/agent-common/src/test/java/com/thoughtworks/go/agent/common/util/HeaderUtilTest.java
+++ b/agent-common/src/test/java/com/thoughtworks/go/agent/common/util/HeaderUtilTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.agent.common.util;
+
+import org.apache.http.message.BasicHeader;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+public class HeaderUtilTest {
+    @Test
+    public void shouldGetExtraPropertiesFromHeader() {
+        assertExtraProperties(null, new HashMap<>());
+        assertExtraProperties("", new HashMap<>());
+
+        assertExtraProperties("Key1=Value1 key2=value2", new HashMap<String, String>() {{
+            put("Key1", "Value1");
+            put("key2", "value2");
+        }});
+
+        assertExtraProperties("  Key1=Value1    key2=value2  ", new HashMap<String, String>() {{
+            put("Key1", "Value1");
+            put("key2", "value2");
+        }});
+
+        assertExtraProperties("Key1=Value1 key2=value2 key2=value3", new HashMap<String, String>() {{
+            put("Key1", "Value1");
+            put("key2", "value2");
+        }});
+
+        assertExtraProperties("Key1%20WithSpace=Value1%20WithSpace key2=value2", new HashMap<String, String>() {{
+            put("Key1 WithSpace", "Value1 WithSpace");
+            put("key2", "value2");
+        }});
+    }
+
+    @Test
+    public void shouldNotFailIfExtraPropertiesAreNotFormattedProperly() {
+        assertExtraProperties("abc", new HashMap<>());
+    }
+
+    private void assertExtraProperties(String actualHeaderValue, Map<String, String> expectedProperties) {
+        final Map<String, String> actualResult = HeaderUtil.parseExtraProperties(new BasicHeader("some-key", actualHeaderValue));
+        assertThat(actualResult, is(expectedProperties));
+
+    }
+
+}

--- a/agent-common/src/test/java/com/thoughtworks/go/agent/launcher/ServerBinaryDownloaderTest.java
+++ b/agent-common/src/test/java/com/thoughtworks/go/agent/launcher/ServerBinaryDownloaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 ThoughtWorks, Inc.
+ * Copyright 2019 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,6 +39,8 @@ import java.io.FileInputStream;
 import java.net.UnknownHostException;
 import java.security.DigestInputStream;
 import java.security.MessageDigest;
+import java.util.HashMap;
+import java.util.Map;
 
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
@@ -55,7 +57,7 @@ public class ServerBinaryDownloaderTest {
     public ExpectedException exception = ExpectedException.none();
 
     @After
-    public void tearDown() throws Exception {
+    public void tearDown() {
         FileUtils.deleteQuietly(new File(Downloader.AGENT_BINARY));
         FileUtils.deleteQuietly(DownloadableFile.AGENT.getLocalFile());
     }
@@ -76,7 +78,32 @@ public class ServerBinaryDownloaderTest {
     }
 
     @Test
-    public void shouldDownloadAgentJarFile() throws Exception {
+    public void shouldGetExtraPropertiesFromHeader() {
+        assertExtraProperties("", new HashMap<>());
+
+        assertExtraProperties("Key1=Value1 key2=value2", new HashMap<String, String>() {{
+            put("Key1", "Value1");
+            put("key2", "value2");
+        }});
+
+        assertExtraProperties("Key1=Value1 key2=value2 key2=value3", new HashMap<String, String>() {{
+            put("Key1", "Value1");
+            put("key2", "value2");
+        }});
+
+        assertExtraProperties("Key1%20WithSpace=Value1%20WithSpace key2=value2", new HashMap<String, String>() {{
+            put("Key1 WithSpace", "Value1 WithSpace");
+            put("key2", "value2");
+        }});
+    }
+
+    @Test
+    public void shouldNotFailIfExtraPropertiesAreNotFormattedProperly() {
+        assertExtraProperties("abc", new HashMap<>());
+    }
+
+    @Test
+    public void shouldDownloadAgentJarFile() {
         ServerBinaryDownloader downloader = new ServerBinaryDownloader(ServerUrlGeneratorMother.generatorFor("localhost", server.getPort()), null, SslVerificationMode.NONE);
         assertThat(DownloadableFile.AGENT.doesNotExist(), is(true));
         downloader.downloadIfNecessary(DownloadableFile.AGENT);
@@ -84,7 +111,7 @@ public class ServerBinaryDownloaderTest {
     }
 
     @Test
-    public void shouldReturnTrueIfTheFileIsDownloaded() throws Exception {
+    public void shouldReturnTrueIfTheFileIsDownloaded() {
         ServerBinaryDownloader downloader = new ServerBinaryDownloader(ServerUrlGeneratorMother.generatorFor("localhost", server.getPort()), null, SslVerificationMode.NONE);
         assertThat(downloader.downloadIfNecessary(DownloadableFile.AGENT), is(true));
     }
@@ -153,5 +180,17 @@ public class ServerBinaryDownloaderTest {
         when(closeableHttpClient.execute(any(HttpRequestBase.class))).thenReturn(httpResponse);
         ServerBinaryDownloader downloader = new ServerBinaryDownloader(builder, ServerUrlGeneratorMother.generatorFor("localhost", server.getPort()));
         assertThat(downloader.download(DownloadableFile.AGENT), is(false));
+    }
+
+    private void assertExtraProperties(String valueToSet, Map<String, String> expectedValue) {
+        ServerBinaryDownloader downloader = new ServerBinaryDownloader(ServerUrlGeneratorMother.generatorFor("localhost", server.getPort()), null, SslVerificationMode.NONE);
+        try {
+            server.setExtraPropertiesHeaderValue(valueToSet);
+            downloader.downloadIfNecessary(DownloadableFile.AGENT);
+
+            assertThat(downloader.getExtraProperties(), is(expectedValue));
+        } finally {
+            server.setExtraPropertiesHeaderValue(null);
+        }
     }
 }

--- a/agent/src/main/java/com/thoughtworks/go/agent/AgentController.java
+++ b/agent/src/main/java/com/thoughtworks/go/agent/AgentController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 ThoughtWorks, Inc.
+ * Copyright 2019 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -80,7 +80,7 @@ public abstract class AgentController {
     public final void loop() {
         try {
             LOG.debug("[Agent Loop] Trying to retrieve work.");
-            agentUpgradeService.checkForUpgrade();
+            agentUpgradeService.checkForUpgradeAndExtraProperties();
             sslInfrastructureService.registerIfNecessary(getAgentAutoRegistrationProperties());
             work();
             LOG.debug("[Agent Loop] Successfully retrieved work.");

--- a/agent/src/test/java/com/thoughtworks/go/agent/AgentControllerTest.java
+++ b/agent/src/test/java/com/thoughtworks/go/agent/AgentControllerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 ThoughtWorks, Inc.
+ * Copyright 2019 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -119,7 +119,7 @@ public class AgentControllerTest {
         agentController = createAgentController();
         InOrder inOrder = inOrder(agentUpgradeService, sslInfrastructureService);
         agentController.loop();
-        inOrder.verify(agentUpgradeService).checkForUpgrade();
+        inOrder.verify(agentUpgradeService).checkForUpgradeAndExtraProperties();
         inOrder.verify(sslInfrastructureService).registerIfNecessary(agentController.getAgentAutoRegistrationProperties());
     }
 

--- a/agent/src/test/java/com/thoughtworks/go/agent/AgentWebSocketClientControllerTest.java
+++ b/agent/src/test/java/com/thoughtworks/go/agent/AgentWebSocketClientControllerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 ThoughtWorks, Inc.
+ * Copyright 2019 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -137,7 +137,7 @@ public class AgentWebSocketClientControllerTest {
 
         agentController.loop();
 
-        verify(agentUpgradeService).checkForUpgrade();
+        verify(agentUpgradeService).checkForUpgradeAndExtraProperties();
         verify(sslInfrastructureService).registerIfNecessary(agentController.getAgentAutoRegistrationProperties());
         verify(sslInfrastructureService).invalidateAgentCertificate();
     }

--- a/agent/src/test/java/com/thoughtworks/go/agent/service/AgentUpgradeServiceTest.java
+++ b/agent/src/test/java/com/thoughtworks/go/agent/service/AgentUpgradeServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 ThoughtWorks, Inc.
+ * Copyright 2019 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,36 +25,38 @@ import org.apache.http.client.methods.HttpGet;
 import org.apache.http.message.BasicHeader;
 import org.apache.http.message.BasicStatusLine;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.contrib.java.lang.system.RestoreSystemProperties;
+import org.junit.rules.TestRule;
 
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.fail;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import static java.util.stream.Collectors.toMap;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 public class AgentUpgradeServiceTest {
+    @Rule
+    public final TestRule restoreSystemProperties = new RestoreSystemProperties();
 
     private SystemEnvironment systemEnvironment;
-    private URLService urlService;
     private AgentUpgradeService agentUpgradeService;
-    private HttpGet httpMethod;
     private CloseableHttpResponse closeableHttpResponse;
     private AgentUpgradeService.JvmExitter jvmExitter;
 
     @Before
     public void setUp() throws Exception {
         systemEnvironment = mock(SystemEnvironment.class);
-        urlService = mock(URLService.class);
+        URLService urlService = mock(URLService.class);
         GoAgentServerHttpClient httpClient = mock(GoAgentServerHttpClient.class);
         jvmExitter = mock(AgentUpgradeService.JvmExitter.class);
         agentUpgradeService = spy(new AgentUpgradeService(urlService, httpClient, systemEnvironment, jvmExitter));
 
-        httpMethod = mock(HttpGet.class);
+        HttpGet httpMethod = mock(HttpGet.class);
         doReturn(httpMethod).when(agentUpgradeService).getAgentLatestStatusGetMethod();
         closeableHttpResponse = mock(CloseableHttpResponse.class);
         when(closeableHttpResponse.getStatusLine()).thenReturn(new BasicStatusLine(HttpVersion.HTTP_1_1, 200, "OK"));
@@ -63,21 +65,15 @@ public class AgentUpgradeServiceTest {
 
     @Test
     public void checkForUpgradeShouldNotKillAgentIfAllDownloadsAreCompatible() throws Exception {
-        when(systemEnvironment.getAgentMd5()).thenReturn("latest-md5");
-        when(systemEnvironment.getGivenAgentLauncherMd5()).thenReturn("latest-md5");
-        when(systemEnvironment.getAgentPluginsMd5()).thenReturn("latest-md5");
-        when(systemEnvironment.getTfsImplMd5()).thenReturn("latest-md5");
+        setupForNoChangesToMD5();
 
-        expectHeaderValue(SystemEnvironment.AGENT_CONTENT_MD5_HEADER, "latest-md5");
-        expectHeaderValue(SystemEnvironment.AGENT_LAUNCHER_CONTENT_MD5_HEADER, "latest-md5");
-        expectHeaderValue(SystemEnvironment.AGENT_PLUGINS_ZIP_MD5_HEADER, "latest-md5");
-        expectHeaderValue(SystemEnvironment.AGENT_TFS_SDK_MD5_HEADER, "latest-md5");
+        agentUpgradeService.checkForUpgradeAndExtraProperties();
 
-        agentUpgradeService.checkForUpgrade();
+        verify(jvmExitter, never()).jvmExit(anyString(), anyString(), anyString());
     }
 
     @Test
-    public void checkForUpgradeShouldKillAgentIfAgentMD5doesNotMatch() throws Exception {
+    public void checkForUpgradeShouldKillAgentIfAgentMD5doesNotMatch() {
         when(systemEnvironment.getAgentMd5()).thenReturn("old-agent-md5");
         expectHeaderValue(SystemEnvironment.AGENT_CONTENT_MD5_HEADER, "new-agent-md5");
 
@@ -85,7 +81,7 @@ public class AgentUpgradeServiceTest {
         doThrow(toBeThrown).when(jvmExitter).jvmExit(anyString(), anyString(), anyString());
 
         try {
-            agentUpgradeService.checkForUpgrade();
+            agentUpgradeService.checkForUpgradeAndExtraProperties();
             fail("should have done jvm exit");
         } catch (Exception e) {
             assertSame(e, toBeThrown);
@@ -95,7 +91,7 @@ public class AgentUpgradeServiceTest {
     }
 
     @Test
-    public void checkForUpgradeShouldKillAgentIfLauncherMD5doesNotMatch() throws Exception {
+    public void checkForUpgradeShouldKillAgentIfLauncherMD5doesNotMatch() {
         when(systemEnvironment.getAgentMd5()).thenReturn("not-changing");
         expectHeaderValue(SystemEnvironment.AGENT_CONTENT_MD5_HEADER, "not-changing");
 
@@ -106,7 +102,7 @@ public class AgentUpgradeServiceTest {
         doThrow(toBeThrown).when(jvmExitter).jvmExit(anyString(), anyString(), anyString());
 
         try {
-            agentUpgradeService.checkForUpgrade();
+            agentUpgradeService.checkForUpgradeAndExtraProperties();
             fail("should have done jvm exit");
         } catch (Exception e) {
             assertSame(e, toBeThrown);
@@ -116,7 +112,7 @@ public class AgentUpgradeServiceTest {
     }
 
     @Test
-    public void checkForUpgradeShouldKillAgentIfPluginZipMd5doesNotMatch() throws Exception {
+    public void checkForUpgradeShouldKillAgentIfPluginZipMd5doesNotMatch() {
         when(systemEnvironment.getAgentMd5()).thenReturn("not-changing");
         expectHeaderValue(SystemEnvironment.AGENT_CONTENT_MD5_HEADER, "not-changing");
 
@@ -130,7 +126,7 @@ public class AgentUpgradeServiceTest {
         doThrow(toBeThrown).when(jvmExitter).jvmExit(anyString(), anyString(), anyString());
 
         try {
-            agentUpgradeService.checkForUpgrade();
+            agentUpgradeService.checkForUpgradeAndExtraProperties();
             fail("should have done jvm exit");
         } catch (Exception e) {
             assertSame(e, toBeThrown);
@@ -140,7 +136,7 @@ public class AgentUpgradeServiceTest {
     }
 
     @Test
-    public void checkForUpgradeShouldKillAgentIfTfsMd5doesNotMatch() throws Exception {
+    public void checkForUpgradeShouldKillAgentIfTfsMd5doesNotMatch() {
         when(systemEnvironment.getAgentMd5()).thenReturn("not-changing");
         expectHeaderValue(SystemEnvironment.AGENT_CONTENT_MD5_HEADER, "not-changing");
 
@@ -157,7 +153,7 @@ public class AgentUpgradeServiceTest {
         doThrow(toBeThrown).when(jvmExitter).jvmExit(anyString(), anyString(), anyString());
 
         try {
-            agentUpgradeService.checkForUpgrade();
+            agentUpgradeService.checkForUpgradeAndExtraProperties();
             fail("should have done jvm exit");
         } catch (Exception e) {
             assertSame(e, toBeThrown);
@@ -166,7 +162,48 @@ public class AgentUpgradeServiceTest {
         verify(jvmExitter).jvmExit("tfs-impl jar", "old-tfs-md5", "new-tfs-md5");
     }
 
+    @Test
+    public void shouldSetAnyExtraPropertiesSentByTheServer() throws Exception {
+        setupForNoChangesToMD5();
+
+        expectHeaderValue(SystemEnvironment.AGENT_EXTRA_PROPERTIES_HEADER, "abc=def%20ghi  jkl%20mno=pqr%20stu");
+        agentUpgradeService.checkForUpgradeAndExtraProperties();
+
+        assertThat(System.getProperty("abc"), is("def ghi"));
+        assertThat(System.getProperty("jkl mno"), is("pqr stu"));
+    }
+
+    @Test
+    public void shouldFailQuietlyWhenExtraPropertiesHeaderValueIsInvalid() throws Exception {
+        setupForNoChangesToMD5();
+
+        final Map<Object, Object> before = System.getProperties().entrySet().stream().collect(toMap(Entry::getKey, Entry::getValue));
+
+        expectHeaderValue(SystemEnvironment.AGENT_EXTRA_PROPERTIES_HEADER, "this_is_invalid");
+        agentUpgradeService.checkForUpgradeAndExtraProperties();
+
+        final Map<Object, Object> after = System.getProperties().entrySet().stream().collect(toMap(Entry::getKey, Entry::getValue));
+
+        assertThat(after, is(before));
+    }
+
+    private void setupForNoChangesToMD5() {
+        when(systemEnvironment.getAgentMd5()).thenReturn("latest-md5");
+        when(systemEnvironment.getGivenAgentLauncherMd5()).thenReturn("latest-md5");
+        when(systemEnvironment.getAgentPluginsMd5()).thenReturn("latest-md5");
+        when(systemEnvironment.getTfsImplMd5()).thenReturn("latest-md5");
+
+        expectHeaderValue(SystemEnvironment.AGENT_CONTENT_MD5_HEADER, "latest-md5");
+        expectHeaderValue(SystemEnvironment.AGENT_LAUNCHER_CONTENT_MD5_HEADER, "latest-md5");
+        expectHeaderValue(SystemEnvironment.AGENT_PLUGINS_ZIP_MD5_HEADER, "latest-md5");
+        expectHeaderValue(SystemEnvironment.AGENT_TFS_SDK_MD5_HEADER, "latest-md5");
+    }
+
     private void expectHeaderValue(final String headerName, final String headerValue) {
-        when(closeableHttpResponse.getFirstHeader(headerName)).thenReturn(new BasicHeader(headerName, headerValue));
+        expectHeader(headerName, new BasicHeader(headerName, headerValue));
+    }
+
+    private void expectHeader(String headerName, BasicHeader header) {
+        when(closeableHttpResponse.getFirstHeader(headerName)).thenReturn(header);
     }
 }

--- a/agent/src/test/java/com/thoughtworks/go/agent/service/AgentUpgradeServiceTest.java
+++ b/agent/src/test/java/com/thoughtworks/go/agent/service/AgentUpgradeServiceTest.java
@@ -33,7 +33,9 @@ import org.junit.rules.TestRule;
 import java.util.Map;
 import java.util.Map.Entry;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.stream.Collectors.toMap;
+import static org.apache.commons.codec.binary.Base64.encodeBase64String;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -166,7 +168,7 @@ public class AgentUpgradeServiceTest {
     public void shouldSetAnyExtraPropertiesSentByTheServer() throws Exception {
         setupForNoChangesToMD5();
 
-        expectHeaderValue(SystemEnvironment.AGENT_EXTRA_PROPERTIES_HEADER, "abc=def%20ghi  jkl%20mno=pqr%20stu");
+        expectHeaderValue(SystemEnvironment.AGENT_EXTRA_PROPERTIES_HEADER, encodeBase64String("abc=def%20ghi  jkl%20mno=pqr%20stu".getBytes(UTF_8)));
         agentUpgradeService.checkForUpgradeAndExtraProperties();
 
         assertThat(System.getProperty("abc"), is("def ghi"));
@@ -179,7 +181,7 @@ public class AgentUpgradeServiceTest {
 
         final Map<Object, Object> before = System.getProperties().entrySet().stream().collect(toMap(Entry::getKey, Entry::getValue));
 
-        expectHeaderValue(SystemEnvironment.AGENT_EXTRA_PROPERTIES_HEADER, "this_is_invalid");
+        expectHeaderValue(SystemEnvironment.AGENT_EXTRA_PROPERTIES_HEADER, encodeBase64String("this_is_invalid".getBytes(UTF_8)));
         agentUpgradeService.checkForUpgradeAndExtraProperties();
 
         final Map<Object, Object> after = System.getProperties().entrySet().stream().collect(toMap(Entry::getKey, Entry::getValue));

--- a/base/src/main/java/com/thoughtworks/go/util/SystemEnvironment.java
+++ b/base/src/main/java/com/thoughtworks/go/util/SystemEnvironment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 ThoughtWorks, Inc.
+ * Copyright 2019 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -64,6 +64,7 @@ public class SystemEnvironment implements Serializable, ConfigDirProvider {
 
     public static final String AGENT_PLUGINS_ZIP_MD5_HEADER = "Agent-Plugins-Content-MD5";
     public static final String AGENT_TFS_SDK_MD5_HEADER = "TFS-SDK-Content-MD5";
+    public static final String AGENT_EXTRA_PROPERTIES_HEADER = "GoCD-Agent-Extra-Properties";
 
     public static final String EMPTY_STRING = "";
     public static final String BLANK_STRING = EMPTY_STRING;
@@ -145,6 +146,7 @@ public class SystemEnvironment implements Serializable, ConfigDirProvider {
     public static final GoSystemProperty<Integer> GO_SERVER_SESSION_TIMEOUT_IN_SECONDS = new GoIntSystemProperty("go.server.session.timeout.seconds", 60 * 60 * 24 * 14);
     public static final GoSystemProperty<Integer> GO_SERVER_SESSION_COOKIE_MAX_AGE_IN_SECONDS = new GoIntSystemProperty("go.sessioncookie.maxage.seconds", 60 * 60 * 24 * 14);
     public static final GoSystemProperty<Boolean> GO_SERVER_SESSION_COOKIE_SECURE = new GoBooleanSystemProperty("go.sessioncookie.secure", false);
+    public static final GoSystemProperty<String> AGENT_EXTRA_PROPERTIES = new GoStringSystemProperty("gocd.agent.extra.properties", "");
 
     /* DATABASE CONFIGURATION - Defaults are of H2 */
     public static GoSystemProperty<String> GO_DATABASE_HOST = new GoStringSystemProperty("db.host", "localhost");

--- a/server/src/main/java/com/thoughtworks/go/server/controller/AgentRegistrationController.java
+++ b/server/src/main/java/com/thoughtworks/go/server/controller/AgentRegistrationController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 ThoughtWorks, Inc.
+ * Copyright 2019 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -55,6 +55,7 @@ import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import java.util.List;
 
+import static com.thoughtworks.go.util.SystemEnvironment.AGENT_EXTRA_PROPERTIES;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.springframework.http.HttpStatus.*;
@@ -115,6 +116,7 @@ public class AgentRegistrationController {
         response.setHeader(SystemEnvironment.AGENT_LAUNCHER_CONTENT_MD5_HEADER, agentLauncherChecksum);
         response.setHeader(SystemEnvironment.AGENT_PLUGINS_ZIP_MD5_HEADER, pluginsZip.md5());
         response.setHeader(SystemEnvironment.AGENT_TFS_SDK_MD5_HEADER, tfsSdkChecksum);
+        response.setHeader(SystemEnvironment.AGENT_EXTRA_PROPERTIES_HEADER, systemEnvironment.get(AGENT_EXTRA_PROPERTIES));
         setOtherHeaders(response);
     }
 
@@ -180,6 +182,7 @@ public class AgentRegistrationController {
 
     private void setOtherHeaders(HttpServletResponse response) {
         response.setHeader("Cruise-Server-Ssl-Port", Integer.toString(systemEnvironment.getSslServerPort()));
+        response.setHeader(SystemEnvironment.AGENT_EXTRA_PROPERTIES_HEADER, systemEnvironment.get(AGENT_EXTRA_PROPERTIES));
     }
 
     @RequestMapping(value = "/admin/agent", method = RequestMethod.GET)

--- a/server/src/test-fast/java/com/thoughtworks/go/server/controller/AgentRegistrationControllerTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/controller/AgentRegistrationControllerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 ThoughtWorks, Inc.
+ * Copyright 2019 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,12 +45,14 @@ import org.springframework.mock.web.MockHttpServletResponse;
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
 import java.io.File;
+import java.io.IOException;
 import java.io.InputStream;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
 import java.util.Base64;
 
+import static com.thoughtworks.go.util.SystemEnvironment.AGENT_EXTRA_PROPERTIES;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.*;
@@ -82,6 +84,7 @@ public class AgentRegistrationControllerTest {
         FileUtils.writeStringToFile(pluginZipFile, "content", UTF_8);
         when(systemEnvironment.get(SystemEnvironment.ALL_PLUGINS_ZIP_PATH)).thenReturn(pluginZipFile.getAbsolutePath());
         when(systemEnvironment.getSslServerPort()).thenReturn(8443);
+        when(systemEnvironment.get(AGENT_EXTRA_PROPERTIES)).thenReturn("");
         pluginsZip = mock(PluginsZip.class);
         controller = new AgentRegistrationController(agentService, goConfigService, systemEnvironment, pluginsZip, agentConfigService);
         controller.populateAgentChecksum();
@@ -90,7 +93,7 @@ public class AgentRegistrationControllerTest {
     }
 
     @Test
-    public void shouldRegisterWithProvidedAgentInformation() throws Exception {
+    public void shouldRegisterWithProvidedAgentInformation() {
         when(goConfigService.hasAgent("blahAgent-uuid")).thenReturn(false);
         ServerConfig serverConfig = mockedServerConfig("token-generation-key", "someKey");
         when(goConfigService.serverConfig()).thenReturn(serverConfig);
@@ -102,7 +105,7 @@ public class AgentRegistrationControllerTest {
     }
 
     @Test
-    public void shouldAutoRegisterAgent() throws Exception {
+    public void shouldAutoRegisterAgent() {
         String uuid = "uuid";
         final ServerConfig serverConfig = mockedServerConfig("token-generation-key", "someKey");
         final String token = token(uuid, serverConfig.getTokenGenerationKey());
@@ -120,7 +123,7 @@ public class AgentRegistrationControllerTest {
     }
 
     @Test
-    public void shouldAutoRegisterAgentWithHostnameFromAutoRegisterProperties() throws Exception {
+    public void shouldAutoRegisterAgentWithHostnameFromAutoRegisterProperties() {
         String uuid = "uuid";
         when(goConfigService.hasAgent(uuid)).thenReturn(false);
         ServerConfig serverConfig = mockedServerConfig("token-generation-key", "someKey");
@@ -137,7 +140,7 @@ public class AgentRegistrationControllerTest {
     }
 
     @Test
-    public void shouldNotAutoRegisterAgentIfKeysDoNotMatch() throws Exception {
+    public void shouldNotAutoRegisterAgentIfKeysDoNotMatch() {
         String uuid = "uuid";
         when(goConfigService.hasAgent(uuid)).thenReturn(false);
         ServerConfig serverConfig = mockedServerConfig("token-generation-key", "someKey");
@@ -153,6 +156,7 @@ public class AgentRegistrationControllerTest {
     @Test
     public void checkAgentStatusShouldIncludeMd5Checksum_forAgent_forLauncher_whenChecksumsAreCached() throws Exception {
         when(pluginsZip.md5()).thenReturn("plugins-zip-md5");
+        when(systemEnvironment.get(AGENT_EXTRA_PROPERTIES)).thenReturn("extra=property");
 
         controller.checkAgentStatus(response);
 
@@ -170,6 +174,18 @@ public class AgentRegistrationControllerTest {
 
         assertEquals("plugins-zip-md5", response.getHeader(SystemEnvironment.AGENT_PLUGINS_ZIP_MD5_HEADER));
         assertEquals("8443", response.getHeader("Cruise-Server-Ssl-Port"));
+    }
+
+    @Test
+    public void checkAgentStatusShouldIncludeExtraPropertiesForAgent() {
+        final String extraPropertiesValue = "extra=property another=extra.property";
+
+        when(pluginsZip.md5()).thenReturn("plugins-zip-md5");
+        when(systemEnvironment.get(AGENT_EXTRA_PROPERTIES)).thenReturn(extraPropertiesValue);
+
+        controller.checkAgentStatus(response);
+
+        assertEquals(extraPropertiesValue, response.getHeader(SystemEnvironment.AGENT_EXTRA_PROPERTIES_HEADER));
     }
 
     @Test
@@ -207,6 +223,17 @@ public class AgentRegistrationControllerTest {
     }
 
     @Test
+    public void contentShouldIncludeExtraAgentProperties_forAgent() throws IOException {
+        final String extraPropertiesValue = "extra=property another=extra.property";
+
+        when(systemEnvironment.get(AGENT_EXTRA_PROPERTIES)).thenReturn(extraPropertiesValue);
+
+        controller.downloadAgent(response);
+
+        assertEquals(extraPropertiesValue, response.getHeader(SystemEnvironment.AGENT_EXTRA_PROPERTIES_HEADER));
+    }
+
+    @Test
     public void contentShouldIncludeMd5Checksum_forAgentLauncher() throws Exception {
         controller.downloadAgentLauncher(response);
         assertEquals("8443", response.getHeader("Cruise-Server-Ssl-Port"));
@@ -221,7 +248,7 @@ public class AgentRegistrationControllerTest {
     }
 
     @Test
-    public void headShouldIncludeMd5Checksum_forPluginsZip() throws Exception {
+    public void headShouldIncludeMd5Checksum_forPluginsZip() {
         when(pluginsZip.md5()).thenReturn("md5");
         controller.checkAgentPluginsZipStatus(response);
 
@@ -263,7 +290,7 @@ public class AgentRegistrationControllerTest {
     }
 
     @Test
-    public void shouldGenerateToken() throws Exception {
+    public void shouldGenerateToken() {
         final ServerConfig serverConfig = mockedServerConfig("agent-auto-register-key", "someKey");
         when(goConfigService.serverConfig()).thenReturn(serverConfig);
         when(agentService.findAgent("uuid-from-agent")).thenReturn(AgentInstanceMother.idle());
@@ -276,7 +303,7 @@ public class AgentRegistrationControllerTest {
     }
 
     @Test
-    public void shouldRejectGenerateTokenRequestIfAgentIsInPendingState() throws Exception {
+    public void shouldRejectGenerateTokenRequestIfAgentIsInPendingState() {
         final ServerConfig serverConfig = mockedServerConfig("agent-auto-register-key", "someKey");
         when(goConfigService.serverConfig()).thenReturn(serverConfig);
         when(agentService.findAgent("uuid-from-agent")).thenReturn(AgentInstanceMother.pendingInstance());
@@ -289,7 +316,7 @@ public class AgentRegistrationControllerTest {
     }
 
     @Test
-    public void shouldRejectGenerateTokenRequestIfAgentIsInConfig() throws Exception {
+    public void shouldRejectGenerateTokenRequestIfAgentIsInConfig() {
         final ServerConfig serverConfig = mockedServerConfig("agent-auto-register-key", "someKey");
         when(goConfigService.serverConfig()).thenReturn(serverConfig);
         when(agentService.findAgent("uuid-from-agent")).thenReturn(AgentInstanceMother.idle());
@@ -302,7 +329,7 @@ public class AgentRegistrationControllerTest {
     }
 
     @Test
-    public void shouldRejectGenerateTokenRequestIfUUIDIsEmpty() throws Exception {
+    public void shouldRejectGenerateTokenRequestIfUUIDIsEmpty() {
         final ResponseEntity responseEntity = controller.getToken("               ");
 
         assertThat(responseEntity.getStatusCode(), is(CONFLICT));
@@ -310,7 +337,7 @@ public class AgentRegistrationControllerTest {
     }
 
     @Test
-    public void shouldRejectRegistrationRequestWhenInvalidTokenProvided() throws Exception {
+    public void shouldRejectRegistrationRequestWhenInvalidTokenProvided() {
         when(goConfigService.hasAgent("blahAgent-uuid")).thenReturn(false);
         ServerConfig serverConfig = mockedServerConfig("token-generation-key", "someKey");
         when(goConfigService.serverConfig()).thenReturn(serverConfig);

--- a/test/test-utils/src/main/java/com/thoughtworks/go/agent/testhelper/AgentBinariesServlet.java
+++ b/test/test-utils/src/main/java/com/thoughtworks/go/agent/testhelper/AgentBinariesServlet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 ThoughtWorks, Inc.
+ * Copyright 2019 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,11 +16,15 @@
 
 package com.thoughtworks.go.agent.testhelper;
 
+import com.thoughtworks.go.util.SystemEnvironment;
+
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
+
+import static com.thoughtworks.go.util.SystemEnvironment.AGENT_EXTRA_PROPERTIES_HEADER;
 
 public class AgentBinariesServlet extends HttpServlet {
 
@@ -36,6 +40,11 @@ public class AgentBinariesServlet extends HttpServlet {
         try {
             response.setHeader("Content-MD5", resource.getMd5());
             response.setHeader("Cruise-Server-Ssl-Port", String.valueOf(fakeGoServer.getSecurePort()));
+
+            final String extraPropertiesHeaderValue = fakeGoServer.getExtraPropertiesHeaderValue();
+            if (extraPropertiesHeaderValue != null) {
+                response.setHeader(AGENT_EXTRA_PROPERTIES_HEADER, extraPropertiesHeaderValue);
+            }
         } catch (Exception e) {
             throw new RuntimeException(e);
         }

--- a/test/test-utils/src/main/java/com/thoughtworks/go/agent/testhelper/AgentBinariesServlet.java
+++ b/test/test-utils/src/main/java/com/thoughtworks/go/agent/testhelper/AgentBinariesServlet.java
@@ -17,12 +17,14 @@
 package com.thoughtworks.go.agent.testhelper;
 
 import com.thoughtworks.go.util.SystemEnvironment;
+import org.apache.commons.codec.binary.Base64;
 
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 
 import static com.thoughtworks.go.util.SystemEnvironment.AGENT_EXTRA_PROPERTIES_HEADER;
 
@@ -43,7 +45,7 @@ public class AgentBinariesServlet extends HttpServlet {
 
             final String extraPropertiesHeaderValue = fakeGoServer.getExtraPropertiesHeaderValue();
             if (extraPropertiesHeaderValue != null) {
-                response.setHeader(AGENT_EXTRA_PROPERTIES_HEADER, extraPropertiesHeaderValue);
+                response.setHeader(AGENT_EXTRA_PROPERTIES_HEADER, Base64.encodeBase64String(extraPropertiesHeaderValue.getBytes(StandardCharsets.UTF_8)));
             }
         } catch (Exception e) {
             throw new RuntimeException(e);

--- a/test/test-utils/src/main/java/com/thoughtworks/go/agent/testhelper/FakeGoServer.java
+++ b/test/test-utils/src/main/java/com/thoughtworks/go/agent/testhelper/FakeGoServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 ThoughtWorks, Inc.
+ * Copyright 2019 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -82,6 +82,7 @@ public class FakeGoServer extends ExternalResource {
     private Server server;
     private int port;
     private int securePort;
+    private String extraPropertiesHeaderValue;
 
     public int getPort() {
         return port;
@@ -149,9 +150,9 @@ public class FakeGoServer extends ExternalResource {
         securePort = secureConnnector.getLocalPort();
     }
 
-    public static final class AgentStatusApi extends HttpServlet {
+    private static final class AgentStatusApi extends HttpServlet {
         public static String status = "disabled";
-        public static Properties pluginProps = new Properties();
+        static Properties pluginProps = new Properties();
 
         @Override
         protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
@@ -163,6 +164,15 @@ public class FakeGoServer extends ExternalResource {
             resp.getOutputStream().write(baos.toByteArray());
             baos.close();
         }
+    }
+
+    public FakeGoServer setExtraPropertiesHeaderValue(String value) {
+        extraPropertiesHeaderValue = value;
+        return this;
+    }
+
+    String getExtraPropertiesHeaderValue() {
+        return extraPropertiesHeaderValue;
     }
 
     private void addlatestAgentStatusCall(WebAppContext wac) {


### PR DESCRIPTION
There is no easy way to put in a toggle, which is controlled from the server side, which affects the agent side.

The benefit of this kind of a toggle is that we can experiment more freely on the agent side. Currently, if we have an agent-side toggle, turning it on and off is a pain, since it has to be done individually. With this toggle framework (or at least a framework to pass in properties to the agent, from the server side), it's easier to toggle it.

1. Server sets the header with a set of values: "GoCD-Agent-Extra-Properties: Key1=Value1 Key2=Value2" etc.

2. Agent sees it the next time it starts or checks for upgrade. Sets its own properties.

I've verified this by printing out the properties by adding a line [here](https://github.com/gocd/gocd/pull/5666/files#diff-c571d5ed8575f158cc12fdc2f23f4f80R102). For this verification, I used:

```
GO_SERVER_SYSTEM_PROPERTIES="'-Dgocd.agent.extra.properties=extra.property=value1%20with%20space extra%20property%20with%20space=value2%20with%20space'" ./server.sh
```

Couple of considerations with this PR:

1. I don't like the name `HeaderUtil`. But, couldn't think of anything. It helps reduce some duplication.

2. The header is added to almost all calls in AgentRegistrationController (like `/admin/agent-plugins.zip`). That's not really needed. I can put it in a more specific place than [here](https://github.com/gocd/gocd/pull/5666/files#diff-9c099507cd71dda2017a601c4e4f3fc7R185), so that it only affects the two calls `/admin/latest-agent.status` and `/admin/agent`. If you want.

Originally: https://github.com/gocd/gocd/pull/5608