### PR TITLE
Add material update in-progress information to the config repos GET/INDEX API call (#5650)

### DIFF
--- a/api/api-config-repos-v1/src/main/java/com/thoughtworks/go/apiv1/configrepos/ConfigRepoWithResult.java
+++ b/api/api-config-repos-v1/src/main/java/com/thoughtworks/go/apiv1/configrepos/ConfigRepoWithResult.java
@@ -24,10 +24,12 @@ import java.util.Objects;
 public class ConfigRepoWithResult {
     private final ConfigRepoConfig repo;
     private final PartialConfigParseResult result;
+    private final boolean isMaterialUpdateInProgress;
 
-    public ConfigRepoWithResult(ConfigRepoConfig repo, PartialConfigParseResult result) {
+    public ConfigRepoWithResult(ConfigRepoConfig repo, PartialConfigParseResult result, boolean isMaterialUpdateInProgress) {
         this.repo = repo;
         this.result = result;
+        this.isMaterialUpdateInProgress = isMaterialUpdateInProgress;
     }
 
     public ConfigRepoConfig repo() {
@@ -36,6 +38,10 @@ public class ConfigRepoWithResult {
 
     public PartialConfigParseResult result() {
         return result;
+    }
+
+    public boolean isMaterialUpdateInProgress() {
+        return isMaterialUpdateInProgress;
     }
 
     @Override

--- a/api/api-config-repos-v1/src/main/java/com/thoughtworks/go/apiv1/configrepos/ConfigReposInternalControllerV1.java
+++ b/api/api-config-repos-v1/src/main/java/com/thoughtworks/go/apiv1/configrepos/ConfigReposInternalControllerV1.java
@@ -145,7 +145,7 @@ public class ConfigReposInternalControllerV1 extends ApiController implements Sp
 
         PartialConfigParseResult result = dataSource.getLastParseResult(repo.getMaterialConfig());
 
-        return new ConfigRepoWithResult(repo, result);
+        return new ConfigRepoWithResult(repo, result, isMaterialUpdateInProgress(repo));
     }
 
     private ConfigRepoConfig repoFromRequest(Request req) {
@@ -161,7 +161,11 @@ public class ConfigReposInternalControllerV1 extends ApiController implements Sp
     private List<ConfigRepoWithResult> allRepos() {
         return service.getConfigRepos().stream().map(r -> {
             PartialConfigParseResult result = dataSource.getLastParseResult(r.getMaterialConfig());
-            return new ConfigRepoWithResult(r, result);
+            return new ConfigRepoWithResult(r, result, isMaterialUpdateInProgress(r));
         }).collect(Collectors.toList());
+    }
+
+    private boolean isMaterialUpdateInProgress(ConfigRepoConfig configRepoConfig) {
+        return mus.isInProgress(converter.toMaterial(configRepoConfig.getMaterialConfig()));
     }
 }

--- a/api/api-config-repos-v1/src/main/java/com/thoughtworks/go/apiv1/configrepos/representers/ConfigRepoWithResultRepresenter.java
+++ b/api/api-config-repos-v1/src/main/java/com/thoughtworks/go/apiv1/configrepos/representers/ConfigRepoWithResultRepresenter.java
@@ -35,6 +35,7 @@ public class ConfigRepoWithResultRepresenter {
         json.addChild("material", w -> MaterialRepresenter.toJSON(w, repo.getMaterialConfig()));
         attachConfigurations(json, repo);
 
+        json.add("material_update_in_progress", crwr.isMaterialUpdateInProgress());
         json.addChild("parse_info", w -> PartialConfigParseResultRepresenter.toJSON(w, result));
     }
 

--- a/api/api-config-repos-v1/src/test/groovy/com/thoughtworks/go/apiv1/configrepos/ConfigReposInternalControllerV1Test.groovy
+++ b/api/api-config-repos-v1/src/test/groovy/com/thoughtworks/go/apiv1/configrepos/ConfigReposInternalControllerV1Test.groovy
@@ -128,8 +128,8 @@ class ConfigReposInternalControllerV1Test implements SecurityServiceTrait, Contr
           ],
           _embedded: [
             config_repos: [
-              expectedRepoJson(ID_1, null, null),
-              expectedRepoJson(ID_2, "abc", null)
+              expectedRepoJson(ID_1, null, null, false),
+              expectedRepoJson(ID_2, "abc", null, false)
             ]
           ]
         ])
@@ -160,7 +160,7 @@ class ConfigReposInternalControllerV1Test implements SecurityServiceTrait, Contr
 
       assertThatResponse().
         isOk().
-        hasJsonBody(expectedRepoJson(ID_1, "abc", null))
+        hasJsonBody(expectedRepoJson(ID_1, "abc", null, false))
     }
 
     @Test
@@ -172,17 +172,17 @@ class ConfigReposInternalControllerV1Test implements SecurityServiceTrait, Contr
     }
   }
 
