### PR TITLE
Adding Server version information in v2 ServerInfoProcessor

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -329,6 +329,7 @@ dependencies {
   testCompile group: 'org.jsoup', name: 'jsoup', version: project.versions.jsoup
   testCompile group: 'org.xmlunit', name: 'xmlunit-matchers', version: project.versions.xmlUnitMatchers
   testCompile group: 'org.assertj', name: 'assertj-core', version: project.versions.assertJ
+
   testCompile project(':test:http-mocks')
 
   testCompileOnly group: 'junit', name: 'junit', version: project.versions.junit

--- a/server/src/main/java/com/thoughtworks/go/server/service/plugins/processor/serverinfo/ServerInfoRequestProcessor.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/plugins/processor/serverinfo/ServerInfoRequestProcessor.java
@@ -25,6 +25,7 @@ import com.thoughtworks.go.plugin.infra.PluginRequestProcessorRegistry;
 import com.thoughtworks.go.plugin.infra.plugininfo.GoPluginDescriptor;
 import com.thoughtworks.go.server.service.GoConfigService;
 import com.thoughtworks.go.server.service.plugins.processor.serverinfo.v1.MessageHandlerForServerInfoRequestProcessor1_0;
+import com.thoughtworks.go.server.service.plugins.processor.serverinfo.v2.MessageHandlerForServerInfoRequestProcessor2_0;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -38,7 +39,7 @@ import static java.lang.String.format;
 @Component
 public class ServerInfoRequestProcessor implements GoPluginApiRequestProcessor {
     private static final Logger LOGGER = LoggerFactory.getLogger(ServerInfoRequestProcessor.class);
-    public static final String GET_SERVER_ID = "go.processor.server-info.get";
+    public static final String GET_SERVER_INFO = "go.processor.server-info.get";
 
     private final GoConfigService configService;
     private Map<String, MessageHandlerForServerInfoRequestProcessor> versionToMessageHandlerMap;
@@ -49,7 +50,8 @@ public class ServerInfoRequestProcessor implements GoPluginApiRequestProcessor {
         this.versionToMessageHandlerMap = new HashMap<>();
 
         this.versionToMessageHandlerMap.put("1.0", new MessageHandlerForServerInfoRequestProcessor1_0());
-        registry.registerProcessorFor(GET_SERVER_ID, this);
+        this.versionToMessageHandlerMap.put("2.0", new MessageHandlerForServerInfoRequestProcessor2_0());
+        registry.registerProcessorFor(GET_SERVER_INFO, this);
     }
 
     @Override

--- a/server/src/main/java/com/thoughtworks/go/server/service/plugins/processor/serverinfo/v2/MessageHandlerForServerInfoRequestProcessor2_0.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/plugins/processor/serverinfo/v2/MessageHandlerForServerInfoRequestProcessor2_0.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.server.service.plugins.processor.serverinfo.v2;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import com.thoughtworks.go.CurrentGoCDVersion;
+import com.thoughtworks.go.config.ServerConfig;
+import com.thoughtworks.go.server.service.plugins.processor.serverinfo.MessageHandlerForServerInfoRequestProcessor;
+
+public class MessageHandlerForServerInfoRequestProcessor2_0 implements MessageHandlerForServerInfoRequestProcessor {
+    private final Gson gson;
+
+    public MessageHandlerForServerInfoRequestProcessor2_0() {
+        gson = new Gson();
+    }
+
+    @Override
+    public String serverInfoToJSON(ServerConfig serverConfig) {
+        JsonObject object = new JsonObject();
+        CurrentGoCDVersion currentGoCDVersion = CurrentGoCDVersion.getInstance();
+
+        object.addProperty("server_id", serverConfig.getServerId());
+        object.addProperty("site_url", serverConfig.getSiteUrl().getUrl());
+        object.addProperty("secure_site_url", serverConfig.getSecureSiteUrl().getUrl());
+        object.addProperty("go_version", currentGoCDVersion.goVersion());
+        object.addProperty("dist_version", currentGoCDVersion.distVersion());
+        object.addProperty("git_revision", currentGoCDVersion.gitRevision());
+
+        return gson.toJson(object);
+    }
+}

--- a/server/src/test-fast/java/com/thoughtworks/go/server/service/plugins/processor/serverinfo/ServerInfoRequestProcessorTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/service/plugins/processor/serverinfo/ServerInfoRequestProcessorTest.java
@@ -31,7 +31,7 @@ import org.mockito.Mock;
 import java.util.Arrays;
 import java.util.Collections;
 
-import static com.thoughtworks.go.server.service.plugins.processor.serverinfo.ServerInfoRequestProcessor.GET_SERVER_ID;
+import static com.thoughtworks.go.server.service.plugins.processor.serverinfo.ServerInfoRequestProcessor.GET_SERVER_INFO;
 import static java.lang.String.format;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
@@ -68,13 +68,13 @@ public class ServerInfoRequestProcessorTest {
 
     @Test
     public void shouldRegisterAPIRequestWithProcessor() {
-        DefaultGoApiRequest request = new DefaultGoApiRequest(GET_SERVER_ID, "1.0", new GoPluginIdentifier("extension1", Collections.singletonList("1.0")));
+        DefaultGoApiRequest request = new DefaultGoApiRequest(GET_SERVER_INFO, "1.0", new GoPluginIdentifier("extension1", Collections.singletonList("1.0")));
         assertThat(processorRegistry.canProcess(request), is(true));
     }
 
     @Test
     public void shouldReturnAServerIdInJSONForm() {
-        DefaultGoApiRequest request = new DefaultGoApiRequest(GET_SERVER_ID, "1.0", new GoPluginIdentifier("extension1", Arrays.asList("1.0")));
+        DefaultGoApiRequest request = new DefaultGoApiRequest(GET_SERVER_INFO, "1.0", new GoPluginIdentifier("extension1", Arrays.asList("1.0")));
 
 
         GoApiResponse response = processor.process(pluginDescriptor, request);
@@ -86,8 +86,17 @@ public class ServerInfoRequestProcessorTest {
     }
 
     @Test
+    public void shouldReturnSuccessForServerInfoV2() {
+        DefaultGoApiRequest request = new DefaultGoApiRequest(GET_SERVER_INFO, "2.0", new GoPluginIdentifier("extension1", Arrays.asList("1.0")));
+
+        GoApiResponse response = processor.process(pluginDescriptor, request);
+
+        assertThat(response.responseCode(), is(200));
+    }
+
+    @Test
     public void shouldReturnAErrorResponseIfExtensionDoesNotSupportServerInfo() {
-        DefaultGoApiRequest request = new DefaultGoApiRequest(GET_SERVER_ID, "bad-version", new GoPluginIdentifier("foo", Arrays.asList("1.0")));
+        DefaultGoApiRequest request = new DefaultGoApiRequest(GET_SERVER_INFO, "bad-version", new GoPluginIdentifier("foo", Arrays.asList("1.0")));
 
         GoApiResponse response = processor.process(pluginDescriptor, request);
 

--- a/server/src/test-fast/java/com/thoughtworks/go/server/service/plugins/processor/serverinfo/v2/MessageHandlerForServerInfoRequestProcessor2_0Test.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/service/plugins/processor/serverinfo/v2/MessageHandlerForServerInfoRequestProcessor2_0Test.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.server.service.plugins.processor.serverinfo.v2;
+
+import com.thoughtworks.go.CurrentGoCDVersion;
+import com.thoughtworks.go.config.ServerConfig;
+import org.junit.Test;
+
+import static java.lang.String.format;
+import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson;
+
+public class MessageHandlerForServerInfoRequestProcessor2_0Test {
+    @Test
+    public void shouldSerializeServerConfigToJSON() {
+        ServerConfig serverConfig = new ServerConfig();
+        serverConfig.ensureServerIdExists();
+        serverConfig.setSecureSiteUrl("https://example.com:8154/go");
+        serverConfig.setSiteUrl("http://example.com:8153/go");
+        CurrentGoCDVersion goCDVersion = CurrentGoCDVersion.getInstance();
+
+        MessageHandlerForServerInfoRequestProcessor2_0 processor = new MessageHandlerForServerInfoRequestProcessor2_0();
+
+        String expectedJsonStr = format("{\"server_id\":\"%s\"," +
+                        "\"site_url\":\"%s\"," +
+                        "\"secure_site_url\":\"%s\"," +
+                        "\"go_version\":\"%s\"," +
+                        "\"dist_version\":\"%s\"," +
+                        "\"git_revision\":\"%s\"" +
+                        "}",
+                serverConfig.getServerId(),
+                serverConfig.getSiteUrl().getUrl(),
+                serverConfig.getSecureSiteUrl().getUrl(),
+                goCDVersion.goVersion(),
+                goCDVersion.distVersion(),
+                goCDVersion.gitRevision()
+        );
+
+        assertThatJson(expectedJsonStr).isEqualTo(processor.serverInfoToJSON(serverConfig));
+    }
+}


### PR DESCRIPTION
The issue aims to expose Go Server version information to the api consumers.
 Fixes GoCD api changes required to address the [issue](https://github.com/gocd-private/azure-elastic-agent-plugin/issues/10) 