### PR TITLE
Exclude secrets extension in PluginInfo API response

### DIFF
--- a/api/api-plugin-infos-v5/src/main/java/com/thoughtworks/go/apiv5/plugininfos/representers/ExtensionRepresenterResolver.java
+++ b/api/api-plugin-infos-v5/src/main/java/com/thoughtworks/go/apiv5/plugininfos/representers/ExtensionRepresenterResolver.java
@@ -35,7 +35,7 @@ public class ExtensionRepresenterResolver {
         extensionRepresenter.put("notification", new NotificationPluginInfoRepresenter());
         extensionRepresenter.put("analytics", new AnalyticsPluginInfoRepresenter());
         extensionRepresenter.put("artifact", new ArtifactPluginInfoRepresenter());
-        extensionRepresenter.put("secrets", new SecretsExtensionRepresenter());
+//        extensionRepresenter.put("secrets", new SecretsExtensionRepresenter());
     }
 
     static ExtensionRepresenter resolveRepresenterFor(PluginInfo extension) {

--- a/server/src/main/java/com/thoughtworks/go/server/service/plugins/builder/DefaultPluginInfoFinder.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/plugins/builder/DefaultPluginInfoFinder.java
@@ -26,7 +26,6 @@ import com.thoughtworks.go.plugin.access.notification.NotificationMetadataStore;
 import com.thoughtworks.go.plugin.access.packagematerial.PackageMaterialMetadataStore;
 import com.thoughtworks.go.plugin.access.pluggabletask.PluggableTaskMetadataStore;
 import com.thoughtworks.go.plugin.access.scm.NewSCMMetadataStore;
-import com.thoughtworks.go.plugin.access.secrets.SecretsMetadataStore;
 import com.thoughtworks.go.plugin.domain.artifact.ArtifactPluginInfo;
 import com.thoughtworks.go.plugin.domain.common.CombinedPluginInfo;
 import com.thoughtworks.go.plugin.domain.common.PluginInfo;
@@ -60,7 +59,7 @@ public class DefaultPluginInfoFinder {
         builders.put(ANALYTICS_EXTENSION, AnalyticsMetadataStore.instance());
         builders.put(CONFIG_REPO_EXTENSION, ConfigRepoMetadataStore.instance());
         builders.put(ARTIFACT_EXTENSION, ArtifactMetadataStore.instance());
-        builders.put(SECRETS_EXTENSION, SecretsMetadataStore.instance());
+//        builders.put(SECRETS_EXTENSION, SecretsMetadataStore.instance());
     }
 
     public CombinedPluginInfo pluginInfoFor(String pluginId) {


### PR DESCRIPTION
This is to hide secrets extension from current release.