### PR TITLE
Encrypt secure plugin properties on server startup (#6184)

### DIFF
--- a/plugin-infra/go-plugin-infra/src/main/java/com/thoughtworks/go/plugin/infra/ElasticAgentInformationMigrator.java
+++ b/plugin-infra/go-plugin-infra/src/main/java/com/thoughtworks/go/plugin/infra/ElasticAgentInformationMigrator.java
@@ -19,5 +19,5 @@ package com.thoughtworks.go.plugin.infra;
 import com.thoughtworks.go.plugin.infra.plugininfo.GoPluginDescriptor;
 
 public interface ElasticAgentInformationMigrator {
-    void migrate(GoPluginDescriptor pluginDescriptor);
+    boolean migrate(GoPluginDescriptor pluginDescriptor);
 }

--- a/plugin-infra/go-plugin-infra/src/main/java/com/thoughtworks/go/plugin/infra/FelixGoPluginOSGiFramework.java
+++ b/plugin-infra/go-plugin-infra/src/main/java/com/thoughtworks/go/plugin/infra/FelixGoPluginOSGiFramework.java
@@ -101,7 +101,6 @@ public class FelixGoPluginOSGiFramework implements GoPluginOSGiFramework {
     public Bundle loadPlugin(GoPluginDescriptor pluginDescriptor) {
         File bundleLocation = pluginDescriptor.bundleLocation();
         return getBundle(pluginDescriptor, bundleLocation);
-
     }
 
     private Bundle getBundle(GoPluginDescriptor pluginDescriptor, File bundleLocation) {
@@ -125,10 +124,6 @@ public class FelixGoPluginOSGiFramework implements GoPluginOSGiFramework {
 
                     return bundle;
                 }
-            }
-
-            if (elasticAgentInformationMigrator != null) {
-                elasticAgentInformationMigrator.migrate(pluginDescriptor);
             }
 
             if (pluginDescriptor.isInvalid()) {
@@ -193,6 +188,15 @@ public class FelixGoPluginOSGiFramework implements GoPluginOSGiFramework {
     @Override
     public void setElasticAgentInformationMigrator(ElasticAgentInformationMigrator elasticAgentInformationMigrator) {
         this.elasticAgentInformationMigrator = elasticAgentInformationMigrator;
+    }
+
+    @Override
+    public boolean migrateConfig(GoPluginDescriptor descriptor) {
+        if (elasticAgentInformationMigrator != null) {
+            return elasticAgentInformationMigrator.migrate(descriptor);
+        }
+
+        return true;
     }
 
     private void registerInternalServices(BundleContext bundleContext) {

--- a/plugin-infra/go-plugin-infra/src/main/java/com/thoughtworks/go/plugin/infra/GoPluginOSGiFramework.java
+++ b/plugin-infra/go-plugin-infra/src/main/java/com/thoughtworks/go/plugin/infra/GoPluginOSGiFramework.java
@@ -43,4 +43,6 @@ public interface GoPluginOSGiFramework {
     <T extends GoPlugin> Map<String, List<String>> getExtensionsInfoFromThePlugin(String pluginId);
 
     void setElasticAgentInformationMigrator(ElasticAgentInformationMigrator elasticAgentInformationMigrator);
+
+    boolean migrateConfig(GoPluginDescriptor descriptor);
 }

--- a/plugin-infra/go-plugin-infra/src/main/java/com/thoughtworks/go/plugin/infra/listeners/DefaultPluginJarChangeListener.java
+++ b/plugin-infra/go-plugin-infra/src/main/java/com/thoughtworks/go/plugin/infra/listeners/DefaultPluginJarChangeListener.java
@@ -149,6 +149,10 @@ public class DefaultPluginJarChangeListener implements PluginJarChangeListener {
         if (!descriptor.isInvalid()) {
             osgiManifestGenerator.updateManifestOf(descriptor);
             goPluginOSGiFramework.loadPlugin(descriptor);
+            boolean migratedSuccessfully = goPluginOSGiFramework.migrateConfig(descriptor);
+            if (!migratedSuccessfully) {
+                goPluginOSGiFramework.unloadPlugin(descriptor);
+            }
         }
     }
 

--- a/plugin-infra/go-plugin-infra/src/test/java/com/thoughtworks/go/plugin/infra/DefaultPluginManagerTest.java
+++ b/plugin-infra/go-plugin-infra/src/test/java/com/thoughtworks/go/plugin/infra/DefaultPluginManagerTest.java
@@ -404,6 +404,11 @@ public class DefaultPluginManagerTest {
         }
 
         @Override
+        public boolean migrateConfig(GoPluginDescriptor descriptor) {
+            return true;
+        }
+
+        @Override
         public <T, R> R doOn(Class<T> serviceReferenceClass, String pluginId, String extensionType, ActionWithReturn<T, R> action) {
             return action.execute((T) serviceReferenceInstance, mock(GoPluginDescriptor.class));
         }

--- a/server/src/test-fast/java/com/thoughtworks/go/server/service/ElasticAgentInformationMigratorImplTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/service/ElasticAgentInformationMigratorImplTest.java
@@ -64,8 +64,9 @@ class ElasticAgentInformationMigratorImplTest {
     void shouldDoNothingForNonElasticAgentPlugins() {
         when(pluginManager.isPluginOfType(ELASTIC_AGENT_EXTENSION, goPluginDescriptor.id())).thenReturn(false);
 
-        elasticAgentInformationMigrator.migrate(goPluginDescriptor);
+        boolean migratedSuccessfully = elasticAgentInformationMigrator.migrate(goPluginDescriptor);
 
+        assertThat(migratedSuccessfully).isTrue();
         verifyZeroInteractions(goConfigService);
     }
 
@@ -78,8 +79,9 @@ class ElasticAgentInformationMigratorImplTest {
         when(pluginManager.isPluginOfType(ELASTIC_AGENT_EXTENSION, goPluginDescriptor.id())).thenReturn(true);
         when(pluginSqlMapDao.findPlugin(PLUGIN_ID)).thenReturn(new Plugin(PLUGIN_ID, JsonHelper.toJsonString(configuration)));
 
-        elasticAgentInformationMigrator.migrate(goPluginDescriptor);
+        boolean migratedSuccessfully = elasticAgentInformationMigrator.migrate(goPluginDescriptor);
 
+        assertThat(migratedSuccessfully).isTrue();
         verify(goConfigService, times(1)).updateConfig(any(ReplaceElasticAgentInformationCommand.class));
     }
 
@@ -88,8 +90,9 @@ class ElasticAgentInformationMigratorImplTest {
         when(pluginManager.isPluginOfType(ELASTIC_AGENT_EXTENSION, goPluginDescriptor.id())).thenReturn(true);
         when(pluginSqlMapDao.findPlugin(PLUGIN_ID)).thenReturn(new Plugin(PLUGIN_ID, null));
 
-        elasticAgentInformationMigrator.migrate(goPluginDescriptor);
+        boolean migratedSuccessfully = elasticAgentInformationMigrator.migrate(goPluginDescriptor);
 
+        assertThat(migratedSuccessfully).isTrue();
         verify(goConfigService, times(1)).updateConfig(any(ReplaceElasticAgentInformationCommand.class));
     }
 
@@ -101,10 +104,11 @@ class ElasticAgentInformationMigratorImplTest {
 
         assertThat(goPluginDescriptor.isInvalid()).isFalse();
 
-        elasticAgentInformationMigrator.migrate(goPluginDescriptor);
+        boolean migratedSuccessfully = elasticAgentInformationMigrator.migrate(goPluginDescriptor);
 
         String expectedErrorMessage = "Plugin 'plugin-id' failed to perform 'cd.go.elastic-agent.migrate-config' call. Plugin sent an invalid config. Reason: Boom!.\n Please fix the errors and restart GoCD server.";
 
+        assertThat(migratedSuccessfully).isFalse();
         assertThat(goPluginDescriptor.isInvalid()).isTrue();
         assertThat(goPluginDescriptor.getStatus().getMessages().get(0)).isEqualTo(expectedErrorMessage);
     }


### PR DESCRIPTION
* On Server startup, GoCD server would make a call to plugin to
  migrate configurations. Upon successful migration, GoCD tries to
  encrypt and store secure plugin properties.
* Server check if a property is secure or not based on the plugin
  info. But, at the time of plugin config migration, plugin info
  is not loaded and all properties are considered to be plainText.

Fix:
* Load plugin infos as part of pluginLoad.
* Perform config migrations after plugin is loaded.
* Unload plugin when the config migration is not successful.