### PR TITLE
Add config repo capabilities to plugin infos

### DIFF
--- a/api/api-plugin-infos-v5/src/main/java/com/thoughtworks/go/apiv5/plugininfos/representers/extensions/ConfigRepoExtensionRepresenter.java
+++ b/api/api-plugin-infos-v5/src/main/java/com/thoughtworks/go/apiv5/plugininfos/representers/extensions/ConfigRepoExtensionRepresenter.java
@@ -27,11 +27,10 @@ public class ConfigRepoExtensionRepresenter extends ExtensionRepresenter {
 
         ConfigRepoPluginInfo configRepoPluginInfo = (ConfigRepoPluginInfo) extension;
 
-        if (configRepoPluginInfo.getCapabilities() != null) {
-            extensionWriter.addChild("capabilities", capabilitiesWriter ->
-                    capabilitiesWriter.add("supports_pipeline_export", configRepoPluginInfo.getCapabilities().isSupportsPipelineExport())
-                            .add("supports_parse_content", configRepoPluginInfo.getCapabilities().isSupportsParseContent()));
-        }
+        extensionWriter.addChild("capabilities", capabilitiesWriter ->
+                capabilitiesWriter.add("supports_pipeline_export", configRepoPluginInfo.getCapabilities().isSupportsPipelineExport())
+                        .add("supports_parse_content", configRepoPluginInfo.getCapabilities().isSupportsParseContent()));
+
     }
 
 }

--- a/api/api-plugin-infos-v5/src/main/java/com/thoughtworks/go/apiv5/plugininfos/representers/extensions/ConfigRepoExtensionRepresenter.java
+++ b/api/api-plugin-infos-v5/src/main/java/com/thoughtworks/go/apiv5/plugininfos/representers/extensions/ConfigRepoExtensionRepresenter.java
@@ -16,5 +16,22 @@
 
 package com.thoughtworks.go.apiv5.plugininfos.representers.extensions;
 
+import com.thoughtworks.go.api.base.OutputWriter;
+import com.thoughtworks.go.plugin.domain.common.PluginInfo;
+import com.thoughtworks.go.plugin.domain.configrepo.ConfigRepoPluginInfo;
+
 public class ConfigRepoExtensionRepresenter extends ExtensionRepresenter {
+    @Override
+    public void toJSON(OutputWriter extensionWriter, PluginInfo extension) {
+        super.toJSON(extensionWriter, extension);
+
+        ConfigRepoPluginInfo configRepoPluginInfo = (ConfigRepoPluginInfo) extension;
+
+        if (configRepoPluginInfo.getCapabilities() != null) {
+            extensionWriter.addChild("capabilities", capabilitiesWriter ->
+                    capabilitiesWriter.add("supports_pipeline_export", configRepoPluginInfo.getCapabilities().isSupportsPipelineExport())
+                            .add("supports_parse_content", configRepoPluginInfo.getCapabilities().isSupportsParseContent()));
+        }
+    }
+
 }

