### PR TITLE
Validation to check if admins to remove are actually admins

### DIFF
--- a/api/api-admins-config-v2/src/main/java/com/thoughtworks/go/apiv2/adminsconfig/representers/BulkUpdateFailureResultRepresenter.java
+++ b/api/api-admins-config-v2/src/main/java/com/thoughtworks/go/apiv2/adminsconfig/representers/BulkUpdateFailureResultRepresenter.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.apiv2.adminsconfig.representers;
+
+import com.thoughtworks.go.api.base.OutputWriter;
+import com.thoughtworks.go.config.CaseInsensitiveString;
+import com.thoughtworks.go.server.service.result.BulkUpdateAdminsResult;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class BulkUpdateFailureResultRepresenter {
+
+    public static void toJSON(OutputWriter outputWriter, BulkUpdateAdminsResult result) {
+        outputWriter.add("message", result.message());
+        outputWriter.addChildList("non_existent_users", toStringList(result.getNonExistentUsers()));
+        outputWriter.addChildList("non_existent_roles", toStringList(result.getNonExistentRoles()));
+    }
+
+    private static List<String> toStringList(List<CaseInsensitiveString> list) {
+        return list.stream().map(CaseInsensitiveString::toString).collect(Collectors.toList());
+    }
+}

--- a/server/src/main/java/com/thoughtworks/go/config/GoConfigDao.java
+++ b/server/src/main/java/com/thoughtworks/go/config/GoConfigDao.java
@@ -16,7 +16,6 @@
 
 package com.thoughtworks.go.config;
 
-import com.rits.cloning.Cloner;
 import com.thoughtworks.go.config.commands.CheckedUpdateCommand;
 import com.thoughtworks.go.config.commands.EntityConfigUpdateCommand;
 import com.thoughtworks.go.config.update.ConfigUpdateCheckFailedException;

--- a/server/src/main/java/com/thoughtworks/go/server/service/result/BulkUpdateAdminsResult.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/result/BulkUpdateAdminsResult.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.server.service.result;
+
+import com.thoughtworks.go.config.CaseInsensitiveString;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+public class BulkUpdateAdminsResult extends HttpLocalizedOperationResult {
+    private List<CaseInsensitiveString> nonExistentUsers;
+    private List<CaseInsensitiveString> nonExistentRoles;
+
+    public BulkUpdateAdminsResult() {
+        this.nonExistentUsers = new ArrayList<>();
+        this.nonExistentRoles = new ArrayList<>();
+    }
+
+    public void setNonExistentUsers(Collection<CaseInsensitiveString> nonExistentUsers) {
+        this.nonExistentUsers = new ArrayList<>(nonExistentUsers);
+    }
+
+    public void setNonExistentRoles(Collection<CaseInsensitiveString> nonExistentRoles) {
+        this.nonExistentRoles = new ArrayList<>(nonExistentRoles);
+    }
+
+    public List<CaseInsensitiveString> getNonExistentUsers() {
+        return nonExistentUsers;
+    }
+
+    public List<CaseInsensitiveString> getNonExistentRoles() {
+        return nonExistentRoles;
+    }
+}


### PR DESCRIPTION
Issue: #5682

Example:
```bash
curl -X PATCH \
  http://localhost:8153/go/api/admin/security/system_admins \
  -H 'Accept: application/vnd.go.cd.v2+json' \
  -H 'Content-Type: application/json' \
  -u 'admin:badger'
  -d '{
     "operations": {
     	"users": {
     		"remove": ["fearless rat"]
     	},
     	"roles": {
     		"remove": ["venomous pool frog"]
     	}
     	
     }
}'
```

Response:
~~404 not found~~
```
422 unprocessable entity
{
    "message": "Update failed because some users or roles do not exist under super admins.",
    non_existent_users: ['fearless rat'],
}
```