### PR TITLE
Add previous and next version to version.json

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -116,6 +116,7 @@ def GO_VERSION_SEGMENTS = [
 ]
 def GO_VERSION = [GO_VERSION_SEGMENTS.year, GO_VERSION_SEGMENTS.releaseInYear, GO_VERSION_SEGMENTS.patch].join('.')
 def GO_VERSION_PREVIOUS = '19.2.0'
+def GO_VERSION_NEXT = '19.4.0'
 def DIST_VERSION = releaseRevision()
 def GIT_REVISION = gitRevision()
 
@@ -148,6 +149,7 @@ if (System.getenv().containsKey("GO_SERVER_URL")) {
 }
 
 rootProject.ext.previousVersion = GO_VERSION_PREVIOUS
+rootProject.ext.nextVersion = GO_VERSION_NEXT
 rootProject.ext.goVersionSegments = GO_VERSION_SEGMENTS
 rootProject.ext.goVersion = GO_VERSION
 rootProject.ext.distVersion = DIST_VERSION
@@ -1122,8 +1124,8 @@ task newApi {
       newProjects.sort().unique().each { out.println "include '${it}'" }
     }
 
-    file('.gitignore').withWriterAppend {out ->
-      ignoredFiles.each {line ->
+    file('.gitignore').withWriterAppend { out ->
+      ignoredFiles.each { line ->
         out.println(line)
       }
     }

--- a/installers/build.gradle
+++ b/installers/build.gradle
@@ -45,16 +45,18 @@ task versionFile {
     versionFile.getParentFile().mkdirs()
     versionFile.withWriter { out ->
       out.write(JsonOutput.prettyPrint(JsonOutput.toJson([
-          go_version      : rootProject.goVersion,
-          go_build_number : rootProject.distVersion,
-          go_full_version : rootProject.fullVersion,
-          git_sha         : rootProject.gitRevision,
-          pipeline_name   : System.getenv('GO_PIPELINE_NAME'),
-          pipeline_counter: System.getenv('GO_PIPELINE_COUNTER'),
-          pipeline_label  : System.getenv('GO_PIPELINE_LABEL'),
-          stage_name      : System.getenv('GO_STAGE_NAME'),
-          stage_counter   : System.getenv('GO_STAGE_COUNTER'),
-          job_name        : System.getenv('GO_JOB_NAME')
+        go_version         : rootProject.goVersion,
+        previous_go_version: rootProject.previousVersion,
+        next_go_version    : rootProject.nextVersion,
+        go_build_number    : rootProject.distVersion,
+        go_full_version    : rootProject.fullVersion,
+        git_sha            : rootProject.gitRevision,
+        pipeline_name      : System.getenv('GO_PIPELINE_NAME'),
+        pipeline_counter   : System.getenv('GO_PIPELINE_COUNTER'),
+        pipeline_label     : System.getenv('GO_PIPELINE_LABEL'),
+        stage_name         : System.getenv('GO_STAGE_NAME'),
+        stage_counter      : System.getenv('GO_STAGE_COUNTER'),
+        job_name           : System.getenv('GO_JOB_NAME')
       ])))
     }
   }


### PR DESCRIPTION
```console
$ cat installers/target/distributions/meta/version.json
{
    "go_version": "19.3.0",
    "previous_go_version": "19.2.0",
    "next_go_version": "19.4.0",
    "go_build_number": "8651",
    "go_full_version": "19.3.0-8651",
    "git_sha": "6d6ea20b4093156424d513793246ef6ea233486b",
    "pipeline_name": null,
    "pipeline_counter": null,
    "pipeline_label": null,
    "stage_name": null,
    "stage_counter": null,
    "job_name": null
}
```