### PR TITLE
Bring back the old User Summary page

### DIFF
--- a/server/src/main/resources/available.toggles
+++ b/server/src/main/resources/available.toggles
@@ -24,7 +24,7 @@
       {
         "key": "users_page_using_rails",
         "description": "Switch users page to use spark.",
-        "value": false
+        "value": true
       },
       {
         "key": "use_old_roles_spa",

--- a/server/webapp/WEB-INF/rails/app/views/admin/users/users.html.erb
+++ b/server/webapp/WEB-INF/rails/app/views/admin/users/users.html.erb
@@ -1,7 +1,7 @@
 <%- @view_title = "Administration" -%>
 <div id="user_summary">
 	<h1>
-        User Summary
+        Users Management
 		<span class="title_secondary_info">
         <ul class="user_counts list_aggregation">
             <li class='enabled'>Enabled: <%= @total_enabled_users -%></li>


### PR DESCRIPTION
* The new User Management page has couple of issues around assigning and
  revoking System Admin permissions and also needs some UX tweaks.
  Bringing back the old User Summary page for now.