### PR TITLE
Show cancelled by on the dashboard on hovering over a stage.

### DIFF
--- a/server/webapp/WEB-INF/rails/spec/webpack/models/dashboard/dashboard_spec.js
+++ b/server/webapp/WEB-INF/rails/spec/webpack/models/dashboard/dashboard_spec.js
@@ -71,7 +71,7 @@ describe("Dashboard", () => {
           responseText:    JSON.stringify(dashboardData),
           responseHeaders: {
             ETag:           'etag',
-            'Content-Type': 'application/vnd.go.cd.v2+json'
+            'Content-Type': 'application/vnd.go.cd.v3+json'
           },
           status:          200
         });
@@ -90,7 +90,7 @@ describe("Dashboard", () => {
         const request = jasmine.Ajax.requests.mostRecent();
         expect(request.method).toBe('GET');
         expect(request.url).toBe('/go/api/dashboard');
-        expect(request.requestHeaders['Accept']).toContain('application/vnd.go.cd.v2+json');
+        expect(request.requestHeaders['Accept']).toContain('application/vnd.go.cd.v3+json');
       });
     });
 

--- a/server/webapp/WEB-INF/rails/spec/webpack/views/dashboard/stages_instance_widget_spec.js
+++ b/server/webapp/WEB-INF/rails/spec/webpack/views/dashboard/stages_instance_widget_spec.js
@@ -69,6 +69,22 @@ describe("Dashboard Stages Instance Widget", () => {
           "status":       "Unknown",
           "approved_by":  "changes",
           "scheduled_at": "2017-11-10T07:25:28.539Z"
+        },
+        {
+          "_links":       {
+            "self": {
+              "href": "http://localhost:8153/go/api/stages/up42/1/cancelled_stage/1"
+            },
+            "doc":  {
+              "href": "https://api.go.cd/current/#get-stage-instance"
+            }
+          },
+          "name":         "cancelled_stage",
+          "counter":      "1",
+          "status":       "Cancelled",
+          "cancelled_by": "someone",
+          "approved_by":  "changes",
+          "scheduled_at": "2017-11-10T07:25:28.539Z"
         }
       ]
     }
@@ -115,8 +131,10 @@ describe("Dashboard Stages Instance Widget", () => {
     const stages       = pipelineInstanceJson._embedded.stages;
     const stage1Status = `${stages[0].name} (${stages[0].status})`;
     const stage2Status = `${stages[1].name} (${stages[1].status})`;
+    const stage3Status = `${stages[2].name} (cancelled by: ${stages[2].cancelled_by})`;
 
     expect($root.find('.pipeline_stage').get(0).title).toEqual(stage1Status);
     expect($root.find('.pipeline_stage').get(1).title).toEqual(stage2Status);
+    expect($root.find('.pipeline_stage').get(2).title).toEqual(stage3Status);
   });
 });

--- a/server/webapp/WEB-INF/rails/webpack/helpers/spark_routes.ts
+++ b/server/webapp/WEB-INF/rails/webpack/helpers/spark_routes.ts
@@ -70,6 +70,10 @@ export default class {
     }
   }
 
+  static showDashboardPath(): string {
+    return "/go/api/dashboard";
+  }
+
   static DataSharingSettingsPath(): string {
     return "/go/api/data_sharing/settings";
   }

--- a/server/webapp/WEB-INF/rails/webpack/models/dashboard/dashboard.js
+++ b/server/webapp/WEB-INF/rails/webpack/models/dashboard/dashboard.js
@@ -17,10 +17,11 @@
 const _          = require('lodash');
 const Stream     = require('mithril/stream');
 const AjaxHelper = require('helpers/ajax_helper');
-const Routes     = require('gen/js-routes');
 
 const DashboardGroups = require('models/dashboard/dashboard_groups');
 const Pipelines       = require('models/dashboard/pipelines');
+
+import SparkRoutes from "helpers/spark_routes";
 
 function Dashboard() {
   let pipelineGroups = DashboardGroups.fromPipelineGroupsJSON([]);
@@ -50,11 +51,11 @@ function Dashboard() {
   };
 }
 
-Dashboard.API_VERSION = 'v2';
+Dashboard.API_VERSION = 'v3';
 
 Dashboard.get = (viewName, etag) => {
   return AjaxHelper.GET({
-    url:        Routes.apiv2ShowDashboardPath({viewName}),
+    url:        SparkRoutes.showDashboardPath({viewName}),
     apiVersion: Dashboard.API_VERSION,
     etag
   });

--- a/server/webapp/WEB-INF/rails/webpack/models/dashboard/pipeline_instance.js
+++ b/server/webapp/WEB-INF/rails/webpack/models/dashboard/pipeline_instance.js
@@ -26,11 +26,13 @@ const StageInstance = function (json, pipelineName, pipelineCounter) {
   this.name                  = json.name;
   this.counter               = json.counter;
   this.status                = json.status;
+  this.cancelledBy           = json.cancelled_by;
   this.stageDetailTabPath    = Routes.stageDetailTabDefaultPath(pipelineName, pipelineCounter, json.name, json.counter);
   this.isBuilding            = () => json.status === 'Building';
   this.isFailing             = () => json.status === 'Failing';
   this.isFailed              = () => json.status === 'Failed';
   this.isBuildingOrCompleted = () => json.status !== 'Unknown';
+  this.isCancelled           = () => json.status === 'Cancelled';
 };
 
 const PipelineInstance = function (info, pipelineName) {

--- a/server/webapp/WEB-INF/rails/webpack/views/dashboard/stages_instance_widget.js.msx
+++ b/server/webapp/WEB-INF/rails/webpack/views/dashboard/stages_instance_widget.js.msx
@@ -21,8 +21,10 @@ const StagesInstanceWidget = {
   view: (vnode) => {
     const stages        = vnode.attrs.stages;
     const stageInstance = _.map(stages, (stage) => {
-      const stageStatus = `${stage.name} (${stage.status})`;
-
+      let stageStatus = `${stage.name} (${stage.status})`;
+      if (stage.isCancelled()) {
+        stageStatus = `${stage.name} (cancelled by: ${stage.cancelledBy})`;
+      }
       if (stage.isBuildingOrCompleted()) {
         return (<a href={stage.stageDetailTabPath}
                    class={`pipeline_stage ${stage.status.toLowerCase()}`}


### PR DESCRIPTION
@GaneshSPatil - we had spoken about showing the cancelled by information instead of `triggered by` on the pipeline. I thought that the title on hover where we show the stage status was more appropriate. Let me know what you and @naveenbhaskar think.

<img width="1440" alt="screen shot 2019-01-08 at 10 26 35 pm" src="https://user-images.githubusercontent.com/4715748/50880967-02d3ca80-1395-11e9-91da-048de2eb80d1.png">
