### PR TITLE
Update token lastused time to DB on timer

### DIFF
--- a/server/src/main/java/com/thoughtworks/go/server/dao/AccessTokenDao.java
+++ b/server/src/main/java/com/thoughtworks/go/server/dao/AccessTokenDao.java
@@ -18,8 +18,10 @@ package com.thoughtworks.go.server.dao;
 
 import com.thoughtworks.go.domain.AccessToken;
 
+import java.sql.Timestamp;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 
 public interface AccessTokenDao {
     void saveOrUpdate(AccessToken accessToken);
@@ -35,4 +37,6 @@ public interface AccessTokenDao {
     AccessToken findAccessTokenBySaltId(String saltId);
 
     void revokeTokensBecauseOfUserDelete(Collection<String> usernames, String byWhom);
+
+    void updateLastUsedTime(Map<Long, Timestamp> accessTokenIdToLastUsedTimestamp);
 }

--- a/server/src/main/java/com/thoughtworks/go/server/newsecurity/filters/AccessTokenAuthenticationFilter.java
+++ b/server/src/main/java/com/thoughtworks/go/server/newsecurity/filters/AccessTokenAuthenticationFilter.java
@@ -68,7 +68,7 @@ public class AccessTokenAuthenticationFilter extends OncePerRequestFilter {
     @Override
     protected void doFilterInternal(HttpServletRequest request,
                                     HttpServletResponse response,
-                                    FilterChain filterChain) throws IOException, ServletException {
+                                    FilterChain filterChain) throws IOException {
         try {
             if (isPreviouslyAuthenticated(request)) {
                 LOGGER.debug("Request is already authenticated.");
@@ -93,7 +93,7 @@ public class AccessTokenAuthenticationFilter extends OncePerRequestFilter {
         }
     }
 
-    private AccessTokenCredential extractAuthTokenCredential(String authorizationHeader) throws Exception {
+    private AccessTokenCredential extractAuthTokenCredential(String authorizationHeader) {
         final Pattern BEARER_AUTH_EXTRACTOR_PATTERN = Pattern.compile("bearer (.*)", Pattern.CASE_INSENSITIVE);
 
         if (isBlank(authorizationHeader)) {
@@ -123,6 +123,7 @@ public class AccessTokenAuthenticationFilter extends OncePerRequestFilter {
             LOGGER.debug("Bearer auth credentials are not provided in request.");
             filterChain.doFilter(request, response);
         } else {
+            accessTokenService.updateLastUsedCacheWith(accessTokenCredential.getAccessToken());
             LOGGER.debug("authenticating user {} using bearer token", accessTokenCredential.getAccessToken().getUsername());
             try {
                 SecurityAuthConfig authConfig = securityAuthConfigService.findProfile(accessTokenCredential.getAccessToken().getAuthConfigId());

--- a/server/src/main/resources/cruise.properties
+++ b/server/src/main/resources/cruise.properties
@@ -32,6 +32,7 @@ go.config.repo.gc.check.delay=10000
 go.config.repo.gc.check.interval=28800000
 cruise.disk.space.check.interval=5000
 cruise.agent.service.refresh.interval=5000
+gocd.accesstoken.lastused.update.interval=60000
 
 cruise.i18n.cache.life=-1
 

--- a/server/src/test-fast/java/com/thoughtworks/go/server/newsecurity/filters/AccessTokenAuthenticationFilterTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/newsecurity/filters/AccessTokenAuthenticationFilterTest.java
@@ -96,6 +96,11 @@ public class AccessTokenAuthenticationFilterTest {
             when(securityService.isSecurityEnabled()).thenReturn(false);
         }
 
+        @AfterEach
+        void tearDown() {
+            verify(accessTokenService, never()).updateLastUsedCacheWith(any());
+        }
+
         @Test
         void shouldAllowAccessWhenCredentialsAreNotProvided() throws ServletException, IOException {
             request = HttpRequestBuilder.GET("/").build();
@@ -145,6 +150,7 @@ public class AccessTokenAuthenticationFilterTest {
             filter.doFilter(request, response, filterChain);
 
             verify(filterChain).doFilter(request, response);
+            verifyZeroInteractions(accessTokenService);
             assertThat(request.getSession(false)).isSameAs(originalSession);
             assertThat(SessionUtils.getAuthenticationToken(request)).isNull();
             assertThat(response.getStatus()).isEqualTo(200);
@@ -163,6 +169,7 @@ public class AccessTokenAuthenticationFilterTest {
             filter.doFilter(request, response, filterChain);
 
             verifyZeroInteractions(filterChain);
+            verify(accessTokenService, never()).updateLastUsedCacheWith(any());
             assertThat(request.getSession(false)).isSameAs(originalSession);
             assertThat(SessionUtils.getAuthenticationToken(request)).isNull();
             assertThat(response.getStatus()).isEqualTo(401);
@@ -183,6 +190,7 @@ public class AccessTokenAuthenticationFilterTest {
             filter.doFilter(request, response, filterChain);
 
             verify(filterChain).doFilter(request, response);
+            verify(accessTokenService).updateLastUsedCacheWith(accessToken);
             assertThat(request.getSession(false)).isNotSameAs(originalSession);
             assertThat(SessionUtils.getAuthenticationToken(request)).isEqualTo(authenticationToken);
             assertThat(response.getStatus()).isEqualTo(200);
@@ -203,6 +211,7 @@ public class AccessTokenAuthenticationFilterTest {
             assertThat(request.getSession(false)).isSameAs(originalSession);
 
             verify(authenticationProvider, never()).authenticate(any(), anyString());
+            verifyZeroInteractions(accessTokenService);
             assertThat(response.getStatus()).isEqualTo(200);
         }
     }

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/AccessTokenServiceIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/AccessTokenServiceIntegrationTest.java
@@ -67,7 +67,7 @@ public class AccessTokenServiceIntegrationTest {
     }
 
     @Test
-    public void shouldCreateAnAccessToken() throws Exception {
+    public void shouldCreateAnAccessToken() {
         String tokenDescription = "This is my first token";
 
         AccessToken.AccessTokenWithDisplayValue createdToken = accessTokenService.create(tokenDescription, "bob", authConfigId);
@@ -89,7 +89,7 @@ public class AccessTokenServiceIntegrationTest {
     }
 
     @Test
-    public void shouldGetAccessTokenProvidedTokenValue() throws Exception {
+    public void shouldGetAccessTokenProvidedTokenValue() {
         String tokenDescription = "This is my first Token";
 
         AccessToken.AccessTokenWithDisplayValue createdToken = accessTokenService.create(tokenDescription, "bob", authConfigId);
@@ -114,7 +114,7 @@ public class AccessTokenServiceIntegrationTest {
     }
 
     @Test
-    public void shouldFailToGetAccessTokenWhenProvidedTokenHashEqualityFails() throws Exception {
+    public void shouldFailToGetAccessTokenWhenProvidedTokenHashEqualityFails() {
         long id = 42;
         String tokenDescription = "This is my first Token";
 
@@ -128,7 +128,7 @@ public class AccessTokenServiceIntegrationTest {
     }
 
     @Test
-    public void shouldNotGetAccessTokenProvidedTokenValueWhenTokenIsRevoked() throws Exception {
+    public void shouldNotGetAccessTokenProvidedTokenValueWhenTokenIsRevoked() {
         long id = 42;
         String tokenDescription = "This is my first Token";
 
@@ -141,7 +141,7 @@ public class AccessTokenServiceIntegrationTest {
     }
 
     @Test
-    public void shouldRevokeAnAccessToken() throws Exception {
+    public void shouldRevokeAnAccessToken() {
         String tokenDescription = "This is my first Token";
         AccessToken createdToken = accessTokenService.create(tokenDescription, "BOB", authConfigId);
 
@@ -156,7 +156,7 @@ public class AccessTokenServiceIntegrationTest {
     }
 
     @Test
-    public void shouldFailToRevokeAnAlreadyRevokedAccessToken() throws Exception {
+    public void shouldFailToRevokeAnAlreadyRevokedAccessToken() {
         String tokenDescription = "This is my first Token";
         AccessToken createdToken = accessTokenService.create(tokenDescription, "BOB", authConfigId);
 
@@ -179,5 +179,19 @@ public class AccessTokenServiceIntegrationTest {
         assertThatCode(() -> accessTokenService.revokeAccessToken(id, "bOb", null))
                 .isInstanceOf(RecordNotFoundException.class)
                 .hasMessage("Cannot locate access token with id 42.");
+    }
+
+    @Test
+    public void shouldUpdateLastUsedTimeToDB() {
+        AccessToken createdToken = accessTokenService.create("This is my first Token", "BOB", authConfigId);
+        final AccessToken fetchedFromDB = accessTokenService.find(createdToken.getId(), createdToken.getUsername());
+        assertThat(fetchedFromDB.getLastUsed()).isNull();
+
+        accessTokenService.updateLastUsedCacheWith(createdToken);
+        accessTokenService.onTimer();
+
+        final AccessToken accessToken = accessTokenService.find(createdToken.getId(), createdToken.getUsername());
+
+        assertThat(accessToken.getLastUsed()).isNotNull();
     }
 }

--- a/server/src/test-shared/resources/test.properties
+++ b/server/src/test-shared/resources/test.properties
@@ -28,6 +28,7 @@ cruise.build.assignment.service.interval=5000
 cruise.config.refresh.interval=5000
 cruise.disk.space.check.interval=5000
 cruise.agent.service.refresh.interval=5000
+gocd.accesstoken.lastused.update.interval=60000
 
 cruise.i18n.cache.life=-1
 

--- a/server/webapp/WEB-INF/spring-cruise-remoting-servlet.xml
+++ b/server/webapp/WEB-INF/spring-cruise-remoting-servlet.xml
@@ -71,7 +71,7 @@
                     fixed-delay="10000"/>
     <task:scheduled ref="accessTokenService" method="onTimer"
                     initial-delay="10000"
-                    fixed-delay="60000"/>
+                    fixed-delay="${gocd.accesstoken.lastused.update.interval}"/>
   </task:scheduled-tasks>
 
   <bean name="/remoteBuildRepository" class="org.springframework.remoting.httpinvoker.HttpInvokerServiceExporter"

--- a/server/webapp/WEB-INF/spring-cruise-remoting-servlet.xml
+++ b/server/webapp/WEB-INF/spring-cruise-remoting-servlet.xml
@@ -68,7 +68,10 @@
                     initial-delay="10000"
                     fixed-delay="${cruise.agent.service.refresh.interval}"/>
     <task:scheduled ref="socketHealthService" method="keepalive"
-                    fixed-delay="10000" />
+                    fixed-delay="10000"/>
+    <task:scheduled ref="accessTokenService" method="onTimer"
+                    initial-delay="10000"
+                    fixed-delay="60000"/>
   </task:scheduled-tasks>
 
   <bean name="/remoteBuildRepository" class="org.springframework.remoting.httpinvoker.HttpInvokerServiceExporter"


### PR DESCRIPTION
- This is to update last-used time for the token in DB. Every minute it will dump the local cache to DB when security is enabled. In case of security is not configured for the GoCD server timer will do nothing.

link to issue: #5824 