### PR TITLE
Encrypt publish-artifact secure-plugin-properties when configured from UI

### DIFF
--- a/config/config-api/src/main/java/com/thoughtworks/go/config/PipelineConfig.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/PipelineConfig.java
@@ -167,19 +167,12 @@ public class PipelineConfig extends BaseCollection<StageConfig> implements Param
     }
 
     public void encryptSecureProperties(CruiseConfig preprocessedConfig, PipelineConfig preprocessedPipelineConfig) {
-        if (hasTemplate() || doesNotHavePublishAndFetchExternalConfig()) {
+        if (hasTemplate()) {
             return;
         }
         for (StageConfig stageConfig : getStages()) {
             stageConfig.encryptSecureProperties(preprocessedConfig, preprocessedPipelineConfig, preprocessedPipelineConfig.getStage(stageConfig.name()));
         }
-    }
-
-    private boolean doesNotHavePublishAndFetchExternalConfig() {
-        if (externalArtifactConfigs == null || fetchExternalArtifactTasks == null) {
-            cachePublishAndFetchExternalConfig();
-        }
-        return externalArtifactConfigs.isEmpty() && fetchExternalArtifactTasks.isEmpty();
     }
 
     private void cachePublishAndFetchExternalConfig() {

--- a/config/config-api/src/test/java/com/thoughtworks/go/config/PipelineConfigTest.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/config/PipelineConfigTest.java
@@ -1014,7 +1014,7 @@ public class PipelineConfigTest {
     }
 
     @Test
-    public void shouldNotAttemptToEncryptPropertiesIfThereAreNoPluginConfigs() {
+    public void shouldAlwaysAttemptToEncryptProperties() {
         PipelineConfig pipelineConfig = new PipelineConfig();
         StageConfig mockStageConfig = mock(StageConfig.class);
         pipelineConfig.add(mockStageConfig);
@@ -1024,7 +1024,7 @@ public class PipelineConfigTest {
 
         pipelineConfig.encryptSecureProperties(new BasicCruiseConfig(), pipelineConfig);
 
-        verify(mockStageConfig, never()).encryptSecureProperties(eq(new BasicCruiseConfig()), eq(pipelineConfig), ArgumentMatchers.any(StageConfig.class));
+        verify(mockStageConfig, times(1)).encryptSecureProperties(eq(new BasicCruiseConfig()), eq(pipelineConfig), ArgumentMatchers.any(StageConfig.class));
     }
 
     private StageConfig completedStage() {


### PR DESCRIPTION
* Always attempt to encrypt secure plugin properties on a full config save.

#### Problem:
* As part of full-config-save, GoCD will clone the existing copy into
  cloned-xml and send it to the update command to update it.
* As the clone will clone entire config, including the externalArtifactConfigs
  and fetchExternalArtifactTasks cache(s), upon update the cache is stale
  as it will not recompute the cache upon update.
* Operating on a stale cache was resulting in no encryption of the fetch/
  publish pluggable artifact secure properties.

#### Fix:
* Traverse entire pipeline-stage-job-artifact-configs to encrypt plugin
  secure properties.