### PR TITLE
Error message for status report of non-existent cluster profile

### DIFF
--- a/server/src/main/java/com/thoughtworks/go/server/service/ElasticAgentPluginService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/ElasticAgentPluginService.java
@@ -20,6 +20,7 @@ import com.google.common.collect.Sets;
 import com.thoughtworks.go.config.elastic.ClusterProfile;
 import com.thoughtworks.go.config.elastic.ClusterProfiles;
 import com.thoughtworks.go.config.elastic.ElasticProfile;
+import com.thoughtworks.go.config.exceptions.RecordNotFoundException;
 import com.thoughtworks.go.domain.AgentInstance;
 import com.thoughtworks.go.domain.JobIdentifier;
 import com.thoughtworks.go.domain.JobInstance;
@@ -232,6 +233,9 @@ public class ElasticAgentPluginService {
         final ElasticAgentPluginInfo pluginInfo = elasticAgentMetadataStore.getPluginInfo(pluginId);
         if (pluginInfo.getCapabilities().supportsClusterStatusReport()) {
             ClusterProfile clusterProfile = clusterProfilesService.getPluginProfiles().findByPluginIdAndProfileId(pluginId, clusterProfileId);
+            if (clusterProfile == null) {
+                throw new RecordNotFoundException(String.format("Cluster profile with id: '%s' is not found.", clusterProfileId));
+            }
             return elasticAgentPluginRegistry.getClusterStatusReport(pluginId, clusterProfile.getConfigurationAsMap(true));
         }
 

--- a/server/src/test-fast/java/com/thoughtworks/go/server/service/ElasticAgentPluginServiceTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/service/ElasticAgentPluginServiceTest.java
@@ -21,6 +21,7 @@ import com.thoughtworks.go.config.PluginProfiles;
 import com.thoughtworks.go.config.elastic.ClusterProfile;
 import com.thoughtworks.go.config.elastic.ClusterProfiles;
 import com.thoughtworks.go.config.elastic.ElasticProfile;
+import com.thoughtworks.go.config.exceptions.RecordNotFoundException;
 import com.thoughtworks.go.domain.*;
 import com.thoughtworks.go.helper.AgentInstanceMother;
 import com.thoughtworks.go.helper.GoConfigMother;
@@ -387,6 +388,20 @@ class ElasticAgentPluginServiceTest {
         assertThat(exception.getMessage()).isEqualTo("Plugin does not support cluster status report.");
 
 
+    }
+
+    @Test
+    void shouldErrorOutWhenClusterProfileNotFound() {
+        final Capabilities capabilities = new Capabilities(true, true, false);
+        final GoPluginDescriptor descriptor = new GoPluginDescriptor("cd.go.example.plugin", null, null, null, null, false);
+        elasticAgentMetadataStore.setPluginInfo(new ElasticAgentPluginInfo(descriptor, null, null, null, null, capabilities));
+        ClusterProfile clusterProfile = new ClusterProfile("cluster-profile-id", "cd.go.example.plugin");
+        clusterProfile.addNewConfigurationWithValue("go-server-url", "server-url", false);
+        PluginProfiles<ClusterProfile> clusterProfiles = new ClusterProfiles(clusterProfile);
+        when(clusterProfilesService.getPluginProfiles()).thenReturn(clusterProfiles);
+
+        final RecordNotFoundException exception = assertThrows(RecordNotFoundException.class, () -> service.getClusterStatusReport("cd.go.example.plugin", "test"));
+        assertThat(exception.getMessage()).isEqualTo("Cluster profile with id: 'test' is not found.");
     }
 
     @Nested


### PR DESCRIPTION
Throw 'RecordNotFoundException' while generating a cluster profile status report for non-existent cluster profile