### PR TITLE
Normalize how URL arguments are split and persisted in SCM configuration

### DIFF
--- a/common/src/test/java/com/thoughtworks/go/domain/materials/DummyMaterial.java
+++ b/common/src/test/java/com/thoughtworks/go/domain/materials/DummyMaterial.java
@@ -20,6 +20,7 @@ import com.thoughtworks.go.config.SecretParams;
 import com.thoughtworks.go.config.materials.ScmMaterial;
 import com.thoughtworks.go.config.materials.SubprocessExecutionContext;
 import com.thoughtworks.go.domain.MaterialInstance;
+import com.thoughtworks.go.security.GoCipher;
 import com.thoughtworks.go.util.command.ConsoleOutputStreamConsumer;
 import com.thoughtworks.go.util.command.UrlArgument;
 
@@ -36,7 +37,7 @@ public final class DummyMaterial extends ScmMaterial {
     private String url;
 
     public DummyMaterial() {
-        super("DummyMaterial");
+        super("DummyMaterial", new GoCipher());
     }
 
     public String getUrl() {
@@ -98,26 +99,6 @@ public final class DummyMaterial extends ScmMaterial {
         throw unsupported();
     }
 
-    public String getUserName() {
-        throw unsupported();
-    }
-
-    @Override
-    public String getPassword() {
-        throw unsupported();
-    }
-
-    @Override
-    public String passwordForCommandLine() {
-        throw unsupported();
-    }
-
-    @Override
-    public String getEncryptedPassword() {
-        throw unsupported();
-    }
-
-
     public boolean isCheckExternals() {
         throw unsupported();
     }
@@ -134,13 +115,4 @@ public final class DummyMaterial extends ScmMaterial {
         throw unsupported();
     }
 
-    @Override
-    public boolean hasSecretParams() {
-        return false;
-    }
-
-    @Override
-    public SecretParams getSecretParams() {
-        return new SecretParams();
-    }
 }

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/SecretParams.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/SecretParams.java
@@ -17,6 +17,7 @@
 package com.thoughtworks.go.config;
 
 import com.thoughtworks.go.config.exceptions.UnresolvedSecretParamException;
+import org.apache.commons.collections4.CollectionUtils;
 
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -86,10 +87,13 @@ public class SecretParams extends ArrayList<SecretParam> implements Serializable
         return secretParams;
     }
 