--- a/api/api-plugin-infos-v5/src/test/groovy/com/thoughtworks/go/apiv5/plugininfos/representers/Helper/PluginInfoMother.java
+++ b/api/api-plugin-infos-v5/src/test/groovy/com/thoughtworks/go/apiv5/plugininfos/representers/Helper/PluginInfoMother.java
@@ -65,7 +65,7 @@ public class PluginInfoMother {
     }
 
     public static ConfigRepoPluginInfo createConfigRepoPluginInfo() {
-        return new ConfigRepoPluginInfo(getGoPluginDescriptor(), null, getPluggableSettings());
+        return new ConfigRepoPluginInfo(getGoPluginDescriptor(), null, getPluggableSettings(), new com.thoughtworks.go.plugin.domain.configrepo.Capabilities(true, true));
     }
 
     public static ConfigRepoPluginInfo createConfigRepoPluginInfoWithoutPluginSettings() {

--- a/api/api-plugin-infos-v5/src/test/groovy/com/thoughtworks/go/apiv5/plugininfos/representers/Helper/PluginInfoMother.java
+++ b/api/api-plugin-infos-v5/src/test/groovy/com/thoughtworks/go/apiv5/plugininfos/representers/Helper/PluginInfoMother.java
@@ -69,7 +69,7 @@ public class PluginInfoMother {
     }
 
     public static ConfigRepoPluginInfo createConfigRepoPluginInfoWithoutPluginSettings() {
-        return new ConfigRepoPluginInfo(getGoPluginDescriptor(), null, null);
+        return new ConfigRepoPluginInfo(getGoPluginDescriptor(), null, null, new com.thoughtworks.go.plugin.domain.configrepo.Capabilities(true, true));
     }
 
     public static ElasticAgentPluginInfo createElasticAgentPluginInfoForV4() {

--- a/api/api-plugin-infos-v5/src/test/groovy/com/thoughtworks/go/apiv5/plugininfos/representers/extensions/ConfigRepoExtensionRepresenterTest.groovy
+++ b/api/api-plugin-infos-v5/src/test/groovy/com/thoughtworks/go/apiv5/plugininfos/representers/extensions/ConfigRepoExtensionRepresenterTest.groovy
@@ -42,6 +42,10 @@ class ConfigRepoExtensionRepresenterTest {
           ]
         ],
         view          : [template: "Template"]
+      ],
+      capabilities   : [
+        supports_pipeline_export: true,
+        supports_parse_content: true
       ]
     ]
     assertThatJson(actualJson).isEqualTo(expectedJSON)

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/configrepo/ConfigRepoPluginInfoBuilder.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/configrepo/ConfigRepoPluginInfoBuilder.java
@@ -18,6 +18,7 @@ package com.thoughtworks.go.plugin.access.configrepo;
 
 import com.thoughtworks.go.plugin.access.common.PluginInfoBuilder;
 import com.thoughtworks.go.plugin.domain.common.PluggableInstanceSettings;
