### PR TITLE
Add errors attribute to top-level config repo object

### DIFF
--- a/server/webapp/WEB-INF/rails/webpack/models/config_repos/serialization.ts
+++ b/server/webapp/WEB-INF/rails/webpack/models/config_repos/serialization.ts
@@ -30,6 +30,7 @@ export interface ConfigRepoJSON {
   material: MaterialJSON;
   configuration: any[];
   parse_info: ParseInfoJSON;
+  errors?: ErrorsJSON;
 }
 
 export interface MaterialModificationJSON {

--- a/server/webapp/WEB-INF/rails/webpack/models/config_repos/types.ts
+++ b/server/webapp/WEB-INF/rails/webpack/models/config_repos/types.ts
@@ -121,6 +121,7 @@ export class ConfigRepo implements ValidatableMixin {
                                       Materials.fromJSON(json.material),
                                       configurations,
                                       parseInfo);
+    configRepo.errors(new Errors(json.errors));
     return configRepo;
   }
 


### PR DESCRIPTION
Bug:
- Create a Config Repo named "Foo" from the UI
- Try to create another Config Repo named "Foo"
- No error is displayed. The API response is correct (422 with message and data).

Fix:
Read the `errors` attribute from the json while parsing