### PR TITLE
Add XML Migration to support optional clusterProfileId attribute on profile tag (#5538)

### DIFF
--- a/base/src/main/java/com/thoughtworks/go/util/GoConstants.java
+++ b/base/src/main/java/com/thoughtworks/go/util/GoConstants.java
@@ -54,7 +54,7 @@ public class GoConstants {
 
     public static final String PRODUCT_NAME = "go";
 
-    public static final int CONFIG_SCHEMA_VERSION = 117;
+    public static final int CONFIG_SCHEMA_VERSION = 118;
 
     public static final String APPROVAL_SUCCESS = "success";
     public static final String APPROVAL_MANUAL = "manual";

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/elastic/ElasticProfile.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/elastic/ElasticProfile.java
@@ -16,6 +16,7 @@
 
 package com.thoughtworks.go.config.elastic;
 
+import com.thoughtworks.go.config.ConfigAttribute;
 import com.thoughtworks.go.config.ConfigCollection;
 import com.thoughtworks.go.config.ConfigTag;
 import com.thoughtworks.go.config.PluginProfile;
@@ -29,6 +30,9 @@ import java.util.Collection;
 @ConfigCollection(value = ConfigurationProperty.class)
 public class ElasticProfile extends PluginProfile {
 
+    @ConfigAttribute(value = "clusterProfileId", allowNull = true)
+    protected String clusterProfileId;
+
     public ElasticProfile() {
         super();
     }
@@ -37,13 +41,26 @@ public class ElasticProfile extends PluginProfile {
         super(id, pluginId, props);
     }
 
+    public ElasticProfile(String id, String pluginId, String clusterProfileId, ConfigurationProperty... props) {
+        super(id, pluginId, props);
+        this.clusterProfileId = clusterProfileId;
+    }
+
     public ElasticProfile(String id, String pluginId, Collection<ConfigurationProperty> configProperties) {
         this(id, pluginId, configProperties.toArray(new ConfigurationProperty[0]));
+    }
+
+    public ElasticProfile(String id, String pluginId, String clusterProfileId, Collection<ConfigurationProperty> configProperties) {
+        this(id, pluginId, clusterProfileId, configProperties.toArray(new ConfigurationProperty[0]));
     }
 
     @Override
     protected String getObjectDescription() {
         return "Elastic agent profile";
+    }
+
+    public String getClusterProfileId() {
+        return clusterProfileId;
     }
 
     @Override

--- a/config/config-server/src/main/resources/schemas/117_cruise-config.xsd
+++ b/config/config-server/src/main/resources/schemas/117_cruise-config.xsd
@@ -89,7 +89,7 @@
           </xsd:unique>
         </xsd:element>
       </xsd:sequence>
-      <xsd:attribute name="schemaVersion" type="xsd:int" use="required" fixed="118"/>
+      <xsd:attribute name="schemaVersion" type="xsd:int" use="required" fixed="117"/>
     </xsd:complexType>
     <xsd:unique name="uniquePipelines">
       <xsd:selector xpath="pipelines"/>
@@ -310,7 +310,7 @@
     <xsd:attribute name="emailOnFailure" type="xsd:boolean" />
   </xsd:complexType>
   <xsd:complexType name="elasticConfigType">
-    <xsd:all>
+    <xsd:sequence>
       <xsd:element name="clusterProfiles" type="elasticAgentClusterProfilesType" minOccurs="0" maxOccurs="1">
         <xsd:unique name="uniqueClusterProfileId">
           <xsd:selector xpath="clusterProfile"/>
@@ -325,12 +325,12 @@
           <!-- Unique profile id -->
         </xsd:unique>
       </xsd:element>
-    </xsd:all>
+    </xsd:sequence>
     <xsd:attribute name="jobStarvationTimeout" type="xsd:long"/>
   </xsd:complexType>
   <xsd:complexType name="elasticAgentProfilesType">
     <xsd:sequence>
-      <xsd:element minOccurs="0" maxOccurs="unbounded" name="profile" type="elasticAgentProfile"/>
+      <xsd:element minOccurs="0" maxOccurs="unbounded" name="profile" type="pluginProfile"/>
     </xsd:sequence>
   </xsd:complexType>
   <xsd:complexType name="elasticAgentClusterProfilesType">
@@ -352,14 +352,6 @@
     <xsd:sequence>
       <xsd:element name="property" minOccurs="0" maxOccurs="unbounded" type="pluginPropertyType"/>
     </xsd:sequence>
-    <xsd:attribute type="nameType" name="pluginId" use="required"/>
-    <xsd:attribute type="nameType" name="id" use="required"/>
-  </xsd:complexType>
-  <xsd:complexType name="elasticAgentProfile">
-    <xsd:sequence>
-      <xsd:element name="property" minOccurs="0" maxOccurs="unbounded" type="pluginPropertyType"/>
-    </xsd:sequence>
-    <xsd:attribute type="nameType" name="clusterProfileId" use="optional"/>
     <xsd:attribute type="nameType" name="pluginId" use="required"/>
     <xsd:attribute type="nameType" name="id" use="required"/>
   </xsd:complexType>

--- a/config/config-server/src/main/resources/upgrades/118.xsl
+++ b/config/config-server/src/main/resources/upgrades/118.xsl
@@ -1,0 +1,28 @@
+<?xml version="1.0"?>
+<!--
+  ~ Copyright 2019 ThoughtWorks, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+    <xsl:template match="/cruise/@schemaVersion">
+        <xsl:attribute name="schemaVersion">118</xsl:attribute>
+    </xsl:template>
+    <!-- Copy everything -->
+    <xsl:template match="@*|node()">
+        <xsl:copy>
+            <xsl:apply-templates select="@*|node()"/>
+        </xsl:copy>
+    </xsl:template>
+</xsl:stylesheet>

--- a/server/config/cruise-config.xml
+++ b/server/config/cruise-config.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<cruise xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="cruise-config.xsd" schemaVersion="117">
+<cruise xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="cruise-config.xsd" schemaVersion="118">
   <server artifactsdir="artifacts" agentAutoRegisterKey="323040d4-f2e4-4b8a-8394-7a2d122054d1" webhookSecret="3d5cd2f5-7fe7-43c0-ba34-7e01678ba8b6" commandRepositoryLocation="default" serverId="60f5f682-5248-4ba9-bb35-72c92841bd75" tokenGenerationKey="8c3c8dc9-08bf-4cd7-ac80-cecb3e7ae86c">
     <security>
       <authConfigs>

--- a/server/src/test-integration/java/com/thoughtworks/go/config/GoConfigMigrationIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/config/GoConfigMigrationIntegrationTest.java
@@ -2460,6 +2460,53 @@ public class GoConfigMigrationIntegrationTest {
         assertThat(migratedContent, containsString(configContent));
     }
 
+    @Test
+    public void shouldOnlyUpdateSchemaVersionForMigration118() throws NoSuchMethodException, IllegalAccessException, InvocationTargetException {
+        String configContent =  " <elastic>\n" +
+                "    <profiles>\n" +
+                "      <profile id=\"asdf\" pluginId=\"cd.go.contrib.elastic-agent.docker\">\n" +
+                "        <property>\n" +
+                "          <key>Image</key>\n" +
+                "          <value>asdf</value>\n" +
+                "        </property>\n" +
+                "      </profile>" +
+                "    </profiles>" +
+                "  </elastic>";
+
+        String configXml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+                + "<cruise schemaVersion=\"117\">\n"
+                + configContent
+                + "</cruise>";
+
+        String migratedContent = migrateXmlString(configXml, 117, 118);
+
+        assertThat(migratedContent, containsString("<cruise schemaVersion=\"118\""));
+        assertThat(migratedContent, containsString(configContent));
+    }
+
+    @Test
+    public void shouldAllowSpecifyingClusterProfileIdAttributeOnProfilesAsPartMigration118() throws Exception {
+        String configContent =  " <elastic>\n" +
+        "    <profiles>\n" +
+                "      <profile clusterProfileId=\"foo\" id=\"profile1\" pluginId=\"cd.go.contrib.elastic-agent.docker\">\n" +
+                "        <property>\n" +
+                "          <key>Image</key>\n" +
+                "          <value>asdf</value>\n" +
+                "        </property>\n" +
+                "      </profile>" +
+                "    </profiles>" +
+                "  </elastic>";
+
+        String configXml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+                + "<cruise schemaVersion=\"118\">\n"
+                + configContent
+                + "</cruise>";
+
+        CruiseConfig config = loadConfigFileWithContent(configXml);
+        ElasticProfile elasticProfile = config.getElasticConfig().getProfiles().find("profile1");
+        assertThat(elasticProfile.getClusterProfileId(), is("foo"));
+    }
+
     private void assertStringsIgnoringCarriageReturnAreEqual(String expected, String actual) {
         assertEquals(expected.replaceAll("\\r", ""), actual.replaceAll("\\r", ""));
     }


### PR DESCRIPTION
* clusterProfileId can be specified on elastic agent profiles defined using EA extension v5
---

Validation for the same will be added as part of elastic agent profiles API v2