### PR TITLE
Disallow users to use Access Token APIs in case plugin does not have capabilities (#5822)

### DIFF
--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/authorization/AuthorizationExtension.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/authorization/AuthorizationExtension.java
@@ -44,7 +44,6 @@ import static com.thoughtworks.go.plugin.domain.common.PluginConstants.AUTHORIZA
 
 @Component
 public class AuthorizationExtension extends AbstractExtension {
-
     private final HashMap<String, AuthorizationMessageConverter> messageHandlerMap = new HashMap<>();
 
     @Autowired
@@ -225,6 +224,11 @@ public class AuthorizationExtension extends AbstractExtension {
         });
     }
 
+    public boolean supportsPluginAPICallsRequiredForAccessToken(SecurityAuthConfig authConfig) {
+        String version = pluginManager.resolveExtensionVersion(authConfig.getPluginId(), AUTHORIZATION_EXTENSION, goSupportedVersions());
+        return !AuthorizationMessageConverterV1.VERSION.equals(version);
+    }
+
     public boolean isValidUser(String pluginId, String username, SecurityAuthConfig authConfig) {
         try {
             return pluginRequestHelper.submitRequest(pluginId, IS_VALID_USER, new DefaultPluginInteractionCallback<Boolean>() {
@@ -241,7 +245,6 @@ public class AuthorizationExtension extends AbstractExtension {
         } catch (Exception e) { //any error happened while verifying the user existence will lead to assume user does not exists.
             return false;
         }
-
     }
 
     public AuthorizationMessageConverter getMessageConverter(String version) {

--- a/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/authorization/AuthorizationExtensionTest.java
+++ b/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/authorization/AuthorizationExtensionTest.java
@@ -21,6 +21,8 @@ import com.thoughtworks.go.config.SecurityAuthConfig;
 import com.thoughtworks.go.config.SecurityAuthConfigs;
 import com.thoughtworks.go.domain.packagerepository.ConfigurationPropertyMother;
 import com.thoughtworks.go.plugin.access.ExtensionsRegistry;
+import com.thoughtworks.go.plugin.access.authorization.v1.AuthorizationMessageConverterV1;
+import com.thoughtworks.go.plugin.access.authorization.v2.AuthorizationMessageConverterV2;
 import com.thoughtworks.go.plugin.access.common.AbstractExtension;
 import com.thoughtworks.go.plugin.api.request.GoPluginApiRequest;
 import com.thoughtworks.go.plugin.api.response.DefaultGoPluginApiResponse;
@@ -89,6 +91,26 @@ public class AuthorizationExtensionTest {
         assertRequest(requestArgumentCaptor.getValue(), AUTHORIZATION_EXTENSION, "1.0", REQUEST_GET_CAPABILITIES, null);
         assertThat(capabilities.getSupportedAuthType().toString()).isEqualTo(SupportedAuthType.Password.toString());
         assertThat(capabilities.canSearch()).isEqualTo(true);
+    }
+
+    @Test
+    public void shouldReturnFalseForSupportsValidatingUserExistenceForAuthorizationExtensionV1() throws Exception {
+        String pluginId = "cd.go.ldap";
+        when(pluginManager.resolveExtensionVersion(pluginId, AUTHORIZATION_EXTENSION, SUPPORTED_VERSIONS)).thenReturn(AuthorizationMessageConverterV1.VERSION);
+        SecurityAuthConfig authConfig = new SecurityAuthConfig("ldap", pluginId, ConfigurationPropertyMother.create("url", false, "some-url"));
+
+        boolean expected = authorizationExtension.supportsPluginAPICallsRequiredForAccessToken(authConfig);
+        assertThat(expected).isFalse();
+    }
+
+    @Test
+    public void shouldReturnTrueForSupportsValidatingUserExistenceForAuthorizationExtensionV2() throws Exception {
+        String pluginId = "cd.go.ldap";
+        when(pluginManager.resolveExtensionVersion(pluginId, AUTHORIZATION_EXTENSION, SUPPORTED_VERSIONS)).thenReturn(AuthorizationMessageConverterV2.VERSION);
+        SecurityAuthConfig authConfig = new SecurityAuthConfig("ldap", pluginId, ConfigurationPropertyMother.create("url", false, "some-url"));
+
+        boolean expected = authorizationExtension.supportsPluginAPICallsRequiredForAccessToken(authConfig);
+        assertThat(expected).isTrue();
     }
 
     @Test
@@ -367,7 +389,7 @@ public class AuthorizationExtensionTest {
             boolean isValidUser = authorizationExtension.isValidUser(PLUGIN_ID, "fooUser", new SecurityAuthConfig("ldap", "cd.go.ldap", ConfigurationPropertyMother.create("foo", false, "bar")));
 
             assertRequest(requestArgumentCaptor.getValue(), AUTHORIZATION_EXTENSION, "2.0", IS_VALID_USER, requestBody);
-            assertThat(isValidUser, is(true));
+            assertThat(isValidUser).isTrue();
         }
 
         @Test
@@ -380,7 +402,7 @@ public class AuthorizationExtensionTest {
             boolean isValidUser = authorizationExtension.isValidUser(PLUGIN_ID, "fooUser", new SecurityAuthConfig("ldap", "cd.go.ldap", ConfigurationPropertyMother.create("foo", false, "bar")));
 
             assertRequest(requestArgumentCaptor.getValue(), AUTHORIZATION_EXTENSION, "2.0", IS_VALID_USER, requestBody);
-            assertThat(isValidUser, is(false));
+            assertThat(isValidUser).isFalse();
         }
 
         @Test


### PR DESCRIPTION

* Access Token feature requires authorization plugins to implement Authorization
  Extension v2.
* Do not allow users to create access token in case the plugin belonging to the current
  auth config id does not support authorization extension v2