### PR TITLE
Validate secret lookup response for unwanted secrets.

### DIFF
--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/exceptions/SecretResolutionFailureException.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/exceptions/SecretResolutionFailureException.java
@@ -16,8 +16,25 @@
 
 package com.thoughtworks.go.plugin.access.exceptions;
 
+import java.util.Set;
+
+import static java.lang.String.format;
+
 public class SecretResolutionFailureException extends RuntimeException {
     public SecretResolutionFailureException(String message) {
         super(message);
+    }
+
+    public static SecretResolutionFailureException withMissingSecretParams(Set<String> secretsToResolve, Set<String> missingSecrets) {
+        return new SecretResolutionFailureException(format("Expected plugin to resolve secret(s) `%s` but plugin failed resolve secret param(s) `%s`. Please make sure that secret with same name exist in your secret management tool.", csv(secretsToResolve), csv(missingSecrets)));
+    }
+
+
+    public static SecretResolutionFailureException withUnwantedSecretParams(Set<String> secretsToResolve, Set<String> unwantedSecrets) {
+        return new SecretResolutionFailureException(format("Expected plugin to resolve secret(s) `%s` but plugin sent addition secret param(s) `%s`.", csv(secretsToResolve), csv(unwantedSecrets)));
+    }
+
+    private static String csv(Set<String> secretsToResolve) {
+        return String.join(", ", secretsToResolve);
     }
 }

--- a/server/src/main/java/com/thoughtworks/go/server/service/SecretParamResolver.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/SecretParamResolver.java
@@ -64,7 +64,6 @@ public class SecretParamResolver {
             List<Secret> resolvedSecrets = secretsExtension.lookupSecrets(secretConfig.getPluginId(), secretConfig, secretParamMap.keySet());
             LOGGER.debug("Resolved secret size '{}'", resolvedSecrets.size());
 
-
             LOGGER.debug("Updating secret params '{}' with values.", secretParamMap.keySet());
             resolvedSecrets.forEach(assignValue(secretParamMap));
             LOGGER.debug("Secret params '{}' updated with values.", secretParamMap.keySet());


### PR DESCRIPTION
- Error out with `SecretResolutionFailureException` if plugin sends
  additional secret params in lookup secret response.
  
  > Lookup request
   ```
   requestBody = ["key1", "key2"]

   ```
  > Response with addtional secret params
  ```
   responseBody = [
	{key: "key1", value="value-1"},
	{key: "key2", value="value-2"},
	{key: "key3", value="value-3"}
   ]
   ```
   This will throw `SecretResolutionFailureException` with the message -

   ```
    Expected plugin to resolve secret(s) `key1, key2` but plugin sent addition 
    secret param(s) `key3`.
   ```

- Error out with `SecretResolutionFailureException` if plugin fails to
  resolve one or more secret params as part of lookup secret response
  and sends partially resolved secret params in response.

   > Lookup request 
   ```
     requestBody = ["key1", "key2", "key3"]
   ```
   >  Response with partially resolved secret params
   ```
  responseBody = [
	{key: "key1", value="value-1"}
   ]
   ```
   This will throw `SecretResolutionFailureException` with message -
   ```
   Expected plugin to resolve secret(s) `key1, key2, key3` but plugin failed resolve secret 
   param(s) `key2, key3`. Please make sure that secret with same name exist in 
   your secret management tool.
   ```