### PR TITLE
Fix data sharing

### DIFF
--- a/server/webapp/WEB-INF/rails/webpack/helpers/api_request_builder.ts
+++ b/server/webapp/WEB-INF/rails/webpack/helpers/api_request_builder.ts
@@ -225,8 +225,9 @@ export class ApiRequestBuilder {
       headers = _.assign({}, options.headers);
     }
 
-    if (apiVersion !== null) {
-      headers.Accept = this.versionHeader(apiVersion as ApiVersion);
+    if (apiVersion !== null || apiVersion !== undefined) {
+      headers.Accept              = this.versionHeader(apiVersion as ApiVersion);
+      headers["X-Requested-With"] = "XMLHttpRequest";
     }
 
     if (options && !_.isEmpty(options.etag)) {
@@ -236,8 +237,6 @@ export class ApiRequestBuilder {
     if ((!options || !options.payload) && ApiRequestBuilder.isAnUpdate(method)) {
       headers["X-GoCD-Confirm"] = "true";
     }
-
-    headers["X-Requested-With"] = "XMLHttpRequest";
 
     return headers;
   }


### PR DESCRIPTION
* Do not send 'X-Requested-With' header for Non-GoCD API requests

Note:
* This header was introduced as part of PR: #5981
* Sending this header while requesting to datasharing.gocd.org
  will fail for CORS.

\cc: @akshaydewan 