### PR TITLE
Do not extend pluginProfileService for elasticProfileService

### DIFF
--- a/server/src/main/java/com/thoughtworks/go/config/update/ElasticAgentProfileCommand.java
+++ b/server/src/main/java/com/thoughtworks/go/config/update/ElasticAgentProfileCommand.java
@@ -16,49 +16,111 @@
 
 package com.thoughtworks.go.config.update;
 
+import com.thoughtworks.go.config.BasicCruiseConfig;
+import com.thoughtworks.go.config.ConfigSaveValidationContext;
+import com.thoughtworks.go.config.ConfigTag;
 import com.thoughtworks.go.config.CruiseConfig;
+import com.thoughtworks.go.config.commands.EntityConfigUpdateCommand;
 import com.thoughtworks.go.config.elastic.ElasticProfile;
 import com.thoughtworks.go.config.elastic.ElasticProfiles;
 import com.thoughtworks.go.config.exceptions.EntityType;
+import com.thoughtworks.go.config.exceptions.RecordNotFoundException;
 import com.thoughtworks.go.plugin.access.elastic.ElasticAgentExtension;
 import com.thoughtworks.go.plugin.api.response.validation.ValidationResult;
 import com.thoughtworks.go.server.domain.Username;
 import com.thoughtworks.go.server.service.GoConfigService;
 import com.thoughtworks.go.server.service.result.LocalizedOperationResult;
+import org.apache.commons.lang3.StringUtils;
 
 import java.util.Map;
 
+import static com.thoughtworks.go.i18n.LocalizedMessage.resourceNotFound;
 import static com.thoughtworks.go.serverhealth.HealthStateType.forbidden;
+import static com.thoughtworks.go.serverhealth.HealthStateType.notFound;
 
