### PR TITLE
Add cluster profile changed elastic agent extension call (#6115)

### DIFF
--- a/domain/src/main/java/com/thoughtworks/go/domain/ClusterProfilesChangedStatus.java
+++ b/domain/src/main/java/com/thoughtworks/go/domain/ClusterProfilesChangedStatus.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.domain;
+
+public enum ClusterProfilesChangedStatus {
+    CREATED("created"),
+    UPDATED("updated"),
+    DELETED("deleted");
+
+    private String status;
+
+    ClusterProfilesChangedStatus(String status) {
+        this.status = status;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+}
+

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/elastic/ElasticAgentExtension.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/elastic/ElasticAgentExtension.java
@@ -16,7 +16,7 @@
 
 package com.thoughtworks.go.plugin.access.elastic;
 
-import com.thoughtworks.go.config.elastic.ClusterProfile;
+import com.thoughtworks.go.domain.ClusterProfilesChangedStatus;
 import com.thoughtworks.go.domain.JobIdentifier;
 import com.thoughtworks.go.plugin.access.ExtensionsRegistry;
 import com.thoughtworks.go.plugin.access.PluginRequestHelper;
@@ -104,8 +104,8 @@ public class ElasticAgentExtension extends AbstractExtension {
         return getVersionedElasticAgentExtension(pluginId).getAgentStatusReport(pluginId, identifier, elasticAgentId, clusterProfile);
     }
 
-    public String getClusterStatusReport(String pluginId, Map<String,String> clusterProfile) {
-        return getVersionedElasticAgentExtension(pluginId).getClusterStatusReport(pluginId,clusterProfile);
+    public String getClusterStatusReport(String pluginId, Map<String, String> clusterProfile) {
+        return getVersionedElasticAgentExtension(pluginId).getClusterStatusReport(pluginId, clusterProfile);
     }
 
     public Capabilities getCapabilities(String pluginId) {
@@ -132,5 +132,9 @@ public class ElasticAgentExtension extends AbstractExtension {
 
     public ElasticAgentInformation migrateConfig(String pluginId, ElasticAgentInformation elasticAgentInformation) {
         return getVersionedElasticAgentExtension(pluginId).migrateConfig(pluginId, elasticAgentInformation);
+    }
+
+    public void clusterProfileChanged(String pluginId, ClusterProfilesChangedStatus status, Map<String, String> oldClusterProfile, Map<String, String> newClusterProfile) {
+        getVersionedElasticAgentExtension(pluginId).clusterProfilesChanged(pluginId, status, oldClusterProfile, newClusterProfile);
     }
 }

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/elastic/ElasticAgentPluginRegistry.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/elastic/ElasticAgentPluginRegistry.java
@@ -16,6 +16,7 @@
 
 package com.thoughtworks.go.plugin.access.elastic;
 
+import com.thoughtworks.go.domain.ClusterProfilesChangedStatus;
 import com.thoughtworks.go.domain.JobIdentifier;
 import com.thoughtworks.go.plugin.access.common.AbstractPluginRegistry;
 import com.thoughtworks.go.plugin.access.elastic.models.AgentMetadata;
@@ -89,4 +90,15 @@ public class ElasticAgentPluginRegistry extends AbstractPluginRegistry<ElasticAg
         extension.reportJobCompletion(pluginId, elasticAgentId, jobIdentifier, elasticProfileConfiguration, clusterProfileConfiguration);
         LOGGER.debug("Done processing report job completion for plugin: {} for elasticAgentId: {} for job: {} with configuration: {} in cluster: {}", pluginId, elasticAgentId, jobIdentifier, elasticProfileConfiguration, clusterProfileConfiguration);
     }
+
+    public void notifyPluginAboutClusterProfileChanged(String pluginId, ClusterProfilesChangedStatus status, Map<String, String> oldClusterProfile, Map<String, String> newClusterProfile) {
+        try {
+            LOGGER.debug("Processing report cluster profile changed for plugin: {} with status: {} with old cluster: {} and new cluster: {} ", pluginId, status, oldClusterProfile, newClusterProfile);
+            extension.clusterProfileChanged(pluginId, status, oldClusterProfile, newClusterProfile);
+            LOGGER.debug("Done processing report cluster profile changed for plugin: {} with status: {} with old cluster: {} and new cluster: {} ", pluginId, status, oldClusterProfile, newClusterProfile);
+        } catch (Exception e) {
+            LOGGER.error("An error occurred while processing report cluster profile changed for plugin: {} with status: {} with old cluster: {} and new cluster: {}. Error: {}", pluginId, status, oldClusterProfile, newClusterProfile, e);
+        }
+    }
+
 }

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/elastic/VersionedElasticAgentExtension.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/elastic/VersionedElasticAgentExtension.java
@@ -16,6 +16,7 @@
 
 package com.thoughtworks.go.plugin.access.elastic;
 
+import com.thoughtworks.go.domain.ClusterProfilesChangedStatus;
 import com.thoughtworks.go.domain.JobIdentifier;
 import com.thoughtworks.go.plugin.access.elastic.models.AgentMetadata;
 import com.thoughtworks.go.plugin.access.elastic.models.ElasticAgentInformation;
@@ -60,4 +61,6 @@ public interface VersionedElasticAgentExtension {
     void jobCompletion(String pluginId, String elasticAgentId, JobIdentifier jobIdentifier, Map<String, String> elasticProfileConfiguration, Map<String, String> clusterProfileConfiguration);
 
     ElasticAgentInformation migrateConfig(String pluginId, ElasticAgentInformation elasticAgentInformation);
+
+    void clusterProfilesChanged(String pluginId, ClusterProfilesChangedStatus status, Map<String, String> oldClusterProfile, Map<String, String> newClusterProfile);
 }

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/elastic/v4/ElasticAgentExtensionV4.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/elastic/v4/ElasticAgentExtensionV4.java
@@ -16,6 +16,7 @@
 
 package com.thoughtworks.go.plugin.access.elastic.v4;
 
+import com.thoughtworks.go.domain.ClusterProfilesChangedStatus;
 import com.thoughtworks.go.domain.JobIdentifier;
 import com.thoughtworks.go.plugin.access.DefaultPluginInteractionCallback;
 import com.thoughtworks.go.plugin.access.PluginRequestHelper;
@@ -192,5 +193,10 @@ public class ElasticAgentExtensionV4 implements VersionedElasticAgentExtension {
     @Override
     public ElasticAgentInformation migrateConfig(String pluginId, ElasticAgentInformation elasticAgentInformation) {
         return elasticAgentInformation;
+    }
+
+    @Override
+    public void clusterProfilesChanged(String pluginId, ClusterProfilesChangedStatus status, Map<String, String> oldClusterProfile, Map<String, String> newClusterProfile) {
+        throw new UnsupportedOperationException(String.format("Plugin: '%s' uses elastic agent extension v4 and cluster profile extension calls are not supported by elastic agent V4", pluginId));
     }
 }

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/elastic/v5/ElasticAgentExtensionV5.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/elastic/v5/ElasticAgentExtensionV5.java
@@ -16,6 +16,7 @@
 
 package com.thoughtworks.go.plugin.access.elastic.v5;
 
+import com.thoughtworks.go.domain.ClusterProfilesChangedStatus;
 import com.thoughtworks.go.domain.JobIdentifier;
 import com.thoughtworks.go.plugin.access.DefaultPluginInteractionCallback;
 import com.thoughtworks.go.plugin.access.PluginRequestHelper;
@@ -237,6 +238,16 @@ public class ElasticAgentExtensionV5 implements VersionedElasticAgentExtension {
             @Override
             public ElasticAgentInformation onSuccess(String responseBody, Map<String, String> responseHeaders, String resolvedExtensionVersion) {
                 return elasticAgentExtensionConverterV5.getElasticAgentInformationFromResponseBody(responseBody);
+            }
+        });
+    }
+
+    @Override
+    public void clusterProfilesChanged(String pluginId, ClusterProfilesChangedStatus status, Map<String, String> oldClusterProfile, Map<String, String> newClusterProfile) {
+        pluginRequestHelper.submitRequest(pluginId, REQUEST_CLUSTER_PROFILE_CHANGED, new DefaultPluginInteractionCallback<String>() {
+            @Override
+            public String requestBody(String resolvedExtensionVersion) {
+                return elasticAgentExtensionConverterV5.getClusterProfileChangedRequestBody(status, oldClusterProfile, newClusterProfile);
             }
         });
     }

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/elastic/v5/ElasticAgentPluginConstantsV5.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/elastic/v5/ElasticAgentPluginConstantsV5.java
@@ -40,4 +40,6 @@ public interface ElasticAgentPluginConstantsV5 {
     String REQUEST_JOB_COMPLETION = REQUEST_PREFIX + ".job-completion";
 
     String REQUEST_MIGRATE_CONFIGURATION = REQUEST_PREFIX + ".migrate-config";
+
+    String REQUEST_CLUSTER_PROFILE_CHANGED = REQUEST_PREFIX + ".cluster-profile-changed";
 }

