### PR TITLE
Fix for edit and clone Elastic Agent Profile buttons:

### DIFF
--- a/server/webapp/WEB-INF/rails/webpack/views/pages/elastic_profiles/cluster_profile_widget.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/elastic_profiles/cluster_profile_widget.tsx
@@ -91,7 +91,7 @@ export class ClusterProfileWidget extends MithrilComponent<ClusterProfileWidgetA
       {this.getClusterProfileDetails(vnode)}
       <h4>Elastic Agent Profiles</h4>
       <ElasticProfilesWidget elasticProfiles={new ElasticAgentProfiles(filteredElasticAgentProfiles)}
-                             pluginInfos={vnode.attrs.pluginInfos}
+                             pluginInfo={pluginInfo}
                              elasticAgentOperations={vnode.attrs.elasticAgentOperations}
                              onShowUsages={vnode.attrs.onShowUsages.bind(vnode.attrs)}
                              isUserAnAdmin={vnode.attrs.isUserAnAdmin}/>


### PR DESCRIPTION
* Both the edit and clone buttons for Elastic Agent Profile were disabled even if installed elastic agent plugin supports Cluster Profile. #6154 

![Screenshot 2019-04-22 at 3 40 11 PM](https://user-images.githubusercontent.com/34642373/56498476-70a89a00-651f-11e9-9f8e-d85ada219b96.png)
