### PR TITLE
Dealing with check_proc output edge case

### DIFF
--- a/installers/go-agent/release/go-agent.init
+++ b/installers/go-agent/release/go-agent.init
@@ -64,7 +64,7 @@ start_go_agent() {
         exit 4
     fi
 
-    check_proc
+    check_proc &>/dev/null
     if [ $? -eq 0 ]; then
         log_success_msg "Go Agent already running."
         exit 0


### PR DESCRIPTION
This is in reference to a comment left by @rajiesh on #5942 

He described the specific issue:
> @ibnc Tested it on latest master it fixes the issue @adityasood had raised.
> 
> An observation, on a fresh installation of go-agent when user start agent like `/etc/init.d/go-agent start` below message is thrown. Think this is because of the `check_proc` is called once before agent startup [here](https://github.com/ibnc/gocd/blob/0c860c08534a39edd681ff38165d32b1976e153e/installers/go-agent/release/go-agent.init#L67) and pid file is not present
> 
> ```
> # /etc/init.d/go-agent start
> cat: /var/run/go-agent/go-agent.pid: No such file or directory
> error: list of process IDs must follow -p
> 
> Usage:
>  ps [options]
> 
>  Try 'ps --help <simple|list|output|threads|misc|all>'
>   or 'ps --help <s|l|o|t|m|a>'
>  for additional help text.
> 
> For more details see ps(1).
> Started Go Agent.
> ```

