### PR TITLE
Part - 2: Support for Secret Params in Materials

### DIFF
--- a/common/src/test/java/com/thoughtworks/go/config/materials/tfs/TfsMaterialConfigUpdateTest.java
+++ b/common/src/test/java/com/thoughtworks/go/config/materials/tfs/TfsMaterialConfigUpdateTest.java
@@ -279,7 +279,7 @@ class TfsMaterialConfigUpdateTest {
             tfsMaterialConfig.setUrl("https://user:pass@{{SECRET:[secret_config_id][hostname]}}/foo.git");
 
             assertThat(tfsMaterialConfig.validateTree(validationContext)).isFalse();
-            assertThat(tfsMaterialConfig.errors().on("url")).isEqualTo("Only username and password can be specified as secret params");
+            assertThat(tfsMaterialConfig.errors().on("url")).isEqualTo("Only password can be specified as secret params");
         }
 
         @Test
@@ -288,14 +288,16 @@ class TfsMaterialConfigUpdateTest {
             tfsMaterialConfig.setUrl("https://{{SECRET:[secret_config_id_1][user]}}:{{SECRET:[secret_config_id_2][pass]}}@host/foo.git");
 
             assertThat(tfsMaterialConfig.validateTree(validationContext)).isFalse();
-            assertThat(tfsMaterialConfig.errors().on("url")).isEqualTo("Secret configs '[secret_config_id_1, secret_config_id_2]' does not exist");
+            assertThat(tfsMaterialConfig.errors().get("url"))
+                    .hasSize(2)
+                    .contains("Only password can be specified as secret params", "Secret configs secret_config_id_1, secret_config_id_2 does not exist");
         }
 
         @Test
         void shouldNotFailIfSecretConfigWithIdPresentForConfiguredSecretParams() {
             final SecretConfig secretConfig = new SecretConfig("secret_config_id", "cd.go.secret.file");
             final ValidationContext validationContext = mockValidationContextForSecretParams(secretConfig);
-            tfsMaterialConfig.setUrl("https://{{SECRET:[secret_config_id][username]}}:password@host/foo.git");
+            tfsMaterialConfig.setUrl("https://username:{{SECRET:[secret_config_id][password]}}@host/foo.git");
 
             assertThat(tfsMaterialConfig.validateTree(validationContext)).isTrue();
             assertThat(tfsMaterialConfig.errors().getAll()).isEmpty();
@@ -342,7 +344,7 @@ class TfsMaterialConfigUpdateTest {
             tfsMaterialConfig.setPassword("{{SECRET:[secret_config_id][password]}}");
 
             assertThat(tfsMaterialConfig.validateTree(validationContext)).isFalse();
-            assertThat(tfsMaterialConfig.errors().on("encryptedPassword")).isEqualTo("Secret configs '[secret_config_id]' does not exist");
+            assertThat(tfsMaterialConfig.errors().on("encryptedPassword")).isEqualTo("Secret configs secret_config_id does not exist");
         }
     }
 

--- a/common/src/test/java/com/thoughtworks/go/config/materials/tfs/TfsMaterialConfigUpdateTest.java
+++ b/common/src/test/java/com/thoughtworks/go/config/materials/tfs/TfsMaterialConfigUpdateTest.java
@@ -16,9 +16,7 @@
 
 package com.thoughtworks.go.config.materials.tfs;
 
-import com.thoughtworks.go.config.CaseInsensitiveString;
-import com.thoughtworks.go.config.ConfigSaveValidationContext;
-import com.thoughtworks.go.config.materials.AbstractMaterialConfig;
+import com.thoughtworks.go.config.*;
 import com.thoughtworks.go.config.materials.Filter;
 import com.thoughtworks.go.config.materials.IgnoredFiles;
 import com.thoughtworks.go.config.materials.ScmMaterialConfig;
@@ -26,37 +24,42 @@ import com.thoughtworks.go.security.CryptoException;
 import com.thoughtworks.go.security.GoCipher;
 import com.thoughtworks.go.util.ReflectionUtil;
 import com.thoughtworks.go.util.command.UrlArgument;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.nullValue;
