### PR TITLE
Add an Id validator and use it in Config Repo SPA

### DIFF
--- a/server/webapp/WEB-INF/rails/webpack/models/config_repos/types.ts
+++ b/server/webapp/WEB-INF/rails/webpack/models/config_repos/types.ts
@@ -106,6 +106,7 @@ export class ConfigRepo implements ValidatableMixin {
     }
     ValidatableMixin.call(this);
     this.validatePresenceOf("id");
+    this.validateIdFormat("id");
     this.validatePresenceOf("pluginId");
     this.validateAssociated("material");
   }

--- a/server/webapp/WEB-INF/rails/webpack/models/mixins/new_validatable_mixin.ts
+++ b/server/webapp/WEB-INF/rails/webpack/models/mixins/new_validatable_mixin.ts
@@ -197,6 +197,17 @@ export class ValidatableMixin {
     this.validateWith(new UrlPatternValidator(options), attr);
   }
 
+  validateIdFormat(attr: string, options?: ValidatorOptions): void {
+    const defaultMessage = `Invalid ${attr}. This must be alphanumeric and can contain underscores and periods (however, it cannot start with a period). The maximum allowed length is 255 characters.`;
+    if (!options) {
+      options = {message: defaultMessage};
+    }
+    if (!options.message) {
+      options.message = defaultMessage;
+    }
+    this.validateFormatOf(attr, /^[-a-zA-Z0-9_][-a-zA-Z0-9_.]*$/, options);
+  }
+
   validateMaxLength(attr: string, maxAllowedLength: number, options?: ValidatorOptions) {
     this.validateWith(new MaxLengthValidator(maxAllowedLength, options), attr);
   }

--- a/server/webapp/WEB-INF/rails/webpack/models/mixins/new_validatable_mixin.ts
+++ b/server/webapp/WEB-INF/rails/webpack/models/mixins/new_validatable_mixin.ts
@@ -198,7 +198,7 @@ export class ValidatableMixin {
   }
 
   validateIdFormat(attr: string, options?: ValidatorOptions): void {
-    const defaultMessage = `Invalid ${attr}. This must be alphanumeric and can contain underscores and periods (however, it cannot start with a period). The maximum allowed length is 255 characters.`;
+    const defaultMessage = `Invalid ${attr}. This must be alphanumeric and can contain hyphens, underscores and periods (however, it cannot start with a period). The maximum allowed length is 255 characters.`;
     if (!options) {
       options = {message: defaultMessage};
     }

--- a/server/webapp/WEB-INF/rails/webpack/models/mixins/new_validatable_mixin.ts
+++ b/server/webapp/WEB-INF/rails/webpack/models/mixins/new_validatable_mixin.ts
@@ -205,7 +205,7 @@ export class ValidatableMixin {
     if (!options.message) {
       options.message = defaultMessage;
     }
-    this.validateFormatOf(attr, /^[-a-zA-Z0-9_][-a-zA-Z0-9_.]*$/, options);
+    this.validateFormatOf(attr, /(^[-a-zA-Z0-9_])([-a-zA-Z0-9_.]{0,254})$/, options);
   }
 
   validateMaxLength(attr: string, maxAllowedLength: number, options?: ValidatorOptions) {

--- a/server/webapp/WEB-INF/rails/webpack/models/mixins/new_validatable_mixin_spec.ts
+++ b/server/webapp/WEB-INF/rails/webpack/models/mixins/new_validatable_mixin_spec.ts
@@ -213,6 +213,57 @@ describe("Validatable", () => {
     });
   });
 
