### PR TITLE
Add validation error details to command result

### DIFF
--- a/api/api-admins-config-v2/src/main/java/com/thoughtworks/go/apiv2/adminsconfig/representers/AdminsConfigRepresenter.java
+++ b/api/api-admins-config-v2/src/main/java/com/thoughtworks/go/apiv2/adminsconfig/representers/AdminsConfigRepresenter.java
@@ -34,6 +34,10 @@ public class AdminsConfigRepresenter {
         jsonWriter.addLinks(
                 outputLinkWriter -> outputLinkWriter.addAbsoluteLink("doc", Routes.SystemAdmins.DOC)
                         .addLink("self", Routes.SystemAdmins.BASE));
+        toJSONWithoutLinks(jsonWriter, admin);
+    }
+
+    public static void toJSONWithoutLinks(OutputWriter jsonWriter, AdminsConfig admin) {
         jsonWriter.addChildList("roles", rolesAsString(admin.getRoles()));
         jsonWriter.addChildList("users", userAsString(admin.getUsers()));
         if (admin.hasErrors()) {

--- a/api/api-admins-config-v2/src/main/java/com/thoughtworks/go/apiv2/adminsconfig/representers/BulkUpdateFailureResultRepresenter.java
+++ b/api/api-admins-config-v2/src/main/java/com/thoughtworks/go/apiv2/adminsconfig/representers/BulkUpdateFailureResultRepresenter.java
@@ -33,6 +33,9 @@ public class BulkUpdateFailureResultRepresenter {
         if (result.getNonExistentRoles() != null && result.getNonExistentRoles().size() > 0) {
             outputWriter.addChildList("non_existent_roles", toStringList(result.getNonExistentRoles()));
         }
+        if (result.getAdminsConfig() != null) {
+            outputWriter.addChild("data", childWriter -> AdminsConfigRepresenter.toJSONWithoutLinks(childWriter, result.getAdminsConfig()));
+        }
     }
 
     private static List<String> toStringList(List<CaseInsensitiveString> list) {

--- a/api/api-admins-config-v2/src/main/java/com/thoughtworks/go/apiv2/adminsconfig/representers/BulkUpdateFailureResultRepresenter.java
+++ b/api/api-admins-config-v2/src/main/java/com/thoughtworks/go/apiv2/adminsconfig/representers/BulkUpdateFailureResultRepresenter.java
@@ -27,8 +27,12 @@ public class BulkUpdateFailureResultRepresenter {
 
     public static void toJSON(OutputWriter outputWriter, BulkUpdateAdminsResult result) {
         outputWriter.add("message", result.message());
-        outputWriter.addChildList("non_existent_users", toStringList(result.getNonExistentUsers()));
-        outputWriter.addChildList("non_existent_roles", toStringList(result.getNonExistentRoles()));
+        if (result.getNonExistentUsers() != null && result.getNonExistentUsers().size() > 0) {
+            outputWriter.addChildList("non_existent_users", toStringList(result.getNonExistentUsers()));
+        }
+        if (result.getNonExistentRoles() != null && result.getNonExistentRoles().size() > 0) {
+            outputWriter.addChildList("non_existent_roles", toStringList(result.getNonExistentRoles()));
+        }
     }
 
     private static List<String> toStringList(List<CaseInsensitiveString> list) {

--- a/api/api-admins-config-v2/src/test/groovy/com/thoughtworks/go/apiv2/adminsconfig/representers/BulkUpdateFailureResultRepresenterTest.groovy
+++ b/api/api-admins-config-v2/src/test/groovy/com/thoughtworks/go/apiv2/adminsconfig/representers/BulkUpdateFailureResultRepresenterTest.groovy
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.apiv2.adminsconfig.representers
+
+
+import com.thoughtworks.go.server.service.result.BulkUpdateAdminsResult
+import org.junit.jupiter.api.Test
+
+import static com.thoughtworks.go.api.base.JsonUtils.toObjectString
+import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson
+
+class BulkUpdateFailureResultRepresenterTest {
+
+  @Test
+  void shouldNotSerializeNonExistentUsersAndRolesWhenAbsent() {
+    def result = new BulkUpdateAdminsResult()
+    result.unprocessableEntity("Validation Failed")
+    def json = toObjectString { BulkUpdateFailureResultRepresenter.toJSON(it, result) }
+    def expected = [message: "Validation Failed"]
+
+    assertThatJson(json).isEqualTo(expected)
+  }
+
+}

--- a/api/api-admins-config-v2/src/test/groovy/com/thoughtworks/go/apiv2/adminsconfig/representers/BulkUpdateFailureResultRepresenterTest.groovy
+++ b/api/api-admins-config-v2/src/test/groovy/com/thoughtworks/go/apiv2/adminsconfig/representers/BulkUpdateFailureResultRepresenterTest.groovy
@@ -16,11 +16,14 @@
 
 package com.thoughtworks.go.apiv2.adminsconfig.representers
 
-
+import com.thoughtworks.go.config.AdminRole
+import com.thoughtworks.go.config.AdminUser
+import com.thoughtworks.go.config.AdminsConfig
 import com.thoughtworks.go.server.service.result.BulkUpdateAdminsResult
 import org.junit.jupiter.api.Test
 
 import static com.thoughtworks.go.api.base.JsonUtils.toObjectString
+import static com.thoughtworks.go.api.base.JsonUtils.toObjectWithoutLinks
 import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson
 
 class BulkUpdateFailureResultRepresenterTest {
@@ -29,8 +32,9 @@ class BulkUpdateFailureResultRepresenterTest {
   void shouldNotSerializeNonExistentUsersAndRolesWhenAbsent() {
     def result = new BulkUpdateAdminsResult()
     result.unprocessableEntity("Validation Failed")
+    result.adminsConfig = new AdminsConfig(new AdminUser("adminUser"), new AdminRole("adminRole"))
     def json = toObjectString { BulkUpdateFailureResultRepresenter.toJSON(it, result) }
-    def expected = [message: "Validation Failed"]
+    def expected = [message: "Validation Failed", data: [roles: ["adminRole"], users: ["adminUser"]]]
 
     assertThatJson(json).isEqualTo(expected)
   }

--- a/common/src/main/java/com/thoughtworks/go/i18n/LocalizedMessage.java
+++ b/common/src/main/java/com/thoughtworks/go/i18n/LocalizedMessage.java
@@ -157,6 +157,10 @@ public abstract class LocalizedMessage {
         return "Validations failed for " + entityType + " '" + entityName + "'. Error(s): [" + errors + "]. Please correct and resubmit.";
     }
 
+    public static String entityConfigValidationFailed(String entityType, String errors) {
+        return "Validations failed for " + entityType + ". Error(s): [" + errors + "]. Please correct and resubmit.";
+    }
+
     public static String entityConfigValidationFailed(String entityType, CaseInsensitiveString entityName, String errors) {
         return entityConfigValidationFailed(entityType, entityName.toString(), errors);
     }

--- a/server/src/main/java/com/thoughtworks/go/config/update/AdminsConfigUpdateCommand.java
+++ b/server/src/main/java/com/thoughtworks/go/config/update/AdminsConfigUpdateCommand.java
@@ -82,6 +82,10 @@ public class AdminsConfigUpdateCommand implements EntityConfigUpdateCommand<Admi
         return preprocessedAdmin;
     }
 
+    public AdminsConfig getEntity() {
+        return admin;
+    }
+
     final AdminsConfig findExistingAdmin(CruiseConfig cruiseConfig) {
         return cruiseConfig.server().security().adminsConfig();
     }

--- a/server/src/main/java/com/thoughtworks/go/server/service/AdminsConfigService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/AdminsConfigService.java
@@ -103,6 +103,7 @@ public class AdminsConfigService {
         AdminsConfigUpdateCommand command = new AdminsConfigUpdateCommand(goConfigService, new AdminsConfig(existingAdmins),
                 currentUser, result, entityHashingService, md5);
         updateConfig(currentUser, result, command);
+        result.setAdminsConfig(command.getEntity());
         return result;
     }
 

--- a/server/src/main/java/com/thoughtworks/go/server/service/AdminsConfigService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/AdminsConfigService.java
@@ -21,10 +21,13 @@ import com.thoughtworks.go.config.*;
 import com.thoughtworks.go.config.commands.EntityConfigUpdateCommand;
 import com.thoughtworks.go.config.exceptions.GoConfigInvalidException;
 import com.thoughtworks.go.config.update.AdminsConfigUpdateCommand;
+import com.thoughtworks.go.domain.ConfigErrors;
 import com.thoughtworks.go.domain.config.Admin;
+import com.thoughtworks.go.i18n.LocalizedMessage;
 import com.thoughtworks.go.server.domain.Username;
 import com.thoughtworks.go.server.service.result.BulkUpdateAdminsResult;
 import com.thoughtworks.go.server.service.result.LocalizedOperationResult;
+import org.apache.commons.lang.StringUtils;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -63,7 +66,9 @@ public class AdminsConfigService {
             goConfigService.updateConfig(command, currentUser);
         } catch (Exception e) {
             if (e instanceof GoConfigInvalidException) {
-                result.unprocessableEntity("Validation failed while updating System Admins, check errors.");
+                String adminsTag = AdminsConfig.class.getAnnotation(ConfigTag.class).value();
+                String errors = deDuplicatedErrors(((GoConfigInvalidException) e).getCruiseConfig().getAllErrors());
+                result.unprocessableEntity(LocalizedMessage.entityConfigValidationFailed(adminsTag, errors));
             } else {
                 if (!result.hasMessage()) {
                     LOGGER.error(e.getMessage(), e);
@@ -71,6 +76,12 @@ public class AdminsConfigService {
                 }
             }
         }
+    }
+
+    //Hack to remove duplicate errors. See `AdminRole.addError`
+    private String deDuplicatedErrors(List<ConfigErrors> allErrors) {
+        Set<String> errors = allErrors.stream().map(ConfigErrors::firstError).collect(Collectors.toSet());
+        return StringUtils.join(errors, ",");
     }
 
     public BulkUpdateAdminsResult bulkUpdate(Username currentUser,

--- a/server/src/main/java/com/thoughtworks/go/server/service/result/BulkUpdateAdminsResult.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/result/BulkUpdateAdminsResult.java
@@ -16,6 +16,7 @@
 
 package com.thoughtworks.go.server.service.result;
 
+import com.thoughtworks.go.config.AdminsConfig;
 import com.thoughtworks.go.config.CaseInsensitiveString;
 
 import java.util.ArrayList;
@@ -25,6 +26,7 @@ import java.util.List;
 public class BulkUpdateAdminsResult extends HttpLocalizedOperationResult {
     private List<CaseInsensitiveString> nonExistentUsers;
     private List<CaseInsensitiveString> nonExistentRoles;
+    private AdminsConfig adminsConfig;
 
     public BulkUpdateAdminsResult() {
         this.nonExistentUsers = new ArrayList<>();
@@ -39,11 +41,19 @@ public class BulkUpdateAdminsResult extends HttpLocalizedOperationResult {
         this.nonExistentRoles = new ArrayList<>(nonExistentRoles);
     }
 
+    public void setAdminsConfig(AdminsConfig adminsConfig) {
+        this.adminsConfig = adminsConfig;
+    }
+
     public List<CaseInsensitiveString> getNonExistentUsers() {
         return nonExistentUsers;
     }
 
     public List<CaseInsensitiveString> getNonExistentRoles() {
         return nonExistentRoles;
+    }
+
+    public AdminsConfig getAdminsConfig() {
+        return adminsConfig;
     }
 }

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/AdminsConfigServiceIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/AdminsConfigServiceIntegrationTest.java
@@ -109,7 +109,7 @@ public class AdminsConfigServiceIntegrationTest {
         adminsConfigService.update(USERNAME, newSystemAdmins, md5ForEntity, result);
 
         assertThat(result.httpCode(), is(422));
-        assertThat(result.message(), is("Validation failed while updating System Admins, check errors."));
+        assertThat(result.message(), is("Validations failed for admins. Error(s): [Role \"qas\" does not exist.]. Please correct and resubmit."));
         assertThat(adminsConfigService.systemAdmins().size(), is(0));
         assertThat(newSystemAdmins.errors().on("roles"), is("Role \"qas\" does not exist."));
     }


### PR DESCRIPTION
Issue #5742

Example:
```
curl -v http://localhost:8153/go/api/admin/security/system_admins \
  -H 'Accept: application/vnd.go.cd.v2+json' \
  -H 'Content-Type: application/json' \
  -H 'X-GoCD-Confirm: true' \
  -X PATCH \
  -u 'admin:badger' \
  -d '{
     "operations": {
      "roles": {
        "add": ["created-via-api1"]
      }
     }
}'

< HTTP/1.1 422 Unprocessable Entity
{
  "message" : "Validations failed for admins. Error(s): [Role \"created-via-api1\" does not exist.]. Please correct and resubmit.",
  "data" : {
    "roles" : [ "created-via-api1" ],
    "users" : [ "admin" ],
    "errors" : {
      "roles" : [ "Role \"created-via-api1\" does not exist." ]
    }
  }
}
```

I've removed the `non_existent_users` and `non_existent_roles` fields from the json in this case because it can be confusing. Populating these fields was difficult in this case because the service/command doesn't know what was the exact validation failure in the entity.
In other cases where we try to revoke an admin who's not actually an admin, `non_existent_users` and `non_existent_roles` fields will continue to be rendered.


I added a hack to de-duplicate the error messages. They are duplicated because of the these lines in `AdminRole` (similar in `AdminUser`)

```java
public void addError(String message) {
        errors().add(NAME, message); // Do not remove this - The old view for editing group authorization, template authorization makes use of it.
        errors().add(ADMIN, message);
    }
```

Does anyone know the first line is still needed?