### PR TITLE
Access token API fixes

### DIFF
--- a/api/api-access-token-v1/src/main/java/com/thoughtworks/go/apiv1/accessToken/AbstractUserAccessTokenControllerV1.java
+++ b/api/api-access-token-v1/src/main/java/com/thoughtworks/go/apiv1/accessToken/AbstractUserAccessTokenControllerV1.java
@@ -21,6 +21,7 @@ import com.thoughtworks.go.api.ApiVersion;
 import com.thoughtworks.go.api.representers.JsonReader;
 import com.thoughtworks.go.api.spring.ApiAuthenticationHelper;
 import com.thoughtworks.go.api.util.GsonTransformer;
+import com.thoughtworks.go.api.util.HaltApiResponses;
 import com.thoughtworks.go.api.util.MessageJson;
 import com.thoughtworks.go.apiv1.accessToken.representers.AccessTokenRepresenter;
 import com.thoughtworks.go.apiv1.accessToken.representers.AccessTokensRepresenter;
@@ -28,6 +29,8 @@ import com.thoughtworks.go.config.exceptions.ConflictException;
 import com.thoughtworks.go.config.exceptions.NotAuthorizedException;
 import com.thoughtworks.go.config.exceptions.RecordNotFoundException;
 import com.thoughtworks.go.domain.AccessToken;
+import com.thoughtworks.go.server.newsecurity.models.AuthenticationToken;
+import com.thoughtworks.go.server.newsecurity.utils.SessionUtils;
 import com.thoughtworks.go.server.service.AccessTokenService;
 import com.thoughtworks.go.spark.Routes;
 import com.thoughtworks.go.spark.spring.SparkSpringController;
@@ -86,5 +89,12 @@ abstract class AbstractUserAccessTokenControllerV1 extends ApiController impleme
             res.status(HttpStatus.CONFLICT.value());
             res.body(MessageJson.create(ex.getMessage()));
         });
+    }
+
+    void verifyRequestIsNotUsingAccessToken(Request request, Response response) {
+        AuthenticationToken<?> authenticationToken = SessionUtils.getAuthenticationToken(request.raw());
+        if (authenticationToken.isAccessTokenCredentials()) {
+            throw HaltApiResponses.haltBecauseForbidden("Unsupported operation: Accessing this API using access token is forbidden.");
+        }
     }
 }

--- a/api/api-access-token-v1/src/main/java/com/thoughtworks/go/apiv1/accessToken/AbstractUserAccessTokenControllerV1.java
+++ b/api/api-access-token-v1/src/main/java/com/thoughtworks/go/apiv1/accessToken/AbstractUserAccessTokenControllerV1.java
@@ -21,6 +21,7 @@ import com.thoughtworks.go.api.ApiVersion;
 import com.thoughtworks.go.api.representers.JsonReader;
 import com.thoughtworks.go.api.spring.ApiAuthenticationHelper;
 import com.thoughtworks.go.api.util.GsonTransformer;
+import com.thoughtworks.go.api.util.MessageJson;
 import com.thoughtworks.go.apiv1.accessToken.representers.AccessTokenRepresenter;
 import com.thoughtworks.go.apiv1.accessToken.representers.AccessTokensRepresenter;
 import com.thoughtworks.go.config.exceptions.ConflictException;
@@ -30,6 +31,7 @@ import com.thoughtworks.go.domain.AccessToken;
 import com.thoughtworks.go.server.service.AccessTokenService;
 import com.thoughtworks.go.spark.Routes;
 import com.thoughtworks.go.spark.spring.SparkSpringController;
+import org.springframework.http.HttpStatus;
 import spark.Request;
 import spark.Response;
 
@@ -80,6 +82,9 @@ abstract class AbstractUserAccessTokenControllerV1 extends ApiController impleme
     void addExceptionHandlers() {
         exception(RecordNotFoundException.class, this::notFound);
         exception(NotAuthorizedException.class, this::renderForbiddenResponse);
-        exception(ConflictException.class, this::renderForbiddenResponse);
+        exception(ConflictException.class, (ex, req, res) -> {
+            res.status(HttpStatus.CONFLICT.value());
+            res.body(MessageJson.create(ex.getMessage()));
+        });
     }
 }

