### PR TITLE
Fix for High CPU usage on Console Logs/Tests page

### DIFF
--- a/server/webapp/WEB-INF/rails/app/assets/javascripts/console_log_tailing.js
+++ b/server/webapp/WEB-INF/rails/app/assets/javascripts/console_log_tailing.js
@@ -86,5 +86,13 @@
       window.setTimeout(maybeHideGlobalBackToTopButton, 50);
     });
 
+    $(".console-area").on('consoleCompleted consoleUpdated consoleInteraction', function () {
+      $(window).trigger($.Event("resetPinOnScroll"), [{
+        calcRequiredScroll: function () {
+          return $(".console-area").offset().top - $("#header").outerHeight(true) - $(".page_header").outerHeight(true);
+        }
+      }]);
+    });
+
   });
 })(jQuery);

--- a/server/webapp/WEB-INF/rails/app/assets/javascripts/lib/jquery-pinOnScroll.js
+++ b/server/webapp/WEB-INF/rails/app/assets/javascripts/lib/jquery-pinOnScroll.js
@@ -87,12 +87,6 @@
       var throttledFixElement   = _.throttle(fixElement, 100);
       var throttledUnFixElement = _.throttle(unFixElement, 100);
 
-      window.setInterval(function () {
-        maybeCallUsingRequestAnimationFrame(function () {
-          throttledFixElement(elem, opts);
-        });
-      }, 100);
-
       $(window).on('scroll.pinOnScroll', function () {
         maybeCallUsingRequestAnimationFrame(function () {
           throttledFixElement(elem, opts);
@@ -104,7 +98,7 @@
           throttledUnFixElement(elem, opts);
           throttledFixElement(elem, opts);
         });
-      })
+      });
 
       $(window).on('resetPinOnScroll', function (e, eParams) {
             if (eParams.calcRequiredScroll) {

--- a/server/webapp/WEB-INF/rails/app/assets/javascripts/old_application.js
+++ b/server/webapp/WEB-INF/rails/app/assets/javascripts/old_application.js
@@ -319,7 +319,7 @@ jQuery(function () {
             jQuery('.back_to_top').fadeOut(200);
 
     });
-    jQuery('.back_to_top,.back-to-top-in-console').click(function(){
+    jQuery('#back_to_top,.back-to-top-in-console').click(function(){
         jQuery('body,html').stop(true).animate({scrollTop : 0},'fast');
     });
 });


### PR DESCRIPTION
Issue #5705

I was able to replicate the issue and concur with @arvindsv's findings - the `fixElement` function being called via `window.setInterval` was the culprit.

I tried increasing the interval value, and the CPU usage went down to 50% instead of 100%. However, it still seemed silly that the page should use that much CPU while doing nothing - no scrolling, no resizing, just sitting idle and eating CPU.

So I tried removing the `setInterval` function and the pages continued working normally. I couldn't find anything broken. The scroll and resize event handlers defined below it continue to pin the header and footer as required. I *think* the `setInterval` function should be safe to remove, but it would be good if someone else tests it too. (After all, it was originally added for some reason, right?)