### PR TITLE
Pass secret config to lookupSecrets request

### DIFF
--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/secrets/v1/SecretsExtensionV1.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/secrets/v1/SecretsExtensionV1.java
@@ -100,7 +100,7 @@ public class SecretsExtensionV1 implements VersionedSecretsExtension {
                 new DefaultPluginInteractionCallback<List<Secret>>() {
                     @Override
                     public String requestBody(String resolvedExtensionVersion) {
-                        return secretsMessageConverterV1.lookupSecretsRequestBody(keys, secretConfig.getConfigurationAsMap(true));
+                        return secretsMessageConverterV1.lookupSecretsRequestBody(keys, secretConfig.getConfiguration().getConfigurationAsMap(true));
                     }
 
                     @Override

--- a/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/secrets/v1/SecretsExtensionV1Test.java
+++ b/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/secrets/v1/SecretsExtensionV1Test.java
@@ -131,8 +131,8 @@ public class SecretsExtensionV1Test {
         when(pluginManager.submitTo(eq(PLUGIN_ID), eq(SECRETS_EXTENSION), requestArgumentCaptor.capture())).thenReturn(DefaultGoPluginApiResponse.success(responseBody));
 
         final SecretConfig secretConfig = new SecretConfig();
-        secretConfig.add(ConfigurationPropertyMother.create("AWS_ACCESS_KEY", false, "some-access-key"));
-        secretConfig.add(ConfigurationPropertyMother.create("AWS_SECRET_KEY", true, "some-secret-value"));
+        secretConfig.getConfiguration().add(ConfigurationPropertyMother.create("AWS_ACCESS_KEY", false, "some-access-key"));
+        secretConfig.getConfiguration().add(ConfigurationPropertyMother.create("AWS_SECRET_KEY", true, "some-secret-value"));
 
         List<Secret> secrets = secretsExtensionV1.lookupSecrets(PLUGIN_ID, secretConfig, new HashSet<>(asList("key1", "key2")));
 


### PR DESCRIPTION
Part of EPIC: https://github.com/gocd/gocd/issues/5830
Related to issue:  https://github.com/gocd/gocd/issues/5832

Here we are passing secret configuration to lookupSecrets request, although SecretConfig is itself a collection of properties, the actual properties are stored inside `configuration` field of the `SecretConfig` object. 

```
<secretConfigs>
  <secretConfig id="secrets_file" pluginId="cd.go.secrets.file-based-plugin">
      <description>All secrets from local environment</description>
      <configuration>
          <property>
              <key>SecretsFilePath</key>
              <value>/foo/bar/secrets.json</value>
          </property>
      </configuration>
  </secretConfig>
</secretConfigs>
```