### PR TITLE
Minor fixes on Users Management Page

### DIFF
--- a/server/webapp/WEB-INF/rails/app/views/layouts/admin.html.erb
+++ b/server/webapp/WEB-INF/rails/app/views/layouts/admin.html.erb
@@ -75,7 +75,7 @@
                       <%= link_to 'Server Configuration', edit_server_config_path, :id => 'tab-link-of-server-configuration' -%>
                     </li>
                     <li id="user-summary-tab-button" class="<%= @tab_name == "user-listing" ? "current_tab" : "" -%>">
-                      <%= link_to "User Summary", user_listing_path, :id => "tab-link-of-user-listing" %>
+                      <%= link_to "Users Management", user_listing_path, :id => "tab-link-of-user-listing" %>
                     </li>
                     <li id="backup-tab-button" class="<%= @tab_name == "backup" ? "current_tab" : "" -%>">
                       <%= link_to "Backup", backup_server_path, :id => "tab-link-of-backup" %>

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/users/add_user_modal.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/users/add_user_modal.tsx
@@ -63,6 +63,7 @@ export class UserSearchModal extends Modal {
         {optionalErrorMesage}
         <div className={classnames(styles.searchUser)}>
           <SearchFieldWithButton property={this.searchText}
+                                 placeholder={'Search user..'}
                                  dataTestId={"user-search-query"}
                                  onclick={this.search.bind(this)}
                                  buttonDisableReason={"Please type the search query to search user."}/>
@@ -74,13 +75,13 @@ export class UserSearchModal extends Modal {
 
   buttons(): m.ChildArray {
     return [
-      <Buttons.Primary data-test-id="button-add" onclick={this.addUser.bind(this)} disabled={_.isEmpty(this.selectedUser())}>Add</Buttons.Primary>,
+      <Buttons.Primary data-test-id="button-add" onclick={this.addUser.bind(this)} disabled={_.isEmpty(this.selectedUser())}>Import</Buttons.Primary>,
       <Buttons.Cancel data-test-id="button-close" onclick={this.close.bind(this)}>Cancel</Buttons.Cancel>
     ];
   }
 
   title(): string {
-    return "Search users";
+    return "Import User";
   }
 
   private addUser() {

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/users/spec/add_user_modal_spec.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/users/spec/add_user_modal_spec.tsx
@@ -28,8 +28,8 @@ describe("UserSearchModal", () => {
   it("should render modal", () => {
        const modal = new UserSearchModal(flashMessageModel, refreshUsers);
        modal.render();
-       expect(modal).toContainTitle("Search users");
-       expect(modal).toContainButtons(["Cancel", "Add"]);
+       expect(modal).toContainTitle("Import User");
+       expect(modal).toContainButtons(["Cancel", "Import"]);
        expect($(`[data-test-id='${modal.id}'] [data-test-id='user-search-query']`)).toBeInDOM();
      }
   );


### PR DESCRIPTION
* Change Import user modal title from 'Search Users' to 'Import User'.
* Change Add button to Import button.
* Add a placeholder text 'Search user..' to the search user textfield.
* On old admin pages, change tab name from 'User Summary 'to 'Users Management'.