### PR TITLE
Change Elastic Agent Extension v5 API call names (#5538)

### DIFF
--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/elastic/v5/ElasticAgentExtensionV5.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/elastic/v5/ElasticAgentExtensionV5.java
@@ -63,7 +63,7 @@ public class ElasticAgentExtensionV5 implements VersionedElasticAgentExtension {
 
     @Override
     public List<PluginConfiguration> getElasticProfileMetadata(String pluginId) {
-        return pluginRequestHelper.submitRequest(pluginId, REQUEST_GET_PROFILE_METADATA, new DefaultPluginInteractionCallback<List<PluginConfiguration>>() {
+        return pluginRequestHelper.submitRequest(pluginId, REQUEST_GET_ELASTIC_AGENT_PROFILE_METADATA, new DefaultPluginInteractionCallback<List<PluginConfiguration>>() {
             @Override
             public List<PluginConfiguration> onSuccess(String responseBody, Map<String, String> responseHeaders, String resolvedExtensionVersion) {
                 return elasticAgentExtensionConverterV5.getElasticProfileMetadataResponseFromBody(responseBody);
@@ -73,7 +73,7 @@ public class ElasticAgentExtensionV5 implements VersionedElasticAgentExtension {
 
     @Override
     public String getElasticProfileView(String pluginId) {
-        return pluginRequestHelper.submitRequest(pluginId, REQUEST_GET_PROFILE_VIEW, new DefaultPluginInteractionCallback<String>() {
+        return pluginRequestHelper.submitRequest(pluginId, REQUEST_GET_ELASTIC_AGENT_PROFILE_VIEW, new DefaultPluginInteractionCallback<String>() {
             @Override
             public String onSuccess(String responseBody, Map<String, String> responseHeaders, String resolvedExtensionVersion) {
                 return elasticAgentExtensionConverterV5.getProfileViewResponseFromBody(responseBody);
@@ -88,7 +88,7 @@ public class ElasticAgentExtensionV5 implements VersionedElasticAgentExtension {
 
     @Override
     public ValidationResult validateElasticProfile(final String pluginId, final Map<String, String> configuration) {
-        return pluginRequestHelper.submitRequest(pluginId, REQUEST_VALIDATE_PROFILE, new DefaultPluginInteractionCallback<ValidationResult>() {
+        return pluginRequestHelper.submitRequest(pluginId, REQUEST_VALIDATE_ELASTIC_AGENT_PROFILE, new DefaultPluginInteractionCallback<ValidationResult>() {
             @Override
             public String requestBody(String resolvedExtensionVersion) {
                 return elasticAgentExtensionConverterV5.validateElasticProfileRequestBody(configuration);

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/elastic/v5/ElasticAgentPluginConstantsV5.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/elastic/v5/ElasticAgentPluginConstantsV5.java
@@ -23,9 +23,9 @@ public interface ElasticAgentPluginConstantsV5 {
     String REQUEST_SERVER_PING = REQUEST_PREFIX + ".server-ping";
     String REQUEST_SHOULD_ASSIGN_WORK = REQUEST_PREFIX + ".should-assign-work";
 
-    String REQUEST_GET_PROFILE_METADATA = REQUEST_PREFIX + ".get-profile-metadata";
-    String REQUEST_GET_PROFILE_VIEW = REQUEST_PREFIX + ".get-profile-view";
-    String REQUEST_VALIDATE_PROFILE = REQUEST_PREFIX + ".validate-profile";
+    String REQUEST_GET_ELASTIC_AGENT_PROFILE_METADATA = REQUEST_PREFIX + ".get-elastic-agent-profile-metadata";
+    String REQUEST_GET_ELASTIC_AGENT_PROFILE_VIEW = REQUEST_PREFIX + ".get-elastic-agent-profile-view";
+    String REQUEST_VALIDATE_ELASTIC_AGENT_PROFILE = REQUEST_PREFIX + ".validate-elastic-agent-profile";
     String REQUEST_GET_PLUGIN_SETTINGS_ICON = REQUEST_PREFIX + ".get-icon";
 
     String REQUEST_GET_CLUSTER_PROFILE_METADATA = REQUEST_PREFIX + ".get-cluster-profile-metadata";

--- a/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/elastic/ElasticAgentExtensionV4Test.java
+++ b/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/elastic/ElasticAgentExtensionV4Test.java
@@ -312,6 +312,13 @@ public class ElasticAgentExtensionV4Test {
     }
 
     @Test
+    public void shouldVerifyPluginApiRequestNamesOfElasticAgentProfile() {
+        assertThat(REQUEST_GET_PROFILE_METADATA, is(String.format("%s.get-profile-metadata", REQUEST_PREFIX)));
+        assertThat(REQUEST_GET_PROFILE_VIEW, is(String.format("%s.get-profile-view", REQUEST_PREFIX)));
+        assertThat(REQUEST_VALIDATE_PROFILE, is(String.format("%s.validate-profile", REQUEST_PREFIX)));
+    }
+
+    @Test
     public void allRequestMustHaveRequestPrefix() {
         assertThat(REQUEST_PREFIX, is("cd.go.elastic-agent"));
 

--- a/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/elastic/ElasticAgentExtensionV5Test.java
+++ b/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/elastic/ElasticAgentExtensionV5Test.java
@@ -120,7 +120,7 @@ public class ElasticAgentExtensionV5Test {
                 new PluginConfiguration("Password", new Metadata(true, true))
         ));
 
-        assertExtensionRequest("5.0", REQUEST_GET_PROFILE_METADATA, null);
+        assertExtensionRequest("5.0", REQUEST_GET_ELASTIC_AGENT_PROFILE_METADATA, null);
     }
 
     @Test
@@ -132,7 +132,7 @@ public class ElasticAgentExtensionV5Test {
 
         assertThat(view, is("<div>This is profile view snippet</div>"));
 
-        assertExtensionRequest("5.0", REQUEST_GET_PROFILE_VIEW, null);
+        assertExtensionRequest("5.0", REQUEST_GET_ELASTIC_AGENT_PROFILE_VIEW, null);
     }
 
     @Test
@@ -148,7 +148,7 @@ public class ElasticAgentExtensionV5Test {
                 new ValidationError("SearchBase", "SearchBase must not be blank.")
         ));
 
-        assertExtensionRequest("5.0", REQUEST_VALIDATE_PROFILE, "{}");
+        assertExtensionRequest("5.0", REQUEST_VALIDATE_ELASTIC_AGENT_PROFILE, "{}");
     }
 
 
@@ -405,6 +405,20 @@ public class ElasticAgentExtensionV5Test {
     }
 
     @Test
+    public void shouldVerifyPluginApiRequestNamesOfElasticAgentProfile() {
+        assertThat(REQUEST_GET_ELASTIC_AGENT_PROFILE_METADATA, is(String.format("%s.get-elastic-agent-profile-metadata", REQUEST_PREFIX)));
+        assertThat(REQUEST_GET_ELASTIC_AGENT_PROFILE_VIEW, is(String.format("%s.get-elastic-agent-profile-view", REQUEST_PREFIX)));
+        assertThat(REQUEST_VALIDATE_ELASTIC_AGENT_PROFILE, is(String.format("%s.validate-elastic-agent-profile", REQUEST_PREFIX)));
+    }
+
+    @Test
+    public void shouldVerifyPluginApiRequestNamesOfClusterProfile() {
+        assertThat(REQUEST_GET_CLUSTER_PROFILE_METADATA, is(String.format("%s.get-cluster-profile-metadata", REQUEST_PREFIX)));
+        assertThat(REQUEST_GET_CLUSTER_PROFILE_VIEW, is(String.format("%s.get-cluster-profile-view", REQUEST_PREFIX)));
+        assertThat(REQUEST_VALIDATE_CLUSTER_PROFILE, is(String.format("%s.validate-cluster-profile", REQUEST_PREFIX)));
+    }
+
+    @Test
     public void allRequestMustHaveRequestPrefix() {
         assertThat(REQUEST_PREFIX, is("cd.go.elastic-agent"));
 
@@ -412,9 +426,9 @@ public class ElasticAgentExtensionV5Test {
         assertThat(REQUEST_SERVER_PING, Matchers.startsWith(REQUEST_PREFIX));
         assertThat(REQUEST_SHOULD_ASSIGN_WORK, Matchers.startsWith(REQUEST_PREFIX));
 
-        assertThat(REQUEST_GET_PROFILE_METADATA, Matchers.startsWith(REQUEST_PREFIX));
-        assertThat(REQUEST_GET_PROFILE_VIEW, Matchers.startsWith(REQUEST_PREFIX));
-        assertThat(REQUEST_VALIDATE_PROFILE, Matchers.startsWith(REQUEST_PREFIX));
+        assertThat(REQUEST_GET_ELASTIC_AGENT_PROFILE_METADATA, Matchers.startsWith(REQUEST_PREFIX));
+        assertThat(REQUEST_GET_ELASTIC_AGENT_PROFILE_VIEW, Matchers.startsWith(REQUEST_PREFIX));
+        assertThat(REQUEST_VALIDATE_ELASTIC_AGENT_PROFILE, Matchers.startsWith(REQUEST_PREFIX));
         assertThat(REQUEST_GET_PLUGIN_SETTINGS_ICON, Matchers.startsWith(REQUEST_PREFIX));
     }
 


### PR DESCRIPTION
Change following plugin api call:
    * 'get-profile-metadata' => 'get-elastic-agent-profile-metadata'
    * 'get-profile-view'     => 'get-elastic-agent-profile-view'
    * 'validate-profile'     => 'validate-elastic-agent-profile'