### PR TITLE
Show Agents assigned to Environments from Config Repos

### DIFF
--- a/server/src/main/java/com/thoughtworks/go/server/ui/EnvironmentViewModel.java
+++ b/server/src/main/java/com/thoughtworks/go/server/ui/EnvironmentViewModel.java
@@ -43,7 +43,7 @@ public class EnvironmentViewModel {
     }
 
     public void setAgentViewModels(AgentService agentService) {
-        this.agentViewModels = agentService.filter(environmentConfig.getLocalAgents().getUuids());
+        this.agentViewModels = agentService.filter(environmentConfig.getAgents().getUuids());
     }
 
     public AgentsViewModel getAgentViewModels() {

--- a/server/webapp/WEB-INF/rails/app/assets/stylesheets/views/agents.scss
+++ b/server/webapp/WEB-INF/rails/app/assets/stylesheets/views/agents.scss
@@ -57,5 +57,11 @@
     margin-bottom: -3px;
 }
 
+.agent_selector {
+    text-align: right;
+}
 
-
+span.contextual_help.agent_tooltip {
+    margin: 0;
+    padding: 0;
+}

--- a/server/webapp/WEB-INF/rails/app/assets/stylesheets/views/agents.scss
+++ b/server/webapp/WEB-INF/rails/app/assets/stylesheets/views/agents.scss
@@ -40,7 +40,7 @@
 
 .agent_header th.selector {
     padding: 0 2px 0 5px;
-    text-align: center;
+    text-align: right;
 }
 
 .agent_header th.hostname {

--- a/server/webapp/WEB-INF/rails/app/controllers/environments_controller.rb
+++ b/server/webapp/WEB-INF/rails/app/controllers/environments_controller.rb
@@ -42,7 +42,7 @@ class EnvironmentsController < ApplicationController
   end
 
   def show
-    @agent_details = agent_service.filter(@environment.getLocalAgents().map(&:uuid))
+    @agent_details = agent_service.filter(@environment.getAgents().map(&:uuid))
   end
 
   def create

--- a/server/webapp/WEB-INF/rails/app/helpers/agents_helper.rb
+++ b/server/webapp/WEB-INF/rails/app/helpers/agents_helper.rb
@@ -18,15 +18,15 @@ module AgentsHelper
 
   AgentStatus = com.thoughtworks.go.domain.AgentStatus
 
-  def agent_selector uuid, selector_name, selected_uuids, is_remote_agent=false
-    "<td class='selector'>#{agent_selector_without_cell(uuid, selector_name, selected_uuids, is_remote_agent)}</td>".html_safe
+  def agent_selector uuid, selector_name, selected_uuids, is_associated_through_config_repo=false
+    "<td class='selector'>#{agent_selector_without_cell(uuid, selector_name, selected_uuids, is_associated_through_config_repo)}</td>".html_safe
   end
 
-  def agent_selector_without_cell uuid, selector_name, selected_uuids, is_remote_agent
+  def agent_selector_without_cell uuid, selector_name, selected_uuids, is_associated_through_config_repo
     disabled_attr, title_attr = "", ""
-    if is_remote_agent
+    if is_associated_through_config_repo
       disabled_attr = "disabled"
-      title_attr = "title='Agent is associated in a Config Repository'"
+      title_attr = "title='Agent is associated in a Config Repository, cannot edit'"
     end
     "<input #{disabled_attr} #{title_attr} type='checkbox' name='#{ERB::Util.h(selector_name)}' value='#{ERB::Util.h(uuid)}' class='agent_select' #{(selected_uuids && selected_uuids.include?(uuid)) ? "checked='true'" : ""}/>".squish.html_safe
   end

--- a/server/webapp/WEB-INF/rails/app/helpers/agents_helper.rb
+++ b/server/webapp/WEB-INF/rails/app/helpers/agents_helper.rb
@@ -18,13 +18,17 @@ module AgentsHelper
 
   AgentStatus = com.thoughtworks.go.domain.AgentStatus
 
-  def agent_selector uuid, selector_name, selected_uuids, disabled
-    "<td class='selector'>#{agent_selector_without_cell(uuid, selector_name, selected_uuids, disabled)}</td>".html_safe
+  def agent_selector uuid, selector_name, selected_uuids, is_remote_agent
+    "<td class='selector'>#{agent_selector_without_cell(uuid, selector_name, selected_uuids, is_remote_agent)}</td>".html_safe
   end
 
-  def agent_selector_without_cell uuid, selector_name, selected_uuids, disabled
-    disabledAttr = if disabled then "disabled" else "" end
-    "<input #{disabledAttr} type='checkbox' name='#{ERB::Util.h(selector_name)}' value='#{ERB::Util.h(uuid)}' class='agent_select' #{(selected_uuids && selected_uuids.include?(uuid)) ? "checked='true'" : ""}/>".html_safe
+  def agent_selector_without_cell uuid, selector_name, selected_uuids, is_remote_agent
+    disabled_attr, tooltip = "", ""
+    if is_remote_agent
+      disabled_attr = "disabled"
+      tooltip = "Agent is associated in a Config Repository"
+    end
+    "<input #{disabled_attr} title='#{tooltip}' type='checkbox' name='#{ERB::Util.h(selector_name)}' value='#{ERB::Util.h(uuid)}' class='agent_select' #{(selected_uuids && selected_uuids.include?(uuid)) ? "checked='true'" : ""}/>".html_safe
   end
 
   def cell_with_title value, klass, title = value

--- a/server/webapp/WEB-INF/rails/app/helpers/agents_helper.rb
+++ b/server/webapp/WEB-INF/rails/app/helpers/agents_helper.rb
@@ -19,16 +19,16 @@ module AgentsHelper
   AgentStatus = com.thoughtworks.go.domain.AgentStatus
 
   def agent_selector uuid, selector_name, selected_uuids, is_associated_through_config_repo=false
-    "<td class='selector'>#{agent_selector_without_cell(uuid, selector_name, selected_uuids, is_associated_through_config_repo)}</td>".html_safe
+    "<td class='agent_selector'>#{agent_selector_without_cell(uuid, selector_name, selected_uuids, is_associated_through_config_repo)}</td>".html_safe
   end
 
   def agent_selector_without_cell uuid, selector_name, selected_uuids, is_associated_through_config_repo
-    disabled_attr, title_attr = "", ""
+    disabled_attr, tooltip = "", ""
     if is_associated_through_config_repo
       disabled_attr = "disabled"
-      title_attr = "title='Agent is associated in a Config Repository, cannot edit'"
+      tooltip = "<span class='contextual_help has_go_tip_right agent_tooltip' title='Agent is associated in a Config Repository, cannot edit'></span>"
     end
-    "<input #{disabled_attr} #{title_attr} type='checkbox' name='#{ERB::Util.h(selector_name)}' value='#{ERB::Util.h(uuid)}' class='agent_select' #{(selected_uuids && selected_uuids.include?(uuid)) ? "checked='true'" : ""}/>".squish.html_safe
+    "#{tooltip}<input #{disabled_attr} type='checkbox' name='#{ERB::Util.h(selector_name)}' value='#{ERB::Util.h(uuid)}' class='agent_select' #{(selected_uuids && selected_uuids.include?(uuid)) ? "checked='true'" : ""}/>".squish.html_safe
   end
 
   def cell_with_title value, klass, title = value

--- a/server/webapp/WEB-INF/rails/app/helpers/agents_helper.rb
+++ b/server/webapp/WEB-INF/rails/app/helpers/agents_helper.rb
@@ -18,17 +18,17 @@ module AgentsHelper
 
   AgentStatus = com.thoughtworks.go.domain.AgentStatus
 
-  def agent_selector uuid, selector_name, selected_uuids, is_remote_agent
+  def agent_selector uuid, selector_name, selected_uuids, is_remote_agent=false
     "<td class='selector'>#{agent_selector_without_cell(uuid, selector_name, selected_uuids, is_remote_agent)}</td>".html_safe
   end
 
   def agent_selector_without_cell uuid, selector_name, selected_uuids, is_remote_agent
-    disabled_attr, tooltip = "", ""
+    disabled_attr, title_attr = "", ""
     if is_remote_agent
       disabled_attr = "disabled"
-      tooltip = "Agent is associated in a Config Repository"
+      title_attr = "title='Agent is associated in a Config Repository'"
     end
-    "<input #{disabled_attr} title='#{tooltip}' type='checkbox' name='#{ERB::Util.h(selector_name)}' value='#{ERB::Util.h(uuid)}' class='agent_select' #{(selected_uuids && selected_uuids.include?(uuid)) ? "checked='true'" : ""}/>".html_safe
+    "<input #{disabled_attr} #{title_attr} type='checkbox' name='#{ERB::Util.h(selector_name)}' value='#{ERB::Util.h(uuid)}' class='agent_select' #{(selected_uuids && selected_uuids.include?(uuid)) ? "checked='true'" : ""}/>".squish.html_safe
   end
 
   def cell_with_title value, klass, title = value

--- a/server/webapp/WEB-INF/rails/app/helpers/agents_helper.rb
+++ b/server/webapp/WEB-INF/rails/app/helpers/agents_helper.rb
@@ -18,12 +18,13 @@ module AgentsHelper
 
   AgentStatus = com.thoughtworks.go.domain.AgentStatus
 
-  def agent_selector uuid, selector_name, selected_uuids
-    "<td class='selector'>#{agent_selector_without_cell(uuid, selector_name, selected_uuids)}</td>".html_safe
+  def agent_selector uuid, selector_name, selected_uuids, disabled
+    "<td class='selector'>#{agent_selector_without_cell(uuid, selector_name, selected_uuids, disabled)}</td>".html_safe
   end
 
-  def agent_selector_without_cell uuid, selector_name, selected_uuids
-    "<input type='checkbox' name='#{ERB::Util.h(selector_name)}' value='#{ERB::Util.h(uuid)}' class='agent_select' #{(selected_uuids && selected_uuids.include?(uuid)) ? "checked='true'" : ""}/>".html_safe
+  def agent_selector_without_cell uuid, selector_name, selected_uuids, disabled
+    disabledAttr = if disabled then "disabled" else "" end
+    "<input #{disabledAttr} type='checkbox' name='#{ERB::Util.h(selector_name)}' value='#{ERB::Util.h(uuid)}' class='agent_select' #{(selected_uuids && selected_uuids.include?(uuid)) ? "checked='true'" : ""}/>".html_safe
   end
 
   def cell_with_title value, klass, title = value

--- a/server/webapp/WEB-INF/rails/app/views/environments/_agents_table.html.erb
+++ b/server/webapp/WEB-INF/rails/app/views/environments/_agents_table.html.erb
@@ -37,11 +37,17 @@ Util.on_load(function() {
             lastChecked = $this;
         });
     });
