### PR TITLE
Fix elastic profiles SPA (#5538)

### DIFF
--- a/server/webapp/WEB-INF/rails/webpack/views/pages/elastic_profiles/modals.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/elastic_profiles/modals.tsx
@@ -141,8 +141,8 @@ abstract class BaseElasticProfileModal extends Modal {
       return {id: pluginInfo.id, text: pluginInfo.about.name};
     });
 
-    const pluginSettings = (this.pluginInfo()
-                                .firstExtensionWithPluginSettings()! as ElasticAgentSettings).profileSettings;
+    const elasticAgentExtension        = this.pluginInfo().extensionOfType(ExtensionType.ELASTIC_AGENTS);
+    const elasticProfileConfigurations = (elasticAgentExtension as ElasticAgentSettings).profileSettings;
 
     return (
       <div class={foundationClassNames(foundationStyles.foundationGridHax, foundationStyles.foundationFormHax)}>
@@ -171,7 +171,7 @@ abstract class BaseElasticProfileModal extends Modal {
         <div class={styles.elasticProfileModalFormBody}>
           <div class="row collapse">
             <AngularPluginNew
-              pluginInfoSettings={stream(pluginSettings)}
+              pluginInfoSettings={stream(elasticProfileConfigurations)}
               configuration={this.elasticProfile().properties()}
               key={this.pluginInfo().id}/>
           </div>


### PR DESCRIPTION
* Do not rely upon plugin settings to fetch elastic profiles settings

---

While creating this SPA,  an assumption was made that, all the elastic agent plugins will always have plugin settings.

Now as the plugin settings are not available from the v5 extension, rely upon extension type to fetch the elastic agent profile settings (configurations + view).
