### PR TITLE
Bring back template support pipeline export

### DIFF
--- a/api/api-export-v1/src/main/java/com/thoughtworks/go/apiv1/export/ExportControllerV1.java
+++ b/api/api-export-v1/src/main/java/com/thoughtworks/go/apiv1/export/ExportControllerV1.java
@@ -111,7 +111,7 @@ public class ExportControllerV1 extends ApiController implements SparkSpringCont
 
     private PipelineConfig pipelineConfigFromRequest(Request req) {
         final String pipelineName = requiredParam(req, "pipeline_name");
-        PipelineConfig pipeline = configService.pipelineConfigNamed(pipelineName);
+        PipelineConfig pipeline = configService.editablePipelineConfigNamed(pipelineName);
 
         if (null == pipeline) {
             throw new RecordNotFoundException(format("Cannot locate pipeline config with name: %s", pipelineName));

--- a/api/api-export-v1/src/main/java/com/thoughtworks/go/apiv1/export/ExportControllerV1.java
+++ b/api/api-export-v1/src/main/java/com/thoughtworks/go/apiv1/export/ExportControllerV1.java
@@ -81,10 +81,6 @@ public class ExportControllerV1 extends ApiController implements SparkSpringCont
         String pluginId = requiredQueryParam(req, "pluginId");
         String groupName = requiredQueryParam(req, "groupName");
 
-        if (pipelineConfig.hasTemplate()) {
-            throw haltBecauseOfReason("Pipeline `%s` cannot be exported because pipelines defined by templates are not yet supported by config-repo plugins.", pipelineConfig.name());
-        }
-
         if (!crPluginService.isConfigRepoPlugin(pluginId)) {
             throw haltBecauseOfReason("Plugin `%s` is not a config-repo plugin.", pluginId);
         }

--- a/api/api-export-v1/src/test/groovy/com/thoughtworks/go/apiv1/export/ExportControllerV1Test.groovy
+++ b/api/api-export-v1/src/test/groovy/com/thoughtworks/go/apiv1/export/ExportControllerV1Test.groovy
@@ -24,7 +24,6 @@ import com.thoughtworks.go.config.GoConfigPluginService
 import com.thoughtworks.go.config.PipelineConfig
 import com.thoughtworks.go.config.remote.FileConfigOrigin
 import com.thoughtworks.go.helper.PipelineConfigMother
-import com.thoughtworks.go.spark.AdminUserSecurity
 import com.thoughtworks.go.spark.ControllerTrait
 import com.thoughtworks.go.spark.GroupAdminUserSecurity
 import com.thoughtworks.go.spark.SecurityServiceTrait
@@ -95,7 +94,7 @@ class ExportControllerV1Test implements SecurityServiceTrait, ControllerTrait<Ex
         PipelineConfig pipeline = PipelineConfigMother.pipelineConfig('pipeline1')
         pipeline.setOrigin(new FileConfigOrigin())
 
-        when(goConfigService.pipelineConfigNamed('pipeline1')).thenReturn(pipeline)
+        when(goConfigService.editablePipelineConfigNamed('pipeline1')).thenReturn(pipeline)
         when(goConfigPluginService.isConfigRepoPlugin(pluginId)).thenReturn(true)
         when(goConfigPluginService.supportsPipelineExport(pluginId)).thenReturn(true)
         when(goConfigPluginService.partialConfigProviderFor(pluginId)).thenReturn(configRepoPlugin)
@@ -121,7 +120,7 @@ class ExportControllerV1Test implements SecurityServiceTrait, ControllerTrait<Ex
         PipelineConfig pipeline = PipelineConfigMother.pipelineConfig("pipeline1")
         pipeline.setOrigin(new FileConfigOrigin())
 
-        when(goConfigService.pipelineConfigNamed("pipeline1")).thenReturn(pipeline)
+        when(goConfigService.editablePipelineConfigNamed("pipeline1")).thenReturn(pipeline)
 
         getWithApiHeader(controller.controllerPath("${pipelinePath("pipeline1")}?groupName=${groupName}"))
 
@@ -141,7 +140,7 @@ class ExportControllerV1Test implements SecurityServiceTrait, ControllerTrait<Ex
         PipelineConfig pipeline = PipelineConfigMother.pipelineConfig("pipeline1")
         pipeline.setOrigin(new FileConfigOrigin())
 
-        when(goConfigService.pipelineConfigNamed("pipeline1")).thenReturn(pipeline)
+        when(goConfigService.editablePipelineConfigNamed("pipeline1")).thenReturn(pipeline)
 
         getWithApiHeader(controller.controllerPath("${pipelinePath("pipeline1")}?pluginId=${pluginId}"))
 
@@ -161,7 +160,7 @@ class ExportControllerV1Test implements SecurityServiceTrait, ControllerTrait<Ex
         PipelineConfig pipeline = PipelineConfigMother.pipelineConfig("pipeline1")
         pipeline.setOrigin(new FileConfigOrigin())
 
-        when(goConfigService.pipelineConfigNamed("pipeline1")).thenReturn(pipeline)
+        when(goConfigService.editablePipelineConfigNamed("pipeline1")).thenReturn(pipeline)
         when(goConfigPluginService.isConfigRepoPlugin(pluginId)).thenReturn(false)
 
         getWithApiHeader(controller.controllerPath("${pipelinePath("pipeline1")}?pluginId=${pluginId}&groupName=${groupName}"))
@@ -176,7 +175,7 @@ class ExportControllerV1Test implements SecurityServiceTrait, ControllerTrait<Ex
         PipelineConfig pipeline = PipelineConfigMother.pipelineConfig("pipeline1")
         pipeline.setOrigin(new FileConfigOrigin())
 
-        when(goConfigService.pipelineConfigNamed("pipeline1")).thenReturn(pipeline)
+        when(goConfigService.editablePipelineConfigNamed("pipeline1")).thenReturn(pipeline)
         when(goConfigPluginService.isConfigRepoPlugin(pluginId)).thenReturn(true)
         when(goConfigPluginService.supportsPipelineExport(pluginId)).thenReturn(false)
 
@@ -192,7 +191,7 @@ class ExportControllerV1Test implements SecurityServiceTrait, ControllerTrait<Ex
         PipelineConfig pipeline = PipelineConfigMother.pipelineConfig("pipeline1")
         pipeline.setOrigin(new FileConfigOrigin())
 
-        when(goConfigService.pipelineConfigNamed("pipeline1")).thenReturn(pipeline)
+        when(goConfigService.editablePipelineConfigNamed("pipeline1")).thenReturn(pipeline)
         when(goConfigPluginService.isConfigRepoPlugin(pluginId)).thenReturn(true)
         when(goConfigPluginService.supportsPipelineExport(pluginId)).thenReturn(true)
         when(goConfigPluginService.partialConfigProviderFor(pluginId)).thenReturn(configRepoPlugin)
@@ -208,7 +207,7 @@ class ExportControllerV1Test implements SecurityServiceTrait, ControllerTrait<Ex
 
       @Test
       void "should return 404 for export pipeline config if pipeline is not found"() {
-        when(goConfigService.pipelineConfigNamed("pipeline1")).thenReturn(null)
+        when(goConfigService.editablePipelineConfigNamed("pipeline1")).thenReturn(null)
 
         getWithApiHeader(controller.controllerPath("${pipelinePath("pipeline1")}?pluginId=${pluginId}&groupName=${groupName}"))
 

--- a/api/api-export-v1/src/test/groovy/com/thoughtworks/go/apiv1/export/ExportControllerV1Test.groovy
+++ b/api/api-export-v1/src/test/groovy/com/thoughtworks/go/apiv1/export/ExportControllerV1Test.groovy
@@ -19,7 +19,6 @@ package com.thoughtworks.go.apiv1.export
 import com.thoughtworks.go.api.SecurityTestTrait
 import com.thoughtworks.go.api.spring.ApiAuthenticationHelper
 import com.thoughtworks.go.api.util.HaltApiMessages
-import com.thoughtworks.go.config.CaseInsensitiveString
 import com.thoughtworks.go.config.ConfigRepoPlugin
 import com.thoughtworks.go.config.GoConfigPluginService
 import com.thoughtworks.go.config.PipelineConfig
@@ -36,7 +35,6 @@ import org.mockito.Mock
 
 import static com.thoughtworks.go.plugin.access.configrepo.ExportedConfig.from
 import static com.thoughtworks.go.spark.Routes.Export
-import static org.mockito.Mockito.mock
 import static org.mockito.Mockito.when
 import static org.mockito.MockitoAnnotations.initMocks
 
@@ -156,22 +154,6 @@ class ExportControllerV1Test implements SecurityServiceTrait, ControllerTrait<Ex
         assertThatResponse()
           .isBadRequest()
           .hasJsonMessage("Request is missing parameter `groupName`")
-      }
-
-      @Test
-      void 'returns a 422 when pipeline is defined by a template'() {
-        PipelineConfig pipeline = mock(PipelineConfig)
-        when(pipeline.hasTemplate()).thenReturn(true)
-        when(pipeline.name()).thenReturn(new CaseInsensitiveString("pipeline1"))
-
-        when(goConfigService.pipelineConfigNamed("pipeline1")).thenReturn(pipeline)
-        when(goConfigPluginService.isConfigRepoPlugin(pluginId)).thenReturn(false)
-
-        getWithApiHeader(controller.controllerPath("${pipelinePath("pipeline1")}?pluginId=${pluginId}&groupName=${groupName}"))
-
-        assertThatResponse()
-          .isUnprocessableEntity()
-          .hasJsonMessage("Pipeline `pipeline1` cannot be exported because pipelines defined by templates are not yet supported by config-repo plugins.")
       }
 
       @Test

--- a/server/src/main/java/com/thoughtworks/go/server/service/GoConfigService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/GoConfigService.java
@@ -248,12 +248,12 @@ public class GoConfigService implements Initializer, CruiseConfigProvider {
         return getCurrentConfig().hasPipelineNamed(pipelineName);
     }
 
-    public PipelineConfig pipelineConfigNamed(final CaseInsensitiveString name) {
-        return getCurrentConfig().pipelineConfigByName(name);
+    public PipelineConfig editablePipelineConfigNamed(final String name) {
+        return getConfigForEditing().pipelineConfigByName(new CaseInsensitiveString(name));
     }
 
-    public PipelineConfig pipelineConfigNamed(final String name) {
-        return pipelineConfigNamed(new CaseInsensitiveString(name));
+    public PipelineConfig pipelineConfigNamed(final CaseInsensitiveString name) {
+        return getCurrentConfig().pipelineConfigByName(name);
     }
 
     public PipelineTemplateConfig templateConfigNamed(final CaseInsensitiveString name) {

--- a/server/webapp/WEB-INF/rails/app/assets/stylesheets/new-theme.scss
+++ b/server/webapp/WEB-INF/rails/app/assets/stylesheets/new-theme.scss
@@ -3402,20 +3402,6 @@ a.add_item {
   @extend %iconstyles;
 }
 
-.export_disabled {
-  color: $disabled-icon-color;
-
-  &:before, &:hover, &:focus {
-    color: $disabled-icon-color;
-  }
-
-  cursor: default;
-
-  .for_down_arrow {
-    visibility: hidden; // want to maintain spacing
-  }
-}
-
 .clone_icon {
   @include icon-before($type: clone);
   @extend %iconstyles;

--- a/server/webapp/WEB-INF/rails/app/views/admin/pipeline_groups/index.html.erb
+++ b/server/webapp/WEB-INF/rails/app/views/admin/pipeline_groups/index.html.erb
@@ -83,24 +83,12 @@
                               </a>
                             </li>
                         <%- end -%>
-
-                      <%- unless pipeline.hasTemplate() -%>
                         <li>
                           <%= link_to("#{spark_url_for({request: request}, SparkRoutes::Export.pipeline(pipeline.name().toString()))}?groupName=#{group.getGroup()}", :class => "export_icon action_icon export_pipeline_config") do -%>
                             Export using
                             <span class="for_down_arrow">&nbsp;</span>
                           <% end -%>
                         </li>
-                      <%- else -%>
-                        <li>
-                          <span class="export_icon export_disabled action_icon export_pipeline_config" title="Cannot export pipelines defined by templates.">
-                            Export using
-                            <!-- want to maintain spacing, so include the arrow even if it's invisible -->
-                            <span class="for_down_arrow">&nbsp;</span>
-                          </span>
-                        </li>
-                      <%- end -%>
-
                         <li>
                           <% if pipeline.isLocal() %>
                               <% pipeline_random_id_for_clone = random_dom_id('clone_button_for_') -%>
@@ -177,10 +165,6 @@
 
     var exportPopupShower = new MicroContentPopup.Shower(exportPopup);
     $(".group_pipelines").on("click", ".export_pipeline_config", function (e) {
-      if ($(e.currentTarget).hasClass("export_disabled")) {
-        return;
-      }
-
       e.preventDefault();
       e.stopPropagation();
 


### PR DESCRIPTION
1. Reverts the commit that blocked export on pipelines using templates
2. Export pipeline configs based on `configForEditing` so we don't denormalize the config we are exporting