### PR TITLE
Fixed config repo api v1 post url normalization of git and hg materials

### DIFF
--- a/api/api-config-repos-v1/src/main/java/com/thoughtworks/go/apiv1/configrepos/representers/GitMaterialRepresenter.java
+++ b/api/api-config-repos-v1/src/main/java/com/thoughtworks/go/apiv1/configrepos/representers/GitMaterialRepresenter.java
@@ -21,20 +21,20 @@ import com.thoughtworks.go.api.representers.JsonReader;
 import com.thoughtworks.go.config.materials.git.GitMaterialConfig;
 import com.thoughtworks.go.domain.materials.MaterialConfig;
 
+import static com.thoughtworks.go.config.migration.UrlDenormalizerXSLTMigration121.urlWithCredentials;
+
 class GitMaterialRepresenter {
     static void toJSON(OutputWriter json, GitMaterialConfig material) {
         json.add("name", material.getName());
         json.add("auto_update", material.getAutoUpdate());
-        json.add("url", material.getUriForDisplay());
+        json.add("url", urlWithCredentials(material.getUrl(), material.getUserName(), material.getPassword() != null ? "******" : null));
         json.addWithDefaultIfBlank("branch", material.getBranch(), "master");
     }
 
     static MaterialConfig fromJSON(JsonReader json) {
-        GitMaterialConfig materialConfig = new GitMaterialConfig();
-
+        GitMaterialConfig materialConfig = new GitMaterialConfig(json.optString("url").orElse(null));
         json.readStringIfPresent("name", materialConfig::setName);
         json.readBooleanIfPresent("auto_update", materialConfig::setAutoUpdate);
-        json.readStringIfPresent("url", materialConfig::setUrl);
         json.readStringIfPresent("branch", materialConfig::setBranch);
 
         return materialConfig;

--- a/api/api-config-repos-v1/src/main/java/com/thoughtworks/go/apiv1/configrepos/representers/HgMaterialRepresenter.java
+++ b/api/api-config-repos-v1/src/main/java/com/thoughtworks/go/apiv1/configrepos/representers/HgMaterialRepresenter.java
@@ -21,19 +21,20 @@ import com.thoughtworks.go.api.representers.JsonReader;
 import com.thoughtworks.go.config.materials.mercurial.HgMaterialConfig;
 import com.thoughtworks.go.domain.materials.MaterialConfig;
 
+import static com.thoughtworks.go.config.migration.UrlDenormalizerXSLTMigration121.urlWithCredentials;
+
 
 class HgMaterialRepresenter {
     static void toJSON(OutputWriter json, HgMaterialConfig material) {
         json.add("name", material.getName());
         json.add("auto_update", material.getAutoUpdate());
-        json.add("url", material.getUriForDisplay());
+        json.add("url", urlWithCredentials(material.getUrl(), material.getUserName(), material.getPassword() != null ? "******" : null));
     }
 
     public static MaterialConfig fromJSON(JsonReader json) {
-        HgMaterialConfig materialConfig = new HgMaterialConfig();
+        HgMaterialConfig materialConfig = new HgMaterialConfig(json.optString("url").orElse(null), null);
         json.readStringIfPresent("name", materialConfig::setName);
         json.readBooleanIfPresent("auto_update", materialConfig::setAutoUpdate);
-        json.readStringIfPresent("url", materialConfig::setUrl);
         return materialConfig;
     }
 }

--- a/api/api-config-repos-v1/src/test/groovy/com/thoughtworks/go/apiv1/configrepos/representers/GitMaterialRepresenterTest.groovy
+++ b/api/api-config-repos-v1/src/test/groovy/com/thoughtworks/go/apiv1/configrepos/representers/GitMaterialRepresenterTest.groovy
@@ -20,6 +20,7 @@ import com.thoughtworks.go.api.representers.JsonReader
 import com.thoughtworks.go.api.util.GsonTransformer
 import com.thoughtworks.go.config.materials.git.GitMaterialConfig
 import com.thoughtworks.go.domain.materials.MaterialConfig
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
 import static com.thoughtworks.go.api.base.JsonUtils.toObjectString
@@ -43,16 +44,44 @@ class GitMaterialRepresenterTest {
     ])
   }
 
