### PR TITLE
Parse and merge ConfigRepos on change to ConfigRepoConfig #5792

### DIFF
--- a/server/src/main/java/com/thoughtworks/go/server/materials/ConfigMaterialUpdateListener.java
+++ b/server/src/main/java/com/thoughtworks/go/server/materials/ConfigMaterialUpdateListener.java
@@ -78,12 +78,13 @@ public class ConfigMaterialUpdateListener implements GoMessageListener<MaterialU
                 if (lastParseRevision == null) {
                     //never parsed
                     updateConfigurationFromCheckout(folder, modification, material);
-                } else if (latestModification.findRevisionFor(material.config())
-                        .hasChangedSince(lastParseRevision)) {
+                } else if (latestModification.findRevisionFor(material.config()).hasChangedSince(lastParseRevision) ||
+                        this.repoConfigDataSource.hasConfigRepoConfigChangedSinceLastUpdate(material.config())) {
                     // revision has changed. the config files might have been updated
                     updateConfigurationFromCheckout(folder, modification, material);
                 } else {
                     // revision is the same as last time, no need to parse again
+                    LOGGER.debug("[Config Material Update] Skipping parsing of Config material {} since material has no change since last parse.", material);
                 }
             }
             LOGGER.debug("[Config Material Update] Completed parsing of Config material {}.", material);

--- a/server/src/test-fast/java/com/thoughtworks/go/config/GoPartialConfigTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/config/GoPartialConfigTest.java
@@ -69,9 +69,9 @@ public class GoPartialConfigTest {
         when(cachedGoConfig.currentConfig()).thenReturn(cruiseConfig);
 
         configWatchList = new GoConfigWatchList(cachedGoConfig, mock(GoConfigService.class));
-        repoConfigDataSource = new GoRepoConfigDataSource(configWatchList, configPluginService, serverHealthService, configRepoService);
-        cachedGoPartials = new CachedGoPartials(serverHealthService);
         goConfigService = mock(GoConfigService.class);
+        repoConfigDataSource = new GoRepoConfigDataSource(configWatchList, configPluginService, serverHealthService, configRepoService, goConfigService);
+        cachedGoPartials = new CachedGoPartials(serverHealthService);
         serverHealthService = mock(ServerHealthService.class);
 
         updateCommand = null;

--- a/server/src/test-integration/java/com/thoughtworks/go/config/GoRepoConfigDataSourceIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/config/GoRepoConfigDataSourceIntegrationTest.java
@@ -80,7 +80,7 @@ public class GoRepoConfigDataSourceIntegrationTest {
         configHelper.usingCruiseConfigDao(goConfigDao).initializeConfigFile();
         configHelper.onSetUp();
 
-        GoRepoConfigDataSource repoConfigDataSource = new GoRepoConfigDataSource(configWatchList, configPluginService, serverHealthService, configRepoService);
+        GoRepoConfigDataSource repoConfigDataSource = new GoRepoConfigDataSource(configWatchList, configPluginService, serverHealthService, configRepoService, goConfigService);
         repoConfigDataSource.registerListener(new GoPartialConfig(repoConfigDataSource, configWatchList, goConfigService, cachedGoPartials, serverHealthService));
 
         configHelper.addTemplate("t1", "param1", "stage");


### PR DESCRIPTION
Fixes issue #2 in https://github.com/gocd/gocd/issues/5792

* ConfigRepos are not parsed and merged if there is no change in the
  ConfigRepo material since last parse. A change to the ConfigRepoConfig
  should force a parse and merge even if the material has not changed.