### PR TITLE
Plugin infos api V5: Test cases and fixes for [#6007]

### DIFF
--- a/api/api-plugin-infos-v5/src/main/java/com/thoughtworks/go/apiv5/plugininfos/representers/extensions/AnalyticsPluginInfoRepresenter.java
+++ b/api/api-plugin-infos-v5/src/main/java/com/thoughtworks/go/apiv5/plugininfos/representers/extensions/AnalyticsPluginInfoRepresenter.java
@@ -27,13 +27,11 @@ public class AnalyticsPluginInfoRepresenter extends ExtensionRepresenter {
 
         AnalyticsPluginInfo analyticsPluginInfo = (AnalyticsPluginInfo) extension;
 
-        if (analyticsPluginInfo.getCapabilities() != null) {
-            extensionWriter.addChild("capabilities", capabilitiesWriter ->
-                    capabilitiesWriter.addChildList("supported_analytics", supportedAnalyticsWriter ->
-                            analyticsPluginInfo.getCapabilities().getSupportedAnalytics().forEach(analytics ->
-                                    supportedAnalyticsWriter.addChild(supportedAnalyticWriter -> supportedAnalyticWriter.add("type", analytics.getType())
-                                            .add("id", analytics.getId())
-                                            .add("title", analytics.getTitle())))));
-        }
+        extensionWriter.addChild("capabilities", capabilitiesWriter ->
+                capabilitiesWriter.addChildList("supported_analytics", supportedAnalyticsWriter ->
+                        analyticsPluginInfo.getCapabilities().getSupportedAnalytics().forEach(analytics ->
+                                supportedAnalyticsWriter.addChild(supportedAnalyticWriter -> supportedAnalyticWriter.add("type", analytics.getType())
+                                        .add("id", analytics.getId())
+                                        .add("title", analytics.getTitle())))));
     }
 }

--- a/api/api-plugin-infos-v5/src/main/java/com/thoughtworks/go/apiv5/plugininfos/representers/extensions/ArtifactPluginInfoRepresenter.java
+++ b/api/api-plugin-infos-v5/src/main/java/com/thoughtworks/go/apiv5/plugininfos/representers/extensions/ArtifactPluginInfoRepresenter.java
@@ -28,22 +28,9 @@ public class ArtifactPluginInfoRepresenter extends ExtensionRepresenter {
         super.toJSON(extensionWriter, extension);
 
         ArtifactPluginInfo artifactPluginInfo = (ArtifactPluginInfo) extension;
-        PluggableInstanceSettings artifactConfigSettings = artifactPluginInfo.getArtifactConfigSettings();
-        PluggableInstanceSettings fetchArtifactSettings = artifactPluginInfo.getFetchArtifactSettings();
-        PluggableInstanceSettings storeConfigSettings = artifactPluginInfo.getStoreConfigSettings();
 
-
-        if (storeConfigSettings != null) {
-            extensionWriter.addChild("store_config_settings", storeConfigWriter -> PluggableInstanceSettingsRepresenter.toJSON(storeConfigWriter, storeConfigSettings));
-        }
-
-        if (artifactConfigSettings != null) {
-            extensionWriter.addChild("artifact_config_settings", artifactConfigWriter -> PluggableInstanceSettingsRepresenter.toJSON(artifactConfigWriter, artifactConfigSettings));
-        }
-
-        if (fetchArtifactSettings != null) {
-            extensionWriter.addChild("fetch_artifact_settings", fetchArtifactWriter -> PluggableInstanceSettingsRepresenter.toJSON(fetchArtifactWriter, fetchArtifactSettings));
-        }
-
+        extensionWriter.addChild("store_config_settings", storeConfigWriter -> PluggableInstanceSettingsRepresenter.toJSON(storeConfigWriter, artifactPluginInfo.getStoreConfigSettings()))
+                .addChild("artifact_config_settings", artifactConfigWriter -> PluggableInstanceSettingsRepresenter.toJSON(artifactConfigWriter, artifactPluginInfo.getArtifactConfigSettings()))
+                .addChild("fetch_artifact_settings", fetchArtifactWriter -> PluggableInstanceSettingsRepresenter.toJSON(fetchArtifactWriter, artifactPluginInfo.getFetchArtifactSettings()));
     }
 }

--- a/api/api-plugin-infos-v5/src/main/java/com/thoughtworks/go/apiv5/plugininfos/representers/extensions/AuthorizationExtensionRepresenter.java
+++ b/api/api-plugin-infos-v5/src/main/java/com/thoughtworks/go/apiv5/plugininfos/representers/extensions/AuthorizationExtensionRepresenter.java
@@ -32,20 +32,16 @@ public class AuthorizationExtensionRepresenter extends ExtensionRepresenter {
         PluggableInstanceSettings authConfigSettings = authorizationExtension.getAuthConfigSettings();
         PluggableInstanceSettings roleConfigSettings = authorizationExtension.getRoleSettings();
 
-        if (authConfigSettings != null) {
-            extensionWriter.addChild("auth_config_settings", authConfigWriter -> PluggableInstanceSettingsRepresenter.toJSON(authConfigWriter, authConfigSettings));
-        }
+        extensionWriter.addChild("auth_config_settings", authConfigWriter -> PluggableInstanceSettingsRepresenter.toJSON(authConfigWriter, authConfigSettings));
 
         if (roleConfigSettings != null) {
             extensionWriter.addChild("role_settings", roleConfigWriter -> PluggableInstanceSettingsRepresenter.toJSON(roleConfigWriter, roleConfigSettings));
         }
 
-        if (authorizationExtension.getCapabilities() != null) {
-            extensionWriter.addChild("capabilities", capabilitiesWriter ->
-                    capabilitiesWriter.add("can_search", authorizationExtension.getCapabilities().canSearch())
-                            .add("supported_auth_type", authorizationExtension.getCapabilities().getSupportedAuthType().toString())
-                            .add("can_authorize", authorizationExtension.getCapabilities().canAuthorize())
-            );
-        }
+        extensionWriter.addChild("capabilities", capabilitiesWriter ->
+                capabilitiesWriter.add("can_search", authorizationExtension.getCapabilities().canSearch())
+                        .add("supported_auth_type", authorizationExtension.getCapabilities().getSupportedAuthType().toString())
+                        .add("can_authorize", authorizationExtension.getCapabilities().canAuthorize())
+        );
     }
 }

