### PR TITLE
Show maintenance mode updated by timestamp along with date (#5786)

### DIFF
--- a/server/webapp/WEB-INF/rails/webpack/models/maintenance_mode/types.ts
+++ b/server/webapp/WEB-INF/rails/webpack/models/maintenance_mode/types.ts
@@ -206,11 +206,11 @@ export class RunningSystem {
 
 export class MaintenanceModeMetadata {
   updatedBy: string;
-  updatedOn: Date;
+  updatedOn: string;
 
   constructor(updatedBy: string, updatedOn: string) {
     this.updatedBy = updatedBy;
-    this.updatedOn = TimeFormatter.formatInDate(updatedOn);
+    this.updatedOn = TimeFormatter.format(updatedOn);
   }
 
   static fromJSON(json: MaintenanceModeMetadataJSON) {

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/maintenance_mode/spec/maintenance_mode_widget_spec.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/maintenance_mode/spec/maintenance_mode_widget_spec.tsx
@@ -24,6 +24,8 @@ describe("Maintenance Mode Widget", () => {
   const toggleMaintenanceMode = jasmine.createSpy("onToggle");
   const onCancelStage         = jasmine.createSpy("onCancelStage");
 
+  const TimeFormatter = require("helpers/time_formatter");
+
   beforeEach(() => {
     // @ts-ignore
     [$root, root] = window.createDomElementForTest();
@@ -48,7 +50,8 @@ describe("Maintenance Mode Widget", () => {
   });
 
   it("should provide the maintenance mode updated information", () => {
-    const expectedUpdatedByInfo = `${TestData.info().metdata.updatedBy} changed the maintenance mode state on ${TestData.info().metdata.updatedOn}.`;
+    const updatedOn             = TimeFormatter.format(TestData.UPDATED_ON);
+    const expectedUpdatedByInfo = `${TestData.info().metdata.updatedBy} changed the maintenance mode state on ${updatedOn}.`;
     expect(find("maintenance-mode-updated-by-info")).toContainText(expectedUpdatedByInfo);
   });
 

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/maintenance_mode/spec/test_data.ts
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/maintenance_mode/spec/test_data.ts
@@ -17,6 +17,8 @@
 import {MaintenanceModeInfo, MaintenanceModeInfoJSON} from "models/maintenance_mode/types";
 
 export class TestData {
+  static UPDATED_ON = "2018-12-10T04:19:31Z";
+
   static info(hasRunningSystems: boolean = true) {
     return MaintenanceModeInfo.fromJSON(this.infoJSON(hasRunningSystems) as MaintenanceModeInfoJSON);
   }
@@ -30,7 +32,7 @@ export class TestData {
       is_maintenance_mode: true,
       metadata: {
         updated_by: "Admin",
-        updated_on: "2018-12-10T04:19:31Z"
+        updated_on: this.UPDATED_ON
       },
       attributes: {
         has_running_systems: true,
@@ -47,7 +49,7 @@ export class TestData {
       is_maintenance_mode: hasRunningSystems,
       metadata: {
         updated_by: "Admin",
-        updated_on: "2018-12-10T04:19:31Z"
+        updated_on: this.UPDATED_ON
       },
       attributes: {
         has_running_systems: true,


### PR DESCRIPTION
#### Before
![screen shot 2019-02-19 at 11 58 19 am](https://user-images.githubusercontent.com/15275847/52995176-da34fb00-343f-11e9-9f5d-8c6f11546a37.png)


#### After
![screen shot 2019-02-19 at 12 04 56 pm](https://user-images.githubusercontent.com/15275847/52995179-dc975500-343f-11e9-995f-9d5141f550fe.png)
