### PR TITLE
Improve config repo validation error formatting (#5712)

### DIFF
--- a/config/config-api/src/main/java/com/thoughtworks/go/config/exceptions/GoConfigInvalidMergeException.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/exceptions/GoConfigInvalidMergeException.java
@@ -43,11 +43,14 @@ public class GoConfigInvalidMergeException extends GoConfigInvalidException {
     private static String allErrorsToString(List<String> allErrors) {
         if (allErrors == null || allErrors.size() == 0)
             return "Error list empty";// should never be
+
         StringBuilder b = new StringBuilder();
-        b.append(allErrors.size()).append("+ errors :: ");
-        for (String e : allErrors) {
-            b.append(e).append(";; ");
+        b.append("Number of errors: ").append(allErrors.size()).append("+").append("\n");
+
+        for (int i = 1; i <= allErrors.size(); i++) {
+            b.append(i).append(". ").append(allErrors.get(i - 1)).append(";; \n");
         }
+
         return b.toString();
     }
 

--- a/plugin-infra/go-plugin-config-repo/src/main/java/com/thoughtworks/go/plugin/configrepo/contract/CRPipeline.java
+++ b/plugin-infra/go-plugin-config-repo/src/main/java/com/thoughtworks/go/plugin/configrepo/contract/CRPipeline.java
@@ -368,7 +368,7 @@ public class CRPipeline extends CRBase {
 
     private void validateAtLeastOneStage(ErrorCollection errors, String location) {
         if(!hasStages())
-            errors.addError(location,"Pipeline has no stages");
+            errors.addError(location,"Pipeline has no stages.");
     }
 
     private boolean hasStages() {
@@ -386,7 +386,7 @@ public class CRPipeline extends CRBase {
 
     private void validateAtLeastOneMaterial(ErrorCollection errors, String location) {
         if(this.materials == null || this.materials.isEmpty())
-            errors.addError(location,"Pipeline has no materials");
+            errors.addError(location,"Pipeline has no materials.");
     }
 
     public boolean hasTemplate() {

--- a/plugin-infra/go-plugin-config-repo/src/main/java/com/thoughtworks/go/plugin/configrepo/contract/ErrorCollection.java
+++ b/plugin-infra/go-plugin-config-repo/src/main/java/com/thoughtworks/go/plugin/configrepo/contract/ErrorCollection.java
@@ -67,10 +67,11 @@ public class ErrorCollection {
         for (Map.Entry<String, List<String>> entry : this.errors.entrySet()) {
             errorsBuilder.append('\n');
             errorsBuilder.append(entry.getKey()).append(';');
-            for (String message : entry.getValue()) {
-                errorsBuilder.append('\n').append('\t').append('-').append(' ');
-                errorsBuilder.append(message);
+
+            for (int i = 1; i <= entry.getValue().size(); i++) {
+                errorsBuilder.append('\n').append(i).append(". ").append(entry.getValue().get(i - 1));
             }
+            errorsBuilder.append("\n");
         }
         return errorsBuilder.toString();
     }
@@ -85,7 +86,7 @@ public class ErrorCollection {
     public void checkMissing(String location, String fieldName, Object value) {
         if (value == null) {
             List<String> list = getOrCreateErrorList(location);
-            list.add(String.format("Missing field '%s'", fieldName));
+            list.add(String.format("Missing field '%s'.", fieldName));
         }
     }
 

--- a/plugin-infra/go-plugin-config-repo/src/test/java/com/thoughtworks/go/plugin/configrepo/contract/CRApprovalTest.java
+++ b/plugin-infra/go-plugin-config-repo/src/test/java/com/thoughtworks/go/plugin/configrepo/contract/CRApprovalTest.java
@@ -91,6 +91,6 @@ public class CRApprovalTest extends CRBaseTest<CRApproval> {
         String fullError = errors.getErrorsAsText();
 
         assertThat(fullError,contains("Pipeline abc; Approval"));
-        assertThat(fullError,contains("Missing field 'type'"));
+        assertThat(fullError,contains("Missing field 'type'."));
     }
 }

--- a/plugin-infra/go-plugin-config-repo/src/test/java/com/thoughtworks/go/plugin/configrepo/contract/CRPipelineTest.java
+++ b/plugin-infra/go-plugin-config-repo/src/test/java/com/thoughtworks/go/plugin/configrepo/contract/CRPipelineTest.java
@@ -93,8 +93,8 @@ public class CRPipelineTest extends CRBaseTest<CRPipeline> {
         String fullError = errors.getErrorsAsText();
 
         assertThat(fullError,contains("pipe4.json; Pipeline pipe4"));
-        assertThat(fullError,contains("Missing field 'group'"));
-        assertThat(fullError,contains("Pipeline has no stages"));
+        assertThat(fullError,contains("Missing field 'group'."));
+        assertThat(fullError,contains("Pipeline has no stages."));
     }
 
     @Test
@@ -114,7 +114,7 @@ public class CRPipelineTest extends CRBaseTest<CRPipeline> {
         String fullError = errors.getErrorsAsText();
 
         assertThat(fullError,contains("Pipeline pipe4; Git material"));
-        assertThat(fullError,contains("Missing field 'url'"));
+        assertThat(fullError,contains("Missing field 'url'."));
     }
     @Test
     public void shouldCheckMissingDestinationDirectoryWhenManySCMs()

--- a/plugin-infra/go-plugin-config-repo/src/test/java/com/thoughtworks/go/plugin/configrepo/contract/CRStageTest.java
+++ b/plugin-infra/go-plugin-config-repo/src/test/java/com/thoughtworks/go/plugin/configrepo/contract/CRStageTest.java
@@ -95,6 +95,6 @@ public class CRStageTest extends CRBaseTest<CRStage> {
         String fullError = errors.getErrorsAsText();
 
         assertThat(fullError,contains("TEST; Stage (build)"));
-        assertThat(fullError,contains("Missing field 'name'"));
+        assertThat(fullError,contains("Missing field 'name'."));
     }
 }

--- a/server/src/main/java/com/thoughtworks/go/config/ConfigReposMaterialParseResultManager.java
+++ b/server/src/main/java/com/thoughtworks/go/config/ConfigReposMaterialParseResultManager.java
@@ -74,8 +74,8 @@ public class ConfigReposMaterialParseResultManager {
 
     private Exception represent(ServerHealthState serverHealthState) {
         String message = new StringBuilder()
-                .append(serverHealthState.getMessage())
-                .append("\n\t")
+                .append(serverHealthState.getMessage().toUpperCase())
+                .append("\n")
                 .append(serverHealthState.getDescription())
                 .toString();
 

--- a/server/src/main/java/com/thoughtworks/go/config/GoPartialConfig.java
+++ b/server/src/main/java/com/thoughtworks/go/config/GoPartialConfig.java
@@ -103,7 +103,7 @@ public class GoPartialConfig implements PartialConfigUpdateCompletedListener, Ch
             return true;
         } catch (Exception e) {
             if (repoConfig != null) {
-                String description = String.format("%s -  Config-Repo: %s", GoConfigValidity.invalid(e).errorMessage(), newPart.getOrigin().displayName());
+                String description = String.format("%s- For Config Repo: %s", GoConfigValidity.invalid(e).errorMessage(), newPart.getOrigin().displayName());
                 ServerHealthState state = ServerHealthState.error(INVALID_CRUISE_CONFIG_MERGE, description, HealthStateType.general(HealthStateScope.forPartialConfigRepo(repoConfig)));
                 serverHealthService.update(state);
             }

--- a/server/src/test-fast/java/com/thoughtworks/go/config/ConfigReposMaterialParseResultManagerTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/config/ConfigReposMaterialParseResultManagerTest.java
@@ -86,7 +86,7 @@ class ConfigReposMaterialParseResultManagerTest {
         PartialConfig partialConfig = new PartialConfig();
         manager.parseSuccess(fingerprint, modification, partialConfig);
 
-        String expectedBeautifiedMessage = String.format("%s\n\t%s", serverHealthState.getMessage(), serverHealthState.getDescription());
+        String expectedBeautifiedMessage = String.format("%s\n%s", serverHealthState.getMessage().toUpperCase(), serverHealthState.getDescription());
 
         assertThat(manager.get(fingerprint).isSuccessful(), is(false));
         assertThat(manager.get(fingerprint).getLastFailure().getMessage(), is(expectedBeautifiedMessage));
@@ -116,7 +116,7 @@ class ConfigReposMaterialParseResultManagerTest {
 
         ConfigReposMaterialParseResultManager manager = new ConfigReposMaterialParseResultManager(serverHealthService, configRepoService);
 
-        String expectedBeautifiedMessage = String.format("%s\n\t%s", serverHealthState.getMessage(), serverHealthState.getDescription());
+        String expectedBeautifiedMessage = String.format("%s\n%s", serverHealthState.getMessage().toUpperCase(), serverHealthState.getDescription());
 
         assertThat(manager.get(fingerprint).isSuccessful(), is(false));
         assertThat(manager.get(fingerprint).getLastFailure().getMessage(), is(expectedBeautifiedMessage));

--- a/server/src/test-integration/java/com/thoughtworks/go/config/CachedGoConfigIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/config/CachedGoConfigIntegrationTest.java
@@ -346,7 +346,7 @@ public class CachedGoConfigIntegrationTest {
         } catch (RuntimeException ex) {
             String errorMessage = ex.getMessage();
             assertThat(errorMessage, containsString("You have defined multiple pipelines named 'pipe1'. Pipeline names must be unique. Source(s):"));
-            Matcher matcher = Pattern.compile("^.*\\[(.*),\\s(.*)\\].*$").matcher(errorMessage);
+            Matcher matcher = Pattern.compile("^.*\\[(.*),\\s(.*)\\].*$", Pattern.DOTALL | Pattern.MULTILINE).matcher(errorMessage);
             assertThat(matcher.matches(), is(true));
             assertThat(matcher.groupCount(), is(2));
             PipelineConfig pipe1 = goConfigService.pipelineConfigNamed(new CaseInsensitiveString("pipe1"));
@@ -951,7 +951,7 @@ public class CachedGoConfigIntegrationTest {
         goPartialConfig.onSuccessPartialConfig(repoConfig1, invalidPartialInRepo1Revision2);
         assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).size(), is(1));
         assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).get(0).getMessage(), is("Invalid Merged Configuration"));
-        assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).get(0).getDescription(), is("1+ errors :: Invalid stage name ''. This must be alphanumeric and can contain underscores and periods (however, it cannot start with a period). The maximum allowed length is 255 characters.;;  -  Config-Repo: url1 at repo1_r2"));
+        assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).get(0).getDescription(), is("Number of errors: 1+\n1. Invalid stage name ''. This must be alphanumeric and can contain underscores and periods (however, it cannot start with a period). The maximum allowed length is 255 characters.;; \n- For Config Repo: url1 at repo1_r2"));
         assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig2)).isEmpty(), is(true));
 
         int countBeforeDeletion = cachedGoConfig.currentConfig().getConfigRepos().size();

--- a/server/src/test-integration/java/com/thoughtworks/go/config/GoPartialConfigIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/config/GoPartialConfigIntegrationTest.java
@@ -185,7 +185,7 @@ public class GoPartialConfigIntegrationTest {
         assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig2)).isEmpty(), is(false));
         ServerHealthState healthStateForInvalidConfigMerge = serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig2)).get(0);
         assertThat(healthStateForInvalidConfigMerge.getMessage(), is("Invalid Merged Configuration"));
