### PR TITLE
Change to inline function definition over function hoisting

### DIFF
--- a/server/webapp/WEB-INF/rails/app/assets/javascripts/application.js
+++ b/server/webapp/WEB-INF/rails/app/assets/javascripts/application.js
@@ -53,7 +53,6 @@
 //= require "lib/often-0.3.2.js"
 //= require "lib/component-emitter-1.2.1.js"
 //= require "plugin-endpoint.js"
-//= require "xhr_promise.js"
 //= require "gocd-link-support.js"
 //= require "plugin-endpoint-request-handler.js"
 //= require "ansi_up.js"
@@ -65,4 +64,6 @@
 //= require "compare_pipelines.js"
 //= require "console_log_tailing.js"
 //= require "js-routes"
+//= require "xhr_promise.js"
 //= require_directory .
+

--- a/server/webapp/WEB-INF/rails/webpack/rails-shared/xhr_promise.js
+++ b/server/webapp/WEB-INF/rails/webpack/rails-shared/xhr_promise.js
@@ -17,15 +17,17 @@
  (function () {
   "use strict";
 
+   var NotSupported = function() { // eslint-disable-line no-inner-declarations
+     throw new Error("Native Promises are not supported in this browser.");
+   }
+
   // This file is shared between new and old pages, so we can't use ES6 syntax as the file
   // isn't guaranteed to be compiled
 
   /* eslint-disable no-var,prefer-template,object-shorthand,prefer-arrow-callback */
 
   if ("function" !== typeof Promise) {
-    function NotSupported() { // eslint-disable-line no-inner-declarations
-      throw new Error("Native Promises are not supported in this browser.");
-    }
+
 
     if ("undefined" !== typeof module) {
       module.exports = NotSupported;
@@ -46,7 +48,7 @@
     };
   }
 
-  function XhrPromise(settings) {
+  var XhrPromise = function(settings) {
     // Uses a native XMLHttpRequest object because jQuery XHR does not support
     // "blob" as a responseType (and doesn't provide a clean way to access the native
     // xhr object)


### PR DESCRIPTION
Needed this change for sahi functional tests which run on old firefox where XhrPromise fails to load. This has caused pipeline history, edit pages broken on old firefox.

Tested it locally, pipeline export feature is not affected by this change. Changes were as per @GaneshSPatil's suggestion

@ketan could you please have a look and merge it if no issues