### PR TITLE
Ensuring Etag is consistent when plugin settings does not change

### DIFF
--- a/server/src/main/java/com/thoughtworks/go/server/domain/PluginSettings.java
+++ b/server/src/main/java/com/thoughtworks/go/server/domain/PluginSettings.java
@@ -155,6 +155,15 @@ public class PluginSettings implements Validatable {
     }
 
     @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        PluginSettings that = (PluginSettings) o;
+        return Objects.equals(pluginId, that.pluginId) &&
+                Objects.equals(settingsMap, that.settingsMap);
+    }
+
+    @Override
     public int hashCode() {
         return Objects.hash(pluginId, settingsMap);
     }

--- a/server/src/main/java/com/thoughtworks/go/server/domain/PluginSettings.java
+++ b/server/src/main/java/com/thoughtworks/go/server/domain/PluginSettings.java
@@ -27,10 +27,7 @@ import com.thoughtworks.go.plugin.access.common.settings.PluginSettingsConfigura
 import com.thoughtworks.go.plugin.access.common.settings.PluginSettingsProperty;
 import com.thoughtworks.go.plugin.domain.common.PluginInfo;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 public class PluginSettings implements Validatable {
     private String pluginId;
@@ -155,5 +152,10 @@ public class PluginSettings implements Validatable {
                 hasErrors = true;
             }
         }
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(pluginId, settingsMap);
     }
 }

--- a/server/src/main/java/com/thoughtworks/go/server/service/EntityHashingService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/EntityHashingService.java
@@ -173,6 +173,7 @@ public class EntityHashingService implements ConfigChangedListener, Initializer 
             return cachedMD5;
         }
         String md5 = CachedDigestUtils.md5Hex(fingerprintSupplier.get());
+        goCache.put(ETAG_CACHE_KEY, cacheKey, md5);
 
         return md5;
     }

--- a/server/src/main/java/com/thoughtworks/go/server/service/EntityHashingService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/EntityHashingService.java
@@ -28,7 +28,6 @@ import com.thoughtworks.go.domain.packagerepository.PackageDefinition;
 import com.thoughtworks.go.domain.packagerepository.PackageRepository;
 import com.thoughtworks.go.domain.scm.SCM;
 import com.thoughtworks.go.listener.ConfigChangedListener;
-import com.thoughtworks.go.listener.DataSharingSettingsChangeListener;
 import com.thoughtworks.go.listener.EntityConfigChangedListener;
 import com.thoughtworks.go.server.cache.GoCache;
 import com.thoughtworks.go.server.domain.DataSharingSettings;