-        assertThat(healthStateForInvalidConfigMerge.getDescription(), is("3+ errors :: Pipeline &quot;p1_repo1&quot; does not exist. It is used from pipeline &quot;p2_repo2&quot;.;; Pipeline with name 'p1_repo1' does not exist, it is defined as a dependency for pipeline 'p2_repo2' (url2 at 1);; Pipeline with name 'p3_repo3' does not exist, it is defined as a dependency for pipeline 'p2_repo2' (url2 at 1);;  -  Config-Repo: url2 at 1"));
+        assertThat(healthStateForInvalidConfigMerge.getDescription(), is("Number of errors: 3+\n1. Pipeline &quot;p1_repo1&quot; does not exist. It is used from pipeline &quot;p2_repo2&quot;.;; \n2. Pipeline with name 'p1_repo1' does not exist, it is defined as a dependency for pipeline 'p2_repo2' (url2 at 1);; \n3. Pipeline with name 'p3_repo3' does not exist, it is defined as a dependency for pipeline 'p2_repo2' (url2 at 1);; \n- For Config Repo: url2 at 1"));
         assertThat(healthStateForInvalidConfigMerge.getLogLevel(), is(HealthStateLevel.ERROR));
         assertThat(cachedGoPartials.lastValidPartials().isEmpty(), is(true));
         assertThat(cachedGoPartials.lastKnownPartials().size(), is(1));
