### PR TITLE
Allow pipeline group admins to export pipelines in groups they see

### DIFF
--- a/server/src/main/java/com/thoughtworks/go/server/newsecurity/filterchains/AuthorizeFilterChain.java
+++ b/server/src/main/java/com/thoughtworks/go/server/newsecurity/filterchains/AuthorizeFilterChain.java
@@ -87,6 +87,7 @@ public class AuthorizeFilterChain extends FilterChainProxy {
                 // new controllers, so we say `ROLE_USER`, and let the controller handle authorization
                 .addAuthorityFilterChain("/api/admin/internal/*", apiAccessDeniedHandler, ROLE_USER)
                 .addAuthorityFilterChain("/api/admin/pipelines/**", apiAccessDeniedHandler, ROLE_USER)
+                .addAuthorityFilterChain("/api/admin/export/**", apiAccessDeniedHandler, ROLE_USER)
                 .addAuthorityFilterChain("/api/admin/encrypt", apiAccessDeniedHandler, ROLE_USER)
                 .addAuthorityFilterChain("/api/admin/scms/**", apiAccessDeniedHandler, ROLE_USER)
                 .addAuthorityFilterChain("/api/admin/repositories/**", apiAccessDeniedHandler, ROLE_USER)

--- a/spark/spark-base/src/test/groovy/com/thoughtworks/go/spark/SecurityServiceTrait.groovy
+++ b/spark/spark-base/src/test/groovy/com/thoughtworks/go/spark/SecurityServiceTrait.groovy
@@ -97,6 +97,15 @@ trait SecurityServiceTrait {
     when(goConfigService.findGroupNameByPipeline(new CaseInsensitiveString(pipelineName))).thenReturn(groupName)
   }
 
+  void loginAsGroupAdminofPipeline(String pipelineName) {
+    Username username = loginAsRandomUser()
+    String groupName = generateGroupName()
+
+    when(securityService.isUserAdmin(username)).thenReturn(false)
+    when(securityService.isUserGroupAdmin(username)).thenReturn(true)
+    when(securityService.isUserAdminOfGroup(username, groupName)).thenReturn(true)
+  }
+
   void loginAsGroupOperateUser(String pipelineName) {
     Username username = loginAsRandomUser()
     String groupName = generateGroupName()


### PR DESCRIPTION
This should fix the second issue described here - https://github.com/gocd/gocd/issues/5688

Previously the filter chain required that a user be an admin to access "/api/admin/export/**" so group admin requests never reached the API control. We whitelisted users (ROLE_USER) access so that the permissions could be handled at the controller level. 

Refactored a little so that the groupName query param is no longer required and can be determined by the pipeline name in the request url. 