### PR TITLE
Add a flag to allow tests to be skipped

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -531,7 +531,12 @@ subprojects {
       project.logger.info("Deleting tmpdir ${tmpDir}")
       project.delete(tmpDir)
 
-      if (!allTestClasses.empty) {
+      def allowTestsToBeSkipped = false
+      if (project.hasProperty("allowTestsToBeSkipped")) {
+        allowTestsToBeSkipped = Boolean.parseBoolean(project.property("allowTestsToBeSkipped"))
+      }
+
+      if (!allTestClasses.empty && !allowTestsToBeSkipped) {
         throw new GradleException("Missed the following classes to test: ${allTestClasses}".toString())
       }
     }


### PR DESCRIPTION
For running only git related tests, we can use the gradle command
`./gradlew :domain:test :common:test --tests "*Git*Test"`

This fails because we assert that all tests should be executed. In cases such as this, where we do need to skip some tests, we can pass the gradle property `allowTestsToBeSkipped` from the CLI

`./gradlew :domain:test :common:test --tests "*Git*Test" -PallowTestsToBeSkipped=true`