### PR TITLE
/etc/init.d/go-agent stop stops the agent using pid from PID_FILE

### DIFF
--- a/installers/go-agent/release/go-agent.init
+++ b/installers/go-agent/release/go-agent.init
@@ -31,12 +31,11 @@ SERVICE_NAME=${0##*/}
 # Strips initV leading chars if the script is located in rcX.d (automatically executed on runlevel change)
 INIT_DIR=${0%/*}; echo ${INIT_DIR##*/} | grep -e '^rc[0-9]\.d$' >/dev/null && SERVICE_NAME=$(echo "${SERVICE_NAME}" | sed 's/^[SK][0-9][0-9]//');
 
-PID_FILE="/var/run/go-agent/${SERVICE_NAME}.pid"
 CUR_USER=$(whoami)
 
 # LSB implimentation is not standard across distros, so we have to roll our own...
 killproc() {
-    kill $(cat $PID_FILE) >/dev/null
+    eval "$@" >/dev/null
 }
 
 start_daemon() {
@@ -96,7 +95,7 @@ stop_go_agent() {
     check_proc
 
     if [ $? -eq 0 ]; then
-        killproc
+        killproc /usr/share/${SERVICE_NAME}/stop-agent.sh ${SERVICE_NAME} service_mode
 
         # Make sure it's dead before we return
         until [ $? -ne 0 ]; do

--- a/installers/go-agent/release/go-agent.init
+++ b/installers/go-agent/release/go-agent.init
@@ -1,6 +1,6 @@
 #!/bin/bash
 #*************************GO-LICENSE-START********************************
-# Copyright 2014 ThoughtWorks, Inc.
+# Copyright 2019 ThoughtWorks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -36,7 +36,7 @@ CUR_USER=$(whoami)
 
 # LSB implimentation is not standard across distros, so we have to roll our own...
 killproc() {
-    pkill -u go -f /usr/share/${SERVICE_NAME}/agent-bootstrapper.jar
+    kill $(cat $PID_FILE) >/dev/null
 }
 
 start_daemon() {
@@ -96,7 +96,7 @@ stop_go_agent() {
     check_proc
 
     if [ $? -eq 0 ]; then
-        killproc -p $PID_FILE /usr/share/${SERVICE_NAME}/agent.sh >/dev/null
+        killproc
 
         # Make sure it's dead before we return
         until [ $? -ne 0 ]; do

--- a/installers/go-agent/release/go-agent.init
+++ b/installers/go-agent/release/go-agent.init
@@ -33,11 +33,6 @@ INIT_DIR=${0%/*}; echo ${INIT_DIR##*/} | grep -e '^rc[0-9]\.d$' >/dev/null && SE
 
 CUR_USER=$(whoami)
 
-# LSB implimentation is not standard across distros, so we have to roll our own...
-killproc() {
-    eval "$@" >/dev/null
-}
-
 start_daemon() {
     eval "$@"
 }
@@ -95,7 +90,7 @@ stop_go_agent() {
     check_proc
 
     if [ $? -eq 0 ]; then
-        killproc /usr/share/${SERVICE_NAME}/stop-agent.sh ${SERVICE_NAME} service_mode
+        /usr/share/${SERVICE_NAME}/stop-agent.sh ${SERVICE_NAME} service_mode
 
         # Make sure it's dead before we return
         until [ $? -ne 0 ]; do


### PR DESCRIPTION
see #5858 for details on the issue this addresses

I would have ideally used `pkill -u go -F $PID_FILE` but pkill on centos 6 does not have a supported way to use the pid file to stop a process. This approach should ideally work on all of the linux distros we support.

I'm also unsure why we were passing arguments we weren't using to `killproc` This line is the one I'm referring to [here](https://github.com/gocd/gocd/compare/master...ibnc:agent_linux_issue?expand=1#diff-48385395d62c8d5e49e9612b048e274dL99)