### PR TITLE
RolesConfig update should notify all Security change listeners

### DIFF
--- a/common/src/main/java/com/thoughtworks/go/listener/SecurityConfigChangeListener.java
+++ b/common/src/main/java/com/thoughtworks/go/listener/SecurityConfigChangeListener.java
@@ -18,6 +18,7 @@ package com.thoughtworks.go.listener;
 
 import com.thoughtworks.go.config.AdminsConfig;
 import com.thoughtworks.go.config.Role;
+import com.thoughtworks.go.config.RolesConfig;
 import com.thoughtworks.go.config.SecurityAuthConfig;
 
 import java.util.Arrays;
@@ -27,12 +28,12 @@ public abstract class SecurityConfigChangeListener extends EntityConfigChangedLi
     private final List<Class<?>> securityConfigClasses = Arrays.asList(
             SecurityAuthConfig.class,
             Role.class,
-            AdminsConfig.class
+            AdminsConfig.class,
+            RolesConfig.class
     );
 
     @Override
     public boolean shouldCareAbout(Object entity) {
         return securityConfigClasses.stream().anyMatch(aClass -> aClass.isAssignableFrom(entity.getClass()));
     }
-
 }

--- a/common/src/test/java/com/thoughtworks/go/listener/SecurityConfigChangeListenerTest.java
+++ b/common/src/test/java/com/thoughtworks/go/listener/SecurityConfigChangeListenerTest.java
@@ -16,10 +16,7 @@
 
 package com.thoughtworks.go.listener;
 
-import com.thoughtworks.go.config.AdminsConfig;
-import com.thoughtworks.go.config.PluginRoleConfig;
-import com.thoughtworks.go.config.RoleConfig;
-import com.thoughtworks.go.config.SecurityAuthConfig;
+import com.thoughtworks.go.config.*;
 import com.thoughtworks.go.config.elastic.ElasticProfile;
 import org.junit.Test;
 
@@ -70,6 +67,17 @@ public class SecurityConfigChangeListenerTest {
             }
         };
         assertThat(securityConfigChangeListener.shouldCareAbout(new AdminsConfig()), is(true));
+    }
+
+    @Test
+    public void shouldCareAboutRolesConfigChange() {
+        SecurityConfigChangeListener securityConfigChangeListener = new SecurityConfigChangeListener() {
+            @Override
+            public void onEntityConfigChange(Object entity) {
+
+            }
+        };
+        assertThat(securityConfigChangeListener.shouldCareAbout(new RolesConfig()), is(true));
     }
 
     @Test


### PR DESCRIPTION
* These changes are required after introducing the bulkUpdate Roles
  API. #5680
* Having SecurityConfigChangeListener care about 'RolesConfig' would
  trigger a re-auth on any change of roles through bulk update.