### PR TITLE
Elastic Profiles SPA Fixes (#6154)

### DIFF
--- a/server/webapp/WEB-INF/rails/webpack/views/pages/elastic_profiles.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/elastic_profiles.tsx
@@ -59,14 +59,14 @@ export class ElasticProfilesPage extends Page<null, State> {
         event.stopPropagation();
         this.flashMessage.clear();
 
-        new CloneElasticProfileModal(elasticProfile.id(), vnode.state.pluginInfos(), vnode.state.clusterProfiles, vnode.state.onSuccessfulSave).render();
+        new CloneElasticProfileModal(elasticProfile.id(), elasticProfile.pluginId(), vnode.state.pluginInfos(), vnode.state.clusterProfiles, vnode.state.onSuccessfulSave).render();
       },
 
       onEdit: (elasticProfile: ElasticAgentProfile, event: MouseEvent) => {
         event.stopPropagation();
         this.flashMessage.clear();
 
-        new EditElasticProfileModal(elasticProfile.id(), vnode.state.pluginInfos(), vnode.state.clusterProfiles, vnode.state.onSuccessfulSave).render();
+        new EditElasticProfileModal(elasticProfile.id(), elasticProfile.pluginId(), vnode.state.pluginInfos(), vnode.state.clusterProfiles, vnode.state.onSuccessfulSave).render();
       },
 
       onDelete: (id: string, event: MouseEvent) => {
@@ -212,8 +212,8 @@ export class ElasticProfilesPage extends Page<null, State> {
   fetchData(vnode: m.Vnode<null, State>) {
     return Promise.all([
                          PluginInfoCRUD.all({type: ExtensionType.ELASTIC_AGENTS}),
-                         ElasticAgentProfilesCRUD.all(),
-                         ClusterProfilesCRUD.all()
+                         ClusterProfilesCRUD.all(),
+                         ElasticAgentProfilesCRUD.all()
                        ]).then((results) => {
       results[0].do(
         (successResponse) => {
@@ -225,14 +225,16 @@ export class ElasticProfilesPage extends Page<null, State> {
       results[1].do(
         (successResponse) => {
           this.pageState              = PageState.OK;
-          vnode.state.elasticProfiles = successResponse.body;
-        },
-        () => this.setErrorState()
-      );
-      results[2].do(
-        (successResponse) => {
-          this.pageState              = PageState.OK;
           vnode.state.clusterProfiles = successResponse.body;
+
+          results[2].do(
+            (successResponse) => {
+              this.pageState              = PageState.OK;
+              successResponse.body.inferPluginIdFromReferencedCluster(vnode.state.clusterProfiles);
+              vnode.state.elasticProfiles = successResponse.body;
+            },
+            () => this.setErrorState()
+          );
         },
         () => this.setErrorState()
       );

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/elastic_profiles/cluster_profile_widget.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/elastic_profiles/cluster_profile_widget.tsx
@@ -66,11 +66,7 @@ interface HeaderAttrs {
 class ClusterProfileHeaderWidget extends MithrilComponent<HeaderAttrs> {
   view(vnode: m.Vnode<HeaderAttrs, State>) {
     const title = <div data-test-id="cluster-profile-name" className={styles.clusterProfileName}><span>{vnode.attrs.clusterProfileId}</span></div>;
-
-    return [
-      <KeyValueTitle title={title} image={vnode.attrs.image}/>,
-      <KeyValuePair inline={true} data={new Map([["Plugin", vnode.attrs.pluginName]])}/>
-    ];
+    return (<KeyValueTitle title={title} image={vnode.attrs.image}/>);
   }
 }
 

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/elastic_profiles/elastic_agent_profiles_modals.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/elastic_profiles/elastic_agent_profiles_modals.tsx
@@ -187,6 +187,7 @@ export class EditElasticProfileModal extends BaseElasticProfileModal {
   private readonly elasticProfileId: string;
 
   constructor(elasticProfileId: string,
+              pluginId: string,
               pluginInfos: Array<PluginInfo<Extension>>,
               clusterProfiles: ClusterProfiles,
               onSuccessfulSave: (msg: m.Children) => any
@@ -201,6 +202,7 @@ export class EditElasticProfileModal extends BaseElasticProfileModal {
         result.do(
           (successResponse) => {
             this.elasticProfile(successResponse.body.object);
+            this.elasticProfile().pluginId(pluginId);
             this.etag = successResponse.body.etag;
           },
           ((errorResponse) => this.onError(errorResponse.message))
@@ -238,6 +240,7 @@ export class CloneElasticProfileModal extends BaseElasticProfileModal {
   private readonly sourceProfileId: string;
 
   constructor(elasticProfileId: string,
+              pluginId: string,
               pluginInfos: Array<PluginInfo<Extension>>,
               clusterProfiles: ClusterProfiles,
               onSuccessfulSave: (msg: m.Children) => any) {
@@ -252,6 +255,7 @@ export class CloneElasticProfileModal extends BaseElasticProfileModal {
           (successResponse) => {
             const elasticProfile = successResponse.body.object;
             elasticProfile.id("");
+            elasticProfile.pluginId(pluginId);
             this.elasticProfile(elasticProfile);
           },
           (errorResponse) => this.onError(errorResponse.message)

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/elastic_profiles/spec/cluster_profiles_widget_spec.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/elastic_profiles/spec/cluster_profiles_widget_spec.tsx
@@ -89,8 +89,6 @@ describe("ClusterProfilesWidget", () => {
     mount(pluginInfos, clusterProfiles, new ElasticAgentProfiles([]));
 
     expect(helper.findIn(helper.findByDataTestId("collapse-header")[0], "cluster-profile-name")).toHaveText("cluster_3");
-    expect(helper.findIn(helper.findByDataTestId("collapse-header")[0], "key-value-key-plugin")).toHaveText("Plugin");
-    expect(helper.findIn(helper.findByDataTestId("collapse-header")[0], "key-value-value-plugin")).toHaveText("Docker Elastic Agent Plugin");
 
     helper.unmount();
   });


### PR DESCRIPTION
* Remove plugin id from the cluster profiles header.
* Appropriately select cluster profile for new elastic agent profiles
  modal.
* Show appropriate cluster profiles in the cluster profile id
  dropdown when multiple EA plugins are used.