### PR TITLE
Removing GO_JAVA_HOME from docker-dind images

### DIFF
--- a/buildSrc/src/main/groovy/com/thoughtworks/go/build/docker/Distro.groovy
+++ b/buildSrc/src/main/groovy/com/thoughtworks/go/build/docker/Distro.groovy
@@ -16,7 +16,6 @@
 
 package com.thoughtworks.go.build.docker
 
-
 import org.gradle.api.Project
 
 enum Distro implements DistroBehavior {
@@ -171,6 +170,17 @@ enum Distro implements DistroBehavior {
     @Override
     List<String> getInstallPrerequisitesCommands() {
       return alpine.getInstallPrerequisitesCommands()
+    }
+
+
+    @Override
+    List<String> getInstallJavaCommands(Project project) {
+      return alpine.getInstallJavaCommands(project)
+    }
+
+    @Override
+    Map<String, String> getEnvironmentVariables() {
+      return [:]
     }
   }
 

--- a/docker/gocd-agent/build.gradle
+++ b/docker/gocd-agent/build.gradle
@@ -44,9 +44,11 @@ subprojects {
     if (project.hasProperty('dockerBuildLocalZip')) {
       task.dependsOn ':installers:agentGenericZip'
       task.artifactZip = rootProject.project(':installers').tasks.getByName('agentGenericZip').outputs.files.singleFile
+    } else if (project.hasProperty('dockerbuildAgentZipLocation')) {
+      task.artifactZip = project.file(project.dockerbuildAgentZipLocation)
     } else {
-      if (project.hasProperty('dockerbuildAgentZipLocation')) {
-        task.artifactZip = project.file(project.dockerbuildAgentZipLocation)
+      task.doFirst {
+        throw new GradleException("You must specify either -PdockerBuildLocalZip or -PdockerbuildAgentZipLocation=/path/to/agent.zip")
       }
     }
 


### PR DESCRIPTION
The docker-dind image for GoCD agent has a different JAVA installation origin, hence `GO_JAVA_HOME` is not required.