### PR TITLE
Split access token API into 2 to simplify URLs

### DIFF
--- a/api/api-access-token-v1/src/main/java/com/thoughtworks/go/apiv1/accessToken/AbstractUserAccessTokenControllerV1.java
+++ b/api/api-access-token-v1/src/main/java/com/thoughtworks/go/apiv1/accessToken/AbstractUserAccessTokenControllerV1.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.apiv1.accessToken;
+
+import com.thoughtworks.go.api.ApiController;
+import com.thoughtworks.go.api.ApiVersion;
+import com.thoughtworks.go.api.representers.JsonReader;
+import com.thoughtworks.go.api.spring.ApiAuthenticationHelper;
+import com.thoughtworks.go.api.util.GsonTransformer;
+import com.thoughtworks.go.apiv1.accessToken.representers.AccessTokenRepresenter;
+import com.thoughtworks.go.apiv1.accessToken.representers.AccessTokensRepresenter;
+import com.thoughtworks.go.config.exceptions.ConflictException;
+import com.thoughtworks.go.config.exceptions.NotAuthorizedException;
+import com.thoughtworks.go.config.exceptions.RecordNotFoundException;
+import com.thoughtworks.go.domain.AccessToken;
+import com.thoughtworks.go.server.service.AccessTokenService;
+import com.thoughtworks.go.spark.Routes;
+import com.thoughtworks.go.spark.spring.SparkSpringController;
+import spark.Request;
+import spark.Response;
+
+import java.io.IOException;
+import java.util.List;
+
+import static spark.Spark.exception;
+
+abstract class AbstractUserAccessTokenControllerV1 extends ApiController implements SparkSpringController {
+    protected final ApiAuthenticationHelper apiAuthenticationHelper;
+    protected AccessTokenService accessTokenService;
+
+    public AbstractUserAccessTokenControllerV1(ApiAuthenticationHelper apiAuthenticationHelper, AccessTokenService AccessTokenService) {
+        super(ApiVersion.v1);
+        this.apiAuthenticationHelper = apiAuthenticationHelper;
+        this.accessTokenService = AccessTokenService;
+    }
+
+    public String getAllAccessTokens(Request request, Response response) throws Exception {
+        List<AccessToken> allTokens = allTokens();
+        return writerForTopLevelObject(request, response, outputWriter -> AccessTokensRepresenter.toJSON(outputWriter, urlContext(), allTokens));
+    }
+
+    public String revokeAccessToken(Request request, Response response) throws Exception {
+        long id = Long.parseLong(request.params(":id"));
+        final JsonReader reader = GsonTransformer.getInstance().jsonReaderFrom(request.body());
+        String revokeCause = reader.optString("cause").orElse(null);
+
+        AccessToken revokeAccessToken = accessTokenService.revokeAccessToken(id, currentUsernameString(), revokeCause);
+
+        return renderAccessToken(request, response, revokeAccessToken);
+    }
+
+    public String getAccessToken(Request request, Response response) throws Exception {
+        final AccessToken token = accessTokenService.find(Long.parseLong(request.params(":id")), currentUsernameString());
+
+        return renderAccessToken(request, response, token);
+    }
+
+    String renderAccessToken(Request request, Response response, AccessToken token) throws IOException {
+        return writerForTopLevelObject(request, response, outputWriter -> AccessTokenRepresenter.toJSON(outputWriter, urlContext(), token));
+    }
+
+    protected abstract List<AccessToken> allTokens();
+
+    abstract Routes.FindUrlBuilder<Long> urlContext();
+
+    void addExceptionHandlers() {
+        exception(RecordNotFoundException.class, this::notFound);
+        exception(NotAuthorizedException.class, this::renderForbiddenResponse);
+        exception(ConflictException.class, this::renderForbiddenResponse);
+    }
+}

