### PR TITLE
Allow expanding environment row from UI containing special character in the name (#5973)

### DIFF
--- a/server/webapp/WEB-INF/rails/app/views/environments/_show_env.html.erb
+++ b/server/webapp/WEB-INF/rails/app/views/environments/_show_env.html.erb
@@ -74,8 +74,9 @@
 <%= end_content_wrapper %>
 <script type="text/javascript">
     Util.on_load(function () {
-        var envHeader = "#<%='environment_entity_'+environment.name().to_s%> .environment-header";
-        var env = "#<%='environment_entity_'+environment.name().to_s%>";
+        var envHeader = "div[id=\"<%='environment_entity_'+environment.name().to_s%>\"] > .environment-header";
+        var env       = "div[id=\"<%='environment_entity_'+environment.name().to_s%>\"]";
+
         jQuery(envHeader).click(function () {
             if (jQuery(env).hasClass("expanded")) {
                 jQuery(env).removeClass("expanded");


### PR DESCRIPTION
* GoCD Environment variables can have "-", "." and "_" in the environment name.
  Allow environments with special characters to be expanded via GUI

* Use attribute selector to specify id in the quotes.

![Screen Shot 2019-03-13 at 1 43 28 PM](https://user-images.githubusercontent.com/15275847/54263192-4a91f080-4596-11e9-837b-69de5aaa5c6c.png)
