### PR TITLE
Fixing ServerAPI spec failure

### DIFF
--- a/server/webapp/WEB-INF/rails/spec/webpack/views/dashboard/trigger_with_options/material_search_results_widget_spec.js
+++ b/server/webapp/WEB-INF/rails/spec/webpack/views/dashboard/trigger_with_options/material_search_results_widget_spec.js
@@ -72,7 +72,7 @@ describe("Dashboard Material Search Results Widget", () => {
     expect(helper.find('.commits')).not.toBeInDOM();
   });
 
-  it("should select searched revision onclick", () => {
+  it("should select searched revision onclick", (done) => {
     material.searchText('implemented');
     material.searchResults(json);
 
@@ -82,6 +82,9 @@ describe("Dashboard Material Search Results Widget", () => {
 
     expect(material.selection()).toEqual(json[1].revision);
     expect(material.searchText()).toEqual(json[1].revision);
+
+    //timeout is required to wait for the debounced search
+    setTimeout(done, 250);
   });
 
   const json = [

--- a/server/webapp/WEB-INF/rails/spec/webpack/views/dashboard/trigger_with_options/material_search_results_widget_spec.js
+++ b/server/webapp/WEB-INF/rails/spec/webpack/views/dashboard/trigger_with_options/material_search_results_widget_spec.js
@@ -115,6 +115,7 @@ describe("Dashboard Material Search Results Widget", () => {
   ];
 
   function mount() {
+    jasmine.Ajax.install();
     helper.mount(() => m(MaterialSearchResultsWidget, {
       material
     }));
@@ -122,5 +123,6 @@ describe("Dashboard Material Search Results Widget", () => {
 
   function unmount() {
     helper.unmount();
+    jasmine.Ajax.uninstall();
   }
 });


### PR DESCRIPTION
The spec failure was due to `debounce` search utilized in `material_search_widget`. Added a wait to the spec calling the same.