### PR TITLE
Adding --no-decorate flag to git-log

### DIFF
--- a/domain/src/main/java/com/thoughtworks/go/domain/materials/git/GitCommand.java
+++ b/domain/src/main/java/com/thoughtworks/go/domain/materials/git/GitCommand.java
@@ -98,12 +98,12 @@ public class GitCommand extends SCMCommand {
     }
 
     public List<Modification> latestModification() {
-        return gitLog("-1", "--date=iso", "--pretty=medium", "--no-color", remoteBranch());
+        return gitLog("-1", "--date=iso", "--no-decorate", "--pretty=medium", "--no-color", remoteBranch());
 
     }
 
     public List<Modification> modificationsSince(Revision revision) {
-        return gitLog("--date=iso", "--pretty=medium", "--no-color", String.format("%s..%s", revision.getRevision(), remoteBranch()));
+        return gitLog("--date=iso", "--pretty=medium", "--no-decorate", "--no-color", String.format("%s..%s", revision.getRevision(), remoteBranch()));
     }
 
     private List<Modification> gitLog(String... args) {


### PR DESCRIPTION
* Fixes the issue raised in #326
* work is part of #5856

The decorations git-log adds throws off the `GitModificationParser`. This PR adds `--no-decorate` to the git-log command which removes the decorations ensuring we are able to parse the modifications properly.

Steps to reproduce the bug:
1. add the following to your `.gitconfig`
```
[log]
  decorate = true
```
2. Push a commit to a test repo
3. Attempt to run a pipeline with the test repo as a material

Result:
The modification check will fail, and the following will be in the logs:
```
2019-02-18 12:08:42,448 WARN  [130@MessageListener for MaterialUpdateListener] MaterialDatabaseUpdater:112 - [Material Update] Modification check failed for material: URL: git@github.com:ibnc/gogogadgetcd.git, Branch: master
java.util.NoSuchElementException: null
        at java.base/java.util.LinkedList.getLast(LinkedList.java:261)
        at com.thoughtworks.go.domain.materials.git.GitModificationParser.processLine(GitModificationParser.java:59)
        at com.thoughtworks.go.domain.materials.git.GitModificationParser.parse(GitModificationParser.java:43)
        at com.thoughtworks.go.domain.materials.git.GitCommand.gitLog(GitCommand.java:120)
        at com.thoughtworks.go.domain.materials.git.GitCommand.modificationsSince(GitCommand.java:101)
        at com.thoughtworks.go.config.materials.git.GitMaterial.modificationsSince(GitMaterial.java:126)
        at com.thoughtworks.go.server.service.materials.GitPoller.modificationsSince(GitPoller.java:37)
        at com.thoughtworks.go.server.service.materials.GitPoller.modificationsSince(GitPoller.java:28)
        at com.thoughtworks.go.server.service.MaterialService.modificationsSince(MaterialService.java:122)
        at com.thoughtworks.go.server.materials.ScmMaterialUpdater.insertLatestOrNewModifications(ScmMaterialUpdater.java:56)
        at com.thoughtworks.go.server.materials.MaterialDatabaseUpdater.insertLatestOrNewModifications(MaterialDatabaseUpdater.java:142)
        at com.thoughtworks.go.server.materials.MaterialDatabaseUpdater.updateMaterialWithNewRevisions(MaterialDatabaseUpdater.java:134)
        at com.thoughtworks.go.server.materials.MaterialDatabaseUpdater$2.doInTransaction(MaterialDatabaseUpdater.java:101)
        at com.thoughtworks.go.server.transaction.TransactionCallback.doWithExceptionHandling(TransactionCallback.java:24)
        at com.thoughtworks.go.server.transaction.TransactionTemplate.lambda$executeWithExceptionHandling$2(TransactionTemplate.java:44)
        at org.springframework.transaction.support.TransactionTemplate.execute(TransactionTemplate.java:133)
        at com.thoughtworks.go.server.transaction.TransactionTemplate.executeWithExceptionHandling(TransactionTemplate.java:41)
        at com.thoughtworks.go.server.materials.MaterialDatabaseUpdater.updateMaterial(MaterialDatabaseUpdater.java:98)
        at com.thoughtworks.go.server.materials.MaterialUpdateListener.onMessage(MaterialUpdateListener.java:64)
        at com.thoughtworks.go.server.materials.MaterialUpdateListener.onMessage(MaterialUpdateListener.java:33)
        at com.thoughtworks.go.server.messaging.activemq.JMSMessageListenerAdapter.runImpl(JMSMessageListenerAdapter.java:86)
        at com.thoughtworks.go.server.messaging.activemq.JMSMessageListenerAdapter.run(JMSMessageListenerAdapter.java:66)
        at java.base/java.lang.Thread.run(Thread.java:834)
```