@@ -245,7 +245,7 @@ public class GoPartialConfigIntegrationTest {
         List<ServerHealthState> serverHealthStates = serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1));
         assertThat(serverHealthStates.isEmpty(), is(false));
         assertThat(serverHealthStates.get(0).getLogLevel(), is(HealthStateLevel.ERROR));
-        assertThat(serverHealthStates.get(0).getDescription(), is("Parameter 'param1' is not defined. All pipelines using this parameter directly or via a template must define it. -  Config-Repo: url1 at 124"));
+        assertThat(serverHealthStates.get(0).getDescription(), is("Parameter 'param1' is not defined. All pipelines using this parameter directly or via a template must define it.- For Config Repo: url1 at 124"));
     }
 
     private boolean cacheContainsPartial(List<PartialConfig> partialConfigs, final PartialConfig partialConfig) {

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/PipelineConfigServiceIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/PipelineConfigServiceIntegrationTest.java
@@ -871,7 +871,7 @@ public class PipelineConfigServiceIntegrationTest {
         assertThat(((RepoConfigOrigin) cachedGoPartials.getKnown(repoConfig1.getMaterialConfig().getFingerprint()).getOrigin()).getRevision(), is("repo1_r2"));
         assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).size(), is(1));
         assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).get(0).getMessage(), is("Invalid Merged Configuration"));
