### PR TITLE
Delete job plan associated entities in job status listener

### DIFF
--- a/server/src/main/java/com/thoughtworks/go/server/dao/JobInstanceSqlMapDao.java
+++ b/server/src/main/java/com/thoughtworks/go/server/dao/JobInstanceSqlMapDao.java
@@ -267,7 +267,9 @@ public class JobInstanceSqlMapDao extends SqlMapClientDaoSupport implements JobI
         }
     }
 
-    private void deleteJobPlanAssociatedEntities(JobInstance job) {
+    //delete all job plan associated entities on job completion
+    //this will be called from Job Status Listener when Job is completed.
+    public void deleteJobPlanAssociatedEntities(JobInstance job) {
         JobPlan jobPlan = loadPlan(job.getId());
         environmentVariableDao.deleteAll(jobPlan.getVariables());
         artifactPlanRepository.deleteAll(jobPlan.getArtifactPlansOfType(ArtifactPlanType.file));
@@ -423,10 +425,6 @@ public class JobInstanceSqlMapDao extends SqlMapClientDaoSupport implements JobI
             return null;
         });
         saveTransitions(jobInstance);
-
-        if (jobInstance.isCompleted()) {
-            deleteJobPlanAssociatedEntities(jobInstance);
-        }
     }
 
     private void updateResult(JobInstance job) {

--- a/server/src/test-fast/java/com/thoughtworks/go/server/messaging/JobStatusListenerTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/messaging/JobStatusListenerTest.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.server.messaging;
+
+import com.thoughtworks.go.domain.*;
+import com.thoughtworks.go.helper.JobIdentifierMother;
+import com.thoughtworks.go.helper.JobInstanceMother;
+import com.thoughtworks.go.helper.StageMother;
+import com.thoughtworks.go.server.dao.JobInstanceSqlMapDao;
+import com.thoughtworks.go.server.service.ElasticAgentPluginService;
+import com.thoughtworks.go.server.service.StageService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+
+import static org.mockito.Mockito.*;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+class JobStatusListenerTest {
+    @Mock
+    private JobInstanceSqlMapDao jobInstanceSqlMapDao;
+    @Mock
+    private StageService stageService;
+    @Mock
+    private StageStatusTopic stageStatusTopic;
+    @Mock
+    private ElasticAgentPluginService elasticAgentPluginService;
+    @Mock
+    private JobStatusTopic jobStatusTopic;
+
+    private JobStatusListener jobStatusListener;
+
+    @BeforeEach
+    void setUp() {
+        initMocks(this);
+        jobStatusListener = new JobStatusListener(jobStatusTopic, stageService, stageStatusTopic, elasticAgentPluginService, jobInstanceSqlMapDao);
+    }
+
+    @Test
+    void shouldAddAListenerOnJobStatusTopic() {
+        jobStatusListener.init();
+
+        verify(jobStatusTopic, times(1)).addListener(jobStatusListener);
+    }
+
+    @Test
+    void shouldDeleteJobPlanAssociatedEntitiesOnJobCompletion() {
+        JobIdentifier jobIdentifier = JobIdentifierMother.anyBuildIdentifier();
+        JobInstance jobInstance = JobInstanceMother.completed(jobIdentifier.getBuildName());
+        Stage stage = StageMother.passedStageInstance(jobIdentifier.getStageName(), jobIdentifier.getBuildName(), jobIdentifier.getPipelineName());
+        stage.setJobInstances(new JobInstances(jobInstance));
+        JobStatusMessage jobStatusMessage = new JobStatusMessage(jobIdentifier, JobState.Completed, "agent1");
+        when(stageService.findStageWithIdentifier(jobStatusMessage.getStageIdentifier())).thenReturn(stage);
+
+        jobStatusListener.onMessage(jobStatusMessage);
+
+        verify(jobInstanceSqlMapDao, times(1)).deleteJobPlanAssociatedEntities(jobInstance);
+    }
+
+    @Test
+    void shouldNotDeleteJobPlanAssociatedEntitiesWhenJobIsStillInProgress() {
+        JobIdentifier jobIdentifier = JobIdentifierMother.anyBuildIdentifier();
+        JobInstance jobInstance = JobInstanceMother.completed(jobIdentifier.getBuildName());
+        Stage stage = StageMother.passedStageInstance(jobIdentifier.getStageName(), jobIdentifier.getBuildName(), jobIdentifier.getPipelineName());
+        stage.setJobInstances(new JobInstances(jobInstance));
+        JobStatusMessage jobStatusMessage = new JobStatusMessage(jobIdentifier, JobState.Building, "agent1");
+        when(stageService.findStageWithIdentifier(jobStatusMessage.getStageIdentifier())).thenReturn(stage);
+
+        jobStatusListener.onMessage(jobStatusMessage);
+
+        verifyZeroInteractions(jobInstanceSqlMapDao);
+    }
+
+    @Test
+    void shouldPostAStageStatusChangeMessageWhenStageIsCompletedBecauseOfJobCompletion() {
+        JobIdentifier jobIdentifier = JobIdentifierMother.anyBuildIdentifier();
+        JobInstance jobInstance = JobInstanceMother.completed(jobIdentifier.getBuildName());
+        Stage stage = StageMother.passedStageInstance(jobIdentifier.getStageName(), jobIdentifier.getBuildName(), jobIdentifier.getPipelineName());
+        stage.setJobInstances(new JobInstances(jobInstance));
+        JobStatusMessage jobStatusMessage = new JobStatusMessage(jobIdentifier, JobState.Completed, "agent1");
+        when(stageService.findStageWithIdentifier(jobStatusMessage.getStageIdentifier())).thenReturn(stage);
+
+        jobStatusListener.onMessage(jobStatusMessage);
+
+        verify(stageStatusTopic, times(1)).post(any());
+    }
+
+    @Test
+    void shouldNotPostAStageStatusChangeMessageWhenJobIsInProgress() {
+        JobIdentifier jobIdentifier = JobIdentifierMother.anyBuildIdentifier();
+        JobInstance jobInstance = JobInstanceMother.completed(jobIdentifier.getBuildName());
+        Stage stage = StageMother.passedStageInstance(jobIdentifier.getStageName(), jobIdentifier.getBuildName(), jobIdentifier.getPipelineName());
+        stage.setJobInstances(new JobInstances(jobInstance));
+        JobStatusMessage jobStatusMessage = new JobStatusMessage(jobIdentifier, JobState.Building, "agent1");
+        when(stageService.findStageWithIdentifier(jobStatusMessage.getStageIdentifier())).thenReturn(stage);
+
+        jobStatusListener.onMessage(jobStatusMessage);
+
+        verifyZeroInteractions(stageStatusTopic);
+    }
+
+    @Test
+    void shouldNotPostAStageStatusChangeMessageWhenStageIsRunningAndJobIsCompleted() {
+        JobIdentifier jobIdentifier = JobIdentifierMother.anyBuildIdentifier();
+        JobInstance jobInstance = JobInstanceMother.completed(jobIdentifier.getBuildName());
+        Stage stage = StageMother.withOneScheduledBuild(jobIdentifier.getStageName(), jobIdentifier.getBuildName(), "running_job", 100);
+        stage.getJobInstances().add(jobInstance);
+        JobStatusMessage jobStatusMessage = new JobStatusMessage(jobIdentifier, JobState.Completed, "agent1");
+        when(stageService.findStageWithIdentifier(jobStatusMessage.getStageIdentifier())).thenReturn(stage);
+
+        jobStatusListener.onMessage(jobStatusMessage);
+
+        verifyZeroInteractions(stageStatusTopic);
+    }
+
+    @Test
+    void shouldPostAMessageToElasticAgentPluginServiceOnJobCompletion() {
+        JobIdentifier jobIdentifier = JobIdentifierMother.anyBuildIdentifier();
+        JobInstance jobInstance = JobInstanceMother.completed(jobIdentifier.getBuildName());
+        Stage stage = StageMother.passedStageInstance(jobIdentifier.getStageName(), jobIdentifier.getBuildName(), jobIdentifier.getPipelineName());
+        stage.setJobInstances(new JobInstances(jobInstance));
+        JobStatusMessage jobStatusMessage = new JobStatusMessage(jobIdentifier, JobState.Completed, "agent1");
+        when(stageService.findStageWithIdentifier(jobStatusMessage.getStageIdentifier())).thenReturn(stage);
+
+        jobStatusListener.onMessage(jobStatusMessage);
+
+        verify(elasticAgentPluginService, times(1)).jobCompleted(jobInstance);
+    }
+
+    @Test
+    void shouldNotPostAMessageToElasticAgentPluginServiceOnJobIsStillInProgress() {
+        JobIdentifier jobIdentifier = JobIdentifierMother.anyBuildIdentifier();
+        JobInstance jobInstance = JobInstanceMother.completed(jobIdentifier.getBuildName());
+        Stage stage = StageMother.passedStageInstance(jobIdentifier.getStageName(), jobIdentifier.getBuildName(), jobIdentifier.getPipelineName());
+        stage.setJobInstances(new JobInstances(jobInstance));
+        JobStatusMessage jobStatusMessage = new JobStatusMessage(jobIdentifier, JobState.Building, "agent1");
+        when(stageService.findStageWithIdentifier(jobStatusMessage.getStageIdentifier())).thenReturn(stage);
+
+        jobStatusListener.onMessage(jobStatusMessage);
+
+        verifyNoMoreInteractions(elasticAgentPluginService);
+    }
+}

--- a/server/src/test-integration/java/com/thoughtworks/go/server/dao/JobInstanceSqlMapDaoIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/dao/JobInstanceSqlMapDaoIntegrationTest.java
@@ -30,6 +30,7 @@ import com.thoughtworks.go.helper.BuildPlanMother;
 import com.thoughtworks.go.helper.JobInstanceMother;
 import com.thoughtworks.go.helper.PipelineMother;
 import com.thoughtworks.go.server.cache.GoCache;
+import com.thoughtworks.go.server.messaging.JobStatusListener;
 import com.thoughtworks.go.server.service.InstanceFactory;
 import com.thoughtworks.go.server.service.JobInstanceService;
 import com.thoughtworks.go.server.service.ScheduleService;
@@ -62,12 +63,7 @@ import static com.thoughtworks.go.server.dao.PersistentObjectMatchers.hasSameId;
 import static com.thoughtworks.go.util.DataStructureUtils.a;
 import static com.thoughtworks.go.util.GoConstants.DEFAULT_APPROVED_BY;
 import static com.thoughtworks.go.util.LogFixture.logFixtureFor;
-import static org.hamcrest.Matchers.hasProperty;
-import static org.hamcrest.Matchers.hasItemInArray;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.not;
-import static org.hamcrest.Matchers.notNullValue;
-import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertThat;
 
 @RunWith(SpringJUnit4ClassRunner.class)
@@ -100,6 +96,8 @@ public class JobInstanceSqlMapDaoIntegrationTest {
     private GoConfigDao goConfigDao;
     @Autowired
     private InstanceFactory instanceFactory;
+    @Autowired
+    private JobStatusListener jobStatusListener;
 
     private GoConfigFileHelper configHelper = new GoConfigFileHelper();
 
@@ -441,10 +439,7 @@ public class JobInstanceSqlMapDaoIntegrationTest {
         assertThat(jobPlanFromDb.getVariables(), is(jobPlan.getVariables()));
         assertThat(jobPlanFromDb.getElasticProfile(), is(jobPlan.getElasticProfile()));
 
-        Date completionDate = new Date();
-        jobInstance.completing(JobResult.Passed, completionDate);
-        jobInstance.completed(completionDate);
-        jobInstanceDao.updateStateAndResult(jobInstance);
+        jobInstanceDao.deleteJobPlanAssociatedEntities(jobInstance);
         jobPlanFromDb = jobInstanceDao.loadPlan(jobInstance.getId());
 
         assertThat(jobPlanFromDb.getArtifactPlans().size(), is(2));


### PR DESCRIPTION
Changes:
* Instead of deleting job plan related entities directly from
  jobInstanceDao, delete the job plan entities from job status
  change listener.

Reason:
* Job Status Change Listener is responsible to notify elastic
  agent plugin service upon job-completion. To provide  multi
  cluster support, we need to send cluster-profile as well, which
  are stored as part of job-agent metadata.
* Though, as the job plan related enitites were deleted even before
  the job status listener was called, job plan was not available
  at the time of notifying elastic agent plugin service.
* Hence, move the job plan deletion logic to job status listener.
  So that the job plan can be deleted after notifying the elastic
  agent plugin for job-completion.