### PR TITLE
Fix NullPointerException during full config save (#5538)

### DIFF
--- a/config/config-api/src/main/java/com/thoughtworks/go/config/elastic/ClusterProfile.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/elastic/ClusterProfile.java
@@ -52,6 +52,7 @@ public class ClusterProfile extends PluginProfile {
 
         if (pluginInfo == null
                 || pluginInfo.getClusterProfileSettings() == null
+                || pluginInfo.getClusterProfileSettings().getConfigurations() == null
                 || pluginInfo.getClusterProfileSettings().getConfiguration(key) == null) {
             return false;
         }


### PR DESCRIPTION
* Config saves were failing will reason null when we have following
  setup:
  - Install a v4 extension based elastic agent plugin
  - Define a cluster profile with some properties belonging to
    that v4 elastic agent plugin.

* In case of full config save, GoCD will try to encrypt secure
  value of plugin specified profiles using
  'PluginProfile.encryptSecureConfigurations'. As the v4 EA plugin
  did not have the capability to read the cluster profile
  configurations, it was failing with null pointer exception.

Fix:
* Verify Configurations exists on cluster profiles, as v4 plugins
  will not support cluster profile configurations.