### PR TITLE
Elastic Profile SPA: Should disable status report button when user is not a super admin

### DIFF
--- a/server/webapp/WEB-INF/rails/webpack/views/pages/elastic_profiles.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/elastic_profiles.tsx
@@ -151,7 +151,8 @@ export class ElasticProfilesPage extends Page<null, State> {
         onEdit={vnode.state.onEdit.bind(vnode.state)}
         onClone={vnode.state.onClone.bind(vnode.state)}
         onDelete={vnode.state.onDelete.bind(vnode.state)}
-        onShowUsages={vnode.state.onShowUsages.bind(vnode.state)}/>
+        onShowUsages={vnode.state.onShowUsages.bind(vnode.state)}
+        isUserAnAdmin={ElasticProfilesPage.isUserAnAdmin()}/>
     </div>;
   }
 
@@ -185,5 +186,10 @@ export class ElasticProfilesPage extends Page<null, State> {
         () => this.setErrorState()
       );
     });
+  }
+
+  private static isUserAnAdmin() {
+    const attribute = document.body.getAttribute("data-is-user-admin");
+    return attribute ? attribute === "true" : false;
   }
 }

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/elastic_profiles/elastic_profiles_widget.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/elastic_profiles/elastic_profiles_widget.tsx
@@ -37,6 +37,7 @@ import {CloneOperation, DeleteOperation, EditOperation} from "views/pages/page_o
 interface Attrs extends EditOperation<ElasticProfile>, DeleteOperation<string>, CloneOperation<ElasticProfile> {
   pluginInfos: Stream<Array<PluginInfo<Extension>>>;
   elasticProfiles: ElasticProfiles;
+  isUserAnAdmin: boolean;
 
   onShowUsages: (profileId: string, event: MouseEvent) => void;
 }
@@ -91,11 +92,15 @@ export class ElasticProfilesWidget extends MithrilComponent<Attrs, {}> {
               const pluginInfo           = ElasticProfilesWidget.findPluginInfoByPluginId(vnode.attrs.pluginInfos(),
                                                                                           pluginId);
               const pluginName           = pluginInfo ? pluginInfo.about.name : undefined;
-              const statusReportButton   = this.createStatusReportButton(pluginId, pluginInfo);
               const pluginImageTag       = ElasticProfilesWidget.createImageTag(pluginInfo);
               const elasticProfileHeader = <ElasticProfilesHeaderWidget image={pluginImageTag}
                                                                         pluginId={pluginId}
                                                                         pluginName={pluginName}/>;
+              let statusReportButton;
+              if (pluginInfo && ElasticProfilesWidget.supportsStatusReport(pluginInfo)) {
+                statusReportButton = this.createStatusReportButton(pluginId, vnode.attrs.isUserAnAdmin);
+              }
+
               return (
                 <CollapsiblePanel key={pluginId} header={elasticProfileHeader} expanded={index === 0}
                                   actions={statusReportButton}>
@@ -157,16 +162,15 @@ export class ElasticProfilesWidget extends MithrilComponent<Attrs, {}> {
     return <HeaderIcon/>;
   }
 
-  private createStatusReportButton(pluginId: string, pluginInfo ?: PluginInfo<Extension>) {
-    if (pluginInfo && ElasticProfilesWidget.supportsStatusReport(pluginInfo)) {
-      const statusReportPath: string = Routes.adminStatusReportPath(pluginId);
-      return (
-        <Buttons.Secondary onclick={ElasticProfilesWidget.goToStatusReportPage.bind(this, statusReportPath)}
-                           data-test-id="status-report-link"
-                           icon={ButtonIcon.DOC}>Status Report
-        </Buttons.Secondary>
-      );
-    }
+  private createStatusReportButton(pluginId: string, isUserAnAdmin: boolean) {
+    const statusReportPath: string = Routes.adminStatusReportPath(pluginId);
+    return (
+      <Buttons.Secondary onclick={ElasticProfilesWidget.goToStatusReportPage.bind(this, statusReportPath)}
+                         data-test-id="status-report-link"
+                         icon={ButtonIcon.DOC}
+                         disabled={!isUserAnAdmin}>Status Report
+      </Buttons.Secondary>
+    );
   }
 }
 

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/elastic_profiles/spec/elastic_profiles_widget_spec.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/elastic_profiles/spec/elastic_profiles_widget_spec.tsx
@@ -114,8 +114,20 @@ describe("New Elastic Profiles Widget", () => {
     });
   });
 
+  describe("StatusReport", () => {
+    it("should disable status report button when user is not an super admin", () => {
+      mount(pluginInfos, elasticProfiles, false);
+      expect(find("status-report-link").get(0)).toBeDisabled();
+    });
+
+    it("should not disable status report button when user is a super admin", () => {
+      mount(pluginInfos, elasticProfiles, true);
+      expect(find("status-report-link").get(0)).not.toBeDisabled();
+    });
+  });
+
   function mount(pluginInfos: Array<PluginInfo<Extension>>,
-                 elasticProfiles: ElasticProfiles) {
+                 elasticProfiles: ElasticProfiles, isUserAnAdmin = true) {
 
     const noop = _.noop;
 
@@ -127,7 +139,8 @@ describe("New Elastic Profiles Widget", () => {
                                  onEdit={noop}
                                  onClone={noop}
                                  onDelete={noop}
-                                 onShowUsages={noop}/>
+                                 onShowUsages={noop}
+                                 isUserAnAdmin={isUserAnAdmin}/>
         );
       }
     });


### PR DESCRIPTION
- Status report page is only accessible to super admins only as it contains information about all running pipelines and agents for that, Hence disabling the status report button on the elastic profile SPA for the group admins. See issue #5776  for more details.

### Plugins Page
![screen shot 2019-02-05 at 3 50 23 pm](https://user-images.githubusercontent.com/7871209/52267162-5c142700-295e-11e9-9535-b0017ded53ff.png)

### Elastic Profiles Page
![screen shot 2019-02-05 at 3 50 10 pm](https://user-images.githubusercontent.com/7871209/52267163-5c142700-295e-11e9-9f8f-09f34217b6cb.png)

