### PR TITLE
Fix system notifications

### DIFF
--- a/server/webapp/WEB-INF/rails/webpack/models/notifications/system_notifications.ts
+++ b/server/webapp/WEB-INF/rails/webpack/models/notifications/system_notifications.ts
@@ -103,7 +103,12 @@ export class SystemNotifications {
                                                message, type, link, linkText
                                              } as Notification));
 
+    const existingArrayPrototype = (Array.prototype as any).toJSON;
+    delete (Array.prototype as any).toJSON;
+
     localStorage.setItem("system_notifications", JSON.stringify(systemNotifications.toJSON()));
+
+    (Array.prototype as any).toJSON = existingArrayPrototype;
   }
 
   //model_mixin method

--- a/server/webapp/WEB-INF/rails/webpack/models/notifications/system_notifications.ts
+++ b/server/webapp/WEB-INF/rails/webpack/models/notifications/system_notifications.ts
@@ -77,8 +77,15 @@ export class SystemNotifications {
 
   static all() {
     return new Promise<SystemNotifications>((resolve) => {
-      const notifications: Notification[] = JSON.parse(localStorage.getItem("system_notifications") || "[]");
-      resolve(SystemNotifications.fromJSON(notifications));
+      try {
+        const notifications: Notification[] = JSON.parse(localStorage.getItem("system_notifications") || "[]");
+        const systemNotifications           = SystemNotifications.fromJSON(notifications);
+        resolve(systemNotifications);
+      } catch (e) {
+        //Badly escaped data causing system notification to fail while reading.
+        //clear the current local storage. on next page refresh, each notification handler will populate the new notification message.
+        localStorage.setItem("system_notifications", "[]");
+      }
     });
   }
 


### PR DESCRIPTION
Fix system notifications string escaping problem (#5968)

* System Notifications are stored into browswer's local storage as string.
to convert system notifications to JSON string we do
'JSON.stringify(systemNotifications)', where systemNotifications is an array
of system notification JSON.

* When a notification is received when the user is on the SPAs, everything works.

### Problem:
When a notification is received when the user is on the old rails pages, the
system notifications are double escaped and then stored into the local storage.
Reading of the double escaped string from local storage fails and system
notifications are never shown on the header.

### Why notifications are double escaped on rails pages only?:
JSON.stringify double escapes string becuase of including prototype.js into older
pages.
prototype.js defines 'Array.prototype.toJSON' method, which will be invoked for
JSON.stringify on an array if present.

### Fix:
Delete 'Array.prototype.toJSON' method definition before doing JSON.stringify of
system notifications.

### Note:
* Prototype.js can not be removed from the older pages as alot of our implementation
  depends on this monkey-patched methods.
* Even with js-componentizations, the exact same code works on SPAs and fails on older
  pages because of poluted environment.

---

#### Clear out local storage when reading of system notifications fails

* Because of issue #5968, the system notification local storage data will
be in a double escaped form.
* Fix mentioned as part of commit d8e4a8a13e7b0c5f48cc0bee6305d603dec4488f
will avoid causing similar situations.
* For the users having badly escaped data, system notifications will not be
shown on the header. Hence, Clear the current local storage. On the next
page refresh, each notification handler will repopulate the local storage with
appropriate notification message.