--- a/api/api-access-token-v1/src/main/java/com/thoughtworks/go/apiv1/accessToken/AdminUserAccessTokenControllerV1.java
+++ b/api/api-access-token-v1/src/main/java/com/thoughtworks/go/apiv1/accessToken/AdminUserAccessTokenControllerV1.java
@@ -49,6 +49,9 @@ public class AdminUserAccessTokenControllerV1 extends AbstractUserAccessTokenCon
             before("", mimeType, this.apiAuthenticationHelper::ensureSecurityEnabled);
             before("/*", mimeType, this.apiAuthenticationHelper::ensureSecurityEnabled);
 
+            before("", mimeType, this::verifyRequestIsNotUsingAccessToken);
+            before("/*", mimeType, this::verifyRequestIsNotUsingAccessToken);
+
             before("", mimeType, this.apiAuthenticationHelper::checkAdminUserAnd403);
             before("/*", mimeType, this.apiAuthenticationHelper::checkAdminUserAnd403);
 

--- a/api/api-access-token-v1/src/main/java/com/thoughtworks/go/apiv1/accessToken/CurrentUserAccessTokenControllerV1.java
+++ b/api/api-access-token-v1/src/main/java/com/thoughtworks/go/apiv1/accessToken/CurrentUserAccessTokenControllerV1.java
@@ -85,7 +85,7 @@ public class CurrentUserAccessTokenControllerV1 extends AbstractUserAccessTokenC
 
         final JsonReader reader = GsonTransformer.getInstance().jsonReaderFrom(request.body());
 
-        String tokenDescription = reader.optString("description").orElse(null);
+        String tokenDescription = reader.getString("description");
 
         AccessToken created = accessTokenService.create(tokenDescription, currentUsernameString(), currentUserAuthConfigId(request));
 

--- a/api/api-access-token-v1/src/main/java/com/thoughtworks/go/apiv1/accessToken/CurrentUserAccessTokenControllerV1.java
+++ b/api/api-access-token-v1/src/main/java/com/thoughtworks/go/apiv1/accessToken/CurrentUserAccessTokenControllerV1.java
@@ -63,6 +63,9 @@ public class CurrentUserAccessTokenControllerV1 extends AbstractUserAccessTokenC
             before("", mimeType, this.apiAuthenticationHelper::ensureSecurityEnabled);
             before("/*", mimeType, this.apiAuthenticationHelper::ensureSecurityEnabled);
 
+            before("", mimeType, this::verifyRequestIsNotUsingAccessToken);
+            before("/*", mimeType, this::verifyRequestIsNotUsingAccessToken);
+
             before("", mimeType, this.apiAuthenticationHelper::checkUserAnd403);
             before("/*", mimeType, this.apiAuthenticationHelper::checkUserAnd403);
 

--- a/api/api-access-token-v1/src/test/groovy/com/thoughtworks/go/apiv1/accessToken/AdminUserAccessTokenControllerV1Test.groovy
+++ b/api/api-access-token-v1/src/test/groovy/com/thoughtworks/go/apiv1/accessToken/AdminUserAccessTokenControllerV1Test.groovy
@@ -17,6 +17,7 @@
 package com.thoughtworks.go.apiv1.accessToken
 
 import com.thoughtworks.go.api.SecurityTestTrait
+import com.thoughtworks.go.api.mocks.MockHttpServletResponseAssert
 import com.thoughtworks.go.api.spring.ApiAuthenticationHelper
 import com.thoughtworks.go.api.util.HaltApiMessages
 import com.thoughtworks.go.apiv1.accessToken.representers.AccessTokenRepresenter
@@ -24,21 +25,34 @@ import com.thoughtworks.go.apiv1.accessToken.representers.AccessTokensRepresente
 import com.thoughtworks.go.config.exceptions.RecordNotFoundException
 import com.thoughtworks.go.config.exceptions.UnprocessableEntityException
 import com.thoughtworks.go.domain.AccessToken