-        assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).get(0).getDescription(), is("1+ errors :: Invalid stage name ''. This must be alphanumeric and can contain underscores and periods (however, it cannot start with a period). The maximum allowed length is 255 characters.;;  -  Config-Repo: url at repo1_r2"));
+        assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).get(0).getDescription(), is("Number of errors: 1+\n1. Invalid stage name ''. This must be alphanumeric and can contain underscores and periods (however, it cannot start with a period). The maximum allowed length is 255 characters.;; \n- For Config Repo: url at repo1_r2"));
         assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig2)).isEmpty(), is(true));
 
         String xml = new MagicalGoConfigXmlWriter(configCache, registry).toXmlPartial(pipelineConfig);
@@ -889,7 +889,7 @@ public class PipelineConfigServiceIntegrationTest {
 
         assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).size(), is(1));
         assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).get(0).getMessage(), is("Invalid Merged Configuration"));
-        assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).get(0).getDescription(), is("1+ errors :: Invalid stage name ''. This must be alphanumeric and can contain underscores and periods (however, it cannot start with a period). The maximum allowed length is 255 characters.;;  -  Config-Repo: url at repo1_r2"));
+        assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).get(0).getDescription(), is("Number of errors: 1+\n1. Invalid stage name ''. This must be alphanumeric and can contain underscores and periods (however, it cannot start with a period). The maximum allowed length is 255 characters.;; \n- For Config Repo: url at repo1_r2"));
         assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig2)).isEmpty(), is(true));
     }
 
@@ -911,7 +911,7 @@ public class PipelineConfigServiceIntegrationTest {
         assertThat(((RepoConfigOrigin) cachedGoPartials.getKnown(repoConfig1.getMaterialConfig().getFingerprint()).getOrigin()).getRevision(), is("repo1_r2"));
         assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).size(), is(1));
         assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).get(0).getMessage(), is("Invalid Merged Configuration"));
