### PR TITLE
Do not add Agent to Environment if it is already associated from a Config Repo

### DIFF
--- a/server/src/main/java/com/thoughtworks/go/config/update/AgentsEntityConfigUpdateCommand.java
+++ b/server/src/main/java/com/thoughtworks/go/config/update/AgentsEntityConfigUpdateCommand.java
@@ -25,19 +25,22 @@ import com.thoughtworks.go.config.exceptions.NoSuchEnvironmentException;
 import com.thoughtworks.go.domain.AgentInstance;
 import com.thoughtworks.go.server.domain.AgentInstances;
 import com.thoughtworks.go.server.domain.Username;
+import com.thoughtworks.go.server.service.EnvironmentConfigService;
 import com.thoughtworks.go.server.service.GoConfigService;
 import com.thoughtworks.go.server.service.result.LocalizedOperationResult;
 import com.thoughtworks.go.util.TriState;
 import com.thoughtworks.go.validation.AgentConfigsUpdateValidator;
 import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import static com.thoughtworks.go.i18n.LocalizedMessage.resourceNotFound;
 import static com.thoughtworks.go.i18n.LocalizedMessage.forbiddenToEdit;
+import static com.thoughtworks.go.i18n.LocalizedMessage.resourceNotFound;
 import static com.thoughtworks.go.serverhealth.HealthStateType.forbidden;
 
 public class AgentsEntityConfigUpdateCommand implements EntityConfigUpdateCommand<Agents> {
@@ -45,6 +48,7 @@ public class AgentsEntityConfigUpdateCommand implements EntityConfigUpdateComman
     private final Username username;
     private final LocalizedOperationResult result;
     private final List<String> uuids;
+    private final EnvironmentConfigService environmentConfigService;
     private final List<String> environmentsToAdd;
     private final List<String> environmentsToRemove;
     private final TriState state;
@@ -52,12 +56,19 @@ public class AgentsEntityConfigUpdateCommand implements EntityConfigUpdateComman
     private final List<String> resourcesToRemove;
     private GoConfigService goConfigService;
     public Agents agents;
+    private static final Logger LOGGER = LoggerFactory.getLogger(AgentsEntityConfigUpdateCommand.class);
 
-    public AgentsEntityConfigUpdateCommand(AgentInstances agentInstances, Username username, LocalizedOperationResult result, List<String> uuids, List<String> environmentsToAdd, List<String> environmentsToRemove, TriState state, List<String> resourcesToAdd, List<String> resourcesToRemove, GoConfigService goConfigService) {
+    public AgentsEntityConfigUpdateCommand(AgentInstances agentInstances, Username username, LocalizedOperationResult result,
+                                           List<String> uuids, EnvironmentConfigService environmentConfigService,
+                                           List<String> environmentsToAdd, List<String> environmentsToRemove,
+                                           TriState state,
+                                           List<String> resourcesToAdd, List<String> resourcesToRemove,
+                                           GoConfigService goConfigService) {
         this.agentInstances = agentInstances;
         this.username = username;
         this.result = result;
         this.uuids = uuids;
+        this.environmentConfigService = environmentConfigService;
         this.environmentsToAdd = environmentsToAdd;
         this.environmentsToRemove = environmentsToRemove;
         this.state = state;
@@ -118,7 +129,10 @@ public class AgentsEntityConfigUpdateCommand implements EntityConfigUpdateComman
 
             for (String environment : environmentsToAdd) {
                 EnvironmentConfig environmentConfig = modifiedConfig.getEnvironments().find(new CaseInsensitiveString(environment));
-                if (environmentConfig != null) {
+                if (environmentConfig == null || agentIsAssociatedInConfigRepo(environment, agentConfig.getUuid())) {
+                    LOGGER.debug("Not adding Agent %s to Environment %s. It is associated from a Config Repo (or the Environment is null)",
+                            agentConfig.getUuid(), environment);
+                } else {
                     environmentConfig.addAgentIfNew(agentConfig.getUuid());
                 }
             }
@@ -130,6 +144,10 @@ public class AgentsEntityConfigUpdateCommand implements EntityConfigUpdateComman
                 }
             }
         }
+    }
+
+    private boolean agentIsAssociatedInConfigRepo(String environment, String agentUuid) throws NoSuchEnvironmentException {
+        return environmentConfigService.getEnvironmentConfig(environment).containsAgentRemotely(agentUuid);
     }
 
     private void validatePresenceOfAgentUuidsInConfig() throws NoSuchAgentException {
@@ -211,7 +229,7 @@ public class AgentsEntityConfigUpdateCommand implements EntityConfigUpdateComman
             return;
         }
 
