### PR TITLE
Implement the `get-icon` call for config repo plugins.

### DIFF
--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/configrepo/ConfigRepoExtension.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/configrepo/ConfigRepoExtension.java
@@ -28,6 +28,7 @@ import com.thoughtworks.go.plugin.configrepo.codec.GsonCodec;
 import com.thoughtworks.go.plugin.configrepo.contract.CRConfigurationProperty;
 import com.thoughtworks.go.plugin.configrepo.contract.CRParseResult;
 import com.thoughtworks.go.plugin.configrepo.contract.CRPipeline;
+import com.thoughtworks.go.plugin.domain.common.Image;
 import com.thoughtworks.go.plugin.domain.configrepo.Capabilities;
 import com.thoughtworks.go.plugin.infra.PluginManager;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -43,6 +44,7 @@ import static java.util.Arrays.asList;
 
 @Component
 public class ConfigRepoExtension extends AbstractExtension implements ConfigRepoExtensionContract {
+    public static final String REQUEST_GET_PLUGIN_ICON = "get-icon";
     public static final String REQUEST_PARSE_DIRECTORY = "parse-directory";
     public static final String REQUEST_PARSE_CONTENT = "parse-content";
     public static final String REQUEST_PIPELINE_EXPORT = "pipeline-export";
@@ -151,5 +153,14 @@ public class ConfigRepoExtension extends AbstractExtension implements ConfigRepo
     @Override
     protected List<String> goSupportedVersions() {
         return goSupportedVersions;
+    }
+
+    public Image getIcon(String pluginId) {
+        return pluginRequestHelper.submitRequest(pluginId, REQUEST_GET_PLUGIN_ICON, new DefaultPluginInteractionCallback<com.thoughtworks.go.plugin.domain.common.Image>() {
+            @Override
+            public com.thoughtworks.go.plugin.domain.common.Image onSuccess(String responseBody, Map<String, String> responseHeaders, String resolvedExtensionVersion) {
+                return messageHandlerMap.get(resolvedExtensionVersion).getImageResponseFromBody(responseBody);
+            }
+        });
     }
 }

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/configrepo/ConfigRepoPluginInfoBuilder.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/configrepo/ConfigRepoPluginInfoBuilder.java
@@ -34,8 +34,12 @@ public class ConfigRepoPluginInfoBuilder implements PluginInfoBuilder<ConfigRepo
 
     public ConfigRepoPluginInfo pluginInfoFor(GoPluginDescriptor descriptor) {
         PluggableInstanceSettings pluggableInstanceSettings = getPluginSettingsAndView(descriptor, extension);
-        return new ConfigRepoPluginInfo(descriptor, pluggableInstanceSettings);
+
+        return new ConfigRepoPluginInfo(descriptor, image(descriptor.id()), pluggableInstanceSettings);
+    }
+
+    private com.thoughtworks.go.plugin.domain.common.Image image(String pluginId) {
+        return extension.getIcon(pluginId);
     }
 
 }
-

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/configrepo/JsonMessageHandler.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/configrepo/JsonMessageHandler.java
@@ -18,6 +18,7 @@ package com.thoughtworks.go.plugin.access.configrepo;
 import com.thoughtworks.go.plugin.configrepo.contract.CRConfigurationProperty;
 import com.thoughtworks.go.plugin.configrepo.contract.CRParseResult;
 import com.thoughtworks.go.plugin.configrepo.contract.CRPipeline;
+import com.thoughtworks.go.plugin.domain.common.Image;
 import com.thoughtworks.go.plugin.domain.configrepo.Capabilities;
 
 import java.util.Collection;
@@ -37,4 +38,6 @@ public interface JsonMessageHandler {
     ExportedConfig responseMessageForPipelineExport(String responseBody, Map<String, String> headers);
 
     Capabilities getCapabilitiesFromResponse(String responseBody);
+
+    Image getImageResponseFromBody(String responseBody);
 }

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/configrepo/v1/JsonMessageHandler1_0.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/configrepo/v1/JsonMessageHandler1_0.java
@@ -28,6 +28,7 @@ import com.thoughtworks.go.plugin.configrepo.contract.CRConfigurationProperty;
 import com.thoughtworks.go.plugin.configrepo.contract.CRParseResult;
 import com.thoughtworks.go.plugin.configrepo.contract.CRPipeline;
 import com.thoughtworks.go.plugin.configrepo.contract.ErrorCollection;
