### PR TITLE
[Reattempt] Encrypt publish-artifact secure-plugin-properties when configured from admin/cruise-config.xml tab

### DIFF
--- a/config/config-server/src/test/java/com/thoughtworks/go/config/MagicalGoConfigXmlLoaderTest.java
+++ b/config/config-server/src/test/java/com/thoughtworks/go/config/MagicalGoConfigXmlLoaderTest.java
@@ -4270,10 +4270,10 @@ public class MagicalGoConfigXmlLoaderTest {
         Configuration childFetchArtifactFromParentConfig = ((FetchPluggableArtifactTask) child.get(0).getJobs().first().tasks().get(1)).getConfiguration();
         ArtifactStore dockerhubStore = config.getArtifactStores().first();
 
-        assertConfigProperty(ancestorPublishArtifactConfig, "Image", "SECRET", true);
+        assertConfigProperty(ancestorPublishArtifactConfig, "Image", "IMAGE_SECRET", true);
         assertConfigProperty(ancestorPublishArtifactConfig, "Tag", "ancestor_tag_${GO_PIPELINE_COUNTER}", false);
 
-        assertConfigProperty(parentPublishArtifactConfig, "Image", "SECRET", true);
+        assertConfigProperty(parentPublishArtifactConfig, "Image", "IMAGE_SECRET", true);
         assertConfigProperty(parentPublishArtifactConfig, "Tag", "parent_tag_${GO_PIPELINE_COUNTER}", false);
 
 

--- a/config/config-server/src/test/resources/data/pluggable_artifacts_with_params.xml
+++ b/config/config-server/src/test/resources/data/pluggable_artifacts_with_params.xml
@@ -60,7 +60,7 @@
                                     </property>
                                     <property>
                                         <key>Image</key>
-                                        <value>SECRET</value>
+                                        <value>IMAGE_SECRET</value>
                                     </property>
                                     <property>
                                         <key>Tag</key>
@@ -96,7 +96,7 @@
                                     </property>
                                     <property>
                                         <key>Image</key>
-                                        <value>SECRET</value>
+                                        <value>IMAGE_SECRET</value>
                                     </property>
                                     <property>
                                         <key>Tag</key>

--- a/server/src/main/java/com/thoughtworks/go/config/FullConfigSaveNormalFlow.java
+++ b/server/src/main/java/com/thoughtworks/go/config/FullConfigSaveNormalFlow.java
@@ -56,11 +56,13 @@ public class FullConfigSaveNormalFlow extends FullConfigSaveFlow {
 
         CruiseConfig configForEdit = configForEditWithPartials(updatingCommand, partials);
 
+        CruiseConfig preProcessedConfig = preprocessAndValidate(configForEdit);
+
         String configForEditXmlString = toXmlString(configForEdit);
 
         postValidationUpdates(configForEdit, configForEditXmlString);
 
-        CruiseConfig preProcessedConfig = preprocessAndValidate(configForEdit);
+        MagicalGoConfigXmlLoader.setMd5(preProcessedConfig, configForEdit.getMd5());
 
         checkinToConfigRepo(currentUser, configForEdit, configForEditXmlString);
 

--- a/server/src/test-integration/java/com/thoughtworks/go/config/CachedGoConfigIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/config/CachedGoConfigIntegrationTest.java
@@ -1182,8 +1182,8 @@ public class CachedGoConfigIntegrationTest {
         Configuration ancestorPluggablePublishAftifactConfigAfterEncryption = goConfigDao.loadConfigHolder()
                 .configForEdit.pipelineConfigByName(new CaseInsensitiveString("ancestor"))
                 .getExternalArtifactConfigs().get(0).getConfiguration();
-        assertThat(ancestorPluggablePublishAftifactConfigAfterEncryption.getProperty("Image").getValue()).isEqualTo("SECRET");
-        assertThat(ancestorPluggablePublishAftifactConfigAfterEncryption.getProperty("Image").getEncryptedValue()).isEqualTo(new GoCipher().encrypt("SECRET"));
+        assertThat(ancestorPluggablePublishAftifactConfigAfterEncryption.getProperty("Image").getValue()).isEqualTo("IMAGE_SECRET");
+        assertThat(ancestorPluggablePublishAftifactConfigAfterEncryption.getProperty("Image").getEncryptedValue()).isEqualTo(new GoCipher().encrypt("IMAGE_SECRET"));
         assertThat(ancestorPluggablePublishAftifactConfigAfterEncryption.getProperty("Image").getConfigValue()).isNull();
     }
 

--- a/server/src/test-integration/java/com/thoughtworks/go/config/FullConfigSaveFlowTestBase.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/config/FullConfigSaveFlowTestBase.java
@@ -42,9 +42,7 @@ import java.util.ArrayList;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Arrays.asList;
-import static org.hamcrest.Matchers.nullValue;
-import static org.hamcrest.Matchers.startsWith;
-import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertThat;
 
 @RunWith(SpringJUnit4ClassRunner.class)
@@ -91,17 +89,23 @@ public abstract class FullConfigSaveFlowTestBase {
         Configuration ancestorPluggablePublishAftifactConfigBeforeEncryption = cruiseConfig
                 .pipelineConfigByName(new CaseInsensitiveString("ancestor"))
                 .getExternalArtifactConfigs().get(0).getConfiguration();
-        assertThat(ancestorPluggablePublishAftifactConfigBeforeEncryption.getProperty("Image").getValue(), is("SECRET"));
+        assertThat(ancestorPluggablePublishAftifactConfigBeforeEncryption.getProperty("Image").getValue(), is("IMAGE_SECRET"));
         assertThat(ancestorPluggablePublishAftifactConfigBeforeEncryption.getProperty("Image").getEncryptedValue(), is(nullValue()));
-        assertThat(ancestorPluggablePublishAftifactConfigBeforeEncryption.getProperty("Image").getConfigValue(), is("SECRET"));
+        assertThat(ancestorPluggablePublishAftifactConfigBeforeEncryption.getProperty("Image").getConfigValue(), is("IMAGE_SECRET"));
 
         GoConfigHolder configHolder = getImplementer().execute(new FullConfigUpdateCommand(cruiseConfig, goConfigService.configFileMd5()), new ArrayList<>(), "Upgrade");
         Configuration ancestorPluggablePublishAftifactConfigAfterEncryption = configHolder.configForEdit
                 .pipelineConfigByName(new CaseInsensitiveString("ancestor"))
                 .getExternalArtifactConfigs().get(0).getConfiguration();
-        assertThat(ancestorPluggablePublishAftifactConfigAfterEncryption.getProperty("Image").getValue(), is("SECRET"));
+
+        assertThat(ancestorPluggablePublishAftifactConfigAfterEncryption.getProperty("Image").getValue(), is("IMAGE_SECRET"));
         assertThat(ancestorPluggablePublishAftifactConfigAfterEncryption.getProperty("Image").getEncryptedValue(), startsWith("AES:"));
         assertThat(ancestorPluggablePublishAftifactConfigAfterEncryption.getProperty("Image").getConfigValue(), is(nullValue()));
+
+        //verify xml on disk contains encrypted Image plugin property
+        assertThat(configHelper.getCurrentXml(), containsString(ancestorPluggablePublishAftifactConfigAfterEncryption.getProperty("Image").getEncryptedValue()));
+        //verify xml from GoConfigHolder contains encrypted Image plugin property
+        assertThat(getImplementer().toXmlString(configHolder.configForEdit), containsString(ancestorPluggablePublishAftifactConfigAfterEncryption.getProperty("Image").getEncryptedValue()));
     }
 
     @Test

--- a/server/src/test-shared/java/com/thoughtworks/go/util/GoConfigFileHelper.java
+++ b/server/src/test-shared/java/com/thoughtworks/go/util/GoConfigFileHelper.java
@@ -177,6 +177,9 @@ public class GoConfigFileHelper {
         new SystemEnvironment().setProperty(SystemEnvironment.CONFIG_FILE_PROPERTY, this.configFile.getAbsolutePath());
     }
 
+    public String getCurrentXml() throws IOException {
+        return FileUtils.readFileToString(this.configFile, UTF_8);
+    }
 
     public void saveFullConfig(String configFileContent, boolean shouldMigrate) throws Exception {
         if (shouldMigrate) {


### PR DESCRIPTION


* Make cruise-config representation consistent for config on disk and GoConfigHolder.

Problem:
* As part of full-config-save from UI, GoCD converts user submitted XML into the string
  and then sends the original config object for preprocessing and validation.
* As the converting XML to string happens before preprocessing is done, the string
  XML will not have plugin properties encrypted.
* Though, upon preprocessing, the config object with encrypted plugin properties
  is populated on GoConfigHolder. This causes the XML on disk and GoConfigHolder
  to be out of sync.

Fix:
* Convert XML to string after validation and preprocessing of cruise-config.xml

Fixes issue: https://hackerone.com/bugs?report_id=548755