### PR TITLE
Allow reordering config repo pipelines

### DIFF
--- a/api/api-dashboard-v2/src/test/groovy/com/thoughtworks/go/apiv2/dashboard/GoDashboardPipelineMother.groovy
+++ b/api/api-dashboard-v2/src/test/groovy/com/thoughtworks/go/apiv2/dashboard/GoDashboardPipelineMother.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 ThoughtWorks, Inc.
+ * Copyright 2019 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,6 +32,6 @@ class GoDashboardPipelineMother {
   static GoDashboardPipeline dashboardPipeline(pipeline_name, group_name = "group1", permissions = new Permissions(Everyone.INSTANCE, Everyone.INSTANCE, Everyone.INSTANCE, Everyone.INSTANCE), timestamp = 1000L) {
     def clock = mock(Clock.class)
     when(clock.currentTimeMillis()).thenReturn(timestamp)
-    new GoDashboardPipeline(pipeline_model(pipeline_name, 'pipeline-label'), permissions, group_name, new TimeStampBasedCounter(clock), new FileConfigOrigin())
+    new GoDashboardPipeline(pipeline_model(pipeline_name, 'pipeline-label'), permissions, group_name, null, new TimeStampBasedCounter(clock), new FileConfigOrigin(), 0)
   }
 }

--- a/api/api-dashboard-v2/src/test/groovy/com/thoughtworks/go/apiv2/dashboard/representers/DashboardGroupRepresenterTest.groovy
+++ b/api/api-dashboard-v2/src/test/groovy/com/thoughtworks/go/apiv2/dashboard/representers/DashboardGroupRepresenterTest.groovy
@@ -143,6 +143,26 @@ class DashboardGroupRepresenterTest {
         can_administer: false
       ])
     }
+
+    @Test
+    void 'renders pipelines in pipeline groups ordered by display-sort-order-weight'() {
+      def env = new GoDashboardEnvironment('env1', NoOne.INSTANCE)
+      def permissions = new Permissions(Everyone.INSTANCE, Everyone.INSTANCE, Everyone.INSTANCE, Everyone.INSTANCE)
+      env.addPipeline(dashboardPipeline('pipeline1', 'group1', permissions, 1000, 20))
+      env.addPipeline(dashboardPipeline('pipeline2', 'group1', permissions, 1000, -1))
+      env.addPipeline(dashboardPipeline('pipeline3', 'group1', permissions, 1000, 10))
+
+      def username = new Username(new CaseInsensitiveString(SecureRandom.hex()))
+
+      def actualJson = toObjectString({ DashboardGroupRepresenter.toJSON(it, env, username) })
+
+      assertThatJson(actualJson).isEqualTo([
+        _links        : expectedLinks,
+        name          : 'env1',
+        pipelines     : ['pipeline2', 'pipeline3', 'pipeline1'],
+        can_administer: false
+      ])
+    }
   }
 
   static GoDashboardPipeline dashboardPipeline(pipeline_name, group_name = "group1", permissions = new Permissions(Everyone.INSTANCE, Everyone.INSTANCE, Everyone.INSTANCE, Everyone.INSTANCE), long timestamp = 1000, int displayOrderWeight = 0) {

--- a/api/api-dashboard-v2/src/test/groovy/com/thoughtworks/go/apiv2/dashboard/representers/DashboardGroupRepresenterTest.groovy
+++ b/api/api-dashboard-v2/src/test/groovy/com/thoughtworks/go/apiv2/dashboard/representers/DashboardGroupRepresenterTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 ThoughtWorks, Inc.
+ * Copyright 2019 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -145,9 +145,9 @@ class DashboardGroupRepresenterTest {
     }
   }
 
-  static GoDashboardPipeline dashboardPipeline(pipeline_name, group_name = "group1", permissions = new Permissions(Everyone.INSTANCE, Everyone.INSTANCE, Everyone.INSTANCE, Everyone.INSTANCE), long timestamp = 1000) {
+  static GoDashboardPipeline dashboardPipeline(pipeline_name, group_name = "group1", permissions = new Permissions(Everyone.INSTANCE, Everyone.INSTANCE, Everyone.INSTANCE, Everyone.INSTANCE), long timestamp = 1000, int displayOrderWeight = 0) {
     def clock = mock(Clock.class)
     when(clock.currentTimeMillis()).thenReturn(timestamp)
-    new GoDashboardPipeline(pipeline_model(pipeline_name, 'pipeline-label'), permissions, group_name, new TimeStampBasedCounter(clock), new FileConfigOrigin())
+    new GoDashboardPipeline(pipeline_model(pipeline_name, 'pipeline-label'), permissions, group_name, null, new TimeStampBasedCounter(clock), new FileConfigOrigin(), displayOrderWeight)
   }
 }

--- a/api/api-dashboard-v2/src/test/groovy/com/thoughtworks/go/apiv2/dashboard/representers/PipelineRepresenterTest.groovy
+++ b/api/api-dashboard-v2/src/test/groovy/com/thoughtworks/go/apiv2/dashboard/representers/PipelineRepresenterTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 ThoughtWorks, Inc.
+ * Copyright 2019 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -46,7 +46,7 @@ class PipelineRepresenterTest {
     when(counter.getNext()).thenReturn(1l)
     def permissions = new Permissions(NoOne.INSTANCE, NoOne.INSTANCE, NoOne.INSTANCE, NoOne.INSTANCE)
     def pipeline = new GoDashboardPipeline(pipeline_model('pipeline_name', 'pipeline_label'),
-      permissions, "grp", new TrackingTool("http://example.com/\${ID}", "##\\d+"), counter, new FileConfigOrigin())
+      permissions, "grp", new TrackingTool("http://example.com/\${ID}", "##\\d+"), counter, new FileConfigOrigin(), 0)
     def username = new Username(new CaseInsensitiveString(SecureRandom.hex()))
 
     def json = toObject({ PipelineRepresenter.toJSON(it, pipeline, username) })
