### PR TITLE
Add cluster information on elastic agent plugin infos API (#5538)

### DIFF
--- a/api/api-plugin-infos-v5/src/main/java/com/thoughtworks/go/apiv5/plugininfos/representers/extensions/ElasticAgentExtensionRepresenter.java
+++ b/api/api-plugin-infos-v5/src/main/java/com/thoughtworks/go/apiv5/plugininfos/representers/extensions/ElasticAgentExtensionRepresenter.java
@@ -28,16 +28,25 @@ public class ElasticAgentExtensionRepresenter extends ExtensionRepresenter {
         super.toJSON(extensionWriter, extension);
 
         ElasticAgentPluginInfo elasticAgentExtension = (ElasticAgentPluginInfo) extension;
-        PluggableInstanceSettings profileSettings = elasticAgentExtension.getProfileSettings();
+        PluggableInstanceSettings elasticAgentProfileSettings = elasticAgentExtension.getProfileSettings();
+        PluggableInstanceSettings clusterProfileSettings = elasticAgentExtension.getClusterProfileSettings();
 
-        if (profileSettings != null) {
-            extensionWriter.addChild("profile_settings", authConfigWriter -> PluggableInstanceSettingsRepresenter.toJSON(authConfigWriter, profileSettings));
+        if (elasticAgentProfileSettings != null) {
+            extensionWriter.addChild("elastic_agent_profile_settings", authConfigWriter -> PluggableInstanceSettingsRepresenter.toJSON(authConfigWriter, elasticAgentProfileSettings));
+        }
+
+        if (clusterProfileSettings != null && clusterProfileSettings.getConfigurations() != null && clusterProfileSettings.getView() != null) {
+            extensionWriter.add("supports_cluster_profiles", true);
+            extensionWriter.addChild("cluster_profile_settings", authConfigWriter -> PluggableInstanceSettingsRepresenter.toJSON(authConfigWriter, clusterProfileSettings));
+        } else {
+            extensionWriter.add("supports_cluster_profiles", false);
         }
 
         if (elasticAgentExtension.getCapabilities() != null) {
             extensionWriter.addChild("capabilities", capabilitiesWriter ->
-                    capabilitiesWriter.add("supports_status_report", elasticAgentExtension.getCapabilities().supportsPluginStatusReport())
-                            .add("supports_agent_status_report", elasticAgentExtension.getCapabilities().supportsAgentStatusReport()));
+                    capabilitiesWriter.add("supports_plugin_status_report", elasticAgentExtension.getCapabilities().supportsPluginStatusReport())
+                            .add("supports_agent_status_report", elasticAgentExtension.getCapabilities().supportsAgentStatusReport())
+                            .add("supports_cluster_status_report", elasticAgentExtension.getCapabilities().supportsClusterStatusReport()));
         }
     }
 }

--- a/api/api-plugin-infos-v5/src/test/groovy/com/thoughtworks/go/apiv5/plugininfos/representers/Helper/PluginInfoMother.java
+++ b/api/api-plugin-infos-v5/src/test/groovy/com/thoughtworks/go/apiv5/plugininfos/representers/Helper/PluginInfoMother.java
@@ -64,12 +64,20 @@ public class PluginInfoMother {
         return new ConfigRepoPluginInfo(descriptor, null, getPluggableSettings());
     }
 
