### PR TITLE
Pass the X-Requested-With header with value XMLHttpRequest in the new…

### DIFF
--- a/server/webapp/WEB-INF/rails/webpack/helpers/api_request_builder.ts
+++ b/server/webapp/WEB-INF/rails/webpack/helpers/api_request_builder.ts
@@ -217,6 +217,8 @@ export class ApiRequestBuilder {
       headers["X-GoCD-Confirm"] = "true";
     }
 
+    headers["X-Requested-With"] = "XMLHttpRequest";
+
     return headers;
   }
 

--- a/server/webapp/WEB-INF/rails/webpack/helpers/spec/api_request_builder_spec.ts
+++ b/server/webapp/WEB-INF/rails/webpack/helpers/spec/api_request_builder_spec.ts
@@ -128,9 +128,10 @@ describe("Api Request Builder", () => {
       mockSuccessfulRequest();
       ApiRequestBuilder.GET("/foo", ApiVersion.v1, {headers: {foo: "bar"}});
       const request = jasmine.Ajax.requests.mostRecent();
-      expect(Object.keys(request.requestHeaders)).toHaveLength(2);
+      expect(Object.keys(request.requestHeaders)).toHaveLength(3);
       expect(request.requestHeaders.Accept).toBe("application/vnd.go.cd.v1+json");
       expect(request.requestHeaders.foo).toBe("bar");
+      expect(request.requestHeaders["X-Requested-With"]).toBe("XMLHttpRequest");
     });
 
     it("should pass if-none-match Header", () => {

--- a/server/webapp/WEB-INF/rails/webpack/models/access_tokens/spec/access_token_crud_spec.ts
+++ b/server/webapp/WEB-INF/rails/webpack/models/access_tokens/spec/access_token_crud_spec.ts
@@ -39,7 +39,7 @@ describe("AccessTokenCRUD", () => {
     const request = jasmine.Ajax.requests.mostRecent();
     expect(request.url).toEqual(ALL_ACESS_TOKENS_PATH);
     expect(request.method).toEqual("GET");
-    expect(request.requestHeaders).toEqual({Accept: "application/vnd.go.cd.v1+json"});
+    expect(request.requestHeaders.Accept).toEqual("application/vnd.go.cd.v1+json");
   });
 
   it("should create access token", (done) => {
@@ -60,10 +60,8 @@ describe("AccessTokenCRUD", () => {
     expect(request.method).toEqual("POST");
     const requestData = toAccessTokenJSON(request.data());
     expect(requestData.description).toEqual(accessToken.description());
-    expect(request.requestHeaders).toEqual({
-                                             "Accept": "application/vnd.go.cd.v1+json",
-                                             "Content-Type": "application/json; charset=utf-8"
-                                           });
+    expect(request.requestHeaders.Accept).toEqual("application/vnd.go.cd.v1+json");
+    expect(request.requestHeaders["Content-Type"]).toEqual("application/json; charset=utf-8");
   });
 
   it("should revoke access token", (done) => {
@@ -84,10 +82,8 @@ describe("AccessTokenCRUD", () => {
     expect(request.method).toEqual("POST");
     const data = toAccessTokenJSON(request.data());
     expect(data.revoke_cause).toEqual("Some cause to revoke the token");
-    expect(request.requestHeaders).toEqual({
-                                             "Accept": "application/vnd.go.cd.v1+json",
-                                             "Content-Type": "application/json; charset=utf-8"
-                                           });
+    expect(request.requestHeaders.Accept).toEqual("application/vnd.go.cd.v1+json");
+    expect(request.requestHeaders["Content-Type"]).toEqual("application/json; charset=utf-8");
   });
 
 });

--- a/server/webapp/WEB-INF/rails/webpack/models/admin_access_tokens/spec/admin_access_token_crud_spec.ts
+++ b/server/webapp/WEB-INF/rails/webpack/models/admin_access_tokens/spec/admin_access_token_crud_spec.ts
@@ -38,7 +38,7 @@ describe("AdminAccessTokenCRUDSpec", () => {
     const request = jasmine.Ajax.requests.mostRecent();
     expect(request.url).toEqual(BASE_PATH + "?filter=all");
     expect(request.method).toEqual("GET");
-    expect(request.requestHeaders).toEqual({Accept: "application/vnd.go.cd.v1+json"});
+    expect(request.requestHeaders.Accept).toEqual("application/vnd.go.cd.v1+json");
   });
 
   it("should revoke access token", (done) => {
@@ -59,10 +59,8 @@ describe("AdminAccessTokenCRUDSpec", () => {
     expect(request.method).toEqual("POST");
     const data = toAccessTokenJSON(request.data());
     expect(data.revoke_cause).toEqual("Some cause to revoke the token");
-    expect(request.requestHeaders).toEqual({
-                                             "Accept": "application/vnd.go.cd.v1+json",
-                                             "Content-Type": "application/json; charset=utf-8"
-                                           });
+    expect(request.requestHeaders.Accept).toEqual("application/vnd.go.cd.v1+json");
+    expect(request.requestHeaders["Content-Type"]).toEqual("application/json; charset=utf-8");
   });
 });
 

--- a/server/webapp/WEB-INF/rails/webpack/models/admins/spec/admin_crud_spec.ts
+++ b/server/webapp/WEB-INF/rails/webpack/models/admins/spec/admin_crud_spec.ts
@@ -53,8 +53,8 @@ describe("admin crud", () => {
 
       expect(request.url).toEqual(API_SYSTEM_ADMINS_PATH);
       expect(request.method).toEqual("PATCH");
-      expect(request.requestHeaders)
-        .toEqual({"Accept": "application/vnd.go.cd.v2+json", "Content-Type": "application/json; charset=utf-8"});
+      expect(request.requestHeaders.Accept).toEqual("application/vnd.go.cd.v2+json");
+      expect(request.requestHeaders["Content-Type"]).toEqual("application/json; charset=utf-8");
     });
   });
 });

