### PR TITLE
Use "less secure" non-blocking `SecureRandom`.

### DIFF
--- a/server/src/main/java/com/thoughtworks/go/domain/AccessToken.java
+++ b/server/src/main/java/com/thoughtworks/go/domain/AccessToken.java
@@ -50,11 +50,7 @@ public class AccessToken extends PersistentObject implements Validatable {
     private static SecureRandom SECURE_RANDOM;
 
     static {
-        try {
-            SECURE_RANDOM = SecureRandom.getInstanceStrong();
-        } catch (NoSuchAlgorithmException e) {
-            SECURE_RANDOM = new SecureRandom();
-        }
+        SECURE_RANDOM = new SecureRandom();
     }
 
     //this is the hashed token value


### PR DESCRIPTION
Since we're just generating an access token, it should be acceptable to
not have to use a blocking `SecureRandom`.

Related to: #6228 