### PR TITLE
Secrets Management plugin infra

### DIFF
--- a/config/config-api/src/main/java/com/thoughtworks/go/config/SecretConfig.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/SecretConfig.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.config;
+
+public class SecretConfig extends PluginProfile {
+    @Override
+    protected String getObjectDescription() {
+        return "Secret configuration";
+    }
+
+    @Override
+    protected boolean isSecure(String key) {
+        return false;
+    }
+
+    @Override
+    protected boolean hasPluginInfo() {
+        return false;
+    }
+}

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/secrets/SecretsExtension.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/secrets/SecretsExtension.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.plugin.access.secrets;
+
+import com.thoughtworks.go.config.SecretConfig;
+import com.thoughtworks.go.plugin.access.ExtensionsRegistry;
+import com.thoughtworks.go.plugin.access.PluginRequestHelper;
+import com.thoughtworks.go.plugin.access.common.AbstractExtension;
+import com.thoughtworks.go.plugin.access.secrets.v1.SecretsExtensionV1;
+import com.thoughtworks.go.plugin.api.response.validation.ValidationResult;
+import com.thoughtworks.go.plugin.domain.common.Image;
+import com.thoughtworks.go.plugin.domain.common.PluginConfiguration;
+import com.thoughtworks.go.plugin.domain.secrets.Secret;
+import com.thoughtworks.go.plugin.infra.PluginManager;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static com.thoughtworks.go.plugin.domain.common.PluginConstants.SECRETS_EXTENSION;
+
+@Component
+public class SecretsExtension extends AbstractExtension {
+    public static final List<String> SUPPORTED_VERSIONS = Arrays.asList(SecretsExtensionV1.VERSION);
+    private Map<String, VersionedSecretsExtension> secretsExtensionMap = new HashMap<>();
+
+    @Autowired
+    public SecretsExtension(PluginManager pluginManager, ExtensionsRegistry extensionsRegistry) {
+        super(pluginManager, extensionsRegistry, new PluginRequestHelper(pluginManager, SUPPORTED_VERSIONS, SECRETS_EXTENSION), SECRETS_EXTENSION);
+
+        secretsExtensionMap.put(SecretsExtensionV1.VERSION, new SecretsExtensionV1(pluginRequestHelper));
+    }
+
+    protected SecretsExtension(PluginManager pluginManager, ExtensionsRegistry extensionsRegistry, Map<String, VersionedSecretsExtension> secretsExtensionMap) {
+        super(pluginManager, extensionsRegistry, new PluginRequestHelper(pluginManager, SUPPORTED_VERSIONS, SECRETS_EXTENSION), SECRETS_EXTENSION);
+
+        this.secretsExtensionMap = secretsExtensionMap;
+    }
+
+    @Override
+    public List<String> goSupportedVersions() {
+        return SUPPORTED_VERSIONS;
+    }
+
+    public Image getIcon(String pluginId) {
+        return getVersionedSecretsExtension(pluginId).getIcon(pluginId);
+    }
+
+    public List<PluginConfiguration> getSecretsConfigMetadata(String pluginId) {
+        return getVersionedSecretsExtension(pluginId).getSecretsConfigMetadata(pluginId);
+    }
+
+    public String getSecretsConfigView(String pluginId) {
+        return getVersionedSecretsExtension(pluginId).getSecretsConfigView(pluginId);
+    }
+
+    public ValidationResult validateSecretsConfig(final String pluginId, final Map<String, String> configuration) {
+        return getVersionedSecretsExtension(pluginId).validateSecretsConfig(pluginId, configuration);
+    }
+
+    public List<Secret> lookupSecrets(String pluginId, List<String> keys, SecretConfig secretConfig) {
+        return getVersionedSecretsExtension(pluginId).lookupSecrets(pluginId, keys, secretConfig);
+    }
+
+    protected VersionedSecretsExtension getVersionedSecretsExtension(String pluginId) {
+        final String resolvedExtensionVersion = pluginManager.resolveExtensionVersion(pluginId, SECRETS_EXTENSION, goSupportedVersions());
+        return secretsExtensionMap.get(resolvedExtensionVersion);
+    }
+}

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/secrets/SecretsMessageConverter.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/secrets/SecretsMessageConverter.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.plugin.access.secrets;
+
+import com.thoughtworks.go.plugin.api.response.validation.ValidationResult;
+import com.thoughtworks.go.plugin.domain.common.Image;
+import com.thoughtworks.go.plugin.domain.common.PluginConfiguration;
+import com.thoughtworks.go.plugin.domain.secrets.Secret;
+
+import java.util.List;
+import java.util.Map;
+
+public interface SecretsMessageConverter {
+    Image getImageFromResponseBody(String responseBody);
+
+    List<PluginConfiguration> getSecretsConfigMetadataFromResponse(String responseBody);
+
+    String getSecretsConfigViewFromResponse(String responseBody);
+
+    ValidationResult getSecretsConfigValidationResultFromResponse(String responseBody);
+
+    String validatePluginConfigurationRequestBody(Map<String, String> configuration);
+
+    String lookupSecretsRequestBody(List<String> lookupStrings);
+
+    List<Secret> getSecretsFromResponse(String responseBody);
+}

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/secrets/SecretsMetadataLoader.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/secrets/SecretsMetadataLoader.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.plugin.access.secrets;
+
+import com.thoughtworks.go.plugin.access.common.MetadataLoader;
+import com.thoughtworks.go.plugin.domain.secrets.SecretsPluginInfo;
+import com.thoughtworks.go.plugin.infra.PluginManager;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class SecretsMetadataLoader extends MetadataLoader<SecretsPluginInfo> {
+    @Autowired
+    public SecretsMetadataLoader(PluginManager pluginManager, SecretsPluginInfoBuilder builder,
+                                 SecretsExtension extension) {
+        this(pluginManager, SecretsMetadataStore.instance(), builder, extension);
+    }
+
+    protected SecretsMetadataLoader(PluginManager pluginManager, SecretsMetadataStore metadataStore,
+                                    SecretsPluginInfoBuilder builder, SecretsExtension extension) {
+        super(pluginManager, builder, metadataStore, extension);
+    }
+}

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/secrets/SecretsPluginConstants.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/secrets/SecretsPluginConstants.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.plugin.access.secrets;
+
+import static java.lang.String.join;
+
+public interface SecretsPluginConstants {
+    String REQUEST_PREFIX = "go.cd.secrets";
+    String _SECRETS_CONFIG_METADATA = "secrets-config";
+
+    String REQUEST_GET_PLUGIN_ICON = REQUEST_PREFIX + ".get-icon";
+    String REQUEST_GET_SECRETS_CONFIG_METADATA = join(".", REQUEST_PREFIX, _SECRETS_CONFIG_METADATA, "get-metadata");
+    String REQUEST_GET_SECRETS_CONFIG_VIEW = join(".", REQUEST_PREFIX, _SECRETS_CONFIG_METADATA, "get-view");
+    String REQUEST_VALIDATE_SECRETS_CONFIG = join(".", REQUEST_PREFIX, _SECRETS_CONFIG_METADATA, "validate");
+    String REQUEST_VERIFY_CONNECTION = join(".", REQUEST_PREFIX, _SECRETS_CONFIG_METADATA, "verify-connection");
+    String REQUEST_LOOKUP_SECRETS = join(".", REQUEST_PREFIX, "secrets-lookup");
+}

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/secrets/SecretsPluginInfoBuilder.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/secrets/SecretsPluginInfoBuilder.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.plugin.access.secrets;
+
+import com.thoughtworks.go.plugin.access.common.PluginInfoBuilder;
+import com.thoughtworks.go.plugin.domain.common.Image;
+import com.thoughtworks.go.plugin.domain.common.PluggableInstanceSettings;
+import com.thoughtworks.go.plugin.domain.common.PluginView;
+import com.thoughtworks.go.plugin.domain.secrets.SecretsPluginInfo;
+import com.thoughtworks.go.plugin.infra.plugininfo.GoPluginDescriptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+
+@Component
+public class SecretsPluginInfoBuilder implements PluginInfoBuilder<SecretsPluginInfo> {
+
+    private SecretsExtension extension;
+
+    @Autowired
+    public SecretsPluginInfoBuilder(SecretsExtension extension) {
+        this.extension = extension;
+    }
+
+    public SecretsPluginInfo pluginInfoFor(GoPluginDescriptor descriptor) {
+        String pluginId = descriptor.id();
+
+        return new SecretsPluginInfo(descriptor, securityConfigSettings(pluginId), image(pluginId));
+    }
+
+    private Image image(String pluginId) {
+        return extension.getIcon(pluginId);
+    }
+
+    private PluggableInstanceSettings securityConfigSettings(String pluginId) {
+        return new PluggableInstanceSettings(extension.getSecretsConfigMetadata(pluginId),
+                new PluginView(extension.getSecretsConfigView(pluginId)));
+    }
+}
+

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/secrets/VersionedSecretsExtension.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/secrets/VersionedSecretsExtension.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.plugin.access.secrets;
+
+import com.thoughtworks.go.config.SecretConfig;
+import com.thoughtworks.go.plugin.api.response.validation.ValidationResult;
+import com.thoughtworks.go.plugin.domain.common.Image;
+import com.thoughtworks.go.plugin.domain.common.PluginConfiguration;
+import com.thoughtworks.go.plugin.domain.secrets.Secret;
+
+import java.util.List;
+import java.util.Map;
+
+public interface VersionedSecretsExtension {
+    Image getIcon(String pluginId);
+
+    List<PluginConfiguration> getSecretsConfigMetadata(String pluginId);
+
+    String getSecretsConfigView(String pluginId);
+
+    ValidationResult validateSecretsConfig(String pluginId, final Map<String, String> configuration);
+
+    List<Secret> lookupSecrets(String pluginId, List<String> lookupStrings, SecretConfig secretConfig);
+}

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/secrets/v1/SecretDTO.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/secrets/v1/SecretDTO.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.plugin.access.secrets.v1;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.SerializedName;
+import com.google.gson.reflect.TypeToken;
+import com.thoughtworks.go.plugin.domain.secrets.Secret;
+
+import java.util.List;
+
+class SecretDTO {
+    private static final Gson GSON = new GsonBuilder().excludeFieldsWithoutExposeAnnotation().create();
+
+    @Expose
+    @SerializedName("key")
+    private final String key;
+    @Expose
+    @SerializedName("value")
+    private final String value;
+
+    public SecretDTO(String key, String value) {
+        this.key = key;
+        this.value = value;
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public static SecretDTO fromJSON(String json) {
+        return GSON.fromJson(json, SecretDTO.class);
+    }
+
+    public static List<SecretDTO> fromJSONList(String json) {
+        return GSON.fromJson(json, new TypeToken<List<SecretDTO>>() {
+        }.getType());
+    }
+
+    public Secret toDomainModel() {
+        return new Secret(this.key, this.value);
+    }
+}

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/secrets/v1/SecretsExtensionV1.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/secrets/v1/SecretsExtensionV1.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.plugin.access.secrets.v1;
+
+import com.thoughtworks.go.config.SecretConfig;
+import com.thoughtworks.go.plugin.access.DefaultPluginInteractionCallback;
+import com.thoughtworks.go.plugin.access.PluginRequestHelper;
+import com.thoughtworks.go.plugin.access.secrets.SecretsPluginConstants;
+import com.thoughtworks.go.plugin.access.secrets.VersionedSecretsExtension;
+import com.thoughtworks.go.plugin.api.response.validation.ValidationResult;
+import com.thoughtworks.go.plugin.domain.common.Image;
+import com.thoughtworks.go.plugin.domain.common.PluginConfiguration;
+import com.thoughtworks.go.plugin.domain.secrets.Secret;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.Map;
+
+import static com.thoughtworks.go.plugin.access.secrets.SecretsPluginConstants.*;
+
+public class SecretsExtensionV1 implements VersionedSecretsExtension {
+    private static final Logger LOG = LoggerFactory.getLogger(SecretsExtensionV1.class);
+    public static final String VERSION = "1.0";
+    private final PluginRequestHelper pluginRequestHelper;
+    private final SecretsMessageConverterV1 secretsMessageConverterV1;
+
+    public SecretsExtensionV1(PluginRequestHelper pluginRequestHelper) {
+        this.pluginRequestHelper = pluginRequestHelper;
+        this.secretsMessageConverterV1 = new SecretsMessageConverterV1();
+    }
+
+    @Override
+    public Image getIcon(String pluginId) {
+        return pluginRequestHelper.submitRequest(pluginId, SecretsPluginConstants.REQUEST_GET_PLUGIN_ICON,
+                new DefaultPluginInteractionCallback<Image>() {
+            @Override
+            public com.thoughtworks.go.plugin.domain.common.Image onSuccess(String responseBody, Map<String,
+                    String> responseHeaders, String resolvedExtensionVersion) {
+                return secretsMessageConverterV1.getImageFromResponseBody(responseBody);
+            }
+        });
+    }
+
+    @Override
+    public List<PluginConfiguration> getSecretsConfigMetadata(String pluginId) {
+        return pluginRequestHelper.submitRequest(pluginId, REQUEST_GET_SECRETS_CONFIG_METADATA,
+                new DefaultPluginInteractionCallback<List<PluginConfiguration>>() {
+            @Override
+            public List<PluginConfiguration> onSuccess(String responseBody, Map<String, String> responseHeaders,
+                                                       String resolvedExtensionVersion) {
+                return secretsMessageConverterV1.getSecretsConfigMetadataFromResponse(responseBody);
+            }
+        });
+    }
+
+    @Override
+    public String getSecretsConfigView(String pluginId) {
+        return pluginRequestHelper.submitRequest(pluginId, REQUEST_GET_SECRETS_CONFIG_VIEW,
+                new DefaultPluginInteractionCallback<String>() {
+            @Override
+            public String onSuccess(String responseBody, Map<String, String> responseHeaders, String resolvedExtensionVersion) {
+                return secretsMessageConverterV1.getSecretsConfigViewFromResponse(responseBody);
+            }
+        });
+    }
+
+    @Override
+    public ValidationResult validateSecretsConfig(String pluginId, final Map<String, String> configuration) {
+        return pluginRequestHelper.submitRequest(pluginId, REQUEST_VALIDATE_SECRETS_CONFIG,
+                new DefaultPluginInteractionCallback<ValidationResult>() {
+                    @Override
+                    public String requestBody(String resolvedExtensionVersion) {
+                        return secretsMessageConverterV1.validatePluginConfigurationRequestBody(configuration);
+                    }
+
+                    @Override
+                    public ValidationResult onSuccess(String responseBody, Map<String, String> responseHeaders,
+                                                      String resolvedExtensionVersion) {
+                        return secretsMessageConverterV1.getSecretsConfigValidationResultFromResponse(responseBody);
+                    }
+                });
+    }
+
+    @Override
+    public List<Secret> lookupSecrets(String pluginId, List<String> keys, SecretConfig secretConfig) {
+        return pluginRequestHelper.submitRequest(pluginId, REQUEST_LOOKUP_SECRETS,
+                new DefaultPluginInteractionCallback<List<Secret>>() {
+                    @Override
+                    public String requestBody(String resolvedExtensionVersion) {
+                        return secretsMessageConverterV1.lookupSecretsRequestBody(keys);
+                    }
+
+                    @Override
+                    public List<Secret> onSuccess(String responseBody, Map<String, String> responseHeaders, String resolvedExtensionVersion) {
+                        return secretsMessageConverterV1.getSecretsFromResponse(responseBody);
+                    }
+                });
+    }
+}

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/secrets/v1/SecretsMessageConverterV1.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/secrets/v1/SecretsMessageConverterV1.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.plugin.access.secrets.v1;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonObject;
+import com.thoughtworks.go.plugin.access.common.handler.JSONResultMessageHandler;
+import com.thoughtworks.go.plugin.access.common.models.ImageDeserializer;
+import com.thoughtworks.go.plugin.access.common.models.PluginProfileMetadataKeys;
+import com.thoughtworks.go.plugin.access.secrets.SecretsMessageConverter;
+import com.thoughtworks.go.plugin.api.response.validation.ValidationResult;
+import com.thoughtworks.go.plugin.domain.common.Image;
+import com.thoughtworks.go.plugin.domain.common.PluginConfiguration;
+import com.thoughtworks.go.plugin.domain.secrets.Secret;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.apache.commons.lang3.StringUtils.isBlank;
+
+public class SecretsMessageConverterV1 implements SecretsMessageConverter {
+    public static final String VERSION = "1.0";
+
+    @Override
+    public Image getImageFromResponseBody(String responseBody) {
+        return new ImageDeserializer().fromJSON(responseBody);
+    }
+
+    @Override
+    public List<PluginConfiguration> getSecretsConfigMetadataFromResponse(String responseBody) {
+        return PluginProfileMetadataKeys.fromJSON(responseBody).toPluginConfigurations();
+    }
+
+    @Override
+    public String getSecretsConfigViewFromResponse(String responseBody) {
+        String statusReportView = (String) new Gson().fromJson(responseBody, Map.class).get("template");
+        if (isBlank(statusReportView)) {
+            throw new RuntimeException("Template is blank!");
+        }
+
+        return statusReportView;
+    }
+
+    @Override
+    public ValidationResult getSecretsConfigValidationResultFromResponse(String responseBody) {
+        return new JSONResultMessageHandler().toValidationResult(responseBody);
+    }
+
+    @Override
+    public String validatePluginConfigurationRequestBody(Map<String, String> configuration) {
+        JsonObject properties = mapToJsonObject(configuration);
+        return new GsonBuilder().serializeNulls().create().toJson(properties);
+    }
+
+    @Override
+    public String lookupSecretsRequestBody(List<String> lookupStrings) {
+        return new GsonBuilder().create().toJson(lookupStrings);
+    }
+
+    @Override
+    public List<Secret> getSecretsFromResponse(String responseBody) {
+        return SecretDTO.fromJSONList(responseBody).stream().map(SecretDTO::toDomainModel).collect(Collectors.toList());
+    }
+
+    private JsonObject mapToJsonObject(Map<String, String> configuration) {
+        final JsonObject properties = new JsonObject();
+
+        configuration.forEach((k,v) -> properties.addProperty(k, v));
+
+        return properties;
+    }
+}

--- a/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/secrets/SecretsExtensionTest.java
+++ b/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/secrets/SecretsExtensionTest.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.plugin.access.secrets;
+
+import com.thoughtworks.go.config.SecretConfig;
+import com.thoughtworks.go.plugin.access.ExtensionsRegistry;
+import com.thoughtworks.go.plugin.access.common.AbstractExtension;
+import com.thoughtworks.go.plugin.access.secrets.v1.SecretsExtensionV1;
+import com.thoughtworks.go.plugin.infra.PluginManager;
+import com.thoughtworks.go.plugin.infra.plugininfo.GoPluginDescriptor;
+import com.thoughtworks.go.util.ReflectionUtil;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static com.thoughtworks.go.plugin.access.secrets.SecretsExtension.SUPPORTED_VERSIONS;
+import static com.thoughtworks.go.plugin.domain.common.PluginConstants.SECRETS_EXTENSION;
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonMap;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+public class SecretsExtensionTest {
+    private static final String PLUGIN_ID = "cd.go.example.plugin";
+    protected PluginManager pluginManager;
+    private ExtensionsRegistry extensionsRegistry;
+    protected GoPluginDescriptor descriptor;
+    protected SecretsExtension extension;
+
+    @Before
+    public void setUp() throws Exception {
+        pluginManager = mock(PluginManager.class);
+        extensionsRegistry = mock(ExtensionsRegistry.class);
+        descriptor = mock(GoPluginDescriptor.class);
+        extension = new SecretsExtension(pluginManager, extensionsRegistry);
+
+        when(descriptor.id()).thenReturn(PLUGIN_ID);
+        when(pluginManager.getPluginDescriptorFor(PLUGIN_ID)).thenReturn(descriptor);
+        when(pluginManager.isPluginOfType(SECRETS_EXTENSION, PLUGIN_ID)).thenReturn(true);
+    }
+
+    @Test
+    public void shouldHaveVersionedSecretsExtensionForAllSupportedVersions() {
+        for (String supportedVersion : SUPPORTED_VERSIONS) {
+            final String message = String.format("Must define versioned extension class for %s extension with version %s", SECRETS_EXTENSION, supportedVersion);
+
+            when(pluginManager.resolveExtensionVersion(PLUGIN_ID, SECRETS_EXTENSION, SUPPORTED_VERSIONS)).thenReturn(supportedVersion);
+
+            final VersionedSecretsExtension extension = this.extension.getVersionedSecretsExtension(PLUGIN_ID);
+
+            assertNotNull(message, extension);
+            assertThat(ReflectionUtil.getField(extension, "VERSION"), is(supportedVersion));
+        }
+    }
+
+    @Test
+    public void getIcon_shouldDelegateToVersionedExtension() {
+        SecretsExtensionV1 secretsExtensionV1 = mock(SecretsExtensionV1.class);
+        Map<String, VersionedSecretsExtension> secretsExtensionMap = singletonMap("1.0", secretsExtensionV1);
+        extension = new SecretsExtension(pluginManager, extensionsRegistry, secretsExtensionMap);
+
+        when(pluginManager.resolveExtensionVersion(PLUGIN_ID, SECRETS_EXTENSION, SUPPORTED_VERSIONS)).thenReturn(SecretsExtensionV1.VERSION);
+
+        this.extension.getIcon(PLUGIN_ID);
+
+        verify(secretsExtensionV1).getIcon(PLUGIN_ID);
+    }
+
+    @Test
+    public void getSecretsConfigMetadata_shouldDelegateToVersionedExtension() {
+        SecretsExtensionV1 secretsExtensionV1 = mock(SecretsExtensionV1.class);
+        Map<String, VersionedSecretsExtension> secretsExtensionMap = singletonMap("1.0", secretsExtensionV1);
+        extension = new SecretsExtension(pluginManager, extensionsRegistry, secretsExtensionMap);
+
+        when(pluginManager.resolveExtensionVersion(PLUGIN_ID, SECRETS_EXTENSION, SUPPORTED_VERSIONS)).thenReturn(SecretsExtensionV1.VERSION);
+
+        this.extension.getSecretsConfigMetadata(PLUGIN_ID);
+
+        verify(secretsExtensionV1).getSecretsConfigMetadata(PLUGIN_ID);
+    }
+
+    @Test
+    public void getSecretsConfigView_shouldDelegateToVersionedExtension() {
+        SecretsExtensionV1 secretsExtensionV1 = mock(SecretsExtensionV1.class);
+        Map<String, VersionedSecretsExtension> secretsExtensionMap = singletonMap("1.0", secretsExtensionV1);
+        extension = new SecretsExtension(pluginManager, extensionsRegistry, secretsExtensionMap);
+
+        when(pluginManager.resolveExtensionVersion(PLUGIN_ID, SECRETS_EXTENSION, SUPPORTED_VERSIONS)).thenReturn(SecretsExtensionV1.VERSION);
+
+        this.extension.getSecretsConfigView(PLUGIN_ID);
+
+        verify(secretsExtensionV1).getSecretsConfigView(PLUGIN_ID);
+    }
+
+    @Test
+    public void validateSecretsConfig_shouldDelegateToVersionedExtension() {
+        SecretsExtensionV1 secretsExtensionV1 = mock(SecretsExtensionV1.class);
+        Map<String, VersionedSecretsExtension> secretsExtensionMap = singletonMap("1.0", secretsExtensionV1);
+        extension = new SecretsExtension(pluginManager, extensionsRegistry, secretsExtensionMap);
+        Map<String, String> configuration = singletonMap("key", "val");
+
+        when(pluginManager.resolveExtensionVersion(PLUGIN_ID, SECRETS_EXTENSION, SUPPORTED_VERSIONS)).thenReturn(SecretsExtensionV1.VERSION);
+
+        this.extension.validateSecretsConfig(PLUGIN_ID, configuration);
+
+        verify(secretsExtensionV1).validateSecretsConfig(PLUGIN_ID, configuration);
+    }
+
+    @Test
+    public void lookupSecrets_shouldDelegateToVersionedExtension() {
+        SecretsExtensionV1 secretsExtensionV1 = mock(SecretsExtensionV1.class);
+        Map<String, VersionedSecretsExtension> secretsExtensionMap = singletonMap("1.0", secretsExtensionV1);
+        extension = new SecretsExtension(pluginManager, extensionsRegistry, secretsExtensionMap);
+        List<String> keys = asList("key1", "key2");
+
+        when(pluginManager.resolveExtensionVersion(PLUGIN_ID, SECRETS_EXTENSION, SUPPORTED_VERSIONS)).thenReturn(SecretsExtensionV1.VERSION);
+
+        this.extension.lookupSecrets(PLUGIN_ID, keys, new SecretConfig());
+
+        verify(secretsExtensionV1).lookupSecrets(PLUGIN_ID, keys, new SecretConfig());
+    }
+
+    @Test
+    public void shouldExtendAbstractExtension() {
+        assertTrue(new SecretsExtension(pluginManager, extensionsRegistry) instanceof AbstractExtension);
+    }
+}

--- a/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/secrets/SecretsMetadataLoaderTest.java
+++ b/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/secrets/SecretsMetadataLoaderTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.plugin.access.secrets;
+
+import com.thoughtworks.go.plugin.domain.secrets.SecretsPluginInfo;
+import com.thoughtworks.go.plugin.infra.PluginManager;
+import com.thoughtworks.go.plugin.infra.plugininfo.GoPluginDescriptor;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+public class SecretsMetadataLoaderTest {
+
+    private SecretsExtension extension;
+    private SecretsPluginInfoBuilder infoBuilder;
+    private SecretsMetadataStore metadataStore;
+    private PluginManager pluginManager;
+
+    @Before
+    public void setUp() throws Exception {
+        extension = mock(SecretsExtension.class);
+        infoBuilder = mock(SecretsPluginInfoBuilder.class);
+        metadataStore = mock(SecretsMetadataStore.class);
+        pluginManager = mock(PluginManager.class);
+    }
+
+    @Test
+    public void shouldBeAPluginChangeListener() {
+        SecretsMetadataLoader analyticsMetadataLoader = new SecretsMetadataLoader(pluginManager, metadataStore, infoBuilder, extension);
+
+        verify(pluginManager).addPluginChangeListener(eq(analyticsMetadataLoader));
+    }
+
+    @Test
+    public void onPluginLoaded_shouldAddPluginInfoToMetadataStore() {
+        GoPluginDescriptor descriptor =  new GoPluginDescriptor("plugin1", null, null, null, null, false);
+        SecretsMetadataLoader metadataLoader = new SecretsMetadataLoader(pluginManager, metadataStore, infoBuilder, extension);
+        SecretsPluginInfo pluginInfo = new SecretsPluginInfo(descriptor, null,null);
+
+        when(extension.canHandlePlugin(descriptor.id())).thenReturn(true);
+        when(infoBuilder.pluginInfoFor(descriptor)).thenReturn(pluginInfo);
+
+        metadataLoader.pluginLoaded(descriptor);
+
+        verify(metadataStore).setPluginInfo(pluginInfo);
+    }
+
+    @Test
+    public void onPluginLoaded_shouldIgnoreNonSecretsPlugins() {
+        GoPluginDescriptor descriptor =  new GoPluginDescriptor("plugin1", null, null, null, null, false);
+        SecretsMetadataLoader metadataLoader = new SecretsMetadataLoader(pluginManager, metadataStore, infoBuilder, extension);
+
+        when(extension.canHandlePlugin(descriptor.id())).thenReturn(false);
+
+        metadataLoader.pluginLoaded(descriptor);
+
+        verifyZeroInteractions(infoBuilder);
+        verifyZeroInteractions(metadataStore);
+    }
+
+    @Test
+    public void onPluginUnloaded_shouldRemoveTheCorrespondingPluginInfoFromStore() {
+        GoPluginDescriptor descriptor =  new GoPluginDescriptor("plugin1", null, null, null, null, false);
+        SecretsMetadataLoader metadataLoader = new SecretsMetadataLoader(pluginManager, metadataStore, infoBuilder, extension);
+        SecretsPluginInfo pluginInfo = new SecretsPluginInfo(descriptor, null,null);
+
+        metadataStore.setPluginInfo(pluginInfo);
+
+        metadataLoader.pluginUnLoaded(descriptor);
+
+        verify(metadataStore).remove(descriptor.id());
+    }
+}

--- a/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/secrets/SecretsPluginInfoBuilderTest.java
+++ b/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/secrets/SecretsPluginInfoBuilderTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.plugin.access.secrets;
+
+import com.thoughtworks.go.plugin.domain.common.*;
+import com.thoughtworks.go.plugin.domain.secrets.SecretsPluginInfo;
+import com.thoughtworks.go.plugin.infra.plugininfo.GoPluginDescriptor;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class SecretsPluginInfoBuilderTest {
+    private SecretsExtension extension;
+
+    @Before
+    public void setUp() throws Exception {
+        extension = mock(SecretsExtension.class);
+    }
+
+    @Test
+    public void shouldBuildPluginInfoWithImage() {
+        GoPluginDescriptor descriptor = new GoPluginDescriptor("plugin1", null, null,
+                null, null, false);
+        Image icon = new Image("content_type", "data", "hash");
+
+        when(extension.getIcon(descriptor.id())).thenReturn(icon);
+
+        SecretsPluginInfo pluginInfo = new SecretsPluginInfoBuilder(extension).pluginInfoFor(descriptor);
+
+        assertThat(pluginInfo.getImage(), is(icon));
+    }
+
+    @Test
+    public void shouldBuildPluginInfoWithPluginDescriptor() {
+        GoPluginDescriptor descriptor = new GoPluginDescriptor("plugin1", null, null,
+                null, null, false);
+
+        SecretsPluginInfo pluginInfo = new SecretsPluginInfoBuilder(extension).pluginInfoFor(descriptor);
+
+        assertThat(pluginInfo.getDescriptor(), is(descriptor));
+    }
+
+    @Test
+    public void shouldBuildPluginInfoWithSecuritySettings() {
+        GoPluginDescriptor descriptor = new GoPluginDescriptor("plugin1", null, null,
+                null, null, false);
+        List<PluginConfiguration> pluginConfigurations = Arrays.asList(
+                new PluginConfiguration("username", new Metadata(true, false)),
+                new PluginConfiguration("password", new Metadata(true, true))
+        );
+
+        when(extension.getSecretsConfigMetadata(descriptor.id())).thenReturn(pluginConfigurations);
+        when(extension.getSecretsConfigView(descriptor.id())).thenReturn("secrets_config_view");
+
+        SecretsPluginInfo pluginInfo = new SecretsPluginInfoBuilder(extension).pluginInfoFor(descriptor);
+
+        assertThat(pluginInfo.getSecretsConfigSettings(),
+                is(new PluggableInstanceSettings(pluginConfigurations, new PluginView("secrets_config_view"))));
+    }
+}

--- a/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/secrets/v1/SecretsExtensionV1Test.java
+++ b/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/secrets/v1/SecretsExtensionV1Test.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.plugin.access.secrets.v1;
+
+import com.thoughtworks.go.config.SecretConfig;
+import com.thoughtworks.go.plugin.access.PluginRequestHelper;
+import com.thoughtworks.go.plugin.api.request.GoPluginApiRequest;
+import com.thoughtworks.go.plugin.api.response.DefaultGoPluginApiResponse;
+import com.thoughtworks.go.plugin.api.response.validation.ValidationError;
+import com.thoughtworks.go.plugin.api.response.validation.ValidationResult;
+import com.thoughtworks.go.plugin.domain.common.Image;
+import com.thoughtworks.go.plugin.domain.common.Metadata;
+import com.thoughtworks.go.plugin.domain.common.PluginConfiguration;
+import com.thoughtworks.go.plugin.domain.secrets.Secret;
+import com.thoughtworks.go.plugin.infra.PluginManager;
+import org.hamcrest.Matchers;
+import org.junit.Assert;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+
+import java.util.List;
+
+import static com.thoughtworks.go.plugin.access.secrets.SecretsPluginConstants.*;
+import static com.thoughtworks.go.plugin.domain.common.PluginConstants.SECRETS_EXTENSION;
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonMap;
+import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson;
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+public class SecretsExtensionV1Test {
+    @Mock
+    private PluginManager pluginManager;
+    protected ArgumentCaptor<GoPluginApiRequest> requestArgumentCaptor;
+    private PluginRequestHelper pluginRequestHelper;
+    private String PLUGIN_ID = "cd.go.example.secrets_plugin";
+    private SecretsExtensionV1 secretsExtensionV1;
+
+    @BeforeEach
+    void setUp() {
+        initMocks(this);
+
+        this.pluginRequestHelper = new PluginRequestHelper(pluginManager, asList("1.0"), SECRETS_EXTENSION);
+        this.requestArgumentCaptor = ArgumentCaptor.forClass(GoPluginApiRequest.class);
+        this.secretsExtensionV1 = new SecretsExtensionV1(pluginRequestHelper);
+
+        when(pluginManager.isPluginOfType(SECRETS_EXTENSION, PLUGIN_ID)).thenReturn(true);
+        when(pluginManager.resolveExtensionVersion(PLUGIN_ID, SECRETS_EXTENSION, asList("1.0"))).thenReturn("1.0");
+    }
+
+    @Test
+    void shouldTalkToPlugin_toGetIcon() {
+        when(pluginManager.submitTo(eq(PLUGIN_ID), eq(SECRETS_EXTENSION), requestArgumentCaptor.capture()))
+                .thenReturn(DefaultGoPluginApiResponse.success("{\"content_type\":\"image/png\",\"data\":\"Zm9vYmEK\"}"));
+
+        final Image icon = secretsExtensionV1.getIcon(PLUGIN_ID);
+
+        assertThat(icon.getContentType(), is("image/png"));
+        assertThat(icon.getData(), is("Zm9vYmEK"));
+        assertExtensionRequest(REQUEST_GET_PLUGIN_ICON, null);
+    }
+
+    @Test
+    void shouldTalkToPlugin_toFetchSecretsConfigMetadata() {
+        String responseBody = "[{\"key\":\"Username\",\"metadata\":{\"required\":true,\"secure\":false}},{\"key\":\"Password\",\"metadata\":{\"required\":true,\"secure\":true}}]";
+        when(pluginManager.submitTo(eq(PLUGIN_ID), eq(SECRETS_EXTENSION), requestArgumentCaptor.capture())).thenReturn(DefaultGoPluginApiResponse.success(responseBody));
+
+        final List<PluginConfiguration> metadata = secretsExtensionV1.getSecretsConfigMetadata(PLUGIN_ID);
+
+        assertThat(metadata, hasSize(2));
+        assertThat(metadata, containsInAnyOrder(
+                new PluginConfiguration("Username", new Metadata(true, false)),
+                new PluginConfiguration("Password", new Metadata(true, true))
+        ));
+
+        assertExtensionRequest(REQUEST_GET_SECRETS_CONFIG_METADATA, null);
+    }
+
+    @Test
+    void shouldTalkToPlugin_toFetchSecretsConfigView() {
+        String responseBody = "{ \"template\": \"<div>This is secrets config view snippet</div>\" }";
+        when(pluginManager.submitTo(eq(PLUGIN_ID), eq(SECRETS_EXTENSION), requestArgumentCaptor.capture())).thenReturn(DefaultGoPluginApiResponse.success(responseBody));
+
+        final String view = secretsExtensionV1.getSecretsConfigView(PLUGIN_ID);
+
+        assertThat(view, is("<div>This is secrets config view snippet</div>"));
+
+        assertExtensionRequest(REQUEST_GET_SECRETS_CONFIG_VIEW, null);
+    }
+
+    @Test
+    void shouldTalkToPlugin_toValidateSecretsConfig() {
+        String responseBody = "[{\"message\":\"Vault Url cannot be blank.\",\"key\":\"Url\"},{\"message\":\"Path cannot be blank.\",\"key\":\"Path\"}]";
+        when(pluginManager.submitTo(eq(PLUGIN_ID), eq(SECRETS_EXTENSION), requestArgumentCaptor.capture())).thenReturn(DefaultGoPluginApiResponse.success(responseBody));
+
+        final ValidationResult result = secretsExtensionV1.validateSecretsConfig(PLUGIN_ID, singletonMap("username", "some_name"));
+
+        assertThat(result.isSuccessful(), is(false));
+        assertThat(result.getErrors(), containsInAnyOrder(
+                new ValidationError("Url", "Vault Url cannot be blank."),
+                new ValidationError("Path", "Path cannot be blank.")
+        ));
+
+        assertExtensionRequest(REQUEST_VALIDATE_SECRETS_CONFIG, "{\"username\":\"some_name\"}");
+    }
+
+    @Test
+    void shouldTalkToPlugin_toLookupForSecrets() {
+        String responseBody = "[{\"key\":\"key1\",\"value\":\"secret1\"},{\"key\":\"key2\",\"value\":\"secret2\"}]";
+        when(pluginManager.submitTo(eq(PLUGIN_ID), eq(SECRETS_EXTENSION), requestArgumentCaptor.capture())).thenReturn(DefaultGoPluginApiResponse.success(responseBody));
+
+        List<Secret> secrets = secretsExtensionV1.lookupSecrets(PLUGIN_ID, asList("key1", "key2"), new SecretConfig());
+
+        assertThat(secrets.size(), is(2));
+        assertThat(secrets, containsInAnyOrder(
+                new Secret("key1", "secret1"),
+                new Secret("key2", "secret2")
+        ));
+
+        assertExtensionRequest(REQUEST_LOOKUP_SECRETS, "[\"key1\",\"key2\"]");
+    }
+
+    private void assertExtensionRequest(String requestName, String requestBody) {
+        final GoPluginApiRequest request = requestArgumentCaptor.getValue();
+        Assert.assertThat(request.requestName(), Matchers.is(requestName));
+        Assert.assertThat(request.extensionVersion(), Matchers.is("1.0"));
+        Assert.assertThat(request.extension(), Matchers.is(SECRETS_EXTENSION));
+        assertThatJson(requestBody).isEqualTo(request.requestBody());
+    }
+}

--- a/plugin-infra/go-plugin-domain/src/main/java/com/thoughtworks/go/plugin/domain/common/PluginConstants.java
+++ b/plugin-infra/go-plugin-domain/src/main/java/com/thoughtworks/go/plugin/domain/common/PluginConstants.java
@@ -26,4 +26,5 @@ public interface PluginConstants {
     String CONFIG_REPO_EXTENSION = "configrepo";
     String ANALYTICS_EXTENSION = "analytics";
     String ARTIFACT_EXTENSION = "artifact";
+    String SECRETS_EXTENSION = "secrets";
 }

--- a/plugin-infra/go-plugin-domain/src/main/java/com/thoughtworks/go/plugin/domain/secrets/Secret.java
+++ b/plugin-infra/go-plugin-domain/src/main/java/com/thoughtworks/go/plugin/domain/secrets/Secret.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.plugin.domain.secrets;
+
+import java.util.Objects;
+
+public class Secret {
+    private final String key;
+    private final String value;
+
+    public Secret(String key, String value) {
+        this.key = key;
+        this.value = value;
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Secret secret = (Secret) o;
+        return Objects.equals(key, secret.key) &&
+                Objects.equals(value, secret.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(key, value);
+    }
+}

--- a/plugin-infra/go-plugin-domain/src/main/java/com/thoughtworks/go/plugin/domain/secrets/SecretsPluginInfo.java
+++ b/plugin-infra/go-plugin-domain/src/main/java/com/thoughtworks/go/plugin/domain/secrets/SecretsPluginInfo.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.plugin.domain.secrets;
+
+import com.thoughtworks.go.plugin.api.info.PluginDescriptor;
+import com.thoughtworks.go.plugin.domain.common.Image;
+import com.thoughtworks.go.plugin.domain.common.PluggableInstanceSettings;
+import com.thoughtworks.go.plugin.domain.common.PluginConstants;
+import com.thoughtworks.go.plugin.domain.common.PluginInfo;
+
+import java.util.Objects;
+
+public class SecretsPluginInfo extends PluginInfo {
+    private final PluggableInstanceSettings secretsConfigSettings;
+
+    public SecretsPluginInfo(PluginDescriptor descriptor, PluggableInstanceSettings secretsConfigSettings, Image image) {
+        super(descriptor, PluginConstants.SECRETS_EXTENSION, null, image);
+
+        this.secretsConfigSettings = secretsConfigSettings;
+    }
+
+    public PluggableInstanceSettings getSecretsConfigSettings() {
+        return secretsConfigSettings;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+        SecretsPluginInfo that = (SecretsPluginInfo) o;
+        return Objects.equals(secretsConfigSettings, that.secretsConfigSettings);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), secretsConfigSettings);
+    }
+}

--- a/plugin-infra/plugin-metadata-store/src/main/java/com/thoughtworks/go/plugin/access/secrets/SecretsMetadataStore.java
+++ b/plugin-infra/plugin-metadata-store/src/main/java/com/thoughtworks/go/plugin/access/secrets/SecretsMetadataStore.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.plugin.access.secrets;
+
+import com.thoughtworks.go.plugin.access.common.MetadataStore;
+
+import com.thoughtworks.go.plugin.domain.secrets.SecretsPluginInfo;
+
+public class SecretsMetadataStore extends MetadataStore<SecretsPluginInfo> {
+    private static final SecretsMetadataStore store = new SecretsMetadataStore();
+
+    protected SecretsMetadataStore() {
+    }
+
+    public static SecretsMetadataStore instance() {
+        return store;
+    }
+
+}


### PR DESCRIPTION
**Not a priority for 19.2.0**

* First pass for #5831.
* This commit adds the skeleton for the Secrets Management Plugin Infra,
  with endpoints to fetch secrets config metadata and view.
* Add infrastructure to build Analytics PluginInfo.