### PR TITLE
Add Toggle Admin Privileges Switch on Users Managemenr Page

### DIFF
--- a/server/webapp/WEB-INF/rails/webpack/models/admins/admin_crud.ts
+++ b/server/webapp/WEB-INF/rails/webpack/models/admins/admin_crud.ts
@@ -29,6 +29,10 @@ export interface BulkUpdateSystemAdminJSON {
 export class AdminsCRUD {
   static API_VERSION_HEADER = ApiVersion.v2;
 
+  static all() {
+    return ApiRequestBuilder.GET(SparkRoutes.apisystemAdminsPath(), this.API_VERSION_HEADER);
+  }
+
   static bulkUpdate(bulkUpdateSystemAdminJson: BulkUpdateSystemAdminJSON) {
     return ApiRequestBuilder.PATCH(SparkRoutes.apisystemAdminsPath(), this.API_VERSION_HEADER, {payload: bulkUpdateSystemAdminJson});
 

--- a/server/webapp/WEB-INF/rails/webpack/models/users/users.ts
+++ b/server/webapp/WEB-INF/rails/webpack/models/users/users.ts
@@ -80,6 +80,18 @@ export class User {
     return new User(json);
   }
 
+  static clone(existingUser: User) {
+    return new User({
+                      login_name: existingUser.loginName(),
+                      display_name: existingUser.displayName(),
+                      enabled: existingUser.enabled(),
+                      email: existingUser.email(),
+                      email_me: existingUser.emailMe(),
+                      is_admin: existingUser.isAdmin(),
+                      checkin_aliases: existingUser.checkinAliases()
+                    });
+  }
+
   matches(searchText: string) {
     searchText               = searchText.toLowerCase();
     const matchesLoginName   = this.loginName().toLowerCase().includes(searchText);

--- a/server/webapp/WEB-INF/rails/webpack/views/components/switch/index.scss
+++ b/server/webapp/WEB-INF/rails/webpack/views/components/switch/index.scss
@@ -15,7 +15,7 @@
  */
 @import "../../global/common";
 
-$switch-on-color: #40b76b;
+$switch-on-color: $go-green;
 $switch-on-in-progress-color: $building;
 $switch-off-color: #cacaca;
 $switch-large-paddle-size: 1.5rem;

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/users/index.scss
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/users/index.scss
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 @import "../../global/common";
+
 $spinner-wrapper-height: 100px;
 
 .hidden {
@@ -28,9 +29,9 @@ $spinner-wrapper-height: 100px;
   @include icon-before($type: $fa-var-circle, $color: $warning-txt);
 }
 
-
 .gocd-role {
   @include icon-before($type: $fa-var-circle, $color: $go-primary);
+  display: inline-block;
 }
 
 .user-management-header {
@@ -150,4 +151,15 @@ $spinner-wrapper-height: 100px;
 
 .spinner-wrapper {
   min-height: $spinner-wrapper-height;
+}
+
+.admin-switch-wrapper {
+  display:     flex;
+  align-items: center;
+}
+
+.is-admin-text {
+  margin-left: 8px;
+  font-size:   13px;
+  font-weight: 600;
 }

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/users/index.scss.d.ts
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/users/index.scss.d.ts
@@ -24,3 +24,5 @@ export const searchUser: string;
 export const button: string;
 export const disabled: string;
 export const spinnerWrapper: string;
+export const adminSwitchWrapper: string;
+export const isAdminText: string;

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/users/spec/super_admin_toggle_widget_spec.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/users/spec/super_admin_toggle_widget_spec.tsx
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as m from "mithril";
+
+import * as stream from "mithril/stream";
+import {Stream} from "mithril/stream";
+
+import {User, Users} from "models/users/users";
+import "views/components/table/spec/table_matchers";
+import {SuperAdminPrivilegeSwitch} from "views/pages/users/super_admin_toggle_widget";
+
+describe("Super Admin Toggle", () => {
+  const simulateEvent = require("simulate-event");
+
+  let $root: any, root: any;
+
+  let user: User,
+      noAdminsConfigured: Stream<boolean>,
+      onRemoveAdmin: (users: Users, e: MouseEvent) => void,
+      onMakeAdmin: (users: Users, e: MouseEvent) => void;
+
+  beforeEach(() => {
+    user               = bob();
+    onMakeAdmin        = jasmine.createSpy("onMakeAdmin");
+    onRemoveAdmin      = jasmine.createSpy("onRemoveAdmin");
+    noAdminsConfigured = stream(false);
+
+    // @ts-ignore
+    [$root, root] = window.createDomElementForTest();
+  });
+
+  beforeEach(mount);
+
+  afterEach(unmount);
+
+  // @ts-ignore
+  afterEach(window.destroyDomElementForTest);
+
+  it("should render YES when the user is an admin", () => {
+    expect(find("is-admin-text")).toContainText("YES");
+  });
+
+  it("should render NO when the user is an admin", () => {
+    user.isAdmin(false);
+    m.redraw();
+
+    expect(find("is-admin-text")).toContainText("NO");
+  });
+
+  it("should render Not Specified when system administrators are not configured", () => {
+    noAdminsConfigured(true);
+    m.redraw();
+
+    expect(find("is-admin-text")).toContainText("Not Specified");
+  });
+
+  it("should render enabled toggle button when the user is an admin", () => {
+    expect(find("switch-checkbox").get(0).checked).toBe(true);
+  });
+
+  it("should render disabled toggle button when the user is NOT an admin", () => {
+    user.isAdmin(false);
+    m.redraw();
+
+    expect(find("switch-checkbox").get(0).checked).toBe(false);
+  });
+
+  it("should render disabled toggle system administrators are not configured", () => {
+    noAdminsConfigured(true);
+    m.redraw();
+
+    expect(find("switch-checkbox").get(0).checked).toBe(false);
+  });
+
+  it("should render make current user admin tooltip when system administrators are not configured", () => {
+    noAdminsConfigured(true);
+    m.redraw();
+
+    const expectedTooltipContent = "Explicitly making 'bob' user a system administrator will result into other users not having system administrator privileges.";
+
+    expect(find("tooltip-wrapper")).toBeInDOM();
+    expect(find("tooltip-content")).toContainText(expectedTooltipContent);
+  });
+
+  it("should NOT render make current user admin tooltip when system administrators are configured", () => {
+    expect(find("tooltip-wrapper")).not.toBeInDOM();
+  });
+
+  it("should make a request to revoke admin on toggling admin user privilege", () => {
+    expect(onRemoveAdmin).not.toHaveBeenCalled();
+    simulateEvent.simulate(find("switch-paddle").get(0), "click");
+    expect(onRemoveAdmin).toHaveBeenCalled();
+  });
+
+  it("should make a request to make admin on toggling non admin user privilege", () => {
+    user.isAdmin(false);
+    m.redraw();
+
+    expect(onMakeAdmin).not.toHaveBeenCalled();
+    simulateEvent.simulate(find("switch-paddle").get(0), "click");
+    expect(onMakeAdmin).toHaveBeenCalled();
+  });
+
+  function mount() {
+    m.mount(root, {
+      view() {
+        return (
+          <SuperAdminPrivilegeSwitch user={user}
+                                     noAdminsConfigured={noAdminsConfigured}
+                                     onRemoveAdmin={onRemoveAdmin}
+                                     onMakeAdmin={onMakeAdmin}/>
+        );
+      }
+    });
+
+    m.redraw();
+  }
+
+  function unmount() {
+    m.mount(root, null);
+    m.redraw();
+  }
+
+  function find(id: string) {
+    return $root.find(`[data-test-id='${id}']`);
+  }
+
+  function bob() {
+    return User.fromJSON({
+                           email: "bob@example.com",
+                           display_name: "Bob",
+                           login_name: "bob",
+                           is_admin: true,
+                           email_me: true,
+                           checkin_aliases: ["bob@gmail.com"],
+                           enabled: true
+                         });
+  }
+});

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/users/spec/user_actions_widget_spec.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/users/spec/user_actions_widget_spec.tsx
@@ -46,7 +46,8 @@ describe("User Actions Widget", () => {
       roleNameToAdd: stream(),
       onRolesAdd: _.noop,
       onMakeAdmin: _.noop,
-      onRemoveAdmin: _.noop
+      onRemoveAdmin: _.noop,
+      noAdminsConfigured: stream(false)
     };
     // @ts-ignore
     [$root, root] = window.createDomElementForTest();

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/users/spec/users_widget_spec.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/users/spec/users_widget_spec.tsx
@@ -44,7 +44,8 @@ describe("UsersWidget", () => {
       roleNameToAdd: stream(),
       onRolesAdd: _.noop,
       onMakeAdmin: _.noop,
-      onRemoveAdmin: _.noop
+      onRemoveAdmin: _.noop,
+      noAdminsConfigured: stream(false)
     };
     // @ts-ignore
     [$root, root] = window.createDomElementForTest();
@@ -97,7 +98,15 @@ describe("UsersWidget", () => {
 
   it("should render a list of user attributes", () => {
     const allUsers = new Users(bob(), alice());
-    const userData = UsersTableWidget.userData(allUsers);
+    const vnode    = {
+      attrs: {
+        noAdminsConfigured: stream(false),
+        onRemoveAdmin: _.noop,
+        onMakeAdmin: _.noop
+      }
+    } as m.Vnode<UserActionsState>;
+
+    const userData = UsersTableWidget.userData(allUsers, vnode);
     m.redraw();
 
     const bobUserData   = userData[0];
@@ -112,17 +121,15 @@ describe("UsersWidget", () => {
     expect(headers[5]).toEqual("Email");
     expect(headers[6]).toEqual("Enabled");
 
-    expect(UsersTableWidget.userData(allUsers)).toHaveLength(2);
+    expect(UsersTableWidget.userData(allUsers, vnode)).toHaveLength(2);
     expect(bobUserData[1].text).toEqual("bob");
     expect(bobUserData[2].text).toEqual("Bob");
-    expect(bobUserData[4].text).toEqual("Yes");
     expect(bobUserData[5].text).toEqual("bob@example.com");
     expect(bobUserData[6].text).toEqual("Yes");
     expect(bobUserData[1].attrs.className).not.toContain("disabled");
 
     expect(aliceUserData[1].text).toEqual("alice");
     expect(aliceUserData[2].text).toEqual("Alice");
-    expect(aliceUserData[4].text).toEqual("No");
     expect(aliceUserData[5].text).toEqual("alice@example.com");
     expect(aliceUserData[6].text).toEqual("No");
     expect(aliceUserData[1].attrs.className).toContain("disabled");

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/users/super_admin_toggle_widget.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/users/super_admin_toggle_widget.tsx
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {MithrilComponent} from "jsx/mithril-component";
+import * as m from "mithril";
+import {Stream} from "mithril/stream";
+import {User, Users} from "models/users/users";
+import {SwitchBtn} from "views/components/switch";
+import * as Tooltip from "views/components/tooltip";
+import {TooltipSize} from "views/components/tooltip";
+import * as styles from "./index.scss";
+
+interface SuperAdminPrivilegeSwitchAttrs {
+  user: User;
+  onRemoveAdmin: (users: Users, e: MouseEvent) => void;
+  onMakeAdmin: (users: Users, e: MouseEvent) => void;
+  noAdminsConfigured: Stream<boolean>;
+}
+
+interface State {
+  userToOperate: User;
+  onToggleClick: (e: MouseEvent) => any;
+  populateUserToOperate: (user: User) => void;
+}
+
+export class SuperAdminPrivilegeSwitch extends MithrilComponent<SuperAdminPrivilegeSwitchAttrs, State> {
+  oninit(vnode: m.Vnode<SuperAdminPrivilegeSwitchAttrs, State>) {
+    vnode.state.onToggleClick = (e: MouseEvent) => {
+      (vnode.state.userToOperate.isAdmin())
+        ? vnode.attrs.onRemoveAdmin(new Users(vnode.state.userToOperate), e)
+        : vnode.attrs.onMakeAdmin(new Users(vnode.state.userToOperate), e);
+    };
+
+    vnode.state.populateUserToOperate = (user: User) => {
+      vnode.state.userToOperate = User.clone(user);
+
+      //if no super admins are configured.. the admin is normal user and can be elevated to system admin.
+      if (vnode.attrs.noAdminsConfigured()) {
+        vnode.state.userToOperate.isAdmin(false);
+      }
+
+      vnode.state.userToOperate.checked(true);
+    };
+  }
+
+  view(vnode: m.Vnode<SuperAdminPrivilegeSwitchAttrs, State>) {
+    vnode.state.populateUserToOperate(vnode.attrs.user);
+
+    let optionalTooltip;
+    let isAdminText = vnode.state.userToOperate.isAdmin() ? "YES" : "NO";
+
+    if (vnode.attrs.noAdminsConfigured()) {
+      const loginName = vnode.attrs.user.loginName;
+      optionalTooltip = (<Tooltip.Info size={TooltipSize.small}
+                                       content={`Explicitly making '${loginName}' user a system administrator will result into other users not having system administrator privileges.`}/>);
+      isAdminText     = "Not Specified";
+    }
+
+    return (
+      <div class={styles.adminSwitchWrapper} data-test-id="admin-switch-wrapper">
+        <SwitchBtn field={vnode.state.userToOperate.isAdmin}
+                   small={true}
+                   onclick={vnode.state.onToggleClick.bind(vnode.state)}/>
+        <span class={styles.isAdminText} data-test-id="is-admin-text">{isAdminText}</span>
+        {optionalTooltip}
+      </div>
+    );
+  }
+}

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/users/user_actions_widget.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/users/user_actions_widget.tsx
@@ -75,6 +75,7 @@ export interface FiltersViewAttrs {
 }
 
 export interface State extends RolesViewAttrs, FiltersViewAttrs, EnableOperation<Users>, DisableOperation<Users>, DeleteOperation<Users>, MakeAdminOperation<Users>, RemoveAdminOperation<Users> {
+  noAdminsConfigured: Stream<boolean>;
 }
 
 class FiltersView extends Dropdown<FiltersViewAttrs> {
@@ -237,10 +238,6 @@ export class UsersActionsWidget extends MithrilViewComponent<State> {
                        disabled={!vnode.attrs.users().anyUserSelected()}>Disable</Secondary>
             <Secondary onclick={vnode.attrs.onDelete.bind(vnode.attrs, vnode.attrs.users())}
                        disabled={!vnode.attrs.users().anyUserSelected()}>Delete</Secondary>
-            <Secondary onclick={vnode.attrs.onMakeAdmin.bind(vnode.attrs, vnode.attrs.users())}
-                       disabled={!vnode.attrs.users().anyUserSelected()}>Make System Admin</Secondary>
-            <Secondary onclick={vnode.attrs.onRemoveAdmin.bind(vnode.attrs, vnode.attrs.users())}
-                       disabled={!vnode.attrs.users().anyUserSelected()}>Revoke System Admin</Secondary>
             <RolesDropdown {...vnode.attrs} show={vnode.attrs.showRoles}/>
           </ButtonGroup>
         </div>

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/users/users_widget.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/users/users_widget.tsx
@@ -19,6 +19,7 @@ import {MithrilViewComponent} from "jsx/mithril-component";
 import * as m from "mithril";
 import {User, Users} from "models/users/users";
 import {Table} from "views/components/table";
+import {SuperAdminPrivilegeSwitch} from "views/pages/users/super_admin_toggle_widget";
 import {State as UserActionsState, UsersActionsWidget} from "views/pages/users/user_actions_widget";
 import * as styles from "./index.scss";
 
@@ -45,7 +46,7 @@ export class UsersTableWidget extends MithrilViewComponent<UserActionsState> {
     ];
   }
 
-  static userData(users: Users): any[][] {
+  static userData(users: Users, vnode: m.Vnode<UserActionsState>): any[][] {
     return users.map((user: User) => {
       const className = (user.enabled() ? "" : styles.disabled);
       return [
@@ -53,7 +54,10 @@ export class UsersTableWidget extends MithrilViewComponent<UserActionsState> {
         <span className={className}>{user.loginName()}</span>,
         <span className={className}>{user.displayName()}</span>,
         <span className={className}>{this.roles(user)}</span>,
-        <span className={className}>{user.isAdmin() ? "Yes" : "No"}</span>,
+        <SuperAdminPrivilegeSwitch user={user}
+                                   noAdminsConfigured={vnode.attrs.noAdminsConfigured}
+                                   onRemoveAdmin={vnode.attrs.onRemoveAdmin}
+                                   onMakeAdmin={vnode.attrs.onMakeAdmin}/>,
         <span className={className}>{user.email()}</span>,
         <span className={className}>{user.enabled() ? "Yes" : "No"}</span>
       ];
@@ -62,7 +66,7 @@ export class UsersTableWidget extends MithrilViewComponent<UserActionsState> {
 
   view(vnode: m.Vnode<UserActionsState>) {
     return <Table headers={UsersTableWidget.headers(vnode.attrs.users() as Users)}
-                  data={UsersTableWidget.userData(vnode.attrs.users())}/>;
+                  data={UsersTableWidget.userData(vnode.attrs.users(), vnode)}/>;
   }
 
   private static roles(user: User) {

--- a/spark/spark-spa/src/main/java/com/thoughtworks/go/spark/spa/UsersController.java
+++ b/spark/spark-spa/src/main/java/com/thoughtworks/go/spark/spa/UsersController.java
@@ -16,8 +16,6 @@
 
 package com.thoughtworks.go.spark.spa;
 
-import com.google.gson.JsonObject;
-import com.thoughtworks.go.server.service.SecurityService;
 import com.thoughtworks.go.spark.Routes;
 import com.thoughtworks.go.spark.SparkController;
 import com.thoughtworks.go.spark.spring.SPAAuthenticationHelper;
@@ -34,12 +32,10 @@ import static spark.Spark.*;
 public class UsersController implements SparkController {
     private final SPAAuthenticationHelper authenticationHelper;
     private final TemplateEngine engine;
-    private final SecurityService securityService;
 
-    public UsersController(SPAAuthenticationHelper authenticationHelper, TemplateEngine engine, SecurityService securityService) {
+    public UsersController(SPAAuthenticationHelper authenticationHelper, TemplateEngine engine) {
         this.authenticationHelper = authenticationHelper;
         this.engine = engine;
-        this.securityService = securityService;
     }
 
     @Override
@@ -56,11 +52,8 @@ public class UsersController implements SparkController {
     }
 
     public ModelAndView index(Request request, Response response) {
-        JsonObject noAdminsConfigured = new JsonObject();
-        noAdminsConfigured.addProperty("noAdminsConfigured", this.securityService.noAdminsConfigured());
         Map<Object, Object> object = new HashMap<Object, Object>() {{
             put("viewTitle", "Users Management");
-            put("meta", noAdminsConfigured);
         }};
         return new ModelAndView(object, null);
     }

--- a/spark/spark-spa/src/main/java/com/thoughtworks/go/spark/spa/spring/SpaControllers.java
+++ b/spark/spark-spa/src/main/java/com/thoughtworks/go/spark/spa/spring/SpaControllers.java
@@ -50,7 +50,7 @@ public class SpaControllers implements SparkSpringController {
 
         sparkControllers.add(new ArtifactStoresController(authenticationHelper, templateEngineFactory.create(ArtifactStoresController.class, () -> featureToggleService.isToggleOn(Toggles.USE_OLD_ARTIFACT_STORES_SPA) ? DEFAULT_LAYOUT_PATH : COMPONENT_LAYOUT_PATH)));
         sparkControllers.add(new AuthConfigsController(authenticationHelper, templateEngineFactory.create(AuthConfigsController.class, () -> featureToggleService.isToggleOn(Toggles.USE_OLD_AUTH_CONFIG_SPA) ? DEFAULT_LAYOUT_PATH : COMPONENT_LAYOUT_PATH)));
-        sparkControllers.add(new UsersController(authenticationHelper, templateEngineFactory.create(UsersController.class, () -> COMPONENT_LAYOUT_PATH), securityService));
+        sparkControllers.add(new UsersController(authenticationHelper, templateEngineFactory.create(UsersController.class, () -> COMPONENT_LAYOUT_PATH)));
         sparkControllers.add(new RolesController(authenticationHelper, templateEngineFactory.create(RolesController.class, () -> featureToggleService.isToggleOn(Toggles.USE_OLD_ROLES_SPA) ? DEFAULT_LAYOUT_PATH : COMPONENT_LAYOUT_PATH)));
         sparkControllers.add(new AgentsControllerController(authenticationHelper, templateEngineFactory.create(AgentsControllerController.class, defaultTemplate), securityService, systemEnvironment));
         sparkControllers.add(new NewDashboardController(authenticationHelper, templateEngineFactory.create(NewDashboardController.class, defaultTemplate), securityService, systemEnvironment, pipelineConfigService));


### PR DESCRIPTION
* Introduce toggle button at user row level to change the admin privileges
	- Show Whether the current user is an admin by YES, NO or Not
	  Specified.
	- Show optional tooltip explaining making current user an
	  admin will cause all other users to loose admin privileges,
	  when no system admins are configured.
* Show and remove 'No admin users configured banner' on the fly,
  without required users to refresh the page.
* Remove 'Make System Admin' and 'Revoke System Admin' buttons.
* Remove 'meta' (noAdminsConfigured) sent from the server as part
  of the body attributes. Make use of System-Admins API to determine
  whether admins are configured or not.