### PR TITLE
Fix agent status report page link on job details page

### DIFF
--- a/server/webapp/WEB-INF/vm/build_detail/_build_detail_summary_jstemplate.vm
+++ b/server/webapp/WEB-INF/vm/build_detail/_build_detail_summary_jstemplate.vm
@@ -30,10 +30,10 @@
   {/if}
   #if ( $elasticAgentPluginId && $userHasAdministratorRights )
     {if build.build_assigned_date != -1}
-    <a href="$req.getContextPath()/admin/status_reports/$elasticAgentPluginId/${elasticAgentId}?job_id=${build.id}"
+    <a href="$req.getContextPath()/admin/status_reports/$elasticAgentPluginId/agent/${elasticAgentId}?job_id=${build.id}"
        class="btn-primary btn-small status-report-btn-small">Check Agent Status</a>
     {else}
-    <a href="$req.getContextPath()/admin/status_reports/$elasticAgentPluginId/unassigned?job_id=${build.id}"
+    <a href="$req.getContextPath()/admin/status_reports/$elasticAgentPluginId/agent/unassigned?job_id=${build.id}"
        class="btn-primary btn-small status-report-btn-small">Check Agent Status</a>
     {/if}
   #end


### PR DESCRIPTION
* Change Agent Status Report page link
  From: '/go/admin/status_reports/PLUGIN_ID/AGENT_ID?job_id=8'
  To  : '/go/admin/status_reports/PLUGIN_ID/agent/AGENT_ID?job_id=8'