-import static org.junit.Assert.*;
+import static com.thoughtworks.go.config.materials.AbstractMaterialConfig.MATERIAL_NAME;
+import static com.thoughtworks.go.config.materials.ScmMaterialConfig.FOLDER;
+import static com.thoughtworks.go.config.materials.ScmMaterialConfig.URL;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class TfsMaterialConfigUpdateTest {
+class TfsMaterialConfigUpdateTest {
+    private TfsMaterialConfig tfsMaterialConfig;
 
-    @Before
-    public void setUp() throws Exception {
+    @BeforeEach
+    void setUp() {
+        tfsMaterialConfig = new TfsMaterialConfig(new GoCipher(), null, "loser", "some_domain", "passwd", "walk_this_path");
     }
 
     @Test
-    public void shouldSetConfigAttributes() {
+    void shouldSetConfigAttributes() {
         TfsMaterialConfig tfsMaterialConfig = new TfsMaterialConfig(new GoCipher(), new UrlArgument("http://10.4.4.101:8080/tfs/Sample"), "loser", "some_domain", "passwd", "walk_this_path");
 
         Map<String, String> map = new HashMap<>();
-        map.put(ScmMaterialConfig.URL, "http://foo:8080/tfs/HelloWorld");
+        map.put(URL, "http://foo:8080/tfs/HelloWorld");
         map.put(ScmMaterialConfig.USERNAME, "boozer");
         map.put(ScmMaterialConfig.PASSWORD, "secret");
-        map.put(ScmMaterialConfig.FOLDER, "folder");
+        map.put(FOLDER, "folder");
         map.put(ScmMaterialConfig.AUTO_UPDATE, "0");
         map.put(ScmMaterialConfig.FILTER, "/root,/**/*.help");
-        map.put(AbstractMaterialConfig.MATERIAL_NAME, "my-tfs-material-name");
+        map.put(MATERIAL_NAME, "my-tfs-material-name");
         map.put(TfsMaterialConfig.PROJECT_PATH, "/useless/project");
         map.put(TfsMaterialConfig.DOMAIN, "CORPORATE");
 
@@ -65,23 +68,23 @@ public class TfsMaterialConfigUpdateTest {
         newTfsMaterialConfig.setName(new CaseInsensitiveString("my-tfs-material-name"));
         newTfsMaterialConfig.setFolder("folder");
 
-        assertThat(tfsMaterialConfig, is(newTfsMaterialConfig));
-        assertThat(tfsMaterialConfig.getPassword(), is("passwd"));
-        assertThat(tfsMaterialConfig.isAutoUpdate(), is(false));
-        assertThat(tfsMaterialConfig.getDomain(), is("CORPORATE"));
+        assertThat(tfsMaterialConfig).isEqualTo(newTfsMaterialConfig);
+        assertThat(tfsMaterialConfig.getPassword()).isEqualTo("passwd");
+        assertThat(tfsMaterialConfig.isAutoUpdate()).isFalse();
+        assertThat(tfsMaterialConfig.getDomain()).isEqualTo("CORPORATE");
 
-        assertThat(tfsMaterialConfig.getName(), is(new CaseInsensitiveString("my-tfs-material-name")));
-        assertThat(tfsMaterialConfig.filter(), is(new Filter(new IgnoredFiles("/root"), new IgnoredFiles("/**/*.help"))));
+        assertThat(tfsMaterialConfig.getName()).isEqualTo(new CaseInsensitiveString("my-tfs-material-name"));
+        assertThat(tfsMaterialConfig.filter()).isEqualTo(new Filter(new IgnoredFiles("/root"), new IgnoredFiles("/**/*.help")));
     }
 
     @Test
-    public void shouldDefaultDomainToEmptyStringWhenNothingIsSet() throws Exception {
+    void shouldDefaultDomainToEmptyStringWhenNothingIsSet() throws Exception {
         TfsMaterialConfig tfsMaterialConfig = new TfsMaterialConfig(mock(GoCipher.class));
-        assertThat(tfsMaterialConfig.getDomain(), is(""));
+        assertThat(tfsMaterialConfig.getDomain()).isEqualTo("");
     }
 
     @Test
-    public void setConfigAttributes_shouldUpdatePasswordWhenPasswordChangedBooleanChanged() throws Exception {
+    void setConfigAttributes_shouldUpdatePasswordWhenPasswordChangedBooleanChanged() throws Exception {
         TfsMaterialConfig tfsMaterialConfig = new TfsMaterialConfig(new GoCipher(), new UrlArgument("http://10.4.4.101:8080/tfs/Sample"), "loser", "CORPORATE", "passwd", "walk_this_path");
         Map<String, String> map = new HashMap<>();
         map.put(TfsMaterialConfig.PASSWORD, "secret");
@@ -90,75 +93,58 @@ public class TfsMaterialConfigUpdateTest {
         tfsMaterialConfig.setConfigAttributes(map);
 
         tfsMaterialConfig.setConfigAttributes(map);
-        assertThat(ReflectionUtil.getField(tfsMaterialConfig, "password"), is(nullValue()));
-        assertThat(tfsMaterialConfig.getPassword(), is("secret"));
-        assertThat(tfsMaterialConfig.getEncryptedPassword(), is(new GoCipher().encrypt("secret")));
+        assertThat(ReflectionUtil.getField(tfsMaterialConfig, "password")).isNull();
+        assertThat(tfsMaterialConfig.getPassword()).isEqualTo("secret");
+        assertThat(tfsMaterialConfig.getEncryptedPassword()).isEqualTo(new GoCipher().encrypt("secret"));
 
         //Dont change
         map.put(TfsMaterialConfig.PASSWORD, "Hehehe");
         map.put(TfsMaterialConfig.PASSWORD_CHANGED, "0");
         tfsMaterialConfig.setConfigAttributes(map);
 
-        assertThat(ReflectionUtil.getField(tfsMaterialConfig, "password"), is(nullValue()));
-        assertThat(tfsMaterialConfig.getPassword(), is("secret"));
-        assertThat(tfsMaterialConfig.getEncryptedPassword(), is(new GoCipher().encrypt("secret")));
+        assertThat(ReflectionUtil.getField(tfsMaterialConfig, "password")).isNull();
+        assertThat(tfsMaterialConfig.getPassword()).isEqualTo("secret");
+        assertThat(tfsMaterialConfig.getEncryptedPassword()).isEqualTo(new GoCipher().encrypt("secret"));
 
         map.put(TfsMaterialConfig.PASSWORD, "");
         map.put(TfsMaterialConfig.PASSWORD_CHANGED, "1");
         tfsMaterialConfig.setConfigAttributes(map);
 
-        assertThat(tfsMaterialConfig.getPassword(), is(nullValue()));
-        assertThat(tfsMaterialConfig.getEncryptedPassword(), is(nullValue()));
-
+        assertThat(tfsMaterialConfig.getPassword()).isNull();
+        assertThat(tfsMaterialConfig.getEncryptedPassword()).isNull();
     }
 
     @Test
-    public void validate_shouldEnsureMandatoryFieldsAreNotBlank() {
+    void validate_shouldEnsureMandatoryFieldsAreNotBlank() {
         TfsMaterialConfig tfsMaterialConfig = new TfsMaterialConfig(new GoCipher(), new UrlArgument(""), "", "CORPORATE", "", "");
         tfsMaterialConfig.validate(new ConfigSaveValidationContext(null));
-        assertThat(tfsMaterialConfig.errors().on(TfsMaterialConfig.URL), is("URL cannot be blank"));
-        assertThat(tfsMaterialConfig.errors().on(TfsMaterialConfig.USERNAME), is("Username cannot be blank"));
-        assertThat(tfsMaterialConfig.errors().on(TfsMaterialConfig.PROJECT_PATH), is("Project Path cannot be blank"));
+        assertThat(tfsMaterialConfig.errors().on(URL)).isEqualTo("URL cannot be blank");
+        assertThat(tfsMaterialConfig.errors().on(TfsMaterialConfig.USERNAME)).isEqualTo("Username cannot be blank");
+        assertThat(tfsMaterialConfig.errors().on(TfsMaterialConfig.PROJECT_PATH)).isEqualTo("Project Path cannot be blank");
     }
 
     @Test
-    public void validate_shouldEnsureMaterialNameIsValid() {
+    void validate_shouldEnsureMaterialNameIsValid() {
         TfsMaterialConfig tfsMaterialConfig = new TfsMaterialConfig(new GoCipher(), new UrlArgument("http://10.4.4.101:8080/tfs/Sample"), "loser", "CORPORATE", "passwd", "walk_this_path");
 
         tfsMaterialConfig.validate(new ConfigSaveValidationContext(null));
-        assertThat(tfsMaterialConfig.errors().on(TfsMaterialConfig.MATERIAL_NAME), is(nullValue()));
+        assertThat(tfsMaterialConfig.errors().on(MATERIAL_NAME)).isNull();
 
         tfsMaterialConfig.setName(new CaseInsensitiveString(".bad-name-with-dot"));
         tfsMaterialConfig.validate(new ConfigSaveValidationContext(null));
-        assertThat(tfsMaterialConfig.errors().on(TfsMaterialConfig.MATERIAL_NAME),
-                is("Invalid material name '.bad-name-with-dot'. This must be alphanumeric and can contain underscores and periods (however, it cannot start with a period). The maximum allowed length is 255 characters."));
+        assertThat(tfsMaterialConfig.errors().on(MATERIAL_NAME)).isEqualTo("Invalid material name '.bad-name-with-dot'. This must be alphanumeric and can contain underscores and periods (however, it cannot start with a period). The maximum allowed length is 255 characters.");
     }
 
     @Test
-    public void validate_shouldEnsureDestFilePathIsValid() {
+    void validate_shouldEnsureDestFilePathIsValid() {
         TfsMaterialConfig tfsMaterialConfig = new TfsMaterialConfig(new GoCipher(), new UrlArgument("http://10.4.4.101:8080/tfs/Sample"), "loser", "CORPORATE", "passwd", "walk_this_path");
-        tfsMaterialConfig.setConfigAttributes(Collections.singletonMap(ScmMaterialConfig.FOLDER, "../a"));
+        tfsMaterialConfig.setConfigAttributes(Collections.singletonMap(FOLDER, "../a"));
         tfsMaterialConfig.validate(new ConfigSaveValidationContext(null));
-        assertThat(tfsMaterialConfig.errors().on(TfsMaterialConfig.FOLDER), is("Dest folder '../a' is not valid. It must be a sub-directory of the working folder."));
+        assertThat(tfsMaterialConfig.errors().on(FOLDER)).isEqualTo("Dest folder '../a' is not valid. It must be a sub-directory of the working folder.");
     }
 
     @Test
-    public void shouldThrowErrorsIfBothPasswordAndEncryptedPasswordAreProvided() {
-        TfsMaterialConfig materialConfig = new TfsMaterialConfig(new UrlArgument("foo/bar"), "password", "encryptedPassword", new GoCipher());
-        materialConfig.validate(new ConfigSaveValidationContext(null));
-        assertThat(materialConfig.errors().on("password"), is("You may only specify `password` or `encrypted_password`, not both!"));
-        assertThat(materialConfig.errors().on("encryptedPassword"), is("You may only specify `password` or `encrypted_password`, not both!"));
-    }
-
-    @Test
-    public void shouldValidateWhetherTheEncryptedPasswordIsCorrect() {
-        TfsMaterialConfig materialConfig = new TfsMaterialConfig(new UrlArgument("foo/bar"), "", "encryptedPassword", new GoCipher());
-        materialConfig.validate(new ConfigSaveValidationContext(null));
-        assertThat(materialConfig.errors().on("encryptedPassword"), is("Encrypted password value for TFS material with url 'foo/bar' is invalid. This usually happens when the cipher text is modified to have an invalid value."));
-    }
-
-    @Test
-     public void shouldEncryptTfsPasswordAndMarkPasswordAsNull() throws Exception {
+    void shouldEncryptTfsPasswordAndMarkPasswordAsNull() throws Exception {
         GoCipher mockGoCipher = mock(GoCipher.class);
         when(mockGoCipher.encrypt("password")).thenReturn("encrypted");
         when(mockGoCipher.maybeReEncryptForPostConstructWithoutExceptions("encrypted")).thenReturn("encrypted");
@@ -166,12 +152,12 @@ public class TfsMaterialConfigUpdateTest {
         TfsMaterialConfig materialConfig = new TfsMaterialConfig(mockGoCipher, new UrlArgument("http://10.4.4.101:8080/tfs/Sample"), "loser", "CORPORATE", "password", "walk_this_path");
         materialConfig.ensureEncrypted();
 
-        assertThat(materialConfig.getPassword(), is(nullValue()));
-        assertThat(materialConfig.getEncryptedPassword(), is("encrypted"));
-     }
+        assertThat(materialConfig.getPassword()).isNull();
+        assertThat(materialConfig.getEncryptedPassword()).isEqualTo("encrypted");
+    }
 
     @Test
-     public void shouldDecryptTfsPassword() throws Exception {
+    void shouldDecryptTfsPassword() throws Exception {
         GoCipher mockGoCipher = mock(GoCipher.class);
         when(mockGoCipher.decrypt("encrypted")).thenReturn("password");
         when(mockGoCipher.maybeReEncryptForPostConstructWithoutExceptions("encrypted")).thenReturn("encrypted");
@@ -180,11 +166,11 @@ public class TfsMaterialConfigUpdateTest {
         ReflectionUtil.setField(materialConfig, "encryptedPassword", "encrypted");
 
         materialConfig.ensureEncrypted();
-        assertThat(materialConfig.getPassword(), is("password"));
+        assertThat(materialConfig.getPassword()).isEqualTo("password");
     }
 
     @Test
-    public void shouldNotDecryptTfsPasswordIfPasswordIsNotNull() throws Exception {
+    void shouldNotDecryptTfsPasswordIfPasswordIsNotNull() throws Exception {
         GoCipher mockGoCipher = mock(GoCipher.class);
         when(mockGoCipher.encrypt("password")).thenReturn("encrypted");
         when(mockGoCipher.decrypt("encrypted")).thenReturn("password");
@@ -195,11 +181,11 @@ public class TfsMaterialConfigUpdateTest {
         materialConfig.setPassword("new_password");
         when(mockGoCipher.decrypt("new_encrypted")).thenReturn("new_password");
 
-        assertThat(materialConfig.getPassword(), is("new_password"));
+        assertThat(materialConfig.getPassword()).isEqualTo("new_password");
     }
 
     @Test
-    public void shouldErrorOutIfDecryptionFails() throws CryptoException {
+    void shouldErrorOutIfDecryptionFails() throws CryptoException {
         GoCipher mockGoCipher = mock(GoCipher.class);
         String fakeCipherText = "fake cipher text";
         when(mockGoCipher.decrypt(fakeCipherText)).thenThrow(new CryptoException("exception"));
@@ -208,48 +194,163 @@ public class TfsMaterialConfigUpdateTest {
         try {
             materialConfig.getPassword();
             fail("Should have thrown up");
-        }
-        catch (Exception e) {
-            assertThat(e.getMessage(), is("Could not decrypt the password to get the real password"));
+        } catch (Exception e) {
+            assertThat(e.getMessage()).isEqualTo("Could not decrypt the password to get the real password");
         }
     }
 
     @Test
-    public void shouldErrorOutIfEncryptionFails() throws Exception {
+    void shouldErrorOutIfEncryptionFails() throws Exception {
         GoCipher mockGoCipher = mock(GoCipher.class);
         when(mockGoCipher.encrypt("password")).thenThrow(new CryptoException("exception"));
         try {
             new TfsMaterialConfig(mockGoCipher, new UrlArgument("http://10.4.4.101:8080/tfs/Sample"), "loser", "CORPORATE", "password", "walk_this_path");
             fail("Should have thrown up");
-        }
-        catch (Exception e) {
-            assertThat(e.getMessage(), is("Password encryption failed. Please verify your cipher key."));
+        } catch (Exception e) {
+            assertThat(e.getMessage()).isEqualTo("Password encryption failed. Please verify your cipher key.");
         }
     }
 
     @Test
-    public void shouldReturnTheUrl() {
+    void shouldReturnTheUrl() {
         String url = "git@github.com/my/repo";
         TfsMaterialConfig config = new TfsMaterialConfig();
 
         config.setUrl(url);
 
-        assertThat(config.getUrl(), is(url));
+        assertThat(config.getUrl()).isEqualTo(url);
     }
 
     @Test
-    public void shouldReturnNullIfUrlForMaterialNotSpecified() {
+    void shouldReturnNullIfUrlForMaterialNotSpecified() {
         TfsMaterialConfig config = new TfsMaterialConfig();
 
-        assertNull(config.getUrl());
+        assertThat(config.getUrl()).isNull();
     }
 
     @Test
-    public void shouldHandleNullWhenSettingUrlForAMaterial() {
+    void shouldHandleNullWhenSettingUrlForAMaterial() {
         TfsMaterialConfig config = new TfsMaterialConfig();
 
         config.setUrl(null);
 
-        assertNull(config.getUrl());
+        assertThat(config.getUrl()).isNull();
+    }
+
+    @Nested
+    class ValidateURL {
+        @Test
+        void shouldEnsureUrlIsNotBlank() {
+            tfsMaterialConfig.setUrl("");
+            tfsMaterialConfig.validate(new ConfigSaveValidationContext(null));
+
+            assertThat(tfsMaterialConfig.errors().on(ScmMaterialConfig.URL)).isEqualTo("URL cannot be blank");
+        }
+
+        @Test
+        void shouldEnsureUrlIsNotNull() {
+            tfsMaterialConfig.setUrl(null);
+
+            tfsMaterialConfig.validate(new ConfigSaveValidationContext(null));
+
+            assertThat(tfsMaterialConfig.errors().on(URL)).isEqualTo("URL cannot be blank");
+        }
+
+        @Test
+        void shouldEnsureMaterialNameIsValid() {
+            tfsMaterialConfig.validate(new ConfigSaveValidationContext(null));
+            assertThat(tfsMaterialConfig.errors().on(MATERIAL_NAME)).isNull();
+
+            tfsMaterialConfig.setName(new CaseInsensitiveString(".bad-name-with-dot"));
+            tfsMaterialConfig.validate(new ConfigSaveValidationContext(null));
+            assertThat(tfsMaterialConfig.errors().on(MATERIAL_NAME)).isEqualTo("Invalid material name '.bad-name-with-dot'. This must be alphanumeric and can contain underscores and periods (however, it cannot start with a period). The maximum allowed length is 255 characters.");
+        }
+
+        @Test
+        void shouldEnsureDestFilePathIsValid() {
+            tfsMaterialConfig.setConfigAttributes(Collections.singletonMap(FOLDER, "../a"));
+            tfsMaterialConfig.validate(new ConfigSaveValidationContext(null));
+            assertThat(tfsMaterialConfig.errors().on(FOLDER)).isEqualTo("Dest folder '../a' is not valid. It must be a sub-directory of the working folder.");
+        }
+
+        @Test
+        void shouldFailValidationIfMaterialURLHasSecretParamsConfiguredOtherThanForUsernamePassword() {
+            final ValidationContext validationContext = mockValidationContextForSecretParams();
+            tfsMaterialConfig.setUrl("https://user:pass@{{SECRET:[secret_config_id][hostname]}}/foo.git");
+
+            assertThat(tfsMaterialConfig.validateTree(validationContext)).isFalse();
+            assertThat(tfsMaterialConfig.errors().on("url")).isEqualTo("Only username and password can be specified as secret params");
+        }
+
+        @Test
+        void shouldFailIfSecretParamConfiguredWithSecretConfigIdWhichDoesNotExist() {
+            final ValidationContext validationContext = mockValidationContextForSecretParams();
+            tfsMaterialConfig.setUrl("https://{{SECRET:[secret_config_id_1][user]}}:{{SECRET:[secret_config_id_2][pass]}}@host/foo.git");
+
+            assertThat(tfsMaterialConfig.validateTree(validationContext)).isFalse();
+            assertThat(tfsMaterialConfig.errors().on("url")).isEqualTo("Secret configs '[secret_config_id_1, secret_config_id_2]' does not exist");
+        }
+
+        @Test
+        void shouldNotFailIfSecretConfigWithIdPresentForConfiguredSecretParams() {
+            final SecretConfig secretConfig = new SecretConfig("secret_config_id", "cd.go.secret.file");
+            final ValidationContext validationContext = mockValidationContextForSecretParams(secretConfig);
+            tfsMaterialConfig.setUrl("https://{{SECRET:[secret_config_id][username]}}:password@host/foo.git");
+
+            assertThat(tfsMaterialConfig.validateTree(validationContext)).isTrue();
+            assertThat(tfsMaterialConfig.errors().getAll()).isEmpty();
+        }
+    }
+
+    @Nested
+    class ValidatePassword {
+        @BeforeEach
+        void setUp() {
+            tfsMaterialConfig.setUrl("/foo/bar");
+        }
+
+        @Test
+        void shouldFailIfEncryptedPasswordIsIncorrect() {
+            tfsMaterialConfig.setEncryptedPassword("encryptedPassword");
+
+            final boolean validationResult = tfsMaterialConfig.validateTree(new ConfigSaveValidationContext(null));
+
+            assertThat(validationResult).isFalse();
+            assertThat(tfsMaterialConfig.errors().on("encryptedPassword")).isEqualTo("Encrypted password value for TfsMaterial with url '/foo/bar' is invalid. This usually happens when the cipher text is modified to have an invalid value.");
+        }
+
+        @Test
+        void shouldPassIfPasswordIsNotSpecifiedAsSecretParams() {
+            tfsMaterialConfig.setPassword("badger");
+
+            assertThat(tfsMaterialConfig.validateTree(null)).isTrue();
+            assertThat(tfsMaterialConfig.errors().getAll()).isEmpty();
+        }
+
+        @Test
+        void shouldPassIfPasswordSpecifiedAsSecretParamIsValid() {
+            final ValidationContext validationContext = mockValidationContextForSecretParams(new SecretConfig("secret_config_id", "cd.go.secret.file"));
+            tfsMaterialConfig.setPassword("{{SECRET:[secret_config_id][password]}}");
+
+            assertThat(tfsMaterialConfig.validateTree(validationContext)).isTrue();
+            assertThat(tfsMaterialConfig.errors().getAll()).isEmpty();
+        }
+
+        @Test
+        void shouldFailIfSecretConfigForPasswordSpecifiedAsSecretParamDoesNotExist() {
+            final ValidationContext validationContext = mockValidationContextForSecretParams();
+            tfsMaterialConfig.setPassword("{{SECRET:[secret_config_id][password]}}");
+
+            assertThat(tfsMaterialConfig.validateTree(validationContext)).isFalse();
+            assertThat(tfsMaterialConfig.errors().on("encryptedPassword")).isEqualTo("Secret configs '[secret_config_id]' does not exist");
+        }
+    }
+
+    private ValidationContext mockValidationContextForSecretParams(SecretConfig... secretConfigs) {
+        final ValidationContext validationContext = mock(ValidationContext.class);
+        final CruiseConfig cruiseConfig = mock(CruiseConfig.class);
+        when(validationContext.getCruiseConfig()).thenReturn(cruiseConfig);
+        when(cruiseConfig.getSecretConfigs()).thenReturn(new SecretConfigs(secretConfigs));
+        return validationContext;
     }
 }

--- a/config/config-api/build.gradle
+++ b/config/config-api/build.gradle
@@ -31,6 +31,9 @@ dependencies {
   compile group: 'org.jdom', name: 'jdom2', version: project.versions.jdom
   compile group: 'org.slf4j', name: 'slf4j-api', version: project.versions.slf4j
   compile group: 'org.apache.felix', name: 'org.apache.felix.framework', version: project.versions.felix
+  compileOnly group: 'com.google.guava', name: 'guava', version: project.versions.guava
+  compileOnly(group: 'org.bouncycastle', name: 'bcprov-jdk15on', version: project.versions.bouncyCastle)
+
   testCompile project(':test:test-utils')
   testCompile group: 'jaxen', name: 'jaxen', version: '1.1.6'
   testCompileOnly group: 'junit', name: 'junit', version: project.versions.junit
@@ -39,6 +42,5 @@ dependencies {
   testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: project.versions.junit5
   testCompile group: 'org.mockito', name: 'mockito-core', version: project.versions.mockito
   testCompile group: 'org.hamcrest', name: 'hamcrest-library', version: project.versions.hamcrest
-  compileOnly group: 'com.google.guava', name: 'guava', version: project.versions.guava
-  compileOnly(group: 'org.bouncycastle', name: 'bcprov-jdk15on', version: project.versions.bouncyCastle)
+  testCompile group: 'org.junit.jupiter', name: 'junit-jupiter-params', version: project.versions.junit5
 }

--- a/config/config-api/build.gradle
+++ b/config/config-api/build.gradle
@@ -43,4 +43,5 @@ dependencies {
   testCompile group: 'org.mockito', name: 'mockito-core', version: project.versions.mockito
   testCompile group: 'org.hamcrest', name: 'hamcrest-library', version: project.versions.hamcrest
   testCompile group: 'org.junit.jupiter', name: 'junit-jupiter-params', version: project.versions.junit5
+  testCompile group: 'org.junit.jupiter', name: 'junit-jupiter-migrationsupport', version: project.versions.junit5
 }

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/SecretParam.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/SecretParam.java
@@ -19,6 +19,8 @@ package com.thoughtworks.go.config;
 import java.io.Serializable;
 import java.util.Objects;
 
+import static java.lang.String.format;
+
 public class SecretParam implements Serializable {
     private String secretConfigId;
     private String key;
@@ -64,5 +66,14 @@ public class SecretParam implements Serializable {
     @Override
     public int hashCode() {
         return Objects.hash(secretConfigId, key);
+    }
+
+    @Override
+    public String toString() {
+        return asString();
+    }
+
+    public String asString() {
+        return format("{{SECRET:[%s][%s]}}", this.secretConfigId, this.key);
     }
 }

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/SecretParams.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/SecretParams.java
@@ -35,6 +35,7 @@ import static org.apache.commons.lang3.StringUtils.replaceOnce;
 
 public class SecretParams extends ArrayList<SecretParam> implements Serializable {
     private static final Pattern PATTERN = Pattern.compile("(?:\\{\\{SECRET:\\[(.*?)\\]\\[(.*?)\\]}})+");
+    public static final String MASKED_VALUE = "******";
 
     public SecretParams() {
     }
@@ -123,6 +124,6 @@ public class SecretParams extends ArrayList<SecretParam> implements Serializable
     }
 
     private Function<String, String> maskFunction(SecretParam secretParam) {
-        return text -> replaceOnce(text, format("{{SECRET:[%s][%s]}}", secretParam.getSecretConfigId(), secretParam.getKey()), "******");
+        return text -> replaceOnce(text, secretParam.asString(), MASKED_VALUE);
     }
 }

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/materials/ScmMaterialConfig.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/materials/ScmMaterialConfig.java
@@ -191,10 +191,10 @@ public abstract class ScmMaterialConfig extends AbstractMaterialConfig implement
     protected final void validateConcreteMaterial(ValidationContext validationContext) {
         validateNotOutsideSandbox();
         validateDestFolderPath();
-        validateConcreteScmMaterial();
+        validateConcreteScmMaterial(validationContext);
     }
 
-    public abstract void validateConcreteScmMaterial();
+    public abstract void validateConcreteScmMaterial(ValidationContext validationContext);
 
     private void validateDestFolderPath() {
         if (StringUtils.isBlank(folder)) {

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/materials/ScmMaterialConfig.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/materials/ScmMaterialConfig.java
@@ -301,7 +301,7 @@ public abstract class ScmMaterialConfig extends AbstractMaterialConfig implement
         }
 
         if (!url.isValid()) {
-            errors.add(URL, "Only username and password can be specified as secret params");
+            errors.add(URL, "Only password can be specified as secret params");
         }
 
         validateSecretParamsConfig(URL, url.getSecretParams(), validationContext);
@@ -328,7 +328,7 @@ public abstract class ScmMaterialConfig extends AbstractMaterialConfig implement
                 .collect(Collectors.toList());
 
         if (!missingSecretConfigs.isEmpty()) {
-            addError(key, String.format("Secret configs '%s' does not exist", missingSecretConfigs));
+            addError(key, String.format("Secret configs %s does not exist", String.join(", ", missingSecretConfigs)));
         }
     }
 }

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/materials/git/GitMaterialConfig.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/materials/git/GitMaterialConfig.java
@@ -16,18 +16,16 @@
 
 package com.thoughtworks.go.config.materials.git;
 
-import com.thoughtworks.go.config.CaseInsensitiveString;
-import com.thoughtworks.go.config.ConfigAttribute;
-import com.thoughtworks.go.config.ConfigTag;
+import com.thoughtworks.go.config.*;
 import com.thoughtworks.go.config.materials.Filter;
 import com.thoughtworks.go.config.materials.ScmMaterialConfig;
 import com.thoughtworks.go.domain.ConfigErrors;
 import com.thoughtworks.go.util.command.UrlArgument;
 import org.apache.commons.lang3.StringUtils;
-import org.springframework.web.util.UriComponents;
-import org.springframework.web.util.UriComponentsBuilder;
 
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 @ConfigTag("git")
 public class GitMaterialConfig extends ScmMaterialConfig {
@@ -147,7 +145,7 @@ public class GitMaterialConfig extends ScmMaterialConfig {
     }
 
     @Override
-    public void validateConcreteScmMaterial() {
+    public void validateConcreteScmMaterial(ValidationContext validationContext) {
         if (url == null || StringUtils.isBlank(url.forDisplay())) {
             errors().add(URL, "URL cannot be blank");
         }

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/materials/git/GitMaterialConfig.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/materials/git/GitMaterialConfig.java
@@ -16,16 +16,17 @@
 
 package com.thoughtworks.go.config.materials.git;
 
-import com.thoughtworks.go.config.*;
+import com.thoughtworks.go.config.CaseInsensitiveString;
+import com.thoughtworks.go.config.ConfigAttribute;
+import com.thoughtworks.go.config.ConfigTag;
+import com.thoughtworks.go.config.ValidationContext;
 import com.thoughtworks.go.config.materials.Filter;
 import com.thoughtworks.go.config.materials.ScmMaterialConfig;
 import com.thoughtworks.go.domain.ConfigErrors;
 import com.thoughtworks.go.util.command.UrlArgument;
 import org.apache.commons.lang3.StringUtils;
 
-import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 @ConfigTag("git")
 public class GitMaterialConfig extends ScmMaterialConfig {
@@ -146,25 +147,7 @@ public class GitMaterialConfig extends ScmMaterialConfig {
 
     @Override
     public void validateConcreteScmMaterial(ValidationContext validationContext) {
-        if (url == null || StringUtils.isBlank(url.forDisplay())) {
-            errors().add(URL, "URL cannot be blank");
-        }
-
-        if (!url.isValid()) {
-            errors.add(URL, "Only username and password can be specified as secret params");
-        }
-
-        if (url.hasSecretParams()) {
-            final SecretConfigs secretConfigs = validationContext.getCruiseConfig().getSecretConfigs();
-            final List<String> missingSecretConfigs = url.getSecretParams().stream()
-                    .filter(secretParam -> secretConfigs.find(secretParam.getSecretConfigId()) == null)
-                    .map(SecretParam::getSecretConfigId)
-                    .collect(Collectors.toList());
-
-            if (!missingSecretConfigs.isEmpty()) {
-                errors.add(URL, String.format("Secret configs '%s' does not exist", missingSecretConfigs));
-            }
-        }
+        validateMaterialUrl(this.url, validationContext);
     }
 
     @Override

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/materials/git/GitMaterialConfig.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/materials/git/GitMaterialConfig.java
@@ -24,6 +24,8 @@ import com.thoughtworks.go.config.materials.ScmMaterialConfig;
 import com.thoughtworks.go.domain.ConfigErrors;
 import com.thoughtworks.go.util.command.UrlArgument;
 import org.apache.commons.lang3.StringUtils;
+import org.springframework.web.util.UriComponents;
+import org.springframework.web.util.UriComponentsBuilder;
 
 import java.util.Map;
 
@@ -149,6 +151,11 @@ public class GitMaterialConfig extends ScmMaterialConfig {
         if (url == null || StringUtils.isBlank(url.forDisplay())) {
             errors().add(URL, "URL cannot be blank");
         }
+        if(!url.isValid()) {
+
+        }
+        final UriComponents uriComponents = UriComponentsBuilder.fromUriString(url.forDisplay()).build();
+
     }
 
     @Override

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/materials/git/GitMaterialConfig.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/materials/git/GitMaterialConfig.java
@@ -149,11 +149,22 @@ public class GitMaterialConfig extends ScmMaterialConfig {
         if (url == null || StringUtils.isBlank(url.forDisplay())) {
             errors().add(URL, "URL cannot be blank");
         }
-        if(!url.isValid()) {
 
+        if (!url.isValid()) {
+            errors.add(URL, "Only username and password can be specified as secret params");
         }
-        final UriComponents uriComponents = UriComponentsBuilder.fromUriString(url.forDisplay()).build();
 
+        if (url.hasSecretParams()) {
+            final SecretConfigs secretConfigs = validationContext.getCruiseConfig().getSecretConfigs();
+            final List<String> missingSecretConfigs = url.getSecretParams().stream()
+                    .filter(secretParam -> secretConfigs.find(secretParam.getSecretConfigId()) == null)
+                    .map(SecretParam::getSecretConfigId)
+                    .collect(Collectors.toList());
+
+            if (!missingSecretConfigs.isEmpty()) {
+                errors.add(URL, String.format("Secret configs '%s' does not exist", missingSecretConfigs));
+            }
+        }
     }
 
     @Override

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/materials/mercurial/HgMaterialConfig.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/materials/mercurial/HgMaterialConfig.java
@@ -16,10 +16,7 @@
 
 package com.thoughtworks.go.config.materials.mercurial;
 
-import com.thoughtworks.go.config.CaseInsensitiveString;
-import com.thoughtworks.go.config.ConfigAttribute;
-import com.thoughtworks.go.config.ConfigTag;
-import com.thoughtworks.go.config.ParamsAttributeAware;
+import com.thoughtworks.go.config.*;
 import com.thoughtworks.go.config.materials.Filter;
 import com.thoughtworks.go.config.materials.ScmMaterialConfig;
 import com.thoughtworks.go.domain.ConfigErrors;
@@ -127,7 +124,7 @@ public class HgMaterialConfig extends ScmMaterialConfig implements ParamsAttribu
     }
 
     @Override
-    public void validateConcreteScmMaterial() {
+    public void validateConcreteScmMaterial(ValidationContext validationContext) {
         if (url == null || StringUtils.isBlank(url.forDisplay())) {
             errors().add(URL, "URL cannot be blank");
         }

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/materials/mercurial/HgMaterialConfig.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/materials/mercurial/HgMaterialConfig.java
@@ -21,7 +21,6 @@ import com.thoughtworks.go.config.materials.Filter;
 import com.thoughtworks.go.config.materials.ScmMaterialConfig;
 import com.thoughtworks.go.domain.ConfigErrors;
 import com.thoughtworks.go.util.command.HgUrlArgument;
-import org.apache.commons.lang3.StringUtils;
 
 import java.util.Map;
 
@@ -125,9 +124,7 @@ public class HgMaterialConfig extends ScmMaterialConfig implements ParamsAttribu
 
     @Override
     public void validateConcreteScmMaterial(ValidationContext validationContext) {
-        if (url == null || StringUtils.isBlank(url.forDisplay())) {
-            errors().add(URL, "URL cannot be blank");
-        }
+        validateMaterialUrl(this.url, validationContext);
     }
 
     @Override

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/materials/perforce/P4MaterialConfig.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/materials/perforce/P4MaterialConfig.java
@@ -31,8 +31,6 @@ import java.util.Map;
 
 import static com.thoughtworks.go.util.ExceptionUtils.bomb;
 import static com.thoughtworks.go.util.ExceptionUtils.bombIfNull;
-import static java.lang.String.format;
-import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 
 @ConfigTag(value = "p4", label = "Perforce")
 public class P4MaterialConfig extends ScmMaterialConfig implements ParamsAttributeAware, PasswordEncrypter, PasswordAwareMaterial {
@@ -233,18 +231,8 @@ public class P4MaterialConfig extends ScmMaterialConfig implements ParamsAttribu
         if (StringUtils.isBlank(getServerAndPort())) {
             errors.add(SERVER_AND_PORT, "P4 port cannot be empty.");
         }
-        if (isNotEmpty(this.password) && isNotEmpty(this.encryptedPassword)) {
-            addError("password", "You may only specify `password` or `encrypted_password`, not both!");
-            addError("encryptedPassword", "You may only specify `password` or `encrypted_password`, not both!");
-        }
-        if (isNotEmpty(this.encryptedPassword)) {
-            try {
-                currentPassword();
-            } catch (Exception e) {
-                addError("encryptedPassword", format("Encrypted password value for P4 material with serverAndPort '%s' is invalid. This usually happens when the cipher text is modified to have an invalid value.",
-                        this.getServerAndPort()));
-            }
-        }
+
+        validatePassword(validationContext);
     }
 
     @Override

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/materials/perforce/P4MaterialConfig.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/materials/perforce/P4MaterialConfig.java
@@ -226,7 +226,7 @@ public class P4MaterialConfig extends ScmMaterialConfig implements ParamsAttribu
     }
 
     @Override
-    public void validateConcreteScmMaterial() {
+    public void validateConcreteScmMaterial(ValidationContext validationContext) {
         if (getView() == null || getView().trim().isEmpty()) {
             errors.add(VIEW, "P4 view cannot be empty.");
         }

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/materials/svn/SvnMaterialConfig.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/materials/svn/SvnMaterialConfig.java
@@ -216,7 +216,7 @@ public class SvnMaterialConfig extends ScmMaterialConfig implements ParamsAttrib
     }
 
     @Override
-    public void validateConcreteScmMaterial() {
+    public void validateConcreteScmMaterial(ValidationContext validationContext) {
         if (url == null || isBlank(url.forDisplay())) {
             errors().add(URL, "URL cannot be blank");
         }

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/materials/svn/SvnMaterialConfig.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/materials/svn/SvnMaterialConfig.java
@@ -26,9 +26,7 @@ import com.thoughtworks.go.security.GoCipher;
 import com.thoughtworks.go.util.command.UrlArgument;
 
 import javax.annotation.PostConstruct;
-import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 import static com.thoughtworks.go.util.ExceptionUtils.bomb;
 import static com.thoughtworks.go.util.ExceptionUtils.bombIfNull;
@@ -210,47 +208,8 @@ public class SvnMaterialConfig extends ScmMaterialConfig implements ParamsAttrib
 
     @Override
     public void validateConcreteScmMaterial(ValidationContext validationContext) {
-        validateMaterialUrl(validationContext);
+        validateMaterialUrl(this.url, validationContext);
         validatePassword(validationContext);
-    }
-
-    private void validatePassword(ValidationContext validationContext) {
-        if (isNotEmpty(this.encryptedPassword)) {
-            try {
-                validateSecretParamsConfig("encryptedPassword", SecretParams.parse(currentPassword()), validationContext);
-            } catch (Exception e) {
-                addError("encryptedPassword", format("Encrypted password value for svn material with url '%s' is invalid. This usually happens when the cipher text is modified to have an invalid value.",
-                        this.getUriForDisplay()));
-            }
-        }
-    }
-
-    private void validateSecretParamsConfig(String key, SecretParams secretParams, ValidationContext validationContext) {
-        if (!secretParams.hasSecretParams()) {
-            return;
-        }
-
-        final List<String> missingSecretConfigs = secretParams.stream()
-                .filter(secretParam -> validationContext.getCruiseConfig().getSecretConfigs().find(secretParam.getSecretConfigId()) == null)
-                .map(SecretParam::getSecretConfigId)
-                .collect(Collectors.toList());
-
-        if (!missingSecretConfigs.isEmpty()) {
-            addError(key, String.format("Secret configs '%s' does not exist", missingSecretConfigs));
-        }
-    }
-
-    private void validateMaterialUrl(ValidationContext validationContext) {
-        if (url == null || isBlank(url.forDisplay())) {
-            errors().add(URL, "URL cannot be blank");
-            return;
-        }
-
-        if (!url.isValid()) {
-            errors.add(URL, "Only username and password can be specified as secret params");
-        }
-
-        validateSecretParamsConfig(URL, url.getSecretParams(), validationContext);
     }
 
     @Override

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/materials/tfs/TfsMaterialConfig.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/materials/tfs/TfsMaterialConfig.java
@@ -33,9 +33,7 @@ import javax.annotation.PostConstruct;
 import java.util.Map;
 
 import static com.thoughtworks.go.util.ExceptionUtils.bomb;
-import static java.lang.String.format;
 import static org.apache.commons.lang3.StringUtils.isBlank;
-import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 
 @ConfigTag(value = "tfs", label = "TFS")
 public class TfsMaterialConfig extends ScmMaterialConfig implements ParamsAttributeAware, PasswordAwareMaterial, PasswordEncrypter {
@@ -176,28 +174,16 @@ public class TfsMaterialConfig extends ScmMaterialConfig implements ParamsAttrib
 
     @Override
     public void validateConcreteScmMaterial(ValidationContext validationContext) {
-        if (url == null || StringUtils.isBlank(url.forDisplay())) {
-            errors().add(URL, "URL cannot be blank");
-        }
+        validateMaterialUrl(this.url, validationContext);
+        validatePassword(validationContext);
+
         if (StringUtils.isBlank(userName)) {
             errors().add(USERNAME, "Username cannot be blank");
         }
         if (StringUtils.isBlank(projectPath)) {
             errors().add(PROJECT_PATH, "Project Path cannot be blank");
         }
-        if (isNotEmpty(this.password) && isNotEmpty(this.encryptedPassword)) {
-            addError("password", "You may only specify `password` or `encrypted_password`, not both!");
-            addError("encryptedPassword", "You may only specify `password` or `encrypted_password`, not both!");
-        }
 
-        if (isNotEmpty(this.encryptedPassword)) {
-            try {
-                goCipher.decrypt(encryptedPassword);
-            } catch (Exception e) {
-                addError("encryptedPassword", format("Encrypted password value for TFS material with url '%s' is invalid. This usually happens when the cipher text is modified to have an invalid value.",
-                        this.getUriForDisplay()));
-            }
-        }
     }
 
     @Override

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/materials/tfs/TfsMaterialConfig.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/materials/tfs/TfsMaterialConfig.java
@@ -175,7 +175,7 @@ public class TfsMaterialConfig extends ScmMaterialConfig implements ParamsAttrib
     }
 
     @Override
-    public void validateConcreteScmMaterial() {
+    public void validateConcreteScmMaterial(ValidationContext validationContext) {
         if (url == null || StringUtils.isBlank(url.forDisplay())) {
             errors().add(URL, "URL cannot be blank");
         }

--- a/config/config-api/src/main/java/com/thoughtworks/go/domain/materials/TestingMaterialConfig.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/domain/materials/TestingMaterialConfig.java
@@ -16,6 +16,7 @@
 
 package com.thoughtworks.go.domain.materials;
 
+import com.thoughtworks.go.config.ValidationContext;
 import com.thoughtworks.go.config.materials.ScmMaterialConfig;
 import org.joda.time.DateTime;
 
@@ -86,7 +87,7 @@ public class TestingMaterialConfig extends ScmMaterialConfig {
     }
 
     @Override
-    public void validateConcreteScmMaterial() {
+    public void validateConcreteScmMaterial(ValidationContext validationContext) {
     }
 
     @Override

--- a/config/config-api/src/test/java/com/thoughtworks/go/config/materials/DummyMaterialConfig.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/config/materials/DummyMaterialConfig.java
@@ -16,7 +16,7 @@
 
 package com.thoughtworks.go.config.materials;
 
-import com.thoughtworks.go.util.command.UrlArgument;
+import com.thoughtworks.go.config.ValidationContext;
 import org.apache.commons.lang3.NotImplementedException;
 
 import java.util.Map;
@@ -67,7 +67,7 @@ public class DummyMaterialConfig extends ScmMaterialConfig {
     }
 
     @Override
-    public void validateConcreteScmMaterial() {
+    public void validateConcreteScmMaterial(ValidationContext validationContext) {
     }
 
     @Override

--- a/config/config-api/src/test/java/com/thoughtworks/go/config/materials/git/GitMaterialConfigTest.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/config/materials/git/GitMaterialConfigTest.java
@@ -164,7 +164,7 @@ class GitMaterialConfigTest {
             final GitMaterialConfig gitMaterialConfig = gitMaterialConfig("https://username:{{SECRET:[secret_config_id][pass]}}@host/foo.git");
 
             assertThat(gitMaterialConfig.validateTree(validationContext)).isFalse();
-            assertThat(gitMaterialConfig.errors().on("url")).isEqualTo("Secret configs '[secret_config_id]' does not exist");
+            assertThat(gitMaterialConfig.errors().on("url")).isEqualTo("Secret configs secret_config_id does not exist");
         }
 
         @Test

--- a/config/config-api/src/test/java/com/thoughtworks/go/config/materials/git/GitMaterialConfigTest.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/config/materials/git/GitMaterialConfigTest.java
@@ -16,26 +16,27 @@
 
 package com.thoughtworks.go.config.materials.git;
 
-import com.thoughtworks.go.config.CaseInsensitiveString;
-import com.thoughtworks.go.config.ConfigSaveValidationContext;
+import com.thoughtworks.go.config.*;
 import com.thoughtworks.go.config.materials.AbstractMaterialConfig;
 import com.thoughtworks.go.config.materials.Filter;
 import com.thoughtworks.go.config.materials.IgnoredFiles;
 import com.thoughtworks.go.config.materials.ScmMaterialConfig;
 import com.thoughtworks.go.util.command.UrlArgument;
-import org.junit.Test;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
+import static com.thoughtworks.go.helper.MaterialConfigsMother.gitMaterialConfig;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
-public class GitMaterialConfigTest {
+class GitMaterialConfigTest {
     @Test
-    public void shouldSetConfigAttributes() {
+    void shouldSetConfigAttributes() {
         GitMaterialConfig gitMaterialConfig = new GitMaterialConfig("");
 
         Map<String, String> map = new HashMap<>();
@@ -49,98 +50,140 @@ public class GitMaterialConfigTest {
 
         gitMaterialConfig.setConfigAttributes(map);
 
-        assertThat(gitMaterialConfig.getUrl(), is("url"));
-        assertThat(gitMaterialConfig.getFolder(), is("folder"));
-        assertThat(gitMaterialConfig.getBranch(), is("some-branch"));
-        assertThat(gitMaterialConfig.getName(), is(new CaseInsensitiveString("material-name")));
-        assertThat(gitMaterialConfig.isAutoUpdate(), is(false));
-        assertThat(gitMaterialConfig.isShallowClone(), is(true));
-        assertThat(gitMaterialConfig.filter(), is(new Filter(new IgnoredFiles("/root"), new IgnoredFiles("/**/*.help"))));
-    }
-    
-    @Test
-    public void byDefaultShallowCloneShouldBeOff() {
-        assertThat(new GitMaterialConfig("http://url", "foo").isShallowClone(), is(false));
-        assertThat(new GitMaterialConfig("http://url", "foo", false).isShallowClone(), is(false));
-        assertThat(new GitMaterialConfig("http://url", "foo", null).isShallowClone(), is(false));
-        assertThat(new GitMaterialConfig("http://url", "foo", true).isShallowClone(), is(true));
+        assertThat(gitMaterialConfig.getUrl()).isEqualTo("url");
+        assertThat(gitMaterialConfig.getFolder()).isEqualTo("folder");
+        assertThat(gitMaterialConfig.getBranch()).isEqualTo("some-branch");
+        assertThat(gitMaterialConfig.getName()).isEqualTo(new CaseInsensitiveString("material-name"));
+        assertThat(gitMaterialConfig.isAutoUpdate()).isFalse();
+        assertThat(gitMaterialConfig.isShallowClone()).isTrue();
+        assertThat(gitMaterialConfig.filter()).isEqualTo(new Filter(new IgnoredFiles("/root"), new IgnoredFiles("/**/*.help")));
     }
 
     @Test
-    public void validate_shouldEnsureUrlIsNotBlank() {
-        GitMaterialConfig gitMaterialConfig = new GitMaterialConfig("");
-        gitMaterialConfig.validate(new ConfigSaveValidationContext(null));
-        assertThat(gitMaterialConfig.errors().on(GitMaterialConfig.URL), is("URL cannot be blank"));
+    void byDefaultShallowCloneShouldBeOff() {
+        assertThat(new GitMaterialConfig("http://url", "foo").isShallowClone()).isFalse();
+        assertThat(new GitMaterialConfig("http://url", "foo", false).isShallowClone()).isFalse();
+        assertThat(new GitMaterialConfig("http://url", "foo", null).isShallowClone()).isFalse();
+        assertThat(new GitMaterialConfig("http://url", "foo", true).isShallowClone()).isTrue();
     }
 
     @Test
-    public void shouldReturnIfAttributeMapIsNull() {
+    void shouldReturnIfAttributeMapIsNull() {
         GitMaterialConfig gitMaterialConfig = new GitMaterialConfig("");
         gitMaterialConfig.setConfigAttributes(null);
-        assertThat(gitMaterialConfig, is(new GitMaterialConfig("")));
+        assertThat(gitMaterialConfig).isEqualTo(new GitMaterialConfig(""));
     }
 
     @Test
-    public void shouldReturnTheUrl() {
+    void shouldReturnTheUrl() {
         String url = "git@github.com/my/repo";
         GitMaterialConfig config = new GitMaterialConfig(url);
 
-        assertThat(config.getUrl(), is(url));
+        assertThat(config.getUrl()).isEqualTo(url);
     }
 
     @Test
-    public void shouldReturnNullIfUrlForMaterialNotSpecified() {
+    void shouldReturnNullIfUrlForMaterialNotSpecified() {
         GitMaterialConfig config = new GitMaterialConfig();
 
-        assertNull(config.getUrl());
+        assertThat(config.getUrl()).isNull();
     }
 
     @Test
-    public void shouldSetUrlForAMaterial() {
+    void shouldSetUrlForAMaterial() {
         String url = "git@github.com/my/repo";
         GitMaterialConfig config = new GitMaterialConfig();
 
         config.setUrl(url);
 
-        assertThat(config.getUrl(), is(url));
+        assertThat(config.getUrl()).isEqualTo(url);
     }
 
     @Test
-    public void shouldHandleNullWhenSettingUrlForAMaterial() {
+    void shouldHandleNullWhenSettingUrlForAMaterial() {
         GitMaterialConfig config = new GitMaterialConfig();
 
         config.setUrl(null);
 
-        assertNull(config.getUrl());
+        assertThat(config.getUrl()).isNull();
     }
 
     @Test
-    public void shouldHandleNullUrlAtTheTimeOfGitMaterialConfigCreation() {
+    void shouldHandleNullUrlAtTheTimeOfGitMaterialConfigCreation() {
         GitMaterialConfig config = new GitMaterialConfig(null);
 
-        assertNull(config.getUrl());
+        assertThat(config.getUrl()).isNull();
     }
 
     @Test
-    public void shouldHandleNullBranchAtTheTimeOfMaterialConfigCreation() {
+    void shouldHandleNullBranchAtTheTimeOfMaterialConfigCreation() {
         GitMaterialConfig config1 = new GitMaterialConfig("http://url", null);
         GitMaterialConfig config2 = new GitMaterialConfig(new UrlArgument("http://url"), null, "sub1", true, new Filter(), false, "folder", new CaseInsensitiveString("git"), false);
 
-        assertThat(config1.getBranch(), is("master"));
-        assertThat(config2.getBranch(), is("master"));
+        assertThat(config1.getBranch()).isEqualTo("master");
+        assertThat(config2.getBranch()).isEqualTo("master");
     }
 
     @Test
-    public void shouldHandleNullBranchWhileSettingConfigAttributes() {
+    void shouldHandleNullBranchWhileSettingConfigAttributes() {
         GitMaterialConfig gitMaterialConfig = new GitMaterialConfig("http://url", "foo");
         gitMaterialConfig.setConfigAttributes(Collections.singletonMap(GitMaterialConfig.BRANCH, null));
-        assertThat(gitMaterialConfig.getBranch(), is("master"));
+        assertThat(gitMaterialConfig.getBranch()).isEqualTo("master");
     }
 
     @Test
-    public void shouldHandleEmptyBranchWhileSettingConfigAttributes() {
+    void shouldHandleEmptyBranchWhileSettingConfigAttributes() {
         GitMaterialConfig gitMaterialConfig = new GitMaterialConfig("http://url", "foo");
         gitMaterialConfig.setConfigAttributes(Collections.singletonMap(GitMaterialConfig.BRANCH, "     "));
-        assertThat(gitMaterialConfig.getBranch(), is("master"));
+        assertThat(gitMaterialConfig.getBranch()).isEqualTo("master");
+    }
+
+    @Nested
+    class Validate {
+        @Test
+        void shouldEnsureUrlIsNotBlank() {
+            GitMaterialConfig gitMaterialConfig = new GitMaterialConfig("");
+            gitMaterialConfig.validate(new ConfigSaveValidationContext(null));
+            assertThat(gitMaterialConfig.errors().on(GitMaterialConfig.URL)).isEqualTo("URL cannot be blank");
+        }
+
+        @Test
+        void shouldFailValidationIfMaterialURLHasSecretParamsConfiguredOtherThanForUsernamePassword() {
+            final ValidationContext validationContext = mock(ValidationContext.class);
+            final CruiseConfig cruiseConfig = mock(CruiseConfig.class);
+            when(validationContext.getCruiseConfig()).thenReturn(cruiseConfig);
+            when(cruiseConfig.getSecretConfigs()).thenReturn(new SecretConfigs());
+
+            final GitMaterialConfig gitMaterialConfig = gitMaterialConfig("https://user:pass@{{SECRET:[secret_config_id][hostname]}}/foo.git");
+
+            assertThat(gitMaterialConfig.validateTree(validationContext)).isFalse();
+            assertThat(gitMaterialConfig.errors().on("url")).isEqualTo("Only username and password can be specified as secret params");
+        }
+
+        @Test
+        void shouldFailIfSecretParamConfiguredWithSecretConfigIdWhichIsNotExist() {
+            final ValidationContext validationContext = mock(ValidationContext.class);
+            final CruiseConfig cruiseConfig = mock(CruiseConfig.class);
+            when(validationContext.getCruiseConfig()).thenReturn(cruiseConfig);
+            when(cruiseConfig.getSecretConfigs()).thenReturn(new SecretConfigs());
+
+            final GitMaterialConfig gitMaterialConfig = gitMaterialConfig("https://{{SECRET:[secret_config_id_1][username]}}:{{SECRET:[secret_config_id_2][pass]}}@host/foo.git");
+
+            assertThat(gitMaterialConfig.validateTree(validationContext)).isFalse();
+            assertThat(gitMaterialConfig.errors().on("url")).isEqualTo("Secret configs '[secret_config_id_1, secret_config_id_2]' does not exist");
+        }
+
+        @Test
+        void shouldNotFailIfSecretConfigWithIdPresentForConfiguredSecretParams() {
+            final ValidationContext validationContext = mock(ValidationContext.class);
+            final CruiseConfig cruiseConfig = mock(CruiseConfig.class);
+            when(validationContext.getCruiseConfig()).thenReturn(cruiseConfig);
+            when(cruiseConfig.getSecretConfigs()).thenReturn(new SecretConfigs(new SecretConfig("secret_config_id", "cd.go.secret.file")));
+
+            final GitMaterialConfig gitMaterialConfig = gitMaterialConfig("https://{{SECRET:[secret_config_id][pass]}}:password@host/foo.git");
+
+            assertThat(gitMaterialConfig.validateTree(validationContext)).isTrue();
+            assertThat(gitMaterialConfig.errors().getAll()).isEmpty();
+        }
     }
 }

--- a/config/config-api/src/test/java/com/thoughtworks/go/config/materials/mercurial/HgMaterialConfigTest.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/config/materials/mercurial/HgMaterialConfigTest.java
@@ -156,23 +156,23 @@ class HgMaterialConfigTest {
             hgMaterialConfig.setUrl("https://user:pass@{{SECRET:[secret_config_id][hostname]}}/foo.git");
 
             assertThat(hgMaterialConfig.validateTree(validationContext)).isFalse();
-            assertThat(hgMaterialConfig.errors().on("url")).isEqualTo("Only username and password can be specified as secret params");
+            assertThat(hgMaterialConfig.errors().on("url")).isEqualTo("Only password can be specified as secret params");
         }
 
         @Test
         void shouldFailIfSecretParamConfiguredWithSecretConfigIdWhichDoesNotExist() {
             final ValidationContext validationContext = mockValidationContextForSecretParams();
-            hgMaterialConfig.setUrl("https://{{SECRET:[secret_config_id_1][user]}}:{{SECRET:[secret_config_id_2][pass]}}@host/foo.git");
+            hgMaterialConfig.setUrl("https://username:{{SECRET:[secret_config_id][pass]}}@host/foo.git");
 
             assertThat(hgMaterialConfig.validateTree(validationContext)).isFalse();
-            assertThat(hgMaterialConfig.errors().on("url")).isEqualTo("Secret configs '[secret_config_id_1, secret_config_id_2]' does not exist");
+            assertThat(hgMaterialConfig.errors().on("url")).isEqualTo("Secret configs '[secret_config_id]' does not exist");
         }
 
         @Test
         void shouldNotFailIfSecretConfigWithIdPresentForConfiguredSecretParams() {
             final SecretConfig secretConfig = new SecretConfig("secret_config_id", "cd.go.secret.file");
             final ValidationContext validationContext = mockValidationContextForSecretParams(secretConfig);
-            hgMaterialConfig.setUrl("https://{{SECRET:[secret_config_id][username]}}:password@host/foo.git");
+            hgMaterialConfig.setUrl("https://username:{{SECRET:[secret_config_id][username]}}@host/foo.git");
 
             assertThat(hgMaterialConfig.validateTree(validationContext)).isTrue();
             assertThat(hgMaterialConfig.errors().getAll()).isEmpty();

--- a/config/config-api/src/test/java/com/thoughtworks/go/config/materials/mercurial/HgMaterialConfigTest.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/config/materials/mercurial/HgMaterialConfigTest.java
@@ -16,24 +16,36 @@
 
 package com.thoughtworks.go.config.materials.mercurial;
 
-import com.thoughtworks.go.config.CaseInsensitiveString;
-import com.thoughtworks.go.config.ConfigSaveValidationContext;
+import com.thoughtworks.go.config.*;
 import com.thoughtworks.go.config.materials.AbstractMaterialConfig;
 import com.thoughtworks.go.config.materials.Filter;
 import com.thoughtworks.go.config.materials.IgnoredFiles;
 import com.thoughtworks.go.config.materials.ScmMaterialConfig;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
+import static com.thoughtworks.go.config.materials.AbstractMaterialConfig.MATERIAL_NAME;
+import static com.thoughtworks.go.config.materials.ScmMaterialConfig.FOLDER;
+import static com.thoughtworks.go.config.materials.ScmMaterialConfig.URL;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
-public class HgMaterialConfigTest {
+class HgMaterialConfigTest {
+    private HgMaterialConfig hgMaterialConfig;
+
+    @BeforeEach
+    void setUp() {
+        hgMaterialConfig = new HgMaterialConfig("", null);
+    }
+
     @Test
-    public void shouldSetConfigAttributes() {
+    void shouldSetConfigAttributes() {
         HgMaterialConfig hgMaterialConfig = new HgMaterialConfig("", null);
 
         Map<String, String> map = new HashMap<>();
@@ -45,60 +57,133 @@ public class HgMaterialConfigTest {
 
         hgMaterialConfig.setConfigAttributes(map);
 
-        assertThat(hgMaterialConfig.getUrl(), is("url"));
-        assertThat(hgMaterialConfig.getFolder(), is("folder"));
-        assertThat(hgMaterialConfig.getName(), is(new CaseInsensitiveString("material-name")));
-        assertThat(hgMaterialConfig.isAutoUpdate(), is(false));
-        assertThat(hgMaterialConfig.filter(), is(new Filter(new IgnoredFiles("/root"), new IgnoredFiles("/**/*.help"))));
+        assertThat(hgMaterialConfig.getUrl()).isEqualTo("url");
+        assertThat(hgMaterialConfig.getFolder()).isEqualTo("folder");
+        assertThat(hgMaterialConfig.getName()).isEqualTo(new CaseInsensitiveString("material-name"));
+        assertThat(hgMaterialConfig.isAutoUpdate()).isFalse();
+        assertThat(hgMaterialConfig.filter()).isEqualTo(new Filter(new IgnoredFiles("/root"), new IgnoredFiles("/**/*.help")));
     }
 
     @Test
-    public void validate_shouldEnsureUrlIsNotBlank() {
+    void validate_shouldEnsureUrlIsNotBlank() {
         HgMaterialConfig hgMaterialConfig = new HgMaterialConfig("", null);
         hgMaterialConfig.validate(new ConfigSaveValidationContext(null));
-        assertThat(hgMaterialConfig.errors().on(HgMaterialConfig.URL), is("URL cannot be blank"));
+        assertThat(hgMaterialConfig.errors().on(HgMaterialConfig.URL)).isEqualTo("URL cannot be blank");
     }
 
     @Test
-    public void shouldReturnIfAttributeMapIsNull() {
+    void shouldReturnIfAttributeMapIsNull() {
         HgMaterialConfig hgMaterialConfig = new HgMaterialConfig("", null);
 
         hgMaterialConfig.setConfigAttributes(null);
 
-        assertThat(hgMaterialConfig, is(new HgMaterialConfig("", null)));
+        assertThat(hgMaterialConfig).isEqualTo(new HgMaterialConfig("", null));
     }
 
     @Test
-    public void shouldReturnTheUrl() {
+    void shouldReturnTheUrl() {
         String url = "git@github.com/my/repo";
         HgMaterialConfig config = new HgMaterialConfig(url, null);
 
-        assertThat(config.getUrl(), is(url));
+        assertThat(config.getUrl()).isEqualTo(url);
     }
 
     @Test
-    public void shouldReturnNullIfUrlForMaterialNotSpecified() {
+    void shouldReturnNullIfUrlForMaterialNotSpecified() {
         HgMaterialConfig config = new HgMaterialConfig();
 
-        assertNull(config.getUrl());
+        assertThat(config.getUrl()).isNull();
     }
 
     @Test
-    public void shouldSetUrlForAMaterial() {
+    void shouldSetUrlForAMaterial() {
         String url = "git@github.com/my/repo";
         HgMaterialConfig config = new HgMaterialConfig();
 
         config.setUrl(url);
 
-        assertThat(config.getUrl(), is(url));
+        assertThat(config.getUrl()).isEqualTo(url);
     }
 
     @Test
-    public void shouldHandleNullWhenSettingUrlForAMaterial() {
+    void shouldHandleNullWhenSettingUrlForAMaterial() {
         HgMaterialConfig config = new HgMaterialConfig();
 
         config.setUrl(null);
 
-        assertNull(config.getUrl());
+        assertThat(config.getUrl()).isNull();
+    }
+
+    @Nested
+    class ValidateURL {
+        @Test
+        void shouldEnsureUrlIsNotBlank() {
+            hgMaterialConfig.setUrl("");
+            hgMaterialConfig.validate(new ConfigSaveValidationContext(null));
+
+            assertThat(hgMaterialConfig.errors().on(ScmMaterialConfig.URL)).isEqualTo("URL cannot be blank");
+        }
+
+        @Test
+        void shouldEnsureUrlIsNotNull() {
+            hgMaterialConfig.setUrl(null);
+
+            hgMaterialConfig.validate(new ConfigSaveValidationContext(null));
+
+            assertThat(hgMaterialConfig.errors().on(URL)).isEqualTo("URL cannot be blank");
+        }
+
+        @Test
+        void shouldEnsureMaterialNameIsValid() {
+            hgMaterialConfig.validate(new ConfigSaveValidationContext(null));
+            assertThat(hgMaterialConfig.errors().on(MATERIAL_NAME)).isNull();
+
+            hgMaterialConfig.setName(new CaseInsensitiveString(".bad-name-with-dot"));
+            hgMaterialConfig.validate(new ConfigSaveValidationContext(null));
+            assertThat(hgMaterialConfig.errors().on(MATERIAL_NAME)).isEqualTo("Invalid material name '.bad-name-with-dot'. This must be alphanumeric and can contain underscores and periods (however, it cannot start with a period). The maximum allowed length is 255 characters.");
+        }
+
+        @Test
+        void shouldEnsureDestFilePathIsValid() {
+            hgMaterialConfig.setConfigAttributes(Collections.singletonMap(FOLDER, "../a"));
+            hgMaterialConfig.validate(new ConfigSaveValidationContext(null));
+            assertThat(hgMaterialConfig.errors().on(FOLDER)).isEqualTo("Dest folder '../a' is not valid. It must be a sub-directory of the working folder.");
+        }
+
+        @Test
+        void shouldFailValidationIfMaterialURLHasSecretParamsConfiguredOtherThanForUsernamePassword() {
+            final ValidationContext validationContext = mockValidationContextForSecretParams();
+            hgMaterialConfig.setUrl("https://user:pass@{{SECRET:[secret_config_id][hostname]}}/foo.git");
+
+            assertThat(hgMaterialConfig.validateTree(validationContext)).isFalse();
+            assertThat(hgMaterialConfig.errors().on("url")).isEqualTo("Only username and password can be specified as secret params");
+        }
+
+        @Test
+        void shouldFailIfSecretParamConfiguredWithSecretConfigIdWhichDoesNotExist() {
+            final ValidationContext validationContext = mockValidationContextForSecretParams();
+            hgMaterialConfig.setUrl("https://{{SECRET:[secret_config_id_1][user]}}:{{SECRET:[secret_config_id_2][pass]}}@host/foo.git");
+
+            assertThat(hgMaterialConfig.validateTree(validationContext)).isFalse();
+            assertThat(hgMaterialConfig.errors().on("url")).isEqualTo("Secret configs '[secret_config_id_1, secret_config_id_2]' does not exist");
+        }
+
+        @Test
+        void shouldNotFailIfSecretConfigWithIdPresentForConfiguredSecretParams() {
+            final SecretConfig secretConfig = new SecretConfig("secret_config_id", "cd.go.secret.file");
+            final ValidationContext validationContext = mockValidationContextForSecretParams(secretConfig);
+            hgMaterialConfig.setUrl("https://{{SECRET:[secret_config_id][username]}}:password@host/foo.git");
+
+            assertThat(hgMaterialConfig.validateTree(validationContext)).isTrue();
+            assertThat(hgMaterialConfig.errors().getAll()).isEmpty();
+        }
+    }
+
+    private ValidationContext mockValidationContextForSecretParams(SecretConfig... secretConfigs) {
+        final ValidationContext validationContext = mock(ValidationContext.class);
+        final CruiseConfig cruiseConfig = mock(CruiseConfig.class);
+        when(validationContext.getCruiseConfig()).thenReturn(cruiseConfig);
+        when(cruiseConfig.getSecretConfigs()).thenReturn(new SecretConfigs(secretConfigs));
+        return validationContext;
     }
 }

--- a/config/config-api/src/test/java/com/thoughtworks/go/config/materials/mercurial/HgMaterialConfigTest.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/config/materials/mercurial/HgMaterialConfigTest.java
@@ -165,7 +165,7 @@ class HgMaterialConfigTest {
             hgMaterialConfig.setUrl("https://username:{{SECRET:[secret_config_id][pass]}}@host/foo.git");
 
             assertThat(hgMaterialConfig.validateTree(validationContext)).isFalse();
-            assertThat(hgMaterialConfig.errors().on("url")).isEqualTo("Secret configs '[secret_config_id]' does not exist");
+            assertThat(hgMaterialConfig.errors().on("url")).isEqualTo("Secret configs secret_config_id does not exist");
         }
 
         @Test

--- a/config/config-api/src/test/java/com/thoughtworks/go/config/materials/perforce/P4MaterialConfigTest.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/config/materials/perforce/P4MaterialConfigTest.java
@@ -176,7 +176,7 @@ class P4MaterialConfigTest {
             p4MaterialConfig.setPassword("{{SECRET:[secret_config_id][password]}}");
 
             assertThat(p4MaterialConfig.validateTree(validationContext)).isFalse();
-            assertThat(p4MaterialConfig.errors().on("encryptedPassword")).isEqualTo("Secret configs '[secret_config_id]' does not exist");
+            assertThat(p4MaterialConfig.errors().on("encryptedPassword")).isEqualTo("Secret configs secret_config_id does not exist");
         }
     }
 

--- a/config/config-api/src/test/java/com/thoughtworks/go/config/materials/svn/SvnMaterialConfigTest.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/config/materials/svn/SvnMaterialConfigTest.java
@@ -16,35 +16,29 @@
 
 package com.thoughtworks.go.config.materials.svn;
 
-import com.thoughtworks.go.config.CaseInsensitiveString;
-import com.thoughtworks.go.config.ConfigSaveValidationContext;
+import com.thoughtworks.go.config.*;
 import com.thoughtworks.go.config.materials.AbstractMaterialConfig;
 import com.thoughtworks.go.config.materials.Filter;
 import com.thoughtworks.go.config.materials.IgnoredFiles;
 import com.thoughtworks.go.config.materials.ScmMaterialConfig;
+import com.thoughtworks.go.config.materials.git.GitMaterialConfig;
+import com.thoughtworks.go.helper.MaterialConfigsMother;
 import com.thoughtworks.go.security.GoCipher;
 import com.thoughtworks.go.util.ReflectionUtil;
-import com.thoughtworks.go.util.command.UrlArgument;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.nullValue;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
-public class SvnMaterialConfigTest {
-
-    @Before
-    public void setUp() throws Exception {
-    }
-
+class SvnMaterialConfigTest {
     @Test
-    public void shouldSetConfigAttributes() {
+    void shouldSetConfigAttributes() {
         SvnMaterialConfig svnMaterialConfig = new SvnMaterialConfig("", "", "", false);
 
         Map<String, String> map = new HashMap<>();
@@ -58,118 +52,192 @@ public class SvnMaterialConfigTest {
 
         svnMaterialConfig.setConfigAttributes(map);
 
-        assertThat(svnMaterialConfig.getUrl(), is("url"));
-        assertThat(svnMaterialConfig.getUserName(), is("username"));
-        assertThat(svnMaterialConfig.isCheckExternals(), is(true));
-        assertThat(svnMaterialConfig.getFolder(), is("folder"));
-        assertThat(svnMaterialConfig.getName(), is(new CaseInsensitiveString("material-name")));
-        assertThat(svnMaterialConfig.isAutoUpdate(), is(false));
-        assertThat(svnMaterialConfig.filter(), is(new Filter(new IgnoredFiles("/root"), new IgnoredFiles("/**/*.help"))));
+        assertThat(svnMaterialConfig.getUrl()).isEqualTo("url");
+        assertThat(svnMaterialConfig.getUserName()).isEqualTo("username");
+        assertThat(svnMaterialConfig.isCheckExternals()).isTrue();
+        assertThat(svnMaterialConfig.getFolder()).isEqualTo("folder");
+        assertThat(svnMaterialConfig.getName()).isEqualTo(new CaseInsensitiveString("material-name"));
+        assertThat(svnMaterialConfig.isAutoUpdate()).isFalse();
+        assertThat(svnMaterialConfig.filter()).isEqualTo(new Filter(new IgnoredFiles("/root"), new IgnoredFiles("/**/*.help")));
     }
 
     @Test
-    public void validate_shouldEnsureUrlIsNotBlank() {
-        SvnMaterialConfig svnMaterialConfig = new SvnMaterialConfig("", "", "", false);
-        svnMaterialConfig.validate(new ConfigSaveValidationContext(null));
-        assertThat(svnMaterialConfig.errors().on(SvnMaterialConfig.URL), is("URL cannot be blank"));
-    }
-
-    @Test
-    public void validate_shouldEnsureUrlIsNotNull() {
-        SvnMaterialConfig svnMaterialConfig = new SvnMaterialConfig();
-        svnMaterialConfig.setUrl(null);
-
-        svnMaterialConfig.validate(new ConfigSaveValidationContext(null));
-
-        assertThat(svnMaterialConfig.errors().on(SvnMaterialConfig.URL), is("URL cannot be blank"));
-    }
-
-    @Test
-    public void validate_shouldEnsureMaterialNameIsValid() {
-        SvnMaterialConfig svnMaterialConfig = new SvnMaterialConfig("/foo", "", "", false);
-        svnMaterialConfig.validate(new ConfigSaveValidationContext(null));
-        assertThat(svnMaterialConfig.errors().on(SvnMaterialConfig.MATERIAL_NAME), is(nullValue()));
-
-        svnMaterialConfig.setName(new CaseInsensitiveString(".bad-name-with-dot"));
-        svnMaterialConfig.validate(new ConfigSaveValidationContext(null));
-        assertThat(svnMaterialConfig.errors().on(SvnMaterialConfig.MATERIAL_NAME),
-                is("Invalid material name '.bad-name-with-dot'. This must be alphanumeric and can contain underscores and periods (however, it cannot start with a period). The maximum allowed length is 255 characters."));
-    }
-
-    @Test
-    public void validate_shouldEnsureDestFilePathIsValid() {
-        SvnMaterialConfig svnMaterialConfig = new SvnMaterialConfig("/foo", "", "", false);
-        svnMaterialConfig.setConfigAttributes(Collections.singletonMap(ScmMaterialConfig.FOLDER, "../a"));
-        svnMaterialConfig.validate(new ConfigSaveValidationContext(null));
-        assertThat(svnMaterialConfig.errors().on(SvnMaterialConfig.FOLDER), is("Dest folder '../a' is not valid. It must be a sub-directory of the working folder."));
-    }
-
-    @Test
-    public void shouldThrowErrorsIfBothPasswordAndEncryptedPasswordAreProvided() {
-        SvnMaterialConfig svnMaterialConfig = new SvnMaterialConfig(new UrlArgument("foo/bar"), "password", "encryptedPassword", new GoCipher(), null, false, "folder");
-        svnMaterialConfig.validate(new ConfigSaveValidationContext(null));
-        assertThat(svnMaterialConfig.errors().on("password"), is("You may only specify `password` or `encrypted_password`, not both!"));
-        assertThat(svnMaterialConfig.errors().on("encryptedPassword"), is("You may only specify `password` or `encrypted_password`, not both!"));
-    }
-
-    @Test
-    public void shouldValidateWhetherTheEncryptedPasswordIsCorrect() {
-        SvnMaterialConfig svnMaterialConfig = new SvnMaterialConfig(new UrlArgument("foo/bar"), "", "encryptedPassword", new GoCipher(), null, false, "folder");
-        svnMaterialConfig.validate(new ConfigSaveValidationContext(null));
-        assertThat(svnMaterialConfig.errors().on("encryptedPassword"), is("Encrypted password value for svn material with url 'foo/bar' is invalid. This usually happens when the cipher text is modified to have an invalid value."));
-    }
-
-    @Test
-    public void setConfigAttributes_shouldUpdatePasswordWhenPasswordChangedBooleanChanged() throws Exception {
+    void setConfigAttributes_shouldUpdatePasswordWhenPasswordChangedBooleanChanged() throws Exception {
         SvnMaterialConfig svnMaterial = new SvnMaterialConfig("", "", "notSoSecret", false);
         Map<String, String> map = new HashMap<>();
         map.put(SvnMaterialConfig.PASSWORD, "secret");
         map.put(SvnMaterialConfig.PASSWORD_CHANGED, "1");
 
         svnMaterial.setConfigAttributes(map);
-        assertThat(ReflectionUtil.getField(svnMaterial, "password"), is(nullValue()));
-        assertThat(svnMaterial.getPassword(), is("secret"));
-        assertThat(svnMaterial.getEncryptedPassword(), is(new GoCipher().encrypt("secret")));
+        assertThat(ReflectionUtil.getField(svnMaterial, "password")).isNull();
+        assertThat(svnMaterial.getPassword()).isEqualTo("secret");
+        assertThat(svnMaterial.getEncryptedPassword()).isEqualTo(new GoCipher().encrypt("secret"));
 
         //Dont change
         map.put(SvnMaterialConfig.PASSWORD, "Hehehe");
         map.put(SvnMaterialConfig.PASSWORD_CHANGED, "0");
         svnMaterial.setConfigAttributes(map);
 
-        assertThat(ReflectionUtil.getField(svnMaterial, "password"), is(nullValue()));
-        assertThat(svnMaterial.getPassword(), is("secret"));
-        assertThat(svnMaterial.getEncryptedPassword(), is(new GoCipher().encrypt("secret")));
+        assertThat(ReflectionUtil.getField(svnMaterial, "password")).isNull();
+        assertThat(svnMaterial.getPassword()).isEqualTo("secret");
+        assertThat(svnMaterial.getEncryptedPassword()).isEqualTo(new GoCipher().encrypt("secret"));
 
         map.put(SvnMaterialConfig.PASSWORD, "");
         map.put(SvnMaterialConfig.PASSWORD_CHANGED, "1");
         svnMaterial.setConfigAttributes(map);
 
-        assertThat(svnMaterial.getPassword(), is(nullValue()));
-        assertThat(svnMaterial.getEncryptedPassword(), is(nullValue()));
+        assertThat(svnMaterial.getPassword()).isNull();
+        assertThat(svnMaterial.getEncryptedPassword()).isNull();
     }
 
     @Test
-    public void shouldReturnTheUrl() {
+    void shouldReturnTheUrl() {
         String url = "git@github.com/my/repo";
         SvnMaterialConfig config = new SvnMaterialConfig();
         config.setUrl(url);
 
-        assertThat(config.getUrl(), is(url));
+        assertThat(config.getUrl()).isEqualTo(url);
     }
 
     @Test
-    public void shouldReturnNullIfUrlForMaterialNotSpecified() {
+    void shouldReturnNullIfUrlForMaterialNotSpecified() {
         SvnMaterialConfig config = new SvnMaterialConfig();
 
-        assertNull(config.getUrl());
+        assertThat(config.getUrl()).isNull();
     }
 
     @Test
-    public void shouldHandleNullWhenSettingUrlForAMaterial() {
+    void shouldHandleNullWhenSettingUrlForAMaterial() {
         SvnMaterialConfig config = new SvnMaterialConfig();
 
         config.setUrl(null);
 
-        assertNull(config.getUrl());
+        assertThat(config.getUrl()).isNull();
+    }
+
+    @Nested
+    class ValidateURL {
+        @Test
+        void shouldEnsureUrlIsNotBlank() {
+            SvnMaterialConfig svnMaterialConfig = new SvnMaterialConfig("", false);
+            svnMaterialConfig.validate(new ConfigSaveValidationContext(null));
+
+            assertThat(svnMaterialConfig.errors().on(GitMaterialConfig.URL)).isEqualTo("URL cannot be blank");
+        }
+
+        @Test
+        void shouldEnsureUrlIsNotNull() {
+            SvnMaterialConfig svnMaterialConfig = new SvnMaterialConfig();
+            svnMaterialConfig.setUrl(null);
+
+            svnMaterialConfig.validate(new ConfigSaveValidationContext(null));
+
+            assertThat(svnMaterialConfig.errors().on(SvnMaterialConfig.URL)).isEqualTo("URL cannot be blank");
+        }
+
+        @Test
+        void shouldEnsureMaterialNameIsValid() {
+            SvnMaterialConfig svnMaterialConfig = new SvnMaterialConfig("/foo", "", "", false);
+            svnMaterialConfig.validate(new ConfigSaveValidationContext(null));
+            assertThat(svnMaterialConfig.errors().on(SvnMaterialConfig.MATERIAL_NAME)).isNull();
+
+            svnMaterialConfig.setName(new CaseInsensitiveString(".bad-name-with-dot"));
+            svnMaterialConfig.validate(new ConfigSaveValidationContext(null));
+            assertThat(svnMaterialConfig.errors().on(SvnMaterialConfig.MATERIAL_NAME)).isEqualTo("Invalid material name '.bad-name-with-dot'. This must be alphanumeric and can contain underscores and periods (however, it cannot start with a period). The maximum allowed length is 255 characters.");
+        }
+
+        @Test
+        void shouldEnsureDestFilePathIsValid() {
+            SvnMaterialConfig svnMaterialConfig = new SvnMaterialConfig("/foo", "", "", false);
+            svnMaterialConfig.setConfigAttributes(Collections.singletonMap(ScmMaterialConfig.FOLDER, "../a"));
+            svnMaterialConfig.validate(new ConfigSaveValidationContext(null));
+            assertThat(svnMaterialConfig.errors().on(SvnMaterialConfig.FOLDER)).isEqualTo("Dest folder '../a' is not valid. It must be a sub-directory of the working folder.");
+        }
+
+        @Test
+        void shouldFailValidationIfMaterialURLHasSecretParamsConfiguredOtherThanForUsernamePassword() {
+            final ValidationContext validationContext = mockValidationContextForSecretParams();
+
+            final SvnMaterialConfig svnMaterialConfig = MaterialConfigsMother.svnMaterialConfig("https://user:pass@{{SECRET:[secret_config_id][hostname]}}/foo.git",
+                    null);
+
+            assertThat(svnMaterialConfig.validateTree(validationContext)).isFalse();
+            assertThat(svnMaterialConfig.errors().on("url")).isEqualTo("Only username and password can be specified as secret params");
+        }
+
+        @Test
+        void shouldFailIfSecretParamConfiguredWithSecretConfigIdWhichDoesNotExist() {
+            final ValidationContext validationContext = mockValidationContextForSecretParams();
+
+
+            final SvnMaterialConfig svnMaterialConfig = MaterialConfigsMother.svnMaterialConfig("https://{{SECRET:[secret_config_id_1][user]}}:{{SECRET:[secret_config_id_2][pass]}}@host/foo.git", null);
+
+            assertThat(svnMaterialConfig.validateTree(validationContext)).isFalse();
+            assertThat(svnMaterialConfig.errors().on("url")).isEqualTo("Secret configs '[secret_config_id_1, secret_config_id_2]' does not exist");
+        }
+
+        @Test
+        void shouldNotFailIfSecretConfigWithIdPresentForConfiguredSecretParams() {
+            final SecretConfig secretConfig = new SecretConfig("secret_config_id", "cd.go.secret.file");
+            final ValidationContext validationContext = mockValidationContextForSecretParams(secretConfig);
+
+            final SvnMaterialConfig svnMaterialConfig = MaterialConfigsMother.svnMaterialConfig("https://{{SECRET:[secret_config_id][username]}}:password@host/foo.git", null);
+
+            assertThat(svnMaterialConfig.validateTree(validationContext)).isTrue();
+            assertThat(svnMaterialConfig.errors().getAll()).isEmpty();
+        }
+    }
+
+    @Nested
+    class ValidatePassword {
+        @Test
+        void shouldFailIfEncryptedPasswordIsIncorrect() {
+            SvnMaterialConfig svnMaterialConfig = new SvnMaterialConfig("foo/bar", "", "password", false);
+            svnMaterialConfig.setEncryptedPassword("encryptedPassword");
+
+            final boolean validationResult = svnMaterialConfig.validateTree(new ConfigSaveValidationContext(null));
+
+            assertThat(validationResult).isFalse();
+            assertThat(svnMaterialConfig.errors().on("encryptedPassword")).isEqualTo("Encrypted password value for svn material with url 'foo/bar' is invalid. This usually happens when the cipher text is modified to have an invalid value.");
+        }
+
+        @Test
+        void shouldPassIfPasswordIsNotSpecifiedAsSecretParams() {
+            final SvnMaterialConfig svnMaterialConfig = MaterialConfigsMother.svnMaterialConfig("url", null);
+            svnMaterialConfig.setPassword("badger");
+
+            assertThat(svnMaterialConfig.validateTree(null)).isTrue();
+            assertThat(svnMaterialConfig.errors().getAll()).isEmpty();
+        }
+
+        @Test
+        void shouldPassIfPasswordSpecifiedAsSecretParamIsValid() {
+            final ValidationContext validationContext = mockValidationContextForSecretParams(new SecretConfig("secret_config_id", "cd.go.secret.file"));
+
+            final SvnMaterialConfig svnMaterialConfig = MaterialConfigsMother.svnMaterialConfig("url", null);
+            svnMaterialConfig.setPassword("{{SECRET:[secret_config_id][password]}}");
+
+            assertThat(svnMaterialConfig.validateTree(validationContext)).isTrue();
+            assertThat(svnMaterialConfig.errors().getAll()).isEmpty();
+        }
+
+        @Test
+        void shouldFailIfSecretConfigForPasswordSpecifiedAsSecretParamDoesNotExist() {
+            final ValidationContext validationContext = mockValidationContextForSecretParams();
+
+            final SvnMaterialConfig svnMaterialConfig = MaterialConfigsMother.svnMaterialConfig("url", null);
+            svnMaterialConfig.setPassword("{{SECRET:[secret_config_id][password]}}");
+
+            assertThat(svnMaterialConfig.validateTree(validationContext)).isFalse();
+            assertThat(svnMaterialConfig.errors().on("encryptedPassword")).isEqualTo("Secret configs '[secret_config_id]' does not exist");
+        }
+    }
+
+    private ValidationContext mockValidationContextForSecretParams(SecretConfig... secretConfigs) {
+        final ValidationContext validationContext = mock(ValidationContext.class);
+        final CruiseConfig cruiseConfig = mock(CruiseConfig.class);
+        when(validationContext.getCruiseConfig()).thenReturn(cruiseConfig);
+        when(cruiseConfig.getSecretConfigs()).thenReturn(new SecretConfigs(secretConfigs));
+        return validationContext;
     }
 }

--- a/config/config-api/src/test/java/com/thoughtworks/go/config/materials/svn/SvnMaterialConfigTest.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/config/materials/svn/SvnMaterialConfigTest.java
@@ -174,7 +174,7 @@ class SvnMaterialConfigTest {
             svnMaterialConfig.setUrl("https://username:{{SECRET:[secret_config_id][pass]}}@host/foo.git");
 
             assertThat(svnMaterialConfig.validateTree(validationContext)).isFalse();
-            assertThat(svnMaterialConfig.errors().on("url")).isEqualTo("Secret configs '[secret_config_id]' does not exist");
+            assertThat(svnMaterialConfig.errors().on("url")).isEqualTo("Secret configs secret_config_id does not exist");
         }
 
         @Test
@@ -230,7 +230,7 @@ class SvnMaterialConfigTest {
             svnMaterialConfig.setPassword("{{SECRET:[secret_config_id][password]}}");
 
             assertThat(svnMaterialConfig.validateTree(validationContext)).isFalse();
-            assertThat(svnMaterialConfig.errors().on("encryptedPassword")).isEqualTo("Secret configs '[secret_config_id]' does not exist");
+            assertThat(svnMaterialConfig.errors().on("encryptedPassword")).isEqualTo("Secret configs secret_config_id does not exist");
         }
     }
 

--- a/config/config-api/src/test/java/com/thoughtworks/go/config/materials/svn/SvnMaterialConfigTest.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/config/materials/svn/SvnMaterialConfigTest.java
@@ -198,7 +198,7 @@ class SvnMaterialConfigTest {
             final boolean validationResult = svnMaterialConfig.validateTree(new ConfigSaveValidationContext(null));
 
             assertThat(validationResult).isFalse();
-            assertThat(svnMaterialConfig.errors().on("encryptedPassword")).isEqualTo("Encrypted password value for svn material with url 'foo/bar' is invalid. This usually happens when the cipher text is modified to have an invalid value.");
+            assertThat(svnMaterialConfig.errors().on("encryptedPassword")).isEqualTo("Encrypted password value for SvnMaterial with url 'foo/bar' is invalid. This usually happens when the cipher text is modified to have an invalid value.");
         }
 
         @Test

--- a/server/webapp/WEB-INF/rails/lib/java_imports.rb
+++ b/server/webapp/WEB-INF/rails/lib/java_imports.rb
@@ -282,5 +282,6 @@ module JavaImports
   java_import com.thoughtworks.go.plugin.domain.common.CombinedPluginInfo unless defined? CombinedPluginInfo
   java_import com.thoughtworks.go.server.service.WebpackAssetsService unless defined? WebpackAssetsService
   java_import com.thoughtworks.go.config.GoConfigCloner unless defined? GoConfigCloner
+  java_import com.thoughtworks.go.server.service.SecretParamResolver unless defined? SecretParamResolver
   (::SparkRoutes = com.thoughtworks.go.spark.Routes) unless defined? ::SparkRoutes
 end

--- a/server/webapp/WEB-INF/rails/lib/services.rb
+++ b/server/webapp/WEB-INF/rails/lib/services.rb
@@ -104,7 +104,8 @@ module Services
     :webpack_assets_service,
     :artifact_store_service,
     :external_artifacts_service,
-    :data_sharing_usage_statistics_reporting_service
+    :data_sharing_usage_statistics_reporting_service,
+    :secret_param_resolver
   )
 
   service_with_alias_name(:go_config_service_for_url, "goConfigService")


### PR DESCRIPTION
See issue #6014 for more details

- Validate and mask secret params in url argument
- Pass on ValidationContext to validateConcreteScmMaterial to validate secret config id
- Validate SCM material url and password for secret params
  - git, P4, TFS, svn, Hg
- Moved material URL and password validation logic to ScmMaterialConfig class
- Only password can be specified as secret params in the material URL.
- Resolve secret params before check connection and handled display of validation errors


Link for Part 1 - #5991 