--- a/api/api-plugin-infos-v5/src/main/java/com/thoughtworks/go/apiv5/plugininfos/representers/extensions/ElasticAgentExtensionRepresenter.java
+++ b/api/api-plugin-infos-v5/src/main/java/com/thoughtworks/go/apiv5/plugininfos/representers/extensions/ElasticAgentExtensionRepresenter.java
@@ -31,9 +31,7 @@ public class ElasticAgentExtensionRepresenter extends ExtensionRepresenter {
         PluggableInstanceSettings elasticAgentProfileSettings = elasticAgentExtension.getProfileSettings();
         PluggableInstanceSettings clusterProfileSettings = elasticAgentExtension.getClusterProfileSettings();
 
-        if (elasticAgentProfileSettings != null) {
-            extensionWriter.addChild("elastic_agent_profile_settings", authConfigWriter -> PluggableInstanceSettingsRepresenter.toJSON(authConfigWriter, elasticAgentProfileSettings));
-        }
+        extensionWriter.addChild("elastic_agent_profile_settings", authConfigWriter -> PluggableInstanceSettingsRepresenter.toJSON(authConfigWriter, elasticAgentProfileSettings));
 
         if (clusterProfileSettings != null && clusterProfileSettings.getConfigurations() != null && clusterProfileSettings.getView() != null) {
             extensionWriter.add("supports_cluster_profiles", true);
@@ -42,11 +40,9 @@ public class ElasticAgentExtensionRepresenter extends ExtensionRepresenter {
             extensionWriter.add("supports_cluster_profiles", false);
         }
 
-        if (elasticAgentExtension.getCapabilities() != null) {
-            extensionWriter.addChild("capabilities", capabilitiesWriter ->
-                    capabilitiesWriter.add("supports_plugin_status_report", elasticAgentExtension.getCapabilities().supportsPluginStatusReport())
-                            .add("supports_agent_status_report", elasticAgentExtension.getCapabilities().supportsAgentStatusReport())
-                            .add("supports_cluster_status_report", elasticAgentExtension.getCapabilities().supportsClusterStatusReport()));
-        }
+        extensionWriter.addChild("capabilities", capabilitiesWriter ->
+                capabilitiesWriter.add("supports_plugin_status_report", elasticAgentExtension.getCapabilities().supportsPluginStatusReport())
+                        .add("supports_agent_status_report", elasticAgentExtension.getCapabilities().supportsAgentStatusReport())
+                        .add("supports_cluster_status_report", elasticAgentExtension.getCapabilities().supportsClusterStatusReport()));
     }
 }

--- a/api/api-plugin-infos-v5/src/main/java/com/thoughtworks/go/apiv5/plugininfos/representers/extensions/PackageMaterialExtensionRepresenter.java
+++ b/api/api-plugin-infos-v5/src/main/java/com/thoughtworks/go/apiv5/plugininfos/representers/extensions/PackageMaterialExtensionRepresenter.java
@@ -26,15 +26,8 @@ public class PackageMaterialExtensionRepresenter extends ExtensionRepresenter {
     @Override
     public void toJSON(OutputWriter extensionWriter, PluginInfo extension) {
         super.toJSON(extensionWriter, extension);
-
         PackageMaterialPluginInfo packageMaterialPluginInfo = (PackageMaterialPluginInfo) extension;
-
-        if (packageMaterialPluginInfo.getPackageSettings() != null) {
-            extensionWriter.addChild("package_settings", taskSettingsWriter -> PluggableInstanceSettingsRepresenter.toJSON(taskSettingsWriter, packageMaterialPluginInfo.getPackageSettings()));
-        }
-
-        if (packageMaterialPluginInfo.getRepositorySettings() != null) {
-            extensionWriter.addChild("repository_settings", taskSettingsWriter -> PluggableInstanceSettingsRepresenter.toJSON(taskSettingsWriter, packageMaterialPluginInfo.getRepositorySettings()));
-        }
+        extensionWriter.addChild("package_settings", taskSettingsWriter -> PluggableInstanceSettingsRepresenter.toJSON(taskSettingsWriter, packageMaterialPluginInfo.getPackageSettings()))
+                .addChild("repository_settings", taskSettingsWriter -> PluggableInstanceSettingsRepresenter.toJSON(taskSettingsWriter, packageMaterialPluginInfo.getRepositorySettings()));
     }
 }