--- a/server/webapp/WEB-INF/rails/webpack/models/artifact_stores/spec/artifact_stores_crud_spec.ts
+++ b/server/webapp/WEB-INF/rails/webpack/models/artifact_stores/spec/artifact_stores_crud_spec.ts
@@ -31,7 +31,7 @@ describe("ArtifactStoreCRUD", () => {
     expect(request.url).toEqual("/go/api/admin/artifact_stores");
     expect(request.method).toEqual("GET");
     expect(request.data()).toEqual(toJSON({} as ArtifactStoreJSON));
-    expect(request.requestHeaders).toEqual({Accept: "application/vnd.go.cd.v1+json"});
+    expect(request.requestHeaders.Accept).toEqual("application/vnd.go.cd.v1+json");
   });
 
   it("should create a new artifact store", () => {
@@ -43,11 +43,8 @@ describe("ArtifactStoreCRUD", () => {
     expect(request.url).toEqual("/go/api/admin/artifact_stores");
     expect(request.method).toEqual("POST");
     expect(request.data()).toEqual(toJSON(ArtifactStoreTestData.dockerArtifactStore()));
-    expect(request.requestHeaders).toEqual({
-                                             "Accept": "application/vnd.go.cd.v1+json",
-                                             "Content-Type": "application/json; charset=utf-8"
-                                           });
-
+    expect(request.requestHeaders.Accept).toEqual("application/vnd.go.cd.v1+json");
+    expect(request.requestHeaders["Content-Type"]).toEqual("application/json; charset=utf-8");
   });
 
   it("should update a artifact store", () => {
@@ -61,12 +58,9 @@ describe("ArtifactStoreCRUD", () => {
     expect(request.url).toEqual(`/go/api/admin/artifact_stores/${dockerArtifactStore.id}`);
     expect(request.method).toEqual("PUT");
     expect(request.data()).toEqual(toJSON(dockerArtifactStore));
-    expect(request.requestHeaders).toEqual({
-                                             "Accept": "application/vnd.go.cd.v1+json",
-                                             "Content-Type": "application/json; charset=utf-8",
-                                             "If-Match": "some-etag"
-                                           });
-
+    expect(request.requestHeaders.Accept).toEqual("application/vnd.go.cd.v1+json");
+    expect(request.requestHeaders["Content-Type"]).toEqual("application/json; charset=utf-8");
+    expect(request.requestHeaders["If-Match"]).toEqual("some-etag");
   });
 
   it("should delete a artifact store", () => {
@@ -80,12 +74,9 @@ describe("ArtifactStoreCRUD", () => {
     expect(request.url).toEqual(`/go/api/admin/artifact_stores/${dockerArtifactStore.id}`);
     expect(request.method).toEqual("DELETE");
     expect(request.data()).toEqual(toJSON({} as ArtifactStoreJSON));
-    expect(request.requestHeaders).toEqual({
-                                             "Accept": "application/vnd.go.cd.v1+json",
-                                             "Content-Type": "application/json; charset=utf-8",
-                                             "X-GoCD-Confirm": "true"
-                                           });
-
+    expect(request.requestHeaders.Accept).toEqual("application/vnd.go.cd.v1+json");
+    expect(request.requestHeaders["Content-Type"]).toEqual("application/json; charset=utf-8");
+    expect(request.requestHeaders["X-GoCD-Confirm"]).toEqual("true");
   });
 
 });

--- a/server/webapp/WEB-INF/rails/webpack/models/auth_configs/spec/auth_configs_crud_spec.ts
+++ b/server/webapp/WEB-INF/rails/webpack/models/auth_configs/spec/auth_configs_crud_spec.ts
@@ -31,7 +31,7 @@ describe("AuthorizationConfigurationCRUD", () => {
     expect(request.url).toEqual("/go/api/admin/security/auth_configs");
     expect(request.method).toEqual("GET");
     expect(request.data()).toEqual(toJSON({} as AuthConfigJSON));
-    expect(request.requestHeaders).toEqual({Accept: "application/vnd.go.cd.v1+json"});
+    expect(request.requestHeaders.Accept).toEqual("application/vnd.go.cd.v1+json");
   });
 
   it("should create a new auth config", () => {
@@ -43,11 +43,8 @@ describe("AuthorizationConfigurationCRUD", () => {
     expect(request.url).toEqual("/go/api/admin/security/auth_configs");
     expect(request.method).toEqual("POST");
     expect(request.data()).toEqual(toJSON(TestData.ldapAuthConfig()));
-    expect(request.requestHeaders).toEqual({
-                                             "Accept": "application/vnd.go.cd.v1+json",
-                                             "Content-Type": "application/json; charset=utf-8"
-                                           });
-
+    expect(request.requestHeaders.Accept).toEqual("application/vnd.go.cd.v1+json");
+    expect(request.requestHeaders["Content-Type"]).toEqual("application/json; charset=utf-8");
   });
 
   it("should update a auth config", () => {
@@ -61,12 +58,9 @@ describe("AuthorizationConfigurationCRUD", () => {
     expect(request.url).toEqual(`/go/api/admin/security/auth_configs/${ldapAuthConfig.id}`);
     expect(request.method).toEqual("PUT");
     expect(request.data()).toEqual(toJSON(ldapAuthConfig));
-    expect(request.requestHeaders).toEqual({
-                                             "Accept": "application/vnd.go.cd.v1+json",
-                                             "Content-Type": "application/json; charset=utf-8",
-                                             "If-Match": "some-etag"
-                                           });
-
+    expect(request.requestHeaders.Accept).toEqual("application/vnd.go.cd.v1+json");
+    expect(request.requestHeaders["Content-Type"]).toEqual("application/json; charset=utf-8");
+    expect(request.requestHeaders["If-Match"]).toEqual("some-etag");
   });
 
   it("should delete a auth config", () => {
@@ -80,12 +74,9 @@ describe("AuthorizationConfigurationCRUD", () => {
     expect(request.url).toEqual(`/go/api/admin/security/auth_configs/${ldapAuthConfig.id}`);
     expect(request.method).toEqual("DELETE");
     expect(request.data()).toEqual(toJSON({} as AuthConfigJSON));
-    expect(request.requestHeaders).toEqual({
-                                             "Accept": "application/vnd.go.cd.v1+json",
-                                             "Content-Type": "application/json; charset=utf-8",
-                                             "X-GoCD-Confirm": "true"
-                                           });
-
+    expect(request.requestHeaders.Accept).toEqual("application/vnd.go.cd.v1+json");
+    expect(request.requestHeaders["Content-Type"]).toEqual("application/json; charset=utf-8");
+    expect(request.requestHeaders["X-GoCD-Confirm"]).toEqual("true");
   });
 
 });

--- a/server/webapp/WEB-INF/rails/webpack/models/roles/spec/roles_crud_spec.ts
+++ b/server/webapp/WEB-INF/rails/webpack/models/roles/spec/roles_crud_spec.ts
@@ -31,7 +31,7 @@ describe("RoleCRUD", () => {
     expect(request.url).toEqual("/go/api/admin/security/roles");
     expect(request.method).toEqual("GET");
     expect(request.data()).toEqual(toJSON({} as RolesJSON));
-    expect(request.requestHeaders).toEqual({Accept: "application/vnd.go.cd.v2+json"});
+    expect(request.requestHeaders.Accept).toEqual("application/vnd.go.cd.v2+json");
   });
 
   it("should create a new gocd role", () => {
@@ -43,10 +43,8 @@ describe("RoleCRUD", () => {
     expect(request.url).toEqual("/go/api/admin/security/roles");
     expect(request.method).toEqual("POST");
     expect(request.data()).toEqual(toJSON(Role.fromJSON(RolesTestData.GoCDRoleJSON())));
-    expect(request.requestHeaders).toEqual({
-                                             "Accept": "application/vnd.go.cd.v2+json",
-                                             "Content-Type": "application/json; charset=utf-8"
-                                           });
+    expect(request.requestHeaders.Accept).toEqual("application/vnd.go.cd.v2+json");
+    expect(request.requestHeaders["Content-Type"]).toEqual("application/json; charset=utf-8");
   });
 
   it("should create a new plugin role", () => {
@@ -58,10 +56,8 @@ describe("RoleCRUD", () => {
     expect(request.url).toEqual("/go/api/admin/security/roles");
     expect(request.method).toEqual("POST");
     expect(request.data()).toEqual(toJSON(Role.fromJSON(RolesTestData.LdapPluginRoleJSON())));
-    expect(request.requestHeaders).toEqual({
-                                             "Accept": "application/vnd.go.cd.v2+json",
-                                             "Content-Type": "application/json; charset=utf-8"
-                                           });
+    expect(request.requestHeaders.Accept).toEqual("application/vnd.go.cd.v2+json");
+    expect(request.requestHeaders["Content-Type"]).toEqual("application/json; charset=utf-8");
   });
 
   it("should update a gocd role", () => {
@@ -75,11 +71,9 @@ describe("RoleCRUD", () => {
     expect(request.url).toEqual(`/go/api/admin/security/roles/${gocdRole.name()}`);
     expect(request.method).toEqual("PUT");
     expect(request.data()).toEqual(toJSON(gocdRole));
-    expect(request.requestHeaders).toEqual({
-                                             "Accept": "application/vnd.go.cd.v2+json",
-                                             "Content-Type": "application/json; charset=utf-8",
-                                             "If-Match": "some-etag"
-                                           });
+    expect(request.requestHeaders.Accept).toEqual("application/vnd.go.cd.v2+json");
+    expect(request.requestHeaders["Content-Type"]).toEqual("application/json; charset=utf-8");
+    expect(request.requestHeaders["If-Match"]).toEqual("some-etag");
   });
 
   it("should delete a gocd role", () => {
@@ -93,12 +87,9 @@ describe("RoleCRUD", () => {
     expect(request.url).toEqual(`/go/api/admin/security/roles/${gocdRole.name()}`);
     expect(request.method).toEqual("DELETE");
     expect(request.data()).toEqual(toJSON({} as RoleJSON));
-    expect(request.requestHeaders).toEqual({
-                                             "Accept": "application/vnd.go.cd.v2+json",
-                                             "Content-Type": "application/json; charset=utf-8",
-                                             "X-GoCD-Confirm": "true"
-                                           });
-
+    expect(request.requestHeaders.Accept).toEqual("application/vnd.go.cd.v2+json");
+    expect(request.requestHeaders["Content-Type"]).toEqual("application/json; charset=utf-8");
+    expect(request.requestHeaders["X-GoCD-Confirm"]).toEqual("true");
   });
 });
 

--- a/server/webapp/WEB-INF/rails/webpack/models/users/spec/users_crud_spec.ts
+++ b/server/webapp/WEB-INF/rails/webpack/models/users/spec/users_crud_spec.ts
@@ -38,7 +38,7 @@ describe("UsersCRUD", () => {
       const request = jasmine.Ajax.requests.mostRecent();
       expect(request.url).toEqual(ALL_USERS_API);
       expect(request.method).toEqual("GET");
-      expect(request.requestHeaders).toEqual({Accept: "application/vnd.go.cd.v3+json"});
+      expect(request.requestHeaders.Accept).toEqual("application/vnd.go.cd.v3+json");
     });
   });
 
@@ -68,8 +68,8 @@ describe("UsersCRUD", () => {
 
       expect(request.url).toEqual(ALL_USERS_API);
       expect(request.method).toEqual("POST");
-      expect(request.requestHeaders)
-        .toEqual({"Accept": "application/vnd.go.cd.v3+json", "Content-Type": "application/json; charset=utf-8"});
+      expect(request.requestHeaders.Accept).toEqual("application/vnd.go.cd.v3+json");
+      expect(request.requestHeaders["Content-Type"]).toEqual("application/json; charset=utf-8");
     });
   });
 
@@ -104,8 +104,8 @@ describe("UsersCRUD", () => {
 
       expect(request.url).toEqual(BULK_UPDATE_USERS_API);
       expect(request.method).toEqual("PATCH");
-      expect(request.requestHeaders)
-        .toEqual({"Accept": "application/vnd.go.cd.v3+json", "Content-Type": "application/json; charset=utf-8"});
+      expect(request.requestHeaders.Accept).toEqual("application/vnd.go.cd.v3+json");
+      expect(request.requestHeaders["Content-Type"]).toEqual("application/json; charset=utf-8");
     });
   });
 
@@ -137,8 +137,8 @@ describe("UsersCRUD", () => {
 
       expect(request.url).toEqual(BULK_DELETE_USERS_API);
       expect(request.method).toEqual("DELETE");
-      expect(request.requestHeaders)
-        .toEqual({"Accept": "application/vnd.go.cd.v3+json", "Content-Type": "application/json; charset=utf-8"});
+      expect(request.requestHeaders.Accept).toEqual("application/vnd.go.cd.v3+json");
+      expect(request.requestHeaders["Content-Type"]).toEqual("application/json; charset=utf-8");
     });
   });
 
@@ -167,7 +167,7 @@ describe("UsersCRUD", () => {
       const request = jasmine.Ajax.requests.mostRecent();
       expect(request.url).toEqual(GET_USER_API);
       expect(request.method).toEqual("GET");
-      expect(request.requestHeaders).toEqual({Accept: "application/vnd.go.cd.v3+json"});
+      expect(request.requestHeaders.Accept).toEqual("application/vnd.go.cd.v3+json");
     });
   });
 });

--- a/server/webapp/WEB-INF/rails/webpack/models/users/spec/users_search_spec.ts
+++ b/server/webapp/WEB-INF/rails/webpack/models/users/spec/users_search_spec.ts
@@ -35,7 +35,7 @@ describe("Users search", () => {
     const request = jasmine.Ajax.requests.mostRecent();
     expect(request.url).toEqual(USERS_SEARCH_API);
     expect(request.method).toEqual("GET");
-    expect(request.requestHeaders).toEqual({Accept: "application/vnd.go.cd.v1+json"});
+    expect(request.requestHeaders.Accept).toEqual("application/vnd.go.cd.v1+json");
   });
 });
 


### PR DESCRIPTION
Pass the X-Requested-With header with value XMLHttpRequest in the new api_request_controller.

This was previously passed automatically with jQuery. The [`BasicAuthenticationWithChallengeFailureResponseHandler`](https://github.com/gocd/gocd/blob/master/server/src/main/java/com/thoughtworks/go/server/newsecurity/handlers/BasicAuthenticationWithChallengeFailureResponseHandler.java#L33) expects the header to be passed, otherwise it sets the 'WWW-Authenticate' response header which shows a Http-Basic login popup when the user gets logged out.