-    public static ElasticAgentPluginInfo createElasticAgentPluginInfo() {
+    public static ElasticAgentPluginInfo createElasticAgentPluginInfoForV4() {
         ArrayList<String> targetOperatingSystems = new ArrayList<>();
         targetOperatingSystems.add("os");
         GoPluginDescriptor descriptor = new GoPluginDescriptor("plugin_id", "1", new GoPluginDescriptor.About("GoPlugin", "v1", "goVersion1", "go plugin", new GoPluginDescriptor.Vendor("go", "goUrl"), targetOperatingSystems), "/home/pluginjar/", null, true);
 
         return new ElasticAgentPluginInfo(descriptor, getPluggableSettings(), null, null, getPluggableSettings(), new com.thoughtworks.go.plugin.domain.elastic.Capabilities(true, false));
+    }
+
+    public static ElasticAgentPluginInfo createElasticAgentPluginInfoForV5() {
+        ArrayList<String> targetOperatingSystems = new ArrayList<>();
+        targetOperatingSystems.add("os");
+        GoPluginDescriptor descriptor = new GoPluginDescriptor("plugin_id", "1", new GoPluginDescriptor.About("GoPlugin", "v1", "goVersion1", "go plugin", new GoPluginDescriptor.Vendor("go", "goUrl"), targetOperatingSystems), "/home/pluginjar/", null, true);
+
+        return new ElasticAgentPluginInfo(descriptor, getPluggableSettings(), getPluggableSettings(), null, null, new com.thoughtworks.go.plugin.domain.elastic.Capabilities(true, true, true));
     }
 
     public static CombinedPluginInfo createBadPluginInfo() {

--- a/api/api-plugin-infos-v5/src/test/groovy/com/thoughtworks/go/apiv5/plugininfos/representers/extensions/ElasticAgentExtensionRepresenterTest.groovy
+++ b/api/api-plugin-infos-v5/src/test/groovy/com/thoughtworks/go/apiv5/plugininfos/representers/extensions/ElasticAgentExtensionRepresenterTest.groovy
@@ -24,13 +24,13 @@ import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson
 
 class ElasticAgentExtensionRepresenterTest {
   @Test
-  void 'should serialize Elastic agent info to json'() {
+  void 'should serialize Elastic agent info to json for elastic agent V4 extension'() {
     def actualJson = toObjectString({
-      new ElasticAgentExtensionRepresenter().toJSON(it, PluginInfoMother.createElasticAgentPluginInfo())
+      new ElasticAgentExtensionRepresenter().toJSON(it, PluginInfoMother.createElasticAgentPluginInfoForV4())
     })
     def expectedJSON = [
-      "type"            : "elastic-agent",
-      "plugin_settings" : [
+      "type"                          : "elastic-agent",
+      "plugin_settings"               : [
         "configurations": [
           [
             "key"     : "key1",
@@ -50,7 +50,8 @@ class ElasticAgentExtensionRepresenterTest {
           "template": "Template"
         ]
       ],
-      "profile_settings": [
+      "supports_cluster_profiles"     : false,
+      "elastic_agent_profile_settings": [
         "configurations": [
           [
             "key"     : "key1",
@@ -69,9 +70,67 @@ class ElasticAgentExtensionRepresenterTest {
           "template": "Template"
         ]
       ],
-      "capabilities"    : [
-        "supports_agent_status_report": false,
-        "supports_status_report"      : true
+      "capabilities"                  : [
+        "supports_agent_status_report"  : false,
+        "supports_cluster_status_report": false,
+        "supports_plugin_status_report" : true
+      ]
+    ]
+
+    assertThatJson(actualJson).isEqualTo(expectedJSON)
+  }
+
+  @Test
+  void 'should serialize Elastic agent info to json elastic agent V5 extension'() {
+    def actualJson = toObjectString({
+      new ElasticAgentExtensionRepresenter().toJSON(it, PluginInfoMother.createElasticAgentPluginInfoForV5())
+    })
+    def expectedJSON = [
+      "type"                          : "elastic-agent",
+      "cluster_profile_settings"      : [
+        "configurations": [
+          [
+            "key"     : "key1",
+            "metadata": [
+              "required": true,
+              "secure"  : false
+            ]
+          ],
+          [
+            "key"     : "key2",
+            "metadata": [
+              "required": true,
+              "secure"  : false
+            ]
+          ]],
+        "view"          : [
+          "template": "Template"
+        ]
+      ],
+      "supports_cluster_profiles"     : true,
+      "elastic_agent_profile_settings": [
+        "configurations": [
+          [
+            "key"     : "key1",
+            "metadata": [
+              "required": true, "secure": false
+            ]
+          ],
+          [
+            "key"     : "key2",
+            "metadata": [
+              "required": true,
+              "secure"  : false
+            ]
+          ]],
+        "view"          : [
+          "template": "Template"
+        ]
+      ],
+      "capabilities"                  : [
+        "supports_agent_status_report"  : true,
+        "supports_cluster_status_report": true,
+        "supports_plugin_status_report" : true
       ]
     ]
 


### PR DESCRIPTION
            * Show cluster profile settings
                    - metadata configurations
                    - view
            * Update capabilities
                    - Change 'supports_status_report' to 'supports_plugin_status_report'
                    - Add 'supports_cluster_status_report' capability.
            * Add 'supports_cluster_profiles' field to denote whether
              the plugin supports defining cluster profiles.