### PR TITLE
Close the modal when clicking on the overlay outside it

### DIFF
--- a/server/webapp/WEB-INF/rails/webpack/views/components/modal/modal_manager.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/components/modal/modal_manager.tsx
@@ -44,7 +44,10 @@ export namespace ModalManager {
       view() {
         return (
           _.map(allModals, (entry) => {
-            return <div key={entry.key} data-test-id={entry.key} class={styles.overlayBg}>{m(entry.value)}</div>;
+            return <div key={entry.key}
+                        data-test-id={entry.key}
+                        class={styles.overlayBg}
+                        onclick={(event) => overlayBackgroundClicked(event, entry.value)}>{m(entry.value)}</div>;
           })
         );
       }
@@ -56,14 +59,12 @@ export namespace ModalManager {
     allModals.push({key: modal.id, value: modal});
     document.body.classList.add(styles.fixed);
     m.redraw();
-    addOutsideClickListener(modal);
   }
 
   export function close(modal: Modal) {
     _.remove(allModals, (entry) => entry.key === modal.id);
     document.body.classList.remove(styles.fixed);
     m.redraw();
-    removeOutsideClickListener(modal);
   }
 
   export function closeAll() {
@@ -72,20 +73,10 @@ export namespace ModalManager {
     });
   }
 
-  function overlayBackgroundClicked(modal: Modal) {
-    return (event: Event) => {
-      const overlayBg = document.getElementsByClassName(styles.overlayBg).item(0);
-      if (event.target === overlayBg) {
-        modal.close();
-      }
-    };
-  }
-
-  function addOutsideClickListener(modal: Modal) {
-    modalContainer.addEventListener("click", overlayBackgroundClicked(modal));
-  }
-
-  function removeOutsideClickListener(modal: Modal) {
-    modalContainer.removeEventListener("click", overlayBackgroundClicked(modal));
+  function overlayBackgroundClicked(event: Event, modal: Modal) {
+    const overlayBg = document.getElementsByClassName(styles.overlayBg).item(0);
+    if (event.target === overlayBg) {
+      modal.close();
+    }
   }
 }

--- a/server/webapp/WEB-INF/rails/webpack/views/components/modal/modal_manager.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/components/modal/modal_manager.tsx
@@ -56,17 +56,36 @@ export namespace ModalManager {
     allModals.push({key: modal.id, value: modal});
     document.body.classList.add(styles.fixed);
     m.redraw();
+    addOutsideClickListener(modal);
   }
 
   export function close(modal: Modal) {
     _.remove(allModals, (entry) => entry.key === modal.id);
     document.body.classList.remove(styles.fixed);
     m.redraw();
+    removeOutsideClickListener(modal);
   }
 
   export function closeAll() {
     _.forEach(allModals, (m: ModalEntry) => {
       ModalManager.close(m.value);
     });
+  }
+
+  function overlayBackgroundClicked(modal: Modal) {
+    return (event: Event) => {
+      const overlayBg = document.getElementsByClassName(styles.overlayBg).item(0);
+      if (event.target === overlayBg) {
+        modal.close();
+      }
+    };
+  }
+
+  function addOutsideClickListener(modal: Modal) {
+    modalContainer.addEventListener("click", overlayBackgroundClicked(modal));
+  }
+
+  function removeOutsideClickListener(modal: Modal) {
+    modalContainer.removeEventListener("click", overlayBackgroundClicked(modal));
   }
 }

--- a/server/webapp/WEB-INF/rails/webpack/views/components/modal/spec/index_spec.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/components/modal/spec/index_spec.tsx
@@ -78,6 +78,29 @@ describe("Modal", () => {
     testModal.close();
   });
 
+  it("should close the modal when the overlay outside is clicked", () => {
+    const testModal = aModal();
+    testModal.render();
+
+    const modalSelector = `.${styles.overlayHeader} h3`;
+    const bgSelector    = `.${styles.overlayBg}`;
+    expect($(modalSelector)).toBeInDOM();
+    simulateEvent.simulate($(bgSelector).get(0), "click");
+    expect($(modalSelector)).not.toBeInDOM();
+    testModal.close();
+  });
+
+  it("should not close the modal when clicked inside", () => {
+    const testModal = aModal();
+    testModal.render();
+
+    const modalSelector = `.${styles.overlayHeader} h3`;
+    expect($(modalSelector)).toBeInDOM();
+    simulateEvent.simulate($("#modal-inside").get(0), "click");
+    expect($(modalSelector)).toBeInDOM();
+    testModal.close();
+  });
+
   function aModal() {
     return new (class TestModal extends Modal {
       constructor() {
@@ -85,7 +108,7 @@ describe("Modal", () => {
       }
 
       body(): m.Children {
-        return m("p", "Hello World!");
+        return m("p", {id: "modal-inside"}, "Hello World!");
       }
 
       title(): string {


### PR DESCRIPTION
The new modal component didn't close when we click the area outside it. This PR adds that functionality.