### PR TITLE
Encrypt publish-artifact secure-plugin-properties for templates

### DIFF
--- a/config/config-api/src/main/java/com/thoughtworks/go/config/BasicCruiseConfig.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/BasicCruiseConfig.java
@@ -1567,6 +1567,10 @@ public class BasicCruiseConfig implements CruiseConfig {
 
     @Override
     public void encryptSecureProperties(CruiseConfig preprocessed) {
+        for (PipelineTemplateConfig template : getTemplates()) {
+            template.encryptSecureProperties(preprocessed, preprocessed.getTemplateByName(template.name()));
+        }
+
         for (PipelineConfig pipelineConfig : getAllPipelineConfigs()) {
             pipelineConfig.encryptSecureProperties(preprocessed, preprocessed.pipelineConfigByName(pipelineConfig.name()));
         }

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/CachedFetchPluggableArtifactTasks.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/CachedFetchPluggableArtifactTasks.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.config;
+
+import java.util.ArrayList;
+
+/*
+CachedFetchPluggableArtifactTasks is used only for caching purposes.
+This class is marked to set null instead of clone at GoConfigCloner,
+which will cause Cloner to not clone CachedFetchPluggableArtifactTasks.
+*/
+
+public class CachedFetchPluggableArtifactTasks extends ArrayList<FetchPluggableArtifactTask> {
+}

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/CachedPluggableArtifactConfigs.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/CachedPluggableArtifactConfigs.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.config;
+
+import java.util.ArrayList;
+
+/*
+CachedPluggableArtifactConfigs is used only for caching purposes.
+This class is marked to set null instead of clone at GoConfigCloner,
+which will cause Cloner to not clone CachedPluggableArtifactConfigs.
+*/
+
+public class CachedPluggableArtifactConfigs extends ArrayList<PluggableArtifactConfig> {
+}

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/PipelineTemplateConfig.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/PipelineTemplateConfig.java
@@ -25,9 +25,7 @@ import com.thoughtworks.go.config.validation.NameTypeValidator;
 import com.thoughtworks.go.domain.BaseCollection;
 import com.thoughtworks.go.domain.ConfigErrors;
 import com.thoughtworks.go.domain.Task;
-import com.thoughtworks.go.domain.config.Admin;
 
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -55,8 +53,8 @@ public class PipelineTemplateConfig extends BaseCollection<StageConfig> implemen
     @SkipParameterResolution
     private Authorization authorization = new Authorization();
 
-    private List<PluggableArtifactConfig> externalArtifactConfigs = null;
-    private List<FetchPluggableArtifactTask> fetchExternalArtifactTasks = null;
+    private CachedPluggableArtifactConfigs externalArtifactConfigs = null;
+    private CachedFetchPluggableArtifactTasks fetchExternalArtifactTasks = null;
 
     private final ConfigErrors configErrors = new ConfigErrors();
 
@@ -102,8 +100,8 @@ public class PipelineTemplateConfig extends BaseCollection<StageConfig> implemen
     }
 
     private void cachePublishAndFetchExternalConfig() {
-        externalArtifactConfigs = new ArrayList<>();
-        fetchExternalArtifactTasks = new ArrayList<>();
+        externalArtifactConfigs = new CachedPluggableArtifactConfigs();
+        fetchExternalArtifactTasks = new CachedFetchPluggableArtifactTasks();
         for (StageConfig stageConfig : getStages()) {
             for (JobConfig jobConfig : stageConfig.getJobs()) {
                 externalArtifactConfigs.addAll(jobConfig.artifactConfigs().getPluggableArtifactConfigs());
@@ -321,8 +319,7 @@ public class PipelineTemplateConfig extends BaseCollection<StageConfig> implemen
         if (attributeMap.containsKey(AUTHORIZATION)) {
             this.authorization = new Authorization();
             this.authorization.setConfigAttributes(attributeMap.get(AUTHORIZATION));
-        }
-        else {
+        } else {
             this.authorization = new Authorization();
         }
 

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/PluggableArtifactConfig.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/PluggableArtifactConfig.java
@@ -195,7 +195,9 @@ public class PluggableArtifactConfig implements ArtifactConfig {
     private void encryptSecureConfigurations(ArtifactStore artifactStore) {
         if (artifactStore != null && hasPluginInfo(artifactStore)) {
             for (ConfigurationProperty configuration : getConfiguration()) {
-                configuration.handleSecureValueConfiguration(isSecure(configuration.getConfigKeyName(), artifactStore));
+                if (!(configuration.getValue() != null && configuration.getValue().contains("#{"))) {
+                    configuration.handleSecureValueConfiguration(isSecure(configuration.getConfigKeyName(), artifactStore));
+                }
             }
         }
     }

--- a/config/config-api/src/test/java/com/thoughtworks/go/config/PipelineConfigTest.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/config/PipelineConfigTest.java
@@ -1014,7 +1014,7 @@ public class PipelineConfigTest {
     }
 
     @Test
-    public void shouldAlwaysAttemptToEncryptProperties() {
+    public void shouldNotAttemptToEncryptPropertiesIfThereAreNoPluginConfigs() {
         PipelineConfig pipelineConfig = new PipelineConfig();
         StageConfig mockStageConfig = mock(StageConfig.class);
         pipelineConfig.add(mockStageConfig);
@@ -1024,7 +1024,7 @@ public class PipelineConfigTest {
 
         pipelineConfig.encryptSecureProperties(new BasicCruiseConfig(), pipelineConfig);
 
-        verify(mockStageConfig, times(1)).encryptSecureProperties(eq(new BasicCruiseConfig()), eq(pipelineConfig), ArgumentMatchers.any(StageConfig.class));
+        verify(mockStageConfig, never()).encryptSecureProperties(eq(new BasicCruiseConfig()), eq(pipelineConfig), ArgumentMatchers.any(StageConfig.class));
     }
 
     private StageConfig completedStage() {

--- a/config/config-server/src/main/java/com/thoughtworks/go/config/GoConfigCloner.java
+++ b/config/config-server/src/main/java/com/thoughtworks/go/config/GoConfigCloner.java
@@ -34,6 +34,8 @@ public class GoConfigCloner extends Cloner {
     public GoConfigCloner() {
         nullInsteadOfClone(AllPipelineConfigs.class,
                 AllTemplatesWithAssociatedPipelines.class,
-                PipelineNameToConfigMap.class);
+                PipelineNameToConfigMap.class,
+                CachedPluggableArtifactConfigs.class,
+                CachedFetchPluggableArtifactTasks.class);
     }
 }

--- a/config/config-server/src/test/java/com/thoughtworks/go/config/GoConfigClonerTest.java
+++ b/config/config-server/src/test/java/com/thoughtworks/go/config/GoConfigClonerTest.java
@@ -22,10 +22,10 @@ import com.thoughtworks.go.helper.PipelineTemplateConfigMother;
 import com.thoughtworks.go.util.ReflectionUtil;
 import org.junit.Test;
 
+import java.util.ArrayList;
+
+import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertThat;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.not;
-import static org.hamcrest.Matchers.nullValue;
 
 public class GoConfigClonerTest {
     @Test
@@ -74,7 +74,33 @@ public class GoConfigClonerTest {
     }
 
     @Test
-    public void shouldDeepCloneObject(){
+    public void shouldNotCloneCachedArtifactConfigs() {
+        BasicCruiseConfig config = GoConfigMother.configWithPipelines("p1", "p2");
+        //to prime cache
+        config.getAllPipelineConfigs();
+        //change state
+        config.encryptSecureProperties(config);
+
+        BasicCruiseConfig cloned = new GoConfigCloner().deepClone(config);
+        assertThat(ReflectionUtil.getField(config.getAllPipelineConfigs().get(0), "externalArtifactConfigs"), is(new ArrayList()));
+        assertThat(ReflectionUtil.getField(cloned.getAllPipelineConfigs().get(0), "externalArtifactConfigs"), is(nullValue()));
+    }
+
+    @Test
+    public void shouldNotCloneCachedFetchPluggableArtifactTasks() {
+        BasicCruiseConfig config = GoConfigMother.configWithPipelines("p1", "p2");
+        //to prime cache
+        config.getAllPipelineConfigs();
+        //change state
+        config.encryptSecureProperties(config);
+
+        BasicCruiseConfig cloned = new GoConfigCloner().deepClone(config);
+        assertThat(ReflectionUtil.getField(config.getAllPipelineConfigs().get(0), "fetchExternalArtifactTasks"), is(new ArrayList()));
+        assertThat(ReflectionUtil.getField(cloned.getAllPipelineConfigs().get(0), "fetchExternalArtifactTasks"), is(nullValue()));
+    }
+
+    @Test
+    public void shouldDeepCloneObject() {
         BasicCruiseConfig config = GoConfigMother.configWithPipelines("p1", "p2");
         BasicCruiseConfig cloned = new GoConfigCloner().deepClone(config);
         assertThat(cloned.getGroups().size(), is(1));


### PR DESCRIPTION
Problem:
* As part of full-config-save, GoCD will clone the existing copy into
  cloned-xml and send it to the update command to update it.
* As the clone will clone entire config, including the externalArtifactConfigs
  and fetchExternalArtifactTasks cache(s), upon update the cache is stale
  as it will not recompute the cache upon update.
* Operating on a stale cache was resulting in no encryption of the fetch/
  publish pluggable artifact secure properties.

Fix:
* Do not clone cached externalArtifactConfigs and fetchExternalArtifactTasks
  as part of config clone.

Fixes issue: https://hackerone.com/bugs?report_id=548755
Improves implementation over https://github.com/gocd/gocd/commit/153c5eaa56c75d7de889919018da9563d6c7c00a