--- a/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/elastic/ElasticAgentExtensionV4Test.java
+++ b/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/elastic/ElasticAgentExtensionV4Test.java
@@ -312,6 +312,14 @@ public class ElasticAgentExtensionV4Test {
     }
 
     @Test
+    public void shouldNotSupportClusterProfileChangedCall() {
+        thrown.expect(UnsupportedOperationException.class);
+        thrown.expectMessage(String.format("Plugin: '%s' uses elastic agent extension v4 and cluster profile extension calls are not supported by elastic agent V4", PLUGIN_ID));
+
+        extensionV4.clusterProfilesChanged(PLUGIN_ID, null, null, null);
+    }
+
+    @Test
     public void shouldVerifyPluginApiRequestNamesOfElasticAgentProfile() {
         assertThat(REQUEST_GET_PROFILE_METADATA, is(String.format("%s.get-profile-metadata", REQUEST_PREFIX)));
         assertThat(REQUEST_GET_PROFILE_VIEW, is(String.format("%s.get-profile-view", REQUEST_PREFIX)));

--- a/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/elastic/ElasticAgentExtensionV5Test.java
+++ b/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/elastic/ElasticAgentExtensionV5Test.java
@@ -16,6 +16,7 @@
 
 package com.thoughtworks.go.plugin.access.elastic;
 
+import com.thoughtworks.go.domain.ClusterProfilesChangedStatus;
 import com.thoughtworks.go.domain.JobIdentifier;
 import com.thoughtworks.go.plugin.access.PluginRequestHelper;
 import com.thoughtworks.go.plugin.access.elastic.models.AgentMetadata;
@@ -257,6 +258,26 @@ public class ElasticAgentExtensionV5Test {
                 "}";
 
         assertExtensionRequest("5.0", REQUEST_JOB_COMPLETION, expectedRequestBody);
+    }
+
+    @Test
+    public void shouldMakeClusterProfileChangedCall() {
+        ClusterProfilesChangedStatus status = ClusterProfilesChangedStatus.CREATED;
+        Map<String, String> oldClusterProfile = null;
+        Map<String, String> newClusterProfile = Collections.singletonMap("key1", "key2");
+
+        when(pluginManager.submitTo(eq(PLUGIN_ID), eq(ELASTIC_AGENT_EXTENSION), requestArgumentCaptor.capture())).thenReturn(DefaultGoPluginApiResponse.success(null));
+
+        extensionV5.clusterProfilesChanged(PLUGIN_ID, status, oldClusterProfile, newClusterProfile);
+
+        String expectedRequestBody = "{" +
+                "  \"status\":\"created\"," +
+                "  \"cluster_profiles_properties\":{" +
+                "    \"key1\":\"key2\"" +
+                "  }" +
+                "}";
+
+        assertExtensionRequest("5.0", REQUEST_CLUSTER_PROFILE_CHANGED, expectedRequestBody);
     }
 
     @Test

--- a/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/elastic/v5/ElasticAgentExtensionConverterV5Test.java
+++ b/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/elastic/v5/ElasticAgentExtensionConverterV5Test.java
@@ -19,6 +19,7 @@ package com.thoughtworks.go.plugin.access.elastic.v5;
 import com.google.gson.Gson;
 import com.thoughtworks.go.config.elastic.ClusterProfile;
 import com.thoughtworks.go.config.elastic.ElasticProfile;
+import com.thoughtworks.go.domain.ClusterProfilesChangedStatus;
 import com.thoughtworks.go.domain.JobIdentifier;
 import com.thoughtworks.go.domain.config.*;
 import com.thoughtworks.go.plugin.access.elastic.ElasticAgentMetadataStore;
@@ -455,23 +456,72 @@ public class ElasticAgentExtensionConverterV5Test {
         clusterProfileConfigurations.add(clusterProfile1);
         clusterProfileConfigurations.add(clusterProfile1);
 
-        new ElasticAgentExtensionConverterV5().getPluginStatusReportRequestBody(clusterProfileConfigurations);
-
         String json = new ElasticAgentExtensionConverterV5().getPluginStatusReportRequestBody(clusterProfileConfigurations);
 
-        assertThatJson(json).isEqualTo(
-                "{\"all_cluster_profiles_properties\":[" +
-                "   {" +
+        assertThatJson(json).isEqualTo("{" +
+                "  \"all_cluster_profiles_properties\":[" +
+                "    {" +
                 "      \"key1\":\"value1\"," +
                 "      \"key2\":\"value2\"" +
-                "   }," +
-                "   {" +
+                "    }," +
+                "    {" +
                 "      \"key1\":\"value1\"," +
                 "      \"key2\":\"value2\"" +
-                "   }" +
-                "]}");
+                "    }" +
+                "  ]" +
+                "}");
     }
 
+    @Test
+    public void shouldGetClusterProfilesChangedRequestBodyWhenClusterProfileIsCreated() {
+        ClusterProfilesChangedStatus status = ClusterProfilesChangedStatus.CREATED;
+        Map<String, String> oldClusterProfile = null;
+        Map<String, String> newClusterProfile = Collections.singletonMap("key1", "key2");
+
+        String json = new ElasticAgentExtensionConverterV5().getClusterProfileChangedRequestBody(status, oldClusterProfile, newClusterProfile);
+
+        assertThatJson(json).isEqualTo("{" +
+                "  \"status\":\"created\"," +
+                "  \"cluster_profiles_properties\":{" +
+                "    \"key1\":\"key2\"" +
+                "  }" +
+                "}");
+    }
+
+    @Test
+    public void shouldGetClusterProfilesChangedRequestBodyWhenClusterProfileIsUpdated() {
+        ClusterProfilesChangedStatus status = ClusterProfilesChangedStatus.UPDATED;
+        Map<String, String> oldClusterProfile = Collections.singletonMap("old_key1", "old_key2");
+        Map<String, String> newClusterProfile = Collections.singletonMap("key1", "key2");
+
+        String json = new ElasticAgentExtensionConverterV5().getClusterProfileChangedRequestBody(status, oldClusterProfile, newClusterProfile);
+
+        assertThatJson(json).isEqualTo("{" +
+                "  \"status\":\"updated\"," +
+                "  \"old_cluster_profiles_properties\":{" +
+                "    \"old_key1\":\"old_key2\"" +
+                "  }," +
+                "  \"cluster_profiles_properties\":{" +
+                "    \"key1\":\"key2\"" +
+                "  }" +
+                "}");
+    }
+
+    @Test
+    public void shouldGetClusterProfilesChangedRequestBodyWhenClusterProfileIsDeleted() {
+        ClusterProfilesChangedStatus status = ClusterProfilesChangedStatus.DELETED;
+        Map<String, String> oldClusterProfile = Collections.singletonMap("key1", "key2");
+        Map<String, String> newClusterProfile = null;
+
+        String json = new ElasticAgentExtensionConverterV5().getClusterProfileChangedRequestBody(status, oldClusterProfile, newClusterProfile);
+
+        assertThatJson(json).isEqualTo("{" +
+                "  \"status\":\"deleted\"," +
+                "  \"cluster_profiles_properties\":{" +
+                "    \"key1\":\"key2\"" +
+                "  }" +
+                "}");
+    }
 
     private AgentMetadata elasticAgent() {
         return new AgentMetadata("52", "Idle", "Idle", "Enabled");

--- a/server/src/main/java/com/thoughtworks/go/config/update/DeleteClusterProfileCommand.java
+++ b/server/src/main/java/com/thoughtworks/go/config/update/DeleteClusterProfileCommand.java
@@ -42,8 +42,8 @@ public class DeleteClusterProfileCommand extends ClusterProfileCommand {
     public void update(CruiseConfig preprocessedConfig) throws Exception {
         ClusterProfiles clusterProfiles = getPluginProfiles(preprocessedConfig);
         clusterProfiles.remove(profile);
-
         preprocessedConfig.getElasticConfig().setClusterProfiles(clusterProfiles);
+        this.preprocessedProfile = profile;
     }
 
     @Override

--- a/server/src/main/java/com/thoughtworks/go/server/service/ClusterProfilesChangedPluginNotifier.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/ClusterProfilesChangedPluginNotifier.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.server.service;
+
+import com.thoughtworks.go.config.CruiseConfig;
+import com.thoughtworks.go.config.elastic.ClusterProfile;
+import com.thoughtworks.go.config.elastic.ClusterProfiles;
+import com.thoughtworks.go.domain.ClusterProfilesChangedStatus;
+import com.thoughtworks.go.listener.ConfigChangedListener;
+import com.thoughtworks.go.listener.EntityConfigChangedListener;
+import com.thoughtworks.go.plugin.access.elastic.ElasticAgentPluginRegistry;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ClusterProfilesChangedPluginNotifier extends EntityConfigChangedListener<ClusterProfile> implements ConfigChangedListener {
+    private ClusterProfiles existingClusterProfiles;
+    private ElasticAgentPluginRegistry registry;
+    private GoConfigService goConfigService;
+
+    @Autowired
+    public ClusterProfilesChangedPluginNotifier(GoConfigService goConfigService, ElasticAgentPluginRegistry registry) {
+        this.goConfigService = goConfigService;
+        this.existingClusterProfiles = goConfigService.getElasticConfig().getClusterProfiles();
+        this.registry = registry;
+        goConfigService.register(this);
+    }
+
+    @Override
+    public void onEntityConfigChange(ClusterProfile updatedClusterProfile) {
+        if (goConfigService.getElasticConfig().getClusterProfiles().find(updatedClusterProfile.getId()) == null) {
+            registry.notifyPluginAboutClusterProfileChanged(updatedClusterProfile.getPluginId(), ClusterProfilesChangedStatus.DELETED, updatedClusterProfile.getConfigurationAsMap(true), null);
+            updateClusterProfilesCopy();
+            return;
+        }
+
+        ClusterProfile oldClusterProfile = existingClusterProfiles.find(updatedClusterProfile.getId());
+        if (oldClusterProfile == null) {
+            registry.notifyPluginAboutClusterProfileChanged(updatedClusterProfile.getPluginId(), ClusterProfilesChangedStatus.CREATED, null, updatedClusterProfile.getConfigurationAsMap(true));
+            updateClusterProfilesCopy();
+            return;
+        }
+
+        //cluster profile has been updated without changing plugin id
+        if (oldClusterProfile.getPluginId().equals(updatedClusterProfile.getPluginId())) {
+            registry.notifyPluginAboutClusterProfileChanged(updatedClusterProfile.getPluginId(), ClusterProfilesChangedStatus.UPDATED, oldClusterProfile.getConfigurationAsMap(true), updatedClusterProfile.getConfigurationAsMap(true));
+            updateClusterProfilesCopy();
+        } else {
+            //cluster profile has been updated including changing plugin id.
+            //this internally results in deletion of a profile belonging to old plugin id and creation of the profile belonging to new plugin id
+            registry.notifyPluginAboutClusterProfileChanged(updatedClusterProfile.getPluginId(), ClusterProfilesChangedStatus.CREATED, null, updatedClusterProfile.getConfigurationAsMap(true));
+            registry.notifyPluginAboutClusterProfileChanged(oldClusterProfile.getPluginId(), ClusterProfilesChangedStatus.DELETED, oldClusterProfile.getConfigurationAsMap(true), null);
+            updateClusterProfilesCopy();
+        }
+
+    }
+
+    private void updateClusterProfilesCopy() {
+        this.existingClusterProfiles = goConfigService.getElasticConfig().getClusterProfiles();
+    }
+
+    @Override
+    public void onConfigChange(CruiseConfig newCruiseConfig) {
+        this.existingClusterProfiles = newCruiseConfig.getElasticConfig().getClusterProfiles();
+    }
+
+    @Deprecated
+        //used only for tests
+    ClusterProfiles getExistingClusterProfiles() {
+        return existingClusterProfiles;
+    }
+}

--- a/server/src/test-fast/java/com/thoughtworks/go/config/update/DeleteClusterProfileCommandTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/config/update/DeleteClusterProfileCommandTest.java
@@ -31,6 +31,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
@@ -72,6 +73,13 @@ class DeleteClusterProfileCommandTest {
 
         boolean canContinue = command.canContinue(config);
         assertThat(canContinue).isFalse();
+    }
+
+    @Test
+    void shouldSetPreprocessedEntityAsPartOfUpdate() throws Exception {
+        assertNull(command.getPreprocessedEntityConfig());
+        command.update(config);
+        assertThat(command.getPreprocessedEntityConfig()).isEqualTo(clusterProfile);
     }
 
     @Test

--- a/server/src/test-fast/java/com/thoughtworks/go/server/service/ClusterProfilesChangedPluginNotifierTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/service/ClusterProfilesChangedPluginNotifierTest.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.server.service;
+
+import com.thoughtworks.go.config.BasicCruiseConfig;
+import com.thoughtworks.go.config.elastic.ClusterProfile;
+import com.thoughtworks.go.config.elastic.ClusterProfiles;
+import com.thoughtworks.go.config.elastic.ElasticConfig;
+import com.thoughtworks.go.domain.ClusterProfilesChangedStatus;
+import com.thoughtworks.go.domain.config.ConfigurationKey;
+import com.thoughtworks.go.domain.config.ConfigurationProperty;
+import com.thoughtworks.go.domain.config.ConfigurationValue;
+import com.thoughtworks.go.plugin.access.elastic.ElasticAgentPluginRegistry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+
+import java.util.ArrayList;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.Mockito.*;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+class ClusterProfilesChangedPluginNotifierTest {
+    @Mock
+    private GoConfigService goConfigService;
+    @Mock
+    private ElasticAgentPluginRegistry registry;
+
+    private ClusterProfilesChangedPluginNotifier notifier;
+    private ClusterProfile newClusterProfile;
+    private String pluginId;
+    private ClusterProfile oldClusterProfile;
+    private ArrayList<ConfigurationProperty> properties;
+
+    @BeforeEach
+    void setUp() {
+        initMocks(this);
+        pluginId = "plugin-id";
+        when(goConfigService.getElasticConfig()).thenReturn(new ElasticConfig());
+        properties = new ArrayList<>();
+        properties.add(new ConfigurationProperty(new ConfigurationKey("key1"), new ConfigurationValue("value1")));
+        oldClusterProfile = new ClusterProfile("profile1", pluginId, properties);
+        newClusterProfile = new ClusterProfile("profile1", pluginId, properties);
+
+        notifier = new ClusterProfilesChangedPluginNotifier(goConfigService, registry);
+    }
+
+    @Test
+    void shouldNotifyPluginRegistryWhenANewClusterProfileIsCreated() {
+        reset(goConfigService);
+        ElasticConfig elasticConfig = new ElasticConfig();
+        elasticConfig.getClusterProfiles().add(newClusterProfile);
+        when(goConfigService.getElasticConfig()).thenReturn(elasticConfig);
+        notifier.onEntityConfigChange(newClusterProfile);
+        verify(registry, times(1)).notifyPluginAboutClusterProfileChanged(pluginId, ClusterProfilesChangedStatus.CREATED, null, newClusterProfile.getConfigurationAsMap(true));
+        verifyNoMoreInteractions(registry);
+        verify(goConfigService, times(2)).getElasticConfig();
+    }
+
+    @Test
+    void shouldNotifyPluginRegistryWhenAClusterProfileIsDeleted() {
+        reset(goConfigService);
+        when(goConfigService.getElasticConfig()).thenReturn(new ElasticConfig());
+        notifier.onEntityConfigChange(oldClusterProfile);
+        verify(registry, times(1)).notifyPluginAboutClusterProfileChanged(pluginId, ClusterProfilesChangedStatus.DELETED, oldClusterProfile.getConfigurationAsMap(true), null);
+        verifyNoMoreInteractions(registry);
+        verify(goConfigService, times(2)).getElasticConfig();
+    }
+
+    @Test
+    void shouldNotifyPluginRegistryWhenAClusterProfileIsUpdated() {
+        reset(goConfigService);
+        ElasticConfig elasticConfig = new ElasticConfig();
+        elasticConfig.getClusterProfiles().add(oldClusterProfile);
+        when(goConfigService.getElasticConfig()).thenReturn(elasticConfig);
+        notifier = new ClusterProfilesChangedPluginNotifier(goConfigService, registry);
+
+        notifier.onEntityConfigChange(newClusterProfile);
+        verify(registry, times(1)).notifyPluginAboutClusterProfileChanged(pluginId, ClusterProfilesChangedStatus.UPDATED, oldClusterProfile.getConfigurationAsMap(true), newClusterProfile.getConfigurationAsMap(true));
+        verifyNoMoreInteractions(registry);
+        verify(goConfigService, times(3)).getElasticConfig();
+    }
+
+    @Test
+    void shouldNotifyPluginRegistryWhenAClusterProfileIsUpdated_WithAChangeInPluginId() {
+        String newPluginId = "updated-plugin-id";
+        newClusterProfile = new ClusterProfile("profile1", newPluginId, properties);
+
+        reset(goConfigService);
+        ElasticConfig elasticConfig = new ElasticConfig();
+        elasticConfig.getClusterProfiles().add(oldClusterProfile);
+        when(goConfigService.getElasticConfig()).thenReturn(elasticConfig);
+        notifier = new ClusterProfilesChangedPluginNotifier(goConfigService, registry);
+
+        notifier.onEntityConfigChange(newClusterProfile);
+
+        verify(registry, times(1)).notifyPluginAboutClusterProfileChanged(this.pluginId, ClusterProfilesChangedStatus.DELETED, oldClusterProfile.getConfigurationAsMap(true), null);
+        verify(registry, times(1)).notifyPluginAboutClusterProfileChanged(newPluginId, ClusterProfilesChangedStatus.CREATED, null, newClusterProfile.getConfigurationAsMap(true));
+        verifyNoMoreInteractions(registry);
+        verify(goConfigService, times(3)).getElasticConfig();
+    }
+
+    @Test
+    void onConfigChangeItShouldUpdateLocalClusterProfilesCopy() {
+        BasicCruiseConfig newCruiseConfig = new BasicCruiseConfig();
+        newCruiseConfig.getElasticConfig().getClusterProfiles().add(newClusterProfile);
+        newCruiseConfig.getElasticConfig().getClusterProfiles().add(oldClusterProfile);
+
+        assertThat(notifier.getExistingClusterProfiles()).isEqualTo(new ClusterProfiles());
+        notifier.onConfigChange(newCruiseConfig);
+        assertThat(notifier.getExistingClusterProfiles()).isEqualTo(new ClusterProfiles(newClusterProfile, oldClusterProfile));
+        verifyNoMoreInteractions(registry);
+    }
+}


### PR DESCRIPTION
* Notify plugins about cluster profile changed:
	- When a new cluster profile is created.
	- When the cluster profile configurations are modified.
	- When a cluster profile is deleted.

* When plugin id of a cluster profile is modified:
	- a cluster status changed with status 'deleted' call is sent
          to the old plugin.
	- a cluster status changed with status 'created' call is sent
          to the new plugin.

Notes:
* Users are not allowed to modify cluster profile id.
* No notification will be sent to plugin in case user modifies
  cluster profile by modifying the cruise-config.xml.