### PR TITLE
#5858 - Use correct arg for checking service mode in stop-agent.sh

### DIFF
--- a/installers/go-agent/release/stop-agent.sh
+++ b/installers/go-agent/release/stop-agent.sh
@@ -28,7 +28,7 @@ AGENT_DIR=`(cd "$CWD" && pwd)`
 
 AGENT_WORK_DIR=${AGENT_WORK_DIR:-"$AGENT_DIR"}
 
-if [ "$1" == "service_mode" ] && [ -d "/var/run/go-agent" ]; then
+if [ "$2" == "service_mode" ] && [ -d "/var/run/go-agent" ]; then
   PID_FILE="/var/run/go-agent/${SERVICE_NAME}.pid"
 else
   PID_FILE="$AGENT_WORK_DIR/go-agent.pid"


### PR DESCRIPTION
Fix suggested by @adityasood in https://github.com/gocd/gocd/issues/5858#issuecomment-468706066.

Does not correct part 2 of that comment.