### PR TITLE
Pass along cluster profile properties to create agent request (#5937)

### DIFF
--- a/domain/src/main/java/com/thoughtworks/go/domain/DefaultJobPlan.java
+++ b/domain/src/main/java/com/thoughtworks/go/domain/DefaultJobPlan.java
@@ -216,7 +216,7 @@ public class DefaultJobPlan implements JobPlan {
     }
 
     public void setElasticProfile(ElasticProfile elasticProfile) {
-        this.elasticProfile = new ElasticProfile(elasticProfile.getId(), elasticProfile.getPluginId(), elasticProfile);
+        this.elasticProfile = new ElasticProfile(elasticProfile.getId(), elasticProfile.getPluginId(), elasticProfile.getClusterProfileId(), elasticProfile);
     }
 
     @Override

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/elastic/ElasticAgentExtension.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/elastic/ElasticAgentExtension.java
@@ -16,6 +16,7 @@
 
 package com.thoughtworks.go.plugin.access.elastic;
 
+import com.thoughtworks.go.config.elastic.ClusterProfile;
 import com.thoughtworks.go.domain.JobIdentifier;
 import com.thoughtworks.go.plugin.access.ExtensionsRegistry;
 import com.thoughtworks.go.plugin.access.PluginRequestHelper;
@@ -54,8 +55,8 @@ public class ElasticAgentExtension extends AbstractExtension {
     }
 
 
-    public void createAgent(String pluginId, final String autoRegisterKey, final String environment, final Map<String, String> configuration, JobIdentifier jobIdentifier) {
-        getVersionedElasticAgentExtension(pluginId).createAgent(pluginId, autoRegisterKey, environment, configuration, jobIdentifier);
+    public void createAgent(String pluginId, final String autoRegisterKey, final String environment, final Map<String, String> configuration, final Map<String, String>  clusterProfileConfiguration, JobIdentifier jobIdentifier) {
+        getVersionedElasticAgentExtension(pluginId).createAgent(pluginId, autoRegisterKey, environment, configuration, clusterProfileConfiguration, jobIdentifier);
     }
 
     public void serverPing(final String pluginId) {

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/elastic/ElasticAgentPluginRegistry.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/elastic/ElasticAgentPluginRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 ThoughtWorks, Inc.
+ * Copyright 2019 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,12 +34,12 @@ public class ElasticAgentPluginRegistry extends AbstractPluginRegistry<ElasticAg
         super(pluginManager, elasticAgentExtension);
     }
 
-    public void createAgent(final String pluginId, String autoRegisterKey, String environment, Map<String, String> configuration, JobIdentifier jobIdentifier) {
+    public void createAgent(final String pluginId, String autoRegisterKey, String environment, Map<String, String> configuration, Map<String, String> clusterProfileConfiguration, JobIdentifier jobIdentifier) {
         PluginDescriptor plugin = findPlugin(pluginId);
         if (plugin != null) {
-            LOGGER.debug("Processing create agent for plugin: {} with environment: {} with configuration: {}", pluginId, environment, configuration);
-            extension.createAgent(pluginId, autoRegisterKey, environment, configuration, jobIdentifier);
-            LOGGER.debug("Done processing create agent for plugin: {} with environment: {} with configuration: {}", pluginId, environment, configuration);
+            LOGGER.debug("Processing create agent for plugin: {} with environment: {} with elastic agent configuration: {} in cluster: {}", pluginId, environment, configuration, clusterProfileConfiguration);
+            extension.createAgent(pluginId, autoRegisterKey, environment, configuration, clusterProfileConfiguration, jobIdentifier);
+            LOGGER.debug("Done processing create agent for plugin: {} with environment: {} with elastic agent configuration: {} in cluster: {}", pluginId, environment, configuration, clusterProfileConfiguration);
         } else {
             LOGGER.warn("Could not find plugin with id: {}", pluginId);
         }

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/elastic/VersionedElasticAgentExtension.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/elastic/VersionedElasticAgentExtension.java
@@ -42,7 +42,7 @@ public interface VersionedElasticAgentExtension {
 
     ValidationResult validateClusterProfile(String pluginId, Map<String, String> configuration);
 
-    void createAgent(String pluginId, String autoRegisterKey, String environment, Map<String, String> configuration, JobIdentifier jobIdentifier);
+    void createAgent(String pluginId, String autoRegisterKey, String environment, Map<String, String> configuration, Map<String, String> clusterProfileConfiguration, JobIdentifier jobIdentifier);
 
     void serverPing(String pluginId);
 

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/elastic/v4/ElasticAgentExtensionV4.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/elastic/v4/ElasticAgentExtensionV4.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 ThoughtWorks, Inc.
+ * Copyright 2019 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -114,7 +114,7 @@ public class ElasticAgentExtensionV4 implements VersionedElasticAgentExtension {
     }
 
     @Override
-    public void createAgent(String pluginId, final String autoRegisterKey, final String environment, final Map<String, String> configuration, JobIdentifier jobIdentifier) {
+    public void createAgent(String pluginId, final String autoRegisterKey, final String environment, final Map<String, String> configuration, Map<String, String> clusterProfileConfiguration, JobIdentifier jobIdentifier) {
         pluginRequestHelper.submitRequest(pluginId, REQUEST_CREATE_AGENT, new DefaultPluginInteractionCallback<Void>() {
             @Override
             public String requestBody(String resolvedExtensionVersion) {

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/elastic/v5/ElasticAgentExtensionConverterV5.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/elastic/v5/ElasticAgentExtensionConverterV5.java
@@ -19,6 +19,7 @@ package com.thoughtworks.go.plugin.access.elastic.v5;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonObject;
+import com.thoughtworks.go.config.elastic.ClusterProfile;
 import com.thoughtworks.go.domain.JobIdentifier;
 import com.thoughtworks.go.plugin.access.common.handler.JSONResultMessageHandler;
 import com.thoughtworks.go.plugin.access.common.models.ImageDeserializer;
@@ -37,10 +38,11 @@ class ElasticAgentExtensionConverterV5 {
     private CapabilitiesConverterV5 capabilitiesConverterV5 = new CapabilitiesConverterV5();
     private AgentMetadataConverterV5 agentMetadataConverterV5 = new AgentMetadataConverterV5();
 
-    String createAgentRequestBody(String autoRegisterKey, String environment, Map<String, String> configuration, JobIdentifier jobIdentifier) {
+    String createAgentRequestBody(String autoRegisterKey, String environment, Map<String, String> configuration, Map<String, String> clusterProfileProperties, JobIdentifier jobIdentifier) {
         JsonObject jsonObject = new JsonObject();
         jsonObject.addProperty("auto_register_key", autoRegisterKey);
-        jsonObject.add("properties", mapToJsonObject(configuration));
+        jsonObject.add("elastic_agent_profile_properties", mapToJsonObject(configuration));
+        jsonObject.add("cluster_profile_properties", mapToJsonObject(clusterProfileProperties));
         jsonObject.addProperty("environment", environment);
         jsonObject.add("job_identifier", jobIdentifierJson(jobIdentifier));
 

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/elastic/v5/ElasticAgentExtensionV5.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/elastic/v5/ElasticAgentExtensionV5.java
@@ -131,11 +131,11 @@ public class ElasticAgentExtensionV5 implements VersionedElasticAgentExtension {
     }
 
     @Override
-    public void createAgent(String pluginId, final String autoRegisterKey, final String environment, final Map<String, String> configuration, JobIdentifier jobIdentifier) {
+    public void createAgent(String pluginId, final String autoRegisterKey, final String environment, final Map<String, String> configuration, Map<String, String> clusterProfileConfiguration, JobIdentifier jobIdentifier) {
         pluginRequestHelper.submitRequest(pluginId, REQUEST_CREATE_AGENT, new DefaultPluginInteractionCallback<Void>() {
             @Override
             public String requestBody(String resolvedExtensionVersion) {
-                return elasticAgentExtensionConverterV5.createAgentRequestBody(autoRegisterKey, environment, configuration, jobIdentifier);
+                return elasticAgentExtensionConverterV5.createAgentRequestBody(autoRegisterKey, environment, configuration, clusterProfileConfiguration, jobIdentifier);
             }
         });
     }

--- a/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/elastic/ElasticAgentExtensionV4Test.java
+++ b/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/elastic/ElasticAgentExtensionV4Test.java
@@ -151,7 +151,7 @@ public class ElasticAgentExtensionV4Test {
         final JobIdentifier jobIdentifier = new JobIdentifier("up42", 2, "Test", "up42_stage", "10", "up42_job");
         when(pluginManager.submitTo(eq(PLUGIN_ID), eq(ELASTIC_AGENT_EXTENSION), requestArgumentCaptor.capture())).thenReturn(DefaultGoPluginApiResponse.success(null));
 
-        extensionV4.createAgent(PLUGIN_ID, "auto-registration-key", "test-env", profile, jobIdentifier);
+        extensionV4.createAgent(PLUGIN_ID, "auto-registration-key", "test-env", profile, null, jobIdentifier);
 
         String expectedRequestBody = "{\n" +
                 "  \"auto_register_key\": \"auto-registration-key\",\n" +

--- a/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/elastic/ElasticAgentExtensionV5Test.java
+++ b/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/elastic/ElasticAgentExtensionV5Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 ThoughtWorks, Inc.
+ * Copyright 2019 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -195,15 +195,19 @@ public class ElasticAgentExtensionV5Test {
 
     @Test
     public void shouldMakeCreateAgentCall() {
-        final Map<String, String> profile = Collections.singletonMap("ServerURL", "https://example.com/go");
+        final Map<String, String> profile = Collections.singletonMap("Image", "alpine:latest");
+        final Map<String, String> clusterProfile = Collections.singletonMap("ServerURL", "https://example.com/go");
         final JobIdentifier jobIdentifier = new JobIdentifier("up42", 2, "Test", "up42_stage", "10", "up42_job");
         when(pluginManager.submitTo(eq(PLUGIN_ID), eq(ELASTIC_AGENT_EXTENSION), requestArgumentCaptor.capture())).thenReturn(DefaultGoPluginApiResponse.success(null));
 
-        extensionV5.createAgent(PLUGIN_ID, "auto-registration-key", "test-env", profile, jobIdentifier);
+        extensionV5.createAgent(PLUGIN_ID, "auto-registration-key", "test-env", profile, clusterProfile, jobIdentifier);
 
         String expectedRequestBody = "{\n" +
                 "  \"auto_register_key\": \"auto-registration-key\",\n" +
-                "  \"properties\": {\n" +
+                "  \"elastic_agent_profile_properties\": {\n" +
+                "    \"Image\": \"alpine:latest\"\n" +
+                "  },\n" +
+                "  \"cluster_profile_properties\": {\n" +
                 "    \"ServerURL\": \"https://example.com/go\"\n" +
                 "  },\n" +
                 "  \"environment\": \"test-env\",\n" +

--- a/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/elastic/ElasticAgentPluginRegistryTest.java
+++ b/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/elastic/ElasticAgentPluginRegistryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 ThoughtWorks, Inc.
+ * Copyright 2019 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -56,13 +56,14 @@ public class ElasticAgentPluginRegistryTest {
     @Test
     public void shouldTalkToExtensionToCreateElasticAgent() {
         final Map<String, String> configuration = Collections.singletonMap("GoServerURL", "foo");
+        final Map<String, String> clusterConfiguration = Collections.singletonMap("GoServerURL", "foo");
         final JobIdentifier jobIdentifier = new JobIdentifier();
         final String autoRegisterKey = "auto-register-key";
         final String environment = "test-env";
 
-        elasticAgentPluginRegistry.createAgent(PLUGIN_ID, autoRegisterKey, environment, configuration, jobIdentifier);
+        elasticAgentPluginRegistry.createAgent(PLUGIN_ID, autoRegisterKey, environment, configuration, clusterConfiguration, jobIdentifier);
 
-        verify(elasticAgentExtension, times(1)).createAgent(PLUGIN_ID, autoRegisterKey, environment, configuration, jobIdentifier);
+        verify(elasticAgentExtension, times(1)).createAgent(PLUGIN_ID, autoRegisterKey, environment, configuration, clusterConfiguration, jobIdentifier);
         verifyNoMoreInteractions(elasticAgentExtension);
     }
 

--- a/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/elastic/v5/ElasticAgentExtensionConverterV5Test.java
+++ b/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/elastic/v5/ElasticAgentExtensionConverterV5Test.java
@@ -58,10 +58,20 @@ public class ElasticAgentExtensionConverterV5Test {
         Map<String, String> configuration = new HashMap<>();
         configuration.put("key1", "value1");
         configuration.put("key2", "value2");
-        String json = new ElasticAgentExtensionConverterV5().createAgentRequestBody("secret-key", "prod", configuration, jobIdentifier);
+
+        Map<String, String> clusterProfileConfiguration = new HashMap<>();
+        clusterProfileConfiguration.put("key1", "value1");
+        clusterProfileConfiguration.put("key2", "value2");
+
+        String json = new ElasticAgentExtensionConverterV5().createAgentRequestBody("secret-key", "prod", configuration, clusterProfileConfiguration, jobIdentifier);
+
         assertThatJson(json).isEqualTo("{" +
                 "  \"auto_register_key\":\"secret-key\"," +
-                "  \"properties\":{" +
+                "  \"elastic_agent_profile_properties\":{" +
+                "    \"key1\":\"value1\"," +
+                "    \"key2\":\"value2\"" +
+                "    }," +
+                "  \"cluster_profile_properties\":{" +
                 "    \"key1\":\"value1\"," +
                 "    \"key2\":\"value2\"" +
                 "    }," +

--- a/server/src/main/java/com/thoughtworks/go/domain/JobAgentMetadata.java
+++ b/server/src/main/java/com/thoughtworks/go/domain/JobAgentMetadata.java
@@ -46,17 +46,19 @@ public class JobAgentMetadata extends PersistentObject {
         Gson gson = new Gson();
         Map map = gson.fromJson(metadata, LinkedHashMap.class);
         String pluginId = (String) map.get("pluginId");
+        String clusterProfileId = (String) map.get("clusterProfileId");
         String id = (String) map.get("id");
         Map<String, String> properties = (Map<String, String>) map.get("properties");
 
         Collection<ConfigurationProperty> configProperties = properties.entrySet().stream().map(entry -> new ConfigurationProperty(new ConfigurationKey(entry.getKey()), new ConfigurationValue(entry.getValue()))).collect(Collectors.toList());
 
-        return new ElasticProfile(id, pluginId, configProperties);
+        return new ElasticProfile(id, pluginId, clusterProfileId, configProperties);
     }
 
     private static String toJSON(ElasticProfile elasticProfile) {
         Gson gson = new Gson();
         Map<String, Object> map = new LinkedHashMap<>();
+        map.put("clusterProfileId", elasticProfile.getClusterProfileId());
         map.put("pluginId", elasticProfile.getPluginId());
         map.put("id", elasticProfile.getId());
         map.put("properties", elasticProfile.getConfigurationAsMap(true));

--- a/server/src/main/java/com/thoughtworks/go/server/messaging/elasticagents/CreateAgentListener.java
+++ b/server/src/main/java/com/thoughtworks/go/server/messaging/elasticagents/CreateAgentListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 ThoughtWorks, Inc.
+ * Copyright 2019 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,6 +29,6 @@ public class CreateAgentListener implements GoMessageListener<CreateAgentMessage
 
     @Override
     public void onMessage(CreateAgentMessage message) {
-        elasticAgentPluginRegistry.createAgent(message.pluginId(), message.autoregisterKey(), message.environment(), message.configuration(), message.jobIdentifier());
+        elasticAgentPluginRegistry.createAgent(message.pluginId(), message.autoregisterKey(), message.environment(), message.configuration(), message.getClusterProfileConfiguration(), message.jobIdentifier());
     }
 }

--- a/server/src/main/java/com/thoughtworks/go/server/messaging/elasticagents/CreateAgentMessage.java
+++ b/server/src/main/java/com/thoughtworks/go/server/messaging/elasticagents/CreateAgentMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 ThoughtWorks, Inc.
+ * Copyright 2019 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,24 +16,28 @@
 
 package com.thoughtworks.go.server.messaging.elasticagents;
 
+import com.thoughtworks.go.config.elastic.ClusterProfile;
 import com.thoughtworks.go.config.elastic.ElasticProfile;
 import com.thoughtworks.go.domain.JobIdentifier;
 import com.thoughtworks.go.server.messaging.PluginAwareMessage;
 
+import java.util.Collections;
 import java.util.Map;
 
 public class CreateAgentMessage implements PluginAwareMessage {
     private final String autoregisterKey;
     private final String environment;
     private final Map<String, String> configuration;
+    private Map<String, String> clusterProfile;
     private final JobIdentifier jobIdentifier;
     private final String pluginId;
 
-    public CreateAgentMessage(String autoregisterKey, String environment, ElasticProfile elasticProfile, JobIdentifier jobIdentifier) {
+    public CreateAgentMessage(String autoregisterKey, String environment, ElasticProfile elasticProfile, ClusterProfile clusterProfile, JobIdentifier jobIdentifier) {
         this.autoregisterKey = autoregisterKey;
         this.environment = environment;
         this.pluginId = elasticProfile.getPluginId();
         this.configuration = elasticProfile.getConfigurationAsMap(true);
+        this.clusterProfile = clusterProfile != null ? clusterProfile.getConfigurationAsMap(true) : Collections.emptyMap();
         this.jobIdentifier = jobIdentifier;
     }
 
@@ -51,6 +55,8 @@ public class CreateAgentMessage implements PluginAwareMessage {
                 "autoregisterKey='" + autoregisterKey + '\'' +
                 ", environment='" + environment + '\'' +
                 ", configuration=" + configuration +
+                ", clusterProfile=" + clusterProfile +
+                ", jobIdentifier=" + jobIdentifier +
                 ", pluginId='" + pluginId + '\'' +
                 '}';
     }
@@ -65,5 +71,9 @@ public class CreateAgentMessage implements PluginAwareMessage {
 
     public JobIdentifier jobIdentifier() {
         return jobIdentifier;
+    }
+
+    public Map<String, String> getClusterProfileConfiguration() {
+        return clusterProfile;
     }
 }

--- a/server/src/test-fast/java/com/thoughtworks/go/server/messaging/elasticagents/CreateAgentMessageTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/messaging/elasticagents/CreateAgentMessageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 ThoughtWorks, Inc.
+ * Copyright 2019 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package com.thoughtworks.go.server.messaging.elasticagents;
 
+import com.thoughtworks.go.config.elastic.ClusterProfile;
 import com.thoughtworks.go.config.elastic.ElasticProfile;
 import com.thoughtworks.go.domain.config.ConfigurationKey;
 import com.thoughtworks.go.domain.config.ConfigurationProperty;
@@ -23,6 +24,7 @@ import com.thoughtworks.go.domain.config.ConfigurationValue;
 import org.junit.Test;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -33,10 +35,22 @@ public class CreateAgentMessageTest {
     @Test
     public void shouldGetPluginId() {
         List<ConfigurationProperty> properties = Arrays.asList(new ConfigurationProperty(new ConfigurationKey("key"), new ConfigurationValue("value")));
-        ElasticProfile jobAgentConfig = new ElasticProfile("foo", "plugin-id", properties);
-        CreateAgentMessage message = new CreateAgentMessage("key", "env", jobAgentConfig, null);
-        assertThat(message.pluginId(), is(jobAgentConfig.getPluginId()));
-        Map<String, String> configurationAsMap = jobAgentConfig.getConfigurationAsMap(true);
+        ElasticProfile elasticProfile = new ElasticProfile("foo", "plugin-id", properties);
+        ClusterProfile clusterProfile = new ClusterProfile("foo", "plugin-id", properties);
+        CreateAgentMessage message = new CreateAgentMessage("key", "env", elasticProfile, clusterProfile, null);
+        assertThat(message.pluginId(), is(elasticProfile.getPluginId()));
+        Map<String, String> configurationAsMap = elasticProfile.getConfigurationAsMap(true);
         assertThat(message.configuration(), is(configurationAsMap));
+        Map<String, String> clusterProfileConfigurations = clusterProfile.getConfigurationAsMap(true);
+        assertThat(message.getClusterProfileConfiguration(), is(clusterProfileConfigurations));
+    }
+
+    @Test
+    public void shouldCreateCreateAgentMessageWhenClusterProfileIsNotSpecified() {
+        List<ConfigurationProperty> properties = Arrays.asList(new ConfigurationProperty(new ConfigurationKey("key"), new ConfigurationValue("value")));
+        ElasticProfile elasticProfile = new ElasticProfile("foo", "plugin-id", properties);
+
+        CreateAgentMessage createAgentMessage = new CreateAgentMessage(null, null, elasticProfile, null, null);
+        assertThat(createAgentMessage.getClusterProfileConfiguration(), is(Collections.emptyMap()));
     }
 }

--- a/server/src/test-integration/java/com/thoughtworks/go/server/dao/JobAgentMetadataSqlMapDaoIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/dao/JobAgentMetadataSqlMapDaoIntegrationTest.java
@@ -75,7 +75,7 @@ public class JobAgentMetadataSqlMapDaoIntegrationTest {
 
     @Test
     public void shouldSaveElasticAgentPropertyOnJob() throws Exception {
-        ElasticProfile profile = new ElasticProfile("elastic", "plugin", new ConfigurationProperty());
+        ElasticProfile profile = new ElasticProfile("elastic", "plugin", "clusterProfileId", new ConfigurationProperty());
         JobAgentMetadata jobAgentMetadata = new JobAgentMetadata(jobId, profile);
         dao.save(jobAgentMetadata);
 
@@ -86,7 +86,7 @@ public class JobAgentMetadataSqlMapDaoIntegrationTest {
 
     @Test
     public void shouldDeleteElasticAgentPropertySetToJob() throws Exception {
-        ElasticProfile profile = new ElasticProfile("elastic", "plugin", new ConfigurationProperty());
+        ElasticProfile profile = new ElasticProfile("elastic", "plugin", "clusterProfileId", new ConfigurationProperty());
         JobAgentMetadata jobAgentMetadata = new JobAgentMetadata(jobId, profile);
         dao.save(jobAgentMetadata);
 


### PR DESCRIPTION
* Modify elastic agent extension v5 create-agent request to pass
  along cluster_profile_properties as part of request body.