### PR TITLE
Use --recurse-submodules=no when doing a git fetch

### DIFF
--- a/domain/src/main/java/com/thoughtworks/go/domain/materials/git/GitCommand.java
+++ b/domain/src/main/java/com/thoughtworks/go/domain/materials/git/GitCommand.java
@@ -331,7 +331,7 @@ public class GitCommand extends SCMCommand {
 
     public void fetch(ConsoleOutputStreamConsumer outputStreamConsumer) {
         outputStreamConsumer.stdOutput("[GIT] Fetching changes");
-        CommandLine gitFetch = git(environment).withArgs("fetch", "origin", "--prune").withWorkingDir(workingDir);
+        CommandLine gitFetch = git(environment).withArgs("fetch", "origin", "--prune", "--recurse-submodules=no").withWorkingDir(workingDir);
 
         int result = run(gitFetch, outputStreamConsumer);
         if (result != 0) {

--- a/domain/src/main/java/com/thoughtworks/go/domain/materials/git/GitMaterialUpdater.java
+++ b/domain/src/main/java/com/thoughtworks/go/domain/materials/git/GitMaterialUpdater.java
@@ -52,7 +52,7 @@ public class GitMaterialUpdater {
     private BuildCommand fetchRemote(String workingDir) {
         return compose(
                 echo("[GIT] Fetching changes"),
-                exec("git", "fetch", "origin", "--prune").setWorkingDirectory(workingDir),
+                exec("git", "fetch", "origin", "--prune", "--recurse-submodules=no").setWorkingDirectory(workingDir),
                 exec("git", "gc", "--auto").setWorkingDirectory(workingDir));
     }
 


### PR DESCRIPTION
This is needed for git 2.21.0

We init and update the submodules subsequently anyway, so fetching can be skipped here. (I hope).