### PR TITLE
#5727 - Handle SSH-based URLs as special when displaying

### DIFF
--- a/config/config-api/src/main/java/com/thoughtworks/go/util/command/UrlArgument.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/util/command/UrlArgument.java
@@ -41,7 +41,7 @@ public class UrlArgument extends CommandArgument {
             URI uri = new URI(sanitizeUrl());
             if (uri.getUserInfo() != null) {
                 //(String scheme, String userInfo, String host, int port, String path, String query, String fragment)
-                uri = new URI(uri.getScheme(), clean(uri.getUserInfo()), uri.getHost(), uri.getPort(), uri.getPath(), uri.getQuery(), uri.getFragment());
+                uri = new URI(uri.getScheme(), clean(uri.getScheme(), uri.getUserInfo()), uri.getHost(), uri.getPort(), uri.getPath(), uri.getQuery(), uri.getFragment());
             }
             return uriToDisplay(uri);
         } catch (URISyntaxException e) {
@@ -63,7 +63,7 @@ public class UrlArgument extends CommandArgument {
             URI uri = new URI(url);
             if (uri.getUserInfo() != null) {
                 //(String scheme, String userInfo, String host, int port, String path, String query, String fragment)
-                uri = new URI(uri.getScheme(), clean(uri.getUserInfo()), uri.getHost(), uri.getPort(), null, null, null);
+                uri = new URI(uri.getScheme(), clean(uri.getScheme(), uri.getUserInfo()), uri.getHost(), uri.getPort(), null, null, null);
             }
             return uri.toString();
         } catch (URISyntaxException e) {
@@ -86,9 +86,11 @@ public class UrlArgument extends CommandArgument {
         }
     }
 
-    private String clean(String userInfo) {
+    private String clean(String scheme, String userInfo) {
         if (userInfo.contains(":")) {
             return userInfo.replaceFirst(":.*", ":******");
+        } else if ("ssh".equals(scheme) || "svn+ssh".equals(scheme)) {
+            return userInfo;
         }
         return "******";
     }

--- a/config/config-api/src/test/java/com/thoughtworks/go/util/command/UrlArgumentTest.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/util/command/UrlArgumentTest.java
@@ -58,10 +58,22 @@ public class UrlArgumentTest {
         Assert.assertThat(url.toString(), is("svn+ssh://user:******@10.18.7.51:8153"));
     }
 
-    @Test public void shouldWorkWithJustUser() throws Exception {
+    @Test public void shouldNotMaskWithJustUserForSvnSshProtocol() throws Exception {
         String normal = "svn+ssh://user@10.18.7.51:8153";
         UrlArgument url = new UrlArgument(normal);
-        Assert.assertThat(url.forDisplay(), is("svn+ssh://******@10.18.7.51:8153"));
+        Assert.assertThat(url.forDisplay(), is("svn+ssh://user@10.18.7.51:8153"));
+    }
+
+    @Test public void shouldNotMaskWithJustUserForSshProtocol() throws Exception {
+        String normal = "ssh://user@10.18.7.51:8153";
+        UrlArgument url = new UrlArgument(normal);
+        Assert.assertThat(url.forDisplay(), is("ssh://user@10.18.7.51:8153"));
+    }
+
+    @Test public void shouldMaskWithUsernameAndPasswordForSshProtocol() throws Exception {
+        String normal = "ssh://user:password@10.18.7.51:8153";
+        UrlArgument url = new UrlArgument(normal);
+        Assert.assertThat(url.forDisplay(), is("ssh://user:******@10.18.7.51:8153"));
     }
 
     @Test public void shouldIgnoreArgumentsThatAreNotRecognisedUrls() throws Exception {


### PR DESCRIPTION
Show username (do not mask) when used as: svn+ssh://user@host or ssh://user@host.

Fixes #5727.

@tetrohed [had not wanted](https://github.com/gocd/gocd/pull/5574#issuecomment-447400512) to break this test. :) I thought it'd be fine. Looks like there are people using it.