### PR TITLE
Slow down when listener starts getting JMSException

### DIFF
--- a/base/src/main/java/com/thoughtworks/go/util/SystemEnvironment.java
+++ b/base/src/main/java/com/thoughtworks/go/util/SystemEnvironment.java
@@ -146,6 +146,7 @@ public class SystemEnvironment implements Serializable, ConfigDirProvider {
     public static final GoSystemProperty<Integer> GO_SERVER_SESSION_COOKIE_MAX_AGE_IN_SECONDS = new GoIntSystemProperty("go.sessioncookie.maxage.seconds", 60 * 60 * 24 * 14);
     public static final GoSystemProperty<Boolean> GO_SERVER_SESSION_COOKIE_SECURE = new GoBooleanSystemProperty("go.sessioncookie.secure", false);
     public static final GoSystemProperty<String> AGENT_EXTRA_PROPERTIES = new GoStringSystemProperty("gocd.agent.extra.properties", "");
+    public static final GoSystemProperty<Integer> JMS_LISTENER_BACKOFF_TIME = new GoIntSystemProperty("go.jms.listener.backoff.time.in.milliseconds", 5000);
 
     /* DATABASE CONFIGURATION - Defaults are of H2 */
     public static GoSystemProperty<String> GO_DATABASE_HOST = new GoStringSystemProperty("db.host", "localhost");

--- a/server/src/main/java/com/thoughtworks/go/server/initializers/ApplicationInitializer.java
+++ b/server/src/main/java/com/thoughtworks/go/server/initializers/ApplicationInitializer.java
@@ -150,15 +150,6 @@ public class ApplicationInitializer implements ApplicationListener<ContextRefres
             scmMaterialSource.initialize();
             dataSharingSettingsService.initialize();
             dataSharingUsageStatisticsReportingService.initialize();
-
-            if ("Y".equals(System.getProperty("delay.gocd.startup.wait.for.file", "N"))) {
-                File file = new File("/tmp/webapp");
-                while (!file.exists()) {
-                    System.err.println("Blocking server startup till file /tmp/webapp is found.");
-                    Thread.sleep(2000);
-                }
-                file.delete();
-            }
         } catch (Throwable throwable) {
             throw new RuntimeException(throwable);
         }

