### PR TITLE
Expand the config repo panels that are in an error state

### DIFF
--- a/server/webapp/WEB-INF/rails/webpack/views/pages/config_repos/config_repos_widget.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/config_repos/config_repos_widget.tsx
@@ -50,7 +50,6 @@ export interface Attrs<T> extends Operations<T>, RequiresPluginInfos {
 
 interface ShowObjectAttrs<T> extends Operations<T>, RequiresPluginInfos {
   obj: T;
-  index: number;
 }
 
 interface HeaderWidgetAttrs extends RequiresPluginInfos {
@@ -198,7 +197,7 @@ class ConfigRepoWidget extends MithrilViewComponent<ShowObjectAttrs<ConfigRepo>>
       <CollapsiblePanel error={!!configRepoHasErrors}
                         header={<HeaderWidget repo={vnode.attrs.obj} pluginInfos={vnode.attrs.pluginInfos}/>}
                         dataTestId={"config-repo-details-panel"}
-                        actions={actionButtons} expanded={vnode.attrs.index === 0}>
+                        actions={actionButtons} expanded={!!configRepoHasErrors}>
         {maybeWarning}
         {this.latestModificationDetails(parseInfo)}
         {this.lastGoodModificationDetails(parseInfo)}
@@ -303,12 +302,11 @@ export class ConfigReposWidget extends MithrilViewComponent<Attrs<ConfigRepo>> {
 
     return (
       <div>
-        {configRepos.map((configRepo, index) => {
+        {configRepos.map((configRepo) => {
           return (
             <ConfigRepoWidget key={configRepo.id()}
                               obj={configRepo}
                               pluginInfos={vnode.attrs.pluginInfos}
-                              index={index}
                               onEdit={(configRepo, e) => vnode.attrs.onEdit(configRepo, e)}
                               onRefresh={(configRepo, e) => vnode.attrs.onRefresh(configRepo, e)}
                               onDelete={(configRepo, e) => vnode.attrs.onDelete(configRepo, e)}

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/config_repos/spec/config_repos_widget_spec.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/config_repos/spec/config_repos_widget_spec.tsx
@@ -261,13 +261,29 @@ describe("ConfigReposWidget", () => {
     expect(find("repo-update-in-progress-icon")).toHaveClass(styles.configRepoUpdateInProgress);
   });
 
-  it("should render red top border to indicate error in config repo parsing", () => {
+  it("should render red top border and expand the widget to indicate error in config repo parsing", () => {
     const repo = createConfigRepo();
     configRepos([repo]);
     pluginInfos([configRepoPluginInfo()]);
     m.redraw();
-    expect(find("config-repo-details-panel")).toBeInDOM();
-    expect(find("config-repo-details-panel")).toHaveClass(collapsiblePanelStyles.error);
+    const detailsPanel = find("config-repo-details-panel");
+    expect(detailsPanel).toBeInDOM();
+    expect(detailsPanel).toHaveClass(collapsiblePanelStyles.error);
+    expect(detailsPanel).toHaveAttr("data-test-element-state", "expanded");
+  });
+
+  it("should not render top border and keep the widget collapsed when there is no error", () => {
+    const repo = createConfigRepo({});
+    if (repo.lastParse()) {
+      repo.lastParse()!.error(null);
+    }
+    configRepos([repo]);
+    pluginInfos([configRepoPluginInfo()]);
+    m.redraw();
+    const detailsPanel = find("config-repo-details-panel");
+    expect(detailsPanel).toBeInDOM();
+    expect(detailsPanel).not.toHaveClass(collapsiblePanelStyles.error);
+    expect(detailsPanel).toHaveAttr("data-test-element-state", "collapsed");
   });
 
   it("should callback the delete function when delete button is clicked", () => {


### PR DESCRIPTION
(a.k.a Smart Expand)

![2ubx5q](https://user-images.githubusercontent.com/6024038/53235424-c693c980-36b7-11e9-8899-9d830b9afb37.jpg)