--- a/api/api-access-token-v1/src/main/java/com/thoughtworks/go/apiv1/accessToken/AdminUserAccessTokenControllerV1.java
+++ b/api/api-access-token-v1/src/main/java/com/thoughtworks/go/apiv1/accessToken/AdminUserAccessTokenControllerV1.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.apiv1.accessToken;
+
+import com.thoughtworks.go.api.spring.ApiAuthenticationHelper;
+import com.thoughtworks.go.domain.AccessToken;
+import com.thoughtworks.go.server.service.AccessTokenService;
+import com.thoughtworks.go.spark.Routes;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+import static spark.Spark.*;
+
+@Component
+public class AdminUserAccessTokenControllerV1 extends AbstractUserAccessTokenControllerV1 {
+
+    @Autowired
+    public AdminUserAccessTokenControllerV1(ApiAuthenticationHelper apiAuthenticationHelper, AccessTokenService AccessTokenService) {
+        super(apiAuthenticationHelper, AccessTokenService);
+    }
+
+    @Override
+    public String controllerBasePath() {
+        return Routes.AdminUserAccessToken.BASE;
+    }
+
+    @Override
+    public void setupRoutes() {
+        path(controllerBasePath(), () -> {
+            before("", mimeType, this::setContentType);
+            before("/*", mimeType, this::setContentType);
+
+            before("", mimeType, this.apiAuthenticationHelper::ensureSecurityEnabled);
+            before("/*", mimeType, this.apiAuthenticationHelper::ensureSecurityEnabled);
+
+            before("", mimeType, this.apiAuthenticationHelper::checkAdminUserAnd403);
+            before("/*", mimeType, this.apiAuthenticationHelper::checkAdminUserAnd403);
+
+            get("", mimeType, this::getAllAccessTokens);
+            post(Routes.AdminUserAccessToken.REVOKE, mimeType, this::revokeAccessToken);
+            get(Routes.AdminUserAccessToken.ID, mimeType, this::getAccessToken);
+
+            addExceptionHandlers();
+        });
+    }
+
+    @Override
+    protected List<AccessToken> allTokens() {
+        return accessTokenService.findAllTokensForAllUsers();
+    }
+
+    @Override
+    Routes.FindUrlBuilder<Long> urlContext() {
+        return new Routes.AdminUserAccessToken();
+    }
+
+
+}

