### PR TITLE
[Early Version] Introduce Elastic Agent Extension v5

### DIFF
--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/elastic/ElasticAgentExtension.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/elastic/ElasticAgentExtension.java
@@ -24,6 +24,7 @@ import com.thoughtworks.go.plugin.access.common.settings.PluginSettingsJsonMessa
 import com.thoughtworks.go.plugin.access.elastic.models.AgentMetadata;
 import com.thoughtworks.go.plugin.access.elastic.v3.ElasticAgentExtensionV3;
 import com.thoughtworks.go.plugin.access.elastic.v4.ElasticAgentExtensionV4;
+import com.thoughtworks.go.plugin.access.elastic.v5.ElasticAgentExtensionV5;
 import com.thoughtworks.go.plugin.api.response.validation.ValidationResult;
 import com.thoughtworks.go.plugin.domain.common.PluginConfiguration;
 import com.thoughtworks.go.plugin.domain.elastic.Capabilities;
@@ -40,7 +41,7 @@ import static com.thoughtworks.go.plugin.domain.common.PluginConstants.ELASTIC_A
 
 @Component
 public class ElasticAgentExtension extends AbstractExtension {
-    public static final List<String> SUPPORTED_VERSIONS = Arrays.asList(ElasticAgentExtensionV3.VERSION, ElasticAgentExtensionV4.VERSION);
+    public static final List<String> SUPPORTED_VERSIONS = Arrays.asList(ElasticAgentExtensionV3.VERSION, ElasticAgentExtensionV4.VERSION, ElasticAgentExtensionV5.VERSION);
     private final Map<String, VersionedElasticAgentExtension> elasticAgentExtensionMap = new HashMap<>();
 
     @Autowired
@@ -48,9 +49,11 @@ public class ElasticAgentExtension extends AbstractExtension {
         super(pluginManager, extensionsRegistry, new PluginRequestHelper(pluginManager, SUPPORTED_VERSIONS, ELASTIC_AGENT_EXTENSION), ELASTIC_AGENT_EXTENSION);
         elasticAgentExtensionMap.put(ElasticAgentExtensionV3.VERSION, new ElasticAgentExtensionV3(pluginRequestHelper));
         elasticAgentExtensionMap.put(ElasticAgentExtensionV4.VERSION, new ElasticAgentExtensionV4(pluginRequestHelper));
+        elasticAgentExtensionMap.put(ElasticAgentExtensionV5.VERSION, new ElasticAgentExtensionV5(pluginRequestHelper));
 
         registerHandler(ElasticAgentExtensionV3.VERSION, new PluginSettingsJsonMessageHandler1_0());
         registerHandler(ElasticAgentExtensionV4.VERSION, new PluginSettingsJsonMessageHandler1_0());
+        registerHandler(ElasticAgentExtensionV5.VERSION, new PluginSettingsJsonMessageHandler1_0());
     }
 
 

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/elastic/ElasticAgentExtension.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/elastic/ElasticAgentExtension.java
@@ -81,6 +81,18 @@ public class ElasticAgentExtension extends AbstractExtension {
         return getVersionedElasticAgentExtension(pluginId).validateElasticProfile(pluginId, configuration);
     }
 
+    List<PluginConfiguration> getClusterProfileMetadata(String pluginId) {
+        return getVersionedElasticAgentExtension(pluginId).getClusterProfileMetadata(pluginId);
+    }
+
+    String getClusterProfileView(String pluginId) {
+        return getVersionedElasticAgentExtension(pluginId).getClusterProfileView(pluginId);
+    }
+
+    public ValidationResult validateClusterProfile(final String pluginId, final Map<String, String> configuration) {
+        return getVersionedElasticAgentExtension(pluginId).validateClusterProfile(pluginId, configuration);
+    }
+
     com.thoughtworks.go.plugin.domain.common.Image getIcon(String pluginId) {
         return getVersionedElasticAgentExtension(pluginId).getIcon(pluginId);
     }

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/elastic/VersionedElasticAgentExtension.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/elastic/VersionedElasticAgentExtension.java
@@ -18,7 +18,6 @@ package com.thoughtworks.go.plugin.access.elastic;
 
 import com.thoughtworks.go.domain.JobIdentifier;
 import com.thoughtworks.go.plugin.access.elastic.models.AgentMetadata;
-import com.thoughtworks.go.plugin.access.elastic.v3.ElasticAgentExtensionV3;
 import com.thoughtworks.go.plugin.api.response.validation.ValidationResult;
 import com.thoughtworks.go.plugin.domain.common.PluginConfiguration;
 import com.thoughtworks.go.plugin.domain.elastic.Capabilities;
@@ -36,6 +35,12 @@ public interface VersionedElasticAgentExtension {
     String getElasticProfileView(String pluginId);
 
     ValidationResult validateElasticProfile(String pluginId, Map<String, String> configuration);
+
+    List<PluginConfiguration> getClusterProfileMetadata(String pluginId);
+
+    String getClusterProfileView(String pluginId);
+
+    ValidationResult validateClusterProfile(String pluginId, Map<String, String> configuration);
 
     void createAgent(String pluginId, String autoRegisterKey, String environment, Map<String, String> configuration, JobIdentifier jobIdentifier);
 

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/elastic/v3/ElasticAgentExtensionV3.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/elastic/v3/ElasticAgentExtensionV3.java
@@ -158,4 +158,19 @@ public class ElasticAgentExtensionV3 implements VersionedElasticAgentExtension {
     public void jobCompletion(String pluginId, String elasticAgentId, JobIdentifier jobIdentifier) {
         LOG.debug("Plugin: '{}' uses elastic agent extension v3 and job completion is not supported by elastic agent V3", pluginId);
     }
+
+    @Override
+    public List<PluginConfiguration> getClusterProfileMetadata(String pluginId) {
+        throw new UnsupportedOperationException(String.format("Plugin: '%s' uses elastic agent extension v3 and cluster profile extension calls are not supported by elastic agent V3", pluginId));
+    }
+
+    @Override
+    public String getClusterProfileView(String pluginId) {
+        throw new UnsupportedOperationException(String.format("Plugin: '%s' uses elastic agent extension v3 and cluster profile extension calls are not supported by elastic agent V3", pluginId));
+    }
+
+    @Override
+    public ValidationResult validateClusterProfile(String pluginId, Map<String, String> configuration) {
+        throw new UnsupportedOperationException(String.format("Plugin: '%s' uses elastic agent extension v3 and cluster profile extension calls are not supported by elastic agent V3", pluginId));
+    }
 }

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/elastic/v4/ElasticAgentExtensionV4.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/elastic/v4/ElasticAgentExtensionV4.java
@@ -24,6 +24,8 @@ import com.thoughtworks.go.plugin.access.elastic.models.AgentMetadata;
 import com.thoughtworks.go.plugin.api.response.validation.ValidationResult;
 import com.thoughtworks.go.plugin.domain.common.PluginConfiguration;
 import com.thoughtworks.go.plugin.domain.elastic.Capabilities;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.List;
 import java.util.Map;
@@ -31,6 +33,7 @@ import java.util.Map;
 import static com.thoughtworks.go.plugin.access.elastic.v4.ElasticAgentPluginConstantsV4.*;
 
 public class ElasticAgentExtensionV4 implements VersionedElasticAgentExtension {
+    private static final Logger LOG = LoggerFactory.getLogger(ElasticAgentExtensionV4.class);
     public static final String VERSION = "4.0";
     private final PluginRequestHelper pluginRequestHelper;
     private final ElasticAgentExtensionConverterV4 elasticAgentExtensionConverterV4;
@@ -95,6 +98,20 @@ public class ElasticAgentExtensionV4 implements VersionedElasticAgentExtension {
         });
     }
 
+    @Override
+    public List<PluginConfiguration> getClusterProfileMetadata(String pluginId) {
+        throw new UnsupportedOperationException(String.format("Plugin: '%s' uses elastic agent extension v4 and cluster profile extension calls are not supported by elastic agent V4", pluginId));
+    }
+
+    @Override
+    public String getClusterProfileView(String pluginId) {
+        throw new UnsupportedOperationException(String.format("Plugin: '%s' uses elastic agent extension v4 and cluster profile extension calls are not supported by elastic agent V4", pluginId));
+    }
+
+    @Override
+    public ValidationResult validateClusterProfile(String pluginId, Map<String, String> configuration) {
+        throw new UnsupportedOperationException(String.format("Plugin: '%s' uses elastic agent extension v4 and cluster profile extension calls are not supported by elastic agent V4", pluginId));
+    }
 
     @Override
     public void createAgent(String pluginId, final String autoRegisterKey, final String environment, final Map<String, String> configuration, JobIdentifier jobIdentifier) {

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/elastic/v5/AgentMetadataConverterV5.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/elastic/v5/AgentMetadataConverterV5.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.plugin.access.elastic.v5;
+
+import com.thoughtworks.go.plugin.access.elastic.DataConverter;
+import com.thoughtworks.go.plugin.access.elastic.models.AgentMetadata;
+
+class AgentMetadataConverterV5 implements DataConverter<AgentMetadata, AgentMetadataDTO> {
+    @Override
+    public AgentMetadata fromDTO(AgentMetadataDTO agentMetadataDTO) {
+        return new AgentMetadata(agentMetadataDTO.elasticAgentId(), agentMetadataDTO.agentState(), agentMetadataDTO.buildState(), agentMetadataDTO.configState());
+    }
+
+    @Override
+    public AgentMetadataDTO toDTO(AgentMetadata agentMetadata) {
+        return new AgentMetadataDTO(agentMetadata.elasticAgentId(), agentMetadata.agentState(), agentMetadata.buildState(), agentMetadata.configState());
+    }
+}

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/elastic/v5/AgentMetadataDTO.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/elastic/v5/AgentMetadataDTO.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.plugin.access.elastic.v5;
+
+import com.google.gson.FieldNamingPolicy;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonElement;
+import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.SerializedName;
+
+import java.io.Serializable;
+
+class AgentMetadataDTO implements Serializable {
+    private static final Gson GSON = new GsonBuilder().
+            excludeFieldsWithoutExposeAnnotation().
+            serializeNulls().
+            setFieldNamingStrategy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES).
+            create();
+
+    @Expose
+    @SerializedName("agent_id")
+    private final String elasticAgentId;
+    @Expose
+    @SerializedName("agent_state")
+    private final String agentState;
+    @Expose
+    @SerializedName("build_state")
+    private final String buildState;
+    @Expose
+    @SerializedName("config_state")
+    private final String configState;
+
+    public AgentMetadataDTO(String elasticAgentId, String agentState, String buildState, String configState) {
+        this.elasticAgentId = elasticAgentId;
+        this.agentState = agentState;
+        this.buildState = buildState;
+        this.configState = configState;
+    }
+
+    public String elasticAgentId() {
+        return elasticAgentId;
+    }
+
+    public String agentState() {
+        return agentState;
+    }
+
+    public String buildState() {
+        return buildState;
+    }
+
+    public String configState() {
+        return configState;
+    }
+
+    public JsonElement toJSON() {
+        return GSON.toJsonTree(this);
+    }
+
+    @Override
+    public String toString() {
+        return "AgentMetadata{" +
+                "elasticAgentId='" + elasticAgentId + '\'' +
+                ", agentState='" + agentState + '\'' +
+                ", buildState='" + buildState + '\'' +
+                ", configState='" + configState + '\'' +
+                '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        AgentMetadataDTO that = (AgentMetadataDTO) o;
+
+        if (elasticAgentId != null ? !elasticAgentId.equals(that.elasticAgentId) : that.elasticAgentId != null)
+            return false;
+        if (agentState != null ? !agentState.equals(that.agentState) : that.agentState != null) return false;
+        if (buildState != null ? !buildState.equals(that.buildState) : that.buildState != null) return false;
+        return configState != null ? configState.equals(that.configState) : that.configState == null;
+
+    }
+
+    @Override
+    public int hashCode() {
+        int result = elasticAgentId != null ? elasticAgentId.hashCode() : 0;
+        result = 31 * result + (agentState != null ? agentState.hashCode() : 0);
+        result = 31 * result + (buildState != null ? buildState.hashCode() : 0);
+        result = 31 * result + (configState != null ? configState.hashCode() : 0);
+        return result;
+    }
+}

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/elastic/v5/CapabilitiesConverterV5.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/elastic/v5/CapabilitiesConverterV5.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.plugin.access.elastic.v5;
+
+import com.thoughtworks.go.plugin.access.elastic.DataConverter;
+import com.thoughtworks.go.plugin.domain.elastic.Capabilities;
+
+class CapabilitiesConverterV5 implements DataConverter<Capabilities, CapabilitiesDTO> {
+    @Override
+    public Capabilities fromDTO(CapabilitiesDTO capabilitiesDTO) {
+        return new Capabilities(capabilitiesDTO.supportsStatusReport(), capabilitiesDTO.supportsAgentStatusReport());
+    }
+
+    @Override
+    public CapabilitiesDTO toDTO(Capabilities object) {
+        throw unsupportedOperationException(object.getClass().getName(), CapabilitiesDTO.class.getName());
+    }
+}

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/elastic/v5/CapabilitiesDTO.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/elastic/v5/CapabilitiesDTO.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.plugin.access.elastic.v5;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.SerializedName;
+
+class CapabilitiesDTO {
+    private static final Gson GSON = new GsonBuilder().excludeFieldsWithoutExposeAnnotation().create();
+    @Expose
+    @SerializedName("supports_status_report")
+    private boolean supportsStatusReport;
+
+    @Expose
+    @SerializedName("supports_agent_status_report")
+    private boolean supportsAgentStatusReport;
+
+    public boolean supportsStatusReport() {
+        return supportsStatusReport;
+    }
+
+    public boolean supportsAgentStatusReport() {
+        return supportsAgentStatusReport;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof CapabilitiesDTO)) return false;
+
+        CapabilitiesDTO that = (CapabilitiesDTO) o;
+
+        if (supportsStatusReport != that.supportsStatusReport) return false;
+        return supportsAgentStatusReport == that.supportsAgentStatusReport;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = (supportsStatusReport ? 1 : 0);
+        result = 31 * result + (supportsAgentStatusReport ? 1 : 0);
+        return result;
+    }
+}

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/elastic/v5/ElasticAgentExtensionConverterV5.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/elastic/v5/ElasticAgentExtensionConverterV5.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.plugin.access.elastic.v5;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonObject;
+import com.thoughtworks.go.domain.JobIdentifier;
+import com.thoughtworks.go.plugin.access.common.handler.JSONResultMessageHandler;
+import com.thoughtworks.go.plugin.access.common.models.ImageDeserializer;
+import com.thoughtworks.go.plugin.access.common.models.PluginProfileMetadataKeys;
+import com.thoughtworks.go.plugin.access.elastic.models.AgentMetadata;
+import com.thoughtworks.go.plugin.api.response.validation.ValidationResult;
+import com.thoughtworks.go.plugin.domain.common.PluginConfiguration;
+import com.thoughtworks.go.plugin.domain.elastic.Capabilities;
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.List;
+import java.util.Map;
+
+class ElasticAgentExtensionConverterV5 {
+    private static final Gson GSON = new GsonBuilder().excludeFieldsWithoutExposeAnnotation().create();
+    private CapabilitiesConverterV5 capabilitiesConverterV5 = new CapabilitiesConverterV5();
+    private AgentMetadataConverterV5 agentMetadataConverterV5 = new AgentMetadataConverterV5();
+
+    String createAgentRequestBody(String autoRegisterKey, String environment, Map<String, String> configuration, JobIdentifier jobIdentifier) {
+        JsonObject jsonObject = new JsonObject();
+        jsonObject.addProperty("auto_register_key", autoRegisterKey);
+        jsonObject.add("properties", mapToJsonObject(configuration));
+        jsonObject.addProperty("environment", environment);
+        jsonObject.add("job_identifier", jobIdentifierJson(jobIdentifier));
+
+        return GSON.toJson(jsonObject);
+    }
+
+    String shouldAssignWorkRequestBody(AgentMetadata elasticAgent, String environment, Map<String, String> configuration, JobIdentifier identifier) {
+        JsonObject jsonObject = new JsonObject();
+        jsonObject.add("properties", mapToJsonObject(configuration));
+        jsonObject.addProperty("environment", environment);
+        jsonObject.add("agent", agentMetadataConverterV5.toDTO(elasticAgent).toJSON());
+        jsonObject.add("job_identifier", jobIdentifierJson(identifier));
+        return GSON.toJson(jsonObject);
+    }
+
+
+    List<PluginConfiguration> getElasticProfileMetadataResponseFromBody(String responseBody) {
+        return PluginProfileMetadataKeys.fromJSON(responseBody).toPluginConfigurations();
+    }
+
+
+    String getProfileViewResponseFromBody(String responseBody) {
+        String template = (String) new Gson().fromJson(responseBody, Map.class).get("template");
+        if (StringUtils.isBlank(template)) {
+            throw new RuntimeException("Template was blank!");
+        }
+        return template;
+    }
+
+
+    com.thoughtworks.go.plugin.domain.common.Image getImageResponseFromBody(String responseBody) {
+        return new ImageDeserializer().fromJSON(responseBody);
+    }
+
+    String getAgentStatusReportRequestBody(JobIdentifier identifier, String elasticAgentId) {
+        JsonObject jsonObject = new JsonObject();
+        if (identifier != null) {
+            jsonObject.add("job_identifier", jobIdentifierJson(identifier));
+        }
+        jsonObject.addProperty("elastic_agent_id", elasticAgentId);
+        return GSON.toJson(jsonObject);
+    }
+
+
+    ValidationResult getElasticProfileValidationResultResponseFromBody(String responseBody) {
+        return new JSONResultMessageHandler().toValidationResult(responseBody);
+    }
+
+
+    String validateElasticProfileRequestBody(Map<String, String> configuration) {
+        JsonObject properties = mapToJsonObject(configuration);
+        return new GsonBuilder().serializeNulls().create().toJson(properties);
+    }
+
+
+    Boolean shouldAssignWorkResponseFromBody(String responseBody) {
+        return new Gson().fromJson(responseBody, Boolean.class);
+    }
+
+    String getStatusReportView(String responseBody) {
+        String statusReportView = (String) new Gson().fromJson(responseBody, Map.class).get("view");
+        if (StringUtils.isBlank(statusReportView)) {
+            throw new RuntimeException("Status Report is blank!");
+        }
+        return statusReportView;
+    }
+
+    Capabilities getCapabilitiesFromResponseBody(String responseBody) {
+        final CapabilitiesDTO capabilitiesDTO = GSON.fromJson(responseBody, CapabilitiesDTO.class);
+        return capabilitiesConverterV5.fromDTO(capabilitiesDTO);
+    }
+
+    private JsonObject mapToJsonObject(Map<String, String> configuration) {
+        final JsonObject properties = new JsonObject();
+        for (Map.Entry<String, String> entry : configuration.entrySet()) {
+            properties.addProperty(entry.getKey(), entry.getValue());
+        }
+        return properties;
+    }
+
+    private JsonObject jobIdentifierJson(JobIdentifier jobIdentifier) {
+        JsonObject jobIdentifierJson = new JsonObject();
+        jobIdentifierJson.addProperty("pipeline_name", jobIdentifier.getPipelineName());
+        jobIdentifierJson.addProperty("pipeline_label", jobIdentifier.getPipelineLabel());
+        jobIdentifierJson.addProperty("pipeline_counter", jobIdentifier.getPipelineCounter());
+        jobIdentifierJson.addProperty("stage_name", jobIdentifier.getStageName());
+        jobIdentifierJson.addProperty("stage_counter", jobIdentifier.getStageCounter());
+        jobIdentifierJson.addProperty("job_name", jobIdentifier.getBuildName());
+        jobIdentifierJson.addProperty("job_id", jobIdentifier.getBuildId());
+        return jobIdentifierJson;
+    }
+
+    public String getJobCompletionRequestBody(String elasticAgentId, JobIdentifier jobIdentifier) {
+        JsonObject jsonObject = new JsonObject();
+        jsonObject.addProperty("elastic_agent_id", elasticAgentId);
+        jsonObject.add("job_identifier", jobIdentifierJson(jobIdentifier));
+        return GSON.toJson(jsonObject);
+    }
+}
+

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/elastic/v5/ElasticAgentExtensionV5.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/elastic/v5/ElasticAgentExtensionV5.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.plugin.access.elastic.v5;
+
+import com.thoughtworks.go.domain.JobIdentifier;
+import com.thoughtworks.go.plugin.access.DefaultPluginInteractionCallback;
+import com.thoughtworks.go.plugin.access.PluginRequestHelper;
+import com.thoughtworks.go.plugin.access.elastic.VersionedElasticAgentExtension;
+import com.thoughtworks.go.plugin.access.elastic.models.AgentMetadata;
+import com.thoughtworks.go.plugin.api.response.validation.ValidationResult;
+import com.thoughtworks.go.plugin.domain.common.PluginConfiguration;
+import com.thoughtworks.go.plugin.domain.elastic.Capabilities;
+
+import java.util.List;
+import java.util.Map;
+
+import static com.thoughtworks.go.plugin.access.elastic.v5.ElasticAgentPluginConstantsV5.*;
+
+public class ElasticAgentExtensionV5 implements VersionedElasticAgentExtension {
+    public static final String VERSION = "5.0";
+    private final PluginRequestHelper pluginRequestHelper;
+    private final ElasticAgentExtensionConverterV5 elasticAgentExtensionConverterV5;
+
+    public ElasticAgentExtensionV5(PluginRequestHelper pluginRequestHelper) {
+        this.pluginRequestHelper = pluginRequestHelper;
+        this.elasticAgentExtensionConverterV5 = new ElasticAgentExtensionConverterV5();
+    }
+
+    @Override
+    public com.thoughtworks.go.plugin.domain.common.Image getIcon(String pluginId) {
+        return pluginRequestHelper.submitRequest(pluginId, REQUEST_GET_PLUGIN_SETTINGS_ICON, new DefaultPluginInteractionCallback<com.thoughtworks.go.plugin.domain.common.Image>() {
+            @Override
+            public com.thoughtworks.go.plugin.domain.common.Image onSuccess(String responseBody, Map<String, String> responseHeaders, String resolvedExtensionVersion) {
+                return elasticAgentExtensionConverterV5.getImageResponseFromBody(responseBody);
+            }
+        });
+    }
+
+    @Override
+    public Capabilities getCapabilities(String pluginId) {
+        return pluginRequestHelper.submitRequest(pluginId, REQUEST_CAPABILITIES, new DefaultPluginInteractionCallback<Capabilities>() {
+            @Override
+            public Capabilities onSuccess(String responseBody, Map<String, String> responseHeaders, String resolvedExtensionVersion) {
+                return elasticAgentExtensionConverterV5.getCapabilitiesFromResponseBody(responseBody);
+            }
+        });
+    }
+
+    @Override
+    public List<PluginConfiguration> getElasticProfileMetadata(String pluginId) {
+        return pluginRequestHelper.submitRequest(pluginId, REQUEST_GET_PROFILE_METADATA, new DefaultPluginInteractionCallback<List<PluginConfiguration>>() {
+            @Override
+            public List<PluginConfiguration> onSuccess(String responseBody, Map<String, String> responseHeaders, String resolvedExtensionVersion) {
+                return elasticAgentExtensionConverterV5.getElasticProfileMetadataResponseFromBody(responseBody);
+            }
+        });
+    }
+
+    @Override
+    public String getElasticProfileView(String pluginId) {
+        return pluginRequestHelper.submitRequest(pluginId, REQUEST_GET_PROFILE_VIEW, new DefaultPluginInteractionCallback<String>() {
+            @Override
+            public String onSuccess(String responseBody, Map<String, String> responseHeaders, String resolvedExtensionVersion) {
+                return elasticAgentExtensionConverterV5.getProfileViewResponseFromBody(responseBody);
+            }
+        });
+    }
+
+    @Override
+    public ValidationResult validateElasticProfile(final String pluginId, final Map<String, String> configuration) {
+        return pluginRequestHelper.submitRequest(pluginId, REQUEST_VALIDATE_PROFILE, new DefaultPluginInteractionCallback<ValidationResult>() {
+            @Override
+            public String requestBody(String resolvedExtensionVersion) {
+                return elasticAgentExtensionConverterV5.validateElasticProfileRequestBody(configuration);
+            }
+
+            @Override
+            public ValidationResult onSuccess(String responseBody, Map<String, String> responseHeaders, String resolvedExtensionVersion) {
+                return elasticAgentExtensionConverterV5.getElasticProfileValidationResultResponseFromBody(responseBody);
+            }
+        });
+    }
+
+
+    @Override
+    public void createAgent(String pluginId, final String autoRegisterKey, final String environment, final Map<String, String> configuration, JobIdentifier jobIdentifier) {
+        pluginRequestHelper.submitRequest(pluginId, REQUEST_CREATE_AGENT, new DefaultPluginInteractionCallback<Void>() {
+            @Override
+            public String requestBody(String resolvedExtensionVersion) {
+                return elasticAgentExtensionConverterV5.createAgentRequestBody(autoRegisterKey, environment, configuration, jobIdentifier);
+            }
+        });
+    }
+
+    @Override
+    public void serverPing(final String pluginId) {
+        pluginRequestHelper.submitRequest(pluginId, REQUEST_SERVER_PING, new DefaultPluginInteractionCallback<Void>());
+    }
+
+    @Override
+    public boolean shouldAssignWork(String pluginId, final AgentMetadata agent, final String environment, final Map<String, String> configuration, JobIdentifier identifier) {
+        return pluginRequestHelper.submitRequest(pluginId, REQUEST_SHOULD_ASSIGN_WORK, new DefaultPluginInteractionCallback<Boolean>() {
+            @Override
+            public String requestBody(String resolvedExtensionVersion) {
+                return elasticAgentExtensionConverterV5.shouldAssignWorkRequestBody(agent, environment, configuration, identifier);
+            }
+
+            @Override
+            public Boolean onSuccess(String responseBody, Map<String, String> responseHeaders, String resolvedExtensionVersion) {
+                return elasticAgentExtensionConverterV5.shouldAssignWorkResponseFromBody(responseBody);
+            }
+        });
+    }
+
+    @Override
+    public String getPluginStatusReport(String pluginId) {
+        return pluginRequestHelper.submitRequest(pluginId, REQUEST_STATUS_REPORT, new DefaultPluginInteractionCallback<String>() {
+            @Override
+            public String onSuccess(String responseBody, Map<String, String> responseHeaders, String resolvedExtensionVersion) {
+                return elasticAgentExtensionConverterV5.getStatusReportView(responseBody);
+            }
+        });
+    }
+
+    @Override
+    public String getAgentStatusReport(String pluginId, JobIdentifier identifier, String elasticAgentId) {
+        return pluginRequestHelper.submitRequest(pluginId, REQUEST_AGENT_STATUS_REPORT, new DefaultPluginInteractionCallback<String>() {
+            @Override
+            public String requestBody(String resolvedExtensionVersion) {
+                return elasticAgentExtensionConverterV5.getAgentStatusReportRequestBody(identifier, elasticAgentId);
+            }
+
+            @Override
+            public String onSuccess(String responseBody, Map<String, String> responseHeaders, String resolvedExtensionVersion) {
+                return elasticAgentExtensionConverterV5.getStatusReportView(responseBody);
+            }
+        });
+    }
+
+    @Override
+    public void jobCompletion(String pluginId, String elasticAgentId, JobIdentifier jobIdentifier) {
+        pluginRequestHelper.submitRequest(pluginId, REQUEST_JOB_COMPLETION, new DefaultPluginInteractionCallback<String>() {
+            @Override
+            public String requestBody(String resolvedExtensionVersion) {
+                return elasticAgentExtensionConverterV5.getJobCompletionRequestBody(elasticAgentId, jobIdentifier);
+            }
+        });
+    }
+}

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/elastic/v5/ElasticAgentExtensionV5.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/elastic/v5/ElasticAgentExtensionV5.java
@@ -95,6 +95,40 @@ public class ElasticAgentExtensionV5 implements VersionedElasticAgentExtension {
         });
     }
 
