### PR TITLE
Return plugins with secrets extension in plugin-info API

### DIFF
--- a/api/api-plugin-infos-v5/src/main/java/com/thoughtworks/go/apiv5/plugininfos/representers/ExtensionRepresenterResolver.java
+++ b/api/api-plugin-infos-v5/src/main/java/com/thoughtworks/go/apiv5/plugininfos/representers/ExtensionRepresenterResolver.java
@@ -35,7 +35,7 @@ public class ExtensionRepresenterResolver {
         extensionRepresenter.put("notification", new NotificationPluginInfoRepresenter());
         extensionRepresenter.put("analytics", new AnalyticsPluginInfoRepresenter());
         extensionRepresenter.put("artifact", new ArtifactPluginInfoRepresenter());
-
+        extensionRepresenter.put("secrets", new SecretsExtensionRepresenter());
     }
 
     static ExtensionRepresenter resolveRepresenterFor(PluginInfo extension) {

--- a/api/api-plugin-infos-v5/src/main/java/com/thoughtworks/go/apiv5/plugininfos/representers/extensions/SecretsExtensionRepresenter.java
+++ b/api/api-plugin-infos-v5/src/main/java/com/thoughtworks/go/apiv5/plugininfos/representers/extensions/SecretsExtensionRepresenter.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.apiv5.plugininfos.representers.extensions;
+
+import com.thoughtworks.go.api.base.OutputWriter;
+import com.thoughtworks.go.apiv5.plugininfos.representers.PluggableInstanceSettingsRepresenter;
+import com.thoughtworks.go.plugin.domain.common.PluggableInstanceSettings;
+import com.thoughtworks.go.plugin.domain.common.PluginInfo;
+import com.thoughtworks.go.plugin.domain.secrets.SecretsPluginInfo;
+
+public class SecretsExtensionRepresenter extends ExtensionRepresenter {
+    @Override
+    public void toJSON(OutputWriter extensionWriter, PluginInfo pluginInfo) {
+        super.toJSON(extensionWriter, pluginInfo);
+
+        SecretsPluginInfo secretsPluginInfo = (SecretsPluginInfo) pluginInfo;
+        PluggableInstanceSettings secretsConfigSettings = secretsPluginInfo.getSecretsConfigSettings();
+        if (secretsConfigSettings != null) {
+            extensionWriter.addChild("secret_config_settings", authConfigWriter -> PluggableInstanceSettingsRepresenter.toJSON(authConfigWriter, secretsConfigSettings));
+        }
+    }
+}

--- a/api/api-plugin-infos-v5/src/test/groovy/com/thoughtworks/go/apiv5/plugininfos/representers/Helper/PluginInfoMother.java
+++ b/api/api-plugin-infos-v5/src/test/groovy/com/thoughtworks/go/apiv5/plugininfos/representers/Helper/PluginInfoMother.java
@@ -29,9 +29,11 @@ import com.thoughtworks.go.plugin.domain.notification.NotificationPluginInfo;
 import com.thoughtworks.go.plugin.domain.packagematerial.PackageMaterialPluginInfo;
 import com.thoughtworks.go.plugin.domain.pluggabletask.PluggableTaskPluginInfo;
 import com.thoughtworks.go.plugin.domain.scm.SCMPluginInfo;
+import com.thoughtworks.go.plugin.domain.secrets.SecretsPluginInfo;
 import com.thoughtworks.go.plugin.infra.plugininfo.GoPluginDescriptor;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 public class PluginInfoMother {
@@ -124,6 +126,14 @@ public class PluginInfoMother {
 
 
         return new PackageMaterialPluginInfo(descriptor, pluggableRepositorySettings, pluggablePackageSettings, null);
+    }
+
+
+    public static SecretsPluginInfo createSecretConfigPluginInfo() {
+        GoPluginDescriptor descriptor = new GoPluginDescriptor("plugin_id", "1", new GoPluginDescriptor.About("GoPlugin", "v1", "goVersion1", "go plugin", new GoPluginDescriptor.Vendor("go", "goUrl"), Collections.emptyList()), "/home/pluginjar/", null, true);
+
+        SecretsPluginInfo secretsPluginInfo = new SecretsPluginInfo(descriptor, getPluggableSettings(), new Image("content_type", "data", "hash"));
+        return secretsPluginInfo;
     }
 
     public static NotificationPluginInfo createNotificationPluginInfo() {

--- a/api/api-plugin-infos-v5/src/test/groovy/com/thoughtworks/go/apiv5/plugininfos/representers/extensions/SecretConfigExtensionRepresenterTest.groovy
+++ b/api/api-plugin-infos-v5/src/test/groovy/com/thoughtworks/go/apiv5/plugininfos/representers/extensions/SecretConfigExtensionRepresenterTest.groovy
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.apiv5.plugininfos.representers.extensions
+
+import com.thoughtworks.go.apiv5.plugininfos.representers.Helper.PluginInfoMother
+import org.junit.jupiter.api.Test
+
+import static com.thoughtworks.go.api.base.JsonUtils.toObjectString
+import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson
+
+class SecretConfigExtensionRepresenterTest {
+  @Test
+  void 'should serialize secret config extension info to JSON'() {
+
+    def actualJson = toObjectString({
+      new SecretsExtensionRepresenter().toJSON(it, PluginInfoMother.createSecretConfigPluginInfo())
+    })
+
+    assertThatJson(actualJson).isEqualTo([
+      "secret_config_settings": [
+        "configurations": [
+          [
+            "key": "key1",
+            "metadata": [
+              "required": true,
+              "secure": false
+            ]
+          ],
+          [
+            "key": "key2",
+            "metadata": [
+              "required": true,
+              "secure": false
+            ]
+          ]
+        ],
+        "view": [
+          "template": "Template"
+        ]
+      ],
+      "type": "secrets"
+    ])
+  }
+}

--- a/server/src/main/java/com/thoughtworks/go/server/service/plugins/builder/DefaultPluginInfoFinder.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/plugins/builder/DefaultPluginInfoFinder.java
@@ -26,6 +26,7 @@ import com.thoughtworks.go.plugin.access.notification.NotificationMetadataStore;
 import com.thoughtworks.go.plugin.access.packagematerial.PackageMaterialMetadataStore;
 import com.thoughtworks.go.plugin.access.pluggabletask.PluggableTaskMetadataStore;
 import com.thoughtworks.go.plugin.access.scm.NewSCMMetadataStore;
+import com.thoughtworks.go.plugin.access.secrets.SecretsMetadataStore;
 import com.thoughtworks.go.plugin.domain.artifact.ArtifactPluginInfo;
 import com.thoughtworks.go.plugin.domain.common.CombinedPluginInfo;
 import com.thoughtworks.go.plugin.domain.common.PluginInfo;
@@ -59,6 +60,7 @@ public class DefaultPluginInfoFinder {
         builders.put(ANALYTICS_EXTENSION, AnalyticsMetadataStore.instance());
         builders.put(CONFIG_REPO_EXTENSION, ConfigRepoMetadataStore.instance());
         builders.put(ARTIFACT_EXTENSION, ArtifactMetadataStore.instance());
+        builders.put(SECRETS_EXTENSION, SecretsMetadataStore.instance());
     }
 
     public CombinedPluginInfo pluginInfoFor(String pluginId) {


### PR DESCRIPTION
Implements #6079
Changes:
 - Added support for secrets extension in `DefaultPluginInfoFinder`
 - Added representer for Secrets Plugin Info, registered it as extension representer