### PR TITLE
Fix version parsing for Git and Hg

### DIFF
--- a/agent/build.gradle
+++ b/agent/build.gradle
@@ -181,6 +181,7 @@ task verifyJar(type: VerifyJarTask) {
       "org.apache.felix.framework-${project.versions.felix}.jar",
       "plugin-metadata-store-${project.version}.jar",
       "quartz-${project.versions.quartz}.jar",
+      "semantic-version-${project.versions.semanticVersion}.jar",
       "slf4j-api-${project.versions.slf4j}.jar",
       "spring-aop-${project.versions.spring}.jar",
       "spring-beans-${project.versions.spring}.jar",

--- a/build.gradle
+++ b/build.gradle
@@ -209,6 +209,7 @@ rootProject.ext.versions = [
   oro                 : '2.0.8',
   quartz              : '2.3.0',
   rack                : '1.1.21',
+  semanticVersion     : '1.2.0',
   servletApi          : '3.1.0',
   slf4j               : '1.7.25',
   spark               : '2.7.2',

--- a/common/src/test/java/com/thoughtworks/go/config/materials/mercurial/HgMaterialTest.java
+++ b/common/src/test/java/com/thoughtworks/go/config/materials/mercurial/HgMaterialTest.java
@@ -19,6 +19,7 @@ package com.thoughtworks.go.config.materials.mercurial;
 import com.thoughtworks.go.config.SecretParam;
 import com.thoughtworks.go.domain.materials.*;
 import com.thoughtworks.go.domain.materials.mercurial.HgCommand;
+import com.thoughtworks.go.domain.materials.mercurial.HgVersion;
 import com.thoughtworks.go.domain.materials.mercurial.StringRevision;
 import com.thoughtworks.go.helper.HgTestRepo;
 import com.thoughtworks.go.helper.MaterialsMother;
@@ -62,26 +63,8 @@ public class HgMaterialTest {
     private HgTestRepo hgTestRepo;
     private File workingFolder;
     private InMemoryStreamConsumer outputStreamConsumer;
-    private static final String LINUX_HG_094 = "Mercurial Distributed SCM (version 0.9.4)\n"
-            + "\n"
-            + "Copyright (C) 2005-2007 Matt Mackall <mpm@selenic.com> and others\n"
-            + "This is free software; see the source for copying conditions. There is NO\n"
-            + "warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.";
-    private static final String LINUX_HG_101 = "Mercurial Distributed SCM (version 1.0.1)\n"
-            + "\n"
-            + "Copyright (C) 2005-2007 Matt Mackall <mpm@selenic.com> and others\n"
-            + "This is free software; see the source for copying conditions. There is NO\n"
-            + "warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.";
-    private static final String LINUX_HG_10 = "Mercurial Distributed SCM (version 1.0)\n"
-            + "\n"
-            + "Copyright (C) 2005-2007 Matt Mackall <mpm@selenic.com> and others\n"
-            + "This is free software; see the source for copying conditions. There is NO\n"
-            + "warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.";
-    private static final String WINDOWS_HG_OFFICAL_102 = "Mercurial Distributed SCM (version 1.0.2+20080813)\n"
-            + "\n"
-            + "Copyright (C) 2005-2008 Matt Mackall <mpm@selenic.com>; and others\n"
-            + "This is free software; see the source for copying conditions. There is NO\n"
-            + "warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.";
+    private static final HgVersion LINUX_HG_094 = HgVersion.parse("Mercurial Distributed SCM (version 0.9.4)\n");
+    private static final HgVersion WINDOWS_HG_OFFICIAL_102 = HgVersion.parse("Mercurial Distributed SCM (version 1.0.2+20080813)\n");
     private static final String WINDOWS_HG_TORTOISE = "Mercurial Distributed SCM (version 626cb86a6523+tortoisehg)";
     private static final String REVISION_0 = "b61d12de515d82d3a377ae3aae6e8abe516a2651";
     private static final String REVISION_1 = "35ff2159f303ecf986b3650fc4299a6ffe5a14e1";
@@ -277,28 +260,8 @@ public class HgMaterialTest {
     }
 
     @Test
-    void shouldReturnTrueForLinuxDistributeLowerThanOneZero() {
-        assertThat(hgMaterial.isVersionOnedotZeorOrHigher(LINUX_HG_094)).isFalse();
-    }
-
-    @Test
-    void shouldReturnTrueForLinuxDistributeHigerThanOneZero() {
-        assertThat(hgMaterial.isVersionOnedotZeorOrHigher(LINUX_HG_101)).isTrue();
-    }
-
-    @Test
-    void shouldReturnTrueForLinuxDistributeEqualsOneZero() {
-        assertThat(hgMaterial.isVersionOnedotZeorOrHigher(LINUX_HG_10)).isTrue();
-    }
-
-    @Test
-    void shouldReturnTrueForWindowsDistributionHigerThanOneZero() {
-        assertThat(hgMaterial.isVersionOnedotZeorOrHigher(WINDOWS_HG_OFFICAL_102)).isTrue();
-    }
-
-    @Test
     void shouldReturnFalseWhenVersionIsNotRecgonized() {
-        assertThatCode(() -> hgMaterial.isVersionOnedotZeorOrHigher(WINDOWS_HG_TORTOISE))
+        assertThatCode(() -> hgMaterial.isVersionOneDotZeroOrHigher(WINDOWS_HG_TORTOISE))
                 .isInstanceOf(Exception.class);
     }
 
@@ -321,19 +284,10 @@ public class HgMaterialTest {
 
     @Test
     void shouldReturnInvalidBeanWithRootCauseAsRepositoryURLIsNotFound() {
-        ValidationBean validationBean = hgMaterial.handleException(new Exception(), WINDOWS_HG_OFFICAL_102);
+        ValidationBean validationBean = hgMaterial.handleException(new Exception(), WINDOWS_HG_OFFICIAL_102);
         assertThat(validationBean.isValid()).isFalse();
         assertThat(validationBean.getError()).contains("not found!");
     }
-
-
-    @Test
-    void shouldReturnInvalidBeanWithRootCauseAsRepositoryURLIsNotFoundIfVersionIsNotKnown() {
-        ValidationBean validationBean = hgMaterial.handleException(new Exception(), WINDOWS_HG_TORTOISE);
-        assertThat(validationBean.isValid()).isFalse();
-        assertThat(validationBean.getError()).contains("not found!");
-    }
-
 
     @Test
     void shouldBeAbleToConvertToJson() {

--- a/domain/build.gradle
+++ b/domain/build.gradle
@@ -20,6 +20,7 @@ dependencies {
   compile project(':db')
   compile project(':commandline')
   compile group: 'org.springframework', name: 'spring-tx', version: project.versions.spring
+  compile group: 'de.skuzzle', name: 'semantic-version', version: project.versions.semanticVersion
   testCompile project(path: ':config:config-api', configuration: 'testOutput')
   testCompile project(':test:test-utils')
   testCompileOnly group: 'junit', name: 'junit', version: project.versions.junit

--- a/domain/src/main/java/com/thoughtworks/go/config/materials/mercurial/HgMaterial.java
+++ b/domain/src/main/java/com/thoughtworks/go/config/materials/mercurial/HgMaterial.java
@@ -24,6 +24,7 @@ import com.thoughtworks.go.domain.MaterialInstance;
 import com.thoughtworks.go.domain.materials.*;
 import com.thoughtworks.go.domain.materials.mercurial.HgCommand;
 import com.thoughtworks.go.domain.materials.mercurial.HgMaterialInstance;
+import com.thoughtworks.go.domain.materials.mercurial.HgVersion;
 import com.thoughtworks.go.domain.materials.svn.MaterialUrl;
 import com.thoughtworks.go.util.GoConstants;
 import com.thoughtworks.go.util.command.*;
@@ -145,7 +146,7 @@ public class HgMaterial extends ScmMaterial {
         hg(baseDir, consumer).push(consumer);
     }
 
-    boolean isVersionOnedotZeorOrHigher(String hgout) {
+    boolean isVersionOneDotZeroOrHigher(String hgout) {
         String hgVersion = parseHgVersion(hgout);
         Float aFloat = NumberUtils.createFloat(hgVersion.subSequence(0, 3).toString());
         return aFloat >= 1;
@@ -168,24 +169,20 @@ public class HgMaterial extends ScmMaterial {
             hgCommand.checkConnection(url);
             return ValidationBean.valid();
         } catch (Exception e) {
-            String message = null;
             try {
-                message = hgCommand.version();
-                return handleException(e, message);
+                return handleException(e, hgCommand.version());
             } catch (Exception ex) {
                 return ValidationBean.notValid(ERR_NO_HG_INSTALLED);
             }
         }
     }
 
-
-    ValidationBean handleException(Exception e, String hgVersionConsoleOut) {
+    ValidationBean handleException(Exception e, HgVersion version) {
         ValidationBean defaultResponse = ValidationBean.notValid(
                 "Repository " + url.forDisplay() + " not found!" + " : \n" + e.getMessage());
         try {
-            boolean olderThanHg10 = !isVersionOnedotZeorOrHigher(hgVersionConsoleOut);
-            if (olderThanHg10) {
-                return ValidationBean.notValid(ERROR_OLD_VERSION + hgVersionConsoleOut);
+            if (version.isOlderThanOneDotZero()) {
+                return ValidationBean.notValid(ERROR_OLD_VERSION + version.toString());
             } else {
                 return defaultResponse;
             }

--- a/domain/src/main/java/com/thoughtworks/go/domain/materials/git/GitCommand.java
+++ b/domain/src/main/java/com/thoughtworks/go/domain/materials/git/GitCommand.java
@@ -282,10 +282,11 @@ public class GitCommand extends SCMCommand {
         return (branchList.output().size() == 1);
     }
 
-    public String version(Map<String, String> map) {
+    public GitVersion version(Map<String, String> map) {
         CommandLine gitLsRemote = git(map).withArgs("version");
 
-        return gitLsRemote.runOrBomb("git version check").outputAsString();
+        String gitVersionString = gitLsRemote.runOrBomb("git version check").outputAsString();
+        return GitVersion.parse(gitVersionString);
     }
 
     public void add(File fileToAdd) {

--- a/domain/src/main/java/com/thoughtworks/go/domain/materials/git/GitVersion.java
+++ b/domain/src/main/java/com/thoughtworks/go/domain/materials/git/GitVersion.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.domain.materials.git;
+
+import de.skuzzle.semantic.Version;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static com.thoughtworks.go.util.ExceptionUtils.bomb;
+
+public class GitVersion {
+
+    private static final Pattern GIT_VERSION_PATTERN = Pattern.compile(
+            "git version (\\d+)\\.(\\d+)(?:\\.(\\d+))?(?:\\.(\\d+))?(.*)", Pattern.CASE_INSENSITIVE);
+
+    private final Version version;
+
+    private GitVersion(Version parsedVersion) {
+        this.version = parsedVersion;
+    }
+
+    public static GitVersion parse(String versionFromConsoleOutput) {
+        String[] lines = versionFromConsoleOutput.split("\n");
+        String firstLine = lines[0];
+        Matcher m = GIT_VERSION_PATTERN.matcher(firstLine);
+        if (m.find()) {
+            try {
+                return new GitVersion(parseVersion(m));
+            } catch (Exception e) {
+                throw bomb("cannot parse git version : " + versionFromConsoleOutput);
+            }
+        }
+        throw bomb("cannot parse git version : " + versionFromConsoleOutput);
+    }
+
+    public boolean isVersionOneDotSixOrHigher() {
+        return this.version.compareTo(Version.create(1, 6, 0)) >= 0;
+    }
+
+    public Version getVersion() {
+        return this.version;
+    }
+
+    private static Version parseVersion(Matcher m) {
+        int major = asInt(m, 1);
+        int minor = asInt(m, 2);
+        int rev = asInt(m, 3);
+        return Version.create(major, minor, rev);
+    }
+
+    private static int asInt(Matcher m, int group) {
+        if (group > m.groupCount() + 1) {
+            return 0;
+        }
+        final String match = m.group(group);
+        if (match == null) {
+            return 0;
+        }
+        return Integer.parseInt(match);
+    }
+}

--- a/domain/src/main/java/com/thoughtworks/go/domain/materials/mercurial/HgCommand.java
+++ b/domain/src/main/java/com/thoughtworks/go/domain/materials/mercurial/HgCommand.java
@@ -58,9 +58,10 @@ public class HgCommand extends SCMCommand {
         return execute(hg, outputStreamConsumer) == 0;
     }
 
-    public String version() {
+    public HgVersion version() {
         CommandLine hg = createCommandLine("hg").withArgs("version").withEncoding("utf-8");
-        return execute(hg, "hg version check").outputAsString();
+        String hgOut = execute(hg, "hg version check").outputAsString();
+        return HgVersion.parse(hgOut);
     }
 
 

--- a/domain/src/main/java/com/thoughtworks/go/domain/materials/mercurial/HgVersion.java
+++ b/domain/src/main/java/com/thoughtworks/go/domain/materials/mercurial/HgVersion.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.domain.materials.mercurial;
+
+import de.skuzzle.semantic.Version;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static com.thoughtworks.go.util.ExceptionUtils.bomb;
+
+public class HgVersion {
+    private static final Pattern HG_VERSION_PATTERN =
+            Pattern.compile(".+\\(\\s*\\S+\\s+(\\d+)\\.(\\d+)[.]?(\\d+)?.*\\s*\\)\\s*.*\\s*", Pattern.CASE_INSENSITIVE);
+    private final Version version;
+
+    public HgVersion(Version version) {
+        this.version = version;
+    }
+
+    public static HgVersion parse(String hgOut) {
+        String[] lines = hgOut.split("\n");
+        String firstLine = lines[0];
+        Matcher m = HG_VERSION_PATTERN.matcher(firstLine);
+        if (m.matches()) {
+            try {
+                return new HgVersion(Version.create(
+                        asInt(m, 1),
+                        asInt(m, 2),
+                        asInt(m, 3)));
+            } catch (Exception e) {
+                throw bomb("cannot parse Hg version : " + hgOut);
+            }
+        }
+        throw bomb("cannot parse Hg version : " + hgOut);
+    }
+
+    public boolean isOlderThanOneDotZero() {
+        return this.version.isLowerThan(Version.create(1, 0, 0));
+    }
+
+    public Version getVersion() {
+        return this.version;
+    }
+
+    private static int asInt(Matcher m, int group) {
+        if (group > m.groupCount() + 1) {
+            return 0;
+        }
+        final String match = m.group(group);
+        if (match == null) {
+            return 0;
+        }
+        return Integer.parseInt(match);
+    }
+}

--- a/domain/src/test/java/com/thoughtworks/go/domain/materials/git/GitVersionTest.java
+++ b/domain/src/test/java/com/thoughtworks/go/domain/materials/git/GitVersionTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.domain.materials.git;
+
+import de.skuzzle.semantic.Version;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+public class GitVersionTest {
+
+    @Test
+    public void shouldParseGitVersions() {
+        assertThat(GitVersion.parse("git version 1.6.0.2").getVersion())
+                .isEqualTo(Version.create(1, 6, 0));
+
+        assertThat(GitVersion.parse("git version 1.5.4.3").getVersion())
+                .isEqualTo(Version.create(1, 5, 4));
+
+        assertThat(GitVersion.parse("git version 1.6.0.2.1172.ga5ed0").getVersion())
+                .isEqualTo(Version.create(1, 6, 0));
+
+        assertThat(GitVersion.parse("git version 1.6.1 (ubuntu 18.04.1)").getVersion())
+                .isEqualTo(Version.create(1, 6, 1));
+    }
+
+    @Test
+    public void shouldThowExceptionWhenGitVersionCannotBeParsed() {
+        String invalidGitVersion = "git version ga5ed0asdasd.ga5ed0";
+        assertThatExceptionOfType(RuntimeException.class)
+                .isThrownBy(() -> GitVersion.parse(invalidGitVersion))
+                .withMessage("cannot parse git version : " + invalidGitVersion);
+    }
+
+    @Test
+    void shouldReturnTrueIfVersionEqualToOrHigherThan1Dot6() {
+        GitVersion version = GitVersion.parse("git version 1.6.0.2");
+        assertThat(version.isVersionOneDotSixOrHigher()).isTrue();
+    }
+
+    @Test
+    void shouldReturnFalseIfVersionLowerThan1Dot6() {
+        GitVersion version = GitVersion.parse("git version 1.5.0.1");
+        assertThat(version.isVersionOneDotSixOrHigher()).isFalse();
+    }
+}

--- a/domain/src/test/java/com/thoughtworks/go/domain/materials/mercurial/HgVersionTest.java
+++ b/domain/src/test/java/com/thoughtworks/go/domain/materials/mercurial/HgVersionTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.domain.materials.mercurial;
+
+import de.skuzzle.semantic.Version;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+public class HgVersionTest {
+
+    private static final String LINUX_HG_094 = "Mercurial Distributed SCM (version 0.9.4)\n"
+            + "\n"
+            + "Copyright (C) 2005-2007 Matt Mackall <mpm@selenic.com> and others\n"
+            + "This is free software; see the source for copying conditions. There is NO\n"
+            + "warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.";
+    private static final String LINUX_HG_101 = "Mercurial Distributed SCM (version 1.0.1)\n"
+            + "\n"
+            + "Copyright (C) 2005-2007 Matt Mackall <mpm@selenic.com> and others\n"
+            + "This is free software; see the source for copying conditions. There is NO\n"
+            + "warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.";
+    private static final String LINUX_HG_10 = "Mercurial Distributed SCM (version 1.0)\n"
+            + "\n"
+            + "Copyright (C) 2005-2007 Matt Mackall <mpm@selenic.com> and others\n"
+            + "This is free software; see the source for copying conditions. There is NO\n"
+            + "warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.";
+    private static final String WINDOWS_HG_OFFICAL_102 = "Mercurial Distributed SCM (version 1.0.2+20080813)\n"
+            + "\n"
+            + "Copyright (C) 2005-2008 Matt Mackall <mpm@selenic.com>; and others\n"
+            + "This is free software; see the source for copying conditions. There is NO\n"
+            + "warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.";
+    private static final String WINDOWS_HG_TORTOISE = "Mercurial Distributed SCM (version 626cb86a6523+tortoisehg)";
+    private static final String HG_TWO_DIGIT_VERSION = "Mercurial Distributed SCM (version 10.19.40)";
+    private static final String HG_MULTIPLE_VERSIONS = "Mercurial Distributed SCM (version 2.6.2), 2.7-rc+5-ca2dfc2f63eb";
+
+    @Test
+    void shouldParseHgVersions() {
+        assertThat(HgVersion.parse(LINUX_HG_094).getVersion()).isEqualTo(Version.create(0,9,4));
+        assertThat(HgVersion.parse(LINUX_HG_101).getVersion()).isEqualTo(Version.create(1,0,1));
+        assertThat(HgVersion.parse(LINUX_HG_10).getVersion()).isEqualTo(Version.create(1,0,0));
+        assertThat(HgVersion.parse(WINDOWS_HG_OFFICAL_102).getVersion()).isEqualTo(Version.create(1,0,2));
+        assertThat(HgVersion.parse(HG_TWO_DIGIT_VERSION).getVersion()).isEqualTo(Version.create(10,19,40));
+        assertThat(HgVersion.parse(HG_MULTIPLE_VERSIONS).getVersion()).isEqualTo(Version.create(2,6,2));
+    }
+
+    @Test
+    void shouldReturnTrueWhenHgVersionIsOlderThanOneDotZero() {
+        assertThat(HgVersion.parse(LINUX_HG_094).isOlderThanOneDotZero()).isTrue();
+    }
+
+    @Test
+    void shouldReturnFalseWhenHgVersionIsOneDotZeroOrNewer() {
+        assertThat(HgVersion.parse(LINUX_HG_101).isOlderThanOneDotZero()).isFalse();
+        assertThat(HgVersion.parse(LINUX_HG_10).isOlderThanOneDotZero()).isFalse();
+        assertThat(HgVersion.parse(WINDOWS_HG_OFFICAL_102).isOlderThanOneDotZero()).isFalse();
+    }
+
+    @Test
+    void shouldBombIfVersionCannotBeParsed() {
+        assertThatExceptionOfType(RuntimeException.class)
+                .isThrownBy(() -> HgVersion.parse(WINDOWS_HG_TORTOISE))
+                .withMessage("cannot parse Hg version : " + WINDOWS_HG_TORTOISE);
+    }
+}

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -920,6 +920,7 @@ task verifyWar(type: VerifyJarTask) {
         "plugin-metadata-store-${project.version}.jar",
         "quartz-${project.versions.quartz}.jar",
         "rack_hack-${project.version}.jar",
+        "semantic-version-${project.versions.semanticVersion}.jar",
         "slf4j-api-${project.versions.slf4j}.jar",
         "smtp-${project.versions.mail}.jar",
         "spark-core-${project.versions.spark}.jar",


### PR DESCRIPTION
- Introduced a library to do Semantic Version parsing and comparisons so that we don't have to compare floats. https://github.com/skuzzle/semantic-version (MIT licensed)

## For Git
The earlier regex did not parse the minor version correctly. E.g. for the string `git version 2.17.2 (Apple Git-113)` we would get `group(1)` as `2.1`.
Since we are interested only `major.minor.patch`, the regex group now looks for that only.

## For Hg
The earlier regex did not parse the major version correctly for double digits. E.g. for the string `Mercurial Distributed SCM (version 10.19.40)`, the match would fail. Also attaching a patch version of zero if not present, so that the semver library can parse it properly.