### PR TITLE
Remove plugin settings support for EA plugins implemented with v5 extension (#5538)

### DIFF
--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/elastic/ElasticAgentPluginInfoBuilder.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/elastic/ElasticAgentPluginInfoBuilder.java
@@ -39,14 +39,19 @@ public class ElasticAgentPluginInfoBuilder implements PluginInfoBuilder<ElasticA
 
     @Override
     public ElasticAgentPluginInfo pluginInfoFor(GoPluginDescriptor descriptor) {
-        PluggableInstanceSettings pluggableInstanceSettings = getPluginSettingsAndView(descriptor, extension);
+        String pluginId = descriptor.id();
+
+        PluggableInstanceSettings pluggableInstanceSettings = null;
+        if (!extension.supportsClusterProfiles(pluginId)) {
+            pluggableInstanceSettings = getPluginSettingsAndView(descriptor, extension);
+        }
 
         return new ElasticAgentPluginInfo(descriptor,
-                elasticElasticAgentProfileSettings(descriptor.id()),
-                elasticClusterProfileSettings(descriptor.id()),
-                image(descriptor.id()),
+                elasticElasticAgentProfileSettings(pluginId),
+                elasticClusterProfileSettings(pluginId),
+                image(pluginId),
                 pluggableInstanceSettings,
-                capabilities(descriptor.id()));
+                capabilities(pluginId));
     }
 
     private com.thoughtworks.go.plugin.domain.common.Image image(String pluginId) {


### PR DESCRIPTION
* Do not make get-plugin-settings-configurations and
  get-plugin-settings-view call to Elastic Agent Plugins implemented
  using V5 Extension

---

Docker Elastic Agent plugin is implemented with v5 extension, which does not support plugin settings.
Kubernetes Elastic Agent plugin is implemented with v4 extension, which supports plugin settings.

![Screen Shot 2019-04-04 at 3 39 07 PM](https://user-images.githubusercontent.com/15275847/55547899-e8895e80-56ef-11e9-8b64-80d4d80e490b.png)
