### PR TITLE
Get user roles should return list of roles as a response body.

### DIFF
--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/authorization/AuthorizationExtension.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/authorization/AuthorizationExtension.java
@@ -210,20 +210,20 @@ public class AuthorizationExtension extends AbstractExtension {
         });
     }
 
-    public AuthenticationResponse getUserRoles(String pluginId, String username, SecurityAuthConfig authConfig, List<PluginRoleConfig> roleConfigs) {
+    public List<String> getUserRoles(String pluginId, String username, SecurityAuthConfig authConfig, List<PluginRoleConfig> roleConfigs) {
         if (authConfig == null) {
             throw new MissingAuthConfigsException(format("Request '%s' requires an AuthConfig. Make sure Authconfig is configured for the plugin '%s'.", REQUEST_GET_USER_ROLES, pluginId));
         }
 
-        return pluginRequestHelper.submitRequest(pluginId, REQUEST_GET_USER_ROLES, new DefaultPluginInteractionCallback<AuthenticationResponse>() {
+        return pluginRequestHelper.submitRequest(pluginId, REQUEST_GET_USER_ROLES, new DefaultPluginInteractionCallback<List<String>>() {
             @Override
             public String requestBody(String resolvedExtensionVersion) {
                 return getMessageConverter(resolvedExtensionVersion).getUserRolesRequestBody(username, authConfig, roleConfigs);
             }
 
             @Override
-            public AuthenticationResponse onSuccess(String responseBody, Map<String, String> responseHeaders, String resolvedExtensionVersion) {
-                return getMessageConverter(resolvedExtensionVersion).getAuthenticatedUserFromResponseBody(responseBody);
+            public List<String> onSuccess(String responseBody, Map<String, String> responseHeaders, String resolvedExtensionVersion) {
+                return getMessageConverter(resolvedExtensionVersion).getUserRolesFromResponseBody(responseBody);
             }
         });
     }

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/authorization/AuthorizationMessageConverter.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/authorization/AuthorizationMessageConverter.java
@@ -73,4 +73,6 @@ public interface AuthorizationMessageConverter {
     String isValidUserRequestBody(String username, SecurityAuthConfig authConfig);
 
     String getUserRolesRequestBody(String username, SecurityAuthConfig authConfig, List<PluginRoleConfig> roleConfigs);
+
+    List<String> getUserRolesFromResponseBody(String responseBody);
 }

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/authorization/v1/AuthorizationMessageConverterV1.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/authorization/v1/AuthorizationMessageConverterV1.java
@@ -228,6 +228,11 @@ public class AuthorizationMessageConverterV1 implements AuthorizationMessageConv
         throw new UnsupportedOperationException("Authorization Extension v1 does not implement get-user-roles call.");
     }
 
+    @Override
+    public List<String> getUserRolesFromResponseBody(String responseBody) {
+        throw new UnsupportedOperationException("Authorization Extension v1 does not implement get-user-roles call.");
+    }
+
     private String authorizationServerCallbackUrl(String pluginId, String siteUrl) {
         return String.format("%s/go/plugin/%s/authenticate", siteUrl, pluginId);
     }

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/authorization/v2/AuthorizationMessageConverterV2.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/authorization/v2/AuthorizationMessageConverterV2.java
@@ -229,6 +229,12 @@ public class AuthorizationMessageConverterV2 implements AuthorizationMessageConv
     }
 
     @Override
+    public List<String> getUserRolesFromResponseBody(String responseBody) {
+        return GSON.fromJson(responseBody, new TypeToken<List<String>>() {
+        }.getType());
+    }
+
+    @Override
     public String authenticateUserRequestBody(String username, List<SecurityAuthConfig> authConfigs, List<PluginRoleConfig> roleConfigs) {
         Map<String, Object> requestMap = new HashMap<>();
 

--- a/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/authorization/AuthorizationExtensionTest.java
+++ b/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/authorization/AuthorizationExtensionTest.java
@@ -361,24 +361,16 @@ public class AuthorizationExtensionTest {
         @Test
         void shouldTalkToPlugin_To_GetUserRoles() {
             String requestBody = "{\"auth_config\":{\"configuration\":{\"foo\":\"bar\"},\"id\":\"ldap\"},\"role_configs\":[],\"username\":\"fooUser\"}";
-            String responseBody = "{\n" +
-                    "  \"user\": {\n" +
-                    "      \"username\":\"bob\",\n" +
-                    "      \"display_name\": \"Bob\",\n" +
-                    "      \"email\": \"bob@example.com\"\n" +
-                    "  },\n" +
-                    "  \"roles\": [\"super-admin\", \"view-only\", \"operator\"] \n" +
-                    "}";
+            String responseBody = "[\"super-admin\", \"view-only\", \"operator\"]";
 
             when(pluginManager.submitTo(eq(PLUGIN_ID), eq(AUTHORIZATION_EXTENSION), requestArgumentCaptor.capture())).thenReturn(new DefaultGoPluginApiResponse(SUCCESS_RESPONSE_CODE, responseBody));
 
 
             SecurityAuthConfig authConfig = new SecurityAuthConfig("ldap", "cd.go.ldap", create("foo", false, "bar"));
-            AuthenticationResponse authenticationResponse = authorizationExtension.getUserRoles(PLUGIN_ID, "fooUser", authConfig, Collections.emptyList());
+            List<String> roles = authorizationExtension.getUserRoles(PLUGIN_ID, "fooUser", authConfig, emptyList());
 
             assertRequest(requestArgumentCaptor.getValue(), AUTHORIZATION_EXTENSION, "2.0", REQUEST_GET_USER_ROLES, requestBody);
-            assertThat(authenticationResponse.getUser()).isEqualTo(new User("bob", "Bob", "bob@example.com"));
-            assertThat(authenticationResponse.getRoles()).hasSize(3)
+            assertThat(roles).hasSize(3)
                     .contains("super-admin", "view-only", "operator");
         }
 

--- a/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/authorization/v2/AuthorizationMessageConverterV2Test.java
+++ b/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/authorization/v2/AuthorizationMessageConverterV2Test.java
@@ -28,6 +28,7 @@ import static com.thoughtworks.go.domain.packagerepository.ConfigurationProperty
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson;
+import static org.assertj.core.api.Assertions.assertThat;
 
 class AuthorizationMessageConverterV2Test {
     private AuthorizationMessageConverterV2 converter;
@@ -86,5 +87,14 @@ class AuthorizationMessageConverterV2Test {
                 "    },\n" +
                 "  \"username\": \"foo\"\n" +
                 "}");
+    }
+
+    @Test
+    void shouldGetRolesFromGetUserRolesResponseBody() {
+        List<String> roles = converter.getUserRolesFromResponseBody("[\"blackbird\",\"admin\",\"foo\"]");
+
+        assertThat(roles)
+                .hasSize(3)
+                .contains("blackbird", "admin", "foo");
     }
 }

--- a/server/src/main/java/com/thoughtworks/go/server/service/AuthorizationExtensionCacheService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/AuthorizationExtensionCacheService.java
@@ -37,7 +37,7 @@ public class AuthorizationExtensionCacheService {
     private final int CACHE_EXPIRY_IN_MINUTES = SystemEnvironment.getGoServerAuthorizationExtensionCallsCacheTimeoutInSeconds() / 60;
 
     private final Cache<String, Boolean> isValidUserCache;
-    private final Cache<String, AuthenticationResponse> getUserRolesCache;
+    private final Cache<String, List<String>> getUserRolesCache;
     private final AuthorizationExtension authorizationExtension;
 
     public AuthorizationExtensionCacheService(GoConfigService goConfigService, AuthorizationExtension authorizationExtension, Ticker ticker) {
@@ -67,16 +67,16 @@ public class AuthorizationExtensionCacheService {
         return fromCache;
     }
 
-    public AuthenticationResponse getUserRoles(String pluginId, String username, SecurityAuthConfig authConfig, List<PluginRoleConfig> pluginRoleConfigs) {
+    public List<String> getUserRoles(String pluginId, String username, SecurityAuthConfig authConfig, List<PluginRoleConfig> pluginRoleConfigs) {
         String cacheKey = cacheKeyFor(pluginId, username, authConfig, pluginRoleConfigs);
-        AuthenticationResponse fromCache = getUserRolesCache.getIfPresent(cacheKey);
+        List<String> rolesFromCache = getUserRolesCache.getIfPresent(cacheKey);
 
-        if (fromCache == null) {
-            fromCache = authorizationExtension.getUserRoles(pluginId, username, authConfig, pluginRoleConfigs);
-            getUserRolesCache.put(cacheKey, fromCache);
+        if (rolesFromCache == null) {
+            rolesFromCache = authorizationExtension.getUserRoles(pluginId, username, authConfig, pluginRoleConfigs);
+            getUserRolesCache.put(cacheKey, rolesFromCache);
         }
 
-        return fromCache;
+        return rolesFromCache;
     }
 
     private String cacheKeyFor(String pluginId, String username, SecurityAuthConfig authConfig, List<PluginRoleConfig> pluginRoleConfigs) {

--- a/server/src/test-fast/java/com/thoughtworks/go/server/newsecurity/providers/AccessTokenBasedPluginAuthenticationProviderTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/newsecurity/providers/AccessTokenBasedPluginAuthenticationProviderTest.java
@@ -78,11 +78,13 @@ class AccessTokenBasedPluginAuthenticationProviderTest {
     @Test
     void shouldReturnRolesFetchedForTheUserFromThePluginForTheProvidedAuthConfig() {
         String username = credentials.getAccessToken().getUsername();
-        AuthenticationResponse responseToSend = new AuthenticationResponse(null, Collections.emptyList());
+        User userToOperate = new User(username);
+        AuthenticationResponse responseToSend = new AuthenticationResponse(new com.thoughtworks.go.plugin.domain.authorization.User(userToOperate.getUsername().getUsername().toString(), userToOperate.getDisplayName(), userToOperate.getEmail()), Collections.emptyList());
 
         when(authorizationService.isValidUser(pluginId, username, authConfig)).thenReturn(true);
         when(store.doesPluginSupportGetUserRolesCall(pluginId)).thenReturn(true);
-        when(authorizationService.getUserRoles(pluginId, username, authConfig, null)).thenReturn(responseToSend);
+        when(authorizationService.getUserRoles(pluginId, username, authConfig, null)).thenReturn(Collections.emptyList());
+        when(userService.findUserByName(username)).thenReturn(userToOperate);
 
         AuthenticationResponse actual = provider.authenticateWithExtension(pluginId, credentials, authConfig, null);
 

--- a/server/src/test-fast/java/com/thoughtworks/go/server/service/AuthorizationExtensionCacheServiceTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/service/AuthorizationExtensionCacheServiceTest.java
@@ -61,7 +61,7 @@ public class AuthorizationExtensionCacheServiceTest {
     }
 
     @Test
-    void shouldAskAuthorizationExtensionWhetherIsUserIsValid() throws Exception {
+    void shouldAskAuthorizationExtensionWhetherIsUserIsValid() {
         when(authorizationExtension.isValidUser(pluginId, username, authConfig)).thenReturn(false);
         boolean validUser = service.isValidUser(pluginId, username, authConfig);
 
@@ -70,7 +70,7 @@ public class AuthorizationExtensionCacheServiceTest {
     }
 
     @Test
-    void shouldLoadFromCacheOnSubsequentCallsToCheckIsUserIsValid() throws Exception {
+    void shouldLoadFromCacheOnSubsequentCallsToCheckIsUserIsValid() {
         when(authorizationExtension.isValidUser(pluginId, username, authConfig)).thenReturn(false);
         boolean validUser = service.isValidUser(pluginId, username, authConfig);
         assertThat(validUser).isFalse();
@@ -101,24 +101,23 @@ public class AuthorizationExtensionCacheServiceTest {
     }
 
     @Test
-    void shouldAskAuthorizationExtensionToGetUserRoles() throws Exception {
+    void shouldAskAuthorizationExtensionToGetUserRoles() {
         List<PluginRoleConfig> pluginRoleConfigs = Collections.emptyList();
-        AuthenticationResponse response = new AuthenticationResponse(null, Collections.emptyList());
-        when(authorizationExtension.getUserRoles(pluginId, username, authConfig, pluginRoleConfigs)).thenReturn(response);
+        when(authorizationExtension.getUserRoles(pluginId, username, authConfig, pluginRoleConfigs)).thenReturn(Collections.emptyList());
 
-        AuthenticationResponse actualResponse = service.getUserRoles(pluginId, username, authConfig, pluginRoleConfigs);
-        assertThat(actualResponse).isEqualTo(response);
+        List<String> actualResponse = service.getUserRoles(pluginId, username, authConfig, pluginRoleConfigs);
+        assertThat(actualResponse).isEqualTo(Collections.emptyList());
 
         verify(authorizationExtension, times(1)).getUserRoles(pluginId, username, authConfig, pluginRoleConfigs);
     }
 
     @Test
-    void shouldLoadFromCacheOnSubsequentCallsToGetUserRoles() throws Exception {
+    void shouldLoadFromCacheOnSubsequentCallsToGetUserRoles() {
         List<PluginRoleConfig> pluginRoleConfigs = Collections.emptyList();
         AuthenticationResponse response = new AuthenticationResponse(null, Collections.emptyList());
-        when(authorizationExtension.getUserRoles(pluginId, username, authConfig, pluginRoleConfigs)).thenReturn(response);
+        when(authorizationExtension.getUserRoles(pluginId, username, authConfig, pluginRoleConfigs)).thenReturn(Collections.emptyList());
 
-        AuthenticationResponse actualResponse = service.getUserRoles(pluginId, username, authConfig, pluginRoleConfigs);
+        List<String> actualResponse = service.getUserRoles(pluginId, username, authConfig, pluginRoleConfigs);
         assertThat(actualResponse).isEqualTo(response);
 
         actualResponse = service.getUserRoles(pluginId, username, authConfig, pluginRoleConfigs);
@@ -130,21 +129,20 @@ public class AuthorizationExtensionCacheServiceTest {
     @Test
     void shouldAskExtensionAgainToGetUserRolesWhenCacheExpires() {
         List<PluginRoleConfig> pluginRoleConfigs = Collections.emptyList();
-        AuthenticationResponse response = new AuthenticationResponse(null, Collections.emptyList());
-        when(authorizationExtension.getUserRoles(pluginId, username, authConfig, pluginRoleConfigs)).thenReturn(response);
+        when(authorizationExtension.getUserRoles(pluginId, username, authConfig, pluginRoleConfigs)).thenReturn(Collections.emptyList());
 
-        AuthenticationResponse actualResponse = service.getUserRoles(pluginId, username, authConfig, pluginRoleConfigs);
-        assertThat(actualResponse).isEqualTo(response);
+        List<String> actualResponse = service.getUserRoles(pluginId, username, authConfig, pluginRoleConfigs);
+        assertThat(actualResponse).isEqualTo(Collections.emptyList());
 
         actualResponse = service.getUserRoles(pluginId, username, authConfig, pluginRoleConfigs);
-        assertThat(actualResponse).isEqualTo(response);
+        assertThat(actualResponse).isEqualTo(Collections.emptyList());
 
         verify(authorizationExtension, times(1)).getUserRoles(pluginId, username, authConfig, pluginRoleConfigs);
 
         ticker.advance(31, TimeUnit.MINUTES);
 
         actualResponse = service.getUserRoles(pluginId, username, authConfig, pluginRoleConfigs);
-        assertThat(actualResponse).isEqualTo(response);
+        assertThat(actualResponse).isEqualTo(Collections.emptyList());
 
         verify(authorizationExtension, times(2)).getUserRoles(pluginId, username, authConfig, pluginRoleConfigs);
     }
@@ -156,16 +154,15 @@ public class AuthorizationExtensionCacheServiceTest {
         SecurityConfigChangeListener listener = captor.getValue();
 
         List<PluginRoleConfig> pluginRoleConfigs = Collections.emptyList();
-        AuthenticationResponse response = new AuthenticationResponse(null, Collections.emptyList());
-        when(authorizationExtension.getUserRoles(pluginId, username, authConfig, pluginRoleConfigs)).thenReturn(response);
+        when(authorizationExtension.getUserRoles(pluginId, username, authConfig, pluginRoleConfigs)).thenReturn(Collections.emptyList());
 
-        AuthenticationResponse actualResponse = service.getUserRoles(pluginId, username, authConfig, pluginRoleConfigs);
-        assertThat(actualResponse).isEqualTo(response);
+        List<String> actualResponse = service.getUserRoles(pluginId, username, authConfig, pluginRoleConfigs);
+        assertThat(actualResponse).isEqualTo(Collections.emptyList());
 
         listener.onEntityConfigChange(new Object());
 
         actualResponse = service.getUserRoles(pluginId, username, authConfig, pluginRoleConfigs);
-        assertThat(actualResponse).isEqualTo(response);
+        assertThat(actualResponse).isEqualTo(Collections.emptyList());
 
         verify(authorizationExtension, times(2)).getUserRoles(pluginId, username, authConfig, pluginRoleConfigs);
     }


### PR DESCRIPTION
Updated response for `getUserRoles` as User info is not expected from this request. We already get it from authorization and authentication call.