### PR TITLE
Validate Cluster Profile Id reference on Elastic Profiles (#5538)

### DIFF
--- a/api/api-elastic-profile-v2/src/main/java/com/thoughtworks/go/apiv2/elasticprofile/representers/ElasticProfileRepresenter.java
+++ b/api/api-elastic-profile-v2/src/main/java/com/thoughtworks/go/apiv2/elasticprofile/representers/ElasticProfileRepresenter.java
@@ -50,7 +50,7 @@ public class ElasticProfileRepresenter {
         ElasticProfile elasticProfile = new ElasticProfile(
                 jsonReader.getString("id"),
                 jsonReader.getString("plugin_id"),
-                jsonReader.optString("cluster_profile_id").orElse(null));
+                jsonReader.getString("cluster_profile_id"));
         elasticProfile.addConfigurations(ConfigurationPropertyRepresenter.fromJSONArray(jsonReader, "properties"));
         return elasticProfile;
     }

--- a/api/api-elastic-profile-v2/src/test/groovy/com/thoughtworks/go/apiv2/elasticprofile/representers/ElasticProfilesRepresenterTest.groovy
+++ b/api/api-elastic-profile-v2/src/test/groovy/com/thoughtworks/go/apiv2/elasticprofile/representers/ElasticProfilesRepresenterTest.groovy
@@ -59,7 +59,7 @@ class ElasticProfilesRepresenterTest {
           ],
           id                : 'ecs',
           plugin_id         : 'cd.go.ecs',
