### PR TITLE
Fix agent status reports links

### DIFF
--- a/server/webapp/WEB-INF/rails/app/controllers/admin/status_reports_controller.rb
+++ b/server/webapp/WEB-INF/rails/app/controllers/admin/status_reports_controller.rb
@@ -37,7 +37,7 @@ module Admin
       @page_header = 'Agent Status Report'
 
       unless valid_params?
-        return render_error_template 'Provide either elastic_agent_id or job_id for Status Report.', 422
+        return render_error_template 'Please provide job_id for Agent Status Report.', 422
       end
 
       @agent_status_report = elastic_agent_plugin_service.getAgentStatusReport(params[:plugin_id], job_identifier, elastic_agent_id)
@@ -50,11 +50,6 @@ module Admin
     def cluster_status
       @view_title = 'Cluster Status Report'
       @page_header = 'Cluster Status Report'
-
-      unless valid_params?
-        return render_error_template 'Provide cluster profile id for Status Report.', 422
-      end
-
       @cluster_status_report = elastic_agent_plugin_service.getClusterStatusReport(params[:plugin_id], params[:cluster_profile_id])
     rescue org.springframework.dao.DataRetrievalFailureException, java.lang.UnsupportedOperationException
       render_error_template "Status Report for plugin with id: #{params[:plugin_id]} for cluster #{params[:cluster_profile_id]} is not found.", 404
@@ -76,7 +71,7 @@ module Admin
     end
 
     def valid_params?
-      !(params[:elastic_agent_id].eql? 'unassigned' and params[:job_id].blank?)
+      !params[:job_id].blank?
     end
 
     def load_plugin_info

--- a/server/webapp/WEB-INF/rails/spec/controllers/admin/status_reports_controller_spec.rb
+++ b/server/webapp/WEB-INF/rails/spec/controllers/admin/status_reports_controller_spec.rb
@@ -286,21 +286,14 @@ describe Admin::StatusReportsController do
       expect(response.response_code).to eq(422)
     end
 
-    it 'should return the status report for an available plugin' do
-      elastic_agent_id = 'elastic_agent_1'
-
-      elastic_agent_plugin_service = instance_double('com.thoughtworks.go.server.service.ElasticAgentPluginService')
-      allow(elastic_agent_plugin_service).to receive(:getAgentStatusReport).with(elastic_plugin_id, nil, elastic_agent_id).and_return('status_report')
-      allow(controller).to receive(:elastic_agent_plugin_service).and_return(elastic_agent_plugin_service)
-
+    it 'should be unprocessable entity when job id is not provided' do
       capabilities = com.thoughtworks.go.plugin.domain.elastic.Capabilities.new(true)
       pluginDescriptor = GoPluginDescriptor.new(elastic_plugin_id, nil, nil, nil, nil, nil)
       ElasticAgentMetadataStore.instance().setPluginInfo(com.thoughtworks.go.plugin.domain.elastic.ElasticAgentPluginInfo.new(pluginDescriptor, nil, nil, nil, nil, capabilities))
 
-      get :agent_status, params: {:plugin_id => elastic_plugin_id, :elastic_agent_id => elastic_agent_id}
+      get :agent_status, params: {:plugin_id => elastic_plugin_id, :elastic_agent_id => '20'}
 
-      expect(response).to be_ok
-      expect(assigns[:agent_status_report]).to eq('status_report')
+      expect(response.response_code).to eq(422)
     end
 
     it 'should be not found if plugin does not support status_report endpoint' do
@@ -389,7 +382,7 @@ describe Admin::StatusReportsController do
 
     it 'should be not found if plugin does not support cluster status_report endpoint' do
       elastic_agent_plugin_service = instance_double('com.thoughtworks.go.server.service.ElasticAgentPluginService')
-      allow(elastic_agent_plugin_service).to receive(:getClusterStatusReport).with(elastic_plugin_id,cluster_profile_id).and_raise(java.lang.UnsupportedOperationException.new)
+      allow(elastic_agent_plugin_service).to receive(:getClusterStatusReport).with(elastic_plugin_id, cluster_profile_id).and_raise(java.lang.UnsupportedOperationException.new)
       allow(controller).to receive(:elastic_agent_plugin_service).and_return(elastic_agent_plugin_service)
 
       capabilities = com.thoughtworks.go.plugin.domain.elastic.Capabilities.new(false, false, false)

--- a/server/webapp/WEB-INF/rails/spec/webpack/views/agents/agent_row_widget_spec.js
+++ b/server/webapp/WEB-INF/rails/spec/webpack/views/agents/agent_row_widget_spec.js
@@ -96,7 +96,7 @@ describe("Agent Row Widget", () => {
     expect(hostname.find('a')[0].href).toContain(`/go/agents/${allAgents.firstAgent().uuid()}/job_run_history`);
   });
 
