### PR TITLE
Pull out user authorization check into its own function

### DIFF
--- a/config/config-server/src/main/java/com/thoughtworks/go/config/commands/EntityConfigUpdateCommand.java
+++ b/config/config-server/src/main/java/com/thoughtworks/go/config/commands/EntityConfigUpdateCommand.java
@@ -21,6 +21,8 @@ import com.thoughtworks.go.config.CruiseConfig;
 public interface EntityConfigUpdateCommand<T> extends CheckedUpdateCommand {
     void update(CruiseConfig preprocessedConfig) throws Exception;
 
+    boolean isUserAuthorized();
+
     boolean isValid(CruiseConfig preprocessedConfig);
 
     void clearErrors();

--- a/server/src/main/java/com/thoughtworks/go/config/GoConfigDao.java
+++ b/server/src/main/java/com/thoughtworks/go/config/GoConfigDao.java
@@ -89,7 +89,7 @@ public class GoConfigDao {
         synchronized (GoConfigWriteLock.class) {
             try {
                 LOGGER.info("Config update for entity request by {} is being processed", currentUser);
-                if (!command.canContinue(cachedConfigService.currentConfig())) {
+                if (!command.isUserAuthorized() || !command.canContinue(cachedConfigService.currentConfig())) {
                     throw new ConfigUpdateCheckFailedException();
                 }
                 cachedConfigService.writeEntityWithLock(command, currentUser);

--- a/server/src/main/java/com/thoughtworks/go/config/update/AdminsConfigUpdateCommand.java
+++ b/server/src/main/java/com/thoughtworks/go/config/update/AdminsConfigUpdateCommand.java
@@ -70,8 +70,18 @@ public class AdminsConfigUpdateCommand implements EntityConfigUpdateCommand<Admi
 
     @Override
     public boolean canContinue(CruiseConfig cruiseConfig) {
-        return isAuthorized() && isRequestFresh(cruiseConfig);
+        return isRequestFresh(cruiseConfig);
     }
+
+    @Override
+    public final boolean isUserAuthorized() {
+        if (goConfigService.isUserAdmin(currentUser)) {
+            return true;
+        }
+        result.forbidden(forbiddenToEdit(), forbidden());
+        return false;
+    }
+
     @Override
     public void clearErrors() {
         BasicCruiseConfig.clearErrors(admin);
@@ -86,7 +96,6 @@ public class AdminsConfigUpdateCommand implements EntityConfigUpdateCommand<Admi
         return cruiseConfig.server().security().adminsConfig();
     }
 
-
     private boolean isRequestFresh(CruiseConfig cruiseConfig) {
         AdminsConfig existingAdminsConfig = findExistingAdmin(cruiseConfig);
 
@@ -96,14 +105,5 @@ public class AdminsConfigUpdateCommand implements EntityConfigUpdateCommand<Admi
             result.stale(staleResourceConfig("System admins", existingAdminsConfig.getClass().getName()));
         }
         return freshRequest;
-    }
-
-    private final boolean isAuthorized() {
-        if (goConfigService.isUserAdmin(currentUser)) {
-            return true;
-        }
-
-        result.forbidden(forbiddenToEdit(), forbidden());
-        return false;
     }
 }

--- a/server/src/main/java/com/thoughtworks/go/config/update/AgentsEntityConfigUpdateCommand.java
+++ b/server/src/main/java/com/thoughtworks/go/config/update/AgentsEntityConfigUpdateCommand.java
@@ -68,10 +68,6 @@ public class AgentsEntityConfigUpdateCommand implements EntityConfigUpdateComman
 
     @Override
     public boolean canContinue(CruiseConfig cruiseConfig) {
-        if (!isAuthorized()) {
-            return false;
-        }
-
         if (isAnyOperationPerformedOnAgents()) {
             return true;
         }
@@ -156,7 +152,8 @@ public class AgentsEntityConfigUpdateCommand implements EntityConfigUpdateComman
         }
     }
 
-    private boolean isAuthorized() {
+    @Override
+    public boolean isUserAuthorized() {
         if (goConfigService.isAdministrator(username.getUsername())) {
             return true;
         }

--- a/server/src/main/java/com/thoughtworks/go/config/update/AgentsUpdateCommand.java
+++ b/server/src/main/java/com/thoughtworks/go/config/update/AgentsUpdateCommand.java
@@ -38,6 +38,11 @@ public class AgentsUpdateCommand implements EntityConfigUpdateCommand<Agents> {
     }
 
     @Override
+    public boolean isUserAuthorized() {
+        return true;
+    }
+
+    @Override
     public void update(CruiseConfig preprocessedConfig) throws Exception {
         updatedConfig = command.update(preprocessedConfig);
     }

--- a/server/src/main/java/com/thoughtworks/go/config/update/ArtifactStoreConfigCommand.java
+++ b/server/src/main/java/com/thoughtworks/go/config/update/ArtifactStoreConfigCommand.java
@@ -39,6 +39,15 @@ abstract class ArtifactStoreConfigCommand extends PluginProfileCommand<ArtifactS
     }
 
     @Override
+    public final boolean isUserAuthorized() {
+        if (goConfigService.isUserAdmin(currentUser)) {
+            return true;
+        }
+        result.forbidden(forbiddenToEdit(), forbidden());
+        return false;
+    }
+
+    @Override
     protected ArtifactStores getPluginProfiles(CruiseConfig preprocessedConfig) {
         return preprocessedConfig.getArtifactStores();
     }
@@ -51,14 +60,6 @@ abstract class ArtifactStoreConfigCommand extends PluginProfileCommand<ArtifactS
     @Override
     protected String getObjectDescriptor() {
         return "Artifact store";
-    }
-
-    protected final boolean isAuthorized() {
-        if (goConfigService.isUserAdmin(currentUser)) {
-            return true;
-        }
-        result.forbidden(forbiddenToEdit(), forbidden());
-        return false;
     }
 
 }

--- a/server/src/main/java/com/thoughtworks/go/config/update/ConfigRepoCommand.java
+++ b/server/src/main/java/com/thoughtworks/go/config/update/ConfigRepoCommand.java
@@ -25,12 +25,12 @@ import com.thoughtworks.go.plugin.access.configrepo.ConfigRepoExtension;
 import com.thoughtworks.go.server.domain.Username;
 import com.thoughtworks.go.server.service.SecurityService;
 import com.thoughtworks.go.server.service.result.HttpLocalizedOperationResult;
-import org.apache.commons.lang3.StringUtils;
 
 import static com.thoughtworks.go.i18n.LocalizedMessage.forbiddenToEdit;
 import static com.thoughtworks.go.serverhealth.HealthStateType.forbidden;
 import static java.lang.String.format;
-import static org.apache.commons.lang3.StringUtils.*;
+import static org.apache.commons.lang3.StringUtils.isBlank;
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 abstract class ConfigRepoCommand implements EntityConfigUpdateCommand<ConfigRepoConfig> {
 
@@ -97,10 +97,11 @@ abstract class ConfigRepoCommand implements EntityConfigUpdateCommand<ConfigRepo
 
     @Override
     public boolean canContinue(CruiseConfig cruiseConfig) {
-        return isUserAuthorized();
+        return true;
     }
 
-    private boolean isUserAuthorized() {
+    @Override
+    public boolean isUserAuthorized() {
         if (!securityService.isUserAdmin(username)) {
             result.forbidden(forbiddenToEdit(), forbidden());
             return false;

--- a/server/src/main/java/com/thoughtworks/go/config/update/CreatePackageConfigCommand.java
+++ b/server/src/main/java/com/thoughtworks/go/config/update/CreatePackageConfigCommand.java
@@ -58,7 +58,7 @@ public class CreatePackageConfigCommand extends PackageConfigCommand implements 
 
     @Override
     public boolean canContinue(CruiseConfig cruiseConfig) {
-        if (!isAuthorized()) {
+        if (!isUserAuthorized()) {
             return false;
         }
         if (cruiseConfig.getPackageRepositories().find(repositoryId) == null) {

--- a/server/src/main/java/com/thoughtworks/go/config/update/CreatePipelineConfigCommand.java
+++ b/server/src/main/java/com/thoughtworks/go/config/update/CreatePipelineConfigCommand.java
@@ -16,7 +16,9 @@
 
 package com.thoughtworks.go.config.update;
 
-import com.thoughtworks.go.config.*;
+import com.thoughtworks.go.config.CruiseConfig;
+import com.thoughtworks.go.config.PipelineConfig;
+import com.thoughtworks.go.config.PipelineConfigSaveValidationContext;
 import com.thoughtworks.go.server.domain.Username;
 import com.thoughtworks.go.server.service.ExternalArtifactsService;
 import com.thoughtworks.go.server.service.GoConfigService;
@@ -60,6 +62,11 @@ public class CreatePipelineConfigCommand extends PipelineConfigCommand {
 
     @Override
     public boolean canContinue(CruiseConfig cruiseConfig) {
+        return true;
+    }
+
+    @Override
+    public boolean isUserAuthorized() {
         if (goConfigService.groups().hasGroup(groupName) && !goConfigService.isUserAdminOfGroup(currentUser.getUsername(), groupName)) {
             result.forbidden(forbiddenToEditGroup(groupName), forbidden());
             return false;

--- a/server/src/main/java/com/thoughtworks/go/config/update/CreatePipelineConfigsCommand.java
+++ b/server/src/main/java/com/thoughtworks/go/config/update/CreatePipelineConfigsCommand.java
@@ -60,6 +60,11 @@ public class CreatePipelineConfigsCommand extends PipelineConfigsCommand {
 
     @Override
     public boolean canContinue(CruiseConfig cruiseConfig) {
+        return true;
+    }
+
+    @Override
+    public boolean isUserAuthorized() {
         return isUserAdmin();
     }
 }

--- a/server/src/main/java/com/thoughtworks/go/config/update/CreateTemplateConfigCommand.java
+++ b/server/src/main/java/com/thoughtworks/go/config/update/CreateTemplateConfigCommand.java
@@ -50,6 +50,11 @@ public class CreateTemplateConfigCommand extends TemplateConfigCommand {
 
     @Override
     public boolean canContinue(CruiseConfig cruiseConfig) {
+        return true;
+    }
+
+    @Override
+    public boolean isUserAuthorized() {
         if (!(securityService.isUserAdmin(currentUser) || securityService.isUserGroupAdmin(currentUser))) {
             result.forbidden(forbiddenToEdit(), forbidden());
             return false;

--- a/server/src/main/java/com/thoughtworks/go/config/update/DeleteConfigRepoCommand.java
+++ b/server/src/main/java/com/thoughtworks/go/config/update/DeleteConfigRepoCommand.java
@@ -64,18 +64,19 @@ public class DeleteConfigRepoCommand implements EntityConfigUpdateCommand<Config
 
     @Override
     public boolean canContinue(CruiseConfig cruiseConfig) {
-        return doesConfigRepoExist(cruiseConfig) && isUserAuthorized();
+        return doesConfigRepoExist(cruiseConfig);
     }
 
-    private boolean doesConfigRepoExist(CruiseConfig cruiseConfig) {
-        return cruiseConfig.getConfigRepos().getConfigRepo(repoId) != null;
-    }
-
+    @Override
     public boolean isUserAuthorized() {
         if (!securityService.isUserAdmin(username)) {
             result.forbidden(forbiddenToEdit(), forbidden());
             return false;
         }
         return true;
+    }
+
+    private boolean doesConfigRepoExist(CruiseConfig cruiseConfig) {
+        return cruiseConfig.getConfigRepos().getConfigRepo(repoId) != null;
     }
 }

--- a/server/src/main/java/com/thoughtworks/go/config/update/DeletePackageConfigCommand.java
+++ b/server/src/main/java/com/thoughtworks/go/config/update/DeletePackageConfigCommand.java
@@ -90,10 +90,11 @@ public class DeletePackageConfigCommand implements EntityConfigUpdateCommand<Pac
 
     @Override
     public boolean canContinue(CruiseConfig cruiseConfig) {
-        return isAuthorized();
+        return true;
     }
 
-    private boolean isAuthorized() {
+    @Override
+    public boolean isUserAuthorized() {
         if (!(goConfigService.isUserAdmin(username) || goConfigService.isGroupAdministrator(username.getUsername()))) {
             result.forbidden(forbiddenToEdit(), forbidden());
             return false;

--- a/server/src/main/java/com/thoughtworks/go/config/update/DeletePackageRepositoryCommand.java
+++ b/server/src/main/java/com/thoughtworks/go/config/update/DeletePackageRepositoryCommand.java
@@ -71,9 +71,9 @@ public class DeletePackageRepositoryCommand implements EntityConfigUpdateCommand
 
     private List<String> populateList(Map<String, List<Pair<PipelineConfig, PipelineConfigs>>> packageUsageInPipelines) {
         ArrayList<String> pipleines = new ArrayList<>();
-        for(String key: packageUsageInPipelines.keySet()) {
+        for (String key : packageUsageInPipelines.keySet()) {
             List<Pair<PipelineConfig, PipelineConfigs>> pairs = packageUsageInPipelines.get(key);
-            for(Pair<PipelineConfig, PipelineConfigs> pair : pairs) {
+            for (Pair<PipelineConfig, PipelineConfigs> pair : pairs) {
                 pipleines.add(pair.first().getName().toLower());
             }
         }
@@ -92,10 +92,11 @@ public class DeletePackageRepositoryCommand implements EntityConfigUpdateCommand
 
     @Override
     public boolean canContinue(CruiseConfig cruiseConfig) {
-        return isAuthorized();
+        return true;
     }
 
-    private boolean isAuthorized() {
+    @Override
+    public boolean isUserAuthorized() {
         if (!(goConfigService.isUserAdmin(username) || goConfigService.isGroupAdministrator(username.getUsername()))) {
             result.forbidden(forbiddenToEdit(), forbidden());
             return false;

--- a/server/src/main/java/com/thoughtworks/go/config/update/DeletePipelineConfigCommand.java
+++ b/server/src/main/java/com/thoughtworks/go/config/update/DeletePipelineConfigCommand.java
@@ -51,14 +51,14 @@ public class DeletePipelineConfigCommand implements EntityConfigUpdateCommand<Pi
     @Override
     public boolean isValid(CruiseConfig preprocessedConfig) {
         for (PipelineConfig pipeline : preprocessedConfig.getAllPipelineConfigs()) {
-            if(pipeline.materialConfigs().hasDependencyMaterial(pipelineConfig)){
+            if (pipeline.materialConfigs().hasDependencyMaterial(pipelineConfig)) {
                 this.result.unprocessableEntity("Cannot delete pipeline '" + pipelineConfig.name() + "' as pipeline '" + String.format("%s (%s)", pipeline.name(), pipeline.getOriginDisplayName()) + "' depends on it");
                 return false;
             }
         }
 
         for (EnvironmentConfig environment : preprocessedConfig.getEnvironments()) {
-            if(environment.getPipelineNames().contains(pipelineConfig.name())){
+            if (environment.getPipelineNames().contains(pipelineConfig.name())) {
                 this.result.unprocessableEntity("Cannot delete pipeline '" + pipelineConfig.name() + "' as it is present in environment '" + environment.name() + "'.");
                 return false;
             }
@@ -79,6 +79,11 @@ public class DeletePipelineConfigCommand implements EntityConfigUpdateCommand<Pi
 
     @Override
     public boolean canContinue(CruiseConfig cruiseConfig) {
+        return true;
+    }
+
+    @Override
+    public boolean isUserAuthorized() {
         String groupName = goConfigService.findGroupNameByPipeline(pipelineConfig.name());
         if (goConfigService.groups().hasGroup(groupName) && !goConfigService.isUserAdminOfGroup(currentUser.getUsername(), groupName)) {
             result.forbidden(LocalizedMessage.forbiddenToDelete("Pipeline", pipelineConfig.getName()), HealthStateType.forbidden());

--- a/server/src/main/java/com/thoughtworks/go/config/update/DeletePipelineConfigsCommand.java
+++ b/server/src/main/java/com/thoughtworks/go/config/update/DeletePipelineConfigsCommand.java
@@ -47,6 +47,11 @@ public class DeletePipelineConfigsCommand extends PipelineConfigsCommand {
 
     @Override
     public boolean canContinue(CruiseConfig cruiseConfig) {
+        return true;
+    }
+
+    @Override
+    public boolean isUserAuthorized() {
         return isUserAdminOfGroup(group.getGroup());
     }
 }

--- a/server/src/main/java/com/thoughtworks/go/config/update/DeleteTemplateConfigCommand.java
+++ b/server/src/main/java/com/thoughtworks/go/config/update/DeleteTemplateConfigCommand.java
@@ -65,10 +65,11 @@ public class DeleteTemplateConfigCommand extends TemplateConfigCommand {
 
     @Override
     public boolean canContinue(CruiseConfig cruiseConfig) {
-        return doesTemplateExist(cruiseConfig) && isUserAuthorized();
+        return doesTemplateExist(cruiseConfig);
     }
 
-    private boolean isUserAuthorized() {
+    @Override
+    public boolean isUserAuthorized() {
         if (!securityService.isAuthorizedToEditTemplate(templateConfig.name(), currentUser)) {
             result.forbidden(forbiddenToEdit(), forbidden());
             return false;

--- a/server/src/main/java/com/thoughtworks/go/config/update/ElasticAgentProfileCommand.java
+++ b/server/src/main/java/com/thoughtworks/go/config/update/ElasticAgentProfileCommand.java
@@ -40,6 +40,15 @@ public abstract class ElasticAgentProfileCommand extends PluginProfileCommand<El
     }
 
     @Override
+    public final boolean isUserAuthorized() {
+        if (!(goConfigService.isUserAdmin(currentUser) || goConfigService.isGroupAdministrator(currentUser.getUsername()))) {
+            result.forbidden(forbiddenToEdit(), forbidden());
+            return false;
+        }
+        return true;
+    }
+
+    @Override
     protected ElasticProfiles getPluginProfiles(CruiseConfig preprocessedConfig) {
         return preprocessedConfig.getElasticConfig().getProfiles();
     }
@@ -52,13 +61,5 @@ public abstract class ElasticAgentProfileCommand extends PluginProfileCommand<El
     @Override
     protected String getObjectDescriptor() {
         return "Elastic agent profile";
-    }
-
-    protected final boolean isAuthorized() {
-        if (!(goConfigService.isUserAdmin(currentUser) || goConfigService.isGroupAdministrator(currentUser.getUsername()))) {
-            result.forbidden(forbiddenToEdit(), forbidden());
-            return false;
-        }
-        return true;
     }
 }

--- a/server/src/main/java/com/thoughtworks/go/config/update/EnvironmentCommand.java
+++ b/server/src/main/java/com/thoughtworks/go/config/update/EnvironmentCommand.java
@@ -63,6 +63,11 @@ public abstract class EnvironmentCommand implements EntityConfigUpdateCommand<En
 
     @Override
     public boolean canContinue(CruiseConfig cruiseConfig) {
+        return true;
+    }
+
+    @Override
+    public boolean isUserAuthorized() {
         if (!goConfigService.isAdministrator(username.getUsername())) {
             result.forbidden(LocalizedMessage.forbiddenToEditResource("environment", environmentConfig.name(), username.getDisplayName()), HealthStateType.forbidden());
             return false;

--- a/server/src/main/java/com/thoughtworks/go/config/update/PackageConfigCommand.java
+++ b/server/src/main/java/com/thoughtworks/go/config/update/PackageConfigCommand.java
@@ -47,6 +47,15 @@ abstract class PackageConfigCommand implements EntityConfigUpdateCommand<Package
         this.username = username;
     }
 
+    @Override
+    public boolean isUserAuthorized() {
+        if (!(goConfigService.isUserAdmin(username) || goConfigService.isGroupAdministrator(username.getUsername()))) {
+            result.forbidden(forbiddenToEdit(), forbidden());
+            return false;
+        }
+        return true;
+    }
+
     public boolean isValid(CruiseConfig preprocessedConfig, String repositoryId) {
         PackageRepositories packageRepositories = preprocessedConfig.getPackageRepositories();
         PackageRepository repository = packageRepositories.find(repositoryId);
@@ -62,14 +71,6 @@ abstract class PackageConfigCommand implements EntityConfigUpdateCommand<Package
         }
         BasicCruiseConfig.copyErrors(preprocessedPackageDefinition, packageDefinition);
         return false;
-    }
-
-    protected boolean isAuthorized() {
-        if (!(goConfigService.isUserAdmin(username) || goConfigService.isGroupAdministrator(username.getUsername()))) {
-            result.forbidden(forbiddenToEdit(), forbidden());
-            return false;
-        }
-        return true;
     }
 
     @Override

--- a/server/src/main/java/com/thoughtworks/go/config/update/PackageRepositoryCommand.java
+++ b/server/src/main/java/com/thoughtworks/go/config/update/PackageRepositoryCommand.java
@@ -69,10 +69,11 @@ public abstract class PackageRepositoryCommand implements EntityConfigUpdateComm
 
     @Override
     public boolean canContinue(CruiseConfig cruiseConfig) {
-        return isAuthorized();
+        return true;
     }
 
-    private boolean isAuthorized() {
+    @Override
+    public boolean isUserAuthorized() {
         if (!(goConfigService.isUserAdmin(username) || goConfigService.isGroupAdministrator(username.getUsername()))) {
             result.forbidden(forbiddenToEdit(), forbidden());
             return false;

--- a/server/src/main/java/com/thoughtworks/go/config/update/PluginProfileCommand.java
+++ b/server/src/main/java/com/thoughtworks/go/config/update/PluginProfileCommand.java
@@ -62,7 +62,7 @@ public abstract class PluginProfileCommand<T extends PluginProfile, M extends Pl
 
     @Override
     public boolean canContinue(CruiseConfig cruiseConfig) {
-        return isAuthorized();
+        return true;
     }
 
     protected boolean isValidForCreateOrUpdate(CruiseConfig preprocessedConfig) {
@@ -99,7 +99,5 @@ public abstract class PluginProfileCommand<T extends PluginProfile, M extends Pl
     private String getTagName() {
         return profile.getClass().getAnnotation(ConfigTag.class).value();
     }
-
-    protected abstract boolean isAuthorized();
 
 }

--- a/server/src/main/java/com/thoughtworks/go/config/update/RoleConfigCommand.java
+++ b/server/src/main/java/com/thoughtworks/go/config/update/RoleConfigCommand.java
@@ -54,7 +54,7 @@ abstract class RoleConfigCommand implements EntityConfigUpdateCommand<Role> {
 
     @Override
     public boolean canContinue(CruiseConfig cruiseConfig) {
-        return isAuthorized();
+        return isUserAuthorized();
     }
 
     @Override
@@ -73,7 +73,8 @@ abstract class RoleConfigCommand implements EntityConfigUpdateCommand<Role> {
         return cruiseConfig.server().security().getRoles().findByName(role.getName());
     }
 
-    protected final boolean isAuthorized() {
+    @Override
+    public final boolean isUserAuthorized() {
         if (goConfigService.isUserAdmin(currentUser)) {
             return true;
         }

--- a/server/src/main/java/com/thoughtworks/go/config/update/RolesConfigBulkUpdateCommand.java
+++ b/server/src/main/java/com/thoughtworks/go/config/update/RolesConfigBulkUpdateCommand.java
@@ -83,10 +83,11 @@ public class RolesConfigBulkUpdateCommand implements EntityConfigUpdateCommand<R
 
     @Override
     public boolean canContinue(CruiseConfig cruiseConfig) {
-        return isAuthorized();
+        return true;
     }
 
-    private boolean isAuthorized() {
+    @Override
+    public boolean isUserAuthorized() {
         if (goConfigService.isUserAdmin(currentUser)) {
             return true;
         }

--- a/server/src/main/java/com/thoughtworks/go/config/update/SCMConfigCommand.java
+++ b/server/src/main/java/com/thoughtworks/go/config/update/SCMConfigCommand.java
@@ -72,10 +72,11 @@ public abstract class SCMConfigCommand implements EntityConfigUpdateCommand<SCM>
 
     @Override
     public boolean canContinue(CruiseConfig cruiseConfig) {
-        return isAuthorized();
+        return true;
     }
 
-    private boolean isAuthorized() {
+    @Override
+    public boolean isUserAuthorized() {
         if (!(goConfigService.isUserAdmin(currentUser) || goConfigService.isGroupAdministrator(currentUser.getUsername()))) {
             result.forbidden(forbiddenToEdit(), forbidden());
             return false;

--- a/server/src/main/java/com/thoughtworks/go/config/update/SecurityAuthConfigCommand.java
+++ b/server/src/main/java/com/thoughtworks/go/config/update/SecurityAuthConfigCommand.java
@@ -39,6 +39,15 @@ public abstract class SecurityAuthConfigCommand extends PluginProfileCommand<Sec
     }
 
     @Override
+    public final boolean isUserAuthorized() {
+        if (goConfigService.isUserAdmin(currentUser)) {
+            return true;
+        }
+        result.forbidden(forbiddenToEdit(), forbidden());
+        return false;
+    }
+
+    @Override
     protected SecurityAuthConfigs getPluginProfiles(CruiseConfig preprocessedConfig) {
         return preprocessedConfig.server().security().securityAuthConfigs();
     }
@@ -51,14 +60,6 @@ public abstract class SecurityAuthConfigCommand extends PluginProfileCommand<Sec
     @Override
     protected String getObjectDescriptor() {
         return "Security auth config";
-    }
-
-    protected final boolean isAuthorized() {
-        if (goConfigService.isUserAdmin(currentUser)) {
-            return true;
-        }
-        result.forbidden(forbiddenToEdit(), forbidden());
-        return false;
     }
 
 }

--- a/server/src/main/java/com/thoughtworks/go/config/update/UpdatePackageConfigCommand.java
+++ b/server/src/main/java/com/thoughtworks/go/config/update/UpdatePackageConfigCommand.java
@@ -68,7 +68,7 @@ public class UpdatePackageConfigCommand extends PackageConfigCommand {
 
     @Override
     public boolean canContinue(CruiseConfig cruiseConfig) {
-        return isAuthorized() && isRepositoryPresent(cruiseConfig) && isIdSame() && isRequestFresh();
+        return isRepositoryPresent(cruiseConfig) && isIdSame() && isRequestFresh();
     }
 
     private boolean isRepositoryPresent(CruiseConfig cruiseConfig) {

--- a/server/src/main/java/com/thoughtworks/go/config/update/UpdatePipelineConfigCommand.java
+++ b/server/src/main/java/com/thoughtworks/go/config/update/UpdatePipelineConfigCommand.java
@@ -16,7 +16,9 @@
 
 package com.thoughtworks.go.config.update;
 
-import com.thoughtworks.go.config.*;
+import com.thoughtworks.go.config.CruiseConfig;
+import com.thoughtworks.go.config.PipelineConfig;
+import com.thoughtworks.go.config.PipelineConfigSaveValidationContext;
 import com.thoughtworks.go.server.domain.Username;
 import com.thoughtworks.go.server.service.EntityHashingService;
 import com.thoughtworks.go.server.service.ExternalArtifactsService;
@@ -60,7 +62,7 @@ public class UpdatePipelineConfigCommand extends PipelineConfigCommand {
         PipelineConfigSaveValidationContext validationContext = PipelineConfigSaveValidationContext.forChain(false, getPipelineGroup(), preprocessedConfig, preprocessedPipelineConfig);
         validatePublishAndFetchExternalConfigs(preprocessedPipelineConfig, preprocessedConfig);
         boolean isValid = preprocessedPipelineConfig.validateTree(validationContext)
-                          && preprocessedPipelineConfig.getAllErrors().isEmpty();
+                && preprocessedPipelineConfig.getAllErrors().isEmpty();
         if (!isValid) {
             copyErrors(preprocessedPipelineConfig, pipelineConfig);
         }
@@ -69,10 +71,13 @@ public class UpdatePipelineConfigCommand extends PipelineConfigCommand {
 
     @Override
     public boolean canContinue(CruiseConfig cruiseConfig) {
-        return canEditPipeline() && isRequestFresh(cruiseConfig);
+        return isRequestFresh(cruiseConfig);
     }
 
-    private boolean canEditPipeline() {
+    @Override
+    public boolean isUserAuthorized() {
+        //TODO this checks not only authorization, but also if the pipeline exists.
+        //checking pipeline existence should be moved to the validation function
         return goConfigService.canEditPipeline(pipelineConfig.name().toString(), currentUser, result, getPipelineGroup());
     }
 

--- a/server/src/main/java/com/thoughtworks/go/config/update/UpdatePipelineConfigsAuthCommand.java
+++ b/server/src/main/java/com/thoughtworks/go/config/update/UpdatePipelineConfigsAuthCommand.java
@@ -64,7 +64,12 @@ public class UpdatePipelineConfigsAuthCommand extends PipelineConfigsCommand {
 
     @Override
     public boolean canContinue(CruiseConfig cruiseConfig) {
-        return isRequestFresh(cruiseConfig) && isUserAdminOfGroup(group);
+        return isRequestFresh(cruiseConfig);
+    }
+
+    @Override
+    public boolean isUserAuthorized() {
+        return isUserAdminOfGroup(group);
     }
 
     private boolean isRequestFresh(CruiseConfig cruiseConfig) {

--- a/server/src/main/java/com/thoughtworks/go/config/update/UpdateTemplateConfigCommand.java
+++ b/server/src/main/java/com/thoughtworks/go/config/update/UpdateTemplateConfigCommand.java
@@ -66,10 +66,11 @@ public class UpdateTemplateConfigCommand extends TemplateConfigCommand {
 
     @Override
     public boolean canContinue(CruiseConfig cruiseConfig) {
-        return isRequestFresh(cruiseConfig) && isUserAuthorized();
+        return isRequestFresh(cruiseConfig);
     }
 
-    private boolean isUserAuthorized() {
+    @Override
+    public boolean isUserAuthorized() {
         if (!securityService.isAuthorizedToEditTemplate(templateConfig.name(), currentUser)) {
             result.forbidden(forbiddenToEdit(), forbidden());
             return false;
@@ -86,4 +87,3 @@ public class UpdateTemplateConfigCommand extends TemplateConfigCommand {
         return freshRequest;
     }
 }
-

--- a/server/src/test-fast/java/com/thoughtworks/go/config/GoConfigDaoTestBase.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/config/GoConfigDaoTestBase.java
@@ -456,15 +456,14 @@ public abstract class GoConfigDaoTestBase {
         when(cachedConfigService.currentConfig()).thenReturn(cruiseConfig);
         goConfigDao = new GoConfigDao(cachedConfigService);
         EntityConfigUpdateCommand command = mock(EntityConfigUpdateCommand.class);
-        when(command.canContinue(cruiseConfig)).thenReturn(false);
+        when(command.isUserAuthorized()).thenReturn(false);
         try {
             goConfigDao.updateConfig(command, new Username(new CaseInsensitiveString("user")));
             fail("Expected to throw exception of type:" + ConfigUpdateCheckFailedException.class.getName());
         } catch (Exception e) {
             assertTrue(e instanceof ConfigUpdateCheckFailedException);
         }
-        verify(cachedConfigService).currentConfig();
-        verifyNoMoreInteractions(cachedConfigService);
+        verifyZeroInteractions(cachedConfigService);
     }
 
     @Test
@@ -475,6 +474,7 @@ public abstract class GoConfigDaoTestBase {
         EntityConfigUpdateCommand saveCommand = mock(EntityConfigUpdateCommand.class);
         when(saveCommand.isValid(cruiseConfig)).thenReturn(true);
         when(saveCommand.canContinue(cruiseConfig)).thenReturn(true);
+        when(saveCommand.isUserAuthorized()).thenReturn(true);
         goConfigDao = new GoConfigDao(cachedConfigService);
         Username currentUser = new Username(new CaseInsensitiveString("user"));
         goConfigDao.updateConfig(saveCommand, currentUser);

--- a/server/src/test-fast/java/com/thoughtworks/go/config/update/AddEnvironmentCommandTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/config/update/AddEnvironmentCommandTest.java
@@ -109,7 +109,7 @@ public class AddEnvironmentCommandTest {
         HttpLocalizedOperationResult expectedResult = new HttpLocalizedOperationResult();
         expectedResult.forbidden("Failed to access environment 'Dev'. User 'user' does not have permission to access environment.", HealthStateType.forbidden());
 
-        assertThat(command.canContinue(cruiseConfig), is(false));
+        assertThat(command.isUserAuthorized(), is(false));
         assertThat(result, is(expectedResult));
     }
 

--- a/server/src/test-fast/java/com/thoughtworks/go/config/update/AdminsConfigUpdateCommandTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/config/update/AdminsConfigUpdateCommandTest.java
@@ -76,7 +76,7 @@ public class AdminsConfigUpdateCommandTest {
 
         AdminsConfigUpdateCommand command = new AdminsConfigUpdateCommand(goConfigService, new AdminsConfig(), currentUser, result, entityHashingService, null);
 
-        assertFalse(command.canContinue(cruiseConfig));
+        assertFalse(command.isUserAuthorized());
         assertThat(result.httpCode(), is(403));
     }
 

--- a/server/src/test-fast/java/com/thoughtworks/go/config/update/AgentsEntityConfigUpdateCommandTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/config/update/AgentsEntityConfigUpdateCommandTest.java
@@ -112,7 +112,7 @@ public class AgentsEntityConfigUpdateCommandTest {
         AgentsEntityConfigUpdateCommand command = new AgentsEntityConfigUpdateCommand(agentInstances, currentUser, result, uuids, environmentsToAdd,
                 environmentsToRemove, triState, resourcesToAdd, resourcesToRemove, goConfigService);
         when(goConfigService.isAdministrator(currentUser.getUsername())).thenReturn(false);
-        assertFalse(command.canContinue(cruiseConfig));
+        assertFalse(command.isUserAuthorized());
         HttpLocalizedOperationResult expectedResult = new HttpLocalizedOperationResult();
         expectedResult.forbidden(forbiddenToEdit(), forbidden());
         assertThat(result, is(expectedResult));

--- a/server/src/test-fast/java/com/thoughtworks/go/config/update/ArtifactStoreConfigCommandTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/config/update/ArtifactStoreConfigCommandTest.java
@@ -31,10 +31,7 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
-import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
-
-import java.util.Map;
 
 import static org.junit.Assert.assertThat;
 import static org.hamcrest.Matchers.*;
@@ -71,7 +68,7 @@ public class ArtifactStoreConfigCommandTest {
         HttpLocalizedOperationResult result = new HttpLocalizedOperationResult();
         StubCommand command = new StubCommand(goConfigService, artifactStore, extension, currentUser, result);
 
-        assertThat(command.canContinue(cruiseConfig), is(false));
+        assertThat(command.isUserAuthorized(), is(false));
         assertThat(result.message(), is("Unauthorized to edit."));
     }
 
@@ -96,7 +93,7 @@ public class ArtifactStoreConfigCommandTest {
         HttpLocalizedOperationResult result = new HttpLocalizedOperationResult();
         StubCommand command = new StubCommand(goConfigService, artifactStore, extension, currentUser, result);
 
-        assertThat(command.canContinue(cruiseConfig), is(false));
+        assertThat(command.isUserAuthorized(), is(false));
         assertThat(result.message(), is("Unauthorized to edit."));
     }
 
@@ -146,7 +143,7 @@ public class ArtifactStoreConfigCommandTest {
         StubCommand command = new StubCommand(goConfigService, artifactStore, extension, currentUser, result);
         assertThat(cruiseConfig.getArtifactStores().find("docker"), nullValue());
 
-        assertThat(command.canContinue(cruiseConfig), is(false));
+        assertThat(command.isUserAuthorized(), is(false));
     }
 
     @Test

--- a/server/src/test-fast/java/com/thoughtworks/go/config/update/CreateConfigRepoCommandTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/config/update/CreateConfigRepoCommandTest.java
@@ -76,7 +76,7 @@ public class CreateConfigRepoCommandTest {
         HttpLocalizedOperationResult expectedResult = new HttpLocalizedOperationResult();
         expectedResult.forbidden(forbiddenToEdit(), forbidden());
 
-        assertThat(command.canContinue(cruiseConfig), is(false));
+        assertThat(command.isUserAuthorized(), is(false));
         assertThat(result, is(expectedResult));
     }
 

--- a/server/src/test-fast/java/com/thoughtworks/go/config/update/CreatePackageRepositoryCommandTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/config/update/CreatePackageRepositoryCommandTest.java
@@ -115,7 +115,7 @@ public class CreatePackageRepositoryCommandTest {
         HttpLocalizedOperationResult expectedResult = new HttpLocalizedOperationResult();
         expectedResult.forbidden(forbiddenToEdit(), forbidden());
 
-        assertThat(command.canContinue(cruiseConfig), is(false));
+        assertThat(command.isUserAuthorized(), is(false));
         assertThat(result, is(expectedResult));
     }
 

--- a/server/src/test-fast/java/com/thoughtworks/go/config/update/CreatePipelineConfigCommandTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/config/update/CreatePipelineConfigCommandTest.java
@@ -74,7 +74,7 @@ public class CreatePipelineConfigCommandTest {
         when(mock.hasGroup("group1")).thenReturn(true);
         when(goConfigService.isUserAdminOfGroup(username.getUsername(), "group1")).thenReturn(false);
 
-        assertFalse(command.canContinue(mock(CruiseConfig.class)));
+        assertFalse(command.isUserAuthorized());
     }
 
     @Test

--- a/server/src/test-fast/java/com/thoughtworks/go/config/update/CreatePipelineConfigsCommandTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/config/update/CreatePipelineConfigsCommandTest.java
@@ -159,7 +159,7 @@ public class CreatePipelineConfigsCommandTest {
         HttpLocalizedOperationResult result = new HttpLocalizedOperationResult();
         CreatePipelineConfigsCommand command = new CreatePipelineConfigsCommand(newPipelineConfigs, user, result, securityService);
 
-        assertFalse(command.canContinue(cruiseConfig));
+        assertFalse(command.isUserAuthorized());
         assertThat(result.httpCode(), is(HttpStatus.SC_FORBIDDEN));
     }
 }

--- a/server/src/test-fast/java/com/thoughtworks/go/config/update/CreateSCMConfigCommandTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/config/update/CreateSCMConfigCommandTest.java
@@ -76,7 +76,7 @@ public class CreateSCMConfigCommandTest {
 
         CreateSCMConfigCommand command = new CreateSCMConfigCommand(scm, pluggableScmService, result, currentUser, goConfigService);
 
-        assertThat(command.canContinue(cruiseConfig), is(false));
+        assertThat(command.isUserAuthorized(), is(false));
     }
 
     @Test

--- a/server/src/test-fast/java/com/thoughtworks/go/config/update/CreateTemplateConfigCommandTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/config/update/CreateTemplateConfigCommandTest.java
@@ -17,7 +17,6 @@
 package com.thoughtworks.go.config.update;
 
 import com.thoughtworks.go.config.*;
-import com.thoughtworks.go.domain.ConfigErrors;
 import com.thoughtworks.go.helper.*;
 import com.thoughtworks.go.server.domain.Username;
 import com.thoughtworks.go.server.service.ExternalArtifactsService;
@@ -99,7 +98,7 @@ public class CreateTemplateConfigCommandTest {
 
         CreateTemplateConfigCommand command = new CreateTemplateConfigCommand(pipelineTemplateConfig, currentUser, securityService, result, externalArtifactsService);
 
-        assertThat(command.canContinue(cruiseConfig), is(false));
+        assertThat(command.isUserAuthorized(), is(false));
         assertThat(result.message(), equalTo("Unauthorized to edit."));
     }
 

--- a/server/src/test-fast/java/com/thoughtworks/go/config/update/DeleteConfigRepoCommandTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/config/update/DeleteConfigRepoCommandTest.java
@@ -71,7 +71,7 @@ public class DeleteConfigRepoCommandTest {
     public void shouldNotContinueIfTheUserDontHavePermissionsToOperateOnConfigRepos() throws Exception {
         DeleteConfigRepoCommand command = new DeleteConfigRepoCommand(securityService, repoId, currentUser, result);
         when(goConfigService.isUserAdmin(currentUser)).thenReturn(false);
-        assertThat(command.canContinue(cruiseConfig), is(false));
+        assertThat(command.isUserAuthorized(), is(false));
         assertFalse(result.isSuccessful());
         assertThat(result.httpCode(), is(403));
         assertThat(result.message(), equalTo("Unauthorized to edit."));

--- a/server/src/test-fast/java/com/thoughtworks/go/config/update/DeleteEnvironmentCommandTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/config/update/DeleteEnvironmentCommandTest.java
@@ -68,7 +68,7 @@ public class DeleteEnvironmentCommandTest {
     public void shouldNotContinueIfTheUserDoesNotHavePermissionsToOperateOnEnvironments() throws Exception {
         DeleteEnvironmentCommand command = new DeleteEnvironmentCommand(goConfigService, environmentConfig, currentUser, actionFailed, result);
         when(goConfigService.isUserAdmin(currentUser)).thenReturn(false);
-        assertThat(command.canContinue(cruiseConfig), is(false));
+        assertThat(command.isUserAuthorized(), is(false));
         assertFalse(result.isSuccessful());
         assertThat(result.httpCode(), is(403));
         assertThat(result.message(), containsString("Failed to access environment 'Dev'. User 'user' does not have permission to access environment."));

--- a/server/src/test-fast/java/com/thoughtworks/go/config/update/DeletePackageConfigCommandTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/config/update/DeletePackageConfigCommandTest.java
@@ -116,7 +116,7 @@ public class DeletePackageConfigCommandTest {
     public void shouldNotContinueIfTheUserDontHavePermissionsToOperateOnPackages() throws Exception {
         DeletePackageConfigCommand command = new DeletePackageConfigCommand(goConfigService, packageDefinition, currentUser, result);
         when(goConfigService.isUserAdmin(currentUser)).thenReturn(false);
-        assertThat(command.canContinue(cruiseConfig), is(false));
+        assertThat(command.isUserAuthorized(), is(false));
 
         HttpLocalizedOperationResult expectedResult = new HttpLocalizedOperationResult();
         expectedResult.forbidden(forbiddenToEdit(), forbidden());

--- a/server/src/test-fast/java/com/thoughtworks/go/config/update/DeletePackageRepositoryCommandTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/config/update/DeletePackageRepositoryCommandTest.java
@@ -95,7 +95,7 @@ public class DeletePackageRepositoryCommandTest {
         when(goConfigService.isUserAdmin(currentUser)).thenReturn(false);
         DeletePackageRepositoryCommand command = new DeletePackageRepositoryCommand(goConfigService, packageRepository, currentUser, result);
 
-        assertFalse(command.canContinue(cruiseConfig));
+        assertFalse(command.isUserAuthorized());
         assertThat(result, is(expectedResult));
     }
 

--- a/server/src/test-fast/java/com/thoughtworks/go/config/update/DeletePipelineConfigsCommandTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/config/update/DeletePipelineConfigsCommandTest.java
@@ -98,7 +98,7 @@ public class DeletePipelineConfigsCommandTest {
         HttpLocalizedOperationResult result = new HttpLocalizedOperationResult();
         DeletePipelineConfigsCommand command = new DeletePipelineConfigsCommand(pipelineConfigs, result, user, securityService);
 
-        assertFalse(command.canContinue(cruiseConfig));
+        assertFalse(command.isUserAuthorized());
         assertThat(result.httpCode(), is(HttpStatus.SC_FORBIDDEN));
     }
 }

--- a/server/src/test-fast/java/com/thoughtworks/go/config/update/DeleteTemplateConfigCommandTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/config/update/DeleteTemplateConfigCommandTest.java
@@ -89,7 +89,7 @@ public class DeleteTemplateConfigCommandTest {
 
         DeleteTemplateConfigCommand command = new DeleteTemplateConfigCommand(pipelineTemplateConfig, result, securityService, currentUser, externalArtifactsService);
 
-        assertThat(command.canContinue(cruiseConfig), is(false));
+        assertThat(command.isUserAuthorized(), is(false));
         assertThat(result.message(), equalTo("Unauthorized to edit."));
     }
 

--- a/server/src/test-fast/java/com/thoughtworks/go/config/update/PatchEnvironmentCommandTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/config/update/PatchEnvironmentCommandTest.java
@@ -334,7 +334,7 @@ public class PatchEnvironmentCommandTest {
     public void shouldNotContinueIfTheUserDontHavePermissionsToOperateOnEnvironments() throws Exception {
         PatchEnvironmentCommand command = new PatchEnvironmentCommand(goConfigService, environmentConfig, pipelinesToAdd, pipelinesToRemove, agentsToAdd, agentsToRemove, envVarsToAdd, envVarsToRemove, currentUser, actionFailed, result);
         when(goConfigService.isAdministrator(currentUser.getUsername())).thenReturn(false);
-        assertThat(command.canContinue(cruiseConfig), is(false));
+        assertThat(command.isUserAuthorized(), is(false));
         HttpLocalizedOperationResult expectResult = new HttpLocalizedOperationResult();
         expectResult.forbidden("Failed to access environment 'Dev'. User 'user' does not have permission to access environment.", HealthStateType.forbidden());
         assertThat(result, is(expectResult));

--- a/server/src/test-fast/java/com/thoughtworks/go/config/update/PluginProfileCommandTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/config/update/PluginProfileCommandTest.java
@@ -67,7 +67,7 @@ public class PluginProfileCommandTest {
         PluginProfileCommand command = new StubSecurityAuthConfigCommand(goConfigService, securityAuthConfig, currentUser, result);
         assertThat(cruiseConfig.server().security().securityAuthConfigs().find("foo"), nullValue());
 
-        assertThat(command.canContinue(cruiseConfig), is(false));
+        assertThat(command.isUserAuthorized(), is(false));
         assertThat(result.message(), equalTo("Unauthorized to edit."));
     }
 
@@ -139,7 +139,8 @@ public class PluginProfileCommandTest {
             return "some foo object";
         }
 
-        protected final boolean isAuthorized() {
+        @Override
+        public final boolean isUserAuthorized() {
             if (goConfigService.isUserAdmin(currentUser)) {
                 return true;
             }

--- a/server/src/test-fast/java/com/thoughtworks/go/config/update/RolesConfigBulkUpdateCommandTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/config/update/RolesConfigBulkUpdateCommandTest.java
@@ -20,7 +20,6 @@ import com.thoughtworks.go.config.*;
 import com.thoughtworks.go.config.exceptions.NoSuchRoleException;
 import com.thoughtworks.go.helper.GoConfigMother;
 import com.thoughtworks.go.server.domain.Username;
-import com.thoughtworks.go.server.service.EntityHashingService;
 import com.thoughtworks.go.server.service.GoConfigService;
 import com.thoughtworks.go.server.service.result.HttpLocalizedOperationResult;
 import org.junit.Before;
@@ -36,7 +35,6 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertFalse;
-import static org.mockito.ArgumentMatchers.refEq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -89,7 +87,7 @@ public class RolesConfigBulkUpdateCommandTest {
         GoCDRolesBulkUpdateRequest request = new GoCDRolesBulkUpdateRequest(Collections.emptyList());
         RolesConfigBulkUpdateCommand command = new RolesConfigBulkUpdateCommand(request, viewUser, goConfigService, result);
 
-        assertFalse(command.canContinue(null));
+        assertFalse(command.isUserAuthorized());
         assertFalse(result.isSuccessful());
         assertThat(result.httpCode(), is(403));
     }

--- a/server/src/test-fast/java/com/thoughtworks/go/config/update/SecurityAuthConfigCommandTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/config/update/SecurityAuthConfigCommandTest.java
@@ -32,12 +32,9 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.mockito.ArgumentMatchers;
 
-import java.util.Map;
-
 import static org.junit.Assert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.ArgumentMatchers.anyMapOf;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -69,7 +66,7 @@ public class SecurityAuthConfigCommandTest {
         SecurityAuthConfigCommand command = new SecurityAuthConfigCommandTest.StubCommand(goConfigService, securityAuthConfig, extension, currentUser, result);
         assertThat(cruiseConfig.server().security().securityAuthConfigs().find("foo"), nullValue());
 
-        assertThat(command.canContinue(cruiseConfig), is(false));
+        assertThat(command.isUserAuthorized(), is(false));
         assertThat(result.message(), equalTo("Unauthorized to edit."));
     }
 
@@ -96,7 +93,7 @@ public class SecurityAuthConfigCommandTest {
         SecurityAuthConfigCommand command = new SecurityAuthConfigCommandTest.StubCommand(goConfigService, securityAuthConfig, extension, currentUser, result);
         assertThat(cruiseConfig.server().security().securityAuthConfigs().find("foo"), nullValue());
 
-        assertThat(command.canContinue(cruiseConfig), is(false));
+        assertThat(command.isUserAuthorized(), is(false));
         assertThat(result.message(), equalTo("Unauthorized to edit."));
     }
 
@@ -146,7 +143,7 @@ public class SecurityAuthConfigCommandTest {
         SecurityAuthConfigCommand command = new SecurityAuthConfigCommandTest.StubCommand(goConfigService, securityAuthConfig, extension, currentUser, result);
         assertThat(cruiseConfig.server().security().securityAuthConfigs().find("ldap"), nullValue());
 
-        assertThat(command.canContinue(cruiseConfig), is(false));
+        assertThat(command.isUserAuthorized(), is(false));
     }
 
     private class StubCommand extends SecurityAuthConfigCommand {

--- a/server/src/test-fast/java/com/thoughtworks/go/config/update/UpdateConfigRepoCommandTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/config/update/UpdateConfigRepoCommandTest.java
@@ -90,7 +90,7 @@ public class UpdateConfigRepoCommandTest {
         HttpLocalizedOperationResult expectedResult = new HttpLocalizedOperationResult();
         expectedResult.forbidden(forbiddenToEdit(), forbidden());
 
-        assertThat(command.canContinue(cruiseConfig), is(false));
+        assertThat(command.isUserAuthorized(), is(false));
         assertThat(result, is(expectedResult));
     }
 

--- a/server/src/test-fast/java/com/thoughtworks/go/config/update/UpdateEnvironmentCommandTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/config/update/UpdateEnvironmentCommandTest.java
@@ -121,7 +121,7 @@ public class UpdateEnvironmentCommandTest {
     public void shouldNotContinueIfTheUserDontHavePermissionsToOperateOnEnvironments() throws Exception {
         UpdateEnvironmentCommand command = new UpdateEnvironmentCommand(goConfigService, oldEnvironmentConfig.name().toString(), newEnvironmentConfig, currentUser, actionFailed, md5, entityHashingService, result);
         when(goConfigService.isAdministrator(currentUser.getUsername())).thenReturn(false);
-        assertThat(command.canContinue(cruiseConfig), is(false));
+        assertThat(command.isUserAuthorized(), is(false));
         HttpLocalizedOperationResult expectResult = new HttpLocalizedOperationResult();
         expectResult.forbidden("Failed to access environment 'Test'. User 'user' does not have permission to access environment.", HealthStateType.forbidden());
 

--- a/server/src/test-fast/java/com/thoughtworks/go/config/update/UpdatePackageConfigCommandTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/config/update/UpdatePackageConfigCommandTest.java
@@ -100,7 +100,7 @@ public class UpdatePackageConfigCommandTest {
         HttpLocalizedOperationResult expectedResult = new HttpLocalizedOperationResult();
         expectedResult.forbidden(forbiddenToEdit(), forbidden());
 
-        assertThat(command.canContinue(cruiseConfig), is(false));
+        assertThat(command.isUserAuthorized(), is(false));
         assertThat(result, is(expectedResult));
     }
 

--- a/server/src/test-fast/java/com/thoughtworks/go/config/update/UpdatePackageRepositoryCommandTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/config/update/UpdatePackageRepositoryCommandTest.java
@@ -153,7 +153,7 @@ public class UpdatePackageRepositoryCommandTest {
         HttpLocalizedOperationResult expectedResult = new HttpLocalizedOperationResult();
         expectedResult.forbidden(forbiddenToEdit(), forbidden());
 
-        assertThat(command.canContinue(cruiseConfig), is(false));
+        assertThat(command.isUserAuthorized(), is(false));
         assertThat(result, is(expectedResult));
     }
 

--- a/server/src/test-fast/java/com/thoughtworks/go/config/update/UpdatePipelineConfigCommandTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/config/update/UpdatePipelineConfigCommandTest.java
@@ -71,7 +71,7 @@ public class UpdatePipelineConfigCommandTest {
 
         when(goConfigService.findGroupNameByPipeline(pipelineConfig.name())).thenReturn("group1");
         when(goConfigService.canEditPipeline(pipelineConfig.name().toString(),username,localizedOperationResult,"group1")).thenReturn(false);
-        assertFalse(command.canContinue(mock(CruiseConfig.class)));
+        assertFalse(command.isUserAuthorized());
     }
 
     @Test

--- a/server/src/test-fast/java/com/thoughtworks/go/config/update/UpdatePipelineConfigsAuthConfigCommandTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/config/update/UpdatePipelineConfigsAuthConfigCommandTest.java
@@ -20,10 +20,8 @@ import com.thoughtworks.go.config.*;
 import com.thoughtworks.go.config.exceptions.PipelineGroupNotFoundException;
 import com.thoughtworks.go.domain.PipelineGroups;
 import com.thoughtworks.go.helper.GoConfigMother;
-import com.thoughtworks.go.helper.StageConfigMother;
 import com.thoughtworks.go.server.domain.Username;
 import com.thoughtworks.go.server.service.EntityHashingService;
-import com.thoughtworks.go.server.service.ExternalArtifactsService;
 import com.thoughtworks.go.server.service.SecurityService;
 import com.thoughtworks.go.server.service.result.HttpLocalizedOperationResult;
 import org.apache.http.HttpStatus;
@@ -171,7 +169,7 @@ public class UpdatePipelineConfigsAuthConfigCommandTest {
         HttpLocalizedOperationResult result = new HttpLocalizedOperationResult();
         UpdatePipelineConfigsAuthCommand command = new UpdatePipelineConfigsAuthCommand("group", newAuthorization, result, user, "md5", entityHashingService, securityService);
 
-        assertFalse(command.canContinue(cruiseConfig));
+        assertFalse(command.isUserAuthorized());
         assertThat(result.httpCode(), is(HttpStatus.SC_FORBIDDEN));
     }
 }

--- a/server/src/test-fast/java/com/thoughtworks/go/config/update/UpdateSCMConfigCommandTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/config/update/UpdateSCMConfigCommandTest.java
@@ -104,7 +104,7 @@ public class UpdateSCMConfigCommandTest {
         SCM updatedScm = new SCM("id", new PluginConfiguration("plugin-id", "1"), new Configuration(new ConfigurationProperty(new ConfigurationKey("key1"),new ConfigurationValue("value1"))));
         UpdateSCMConfigCommand command = new UpdateSCMConfigCommand(updatedScm, pluggableScmService, goConfigService, currentUser, result, "md5", entityHashingService);
 
-        assertThat(command.canContinue(cruiseConfig), is(false));
+        assertThat(command.isUserAuthorized(), is(false));
         assertThat(result.message(), equalTo("Unauthorized to edit."));
     }
 

--- a/server/src/test-fast/java/com/thoughtworks/go/config/update/UpdateTemplateConfigCommandTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/config/update/UpdateTemplateConfigCommandTest.java
@@ -148,7 +148,7 @@ public class UpdateTemplateConfigCommandTest {
 
         UpdateTemplateConfigCommand command = new UpdateTemplateConfigCommand(pipelineTemplateConfig, currentUser, securityService, result, "md5", entityHashingService, externalArtifactsService);
 
-        assertThat(command.canContinue(cruiseConfig), is(false));
+        assertThat(command.isUserAuthorized(), is(false));
         assertThat(result.message(), equalTo("Unauthorized to edit."));
     }
 


### PR DESCRIPTION
Related to #2780 

Just pulling out `isUserAuthorized` into its own function. This will be followed by a clean up of `canContinue` and the validation functions in subsequent PRs.