### PR TITLE
Cache Access token related authorization plugin api calls for 30 minutes (#5823)

### DIFF
--- a/base/src/main/java/com/thoughtworks/go/util/SystemEnvironment.java
+++ b/base/src/main/java/com/thoughtworks/go/util/SystemEnvironment.java
@@ -148,6 +148,8 @@ public class SystemEnvironment implements Serializable, ConfigDirProvider {
     public static final GoSystemProperty<String> AGENT_EXTRA_PROPERTIES = new GoStringSystemProperty("gocd.agent.extra.properties", "");
     public static final GoSystemProperty<Integer> JMS_LISTENER_BACKOFF_TIME = new GoIntSystemProperty("go.jms.listener.backoff.time.in.milliseconds", 5000);
 
+    public static final GoSystemProperty<Integer> GO_SERVER_AUTHORIZATION_EXTENSION_CALLS_CACHE_TIMEOUT_IN_SECONDS = new GoIntSystemProperty("go.server.authorization.extension.calls.cache.timeout.in.secs", 60 * 30);
+
     /* DATABASE CONFIGURATION - Defaults are of H2 */
     public static GoSystemProperty<String> GO_DATABASE_HOST = new GoStringSystemProperty("db.host", "localhost");
     public static GoSystemProperty<String> GO_DATABASE_PORT = new GoStringSystemProperty("db.port", "");
@@ -715,6 +717,10 @@ public class SystemEnvironment implements Serializable, ConfigDirProvider {
 
     public String getExternalPluginAbsolutePath() {
         return new File(get(PLUGIN_EXTERNAL_PROVIDED_PATH)).getAbsolutePath();
+    }
+
+    public static Integer getGoServerAuthorizationExtensionCallsCacheTimeoutInSeconds() {
+        return GO_SERVER_AUTHORIZATION_EXTENSION_CALLS_CACHE_TIMEOUT_IN_SECONDS.getValue();
     }
 
     public String getBundledPluginAbsolutePath() {

--- a/server/src/main/java/com/thoughtworks/go/server/newsecurity/providers/AccessTokenBasedPluginAuthenticationProvider.java
+++ b/server/src/main/java/com/thoughtworks/go/server/newsecurity/providers/AccessTokenBasedPluginAuthenticationProvider.java
@@ -18,7 +18,6 @@ package com.thoughtworks.go.server.newsecurity.providers;
 
 import com.thoughtworks.go.config.PluginRoleConfig;
 import com.thoughtworks.go.config.SecurityAuthConfig;
-import com.thoughtworks.go.plugin.access.authorization.AuthorizationExtension;
 import com.thoughtworks.go.plugin.access.authorization.AuthorizationMetadataStore;
 import com.thoughtworks.go.plugin.domain.authorization.AuthenticationResponse;
 import com.thoughtworks.go.plugin.domain.authorization.User;
@@ -27,6 +26,7 @@ import com.thoughtworks.go.server.newsecurity.models.AccessTokenCredential;
 import com.thoughtworks.go.server.newsecurity.models.AuthenticationToken;
 import com.thoughtworks.go.server.security.AuthorityGranter;
 import com.thoughtworks.go.server.security.userdetail.GoUserPrinciple;
+import com.thoughtworks.go.server.service.AuthorizationExtensionCacheService;
 import com.thoughtworks.go.server.service.GoConfigService;
 import com.thoughtworks.go.server.service.PluginRoleService;
 import com.thoughtworks.go.server.service.UserService;
@@ -41,20 +41,20 @@ import static java.util.Collections.singletonList;
 
 @Component
 public class AccessTokenBasedPluginAuthenticationProvider extends AbstractPluginAuthenticationProvider<AccessTokenCredential> {
-    private final AuthorizationExtension authorizationExtension;
+    private final AuthorizationExtensionCacheService authorizationExtension;
     private final UserService userService;
     private final Clock clock;
     private AuthorizationMetadataStore store;
 
     @Autowired
-    public AccessTokenBasedPluginAuthenticationProvider(AuthorizationExtension authorizationExtension,
+    public AccessTokenBasedPluginAuthenticationProvider(AuthorizationExtensionCacheService authorizationExtensionCacheService,
                                                         AuthorityGranter authorityGranter,
                                                         GoConfigService goConfigService,
                                                         PluginRoleService pluginRoleService,
                                                         UserService userService,
                                                         Clock clock) {
         super(goConfigService, pluginRoleService, userService, authorityGranter);
-        this.authorizationExtension = authorizationExtension;
+        this.authorizationExtension = authorizationExtensionCacheService;
         this.userService = userService;
         this.store = AuthorizationMetadataStore.instance();
         this.clock = clock;

--- a/server/src/main/java/com/thoughtworks/go/server/service/AuthorizationExtensionCacheService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/AuthorizationExtensionCacheService.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.server.service;
+
+import com.google.common.base.Ticker;
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import com.thoughtworks.go.config.PluginRoleConfig;
+import com.thoughtworks.go.config.SecurityAuthConfig;
+import com.thoughtworks.go.plugin.access.authorization.AuthorizationExtension;
+import com.thoughtworks.go.plugin.domain.authorization.AuthenticationResponse;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+@Component
+public class AuthorizationExtensionCacheService {
+    private final int CACHE_EXPIRY_IN_MINUTES = 30;
+
+    private Cache<String, Boolean> isValidUserCache;
+    private Cache<String, AuthenticationResponse> getUserRolesCache;
+    private final AuthorizationExtension authorizationExtension;
+    private final String IS_VALID_USER_CACHE_KEY = "is_valid_user_request_for";
+
+    public AuthorizationExtensionCacheService(AuthorizationExtension authorizationExtension, Ticker ticker) {
+        this.authorizationExtension = authorizationExtension;
+        isValidUserCache = CacheBuilder.newBuilder()
+                .ticker(ticker).expireAfterWrite(CACHE_EXPIRY_IN_MINUTES, TimeUnit.MINUTES).build();
+        getUserRolesCache = CacheBuilder.newBuilder()
+                .ticker(ticker).expireAfterWrite(CACHE_EXPIRY_IN_MINUTES, TimeUnit.MINUTES).build();
+    }
+
+    @Autowired
+    public AuthorizationExtensionCacheService(AuthorizationExtension authorizationExtension) {
+        this(authorizationExtension, Ticker.systemTicker());
+    }
+
+    public boolean isValidUser(String pluginId, String username, SecurityAuthConfig authConfig) {
+        String cacheKey = cacheKeyFor(IS_VALID_USER_CACHE_KEY, pluginId, username, authConfig);
+        Boolean fromCache = isValidUserCache.getIfPresent(cacheKey);
+
+        if (fromCache == null) {
+            fromCache = authorizationExtension.isValidUser(pluginId, username, authConfig);
+            isValidUserCache.put(cacheKey, fromCache);
+        }
+
+        return fromCache;
+    }
+
+    public AuthenticationResponse getUserRoles(String pluginId, String username, SecurityAuthConfig authConfig, List<PluginRoleConfig> pluginRoleConfigs) {
+        String cacheKey = cacheKeyFor(IS_VALID_USER_CACHE_KEY, pluginId, username, authConfig, pluginRoleConfigs);
+        AuthenticationResponse fromCache = getUserRolesCache.getIfPresent(cacheKey);
+
+        if (fromCache == null) {
+            fromCache = authorizationExtension.getUserRoles(pluginId, username, authConfig, pluginRoleConfigs);
+            getUserRolesCache.put(cacheKey, fromCache);
+        }
+
+        return fromCache;
+    }
+
+    private String cacheKeyFor(String key, String pluginId, String username, SecurityAuthConfig authConfig, List<PluginRoleConfig> pluginRoleConfigs) {
+        String roleConfigNames = pluginRoleConfigs.stream().map(role -> role.getName().toString()).collect(Collectors.joining("__"));
+
+        return String.format("%s__%s__%s_auth_config_%s_role_configs_%s", key, pluginId, username, authConfig.getId(), roleConfigNames);
+    }
+
+    private String cacheKeyFor(String key, String pluginId, String username, SecurityAuthConfig authConfig) {
+        return String.format("%s__%s__%s__%s", key, pluginId, username, authConfig.getId());
+    }
+}

--- a/server/src/main/java/com/thoughtworks/go/server/service/AuthorizationExtensionCacheService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/AuthorizationExtensionCacheService.java
@@ -21,6 +21,7 @@ import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import com.thoughtworks.go.config.PluginRoleConfig;
 import com.thoughtworks.go.config.SecurityAuthConfig;
+import com.thoughtworks.go.listener.SecurityConfigChangeListener;
 import com.thoughtworks.go.plugin.access.authorization.AuthorizationExtension;
 import com.thoughtworks.go.plugin.domain.authorization.AuthenticationResponse;
 import com.thoughtworks.go.util.SystemEnvironment;
@@ -39,17 +40,19 @@ public class AuthorizationExtensionCacheService {
     private final Cache<String, AuthenticationResponse> getUserRolesCache;
     private final AuthorizationExtension authorizationExtension;
 
-    public AuthorizationExtensionCacheService(AuthorizationExtension authorizationExtension, Ticker ticker) {
+    public AuthorizationExtensionCacheService(GoConfigService goConfigService, AuthorizationExtension authorizationExtension, Ticker ticker) {
         this.authorizationExtension = authorizationExtension;
         isValidUserCache = CacheBuilder.newBuilder()
                 .ticker(ticker).expireAfterWrite(CACHE_EXPIRY_IN_MINUTES, TimeUnit.MINUTES).build();
         getUserRolesCache = CacheBuilder.newBuilder()
                 .ticker(ticker).expireAfterWrite(CACHE_EXPIRY_IN_MINUTES, TimeUnit.MINUTES).build();
+
+        goConfigService.register(this.securityConfigChangeListener());
     }
 
     @Autowired
-    public AuthorizationExtensionCacheService(AuthorizationExtension authorizationExtension) {
-        this(authorizationExtension, Ticker.systemTicker());
+    public AuthorizationExtensionCacheService(GoConfigService goConfigService, AuthorizationExtension authorizationExtension) {
+        this(goConfigService, authorizationExtension, Ticker.systemTicker());
     }
 
     public boolean isValidUser(String pluginId, String username, SecurityAuthConfig authConfig) {
@@ -83,5 +86,15 @@ public class AuthorizationExtensionCacheService {
 
     private String cacheKeyFor(String pluginId, String username, SecurityAuthConfig authConfig) {
         return String.format("%s##%s##%s", pluginId, username, authConfig.getId());
+    }
+
+    private SecurityConfigChangeListener securityConfigChangeListener() {
+        return new SecurityConfigChangeListener() {
+            @Override
+            public void onEntityConfigChange(Object entity) {
+                isValidUserCache.invalidateAll();
+                getUserRolesCache.invalidateAll();
+            }
+        };
     }
 }

--- a/server/src/test-fast/java/com/thoughtworks/go/server/service/AuthorizationExtensionCacheServiceTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/service/AuthorizationExtensionCacheServiceTest.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.server.service;
+
+import com.google.common.base.Ticker;
+import com.thoughtworks.go.config.PluginRoleConfig;
+import com.thoughtworks.go.config.SecurityAuthConfig;
+import com.thoughtworks.go.config.SecurityAuthConfigs;
+import com.thoughtworks.go.plugin.access.authorization.AuthorizationExtension;
+import com.thoughtworks.go.plugin.domain.authorization.AuthenticationResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+public class AuthorizationExtensionCacheServiceTest {
+    private final String pluginId = "pluginId";
+    private final String username = "username";
+    private final SecurityAuthConfig authConfig = new SecurityAuthConfig("ldap", "cd.go.ldap");
+    private final FakeTicker ticker = new FakeTicker();
+
+    @Mock
+    private AuthorizationExtension authorizationExtension;
+
+    AuthorizationExtensionCacheService service;
+
+    @BeforeEach
+    void setUp() {
+        initMocks(this);
+        service = new AuthorizationExtensionCacheService(authorizationExtension, ticker);
+    }
+
+    @Test
+    void shouldAskAuthorizationExtensionWhetherIsUserIsValid() throws Exception {
+        when(authorizationExtension.isValidUser(pluginId, username, authConfig)).thenReturn(false);
+        boolean validUser = service.isValidUser(pluginId, username, authConfig);
+
+        assertThat(validUser).isFalse();
+        verify(authorizationExtension, times(1)).isValidUser(pluginId, username, authConfig);
+    }
+
+    @Test
+    void shouldLoadFromCacheOnSubsequentCallsToCheckIsUserIsValid() throws Exception {
+        when(authorizationExtension.isValidUser(pluginId, username, authConfig)).thenReturn(false);
+        boolean validUser = service.isValidUser(pluginId, username, authConfig);
+        assertThat(validUser).isFalse();
+
+        validUser = service.isValidUser(pluginId, username, authConfig);
+        assertThat(validUser).isFalse();
+
+        verify(authorizationExtension, times(1)).isValidUser(pluginId, username, authConfig);
+    }
+
+    @Test
+    void shouldAskExtensionAgainWhenCacheExpires() {
+        when(authorizationExtension.isValidUser(pluginId, username, authConfig)).thenReturn(false);
+        boolean validUser = service.isValidUser(pluginId, username, authConfig);
+        assertThat(validUser).isFalse();
+
+        validUser = service.isValidUser(pluginId, username, authConfig);
+        assertThat(validUser).isFalse();
+
+        verify(authorizationExtension, times(1)).isValidUser(pluginId, username, authConfig);
+
+        ticker.advance(31, TimeUnit.MINUTES);
+
+        validUser = service.isValidUser(pluginId, username, authConfig);
+        assertThat(validUser).isFalse();
+
+        verify(authorizationExtension, times(2)).isValidUser(pluginId, username, authConfig);
+    }
+
+    @Test
+    void shouldAskAuthorizationExtensionToGetUserRoles() throws Exception {
+        List<PluginRoleConfig> pluginRoleConfigs = Collections.emptyList();
+        AuthenticationResponse response = new AuthenticationResponse(null, Collections.emptyList());
+        when(authorizationExtension.getUserRoles(pluginId, username, authConfig, pluginRoleConfigs)).thenReturn(response);
+
+        AuthenticationResponse actualResponse = service.getUserRoles(pluginId, username, authConfig, pluginRoleConfigs);
+        assertThat(actualResponse).isEqualTo(response);
+
+        verify(authorizationExtension, times(1)).getUserRoles(pluginId, username, authConfig, pluginRoleConfigs);
+    }
+
+    @Test
+    void shouldLoadFromCacheOnSubsequentCallsToGetUserRoles() throws Exception {
+        List<PluginRoleConfig> pluginRoleConfigs = Collections.emptyList();
+        AuthenticationResponse response = new AuthenticationResponse(null, Collections.emptyList());
+        when(authorizationExtension.getUserRoles(pluginId, username, authConfig, pluginRoleConfigs)).thenReturn(response);
+
+        AuthenticationResponse actualResponse = service.getUserRoles(pluginId, username, authConfig, pluginRoleConfigs);
+        assertThat(actualResponse).isEqualTo(response);
+
+        actualResponse = service.getUserRoles(pluginId, username, authConfig, pluginRoleConfigs);
+        assertThat(actualResponse).isEqualTo(response);
+
+        verify(authorizationExtension, times(1)).getUserRoles(pluginId, username, authConfig, pluginRoleConfigs);
+    }
+
+    @Test
+    void shouldAskExtensionAgainToGetUserRolesWhenCacheExpires() {
+        List<PluginRoleConfig> pluginRoleConfigs = Collections.emptyList();
+        AuthenticationResponse response = new AuthenticationResponse(null, Collections.emptyList());
+        when(authorizationExtension.getUserRoles(pluginId, username, authConfig, pluginRoleConfigs)).thenReturn(response);
+
+        AuthenticationResponse actualResponse = service.getUserRoles(pluginId, username, authConfig, pluginRoleConfigs);
+        assertThat(actualResponse).isEqualTo(response);
+
+        actualResponse = service.getUserRoles(pluginId, username, authConfig, pluginRoleConfigs);
+        assertThat(actualResponse).isEqualTo(response);
+
+        verify(authorizationExtension, times(1)).getUserRoles(pluginId, username, authConfig, pluginRoleConfigs);
+
+        ticker.advance(31, TimeUnit.MINUTES);
+
+        actualResponse = service.getUserRoles(pluginId, username, authConfig, pluginRoleConfigs);
+        assertThat(actualResponse).isEqualTo(response);
+
+        verify(authorizationExtension, times(2)).getUserRoles(pluginId, username, authConfig, pluginRoleConfigs);
+    }
+
+    class FakeTicker extends Ticker {
+        private final AtomicLong nanos = new AtomicLong();
+
+        void advance(long time, TimeUnit timeUnit) {
+            nanos.addAndGet(timeUnit.toNanos(time));
+        }
+
+        public long read() {
+            return nanos.getAndAdd(0);
+        }
+    }
+}


### PR DESCRIPTION
* Cache 'is-user-valid' and 'get-user-oles' plugin API calls for 30 minutes.
* After 30 mins, the cache will be invalidated and a new call will be made to
  the plugin to fetch the new response.
* Use com.google.common.cache.CacheBuilder to implement the time-based cache.

References:
https://github.com/google/guava/blob/master/guava/src/com/google/common/cache/CacheBuilder.java