-          cluster_profile_id: null,
+          cluster_profile_id: "bar",
           "properties"      : [
             [
               "key"            : "ACCESS_KEY",
@@ -75,7 +75,7 @@ class ElasticProfilesRepresenterTest {
   void 'should serialize elastic profiles to json'() {
     def elasticProfiles = new ElasticProfiles(
       new ElasticProfile("docker", "cd.go.docker", 'foo', create("docker-uri", false, "unix:///var/run/docker")),
-      new ElasticProfile("ecs", "cd.go.ecs", null, create("ACCESS_KEY", true, "encrypted-key"))
+      new ElasticProfile("ecs", "cd.go.ecs", "bar", create("ACCESS_KEY", true, "encrypted-key"))
     )
 
     def actualJson = toObjectString({ ElasticProfilesRepresenter.toJSON(it, elasticProfiles) })

--- a/common/src/main/java/com/thoughtworks/go/validation/RolesConfigUpdateValidator.java
+++ b/common/src/main/java/com/thoughtworks/go/validation/RolesConfigUpdateValidator.java
@@ -17,6 +17,7 @@
 package com.thoughtworks.go.validation;
 
 import com.thoughtworks.go.config.*;
+import com.thoughtworks.go.config.elastic.ClusterProfiles;
 import com.thoughtworks.go.config.materials.MaterialConfigs;
 import com.thoughtworks.go.config.remote.ConfigReposConfig;
 import com.thoughtworks.go.domain.packagerepository.PackageRepository;
@@ -141,6 +142,11 @@ public class RolesConfigUpdateValidator implements ConfigUpdateValidator {
             @Override
             public boolean isValidProfileId(String profileId) {
                 return false;
+            }
+
+            @Override
+            public ClusterProfiles getClusterProfiles() {
+                return null;
             }
 
             @Override

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/ConfigSaveValidationContext.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/ConfigSaveValidationContext.java
@@ -16,6 +16,7 @@
 
 package com.thoughtworks.go.config;
 
+import com.thoughtworks.go.config.elastic.ClusterProfiles;
 import com.thoughtworks.go.config.materials.MaterialConfigs;
 import com.thoughtworks.go.config.remote.ConfigReposConfig;
 import com.thoughtworks.go.domain.materials.MaterialConfig;
@@ -216,6 +217,11 @@ public class ConfigSaveValidationContext implements ValidationContext {
     @Override
     public boolean isValidProfileId(String profileId) {
         return this.getCruiseConfig().getElasticConfig().getProfiles().find(profileId) != null;
+    }
+
+    @Override
+    public ClusterProfiles getClusterProfiles() {
+        return this.getCruiseConfig().getElasticConfig().getClusterProfiles();
     }
 
     @Override

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/DelegatingValidationContext.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/DelegatingValidationContext.java
@@ -16,6 +16,7 @@
 
 package com.thoughtworks.go.config;
 
+import com.thoughtworks.go.config.elastic.ClusterProfiles;
 import com.thoughtworks.go.config.materials.MaterialConfigs;
 import com.thoughtworks.go.config.remote.ConfigReposConfig;
 import com.thoughtworks.go.domain.packagerepository.PackageRepository;
@@ -103,6 +104,11 @@ public abstract class DelegatingValidationContext implements ValidationContext {
 
     public boolean isValidProfileId(String profileId) {
         return validationContext.isValidProfileId(profileId);
+    }
+
+    @Override
+    public ClusterProfiles getClusterProfiles() {
+        return validationContext.getClusterProfiles();
     }
 
     @Override

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/PipelineConfigSaveValidationContext.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/PipelineConfigSaveValidationContext.java
@@ -16,6 +16,7 @@
 
 package com.thoughtworks.go.config;
 
+import com.thoughtworks.go.config.elastic.ClusterProfiles;
 import com.thoughtworks.go.config.exceptions.RecordNotFoundException;
 import com.thoughtworks.go.config.materials.MaterialConfigs;
 import com.thoughtworks.go.config.remote.ConfigReposConfig;
@@ -256,6 +257,11 @@ public class PipelineConfigSaveValidationContext implements ValidationContext {
     @Override
     public boolean isValidProfileId(String profileId) {
         return this.cruiseConfig.getElasticConfig().getProfiles().find(profileId) != null;
+    }
+
+    @Override
+    public ClusterProfiles getClusterProfiles() {
+        return this.cruiseConfig.getElasticConfig().getClusterProfiles();
     }
 
     @Override

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/ValidationContext.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/ValidationContext.java
@@ -16,6 +16,7 @@
 
 package com.thoughtworks.go.config;
 
+import com.thoughtworks.go.config.elastic.ClusterProfiles;
 import com.thoughtworks.go.config.materials.MaterialConfigs;
 import com.thoughtworks.go.config.remote.ConfigReposConfig;
 import com.thoughtworks.go.domain.packagerepository.PackageRepository;
@@ -60,6 +61,8 @@ public interface ValidationContext {
     ValidationContext withParent(Validatable validatable);
 
     boolean isValidProfileId(String profileId);
+
+    ClusterProfiles getClusterProfiles();
 
     boolean shouldNotCheckRole();
 

--- a/config/config-api/src/test/java/com/thoughtworks/go/config/ConfigSaveValidationContextTest.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/config/ConfigSaveValidationContextTest.java
@@ -16,9 +16,7 @@
 
 package com.thoughtworks.go.config;
 
-import com.thoughtworks.go.config.elastic.ElasticConfig;
-import com.thoughtworks.go.config.elastic.ElasticProfile;
-import com.thoughtworks.go.config.elastic.ElasticProfiles;
+import com.thoughtworks.go.config.elastic.*;
 import com.thoughtworks.go.config.materials.MaterialConfigs;
 import com.thoughtworks.go.config.materials.mercurial.HgMaterialConfig;
 import com.thoughtworks.go.domain.PipelineGroups;
@@ -147,6 +145,18 @@ public class ConfigSaveValidationContextTest {
         ValidationContext context = ConfigSaveValidationContext.forChain(cruiseConfig);
 
         assertTrue(context.isValidProfileId("docker.unit-test"));
+    }
+
+    @Test
+    public void shouldGetAllClusterProfiles() {
+        BasicCruiseConfig cruiseConfig = new BasicCruiseConfig();
+        ElasticConfig elasticConfig = new ElasticConfig();
+        ClusterProfiles clusterProfiles = new ClusterProfiles(new ClusterProfile("cluster1", "docker"));
+        elasticConfig.setClusterProfiles(clusterProfiles);
+        cruiseConfig.setElasticConfig(elasticConfig);
+        ValidationContext context = ConfigSaveValidationContext.forChain(cruiseConfig);
+
+        assertThat(context.getClusterProfiles(), is(clusterProfiles));
     }
 
     @Test

--- a/config/config-api/src/test/java/com/thoughtworks/go/config/helper/ValidationContextMother.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/config/helper/ValidationContextMother.java
@@ -17,6 +17,7 @@
 package com.thoughtworks.go.config.helper;
 
 import com.thoughtworks.go.config.*;
+import com.thoughtworks.go.config.elastic.ClusterProfiles;
 import com.thoughtworks.go.config.materials.MaterialConfigs;
 import com.thoughtworks.go.config.remote.ConfigReposConfig;
 import com.thoughtworks.go.domain.packagerepository.PackageRepository;
@@ -136,6 +137,11 @@ public class ValidationContextMother {
         @Override
         public boolean isValidProfileId(String profileId) {
             return false;
+        }
+
+        @Override
+        public ClusterProfiles getClusterProfiles() {
+            return null;
         }
 
         @Override

--- a/server/src/main/java/com/thoughtworks/go/config/update/PluginProfileCommand.java
+++ b/server/src/main/java/com/thoughtworks/go/config/update/PluginProfileCommand.java
@@ -68,7 +68,7 @@ public abstract class PluginProfileCommand<T extends PluginProfile, M extends Pl
 
     protected boolean isValidForCreateOrUpdate(CruiseConfig preprocessedConfig) {
         preprocessedProfile = findExistingProfile(preprocessedConfig);
-        preprocessedProfile.validateTree(null);
+        preprocessedProfile.validateTree(new ConfigSaveValidationContext(preprocessedConfig));
 
         if (preprocessedProfile.getAllErrors().isEmpty()) {
             getPluginProfiles(preprocessedConfig).validate(null);

--- a/server/src/test-integration/java/com/thoughtworks/go/config/GoConfigMigratorIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/config/GoConfigMigratorIntegrationTest.java
@@ -1270,29 +1270,6 @@ public class GoConfigMigratorIntegrationTest {
     }
 
     @Test
-    public void shouldAllowSpecifyingClusterProfileIdAttributeOnProfilesAsPartMigration118() throws Exception {
-        String configContent =  " <elastic>\n" +
-                "    <profiles>\n" +
-                "      <profile clusterProfileId=\"foo\" id=\"profile1\" pluginId=\"cd.go.contrib.elastic-agent.docker\">\n" +
-                "        <property>\n" +
-                "          <key>Image</key>\n" +
-                "          <value>asdf</value>\n" +
-                "        </property>\n" +
-                "      </profile>" +
-                "    </profiles>" +
-                "  </elastic>";
-
-        String configXml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
-                + "<cruise schemaVersion=\"118\">\n"
-                + configContent
-                + "</cruise>";
-
-        CruiseConfig config = loadConfigFileWithContent(configXml);
-        ElasticProfile elasticProfile = config.getElasticConfig().getProfiles().find("profile1");
-        assertThat(elasticProfile.getClusterProfileId()).isEqualTo("foo");
-    }
-
-    @Test
     public void shouldDefineNoOpClustersAsPartOfMigration119() throws Exception {
         String configContent =  " <elastic>\n" +
                 "    <profiles>\n" +


### PR DESCRIPTION
* Mandate specifying cluster_profile_id field as part of Elastic
  Agent Profiles API v2

* Validate existence of referenced cluster profile.

* Validate plugin id matches for elastic profile and referenced cluster
  profile.

* Move API validation to entity validations for consistency.