### PR TITLE
ValidationContext exposes RulesValidationContext

### DIFF
--- a/common/src/main/java/com/thoughtworks/go/validation/RolesConfigUpdateValidator.java
+++ b/common/src/main/java/com/thoughtworks/go/validation/RolesConfigUpdateValidator.java
@@ -163,6 +163,11 @@ public class RolesConfigUpdateValidator implements ConfigUpdateValidator {
             public CruiseConfig getCruiseConfig() {
                 return null;
             }
+
+            @Override
+            public RulesValidationContext getRulesValidationContext() {
+                return null;
+            }
         };
     }
 }

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/AbstractDirective.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/AbstractDirective.java
@@ -46,13 +46,15 @@ public abstract class AbstractDirective implements Directive {
     }
 
     @Override
-    public void validate(RulesValidationContext validationContext) {
-        if (isInvalid(action, validationContext.getAllowedActions())) {
-            this.addError("action", format("Invalid action, must be one of %s.", validationContext.getAllowedActions()));
+    public void validate(ValidationContext validationContext) {
+        RulesValidationContext rulesValidationContext = validationContext.getRulesValidationContext();
+
+        if (isInvalid(action, rulesValidationContext.getAllowedActions())) {
+            this.addError("action", format("Invalid action, must be one of %s.", rulesValidationContext.getAllowedActions()));
         }
 
-        if (isInvalid(type, validationContext.getAllowedTypes())) {
-            this.addError("type", format("Invalid type, must be one of %s.", validationContext.getAllowedTypes()));
+        if (isInvalid(type, rulesValidationContext.getAllowedTypes())) {
+            this.addError("type", format("Invalid type, must be one of %s.", rulesValidationContext.getAllowedTypes()));
         }
     }
 

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/ConfigSaveValidationContext.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/ConfigSaveValidationContext.java
@@ -83,6 +83,14 @@ public class ConfigSaveValidationContext implements ValidationContext {
     }
 
     @Override
+    public RulesValidationContext getRulesValidationContext() {
+        RulesAware rulesAware = loadFirstOfType(RulesAware.class);
+
+        return new RulesValidationContext(rulesAware.allowedActions(), rulesAware.allowedTypes());
+    }
+
+
+    @Override
     public ConfigReposConfig getConfigRepos() {
         return getCruiseConfig().getConfigRepos();
     }

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/DelegatingValidationContext.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/DelegatingValidationContext.java
@@ -22,6 +22,8 @@ import com.thoughtworks.go.config.remote.ConfigReposConfig;
 import com.thoughtworks.go.domain.packagerepository.PackageRepository;
 import com.thoughtworks.go.domain.scm.SCM;
 
+import java.util.List;
+
 public abstract class DelegatingValidationContext implements ValidationContext {
     protected ValidationContext validationContext;
 
@@ -123,5 +125,10 @@ public abstract class DelegatingValidationContext implements ValidationContext {
     @Override
     public CruiseConfig getCruiseConfig() {
         return validationContext.getCruiseConfig();
+    }
+
+    @Override
+    public RulesValidationContext getRulesValidationContext() {
+        return null;
     }
 }

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/Directive.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/Directive.java
@@ -19,6 +19,6 @@ package com.thoughtworks.go.config;
 import java.io.Serializable;
 
 @ConfigInterface
-public interface Directive extends Validatable<RulesValidationContext>, Serializable {
+public interface Directive extends Validatable, Serializable {
     boolean hasErrors();
 }

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/PipelineConfigSaveValidationContext.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/PipelineConfigSaveValidationContext.java
@@ -27,10 +27,7 @@ import com.thoughtworks.go.domain.scm.SCM;
 import com.thoughtworks.go.util.Node;
 import org.apache.commons.lang3.NotImplementedException;
 
-import java.util.ArrayList;
-import java.util.Hashtable;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 
 public class PipelineConfigSaveValidationContext implements ValidationContext {
@@ -277,5 +274,10 @@ public class PipelineConfigSaveValidationContext implements ValidationContext {
     @Override
     public CruiseConfig getCruiseConfig() {
         return this.cruiseConfig;
+    }
+
+    @Override
+    public RulesValidationContext getRulesValidationContext() {
+        return null;
     }
 }

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/Rules.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/Rules.java
@@ -23,7 +23,7 @@ import java.util.Collection;
 
 @ConfigTag("rules")
 @ConfigCollection(Directive.class)
-public class Rules extends BaseCollection<Directive> implements Validatable<RulesValidationContext> {
+public class Rules extends BaseCollection<Directive> implements Validatable {
     public Rules() {
     }
 
@@ -36,17 +36,16 @@ public class Rules extends BaseCollection<Directive> implements Validatable<Rule
     }
 
     @Override
-    public void validate(RulesValidationContext validationContext) {
-        if (this.isEmpty()) {
-            return;
-        }
+    public void validate(ValidationContext validationContext) {
+    }
 
-        this.forEach(directive -> directive.validate(validationContext));
+    public void validateTree(ValidationContext validationContext) {
+        stream().forEach(directive -> directive.validate(validationContext));
     }
 
     @Override
     public ConfigErrors errors() {
-        throw new UnsupportedOperationException("Rules cannot have errors.");
+        return new ConfigErrors();
     }
 
     public boolean hasErrors() {
@@ -55,6 +54,6 @@ public class Rules extends BaseCollection<Directive> implements Validatable<Rule
 
     @Override
     public void addError(String fieldName, String message) {
-        throw new UnsupportedOperationException("Rules cannot have errors. Errors can be added to the directives.");
+
     }
 }

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/RulesAware.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/RulesAware.java
@@ -18,20 +18,8 @@ package com.thoughtworks.go.config;
 
 import java.util.List;
 
-public class RulesValidationContext  {
-    private final List<String> allowedActions;
-    private final List<String> allowedTypes;
+public interface RulesAware {
+    List<String> allowedActions();
 
-    protected RulesValidationContext(List<String> allowedActions, List<String> allowedTypes) {
-        this.allowedActions = allowedActions;
-        this.allowedTypes = allowedTypes;
-    }
-
-    public List<String> getAllowedActions() {
-        return allowedActions;
-    }
-
-    public List<String> getAllowedTypes() {
-        return allowedTypes;
-    }
+    List<String> allowedTypes();
 }

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/Validatable.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/Validatable.java
@@ -18,8 +18,8 @@ package com.thoughtworks.go.config;
 
 import com.thoughtworks.go.domain.ConfigErrors;
 
-public interface Validatable<T extends ValidationContext> {
-    void validate(T validationContext);
+public interface Validatable {
+    void validate(ValidationContext validationContext);
 
     ConfigErrors errors();
 

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/ValidationContext.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/ValidationContext.java
@@ -23,6 +23,8 @@ import com.thoughtworks.go.domain.packagerepository.PackageRepository;
 import com.thoughtworks.go.domain.scm.SCM;
 import com.thoughtworks.go.util.SystemEnvironment;
 
+import java.util.List;
+
 public interface ValidationContext {
     ConfigReposConfig getConfigRepos();
 
@@ -73,5 +75,7 @@ public interface ValidationContext {
     ArtifactStores artifactStores();
 
     CruiseConfig getCruiseConfig();
+
+    RulesValidationContext getRulesValidationContext();
 }
 

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/materials/ScmMaterialConfig.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/materials/ScmMaterialConfig.java
@@ -17,8 +17,10 @@
 package com.thoughtworks.go.config.materials;
 
 import com.thoughtworks.go.config.*;
+import com.thoughtworks.go.config.elastic.ElasticProfile;
 import com.thoughtworks.go.config.validation.FilePathTypeValidator;
 import com.thoughtworks.go.domain.ConfigErrors;
+import com.thoughtworks.go.domain.PipelineGroups;
 import com.thoughtworks.go.domain.materials.MaterialConfig;
 import com.thoughtworks.go.util.FilenameUtil;
 import com.thoughtworks.go.util.command.UrlArgument;

--- a/config/config-api/src/test/java/com/thoughtworks/go/config/AbstractDirectiveTest.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/config/AbstractDirectiveTest.java
@@ -19,8 +19,11 @@ package com.thoughtworks.go.config;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
+
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.registerCustomDateFormat;
 
 abstract class AbstractDirectiveTest {
     @Nested
@@ -29,7 +32,7 @@ abstract class AbstractDirectiveTest {
         void shouldAddErrorIfActionIsNotSet() {
             Directive directive = getDirective(null, "pipeline_group", "");
 
-            directive.validate(new RulesValidationContext(null, singletonList("refer"), singletonList("pipeline_group")));
+            directive.validate(rulesValidationContext(singletonList("refer"), singletonList("pipeline_group")));
 
             assertThat(directive.errors()).hasSize(1);
             assertThat(directive.errors().get("action"))
@@ -41,7 +44,7 @@ abstract class AbstractDirectiveTest {
         void shouldAddErrorIfActionIsSetToOtherThanAllowedActions() {
             Directive directive = getDirective("invalid", "pipeline_group", null);
 
-            directive.validate(new RulesValidationContext(null, singletonList("refer"), singletonList("pipeline_group")));
+            directive.validate(rulesValidationContext(singletonList("refer"), singletonList("pipeline_group")));
 
             assertThat(directive.errors()).hasSize(1);
 
@@ -54,7 +57,7 @@ abstract class AbstractDirectiveTest {
         void shouldAllowActionToHaveWildcard() {
             Directive directive = getDirective("*", "pipeline_group", null);
 
-            directive.validate(new RulesValidationContext(null, singletonList("refer"), singletonList("pipeline_group")));
+            directive.validate(rulesValidationContext(singletonList("refer"), singletonList("pipeline_group")));
 
             assertThat(directive.errors()).hasSize(0);
         }
@@ -63,7 +66,7 @@ abstract class AbstractDirectiveTest {
         void shouldAddErrorIfTypeIsNotSet() {
             Directive directive = getDirective("refer", null, "");
 
-            directive.validate(new RulesValidationContext(null, singletonList("refer"), singletonList("pipeline_group")));
+            directive.validate(rulesValidationContext(singletonList("refer"), singletonList("pipeline_group")));
 
             assertThat(directive.errors()).hasSize(1);
             assertThat(directive.errors().get("type"))
@@ -75,7 +78,7 @@ abstract class AbstractDirectiveTest {
         void shouldAddErrorIfTypeIsSetToOtherThanAllowedActions() {
             Directive directive = getDirective("refer", "invalid", "");
 
-            directive.validate(new RulesValidationContext(null, singletonList("refer"), singletonList("pipeline_group")));
+            directive.validate(rulesValidationContext(singletonList("refer"), singletonList("pipeline_group")));
 
             assertThat(directive.errors()).hasSize(1);
 
@@ -88,11 +91,21 @@ abstract class AbstractDirectiveTest {
         void shouldAllowTypeToHaveWildcard() {
             Directive directive = getDirective("refer", "*", "");
 
-            directive.validate(new RulesValidationContext(null, singletonList("refer"), singletonList("pipeline_group")));
+            directive.validate(rulesValidationContext(singletonList("refer"), singletonList("pipeline_group")));
 
             assertThat(directive.errors()).hasSize(0);
         }
     }
+
+    private ValidationContext rulesValidationContext(List<String> allowedAction, List<String> allowedType) {
+        return new DelegatingValidationContext(null) {
+            @Override
+            public RulesValidationContext getRulesValidationContext() {
+                return new RulesValidationContext(allowedAction, allowedType);
+            }
+        };
+    }
+
 
     abstract Directive getDirective(String action, String type, String resource);
 }

--- a/config/config-api/src/test/java/com/thoughtworks/go/config/ConfigSaveValidationContextTest.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/config/ConfigSaveValidationContextTest.java
@@ -28,36 +28,34 @@ import com.thoughtworks.go.domain.scm.SCMMother;
 import com.thoughtworks.go.domain.scm.SCMs;
 import com.thoughtworks.go.helper.GoConfigMother;
 import com.thoughtworks.go.helper.PipelineConfigMother;
-import org.hamcrest.MatcherAssert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
 
 import static junit.framework.TestCase.assertTrue;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.nullValue;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class ConfigSaveValidationContextTest {
 
-    @Before
-    public void setUp() throws Exception {
+    @BeforeEach
+    void setUp() throws Exception {
     }
 
     @Test
-    public void testShouldReturnTrueIfTemplatesIsAnAncestor() {
+    void testShouldReturnTrueIfTemplatesIsAnAncestor() {
         ValidationContext context = ConfigSaveValidationContext.forChain(new BasicCruiseConfig(), new TemplatesConfig(), new PipelineTemplateConfig());
-        assertThat(context.isWithinTemplates(), is(true));
+        assertThat(context.isWithinTemplates()).isTrue();
     }
 
     @Test
-    public void testShouldReturnFalseIfTemplatesIsNotAnAncestor() {
+    void testShouldReturnFalseIfTemplatesIsNotAnAncestor() {
         ValidationContext context = ConfigSaveValidationContext.forChain(new BasicCruiseConfig(), new PipelineGroups(), new BasicPipelineConfigs(), new PipelineConfig());
-        assertThat(context.isWithinTemplates(), is(false));
+        assertThat(context.isWithinTemplates()).isFalse();
     }
 
     @Test
-    public void shouldReturnAllMaterialsMatchingTheFingerprint() {
+    void shouldReturnAllMaterialsMatchingTheFingerprint() {
         CruiseConfig cruiseConfig = new BasicCruiseConfig();
         HgMaterialConfig hg = new HgMaterialConfig("url", null);
         for (int i = 0; i < 10; i++) {
@@ -66,78 +64,77 @@ public class ConfigSaveValidationContextTest {
         }
         ValidationContext context = ConfigSaveValidationContext.forChain(cruiseConfig);
 
-        assertThat(context.getAllMaterialsByFingerPrint(hg.getFingerprint()).size(), is(10));
+        assertThat(context.getAllMaterialsByFingerPrint(hg.getFingerprint()).size()).isEqualTo(10);
     }
 
     @Test
-    public void shouldReturnEmptyListWhenNoMaterialsMatch() {
+    void shouldReturnEmptyListWhenNoMaterialsMatch() {
         CruiseConfig cruiseConfig = new BasicCruiseConfig();
         ValidationContext context = ConfigSaveValidationContext.forChain(cruiseConfig);
-        assertThat(context.getAllMaterialsByFingerPrint("something").isEmpty(), is(true));
+        assertThat(context.getAllMaterialsByFingerPrint("something").isEmpty()).isTrue();
     }
 
     @Test
-    public void shouldGetPipelineConfigByName() {
+    void shouldGetPipelineConfigByName() {
         BasicCruiseConfig cruiseConfig = GoConfigMother.configWithPipelines("p1");
         ValidationContext context = ConfigSaveValidationContext.forChain(cruiseConfig);
-        assertThat(context.getPipelineConfigByName(new CaseInsensitiveString("p1")), is(cruiseConfig.allPipelines().get(0)));
-        assertThat(context.getPipelineConfigByName(new CaseInsensitiveString("does_not_exist")), is(nullValue()));
+        assertThat(context.getPipelineConfigByName(new CaseInsensitiveString("p1"))).isEqualTo(cruiseConfig.allPipelines().get(0));
+        assertThat(context.getPipelineConfigByName(new CaseInsensitiveString("does_not_exist"))).isNull();
     }
 
     @Test
-    public void shouldGetServerSecurityConfig() {
+    void shouldGetServerSecurityConfig() {
         BasicCruiseConfig cruiseConfig = GoConfigMother.configWithPipelines("p1");
         GoConfigMother.enableSecurityWithPasswordFilePlugin(cruiseConfig);
         ValidationContext context = ConfigSaveValidationContext.forChain(cruiseConfig);
-        assertThat(context.getServerSecurityConfig(), is(cruiseConfig.server().security()));
+        assertThat(context.getServerSecurityConfig()).isEqualTo(cruiseConfig.server().security());
     }
 
     @Test
-    public void shouldReturnIfTheContextBelongsToPipeline() {
+    void shouldReturnIfTheContextBelongsToPipeline() {
         ValidationContext context = ConfigSaveValidationContext.forChain(new BasicPipelineConfigs());
-        assertThat(context.isWithinPipelines(), is(true));
-        assertThat(context.isWithinTemplates(), is(false));
+        assertThat(context.isWithinPipelines()).isTrue();
+        assertThat(context.isWithinTemplates()).isFalse();
     }
 
     @Test
-    public void shouldReturnIfTheContextBelongsToTemplate() {
+    void shouldReturnIfTheContextBelongsToTemplate() {
         ValidationContext context = ConfigSaveValidationContext.forChain(new TemplatesConfig());
-        assertThat(context.isWithinPipelines(), is(false));
-        assertThat(context.isWithinTemplates(), is(true));
+        assertThat(context.isWithinPipelines()).isFalse();
+        assertThat(context.isWithinTemplates()).isTrue();
     }
 
     @Test
-    public void shouldCheckForExistenceOfTemplate() {
+    void shouldCheckForExistenceOfTemplate() {
         BasicCruiseConfig cruiseConfig = new BasicCruiseConfig();
         cruiseConfig.addTemplate(new PipelineTemplateConfig(new CaseInsensitiveString("t1")));
         ValidationContext context = ConfigSaveValidationContext.forChain(cruiseConfig);
 
-        MatcherAssert.assertThat(context.doesTemplateExist(new CaseInsensitiveString("t1")), is(true));
-        MatcherAssert.assertThat(context.doesTemplateExist(new CaseInsensitiveString("t2")), is(false));
+        assertThat(context.doesTemplateExist(new CaseInsensitiveString("t1"))).isTrue();
+        assertThat(context.doesTemplateExist(new CaseInsensitiveString("t2"))).isFalse();
     }
 
     @Test
-    public void shouldCheckForExistenceOfSCMS() throws Exception {
+    void shouldCheckForExistenceOfSCMS() throws Exception {
         BasicCruiseConfig cruiseConfig = new BasicCruiseConfig();
         cruiseConfig.setSCMs(new SCMs(SCMMother.create("scm-id")));
         ValidationContext context = ConfigSaveValidationContext.forChain(cruiseConfig);
 
-        MatcherAssert.assertThat(context.findScmById("scm-id").getId(), is("scm-id"));
-
+        assertThat(context.findScmById("scm-id").getId()).isEqualTo("scm-id");
     }
 
     @Test
-    public void shouldCheckForExistenceOfPackage() throws Exception {
+    void shouldCheckForExistenceOfPackage() throws Exception {
         BasicCruiseConfig cruiseConfig = new BasicCruiseConfig();
         cruiseConfig.setPackageRepositories(new PackageRepositories(PackageRepositoryMother.create("repo-id")));
         cruiseConfig.getPackageRepositories().find("repo-id").setPackages(new Packages(PackageDefinitionMother.create("package-id")));
         ValidationContext context = ConfigSaveValidationContext.forChain(cruiseConfig);
 
-        MatcherAssert.assertThat(context.findPackageById("package-id").getId(), is("repo-id"));
+        assertThat(context.findPackageById("package-id").getId()).isEqualTo("repo-id");
     }
 
     @Test
-    public void isValidProfileIdShouldBeValidInPresenceOfElasticProfile() {
+    void isValidProfileIdShouldBeValidInPresenceOfElasticProfile() {
         BasicCruiseConfig cruiseConfig = new BasicCruiseConfig();
         ElasticConfig elasticConfig = new ElasticConfig();
         elasticConfig.setProfiles(new ElasticProfiles(new ElasticProfile("docker.unit-test", "docker")));
@@ -148,7 +145,7 @@ public class ConfigSaveValidationContextTest {
     }
 
     @Test
-    public void shouldGetAllClusterProfiles() {
+    void shouldGetAllClusterProfiles() {
         BasicCruiseConfig cruiseConfig = new BasicCruiseConfig();
         ElasticConfig elasticConfig = new ElasticConfig();
         ClusterProfiles clusterProfiles = new ClusterProfiles(new ClusterProfile("cluster1", "docker"));
@@ -156,25 +153,39 @@ public class ConfigSaveValidationContextTest {
         cruiseConfig.setElasticConfig(elasticConfig);
         ValidationContext context = ConfigSaveValidationContext.forChain(cruiseConfig);
 
-        assertThat(context.getClusterProfiles(), is(clusterProfiles));
+        assertThat(context.getClusterProfiles()).isEqualTo(clusterProfiles);
     }
 
     @Test
-    public void isValidProfileIdShouldBeInValidInAbsenceOfElasticProfileForTheGivenId() {
+    void isValidProfileIdShouldBeInValidInAbsenceOfElasticProfileForTheGivenId() {
         BasicCruiseConfig cruiseConfig = new BasicCruiseConfig();
         ElasticConfig elasticConfig = new ElasticConfig();
         elasticConfig.setProfiles(new ElasticProfiles(new ElasticProfile("docker.unit-test", "docker")));
         cruiseConfig.setElasticConfig(elasticConfig);
         ValidationContext context = ConfigSaveValidationContext.forChain(cruiseConfig);
 
-        assertFalse(context.isValidProfileId("invalid.profile-id"));
+        assertThat(context.isValidProfileId("invalid.profile-id")).isFalse();
     }
 
     @Test
-    public void isValidProfileIdShouldBeInValidInAbsenceOfElasticProfiles() {
+    void isValidProfileIdShouldBeInValidInAbsenceOfElasticProfiles() {
         BasicCruiseConfig cruiseConfig = new BasicCruiseConfig();
         ValidationContext context = ConfigSaveValidationContext.forChain(cruiseConfig);
 
-        assertFalse(context.isValidProfileId("docker.unit-test"));
+        assertThat(context.isValidProfileId("docker.unit-test")).isFalse();
+    }
+
+    @Nested
+    class rulesValidationContext {
+        @Test
+        void shouldBuildRulesValidationContext() {
+            SecretConfig secretConfig = new SecretConfig();
+            ConfigSaveValidationContext configSaveValidationContext = ConfigSaveValidationContext.forChain(secretConfig);
+
+            RulesValidationContext rulesValidationContext = configSaveValidationContext.getRulesValidationContext();
+
+            assertThat(rulesValidationContext.getAllowedActions()).isEqualTo(secretConfig.allowedActions());
+            assertThat(rulesValidationContext.getAllowedTypes()).isEqualTo(secretConfig.allowedTypes());
+        }
     }
 }

--- a/config/config-api/src/test/java/com/thoughtworks/go/config/PluginProfileTest.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/config/PluginProfileTest.java
@@ -18,7 +18,8 @@ package com.thoughtworks.go.config;
 
 import com.thoughtworks.go.domain.config.ConfigurationProperty;
 import com.thoughtworks.go.domain.packagerepository.ConfigurationPropertyMother;
-import org.junit.Test;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
 
 import static java.lang.String.format;
 import static org.hamcrest.Matchers.is;
@@ -29,38 +30,45 @@ public abstract class PluginProfileTest {
     protected abstract PluginProfile pluginProfile(String id, String pluginId, ConfigurationProperty... configurationProperties);
     protected abstract String getObjectDescription();
 
-    @Test
-    public void shouldNotAllowNullPluginIdOrProfileId() throws Exception {
-        PluginProfile profile = pluginProfile(null, null);
+    @Nested
+    class validate {
+        @Test
+        void shouldNotAllowNullPluginIdOrProfileId() {
+            PluginProfile profile = pluginProfile(null, null);
 
-        profile.validate(null);
-        assertThat(profile.errors().size(), is(2));
-        assertThat(profile.errors().on("pluginId"), is(format("%s cannot have a blank plugin id.", getObjectDescription())));
-        assertThat(profile.errors().on("id"), is(format("%s cannot have a blank id.", getObjectDescription())));
-    }
+            profile.validate(null);
 
-    @Test
-    public void shouldValidatePluginIdPattern() throws Exception {
-        PluginProfile profile = pluginProfile("!123", "docker");
-        profile.validate(null);
-        assertThat(profile.errors().size(), is(1));
-        assertThat(profile.errors().on("id"), is("Invalid id '!123'. This must be alphanumeric and can contain underscores and periods (however, it cannot start with a period). The maximum allowed length is 255 characters."));
-    }
+            assertThat(profile.errors().size(), is(2));
+            assertThat(profile.errors().on("pluginId"), is(format("%s cannot have a blank plugin id.", getObjectDescription())));
+            assertThat(profile.errors().on("id"), is(format("%s cannot have a blank id.", getObjectDescription())));
+        }
 
-    @Test
-    public void shouldValidateConfigPropertyNameUniqueness() throws Exception {
-        ConfigurationProperty prop1 = ConfigurationPropertyMother.create("USERNAME");
-        ConfigurationProperty prop2 = ConfigurationPropertyMother.create("USERNAME");
-        PluginProfile profile = pluginProfile("docker.unit-test", "cd.go.elastic-agent.docker", prop1, prop2);
+        @Test
+        void shouldValidatePluginIdPattern() throws Exception {
+            PluginProfile profile = pluginProfile("!123", "docker");
 
-        profile.validate(null);
+            profile.validate(null);
 
-        assertThat(profile.errors().size(), is(0));
+            assertThat(profile.errors().size(), is(1));
+            assertThat(profile.errors().on("id"), is("Invalid id '!123'. This must be alphanumeric and " +
+                    "can contain underscores and periods (however, it cannot start with a period). The maximum allowed length is 255 characters."));
+        }
 
-        assertThat(prop1.errors().size(), is(1));
-        assertThat(prop2.errors().size(), is(1));
+        @Test
+        void shouldValidateConfigPropertyNameUniqueness() throws Exception {
+            ConfigurationProperty prop1 = ConfigurationPropertyMother.create("USERNAME");
+            ConfigurationProperty prop2 = ConfigurationPropertyMother.create("USERNAME");
+            PluginProfile profile = pluginProfile("docker.unit-test", "cd.go.elastic-agent.docker", prop1, prop2);
 
-        assertThat(prop1.errors().on("configurationKey"), is(format("Duplicate key 'USERNAME' found for %s 'docker.unit-test'", getObjectDescription())));
-        assertThat(prop2.errors().on("configurationKey"), is(format("Duplicate key 'USERNAME' found for %s 'docker.unit-test'", getObjectDescription())));
+            profile.validate(null);
+
+            assertThat(profile.errors().size(), is(0));
+
+            assertThat(prop1.errors().size(), is(1));
+            assertThat(prop2.errors().size(), is(1));
+
+            assertThat(prop1.errors().on("configurationKey"), is(format("Duplicate key 'USERNAME' found for %s 'docker.unit-test'", getObjectDescription())));
+            assertThat(prop2.errors().on("configurationKey"), is(format("Duplicate key 'USERNAME' found for %s 'docker.unit-test'", getObjectDescription())));
+        }
     }
 }

--- a/config/config-api/src/test/java/com/thoughtworks/go/config/SecretConfigTest.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/config/SecretConfigTest.java
@@ -130,18 +130,19 @@ public class SecretConfigTest extends PluginProfileTest {
     }
 
     @Nested
-    class validate {
+    class validateTree {
         @Test
         void shouldValidateRulesConfig() {
             final Rules rules = mock(Rules.class);
             final SecretConfig secretConfig = new SecretConfig("some-id", "cd.go.secret.file", rules);
 
-            secretConfig.validate(null);
+            secretConfig.validateTree(null);
 
-            final ArgumentCaptor<RulesValidationContext> argumentCaptor = ArgumentCaptor.forClass(RulesValidationContext.class);
-            verify(rules).validate(argumentCaptor.capture());
+            final ArgumentCaptor<ValidationContext> argumentCaptor = ArgumentCaptor.forClass(ValidationContext.class);
+            verify(rules).validateTree(argumentCaptor.capture());
 
-            final RulesValidationContext rulesValidationContext = argumentCaptor.getValue();
+            final ValidationContext validationContext = argumentCaptor.getValue();
+            RulesValidationContext rulesValidationContext = validationContext.getRulesValidationContext();
             assertThat(rulesValidationContext.getAllowedActions())
                     .hasSize(1)
                     .contains("refer");
@@ -152,27 +153,12 @@ public class SecretConfigTest extends PluginProfileTest {
         }
 
         @Test
-        void shouldPassOriginalValidationContextInRulesValidationContextToValidateRulesConfig() {
-            final Rules rules = mock(Rules.class);
-            final ValidationContext originalValidationContext = mock(ValidationContext.class);
-            final SecretConfig secretConfig = new SecretConfig("some-id", "cd.go.secret.file", rules);
-
-            secretConfig.validate(originalValidationContext);
-
-            final ArgumentCaptor<RulesValidationContext> argumentCaptor = ArgumentCaptor.forClass(RulesValidationContext.class);
-            verify(rules).validate(argumentCaptor.capture());
-
-            assertThat(argumentCaptor.getValue()).isNotNull();
-            assertThat(argumentCaptor.getValue().getOriginalValidationContext()).isEqualTo(originalValidationContext);
-        }
-
-        @Test
         void shouldBeInvalidIfRulesHasErrors() {
             final SecretConfig secretConfig = new SecretConfig("some-id", "cd.go.secret.file");
             final Allow invalidRuleConfig = new Allow(null, "pipeline_group", null);
             secretConfig.getRules().add(invalidRuleConfig);
 
-            secretConfig.validate(null);
+            secretConfig.validateTree(null);
 
             assertThat(secretConfig.hasErrors()).isTrue();
         }
@@ -184,7 +170,7 @@ public class SecretConfigTest extends PluginProfileTest {
 
             final SecretConfig secretConfig = new SecretConfig("some-id", "cd.go.secret.file", configurationPropertyWithError);
 
-            secretConfig.validate(null);
+            secretConfig.validateTree(null);
 
             assertThat(secretConfig.hasErrors()).isTrue();
         }

--- a/config/config-api/src/test/java/com/thoughtworks/go/config/helper/ValidationContextMother.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/config/helper/ValidationContextMother.java
@@ -23,6 +23,8 @@ import com.thoughtworks.go.config.remote.ConfigReposConfig;
 import com.thoughtworks.go.domain.packagerepository.PackageRepository;
 import com.thoughtworks.go.domain.scm.SCM;
 
+import java.util.List;
+
 public class ValidationContextMother {
 
     public static ValidationContext validationContext(SecurityConfig securityConfig) {
@@ -156,6 +158,11 @@ public class ValidationContextMother {
 
         @Override
         public CruiseConfig getCruiseConfig() {
+            return null;
+        }
+
+        @Override
+        public RulesValidationContext getRulesValidationContext() {
             return null;
         }
     }


### PR DESCRIPTION
* part of #6095
* Validating Rules requires RulesValidationContext which defines the
  allowedActions and allowedTypes.
* ConfigSaveValidationContext builds RulesValidationContext from
  SecretConfig which is RulesAware now.
* SecretConfig#validateTree validates the rules.