### PR TITLE
Validate User belonging to the access token exists before proceeding with AccessTokenFilter (#5321)

### DIFF
--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/authorization/AuthorizationExtension.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/authorization/AuthorizationExtension.java
@@ -224,6 +224,25 @@ public class AuthorizationExtension extends AbstractExtension {
         });
     }
 
+    public boolean isValidUser(String pluginId, String username, SecurityAuthConfig authConfig) {
+        try {
+            return pluginRequestHelper.submitRequest(pluginId, IS_VALID_USER, new DefaultPluginInteractionCallback<Boolean>() {
+                @Override
+                public String requestBody(String resolvedExtensionVersion) {
+                    return getMessageConverter(resolvedExtensionVersion).isValidUserRequestBody(username, authConfig);
+                }
+
+                @Override
+                public Boolean onSuccess(String responseBody, Map<String, String> responseHeaders, String resolvedExtensionVersion) {
+                    return true;
+                }
+            });
+        } catch (Exception e) { //any error happened while verifying the user existence will lead to assume user does not exists.
+            return false;
+        }
+
+    }
+
     public AuthorizationMessageConverter getMessageConverter(String version) {
         return messageHandlerMap.get(version);
     }

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/authorization/AuthorizationMessageConverter.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/authorization/AuthorizationMessageConverter.java
@@ -70,5 +70,5 @@ public interface AuthorizationMessageConverter {
 
     String authorizationServerUrlRequestBody(String pluginId, List<SecurityAuthConfig> authConfigs, String siteUrl);
 
-
+    String isValidUserRequestBody(String username, SecurityAuthConfig authConfig);
 }

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/authorization/AuthorizationPluginConstants.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/authorization/AuthorizationPluginConstants.java
@@ -29,6 +29,7 @@ public interface AuthorizationPluginConstants {
     String REQUEST_GET_CAPABILITIES = REQUEST_PREFIX + ".get-capabilities";
     String REQUEST_GET_PLUGIN_ICON = REQUEST_PREFIX + ".get-icon";
     String REQUEST_GET_USER_ROLES = REQUEST_PREFIX + ".get-user-roles";
+    String IS_VALID_USER = REQUEST_PREFIX + ".is-valid-user";
 
     String _AUTH_CONFIG_METADATA = "auth-config";
     String _ROLE_CONFIG_METADATA = "role-config";

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/authorization/v1/AuthorizationMessageConverterV1.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/authorization/v1/AuthorizationMessageConverterV1.java
@@ -218,6 +218,11 @@ public class AuthorizationMessageConverterV1 implements AuthorizationMessageConv
         return template;
     }
 
+    @Override
+    public String isValidUserRequestBody(String username, SecurityAuthConfig authConfig) {
+        throw new UnsupportedOperationException("Authorization Extension v1 does not implement is-valid-user call.");
+    }
+
     private String authorizationServerCallbackUrl(String pluginId, String siteUrl) {
         return String.format("%s/go/plugin/%s/authenticate", siteUrl, pluginId);
     }

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/authorization/v2/AuthorizationMessageConverterV2.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/authorization/v2/AuthorizationMessageConverterV2.java
@@ -127,12 +127,16 @@ public class AuthorizationMessageConverterV2 implements AuthorizationMessageConv
         }
 
         for (SecurityAuthConfig securityAuthConfig : authConfigs) {
-            Map<String, Object> authConfig = new HashMap<>();
-            authConfig.put("id", securityAuthConfig.getId());
-            authConfig.put("configuration", securityAuthConfig.getConfigurationAsMap(true));
-            configs.add(authConfig);
+            configs.add(getAuthConfig(securityAuthConfig));
         }
         return configs;
+    }
+
+    private Map<String, Object> getAuthConfig(SecurityAuthConfig securityAuthConfig) {
+        Map<String, Object> authConfig = new HashMap<>();
+        authConfig.put("id", securityAuthConfig.getId());
+        authConfig.put("configuration", securityAuthConfig.getConfigurationAsMap(true));
+        return authConfig;
     }
 
     @Override
@@ -201,6 +205,15 @@ public class AuthorizationMessageConverterV2 implements AuthorizationMessageConv
         Map<String, Object> requestMap = new HashMap<>();
         requestMap.put("auth_configs", getAuthConfigs(authConfigs));
         requestMap.put("authorization_server_callback_url", authorizationServerCallbackUrl(pluginId, siteUrl));
+
+        return GSON.toJson(requestMap);
+    }
+
+    @Override
+    public String isValidUserRequestBody(String username, SecurityAuthConfig authConfig) {
+        Map<String, Object> requestMap = new HashMap<>();
+        requestMap.put("username", username);
+        requestMap.put("auth_config", getAuthConfig(authConfig));
 
         return GSON.toJson(requestMap);
     }