--- a/server/src/main/java/com/thoughtworks/go/server/messaging/activemq/ActiveMqMessagingService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/messaging/activemq/ActiveMqMessagingService.java
@@ -51,11 +51,12 @@ public class ActiveMqMessagingService implements MessagingService {
     private ActiveMQConnection connection;
     public ActiveMQConnectionFactory factory;
     private BrokerService broker;
+    private final SystemEnvironment systemEnvironment;
 
     @Autowired
     public ActiveMqMessagingService(DaemonThreadStatsCollector daemonThreadStatsCollector) throws Exception {
         this.daemonThreadStatsCollector = daemonThreadStatsCollector;
-        SystemEnvironment systemEnvironment = new SystemEnvironment();
+        systemEnvironment = new SystemEnvironment();
 
         broker = new BrokerService();
         broker.setBrokerName(BROKER_NAME);
@@ -90,7 +91,7 @@ public class ActiveMqMessagingService implements MessagingService {
         try {
             Session session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
             MessageConsumer consumer = session.createConsumer(session.createTopic(topic));
-            return JMSMessageListenerAdapter.startListening(consumer, listener, daemonThreadStatsCollector);
+            return JMSMessageListenerAdapter.startListening(consumer, listener, daemonThreadStatsCollector, systemEnvironment);
         } catch (Exception e) {
             throw bomb(e);
         }
@@ -112,7 +113,7 @@ public class ActiveMqMessagingService implements MessagingService {
         try {
             Session session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
             MessageConsumer consumer = session.createConsumer(session.createQueue(queueName));
-            return JMSMessageListenerAdapter.startListening(consumer, listener, daemonThreadStatsCollector);
+            return JMSMessageListenerAdapter.startListening(consumer, listener, daemonThreadStatsCollector, systemEnvironment);
         } catch (Exception e) {
             throw bomb(e);
         }

--- a/server/src/test-fast/java/com/thoughtworks/go/server/messaging/activemq/JMSMessageListenerAdapterTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/messaging/activemq/JMSMessageListenerAdapterTest.java
@@ -1,18 +1,18 @@
-/*************************GO-LICENSE-START*********************************
- * Copyright 2014 ThoughtWorks, Inc.
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *************************GO-LICENSE-END***********************************/
+ */
 
 package com.thoughtworks.go.server.messaging.activemq;
 
@@ -24,30 +24,35 @@ import com.thoughtworks.go.server.service.support.DaemonThreadStatsCollector;
 import com.thoughtworks.go.server.messaging.GoMessage;
 import com.thoughtworks.go.server.messaging.GoMessageListener;
 
+import static com.thoughtworks.go.serverhealth.HealthStateLevel.ERROR;
 import static com.thoughtworks.go.util.LogFixture.logFixtureFor;
 
+import com.thoughtworks.go.serverhealth.HealthStateLevel;
+import com.thoughtworks.go.serverhealth.ServerHealthService;
+import com.thoughtworks.go.serverhealth.ServerHealthState;
 import com.thoughtworks.go.util.LogFixture;
 import com.thoughtworks.go.util.SystemEnvironment;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.ArgumentMatcher;
 
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.lessThan;
 import static org.junit.Assert.*;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 public class JMSMessageListenerAdapterTest {
 
     private MessageConsumer consumer;
     private GoMessageListener mockListener;
     private SystemEnvironment systemEnvironment;
+    private ServerHealthService serverHealthService;
 
     @Before
     public void setUp() throws Exception {
         consumer = mock(MessageConsumer.class);
-
         systemEnvironment = mock(SystemEnvironment.class);
+        serverHealthService = mock(ServerHealthService.class);
 
         mockListener = new GoMessageListener() {
             public void onMessage(GoMessage message) {
@@ -65,7 +70,7 @@ public class JMSMessageListenerAdapterTest {
     public void shouldNotKillTheThreadWhenThereIsAnException() throws Exception {
         when(consumer.receive()).thenThrow(new RuntimeException("should swallow me"));
 
-        JMSMessageListenerAdapter listenerAdapter = JMSMessageListenerAdapter.startListening(consumer, mockListener, mock(DaemonThreadStatsCollector.class), systemEnvironment);
+        JMSMessageListenerAdapter listenerAdapter = JMSMessageListenerAdapter.startListening(consumer, mockListener, mock(DaemonThreadStatsCollector.class), systemEnvironment, serverHealthService);
         try {
             listenerAdapter.runImpl();
         } catch (Exception e) {
@@ -80,7 +85,7 @@ public class JMSMessageListenerAdapterTest {
         when(systemEnvironment.get(SystemEnvironment.JMS_LISTENER_BACKOFF_TIME)).thenReturn(3000);
 
         try (LogFixture logFixture = logFixtureFor(JMSMessageListenerAdapter.class, Level.DEBUG)) {
-            JMSMessageListenerAdapter listenerAdapter = JMSMessageListenerAdapter.startListening(consumer, mockListener, mock(DaemonThreadStatsCollector.class), systemEnvironment);
+            JMSMessageListenerAdapter listenerAdapter = JMSMessageListenerAdapter.startListening(consumer, mockListener, mock(DaemonThreadStatsCollector.class), systemEnvironment, serverHealthService);
 
             final long startTime = System.nanoTime();
             listenerAdapter.runImpl();
@@ -89,6 +94,8 @@ public class JMSMessageListenerAdapterTest {
             assertTrue(logFixture.contains(Level.WARN, "Backing off for a few seconds"));
             assertThat(endTime - startTime, greaterThan(2000 * 1000 * 1000L));
             assertThat(endTime - startTime, lessThan(4000 * 1000 * 1000L));
+
+            verify(serverHealthService, atLeastOnce()).update(matchesServerHealthMessage(ERROR, "Message queue closed"));
         }
     }
 
@@ -98,7 +105,7 @@ public class JMSMessageListenerAdapterTest {
         when(systemEnvironment.get(SystemEnvironment.JMS_LISTENER_BACKOFF_TIME)).thenThrow(new RuntimeException("Should not have needed listener backoff time"));
 
         try (LogFixture logFixture = logFixtureFor(JMSMessageListenerAdapter.class, Level.DEBUG)) {
-            JMSMessageListenerAdapter listenerAdapter = JMSMessageListenerAdapter.startListening(consumer, mockListener, mock(DaemonThreadStatsCollector.class), systemEnvironment);
+            JMSMessageListenerAdapter listenerAdapter = JMSMessageListenerAdapter.startListening(consumer, mockListener, mock(DaemonThreadStatsCollector.class), systemEnvironment, serverHealthService);
 
             final long startTime = System.nanoTime();
             listenerAdapter.runImpl();
@@ -106,6 +113,23 @@ public class JMSMessageListenerAdapterTest {
 
             assertFalse(logFixture.contains(Level.WARN, "Backing off for a few seconds"));
             assertThat(endTime - startTime, lessThan(1000 * 1000 * 1000L));
+
+            verify(serverHealthService, never()).update(any(ServerHealthState.class));
         }
     }
+
+    private ServerHealthState matchesServerHealthMessage(final HealthStateLevel expectedLevel, String expectedPartOfMessage) {
+        return argThat(new ArgumentMatcher<ServerHealthState>() {
+            @Override
+            public boolean matches(ServerHealthState argument) {
+                return argument.getLogLevel().equals(expectedLevel) && argument.getMessage().contains(expectedPartOfMessage);
+            }
+
+            @Override
+            public String toString() {
+                return "a server health message of level " + expectedLevel + " with message containing " + expectedPartOfMessage;
+            }
+        });
+    }
+
 }

--- a/server/src/test-integration/java/com/thoughtworks/go/server/messaging/activemq/ActiveMqTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/messaging/activemq/ActiveMqTest.java
@@ -18,6 +18,8 @@ package com.thoughtworks.go.server.messaging.activemq;
 
 import com.thoughtworks.go.server.messaging.*;
 import com.thoughtworks.go.server.service.support.DaemonThreadStatsCollector;
+import com.thoughtworks.go.serverhealth.ServerHealthService;
+import com.thoughtworks.go.util.SystemEnvironment;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -44,7 +46,7 @@ public class ActiveMqTest implements GoMessageListener {
 
     @Before
     public void setUp() throws Exception {
-        messaging = new ActiveMqMessagingService(new DaemonThreadStatsCollector());
+        messaging = new ActiveMqMessagingService(new DaemonThreadStatsCollector(), new SystemEnvironment(), new ServerHealthService());
     }
 
     @After

--- a/util/src/main/java/com/thoughtworks/go/util/LogFixture.java
+++ b/util/src/main/java/com/thoughtworks/go/util/LogFixture.java
@@ -28,6 +28,8 @@ import org.slf4j.LoggerFactory;
 import java.io.Closeable;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
 
 public class LogFixture implements Closeable {
 
@@ -92,7 +94,7 @@ public class LogFixture implements Closeable {
     private class ListAppender extends AppenderBase<ILoggingEvent> {
 
         private final PatternLayoutEncoder encoder;
-        private List<ILoggingEvent> events = new ArrayList<>();
+        private Queue<ILoggingEvent> events = new ConcurrentLinkedQueue<ILoggingEvent>();
 
         ListAppender(PatternLayoutEncoder encoder) {
             this.encoder = encoder;
@@ -102,7 +104,7 @@ public class LogFixture implements Closeable {
             events.add(e);
         }
 
-        public List<ILoggingEvent> getRawEvents() {
+        Queue<ILoggingEvent> getRawEvents() {
             return events;
         }
 


### PR DESCRIPTION
JMSException is unexpected and can happen when the consumer is somehow closed. This leads to the while loop in the [run method](https://github.com/gocd/gocd/blob/ba495470c154cf46aadf3ac45c67544735391c61/server/src/main/java/com/thoughtworks/go/server/messaging/activemq/JMSMessageListenerAdapter.java#L51-L57) running a lot, very quickly, filling up logs and overwhelming everything till the server is restarted.