### PR TITLE
Elastic profile Fix

### DIFF
--- a/server/webapp/WEB-INF/rails/webpack/views/pages/elastic_profiles/modals.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/elastic_profiles/modals.tsx
@@ -224,7 +224,9 @@ export class CloneElasticProfileModal extends BaseElasticProfileModal {
       .then((result) => {
         result.do(
           (successResponse) => {
-            this.elasticProfile(successResponse.body.object);
+            const elasticProfile = successResponse.body.object;
+            elasticProfile.id("");
+            this.elasticProfile(elasticProfile);
           },
           (errorResponse) => this.onError(errorResponse.message)
         );


### PR DESCRIPTION
 - On cloning existing elastic profile, set `id` to blank string as `id` is unique so user needs to add it.