### PR TITLE
Output parse-content errors in a yaml-compatible format

### DIFF
--- a/plugin-infra/go-plugin-config-repo/src/main/java/com/thoughtworks/go/plugin/configrepo/contract/ErrorCollection.java
+++ b/plugin-infra/go-plugin-config-repo/src/main/java/com/thoughtworks/go/plugin/configrepo/contract/ErrorCollection.java
@@ -16,20 +16,16 @@
 
 package com.thoughtworks.go.plugin.configrepo.contract;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 public class ErrorCollection {
     // key is location (file path or object description); values are errors detected
-    private Map<String,List<String>> errors = new HashMap<>();
+    private Map<String, List<String>> errors = new HashMap<>();
 
     @Override
-    public String toString()
-    {
+    public String toString() {
         StringBuilder builder = new StringBuilder();
-        if(this.isEmpty())
+        if (this.isEmpty())
             builder.append("No errors");
         else {
             builder.append(this.getErrorCount());
@@ -44,30 +40,42 @@ public class ErrorCollection {
 
     public int getErrorCount() {
         int count = 0;
-        for(List<String> entry : this.errors.values())
-        {
+        for (List<String> entry : this.errors.values()) {
             count += entry.size();
         }
-        return  count;
+        return count;
     }
 
-    public String getErrorsAsText()
-    {
+    public String yamlFormat() {
+        StringBuilder sb = new StringBuilder();
+        Iterator<Map.Entry<String, List<String>>> it = this.errors.entrySet().iterator();
+        while (it.hasNext()) {
+            Map.Entry<String, List<String>> entry = it.next();
+            sb.append(entry.getKey()).append(':');
+            for (String message : entry.getValue()) {
+                sb.append('\n').append("  ").append('-').append(' ').append(message);
+            }
+            if (it.hasNext()) {
+                sb.append("\n\n");
+            }
+        }
+        return sb.toString();
+    }
+
+    public String getErrorsAsText() {
         StringBuilder errorsBuilder = new StringBuilder();
-        for(Map.Entry<String,List<String>> entry : this.errors.entrySet())
-        {
+        for (Map.Entry<String, List<String>> entry : this.errors.entrySet()) {
             errorsBuilder.append('\n');
             errorsBuilder.append(entry.getKey()).append(';');
-            for(String message : entry.getValue())
-            {
+            for (String message : entry.getValue()) {
                 errorsBuilder.append('\n').append('\t').append('-').append(' ');
                 errorsBuilder.append(message);
             }
         }
         return errorsBuilder.toString();
     }
-    public List<String> getOrCreateErrorList(String location)
-    {
+
+    public List<String> getOrCreateErrorList(String location) {
         if (!errors.containsKey(location))
             errors.put(location, new ArrayList<>());
 
@@ -75,22 +83,20 @@ public class ErrorCollection {
     }
 
     public void checkMissing(String location, String fieldName, Object value) {
-        if(value == null) {
+        if (value == null) {
             List<String> list = getOrCreateErrorList(location);
             list.add(String.format("Missing field '%s'", fieldName));
         }
     }
 
-    public void addError(String location,String error)
-    {
+    public void addError(String location, String error) {
         List<String> list = getOrCreateErrorList(location);
         list.add(error);
     }
 
     public void addErrors(List<CRError> pluginErrors) {
-        for(CRError error : pluginErrors)
-        {
-            this.addError(error.getLocation(),error.getMessage());
+        for (CRError error : pluginErrors) {
+            this.addError(error.getLocation(), error.getMessage());
         }
     }
 }

--- a/server/src/main/java/com/thoughtworks/go/config/ConfigRepoPlugin.java
+++ b/server/src/main/java/com/thoughtworks/go/config/ConfigRepoPlugin.java
@@ -25,6 +25,7 @@ import com.thoughtworks.go.plugin.access.configrepo.InvalidPartialConfigExceptio
 import com.thoughtworks.go.plugin.configrepo.contract.CRConfigurationProperty;
 import com.thoughtworks.go.plugin.configrepo.contract.CRParseResult;
 import com.thoughtworks.go.plugin.configrepo.contract.CRPipeline;
+import com.thoughtworks.go.plugin.configrepo.contract.ErrorCollection;
 
 import java.io.File;
 import java.util.*;
@@ -76,7 +77,7 @@ public class ConfigRepoPlugin implements PartialConfigProvider {
     public PartialConfig parseContent(List<Map<String, String>> content, PartialConfigLoadContext context) {
         CRParseResult parseResult = this.crExtension.parseContent(pluginId, content);
         if (parseResult.hasErrors()) {
-            throw new InvalidPartialConfigException(parseResult, parseResult.getErrors().getErrorsAsText());
+            throw new InvalidPartialConfigException(parseResult, parseResult.getErrors().yamlFormat());
         }
         return configConverter.toPartialConfig(parseResult, context);
     }


### PR DESCRIPTION
The output will look like this:

```
filename1.ext:
  - first error
  - second error

filename2.ext:
  - first error
...
```

This is slightly different that `errorsAsText()` which uses semicolons for delimiters and tabs for indentation. I did not want to change existing behavior for `parse-directory`, so made this new formatter instead for `parse-content`, as the errors will be user-facing.