### PR TITLE
Clean submodule folders using `foreach`

### DIFF
--- a/common/src/test/java/com/thoughtworks/go/domain/materials/git/GitCommandTest.java
+++ b/common/src/test/java/com/thoughtworks/go/domain/materials/git/GitCommandTest.java
@@ -733,6 +733,12 @@ public class GitCommandTest {
         assertThat(ignoredFile.exists()).isTrue();
     }
 
+    @Test
+    void shouldNotThrowExceptionWhenSubmoduleIsAddedWithACustomName() {
+        executeOnDir(gitLocalRepoDir, "git", "submodule", "add", "--name", "Custom", gitFooBranchBundle.projectRepositoryUrl());
+        git.fetchAndResetToHead(inMemoryConsumer());
+    }
+
     private List<File> allFilesIn(File directory, String prefixOfFiles) {
         return new ArrayList<>(FileUtils.listFiles(directory, andFileFilter(fileFileFilter(), prefixFileFilter(prefixOfFiles)), null));
     }

--- a/domain/src/main/java/com/thoughtworks/go/domain/materials/git/GitCommand.java
+++ b/domain/src/main/java/com/thoughtworks/go/domain/materials/git/GitCommand.java
@@ -172,9 +172,7 @@ public class GitCommand extends SCMCommand {
 
     private void cleanAllUnversionedFiles(ConsoleOutputStreamConsumer outputStreamConsumer) {
         log(outputStreamConsumer, "Cleaning all unversioned files in working copy");
-        for (Map.Entry<String, String> submoduleFolder : submoduleUrls().entrySet()) {
-            cleanUnversionedFiles(new File(workingDir, submoduleFolder.getKey()));
-        }
+        cleanUnversionedFilesInAllSubmodules();
         cleanUnversionedFiles(workingDir);
     }
 
@@ -275,6 +273,14 @@ public class GitCommand extends SCMCommand {
     private void cleanUnversionedFiles(File workingDir) {
         CommandLine gitCmd = git(environment)
                 .withArgs("clean", gitCleanArgs())
+                .withWorkingDir(workingDir);
+        runOrBomb(gitCmd);
+    }
+
+    private void cleanUnversionedFilesInAllSubmodules() {
+        CommandLine gitCmd = git(environment)
+                .withArgs("submodule", "foreach", "--recursive")
+                .withArgs("git", "clean", gitCleanArgs())
                 .withWorkingDir(workingDir);
         runOrBomb(gitCmd);
     }


### PR DESCRIPTION
...instead of iterating through urls

This fixes https://github.com/gocd/gocd/issues/3635 where the submodule is added with a custom `--name`