-  static Map expectedRepoJson(String id, String revision, String error) {
+  static Map expectedRepoJson(String id, String revision, String error, boolean isInProgress) {
     return [
-      _links       : [
+      _links                     : [
         self: [href: "http://test.host/go${Routes.ConfigRepos.id(id)}".toString()],
         doc : [href: Routes.ConfigRepos.DOC],
         find: [href: "http://test.host/go${Routes.ConfigRepos.find()}".toString()],
       ],
 
-      id           : id,
-      plugin_id    : TEST_PLUGIN_ID,
-      material     : [
+      id                         : id,
+      plugin_id                  : TEST_PLUGIN_ID,
+      material                   : [
         type      : "hg",
         attributes: [
           name       : null,
@@ -190,9 +190,11 @@ class ConfigReposInternalControllerV1Test implements SecurityServiceTrait, Contr
           auto_update: true
         ]
       ],
-      configuration: [],
+      configuration              : [],
 
-      parse_info   : null == revision ? [:] : [
+      material_update_in_progress: isInProgress,
+
+      parse_info                 : null == revision ? [:] : [
         error                     : error,
         good_modification         : [
           "username"     : null,

--- a/api/api-config-repos-v1/src/test/groovy/com/thoughtworks/go/apiv1/configrepos/representers/ConfigRepoWithResultListRepresenterTest.groovy
+++ b/api/api-config-repos-v1/src/test/groovy/com/thoughtworks/go/apiv1/configrepos/representers/ConfigRepoWithResultListRepresenterTest.groovy
@@ -52,15 +52,15 @@ class ConfigRepoWithResultListRepresenterTest {
 
   static Map expectedRepoJson(String id) {
     return [
-      _links       : [
+      _links                     : [
         self: [href: "http://test.host/go${Routes.ConfigRepos.id(id)}".toString()],
         doc : [href: Routes.ConfigRepos.DOC],
         find: [href: "http://test.host/go${Routes.ConfigRepos.find()}".toString()],
       ],
 
-      id           : id,
-      plugin_id    : TEST_PLUGIN_ID,
-      material     : [
+      id                         : id,
+      plugin_id                  : TEST_PLUGIN_ID,
+      material                   : [
         type      : "hg",
         attributes: [
           name       : null,
@@ -68,8 +68,9 @@ class ConfigRepoWithResultListRepresenterTest {
           auto_update: true
         ]
       ],
-      configuration: [],
-      parse_info   : [
+      configuration              : [],
+      material_update_in_progress: false,
+      parse_info                 : [
         error                     : null,
         good_modification         : [
           "username"     : null,
@@ -97,6 +98,6 @@ class ConfigRepoWithResultListRepresenterTest {
 
     PartialConfig partialConfig = new PartialConfig()
     PartialConfigParseResult expectedParseResult = PartialConfigParseResult.parseSuccess(modification, partialConfig)
-    return new ConfigRepoWithResult(new ConfigRepoConfig(materialConfig, TEST_PLUGIN_ID, id), expectedParseResult)
+    return new ConfigRepoWithResult(new ConfigRepoConfig(materialConfig, TEST_PLUGIN_ID, id), expectedParseResult, false)
   }
 }

--- a/api/api-config-repos-v1/src/test/groovy/com/thoughtworks/go/apiv1/configrepos/representers/ConfigRepoWithResultRepresenterTest.groovy
+++ b/api/api-config-repos-v1/src/test/groovy/com/thoughtworks/go/apiv1/configrepos/representers/ConfigRepoWithResultRepresenterTest.groovy
@@ -47,15 +47,15 @@ class ConfigRepoWithResultRepresenterTest {
     String find = "http://test.host/go${Routes.ConfigRepos.find()}"
 
     assertThatJson(json).isEqualTo([
-      _links       : [
+      _links                     : [
         self: [href: self],
         doc : [href: Routes.ConfigRepos.DOC],
         find: [href: find],
       ],
 
-      id           : id,
-      plugin_id    : TEST_PLUGIN_ID,
-      material     : [
+      id                         : id,
+      plugin_id                  : TEST_PLUGIN_ID,
+      material                   : [
         type      : "hg",
         attributes: [
           name       : null,
@@ -63,12 +63,12 @@ class ConfigRepoWithResultRepresenterTest {
           auto_update: true
         ]
       ],
-      configuration: [
+      configuration              : [
         [key: "foo", value: "bar"],
         [key: "baz", value: "quu"]
       ],
-
-      parse_info   : [
+      material_update_in_progress: false,
+      parse_info                 : [
         error                     : "Boom!",
         good_modification         : null,
         latest_parsed_modification: [
@@ -96,6 +96,6 @@ class ConfigRepoWithResultRepresenterTest {
     ConfigRepoConfig repo = new ConfigRepoConfig(materialConfig, TEST_PLUGIN_ID, id)
     repo.setConfiguration(c)
 
-    return new ConfigRepoWithResult(repo, expectedParseResult)
+    return new ConfigRepoWithResult(repo, expectedParseResult, false)
   }
 }


### PR DESCRIPTION
Introduce `material_update_in_progress` field to denote the status of the config repo material MDU.

---

We've another get status API endpoint which returns only this information. Not sure if it's still required.

\cc: @marques-work 