### PR TITLE
[Environment Config API] Render secure environment variable value as encrypted value (#5956)

### DIFF
--- a/api/api-environments-v2/src/main/java/com/thoughtworks/go/apiv2/environments/representers/EnvironmentVariableRepresenter.java
+++ b/api/api-environments-v2/src/main/java/com/thoughtworks/go/apiv2/environments/representers/EnvironmentVariableRepresenter.java
@@ -41,9 +41,9 @@ public class EnvironmentVariableRepresenter {
 
     private static void addValue(OutputWriter outputWriter, EnvironmentVariableConfig environmentVariableConfig) {
         if (environmentVariableConfig.isSecure()) {
-            outputWriter.add("encrypted_value", environmentVariableConfig.getDisplayValue());
+            outputWriter.add("encrypted_value", environmentVariableConfig.getEncryptedValue());
         } else {
-            outputWriter.add("value", environmentVariableConfig.getDisplayValue());
+            outputWriter.add("value", environmentVariableConfig.getValue());
         }
     }
 }

--- a/api/api-environments-v2/src/test/groovy/com/thoughtworks/go/apiv2/environments/representers/EnvironmentVariableRepresenterTest.groovy
+++ b/api/api-environments-v2/src/test/groovy/com/thoughtworks/go/apiv2/environments/representers/EnvironmentVariableRepresenterTest.groovy
@@ -45,7 +45,7 @@ class EnvironmentVariableRepresenterTest {
     def json = toObjectString({ EnvironmentVariableRepresenter.toJSON(it, config) })
 
     assertThatJson(json).isEqualTo([
-      "encrypted_value": "****",
+      "encrypted_value": config.getEncryptedValue(),
       "name"           : "secret",
       "secure"         : true
     ])


### PR DESCRIPTION
* Render encrypted value instead of rendering display value of the env var.