### PR TITLE
Ui improvements for access token spa

### DIFF
--- a/server/webapp/WEB-INF/rails/webpack/views/components/ellipsize/index.scss
+++ b/server/webapp/WEB-INF/rails/webpack/views/components/ellipsize/index.scss
@@ -16,9 +16,10 @@
 
 $button_color: #2d6ca2;
 .wrapper {
-  display:   inline-block;
-  max-width: 300px;
-  min-width: 250px;
+  display:    inline-block;
+  max-width:  300px;
+  min-width:  250px;
+  word-break: break-all;
 }
 
 .ellipsis-action-button {

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/access_tokens/index.scss
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/access_tokens/index.scss
@@ -103,3 +103,7 @@ $revoked_text_color: #e94c35;
   }
 }
 
+.spinner-container {
+  height: 200px;
+}
+

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/access_tokens/index.scss.d.ts
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/access_tokens/index.scss.d.ts
@@ -7,3 +7,4 @@ export const personalAccessTokenContainer: string;
 export const activeTokensTable: string;
 export const revokedTokensTable: string;
 export const adminAccessTokenContainer: string;
+export const spinnerContainer: string;

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/access_tokens/modals.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/access_tokens/modals.tsx
@@ -24,7 +24,10 @@ import {AdminAccessTokenCRUD} from "models/admin_access_tokens/admin_access_toke
 import * as Buttons from "views/components/buttons";
 import {FlashMessage, MessageType} from "views/components/flash_message";
 import {CopyField, Size, TextAreaField} from "views/components/forms/input_fields";
+import {Spinner} from "views/components/spinner";
 import {BaseModal, RevokeTokenModal} from "views/pages/access_tokens/commons/modals";
+import * as styles from "views/pages/access_tokens/index.scss";
+import {PageState} from "views/pages/page";
 
 export class GenerateTokenModal extends BaseModal {
   constructor(accessTokens: Stream<AccessTokens>,
@@ -39,6 +42,12 @@ export class GenerateTokenModal extends BaseModal {
   }
 
   body(): m.Children {
+    if (this.operationState() === PageState.LOADING) {
+      return <div className={styles.spinnerContainer}>
+        <Spinner/>
+      </div>;
+    }
+
     if (this.hasToken()) {
       return (<div>
         <FlashMessage type={MessageType.info}


### PR DESCRIPTION
- Show spinner when token creation on revoke is in progress.

![spinner](https://user-images.githubusercontent.com/7871209/54916398-79598080-4f1f-11e9-80e3-8b4737f33d2a.gif)

- Break a long word (Issue: #5949)