+    @Override
+    public List<PluginConfiguration> getClusterProfileMetadata(String pluginId) {
+        return pluginRequestHelper.submitRequest(pluginId, REQUEST_GET_CLUSTER_PROFILE_METADATA, new DefaultPluginInteractionCallback<List<PluginConfiguration>>() {
+            @Override
+            public List<PluginConfiguration> onSuccess(String responseBody, Map<String, String> responseHeaders, String resolvedExtensionVersion) {
+                return elasticAgentExtensionConverterV5.getElasticProfileMetadataResponseFromBody(responseBody);
+            }
+        });
+    }
+
+    @Override
+    public String getClusterProfileView(String pluginId) {
+        return pluginRequestHelper.submitRequest(pluginId, REQUEST_GET_CLUSTER_PROFILE_VIEW, new DefaultPluginInteractionCallback<String>() {
+            @Override
+            public String onSuccess(String responseBody, Map<String, String> responseHeaders, String resolvedExtensionVersion) {
+                return elasticAgentExtensionConverterV5.getProfileViewResponseFromBody(responseBody);
+            }
+        });
+    }
+
+    @Override
+    public ValidationResult validateClusterProfile(String pluginId, Map<String, String> configuration) {
+        return pluginRequestHelper.submitRequest(pluginId, REQUEST_VALIDATE_CLUSTER_PROFILE, new DefaultPluginInteractionCallback<ValidationResult>() {
+            @Override
+            public String requestBody(String resolvedExtensionVersion) {
+                return elasticAgentExtensionConverterV5.validateElasticProfileRequestBody(configuration);
+            }
+
+            @Override
+            public ValidationResult onSuccess(String responseBody, Map<String, String> responseHeaders, String resolvedExtensionVersion) {
+                return elasticAgentExtensionConverterV5.getElasticProfileValidationResultResponseFromBody(responseBody);
+            }
+        });
+    }
 
     @Override
     public void createAgent(String pluginId, final String autoRegisterKey, final String environment, final Map<String, String> configuration, JobIdentifier jobIdentifier) {

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/elastic/v5/ElasticAgentPluginConstantsV5.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/elastic/v5/ElasticAgentPluginConstantsV5.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.plugin.access.elastic.v5;
+
+public interface ElasticAgentPluginConstantsV5 {
+    String REQUEST_PREFIX = "cd.go.elastic-agent";
+
+    String REQUEST_CREATE_AGENT = REQUEST_PREFIX + ".create-agent";
+    String REQUEST_SERVER_PING = REQUEST_PREFIX + ".server-ping";
+    String REQUEST_SHOULD_ASSIGN_WORK = REQUEST_PREFIX + ".should-assign-work";
+
+    String REQUEST_GET_PROFILE_METADATA = REQUEST_PREFIX + ".get-profile-metadata";
+    String REQUEST_GET_PROFILE_VIEW = REQUEST_PREFIX + ".get-profile-view";
+    String REQUEST_VALIDATE_PROFILE = REQUEST_PREFIX + ".validate-profile";
+    String REQUEST_GET_PLUGIN_SETTINGS_ICON = REQUEST_PREFIX + ".get-icon";
+
+    String REQUEST_STATUS_REPORT = REQUEST_PREFIX + ".status-report";
+    String REQUEST_AGENT_STATUS_REPORT = REQUEST_PREFIX + ".agent-status-report";
+    String REQUEST_CAPABILITIES = REQUEST_PREFIX + ".get-capabilities";
+
+    String REQUEST_JOB_COMPLETION = REQUEST_PREFIX + ".job-completion";
+}

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/elastic/v5/ElasticAgentPluginConstantsV5.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/elastic/v5/ElasticAgentPluginConstantsV5.java
@@ -28,6 +28,10 @@ public interface ElasticAgentPluginConstantsV5 {
     String REQUEST_VALIDATE_PROFILE = REQUEST_PREFIX + ".validate-profile";
     String REQUEST_GET_PLUGIN_SETTINGS_ICON = REQUEST_PREFIX + ".get-icon";
 
+    String REQUEST_GET_CLUSTER_PROFILE_METADATA = REQUEST_PREFIX + ".get-cluster-profile-metadata";
+    String REQUEST_GET_CLUSTER_PROFILE_VIEW = REQUEST_PREFIX + ".get-cluster-profile-view";
+    String REQUEST_VALIDATE_CLUSTER_PROFILE = REQUEST_PREFIX + ".validate-cluster-profile";
+
     String REQUEST_STATUS_REPORT = REQUEST_PREFIX + ".status-report";
     String REQUEST_AGENT_STATUS_REPORT = REQUEST_PREFIX + ".agent-status-report";
     String REQUEST_CAPABILITIES = REQUEST_PREFIX + ".get-capabilities";

--- a/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/elastic/ElasticAgentExtensionV3Test.java
+++ b/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/elastic/ElasticAgentExtensionV3Test.java
@@ -40,18 +40,13 @@ import org.junit.rules.ExpectedException;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import static com.thoughtworks.go.plugin.access.elastic.v3.ElasticAgentPluginConstantsV3.*;
 import static com.thoughtworks.go.plugin.domain.common.PluginConstants.ELASTIC_AGENT_EXTENSION;
 import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson;
-import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertThat;
-import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.hamcrest.Matchers.hasSize;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verifyZeroInteractions;
@@ -248,6 +243,30 @@ public class ElasticAgentExtensionV3Test {
                 "}";
 
         assertExtensionRequest("3.0", REQUEST_AGENT_STATUS_REPORT, requestBody);
+    }
+
+    @Test
+    public void shouldNotSupportGetClusterProfileConfigurationCall() {
+        thrown.expect(UnsupportedOperationException.class);
+        thrown.expectMessage(String.format("Plugin: '%s' uses elastic agent extension v3 and cluster profile extension calls are not supported by elastic agent V3", PLUGIN_ID));
+
+        extensionV3.getClusterProfileMetadata(PLUGIN_ID);
+    }
+
+    @Test
+    public void shouldNotSupportGetClusterProfileViewCall() {
+        thrown.expect(UnsupportedOperationException.class);
+        thrown.expectMessage(String.format("Plugin: '%s' uses elastic agent extension v3 and cluster profile extension calls are not supported by elastic agent V3", PLUGIN_ID));
+
+        extensionV3.getClusterProfileView(PLUGIN_ID);
+    }
+
+    @Test
+    public void shouldNotSupportValidateClusterProfileCall() {
+        thrown.expect(UnsupportedOperationException.class);
+        thrown.expectMessage(String.format("Plugin: '%s' uses elastic agent extension v3 and cluster profile extension calls are not supported by elastic agent V3", PLUGIN_ID));
+
+        extensionV3.validateClusterProfile(PLUGIN_ID, new HashMap<>());
     }
 
     @Test

--- a/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/elastic/ElasticAgentExtensionV4Test.java
+++ b/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/elastic/ElasticAgentExtensionV4Test.java
@@ -40,18 +40,13 @@ import org.junit.rules.ExpectedException;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import static com.thoughtworks.go.plugin.access.elastic.v4.ElasticAgentPluginConstantsV4.*;
 import static com.thoughtworks.go.plugin.domain.common.PluginConstants.ELASTIC_AGENT_EXTENSION;
 import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson;
-import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertThat;
-import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.hamcrest.Matchers.hasSize;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
@@ -271,6 +266,31 @@ public class ElasticAgentExtensionV4Test {
                 "}";
 
         assertExtensionRequest("4.0", REQUEST_AGENT_STATUS_REPORT, requestBody);
+    }
+
+
+    @Test
+    public void shouldNotSupportGetClusterProfileConfigurationCall() {
+        thrown.expect(UnsupportedOperationException.class);
+        thrown.expectMessage(String.format("Plugin: '%s' uses elastic agent extension v4 and cluster profile extension calls are not supported by elastic agent V4", PLUGIN_ID));
+
+        extensionV4.getClusterProfileMetadata(PLUGIN_ID);
+    }
+
+    @Test
+    public void shouldNotSupportGetClusterProfileViewCall() {
+        thrown.expect(UnsupportedOperationException.class);
+        thrown.expectMessage(String.format("Plugin: '%s' uses elastic agent extension v4 and cluster profile extension calls are not supported by elastic agent V4", PLUGIN_ID));
+
+        extensionV4.getClusterProfileView(PLUGIN_ID);
+    }
+
+    @Test
+    public void shouldNotSupportValidateClusterProfileCall() {
+        thrown.expect(UnsupportedOperationException.class);
+        thrown.expectMessage(String.format("Plugin: '%s' uses elastic agent extension v4 and cluster profile extension calls are not supported by elastic agent V4", PLUGIN_ID));
+
+        extensionV4.validateClusterProfile(PLUGIN_ID, new HashMap<>());
     }
 
     @Test

--- a/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/elastic/ElasticAgentExtensionV5Test.java
+++ b/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/elastic/ElasticAgentExtensionV5Test.java
@@ -1,0 +1,296 @@
+/*
+ * Copyright 2018 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.plugin.access.elastic;
+
+import com.thoughtworks.go.domain.JobIdentifier;
+import com.thoughtworks.go.plugin.access.PluginRequestHelper;
+import com.thoughtworks.go.plugin.access.elastic.models.AgentMetadata;
+import com.thoughtworks.go.plugin.access.elastic.v5.ElasticAgentExtensionV5;
+import com.thoughtworks.go.plugin.api.request.GoPluginApiRequest;
+import com.thoughtworks.go.plugin.api.response.DefaultGoPluginApiResponse;
+import com.thoughtworks.go.plugin.api.response.validation.ValidationError;
+import com.thoughtworks.go.plugin.api.response.validation.ValidationResult;
+import com.thoughtworks.go.plugin.domain.common.Image;
+import com.thoughtworks.go.plugin.domain.common.Metadata;
+import com.thoughtworks.go.plugin.domain.common.PluginConfiguration;
+import com.thoughtworks.go.plugin.domain.common.PluginConstants;
+import com.thoughtworks.go.plugin.domain.elastic.Capabilities;
+import com.thoughtworks.go.plugin.infra.PluginManager;
+import com.thoughtworks.go.plugin.infra.plugininfo.GoPluginDescriptor;
+import org.hamcrest.Matchers;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static com.thoughtworks.go.plugin.access.elastic.v4.ElasticAgentPluginConstantsV4.*;
+import static com.thoughtworks.go.plugin.domain.common.PluginConstants.ELASTIC_AGENT_EXTENSION;
+import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson;
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+public class ElasticAgentExtensionV5Test {
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+    private static final String PLUGIN_ID = "cd.go.example.plugin";
+    @Mock
+    private PluginManager pluginManager;
+    @Mock
+    private GoPluginDescriptor descriptor;
+    private ArgumentCaptor<GoPluginApiRequest> requestArgumentCaptor;
+    private ElasticAgentExtensionV5 extensionV5;
+
+    @Before
+    public void setUp() throws Exception {
+        initMocks(this);
+        requestArgumentCaptor = ArgumentCaptor.forClass(GoPluginApiRequest.class);
+        final List<String> goSupportedVersions = Arrays.asList("3.0", "4.0", "5.0");
+
+        when(descriptor.id()).thenReturn(PLUGIN_ID);
+
+        when(pluginManager.getPluginDescriptorFor(PLUGIN_ID)).thenReturn(descriptor);
+        when(pluginManager.isPluginOfType(ELASTIC_AGENT_EXTENSION, PLUGIN_ID)).thenReturn(true);
+        when(pluginManager.resolveExtensionVersion(PLUGIN_ID, ELASTIC_AGENT_EXTENSION, goSupportedVersions)).thenReturn("5.0");
+
+        final PluginRequestHelper pluginRequestHelper = new PluginRequestHelper(pluginManager, goSupportedVersions, ELASTIC_AGENT_EXTENSION);
+        extensionV5 = new ElasticAgentExtensionV5(pluginRequestHelper);
+    }
+
+    @Test
+    public void shouldGetPluginIcon() {
+        when(pluginManager.submitTo(eq(PLUGIN_ID), eq(ELASTIC_AGENT_EXTENSION), requestArgumentCaptor.capture())).thenReturn(DefaultGoPluginApiResponse.success("{\"content_type\":\"image/png\",\"data\":\"Zm9vYmEK\"}"));
+        final Image icon = extensionV5.getIcon(PLUGIN_ID);
+
+        assertThat(icon.getContentType(), is("image/png"));
+        assertThat(icon.getData(), is("Zm9vYmEK"));
+
+        assertExtensionRequest("5.0", REQUEST_GET_PLUGIN_SETTINGS_ICON, null);
+    }
+
+    @Test
+    public void shouldGetCapabilitiesOfAPlugin() {
+        final String responseBody = "{\"supports_status_report\":\"true\", \"supports_agent_status_report\":\"true\"}";
+        when(pluginManager.submitTo(eq(PLUGIN_ID), eq(ELASTIC_AGENT_EXTENSION), requestArgumentCaptor.capture())).thenReturn(DefaultGoPluginApiResponse.success(responseBody));
+
+        final Capabilities capabilities = extensionV5.getCapabilities(PLUGIN_ID);
+
+        assertTrue(capabilities.supportsStatusReport());
+        assertTrue(capabilities.supportsAgentStatusReport());
+    }
+
+    @Test
+    public void shouldGetProfileMetadata() {
+        String responseBody = "[{\"key\":\"Username\",\"metadata\":{\"required\":true,\"secure\":false}},{\"key\":\"Password\",\"metadata\":{\"required\":true,\"secure\":true}}]";
+        when(pluginManager.submitTo(eq(PLUGIN_ID), eq(ELASTIC_AGENT_EXTENSION), requestArgumentCaptor.capture())).thenReturn(DefaultGoPluginApiResponse.success(responseBody));
+
+        final List<PluginConfiguration> metadata = extensionV5.getElasticProfileMetadata(PLUGIN_ID);
+
+        assertThat(metadata, hasSize(2));
+        assertThat(metadata, containsInAnyOrder(
+                new PluginConfiguration("Username", new Metadata(true, false)),
+                new PluginConfiguration("Password", new Metadata(true, true))
+        ));
+
+        assertExtensionRequest("5.0", REQUEST_GET_PROFILE_METADATA, null);
+    }
+
+    @Test
+    public void shouldGetProfileView() {
+        String responseBody = "{ \"template\": \"<div>This is profile view snippet</div>\" }";
+        when(pluginManager.submitTo(eq(PLUGIN_ID), eq(ELASTIC_AGENT_EXTENSION), requestArgumentCaptor.capture())).thenReturn(DefaultGoPluginApiResponse.success(responseBody));
+
+        final String view = extensionV5.getElasticProfileView(PLUGIN_ID);
+
+        assertThat(view, is("<div>This is profile view snippet</div>"));
+
+        assertExtensionRequest("5.0", REQUEST_GET_PROFILE_VIEW, null);
+    }
+
+    @Test
+    public void shouldValidateProfile() {
+        String responseBody = "[{\"message\":\"Url must not be blank.\",\"key\":\"Url\"},{\"message\":\"SearchBase must not be blank.\",\"key\":\"SearchBase\"}]";
+        when(pluginManager.submitTo(eq(PLUGIN_ID), eq(ELASTIC_AGENT_EXTENSION), requestArgumentCaptor.capture())).thenReturn(DefaultGoPluginApiResponse.success(responseBody));
+
+        final ValidationResult result = extensionV5.validateElasticProfile(PLUGIN_ID, Collections.emptyMap());
+
+        assertThat(result.isSuccessful(), is(false));
+        assertThat(result.getErrors(), containsInAnyOrder(
+                new ValidationError("Url", "Url must not be blank."),
+                new ValidationError("SearchBase", "SearchBase must not be blank.")
+        ));
+
+        assertExtensionRequest("5.0", REQUEST_VALIDATE_PROFILE, "{}");
+    }
+
+    @Test
+    public void shouldMakeCreateAgentCall() {
+        final Map<String, String> profile = Collections.singletonMap("ServerURL", "https://example.com/go");
+        final JobIdentifier jobIdentifier = new JobIdentifier("up42", 2, "Test", "up42_stage", "10", "up42_job");
+        when(pluginManager.submitTo(eq(PLUGIN_ID), eq(ELASTIC_AGENT_EXTENSION), requestArgumentCaptor.capture())).thenReturn(DefaultGoPluginApiResponse.success(null));
+
+        extensionV5.createAgent(PLUGIN_ID, "auto-registration-key", "test-env", profile, jobIdentifier);
+
+        String expectedRequestBody = "{\n" +
+                "  \"auto_register_key\": \"auto-registration-key\",\n" +
+                "  \"properties\": {\n" +
+                "    \"ServerURL\": \"https://example.com/go\"\n" +
+                "  },\n" +
+                "  \"environment\": \"test-env\",\n" +
+                "  \"job_identifier\": {\n" +
+                "    \"pipeline_name\": \"up42\",\n" +
+                "    \"pipeline_label\": \"Test\",\n" +
+                "    \"pipeline_counter\": 2,\n" +
+                "    \"stage_name\": \"up42_stage\",\n" +
+                "    \"stage_counter\": \"10\",\n" +
+                "    \"job_name\": \"up42_job\",\n" +
+                "    \"job_id\": -1\n" +
+                "  }\n" +
+                "}";
+        assertExtensionRequest("5.0", REQUEST_CREATE_AGENT, expectedRequestBody);
+    }
+
+    @Test
+    public void shouldMakeJobCompletionCall() {
+        final String elasticAgentId = "ea1";
+        final JobIdentifier jobIdentifier = new JobIdentifier("up42", 2, "Test", "up42_stage", "10", "up42_job");
+        when(pluginManager.submitTo(eq(PLUGIN_ID), eq(ELASTIC_AGENT_EXTENSION), requestArgumentCaptor.capture())).thenReturn(DefaultGoPluginApiResponse.success(null));
+
+        extensionV5.jobCompletion(PLUGIN_ID, elasticAgentId, jobIdentifier);
+
+        String expectedRequestBody = "{\n" +
+                "  \"elastic_agent_id\": \"ea1\",\n" +
+                "  \"job_identifier\": {\n" +
+                "    \"pipeline_name\": \"up42\",\n" +
+                "    \"pipeline_label\": \"Test\",\n" +
+                "    \"pipeline_counter\": 2,\n" +
+                "    \"stage_name\": \"up42_stage\",\n" +
+                "    \"stage_counter\": \"10\",\n" +
+                "    \"job_name\": \"up42_job\",\n" +
+                "    \"job_id\": -1\n" +
+                "  }\n" +
+                "}";
+
+        assertExtensionRequest("5.0", REQUEST_JOB_COMPLETION, expectedRequestBody);
+    }
+
+    @Test
+    public void shouldSendServerPing() {
+        when(pluginManager.submitTo(eq(PLUGIN_ID), eq(ELASTIC_AGENT_EXTENSION), requestArgumentCaptor.capture())).thenReturn(DefaultGoPluginApiResponse.success(null));
+
+        extensionV5.serverPing(PLUGIN_ID);
+
+        assertExtensionRequest("5.0", REQUEST_SERVER_PING, null);
+    }
+
+    @Test
+    public void shouldMakeShouldAssignWorkCall() {
+        final Map<String, String> profile = Collections.singletonMap("ServerURL", "https://example.com/go");
+        final AgentMetadata agentMetadata = new AgentMetadata("foo-agent-id", "Idle", "Idle", "Enabled");
+        when(pluginManager.submitTo(eq(PLUGIN_ID), eq(ELASTIC_AGENT_EXTENSION), requestArgumentCaptor.capture())).thenReturn(DefaultGoPluginApiResponse.success("true"));
+
+        final boolean shouldAssignWork = extensionV5.shouldAssignWork(PLUGIN_ID, agentMetadata, "test-env", profile, new JobIdentifier());
+
+        assertTrue(shouldAssignWork);
+
+        String expectedRequestBody = "{\n" +
+                "  \"properties\": {\n" +
+                "    \"ServerURL\": \"https://example.com/go\"\n" +
+                "  },\n" +
+                "  \"environment\": \"test-env\",\n" +
+                "  \"agent\": {\n" +
+                "    \"agent_id\": \"foo-agent-id\",\n" +
+                "    \"agent_state\": \"Idle\",\n" +
+                "    \"build_state\": \"Idle\",\n" +
+                "    \"config_state\": \"Enabled\"\n" +
+                "  },\n" +
+                "  \"job_identifier\": {}\n" +
+                "}";
+
+        assertExtensionRequest("5.0", REQUEST_SHOULD_ASSIGN_WORK, expectedRequestBody);
+    }
+
+    @Test
+    public void shouldGetStatusReport() {
+        final String responseBody = "{\"view\":\"<div>This is a status report snippet.</div>\"}";
+        when(pluginManager.submitTo(eq(PLUGIN_ID), eq(ELASTIC_AGENT_EXTENSION), requestArgumentCaptor.capture())).thenReturn(DefaultGoPluginApiResponse.success(responseBody));
+
+        final String statusReportView = extensionV5.getPluginStatusReport(PLUGIN_ID);
+
+        assertThat(statusReportView, is("<div>This is a status report snippet.</div>"));
+        assertExtensionRequest("5.0", REQUEST_STATUS_REPORT, null);
+    }
+
+    @Test
+    public void shouldGetAgentStatusReport() {
+        final String responseBody = "{\"view\":\"<div>This is a status report snippet.</div>\"}";
+        final JobIdentifier jobIdentifier = new JobIdentifier("up42", 2, "Test", "up42_stage", "10", "up42_job");
+
+        when(pluginManager.submitTo(eq(PLUGIN_ID), eq(ELASTIC_AGENT_EXTENSION), requestArgumentCaptor.capture())).thenReturn(DefaultGoPluginApiResponse.success(responseBody));
+
+        extensionV5.getAgentStatusReport(PLUGIN_ID, jobIdentifier, "GoCD193659b3b930480287b898eeef0ade37");
+
+        final String requestBody = "{\n" +
+                "  \"job_identifier\": {\n" +
+                "    \"pipeline_name\": \"up42\",\n" +
+                "    \"pipeline_label\": \"Test\",\n" +
+                "    \"pipeline_counter\": 2,\n" +
+                "    \"stage_name\": \"up42_stage\",\n" +
+                "    \"stage_counter\": \"10\",\n" +
+                "    \"job_name\": \"up42_job\",\n" +
+                "    \"job_id\": -1\n" +
+                "  },\n" +
+                "  \"elastic_agent_id\": \"GoCD193659b3b930480287b898eeef0ade37\"\n" +
+                "}";
+
+        assertExtensionRequest("5.0", REQUEST_AGENT_STATUS_REPORT, requestBody);
+    }
+
+    @Test
+    public void allRequestMustHaveRequestPrefix() {
+        assertThat(REQUEST_PREFIX, is("cd.go.elastic-agent"));
+
+        assertThat(REQUEST_CREATE_AGENT, Matchers.startsWith(REQUEST_PREFIX));
+        assertThat(REQUEST_SERVER_PING, Matchers.startsWith(REQUEST_PREFIX));
+        assertThat(REQUEST_SHOULD_ASSIGN_WORK, Matchers.startsWith(REQUEST_PREFIX));
+
+        assertThat(REQUEST_GET_PROFILE_METADATA, Matchers.startsWith(REQUEST_PREFIX));
+        assertThat(REQUEST_GET_PROFILE_VIEW, Matchers.startsWith(REQUEST_PREFIX));
+        assertThat(REQUEST_VALIDATE_PROFILE, Matchers.startsWith(REQUEST_PREFIX));
+        assertThat(REQUEST_GET_PLUGIN_SETTINGS_ICON, Matchers.startsWith(REQUEST_PREFIX));
+    }
+
+    private void assertExtensionRequest(String extensionVersion, String requestName, String requestBody) {
+        final GoPluginApiRequest request = requestArgumentCaptor.getValue();
+        Assert.assertThat(request.requestName(), Matchers.is(requestName));
+        Assert.assertThat(request.extensionVersion(), Matchers.is(extensionVersion));
+        Assert.assertThat(request.extension(), Matchers.is(PluginConstants.ELASTIC_AGENT_EXTENSION));
+        assertThatJson(requestBody).isEqualTo(request.requestBody());
+    }
+}
+

--- a/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/elastic/v5/AgentMetadataConverterV5Test.java
+++ b/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/elastic/v5/AgentMetadataConverterV5Test.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.plugin.access.elastic.v5;
+
+import com.thoughtworks.go.plugin.access.elastic.models.AgentMetadata;
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+public class AgentMetadataConverterV5Test {
+
+    @Test
+    public void fromDTO_shouldConvertToAgentMetadataFromAgentMetadataDTO() {
+        final com.thoughtworks.go.plugin.access.elastic.v5.AgentMetadataDTO agentMetadataDTO = new com.thoughtworks.go.plugin.access.elastic.v5.AgentMetadataDTO("agent-id", "Idle", "Building", "Enabled");
+
+        final AgentMetadata agentMetadata = new AgentMetadataConverterV5().fromDTO(agentMetadataDTO);
+
+        assertThat(agentMetadata.elasticAgentId(), is("agent-id"));
+        assertThat(agentMetadata.agentState(), is("Idle"));
+        assertThat(agentMetadata.buildState(), is("Building"));
+        assertThat(agentMetadata.configState(), is("Enabled"));
+    }
+
+    @Test
+    public void fromDTO_shouldConvertToAgentMetadataDTOFromAgentMetadata() {
+        final AgentMetadata agentMetadata = new AgentMetadata("agent-id", "Idle", "Building", "Enabled");
+
+        final com.thoughtworks.go.plugin.access.elastic.v5.AgentMetadataDTO agentMetadataDTO = new AgentMetadataConverterV5().toDTO(agentMetadata);
+
+        assertThat(agentMetadataDTO.elasticAgentId(), is("agent-id"));
+        assertThat(agentMetadataDTO.agentState(), is("Idle"));
+        assertThat(agentMetadataDTO.buildState(), is("Building"));
+        assertThat(agentMetadataDTO.configState(), is("Enabled"));
+    }
+}

--- a/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/elastic/v5/CapabilitiesConverterV5Test.java
+++ b/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/elastic/v5/CapabilitiesConverterV5Test.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.plugin.access.elastic.v5;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.mockito.Mock;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+public class CapabilitiesConverterV5Test {
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+    @Mock
+    private com.thoughtworks.go.plugin.access.elastic.v5.CapabilitiesDTO capabilitiesDTO;
+    private CapabilitiesConverterV5 capabilitiesConverter;
+
+    @Before
+    public void setUp() throws Exception {
+        initMocks(this);
+        capabilitiesConverter = new CapabilitiesConverterV5();
+    }
+
+    @Test
+    public void fromDTO_shouldConvertToCapabilitiesFromCapabilitiesDTO() {
+        when(capabilitiesDTO.supportsStatusReport()).thenReturn(false);
+        when(capabilitiesDTO.supportsAgentStatusReport()).thenReturn(false);
+        assertFalse(capabilitiesConverter.fromDTO(capabilitiesDTO).supportsStatusReport());
+        assertFalse(capabilitiesConverter.fromDTO(capabilitiesDTO).supportsAgentStatusReport());
+
+        when(capabilitiesDTO.supportsStatusReport()).thenReturn(true);
+        when(capabilitiesDTO.supportsAgentStatusReport()).thenReturn(true);
+        assertTrue(capabilitiesConverter.fromDTO(capabilitiesDTO).supportsStatusReport());
+        assertTrue(capabilitiesConverter.fromDTO(capabilitiesDTO).supportsAgentStatusReport());
+
+        when(capabilitiesDTO.supportsStatusReport()).thenReturn(false);
+        when(capabilitiesDTO.supportsAgentStatusReport()).thenReturn(true);
+        assertFalse(capabilitiesConverter.fromDTO(capabilitiesDTO).supportsStatusReport());
+        assertTrue(capabilitiesConverter.fromDTO(capabilitiesDTO).supportsAgentStatusReport());
+
+        when(capabilitiesDTO.supportsStatusReport()).thenReturn(true);
+        when(capabilitiesDTO.supportsAgentStatusReport()).thenReturn(false);
+        assertTrue(capabilitiesConverter.fromDTO(capabilitiesDTO).supportsStatusReport());
+        assertFalse(capabilitiesConverter.fromDTO(capabilitiesDTO).supportsAgentStatusReport());
+    }
+}

--- a/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/elastic/v5/ElasticAgentExtensionConverterV5Test.java
+++ b/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/elastic/v5/ElasticAgentExtensionConverterV5Test.java
@@ -1,0 +1,214 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.plugin.access.elastic.v5;
+
+import com.google.gson.Gson;
+import com.thoughtworks.go.domain.JobIdentifier;
+import com.thoughtworks.go.plugin.access.elastic.models.AgentMetadata;
+import com.thoughtworks.go.plugin.api.response.validation.ValidationResult;
+import com.thoughtworks.go.plugin.domain.elastic.Capabilities;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static java.lang.String.format;
+import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.*;
+
+public class ElasticAgentExtensionConverterV5Test {
+    private JobIdentifier jobIdentifier;
+
+    @Before
+    public void setUp() throws Exception {
+        jobIdentifier = new JobIdentifier("test-pipeline", 1, "Test Pipeline", "test-stage", "1", "test-job");
+        jobIdentifier.setBuildId(100L);
+    }
+
+    @Test
+    public void shouldUnJSONizeCanHandleResponseBody() {
+        assertTrue(new Gson().fromJson("true", Boolean.class));
+        assertFalse(new Gson().fromJson("false", Boolean.class));
+    }
+
+    @Test
+    public void shouldUnJSONizeShouldAssignWorkResponseFromBody() {
+        assertTrue(new ElasticAgentExtensionConverterV5().shouldAssignWorkResponseFromBody("true"));
+        assertFalse(new ElasticAgentExtensionConverterV5().shouldAssignWorkResponseFromBody("false"));
+    }
+
+    @Test
+    public void shouldJSONizeCreateAgentRequestBody() throws Exception {
+        Map<String, String> configuration = new HashMap<>();
+        configuration.put("key1", "value1");
+        configuration.put("key2", "value2");
+        String json = new ElasticAgentExtensionConverterV5().createAgentRequestBody("secret-key", "prod", configuration, jobIdentifier);
+        assertThatJson(json).isEqualTo("{" +
+                "  \"auto_register_key\":\"secret-key\"," +
+                "  \"properties\":{" +
+                "    \"key1\":\"value1\"," +
+                "    \"key2\":\"value2\"" +
+                "    }," +
+                "  \"environment\":\"prod\"," +
+                "  \"job_identifier\": {\n" +
+                "    \"pipeline_name\": \"test-pipeline\",\n" +
+                "    \"pipeline_counter\": 1,\n" +
+                "    \"pipeline_label\": \"Test Pipeline\",\n" +
+                "    \"stage_name\": \"test-stage\",\n" +
+                "    \"stage_counter\": \"1\",\n" +
+                "    \"job_name\": \"test-job\",\n" +
+                "    \"job_id\": 100\n" +
+                "  }\n" +
+                "}");
+    }
+
+    @Test
+    public void shouldJSONizeShouldAssignWorkRequestBody() throws Exception {
+        HashMap<String, String> configuration = new HashMap<>();
+        configuration.put("property_name", "property_value");
+        String actual = new ElasticAgentExtensionConverterV5().shouldAssignWorkRequestBody(elasticAgent(), "prod", configuration, jobIdentifier);
+        String expected = "{" +
+                "  \"environment\":\"prod\"," +
+                "  \"agent\":{" +
+                "    \"agent_id\":\"52\"," +
+                "    \"agent_state\":\"Idle\"," +
+                "    \"build_state\":\"Idle\"," +
+                "    \"config_state\":\"Enabled\"" +
+                "  }," +
+                "  \"properties\":{" +
+                "    \"property_name\":\"property_value\"" +
+                "  }," +
+                "  \"job_identifier\": {\n" +
+                "    \"pipeline_name\": \"test-pipeline\",\n" +
+                "    \"pipeline_counter\": 1,\n" +
+                "    \"pipeline_label\": \"Test Pipeline\",\n" +
+                "    \"stage_name\": \"test-stage\",\n" +
+                "    \"stage_counter\": \"1\",\n" +
+                "    \"job_name\": \"test-job\",\n" +
+                "    \"job_id\": 100\n" +
+                "  }\n" +
+                "}";
+
+        assertThatJson(expected).isEqualTo(actual);
+    }
+
+    @Test
+    public void shouldJSONizeJobCompletionRequestBody() throws Exception {
+        String actual = new ElasticAgentExtensionConverterV5().getJobCompletionRequestBody("ea1", jobIdentifier);
+
+        String expected = "{" +
+                "  \"elastic_agent_id\":\"ea1\"," +
+                "  \"job_identifier\": {\n" +
+                "    \"pipeline_name\": \"test-pipeline\",\n" +
+                "    \"pipeline_counter\": 1,\n" +
+                "    \"pipeline_label\": \"Test Pipeline\",\n" +
+                "    \"stage_name\": \"test-stage\",\n" +
+                "    \"stage_counter\": \"1\",\n" +
+                "    \"job_name\": \"test-job\",\n" +
+                "    \"job_id\": 100\n" +
+                "  }\n" +
+                "}";
+
+        assertThatJson(expected).isEqualTo(actual);
+    }
+
+    @Test
+    public void shouldJSONizeElasticAgentStatusReportRequestBodyWhenElasticAgentIdIsProvided() throws Exception {
+        String elasticAgentId = "my-fancy-elastic-agent-id";
+        String actual = new ElasticAgentExtensionConverterV5().getAgentStatusReportRequestBody(null, elasticAgentId);
+        String expected = format("{" +
+                "  \"elastic_agent_id\": \"%s\"" +
+                "}", elasticAgentId);
+
+        assertThatJson(expected).isEqualTo(actual);
+    }
+
+    @Test
+    public void shouldJSONizeElasticAgentStatusReportRequestBodyWhenJobIdentifierIsProvided() throws Exception {
+        String actual = new ElasticAgentExtensionConverterV5().getAgentStatusReportRequestBody(jobIdentifier, null);
+        String expected = "{" +
+                "  \"job_identifier\": {\n" +
+                "    \"pipeline_name\": \"test-pipeline\",\n" +
+                "    \"pipeline_counter\": 1,\n" +
+                "    \"pipeline_label\": \"Test Pipeline\",\n" +
+                "    \"stage_name\": \"test-stage\",\n" +
+                "    \"stage_counter\": \"1\",\n" +
+                "    \"job_name\": \"test-job\",\n" +
+                "    \"job_id\": 100\n" +
+                "  }\n" +
+                "}";
+
+        assertThatJson(expected).isEqualTo(actual);
+    }
+
+    @Test
+    public void shouldConstructValidationRequest() {
+        HashMap<String, String> configuration = new HashMap<>();
+        configuration.put("key1", "value1");
+        configuration.put("key2", "value2");
+        configuration.put("key3", null);
+        String requestBody = new ElasticAgentExtensionConverterV5().validateElasticProfileRequestBody(configuration);
+        assertThatJson(requestBody).isEqualTo("{\"key3\":null,\"key2\":\"value2\",\"key1\":\"value1\"}");
+    }
+
+    @Test
+    public void shouldHandleValidationResponse() {
+        String responseBody = "[{\"key\":\"key-one\",\"message\":\"error on key one\"}, {\"key\":\"key-two\",\"message\":\"error on key two\"}]";
+        ValidationResult result = new ElasticAgentExtensionConverterV5().getElasticProfileValidationResultResponseFromBody(responseBody);
+        assertThat(result.isSuccessful(), is(false));
+        assertThat(result.getErrors().size(), is(2));
+        assertThat(result.getErrors().get(0).getKey(), is("key-one"));
+        assertThat(result.getErrors().get(0).getMessage(), is("error on key one"));
+        assertThat(result.getErrors().get(1).getKey(), is("key-two"));
+        assertThat(result.getErrors().get(1).getMessage(), is("error on key two"));
+    }
+
+    @Test
+    public void shouldUnJSONizeGetProfileViewResponseFromBody() {
+        String template = new ElasticAgentExtensionConverterV5().getProfileViewResponseFromBody("{\"template\":\"foo\"}");
+        assertThat(template, is("foo"));
+    }
+
+    @Test
+    public void shouldUnJSONizeGetImageResponseFromBody() {
+        com.thoughtworks.go.plugin.domain.common.Image image = new ElasticAgentExtensionConverterV5().getImageResponseFromBody("{\"content_type\":\"foo\", \"data\":\"bar\"}");
+        assertThat(image.getContentType(), is("foo"));
+        assertThat(image.getData(), is("bar"));
+    }
+
+    @Test
+    public void shouldGetStatusReportViewFromResponseBody() {
+        String template = new ElasticAgentExtensionConverterV5().getStatusReportView("{\"view\":\"foo\"}");
+        assertThat(template, is("foo"));
+    }
+
+    @Test
+    public void shouldGetCapabilitiesFromResponseBody() {
+        String responseBody = "{\"supports_status_report\":\"true\",\"supports_agent_status_report\":\"true\"}";
+
+        Capabilities capabilities = new ElasticAgentExtensionConverterV5().getCapabilitiesFromResponseBody(responseBody);
+
+        assertTrue(capabilities.supportsStatusReport());
+        assertTrue(capabilities.supportsAgentStatusReport());
+    }
+
+    private AgentMetadata elasticAgent() {
+        return new AgentMetadata("52", "Idle", "Idle", "Enabled");
+    }
+}

--- a/server/src/main/java/com/thoughtworks/go/config/update/AddClusterProfileCommand.java
+++ b/server/src/main/java/com/thoughtworks/go/config/update/AddClusterProfileCommand.java
@@ -19,13 +19,14 @@ package com.thoughtworks.go.config.update;
 import com.thoughtworks.go.config.CruiseConfig;
 import com.thoughtworks.go.config.elastic.ClusterProfile;
 import com.thoughtworks.go.config.elastic.ClusterProfiles;
+import com.thoughtworks.go.plugin.access.elastic.ElasticAgentExtension;
 import com.thoughtworks.go.server.domain.Username;
 import com.thoughtworks.go.server.service.GoConfigService;
 import com.thoughtworks.go.server.service.result.HttpLocalizedOperationResult;
 
 public class AddClusterProfileCommand extends ClusterProfileCommand {
-    public AddClusterProfileCommand(GoConfigService goConfigService, ClusterProfile clusterProfile, Username username, HttpLocalizedOperationResult result) {
-        super(goConfigService, clusterProfile, username, result);
+    public AddClusterProfileCommand(ElasticAgentExtension extension, GoConfigService goConfigService, ClusterProfile clusterProfile, Username username, HttpLocalizedOperationResult result) {
+        super(extension, goConfigService, clusterProfile, username, result);
     }
 
     @Override

--- a/server/src/main/java/com/thoughtworks/go/config/update/ClusterProfileCommand.java
+++ b/server/src/main/java/com/thoughtworks/go/config/update/ClusterProfileCommand.java
@@ -20,6 +20,7 @@ import com.thoughtworks.go.config.CruiseConfig;
 import com.thoughtworks.go.config.elastic.ClusterProfile;
 import com.thoughtworks.go.config.elastic.ClusterProfiles;
 import com.thoughtworks.go.i18n.LocalizedMessage;
+import com.thoughtworks.go.plugin.access.elastic.ElasticAgentExtension;
 import com.thoughtworks.go.plugin.api.response.validation.ValidationResult;
 import com.thoughtworks.go.server.domain.Username;
 import com.thoughtworks.go.server.service.GoConfigService;
@@ -29,8 +30,11 @@ import com.thoughtworks.go.serverhealth.HealthStateType;
 import java.util.Map;
 
 public abstract class ClusterProfileCommand extends PluginProfileCommand<ClusterProfile, ClusterProfiles> {
-    public ClusterProfileCommand(GoConfigService goConfigService, ClusterProfile clusterProfile, Username username, HttpLocalizedOperationResult result) {
+    private final ElasticAgentExtension extension;
+
+    public ClusterProfileCommand(ElasticAgentExtension extension, GoConfigService goConfigService, ClusterProfile clusterProfile, Username username, HttpLocalizedOperationResult result) {
         super(goConfigService, clusterProfile, username, result);
+        this.extension = extension;
     }
 
     @Override
@@ -40,8 +44,7 @@ public abstract class ClusterProfileCommand extends PluginProfileCommand<Cluster
 
     @Override
     public ValidationResult validateUsingExtension(String pluginId, Map<String, String> configuration) {
-        //todo: @Vrushali and @Ganesh did this. change this to talk to real extension.
-        return new ValidationResult();
+        return extension.validateClusterProfile(pluginId, configuration);
     }
 
     @Override

--- a/server/src/main/java/com/thoughtworks/go/config/update/DeleteClusterProfileCommand.java
+++ b/server/src/main/java/com/thoughtworks/go/config/update/DeleteClusterProfileCommand.java
@@ -20,13 +20,14 @@ import com.thoughtworks.go.config.CruiseConfig;
 import com.thoughtworks.go.config.elastic.ClusterProfile;
 import com.thoughtworks.go.config.elastic.ClusterProfiles;
 import com.thoughtworks.go.i18n.LocalizedMessage;
+import com.thoughtworks.go.plugin.access.elastic.ElasticAgentExtension;
 import com.thoughtworks.go.server.domain.Username;
 import com.thoughtworks.go.server.service.GoConfigService;
 import com.thoughtworks.go.server.service.result.HttpLocalizedOperationResult;
 
 public class DeleteClusterProfileCommand extends ClusterProfileCommand {
-    public DeleteClusterProfileCommand(GoConfigService goConfigService, ClusterProfile clusterProfile, Username currentUser, HttpLocalizedOperationResult result) {
-        super(goConfigService, clusterProfile, currentUser, result);
+    public DeleteClusterProfileCommand(ElasticAgentExtension extension, GoConfigService goConfigService, ClusterProfile clusterProfile, Username currentUser, HttpLocalizedOperationResult result) {
+        super(extension, goConfigService, clusterProfile, currentUser, result);
     }
 
     @Override

--- a/server/src/main/java/com/thoughtworks/go/config/update/UpdateClusterProfileCommand.java
+++ b/server/src/main/java/com/thoughtworks/go/config/update/UpdateClusterProfileCommand.java
@@ -19,13 +19,14 @@ package com.thoughtworks.go.config.update;
 import com.thoughtworks.go.config.CruiseConfig;
 import com.thoughtworks.go.config.elastic.ClusterProfile;
 import com.thoughtworks.go.config.elastic.ClusterProfiles;
+import com.thoughtworks.go.plugin.access.elastic.ElasticAgentExtension;
 import com.thoughtworks.go.server.domain.Username;
 import com.thoughtworks.go.server.service.GoConfigService;
 import com.thoughtworks.go.server.service.result.HttpLocalizedOperationResult;
 
 public class UpdateClusterProfileCommand extends ClusterProfileCommand {
-    public UpdateClusterProfileCommand(GoConfigService goConfigService, ClusterProfile clusterProfile, Username username, HttpLocalizedOperationResult result) {
-        super(goConfigService, clusterProfile, username, result);
+    public UpdateClusterProfileCommand(ElasticAgentExtension extension, GoConfigService goConfigService, ClusterProfile clusterProfile, Username username, HttpLocalizedOperationResult result) {
+        super(extension, goConfigService, clusterProfile, username, result);
     }
 
     @Override

--- a/server/src/main/java/com/thoughtworks/go/server/service/ClusterProfilesService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/ClusterProfilesService.java
@@ -21,6 +21,7 @@ import com.thoughtworks.go.config.elastic.ClusterProfile;
 import com.thoughtworks.go.config.update.AddClusterProfileCommand;
 import com.thoughtworks.go.config.update.DeleteClusterProfileCommand;
 import com.thoughtworks.go.config.update.UpdateClusterProfileCommand;
+import com.thoughtworks.go.plugin.access.elastic.ElasticAgentExtension;
 import com.thoughtworks.go.server.domain.Username;
 import com.thoughtworks.go.server.service.result.HttpLocalizedOperationResult;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -28,9 +29,12 @@ import org.springframework.stereotype.Component;
 
 @Component
 public class ClusterProfilesService extends PluginProfilesService<ClusterProfile> {
+    private final ElasticAgentExtension extension;
+
     @Autowired
-    public ClusterProfilesService(GoConfigService goConfigService, EntityHashingService hashingService) {
+    public ClusterProfilesService(GoConfigService goConfigService, EntityHashingService hashingService, ElasticAgentExtension extension) {
         super(goConfigService, hashingService);
+        this.extension = extension;
     }
 
     @Override
@@ -39,18 +43,18 @@ public class ClusterProfilesService extends PluginProfilesService<ClusterProfile
     }
 
     public ClusterProfile create(ClusterProfile clusterProfile, Username currentUser, HttpLocalizedOperationResult result) {
-        AddClusterProfileCommand addClusterProfileCommand = new AddClusterProfileCommand(goConfigService, clusterProfile, currentUser, result);
+        AddClusterProfileCommand addClusterProfileCommand = new AddClusterProfileCommand(extension, goConfigService, clusterProfile, currentUser, result);
         update(currentUser, clusterProfile, result, addClusterProfileCommand);
         return clusterProfile;
     }
 
     public void delete(ClusterProfile clusterProfile, Username currentUser, HttpLocalizedOperationResult result) {
-        DeleteClusterProfileCommand deleteClusterProfileCommand = new DeleteClusterProfileCommand(goConfigService, clusterProfile, currentUser, result);
+        DeleteClusterProfileCommand deleteClusterProfileCommand = new DeleteClusterProfileCommand(extension, goConfigService, clusterProfile, currentUser, result);
         update(currentUser, clusterProfile, result, deleteClusterProfileCommand);
     }
 
     public ClusterProfile update(ClusterProfile newClusterProfile, Username currentUser, HttpLocalizedOperationResult result) {
-        UpdateClusterProfileCommand updateClusterProfileCommand = new UpdateClusterProfileCommand(goConfigService, newClusterProfile, currentUser, result);
+        UpdateClusterProfileCommand updateClusterProfileCommand = new UpdateClusterProfileCommand(extension, goConfigService, newClusterProfile, currentUser, result);
         update(currentUser, newClusterProfile, result, updateClusterProfileCommand);
         return newClusterProfile;
     }

--- a/server/src/test-fast/java/com/thoughtworks/go/config/update/AddClusterProfileCommandTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/config/update/AddClusterProfileCommandTest.java
@@ -19,6 +19,7 @@ package com.thoughtworks.go.config.update;
 import com.thoughtworks.go.config.BasicCruiseConfig;
 import com.thoughtworks.go.config.CruiseConfig;
 import com.thoughtworks.go.config.elastic.ClusterProfile;
+import com.thoughtworks.go.plugin.access.elastic.ElasticAgentExtension;
 import com.thoughtworks.go.server.domain.Username;
 import com.thoughtworks.go.server.service.GoConfigService;
 import com.thoughtworks.go.server.service.result.HttpLocalizedOperationResult;
@@ -26,13 +27,17 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 
+import java.util.HashMap;
+
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 import static org.mockito.MockitoAnnotations.initMocks;
 
 class AddClusterProfileCommandTest {
     @Mock
     private GoConfigService goConfigService;
+    @Mock
+    private ElasticAgentExtension extension;
     private ClusterProfile clusterProfile;
     private Username username;
     private HttpLocalizedOperationResult result;
@@ -47,7 +52,7 @@ class AddClusterProfileCommandTest {
         clusterProfile = new ClusterProfile("cluster-id", "plugin-id");
         username = new Username("Bob");
         result = new HttpLocalizedOperationResult();
-        command = new AddClusterProfileCommand(goConfigService, clusterProfile, username, result);
+        command = new AddClusterProfileCommand(extension, goConfigService, clusterProfile, username, result);
     }
 
     @Test
@@ -84,5 +89,14 @@ class AddClusterProfileCommandTest {
     @Test
     void shouldSpecifyClusterProfileObjectDescriptor() {
         assertThat(command.getObjectDescriptor()).isEqualTo("Cluster Profile");
+    }
+
+    @Test
+    void shouldMakeACallToExtensionToValidateClusterProfile() {
+        String pluginId = "plugin-id";
+        HashMap<String, String> configuration = new HashMap<>();
+        command.validateUsingExtension(pluginId, configuration);
+
+        verify(extension, times(1)).validateClusterProfile(pluginId, configuration);
     }
 }

--- a/server/src/test-fast/java/com/thoughtworks/go/config/update/DeleteClusterProfileCommandTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/config/update/DeleteClusterProfileCommandTest.java
@@ -19,6 +19,7 @@ package com.thoughtworks.go.config.update;
 import com.thoughtworks.go.config.BasicCruiseConfig;
 import com.thoughtworks.go.config.CruiseConfig;
 import com.thoughtworks.go.config.elastic.ClusterProfile;
+import com.thoughtworks.go.plugin.access.elastic.ElasticAgentExtension;
 import com.thoughtworks.go.server.domain.Username;
 import com.thoughtworks.go.server.service.GoConfigService;
 import com.thoughtworks.go.server.service.result.HttpLocalizedOperationResult;
@@ -33,6 +34,8 @@ import static org.mockito.MockitoAnnotations.initMocks;
 class DeleteClusterProfileCommandTest {
     @Mock
     private GoConfigService goConfigService;
+    @Mock
+    private ElasticAgentExtension extension;
     private ClusterProfile clusterProfile;
     private Username username;
     private HttpLocalizedOperationResult result;
@@ -48,7 +51,7 @@ class DeleteClusterProfileCommandTest {
         config.getElasticConfig().getClusterProfiles().add(clusterProfile);
         username = new Username("Bob");
         result = new HttpLocalizedOperationResult();
-        command = new DeleteClusterProfileCommand(goConfigService, clusterProfile, username, result);
+        command = new DeleteClusterProfileCommand(extension, goConfigService, clusterProfile, username, result);
     }
 
     @Test

--- a/server/src/test-fast/java/com/thoughtworks/go/config/update/UpdateClusterProfileCommandTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/config/update/UpdateClusterProfileCommandTest.java
@@ -19,6 +19,7 @@ package com.thoughtworks.go.config.update;
 import com.thoughtworks.go.config.BasicCruiseConfig;
 import com.thoughtworks.go.config.CruiseConfig;
 import com.thoughtworks.go.config.elastic.ClusterProfile;
+import com.thoughtworks.go.plugin.access.elastic.ElasticAgentExtension;
 import com.thoughtworks.go.server.domain.Username;
 import com.thoughtworks.go.server.service.GoConfigService;
 import com.thoughtworks.go.server.service.result.HttpLocalizedOperationResult;
@@ -26,13 +27,18 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 
+import java.util.HashMap;
+
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 import static org.mockito.MockitoAnnotations.initMocks;
 
 class UpdateClusterProfileCommandTest {
     @Mock
     private GoConfigService goConfigService;
+    @Mock
+    private ElasticAgentExtension extension;
+
     private ClusterProfile clusterProfile;
     private Username username;
     private HttpLocalizedOperationResult result;
@@ -48,7 +54,7 @@ class UpdateClusterProfileCommandTest {
         config.getElasticConfig().getClusterProfiles().add(clusterProfile);
         username = new Username("Bob");
         result = new HttpLocalizedOperationResult();
-        command = new UpdateClusterProfileCommand(goConfigService, clusterProfile, username, result);
+        command = new UpdateClusterProfileCommand(extension, goConfigService, clusterProfile, username, result);
     }
 
     @Test
@@ -84,5 +90,14 @@ class UpdateClusterProfileCommandTest {
     @Test
     void shouldSpecifyClusterProfileObjectDescriptor() {
         assertThat(command.getObjectDescriptor()).isEqualTo("Cluster Profile");
+    }
+
+    @Test
+    void shouldMakeACallToExtensionToValidateClusterProfile() {
+        String pluginId = "plugin-id";
+        HashMap<String, String> configuration = new HashMap<>();
+        command.validateUsingExtension(pluginId, configuration);
+
+        verify(extension, times(1)).validateClusterProfile(pluginId, configuration);
     }
 }

--- a/server/src/test-fast/java/com/thoughtworks/go/server/service/ClusterProfilesServiceTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/service/ClusterProfilesServiceTest.java
@@ -20,12 +20,15 @@ import com.thoughtworks.go.config.PluginProfiles;
 import com.thoughtworks.go.config.elastic.ClusterProfile;
 import com.thoughtworks.go.config.elastic.ClusterProfiles;
 import com.thoughtworks.go.config.elastic.ElasticConfig;
+import com.thoughtworks.go.plugin.access.elastic.ElasticAgentExtension;
+import com.thoughtworks.go.server.domain.Username;
+import com.thoughtworks.go.server.service.result.HttpLocalizedOperationResult;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 import static org.mockito.MockitoAnnotations.initMocks;
 
 public class ClusterProfilesServiceTest {
@@ -33,6 +36,8 @@ public class ClusterProfilesServiceTest {
     private GoConfigService goConfigService;
     @Mock
     private EntityHashingService hashingService;
+    @Mock
+    private ElasticAgentExtension extension;
 
     private ClusterProfilesService clusterProfilesService;
     private ClusterProfile clusterProfile;
@@ -43,7 +48,7 @@ public class ClusterProfilesServiceTest {
 
         clusterProfile = new ClusterProfile("prod_cluster", "k8s.ea.plugin");
 
-        clusterProfilesService = new ClusterProfilesService(goConfigService, hashingService);
+        clusterProfilesService = new ClusterProfilesService(goConfigService, hashingService, extension);
     }
 
     @Test
@@ -55,5 +60,19 @@ public class ClusterProfilesServiceTest {
         PluginProfiles<ClusterProfile> actualClusterProfiles = clusterProfilesService.getPluginProfiles();
 
         assertThat(actualClusterProfiles).isEqualTo(elasticConfig.getClusterProfiles());
+    }
+
+    @Test
+    void shouldValidateClusterProfileUponClusterProfileCreation() {
+        clusterProfilesService.create(clusterProfile, new Username("Bob"), new HttpLocalizedOperationResult());
+
+        verify(extension, times(1)).validateClusterProfile(clusterProfile.getPluginId(), clusterProfile.getConfigurationAsMap(true));
+    }
+
+    @Test
+    void shouldValidateClusterProfileUponClusterProfileUpdate() {
+        clusterProfilesService.update(clusterProfile, new Username("Bob"), new HttpLocalizedOperationResult());
+
+        verify(extension, times(1)).validateClusterProfile(clusterProfile.getPluginId(), clusterProfile.getConfigurationAsMap(true));
     }
 }


### PR DESCRIPTION
* Introduce cluster profile related plugin API calls into EA extension v5
* Introduce following new extension API calls:
	- get-cluster-profile-metadata
	- get-cluster-profile-view
	- validate-cluster-profile
* Modify Cluster Profile API to validate cluster profiles upon creation and
  update.