-        assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).get(0).getDescription(), is(String.format("1+ errors :: Stage with name 'upstream_stage_renamed' does not exist on pipeline '%s', it is being referred to from pipeline 'remote-downstream' (url at repo1_r2);;  -  Config-Repo: url at repo1_r2", pipelineConfig.name())));
+        assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).get(0).getDescription(), is(String.format("Number of errors: 1+\n1. Stage with name 'upstream_stage_renamed' does not exist on pipeline '%s', it is being referred to from pipeline 'remote-downstream' (url at repo1_r2);; \n- For Config Repo: url at repo1_r2", pipelineConfig.name())));
         assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig2)).isEmpty(), is(true));
 
         String xml = new MagicalGoConfigXmlWriter(configCache, registry).toXmlPartial(pipelineConfig);
@@ -950,7 +950,7 @@ public class PipelineConfigServiceIntegrationTest {
         assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).isEmpty(), is(true));
         assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig2)).size(), is(1));
         assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig2)).get(0).getMessage(), is("Invalid Merged Configuration"));
-        assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig2)).get(0).getDescription(), is("1+ errors :: Invalid stage name ''. This must be alphanumeric and can contain underscores and periods (however, it cannot start with a period). The maximum allowed length is 255 characters.;;  -  Config-Repo: url2 at repo2_r2"));
+        assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig2)).get(0).getDescription(), is("Number of errors: 1+\n1. Invalid stage name ''. This must be alphanumeric and can contain underscores and periods (however, it cannot start with a period). The maximum allowed length is 255 characters.;; \n- For Config Repo: url2 at repo2_r2"));
 
         final CaseInsensitiveString upstreamStageRenamed = new CaseInsensitiveString("upstream_stage_renamed");
         partialConfig = PartialConfigMother.pipelineWithDependencyMaterial("remote-downstream", new PipelineConfig(pipelineConfig.name(), pipelineConfig.materialConfigs(), new StageConfig(upstreamStageRenamed, new JobConfigs())), new RepoConfigOrigin(repoConfig1, "repo1_r2"));
@@ -963,10 +963,10 @@ public class PipelineConfigServiceIntegrationTest {
         assertThat(((RepoConfigOrigin) cachedGoPartials.getKnown(repoConfig1.getMaterialConfig().getFingerprint()).getOrigin()).getRevision(), is("repo1_r2"));
         assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).size(), is(1));
         assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).get(0).getMessage(), is("Invalid Merged Configuration"));
-        assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).get(0).getDescription(), is(String.format("1+ errors :: Stage with name 'upstream_stage_renamed' does not exist on pipeline '%s', it is being referred to from pipeline 'remote-downstream' (url at repo1_r2);;  -  Config-Repo: url at repo1_r2", pipelineConfig.name())));
+        assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).get(0).getDescription(), is(String.format("Number of errors: 1+\n1. Stage with name 'upstream_stage_renamed' does not exist on pipeline '%s', it is being referred to from pipeline 'remote-downstream' (url at repo1_r2);; \n- For Config Repo: url at repo1_r2", pipelineConfig.name())));
         assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig2)).size(), is(1));
         assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig2)).get(0).getMessage(), is("Invalid Merged Configuration"));
-        assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig2)).get(0).getDescription(), is("1+ errors :: Invalid stage name ''. This must be alphanumeric and can contain underscores and periods (however, it cannot start with a period). The maximum allowed length is 255 characters.;;  -  Config-Repo: url2 at repo2_r2"));
+        assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig2)).get(0).getDescription(), is("Number of errors: 1+\n1. Invalid stage name ''. This must be alphanumeric and can contain underscores and periods (however, it cannot start with a period). The maximum allowed length is 255 characters.;; \n- For Config Repo: url2 at repo2_r2"));
 
         String xml = new MagicalGoConfigXmlWriter(configCache, registry).toXmlPartial(pipelineConfig);
         String md5 = CachedDigestUtils.md5Hex(xml);
