### PR TITLE
Disable config repo modal specs

### DIFF
--- a/server/webapp/WEB-INF/rails/webpack/views/pages/config_repos/spec/config_repos_test_connection_spec.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/config_repos/spec/config_repos_test_connection_spec.tsx
@@ -35,7 +35,7 @@ describe("ConfigReposModal", () => {
     ModalManager.closeAll();
   });
 
-  it("should render error message and exclamation icon when connection is not successful", (done) => {
+  xit("should render error message and exclamation icon when connection is not successful", (done) => {
     jasmine.Ajax.withMock(() => {
       const response = {message: "Error while parsing material URL"};
 
@@ -64,7 +64,7 @@ describe("ConfigReposModal", () => {
     });
   });
 
-  it("should render success icon when connection is successful", (done) => {
+  xit("should render success icon when connection is successful", (done) => {
     jasmine.Ajax.withMock(() => {
       const response = {message: "Connection OK."};
 


### PR DESCRIPTION
* Running all 973 tests took 4.621s, whereas,
  running these two specs took 4.439s

* Ideally a modal shouldn't be tested by rendering it, instead,
  only the contents of the modal should be tested.

* Ignoring these specs as of now, needs to be rewritten.

\cc: @vishaldevgire @ketan 