### PR TITLE
Do not build alpine-3.6 based docker gocd agent image

### DIFF
--- a/buildSrc/src/main/groovy/com/thoughtworks/go/build/docker/Distro.groovy
+++ b/buildSrc/src/main/groovy/com/thoughtworks/go/build/docker/Distro.groovy
@@ -25,7 +25,6 @@ enum Distro implements DistroBehavior {
     @Override
     List<DistroVersion> getSupportedVersions() {
       return [
-        new DistroVersion(version: '3.6', releaseName: '3.6', eolDate: parseDate('2019-05-01'), continueToBuild: true),
         new DistroVersion(version: '3.7', releaseName: '3.7', eolDate: parseDate('2019-11-01')),
         new DistroVersion(version: '3.8', releaseName: '3.8', eolDate: parseDate('2020-05-01')),
         new DistroVersion(version: '3.9', releaseName: '3.9', eolDate: parseDate('2021-01-01'))


### PR DESCRIPTION
* alpine-3.6 has reached EOL on 2019-05-01.
* alpine-3.6 based docker gocd agent image will not be
  build from upcoming releases.

Links:
* https://wiki.alpinelinux.org/wiki/Alpine_Linux:Releases