### PR TITLE
Reparse previously failed Config Repo parses if Server side issues have been resolved

### DIFF
--- a/server/src/main/java/com/thoughtworks/go/config/ConfigReposMaterialParseResultManager.java
+++ b/server/src/main/java/com/thoughtworks/go/config/ConfigReposMaterialParseResultManager.java
@@ -45,20 +45,22 @@ public class ConfigReposMaterialParseResultManager {
 
     public PartialConfigParseResult get(String fingerprint) {
         PartialConfigParseResult result = fingerprintOfPartialToParseResultMap.get(fingerprint);
-        // config repository was never parsed, check if there are any material clone or update related errors
         if (result == null) {
-            HealthStateScope healthStateScope = HealthStateScope.forMaterialConfig(configRepoService.findByFingerprint(fingerprint).getMaterialConfig());
-            List<ServerHealthState> serverHealthStates = serverHealthService.filterByScope(healthStateScope);
-            if (!serverHealthStates.isEmpty()) {
-                result = PartialConfigParseResult.parseFailed(null, represent(serverHealthStates.get(0)));
-            }
+            // config repository was never parsed, check if there are any material clone or update related errors
+            result = getMaterialResult(fingerprint);
         }
 
-        //config repository was parsed, but does not have merge or clone related errors.
-        if (result != null && result.getLastFailure() == null) {
+        if (result !=null) {
+            //config repository was parsed, but does not have merge or clone related errors.
+
             HealthStateScope healthStateScope = HealthStateScope.forPartialConfigRepo(fingerprint);
             List<ServerHealthState> serverHealthStates = serverHealthService.filterByScope(healthStateScope);
-            if (!serverHealthStates.isEmpty()) {
+            // It should be noted that the server health state and the result can be thought of as the following:
+            // serverHealthState is the current state
+            // result.isSuccessfully() is the state at the last parse
+
+            // here we're checking that the current state is bad, but the previous state was good
+            if (!serverHealthStates.isEmpty() && result.isSuccessful()) {
                 result.setException(represent(serverHealthStates.get(0)));
 
                 //clear out the good modification, in case good modification is same as of latest parsed modification
@@ -66,10 +68,25 @@ public class ConfigReposMaterialParseResultManager {
                     result.setGoodModification(null);
                     result.setPartialConfig(null);
                 }
+            // here we're checking that the current state is good, but the previous state was bad
+            } else if (serverHealthStates.isEmpty() && !result.isSuccessful()) {
+                // The issues that caused the previous state to be bad are gone.
+                // An example would be that previously a upstream pipeline didn't exist, but now does
+                // Clearing latest parsed modification to allow for another parse attempt
+                result.setLatestParsedModification(null);
             }
         }
 
         return result;
+    }
+
+    private PartialConfigParseResult getMaterialResult(String fingerprint) {
+        HealthStateScope healthStateScope = HealthStateScope.forMaterialConfig(configRepoService.findByFingerprint(fingerprint).getMaterialConfig());
+        List<ServerHealthState> serverHealthStates = serverHealthService.filterByScope(healthStateScope);
+        if (!serverHealthStates.isEmpty()) {
+            return PartialConfigParseResult.parseFailed(null, represent(serverHealthStates.get(0)));
+        }
+        return null;
     }
 
     private Exception represent(ServerHealthState serverHealthState) {


### PR DESCRIPTION
see the first issue in #5792 

Here's how to reproduce the issue this PR is fixing:
1. Add a config repo with the following yaml
```
format_version: 3 
pipelines:
  blah:
    group: first
    label_template: ${COUNT}
    lock_behavior: none
    materials:
      git:
        git: git@github.com:tomzo/gocd-yaml-config-plugin.git
        shallow_clone: false
        auto_update: true
        branch: master
      dependency:
        pipeline: aincrad
        stage: defaultStage
    stages:
    - '2':
        fetch_materials: true
        keep_artifacts: false
        clean_workspace: false
        approval:
          type: success
        jobs:
          '2':
            run_instances: '0'
            tasks:
            - exec:
                command: ls
                run_if: passed
```
2. Wait until that revision is parsed, and the error appears on the config repo page and in the server health messages
3. Create the pipeline `aincrad` with the stage `defaultStage`
4. The server health message will disappear, but it's impossible to have the config repo config merged without a fake commit or server restart

When testing if this works, be sure to either delete the pipeline aincrad or change the yaml before merging the code and starting the server. 

This PR will remove the need to restart the server or make a fake commit. It'll be possible for the failed parse to be retried after the blocking issue is resolved (in the case of the above example, once the pipeline is created). 

@maheshp @GaneshSPatil Would y'all be up for reviewing at this PR? 