### PR TITLE
Windows batch file cleanup

### DIFF
--- a/installers/go-agent/release/agent.cmd
+++ b/installers/go-agent/release/agent.cmd
@@ -1,6 +1,6 @@
 @echo off
 REM #########################################################################
-REM Copyright 2015 ThoughtWorks, Inc.
+REM Copyright 2019 ThoughtWorks, Inc.
 REM
 REM Licensed under the Apache License, Version 2.0 (the "License");
 REM you may not use this file except in compliance with the License.
@@ -21,38 +21,12 @@ if not defined STOP_BEFORE_STARTUP set STOP_BEFORE_STARTUP=Y
 if not defined AGENT_DIR set AGENT_DIR=%cd%
 if not defined AGENT_MEM set AGENT_MEM=128m
 if not defined AGENT_MAX_MEM set AGENT_MAX_MEM=256m
-set GOCD_LEGACY_MODE=
-if defined GO_SERVER set GOCD_LEGACY_MODE=true
-if defined GO_SERVER_PORT set GOCD_LEGACY_MODE=true
 
-if defined GOCD_LEGACY_MODE (
-  echo "The environment variable GO_SERVER and GO_SERVER_PORT has been deprecated in favor of GO_SERVER_URL. Please set GO_SERVER_URL instead to a https url (https://example.com:8154/go)"
-  set GO_LEGACY_MODE=
-)
-
-if not defined GO_SERVER_URL (
-  if defined GO_SERVER (
-    set GO_SERVER_URL=https://%GO_SERVER%:8154/go
-  ) else (
-    set GO_SERVER_URL=https://127.0.0.1:8154/go
-  )
-)
+if not defined GO_SERVER_URL set GO_SERVER_URL=https://127.0.0.1:8154/go
 
 if not defined GO_AGENT_SYSTEM_PROPERTIES set GO_AGENT_SYSTEM_PROPERTIES=
 
-if defined JVM_DEBUG (
-  set JVM_DEBUG=-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=5006
-) else (
-  set JVM_DEBUG=
-)
-
-if defined GC_LOG (
-  set GC_LOG=-verbose:gc -Xloggc:go-agent-gc.log -XX:+PrintGCTimeStamps -XX:+PrintTenuringDistribution -XX:+PrintGCDetails -XX:+PrintGC
-) else (
-  set GC_LOG=
-)
-
-set AGENT_STARTUP_ARGS=-Xms%AGENT_MEM% -Xmx%AGENT_MAX_MEM% %JVM_DEBUG% %GC_LOG% %GO_AGENT_SYSTEM_PROPERTIES% -Dcruise.console.publish.interval=10
+set AGENT_STARTUP_ARGS=-Xms%AGENT_MEM% -Xmx%AGENT_MAX_MEM% %GO_AGENT_SYSTEM_PROPERTIES% -Dcruise.console.publish.interval=10
 
 set JAVA_CMD=%GO_AGENT_JAVA_HOME%\bin\java.exe
 set JAVA_HOME=%GO_AGENT_JAVA_HOME%

--- a/installers/go-agent/release/agent.sh
+++ b/installers/go-agent/release/agent.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 ##########################################################################
-# Copyright 2016 ThoughtWorks, Inc.
+# Copyright 2019 ThoughtWorks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -73,16 +73,8 @@ function stringToArgsArray() {
 function autoDetectGoServerUrl() {
   local url
 
-  if [[ ! -z "${GO_SERVER}" || ! -z "${GO_SERVER_PORT}" ]]; then
-    yell "The environment variable GO_SERVER and GO_SERVER_PORT has been deprecated in favor of GO_SERVER_URL. Please set GO_SERVER_URL instead to a https url (https://example.com:8154/go)"
-  fi
-
   if [ -z "${GO_SERVER_URL}" ]; then
-    if [ -z "${GO_SERVER}" ]; then
       url="https://127.0.0.1:8154/go"
-    else
-      url="https://${GO_SERVER}:8154/go"
-    fi
   else
     url="${GO_SERVER_URL}"
   fi

--- a/installers/go-server/release/server.cmd
+++ b/installers/go-server/release/server.cmd
@@ -25,44 +25,10 @@ if not defined JAVA_CMD set JAVA_CMD=%GO_SERVER_JAVA_HOME%\bin\java.exe
 if not defined GO_SERVER_SYSTEM_PROPERTIES set GO_SERVER_SYSTEM_PROPERTIES=
 set JAVA_HOME=%GO_SERVER_JAVA_HOME%
 
-if defined GC_LOG (
-  set GC_LOG=-verbose:gc -Xloggc:go-server-gc.log -XX:+PrintGCTimeStamps -XX:+PrintTenuringDistribution -XX:+PrintGCDetails -XX:+PrintGC
-) else (
-  set GC_LOG=
-)
-
-if defined JVM_DEBUG (
-  set JVM_DEBUG=-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=5005
-) else (
-  set JVM_DEBUG=
-)
-
-if not defined YOURKIT_PATH (
-  if exist C:\yjpagent.dll (
-    set YOURKIT_PATH=C:\yjpagent.dll
-  )
-)
-
 if not exist "%SERVER_DIR%\tmp" (
     mkdir "%SERVER_DIR%\tmp"
 )
 
-if defined YOURKIT_PATH (
-    set YOURKIT=-agentpath:%YOURKIT_PATH%=port=6133
-) else (
-    set YOURKIT=
-)
-
 if not exist "%JAVA_CMD%" set JAVA_CMD=java.exe
 
-javac.exe 2>NUL
-if ERRORLEVEL 3 goto :jre
-set OPTION=-server
-goto :done
-
-:jre
-set OPTION=-client
-
-:done
-
-"%JAVA_CMD%" %OPTION% %YOURKIT% -Xms%SERVER_MEM% -Xmx%SERVER_MAX_MEM% -XX:MaxMetaspaceSize=%SERVER_MAX_PERM_GEN% %JVM_DEBUG% %GC_LOG% %GO_SERVER_SYSTEM_PROPERTIES% -Duser.language=en -DJAVA_SYS_MON_TEMP_DIR="%SERVER_DIR%\tmp" -Dorg.eclipse.jetty.server.Request.maxFormContentSize=30000000 -Djruby.rack.request.size.threshold.bytes=30000000 -Duser.country=US -Dcruise.config.dir="%SERVER_DIR%\config" -Dcruise.config.file="%SERVER_DIR%\config\cruise-config.xml" -Dcruise.server.port=%GO_SERVER_PORT% -Dcruise.server.ssl.port=%GO_SERVER_SSL_PORT% -jar "%SERVER_DIR%\go.jar"
+"%JAVA_CMD%" -Xms%SERVER_MEM% -Xmx%SERVER_MAX_MEM% -XX:MaxMetaspaceSize=%SERVER_MAX_PERM_GEN% %GO_SERVER_SYSTEM_PROPERTIES% -Duser.language=en -DJAVA_SYS_MON_TEMP_DIR="%SERVER_DIR%\tmp" -Djruby.rack.request.size.threshold.bytes=30000000 -Duser.country=US -Dcruise.config.dir="%SERVER_DIR%\config" -Dcruise.config.file="%SERVER_DIR%\config\cruise-config.xml" -Dcruise.server.port=%GO_SERVER_PORT% -Dcruise.server.ssl.port=%GO_SERVER_SSL_PORT% -jar "%SERVER_DIR%\go.jar"


### PR DESCRIPTION
Cleaned up the windows agent and server bash startup file.
Removed the debug, log and yourkit (for agent) setup as it is not utilized.
Removed the fallback for GO_SERVER and GO_SERVER_PORT