### PR TITLE
Changed JSON keys returned by `get-capabilities` call

### DIFF
--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/configrepo/v2/JsonMessageHandler2_0.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/configrepo/v2/JsonMessageHandler2_0.java
@@ -50,7 +50,7 @@ public class JsonMessageHandler2_0 implements JsonMessageHandler {
 
     @Override
     public Capabilities getCapabilitiesFromResponse(String responseBody) {
-        return codec.getGson().fromJson(responseBody, Capabilities.class);
+        return com.thoughtworks.go.plugin.access.configrepo.v2.models.Capabilities.fromJSON(responseBody).toCapabilities();
     }
 
     @Override

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/configrepo/v2/models/Capabilities.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/configrepo/v2/models/Capabilities.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.plugin.access.configrepo.v2.models;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.SerializedName;
+
+public class Capabilities {
+    private static final Gson GSON = new GsonBuilder().excludeFieldsWithoutExposeAnnotation().create();
+
+    @Expose
+    @SerializedName("supports_pipeline_export")
+    private boolean supportsPipelineExport;
+
+    @Expose
+    @SerializedName("supports_parse_content")
+    private boolean supportsParseContent;
+
+    public static Capabilities fromJSON(String json) {
+        return GSON.fromJson(json, Capabilities.class);
+    }
+
+    public com.thoughtworks.go.plugin.domain.configrepo.Capabilities toCapabilities() {
+        return new com.thoughtworks.go.plugin.domain.configrepo.Capabilities(supportsPipelineExport, supportsParseContent);
+    }
+}

--- a/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/configrepo/v2/JsonMessageHandler2_0Test.java
+++ b/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/configrepo/v2/JsonMessageHandler2_0Test.java
@@ -35,6 +35,6 @@ public class JsonMessageHandler2_0Test {
 
     @Test
     public void shouldReturnAllFalseCapabilities() {
-        assertThat(handler.getCapabilitiesFromResponse("{\"supportsPipelineExport\":\"true\",\"supportsParseContent\":\"true\"}"), is(new Capabilities(true, true)));
+        assertThat(handler.getCapabilitiesFromResponse("{\"supports_pipeline_export\":\"true\",\"supports_parse_content\":\"true\"}"), is(new Capabilities(true, true)));
     }
 }


### PR DESCRIPTION
The JSON uses snake-cased keys, instead of the camel case keys
used earlier.