### PR TITLE
Fix regex to be in line with `FilePathTypeValidator`.

### DIFF
--- a/config/config-server/src/main/resources/cruise-config.xsd
+++ b/config/config-server/src/main/resources/cruise-config.xsd
@@ -971,7 +971,7 @@
   </xsd:element>
   <xsd:simpleType name="filePathType">
     <xsd:restriction base="xsd:string" xml:space="default">
-      <xsd:pattern value="(([.]\/)?[.][^. ]+)|([^. ].+[^. ])|([^. ][^. ])|([^. ])"/>
+      <xsd:pattern value="(([.]\\/)?[.][^. ]+)|([^. ].+[^. ])|([^. ][^. ])|([^. ])"/>
     </xsd:restriction>
   </xsd:simpleType>
   <xsd:complexType name="timerType">


### PR DESCRIPTION
Fixes #6037.