### PR TITLE
[DNM] Introduce elastic agent extension v5 migrate-config call (#5937) (#5538)

### DIFF
--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/elastic/ElasticAgentExtension.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/elastic/ElasticAgentExtension.java
@@ -111,6 +111,10 @@ public class ElasticAgentExtension extends AbstractExtension {
         getVersionedElasticAgentExtension(pluginId).jobCompletion(pluginId, elasticAgentId, jobIdentifier, elasticProfileConfiguration, clusterProfileConfiguration);
     }
 
+    public boolean supportsClusterProfiles(String pluginId) {
+        return getVersionedElasticAgentExtension(pluginId).supportsClusterProfile();
+    }
+
     @Override
     public List<String> goSupportedVersions() {
         return SUPPORTED_VERSIONS;

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/elastic/ElasticAgentExtension.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/elastic/ElasticAgentExtension.java
@@ -22,6 +22,7 @@ import com.thoughtworks.go.plugin.access.PluginRequestHelper;
 import com.thoughtworks.go.plugin.access.common.AbstractExtension;
 import com.thoughtworks.go.plugin.access.common.settings.PluginSettingsJsonMessageHandler1_0;
 import com.thoughtworks.go.plugin.access.elastic.models.AgentMetadata;
+import com.thoughtworks.go.plugin.access.elastic.models.ElasticAgentInformation;
 import com.thoughtworks.go.plugin.access.elastic.v4.ElasticAgentExtensionV4;
 import com.thoughtworks.go.plugin.access.elastic.v5.ElasticAgentExtensionV5;
 import com.thoughtworks.go.plugin.api.response.validation.ValidationResult;
@@ -118,5 +119,9 @@ public class ElasticAgentExtension extends AbstractExtension {
     protected VersionedElasticAgentExtension getVersionedElasticAgentExtension(String pluginId) {
         final String resolvedExtensionVersion = pluginManager.resolveExtensionVersion(pluginId, ELASTIC_AGENT_EXTENSION, goSupportedVersions());
         return elasticAgentExtensionMap.get(resolvedExtensionVersion);
+    }
+
+    public ElasticAgentInformation migrateConfig(String pluginId, ElasticAgentInformation elasticAgentInformation) {
+        return getVersionedElasticAgentExtension(pluginId).migrateConfig(pluginId, elasticAgentInformation);
     }
 }

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/elastic/ElasticAgentPluginInfoBuilder.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/elastic/ElasticAgentPluginInfoBuilder.java
@@ -60,9 +60,13 @@ public class ElasticAgentPluginInfoBuilder implements PluginInfoBuilder<ElasticA
     }
 
     private PluggableInstanceSettings elasticClusterProfileSettings(String pluginId) {
-        List<PluginConfiguration> profileMetadata = extension.getClusterProfileMetadata(pluginId);
-        String profileView = extension.getClusterProfileView(pluginId);
-        return new PluggableInstanceSettings(profileMetadata, new PluginView(profileView));
+        if (extension.supportsClusterProfiles(pluginId)) {
+            List<PluginConfiguration> profileMetadata = extension.getClusterProfileMetadata(pluginId);
+            String profileView = extension.getClusterProfileView(pluginId);
+            return new PluggableInstanceSettings(profileMetadata, new PluginView(profileView));
+        }
+
+        return new PluggableInstanceSettings(null, null);
     }
 
     private Capabilities capabilities(String pluginId) {

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/elastic/VersionedElasticAgentExtension.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/elastic/VersionedElasticAgentExtension.java
@@ -18,6 +18,7 @@ package com.thoughtworks.go.plugin.access.elastic;
 
 import com.thoughtworks.go.domain.JobIdentifier;
 import com.thoughtworks.go.plugin.access.elastic.models.AgentMetadata;
+import com.thoughtworks.go.plugin.access.elastic.models.ElasticAgentInformation;
 import com.thoughtworks.go.plugin.api.response.validation.ValidationResult;
 import com.thoughtworks.go.plugin.domain.common.PluginConfiguration;
 import com.thoughtworks.go.plugin.domain.elastic.Capabilities;
@@ -53,4 +54,6 @@ public interface VersionedElasticAgentExtension {
     String getAgentStatusReport(String pluginId, JobIdentifier identifier, String elasticAgentId);
 
     void jobCompletion(String pluginId, String elasticAgentId, JobIdentifier jobIdentifier, Map<String, String> elasticProfileConfiguration, Map<String, String> clusterProfileConfiguration);
+
+    ElasticAgentInformation migrateConfig(String pluginId, ElasticAgentInformation elasticAgentInformation);
 }

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/elastic/VersionedElasticAgentExtension.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/elastic/VersionedElasticAgentExtension.java
@@ -35,6 +35,8 @@ public interface VersionedElasticAgentExtension {
 
     String getElasticProfileView(String pluginId);
 
+    boolean supportsClusterProfile();
+
     ValidationResult validateElasticProfile(String pluginId, Map<String, String> configuration);
 
     List<PluginConfiguration> getClusterProfileMetadata(String pluginId);

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/elastic/models/ElasticAgentInformation.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/elastic/models/ElasticAgentInformation.java
@@ -24,17 +24,17 @@ import java.util.Map;
 import java.util.Objects;
 
 public class ElasticAgentInformation {
-    private final Map<String, Map<String, Object>> pluginSettings;
+    private final Map<String, String> pluginSettings;
     private final List<ClusterProfile> clusterProfiles;
     private final List<ElasticProfile> elasticAgentProfiles;
 
-    public ElasticAgentInformation(Map<String, Map<String, Object>> pluginSettings, List<ClusterProfile> clusterProfiles, List<ElasticProfile> elasticAgentProfiles) {
+    public ElasticAgentInformation(Map<String, String> pluginSettings, List<ClusterProfile> clusterProfiles, List<ElasticProfile> elasticAgentProfiles) {
         this.pluginSettings = pluginSettings;
         this.clusterProfiles = clusterProfiles;
         this.elasticAgentProfiles = elasticAgentProfiles;
     }
 
-    public Map<String, Map<String, Object>> getPluginSettings() {
+    public Map<String, String> getPluginSettings() {
         return pluginSettings;
     }
 

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/elastic/models/ElasticAgentInformation.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/elastic/models/ElasticAgentInformation.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.plugin.access.elastic.models;
+
+import com.thoughtworks.go.config.elastic.ClusterProfile;
+import com.thoughtworks.go.config.elastic.ElasticProfile;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+public class ElasticAgentInformation {
+    private final Map<String, Map<String, Object>> pluginSettings;
+    private final List<ClusterProfile> clusterProfiles;
+    private final List<ElasticProfile> elasticAgentProfiles;
+
+    public ElasticAgentInformation(Map<String, Map<String, Object>> pluginSettings, List<ClusterProfile> clusterProfiles, List<ElasticProfile> elasticAgentProfiles) {
+        this.pluginSettings = pluginSettings;
+        this.clusterProfiles = clusterProfiles;
+        this.elasticAgentProfiles = elasticAgentProfiles;
+    }
+
+    public Map<String, Map<String, Object>> getPluginSettings() {
+        return pluginSettings;
+    }
+
+    public List<ClusterProfile> getClusterProfiles() {
+        return clusterProfiles;
+    }
+
+    public List<ElasticProfile> getElasticAgentProfiles() {
+        return elasticAgentProfiles;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ElasticAgentInformation that = (ElasticAgentInformation) o;
+        return Objects.equals(pluginSettings, that.pluginSettings) &&
+                Objects.equals(clusterProfiles, that.clusterProfiles) &&
+                Objects.equals(elasticAgentProfiles, that.elasticAgentProfiles);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(pluginSettings, clusterProfiles, elasticAgentProfiles);
+    }
+
+    @Override
+    public String toString() {
+        return "ElasticAgentInformation{" +
+                "pluginSettings=" + pluginSettings +
+                ", clusterProfiles=" + clusterProfiles +
+                ", elasticAgentProfiles=" + elasticAgentProfiles +
+                '}';
+    }
+}

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/elastic/v4/ElasticAgentExtensionV4.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/elastic/v4/ElasticAgentExtensionV4.java
@@ -85,6 +85,11 @@ public class ElasticAgentExtensionV4 implements VersionedElasticAgentExtension {
     }
 
     @Override
+    public boolean supportsClusterProfile() {
+        return false;
+    }
+
+    @Override
     public ValidationResult validateElasticProfile(final String pluginId, final Map<String, String> configuration) {
         return pluginRequestHelper.submitRequest(pluginId, REQUEST_VALIDATE_PROFILE, new DefaultPluginInteractionCallback<ValidationResult>() {
             @Override

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/elastic/v4/ElasticAgentExtensionV4.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/elastic/v4/ElasticAgentExtensionV4.java
@@ -21,6 +21,7 @@ import com.thoughtworks.go.plugin.access.DefaultPluginInteractionCallback;
 import com.thoughtworks.go.plugin.access.PluginRequestHelper;
 import com.thoughtworks.go.plugin.access.elastic.VersionedElasticAgentExtension;
 import com.thoughtworks.go.plugin.access.elastic.models.AgentMetadata;
+import com.thoughtworks.go.plugin.access.elastic.models.ElasticAgentInformation;
 import com.thoughtworks.go.plugin.api.response.validation.ValidationResult;
 import com.thoughtworks.go.plugin.domain.common.PluginConfiguration;
 import com.thoughtworks.go.plugin.domain.elastic.Capabilities;
@@ -176,5 +177,10 @@ public class ElasticAgentExtensionV4 implements VersionedElasticAgentExtension {
                 return elasticAgentExtensionConverterV4.getJobCompletionRequestBody(elasticAgentId, jobIdentifier);
             }
         });
+    }
+
+    @Override
+    public ElasticAgentInformation migrateConfig(String pluginId, ElasticAgentInformation elasticAgentInformation) {
+        return elasticAgentInformation;
     }
 }

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/elastic/v5/ClusterProfileDTO.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/elastic/v5/ClusterProfileDTO.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.plugin.access.elastic.v5;
+
+import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.SerializedName;
+import com.thoughtworks.go.config.builder.ConfigurationPropertyBuilder;
+import com.thoughtworks.go.config.elastic.ClusterProfile;
+import com.thoughtworks.go.domain.config.ConfigurationProperty;
+
+import java.util.ArrayList;
+import java.util.Map;
+import java.util.Objects;
+
+public class ClusterProfileDTO {
+    @Expose
+    @SerializedName("id")
+    private String id;
+
+    @Expose
+    @SerializedName("plugin_id")
+    private String pluginId;
+
+    @Expose
+    @SerializedName("properties")
+    private Map<String, Map<String, Object>> properties;
+
+    public ClusterProfileDTO() {
+    }
+
+    public ClusterProfileDTO(String id, String pluginId, Map<String, Map<String, Object>> properties) {
+        this.id = id;
+        this.pluginId = pluginId;
+        this.properties = properties;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getPluginId() {
+        return pluginId;
+    }
+
+    public Map<String, Map<String, Object>> getProperties() {
+        return properties;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ClusterProfileDTO that = (ClusterProfileDTO) o;
+        return Objects.equals(id, that.id) &&
+                Objects.equals(pluginId, that.pluginId) &&
+                Objects.equals(properties, that.properties);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, pluginId, properties);
+    }
+
+    @Override
+    public String toString() {
+        return "ClusterProfileDTO{" +
+                "id='" + id + '\'' +
+                ", pluginId='" + pluginId + '\'' +
+                ", properties=" + properties +
+                '}';
+    }
+
+    public ClusterProfile toDomainModel() {
+        ArrayList<ConfigurationProperty> configurationProperties = new ArrayList<>();
+
+        ConfigurationPropertyBuilder builder = new ConfigurationPropertyBuilder();
+        this.properties.forEach((key, valueObject) -> {
+            boolean isSecure = (boolean) valueObject.get("isSecure");
+            String value = isSecure ? null : (String) valueObject.get("value");
+            String encryptedValue = isSecure ? (String) valueObject.get("value") : null;
+
+            configurationProperties.add(builder.create(key, value, encryptedValue, isSecure));
+        });
+
+        return new ClusterProfile(this.id, this.pluginId, configurationProperties);
+    }
+}

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/elastic/v5/ClusterProfileDTO.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/elastic/v5/ClusterProfileDTO.java
@@ -18,9 +18,10 @@ package com.thoughtworks.go.plugin.access.elastic.v5;
 
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
-import com.thoughtworks.go.config.builder.ConfigurationPropertyBuilder;
 import com.thoughtworks.go.config.elastic.ClusterProfile;
+import com.thoughtworks.go.domain.config.ConfigurationKey;
 import com.thoughtworks.go.domain.config.ConfigurationProperty;
+import com.thoughtworks.go.domain.config.ConfigurationValue;
 
 import java.util.ArrayList;
 import java.util.Map;
@@ -37,12 +38,12 @@ public class ClusterProfileDTO {
 
     @Expose
     @SerializedName("properties")
-    private Map<String, Map<String, Object>> properties;
+    private Map<String, String> properties;
 
     public ClusterProfileDTO() {
     }
 
-    public ClusterProfileDTO(String id, String pluginId, Map<String, Map<String, Object>> properties) {
+    public ClusterProfileDTO(String id, String pluginId, Map<String, String> properties) {
         this.id = id;
         this.pluginId = pluginId;
         this.properties = properties;
@@ -56,7 +57,7 @@ public class ClusterProfileDTO {
         return pluginId;
     }
 
-    public Map<String, Map<String, Object>> getProperties() {
+    public Map<String, String> getProperties() {
         return properties;
     }
 
@@ -86,16 +87,13 @@ public class ClusterProfileDTO {
 
     public ClusterProfile toDomainModel() {
         ArrayList<ConfigurationProperty> configurationProperties = new ArrayList<>();
-
-        ConfigurationPropertyBuilder builder = new ConfigurationPropertyBuilder();
-        this.properties.forEach((key, valueObject) -> {
-            boolean isSecure = (boolean) valueObject.get("isSecure");
-            String value = isSecure ? null : (String) valueObject.get("value");
-            String encryptedValue = isSecure ? (String) valueObject.get("value") : null;
-
-            configurationProperties.add(builder.create(key, value, encryptedValue, isSecure));
+        this.properties.forEach((key, value) -> {
+            configurationProperties.add(new ConfigurationProperty(new ConfigurationKey(key), new ConfigurationValue(value)));
         });
 
-        return new ClusterProfile(this.id, this.pluginId, configurationProperties);
+        ClusterProfile clusterProfile = new ClusterProfile(this.id, this.pluginId);
+        clusterProfile.addConfigurations(configurationProperties);
+
+        return clusterProfile;
     }
 }

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/elastic/v5/ConfigurationPropertyDTO.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/elastic/v5/ConfigurationPropertyDTO.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.plugin.access.elastic.v5;
+
+import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.SerializedName;
+import com.thoughtworks.go.config.builder.ConfigurationPropertyBuilder;
+import com.thoughtworks.go.config.elastic.ClusterProfile;
+import com.thoughtworks.go.domain.config.ConfigurationProperty;
+
+import java.util.ArrayList;
+import java.util.Map;
+import java.util.Objects;
+
+public class ConfigurationPropertyDTO {
+    @Expose
+    @SerializedName("id")
+    private String id;
+
+    @Expose
+    @SerializedName("plugin_id")
+    private String pluginId;
+
+    @Expose
+    @SerializedName("properties")
+    private Map<String, Map<String, Object>> properties;
+
+    public ConfigurationPropertyDTO() {
+    }
+
+    public ConfigurationPropertyDTO(String id, String pluginId, Map<String, Map<String, Object>> properties) {
+        this.id = id;
+        this.pluginId = pluginId;
+        this.properties = properties;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getPluginId() {
+        return pluginId;
+    }
+
+    public Map<String, Map<String, Object>> getProperties() {
+        return properties;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ConfigurationPropertyDTO that = (ConfigurationPropertyDTO) o;
+        return Objects.equals(id, that.id) &&
+                Objects.equals(pluginId, that.pluginId) &&
+                Objects.equals(properties, that.properties);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, pluginId, properties);
+    }
+
+    @Override
+    public String toString() {
+        return "ClusterProfileDTO{" +
+                "id='" + id + '\'' +
+                ", pluginId='" + pluginId + '\'' +
+                ", properties=" + properties +
+                '}';
+    }
+
+    public ClusterProfile toDomainModel() {
+        ArrayList<ConfigurationProperty> configurationProperties = new ArrayList<>();
+
+        ConfigurationPropertyBuilder builder = new ConfigurationPropertyBuilder();
+        this.properties.forEach((key, valueObject) -> {
+            boolean isSecure = (boolean) valueObject.get("isSecure");
+            String value = isSecure ? null : (String) valueObject.get("value");
+            String encryptedValue = isSecure ? (String) valueObject.get("value") : null;
+
+            configurationProperties.add(builder.create(key, value, encryptedValue, isSecure));
+        });
+
+        return new ClusterProfile(this.id, this.pluginId, configurationProperties);
+    }
+}

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/elastic/v5/ElasticAgentExtensionConverterV5.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/elastic/v5/ElasticAgentExtensionConverterV5.java
@@ -25,6 +25,7 @@ import com.thoughtworks.go.plugin.access.common.handler.JSONResultMessageHandler
 import com.thoughtworks.go.plugin.access.common.models.ImageDeserializer;
 import com.thoughtworks.go.plugin.access.common.models.PluginProfileMetadataKeys;
 import com.thoughtworks.go.plugin.access.elastic.models.AgentMetadata;
+import com.thoughtworks.go.plugin.access.elastic.models.ElasticAgentInformation;
 import com.thoughtworks.go.plugin.api.response.validation.ValidationResult;
 import com.thoughtworks.go.plugin.domain.common.PluginConfiguration;
 import com.thoughtworks.go.plugin.domain.elastic.Capabilities;
@@ -35,6 +36,7 @@ import java.util.Map;
 
 class ElasticAgentExtensionConverterV5 {
     private static final Gson GSON = new GsonBuilder().excludeFieldsWithoutExposeAnnotation().create();
+    private ElasticAgentInformationConverterV5 elasticAgentInformationConverterV5 = new ElasticAgentInformationConverterV5();
     private CapabilitiesConverterV5 capabilitiesConverterV5 = new CapabilitiesConverterV5();
     private AgentMetadataConverterV5 agentMetadataConverterV5 = new AgentMetadataConverterV5();
 
@@ -116,6 +118,11 @@ class ElasticAgentExtensionConverterV5 {
         return capabilitiesConverterV5.fromDTO(capabilitiesDTO);
     }
 
+    public ElasticAgentInformation getElasticAgentInformationFromResponseBody(String responseBody) {
+        final ElasticAgentInformationDTO elasticAgentInformationDTO = GSON.fromJson(responseBody, ElasticAgentInformationDTO.class);
+        return elasticAgentInformationConverterV5.fromDTO(elasticAgentInformationDTO);
+    }
+
     private JsonObject mapToJsonObject(Map<String, String> configuration) {
         final JsonObject properties = new JsonObject();
         for (Map.Entry<String, String> entry : configuration.entrySet()) {
@@ -161,6 +168,10 @@ class ElasticAgentExtensionConverterV5 {
         JsonObject jsonObject = new JsonObject();
         jsonObject.add("all_cluster_profile_properties", mapToJsonArray(clusterProfileConfigurations));
         return GSON.toJson(jsonObject);
+    }
+
+    public ElasticAgentInformationDTO getElasticAgentInformationDTO(ElasticAgentInformation elasticAgentInformation) {
+        return elasticAgentInformationConverterV5.toDTO(elasticAgentInformation);
     }
 }
 

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/elastic/v5/ElasticAgentExtensionV5.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/elastic/v5/ElasticAgentExtensionV5.java
@@ -82,6 +82,11 @@ public class ElasticAgentExtensionV5 implements VersionedElasticAgentExtension {
     }
 
     @Override
+    public boolean supportsClusterProfile() {
+        return true;
+    }
+
+    @Override
     public ValidationResult validateElasticProfile(final String pluginId, final Map<String, String> configuration) {
         return pluginRequestHelper.submitRequest(pluginId, REQUEST_VALIDATE_PROFILE, new DefaultPluginInteractionCallback<ValidationResult>() {
             @Override

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/elastic/v5/ElasticAgentExtensionV5.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/elastic/v5/ElasticAgentExtensionV5.java
@@ -21,6 +21,7 @@ import com.thoughtworks.go.plugin.access.DefaultPluginInteractionCallback;
 import com.thoughtworks.go.plugin.access.PluginRequestHelper;
 import com.thoughtworks.go.plugin.access.elastic.VersionedElasticAgentExtension;
 import com.thoughtworks.go.plugin.access.elastic.models.AgentMetadata;
+import com.thoughtworks.go.plugin.access.elastic.models.ElasticAgentInformation;
 import com.thoughtworks.go.plugin.api.response.validation.ValidationResult;
 import com.thoughtworks.go.plugin.domain.common.PluginConfiguration;
 import com.thoughtworks.go.plugin.domain.elastic.Capabilities;
@@ -142,7 +143,7 @@ public class ElasticAgentExtensionV5 implements VersionedElasticAgentExtension {
 
     @Override
     public void serverPing(final String pluginId, List<Map<String, String>> clusterProfileConfigurations) {
-        pluginRequestHelper.submitRequest(pluginId, REQUEST_SERVER_PING, new DefaultPluginInteractionCallback<Void>(){
+        pluginRequestHelper.submitRequest(pluginId, REQUEST_SERVER_PING, new DefaultPluginInteractionCallback<Void>() {
             @Override
             public String requestBody(String resolvedExtensionVersion) {
                 return elasticAgentExtensionConverterV5.serverPingRequestBody(clusterProfileConfigurations);
@@ -155,7 +156,7 @@ public class ElasticAgentExtensionV5 implements VersionedElasticAgentExtension {
         return pluginRequestHelper.submitRequest(pluginId, REQUEST_SHOULD_ASSIGN_WORK, new DefaultPluginInteractionCallback<Boolean>() {
             @Override
             public String requestBody(String resolvedExtensionVersion) {
-                return elasticAgentExtensionConverterV5.shouldAssignWorkRequestBody(agent, environment, configuration,clusterProfileProperties, identifier);
+                return elasticAgentExtensionConverterV5.shouldAssignWorkRequestBody(agent, environment, configuration, clusterProfileProperties, identifier);
             }
 
             @Override
@@ -196,6 +197,21 @@ public class ElasticAgentExtensionV5 implements VersionedElasticAgentExtension {
             @Override
             public String requestBody(String resolvedExtensionVersion) {
                 return elasticAgentExtensionConverterV5.getJobCompletionRequestBody(elasticAgentId, jobIdentifier, elasticProfileConfiguration, clusterProfileConfiguration);
+            }
+        });
+    }
+
+    @Override
+    public ElasticAgentInformation migrateConfig(String pluginId, ElasticAgentInformation elasticAgentInformation) {
+        return pluginRequestHelper.submitRequest(pluginId, REQUEST_MIGRATE_CONFIGURATION, new DefaultPluginInteractionCallback<ElasticAgentInformation>() {
+            @Override
+            public String requestBody(String resolvedExtensionVersion) {
+                return elasticAgentExtensionConverterV5.getElasticAgentInformationDTO(elasticAgentInformation).toJSON().toString();
+            }
+
+            @Override
+            public ElasticAgentInformation onSuccess(String responseBody, Map<String, String> responseHeaders, String resolvedExtensionVersion) {
+                return elasticAgentExtensionConverterV5.getElasticAgentInformationFromResponseBody(responseBody);
             }
         });
     }

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/elastic/v5/ElasticAgentInformationConverterV5.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/elastic/v5/ElasticAgentInformationConverterV5.java
@@ -31,6 +31,6 @@ class ElasticAgentInformationConverterV5 implements DataConverter<ElasticAgentIn
     public ElasticAgentInformationDTO toDTO(ElasticAgentInformation elasticAgentInformation) {
         return new ElasticAgentInformationDTO(elasticAgentInformation.getPluginSettings(),
                 elasticAgentInformation.getClusterProfiles().stream().map(clusterProfile -> new ClusterProfileDTO(clusterProfile.getId(), clusterProfile.getPluginId(), clusterProfile.getConfigurationAsMap(true))).collect(Collectors.toList()),
-                elasticAgentInformation.getElasticAgentProfiles().stream().map(elasticProfile -> new ElasticProfileDTO(elasticProfile.getId(), elasticProfile.getPluginId(), elasticProfile.getClusterProfileId(), elasticProfile.getPropertyMetadataAndValuesAsMap())).collect(Collectors.toList()));
+                elasticAgentInformation.getElasticAgentProfiles().stream().map(elasticProfile -> new ElasticProfileDTO(elasticProfile.getId(), elasticProfile.getPluginId(), elasticProfile.getClusterProfileId(), elasticProfile.getConfigurationAsMap(true))).collect(Collectors.toList()));
     }
 }

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/elastic/v5/ElasticAgentInformationConverterV5.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/elastic/v5/ElasticAgentInformationConverterV5.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.plugin.access.elastic.v5;
+
+import com.thoughtworks.go.plugin.access.elastic.DataConverter;
+import com.thoughtworks.go.plugin.access.elastic.models.ElasticAgentInformation;
+
+import java.util.stream.Collectors;
+
+class ElasticAgentInformationConverterV5 implements DataConverter<ElasticAgentInformation, ElasticAgentInformationDTO> {
+
+    @Override
+    public ElasticAgentInformation fromDTO(ElasticAgentInformationDTO elasticAgentInformationDTO) {
+        return new ElasticAgentInformation(elasticAgentInformationDTO.getPluginSettings(), elasticAgentInformationDTO.getClusterProfiles(), elasticAgentInformationDTO.getElasticAgentProfiles());
+    }
+
+    @Override
+    public ElasticAgentInformationDTO toDTO(ElasticAgentInformation elasticAgentInformation) {
+        return new ElasticAgentInformationDTO(elasticAgentInformation.getPluginSettings(),
+                elasticAgentInformation.getClusterProfiles().stream().map(clusterProfile -> new ClusterProfileDTO(clusterProfile.getId(), clusterProfile.getPluginId(), clusterProfile.getPropertyMetadataAndValuesAsMap())).collect(Collectors.toList()),
+                elasticAgentInformation.getElasticAgentProfiles().stream().map(elasticProfile -> new ElasticProfileDTO(elasticProfile.getId(), elasticProfile.getPluginId(), elasticProfile.getClusterProfileId(), elasticProfile.getPropertyMetadataAndValuesAsMap())).collect(Collectors.toList()));
+    }
+}

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/elastic/v5/ElasticAgentInformationConverterV5.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/elastic/v5/ElasticAgentInformationConverterV5.java
@@ -22,7 +22,6 @@ import com.thoughtworks.go.plugin.access.elastic.models.ElasticAgentInformation;
 import java.util.stream.Collectors;
 
 class ElasticAgentInformationConverterV5 implements DataConverter<ElasticAgentInformation, ElasticAgentInformationDTO> {
-
     @Override
     public ElasticAgentInformation fromDTO(ElasticAgentInformationDTO elasticAgentInformationDTO) {
         return new ElasticAgentInformation(elasticAgentInformationDTO.getPluginSettings(), elasticAgentInformationDTO.getClusterProfiles(), elasticAgentInformationDTO.getElasticAgentProfiles());

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/elastic/v5/ElasticAgentInformationConverterV5.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/elastic/v5/ElasticAgentInformationConverterV5.java
@@ -30,7 +30,7 @@ class ElasticAgentInformationConverterV5 implements DataConverter<ElasticAgentIn
     @Override
     public ElasticAgentInformationDTO toDTO(ElasticAgentInformation elasticAgentInformation) {
         return new ElasticAgentInformationDTO(elasticAgentInformation.getPluginSettings(),
-                elasticAgentInformation.getClusterProfiles().stream().map(clusterProfile -> new ClusterProfileDTO(clusterProfile.getId(), clusterProfile.getPluginId(), clusterProfile.getPropertyMetadataAndValuesAsMap())).collect(Collectors.toList()),
+                elasticAgentInformation.getClusterProfiles().stream().map(clusterProfile -> new ClusterProfileDTO(clusterProfile.getId(), clusterProfile.getPluginId(), clusterProfile.getConfigurationAsMap(true))).collect(Collectors.toList()),
                 elasticAgentInformation.getElasticAgentProfiles().stream().map(elasticProfile -> new ElasticProfileDTO(elasticProfile.getId(), elasticProfile.getPluginId(), elasticProfile.getClusterProfileId(), elasticProfile.getPropertyMetadataAndValuesAsMap())).collect(Collectors.toList()));
     }
 }

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/elastic/v5/ElasticAgentInformationDTO.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/elastic/v5/ElasticAgentInformationDTO.java
@@ -40,7 +40,7 @@ class ElasticAgentInformationDTO implements Serializable {
 
     @Expose
     @SerializedName("plugin_settings")
-    private final Map<String, Map<String, Object>> pluginSettings;
+    private final Map<String, String> pluginSettings;
 
     @Expose
     @SerializedName("cluster_profiles")
@@ -50,7 +50,7 @@ class ElasticAgentInformationDTO implements Serializable {
     @SerializedName("elastic_agent_profiles")
     private final List<ElasticProfileDTO> elasticAgentProfilesDTO;
 
-    public ElasticAgentInformationDTO(Map<String, Map<String, Object>> pluginSettings, List<ClusterProfileDTO> clusterProfilesDTO, List<ElasticProfileDTO> elasticAgentProfilesDTO) {
+    public ElasticAgentInformationDTO(Map<String, String> pluginSettings, List<ClusterProfileDTO> clusterProfilesDTO, List<ElasticProfileDTO> elasticAgentProfilesDTO) {
         this.pluginSettings = pluginSettings;
         this.clusterProfilesDTO = clusterProfilesDTO;
         this.elasticAgentProfilesDTO = elasticAgentProfilesDTO;
@@ -60,7 +60,7 @@ class ElasticAgentInformationDTO implements Serializable {
         return GSON.toJsonTree(this);
     }
 
-    public Map<String, Map<String, Object>> getPluginSettings() {
+    public Map<String, String> getPluginSettings() {
         return pluginSettings;
     }
 

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/elastic/v5/ElasticAgentInformationDTO.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/elastic/v5/ElasticAgentInformationDTO.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.plugin.access.elastic.v5;
+
+import com.google.gson.FieldNamingPolicy;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonElement;
+import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.SerializedName;
+import com.thoughtworks.go.config.elastic.ClusterProfile;
+import com.thoughtworks.go.config.elastic.ElasticProfile;
+
+import java.io.Serializable;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+class ElasticAgentInformationDTO implements Serializable {
+    private static final Gson GSON = new GsonBuilder().
+            excludeFieldsWithoutExposeAnnotation().
+            serializeNulls().
+            setFieldNamingStrategy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES).
+            create();
+
+    @Expose
+    @SerializedName("plugin_settings")
+    private final Map<String, Map<String, Object>> pluginSettings;
+
+    @Expose
+    @SerializedName("cluster_profiles")
+    private final List<ClusterProfileDTO> clusterProfilesDTO;
+
+    @Expose
+    @SerializedName("elastic_agent_profiles")
+    private final List<ElasticProfileDTO> elasticAgentProfilesDTO;
+
+    public ElasticAgentInformationDTO(Map<String, Map<String, Object>> pluginSettings, List<ClusterProfileDTO> clusterProfilesDTO, List<ElasticProfileDTO> elasticAgentProfilesDTO) {
+        this.pluginSettings = pluginSettings;
+        this.clusterProfilesDTO = clusterProfilesDTO;
+        this.elasticAgentProfilesDTO = elasticAgentProfilesDTO;
+    }
+
+    public JsonElement toJSON() {
+        return GSON.toJsonTree(this);
+    }
+
+    public Map<String, Map<String, Object>> getPluginSettings() {
+        return pluginSettings;
+    }
+
+    public List<ClusterProfile> getClusterProfiles() {
+        return clusterProfilesDTO.stream().map(ClusterProfileDTO::toDomainModel).collect(Collectors.toList());
+    }
+
+    public List<ElasticProfile> getElasticAgentProfiles() {
+        return elasticAgentProfilesDTO.stream().map(ElasticProfileDTO::toDomainModel).collect(Collectors.toList());
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ElasticAgentInformationDTO that = (ElasticAgentInformationDTO) o;
+        return Objects.equals(pluginSettings, that.pluginSettings) &&
+                Objects.equals(clusterProfilesDTO, that.clusterProfilesDTO) &&
+                Objects.equals(elasticAgentProfilesDTO, that.elasticAgentProfilesDTO);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(pluginSettings, clusterProfilesDTO, elasticAgentProfilesDTO);
+    }
+
+    @Override
+    public String toString() {
+        return "ElasticAgentInformationDTO{" +
+                "pluginSettings=" + pluginSettings +
+                ", clusterProfilesDTO=" + clusterProfilesDTO +
+                ", elasticAgentProfilesDTO=" + elasticAgentProfilesDTO +
+                '}';
+    }
+}

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/elastic/v5/ElasticAgentPluginConstantsV5.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/elastic/v5/ElasticAgentPluginConstantsV5.java
@@ -37,4 +37,6 @@ public interface ElasticAgentPluginConstantsV5 {
     String REQUEST_CAPABILITIES = REQUEST_PREFIX + ".get-capabilities";
 
     String REQUEST_JOB_COMPLETION = REQUEST_PREFIX + ".job-completion";
+
+    String REQUEST_MIGRATE_CONFIGURATION = REQUEST_PREFIX + ".migrate-config";
 }

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/elastic/v5/ElasticProfileDTO.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/elastic/v5/ElasticProfileDTO.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.plugin.access.elastic.v5;
+
+import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.SerializedName;
+import com.thoughtworks.go.config.builder.ConfigurationPropertyBuilder;
+import com.thoughtworks.go.config.elastic.ElasticProfile;
+import com.thoughtworks.go.domain.config.ConfigurationProperty;
+
+import java.util.ArrayList;
+import java.util.Map;
+import java.util.Objects;
+
+public class ElasticProfileDTO {
+    @Expose
+    @SerializedName("id")
+    private String id;
+
+    @Expose
+    @SerializedName("plugin_id")
+    private String pluginId;
+
+    @Expose
+    @SerializedName("cluster_profile_id")
+    private String clusterProfileId;
+
+    @Expose
+    @SerializedName("properties")
+    private Map<String, Map<String, Object>> properties;
+
+    public ElasticProfileDTO() {
+    }
+
+    public ElasticProfileDTO(String id, String pluginId, String clusterProfileId, Map<String, Map<String, Object>> properties) {
+        this.id = id;
+        this.pluginId = pluginId;
+        this.clusterProfileId = clusterProfileId;
+        this.properties = properties;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getPluginId() {
+        return pluginId;
+    }
+
+    public Map<String, Map<String, Object>> getProperties() {
+        return properties;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ElasticProfileDTO that = (ElasticProfileDTO) o;
+        return Objects.equals(id, that.id) &&
+                Objects.equals(pluginId, that.pluginId) &&
+                Objects.equals(clusterProfileId, that.clusterProfileId) &&
+                Objects.equals(properties, that.properties);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, pluginId, clusterProfileId, properties);
+    }
+
+    @Override
+    public String toString() {
+        return "ElasticProfileDTO{" +
+                "id='" + id + '\'' +
+                ", pluginId='" + pluginId + '\'' +
+                ", clusterProfileId='" + clusterProfileId + '\'' +
+                ", properties=" + properties +
+                '}';
+    }
+
+    public ElasticProfile toDomainModel() {
+        ArrayList<ConfigurationProperty> configurationProperties = new ArrayList<>();
+
+        ConfigurationPropertyBuilder builder = new ConfigurationPropertyBuilder();
+        this.properties.forEach((key, valueObject) -> {
+            boolean isSecure = (boolean) valueObject.get("isSecure");
+            String value = isSecure ? null : (String) valueObject.get("value");
+            String encryptedValue = isSecure ? (String) valueObject.get("value") : null;
+
+            configurationProperties.add(builder.create(key, value, encryptedValue, isSecure));
+        });
+
+        return new ElasticProfile(this.id, this.pluginId, this.clusterProfileId, configurationProperties);
+    }
+}

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/elastic/v5/ElasticProfileDTO.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/elastic/v5/ElasticProfileDTO.java
@@ -18,9 +18,10 @@ package com.thoughtworks.go.plugin.access.elastic.v5;
 
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
-import com.thoughtworks.go.config.builder.ConfigurationPropertyBuilder;
 import com.thoughtworks.go.config.elastic.ElasticProfile;
+import com.thoughtworks.go.domain.config.ConfigurationKey;
 import com.thoughtworks.go.domain.config.ConfigurationProperty;
+import com.thoughtworks.go.domain.config.ConfigurationValue;
 
 import java.util.ArrayList;
 import java.util.Map;
@@ -41,12 +42,12 @@ public class ElasticProfileDTO {
 
     @Expose
     @SerializedName("properties")
-    private Map<String, Map<String, Object>> properties;
+    private Map<String, String> properties;
 
     public ElasticProfileDTO() {
     }
 
-    public ElasticProfileDTO(String id, String pluginId, String clusterProfileId, Map<String, Map<String, Object>> properties) {
+    public ElasticProfileDTO(String id, String pluginId, String clusterProfileId, Map<String, String> properties) {
         this.id = id;
         this.pluginId = pluginId;
         this.clusterProfileId = clusterProfileId;
@@ -61,7 +62,7 @@ public class ElasticProfileDTO {
         return pluginId;
     }
 
-    public Map<String, Map<String, Object>> getProperties() {
+    public Map<String, String> getProperties() {
         return properties;
     }
 
@@ -94,15 +95,13 @@ public class ElasticProfileDTO {
     public ElasticProfile toDomainModel() {
         ArrayList<ConfigurationProperty> configurationProperties = new ArrayList<>();
 
-        ConfigurationPropertyBuilder builder = new ConfigurationPropertyBuilder();
-        this.properties.forEach((key, valueObject) -> {
-            boolean isSecure = (boolean) valueObject.get("isSecure");
-            String value = isSecure ? null : (String) valueObject.get("value");
-            String encryptedValue = isSecure ? (String) valueObject.get("value") : null;
-
-            configurationProperties.add(builder.create(key, value, encryptedValue, isSecure));
+        this.properties.forEach((key, value) -> {
+            configurationProperties.add(new ConfigurationProperty(new ConfigurationKey(key), new ConfigurationValue(value)));
         });
 
-        return new ElasticProfile(this.id, this.pluginId, this.clusterProfileId, configurationProperties);
+        ElasticProfile elasticProfile = new ElasticProfile(this.id, this.pluginId, this.clusterProfileId);
+        elasticProfile.addConfigurations(configurationProperties);
+
+        return elasticProfile;
     }
 }

--- a/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/elastic/ElasticAgentExtensionV4Test.java
+++ b/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/elastic/ElasticAgentExtensionV4Test.java
@@ -19,6 +19,7 @@ package com.thoughtworks.go.plugin.access.elastic;
 import com.thoughtworks.go.domain.JobIdentifier;
 import com.thoughtworks.go.plugin.access.PluginRequestHelper;
 import com.thoughtworks.go.plugin.access.elastic.models.AgentMetadata;
+import com.thoughtworks.go.plugin.access.elastic.models.ElasticAgentInformation;
 import com.thoughtworks.go.plugin.access.elastic.v4.ElasticAgentExtensionV4;
 import com.thoughtworks.go.plugin.api.request.GoPluginApiRequest;
 import com.thoughtworks.go.plugin.api.response.DefaultGoPluginApiResponse;
@@ -291,6 +292,15 @@ public class ElasticAgentExtensionV4Test {
         thrown.expectMessage(String.format("Plugin: '%s' uses elastic agent extension v4 and cluster profile extension calls are not supported by elastic agent V4", PLUGIN_ID));
 
         extensionV4.validateClusterProfile(PLUGIN_ID, new HashMap<>());
+    }
+
+    @Test
+    public void shouldMigrateElasticAgentInformation() {
+        ElasticAgentInformation elasticAgentInformation = new ElasticAgentInformation(Collections.emptyMap(), Collections.emptyList(), Collections.emptyList());
+        ElasticAgentInformation responseElasticAgentInformation = extensionV4.migrateConfig(PLUGIN_ID, elasticAgentInformation);
+
+        assertThat(responseElasticAgentInformation, is(elasticAgentInformation));
+        assertThat(requestArgumentCaptor.getAllValues(), is(Collections.emptyList()));
     }
 
     @Test

--- a/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/elastic/ElasticAgentExtensionV5Test.java
+++ b/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/elastic/ElasticAgentExtensionV5Test.java
@@ -19,6 +19,7 @@ package com.thoughtworks.go.plugin.access.elastic;
 import com.thoughtworks.go.domain.JobIdentifier;
 import com.thoughtworks.go.plugin.access.PluginRequestHelper;
 import com.thoughtworks.go.plugin.access.elastic.models.AgentMetadata;
+import com.thoughtworks.go.plugin.access.elastic.models.ElasticAgentInformation;
 import com.thoughtworks.go.plugin.access.elastic.v5.ElasticAgentExtensionV5;
 import com.thoughtworks.go.plugin.api.request.GoPluginApiRequest;
 import com.thoughtworks.go.plugin.api.response.DefaultGoPluginApiResponse;
@@ -340,6 +341,23 @@ public class ElasticAgentExtensionV5Test {
                 "}";
 
         assertExtensionRequest("5.0", REQUEST_AGENT_STATUS_REPORT, requestBody);
+    }
+
+    @Test
+    public void shouldMigrateElasticAgentInformation() {
+        String responseBody = "{" +
+                "    \"plugin_settings\":{}," +
+                "    \"cluster_profiles\":[]," +
+                "    \"elastic_agent_profiles\":[]" +
+                "}\n";
+        when(pluginManager.submitTo(eq(PLUGIN_ID), eq(ELASTIC_AGENT_EXTENSION), requestArgumentCaptor.capture())).thenReturn(DefaultGoPluginApiResponse.success(responseBody));
+
+        ElasticAgentInformation elasticAgentInformation = new ElasticAgentInformation(Collections.emptyMap(), Collections.emptyList(), Collections.emptyList());
+        extensionV5.migrateConfig(PLUGIN_ID, elasticAgentInformation);
+
+        final String expectedRequestBody = responseBody;
+
+        assertExtensionRequest("5.0", REQUEST_MIGRATE_CONFIGURATION, expectedRequestBody);
     }
 
     @Test

--- a/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/elastic/v5/ElasticAgentExtensionConverterV5Test.java
+++ b/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/elastic/v5/ElasticAgentExtensionConverterV5Test.java
@@ -25,6 +25,8 @@ import com.thoughtworks.go.plugin.access.elastic.models.AgentMetadata;
 import com.thoughtworks.go.plugin.access.elastic.models.ElasticAgentInformation;
 import com.thoughtworks.go.plugin.api.response.validation.ValidationResult;
 import com.thoughtworks.go.plugin.domain.elastic.Capabilities;
+import com.thoughtworks.go.security.CryptoException;
+import com.thoughtworks.go.security.GoCipher;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -267,13 +269,14 @@ public class ElasticAgentExtensionConverterV5Test {
     }
 
     @Test
-    public void shouldGetRequestBodyForMigrateCall_withOldConfig() {
+    public void shouldGetRequestBodyForMigrateCall_withOldConfig() throws CryptoException {
         ConfigurationProperty property1 = new ConfigurationProperty(new ConfigurationKey("key"), new ConfigurationValue("value"));
-        ConfigurationProperty property2 = new ConfigurationProperty(new ConfigurationKey("key2"), new EncryptedConfigurationValue("encrypted"));
+        ConfigurationProperty property2 = new ConfigurationProperty(new ConfigurationKey("key2"), new EncryptedConfigurationValue(new GoCipher().encrypt("password")));
+
         Configuration configuration = new Configuration();
         configuration.add(property1);
         configuration.add(property2);
-        Map<String, Map<String, Object>> pluginSettings = configuration.getPropertyMetadataAndValuesAsMap();
+        Map<String, String> pluginSettings = configuration.getConfigurationAsMap(true);
 
         List<ClusterProfile> clusterProfiles = new ArrayList<>();
 
@@ -287,16 +290,8 @@ public class ElasticAgentExtensionConverterV5Test {
 
         String expectedRequestBody = "{" +
                 "    \"plugin_settings\":{" +
-                "        \"key2\":{" +
-                "            \"displayValue\":\"****\"," +
-                "            \"isSecure\":true," +
-                "            \"value\":\"encrypted\"" +
-                "        }," +
-                "        \"key\":{" +
-                "            \"displayValue\":\"value\"," +
-                "            \"isSecure\":false," +
-                "            \"value\":\"value\"" +
-                "        }" +
+                "        \"key2\":\"password\", " +
+                "        \"key\":\"value\"" +
                 "    }," +
                 "    \"cluster_profiles\":[]," +
                 "    \"elastic_agent_profiles\":[" +
@@ -324,13 +319,13 @@ public class ElasticAgentExtensionConverterV5Test {
     }
 
     @Test
-    public void shouldGetRequestBodyForMigrateCall_withNewConfig() {
+    public void shouldGetRequestBodyForMigrateCall_withNewConfig() throws CryptoException {
         ConfigurationProperty property1 = new ConfigurationProperty(new ConfigurationKey("key"), new ConfigurationValue("value"));
-        ConfigurationProperty property2 = new ConfigurationProperty(new ConfigurationKey("key2"), new EncryptedConfigurationValue("encrypted"));
+        ConfigurationProperty property2 = new ConfigurationProperty(new ConfigurationKey("key2"), new EncryptedConfigurationValue(new GoCipher().encrypt("password")));
         Configuration configuration = new Configuration();
         configuration.add(property1);
         configuration.add(property2);
-        Map<String, Map<String, Object>> pluginSettings = configuration.getPropertyMetadataAndValuesAsMap();
+        Map<String, String> pluginSettings = configuration.getConfigurationAsMap(true);
 
         List<ClusterProfile> clusterProfiles = new ArrayList<>();
         clusterProfiles.add(new ClusterProfile("cluster_profile_id", "plugin_id", new ConfigurationProperty(new ConfigurationKey("some_key"), new ConfigurationValue("some_value")), new ConfigurationProperty(new ConfigurationKey("some_key2"), new EncryptedConfigurationValue("some_value2"))));
@@ -345,16 +340,8 @@ public class ElasticAgentExtensionConverterV5Test {
 
         String expectedRequestBody = "{" +
                 "    \"plugin_settings\":{" +
-                "        \"key2\":{" +
-                "            \"displayValue\":\"****\"," +
-                "            \"isSecure\":true," +
-                "            \"value\":\"encrypted\"" +
-                "        }," +
-                "        \"key\":{" +
-                "            \"displayValue\":\"value\"," +
-                "            \"isSecure\":false," +
-                "            \"value\":\"value\"" +
-                "        }" +
+                "        \"key2\":\"password\", " +
+                "        \"key\":\"value\"" +
                 "    }," +
                 "    \"cluster_profiles\":[" +
                 "        {" +
@@ -399,19 +386,11 @@ public class ElasticAgentExtensionConverterV5Test {
     }
 
     @Test
-    public void shouldGetTheElasticAgentInformationFromResponseBodyOfMigrateCall() {
+    public void shouldGetTheElasticAgentInformationFromResponseBodyOfMigrateCall() throws CryptoException {
         String responseBody = "{" +
                 "    \"plugin_settings\":{" +
-                "        \"key2\":{" +
-                "            \"displayValue\":\"****\"," +
-                "            \"isSecure\":true," +
-                "            \"value\":\"encrypted\"" +
-                "        }," +
-                "        \"key\":{" +
-                "            \"displayValue\":\"value\"," +
-                "            \"isSecure\":false," +
-                "            \"value\":\"value\"" +
-                "        }" +
+                "        \"key2\":\"password\", " +
+                "        \"key\":\"value\"" +
                 "    }," +
                 "    \"cluster_profiles\":[" +
                 "        {" +
@@ -455,11 +434,12 @@ public class ElasticAgentExtensionConverterV5Test {
         ElasticAgentInformation elasticAgentInformation = new ElasticAgentExtensionConverterV5().getElasticAgentInformationFromResponseBody(responseBody);
 
         ConfigurationProperty property1 = new ConfigurationProperty(new ConfigurationKey("key"), new ConfigurationValue("value"));
-        ConfigurationProperty property2 = new ConfigurationProperty(new ConfigurationKey("key2"), new EncryptedConfigurationValue("encrypted"));
+        ConfigurationProperty property2 = new ConfigurationProperty(new ConfigurationKey("key2"), new EncryptedConfigurationValue(new GoCipher().encrypt("password")));
         Configuration configuration = new Configuration();
         configuration.add(property1);
         configuration.add(property2);
-        Map<String, Map<String, Object>> pluginSettings = configuration.getPropertyMetadataAndValuesAsMap();
+
+        Map<String, String> pluginSettings = configuration.getConfigurationAsMap(true);
 
         List<ClusterProfile> clusterProfiles = new ArrayList<>();
         clusterProfiles.add(new ClusterProfile("cluster_profile_id", "plugin_id", new ConfigurationProperty(new ConfigurationKey("some_key"), new ConfigurationValue("some_value")), new ConfigurationProperty(new ConfigurationKey("some_key2"), new EncryptedConfigurationValue("some_value2"))));

--- a/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/elastic/v5/ElasticAgentExtensionConverterV5Test.java
+++ b/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/elastic/v5/ElasticAgentExtensionConverterV5Test.java
@@ -287,7 +287,7 @@ public class ElasticAgentExtensionConverterV5Test {
         List<ClusterProfile> clusterProfiles = new ArrayList<>();
 
         List<ElasticProfile> elasticAgentProfiles = new ArrayList<>();
-        elasticAgentProfiles.add(new ElasticProfile("profile_id", "plugin_id", new ConfigurationProperty(new ConfigurationKey("some_key"), new ConfigurationValue("some_value")), new ConfigurationProperty(new ConfigurationKey("some_key2"), new EncryptedConfigurationValue("some_value2"))));
+        elasticAgentProfiles.add(new ElasticProfile("profile_id", "plugin_id", new ConfigurationProperty(new ConfigurationKey("some_key"), new ConfigurationValue("some_value")), new ConfigurationProperty(new ConfigurationKey("some_key2"), new EncryptedConfigurationValue(new GoCipher().encrypt("some_value2")))));
 
         ElasticAgentInformation elasticAgentInformation = new ElasticAgentInformation(pluginSettings, clusterProfiles, elasticAgentProfiles);
 
@@ -306,16 +306,8 @@ public class ElasticAgentExtensionConverterV5Test {
                 "            \"plugin_id\":\"plugin_id\"," +
                 "            \"cluster_profile_id\": null," +
                 "            \"properties\":{" +
-                "                \"some_key\":{" +
-                "                    \"displayValue\":\"some_value\"," +
-                "                    \"isSecure\":false," +
-                "                    \"value\":\"some_value\"" +
-                "                }," +
-                "                \"some_key2\":{" +
-                "                    \"displayValue\":\"****\"," +
-                "                    \"isSecure\":true," +
-                "                    \"value\":\"some_value2\"" +
-                "                }" +
+                "                \"some_key\":\"some_value\", " +
+                "                \"some_key2\":\"some_value2\"" +
                 "            }" +
                 "        }" +
                 "    ]" +
@@ -338,7 +330,7 @@ public class ElasticAgentExtensionConverterV5Test {
         clusterProfiles.add(new ClusterProfile("cluster_profile_id", "plugin_id", new ConfigurationProperty(new ConfigurationKey("some_key"), new ConfigurationValue("some_value")), new ConfigurationProperty(new ConfigurationKey("some_key2"), new EncryptedConfigurationValue(new GoCipher().encrypt("some_value2")))));
 
         List<ElasticProfile> elasticAgentProfiles = new ArrayList<>();
-        elasticAgentProfiles.add(new ElasticProfile("profile_id", "plugin_id", "cluster_profile_id", new ConfigurationProperty(new ConfigurationKey("some_key"), new ConfigurationValue("some_value")), new ConfigurationProperty(new ConfigurationKey("some_key2"), new EncryptedConfigurationValue("some_value2"))));
+        elasticAgentProfiles.add(new ElasticProfile("profile_id", "plugin_id", "cluster_profile_id", new ConfigurationProperty(new ConfigurationKey("some_key"), new ConfigurationValue("some_value")), new ConfigurationProperty(new ConfigurationKey("some_key2"), new EncryptedConfigurationValue(new GoCipher().encrypt("some_value2")))));
 
         ElasticAgentInformation elasticAgentInformation = new ElasticAgentInformation(pluginSettings, clusterProfiles, elasticAgentProfiles);
 
@@ -366,16 +358,8 @@ public class ElasticAgentExtensionConverterV5Test {
                 "            \"plugin_id\":\"plugin_id\"," +
                 "            \"cluster_profile_id\":\"cluster_profile_id\"," +
                 "            \"properties\":{" +
-                "                \"some_key\":{" +
-                "                    \"displayValue\":\"some_value\"," +
-                "                    \"isSecure\":false," +
-                "                    \"value\":\"some_value\"" +
-                "                }," +
-                "                \"some_key2\":{" +
-                "                    \"displayValue\":\"****\"," +
-                "                    \"isSecure\":true," +
-                "                    \"value\":\"some_value2\"" +
-                "                }" +
+                "                \"some_key\":\"some_value\", " +
+                "                \"some_key2\":\"some_value2\"" +
                 "            }" +
                 "        }" +
                 "    ]" +
@@ -407,24 +391,17 @@ public class ElasticAgentExtensionConverterV5Test {
                 "            \"plugin_id\":\"plugin_id\"," +
                 "            \"cluster_profile_id\":\"cluster_profile_id\"," +
                 "            \"properties\":{" +
-                "                \"some_key\":{" +
-                "                    \"displayValue\":\"some_value\"," +
-                "                    \"isSecure\":false," +
-                "                    \"value\":\"some_value\"" +
-                "                }," +
-                "                \"some_key2\":{" +
-                "                    \"displayValue\":\"****\"," +
-                "                    \"isSecure\":true," +
-                "                    \"value\":\"some_value2\"" +
-                "                }" +
+                "                \"some_key\":\"some_value\"," +
+                "                \"some_key2\":\"some_value2\"" +
                 "            }" +
                 "        }" +
                 "    ]" +
                 "}\n";
 
         ElasticAgentMetadataStore store = ElasticAgentMetadataStore.instance();
+        PluggableInstanceSettings elasticAgentProfileSettings = new PluggableInstanceSettings(Arrays.asList(new PluginConfiguration("some_key", new Metadata(true, true))));
         PluggableInstanceSettings clusterProfileSettings = new PluggableInstanceSettings(Arrays.asList(new PluginConfiguration("some_key2", new Metadata(true, true))));
-        store.setPluginInfo(new ElasticAgentPluginInfo(pluginDescriptor("plugin_id"), null, clusterProfileSettings, null, null, null));
+        store.setPluginInfo(new ElasticAgentPluginInfo(pluginDescriptor("plugin_id"), elasticAgentProfileSettings, clusterProfileSettings, null, null, null));
 
         ElasticAgentInformation elasticAgentInformation = new ElasticAgentExtensionConverterV5().getElasticAgentInformationFromResponseBody(responseBody);
 
@@ -440,7 +417,7 @@ public class ElasticAgentExtensionConverterV5Test {
         clusterProfiles.add(new ClusterProfile("cluster_profile_id", "plugin_id", new ConfigurationProperty(new ConfigurationKey("some_key"), new ConfigurationValue("some_value")), new ConfigurationProperty(new ConfigurationKey("some_key2"), new EncryptedConfigurationValue(new GoCipher().encrypt("some_value2")))));
 
         List<ElasticProfile> elasticAgentProfiles = new ArrayList<>();
-        elasticAgentProfiles.add(new ElasticProfile("profile_id", "plugin_id", "cluster_profile_id", new ConfigurationProperty(new ConfigurationKey("some_key"), new ConfigurationValue("some_value")), new ConfigurationProperty(new ConfigurationKey("some_key2"), new EncryptedConfigurationValue("some_value2"))));
+        elasticAgentProfiles.add(new ElasticProfile("profile_id", "plugin_id", "cluster_profile_id", new ConfigurationProperty(new ConfigurationKey("some_key"), new EncryptedConfigurationValue(new GoCipher().encrypt("some_value"))), new ConfigurationProperty(new ConfigurationKey("some_key2"), new ConfigurationValue("some_value2"))));
 
         ElasticAgentInformation expectedElasticAgentInformation = new ElasticAgentInformation(pluginSettings, clusterProfiles, elasticAgentProfiles);
 

--- a/plugin-infra/go-plugin-infra/src/main/java/com/thoughtworks/go/plugin/infra/DefaultPluginManager.java
+++ b/plugin-infra/go-plugin-infra/src/main/java/com/thoughtworks/go/plugin/infra/DefaultPluginManager.java
@@ -141,6 +141,11 @@ public class DefaultPluginManager implements PluginManager {
     }
 
     @Override
+    public void setElasticAgentInformationMigrator(ElasticAgentInformationMigrator elasticAgentInformationMigrator) {
+        goPluginOSGiFramework.setElasticAgentInformationMigrator(elasticAgentInformationMigrator);
+    }
+
+    @Override
     public GoPluginApiResponse submitTo(final String pluginId, String extensionType, final GoPluginApiRequest apiRequest) {
         return goPluginOSGiFramework.doOn(GoPlugin.class, pluginId, extensionType, (plugin, pluginDescriptor) -> {
             ensureInitializerInvoked(pluginDescriptor, plugin, extensionType);

--- a/plugin-infra/go-plugin-infra/src/main/java/com/thoughtworks/go/plugin/infra/ElasticAgentInformationMigrator.java
+++ b/plugin-infra/go-plugin-infra/src/main/java/com/thoughtworks/go/plugin/infra/ElasticAgentInformationMigrator.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.plugin.infra;
+
+import com.thoughtworks.go.plugin.infra.plugininfo.GoPluginDescriptor;
+
+public interface ElasticAgentInformationMigrator {
+    void migrate(GoPluginDescriptor pluginDescriptor);
+}

--- a/plugin-infra/go-plugin-infra/src/main/java/com/thoughtworks/go/plugin/infra/FelixGoPluginOSGiFramework.java
+++ b/plugin-infra/go-plugin-infra/src/main/java/com/thoughtworks/go/plugin/infra/FelixGoPluginOSGiFramework.java
@@ -56,6 +56,7 @@ public class FelixGoPluginOSGiFramework implements GoPluginOSGiFramework {
     private SystemEnvironment systemEnvironment;
     private Collection<PluginChangeListener> pluginChangeListeners = new ConcurrentLinkedQueue<>();
     private PluginExtensionsAndVersionValidator pluginExtensionsAndVersionValidator;
+    private ElasticAgentInformationMigrator elasticAgentInformationMigrator;
 
     @Autowired
     public FelixGoPluginOSGiFramework(PluginRegistry registry, SystemEnvironment systemEnvironment) {
@@ -126,6 +127,10 @@ public class FelixGoPluginOSGiFramework implements GoPluginOSGiFramework {
                 }
             }
 
+            if (elasticAgentInformationMigrator != null) {
+                elasticAgentInformationMigrator.migrate(pluginDescriptor);
+            }
+
             IterableUtils.forEach(pluginChangeListeners, notifyPluginLoadedEvent(pluginDescriptor));
             return bundle;
         } catch (Exception e) {
@@ -179,6 +184,11 @@ public class FelixGoPluginOSGiFramework implements GoPluginOSGiFramework {
     @Override
     public void setPluginExtensionsAndVersionValidator(PluginExtensionsAndVersionValidator pluginExtensionsAndVersionValidator) {
         this.pluginExtensionsAndVersionValidator = pluginExtensionsAndVersionValidator;
+    }
+
+    @Override
+    public void setElasticAgentInformationMigrator(ElasticAgentInformationMigrator elasticAgentInformationMigrator) {
+        this.elasticAgentInformationMigrator = elasticAgentInformationMigrator;
     }
 
     private void registerInternalServices(BundleContext bundleContext) {

--- a/plugin-infra/go-plugin-infra/src/main/java/com/thoughtworks/go/plugin/infra/GoPluginOSGiFramework.java
+++ b/plugin-infra/go-plugin-infra/src/main/java/com/thoughtworks/go/plugin/infra/GoPluginOSGiFramework.java
@@ -41,4 +41,6 @@ public interface GoPluginOSGiFramework {
     <T> boolean hasReferenceFor(Class<T> serviceReferenceClass, String pluginId, String extensionType);
 
     <T extends GoPlugin> Map<String, List<String>> getExtensionsInfoFromThePlugin(String pluginId);
+
+    void setElasticAgentInformationMigrator(ElasticAgentInformationMigrator elasticAgentInformationMigrator);
 }

--- a/plugin-infra/go-plugin-infra/src/main/java/com/thoughtworks/go/plugin/infra/PluginManager.java
+++ b/plugin-infra/go-plugin-infra/src/main/java/com/thoughtworks/go/plugin/infra/PluginManager.java
@@ -44,4 +44,6 @@ public interface PluginManager {
     String resolveExtensionVersion(String pluginId, String extensionType, List<String> goSupportedExtensionVersions);
 
     List<String> getRequiredExtensionVersionsByPlugin(String pluginId, String extensionType);
+
+    void setElasticAgentInformationMigrator(ElasticAgentInformationMigrator elasticAgentInformationMigrator);
 }

--- a/plugin-infra/go-plugin-infra/src/test/java/com/thoughtworks/go/plugin/infra/DefaultPluginManagerTest.java
+++ b/plugin-infra/go-plugin-infra/src/test/java/com/thoughtworks/go/plugin/infra/DefaultPluginManagerTest.java
@@ -399,6 +399,11 @@ public class DefaultPluginManagerTest {
         }
 
         @Override
+        public void setElasticAgentInformationMigrator(ElasticAgentInformationMigrator elasticAgentInformationMigrator) {
+
+        }
+
+        @Override
         public <T, R> R doOn(Class<T> serviceReferenceClass, String pluginId, String extensionType, ActionWithReturn<T, R> action) {
             return action.execute((T) serviceReferenceInstance, mock(GoPluginDescriptor.class));
         }

--- a/server/src/main/java/com/thoughtworks/go/config/update/ReplaceElasticAgentInformationCommand.java
+++ b/server/src/main/java/com/thoughtworks/go/config/update/ReplaceElasticAgentInformationCommand.java
@@ -63,11 +63,11 @@ public class ReplaceElasticAgentInformationCommand implements EntityConfigUpdate
         List<ClusterProfile> migratedClusterProfiles = migratedElasticAgentInformation.getClusterProfiles();
         List<ElasticProfile> migratedElasticAgentProfiles = migratedElasticAgentInformation.getElasticAgentProfiles();
 
-        goConfigService.getElasticConfig().getClusterProfiles().removeAll(clusterProfiles);
-        goConfigService.getElasticConfig().getClusterProfiles().addAll(migratedClusterProfiles);
+        preprocessedConfig.getElasticConfig().getClusterProfiles().removeAll(clusterProfiles);
+        preprocessedConfig.getElasticConfig().getClusterProfiles().addAll(migratedClusterProfiles);
 
-        goConfigService.getElasticConfig().getProfiles().removeAll(elasticAgentProfiles);
-        goConfigService.getElasticConfig().getProfiles().addAll(migratedElasticAgentProfiles);
+        preprocessedConfig.getElasticConfig().getProfiles().removeAll(elasticAgentProfiles);
+        preprocessedConfig.getElasticConfig().getProfiles().addAll(migratedElasticAgentProfiles);
     }
 
     @Override

--- a/server/src/main/java/com/thoughtworks/go/config/update/ReplaceElasticAgentInformationCommand.java
+++ b/server/src/main/java/com/thoughtworks/go/config/update/ReplaceElasticAgentInformationCommand.java
@@ -61,7 +61,7 @@ public class ReplaceElasticAgentInformationCommand implements EntityConfigUpdate
             configurationProperties.addAll(pluginSettings.getPluginSettingsProperties());
         }
 
-        Map<String, Map<String, Object>> pluginSettingsConfiguration = configurationProperties.getPropertyMetadataAndValuesAsMap();
+        Map<String, String> pluginSettingsConfiguration = configurationProperties.getConfigurationAsMap(true);
         List<ClusterProfile> clusterProfiles = clusterProfilesService.getPluginProfiles().findByPluginId(pluginId);
         List<ElasticProfile> elasticAgentProfiles = elasticProfileService.getPluginProfiles().findByPluginId(pluginId);
 

--- a/server/src/main/java/com/thoughtworks/go/config/update/ReplaceElasticAgentInformationCommand.java
+++ b/server/src/main/java/com/thoughtworks/go/config/update/ReplaceElasticAgentInformationCommand.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.config.update;
+
+import com.thoughtworks.go.config.CruiseConfig;
+import com.thoughtworks.go.config.commands.EntityConfigUpdateCommand;
+import com.thoughtworks.go.config.elastic.ClusterProfile;
+import com.thoughtworks.go.config.elastic.ElasticProfile;
+import com.thoughtworks.go.domain.config.Configuration;
+import com.thoughtworks.go.plugin.access.elastic.ElasticAgentExtension;
+import com.thoughtworks.go.plugin.access.elastic.models.ElasticAgentInformation;
+import com.thoughtworks.go.plugin.infra.plugininfo.GoPluginDescriptor;
+import com.thoughtworks.go.server.service.ClusterProfilesService;
+import com.thoughtworks.go.server.service.ElasticProfileService;
+import com.thoughtworks.go.server.service.GoConfigService;
+import com.thoughtworks.go.server.service.PluginService;
+
+import java.util.List;
+import java.util.Map;
+
+public class ReplaceElasticAgentInformationCommand implements EntityConfigUpdateCommand<ElasticAgentInformation> {
+    private final PluginService pluginService;
+    private final ClusterProfilesService clusterProfilesService;
+    private final ElasticProfileService elasticProfileService;
+    private final ElasticAgentExtension elasticAgentExtension;
+    private GoConfigService goConfigService;
+    private GoPluginDescriptor pluginDescriptor;
+    private ElasticAgentInformation migratedElasticAgentInformation;
+
+    public ReplaceElasticAgentInformationCommand(PluginService pluginService, ClusterProfilesService clusterProfilesService, ElasticProfileService elasticProfileService, ElasticAgentExtension elasticAgentExtension, GoConfigService goConfigService, GoPluginDescriptor pluginDescriptor) {
+        this.pluginService = pluginService;
+        this.clusterProfilesService = clusterProfilesService;
+        this.elasticProfileService = elasticProfileService;
+        this.elasticAgentExtension = elasticAgentExtension;
+        this.goConfigService = goConfigService;
+        this.pluginDescriptor = pluginDescriptor;
+    }
+
+    @Override
+    public void update(CruiseConfig preprocessedConfig) throws Exception {
+        String pluginId = pluginDescriptor.id();
+
+        Map<String, Map<String, Object>> pluginSettings = new Configuration(pluginService.getPluginSettings(pluginId).getPluginSettingsProperties()).getPropertyMetadataAndValuesAsMap();
+        List<ClusterProfile> clusterProfiles = clusterProfilesService.getPluginProfiles().findByPluginId(pluginId);
+        List<ElasticProfile> elasticAgentProfiles = elasticProfileService.getPluginProfiles().findByPluginId(pluginId);
+
+        ElasticAgentInformation elasticAgentInformation = new ElasticAgentInformation(pluginSettings, clusterProfiles, elasticAgentProfiles);
+        migratedElasticAgentInformation = elasticAgentExtension.migrateConfig(pluginId, elasticAgentInformation);
+
+        List<ClusterProfile> migratedClusterProfiles = migratedElasticAgentInformation.getClusterProfiles();
+        List<ElasticProfile> migratedElasticAgentProfiles = migratedElasticAgentInformation.getElasticAgentProfiles();
+
+        goConfigService.getElasticConfig().getClusterProfiles().removeAll(clusterProfiles);
+        goConfigService.getElasticConfig().getClusterProfiles().addAll(migratedClusterProfiles);
+
+        goConfigService.getElasticConfig().getProfiles().removeAll(elasticAgentProfiles);
+        goConfigService.getElasticConfig().getProfiles().addAll(migratedElasticAgentProfiles);
+    }
+
+    @Override
+    public boolean isValid(CruiseConfig preprocessedConfig) {
+        //todo: Add validation to check if plugin returns valid config
+        return true;
+    }
+
+    @Override
+    public void clearErrors() {
+    }
+
+    @Override
+    public ElasticAgentInformation getPreprocessedEntityConfig() {
+        return migratedElasticAgentInformation;
+    }
+
+    @Override
+    public boolean canContinue(CruiseConfig cruiseConfig) {
+        return true;
+    }
+}

--- a/server/src/main/java/com/thoughtworks/go/server/initializers/PluginsInitializer.java
+++ b/server/src/main/java/com/thoughtworks/go/server/initializers/PluginsInitializer.java
@@ -16,6 +16,7 @@
 
 package com.thoughtworks.go.server.initializers;
 
+import com.thoughtworks.go.plugin.infra.ElasticAgentInformationMigrator;
 import com.thoughtworks.go.plugin.infra.PluginExtensionsAndVersionValidator;
 import com.thoughtworks.go.plugin.infra.PluginManager;
 import com.thoughtworks.go.util.SystemEnvironment;
@@ -42,11 +43,12 @@ public class PluginsInitializer implements Initializer {
     private ZipUtil zipUtil;
 
     @Autowired
-    public PluginsInitializer(PluginManager pluginManager, SystemEnvironment systemEnvironment, ZipUtil zipUtil, PluginExtensionsAndVersionValidator pluginExtensionsAndVersionValidator) {
+    public PluginsInitializer(PluginManager pluginManager, SystemEnvironment systemEnvironment, ZipUtil zipUtil, PluginExtensionsAndVersionValidator pluginExtensionsAndVersionValidator, ElasticAgentInformationMigrator elasticAgentInformationMigrator) {
         this.pluginManager = pluginManager;
         this.systemEnvironment = systemEnvironment;
         this.zipUtil = zipUtil;
         this.pluginManager.setPluginExtensionsAndVersionValidator(pluginExtensionsAndVersionValidator);
+        this.pluginManager.setElasticAgentInformationMigrator(elasticAgentInformationMigrator);
     }
 
     @Override

--- a/server/src/main/java/com/thoughtworks/go/server/service/ElasticAgentInformationMigratorImpl.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/ElasticAgentInformationMigratorImpl.java
@@ -1,0 +1,55 @@
+package com.thoughtworks.go.server.service;
+
+import com.thoughtworks.go.config.commands.EntityConfigUpdateCommand;
+import com.thoughtworks.go.config.update.ReplaceElasticAgentInformationCommand;
+import com.thoughtworks.go.plugin.access.elastic.ElasticAgentExtension;
+import com.thoughtworks.go.plugin.infra.ElasticAgentInformationMigrator;
+import com.thoughtworks.go.plugin.infra.PluginManager;
+import com.thoughtworks.go.plugin.infra.plugininfo.GoPluginDescriptor;
+import com.thoughtworks.go.server.domain.Username;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import static com.thoughtworks.go.plugin.domain.common.PluginConstants.ELASTIC_AGENT_EXTENSION;
+
+@Component
+public class ElasticAgentInformationMigratorImpl implements ElasticAgentInformationMigrator {
+    private PluginService pluginService;
+    private final ClusterProfilesService clusterProfilesService;
+    private final ElasticProfileService elasticProfileService;
+    private ElasticAgentExtension elasticAgentExtension;
+    private PluginManager pluginManager;
+    private GoConfigService goConfigService;
+
+    @Autowired
+    public ElasticAgentInformationMigratorImpl(PluginService pluginService, ClusterProfilesService clusterProfilesService, ElasticProfileService elasticProfileService, ElasticAgentExtension elasticAgentExtension, PluginManager pluginManager, GoConfigService goConfigService) {
+        this.pluginService = pluginService;
+        this.clusterProfilesService = clusterProfilesService;
+        this.elasticProfileService = elasticProfileService;
+        this.elasticAgentExtension = elasticAgentExtension;
+        this.pluginManager = pluginManager;
+        this.goConfigService = goConfigService;
+    }
+
+    @Override
+    public void migrate(GoPluginDescriptor pluginDescriptor) {
+        String pluginId = pluginDescriptor.id();
+        boolean isElasticAgentPlugin = pluginManager.isPluginOfType(ELASTIC_AGENT_EXTENSION, pluginId);
+
+        if (!isElasticAgentPlugin) {
+            return;
+        }
+
+        ReplaceElasticAgentInformationCommand command = new ReplaceElasticAgentInformationCommand(pluginService, clusterProfilesService, elasticProfileService, elasticAgentExtension, goConfigService, pluginDescriptor);
+        update(command);
+    }
+
+    private void update(EntityConfigUpdateCommand command) {
+        try {
+            goConfigService.updateConfig(command, new Username("GoCD"));
+        } catch (Exception e) {
+            //todo: mark plugin invalid if migration fails
+//            e.getMessage()
+        }
+    }
+}

--- a/server/src/main/java/com/thoughtworks/go/server/service/ElasticAgentInformationMigratorImpl.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/ElasticAgentInformationMigratorImpl.java
@@ -2,28 +2,33 @@ package com.thoughtworks.go.server.service;
 
 import com.thoughtworks.go.config.commands.EntityConfigUpdateCommand;
 import com.thoughtworks.go.config.update.ReplaceElasticAgentInformationCommand;
+import com.thoughtworks.go.domain.Plugin;
 import com.thoughtworks.go.plugin.access.elastic.ElasticAgentExtension;
 import com.thoughtworks.go.plugin.infra.ElasticAgentInformationMigrator;
 import com.thoughtworks.go.plugin.infra.PluginManager;
 import com.thoughtworks.go.plugin.infra.plugininfo.GoPluginDescriptor;
+import com.thoughtworks.go.server.dao.PluginSqlMapDao;
 import com.thoughtworks.go.server.domain.Username;
+import com.thoughtworks.go.util.json.JsonHelper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+
+import java.util.HashMap;
 
 import static com.thoughtworks.go.plugin.domain.common.PluginConstants.ELASTIC_AGENT_EXTENSION;
 
 @Component
 public class ElasticAgentInformationMigratorImpl implements ElasticAgentInformationMigrator {
-    private PluginService pluginService;
     private final ClusterProfilesService clusterProfilesService;
     private final ElasticProfileService elasticProfileService;
     private ElasticAgentExtension elasticAgentExtension;
     private PluginManager pluginManager;
     private GoConfigService goConfigService;
+    private PluginSqlMapDao pluginSqlMapDao;
 
     @Autowired
-    public ElasticAgentInformationMigratorImpl(PluginService pluginService, ClusterProfilesService clusterProfilesService, ElasticProfileService elasticProfileService, ElasticAgentExtension elasticAgentExtension, PluginManager pluginManager, GoConfigService goConfigService) {
-        this.pluginService = pluginService;
+    public ElasticAgentInformationMigratorImpl(PluginSqlMapDao pluginSqlMapDao, ClusterProfilesService clusterProfilesService, ElasticProfileService elasticProfileService, ElasticAgentExtension elasticAgentExtension, PluginManager pluginManager, GoConfigService goConfigService) {
+        this.pluginSqlMapDao = pluginSqlMapDao;
         this.clusterProfilesService = clusterProfilesService;
         this.elasticProfileService = elasticProfileService;
         this.elasticAgentExtension = elasticAgentExtension;
@@ -40,7 +45,11 @@ public class ElasticAgentInformationMigratorImpl implements ElasticAgentInformat
             return;
         }
 
-        ReplaceElasticAgentInformationCommand command = new ReplaceElasticAgentInformationCommand(pluginService, clusterProfilesService, elasticProfileService, elasticAgentExtension, goConfigService, pluginDescriptor);
+        Plugin plugin = pluginSqlMapDao.findPlugin(pluginId);
+        String pluginConfiguration = plugin.getConfiguration();
+        HashMap<String, String> pluginSettings = (pluginConfiguration == null) ? new HashMap<>() : JsonHelper.fromJson(pluginConfiguration, HashMap.class);
+        ReplaceElasticAgentInformationCommand command = new ReplaceElasticAgentInformationCommand(clusterProfilesService, elasticProfileService, elasticAgentExtension, goConfigService, pluginDescriptor, pluginSettings);
+
         update(command);
     }
 

--- a/server/src/test-fast/java/com/thoughtworks/go/config/update/ReplaceElasticAgentInformationCommandTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/config/update/ReplaceElasticAgentInformationCommandTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.config.update;
+
+import com.thoughtworks.go.config.BasicCruiseConfig;
+import com.thoughtworks.go.config.elastic.*;
+import com.thoughtworks.go.plugin.access.elastic.ElasticAgentExtension;
+import com.thoughtworks.go.plugin.access.elastic.models.ElasticAgentInformation;
+import com.thoughtworks.go.plugin.infra.plugininfo.GoPluginDescriptor;
+import com.thoughtworks.go.server.domain.PluginSettings;
+import com.thoughtworks.go.server.service.ClusterProfilesService;
+import com.thoughtworks.go.server.service.ElasticProfileService;
+import com.thoughtworks.go.server.service.GoConfigService;
+import com.thoughtworks.go.server.service.PluginService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+class ReplaceElasticAgentInformationCommandTest {
+    @Mock
+    private PluginService pluginService;
+    @Mock
+    private ClusterProfilesService clusterProfilesService;
+    @Mock
+    private ElasticProfileService elasticProfileService;
+    @Mock
+    private ElasticAgentExtension elasticAgentExtension;
+    @Mock
+    private GoConfigService goConfigService;
+    @Mock
+    private GoPluginDescriptor pluginDescriptor;
+
+    private ReplaceElasticAgentInformationCommand replaceElasticAgentInformationCommand;
+    private BasicCruiseConfig basicCruiseConfig;
+    private String pluginId;
+    private PluginSettings pluginSettings;
+    private ClusterProfiles clusterProfiles;
+    private ElasticProfiles elasticProfiles;
+
+    @BeforeEach
+    void setUp() {
+        initMocks(this);
+        basicCruiseConfig = new BasicCruiseConfig();
+
+        pluginId = "plugin-id";
+
+        pluginSettings = new PluginSettings();
+        clusterProfiles = new ClusterProfiles();
+        clusterProfiles.add(new ClusterProfile("cluster-id", pluginId));
+        elasticProfiles = new ElasticProfiles();
+        elasticProfiles.add(new ElasticProfile("profile-id", pluginId));
+
+        replaceElasticAgentInformationCommand = new ReplaceElasticAgentInformationCommand(pluginService, clusterProfilesService, elasticProfileService, elasticAgentExtension, goConfigService, pluginDescriptor);
+
+        when(pluginDescriptor.id()).thenReturn(pluginId);
+        when(pluginService.getPluginSettings(pluginId)).thenReturn(pluginSettings);
+        when(clusterProfilesService.getPluginProfiles()).thenReturn(clusterProfiles);
+        when(elasticProfileService.getPluginProfiles()).thenReturn(elasticProfiles);
+        when(elasticAgentExtension.migrateConfig(eq(pluginId), any())).thenReturn(new ElasticAgentInformation(Collections.emptyMap(), clusterProfiles, elasticProfiles));
+        when(goConfigService.getElasticConfig()).thenReturn(new ElasticConfig());
+    }
+
+    @Test
+    void shouldMakeCallToElasticAgentExtensionToMigrateElasticAgentRelatedConfig() throws Exception {
+        replaceElasticAgentInformationCommand.update(basicCruiseConfig);
+
+        verify(elasticAgentExtension).migrateConfig(pluginId, new ElasticAgentInformation(Collections.emptyMap(), clusterProfiles, elasticProfiles));
+    }
+
+    @Test
+    void shouldUpdateGoCDConfigWithPluginReturnedMigratedConfig() throws Exception {
+        ElasticConfig elasticConfig = new ElasticConfig();
+        when(goConfigService.getElasticConfig()).thenReturn(elasticConfig);
+
+        assertThat(elasticConfig.getProfiles()).hasSize(0);
+        assertThat(elasticConfig.getClusterProfiles()).hasSize(0);
+
+        replaceElasticAgentInformationCommand.update(basicCruiseConfig);
+
+        verify(elasticAgentExtension).migrateConfig(pluginId, new ElasticAgentInformation(Collections.emptyMap(), clusterProfiles, elasticProfiles));
+
+        assertThat(elasticConfig.getProfiles()).hasSize(1);
+        assertThat(elasticConfig.getProfiles()).isEqualTo(elasticProfiles);
+        assertThat(elasticConfig.getClusterProfiles()).hasSize(1);
+        assertThat(elasticConfig.getClusterProfiles()).isEqualTo(clusterProfiles);
+    }
+
+    @Test
+    void shouldGetPreprocessedConfig() throws Exception {
+        replaceElasticAgentInformationCommand.update(basicCruiseConfig);
+
+        ElasticAgentInformation preprocessedEntityConfig = replaceElasticAgentInformationCommand.getPreprocessedEntityConfig();
+
+        assertThat(preprocessedEntityConfig).isEqualTo(new ElasticAgentInformation(Collections.emptyMap(), clusterProfiles, elasticProfiles));
+    }
+
+    @Test
+    void shouldAlwaysAllowTheReplaceElasticAgentInformationCommandToProceed() {
+        assertThat(replaceElasticAgentInformationCommand.canContinue(basicCruiseConfig)).isTrue();
+    }
+}

--- a/server/src/test-fast/java/com/thoughtworks/go/config/update/ReplaceElasticAgentInformationCommandTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/config/update/ReplaceElasticAgentInformationCommandTest.java
@@ -21,7 +21,6 @@ import com.thoughtworks.go.config.elastic.*;
 import com.thoughtworks.go.plugin.access.elastic.ElasticAgentExtension;
 import com.thoughtworks.go.plugin.access.elastic.models.ElasticAgentInformation;
 import com.thoughtworks.go.plugin.infra.plugininfo.GoPluginDescriptor;
-import com.thoughtworks.go.server.domain.PluginSettings;
 import com.thoughtworks.go.server.service.ClusterProfilesService;
 import com.thoughtworks.go.server.service.ElasticProfileService;
 import com.thoughtworks.go.server.service.GoConfigService;
@@ -108,10 +107,10 @@ class ReplaceElasticAgentInformationCommandTest {
 
         verify(elasticAgentExtension).migrateConfig(pluginId, new ElasticAgentInformation(Collections.emptyMap(), clusterProfiles, elasticProfiles));
 
-        assertThat(elasticConfig.getProfiles()).hasSize(1);
-        assertThat(elasticConfig.getProfiles()).isEqualTo(elasticProfiles);
-        assertThat(elasticConfig.getClusterProfiles()).hasSize(1);
-        assertThat(elasticConfig.getClusterProfiles()).isEqualTo(clusterProfiles);
+        assertThat(basicCruiseConfig.getElasticConfig().getProfiles()).hasSize(1);
+        assertThat(basicCruiseConfig.getElasticConfig().getProfiles()).isEqualTo(elasticProfiles);
+        assertThat(basicCruiseConfig.getElasticConfig().getClusterProfiles()).hasSize(1);
+        assertThat(basicCruiseConfig.getElasticConfig().getClusterProfiles()).isEqualTo(clusterProfiles);
     }
 
     @Test

--- a/server/src/test-fast/java/com/thoughtworks/go/config/update/ReplaceElasticAgentInformationCommandTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/config/update/ReplaceElasticAgentInformationCommandTest.java
@@ -25,12 +25,12 @@ import com.thoughtworks.go.server.domain.PluginSettings;
 import com.thoughtworks.go.server.service.ClusterProfilesService;
 import com.thoughtworks.go.server.service.ElasticProfileService;
 import com.thoughtworks.go.server.service.GoConfigService;
-import com.thoughtworks.go.server.service.PluginService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 
 import java.util.Collections;
+import java.util.HashMap;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -40,8 +40,6 @@ import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 
 class ReplaceElasticAgentInformationCommandTest {
-    @Mock
-    private PluginService pluginService;
     @Mock
     private ClusterProfilesService clusterProfilesService;
     @Mock
@@ -56,7 +54,7 @@ class ReplaceElasticAgentInformationCommandTest {
     private ReplaceElasticAgentInformationCommand replaceElasticAgentInformationCommand;
     private BasicCruiseConfig basicCruiseConfig;
     private String pluginId;
-    private PluginSettings pluginSettings;
+    private HashMap<String, String> pluginSettings;
     private ClusterProfiles clusterProfiles;
     private ElasticProfiles elasticProfiles;
 
@@ -67,16 +65,15 @@ class ReplaceElasticAgentInformationCommandTest {
 
         pluginId = "plugin-id";
 
-        pluginSettings = new PluginSettings();
+        pluginSettings = new HashMap<>();
         clusterProfiles = new ClusterProfiles();
         clusterProfiles.add(new ClusterProfile("cluster-id", pluginId));
         elasticProfiles = new ElasticProfiles();
         elasticProfiles.add(new ElasticProfile("profile-id", pluginId));
 
-        replaceElasticAgentInformationCommand = new ReplaceElasticAgentInformationCommand(pluginService, clusterProfilesService, elasticProfileService, elasticAgentExtension, goConfigService, pluginDescriptor);
+        replaceElasticAgentInformationCommand = new ReplaceElasticAgentInformationCommand(clusterProfilesService, elasticProfileService, elasticAgentExtension, goConfigService, pluginDescriptor, pluginSettings);
 
         when(pluginDescriptor.id()).thenReturn(pluginId);
-        when(pluginService.getPluginSettings(pluginId)).thenReturn(pluginSettings);
         when(clusterProfilesService.getPluginProfiles()).thenReturn(clusterProfiles);
         when(elasticProfileService.getPluginProfiles()).thenReturn(elasticProfiles);
         when(elasticAgentExtension.migrateConfig(eq(pluginId), any())).thenReturn(new ElasticAgentInformation(Collections.emptyMap(), clusterProfiles, elasticProfiles));
@@ -92,7 +89,7 @@ class ReplaceElasticAgentInformationCommandTest {
 
     @Test
     void shouldMakeCallToElasticAgentExtensionToMigrateElasticAgentRelatedConfig_WhenNoPluginSettingsAreConfigured() throws Exception {
-        when(pluginService.getPluginSettings(pluginId)).thenReturn(null);
+        replaceElasticAgentInformationCommand = new ReplaceElasticAgentInformationCommand(clusterProfilesService, elasticProfileService, elasticAgentExtension, goConfigService, pluginDescriptor, new HashMap<>());
 
         replaceElasticAgentInformationCommand.update(basicCruiseConfig);
 

--- a/server/src/test-fast/java/com/thoughtworks/go/config/update/ReplaceElasticAgentInformationCommandTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/config/update/ReplaceElasticAgentInformationCommandTest.java
@@ -91,6 +91,15 @@ class ReplaceElasticAgentInformationCommandTest {
     }
 
     @Test
+    void shouldMakeCallToElasticAgentExtensionToMigrateElasticAgentRelatedConfig_WhenNoPluginSettingsAreConfigured() throws Exception {
+        when(pluginService.getPluginSettings(pluginId)).thenReturn(null);
+
+        replaceElasticAgentInformationCommand.update(basicCruiseConfig);
+
+        verify(elasticAgentExtension).migrateConfig(pluginId, new ElasticAgentInformation(Collections.emptyMap(), clusterProfiles, elasticProfiles));
+    }
+
+    @Test
     void shouldUpdateGoCDConfigWithPluginReturnedMigratedConfig() throws Exception {
         ElasticConfig elasticConfig = new ElasticConfig();
         when(goConfigService.getElasticConfig()).thenReturn(elasticConfig);

--- a/server/src/test-fast/java/com/thoughtworks/go/server/initializers/PluginsInitializerTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/initializers/PluginsInitializerTest.java
@@ -16,6 +16,7 @@
 
 package com.thoughtworks.go.server.initializers;
 
+import com.thoughtworks.go.plugin.infra.ElasticAgentInformationMigrator;
 import com.thoughtworks.go.plugin.infra.PluginExtensionsAndVersionValidator;
 import com.thoughtworks.go.plugin.infra.PluginManager;
 import com.thoughtworks.go.util.SystemEnvironment;
@@ -47,6 +48,7 @@ public class PluginsInitializerTest {
     private PluginsInitializer pluginsInitializer;
     private PluginManager pluginManager;
     private PluginExtensionsAndVersionValidator pluginExtensionsAndVersionValidator;
+    private ElasticAgentInformationMigrator elasticAgentInformationMigrator;
 
     @Before
     public void setUp() throws Exception {
@@ -55,7 +57,8 @@ public class PluginsInitializerTest {
         when(systemEnvironment.get(SystemEnvironment.PLUGIN_GO_PROVIDED_PATH)).thenReturn(goPluginsDir.getAbsolutePath());
         pluginManager = mock(PluginManager.class);
         pluginExtensionsAndVersionValidator = mock(PluginExtensionsAndVersionValidator.class);
-        pluginsInitializer = new PluginsInitializer(pluginManager, systemEnvironment, new ZipUtil(), pluginExtensionsAndVersionValidator) {
+        elasticAgentInformationMigrator = mock(ElasticAgentInformationMigrator.class);
+        pluginsInitializer = new PluginsInitializer(pluginManager, systemEnvironment, new ZipUtil(), pluginExtensionsAndVersionValidator, elasticAgentInformationMigrator) {
             @Override
             public void startDaemon() {
 
@@ -76,7 +79,7 @@ public class PluginsInitializerTest {
     @Test
     public void shouldUnzipPluginsAndRegisterZipUpdaterBeforeStartingPluginsFramework() throws IOException {
         ZipUtil zipUtil = mock(ZipUtil.class);
-        pluginsInitializer = new PluginsInitializer(pluginManager, systemEnvironment, zipUtil, pluginExtensionsAndVersionValidator) {
+        pluginsInitializer = new PluginsInitializer(pluginManager, systemEnvironment, zipUtil, pluginExtensionsAndVersionValidator, elasticAgentInformationMigrator) {
             @Override
             public void startDaemon() {
 
@@ -144,5 +147,13 @@ public class PluginsInitializerTest {
             FileUtils.deleteQuietly(pluginsBundles);
             FileUtils.deleteQuietly(pluginsNew);
         }
+    }
+
+    @Test
+    public void shouldSetElasticAgentInformationMigratorOnPluginManager() {
+        reset(pluginManager);
+        new PluginsInitializer(pluginManager, systemEnvironment, new ZipUtil(), pluginExtensionsAndVersionValidator, elasticAgentInformationMigrator);
+
+        verify(pluginManager, times(1)).setElasticAgentInformationMigrator(elasticAgentInformationMigrator);
     }
 }

--- a/server/src/test-fast/java/com/thoughtworks/go/server/service/ElasticAgentInformationMigratorImplTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/service/ElasticAgentInformationMigratorImplTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.server.service;
+
+import com.thoughtworks.go.config.update.ReplaceElasticAgentInformationCommand;
+import com.thoughtworks.go.plugin.access.elastic.ElasticAgentExtension;
+import com.thoughtworks.go.plugin.infra.PluginManager;
+import com.thoughtworks.go.plugin.infra.plugininfo.GoPluginDescriptor;
+import com.thoughtworks.go.server.domain.Username;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+
+import static com.thoughtworks.go.plugin.domain.common.PluginConstants.ELASTIC_AGENT_EXTENSION;
+import static org.mockito.Mockito.*;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+class ElasticAgentInformationMigratorImplTest {
+    @Mock
+    private PluginService pluginService;
+    @Mock
+    private ClusterProfilesService clusterProfilesService;
+    @Mock
+    private ElasticProfileService elasticProfileService;
+    @Mock
+    private ElasticAgentExtension elasticAgentExtension;
+    @Mock
+    private PluginManager pluginManager;
+    @Mock
+    private GoConfigService goConfigService;
+
+    private ElasticAgentInformationMigratorImpl elasticAgentInformationMigrator;
+    private GoPluginDescriptor goPluginDescriptor;
+
+    @BeforeEach
+    void setUp() {
+        initMocks(this);
+        goPluginDescriptor = new GoPluginDescriptor("test-plugin", "1.0.0", null, "/var/lib", null, false);
+        elasticAgentInformationMigrator = new ElasticAgentInformationMigratorImpl(pluginService, clusterProfilesService, elasticProfileService, elasticAgentExtension, pluginManager, goConfigService);
+    }
+
+    @Test
+    void shouldDoNothingForNonElasticAgentPlugins() {
+        when(pluginManager.isPluginOfType(ELASTIC_AGENT_EXTENSION, goPluginDescriptor.id())).thenReturn(false);
+
+        elasticAgentInformationMigrator.migrate(goPluginDescriptor);
+
+        verifyZeroInteractions(goConfigService);
+    }
+
+    @Test
+    void shouldPerformReplaceElasticAgentInformationCommandToMigrateElasticAgentInformation() {
+        when(pluginManager.isPluginOfType(ELASTIC_AGENT_EXTENSION, goPluginDescriptor.id())).thenReturn(true);
+
+        elasticAgentInformationMigrator.migrate(goPluginDescriptor);
+
+        verify(goConfigService, times(1)).updateConfig(any(ReplaceElasticAgentInformationCommand.class), any(Username.class));
+    }
+}


### PR DESCRIPTION
* On plugin load, make a config migration call to all elastic agent plugins
  to migrate cluster profile(s) and elastic agent profile(s) providing
  plugin settings, cluster profile(s) and elastic agent profile(s).
* Save received migrated config back to the xml.

* Migrate will always be made to plugin on plugin load even if the latest
  available config has already been migrated.