### PR TITLE
Go back to the old way of resetWorkingDir

### DIFF
--- a/common/src/test/java/com/thoughtworks/go/config/materials/git/GitMaterialUpdaterTest.java
+++ b/common/src/test/java/com/thoughtworks/go/config/materials/git/GitMaterialUpdaterTest.java
@@ -236,7 +236,7 @@ class GitMaterialUpdaterTest extends BuildSessionBasedTestCase {
     }
 
     @Test
-    void shouldAllowSubmoduleUrlstoChange() throws Exception {
+    void shouldAllowSubmoduleUrlsToChange() throws Exception {
         GitSubmoduleRepos submoduleRepos = new GitSubmoduleRepos(temporaryFolder);
         String submoduleDirectoryName = "local-submodule";
         submoduleRepos.addSubmodule(SUBMODULE, submoduleDirectoryName);


### PR DESCRIPTION
This is because the `--all` flag was introduced much later with submodule deinit. https://github.com/git/git/commit/f6a527997743b79d6986a16313a7488cfc53d123

Related to #5856