### PR TITLE
Shallow clone submodules

### DIFF
--- a/base/src/main/java/com/thoughtworks/go/util/FileUtil.java
+++ b/base/src/main/java/com/thoughtworks/go/util/FileUtil.java
@@ -107,6 +107,10 @@ public class FileUtil {
         return uriString.replaceAll("^file:/", "file:///");
     }
 
+    public static String toFileURI(String path) {
+        return toFileURI(new File(path));
+    }
+
     public static String filesystemSafeFileHash(File folder) {
         String hash = Base64.getEncoder().encodeToString(DigestUtils.sha1(folder.getAbsolutePath().getBytes()));
         hash = hash.replaceAll("[^0-9a-zA-Z\\.\\-]", "");

--- a/build.gradle
+++ b/build.gradle
@@ -594,6 +594,22 @@ task gitRelatedTests { thisTask ->
     })
     thisTask.dependsOn eachTestTask
   }
+  finalizedBy 'gitRelatedTestsJunitHtmlReport'
+}
+
+task gitRelatedTestsJunitHtmlReport(type: TestReport) { TestReport thisTask ->
+  group LifecycleBasePlugin.VERIFICATION_GROUP
+  description = "Run all Git related tests"
+
+  forAllTask { Test eachTestTask ->
+    eachTestTask.filter({ TestFilter testFilter ->
+      testFilter.setFailOnNoMatchingTests(false)
+      testFilter.setIncludePatterns("*Git*Test*")
+    })
+    thisTask.reportOn eachTestTask.binResultsDir
+    eachTestTask.finalizedBy(thisTask)
+  }
+  destinationDir = file("${project.buildDir}/reports/tests/gitRelatedTests")
 }
 
 task sparkTest { thisTask ->

--- a/build.gradle
+++ b/build.gradle
@@ -584,6 +584,18 @@ task compileAll { compileAllTask ->
 
 task prepare(dependsOn: compileAll)
 
+task gitRelatedTests { thisTask ->
+  group LifecycleBasePlugin.VERIFICATION_GROUP
+  description = "Run all Git related tests"
+  forAllTask { Test eachTestTask ->
+    eachTestTask.filter({ TestFilter testFilter ->
+      testFilter.setFailOnNoMatchingTests(false)
+      testFilter.setIncludePatterns("*Git*Test*")
+    })
+    thisTask.dependsOn eachTestTask
+  }
+}
+
 task sparkTest { thisTask ->
   group LifecycleBasePlugin.VERIFICATION_GROUP
   description = "Run all api tests"

--- a/commandline/src/main/java/com/thoughtworks/go/util/command/CommandLine.java
+++ b/commandline/src/main/java/com/thoughtworks/go/util/command/CommandLine.java
@@ -313,6 +313,11 @@ public class CommandLine {
         return this;
     }
 
+    public CommandLine withArgs(List<String> args) {
+        args.forEach(arg -> arguments.add(new StringArgument(arg)));
+        return this;
+    }
+
     public CommandLine argPassword(String password) {
         arguments.add(new PasswordArgument(password));
         return this;

--- a/common/src/test/java/com/thoughtworks/go/domain/materials/git/EnabledOnGitVersionCondition.java
+++ b/common/src/test/java/com/thoughtworks/go/domain/materials/git/EnabledOnGitVersionCondition.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.domain.materials.git;
+
+import com.thoughtworks.go.config.materials.git.GitMaterialConfig;
+import de.skuzzle.semantic.Version;
+import org.junit.jupiter.api.extension.ConditionEvaluationResult;
+import org.junit.jupiter.api.extension.ExecutionCondition;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+import java.io.File;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Optional;
+
+import static org.junit.platform.commons.util.AnnotationUtils.findAnnotation;
+
+public class EnabledOnGitVersionCondition implements ExecutionCondition {
+
+
+    @Override
+    public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext context) {
+        Optional<EnabledOnGitVersionsAbove> annotation = findAnnotation(context.getElement(), EnabledOnGitVersionsAbove.class);
+        if (annotation.isPresent()) {
+            String version = annotation.get().value();
+            Version requiredVersion = Version.parseVersion(version);
+            GitCommand git = new GitCommand(null, new File(""), GitMaterialConfig.DEFAULT_BRANCH, false, new HashMap<>(), null);
+            Version gitVersion = git.version(Collections.emptyMap()).getVersion();
+            if (gitVersion.compareTo(requiredVersion) >= 0) {
+                return ConditionEvaluationResult.enabled(String.format(
+                        "Git version required for this test is %s or later. Detected Version is %s", requiredVersion, gitVersion));
+            } else {
+                return ConditionEvaluationResult.disabled(String.format(
+                        "Git version required for this test is %s or later. Detected Version is %s", requiredVersion, gitVersion));
+            }
+        }
+        return ConditionEvaluationResult.enabled("Version not provided. Running by default");
+    }
+}

--- a/common/src/test/java/com/thoughtworks/go/domain/materials/git/EnabledOnGitVersionsAbove.java
+++ b/common/src/test/java/com/thoughtworks/go/domain/materials/git/EnabledOnGitVersionsAbove.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.domain.materials.git;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ ElementType.TYPE, ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+@ExtendWith(EnabledOnGitVersionCondition.class)
+public @interface EnabledOnGitVersionsAbove {
+
+    String value(); //use the format: major.minor.rev
+}

--- a/domain/src/main/java/com/thoughtworks/go/config/materials/git/GitMaterial.java
+++ b/domain/src/main/java/com/thoughtworks/go/config/materials/git/GitMaterial.java
@@ -153,7 +153,7 @@ public class GitMaterial extends ScmMaterial {
             GitCommand git = git(outputStreamConsumer, workingDir, revisionContext.numberOfModifications() + 1, execCtx);
             git.fetch(outputStreamConsumer);
             unshallowIfNeeded(git, outputStreamConsumer, revisionContext.getOldestRevision(), baseDir);
-            git.resetWorkingDir(outputStreamConsumer, revision);
+            git.resetWorkingDir(outputStreamConsumer, revision, shallowClone);
             outputStreamConsumer.stdOutput(format("[%s] Done.\n", GoConstants.PRODUCT_NAME));
         } catch (Exception e) {
             bomb(e);

--- a/domain/src/main/java/com/thoughtworks/go/domain/materials/git/GitVersion.java
+++ b/domain/src/main/java/com/thoughtworks/go/domain/materials/git/GitVersion.java
@@ -30,6 +30,7 @@ public class GitVersion {
 
     private final Version version;
     private final static Version MINIMUM_SUPPORTED_VERSION = Version.create(1,9,0);
+    private final static Version SUBMODULE_DEPTH_SUPPORT = Version.create(2, 10, 0);
 
     private GitVersion(Version parsedVersion) {
         this.version = parsedVersion;
@@ -51,6 +52,10 @@ public class GitVersion {
 
     public boolean isMinimumSupportedVersionOrHigher() {
         return this.version.compareTo(MINIMUM_SUPPORTED_VERSION) >= 0;
+    }
+
+    public boolean supportsSubmoduleDepth() {
+        return version.compareTo(SUBMODULE_DEPTH_SUPPORT) >= 0;
     }
 
     public Version getVersion() {

--- a/domain/src/test/java/com/thoughtworks/go/config/materials/git/GitMaterialTest.java
+++ b/domain/src/test/java/com/thoughtworks/go/config/materials/git/GitMaterialTest.java
@@ -24,7 +24,7 @@ import com.thoughtworks.go.domain.materials.*;
 import com.thoughtworks.go.domain.materials.git.GitTestRepo;
 import com.thoughtworks.go.domain.materials.git.GitVersion;
 import com.thoughtworks.go.domain.materials.mercurial.StringRevision;
-import com.thoughtworks.go.helper.GitSubmoduleRepos;
+import com.thoughtworks.go.helper.GitRepoContainingSubmodule;
 import com.thoughtworks.go.helper.MaterialsMother;
 import com.thoughtworks.go.helper.TestRepo;
 import com.thoughtworks.go.util.JsonValue;
@@ -195,7 +195,7 @@ public class GitMaterialTest {
 
     @Test
     void shouldRemoveSubmoduleFolderFromWorkingDirWhenSubmoduleIsRemovedFromRepo() throws Exception {
-        GitSubmoduleRepos submoduleRepos = new GitSubmoduleRepos(temporaryFolder);
+        GitRepoContainingSubmodule submoduleRepos = new GitRepoContainingSubmodule(temporaryFolder);
         submoduleRepos.addSubmodule(SUBMODULE, "sub1");
         GitMaterial gitMaterial = new GitMaterial(submoduleRepos.mainRepo().getUrl());
 
@@ -392,7 +392,7 @@ public class GitMaterialTest {
 
     @Test
     void shouldGetLatestModificationsFromRepoWithSubmodules() throws Exception {
-        GitSubmoduleRepos submoduleRepos = new GitSubmoduleRepos(temporaryFolder);
+        GitRepoContainingSubmodule submoduleRepos = new GitRepoContainingSubmodule(temporaryFolder);
         submoduleRepos.addSubmodule(SUBMODULE, "sub1");
         GitMaterial gitMaterial = new GitMaterial(submoduleRepos.mainRepo().getUrl());
 
@@ -403,12 +403,12 @@ public class GitMaterialTest {
         MaterialRevisions materialRevisions = materials.latestModification(workingDirectory, new TestSubprocessExecutionContext());
         assertThat(materialRevisions.numberOfRevisions()).isEqualTo(1);
         MaterialRevision materialRevision = materialRevisions.getMaterialRevision(0);
-        assertThat(materialRevision.getRevision().getRevision()).isEqualTo(submoduleRepos.currentRevision(GitSubmoduleRepos.NAME));
+        assertThat(materialRevision.getRevision().getRevision()).isEqualTo(submoduleRepos.currentRevision(GitRepoContainingSubmodule.NAME));
     }
 
     @Test
     void shouldUpdateSubmodules() throws Exception {
-        GitSubmoduleRepos submoduleRepos = new GitSubmoduleRepos(temporaryFolder);
+        GitRepoContainingSubmodule submoduleRepos = new GitRepoContainingSubmodule(temporaryFolder);
         submoduleRepos.addSubmodule(SUBMODULE, "sub1");
         GitMaterial gitMaterial = new GitMaterial(submoduleRepos.mainRepo().getUrl());
 
@@ -422,7 +422,7 @@ public class GitMaterialTest {
         MaterialRevision materialRevision = materialRevisions.getMaterialRevision(0);
         materialRevision.updateTo(agentWorkingDir, inMemoryConsumer(), new TestSubprocessExecutionContext());
 
-        File localFile = submoduleRepos.files(GitSubmoduleRepos.NAME).get(0);
+        File localFile = submoduleRepos.files(GitRepoContainingSubmodule.NAME).get(0);
         assertThat(new File(agentWorkingDir, localFile.getName())).exists();
 
         File file = submoduleRepos.files(SUBMODULE).get(0);
@@ -432,7 +432,7 @@ public class GitMaterialTest {
 
     @Test
     void shouldHaveModificationsWhenSubmoduleIsAdded() throws Exception {
-        GitSubmoduleRepos submoduleRepos = new GitSubmoduleRepos(temporaryFolder);
+        GitRepoContainingSubmodule submoduleRepos = new GitRepoContainingSubmodule(temporaryFolder);
         submoduleRepos.addSubmodule(SUBMODULE, "sub1");
         GitMaterial gitMaterial = new GitMaterial(submoduleRepos.mainRepo().getUrl());
 
@@ -450,7 +450,7 @@ public class GitMaterialTest {
 
     @Test
     void shouldHaveModificationsWhenSubmoduleIsRemoved() throws Exception {
-        GitSubmoduleRepos submoduleRepos = new GitSubmoduleRepos(temporaryFolder);
+        GitRepoContainingSubmodule submoduleRepos = new GitRepoContainingSubmodule(temporaryFolder);
         submoduleRepos.addSubmodule(SUBMODULE, "sub1");
         GitMaterial gitMaterial = new GitMaterial(submoduleRepos.mainRepo().getUrl());
 
@@ -480,7 +480,7 @@ public class GitMaterialTest {
      * A git abbreviated hash is 7 chars. See the git documentation.
      */
     @Test
-    void shouldtruncateHashTo7charsforAShortRevision() throws Exception {
+    void shouldTruncateHashTo7CharsForAShortRevision() throws Exception {
         Material git = new GitMaterial("file:///foo");
         assertThat(git.getShortRevision("dc3d7e656831d1b203d8b7a63c4de82e26604e52")).isEqualTo("dc3d7e6");
         assertThat(git.getShortRevision("24")).isEqualTo("24");

--- a/server/src/test-fast/java/com/thoughtworks/go/server/service/MaterialExpansionServiceTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/service/MaterialExpansionServiceTest.java
@@ -155,7 +155,7 @@ public class MaterialExpansionServiceTest {
 
     @Test
     public void shouldNotExpandGitSubmodulesIntoMultipleMaterialsWhenExpandingGitMaterialForScheduling() throws Exception {
-        GitSubmoduleRepos submoduleRepos = new GitSubmoduleRepos(temporaryFolder);
+        GitRepoContainingSubmodule submoduleRepos = new GitRepoContainingSubmodule(temporaryFolder);
         submoduleRepos.addSubmodule("submodule-1", "sub1");
         GitMaterial gitMaterial = new GitMaterial(submoduleRepos.mainRepo().getUrl());
         when(materialConfigConverter.toMaterials(new MaterialConfigs(gitMaterial.config()))).thenReturn(new Materials(gitMaterial));

--- a/server/src/test-integration/java/com/thoughtworks/go/server/materials/MaterialDatabaseGitWithSubmodulesUpdaterTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/materials/MaterialDatabaseGitWithSubmodulesUpdaterTest.java
@@ -19,7 +19,7 @@ package com.thoughtworks.go.server.materials;
 import com.thoughtworks.go.config.materials.git.GitMaterial;
 import com.thoughtworks.go.domain.MaterialRevisions;
 import com.thoughtworks.go.domain.materials.Material;
-import com.thoughtworks.go.helper.GitSubmoduleRepos;
+import com.thoughtworks.go.helper.GitRepoContainingSubmodule;
 import com.thoughtworks.go.helper.TestRepo;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
@@ -32,7 +32,7 @@ public class MaterialDatabaseGitWithSubmodulesUpdaterTest extends TestBaseForDat
     }
 
     protected TestRepo repo() throws Exception {
-        GitSubmoduleRepos testRepoWithExternal = new GitSubmoduleRepos(temporaryFolder);
+        GitRepoContainingSubmodule testRepoWithExternal = new GitRepoContainingSubmodule(temporaryFolder);
         testRepoWithExternal.addSubmodule("submodule-1", "sub1");
         return testRepoWithExternal;
     }


### PR DESCRIPTION
Issues: #5856 and #2123

The test for this is kinda hacky and checks only whether the required arguments are present or absent depending on the git version. If there's anything better that can be done, let me know.

I see that sometimes we want to "unshallow" a working copy. Not sure of this scenario (perhaps during a force-push?). Is there any similar scenario where an unshallow may be required for a submodule?