### PR TITLE
Change logging application name from 'Cruise' to 'GoCD'

### DIFF
--- a/config/config-server/src/main/java/com/thoughtworks/go/config/GoConfigMigration.java
+++ b/config/config-server/src/main/java/com/thoughtworks/go/config/GoConfigMigration.java
@@ -67,8 +67,8 @@ public class GoConfigMigration {
             e.printStackTrace();
             System.err.println(
                     "There are errors in the Cruise config file.  Please read the error message and correct the errors.\n"
-                            + "Once fixed, please restart Cruise.\nError: " + e.getMessage());
-            LOG.error("There are errors in the Cruise config file.  Please read the error message and correct the errors.\nOnce fixed, please restart Cruise.\nError: {}", e.getMessage());
+                            + "Once fixed, please restart GoCD.\nError: " + e.getMessage());
+            LOG.error("There are errors in the Cruise config file.  Please read the error message and correct the errors.\nOnce fixed, please restart GoCD.\nError: {}", e.getMessage());
             // Send exit signal in a separate thread otherwise it will deadlock jetty
             new Thread(() -> System.exit(1)).start();
 

--- a/server/src/main/java/com/thoughtworks/go/config/GoConfigMigrator.java
+++ b/server/src/main/java/com/thoughtworks/go/config/GoConfigMigrator.java
@@ -76,10 +76,10 @@ public class GoConfigMigrator {
             e.printStackTrace();
             System.err.println(
                     "There are errors in the Cruise config file.  Please read the error message and correct the errors.\n"
-                            + "Once fixed, please restart Cruise.\nError: " + e.getMessage());
+                            + "Once fixed, please restart GoCD.\nError: " + e.getMessage());
             LOGGER.error(MarkerFactory.getMarker("FATAL"),
                     "There are errors in the Cruise config file.  Please read the error message and correct the errors.\n"
-                            + "Once fixed, please restart Cruise.\nError: " + e.getMessage());
+                            + "Once fixed, please restart GoCD.\nError: " + e.getMessage());
             // Send exit signal in a separate thread otherwise it will deadlock jetty
             new Thread(() -> System.exit(1)).start();
         }


### PR DESCRIPTION
#### Before
```text
There are errors in the Cruise config file.  Please read the error message and correct the errors.
Once fixed, please restart Cruise.
```

#### After
```text
There are errors in the Cruise config file.  Please read the error message and correct the errors.
Once fixed, please restart GoCD.
```
