### PR TITLE
Render job console log containing new line characters in executable task (#5037)

### DIFF
--- a/server/webapp/WEB-INF/rails/spec/javascripts/log_output_transformer_spec.js
+++ b/server/webapp/WEB-INF/rails/spec/javascripts/log_output_transformer_spec.js
@@ -86,6 +86,23 @@
 
         assertFalse(fixture.find(".console-log-loading").is(':visible'));
       });
+
+      it("should inline multiline executable task", function() {
+        var lines = [
+          "!!|12:33:01.817 [go] Task: /bin/bash -c \"echo -e 'this is \n",
+          "!!|12:33:01.817 theBestUse \n",
+          "!!|12:33:01.817 ofOurplugin\n",
+          "!!|12:33:01.817 '>testFile.txt\"\n"
+        ];
+
+        var expectedLines = [
+          "!!|12:33:01.817 [go] Task: /bin/bash -c \"echo -e 'this is \\ntheBestUse \\nofOurplugin\\n'>testFile.txt\""
+        ];
+
+        transformer.transform(lines);
+
+        assertEquals(lines[0], expectedLines[0]);
+      })
   });
 
 })(jQuery);


### PR DESCRIPTION
#### Raw Console Log for exec task containing new line:
```task
##|12:33:01.795 [go] Start to build yamlpipe123/1/build/1/build on in-ganeshpl-2.local [/Users/ganeshp/projects/gocd/gocd/agent]
!!|12:33:01.817 [go] Task: /bin/bash -c "echo -e 'this is 
!!|12:33:01.817 theBestUse 
!!|12:33:01.817 ofOurplugin
!!|12:33:01.817 '>testFile.txt"
?0|12:33:01.988 [go] Task status: passed (168 ms)
j0|12:33:02.017 [go] Current job status: passed
```

#### Why did it fail?
Console Log Appender was expecting the exec task in the format `!!|{DATE} [go] Task: {COMMAND} \n`, but as the task itself was split into multiple lines, it was assuming each line as a separate task.

As the subsequent lines from the exec task command werent satisfying the exec task format, it was failing to render such tasks.

---

#### Fix:

Each line from the console is processed via Console log output transformer which formats and prettifies the log content. (eg: printing red, green, yellow, etc).

Before sending the logs to transformer, inline multiline executable tasks into a single line.

With this fix, all the existing logs should continue to work as is. This fix is concats multi-line exec task command into a single line and then sends it to log transformer for processing.