-        result.badRequest("Resources on elastic agents with uuids [" + StringUtils.join(elasticAgentUUIDs, ", ") + "] can not be updated." );
+        result.badRequest("Resources on elastic agents with uuids [" + StringUtils.join(elasticAgentUUIDs, ", ") + "] can not be updated.");
         throw new ElasticAgentsResourceUpdateException(elasticAgentUUIDs);
     }
 
@@ -231,7 +249,7 @@ public class AgentsEntityConfigUpdateCommand implements EntityConfigUpdateComman
         AgentConfigsUpdateValidator validator = new AgentConfigsUpdateValidator(uuids);
         boolean isValid = validator.isValid(preprocessedConfig);
         if (!isValid) {
-           result.unprocessableEntity("Validations failed for bulk update of agents. Error(s): " + agents.getAllErrors());
+            result.unprocessableEntity("Validations failed for bulk update of agents. Error(s): " + agents.getAllErrors());
         }
         return isValid;
     }

--- a/server/src/main/java/com/thoughtworks/go/server/service/AgentConfigService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/AgentConfigService.java
@@ -229,8 +229,14 @@ public class AgentConfigService {
         }
     }
 
-    public void bulkUpdateAgentAttributes(AgentInstances agentInstances, final Username username, final LocalizedOperationResult result, final List<String> uuids, final List<String> resourcesToAdd, final List<String> resourcesToRemove, final List<String> environmentsToAdd, final List<String> environmentsToRemove, final TriState enable) {
-        EntityConfigUpdateCommand<Agents> agentsEntityConfigUpdateCommand = new AgentsEntityConfigUpdateCommand(agentInstances, username, result, uuids, environmentsToAdd, environmentsToRemove, enable, resourcesToAdd, resourcesToRemove, goConfigService);
+    public void bulkUpdateAgentAttributes(AgentInstances agentInstances, final Username username, final LocalizedOperationResult result,
+                                          final List<String> uuids, EnvironmentConfigService environmentConfigService,
+                                          final List<String> resourcesToAdd, final List<String> resourcesToRemove,
+                                          final List<String> environmentsToAdd, final List<String> environmentsToRemove,
+                                          final TriState enable) {
+        EntityConfigUpdateCommand<Agents> agentsEntityConfigUpdateCommand = new AgentsEntityConfigUpdateCommand(agentInstances,
+                username, result, uuids, environmentConfigService, environmentsToAdd, environmentsToRemove, enable,
+                resourcesToAdd, resourcesToRemove, goConfigService);
         try {
             goConfigService.updateConfig(agentsEntityConfigUpdateCommand, username);
             if(result.isSuccessful()){

--- a/server/src/main/java/com/thoughtworks/go/server/service/AgentService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/AgentService.java
@@ -178,8 +178,12 @@ public class AgentService {
         return null;
     }
 
-    public void bulkUpdateAgentAttributes(Username username, LocalizedOperationResult result, List<String> uuids, List<String> resourcesToAdd, List<String> resourcesToRemove, List<String> environmentsToAdd, List<String> environmentsToRemove, TriState enable) {
-        agentConfigService.bulkUpdateAgentAttributes(agentInstances, username, result, uuids, resourcesToAdd, resourcesToRemove, environmentsToAdd, environmentsToRemove, enable);
+    public void bulkUpdateAgentAttributes(Username username, LocalizedOperationResult result, List<String> uuids,
+                                          List<String> resourcesToAdd, List<String> resourcesToRemove,
+                                          List<String> environmentsToAdd, List<String> environmentsToRemove,
+                                          TriState enable) {
+        agentConfigService.bulkUpdateAgentAttributes(agentInstances, username, result, uuids, environmentConfigService,
+                resourcesToAdd, resourcesToRemove, environmentsToAdd, environmentsToRemove, enable);
     }
 
     public void enableAgents(Username username, OperationResult operationResult, List<String> uuids) {

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/AgentConfigServiceIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/AgentConfigServiceIntegrationTest.java
@@ -24,6 +24,7 @@ import com.thoughtworks.go.i18n.LocalizedMessage;
 import com.thoughtworks.go.listener.AgentStatusChangeListener;
 import com.thoughtworks.go.server.domain.AgentInstances;
 import com.thoughtworks.go.server.domain.Username;
+import com.thoughtworks.go.server.service.EnvironmentConfigService;
 import com.thoughtworks.go.server.service.result.HttpLocalizedOperationResult;
 import com.thoughtworks.go.util.GoConfigFileHelper;
 import com.thoughtworks.go.util.ReflectionUtil;
@@ -58,6 +59,7 @@ public class AgentConfigServiceIntegrationTest {
     @Autowired private AgentConfigService agentConfigService;
     @Autowired private GoConfigDao goConfigDao;
     @Autowired private GoConfigService goConfigService;
+    @Autowired private EnvironmentConfigService environmentConfigService;
     private GoConfigFileHelper configHelper;
     private AgentInstances agentInstances;
 
@@ -239,7 +241,7 @@ public class AgentConfigServiceIntegrationTest {
         uuids.add(agentConfig1.getUuid());
         uuids.add(agentConfig2.getUuid());
 
-        agentConfigService.bulkUpdateAgentAttributes(agentInstances, Username.ANONYMOUS, result, uuids, new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), TriState.TRUE);
+        agentConfigService.bulkUpdateAgentAttributes(agentInstances, Username.ANONYMOUS, result, uuids, environmentConfigService, new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), TriState.TRUE);
 
         cruiseConfig = goConfigDao.load();
         assertTrue(result.isSuccessful());
@@ -258,7 +260,7 @@ public class AgentConfigServiceIntegrationTest {
         ArrayList<String> uuids = new ArrayList<>();
         uuids.add(pendingAgent.getUuid());
 
-        agentConfigService.bulkUpdateAgentAttributes(agentInstances, Username.ANONYMOUS, result, uuids, new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), TriState.TRUE);
+        agentConfigService.bulkUpdateAgentAttributes(agentInstances, Username.ANONYMOUS, result, uuids, environmentConfigService, new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), TriState.TRUE);
 
         assertTrue(result.isSuccessful());
         assertThat(result.message(), is("Updated agent(s) with uuid(s): [" + StringUtils.join(uuids, ", ") + "]."));
@@ -276,7 +278,7 @@ public class AgentConfigServiceIntegrationTest {
         ArrayList<String> uuids = new ArrayList<>();
         uuids.add(pendingAgent.getUuid());
 
-        agentConfigService.bulkUpdateAgentAttributes(agentInstances, Username.ANONYMOUS, result, uuids, new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), TriState.FALSE);
+        agentConfigService.bulkUpdateAgentAttributes(agentInstances, Username.ANONYMOUS, result, uuids, environmentConfigService, new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), TriState.FALSE);
 
         assertTrue(result.isSuccessful());
         assertThat(result.message(), is("Updated agent(s) with uuid(s): [" + StringUtils.join(uuids, ", ") + "]."));
@@ -300,7 +302,7 @@ public class AgentConfigServiceIntegrationTest {
         ArrayList<String> resourcesToRemove = new ArrayList<>();
         resourcesToRemove.add("Gauge");
 
-        agentConfigService.bulkUpdateAgentAttributes(agentInstances, Username.ANONYMOUS, result, uuids, resourcesToAdd, resourcesToRemove, new ArrayList<>(), new ArrayList<>(), TriState.UNSET);
+        agentConfigService.bulkUpdateAgentAttributes(agentInstances, Username.ANONYMOUS, result, uuids, environmentConfigService, resourcesToAdd, resourcesToRemove, new ArrayList<>(), new ArrayList<>(), TriState.UNSET);
 
         HttpLocalizedOperationResult expectedResult = new HttpLocalizedOperationResult();
         expectedResult.badRequest("Pending agents [" + pendingAgent.getUuid() + "] must be explicitly enabled or disabled when performing any operations on them.");
@@ -319,7 +321,7 @@ public class AgentConfigServiceIntegrationTest {
         uuids.add(pendingAgent.getUuid());
         uuids.add(registeredAgent.getUuid());
 
-        agentConfigService.bulkUpdateAgentAttributes(agentInstances, Username.ANONYMOUS, result, uuids, new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), TriState.UNSET);
+        agentConfigService.bulkUpdateAgentAttributes(agentInstances, Username.ANONYMOUS, result, uuids, environmentConfigService, new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), TriState.UNSET);
 
         HttpLocalizedOperationResult expectedResult = new HttpLocalizedOperationResult();
         expectedResult.badRequest("No Operation performed on agents.");
@@ -347,7 +349,7 @@ public class AgentConfigServiceIntegrationTest {
         uuids.add(pendingAgent.getUuid());
         uuids.add(agentConfig.getUuid());
 
-        agentConfigService.bulkUpdateAgentAttributes(agentInstances, Username.ANONYMOUS, result, uuids, new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), TriState.TRUE);
+        agentConfigService.bulkUpdateAgentAttributes(agentInstances, Username.ANONYMOUS, result, uuids, environmentConfigService, new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), TriState.TRUE);
 
         assertTrue(result.isSuccessful());
         assertThat(result.message(), is("Updated agent(s) with uuid(s): [" + StringUtils.join(uuids, ", ") + "]."));
@@ -377,7 +379,7 @@ public class AgentConfigServiceIntegrationTest {
         uuids.add(agentConfig1.getUuid());
         uuids.add(agentConfig2.getUuid());
 
-        agentConfigService.bulkUpdateAgentAttributes(agentInstances, Username.ANONYMOUS, result, uuids, new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), TriState.FALSE);
+        agentConfigService.bulkUpdateAgentAttributes(agentInstances, Username.ANONYMOUS, result, uuids, environmentConfigService, new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), TriState.FALSE);
 
         cruiseConfig = goConfigDao.load();
         assertTrue(result.isSuccessful());
@@ -408,7 +410,7 @@ public class AgentConfigServiceIntegrationTest {
         uuids.add(agentConfig2.getUuid());
         uuids.add("invalid-uuid");
 
-        agentConfigService.bulkUpdateAgentAttributes(agentInstances, Username.ANONYMOUS, result, uuids, new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), TriState.FALSE);
+        agentConfigService.bulkUpdateAgentAttributes(agentInstances, Username.ANONYMOUS, result, uuids, environmentConfigService, new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), TriState.FALSE);
 
         cruiseConfig = goConfigDao.load();
         assertFalse(cruiseConfig.agents().getAgentByUuid(agentConfig1.getUuid()).isDisabled());
@@ -434,7 +436,7 @@ public class AgentConfigServiceIntegrationTest {
         List<String> resourcesToAdd = Arrays.asList("resource");
 
         assertTrue(cruiseConfig.agents().getAgentByUuid(elasticAgent.getUuid()).getResourceConfigs().isEmpty());
-        agentConfigService.bulkUpdateAgentAttributes(agentInstances, Username.ANONYMOUS, result, uuids, resourcesToAdd, new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), TriState.FALSE);
+        agentConfigService.bulkUpdateAgentAttributes(agentInstances, Username.ANONYMOUS, result, uuids, environmentConfigService, resourcesToAdd, new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), TriState.FALSE);
         cruiseConfig = goConfigDao.load();
 
         HttpLocalizedOperationResult expectedResult = new HttpLocalizedOperationResult();
