### PR TITLE
Do not blow up while taking /api/support (#5732)

### DIFF
--- a/server/src/main/java/com/thoughtworks/go/server/service/support/CacheInformationProvider.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/support/CacheInformationProvider.java
@@ -110,8 +110,13 @@ public class CacheInformationProvider implements ServerInfoProvider {
         json.put("Eternal", config.isEternal());
         json.put("Time To Idle Seconds", config.getTimeToIdleSeconds());
         json.put("time To Live Seconds", config.getTimeToLiveSeconds());
-        json.put("Persistence Configuration Strategy", config.getPersistenceConfiguration().getStrategy());
-        json.put("Persistence Configuration Synchronous writes", config.getPersistenceConfiguration().getSynchronousWrites());
+        if (config.getPersistenceConfiguration() != null) {
+            json.put("Persistence Configuration Strategy", config.getPersistenceConfiguration().getStrategy());
+            json.put("Persistence Configuration Synchronous writes", config.getPersistenceConfiguration().getSynchronousWrites());
+        } else {
+            json.put("Persistence Configuration Strategy", "NONE");
+            json.put("Persistence Configuration Synchronous writes", false);
+        }
         json.put("Disk Spool Buffer Size in MB", config.getDiskSpoolBufferSizeMB());
         json.put("Disk Access Stripes", config.getDiskAccessStripes());
         json.put("Disk Expiry Thread Interval Seconds", config.getDiskExpiryThreadIntervalSeconds());


### PR DESCRIPTION
* EhCache Persistence Implementation does not have PersistenceConfiguration specified all the time,
  calling a 'getStrategy' method on null PersistenceConfiguration was blowing up with java.lang.NullPointerException
* Set defaults of PersistenceConfiguration to following when not specified:
  - Persistence Configuration Strategy: NONE
  - Persistence Configuration Synchronous Writes: false

More information: https://www.ehcache.org/documentation/2.7/configuration/fast-restart.html