### PR TITLE
Fix encryption API to honour "go.encryption.api.max.requests" system property.

### DIFF
--- a/api/api-encryption-v1/src/main/java/com/thoughtworks/go/apiv1/admin/encryption/spring/EncryptionController.java
+++ b/api/api-encryption-v1/src/main/java/com/thoughtworks/go/apiv1/admin/encryption/spring/EncryptionController.java
@@ -21,12 +21,13 @@ import com.thoughtworks.go.api.spring.ApiAuthenticationHelper;
 import com.thoughtworks.go.apiv1.admin.encryption.EncryptionControllerDelegate;
 import com.thoughtworks.go.security.GoCipher;
 import com.thoughtworks.go.spark.spring.SparkSpringController;
+import com.thoughtworks.go.util.SystemEnvironment;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 @Component
 public class EncryptionController implements SparkSpringController {
-    private static final int DEFAULT_REQUESTS_PER_MINUTE = 60;
+    private static final int DEFAULT_REQUESTS_PER_MINUTE = SystemEnvironment.getMaxEncryptionAPIRequestsPerMinute();
     private final EncryptionControllerDelegate delegate;
 
     @Autowired

--- a/base/src/main/java/com/thoughtworks/go/util/SystemEnvironment.java
+++ b/base/src/main/java/com/thoughtworks/go/util/SystemEnvironment.java
@@ -664,7 +664,7 @@ public class SystemEnvironment implements Serializable, ConfigDirProvider {
 
     public static final ThreadLocal<Boolean> enforceServerImmutability = ThreadLocal.withInitial(() -> false);
 
-    public int getMaxEncryptionAPIRequestsPerMinute() {
+    public static int getMaxEncryptionAPIRequestsPerMinute() {
         return GO_ENCRYPTION_API_MAX_REQUESTS.getValue();
     }
 


### PR DESCRIPTION
* GoCD encryption API was introduced as part of release v17.1.0 (rails implementation)
* To prevent brute force attacks that may allow attackers to guess the cipher key,
  GoCD prevents the maximum number of encryption API requests through
  "go.encryption.api.max.requests" system property (defaults to 30).
* As part of GoCD release v18.2.0 encryption API was moved to Spark.
  as part of migration, the consumption of this system property was lost
  and a fix value 60 is used instead.

Behaviour:
* From release v17.1.0 to v18.2.0 "go.encryption.api.max.requests" system
  property is honoured. The maximum number of encryption API requests is
  equal to the value set by this system property.
* From release v18.3.0 to v19.3.0 "go.encryption.api.max.requests" system
  property is NOT honoured. The maximum number of encryption API requests is
  always 60.
* For release v18.2.0, 'spark_encryption_enabled_key' toggle was introduced
  to switch between rails and spark API endpoints. Depending upon the toggle
  value the endpoint will honour the system property. By default rails endpoint
  is used, whereas, enabling this toggle would use Spark API.

Links:
* https://github.com/gocd/gocd/pull/4227/commits/73768b398d8796a71aea9ce046af3085f002af83#diff-d69324151b9125993b59388ba0312b40R29