### PR TITLE
Do not mark in-progress backups as aborted if server is in standby mode

### DIFF
--- a/server/src/main/java/com/thoughtworks/go/server/service/BackupService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/BackupService.java
@@ -111,7 +111,11 @@ public class BackupService implements BackupStatusProvider {
     }
 
     public void initialize() {
-        serverBackupRepository.markInProgressBackupsAsAborted(ABORTED_BACKUPS_MESSAGE);
+        if (systemEnvironment.isServerInStandbyMode()) {
+            LOGGER.info("GoCD server in 'standby' mode, not changing 'in-progress' backups to 'aborted'.");
+        } else {
+            serverBackupRepository.markInProgressBackupsAsAborted(ABORTED_BACKUPS_MESSAGE);
+        }
     }
 
     public ServerBackup scheduleBackup(Username username) {

--- a/server/src/test-fast/java/com/thoughtworks/go/server/service/BackupServiceTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/service/BackupServiceTest.java
@@ -176,4 +176,14 @@ public class BackupServiceTest {
 
         verify(serverBackupRepository).markInProgressBackupsAsAborted(ABORTED_BACKUPS_MESSAGE);
     }
+
+    @Test
+    public void shouldNotMarkInProgressBackupsAsAbortedIfServerIsInStandbyMode() {
+        when(systemEnvironment.isServerInStandbyMode()).thenReturn(true);
+        BackupService backupService = new BackupService(artifactsDirHolder, mock(GoConfigService.class), null, serverBackupRepository, systemEnvironment, configRepo, databaseStrategy, null);
+
+        backupService.initialize();
+
+        verifyZeroInteractions(serverBackupRepository);
+    }
 }


### PR DESCRIPTION
In standby mode, the DB will be synced with the primary, and the secondary's connection to the DB is readonly.