-  it('should contain link to agent status report page for elastic agents', () => {
+  it('should contain link to job run history page for elastic agents', () => {
     agents(allAgents);
     const model = Stream(true);
     mount(agents().lastAgent(), model, true, true);
@@ -106,7 +106,7 @@ describe("Agent Row Widget", () => {
     const hostname    = $(information[2]).find('.content');
 
     expect(hostname).toHaveText('elastic-agent-hostname');
-    expect(hostname.find('a')[0].href).toContain(`/go/admin/status_reports/${allAgents.lastAgent().elasticPluginId()}/agent/${allAgents.lastAgent().elasticAgentId()}`);
+    expect(hostname.find('a')[0].href).toContain(`/go/agents/${allAgents.lastAgent().uuid()}/job_run_history`);
   });
 
   it('should contain link to job run history page for elastic agents when elastic agent plugin is missing', () => {
@@ -273,9 +273,9 @@ describe("Agent Row Widget", () => {
       "resources":          [
         "firefox"
       ],
-      "environments": [
+      "environments":       [
         {
-          "name": "Dev",
+          "name":   "Dev",
           "origin": {
             "type":   "gocd",
             "_links": {
@@ -338,9 +338,9 @@ describe("Agent Row Widget", () => {
       "resources":          [
         "linux", "java"
       ],
-      "environments": [
+      "environments":       [
         {
-          "name": "staging",
+          "name":   "staging",
           "origin": {
             "type":   "gocd",
             "_links": {
@@ -354,7 +354,7 @@ describe("Agent Row Widget", () => {
           }
         },
         {
-          "name": "perf",
+          "name":   "perf",
           "origin": {
             "type":   "gocd",
             "_links": {
@@ -468,9 +468,9 @@ describe("Agent Row Widget", () => {
           }
         },
         "capabilities":     {
-          "supports_plugin_status_report": true,
+          "supports_plugin_status_report":  true,
           "supports_cluster_status_report": true,
-          "supports_agent_status_report": true
+          "supports_agent_status_report":   true
         }
       }
     ]

--- a/server/webapp/WEB-INF/rails/webpack/views/agents/agent_row_widget.js.msx
+++ b/server/webapp/WEB-INF/rails/webpack/views/agents/agent_row_widget.js.msx
@@ -33,10 +33,6 @@ const agentJobHistoryPath = function (uuid) {
   return `/go/agents/${uuid}/job_run_history`;
 };
 
-const agentStatusReportPath = function (elasticPluginId, elasticAgentId) {
-  return `/go/admin/status_reports/${elasticPluginId}/agent/${elasticAgentId}`;
-};
-
 const createBuildDetailsDropDown = function (agent, args) {
   return (
     <BuildDetailsWidget agent={agent}
@@ -44,32 +40,12 @@ const createBuildDetailsDropDown = function (agent, args) {
   );
 };
 
-const supportsAgentStatusReport = function (pluginInfos, pluginId) {
-  if (!pluginInfos || !pluginInfos()) {
-    return false;
-  }
-
-  const pluginInfo = pluginInfos().findById(pluginId);
-  if (pluginInfo) {
-    return pluginInfo.extensions()['elastic-agent'].capabilities().supportsAgentStatusReport();
-  }
-
-  return false;
-};
-
-const getHostnameLink = function (isUserAdmin, agent, pluginInfos) {
+const getHostnameLink = function (isUserAdmin, agent) {
   if (!isUserAdmin) {
     return (<span>{agent.hostname()}</span>);
   }
-  if (!agent.isElasticAgent()) {
-    return (<a href={agentJobHistoryPath(agent.uuid())}>{agent.hostname()}</a>);
-  }
 
-  if (supportsAgentStatusReport(pluginInfos, agent.elasticPluginId())) {
-    return (<a href={agentStatusReportPath(agent.elasticPluginId(), agent.elasticAgentId())}>{agent.hostname()}</a>);
-  } else {
-    return (<a href={agentJobHistoryPath(agent.uuid())}>{agent.hostname()}</a>);
-  }
+  return <a href={agentJobHistoryPath(agent.uuid())}>{agent.hostname()}</a>;
 };
 
 const AgentRowWidget = {
@@ -109,16 +85,16 @@ const AgentRowWidget = {
     const ctrl = vnode.state;
     const args = vnode.attrs;
 
-    const agent           = args.agent;
-    const resources       = joinOrNoneSpecified(agent.resources());
-    const environmentNames    = joinOrNoneSpecified(agent.environmentNames());
-    let agentStatus       = agent.status();
-    const isBuildingAgent = !agent.buildDetails().isEmpty();
-    const isElasticAgent  = agent.isElasticAgent();
-    const pluginInfos     = args.pluginInfos;
+    const agent            = args.agent;
+    const resources        = joinOrNoneSpecified(agent.resources());
+    const environmentNames = joinOrNoneSpecified(agent.environmentNames());
+    let agentStatus        = agent.status();
+    const isBuildingAgent  = !agent.buildDetails().isEmpty();
+    const isElasticAgent   = agent.isElasticAgent();
+    const pluginInfos      = args.pluginInfos;
     let selectAgentCheckbox;
     let elasticAgentIcon;
-    const hostnameLink    = getHostnameLink(args.isUserAdmin, agent, pluginInfos);
+    const hostnameLink     = getHostnameLink(args.isUserAdmin, agent, pluginInfos);
 
     if (isBuildingAgent) {
       agentStatus = <f.link onclick={ctrl.buildDetailsClicked.bind(ctrl, agent.uuid())}


### PR DESCRIPTION
* Make job identifier mandatory as part of agent status report page
* Navigate to job run history page for elastic agents instead of agent status report (#5538)