### PR TITLE
Environment api accepts both value and encrypted_value for env vars

### DIFF
--- a/api/api-environments-v2/src/main/java/com/thoughtworks/go/apiv2/environments/representers/EnvironmentRepresenter.java
+++ b/api/api-environments-v2/src/main/java/com/thoughtworks/go/apiv2/environments/representers/EnvironmentRepresenter.java
@@ -60,10 +60,7 @@ public class EnvironmentRepresenter {
 
         jsonReader.readArrayIfPresent("environment_variables",
                 array -> array.forEach(envVar -> {
-                            String name = envVar.getAsJsonObject().get("name").getAsString();
-                            String value = envVar.getAsJsonObject().get("value").getAsString();
-                            boolean secure = envVar.getAsJsonObject().get("secure").getAsBoolean();
-                            environmentConfig.addEnvironmentVariable(new EnvironmentVariableConfig(new GoCipher(), name, value, secure));
+                            environmentConfig.addEnvironmentVariable(EnvironmentVariableRepresenter.fromJSON(envVar.getAsJsonObject()));
                         }
                 )
         );

--- a/api/api-environments-v2/src/main/java/com/thoughtworks/go/apiv2/environments/representers/EnvironmentVariableRepresenter.java
+++ b/api/api-environments-v2/src/main/java/com/thoughtworks/go/apiv2/environments/representers/EnvironmentVariableRepresenter.java
@@ -19,6 +19,7 @@ package com.thoughtworks.go.apiv2.environments.representers;
 import com.google.gson.JsonObject;
 import com.thoughtworks.go.api.base.OutputWriter;
 import com.thoughtworks.go.config.EnvironmentVariableConfig;
+import com.thoughtworks.go.config.VariableValueConfig;
 import com.thoughtworks.go.security.GoCipher;
 
 
@@ -31,12 +32,16 @@ public class EnvironmentVariableRepresenter {
     }
 
     public static EnvironmentVariableConfig fromJSON(JsonObject jsonReader) {
-        String name = jsonReader.get("name").getAsString();
-        String value = jsonReader.get("value").getAsString();
         boolean secure = jsonReader.has("secure") && jsonReader.get("secure").getAsBoolean();
-
-        EnvironmentVariableConfig environmentConfig = new EnvironmentVariableConfig(new GoCipher(), name, value, secure);
-        return environmentConfig;
+        EnvironmentVariableConfig environmentVariableConfig = new EnvironmentVariableConfig();
+        environmentVariableConfig.setName(jsonReader.get("name").getAsString());
+        if (secure) {
+            environmentVariableConfig.setEncryptedValue(jsonReader.get("encrypted_value").getAsString());
+            environmentVariableConfig.setIsSecure(secure);
+        } else {
+            environmentVariableConfig.setValue(new VariableValueConfig(jsonReader.get("value").getAsString()));
+        }
+        return environmentVariableConfig;
     }
 
     private static void addValue(OutputWriter outputWriter, EnvironmentVariableConfig environmentVariableConfig) {

--- a/api/api-environments-v2/src/main/java/com/thoughtworks/go/apiv2/environments/representers/EnvironmentVariableRepresenter.java
+++ b/api/api-environments-v2/src/main/java/com/thoughtworks/go/apiv2/environments/representers/EnvironmentVariableRepresenter.java
@@ -19,8 +19,6 @@ package com.thoughtworks.go.apiv2.environments.representers;
 import com.google.gson.JsonObject;
 import com.thoughtworks.go.api.base.OutputWriter;
 import com.thoughtworks.go.config.EnvironmentVariableConfig;
-import com.thoughtworks.go.config.VariableValueConfig;
-import com.thoughtworks.go.security.GoCipher;
 
 
 public class EnvironmentVariableRepresenter {
@@ -32,14 +30,14 @@ public class EnvironmentVariableRepresenter {
     }
 
     public static EnvironmentVariableConfig fromJSON(JsonObject jsonReader) {
-        boolean secure = jsonReader.has("secure") && jsonReader.get("secure").getAsBoolean();
         EnvironmentVariableConfig environmentVariableConfig = new EnvironmentVariableConfig();
         environmentVariableConfig.setName(jsonReader.get("name").getAsString());
-        if (secure) {
+        environmentVariableConfig.setIsSecure(jsonReader.has("secure") && jsonReader.get("secure").getAsBoolean());
+        if (jsonReader.has("encrypted_value")) {
             environmentVariableConfig.setEncryptedValue(jsonReader.get("encrypted_value").getAsString());
-            environmentVariableConfig.setIsSecure(secure);
-        } else {
-            environmentVariableConfig.setValue(new VariableValueConfig(jsonReader.get("value").getAsString()));
+        }
+        if (jsonReader.has("value")) {
+            environmentVariableConfig.setValue(jsonReader.get("value").getAsString());
         }
         return environmentVariableConfig;
     }

--- a/api/api-environments-v2/src/test/groovy/com/thoughtworks/go/apiv2/environments/EnvironmentsControllerV2Test.groovy
+++ b/api/api-environments-v2/src/test/groovy/com/thoughtworks/go/apiv2/environments/EnvironmentsControllerV2Test.groovy
@@ -23,7 +23,9 @@ import com.thoughtworks.go.apiv2.environments.representers.EnvironmentsRepresent
 import com.thoughtworks.go.config.BasicEnvironmentConfig
 import com.thoughtworks.go.config.CaseInsensitiveString
 import com.thoughtworks.go.config.EnvironmentConfig
+import com.thoughtworks.go.config.EnvironmentVariableConfig
 import com.thoughtworks.go.domain.ConfigElementForEdit
+import com.thoughtworks.go.security.GoCipher
 import com.thoughtworks.go.server.service.EntityHashingService
 import com.thoughtworks.go.server.service.EnvironmentConfigService
 import com.thoughtworks.go.server.service.result.HttpLocalizedOperationResult
@@ -260,6 +262,7 @@ class EnvironmentsControllerV2Test implements SecurityServiceTrait, ControllerTr
         def env1 = new BasicEnvironmentConfig(new CaseInsensitiveString("env1"))
         env1.addAgent("agent1")
         env1.addAgent("agent2")
+        env1.addEnvironmentVariable(new EnvironmentVariableConfig(new GoCipher(), "SECURE", "password", true))
         env1.addEnvironmentVariable("JAVA_HOME", "/bin/java")
         env1.addPipeline(new CaseInsensitiveString("Pipeline1"))
         env1.addPipeline(new CaseInsensitiveString("Pipeline2"))
@@ -437,6 +440,7 @@ class EnvironmentsControllerV2Test implements SecurityServiceTrait, ControllerTr
         def env1 = new BasicEnvironmentConfig(new CaseInsensitiveString("env1"))
         env1.addAgent("agent1")
         env1.addAgent("agent2")
+        env1.addEnvironmentVariable(new EnvironmentVariableConfig(new GoCipher(), "SECURE", "password", true))
         env1.addEnvironmentVariable("JAVA_HOME", "/bin/java")
         env1.addPipeline(new CaseInsensitiveString("Pipeline1"))
         env1.addPipeline(new CaseInsensitiveString("Pipeline2"))

--- a/api/api-environments-v2/src/test/groovy/com/thoughtworks/go/apiv2/environments/representers/EnvironmentVariableRepresenterTest.groovy
+++ b/api/api-environments-v2/src/test/groovy/com/thoughtworks/go/apiv2/environments/representers/EnvironmentVariableRepresenterTest.groovy
@@ -16,12 +16,14 @@
 
 package com.thoughtworks.go.apiv2.environments.representers
 
+import com.google.gson.JsonParser
 import com.thoughtworks.go.config.EnvironmentVariableConfig
 import com.thoughtworks.go.security.GoCipher
 import org.junit.jupiter.api.Test
 
 import static com.thoughtworks.go.api.base.JsonUtils.toObjectString
 import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson
+import static org.assertj.core.api.Assertions.assertThat
 
 class EnvironmentVariableRepresenterTest {
 
@@ -49,5 +51,27 @@ class EnvironmentVariableRepresenterTest {
       "name"           : "secret",
       "secure"         : true
     ])
+  }
+
+  @Test
+  void 'should deserialize from JSON'() {
+    EnvironmentVariableConfig expected = new EnvironmentVariableConfig("JAVA_HOME", "/bin/java")
+
+    def json = toObjectString({ EnvironmentVariableRepresenter.toJSON(it, expected) })
+    JsonParser parser = new JsonParser()
+    EnvironmentVariableConfig actual = EnvironmentVariableRepresenter.fromJSON(parser.parse(json).getAsJsonObject())
+
+    assertThat(actual).isEqualTo(expected)
+  }
+
+  @Test
+  void 'should deserialize secure environment variable from JSON'() {
+    EnvironmentVariableConfig expected = new EnvironmentVariableConfig(new GoCipher(), "secret", "password", true)
+
+    def json = toObjectString({ EnvironmentVariableRepresenter.toJSON(it, expected) })
+    JsonParser parser = new JsonParser()
+    EnvironmentVariableConfig actual = EnvironmentVariableRepresenter.fromJSON(parser.parse(json).getAsJsonObject())
+
+    assertThat(actual).isEqualTo(expected)
   }
 }


### PR DESCRIPTION
see #5956 bug number two. @rajiesh provides more details [here](https://github.com/gocd/gocd/issues/5956#issuecomment-470489060)