### PR TITLE
Add webhook endpoint for hosted bitbucket servers (#4241)

### DIFF
--- a/server/webapp/WEB-INF/rails/app/controllers/api/web_hooks/bit_bucket_controller.rb
+++ b/server/webapp/WEB-INF/rails/app/controllers/api/web_hooks/bit_bucket_controller.rb
@@ -16,7 +16,7 @@
 
 module Api
   module WebHooks
-    class BitBucketController < WebHookController
+    class BitBucketController < GuessUrlWebHookController
       before_action :verify_content_origin
       before_action :allow_only_push_event
       before_action :allow_only_git_scm

--- a/server/webapp/WEB-INF/rails/app/controllers/api/web_hooks/git_hub_controller.rb
+++ b/server/webapp/WEB-INF/rails/app/controllers/api/web_hooks/git_hub_controller.rb
@@ -16,7 +16,7 @@
 
 module Api
   module WebHooks
-    class GitHubController < WebHookController
+    class GitHubController < GuessUrlWebHookController
       before_action :verify_content_origin
       before_action :prempt_ping_call
       before_action :allow_only_push_event

--- a/server/webapp/WEB-INF/rails/app/controllers/api/web_hooks/git_lab_controller.rb
+++ b/server/webapp/WEB-INF/rails/app/controllers/api/web_hooks/git_lab_controller.rb
@@ -16,7 +16,7 @@
 
 module Api
   module WebHooks
-    class GitLabController < WebHookController
+    class GitLabController < GuessUrlWebHookController
       before_action :verify_content_origin
       before_action :allow_only_push_event
       before_action :verify_payload

--- a/server/webapp/WEB-INF/rails/app/controllers/api/web_hooks/guess_url_web_hook_controller.rb
+++ b/server/webapp/WEB-INF/rails/app/controllers/api/web_hooks/guess_url_web_hook_controller.rb
@@ -1,0 +1,57 @@
+##########################################################################
+# Copyright 2018 ThoughtWorks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+
+module Api
+  module WebHooks
+    class GuessUrlWebHookController < WebHookController
+
+      protected
+      def possible_urls
+        %W(
+          https://#{repo_host_name}/#{repo_full_name}
+          https://#{repo_host_name}/#{repo_full_name}/
+          https://#{repo_host_name}/#{repo_full_name}.git
+          https://#{repo_host_name}/#{repo_full_name}.git/
+          http://#{repo_host_name}/#{repo_full_name}
+          http://#{repo_host_name}/#{repo_full_name}/
+          http://#{repo_host_name}/#{repo_full_name}.git
+          http://#{repo_host_name}/#{repo_full_name}.git/
+          git://#{repo_host_name}/#{repo_full_name}
+          git://#{repo_host_name}/#{repo_full_name}/
+          git://#{repo_host_name}/#{repo_full_name}.git
+          git://#{repo_host_name}/#{repo_full_name}.git/
+          git@#{repo_host_name}:#{repo_full_name}
+          git@#{repo_host_name}:#{repo_full_name}/
+          git@#{repo_host_name}:#{repo_full_name}.git
+          git@#{repo_host_name}:#{repo_full_name}.git/
+        )
+      end
+
+      def repo_log_name
+        "#{repo_host_name}/#{repo_full_name}"
+      end
+
+      def repo_host_name
+        raise 'Subclass responsibility!'
+      end
+
+      def repo_full_name
+        raise 'Subclass responsibility!'
+      end
+      
+    end
+  end
+end

--- a/server/webapp/WEB-INF/rails/app/controllers/api/web_hooks/hosted_bit_bucket_controller.rb
+++ b/server/webapp/WEB-INF/rails/app/controllers/api/web_hooks/hosted_bit_bucket_controller.rb
@@ -1,0 +1,109 @@
+##########################################################################
+# Copyright 2017 ThoughtWorks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+
+module Api
+  module WebHooks
+    class HostedBitBucketController < WebHookController
+      before_action :prempt_ping_call
+      before_action :verify_content_origin
+      before_action :allow_only_push_event
+      before_action :allow_only_git_scm
+      before_action :verify_payload
+
+      protected
+
+      def repo_branch
+        payload['changes'].find {|change| change['ref']['type'] == 'BRANCH'}['ref']['displayId']
+      rescue
+        nil
+      end
+
+      def possible_urls
+        payload['repository']['links']['clone'].collect {|l| without_credentials(l['href'])}
+      end
+
+      def without_credentials (str)
+        uri = URI.parse(str)
+        uri.user = nil
+        uri.password = nil
+        uri.to_s()
+      rescue
+        str
+      end
+
+      def repo_host_name
+        # Return the full repo url for logging purposes only
+        payload['repository']['links']['self'][0]['href']
+      end
+
+      def repo_full_name
+        # Already returning the full repo url in repo_host_name.
+        ''
+      end
+
+      def prempt_ping_call
+        if request.headers['X-Event-Key'] == 'diagnostics:ping'
+          render plain: nil, status: :accepted, layout: nil
+        end
+      end
+
+      def allow_only_push_event
+        unless request.headers['X-Event-Key'] == 'repo:refs_changed'
+          render plain: "Ignoring event of type `#{request.headers['X-Event-Key']}'", status: :bad_request, layout: nil
+        end
+      end
+
+      def verify_payload
+        if payload.blank?
+          render plain: 'Could not understand the payload!', status: :bad_request, layout: nil
+        end
+        if repo_branch.blank?
+          render plain: 'No branch present in payload, ignoring.', status: :bad_request, layout: nil
+        end
+      rescue => e
+        Rails.logger.warn('Could not understand bitbucket webhook payload:')
+        Rails.logger.warn(e)
+        render plain: 'Could not understand the payload!', status: :bad_request, layout: nil
+      end
+
+      def payload
+        if request.content_mime_type == :json
+          JSON.parse(request.raw_post)
+        end
+      end
+
+      def verify_content_origin
+        if request.headers['X-Hub-Signature'].blank?
+          return render plain: "No HMAC signature specified via `X-Hub-Signature' header!", status: :bad_request, layout: nil
+        end
+
+        expected_signature = 'sha256=' + OpenSSL::HMAC.hexdigest(OpenSSL::Digest.new('sha256'), webhook_secret, request.body.read)
+        Rails.logger.warn("Expected sig: #{expected_signature}")
+
+        unless Rack::Utils.secure_compare(expected_signature, request.headers['X-Hub-Signature'])
+          render plain: "HMAC signature specified via `X-Hub-Signature' did not match!", status: :bad_request, layout: nil
+        end
+      end
+
+      def allow_only_git_scm
+        if payload['repository']['scmId'] != 'git'
+          render plain: "Only `git' repositories are currently supported!", status: :bad_request, layout: nil
+        end
+      end
+    end
+
+  end
+end

--- a/server/webapp/WEB-INF/rails/app/controllers/api/web_hooks/web_hook_controller.rb
+++ b/server/webapp/WEB-INF/rails/app/controllers/api/web_hooks/web_hook_controller.rb
@@ -18,7 +18,7 @@ module Api
   module WebHooks
     class WebHookController < ::Api::ApiController
       def notify
-        Rails.logger.info("[WebHook] Noticed a git push to #{repo_host_name}/#{repo_full_name} on branch #{repo_branch}")
+        Rails.logger.info("[WebHook] Noticed a git push to #{repo_log_name} on branch #{repo_branch}")
 
         if material_update_service.updateGitMaterial(repo_branch, possible_urls)
           render plain: 'OK!', status: :accepted, layout: nil
@@ -28,36 +28,16 @@ module Api
       end
 
       protected
+
       def possible_urls
-        %W(
-          https://#{repo_host_name}/#{repo_full_name}
-          https://#{repo_host_name}/#{repo_full_name}/
-          https://#{repo_host_name}/#{repo_full_name}.git
-          https://#{repo_host_name}/#{repo_full_name}.git/
-          http://#{repo_host_name}/#{repo_full_name}
-          http://#{repo_host_name}/#{repo_full_name}/
-          http://#{repo_host_name}/#{repo_full_name}.git
-          http://#{repo_host_name}/#{repo_full_name}.git/
-          git://#{repo_host_name}/#{repo_full_name}
-          git://#{repo_host_name}/#{repo_full_name}/
-          git://#{repo_host_name}/#{repo_full_name}.git
-          git://#{repo_host_name}/#{repo_full_name}.git/
-          git@#{repo_host_name}:#{repo_full_name}
-          git@#{repo_host_name}:#{repo_full_name}/
-          git@#{repo_host_name}:#{repo_full_name}.git
-          git@#{repo_host_name}:#{repo_full_name}.git/
-        )
+        raise 'Subclass responsibility!'
       end
 
       def repo_branch
         raise 'Subclass responsibility!'
       end
 
-      def repo_host_name
-        raise 'Subclass responsibility!'
-      end
-
-      def repo_full_name
+      def repo_log_name
         raise 'Subclass responsibility!'
       end
 

--- a/server/webapp/WEB-INF/rails/config/routes.rb
+++ b/server/webapp/WEB-INF/rails/config/routes.rb
@@ -337,6 +337,7 @@ Rails.application.routes.draw do
       post 'webhooks/github/notify' => 'web_hooks/git_hub#notify'
       post 'webhooks/gitlab/notify' => 'web_hooks/git_lab#notify'
       post 'webhooks/bitbucket/notify' => 'web_hooks/bit_bucket#notify'
+      post 'webhooks/hosted_bitbucket/notify' => 'web_hooks/hosted_bit_bucket#notify'
 
       scope 'admin/feature_toggles' do
         defaults :no_layout => true, :format => :json do

--- a/server/webapp/WEB-INF/rails/spec/controllers/api/web_hooks/hosted_bit_bucket_controller_spec.rb
+++ b/server/webapp/WEB-INF/rails/spec/controllers/api/web_hooks/hosted_bit_bucket_controller_spec.rb
@@ -1,0 +1,166 @@
+##########################################################################
+# Copyright 2017 ThoughtWorks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+
+require 'rails_helper'
+
+describe Api::WebHooks::HostedBitBucketController do
+
+  before :each do
+    @material_update_service = double('Material Update Service')
+    @server_config_service = double('Server Config Service')
+    allow(controller).to receive(:material_update_service).and_return(@material_update_service)
+    allow(controller).to receive(:server_config_service).and_return(@server_config_service)
+  end
+
+  describe "notify" do
+
+    it 'should return 400 [bad request] if the request is missing the X-Hub-Signature header' do
+      post :notify
+      expect(response.status).to eq(400)
+      expect(response.body).to eq("No HMAC signature specified via `X-Hub-Signature' header!")
+    end
+
+    describe 'with json' do
+      it 'should call the material update service upon receiving a good request and respond with 202 [accepted]' do
+        expect(@server_config_service).to receive(:getWebhookSecret).and_return('secret')
+
+        params = {
+          repository: {
+            name: 'my-repo',
+            scmId: 'git',
+            links: {
+              clone: [
+                {
+                  href: 'https://my-company.com/bitbucket/scm/my-proj/my-repo.git',
+                  name: 'http'
+                },
+                {
+                  href: 'ssh://git@git.my-company.com:7999/my-proj/my-repo.git',
+                  name: 'ssh'
+                }
+              ],
+              self: [
+                {
+                  href: 'https://my-company.com/bitbucket/users/my-proj/repos/my-repo/browse'
+                }
+              ]
+            }
+          },
+          changes: [
+            {
+              ref: {
+                id: 'refs/heads/master',
+                displayId: 'master',
+                type: 'BRANCH'
+              },
+              refId: 'refs/heads/master',
+              fromHash: '6ef89f26fa552806ec78b7eb2be6795b5ffe4d94',
+              toHash: '060c12d6b818b96fae7f3375ad3fea56a05d9aa1',
+              type: 'UPDATE'
+            }
+          ]
+        }
+
+        params_string = params.to_json
+
+        allow(request).to receive(:body) do
+          StringIO.new(params_string)
+        end
+
+        signature = 'sha256=' + OpenSSL::HMAC.hexdigest(OpenSSL::Digest.new('sha256'), 'secret', request.body.read)
+
+        request.headers.merge!({
+                                 'X-Event-Key' => 'repo:refs_changed',
+                                 'X-Hub-Signature' => signature,
+                                 'Content-Type' => 'application/json'
+                               })
+
+        all_matching_repos = %w(
+                            https://my-company.com/bitbucket/scm/my-proj/my-repo.git
+                            ssh://git.my-company.com:7999/my-proj/my-repo.git
+                            )
+
+        expect(@material_update_service)
+          .to receive(:updateGitMaterial)
+          .with('master', all_matching_repos)
+          .and_return(true)
+
+        post :notify, params: params
+        expect(response.body).to eq('OK!')
+        expect(response.status).to eq(202)
+      end
+
+      it 'should return 400 [bad request] if the signature does not match our signed payload' do
+        expect(@server_config_service).to receive(:getWebhookSecret).and_return('secret')
+        params = {}
+        params_string = params.to_json
+        allow(request).to receive(:body) do
+          StringIO.new(params_string)
+        end
+
+        request.headers.merge!({
+                                 'X-Event-Key' => 'repo:refs_changed',
+                                 'X-Hub-Signature' => 'some_bad_signature',
+                                 'Content-Type' => 'application/json'
+                               })
+
+        post :notify, params: params
+        expect(response.status).to eq(400)
+        expect(response.body).to eq("HMAC signature specified via `X-Hub-Signature' did not match!")
+      end
+
+      it 'should return 400 [bad request] if the event header is unknown' do
+        expect(@server_config_service).to receive(:getWebhookSecret).and_return('secret')
+        params = {}
+        params_string = params.to_json
+        allow(request).to receive(:body) do
+          StringIO.new(params_string)
+        end
+
+        signature = 'sha256=' + OpenSSL::HMAC.hexdigest(OpenSSL::Digest.new('sha256'), 'secret', request.body.read)
+
+        request.headers.merge!({
+                                 'X-Event-Key' => 'some-unknown-event',
+                                 'X-Hub-Signature' => signature,
+                                 'Content-Type' => 'application/json'
+                               })
+
+        post :notify, params: params
+        expect(response.status).to eq(400)
+        expect(response.body).to eq("Ignoring event of type `some-unknown-event'")
+      end
+
+      it 'should respond with 202 [accepted] upon receiving a ping event' do
+        params = {}
+        params_string = params.to_json
+        allow(request).to receive(:body) do
+          StringIO.new(params_string)
+        end
+
+        request.headers.merge!({
+                                 'Content-Type' => 'application/json',
+                                 'X-Event-Key' => 'diagnostics:ping'
+                               })
+
+
+        post :notify, params: params
+        expect(response.status).to eq(202)
+      end
+
+    end
+  end
+
+end

--- a/server/webapp/WEB-INF/rails/spec/controllers/api/web_hooks/hosted_bit_bucket_controller_spec.rb
+++ b/server/webapp/WEB-INF/rails/spec/controllers/api/web_hooks/hosted_bit_bucket_controller_spec.rb
@@ -44,7 +44,7 @@ describe Api::WebHooks::HostedBitBucketController do
             links: {
               clone: [
                 {
-                  href: 'https://my-company.com/bitbucket/scm/my-proj/my-repo.git',
+                  href: 'https://subdomain.my-company.com/bitbucket/scm/my-proj/my-repo.git',
                   name: 'http'
                 },
                 {
@@ -89,7 +89,7 @@ describe Api::WebHooks::HostedBitBucketController do
                                })
 
         all_matching_repos = %w(
-                            https://my-company.com/bitbucket/scm/my-proj/my-repo.git
+                            https://subdomain.my-company.com/bitbucket/scm/my-proj/my-repo.git
                             ssh://git.my-company.com:7999/my-proj/my-repo.git
                             )
 


### PR DESCRIPTION
Hosted bitbucket server sends different webhook requests than the
cloud version.

Rather than trying to detect which type of server it is in the existing endpoint,
use a new endpoint 'webhooks/hosted_bitbucket/notify'.

Main differences to cloud bitbucket, based on hosted version 5.16.1:

- Finding the correct material url is different, because the
  hosted bitbucket server simply sends a list of clone urls
  that can be used directly (minus credentials). So there's no need
  to guess from a list of possible urls. This way we can also trivially
  support ssh urls.

- Hosted bitbucket sends a standard HMAC signature header using the webhook secret.
  No need to check basic auth headers.

- The request body is differently structured.