### PR TITLE
configrepo - allow empty string secure variables

### DIFF
--- a/plugin-infra/go-plugin-config-repo/src/main/java/com/thoughtworks/go/plugin/configrepo/contract/CREnvironmentVariable.java
+++ b/plugin-infra/go-plugin-config-repo/src/main/java/com/thoughtworks/go/plugin/configrepo/contract/CREnvironmentVariable.java
@@ -135,4 +135,8 @@ public class CREnvironmentVariable extends CRBase {
     public boolean hasEncryptedValue() {
         return !StringUtils.isBlank(encrypted_value);
     }
+
+    public boolean hasValue() {
+        return !StringUtils.isBlank(value);
+    }
 }

--- a/server/src/main/java/com/thoughtworks/go/config/ConfigConverter.java
+++ b/server/src/main/java/com/thoughtworks/go/config/ConfigConverter.java
@@ -136,8 +136,7 @@ public class ConfigConverter {
                 throw new RuntimeException("Encryption of empty secure variable failed", e);
             }
             return new EnvironmentVariableConfig(cipher, crEnvironmentVariable.getName(), encryptedValue);
-        }
-        else {
+        } else {
             String value = crEnvironmentVariable.getValue();
             if(StringUtils.isBlank(value))
                 value = "";

--- a/server/src/main/java/com/thoughtworks/go/config/ConfigConverter.java
+++ b/server/src/main/java/com/thoughtworks/go/config/ConfigConverter.java
@@ -41,6 +41,7 @@ import com.thoughtworks.go.domain.scm.SCMs;
 import com.thoughtworks.go.plugin.configrepo.contract.*;
 import com.thoughtworks.go.plugin.configrepo.contract.material.*;
 import com.thoughtworks.go.plugin.configrepo.contract.tasks.*;
+import com.thoughtworks.go.security.CryptoException;
 import com.thoughtworks.go.security.GoCipher;
 import com.thoughtworks.go.util.command.CommandLine;
 import com.thoughtworks.go.util.command.HgUrlArgument;
@@ -124,8 +125,19 @@ public class ConfigConverter {
 
     public EnvironmentVariableConfig toEnvironmentVariableConfig(CREnvironmentVariable crEnvironmentVariable) {
         if (crEnvironmentVariable.hasEncryptedValue()) {
+            // encrypted value is not null or empty string
             return new EnvironmentVariableConfig(cipher, crEnvironmentVariable.getName(), crEnvironmentVariable.getEncryptedValue());
-        } else {
+        } else if(!crEnvironmentVariable.hasValue() && "".equals(crEnvironmentVariable.getEncryptedValue())) {
+            // encrypted value is an empty string - user wants an empty, but secure value, possibly to override at trigger-time
+            String encryptedValue = null;
+            try {
+                encryptedValue = cipher.encrypt("");
+            } catch (CryptoException e) {
+                throw new RuntimeException("Encryption of empty secure variable failed", e);
+            }
+            return new EnvironmentVariableConfig(cipher, crEnvironmentVariable.getName(), encryptedValue);
+        }
+        else {
             String value = crEnvironmentVariable.getValue();
             if(StringUtils.isBlank(value))
                 value = "";

--- a/server/src/test-fast/java/com/thoughtworks/go/config/ConfigConverterTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/config/ConfigConverterTest.java
@@ -138,7 +138,7 @@ public class ConfigConverterTest {
     }
 
     @Test
-    public void shouldConvertEnvironmentVariableWhenNotSecure() {
+    public void shouldConvertEnvironmentVariableToInsecureWhenValueIsNotBlank() {
         CREnvironmentVariable crEnvironmentVariable = new CREnvironmentVariable("key1", "value");
         EnvironmentVariableConfig result = configConverter.toEnvironmentVariableConfig(crEnvironmentVariable);
         assertThat(result.getValue(), is("value"));
@@ -147,16 +147,7 @@ public class ConfigConverterTest {
     }
 
     @Test
-    public void shouldConvertNullEnvironmentVariableWhenNotSecure() {
-        CREnvironmentVariable crEnvironmentVariable = new CREnvironmentVariable("key1", null);
-        EnvironmentVariableConfig result = configConverter.toEnvironmentVariableConfig(crEnvironmentVariable);
-        assertThat(result.getValue(), is(""));
-        assertThat(result.getName(), is("key1"));
-        assertThat(result.isSecure(), is(false));
-    }
-
-    @Test
-    public void shouldConvertEnvironmentVariableWhenSecure() {
+    public void shouldConvertEnvironmentVariableToSecureWhenEncryptedValueIsNotBlank() {
         CREnvironmentVariable crEnvironmentVariable = new CREnvironmentVariable("key1", null, "encryptedvalue");
         EnvironmentVariableConfig result = configConverter.toEnvironmentVariableConfig(crEnvironmentVariable);
         assertThat(result.isSecure(), is(true));
@@ -174,7 +165,7 @@ public class ConfigConverterTest {
     }
 
     @Test
-    public void shouldConvertEnvironmentVariableToInsecureWhenEncryptedValueIsNull() {
+    public void shouldConvertEnvironmentVariableToInsecureWhenValueAndEncryptedValueIsNull() {
         CREnvironmentVariable crEnvironmentVariable = new CREnvironmentVariable("key1", null, null);
         EnvironmentVariableConfig result = configConverter.toEnvironmentVariableConfig(crEnvironmentVariable);
         assertThat(result.isSecure(), is(false));

--- a/server/src/test-fast/java/com/thoughtworks/go/config/ConfigConverterTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/config/ConfigConverterTest.java
@@ -103,6 +103,8 @@ public class ConfigConverterTest {
         String encryptedText = "secret";
         when(goCipher.decrypt("encryptedvalue")).thenReturn(encryptedText);
         when(goCipher.encrypt("secret")).thenReturn("encryptedvalue");
+        when(goCipher.encrypt("")).thenReturn("encryptedEmptyString");
+        when(goCipher.decrypt("encryptedEmptyString")).thenReturn("");
 
         filter = new ArrayList<>();
         filter.add("filter");
@@ -159,6 +161,24 @@ public class ConfigConverterTest {
         EnvironmentVariableConfig result = configConverter.toEnvironmentVariableConfig(crEnvironmentVariable);
         assertThat(result.isSecure(), is(true));
         assertThat(result.getValue(), is("secret"));
+        assertThat(result.getName(), is("key1"));
+    }
+
+    @Test
+    public void shouldConvertEnvironmentVariableToSecureWhenEncryptedValueIsEmptyString() {
+        CREnvironmentVariable crEnvironmentVariable = new CREnvironmentVariable("key1", null, "");
+        EnvironmentVariableConfig result = configConverter.toEnvironmentVariableConfig(crEnvironmentVariable);
+        assertThat(result.isSecure(), is(true));
+        assertThat(result.getValue(), is(""));
+        assertThat(result.getName(), is("key1"));
+    }
+
+    @Test
+    public void shouldConvertEnvironmentVariableToInsecureWhenEncryptedValueIsNull() {
+        CREnvironmentVariable crEnvironmentVariable = new CREnvironmentVariable("key1", null, null);
+        EnvironmentVariableConfig result = configConverter.toEnvironmentVariableConfig(crEnvironmentVariable);
+        assertThat(result.isSecure(), is(false));
+        assertThat(result.getValue(), is(""));
         assertThat(result.getName(), is("key1"));
     }
 


### PR DESCRIPTION
Original issue - https://github.com/tomzo/gocd-yaml-config-plugin/issues/84

This change allows config-repo users to set secure environment variables to empty strings.
Technically the following definition is not correct because empty string `""` should have been encrypted with cipher text and look something like `AES: 3a23gfh`
```
    secure_variables:
      MYSECRET: ""
```

There is one reasonable use case to allow above definitions - when user actually does not want to store secret in the config-repo, but rather provide it at runtime when triggering pipeline with overridden
 environment variables.

![empty_secure_var](https://user-images.githubusercontent.com/5710970/52561379-8d2ba600-2dfb-11e9-9561-4ec5df8c9966.png)

Above screenshot from following pipeline:
```yaml
  "yaml-example": # definition of yaml-example pipeline
    group: yaml-example
    label_template: "${mygit[:8]}"
    locking: off
    materials:
      mygit: # this is the name of material
        # keyword git says about type of material and url at once
        git: http://my.example.org/mygit.git
        branch: ci
      upstream:
        # type is optional here, material type is implied based on presence of pipeline and stage fields
        # type: dependency
        pipeline: yamlpipe1
        stage: build
    environment_variables:
      DUMMY: "Tigers"
    secure_variables:
      MYSECRET: ""
    stages: # list of stages in order
      - build: # name of stage
          clean_workspace: true
          jobs:
            csharp: # name of the job
              resources:
               - net45
              artifacts:
               - build:
                   source: bin/
                   destination: build
               - test:
                   source: tests/
                   destination: test-reports/
              tabs:
                report: test-reports/index.html
              tasks: # ordered list of tasks to execute in job csharp
               - fetch:
                   pipeline: yamlpipe1
                   stage: build
                   job: build
                   source: test-bin/
                   destination: bin/
               - exec: # indicates type of task
                   command: bash
                   arguments:
                    - -c
                    - "echo ${MYSECRET}"
```

## Implementation

When `ConfigConverter` sees that `encrypted value` is an empty string, it will be encrypted using current cipher and returned as secure variable to the config server.
Previously it would lead to situation when secure variable is treated as normal one. So no way to implement the use case of providing secrets at run time.

@ibnc can you take a look at this?