### PR TITLE
Reimplement disallowing access token creation when plugin does not support extension v2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,6 +96,7 @@ api/api-artifact-store-config-v1/config/
 api/api-access-token-v1/logs/
 api/api-access-token-v1/out/
 api/api-access-token-v1/target/
+api/api-access-token-v1/config/
 api/api-artifact-store-config-v1/logs/
 api/api-artifact-store-config-v1/out/
 api/api-artifact-store-config-v1/target/


### PR DESCRIPTION
* This feature was originally implemented as part of: https://github.com/gocd/gocd/pull/5827
* But due to some conflicts while merging https://github.com/gocd/gocd/pull/5840 , these
  changes were removed.
* Added the check again for not letting users create access token against an auth config
  belonging to plugin which does not support authroization extension v2.

Related links:
* https://github.com/gocd/gocd/pull/5822
* https://github.com/gocd/gocd/pull/5827
* https://github.com/gocd/gocd/pull/5840