+import com.thoughtworks.go.plugin.domain.configrepo.Capabilities;
 import com.thoughtworks.go.plugin.domain.configrepo.ConfigRepoPluginInfo;
 import com.thoughtworks.go.plugin.infra.plugininfo.GoPluginDescriptor;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -35,7 +36,11 @@ public class ConfigRepoPluginInfoBuilder implements PluginInfoBuilder<ConfigRepo
     public ConfigRepoPluginInfo pluginInfoFor(GoPluginDescriptor descriptor) {
         PluggableInstanceSettings pluggableInstanceSettings = getPluginSettingsAndView(descriptor, extension);
 
-        return new ConfigRepoPluginInfo(descriptor, image(descriptor.id()), pluggableInstanceSettings);
+        return new ConfigRepoPluginInfo(descriptor, image(descriptor.id()), pluggableInstanceSettings, capabilities(descriptor.id()));
+    }
+
+    private Capabilities capabilities(String pluginId) {
+        return extension.getCapabilities(pluginId);
     }
 
     private com.thoughtworks.go.plugin.domain.common.Image image(String pluginId) {

--- a/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/configrepo/ConfigRepoPluginInfoBuilderTest.java
+++ b/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/configrepo/ConfigRepoPluginInfoBuilderTest.java
@@ -23,6 +23,7 @@ import com.thoughtworks.go.plugin.domain.common.Metadata;
 import com.thoughtworks.go.plugin.domain.common.PluggableInstanceSettings;
 import com.thoughtworks.go.plugin.domain.common.PluginConfiguration;
 import com.thoughtworks.go.plugin.domain.common.PluginView;
+import com.thoughtworks.go.plugin.domain.configrepo.Capabilities;
 import com.thoughtworks.go.plugin.domain.configrepo.ConfigRepoPluginInfo;
 import com.thoughtworks.go.plugin.infra.plugininfo.GoPluginDescriptor;
 import org.junit.Before;
@@ -53,6 +54,7 @@ public class ConfigRepoPluginInfoBuilderTest {
     public void shouldBuildPluginInfo() throws Exception {
         GoPluginDescriptor descriptor = new GoPluginDescriptor("plugin1", null, null, null, null, false);
         when(extension.getPluginSettingsView("plugin1")).thenReturn("some-html");
+        when(extension.getCapabilities("plugin1")).thenReturn(new Capabilities(true, true));
         ConfigRepoPluginInfo pluginInfo = new ConfigRepoPluginInfoBuilder(extension).pluginInfoFor(descriptor);
 
         List<PluginConfiguration> pluginConfigurations = Arrays.asList(
@@ -64,6 +66,7 @@ public class ConfigRepoPluginInfoBuilderTest {
         assertThat(pluginInfo.getDescriptor(), is(descriptor));
         assertThat(pluginInfo.getExtensionName(), is("configrepo"));
         assertThat(pluginInfo.getPluginSettings(), is(new PluggableInstanceSettings(pluginConfigurations, pluginView)));
+        assertThat(pluginInfo.getCapabilities(), is(new Capabilities(true, true)));
     }
 
     @Test
@@ -76,6 +79,5 @@ public class ConfigRepoPluginInfoBuilderTest {
         assertThat(pluginInfo.getDescriptor(), is(descriptor));
         assertThat(pluginInfo.getExtensionName(), is("configrepo"));
         assertNull(pluginInfo.getPluginSettings());
-
     }
 }

--- a/plugin-infra/go-plugin-domain/src/main/java/com/thoughtworks/go/plugin/domain/configrepo/ConfigRepoPluginInfo.java
+++ b/plugin-infra/go-plugin-domain/src/main/java/com/thoughtworks/go/plugin/domain/configrepo/ConfigRepoPluginInfo.java
@@ -24,8 +24,15 @@ import com.thoughtworks.go.plugin.domain.common.PluginInfo;
 
 public class ConfigRepoPluginInfo extends PluginInfo {
 
-    public ConfigRepoPluginInfo(PluginDescriptor descriptor, Image image, PluggableInstanceSettings pluginSettings) {
+    private final Capabilities capabilities;
+
+    public ConfigRepoPluginInfo(PluginDescriptor descriptor, Image image, PluggableInstanceSettings pluginSettings, Capabilities capabilities) {
         super(descriptor, PluginConstants.CONFIG_REPO_EXTENSION, pluginSettings, image);
+        this.capabilities = capabilities;
+    }
+
+    public Capabilities getCapabilities() {
+        return capabilities;
     }
 
 }

--- a/server/src/main/java/com/thoughtworks/go/config/GoConfigPluginService.java
+++ b/server/src/main/java/com/thoughtworks/go/config/GoConfigPluginService.java
@@ -19,6 +19,7 @@ import com.thoughtworks.go.config.parts.XmlPartialConfigProvider;
 import com.thoughtworks.go.config.registry.ConfigElementImplementationRegistry;
 import com.thoughtworks.go.config.remote.ConfigRepoConfig;
 import com.thoughtworks.go.plugin.access.configrepo.ConfigRepoExtension;
+import com.thoughtworks.go.plugin.access.configrepo.ConfigRepoMetadataStore;
 import com.thoughtworks.go.security.GoCipher;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -60,6 +61,6 @@ public class GoConfigPluginService {
     }
 
     public boolean supportsPipelineExport(String pluginId) {
-        return crExtension.getCapabilities(pluginId).isSupportsPipelineExport();
+        return ConfigRepoMetadataStore.instance().getPluginInfo(pluginId).getCapabilities().isSupportsPipelineExport();
     }
 }

--- a/server/src/test-fast/java/com/thoughtworks/go/server/domain/PluginSettingsTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/domain/PluginSettingsTest.java
@@ -27,6 +27,7 @@ import com.thoughtworks.go.plugin.domain.common.Metadata;
 import com.thoughtworks.go.plugin.domain.common.PluggableInstanceSettings;
 import com.thoughtworks.go.plugin.domain.common.PluginConfiguration;
 import com.thoughtworks.go.plugin.domain.common.PluginInfo;
+import com.thoughtworks.go.plugin.domain.configrepo.Capabilities;
 import com.thoughtworks.go.plugin.domain.configrepo.ConfigRepoPluginInfo;
 import com.thoughtworks.go.plugin.domain.elastic.ElasticAgentPluginInfo;
 import com.thoughtworks.go.security.CryptoException;
@@ -102,7 +103,7 @@ public class PluginSettingsTest {
         ArrayList<PluginConfiguration> pluginConfigurations = new ArrayList<>();
         pluginConfigurations.add(new PluginConfiguration("k1", new Metadata(true, false)));
         pluginConfigurations.add(new PluginConfiguration("k2", new Metadata(true, true)));
-        ConfigRepoPluginInfo pluginInfo = new ConfigRepoPluginInfo(null, null, new PluggableInstanceSettings(pluginConfigurations));
+        ConfigRepoPluginInfo pluginInfo = new ConfigRepoPluginInfo(null, null, new PluggableInstanceSettings(pluginConfigurations), new Capabilities());
 
         ArrayList<ConfigurationProperty> configurationProperties = new ArrayList<>();
         configurationProperties.add(new ConfigurationProperty(new ConfigurationKey("k1"), new ConfigurationValue("v1")));
@@ -122,7 +123,7 @@ public class PluginSettingsTest {
         ArrayList<PluginConfiguration> pluginConfigurations = new ArrayList<>();
         pluginConfigurations.add(new PluginConfiguration("k1", new Metadata(true, false)));
         pluginConfigurations.add(new PluginConfiguration("k2", new Metadata(true, true)));
-        ConfigRepoPluginInfo pluginInfo = new ConfigRepoPluginInfo(null, null, new PluggableInstanceSettings(pluginConfigurations));
+        ConfigRepoPluginInfo pluginInfo = new ConfigRepoPluginInfo(null, null, new PluggableInstanceSettings(pluginConfigurations), new Capabilities());
 
         ConfigurationProperty configProperty1 = new ConfigurationProperty(new ConfigurationKey("k1"), new ConfigurationValue("v1"));
         ConfigurationProperty configProperty2 = new ConfigurationProperty(new ConfigurationKey("k2"), new EncryptedConfigurationValue(new GoCipher().encrypt("v2")));

--- a/server/webapp/WEB-INF/rails/app/assets/javascripts/pipeline_export.js
+++ b/server/webapp/WEB-INF/rails/app/assets/javascripts/pipeline_export.js
@@ -49,16 +49,22 @@
         type: "GET",
         responseType: "json",
         headers: {
-          Accept: "application/vnd.go.cd.v4+json"
+          Accept: "application/vnd.go.cd.v5+json"
         }
       }).then(function (res) {
-        plugins = _.filter(res.data._embedded.plugin_info, function(el) {
-          return "active" === el.status.state;
-        });
+        plugins = PipelineExport.filterPlugins(res.data._embedded.plugin_info);
       }).catch(function (res) {
         Flash.error(res.error.message);
       });
     };
+
+    this.filterPlugins = function filterPlugins(pluginInfos) {
+      return _.filter(pluginInfos, function(el) {
+        if ("active" === el.status.state) {
+          return (_.filter(el.extensions, function(ext) { return ext.type === "configrepo" && ext.capabilities.supports_pipeline_export } )).length
+        }
+      });
+    }
   }
 
   function createPluginListOption(p) {

--- a/server/webapp/WEB-INF/rails/spec/controllers/api_v1/admin/plugin_settings_controller_spec.rb
+++ b/server/webapp/WEB-INF/rails/spec/controllers/api_v1/admin/plugin_settings_controller_spec.rb
@@ -21,7 +21,7 @@ describe ApiV1::Admin::PluginSettingsController do
   include ApiV1::ApiVersionHelper
 
   before :each do
-    @plugin_info = com.thoughtworks.go.plugin.domain.configrepo.ConfigRepoPluginInfo.new(nil, nil, com.thoughtworks.go.plugin.domain.common.PluggableInstanceSettings.new([com.thoughtworks.go.plugin.domain.common.PluginConfiguration.new('username', nil)]))
+    @plugin_info = com.thoughtworks.go.plugin.domain.configrepo.ConfigRepoPluginInfo.new(nil, nil, com.thoughtworks.go.plugin.domain.common.PluggableInstanceSettings.new([com.thoughtworks.go.plugin.domain.common.PluginConfiguration.new('username', nil)]), nil)
     @plugin_settings = PluginSettings.new("plugin.id.1")
     @plugin_settings.addConfigurations(@plugin_info, [ConfigurationProperty.new(ConfigurationKey.new('username'), ConfigurationValue.new('admin'))])
     @plugin_service = double('plugin_service')
@@ -171,7 +171,7 @@ describe ApiV1::Admin::PluginSettingsController do
           [
             com.thoughtworks.go.plugin.domain.common.PluginConfiguration.new('url', nil),
             com.thoughtworks.go.plugin.domain.common.PluginConfiguration.new('password', nil)
-          ])))
+          ]), nil))
       end
 
       it 'should deserialize plugin settings from given object' do
