### PR TITLE
Error message should not remove id suffix from attribute name.

### DIFF
--- a/server/webapp/WEB-INF/rails/webpack/models/access_tokens/spec/access_token_crud_spec.ts
+++ b/server/webapp/WEB-INF/rails/webpack/models/access_tokens/spec/access_token_crud_spec.ts
@@ -23,10 +23,10 @@ describe("AccessTokenCRUD", () => {
   beforeEach(() => jasmine.Ajax.install());
   afterEach(() => jasmine.Ajax.uninstall());
   const BASE_PATH             = "/go/api/current_user/access_tokens";
-  const ALL_ACESS_TOKENS_PATH = `${BASE_PATH}?filter=all`;
+  const ALL_ACCESS_TOKENS_PATH = `${BASE_PATH}?filter=all`;
 
   it("should get all access tokens", (done) => {
-    jasmine.Ajax.stubRequest(ALL_ACESS_TOKENS_PATH).andReturn(accessTokensResponse());
+    jasmine.Ajax.stubRequest(ALL_ACCESS_TOKENS_PATH).andReturn(accessTokensResponse());
 
     const onResponse = jasmine.createSpy().and.callFake((response: ApiResult<any>) => {
       const responseJSON = response.unwrap() as SuccessResponse<any>;
@@ -37,7 +37,7 @@ describe("AccessTokenCRUD", () => {
     AccessTokenCRUD.all().then(onResponse);
 
     const request = jasmine.Ajax.requests.mostRecent();
-    expect(request.url).toEqual(ALL_ACESS_TOKENS_PATH);
+    expect(request.url).toEqual(ALL_ACCESS_TOKENS_PATH);
     expect(request.method).toEqual("GET");
     expect(request.requestHeaders.Accept).toEqual("application/vnd.go.cd.v1+json");
   });

--- a/server/webapp/WEB-INF/rails/webpack/models/mixins/new_validatable_mixin.ts
+++ b/server/webapp/WEB-INF/rails/webpack/models/mixins/new_validatable_mixin.ts
@@ -73,7 +73,7 @@ class MaxLengthValidator extends Validator {
     }
 
     if (entity[attr]().length > this.maxLength) {
-      entity.errors().add(attr, this.options.message || ErrorMessages.mustNotExceedMaxLenth(attr, this.maxLength));
+      entity.errors().add(attr, this.options.message || ErrorMessages.mustNotExceedMaxLength(attr, this.maxLength));
     }
   }
 }

--- a/server/webapp/WEB-INF/rails/webpack/models/mixins/new_validatable_mixin_spec.ts
+++ b/server/webapp/WEB-INF/rails/webpack/models/mixins/new_validatable_mixin_spec.ts
@@ -19,6 +19,7 @@ import * as stream from "mithril/stream";
 import {Stream} from "mithril/stream";
 import {applyMixins} from "models/mixins/mixins";
 import {ValidatableMixin, Validator, ValidatorOptions} from "models/mixins/new_validatable_mixin";
+import {ErrorMessages} from "models/mixins/validatable";
 import * as s from "underscore.string";
 
 describe("Validatable", () => {
@@ -587,5 +588,56 @@ describe("Validatable", () => {
       expect(var1.errors().hasErrors()).toBe(false);
     });
 
+  });
+
+  describe("Error Message", function () {
+    it("duplicate", () => {
+      expect(ErrorMessages.duplicate("id")).toEqual("Id is a duplicate");
+      expect(ErrorMessages.duplicate("PluginId")).toEqual("Plugin id is a duplicate");
+      expect(ErrorMessages.duplicate("pluginId")).toEqual("Plugin id is a duplicate");
+      expect(ErrorMessages.duplicate("plugin_id")).toEqual("Plugin id is a duplicate");
+      expect(ErrorMessages.duplicate("plugin id")).toEqual("Plugin id is a duplicate");
+    });
+
+    it("mustBePresent", () => {
+      expect(ErrorMessages.mustBePresent("id")).toEqual("Id must be present");
+      expect(ErrorMessages.mustBePresent("PluginId")).toEqual("Plugin id must be present");
+      expect(ErrorMessages.mustBePresent("pluginId")).toEqual("Plugin id must be present");
+      expect(ErrorMessages.mustBePresent("plugin_id")).toEqual("Plugin id must be present");
+      expect(ErrorMessages.mustBePresent("plugin id")).toEqual("Plugin id must be present");
+    });
+
+    it("mustBeAUrl", () => {
+      expect(ErrorMessages.mustBeAUrl("url")).toEqual("Url must be a valid http(s) url");
+      expect(ErrorMessages.mustBeAUrl("SomeUrl")).toEqual("Some url must be a valid http(s) url");
+      expect(ErrorMessages.mustBeAUrl("someUrl")).toEqual("Some url must be a valid http(s) url");
+      expect(ErrorMessages.mustBeAUrl("some_url")).toEqual("Some url must be a valid http(s) url");
+      expect(ErrorMessages.mustBeAUrl("some url")).toEqual("Some url must be a valid http(s) url");
+    });
+
+    it("mustBePositiveNumber", () => {
+      expect(ErrorMessages.mustBePositiveNumber("counter")).toEqual("Counter must be a positive integer");
+      expect(ErrorMessages.mustBePositiveNumber("StageCounter")).toEqual("Stage counter must be a positive integer");
+      expect(ErrorMessages.mustBePositiveNumber("stageCounter")).toEqual("Stage counter must be a positive integer");
+      expect(ErrorMessages.mustBePositiveNumber("stage_counter")).toEqual("Stage counter must be a positive integer");
+      expect(ErrorMessages.mustBePositiveNumber("stage counter")).toEqual("Stage counter must be a positive integer");
+    });
+
+
+    it("mustContainString", () => {
+      expect(ErrorMessages.mustContainString("id", "foo")).toEqual("Id must contain the string 'foo'");
+      expect(ErrorMessages.mustContainString("PluginId", "foo")).toEqual("Plugin id must contain the string 'foo'");
+      expect(ErrorMessages.mustContainString("pluginId", "foo")).toEqual("Plugin id must contain the string 'foo'");
+      expect(ErrorMessages.mustContainString("plugin_id", "foo")).toEqual("Plugin id must contain the string 'foo'");
+      expect(ErrorMessages.mustContainString("plugin id", "foo")).toEqual("Plugin id must contain the string 'foo'");
+    });
+
+    it("mustNotExceedMaxLength", () => {
+      expect(ErrorMessages.mustNotExceedMaxLength("id", 255)).toEqual("Id must not exceed length 255");
+      expect(ErrorMessages.mustNotExceedMaxLength("PluginId", 255)).toEqual("Plugin id must not exceed length 255");
+      expect(ErrorMessages.mustNotExceedMaxLength("pluginId", 255)).toEqual("Plugin id must not exceed length 255");
+      expect(ErrorMessages.mustNotExceedMaxLength("plugin_id", 255)).toEqual("Plugin id must not exceed length 255");
+      expect(ErrorMessages.mustNotExceedMaxLength("plugin id", 255)).toEqual("Plugin id must not exceed length 255");
+    });
   });
 });

--- a/server/webapp/WEB-INF/rails/webpack/models/mixins/validatable.ts
+++ b/server/webapp/WEB-INF/rails/webpack/models/mixins/validatable.ts
@@ -18,27 +18,31 @@ import * as s from "underscore.string";
 
 export namespace ErrorMessages {
   export function duplicate(attribute: string) {
-    return `${s.humanize(attribute)} is a duplicate`;
+    return `${humanize(attribute)} is a duplicate`;
   }
 
   export function mustBePresent(attribute: string) {
-    return `${s.humanize(attribute).replace(/\bxpath\b/i, "XPath").replace(/\burl\b/i, "URL")} must be present`;
+    return `${humanize(attribute).replace(/\bxpath\b/i, "XPath").replace(/\burl\b/i, "URL")} must be present`;
   }
 
   export function mustBeAUrl(attribute: string) {
-    return `${s.humanize(attribute)} must be a valid http(s) url`;
+    return `${humanize(attribute)} must be a valid http(s) url`;
   }
 
   export function mustBePositiveNumber(attribute: string) {
-    return `${s.humanize(attribute)} must be a positive integer`;
+    return `${humanize(attribute)} must be a positive integer`;
   }
 
   export function mustContainString(attribute: string, requiredString: string) {
-    return `${s.humanize(attribute)} must contain the string '${requiredString}'`;
+    return `${humanize(attribute)} must contain the string '${requiredString}'`;
   }
 
-  export function mustNotExceedMaxLenth(attribute: string, maxLength: number) {
-    return `${s.humanize(attribute)} must not exceed length ${maxLength}`;
+  export function mustNotExceedMaxLength(attribute: string, maxLength: number) {
+    return `${humanize(attribute)} must not exceed length ${maxLength}`;
+  }
+
+  function humanize(str: string) {
+    return s.capitalize(s.trim(s.underscored(str).replace(/_/g, " ")));
   }
 }
 


### PR DESCRIPTION
- `underscore.string` removes `id` suffix as part of `humanize(str)`.