@@ -466,7 +468,7 @@ public class AgentConfigServiceIntegrationTest {
         uuids.add(agentConfig2.getUuid());
         uuids.add("invalid-uuid");
 
-        agentConfigService.bulkUpdateAgentAttributes(agentInstances, Username.ANONYMOUS, result, uuids, new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), TriState.TRUE);
+        agentConfigService.bulkUpdateAgentAttributes(agentInstances, Username.ANONYMOUS, result, uuids, environmentConfigService, new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), TriState.TRUE);
 
         cruiseConfig = goConfigDao.load();
         assertThat(cruiseConfig.agents().getAgentByUuid(agentConfig1.getUuid()).isDisabled(), is(false));
@@ -503,7 +505,7 @@ public class AgentConfigServiceIntegrationTest {
         resources.add("resource1");
         resources.add("resource2");
 
-        agentConfigService.bulkUpdateAgentAttributes(agentInstances, Username.ANONYMOUS, result, uuids, resources, new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), TriState.FALSE);
+        agentConfigService.bulkUpdateAgentAttributes(agentInstances, Username.ANONYMOUS, result, uuids, environmentConfigService, resources, new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), TriState.FALSE);
 
         cruiseConfig = goConfigDao.load();
 
@@ -542,7 +544,7 @@ public class AgentConfigServiceIntegrationTest {
         ArrayList<String> resources = new ArrayList<>();
         resources.add("resource-2");
 
-        agentConfigService.bulkUpdateAgentAttributes(agentInstances, Username.ANONYMOUS, result, uuids, new ArrayList<>(), resources, new ArrayList<>(), new ArrayList<>(), TriState.FALSE);
+        agentConfigService.bulkUpdateAgentAttributes(agentInstances, Username.ANONYMOUS, result, uuids, environmentConfigService, new ArrayList<>(), resources, new ArrayList<>(), new ArrayList<>(), TriState.FALSE);
 
         cruiseConfig = goConfigDao.load();
 
@@ -580,7 +582,7 @@ public class AgentConfigServiceIntegrationTest {
         ArrayList<String> environmentsToAdd = new ArrayList<>();
         environmentsToAdd.add("Dev");
 
-        agentConfigService.bulkUpdateAgentAttributes(agentInstances, Username.ANONYMOUS, result, uuids, new ArrayList<>(), new ArrayList<>(), environmentsToAdd, new ArrayList<>(), TriState.TRUE);
+        agentConfigService.bulkUpdateAgentAttributes(agentInstances, Username.ANONYMOUS, result, uuids, environmentConfigService, new ArrayList<>(), new ArrayList<>(), environmentsToAdd, new ArrayList<>(), TriState.TRUE);
 
         assertTrue(result.isSuccessful());
         assertThat(result.message(), is("Updated agent(s) with uuid(s): [" + StringUtils.join(uuids, ", ") + "]."));
@@ -619,7 +621,7 @@ public class AgentConfigServiceIntegrationTest {
         ArrayList<String> environmentsToRemove = new ArrayList<>();
         environmentsToRemove.add("Dev");
 
-        agentConfigService.bulkUpdateAgentAttributes(agentInstances, Username.ANONYMOUS, result, uuids, new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), environmentsToRemove, TriState.TRUE);
+        agentConfigService.bulkUpdateAgentAttributes(agentInstances, Username.ANONYMOUS, result, uuids, environmentConfigService, new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), environmentsToRemove, TriState.TRUE);
 
         assertTrue(result.isSuccessful());
         assertThat(result.message(), is("Updated agent(s) with uuid(s): [" + StringUtils.join(uuids, ", ") + "]."));
@@ -649,7 +651,7 @@ public class AgentConfigServiceIntegrationTest {
         ArrayList<String> environmentsToAdd = new ArrayList<>();
         environmentsToAdd.add("Non-Existing-Environment");
 
-        agentConfigService.bulkUpdateAgentAttributes(agentInstances, Username.ANONYMOUS, result, uuids, new ArrayList<>(), new ArrayList<>(), environmentsToAdd, new ArrayList<>(), TriState.TRUE);
+        agentConfigService.bulkUpdateAgentAttributes(agentInstances, Username.ANONYMOUS, result, uuids, environmentConfigService, new ArrayList<>(), new ArrayList<>(), environmentsToAdd, new ArrayList<>(), TriState.TRUE);
 
         assertFalse(result.isSuccessful());
         assertThat(result.httpCode(), is(400));
@@ -678,7 +680,7 @@ public class AgentConfigServiceIntegrationTest {
         ArrayList<String> environmentsToRemove = new ArrayList<>();
         environmentsToRemove.add("NonExistingEnvironment");
 
-        agentConfigService.bulkUpdateAgentAttributes(agentInstances, Username.ANONYMOUS, result, uuids, new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), environmentsToRemove, TriState.TRUE);
+        agentConfigService.bulkUpdateAgentAttributes(agentInstances, Username.ANONYMOUS, result, uuids, environmentConfigService, new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), environmentsToRemove, TriState.TRUE);
 
         assertFalse(result.isSuccessful());
         assertThat(result.httpCode(), is(400));
@@ -717,7 +719,7 @@ public class AgentConfigServiceIntegrationTest {
         ArrayList<String> environmentsToAdd = new ArrayList<>();
         environmentsToAdd.add("Dev");
 
-        agentConfigService.bulkUpdateAgentAttributes(agentInstances, Username.ANONYMOUS, result, uuids, resources, new ArrayList<>(), environmentsToAdd, new ArrayList<>(), TriState.FALSE);
+        agentConfigService.bulkUpdateAgentAttributes(agentInstances, Username.ANONYMOUS, result, uuids, environmentConfigService, resources, new ArrayList<>(), environmentsToAdd, new ArrayList<>(), TriState.FALSE);
 
         cruiseConfig = goConfigDao.load();
         assertTrue(result.isSuccessful());


### PR DESCRIPTION
The `addAgentIfNew` check isn't enough because it only checks the config xml.

Issue described in https://github.com/gocd/gocd/issues/5861#issuecomment-466960836