-public abstract class ElasticAgentProfileCommand extends PluginProfileCommand<ElasticProfile, ElasticProfiles> {
-
+public abstract class ElasticAgentProfileCommand implements EntityConfigUpdateCommand<ElasticProfile> {
+    private final GoConfigService goConfigService;
     private final ElasticAgentExtension extension;
+    private final Username currentUser;
+    final LocalizedOperationResult result;
+    final ElasticProfile elasticProfile;
+    ElasticProfile preprocessedProfile;
 
-    public ElasticAgentProfileCommand(GoConfigService goConfigService, ElasticProfile elasticProfile, ElasticAgentExtension extension, Username currentUser, LocalizedOperationResult result) {
-        super(goConfigService, elasticProfile, currentUser, result);
+    public ElasticAgentProfileCommand(GoConfigService goConfigService, ElasticProfile profile, ElasticAgentExtension extension, Username currentUser, LocalizedOperationResult result) {
+        this.goConfigService = goConfigService;
+        this.elasticProfile = profile;
         this.extension = extension;
+        this.currentUser = currentUser;
+        this.result = result;
     }
 
-    @Override
     protected ElasticProfiles getPluginProfiles(CruiseConfig preprocessedConfig) {
         return preprocessedConfig.getElasticConfig().getProfiles();
     }
 
-    @Override
     public ValidationResult validateUsingExtension(String pluginId, Map<String, String> configuration) {
         return extension.validate(pluginId, configuration);
     }
 
     @Override
+    public void clearErrors() {
+        BasicCruiseConfig.clearErrors(elasticProfile);
+    }
+
+    @Override
+    public ElasticProfile getPreprocessedEntityConfig() {
+        return preprocessedProfile;
+    }
+
+    @Override
+    public boolean canContinue(CruiseConfig cruiseConfig) {
+        return isAuthorized();
+    }
+
     protected EntityType getObjectDescriptor() {
         return EntityType.ElasticProfile;
     }
 
     protected final boolean isAuthorized() {
         if (!(goConfigService.isUserAdmin(currentUser) || goConfigService.isGroupAdministrator(currentUser.getUsername()))) {
-            result.forbidden(EntityType.ElasticProfile.forbiddenToEdit(profile.getId(), currentUser.getUsername()), forbidden());
+            result.forbidden(EntityType.ElasticProfile.forbiddenToEdit(elasticProfile.getId(), currentUser.getUsername()), forbidden());
             return false;
         }
         return true;
+    }
+
+    protected boolean isValidForCreateOrUpdate(CruiseConfig preprocessedConfig) {
+        preprocessedProfile = findExistingProfile(preprocessedConfig);
+        preprocessedProfile.validateTree(new ConfigSaveValidationContext(preprocessedConfig));
+
+        if (preprocessedProfile.getAllErrors().isEmpty()) {
+            getPluginProfiles(preprocessedConfig).validate(null);
+            BasicCruiseConfig.copyErrors(preprocessedProfile, elasticProfile);
+            return preprocessedProfile.getAllErrors().isEmpty();
+        }
+
+        BasicCruiseConfig.copyErrors(preprocessedProfile, elasticProfile);
+        return false;
+    }
+
+    protected final ElasticProfile findExistingProfile(CruiseConfig cruiseConfig) {
+        if (elasticProfile == null || StringUtils.isBlank(elasticProfile.getId())) {
+            if (elasticProfile != null) {
+                elasticProfile.addError("id", getObjectDescriptor() + " cannot have a blank id.");
+            }
+            result.unprocessableEntity("The " + getObjectDescriptor().getEntityNameLowerCase() + " config is invalid. Attribute 'id' cannot be null.");
+            throw new IllegalArgumentException(getObjectDescriptor().idCannotBeBlank());
+        } else {
+            ElasticProfile profile = getPluginProfiles(cruiseConfig).find(this.elasticProfile.getId());
+            if (profile == null) {
+                result.notFound(resourceNotFound(getTagName(), elasticProfile.getId()), notFound());
+                throw new RecordNotFoundException(getObjectDescriptor(), elasticProfile.getId());
+            }
+            return profile;
+        }
+    }
+
+    private String getTagName() {
+        return elasticProfile.getClass().getAnnotation(ConfigTag.class).value();
     }
 }

--- a/server/src/main/java/com/thoughtworks/go/config/update/ElasticAgentProfileCreateCommand.java
+++ b/server/src/main/java/com/thoughtworks/go/config/update/ElasticAgentProfileCreateCommand.java
@@ -31,7 +31,7 @@ public class ElasticAgentProfileCreateCommand extends ElasticAgentProfileCommand
 
     @Override
     public void update(CruiseConfig preprocessedConfig) {
-        getPluginProfiles(preprocessedConfig).add(profile);
+        getPluginProfiles(preprocessedConfig).add(elasticProfile);
     }
 
     @Override

--- a/server/src/main/java/com/thoughtworks/go/config/update/ElasticAgentProfileDeleteCommand.java
+++ b/server/src/main/java/com/thoughtworks/go/config/update/ElasticAgentProfileDeleteCommand.java
@@ -64,8 +64,8 @@ public class ElasticAgentProfileDeleteCommand extends ElasticAgentProfileCommand
         }
 
         if (!usedByPipelines.isEmpty()) {
-            result.unprocessableEntity(cannotDeleteResourceBecauseOfDependentPipelines(getObjectDescriptor().getEntityNameLowerCase(), profile.getId(), pipelineNames));
-            throw new GoConfigInvalidException(preprocessedConfig, String.format("The %s '%s' is being referenced by pipeline(s): %s.", getObjectDescriptor().getEntityNameLowerCase(), profile.getId(), StringUtils.join(pipelineNames, ", ")));
+            result.unprocessableEntity(cannotDeleteResourceBecauseOfDependentPipelines(getObjectDescriptor().getEntityNameLowerCase(), elasticProfile.getId(), pipelineNames));
+            throw new GoConfigInvalidException(preprocessedConfig, String.format("The %s '%s' is being referenced by pipeline(s): %s.", getObjectDescriptor().getEntityNameLowerCase(), elasticProfile.getId(), StringUtils.join(pipelineNames, ", ")));
         }
         return true;
     }
