### PR TITLE
Add XML Migration to support ClusterProfiles tag under elastic (#5938)

### DIFF
--- a/base/src/main/java/com/thoughtworks/go/util/GoConstants.java
+++ b/base/src/main/java/com/thoughtworks/go/util/GoConstants.java
@@ -54,7 +54,7 @@ public class GoConstants {
 
     public static final String PRODUCT_NAME = "go";
 
-    public static final int CONFIG_SCHEMA_VERSION = 116;
+    public static final int CONFIG_SCHEMA_VERSION = 117;
 
     public static final String APPROVAL_SUCCESS = "success";
     public static final String APPROVAL_MANUAL = "manual";

--- a/config/config-server/src/main/resources/schemas/116_cruise-config.xsd
+++ b/config/config-server/src/main/resources/schemas/116_cruise-config.xsd
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2019 ThoughtWorks, Inc.
+  ~ Copyright 2018 ThoughtWorks, Inc.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -89,7 +89,7 @@
           </xsd:unique>
         </xsd:element>
       </xsd:sequence>
-      <xsd:attribute name="schemaVersion" type="xsd:int" use="required" fixed="117"/>
+      <xsd:attribute name="schemaVersion" type="xsd:int" use="required" fixed="116"/>
     </xsd:complexType>
     <xsd:unique name="uniquePipelines">
       <xsd:selector xpath="pipelines"/>
@@ -311,13 +311,6 @@
   </xsd:complexType>
   <xsd:complexType name="elasticConfigType">
     <xsd:sequence>
-      <xsd:element name="clusterProfiles" type="elasticAgentClusterProfilesType" minOccurs="0" maxOccurs="1">
-        <xsd:unique name="uniqueClusterProfileId">
-          <xsd:selector xpath="clusterProfile"/>
-          <xsd:field xpath="@id"/>
-          <!-- Unique clusterProfile id -->
-        </xsd:unique>
-      </xsd:element>
       <xsd:element name="profiles" type="elasticAgentProfilesType" minOccurs="0" maxOccurs="1">
         <xsd:unique name="uniqueProfileId">
           <xsd:selector xpath="profile"/>
@@ -331,11 +324,6 @@
   <xsd:complexType name="elasticAgentProfilesType">
     <xsd:sequence>
       <xsd:element minOccurs="0" maxOccurs="unbounded" name="profile" type="pluginProfile"/>
-    </xsd:sequence>
-  </xsd:complexType>
-  <xsd:complexType name="elasticAgentClusterProfilesType">
-    <xsd:sequence>
-      <xsd:element minOccurs="0" maxOccurs="unbounded" name="clusterProfile" type="pluginProfile"/>
     </xsd:sequence>
   </xsd:complexType>
   <xsd:complexType name="artifactStoresType">

--- a/config/config-server/src/main/resources/upgrades/117.xsl
+++ b/config/config-server/src/main/resources/upgrades/117.xsl
@@ -1,0 +1,28 @@
+<?xml version="1.0"?>
+<!--
+  ~ Copyright 2019 ThoughtWorks, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+    <xsl:template match="/cruise/@schemaVersion">
+        <xsl:attribute name="schemaVersion">117</xsl:attribute>
+    </xsl:template>
+    <!-- Copy everything -->
+    <xsl:template match="@*|node()">
+        <xsl:copy>
+            <xsl:apply-templates select="@*|node()"/>
+        </xsl:copy>
+    </xsl:template>
+</xsl:stylesheet>

--- a/server/config/cruise-config.xml
+++ b/server/config/cruise-config.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<cruise xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="cruise-config.xsd" schemaVersion="116">
+<cruise xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="cruise-config.xsd" schemaVersion="117">
   <server artifactsdir="artifacts" agentAutoRegisterKey="323040d4-f2e4-4b8a-8394-7a2d122054d1" webhookSecret="3d5cd2f5-7fe7-43c0-ba34-7e01678ba8b6" commandRepositoryLocation="default" serverId="60f5f682-5248-4ba9-bb35-72c92841bd75" tokenGenerationKey="8c3c8dc9-08bf-4cd7-ac80-cecb3e7ae86c">
     <security>
       <authConfigs>


### PR DESCRIPTION
* Current changes modifies the cruise-config.xsd to allow defining
  ClusterProfiles and ClusterProfile tags.

---

Domain models to hold store these objects will be introduced in subsequent PR