### PR TITLE
Added dojofile to support building in docker with dojo

### DIFF
--- a/Dojofile
+++ b/Dojofile
@@ -1,0 +1,2 @@
+# For building GoCD in docker see https://github.com/kudulab/docker-gocd-dojo
+DOJO_DOCKER_IMAGE=kudulab/gocd-dojo:2.0.0


### PR DESCRIPTION
I have recently [rewritten a docker image](https://github.com/kudulab/docker-gocd-dojo) which can be used to build GoCD. Now the image uses https://github.com/gocd-contrib/gocd-oss-cookbooks so it is consistent with the agents on build.gocd

Adding this file is not necessary although more correct, because now it points to exact docker image which should be used for building GoCD. It is pretty much an implementation of idea we discussed long ago - https://github.com/gocd/gocd/issues/1698 

This is just a helper for contributors, not an attempt to introduce docker+dojo builds on all agents.

If this is merged then gocd can be built with:
```
git clone https://github.com/gocd/gocd.git
cd gocd
dojo "./gradlew clean serverPackageDeb agentPackageDeb agentGenericZip versionFile"
```