### PR TITLE
Allow plugin settings API to accept booleans

### DIFF
--- a/server/webapp/WEB-INF/rails/app/presenters/api_v1/config/plugin_configuration_property_representer.rb
+++ b/server/webapp/WEB-INF/rails/app/presenters/api_v1/config/plugin_configuration_property_representer.rb
@@ -1,5 +1,5 @@
 ##########################################################################
-# Copyright 2015 ThoughtWorks, Inc.
+# Copyright 2019 ThoughtWorks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -44,7 +44,7 @@ module ApiV1
 
       def from_hash(data, options={})
         data = data.with_indifferent_access
-        configuration_property.deserialize(data[:key], data[:value], data[:encrypted_value])
+        configuration_property.deserialize(data[:key], data[:value].to_s, data[:encrypted_value])
         configuration_property
       end
     end

--- a/server/webapp/WEB-INF/rails/spec/presenters/api_v1/config/plugin_configuration_property_representer_spec.rb
+++ b/server/webapp/WEB-INF/rails/spec/presenters/api_v1/config/plugin_configuration_property_representer_spec.rb
@@ -1,0 +1,101 @@
+##########################################################################
+# Copyright 2019 ThoughtWorks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+
+require 'rails_helper'
+
+describe ApiV1::Config::PluginConfigurationPropertyRepresenter do
+  describe 'serialize' do
+    it 'non-secure configuration value with hal representation' do
+      actual_json   = ApiV1::Config::PluginConfigurationPropertyRepresenter.new(get_non_secure_property).to_hash(url_builder: UrlBuilder.new)
+      expect(actual_json).to eq(get_plain_text_hash)
+    end
+
+    it 'secure configuration value with hal representation' do
+      actual_json   = ApiV1::Config::PluginConfigurationPropertyRepresenter.new(get_secure_property).to_hash(url_builder: UrlBuilder.new)
+      expect(actual_json).to eq(secure_hash_with_encrypted_value)
+    end
+  end
+
+  describe 'deserialize' do
+    it 'from hash with encrypted value' do
+      configuration_property = ConfigurationProperty.new
+      presenter = ApiV1::Config::PluginConfigurationPropertyRepresenter.new(configuration_property)
+      presenter.from_hash(secure_hash_with_encrypted_value)
+      expect(configuration_property).to eq(get_secure_property)
+    end
+
+    it 'from hash with clear text value' do
+      configuration_property = ConfigurationProperty.new
+      presenter = ApiV1::Config::PluginConfigurationPropertyRepresenter.new(configuration_property)
+      presenter.from_hash(get_plain_text_hash)
+      expect(configuration_property).to eq(get_non_secure_property)
+    end
+
+    it 'should handle boolean as string' do
+      configuration_property = ConfigurationProperty.new
+      presenter = ApiV1::Config::PluginConfigurationPropertyRepresenter.new(configuration_property)
+
+      presenter.from_hash({key: 'boolean-prop', value: true})
+
+      expect(configuration_property).to eq(property('boolean-prop', 'true'))
+    end
+
+    it 'should handle nil' do
+      configuration_property = ConfigurationProperty.new
+      presenter = ApiV1::Config::PluginConfigurationPropertyRepresenter.new(configuration_property)
+
+      presenter.from_hash({key: 'null-prop', value: nil})
+
+      expect(configuration_property).to eq(property('null-prop', nil))
+    end
+
+    it 'should handle missing value' do
+      configuration_property = ConfigurationProperty.new
+      presenter = ApiV1::Config::PluginConfigurationPropertyRepresenter.new(configuration_property)
+
+      presenter.from_hash({key: 'missing-value-prop'})
+
+      expect(configuration_property).to eq(property('missing-value-prop', nil))
+    end
+  end
+
+  def property(key, value)
+    value_to_use = value.nil? ? nil : ConfigurationValue.new(value)
+    ConfigurationProperty.new(ConfigurationKey.new(key), value_to_use)
+  end
+
+  def get_non_secure_property
+    property('key', 'non-encrypted-value')
+  end
+
+  def get_secure_property
+    ConfigurationProperty.new(ConfigurationKey.new('key'), EncryptedConfigurationValue.new(GoCipher.new.encrypt('confidential')))
+  end
+
+  def secure_hash_with_encrypted_value
+    {
+      key: "key",
+      encrypted_value: GoCipher.new.encrypt('confidential')
+    }
+  end
+
+  def get_plain_text_hash
+    {
+      key:   'key',
+      value:  'non-encrypted-value'
+    }
+  end
+end

--- a/server/webapp/WEB-INF/rails/spec/presenters/api_v1/scms/pluggable_scm_representer_spec.rb
+++ b/server/webapp/WEB-INF/rails/spec/presenters/api_v1/scms/pluggable_scm_representer_spec.rb
@@ -1,5 +1,5 @@
 ##########################################################################
-# Copyright 2016 ThoughtWorks, Inc.
+# Copyright 2019 ThoughtWorks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -40,52 +40,6 @@ describe ApiV1::Scms::PluggableScmRepresenter do
     deserialized_scm = SCM.new
     ApiV1::Scms::PluggableScmRepresenter.new(deserialized_scm).from_hash(json)
     expect(deserialized_scm).to eq(@scm)
