### PR TITLE
Introduced 'errorMessage' callback on PluginInteractionCallback

### DIFF
--- a/plugin-infra/go-plugin-access/build.gradle
+++ b/plugin-infra/go-plugin-access/build.gradle
@@ -36,4 +36,5 @@ dependencies {
   testRuntimeOnly group: 'org.junit.vintage', name: 'junit-vintage-engine', version: project.versions.junit5
   testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: project.versions.junit5
   testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: project.versions.junit5
+  testCompile group: 'org.assertj', name: 'assertj-core', version: project.versions.assertJ
 }

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/DefaultPluginInteractionCallback.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/DefaultPluginInteractionCallback.java
@@ -18,6 +18,8 @@ package com.thoughtworks.go.plugin.access;
 
 import java.util.Map;
 
+import static java.lang.String.format;
+
 public class DefaultPluginInteractionCallback<T> implements PluginInteractionCallback<T> {
     @Override
     public String requestBody(String resolvedExtensionVersion) {
@@ -37,5 +39,9 @@ public class DefaultPluginInteractionCallback<T> implements PluginInteractionCal
     @Override
     public T onSuccess(String responseBody, Map<String, String> responseHeaders, String resolvedExtensionVersion) {
         return null;
+    }
+
+    @Override
+    public void onFailure(int responseCode, String responseBody, String resolvedExtensionVersion) {
     }
 }

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/PluginRequestHelper.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/PluginRequestHelper.java
@@ -53,9 +53,14 @@ public class PluginRequestHelper {
             if (DefaultGoApiResponse.SUCCESS_RESPONSE_CODE == response.responseCode()) {
                 return pluginInteractionCallback.onSuccess(response.responseBody(), response.responseHeaders(), resolvedExtensionVersion);
             }
+            pluginInteractionCallback.onFailure(response.responseCode(), response.responseBody(), resolvedExtensionVersion);
+
             throw new RuntimeException(format("The plugin sent a response that could not be understood by Go. Plugin returned with code '%s' and the following response: '%s'", response.responseCode(), response.responseBody()));
+        } catch (RuntimeException e) {
+            throw e;
         } catch (Exception e) {
             throw new RuntimeException(format("Interaction with plugin with id '%s' implementing '%s' extension failed while requesting for '%s'. Reason: [%s]", pluginId, extensionName, requestName, e.getMessage()), e);
         }
     }
+
 }

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/exceptions/SecretResolutionFailureException.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/exceptions/SecretResolutionFailureException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 ThoughtWorks, Inc.
+ * Copyright 2019 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,18 +14,10 @@
  * limitations under the License.
  */
 
-package com.thoughtworks.go.plugin.access;
+package com.thoughtworks.go.plugin.access.exceptions;
 
-import java.util.Map;
-
-public interface PluginInteractionCallback<T> {
-    String requestBody(String resolvedExtensionVersion);
-
-    Map<String, String> requestParams(String resolvedExtensionVersion);
-
-    Map<String, String> requestHeaders(String resolvedExtensionVersion);
-
-    T onSuccess(String responseBody, Map<String, String> responseHeaders, String resolvedExtensionVersion);
-
-    void onFailure(int responseCode, String responseBody, String resolvedExtensionVersion);
+public class SecretResolutionFailureException extends RuntimeException {
+    public SecretResolutionFailureException(String message) {
+        super(message);
+    }
 }

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/secrets/SecretsMessageConverter.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/secrets/SecretsMessageConverter.java
@@ -39,4 +39,6 @@ public interface SecretsMessageConverter {
     String lookupSecretsRequestBody(Set<String> lookupStrings, Map<String, String> configurationAsMap);
 
     List<Secret> getSecretsFromResponse(String responseBody);
+
+    String getErrorMessageFromResponse(String responseBody);
 }

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/secrets/v1/SecretsExtensionV1.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/secrets/v1/SecretsExtensionV1.java
@@ -19,6 +19,7 @@ package com.thoughtworks.go.plugin.access.secrets.v1;
 import com.thoughtworks.go.config.SecretConfig;
 import com.thoughtworks.go.plugin.access.DefaultPluginInteractionCallback;
 import com.thoughtworks.go.plugin.access.PluginRequestHelper;
+import com.thoughtworks.go.plugin.access.exceptions.SecretResolutionFailureException;
 import com.thoughtworks.go.plugin.access.secrets.SecretsPluginConstants;
 import com.thoughtworks.go.plugin.access.secrets.VersionedSecretsExtension;
 import com.thoughtworks.go.plugin.api.response.validation.ValidationResult;
@@ -31,6 +32,7 @@ import java.util.Map;
 import java.util.Set;
 
 import static com.thoughtworks.go.plugin.access.secrets.SecretsPluginConstants.*;
+import static java.lang.String.format;
 
 public class SecretsExtensionV1 implements VersionedSecretsExtension {
     public static final String VERSION = "1.0";
@@ -106,6 +108,13 @@ public class SecretsExtensionV1 implements VersionedSecretsExtension {
                     @Override
                     public List<Secret> onSuccess(String responseBody, Map<String, String> responseHeaders, String resolvedExtensionVersion) {
                         return secretsMessageConverterV1.getSecretsFromResponse(responseBody);
+                    }
+
+                    @Override
+                    public void onFailure(int responseCode, String responseBody, String resolvedExtensionVersion) {
+                        String errorMessage = secretsMessageConverterV1.getErrorMessageFromResponse(responseBody);
+                        throw new SecretResolutionFailureException(
+                                format("Error looking up secrets, plugin returned error code '%s' with response: '%s'", responseCode, errorMessage));
                     }
                 });
     }

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/secrets/v1/SecretsMessageConverterV1.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/secrets/v1/SecretsMessageConverterV1.java
@@ -81,6 +81,13 @@ public class SecretsMessageConverterV1 implements SecretsMessageConverter {
         return SecretDTO.fromJSONList(responseBody).stream().map(SecretDTO::toDomainModel).collect(Collectors.toList());
     }
 
+    @Override
+    public String getErrorMessageFromResponse(String responseBody) {
+        String errorMessage = (String) new Gson().fromJson(responseBody, Map.class).get("message");
+
+        return errorMessage;
+    }
+
     private JsonObject mapToJsonObject(Map<String, String> configuration) {
         final JsonObject properties = new JsonObject();
         configuration.forEach(properties::addProperty);


### PR DESCRIPTION
Fixes https://github.com/gocd/gocd/issues/6018

* PluginRequestHelper would earlier throw an exception for response code
  other than 200, with a generic message. Introduced 'onFailure'
  callback which would allow extensions to either handle failures
  appropriately or throw exceptions.