+import com.thoughtworks.go.http.mocks.HttpRequestBuilder
+import com.thoughtworks.go.http.mocks.MockHttpServletResponse
+import com.thoughtworks.go.server.newsecurity.models.AccessTokenCredential
+import com.thoughtworks.go.server.newsecurity.models.AuthenticationToken
+import com.thoughtworks.go.server.newsecurity.utils.SessionUtils
 import com.thoughtworks.go.server.service.AccessTokenService
 import com.thoughtworks.go.spark.AdminUserOnlyIfSecurityEnabled
 import com.thoughtworks.go.spark.ControllerTrait
 import com.thoughtworks.go.spark.SecurityServiceTrait
+import com.thoughtworks.go.spark.mocks.TestApplication
+import com.thoughtworks.go.spark.mocks.TestSparkPreFilter
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
 import org.mockito.Mock
+import spark.servlet.SparkFilter
+
+import javax.servlet.FilterConfig
+import java.util.stream.Stream
 
 import static com.thoughtworks.go.api.base.JsonUtils.toObjectString
 import static com.thoughtworks.go.apiv1.accessToken.representers.AccessTokenRepresenterTest.randomAccessToken
 import static org.mockito.ArgumentMatchers.any
 import static org.mockito.ArgumentMatchers.eq
-import static org.mockito.Mockito.when
-import static org.mockito.Mockito.verify
+import static org.mockito.Mockito.*
 import static org.mockito.MockitoAnnotations.initMocks
 
 class AdminUserAccessTokenControllerV1Test implements ControllerTrait<AdminUserAccessTokenControllerV1>, SecurityServiceTrait {
@@ -53,6 +67,49 @@ class AdminUserAccessTokenControllerV1Test implements ControllerTrait<AdminUserA
   @Override
   AdminUserAccessTokenControllerV1 createControllerInstance() {
     return new AdminUserAccessTokenControllerV1(new ApiAuthenticationHelper(securityService, goConfigService), accessTokenService)
+  }
+
+
+  @Nested
+  class APIAccessUsingAccessToken {
+    private preFilter
+    private authenticationToken
+
+    @BeforeEach
+    void setUp() {
+      enableSecurity()
+      def filterConfig = mock(FilterConfig.class)
+      when(filterConfig.getInitParameter(SparkFilter.APPLICATION_CLASS_PARAM)).thenReturn(TestApplication.class.getName())
+      preFilter = new TestSparkPreFilter(new TestApplication(getController()))
+      this.preFilter.init(filterConfig)
+      this.authenticationToken = new AuthenticationToken<>(null, new AccessTokenCredential(null), null, 0, null)
+    }
+
+    @ParameterizedTest
+    @MethodSource("allRequests")
+    void 'should return 409 when called with another access token'(String method, String path) {
+      def request = new HttpRequestBuilder()
+        .withMethod(method)
+        .withPath(getController()
+        .controllerPath(path))
+        .build()
+      SessionUtils.setAuthenticationTokenAfterRecreatingSession(authenticationToken, request)
+      def response = new MockHttpServletResponse()
+
+      preFilter.doFilter(request, response, null)
+
+      MockHttpServletResponseAssert.assertThat(response)
+        .isForbidden()
+        .hasJsonMessage("Unsupported operation: Accessing this API using access token is forbidden.")
+    }
+
+    static Stream<Arguments> allRequests() {
+      return Stream.of(
+        Arguments.of("GET", ""),
+        Arguments.of("GET", "some-id"),
+        Arguments.of("POST", "some-id/revoke")
+      )
+    }
   }
 
   @Nested

--- a/api/api-access-token-v1/src/test/groovy/com/thoughtworks/go/apiv1/accessToken/CurrentUserAccessTokenControllerV1Test.groovy
+++ b/api/api-access-token-v1/src/test/groovy/com/thoughtworks/go/apiv1/accessToken/CurrentUserAccessTokenControllerV1Test.groovy
@@ -17,6 +17,7 @@
 package com.thoughtworks.go.apiv1.accessToken
 
 import com.thoughtworks.go.api.SecurityTestTrait
+import com.thoughtworks.go.api.mocks.MockHttpServletResponseAssert
 import com.thoughtworks.go.api.spring.ApiAuthenticationHelper
 import com.thoughtworks.go.api.util.HaltApiMessages
 import com.thoughtworks.go.apiv1.accessToken.representers.AccessTokenRepresenter
@@ -26,23 +27,36 @@ import com.thoughtworks.go.config.exceptions.RecordNotFoundException
 import com.thoughtworks.go.config.exceptions.UnprocessableEntityException
 import com.thoughtworks.go.domain.AccessToken
 import com.thoughtworks.go.domain.packagerepository.ConfigurationPropertyMother
+import com.thoughtworks.go.http.mocks.HttpRequestBuilder
+import com.thoughtworks.go.http.mocks.MockHttpServletResponse
 import com.thoughtworks.go.plugin.access.authorization.AuthorizationExtension
+import com.thoughtworks.go.server.newsecurity.models.AccessTokenCredential
+import com.thoughtworks.go.server.newsecurity.models.AuthenticationToken
+import com.thoughtworks.go.server.newsecurity.utils.SessionUtils
 import com.thoughtworks.go.server.service.AccessTokenService
 import com.thoughtworks.go.server.service.SecurityAuthConfigService
 import com.thoughtworks.go.spark.ControllerTrait
 import com.thoughtworks.go.spark.NormalUserOnlyIfSecurityEnabled
 import com.thoughtworks.go.spark.SecurityServiceTrait
+import com.thoughtworks.go.spark.mocks.TestApplication
+import com.thoughtworks.go.spark.mocks.TestSparkPreFilter
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
 import org.mockito.Mock
+import spark.servlet.SparkFilter
+
+import javax.servlet.FilterConfig
+import java.util.stream.Stream
 
 import static com.thoughtworks.go.api.base.JsonUtils.toObjectString
 import static com.thoughtworks.go.apiv1.accessToken.representers.AccessTokenRepresenterTest.randomAccessToken
 import static org.mockito.ArgumentMatchers.any
 import static org.mockito.ArgumentMatchers.eq
-import static org.mockito.Mockito.verify
-import static org.mockito.Mockito.when
+import static org.mockito.Mockito.*
 import static org.mockito.MockitoAnnotations.initMocks
 
 class CurrentUserAccessTokenControllerV1Test implements ControllerTrait<CurrentUserAccessTokenControllerV1>, SecurityServiceTrait {
@@ -61,6 +75,49 @@ class CurrentUserAccessTokenControllerV1Test implements ControllerTrait<CurrentU
   @Override
   CurrentUserAccessTokenControllerV1 createControllerInstance() {
     return new CurrentUserAccessTokenControllerV1(new ApiAuthenticationHelper(securityService, goConfigService), accessTokenService, authConfigService, extension)
+  }
+
+  @Nested
+  class APIAccessUsingAccessToken {
+    private preFilter
+    private authenticationToken
+
+    @BeforeEach
+    void setUp() {
+      enableSecurity()
+      def filterConfig = mock(FilterConfig.class)
+      when(filterConfig.getInitParameter(SparkFilter.APPLICATION_CLASS_PARAM)).thenReturn(TestApplication.class.getName())
+      preFilter = new TestSparkPreFilter(new TestApplication(getController()))
+      this.preFilter.init(filterConfig)
+      this.authenticationToken = new AuthenticationToken<>(null, new AccessTokenCredential(null), null, 0, null)
+    }
+
+    @ParameterizedTest
+    @MethodSource("allRequests")
+    void 'should return 409 when called with another access token'(String method, String path) {
+      def request = new HttpRequestBuilder()
+        .withMethod(method)
+        .withPath(getController()
+        .controllerPath(path))
+        .build()
+      SessionUtils.setAuthenticationTokenAfterRecreatingSession(authenticationToken, request)
+      def response = new MockHttpServletResponse()
+
+      preFilter.doFilter(request, response, null)
+
+      MockHttpServletResponseAssert.assertThat(response)
+        .isForbidden()
+        .hasJsonMessage("Unsupported operation: Accessing this API using access token is forbidden.")
+    }
+
+    static Stream<Arguments> allRequests() {
+      return Stream.of(
+        Arguments.of("GET", ""),
+        Arguments.of("POST", ""),
+        Arguments.of("GET", "some-id"),
+        Arguments.of("POST", "some-id/revoke")
+      )
+    }
   }
 
   @Nested

--- a/api/api-access-token-v1/src/test/groovy/com/thoughtworks/go/apiv1/accessToken/CurrentUserAccessTokenControllerV1Test.groovy
+++ b/api/api-access-token-v1/src/test/groovy/com/thoughtworks/go/apiv1/accessToken/CurrentUserAccessTokenControllerV1Test.groovy
@@ -177,7 +177,7 @@ class CurrentUserAccessTokenControllerV1Test implements ControllerTrait<CurrentU
       }
 
       @Test
-      void 'should create a new access token without providing token description'() {
+      void 'should not create a new access token without providing token description'() {
         token.description = null
         when(accessTokenService.create(eq(token.description), eq(currentUsernameString()), eq(authConfigId))).thenReturn(token)
 
@@ -188,9 +188,9 @@ class CurrentUserAccessTokenControllerV1Test implements ControllerTrait<CurrentU
         postWithApiHeader(controller.controllerPath(), requestBody)
 
         assertThatResponse()
-          .isOk()
+          .isUnprocessableEntity()
           .hasContentType(controller.mimeType)
-          .hasBody(toObjectString({ AccessTokenRepresenter.toJSON(it, controller.urlContext(), token) }))
+          .hasJsonMessage("Json `{}` does not contain property 'description'")
       }
 
       @Test

--- a/api/api-base/src/main/java/com/thoughtworks/go/api/util/HaltApiResponses.java
+++ b/api/api-base/src/main/java/com/thoughtworks/go/api/util/HaltApiResponses.java
@@ -41,6 +41,10 @@ public abstract class HaltApiResponses {
         return halt(HttpStatus.FORBIDDEN.value(), MessageJson.create(forbiddenMessage()));
     }
 
+    public static HaltException haltBecauseForbidden(String message) {
+        return halt(HttpStatus.FORBIDDEN.value(), MessageJson.create(message));
+    }
+
     public static HaltException haltBecauseEntityAlreadyExists(Consumer<OutputWriter> jsonInRequestBody, String entityType, Object existingName) {
         return halt(HttpStatus.UNPROCESSABLE_ENTITY.value(), MessageJson.create(entityAlreadyExistsMessage(entityType, existingName), jsonInRequestBody));
     }

--- a/server/src/main/java/com/thoughtworks/go/server/newsecurity/models/AuthenticationToken.java
+++ b/server/src/main/java/com/thoughtworks/go/server/newsecurity/models/AuthenticationToken.java
@@ -73,6 +73,10 @@ public class AuthenticationToken<T extends Credentials> {
         return credentials instanceof UsernamePassword;
     }
 
+    public boolean isAccessTokenCredentials() {
+        return credentials instanceof AccessTokenCredential;
+    }
+
     private boolean isExpired(Clock clock, SystemEnvironment systemEnvironment) {
         return systemEnvironment.isReAuthenticationEnabled() &&
                 (clock.currentTimeMillis() - authenticatedAt) > systemEnvironment.getReAuthenticationTimeInterval();


### PR DESCRIPTION
### Summary

1. Returning CONFLICT (409) on revoke access token api when the token in question has already been revoked. 
Note: This needs to be updated in #5869 
2. Made `description` property mandatory in create access token API - in case description is not provided, 422 status is received.
3. Fixed the issue wherein access token APIs were called using existing access tokens.

