### PR TITLE
Modify elastic agent extension v5 capabilites (#5937)

### DIFF
--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/elastic/v5/CapabilitiesConverterV5.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/elastic/v5/CapabilitiesConverterV5.java
@@ -22,7 +22,7 @@ import com.thoughtworks.go.plugin.domain.elastic.Capabilities;
 class CapabilitiesConverterV5 implements DataConverter<Capabilities, CapabilitiesDTO> {
     @Override
     public Capabilities fromDTO(CapabilitiesDTO capabilitiesDTO) {
-        return new Capabilities(capabilitiesDTO.supportsStatusReport(), capabilitiesDTO.supportsAgentStatusReport());
+        return new Capabilities(capabilitiesDTO.supportsPluginStatusReport(), capabilitiesDTO.supportsClusterStatusReport(), capabilitiesDTO.supportsAgentStatusReport());
     }
 
     @Override

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/elastic/v5/CapabilitiesDTO.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/elastic/v5/CapabilitiesDTO.java
@@ -21,18 +21,28 @@ import com.google.gson.GsonBuilder;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 
+import java.util.Objects;
+
 class CapabilitiesDTO {
     private static final Gson GSON = new GsonBuilder().excludeFieldsWithoutExposeAnnotation().create();
     @Expose
-    @SerializedName("supports_status_report")
+    @SerializedName("supports_plugin_status_report")
     private boolean supportsStatusReport;
+
+    @Expose
+    @SerializedName("supports_cluster_status_report")
+    private boolean supportsClusterStatusReport;
 
     @Expose
     @SerializedName("supports_agent_status_report")
     private boolean supportsAgentStatusReport;
 
-    public boolean supportsStatusReport() {
+    public boolean supportsPluginStatusReport() {
         return supportsStatusReport;
+    }
+
+    public boolean supportsClusterStatusReport() {
+        return supportsClusterStatusReport;
     }
 
     public boolean supportsAgentStatusReport() {
@@ -42,18 +52,15 @@ class CapabilitiesDTO {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof CapabilitiesDTO)) return false;
-
+        if (o == null || getClass() != o.getClass()) return false;
         CapabilitiesDTO that = (CapabilitiesDTO) o;
-
-        if (supportsStatusReport != that.supportsStatusReport) return false;
-        return supportsAgentStatusReport == that.supportsAgentStatusReport;
+        return supportsStatusReport == that.supportsStatusReport &&
+                supportsClusterStatusReport == that.supportsClusterStatusReport &&
+                supportsAgentStatusReport == that.supportsAgentStatusReport;
     }
 
     @Override
     public int hashCode() {
-        int result = (supportsStatusReport ? 1 : 0);
-        result = 31 * result + (supportsAgentStatusReport ? 1 : 0);
-        return result;
+        return Objects.hash(supportsStatusReport, supportsClusterStatusReport, supportsAgentStatusReport);
     }
 }

--- a/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/elastic/ElasticAgentExtensionV4Test.java
+++ b/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/elastic/ElasticAgentExtensionV4Test.java
@@ -46,8 +46,7 @@ import static com.thoughtworks.go.plugin.access.elastic.v4.ElasticAgentPluginCon
 import static com.thoughtworks.go.plugin.domain.common.PluginConstants.ELASTIC_AGENT_EXTENSION;
 import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
@@ -97,7 +96,8 @@ public class ElasticAgentExtensionV4Test {
 
         final Capabilities capabilities = extensionV4.getCapabilities(PLUGIN_ID);
 
-        assertTrue(capabilities.supportsStatusReport());
+        assertTrue(capabilities.supportsPluginStatusReport());
+        assertFalse(capabilities.supportsClusterStatusReport());
         assertTrue(capabilities.supportsAgentStatusReport());
     }
 

--- a/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/elastic/ElasticAgentExtensionV5Test.java
+++ b/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/elastic/ElasticAgentExtensionV5Test.java
@@ -95,12 +95,17 @@ public class ElasticAgentExtensionV5Test {
 
     @Test
     public void shouldGetCapabilitiesOfAPlugin() {
-        final String responseBody = "{\"supports_status_report\":\"true\", \"supports_agent_status_report\":\"true\"}";
+        final String responseBody = "{" +
+                "    \"supports_plugin_status_report\":\"true\", " +
+                "    \"supports_cluster_status_report\":\"true\", " +
+                "    \"supports_agent_status_report\":\"true\"" +
+                "}";
         when(pluginManager.submitTo(eq(PLUGIN_ID), eq(ELASTIC_AGENT_EXTENSION), requestArgumentCaptor.capture())).thenReturn(DefaultGoPluginApiResponse.success(responseBody));
 
         final Capabilities capabilities = extensionV5.getCapabilities(PLUGIN_ID);
 
-        assertTrue(capabilities.supportsStatusReport());
+        assertTrue(capabilities.supportsPluginStatusReport());
+        assertTrue(capabilities.supportsClusterStatusReport());
         assertTrue(capabilities.supportsAgentStatusReport());
     }
 

--- a/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/elastic/v4/CapabilitiesConverterV4Test.java
+++ b/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/elastic/v4/CapabilitiesConverterV4Test.java
@@ -44,22 +44,22 @@ public class CapabilitiesConverterV4Test {
     public void fromDTO_shouldConvertToCapabilitiesFromCapabilitiesDTO() {
         when(capabilitiesDTO.supportsStatusReport()).thenReturn(false);
         when(capabilitiesDTO.supportsAgentStatusReport()).thenReturn(false);
-        assertFalse(capabilitiesConverter.fromDTO(capabilitiesDTO).supportsStatusReport());
+        assertFalse(capabilitiesConverter.fromDTO(capabilitiesDTO).supportsPluginStatusReport());
         assertFalse(capabilitiesConverter.fromDTO(capabilitiesDTO).supportsAgentStatusReport());
 
         when(capabilitiesDTO.supportsStatusReport()).thenReturn(true);
         when(capabilitiesDTO.supportsAgentStatusReport()).thenReturn(true);
-        assertTrue(capabilitiesConverter.fromDTO(capabilitiesDTO).supportsStatusReport());
+        assertTrue(capabilitiesConverter.fromDTO(capabilitiesDTO).supportsPluginStatusReport());
         assertTrue(capabilitiesConverter.fromDTO(capabilitiesDTO).supportsAgentStatusReport());
 
         when(capabilitiesDTO.supportsStatusReport()).thenReturn(false);
         when(capabilitiesDTO.supportsAgentStatusReport()).thenReturn(true);
-        assertFalse(capabilitiesConverter.fromDTO(capabilitiesDTO).supportsStatusReport());
+        assertFalse(capabilitiesConverter.fromDTO(capabilitiesDTO).supportsPluginStatusReport());
         assertTrue(capabilitiesConverter.fromDTO(capabilitiesDTO).supportsAgentStatusReport());
 
         when(capabilitiesDTO.supportsStatusReport()).thenReturn(true);
         when(capabilitiesDTO.supportsAgentStatusReport()).thenReturn(false);
-        assertTrue(capabilitiesConverter.fromDTO(capabilitiesDTO).supportsStatusReport());
+        assertTrue(capabilitiesConverter.fromDTO(capabilitiesDTO).supportsPluginStatusReport());
         assertFalse(capabilitiesConverter.fromDTO(capabilitiesDTO).supportsAgentStatusReport());
     }
 }

--- a/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/elastic/v4/ElasticAgentExtensionConverterV4Test.java
+++ b/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/elastic/v4/ElasticAgentExtensionConverterV4Test.java
@@ -204,7 +204,7 @@ public class ElasticAgentExtensionConverterV4Test {
 
         Capabilities capabilities = new ElasticAgentExtensionConverterV4().getCapabilitiesFromResponseBody(responseBody);
 
-        assertTrue(capabilities.supportsStatusReport());
+        assertTrue(capabilities.supportsPluginStatusReport());
         assertTrue(capabilities.supportsAgentStatusReport());
     }
 

--- a/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/elastic/v5/CapabilitiesConverterV5Test.java
+++ b/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/elastic/v5/CapabilitiesConverterV5Test.java
@@ -42,24 +42,24 @@ public class CapabilitiesConverterV5Test {
 
     @Test
     public void fromDTO_shouldConvertToCapabilitiesFromCapabilitiesDTO() {
-        when(capabilitiesDTO.supportsStatusReport()).thenReturn(false);
+        when(capabilitiesDTO.supportsPluginStatusReport()).thenReturn(false);
         when(capabilitiesDTO.supportsAgentStatusReport()).thenReturn(false);
-        assertFalse(capabilitiesConverter.fromDTO(capabilitiesDTO).supportsStatusReport());
+        assertFalse(capabilitiesConverter.fromDTO(capabilitiesDTO).supportsPluginStatusReport());
         assertFalse(capabilitiesConverter.fromDTO(capabilitiesDTO).supportsAgentStatusReport());
 
-        when(capabilitiesDTO.supportsStatusReport()).thenReturn(true);
+        when(capabilitiesDTO.supportsPluginStatusReport()).thenReturn(true);
         when(capabilitiesDTO.supportsAgentStatusReport()).thenReturn(true);
-        assertTrue(capabilitiesConverter.fromDTO(capabilitiesDTO).supportsStatusReport());
+        assertTrue(capabilitiesConverter.fromDTO(capabilitiesDTO).supportsPluginStatusReport());
         assertTrue(capabilitiesConverter.fromDTO(capabilitiesDTO).supportsAgentStatusReport());
 
-        when(capabilitiesDTO.supportsStatusReport()).thenReturn(false);
+        when(capabilitiesDTO.supportsPluginStatusReport()).thenReturn(false);
         when(capabilitiesDTO.supportsAgentStatusReport()).thenReturn(true);
-        assertFalse(capabilitiesConverter.fromDTO(capabilitiesDTO).supportsStatusReport());
+        assertFalse(capabilitiesConverter.fromDTO(capabilitiesDTO).supportsPluginStatusReport());
         assertTrue(capabilitiesConverter.fromDTO(capabilitiesDTO).supportsAgentStatusReport());
 
-        when(capabilitiesDTO.supportsStatusReport()).thenReturn(true);
+        when(capabilitiesDTO.supportsPluginStatusReport()).thenReturn(true);
         when(capabilitiesDTO.supportsAgentStatusReport()).thenReturn(false);
-        assertTrue(capabilitiesConverter.fromDTO(capabilitiesDTO).supportsStatusReport());
+        assertTrue(capabilitiesConverter.fromDTO(capabilitiesDTO).supportsPluginStatusReport());
         assertFalse(capabilitiesConverter.fromDTO(capabilitiesDTO).supportsAgentStatusReport());
     }
 }

--- a/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/elastic/v5/ElasticAgentExtensionConverterV5Test.java
+++ b/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/elastic/v5/ElasticAgentExtensionConverterV5Test.java
@@ -251,11 +251,16 @@ public class ElasticAgentExtensionConverterV5Test {
 
     @Test
     public void shouldGetCapabilitiesFromResponseBody() {
-        String responseBody = "{\"supports_status_report\":\"true\",\"supports_agent_status_report\":\"true\"}";
+        String responseBody = "{" +
+                "    \"supports_plugin_status_report\":\"true\"," +
+                "    \"supports_cluster_status_report\":\"true\"," +
+                "    \"supports_agent_status_report\":\"true\"" +
+                "}";
 
         Capabilities capabilities = new ElasticAgentExtensionConverterV5().getCapabilitiesFromResponseBody(responseBody);
 
-        assertTrue(capabilities.supportsStatusReport());
+        assertTrue(capabilities.supportsPluginStatusReport());
+        assertTrue(capabilities.supportsClusterStatusReport());
         assertTrue(capabilities.supportsAgentStatusReport());
     }
 

--- a/plugin-infra/go-plugin-domain/src/main/java/com/thoughtworks/go/plugin/domain/elastic/Capabilities.java
+++ b/plugin-infra/go-plugin-domain/src/main/java/com/thoughtworks/go/plugin/domain/elastic/Capabilities.java
@@ -17,20 +17,31 @@
 package com.thoughtworks.go.plugin.domain.elastic;
 
 public class Capabilities {
-    private boolean supportsStatusReport;
+    private boolean supportsPluginStatusReport;
+    private boolean supportsClusterStatusReport;
     private boolean supportsAgentStatusReport;
 
-    public Capabilities(boolean supportsStatusReport) {
-        this.supportsStatusReport = supportsStatusReport;
+    public Capabilities(boolean supportsPluginStatusReport) {
+        this.supportsPluginStatusReport = supportsPluginStatusReport;
     }
 
-    public Capabilities(boolean supportsStatusReport, boolean supportsAgentStatusReport) {
-        this.supportsStatusReport = supportsStatusReport;
+    public Capabilities(boolean supportsPluginStatusReport, boolean supportsAgentStatusReport) {
+        this.supportsPluginStatusReport = supportsPluginStatusReport;
         this.supportsAgentStatusReport = supportsAgentStatusReport;
     }
 
-    public boolean supportsStatusReport() {
-        return supportsStatusReport;
+    public Capabilities(boolean supportsPluginStatusReport, boolean supportsClusterStatusReport, boolean supportsAgentStatusReport) {
+        this.supportsPluginStatusReport = supportsPluginStatusReport;
+        this.supportsClusterStatusReport = supportsClusterStatusReport;
+        this.supportsAgentStatusReport = supportsAgentStatusReport;
+    }
+
+    public boolean supportsPluginStatusReport() {
+        return supportsPluginStatusReport;
+    }
+
+    public boolean supportsClusterStatusReport() {
+        return supportsClusterStatusReport;
     }
 
     public boolean supportsAgentStatusReport() {
@@ -44,12 +55,12 @@ public class Capabilities {
 
         Capabilities that = (Capabilities) o;
 
-        return supportsStatusReport == that.supportsStatusReport;
+        return supportsPluginStatusReport == that.supportsPluginStatusReport;
 
     }
 
     @Override
     public int hashCode() {
-        return (supportsStatusReport ? 1 : 0);
+        return (supportsPluginStatusReport ? 1 : 0);
     }
 }

--- a/plugin-infra/go-plugin-domain/src/main/java/com/thoughtworks/go/plugin/domain/elastic/ElasticAgentPluginInfo.java
+++ b/plugin-infra/go-plugin-domain/src/main/java/com/thoughtworks/go/plugin/domain/elastic/ElasticAgentPluginInfo.java
@@ -42,7 +42,7 @@ public class ElasticAgentPluginInfo extends PluginInfo {
     }
 
     public boolean supportsStatusReport() {
-        return this.capabilities != null ? this.capabilities.supportsStatusReport() : false;
+        return this.capabilities != null ? this.capabilities.supportsPluginStatusReport() : false;
     }
 
     @Override

--- a/server/src/main/java/com/thoughtworks/go/server/service/ElasticAgentPluginService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/ElasticAgentPluginService.java
@@ -200,7 +200,7 @@ public class ElasticAgentPluginService {
 
     public String getPluginStatusReport(String pluginId) {
         final ElasticAgentPluginInfo pluginInfo = elasticAgentMetadataStore.getPluginInfo(pluginId);
-        if (pluginInfo.getCapabilities().supportsStatusReport()) {
+        if (pluginInfo.getCapabilities().supportsPluginStatusReport()) {
             return elasticAgentPluginRegistry.getPluginStatusReport(pluginId);
         }
 

--- a/server/webapp/WEB-INF/rails/app/presenters/api_v4/plugin/elastic_plugin_capabilities_representer.rb
+++ b/server/webapp/WEB-INF/rails/app/presenters/api_v4/plugin/elastic_plugin_capabilities_representer.rb
@@ -18,7 +18,7 @@ module ApiV4
     class ElasticPluginCapabilitiesRepresenter < BaseRepresenter
       alias_method :capabilities, :represented
 
-      property :supports_status_report
+      property :supports_plugin_status_report, as: :supports_status_report
       property :supports_agent_status_report
 
     end


### PR DESCRIPTION
* Modify 'supports_status_report' to 'supports_plugin_status_report'.
* Introduce 'supports_cluster_status_report' in v5 extension.
* 'supports_agent_status_report' remains unchanged.

---

new capabilities json:
```
{
  "supports_plugin_status_report": true,
  "supports_cluster_status_report": true,
  "supports_agent_status_report": true
}
```
