### PR TITLE
Do not render config repo material passwords in plaintext (#5650)

### DIFF
--- a/api/api-config-repos-v1/src/main/java/com/thoughtworks/go/apiv1/configrepos/representers/GitMaterialRepresenter.java
+++ b/api/api-config-repos-v1/src/main/java/com/thoughtworks/go/apiv1/configrepos/representers/GitMaterialRepresenter.java
@@ -25,7 +25,7 @@ class GitMaterialRepresenter {
     static void toJSON(OutputWriter json, GitMaterialConfig material) {
         json.add("name", material.getName());
         json.add("auto_update", material.getAutoUpdate());
-        json.add("url", material.getUrl());
+        json.add("url", material.getUriForDisplay());
         json.addWithDefaultIfBlank("branch", material.getBranch(), "master");
     }
 

--- a/api/api-config-repos-v1/src/main/java/com/thoughtworks/go/apiv1/configrepos/representers/HgMaterialRepresenter.java
+++ b/api/api-config-repos-v1/src/main/java/com/thoughtworks/go/apiv1/configrepos/representers/HgMaterialRepresenter.java
@@ -26,7 +26,7 @@ class HgMaterialRepresenter {
     static void toJSON(OutputWriter json, HgMaterialConfig material) {
         json.add("name", material.getName());
         json.add("auto_update", material.getAutoUpdate());
-        json.add("url", material.getUrl());
+        json.add("url", material.getUriForDisplay());
     }
 
     public static MaterialConfig fromJSON(JsonReader json) {

--- a/api/api-config-repos-v1/src/main/java/com/thoughtworks/go/apiv1/configrepos/representers/P4MaterialRepresenter.java
+++ b/api/api-config-repos-v1/src/main/java/com/thoughtworks/go/apiv1/configrepos/representers/P4MaterialRepresenter.java
@@ -20,7 +20,6 @@ import com.thoughtworks.go.api.base.OutputWriter;
 import com.thoughtworks.go.api.representers.JsonReader;
 import com.thoughtworks.go.config.materials.PasswordDeserializer;
 import com.thoughtworks.go.config.materials.perforce.P4MaterialConfig;
-import com.thoughtworks.go.domain.materials.MaterialConfig;
 
 class P4MaterialRepresenter {
     private static final PasswordDeserializer PASSWORD_DESERIALIZER = new PasswordDeserializer();

--- a/api/api-config-repos-v1/src/main/java/com/thoughtworks/go/apiv1/configrepos/representers/SvnMaterialRepresenter.java
+++ b/api/api-config-repos-v1/src/main/java/com/thoughtworks/go/apiv1/configrepos/representers/SvnMaterialRepresenter.java
@@ -28,7 +28,7 @@ class SvnMaterialRepresenter {
     static void toJSON(OutputWriter json, SvnMaterialConfig material) {
         json.add("name", material.getName());
         json.add("auto_update", material.getAutoUpdate());
-        json.add("url", material.getUrl());
+        json.add("url", material.getUriForDisplay());
         json.add("check_externals", material.isCheckExternals());
         json.add("username", material.getUserName());
         json.addIfNotNull("encrypted_password", material.getEncryptedPassword());

--- a/api/api-config-repos-v1/src/test/groovy/com/thoughtworks/go/apiv1/configrepos/representers/GitMaterialRepresenterTest.groovy
+++ b/api/api-config-repos-v1/src/test/groovy/com/thoughtworks/go/apiv1/configrepos/representers/GitMaterialRepresenterTest.groovy
@@ -27,7 +27,7 @@ import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson
 import static org.junit.jupiter.api.Assertions.assertEquals
 
 class GitMaterialRepresenterTest {
-  private static final String REPO_URL = "https://guthib.com/chewbacca"
+  private static final String REPO_URL = "https://user:password@guthib.com/chewbacca"
   private static final String BRANCH = "wookie"
 
   @Test
@@ -37,7 +37,7 @@ class GitMaterialRepresenterTest {
 
     assertThatJson(json).isEqualTo([
       name       : null,
-      url        : REPO_URL,
+      url        : REPO_URL.replace('password', '******'),
       branch     : BRANCH,
       auto_update: true
     ])

--- a/api/api-config-repos-v1/src/test/groovy/com/thoughtworks/go/apiv1/configrepos/representers/HgMaterialRepresenterTest.groovy
+++ b/api/api-config-repos-v1/src/test/groovy/com/thoughtworks/go/apiv1/configrepos/representers/HgMaterialRepresenterTest.groovy
@@ -27,7 +27,7 @@ import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson
 import static org.junit.jupiter.api.Assertions.assertEquals
 
 class HgMaterialRepresenterTest {
-  private static final String REPO_URL = "https://bitnugget.com/chewbacca"
+  private static final String REPO_URL = "http://username:password@mydomain.com/myproject"
 
   @Test
   void toJSON() {
@@ -36,7 +36,7 @@ class HgMaterialRepresenterTest {
 
     assertThatJson(json).isEqualTo([
       name       : null,
-      url        : REPO_URL,
+      url        : REPO_URL.replace('password', '******'),
       auto_update: true
     ])
   }

--- a/api/api-config-repos-v1/src/test/groovy/com/thoughtworks/go/apiv1/configrepos/representers/SvnMaterialRepresenterTest.groovy
+++ b/api/api-config-repos-v1/src/test/groovy/com/thoughtworks/go/apiv1/configrepos/representers/SvnMaterialRepresenterTest.groovy
@@ -18,27 +18,20 @@ package com.thoughtworks.go.apiv1.configrepos.representers
 
 import com.thoughtworks.go.api.representers.JsonReader
 import com.thoughtworks.go.api.util.GsonTransformer
-import com.thoughtworks.go.config.materials.AbstractMaterialConfig
-import com.thoughtworks.go.config.materials.PasswordDeserializer
 import com.thoughtworks.go.config.materials.svn.SvnMaterialConfig
 import com.thoughtworks.go.domain.materials.MaterialConfig
 import com.thoughtworks.go.security.GoCipher
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import org.mockito.Mock
 
 import static com.thoughtworks.go.api.base.JsonUtils.toObjectString
 import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson
 import static org.junit.jupiter.api.Assertions.assertEquals
 import static org.junit.jupiter.api.Assertions.assertTrue
-import static org.mockito.ArgumentMatchers.any
-import static org.mockito.ArgumentMatchers.eq
-import static org.mockito.Mockito.mock
-import static org.mockito.Mockito.when
 import static org.mockito.MockitoAnnotations.initMocks
 
 class SvnMaterialRepresenterTest {
-  private static final String REPO_URL = "https://dontusesvn.com/chewbacca"
+  private static final String REPO_URL = "svn+ssh://username:password@10.106.191.164/home/svn/shproject"
   private static final String USER = "user"
   private static final String PASSWORD = "it's secret!"
 
@@ -52,7 +45,7 @@ class SvnMaterialRepresenterTest {
 
     assertThatJson(json).isEqualTo([
       name           : null,
-      url            : REPO_URL,
+      url            : REPO_URL.replace('password', '******'),
       check_externals: true,
       auto_update    : true,
       username       : null
@@ -68,7 +61,7 @@ class SvnMaterialRepresenterTest {
 
     assertThatJson(json).isEqualTo([
       name              : null,
-      url               : REPO_URL,
+      url            : REPO_URL.replace('password', '******'),
       check_externals   : false,
       auto_update       : true,
       username          : USER,


### PR DESCRIPTION
Config Repo API (consumed by SPA as well) was rendering passwords specified as part of URLs in plain text.
Do not render config repo material url passwords in plain text.

#### Before
<img width="1409" alt="screen shot 2019-02-20 at 3 06 44 pm" src="https://user-images.githubusercontent.com/15275847/53081585-27d56480-3521-11e9-9ce5-de59b0082168.png">


#### After
<img width="1419" alt="screen shot 2019-02-20 at 3 06 24 pm" src="https://user-images.githubusercontent.com/15275847/53081589-299f2800-3521-11e9-9b77-532267311d5b.png">