@@ -981,8 +981,8 @@ public class PipelineConfigServiceIntegrationTest {
                 "it is being referred to from pipeline 'remote-downstream' (url at repo1_r1)]" +
                 System.lineSeparator() +
                 "Merged config update operation failed using fallback LAST KNOWN 2 partials. " +
-                "Exception message was: 1+ errors :: Invalid stage name ''. This must be alphanumeric and can contain underscores and periods " +
-                "(however, it cannot start with a period). The maximum allowed length is 255 characters.;; ]. Please correct and resubmit.", pipelineConfig.name(), pipelineConfig.name())));
+                "Exception message was: Number of errors: 1+\n1. Invalid stage name ''. This must be alphanumeric and can contain underscores and periods " +
+                "(however, it cannot start with a period). The maximum allowed length is 255 characters.;; \n]. Please correct and resubmit.", pipelineConfig.name(), pipelineConfig.name())));
         assertThat(ErrorCollector.getAllErrors(pipelineConfig).isEmpty(), is(true));
         currentConfig = goConfigService.getCurrentConfig();
         assertThat(currentConfig.getAllPipelineNames().contains(remoteDownstreamPipeline.name()), is(true));
@@ -997,10 +997,10 @@ public class PipelineConfigServiceIntegrationTest {
         assertThat(((RepoConfigOrigin) cachedGoPartials.getKnown(repoConfig2.getMaterialConfig().getFingerprint()).getOrigin()).getRevision(), is("repo2_r2"));
         assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).size(), is(1));
         assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).get(0).getMessage(), is("Invalid Merged Configuration"));
-        assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).get(0).getDescription(), is(String.format("1+ errors :: Stage with name 'upstream_stage_renamed' does not exist on pipeline '%s', it is being referred to from pipeline 'remote-downstream' (url at repo1_r2);;  -  Config-Repo: url at repo1_r2", pipelineConfig.name())));
+        assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).get(0).getDescription(), is(String.format("Number of errors: 1+\n1. Stage with name 'upstream_stage_renamed' does not exist on pipeline '%s', it is being referred to from pipeline 'remote-downstream' (url at repo1_r2);; \n- For Config Repo: url at repo1_r2", pipelineConfig.name())));
         assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig2)).size(), is(1));
         assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig2)).get(0).getMessage(), is("Invalid Merged Configuration"));
-        assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig2)).get(0).getDescription(), is("1+ errors :: Invalid stage name ''. This must be alphanumeric and can contain underscores and periods (however, it cannot start with a period). The maximum allowed length is 255 characters.;;  -  Config-Repo: url2 at repo2_r2"));
+        assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig2)).get(0).getDescription(), is("Number of errors: 1+\n1. Invalid stage name ''. This must be alphanumeric and can contain underscores and periods (however, it cannot start with a period). The maximum allowed length is 255 characters.;; \n- For Config Repo: url2 at repo2_r2"));
     }
 
     @Test
@@ -1019,7 +1019,7 @@ public class PipelineConfigServiceIntegrationTest {
         assertThat(((RepoConfigOrigin) cachedGoPartials.getKnown(repoConfig1.getMaterialConfig().getFingerprint()).getOrigin()).getRevision(), is("repo1_r2"));
         assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).size(), is(1));
         assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).get(0).getMessage(), is("Invalid Merged Configuration"));
-        assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).get(0).getDescription(), is(String.format("1+ errors :: Stage with name 'upstream_stage_renamed' does not exist on pipeline '%s', it is being referred to from pipeline 'remote-downstream' (url at repo1_r2);;  -  Config-Repo: url at repo1_r2", pipelineConfig.name())));
+        assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).get(0).getDescription(), is(String.format("Number of errors: 1+\n1. Stage with name 'upstream_stage_renamed' does not exist on pipeline '%s', it is being referred to from pipeline 'remote-downstream' (url at repo1_r2);; \n- For Config Repo: url at repo1_r2", pipelineConfig.name())));
         assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig2)).isEmpty(), is(true));
 
         String xml = new MagicalGoConfigXmlWriter(configCache, registry).toXmlPartial(pipelineConfig);
