### PR TITLE
UI fixes for elastic profiles page

### DIFF
--- a/server/webapp/WEB-INF/rails/webpack/views/components/buttons/index.scss
+++ b/server/webapp/WEB-INF/rails/webpack/views/components/buttons/index.scss
@@ -72,7 +72,11 @@
 }
 
 .icon-add {
-  border: 10px solid $secondary-bg;
+  @include icon-before($type: $fa-var-plus);
+
+  &:before {
+    margin: 5px 10px 5px -5px;
+  }
 }
 
 .icon-doc {

--- a/server/webapp/WEB-INF/rails/webpack/views/components/key_value_pair/index.scss
+++ b/server/webapp/WEB-INF/rails/webpack/views/components/key_value_pair/index.scss
@@ -76,7 +76,7 @@ $title-element-width: 360px;
 
 .key-value-item {
   display:        flex;
-  padding:        5px;
+  padding:        5px 5px 5px 0;
   border-bottom:  1px dashed $border-color;
   align-content:  center;
   flex-direction: column;

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/elastic_profiles/cluster_profile_widget.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/elastic_profiles/cluster_profile_widget.tsx
@@ -40,7 +40,7 @@ import * as styles from ".//index.scss";
 const classnames = bind(styles);
 export type ClusterProfileOperations = EditOperation<ClusterProfile> & DeleteOperation<string> & AddOperation<void> & CloneOperation<ClusterProfile>;
 
-export interface Attrs extends ElasticProfilesWidgetAttrs{
+export interface Attrs extends ElasticProfilesWidgetAttrs {
   pluginInfos: Stream<Array<PluginInfo<Extension>>>;
   elasticProfiles: ElasticAgentProfiles;
   isUserAnAdmin: boolean;
@@ -164,7 +164,7 @@ export class ClusterProfileWidget extends MithrilComponent<ClusterProfileWidgetA
                                              ]);
     return (
       <div className={styles.clusterProfileDetailsContainer}>
-        <h5 className={classnames(styles.clusterProfileDetailsHeader, {[styles.expanded]: vnode.state.clusterProfileDetailsExpanded()})} onclick={this.toggle.bind(this, vnode)} data-test-id="cluster-profile-details-header">Cluster info </h5>
+        <h5 className={classnames(styles.clusterProfileDetailsHeader, {[styles.expanded]: vnode.state.clusterProfileDetailsExpanded()})} onclick={this.toggle.bind(this, vnode)} data-test-id="cluster-profile-details-header">Cluster configuration</h5>
         <div className={classnames(styles.clusterProfileDetails, {[styles.expanded]: vnode.state.clusterProfileDetailsExpanded()})} data-test-id="cluster-profile-details">
           <KeyValuePair data={clusterProfileDetails}/>
         </div>

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/elastic_profiles/cluster_profile_widget.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/elastic_profiles/cluster_profile_widget.tsx
@@ -1,0 +1,178 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {bind} from "classnames/bind";
+import * as Routes from "gen/ts-routes";
+import {MithrilComponent} from "jsx/mithril-component";
+import * as _ from "lodash";
+import * as m from "mithril";
+import {Stream} from "mithril/stream";
+import * as stream from "mithril/stream";
+import {ClusterProfile, ElasticAgentProfile, ElasticAgentProfiles} from "models/elastic_profiles/types";
+import {Configurations} from "models/shared/configuration";
+import {ExtensionType} from "models/shared/plugin_infos_new/extension_type";
+import {Extension} from "models/shared/plugin_infos_new/extensions";
+import {PluginInfo} from "models/shared/plugin_infos_new/plugin_info";
+import {ButtonIcon} from "views/components/buttons";
+import * as Buttons from "views/components/buttons";
+import {CollapsiblePanel} from "views/components/collapsible_panel";
+import {HeaderIcon} from "views/components/header_icon";
+import * as Icons from "views/components/icons";
+import {IconGroup} from "views/components/icons";
+import {KeyValuePair, KeyValueTitle} from "views/components/key_value_pair";
+import {Attrs as ElasticProfilesWidgetAttrs, ElasticProfilesWidget} from "views/pages/elastic_profiles/elastic_profiles_widget";
+import {AddOperation, CloneOperation, DeleteOperation, EditOperation} from "views/pages/page_operations";
+import * as styles from ".//index.scss";
+
+const classnames = bind(styles);
+export type ClusterProfileOperations = EditOperation<ClusterProfile> & DeleteOperation<string> & AddOperation<void> & CloneOperation<ClusterProfile>;
+
+export interface Attrs extends ElasticProfilesWidgetAttrs{
+  pluginInfos: Stream<Array<PluginInfo<Extension>>>;
+  elasticProfiles: ElasticAgentProfiles;
+  isUserAnAdmin: boolean;
+  clusterProfileOperations: ClusterProfileOperations;
+}
+
+interface ClusterProfileAttrs {
+  clusterProfile: ClusterProfile;
+}
+
+interface State {
+  clusterProfileDetailsExpanded: Stream<boolean>;
+}
+
+type ClusterProfileWidgetAttrs = Attrs & ClusterProfileAttrs;
+
+interface HeaderAttrs {
+  clusterProfileId: string;
+  pluginName: string;
+  image: m.Children;
+}
+
+class ClusterProfileHeaderWidget extends MithrilComponent<HeaderAttrs> {
+  view(vnode: m.Vnode<HeaderAttrs, State>) {
+    const title = <div data-test-id="cluster-profile-name" className={styles.clusterProfileName}><span>{vnode.attrs.clusterProfileId}</span></div>;
+
+    return [
+      <KeyValueTitle title={title} image={vnode.attrs.image}/>,
+      <KeyValuePair inline={true} data={new Map([["Plugin", vnode.attrs.pluginName]])}/>
+    ];
+  }
+}
+
+export class ClusterProfileWidget extends MithrilComponent<ClusterProfileWidgetAttrs, State> {
+  oninit(vnode: m.Vnode<ClusterProfileWidgetAttrs, State>) {
+    vnode.state.clusterProfileDetailsExpanded = stream(false);
+  }
+
+  view(vnode: m.Vnode<ClusterProfileWidgetAttrs, State>) {
+    const filteredElasticAgentProfiles = vnode.attrs.elasticProfiles.filterByClusterProfile(vnode.attrs.clusterProfile.id());
+    const pluginInfo                   = this.pluginInfo(vnode);
+    const pluginImageTag               = ClusterProfileWidget.createImageTag(pluginInfo);
+    const pluginName                   = pluginInfo ? pluginInfo.about.name : "";
+    return <CollapsiblePanel key={vnode.attrs.clusterProfile.id()}
+                             header={<ClusterProfileHeaderWidget clusterProfileId={vnode.attrs.clusterProfile.id()} pluginName={pluginName} image={pluginImageTag}/>}
+                             actions={this.getActionButtons(vnode)}
+                             dataTestId={"cluster-profile-panel"}>
+      {this.getClusterProfileDetails(vnode)}
+      <h4>Elastic Agent Profiles</h4>
+      <ElasticProfilesWidget elasticProfiles={new ElasticAgentProfiles(filteredElasticAgentProfiles)}
+                             pluginInfos={vnode.attrs.pluginInfos}
+                             elasticAgentOperations={vnode.attrs.elasticAgentOperations}
+                             onShowUsages={vnode.attrs.onShowUsages.bind(vnode.attrs)}
+                             isUserAnAdmin={vnode.attrs.isUserAnAdmin}/>
+    </CollapsiblePanel>;
+  }
+
+  private static supportsClusterStatusReport(pluginInfo: PluginInfo<any> | undefined) {
+    if (pluginInfo && pluginInfo.extensionOfType(ExtensionType.ELASTIC_AGENTS)) {
+      const extension = pluginInfo.extensionOfType(ExtensionType.ELASTIC_AGENTS);
+      return extension && extension.capabilities && extension.capabilities.supportsClusterStatusReport;
+    }
+    return false;
+  }
+
+  private static createImageTag(pluginInfo: PluginInfo<any> | undefined) {
+    if (pluginInfo && pluginInfo.imageUrl) {
+      return <HeaderIcon name="Plugin Icon" imageUrl={pluginInfo.imageUrl}/>;
+    }
+    return <HeaderIcon/>;
+  }
+
+  private goToStatusReportPage(statusReportHref: string, event: Event): void {
+    event.stopPropagation();
+    window.location.href = statusReportHref;
+  }
+
+  private getActionButtons(vnode: m.Vnode<ClusterProfileWidgetAttrs>) {
+    const actionButtons = [];
+    const pluginInfo    = this.pluginInfo(vnode);
+    if (pluginInfo != null && ClusterProfileWidget.supportsClusterStatusReport(pluginInfo)) {
+      const statusReportPath: string = Routes.adminClusterStatusReportPath(vnode.attrs.clusterProfile.pluginId(), vnode.attrs.clusterProfile.id());
+
+      actionButtons.push(
+        <Buttons.Secondary onclick={this.goToStatusReportPage.bind(this, statusReportPath)}
+                           data-test-id="status-report-link"
+                           icon={ButtonIcon.DOC}
+                           disabled={!vnode.attrs.isUserAnAdmin || !pluginInfo}>
+          Status Report
+        </Buttons.Secondary>);
+    }
+
+    actionButtons.push(
+      <Buttons.Secondary onclick={(e) => {
+        vnode.attrs.elasticAgentOperations.onAdd(new ElasticAgentProfile("", vnode.attrs.clusterProfile.pluginId(), vnode.attrs.clusterProfile.id(), new Configurations([])), e);
+      }} data-test-id={"new-elastic-agent-profile-button"} disabled={!pluginInfo} icon={ButtonIcon.ADD}>
+        Elastic Agent Profile
+      </Buttons.Secondary>);
+
+    actionButtons.push(<div className={styles.clusterProfileCrudActions}>
+      <IconGroup>
+        <Icons.Edit data-test-id="edit-cluster-profile" onclick={vnode.attrs.clusterProfileOperations.onEdit.bind(this, vnode.attrs.clusterProfile)} disabled={!pluginInfo}/>
+        <Icons.Clone data-test-id="clone-cluster-profile" onclick={vnode.attrs.clusterProfileOperations.onClone.bind(this, vnode.attrs.clusterProfile)} disabled={!pluginInfo}/>
+        <Icons.Delete data-test-id="delete-cluster-profile" onclick={vnode.attrs.clusterProfileOperations.onDelete.bind(this, vnode.attrs.clusterProfile.id())}/>
+      </IconGroup>
+    </div>);
+
+    return actionButtons;
+  }
+
+  private toggle(vnode: m.Vnode<ClusterProfileWidgetAttrs, State>) {
+    vnode.state.clusterProfileDetailsExpanded(!vnode.state.clusterProfileDetailsExpanded());
+  }
+
+  private getClusterProfileDetails(vnode: m.Vnode<ClusterProfileWidgetAttrs, State>) {
+    const clusterProfileProperties = vnode.attrs.clusterProfile.properties() ? vnode.attrs.clusterProfile.properties().asMap() : [];
+    const clusterProfileDetails    = new Map([
+                                               ["Id", vnode.attrs.clusterProfile.id()],
+                                               ["PluginId", vnode.attrs.clusterProfile.pluginId()],
+                                               ...Array.from(clusterProfileProperties)
+                                             ]);
+    return (
+      <div className={styles.clusterProfileDetailsContainer}>
+        <h5 className={classnames(styles.clusterProfileDetailsHeader, {[styles.expanded]: vnode.state.clusterProfileDetailsExpanded()})} onclick={this.toggle.bind(this, vnode)} data-test-id="cluster-profile-details-header">Cluster info </h5>
+        <div className={classnames(styles.clusterProfileDetails, {[styles.expanded]: vnode.state.clusterProfileDetailsExpanded()})} data-test-id="cluster-profile-details">
+          <KeyValuePair data={clusterProfileDetails}/>
+        </div>
+      </div>
+    );
+  }
+
+  private pluginInfo(vnode: m.Vnode<ClusterProfileWidgetAttrs>) {
+    return _.find(vnode.attrs.pluginInfos(), ["id", vnode.attrs.clusterProfile.pluginId()]);
+  }
+}

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/elastic_profiles/cluster_profiles_modals.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/elastic_profiles/cluster_profiles_modals.tsx
@@ -106,7 +106,8 @@ export abstract class BaseClusterProfileModal extends Modal {
       return {id: pluginInfo.id, text: pluginInfo.about.name};
     });
 
-    this.elasticAgentPluginInfo(this.pluginInfo() || this.pluginInfos[0]);
+    const extensionPluginInfo = this.pluginInfo();
+    this.elasticAgentPluginInfo(extensionPluginInfo || this.pluginInfos[0]);
 
     const elasticAgentSettings = this.elasticAgentPluginInfo().extensionOfType(ExtensionType.ELASTIC_AGENTS) as ElasticAgentSettings;
 
@@ -117,7 +118,12 @@ export abstract class BaseClusterProfileModal extends Modal {
                                              configuration={this.clusterProfile().properties()}
                                              key={this.elasticAgentPluginInfo().id}/>;
     } else {
-      alertMessage = <FlashMessage type={MessageType.alert} message={`Can not define Cluster profiles for '${this.clusterProfile().pluginId()}' plugin as it does not support cluster profiles.`}/>;
+      const pluginName = extensionPluginInfo ? extensionPluginInfo.about.name : "";
+      if (this.modalType === ModalType.create) {
+        alertMessage = <FlashMessage type={MessageType.alert} message={`Can not define Cluster profiles for '${pluginName}' plugin as it does not support cluster profiles.`}/>;
+      } else {
+        alertMessage = <FlashMessage type={MessageType.warning} message={`Can not edit Cluster profile for '${pluginName}' plugin as it does not support cluster profiles.`}/>;
+      }
     }
 
     return (
@@ -239,6 +245,7 @@ export class EditClusterProfileModal extends BaseClusterProfileModal {
             this.close();
           },
           (errorResponse) => {
+            this.onError(errorResponse.message);
             this.showErrors(result, errorResponse);
           }
         );
@@ -280,6 +287,7 @@ export class CloneClusterProfileModal extends BaseClusterProfileModal {
                              this.close();
                            },
                            (errorResponse) => {
+                             this.onError(errorResponse.message);
                              this.showErrors(result, errorResponse);
                            }
                          );

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/elastic_profiles/cluster_profiles_widget.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/elastic_profiles/cluster_profiles_widget.tsx
@@ -13,70 +13,26 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {bind} from "classnames/bind";
-import * as Routes from "gen/ts-routes";
 import {MithrilComponent} from "jsx/mithril-component";
-import * as _ from "lodash";
 import * as m from "mithril";
 import {Stream} from "mithril/stream";
-import * as stream from "mithril/stream";
-import {ClusterProfile, ClusterProfiles, ElasticAgentProfile, ElasticAgentProfiles} from "models/elastic_profiles/types";
-import {Configurations} from "models/shared/configuration";
-import {ExtensionType} from "models/shared/plugin_infos_new/extension_type";
+import {ClusterProfiles} from "models/elastic_profiles/types";
 import {Extension} from "models/shared/plugin_infos_new/extensions";
 import {PluginInfo} from "models/shared/plugin_infos_new/plugin_info";
-import {ButtonIcon} from "views/components/buttons";
-import * as Buttons from "views/components/buttons";
-import {CollapsiblePanel} from "views/components/collapsible_panel";
 import {FlashMessage, MessageType} from "views/components/flash_message";
-import {HeaderIcon} from "views/components/header_icon";
-import * as Icons from "views/components/icons";
-import {IconGroup} from "views/components/icons";
-import {KeyValuePair, KeyValueTitle} from "views/components/key_value_pair";
-import {Attrs as ElasticProfilesWidgetAttrs, ElasticProfilesWidget} from "views/pages/elastic_profiles/elastic_profiles_widget";
-import * as styles from "views/pages/elastic_profiles/index.scss";
-import {AddOperation, CloneOperation, DeleteOperation, EditOperation} from "views/pages/page_operations";
-
-const classnames = bind(styles);
-export type ClusterProfileOperations = EditOperation<ClusterProfile> & DeleteOperation<string> & AddOperation<void> & CloneOperation<ClusterProfile>;
+import {ClusterProfileWidget} from "views/pages/elastic_profiles/cluster_profile_widget";
+import {Attrs as ClusterProfileWidgetAttrs} from "views/pages/elastic_profiles/cluster_profile_widget";
 
 interface Attrs {
   pluginInfos: Stream<Array<PluginInfo<Extension>>>;
-  elasticProfiles: ElasticAgentProfiles;
   clusterProfiles: ClusterProfiles;
-  isUserAnAdmin: boolean;
-  clusterProfileOperations: ClusterProfileOperations;
 }
 
-interface State {
-  clusterProfileDetailsExpanded: Stream<boolean>;
-}
+export type ClusterProfilesWidgetAttrs = Attrs & ClusterProfileWidgetAttrs;
 
-export type ClusterProfilesWidgetAttrs = Attrs & ElasticProfilesWidgetAttrs;
+export class ClusterProfilesWidget extends MithrilComponent<ClusterProfilesWidgetAttrs, {}> {
 
-interface HeaderAttrs {
-  clusterProfileId: string;
-  pluginName: string;
-  image: m.Children;
-}
-
-class ClusterProfilesHeaderWidget extends MithrilComponent<HeaderAttrs> {
-  view(vnode: m.Vnode<HeaderAttrs, State>) {
-    const title = <div data-test-id="cluster-profile-name" className={styles.clusterProfileName}><span>{vnode.attrs.clusterProfileId}</span></div>;
-
-    return [
-      <KeyValueTitle title={title} image={vnode.attrs.image}/>,
-      <KeyValuePair inline={true} data={new Map([["Plugin", vnode.attrs.pluginName]])}/>
-    ];
-  }
-}
-
-export class ClusterProfilesWidget extends MithrilComponent<ClusterProfilesWidgetAttrs, State> {
-  oninit(vnode: m.Vnode<ClusterProfilesWidgetAttrs, State>) {
-    vnode.state.clusterProfileDetailsExpanded = stream(false);
-  }
-
-  view(vnode: m.Vnode<ClusterProfilesWidgetAttrs, State>) {
+  view(vnode: m.Vnode<ClusterProfilesWidgetAttrs, {}>) {
     let noPluginInstalledMessage;
 
     if (ClusterProfilesWidget.noElasticAgentPluginInstalled(vnode)) {
@@ -93,22 +49,7 @@ export class ClusterProfilesWidget extends MithrilComponent<ClusterProfilesWidge
         <div data-test-id="cluster-profile-list">
           {
             vnode.attrs.clusterProfiles.all().map((clusterProfile) => {
-              const filteredElasticAgentProfiles = vnode.attrs.elasticProfiles.filterByClusterProfile(clusterProfile.id());
-              const pluginInfo                   = ClusterProfilesWidget.findPluginInfoByPluginId(vnode.attrs.pluginInfos(), clusterProfile.pluginId());
-              const pluginImageTag               = ClusterProfilesWidget.createImageTag(pluginInfo);
-              const pluginName                   = pluginInfo ? pluginInfo.about.name : "";
-              return <CollapsiblePanel key={clusterProfile.id()}
-                                       header={<ClusterProfilesHeaderWidget clusterProfileId={clusterProfile.id()} pluginName={pluginName} image={pluginImageTag}/>}
-                                       actions={this.getActionButtons(vnode, clusterProfile, pluginInfo)}
-                                       dataTestId={"cluster-profile-panel"}>
-                {this.getClusterProfileDetails(clusterProfile, vnode)}
-                <h4>Elastic Agent Profiles</h4>
-                <ElasticProfilesWidget elasticProfiles={new ElasticAgentProfiles(filteredElasticAgentProfiles)}
-                                       pluginInfos={vnode.attrs.pluginInfos}
-                                       elasticAgentOperations={vnode.attrs.elasticAgentOperations}
-                                       onShowUsages={vnode.attrs.onShowUsages.bind(vnode.attrs)}
-                                       isUserAnAdmin={vnode.attrs.isUserAnAdmin}/>
-              </CollapsiblePanel>;
+              return <ClusterProfileWidget {...vnode.attrs} clusterProfile={clusterProfile}/>;
             })
           }
         </div>
@@ -122,83 +63,5 @@ export class ClusterProfilesWidget extends MithrilComponent<ClusterProfilesWidge
 
   private static noClusterProfileConfigured(vnode: m.Vnode<ClusterProfilesWidgetAttrs, {}>) {
     return vnode.attrs.clusterProfiles == null || vnode.attrs.clusterProfiles.all().length === 0;
-  }
-
-  private static createImageTag(pluginInfo: PluginInfo<any> | undefined) {
-    if (pluginInfo && pluginInfo.imageUrl) {
-      return <HeaderIcon name="Plugin Icon" imageUrl={pluginInfo.imageUrl}/>;
-    }
-    return <HeaderIcon/>;
-  }
-
-  private static findPluginInfoByPluginId(pluginInfos: Array<PluginInfo<Extension>>, pluginId: string) {
-    return _.find(pluginInfos, ["id", pluginId]);
-  }
-
-  private static supportsClusterStatusReport(pluginInfo: PluginInfo<any> | undefined) {
-    if (pluginInfo && pluginInfo.extensionOfType(ExtensionType.ELASTIC_AGENTS)) {
-      const extension = pluginInfo.extensionOfType(ExtensionType.ELASTIC_AGENTS);
-      return extension && extension.capabilities && extension.capabilities.supportsClusterStatusReport;
-    }
-    return false;
-  }
-
-  private goToStatusReportPage(statusReportHref: string, event: Event): void {
-    event.stopPropagation();
-    window.location.href = statusReportHref;
-  }
-
-  private getActionButtons(vnode: m.Vnode<ClusterProfilesWidgetAttrs>, clusterProfile: ClusterProfile, pluginInfo: PluginInfo<Extension> | undefined) {
-    const actionButtons = [];
-
-    if (pluginInfo != null && ClusterProfilesWidget.supportsClusterStatusReport(pluginInfo)) {
-      const statusReportPath: string = Routes.adminClusterStatusReportPath(clusterProfile.pluginId(), clusterProfile.id());
-
-      actionButtons.push(
-        <Buttons.Secondary onclick={this.goToStatusReportPage.bind(this, statusReportPath)}
-                           data-test-id="status-report-link"
-                           icon={ButtonIcon.DOC}
-                           disabled={!vnode.attrs.isUserAnAdmin || !pluginInfo}>
-          Status Report
-        </Buttons.Secondary>);
-    }
-
-    actionButtons.push(
-      <Buttons.Secondary onclick={(e) => {
-        vnode.attrs.elasticAgentOperations.onAdd(new ElasticAgentProfile("", clusterProfile.pluginId(), clusterProfile.id(), new Configurations([])), e);
-      }} data-test-id={"new-elastic-agent-profile-button"} disabled={!pluginInfo} icon={ButtonIcon.ADD}>
-        Elastic Agent Profile
-      </Buttons.Secondary>);
-
-    actionButtons.push(<div className={styles.clusterProfileCrudActions}>
-      <IconGroup>
-        <Icons.Edit data-test-id="edit-cluster-profile" onclick={vnode.attrs.clusterProfileOperations.onEdit.bind(this, clusterProfile)} disabled={!pluginInfo}/>
-        <Icons.Clone data-test-id="clone-cluster-profile" onclick={vnode.attrs.clusterProfileOperations.onClone.bind(this, clusterProfile)} disabled={!pluginInfo}/>
-        <Icons.Delete data-test-id="delete-cluster-profile" onclick={vnode.attrs.clusterProfileOperations.onDelete.bind(this, clusterProfile.id())}/>
-      </IconGroup>
-    </div>);
-
-    return actionButtons;
-  }
-
-  private toggle(vnode: m.Vnode<ClusterProfilesWidgetAttrs, State>) {
-    vnode.state.clusterProfileDetailsExpanded(!vnode.state.clusterProfileDetailsExpanded());
-  }
-
-  private getClusterProfileDetails(clusterProfile: ClusterProfile, vnode: m.Vnode<ClusterProfilesWidgetAttrs, State>) {
-    const clusterProfileProperties = clusterProfile.properties() ? clusterProfile.properties().asMap() : [];
-    const clusterProfileDetails    = new Map([
-                                               ["Id", clusterProfile.id()],
-                                               ["PluginId", clusterProfile.pluginId()],
-                                               ...Array.from(clusterProfileProperties)
-                                             ]);
-    return (
-      <div className={styles.clusterProfileDetailsContainer}>
-        <h5 className={classnames(styles.clusterProfileDetailsHeader, {[styles.expanded]: vnode.state.clusterProfileDetailsExpanded()})} onclick={this.toggle.bind(this, vnode)} data-test-id="cluster-profile-details-header">Cluster info </h5>
-        <div className={classnames(styles.clusterProfileDetails, {[styles.expanded]: vnode.state.clusterProfileDetailsExpanded()})} data-test-id="cluster-profile-details">
-          <KeyValuePair data={clusterProfileDetails}/>
-        </div>
-      </div>
-    );
   }
 }

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/elastic_profiles/cluster_profiles_widget.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/elastic_profiles/cluster_profiles_widget.tsx
@@ -13,17 +13,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
+import {bind} from "classnames/bind";
 import * as Routes from "gen/ts-routes";
 import {MithrilComponent} from "jsx/mithril-component";
 import * as _ from "lodash";
 import * as m from "mithril";
 import {Stream} from "mithril/stream";
+import * as stream from "mithril/stream";
 import {ClusterProfile, ClusterProfiles, ElasticAgentProfile, ElasticAgentProfiles} from "models/elastic_profiles/types";
 import {Configurations} from "models/shared/configuration";
 import {ExtensionType} from "models/shared/plugin_infos_new/extension_type";
 import {Extension} from "models/shared/plugin_infos_new/extensions";
 import {PluginInfo} from "models/shared/plugin_infos_new/plugin_info";
+import {ButtonIcon} from "views/components/buttons";
 import * as Buttons from "views/components/buttons";
 import {CollapsiblePanel} from "views/components/collapsible_panel";
 import {FlashMessage, MessageType} from "views/components/flash_message";
@@ -35,6 +37,7 @@ import {Attrs as ElasticProfilesWidgetAttrs, ElasticProfilesWidget} from "views/
 import * as styles from "views/pages/elastic_profiles/index.scss";
 import {AddOperation, CloneOperation, DeleteOperation, EditOperation} from "views/pages/page_operations";
 
+const classnames = bind(styles);
 export type ClusterProfileOperations = EditOperation<ClusterProfile> & DeleteOperation<string> & AddOperation<void> & CloneOperation<ClusterProfile>;
 
 interface Attrs {
@@ -45,27 +48,35 @@ interface Attrs {
   clusterProfileOperations: ClusterProfileOperations;
 }
 
+interface State {
+  clusterProfileDetailsExpanded: Stream<boolean>;
+}
+
 export type ClusterProfilesWidgetAttrs = Attrs & ElasticProfilesWidgetAttrs;
 
 interface HeaderAttrs {
   clusterProfileId: string;
-  pluginId: string;
+  pluginName: string;
   image: m.Children;
 }
 
 class ClusterProfilesHeaderWidget extends MithrilComponent<HeaderAttrs> {
-  view(vnode: m.Vnode<HeaderAttrs, {}>) {
-    const title = <div data-test-id="cluster-profile-name" className={styles.clusterProfileName}>{vnode.attrs.clusterProfileId}</div>;
+  view(vnode: m.Vnode<HeaderAttrs, State>) {
+    const title = <div data-test-id="cluster-profile-name" className={styles.clusterProfileName}><span>{vnode.attrs.clusterProfileId}</span></div>;
 
     return [
       <KeyValueTitle title={title} image={vnode.attrs.image}/>,
-      <KeyValuePair inline={true} data={new Map([["PluginId", vnode.attrs.pluginId]])}/>
+      <KeyValuePair inline={true} data={new Map([["Plugin", vnode.attrs.pluginName]])}/>
     ];
   }
 }
 
-export class ClusterProfilesWidget extends MithrilComponent<ClusterProfilesWidgetAttrs, {}> {
-  view(vnode: m.Vnode<ClusterProfilesWidgetAttrs, {}>) {
+export class ClusterProfilesWidget extends MithrilComponent<ClusterProfilesWidgetAttrs, State> {
+  oninit(vnode: m.Vnode<ClusterProfilesWidgetAttrs, State>) {
+    vnode.state.clusterProfileDetailsExpanded = stream(false);
+  }
+
+  view(vnode: m.Vnode<ClusterProfilesWidgetAttrs, State>) {
     let noPluginInstalledMessage;
 
     if (ClusterProfilesWidget.noElasticAgentPluginInstalled(vnode)) {
@@ -85,12 +96,13 @@ export class ClusterProfilesWidget extends MithrilComponent<ClusterProfilesWidge
               const filteredElasticAgentProfiles = vnode.attrs.elasticProfiles.filterByClusterProfile(clusterProfile.id());
               const pluginInfo                   = ClusterProfilesWidget.findPluginInfoByPluginId(vnode.attrs.pluginInfos(), clusterProfile.pluginId());
               const pluginImageTag               = ClusterProfilesWidget.createImageTag(pluginInfo);
-
+              const pluginName                   = pluginInfo ? pluginInfo.about.name : "";
               return <CollapsiblePanel key={clusterProfile.id()}
-                                       header={<ClusterProfilesHeaderWidget clusterProfileId={clusterProfile.id()} pluginId={clusterProfile.pluginId()} image={pluginImageTag}/>}
+                                       header={<ClusterProfilesHeaderWidget clusterProfileId={clusterProfile.id()} pluginName={pluginName} image={pluginImageTag}/>}
                                        actions={this.getActionButtons(vnode, clusterProfile, pluginInfo)}
                                        dataTestId={"cluster-profile-panel"}>
-                {this.getClusterProfileDetails(clusterProfile)}
+                {this.getClusterProfileDetails(clusterProfile, vnode)}
+                <h4>Elastic Agent Profiles</h4>
                 <ElasticProfilesWidget elasticProfiles={new ElasticAgentProfiles(filteredElasticAgentProfiles)}
                                        pluginInfos={vnode.attrs.pluginInfos}
                                        elasticAgentOperations={vnode.attrs.elasticAgentOperations}
@@ -145,17 +157,18 @@ export class ClusterProfilesWidget extends MithrilComponent<ClusterProfilesWidge
       actionButtons.push(
         <Buttons.Secondary onclick={this.goToStatusReportPage.bind(this, statusReportPath)}
                            data-test-id="status-report-link"
+                           icon={ButtonIcon.DOC}
                            disabled={!vnode.attrs.isUserAnAdmin || !pluginInfo}>
           Status Report
         </Buttons.Secondary>);
     }
 
     actionButtons.push(
-      <Buttons.Default onclick={(e) => {
+      <Buttons.Secondary onclick={(e) => {
         vnode.attrs.elasticAgentOperations.onAdd(new ElasticAgentProfile("", clusterProfile.pluginId(), clusterProfile.id(), new Configurations([])), e);
-      }} data-test-id={"new-elastic-agent-profile-button"} disabled={!pluginInfo}>
-        + New Elastic Agent Profile
-      </Buttons.Default>);
+      }} data-test-id={"new-elastic-agent-profile-button"} disabled={!pluginInfo} icon={ButtonIcon.ADD}>
+        Elastic Agent Profile
+      </Buttons.Secondary>);
 
     actionButtons.push(<div className={styles.clusterProfileCrudActions}>
       <IconGroup>
@@ -168,7 +181,11 @@ export class ClusterProfilesWidget extends MithrilComponent<ClusterProfilesWidge
     return actionButtons;
   }
 
-  private getClusterProfileDetails(clusterProfile: ClusterProfile) {
+  private toggle(vnode: m.Vnode<ClusterProfilesWidgetAttrs, State>) {
+    vnode.state.clusterProfileDetailsExpanded(!vnode.state.clusterProfileDetailsExpanded());
+  }
+
+  private getClusterProfileDetails(clusterProfile: ClusterProfile, vnode: m.Vnode<ClusterProfilesWidgetAttrs, State>) {
     const clusterProfileProperties = clusterProfile.properties() ? clusterProfile.properties().asMap() : [];
     const clusterProfileDetails    = new Map([
                                                ["Id", clusterProfile.id()],
@@ -176,9 +193,12 @@ export class ClusterProfilesWidget extends MithrilComponent<ClusterProfilesWidge
                                                ...Array.from(clusterProfileProperties)
                                              ]);
     return (
-      <CollapsiblePanel key={"show-cluster-info"} header={"Show Cluster Info"} dataTestId={"cluster-profile-info-panel"}>
-        <KeyValuePair data={clusterProfileDetails}/>
-      </CollapsiblePanel>
+      <div className={styles.clusterProfileDetailsContainer}>
+        <h5 className={classnames(styles.clusterProfileDetailsHeader, {[styles.expanded]: vnode.state.clusterProfileDetailsExpanded()})} onclick={this.toggle.bind(this, vnode)} data-test-id="cluster-profile-details-header">Cluster info </h5>
+        <div className={classnames(styles.clusterProfileDetails, {[styles.expanded]: vnode.state.clusterProfileDetailsExpanded()})} data-test-id="cluster-profile-details">
+          <KeyValuePair data={clusterProfileDetails}/>
+        </div>
+      </div>
     );
   }
 }

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/elastic_profiles/elastic_agent_profiles_modals.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/elastic_profiles/elastic_agent_profiles_modals.tsx
@@ -21,7 +21,6 @@ import {Stream} from "mithril/stream";
 import * as stream from "mithril/stream";
 import {ElasticAgentProfilesCRUD} from "models/elastic_profiles/elastic_agent_profiles_crud";
 import {ClusterProfile, ClusterProfiles, ElasticAgentProfile, ProfileUsage} from "models/elastic_profiles/types";
-import {Configurations} from "models/shared/configuration";
 import {ExtensionType} from "models/shared/plugin_infos_new/extension_type";
 import {ElasticAgentSettings, Extension} from "models/shared/plugin_infos_new/extensions";
 import {PluginInfo} from "models/shared/plugin_infos_new/plugin_info";
@@ -121,13 +120,8 @@ abstract class BaseElasticProfileModal extends Modal {
     }
 
     const clustersList = _.map(clustersBelongingToPlugin, (clusterProfile: ClusterProfile) => {
-      return {id: clusterProfile.id(), text: clusterProfile.id()};
+      return {id: clusterProfile.id(), text: `${clusterProfile.id()} (${this.pluginInfo().about.name})`};
     }) || [];
-
-    const pluginList = _.map(this.pluginInfos, (pluginInfo: PluginInfo<any>) => {
-      return {id: pluginInfo.id, text: pluginInfo.about.name};
-    });
-
     const elasticAgentExtension        = this.pluginInfo().extensionOfType(ExtensionType.ELASTIC_AGENTS);
     const elasticProfileConfigurations = (elasticAgentExtension as ElasticAgentSettings).profileSettings;
 
@@ -142,14 +136,6 @@ abstract class BaseElasticProfileModal extends Modal {
                          property={this.elasticProfile().id}
                          errorText={this.elasticProfile().errors().errorsForDisplay("id")}
                          required={true}/>
-
-              <SelectField label="Plugin ID"
-                           property={this.pluginIdProxy.bind(this)}
-                           required={true}
-                           errorText={this.elasticProfile().errors().errorsForDisplay("pluginId")}>
-                <SelectFieldOptions selected={this.elasticProfile().pluginId()}
-                                    items={pluginList}/>
-              </SelectField>
               <SelectField label="Cluster Profile ID"
                            property={this.clusterProfileIdProxy.bind(this)}
                            required={true}
@@ -192,20 +178,6 @@ abstract class BaseElasticProfileModal extends Modal {
     }
 
     return this.elasticProfile().clusterProfileId();
-  }
-
-  private pluginIdProxy(newValue ?: string) {
-    if (newValue) {
-      if (this.pluginInfo().id !== newValue) {
-        const pluginInfo = _.find(this.pluginInfos, (p) => p.id === newValue);
-        this.pluginInfo(pluginInfo!);
-        this.elasticProfile(new ElasticAgentProfile(this.elasticProfile().id(),
-                                                    pluginInfo!.id,
-                                                    undefined,
-                                                    new Configurations([])));
-      }
-    }
-    return this.pluginInfo().id;
   }
 }
 

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/elastic_profiles/index.scss
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/elastic_profiles/index.scss
@@ -42,10 +42,10 @@ $disabled-text-color: #999;
   }
 }
 
-.plugin-name, .cluster-profile-name {
-  font-weight:  600;
-  font-size:    13px;
-  margin-right: 50px;
+.plugin-name {
+  font-weight: 600;
+  font-size:   13px;
+
   @media (min-width: $screen-md) {
     font-size: 12px;
   }
@@ -53,6 +53,12 @@ $disabled-text-color: #999;
     font-size: 15px;
   }
 
+}
+
+.cluster-profile-name {
+  overflow:      hidden;
+  text-overflow: ellipsis;
+  white-space:   nowrap;
 }
 
 .plugin-not-installed {
@@ -114,4 +120,45 @@ $disabled-text-color: #999;
 
 .cluster-profile-crud-actions {
   margin-left: 20px;
+}
+
+.cluster-profile-details-header {
+  @include icon-before($type: $fa-var-angle-right, $size: 16px);
+  position:     relative;
+  padding-left: 17px;
+  cursor:       pointer;
+  margin:       0 0 20px 0;
+
+  &:before {
+    position:   absolute;
+    left:       1px;
+    top:        1px;
+    margin:     0;
+    transition: $transition;
+  }
+
+  &.expanded {
+    &:before {
+      transform:  rotate(90deg);
+      transition: $transition;
+      left:       3px;
+      top:        2px;
+    }
+  }
+}
+
+.cluster-profile-details-container {
+  display: block;
+}
+
+.cluster-profile-details {
+  display: none;
+
+  &.expanded {
+    display: block;
+  }
+}
+
+.add-icon {
+  @include icon-before($type: $fa-var-plus);
 }

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/elastic_profiles/index.scss.d.ts
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/elastic_profiles/index.scss.d.ts
@@ -13,3 +13,8 @@ export const disabled: string;
 export const note: string;
 export const spinnerWrapper: string;
 export const clusterProfileCrudActions: string;
+export const clusterProfileDetailsHeader: string;
+export const expanded: string;
+export const clusterProfileDetailsContainer: string;
+export const clusterProfileDetails: string;
+export const addIcon: string;

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/elastic_profiles/spec/cluster_profiles_modals_spec.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/elastic_profiles/spec/cluster_profiles_modals_spec.tsx
@@ -36,17 +36,25 @@ describe("ClusterProfileModal", () => {
   });
 
   describe("EditModalType", () => {
-    beforeEach(() => {
+    it("id field should be disabled for edit modal type", () => {
       modal = new TestClusterProfile(pluginInfos, ModalType.edit, ClusterProfile.fromJSON(TestData.dockerClusterProfile()));
       helper.mount(modal.body.bind(modal));
-    });
 
-    afterEach(() => {
+      expect(find("form-field-input-id")).toBeDisabled();
+
       helper.unmount();
     });
 
-    it("id field should be disabled for edit modal type", () => {
-      expect(find("form-field-input-id")).toBeDisabled();
+    it("should display warning message if selected plugin do not support cluster profile", () => {
+      const clusterProfile = new ClusterProfile("", "cd.go.contrib.elasticagent.kubernetes");
+      modal                = new TestClusterProfile(pluginInfos, ModalType.edit, clusterProfile);
+      helper.mount(modal.body.bind(modal));
+
+      expect(helper.findIn(find("cluster-profile-form-header"), "flash-message-warning")).toBeInDOM();
+      expect(helper.findIn(find("cluster-profile-form-header"), "flash-message-warning")).toHaveText("Can not edit Cluster profile for 'Kubernetes Elastic Agent Plugin' plugin as it does not support cluster profiles.");
+      expect(helper.findByDataTestId("cluster-profile-properties-form")).toBeEmpty();
+
+      helper.unmount();
     });
   });
 
@@ -79,7 +87,7 @@ describe("ClusterProfileModal", () => {
       helper.mount(modal.body.bind(modal));
 
       expect(helper.findIn(find("cluster-profile-form-header"), "flash-message-alert")).toBeInDOM();
-      expect(helper.findIn(find("cluster-profile-form-header"), "flash-message-alert")).toHaveText("Can not define Cluster profiles for 'cd.go.contrib.elasticagent.kubernetes' plugin as it does not support cluster profiles.");
+      expect(helper.findIn(find("cluster-profile-form-header"), "flash-message-alert")).toHaveText("Can not define Cluster profiles for 'Kubernetes Elastic Agent Plugin' plugin as it does not support cluster profiles.");
       expect(helper.findByDataTestId("cluster-profile-properties-form")).toBeEmpty();
 
       helper.unmount();

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/elastic_profiles/spec/cluster_profiles_widget_spec.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/elastic_profiles/spec/cluster_profiles_widget_spec.tsx
@@ -22,6 +22,7 @@ import {Extension} from "models/shared/plugin_infos_new/extensions";
 import {PluginInfo} from "models/shared/plugin_infos_new/plugin_info";
 import * as collapsiblePanelStyles from "views/components/collapsible_panel/index.scss";
 import {ClusterProfilesWidget} from "views/pages/elastic_profiles/cluster_profiles_widget";
+import * as elasticProfilePageStyles from "views/pages/elastic_profiles/index.scss";
 import {TestData} from "views/pages/elastic_profiles/spec/test_data";
 import {TestHelper} from "views/pages/spec/test_helper";
 
@@ -68,7 +69,7 @@ describe("ClusterProfilesWidget", () => {
     mount(pluginInfos, clusterProfiles, new ElasticAgentProfiles([]));
 
     expect(helper.findByDataTestId("new-elastic-agent-profile-button")).toBeInDOM();
-    expect(helper.findByDataTestId("new-elastic-agent-profile-button")).toHaveText("+ New Elastic Agent Profile");
+    expect(helper.findByDataTestId("new-elastic-agent-profile-button")).toHaveText("Elastic Agent Profile");
 
     helper.unmount();
   });
@@ -88,8 +89,8 @@ describe("ClusterProfilesWidget", () => {
     mount(pluginInfos, clusterProfiles, new ElasticAgentProfiles([]));
 
     expect(helper.findIn(helper.findByDataTestId("collapse-header")[0], "cluster-profile-name")).toHaveText("cluster_3");
-    expect(helper.findIn(helper.findByDataTestId("collapse-header")[0], "key-value-key-pluginid")).toHaveText("PluginId");
-    expect(helper.findIn(helper.findByDataTestId("collapse-header")[0], "key-value-value-pluginid")).toHaveText("cd.go.contrib.elastic-agent.docker");
+    expect(helper.findIn(helper.findByDataTestId("collapse-header")[0], "key-value-key-plugin")).toHaveText("Plugin");
+    expect(helper.findIn(helper.findByDataTestId("collapse-header")[0], "key-value-value-plugin")).toHaveText("Docker Elastic Agent Plugin");
 
     helper.unmount();
   });
@@ -222,13 +223,15 @@ describe("ClusterProfilesWidget", () => {
     it("should toggle expanded state of cluster profile show details on click", () => {
       simulateEvent.simulate(clusterProfilePanelHeader, "click");
 
-      const clusterProfileInfoHeader = helper.findIn(helper.findByDataTestId("cluster-profile-info-panel")[0], "collapse-header")[0];
+      const clusterProfileInfoHeader = helper.findIn(helper.findByDataTestId("cluster-profile-panel"), "cluster-profile-details-header")[0];
 
-      expect(clusterProfileInfoHeader).not.toHaveClass(collapsiblePanelStyles.expanded);
+      expect(clusterProfileInfoHeader).not.toHaveClass(elasticProfilePageStyles.expanded);
+      expect(helper.findIn(helper.findByDataTestId("cluster-profile-panel"), "cluster-profile-details")[0]).not.toHaveClass(elasticProfilePageStyles.expanded);
 
       simulateEvent.simulate(clusterProfileInfoHeader, "click");
 
-      expect(clusterProfileInfoHeader).toHaveClass(collapsiblePanelStyles.expanded);
+      expect(clusterProfileInfoHeader).toHaveClass(elasticProfilePageStyles.expanded);
+      expect(helper.findIn(helper.findByDataTestId("cluster-profile-panel"), "cluster-profile-details")[0]).toHaveClass(elasticProfilePageStyles.expanded);
     });
 
     it("should toggle expanded state of elastic agent profile show details on click", () => {


### PR DESCRIPTION
* Change in key-value pair padding for better alignment.
* Add a custom collapsible element to show Cluster Profile details as the styles are very specific.
* Truncate cluster profile ID.
* Header for elastic agent profiles.
* Change `+ New Elastic Agent Profile` button to `+ Elastic Agent Profile`.
* Display generic error message while saving a cluster profile.
* Show warning message on `Edit Cluster Profile Modal` for plugins not supporting Cluster Profiles.