### PR TITLE
[Environment API Spark]: Compute MergedEnvironmentConfig etag using `Objects.hash`

### DIFF
--- a/api/api-environments-v2/src/main/java/com/thoughtworks/go/apiv2/environments/EnvironmentsControllerV2.java
+++ b/api/api-environments-v2/src/main/java/com/thoughtworks/go/apiv2/environments/EnvironmentsControllerV2.java
@@ -47,8 +47,9 @@ import spark.Response;
 
 import java.io.IOException;
 import java.util.Collection;
+import java.util.Comparator;
+import java.util.List;
 import java.util.Objects;
-import java.util.Set;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
@@ -96,7 +97,8 @@ public class EnvironmentsControllerV2 extends ApiController implements SparkSpri
     }
 
     public String index(Request request, Response response) throws IOException {
-        Set<EnvironmentConfig> environmentViewModelList = environmentConfigService.getEnvironments();
+        List<EnvironmentConfig> environmentViewModelList = environmentConfigService.getEnvironments().stream()
+                .sorted(Comparator.comparing(EnvironmentConfig::name)).collect(Collectors.toList());
 
         setEtagHeader(response, calculateEtag(environmentViewModelList));
 

--- a/api/api-environments-v2/src/main/java/com/thoughtworks/go/apiv2/environments/EnvironmentsControllerV2.java
+++ b/api/api-environments-v2/src/main/java/com/thoughtworks/go/apiv2/environments/EnvironmentsControllerV2.java
@@ -31,6 +31,7 @@ import com.thoughtworks.go.config.BasicEnvironmentConfig;
 import com.thoughtworks.go.config.EnvironmentConfig;
 import com.thoughtworks.go.config.exceptions.NoSuchEnvironmentException;
 import com.thoughtworks.go.config.exceptions.RecordNotFoundException;
+import com.thoughtworks.go.config.merge.MergeEnvironmentConfig;
 import com.thoughtworks.go.domain.ConfigElementForEdit;
 import com.thoughtworks.go.server.service.EntityHashingService;
 import com.thoughtworks.go.server.service.EnvironmentConfigService;
@@ -182,6 +183,9 @@ public class EnvironmentsControllerV2 extends ApiController implements SparkSpri
 
     @Override
     public String etagFor(EnvironmentConfig entityFromServer) {
+        if (entityFromServer instanceof MergeEnvironmentConfig) {
+            return DigestUtils.md5Hex(String.valueOf(Objects.hash(entityFromServer)));
+        }
         return entityHashingService.md5ForEntity(entityFromServer);
     }
 

--- a/api/api-environments-v2/src/main/java/com/thoughtworks/go/apiv2/environments/EnvironmentsControllerV2.java
+++ b/api/api-environments-v2/src/main/java/com/thoughtworks/go/apiv2/environments/EnvironmentsControllerV2.java
@@ -29,6 +29,7 @@ import com.thoughtworks.go.apiv2.environments.representers.EnvironmentsRepresent
 import com.thoughtworks.go.apiv2.environments.representers.PatchEnvironmentRequestRepresenter;
 import com.thoughtworks.go.config.BasicEnvironmentConfig;
 import com.thoughtworks.go.config.EnvironmentConfig;
+import com.thoughtworks.go.config.exceptions.NoSuchEnvironmentException;
 import com.thoughtworks.go.config.exceptions.RecordNotFoundException;
 import com.thoughtworks.go.domain.ConfigElementForEdit;
 import com.thoughtworks.go.server.service.EntityHashingService;
@@ -44,7 +45,9 @@ import spark.Request;
 import spark.Response;
 
 import java.io.IOException;
-import java.util.List;
+import java.util.Collection;
+import java.util.Objects;
+import java.util.Set;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
@@ -92,7 +95,7 @@ public class EnvironmentsControllerV2 extends ApiController implements SparkSpri
     }
 
     public String index(Request request, Response response) throws IOException {
-        List<EnvironmentConfig> environmentViewModelList = environmentConfigService.getAllMergedEnvironments();
+        Set<EnvironmentConfig> environmentViewModelList = environmentConfigService.getEnvironments();
 
         setEtagHeader(response, calculateEtag(environmentViewModelList));
 
@@ -184,9 +187,11 @@ public class EnvironmentsControllerV2 extends ApiController implements SparkSpri
 
     @Override
     public EnvironmentConfig doFetchEntityFromConfig(String name) {
-        ConfigElementForEdit<EnvironmentConfig> mergedEnvironmentforDisplay = environmentConfigService.getMergedEnvironmentforDisplay(name, new HttpLocalizedOperationResult());
-
-        return mergedEnvironmentforDisplay == null ? null : mergedEnvironmentforDisplay.getConfigElement();
+        try {
+            return environmentConfigService.getEnvironmentConfig(name);
+        } catch (NoSuchEnvironmentException e) {
+            throw new RecordNotFoundException(e);
+        }
     }
 
     @Override
@@ -212,7 +217,7 @@ public class EnvironmentsControllerV2 extends ApiController implements SparkSpri
         throw haltBecauseEntityAlreadyExists(jsonWriter(environmentConfig), "environment", environmentConfig.name().toString());
     }
 