-  end
-
-  it 'should render configuration value with hal representation' do
-    actual_json   = ApiV1::Config::PluginConfigurationPropertyRepresenter.new(get_non_secure_property).to_hash(url_builder: UrlBuilder.new)
-    expect(actual_json).to eq(get_plain_text_hash)
-  end
-
-  it 'should render secure configuration value with hal representation' do
-    actual_json   = ApiV1::Config::PluginConfigurationPropertyRepresenter.new(get_secure_property).to_hash(url_builder: UrlBuilder.new)
-    expect(actual_json).to eq(secure_hash_with_encrypted_value)
-  end
-
-  it 'should convert from hash with encrypted value to Configuration Property' do
-    configuration_property    = ConfigurationProperty.new
-    presenter = ApiV1::Config::PluginConfigurationPropertyRepresenter.new(configuration_property)
-    presenter.from_hash(secure_hash_with_encrypted_value)
-    expect(configuration_property).to eq(get_secure_property)
-  end
-
-  it 'should convert from hash with clear text value to Configuration Property' do
-    configuration_property    = ConfigurationProperty.new
-    presenter = ApiV1::Config::PluginConfigurationPropertyRepresenter.new(configuration_property)
-    presenter.from_hash(get_plain_text_hash)
-    expect(configuration_property).to eq(get_non_secure_property)
-  end
-
-  def get_non_secure_property
-    ConfigurationProperty.new(ConfigurationKey.new('key'), ConfigurationValue.new('non-encrypted-value'))
-  end
-
-  def get_secure_property
-    ConfigurationProperty.new(ConfigurationKey.new('key'), EncryptedConfigurationValue.new(GoCipher.new.encrypt('confidential')))
-  end
-
-  def get_plain_text_hash
-    {
-        key:   'key',
-        value:  'non-encrypted-value'
-    }
-  end
-
-  def secure_hash_with_encrypted_value
-    {
-        key: "key",
-        encrypted_value: GoCipher.new.encrypt('confidential')
-    }
   end
 
   def json


### PR DESCRIPTION
If plugin settings UI has a checkbox with code such as:

```
<input type="checkbox" ng-model="abc1" id="abc1" ng-true-value="true" ng-false-value="false" />
```

then, upon save, it fails with an exception in the GoCD server logs:

```
ERROR [qtp1275035040-38] Rails:-2 -
ERROR [qtp1275035040-38] Rails:-2 - TypeError (cannot convert instance of class org.jruby.RubyBoolean$False to class java.lang.String):
ERROR [qtp1275035040-38] Rails:-2 -
ERROR [qtp1275035040-38] Rails:-2 - app/presenters/api_v1/config/plugin_configuration_property_representer.rb:47:in `from_hash'
app/presenters/api_v1/base_representer.rb:105:in `from_hash'
app/controllers/api_v1/admin/plugin_settings_controller.rb:31:in `create'
```

This PR allows it to accept: `[ { "key": "some.key.1", "value": true } ]` in the JSON and convert it to `[ { "key": "some.key.1", "value": "true" } ]` and use it.

To test this, you can use the two commands below. The second one will fail, without this change.

```
$ curl -v 'http://localhost:8153/go/api/admin/plugin_settings' \
    -H 'Accept: application/vnd.go.cd.v1+json' \
    -H 'Content-Type: application/json' \
    -X POST \
    -d '{ "plugin_id": "json.config.plugin", "configuration": [ { "key": "some.key.1", "value": "true" } ] }'
...
< HTTP/1.1 200 OK
< Content-Type: application/vnd.go.cd.v1+json; charset=utf-8

{
  "_links": {
    "self": {
      "href": "http://localhost:8153/go/api/admin/plugin_settings/json.config.plugin"
    },
    "doc": {
      "href": "https://api.gocd.org/19.2.0/#plugin-settings"
    },
    "find": {
      "href": "http://localhost:8153/go/api/admin/plugin_settings/:plugin_id"
    }
  },
  "plugin_id": "json.config.plugin",
  "configuration": [
    {
      "key": "some.key.1",
      "value": "true"
    }
  ]
}

$ curl -v 'http://localhost:8153/go/api/admin/plugin_settings' \
    -H 'Accept: application/vnd.go.cd.v1+json' \
    -H 'Content-Type: application/json' \
    -X POST \
    -d '{ "plugin_id": "json.config.plugin", "configuration": [ { "key": "some.key.1", "value": true } ] }'

< HTTP/1.1 500 Server Error
< Content-Type: text/html;charset=utf-8

<!DOCTYPE html>
<html>
<head>
  <title>We're sorry, but something went wrong (500)</title>

...

<body class="rails-default-error-page">
  <!-- This file lives in public/500.html -->
  <div class="dialog">
    <div>
      <h1>We're sorry, but something went wrong.</h1>
    </div>
    <p>If you are the application owner check the logs for more information.</p>
  </div>
</body>
</html>
```

To use this from a plugin, a recommended pattern in the UI should be:

```
<input type="checkbox" ng-model="abc1" id="abc1" ng-init="abc1 = abc1 || false" ng-true-value="true" ng-false-value="false" />
```