--- a/api/api-plugin-infos-v5/src/main/java/com/thoughtworks/go/apiv5/plugininfos/representers/extensions/SCMExtensionRepresenter.java
+++ b/api/api-plugin-infos-v5/src/main/java/com/thoughtworks/go/apiv5/plugininfos/representers/extensions/SCMExtensionRepresenter.java
@@ -28,13 +28,7 @@ public class SCMExtensionRepresenter extends ExtensionRepresenter {
 
         SCMPluginInfo scmPluginInfo = (SCMPluginInfo) extension;
 
-        extensionWriter.add("display_name", scmPluginInfo.getDisplayName());
-
-        if (scmPluginInfo.getScmSettings() != null) {
-            extensionWriter.addChild("scm_settings", scmSettingsWriter -> PluggableInstanceSettingsRepresenter.toJSON(scmSettingsWriter, scmPluginInfo.getScmSettings()));
-
-        }
-
+        extensionWriter.add("display_name", scmPluginInfo.getDisplayName())
+                .addChild("scm_settings", scmSettingsWriter -> PluggableInstanceSettingsRepresenter.toJSON(scmSettingsWriter, scmPluginInfo.getScmSettings()));
     }
-
 }

--- a/api/api-plugin-infos-v5/src/main/java/com/thoughtworks/go/apiv5/plugininfos/representers/extensions/TaskExtensionRepresenter.java
+++ b/api/api-plugin-infos-v5/src/main/java/com/thoughtworks/go/apiv5/plugininfos/representers/extensions/TaskExtensionRepresenter.java
@@ -27,11 +27,7 @@ public class TaskExtensionRepresenter extends ExtensionRepresenter {
         super.toJSON(extensionWriter, extension);
 
         PluggableTaskPluginInfo taskPluginInfo = (PluggableTaskPluginInfo) extension;
-        extensionWriter.add("display_name", taskPluginInfo.getDisplayName());
-
-        if (taskPluginInfo.getTaskSettings() != null) {
-            extensionWriter.addChild("task_settings", taskSettingsWriter -> PluggableInstanceSettingsRepresenter.toJSON(taskSettingsWriter, taskPluginInfo.getTaskSettings()));
-        }
-
+        extensionWriter.add("display_name", taskPluginInfo.getDisplayName())
+                .addChild("task_settings", taskSettingsWriter -> PluggableInstanceSettingsRepresenter.toJSON(taskSettingsWriter, taskPluginInfo.getTaskSettings()));
     }
 }

