### PR TITLE
[DNM] Agent configuration refactoring (#911)

### DIFF
--- a/api/api-environments-v2/src/test/groovy/com/thoughtworks/go/apiv2/environments/EnvironmentsControllerV2Test.groovy
+++ b/api/api-environments-v2/src/test/groovy/com/thoughtworks/go/apiv2/environments/EnvironmentsControllerV2Test.groovy
@@ -25,6 +25,7 @@ import com.thoughtworks.go.config.BasicEnvironmentConfig
 import com.thoughtworks.go.config.CaseInsensitiveString
 import com.thoughtworks.go.config.EnvironmentConfig
 import com.thoughtworks.go.config.EnvironmentVariableConfig
+import com.thoughtworks.go.config.EnvironmentsConfig
 import com.thoughtworks.go.domain.ConfigElementForEdit
 import com.thoughtworks.go.security.GoCipher
 import com.thoughtworks.go.server.service.EntityHashingService
@@ -523,20 +524,20 @@ class EnvironmentsControllerV2Test implements SecurityServiceTrait, ControllerTr
 
         assertThatResponse()
           .hasJsonBody([
-          "data": [
+          "data"   : [
             "environment_variables": [
               [
                 "encrypted_value": new GoCipher().encrypt("/bin/java"),
-                "errors": [
+                "errors"         : [
                   "encrypted_value": [
                     "You may only specify `value` or `encrypted_value`, not both!"
                   ],
-                  "value": [
+                  "value"          : [
                     "You may only specify `value` or `encrypted_value`, not both!"
                   ]
                 ],
-                "name": "JAVA_HOME",
-                "secure": true
+                "name"           : "JAVA_HOME",
+                "secure"         : true
               ]
             ]
           ],
@@ -706,15 +707,13 @@ class EnvironmentsControllerV2Test implements SecurityServiceTrait, ControllerTr
         def devEnv = new BasicEnvironmentConfig(new CaseInsensitiveString("dev"))
         def qaEnv = new BasicEnvironmentConfig(new CaseInsensitiveString("qa"))
 
-        def listOfEnvironmentConfigs = new HashSet([qaEnv, devEnv, prodEnv])
+        def environmentConfigs = new EnvironmentsConfig(devEnv, qaEnv)
 
-        when(environmentConfigService.getEnvironments()).thenReturn(listOfEnvironmentConfigs)
+        when(environmentConfigService.getEnvironments()).thenReturn(environmentConfigs)
 
         getWithApiHeader(controller.controllerBasePath())
 
-        def environmentsConfigSortedByName = new LinkedHashSet([devEnv, prodEnv, qaEnv])
-        assertThatResponse()
-          .hasBodyWithJsonObject(environmentsConfigSortedByName, EnvironmentsRepresenter)
+        assertThatResponse().hasBodyWithJsonObject(environmentConfigs, EnvironmentsRepresenter)
       }
 
 
@@ -734,7 +733,7 @@ class EnvironmentsControllerV2Test implements SecurityServiceTrait, ControllerTr
           ]
         ]
 
-        when(environmentConfigService.getEnvironments()).thenReturn(new HashSet<>([]))
+        when(environmentConfigService.getEnvironments()).thenReturn(new EnvironmentsConfig())
 
         getWithApiHeader(controller.controllerBasePath())
 

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/EnvironmentsConfig.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/EnvironmentsConfig.java
@@ -38,6 +38,10 @@ public class EnvironmentsConfig extends BaseCollection<EnvironmentConfig> implem
     public EnvironmentsConfig() {
     }
 
+    public EnvironmentsConfig(EnvironmentConfig... configs) {
+        super(configs);
+    }
+
     public void validate(ValidationContext validationContext) {
         List<CaseInsensitiveString> allPipelineNames = validationContext.getCruiseConfig().getAllPipelineNames();
         List<CaseInsensitiveString> allEnvironmentNames = new ArrayList<>();

--- a/server/src/main/java/com/thoughtworks/go/config/update/AddAgentCommand.java
+++ b/server/src/main/java/com/thoughtworks/go/config/update/AddAgentCommand.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.config.update;
+
+import com.thoughtworks.go.config.AgentConfig;
+import com.thoughtworks.go.config.CruiseConfig;
+import com.thoughtworks.go.config.UpdateConfigCommand;
+
+public class AddAgentCommand implements UpdateConfigCommand {
+    private final AgentConfig agentConfig;
+
+    public AddAgentCommand(AgentConfig agentConfig) {
+        this.agentConfig = agentConfig;
+    }
+
+    public CruiseConfig update(CruiseConfig cruiseConfig) {
+        cruiseConfig.agents().add(agentConfig);
+        return cruiseConfig;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        AddAgentCommand that = (AddAgentCommand) o;
+
+        if (agentConfig != null ? !agentConfig.equals(that.agentConfig) : that.agentConfig != null) {
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        return agentConfig != null ? agentConfig.hashCode() : 0;
+    }
+
+    @Override
+    public String toString() {
+        return "AddAgentcommand{" +
+                "agentConfig=" + agentConfig +
+                '}';
+    }
+
+}

--- a/server/src/main/java/com/thoughtworks/go/server/controller/JobController.java
+++ b/server/src/main/java/com/thoughtworks/go/server/controller/JobController.java
@@ -170,7 +170,7 @@ public class JobController {
         String pipelineName = current.getIdentifier().getPipelineName();
         String stageName = current.getIdentifier().getStageName();
         JobInstances recent25 = jobInstanceService.latestCompletedJobs(pipelineName, stageName, current.getName());
-        AgentConfig agentConfig = goConfigService.agentByUuid(current.getAgentUuid());
+        AgentConfig agentConfig = agentService.registeredAgentByUUID(current.getAgentUuid());
         Pipeline pipelineWithOneBuild = pipelineService.wrapBuildDetails(current);
         Tabs customizedTabs = goConfigService.getCustomizedTabs(pipelineWithOneBuild.getName(),
                 pipelineWithOneBuild.getFirstStage().getName(), current.getName());
@@ -192,7 +192,7 @@ public class JobController {
         data.put("websocketEnabled", Toggles.isToggleOn(Toggles.BROWSER_CONSOLE_LOG_WS));
         data.put("useIframeSandbox", systemEnvironment.useIframeSandbox());
         data.put("isEditableViaUI", goConfigService.isPipelineEditable(jobDetail.getPipelineName()));
-        data.put("isAgentAlive", goConfigService.hasAgent(jobDetail.getAgentUuid()));
+        data.put("isAgentAlive", agentService.hasRegisteredAgent(jobDetail.getAgentUuid()));
         addElasticAgentInfo(jobDetail, data);
         return new ModelAndView("build_detail/build_detail_page", data);
     }
@@ -211,7 +211,7 @@ public class JobController {
         final ElasticAgentPluginInfo pluginInfo = elasticAgentMetadataStore.getPluginInfo(pluginId);
 
         if (pluginInfo != null && pluginInfo.getCapabilities().supportsAgentStatusReport()) {
-            final AgentConfig agentConfig = goConfigService.agentByUuid(jobInstance.getAgentUuid());
+            final AgentConfig agentConfig = agentService.registeredAgentByUUID(jobInstance.getAgentUuid());
 
             if (agentConfig != null && agentConfig.isElastic()) {
                 data.put("elasticAgentPluginId", agentConfig.getElasticPluginId());

--- a/server/src/main/java/com/thoughtworks/go/server/service/AgentConfigService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/AgentConfigService.java
@@ -20,6 +20,7 @@ import com.google.common.collect.Sets;
 import com.thoughtworks.go.config.*;
 import com.thoughtworks.go.config.commands.EntityConfigUpdateCommand;
 import com.thoughtworks.go.config.exceptions.GoConfigInvalidException;
+import com.thoughtworks.go.config.update.AddAgentCommand;
 import com.thoughtworks.go.config.update.AgentsEntityConfigUpdateCommand;
 import com.thoughtworks.go.config.update.AgentsUpdateCommand;
 import com.thoughtworks.go.config.update.ModifyEnvironmentCommand;
@@ -313,53 +314,6 @@ public class AgentConfigService {
         } else {
             updateAgent(new AddAgentCommand(agentInstance.agentConfig()), agentInstance.getUuid(), new HttpOperationResult(), Username.ANONYMOUS);
         }
-    }
-
-    /**
-     * @understands how to add an agent to the config file
-     */
-    public static class AddAgentCommand implements UpdateConfigCommand {
-        private final AgentConfig agentConfig;
-
-        public AddAgentCommand(AgentConfig agentConfig) {
-            this.agentConfig = agentConfig;
-        }
-
-        public CruiseConfig update(CruiseConfig cruiseConfig) {
-            cruiseConfig.agents().add(agentConfig);
-            return cruiseConfig;
-        }
-
-        @Override
-        public boolean equals(Object o) {
-            if (this == o) {
-                return true;
-            }
-            if (o == null || getClass() != o.getClass()) {
-                return false;
-            }
-
-            AddAgentCommand that = (AddAgentCommand) o;
-
-            if (agentConfig != null ? !agentConfig.equals(that.agentConfig) : that.agentConfig != null) {
-                return false;
-            }
-
-            return true;
-        }
-
-        @Override
-        public int hashCode() {
-            return agentConfig != null ? agentConfig.hashCode() : 0;
-        }
-
-        @Override
-        public String toString() {
-            return "AddAgentcommand{" +
-                    "agentConfig=" + agentConfig +
-                    '}';
-        }
-
     }
 
     @Deprecated

--- a/server/src/main/java/com/thoughtworks/go/server/service/AgentService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/AgentService.java
@@ -16,10 +16,9 @@
 
 package com.thoughtworks.go.server.service;
 
-import com.thoughtworks.go.config.AgentConfig;
-import com.thoughtworks.go.config.Agents;
-import com.thoughtworks.go.config.EnvironmentConfig;
+import com.thoughtworks.go.config.*;
 import com.thoughtworks.go.domain.AgentInstance;
+import com.thoughtworks.go.domain.NullAgentInstance;
 import com.thoughtworks.go.listener.AgentChangeListener;
 import com.thoughtworks.go.presentation.TriStateSelection;
 import com.thoughtworks.go.remote.AgentIdentifier;
@@ -343,6 +342,18 @@ public class AgentService {
         return agentInstances.findAgent(uuid);
     }
 
+    public AgentConfig registeredAgentByUUID(String uuid) {
+        return agentConfigService.agents().getAgentByUuid(uuid);
+    }
+
+    public Agents registeredAgentConfigs() {
+        return agentConfigService.agents();
+    }
+
+    public boolean hasRegisteredAgent(String uuid) {
+        return agentConfigService.agents().hasAgent(uuid);
+    }
+
     public void clearAll() {
         agentInstances.clearAll();
     }
@@ -401,5 +412,17 @@ public class AgentService {
 
     public AgentInstances findDisabledAgents() {
         return agentInstances.findDisabledAgents();
+    }
+
+    public void deleteAgents(Username username, AgentInstance... agentInstances) {
+        agentConfigService.deleteAgents(username, agentInstances);
+    }
+
+    public void disableAgents(Username username, AgentInstance... agentInstances) {
+        agentConfigService.disableAgents(username, agentInstances);
+    }
+
+    public AgentConfig updateAgent(UpdateConfigCommand compositeConfigCommand, String uuid, HttpOperationResult result, Username agentUsername) {
+        return agentConfigService.updateAgent(compositeConfigCommand, uuid, result, agentUsername);
     }
 }

--- a/server/src/main/java/com/thoughtworks/go/server/service/EnvironmentConfigService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/EnvironmentConfigService.java
@@ -119,24 +119,6 @@ public class EnvironmentConfigService implements ConfigChangedListener {
         return null;
     }
 
-    public Agents agentsForPipeline(final CaseInsensitiveString pipelineName) {
-        Agents configs = new Agents();
-        if (environments.isPipelineAssociatedWithAnyEnvironment(pipelineName)) {
-            EnvironmentConfig forPipeline = environments.findEnvironmentForPipeline(pipelineName);
-            for (EnvironmentAgentConfig environmentAgentConfig : forPipeline.getAgents()) {
-                configs.add(goConfigService.agentByUuid(environmentAgentConfig.getUuid()));
-            }
-
-        } else {
-            for (AgentConfig agentConfig : goConfigService.agents()) {
-                if (!environments.isAgentUnderEnvironment(agentConfig.getUuid())) {
-                    configs.add(agentConfig);
-                }
-            }
-        }
-        return configs;
-    }
-
     public List<CaseInsensitiveString> pipelinesFor(final CaseInsensitiveString environmentName) {
         return environments.named(environmentName).getPipelineNames();
     }
@@ -145,10 +127,8 @@ public class EnvironmentConfigService implements ConfigChangedListener {
         return environments.names();
     }
 
-    public Set<EnvironmentConfig> getEnvironments() {
-        Set<EnvironmentConfig> environmentConfigs = new HashSet<>();
-        environmentConfigs.addAll(environments);
-        return environmentConfigs;
+    public EnvironmentsConfig getEnvironments() {
+        return environments;
     }
 
     public Set<String> environmentsFor(String uuid) {

--- a/server/src/main/java/com/thoughtworks/go/server/service/GoConfigService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/GoConfigService.java
@@ -235,10 +235,6 @@ public class GoConfigService implements Initializer, CruiseConfigProvider {
         return goConfigDao.load();
     }
 
-    public AgentConfig agentByUuid(String uuid) {
-        return agents().getAgentByUuid(uuid);
-    }
-
     public StageConfig stageConfigNamed(String pipelineName, String stageName) {
         return getCurrentConfig().stageConfigByName(new CaseInsensitiveString(pipelineName), new CaseInsensitiveString(stageName));
     }

--- a/server/src/main/java/com/thoughtworks/go/server/service/PropertiesService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/PropertiesService.java
@@ -62,12 +62,12 @@ public class PropertiesService implements JobPropertiesReader {
     private PropertyDao propertyDao;
     private TransactionTemplate transactionTemplate;
     private final JobResolverService jobResolverService;
-    private GoConfigService goConfigService;
+    private final AgentService agentService;
 
     @Autowired
-    public PropertiesService(PropertyDao propertyDao, GoConfigService goConfigService, TransactionTemplate transactionTemplate, JobResolverService jobResolverService) {
+    public PropertiesService(PropertyDao propertyDao, AgentService agentService, TransactionTemplate transactionTemplate, JobResolverService jobResolverService) {
         this.propertyDao = propertyDao;
-        this.goConfigService = goConfigService;
+        this.agentService = agentService;
         this.transactionTemplate = transactionTemplate;
         this.jobResolverService = jobResolverService;
     }
@@ -179,7 +179,7 @@ public class PropertiesService implements JobPropertiesReader {
     }
 
     private void saveBuildAgent(JobInstance instance) {
-        propertyDao.save(instance.getId(), new Property(CRUISE_AGENT, goConfigService.agentByUuid(instance.getAgentUuid()).getHostname()));
+        propertyDao.save(instance.getId(), new Property(CRUISE_AGENT, agentService.registeredAgentByUUID(instance.getAgentUuid()).getHostname()));
     }
 
     public Properties getPropertiesForJob(long id) {

--- a/server/src/main/java/com/thoughtworks/go/server/service/plugins/processor/elasticagent/AbstractVersionableElasticAgentProcessor.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/plugins/processor/elasticagent/AbstractVersionableElasticAgentProcessor.java
@@ -20,7 +20,6 @@ import com.thoughtworks.go.domain.AgentInstance;
 import com.thoughtworks.go.plugin.access.elastic.models.AgentMetadata;
 import com.thoughtworks.go.server.domain.ElasticAgentMetadata;
 import com.thoughtworks.go.server.domain.Username;
-import com.thoughtworks.go.server.service.AgentConfigService;
 import com.thoughtworks.go.server.service.AgentService;
 import com.thoughtworks.go.server.service.ElasticAgentPluginService;
 import org.slf4j.Logger;
@@ -34,11 +33,9 @@ import static java.lang.String.format;
 public abstract class AbstractVersionableElasticAgentProcessor implements VersionableElasticAgentProcessor {
     protected final Logger LOGGER = LoggerFactory.getLogger(getClass());
     protected final AgentService agentService;
-    protected final AgentConfigService agentConfigService;
 
-    public AbstractVersionableElasticAgentProcessor(AgentService agentService, AgentConfigService agentConfigService) {
+    public AbstractVersionableElasticAgentProcessor(AgentService agentService) {
         this.agentService = agentService;
-        this.agentConfigService = agentConfigService;
     }
 
     protected Collection<AgentMetadata> getAgentMetadataForPlugin(String pluginId) {
@@ -78,7 +75,7 @@ public abstract class AbstractVersionableElasticAgentProcessor implements Versio
         }
 
         LOGGER.debug("Deleting agents from plugin {} {}", pluginId, agentInstances);
-        agentConfigService.deleteAgents(usernameFor(pluginId), agentInstances.toArray(new AgentInstance[agentInstances.size()]));
+        agentService.deleteAgents(usernameFor(pluginId), agentInstances.toArray(new AgentInstance[agentInstances.size()]));
         LOGGER.debug("Done deleting agents from plugin {} {}", pluginId, agentInstances);
     }
 
@@ -91,7 +88,7 @@ public abstract class AbstractVersionableElasticAgentProcessor implements Versio
         }
 
         LOGGER.debug("Disabling agents from plugin {} {}", pluginId, agentInstances);
-        agentConfigService.disableAgents(usernameFor(pluginId), agentInstances.toArray(new AgentInstance[agentInstances.size()]));
+        agentService.disableAgents(usernameFor(pluginId), agentInstances.toArray(new AgentInstance[agentInstances.size()]));
         LOGGER.debug("Done disabling agents from plugin {} {}", pluginId, agentInstances);
     }
 }

--- a/server/src/main/java/com/thoughtworks/go/server/service/plugins/processor/elasticagent/ElasticAgentRequestProcessor.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/plugins/processor/elasticagent/ElasticAgentRequestProcessor.java
@@ -21,7 +21,6 @@ import com.thoughtworks.go.plugin.api.response.GoApiResponse;
 import com.thoughtworks.go.plugin.infra.GoPluginApiRequestProcessor;
 import com.thoughtworks.go.plugin.infra.PluginRequestProcessorRegistry;
 import com.thoughtworks.go.plugin.infra.plugininfo.GoPluginDescriptor;
-import com.thoughtworks.go.server.service.AgentConfigService;
 import com.thoughtworks.go.server.service.AgentService;
 import com.thoughtworks.go.server.service.plugins.processor.elasticagent.v1.ElasticAgentRequestProcessorV1;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -37,9 +36,9 @@ public class ElasticAgentRequestProcessor implements GoPluginApiRequestProcessor
     private Map<String, VersionableElasticAgentProcessor> versionableProcessorMap = new HashMap<>();
 
     @Autowired
-    public ElasticAgentRequestProcessor(PluginRequestProcessorRegistry registry, AgentService agentService, AgentConfigService agentConfigService) {
+    public ElasticAgentRequestProcessor(PluginRequestProcessorRegistry registry, AgentService agentService) {
         this(registry, new HashMap<String, VersionableElasticAgentProcessor>() {{
-            put("1.0", new ElasticAgentRequestProcessorV1(agentService, agentConfigService));
+            put("1.0", new ElasticAgentRequestProcessorV1(agentService));
         }});
     }
 

--- a/server/src/main/java/com/thoughtworks/go/server/service/plugins/processor/elasticagent/v1/ElasticAgentRequestProcessorV1.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/plugins/processor/elasticagent/v1/ElasticAgentRequestProcessorV1.java
@@ -21,7 +21,6 @@ import com.thoughtworks.go.plugin.api.request.GoApiRequest;
 import com.thoughtworks.go.plugin.api.response.DefaultGoApiResponse;
 import com.thoughtworks.go.plugin.api.response.GoApiResponse;
 import com.thoughtworks.go.plugin.infra.plugininfo.GoPluginDescriptor;
-import com.thoughtworks.go.server.service.AgentConfigService;
 import com.thoughtworks.go.server.service.AgentService;
 import com.thoughtworks.go.server.service.plugins.processor.elasticagent.AbstractVersionableElasticAgentProcessor;
 import com.thoughtworks.go.server.service.plugins.processor.elasticagent.ElasticAgentProcessorConverter;
@@ -34,12 +33,12 @@ public class ElasticAgentRequestProcessorV1 extends AbstractVersionableElasticAg
     public static final String VERSION = "1.0";
     private ElasticAgentProcessorConverter elasticAgentProcessorConverterV1;
 
-    public ElasticAgentRequestProcessorV1(AgentService agentService, AgentConfigService agentConfigService) {
-        this(agentService, agentConfigService, new ElasticAgentProcessorConverterV1());
+    public ElasticAgentRequestProcessorV1(AgentService agentService) {
+        this(agentService, new ElasticAgentProcessorConverterV1());
     }
 
-    ElasticAgentRequestProcessorV1(AgentService agentService, AgentConfigService agentConfigService, ElasticAgentProcessorConverterV1 converterV1) {
-        super(agentService, agentConfigService);
+    ElasticAgentRequestProcessorV1(AgentService agentService, ElasticAgentProcessorConverterV1 converterV1) {
+        super(agentService);
         elasticAgentProcessorConverterV1 = converterV1;
     }
 

--- a/server/src/main/java/com/thoughtworks/go/server/service/support/ConfigInfoProvider.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/support/ConfigInfoProvider.java
@@ -19,6 +19,7 @@ package com.thoughtworks.go.server.service.support;
 import com.thoughtworks.go.config.CruiseConfig;
 import com.thoughtworks.go.plugin.access.authorization.AuthorizationMetadataStore;
 import com.thoughtworks.go.plugin.domain.authorization.AuthorizationPluginInfo;
+import com.thoughtworks.go.server.service.AgentService;
 import com.thoughtworks.go.server.service.GoConfigService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -33,15 +34,17 @@ import static java.util.Collections.singletonMap;
 public class ConfigInfoProvider implements ServerInfoProvider {
     private GoConfigService goConfigService;
     private final AuthorizationMetadataStore authorizationMetadataStore;
+    private AgentService agentService;
 
     @Autowired
-    public ConfigInfoProvider(GoConfigService goConfigService) {
-        this(goConfigService, AuthorizationMetadataStore.instance());
+    public ConfigInfoProvider(GoConfigService goConfigService, AgentService agentService) {
+        this(goConfigService, AuthorizationMetadataStore.instance(), agentService);
     }
 
-    ConfigInfoProvider(GoConfigService goConfigService, AuthorizationMetadataStore authorizationMetadataStore) {
+    ConfigInfoProvider(GoConfigService goConfigService, AuthorizationMetadataStore authorizationMetadataStore, AgentService agentService) {
         this.goConfigService = goConfigService;
         this.authorizationMetadataStore = authorizationMetadataStore;
+        this.agentService = agentService;
     }
 
     @Override
@@ -56,7 +59,7 @@ public class ConfigInfoProvider implements ServerInfoProvider {
 
         LinkedHashMap<String, Object> validConfig = new LinkedHashMap<>();
         validConfig.put("Number of pipelines", goConfigService.getAllPipelineConfigs().size());
-        validConfig.put("Number of agents", goConfigService.agents().size());
+        validConfig.put("Number of agents", agentService.agents().size());
         validConfig.put("Number of environments", currentConfig.getEnvironments().size());
         validConfig.put("Number of unique materials", currentConfig.getAllUniqueMaterials().size());
         validConfig.put("Number of schedulable materials", goConfigService.getSchedulableMaterials().size());

--- a/server/src/test-fast/java/com/thoughtworks/go/server/controller/JobControllerTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/controller/JobControllerTest.java
@@ -49,7 +49,7 @@ public class JobControllerTest {
     private JobController jobController;
     private JobInstanceService jobInstanceService;
     private JobInstanceDao jobInstanceDao;
-    private GoConfigService jobConfigService;
+    private GoConfigService goConfigService;
     private AgentService agentService;
     private StageService stageService;
     private PipelineService pipelineService;
@@ -62,7 +62,7 @@ public class JobControllerTest {
     public void setUp() throws Exception {
         jobInstanceService = mock(JobInstanceService.class);
         jobInstanceDao = mock(JobInstanceDao.class);
-        jobConfigService = mock(GoConfigService.class);
+        goConfigService = mock(GoConfigService.class);
         agentService = mock(AgentService.class);
         stageService = mock(StageService.class);
         response = new MockHttpServletResponse();
@@ -70,7 +70,7 @@ public class JobControllerTest {
         pipelineService = mock(PipelineService.class);
         restfulService = mock(RestfulService.class);
         propertiesService = mock(PropertiesService.class);
-        jobController = new JobController(jobInstanceService, agentService, jobInstanceDao, jobConfigService, pipelineService, restfulService, null, propertiesService, stageService, null, systemEnvironment);
+        jobController = new JobController(jobInstanceService, agentService, jobInstanceDao, goConfigService, pipelineService, restfulService, null, propertiesService, stageService, null, systemEnvironment);
     }
 
     @Test
@@ -166,14 +166,14 @@ public class JobControllerTest {
             jobInstance.setState(JobState.Unknown);
 
             when(jobInstanceService.latestCompletedJobs("p1", "s1", jobInstance.getName())).thenReturn(new JobInstances());
-            when(jobConfigService.agentByUuid(anyString())).thenReturn(new AgentConfig());
+            when(agentService.registeredAgentByUUID(anyString())).thenReturn(new AgentConfig());
             when(pipelineService.wrapBuildDetails(jobInstance)).thenReturn(pipeline);
             when(pipelineService.resolvePipelineCounter(eq("p1"), anyString())).thenReturn(Optional.of(1));
             when(restfulService.translateStageCounter(any(PipelineIdentifier.class), eq("s1"), anyString())).thenReturn(stageIdentifier);
             when(pipelineService.findPipelineByNameAndCounter("p1", 1)).thenReturn(pipeline);
             when(jobInstanceDao.mostRecentJobWithTransitions(jobIdentifier)).thenReturn(jobInstance);
             when(jobInstanceDao.mostRecentJobWithTransitions(any(JobIdentifier.class))).thenReturn(jobInstance);
-            when(jobConfigService.pipelineConfigNamed(any(CaseInsensitiveString.class))).thenReturn(PipelineConfigMother.pipelineConfig("p1"));
+            when(goConfigService.pipelineConfigNamed(any(CaseInsensitiveString.class))).thenReturn(PipelineConfigMother.pipelineConfig("p1"));
             when(propertiesService.getPropertiesForJob(any(Long.class))).thenReturn(new Properties());
             when(stageService.getStageByBuild(jobInstance)).thenReturn(StageMother.passedStageInstance("s1", "plan1", "p1"));
 

--- a/server/src/test-fast/java/com/thoughtworks/go/server/service/AgentConfigServiceTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/service/AgentConfigServiceTest.java
@@ -20,6 +20,7 @@ import com.thoughtworks.go.config.AgentConfig;
 import com.thoughtworks.go.config.CruiseConfig;
 import com.thoughtworks.go.config.GoConfigDao;
 import com.thoughtworks.go.config.UpdateConfigCommand;
+import com.thoughtworks.go.config.update.AddAgentCommand;
 import com.thoughtworks.go.config.update.AgentsUpdateCommand;
 import com.thoughtworks.go.domain.AgentInstance;
 import com.thoughtworks.go.domain.AgentRuntimeStatus;
@@ -54,7 +55,7 @@ public class AgentConfigServiceTest {
         AgentRuntimeInfo agentRuntimeInfo = AgentRuntimeInfo.fromAgent(new AgentIdentifier("remote-host", "50.40.30.20", agentId), AgentRuntimeStatus.Unknown, "cookie", false);
         AgentInstance instance = AgentInstance.createFromLiveAgent(agentRuntimeInfo, new SystemEnvironment(), null);
         agentConfigService.enableAgents(Username.ANONYMOUS, instance);
-        shouldPerformCommand(new GoConfigDao.CompositeConfigCommand(new AgentConfigService.AddAgentCommand(agentConfig)));
+        shouldPerformCommand(new GoConfigDao.CompositeConfigCommand(new AddAgentCommand(agentConfig)));
     }
 
     private void shouldPerformCommand(UpdateConfigCommand command) {
@@ -78,7 +79,7 @@ public class AgentConfigServiceTest {
         agentConfigService.enableAgents(Username.ANONYMOUS, pending, fromConfigFile);
 
         GoConfigDao.CompositeConfigCommand command = new GoConfigDao.CompositeConfigCommand(
-                new AgentConfigService.AddAgentCommand(pending.agentConfig()),
+                new AddAgentCommand(pending.agentConfig()),
                 new AgentConfigService.UpdateAgentApprovalStatus("UUID2", false));
         ArgumentCaptor<AgentsUpdateCommand> captor = ArgumentCaptor.forClass(AgentsUpdateCommand.class);
         verify(goConfigService).updateConfig(captor.capture(), eq(Username.ANONYMOUS));

--- a/server/src/test-fast/java/com/thoughtworks/go/server/service/EnvironmentConfigServiceTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/service/EnvironmentConfigServiceTest.java
@@ -176,35 +176,6 @@ public class EnvironmentConfigServiceTest {
     }
 
     @Test
-    public void shouldFindAgentsForPipelineUnderEnvironment() throws Exception {
-        environmentConfigService.sync(environments("uat", "prod"));
-        AgentConfig agentUnderEnv = new AgentConfig("uat-agent", "localhost", "127.0.0.1");
-        AgentConfig omnipresentAgent = new AgentConfig(EnvironmentConfigMother.OMNIPRESENT_AGENT, "localhost", "127.0.0.2");
-
-        Mockito.when(mockGoConfigService.agentByUuid("uat-agent")).thenReturn(agentUnderEnv);
-        Mockito.when(mockGoConfigService.agentByUuid(EnvironmentConfigMother.OMNIPRESENT_AGENT)).thenReturn(omnipresentAgent);
-
-        assertThat(environmentConfigService.agentsForPipeline(new CaseInsensitiveString("uat-pipeline")).size(), is(2));
-        assertThat(environmentConfigService.agentsForPipeline(new CaseInsensitiveString("uat-pipeline")), hasItem(agentUnderEnv));
-        assertThat(environmentConfigService.agentsForPipeline(new CaseInsensitiveString("uat-pipeline")), hasItem(omnipresentAgent));
-    }
-
-    @Test
-    public void shouldFindAgentsForPipelineUnderNoEnvironment() throws Exception {
-        environmentConfigService.sync(environments("uat", "prod"));
-        AgentConfig noEnvAgent = new AgentConfig("no-env-agent", "localhost", "127.0.0.1");
-
-        Agents agents = new Agents();
-        agents.add(noEnvAgent);
-        agents.add(new AgentConfig(EnvironmentConfigMother.OMNIPRESENT_AGENT, "localhost", "127.0.0.2"));
-        Mockito.when(mockGoConfigService.agents()).thenReturn(agents);
-
-
-        assertThat(environmentConfigService.agentsForPipeline(new CaseInsensitiveString("no-env-pipeline")).size(), is(1));
-        assertThat(environmentConfigService.agentsForPipeline(new CaseInsensitiveString("no-env-pipeline")), hasItem(noEnvAgent));
-    }
-
-    @Test
     public void shouldListEnvironmentVariablesDefinedForAnEnvironment() throws Exception {
         EnvironmentsConfig environmentConfigs = new EnvironmentsConfig();
         BasicEnvironmentConfig environment = environment("uat");

--- a/server/src/test-fast/java/com/thoughtworks/go/server/service/plugins/processor/elasticagent/v1/ElasticAgentRequestProcessorV1Test.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/service/plugins/processor/elasticagent/v1/ElasticAgentRequestProcessorV1Test.java
@@ -24,7 +24,6 @@ import com.thoughtworks.go.plugin.api.request.DefaultGoApiRequest;
 import com.thoughtworks.go.plugin.api.response.GoApiResponse;
 import com.thoughtworks.go.plugin.infra.plugininfo.GoPluginDescriptor;
 import com.thoughtworks.go.server.domain.ElasticAgentMetadata;
-import com.thoughtworks.go.server.service.AgentConfigService;
 import com.thoughtworks.go.server.service.AgentService;
 import org.junit.Before;
 import org.junit.Test;
@@ -35,16 +34,12 @@ import java.util.Arrays;
 
 import static com.thoughtworks.go.server.service.plugins.processor.elasticagent.v1.ElasticAgentProcessorRequestsV1.*;
 import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 import static org.mockito.MockitoAnnotations.initMocks;
 
 public class ElasticAgentRequestProcessorV1Test {
     @Mock
     private AgentService agentService;
-    @Mock
-    private AgentConfigService agentConfigService;
     @Mock
     private GoPluginDescriptor pluginDescriptor;
     @Mock
@@ -58,7 +53,7 @@ public class ElasticAgentRequestProcessorV1Test {
 
         when(pluginDescriptor.id()).thenReturn("cd.go.example.plugin");
 
-        processor = new ElasticAgentRequestProcessorV1(agentService, agentConfigService);
+        processor = new ElasticAgentRequestProcessorV1(agentService);
     }
 
     @Test
@@ -85,7 +80,7 @@ public class ElasticAgentRequestProcessorV1Test {
 
         processor.process(pluginDescriptor, request);
 
-        verify(agentConfigService).disableAgents(processor.usernameFor(pluginDescriptor.id()), agentInstance);
+        verify(agentService).disableAgents(processor.usernameFor(pluginDescriptor.id()), agentInstance);
     }
 
     @Test
@@ -96,7 +91,8 @@ public class ElasticAgentRequestProcessorV1Test {
 
         processor.process(pluginDescriptor, request);
 
-        verifyZeroInteractions(agentConfigService);
+        verify(agentService).findElasticAgent("foo", "cd.go.example.plugin");
+        verifyNoMoreInteractions(agentService);
     }
 
     @Test
@@ -109,7 +105,7 @@ public class ElasticAgentRequestProcessorV1Test {
 
         processor.process(pluginDescriptor, request);
 
-        verify(agentConfigService).deleteAgents(processor.usernameFor(pluginDescriptor.id()), agentInstance);
+        verify(agentService).deleteAgents(processor.usernameFor(pluginDescriptor.id()), agentInstance);
     }
 
     @Test
@@ -120,6 +116,7 @@ public class ElasticAgentRequestProcessorV1Test {
 
         processor.process(pluginDescriptor, request);
 
-        verifyZeroInteractions(agentConfigService);
+        verify(agentService).findElasticAgent("foo", "cd.go.example.plugin");
+        verifyNoMoreInteractions(agentService);
     }
 }

--- a/server/src/test-integration/java/com/thoughtworks/go/server/controller/AgentRegistrationControllerIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/controller/AgentRegistrationControllerIntegrationTest.java
@@ -88,7 +88,7 @@ public class AgentRegistrationControllerIntegrationTest {
         String uuid = UUID.randomUUID().toString();
         MockHttpServletRequest request = new MockHttpServletRequest();
         final ResponseEntity responseEntity = controller.agentRequest("hostname", uuid, "sandbox", "100", null, null, null, null, null, null, null, false, token(uuid, goConfigService.serverConfig().getTokenGenerationKey()), request);
-        AgentConfig agentConfig = goConfigService.agentByUuid(uuid);
+        AgentConfig agentConfig = agentService.registeredAgentByUUID(uuid);
 
         assertThat(agentConfig.getHostname(), is("hostname"));
         assertThat(responseEntity.getStatusCode(), is(HttpStatus.OK));
@@ -116,7 +116,7 @@ public class AgentRegistrationControllerIntegrationTest {
                 false,
                 token(uuid, goConfigService.serverConfig().getTokenGenerationKey()),
                 request);
-        AgentConfig agentConfig = goConfigService.agentByUuid(uuid);
+        AgentConfig agentConfig = agentService.registeredAgentByUUID(uuid);
 
         assertTrue(agentConfig.isElastic());
         assertThat(responseEntity.getStatusCode(), is(HttpStatus.OK));
@@ -145,7 +145,7 @@ public class AgentRegistrationControllerIntegrationTest {
                 false,
                 token(uuid, goConfigService.serverConfig().getTokenGenerationKey()),
                 request);
-        AgentConfig agentConfig = goConfigService.agentByUuid(uuid);
+        AgentConfig agentConfig = agentService.registeredAgentByUUID(uuid);
         assertTrue(agentConfig.isElastic());
 
         final ResponseEntity responseEntity = controller.agentRequest("elastic-agent-hostname",
@@ -198,9 +198,9 @@ public class AgentRegistrationControllerIntegrationTest {
     @Test
     public void shouldNotRegisterAgentWhenValidationFails() throws Exception {
         MockHttpServletRequest request = new MockHttpServletRequest();
-        int totalAgentsBeforeRegistrationRequest = goConfigService.agents().size();
+        int totalAgentsBeforeRegistrationRequest = agentService.registeredAgentConfigs().size();
         final ResponseEntity responseEntity = controller.agentRequest("hostname", "", "sandbox", "100", null, null, null, null, null, null, null, false, token("", goConfigService.serverConfig().getTokenGenerationKey()), request);
-        int totalAgentsAfterRegistrationRequest = goConfigService.agents().size();
+        int totalAgentsAfterRegistrationRequest = agentService.registeredAgentConfigs().size();
         assertThat(totalAgentsBeforeRegistrationRequest, is(totalAgentsAfterRegistrationRequest));
 
         assertThat(responseEntity.getStatusCode(), is(UNPROCESSABLE_ENTITY));

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/PipelineScheduleServiceTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/PipelineScheduleServiceTest.java
@@ -80,9 +80,8 @@ public class PipelineScheduleServiceTest {
     @Autowired private DatabaseAccessHelper dbHelper;
     @Autowired private PipelineLockService pipelineLockService;
     @Autowired private GoCache goCache;
-    @Autowired private EnvironmentConfigService environmentConfigService;
     @Autowired private MaterialRepository materialRepository;
-    @Autowired private TransactionTemplate transactionTemplate;
+    @Autowired private TransactionTemplate  transactionTemplate;
     @Autowired private SubprocessExecutionContext subprocessExecutionContext;
     @Autowired private InstanceFactory instanceFactory;
     @Rule
@@ -190,7 +189,7 @@ public class PipelineScheduleServiceTest {
         BuildCause buildCause = BuildCause.createWithModifications(revisions, "");
         dbHelper.saveMaterials(buildCause.getMaterialRevisions());
 
-        Pipeline pipeline = instanceFactory.createPipelineInstance(evolveConfig, buildCause, new DefaultSchedulingContext(DEFAULT_APPROVED_BY, environmentConfigService.agentsForPipeline(evolveConfig.name())), md5,
+        Pipeline pipeline = instanceFactory.createPipelineInstance(evolveConfig, buildCause, new DefaultSchedulingContext(DEFAULT_APPROVED_BY, scheduleService.agentsForPipeline(evolveConfig.name())), md5,
                 new TimeProvider());
         pipelineService.save(pipeline);
 
@@ -215,7 +214,7 @@ public class PipelineScheduleServiceTest {
 		BuildCause buildCause = BuildCause.createWithModifications(revisions, "");
 		dbHelper.saveMaterials(buildCause.getMaterialRevisions());
 
-		Pipeline pipeline = instanceFactory.createPipelineInstance(evolveConfig, buildCause, new DefaultSchedulingContext(DEFAULT_APPROVED_BY, environmentConfigService.agentsForPipeline(evolveConfig.name())), md5, new TimeProvider());
+		Pipeline pipeline = instanceFactory.createPipelineInstance(evolveConfig, buildCause, new DefaultSchedulingContext(DEFAULT_APPROVED_BY, scheduleService.agentsForPipeline(evolveConfig.name())), md5, new TimeProvider());
 		pipelineService.save(pipeline);
 
 		Stage instance = scheduleService.scheduleStage(pipeline, STAGE_NAME, "anyone", new ScheduleService.NewStageInstanceCreator(goConfigService), new ScheduleService.ExceptioningErrorHandler());


### PR DESCRIPTION
#911
- Use `AgentService#hasRegisteredAgent()` instead of `GoConfigService#hasAgent()`
- Move `agentsForPipeline()` from `EnvironmentConfigService` to `ScheduleService`.
- Use `AgentService` to get agents instead of using `GoConfigService`.