+
+  jQuery(".has_go_tip_right").tipTip({
+    activation:      "click",
+    maxWidth:        "auto",
+    edgeOffset:      10,
+    defaultPosition: "right",
+    keepAlive:       false
+  });
 })
 
 </script>
-
-<%= render :partial => 'shared/convert_tool_tips.html', :locals => {:scope => {}} %>
 <table id='agent_details' class='agents list_table <%=" sortable_table" if scope[:sortable_columns]%> selectable_table'>
     <thead>
     <tr class='agent_header'>

--- a/server/webapp/WEB-INF/rails/app/views/environments/_agents_table.html.erb
+++ b/server/webapp/WEB-INF/rails/app/views/environments/_agents_table.html.erb
@@ -41,7 +41,7 @@ Util.on_load(function() {
 
 </script>
 
-
+<%= render :partial => 'shared/convert_tool_tips.html', :locals => {:scope => {}} %>
 <table id='agent_details' class='agents list_table <%=" sortable_table" if scope[:sortable_columns]%> selectable_table'>
     <thead>
     <tr class='agent_header'>

--- a/server/webapp/WEB-INF/rails/app/views/environments/_agents_table.html.erb
+++ b/server/webapp/WEB-INF/rails/app/views/environments/_agents_table.html.erb
@@ -89,7 +89,8 @@ Util.on_load(function() {
         <tr class='agent_instance <%= get_agent_status_class(scope[:show_only_disabled],agent_in_agent_table.getStatus()) %>' id='<%= agent_in_agent_table.getUuid() %>'>
             <% agent_uuid = agent_in_agent_table.getUuid()-%>
             <% if has_operate_permission_for_agents? %>
-                <%== agent_selector(agent_uuid, scope[:selector_name], scope[:selected], scope[:environment].containsAgentRemotely(agent_uuid) ) %>
+                <%== contains_agent_remotely = scope[:environment]&.containsAgentRemotely(agent_uuid)
+                     agent_selector(agent_uuid, scope[:selector_name], scope[:selected], contains_agent_remotely) %>
             <% end %>
             <% unless scope[:exclude_columns].include?('hostname') -%>
 

--- a/server/webapp/WEB-INF/rails/app/views/environments/_agents_table.html.erb
+++ b/server/webapp/WEB-INF/rails/app/views/environments/_agents_table.html.erb
@@ -9,7 +9,7 @@
 <script type="text/javascript">
 Util.on_load(function() {
     jQuery('#select_all_agents').change(function(){
-          jQuery('.agent_select').prop("checked", $(this).checked);
+          jQuery('.agent_select:not([disabled])').prop("checked", $(this).checked);
     });
 
     var lastChecked = null;

--- a/server/webapp/WEB-INF/rails/app/views/environments/_agents_table.html.erb
+++ b/server/webapp/WEB-INF/rails/app/views/environments/_agents_table.html.erb
@@ -89,7 +89,7 @@ Util.on_load(function() {
         <tr class='agent_instance <%= get_agent_status_class(scope[:show_only_disabled],agent_in_agent_table.getStatus()) %>' id='<%= agent_in_agent_table.getUuid() %>'>
             <% agent_uuid = agent_in_agent_table.getUuid()-%>
             <% if has_operate_permission_for_agents? %>
-                <%== agent_selector(agent_uuid, scope[:selector_name], scope[:selected]) %>
+                <%== agent_selector(agent_uuid, scope[:selector_name], scope[:selected], scope[:environment].containsAgentRemotely(agent_uuid) ) %>
             <% end %>
             <% unless scope[:exclude_columns].include?('hostname') -%>
 

--- a/server/webapp/WEB-INF/rails/app/views/environments/_edit_agents.html.erb
+++ b/server/webapp/WEB-INF/rails/app/views/environments/_edit_agents.html.erb
@@ -5,7 +5,15 @@
                 <% if scope[:agents].empty? %>
                     There are no agents available
                 <% else %>
-                    <%= render :partial => "environments/agents_table", :locals => {:scope => {:agents => scope[:agents], :exclude_columns => ["status", "usable_space"], :sortable_columns => false, :show_only_disabled => true, :selector_name => 'environment[agents][][uuid]', :selected => scope[:environment].agents.map(&:uuid)}} %>
+                    <%= render :partial => "environments/agents_table",
+                               :locals => {:scope => {
+                                   :agents => scope[:agents],
+                                   :exclude_columns => ["status", "usable_space"],
+                                   :sortable_columns => false,
+                                   :show_only_disabled => true,
+                                   :selector_name => 'environment[agents][][uuid]',
+                                   :environment => scope[:environment],
+                                   :selected => scope[:environment].agents.map(&:uuid)}} %>
                 <% end %>
             </div>
         </div>

--- a/server/webapp/WEB-INF/rails/spec/controllers/environments_controller_spec.rb
+++ b/server/webapp/WEB-INF/rails/spec/controllers/environments_controller_spec.rb
@@ -440,7 +440,7 @@ describe EnvironmentsController do
 
       expect(assigns[:environment]).to_not be_nil
 
-      expect(response.body).to have_selector("form input[type='checkbox'][name='environment[agents][][uuid]'][value='some-uuid'][checked='true'][disabled][title='Agent is associated in a Config Repository']")
+      expect(response.body).to have_selector("form input[type='checkbox'][name='environment[agents][][uuid]'][value='some-uuid'][checked='true'][disabled][title='Agent is associated in a Config Repository, cannot edit']")
       expect(response.body).to have_selector("form input[type='checkbox'][name='environment[agents][][uuid]'][value='out-env']")
     end
 

--- a/server/webapp/WEB-INF/rails/spec/controllers/environments_controller_spec.rb
+++ b/server/webapp/WEB-INF/rails/spec/controllers/environments_controller_spec.rb
@@ -440,7 +440,7 @@ describe EnvironmentsController do
 
       expect(assigns[:environment]).to_not be_nil
 
-      expect(response.body).to have_selector("form input[type='checkbox'][name='environment[agents][][uuid]'][value='some-uuid'][checked='true']")
+      expect(response.body).to have_selector("form input[type='checkbox'][name='environment[agents][][uuid]'][value='some-uuid'][checked='true'][disabled][title='Agent is associated in a Config Repository']")
       expect(response.body).to have_selector("form input[type='checkbox'][name='environment[agents][][uuid]'][value='out-env']")
     end
 

--- a/server/webapp/WEB-INF/rails/spec/controllers/environments_controller_spec.rb
+++ b/server/webapp/WEB-INF/rails/spec/controllers/environments_controller_spec.rb
@@ -440,7 +440,8 @@ describe EnvironmentsController do
 
       expect(assigns[:environment]).to_not be_nil
 
-      expect(response.body).to have_selector("form input[type='checkbox'][name='environment[agents][][uuid]'][value='some-uuid'][checked='true'][disabled][title='Agent is associated in a Config Repository, cannot edit']")
+      expect(response.body).to have_selector("form input[type='checkbox'][name='environment[agents][][uuid]'][value='some-uuid'][checked='true'][disabled]")
+      expect(response.body).to have_selector("span[class='contextual_help has_go_tip_right agent_tooltip'][title='Agent is associated in a Config Repository, cannot edit']")
       expect(response.body).to have_selector("form input[type='checkbox'][name='environment[agents][][uuid]'][value='out-env']")
     end
 

--- a/server/webapp/WEB-INF/rails/spec/helpers/agents_helper_spec.rb
+++ b/server/webapp/WEB-INF/rails/spec/helpers/agents_helper_spec.rb
@@ -32,16 +32,16 @@ describe AgentsHelper do
     end
 
     it "should select agent thats selected in current request" do
-      expect(agent_selector('uuid', 'selected[]', @selected)).to eq("<td class='selector'><input type='checkbox' name='selected[]' value='uuid' class='agent_select' checked='true'/></td>")
+      expect(agent_selector('uuid', 'selected[]', @selected)).to eq("<td class='agent_selector'><input type='checkbox' name='selected[]' value='uuid' class='agent_select' checked='true'/></td>")
     end
 
     it "should not select agent thats not selected in current request" do
-      expect(agent_selector('uuid1', 'selected[]', @selected)).to eq("<td class='selector'><input type='checkbox' name='selected[]' value='uuid1' class='agent_select' /></td>")
+      expect(agent_selector('uuid1', 'selected[]', @selected)).to eq("<td class='agent_selector'><input type='checkbox' name='selected[]' value='uuid1' class='agent_select' /></td>")
     end
 
     describe "when selected is not set" do
       it "should not select agent thats not selected in current request" do
-        expect(agent_selector('uuid1', 'selected[]', nil)).to eq("<td class='selector'><input type='checkbox' name='selected[]' value='uuid1' class='agent_select' /></td>")
+        expect(agent_selector('uuid1', 'selected[]', nil)).to eq("<td class='agent_selector'><input type='checkbox' name='selected[]' value='uuid1' class='agent_select' /></td>")
       end
     end
   end


### PR DESCRIPTION
Issue #5761

This change is to fetch all the agents (instead of just local agents) so that agents associated via Config Repo can be displayed on the Environments page.

When a user tries to Edit agents on this page, the ones configured via Config Repo will be checked and disabled (similar to Pipelines and Environment Variables configured via the Config Repo).

<img width="1437" alt="screenshot 2019-01-31 at 12 29 35" src="https://user-images.githubusercontent.com/6024038/52037301-a196b580-2554-11e9-83c9-ccc7b02e6e18.png">
<img width="1215" alt="screenshot 2019-01-31 at 12 29 49" src="https://user-images.githubusercontent.com/6024038/52037311-a9eef080-2554-11e9-99a3-2c5a8b23ba81.png">