--- a/api/api-plugin-infos-v5/src/test/groovy/com/thoughtworks/go/apiv5/plugininfos/representers/Helper/PluginInfoMother.java
+++ b/api/api-plugin-infos-v5/src/test/groovy/com/thoughtworks/go/apiv5/plugininfos/representers/Helper/PluginInfoMother.java
@@ -36,40 +36,44 @@ import java.util.List;
 
 public class PluginInfoMother {
     public static AuthorizationPluginInfo createAuthorizationPluginInfo() {
-        ArrayList<String> targetOperatingSystems = new ArrayList<>();
-        targetOperatingSystems.add("os");
-        GoPluginDescriptor descriptor = new GoPluginDescriptor("plugin_id", "1", new GoPluginDescriptor.About("GoPlugin", "v1", "goVersion1", "go plugin", new GoPluginDescriptor.Vendor("go", "goUrl"), targetOperatingSystems), "/home/pluginjar/", null, true);
         Capabilities capabilities = new Capabilities(SupportedAuthType.Password, true, true, true);
+        return new AuthorizationPluginInfo(getGoPluginDescriptor(), getPluggableSettings(), getPluggableSettings(), new Image("content_type", "data", "hash"), capabilities);
+    }
 
-        return new AuthorizationPluginInfo(descriptor, getPluggableSettings(), getPluggableSettings(), new Image("content_type", "data", "hash"), capabilities);
+    public static AuthorizationPluginInfo createAuthorizationPluginInfoWithoutAbout() {
+        Capabilities capabilities = new Capabilities(SupportedAuthType.Password, true, true, true);
+        GoPluginDescriptor descriptor = new GoPluginDescriptor("plugin_id", "1", null, "/home/pluginjar/", null, true);
+        return new AuthorizationPluginInfo(descriptor, getPluggableSettings(), null, new Image("content_type", "data", "hash"), capabilities);
+    }
+
+    public static AuthorizationPluginInfo createAuthorizationPluginInfoWithoutImage() {
+        Capabilities capabilities = new Capabilities(SupportedAuthType.Password, true, true, true);
+        return new AuthorizationPluginInfo(getGoPluginDescriptor(), getPluggableSettings(), null, null, capabilities);
+    }
+
+    public static AuthorizationPluginInfo createAuthorizationPluginInfoWithoutRoleSettings() {
+        Capabilities capabilities = new Capabilities(SupportedAuthType.Password, true, true, true);
+        return new AuthorizationPluginInfo(getGoPluginDescriptor(), getPluggableSettings(), null, new Image("content_type", "data", "hash"), capabilities);
     }
 
     public static SCMPluginInfo createSCMPluginInfo() {
-        ArrayList<String> targetOperatingSystems = new ArrayList<>();
-        targetOperatingSystems.add("os");
-        GoPluginDescriptor descriptor = new GoPluginDescriptor("plugin_id", "1", new GoPluginDescriptor.About("GoPlugin", "v1", "goVersion1", "go plugin", new GoPluginDescriptor.Vendor("go", "goUrl"), targetOperatingSystems), "/home/pluginjar/", null, true);
 
         ArrayList<PluginConfiguration> configurations = new ArrayList<>();
         PluginConfiguration pluginConfiguration1 = new PluginConfiguration("key1", new MetadataWithPartOfIdentity(true, false, true));
         configurations.add(pluginConfiguration1);
-
-        return new SCMPluginInfo(descriptor, "SCM", new PluggableInstanceSettings(configurations, new PluginView("Template")), null);
+        return new SCMPluginInfo(getGoPluginDescriptor(), "SCM", new PluggableInstanceSettings(configurations, new PluginView("Template")), null);
     }
 
     public static ConfigRepoPluginInfo createConfigRepoPluginInfo() {
-        ArrayList<String> targetOperatingSystems = new ArrayList<>();
-        targetOperatingSystems.add("os");
-        GoPluginDescriptor descriptor = new GoPluginDescriptor("plugin_id", "1", new GoPluginDescriptor.About("GoPlugin", "v1", "goVersion1", "go plugin", new GoPluginDescriptor.Vendor("go", "goUrl"), targetOperatingSystems), "/home/pluginjar/", null, true);
+        return new ConfigRepoPluginInfo(getGoPluginDescriptor(), null, getPluggableSettings());
+    }
 
-        return new ConfigRepoPluginInfo(descriptor, null, getPluggableSettings());
+    public static ConfigRepoPluginInfo createConfigRepoPluginInfoWithoutPluginSettings() {
+        return new ConfigRepoPluginInfo(getGoPluginDescriptor(), null, null);
     }
 
     public static ElasticAgentPluginInfo createElasticAgentPluginInfoForV4() {
-        ArrayList<String> targetOperatingSystems = new ArrayList<>();
-        targetOperatingSystems.add("os");
-        GoPluginDescriptor descriptor = new GoPluginDescriptor("plugin_id", "1", new GoPluginDescriptor.About("GoPlugin", "v1", "goVersion1", "go plugin", new GoPluginDescriptor.Vendor("go", "goUrl"), targetOperatingSystems), "/home/pluginjar/", null, true);
-
-        return new ElasticAgentPluginInfo(descriptor, getPluggableSettings(), null, null, getPluggableSettings(), new com.thoughtworks.go.plugin.domain.elastic.Capabilities(true, false));
+        return new ElasticAgentPluginInfo(getGoPluginDescriptor(), getPluggableSettings(), null, null, getPluggableSettings(), new com.thoughtworks.go.plugin.domain.elastic.Capabilities(true, false));
     }
 
     public static ElasticAgentPluginInfo createElasticAgentPluginInfoForV5() {
@@ -101,11 +105,8 @@ public class PluginInfoMother {
     }
 
     public static PluggableTaskPluginInfo createTaskPluginInfo() {
-        ArrayList<String> targetOperatingSystems = new ArrayList<>();
-        targetOperatingSystems.add("os");
-        GoPluginDescriptor descriptor = new GoPluginDescriptor("plugin_id", "1", new GoPluginDescriptor.About("GoPlugin", "v1", "goVersion1", "go plugin", new GoPluginDescriptor.Vendor("go", "goUrl"), targetOperatingSystems), "/home/pluginjar/", null, true);
 
-        return new PluggableTaskPluginInfo(descriptor, "Task", getPluggableSettings());
+        return new PluggableTaskPluginInfo(getGoPluginDescriptor(), "Task", getPluggableSettings());
     }
 
     public static PackageMaterialPluginInfo createPackageMaterialPluginInfo() {
@@ -118,37 +119,41 @@ public class PluginInfoMother {
         packageSettings.add(settings);
         PluggableInstanceSettings pluggablePackageSettings = new PluggableInstanceSettings(packageSettings, new PluginView("Template"));
 
+        return new PackageMaterialPluginInfo(getGoPluginDescriptor(), pluggableRepositorySettings, pluggablePackageSettings, null);
+    }
+
+    private static GoPluginDescriptor getGoPluginDescriptor() {
         ArrayList<String> targetOperatingSystems = new ArrayList<>();
         targetOperatingSystems.add("os");
-        GoPluginDescriptor descriptor = new GoPluginDescriptor("plugin_id", "1", new GoPluginDescriptor.About("GoPlugin", "v1", "goVersion1", "go plugin", new GoPluginDescriptor.Vendor("go", "goUrl"), targetOperatingSystems), "/home/pluginjar/", null, true);
-
-
-        return new PackageMaterialPluginInfo(descriptor, pluggableRepositorySettings, pluggablePackageSettings, null);
+        return new GoPluginDescriptor("plugin_id", "1", new GoPluginDescriptor.About("GoPlugin", "v1", "goVersion1", "go plugin", new GoPluginDescriptor.Vendor("go", "goUrl"), targetOperatingSystems), "/home/pluginjar/", null, true);
     }
 
     public static NotificationPluginInfo createNotificationPluginInfo() {
-        ArrayList<String> targetOperatingSystems = new ArrayList<>();
-        targetOperatingSystems.add("os");
-        GoPluginDescriptor descriptor = new GoPluginDescriptor("plugin_id", "1", new GoPluginDescriptor.About("GoPlugin", "v1", "goVersion1", "go plugin", new GoPluginDescriptor.Vendor("go", "goUrl"), targetOperatingSystems), "/home/pluginjar/", null, true);
+        return new NotificationPluginInfo(getGoPluginDescriptor(), getPluggableSettings());
+    }
 
-        return new NotificationPluginInfo(descriptor, getPluggableSettings());
+    public static NotificationPluginInfo createNotificationPluginInfoWithoutPluginSettings() {
+        return new NotificationPluginInfo(getGoPluginDescriptor(), null);
     }
 
     public static AnalyticsPluginInfo createAnalyticsPluginInfo() {
-        ArrayList<String> targetOperatingSystems = new ArrayList<>();
         List<SupportedAnalytics> supportedAnalytics = new ArrayList<>();
-        targetOperatingSystems.add("os");
         supportedAnalytics.add(new SupportedAnalytics("Type 1", "Id 1", "Title 1"));
-        GoPluginDescriptor descriptor = new GoPluginDescriptor("plugin_id", "1", new GoPluginDescriptor.About("GoPlugin", "v1", "goVersion1", "go plugin", new GoPluginDescriptor.Vendor("go", "goUrl"), targetOperatingSystems), "/home/pluginjar/", null, true);
+        return new AnalyticsPluginInfo(getGoPluginDescriptor(), null, new com.thoughtworks.go.plugin.domain.analytics.Capabilities(supportedAnalytics), getPluggableSettings());
+    }
 
-        return new AnalyticsPluginInfo(descriptor, null, new com.thoughtworks.go.plugin.domain.analytics.Capabilities(supportedAnalytics), getPluggableSettings());
+    public static AnalyticsPluginInfo createAnalyticsPluginInfoWithoutPluginSettings() {
+        List<SupportedAnalytics> supportedAnalytics = new ArrayList<>();
+        supportedAnalytics.add(new SupportedAnalytics("Type 1", "Id 1", "Title 1"));
+        return new AnalyticsPluginInfo(getGoPluginDescriptor(), null, new com.thoughtworks.go.plugin.domain.analytics.Capabilities(supportedAnalytics), null);
+    }
+
+    public static AnalyticsPluginInfo createAnalyticsPluginWithoutSupportedAnalytics() {
+        List<SupportedAnalytics> supportedAnalytics = new ArrayList<>();
+        return new AnalyticsPluginInfo(getGoPluginDescriptor(), null, new com.thoughtworks.go.plugin.domain.analytics.Capabilities(supportedAnalytics), getPluggableSettings());
     }
 
     public static ArtifactPluginInfo createArtifactExtension() {
-        ArrayList<String> targetOperatingSystems = new ArrayList<>();
-        targetOperatingSystems.add("os");
-        GoPluginDescriptor descriptor = new GoPluginDescriptor("plugin_id", "1", new GoPluginDescriptor.About("GoPlugin", "v1", "goVersion1", "go plugin", new GoPluginDescriptor.Vendor("go", "goUrl"), targetOperatingSystems), "/home/pluginjar/", null, true);
-
-        return new ArtifactPluginInfo(descriptor, getPluggableSettings(), getPluggableSettings(), getPluggableSettings(), null, null);
+        return new ArtifactPluginInfo(getGoPluginDescriptor(), getPluggableSettings(), getPluggableSettings(), getPluggableSettings(), null, null);
     }
 }

--- a/api/api-plugin-infos-v5/src/test/groovy/com/thoughtworks/go/apiv5/plugininfos/representers/PluginInfoRepresenterTest.groovy
+++ b/api/api-plugin-infos-v5/src/test/groovy/com/thoughtworks/go/apiv5/plugininfos/representers/PluginInfoRepresenterTest.groovy
@@ -26,12 +26,8 @@ import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson
 
 class PluginInfoRepresenterTest {
 
-  @Test
-  void 'it should serialize valid pluginInfo'() {
-    def actualJson = toObjectString({
-      PluginInfoRepresenter.toJSON(it, new CombinedPluginInfo(PluginInfoMother.createAuthorizationPluginInfo()))
-    })
-    def expectedJson = [
+  static LinkedHashMap<Object, Object> expectedJson() {
+    return [
       "_links"              : [
         "doc"  : [
           "href": apiDocsUrl("#plugin-info")
@@ -116,8 +112,15 @@ class PluginInfoRepresenterTest {
         ]
       ]
     ]
+  }
 
-    assertThatJson(actualJson).isEqualTo(expectedJson)
+  @Test
+  void 'it should serialize valid pluginInfo'() {
+    def actualJson = toObjectString({
+      PluginInfoRepresenter.toJSON(it, new CombinedPluginInfo(PluginInfoMother.createAuthorizationPluginInfo()))
+    })
+
+    assertThatJson(actualJson).isEqualTo(expectedJson())
   }
 
   @Test
@@ -159,6 +162,122 @@ class PluginInfoRepresenterTest {
         ],
       ],
       "extensions"          : []
+    ]
+
+    assertThatJson(actualJson).isEqualTo(expectedJson)
+  }
+
+  @Test
+  void "should serialize plugin info if about information is not specified"() {
+    def actualJson = toObjectString({
+      PluginInfoRepresenter.toJSON(it, new CombinedPluginInfo(PluginInfoMother.createAuthorizationPluginInfoWithoutAbout()))
+    })
+    def expectedJson = [
+      "_links"              : [
+        "doc"  : [
+          "href": apiDocsUrl("#plugin-info")
+        ],
+        "find" : [
+          "href": "http://test.host/go/api/admin/plugin_info/:id"
+        ],
+        "self" : [
+          "href": "http://test.host/go/api/admin/plugin_info/plugin_id"
+        ],
+        "image": [
+          "href": "http://test.host/go/api/plugin_images/plugin_id/hash"
+        ]
+      ],
+      "id"                  : "plugin_id",
+      "status"              : [
+        "state": "active"
+      ],
+      "plugin_file_location": "/home/pluginjar/",
+      "bundled_plugin"      : true,
+      "extensions"          : [
+        [
+          type                : "authorization",
+          auth_config_settings: [
+            configurations: [
+              [
+                key     : "key1",
+                metadata: [required: true, secure: false]
+              ],
+              [
+                key     : "key2",
+                metadata: [required: true, secure: false]
+              ]
+            ],
+            view          : [template: "Template"]
+          ],
+          capabilities        : [
+            can_authorize      : true,
+            can_search         : true,
+            supported_auth_type: "Password"
+          ]
+        ]
+      ]
+    ]
+
+    assertThatJson(actualJson).isEqualTo(expectedJson)
+  }
+
+  @Test
+  void "should serialize plugin info if image is not specified"() {
+    def actualJson = toObjectString({
+      PluginInfoRepresenter.toJSON(it, new CombinedPluginInfo(PluginInfoMother.createAuthorizationPluginInfoWithoutImage()))
+    })
+    def expectedJson = [
+      "_links"              : [
+        "doc" : [
+          "href": apiDocsUrl("#plugin-info")
+        ],
+        "find": [
+          "href": "http://test.host/go/api/admin/plugin_info/:id"
+        ],
+        "self": [
+          "href": "http://test.host/go/api/admin/plugin_info/plugin_id"
+        ]
+      ],
+      "id"                  : "plugin_id",
+      "status"              : [
+        "state": "active"
+      ],
+      "plugin_file_location": "/home/pluginjar/",
+      "bundled_plugin"      : true,
+      "about"               : [
+        "name"                    : "GoPlugin",
+        "version"                 : "v1",
+        "target_go_version"       : "goVersion1",
+        "description"             : "go plugin",
+        "target_operating_systems": ["os"],
+        "vendor"                  : [
+          "name": "go",
+          "url" : "goUrl"
+        ],
+      ],
+      "extensions"          : [
+        [
+          type                : "authorization",
+          auth_config_settings: [
+            configurations: [
+              [
+                key     : "key1",
+                metadata: [required: true, secure: false]
+              ],
+              [
+                key     : "key2",
+                metadata: [required: true, secure: false]
+              ]
+            ],
+            view          : [template: "Template"]
+          ],
+          capabilities        : [
+            can_authorize      : true,
+            can_search         : true,
+            supported_auth_type: "Password"
+          ]
+        ]
+      ]
     ]
 
     assertThatJson(actualJson).isEqualTo(expectedJson)

--- a/api/api-plugin-infos-v5/src/test/groovy/com/thoughtworks/go/apiv5/plugininfos/representers/PluginInfoRepresenterTest.groovy
+++ b/api/api-plugin-infos-v5/src/test/groovy/com/thoughtworks/go/apiv5/plugininfos/representers/PluginInfoRepresenterTest.groovy
@@ -20,6 +20,7 @@ import com.thoughtworks.go.apiv5.plugininfos.representers.Helper.PluginInfoMothe
 import com.thoughtworks.go.plugin.domain.common.CombinedPluginInfo
 import org.junit.jupiter.api.Test
 
+import static com.thoughtworks.go.CurrentGoCDVersion.apiDocsUrl
 import static com.thoughtworks.go.api.base.JsonUtils.toObjectString
 import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson
 
@@ -33,7 +34,7 @@ class PluginInfoRepresenterTest {
     def expectedJson = [
       "_links"              : [
         "doc"  : [
-          "href": "https://api.gocd.org/19.3.0/#plugin-info"
+          "href": apiDocsUrl("#plugin-info")
         ],
         "find" : [
           "href": "http://test.host/go/api/admin/plugin_info/:id"
@@ -128,7 +129,7 @@ class PluginInfoRepresenterTest {
     def expectedJson = [
       "_links"              : [
         "doc" : [
-          "href": "https://api.gocd.org/19.3.0/#plugin-info"
+          "href": apiDocsUrl("#plugin-info")
         ],
         "find": [
           "href": "http://test.host/go/api/admin/plugin_info/:id"

--- a/api/api-plugin-infos-v5/src/test/groovy/com/thoughtworks/go/apiv5/plugininfos/representers/PluginInfosRepresenterTest.groovy
+++ b/api/api-plugin-infos-v5/src/test/groovy/com/thoughtworks/go/apiv5/plugininfos/representers/PluginInfosRepresenterTest.groovy
@@ -4,6 +4,7 @@ import com.thoughtworks.go.apiv5.plugininfos.representers.Helper.PluginInfoMothe
 import com.thoughtworks.go.plugin.domain.common.CombinedPluginInfo
 import org.junit.jupiter.api.Test
 
+import static com.thoughtworks.go.CurrentGoCDVersion.apiDocsUrl
 import static com.thoughtworks.go.api.base.JsonUtils.toObjectString
 import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson
 
@@ -27,7 +28,7 @@ class PluginInfosRepresenterTest {
           "href": "http://test.host/go/api/admin/plugin_info"
         ],
         "doc" : [
-          "href": "https://api.gocd.org/19.3.0/#plugin-info"
+          "href": apiDocsUrl("#plugin-info")
         ],
         "find": [
           "href": "http://test.host/go/api/admin/plugin_info/:id"
@@ -41,7 +42,7 @@ class PluginInfosRepresenterTest {
                 "href": "http://test.host/go/api/admin/plugin_info/plugin_id"
               ],
               "doc" : [
-                "href": "https://api.gocd.org/19.3.0/#plugin-info"
+                "href": apiDocsUrl("#plugin-info")
               ],
               "find": [
                 "href": "http://test.host/go/api/admin/plugin_info/:id"
@@ -92,7 +93,7 @@ class PluginInfosRepresenterTest {
                 "href": "http://test.host/go/api/admin/plugin_info/plugin_id"
               ],
               "doc"  : [
-                "href": "https://api.gocd.org/19.3.0/#plugin-info"
+                "href": apiDocsUrl("#plugin-info")
               ],
               "image": [
                 "href": "http://test.host/go/api/plugin_images/plugin_id/hash"

--- a/api/api-plugin-infos-v5/src/test/groovy/com/thoughtworks/go/apiv5/plugininfos/representers/extensions/AnalyticsPluginInfoRepresenterTest.groovy
+++ b/api/api-plugin-infos-v5/src/test/groovy/com/thoughtworks/go/apiv5/plugininfos/representers/extensions/AnalyticsPluginInfoRepresenterTest.groovy
@@ -58,4 +58,34 @@ class AnalyticsPluginInfoRepresenterTest {
 
     assertThatJson(actualJson).isEqualTo(expectedJSON)
   }
+
+  @Test
+  void 'should serialize analytics plugin info without capabilities for supported analytics to json'() {
+    def actualJson = toObjectString({
+      new AnalyticsPluginInfoRepresenter().toJSON(it, PluginInfoMother.createAnalyticsPluginWithoutSupportedAnalytics())
+    })
+
+    def expectedJSON = [
+      type           : "analytics",
+      plugin_settings: [
+        configurations: [
+          [
+            key     : "key1",
+            metadata: [required: true, secure: false]
+          ],
+          [
+            key     : "key2",
+            metadata: [required: true, secure: false]
+          ]
+        ],
+        view          : [template: "Template"],
+      ],
+      capabilities   : [
+        supported_analytics: []
+      ]
+    ]
+
+    assertThatJson(actualJson).isEqualTo(expectedJSON)
+  }
+
 }

--- a/api/api-plugin-infos-v5/src/test/groovy/com/thoughtworks/go/apiv5/plugininfos/representers/extensions/ArtifactPluginInfoRepresenterTest.groovy
+++ b/api/api-plugin-infos-v5/src/test/groovy/com/thoughtworks/go/apiv5/plugininfos/representers/extensions/ArtifactPluginInfoRepresenterTest.groovy
@@ -74,5 +74,4 @@ class ArtifactPluginInfoRepresenterTest {
     ]
     assertThatJson(actualJson).isEqualTo(expectedJSON)
   }
-
 }

--- a/api/api-plugin-infos-v5/src/test/groovy/com/thoughtworks/go/apiv5/plugininfos/representers/extensions/AuthorizationExtensionRepresenterTest.groovy
+++ b/api/api-plugin-infos-v5/src/test/groovy/com/thoughtworks/go/apiv5/plugininfos/representers/extensions/AuthorizationExtensionRepresenterTest.groovy
@@ -67,4 +67,35 @@ class AuthorizationExtensionRepresenterTest {
     ]
     assertThatJson(actualJson).isEqualTo(expectedJSON)
   }
+
+  @Test
+  void 'should serialize authorization extension info without role settings to JSON'() {
+
+    def actualJson = toObjectString({
+      new AuthorizationExtensionRepresenter().toJSON(it, PluginInfoMother.createAuthorizationPluginInfoWithoutRoleSettings())
+    })
+
+    def expectedJSON = [
+      type                : "authorization",
+      auth_config_settings: [
+        configurations: [
+          [
+            key     : "key1",
+            metadata: [required: true, secure: false]
+          ],
+          [
+            key     : "key2",
+            metadata: [required: true, secure: false]
+          ]
+        ],
+        view          : [template: "Template"]
+      ],
+      capabilities        : [
+        can_authorize      : true,
+        can_search         : true,
+        supported_auth_type: "Password"
+      ]
+    ]
+    assertThatJson(actualJson).isEqualTo(expectedJSON)
+  }
 }

--- a/api/api-plugin-infos-v5/src/test/groovy/com/thoughtworks/go/apiv5/plugininfos/representers/extensions/ConfigRepoExtensionRepresenterTest.groovy
+++ b/api/api-plugin-infos-v5/src/test/groovy/com/thoughtworks/go/apiv5/plugininfos/representers/extensions/ConfigRepoExtensionRepresenterTest.groovy
@@ -24,15 +24,12 @@ import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson
 
 class ConfigRepoExtensionRepresenterTest {
   @Test
-  void 'should serialize authorization extension info to JSON'() {
-
+  void 'should serialize config repo extension info to JSON'() {
     def actualJson = toObjectString({
       new ConfigRepoExtensionRepresenter().toJSON(it, PluginInfoMother.createConfigRepoPluginInfo())
     })
-
-
     def expectedJSON = [
-      type                : "configrepo",
+      type           : "configrepo",
       plugin_settings: [
         configurations: [
           [
@@ -47,7 +44,17 @@ class ConfigRepoExtensionRepresenterTest {
         view          : [template: "Template"]
       ]
     ]
+    assertThatJson(actualJson).isEqualTo(expectedJSON)
+  }
 
+  @Test
+  void 'should serialize config repo extension info without plugin settings to JSON'() {
+    def actualJson = toObjectString({
+      new ConfigRepoExtensionRepresenter().toJSON(it, PluginInfoMother.createConfigRepoPluginInfoWithoutPluginSettings())
+    })
+    def expectedJSON = [
+      type: "configrepo"
+    ]
     assertThatJson(actualJson).isEqualTo(expectedJSON)
   }
 }

--- a/api/api-plugin-infos-v5/src/test/groovy/com/thoughtworks/go/apiv5/plugininfos/representers/extensions/ExtensionRepresenterTest.groovy
+++ b/api/api-plugin-infos-v5/src/test/groovy/com/thoughtworks/go/apiv5/plugininfos/representers/extensions/ExtensionRepresenterTest.groovy
@@ -22,46 +22,61 @@ import org.junit.jupiter.api.Test
 import static com.thoughtworks.go.api.base.JsonUtils.toObjectString
 import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson
 
-class NotificationPluginInfoRepresenterTest {
+class ExtensionRepresenterTest {
   @Test
-  void 'should serialize notification extension info to JSON'() {
-
-
+  void "should serialize extension with plugin settings"() {
     def actualJson = toObjectString({
-      new NotificationPluginInfoRepresenter().toJSON(it, PluginInfoMother.createNotificationPluginInfo())
+      new AnalyticsPluginInfoRepresenter().toJSON(it, PluginInfoMother.createAnalyticsPluginInfo())
     })
 
-    assertThatJson(actualJson).isEqualTo([
-      type           : "notification",
+    def expectedJSON = [
+      type           : "analytics",
       plugin_settings: [
         configurations: [
           [
             key     : "key1",
-            metadata: [
-              required: true,
-              secure  : false
-            ]
+            metadata: [required: true, secure: false]
           ],
           [
             key     : "key2",
-            metadata: [
-              required: true,
-              secure  : false
-            ]
+            metadata: [required: true, secure: false]
           ]
         ],
         view          : [template: "Template"]
+      ],
+      capabilities   : [
+        supported_analytics: [
+          [
+            type : "Type 1",
+            id   : "Id 1",
+            title: "Title 1"
+          ]
+        ]
       ]
-    ])
+    ]
+
+    assertThatJson(actualJson).isEqualTo(expectedJSON)
   }
 
   @Test
-  void 'should serialize notification extension info without plugin settings to JSON'() {
+  void "should serialize extension without plugin settings"() {
     def actualJson = toObjectString({
-      new NotificationPluginInfoRepresenter().toJSON(it, PluginInfoMother.createNotificationPluginInfoWithoutPluginSettings())
+      new AnalyticsPluginInfoRepresenter().toJSON(it, PluginInfoMother.createAnalyticsPluginInfoWithoutPluginSettings())
     })
-    assertThatJson(actualJson).isEqualTo([
-      type           : "notification"
-    ])
+
+    def expectedJSON = [
+      type        : "analytics",
+      capabilities: [
+        supported_analytics: [
+          [
+            type : "Type 1",
+            id   : "Id 1",
+            title: "Title 1"
+          ]
+        ]
+      ]
+    ]
+
+    assertThatJson(actualJson).isEqualTo(expectedJSON)
   }
 }

--- a/api/api-plugin-infos-v5/src/test/groovy/com/thoughtworks/go/apiv5/plugininfos/representers/extensions/PackageMaterialExtensionRepresenterTest.groovy
+++ b/api/api-plugin-infos-v5/src/test/groovy/com/thoughtworks/go/apiv5/plugininfos/representers/extensions/PackageMaterialExtensionRepresenterTest.groovy
@@ -25,8 +25,6 @@ import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson
 class PackageMaterialExtensionRepresenterTest {
   @Test
   void 'should serialize package material extension info to JSON'() {
-
-
     def actualJson = toObjectString({
       new PackageMaterialExtensionRepresenter().toJSON(it, PluginInfoMother.createPackageMaterialPluginInfo())
     })


### PR DESCRIPTION
#6007 
- Removed hard-coded GoCD version specified for docs url from tests
- Removed unnecessary null checks in representers.
    - `auth_config_settings` and `capabilities` [for Authorization plugin]
    - `capabilities` [for Analytics plugin]
    - `profile_settings` and `capabilities` [for Elastic agent Plugin]
    - `package_settings` and `repository_settings` [for PackageMaterialPluginInfo]
    - `scm_settings` [for SCM plugin]
    - `task_settings` [for Task plugin ]
    - `store_config_settings`, `artifact_config_settings`, `fetch_artifact_settings`  [for artifact ]
- Added test cases for optional parameters in extension details in plugin info API