@@ -278,7 +278,7 @@ describe ApiV1::Admin::PluginSettingsController do
 
         expect(@plugin_service).to receive(:pluginInfoForExtensionThatHandlesPluginSettings).with('plugin.id.1').exactly(2).times.and_return(
           com.thoughtworks.go.plugin.domain.configrepo.ConfigRepoPluginInfo.new(nil, nil, com.thoughtworks.go.plugin.domain.common.PluggableInstanceSettings.new(
-            [com.thoughtworks.go.plugin.domain.common.PluginConfiguration.new('url', nil), com.thoughtworks.go.plugin.domain.common.PluginConfiguration.new('password', nil)])))
+            [com.thoughtworks.go.plugin.domain.common.PluginConfiguration.new('url', nil), com.thoughtworks.go.plugin.domain.common.PluginConfiguration.new('password', nil)]), nil))
         allow(controller).to receive(:check_for_stale_request)
         hash = {plugin_id: 'plugin.id.1', configuration: [{"key" => 'url', "value" => 'git@github.com:foo/bagdgr.git'}, {"key" => 'password', "value" => "some-value"}]}
 
@@ -315,7 +315,7 @@ describe ApiV1::Admin::PluginSettingsController do
         allow(controller).to receive(:plugin_service).and_return(@plugin_service)
         expect(@plugin_service).to receive(:pluginInfoForExtensionThatHandlesPluginSettings).with('plugin.id.1').exactly(2).times.and_return(
           com.thoughtworks.go.plugin.domain.configrepo.ConfigRepoPluginInfo.new(nil, nil, com.thoughtworks.go.plugin.domain.common.PluggableInstanceSettings.new(
-            [com.thoughtworks.go.plugin.domain.common.PluginConfiguration.new('url', nil), com.thoughtworks.go.plugin.domain.common.PluginConfiguration.new('password', nil)])))
+            [com.thoughtworks.go.plugin.domain.common.PluginConfiguration.new('url', nil), com.thoughtworks.go.plugin.domain.common.PluginConfiguration.new('password', nil)]), nil))
         controller.request.env['HTTP_IF_MATCH'] = controller.send(:generate_strong_etag, 'md5')
         hash = {plugin_id: 'plugin.id.1', configuration: [{key: 'url', value: 'git@github.com:foo/bar.git'}, {key: 'password', value: "some-value"}]}
 

