### PR TITLE
Remove unnecessary dashboard API v2 route from rails routes.rb

### DIFF
--- a/server/webapp/WEB-INF/rails/config/routes.rb
+++ b/server/webapp/WEB-INF/rails/config/routes.rb
@@ -276,8 +276,6 @@ Rails.application.routes.draw do
       delete 'users', controller: 'users', action: 'bulk_delete'
       patch 'users/:login_name', to: 'users#update', constraints: {login_name: /(.*?)/}
 
-      get 'dashboard', controller: :dashboard, action: :dashboard, as: :show_dashboard
-
       match '*url', via: :all, to: 'errors#not_found'
     end
   end


### PR DESCRIPTION
* Dashboard API was initially written in rails and later was ported to spark.
  But while removing rails code, remove route part was not done.
* As there was was a route, jsroutes gem was resolving a non-existing path Routes.apiv2ShowDashboardPath