--- a/api/api-access-token-v1/src/main/java/com/thoughtworks/go/apiv1/accessToken/representers/AccessTokenRepresenter.java
+++ b/api/api-access-token-v1/src/main/java/com/thoughtworks/go/apiv1/accessToken/representers/AccessTokenRepresenter.java
@@ -24,21 +24,28 @@ import com.thoughtworks.go.spark.Routes;
 import java.util.Collections;
 
 public class AccessTokenRepresenter {
-    public static void toJSON(OutputWriter outputWriter, AccessToken token) {
+    public static void toJSON(OutputWriter outputWriter, Routes.FindUrlBuilder<Long> urlBuilder, AccessToken token) {
         outputWriter.addLinks(linksWriter -> linksWriter
-                .addLink("self", Routes.AccessToken.find(token.getId()))
-                .addAbsoluteLink("doc", Routes.AccessToken.DOC)
-                .addLink("find", Routes.AccessToken.find()));
+                .addLink("self", urlBuilder.find(token.getId()))
+                .addAbsoluteLink("doc", urlBuilder.doc())
+                .addLink("find", urlBuilder.find()));
 
         outputWriter.add("id", token.getId())
                 .add("description", token.getDescription())
-                .add("auth_config_id", token.getAuthConfigId())
-                .addChild("_meta", metaWriter -> {
-                    metaWriter.add("revoked", token.isRevoked())
-                            .add("revoked_at", token.getRevokedAt())
-                            .add("created_at", token.getCreatedAt())
-                            .add("last_used_at", token.getLastUsed());
-                });
+                .add("username", token.getUsername())
+
+                .add("revoked", token.isRevoked())
+                .add("revoke_cause", token.getRevokeCause())
+                .add("revoked_by", token.getRevokedBy())
+                .add("revoked_at", token.getRevokedAt())
+
+                .add("created_at", token.getCreatedAt())
+                .add("last_used_at", token.getLastUsed())
+                .add("auth_config_id", token.getAuthConfigId());
+
+        if (urlBuilder instanceof Routes.AdminUserAccessToken) {
+            outputWriter.add("deletedBecauseUserDeleted", token.isDeletedBecauseUserDeleted());
+        }
 
         if (token instanceof AccessToken.AccessTokenWithDisplayValue) {
             outputWriter.addIfNotNull("token", ((AccessToken.AccessTokenWithDisplayValue) token).getDisplayValue());

--- a/api/api-access-token-v1/src/main/java/com/thoughtworks/go/apiv1/accessToken/representers/AccessTokensRepresenter.java
+++ b/api/api-access-token-v1/src/main/java/com/thoughtworks/go/apiv1/accessToken/representers/AccessTokensRepresenter.java
@@ -23,13 +23,13 @@ import com.thoughtworks.go.spark.Routes;
 import java.util.List;
 
 public class AccessTokensRepresenter {
-    public static void toJSON(OutputWriter outputWriter, List<AccessToken> allTokens) {
+    public static void toJSON(OutputWriter outputWriter, Routes.FindUrlBuilder<Long> urlBuilder, List<AccessToken> allTokens) {
         outputWriter.addLinks(outputLinkWriter -> outputLinkWriter
-                .addLink("self", Routes.AccessToken.BASE)
-                .addAbsoluteLink("doc", Routes.AccessToken.DOC))
+                .addLink("self", Routes.CurrentUserAccessToken.BASE)
+                .addAbsoluteLink("doc", urlBuilder.doc()))
                 .addChild("_embedded", embeddedWriter ->
                         embeddedWriter.addChildList("access_tokens", AccessTokenWriter -> {
-                            allTokens.forEach(token -> AccessTokenWriter.addChild(artifactStoreWriter -> AccessTokenRepresenter.toJSON(artifactStoreWriter, token)));
+                            allTokens.forEach(token -> AccessTokenWriter.addChild(artifactStoreWriter -> AccessTokenRepresenter.toJSON(artifactStoreWriter, urlBuilder, token)));
                         })
                 );
     }

--- a/api/api-access-token-v1/src/test/groovy/com/thoughtworks/go/apiv1/accessToken/CurrentUserAccessTokenControllerV1Test.groovy
+++ b/api/api-access-token-v1/src/test/groovy/com/thoughtworks/go/apiv1/accessToken/CurrentUserAccessTokenControllerV1Test.groovy
@@ -1,0 +1,309 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.apiv1.accessToken
+
+import com.thoughtworks.go.api.SecurityTestTrait
+import com.thoughtworks.go.api.spring.ApiAuthenticationHelper
+import com.thoughtworks.go.api.util.HaltApiMessages
+import com.thoughtworks.go.apiv1.accessToken.representers.AccessTokenRepresenter
+import com.thoughtworks.go.apiv1.accessToken.representers.AccessTokensRepresenter
+import com.thoughtworks.go.config.SecurityAuthConfig
+import com.thoughtworks.go.config.exceptions.RecordNotFoundException
+import com.thoughtworks.go.config.exceptions.UnprocessableEntityException
+import com.thoughtworks.go.domain.AccessToken
+import com.thoughtworks.go.domain.packagerepository.ConfigurationPropertyMother
+import com.thoughtworks.go.plugin.access.authorization.AuthorizationExtension
+import com.thoughtworks.go.server.service.AccessTokenService
+import com.thoughtworks.go.server.service.SecurityAuthConfigService
+import com.thoughtworks.go.spark.ControllerTrait
+import com.thoughtworks.go.spark.NormalUserOnlyIfSecurityEnabled
+import com.thoughtworks.go.spark.SecurityServiceTrait
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.mockito.Mock
+
+import static com.thoughtworks.go.api.base.JsonUtils.toObjectString
+import static com.thoughtworks.go.apiv1.accessToken.representers.AccessTokenRepresenterTest.randomAccessToken
+import static org.mockito.ArgumentMatchers.any
+import static org.mockito.ArgumentMatchers.eq
+import static org.mockito.Mockito.verify
+import static org.mockito.Mockito.when
+import static org.mockito.MockitoAnnotations.initMocks
+
+class CurrentUserAccessTokenControllerV1Test implements ControllerTrait<CurrentUserAccessTokenControllerV1>, SecurityServiceTrait {
+  @Mock
+  SecurityAuthConfigService authConfigService
+  @Mock
+  AccessTokenService accessTokenService
+  @Mock
+  AuthorizationExtension extension
+
+  @BeforeEach
+  void setUp() {
+    initMocks(this)
+  }
+
+  @Override
+  CurrentUserAccessTokenControllerV1 createControllerInstance() {
+    return new CurrentUserAccessTokenControllerV1(new ApiAuthenticationHelper(securityService, goConfigService), accessTokenService, authConfigService, extension)
+  }
+
+  @Nested
+  class Show {
+    def token = randomAccessToken()
+
+    @Nested
+    class Security implements SecurityTestTrait, NormalUserOnlyIfSecurityEnabled {
+      @BeforeEach
+      void setUp() {
+        when(accessTokenService.find(token.id, currentUsernameString())).thenReturn(token)
+      }
+
+      @Override
+      String getControllerMethodUnderTest() {
+        return "getAccessToken"
+      }
+
+      @Override
+      void makeHttpCall() {
+        getWithApiHeader(controller.controllerPath(token.id))
+      }
+    }
+
+    @Nested
+    class AsAuthenticatedUser {
+      @BeforeEach
+      void setUp() {
+        enableSecurity()
+        loginAsUser()
+
+        when(accessTokenService.find(eq(token.id), any(String.class))).thenReturn(token)
+      }
+
+      @Test
+      void 'should render the access token'() {
+        getWithApiHeader(controller.controllerPath(token.id))
+
+        assertThatResponse()
+          .isOk()
+          .hasContentType(controller.mimeType)
+          .hasBody(toObjectString({ AccessTokenRepresenter.toJSON(it, controller.urlContext(), token) }))
+      }
+
+      @Test
+      void 'should render not found when the specified access token does not exists'() {
+        when(accessTokenService.find(eq(token.id), any(String.class))).thenThrow(new RecordNotFoundException("blah!"))
+
+        getWithApiHeader(controller.controllerPath(token.id))
+
+        assertThatResponse()
+          .isNotFound()
+          .hasJsonMessage(HaltApiMessages.notFoundMessage())
+          .hasContentType(controller.mimeType)
+      }
+    }
+  }
+
+  @Nested
+  class Create {
+    def authConfigId = 'authConfigId'
+
+    @Nested
+    class Security implements SecurityTestTrait, NormalUserOnlyIfSecurityEnabled {
+      @Override
+      String getControllerMethodUnderTest() {
+        return "createAccessToken"
+      }
+
+      @Override
+      void makeHttpCall() {
+        postWithApiHeader(controller.controllerPath(), [:])
+      }
+    }
+
+    @Nested
+    class AsAuthenticatedUser {
+      def token = randomAccessToken()
+
+      @BeforeEach
+      void setUp() {
+        enableSecurity()
+        loginAsUser()
+
+        when(accessTokenService.create(token.description, currentUsernameString(), authConfigId)).thenReturn(token)
+        when(extension.supportsPluginAPICallsRequiredForAccessToken(any())).thenReturn(true)
+      }
+
+      @Test
+      void 'should create a new access token'() {
+        def requestBody = [
+          description: token.description
+        ]
+
+        postWithApiHeader(controller.controllerPath(), requestBody)
+
+        assertThatResponse()
+          .isOk()
+          .hasContentType(controller.mimeType)
+          .hasBody(toObjectString({ AccessTokenRepresenter.toJSON(it, controller.urlContext(), token) }))
+      }
+
+      @Test
+      void 'should disallow access token creation when the plugin does not support access token related API calls'() {
+        def authConfig = new SecurityAuthConfig("ldap", "plugin-id", ConfigurationPropertyMother.create("url", false, "some-url"));
+        when(authConfigService.findProfile(any())).thenReturn(authConfig)
+        when(extension.supportsPluginAPICallsRequiredForAccessToken(authConfig)).thenReturn(false)
+
+        postWithApiHeader(controller.controllerPath(), [:])
+
+        assertThatResponse()
+          .isUnprocessableEntity()
+          .hasJsonMessage("Can not create Access Token. Please upgrade 'plugin-id' plugin to use Access Token Feature.")
+      }
+
+      @Test
+      void 'should create a new access token without providing token description'() {
+        token.description = null
+        when(accessTokenService.create(eq(token.description), eq(currentUsernameString()), eq(authConfigId))).thenReturn(token)
+
+        def requestBody = [
+          description: null
+        ]
+
+        postWithApiHeader(controller.controllerPath(), requestBody)
+
+        assertThatResponse()
+          .isOk()
+          .hasContentType(controller.mimeType)
+          .hasBody(toObjectString({ AccessTokenRepresenter.toJSON(it, controller.urlContext(), token) }))
+      }
+
+      @Test
+      void 'should show errors occurred while creating a new access token'() {
+        when(accessTokenService.create(token.description, currentUsernameString(), authConfigId)).thenThrow(new UnprocessableEntityException("Boom!"))
+
+        def requestBody = [
+          description: token.description
+        ]
+
+        postWithApiHeader(controller.controllerPath(), requestBody)
+
+        assertThatResponse()
+          .isUnprocessableEntity()
+          .hasJsonMessage("Your request could not be processed. Boom!")
+      }
+    }
+  }
+
+  @Nested
+  class Index {
+    AccessToken.AccessTokenWithDisplayValue token = randomAccessToken()
+
+    @Nested
+    class Security implements SecurityTestTrait, NormalUserOnlyIfSecurityEnabled {
+      @BeforeEach
+      void setUp() {
+        when(accessTokenService.findAllTokensForUser(currentUsernameString())).thenReturn([token])
+      }
+
+      @Override
+      String getControllerMethodUnderTest() {
+        return "getAllAccessTokens"
+      }
+
+      @Override
+      void makeHttpCall() {
+        getWithApiHeader(controller.controllerPath())
+      }
+    }
+
+    @Nested
+    class AsAuthenticatedUser {
+      @BeforeEach
+      void setUp() {
+        enableSecurity()
+        loginAsUser()
+
+        when(accessTokenService.findAllTokensForUser(currentUsernameString())).thenReturn([token])
+      }
+
+      @Test
+      void 'should render all the access tokens'() {
+        getWithApiHeader(controller.controllerPath())
+
+        assertThatResponse()
+          .isOk()
+          .hasContentType(controller.mimeType)
+          .hasBody(toObjectString({ AccessTokensRepresenter.toJSON(it, controller.urlContext(), [token]) }))
+      }
+    }
+  }
+
+  @Nested
+  class Revoke {
+    def token = randomAccessToken()
+
+    @Nested
+    class NormalSecurity implements SecurityTestTrait, NormalUserOnlyIfSecurityEnabled {
+      @Override
+      String getControllerMethodUnderTest() {
+        return "revokeAccessToken"
+      }
+
+      @Override
+      void makeHttpCall() {
+        postWithApiHeader(controller.controllerPath(token.id, 'revoke'), [:])
+      }
+    }
+
+    @Nested
+    class AsAuthorizedUser {
+      @BeforeEach
+      void setUp() {
+        enableSecurity()
+        loginAsUser()
+      }
+
+      @Test
+      void 'should revoke the access token'() {
+        when(accessTokenService.find(token.id, currentUsernameString())).thenReturn(token)
+        when(accessTokenService.revokeAccessToken(token.id, currentUsernameString(), "blah")).thenReturn(token)
+
+        postWithApiHeader(controller.controllerPath(token.id, 'revoke'), [cause: 'blah'])
+
+        verify(accessTokenService).revokeAccessToken(token.id, currentUsernameString(), "blah")
+
+        assertThatResponse()
+          .isOk()
+          .hasContentType(controller.mimeType)
+          .hasBody(toObjectString({ AccessTokenRepresenter.toJSON(it, controller.urlContext(), token) }))
+      }
+
+      @Test
+      void 'should show errors occurred while revoking a new access token'() {
+        when(accessTokenService.revokeAccessToken(token.id, currentUsernameString(), null)).thenThrow(new UnprocessableEntityException("Boom!"))
+
+        postWithApiHeader(controller.controllerPath(token.id, 'revoke'), [:])
+
+        assertThatResponse()
+          .isUnprocessableEntity()
+          .hasJsonMessage("Your request could not be processed. Boom!")
+      }
+    }
+  }
+}

--- a/api/api-access-token-v1/src/test/groovy/com/thoughtworks/go/apiv1/accessToken/representers/AccessTokensRepresenterTest.groovy
+++ b/api/api-access-token-v1/src/test/groovy/com/thoughtworks/go/apiv1/accessToken/representers/AccessTokensRepresenterTest.groovy
@@ -17,6 +17,7 @@
 package com.thoughtworks.go.apiv1.accessToken.representers
 
 import com.thoughtworks.go.domain.AccessToken
+import com.thoughtworks.go.spark.Routes
 import org.junit.jupiter.api.Test
 
 import static com.thoughtworks.go.CurrentGoCDVersion.apiDocsUrl
@@ -32,13 +33,13 @@ class AccessTokensRepresenterTest {
     AccessToken.AccessTokenWithDisplayValue token2 = randomAccessToken(42, true)
 
     def json = toObjectString({
-      AccessTokensRepresenter.toJSON(it, [token1, token2])
+      AccessTokensRepresenter.toJSON(it, new Routes.CurrentUserAccessToken(), [token1, token2])
     })
 
     def expectedJSON = [
       "_links"   : [
         "self": [
-          "href": "http://test.host/go/api/access_tokens"
+          "href": "http://test.host/go/api/current_user/access_tokens"
         ],
         "doc" : [
           "href": apiDocsUrl('#access-token')
@@ -49,46 +50,48 @@ class AccessTokensRepresenterTest {
           [
             "_links"        : [
               "self": [
-                "href": "http://test.host/go/api/access_tokens/41"
+                "href": "http://test.host/go/api/current_user/access_tokens/41"
               ],
               "doc" : [
                 "href": apiDocsUrl('#access-token')
               ],
               "find": [
-                "href": "http://test.host/go/api/access_tokens/:id"
+                "href": "http://test.host/go/api/current_user/access_tokens/:id"
               ]
             ],
-            "id"          : token1.id,
+            "id"            : token1.id,
             "description"   : token1.description,
+            "username"      : token1.username,
             "auth_config_id": token1.authConfigId,
-            "_meta"         : [
-              "revoked"  : token1.revoked,
-              "revoked_at"  : null,
-              "created_at"  : jsonDate(token1.createdAt),
-              "last_used_at": null
-            ]
+            "revoked"       : token1.revoked,
+            "revoked_at"    : null,
+            "revoke_cause"  : null,
+            "revoked_by"    : null,
+            "created_at"    : jsonDate(token1.createdAt),
+            "last_used_at"  : null
           ],
           [
             "_links"        : [
               "self": [
-                "href": "http://test.host/go/api/access_tokens/42"
+                "href": "http://test.host/go/api/current_user/access_tokens/42"
               ],
               "doc" : [
                 "href": apiDocsUrl('#access-token')
               ],
               "find": [
-                "href": "http://test.host/go/api/access_tokens/:id"
+                "href": "http://test.host/go/api/current_user/access_tokens/:id"
               ]
             ],
-            "id"          : token2.id,
+            "id"            : token2.id,
             "description"   : token2.description,
+            "username"      : token2.username,
             "auth_config_id": token2.authConfigId,
-            "_meta"         : [
-              "revoked"  : token2.revoked,
-              "revoked_at"  : null,
-              "created_at"  : jsonDate(token2.createdAt),
-              "last_used_at": null
-            ]
+            "revoked"       : token2.revoked,
+            "revoked_at"    : null,
+            "revoke_cause"  : null,
+            "revoked_by"    : null,
+            "created_at"    : jsonDate(token2.createdAt),
+            "last_used_at"  : null
           ]
         ]
       ]

--- a/server/src/main/java/com/thoughtworks/go/server/dao/AccessTokenDao.java
+++ b/server/src/main/java/com/thoughtworks/go/server/dao/AccessTokenDao.java
@@ -24,7 +24,9 @@ import java.util.List;
 public interface AccessTokenDao {
     void saveOrUpdate(AccessToken accessToken);
 
-    AccessToken load(long id);
+    AccessToken loadForAdminUser(long id);
+
+    AccessToken loadNotDeletedTokenForUser(long id, String username);
 
     List<AccessToken> findAllTokens();
 

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/AccessTokenServiceIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/AccessTokenServiceIntegrationTest.java
@@ -178,6 +178,6 @@ public class AccessTokenServiceIntegrationTest {
 
         assertThatCode(() -> accessTokenService.revokeAccessToken(id, "bOb", null))
                 .isInstanceOf(RecordNotFoundException.class)
-                .hasMessage("Cannot locate access token with id 42");
+                .hasMessage("Cannot locate access token with id 42.");
     }
 }

--- a/server/webapp/WEB-INF/urlrewrite.xml
+++ b/server/webapp/WEB-INF/urlrewrite.xml
@@ -48,20 +48,20 @@
 
   <rule>
     <name>Access Token Index and Create API</name>
-    <from>^/api/access_tokens(/?)$</from>
-    <to last="true">/spark/api/access_tokens</to>
+    <from>^/api/(current_user|admin)/access_tokens(/?)$</from>
+    <to last="true">/spark/api/$1/access_tokens</to>
   </rule>
 
   <rule>
     <name>Spark Access Token Show API</name>
-    <from>^/api/access_tokens/(.*)$</from>
-    <to last="true">/spark/api/access_tokens/${escape:$1}</to>
+    <from>^/api/(current_user|admin)/access_tokens/(.*)$</from>
+    <to last="true">/spark/api/$1/access_tokens/${escape:$2}</to>
   </rule>
 
   <rule>
     <name>Spark Access Token Revoke API</name>
-    <from>^/api/access_tokens/([^/]+)/([^/]+)/revoke</from>
-    <to last="true">/spark/api/access_tokens/${escape:$1}/${escape:$2}/revoke</to>
+    <from>^/api/(current_user|admin)/access_tokens/([^/]+)/([^/]+)/revoke</from>
+    <to last="true">/spark/api/$1/access_tokens/${escape:$2}/${escape:$3}/revoke</to>
   </rule>
 
   <rule>

--- a/spark/spark-base/src/main/java/com/thoughtworks/go/spark/Routes.java
+++ b/spark/spark-base/src/main/java/com/thoughtworks/go/spark/Routes.java
@@ -434,18 +434,55 @@ public class Routes {
         public static final String SPA_BASE = "/admin/artifact_stores";
     }
 
-    public static class AccessToken {
-        public static final String BASE = "/api/access_tokens";
+    public interface FindUrlBuilder<Identifier> {
+        String find();
+
+        String find(Identifier id);
+
+        String doc();
+    }
+
+    public static class CurrentUserAccessToken implements FindUrlBuilder<Long> {
+        public static final String BASE = "/api/current_user/access_tokens";
         public static final String ID = "/:id";
         public static final String REVOKE = ID + "/revoke";
-        public static final String DOC = apiDocsUrl("#access-token");
+        private static final String DOC = apiDocsUrl("#access-token");
 
-        public static String find() {
+        @Override
+        public String find() {
             return BASE + ID;
         }
 
-        public static String find(long id) {
+        @Override
+        public String find(Long id) {
             return find().replaceAll(":id", String.valueOf(id));
+        }
+
+        @Override
+        public String doc() {
+            return DOC;
+        }
+    }
+
+    public static class AdminUserAccessToken implements FindUrlBuilder<Long> {
+        public static final String BASE = "/api/admin/access_tokens";
+        public static final String ID = "/:id";
+        public static final String REVOKE = ID + "/revoke";
+        private static final String DOC = apiDocsUrl("#access-token");
+
+        @Override
+        public String find() {
+            return BASE + ID;
+        }
+
+        @Override
+        public String find(Long id) {
+            return find().replaceAll(":id", String.valueOf(id));
+        }
+
+        @Override
+        public String doc() {
+            return DOC;
         }
     }
 

--- a/spark/spark-base/src/test/groovy/com/thoughtworks/go/spark/AdminUserOnlyIfSecurityEnabled.groovy
+++ b/spark/spark-base/src/test/groovy/com/thoughtworks/go/spark/AdminUserOnlyIfSecurityEnabled.groovy
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.spark
+
+import org.junit.jupiter.api.Test
+
+trait AdminUserOnlyIfSecurityEnabled {
+
+  @Test
+  void 'should disallow all with security disabled'() {
+    disableSecurity()
+
+    makeHttpCall()
+    assertDeniedBecauseSecurityDisabled()
+  }
+
+  @Test
+  void "should disallow anonymous users, with security enabled"() {
+    enableSecurity()
+    loginAsAnonymous()
+
+    makeHttpCall()
+
+    assertRequestForbidden()
+  }
+
+  @Test
+  void 'should disallow normal users, with security enabled'() {
+    enableSecurity()
+    loginAsUser()
+
+    makeHttpCall()
+    assertRequestForbidden()
+  }
+
+  @Test
+  void 'should allow admin, with security enabled'() {
+    enableSecurity()
+    loginAsAdmin()
+
+    makeHttpCall()
+    assertRequestAllowed()
+  }
+
+  @Test
+  void 'should disallow pipeline group admin users, with security enabled'() {
+    enableSecurity()
+    loginAsGroupAdmin()
+
+    makeHttpCall()
+    assertRequestForbidden()
+  }
+}


### PR DESCRIPTION
- /go/api/current_user/access_tokens: for the current user
- /go/api/admins/access_tokens: for admins to list tokens for all users