### PR TITLE
Added cluster status report api to elastic agent extension v5

### DIFF
--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/elastic/ElasticAgentExtension.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/elastic/ElasticAgentExtension.java
@@ -16,6 +16,7 @@
 
 package com.thoughtworks.go.plugin.access.elastic;
 
+import com.thoughtworks.go.config.elastic.ClusterProfile;
 import com.thoughtworks.go.domain.JobIdentifier;
 import com.thoughtworks.go.plugin.access.ExtensionsRegistry;
 import com.thoughtworks.go.plugin.access.PluginRequestHelper;
@@ -101,6 +102,10 @@ public class ElasticAgentExtension extends AbstractExtension {
 
     public String getAgentStatusReport(String pluginId, JobIdentifier identifier, String elasticAgentId, Map<String, String> clusterProfile) {
         return getVersionedElasticAgentExtension(pluginId).getAgentStatusReport(pluginId, identifier, elasticAgentId, clusterProfile);
+    }
+
+    public String getClusterStatusReport(String pluginId, Map<String,String> clusterProfile) {
+        return getVersionedElasticAgentExtension(pluginId).getClusterStatusReport(pluginId,clusterProfile);
     }
 
     public Capabilities getCapabilities(String pluginId) {

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/elastic/ElasticAgentPluginRegistry.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/elastic/ElasticAgentPluginRegistry.java
@@ -73,6 +73,13 @@ public class ElasticAgentPluginRegistry extends AbstractPluginRegistry<ElasticAg
         return agentStatusReportView;
     }
 
+    public String getClusterStatusReport(String pluginId, Map<String, String> clusterProfileConfigurations) {
+        LOGGER.debug("Processing get cluster status report for plugin: {} for cluster: {}", pluginId, clusterProfileConfigurations);
+        final String clusterStatusReportView = extension.getClusterStatusReport(pluginId, clusterProfileConfigurations);
+        LOGGER.debug("Done processing get cluster status report for plugin: {} for cluster: {}", pluginId, clusterProfileConfigurations);
+        return clusterStatusReportView;
+    }
+
     public boolean has(String pluginId) {
         return findPlugin(pluginId) != null;
     }

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/elastic/VersionedElasticAgentExtension.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/elastic/VersionedElasticAgentExtension.java
@@ -55,6 +55,8 @@ public interface VersionedElasticAgentExtension {
 
     String getAgentStatusReport(String pluginId, JobIdentifier identifier, String elasticAgentId, Map<String, String> clusterProfile);
 
+    String getClusterStatusReport(String pluginId, Map<String, String> clusterProfile);
+
     void jobCompletion(String pluginId, String elasticAgentId, JobIdentifier jobIdentifier, Map<String, String> elasticProfileConfiguration, Map<String, String> clusterProfileConfiguration);
 
     ElasticAgentInformation migrateConfig(String pluginId, ElasticAgentInformation elasticAgentInformation);

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/elastic/v4/ElasticAgentExtensionV4.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/elastic/v4/ElasticAgentExtensionV4.java
@@ -175,6 +175,11 @@ public class ElasticAgentExtensionV4 implements VersionedElasticAgentExtension {
     }
 
     @Override
+    public String getClusterStatusReport(String pluginId, Map<String, String> clusterProfile) {
+        throw new UnsupportedOperationException(String.format("Plugin: '%s' uses elastic agent extension v4 and cluster profile extension calls are not supported by elastic agent V4", pluginId));
+    }
+
+    @Override
     public void jobCompletion(String pluginId, String elasticAgentId, JobIdentifier jobIdentifier, Map<String, String> elasticProfileConfiguration, Map<String, String> clusterProfileConfiguration) {
         pluginRequestHelper.submitRequest(pluginId, REQUEST_JOB_COMPLETION, new DefaultPluginInteractionCallback<String>() {
             @Override

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/elastic/v5/ElasticAgentExtensionConverterV5.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/elastic/v5/ElasticAgentExtensionConverterV5.java
@@ -174,5 +174,11 @@ class ElasticAgentExtensionConverterV5 {
     public ElasticAgentInformationDTO getElasticAgentInformationDTO(ElasticAgentInformation elasticAgentInformation) {
         return elasticAgentInformationConverterV5.toDTO(elasticAgentInformation);
     }
+
+    public String getClusterStatusReportRequestBody(Map<String, String> clusterProfile) {
+        JsonObject jsonObject = new JsonObject();
+        jsonObject.add("cluster_profile_properties", mapToJsonObject(clusterProfile));
+        return GSON.toJson(jsonObject);
+    }
 }
 

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/elastic/v5/ElasticAgentExtensionV5.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/elastic/v5/ElasticAgentExtensionV5.java
@@ -197,6 +197,21 @@ public class ElasticAgentExtensionV5 implements VersionedElasticAgentExtension {
     }
 
     @Override
+    public String getClusterStatusReport(String pluginId, Map<String, String> clusterProfile) {
+        return pluginRequestHelper.submitRequest(pluginId, REQUEST_CLUSTER_STATUS_REPORT, new DefaultPluginInteractionCallback<String>() {
+            @Override
+            public String requestBody(String resolvedExtensionVersion) {
+                return elasticAgentExtensionConverterV5.getClusterStatusReportRequestBody(clusterProfile);
+            }
+
+            @Override
+            public String onSuccess(String responseBody, Map<String, String> responseHeaders, String resolvedExtensionVersion) {
+                return elasticAgentExtensionConverterV5.getStatusReportView(responseBody);
+            }
+        });
+    }
+
+    @Override
     public void jobCompletion(String pluginId, String elasticAgentId, JobIdentifier jobIdentifier, Map<String, String> elasticProfileConfiguration, Map<String, String> clusterProfileConfiguration) {
         pluginRequestHelper.submitRequest(pluginId, REQUEST_JOB_COMPLETION, new DefaultPluginInteractionCallback<String>() {
             @Override

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/elastic/v5/ElasticAgentPluginConstantsV5.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/elastic/v5/ElasticAgentPluginConstantsV5.java
@@ -34,6 +34,7 @@ public interface ElasticAgentPluginConstantsV5 {
 
     String REQUEST_STATUS_REPORT = REQUEST_PREFIX + ".status-report";
     String REQUEST_AGENT_STATUS_REPORT = REQUEST_PREFIX + ".agent-status-report";
+    String REQUEST_CLUSTER_STATUS_REPORT = REQUEST_PREFIX + ".cluster-status-report";
     String REQUEST_CAPABILITIES = REQUEST_PREFIX + ".get-capabilities";
 
     String REQUEST_JOB_COMPLETION = REQUEST_PREFIX + ".job-completion";

--- a/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/elastic/ElasticAgentExtensionV4Test.java
+++ b/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/elastic/ElasticAgentExtensionV4Test.java
@@ -304,6 +304,14 @@ public class ElasticAgentExtensionV4Test {
     }
 
     @Test
+    public void shouldNotSupportGetClusterProfileStatusReportCall() {
+        thrown.expect(UnsupportedOperationException.class);
+        thrown.expectMessage(String.format("Plugin: '%s' uses elastic agent extension v4 and cluster profile extension calls are not supported by elastic agent V4", PLUGIN_ID));
+
+        extensionV4.getClusterStatusReport(PLUGIN_ID, new HashMap<>());
+    }
+
+    @Test
     public void allRequestMustHaveRequestPrefix() {
         assertThat(REQUEST_PREFIX, is("cd.go.elastic-agent"));
 

--- a/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/elastic/ElasticAgentExtensionV5Test.java
+++ b/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/elastic/ElasticAgentExtensionV5Test.java
@@ -367,6 +367,25 @@ public class ElasticAgentExtensionV5Test {
     }
 
     @Test
+    public void shouldGetClusterStatusReport() {
+        final String responseBody = "{\"view\":\"<div>This is a cluster status report snippet.</div>\"}";
+
+        when(pluginManager.submitTo(eq(PLUGIN_ID), eq(ELASTIC_AGENT_EXTENSION), requestArgumentCaptor.capture())).thenReturn(DefaultGoPluginApiResponse.success(responseBody));
+
+
+        Map<String, String> clusterProfile = Collections.singletonMap("key1", "value1");
+        extensionV5.getClusterStatusReport(PLUGIN_ID, clusterProfile);
+
+        final String requestBody = "{\n" +
+                "  \"cluster_profile_properties\":{" +
+                "       \"key1\":\"value1\"" +
+                "  }" +
+                "}";
+
+        assertExtensionRequest("5.0", REQUEST_CLUSTER_STATUS_REPORT, requestBody);
+    }
+
+    @Test
     public void allRequestMustHaveRequestPrefix() {
         assertThat(REQUEST_PREFIX, is("cd.go.elastic-agent"));
 

--- a/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/elastic/ElasticAgentPluginRegistryTest.java
+++ b/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/elastic/ElasticAgentPluginRegistryTest.java
@@ -109,6 +109,17 @@ public class ElasticAgentPluginRegistryTest {
     }
 
     @Test
+    public void shouldTalkToExtensionToGetClusterStatusReport() {
+        final JobIdentifier jobIdentifier = new JobIdentifier();
+
+        Map<String, String> clusterProfileConfigurations = Collections.emptyMap();
+        elasticAgentPluginRegistry.getClusterStatusReport(PLUGIN_ID, clusterProfileConfigurations);
+
+        verify(elasticAgentExtension, times(1)).getClusterStatusReport(PLUGIN_ID, clusterProfileConfigurations);
+        verifyNoMoreInteractions(elasticAgentExtension);
+    }
+
+    @Test
     public void shouldTalkToExtensionToReportJobCompletion() {
         final JobIdentifier jobIdentifier = new JobIdentifier();
         final String elasticAgentId = "ea_1";

--- a/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/elastic/v5/ElasticAgentExtensionConverterV5Test.java
+++ b/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/elastic/v5/ElasticAgentExtensionConverterV5Test.java
@@ -228,6 +228,18 @@ public class ElasticAgentExtensionConverterV5Test {
     }
 
     @Test
+    public void shouldJSONizeClusterStatusReportRequestBody() throws Exception {
+        String actual = new ElasticAgentExtensionConverterV5().getClusterStatusReportRequestBody(Collections.singletonMap("key1", "value1"));
+        String expected = "{" +
+                "   \"cluster_profile_properties\":{" +
+                "       \"key1\":\"value1\"" +
+                "   }" +
+                "}";
+
+        assertThatJson(expected).isEqualTo(actual);
+    }
+
+    @Test
     public void shouldConstructValidationRequest() {
         HashMap<String, String> configuration = new HashMap<>();
         configuration.put("key1", "value1");

--- a/server/src/main/java/com/thoughtworks/go/server/service/ElasticAgentPluginService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/ElasticAgentPluginService.java
@@ -227,6 +227,16 @@ public class ElasticAgentPluginService {
         throw new UnsupportedOperationException("Plugin does not support agent status report.");
     }
 
+    public String getClusterStatusReport(String pluginId, String clusterProfileId) {
+        final ElasticAgentPluginInfo pluginInfo = elasticAgentMetadataStore.getPluginInfo(pluginId);
+        if (pluginInfo.getCapabilities().supportsClusterStatusReport()) {
+            ClusterProfile clusterProfile = clusterProfilesService.getPluginProfiles().findByPluginIdAndProfileId(pluginId, clusterProfileId);
+            return elasticAgentPluginRegistry.getClusterStatusReport(pluginId, clusterProfile.getConfigurationAsMap(true));
+        }
+
+        throw new UnsupportedOperationException("Plugin does not support cluster status report.");
+    }
+
     public void jobCompleted(JobInstance job) {
         AgentInstance agentInstance = agentService.findAgent(job.getAgentUuid());
         if (!agentInstance.isElastic()) {

--- a/server/webapp/WEB-INF/rails/app/controllers/admin/status_reports_controller.rb
+++ b/server/webapp/WEB-INF/rails/app/controllers/admin/status_reports_controller.rb
@@ -47,7 +47,23 @@ module Admin
       render_plugin_error e
     end
 
+    def cluster_status
+      @view_title = 'Cluster Status Report'
+      @page_header = 'Cluster Status Report'
+
+      unless valid_params?
+        return render_error_template 'Provide cluster profile id for Status Report.', 422
+      end
+
+      @cluster_status_report = elastic_agent_plugin_service.getClusterStatusReport(params[:plugin_id], params[:cluster_profile_id])
+    rescue org.springframework.dao.DataRetrievalFailureException, java.lang.UnsupportedOperationException
+      render_error_template "Status Report for plugin with id: #{params[:plugin_id]} for cluster #{params[:cluster_profile_id]} is not found.", 404
+    rescue java.lang.Exception => e
+      render_plugin_error e
+    end
+
     private
+
     def elastic_agent_id
       (params[:elastic_agent_id].eql? 'unassigned') ? nil : params[:elastic_agent_id]
     end

--- a/server/webapp/WEB-INF/rails/app/views/admin/status_reports/cluster_status.html.erb
+++ b/server/webapp/WEB-INF/rails/app/views/admin/status_reports/cluster_status.html.erb
@@ -1,0 +1,3 @@
+<div id="status_reports">
+  <%== @cluster_status_report %>
+</div>

--- a/server/webapp/WEB-INF/rails/config/routes.rb
+++ b/server/webapp/WEB-INF/rails/config/routes.rb
@@ -178,7 +178,7 @@ Rails.application.routes.draw do
     get ':pipeline_name/list/compare_with/:other_pipeline_counter' => 'comparison#list', constraints: {pipeline_name: PIPELINE_NAME_FORMAT}, format: 'json', as: :compare_pipelines_list
     get ':pipeline_name/timeline/:page' => 'comparison#timeline', constraints: {pipeline_name: PIPELINE_NAME_FORMAT}, as: :compare_pipelines_timeline
   end
-  
+
   scope 'config_view' do
     get "templates/:name" => "config_view/templates#show", as: :config_view_templates_show, constraints: {name: TEMPLATE_NAME_FORMAT}
   end
@@ -287,7 +287,8 @@ Rails.application.routes.draw do
 
   namespace :admin do
     get 'status_reports/:plugin_id' => 'status_reports#plugin_status', constraints: {plugin_id: PLUGIN_ID_FORMAT}, format: false, as: :status_report
-    get 'status_reports/:plugin_id/:elastic_agent_id' => 'status_reports#agent_status', constraints: {plugin_id: PLUGIN_ID_FORMAT}, format: false, as: :agent_status_report
+    get 'status_reports/:plugin_id/agent/:elastic_agent_id' => 'status_reports#agent_status', constraints: {plugin_id: PLUGIN_ID_FORMAT}, format: false, as: :agent_status_report
+    get 'status_reports/:plugin_id/cluster/:cluster_profile_id' => 'status_reports#cluster_status', constraints: {plugin_id: PLUGIN_ID_FORMAT}, format: false, as: :cluster_status_report
 
     namespace :security do
       resources :auth_configs, only: [:index], controller: :auth_configs, as: :auth_configs

--- a/server/webapp/WEB-INF/rails/spec/controllers/admin/status_reports_controller_spec.rb
+++ b/server/webapp/WEB-INF/rails/spec/controllers/admin/status_reports_controller_spec.rb
@@ -63,7 +63,7 @@ describe Admin::StatusReportsController do
     end
 
     it 'should verify availability of plugin' do
-      get :plugin_status, params:{:plugin_id => 'invalid_plugin_id'}
+      get :plugin_status, params: {:plugin_id => 'invalid_plugin_id'}
 
       expect(response.response_code).to eq(404)
     end
@@ -77,7 +77,7 @@ describe Admin::StatusReportsController do
       pluginDescriptor = GoPluginDescriptor.new(elastic_plugin_id, nil, nil, nil, nil, nil)
       ElasticAgentMetadataStore.instance().setPluginInfo(com.thoughtworks.go.plugin.domain.elastic.ElasticAgentPluginInfo.new(pluginDescriptor, nil, nil, nil, nil, capabilities))
 
-      get :plugin_status, params:{:plugin_id => elastic_plugin_id}
+      get :plugin_status, params: {:plugin_id => elastic_plugin_id}
 
       expect(response).to be_ok
       expect(assigns[:status_report]).to eq('status_report')
@@ -93,7 +93,7 @@ describe Admin::StatusReportsController do
       pluginDescriptor = GoPluginDescriptor.new(elastic_plugin_id, nil, nil, nil, nil, nil)
       ElasticAgentMetadataStore.instance().setPluginInfo(com.thoughtworks.go.plugin.domain.elastic.ElasticAgentPluginInfo.new(pluginDescriptor, nil, nil, nil, nil, capabilities))
 
-      get :plugin_status, params:{:plugin_id => elastic_plugin_id}
+      get :plugin_status, params: {:plugin_id => elastic_plugin_id}
 
       expect(response.response_code).to eq(404)
     end
@@ -102,8 +102,8 @@ describe Admin::StatusReportsController do
   describe 'agent status report using job id' do
     describe 'routes' do
       it 'should route to show' do
-        expect({:get => '/admin/status_reports/pluginId/unassigned?job_id=jobId'}).to route_to(:controller => 'admin/status_reports', :action => 'agent_status', :plugin_id => 'pluginId', :elastic_agent_id => 'unassigned', :job_id => 'jobId')
-        expect(admin_agent_status_report_path(:plugin_id => elastic_plugin_id, :elastic_agent_id => 'unassigned', :job_id => '100')).to eq('/admin/status_reports/com.tw.myplugin/unassigned?job_id=100')
+        expect({:get => '/admin/status_reports/pluginId/agent/unassigned?job_id=jobId'}).to route_to(:controller => 'admin/status_reports', :action => 'agent_status', :plugin_id => 'pluginId', :elastic_agent_id => 'unassigned', :job_id => 'jobId')
+        expect(admin_agent_status_report_path(:plugin_id => elastic_plugin_id, :elastic_agent_id => 'unassigned', :job_id => '100')).to eq('/admin/status_reports/com.tw.myplugin/agent/unassigned?job_id=100')
       end
     end
 
@@ -143,7 +143,7 @@ describe Admin::StatusReportsController do
     end
 
     it 'should verify availability of plugin' do
-      get :agent_status, params:{:plugin_id => 'invalid_plugin_id', :job_id => '100', :elastic_agent_id => 'unassigned'}
+      get :agent_status, params: {:plugin_id => 'invalid_plugin_id', :job_id => '100', :elastic_agent_id => 'unassigned'}
 
       expect(response.response_code).to eq(404)
     end
@@ -153,7 +153,7 @@ describe Admin::StatusReportsController do
       pluginDescriptor = GoPluginDescriptor.new(elastic_plugin_id, nil, nil, nil, nil, nil)
       ElasticAgentMetadataStore.instance().setPluginInfo(com.thoughtworks.go.plugin.domain.elastic.ElasticAgentPluginInfo.new(pluginDescriptor, nil, nil, nil, nil, capabilities))
 
-      get :agent_status, params:{:plugin_id => elastic_plugin_id, :elastic_agent_id => 'unassigned'}
+      get :agent_status, params: {:plugin_id => elastic_plugin_id, :elastic_agent_id => 'unassigned'}
 
       expect(response.response_code).to eq(422)
     end
@@ -178,7 +178,7 @@ describe Admin::StatusReportsController do
       pluginDescriptor = GoPluginDescriptor.new(elastic_plugin_id, nil, nil, nil, nil, nil)
       ElasticAgentMetadataStore.instance().setPluginInfo(com.thoughtworks.go.plugin.domain.elastic.ElasticAgentPluginInfo.new(pluginDescriptor, nil, nil, nil, nil, capabilities))
 
-      get :agent_status, params:{:plugin_id => elastic_plugin_id, :job_id => '100', :elastic_agent_id => 'unassigned'}
+      get :agent_status, params: {:plugin_id => elastic_plugin_id, :job_id => '100', :elastic_agent_id => 'unassigned'}
 
       expect(response).to be_ok
       expect(assigns[:agent_status_report]).to eq('status_report')
@@ -205,7 +205,7 @@ describe Admin::StatusReportsController do
       pluginDescriptor = GoPluginDescriptor.new(elastic_plugin_id, nil, nil, nil, nil, nil)
       ElasticAgentMetadataStore.instance().setPluginInfo(com.thoughtworks.go.plugin.domain.elastic.ElasticAgentPluginInfo.new(pluginDescriptor, nil, nil, nil, nil, capabilities))
 
-      get :agent_status, params:{:plugin_id => elastic_plugin_id, :job_id => '100', :elastic_agent_id => 'unassigned'}
+      get :agent_status, params: {:plugin_id => elastic_plugin_id, :job_id => '100', :elastic_agent_id => 'unassigned'}
 
       expect(response).to be_ok
       expect(assigns[:agent_status_report]).to eq('status_report')
@@ -221,7 +221,7 @@ describe Admin::StatusReportsController do
       pluginDescriptor = GoPluginDescriptor.new(elastic_plugin_id, nil, nil, nil, nil, nil)
       ElasticAgentMetadataStore.instance().setPluginInfo(com.thoughtworks.go.plugin.domain.elastic.ElasticAgentPluginInfo.new(pluginDescriptor, nil, nil, nil, nil, capabilities))
 
-      get :agent_status, params:{:plugin_id => elastic_plugin_id, :job_id => '100', :elastic_agent_id => 'unassigned'}
+      get :agent_status, params: {:plugin_id => elastic_plugin_id, :job_id => '100', :elastic_agent_id => 'unassigned'}
 
       expect(response.response_code).to eq(404)
     end
@@ -230,8 +230,8 @@ describe Admin::StatusReportsController do
   describe 'agent status report using elastic agent id' do
     describe 'routes' do
       it 'should route to show' do
-        expect({:get => '/admin/status_reports/pluginId/elasticAgentId'}).to route_to(:controller => 'admin/status_reports', :action => 'agent_status', :plugin_id => 'pluginId', :elastic_agent_id => 'elasticAgentId')
-        expect(admin_agent_status_report_path(:plugin_id => elastic_plugin_id, :elastic_agent_id => 'elasticAgentId')).to eq('/admin/status_reports/com.tw.myplugin/elasticAgentId')
+        expect({:get => '/admin/status_reports/pluginId/agent/elasticAgentId'}).to route_to(:controller => 'admin/status_reports', :action => 'agent_status', :plugin_id => 'pluginId', :elastic_agent_id => 'elasticAgentId')
+        expect(admin_agent_status_report_path(:plugin_id => elastic_plugin_id, :elastic_agent_id => 'elasticAgentId')).to eq('/admin/status_reports/com.tw.myplugin/agent/elasticAgentId')
       end
     end
 
@@ -271,7 +271,7 @@ describe Admin::StatusReportsController do
     end
 
     it 'should verify availability of plugin' do
-      get :agent_status, params:{:plugin_id => 'invalid_plugin_id', :elastic_agent_id => 'agent1'}
+      get :agent_status, params: {:plugin_id => 'invalid_plugin_id', :elastic_agent_id => 'agent1'}
 
       expect(response.response_code).to eq(404)
     end
@@ -281,7 +281,7 @@ describe Admin::StatusReportsController do
       pluginDescriptor = GoPluginDescriptor.new(elastic_plugin_id, nil, nil, nil, nil, nil)
       ElasticAgentMetadataStore.instance().setPluginInfo(com.thoughtworks.go.plugin.domain.elastic.ElasticAgentPluginInfo.new(pluginDescriptor, nil, nil, nil, nil, capabilities))
 
-      get :agent_status, params:{:plugin_id => elastic_plugin_id, :elastic_agent_id => 'unassigned'}
+      get :agent_status, params: {:plugin_id => elastic_plugin_id, :elastic_agent_id => 'unassigned'}
 
       expect(response.response_code).to eq(422)
     end
@@ -297,7 +297,7 @@ describe Admin::StatusReportsController do
       pluginDescriptor = GoPluginDescriptor.new(elastic_plugin_id, nil, nil, nil, nil, nil)
       ElasticAgentMetadataStore.instance().setPluginInfo(com.thoughtworks.go.plugin.domain.elastic.ElasticAgentPluginInfo.new(pluginDescriptor, nil, nil, nil, nil, capabilities))
 
-      get :agent_status, params:{:plugin_id => elastic_plugin_id, :elastic_agent_id => elastic_agent_id}
+      get :agent_status, params: {:plugin_id => elastic_plugin_id, :elastic_agent_id => elastic_agent_id}
 
       expect(response).to be_ok
       expect(assigns[:agent_status_report]).to eq('status_report')
@@ -310,7 +310,93 @@ describe Admin::StatusReportsController do
       allow(elastic_agent_plugin_service).to receive(:getAgentStatusReport).with(elastic_plugin_id, nil, elastic_agent_id).and_raise(java.lang.UnsupportedOperationException.new)
       allow(controller).to receive(:elastic_agent_plugin_service).and_return(elastic_agent_plugin_service)
 
-      get :agent_status, params:{:plugin_id => elastic_plugin_id, :elastic_agent_id => elastic_agent_id}
+      get :agent_status, params: {:plugin_id => elastic_plugin_id, :elastic_agent_id => elastic_agent_id}
+
+      expect(response.response_code).to eq(404)
+    end
+  end
+
+  describe 'cluster status report' do
+    cluster_profile_id = 'dev'
+
+    describe 'routes' do
+      it 'should route to index' do
+        expect({:get => '/admin/status_reports/pluginId/cluster/clusterProfileId'}).to route_to(:controller => 'admin/status_reports', :action => 'cluster_status', :plugin_id => 'pluginId', :cluster_profile_id => 'clusterProfileId')
+        expect(admin_cluster_status_report_path(:plugin_id => elastic_plugin_id, :cluster_profile_id => cluster_profile_id)).to eq('/admin/status_reports/com.tw.myplugin/cluster/dev')
+      end
+    end
+
+    describe 'security' do
+      before :each do
+        pluginDescriptor = GoPluginDescriptor.new(elastic_plugin_id, nil, nil, nil, nil, nil)
+        ElasticAgentMetadataStore.instance().setPluginInfo(com.thoughtworks.go.plugin.domain.elastic.ElasticAgentPluginInfo.new(pluginDescriptor, nil, nil, nil, nil, nil))
+      end
+
+      after :each do
+        ElasticAgentMetadataStore.instance().clear()
+      end
+
+      it 'should be accessible only to admins' do
+        login_as_admin
+
+        expect(controller).to allow_action(:get, :plugin_status, params: {:plugin_id => elastic_plugin_id, :cluster_profile_id => cluster_profile_id})
+      end
+
+      it 'should be inaccessible by non-admins' do
+        login_as_group_admin
+
+        expect(controller).to disallow_action(:get, :plugin_status, params: {:plugin_id => elastic_plugin_id, :cluster_profile_id => cluster_profile_id}).with(403, 'You are not authorized to perform this action.')
+      end
+
+      it 'should be accessible by all if security is disabled' do
+        disable_security
+        login_as_anonymous
+
+        expect(controller).to allow_action(:get, :plugin_status, params: {:plugin_id => elastic_plugin_id, :cluster_profile_id => cluster_profile_id})
+      end
+    end
+
+    before :each do
+      login_as_admin
+    end
+
+    it 'should verify availability of plugin' do
+      get :cluster_status, params: {:plugin_id => 'invalid_plugin_id', :cluster_profile_id => cluster_profile_id}
+
+      expect(response.response_code).to eq(404)
+    end
+
+    it 'should verify availability of cluster' do
+      get :cluster_status, params: {:plugin_id => elastic_plugin_id, :cluster_profile_id => "invalid-cluster-id"}
+
+      expect(response.response_code).to eq(404)
+    end
+
+    it 'should return the cluster status report for an available plugin and a valid cluster' do
+      elastic_agent_plugin_service = instance_double('com.thoughtworks.go.server.service.ElasticAgentPluginService')
+      allow(elastic_agent_plugin_service).to receive(:getClusterStatusReport).with(elastic_plugin_id, cluster_profile_id).and_return('cluster_status_report')
+
+      allow(controller).to receive(:elastic_agent_plugin_service).and_return(elastic_agent_plugin_service)
+      capabilities = com.thoughtworks.go.plugin.domain.elastic.Capabilities.new(false, true, false)
+      pluginDescriptor = GoPluginDescriptor.new(elastic_plugin_id, nil, nil, nil, nil, nil)
+      ElasticAgentMetadataStore.instance().setPluginInfo(com.thoughtworks.go.plugin.domain.elastic.ElasticAgentPluginInfo.new(pluginDescriptor, nil, nil, nil, nil, capabilities))
+
+      get :cluster_status, params: {:plugin_id => elastic_plugin_id, :cluster_profile_id => cluster_profile_id}
+
+      expect(response).to be_ok
+      expect(assigns[:cluster_status_report]).to eq('cluster_status_report')
+    end
+
+    it 'should be not found if plugin does not support cluster status_report endpoint' do
+      elastic_agent_plugin_service = instance_double('com.thoughtworks.go.server.service.ElasticAgentPluginService')
+      allow(elastic_agent_plugin_service).to receive(:getClusterStatusReport).with(elastic_plugin_id,cluster_profile_id).and_raise(java.lang.UnsupportedOperationException.new)
+      allow(controller).to receive(:elastic_agent_plugin_service).and_return(elastic_agent_plugin_service)
+
+      capabilities = com.thoughtworks.go.plugin.domain.elastic.Capabilities.new(false, false, false)
+      pluginDescriptor = GoPluginDescriptor.new(elastic_plugin_id, nil, nil, nil, nil, nil)
+      ElasticAgentMetadataStore.instance().setPluginInfo(com.thoughtworks.go.plugin.domain.elastic.ElasticAgentPluginInfo.new(pluginDescriptor, nil, nil, nil, nil, capabilities))
+
+      get :cluster_status, params: {:plugin_id => elastic_plugin_id, :cluster_profile_id => cluster_profile_id}
 
       expect(response.response_code).to eq(404)
     end


### PR DESCRIPTION
The API to access the cluster status if supported will be:
`/go/admin/status_reports/:plugin_id/cluster/:cluster_profile_id`
Link to the issue: #5937