### PR TITLE
Fail job on SecretParam resolution failures #5834

### DIFF
--- a/server/src/main/java/com/thoughtworks/go/server/messaging/JobStatusListener.java
+++ b/server/src/main/java/com/thoughtworks/go/server/messaging/JobStatusListener.java
@@ -24,6 +24,8 @@ import com.thoughtworks.go.server.service.StageService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import static java.util.Optional.ofNullable;
+
 @Component
 public class JobStatusListener implements GoMessageListener<JobStatusMessage> {
     private final JobStatusTopic jobStatusTopic;
@@ -58,6 +60,7 @@ public class JobStatusListener implements GoMessageListener<JobStatusMessage> {
             }
             JobInstance job = stage.findJob(message.getJobIdentifier().getBuildName());
             job.setPlan(jobInstanceSqlMapDao.loadPlan(job.getId()));
+            job.setAgentUuid(ofNullable(job.getAgentUuid()).orElse(message.getAgentUuid()));
 
             //send job-completion message to elastic agent plugin
             elasticAgentPluginService.jobCompleted(job);

--- a/server/src/main/java/com/thoughtworks/go/server/messaging/JobStatusMessage.java
+++ b/server/src/main/java/com/thoughtworks/go/server/messaging/JobStatusMessage.java
@@ -47,6 +47,10 @@ public class JobStatusMessage implements GoMessage {
         return jobIdentifier.getStageIdentifier();
     }
 
+    public String getAgentUuid() {
+        return agentUuid;
+    }
+
     public boolean equals(Object o) {
         if (this == o) {
             return true;

--- a/server/src/main/java/com/thoughtworks/go/server/service/BuildAssignmentService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/BuildAssignmentService.java
@@ -367,7 +367,9 @@ public class BuildAssignmentService implements ConfigChangedListener {
 
     private void logSecretsResolutionFailure(JobPlan job, SecretResolutionFailureException e) {
         try {
-            consoleService.appendToConsoleLog(job.getIdentifier(), format("Error while resolving secret params, reason: %s", e.getMessage()));
+            final String description = format("\nJob for pipeline '%s' failed due to errors while resolving secret params.", job.getIdentifier().buildLocator());
+            consoleService.appendToConsoleLog(job.getIdentifier(), description);
+            consoleService.appendToConsoleLog(job.getIdentifier(), format("\nReason: %s\n", e.getMessage()));
         } catch (IllegalArtifactLocationException | IOException e1) {
             LOGGER.error(e1.getMessage(), e1);
         }

--- a/server/src/main/java/com/thoughtworks/go/server/service/BuildAssignmentService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/BuildAssignmentService.java
@@ -46,6 +46,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import java.io.IOException;
 import java.util.*;
 
 import static com.thoughtworks.go.util.ArtifactLogUtil.getConsoleOutputFolderAndFileNameUrl;
@@ -367,7 +368,7 @@ public class BuildAssignmentService implements ConfigChangedListener {
     private void logSecretsResolutionFailure(JobPlan job, SecretResolutionFailureException e) {
         try {
             consoleService.appendToConsoleLog(job.getIdentifier(), format("Error while resolving secret params, reason: %s", e.getMessage()));
-        } catch (IllegalArtifactLocationException e1) {
+        } catch (IllegalArtifactLocationException | IOException e1) {
             LOGGER.error(e1.getMessage(), e1);
         }
     }

--- a/server/src/test-fast/java/com/thoughtworks/go/server/service/BuildAssignmentServiceTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/service/BuildAssignmentServiceTest.java
@@ -42,6 +42,7 @@ import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.springframework.transaction.PlatformTransactionManager;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.UUID;
@@ -270,21 +271,18 @@ class BuildAssignmentServiceTest {
 
     @Nested
     class assignWorkToAgent {
-
-
         @Test
         void shouldResolveSecretParamsInEnvironmentVariableContext() {
             final EnvironmentVariableContext environmentVariableContext = new EnvironmentVariableContext();
             environmentVariableContext.setProperty("Foo", "{{SECRET:[secret_config_id][lookup_password]}}", true);
             environmentVariableContext.setProperty("Bar", "some-value", false);
 
-            final TransactionTemplate transactionTemplate = dummy();
             final PipelineConfig pipelineConfig = PipelineConfigMother.pipelineConfig(UUID.randomUUID().toString());
             pipelineConfig.get(0).getJobs().add(JobConfigMother.jobWithNoResourceRequirement());
             final AgentInstance agentInstance = mock(AgentInstance.class);
             final Pipeline pipeline = mock(Pipeline.class);
             final JobPlan jobPlan1 = getJobPlan(pipelineConfig.getName(), pipelineConfig.get(0).name(), pipelineConfig.get(0).getJobs().last());
-            final SecretParamResolver secretParamResolver = mock(SecretParamResolver.class);
+
             when(agentInstance.isRegistered()).thenReturn(true);
             when(agentInstance.agentConfig()).thenReturn(mock(AgentConfig.class));
             when(agentInstance.firstMatching(anyList())).thenReturn(jobPlan1);
@@ -330,7 +328,7 @@ class BuildAssignmentServiceTest {
         }
 
         @Test
-        void shouldFailJobIfSecretsResolutionFails() throws IllegalArtifactLocationException {
+        void shouldFailJobIfSecretsResolutionFails() throws Exception {
             final MaterialRevisions materialRevisions = new MaterialRevisions();
             final PipelineConfig pipelineConfig = PipelineConfigMother.pipelineConfig(UUID.randomUUID().toString());
             pipelineConfig.get(0).getJobs().add(JobConfigMother.jobWithNoResourceRequirement());

--- a/server/src/test-fast/java/com/thoughtworks/go/server/service/BuildAssignmentServiceTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/service/BuildAssignmentServiceTest.java
@@ -352,7 +352,7 @@ class BuildAssignmentServiceTest {
                     .isInstanceOf(SecretResolutionFailureException.class);
 
             InOrder inOrder = inOrder(scheduleService, jobStatusTopic, consoleService);
-            inOrder.verify(consoleService).appendToConsoleLog(jobPlan1.getIdentifier(), "Error while resolving secret params, reason: Failed resolving params for keys: 'key1'");
+            inOrder.verify(consoleService, times(2)).appendToConsoleLog(eq(jobPlan1.getIdentifier()), anyString());
             inOrder.verify(scheduleService).failJob(jobInstance);
             inOrder.verify(jobStatusTopic).post(new JobStatusMessage(jobPlan1.getIdentifier(), JobState.Completed, "agent_uuid"));
         }

--- a/server/src/test-fast/java/com/thoughtworks/go/server/service/BuildAssignmentServiceTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/service/BuildAssignmentServiceTest.java
@@ -21,18 +21,24 @@ import com.thoughtworks.go.config.elastic.ElasticProfile;
 import com.thoughtworks.go.config.materials.svn.SvnMaterial;
 import com.thoughtworks.go.domain.*;
 import com.thoughtworks.go.domain.buildcause.BuildCause;
+import com.thoughtworks.go.domain.exception.IllegalArtifactLocationException;
 import com.thoughtworks.go.domain.materials.Modification;
 import com.thoughtworks.go.helper.*;
+import com.thoughtworks.go.plugin.access.exceptions.SecretResolutionFailureException;
 import com.thoughtworks.go.remote.work.BuildWork;
 import com.thoughtworks.go.server.domain.ElasticAgentMetadata;
+import com.thoughtworks.go.server.messaging.JobStatusMessage;
+import com.thoughtworks.go.server.messaging.JobStatusTopic;
 import com.thoughtworks.go.server.service.builders.BuilderFactory;
 import com.thoughtworks.go.server.transaction.TransactionTemplate;
 import com.thoughtworks.go.server.websocket.AgentRemoteHandler;
 import com.thoughtworks.go.util.SystemEnvironment;
 import com.thoughtworks.go.util.command.EnvironmentVariableContext;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
+import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.springframework.transaction.PlatformTransactionManager;
 
@@ -42,6 +48,7 @@ import java.util.UUID;
 
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 import static org.mockito.MockitoAnnotations.initMocks;
@@ -72,8 +79,14 @@ class BuildAssignmentServiceTest {
     private EnvironmentConfigService environmentConfigService;
     @Mock
     private AgentService agentService;
-    private BuildAssignmentService buildAssignmentService;
     @Mock
+    private SecretParamResolver secretParamResolver;
+    @Mock
+    private JobStatusTopic jobStatusTopic;
+    @Mock
+    private ConsoleService consoleService;
+
+    private BuildAssignmentService buildAssignmentService;
     private TransactionTemplate transactionTemplate;
     private SchedulingContext schedulingContext;
     private ArrayList<JobPlan> jobPlans;
@@ -88,7 +101,11 @@ class BuildAssignmentServiceTest {
     @BeforeEach
     void setUp() throws Exception {
         initMocks(this);
-        buildAssignmentService = new BuildAssignmentService(goConfigService, jobInstanceService, scheduleService, agentService, environmentConfigService, transactionTemplate, scheduledPipelineLoader, pipelineService, builderFactory, agentRemoteHandler, maintenanceModeService, elasticAgentPluginService, systemEnvironment, null);
+        transactionTemplate = dummy();
+        buildAssignmentService = new BuildAssignmentService(goConfigService, jobInstanceService, scheduleService, agentService,
+                environmentConfigService, transactionTemplate, scheduledPipelineLoader, pipelineService, builderFactory,
+                agentRemoteHandler, maintenanceModeService, elasticAgentPluginService, systemEnvironment, secretParamResolver,
+                jobStatusTopic, consoleService);
         elasticProfileId1 = "elastic.profile.id.1";
         elasticProfileId2 = "elastic.profile.id.2";
         elasticAgent = AgentMother.elasticAgent();
@@ -251,68 +268,96 @@ class BuildAssignmentServiceTest {
         assertThat(jobPlans.get(0)).isEqualTo(jobPlan3);
     }
 
-    @Test
-    void shouldResolveSecretParamsInEnvironmentVariableContext() {
-        final EnvironmentVariableContext environmentVariableContext = new EnvironmentVariableContext();
-        environmentVariableContext.setProperty("Foo", "{{SECRET:[secret_config_id][lookup_password]}}", true);
-        environmentVariableContext.setProperty("Bar", "some-value", false);
+    @Nested
+    class assignWorkToAgent {
 
-        final TransactionTemplate transactionTemplate = dummy();
-        final PipelineConfig pipelineConfig = PipelineConfigMother.pipelineConfig(UUID.randomUUID().toString());
-        pipelineConfig.get(0).getJobs().add(JobConfigMother.jobWithNoResourceRequirement());
-        final AgentInstance agentInstance = mock(AgentInstance.class);
-        final Pipeline pipeline = mock(Pipeline.class);
-        final JobPlan jobPlan1 = getJobPlan(pipelineConfig.getName(), pipelineConfig.get(0).name(), pipelineConfig.get(0).getJobs().last());
-        final SecretParamResolver secretParamResolver = mock(SecretParamResolver.class);
-        when(agentInstance.isRegistered()).thenReturn(true);
-        when(agentInstance.agentConfig()).thenReturn(mock(AgentConfig.class));
-        when(agentInstance.firstMatching(anyList())).thenReturn(jobPlan1);
-        when(pipeline.getBuildCause()).thenReturn(BuildCause.createNeverRun());
-        when(environmentConfigService.filterJobsByAgent(any(), any())).thenReturn(singletonList(jobPlan1));
-        when(scheduledPipelineLoader.pipelineWithPasswordAwareBuildCauseByBuildId(anyLong())).thenReturn(pipeline);
-        when(scheduleService.updateAssignedInfo(anyString(), any())).thenReturn(false);
-        when(goConfigService.artifactStores()).thenReturn(new ArtifactStores());
-        when(environmentConfigService.environmentVariableContextFor(anyString())).thenReturn(environmentVariableContext);
 
-        BuildWork work = (BuildWork) new BuildAssignmentService(goConfigService, jobInstanceService, scheduleService,
-                agentService, environmentConfigService, transactionTemplate,
-                scheduledPipelineLoader, pipelineService, builderFactory,
-                agentRemoteHandler, maintenanceModeService, elasticAgentPluginService, systemEnvironment, secretParamResolver)
-                .assignWorkToAgent(agentInstance);
+        @Test
+        void shouldResolveSecretParamsInEnvironmentVariableContext() {
+            final EnvironmentVariableContext environmentVariableContext = new EnvironmentVariableContext();
+            environmentVariableContext.setProperty("Foo", "{{SECRET:[secret_config_id][lookup_password]}}", true);
+            environmentVariableContext.setProperty("Bar", "some-value", false);
 
-        verify(secretParamResolver).resolve(work.getAssignment().initialEnvironmentVariableContext().getSecretParams());
-    }
+            final TransactionTemplate transactionTemplate = dummy();
+            final PipelineConfig pipelineConfig = PipelineConfigMother.pipelineConfig(UUID.randomUUID().toString());
+            pipelineConfig.get(0).getJobs().add(JobConfigMother.jobWithNoResourceRequirement());
+            final AgentInstance agentInstance = mock(AgentInstance.class);
+            final Pipeline pipeline = mock(Pipeline.class);
+            final JobPlan jobPlan1 = getJobPlan(pipelineConfig.getName(), pipelineConfig.get(0).name(), pipelineConfig.get(0).getJobs().last());
+            final SecretParamResolver secretParamResolver = mock(SecretParamResolver.class);
+            when(agentInstance.isRegistered()).thenReturn(true);
+            when(agentInstance.agentConfig()).thenReturn(mock(AgentConfig.class));
+            when(agentInstance.firstMatching(anyList())).thenReturn(jobPlan1);
+            when(pipeline.getBuildCause()).thenReturn(BuildCause.createNeverRun());
+            when(environmentConfigService.filterJobsByAgent(any(), any())).thenReturn(singletonList(jobPlan1));
+            when(scheduledPipelineLoader.pipelineWithPasswordAwareBuildCauseByBuildId(anyLong())).thenReturn(pipeline);
+            when(scheduleService.updateAssignedInfo(anyString(), any())).thenReturn(false);
+            when(goConfigService.artifactStores()).thenReturn(new ArtifactStores());
+            when(environmentConfigService.environmentVariableContextFor(anyString())).thenReturn(environmentVariableContext);
 
-    @Test
-    void shouldResolveSecretParamsInMaterials() {
-        final SvnMaterial svnMaterial = MaterialsMother.svnMaterial("http://username:{{SECRET:[secret_config_id][lookup_password]}}@foo.com");
-        final Modification modification = new Modification("user", null, null, null, "rev1");
-        final MaterialRevisions materialRevisions = new MaterialRevisions(new MaterialRevision(svnMaterial, modification));
-        final TransactionTemplate transactionTemplate = dummy();
-        final PipelineConfig pipelineConfig = PipelineConfigMother.pipelineConfig(UUID.randomUUID().toString());
-        pipelineConfig.get(0).getJobs().add(JobConfigMother.jobWithNoResourceRequirement());
-        final AgentInstance agentInstance = mock(AgentInstance.class);
-        final Pipeline pipeline = mock(Pipeline.class);
-        final JobPlan jobPlan1 = getJobPlan(pipelineConfig.getName(), pipelineConfig.get(0).name(), pipelineConfig.get(0).getJobs().last());
-        final SecretParamResolver secretParamResolver = mock(SecretParamResolver.class);
+            BuildWork work = (BuildWork) buildAssignmentService.assignWorkToAgent(agentInstance);
 
-        when(agentInstance.isRegistered()).thenReturn(true);
-        when(agentInstance.agentConfig()).thenReturn(mock(AgentConfig.class));
-        when(agentInstance.firstMatching(anyList())).thenReturn(jobPlan1);
-        when(pipeline.getBuildCause()).thenReturn(BuildCause.createWithModifications(materialRevisions, "bob"));
-        when(environmentConfigService.filterJobsByAgent(any(), any())).thenReturn(singletonList(jobPlan1));
-        when(scheduledPipelineLoader.pipelineWithPasswordAwareBuildCauseByBuildId(anyLong())).thenReturn(pipeline);
-        when(scheduleService.updateAssignedInfo(anyString(), any())).thenReturn(false);
-        when(goConfigService.artifactStores()).thenReturn(new ArtifactStores());
-        when(environmentConfigService.environmentVariableContextFor(anyString())).thenReturn(new EnvironmentVariableContext());
+            verify(secretParamResolver).resolve(work.getAssignment().initialEnvironmentVariableContext().getSecretParams());
+        }
 
-        new BuildAssignmentService(goConfigService, jobInstanceService, scheduleService,
-                agentService, environmentConfigService, transactionTemplate,
-                scheduledPipelineLoader, pipelineService, builderFactory,
-                agentRemoteHandler, maintenanceModeService, elasticAgentPluginService, systemEnvironment, secretParamResolver)
-                .assignWorkToAgent(agentInstance);
+        @Test
+        void shouldResolveSecretParamsInMaterials() {
+            final SvnMaterial svnMaterial = MaterialsMother.svnMaterial("http://username:{{SECRET:[secret_config_id][lookup_password]}}@foo.com");
+            final Modification modification = new Modification("user", null, null, null, "rev1");
+            final MaterialRevisions materialRevisions = new MaterialRevisions(new MaterialRevision(svnMaterial, modification));
+            final PipelineConfig pipelineConfig = PipelineConfigMother.pipelineConfig(UUID.randomUUID().toString());
+            pipelineConfig.get(0).getJobs().add(JobConfigMother.jobWithNoResourceRequirement());
+            final AgentInstance agentInstance = mock(AgentInstance.class);
+            final Pipeline pipeline = mock(Pipeline.class);
+            final JobPlan jobPlan1 = getJobPlan(pipelineConfig.getName(), pipelineConfig.get(0).name(), pipelineConfig.get(0).getJobs().last());
 
-        verify(secretParamResolver).resolve(svnMaterial.getSecretParams());
+            when(agentInstance.isRegistered()).thenReturn(true);
+            when(agentInstance.agentConfig()).thenReturn(mock(AgentConfig.class));
+            when(agentInstance.firstMatching(anyList())).thenReturn(jobPlan1);
+            when(pipeline.getBuildCause()).thenReturn(BuildCause.createWithModifications(materialRevisions, "bob"));
+            when(environmentConfigService.filterJobsByAgent(any(), any())).thenReturn(singletonList(jobPlan1));
+            when(scheduledPipelineLoader.pipelineWithPasswordAwareBuildCauseByBuildId(anyLong())).thenReturn(pipeline);
+            when(scheduleService.updateAssignedInfo(anyString(), any())).thenReturn(false);
+            when(goConfigService.artifactStores()).thenReturn(new ArtifactStores());
+            when(environmentConfigService.environmentVariableContextFor(anyString())).thenReturn(new EnvironmentVariableContext());
+
+            buildAssignmentService.assignWorkToAgent(agentInstance);
+
+            verify(secretParamResolver).resolve(svnMaterial.getSecretParams());
+            verify(scheduleService, never()).failJob(any());
+            verifyZeroInteractions(consoleService);
+            verifyZeroInteractions(jobStatusTopic);
+        }
+
+        @Test
+        void shouldFailJobIfSecretsResolutionFails() throws IllegalArtifactLocationException {
+            final MaterialRevisions materialRevisions = new MaterialRevisions();
+            final PipelineConfig pipelineConfig = PipelineConfigMother.pipelineConfig(UUID.randomUUID().toString());
+            pipelineConfig.get(0).getJobs().add(JobConfigMother.jobWithNoResourceRequirement());
+            final AgentInstance agentInstance = mock(AgentInstance.class);
+            final Pipeline pipeline = mock(Pipeline.class);
+            final JobPlan jobPlan1 = getJobPlan(pipelineConfig.getName(), pipelineConfig.get(0).name(), pipelineConfig.get(0).getJobs().last());
+            JobInstance jobInstance = mock(JobInstance.class);
+
+            when(agentInstance.isRegistered()).thenReturn(true);
+            when(agentInstance.firstMatching(anyList())).thenReturn(jobPlan1);
+            when(pipeline.getBuildCause()).thenReturn(BuildCause.createWithModifications(materialRevisions, "bob"));
+            when(scheduledPipelineLoader.pipelineWithPasswordAwareBuildCauseByBuildId(anyLong())).thenReturn(pipeline);
+            when(goConfigService.artifactStores()).thenReturn(new ArtifactStores());
+            when(environmentConfigService.environmentVariableContextFor(anyString())).thenReturn(new EnvironmentVariableContext());
+            doThrow(new SecretResolutionFailureException("Failed resolving params for keys: 'key1'")).when(secretParamResolver).resolve(any());
+            when(jobInstanceService.buildById(jobPlan1.getJobId())).thenReturn(jobInstance);
+            when(agentInstance.getUuid()).thenReturn("agent_uuid");
+            when(jobInstance.getState()).thenReturn(JobState.Completed);
+
+            assertThatCode(() -> buildAssignmentService.assignWorkToAgent(agentInstance))
+                    .isInstanceOf(SecretResolutionFailureException.class);
+
+            InOrder inOrder = inOrder(scheduleService, jobStatusTopic, consoleService);
+            inOrder.verify(consoleService).appendToConsoleLog(jobPlan1.getIdentifier(), "Error while resolving secret params, reason: Failed resolving params for keys: 'key1'");
+            inOrder.verify(scheduleService).failJob(jobInstance);
+            inOrder.verify(jobStatusTopic).post(new JobStatusMessage(jobPlan1.getIdentifier(), JobState.Completed, "agent_uuid"));
+        }
     }
 
     private JobPlan getJobPlan(CaseInsensitiveString pipelineName, CaseInsensitiveString stageName, JobConfig job) {

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/BuildAssignmentServiceIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/BuildAssignmentServiceIntegrationTest.java
@@ -50,6 +50,7 @@ import com.thoughtworks.go.server.dao.StageDao;
 import com.thoughtworks.go.server.domain.ServerMaintenanceMode;
 import com.thoughtworks.go.server.domain.Username;
 import com.thoughtworks.go.server.materials.DependencyMaterialUpdateNotifier;
+import com.thoughtworks.go.server.messaging.JobStatusTopic;
 import com.thoughtworks.go.server.persistence.MaterialRepository;
 import com.thoughtworks.go.server.scheduling.ScheduleHelper;
 import com.thoughtworks.go.server.service.builders.BuilderFactory;
@@ -120,6 +121,8 @@ public class BuildAssignmentServiceIntegrationTest {
     @Autowired private DependencyMaterialUpdateNotifier notifier;
     @Autowired private MaintenanceModeService maintenanceModeService;
     @Autowired private SecretParamResolver secretParamResolver;
+    @Autowired private ConsoleService consoleService;
+    @Autowired private JobStatusTopic jobStatusTopic;
 
     private PipelineConfig evolveConfig;
     private static final String STAGE_NAME = "dev";
@@ -396,7 +399,8 @@ public class BuildAssignmentServiceIntegrationTest {
         };
 
         final BuildAssignmentService buildAssignmentServiceUnderTest = new BuildAssignmentService(goConfigService, mockJobInstanceService, scheduleService,
-                agentService, environmentConfigService, transactionTemplate, scheduledPipelineLoader, pipelineService, builderFactory, agentRemoteHandler, maintenanceModeService, elasticAgentPluginService, systemEnvironment, secretParamResolver);
+                agentService, environmentConfigService, transactionTemplate, scheduledPipelineLoader, pipelineService, builderFactory, agentRemoteHandler,
+                maintenanceModeService, elasticAgentPluginService, systemEnvironment, secretParamResolver, jobStatusTopic, consoleService);
 
         final Throwable[] fromThread = new Throwable[1];
         buildAssignmentServiceUnderTest.onTimer();
@@ -437,7 +441,8 @@ public class BuildAssignmentServiceIntegrationTest {
         when(mockGoConfigService.getCurrentConfig()).thenReturn(config);
 
         buildAssignmentService = new BuildAssignmentService(mockGoConfigService, jobInstanceService, scheduleService, agentService, environmentConfigService,
-                transactionTemplate, scheduledPipelineLoader, pipelineService, builderFactory, agentRemoteHandler, maintenanceModeService, elasticAgentPluginService, systemEnvironment, secretParamResolver);
+                transactionTemplate, scheduledPipelineLoader, pipelineService, builderFactory, agentRemoteHandler, maintenanceModeService, elasticAgentPluginService,
+                systemEnvironment, secretParamResolver, jobStatusTopic, consoleService);
         buildAssignmentService.onTimer();
 
         AgentConfig agentConfig = AgentMother.localAgent();


### PR DESCRIPTION
* Before a job is assigned to an agent, the secret params in the job are
  resolved. If the secret resolution fails, the job is marked as failed
  and approriate error message is logged to job console.
* Also notify elastic agent plugin for job completion in case of elastic agents.