-    public static SecretParams union(SecretParams list1, SecretParams list2) {
-        final SecretParams newMergedList = new SecretParams(list1.size() + list2.size());
-        newMergedList.addAll(list1);
-        newMergedList.addAll(list2);
+    public static SecretParams union(SecretParams... params) {
+        final SecretParams newMergedList = new SecretParams();
+        for (SecretParams param : params) {
+            if (!CollectionUtils.isEmpty(param)) {
+                newMergedList.addAll(param);
+            }
+        }
         return newMergedList;
     }
 

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/migration/UrlDenormalizerXSLTMigration121.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/migration/UrlDenormalizerXSLTMigration121.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.config.migration;
+
+import org.apache.http.client.utils.URIBuilder;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
+
+public class UrlDenormalizerXSLTMigration121 {
+
+    public static String urlWithoutCredentials(String originalUrl) {
+        try {
+            if (isSupportedUrl(originalUrl)) {
+                String[] credentials = getCredentials(originalUrl);
+                if (credentials != null) {
+
+                    URI url = new URI(originalUrl);
+                    return new URI(url.getScheme(), null, url.getHost(), url.getPort(), url.getPath(), url.getQuery(), url.getFragment()).toString();
+                }
+            }
+            return originalUrl;
+        } catch (URISyntaxException e) {
+            return originalUrl;
+        }
+    }
+
+    public static String urlWithCredentials(String urlWithoutCredentials, String username, String password) {
+        try {
+            if (isSupportedUrl(urlWithoutCredentials)) {
+                String credentials = "";
+                // intentionally not checking `blank` whitespace is still a valid (though unlikely) username/password
+                if (username != null && !username.equals("")) {
+                    credentials += username;
+                }
+
+                if (password != null && !password.equals("")) {
+                    credentials += ":" + password;
+                }
+
+                URI url = new URI(urlWithoutCredentials);
+
+                return new URI(url.getScheme(), credentials.equals("") ? null : credentials, url.getHost(), url.getPort(), url.getPath(), url.getQuery(), url.getFragment()).toString();
+            }
+            return urlWithoutCredentials;
+        } catch (URISyntaxException e) {
+            return urlWithoutCredentials;
+        }
+    }
+
+    public static String getUsername(String originalUrl) {
+        try {
+            if (isSupportedUrl(originalUrl)) {
+                String[] credentials = getCredentials(originalUrl);
+                if (credentials != null) {
+                    if ("".equals(credentials[0])) {
+                        return null;
+                    } else {
+                        return credentials[0];
+                    }
+                }
+            }
+            return null;
+        } catch (URISyntaxException e) {
+            return null;
+        }
+    }
+
+    public static String getPassword(String originalUrl) {
+        try {
+            if (isSupportedUrl(originalUrl)) {
+                String[] credentials = getCredentials(originalUrl);
+                if (credentials != null && credentials.length >= 2) {
+                    if ("".equals(credentials[1])) {
+                        return null;
+                    } else {
+                        return credentials[1];
+                    }
+                }
+            }
+            return null;
+        } catch (URISyntaxException e) {
+            return null;
+        }
+    }
+
+    private static boolean isSupportedUrl(String originalUrl) throws URISyntaxException {
+        if (isNotBlank(originalUrl) && (originalUrl.startsWith("http") || originalUrl.startsWith("https"))) {
+            new URI(originalUrl);
+            return true;
+        }
+
+        return false;
+    }
+
+    private static String[] getCredentials(String originalUrl) throws URISyntaxException {
+
+        String userInfo = new URI(originalUrl).getUserInfo();
+        if (isNotBlank(userInfo)) {
+            return userInfo.split(":", 2);
+        }
+        return null;
+    }
+
+}

--- a/config/config-api/src/main/java/com/thoughtworks/go/domain/materials/TestingMaterialConfig.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/domain/materials/TestingMaterialConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 ThoughtWorks, Inc.
+ * Copyright 2019 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,21 +44,6 @@ public class TestingMaterialConfig extends ScmMaterialConfig {
 
     public void setUrl(String url) {
         this.url = url;
-    }
-
-    @Override
-    public String getUserName() {
-        return null;
-    }
-
-    @Override
-    public String getPassword() {
-        return null;
-    }
-
-    @Override
-    public String getEncryptedPassword() {
-        return null;
     }
 
     @Override

--- a/config/config-api/src/test/java/com/thoughtworks/go/config/materials/DummyMaterialConfig.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/config/materials/DummyMaterialConfig.java
@@ -27,21 +27,6 @@ public class DummyMaterialConfig extends ScmMaterialConfig {
     }
 
     @Override
-    public String getUserName() {
-        return null;
-    }
-
-    @Override
-    public String getPassword() {
-        return null;
-    }
-
-    @Override
-    public String getEncryptedPassword() {
-        return null;
-    }
-
-    @Override
     public boolean isCheckExternals() {
         return false;
     }

--- a/config/config-api/src/test/java/com/thoughtworks/go/config/migration/UrlDenormalizerXSLTMigration121Test.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/config/migration/UrlDenormalizerXSLTMigration121Test.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.config.migration;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+class UrlDenormalizerXSLTMigration121Test {
+
+    @ParameterizedTest
+    @MethodSource("getTestStrings")
+    void shouldReturnNormalizedURl(String expectedUrl, String originalUrl, String expectedUsername, String expectedPassword, String expectedDenormalizedUrl) {
+        String normalizedUrl = UrlDenormalizerXSLTMigration121.urlWithoutCredentials(originalUrl);
+        String username = UrlDenormalizerXSLTMigration121.getUsername(originalUrl);
+        String password = UrlDenormalizerXSLTMigration121.getPassword(originalUrl);
+
+
+        assertThat(normalizedUrl)
+                .isEqualTo(expectedUrl);
+
+        assertThat(username)
+                .isEqualTo(expectedUsername);
+
+        assertThat(password)
+                .isEqualTo(expectedPassword);
+
+        String urlWithCredentials = UrlDenormalizerXSLTMigration121.urlWithCredentials(normalizedUrl, username, password);
+
+        assertThat(urlWithCredentials)
+                .isEqualTo(expectedDenormalizedUrl);
+    }
+
+    private static Stream<Arguments> getTestStrings() {
+        return Stream.of(
+                Arguments.of("https://example.com/xxx", "https://example.com/xxx", null, null, "https://example.com/xxx")
+                , Arguments.of("https://example.com:8443/xxx", "https://example.com:8443/xxx", null, null, "https://example.com:8443/xxx")
+
+                , Arguments.of("https://example.com/yyy", "https://foo@example.com/yyy", "foo", null, "https://foo@example.com/yyy")
+                , Arguments.of("https://example.com/yyy", "https://foo:@example.com/yyy", "foo", null, "https://foo@example.com/yyy")
+                , Arguments.of("https://example.com/yyy", "https://:@example.com/yyy", null, null, "https://example.com/yyy")
+
+                , Arguments.of("https://example.com/yyy", "https://:bar@example.com/yyy", null, "bar", "https://:bar@example.com/yyy")
+                , Arguments.of("https://example.com/yyy", "https://foo:bar@example.com/yyy", "foo", "bar", "https://foo:bar@example.com/yyy")
+                , Arguments.of("https://example.com:8154/aaa", "https://foo@example.com:8154/aaa", "foo", null, "https://foo@example.com:8154/aaa")
+                , Arguments.of("https://example.com:8154/vbb", "https://foo:@example.com:8154/vbb", "foo", null, "https://foo@example.com:8154/vbb")
+                , Arguments.of("https://example.com:8154/ccc", "https://:bar@example.com:8154/ccc", null, "bar", "https://:bar@example.com:8154/ccc")
+                , Arguments.of("https://example.com:8154/eee", "https://foo:bar@example.com:8154/eee", "foo", "bar", "https://foo:bar@example.com:8154/eee")
+                , Arguments.of("https://github.com/gocd/gocd", "https://bobfoo%40example.com:p%40ssw0r&:d@github.com/gocd/gocd", "bobfoo@example.com", "p@ssw0r&:d", "https://bobfoo%40example.com:p%40ssw0r&:d@github.com/gocd/gocd")
+                , Arguments.of("http://github.com/gocd/gocd", "http://bobfoo%40example.com:p%40ssw0r&:d@github.com/gocd/gocd", "bobfoo@example.com", "p@ssw0r&:d", "http://bobfoo%40example.com:p%40ssw0r&:d@github.com/gocd/gocd")
+                , Arguments.of("git@example.com/ddd", "git@example.com/ddd", null, null, "git@example.com/ddd")
+                , Arguments.of("git@example.com:8154/ddd", "git@example.com:8154/ddd", null, null, "git@example.com:8154/ddd")
+                , Arguments.of("https://", "https://", null, null, "https://")
+                , Arguments.of("http://", "http://", null, null, "http://")
+        );
+    }
+
+}

--- a/config/config-server/src/main/resources/cruise-config.xsd
+++ b/config/config-server/src/main/resources/cruise-config.xsd
@@ -18,7 +18,7 @@
 <xsd:schema elementFormDefault="qualified" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <xsd:annotation>
     <xsd:documentation xml:lang="en">
-      Configuration schema for Go. Copyright (c) 2017 ThoughtWorks, Inc.
+      Configuration schema for Go. Copyright (c) 2019 ThoughtWorks, Inc.
       www.thoughtworks.com. All rights reserved.
     </xsd:documentation>
   </xsd:annotation>
@@ -220,11 +220,17 @@
   </xsd:complexType>
   <xsd:complexType name="configRepoGitType">
     <xsd:attribute name="url" type="xsd:string" use="required"/>
+    <xsd:attribute name="username" type="xsd:string"/>
+    <xsd:attribute name="password" type="xsd:string"/>
+    <xsd:attribute name="encryptedPassword" type="xsd:string"/>
     <xsd:attribute name="branch" type="xsd:string" use="optional"/>
     <xsd:attribute name="autoUpdate" type="xsd:boolean" use="optional"/>
   </xsd:complexType>
   <xsd:complexType name="configRepoHgType">
     <xsd:attribute name="url" type="xsd:string" use="required"/>
+    <xsd:attribute name="username" type="xsd:string"/>
+    <xsd:attribute name="password" type="xsd:string"/>
+    <xsd:attribute name="encryptedPassword" type="xsd:string"/>
     <xsd:attribute name="autoUpdate" type="xsd:boolean" use="optional"/>
   </xsd:complexType>
   <xsd:complexType name="configRepoTfsType">
@@ -543,6 +549,9 @@
       <xsd:element name="filter" type="filterType" minOccurs="0" maxOccurs="1"/>
     </xsd:sequence>
     <xsd:attribute name="url" type="xsd:string" use="required"/>
+    <xsd:attribute name="username" type="xsd:string"/>
+    <xsd:attribute name="password" type="xsd:string"/>
+    <xsd:attribute name="encryptedPassword" type="xsd:string"/>
     <xsd:attribute name="dest" type="filePathType" use="optional"/>
     <xsd:attribute name="branch" type="xsd:string" use="optional"/>
     <xsd:attribute name="shallowClone" type="xsd:boolean" use="optional"/>
@@ -555,6 +564,9 @@
       <xsd:element name="filter" type="filterType" minOccurs="0" maxOccurs="1"/>
     </xsd:sequence>
     <xsd:attribute name="url" type="xsd:string" use="required"/>
+    <xsd:attribute name="username" type="xsd:string"/>
+    <xsd:attribute name="password" type="xsd:string"/>
+    <xsd:attribute name="encryptedPassword" type="xsd:string"/>
     <xsd:attribute name="dest" type="filePathType" use="optional"/>
     <xsd:attribute name="materialName" type="nameType" use="optional"/>
     <xsd:attribute name="autoUpdate" type="xsd:boolean" use="optional"/>

--- a/config/config-server/src/main/resources/upgrades/121.xsl
+++ b/config/config-server/src/main/resources/upgrades/121.xsl
@@ -1,0 +1,57 @@
+<?xml version="1.0"?>
+<!--
+  ~ Copyright 2019 ThoughtWorks, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:denormalizer="com.thoughtworks.go.config.migration.UrlDenormalizerXSLTMigration121"
+                version="1.0">
+
+  <xsl:template match="/cruise/@schemaVersion">
+    <xsl:attribute name="schemaVersion">121</xsl:attribute>
+  </xsl:template>
+
+  <!-- Copy everything -->
+  <xsl:template match="@*|node()">
+    <xsl:copy>
+      <xsl:apply-templates select="@*|node()"/>
+    </xsl:copy>
+  </xsl:template>
+
+  <xsl:template match="//materials/git/@url|//materials/hg/@url">
+    <xsl:call-template name="denormalizeUrl">
+      <xsl:with-param name="url" select="."/>
+    </xsl:call-template>
+  </xsl:template>
+
+  <xsl:template name="denormalizeUrl">
+    <xsl:param name="url"/>
+
+    <xsl:attribute name="url"><xsl:value-of select="denormalizer:urlWithoutCredentials($url)"/></xsl:attribute>
+
+    <xsl:variable name="username" select="denormalizer:getUsername($url)"/>
+    <xsl:variable name="password" select="denormalizer:getPassword($url)"/>
+
+    <!-- print username password attributes if non blank -->
+    <xsl:if test="string-length($username) &gt; 0">
+      <xsl:attribute name="username"><xsl:value-of select="$username"/></xsl:attribute>
+    </xsl:if>
+    <xsl:if test="string-length($password) &gt; 0">
+      <xsl:attribute name="password"><xsl:value-of select="$password"/></xsl:attribute>
+    </xsl:if>
+
+  </xsl:template>
+
+</xsl:stylesheet>

--- a/config/config-server/src/test/java/com/thoughtworks/go/config/MagicalGoConfigXmlLoaderTest.java
+++ b/config/config-server/src/test/java/com/thoughtworks/go/config/MagicalGoConfigXmlLoaderTest.java
@@ -3513,7 +3513,7 @@ public class MagicalGoConfigXmlLoaderTest {
     @Test
     public void shouldSerializeJobElasticProfileId() throws Exception {
         String configWithJobElasticProfileId =
-                "<cruise schemaVersion='119'>\n"
+                "<cruise schemaVersion='" + CONFIG_SCHEMA_VERSION + "'>\n"
                         + "  <elastic jobStarvationTimeout=\"10\">\n"
                         + "    <profiles>\n"
                         + "      <profile clusterProfileId='blah' id='unit-test' pluginId='aws'>\n"
@@ -3552,7 +3552,7 @@ public class MagicalGoConfigXmlLoaderTest {
     @Test
     public void shouldSerializeElasticAgentProfiles() throws Exception {
         String configWithElasticProfile =
-                "<cruise schemaVersion='119'>\n"
+                "<cruise schemaVersion='" + CONFIG_SCHEMA_VERSION + "'>\n"
                         + "  <elastic jobStarvationTimeout=\"2\">\n"
                         + "    <profiles>\n"
                         + "      <profile clusterProfileId='blah' id=\"foo\" pluginId=\"docker\">\n"

--- a/domain/src/main/java/com/thoughtworks/go/config/materials/mercurial/HgMaterial.java
+++ b/domain/src/main/java/com/thoughtworks/go/config/materials/mercurial/HgMaterial.java
@@ -16,16 +16,17 @@
 
 package com.thoughtworks.go.config.materials.mercurial;
 
-import com.thoughtworks.go.config.SecretParams;
 import com.thoughtworks.go.config.materials.ScmMaterial;
 import com.thoughtworks.go.config.materials.ScmMaterialConfig;
 import com.thoughtworks.go.config.materials.SubprocessExecutionContext;
+import com.thoughtworks.go.config.migration.UrlDenormalizerXSLTMigration121;
 import com.thoughtworks.go.domain.MaterialInstance;
 import com.thoughtworks.go.domain.materials.*;
 import com.thoughtworks.go.domain.materials.mercurial.HgCommand;
 import com.thoughtworks.go.domain.materials.mercurial.HgMaterialInstance;
 import com.thoughtworks.go.domain.materials.mercurial.HgVersion;
 import com.thoughtworks.go.domain.materials.svn.MaterialUrl;
+import com.thoughtworks.go.security.GoCipher;
 import com.thoughtworks.go.util.GoConstants;
 import com.thoughtworks.go.util.command.*;
 import org.apache.commons.io.FileUtils;
@@ -62,7 +63,7 @@ public class HgMaterial extends ScmMaterial {
     private final String HG_DEFAULT_BRANCH = "default";
 
     private HgMaterial() {
-        super(TYPE);
+        super(TYPE, new GoCipher());
     }
 
     public HgMaterial(String url, String folder) {
@@ -72,7 +73,8 @@ public class HgMaterial extends ScmMaterial {
     }
 
     public HgMaterial(HgMaterialConfig config) {
-        this(config.getUrl(), config.getFolder());
+        this(UrlDenormalizerXSLTMigration121.urlWithCredentials(config.getUrl(), config.getUserName(), config.getPassword()), config.getFolder());
+        this.userName = config.getUserName();
         this.autoUpdate = config.getAutoUpdate();
         this.filter = config.rawFilter();
         this.invertFilter = config.getInvertFilter();
@@ -221,25 +223,6 @@ public class HgMaterial extends ScmMaterial {
         return !MaterialUrl.sameUrl(url.defaultRemoteUrl(), new HgUrlArgument(result.outputAsString()).defaultRemoteUrl());
     }
 
-    public String getUserName() {
-        return null;
-    }
-
-    @Override
-    public String getPassword() {
-        return null;
-    }
-
-    @Override
-    public String passwordForCommandLine() {
-        return null;
-    }
-
-    @Override
-    public String getEncryptedPassword() {
-        return null;
-    }
-
     public boolean isCheckExternals() {
         return false;
     }
@@ -346,13 +329,4 @@ public class HgMaterial extends ScmMaterial {
         return HG_DEFAULT_BRANCH;
     }
 
-    @Override
-    public boolean hasSecretParams() {
-        return this.url != null && url.hasSecretParams();
-    }
-
-    @Override
-    public SecretParams getSecretParams() {
-        return this.url.getSecretParams();
-    }
 }

--- a/domain/src/main/java/com/thoughtworks/go/domain/materials/TestingMaterial.java
+++ b/domain/src/main/java/com/thoughtworks/go/domain/materials/TestingMaterial.java
@@ -20,6 +20,7 @@ import com.thoughtworks.go.config.SecretParams;
 import com.thoughtworks.go.config.materials.ScmMaterial;
 import com.thoughtworks.go.config.materials.SubprocessExecutionContext;
 import com.thoughtworks.go.domain.MaterialInstance;
+import com.thoughtworks.go.security.GoCipher;
 import com.thoughtworks.go.util.command.ConsoleOutputStreamConsumer;
 import com.thoughtworks.go.util.command.UrlArgument;
 import org.joda.time.DateTime;
@@ -41,7 +42,7 @@ public class TestingMaterial extends ScmMaterial {
     private String url;
 
     public TestingMaterial() {
-        super(TYPE);
+        super(TYPE, new GoCipher());
     }
 
     public TestingMaterial(TestingMaterialConfig config) {
@@ -87,25 +88,6 @@ public class TestingMaterial extends ScmMaterial {
 
     public void setUrl(String url) {
         this.url = url;
-    }
-
-    public String getUserName() {
-        return null;
-    }
-
-    @Override
-    public String getPassword() {
-        return null;
-    }
-
-    @Override
-    public String passwordForCommandLine() {
-        return null;
-    }
-
-    @Override
-    public String getEncryptedPassword() {
-        return null;
     }
 
     public boolean isCheckExternals() {
@@ -157,13 +139,4 @@ public class TestingMaterial extends ScmMaterial {
         return new TestingMaterialConfig(url);
     }
 
-    @Override
-    public boolean hasSecretParams() {
-        return false;
-    }
-
-    @Override
-    public SecretParams getSecretParams() {
-        return new SecretParams();
-    }
 }

--- a/domain/src/test/java/com/thoughtworks/go/config/materials/git/GitMaterialTest.java
+++ b/domain/src/test/java/com/thoughtworks/go/config/materials/git/GitMaterialTest.java
@@ -559,7 +559,7 @@ public class GitMaterialTest {
     }
 
     @Nested
-    class getSecretParams {
+    class GetSecretParams {
         @Test
         void shouldReturnAListOfSecretParams() {
             GitMaterial git = new GitMaterial("http://username:{{SECRET:[secret_config_id][lookup_password]}}@foo.com");

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/configrepo/migrator/V5.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/configrepo/migrator/V5.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.plugin.access.configrepo.migrator;
+
+import com.bazaarvoice.jolt.Transform;
+import com.thoughtworks.go.config.migration.UrlDenormalizerXSLTMigration121;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
+
+public class V5 implements Transform {
+    @Override
+    public Object transform(Object input) {
+
+        if (input instanceof Map) {
+            Object pipelines = ((Map) input).get("pipelines");
+            if (pipelines instanceof List) {
+                for (Object pipeline : (List) pipelines) {
+                    doTransformPipeline(pipeline);
+                }
+            }
+        }
+        return input;
+    }
+
+    private void doTransformPipeline(Object mapLike) {
+        if (mapLike instanceof Map) {
+            Map pipeline = (Map) mapLike;
+            Object materials = pipeline.get("materials");
+            if (materials instanceof List) {
+                for (Object material : (List) materials) {
+                    doTransformMaterial(material);
+                }
+
+            }
+        }
+    }
+
+    private void doTransformMaterial(Object mapLike) {
+        if (mapLike instanceof Map) {
+            Map material = (Map) mapLike;
+
+            if ("git".equals(material.get("type")) || "hg".equals(material.get("type"))) {
+                doTransformGitAndHgMaterial(material);
+            }
+        }
+    }
+
+    private void doTransformGitAndHgMaterial(Map<Object, Object> material) {
+        Object maybeUrlString = material.get("url");
+        if (maybeUrlString instanceof String) {
+            String url = (String) maybeUrlString;
+
+            String newUrl = UrlDenormalizerXSLTMigration121.urlWithoutCredentials(url);
+            String username = UrlDenormalizerXSLTMigration121.getUsername(url);
+            String password = UrlDenormalizerXSLTMigration121.getPassword(url);
+
+            material.put("url", newUrl);
+
+            if (isNotBlank(username)) {
+                material.put("username", username);
+            }
+            if (isNotBlank(password)) {
+                material.put("password", password);
+            }
+        }
+    }
+}

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/configrepo/v1/JsonMessageHandler1_0.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/configrepo/v1/JsonMessageHandler1_0.java
@@ -38,7 +38,7 @@ import java.util.Map;
 
 public class JsonMessageHandler1_0 implements JsonMessageHandler {
 
-    static final int CURRENT_CONTRACT_VERSION = 4;
+    static final int CURRENT_CONTRACT_VERSION = 5;
     private static final Logger LOGGER = LoggerFactory.getLogger(JsonMessageHandler1_0.class);
     private final GsonCodec codec;
     private final ConfigRepoMigrator migrator;

--- a/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/configrepo/v2/JsonMessageHandler2_0.java
+++ b/plugin-infra/go-plugin-access/src/main/java/com/thoughtworks/go/plugin/access/configrepo/v2/JsonMessageHandler2_0.java
@@ -49,7 +49,7 @@ import java.util.Map;
  *   - Introduce target_version of 4: Allow display_order_weight at pipeline level.
  */
 public class JsonMessageHandler2_0 implements JsonMessageHandler {
-    static final int CURRENT_CONTRACT_VERSION = 4;
+    static final int CURRENT_CONTRACT_VERSION = 5;
     private static final Logger LOGGER = LoggerFactory.getLogger(JsonMessageHandler2_0.class);
     private final GsonCodec codec;
     private final ConfigRepoMigrator migrator;

--- a/plugin-infra/go-plugin-access/src/main/resources/config-repo/migrations/5.json
+++ b/plugin-infra/go-plugin-access/src/main/resources/config-repo/migrations/5.json
@@ -1,0 +1,18 @@
+[
+  {
+    "operation": "shift",
+    "spec": {
+      "target_version": {
+        "#5": "&1" // Set target version to 5.
+      },
+      "*": "&"
+    }
+  },
+  {
+    "operation": "com.thoughtworks.go.plugin.access.configrepo.migrator.V5",
+    "spec": {
+      "materials": {
+      }
+    }
+  }
+]

--- a/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/configrepo/ConfigRepoDocumentMother.java
+++ b/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/configrepo/ConfigRepoDocumentMother.java
@@ -84,4 +84,12 @@ class ConfigRepoDocumentMother {
     String v4ComprehensiveWithDisplayOrderWeightsOf10AndMinusOne() {
         return JsonUtils.toJsonString(getJSONFor("/v4_comprehensive_with_display_order_weights_of_10_and_minus_one.json"));
     }
+
+    String v4GitMaterialWithCredentialInUrl() {
+        return JsonUtils.toJsonString(getJSONFor("/v4_git_and_hg_material_with_credential_inside_url.json"));
+    }
+
+    String v5GitMaterialWithCredentialNotInUrl() {
+        return JsonUtils.toJsonString(getJSONFor("/v5_git_and_hg_materials_with_denormalized_url.json"));
+    }
 }

--- a/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/configrepo/ConfigRepoMigratorTest.java
+++ b/plugin-infra/go-plugin-access/src/test/java/com/thoughtworks/go/plugin/access/configrepo/ConfigRepoMigratorTest.java
@@ -20,7 +20,6 @@ import org.junit.Before;
 import org.junit.Test;
 
 import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson;
-import static org.assertj.core.api.Assertions.assertThat;
 
 public class ConfigRepoMigratorTest {
     private ConfigRepoMigrator migrator;
@@ -126,6 +125,19 @@ public class ConfigRepoMigratorTest {
         String newJSON = documentMother.v4ComprehensiveWithDisplayOrderWeightsOf10AndMinusOne();
 
         String transformedJSON = migrator.migrate(oldJSON, 4);
+
+        assertThatJson(newJSON).isEqualTo(transformedJSON);
+    }
+
+
+    @Test
+    public void migrateV4ToV5_shouldNormalizeMaterialUrlsForGit() {
+        ConfigRepoDocumentMother documentMother = new ConfigRepoDocumentMother();
+
+        String oldJSON = documentMother.v4GitMaterialWithCredentialInUrl();
+        String newJSON = documentMother.v5GitMaterialWithCredentialNotInUrl();
+
+        String transformedJSON = migrator.migrate(oldJSON, 5);
 
         assertThatJson(newJSON).isEqualTo(transformedJSON);
     }

--- a/plugin-infra/go-plugin-access/src/test/resources/v4_git_and_hg_material_with_credential_inside_url.json
+++ b/plugin-infra/go-plugin-access/src/test/resources/v4_git_and_hg_material_with_credential_inside_url.json
@@ -1,0 +1,53 @@
+{
+  "target_version": "4",
+  "pipelines": [
+    {
+      "name": "firstpipe",
+      "environment_variables": [
+        {
+          "name": "env1",
+          "value": "value1"
+        }
+      ],
+      "lock_behavior": "lockOnFailure",
+      "group": "configrepo-example",
+      "materials": [
+        {
+          "url": "https://bob%40example.com:p%40ssw0rd@github.com/tomzo/gocd-json-config-example.git",
+          "type": "git"
+        },
+        {
+          "url": "https://bob%40example.com:p%40ssw0rd@bitbucket.com/tomzo/gocd-json-config-example.git#my-branch",
+          "type": "hg"
+        }
+      ],
+      "stages": [
+        {
+          "name": "build",
+          "fetch_materials": true,
+          "never_cleanup_artifacts": false,
+          "clean_working_directory": false,
+          "environment_variables": [],
+          "jobs": [
+            {
+              "name": "build",
+              "environment_variables": [],
+              "tabs": [],
+              "resources": [],
+              "artifacts": [],
+              "properties": [],
+              "run_instance_count": null,
+              "timeout": 0,
+              "tasks": [
+                {
+                  "type": "rake"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "errors": []
+}

--- a/plugin-infra/go-plugin-access/src/test/resources/v5_git_and_hg_materials_with_denormalized_url.json
+++ b/plugin-infra/go-plugin-access/src/test/resources/v5_git_and_hg_materials_with_denormalized_url.json
@@ -1,0 +1,57 @@
+{
+  "target_version": "5",
+  "pipelines": [
+    {
+      "name": "firstpipe",
+      "environment_variables": [
+        {
+          "name": "env1",
+          "value": "value1"
+        }
+      ],
+      "lock_behavior": "lockOnFailure",
+      "group": "configrepo-example",
+      "materials": [
+        {
+          "url": "https://github.com/tomzo/gocd-json-config-example.git",
+          "username": "bob@example.com",
+          "password": "p@ssw0rd",
+          "type": "git"
+        },
+        {
+          "url": "https://bitbucket.com/tomzo/gocd-json-config-example.git#my-branch",
+          "username": "bob@example.com",
+          "password": "p@ssw0rd",
+          "type": "hg"
+        }
+      ],
+      "stages": [
+        {
+          "name": "build",
+          "fetch_materials": true,
+          "never_cleanup_artifacts": false,
+          "clean_working_directory": false,
+          "environment_variables": [],
+          "jobs": [
+            {
+              "name": "build",
+              "environment_variables": [],
+              "tabs": [],
+              "resources": [],
+              "artifacts": [],
+              "properties": [],
+              "run_instance_count": null,
+              "timeout": 0,
+              "tasks": [
+                {
+                  "type": "rake"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "errors": []
+}

--- a/server/webapp/WEB-INF/rails/app/presenters/api_v1/admin/pipelines/materials/git_material_representer.rb
+++ b/server/webapp/WEB-INF/rails/app/presenters/api_v1/admin/pipelines/materials/git_material_representer.rb
@@ -19,16 +19,25 @@ module ApiV1
     module Pipelines
       module Materials
         class GitMaterialRepresenter < ScmMaterialRepresenter
+          include EncryptedPasswordSupport
+
           property :branch,
-                   getter: lambda { |args|
+                   getter: lambda {|args|
                      branch = self.getBranch
                      branch.blank? ? 'master' : branch
                    },
-                   setter: lambda { |value, options|
+                   setter: lambda {|value, options|
                      value.blank? ? self.setBranch('master') : self.setBranch(value)
                    }
           property :submodule_folder
           property :shallow_clone
+          property :user_name, as: :username
+          property :password,
+                   skip_render: true,
+                   skip_nil: true,
+                   skip_parse: true
+
+          property :encrypted_password, skip_nil: true, skip_parse: true
         end
       end
     end

--- a/server/webapp/WEB-INF/rails/app/presenters/api_v1/admin/pipelines/materials/hg_material_representer.rb
+++ b/server/webapp/WEB-INF/rails/app/presenters/api_v1/admin/pipelines/materials/hg_material_representer.rb
@@ -19,6 +19,15 @@ module ApiV1
     module Pipelines
       module Materials
         class HgMaterialRepresenter < ScmMaterialRepresenter
+          include EncryptedPasswordSupport
+          
+          property :user_name, as: :username
+          property :password,
+                   skip_render: true,
+                   skip_nil: true,
+                   skip_parse: true
+
+          property :encrypted_password, skip_nil: true, skip_parse: true
         end
       end
     end

--- a/server/webapp/WEB-INF/rails/app/views/admin/materials/git/_form.html.erb
+++ b/server/webapp/WEB-INF/rails/app/views/admin/materials/git/_form.html.erb
@@ -21,6 +21,19 @@
                     <%= error_message_on(scope[:material], com.thoughtworks.go.config.materials.git.GitMaterialConfig::URL, :css_class => "form_error") %>
                 </div>
 
+                <div class="form_item_block">
+                  <label>Username</label>
+                  <%= f.text_field com.thoughtworks.go.config.materials.svn.SvnMaterialConfig::USERNAME, {:class => "form_input username", :id => nil} -%>
+                  <%= error_message_on(scope[:material], com.thoughtworks.go.config.materials.svn.SvnMaterialConfig::USERNAME, :css_class => "form_error") %>
+                </div>
+
+
+                <% if scope[:edit_mode] %>
+                  <%= render :partial => 'admin/materials/shared/password', :locals => {:scope => {:form => f}} %>
+                <% else %>
+                  <%= render :partial => 'admin/materials/shared/plain_password', :locals => {:scope => {:form => f}} %>
+                <% end %>
+
                 <%= render :partial => "admin/materials/shared/options", :locals => {:scope => {:form => f}} %>
 
                 <div class="form_item_block">
@@ -37,7 +50,7 @@
                   <%= error_message_on(f.object, com.thoughtworks.go.config.materials.git.GitMaterialConfig::SHALLOW_CLONE, :css_class => "form_error") %>
                 </div>
 
-                <%= render :partial => 'admin/materials/shared/check_connection', :locals => {:scope => {:url => ".url", :type => "git", :branch => ".branch"}} %>
+                <%= render :partial => 'admin/materials/shared/check_connection', :locals => {:scope => {:url => ".url", :type => "git", :branch => ".branch", :username => ".username", :password => '.password', :encrypted_password => '.encrypted_password'}} %>
                 <div class="clear"></div>
             </div>
             <%= render :partial => 'shared/form_required_message.html', :locals => {:scope => {}} %>

--- a/server/webapp/WEB-INF/rails/app/views/admin/materials/git/edit.html.erb
+++ b/server/webapp/WEB-INF/rails/app/views/admin/materials/git/edit.html.erb
@@ -1,1 +1,1 @@
-<%= render :partial => "form", :locals => {:scope => {:submit_label => 'SAVE', :material => @material, :url => admin_git_update_path, :method => "PUT"}} %>
+<%= render :partial => "form", :locals => {:scope => {:submit_label => 'SAVE', :material => @material, :url => admin_git_update_path, :method => "PUT", :edit_mode => true}} %>

--- a/server/webapp/WEB-INF/rails/app/views/admin/materials/hg/_form.html.erb
+++ b/server/webapp/WEB-INF/rails/app/views/admin/materials/hg/_form.html.erb
@@ -21,10 +21,23 @@
                     <%= error_message_on(scope[:material], com.thoughtworks.go.config.materials.mercurial.HgMaterialConfig::URL, :css_class => "form_error") %>
                 </div>
 
+                <div class="form_item_block">
+                  <label>Username</label>
+                  <%= f.text_field com.thoughtworks.go.config.materials.svn.SvnMaterialConfig::USERNAME, {:class => "form_input username", :id => nil} -%>
+                  <%= error_message_on(scope[:material], com.thoughtworks.go.config.materials.svn.SvnMaterialConfig::USERNAME, :css_class => "form_error") %>
+                </div>
+
+
+                <% if scope[:edit_mode] %>
+                  <%= render :partial => 'admin/materials/shared/password', :locals => {:scope => {:form => f}} %>
+                <% else %>
+                  <%= render :partial => 'admin/materials/shared/plain_password', :locals => {:scope => {:form => f}} %>
+                <% end %>
+
                 <%= render :partial => "admin/materials/shared/options", :locals => {:scope => {:form => f}} %>
 
                 <%= render :partial => 'admin/materials/shared/dest_folder', :locals => {:scope => {:form => f}} %>
-                <%= render :partial => 'admin/materials/shared/check_connection', :locals => {:scope => {:url => ".url", :type => "hg"}} %>
+                <%= render :partial => 'admin/materials/shared/check_connection', :locals => {:scope => {:url => ".url", :type => "hg", :username => ".username", :password => '.password', :encrypted_password => '.encrypted_password'}} %>
                 <div class="clear"></div>
             </div>
             <%= render :partial => 'shared/form_required_message.html', :locals => {:scope => {}} %>

--- a/server/webapp/WEB-INF/rails/app/views/admin/materials/hg/edit.html.erb
+++ b/server/webapp/WEB-INF/rails/app/views/admin/materials/hg/edit.html.erb
@@ -1,1 +1,1 @@
-<%= render :partial => "form", :locals => {:scope => {:submit_label => 'SAVE', :material => @material, :url => admin_hg_update_path, :method => "PUT"}} %>
+<%= render :partial => "form", :locals => {:scope => {:submit_label => 'SAVE', :material => @material, :url => admin_hg_update_path, :method => "PUT", :edit_mode => true}} %>

--- a/util/build.gradle
+++ b/util/build.gradle
@@ -26,6 +26,8 @@ dependencies {
   testRuntimeOnly group: 'org.junit.vintage', name: 'junit-vintage-engine', version: project.versions.junit5
   testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: project.versions.junit5
   testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: project.versions.junit5
+  testCompile group: 'org.junit.jupiter', name: 'junit-jupiter-params', version: project.versions.junit5
   testCompile group: 'org.hamcrest', name: 'hamcrest-core', version: project.versions.hamcrest
   testCompile group: 'org.hamcrest', name: 'hamcrest-library', version: project.versions.hamcrest
+  testCompile group: 'org.assertj', name: 'assertj-core', version: project.versions.assertJ
 }


### PR DESCRIPTION
Issue Link:  #6132

 - Introduces `username`, `password`, `encryptedPassword` attributes on SCM materials that did not support it (git, hg).
- XSL and config repo migrations that grab the credentials from the URL and convert it to relevant username/password attributes for git and hg materials.
- Added `username` and `password` fields on (rails) UI to allow users to enter the respective values.