@@ -74,7 +74,7 @@ public class ElasticAgentProfileDeleteCommand extends ElasticAgentProfileCommand
         for (StageConfig stage : pipelineConfig) {
             JobConfigs jobs = stage.getJobs();
             for (JobConfig job : jobs) {
-                String id = profile.getId();
+                String id = elasticProfile.getId();
                 if (id.equals(job.getElasticProfileId())) {
                     usedByPipelines.add(new JobConfigIdentifier(pipelineConfig.name(), stage.name(), job.name()));
                 }

--- a/server/src/main/java/com/thoughtworks/go/config/update/ElasticAgentProfileUpdateCommand.java
+++ b/server/src/main/java/com/thoughtworks/go/config/update/ElasticAgentProfileUpdateCommand.java
@@ -39,7 +39,7 @@ public class ElasticAgentProfileUpdateCommand extends ElasticAgentProfileCommand
     public void update(CruiseConfig preprocessedConfig) {
         ElasticProfile existingProfile = findExistingProfile(preprocessedConfig);
         ElasticProfiles profiles = getPluginProfiles(preprocessedConfig);
-        profiles.set(profiles.indexOf(existingProfile), profile);
+        profiles.set(profiles.indexOf(existingProfile), elasticProfile);
     }
 
     @Override

--- a/server/src/main/java/com/thoughtworks/go/server/service/plugins/validators/elastic/ElasticAgentProfileConfigurationValidator.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/plugins/validators/elastic/ElasticAgentProfileConfigurationValidator.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.server.service.plugins.validators.elastic;
+
+import com.thoughtworks.go.config.elastic.ElasticProfile;
+import com.thoughtworks.go.config.exceptions.RecordNotFoundException;
+import com.thoughtworks.go.domain.config.ConfigurationProperty;
+import com.thoughtworks.go.plugin.access.elastic.ElasticAgentExtension;
+import com.thoughtworks.go.plugin.api.response.validation.ValidationError;
+import com.thoughtworks.go.plugin.api.response.validation.ValidationResult;
+
+public class ElasticAgentProfileConfigurationValidator {
+    private final ElasticAgentExtension elasticAgentExtension;
+
+    public ElasticAgentProfileConfigurationValidator(ElasticAgentExtension elasticAgentExtension) {
+        this.elasticAgentExtension = elasticAgentExtension;
+    }
+
+    public void validate(ElasticProfile elasticAgentProfile, String pluginId) {
+        try {
+            ValidationResult result = elasticAgentExtension.validate(pluginId, elasticAgentProfile.getConfigurationAsMap(true));
+
+            if (!result.isSuccessful()) {
+                for (ValidationError error : result.getErrors()) {
+                    ConfigurationProperty property = elasticAgentProfile.getProperty(error.getKey());
+
+                    if (property == null) {
+                        elasticAgentProfile.addNewConfiguration(error.getKey(), false);
+                        property = elasticAgentProfile.getProperty(error.getKey());
+                    }
+                    property.addError(error.getKey(), error.getMessage());
+                }
+            }
+        } catch (RecordNotFoundException e) {
+            elasticAgentProfile.addError("pluginId", String.format("Unable to validate Elastic Agent Profile configuration, missing plugin: %s", pluginId));
+        }
+    }
+}

--- a/server/src/test-fast/java/com/thoughtworks/go/config/update/ElasticAgentProfileCreateCommandTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/config/update/ElasticAgentProfileCreateCommandTest.java
@@ -17,6 +17,9 @@
 package com.thoughtworks.go.config.update;
 
 import com.thoughtworks.go.config.BasicCruiseConfig;
+import com.thoughtworks.go.config.commands.EntityConfigUpdateCommand;
+import com.thoughtworks.go.config.elastic.ClusterProfile;
+import com.thoughtworks.go.config.elastic.ElasticConfig;
 import com.thoughtworks.go.config.elastic.ElasticProfile;
 import com.thoughtworks.go.config.exceptions.EntityType;
 import com.thoughtworks.go.config.exceptions.RecordNotFoundException;
@@ -69,7 +72,7 @@ public class ElasticAgentProfileCreateCommandTest {
         validationResult.addError(new ValidationError("key", "error"));
         when(extension.validate(eq("aws"), anyMap())).thenReturn(validationResult);
         ElasticProfile newProfile = new ElasticProfile("foo", "aws", new ConfigurationProperty(new ConfigurationKey("key"), new ConfigurationValue("val")));
-        PluginProfileCommand command = new ElasticAgentProfileCreateCommand(mock(GoConfigService.class), newProfile, extension, null, new HttpLocalizedOperationResult());
+        EntityConfigUpdateCommand command = new ElasticAgentProfileCreateCommand(mock(GoConfigService.class), newProfile, extension, null, new HttpLocalizedOperationResult());
         BasicCruiseConfig cruiseConfig = new BasicCruiseConfig();
 
         thrown.expect(RecordNotFoundException.class);
@@ -79,5 +82,4 @@ public class ElasticAgentProfileCreateCommandTest {
         assertThat(newProfile.first().errors().size(), is(1));
         assertThat(newProfile.first().errors().asString(), is("error"));
     }
-
 }

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/ElasticProfileServiceIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/ElasticProfileServiceIntegrationTest.java
@@ -1,0 +1,234 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.server.service;
+
+import com.thoughtworks.go.config.BasicCruiseConfig;
+import com.thoughtworks.go.config.elastic.ClusterProfile;
+import com.thoughtworks.go.config.elastic.ClusterProfiles;
+import com.thoughtworks.go.config.elastic.ElasticProfile;
+import com.thoughtworks.go.domain.config.ConfigurationKey;
+import com.thoughtworks.go.domain.config.ConfigurationProperty;
+import com.thoughtworks.go.domain.config.ConfigurationValue;
+import com.thoughtworks.go.server.domain.Username;
+import com.thoughtworks.go.server.service.plugins.validators.elastic.ElasticAgentProfileConfigurationValidator;
+import com.thoughtworks.go.server.service.result.HttpLocalizedOperationResult;
+import com.thoughtworks.go.util.GoConfigFileHelper;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import java.util.HashMap;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(locations = {
+        "classpath:WEB-INF/applicationContext-global.xml",
+        "classpath:WEB-INF/applicationContext-dataLocalAccess.xml",
+        "classpath:testPropertyConfigurer.xml",
+        "classpath:WEB-INF/spring-all-servlet.xml",
+})
+public class ElasticProfileServiceIntegrationTest {
+    @Autowired
+    private GoConfigService goConfigService;
+    @Autowired
+    private ElasticProfileService elasticProfileService;
+    @Autowired
+    private EntityHashingService entityHashingService;
+
+    private GoConfigFileHelper configHelper;
+    private String pluginId;
+    private ClusterProfile clusterProfile;
+    private Username username;
+    private String clusterProfileId;
+    private ElasticProfile elasticProfile;
+    private ElasticProfile newElasticProfile;
+    private String elasticProfileId;
+
+    @Mock
+    private ElasticAgentProfileConfigurationValidator validator;
+
+    @Before
+    public void setUp() throws Exception {
+        initMocks(this);
+        pluginId = "aws";
+        clusterProfileId = "prod-cluster";
+        elasticProfileId = "id";
+        username = new Username("Bob");
+        configHelper = new GoConfigFileHelper();
+        configHelper.onSetUp();
+        goConfigService.forceNotifyListeners();
+        clusterProfile = new ClusterProfile(clusterProfileId, pluginId);
+        elasticProfile = new ElasticProfile(elasticProfileId, pluginId, clusterProfileId);
+        newElasticProfile = new ElasticProfile(elasticProfileId, pluginId, clusterProfileId, new ConfigurationProperty(new ConfigurationKey("key1"), new ConfigurationValue("value1")));
+
+        goConfigService.updateConfig(cruiseConfig -> {
+            ClusterProfiles clusterProfiles = new ClusterProfiles();
+            clusterProfiles.add(clusterProfile);
+            cruiseConfig.getElasticConfig().setClusterProfiles(clusterProfiles);
+            return cruiseConfig;
+        });
+        elasticProfileService.setProfileConfigurationValidator(validator);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        configHelper.onTearDown();
+        goConfigService.updateConfig(cruiseConfig -> new BasicCruiseConfig());
+    }
+
+    @Test
+    public void shouldCreateElasticAgentProfile() {
+        HttpLocalizedOperationResult result = new HttpLocalizedOperationResult();
+
+        assertThat(elasticProfileService.getPluginProfiles()).hasSize(0);
+        elasticProfileService.create(username, elasticProfile, result);
+
+        assertThat(result.isSuccessful()).isTrue();
+        assertThat(elasticProfileService.getPluginProfiles()).hasSize(1);
+        ElasticProfile created = elasticProfileService.getPluginProfiles().get(0);
+        assertThat(created.getId()).isEqualTo(elasticProfileId);
+        assertThat(created.getPluginId()).isEqualTo(pluginId);
+        assertThat(created.getConfigWithErrorsAsMap()).isEqualTo(new HashMap<>());
+    }
+
+    @Test
+    public void shouldValidateElasticAgentProfileWithExtensionAtTheTimeOfCreation() {
+        HttpLocalizedOperationResult result = new HttpLocalizedOperationResult();
+
+        assertThat(elasticProfileService.getPluginProfiles()).hasSize(0);
+        elasticProfileService.create(username, elasticProfile, result);
+
+        assertThat(result.isSuccessful()).isTrue();
+        assertThat(elasticProfileService.getPluginProfiles()).hasSize(1);
+
+        verify(validator, times(1)).validate(elasticProfile, pluginId);
+    }
+
+    @Test
+    public void shouldFailToCreateElasticAgentProfileWhenReferencedClusterProfileDoesNotExists() {
+        clusterProfileId = "non-existing-cluster";
+        elasticProfile = new ElasticProfile(elasticProfileId, pluginId, clusterProfileId);
+        HttpLocalizedOperationResult result = new HttpLocalizedOperationResult();
+
+        assertThat(elasticProfileService.getPluginProfiles()).hasSize(0);
+        elasticProfileService.create(username, elasticProfile, result);
+
+        assertThat(result.isSuccessful()).isFalse();
+        assertThat(elasticProfileService.getPluginProfiles()).hasSize(0);
+        assertThat(result.message()).isEqualTo("Validations failed for agentProfile 'id'. Error(s): [No Cluster Profile exists with the specified cluster_profile_id 'non-existing-cluster'.]. Please correct and resubmit.");
+    }
+
+    @Test
+    public void shouldFailToCreateElasticAgentProfileWhenAnElasticAgentProfileWithSameNameAlreadyExists() {
+        HttpLocalizedOperationResult result = new HttpLocalizedOperationResult();
+
+        assertThat(elasticProfileService.getPluginProfiles()).hasSize(0);
+        elasticProfileService.create(username, elasticProfile, result);
+        assertThat(result.isSuccessful()).isTrue();
+        assertThat(elasticProfileService.getPluginProfiles()).hasSize(1);
+
+        elasticProfileService.create(username, elasticProfile, result);
+        assertThat(result.isSuccessful()).isFalse();
+        assertThat(result.message()).isEqualTo("Validations failed for agentProfile 'id'. Error(s): [Elastic agent profile id 'id' is not unique, Elastic agent profile id 'id' is not unique]. Please correct and resubmit.");
+    }
+
+    @Test
+    public void shouldUpdateElasticAgentProfile() {
+        HttpLocalizedOperationResult result = new HttpLocalizedOperationResult();
+
+        assertThat(elasticProfileService.getPluginProfiles()).hasSize(0);
+        elasticProfileService.create(username, elasticProfile, result);
+        assertThat(elasticProfileService.getPluginProfiles()).hasSize(1);
+        ElasticProfile existing = elasticProfileService.getPluginProfiles().get(0);
+
+        assertThat(existing.getConfigWithErrorsAsMap()).isEmpty();
+        elasticProfileService.update(username, entityHashingService.md5ForEntity(this.elasticProfile), newElasticProfile, result);
+        ElasticProfile updated = elasticProfileService.getPluginProfiles().get(0);
+        assertThat(updated.getId()).isEqualTo(elasticProfileId);
+        assertThat(updated.getPluginId()).isEqualTo(pluginId);
+        assertThat(updated.get(0)).isEqualTo(new ConfigurationProperty(new ConfigurationKey("key1"), new ConfigurationValue("value1")));
+    }
+
+    @Test
+    public void shouldFailToUpdateElasticAgentProfileWhenMd5DoesNotMatch() {
+        HttpLocalizedOperationResult result = new HttpLocalizedOperationResult();
+
+        assertThat(elasticProfileService.getPluginProfiles()).hasSize(0);
+        elasticProfileService.create(username, elasticProfile, result);
+        assertThat(elasticProfileService.getPluginProfiles()).hasSize(1);
+
+        assertThat(elasticProfileService.getPluginProfiles().get(0).getConfigWithErrorsAsMap()).isEmpty();
+        elasticProfileService.update(username, "md5", newElasticProfile, result);
+        assertThat(elasticProfileService.getPluginProfiles().get(0).getConfigWithErrorsAsMap()).isEmpty();
+
+        assertThat(result.isSuccessful()).isFalse();
+        assertThat(result.message()).isEqualTo("Someone has modified the configuration for elastic agent profile with id 'id'. Please update your copy of the config with the changes.");
+    }
+
+    @Test
+    public void shouldDeleteElasticAgentProfile() {
+        HttpLocalizedOperationResult result = new HttpLocalizedOperationResult();
+
+        assertThat(elasticProfileService.getPluginProfiles()).hasSize(0);
+        elasticProfileService.create(username, elasticProfile, result);
+        assertThat(elasticProfileService.getPluginProfiles()).hasSize(1);
+
+        elasticProfileService.delete(username, elasticProfile, result);
+        assertThat(elasticProfileService.getPluginProfiles()).hasSize(0);
+        assertThat(result.isSuccessful()).isTrue();
+    }
+
+    @Test
+    public void shouldFailToDeleteNonExistingElasticAgentProfile() {
+        HttpLocalizedOperationResult result = new HttpLocalizedOperationResult();
+
+        assertThat(elasticProfileService.getPluginProfiles()).hasSize(0);
+        elasticProfileService.create(username, elasticProfile, result);
+        assertThat(elasticProfileService.getPluginProfiles()).hasSize(1);
+
+        elasticProfile = new ElasticProfile("non-existing-profile", pluginId, clusterProfileId);
+
+        elasticProfileService.delete(username, elasticProfile, result);
+        assertThat(elasticProfileService.getPluginProfiles()).hasSize(1);
+        assertThat(result.isSuccessful()).isFalse();
+        assertThat(result.message()).isEqualTo("agentProfile 'non-existing-profile' not found.");
+    }
+
+    @Test
+    public void shouldFindElasticAgentProfile() {
+        HttpLocalizedOperationResult result = new HttpLocalizedOperationResult();
+
+        assertThat(elasticProfileService.getPluginProfiles()).hasSize(0);
+        elasticProfileService.create(username, elasticProfile, result);
+        assertThat(elasticProfileService.getPluginProfiles()).hasSize(1);
+
+        ElasticProfile found = elasticProfileService.findProfile(elasticProfileId);
+        assertThat(found.getId()).isEqualTo(elasticProfileId);
+        assertThat(found.getPluginId()).isEqualTo(pluginId);
+        assertThat(found.getConfigWithErrorsAsMap()).isEqualTo(new HashMap<>());
+    }
+}


### PR DESCRIPTION
* PluginProfileService requires pluginId to be present on the operating
  entity. As pluginId will be removed from the elastic-agent-profile,
  elasticAgentService can not extend pluginProfileService.

* This refactoring is required for the removal of pluginId from
  elastic agent profile.