### PR TITLE
Show the affected pipelines when material update fails.

### DIFF
--- a/common/src/main/java/com/thoughtworks/go/serverhealth/ServerHealthState.java
+++ b/common/src/main/java/com/thoughtworks/go/serverhealth/ServerHealthState.java
@@ -24,7 +24,10 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.joda.time.DateTime;
 
 import java.text.SimpleDateFormat;
-import java.util.*;
+import java.util.Date;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
 
 import static com.thoughtworks.go.util.ExceptionUtils.bombIfNull;
 import static org.apache.commons.lang3.StringEscapeUtils.escapeHtml4;
@@ -87,6 +90,10 @@ public class ServerHealthState {
 
     public static ServerHealthState error(String message, String description, HealthStateType type) {
         return new ServerHealthState(HealthStateLevel.ERROR, type, escapeHtml4(message), escapeHtml4(description));
+    }
+
+    public static ServerHealthState errorWithHtml(String message, String description, HealthStateType type) {
+        return new ServerHealthState(HealthStateLevel.ERROR, type, message, description);
     }
 
     public static ServerHealthState warning(String message, String description, HealthStateType healthStateType, Timeout timeout) {

--- a/common/src/test/java/com/thoughtworks/go/serverhealth/ServerHealthStateTest.java
+++ b/common/src/test/java/com/thoughtworks/go/serverhealth/ServerHealthStateTest.java
@@ -165,4 +165,12 @@ public class ServerHealthStateTest {
         assertThat(warningStateWithTime.getMessage(), is("\"<message1 & message2>\""));
         assertThat(warningStateWithTime.getDescription(), is("\"<message1 & message2>\""));
     }
+
+    @Test
+    public void shouldPreserveHtmlInErrorMessageAndDescription() {
+        ServerHealthState error = ServerHealthState.errorWithHtml("\"<message1 & message2>\"", "\"<message1 & message2>\"", HealthStateType.general(HealthStateScope.forPipeline("foo")));
+
+        assertThat(error.getMessage(), is("\"<message1 & message2>\""));
+        assertThat(error.getDescription(), is("\"<message1 & message2>\""));
+    }
 }

--- a/server/src/main/java/com/thoughtworks/go/server/materials/MaterialUpdateListenerFactory.java
+++ b/server/src/main/java/com/thoughtworks/go/server/materials/MaterialUpdateListenerFactory.java
@@ -21,6 +21,7 @@ import com.thoughtworks.go.server.messaging.GoMessageChannel;
 import com.thoughtworks.go.server.messaging.GoMessageQueue;
 import com.thoughtworks.go.server.perf.MDUPerformanceLogger;
 import com.thoughtworks.go.server.persistence.MaterialRepository;
+import com.thoughtworks.go.server.service.GoConfigService;
 import com.thoughtworks.go.server.service.MaintenanceModeService;
 import com.thoughtworks.go.server.service.MaterialExpansionService;
 import com.thoughtworks.go.server.transaction.TransactionTemplate;
@@ -38,6 +39,7 @@ public class MaterialUpdateListenerFactory {
     private DependencyMaterialUpdateQueue dependencyMaterialQueue;
     private MaintenanceModeService maintenanceModeService;
     private ConfigMaterialPostUpdateQueue configMaterialPostUpdateQueue;
+    private GoConfigService goConfigService;
     private SystemEnvironment systemEnvironment;
     private final ServerHealthService serverHealthService;
     private final GoDiskSpaceMonitor diskSpaceMonitor;
@@ -66,7 +68,8 @@ public class MaterialUpdateListenerFactory {
                                          MDUPerformanceLogger mduPerformanceLogger,
                                          DependencyMaterialUpdateQueue dependencyMaterialQueue,
                                          MaintenanceModeService maintenanceModeService,
-                                         ConfigMaterialPostUpdateQueue configMaterialPostUpdateQueue) {
+                                         ConfigMaterialPostUpdateQueue configMaterialPostUpdateQueue,
+                                         GoConfigService goConfigService) {
         this.topic = topic;
         this.queue = queue;
         this.configQueue = configQueue;
@@ -84,6 +87,7 @@ public class MaterialUpdateListenerFactory {
         this.dependencyMaterialQueue = dependencyMaterialQueue;
         this.maintenanceModeService = maintenanceModeService;
         this.configMaterialPostUpdateQueue = configMaterialPostUpdateQueue;
+        this.goConfigService = goConfigService;
     }
 
     public void init() {
@@ -106,7 +110,7 @@ public class MaterialUpdateListenerFactory {
 
     private void createWorker(GoMessageQueue<MaterialUpdateMessage> queue, GoMessageChannel<MaterialUpdateCompletedMessage> topic) {
         MaterialDatabaseUpdater updater = new MaterialDatabaseUpdater(materialRepository, serverHealthService, transactionTemplate, dependencyMaterialUpdater, scmMaterialUpdater,
-                packageMaterialUpdater, pluggableSCMMaterialUpdater, materialExpansionService);
+                packageMaterialUpdater, pluggableSCMMaterialUpdater, materialExpansionService, goConfigService);
         queue.addListener(new MaterialUpdateListener(topic, updater, mduPerformanceLogger, diskSpaceMonitor, maintenanceModeService));
     }
 }

--- a/server/src/main/java/com/thoughtworks/go/server/service/GoConfigService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/GoConfigService.java
@@ -65,6 +65,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.StringReader;
 import java.util.*;
+import java.util.stream.Stream;
 
 import static com.thoughtworks.go.config.validation.GoConfigValidity.invalid;
 import static com.thoughtworks.go.i18n.LocalizedMessage.*;
@@ -662,6 +663,15 @@ public class GoConfigService implements Initializer, CruiseConfigProvider {
         }
         LOGGER.error("material with fingerprint [{}] not found in pipeline [{}]", pipelineUniqueFingerprint, pipeline);
         return null;
+    }
+
+    public List<CaseInsensitiveString> pipelinesWithMaterial(String fingerprint) {
+        ArrayList<CaseInsensitiveString> pipelineNames = new ArrayList<>();
+        getAllPipelineConfigs().forEach(pipeline -> {
+            pipeline.materialConfigs().stream().filter(materialConfig -> materialConfig.getFingerprint().equals(fingerprint)).findFirst().ifPresent(expectedMaterialConfig -> pipelineNames.add(pipeline.name()));
+
+        });
+        return pipelineNames;
     }
 
     public List<PackageDefinition> getPackages() {

--- a/server/src/test-fast/java/com/thoughtworks/go/server/materials/MaterialDatabaseUpdaterTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/materials/MaterialDatabaseUpdaterTest.java
@@ -20,6 +20,7 @@ import com.thoughtworks.go.config.materials.git.GitMaterial;
 import com.thoughtworks.go.domain.materials.Material;
 import com.thoughtworks.go.helper.MaterialsMother;
 import com.thoughtworks.go.server.persistence.MaterialRepository;
+import com.thoughtworks.go.server.service.GoConfigService;
 import com.thoughtworks.go.server.service.MaterialExpansionService;
 import com.thoughtworks.go.server.transaction.TransactionTemplate;
 import com.thoughtworks.go.serverhealth.HealthStateScope;
@@ -46,6 +47,7 @@ public class MaterialDatabaseUpdaterTest {
     @Mock private PackageMaterialUpdater packageMaterialUpdater;
     @Mock private PluggableSCMMaterialUpdater pluggableSCMMaterialUpdater;
     @Mock private MaterialExpansionService materialExpansionService;
+    @Mock private GoConfigService goConfigService;
 
     private MaterialDatabaseUpdater materialDatabaseUpdater;
 
@@ -53,7 +55,7 @@ public class MaterialDatabaseUpdaterTest {
     public void setUp() throws Exception {
         initMocks(this);
         materialDatabaseUpdater = new MaterialDatabaseUpdater(materialRepository, healthService, transactionTemplate, dependencyMaterialUpdater, scmMaterialUpdater,
-                packageMaterialUpdater, pluggableSCMMaterialUpdater, materialExpansionService);
+                packageMaterialUpdater, pluggableSCMMaterialUpdater, materialExpansionService, goConfigService);
     }
 
     @Test

--- a/server/src/test-fast/java/com/thoughtworks/go/server/materials/MaterialUpdateListenerFactoryTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/materials/MaterialUpdateListenerFactoryTest.java
@@ -20,6 +20,7 @@ import com.thoughtworks.go.server.cronjob.GoDiskSpaceMonitor;
 import com.thoughtworks.go.server.messaging.GoMessageListener;
 import com.thoughtworks.go.server.perf.MDUPerformanceLogger;
 import com.thoughtworks.go.server.persistence.MaterialRepository;
+import com.thoughtworks.go.server.service.GoConfigService;
 import com.thoughtworks.go.server.service.MaintenanceModeService;
 import com.thoughtworks.go.server.service.MaterialExpansionService;
 import com.thoughtworks.go.server.transaction.TransactionTemplate;
@@ -57,6 +58,7 @@ public class MaterialUpdateListenerFactoryTest {
     @Mock private DependencyMaterialUpdateQueue dependencyMaterialQueue;
     @Mock private MaintenanceModeService maintenanceModeService;
     @Mock ConfigMaterialPostUpdateQueue configMaterialPostUpdateQueue;
+    @Mock private GoConfigService goConfigService;
 
     @Before
     public void setUp() throws Exception {
@@ -71,7 +73,7 @@ public class MaterialUpdateListenerFactoryTest {
                 materialRepository, systemEnvironment, healthService, diskSpaceMonitor,
                 transactionTemplate, dependencyMaterialUpdater, scmMaterialUpdater,
                 packageMaterialUpdater, pluggableSCMMaterialUpdater, materialExpansionService, mduPerformanceLogger,
-                dependencyMaterialQueue, maintenanceModeService, configMaterialPostUpdateQueue);
+                dependencyMaterialQueue, maintenanceModeService, configMaterialPostUpdateQueue, goConfigService);
         factory.init();
 
         verify(queue, new Times(NUMBER_OF_CONSUMERS)).addListener(any(GoMessageListener.class));
@@ -85,7 +87,7 @@ public class MaterialUpdateListenerFactoryTest {
                 materialRepository, systemEnvironment, healthService, diskSpaceMonitor,
                 transactionTemplate, dependencyMaterialUpdater, scmMaterialUpdater,
                 packageMaterialUpdater, pluggableSCMMaterialUpdater, materialExpansionService, mduPerformanceLogger,
-                dependencyMaterialQueue, maintenanceModeService, configMaterialPostUpdateQueue);
+                dependencyMaterialQueue, maintenanceModeService, configMaterialPostUpdateQueue, goConfigService);
         factory.init();
 
         verify(configQueue, new Times(NUMBER_OF_CONFIG_CONSUMERS)).addListener(any(GoMessageListener.class));
@@ -101,7 +103,7 @@ public class MaterialUpdateListenerFactoryTest {
                 materialRepository, systemEnvironment, healthService, diskSpaceMonitor,
                 transactionTemplate, dependencyMaterialUpdater, scmMaterialUpdater,
                 packageMaterialUpdater, pluggableSCMMaterialUpdater, materialExpansionService, mduPerformanceLogger,
-                dependencyMaterialQueue, maintenanceModeService, configMaterialPostUpdateQueue);
+                dependencyMaterialQueue, maintenanceModeService, configMaterialPostUpdateQueue, goConfigService);
         factory.init();
 
         verify(dependencyMaterialQueue, new Times(noOfDependencyMaterialCheckListeners)).addListener(any(GoMessageListener.class));

--- a/server/src/test-integration/java/com/thoughtworks/go/server/materials/MaterialDatabaseDependencyUpdaterTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/materials/MaterialDatabaseDependencyUpdaterTest.java
@@ -34,6 +34,7 @@ import com.thoughtworks.go.server.cache.GoCache;
 import com.thoughtworks.go.server.dao.DatabaseAccessHelper;
 import com.thoughtworks.go.server.dao.DependencyMaterialSourceDao;
 import com.thoughtworks.go.server.persistence.MaterialRepository;
+import com.thoughtworks.go.server.service.GoConfigService;
 import com.thoughtworks.go.server.service.MaterialExpansionService;
 import com.thoughtworks.go.server.service.MaterialService;
 import com.thoughtworks.go.server.transaction.TransactionTemplate;
@@ -75,6 +76,7 @@ public class MaterialDatabaseDependencyUpdaterTest {
     @Autowired private LegacyMaterialChecker legacyMaterialChecker;
     @Autowired private SubprocessExecutionContext subprocessExecutionContext;
     @Autowired private MaterialExpansionService materialExpansionService;
+    @Autowired private GoConfigService goConfigService;
 
     protected MaterialDatabaseUpdater updater;
     protected Material material;
@@ -91,7 +93,7 @@ public class MaterialDatabaseDependencyUpdaterTest {
         healthService = Mockito.mock(ServerHealthService.class);
         dependencyMaterialUpdater = new DependencyMaterialUpdater(dependencyMaterialSourceDao, materialRepository);
         scmMaterialUpdater = new ScmMaterialUpdater(materialRepository, legacyMaterialChecker, subprocessExecutionContext, materialService);
-        updater = new MaterialDatabaseUpdater(materialRepository, healthService, transactionTemplate, dependencyMaterialUpdater, scmMaterialUpdater, null, null, materialExpansionService);
+        updater = new MaterialDatabaseUpdater(materialRepository, healthService, transactionTemplate, dependencyMaterialUpdater, scmMaterialUpdater, null, null, materialExpansionService, goConfigService);
     }
 
     @After
@@ -131,7 +133,7 @@ public class MaterialDatabaseDependencyUpdaterTest {
         }
 
         HealthStateType scope = HealthStateType.general(HealthStateScope.forMaterial(dependencyMaterial));
-        ServerHealthState state = ServerHealthState.error("Modification check failed for material: pipeline-name", "Description of error", scope);
+        ServerHealthState state = ServerHealthState.errorWithHtml("Modification check failed for material: pipeline-name <br/> Affected pipelines: []", "Description of error", scope);
         Mockito.verify(healthService).update(state);
     }
 

--- a/server/src/test-integration/java/com/thoughtworks/go/server/materials/MaterialDatabaseUpdaterIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/materials/MaterialDatabaseUpdaterIntegrationTest.java
@@ -69,6 +69,7 @@ public class MaterialDatabaseUpdaterIntegrationTest {
     @Autowired private PackageRepositoryExtension packageRepositoryExtension;
     @Autowired private SCMExtension scmExtension;
     @Autowired private SecretParamResolver secretParamResolver;
+
     @Rule
     public final TemporaryFolder temporaryFolder = new TemporaryFolder();
 
@@ -86,7 +87,7 @@ public class MaterialDatabaseUpdaterIntegrationTest {
         ScmMaterialUpdater scmMaterialUpdater = new ScmMaterialUpdater(materialRepository, materialChecker, subprocessExecutionContext, slowMaterialService);
         transactionTemplateWithInvocationCount = new TransactionTemplateWithInvocationCount(transactionTemplate);
         updater = new MaterialDatabaseUpdater(materialRepository, serverHealthService, transactionTemplateWithInvocationCount, dependencyMaterialUpdater,
-                scmMaterialUpdater, packageMaterialUpdater, pluggableSCMMaterialUpdater, materialExpansionService);
+                scmMaterialUpdater, packageMaterialUpdater, pluggableSCMMaterialUpdater, materialExpansionService, goConfigService);
     }
 
     @After

--- a/server/src/test-integration/java/com/thoughtworks/go/server/materials/TestBaseForDatabaseUpdater.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/materials/TestBaseForDatabaseUpdater.java
@@ -22,6 +22,7 @@ import com.thoughtworks.go.domain.materials.Modification;
 import com.thoughtworks.go.helper.TestRepo;
 import com.thoughtworks.go.server.dao.DatabaseAccessHelper;
 import com.thoughtworks.go.server.persistence.MaterialRepository;
+import com.thoughtworks.go.server.service.GoConfigService;
 import com.thoughtworks.go.server.service.MaterialExpansionService;
 import com.thoughtworks.go.server.transaction.TransactionTemplate;
 import com.thoughtworks.go.serverhealth.ServerHealthService;
@@ -64,13 +65,14 @@ public abstract class TestBaseForDatabaseUpdater {
     @Autowired private DependencyMaterialUpdater dependencyMaterialUpdater;
     @Autowired private ScmMaterialUpdater scmMaterialUpdater;
     @Autowired private MaterialExpansionService materialExpansionService;
+    @Autowired private GoConfigService goConfigService;
 
     protected MaterialDatabaseUpdater updater;
     protected Material material;
 
     @Before public void setUp() throws Exception {
         dbHelper.onSetUp();
-        updater = new MaterialDatabaseUpdater(materialRepository, serverHealthService, transactionTemplate, dependencyMaterialUpdater, scmMaterialUpdater, null, null, materialExpansionService);
+        updater = new MaterialDatabaseUpdater(materialRepository, serverHealthService, transactionTemplate, dependencyMaterialUpdater, scmMaterialUpdater, null, null, materialExpansionService, goConfigService);
         testRepo = repo();
         material = material();
         testRepo.onSetup();

--- a/server/webapp/WEB-INF/rails/webpack/views/components/server_health_summary/server_health_messages_modal.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/components/server_health_summary/server_health_messages_modal.tsx
@@ -58,7 +58,7 @@ export class ServerHealthMessagesModal extends Modal {
     return <li data-test-id={messageId}
                data-test-message-level={message.level.toLowerCase()}
                className={classnames(styles.serverHealthStatus, message.level.toLowerCase())}>
-      <span data-test-class="server-health-message_message" className={styles.message}>{message.message}</span>
+      <span data-test-class="server-health-message_message" className={styles.message}>{m.trust(message.message)}</span>
       <span data-test-class="server-health-message_timestamp"
             className={styles.timestamp}>{TimeFormatter.format(message.time)}</span>
       <p data-test-class="server-health-message_detail" className={styles.detail}>{m.trust(message.detail)}</p>


### PR DESCRIPTION
* This shows all pipelines - local and config repo.

Showing the pipeline names for pipelines for which a user may not have access to view should be alright as its just the pipeline name, imo. 

<img width="937" alt="Screen Shot 2019-04-11 at 9 38 48 PM" src="https://user-images.githubusercontent.com/4715748/56012677-6c1fee00-5ca2-11e9-8e20-93959c5e2abb.png">