--- a/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/authorization/v2/AuthorizationMessageConverterV2Test.java
+++ b/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/authorization/v2/AuthorizationMessageConverterV2Test.java
@@ -72,4 +72,21 @@ public class AuthorizationMessageConverterV2Test {
                 "  ]\n" +
                 "}");
     }
+
+    @Test
+    public void shouldReturnRequestBodyForDoesUserExistsRequest() {
+        SecurityAuthConfig authConfig = new SecurityAuthConfig("p1", "ldap", ConfigurationPropertyMother.create("key1", false, "value2"));
+
+        String requestBody = converter.isValidUserRequestBody("foo", authConfig);
+
+        assertThatJson(requestBody).isEqualTo("{\n" +
+                "  \"auth_config\": {\n" +
+                "      \"configuration\": {\n" +
+                "        \"key1\": \"value2\"\n" +
+                "      },\n" +
+                "      \"id\": \"p1\"\n" +
+                "    },\n" +
+                "  \"username\": \"foo\"\n" +
+                "}");
+    }
 }

--- a/plugin-infra/go-plugin-domain/src/main/java/com/thoughtworks/go/plugin/domain/authorization/AuthenticationResponse.java
+++ b/plugin-infra/go-plugin-domain/src/main/java/com/thoughtworks/go/plugin/domain/authorization/AuthenticationResponse.java
@@ -17,6 +17,7 @@
 package com.thoughtworks.go.plugin.domain.authorization;
 
 import java.util.List;
