### PR TITLE
Reparse failed config-repos on config update

### DIFF
--- a/server/src/main/java/com/thoughtworks/go/config/ConfigReposMaterialParseResultManager.java
+++ b/server/src/main/java/com/thoughtworks/go/config/ConfigReposMaterialParseResultManager.java
@@ -16,13 +16,10 @@
 
 package com.thoughtworks.go.config;
 
-/*  @description
- * Keeps track all config repo parsing states
- */
-
-
 import com.thoughtworks.go.config.remote.PartialConfig;
+import com.thoughtworks.go.domain.materials.MaterialConfig;
 import com.thoughtworks.go.domain.materials.Modification;
+import com.thoughtworks.go.listener.ConfigChangedListener;
 import com.thoughtworks.go.server.service.ConfigRepoService;
 import com.thoughtworks.go.serverhealth.HealthStateScope;
 import com.thoughtworks.go.serverhealth.ServerHealthService;
@@ -33,73 +30,82 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
+/**
+ * Tracks all config-repo parsing states
+ */
 public class ConfigReposMaterialParseResultManager {
     private Map<String, PartialConfigParseResult> fingerprintOfPartialToParseResultMap = new ConcurrentHashMap<>();
     private ServerHealthService serverHealthService;
     private ConfigRepoService configRepoService;
 
-    public ConfigReposMaterialParseResultManager(ServerHealthService serverHealthService, ConfigRepoService configRepoService) {
+    ConfigReposMaterialParseResultManager(ServerHealthService serverHealthService, ConfigRepoService configRepoService) {
         this.serverHealthService = serverHealthService;
         this.configRepoService = configRepoService;
     }
 
     public PartialConfigParseResult get(String fingerprint) {
         PartialConfigParseResult result = fingerprintOfPartialToParseResultMap.get(fingerprint);
+        // config repository was never parsed, check if there are any material clone or update related errors
         if (result == null) {
-            // config repository was never parsed, check if there are any material clone or update related errors
-            result = getMaterialResult(fingerprint);
+            result = checkForMaterialErrors(fingerprint);
         }
 
-        if (result !=null) {
-            //config repository was parsed, but does not have merge or clone related errors.
-
+        //config repository was parsed, but does not have merge or clone related errors.
+        if (result != null && result.isSuccessful()) {
             HealthStateScope healthStateScope = HealthStateScope.forPartialConfigRepo(fingerprint);
             List<ServerHealthState> serverHealthStates = serverHealthService.filterByScope(healthStateScope);
-            // It should be noted that the server health state and the result can be thought of as the following:
-            // serverHealthState is the current state
-            // result.isSuccessfully() is the state at the last parse
-
-            // here we're checking that the current state is bad, but the previous state was good
-            if (!serverHealthStates.isEmpty() && result.isSuccessful()) {
-                result.setException(represent(serverHealthStates.get(0)));
+            if (!serverHealthStates.isEmpty()) {
+                result.setException(asError(serverHealthStates.get(0)));
 
                 //clear out the good modification, in case good modification is same as of latest parsed modification
                 if (result.getLatestParsedModification().equals(result.getGoodModification())) {
                     result.setGoodModification(null);
                     result.setPartialConfig(null);
                 }
-            // here we're checking that the current state is good, but the previous state was bad
-            } else if (serverHealthStates.isEmpty() && !result.isSuccessful()) {
-                // The issues that caused the previous state to be bad are gone.
-                // An example would be that previously a upstream pipeline didn't exist, but now does
-                // Clearing latest parsed modification to allow for another parse attempt
-                result.setLatestParsedModification(null);
             }
         }
 
         return result;
     }
 
-    private PartialConfigParseResult getMaterialResult(String fingerprint) {
-        HealthStateScope healthStateScope = HealthStateScope.forMaterialConfig(configRepoService.findByFingerprint(fingerprint).getMaterialConfig());
+    /**
+     * After a successful update of the server config, we should reparse any failed config-repos in case
+     * any upstream dependency issues have been resolved.
+     *
+     * @return a listener that clears the last parse states and errors related to config-repos so as to allow reparsing
+     */
+    ConfigChangedListener onConfigUpdateDoReparse() {
+        return newCruiseConfig -> {
+            for (Map.Entry<String, PartialConfigParseResult> entry : fingerprintOfPartialToParseResultMap.entrySet()) {
+                String fingerprint = entry.getKey();
+                PartialConfigParseResult result = entry.getValue();
+
+                HealthStateScope scope = HealthStateScope.forPartialConfigRepo(fingerprint);
+                List<ServerHealthState> serverHealthErrors = serverHealthService.filterByScope(scope);
+
+                if (!serverHealthErrors.isEmpty() || !result.isSuccessful()) {
+                    result.setLatestParsedModification(null); // clear modification to allow a reparse to happen
+                    serverHealthService.removeByScope(scope); // clear errors until next reparse
+                }
+            }
+        };
+    }
+
+    private PartialConfigParseResult checkForMaterialErrors(String fingerprint) {
+        MaterialConfig naterial = configRepoService.findByFingerprint(fingerprint).getMaterialConfig();
+        HealthStateScope healthStateScope = HealthStateScope.forMaterialConfig(naterial);
         List<ServerHealthState> serverHealthStates = serverHealthService.filterByScope(healthStateScope);
-        if (!serverHealthStates.isEmpty()) {
-            return PartialConfigParseResult.parseFailed(null, represent(serverHealthStates.get(0)));
-        }
-        return null;
+
+        return serverHealthStates.isEmpty() ?
+                null :
+                PartialConfigParseResult.parseFailed(null, asError(serverHealthStates.get(0)));
     }
 
-    private Exception represent(ServerHealthState serverHealthState) {
-        String message = new StringBuilder()
-                .append(serverHealthState.getMessage().toUpperCase())
-                .append("\n")
-                .append(serverHealthState.getDescription())
-                .toString();
-
-        return new Exception(message);
+    private Exception asError(ServerHealthState serverHealthState) {
+        return new Exception(serverHealthState.getMessage().toUpperCase() + "\n" + serverHealthState.getDescription());
     }
 
-    public Set<String> allFingerprints() {
+    Set<String> allFingerprints() {
         return fingerprintOfPartialToParseResultMap.keySet();
     }
 
@@ -107,7 +113,7 @@ public class ConfigReposMaterialParseResultManager {
         fingerprintOfPartialToParseResultMap.remove(fingerprint);
     }
 
-    public PartialConfigParseResult parseFailed(String fingerprint, Modification modification, Exception exception) {
+    PartialConfigParseResult parseFailed(String fingerprint, Modification modification, Exception exception) {
         PartialConfigParseResult existingResult = get(fingerprint);
         if (existingResult == null) { //if no result exists in the map, create a new one
             return fingerprintOfPartialToParseResultMap.put(fingerprint, PartialConfigParseResult.parseFailed(modification, exception));
@@ -119,7 +125,7 @@ public class ConfigReposMaterialParseResultManager {
         }
     }
 
-    public PartialConfigParseResult parseSuccess(String fingerprint, Modification modification, PartialConfig newPart) {
+    PartialConfigParseResult parseSuccess(String fingerprint, Modification modification, PartialConfig newPart) {
         //if no result exists in the map, create a new one
         //if already a result exists in the map, override the result, as the latest modification is successful. regardless of the result being successful or failed
         return fingerprintOfPartialToParseResultMap.put(fingerprint, PartialConfigParseResult.parseSuccess(modification, newPart));

--- a/server/src/main/java/com/thoughtworks/go/config/ConfigReposMaterialParseResultManager.java
+++ b/server/src/main/java/com/thoughtworks/go/config/ConfigReposMaterialParseResultManager.java
@@ -16,11 +16,11 @@
 
 package com.thoughtworks.go.config;
 
-import com.thoughtworks.go.config.materials.ScmMaterialConfig;
 import com.thoughtworks.go.config.remote.ConfigRepoConfig;
 import com.thoughtworks.go.config.remote.PartialConfig;
 import com.thoughtworks.go.domain.materials.MaterialConfig;
 import com.thoughtworks.go.domain.materials.Modification;
+import com.thoughtworks.go.domain.scm.SCM;
 import com.thoughtworks.go.listener.ConfigChangedListener;
 import com.thoughtworks.go.listener.EntityConfigChangedListener;
 import com.thoughtworks.go.server.service.ConfigRepoService;
@@ -82,7 +82,7 @@ public class ConfigReposMaterialParseResultManager {
         configService.register(reparseOnPipelineConfigUpdate());
         configService.register(reparseOnEnvConfigUpdate());
         configService.register(reparseOnTemplateConfigUpdate());
-        configService.register(reparseOnScmConfigUpdate());
+        configService.register(reparseOnScmUpdate());
         configService.register(reparseOnConfigRepoConfigUpdate());
     }
 
@@ -117,10 +117,10 @@ public class ConfigReposMaterialParseResultManager {
         };
     }
 
-    EntityConfigChangedListener<ScmMaterialConfig> reparseOnScmConfigUpdate() {
-        return new EntityConfigChangedListener<ScmMaterialConfig>() {
+    EntityConfigChangedListener<SCM> reparseOnScmUpdate() {
+        return new EntityConfigChangedListener<SCM>() {
             @Override
-            public void onEntityConfigChange(ScmMaterialConfig entity) {
+            public void onEntityConfigChange(SCM entity) {
                 markFailedResultsForReparse();
             }
         };

--- a/server/src/main/java/com/thoughtworks/go/config/GoRepoConfigDataSource.java
+++ b/server/src/main/java/com/thoughtworks/go/config/GoRepoConfigDataSource.java
@@ -74,7 +74,7 @@ public class GoRepoConfigDataSource implements ChangedRepoConfigWatchListListene
                 onConfigRepoConfigChange(entity);
             }
         });
-        this.goConfigService.register(configReposMaterialParseResultManager.onConfigUpdateDoReparse());
+        configReposMaterialParseResultManager.attachConfigUpdateListeners(this.goConfigService);
     }
 
     public boolean hasListener(PartialConfigUpdateCompletedListener listener) {

--- a/server/src/main/java/com/thoughtworks/go/config/GoRepoConfigDataSource.java
+++ b/server/src/main/java/com/thoughtworks/go/config/GoRepoConfigDataSource.java
@@ -74,6 +74,7 @@ public class GoRepoConfigDataSource implements ChangedRepoConfigWatchListListene
                 onConfigRepoConfigChange(entity);
             }
         });
+        this.goConfigService.register(configReposMaterialParseResultManager.onConfigUpdateDoReparse());
     }
 
     public boolean hasListener(PartialConfigUpdateCompletedListener listener) {

--- a/server/src/test-fast/java/com/thoughtworks/go/config/ConfigReposMaterialParseResultManagerTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/config/ConfigReposMaterialParseResultManagerTest.java
@@ -60,7 +60,7 @@ class ConfigReposMaterialParseResultManagerTest {
     }
 
     @Test
-    void shouldClearLastModificationAndHealthErrorsOnConfigChanged() {
+    void markForReparseShouldClearLastModificationAndHealthErrors() {
         String fingerprint = "repo1";
         HealthStateScope scope = HealthStateScope.forPartialConfigRepo(fingerprint);
         ServerHealthState error = ServerHealthState.error("boom", "bang!", HealthStateType.general(scope));
@@ -78,7 +78,7 @@ class ConfigReposMaterialParseResultManagerTest {
         assertNotNull(result.getLatestParsedModification());
         assertEquals(modification, result.getLatestParsedModification());
 
-        manager.onConfigUpdateDoReparse().onConfigChange(null);
+        manager.markFailedResultsForReparse();
         assertNull(result.getLatestParsedModification());
         verify(serverHealthService, times(1)).removeByScope(scope);
     }

--- a/server/src/test-fast/java/com/thoughtworks/go/config/ConfigReposMaterialParseResultManagerTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/config/ConfigReposMaterialParseResultManagerTest.java
@@ -21,22 +21,28 @@ import com.thoughtworks.go.config.materials.git.GitMaterialConfig;
 import com.thoughtworks.go.config.remote.ConfigRepoConfig;
 import com.thoughtworks.go.config.remote.PartialConfig;
 import com.thoughtworks.go.domain.materials.Modification;
+import com.thoughtworks.go.domain.scm.SCM;
 import com.thoughtworks.go.helper.ModificationsMother;
+import com.thoughtworks.go.listener.ConfigChangedListener;
 import com.thoughtworks.go.server.service.ConfigRepoService;
+import com.thoughtworks.go.server.service.GoConfigService;
 import com.thoughtworks.go.serverhealth.HealthStateScope;
 import com.thoughtworks.go.serverhealth.HealthStateType;
 import com.thoughtworks.go.serverhealth.ServerHealthService;
 import com.thoughtworks.go.serverhealth.ServerHealthState;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 
 import java.util.Arrays;
 import java.util.Collections;
 
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.nullValue;
-import static org.junit.Assert.*;
+import static com.thoughtworks.go.config.ConfigReposMaterialParseResultManager.ConfigRepoReparseListener;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
@@ -48,6 +54,7 @@ class ConfigReposMaterialParseResultManagerTest {
 
     @Mock
     ConfigRepoService configRepoService;
+    private ConfigReposMaterialParseResultManager manager;
 
     @BeforeEach
     void setUp() {
@@ -57,6 +64,8 @@ class ConfigReposMaterialParseResultManagerTest {
         ScmMaterialConfig material = new GitMaterialConfig("http://my.git");
         ConfigRepoConfig configRepoConfig = new ConfigRepoConfig(material, "myplugin");
         when(configRepoService.findByFingerprint(anyString())).thenReturn(configRepoConfig);
+
+        manager = new ConfigReposMaterialParseResultManager(serverHealthService, configRepoService);
     }
 
     @Test
@@ -67,19 +76,19 @@ class ConfigReposMaterialParseResultManagerTest {
 
         when(serverHealthService.filterByScope(scope)).thenReturn(Collections.singletonList(error));
 
-        ConfigReposMaterialParseResultManager manager = new ConfigReposMaterialParseResultManager(serverHealthService, configRepoService);
+
         Modification modification = modificationFor("rev1");
         manager.parseFailed(fingerprint, modification, new Exception());
 
         PartialConfigParseResult result = manager.get(fingerprint);
 
-        assertNotNull(result);
-        assertFalse(result.isSuccessful());
-        assertNotNull(result.getLatestParsedModification());
-        assertEquals(modification, result.getLatestParsedModification());
+        assertThat(result).isNotNull();
+        assertThat(result.isSuccessful()).isFalse();
+        assertThat(result.getLatestParsedModification()).isNotNull();
+        assertThat(modification).isEqualTo(result.getLatestParsedModification());
 
         manager.markFailedResultsForReparse();
-        assertNull(result.getLatestParsedModification());
+        assertThat(result.getLatestParsedModification()).isNull();
         verify(serverHealthService, times(1)).removeByScope(scope);
     }
 
@@ -87,15 +96,15 @@ class ConfigReposMaterialParseResultManagerTest {
     void shouldAddResultForAConfigRepoMaterialUponSuccessfulParse() {
         String fingerprint = "repo1";
 
-        ConfigReposMaterialParseResultManager manager = new ConfigReposMaterialParseResultManager(serverHealthService, configRepoService);
+
         Modification modification = modificationFor("rev1");
         PartialConfig partialConfig = new PartialConfig();
         manager.parseSuccess(fingerprint, modification, partialConfig);
 
         PartialConfigParseResult expectedParseResult = PartialConfigParseResult.parseSuccess(modification, partialConfig);
 
-        assertThat(manager.get(fingerprint), is(expectedParseResult));
-        assertThat(manager.get(fingerprint).isSuccessful(), is(true));
+        assertThat(manager.get(fingerprint)).isEqualTo(expectedParseResult);
+        assertThat(manager.get(fingerprint).isSuccessful()).isTrue();
     }
 
     @Test
@@ -104,15 +113,15 @@ class ConfigReposMaterialParseResultManagerTest {
         when(serverHealthService.filterByScope(any())).thenReturn(Arrays.asList(serverHealthState));
         String fingerprint = "repo1";
 
-        ConfigReposMaterialParseResultManager manager = new ConfigReposMaterialParseResultManager(serverHealthService, configRepoService);
+
         Modification modification = modificationFor("rev1");
         PartialConfig partialConfig = new PartialConfig();
         manager.parseSuccess(fingerprint, modification, partialConfig);
 
         String expectedBeautifiedMessage = String.format("%s\n%s", serverHealthState.getMessage().toUpperCase(), serverHealthState.getDescription());
 
-        assertThat(manager.get(fingerprint).isSuccessful(), is(false));
-        assertThat(manager.get(fingerprint).getLastFailure().getMessage(), is(expectedBeautifiedMessage));
+        assertThat(manager.get(fingerprint).isSuccessful()).isFalse();
+        assertThat(manager.get(fingerprint).getLastFailure().getMessage()).isEqualTo(expectedBeautifiedMessage);
     }
 
     @Test
@@ -121,14 +130,14 @@ class ConfigReposMaterialParseResultManagerTest {
         when(serverHealthService.filterByScope(any())).thenReturn(Arrays.asList(serverHealthState));
         String fingerprint = "repo1";
 
-        ConfigReposMaterialParseResultManager manager = new ConfigReposMaterialParseResultManager(serverHealthService, configRepoService);
+
         Modification modification = modificationFor("rev1");
         PartialConfig partialConfig = new PartialConfig();
         manager.parseSuccess(fingerprint, modification, partialConfig);
 
-        assertThat(manager.get(fingerprint).isSuccessful(), is(false));
-        assertNull(manager.get(fingerprint).getGoodModification());
-        assertNull(manager.get(fingerprint).lastGoodPartialConfig());
+        assertThat(manager.get(fingerprint).isSuccessful()).isFalse();
+        assertThat(manager.get(fingerprint).getGoodModification()).isNull();
+        assertThat(manager.get(fingerprint).lastGoodPartialConfig()).isNull();
     }
 
     @Test
@@ -137,12 +146,11 @@ class ConfigReposMaterialParseResultManagerTest {
         when(serverHealthService.filterByScope(any())).thenReturn(Arrays.asList(serverHealthState));
         String fingerprint = "repo1";
 
-        ConfigReposMaterialParseResultManager manager = new ConfigReposMaterialParseResultManager(serverHealthService, configRepoService);
 
         String expectedBeautifiedMessage = String.format("%s\n%s", serverHealthState.getMessage().toUpperCase(), serverHealthState.getDescription());
 
-        assertThat(manager.get(fingerprint).isSuccessful(), is(false));
-        assertThat(manager.get(fingerprint).getLastFailure().getMessage(), is(expectedBeautifiedMessage));
+        assertThat(manager.get(fingerprint).isSuccessful()).isFalse();
+        assertThat(manager.get(fingerprint).getLastFailure().getMessage()).isEqualTo(expectedBeautifiedMessage);
     }
 
     @Test
@@ -151,50 +159,49 @@ class ConfigReposMaterialParseResultManagerTest {
         when(serverHealthService.filterByScope(any())).thenReturn(Arrays.asList(serverHealthState));
         String fingerprint = "repo1";
 
-        ConfigReposMaterialParseResultManager manager = new ConfigReposMaterialParseResultManager(serverHealthService, configRepoService);
 
-        assertThat(manager.get(fingerprint).isSuccessful(), is(false));
-        assertNull(manager.get(fingerprint).getGoodModification());
-        assertNull(manager.get(fingerprint).getLatestParsedModification());
-        assertNull(manager.get(fingerprint).lastGoodPartialConfig());
+        assertThat(manager.get(fingerprint).isSuccessful()).isFalse();
+        assertThat(manager.get(fingerprint).getGoodModification()).isNull();
+        assertThat(manager.get(fingerprint).getLatestParsedModification()).isNull();
+        assertThat(manager.get(fingerprint).lastGoodPartialConfig()).isNull();
     }
 
     @Test
     void shouldAddResultForAConfigRepoMaterialUponUnsuccessfulParse() {
         String fingerprint = "repo1";
 
-        ConfigReposMaterialParseResultManager manager = new ConfigReposMaterialParseResultManager(serverHealthService, configRepoService);
+
         Modification modification = modificationFor("rev1");
         Exception exception = new Exception("Boom!");
         manager.parseFailed(fingerprint, modification, exception);
 
         PartialConfigParseResult expectedParseResult = PartialConfigParseResult.parseFailed(modification, exception);
 
-        assertThat(manager.get(fingerprint), is(expectedParseResult));
-        assertThat(manager.get(fingerprint).isSuccessful(), is(false));
+        assertThat(manager.get(fingerprint)).isEqualTo(expectedParseResult);
+        assertThat(manager.get(fingerprint).isSuccessful()).isFalse();
     }
 
     @Test
     void shouldReturnNullIfManagerDoesNotContainResultForProvidedConfigRepoMaterialFingerprint() {
         String fingerprint = "repo1";
 
-        ConfigReposMaterialParseResultManager manager = new ConfigReposMaterialParseResultManager(serverHealthService, configRepoService);
-        assertThat(manager.get(fingerprint), is(nullValue()));
+
+        assertThat(manager.get(fingerprint)).isNull();
     }
 
     @Test
     void shouldUpdateTheResultForAConfigRepoMaterialIfResultAlreadyExists_WhenMaterialParseFails() {
         String fingerprint = "repo1";
 
-        ConfigReposMaterialParseResultManager manager = new ConfigReposMaterialParseResultManager(serverHealthService, configRepoService);
+
         Modification modification = modificationFor("rev1");
         PartialConfig partialConfig = new PartialConfig();
         manager.parseSuccess(fingerprint, modification, partialConfig);
 
         PartialConfigParseResult expectedParseResult = PartialConfigParseResult.parseSuccess(modification, partialConfig);
 
-        assertThat(manager.get(fingerprint), is(expectedParseResult));
-        assertThat(manager.get(fingerprint).isSuccessful(), is(true));
+        assertThat(manager.get(fingerprint)).isEqualTo(expectedParseResult);
+        assertThat(manager.get(fingerprint).isSuccessful()).isTrue();
 
         Modification modification2 = modificationFor("rev2");
         Exception exception = new Exception("Boom!");
@@ -203,26 +210,26 @@ class ConfigReposMaterialParseResultManagerTest {
 
         PartialConfigParseResult parseResult = manager.get(fingerprint);
 
-        assertThat(parseResult.isSuccessful(), is(false));
-        assertThat(parseResult.getLatestParsedModification(), is(modification2));
-        assertThat(parseResult.getGoodModification(), is(modification));
-        assertThat(parseResult.lastGoodPartialConfig(), is(partialConfig));
-        assertThat(parseResult.getLastFailure(), is(exception));
+        assertThat(parseResult.isSuccessful()).isFalse();
+        assertThat(parseResult.getLatestParsedModification()).isEqualTo(modification2);
+        assertThat(parseResult.getGoodModification()).isEqualTo(modification);
+        assertThat(parseResult.lastGoodPartialConfig()).isEqualTo(partialConfig);
+        assertThat(parseResult.getLastFailure()).isEqualTo(exception);
     }
 
     @Test
     void shouldUpdateTheResultForAConfigRepoMaterialIfResultAlreadyExists_WhenMaterialParseIsFixed() {
         String fingerprint = "repo1";
 
-        ConfigReposMaterialParseResultManager manager = new ConfigReposMaterialParseResultManager(serverHealthService, configRepoService);
+
         Modification modification = modificationFor("rev1");
         Exception exception = new Exception("Boom!");
         manager.parseFailed(fingerprint, modification, exception);
 
         PartialConfigParseResult expectedParseResult = PartialConfigParseResult.parseFailed(modification, exception);
 
-        assertThat(manager.get(fingerprint), is(expectedParseResult));
-        assertThat(manager.get(fingerprint).isSuccessful(), is(false));
+        assertThat(manager.get(fingerprint)).isEqualTo(expectedParseResult);
+        assertThat(manager.get(fingerprint).isSuccessful()).isFalse();
 
         Modification modification2 = modificationFor("rev2");
         PartialConfig partialConfig = new PartialConfig();
@@ -230,11 +237,43 @@ class ConfigReposMaterialParseResultManagerTest {
 
         PartialConfigParseResult parseResult = manager.get(fingerprint);
 
-        assertThat(parseResult.isSuccessful(), is(true));
-        assertThat(parseResult.getLatestParsedModification(), is(modification2));
-        assertThat(parseResult.getGoodModification(), is(modification2));
-        assertThat(parseResult.lastGoodPartialConfig(), is(partialConfig));
-        assertThat(parseResult.getLastFailure(), is(nullValue()));
+        assertThat(parseResult.isSuccessful()).isTrue();
+        assertThat(parseResult.getLatestParsedModification()).isEqualTo(modification2);
+        assertThat(parseResult.getGoodModification()).isEqualTo(modification2);
+        assertThat(parseResult.lastGoodPartialConfig()).isEqualTo(partialConfig);
+        assertThat(parseResult.getLastFailure()).isNull();
+    }
+
+    @Test
+    void shouldAddEntityConfigChangedListeners() {
+        final GoConfigService goConfigService = mock(GoConfigService.class);
+
+        manager.attachConfigUpdateListeners(goConfigService);
+
+        final ArgumentCaptor<ConfigChangedListener> listenerArgumentCaptor = ArgumentCaptor.forClass(ConfigChangedListener.class);
+        verify(goConfigService).register(listenerArgumentCaptor.capture());
+        assertThat(listenerArgumentCaptor.getValue()).isInstanceOf(ConfigRepoReparseListener.class);
+    }
+
+    @Nested
+    class ConfigRepoReparseListenerTest {
+        @ParameterizedTest
+        @ValueSource(classes = {PipelineConfig.class, EnvironmentConfig.class, PipelineTemplateConfig.class, SCM.class, ConfigRepoConfig.class})
+        void shouldCareAboutSpecifiedConfigClasses(Class<? extends Validatable> configClassToCareAbout) {
+            final ConfigReposMaterialParseResultManager manager = mock(ConfigReposMaterialParseResultManager.class);
+            final ConfigRepoReparseListener configRepoReparseListener = new ConfigRepoReparseListener(manager);
+
+            assertThat(configRepoReparseListener.shouldCareAbout(mock(configClassToCareAbout))).isTrue();
+        }
+
+        @ParameterizedTest
+        @ValueSource(classes = {Role.class, SecurityAuthConfig.class, AgentConfig.class})
+        void shouldNotCareAboutOtherConfigEntities(Class<? extends Validatable> configClassToCareAbout) {
+            final ConfigReposMaterialParseResultManager manager = mock(ConfigReposMaterialParseResultManager.class);
+            final ConfigRepoReparseListener configRepoReparseListener = new ConfigRepoReparseListener(manager);
+
+            assertThat(configRepoReparseListener.shouldCareAbout(mock(configClassToCareAbout))).isFalse();
+        }
     }
 
     private Modification modificationFor(String revision) {


### PR DESCRIPTION
  - Reverts changes to ConfigReposMaterialParseResultManager
    from https://github.com/gocd/gocd/pull/5843
  - This should resolve the issue where a config-repo is not
    reparsed after fixing a missing upstream pipeline (or similar
    missing dependency)
  - More reliable than consulting ServerHealthStates to determine
    when or whether to reparse
  - Also resolves issue noted in https://github.com/gocd/gocd/issues/5792#issuecomment-465845347

This essentially adds a ConfigChangedListener that clears the last parsed modification of a PartialConfigParseResult on config update. This allows the config repo to be reparsed.