### PR TITLE
Remove 'save' calls from 'find' functions

### DIFF
--- a/server/src/main/java/com/thoughtworks/go/server/persistence/PipelineRepository.java
+++ b/server/src/main/java/com/thoughtworks/go/server/persistence/PipelineRepository.java
@@ -251,7 +251,6 @@ public class PipelineRepository extends HibernateDaoSupport {
             pipelineSelections = getHibernateTemplate().get(PipelineSelections.class, id);
 
             if (null != pipelineSelections) {
-                getHibernateTemplate().saveOrUpdate(pipelineSelections);
                 goCache.put(key, pipelineSelections);
             }
 
@@ -284,8 +283,6 @@ public class PipelineRepository extends HibernateDaoSupport {
                 pipelineSelections = null;
             } else {
                 pipelineSelections = (PipelineSelections) list.get(0);
-
-                getHibernateTemplate().saveOrUpdate(pipelineSelections);
             }
 
             goCache.put(key, pipelineSelections);


### PR DESCRIPTION
The save calls seem to be redundant and would cause problems if a user wants to view the dashboard in readonly mode on a standby server
