### PR TITLE
Moved secrets resolution for materials to MaterialService

### DIFF
--- a/domain/src/main/java/com/thoughtworks/go/config/materials/git/GitMaterial.java
+++ b/domain/src/main/java/com/thoughtworks/go/config/materials/git/GitMaterial.java
@@ -425,7 +425,7 @@ public class GitMaterial extends ScmMaterial {
 
     @Override
     public boolean hasSecretParams() {
-        return this.url.hasSecretParams();
+        return this.url != null && this.url.hasSecretParams();
     }
 
     @Override

--- a/domain/src/main/java/com/thoughtworks/go/config/materials/git/GitMaterial.java
+++ b/domain/src/main/java/com/thoughtworks/go/config/materials/git/GitMaterial.java
@@ -436,7 +436,10 @@ public class GitMaterial extends ScmMaterial {
     public GitMaterial withShallowClone(boolean value) {
         GitMaterialConfig config = (GitMaterialConfig) config();
         config.setShallowClone(value);
-        return new GitMaterial(config);
+        GitMaterial gitMaterial = new GitMaterial(config);
+        gitMaterial.url = this.url;
+
+        return gitMaterial;
     }
 
     public String branchWithDefault() {

--- a/domain/src/main/java/com/thoughtworks/go/config/materials/mercurial/HgMaterial.java
+++ b/domain/src/main/java/com/thoughtworks/go/config/materials/mercurial/HgMaterial.java
@@ -348,11 +348,11 @@ public class HgMaterial extends ScmMaterial {
 
     @Override
     public boolean hasSecretParams() {
-        return getUrlArgument().hasSecretParams();
+        return this.url != null && url.hasSecretParams();
     }
 
     @Override
     public SecretParams getSecretParams() {
-        return getUrlArgument().getSecretParams();
+        return this.url.getSecretParams();
     }
 }

--- a/domain/src/main/java/com/thoughtworks/go/config/materials/perforce/P4Material.java
+++ b/domain/src/main/java/com/thoughtworks/go/config/materials/perforce/P4Material.java
@@ -433,7 +433,7 @@ public class P4Material extends ScmMaterial implements PasswordEncrypter, Passwo
 
     @Override
     public boolean hasSecretParams() {
-        return !this.secretParamsForPassword.isEmpty();
+        return this.secretParamsForPassword != null && !this.secretParamsForPassword.isEmpty();
     }
 
     @Override

--- a/domain/src/main/java/com/thoughtworks/go/config/materials/svn/SvnMaterial.java
+++ b/domain/src/main/java/com/thoughtworks/go/config/materials/svn/SvnMaterial.java
@@ -388,7 +388,8 @@ public class SvnMaterial extends ScmMaterial implements PasswordEncrypter, Passw
 
     @Override
     public boolean hasSecretParams() {
-        return this.url.hasSecretParams() || !secretParamsForPassword.isEmpty();
+        return (this.url != null && this.url.hasSecretParams())
+                || (this.secretParamsForPassword != null && !this.secretParamsForPassword.isEmpty());
     }
 
     @Override

--- a/domain/src/main/java/com/thoughtworks/go/config/materials/tfs/TfsMaterial.java
+++ b/domain/src/main/java/com/thoughtworks/go/config/materials/tfs/TfsMaterial.java
@@ -322,7 +322,9 @@ public class TfsMaterial extends ScmMaterial implements PasswordAwareMaterial, P
 
     @Override
     public boolean hasSecretParams() {
-        return this.url.hasSecretParams() || !this.secretParamsForPassword.isEmpty();
+        return (this.url != null && this.url.hasSecretParams())
+                || (this.secretParamsForPassword != null && !this.secretParamsForPassword.isEmpty());
+
     }
 
     @Override

--- a/domain/src/test/java/com/thoughtworks/go/config/materials/git/GitMaterialShallowCloneTest.java
+++ b/domain/src/test/java/com/thoughtworks/go/config/materials/git/GitMaterialShallowCloneTest.java
@@ -17,6 +17,7 @@
 package com.thoughtworks.go.config.materials.git;
 
 
+import com.thoughtworks.go.config.SecretParams;
 import com.thoughtworks.go.domain.materials.Modification;
 import com.thoughtworks.go.domain.materials.RevisionContext;
 import com.thoughtworks.go.domain.materials.TestSubprocessExecutionContext;
@@ -42,6 +43,7 @@ import static com.thoughtworks.go.domain.materials.git.GitTestRepo.*;
 import static com.thoughtworks.go.util.command.ProcessOutputStreamConsumer.inMemoryConsumer;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -150,6 +152,19 @@ public class GitMaterialShallowCloneTest {
         assertThat(original.withShallowClone(true).isShallowClone(), is(true));
         assertThat(original.withShallowClone(false).isShallowClone(), is(false));
         assertThat(original.isShallowClone(), is(false));
+    }
+
+    @Test
+    public void withShallowCloneShouldGenerateANewMaterialRetainingTheResolvedSecretParams() {
+        GitMaterial original = new GitMaterial("http://username:{{SECRET:[id][key]}}@foo.bar");
+        original.getSecretParams().get(0).setValue("pass");
+
+        GitMaterial newMaterial = original.withShallowClone(true);
+
+        SecretParams secretParams = newMaterial.getSecretParams();
+
+        assertTrue(newMaterial.hasSecretParams());
+        assertThat(secretParams.get(0).getValue(), is("pass"));
     }
 
     @Test

--- a/server/src/main/java/com/thoughtworks/go/server/materials/ConfigMaterialUpdateListener.java
+++ b/server/src/main/java/com/thoughtworks/go/server/materials/ConfigMaterialUpdateListener.java
@@ -99,8 +99,7 @@ public class ConfigMaterialUpdateListener implements GoMessageListener<MaterialU
 
     private void updateConfigurationFromCheckout(File folder, Modification modification, Material material) {
         Revision revision = new StringRevision(modification.getRevision());
-        MaterialPoller poller = this.materialService.getPollerImplementation(material);
-        poller.checkout(material, folder, revision, this.subprocessExecutionContext);
+        this.materialService.checkout(material, folder, revision, this.subprocessExecutionContext);
         this.repoConfigDataSource.onCheckoutComplete(material.config(), folder, modification);
     }
 

--- a/server/src/main/java/com/thoughtworks/go/server/materials/MaterialUpdateService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/materials/MaterialUpdateService.java
@@ -176,7 +176,6 @@ public class MaterialUpdateService implements GoMessageListener<MaterialUpdateCo
             LOGGER.debug("[Material Update] Starting update of material {}", material);
             try {
                 long trackingId = mduPerformanceLogger.materialSentToUpdateQueue(material);
-                resolveSecretParams(material);
                 queueFor(material).post(new MaterialUpdateMessage(material, trackingId));
 
                 return true;
@@ -195,12 +194,6 @@ public class MaterialUpdateService implements GoMessageListener<MaterialUpdateCo
                         general(scope)));
             }
             return false;
-        }
-    }
-
-    private void resolveSecretParams(Material material) {
-        if ((material instanceof SecretParamAware) && ((SecretParamAware) material).hasSecretParams()) {
-            secretParamResolver.resolve(((SecretParamAware) material).getSecretParams());
         }
     }
 