@@ -88,7 +88,7 @@ class PipelineRepresenterTest {
     def counter = mock(Counter.class)
     when(counter.getNext()).thenReturn(1l)
     def permissions = new Permissions(NoOne.INSTANCE, NoOne.INSTANCE, NoOne.INSTANCE, NoOne.INSTANCE)
-    def pipeline = new GoDashboardPipeline(pipeline_model('p1', 'p1l1'), permissions, "grp", counter, null)
+    def pipeline = new GoDashboardPipeline(pipeline_model('p1', 'p1l1'), permissions, "grp", null, counter, null, 0)
 
     def json = toObject({ PipelineRepresenter.toJSON(it, pipeline, new Username(new CaseInsensitiveString(SecureRandom.hex()))) })
 
@@ -104,7 +104,7 @@ class PipelineRepresenterTest {
       when(counter.getNext()).thenReturn(1l)
       def permissions = new Permissions(NoOne.INSTANCE, NoOne.INSTANCE, NoOne.INSTANCE, Everyone.INSTANCE)
       def origin = new RepoConfigOrigin(new ConfigRepoConfig(MaterialConfigsMother.gitMaterialConfig(), "plugin", "repo1"), "rev1")
-      def pipeline = new GoDashboardPipeline(pipeline_model('pipeline_name', 'pipeline_label'), permissions, "grp", counter, origin)
+      def pipeline = new GoDashboardPipeline(pipeline_model('pipeline_name', 'pipeline_label'), permissions, "grp", null, counter, origin, 0)
       def username = new Username(new CaseInsensitiveString(SecureRandom.hex()))
 
       def actualJson = toObject({ PipelineRepresenter.toJSON(it, pipeline, username) })
@@ -122,7 +122,7 @@ class PipelineRepresenterTest {
       when(counter.getNext()).thenReturn(1l)
       def permissions = new Permissions(NoOne.INSTANCE, NoOne.INSTANCE, Everyone.INSTANCE, NoOne.INSTANCE)
       def origin = new RepoConfigOrigin(new ConfigRepoConfig(MaterialConfigsMother.gitMaterialConfig(), "plugin", "repo1"), "rev1")
-      def pipeline = new GoDashboardPipeline(pipeline_model('pipeline_name', 'pipeline_label'), permissions, "grp", counter, origin)
+      def pipeline = new GoDashboardPipeline(pipeline_model('pipeline_name', 'pipeline_label'), permissions, "grp", null, counter, origin, 0)
       def username = new Username(new CaseInsensitiveString(SecureRandom.hex()))
 
       def actualJson = toObject({ PipelineRepresenter.toJSON(it, pipeline, username) })
@@ -140,7 +140,7 @@ class PipelineRepresenterTest {
       when(counter.getNext()).thenReturn(1l)
       def permissions = new Permissions(NoOne.INSTANCE, Everyone.INSTANCE, NoOne.INSTANCE, NoOne.INSTANCE)
       def origin = new RepoConfigOrigin(new ConfigRepoConfig(MaterialConfigsMother.gitMaterialConfig(), "plugin", "repo1"), "rev1")
-      def pipeline = new GoDashboardPipeline(pipeline_model('pipeline_name', 'pipeline_label'), permissions, "grp", counter, origin)
+      def pipeline = new GoDashboardPipeline(pipeline_model('pipeline_name', 'pipeline_label'), permissions, "grp", null, counter, origin, 0)
       def username = new Username(new CaseInsensitiveString(SecureRandom.hex()))
 
       def actualJson = toObject({ PipelineRepresenter.toJSON(it, pipeline, username) })

--- a/api/api-dashboard-v3/src/test/groovy/com/thoughtworks/go/apiv3/dashboard/GoDashboardPipelineMother.groovy
+++ b/api/api-dashboard-v3/src/test/groovy/com/thoughtworks/go/apiv3/dashboard/GoDashboardPipelineMother.groovy
@@ -32,6 +32,6 @@ class GoDashboardPipelineMother {
   static GoDashboardPipeline dashboardPipeline(pipeline_name, group_name = "group1", permissions = new Permissions(Everyone.INSTANCE, Everyone.INSTANCE, Everyone.INSTANCE, Everyone.INSTANCE), timestamp = 1000L) {
     def clock = mock(Clock.class)
     when(clock.currentTimeMillis()).thenReturn(timestamp)
-    new GoDashboardPipeline(pipeline_model(pipeline_name, 'pipeline-label'), permissions, group_name, new TimeStampBasedCounter(clock), new FileConfigOrigin())
+    new GoDashboardPipeline(pipeline_model(pipeline_name, 'pipeline-label'), permissions, group_name, null, new TimeStampBasedCounter(clock), new FileConfigOrigin(), 0)
   }
 }

--- a/api/api-dashboard-v3/src/test/groovy/com/thoughtworks/go/apiv3/dashboard/representers/DashboardGroupRepresenterTest.groovy
+++ b/api/api-dashboard-v3/src/test/groovy/com/thoughtworks/go/apiv3/dashboard/representers/DashboardGroupRepresenterTest.groovy
@@ -148,6 +148,6 @@ class DashboardGroupRepresenterTest {
   static GoDashboardPipeline dashboardPipeline(pipeline_name, group_name = "group1", permissions = new Permissions(Everyone.INSTANCE, Everyone.INSTANCE, Everyone.INSTANCE, Everyone.INSTANCE), long timestamp = 1000) {
     def clock = mock(Clock.class)
     when(clock.currentTimeMillis()).thenReturn(timestamp)
-    new GoDashboardPipeline(pipeline_model(pipeline_name, 'pipeline-label'), permissions, group_name, new TimeStampBasedCounter(clock), new FileConfigOrigin())
+    new GoDashboardPipeline(pipeline_model(pipeline_name, 'pipeline-label'), permissions, group_name, null, new TimeStampBasedCounter(clock), new FileConfigOrigin(), 0)
   }
 }

--- a/api/api-dashboard-v3/src/test/groovy/com/thoughtworks/go/apiv3/dashboard/representers/PipelineRepresenterTest.groovy
+++ b/api/api-dashboard-v3/src/test/groovy/com/thoughtworks/go/apiv3/dashboard/representers/PipelineRepresenterTest.groovy
@@ -46,7 +46,7 @@ class PipelineRepresenterTest {
     when(counter.getNext()).thenReturn(1l)
     def permissions = new Permissions(NoOne.INSTANCE, NoOne.INSTANCE, NoOne.INSTANCE, NoOne.INSTANCE)
     def pipeline = new GoDashboardPipeline(pipeline_model('pipeline_name', 'pipeline_label'),
-      permissions, "grp", new TrackingTool("http://example.com/\${ID}", "##\\d+"), counter, new FileConfigOrigin())
+      permissions, "grp", new TrackingTool("http://example.com/\${ID}", "##\\d+"), counter, new FileConfigOrigin(), 0)
     def username = new Username(new CaseInsensitiveString(SecureRandom.hex()))
 
     def json = toObject({ PipelineRepresenter.toJSON(it, pipeline, username) })
@@ -89,7 +89,7 @@ class PipelineRepresenterTest {
     def counter = mock(Counter.class)
     when(counter.getNext()).thenReturn(1l)
     def permissions = new Permissions(NoOne.INSTANCE, NoOne.INSTANCE, NoOne.INSTANCE, NoOne.INSTANCE)
-    def pipeline = new GoDashboardPipeline(pipeline_model('p1', 'p1l1'), permissions, "grp", counter, null)
+    def pipeline = new GoDashboardPipeline(pipeline_model('p1', 'p1l1'), permissions, "grp", null, counter, null, 0)
 
     def json = toObject({ PipelineRepresenter.toJSON(it, pipeline, new Username(new CaseInsensitiveString(SecureRandom.hex()))) })
 
@@ -101,7 +101,7 @@ class PipelineRepresenterTest {
     def counter = mock(Counter.class)
     when(counter.getNext()).thenReturn(1l)
     def permissions = new Permissions(NoOne.INSTANCE, NoOne.INSTANCE, NoOne.INSTANCE, NoOne.INSTANCE)
-    def pipeline = new GoDashboardPipeline(pipeline_model('p1', 'p1l1', false, true, "under construction"), permissions, "grp", counter, null)
+    def pipeline = new GoDashboardPipeline(pipeline_model('p1', 'p1l1', false, true, "under construction"), permissions, "grp", null, counter, null, 0)
 
     def json = toObject({ PipelineRepresenter.toJSON(it, pipeline, new Username(new CaseInsensitiveString(SecureRandom.hex()))) })
 
@@ -122,7 +122,7 @@ class PipelineRepresenterTest {
       when(counter.getNext()).thenReturn(1l)
       def permissions = new Permissions(NoOne.INSTANCE, NoOne.INSTANCE, NoOne.INSTANCE, Everyone.INSTANCE)
       def origin = new RepoConfigOrigin(new ConfigRepoConfig(MaterialConfigsMother.gitMaterialConfig(), "plugin", "repo1"), "rev1")
-      def pipeline = new GoDashboardPipeline(pipeline_model('pipeline_name', 'pipeline_label'), permissions, "grp", counter, origin)
+      def pipeline = new GoDashboardPipeline(pipeline_model('pipeline_name', 'pipeline_label'), permissions, "grp", null, counter, origin, 0)
       def username = new Username(new CaseInsensitiveString(SecureRandom.hex()))
 
       def actualJson = toObject({ PipelineRepresenter.toJSON(it, pipeline, username) })
@@ -140,7 +140,7 @@ class PipelineRepresenterTest {
       when(counter.getNext()).thenReturn(1l)
       def permissions = new Permissions(NoOne.INSTANCE, NoOne.INSTANCE, Everyone.INSTANCE, NoOne.INSTANCE)
       def origin = new RepoConfigOrigin(new ConfigRepoConfig(MaterialConfigsMother.gitMaterialConfig(), "plugin", "repo1"), "rev1")
-      def pipeline = new GoDashboardPipeline(pipeline_model('pipeline_name', 'pipeline_label'), permissions, "grp", counter, origin)
+      def pipeline = new GoDashboardPipeline(pipeline_model('pipeline_name', 'pipeline_label'), permissions, "grp", null, counter, origin, 0)
       def username = new Username(new CaseInsensitiveString(SecureRandom.hex()))
 
       def actualJson = toObject({ PipelineRepresenter.toJSON(it, pipeline, username) })
@@ -158,7 +158,7 @@ class PipelineRepresenterTest {
       when(counter.getNext()).thenReturn(1l)
       def permissions = new Permissions(NoOne.INSTANCE, Everyone.INSTANCE, NoOne.INSTANCE, NoOne.INSTANCE)
       def origin = new RepoConfigOrigin(new ConfigRepoConfig(MaterialConfigsMother.gitMaterialConfig(), "plugin", "repo1"), "rev1")
-      def pipeline = new GoDashboardPipeline(pipeline_model('pipeline_name', 'pipeline_label'), permissions, "grp", counter, origin)
+      def pipeline = new GoDashboardPipeline(pipeline_model('pipeline_name', 'pipeline_label'), permissions, "grp", null, counter, origin, 0)
       def username = new Username(new CaseInsensitiveString(SecureRandom.hex()))
 
       def actualJson = toObject({ PipelineRepresenter.toJSON(it, pipeline, username) })

--- a/api/api-server-maintenance-mode-v1/src/test/groovy/com/thoughtworks/go/apiv1/servermaintenancemode/ServerMaintenanceModeControllerV1Test.groovy
+++ b/api/api-server-maintenance-mode-v1/src/test/groovy/com/thoughtworks/go/apiv1/servermaintenancemode/ServerMaintenanceModeControllerV1Test.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 ThoughtWorks, Inc.
+ * Copyright 2019 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -342,7 +342,7 @@ class ServerMaintenanceModeControllerV1Test implements SecurityServiceTrait, Con
         allStages.add(new StageInstanceModel("stage1", "1", allJobs))
         def pipelineInstanceModel = new PipelineInstanceModel(pipelineName, 1, pipelineName, null, allStages)
         pipelineModel.addPipelineInstance(pipelineInstanceModel)
-        return new GoDashboardPipeline(pipelineModel, null, "group1", new TimeStampBasedCounter(testingClock), new FileConfigOrigin())
+        return new GoDashboardPipeline(pipelineModel, null, "group1", null, new TimeStampBasedCounter(testingClock), new FileConfigOrigin(), 0)
       }
     }
   }

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/PipelineConfig.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/PipelineConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 ThoughtWorks, Inc.
+ * Copyright 2019 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -119,6 +119,7 @@ public class PipelineConfig extends BaseCollection<StageConfig> implements Param
     private CaseInsensitiveString templateName;
 
     private ConfigOrigin origin;
+    private int displayOrderWeight = -1;
 
     private boolean templateApplied;
 
@@ -1038,5 +1039,13 @@ public class PipelineConfig extends BaseCollection<StageConfig> implements Param
 
     public String getOriginDisplayName() {
         return getOrigin() != null ? getOrigin().displayName() : new FileConfigOrigin().displayName();
+    }
+
+    public void setDisplayOrderWeight(int displayOrderWeight) {
+        this.displayOrderWeight = displayOrderWeight;
+    }
+
+    public int getDisplayOrderWeight() {
+        return displayOrderWeight;
     }
 }

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/configrepo/v1/JsonMessageHandler1_0.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/configrepo/v1/JsonMessageHandler1_0.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 ThoughtWorks, Inc.
+ * Copyright 2019 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,7 +38,7 @@ import java.util.Map;
 
 public class JsonMessageHandler1_0 implements JsonMessageHandler {
 
-    static final int CURRENT_CONTRACT_VERSION = 3;
+    static final int CURRENT_CONTRACT_VERSION = 4;
     private static final Logger LOGGER = LoggerFactory.getLogger(JsonMessageHandler1_0.class);
     private final GsonCodec codec;
     private final ConfigRepoMigrator migrator;

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/configrepo/v2/JsonMessageHandler2_0.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/configrepo/v2/JsonMessageHandler2_0.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 ThoughtWorks, Inc.
+ * Copyright 2019 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,8 +39,17 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
 
+/**
+ * Changes from V1:
+ *   - Introduce parse-content (for validation + CLI).
+ *   - Introduce get-icon (to show in the UI).
+ *   - Introduce pipeline-export call (to allow export/conversion of pipeline back to the original format).
+ *   - Introduce get-capabilities call (to tell whether the plugin supports exports and parse content).
+ *
+ *   - Introduce target_version of 4: Allow display_order_weight at pipeline level.
+ */
 public class JsonMessageHandler2_0 implements JsonMessageHandler {
-    static final int CURRENT_CONTRACT_VERSION = 3;
+    static final int CURRENT_CONTRACT_VERSION = 4;
     private static final Logger LOGGER = LoggerFactory.getLogger(JsonMessageHandler2_0.class);
     private final GsonCodec codec;
     private final ConfigRepoMigrator migrator;

--- a/plugin-infra/go-plugin-access/src/main/resources/config-repo/migrations/4.json
+++ b/plugin-infra/go-plugin-access/src/main/resources/config-repo/migrations/4.json
@@ -1,0 +1,21 @@
+[
+  {
+    "operation": "shift",
+    "spec": {
+      "target_version": {
+        "#4": "&1" // Set target version to 4.
+      },
+      "*": "&"
+    }
+  },
+  {
+    "operation": "default",
+    "spec": {
+      "pipelines[]": {
+        "*": {
+          "display_order_weight": -1
+        }
+      }
+    }
+  }
+]

--- a/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/configrepo/ConfigRepoDocumentMother.java
+++ b/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/configrepo/ConfigRepoDocumentMother.java
@@ -24,15 +24,15 @@ import java.util.Map;
 import static com.bazaarvoice.jolt.utils.JoltUtils.remove;
 import static com.bazaarvoice.jolt.utils.JoltUtils.store;
 
-public class ConfigRepoDocumentMother {
-    public String versionOneWithLockingSetTo(boolean enablePipelineLockingValue) {
+class ConfigRepoDocumentMother {
+    String versionOneWithLockingSetTo(boolean enablePipelineLockingValue) {
         Map<String, Object> map = getJSONFor("/v1_simple.json");
         store(map, "1", "target_version");
         store(map, enablePipelineLockingValue, "pipelines", 0, "enable_pipeline_locking");
         return JsonUtils.toJsonString(map);
     }
 
-    public String versionOneComprehensiveWithNoLocking() {
+    String versionOneComprehensiveWithNoLocking() {
         Map<String, Object> map = getJSONFor("/v1_comprehensive.json");
         store(map, "1", "target_version");
         remove(map, "pipelines", 0, "enable_pipeline_locking");
@@ -49,27 +49,39 @@ public class ConfigRepoDocumentMother {
         }
     }
 
-    public String versionTwoComprehensive() {
+    String versionTwoComprehensive() {
         return JsonUtils.toJsonString(getJSONFor("/v2_comprehensive.json"));
     }
 
-    public String v2WithFetchTask() {
+    String v2WithFetchTask() {
         return JsonUtils.toJsonString(getJSONFor("/v2_with_fetch_tasks.json"));
     }
 
-    public String v2WithFetchExternalArtifactTask() {
+    String v2WithFetchExternalArtifactTask() {
         return JsonUtils.toJsonString(getJSONFor("/v2_with_fetch_external_artifact_task.json"));
     }
 
-    public String v3Comprehensive() {
+    String v3Comprehensive() {
         return JsonUtils.toJsonString(getJSONFor("/v3_comprehensive.json"));
     }
 
-    public String v3WithFetchTask() {
+    String v3WithFetchTask() {
         return JsonUtils.toJsonString(getJSONFor("/v3_with_fetch_tasks.json"));
     }
 
-    public String v3WithFetchExternalArtifactTask() {
+    String v3WithFetchExternalArtifactTask() {
         return JsonUtils.toJsonString(getJSONFor("/v3_with_fetch_external_artifact_task.json"));
+    }
+
+    String v3ComprehensiveWithDisplayOrderWeightsOf10AndNull() {
+        return JsonUtils.toJsonString(getJSONFor("/v3_comprehensive_with_display_order_weight_which_was_introduced_in_v4_for_one_pipeline.json"));
+    }
+
+    String v4ComprehensiveWithDisplayOrderWeightOfMinusOneForBothPipelines() {
+        return JsonUtils.toJsonString(getJSONFor("/v4_comprehensive_with_display_order_weight_of_minus_one_for_both_pipelines.json"));
+    }
+
+    String v4ComprehensiveWithDisplayOrderWeightsOf10AndMinusOne() {
+        return JsonUtils.toJsonString(getJSONFor("/v4_comprehensive_with_display_order_weights_of_10_and_minus_one.json"));
     }
 }

--- a/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/configrepo/ConfigRepoMigratorTest.java
+++ b/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/configrepo/ConfigRepoMigratorTest.java
@@ -16,11 +16,11 @@
 
 package com.thoughtworks.go.plugin.access.configrepo;
 
-import net.javacrumbs.jsonunit.fluent.JsonFluentAssert;
 import org.junit.Before;
 import org.junit.Test;
 
 import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class ConfigRepoMigratorTest {
     private ConfigRepoMigrator migrator;
@@ -106,5 +106,27 @@ public class ConfigRepoMigratorTest {
         String transformedJSON = migrator.migrate(oldJSON, 3);
 
         assertThatJson(newJson).isEqualTo(transformedJSON);
+    }
+
+    @Test
+    public void migrateV3ToV4_shouldAddADefaultDisplayOrderWeightToPipelines() {
+        ConfigRepoDocumentMother documentMother = new ConfigRepoDocumentMother();
+        String oldJSON = documentMother.v3Comprehensive();
+        String newJSON = documentMother.v4ComprehensiveWithDisplayOrderWeightOfMinusOneForBothPipelines();
+
+        String transformedJSON = migrator.migrate(oldJSON, 4);
+
+        assertThatJson(newJSON).isEqualTo(transformedJSON);
+    }
+
+    @Test
+    public void migrateV3ToV4_shouldDefaultDisplayOrderWeightsToMinusOneOnlyForPipelinesWithoutIt() {
+        ConfigRepoDocumentMother documentMother = new ConfigRepoDocumentMother();
+        String oldJSON = documentMother.v3ComprehensiveWithDisplayOrderWeightsOf10AndNull();
+        String newJSON = documentMother.v4ComprehensiveWithDisplayOrderWeightsOf10AndMinusOne();
+
+        String transformedJSON = migrator.migrate(oldJSON, 4);
+
+        assertThatJson(newJSON).isEqualTo(transformedJSON);
     }
 }

--- a/plugin-infra/go-plugin-access/src/test/resources/v3_comprehensive_with_display_order_weight_which_was_introduced_in_v4_for_one_pipeline.json
+++ b/plugin-infra/go-plugin-access/src/test/resources/v3_comprehensive_with_display_order_weight_which_was_introduced_in_v4_for_one_pipeline.json
@@ -1,0 +1,93 @@
+{
+  "target_version": "3",
+  "pipelines": [
+    {
+      "name": "firstpipe",
+      "environment_variables": [
+        {
+          "name": "env1",
+          "value": "value1"
+        }
+      ],
+      "lock_behavior": "lockOnFailure",
+      "group": "configrepo-example",
+      "display_order_weight": 10,
+      "materials": [
+        {
+          "url": "https://github.com/tomzo/gocd-json-config-example.git",
+          "type": "git"
+        }
+      ],
+      "stages": [
+        {
+          "name": "build",
+          "fetch_materials": true,
+          "never_cleanup_artifacts": false,
+          "clean_working_directory": false,
+          "environment_variables": [],
+          "jobs": [
+            {
+              "name": "build",
+              "environment_variables": [],
+              "tabs": [],
+              "resources": [],
+              "artifacts": [],
+              "properties": [],
+              "run_instance_count": null,
+              "timeout": 0,
+              "tasks": [
+                {
+                  "type": "rake"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "secondpipeline",
+      "environment_variables": [
+        {
+          "name": "env2",
+          "value": "value2"
+        }
+      ],
+      "lock_behavior": "none",
+      "group": "configrepo-example-2",
+      "materials": [
+        {
+          "url": "https://github.com/tomzo/gocd-json-config-example-2.git",
+          "type": "git"
+        }
+      ],
+      "stages": [
+        {
+          "name": "build-2",
+          "fetch_materials": true,
+          "never_cleanup_artifacts": false,
+          "clean_working_directory": false,
+          "environment_variables": [],
+          "jobs": [
+            {
+              "name": "build-2",
+              "environment_variables": [],
+              "tabs": [],
+              "resources": [],
+              "artifacts": [],
+              "properties": [],
+              "run_instance_count": null,
+              "timeout": 0,
+              "tasks": [
+                {
+                  "type": "rake"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "errors": []
+}

--- a/plugin-infra/go-plugin-access/src/test/resources/v4_comprehensive_with_display_order_weight_of_minus_one_for_both_pipelines.json
+++ b/plugin-infra/go-plugin-access/src/test/resources/v4_comprehensive_with_display_order_weight_of_minus_one_for_both_pipelines.json
@@ -1,0 +1,94 @@
+{
+  "target_version": "4",
+  "pipelines": [
+    {
+      "name": "firstpipe",
+      "environment_variables": [
+        {
+          "name": "env1",
+          "value": "value1"
+        }
+      ],
+      "lock_behavior": "lockOnFailure",
+      "group": "configrepo-example",
+      "display_order_weight": -1,
+      "materials": [
+        {
+          "url": "https://github.com/tomzo/gocd-json-config-example.git",
+          "type": "git"
+        }
+      ],
+      "stages": [
+        {
+          "name": "build",
+          "fetch_materials": true,
+          "never_cleanup_artifacts": false,
+          "clean_working_directory": false,
+          "environment_variables": [],
+          "jobs": [
+            {
+              "name": "build",
+              "environment_variables": [],
+              "tabs": [],
+              "resources": [],
+              "artifacts": [],
+              "properties": [],
+              "run_instance_count": null,
+              "timeout": 0,
+              "tasks": [
+                {
+                  "type": "rake"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "secondpipeline",
+      "environment_variables": [
+        {
+          "name": "env2",
+          "value": "value2"
+        }
+      ],
+      "lock_behavior": "none",
+      "group": "configrepo-example-2",
+      "display_order_weight": -1,
+      "materials": [
+        {
+          "url": "https://github.com/tomzo/gocd-json-config-example-2.git",
+          "type": "git"
+        }
+      ],
+      "stages": [
+        {
+          "name": "build-2",
+          "fetch_materials": true,
+          "never_cleanup_artifacts": false,
+          "clean_working_directory": false,
+          "environment_variables": [],
+          "jobs": [
+            {
+              "name": "build-2",
+              "environment_variables": [],
+              "tabs": [],
+              "resources": [],
+              "artifacts": [],
+              "properties": [],
+              "run_instance_count": null,
+              "timeout": 0,
+              "tasks": [
+                {
+                  "type": "rake"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "errors": []
+}

--- a/plugin-infra/go-plugin-access/src/test/resources/v4_comprehensive_with_display_order_weights_of_10_and_minus_one.json
+++ b/plugin-infra/go-plugin-access/src/test/resources/v4_comprehensive_with_display_order_weights_of_10_and_minus_one.json
@@ -1,0 +1,94 @@
+{
+  "target_version": "4",
+  "pipelines": [
+    {
+      "name": "firstpipe",
+      "environment_variables": [
+        {
+          "name": "env1",
+          "value": "value1"
+        }
+      ],
+      "lock_behavior": "lockOnFailure",
+      "group": "configrepo-example",
+      "display_order_weight": 10,
+      "materials": [
+        {
+          "url": "https://github.com/tomzo/gocd-json-config-example.git",
+          "type": "git"
+        }
+      ],
+      "stages": [
+        {
+          "name": "build",
+          "fetch_materials": true,
+          "never_cleanup_artifacts": false,
+          "clean_working_directory": false,
+          "environment_variables": [],
+          "jobs": [
+            {
+              "name": "build",
+              "environment_variables": [],
+              "tabs": [],
+              "resources": [],
+              "artifacts": [],
+              "properties": [],
+              "run_instance_count": null,
+              "timeout": 0,
+              "tasks": [
+                {
+                  "type": "rake"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "secondpipeline",
+      "environment_variables": [
+        {
+          "name": "env2",
+          "value": "value2"
+        }
+      ],
+      "lock_behavior": "none",
+      "group": "configrepo-example-2",
+      "display_order_weight": -1,
+      "materials": [
+        {
+          "url": "https://github.com/tomzo/gocd-json-config-example-2.git",
+          "type": "git"
+        }
+      ],
+      "stages": [
+        {
+          "name": "build-2",
+          "fetch_materials": true,
+          "never_cleanup_artifacts": false,
+          "clean_working_directory": false,
+          "environment_variables": [],
+          "jobs": [
+            {
+              "name": "build-2",
+              "environment_variables": [],
+              "tabs": [],
+              "resources": [],
+              "artifacts": [],
+              "properties": [],
+              "run_instance_count": null,
+              "timeout": 0,
+              "tasks": [
+                {
+                  "type": "rake"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "errors": []
+}

--- a/plugin-infra/go-plugin-config-repo/src/main/java/com/thoughtworks/go/plugin/configrepo/contract/CRPipeline.java
+++ b/plugin-infra/go-plugin-config-repo/src/main/java/com/thoughtworks/go/plugin/configrepo/contract/CRPipeline.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 ThoughtWorks, Inc.
+ * Copyright 2019 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,6 +38,7 @@ public class CRPipeline extends CRBase {
     private Collection<CRMaterial> materials = new ArrayList<>();
     private List<CRStage> stages = new ArrayList<>();
     private String template;
+    private int display_order_weight = -1;
 
     public CRPipeline(){}
     public CRPipeline(String name, String groupName, CRMaterial material, String template, CRStage... stages)
@@ -399,5 +400,13 @@ public class CRPipeline extends CRBase {
 
     public void setLock_behavior(String lock_behavior) {
         this.lock_behavior = lock_behavior;
+    }
+
+    public void setDisplayOrderWeight(int display_order_weight) {
+        this.display_order_weight = display_order_weight;
+    }
+
+    public int getDisplayOrderWeight() {
+        return display_order_weight;
     }
 }

--- a/server/src/main/java/com/thoughtworks/go/config/ConfigConverter.java
+++ b/server/src/main/java/com/thoughtworks/go/config/ConfigConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 ThoughtWorks, Inc.
+ * Copyright 2019 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -652,6 +652,7 @@ public class ConfigConverter {
         }
 
         pipelineConfig.setLockBehaviorIfNecessary(crPipeline.lockBehavior());
+        pipelineConfig.setDisplayOrderWeight(crPipeline.getDisplayOrderWeight());
 
         return pipelineConfig;
     }
@@ -703,12 +704,13 @@ public class ConfigConverter {
         crPipeline.setTimer(timerConfigToCRTimer(pipelineConfig.getTimer()));
         crPipeline.setLock_behavior(pipelineConfig.getLockBehavior());
 
-
         if (pipelineConfig.getMingleConfig().isDefined()) {
             crPipeline.setMingle(mingleToCRMingle(pipelineConfig.getMingleConfig()));
         }
 
         crPipeline.setLabelTemplate(pipelineConfig.getLabelTemplate());
+        crPipeline.setDisplayOrderWeight(pipelineConfig.getDisplayOrderWeight());
+
         return crPipeline;
     }
 

--- a/server/src/main/java/com/thoughtworks/go/server/dashboard/AbstractDashboardGroup.java
+++ b/server/src/main/java/com/thoughtworks/go/server/dashboard/AbstractDashboardGroup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 ThoughtWorks, Inc.
+ * Copyright 2019 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,10 +26,11 @@ import java.io.OutputStreamWriter;
 import java.io.UncheckedIOException;
 import java.security.DigestOutputStream;
 import java.security.MessageDigest;
-import java.util.Collection;
-import java.util.LinkedHashMap;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
+import java.util.stream.Collectors;
+
+import static java.util.Comparator.comparing;
+import static java.util.stream.Collectors.toList;
 
 public abstract class AbstractDashboardGroup implements DashboardGroup {
     private String name;
@@ -45,8 +46,13 @@ public abstract class AbstractDashboardGroup implements DashboardGroup {
     }
 
     @Override
-    public Set<String> pipelines() {
-        return pipelines.keySet();
+    public List<String> pipelines() {
+        return pipelines
+                .values()
+                .stream()
+                .sorted(comparing(GoDashboardPipeline::getdisplayOrderWeight))
+                .map(pipeline -> pipeline.name().toString())
+                .collect(toList());
     }
 
     public abstract boolean canAdminister(Username username);

--- a/server/src/main/java/com/thoughtworks/go/server/dashboard/DashboardGroup.java
+++ b/server/src/main/java/com/thoughtworks/go/server/dashboard/DashboardGroup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 ThoughtWorks, Inc.
+ * Copyright 2019 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,12 +19,12 @@ package com.thoughtworks.go.server.dashboard;
 import com.thoughtworks.go.server.domain.Username;
 
 import java.util.Collection;
-import java.util.Set;
+import java.util.List;
 
 public interface DashboardGroup {
     String name();
 
-    Set<String> pipelines();
+    List<String> pipelines();
 
     boolean canAdminister(Username username);
 

--- a/server/src/main/java/com/thoughtworks/go/server/dashboard/GoDashboardCurrentStateLoader.java
+++ b/server/src/main/java/com/thoughtworks/go/server/dashboard/GoDashboardCurrentStateLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 ThoughtWorks, Inc.
+ * Copyright 2019 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -144,7 +144,7 @@ public class GoDashboardCurrentStateLoader {
     private GoDashboardPipeline createGoDashboardPipeline(PipelineConfig pipelineConfig, Permissions permissions, PipelineInstanceModels historyForDashboard, PipelineConfigs group) {
         PipelineModel pipelineModel = pipelineModelFor(pipelineConfig, historyForDashboard);
         Optional<TrackingTool> trackingTool = pipelineConfig.getIntegratedTrackingTool();
-        return new GoDashboardPipeline(pipelineModel, permissions, group.getGroup(), trackingTool.orElse(null), timeStampBasedCounter, pipelineConfig.getOrigin());
+        return new GoDashboardPipeline(pipelineModel, permissions, group.getGroup(), trackingTool.orElse(null), timeStampBasedCounter, pipelineConfig.getOrigin(), pipelineConfig.getDisplayOrderWeight());
     }
 
     private PipelineModel pipelineModelFor(PipelineConfig pipelineConfig, PipelineInstanceModels historyForDashboard) {

--- a/server/src/main/java/com/thoughtworks/go/server/dashboard/GoDashboardPipeline.java
+++ b/server/src/main/java/com/thoughtworks/go/server/dashboard/GoDashboardPipeline.java
@@ -34,18 +34,16 @@ public class GoDashboardPipeline {
     private final TrackingTool trackingTool;
     private final long lastUpdatedTimeStamp;
     private ConfigOrigin origin;
+    private int displayOrderWeight;
 
-    public GoDashboardPipeline(PipelineModel pipelineModel, Permissions permissions, String groupName, TrackingTool trackingTool, Counter timeStampBasedCounter, ConfigOrigin origin) {
+    public GoDashboardPipeline(PipelineModel pipelineModel, Permissions permissions, String groupName, TrackingTool trackingTool, Counter timeStampBasedCounter, ConfigOrigin origin, int displayOrderWeight) {
         this.pipelineModel = pipelineModel;
         this.permissions = permissions;
         this.groupName = groupName;
         this.trackingTool = trackingTool;
         this.lastUpdatedTimeStamp = timeStampBasedCounter.getNext();
         this.origin = origin;
-    }
-
-    public GoDashboardPipeline(PipelineModel pipelineModel, Permissions permissions, String groupName, Counter timeStampBasedCounter, ConfigOrigin origin) {
-        this(pipelineModel, permissions, groupName, null, timeStampBasedCounter, origin);
+        this.displayOrderWeight = displayOrderWeight;
     }
 
     public String groupName() {
@@ -130,5 +128,9 @@ public class GoDashboardPipeline {
 
     public boolean isLocal() {
         return origin == null || origin.isLocal();
+    }
+
+    public Integer getdisplayOrderWeight() {
+        return displayOrderWeight;
     }
 }

--- a/server/src/test-fast/java/com/thoughtworks/go/config/ConfigConverterTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/config/ConfigConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 ThoughtWorks, Inc.
+ * Copyright 2019 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -1053,6 +1053,7 @@ public class ConfigConverterTest {
     public void shouldConvertPipeline() {
         CRPipeline crPipeline = new CRPipeline("pipename", "group1", "label", LOCK_VALUE_LOCK_ON_FAILURE,
                 trackingTool, null, timer, environmentVariables, materials, stages, null, parameters);
+        crPipeline.setDisplayOrderWeight(10);
 
         PipelineConfig pipelineConfig = configConverter.toPipelineConfig(crPipeline, context);
         assertThat(pipelineConfig.name().toLower(), is("pipename"));
@@ -1063,6 +1064,7 @@ public class ConfigConverterTest {
         assertThat(pipelineConfig.getTimer().getTimerSpec(), is("timer"));
         assertThat(pipelineConfig.getLabelTemplate(), is("label"));
         assertThat(pipelineConfig.isLockableOnFailure(), is(true));
+        assertThat(pipelineConfig.getDisplayOrderWeight(), is(10));
     }
 
     @Test
@@ -1221,6 +1223,7 @@ public class ConfigConverterTest {
         pipeline.setTimer(timerConfig);
         pipeline.setTrackingTool(trackingTool);
         pipeline.addEnvironmentVariable("testing", "123");
+        pipeline.setDisplayOrderWeight(10);
 
         StageConfig stage = new StageConfig();
         stage.setName(new CaseInsensitiveString("build"));
@@ -1249,6 +1252,7 @@ public class ConfigConverterTest {
         assertThat(crPipeline.getStages().get(0).getName(), is("build"));
         assertThat(crPipeline.getStages().get(0).getJobs().size(), is(1));
         assertNull(crPipeline.getMingle());
+        assertThat(crPipeline.getDisplayOrderWeight(), is(10));
     }
 
     @Test

--- a/server/src/test-fast/java/com/thoughtworks/go/server/dashboard/GoDashboardPipelineMother.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/dashboard/GoDashboardPipelineMother.java
@@ -36,6 +36,6 @@ public class GoDashboardPipelineMother {
 
     public static GoDashboardPipeline pipeline(String pipelineName, String groupName, Permissions permissions) {
         return new GoDashboardPipeline(new PipelineModel(pipelineName, false, false, notPaused()),
-                permissions, groupName, new TimeStampBasedCounter(new SystemTimeClock()), new FileConfigOrigin());
+                permissions, groupName, null, new TimeStampBasedCounter(new SystemTimeClock()), new FileConfigOrigin(), 0);
     }
 }

--- a/server/src/test-fast/java/com/thoughtworks/go/server/dashboard/GoDashboardPipelineTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/dashboard/GoDashboardPipelineTest.java
@@ -44,7 +44,7 @@ public class GoDashboardPipelineTest {
                 new AllowedUsers(s("admin", "root"), Collections.emptySet()),
                 Everyone.INSTANCE);
 
-        GoDashboardPipeline pipeline = new GoDashboardPipeline(new PipelineModel("pipeline1", false, false, notPaused()), permissions, "group1", mock(TimeStampBasedCounter.class), new FileConfigOrigin());
+        GoDashboardPipeline pipeline = new GoDashboardPipeline(new PipelineModel("pipeline1", false, false, notPaused()), permissions, "group1", null, mock(TimeStampBasedCounter.class), new FileConfigOrigin(), 0);
 
         assertThat(pipeline.canBeViewedBy("viewer1"), is(true));
         assertThat(pipeline.canBeViewedBy("viewer2"), is(true));
@@ -62,7 +62,7 @@ public class GoDashboardPipelineTest {
                 NoOne.INSTANCE);
 
         GoDashboardPipeline pipeline = new GoDashboardPipeline(new PipelineModel("pipeline1", false, false, notPaused()),
-                permissions, "group1", mock(TimeStampBasedCounter.class), new FileConfigOrigin());
+                permissions, "group1", null, mock(TimeStampBasedCounter.class), new FileConfigOrigin(), 0);
 
         assertTrue(pipeline.canBeOperatedBy("operator1"));
         assertFalse(pipeline.canBeOperatedBy("viewer1"));
@@ -77,7 +77,7 @@ public class GoDashboardPipelineTest {
                 NoOne.INSTANCE);
 
         GoDashboardPipeline pipeline = new GoDashboardPipeline(new PipelineModel("pipeline1", false, false, notPaused()),
-                permissions, "group1", mock(TimeStampBasedCounter.class), new FileConfigOrigin());
+                permissions, "group1", null, mock(TimeStampBasedCounter.class), new FileConfigOrigin(), 0);
 
         assertTrue(pipeline.canBeAdministeredBy("admin1"));
         assertFalse(pipeline.canBeAdministeredBy("viewer1"));
@@ -92,7 +92,7 @@ public class GoDashboardPipelineTest {
                 new AllowedUsers(s("pipeline_operator"), Collections.emptySet()));
 
         GoDashboardPipeline pipeline = new GoDashboardPipeline(new PipelineModel("pipeline1", false, false, notPaused()),
-                permissions, "group1", mock(TimeStampBasedCounter.class), new FileConfigOrigin());
+                permissions, "group1", null, mock(TimeStampBasedCounter.class), new FileConfigOrigin(), 0);
 
         assertTrue(pipeline.isPipelineOperator("pipeline_operator"));
         assertFalse(pipeline.canBeAdministeredBy("viewer1"));
@@ -102,7 +102,7 @@ public class GoDashboardPipelineTest {
     public void shouldSetTheLastUpdateTime() throws Exception {
         TimeStampBasedCounter provider = mock(TimeStampBasedCounter.class);
         when(provider.getNext()).thenReturn(1000L);
-        GoDashboardPipeline pipeline = new GoDashboardPipeline(new PipelineModel("pipeline1", false, false, notPaused()), null, "group1", provider, new FileConfigOrigin());
+        GoDashboardPipeline pipeline = new GoDashboardPipeline(new PipelineModel("pipeline1", false, false, notPaused()), null, "group1", null, provider, new FileConfigOrigin(), 0);
 
         assertThat(pipeline.getLastUpdatedTimeStamp(), is(1000L));
     }


### PR DESCRIPTION
Attempt to implement gocd/gocd#6042.

## How it works:

At the level of a pipeline (for instance, here), add a property called: `display_order_weight` set to any integer. When the repository is parsed and the pipeline is shown in the dashboard, the order of the pipelines in each group is based on their weight, lowest to highest. Pipelines defined in XML have a weight of `-1` and there is no way provided to change that.

Ideally, the `format_version` of the JSON file should be changed to `4`, but earlier versions will also work.

Example:

```json
{
  "format_version" : 4,
  "display_order_weight": 11,

  "name": "allmaterials",
  "group" : "configrepo-example",
  "enable_pipeline_locking": true,
  "environment_variables": [],

  "materials": [
    {
      "url": "https://github.com/tomzo/gocd-json-config-example.git",
      "type": "git",
      "name" : "mygit",
      "destination" : "mydest"
    }
...
```

## Todo:

- [ ] Update plugin API documentation.
- [ ] Update functional tests?
- [ ] Update YAML plugin + documentation.
- [ ] Update JSON plugin + documentation.
- [ ] Update Groovy plugin + documentation.
- [ ] Consider: Is `display_order_weight` the right term to use?

**Note**: This PR can be merged now. This doesn't need to wait for the todos. But, if no one has concerns and this gets merged, the rest can be worked on.

## Scenarios considered:

1. Target version set to 4 and `display_order_weight` set to `10`.
2. Target version set to 3 and `display_order_weight` set to `10`. Doesn't complain. Uses `10`.
3. Target version set to 4 and `display_order_weight` set to `-10` (shows up before pipelines defined in XML).
4. Target version set to `4` and no `display_order_weight` is set. Defaults to `-1`.
5. Different pipelines having the same weight. This works fine. The order (within those pipelines with the same weight) is indeterminate. These values are weights and not the order itself.
6. Export to JSON/YAML might not export `display_order_weight`. I'm not too worried about it. I think it's ok not to.

## Trying it out manually:

After building using the code from this PR, adding this repository as a JSON code repo, should work: https://github.com/arvindsv/gocd_6043

Since the JSON plugin doesn't really do much validation, it will work, even without any support added to it.

## Reviewing this change:

It's not very complicated.

1. A temporary weight [is stored](https://github.com/gocd/gocd/pull/6043/files#diff-5e12ba8869542f14466578e303653372R122) at the pipeline config level.

2. A [jolt migration](https://github.com/gocd/gocd/pull/6043/files#diff-ab16a1bef4eacd64846d7ccc238d4c5bR2) which is [tested here](https://github.com/gocd/gocd/pull/6043/files#diff-06a0928ddb219b95df8daf2c479161d3R112) takes care of defaulting the value to -1. It's just to maintain consistency. This wasn't strictly needed.

3. [This is where](https://github.com/gocd/gocd/pull/6043/files#diff-3bf6efba239b7b48bdc3744936990418R49) order used to get lost, earlier.

4. [This test](https://github.com/gocd/gocd/pull/6043/files#diff-3c33665342fbf09d601a0d63c4448e8fR148) shows how it is used in the dashboard representer, just before sending it.

Most of the rest of the code is test files, most of which consist of just some small refactoring.