@@ -41,6 +40,7 @@ import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Supplier;
 
 @Component
 public class EntityHashingService implements ConfigChangedListener, Initializer {
@@ -87,67 +87,67 @@ public class EntityHashingService implements ConfigChangedListener, Initializer 
 
     public String md5ForEntity(PipelineTemplateConfig config) {
         String cacheKey = cacheKey(config, config.name());
-        return getFromCache(config, cacheKey);
+        return getDomainEntityMd5FromCache(config, cacheKey);
     }
 
     public String md5ForEntity(EnvironmentConfig config) {
         String cacheKey = cacheKey(config, config.name());
-        return getFromCache(config, cacheKey);
+        return getDomainEntityMd5FromCache(config, cacheKey);
     }
 
     public String md5ForEntity(PackageRepository config) {
         String cacheKey = cacheKey(config, config.getId());
-        return getFromCache(config, cacheKey);
+        return getDomainEntityMd5FromCache(config, cacheKey);
     }
 
     public String md5ForEntity(SCM config) {
         String cacheKey = cacheKey(config, config.getName());
-        return getFromCache(config, cacheKey);
+        return getDomainEntityMd5FromCache(config, cacheKey);
     }
 
     public String md5ForEntity(PipelineConfig config) {
         String cacheKey = cacheKey(config, config.name());
-        return getFromCache(config, cacheKey);
+        return getDomainEntityMd5FromCache(config, cacheKey);
     }
 
     public String md5ForEntity(ConfigRepoConfig config) {
         String cacheKey = cacheKey(config, config.getId());
-        return getFromCache(config, cacheKey);
+        return getDomainEntityMd5FromCache(config, cacheKey);
     }
 
     public String md5ForEntity(ElasticProfile config) {
         String cacheKey = cacheKey(config, config.getId());
-        return getFromCache(config, cacheKey);
+        return getDomainEntityMd5FromCache(config, cacheKey);
     }
 
     public String md5ForEntity(SecurityAuthConfig config) {
         String cacheKey = cacheKey(config, config.getId());
-        return getFromCache(config, cacheKey);
+        return getDomainEntityMd5FromCache(config, cacheKey);
     }
 
     public String md5ForEntity(Role config) {
         String cacheKey = cacheKey(config, config.getName());
-        return getFromCache(config, cacheKey);
+        return getDomainEntityMd5FromCache(config, cacheKey);
     }
 
     public String md5ForEntity(AdminsConfig config) {
         String cacheKey = cacheKey(config, "cacheKey");
-        return getFromCache(config, cacheKey);
+        return getDomainEntityMd5FromCache(config, cacheKey);
     }
 
     public String md5ForEntity(PackageDefinition config) {
         String cacheKey = cacheKey(config, config.getId());
-        return getFromCache(config, cacheKey);
+        return getDomainEntityMd5FromCache(config, cacheKey);
     }
 
     public String md5ForEntity(PluginSettings pluginSettings) {
         String cacheKey = cacheKey(pluginSettings, pluginSettings.getPluginId());
-        return getFromCache(cacheKey, pluginSettings);
+        return getFromCache(cacheKey, () -> String.valueOf(pluginSettings.hashCode()));
     }
 
     public String md5ForEntity(ArtifactStore artifactStore) {
         String cacheKey = cacheKey(artifactStore, artifactStore.getId());
-        return getFromCache(cacheKey, artifactStore);
+        return getDbEntityMd5FromCache(cacheKey, artifactStore);
     }
 
     private String cacheKey(Object domainObject, CaseInsensitiveString name) {
@@ -158,27 +158,21 @@ public class EntityHashingService implements ConfigChangedListener, Initializer 
         return getClass(domainObject) + "." + name;
     }
 
-    private String getFromCache(String cacheKey, Object dbObject) {
-        String cachedMD5 = getFromCache(cacheKey);
-
-        if (cachedMD5 != null) {
-            return cachedMD5;
-        }
-        String md5 = CachedDigestUtils.md5Hex(new GsonBuilder().create().toJson(dbObject));
-        goCache.put(ETAG_CACHE_KEY, cacheKey, md5);
-
-        return md5;
+    private String getDbEntityMd5FromCache(String cacheKey, Object dbObject) {
+        return getFromCache(cacheKey, () -> new GsonBuilder().create().toJson(dbObject));
     }
 
-    private String getFromCache(Object domainObject, String cacheKey) {
+    private String getDomainEntityMd5FromCache(Object domainObject, String cacheKey) {
+        return getFromCache(cacheKey, () -> getDomainObjectXmlPartial(domainObject));
+    }
+
+    private String getFromCache(String cacheKey, Supplier<String> fingerprintSupplier) {
         String cachedMD5 = getFromCache(cacheKey);
 
         if (cachedMD5 != null) {
             return cachedMD5;
         }
-
-        String md5 = computeMd5For(domainObject);
-        goCache.put(ETAG_CACHE_KEY, cacheKey, md5);
+        String md5 = CachedDigestUtils.md5Hex(fingerprintSupplier.get());
 
         return md5;
     }
@@ -199,9 +193,8 @@ public class EntityHashingService implements ConfigChangedListener, Initializer 
         return entity.getClass().getName();
     }
 
-    private String computeMd5For(Object domainObject) {
-        String xml = new MagicalGoConfigXmlWriter(configCache, registry).toXmlPartial(domainObject);
-        return CachedDigestUtils.md5Hex(xml);
+    private String getDomainObjectXmlPartial(Object domainObject) {
+        return new MagicalGoConfigXmlWriter(configCache, registry).toXmlPartial(domainObject);
     }
 
     public String md5ForEntity(RolesConfig roles) {
@@ -214,12 +207,12 @@ public class EntityHashingService implements ConfigChangedListener, Initializer 
 
     public String md5ForEntity(UsageStatisticsReporting usageStatisticsReporting) {
         String cacheKey = cacheKey(usageStatisticsReporting, usageStatisticsReporting.getServerId());
-        return getFromCache(cacheKey, usageStatisticsReporting);
+        return getDbEntityMd5FromCache(cacheKey, usageStatisticsReporting);
     }
 
     public String md5ForEntity(DataSharingSettings dataSharingSettings) {
         String cacheKey = cacheKey(dataSharingSettings, "data_sharing_settings");
-        return getFromCache(cacheKey, dataSharingSettings);
+        return getDbEntityMd5FromCache(cacheKey, dataSharingSettings);
     }
 
     public String md5ForEntity(PipelineGroups pipelineGroups) {
@@ -232,7 +225,7 @@ public class EntityHashingService implements ConfigChangedListener, Initializer 
 
     public String md5ForEntity(PipelineConfigs pipelineConfigs) {
         String cacheKey = cacheKey(pipelineConfigs, pipelineConfigs.getGroup());
-        return getFromCache(pipelineConfigs, cacheKey);
+        return getDomainEntityMd5FromCache(pipelineConfigs, cacheKey);
     }
 
     class PipelineConfigChangedListener extends EntityConfigChangedListener<PipelineConfig> {

--- a/server/src/test-fast/java/com/thoughtworks/go/server/service/EntityHashingServiceTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/service/EntityHashingServiceTest.java
@@ -76,12 +76,13 @@ public class EntityHashingServiceTest {
 
     @Test
     public void shouldUseObjectHashCodeForPluginSettings() {
-        PluginSettings pluginSettings = new PluginSettings();
-        String expectedMd5 = CachedDigestUtils.md5Hex(String.valueOf(pluginSettings.hashCode()));
+        PluginSettings pluginSettings = new PluginSettings("com.foo.plugin");
+        String expectedMd5 = "8f54eed0331c2bd93ca4cf8f470f4406";
 
         String actualMd5 = entityHashingService.md5ForEntity(pluginSettings);
 
         assertThat(actualMd5, is(expectedMd5));
+        verify(goCache).put("GO_ETAG_CACHE", "com.thoughtworks.go.server.domain.PluginSettings.com.foo.plugin", expectedMd5);
     }
 
     @Test

--- a/server/src/test-fast/java/com/thoughtworks/go/server/service/EntityHashingServiceTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/service/EntityHashingServiceTest.java
@@ -22,6 +22,7 @@ import com.thoughtworks.go.config.PipelineConfig;
 import com.thoughtworks.go.config.registry.ConfigElementImplementationRegistry;
 import com.thoughtworks.go.helper.PipelineConfigMother;
 import com.thoughtworks.go.server.cache.GoCache;
+import com.thoughtworks.go.server.domain.PluginSettings;
 import com.thoughtworks.go.util.CachedDigestUtils;
 import com.thoughtworks.go.util.ConfigElementImplementationRegistryMother;
 import org.junit.Before;
@@ -71,6 +72,16 @@ public class EntityHashingServiceTest {
         entityHashingService.initialize();
 
         verify(goConfigService).register(entityHashingService);
+    }
+
+    @Test
+    public void shouldUseObjectHashCodeForPluginSettings() {
+        PluginSettings pluginSettings = new PluginSettings();
+        String expectedMd5 = CachedDigestUtils.md5Hex(String.valueOf(pluginSettings.hashCode()));
+
+        String actualMd5 = entityHashingService.md5ForEntity(pluginSettings);
+
+        assertThat(actualMd5, is(expectedMd5));
     }
 
     @Test

--- a/server/webapp/WEB-INF/rails/app/controllers/api_v1/admin/plugin_settings_controller.rb
+++ b/server/webapp/WEB-INF/rails/app/controllers/api_v1/admin/plugin_settings_controller.rb
@@ -37,9 +37,9 @@ module ApiV1
       def update
         result = HttpLocalizedOperationResult.new
         object = ApiV1::Config::PluginSettingsRepresenter.new({plugin_settings: PluginSettings.new, plugin_info: load_plugin_info(params[:plugin_setting][:plugin_id])}).from_hash(params[:plugin_setting])
-        @plugin_settings = object[:plugin_settings]
-        plugin_service.updatePluginSettings(@plugin_settings, current_user, result, etag_for(@plugin_settings))
-        handle_create_or_update_response(result, @plugin_settings)
+        new_plugin_settings = object[:plugin_settings]
+        plugin_service.updatePluginSettings(new_plugin_settings, current_user, result, etag_for(@plugin_settings))
+        handle_create_or_update_response(result, new_plugin_settings)
       end
 
       protected

--- a/server/webapp/WEB-INF/rails/spec/controllers/api_v1/admin/plugin_settings_controller_spec.rb
+++ b/server/webapp/WEB-INF/rails/spec/controllers/api_v1/admin/plugin_settings_controller_spec.rb
@@ -353,7 +353,10 @@ describe ApiV1::Admin::PluginSettingsController do
 
         expect(@plugin_service).to receive(:isPluginLoaded).with('plugin.id.1').and_return(true)
         expect(@plugin_service).to receive(:isPluginLoaded).with('plugin.id.1').and_return(true)
-        expect(@entity_hashing_service).to receive(:md5ForEntity).with(an_instance_of(PluginSettings)).exactly(3).times.and_return('md5')
+
+        expect(@entity_hashing_service).to receive(:md5ForEntity).twice.ordered.with(@plugin_settings).and_return('md5')
+        expect(@entity_hashing_service).to receive(:md5ForEntity).once.ordered.with(an_instance_of(PluginSettings)).and_return('newmd5')
+
         expect(@plugin_service).to receive(:getPluginSettings).with('plugin.id.1').and_return(@plugin_settings)
         expect(@plugin_service).to receive(:updatePluginSettings).with(an_instance_of(PluginSettings), anything, anything, "md5")
 


### PR DESCRIPTION
Fix for issue #5842
 -  Using PluginSettings HashCode to generate the entity md5 instead of json since json has encrypted secure environment variables whose value changes one each request due to new salt.
- Fixing usage of entity md5 in plugins_controller by passing the md5 of plugin setting fetched from db. This worked earlier since the md5 was different for each call and hence the stale check in PluginService.updatePluginSettings would never be true.