+import java.util.Objects;
 
 public class AuthenticationResponse {
     private final User user;
@@ -33,5 +34,27 @@ public class AuthenticationResponse {
 
     public List<String> getRoles() {
         return roles;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        AuthenticationResponse that = (AuthenticationResponse) o;
+        return Objects.equals(user, that.user) &&
+                Objects.equals(roles, that.roles);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(user, roles);
+    }
+
+    @Override
+    public String toString() {
+        return "AuthenticationResponse{" +
+                "user=" + user +
+                ", roles=" + roles +
+                '}';
     }
 }

--- a/server/src/main/java/com/thoughtworks/go/server/exceptions/InvalidAccessTokenException.java
+++ b/server/src/main/java/com/thoughtworks/go/server/exceptions/InvalidAccessTokenException.java
@@ -20,4 +20,8 @@ public class InvalidAccessTokenException extends RuntimeException {
     public InvalidAccessTokenException() {
         super("Invalid Personal Access Token.");
     }
+
+    public InvalidAccessTokenException(String msg) {
+        super(String.format("Invalid Personal Access Token. %s", msg));
+    }
 }

--- a/server/src/main/java/com/thoughtworks/go/server/newsecurity/providers/AbstractPluginAuthenticationProvider.java
+++ b/server/src/main/java/com/thoughtworks/go/server/newsecurity/providers/AbstractPluginAuthenticationProvider.java
@@ -22,6 +22,7 @@ import com.thoughtworks.go.config.PluginRoleConfig;
 import com.thoughtworks.go.config.SecurityAuthConfig;
 import com.thoughtworks.go.plugin.domain.authorization.AuthenticationResponse;
 import com.thoughtworks.go.plugin.domain.authorization.User;
+import com.thoughtworks.go.server.exceptions.InvalidAccessTokenException;
 import com.thoughtworks.go.server.newsecurity.models.AuthenticationToken;
 import com.thoughtworks.go.server.newsecurity.models.Credentials;
 import com.thoughtworks.go.server.security.AuthorityGranter;
@@ -132,6 +133,9 @@ public abstract class AbstractPluginAuthenticationProvider<T extends Credentials
             }
         } catch (OnlyKnownUsersAllowedException e) {
             LOGGER.info("User {} is successfully authenticated. Auto register new user is disabled. Please refer {}", e.getUsername(), CurrentGoCDVersion.docsUrl("configuration/dev_authentication.html#controlling-user-access"));
+            throw e;
+        } catch (InvalidAccessTokenException e) {
+            LOGGER.error("Error while authenticating user using auth_config: {} with the authorization plugin: {} ", authConfig.getId(), pluginId);
             throw e;
         } catch (Exception e) {
             LOGGER.error("Error while authenticating user using auth_config: {} with the authorization plugin: {} ", authConfig.getId(), pluginId);

--- a/server/src/test-fast/java/com/thoughtworks/go/server/newsecurity/providers/AccessTokenBasedPluginAuthenticationProviderTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/newsecurity/providers/AccessTokenBasedPluginAuthenticationProviderTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.server.newsecurity.providers;
+
+import com.thoughtworks.go.config.SecurityAuthConfig;
+import com.thoughtworks.go.domain.User;
+import com.thoughtworks.go.helper.AccessTokenMother;
+import com.thoughtworks.go.plugin.access.authorization.AuthorizationExtension;
+import com.thoughtworks.go.plugin.access.authorization.AuthorizationMetadataStore;
+import com.thoughtworks.go.plugin.domain.authorization.AuthenticationResponse;
+import com.thoughtworks.go.server.exceptions.InvalidAccessTokenException;
+import com.thoughtworks.go.server.newsecurity.models.AccessTokenCredential;
+import com.thoughtworks.go.server.security.AuthorityGranter;
+import com.thoughtworks.go.server.service.GoConfigService;
+import com.thoughtworks.go.server.service.PluginRoleService;
+import com.thoughtworks.go.server.service.UserService;
+import com.thoughtworks.go.util.Clock;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+
+import java.util.Collections;
+
+import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+class AccessTokenBasedPluginAuthenticationProviderTest {
+    private final String pluginId = "pluginId";
+    private final String authConfigId = "auth-config-id";
+    private final String accessTokenName = "token1";
+
+
+    @Mock
+    private AuthorizationExtension authorizationExtension;
+    @Mock
+    private AuthorityGranter authorityGranter;
+    @Mock
+    private GoConfigService goConfigService;
+    @Mock
+    private PluginRoleService pluginRoleService;
+    @Mock
+    private UserService userService;
+    @Mock
+    private Clock clock;
+    @Mock
+    private AuthorizationMetadataStore store;
+
+    private AccessTokenBasedPluginAuthenticationProvider provider;
+    private final SecurityAuthConfig authConfig = new SecurityAuthConfig();
+    private final AccessTokenCredential credentials = new AccessTokenCredential(AccessTokenMother.accessTokenWithName(accessTokenName));
+
+    @BeforeEach
+    void setUp() {
+        initMocks(this);
+        provider = new AccessTokenBasedPluginAuthenticationProvider(authorizationExtension, authorityGranter, goConfigService, pluginRoleService, userService, clock);
+        provider.setStore(store);
+
+        authConfig.setId(authConfigId);
+    }
+
+    @Test
+    void shouldReturnRolesFetchedForTheUserFromThePluginForTheProvidedAuthConfig() {
+        String username = credentials.getAccessToken().getUsername();
+        AuthenticationResponse responseToSend = new AuthenticationResponse(null, Collections.emptyList());
+
+        when(authorizationExtension.isValidUser(pluginId, username, authConfig)).thenReturn(true);
+        when(store.doesPluginSupportGetUserRolesCall(pluginId)).thenReturn(true);
+        when(authorizationExtension.getUserRoles(pluginId, username, singletonList(authConfig), null)).thenReturn(responseToSend);
+
+        AuthenticationResponse actual = provider.authenticateWithExtension(pluginId, credentials, authConfig, null);
+
+        assertThat(actual).isEqualTo(responseToSend);
+    }
+
+    @Test
+    void shouldReturnAuthenticationResponseFetchingUsersFromTheDBWhenPluginDoesNotSupportGetRolesCapability() {
+        String username = credentials.getAccessToken().getUsername();
+        User userToOperate = new User(username);
+        AuthenticationResponse responseToSend = new AuthenticationResponse(new com.thoughtworks.go.plugin.domain.authorization.User(userToOperate.getUsername().getUsername().toString(), userToOperate.getDisplayName(), userToOperate.getEmail()), Collections.emptyList());
+
+        when(authorizationExtension.isValidUser(pluginId, username, authConfig)).thenReturn(true);
+        when(store.doesPluginSupportGetUserRolesCall(pluginId)).thenReturn(false);
+        when(userService.findUserByName(username)).thenReturn(userToOperate);
+
+        AuthenticationResponse actual = provider.authenticateWithExtension(pluginId, credentials, authConfig, null);
+
+        assertThat(actual).isEqualTo(responseToSend);
+    }
+
+    @Test
+    void itShouldThrowErrorWhenAccessTokenBelongingTheUserDoesNotExists() {
+        when(authorizationExtension.isValidUser(pluginId, credentials.getAccessToken().getUsername(), authConfig)).thenReturn(false);
+
+        InvalidAccessTokenException exception = assertThrows(InvalidAccessTokenException.class, () -> {
+            provider.authenticateWithExtension(pluginId, credentials, authConfig, null);
+        });
+
+        assertThat(exception.getMessage()).startsWith("Invalid Personal Access Token. Access Token belonging to the user has either been disabled, removed or expired.");
+    }
+}


### PR DESCRIPTION
AccessTokenBasedPluginAuthenticationProvider flow:
1. Verify provided access token is valid.
2. Verify access token is not revoked.
3. Check is the current user still exists with authorization plugins,
   against the belonging auth config id.
4. If user exists and plugin has fetching roles for user capability, fetch roles.
5. Mark user authenticated and proceed with the requested operation.

**NOTE:**
This change will require an upgrade in the authorization plugins to support
'doesUserExists' plugin-extension call. Without this implementations, GoCD
users will not be able to use access-token feature.