+  describe("validateIdFormat", () => {
+
+    it("should validate Id format", () => {
+      //tslint:disable-next-line
+      interface Material extends ValidatableMixin {
+      }
+
+      class Material implements ValidatableMixin {
+        id: Stream<string>;
+
+        constructor(id: string) {
+          ValidatableMixin.call(this);
+          this.id = stream(id);
+          this.validateIdFormat("id");
+        }
+      }
+
+      applyMixins(Material, ValidatableMixin);
+      const material = new Material("shaky salamander");
+
+      material.validate();
+
+      expect(material.errors().hasErrors()).toBe(true);
+      expect(material.errors().errors("id")).toEqual(["Invalid id. This must be alphanumeric and can contain underscores and periods (however, it cannot start with a period). The maximum allowed length is 255 characters."]);
+    });
+
+    it("should validate Id format using provided message", () => {
+      //tslint:disable-next-line
+      interface Material extends ValidatableMixin {
+      }
+
+      class Material implements ValidatableMixin {
+        id: Stream<string>;
+
+        constructor(id: string) {
+          ValidatableMixin.call(this);
+          this.id = stream(id);
+          this.validateIdFormat("id", {message: "Id is invalid"});
+        }
+      }
+
+      applyMixins(Material, ValidatableMixin);
+      const material = new Material("shaky salamander");
+
+      material.validate();
+
+      expect(material.errors().hasErrors()).toBe(true);
+      expect(material.errors().errors("id")).toEqual(["Id is invalid"]);
+    });
+  });
+
   describe("validateWith", () => {
     class CustomUrlValidator extends Validator {
       constructor(options?: ValidatorOptions) {
@@ -500,7 +551,7 @@ describe("Validatable", () => {
 
       constructor(key: string) {
         ValidatableMixin.call(this);
-        this.key    = stream(key);
+        this.key = stream(key);
         this.validateMaxLength("key", 10);
       }
     }
@@ -508,7 +559,7 @@ describe("Validatable", () => {
     applyMixins(Variable, ValidatableMixin);
 
     it("should validate max length of a given field", () => {
-      const var1      = new Variable("strGreaterThanTenChars");
+      const var1 = new Variable("strGreaterThanTenChars");
 
       var1.validate();
 
@@ -517,7 +568,7 @@ describe("Validatable", () => {
     });
 
     it("should skip validation if attribute is empty", () => {
-      const var1      = new Variable("");
+      const var1 = new Variable("");
 
       var1.validate();
 
@@ -525,7 +576,7 @@ describe("Validatable", () => {
     });
 
     it("should not give validation errors if field has valid length", () => {
-      const var1      = new Variable("foobarbaz");
+      const var1 = new Variable("foobarbaz");
 
       var1.validate();
 

--- a/server/webapp/WEB-INF/rails/webpack/models/mixins/new_validatable_mixin_spec.ts
+++ b/server/webapp/WEB-INF/rails/webpack/models/mixins/new_validatable_mixin_spec.ts
@@ -238,7 +238,7 @@ describe("Validatable", () => {
         material.validate();
         expect(material.errors().hasErrors()).toBe(true);
         expect(material.errors().errors("id"))
-          .toEqual(["Invalid id. This must be alphanumeric and can contain underscores and periods (however, it cannot start with a period). The maximum allowed length is 255 characters."]);
+          .toEqual(["Invalid id. This must be alphanumeric and can contain hyphens, underscores and periods (however, it cannot start with a period). The maximum allowed length is 255 characters."]);
       });
 
     });

--- a/server/webapp/WEB-INF/rails/webpack/models/mixins/new_validatable_mixin_spec.ts
+++ b/server/webapp/WEB-INF/rails/webpack/models/mixins/new_validatable_mixin_spec.ts
@@ -231,12 +231,16 @@ describe("Validatable", () => {
       }
 
       applyMixins(Material, ValidatableMixin);
-      const material = new Material("shaky salamander");
 
-      material.validate();
+      const badStrings = ["shaky salamander", ".hello", _.repeat("a", 256)];
+      badStrings.forEach((badString) => {
+        const material = new Material(badString);
+        material.validate();
+        expect(material.errors().hasErrors()).toBe(true);
+        expect(material.errors().errors("id"))
+          .toEqual(["Invalid id. This must be alphanumeric and can contain underscores and periods (however, it cannot start with a period). The maximum allowed length is 255 characters."]);
+      });
 
-      expect(material.errors().hasErrors()).toBe(true);
-      expect(material.errors().errors("id")).toEqual(["Invalid id. This must be alphanumeric and can contain underscores and periods (however, it cannot start with a period). The maximum allowed length is 255 characters."]);
     });
 
     it("should validate Id format using provided message", () => {


### PR DESCRIPTION
There was no client side validation and the server returns a 500 when the Id format is invalid, so the user was getting a cryptic error message.

@arvindsv, I've copied the error message from the older code and it's a bit long. Let me know if we want to change it - `Invalid ${attr}. This must be alphanumeric and can contain underscores and periods (however, it cannot start with a period). The maximum allowed length is 255 characters.`