### PR TITLE
Added toggle for personal access token SPA.

### DIFF
--- a/api/api-base/src/main/java/com/thoughtworks/go/api/spring/ApiAuthenticationHelper.java
+++ b/api/api-base/src/main/java/com/thoughtworks/go/api/spring/ApiAuthenticationHelper.java
@@ -40,6 +40,12 @@ public class ApiAuthenticationHelper extends AbstractAuthenticationHelper {
         return HaltApiResponses.haltBecauseForbidden();
     }
 
+    @Override
+    protected HaltException renderNotFoundResponse() {
+        LOG.info("User {} attempted to access a non-existent resource!", currentUserLoginName());
+        return HaltApiResponses.haltBecauseNotFound();
+    }
+
     public void ensureSecurityEnabled(Request request, Response response) {
         if (!securityService.isSecurityEnabled()) {
             throw HaltApiResponses.haltBecauseSecurityIsNotEnabled();

--- a/server/src/main/java/com/thoughtworks/go/server/service/support/toggle/Toggles.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/support/toggle/Toggles.java
@@ -23,6 +23,7 @@ public class Toggles {
     public static String USE_OLD_ARTIFACT_STORES_SPA = "use_old_artifact_stores_spa";
     public static String USE_OLD_ROLES_SPA = "use_old_roles_spa";
     public static String USE_OLD_ENVIRONMENTS_API = "use_old_environments_api";
+    public static String ENABLE_ACCESS_TOKENS_SPA = "enable_access_tokens_spa";
 
 
     private static FeatureToggleService service;

--- a/server/src/main/java/com/thoughtworks/go/server/web/GoVelocityView.java
+++ b/server/src/main/java/com/thoughtworks/go/server/web/GoVelocityView.java
@@ -125,6 +125,7 @@ public class GoVelocityView extends VelocityToolboxView {
         velocityContext.put(SHOW_ANALYTICS_DASHBOARD, (securityService.isUserAdmin(username) && supportsAnalyticsDashboard()));
         velocityContext.put(WEBPACK_ASSETS_SERVICE, webpackAssetsService());
         velocityContext.put(MAINTENANCE_MODE_SERVICE, getMaintenanceModeService());
+        velocityContext.put(Toggles.ENABLE_ACCESS_TOKENS_SPA, Toggles.isToggleOn(Toggles.ENABLE_ACCESS_TOKENS_SPA));
         if (!SessionUtils.hasAuthenticationToken(request)) {
             return;
         }

--- a/server/src/main/resources/available.toggles
+++ b/server/src/main/resources/available.toggles
@@ -35,6 +35,11 @@
         "key": "use_old_environments_api",
         "description": "Switch to using rails environments API.",
         "value": false
+      },
+      {
+        "key": "enable_access_tokens_spa",
+        "description": "Show personal access tokens SPA. Default: false",
+        "value": false
       }
   ]
 }

--- a/server/webapp/WEB-INF/rails/app/helpers/application_helper.rb
+++ b/server/webapp/WEB-INF/rails/app/helpers/application_helper.rb
@@ -493,6 +493,10 @@ module ApplicationHelper
     maintenance_mode_service.isMaintenanceMode
   end
 
+  def enable_access_tokens_spa?
+    Toggles.isToggleOn(Toggles.ENABLE_ACCESS_TOKENS_SPA)
+  end
+
   def edit_path_for_pipeline(pipeline_name)
     pipeline_edit_path(:pipeline_name => pipeline_name, :current_tab => 'general')
   end

--- a/server/webapp/WEB-INF/rails/app/views/shared/_body_data_attrs.html.erb
+++ b/server/webapp/WEB-INF/rails/app/views/shared/_body_data_attrs.html.erb
@@ -6,3 +6,4 @@ data-show-analytics-dashboard="<%= is_user_an_admin? && supports_analytics_dashb
 data-user-display-name="<%= current_user.display_name %>"
 data-user-anonymous="<%= current_user.anonymous %>"
 data-is-server-in-maintenance-mode="<%= is_server_in_maintenance_mode? %>"
+data-enable-personal-access-token-spa="<%= enable_access_tokens_spa? %>"

--- a/server/webapp/WEB-INF/rails/webpack/helpers/spa_base.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/helpers/spa_base.tsx
@@ -69,14 +69,15 @@ export default abstract class Page {
 
       const body: Element = document.querySelector("body") as Element;
 
-      const showAnalyticsDashboard    = this.extractBoolean(body, "data-show-analytics-dashboard");
-      const canViewAdminPage          = this.extractBoolean(body, "data-can-user-view-admin");
-      const isUserAdmin               = this.extractBoolean(body, "data-is-user-admin");
-      const isGroupAdmin              = this.extractBoolean(body, "data-is-user-group-admin");
-      const canViewTemplates          = this.extractBoolean(body, "data-can-user-view-templates");
-      const isAnonymous               = this.extractBoolean(body, "data-user-anonymous");
-      const isServerInMaintenanceMode = this.extractBoolean(body, "data-is-server-in-maintenance-mode");
-      const userDisplayName           = body.getAttribute("data-user-display-name") || "";
+      const showAnalyticsDashboard       = this.extractBoolean(body, "data-show-analytics-dashboard");
+      const canViewAdminPage             = this.extractBoolean(body, "data-can-user-view-admin");
+      const isUserAdmin                  = this.extractBoolean(body, "data-is-user-admin");
+      const isGroupAdmin                 = this.extractBoolean(body, "data-is-user-group-admin");
+      const canViewTemplates             = this.extractBoolean(body, "data-can-user-view-templates");
+      const isAnonymous                  = this.extractBoolean(body, "data-user-anonymous");
+      const isServerInMaintenanceMode    = this.extractBoolean(body, "data-is-server-in-maintenance-mode");
+      const enablePersonalAccessTokenSPA = this.extractBoolean(body, "data-enable-personal-access-token-spa");
+      const userDisplayName              = body.getAttribute("data-user-display-name") || "";
 
       const footerData = {
         isServerInMaintenanceMode,
@@ -90,7 +91,8 @@ export default abstract class Page {
         isGroupAdmin,
         canViewTemplates,
         userDisplayName,
-        isAnonymous
+        isAnonymous,
+        enablePersonalAccessTokenSPA
       };
 
       m.mount(body, {

--- a/server/webapp/WEB-INF/rails/webpack/single_page_apps/header_footer_shim.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/single_page_apps/header_footer_shim.tsx
@@ -37,14 +37,15 @@ $(() => {
       return JSON.parse(body.getAttribute(attribute) as string);
     }
 
-    const showAnalyticsDashboard    = extractBoolean(body, "data-show-analytics-dashboard");
-    const canViewAdminPage          = extractBoolean(body, "data-can-user-view-admin");
-    const isUserAdmin               = extractBoolean(body, "data-is-user-admin");
-    const isGroupAdmin              = extractBoolean(body, "data-is-user-group-admin");
-    const canViewTemplates          = extractBoolean(body, "data-can-user-view-templates");
-    const isAnonymous               = extractBoolean(body, "data-user-anonymous");
-    const isServerInMaintenanceMode = extractBoolean(body, "data-is-server-in-maintenance-mode");
-    const userDisplayName           = body.getAttribute("data-user-display-name") || "";
+    const showAnalyticsDashboard       = extractBoolean(body, "data-show-analytics-dashboard");
+    const canViewAdminPage             = extractBoolean(body, "data-can-user-view-admin");
+    const isUserAdmin                  = extractBoolean(body, "data-is-user-admin");
+    const isGroupAdmin                 = extractBoolean(body, "data-is-user-group-admin");
+    const canViewTemplates             = extractBoolean(body, "data-can-user-view-templates");
+    const isAnonymous                  = extractBoolean(body, "data-user-anonymous");
+    const isServerInMaintenanceMode    = extractBoolean(body, "data-is-server-in-maintenance-mode");
+    const userDisplayName              = body.getAttribute("data-user-display-name") || "";
+    const enablePersonalAccessTokenSPA = extractBoolean(body, "data-enable-personal-access-token-spa");
 
     const footerData = {
       isServerInMaintenanceMode,
@@ -58,7 +59,8 @@ $(() => {
       isGroupAdmin,
       canViewTemplates,
       userDisplayName,
-      isAnonymous
+      isAnonymous,
+      enablePersonalAccessTokenSPA
     } as Attrs;
 
     const menuMountPoint = document.querySelector("#app-menu");

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/partials/site_header.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/partials/site_header.tsx
@@ -32,21 +32,27 @@ export interface Attrs {
   isUserAdmin: boolean;
   canViewAdminPage: boolean;
   showAnalyticsDashboard: boolean;
+  enablePersonalAccessTokenSPA: boolean;
 }
 
 export class SiteHeader extends MithrilViewComponent<Attrs> {
   view(vnode: m.Vnode<Attrs>) {
-    const showAnalyticsDashboard = vnode.attrs.showAnalyticsDashboard;
-    const canViewAdminPage       = vnode.attrs.canViewAdminPage;
-    const isUserAdmin            = vnode.attrs.isUserAdmin;
-    const isGroupAdmin           = vnode.attrs.isGroupAdmin;
-    const canViewTemplates       = vnode.attrs.canViewTemplates;
-    const userDisplayName        = vnode.attrs.userDisplayName;
-    const isAnonymous            = vnode.attrs.isAnonymous;
+    const showAnalyticsDashboard       = vnode.attrs.showAnalyticsDashboard;
+    const canViewAdminPage             = vnode.attrs.canViewAdminPage;
+    const isUserAdmin                  = vnode.attrs.isUserAdmin;
+    const isGroupAdmin                 = vnode.attrs.isGroupAdmin;
+    const canViewTemplates             = vnode.attrs.canViewTemplates;
+    const userDisplayName              = vnode.attrs.userDisplayName;
+    const isAnonymous                  = vnode.attrs.isAnonymous;
+    const enablePersonalAccessTokenSPA = vnode.attrs.enablePersonalAccessTokenSPA;
 
     let userMenu: m.Children = null;
 
     if (!isAnonymous) {
+      let personalAccessTokenItem;
+      if (enablePersonalAccessTokenSPA) {
+        personalAccessTokenItem = <SiteSubNavItem href="/go/access_tokens" text="Personal Access Tokens"/>;
+      }
       userMenu = (
         <div data-test-id="user-menu" class={classnames(styles.user, styles.isDropDown)}>
           <a data-test-id="username" href="#" class={styles.userLink}>
@@ -57,7 +63,7 @@ export class SiteHeader extends MithrilViewComponent<Attrs> {
 
           <ul class={styles.userSubnav}>
             <SiteSubNavItem href="/go/preferences/notifications" text="Preferences"/>
-            <SiteSubNavItem href="/go/access_tokens" text="Personal Access Tokens"/>
+            {personalAccessTokenItem}
             <SiteSubNavItem href="/go/auth/logout" text="Sign out"/>
           </ul>
         </div>

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/partials/spec/site_header_spec.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/partials/spec/site_header_spec.tsx
@@ -18,8 +18,7 @@ import * as m from "mithril";
 import {Attrs, SiteHeader} from "views/pages/partials/site_header";
 import * as styles from "../site_header.scss";
 
-//currently disabled because background Ajax requests aren't getting mocked
-xdescribe("Site Header", () => {
+describe("SiteHeader", () => {
 
   let $root: any, root: any;
   beforeEach(() => {
@@ -39,14 +38,15 @@ xdescribe("Site Header", () => {
 
   it("should display the user menu when a user is logged in", () => {
     mount({
-      isAnonymous: false,
-      userDisplayName: "Jon Doe",
-      canViewTemplates: false,
-      isGroupAdmin: false,
-      isUserAdmin: false,
-      canViewAdminPage: false,
-      showAnalyticsDashboard: false
-    });
+            isAnonymous: false,
+            userDisplayName: "Jon Doe",
+            canViewTemplates: false,
+            isGroupAdmin: false,
+            isUserAdmin: false,
+            canViewAdminPage: false,
+            showAnalyticsDashboard: false,
+            enablePersonalAccessTokenSPA: true
+          });
     expect($root.find(`.${styles.userLink}`)).toHaveText("Jon Doe");
     expect(findMenuItem("/go/preferences/notifications")).toHaveText("Preferences");
     expect(findMenuItem("/go/access_tokens")).toHaveText("Personal Access Tokens");
@@ -56,19 +56,53 @@ xdescribe("Site Header", () => {
 
   it("should not display the user menu when logged in as anonymous", () => {
     mount({
-      isAnonymous: true,
-      userDisplayName: "",
-      canViewTemplates: false,
-      isGroupAdmin: false,
-      isUserAdmin: false,
-      canViewAdminPage: false,
-      showAnalyticsDashboard: false
-    });
+            isAnonymous: true,
+            userDisplayName: "",
+            canViewTemplates: false,
+            isGroupAdmin: false,
+            isUserAdmin: false,
+            canViewAdminPage: false,
+            showAnalyticsDashboard: false,
+            enablePersonalAccessTokenSPA: true
+          });
     expect($root.find(`.${styles.userLink}`)).not.toBeInDOM();
     expect(findMenuItem("/go/preferences/notifications")).not.toBeInDOM();
     expect(findMenuItem("/go/access_tokens")).not.toBeInDOM();
     expect(findMenuItem("/go/auth/logout")).not.toBeInDOM();
     expect(findMenuItem("https://gocd.org/help")).toHaveText("Need Help?");
+  });
+
+  describe("AccessTokenMenu", () => {
+
+    it("should display the menu item when toggle is on", () => {
+      mount({
+              isAnonymous: false,
+              userDisplayName: "Jon Doe",
+              canViewTemplates: false,
+              isGroupAdmin: false,
+              isUserAdmin: false,
+              canViewAdminPage: false,
+              showAnalyticsDashboard: false,
+              enablePersonalAccessTokenSPA: true
+            } as Attrs);
+      expect(findMenuItem("/go/access_tokens")).toBeInDOM();
+      expect(findMenuItem("/go/access_tokens")).toHaveText("Personal Access Tokens");
+    });
+
+    it("should not display the menu item when toggle is off", () => {
+      mount({
+              isAnonymous: false,
+              userDisplayName: "Jon Doe",
+              canViewTemplates: false,
+              isGroupAdmin: false,
+              isUserAdmin: false,
+              canViewAdminPage: false,
+              showAnalyticsDashboard: false,
+              enablePersonalAccessTokenSPA: false
+            } as Attrs);
+
+      expect(findMenuItem("/go/access_tokens")).not.toBeInDOM();
+    });
   });
 
   function mount(attrs: Attrs) {

--- a/server/webapp/WEB-INF/vm/shared/_header.vm
+++ b/server/webapp/WEB-INF/vm/shared/_header.vm
@@ -63,7 +63,8 @@
       data-show-analytics-dashboard="$showAnalyticsDashboard"
       data-user-display-name="$principal"
       data-user-anonymous="$isAnonymousUser"
-      data-is-server-in-maintenance-mode="${maintenanceModeService.isMaintenanceMode()}">
+      data-is-server-in-maintenance-mode="${maintenanceModeService.isMaintenanceMode()}"
+      data-enable-personal-access-token-spa="$enable_access_tokens_spa">
 <div class="page-wrap">
   <div id="body_bg">
     <div id="body_bg_highlight">

--- a/spark/spark-base/src/main/java/com/thoughtworks/go/spark/spring/AbstractAuthenticationHelper.java
+++ b/spark/spark-base/src/main/java/com/thoughtworks/go/spark/spring/AbstractAuthenticationHelper.java
@@ -204,4 +204,5 @@ public abstract class AbstractAuthenticationHelper {
         return securityService.isSecurityEnabled();
     }
 
+    protected abstract HaltException renderNotFoundResponse();
 }

--- a/spark/spark-base/src/main/java/com/thoughtworks/go/spark/spring/SPAAuthenticationHelper.java
+++ b/spark/spark-base/src/main/java/com/thoughtworks/go/spark/spring/SPAAuthenticationHelper.java
@@ -23,8 +23,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import spark.HaltException;
 
-import java.io.IOException;
-
 import static spark.Spark.halt;
 
 @Component
@@ -39,6 +37,11 @@ public class SPAAuthenticationHelper extends AbstractAuthenticationHelper {
     @Override
     protected HaltException renderForbiddenResponse() {
         return halt(403, HtmlErrorPage.errorPage(403, "Forbidden"));
+    }
+
+    @Override
+    public HaltException renderNotFoundResponse() {
+        return halt(404, HtmlErrorPage.errorPage(404, "Not Found"));
     }
 
 }

--- a/spark/spark-spa/src/main/java/com/thoughtworks/go/spark/spa/AccessTokensController.java
+++ b/spark/spark-spa/src/main/java/com/thoughtworks/go/spark/spa/AccessTokensController.java
@@ -1,20 +1,23 @@
 /*
-* Copyright 2019 ThoughtWorks, Inc.
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package com.thoughtworks.go.spark.spa;
+
+import com.thoughtworks.go.server.service.support.toggle.FeatureToggleService;
+import com.thoughtworks.go.server.service.support.toggle.Toggles;
 import com.thoughtworks.go.spark.Routes;
 import com.thoughtworks.go.spark.SparkController;
 import com.thoughtworks.go.spark.spring.SPAAuthenticationHelper;
@@ -22,34 +25,47 @@ import spark.ModelAndView;
 import spark.Request;
 import spark.Response;
 import spark.TemplateEngine;
+
 import java.util.HashMap;
 import java.util.Map;
+
 import static spark.Spark.*;
 
 public class AccessTokensController implements SparkController {
-  private final SPAAuthenticationHelper authenticationHelper;
-  private final TemplateEngine engine;
-  public AccessTokensController(SPAAuthenticationHelper authenticationHelper, TemplateEngine engine) {
-    this.authenticationHelper = authenticationHelper;
-    this.engine = engine;
-  }
+    private final SPAAuthenticationHelper authenticationHelper;
+    private final FeatureToggleService featureToggleService;
+    private final TemplateEngine engine;
 
-  @Override
-  public String controllerBasePath() {
+    public AccessTokensController(SPAAuthenticationHelper authenticationHelper, FeatureToggleService featureToggleService, TemplateEngine engine) {
+        this.authenticationHelper = authenticationHelper;
+        this.featureToggleService = featureToggleService;
+        this.engine = engine;
+    }
+
+    @Override
+    public String controllerBasePath() {
         return Routes.AccessTokens.SPA_BASE;
-  }
+    }
 
-  @Override
-  public void setupRoutes() {
-     path(controllerBasePath(), () -> {
-        before("", authenticationHelper::checkUserAnd403);
-        get("", this::index, engine);
-    });
-  }
-  public ModelAndView index(Request request, Response response) {
-      Map<Object, Object> object = new HashMap<Object, Object>() {{
-          put("viewTitle", "Access Tokens");
-      }};
-      return new ModelAndView(object, null);
-  }
+    @Override
+    public void setupRoutes() {
+        path(controllerBasePath(), () -> {
+            before("", authenticationHelper::checkUserAnd403);
+            before("", this::showWhenEnabled);
+            get("", this::index, engine);
+        });
+    }
+
+    private void showWhenEnabled(Request request, Response response) {
+        if (!featureToggleService.isToggleOn(Toggles.ENABLE_ACCESS_TOKENS_SPA)) {
+            throw authenticationHelper.renderNotFoundResponse();
+        }
+    }
+
+    public ModelAndView index(Request request, Response response) {
+        Map<Object, Object> object = new HashMap<Object, Object>() {{
+            put("viewTitle", "Access Tokens");
+        }};
+        return new ModelAndView(object, null);
+    }
 }

--- a/spark/spark-spa/src/main/java/com/thoughtworks/go/spark/spa/spring/InitialContextProvider.java
+++ b/spark/spark-spa/src/main/java/com/thoughtworks/go/spark/spa/spring/InitialContextProvider.java
@@ -76,6 +76,7 @@ public class InitialContextProvider {
         context.put("spaTimeout", SystemEnvironment.goSpaTimeout());
         context.put("showAnalyticsDashboard", showAnalyticsDashboard());
         context.put("devMode", !new SystemEnvironment().useCompressedJs());
+        context.put(Toggles.ENABLE_ACCESS_TOKENS_SPA, Toggles.isToggleOn(Toggles.ENABLE_ACCESS_TOKENS_SPA));
         return new VelocityContext(context);
     }
 

--- a/spark/spark-spa/src/main/java/com/thoughtworks/go/spark/spa/spring/SpaControllers.java
+++ b/spark/spark-spa/src/main/java/com/thoughtworks/go/spark/spa/spring/SpaControllers.java
@@ -48,7 +48,8 @@ public class SpaControllers implements SparkSpringController {
         LayoutTemplateProvider defaultTemplate = () -> DEFAULT_LAYOUT_PATH;
         LayoutTemplateProvider componentTemplate = () -> COMPONENT_LAYOUT_PATH;
 
-        sparkControllers.add(new AccessTokensController(authenticationHelper, templateEngineFactory.create(AccessTokensController.class, () -> COMPONENT_LAYOUT_PATH)));
+
+        sparkControllers.add(new AccessTokensController(authenticationHelper, featureToggleService, templateEngineFactory.create(AccessTokensController.class, () -> COMPONENT_LAYOUT_PATH)));
         sparkControllers.add(new ArtifactStoresController(authenticationHelper, templateEngineFactory.create(ArtifactStoresController.class, () -> featureToggleService.isToggleOn(Toggles.USE_OLD_ARTIFACT_STORES_SPA) ? DEFAULT_LAYOUT_PATH : COMPONENT_LAYOUT_PATH)));
         sparkControllers.add(new AuthConfigsController(authenticationHelper, templateEngineFactory.create(AuthConfigsController.class, () -> featureToggleService.isToggleOn(Toggles.USE_OLD_AUTH_CONFIG_SPA) ? DEFAULT_LAYOUT_PATH : COMPONENT_LAYOUT_PATH)));
         sparkControllers.add(new UsersController(authenticationHelper, templateEngineFactory.create(UsersController.class, () -> COMPONENT_LAYOUT_PATH)));

--- a/spark/spark-spa/src/main/resources/velocity/layouts/component_layout.vm
+++ b/spark/spark-spa/src/main/resources/velocity/layouts/component_layout.vm
@@ -48,6 +48,7 @@
       data-user-anonymous="${currentUser.anonymous}"
       data-is-server-in-maintenance-mode="${maintenanceModeService.isMaintenanceMode()}"
       data-meta="${meta}"
+      data-enable-personal-access-token-spa="$enable_access_tokens_spa"
       >
 
     #if(${devMode})

--- a/spark/spark-spa/src/main/resources/velocity/layouts/single_page_app.vm
+++ b/spark/spark-spa/src/main/resources/velocity/layouts/single_page_app.vm
@@ -51,7 +51,8 @@
       data-show-analytics-dashboard="${showAnalyticsDashboard}"
       data-user-display-name="${currentUser.displayName}"
       data-user-anonymous="${currentUser.anonymous}"
-      data-is-server-in-maintenance-mode="${maintenanceModeService.isMaintenanceMode()}">
+      data-is-server-in-maintenance-mode="${maintenanceModeService.isMaintenanceMode()}"
+      data-enable-personal-access-token-spa="$enable_access_tokens_spa">
 <div class="page-wrap">
   <header id="app-menu">
   </header>

--- a/spark/spark-spa/src/test/groovy/com/thoughtworks/go/spark/spa/AccessTokensControllerTest.groovy
+++ b/spark/spark-spa/src/test/groovy/com/thoughtworks/go/spark/spa/AccessTokensControllerTest.groovy
@@ -16,7 +16,9 @@
 
 package com.thoughtworks.go.spark.spa
 
-import com.thoughtworks.go.spark.AdminUserSecurity
+
+import com.thoughtworks.go.server.service.support.toggle.FeatureToggleService
+import com.thoughtworks.go.server.service.support.toggle.Toggles
 import com.thoughtworks.go.spark.ControllerTrait
 import com.thoughtworks.go.spark.NormalUserSecurity
 import com.thoughtworks.go.spark.SecurityServiceTrait
@@ -24,13 +26,16 @@ import com.thoughtworks.go.spark.spring.SPAAuthenticationHelper
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 
+import static org.mockito.Mockito.mock
+import static org.mockito.Mockito.when
 import static org.mockito.MockitoAnnotations.initMocks
 
 class AccessTokensControllerTest implements ControllerTrait<AccessTokensController>, SecurityServiceTrait {
+  FeatureToggleService featureToggleService
 
   @Override
   AccessTokensController createControllerInstance() {
-    return new AccessTokensController(new SPAAuthenticationHelper(securityService, goConfigService), templateEngine)
+    return new AccessTokensController(new SPAAuthenticationHelper(securityService, goConfigService), featureToggleService, templateEngine)
   }
 
   @Nested
@@ -45,6 +50,7 @@ class AccessTokensControllerTest implements ControllerTrait<AccessTokensControll
 
       @Override
       void makeHttpCall() {
+        when(featureToggleService.isToggleOn(Toggles.ENABLE_ACCESS_TOKENS_SPA)).thenReturn(true);
         get(controller.controllerPath())
       }
     }
@@ -52,6 +58,7 @@ class AccessTokensControllerTest implements ControllerTrait<AccessTokensControll
 
   @BeforeEach
   void setUp() {
+    featureToggleService = mock(FeatureToggleService.class)
     initMocks(this)
   }
 }


### PR DESCRIPTION
The default value is false. To enable personal access token SPA use:

``` bash
curl http://localhost:8153/go/api/admin/feature_toggles/enable_access_tokens_spa -d toggle_value=on -H 'Confirm:true' -u admin:badger
```