### PR TITLE
Fix for integration test random failure

### DIFF
--- a/server/src/main/java/com/thoughtworks/go/config/GoRepoConfigDataSource.java
+++ b/server/src/main/java/com/thoughtworks/go/config/GoRepoConfigDataSource.java
@@ -204,7 +204,7 @@ public class GoRepoConfigDataSource implements ChangedRepoConfigWatchListListene
 
     public String getRevisionAtLastAttempt(MaterialConfig material) {
         PartialConfigParseResult result = getLastParseResult(material);
-        if (result == null)
+        if (result == null || result.getLatestParsedModification() == null)
             return null;
 
         return result.getLatestParsedModification().getRevision();

--- a/server/src/test-integration/java/com/thoughtworks/go/server/materials/ConfigMaterialUpdateListenerIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/materials/ConfigMaterialUpdateListenerIntegrationTest.java
@@ -30,6 +30,7 @@ import com.thoughtworks.go.server.dao.DatabaseAccessHelper;
 import com.thoughtworks.go.server.perf.MDUPerformanceLogger;
 import com.thoughtworks.go.server.persistence.MaterialRepository;
 import com.thoughtworks.go.server.service.*;
+import com.thoughtworks.go.serverhealth.HealthStateScope;
 import com.thoughtworks.go.serverhealth.ServerHealthService;
 import com.thoughtworks.go.util.ConfigElementImplementationRegistryMother;
 import com.thoughtworks.go.util.GoConfigFileHelper;
@@ -46,11 +47,9 @@ import java.io.File;
 
 import static junit.framework.Assert.fail;
 import static junit.framework.TestCase.assertNotNull;
-import static org.junit.Assert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertSame;
+import static org.junit.Assert.*;
 import static org.mockito.Mockito.mock;
 
 @RunWith(SpringJUnit4ClassRunner.class)
@@ -171,8 +170,9 @@ public class ConfigMaterialUpdateListenerIntegrationTest {
     }
 
     private void assertInProgressState() throws InterruptedException {
+        HealthStateScope healthStateScope = HealthStateScope.forPartialConfigRepo(material.config().getFingerprint());
         int i = 0;
-        while (goRepoConfigDataSource.getRevisionAtLastAttempt(materialConfig) == null) {
+        while (serverHealthService.filterByScope(healthStateScope).isEmpty() && goRepoConfigDataSource.getRevisionAtLastAttempt(material.config()) == null) {
             if (!materialUpdateService.isInProgress(material))
                 Assert.fail("should be still in progress");
 


### PR DESCRIPTION
This PR contains a fix for a randomly failing integration test introduced in #5843

See [here](https://build.gocd.org/go/tab/build/detail/build-linux/3479/build-server/2/ServerIntegrationTests-runInstance-2#) for the specific failure