### PR TITLE
Revert "Made `description` property mandatory in create access token API

### DIFF
--- a/api/api-access-token-v1/src/main/java/com/thoughtworks/go/apiv1/accessToken/CurrentUserAccessTokenControllerV1.java
+++ b/api/api-access-token-v1/src/main/java/com/thoughtworks/go/apiv1/accessToken/CurrentUserAccessTokenControllerV1.java
@@ -88,7 +88,7 @@ public class CurrentUserAccessTokenControllerV1 extends AbstractUserAccessTokenC
 
         final JsonReader reader = GsonTransformer.getInstance().jsonReaderFrom(request.body());
 
-        String tokenDescription = reader.getString("description");
+        String tokenDescription = reader.optString("description").orElse(null);
 
         AccessToken created = accessTokenService.create(tokenDescription, currentUsernameString(), currentUserAuthConfigId(request));
 

--- a/api/api-access-token-v1/src/test/groovy/com/thoughtworks/go/apiv1/accessToken/CurrentUserAccessTokenControllerV1Test.groovy
+++ b/api/api-access-token-v1/src/test/groovy/com/thoughtworks/go/apiv1/accessToken/CurrentUserAccessTokenControllerV1Test.groovy
@@ -234,7 +234,7 @@ class CurrentUserAccessTokenControllerV1Test implements ControllerTrait<CurrentU
       }
 
       @Test
-      void 'should not create a new access token without providing token description'() {
+      void 'should create a new access token without providing token description'() {
         token.description = null
         when(accessTokenService.create(eq(token.description), eq(currentUsernameString()), eq(authConfigId))).thenReturn(token)
 
@@ -245,9 +245,9 @@ class CurrentUserAccessTokenControllerV1Test implements ControllerTrait<CurrentU
         postWithApiHeader(controller.controllerPath(), requestBody)
 
         assertThatResponse()
-          .isUnprocessableEntity()
+          .isOk()
           .hasContentType(controller.mimeType)
-          .hasJsonMessage("Json `{}` does not contain property 'description'")
+          .hasBody(toObjectString({ AccessTokenRepresenter.toJSON(it, controller.urlContext(), token) }))
       }
 
       @Test


### PR DESCRIPTION
This reverts commit 77528410fa6aa2d755230978024d209a6a7b5053.

Reverting as a model is already validating description on creation.

```bash
curl -v  -X POST "http://localhost:8153/go/api/current_user/access_tokens" \                                                                                                      
      -u 'admin:badger' \
      -H 'Accept: application/vnd.go.cd.v1+json' \
      -H 'Content-Type: application/json' -d '{
        "foo": "bar"
      }'

{
  "_links": {
    "doc": {
      "href": "https://api.gocd.org/19.2.0/#access-tokens"
    },
    "find": {
      "href": "http://localhost:8153/go/api/current_user/access_tokens/:id"
    }
  },
  "description": null,
  "username": "admin",
  "revoked": false,
  "revoke_cause": null,
  "revoked_by": null,
  "revoked_at": null,
  "created_at": "2019-02-25T08:45:18Z",
  "last_used_at": null,
  "errors": {
    "description": [
      "must not be blank"
    ]
  }
}
```