-  @Test
-  void fromJSON() {
-    JsonReader json = GsonTransformer.getInstance().jsonReaderFrom([
-      name      : null,
-      url       : REPO_URL,
-      branch    : BRANCH,
-      auto_upate: true
-    ])
+  @Nested
+  class fromJSON {
+    @Test
+    void shouldConvertToMaterialObject() {
+      JsonReader json = GsonTransformer.getInstance().jsonReaderFrom([
+        name      : null,
+        url       : REPO_URL,
+        branch    : BRANCH,
+        auto_upate: true
+      ])
 
-    MaterialConfig expected = new GitMaterialConfig(REPO_URL, BRANCH)
-    assertEquals(expected, GitMaterialRepresenter.fromJSON(json))
+      MaterialConfig expected = new GitMaterialConfig(REPO_URL, BRANCH)
+      assertEquals(expected, GitMaterialRepresenter.fromJSON(json))
+    }
+
+    @Test
+    void shouldHandleNullUrl() {
+      JsonReader json = GsonTransformer.getInstance().jsonReaderFrom([
+        name      : null,
+        url       : null,
+        branch    : BRANCH,
+        auto_upate: true
+      ])
+
+      MaterialConfig expected = new GitMaterialConfig(null, BRANCH)
+      assertEquals(expected, GitMaterialRepresenter.fromJSON(json))
+    }
+
+    @Test
+    void shouldHandleNullMissingUrlField() {
+      JsonReader json = GsonTransformer.getInstance().jsonReaderFrom([
+        name      : null,
+        branch    : BRANCH,
+        auto_upate: true
+      ])
+
+      MaterialConfig expected = new GitMaterialConfig(null, BRANCH)
+      assertEquals(expected, GitMaterialRepresenter.fromJSON(json))
+    }
   }
 }

--- a/api/api-config-repos-v1/src/test/groovy/com/thoughtworks/go/apiv1/configrepos/representers/HgMaterialRepresenterTest.groovy
+++ b/api/api-config-repos-v1/src/test/groovy/com/thoughtworks/go/apiv1/configrepos/representers/HgMaterialRepresenterTest.groovy
@@ -20,6 +20,7 @@ import com.thoughtworks.go.api.representers.JsonReader
 import com.thoughtworks.go.api.util.GsonTransformer
 import com.thoughtworks.go.config.materials.mercurial.HgMaterialConfig
 import com.thoughtworks.go.domain.materials.MaterialConfig
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
 import static com.thoughtworks.go.api.base.JsonUtils.toObjectString
@@ -41,15 +42,41 @@ class HgMaterialRepresenterTest {
     ])
   }
 
-  @Test
-  void fromJSON() {
-    JsonReader json = GsonTransformer.getInstance().jsonReaderFrom([
-      name      : null,
-      url       : REPO_URL,
-      auto_upate: true
-    ])
+  @Nested
+  class fromJSON {
+    @Test
+    void shouldConvertToMaterialObject() {
+      JsonReader json = GsonTransformer.getInstance().jsonReaderFrom([
+        name      : null,
+        url       : REPO_URL,
+        auto_upate: true
+      ])
 
-    MaterialConfig expected = new HgMaterialConfig(REPO_URL, null)
-    assertEquals(expected, HgMaterialRepresenter.fromJSON(json))
+      MaterialConfig expected = new HgMaterialConfig(REPO_URL, null)
+      assertEquals(expected, HgMaterialRepresenter.fromJSON(json))
+    }
+
+    @Test
+    void shouldHandleNullMaterialUrl() {
+      JsonReader json = GsonTransformer.getInstance().jsonReaderFrom([
+        name      : null,
+        url       : null,
+        auto_upate: true
+      ])
+
+      MaterialConfig expected = new HgMaterialConfig()
+      assertEquals(expected, HgMaterialRepresenter.fromJSON(json))
+    }
+
+    @Test
+    void shouldHandleIfUrlFieldIsMissingInJson() {
+      JsonReader json = GsonTransformer.getInstance().jsonReaderFrom([
+        name      : null,
+        auto_upate: true
+      ])
+
+      MaterialConfig expected = new HgMaterialConfig()
+      assertEquals(expected, HgMaterialRepresenter.fromJSON(json))
+    }
   }
 }


### PR DESCRIPTION
Post URL normalization git and hg url credentials were removed from the url and updated as attributes on the material. The fix is to retain the same form of API response and request.