### PR TITLE
 An unclosed html tag, was causing the title on job details page to be not shown. Issue #6064

### DIFF
--- a/server/webapp/WEB-INF/vm/shared/_header.vm
+++ b/server/webapp/WEB-INF/vm/shared/_header.vm
@@ -42,7 +42,7 @@
       <script src="${js}"></script>
     #end
     #foreach( $css in ${webpackAssetsService.getCSSAssetPathsFor("single_page_apps/header_footer_shim")})
-      <link rel="stylesheet" type="text/css" href="${css}"
+      <link rel="stylesheet" type="text/css" href="${css}" />
     #end
 
   <title>


### PR DESCRIPTION
implemented the fix as highlighted in the issue #6064