### PR TITLE
Adding --no-color to git log cmd

### DIFF
--- a/common/src/test/java/com/thoughtworks/go/domain/materials/git/GitCommandTest.java
+++ b/common/src/test/java/com/thoughtworks/go/domain/materials/git/GitCommandTest.java
@@ -677,17 +677,17 @@ public class GitCommandTest {
     }
 
     private void setColoring() throws IOException {
-        executeOnGitRepo("git", "config", "--local", "color.diff", "always");
-        executeOnGitRepo("git", "config", "--local", "color.status", "always");
-        executeOnGitRepo("git", "config", "--local", "color.interactive", "always");
-        executeOnGitRepo("git", "config", "--local", "color.branch", "always");
+        executeOnGitRepo("git", "config", "color.diff", "always");
+        executeOnGitRepo("git", "config", "color.status", "always");
+        executeOnGitRepo("git", "config", "color.interactive", "always");
+        executeOnGitRepo("git", "config", "color.branch", "always");
     }
 
     private void unsetColoring() throws IOException {
-        executeOnGitRepo("git", "config", "--local", "color.diff", "auto");
-        executeOnGitRepo("git", "config", "--local", "color.status", "auto");
-        executeOnGitRepo("git", "config", "--local", "color.interactive", "auto");
-        executeOnGitRepo("git", "config", "--local", "color.branch", "auto");
+        executeOnGitRepo("git", "config", "color.diff", "auto");
+        executeOnGitRepo("git", "config", "color.status", "auto");
+        executeOnGitRepo("git", "config", "color.interactive", "auto");
+        executeOnGitRepo("git", "config", "color.branch", "auto");
     }
 
     private void assertWorkingCopyNotCheckedOut() {

--- a/common/src/test/java/com/thoughtworks/go/domain/materials/git/GitCommandTest.java
+++ b/common/src/test/java/com/thoughtworks/go/domain/materials/git/GitCommandTest.java
@@ -100,6 +100,7 @@ public class GitCommandTest {
     }
 
     @After public void teardown() throws Exception {
+        unsetColoring();
         TestRepo.internalTearDown();
     }
 
@@ -281,7 +282,6 @@ public class GitCommandTest {
         assertThat(files.size(), is(1));
         assertThat(files.get(0).getFileName(), is("build.xml"));
         assertThat(files.get(0).getAction(), Matchers.is(ModifiedAction.modified));
-        unsetColoring();
     }
 
     @Test
@@ -332,7 +332,6 @@ public class GitCommandTest {
         setColoring();
 
         assertThat(command.modificationsSince(REVISION_4).get(0), is(modification));
-        unsetColoring();
     }
 
     @Test(expected = CommandLineException.class)
@@ -681,7 +680,6 @@ public class GitCommandTest {
         executeOnGitRepo("git", "config", "color.status", "always");
         executeOnGitRepo("git", "config", "color.interactive", "always");
         executeOnGitRepo("git", "config", "color.branch", "always");
-        executeOnGitRepo("git", "config", "log.decorate", "true");
     }
 
     private void unsetColoring() throws IOException {
@@ -689,7 +687,6 @@ public class GitCommandTest {
         executeOnGitRepo("git", "config", "color.status", "auto");
         executeOnGitRepo("git", "config", "color.interactive", "auto");
         executeOnGitRepo("git", "config", "color.branch", "auto");
-        executeOnGitRepo("git", "config", "log.decorate", "false");
     }
 
     private void assertWorkingCopyNotCheckedOut() {

--- a/common/src/test/java/com/thoughtworks/go/domain/materials/git/GitCommandTest.java
+++ b/common/src/test/java/com/thoughtworks/go/domain/materials/git/GitCommandTest.java
@@ -270,7 +270,7 @@ public class GitCommandTest {
 
     @Test
     public void shouldRetrieveLatestModificationWhenColoringIsSetToAlways() throws Exception {
-        gitRepo.setColoring();
+        setColoring();
         Modification mod = git.latestModification().get(0);
         assertThat(mod.getUserName(), is("Chris Turner <cturner@thoughtworks.com>"));
         assertThat(mod.getComment(), is("Added 'run-till-file-exists' ant target"));
@@ -281,7 +281,7 @@ public class GitCommandTest {
         assertThat(files.size(), is(1));
         assertThat(files.get(0).getFileName(), is("build.xml"));
         assertThat(files.get(0).getAction(), Matchers.is(ModifiedAction.modified));
-        gitRepo.unsetColoring();
+        unsetColoring();
     }
 
     @Test
@@ -323,16 +323,16 @@ public class GitCommandTest {
 
     @Test
     public void shouldReturnTheRebasedCommitForModificationsSinceTheRevisionBeforeRebaseWithColoringIsSetToAlways() throws IOException {
-        gitRepo.setColoring();
         GitTestRepo remoteRepo = new GitTestRepo(temporaryFolder);
         executeOnGitRepo("git", "remote", "rm", "origin");
         executeOnGitRepo("git", "remote", "add", "origin", remoteRepo.projectRepositoryUrl());
         GitCommand command = new GitCommand(remoteRepo.createMaterial().getFingerprint(), gitLocalRepoDir, "master", false, new HashMap<>(), null);
 
         Modification modification = remoteRepo.addFileAndAmend("foo", "amendedCommit").get(0);
+        setColoring();
 
         assertThat(command.modificationsSince(REVISION_4).get(0), is(modification));
-        gitRepo.unsetColoring();
+        unsetColoring();
     }
 
     @Test(expected = CommandLineException.class)
@@ -674,6 +674,20 @@ public class GitCommandTest {
         assertThat(dir.exists(), is(true));
         commandLine.setWorkingDir(dir);
         commandLine.runOrBomb(true, null);
+    }
+
+    private void setColoring() throws IOException {
+        executeOnGitRepo("git", "config", "--local", "color.diff", "always");
+        executeOnGitRepo("git", "config", "--local", "color.status", "always");
+        executeOnGitRepo("git", "config", "--local", "color.interactive", "always");
+        executeOnGitRepo("git", "config", "--local", "color.branch", "always");
+    }
+
+    private void unsetColoring() throws IOException {
+        executeOnGitRepo("git", "config", "--local", "color.diff", "auto");
+        executeOnGitRepo("git", "config", "--local", "color.status", "auto");
+        executeOnGitRepo("git", "config", "--local", "color.interactive", "auto");
+        executeOnGitRepo("git", "config", "--local", "color.branch", "auto");
     }
 
     private void assertWorkingCopyNotCheckedOut() {

--- a/common/src/test/java/com/thoughtworks/go/domain/materials/git/GitCommandTest.java
+++ b/common/src/test/java/com/thoughtworks/go/domain/materials/git/GitCommandTest.java
@@ -681,6 +681,7 @@ public class GitCommandTest {
         executeOnGitRepo("git", "config", "color.status", "always");
         executeOnGitRepo("git", "config", "color.interactive", "always");
         executeOnGitRepo("git", "config", "color.branch", "always");
+        executeOnGitRepo("git", "config", "log.decorate", "true");
     }
 
     private void unsetColoring() throws IOException {
@@ -688,6 +689,7 @@ public class GitCommandTest {
         executeOnGitRepo("git", "config", "color.status", "auto");
         executeOnGitRepo("git", "config", "color.interactive", "auto");
         executeOnGitRepo("git", "config", "color.branch", "auto");
+        executeOnGitRepo("git", "config", "log.decorate", "false");
     }
 
     private void assertWorkingCopyNotCheckedOut() {

--- a/domain/src/main/java/com/thoughtworks/go/domain/materials/git/GitCommand.java
+++ b/domain/src/main/java/com/thoughtworks/go/domain/materials/git/GitCommand.java
@@ -93,12 +93,12 @@ public class GitCommand extends SCMCommand {
     }
 
     public List<Modification> latestModification() {
-        return gitLog("-1", "--date=iso", "--pretty=medium", "--no-color", remoteBranch());
+        return gitLog("-1", "--date=iso", "--pretty=medium", "--decorate=no", "--no-color", remoteBranch());
 
     }
 
     public List<Modification> modificationsSince(Revision revision) {
-        return gitLog("--date=iso", "--pretty=medium", "--no-color", String.format("%s..%s", revision.getRevision(), remoteBranch()));
+        return gitLog("--date=iso", "--pretty=medium", "--decorate=no", "--no-color", String.format("%s..%s", revision.getRevision(), remoteBranch()));
     }
 
     private List<Modification> gitLog(String... args) {

--- a/domain/src/main/java/com/thoughtworks/go/domain/materials/git/GitCommand.java
+++ b/domain/src/main/java/com/thoughtworks/go/domain/materials/git/GitCommand.java
@@ -93,12 +93,12 @@ public class GitCommand extends SCMCommand {
     }
 
     public List<Modification> latestModification() {
-        return gitLog("-1", "--date=iso", "--pretty=medium", "--no-decorate", "--no-color", remoteBranch());
+        return gitLog("-1", "--date=iso", "--pretty=medium", "--no-color", remoteBranch());
 
     }
 
     public List<Modification> modificationsSince(Revision revision) {
-        return gitLog("--date=iso", "--pretty=medium", "--no-decorate", "--no-color", String.format("%s..%s", revision.getRevision(), remoteBranch()));
+        return gitLog("--date=iso", "--pretty=medium", "--no-color", String.format("%s..%s", revision.getRevision(), remoteBranch()));
     }
 
     private List<Modification> gitLog(String... args) {

--- a/domain/src/main/java/com/thoughtworks/go/domain/materials/git/GitCommand.java
+++ b/domain/src/main/java/com/thoughtworks/go/domain/materials/git/GitCommand.java
@@ -93,12 +93,12 @@ public class GitCommand extends SCMCommand {
     }
 
     public List<Modification> latestModification() {
-        return gitLog("-1", "--date=iso", "--pretty=medium", "--decorate=no", "--no-color", remoteBranch());
+        return gitLog("-1", "--date=iso", "--pretty=medium", "--no-color", remoteBranch());
 
     }
 
     public List<Modification> modificationsSince(Revision revision) {
-        return gitLog("--date=iso", "--pretty=medium", "--decorate=no", "--no-color", String.format("%s..%s", revision.getRevision(), remoteBranch()));
+        return gitLog("--date=iso", "--pretty=medium", "--no-color", String.format("%s..%s", revision.getRevision(), remoteBranch()));
     }
 
     private List<Modification> gitLog(String... args) {

--- a/domain/src/main/java/com/thoughtworks/go/domain/materials/git/GitCommand.java
+++ b/domain/src/main/java/com/thoughtworks/go/domain/materials/git/GitCommand.java
@@ -93,12 +93,12 @@ public class GitCommand extends SCMCommand {
     }
 
     public List<Modification> latestModification() {
-        return gitLog("-1", "--date=iso", "--pretty=medium", remoteBranch());
+        return gitLog("-1", "--date=iso", "--pretty=medium", "--no-decorate", "--no-color", remoteBranch());
 
     }
 
     public List<Modification> modificationsSince(Revision revision) {
-        return gitLog("--date=iso", "--pretty=medium", String.format("%s..%s", revision.getRevision(), remoteBranch()));
+        return gitLog("--date=iso", "--pretty=medium", "--no-decorate", "--no-color", String.format("%s..%s", revision.getRevision(), remoteBranch()));
     }
 
     private List<Modification> gitLog(String... args) {

--- a/domain/src/test/java/com/thoughtworks/go/domain/materials/git/GitTestRepo.java
+++ b/domain/src/test/java/com/thoughtworks/go/domain/materials/git/GitTestRepo.java
@@ -80,6 +80,20 @@ public class GitTestRepo extends TestRepo {
         tmpFolders.add(gitRepo);
     }
 
+    public void setColoring() {
+        createCommandLine("git").withEncoding("UTF-8").withWorkingDir(gitRepo).withArgs("config", "--global", "color.diff", "always").runOrBomb(true, "git_config");
+        createCommandLine("git").withEncoding("UTF-8").withWorkingDir(gitRepo).withArgs("config", "--global", "color.status", "always").runOrBomb(true, "git_config");
+        createCommandLine("git").withEncoding("UTF-8").withWorkingDir(gitRepo).withArgs("config", "--global", "color.interactive", "always").runOrBomb(true, "git_config");
+        createCommandLine("git").withEncoding("UTF-8").withWorkingDir(gitRepo).withArgs("config", "--global", "color.branch", "always").runOrBomb(true, "git_config");
+    }
+
+    public void unsetColoring() {
+        createCommandLine("git").withEncoding("UTF-8").withWorkingDir(gitRepo).withArgs("config", "--global", "color.diff", "auto").runOrBomb(true, "git_config");
+        createCommandLine("git").withEncoding("UTF-8").withWorkingDir(gitRepo).withArgs("config", "--global", "color.status", "auto").runOrBomb(true, "git_config");
+        createCommandLine("git").withEncoding("UTF-8").withWorkingDir(gitRepo).withArgs("config", "--global", "color.interactive", "auto").runOrBomb(true, "git_config");
+        createCommandLine("git").withEncoding("UTF-8").withWorkingDir(gitRepo).withArgs("config", "--global", "color.branch", "auto").runOrBomb(true, "git_config");
+    }
+
     public String projectRepositoryUrl() {
         return FileUtil.toFileURI(gitRepo);
     }

--- a/domain/src/test/java/com/thoughtworks/go/domain/materials/git/GitTestRepo.java
+++ b/domain/src/test/java/com/thoughtworks/go/domain/materials/git/GitTestRepo.java
@@ -80,20 +80,6 @@ public class GitTestRepo extends TestRepo {
         tmpFolders.add(gitRepo);
     }
 
-    public void setColoring() {
-        createCommandLine("git").withEncoding("UTF-8").withWorkingDir(gitRepo).withArgs("config", "--global", "color.diff", "always").runOrBomb(true, "git_config");
-        createCommandLine("git").withEncoding("UTF-8").withWorkingDir(gitRepo).withArgs("config", "--global", "color.status", "always").runOrBomb(true, "git_config");
-        createCommandLine("git").withEncoding("UTF-8").withWorkingDir(gitRepo).withArgs("config", "--global", "color.interactive", "always").runOrBomb(true, "git_config");
-        createCommandLine("git").withEncoding("UTF-8").withWorkingDir(gitRepo).withArgs("config", "--global", "color.branch", "always").runOrBomb(true, "git_config");
-    }
-
-    public void unsetColoring() {
-        createCommandLine("git").withEncoding("UTF-8").withWorkingDir(gitRepo).withArgs("config", "--global", "color.diff", "auto").runOrBomb(true, "git_config");
-        createCommandLine("git").withEncoding("UTF-8").withWorkingDir(gitRepo).withArgs("config", "--global", "color.status", "auto").runOrBomb(true, "git_config");
-        createCommandLine("git").withEncoding("UTF-8").withWorkingDir(gitRepo).withArgs("config", "--global", "color.interactive", "auto").runOrBomb(true, "git_config");
-        createCommandLine("git").withEncoding("UTF-8").withWorkingDir(gitRepo).withArgs("config", "--global", "color.branch", "auto").runOrBomb(true, "git_config");
-    }
-
     public String projectRepositoryUrl() {
         return FileUtil.toFileURI(gitRepo);
     }


### PR DESCRIPTION
* Fixes the issue raised in #326
* work is part of #5856

Text coloring throws off the `GitModificationParser`. This PR removes any coloring from the output of the git log command ensuring we are able to parse the modifications properly.

Steps to reproduce the bug:
1. add the following to your `.gitconfig`
```
[color]
  diff = always
  status = always
  interactive = always
  branch = always
```
2. Push a commit to a test repo
3. Attempt to run a pipeline with the test repo as a material

Result:
The modification check will fail, and the following will be in the logs:
```
2019-02-18 12:08:42,448 WARN  [130@MessageListener for MaterialUpdateListener] MaterialDatabaseUpdater:112 - [Material Update] Modification check failed for material: URL: git@github.com:ibnc/gogogadgetcd.git, Branch: master
java.util.NoSuchElementException: null
        at java.base/java.util.LinkedList.getLast(LinkedList.java:261)
        at com.thoughtworks.go.domain.materials.git.GitModificationParser.processLine(GitModificationParser.java:59)
        at com.thoughtworks.go.domain.materials.git.GitModificationParser.parse(GitModificationParser.java:43)
        at com.thoughtworks.go.domain.materials.git.GitCommand.gitLog(GitCommand.java:120)
        at com.thoughtworks.go.domain.materials.git.GitCommand.modificationsSince(GitCommand.java:101)
        at com.thoughtworks.go.config.materials.git.GitMaterial.modificationsSince(GitMaterial.java:126)
        at com.thoughtworks.go.server.service.materials.GitPoller.modificationsSince(GitPoller.java:37)
        at com.thoughtworks.go.server.service.materials.GitPoller.modificationsSince(GitPoller.java:28)
        at com.thoughtworks.go.server.service.MaterialService.modificationsSince(MaterialService.java:122)
        at com.thoughtworks.go.server.materials.ScmMaterialUpdater.insertLatestOrNewModifications(ScmMaterialUpdater.java:56)
        at com.thoughtworks.go.server.materials.MaterialDatabaseUpdater.insertLatestOrNewModifications(MaterialDatabaseUpdater.java:142)
        at com.thoughtworks.go.server.materials.MaterialDatabaseUpdater.updateMaterialWithNewRevisions(MaterialDatabaseUpdater.java:134)
        at com.thoughtworks.go.server.materials.MaterialDatabaseUpdater$2.doInTransaction(MaterialDatabaseUpdater.java:101)
        at com.thoughtworks.go.server.transaction.TransactionCallback.doWithExceptionHandling(TransactionCallback.java:24)
        at com.thoughtworks.go.server.transaction.TransactionTemplate.lambda$executeWithExceptionHandling$2(TransactionTemplate.java:44)
        at org.springframework.transaction.support.TransactionTemplate.execute(TransactionTemplate.java:133)
        at com.thoughtworks.go.server.transaction.TransactionTemplate.executeWithExceptionHandling(TransactionTemplate.java:41)
        at com.thoughtworks.go.server.materials.MaterialDatabaseUpdater.updateMaterial(MaterialDatabaseUpdater.java:98)
        at com.thoughtworks.go.server.materials.MaterialUpdateListener.onMessage(MaterialUpdateListener.java:64)
        at com.thoughtworks.go.server.materials.MaterialUpdateListener.onMessage(MaterialUpdateListener.java:33)
        at com.thoughtworks.go.server.messaging.activemq.JMSMessageListenerAdapter.runImpl(JMSMessageListenerAdapter.java:86)
        at com.thoughtworks.go.server.messaging.activemq.JMSMessageListenerAdapter.run(JMSMessageListenerAdapter.java:66)
        at java.base/java.lang.Thread.run(Thread.java:834)
```