### PR TITLE
Admin Access Token API - minor fix

### DIFF
--- a/api/api-access-token-v1/src/main/java/com/thoughtworks/go/apiv1/accessToken/representers/AccessTokensRepresenter.java
+++ b/api/api-access-token-v1/src/main/java/com/thoughtworks/go/apiv1/accessToken/representers/AccessTokensRepresenter.java
@@ -25,7 +25,7 @@ import java.util.List;
 public class AccessTokensRepresenter {
     public static void toJSON(OutputWriter outputWriter, Routes.FindUrlBuilder<Long> urlBuilder, List<AccessToken> allTokens) {
         outputWriter.addLinks(outputLinkWriter -> outputLinkWriter
-                .addLink("self", Routes.CurrentUserAccessToken.BASE)
+                .addLink("self", urlBuilder.base())
                 .addAbsoluteLink("doc", urlBuilder.doc()))
                 .addChild("_embedded", embeddedWriter ->
                         embeddedWriter.addChildList("access_tokens", AccessTokenWriter -> {

--- a/api/api-access-token-v1/src/test/groovy/com/thoughtworks/go/apiv1/accessToken/representers/AccessTokensRepresenterTest.groovy
+++ b/api/api-access-token-v1/src/test/groovy/com/thoughtworks/go/apiv1/accessToken/representers/AccessTokensRepresenterTest.groovy
@@ -48,7 +48,7 @@ class AccessTokensRepresenterTest {
       "_embedded": [
         "access_tokens": [
           [
-            "_links"        : [
+            "_links"      : [
               "self": [
                 "href": "http://test.host/go/api/current_user/access_tokens/41"
               ],
@@ -59,18 +59,18 @@ class AccessTokensRepresenterTest {
                 "href": "http://test.host/go/api/current_user/access_tokens/:id"
               ]
             ],
-            "id"            : token1.id,
-            "description"   : token1.description,
-            "username"      : token1.username,
-            "revoked"       : token1.revoked,
-            "revoked_at"    : null,
-            "revoke_cause"  : null,
-            "revoked_by"    : null,
-            "created_at"    : jsonDate(token1.createdAt),
-            "last_used_at"  : null
+            "id"          : token1.id,
+            "description" : token1.description,
+            "username"    : token1.username,
+            "revoked"     : token1.revoked,
+            "revoked_at"  : null,
+            "revoke_cause": null,
+            "revoked_by"  : null,
+            "created_at"  : jsonDate(token1.createdAt),
+            "last_used_at": null
           ],
           [
-            "_links"        : [
+            "_links"      : [
               "self": [
                 "href": "http://test.host/go/api/current_user/access_tokens/42"
               ],
@@ -81,15 +81,63 @@ class AccessTokensRepresenterTest {
                 "href": "http://test.host/go/api/current_user/access_tokens/:id"
               ]
             ],
-            "id"            : token2.id,
-            "description"   : token2.description,
-            "username"      : token2.username,
-            "revoked"       : token2.revoked,
-            "revoked_at"    : null,
-            "revoke_cause"  : null,
-            "revoked_by"    : null,
-            "created_at"    : jsonDate(token2.createdAt),
-            "last_used_at"  : null
+            "id"          : token2.id,
+            "description" : token2.description,
+            "username"    : token2.username,
+            "revoked"     : token2.revoked,
+            "revoked_at"  : null,
+            "revoke_cause": null,
+            "revoked_by"  : null,
+            "created_at"  : jsonDate(token2.createdAt),
+            "last_used_at": null
+          ]
+        ]
+      ]
+    ]
+
+    assertThatJson(json).isEqualTo(expectedJSON)
+  }
+
+  @Test
+  void 'renders the access token for admin users without token value'() {
+    AccessToken.AccessTokenWithDisplayValue token1 = randomAccessToken(41, true)
+    def json = toObjectString({
+      AccessTokensRepresenter.toJSON(it, new Routes.AdminUserAccessToken(), [token1])
+    })
+
+    def expectedJSON = [
+      "_links"   : [
+        "self": [
+          "href": "http://test.host/go/api/admin/access_tokens"
+        ],
+        "doc" : [
+          "href": apiDocsUrl('#access-tokens')
+        ],
+      ],
+      "_embedded": [
+        "access_tokens": [
+          [
+            "_links"                      : [
+              "self": [
+                "href": "http://test.host/go/api/admin/access_tokens/41"
+              ],
+              "doc" : [
+                "href": apiDocsUrl('#access-tokens')
+              ],
+              "find": [
+                "href": "http://test.host/go/api/admin/access_tokens/:id"
+              ]
+            ],
+            "id"                          : token1.id,
+            "description"                 : token1.description,
+            "username"                    : token1.username,
+            "revoked"                     : token1.revoked,
+            "revoked_at"                  : null,
+            "revoke_cause"                : null,
+            "revoked_by"                  : null,
+            "created_at"                  : jsonDate(token1.createdAt),
+            "revoked_because_user_deleted": false,
+            "last_used_at"                : null
           ]
         ]
       ]

--- a/spark/spark-base/src/main/java/com/thoughtworks/go/spark/Routes.java
+++ b/spark/spark-base/src/main/java/com/thoughtworks/go/spark/Routes.java
@@ -440,6 +440,8 @@ public class Routes {
         String find(Identifier id);
 
         String doc();
+
+        String base();
     }
 
     public static class CurrentUserAccessToken implements FindUrlBuilder<Long> {
@@ -462,6 +464,11 @@ public class Routes {
         public String doc() {
             return DOC;
         }
+
+        @Override
+        public String base() {
+            return BASE;
+        }
     }
 
     public static class AdminUserAccessToken implements FindUrlBuilder<Long> {
@@ -483,6 +490,11 @@ public class Routes {
         @Override
         public String doc() {
             return DOC;
+        }
+
+        @Override
+        public String base() {
+            return BASE;
         }
     }
 


### PR DESCRIPTION
Bug: the fetch all access token for admin API was returning wrong `self` url.

```bash
curl 'http://localhost:8153/go/api/admin/access_tokens' \
      -u 'admin:badger' \
      -H 'Accept: application/vnd.go.cd.v1+json'

{
  "_links" : {
    "self" : {
      "href" : "http://localhost:8153/go/api/current_user/access_tokens"
    },
    "doc" : {
      "href" : "https://api.gocd.org/19.2.0/#access-tokens"
    }
  },
  "_embedded" : {
    "access_tokens" : [ ]
  }
}
```
Summary: Fixed the AccessTokensRepresenter to utlize the `base` method of `Routes.FindUrlBuilder`