### PR TITLE
Ensuring H2 database tests are run only H2 is the database provider #000

### DIFF
--- a/server/src/test-fast/java/com/thoughtworks/go/server/database/H2DatabaseTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/database/H2DatabaseTest.java
@@ -38,6 +38,7 @@ import static org.junit.Assert.assertThat;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
 
+@EnableIfH2
 class H2DatabaseTest {
     private H2Database h2Database;
     private DatabaseFixture dbFixture;


### PR DESCRIPTION
* This is required to ensure H2 tests are ignored as part of enterprise
  build. This was missed while migrating the tests from junit 4 to 5.