### PR TITLE
Initial cut of replacing X509 with simpler HTTP authentication.

### DIFF
--- a/agent/src/main/resources/applicationContext.xml
+++ b/agent/src/main/resources/applicationContext.xml
@@ -44,10 +44,7 @@
   <bean id="buildLoopServer" class="com.thoughtworks.go.agent.service.HttpInvokerProxyFactoryWrapper"
         p:serviceInterface="com.thoughtworks.go.remote.BuildRepositoryRemote">
     <property name="httpInvokerRequestExecutor">
-      <bean class="com.thoughtworks.go.agent.GoHttpClientHttpInvokerRequestExecutor">
-        <constructor-arg ref="httpClient"/>
-        <constructor-arg ref="systemEnvironment"/>
-      </bean>
+      <bean class="com.thoughtworks.go.agent.GoHttpClientHttpInvokerRequestExecutor" autowire="constructor" />
     </property>
   </bean>
 

--- a/server/src/main/java/com/thoughtworks/go/server/newsecurity/filters/X509AuthenticationFilter.java
+++ b/server/src/main/java/com/thoughtworks/go/server/newsecurity/filters/X509AuthenticationFilter.java
@@ -16,12 +16,14 @@
 
 package com.thoughtworks.go.server.newsecurity.filters;
 
+import com.thoughtworks.go.server.newsecurity.models.AgentToken;
 import com.thoughtworks.go.server.newsecurity.models.AuthenticationToken;
 import com.thoughtworks.go.server.newsecurity.models.X509Credential;
 import com.thoughtworks.go.server.newsecurity.utils.SessionUtils;
 import com.thoughtworks.go.server.newsecurity.x509.CachingSubjectDnX509PrincipalExtractor;
 import com.thoughtworks.go.server.security.GoAuthority;
 import com.thoughtworks.go.server.security.userdetail.GoUserPrinciple;
+import com.thoughtworks.go.server.service.GoConfigService;
 import com.thoughtworks.go.util.Clock;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -29,12 +31,19 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
 import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
 import java.security.cert.X509Certificate;