--- a/server/webapp/WEB-INF/rails/spec/controllers/api_v4/admin/plugin_infos_controller_spec.rb
+++ b/server/webapp/WEB-INF/rails/spec/controllers/api_v4/admin/plugin_infos_controller_spec.rb
@@ -163,7 +163,7 @@ describe ApiV4::Admin::PluginInfosController do
 
       allPluginInfos = [CombinedPluginInfo.new(AnalyticsPluginInfo.new(descriptor, nil, nil, nil)),
                         CombinedPluginInfo.new(AuthorizationPluginInfo.new(descriptor, nil, nil, nil, nil)),
-                        CombinedPluginInfo.new(ConfigRepoPluginInfo.new(descriptor, nil, @plugin_settings)),
+                        CombinedPluginInfo.new(ConfigRepoPluginInfo.new(descriptor, nil, @plugin_settings, nil)),
                         CombinedPluginInfo.new(ElasticAgentPluginInfo.new(descriptor, nil, nil, nil, nil, nil)),
                         CombinedPluginInfo.new(NotificationPluginInfo.new(descriptor, @plugin_settings)),
                         CombinedPluginInfo.new(PackageMaterialPluginInfo.new(descriptor, nil, nil, nil)),

--- a/server/webapp/WEB-INF/rails/spec/javascripts/pipeline_export_spec.js
+++ b/server/webapp/WEB-INF/rails/spec/javascripts/pipeline_export_spec.js
@@ -14,10 +14,13 @@
  * limitations under the License.
  */
 
-
 describe("PipelineExport", function () {
   var c = crel, panel, link;
   var TEST_URL = "http://export.me";
+  var testPluginInfos = [createPluginInfo("pos.test.id", "active", true),
+  createPluginInfo("invalid.id", "invalid", true),
+  createPluginInfo("not.support.id", "active", false),
+  createPluginInfo("neither.id", "invalid", false)]
 
   beforeEach(function setup() {
     panel = c("div"), link = c("a", {href: TEST_URL}, "click me");
@@ -39,6 +42,14 @@ describe("PipelineExport", function () {
     expect(choices[1].textContent).toBe("plugin 2");
     expect(choices[1].getAttribute("data-plugin-id")).toBe("plug.2");
   });
+
+  it("filterPlugins() returns only active plugins that support pipeline export", function() {
+    var plugins = PipelineExport.filterPlugins(testPluginInfos)
+
+    expect(plugins.length).toBe(1);
+    expect(plugins[0].id).toBe("pos.test.id");
+  });
+
 
   it("clicking on a plugin link causes a download", function(done) {
     if ("function" !== typeof Promise) {
@@ -71,4 +82,12 @@ describe("PipelineExport", function () {
       choice.click();
     });
   });
+
+  function createPluginInfo(pluginId, stat, supportsExport) {
+    return {
+      id: pluginId,
+      status: { state: stat },
+      extensions: [{ type: "configrepo", capabilities: { supports_pipeline_export: supportsExport }}]
+    }
+  }
 });

--- a/server/webapp/WEB-INF/rails/spec/presenters/api_v1/config/plugin_settings_representer_spec.rb
+++ b/server/webapp/WEB-INF/rails/spec/presenters/api_v1/config/plugin_settings_representer_spec.rb
@@ -19,7 +19,7 @@ require 'rails_helper'
 describe ApiV1::Config::PluginSettingsRepresenter do
   describe 'serialize' do
     it 'renders plugin settings with hal representation' do
-      plugin_info = com.thoughtworks.go.plugin.domain.configrepo.ConfigRepoPluginInfo.new(nil, nil, com.thoughtworks.go.plugin.domain.common.PluggableInstanceSettings.new([com.thoughtworks.go.plugin.domain.common.PluginConfiguration.new('username', nil)]))
+      plugin_info = com.thoughtworks.go.plugin.domain.configrepo.ConfigRepoPluginInfo.new(nil, nil, com.thoughtworks.go.plugin.domain.common.PluggableInstanceSettings.new([com.thoughtworks.go.plugin.domain.common.PluginConfiguration.new('username', nil)]), nil)
       presenter = ApiV1::Config::PluginSettingsRepresenter.new({plugin_settings: plugin_settings(plugin_info), plugin_info: plugin_info})
       actual_json = presenter.to_hash(url_builder: UrlBuilder.new)
       expect(actual_json).to have_link(:self).with_url(UrlBuilder.new.apiv1_admin_plugin_setting_url(plugin_id: 'foo.bar'))
@@ -34,7 +34,7 @@ describe ApiV1::Config::PluginSettingsRepresenter do
   describe 'deserialize' do
     it 'create plugin settings out of given json' do
       plugin_settings = PluginSettings.new
-      plugin_info = com.thoughtworks.go.plugin.domain.configrepo.ConfigRepoPluginInfo.new(nil, nil, com.thoughtworks.go.plugin.domain.common.PluggableInstanceSettings.new([com.thoughtworks.go.plugin.domain.common.PluginConfiguration.new('username', nil)]))
+      plugin_info = com.thoughtworks.go.plugin.domain.configrepo.ConfigRepoPluginInfo.new(nil, nil, com.thoughtworks.go.plugin.domain.common.PluggableInstanceSettings.new([com.thoughtworks.go.plugin.domain.common.PluginConfiguration.new('username', nil)]), nil)
       ApiV1::Config::PluginSettingsRepresenter.new({plugin_settings: plugin_settings, plugin_info: plugin_info}).from_hash(plugin_settings_json)
       expected_plugin_settings = plugin_settings
       expect(expected_plugin_settings.getPluginId).to eq(plugin_settings.getPluginId)

--- a/server/webapp/WEB-INF/rails/spec/presenters/api_v4/plugin/plugin_info_representer_spec.rb
+++ b/server/webapp/WEB-INF/rails/spec/presenters/api_v4/plugin/plugin_info_representer_spec.rb
@@ -58,7 +58,7 @@ describe ApiV4::Plugin::PluginInfoRepresenter do
       plugin_metadata = com.thoughtworks.go.plugin.domain.common.Metadata.new(true, false)
       plugin_settings = com.thoughtworks.go.plugin.domain.common.PluggableInstanceSettings.new([com.thoughtworks.go.plugin.domain.common.PluginConfiguration.new('memberOf', plugin_metadata)], plugin_view)
 
-      plugin_info = CombinedPluginInfo.new(ConfigRepoPluginInfo.new(descriptor, nil, plugin_settings))
+      plugin_info = CombinedPluginInfo.new(ConfigRepoPluginInfo.new(descriptor, nil, plugin_settings, nil))
       actual_json = ApiV4::Plugin::PluginInfoRepresenter.new(plugin_info).to_hash(url_builder: UrlBuilder.new)
 
       expect(actual_json).to have_links(:self, :doc, :find)
@@ -395,7 +395,7 @@ describe ApiV4::Plugin::PluginInfoRepresenter do
       notification_plugin_settings = com.thoughtworks.go.plugin.domain.common.PluggableInstanceSettings.new([com.thoughtworks.go.plugin.domain.common.PluginConfiguration.new('memberOf', notification_plugin_metadata)], notification_plugin_view)
       notification_plugin_info = NotificationPluginInfo.new(descriptor, notification_plugin_settings)
 
-      config_repo_plugin_info = ConfigRepoPluginInfo.new(descriptor, nil, nil)
+      config_repo_plugin_info = ConfigRepoPluginInfo.new(descriptor, nil, nil, nil)
 
       plugin_info_with_multiple_extensions = CombinedPluginInfo.new([notification_plugin_info, task_plugin_info, config_repo_plugin_info])
       actual_json = ApiV4::Plugin::PluginInfoRepresenter.new(plugin_info_with_multiple_extensions).to_hash(url_builder: UrlBuilder.new)


### PR DESCRIPTION
In order to fix #5730 we need to be able to filter the list of plugins displayed to only include those that support pipeline export. 

This adds capabilities to the config repo extension of the plugin infos so that it can be accessed. 
It caches the capabilities in the metastore. 
It filters the list to include plugins that support pipeline export.