--- a/server/src/main/java/com/thoughtworks/go/server/service/MaterialService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/MaterialService.java
@@ -128,7 +128,13 @@ public class MaterialService {
         return getPollerImplementation(material).modificationsSince(material, baseDir, revision, execCtx);
     }
 
-    public MaterialPoller getPollerImplementation(Material material) {
+    public void checkout(Material material, File baseDir, Revision revision, final SubprocessExecutionContext execCtx) {
+        resolveSecretParams(material);
+
+        getPollerImplementation(material).checkout(material, baseDir, revision, execCtx);
+    }
+
+    protected MaterialPoller getPollerImplementation(Material material) {
         MaterialPoller materialPoller = materialPollerMap.get(getMaterialClass(material));
         return materialPoller == null ? new NoOpPoller() : materialPoller;
     }

--- a/server/src/main/java/com/thoughtworks/go/server/service/MaterialService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/MaterialService.java
@@ -16,6 +16,7 @@
 
 package com.thoughtworks.go.server.service;
 
+import com.thoughtworks.go.config.SecretParamAware;
 import com.thoughtworks.go.config.exceptions.EntityType;
 import com.thoughtworks.go.config.materials.PackageMaterial;
 import com.thoughtworks.go.config.materials.PluggableSCMMaterial;
@@ -58,6 +59,7 @@ public class MaterialService {
     private PackageRepositoryExtension packageRepositoryExtension;
     private SCMExtension scmExtension;
     private TransactionTemplate transactionTemplate;
+    private SecretParamResolver secretParamResolver;
     private Map<Class, MaterialPoller> materialPollerMap = new HashMap<>();
 
     @Autowired
@@ -66,13 +68,15 @@ public class MaterialService {
                            SecurityService securityService,
                            PackageRepositoryExtension packageRepositoryExtension,
                            SCMExtension scmExtension,
-                           TransactionTemplate transactionTemplate) {
+                           TransactionTemplate transactionTemplate,
+                           SecretParamResolver secretParamResolver) {
         this.materialRepository = materialRepository;
         this.goConfigService = goConfigService;
         this.securityService = securityService;
         this.packageRepositoryExtension = packageRepositoryExtension;
         this.scmExtension = scmExtension;
         this.transactionTemplate = transactionTemplate;
+        this.secretParamResolver = secretParamResolver;
         populatePollerImplementations();
     }
 
@@ -112,6 +116,7 @@ public class MaterialService {
     public List<Modification> latestModification(Material material,
                                                  File baseDir,
                                                  final SubprocessExecutionContext execCtx) {
+        resolveSecretParams(material);
         return getPollerImplementation(material).latestModification(material, baseDir, execCtx);
     }
 
@@ -119,6 +124,7 @@ public class MaterialService {
                                                  File baseDir,
                                                  Revision revision,
                                                  final SubprocessExecutionContext execCtx) {
+        resolveSecretParams(material);
         return getPollerImplementation(material).modificationsSince(material, baseDir, revision, execCtx);
     }
 
@@ -137,6 +143,12 @@ public class MaterialService {
         MaterialInstance materialInstance = materialRepository.findMaterialInstance(materialConfig);
 
         return materialRepository.getModificationsFor(materialInstance, pagination);
+    }
+
+    private void resolveSecretParams(Material material) {
+        if ((material instanceof SecretParamAware) && ((SecretParamAware) material).hasSecretParams()) {
+            this.secretParamResolver.resolve(((SecretParamAware) material).getSecretParams());
+        }
     }
 
     Class<? extends Material> getMaterialClass(Material material) {

--- a/server/src/test-fast/java/com/thoughtworks/go/server/materials/ConfigMaterialUpdateListenerTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/materials/ConfigMaterialUpdateListenerTest.java
@@ -48,7 +48,6 @@ public class ConfigMaterialUpdateListenerTest {
     private Material material;
     private File folder = new File("checkoutDir");
     private MaterialRevisions mods;
-    private MaterialPoller poller;
     private Modification svnModification;
 
     @Before
@@ -63,8 +62,6 @@ public class ConfigMaterialUpdateListenerTest {
         material = new SvnMaterial("url", "tom", "pass", false);
 
         when(materialRepository.folderFor(material)).thenReturn(folder);
-        poller = mock(MaterialPoller.class);
-        when(materialService.getPollerImplementation(any(Material.class))).thenReturn(poller);
 
         svnModification = new Modification("user", "commend", "em@il", new Date(), "1");
         mods = revisions(material, svnModification);
@@ -88,11 +85,12 @@ public class ConfigMaterialUpdateListenerTest {
     }
 
     @Test
-    public void shouldPerformCheckoutUsingMaterialPoller() {
+    public void shouldCheckoutMaterialToASpecificRevision() {
         MaterialUpdateSuccessfulMessage message = new MaterialUpdateSuccessfulMessage(material, 123);
+
         this.configUpdater.onMessage(message);
 
-        verify(poller, times(1)).checkout(any(Material.class), any(File.class), any(Revision.class), any(SubprocessExecutionContext.class));
+        verify(materialService, times(1)).checkout(any(Material.class), any(File.class), any(Revision.class), any(SubprocessExecutionContext.class));
     }
 
     @Test

--- a/server/src/test-fast/java/com/thoughtworks/go/server/materials/MaterialUpdateServiceTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/materials/MaterialUpdateServiceTest.java
@@ -224,19 +224,6 @@ public class MaterialUpdateServiceTest {
         }
 
         @Test
-        void shouldResolveSecretParamsForMaterials() {
-            ScmMaterial material = mock(ScmMaterial.class);
-            SecretParams secretParams = new SecretParams(new SecretParam("id", "key"));
-
-            when(material.hasSecretParams()).thenReturn(true);
-            when(material.getSecretParams()).thenReturn(secretParams);
-
-            service.updateMaterial(material);
-
-            verify(secretParamResolver).resolve(secretParams);
-        }
-
-        @Test
         void shouldAllowPostCommitNotificationsToPassThroughToTheQueue_WhenTheSameMaterialIsNotCurrentlyInProgressAndMaterialIsAutoUpdateTrue() throws Exception {
             ScmMaterial material = mock(ScmMaterial.class);
             when(material.isAutoUpdate()).thenReturn(true);

--- a/server/src/test-fast/java/com/thoughtworks/go/server/service/MaterialServiceTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/service/MaterialServiceTest.java
@@ -52,6 +52,7 @@ import com.thoughtworks.go.security.GoCipher;
 import com.thoughtworks.go.server.domain.Username;
 import com.thoughtworks.go.server.persistence.MaterialRepository;
 import com.thoughtworks.go.server.service.materials.GitPoller;
+import com.thoughtworks.go.server.service.materials.MaterialPoller;
 import com.thoughtworks.go.server.service.result.LocalizedOperationResult;
 import com.thoughtworks.go.server.transaction.TransactionTemplate;
 import com.thoughtworks.go.server.util.Pagination;
@@ -241,6 +242,22 @@ public class MaterialServiceTest {
         assertThat(actual, is(MODIFICATIONS));
     }
 
+    @Theory
+    public void shouldCheckoutAGivenRevision(RequestDataPoints data) {
+        Revision revision = mock(Revision.class);
+        MaterialPoller materialPoller = mock(MaterialPoller.class);
+        MaterialService spy = spy(materialService);
+        File baseDir = mock(File.class);
+        SubprocessExecutionContext execCtx = mock(SubprocessExecutionContext.class);
+
+        doReturn(data.klass).when(spy).getMaterialClass(data.material);
+        doReturn(materialPoller).when(spy).getPollerImplementation(data.material);
+
+        spy.checkout(data.material, baseDir, revision, execCtx);
+
+        verify(materialPoller).checkout(data.material, baseDir, revision, execCtx);
+    }
+
     @Test
     public void shouldThrowExceptionWhenPollerForMaterialNotFound() {
         try {
@@ -286,7 +303,6 @@ public class MaterialServiceTest {
         spy.modificationsSince(gitMaterial, null, null, null);
 
         verify(secretParamResolver).resolve(secretParams);
-
     }
 
     @Test

--- a/server/src/test-integration/java/com/thoughtworks/go/server/materials/MaterialDatabaseUpdaterIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/materials/MaterialDatabaseUpdaterIntegrationTest.java
@@ -26,10 +26,7 @@ import com.thoughtworks.go.plugin.access.packagematerial.PackageRepositoryExtens
 import com.thoughtworks.go.plugin.access.scm.SCMExtension;
 import com.thoughtworks.go.server.dao.DatabaseAccessHelper;
 import com.thoughtworks.go.server.persistence.MaterialRepository;
-import com.thoughtworks.go.server.service.GoConfigService;
-import com.thoughtworks.go.server.service.MaterialExpansionService;
-import com.thoughtworks.go.server.service.MaterialService;
-import com.thoughtworks.go.server.service.SecurityService;
+import com.thoughtworks.go.server.service.*;
 import com.thoughtworks.go.server.transaction.TransactionCallback;
 import com.thoughtworks.go.server.transaction.TransactionTemplate;
 import com.thoughtworks.go.serverhealth.ServerHealthService;
@@ -71,6 +68,7 @@ public class MaterialDatabaseUpdaterIntegrationTest {
     @Autowired private SecurityService securityService;
     @Autowired private PackageRepositoryExtension packageRepositoryExtension;
     @Autowired private SCMExtension scmExtension;
+    @Autowired private SecretParamResolver secretParamResolver;
     @Rule
     public final TemporaryFolder temporaryFolder = new TemporaryFolder();
 
@@ -144,7 +142,7 @@ public class MaterialDatabaseUpdaterIntegrationTest {
     private class MaterialServiceWhichSlowsDownFirstTimeModificationCheck extends MaterialService {
         public MaterialServiceWhichSlowsDownFirstTimeModificationCheck(MaterialRepository materialRepository, GoConfigService goConfigService, SecurityService securityService,
                                                                        PackageRepositoryExtension packageRepositoryExtension, SCMExtension scmExtension) {
-            super(materialRepository, goConfigService, securityService, packageRepositoryExtension, scmExtension, transactionTemplate);
+            super(materialRepository, goConfigService, securityService, packageRepositoryExtension, scmExtension, transactionTemplate, secretParamResolver);
         }
 
         @Override

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/MaterialExpansionServiceCachingTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/MaterialExpansionServiceCachingTest.java
@@ -52,12 +52,14 @@ public class MaterialExpansionServiceCachingTest {
     GoCache goCache;
     @Autowired
     private MaterialConfigConverter materialConfigConverter;
+    @Autowired
+    SecretParamResolver secretParamResolver;
     private static SvnTestRepoWithExternal svnRepo;
     private static MaterialExpansionService materialExpansionService;
 
     @Before
     public void setUp() throws Exception {
-        materialExpansionService = new MaterialExpansionService(goCache, materialConfigConverter);
+        materialExpansionService = new MaterialExpansionService(goCache, materialConfigConverter, secretParamResolver);
     }
 
     @BeforeClass


### PR DESCRIPTION
* This is related to resolution of secret params for materials, #6014
* Materials were earlier resolved in MaterialUpdateService before adding
  the material to the update queue. This approach had couple of issues,
  - As part of MDU, we use the MaterialExpansionService to expand the
  materials, during expansion the Material object is converted MaterialConfig
  and back. During this conversion the resolved secrets are lost and MDU
  fails. Moved resolution of secrets to MaterialService just before we
  poll the materials.
* MaterialExpansionService resolves secrets for SVNMaterial before using
  the SVNCommand to check for externals.