### PR TITLE
Backup Page improvements

### DIFF
--- a/api/api-backups-v1/src/main/java/com/thoughtworks/go/apiv1/admin/backups/BackupsController.java
+++ b/api/api-backups-v1/src/main/java/com/thoughtworks/go/apiv1/admin/backups/BackupsController.java
@@ -24,7 +24,6 @@ import com.thoughtworks.go.apiv1.admin.backups.representers.BackupRepresenter;
 import com.thoughtworks.go.server.domain.ServerBackup;
 import com.thoughtworks.go.server.security.HeaderConstraint;
 import com.thoughtworks.go.server.service.BackupService;
-import com.thoughtworks.go.server.service.result.HttpLocalizedOperationResult;
 import com.thoughtworks.go.spark.Routes;
 import com.thoughtworks.go.spark.spring.SparkSpringController;
 import com.thoughtworks.go.util.SystemEnvironment;

--- a/api/api-backups-v2/src/main/java/com/thoughtworks/go/apiv2/backups/BackupsControllerV2.java
+++ b/api/api-backups-v2/src/main/java/com/thoughtworks/go/apiv2/backups/BackupsControllerV2.java
@@ -34,6 +34,7 @@ import spark.Request;
 import spark.Response;
 
 import java.io.IOException;
+import java.util.Optional;
 
 import static com.thoughtworks.go.spark.Routes.Backups.ID_PATH;
 import static spark.Spark.*;
@@ -87,10 +88,10 @@ public class BackupsControllerV2 extends ApiController implements SparkSpringCon
 
     public String show(Request request, Response response) throws IOException {
         String backupId = request.params("id");
-        ServerBackup backup = backupService.getServerBackup(backupId);
-        if (null == backup) {
+        Optional<ServerBackup> backup = backupService.getServerBackup(backupId);
+        if (!backup.isPresent()) {
             throw new RecordNotFoundException(EntityType.Backup, backupId);
         }
-        return writerForTopLevelObject(request, response, outputWriter -> BackupRepresenter.toJSON(outputWriter, backup));
+        return writerForTopLevelObject(request, response, outputWriter -> BackupRepresenter.toJSON(outputWriter, backup.get()));
     }
 }

