### PR TITLE
Drain mode fixes

### DIFF
--- a/api/api-server-drain-mode-v1/src/main/java/com/thoughtworks/go/apiv1/serverdrainmode/representers/DrainModeInfoRepresenter.java
+++ b/api/api-server-drain-mode-v1/src/main/java/com/thoughtworks/go/apiv1/serverdrainmode/representers/DrainModeInfoRepresenter.java
@@ -44,7 +44,7 @@ public class DrainModeInfoRepresenter {
             jsonWriter.addChild("attributes", attributesWriter -> {
                 attributesWriter.add("is_completely_drained", isServerCompletelyDrained);
                 attributesWriter.addChild("running_systems", runningSystemsChildWriter -> {
-                    runningSystemsChildWriter.addChildList("mdu", runningMDUsToJSON(runningMDUs));
+                    runningSystemsChildWriter.addChildList("material_update_in_progress", runningMDUsToJSON(runningMDUs));
                     runningSystemsChildWriter.addChildList("building_jobs", runningJobsToJSON(buildingJobs));
                     runningSystemsChildWriter.addChildList("scheduled_jobs", runningJobsToJSON(scheduledJobs));
                 });

--- a/api/api-server-drain-mode-v1/src/main/java/com/thoughtworks/go/apiv1/serverdrainmode/representers/DrainModeInfoRepresenter.java
+++ b/api/api-server-drain-mode-v1/src/main/java/com/thoughtworks/go/apiv1/serverdrainmode/representers/DrainModeInfoRepresenter.java
@@ -25,12 +25,13 @@ import com.thoughtworks.go.server.service.DrainModeService.MaterialPerformingMDU
 import com.thoughtworks.go.spark.Routes;
 
 import java.sql.Timestamp;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.function.Consumer;
 
 public class DrainModeInfoRepresenter {
-    public static void toJSON(OutputWriter jsonWriter, ServerDrainMode serverDrainMode, boolean isServerCompletelyDrained, Collection<MaterialPerformingMDU> runningMDUs, List<JobInstance> jobInstances) {
+    public static void toJSON(OutputWriter jsonWriter, ServerDrainMode serverDrainMode, boolean isServerCompletelyDrained, Collection<MaterialPerformingMDU> runningMDUs, List<JobInstance> buildingJobs, List<JobInstance> scheduledJobs) {
         jsonWriter
                 .addLinks(linksWriter -> linksWriter.addLink("self", Routes.DrainMode.BASE + Routes.DrainMode.INFO)
                         .addAbsoluteLink("doc", Routes.DrainMode.INFO_DOC))
@@ -46,7 +47,8 @@ public class DrainModeInfoRepresenter {
                             attributesWriter.add("is_completely_drained", isServerCompletelyDrained);
                             attributesWriter.addChild("running_systems", runningSystemsChildWriter -> {
                                 runningSystemsChildWriter.addChildList("mdu", runningMDUsToJSON(runningMDUs));
-                                runningSystemsChildWriter.addChildList("jobs", runningJobsToJSON(jobInstances));
+                                runningSystemsChildWriter.addChildList("building_jobs", runningJobsToJSON(buildingJobs));
+                                runningSystemsChildWriter.addChildList("scheduled_jobs", runningJobsToJSON(scheduledJobs));
                             });
                         });
                     }

--- a/api/api-server-drain-mode-v1/src/main/java/com/thoughtworks/go/apiv1/serverdrainmode/representers/DrainModeInfoRepresenter.java
+++ b/api/api-server-drain-mode-v1/src/main/java/com/thoughtworks/go/apiv1/serverdrainmode/representers/DrainModeInfoRepresenter.java
@@ -25,7 +25,6 @@ import com.thoughtworks.go.server.service.DrainModeService.MaterialPerformingMDU
 import com.thoughtworks.go.spark.Routes;
 
 import java.sql.Timestamp;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.function.Consumer;
@@ -34,25 +33,23 @@ public class DrainModeInfoRepresenter {
     public static void toJSON(OutputWriter jsonWriter, ServerDrainMode serverDrainMode, boolean isServerCompletelyDrained, Collection<MaterialPerformingMDU> runningMDUs, List<JobInstance> buildingJobs, List<JobInstance> scheduledJobs) {
         jsonWriter
                 .addLinks(linksWriter -> linksWriter.addLink("self", Routes.DrainMode.BASE + Routes.DrainMode.INFO)
-                        .addAbsoluteLink("doc", Routes.DrainMode.INFO_DOC))
-                .addChild("_embedded", childWriter -> {
-                    childWriter.add("is_drain_mode", serverDrainMode.isDrainMode());
-                    childWriter.addChild("metadata", metadataChildWriter -> {
-                        metadataChildWriter.add("updated_by", serverDrainMode.updatedBy());
-                        metadataChildWriter.add("updated_on", serverDrainMode.updatedOn());
-                    });
+                        .addAbsoluteLink("doc", Routes.DrainMode.INFO_DOC));
+        jsonWriter.add("is_drain_mode", serverDrainMode.isDrainMode());
+        jsonWriter.addChild("metadata", metadataChildWriter -> {
+            metadataChildWriter.add("updated_by", serverDrainMode.updatedBy());
+            metadataChildWriter.add("updated_on", serverDrainMode.updatedOn());
+        });
 
-                    if (serverDrainMode.isDrainMode()) {
-                        childWriter.addChild("attributes", attributesWriter -> {
-                            attributesWriter.add("is_completely_drained", isServerCompletelyDrained);
-                            attributesWriter.addChild("running_systems", runningSystemsChildWriter -> {
-                                runningSystemsChildWriter.addChildList("mdu", runningMDUsToJSON(runningMDUs));
-                                runningSystemsChildWriter.addChildList("building_jobs", runningJobsToJSON(buildingJobs));
-                                runningSystemsChildWriter.addChildList("scheduled_jobs", runningJobsToJSON(scheduledJobs));
-                            });
-                        });
-                    }
+        if (serverDrainMode.isDrainMode()) {
+            jsonWriter.addChild("attributes", attributesWriter -> {
+                attributesWriter.add("is_completely_drained", isServerCompletelyDrained);
+                attributesWriter.addChild("running_systems", runningSystemsChildWriter -> {
+                    runningSystemsChildWriter.addChildList("mdu", runningMDUsToJSON(runningMDUs));
+                    runningSystemsChildWriter.addChildList("building_jobs", runningJobsToJSON(buildingJobs));
+                    runningSystemsChildWriter.addChildList("scheduled_jobs", runningJobsToJSON(scheduledJobs));
                 });
+            });
+        }
     }
 
     private static Consumer<OutputListWriter> runningMDUsToJSON(Collection<MaterialPerformingMDU> runningMDUs) {

--- a/api/api-server-drain-mode-v1/src/test/groovy/com/thoughtworks/go/apiv1/serverdrainmode/representers/DrainModeInfoRepresenterTest.groovy
+++ b/api/api-server-drain-mode-v1/src/test/groovy/com/thoughtworks/go/apiv1/serverdrainmode/representers/DrainModeInfoRepresenterTest.groovy
@@ -68,10 +68,12 @@ class DrainModeInfoRepresenterTest {
     def runningMDUs = drainModeService.getRunningMDUs()
     def scheduled = JobInstanceMother.scheduled("up42_job_1")
     def building = JobInstanceMother.building("up42_job_2")
-    def jobInstances = Arrays.asList(scheduled, building)
+
+    def buildingJobs = Arrays.asList(building)
+    def scheduledJobs = Arrays.asList(scheduled)
 
     def actualJson = toObjectString({
-      DrainModeInfoRepresenter.toJSON(it, drainModeService.get(), true, runningMDUs, jobInstances)
+      DrainModeInfoRepresenter.toJSON(it, drainModeService.get(), true, runningMDUs, buildingJobs, scheduledJobs)
     })
 
     def expectedJson = [
@@ -88,7 +90,7 @@ class DrainModeInfoRepresenterTest {
         "attributes"   : [
           "is_completely_drained": true,
           "running_systems"      : [
-            "mdu": [
+            "mdu"         : [
               [
                 "type"          : "git",
                 "attributes"    : [
@@ -134,17 +136,7 @@ class DrainModeInfoRepresenterTest {
                 "mdu_start_time": "1970-01-01T08:20:00Z"
               ]
             ],
-            jobs : [
-              [
-                pipeline_name   : scheduled.pipelineName,
-                pipeline_counter: scheduled.pipelineCounter,
-                stage_name      : scheduled.stageName,
-                stage_counter   : scheduled.stageCounter,
-                name            : scheduled.name,
-                state           : scheduled.state,
-                scheduled_date  : jsonDate(new Timestamp(scheduled.getScheduledDate().getTime())),
-                agent_uuid      : scheduled.getAgentUuid()
-              ],
+            building_jobs : [
               [
                 pipeline_name   : building.pipelineName,
                 pipeline_counter: building.pipelineCounter,
@@ -154,6 +146,18 @@ class DrainModeInfoRepresenterTest {
                 state           : building.state,
                 scheduled_date  : jsonDate(new Timestamp(building.getScheduledDate().getTime())),
                 agent_uuid      : building.getAgentUuid()
+              ]
+            ],
+            scheduled_jobs: [
+              [
+                pipeline_name   : scheduled.pipelineName,
+                pipeline_counter: scheduled.pipelineCounter,
+                stage_name      : scheduled.stageName,
+                stage_counter   : scheduled.stageCounter,
+                name            : scheduled.name,
+                state           : scheduled.state,
+                scheduled_date  : jsonDate(new Timestamp(scheduled.getScheduledDate().getTime())),
+                agent_uuid      : scheduled.getAgentUuid()
               ]
             ]
           ]
@@ -169,7 +173,7 @@ class DrainModeInfoRepresenterTest {
     def drainModeService = new DrainModeService(timeProvider)
 
     def actualJson = toObjectString({
-      DrainModeInfoRepresenter.toJSON(it, drainModeService.get(), false, null, null)
+      DrainModeInfoRepresenter.toJSON(it, drainModeService.get(), false, null, null, null)
     })
 
     def expectedJson = [

--- a/api/api-server-drain-mode-v1/src/test/groovy/com/thoughtworks/go/apiv1/serverdrainmode/representers/DrainModeInfoRepresenterTest.groovy
+++ b/api/api-server-drain-mode-v1/src/test/groovy/com/thoughtworks/go/apiv1/serverdrainmode/representers/DrainModeInfoRepresenterTest.groovy
@@ -77,88 +77,86 @@ class DrainModeInfoRepresenterTest {
     })
 
     def expectedJson = [
-      _links   : [
+      _links         : [
         self: [href: 'http://test.host/go/api/admin/drain_mode/info'],
         doc : [href: 'https://api.gocd.org/current/#drain-mode-info']
       ],
-      _embedded: [
-        "is_drain_mode": true,
-        "metadata"     : [
-          "updated_by": drainModeService.get().updatedBy(),
-          "updated_on": jsonDate(drainModeService.get().updatedOn())
-        ],
-        "attributes"   : [
-          "is_completely_drained": true,
-          "running_systems"      : [
-            "mdu"         : [
-              [
-                "type"          : "git",
-                "attributes"    : [
-                  "url"             : "foo/bar",
-                  "destination"     : null,
-                  "filter"          : null,
-                  "invert_filter"   : false,
-                  "name"            : null,
-                  "auto_update"     : true,
-                  "branch"          : "master",
-                  "submodule_folder": null,
-                  "shallow_clone"   : false
-                ],
-                "mdu_start_time": "1970-01-01T02:46:40Z"
+      "is_drain_mode": true,
+      "metadata"     : [
+        "updated_by": drainModeService.get().updatedBy(),
+        "updated_on": jsonDate(drainModeService.get().updatedOn())
+      ],
+      "attributes"   : [
+        "is_completely_drained": true,
+        "running_systems"      : [
+          "mdu"         : [
+            [
+              "type"          : "git",
+              "attributes"    : [
+                "url"             : "foo/bar",
+                "destination"     : null,
+                "filter"          : null,
+                "invert_filter"   : false,
+                "name"            : null,
+                "auto_update"     : true,
+                "branch"          : "master",
+                "submodule_folder": null,
+                "shallow_clone"   : false
               ],
-              [
-                "type"          : "hg",
-                "attributes"    : [
-                  "url"          : "hg-url",
-                  "destination"  : null,
-                  "filter"       : null,
-                  "invert_filter": false,
-                  "name"         : null,
-                  "auto_update"  : true
-                ],
-                "mdu_start_time": "1970-01-01T05:33:20Z"
+              "mdu_start_time": "1970-01-01T02:46:40Z"
+            ],
+            [
+              "type"          : "hg",
+              "attributes"    : [
+                "url"          : "hg-url",
+                "destination"  : null,
+                "filter"       : null,
+                "invert_filter": false,
+                "name"         : null,
+                "auto_update"  : true
               ],
-              [
-                "type"          : "svn",
-                "attributes"    : [
-                  "url"               : "url",
-                  "destination"       : "svnDir",
-                  "filter"            : [
-                    "ignore": ["*.doc"]
-                  ],
-                  "invert_filter"     : false,
-                  "name"              : null,
-                  "auto_update"       : true,
-                  "check_externals"   : true,
-                  "username"          : "user",
-                  "encrypted_password": svnMaterial.encryptedPassword
+              "mdu_start_time": "1970-01-01T05:33:20Z"
+            ],
+            [
+              "type"          : "svn",
+              "attributes"    : [
+                "url"               : "url",
+                "destination"       : "svnDir",
+                "filter"            : [
+                  "ignore": ["*.doc"]
                 ],
-                "mdu_start_time": "1970-01-01T08:20:00Z"
-              ]
-            ],
-            building_jobs : [
-              [
-                pipeline_name   : building.pipelineName,
-                pipeline_counter: building.pipelineCounter,
-                stage_name      : building.stageName,
-                stage_counter   : building.stageCounter,
-                name            : building.name,
-                state           : building.state,
-                scheduled_date  : jsonDate(new Timestamp(building.getScheduledDate().getTime())),
-                agent_uuid      : building.getAgentUuid()
-              ]
-            ],
-            scheduled_jobs: [
-              [
-                pipeline_name   : scheduled.pipelineName,
-                pipeline_counter: scheduled.pipelineCounter,
-                stage_name      : scheduled.stageName,
-                stage_counter   : scheduled.stageCounter,
-                name            : scheduled.name,
-                state           : scheduled.state,
-                scheduled_date  : jsonDate(new Timestamp(scheduled.getScheduledDate().getTime())),
-                agent_uuid      : scheduled.getAgentUuid()
-              ]
+                "invert_filter"     : false,
+                "name"              : null,
+                "auto_update"       : true,
+                "check_externals"   : true,
+                "username"          : "user",
+                "encrypted_password": svnMaterial.encryptedPassword
+              ],
+              "mdu_start_time": "1970-01-01T08:20:00Z"
+            ]
+          ],
+          building_jobs : [
+            [
+              pipeline_name   : building.pipelineName,
+              pipeline_counter: building.pipelineCounter,
+              stage_name      : building.stageName,
+              stage_counter   : building.stageCounter,
+              name            : building.name,
+              state           : building.state,
+              scheduled_date  : jsonDate(new Timestamp(building.getScheduledDate().getTime())),
+              agent_uuid      : building.getAgentUuid()
+            ]
+          ],
+          scheduled_jobs: [
+            [
+              pipeline_name   : scheduled.pipelineName,
+              pipeline_counter: scheduled.pipelineCounter,
+              stage_name      : scheduled.stageName,
+              stage_counter   : scheduled.stageCounter,
+              name            : scheduled.name,
+              state           : scheduled.state,
+              scheduled_date  : jsonDate(new Timestamp(scheduled.getScheduledDate().getTime())),
+              agent_uuid      : scheduled.getAgentUuid()
             ]
           ]
         ]
@@ -177,16 +175,14 @@ class DrainModeInfoRepresenterTest {
     })
 
     def expectedJson = [
-      _links   : [
+      _links         : [
         self: [href: 'http://test.host/go/api/admin/drain_mode/info'],
         doc : [href: 'https://api.gocd.org/current/#drain-mode-info']
       ],
-      _embedded: [
-        "is_drain_mode": false,
-        "metadata"     : [
-          "updated_by": drainModeService.get().updatedBy(),
-          "updated_on": jsonDate(drainModeService.get().updatedOn())
-        ]
+      "is_drain_mode": false,
+      "metadata"     : [
+        "updated_by": drainModeService.get().updatedBy(),
+        "updated_on": jsonDate(drainModeService.get().updatedOn())
       ]
     ]
 

--- a/api/api-server-drain-mode-v1/src/test/groovy/com/thoughtworks/go/apiv1/serverdrainmode/representers/DrainModeInfoRepresenterTest.groovy
+++ b/api/api-server-drain-mode-v1/src/test/groovy/com/thoughtworks/go/apiv1/serverdrainmode/representers/DrainModeInfoRepresenterTest.groovy
@@ -89,7 +89,7 @@ class DrainModeInfoRepresenterTest {
       "attributes"   : [
         "is_completely_drained": true,
         "running_systems"      : [
-          "mdu"         : [
+          "material_update_in_progress": [
             [
               "type"          : "git",
               "attributes"    : [
@@ -135,7 +135,7 @@ class DrainModeInfoRepresenterTest {
               "mdu_start_time": "1970-01-01T08:20:00Z"
             ]
           ],
-          building_jobs : [
+          building_jobs                : [
             [
               pipeline_name   : building.pipelineName,
               pipeline_counter: building.pipelineCounter,
@@ -147,7 +147,7 @@ class DrainModeInfoRepresenterTest {
               agent_uuid      : building.getAgentUuid()
             ]
           ],
-          scheduled_jobs: [
+          scheduled_jobs               : [
             [
               pipeline_name   : scheduled.pipelineName,
               pipeline_counter: scheduled.pipelineCounter,

--- a/server/src/main/resources/server_in_drain_mode.html
+++ b/server/src/main/resources/server_in_drain_mode.html
@@ -81,9 +81,12 @@
     <div id="header">
         <div class="header clear_float">
             <a href="#" id="application_logo">&nbsp;</a>
-
-            <div class="message">GoCD Server is under drain mode. Learn more...</span>'
+            <div class="message">
+                GoCD Server is in the drain state (Maintenance mode).
+                &nbsp;
+                <a target="_blank" href="https://docs.gocd.org/advanced_usage/drain_mode.html">Learn more..</a>
             </div>
+        </div>
         </div>
     </div>
 </div>

--- a/server/webapp/WEB-INF/rails/webpack/models/drain_mode/types.ts
+++ b/server/webapp/WEB-INF/rails/webpack/models/drain_mode/types.ts
@@ -163,21 +163,27 @@ export class Stage {
 }
 
 export class RunningSystem {
-  stages: Stage[];
-  mdu: Materials;
+  buildingJobsGroupedByStages: Stage[];
+  scheduledJobsGroupedByStages: Stage[];
+  materialUpdateInProgress: Materials;
 
-  constructor(stages: Stage[], mdu: Materials) {
-    this.stages = stages;
-    this.mdu    = mdu;
+  constructor(buildingJobsGroupedByStages: Stage[], scheduledJobsGroupedByStages: Stage[], mdu: Materials) {
+    this.buildingJobsGroupedByStages  = buildingJobsGroupedByStages;
+    this.scheduledJobsGroupedByStages = scheduledJobsGroupedByStages;
+    this.materialUpdateInProgress     = mdu;
   }
 
   static fromJSON(runningSystemJSON: RunningSystemJSON | null = null) {
     if (runningSystemJSON === null) {
       return null;
     }
-    const buildingJobsGroupedByStages    = RunningSystem.groupJobsByStage(runningSystemJSON.building_jobs ? runningSystemJSON.building_jobs.map(Job.fromJSON) : []);
-    const materials = runningSystemJSON.material_update_in_progress ? Materials.fromJSON(runningSystemJSON.material_update_in_progress) : new Materials([]);
-    return new RunningSystem(buildingJobsGroupedByStages, materials);
+    const buildingJobsGroupedByStages  = RunningSystem.groupJobsByStage(runningSystemJSON.building_jobs ? runningSystemJSON.building_jobs.map(
+      Job.fromJSON) : []);
+    const scheduledJobsGroupedByStages = RunningSystem.groupJobsByStage(runningSystemJSON.scheduled_jobs ? runningSystemJSON.scheduled_jobs.map(
+      Job.fromJSON) : []);
+    const materials                    = runningSystemJSON.material_update_in_progress ? Materials.fromJSON(
+      runningSystemJSON.material_update_in_progress) : new Materials([]);
+    return new RunningSystem(buildingJobsGroupedByStages, scheduledJobsGroupedByStages, materials);
   }
 
   private static groupJobsByStage(jobs: Job[]) {

--- a/server/webapp/WEB-INF/rails/webpack/models/drain_mode/types.ts
+++ b/server/webapp/WEB-INF/rails/webpack/models/drain_mode/types.ts
@@ -33,8 +33,9 @@ export interface JobJSON {
 }
 
 export interface RunningSystemJSON {
-  mdu?: MaterialJSON[];
-  jobs?: JobJSON[];
+  material_update_in_progress?: MaterialJSON[];
+  building_jobs?: JobJSON[];
+  scheduled_jobs?: JobJSON[];
 }
 
 export interface DrainModeMetadataJSON {
@@ -47,14 +48,10 @@ export interface Attributes {
   running_systems?: RunningSystemJSON;
 }
 
-export interface EmbeddedJSON {
+export interface DrainModeInfoJSON {
   is_drain_mode: boolean;
   metadata: DrainModeMetadataJSON;
   attributes?: Attributes;
-}
-
-export interface DrainModeInfoJSON {
-  _embedded: EmbeddedJSON;
 }
 
 export class StageLocator {
@@ -178,9 +175,9 @@ export class RunningSystem {
     if (runningSystemJSON === null) {
       return null;
     }
-    const stages    = RunningSystem.groupJobsByStage(runningSystemJSON.jobs ? runningSystemJSON.jobs.map(Job.fromJSON) : []);
-    const materials = runningSystemJSON.mdu ? Materials.fromJSON(runningSystemJSON.mdu) : new Materials([]);
-    return new RunningSystem(stages, materials);
+    const buildingJobsGroupedByStages    = RunningSystem.groupJobsByStage(runningSystemJSON.building_jobs ? runningSystemJSON.building_jobs.map(Job.fromJSON) : []);
+    const materials = runningSystemJSON.material_update_in_progress ? Materials.fromJSON(runningSystemJSON.material_update_in_progress) : new Materials([]);
+    return new RunningSystem(buildingJobsGroupedByStages, materials);
   }
 
   private static groupJobsByStage(jobs: Job[]) {
@@ -232,10 +229,10 @@ export class DrainModeInfo {
   }
 
   static fromJSON(json: DrainModeInfoJSON) {
-    json._embedded.attributes = json._embedded.attributes || {} as Attributes;
-    return new DrainModeInfo(json._embedded.is_drain_mode,
-                             json._embedded.attributes.is_completely_drained,
-                             DrainModeMetadata.fromJSON(json._embedded.metadata),
-                             RunningSystem.fromJSON(json._embedded.attributes.running_systems));
+    json.attributes = json.attributes || {} as Attributes;
+    return new DrainModeInfo(json.is_drain_mode,
+                             json.attributes.is_completely_drained,
+                             DrainModeMetadata.fromJSON(json.metadata),
+                             RunningSystem.fromJSON(json.attributes.running_systems));
   }
 }

--- a/server/webapp/WEB-INF/rails/webpack/views/components/tooltip/index.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/components/tooltip/index.tsx
@@ -48,7 +48,10 @@ class Tooltip extends MithrilViewComponent<Attrs> {
     return (
       <div data-test-id="tooltip-wrapper">
         <div className={this.tooltipType}>
-          <span className={classnames(styles.tooltiptext, size)}>{vnode.attrs.content}</span>
+          <span data-test-id="tooltip-content"
+                className={classnames(styles.tooltiptext, size)}>
+            {vnode.attrs.content}
+          </span>
         </div>
       </div>);
   }

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/drain_mode/disabled_susbsystems_widget.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/drain_mode/disabled_susbsystems_widget.tsx
@@ -83,13 +83,13 @@ class SubsystemInfoWithIconWidget extends MithrilViewComponent<RunningSystemAttr
 class InformationWhenInDrainMode extends MithrilViewComponent<Attrs> {
   view(vnode: m.Vnode<Attrs>) {
     const runningSystem    = vnode.attrs.drainModeInfo.runningSystem as RunningSystem;
-    const mduRunningSystem = runningSystem.mdu.count() === 0
+    const mduRunningSystem = runningSystem.materialUpdateInProgress.count() === 0
       ? <SubsystemInfoWithIconWidget inProgress={false} dataTestId={"mdu-stopped"}
                                      text={"Stopped material subsystem."}/>
       : <SubsystemInfoWithIconWidget inProgress={true} dataTestId={"mdu-in-progress"}
                                      text={"Waiting for material subsystem to stop.."}/>;
 
-    const buildingJobsSystem = runningSystem.stages.length === 0
+    const buildingJobsSystem = runningSystem.buildingJobsGroupedByStages.length === 0
       ? <SubsystemInfoWithIconWidget inProgress={false} dataTestId={"scheduling-system-stopped"}
                                      text={"Stopped scheduling subsystem."}/>
       : <SubsystemInfoWithIconWidget inProgress={true} dataTestId={"scheduling-system-in-progress"}

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/drain_mode/drain_mode_widget.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/drain_mode/drain_mode_widget.tsx
@@ -62,7 +62,7 @@ export class DrainModeWidget extends MithrilViewComponent<Attrs> {
           The drain mode is a maintenance mode which a GoCD system administrator can put GoCD into so that it is
           safe to restart it or upgrade it without having running jobs reschedule when it is back.
           &nbsp;
-          <a href="https://docs.gocd.org/advanced_usage/drain_mode.html">Learn more..</a>
+          <a target="_blank" href="https://docs.gocd.org/advanced_usage/drain_mode.html">Learn more..</a>
         </p>
 
         <div class={styles.drainModeInfo}>

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/drain_mode/drain_mode_widget.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/drain_mode/drain_mode_widget.tsx
@@ -18,6 +18,8 @@ import {MithrilViewComponent} from "jsx/mithril-component";
 import * as m from "mithril";
 import {DrainModeInfo, RunningSystem, StageLocator} from "models/drain_mode/types";
 import {SwitchBtn} from "views/components/switch";
+import {TooltipSize} from "views/components/tooltip";
+import * as Tooltip from "views/components/tooltip";
 import {DisabledSubsystemsWidget} from "views/pages/drain_mode/disabled_susbsystems_widget";
 import {JobInfoWidget} from "views/pages/drain_mode/running_jobs_widget.tsx";
 import {MDUInfoWidget} from "views/pages/drain_mode/running_mdus_widget";
@@ -93,7 +95,11 @@ export class DrainModeInfoWidget extends MithrilViewComponent<InfoAttrs> {
                      onCancelStage={vnode.attrs.onCancelStage}/>,
       <MDUInfoWidget materials={(vnode.attrs.drainModeInfo.runningSystem as RunningSystem).materialUpdateInProgress}/>,
       <JobInfoWidget stages={(vnode.attrs.drainModeInfo.runningSystem as RunningSystem).scheduledJobsGroupedByStages}
-                     title={"Scheduled Stages"}
+                     title={<span class={styles.scheduledStagesTitleWrapper}>
+                       <div class={styles.scheduledStagesTitle}> Scheduled Stages </div>
+                       <Tooltip.Info size={TooltipSize.large}
+                                     content={"Scheduled stages contains the jobs which are scheduled but not yet assigned to any agent. As the job assignment to agents is stopped during drain mode, scheduled jobs will not have a side effect on the server state. Hence, Scheduled stages are ignored while considering server drain mode."}/>
+                     </span>}
                      onCancelStage={vnode.attrs.onCancelStage}/>,
     ] as m.ChildArray;
   }

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/drain_mode/drain_mode_widget.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/drain_mode/drain_mode_widget.tsx
@@ -61,6 +61,8 @@ export class DrainModeWidget extends MithrilViewComponent<Attrs> {
         <p data-test-id="drain-mode-description" className={styles.drainModeDescription}>
           The drain mode is a maintenance mode which a GoCD system administrator can put GoCD into so that it is
           safe to restart it or upgrade it without having running jobs reschedule when it is back.
+          &nbsp;
+          <a href="https://docs.gocd.org/advanced_usage/drain_mode.html">Learn more..</a>
         </p>
 
         <div class={styles.drainModeInfo}>

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/drain_mode/drain_mode_widget.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/drain_mode/drain_mode_widget.tsx
@@ -88,9 +88,13 @@ interface InfoAttrs {
 export class DrainModeInfoWidget extends MithrilViewComponent<InfoAttrs> {
   view(vnode: m.Vnode<InfoAttrs>): m.Children {
     return [
-      <JobInfoWidget stages={(vnode.attrs.drainModeInfo.runningSystem as RunningSystem).stages}
+      <JobInfoWidget stages={(vnode.attrs.drainModeInfo.runningSystem as RunningSystem).buildingJobsGroupedByStages}
+                     title={"Running Stages"}
                      onCancelStage={vnode.attrs.onCancelStage}/>,
-      <MDUInfoWidget materials={(vnode.attrs.drainModeInfo.runningSystem as RunningSystem).mdu}/>
+      <MDUInfoWidget materials={(vnode.attrs.drainModeInfo.runningSystem as RunningSystem).materialUpdateInProgress}/>,
+      <JobInfoWidget stages={(vnode.attrs.drainModeInfo.runningSystem as RunningSystem).scheduledJobsGroupedByStages}
+                     title={"Scheduled Stages"}
+                     onCancelStage={vnode.attrs.onCancelStage}/>,
     ] as m.ChildArray;
   }
 }

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/drain_mode/index.scss
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/drain_mode/index.scss
@@ -120,3 +120,11 @@
   margin:  0;
 }
 
+.scheduled-stages-title-wrapper {
+  display:     flex;
+  align-items: center;
+}
+
+.scheduled-stages-title {
+  margin-right: 7px;
+}

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/drain_mode/index.scss.d.ts
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/drain_mode/index.scss.d.ts
@@ -16,3 +16,5 @@ export const panel: string;
 export const panelHeader: string;
 export const panelBody: string;
 export const runningSystemHeader: string;
+export const scheduledStagesTitleWrapper: string;
+export const scheduledStagesTitle: string;

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/drain_mode/running_jobs_widget.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/drain_mode/running_jobs_widget.tsx
@@ -26,7 +26,7 @@ import * as styles from "views/pages/drain_mode/index.scss";
 
 interface JobInfoAttrs {
   stages: Stage[];
-  title: string;
+  title: string | JSX.Element;
   onCancelStage: (stageLocator: StageLocator) => void;
 }
 

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/drain_mode/running_jobs_widget.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/drain_mode/running_jobs_widget.tsx
@@ -26,6 +26,7 @@ import * as styles from "views/pages/drain_mode/index.scss";
 
 interface JobInfoAttrs {
   stages: Stage[];
+  title: string;
   onCancelStage: (stageLocator: StageLocator) => void;
 }
 
@@ -59,7 +60,7 @@ export class JobInfoWidget extends MithrilViewComponent<JobInfoAttrs> {
     }
 
     return (
-      <CollapsiblePanel header={<h3 className={styles.runningSystemHeader}>Running stages</h3>} expanded={true}>
+      <CollapsiblePanel header={<h3 className={styles.runningSystemHeader}>{vnode.attrs.title}</h3>} expanded={true}>
         <div>{runningStages}</div>
       </CollapsiblePanel>
     );

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/drain_mode/spec/drain_mode_widget_spec.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/drain_mode/spec/drain_mode_widget_spec.tsx
@@ -38,6 +38,14 @@ describe("Drain Mode Widget", () => {
     expect(find("drain-mode-description")).toContainText(expectedDescription);
   });
 
+  it("should add a link to the drain mode documentation", () => {
+    const expectedLink = "https://docs.gocd.org/advanced_usage/drain_mode.html";
+    const expectedText = "Learn more..";
+
+    expect($root.find("a")[0].href).toBe(expectedLink);
+    expect($root.find("a")[0].innerText).toBe(expectedText);
+  });
+
   it("should provide the drain mode updated information", () => {
     const expectedUpdatedByInfo = `${TestData.info().metdata.updatedBy} changed the drain mode state on ${TestData.info().metdata.updatedOn}.`;
     expect(find("drain-mode-updated-by-info")).toContainText(expectedUpdatedByInfo);

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/drain_mode/spec/test_data.ts
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/drain_mode/spec/test_data.ts
@@ -27,18 +27,16 @@ export class TestData {
 
   static completelyDrainedJSON() {
     return {
-      _embedded: {
-        is_drain_mode: true,
-        metadata: {
-          updated_by: "Admin",
-          updated_on: "2018-12-10T04:19:31Z"
-        },
-        attributes: {
-          is_completely_drained: true,
-          running_systems: {
-            mdu: [],
-            jobs: []
-          }
+      is_drain_mode: true,
+      metadata: {
+        updated_by: "Admin",
+        updated_on: "2018-12-10T04:19:31Z"
+      },
+      attributes: {
+        is_completely_drained: true,
+        running_systems: {
+          material_update_in_progress: [],
+          building_jobs: []
         }
       }
     };
@@ -46,20 +44,17 @@ export class TestData {
 
   static infoJSON(isDrainMode: boolean) {
     return {
-      _embedded: {
-        is_drain_mode: isDrainMode,
-        metadata: {
-          updated_by: "Admin",
-          updated_on: "2018-12-10T04:19:31Z"
-        },
-        attributes: {
-          is_completely_drained: false,
-          running_systems: {
-            mdu: this.getMdu(),
-            jobs: this.getJobs()
-          }
+      is_drain_mode: isDrainMode,
+      metadata: {
+        updated_by: "Admin",
+        updated_on: "2018-12-10T04:19:31Z"
+      },
+      attributes: {
+        is_completely_drained: false,
+        running_systems: {
+          material_update_in_progress: this.getMdu(),
+          building_jobs: this.getJobs()
         }
-
       }
     };
   }

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/partials/site_footer.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/partials/site_footer.tsx
@@ -66,7 +66,7 @@ export class SiteFooter extends MithrilViewComponent<Attrs> {
       return (<div data-test-id="drain-mode-banner" class={styles.footerWarningBanner}>
         GoCD Server is in the drain state (Maintenance mode).
         &nbsp;
-        <a href="https://docs.gocd.org/advanced_usage/drain_mode.html">Learn more..</a>
+        <a target="_blank" href="https://docs.gocd.org/advanced_usage/drain_mode.html">Learn more..</a>
       </div>);
     }
 

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/partials/site_footer.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/partials/site_footer.tsx
@@ -64,7 +64,9 @@ export class SiteFooter extends MithrilViewComponent<Attrs> {
   private static drainModeOrLegacyBrowserBanner(vnode: m.Vnode<Attrs>) {
     if (vnode.attrs.isServerInDrainMode) {
       return (<div data-test-id="drain-mode-banner" class={styles.footerWarningBanner}>
-        GoCD Server is in the drain state (Maintenance mode). Learn more...
+        GoCD Server is in the drain state (Maintenance mode).
+        &nbsp;
+        <a href="https://docs.gocd.org/advanced_usage/drain_mode.html">Learn more..</a>
       </div>);
     }
 


### PR DESCRIPTION
# Drain mode fixes
- [x] Separate scheduled jobs and building jobs
    - [x] API
    - [x] UI (Show scheduled jobs information on the spa)
- [x] Remove _embedded from drain_mode_info API response
- [x] Change mdu field to material_update_in_progress
- [x] Add a link to drain mode spa docs
- [x] Add tooltip to scheduled jobs section explaining why scheduled jobs doesnt affect drain mode.