+import com.thoughtworks.go.plugin.domain.common.Image;
 import com.thoughtworks.go.plugin.domain.configrepo.Capabilities;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -72,6 +73,11 @@ public class JsonMessageHandler1_0 implements JsonMessageHandler {
 
     @Override
     public Capabilities getCapabilitiesFromResponse(String responseBody) {
+        return null;
+    }
+
+    @Override
+    public Image getImageResponseFromBody(String responseBody) {
         return null;
     }
 

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/configrepo/v2/JsonMessageHandler2_0.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/configrepo/v2/JsonMessageHandler2_0.java
@@ -17,6 +17,7 @@
 package com.thoughtworks.go.plugin.access.configrepo.v2;
 
 import com.google.gson.GsonBuilder;
+import com.thoughtworks.go.plugin.access.common.models.ImageDeserializer;
 import com.thoughtworks.go.plugin.access.configrepo.ConfigRepoMigrator;
 import com.thoughtworks.go.plugin.access.configrepo.ExportedConfig;
 import com.thoughtworks.go.plugin.access.configrepo.JsonMessageHandler;
@@ -29,6 +30,7 @@ import com.thoughtworks.go.plugin.configrepo.contract.CRConfigurationProperty;
 import com.thoughtworks.go.plugin.configrepo.contract.CRParseResult;
 import com.thoughtworks.go.plugin.configrepo.contract.CRPipeline;
 import com.thoughtworks.go.plugin.configrepo.contract.ErrorCollection;
+import com.thoughtworks.go.plugin.domain.common.Image;
 import com.thoughtworks.go.plugin.domain.configrepo.Capabilities;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -51,6 +53,11 @@ public class JsonMessageHandler2_0 implements JsonMessageHandler {
     @Override
     public Capabilities getCapabilitiesFromResponse(String responseBody) {
         return com.thoughtworks.go.plugin.access.configrepo.v2.models.Capabilities.fromJSON(responseBody).toCapabilities();
+    }
+
+    @Override
+    public Image getImageResponseFromBody(String responseBody) {
+        return new ImageDeserializer().fromJSON(responseBody);
     }
 
     @Override

--- a/plugin-infra/go-plugin-domain/src/main/java/com/thoughtworks/go/plugin/domain/configrepo/ConfigRepoPluginInfo.java
+++ b/plugin-infra/go-plugin-domain/src/main/java/com/thoughtworks/go/plugin/domain/configrepo/ConfigRepoPluginInfo.java
@@ -17,14 +17,15 @@
 package com.thoughtworks.go.plugin.domain.configrepo;
 
 import com.thoughtworks.go.plugin.api.info.PluginDescriptor;
+import com.thoughtworks.go.plugin.domain.common.Image;
 import com.thoughtworks.go.plugin.domain.common.PluggableInstanceSettings;
 import com.thoughtworks.go.plugin.domain.common.PluginConstants;
 import com.thoughtworks.go.plugin.domain.common.PluginInfo;
 
 public class ConfigRepoPluginInfo extends PluginInfo {
 
-    public ConfigRepoPluginInfo(PluginDescriptor descriptor, PluggableInstanceSettings pluginSettings) {
-        super(descriptor, PluginConstants.CONFIG_REPO_EXTENSION, pluginSettings, null);
+    public ConfigRepoPluginInfo(PluginDescriptor descriptor, Image image, PluggableInstanceSettings pluginSettings) {
+        super(descriptor, PluginConstants.CONFIG_REPO_EXTENSION, pluginSettings, image);
     }
 
 }

--- a/server/src/test-fast/java/com/thoughtworks/go/server/domain/PluginSettingsTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/domain/PluginSettingsTest.java
@@ -102,7 +102,7 @@ public class PluginSettingsTest {
         ArrayList<PluginConfiguration> pluginConfigurations = new ArrayList<>();
         pluginConfigurations.add(new PluginConfiguration("k1", new Metadata(true, false)));
         pluginConfigurations.add(new PluginConfiguration("k2", new Metadata(true, true)));
-        ConfigRepoPluginInfo pluginInfo = new ConfigRepoPluginInfo(null, new PluggableInstanceSettings(pluginConfigurations));
+        ConfigRepoPluginInfo pluginInfo = new ConfigRepoPluginInfo(null, null, new PluggableInstanceSettings(pluginConfigurations));
 
         ArrayList<ConfigurationProperty> configurationProperties = new ArrayList<>();
         configurationProperties.add(new ConfigurationProperty(new ConfigurationKey("k1"), new ConfigurationValue("v1")));
@@ -122,7 +122,7 @@ public class PluginSettingsTest {
         ArrayList<PluginConfiguration> pluginConfigurations = new ArrayList<>();
         pluginConfigurations.add(new PluginConfiguration("k1", new Metadata(true, false)));
         pluginConfigurations.add(new PluginConfiguration("k2", new Metadata(true, true)));
-        ConfigRepoPluginInfo pluginInfo = new ConfigRepoPluginInfo(null, new PluggableInstanceSettings(pluginConfigurations));
+        ConfigRepoPluginInfo pluginInfo = new ConfigRepoPluginInfo(null, null, new PluggableInstanceSettings(pluginConfigurations));
 
         ConfigurationProperty configProperty1 = new ConfigurationProperty(new ConfigurationKey("k1"), new ConfigurationValue("v1"));
         ConfigurationProperty configProperty2 = new ConfigurationProperty(new ConfigurationKey("k2"), new EncryptedConfigurationValue(new GoCipher().encrypt("v2")));


### PR DESCRIPTION
This is identical to the elastic agent plugin, except the request name.