### PR TITLE
Support associating cluster profile to an elastic agent profile (#5538)

### DIFF
--- a/server/webapp/WEB-INF/rails/webpack/helpers/spark_routes.ts
+++ b/server/webapp/WEB-INF/rails/webpack/helpers/spark_routes.ts
@@ -142,6 +142,10 @@ export default class {
     return `/go/api/internal/elastic/profiles/${profileId}/usages`;
   }
 
+  static clusterProfilesListPath(): string {
+    return "/go/api/admin/elastic/cluster_profiles";
+  }
+
   static agentsPath(uuid?: string): string {
     if (uuid) {
       return `/go/api/agents/${uuid}`;

--- a/server/webapp/WEB-INF/rails/webpack/models/elastic_profiles/cluster_profiles_crud.ts
+++ b/server/webapp/WEB-INF/rails/webpack/models/elastic_profiles/cluster_profiles_crud.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {ApiRequestBuilder, ApiResult, ApiVersion} from "helpers/api_request_builder";
+import SparkRoutes from "helpers/spark_routes";
+import {ClusterProfileJSON, ClusterProfiles} from "./types";
+
+export class ClusterProfilesCRUD {
+  private static API_VERSION_HEADER = ApiVersion.v1;
+
+  static all() {
+    return ApiRequestBuilder.GET(SparkRoutes.clusterProfilesListPath(), this.API_VERSION_HEADER)
+                            .then((result: ApiResult<string>) => result.map((body) => {
+                              const data = JSON.parse(body)._embedded.cluster_profiles as ClusterProfileJSON[];
+                              return ClusterProfiles.fromJSON(data);
+                            }));
+  }
+}

--- a/server/webapp/WEB-INF/rails/webpack/models/elastic_profiles/elastic_profiles_crud.ts
+++ b/server/webapp/WEB-INF/rails/webpack/models/elastic_profiles/elastic_profiles_crud.ts
@@ -19,8 +19,7 @@ import SparkRoutes from "helpers/spark_routes";
 import {ElasticProfile, ElasticProfileJSON, ElasticProfiles, ProfileUsage, ProfileUsageJSON} from "./types";
 
 export class ElasticProfilesCRUD {
-  private static API_VERSION_HEADER = ApiVersion.v1;
-
+  private static API_VERSION_HEADER = ApiVersion.v2;
   static all() {
     return ApiRequestBuilder.GET(SparkRoutes.elasticProfileListPath(), this.API_VERSION_HEADER)
                             .then((result: ApiResult<string>) => result.map((body) => {

--- a/server/webapp/WEB-INF/rails/webpack/models/elastic_profiles/spec/cluster_profiles_crud_spec.ts
+++ b/server/webapp/WEB-INF/rails/webpack/models/elastic_profiles/spec/cluster_profiles_crud_spec.ts
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {ApiResult, SuccessResponse} from "helpers/api_request_builder";
+import {ClusterProfilesCRUD} from "models/elastic_profiles/cluster_profiles_crud";
+import {ClusterProfiles} from "models/elastic_profiles/types";
+
+describe("ClusterProfileCRUD", () => {
+  beforeEach(() => jasmine.Ajax.install());
+  afterEach(() => jasmine.Ajax.uninstall());
+  const ALL_CLUSTER_PROFILES_PATH = "/go/api/admin/elastic/cluster_profiles";
+
+  it("should get all cluster profiles", (done) => {
+    jasmine.Ajax.stubRequest(ALL_CLUSTER_PROFILES_PATH).andReturn(clusterProfilesResponse());
+
+    const onResponse = jasmine.createSpy().and.callFake((response: ApiResult<any>) => {
+      const responseJSON    = response.unwrap() as SuccessResponse<any>;
+      const clusterProfiles = (responseJSON.body as ClusterProfiles);
+      expect(clusterProfiles.all()).toHaveLength(1);
+      done();
+    });
+
+    ClusterProfilesCRUD.all().then(onResponse);
+
+    const request = jasmine.Ajax.requests.mostRecent();
+    expect(request.url).toEqual(ALL_CLUSTER_PROFILES_PATH);
+    expect(request.method).toEqual("GET");
+    expect(request.requestHeaders.Accept).toEqual("application/vnd.go.cd.v1+json");
+  });
+
+  function clusterProfilesResponse() {
+    return {
+      status: 200,
+      responseHeaders: {
+        "Content-Type": "application/vnd.go.cd.v1+json; charset=utf-8",
+        "ETag": "some-etag"
+      },
+      responseText: JSON.stringify({
+                                     _embedded: {
+                                       cluster_profiles: [
+                                         {
+                                           id: "dev1",
+                                           plugin_id: "cd.go.contrib.elastic-agent.docker",
+                                           properties: [
+                                             {
+                                               key: "docker_uri",
+                                               value: "unix:///var/run/docker.sock"
+                                             }
+                                           ]
+                                         }
+                                       ]
+                                     }
+                                   })
+    };
+  }
+});

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/elastic_profiles/elastic_profiles_widget.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/elastic_profiles/elastic_profiles_widget.tsx
@@ -185,10 +185,18 @@ export interface ProfileAttrs {
 
 export class ElasticProfileWidget extends MithrilComponent<ProfileAttrs> {
 
-  static profileHeader(profileId: string) {
-    return (<KeyValuePair inline={true} data={new Map([
-                                                        ["Profile Id", profileId]
-                                                      ])}/>);
+  static profileHeader(profileId: string, clusterProfileId: string) {
+    let optionalClusterProfileId;
+    if (clusterProfileId) {
+      optionalClusterProfileId = (
+        <KeyValuePair inline={true} data={new Map([["Cluster Profile Id", clusterProfileId]])}/>
+      );
+    }
+
+    return [
+      <KeyValueTitle image={null} titleTestId="elastic-profile-id" title={`Profile Id: ${profileId}`}/>,
+      optionalClusterProfileId
+    ];
   }
 
   view(vnode: m.Vnode<ProfileAttrs, {}>) {
@@ -203,7 +211,7 @@ export class ElasticProfileWidget extends MithrilComponent<ProfileAttrs> {
         <Icons.Usage data-test-id="show-usage-elastic-profile" onclick={vnode.attrs.onShowUsage}/>
       </IconGroup>
     ];
-    return (<CollapsiblePanel header={ElasticProfileWidget.profileHeader(elasticProfile.id())}
+    return (<CollapsiblePanel header={ElasticProfileWidget.profileHeader(elasticProfile.id(), elasticProfile.clusterProfileId())}
                               actions={actions}
                               dataTestId={"elastic-profile"}>
       <KeyValuePair data={elasticProfile.properties().asMap()}/>

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/elastic_profiles/spec/elastic_profile_widget_spec.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/elastic_profiles/spec/elastic_profile_widget_spec.tsx
@@ -39,9 +39,8 @@ describe("New Elastic Profile Widget", () => {
   afterEach(helper.unmount.bind(helper));
 
   it("should render elastic profile id", () => {
-    const profileHeader = helper.find(`.${keyValuePairStyles.keyValuePair}`).get(0);
-    expect(profileHeader).toContainText("Profile Id");
-    expect(profileHeader).toContainText(TestData.DockerElasticProfile().id);
+    expect(helper.findByDataTestId("elastic-profile-id").get(0)).toContainText("Profile Id");
+    expect(helper.findByDataTestId("elastic-profile-id").get(0)).toContainText(TestData.DockerElasticProfile().id);
   });
 
   it("should render edit, delete, clone buttons", () => {
@@ -51,7 +50,7 @@ describe("New Elastic Profile Widget", () => {
   });
 
   it("should render properties of elastic profile", () => {
-    const profileHeader = helper.find(`.${keyValuePairStyles.keyValuePair}`).get(1);
+    const profileHeader = helper.find(`.${keyValuePairStyles.keyValuePair}`).get(0);
 
     expect(profileHeader).toContainText("Image");
     expect(profileHeader).toContainText("docker-image122345");

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/elastic_profiles/spec/modals_spec.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/elastic_profiles/spec/modals_spec.tsx
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {ClusterProfile, ClusterProfiles} from "models/elastic_profiles/types";
+import {ExtensionType} from "models/shared/plugin_infos_new/extension_type";
+import {ElasticAgentSettings} from "models/shared/plugin_infos_new/extensions";
+import {PluginInfo} from "models/shared/plugin_infos_new/plugin_info";
+
+import {TestHelper} from "views/pages/artifact_stores/spec/test_helper";
+import {NewElasticProfileModal} from "views/pages/elastic_profiles/modals";
+import {TestData} from "views/pages/elastic_profiles/spec/test_data";
+
+describe("New Elastic Profile Modals Spec", () => {
+  let pluginInfo: PluginInfo<any>, clusterProfiles: ClusterProfile[] = [], helper: TestHelper;
+
+  beforeEach(() => {
+    clusterProfiles = [];
+    pluginInfo     = PluginInfo.fromJSON(TestData.DockerPluginJSON(), TestData.DockerPluginJSON()._links);
+    helper         = new TestHelper();
+  });
+
+  function mountModal() {
+    const modal = new NewElasticProfileModal(
+      [pluginInfo],
+      new ClusterProfiles(clusterProfiles),
+      () => {
+        //do nothing
+      });
+
+    helper.mount(modal.body.bind(modal));
+  }
+
+  it("should get modal title", () => {
+    const modal = new NewElasticProfileModal(
+      [pluginInfo],
+      new ClusterProfiles(clusterProfiles),
+      () => {
+        //do nothing
+      });
+
+    expect(modal.title()).toEqual("Add a new profile");
+  });
+
+  it("it should not render cluster profiles dropdown when plugin infos does not support cluster profiles", () => {
+    mountModal();
+    const extension = pluginInfo.extensionOfType(ExtensionType.ELASTIC_AGENTS);
+    expect(!!(extension as ElasticAgentSettings).supportsClusterProfiles).toEqual(false);
+
+    expect(find("form-field-label-cluster-profile-id")).not.toBeInDOM();
+    expect(find("form-field-input-cluster-profile-id")).not.toBeInDOM();
+
+    helper.unmount();
+  });
+
+  it("it should render an error message when plugin infos supports cluster profiles and no cluster profiles are defined",
+     () => {
+       const data                                   = TestData.DockerPluginJSON();
+       data.extensions[0].supports_cluster_profiles = true;
+
+       pluginInfo = PluginInfo.fromJSON(data, TestData.DockerPluginJSON()._links);
+
+       mountModal();
+
+       const extension = pluginInfo.extensionOfType(ExtensionType.ELASTIC_AGENTS);
+       expect(!!(extension as ElasticAgentSettings).supportsClusterProfiles).toEqual(true);
+
+       const expectedErrorMessage = "Can not create Elastic Agent Profile for plugin 'cd.go.contrib.elastic-agent.docker'. The plugin requires a Cluster Profile to be configured first in order to define an Elastic Agent Profile.";
+
+       expect(find("flash-message-alert")).toContainText(expectedErrorMessage);
+       expect(find("form-field-label-cluster-profile-id")).not.toBeInDOM();
+       expect(find("form-field-input-cluster-profile-id")).not.toBeInDOM();
+
+       helper.unmount();
+     });
+
+  it("should render cluster profiles dropdown", () => {
+    const data = TestData.DockerPluginJSON();
+
+    data.extensions[0].supports_cluster_profiles = true;
+
+    pluginInfo     = PluginInfo.fromJSON(data, TestData.DockerPluginJSON()._links);
+    clusterProfiles = [
+      new ClusterProfile("cluster1", pluginInfo.id),
+      new ClusterProfile("cluster2", pluginInfo.id),
+    ];
+
+    mountModal();
+
+    const extension = pluginInfo.extensionOfType(ExtensionType.ELASTIC_AGENTS);
+    expect(!!(extension as ElasticAgentSettings).supportsClusterProfiles).toEqual(true);
+
+    expect(find("form-field-label-cluster-profile-id")).toBeInDOM();
+    expect(find("form-field-input-cluster-profile-id")).toBeInDOM();
+
+    expect(find("form-field-input-cluster-profile-id").get(0).children[0]).toContainText("cluster1");
+    expect(find("form-field-input-cluster-profile-id").get(0).children[1]).toContainText("cluster2");
+
+    helper.unmount();
+  });
+
+  it("should render cluster profiles belonging to the selected plugin", () => {
+    const data = TestData.DockerPluginJSON();
+
+    data.extensions[0].supports_cluster_profiles = true;
+
+    pluginInfo     = PluginInfo.fromJSON(data, TestData.DockerPluginJSON()._links);
+    clusterProfiles = [
+      new ClusterProfile("cluster1", pluginInfo.id),
+      new ClusterProfile("cluster3", "random.foo.plugin"),
+      new ClusterProfile("cluster4", "another.random.foo.plugin"),
+      new ClusterProfile("cluster2", pluginInfo.id)
+    ];
+
+    mountModal();
+
+    const extension = pluginInfo.extensionOfType(ExtensionType.ELASTIC_AGENTS);
+    expect(!!(extension as ElasticAgentSettings).supportsClusterProfiles).toEqual(true);
+
+    expect(find("form-field-label-cluster-profile-id")).toBeInDOM();
+    expect(find("form-field-input-cluster-profile-id")).toBeInDOM();
+
+    expect(find("form-field-input-cluster-profile-id").get(0).children).toHaveLength(2);
+
+    expect(find("form-field-input-cluster-profile-id").get(0).children[0]).toContainText("cluster1");
+    expect(find("form-field-input-cluster-profile-id").get(0).children[1]).toContainText("cluster2");
+
+    helper.unmount();
+  });
+
+  function find(id: string) {
+    return helper.findByDataTestId(id);
+  }
+});


### PR DESCRIPTION
* Show cluster profile ids dropdown to associate the newly defined elastic
  agent profile with a cluster.
* Do not show cluster profile ids dropdown for profile creation of v4 plugin.
* Show an error while creating elastic agent profile when no cluster is
  defined for the current plugin.

---

### Associate a cluster with elastic agent profile
![Screen Shot 2019-04-04 at 1 58 16 PM](https://user-images.githubusercontent.com/15275847/55541229-2ed7c100-56e2-11e9-98e1-75b38826d0b8.png)


### No Cluster association for v4 plugins
![Screen Shot 2019-04-04 at 1 58 24 PM](https://user-images.githubusercontent.com/15275847/55541140-0354d680-56e2-11e9-8d24-0fa2e82f743f.png)

### Show errors when No Clusters are defined.
![Screen Shot 2019-04-04 at 1 58 53 PM](https://user-images.githubusercontent.com/15275847/55541142-04860380-56e2-11e9-9c82-6f667849a80a.png)