-    private String calculateEtag(List<EnvironmentConfig> environmentConfigs) {
+    private String calculateEtag(Collection<EnvironmentConfig> environmentConfigs) {
         final String environmentConfigSegment = environmentConfigs
                 .stream()
                 .map(this::etagFor)

--- a/api/api-environments-v2/src/main/java/com/thoughtworks/go/apiv2/environments/representers/EnvironmentRepresenter.java
+++ b/api/api-environments-v2/src/main/java/com/thoughtworks/go/apiv2/environments/representers/EnvironmentRepresenter.java
@@ -60,11 +60,11 @@ public class EnvironmentRepresenter {
 
         jsonReader.readArrayIfPresent("environment_variables",
                 array -> array.forEach(envVar -> {
-                        String name = envVar.getAsJsonObject().get("name").getAsString();
-                        String value = envVar.getAsJsonObject().get("value").getAsString();
-                        boolean secure = envVar.getAsJsonObject().get("secure").getAsBoolean();
-                        environmentConfig.addEnvironmentVariable(new EnvironmentVariableConfig(new GoCipher(), name, value, secure));
-                    }
+                            String name = envVar.getAsJsonObject().get("name").getAsString();
+                            String value = envVar.getAsJsonObject().get("value").getAsString();
+                            boolean secure = envVar.getAsJsonObject().get("secure").getAsBoolean();
+                            environmentConfig.addEnvironmentVariable(new EnvironmentVariableConfig(new GoCipher(), name, value, secure));
+                        }
                 )
         );
 

--- a/api/api-environments-v2/src/main/java/com/thoughtworks/go/apiv2/environments/representers/EnvironmentsRepresenter.java
+++ b/api/api-environments-v2/src/main/java/com/thoughtworks/go/apiv2/environments/representers/EnvironmentsRepresenter.java
@@ -20,18 +20,18 @@ import com.thoughtworks.go.api.base.OutputWriter;
 import com.thoughtworks.go.config.EnvironmentConfig;
 import com.thoughtworks.go.spark.Routes;
 
-import java.util.List;
+import java.util.Collection;
 
 public class EnvironmentsRepresenter {
-    public static void toJSON(OutputWriter writer, List<EnvironmentConfig> environmentViewModelList) {
-            writer.addLinks(
-                    outputLinkWriter -> outputLinkWriter
-                            .addLink("self", Routes.Environments.BASE)
-                            .addAbsoluteLink("doc", Routes.Environments.DOC))
-                    .addChild("_embedded",
-                            embeddedWriter -> embeddedWriter.addChildList("environments",
-                                    environmentsWriter -> environmentViewModelList.forEach(
-                                            environment -> environmentsWriter.addChild(
-                                                    environmentWriter -> EnvironmentRepresenter.toJSON(environmentWriter, environment)))));
+    public static void toJSON(OutputWriter writer, Collection<EnvironmentConfig> environmentViewModelList) {
+        writer.addLinks(
+                outputLinkWriter -> outputLinkWriter
+                        .addLink("self", Routes.Environments.BASE)
+                        .addAbsoluteLink("doc", Routes.Environments.DOC))
+                .addChild("_embedded",
+                        embeddedWriter -> embeddedWriter.addChildList("environments",
+                                environmentsWriter -> environmentViewModelList.forEach(
+                                        environment -> environmentsWriter.addChild(
+                                                environmentWriter -> EnvironmentRepresenter.toJSON(environmentWriter, environment)))));
     }
 }

--- a/api/api-environments-v2/src/main/java/com/thoughtworks/go/apiv2/environments/representers/PatchEnvironmentRequestRepresenter.java
+++ b/api/api-environments-v2/src/main/java/com/thoughtworks/go/apiv2/environments/representers/PatchEnvironmentRequestRepresenter.java
@@ -50,9 +50,9 @@ public class PatchEnvironmentRequestRepresenter {
             envVariableToRemove.addAll(reader.readStringArrayIfPresent("remove").orElse(emptyList()));
 
             reader.readArrayIfPresent("add", array ->
-                            array.forEach(envVariable -> envVariablesToAdd
-                                    .add(EnvironmentVariableRepresenter.fromJSON(envVariable.getAsJsonObject()))
-                            ));
+                    array.forEach(envVariable -> envVariablesToAdd
+                            .add(EnvironmentVariableRepresenter.fromJSON(envVariable.getAsJsonObject()))
+                    ));
         });
 
         PatchEnvironmentRequest patchRequest = new PatchEnvironmentRequest(

--- a/api/api-environments-v2/src/main/java/com/thoughtworks/go/apiv2/environments/representers/PipelineRepresenter.java
+++ b/api/api-environments-v2/src/main/java/com/thoughtworks/go/apiv2/environments/representers/PipelineRepresenter.java
@@ -32,6 +32,6 @@ public class PipelineRepresenter {
         String pipelineName = pipelineConfig.getName().toString();
         linksWriter.addLink("self", Routes.Pipeline.history(pipelineName))
                 .addAbsoluteLink("doc", Routes.Pipeline.DOC)
-        .addAbsoluteLink("find", Routes.PipelineConfig.find());
+                .addAbsoluteLink("find", Routes.PipelineConfig.find());
     }
 }

--- a/api/api-environments-v2/src/test/groovy/com/thoughtworks/go/apiv2/environments/EnvironmentsControllerV2Test.groovy
+++ b/api/api-environments-v2/src/test/groovy/com/thoughtworks/go/apiv2/environments/EnvironmentsControllerV2Test.groovy
@@ -94,7 +94,7 @@ class EnvironmentsControllerV2Test implements SecurityServiceTrait, ControllerTr
         env1.addPipeline(new CaseInsensitiveString("Pipeline2"))
 
         when(entityHashingService.md5ForEntity(env1)).thenReturn("md5-hash")
-        when(environmentConfigService.getMergedEnvironmentforDisplay(eq("env1"), any(HttpLocalizedOperationResult.class))).thenReturn(new ConfigElementForEdit(env1, "md5-hash"))
+        when(environmentConfigService.getEnvironmentConfig(eq("env1"))).thenReturn(env1)
 
         getWithApiHeader(controller.controllerPath("env1"))
 
@@ -154,7 +154,7 @@ class EnvironmentsControllerV2Test implements SecurityServiceTrait, ControllerTr
         env1.addPipeline(new CaseInsensitiveString("Pipeline1"))
         env1.addPipeline(new CaseInsensitiveString("Pipeline2"))
 
-        when(environmentConfigService.getMergedEnvironmentforDisplay(anyString(), any(HttpLocalizedOperationResult.class))).thenReturn(new ConfigElementForEdit(env1, "3123abcef"))
+        when(environmentConfigService.getEnvironmentConfig(anyString())).thenReturn(env1)
         when(environmentConfigService.deleteEnvironment(eq(env1), eq(currentUsername()), any(HttpLocalizedOperationResult))).then({
           InvocationOnMock invocation ->
             HttpLocalizedOperationResult result = (HttpLocalizedOperationResult) invocation.getArguments().last()
@@ -223,14 +223,11 @@ class EnvironmentsControllerV2Test implements SecurityServiceTrait, ControllerTr
         newConfig.addPipeline(new CaseInsensitiveString("Pipeline1"))
 
         when(entityHashingService.md5ForEntity(existingConfig)).thenReturn("ffff")
-        when(environmentConfigService.getMergedEnvironmentforDisplay(
-          eq("env1"),
-          any(HttpLocalizedOperationResult))
-        ).thenReturn(new ConfigElementForEdit<>(existingConfig, "ffff"))
+        when(environmentConfigService.getEnvironmentConfig(eq("env1"))).thenReturn(existingConfig)
 
         def json = toObjectString({ EnvironmentRepresenter.toJSON(it, newConfig) })
 
-        putWithApiHeader(controller.controllerPath("env1"),['if-match': 'ffff'], json)
+        putWithApiHeader(controller.controllerPath("env1"), ['if-match': 'ffff'], json)
 
         assertThatResponse()
           .isUnprocessableEntity()
@@ -245,16 +242,13 @@ class EnvironmentsControllerV2Test implements SecurityServiceTrait, ControllerTr
         env1.addPipeline(new CaseInsensitiveString("Pipeline1"))
 
 
-        when(environmentConfigService.getMergedEnvironmentforDisplay(
-          eq("env1"),
-          any(HttpLocalizedOperationResult))
-        ).thenReturn(new ConfigElementForEdit<>(env1, "ffff"))
+        when(environmentConfigService.getEnvironmentConfig(eq("env1"))).thenReturn(env1)
 
         when(entityHashingService.md5ForEntity(env1)).thenReturn("wrong-md5")
 
         def json = toObjectString({ EnvironmentRepresenter.toJSON(it, env1) })
 
-        putWithApiHeader(controller.controllerPath("env1"),['if-match': 'ffff'], json)
+        putWithApiHeader(controller.controllerPath("env1"), ['if-match': 'ffff'], json)
 
         assertThatResponse()
           .isPreconditionFailed()
@@ -272,10 +266,7 @@ class EnvironmentsControllerV2Test implements SecurityServiceTrait, ControllerTr
 
         when(entityHashingService.md5ForEntity(env1)).thenReturn("ffff")
 
-        when(
-            environmentConfigService.getMergedEnvironmentforDisplay(eq("env1"),
-            any(HttpLocalizedOperationResult))
-        ).thenReturn(new ConfigElementForEdit<>(env1, "ffff"))
+        when(environmentConfigService.getEnvironmentConfig(eq("env1"))).thenReturn(env1)
 
         when(environmentConfigService.updateEnvironment(eq("env1"), eq(env1), eq(currentUsername()), anyString(), any(HttpLocalizedOperationResult))).then({
           InvocationOnMock invocation ->
@@ -285,7 +276,7 @@ class EnvironmentsControllerV2Test implements SecurityServiceTrait, ControllerTr
 
         def json = toObjectString({ EnvironmentRepresenter.toJSON(it, env1) })
 
-        putWithApiHeader(controller.controllerPath("env1"),['if-match': 'ffff'], json)
+        putWithApiHeader(controller.controllerPath("env1"), ['if-match': 'ffff'], json)
 
         assertThatResponse()
           .isOk()
@@ -296,7 +287,7 @@ class EnvironmentsControllerV2Test implements SecurityServiceTrait, ControllerTr
       @Test
       void 'should error out if the environment does not exist'() {
         when(environmentConfigService.getMergedEnvironmentforDisplay(eq("env1"), any(HttpLocalizedOperationResult)))
-        .then({
+          .then({
           InvocationOnMock invocation ->
             def result = (HttpLocalizedOperationResult) invocation.arguments.last()
             result.badRequest("The environment does not exist")
@@ -352,12 +343,10 @@ class EnvironmentsControllerV2Test implements SecurityServiceTrait, ControllerTr
         updatedConfig.addPipeline(new CaseInsensitiveString("Pipeline2"))
 
         when(entityHashingService.md5ForEntity(updatedConfig)).thenReturn("md5-hash")
-        when(environmentConfigService.getMergedEnvironmentforDisplay(eq("env1"), any(HttpLocalizedOperationResult)))
-          .thenReturn(new ConfigElementForEdit<>(oldConfig, "old_md5_hash"))
-        when(environmentConfigService.getMergedEnvironmentforDisplay(eq("env1"), any(HttpLocalizedOperationResult)))
-          .thenReturn(new ConfigElementForEdit<>(updatedConfig, "new_md5_hash"))
+        when(environmentConfigService.getEnvironmentConfig(eq("env1"))).thenReturn(oldConfig)
+        when(environmentConfigService.getEnvironmentConfig(eq("env1"))).thenReturn(updatedConfig)
         when(environmentConfigService.patchEnvironment(
-          eq(oldConfig), anyList(), anyList(), anyList(), anyList(),anyList(), anyList(),eq(currentUsername()), any(HttpLocalizedOperationResult))
+          eq(oldConfig), anyList(), anyList(), anyList(), anyList(), anyList(), anyList(), eq(currentUsername()), any(HttpLocalizedOperationResult))
         ).then({
           InvocationOnMock invocation ->
             HttpLocalizedOperationResult result = (HttpLocalizedOperationResult) invocation.arguments.last()
@@ -366,16 +355,16 @@ class EnvironmentsControllerV2Test implements SecurityServiceTrait, ControllerTr
 
 
         patchWithApiHeader(controller.controllerPath("env1"), [
-          "pipelines": [
-            "add": [
+          "pipelines"            : [
+            "add"   : [
               "Pipeline1", "Pipeline2"
             ],
             "remove": [
               "Pipeline3"
             ]
           ],
-          "agents": [
-            "add": [
+          "agents"               : [
+            "add"   : [
               "agent1"
             ],
             "remove": [
@@ -383,9 +372,9 @@ class EnvironmentsControllerV2Test implements SecurityServiceTrait, ControllerTr
             ]
           ],
           "environment_variables": [
-            "add": [
+            "add"   : [
               [
-                "name": "JAVA_HOME",
+                "name" : "JAVA_HOME",
                 "value": "/bin/java"
               ]
             ],
@@ -526,9 +515,9 @@ class EnvironmentsControllerV2Test implements SecurityServiceTrait, ControllerTr
 
         def env2 = new BasicEnvironmentConfig(new CaseInsensitiveString("env2"))
 
-        def listOfEnvironmentConfigs = [env1, env2]
+        def listOfEnvironmentConfigs = new HashSet([env1, env2])
 
-        when(environmentConfigService.getAllMergedEnvironments()).thenReturn(listOfEnvironmentConfigs)
+        when(environmentConfigService.getEnvironments()).thenReturn(listOfEnvironmentConfigs)
 
         getWithApiHeader(controller.controllerBasePath())
 

--- a/api/api-environments-v2/src/test/groovy/com/thoughtworks/go/apiv2/environments/EnvironmentsControllerV2Test.groovy
+++ b/api/api-environments-v2/src/test/groovy/com/thoughtworks/go/apiv2/environments/EnvironmentsControllerV2Test.groovy
@@ -505,24 +505,26 @@ class EnvironmentsControllerV2Test implements SecurityServiceTrait, ControllerTr
       }
 
       @Test
-      void 'should return all configured environments'() {
-        def env1 = new BasicEnvironmentConfig(new CaseInsensitiveString("env1"))
-        env1.addAgent("agent1")
-        env1.addAgent("agent2")
-        env1.addEnvironmentVariable("JAVA_HOME", "/bin/java")
-        env1.addPipeline(new CaseInsensitiveString("Pipeline1"))
-        env1.addPipeline(new CaseInsensitiveString("Pipeline2"))
+      void 'should sort environments by name and return all configured environments'() {
+        def prodEnv = new BasicEnvironmentConfig(new CaseInsensitiveString("prod"))
+        prodEnv.addAgent("agent1")
+        prodEnv.addAgent("agent2")
+        prodEnv.addEnvironmentVariable("JAVA_HOME", "/bin/java")
+        prodEnv.addPipeline(new CaseInsensitiveString("Pipeline1"))
+        prodEnv.addPipeline(new CaseInsensitiveString("Pipeline2"))
 
-        def env2 = new BasicEnvironmentConfig(new CaseInsensitiveString("env2"))
+        def devEnv = new BasicEnvironmentConfig(new CaseInsensitiveString("dev"))
+        def qaEnv = new BasicEnvironmentConfig(new CaseInsensitiveString("qa"))
 
-        def listOfEnvironmentConfigs = new HashSet([env1, env2])
+        def listOfEnvironmentConfigs = new HashSet([qaEnv, devEnv, prodEnv])
 
         when(environmentConfigService.getEnvironments()).thenReturn(listOfEnvironmentConfigs)
 
         getWithApiHeader(controller.controllerBasePath())
-
+        
+        def environmentsConfigSortedByName = new LinkedHashSet([devEnv, prodEnv, qaEnv])
         assertThatResponse()
-          .hasBodyWithJsonObject(listOfEnvironmentConfigs, EnvironmentsRepresenter)
+          .hasBodyWithJsonObject(environmentsConfigSortedByName, EnvironmentsRepresenter)
       }
 
 
@@ -542,7 +544,7 @@ class EnvironmentsControllerV2Test implements SecurityServiceTrait, ControllerTr
           ]
         ]
 
-        when(environmentConfigService.getAllMergedEnvironments()).thenReturn([])
+        when(environmentConfigService.getEnvironments()).thenReturn(new HashSet<>([]))
 
         getWithApiHeader(controller.controllerBasePath())
 

--- a/api/api-environments-v2/src/test/groovy/com/thoughtworks/go/apiv2/environments/representers/AgentRepresenterTest.groovy
+++ b/api/api-environments-v2/src/test/groovy/com/thoughtworks/go/apiv2/environments/representers/AgentRepresenterTest.groovy
@@ -33,7 +33,7 @@ class AgentRepresenterTest {
 
     assertThatJson(json).isEqualTo([
       "_links": [
-        "doc": [
+        "doc" : [
           "href": apiDocsUrl("#agents")
         ],
         "find": [

--- a/api/api-environments-v2/src/test/groovy/com/thoughtworks/go/apiv2/environments/representers/AgentRepresenterTest.groovy
+++ b/api/api-environments-v2/src/test/groovy/com/thoughtworks/go/apiv2/environments/representers/AgentRepresenterTest.groovy
@@ -43,7 +43,7 @@ class AgentRepresenterTest {
           "href": "http://test.host/go/api/agents/agent1"
         ]
       ],
-      "uuid": "agent1"
+      "uuid"  : "agent1"
     ])
   }
 }

--- a/api/api-environments-v2/src/test/groovy/com/thoughtworks/go/apiv2/environments/representers/EnvironmentRepresenterTest.groovy
+++ b/api/api-environments-v2/src/test/groovy/com/thoughtworks/go/apiv2/environments/representers/EnvironmentRepresenterTest.groovy
@@ -32,8 +32,8 @@ class EnvironmentRepresenterTest {
   @Test
   void 'should de-serialize from JSON'() {
     def environmentConfig = [
-      "_links": [
-        "doc": [
+      "_links"               : [
+        "doc" : [
           "href": "https://api.go.cd/current/#environment-config"
         ],
         "find": [
@@ -43,10 +43,10 @@ class EnvironmentRepresenterTest {
           "href": "http://test.host/go/api/admin/environments/env1"
         ]
       ],
-      "agents": [
+      "agents"               : [
         [
           "_links": [
-            "doc": [
+            "doc" : [
               "href": apiDocsUrl("#agents")
             ],
             "find": [
@@ -56,11 +56,11 @@ class EnvironmentRepresenterTest {
               "href": "http://test.host/go/api/agents/agent1"
             ]
           ],
-          "uuid": "agent1"
+          "uuid"  : "agent1"
         ],
         [
           "_links": [
-            "doc": [
+            "doc" : [
               "href": apiDocsUrl("#agents")
             ],
             "find": [
@@ -70,21 +70,21 @@ class EnvironmentRepresenterTest {
               "href": "http://test.host/go/api/agents/agent2"
             ]
           ],
-          "uuid": "agent2"
+          "uuid"  : "agent2"
         ]
       ],
       "environment_variables": [
         [
-          "name": "JAVA_HOME",
+          "name"  : "JAVA_HOME",
           "secure": false,
-          "value": "/bin/java"
+          "value" : "/bin/java"
         ]
       ],
-      "name": "env1",
-      "pipelines": [
+      "name"                 : "env1",
+      "pipelines"            : [
         [
           "_links": [
-            "doc": [
+            "doc" : [
               "href": "https://api.go.cd/current/#pipelines"
             ],
             "find": [
@@ -94,11 +94,11 @@ class EnvironmentRepresenterTest {
               "href": "http://test.host/go/api/pipelines/Pipeline1/history"
             ]
           ],
-          "name": "Pipeline1"
+          "name"  : "Pipeline1"
         ],
         [
           "_links": [
-            "doc": [
+            "doc" : [
               "href": "https://api.go.cd/current/#pipelines"
             ],
             "find": [
@@ -108,7 +108,7 @@ class EnvironmentRepresenterTest {
               "href": "http://test.host/go/api/pipelines/Pipeline2/history"
             ]
           ],
-          "name": "Pipeline2"
+          "name"  : "Pipeline2"
         ]
       ]
     ]
@@ -138,8 +138,8 @@ class EnvironmentRepresenterTest {
     def json = toObjectString({ EnvironmentRepresenter.toJSON(it, env1) })
 
     def response = [
-      "_links": [
-        "doc": [
+      "_links"               : [
+        "doc" : [
           "href": "https://api.go.cd/current/#environment-config"
         ],
         "find": [
@@ -149,10 +149,10 @@ class EnvironmentRepresenterTest {
           "href": "http://test.host/go/api/admin/environments/env1"
         ]
       ],
-      "agents": [
+      "agents"               : [
         [
           "_links": [
-            "doc": [
+            "doc" : [
               "href": apiDocsUrl("#agents")
             ],
             "find": [
@@ -162,11 +162,11 @@ class EnvironmentRepresenterTest {
               "href": "http://test.host/go/api/agents/agent1"
             ]
           ],
-          "uuid": "agent1"
+          "uuid"  : "agent1"
         ],
         [
           "_links": [
-            "doc": [
+            "doc" : [
               "href": apiDocsUrl("#agents")
             ],
             "find": [
@@ -176,21 +176,21 @@ class EnvironmentRepresenterTest {
               "href": "http://test.host/go/api/agents/agent2"
             ]
           ],
-          "uuid": "agent2"
+          "uuid"  : "agent2"
         ]
       ],
       "environment_variables": [
         [
-          "name": "JAVA_HOME",
+          "name"  : "JAVA_HOME",
           "secure": false,
-          "value": "/bin/java"
+          "value" : "/bin/java"
         ]
       ],
-      "name": "env1",
-      "pipelines": [
+      "name"                 : "env1",
+      "pipelines"            : [
         [
           "_links": [
-            "doc": [
+            "doc" : [
               "href": "https://api.go.cd/current/#pipelines"
             ],
             "find": [
@@ -200,11 +200,11 @@ class EnvironmentRepresenterTest {
               "href": "http://test.host/go/api/pipelines/Pipeline1/history"
             ]
           ],
-          "name": "Pipeline1"
+          "name"  : "Pipeline1"
         ],
         [
           "_links": [
-            "doc": [
+            "doc" : [
               "href": "https://api.go.cd/current/#pipelines"
             ],
             "find": [
@@ -214,7 +214,7 @@ class EnvironmentRepresenterTest {
               "href": "http://test.host/go/api/pipelines/Pipeline2/history"
             ]
           ],
-          "name": "Pipeline2"
+          "name"  : "Pipeline2"
         ]
       ]
     ]

--- a/api/api-environments-v2/src/test/groovy/com/thoughtworks/go/apiv2/environments/representers/EnvironmentVariableRepresenterTest.groovy
+++ b/api/api-environments-v2/src/test/groovy/com/thoughtworks/go/apiv2/environments/representers/EnvironmentVariableRepresenterTest.groovy
@@ -16,11 +16,9 @@
 
 package com.thoughtworks.go.apiv2.environments.representers
 
-
 import com.thoughtworks.go.config.EnvironmentVariableConfig
 import com.thoughtworks.go.security.GoCipher
 import org.junit.jupiter.api.Test
-
 
 import static com.thoughtworks.go.api.base.JsonUtils.toObjectString
 import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson
@@ -29,27 +27,27 @@ class EnvironmentVariableRepresenterTest {
 
   @Test
   void 'should serialize to JSON'() {
-    EnvironmentVariableConfig config = new EnvironmentVariableConfig("JAVA_HOME","/bin/java")
+    EnvironmentVariableConfig config = new EnvironmentVariableConfig("JAVA_HOME", "/bin/java")
 
     def json = toObjectString({ EnvironmentVariableRepresenter.toJSON(it, config) })
 
     assertThatJson(json).isEqualTo([
-      "name": "JAVA_HOME",
+      "name"  : "JAVA_HOME",
       "secure": false,
-      "value": "/bin/java"
+      "value" : "/bin/java"
     ])
   }
 
   @Test
   void 'should serialize secure environment variable to JSON'() {
-    EnvironmentVariableConfig config = new EnvironmentVariableConfig(new GoCipher(),"secret","password",true)
+    EnvironmentVariableConfig config = new EnvironmentVariableConfig(new GoCipher(), "secret", "password", true)
 
     def json = toObjectString({ EnvironmentVariableRepresenter.toJSON(it, config) })
 
     assertThatJson(json).isEqualTo([
       "encrypted_value": "****",
-      "name": "secret",
-      "secure": true
+      "name"           : "secret",
+      "secure"         : true
     ])
   }
 }

--- a/api/api-environments-v2/src/test/groovy/com/thoughtworks/go/apiv2/environments/representers/EnvironmentsRepresenterTest.groovy
+++ b/api/api-environments-v2/src/test/groovy/com/thoughtworks/go/apiv2/environments/representers/EnvironmentsRepresenterTest.groovy
@@ -49,8 +49,8 @@ class EnvironmentsRepresenterTest {
       "_embedded": [
         "environments": [
           [
-            "_links": [
-              "doc": [
+            "_links"               : [
+              "doc" : [
                 "href": "https://api.go.cd/current/#environment-config"
               ],
               "find": [
@@ -60,10 +60,10 @@ class EnvironmentsRepresenterTest {
                 "href": "http://test.host/go/api/admin/environments/env1"
               ]
             ],
-            "agents": [
+            "agents"               : [
               [
                 "_links": [
-                  "doc": [
+                  "doc" : [
                     "href": apiDocsUrl("#agents")
                   ],
                   "find": [
@@ -73,11 +73,11 @@ class EnvironmentsRepresenterTest {
                     "href": "http://test.host/go/api/agents/agent1"
                   ]
                 ],
-                "uuid": "agent1"
+                "uuid"  : "agent1"
               ],
               [
                 "_links": [
-                  "doc": [
+                  "doc" : [
                     "href": apiDocsUrl("#agents")
                   ],
                   "find": [
@@ -87,21 +87,21 @@ class EnvironmentsRepresenterTest {
                     "href": "http://test.host/go/api/agents/agent2"
                   ]
                 ],
-                "uuid": "agent2"
+                "uuid"  : "agent2"
               ]
             ],
             "environment_variables": [
               [
-                "name": "JAVA_HOME",
+                "name"  : "JAVA_HOME",
                 "secure": false,
-                "value": "/bin/java"
+                "value" : "/bin/java"
               ]
             ],
-            "name": "env1",
-            "pipelines": [
+            "name"                 : "env1",
+            "pipelines"            : [
               [
                 "_links": [
-                  "doc": [
+                  "doc" : [
                     "href": "https://api.go.cd/current/#pipelines"
                   ],
                   "find": [
@@ -111,11 +111,11 @@ class EnvironmentsRepresenterTest {
                     "href": "http://test.host/go/api/pipelines/Pipeline1/history"
                   ]
                 ],
-                "name": "Pipeline1"
+                "name"  : "Pipeline1"
               ],
               [
                 "_links": [
-                  "doc": [
+                  "doc" : [
                     "href": "https://api.go.cd/current/#pipelines"
                   ],
                   "find": [
@@ -125,13 +125,13 @@ class EnvironmentsRepresenterTest {
                     "href": "http://test.host/go/api/pipelines/Pipeline2/history"
                   ]
                 ],
-                "name": "Pipeline2"
+                "name"  : "Pipeline2"
               ]
             ]
           ],
           [
-            "_links": [
-              "doc": [
+            "_links"               : [
+              "doc" : [
                 "href": "https://api.go.cd/current/#environment-config"
               ],
               "find": [
@@ -141,19 +141,19 @@ class EnvironmentsRepresenterTest {
                 "href": "http://test.host/go/api/admin/environments/env2"
               ]
             ],
-            "agents": [],
+            "agents"               : [],
             "environment_variables": [
               [
-                "name": "GROOVY_HOME",
+                "name"  : "GROOVY_HOME",
                 "secure": false,
-                "value": "/bin/groovy"
+                "value" : "/bin/groovy"
               ]
             ],
-            "name": "env2",
-            "pipelines": [
+            "name"                 : "env2",
+            "pipelines"            : [
               [
                 "_links": [
-                  "doc": [
+                  "doc" : [
                     "href": "https://api.go.cd/current/#pipelines"
                   ],
                   "find": [
@@ -163,14 +163,14 @@ class EnvironmentsRepresenterTest {
                     "href": "http://test.host/go/api/pipelines/Pipeline3/history"
                   ]
                 ],
-                "name": "Pipeline3"
+                "name"  : "Pipeline3"
               ]
             ]
           ]
         ]
       ],
-      "_links": [
-        "doc": [
+      "_links"   : [
+        "doc" : [
           "href": "https://api.go.cd/current/#environment-config"
         ],
         "self": [
@@ -188,8 +188,8 @@ class EnvironmentsRepresenterTest {
       "_embedded": [
         "environments": []
       ],
-      "_links": [
-        "doc": [
+      "_links"   : [
+        "doc" : [
           "href": "https://api.go.cd/current/#environment-config"
         ],
         "self": [

--- a/api/api-environments-v2/src/test/groovy/com/thoughtworks/go/apiv2/environments/representers/PatchEnvironmentRequestRepresenterTest.groovy
+++ b/api/api-environments-v2/src/test/groovy/com/thoughtworks/go/apiv2/environments/representers/PatchEnvironmentRequestRepresenterTest.groovy
@@ -43,8 +43,8 @@ class PatchEnvironmentRequestRepresenterTest {
             "value": "https://ci.example.com/go"
           ],
           [
-            "name" : "GO_NO_SERVER_URL",
-            "value": "https://ci.example.com/go",
+            "name"  : "GO_NO_SERVER_URL",
+            "value" : "https://ci.example.com/go",
             "secure": true
           ]
         ],

--- a/api/api-environments-v2/src/test/groovy/com/thoughtworks/go/apiv2/environments/representers/PipelineRepresenterTest.groovy
+++ b/api/api-environments-v2/src/test/groovy/com/thoughtworks/go/apiv2/environments/representers/PipelineRepresenterTest.groovy
@@ -19,9 +19,9 @@ package com.thoughtworks.go.apiv2.environments.representers
 import com.thoughtworks.go.config.CaseInsensitiveString
 import com.thoughtworks.go.config.EnvironmentPipelineConfig
 import org.junit.jupiter.api.Test
+
 import static com.thoughtworks.go.api.base.JsonUtils.toObjectString
 import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson
-
 
 class PipelineRepresenterTest {
 
@@ -35,7 +35,7 @@ class PipelineRepresenterTest {
 
     assertThatJson(json).isEqualTo([
       "_links": [
-        "doc": [
+        "doc" : [
           "href": "https://api.go.cd/current/#pipelines"
         ],
         "find": [
@@ -45,7 +45,7 @@ class PipelineRepresenterTest {
           "href": "http://test.host/go/api/pipelines/pipeline1/history"
         ]
       ],
-      "name": "pipeline1"
+      "name"  : "pipeline1"
     ])
   }
 }


### PR DESCRIPTION
Issue link: #5807 

### Summary

Environment coming from config repo is represented using `MergedEnvironmentConfig`. The `EntityHashingService` is calculating hashes only for the config entities. As`MergedEnvironmentConfig` is not a config entity it fails to detect `@ConfigTag` annotation and fails to generate md5.

In ruby, we calculate the md5 on generated JSON payload for index calls.

### Fix

Calculate md5 using object hash.

- This is done as Environment coming from config repo represented using
  MergedEnvironmentConfig object and calculating Etag for none config
  the entity is not supported by entity hashing service.

- Here we have used `Objects.hash(...)` which generates an identical hash
  for the same valued objects.

- Sort the EnvironmentConfigs by name to guaranty the order in the response as well as for Etag computation.