### PR TITLE
Fix version updater check to show notification only when newer version is avalialble (#6142)

### DIFF
--- a/base/src/main/java/com/thoughtworks/go/CurrentGoCDVersion.java
+++ b/base/src/main/java/com/thoughtworks/go/CurrentGoCDVersion.java
@@ -30,6 +30,7 @@ public class CurrentGoCDVersion {
     private final String copyrightYear;
     private final String baseDocsUrl;
     private final String baseApiDocsUrl;
+    private final String gocdDistVersion;
 
     private CurrentGoCDVersion() {
         try (InputStream in = getClass().getClassLoader().getResourceAsStream("gocd-version.properties")) {
@@ -42,6 +43,7 @@ public class CurrentGoCDVersion {
             this.fullVersion = properties.getProperty("fullVersion", "unknown");
             this.copyrightYear = properties.getProperty("copyrightYear", "unknown");
             this.formatted = String.format("%s (%s-%s)", goVersion, distVersion, gitRevision);
+            this.gocdDistVersion = String.format("%s-%s", goVersion, distVersion);
             this.baseDocsUrl = "https://docs.gocd.org/" + this.goVersion;
             this.baseApiDocsUrl = "https://api.gocd.org/" + this.goVersion;
         } catch (IOException e) {
@@ -75,6 +77,10 @@ public class CurrentGoCDVersion {
 
     public String baseDocsUrl() {
         return baseDocsUrl;
+    }
+
+    public String getGocdDistVersion() {
+        return gocdDistVersion;
     }
 
     public String baseApiDocsUrl() {

--- a/server/webapp/WEB-INF/rails/app/helpers/application_helper.rb
+++ b/server/webapp/WEB-INF/rails/app/helpers/application_helper.rb
@@ -244,6 +244,10 @@ module ApplicationHelper
     security_service.isAuthorizedToViewTemplates(current_user)
   end
 
+  def current_gocd_version
+    com.thoughtworks.go.CurrentGoCDVersion.getInstance().getGocdDistVersion()
+  end
+
   def is_pipeline_editable? pipeline_name
     go_config_service.isPipelineEditable(pipeline_name.to_s)
   end

--- a/server/webapp/WEB-INF/rails/app/views/layouts/single_page_app.html.erb
+++ b/server/webapp/WEB-INF/rails/app/views/layouts/single_page_app.html.erb
@@ -24,6 +24,7 @@
 </head>
 
 <body data-controller-name="<%= controller_name %>"
+      data-current-gocd-version="<%= com.thoughtworks.go.CurrentGoCDVersion.getInstance().getGocdDistVersion() %>"
       data-action-name="<%= action_name %>"
       id="<%= controller_name %>-page" <%= render "shared/body_data_attrs" %>>
 <div class="page-wrap">

--- a/server/webapp/WEB-INF/rails/app/views/shared/_body_data_attrs.html.erb
+++ b/server/webapp/WEB-INF/rails/app/views/shared/_body_data_attrs.html.erb
@@ -1,4 +1,5 @@
 data-is-user-admin="<%= is_user_an_admin? %>"
+data-current-gocd-version="<%= current_gocd_version %>"
 data-can-user-view-admin="<%= can_view_admin_page? %>"
 data-is-user-group-admin="<%= is_user_a_group_admin? %>"
 data-can-user-view-templates="<%= is_user_authorized_to_view_templates? %>"

--- a/server/webapp/WEB-INF/rails/webpack/models/notifications/system_notifications.ts
+++ b/server/webapp/WEB-INF/rails/webpack/models/notifications/system_notifications.ts
@@ -113,9 +113,13 @@ export class SystemNotifications {
     const existingArrayPrototype = (Array.prototype as any).toJSON;
     delete (Array.prototype as any).toJSON;
 
-    localStorage.setItem("system_notifications", JSON.stringify(systemNotifications.toJSON()));
+    SystemNotifications.setNotifications(systemNotifications);
 
     (Array.prototype as any).toJSON = existingArrayPrototype;
+  }
+
+  static setNotifications(notifications: SystemNotifications) {
+    localStorage.setItem("system_notifications", JSON.stringify(notifications.toJSON()));
   }
 
   //model_mixin method

--- a/server/webapp/WEB-INF/rails/webpack/models/shared/version_updater.ts
+++ b/server/webapp/WEB-INF/rails/webpack/models/shared/version_updater.ts
@@ -44,12 +44,27 @@ interface LatestVersion {
 }
 
 export class VersionUpdater {
+  public static readonly CURRENT_GOCD_VERSION_KEY: string = "current-gocd-version";
+
   static update() {
+    const gocdVersionFromLocalStorage  = localStorage.getItem(this.CURRENT_GOCD_VERSION_KEY);
+    const installedGoCDVersion: string = document.body.getAttribute("data-current-gocd-version")!;
+
+    if (gocdVersionFromLocalStorage !== installedGoCDVersion) {
+      localStorage.setItem(VersionUpdater.CURRENT_GOCD_VERSION_KEY, installedGoCDVersion);
+      SystemNotifications.all().then((notifications: SystemNotifications) => {
+        notifications.remove((notification) => (notification.type === "UpdateCheck"));
+        SystemNotifications.setNotifications(notifications);
+      });
+    }
+
     if (VersionUpdater.canUpdateVersion()) {
       VersionUpdater.fetchStaleVersionInfo().then((data: StaleVersionInfo | {}) => {
         _.isEmpty(data) ? VersionUpdater.markUpdateDoneAndNotify() : VersionUpdater.fetchLatestVersion(data as StaleVersionInfo);
       });
     }
+
+    return Promise.resolve();
   }
 
   private static fetchStaleVersionInfo() {

--- a/server/webapp/WEB-INF/vm/shared/_header.vm
+++ b/server/webapp/WEB-INF/vm/shared/_header.vm
@@ -58,6 +58,7 @@
     #end
 <body
   data-is-user-admin="$userHasAdministratorRights"
+  data-current-gocd-version="$currentGoCDVersion.getGocdDistVersion()"
   data-can-user-view-admin="$userHasViewAdministratorRights"
   data-is-user-group-admin="$userHasGroupAdministratorRights"
   data-can-user-view-templates="$userHasTemplateViewUserRights"

--- a/spark/spark-spa/src/main/java/com/thoughtworks/go/spark/spa/spring/InitialContextProvider.java
+++ b/spark/spark-spa/src/main/java/com/thoughtworks/go/spark/spa/spring/InitialContextProvider.java
@@ -59,6 +59,7 @@ public class InitialContextProvider {
 
     public Map<String, Object> getContext(Map<String, Object> modelMap, Class<? extends SparkController> controller, String viewName) {
         HashMap<String, Object> context = new HashMap<>(modelMap);
+        context.put("currentGoCDVersion", CurrentGoCDVersion.getInstance().getGocdDistVersion());
         context.put("railsAssetsService", railsAssetsService);
         context.put("webpackAssetsService", webpackAssetsService);
         context.put("securityService", securityService);

--- a/spark/spark-spa/src/main/java/freemarker_implicit.ftl
+++ b/spark/spark-spa/src/main/java/freemarker_implicit.ftl
@@ -1,6 +1,7 @@
 [#ftl]
 [#-- @implicitly included --]
 [#-- @ftlvariable name="enableAdminAccessTokensSPA" type="boolean" --]
+[#-- @ftlvariable name="currentGoCDVersion" type="java.lang.String" --]
 [#-- @ftlvariable name="controllerName" type="java.lang.String" --]
 [#-- @ftlvariable name="currentUser" type="com.thoughtworks.go.server.domain.Username" --]
 [#-- @ftlvariable name="currentVersion" type="com.thoughtworks.go.CurrentGoCDVersion" --]

--- a/spark/spark-spa/src/main/resources/freemarker/layouts/component_layout.ftlh
+++ b/spark/spark-spa/src/main/resources/freemarker/layouts/component_layout.ftlh
@@ -38,6 +38,7 @@
 
 <body id="${controllerName}-page" class="component-layout-body"
       data-controller-name="${controllerName}"
+      data-current-gocd-version="${currentGoCDVersion}"
       data-is-user-admin="${securityService.isUserAdmin(currentUser)?c}"
       data-can-user-view-admin="${securityService.canViewAdminPage(currentUser)?c}"
       data-is-user-group-admin="${securityService.isUserGroupAdmin(currentUser)?c}"

--- a/spark/spark-spa/src/main/resources/freemarker/layouts/single_page_app.ftlh
+++ b/spark/spark-spa/src/main/resources/freemarker/layouts/single_page_app.ftlh
@@ -43,6 +43,7 @@
 
 <body id="${controllerName}-page"
       data-controller-name="${controllerName}"
+      data-current-gocd-version="${currentGoCDVersion}"
       data-is-user-admin="${securityService.isUserAdmin(currentUser)?c}"
       data-can-user-view-admin="${securityService.canViewAdminPage(currentUser)?c}"
       data-is-user-group-admin="${securityService.isUserGroupAdmin(currentUser)?c}"


### PR DESCRIPTION
* GoCD server stores user notifications as part of local storage.
* When a newer gocd version is available, a new system notification
  for newer version is added into the local storage, which gets
  displayed on the header (bell icon)
* But, if the user doesnt read the notification and upgrades GoCD
  instance, the stale system notification from the local storage will
  be diplayed.

* The system notification for an upgrade is added based on comparision
  between currently installed GoCD version and newly available GoCD version.
* If the currently installed GoCD version and the version for which update
  notification was added are different, then its a stale notification and
  such notification is removed.