### PR TITLE
Test fixes pos url normalization changes

### DIFF
--- a/api/api-shared-v1/src/main/java/com/thoughtworks/go/apiv1/shared/representers/materials/GitMaterialRepresenter.java
+++ b/api/api-shared-v1/src/main/java/com/thoughtworks/go/apiv1/shared/representers/materials/GitMaterialRepresenter.java
@@ -21,17 +21,20 @@ import com.thoughtworks.go.api.representers.JsonReader;
 import com.thoughtworks.go.config.materials.git.GitMaterialConfig;
 import org.apache.commons.lang3.StringUtils;
 
+import static com.thoughtworks.go.config.migration.UrlDenormalizerXSLTMigration121.urlWithCredentials;
+
 public class GitMaterialRepresenter {
 
     public static void toJSON(OutputWriter jsonWriter, GitMaterialConfig gitMaterialConfig) {
         ScmMaterialRepresenter.toJSON(jsonWriter, gitMaterialConfig);
+        jsonWriter.add("url", urlWithCredentials(gitMaterialConfig.getUrl(), gitMaterialConfig.getUserName(), gitMaterialConfig.getPassword() != null ? "******" : null));
         jsonWriter.addWithDefaultIfBlank("branch", gitMaterialConfig.getBranch(), "master");
         jsonWriter.add("submodule_folder", gitMaterialConfig.getSubmoduleFolder());
         jsonWriter.add("shallow_clone", gitMaterialConfig.isShallowClone());
     }
 
     public static GitMaterialConfig fromJSON(JsonReader jsonReader) {
-        GitMaterialConfig gitMaterialConfig = new GitMaterialConfig();
+        GitMaterialConfig gitMaterialConfig = new GitMaterialConfig(jsonReader.optString("url").orElse(null));
         ScmMaterialRepresenter.fromJSON(jsonReader, gitMaterialConfig);
         jsonReader.optString("branch").ifPresent(branch -> {
             if (StringUtils.isNotBlank(branch)) {

--- a/api/api-shared-v1/src/main/java/com/thoughtworks/go/apiv1/shared/representers/materials/HgMaterialRepresenter.java
+++ b/api/api-shared-v1/src/main/java/com/thoughtworks/go/apiv1/shared/representers/materials/HgMaterialRepresenter.java
@@ -20,14 +20,17 @@ import com.thoughtworks.go.api.base.OutputWriter;
 import com.thoughtworks.go.api.representers.JsonReader;
 import com.thoughtworks.go.config.materials.mercurial.HgMaterialConfig;
 
+import static com.thoughtworks.go.config.migration.UrlDenormalizerXSLTMigration121.urlWithCredentials;
+
 public class HgMaterialRepresenter {
 
     public static void toJSON(OutputWriter jsonWriter, HgMaterialConfig hgMaterialConfig) {
         ScmMaterialRepresenter.toJSON(jsonWriter, hgMaterialConfig);
+        jsonWriter.add("url", urlWithCredentials(hgMaterialConfig.getUrl(), hgMaterialConfig.getUserName(), hgMaterialConfig.getPassword() != null ? "******" : null));
     }
 
     public static HgMaterialConfig fromJSON(JsonReader jsonReader) {
-        HgMaterialConfig hgMaterialConfig = new HgMaterialConfig();
+        HgMaterialConfig hgMaterialConfig = new HgMaterialConfig(jsonReader.optString("url").orElse(null), null);
         ScmMaterialRepresenter.fromJSON(jsonReader, hgMaterialConfig);
         return hgMaterialConfig;
     }

--- a/api/api-shared-v1/src/main/java/com/thoughtworks/go/apiv1/shared/representers/materials/ScmMaterialRepresenter.java
+++ b/api/api-shared-v1/src/main/java/com/thoughtworks/go/apiv1/shared/representers/materials/ScmMaterialRepresenter.java
@@ -19,14 +19,10 @@ package com.thoughtworks.go.apiv1.shared.representers.materials;
 import com.thoughtworks.go.api.base.OutputWriter;
 import com.thoughtworks.go.api.representers.JsonReader;
 import com.thoughtworks.go.config.materials.ScmMaterialConfig;
-import com.thoughtworks.go.config.materials.perforce.P4MaterialConfig;
 
 public class ScmMaterialRepresenter {
 
     public static void toJSON(OutputWriter jsonWriter, ScmMaterialConfig scmMaterialConfig) {
-        if (!(scmMaterialConfig instanceof P4MaterialConfig)) {
-            jsonWriter.add("url", scmMaterialConfig.getUrl());
-        }
         jsonWriter.add("destination", scmMaterialConfig.getFolder());
 
         if (scmMaterialConfig.filter().isEmpty()) {
@@ -40,7 +36,6 @@ public class ScmMaterialRepresenter {
     }
 
     public static void fromJSON(JsonReader jsonReader, ScmMaterialConfig scmMaterialConfig) {
-        jsonReader.readStringIfPresent("url", scmMaterialConfig::setUrl);
         jsonReader.readStringIfPresent("destination", scmMaterialConfig::setFolder);
         jsonReader.optBoolean("invert_filter").ifPresent(scmMaterialConfig::setInvertFilter);
         jsonReader.optJsonObject("filter").ifPresent(filterReader -> {

--- a/api/api-shared-v1/src/main/java/com/thoughtworks/go/apiv1/shared/representers/materials/SvnMaterialRepresenter.java
+++ b/api/api-shared-v1/src/main/java/com/thoughtworks/go/apiv1/shared/representers/materials/SvnMaterialRepresenter.java
@@ -25,6 +25,7 @@ public class SvnMaterialRepresenter {
 
     public static void toJSON(OutputWriter jsonWriter, SvnMaterialConfig svnMaterialConfig) {
         ScmMaterialRepresenter.toJSON(jsonWriter, svnMaterialConfig);
+        jsonWriter.add("url", svnMaterialConfig.getUrl());
         jsonWriter.add("check_externals", svnMaterialConfig.isCheckExternals());
         jsonWriter.add("username", svnMaterialConfig.getUserName());
         jsonWriter.addIfNotNull("encrypted_password", svnMaterialConfig.getEncryptedPassword());
@@ -33,6 +34,7 @@ public class SvnMaterialRepresenter {
     public static SvnMaterialConfig fromJSON(JsonReader jsonReader, ConfigHelperOptions options) {
         SvnMaterialConfig svnMaterialConfig = new SvnMaterialConfig();
         ScmMaterialRepresenter.fromJSON(jsonReader, svnMaterialConfig);
+        jsonReader.readStringIfPresent("url", svnMaterialConfig::setUrl);
         jsonReader.optBoolean("check_externals").ifPresent(svnMaterialConfig::setCheckExternals);
         jsonReader.readStringIfPresent("username", svnMaterialConfig::setUserName);
         String password = null, encryptedPassword = null;

--- a/api/api-shared-v1/src/main/java/com/thoughtworks/go/apiv1/shared/representers/materials/TfsMaterialRepresenter.java
+++ b/api/api-shared-v1/src/main/java/com/thoughtworks/go/apiv1/shared/representers/materials/TfsMaterialRepresenter.java
@@ -25,6 +25,7 @@ public class TfsMaterialRepresenter {
 
     public static void toJSON(OutputWriter jsonWriter, TfsMaterialConfig tfsMaterialConfig) {
         ScmMaterialRepresenter.toJSON(jsonWriter, tfsMaterialConfig);
+        jsonWriter.add("url", tfsMaterialConfig.getUrl());
         jsonWriter.add("domain", tfsMaterialConfig.getDomain());
         jsonWriter.add("username", tfsMaterialConfig.getUserName());
         jsonWriter.addIfNotNull("encrypted_password", tfsMaterialConfig.getEncryptedPassword());
@@ -34,6 +35,7 @@ public class TfsMaterialRepresenter {
     public static TfsMaterialConfig fromJSON(JsonReader jsonReader, ConfigHelperOptions options) {
         TfsMaterialConfig tfsMaterialConfig = new TfsMaterialConfig();
         ScmMaterialRepresenter.fromJSON(jsonReader, tfsMaterialConfig);
+        jsonReader.readStringIfPresent("url", tfsMaterialConfig::setUrl);
         jsonReader.readStringIfPresent("domain", tfsMaterialConfig::setDomain);
         jsonReader.readStringIfPresent("username", tfsMaterialConfig::setUserName);
         jsonReader.readStringIfPresent("project_path", tfsMaterialConfig::setProjectPath);

--- a/api/api-shared-v1/src/test/groovy/com/thoughtworks/go/apiv1/shared/representers/materials/GitMaterialRepresenterTest.groovy
+++ b/api/api-shared-v1/src/test/groovy/com/thoughtworks/go/apiv1/shared/representers/materials/GitMaterialRepresenterTest.groovy
@@ -151,7 +151,7 @@ class GitMaterialRepresenterTest implements MaterialRepresenterTrait {
   [
     type: 'git',
     attributes: [
-      url: "http://user:password@funk.com/blank",
+      url: "http://user:******@funk.com/blank",
       destination: "destination",
       filter: [
         ignore: ['**/*.html','**/foobar/']
@@ -169,7 +169,7 @@ class GitMaterialRepresenterTest implements MaterialRepresenterTrait {
   [
     type: 'git',
     attributes: [
-      url: "http://user:password@funk.com/blank",
+      url: "http://user:******@funk.com/blank",
       destination: null,
       filter: null,
       invert_filter: false,

--- a/common/src/test/java/com/thoughtworks/go/config/materials/tfs/TFSMaterialUpdaterTest.java
+++ b/common/src/test/java/com/thoughtworks/go/config/materials/tfs/TFSMaterialUpdaterTest.java
@@ -21,13 +21,12 @@ import com.thoughtworks.go.domain.materials.Revision;
 import com.thoughtworks.go.domain.materials.RevisionContext;
 import com.thoughtworks.go.domain.materials.tfs.TfsMaterialUpdater;
 import com.thoughtworks.go.helper.MaterialsMother;
+import com.thoughtworks.go.security.GoCipher;
+import com.thoughtworks.go.util.command.UrlArgument;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.io.File;
-
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -54,16 +53,7 @@ class TFSMaterialUpdaterTest {
     }
 
     void mockTfsMaterial() {
-        File workingDir = mock(File.class);
-        when(workingDir.getPath()).thenReturn("someDir");
-
-        tfsMaterial = mock(TfsMaterial.class);
-        when(tfsMaterial.workingdir(any(File.class))).thenReturn(workingDir);
-        when(tfsMaterial.passwordForCommandLine()).thenReturn("password");
-        when(tfsMaterial.getUserName()).thenReturn("username");
-        when(tfsMaterial.getDomain()).thenReturn("domain");
-        when(tfsMaterial.getProjectPath()).thenReturn("projectpath");
-        when(tfsMaterial.urlForCommandLine()).thenReturn("url");
+        tfsMaterial = new TfsMaterial(new GoCipher(), new UrlArgument("url"), "username", "domain", "password", "projectpath");
     }
 
     @Test

--- a/common/src/test/java/com/thoughtworks/go/server/service/MagicalMaterialAndMaterialConfigConversionTest.java
+++ b/common/src/test/java/com/thoughtworks/go/server/service/MagicalMaterialAndMaterialConfigConversionTest.java
@@ -60,9 +60,8 @@ import static com.thoughtworks.go.domain.packagerepository.ConfigurationProperty
 import static com.thoughtworks.go.helper.FilterMother.filterFor;
 import static org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals;
 import static org.apache.commons.lang3.builder.ToStringBuilder.reflectionToString;
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(Theories.class)
@@ -84,14 +83,14 @@ public class MagicalMaterialAndMaterialConfigConversionTest {
     @DataPoint public static MaterialConfig dependencyMaterialConfig = new DependencyMaterialConfig(cis("name1"), cis("pipeline1"), cis("stage1"));
 
     static {
-        fieldsWhichShouldBeIgnoredWhenSavedInDbAndGotBack.put(GitMaterialConfig.class, new String[]{"filter"});
-        fieldsWhichShouldBeIgnoredWhenSavedInDbAndGotBack.put(HgMaterialConfig.class, new String[]{"filter"});
-        fieldsWhichShouldBeIgnoredWhenSavedInDbAndGotBack.put(SvnMaterialConfig.class, new String[]{"filter", "encryptedPassword", "goCipher"});
-        fieldsWhichShouldBeIgnoredWhenSavedInDbAndGotBack.put(P4MaterialConfig.class, new String[]{"filter", "encryptedPassword", "goCipher"});
-        fieldsWhichShouldBeIgnoredWhenSavedInDbAndGotBack.put(TfsMaterialConfig.class, new String[]{"filter", "encryptedPassword", "goCipher"});
+        fieldsWhichShouldBeIgnoredWhenSavedInDbAndGotBack.put(GitMaterialConfig.class, new String[]{"filter", "goCipher"});
+        fieldsWhichShouldBeIgnoredWhenSavedInDbAndGotBack.put(HgMaterialConfig.class, new String[]{"filter", "goCipher"});
+        fieldsWhichShouldBeIgnoredWhenSavedInDbAndGotBack.put(SvnMaterialConfig.class, new String[]{"filter", "goCipher"});
+        fieldsWhichShouldBeIgnoredWhenSavedInDbAndGotBack.put(P4MaterialConfig.class, new String[]{"filter", "goCipher"});
+        fieldsWhichShouldBeIgnoredWhenSavedInDbAndGotBack.put(TfsMaterialConfig.class, new String[]{"filter", "goCipher"});
         fieldsWhichShouldBeIgnoredWhenSavedInDbAndGotBack.put(PackageMaterialConfig.class, new String[]{"filter", "packageId", "packageDefinition", "fingerprint"});
         fieldsWhichShouldBeIgnoredWhenSavedInDbAndGotBack.put(PluggableSCMMaterialConfig.class, new String[]{"filter", "scmId", "scmConfig", "fingerprint"});
-        fieldsWhichShouldBeIgnoredWhenSavedInDbAndGotBack.put(DependencyMaterialConfig.class, new String[]{"filter", "encryptedPassword", "goCipher"});
+        fieldsWhichShouldBeIgnoredWhenSavedInDbAndGotBack.put(DependencyMaterialConfig.class, new String[]{"filter", "goCipher"});
     }
 
     @Theory
@@ -101,7 +100,7 @@ public class MagicalMaterialAndMaterialConfigConversionTest {
 
         assertThat(materialConfigConvertedBackFromMaterial, is(materialConfig));
         assertTrue(message("Material <-> MaterialConfig conversion failed.", materialConfigConvertedBackFromMaterial, materialConfig),
-                reflectionEquals(materialConfigConvertedBackFromMaterial, materialConfig));
+                reflectionEquals(materialConfigConvertedBackFromMaterial, materialConfig, fieldsWhichShouldBeIgnoredWhenSavedInDbAndGotBack.get(materialConfig.getClass())));
 
         assertThat(materialFromConfig.getFingerprint(), is(materialConfig.getFingerprint()));
         assertThat(materialFromConfig.isAutoUpdate(), is(materialConfig.isAutoUpdate()));

--- a/config/config-api/src/main/java/com/thoughtworks/go/security/GoCipher.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/security/GoCipher.java
@@ -80,7 +80,6 @@ public class GoCipher implements Serializable {
         return passwordEquals(password1, password2);
     }
 
-
     public boolean passwordEquals(EncryptedVariableValueConfig p1, EncryptedVariableValueConfig p2) {
         if (p1 == null && p2 == null) {
             return true;

--- a/config/config-server/src/main/resources/cruise-config.xsd
+++ b/config/config-server/src/main/resources/cruise-config.xsd
@@ -89,7 +89,7 @@
           </xsd:unique>
         </xsd:element>
       </xsd:sequence>
-      <xsd:attribute name="schemaVersion" type="xsd:int" use="required" fixed="120"/>
+      <xsd:attribute name="schemaVersion" type="xsd:int" use="required" fixed="121"/>
     </xsd:complexType>
     <xsd:unique name="uniquePipelines">
       <xsd:selector xpath="pipelines"/>

--- a/domain/src/main/java/com/thoughtworks/go/config/materials/ScmMaterial.java
+++ b/domain/src/main/java/com/thoughtworks/go/config/materials/ScmMaterial.java
@@ -105,7 +105,7 @@ public abstract class ScmMaterial extends AbstractMaterial implements SecretPara
         this.updateTo(output, baseDir, new RevisionContext(revision), execCtx);
     }
 
-    public final String getUserName() {
+    public String getUserName() {
         return this.userName;
     }
 
@@ -158,22 +158,22 @@ public abstract class ScmMaterial extends AbstractMaterial implements SecretPara
         return encryptedPassword;
     }
 
-    public final String getPassword() {
+    public String getPassword() {
         return currentPassword();
     }
 
-    public final String passwordForCommandLine() {
+    public String passwordForCommandLine() {
         return secretParamsForPassword.isEmpty() ? getPassword() : secretParamsForPassword.substitute(getPassword());
     }
 
     @Override
-    public final boolean hasSecretParams() {
+    public boolean hasSecretParams() {
         return (getUrlArgument() != null && this.getUrlArgument().hasSecretParams())
                 || (this.secretParamsForPassword != null && !this.secretParamsForPassword.isEmpty());
     }
 
     @Override
-    public final SecretParams getSecretParams() {
+    public SecretParams getSecretParams() {
         return SecretParams.union(getUrlArgument().getSecretParams(), secretParamsForPassword);
     }
 

--- a/server/config/cruise-config.xml
+++ b/server/config/cruise-config.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<cruise xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="cruise-config.xsd" schemaVersion="120">
+<cruise xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="cruise-config.xsd" schemaVersion="121">
   <server artifactsdir="artifacts" agentAutoRegisterKey="323040d4-f2e4-4b8a-8394-7a2d122054d1" webhookSecret="3d5cd2f5-7fe7-43c0-ba34-7e01678ba8b6" commandRepositoryLocation="default" serverId="60f5f682-5248-4ba9-bb35-72c92841bd75" tokenGenerationKey="8c3c8dc9-08bf-4cd7-ac80-cecb3e7ae86c">
     <security>
       <authConfigs>

--- a/server/src/test-fast/java/com/thoughtworks/go/server/view/velocity/BuildDetailPageVelocityTemplateTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/view/velocity/BuildDetailPageVelocityTemplateTest.java
@@ -17,6 +17,7 @@
 package com.thoughtworks.go.server.view.velocity;
 
 import com.thoughtworks.go.config.materials.MaterialConfigs;
+import com.thoughtworks.go.config.materials.git.GitMaterial;
 import com.thoughtworks.go.config.materials.git.GitMaterialConfig;
 import com.thoughtworks.go.domain.JobInstances;
 import com.thoughtworks.go.domain.MaterialRevisions;
@@ -36,7 +37,6 @@ import static com.thoughtworks.go.config.TrackingTool.createTrackingTool;
 import static com.thoughtworks.go.domain.buildcause.BuildCause.createWithModifications;
 import static com.thoughtworks.go.helper.JobInstanceMother.building;
 import static com.thoughtworks.go.helper.MaterialConfigsMother.gitMaterialConfig;
-import static com.thoughtworks.go.helper.MaterialsMother.gitMaterial;
 import static com.thoughtworks.go.helper.PipelineConfigMother.pipelineConfig;
 import static com.thoughtworks.go.helper.PipelineMother.schedule;
 import static org.hamcrest.Matchers.containsString;
@@ -110,7 +110,7 @@ public class BuildDetailPageVelocityTemplateTest {
         GitMaterialConfig gitMaterialConfig = gitMaterialConfig();
 
         MaterialRevisions materialRevisions = new MaterialRevisions();
-        materialRevisions.addRevision(gitMaterial(gitMaterialConfig.getUrl(), gitMaterialConfig.getSubmoduleFolder(), gitMaterialConfig.getBranch()),
+        materialRevisions.addRevision(new GitMaterial(gitMaterialConfig),
                 new Modification("Ernest Hemingway <oldman@sea.com>", "comment", "email", new Date(), "12", ""));
 
         Pipeline pipeline = schedule(pipelineConfig("pipeline", new MaterialConfigs(gitMaterialConfig)), createWithModifications(materialRevisions, ""));


### PR DESCRIPTION
commit c25d8412f1af535d2fdd3d56368a8d465c8a45bf
-  Exclude cipher from reflection assert
  * This is needed as while converting MaterialConfig <-> Material <->
      MaterialInstance creates new GoCipher instance. GoCipher does not
      implements hashcode and equals.

commit 9508f8604883245b952099dad9f733ea7d136359
- Convert MaterialConfig to Material using constructor which takes a config object.
   * This is done as getUrl returns the object without credentials and as a result, the generated fingerprint will not match

commit 77c73a0e7db62a98cab658388d88daf23e8c6340
- Removing final from few methods.
   * Discussed it with @ketan - This was added to see child classes are overriding the method or not.

commit 5868831291c28f7123e4dad6bf90eb37921711f5
- Fixed TFSMaterialUpdaterTest test mocks

commit 24d969a35808416f6a6cfa77b27e42b3ae60576f
- Bump up the schema version missed in rebase of the old PR.

commit 752d2429419a302aa6536e5bec7816fbdd12d3a6
- Updated shared material representer to handle credentials in URL
   * There was a but in maintenance mode API where url credentials are
      represented in plain text. Since it is bug fix not bumping up the API
      version.