### PR TITLE
Dashboard - pipeline pause message fix

### DIFF
--- a/server/webapp/WEB-INF/rails/webpack/views/dashboard/pipeline_operations_widget.js.msx
+++ b/server/webapp/WEB-INF/rails/webpack/views/dashboard/pipeline_operations_widget.js.msx
@@ -193,9 +193,17 @@ const PipelineOperationsWidget = {
 
     let pipelinePauseMessage;
     if (pipeline.isPaused) {
-      const pausedAtLocalTime  = TimeFormatter.format(pipeline.pausedAt);
-      const pausedAtServerTime = TimeFormatter.formatInServerTime(pipeline.pausedAt);
-      pipelinePauseMessage = (<div className="pipeline_pause-message"><div>{pausedMessage}</div><div title={pausedAtServerTime}>on {pausedAtLocalTime}</div></div>);
+      let pausedTimeMsg;
+      if (pipeline.pausedAt) {
+        const pausedAtLocalTime  = TimeFormatter.format(pipeline.pausedAt);
+        const pausedAtServerTime = TimeFormatter.formatInServerTime(pipeline.pausedAt);
+        pausedTimeMsg            = <div title={pausedAtServerTime}>on {pausedAtLocalTime}</div>;
+      }
+      pipelinePauseMessage = (<div
+        className="pipeline_pause-message">
+        {pausedMessage}
+        {pausedTimeMsg}
+      </div>);
     }
 
     return (


### PR DESCRIPTION
In case of a paused pipeline, if the pause time is not present - it won't get rendered