--- a/api/api-backups-v2/src/main/java/com/thoughtworks/go/apiv2/backups/BackupsControllerV2.java
+++ b/api/api-backups-v2/src/main/java/com/thoughtworks/go/apiv2/backups/BackupsControllerV2.java
@@ -43,6 +43,7 @@ import static spark.Spark.*;
 public class BackupsControllerV2 extends ApiController implements SparkSpringController {
 
     private static final String RETRY_INTERVAL_IN_SECONDS = "5";
+    private static final String RUNNING = "running";
 
     private final ApiAuthenticationHelper apiAuthenticationHelper;
     private BackupService backupService;
@@ -88,7 +89,13 @@ public class BackupsControllerV2 extends ApiController implements SparkSpringCon
 
     public String show(Request request, Response response) throws IOException {
         String backupId = request.params("id");
-        Optional<ServerBackup> backup = backupService.getServerBackup(backupId);
+        Optional<ServerBackup> backup;
+        if (RUNNING.equals(backupId)) {
+            backup = backupService.runningBackup();
+        } else {
+            backup = backupService.getServerBackup(backupId);
+        }
+
         if (!backup.isPresent()) {
             throw new RecordNotFoundException(EntityType.Backup, backupId);
         }

--- a/api/api-backups-v2/src/main/java/com/thoughtworks/go/apiv2/backups/representers/BackupRepresenter.java
+++ b/api/api-backups-v2/src/main/java/com/thoughtworks/go/apiv2/backups/representers/BackupRepresenter.java
@@ -18,6 +18,7 @@ package com.thoughtworks.go.apiv2.backups.representers;
 
 import com.thoughtworks.go.api.base.OutputWriter;
 import com.thoughtworks.go.apiv1.user.representers.UserSummaryRepresenter;
+import com.thoughtworks.go.server.domain.BackupProgressStatus;
 import com.thoughtworks.go.server.domain.ServerBackup;
 import com.thoughtworks.go.spark.Routes;
 
@@ -29,6 +30,7 @@ public class BackupRepresenter {
             .add("time", backup.getTime())
             .add("path", backup.getPath())
             .add("status", backup.getStatus().name())
+            .addIfNotNull("progress_status", backup.getBackupProgressStatus().map(BackupProgressStatus::name).orElse(null))
             .add("message", backup.getMessage())
             .addChild("user", userWriter -> UserSummaryRepresenter.toJSON(userWriter, backup.getUsername()));
     }

--- a/api/api-backups-v2/src/main/java/com/thoughtworks/go/apiv2/backups/representers/BackupRepresenter.java
+++ b/api/api-backups-v2/src/main/java/com/thoughtworks/go/apiv2/backups/representers/BackupRepresenter.java
@@ -26,7 +26,10 @@ public class BackupRepresenter {
 
     public static void toJSON(OutputWriter jsonOutputWriter, ServerBackup backup) {
         jsonOutputWriter
-            .addLinks(outputLinkWriter -> outputLinkWriter.addAbsoluteLink("doc", Routes.Backups.DOC))
+            .addLinks(outputLinkWriter -> {
+                outputLinkWriter.addAbsoluteLink("doc", Routes.Backups.DOC);
+                outputLinkWriter.addLink("self", Routes.Backups.serverBackup(String.valueOf(backup.getId())));
+            })
             .add("time", backup.getTime())
             .add("path", backup.getPath())
             .add("status", backup.getStatus().name())

--- a/api/api-backups-v2/src/test/groovy/com/thoughtworks/go/apiv2/backups/BackupsControllerV2Test.groovy
+++ b/api/api-backups-v2/src/test/groovy/com/thoughtworks/go/apiv2/backups/BackupsControllerV2Test.groovy
@@ -119,7 +119,7 @@ class BackupsControllerV2Test implements SecurityServiceTrait, ControllerTrait<B
 
       @Test
       void 'should get 404 when id does not exist'() {
-        doReturn(null).when(backupService).getServerBackup(BACKUP_ID.toString())
+        doReturn(Optional.empty()).when(backupService).getServerBackup(BACKUP_ID.toString())
 
         getWithApiHeader(controller.controllerPath(BACKUP_ID))
 
@@ -133,7 +133,7 @@ class BackupsControllerV2Test implements SecurityServiceTrait, ControllerTrait<B
       void 'should get serverBackup json'() {
         def backup = new ServerBackup("/foo/bar", new Date(), currentUserLoginName().toString(), BackupStatus.IN_PROGRESS, "", BACKUP_ID)
 
-        doReturn(backup).when(backupService).getServerBackup(BACKUP_ID.toString())
+        doReturn(Optional.of(backup)).when(backupService).getServerBackup(BACKUP_ID.toString())
 
         getWithApiHeader(controller.controllerPath(BACKUP_ID))
 

--- a/api/api-backups-v2/src/test/groovy/com/thoughtworks/go/apiv2/backups/BackupsControllerV2Test.groovy
+++ b/api/api-backups-v2/src/test/groovy/com/thoughtworks/go/apiv2/backups/BackupsControllerV2Test.groovy
@@ -142,6 +142,19 @@ class BackupsControllerV2Test implements SecurityServiceTrait, ControllerTrait<B
           .hasBodyWithJsonObject(backup, BackupRepresenter.class)
           .hasContentType(controller.mimeType)
       }
+
+      @Test
+      void 'should get running backup'() {
+        def backup = new ServerBackup("/foo/bar", new Date(), currentUserLoginName().toString(), BackupStatus.IN_PROGRESS, "", BACKUP_ID)
+        doReturn(Optional.of(backup)).when(backupService).runningBackup()
+
+        getWithApiHeader(controller.controllerPath("running"))
+
+        assertThatResponse()
+          .isOk()
+          .hasBodyWithJsonObject(backup, BackupRepresenter.class)
+          .hasContentType(controller.mimeType)
+      }
     }
   }
 

--- a/api/api-backups-v2/src/test/groovy/com/thoughtworks/go/apiv2/backups/representers/BackupRepresenterTest.groovy
+++ b/api/api-backups-v2/src/test/groovy/com/thoughtworks/go/apiv2/backups/representers/BackupRepresenterTest.groovy
@@ -31,21 +31,22 @@ import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson
 class BackupRepresenterTest {
   @Test
   void 'should serialize'() {
-    def backup = new ServerBackup("/foo/bar", new Date(42), "bob", BackupStatus.IN_PROGRESS, "exporting config", 99)
-    backup.setProgressStatus(BackupProgressStatus.STARTING)
+    def backup = new ServerBackup("/foo/bar", new Date(42), "bob", BackupStatus.IN_PROGRESS, "", 99)
+    backup.setProgressStatus(BackupProgressStatus.BACKUP_CONFIG)
 
     def actualJson = toObjectString({ BackupRepresenter.toJSON(it, backup) })
 
     Map<String, Object> expectedJson = [
-      _links         : [
-        doc: [href: apiDocsUrl('#backups')]
+      _links           : [
+        doc : [href: apiDocsUrl('#backups')],
+        self: [href: "http://test.host/go/api/backups/99"]
       ],
-      time           : jsonDate(new Date(42)),
-      path           : "/foo/bar",
-      user           : toObject({ UserSummaryRepresenter.toJSON(it, "bob") }),
-      status         : 'IN_PROGRESS',
-      "progress_step": 'STARTING',
-      message        : 'exporting config'
+      time             : jsonDate(new Date(42)),
+      path             : "/foo/bar",
+      user             : toObject({ UserSummaryRepresenter.toJSON(it, "bob") }),
+      status           : 'IN_PROGRESS',
+      "progress_status": 'BACKUP_CONFIG',
+      message          : 'Backing up Config'
     ]
 
     assertThatJson(actualJson).isEqualTo(expectedJson)
@@ -58,14 +59,15 @@ class BackupRepresenterTest {
     def actualJson = toObjectString({ BackupRepresenter.toJSON(it, backup) })
 
     Map<String, Object> expectedJson = [
-      _links         : [
-        doc: [href: apiDocsUrl('#backups')]
+      _links : [
+        doc : [href: apiDocsUrl('#backups')],
+        self: [href: "http://test.host/go/api/backups/99"],
       ],
-      time           : jsonDate(new Date(42)),
-      path           : "/foo/bar",
-      user           : toObject({ UserSummaryRepresenter.toJSON(it, "bob") }),
-      status         : 'COMPLETED',
-      message        : 'exporting config'
+      time   : jsonDate(new Date(42)),
+      path   : "/foo/bar",
+      user   : toObject({ UserSummaryRepresenter.toJSON(it, "bob") }),
+      status : 'COMPLETED',
+      message: 'exporting config'
     ]
 
     assertThatJson(actualJson).isEqualTo(expectedJson)

--- a/api/api-backups-v2/src/test/groovy/com/thoughtworks/go/apiv2/backups/representers/BackupRepresenterTest.groovy
+++ b/api/api-backups-v2/src/test/groovy/com/thoughtworks/go/apiv2/backups/representers/BackupRepresenterTest.groovy
@@ -17,6 +17,7 @@
 package com.thoughtworks.go.apiv2.backups.representers
 
 import com.thoughtworks.go.apiv1.user.representers.UserSummaryRepresenter
+import com.thoughtworks.go.server.domain.BackupProgressStatus
 import com.thoughtworks.go.server.domain.BackupStatus
 import com.thoughtworks.go.server.domain.ServerBackup
 import org.junit.jupiter.api.Test
@@ -31,18 +32,40 @@ class BackupRepresenterTest {
   @Test
   void 'should serialize'() {
     def backup = new ServerBackup("/foo/bar", new Date(42), "bob", BackupStatus.IN_PROGRESS, "exporting config", 99)
+    backup.setProgressStatus(BackupProgressStatus.STARTING)
 
     def actualJson = toObjectString({ BackupRepresenter.toJSON(it, backup) })
 
     Map<String, Object> expectedJson = [
-      _links: [
+      _links         : [
         doc: [href: apiDocsUrl('#backups')]
       ],
-      time  : jsonDate(new Date(42)),
-      path  : "/foo/bar",
-      user  : toObject({ UserSummaryRepresenter.toJSON(it, "bob") }),
-      status : 'IN_PROGRESS',
-      message : 'exporting config'
+      time           : jsonDate(new Date(42)),
+      path           : "/foo/bar",
+      user           : toObject({ UserSummaryRepresenter.toJSON(it, "bob") }),
+      status         : 'IN_PROGRESS',
+      "progress_step": 'STARTING',
+      message        : 'exporting config'
+    ]
+
+    assertThatJson(actualJson).isEqualTo(expectedJson)
+  }
+
+  @Test
+  void 'should not serialize progress status when not present'() {
+    def backup = new ServerBackup("/foo/bar", new Date(42), "bob", BackupStatus.COMPLETED, "exporting config", 99)
+
+    def actualJson = toObjectString({ BackupRepresenter.toJSON(it, backup) })
+
+    Map<String, Object> expectedJson = [
+      _links         : [
+        doc: [href: apiDocsUrl('#backups')]
+      ],
+      time           : jsonDate(new Date(42)),
+      path           : "/foo/bar",
+      user           : toObject({ UserSummaryRepresenter.toJSON(it, "bob") }),
+      status         : 'COMPLETED',
+      message        : 'exporting config'
     ]
 
     assertThatJson(actualJson).isEqualTo(expectedJson)

--- a/server/db/migrate/h2deltas/1903001_add_status_and_message_to_server_backup.sql
+++ b/server/db/migrate/h2deltas/1903001_add_status_and_message_to_server_backup.sql
@@ -20,5 +20,5 @@ UPDATE serverBackups set status='COMPLETED' WHERE status IS NULL;
 ALTER TABLE serverBackups ALTER COLUMN status SET NOT NULL;
 
 --//@UNDO
-ALTER TABLE agents DROP COLUMN status;
-ALTER TABLE agents DROP COLUMN message;
+ALTER TABLE serverBackups DROP COLUMN status;
+ALTER TABLE serverBackups DROP COLUMN message;

--- a/server/src/main/java/com/thoughtworks/go/server/domain/BackupProgressStatus.java
+++ b/server/src/main/java/com/thoughtworks/go/server/domain/BackupProgressStatus.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.server.domain;
+
+public enum BackupProgressStatus {
+
+    STARTING("Starting Backup"),
+    CREATING_DIR("Creating backup directory"),
+    BACKUP_VERSION_FILE("Backing up version file"),
+    BACKUP_CONFIG("Backing up Config"),
+    BACKUP_CONFIG_REPO("Backing up config repo"),
+    BACKUP_DATABASE("Backing up Database"),
+    POST_BACKUP_SCRIPT_START("Executing Post backup script"),
+    POST_BACKUP_SCRIPT_COMPLETE("Post backup script executed successfully");
+
+    private final String message;
+
+    BackupProgressStatus(String message) {
+        this.message = message;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+}

--- a/server/src/main/java/com/thoughtworks/go/server/domain/ServerBackup.java
+++ b/server/src/main/java/com/thoughtworks/go/server/domain/ServerBackup.java
@@ -19,22 +19,25 @@ package com.thoughtworks.go.server.domain;
 import com.thoughtworks.go.domain.PersistentObject;
 
 import java.util.Date;
+import java.util.Optional;
 
 /**
  * @understands A single backup of the server
  */
-public class ServerBackup extends PersistentObject{
+public class ServerBackup extends PersistentObject {
     private Date time;
     private String path;
     private String username;
     private BackupStatus status;
     private String message;
+    private BackupProgressStatus backupProgressStatus;
 
     private ServerBackup() {
     }
 
     public ServerBackup(String path, Date time, String username, String message) {
         this(path, time, username, message, BackupStatus.IN_PROGRESS);
+        this.backupProgressStatus = BackupProgressStatus.STARTING;
     }
 
     public ServerBackup(String path, Date time, String username, String message, BackupStatus status) {
@@ -114,6 +117,10 @@ public class ServerBackup extends PersistentObject{
         return status;
     }
 
+    public Optional<BackupProgressStatus> getBackupProgressStatus() {
+        return Optional.ofNullable(backupProgressStatus);
+    }
+
     public String getMessage() {
         return message;
     }
@@ -126,13 +133,20 @@ public class ServerBackup extends PersistentObject{
         this.message = message;
     }
 
+    public void setProgressStatus(BackupProgressStatus status) {
+        this.backupProgressStatus = status;
+        this.message = status.getMessage();
+    }
+
     public void markCompleted() {
         this.status = BackupStatus.COMPLETED;
+        this.backupProgressStatus = null;
     }
 
     public void markError(String message) {
         this.status = BackupStatus.ERROR;
         this.message = message;
+        this.backupProgressStatus = null;
     }
 
     public Boolean hasFailed() {

--- a/server/src/main/java/com/thoughtworks/go/server/domain/ServerBackup.java
+++ b/server/src/main/java/com/thoughtworks/go/server/domain/ServerBackup.java
@@ -17,6 +17,7 @@
 package com.thoughtworks.go.server.domain;
 
 import com.thoughtworks.go.domain.PersistentObject;
+import lombok.EqualsAndHashCode;
 
 import java.util.Date;
 import java.util.Optional;
@@ -24,6 +25,7 @@ import java.util.Optional;
 /**
  * @understands A single backup of the server
  */
+@EqualsAndHashCode(callSuper = true, exclude = "backupProgressStatus")
 public class ServerBackup extends PersistentObject {
     private Date time;
     private String path;
@@ -71,46 +73,6 @@ public class ServerBackup extends PersistentObject {
 
     public void setUsername(String username) {
         this.username = username;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-
-        ServerBackup that = (ServerBackup) o;
-
-        if (path != null ? !path.equals(that.path) : that.path != null) {
-            return false;
-        }
-        if (time != null ? !time.equals(that.time) : that.time != null) {
-            return false;
-        }
-        if (status != null ? !status.equals(that.status) : that.status != null) {
-            return false;
-        }
-        if (message != null ? !message.equals(that.message) : that.message != null) {
-            return false;
-        }
-        if (username != null ? !username.equals(that.username) : that.username != null) {
-            return false;
-        }
-
-        return true;
-    }
-
-    @Override
-    public int hashCode() {
-        int result = time != null ? time.hashCode() : 0;
-        result = 31 * result + (path != null ? path.hashCode() : 0);
-        result = 31 * result + (username != null ? username.hashCode() : 0);
-        result = 31 * result + (status != null ? status.hashCode() : 0);
-        result = 31 * result + (message != null ? message.hashCode() : 0);
-        return result;
     }
 
     public BackupStatus getStatus() {

--- a/server/src/main/java/com/thoughtworks/go/server/persistence/ServerBackupRepository.java
+++ b/server/src/main/java/com/thoughtworks/go/server/persistence/ServerBackupRepository.java
@@ -30,6 +30,7 @@ import org.springframework.orm.hibernate3.support.HibernateDaoSupport;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Optional;
 
 @Service
 public class ServerBackupRepository extends HibernateDaoSupport {
@@ -40,7 +41,7 @@ public class ServerBackupRepository extends HibernateDaoSupport {
         setSessionFactory(sessionFactory);
     }
 
-    public ServerBackup lastSuccessfulBackup() {
+    public Optional<ServerBackup> lastSuccessfulBackup() {
         List results = (List) getHibernateTemplate().execute((HibernateCallback) session -> {
             Criteria criteria = session.createCriteria(ServerBackup.class);
             criteria.add(Restrictions.eq("status", BackupStatus.COMPLETED));
@@ -49,7 +50,7 @@ public class ServerBackupRepository extends HibernateDaoSupport {
             return criteria.list();
         });
 
-        return results.isEmpty() ? null : (ServerBackup) results.get(0);
+        return results.isEmpty() ? Optional.empty() : Optional.of((ServerBackup) results.get(0));
     }
 
     public ServerBackup save(ServerBackup serverBackup) {
@@ -71,15 +72,15 @@ public class ServerBackupRepository extends HibernateDaoSupport {
         });
     }
 
-    public ServerBackup getBackup(String id) {
+    public Optional<ServerBackup> getBackup(String id) {
         if (StringUtils.isEmpty(id)) {
-            return null;
+            return Optional.empty();
         }
         return getBackup(Long.parseLong(id));
     }
 
-    public ServerBackup getBackup(long id) {
-        return getHibernateTemplate().get(ServerBackup.class, id);
+    public Optional<ServerBackup> getBackup(long id) {
+        return Optional.ofNullable(getHibernateTemplate().get(ServerBackup.class, id));
     }
 
     public void update(ServerBackup serverBackup) {

--- a/server/src/main/java/com/thoughtworks/go/server/service/BackupService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/BackupService.java
@@ -22,6 +22,7 @@ import com.thoughtworks.go.config.GoMailSender;
 import com.thoughtworks.go.database.Database;
 import com.thoughtworks.go.security.AESCipherProvider;
 import com.thoughtworks.go.security.DESCipherProvider;
+import com.thoughtworks.go.server.domain.BackupProgressStatus;
 import com.thoughtworks.go.server.domain.PostBackupScript;
 import com.thoughtworks.go.server.domain.ServerBackup;
 import com.thoughtworks.go.server.domain.Username;
@@ -70,6 +71,7 @@ public class BackupService implements BackupStatusProvider {
         TIMER,
         USER
     }
+
     private static final Logger LOGGER = LoggerFactory.getLogger(BackupService.class);
     static final String BACKUP = "backup_";
 
@@ -89,6 +91,7 @@ public class BackupService implements BackupStatusProvider {
     private static final String VERSION_BACKUP_FILE = "version.txt";
 
     private static final Object BACKUP_MUTEX = new Object();
+
     @Autowired
     public BackupService(ArtifactsDirHolder artifactsDirHolder,
                          GoConfigService goConfigService,
@@ -117,17 +120,21 @@ public class BackupService implements BackupStatusProvider {
         return serverBackup;
     }
 
-    public ServerBackup getServerBackup(String id) {
+    public Optional<ServerBackup> getServerBackup(String id) {
+        if (runningBackup != null && id.equals(String.valueOf(runningBackup.getId()))) {
+            return Optional.of(runningBackup);
+        }
         return serverBackupRepository.getBackup(id);
     }
 
-    public ServerBackup startBackupWithId(long id) {
-        ServerBackup backup = serverBackupRepository.getBackup(id);
-        if (backup == null) {
+    public Optional<ServerBackup> startBackupWithId(long id) {
+        Optional<ServerBackup> backup = serverBackupRepository.getBackup(id);
+        if (!backup.isPresent()) {
             LOGGER.error("Cannot find backup with id: {}. Skipping backup generation", id);
-            return null;
+            return Optional.empty();
         }
-        return performBackup(backup, singletonList(new BackupStatusUpdater(backup, serverBackupRepository)), BackupInitiator.USER);
+        ServerBackup serverBackup = performBackup(backup.get(), singletonList(new BackupStatusUpdater(backup.get(), serverBackupRepository)), BackupInitiator.USER);
+        return Optional.of(serverBackup);
     }
 
     ServerBackup backupViaTimer() {
@@ -151,7 +158,7 @@ public class BackupService implements BackupStatusProvider {
         synchronized (BACKUP_MUTEX) {
             try {
                 runningBackup = backup;
-                notifyUpdateToListeners(backupUpdateListeners, "Creating backup directory");
+                notifyUpdateToListeners(backupUpdateListeners, BackupProgressStatus.CREATING_DIR);
                 if (!destDir.mkdirs()) {
                     notifyErrorToListeners(backupUpdateListeners, "Failed to perform backup. Reason: Could not create the backup directory.");
                     return backup;
@@ -185,7 +192,7 @@ public class BackupService implements BackupStatusProvider {
     }
 
     private void backupConfigRepo(List<BackupUpdateListener> backupUpdateListeners, File destDir) throws IOException {
-        notifyUpdateToListeners(backupUpdateListeners, "Backing up config repo");
+        notifyUpdateToListeners(backupUpdateListeners, BackupProgressStatus.BACKUP_CONFIG_REPO);
         configRepository.doLocked(new VoidThrowingFn<IOException>() {
             @Override
             public void run() throws IOException {
@@ -196,8 +203,9 @@ public class BackupService implements BackupStatusProvider {
             }
         });
     }
-    private void notifyUpdateToListeners(List<BackupUpdateListener> listeners, String message) {
-        listeners.forEach(backupUpdateListener -> backupUpdateListener.updateStep(message));
+
+    private void notifyUpdateToListeners(List<BackupUpdateListener> listeners, BackupProgressStatus status) {
+        listeners.forEach(backupUpdateListener -> backupUpdateListener.updateStep(status));
     }
 
     private void notifyErrorToListeners(List<BackupUpdateListener> listeners, String message) {
@@ -205,7 +213,7 @@ public class BackupService implements BackupStatusProvider {
     }
 
     private void notifyCompletionToListeners(List<BackupUpdateListener> listeners) {
-        listeners.forEach(backupUpdateListener -> backupUpdateListener.completed());
+        listeners.forEach(BackupUpdateListener::completed);
     }
 
     private File getBackupDir(DateTime backupTime) {
@@ -227,10 +235,10 @@ public class BackupService implements BackupStatusProvider {
     private boolean executePostBackupScript(String username, BackupInitiator initiatedBy, ServerBackup serverBackup, List<BackupUpdateListener> notifyUpdateToListeners) {
         String postBackupScriptFile = postBackupScriptFile();
         if (isNotBlank(postBackupScriptFile)) {
-            notifyUpdateToListeners(notifyUpdateToListeners, "Executing Post backup script");
+            notifyUpdateToListeners(notifyUpdateToListeners, BackupProgressStatus.POST_BACKUP_SCRIPT_START);
             PostBackupScript postBackupScript = new PostBackupScript(postBackupScriptFile, initiatedBy, username, serverBackup, backupLocation(), serverBackup.getTime());
             if (postBackupScript.execute()) {
-                notifyUpdateToListeners(notifyUpdateToListeners, "Post backup script executed successfully.");
+                notifyUpdateToListeners(notifyUpdateToListeners, BackupProgressStatus.POST_BACKUP_SCRIPT_COMPLETE);
                 return true;
             } else {
                 notifyErrorToListeners(notifyUpdateToListeners, "Post backup script exited with an error, check the server log for details.");
@@ -265,13 +273,13 @@ public class BackupService implements BackupStatusProvider {
     }
 
     private void backupVersion(File backupDir, List<BackupUpdateListener> backupUpdateListeners) throws IOException {
-        notifyUpdateToListeners(backupUpdateListeners, "Backing up version file.");
+        notifyUpdateToListeners(backupUpdateListeners, BackupProgressStatus.BACKUP_VERSION_FILE);
         File versionFile = new File(backupDir, VERSION_BACKUP_FILE);
         FileUtils.writeStringToFile(versionFile, CurrentGoCDVersion.getInstance().formatted(), UTF_8);
     }
 
     private void backupConfig(File backupDir, List<BackupUpdateListener> backupUpdateListeners) throws IOException {
-        notifyUpdateToListeners(backupUpdateListeners, "Backing up Config.");
+        notifyUpdateToListeners(backupUpdateListeners, BackupProgressStatus.BACKUP_CONFIG);
         String configDirectory = systemEnvironment.getConfigDir();
         try (ZipOutputStream configZip = new ZipOutputStream(new BufferedOutputStream(new FileOutputStream(new File(backupDir, CONFIG_BACKUP_ZIP))))) {
             File cruiseConfigFile = new File(systemEnvironment.getCruiseConfigFile());
@@ -293,7 +301,7 @@ public class BackupService implements BackupStatusProvider {
     }
 
     private void backupDb(File backupDir, List<BackupUpdateListener> backupUpdateListener) {
-        notifyUpdateToListeners(backupUpdateListener, "Backing up Database.");
+        notifyUpdateToListeners(backupUpdateListener, BackupProgressStatus.BACKUP_DATABASE);
         databaseStrategy.backup(backupDir);
     }
 
@@ -301,14 +309,12 @@ public class BackupService implements BackupStatusProvider {
         return artifactsDirHolder.getBackupsDir().getAbsolutePath();
     }
 
-    public Date lastBackupTime() {
-        ServerBackup serverBackup = serverBackupRepository.lastSuccessfulBackup();
-        return serverBackup == null ? null : serverBackup.getTime();
+    public Optional<Date> lastBackupTime() {
+        return serverBackupRepository.lastSuccessfulBackup().map((ServerBackup::getTime));
     }
 
-    public String lastBackupUser() {
-        ServerBackup serverBackup = serverBackupRepository.lastSuccessfulBackup();
-        return serverBackup == null ? null : serverBackup.getUsername();
+    public Optional<String> lastBackupUser() {
+        return serverBackupRepository.lastSuccessfulBackup().map((ServerBackup::getUsername));
     }
 
     public void deleteAll() {
@@ -319,12 +325,18 @@ public class BackupService implements BackupStatusProvider {
         return runningBackup != null;
     }
 
-    public String backupRunningSinceISO8601() {
-        return !(runningBackup == null) ? new DateTime(runningBackup.getTime()).toString() : null;
+    public Optional<String> backupRunningSinceISO8601() {
+        if (runningBackup != null) {
+            return Optional.of(new DateTime(runningBackup.getTime()).toString());
+        }
+        return Optional.empty();
     }
 
-    public String backupStartedBy() {
-        return !(runningBackup == null) ? runningBackup.getUsername() : null;
+    public Optional<String> backupStartedBy() {
+        if (runningBackup != null) {
+            return Optional.of(runningBackup.getUsername());
+        }
+        return Optional.empty();
     }
 
     public String availableDiskSpace() {

--- a/server/src/main/java/com/thoughtworks/go/server/service/BackupService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/BackupService.java
@@ -120,6 +120,10 @@ public class BackupService implements BackupStatusProvider {
         return serverBackup;
     }
 
+    public Optional<ServerBackup> runningBackup() {
+        return Optional.ofNullable(runningBackup);
+    }
+
     public Optional<ServerBackup> getServerBackup(String id) {
         if (runningBackup != null && id.equals(String.valueOf(runningBackup.getId()))) {
             return Optional.of(runningBackup);

--- a/server/src/main/java/com/thoughtworks/go/server/service/backup/BackupStatusUpdater.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/backup/BackupStatusUpdater.java
@@ -16,6 +16,7 @@
 
 package com.thoughtworks.go.server.service.backup;
 
+import com.thoughtworks.go.server.domain.BackupProgressStatus;
 import com.thoughtworks.go.server.domain.ServerBackup;
 import com.thoughtworks.go.server.persistence.ServerBackupRepository;
 
@@ -29,8 +30,8 @@ public class BackupStatusUpdater implements BackupUpdateListener {
     }
 
     @Override
-    public void updateStep(String message) {
-        serverBackup.setMessage(message);
+    public void updateStep(BackupProgressStatus status) {
+        serverBackup.setProgressStatus(status);
         this.serverBackupRepository.update(serverBackup);
     }
 

--- a/server/src/main/java/com/thoughtworks/go/server/service/backup/BackupUpdateListener.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/backup/BackupUpdateListener.java
@@ -16,8 +16,10 @@
 
 package com.thoughtworks.go.server.service.backup;
 
+import com.thoughtworks.go.server.domain.BackupProgressStatus;
+
 public interface BackupUpdateListener {
-    void updateStep(String message);
+    void updateStep(BackupProgressStatus status);
 
     void error(String message);
 

--- a/server/src/main/java/com/thoughtworks/go/server/web/BackupFilter.java
+++ b/server/src/main/java/com/thoughtworks/go/server/web/BackupFilter.java
@@ -51,8 +51,10 @@ public class BackupFilter implements Filter {
     private final static Logger LOGGER = LoggerFactory.getLogger(BackupFilter.class);
 
     private static final OrRequestMatcher REQUESTS_ALLOWED_WHILE_BACKUP_RUNNING_MATCHER = new OrRequestMatcher(
-            new RegexRequestMatcher("/api/backups/\\d+", "GET", true),
-            new RegexRequestMatcher("/api/v1/health", "GET", true)
+            new RegexRequestMatcher("/api/backups/(\\d+|running)", "GET", true),
+            new RegexRequestMatcher("/api/v1/health", "GET", true),
+            new RegexRequestMatcher("/admin/backup", "GET", true),
+            new RegexRequestMatcher("/assets/.*", "GET", true)
     );
 
     // For the Test
@@ -101,8 +103,8 @@ public class BackupFilter implements Filter {
     }
 
     String replaceStringLiterals(String content) {
-        content = content.replaceAll("%backup_initiated_by%", HtmlUtils.htmlEscape(backupService.backupRunningSinceISO8601()));
-        content = content.replaceAll("%backup_started_by%", HtmlUtils.htmlEscape(backupService.backupStartedBy()));
+        content = content.replaceAll("%backup_initiated_by%", HtmlUtils.htmlEscape(backupService.backupRunningSinceISO8601().orElse("")));
+        content = content.replaceAll("%backup_started_by%", HtmlUtils.htmlEscape(backupService.backupStartedBy().orElse("")));
         return content;
     }
 

--- a/server/src/main/java/com/thoughtworks/go/server/web/BackupStatusProvider.java
+++ b/server/src/main/java/com/thoughtworks/go/server/web/BackupStatusProvider.java
@@ -16,10 +16,12 @@
 
 package com.thoughtworks.go.server.web;
 
+import java.util.Optional;
+
 public interface BackupStatusProvider {
     boolean isBackingUp();
 
-    String backupRunningSinceISO8601();
+    Optional<String> backupRunningSinceISO8601();
 
-    String backupStartedBy();
+    Optional<String> backupStartedBy();
 }

--- a/server/src/test-fast/java/com/thoughtworks/go/server/domain/ServerBackupTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/domain/ServerBackupTest.java
@@ -20,39 +20,51 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Date;
 
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.not;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class ServerBackupTest {
 
     @Test
     void shouldBeSuccessfulIfStatusCompleted() {
-        assertThat(new ServerBackup("path", new Date(), "admin", "").isSuccessful(), is(false));
-        assertThat(new ServerBackup("path", new Date(), "admin", BackupStatus.ERROR, "", 123).isSuccessful(), is(false));
-        assertThat(new ServerBackup("path", new Date(), "admin", BackupStatus.COMPLETED, "", 123).isSuccessful(), is(true));
+        assertThat(new ServerBackup("path", new Date(), "admin", "").isSuccessful()).isFalse();
+        assertThat(new ServerBackup("path", new Date(), "admin", BackupStatus.ERROR, "", 123).isSuccessful()).isFalse();
+        assertThat(new ServerBackup("path", new Date(), "admin", BackupStatus.COMPLETED, "", 123).isSuccessful()).isTrue();
     }
 
     @Test
     void shouldMarkCompleted() {
         ServerBackup backup = new ServerBackup("path", new Date(), "admin", "");
-        assertThat(backup.getStatus(), not(BackupStatus.COMPLETED));
+        assertThat(backup.getStatus()).isNotEqualTo(BackupStatus.COMPLETED);
 
         backup.markCompleted();
-        assertThat(backup.getStatus(), is(BackupStatus.COMPLETED));
-        assertThat(backup.getMessage(), is(""));
+        assertThat(backup.getStatus()).isEqualTo(BackupStatus.COMPLETED);
+        assertThat(backup.getMessage()).isEmpty();
+        assertThat(backup.getBackupProgressStatus()).isNotPresent();
     }
 
     @Test
     void shouldMarkError() {
         ServerBackup backup = new ServerBackup("path", new Date(), "admin", "");
-        assertThat(backup.getStatus(), not(BackupStatus.ERROR));
-        assertThat(backup.hasFailed(), is(false));
+        assertThat(backup.getStatus()).isNotEqualTo(BackupStatus.ERROR);
+        assertThat(backup.hasFailed()).isFalse();
 
         backup.markError("boom");
 
-        assertThat(backup.getStatus(), is(BackupStatus.ERROR));
-        assertThat(backup.getMessage(), is("boom"));
-        assertThat(backup.hasFailed(), is(true));
+        assertThat(backup.getStatus()).isEqualTo(BackupStatus.ERROR);
+        assertThat(backup.getMessage()).isEqualTo("boom");
+        assertThat(backup.hasFailed()).isTrue();
+        assertThat(backup.getBackupProgressStatus()).isNotPresent();
+    }
+
+    @Test
+    void shouldSetProgressStatus() {
+        ServerBackup backup = new ServerBackup("path", new Date(), "admin", "");
+        assertThat(backup.getBackupProgressStatus()).hasValue(BackupProgressStatus.STARTING);
+
+        backup.setProgressStatus(BackupProgressStatus.BACKUP_CONFIG);
+
+        assertThat(backup.getBackupProgressStatus()).hasValue(BackupProgressStatus.BACKUP_CONFIG);
+        assertThat(backup.getMessage()).isEqualTo(BackupProgressStatus.BACKUP_CONFIG.getMessage());
+        assertThat(backup.getStatus()).isEqualTo(BackupStatus.IN_PROGRESS);
     }
 }

--- a/server/src/test-fast/java/com/thoughtworks/go/server/service/BackupServiceTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/service/BackupServiceTest.java
@@ -41,6 +41,7 @@ import org.mockito.MockitoAnnotations;
 
 import java.io.File;
 import java.util.Date;
+import java.util.Optional;
 
 import static com.thoughtworks.go.server.service.BackupService.ABORTED_BACKUPS_MESSAGE;
 import static org.hamcrest.Matchers.is;
@@ -96,11 +97,11 @@ public class BackupServiceTest {
     public void shouldReturnTheLatestBackupTime() {
         ServerBackupRepository repo = mock(ServerBackupRepository.class);
         Date serverBackupTime = new Date();
-        when(repo.lastSuccessfulBackup()).thenReturn(new ServerBackup("file_path", serverBackupTime, "user", ""));
+        when(repo.lastSuccessfulBackup()).thenReturn(Optional.of(new ServerBackup("file_path", serverBackupTime, "user", "")));
         BackupService backupService = new BackupService(null, mock(GoConfigService.class), null, repo, systemEnvironment, configRepo, databaseStrategy, null);
 
-        Date date = backupService.lastBackupTime();
-        assertThat(date, is(serverBackupTime));
+        Optional<Date> date = backupService.lastBackupTime();
+        assertThat(date.get(), is(serverBackupTime));
     }
 
     @Test
@@ -114,11 +115,11 @@ public class BackupServiceTest {
     @Test
     public void shouldReturnTheUserThatTriggeredTheLastBackup() {
         ServerBackupRepository repo = mock(ServerBackupRepository.class);
-        when(repo.lastSuccessfulBackup()).thenReturn(new ServerBackup("file_path", new Date(), "loser", ""));
+        when(repo.lastSuccessfulBackup()).thenReturn(Optional.of(new ServerBackup("file_path", new Date(), "loser", "")));
         BackupService backupService = new BackupService(null, mock(GoConfigService.class), null, repo, systemEnvironment, configRepo, databaseStrategy, null);
 
-        String username = backupService.lastBackupUser();
-        assertThat(username, is("loser"));
+        Optional<String> username = backupService.lastBackupUser();
+        assertThat(username.get(), is("loser"));
     }
 
     @Test

--- a/server/src/test-fast/java/com/thoughtworks/go/server/service/backup/BackupStatusUpdaterTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/service/backup/BackupStatusUpdaterTest.java
@@ -16,6 +16,7 @@
 
 package com.thoughtworks.go.server.service.backup;
 
+import com.thoughtworks.go.server.domain.BackupProgressStatus;
 import com.thoughtworks.go.server.domain.BackupStatus;
 import com.thoughtworks.go.server.domain.ServerBackup;
 import com.thoughtworks.go.server.persistence.ServerBackupRepository;
@@ -25,8 +26,7 @@ import org.mockito.Mock;
 
 import java.util.Date;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.verify;
 import static org.mockito.MockitoAnnotations.initMocks;
 
@@ -45,10 +45,11 @@ public class BackupStatusUpdaterTest {
         ServerBackup serverBackup = new ServerBackup("path", new Date(), "admin", "a message");
         BackupStatusUpdater backupStatusUpdater = new BackupStatusUpdater(serverBackup, serverBackupRepository);
 
-        backupStatusUpdater.updateStep("new message");
+        backupStatusUpdater.updateStep(BackupProgressStatus.BACKUP_DATABASE);
 
         verify(serverBackupRepository).update(serverBackup);
-        assertThat(serverBackup.getMessage(), is("new message"));
+        assertThat(serverBackup.getStatus()).isEqualTo(BackupProgressStatus.BACKUP_DATABASE);
+        assertThat(serverBackup.getMessage()).isEqualTo(BackupProgressStatus.BACKUP_DATABASE.getMessage());
     }
 
     @Test
@@ -59,8 +60,8 @@ public class BackupStatusUpdaterTest {
         backupStatusUpdater.error("boom");
 
         verify(serverBackupRepository).update(serverBackup);
-        assertThat(serverBackup.getMessage(), is("boom"));
-        assertThat(serverBackup.getStatus(), is(BackupStatus.ERROR));
+        assertThat(serverBackup.getMessage()).isEqualTo("boom");
+        assertThat(serverBackup.getStatus()).isEqualTo(BackupStatus.ERROR);
     }
 
     @Test
@@ -71,7 +72,7 @@ public class BackupStatusUpdaterTest {
         backupStatusUpdater.completed();
 
         verify(serverBackupRepository).update(serverBackup);
-        assertThat(serverBackup.getMessage(), is("Backup was generated successfully."));
-        assertThat(serverBackup.isSuccessful(), is(true));
+        assertThat(serverBackup.getMessage()).isEqualTo("Backup was generated successfully.");
+        assertThat(serverBackup.isSuccessful()).isTrue();
     }
 }

--- a/server/src/test-fast/java/com/thoughtworks/go/server/web/BackupFilterTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/web/BackupFilterTest.java
@@ -90,6 +90,16 @@ public class BackupFilterTest {
     }
 
     @Test
+    public void shouldPassBackupPageSPARequestWhenBackupIsBeingTaken() throws Exception {
+        when(backupService.isBackingUp()).thenReturn(true);
+        Request request = request(HttpMethod.GET, "", "/admin/backup");
+        backupFilter.doFilter(request, res, chain);
+        verify(res, times(0)).setContentType("text/html");
+        verify(writer, times(0)).print("some test data for my input stream");
+        verify(res, never()).setStatus(anyInt());
+    }
+
+    @Test
     public void shouldWriteToResponseWhenBackupIsBeingTaken() throws Exception {
         when(backupService.isBackingUp()).thenReturn(true);
         when(backupService.backupRunningSinceISO8601()).thenReturn(BACKUP_STARTED_AT);
@@ -119,6 +129,27 @@ public class BackupFilterTest {
         verify(res, never()).setStatus(anyInt());
     }
 
+    @Test
+    public void shouldGetRunningServerBackupWhenBackupIsBeingTaken() throws Exception {
+        when(backupService.isBackingUp()).thenReturn(true);
+        Request request = request(HttpMethod.GET, "", "/api/backups/running");
+        backupFilter.doFilter(request, res, chain);
+
+        verify(res, times(0)).setContentType("text/html");
+        verify(writer, times(0)).print("some test data for my input stream");
+        verify(res, never()).setStatus(anyInt());
+    }
+
+    @Test
+    public void shouldGetStaticAssetsWhenBackupIsBeingTaken() throws IOException, ServletException {
+        when(backupService.isBackingUp()).thenReturn(true);
+        Request request = request(HttpMethod.GET, "", "/assets/foo.js");
+        backupFilter.doFilter(request, res, chain);
+
+        verify(res, times(0)).setContentType("text/html");
+        verify(writer, times(0)).print("some test data for my input stream");
+        verify(res, never()).setStatus(anyInt());
+    }
 
     @Test
     public void shouldReturnJsonResponseWhenBackupIsFinishedJsonAPIIsBeingCalled() throws Exception {

--- a/server/src/test-fast/java/com/thoughtworks/go/server/web/BackupFilterTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/web/BackupFilterTest.java
@@ -37,6 +37,7 @@ import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.PrintWriter;
+import java.util.Optional;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.mockito.Mockito.*;
@@ -45,8 +46,8 @@ public class BackupFilterTest {
 
     private HttpServletResponse res;
     private BackupFilter backupFilter;
-    private static final String BACKUP_STARTED_AT = "Some old date";
-    private static final String BACKUP_STARTED_BY = "admin";
+    private static final Optional<String> BACKUP_STARTED_AT = Optional.of("Some old date");
+    private static final Optional<String> BACKUP_STARTED_BY = Optional.of("admin");
     private FilterChain chain;
     private FilterConfig filterConfig;
     private BackupService backupService;

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/BackupServiceH2IntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/BackupServiceH2IntegrationTest.java
@@ -138,7 +138,7 @@ public class BackupServiceH2IntegrationTest {
         File backup = new File(backupsDirectory, BackupService.BACKUP + now.toString("YYYYMMdd-HHmmss"));
         assertThat(backup.exists(), is(true));
         assertThat(new File(backup, "db.zip").exists(), is(true));
-        assertEquals(serverBackup, backupInfoRepository.lastSuccessfulBackup());
+        assertEquals(serverBackup, backupInfoRepository.lastSuccessfulBackup().get());
     }
 
     @Test

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/BackupServiceIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/BackupServiceIntegrationTest.java
@@ -425,7 +425,7 @@ public class BackupServiceIntegrationTest {
 
         backupThd.start();
         waitForBackupToComplete.acquire();
-        assertThat(backupUpdateListener.getMessages().contains("Post backup script executed successfully."), is(true));
+        assertThat(backupUpdateListener.getMessages().contains("Post backup script executed successfully"), is(true));
         backupThd.join();
     }
 

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/BackupServiceIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/BackupServiceIntegrationTest.java
@@ -27,6 +27,7 @@ import com.thoughtworks.go.domain.materials.mercurial.StringRevision;
 import com.thoughtworks.go.security.AESCipherProvider;
 import com.thoughtworks.go.security.DESCipherProvider;
 import com.thoughtworks.go.server.dao.DatabaseAccessHelper;
+import com.thoughtworks.go.server.domain.BackupProgressStatus;
 import com.thoughtworks.go.server.domain.ServerBackup;
 import com.thoughtworks.go.server.domain.Username;
 import com.thoughtworks.go.server.messaging.SendEmailMessage;
@@ -59,6 +60,7 @@ import javax.sql.DataSource;
 import java.io.*;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.Semaphore;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
@@ -311,14 +313,14 @@ public class BackupServiceIntegrationTest {
 
     @Test
     public void shouldReturnBackupRunningSinceValue_inISO8601_format() throws InterruptedException {
-        assertThat(backupService.backupRunningSinceISO8601(), is(nullValue()));
+        assertThat(backupService.backupRunningSinceISO8601(), is(Optional.empty()));
 
         final Semaphore waitForBackupToStart = new Semaphore(1);
         final Semaphore waitForAssertionToCompleteWhileBackupIsOn = new Semaphore(1);
         final BackupUpdateListener backupUpdateListener = new BackupUpdateListener() {
             private boolean backupStarted = false;
             @Override
-            public void updateStep(String message) {
+            public void updateStep(BackupProgressStatus step) {
                 if (!backupStarted) {
                     backupStarted = true;
                     waitForBackupToStart.release();
@@ -345,7 +347,7 @@ public class BackupServiceIntegrationTest {
 
         backupThd.start();
         waitForBackupToStart.acquire();
-        String backupStartedTimeString = backupService.backupRunningSinceISO8601();
+        String backupStartedTimeString = backupService.backupRunningSinceISO8601().get();
         DateTimeFormatter dateTimeFormatter = ISODateTimeFormat.dateTime();
         DateTime backupTime = dateTimeFormatter.parseDateTime(backupStartedTimeString);
 
@@ -357,14 +359,14 @@ public class BackupServiceIntegrationTest {
 
     @Test
     public void shouldReturnBackupStartedBy() throws InterruptedException {
-        assertThat(backupService.backupStartedBy(), is(nullValue()));
+        assertThat(backupService.backupStartedBy(), is(Optional.empty()));
 
         final Semaphore waitForBackupToStart = new Semaphore(1);
         final Semaphore waitForAssertionToCompleteWhileBackupIsOn = new Semaphore(1);
         final BackupUpdateListener backupUpdateListener = new BackupUpdateListener() {
             private boolean backupStarted = false;
             @Override
-            public void updateStep(String message) {
+            public void updateStep(BackupProgressStatus step) {
                 if (!backupStarted) {
                     backupStarted = true;
                     waitForBackupToStart.release();
@@ -391,7 +393,7 @@ public class BackupServiceIntegrationTest {
 
         backupThd.start();
         waitForBackupToStart.acquire();
-        String backupStartedBy = backupService.backupStartedBy();
+        String backupStartedBy = backupService.backupStartedBy().get();
         ServerBackup runningBackup = (ServerBackup) ReflectionUtil.getField(backupService, "runningBackup");
 
         assertThat(runningBackup.getUsername(), is(backupStartedBy));
@@ -533,7 +535,7 @@ public class BackupServiceIntegrationTest {
         FileUtils.deleteQuietly(artifactsDirHolder.getArtifactsDir());
     }
 
-    class MessageCollectingBackupUpdateListener implements BackupUpdateListener{
+    class MessageCollectingBackupUpdateListener implements BackupUpdateListener {
 
         private final List<String> messages;
 
@@ -545,8 +547,8 @@ public class BackupServiceIntegrationTest {
         }
 
         @Override
-        public void updateStep(String message) {
-            messages.add(message);
+        public void updateStep(BackupProgressStatus step) {
+            messages.add(step.getMessage());
         }
 
         public List<String> getMessages() {

--- a/server/webapp/WEB-INF/rails/app/controllers/admin/backup_controller.rb
+++ b/server/webapp/WEB-INF/rails/app/controllers/admin/backup_controller.rb
@@ -21,8 +21,8 @@ class Admin::BackupController < ApplicationController
   def index
     @tab_name = "backup"
     @backup_location = backup_service.backupLocation()
-    @last_backup_time = backup_service.lastBackupTime()
-    @last_backup_user = backup_service.lastBackupUser()
+    @last_backup_time = backup_service.lastBackupTime().orElse(nil)
+    @last_backup_user = backup_service.lastBackupUser().orElse(nil)
     @available_disk_space_on_artifacts_directory = backup_service.availableDiskSpace()
   end
 

--- a/server/webapp/WEB-INF/rails/spec/controllers/admin/backup_controller_spec.rb
+++ b/server/webapp/WEB-INF/rails/spec/controllers/admin/backup_controller_spec.rb
@@ -40,10 +40,10 @@ describe Admin::BackupController do
   describe "index" do
 
     before :each do
-      expect(@backup_service).to receive(:lastBackupTime).and_return(@time = java.util.Date.new)
+      expect(@backup_service).to receive(:lastBackupTime).and_return(@time = java.util.Optional.of(java.util.Date.new))
       expect(@backup_service).to receive(:backupLocation).and_return(@location = "/var/lib/go-server/logs/server-backups")
       expect(@backup_service).to receive(:availableDiskSpace).and_return(@space = "424242")
-      expect(@backup_service).to receive(:lastBackupUser).and_return(@user = "loser")
+      expect(@backup_service).to receive(:lastBackupUser).and_return(@user = java.util.Optional.of("loser"))
     end
 
     it "should populate the tab name" do
@@ -62,13 +62,13 @@ describe Admin::BackupController do
     it "should populate the last backup time" do
       get :index
 
-      expect(assigns[:last_backup_time]).to eq(@time)
+      expect(assigns[:last_backup_time]).to eq(@time.get())
     end
 
     it "should populate the user that triggered the last backup" do
       get :index
 
-      expect(assigns[:last_backup_user]).to eq(@user)
+      expect(assigns[:last_backup_user]).to eq(@user.get())
     end
 
     it "should populate available disk space on artifact directory" do

--- a/server/webapp/WEB-INF/rails/webpack/helpers/spark_routes.ts
+++ b/server/webapp/WEB-INF/rails/webpack/helpers/spark_routes.ts
@@ -218,6 +218,10 @@ export default class {
     return `/go/api/backups`;
   }
 
+  static apiRunningServerBackupsPath() {
+    return `/go/api/backups/running`;
+  }
+
   static apiCurrentAccessTokenPath(id: number) {
     return `/go/api/current_user/access_tokens/${id}`;
   }

--- a/server/webapp/WEB-INF/rails/webpack/models/backups/types.ts
+++ b/server/webapp/WEB-INF/rails/webpack/models/backups/types.ts
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import {Links} from "models/shared/links";
 import {UserJSON} from "../users/users";
 
 export interface ServerBackupJson {
@@ -20,6 +21,7 @@ export interface ServerBackupJson {
   message: string;
   time: Date;
   user: UserJSON;
+  _links: any;
 }
 
 export enum BackupStatus {
@@ -34,17 +36,20 @@ export class ServerBackup {
   readonly message: string;
   readonly time: Date;
   readonly username: string;
+  readonly links: Links;
 
-  constructor(status: BackupStatus, message: string, time: Date, username: string) {
+  constructor(status: BackupStatus, message: string, time: Date, username: string, links: Links) {
     this.status = status;
     this.message = message;
     this.time = time;
     this.username = username;
+    this.links = links;
   }
 
   static fromJSON(serverBackupJson: ServerBackupJson): ServerBackup {
     // @ts-ignore
-    return new ServerBackup(BackupStatus[serverBackupJson.status], serverBackupJson.message, new Date(serverBackupJson.time), serverBackupJson.user.login_name);
+    return new ServerBackup(BackupStatus[serverBackupJson.status], serverBackupJson.message,
+                            new Date(serverBackupJson.time), serverBackupJson.user.login_name, Links.fromJSON(serverBackupJson._links));
   }
 
   isInProgress(): boolean {

--- a/server/webapp/WEB-INF/rails/webpack/models/shared/links.ts
+++ b/server/webapp/WEB-INF/rails/webpack/models/shared/links.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export class Links {
+  readonly self?: string;
+  readonly doc?: string;
+
+  constructor(self?: string, doc?: string) {
+    this.self = self;
+    this.doc  = doc;
+  }
+
+  static fromJSON(links: any) {
+    return new Links(Links.href(links.self), Links.href(links.doc));
+  }
+
+  private static href(link: any) {
+    return link ? link.href : undefined;
+  }
+}

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/backup.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/backup.tsx
@@ -14,9 +14,11 @@
  * limitations under the License.
  */
 
+import {SuccessResponse} from "helpers/api_request_builder";
+import SparkRoutes from "helpers/spark_routes";
 import * as m from "mithril";
 import {ServerBackupAPI} from "models/backups/server_backup_api";
-import {BackupStatus} from "models/backups/types";
+import {BackupStatus, ServerBackup} from "models/backups/types";
 import {BackupWidget} from "views/pages/backup/backup_widget";
 import {ToggleConfirmModal} from "views/pages/maintenance_mode/confirm_modal";
 import {Page} from "./page";
@@ -34,40 +36,32 @@ interface State {
   onPerformBackup: () => void;
 }
 
+const DEFAULT_POLLING_INTERVAL_MILLIS = 5000;
+
 export class BackupPage extends Page<null, State> {
   oninit(vnode: m.Vnode<null, State>) {
     super.oninit(vnode);
-    vnode.state.availableDiskSpace = this.getMeta().availableDiskSpace;
-    vnode.state.lastBackupUser = this.getMeta().lastBackupUser;
-    vnode.state.lastBackupTime = new Date(this.getMeta().lastBackupTime);
-    vnode.state.backupLocation = this.getMeta().backupLocation;
-    vnode.state.backupInProgress = false;
+    vnode.state.availableDiskSpace     = this.getMeta().availableDiskSpace;
+    vnode.state.lastBackupUser         = this.getMeta().lastBackupUser;
+    vnode.state.lastBackupTime         = new Date(this.getMeta().lastBackupTime);
+    vnode.state.backupInProgress       = false;
+    vnode.state.backupLocation         = this.getMeta().backupLocation;
     vnode.state.displayProgressConsole = false;
-    vnode.state.progressMessages = [];
-    vnode.state.backupStatus = BackupStatus.NOT_STARTED;
+    vnode.state.progressMessages       = [];
+    vnode.state.backupStatus           = BackupStatus.NOT_STARTED;
 
     vnode.state.onPerformBackup = () => {
       const message = "Jobs that are building may get rescheduled if the backup process takes a long time. Proceed with backup?";
       const modal   = new ToggleConfirmModal(message, () => {
         modal.close();
         vnode.state.displayProgressConsole = true;
-        vnode.state.progressMessages = [];
-        ServerBackupAPI.start((backup) => {
-          vnode.state.backupStatus = backup.status;
-          this.addProgressMessage(vnode, `${backup.message}...`);
-        }, (backup) => {
-          this.addProgressMessage(vnode, backup.message);
-          vnode.state.backupStatus = backup.status;
-          vnode.state.lastBackupUser = backup.username;
-          vnode.state.lastBackupTime = backup.time;
-        }, (error) => {
-          this.addProgressMessage(vnode, error);
-          vnode.state.backupStatus = BackupStatus.ERROR;
-        });
+        vnode.state.progressMessages       = [];
+        ServerBackupAPI.start(this.onProgress(vnode), this.onCompletion(vnode), this.onError(vnode));
       }, "Server backup confirmation", "Confirm");
       modal.render();
     };
   }
+
   pageName() {
     return "Backup";
   }
@@ -85,8 +79,28 @@ export class BackupPage extends Page<null, State> {
     />;
   }
 
-  fetchData() {
-    return Promise.resolve({});
+  fetchData(vnode: m.Vnode<null, State>) {
+    const onSuccess = (successResponse: SuccessResponse<ServerBackup>) => {
+      vnode.state.backupInProgress       = successResponse.body.getStatus() === BackupStatus.IN_PROGRESS;
+      vnode.state.displayProgressConsole = vnode.state.backupInProgress;
+      vnode.state.progressMessages       = [];
+      vnode.state.backupStatus           = successResponse.body.getStatus();
+      const pollingUrl                   = successResponse.body.links.self || SparkRoutes.apiRunningServerBackupsPath();
+      ServerBackupAPI.startPolling(pollingUrl, DEFAULT_POLLING_INTERVAL_MILLIS, this.onProgress(vnode),
+                                   this.onCompletion(vnode), this.onError(vnode));
+    };
+
+    const onError = () => {
+      vnode.state.backupInProgress       = false;
+      vnode.state.displayProgressConsole = false;
+      vnode.state.progressMessages       = [];
+      vnode.state.backupStatus           = BackupStatus.NOT_STARTED;
+    };
+
+    return ServerBackupAPI.getRunningBackups()
+                          .then((result) => {
+                            result.do(onSuccess, onError);
+                          });
   }
 
   private addProgressMessage(vnode: m.Vnode<null, State>, message: string) {
@@ -94,4 +108,28 @@ export class BackupPage extends Page<null, State> {
       vnode.state.progressMessages.push(message);
     }
   }
+
+  private onError(vnode: m.Vnode<null, State>) {
+    return (error: string) => {
+      this.addProgressMessage(vnode, error);
+      vnode.state.backupStatus = BackupStatus.ERROR;
+    };
+  }
+
+  private onCompletion(vnode: m.Vnode<null, State>) {
+    return (backup: ServerBackup) => {
+      this.addProgressMessage(vnode, backup.message);
+      vnode.state.backupStatus   = backup.status;
+      vnode.state.lastBackupUser = backup.username;
+      vnode.state.lastBackupTime = backup.time;
+    };
+  }
+
+  private onProgress(vnode: m.Vnode<null, State>) {
+    return (backup: ServerBackup) => {
+      vnode.state.backupStatus = backup.status;
+      this.addProgressMessage(vnode, `${backup.message}...`);
+    };
+  }
+
 }

--- a/spark/spark-spa/src/main/java/com/thoughtworks/go/spark/spa/BackupsController.java
+++ b/spark/spark-spa/src/main/java/com/thoughtworks/go/spark/spa/BackupsController.java
@@ -27,6 +27,7 @@ import spark.Response;
 import spark.TemplateEngine;
 
 import java.util.HashMap;
+import java.util.Optional;
 
 import static spark.Spark.*;
 
@@ -66,8 +67,9 @@ public class BackupsController implements SparkController {
 
     private HashMap<String, String> meta() {
         HashMap<String, String> meta = new HashMap<>();
-        meta.put("lastBackupTime", new DateTime(backupService.lastBackupTime()).toString());
-        meta.put("lastBackupUser", backupService.lastBackupUser());
+        Optional<DateTime> dateTime = backupService.lastBackupTime().map(DateTime::new);
+        meta.put("lastBackupTime", dateTime.map(Object::toString).orElse(null));
+        meta.put("lastBackupUser", backupService.lastBackupUser().orElse(null));
         meta.put("availableDiskSpace", backupService.availableDiskSpace());
         meta.put("backupLocation", backupService.backupLocation());
         return meta;


### PR DESCRIPTION
Added `BackupProgressStatus` to monitor the state that the backup progress is in.This info isn't persisted in the DB. The service will prefer to return the runningBackup when possible, to avoid a DB call, and because the progress status isn't saved in the DB. Updated the API to return a `progress_status` field when the backup is in progress.

Added an endpoint `/backups/running` to show the currently running backup. Because if the backup page is refreshed, the page would lose the `id` of the backup that is running. This endpoint provides a way to get a handle on the currently running backup. When the page is refreshed, (or opened in a new tab), it will start polling again for the running backup status. Once it has the `id` from the `self` link, it will start polling on the `id` link instead of `running`.

Note: The polling wasn't using `ajax_poller`, it just uses a setTimeout.
Note: When the page is refreshed, the older backup progress messages are gone. This should be fixed when the UI is updated.

Other changes:
- Fixed the UNDO section of the sql migration 1903001
- Changed some method signatures to return Optional types instead of nulls
- Changed some tests to use assertJ