+
+import static org.apache.commons.codec.binary.Base64.encodeBase64String;
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 @Component
 public class X509AuthenticationFilter extends OncePerRequestFilter {
@@ -42,10 +51,13 @@ public class X509AuthenticationFilter extends OncePerRequestFilter {
 
     private static final String X509_HEADER_KEY = "javax.servlet.request.X509Certificate";
     private final CachingSubjectDnX509PrincipalExtractor subjectDnX509PrincipalExtractor;
+    private final GoConfigService goConfigService;
     private final Clock clock;
+    private Mac mac;
 
     @Autowired
-    public X509AuthenticationFilter(Clock clock) {
+    public X509AuthenticationFilter(GoConfigService goConfigService, Clock clock) {
+        this.goConfigService = goConfigService;
         this.clock = clock;
         this.subjectDnX509PrincipalExtractor = new CachingSubjectDnX509PrincipalExtractor();
     }
@@ -54,7 +66,15 @@ public class X509AuthenticationFilter extends OncePerRequestFilter {
     protected void doFilterInternal(HttpServletRequest request,
                                     HttpServletResponse response,
                                     FilterChain filterChain) throws ServletException, IOException {
-        final X509Certificate x509Certificate = extractClientCertificate(request);
+        if (headersMatchForAgent(request)) {
+            tokenBasedFilter(request, response, filterChain);
+        } else {
+            x509BasedFilter(request, response, filterChain);
+        }
+    }
+
+    private void x509BasedFilter(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws IOException, ServletException {
+        X509Certificate x509Certificate = extractClientCertificate(request);
         if (x509Certificate == null) {
             LOGGER.debug("Denying access, certificate is not provided.");
             response.setStatus(403);
@@ -73,6 +93,66 @@ public class X509AuthenticationFilter extends OncePerRequestFilter {
 
             filterChain.doFilter(request, response);
         }
+    }
+
+    private void tokenBasedFilter(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws IOException, ServletException {
+        String uuid = request.getHeader("X-Agent-GUID");
+        String token = request.getHeader("Authorization");
+
+        if (!goConfigService.hasAgent(uuid)) {
+            LOGGER.debug("Denying access, agent with uuid '{}' is not registered.", uuid);
+            response.setStatus(403);
+            return;
+        }
+
+        AuthenticationToken<?> authenticationToken = SessionUtils.getAuthenticationToken(request);
+        AgentToken agentToken = new AgentToken(uuid, token);
+
+        if (isAuthenticated(agentToken, authenticationToken)) {
+            LOGGER.debug("Agent is already authenticated");
+        } else {
+            if (!hmacOf(uuid).equals(token)) {
+                LOGGER.debug("Denying access, agent with uuid '{}' submitted bad token.", uuid);
+                response.setStatus(403);
+                return;
+            }
+
+            GoUserPrinciple agentUser = new GoUserPrinciple("_go_agent_" + uuid, "", GoAuthority.ROLE_AGENT.asAuthority());
+            AuthenticationToken<AgentToken> authentication = new AuthenticationToken<>(agentUser, agentToken, null, clock.currentTimeMillis(), null);
+
+            LOGGER.debug("Adding agent user to current session and proceeding.");
+            SessionUtils.setAuthenticationTokenAfterRecreatingSession(authentication, request);
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    String hmacOf(String string) {
+        return encodeBase64String(hmac().doFinal(string.getBytes()));
+    }
+
+    private boolean headersMatchForAgent(HttpServletRequest request) {
+        return isNotBlank(request.getHeader("X-Agent-GUID")) && isNotBlank(request.getHeader("Authorization"));
+    }
+
+
+    private boolean isAuthenticated(AgentToken agentToken, AuthenticationToken<?> authenticationToken) {
+        return authenticationToken != null
+                && authenticationToken.getCredentials() instanceof AgentToken
+                && authenticationToken.getCredentials().equals(agentToken);
+    }
+
+    private Mac hmac() {
+        if (mac == null) {
+            try {
+                mac = Mac.getInstance("HmacSHA256");
+                SecretKeySpec secretKey = new SecretKeySpec(goConfigService.serverConfig().getTokenGenerationKey().getBytes(), "HmacSHA256");
+                mac.init(secretKey);
+            } catch (NoSuchAlgorithmException | InvalidKeyException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        return mac;
     }
 
     private boolean isAuthenticated(X509Certificate x509Certificate, AuthenticationToken<?> authenticationToken) {

--- a/server/src/main/java/com/thoughtworks/go/server/newsecurity/models/AgentToken.java
+++ b/server/src/main/java/com/thoughtworks/go/server/newsecurity/models/AgentToken.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.server.newsecurity.models;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+
+@Getter
+@EqualsAndHashCode
+public class AgentToken implements Credentials {
+    private final String uuid;
+    private final String token;
+
+    public AgentToken(String uuid, String token) {
+        this.uuid = uuid;
+        this.token = token;
+    }
+}

--- a/server/src/test-fast/java/com/thoughtworks/go/server/newsecurity/filterchains/AuthenticationFilterChainTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/newsecurity/filterchains/AuthenticationFilterChainTest.java
@@ -103,7 +103,7 @@ public class AuthenticationFilterChainTest {
         @ValueSource(strings = {"/remoting/blah", "/agent-websocket/blah"})
         void shouldAuthenticateAgentUsingX509Certificate(String url) throws IOException, ServletException {
             final Registration registration = createRegistration("blah");
-            final X509AuthenticationFilter x509AuthenticationFilter = new X509AuthenticationFilter(clock);
+            final X509AuthenticationFilter x509AuthenticationFilter = new X509AuthenticationFilter(null, clock);
             final AuthenticationFilterChain authenticationFilterChain = new AuthenticationFilterChain(x509AuthenticationFilter, null, null, null, null, null, null, null);
 
             request = HttpRequestBuilder.GET(url)
@@ -124,7 +124,7 @@ public class AuthenticationFilterChainTest {
             request = HttpRequestBuilder.GET(url)
                     .build();
 
-            final X509AuthenticationFilter x509AuthenticationFilter = new X509AuthenticationFilter(clock);
+            final X509AuthenticationFilter x509AuthenticationFilter = new X509AuthenticationFilter(null, clock);
             final AuthenticationFilterChain authenticationFilterChain = new AuthenticationFilterChain(x509AuthenticationFilter, null, null, null, null, null, null, null);
 
             authenticationFilterChain.doFilter(request, response, filterChain);

--- a/server/src/test-fast/java/com/thoughtworks/go/server/newsecurity/filters/X509AuthenticationFilterTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/newsecurity/filters/X509AuthenticationFilterTest.java
@@ -17,17 +17,27 @@
 package com.thoughtworks.go.server.newsecurity.filters;
 
 import com.thoughtworks.go.ClearSingleton;
-import com.thoughtworks.go.http.mocks.*;
+import com.thoughtworks.go.config.ServerConfig;
+import com.thoughtworks.go.http.mocks.HttpRequestBuilder;
+import com.thoughtworks.go.http.mocks.MockHttpServletRequest;
+import com.thoughtworks.go.http.mocks.MockHttpServletResponse;
+import com.thoughtworks.go.http.mocks.MockHttpSession;
 import com.thoughtworks.go.security.Registration;
 import com.thoughtworks.go.security.X509CertificateGenerator;
+import com.thoughtworks.go.server.newsecurity.models.AccessToken;
+import com.thoughtworks.go.server.newsecurity.models.AgentToken;
 import com.thoughtworks.go.server.newsecurity.models.AuthenticationToken;
 import com.thoughtworks.go.server.newsecurity.models.X509Credential;
 import com.thoughtworks.go.server.newsecurity.utils.SessionUtils;
 import com.thoughtworks.go.server.security.GoAuthority;
 import com.thoughtworks.go.server.security.userdetail.GoUserPrinciple;
+import com.thoughtworks.go.server.service.GoConfigService;
 import com.thoughtworks.go.util.TestingClock;
 import org.junit.Rule;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.migrationsupport.rules.EnableRuleMigrationSupport;
 import org.junit.rules.TemporaryFolder;
 
@@ -42,8 +52,9 @@ import static org.mockito.Mockito.*;
 
 @EnableRuleMigrationSupport
 public class X509AuthenticationFilterTest {
-    @Rule
-    public final TemporaryFolder temporaryFolder = new TemporaryFolder();
+    @TempDir
+    File tempDir;
+    private TemporaryFolder temporaryFolder;
     @Rule
     public final ClearSingleton clearSingleton = new ClearSingleton();
 
@@ -51,83 +62,226 @@ public class X509AuthenticationFilterTest {
     private final FilterChain filterChain = mock(FilterChain.class);
     private final TestingClock clock = new TestingClock();
 
-    @Test
-    void shouldPopulateAgentUserInSession() throws Exception {
-        final Registration registration = createRegistration("blah");
-        final MockHttpServletRequest request = HttpRequestBuilder.GET("/")
-                .withX509(registration.getChain())
-                .build();
-
-        new X509AuthenticationFilter(clock).doFilter(request, response, filterChain);
-
-        final AuthenticationToken authentication = SessionUtils.getAuthenticationToken(request);
-        assertThat(authentication.getUser().getUsername())
-                .isEqualTo("_go_agent_blah");
-        assertThat(authentication.getUser().getAuthorities())
-                .hasSize(1)
-                .contains(GoAuthority.ROLE_AGENT.asAuthority());
-        verify(filterChain).doFilter(request, response);
-        assertThat(response.getStatus()).isEqualTo(200);
+    @BeforeEach
+    void setUp() throws IOException {
+        temporaryFolder = new TemporaryFolder(tempDir);
+        temporaryFolder.create();
     }
 
-    @Test
-    void shouldRejectRequestWith403IfCertificateIsNotProvided() throws Exception {
-        final MockHttpServletRequest request = HttpRequestBuilder.GET("/").build();
-        new X509AuthenticationFilter(clock).doFilter(request, response, filterChain);
 
-        assertThat(SessionUtils.getAuthenticationToken(request)).isNull();
-        verifyZeroInteractions(filterChain);
-        assertThat(response.getStatus()).isEqualTo(403);
+    @Nested
+    class X509 {
+        @Test
+        void shouldPopulateAgentUserInSessionIfUse() throws Exception {
+            final Registration registration = createRegistration("blah");
+            final MockHttpServletRequest request = HttpRequestBuilder.GET("/")
+                    .withX509(registration.getChain())
+                    .build();
+
+            new X509AuthenticationFilter(null, clock).doFilter(request, response, filterChain);
+
+            final AuthenticationToken authentication = SessionUtils.getAuthenticationToken(request);
+            assertThat(authentication.getUser().getUsername())
+                    .isEqualTo("_go_agent_blah");
+            assertThat(authentication.getUser().getAuthorities())
+                    .hasSize(1)
+                    .contains(GoAuthority.ROLE_AGENT.asAuthority());
+            verify(filterChain).doFilter(request, response);
+            assertThat(response.getStatus()).isEqualTo(200);
+        }
+
+        @Test
+        void shouldRejectRequestWith403IfCertificateIsNotProvided() throws Exception {
+            final MockHttpServletRequest request = HttpRequestBuilder.GET("/").build();
+            new X509AuthenticationFilter(null, clock).doFilter(request, response, filterChain);
+
+            assertThat(SessionUtils.getAuthenticationToken(request)).isNull();
+            verifyZeroInteractions(filterChain);
+            assertThat(response.getStatus()).isEqualTo(403);
+        }
+
+        @Test
+        void shouldReauthenticateIfCredentialsAreProvidedInRequestEvenIfRequestWasPreviouslyAuthenticatedAsANormalUser() throws ServletException, IOException {
+            final Registration registration = createRegistration("blah");
+            final MockHttpServletRequest request = HttpRequestBuilder.GET("/")
+                    .withX509(registration.getChain())
+                    .build();
+
+            com.thoughtworks.go.server.newsecurity.SessionUtilsHelper.loginAsRandomUser(request);
+            final HttpSession originalSession = request.getSession(true);
+
+            new X509AuthenticationFilter(null, clock).doFilter(request, response, filterChain);
+
+            final AuthenticationToken authentication = SessionUtils.getAuthenticationToken(request);
+            assertThat(authentication.getUser().getUsername())
+                    .isEqualTo("_go_agent_blah");
+            assertThat(authentication.getUser().getAuthorities())
+                    .hasSize(1)
+                    .contains(GoAuthority.ROLE_AGENT.asAuthority());
+            verify(filterChain).doFilter(request, response);
+            assertThat(response.getStatus()).isEqualTo(200);
+            assertThat(request.getSession(false)).isNotSameAs(originalSession);
+        }
+
+        @Test
+        void shouldReauthenticateIfCredentialsAreProvidedInRequestEvenIfRequestWasPreviouslyAuthenticatedUsingAStolenX509Certificate() throws ServletException, IOException {
+            final Registration registration = createRegistration("good");
+            GoUserPrinciple goodAgentPrinciple = new GoUserPrinciple("_go_agent_good", "");
+            X509Credential x509Credential = new X509Credential(registration.getFirstCertificate());
+            MockHttpSession originalSession = new MockHttpSession();
+            SessionUtils.setAuthenticationTokenWithoutRecreatingSession(new AuthenticationToken<>(goodAgentPrinciple, x509Credential, null, 0, null), HttpRequestBuilder.GET("/dont-care").withSession(originalSession).build());
+
+            final Registration anotherRegistration = createRegistration("reject-me");
+            final MockHttpServletRequest request = HttpRequestBuilder.GET("/")
+                    .withX509(anotherRegistration.getChain())
+                    .withSession(originalSession)
+                    .build();
+
+            new X509AuthenticationFilter(null, clock).doFilter(request, response, filterChain);
+
+            final AuthenticationToken authentication = SessionUtils.getAuthenticationToken(request);
+            assertThat(authentication.getUser().getUsername())
+                    .isEqualTo("_go_agent_reject-me");
+            assertThat(authentication.getUser().getAuthorities())
+                    .hasSize(1)
+                    .contains(GoAuthority.ROLE_AGENT.asAuthority());
+            verify(filterChain).doFilter(request, response);
+            assertThat(response.getStatus()).isEqualTo(200);
+            assertThat(request.getSession(false)).isNotSameAs(originalSession);
+        }
     }
 
-    @Test
-    void shouldReauthenticateIfCredentialsAreProvidedInRequestEvenIfRequestWasPreviouslyAuthenticatedAsANormalUser() throws ServletException, IOException {
-        final Registration registration = createRegistration("blah");
-        final MockHttpServletRequest request = HttpRequestBuilder.GET("/")
-                .withX509(registration.getChain())
-                .build();
+    @Nested
+    class TokenBased {
+        @Test
+        void shouldPopulateAgentUserInSessionIfAgentExistsInConfig() throws Exception {
+            GoConfigService goConfigService = mock(GoConfigService.class);
+            ServerConfig serverConfig = new ServerConfig();
+            serverConfig.ensureTokenGenerationKeyExists();
 
-        com.thoughtworks.go.server.newsecurity.SessionUtilsHelper.loginAsRandomUser(request);
-        final HttpSession originalSession = request.getSession(true);
+            when(goConfigService.serverConfig()).thenReturn(serverConfig);
+            when(goConfigService.hasAgent("blah")).thenReturn(true);
 
-        new X509AuthenticationFilter(clock).doFilter(request, response, filterChain);
+            X509AuthenticationFilter filter = new X509AuthenticationFilter(goConfigService, clock);
 
-        final AuthenticationToken authentication = SessionUtils.getAuthenticationToken(request);
-        assertThat(authentication.getUser().getUsername())
-                .isEqualTo("_go_agent_blah");
-        assertThat(authentication.getUser().getAuthorities())
-                .hasSize(1)
-                .contains(GoAuthority.ROLE_AGENT.asAuthority());
-        verify(filterChain).doFilter(request, response);
-        assertThat(response.getStatus()).isEqualTo(200);
-        assertThat(request.getSession(false)).isNotSameAs(originalSession);
-    }
+            final MockHttpServletRequest request = HttpRequestBuilder.GET("/")
+                    .withHeader("X-Agent-GUID", "blah")
+                    .withHeader("Authorization", filter.hmacOf("blah"))
+                    .build();
 
-    @Test
-    void shouldReauthenticateIfCredentialsAreProvidedInRequestEvenIfRequestWasPreviouslyAuthenticatedUsingAStolenX509Certificate() throws ServletException, IOException {
-        final Registration registration = createRegistration("good");
-        GoUserPrinciple goodAgentPrinciple = new GoUserPrinciple("_go_agent_good", "");
-        X509Credential x509Credential = new X509Credential(registration.getFirstCertificate());
-        MockHttpSession originalSession = new MockHttpSession();
-        SessionUtils.setAuthenticationTokenWithoutRecreatingSession(new AuthenticationToken<>(goodAgentPrinciple, x509Credential, null, 0, null), HttpRequestBuilder.GET("/dont-care").withSession(originalSession).build());
+            filter.doFilter(request, response, filterChain);
 
-        final Registration anotherRegistration = createRegistration("reject-me");
-        final MockHttpServletRequest request = HttpRequestBuilder.GET("/")
-                .withX509(anotherRegistration.getChain())
-                .withSession(originalSession)
-                .build();
+            final AuthenticationToken authentication = SessionUtils.getAuthenticationToken(request);
+            assertThat(authentication.getUser().getUsername())
+                    .isEqualTo("_go_agent_blah");
+            assertThat(authentication.getUser().getAuthorities())
+                    .hasSize(1)
+                    .contains(GoAuthority.ROLE_AGENT.asAuthority());
+            verify(filterChain).doFilter(request, response);
+            assertThat(response.getStatus()).isEqualTo(200);
+        }
 
-        new X509AuthenticationFilter(clock).doFilter(request, response, filterChain);
+        @Test
+        void shouldRejectRequestIfUUIDIsNotInConfig() throws Exception {
+            GoConfigService goConfigService = mock(GoConfigService.class);
+            ServerConfig serverConfig = new ServerConfig();
+            serverConfig.ensureTokenGenerationKeyExists();
 
-        final AuthenticationToken authentication = SessionUtils.getAuthenticationToken(request);
-        assertThat(authentication.getUser().getUsername())
-                .isEqualTo("_go_agent_reject-me");
-        assertThat(authentication.getUser().getAuthorities())
-                .hasSize(1)
-                .contains(GoAuthority.ROLE_AGENT.asAuthority());
-        verify(filterChain).doFilter(request, response);
-        assertThat(response.getStatus()).isEqualTo(200);
-        assertThat(request.getSession(false)).isNotSameAs(originalSession);
+            when(goConfigService.serverConfig()).thenReturn(serverConfig);
+            when(goConfigService.hasAgent("blah")).thenReturn(false);
+
+            X509AuthenticationFilter filter = new X509AuthenticationFilter(goConfigService, clock);
+
+            final MockHttpServletRequest request = HttpRequestBuilder.GET("/")
+                    .withHeader("X-Agent-GUID", "blah")
+                    .withHeader("Authorization", filter.hmacOf("blah"))
+                    .build();
+
+            filter.doFilter(request, response, filterChain);
+
+            final AuthenticationToken authentication = SessionUtils.getAuthenticationToken(request);
+            assertThat(authentication).isNull();
+            verifyZeroInteractions(filterChain);
+            assertThat(response.getStatus()).isEqualTo(403);
+        }
+
+        @Test
+        void shouldRejectRequestWith403IfCredentialsAreBad() throws Exception {
+            GoConfigService goConfigService = mock(GoConfigService.class);
+            ServerConfig serverConfig = new ServerConfig();
+            serverConfig.ensureTokenGenerationKeyExists();
+
+            when(goConfigService.serverConfig()).thenReturn(serverConfig);
+            when(goConfigService.hasAgent("blah")).thenReturn(true);
+
+            X509AuthenticationFilter filter = new X509AuthenticationFilter(goConfigService, clock);
+
+            final MockHttpServletRequest request = HttpRequestBuilder.GET("/")
+                    .withHeader("X-Agent-GUID", "blah")
+                    .withHeader("Authorization", "bad-authorization")
+                    .build();
+
+            filter.doFilter(request, response, filterChain);
+
+            assertThat(SessionUtils.getAuthenticationToken(request)).isNull();
+            verifyZeroInteractions(filterChain);
+            assertThat(response.getStatus()).isEqualTo(403);
+        }
+
+        @Test
+        void shouldReauthenticateIfCredentialsAreProvidedInRequestEvenIfRequestWasPreviouslyAuthenticatedAsANormalUser() throws ServletException, IOException {
+            final Registration registration = createRegistration("blah");
+            final MockHttpServletRequest request = HttpRequestBuilder.GET("/")
+                    .withX509(registration.getChain())
+                    .build();
+
+            com.thoughtworks.go.server.newsecurity.SessionUtilsHelper.loginAsRandomUser(request);
+            final HttpSession originalSession = request.getSession(true);
+
+            new X509AuthenticationFilter(null, clock).doFilter(request, response, filterChain);
+
+            final AuthenticationToken authentication = SessionUtils.getAuthenticationToken(request);
+            assertThat(authentication.getUser().getUsername())
+                    .isEqualTo("_go_agent_blah");
+            assertThat(authentication.getUser().getAuthorities())
+                    .hasSize(1)
+                    .contains(GoAuthority.ROLE_AGENT.asAuthority());
+            verify(filterChain).doFilter(request, response);
+            assertThat(response.getStatus()).isEqualTo(200);
+            assertThat(request.getSession(false)).isNotSameAs(originalSession);
+        }
+
+        @Test
+        void shouldReAuthenticateIfSessionContainsTheSameTokenAsInRequest() throws ServletException, IOException {
+            String uuid = "blah";
+
+            GoConfigService goConfigService = mock(GoConfigService.class);
+            ServerConfig serverConfig = new ServerConfig();
+            serverConfig.ensureTokenGenerationKeyExists();
+
+            when(goConfigService.serverConfig()).thenReturn(serverConfig);
+            when(goConfigService.hasAgent(uuid)).thenReturn(true);
+
+            X509AuthenticationFilter filter = new X509AuthenticationFilter(goConfigService, clock);
+
+            MockHttpSession existingSession = new MockHttpSession();
+            GoUserPrinciple goodAgentPrinciple = new GoUserPrinciple("_go_agent_blah", "");
+            String token = filter.hmacOf(uuid);
+
+            SessionUtils.setAuthenticationTokenWithoutRecreatingSession(new AuthenticationToken<>(goodAgentPrinciple, new AgentToken(uuid, token), null, 0, null), HttpRequestBuilder.GET("/dont-care").withSession(existingSession).build());
+
+            final MockHttpServletRequest request = HttpRequestBuilder.GET("/")
+                    .withHeader("X-Agent-GUID", uuid)
+                    .withHeader("Authorization", token)
+                    .withSession(existingSession)
+                    .build();
+
+            filter.doFilter(request, response, filterChain);
+
+            assertThat(response.getStatus()).isEqualTo(200);
+            verify(filterChain).doFilter(any(), any());
+            assertThat(request.getSession(false)).isSameAs(existingSession);
+        }
     }
 
     private Registration createRegistration(String hostname) throws IOException {


### PR DESCRIPTION
An agent would now be expected to send the following headers:

```
X-Agent-GUID: some-guid
Authorization: token
```

The `token` is the HMAC based token returned to the agent as
part of the agent registration process.