@@ -1035,8 +1035,8 @@ public class PipelineConfigServiceIntegrationTest {
                 "it is being referred to from pipeline 'remote-downstream' (url at repo1_r1)]" +
                 System.lineSeparator() +
                 "Merged config update operation failed using fallback LAST KNOWN 2 partials. " +
-                "Exception message was: 1+ errors :: Stage with name 'upstream_stage_renamed' does not exist on pipeline " +
-                "'%s', it is being referred to from pipeline 'remote-downstream' (url at repo1_r2);; ]. " +
+                "Exception message was: Number of errors: 1+\n1. Stage with name 'upstream_stage_renamed' does not exist on pipeline " +
+                "'%s', it is being referred to from pipeline 'remote-downstream' (url at repo1_r2);; \n]. " +
                 "Please correct and resubmit.", pipelineConfig.name(), pipelineConfig.name(), pipelineConfig.name())));
         currentConfig = goConfigService.getCurrentConfig();
         assertThat(currentConfig.getAllPipelineNames().contains(remoteDownstreamPipeline.name()), is(true));
@@ -1050,7 +1050,7 @@ public class PipelineConfigServiceIntegrationTest {
         assertThat(((RepoConfigOrigin) cachedGoPartials.lastKnownPartials().get(0).getOrigin()).getRevision(), is("repo1_r2"));
         assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).size(), is(1));
         assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).get(0).getMessage(), is("Invalid Merged Configuration"));
-        assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).get(0).getDescription(), is(String.format("1+ errors :: Stage with name 'upstream_stage_renamed' does not exist on pipeline '%s', it is being referred to from pipeline 'remote-downstream' (url at repo1_r2);;  -  Config-Repo: url at repo1_r2", pipelineConfig.name())));
+        assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig1)).get(0).getDescription(), is(String.format("Number of errors: 1+\n1. Stage with name 'upstream_stage_renamed' does not exist on pipeline '%s', it is being referred to from pipeline 'remote-downstream' (url at repo1_r2);; \n- For Config Repo: url at repo1_r2", pipelineConfig.name())));
         assertThat(serverHealthService.filterByScope(HealthStateScope.forPartialConfigRepo(repoConfig2)).isEmpty(), is(true));
     }
 

--- a/server/webapp/WEB-INF/rails/webpack/views/components/server_health_summary/server_health_messages_count_widget.scss
+++ b/server/webapp/WEB-INF/rails/webpack/views/components/server_health_summary/server_health_messages_count_widget.scss
@@ -52,6 +52,7 @@
     margin-top:    5px;
     padding-left:  10px;
     margin-bottom: 0;
+    white-space:   pre-wrap;
   }
 
   .timestamp:before {


### PR DESCRIPTION
	* Show each error on a new line (validation + parsing)
	* Use period character for appropriate punctuations.
	* Add an error message number to each validation error.
	* Separate parsing errors by new line as per file.

### Screenshots:

#### YAML/JSON Parsing Errors:
<img width="1417" alt="screen shot 2019-01-16 at 12 03 03 pm" src="https://user-images.githubusercontent.com/15275847/51233519-087e7100-1990-11e9-939d-6168c22d569b.png">

#### Entity Parsing Errors (multiple files):
<img width="1413" alt="screen shot 2019-01-16 at 12 58 09 pm" src="https://user-images.githubusercontent.com/15275847/51233501-01576300-1990-11e9-90ce-6d10956ca685.png">

#### Partial Config Merge Errors:
<img width="1410" alt="screen shot 2019-01-16 at 12 58 42 pm" src="https://user-images.githubusercontent.com/15275847/51233487-f8669180-198f-11e9-8d4f-adc6b45f530b.png">

#### Config Repo Clone Errors:
<img width="1438" alt="screen shot 2019-01-16 at 1 07 35 pm" src="https://user-images.githubusercontent.com/15275847/51233459-f13f8380-198f-11e9-86bb-3a34f045c55c.png">

#### Show Whitespaces under server health messages:
<img width="1002" alt="screen shot 2019-01-16 at 12 58 59 pm" src="https://user-images.githubusercontent.com/15275847/51233557-28ae3000-1990-11e9-8521-2b438b7d9d95.png">
