### PR TITLE
Add a link to create pipeline from dashboard when grouped by pipeline groups. (#5715)

### DIFF
--- a/server/webapp/WEB-INF/rails/app/assets/new_stylesheets/single_page_apps/new_dashboard.scss
+++ b/server/webapp/WEB-INF/rails/app/assets/new_stylesheets/single_page_apps/new_dashboard.scss
@@ -174,7 +174,7 @@ body {
 .dashboard-group_title {
   background:    #e7eef0;
   margin:        0;
-  padding:       10px 30px;
+  padding:       10px 10px 10px 30px;
   position:      relative;
 
   border-radius: $global-border-radius $global-border-radius 0 0;
@@ -253,6 +253,17 @@ body {
 .dashboard-group_title {
   .tooltip {
     top: 120%;
+  }
+
+  .dashboard-group_add_pipeline {
+    float:      right;
+    background: #fff;
+    padding:    2px 10px;
+    .icon_add {
+      color:        $icon-color;
+      font-weight:  600;
+      line-height:  25px;
+    }
   }
 }
 

--- a/server/webapp/WEB-INF/rails/config/initializers/jsroutes.rb
+++ b/server/webapp/WEB-INF/rails/config/initializers/jsroutes.rb
@@ -2,6 +2,7 @@ JsRoutes.setup do |config|
   config.prefix = com.thoughtworks.go.util.SystemEnvironment.new.getWebappContextPath
   config.camel_case = true
   config.include = [
+    /^pipeline_new/,
     /analytics/,
     /^api_internal/,
     /^apiv\d/,

--- a/server/webapp/WEB-INF/rails/spec/webpack/models/dashboard/dashboard_groups_spec.js
+++ b/server/webapp/WEB-INF/rails/spec/webpack/models/dashboard/dashboard_groups_spec.js
@@ -44,6 +44,9 @@ describe("DashboardGroups", () => {
       expect(pipelineGroups.groups[0].tooltipForEdit()).toBe("");
       expect(pipelineGroups.groups[0].titleForEdit()).toBe("Edit Pipeline Group 'first'");
       expect(pipelineGroups.groups[0].ariaLabelForEdit()).toBe("Edit Pipeline Group 'first'");
+      expect(pipelineGroups.groups[0].tooltipForNewPipeline()).toBe("");
+      expect(pipelineGroups.groups[0].titleForNewPipeline()).toBe("Create a new pipeline within this group");
+      expect(pipelineGroups.groups[0].ariaLabelForNewPipeline()).toBe("Create a new pipeline within this group");
     });
 
     it('should set values for an environment when a user can administer it', () => {
@@ -52,6 +55,9 @@ describe("DashboardGroups", () => {
       expect(environments.groups[0].tooltipForEdit()).toBe("");
       expect(environments.groups[0].titleForEdit()).toBe("Edit Environment 'first'");
       expect(environments.groups[0].ariaLabelForEdit()).toBe("Edit Environment 'first'");
+      expect(environments.groups[0].tooltipForNewPipeline()).toBe("");
+      expect(environments.groups[0].titleForNewPipeline()).toBe("");
+      expect(environments.groups[0].ariaLabelForNewPipeline()).toBe("");
     });
 
     it('should set values for a pipeline group when a user cannot administer it', () => {
@@ -64,6 +70,9 @@ describe("DashboardGroups", () => {
       expect(pipelineGroups.groups[0].tooltipForEdit()).toBe("You don't have permission to edit this pipeline group");
       expect(pipelineGroups.groups[0].titleForEdit()).toBe("");
       expect(pipelineGroups.groups[0].ariaLabelForEdit()).toBe("You don't have permission to edit this pipeline group");
+      expect(pipelineGroups.groups[0].tooltipForNewPipeline()).toBe("You don't have permission to create new pipeline within this pipeline group");
+      expect(pipelineGroups.groups[0].titleForNewPipeline()).toBe("");
+      expect(pipelineGroups.groups[0].ariaLabelForNewPipeline()).toBe("You don't have permission to create new pipeline within this pipeline group");
     });
 
     it('should set values for an environment when a user cannot administer it', () => {
@@ -76,6 +85,9 @@ describe("DashboardGroups", () => {
       expect(environments.groups[0].tooltipForEdit()).toBe("You don't have permission to edit this environment");
       expect(environments.groups[0].titleForEdit()).toBe("");
       expect(environments.groups[0].ariaLabelForEdit()).toBe("You don't have permission to edit this environment");
+      expect(environments.groups[0].tooltipForNewPipeline()).toBe("");
+      expect(environments.groups[0].titleForNewPipeline()).toBe("");
+      expect(environments.groups[0].ariaLabelForNewPipeline()).toBe("");
     });
 
   });

--- a/server/webapp/WEB-INF/rails/spec/webpack/views/dashboard/dashboard_widget_spec.js
+++ b/server/webapp/WEB-INF/rails/spec/webpack/views/dashboard/dashboard_widget_spec.js
@@ -304,6 +304,21 @@ describe("Dashboard Widget", () => {
     expect(title.href.indexOf(`/go/admin/pipeline_group/${pipelineGroupJSON.name}/edit`)).not.toEqual(-1);
   });
 
+  it("should show pipeline add icon when grouped by pipeline group for admin users", () => {
+    const pipelineGroupJSON = dashboardJson._embedded.pipeline_groups[0];
+
+    const title = helper.find('.dashboard-group_add_pipeline>a').get(0);
+    expect(title.href.indexOf(`/go/admin/pipeline/new?group=${pipelineGroupJSON.name}`)).not.toEqual(-1);
+
+  });
+
+  it("should not show pipeline add icon when grouped by environments for admin users", () => {
+    const pipelineGroupJSON = dashboardJson._embedded.environments[0];
+
+    const title = helper.find('.dashboard-group_add_pipeline>a').get(0);
+    expect(title.href.indexOf(`/go/admin/pipeline/new?group=${pipelineGroupJSON.name}`)).toEqual(-1);
+  });
+
   it("should show disabled pipeline group settings icon showing tooltip for non admin users", () => {
     unmount();
     mount(false);
@@ -372,6 +387,21 @@ describe("Dashboard Widget", () => {
             },
             "name":           "first",
             "pipelines":      ["up42", "up43"],
+            "can_administer": canAdminister
+          }
+        ],
+        "environments": [
+          {
+            "_links":         {
+              "self": {
+                "href": "http://localhost:8153/go/api/admin/environments/e1"
+              },
+              "doc":  {
+                "href": "https://api.gocd.org/current/#environment-config"
+              }
+            },
+            "name":           "e1",
+            "pipelines":      ["up42"],
             "can_administer": canAdminister
           }
         ],

--- a/server/webapp/WEB-INF/rails/webpack/models/dashboard/dashboard_groups.js
+++ b/server/webapp/WEB-INF/rails/webpack/models/dashboard/dashboard_groups.js
@@ -53,6 +53,24 @@ class PipelineGroup extends Group {
     return "";
   }
 
+  tooltipForNewPipeline() {
+    if (!this.canAdminister) {
+      return "You don't have permission to create new pipeline within this pipeline group";
+    }
+    return "";
+  }
+
+  ariaLabelForNewPipeline() {
+    return this.tooltipForNewPipeline() || 'Create a new pipeline within this group';
+  }
+
+  titleForNewPipeline() {
+    if (this.canAdminister) {
+      return 'Create a new pipeline within this group';
+    }
+    return "";
+  }
+
   select(filter) {
     const pipelines = _.filter(this.pipelines, filter);
     if (pipelines.length === 0) {
@@ -67,7 +85,8 @@ class PipelineGroup extends Group {
     }
     return {
       show: `${Routes.pipelineGroupsPath()}#group-${this.name}`,
-      edit: Routes.pipelineGroupEditPath(this.name)
+      edit: Routes.pipelineGroupEditPath(this.name),
+      newPipeline: `${Routes.pipelineNewPath()}?group=${this.name}`
     };
   }
 }
@@ -92,6 +111,18 @@ class Environment extends Group {
     if (this.canAdminister) {
       return `Edit ${this.label()}`;
     }
+    return "";
+  }
+
+  tooltipForNewPipeline() {
+    return "";
+  }
+
+  ariaLabelForNewPipeline() {
+    return "";
+  }
+
+  titleForNewPipeline() {
     return "";
   }
 

--- a/server/webapp/WEB-INF/rails/webpack/views/dashboard/dashboard_groups_widget.js.msx
+++ b/server/webapp/WEB-INF/rails/webpack/views/dashboard/dashboard_groups_widget.js.msx
@@ -7,12 +7,18 @@ const GroupHeading = {
   view(vnode) {
     const vm    = vnode.attrs.vm;
     const paths = vm.routes();
-
+    let addPipeline = "";
+    if (paths.newPipeline && vm.canAdminister) {
+      addPipeline = <div class="dashboard-group_add_pipeline"><f.link class="icon_add" disabled={!vm.canAdminister} href={paths.newPipeline}
+                    tooltipText={vm.tooltipForNewPipeline()} title={vm.titleForNewPipeline()} aria-label={vm.ariaLabelForNewPipeline()}>New Pipeline</f.link></div>;
+    }
     return <div class="dashboard-group_title">
       <f.link disabled={!vm.canAdminister} href={paths.show} class="dashboard-group_name"
               aria-label={vm.label()}>{vm.name || "Pipelines not in any Environment"}</f.link>
       {vm.name && <f.link class="edit_config dashboard-group_edit-config" disabled={!vm.canAdminister} href={paths.edit}
                           tooltipText={vm.tooltipForEdit()} title={vm.titleForEdit()} aria-label={vm.ariaLabelForEdit()}/>}
+
+      {addPipeline}
     </div>;
   }
 };


### PR DESCRIPTION
#5715 

<img width="320" alt="screen shot 2019-02-19 at 11 57 44 pm" src="https://user-images.githubusercontent.com/4715748/53123138-3ade3980-350d-11e9-8941-d7ad6b5a6336.png">



Um, I don't know if there is a better way to show the add icon. 
cc @naveenbhaskar 