### PR TITLE
Introduce a new class to store naturalOrderPmm and scheduleOrderPmm per pipeline

### DIFF
--- a/addon-api/database/src/main/java/com/thoughtworks/go/database/QueryExtensions.java
+++ b/addon-api/database/src/main/java/com/thoughtworks/go/database/QueryExtensions.java
@@ -23,4 +23,6 @@ public interface QueryExtensions {
     String queryRelevantToLookedUpDependencyMap(List<Long> pipelineIds);
     
     String retrievePipelineTimeline();
+
+    String retrievePipelineTimelineFor(String pipelineName);
 }

--- a/server/src/main/java/com/thoughtworks/go/server/database/H2QueryExtensions.java
+++ b/server/src/main/java/com/thoughtworks/go/server/database/H2QueryExtensions.java
@@ -78,7 +78,7 @@ class H2QueryExtensions implements QueryExtensions {
                 + "FROM pipelines p, pipelinematerialrevisions pmr, modifications m "
                 + "WHERE p.id = pmr.pipelineid "
                 + "AND pmr.torevisionid = m.id "
-                + "AND p.id > :pipelineId"
+                + "AND p.id > :pipelineId "
                 + "AND p.name = "+ StringUtils.quoteStringSQL(pipelineName) ;
     }
 }

--- a/server/src/main/java/com/thoughtworks/go/server/database/H2QueryExtensions.java
+++ b/server/src/main/java/com/thoughtworks/go/server/database/H2QueryExtensions.java
@@ -70,4 +70,15 @@ class H2QueryExtensions implements QueryExtensions {
                 + "AND pmr.torevisionid = m.id "
                 + "AND p.id > :pipelineId";
     }
+
+    @Override
+    public String retrievePipelineTimelineFor(String pipelineName) {
+        return "SELECT CAST(p.name AS VARCHAR), p.id AS p_id, p.counter, m.modifiedtime, "
+                + " (SELECT CAST(materials.fingerprint AS VARCHAR) FROM materials WHERE id = m.materialId), naturalOrder, m.revision, pmr.folder, pmr.toRevisionId AS mod_id, pmr.Id as pmrid "
+                + "FROM pipelines p, pipelinematerialrevisions pmr, modifications m "
+                + "WHERE p.id = pmr.pipelineid "
+                + "AND pmr.torevisionid = m.id "
+                + "AND p.id > :pipelineId"
+                + "AND p.name = "+ StringUtils.quoteStringSQL(pipelineName) ;
+    }
 }

--- a/server/src/main/java/com/thoughtworks/go/server/domain/PipelineTimeline.java
+++ b/server/src/main/java/com/thoughtworks/go/server/domain/PipelineTimeline.java
@@ -77,7 +77,9 @@ public class PipelineTimeline {
     }
 
     public long getMaximumIdFor(String pipelineName) {
-        return pipelineToEntries.get(new CaseInsensitiveString(pipelineName)).getMaximumId();
+        PipelineTimelineEntrySet pipelineTimelineEntrySet = pipelineToEntries.get(new CaseInsensitiveString(pipelineName));
+
+        return pipelineTimelineEntrySet == null ? -1 : pipelineTimelineEntrySet.getMaximumId();
     }
 
     public void add(PipelineTimelineEntry pipelineTimelineEntry) {
@@ -112,7 +114,7 @@ public class PipelineTimeline {
                         for (PipelineTimelineEntry entry : newlyAddedEntries) {
                             rollbackNewEntryFor(entry);
                         }
-                        pipelineTimelineEntrySet.updateMaximumId(maximumIdBeforeUpdate);
+                        pipelineTimelineEntrySet.setMaximumId(maximumIdBeforeUpdate);
                     }
 
                     private void rollbackNewEntryFor(PipelineTimelineEntry entry) {

--- a/server/src/main/java/com/thoughtworks/go/server/domain/PipelineTimeline.java
+++ b/server/src/main/java/com/thoughtworks/go/server/domain/PipelineTimeline.java
@@ -171,18 +171,6 @@ public class PipelineTimeline {
     }
 
     /**
-     * This is called on system init and is called by Spring. Hence, this is not done in a transaction. At any other time, the method update should be used
-     */
-    public void updateTimelineOnInit() {
-        acquireAllWriteLocks();
-        try {
-//            pipelineRepository.updatePipelineTimeline(this, new ArrayList<>());
-        } finally {
-            releaseAllWriteLocks();
-        }
-    }
-
-    /**
      * @param id           for the pipeline
      * @param pipelineName
      * @return PMM which was before the pipeline with this id at the time of insertion of the PTE with the id or null if there was nothing before this pipeline during insertion

--- a/server/src/main/java/com/thoughtworks/go/server/domain/PipelineTimeline.java
+++ b/server/src/main/java/com/thoughtworks/go/server/domain/PipelineTimeline.java
@@ -41,7 +41,6 @@ public class PipelineTimeline {
     private static final Logger LOGGER = LoggerFactory.getLogger(PipelineTimeline.class);
 
     private final Map<CaseInsensitiveString, PipelineTimelineEntrySet> pipelineToEntries;
-    private volatile long maximumId;
     private final PipelineRepository pipelineRepository;
     private TransactionTemplate transactionTemplate;
     private TransactionSynchronizationManager transactionSynchronizationManager;
@@ -58,7 +57,6 @@ public class PipelineTimeline {
         this.transactionSynchronizationManager = transactionSynchronizationManager;
         this.listeners = listeners;
         pipelineToEntries = new HashMap<>();
-        maximumId = -1;
     }
 
     /**
@@ -76,10 +74,6 @@ public class PipelineTimeline {
         } finally {
             naturalOrderLock.readLock().unlock();
         }
-    }
-
-    public long maximumId() {
-        return maximumId;
     }
 
     public long getMaximumIdFor(String pipelineName) {

--- a/server/src/main/java/com/thoughtworks/go/server/domain/PipelineTimelineEntrySet.java
+++ b/server/src/main/java/com/thoughtworks/go/server/domain/PipelineTimelineEntrySet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 ThoughtWorks, Inc.
+ * Copyright 2019 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,6 +42,10 @@ public class PipelineTimelineEntrySet {
 
     public void updateMaximumId(long id) {
         maximumId = Math.max(id, maximumId);
+    }
+
+    public void setMaximumId(long id) {
+        maximumId = id;
     }
 
     public long getMaximumId() {

--- a/server/src/main/java/com/thoughtworks/go/server/domain/PipelineTimelineEntrySet.java
+++ b/server/src/main/java/com/thoughtworks/go/server/domain/PipelineTimelineEntrySet.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2018 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.server.domain;
+
+import com.thoughtworks.go.domain.PipelineTimelineEntry;
+
+import java.util.ArrayList;
+import java.util.TreeSet;
+
+// this can have things like timestamp etc based on which this object can be evicted from PipelineTimeline.pipelineToEntries
+public class PipelineTimelineEntrySet {
+    private volatile long maximumId;
+    private TreeSet<PipelineTimelineEntry> naturalOrderSet;
+    private ArrayList<PipelineTimelineEntry> scheduledOrderSet;
+
+    public PipelineTimelineEntrySet() {
+        maximumId = -1;
+        naturalOrderSet = new TreeSet<>();
+        scheduledOrderSet = new ArrayList<>();
+    }
+    public TreeSet<PipelineTimelineEntry> getNaturalOrderSet() {
+        return naturalOrderSet;
+    }
+
+    public ArrayList<PipelineTimelineEntry> getScheduledOrderSet() {
+        return scheduledOrderSet;
+    }
+
+    public void updateMaximumId(long id) {
+        maximumId = Math.max(id, maximumId);
+    }
+
+    public long getMaximumId() {
+        return maximumId;
+    }
+}

--- a/server/src/main/java/com/thoughtworks/go/server/domain/PipelineTimelineEntrySet.java
+++ b/server/src/main/java/com/thoughtworks/go/server/domain/PipelineTimelineEntrySet.java
@@ -23,12 +23,11 @@ import java.util.TreeSet;
 
 // this can have things like timestamp etc based on which this object can be evicted from PipelineTimeline.pipelineToEntries
 public class PipelineTimelineEntrySet {
-    private volatile long maximumId;
+    private volatile long maximumId = -1;
     private TreeSet<PipelineTimelineEntry> naturalOrderSet;
     private ArrayList<PipelineTimelineEntry> scheduledOrderSet;
 
     public PipelineTimelineEntrySet() {
-        maximumId = -1;
         naturalOrderSet = new TreeSet<>();
         scheduledOrderSet = new ArrayList<>();
     }

--- a/server/src/main/java/com/thoughtworks/go/server/initializers/ApplicationInitializer.java
+++ b/server/src/main/java/com/thoughtworks/go/server/initializers/ApplicationInitializer.java
@@ -136,7 +136,6 @@ public class ApplicationInitializer implements ApplicationListener<ContextRefres
             pipelineScheduler.initialize();
             invalidateAuthenticationOnSecurityConfigChangeFilter.initialize();
 
-            pipelineTimeline.updateTimelineOnInit();
             pipelineSqlMapDao.initialize();
             commandRepositoryInitializer.initialize();
             consoleActivityMonitor.populateActivityMap();

--- a/server/src/main/java/com/thoughtworks/go/server/service/PipelineService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/PipelineService.java
@@ -97,7 +97,7 @@ public class PipelineService implements UpstreamPipelineResolver {
                     stageService.save(pipelineWithId, stage);
                 }
 
-                pipelineTimeline.update();
+                pipelineTimeline.update(pipeline.getName());
                 return pipelineWithId;
             });
         }

--- a/server/src/test-fast/java/com/thoughtworks/go/server/domain/PipelineTimelineTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/domain/PipelineTimelineTest.java
@@ -197,15 +197,15 @@ public class PipelineTimelineTest {
     }
 
     @Test public void updateOnInitShouldBeDoneOutsideTransaction() throws Exception {
-        PipelineTimeline timeline = new PipelineTimeline(pipelineRepository, transactionTemplate, transactionSynchronizationManager);
-        PipelineTimelineEntry[] entries = {first, second};
-        stubPipelineRepository(timeline, true, entries);
-
-        timeline.updateTimelineOnInit();
-
-        verify(pipelineRepository).updatePipelineTimeline(timeline, Arrays.asList(entries), first.getPipelineName());
-        verifyNoMoreInteractions(transactionSynchronizationManager);
-        verifyNoMoreInteractions(transactionTemplate);
+//        PipelineTimeline timeline = new PipelineTimeline(pipelineRepository, transactionTemplate, transactionSynchronizationManager);
+//        PipelineTimelineEntry[] entries = {first, second};
+//        stubPipelineRepository(timeline, true, entries);
+//
+//        timeline.updateTimelineOnInit();
+//
+//        verify(pipelineRepository).updatePipelineTimeline(timeline, Arrays.asList(entries), first.getPipelineName());
+//        verifyNoMoreInteractions(transactionSynchronizationManager);
+//        verifyNoMoreInteractions(transactionTemplate);
 //        assertThat(timeline.maximumId(), is(2L));
     }
 

--- a/server/src/test-fast/java/com/thoughtworks/go/server/domain/PipelineTimelineTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/domain/PipelineTimelineTest.java
@@ -196,19 +196,6 @@ public class PipelineTimelineTest {
         verify(anotherListener).added(eq(first), any(TreeSet.class));
     }
 
-    @Test public void updateOnInitShouldBeDoneOutsideTransaction() throws Exception {
-//        PipelineTimeline timeline = new PipelineTimeline(pipelineRepository, transactionTemplate, transactionSynchronizationManager);
-//        PipelineTimelineEntry[] entries = {first, second};
-//        stubPipelineRepository(timeline, true, entries);
-//
-//        timeline.updateTimelineOnInit();
-//
-//        verify(pipelineRepository).updatePipelineTimeline(timeline, Arrays.asList(entries), first.getPipelineName());
-//        verifyNoMoreInteractions(transactionSynchronizationManager);
-//        verifyNoMoreInteractions(transactionTemplate);
-//        assertThat(timeline.maximumId(), is(2L));
-    }
-
     @Test public void updateShouldLoadNewInstancesFromTheDatabase() throws Exception {
         stubTransactionSynchronization();
         setupTransactionTemplateStub(TransactionSynchronization.STATUS_COMMITTED, true);

--- a/server/src/test-fast/java/com/thoughtworks/go/server/domain/PipelineTimelineTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/domain/PipelineTimelineTest.java
@@ -22,6 +22,7 @@ import com.thoughtworks.go.listener.TimelineUpdateListener;
 import com.thoughtworks.go.server.persistence.PipelineRepository;
 import com.thoughtworks.go.server.transaction.TransactionSynchronizationManager;
 import com.thoughtworks.go.server.transaction.TransactionTemplate;
+import com.thoughtworks.go.util.SystemEnvironment;
 import org.joda.time.DateTime;
 import org.junit.Before;
 import org.junit.Test;
@@ -53,11 +54,13 @@ public class PipelineTimelineTest {
     private TransactionSynchronization transactionSynchronization;
     private PipelineTimelineEntry[] repositoryEntries;
     private int txnStatus;
+    private SystemEnvironment systemEnvironment;
 
 
     @Before public void setUp() throws Exception {
         now = new DateTime();
         pipelineRepository = mock(PipelineRepository.class);
+        systemEnvironment = mock(SystemEnvironment.class);
         materials = Arrays.asList("first", "second", "third", "fourth");
         first = PipelineMaterialModificationMother.modification(1, materials, Arrays.asList(now, now.plusMinutes(1), now.plusMinutes(2), now.plusMinutes(3)), 1, "111", "pipeline");
         second = PipelineMaterialModificationMother.modification(2, materials, Arrays.asList(now, now.plusMinutes(2), now.plusMinutes(1), now.plusMinutes(2)), 2, "222", "pipeline");
@@ -168,7 +171,7 @@ public class PipelineTimelineTest {
         });
         stubPipelineRepository(timeline, true, new PipelineTimelineEntry[]{first, second});
 
-        timeline.update();
+        timeline.update(first.getPipelineName()); // this updates 2 entries `first` and `second` for pipeline with name `pipeline` at once like before
 
         assertThat(entries[0].size(), is(1));
         assertThat(entries[0].contains(first), is(true));
@@ -186,7 +189,7 @@ public class PipelineTimelineTest {
         }, anotherListener);
         stubPipelineRepository(timeline, true, new PipelineTimelineEntry[]{first, second});
         try {
-            timeline.update();
+            timeline.update(first.getPipelineName());
         } catch (Exception e) {
             fail("should not have failed because of exception thrown by listener");
         }
@@ -200,7 +203,7 @@ public class PipelineTimelineTest {
 
         timeline.updateTimelineOnInit();
 
-        verify(pipelineRepository).updatePipelineTimeline(timeline, Arrays.asList(entries));
+        verify(pipelineRepository).updatePipelineTimeline(timeline, Arrays.asList(entries), first.getPipelineName());
         verifyNoMoreInteractions(transactionSynchronizationManager);
         verifyNoMoreInteractions(transactionTemplate);
         assertThat(timeline.maximumId(), is(2L));
@@ -214,10 +217,10 @@ public class PipelineTimelineTest {
         PipelineTimelineEntry[] entries = {first, second};
         stubPipelineRepository(timeline, true, entries);
 
-        timeline.update();
+        timeline.update(first.getPipelineName());
 
-        verify(pipelineRepository).updatePipelineTimeline(timeline, Arrays.asList(entries));
-        assertThat(timeline.maximumId(), is(2L));
+        verify(pipelineRepository).updatePipelineTimeline(timeline, Arrays.asList(entries), first.getPipelineName());
+        assertThat(timeline.getMaximumIdFor(first.getPipelineName()), is(2L));
     }
 
     @Test public void updateShouldRemoveTheTimelinesReturnedOnRollback() throws Exception {
@@ -227,9 +230,9 @@ public class PipelineTimelineTest {
         PipelineTimelineEntry[] entries = {first, second};
         stubPipelineRepository(timeline, true, new PipelineTimelineEntry[]{first, second});
 
-        timeline.update();
+        timeline.update(first.getPipelineName());
 
-        verify(pipelineRepository).updatePipelineTimeline(timeline, Arrays.asList(entries));
+        verify(pipelineRepository).updatePipelineTimeline(timeline, Arrays.asList(entries), first.getPipelineName());
         assertThat(timeline.maximumId(), is(-1L));
     }
 
@@ -242,16 +245,16 @@ public class PipelineTimelineTest {
         final PipelineTimeline timeline = new PipelineTimeline(pipelineRepository, transactionTemplate, transactionSynchronizationManager);
 
         stubPipelineRepository(timeline, true, first, second);
-        timeline.update();
+        timeline.update(first.getPipelineName());
         allEntries = timeline.getEntriesFor("pipeline");
 
         setupTransactionTemplateStub(TransactionSynchronization.STATUS_ROLLED_BACK, false);
 
         stubPipelineRepository(timeline, false, third, fourth);
-        timeline.update();
+        timeline.update(first.getPipelineName());
         allEntries = timeline.getEntriesFor("pipeline");
 
-        assertThat(timeline.maximumId(), is(2L));
+        assertThat(timeline.getMaximumIdFor(first.getPipelineName()), is(2L));
         assertThat(timeline.getEntriesFor("pipeline").size(), is(2));
         assertThat(allEntries, hasItems(first, second));
         assertThat(timeline.instanceCount(new CaseInsensitiveString("pipeline")), is(2));
@@ -271,7 +274,7 @@ public class PipelineTimelineTest {
                     ((List<PipelineTimelineEntry>) invocationOnMock.getArguments()[1]).addAll(Arrays.asList(repositoryEntries));
                     return Arrays.asList(repositoryEntries);
                 }
-            }).when(pipelineRepository).updatePipelineTimeline(eq(timeline), anyListOf(PipelineTimelineEntry.class));
+            }).when(pipelineRepository).updatePipelineTimeline(eq(timeline), anyListOf(PipelineTimelineEntry.class), any());
         }
     }
 

--- a/server/src/test-fast/java/com/thoughtworks/go/server/domain/PipelineTimelineTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/domain/PipelineTimelineTest.java
@@ -206,7 +206,7 @@ public class PipelineTimelineTest {
         verify(pipelineRepository).updatePipelineTimeline(timeline, Arrays.asList(entries), first.getPipelineName());
         verifyNoMoreInteractions(transactionSynchronizationManager);
         verifyNoMoreInteractions(transactionTemplate);
-        assertThat(timeline.maximumId(), is(2L));
+//        assertThat(timeline.maximumId(), is(2L));
     }
 
     @Test public void updateShouldLoadNewInstancesFromTheDatabase() throws Exception {
@@ -233,7 +233,7 @@ public class PipelineTimelineTest {
         timeline.update(first.getPipelineName());
 
         verify(pipelineRepository).updatePipelineTimeline(timeline, Arrays.asList(entries), first.getPipelineName());
-        assertThat(timeline.maximumId(), is(-1L));
+        assertThat(timeline.getMaximumIdFor(first.getPipelineName()), is(-1L));
     }
 
     @Test

--- a/server/src/test-fast/java/com/thoughtworks/go/server/persistence/PipelineRepositoryTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/persistence/PipelineRepositoryTest.java
@@ -26,6 +26,7 @@ import com.thoughtworks.go.server.domain.user.Filters;
 import com.thoughtworks.go.server.domain.user.PipelineSelections;
 import com.thoughtworks.go.server.transaction.TransactionSynchronizationManager;
 import com.thoughtworks.go.server.transaction.TransactionTemplate;
+import com.thoughtworks.go.util.SystemEnvironment;
 import org.hibernate.SQLQuery;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
@@ -60,6 +61,7 @@ public class PipelineRepositoryTest {
     private TransactionTemplate transactionTemplate;
     private Session session;
     private SQLQuery sqlQuery;
+    private SystemEnvironment systemEnvironment;
 
     @Before
     public void setup() {
@@ -68,6 +70,7 @@ public class PipelineRepositoryTest {
         sessionFactory = mock(SessionFactory.class);
         hibernateTemplate = mock(HibernateTemplate.class);
         goCache = mock(GoCache.class);
+        systemEnvironment = mock(SystemEnvironment.class);
         databaseStrategy = mock(DatabaseStrategy.class);
         when(databaseStrategy.getQueryExtensions()).thenReturn(mock(QueryExtensions.class));
         pipelineRepository = new PipelineRepository(sessionFactory, goCache, databaseStrategy);
@@ -133,7 +136,7 @@ public class PipelineRepositoryTest {
         ArrayList<PipelineTimelineEntry> tempEntries = new ArrayList<>();
         PipelineTimeline pipelineTimeline = new PipelineTimeline(pipelineRepository, transactionTemplate, transactionSynchronizationManager);
 
-        pipelineRepository.updatePipelineTimeline(pipelineTimeline, tempEntries);
+        pipelineRepository.updatePipelineTimeline(pipelineTimeline, tempEntries, "p1");
 
         PipelineTimelineEntry timelineEntry1 = pipelineTimeline.getEntryFor(new CaseInsensitiveString("p1"), 1);
         PipelineTimelineEntry timelineEntry2 = pipelineTimeline.getEntryFor(new CaseInsensitiveString("p1"), 2);
@@ -154,7 +157,7 @@ public class PipelineRepositoryTest {
         PipelineTimeline pipelineTimeline = new PipelineTimeline(pipelineRepository, transactionTemplate, transactionSynchronizationManager);
 
         try {
-            pipelineRepository.updatePipelineTimeline(pipelineTimeline, tempEntries);
+            pipelineRepository.updatePipelineTimeline(pipelineTimeline, tempEntries, "p1");
             fail("Should fail to retrieve pipeline.");
         } catch (ClassCastException e) {
             assertThat(tempEntries.size(), is(0));
@@ -174,7 +177,7 @@ public class PipelineRepositoryTest {
         PipelineTimeline pipelineTimeline = new PipelineTimeline(pipelineRepository, transactionTemplate, transactionSynchronizationManager);
 
         try {
-            pipelineRepository.updatePipelineTimeline(pipelineTimeline, tempEntries);
+            pipelineRepository.updatePipelineTimeline(pipelineTimeline, tempEntries, "p1");
         } catch (RuntimeException e) {
             PipelineTimelineEntry timelineEntry1 = pipelineTimeline.getEntryFor(new CaseInsensitiveString("p1"), 1);
             PipelineTimelineEntry timelineEntry2 = pipelineTimeline.getEntryFor(new CaseInsensitiveString("p1"), 2);

--- a/server/src/test-integration/java/com/thoughtworks/go/server/persistence/PipelineRepositoryIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/persistence/PipelineRepositoryIntegrationTest.java
@@ -184,7 +184,7 @@ public class PipelineRepositoryIntegrationTest {
         PipelineTimeline pipelineTimeline = new PipelineTimeline(pipelineRepository, transactionTemplate, transactionSynchronizationManager);
 
         ArrayList<PipelineTimelineEntry> entries = new ArrayList<>();
-        pipelineRepository.updatePipelineTimeline(pipelineTimeline, entries);
+        pipelineRepository.updatePipelineTimeline(pipelineTimeline, entries, PIPELINE_NAME);
 
         assertThat(pipelineTimeline.getEntriesFor(PIPELINE_NAME).size(), is(2));
         assertThat(entries.size(), is(2));
@@ -201,7 +201,7 @@ public class PipelineRepositoryIntegrationTest {
 
         long thirdId = createPipeline(hgmaterial, pipelineConfig, 3, oneModifiedFile("30", date.plusDays(10).toDate()));
 
-        pipelineRepository.updatePipelineTimeline(pipelineTimeline, new ArrayList<>());
+        pipelineRepository.updatePipelineTimeline(pipelineTimeline, new ArrayList<>(), PIPELINE_NAME);
 
         assertThat(pipelineTimeline.getEntriesFor(PIPELINE_NAME).size(), is(3));
         assertThat(pipelineTimeline.getEntriesFor(PIPELINE_NAME), hasItem(expected(thirdId,
@@ -213,7 +213,7 @@ public class PipelineRepositoryIntegrationTest {
         assertThat(pipelineSqlMapDao.pipelineByIdWithMods(thirdId).getNaturalOrder(), is(2.0));
 
         PipelineTimeline pipelineTimeline2 = new PipelineTimeline(pipelineRepository, transactionTemplate, transactionSynchronizationManager);
-        pipelineRepository.updatePipelineTimeline(pipelineTimeline2, new ArrayList<>());
+        pipelineRepository.updatePipelineTimeline(pipelineTimeline2, new ArrayList<>(), PIPELINE_NAME);
     }
 
     @Test
@@ -235,13 +235,13 @@ public class PipelineRepositoryIntegrationTest {
 
 
         PipelineTimeline mods = new PipelineTimeline(pipelineRepository, transactionTemplate, transactionSynchronizationManager);
-        mods.update();
+        mods.update(PIPELINE_NAME);
 
         assertThat(pipelineSqlMapDao.pipelineByIdWithMods(firstId).getNaturalOrder(), is(1.0));
         assertThat(pipelineSqlMapDao.pipelineByIdWithMods(secondId).getNaturalOrder(), is(0.5));
 
         PipelineTimeline modsAfterReboot = new PipelineTimeline(pipelineRepository, transactionTemplate, transactionSynchronizationManager);
-        modsAfterReboot.update();
+        modsAfterReboot.update(PIPELINE_NAME);
     }
 
     @Test
@@ -271,7 +271,7 @@ public class PipelineRepositoryIntegrationTest {
                         oneModifiedFile("25", date.plusDays(5).toDate())));
 
         PipelineTimeline pipelineTimeline = new PipelineTimeline(pipelineRepository, transactionTemplate, transactionSynchronizationManager);
-        pipelineRepository.updatePipelineTimeline(pipelineTimeline, new ArrayList<>());
+        pipelineRepository.updatePipelineTimeline(pipelineTimeline, new ArrayList<>(), PIPELINE_NAME);
 
         Collection<PipelineTimelineEntry> modifications = pipelineTimeline.getEntriesFor(PIPELINE_NAME);
         assertThat(modifications.size(), is(2));

--- a/server/src/test-integration/java/com/thoughtworks/go/server/persistence/PipelineRepositoryIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/persistence/PipelineRepositoryIntegrationTest.java
@@ -127,7 +127,7 @@ public class PipelineRepositoryIntegrationTest {
         u.runAndPass(p, "g2", "g1");
 
         PipelineTimeline timeline = new PipelineTimeline(pipelineRepository, transactionTemplate, transactionSynchronizationManager);
-        timeline.updateTimelineOnInit();
+        timeline.update("P");
 
         List<PipelineTimelineEntry> timelineEntries = new ArrayList<>(timeline.getEntriesFor("P"));
         assertThat(timelineEntries.get(0).getPipelineLocator().getCounter(), is(1));
@@ -148,7 +148,7 @@ public class PipelineRepositoryIntegrationTest {
         goConfigDao.load();
 
         timeline = new PipelineTimeline(pipelineRepository, transactionTemplate, transactionSynchronizationManager);
-        timeline.updateTimelineOnInit();
+        timeline.update("P");
 
         timelineEntries = new ArrayList<>(timeline.getEntriesFor("P"));
         assertThat(timelineEntries.get(0).getPipelineLocator().getCounter(), is(1));

--- a/server/src/test-integration/java/com/thoughtworks/go/server/persistence/PipelineRepositoryIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/persistence/PipelineRepositoryIntegrationTest.java
@@ -197,7 +197,7 @@ public class PipelineRepositoryIntegrationTest {
                 Collections.singletonMap(hgmaterial.getFingerprint(), a(new PipelineTimelineEntry.Revision(date.plusDays(2).toDate(), "123", hgmaterial.getFingerprint(), 10))), 1)));
         assertThat(pipelineTimeline.getEntriesFor(PIPELINE_NAME), hasItem(expected(secondId,
                 Collections.singletonMap(hgmaterial.getFingerprint(), a(new PipelineTimelineEntry.Revision(date.plusDays(1).toDate(), "12", hgmaterial.getFingerprint(), 8))), 2)));
-        assertThat(pipelineTimeline.maximumId(), is(secondId));
+        assertThat(pipelineTimeline.getMaximumIdFor(PIPELINE_NAME), is(secondId));
 
         long thirdId = createPipeline(hgmaterial, pipelineConfig, 3, oneModifiedFile("30", date.plusDays(10).toDate()));
 
@@ -206,7 +206,7 @@ public class PipelineRepositoryIntegrationTest {
         assertThat(pipelineTimeline.getEntriesFor(PIPELINE_NAME).size(), is(3));
         assertThat(pipelineTimeline.getEntriesFor(PIPELINE_NAME), hasItem(expected(thirdId,
                 Collections.singletonMap(hgmaterial.getFingerprint(), a(new PipelineTimelineEntry.Revision(date.plusDays(10).toDate(), "1234", hgmaterial.getFingerprint(), 12))), 3)));
-        assertThat(pipelineTimeline.maximumId(), is(thirdId));
+        assertThat(pipelineTimeline.getMaximumIdFor(PIPELINE_NAME), is(thirdId));
 
         assertThat(pipelineSqlMapDao.pipelineByIdWithMods(firstId).getNaturalOrder(), is(1.0));
         assertThat(pipelineSqlMapDao.pipelineByIdWithMods(secondId).getNaturalOrder(), is(0.5));

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/AutoBuildIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/AutoBuildIntegrationTest.java
@@ -97,10 +97,10 @@ public class AutoBuildIntegrationTest {
         ScheduleTestUtil.AddedPipeline down_pipe = scheduleUtil.saveConfigWith("down_pipe", scheduleUtil.m(svn), scheduleUtil.m(up_pipe));
 
         String up_pipe_1 = scheduleUtil.runAndPass(up_pipe, "s1");
-        pipelineTimeline.update();
+        pipelineTimeline.update(up_pipe.config.name().toString());
 
         String down_pipe_1 = scheduleUtil.runAndPass(down_pipe, "s1", up_pipe_1);
-        pipelineTimeline.update();
+        pipelineTimeline.update(down_pipe.config.name().toString());
 
         down_pipe.config.removeMaterialConfig(svn.config());
 

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/AutoTriggerDependencyResolutionTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/AutoTriggerDependencyResolutionTest.java
@@ -220,7 +220,7 @@ public class AutoTriggerDependencyResolutionTest {
     }
 
     private MaterialRevisions getRevisionsBasedOnDependencies(CruiseConfig cruiseConfig, MaterialRevisions given, CaseInsensitiveString pipelineName) {
-        pipelineTimeline.update();
+        pipelineTimeline.update(pipelineName.toString());
         return pipelineService.getRevisionsBasedOnDependencies(given, cruiseConfig, pipelineName);
     }
 
@@ -265,7 +265,7 @@ public class AutoTriggerDependencyResolutionTest {
         int extraHours = i++;
         String p3_2 = u.runAndPassWithGivenMDUTimestampAndRevisionStrings(p3, u.d(extraHours), p1_2, p2_1);
 
-        pipelineTimeline.update();
+        pipelineTimeline.update(p1_1);
 
         final MaterialRevisions given = new MaterialRevisions();
         given.addRevision(u.mr(p3, true, p3_2));
@@ -363,7 +363,7 @@ public class AutoTriggerDependencyResolutionTest {
                 u.mr(p2, false, p2_6),
                 u.mr(git, true, "g3")});
 
-        pipelineTimeline.update();
+        pipelineTimeline.update("P3");
 
         AutoBuild autoBuild = new AutoBuild(goConfigService, pipelineService, "P3", systemEnvironment, materialChecker);
 
@@ -1549,7 +1549,7 @@ public class AutoTriggerDependencyResolutionTest {
         });
 
         AutoBuild autoBuild = new AutoBuild(goConfigService, pipelineService, p2.config.name().toString(), systemEnvironment, materialChecker);
-        pipelineTimeline.update();
+        pipelineTimeline.update(p2.config.name().toString());
         BuildCause buildCause = autoBuild.onModifications(given, false, previousRevisions);
         assertThat(buildCause, is(nullValue()));
     }
@@ -1588,7 +1588,7 @@ public class AutoTriggerDependencyResolutionTest {
         });
 
         AutoBuild autoBuild = new AutoBuild(goConfigService, pipelineService, p2.config.name().toString(), systemEnvironment, materialChecker);
-        pipelineTimeline.update();
+        pipelineTimeline.update(p2.config.name().toString());
         BuildCause buildCause = autoBuild.onModifications(given, true, previousRevisions);
         assertThat(buildCause, is(notNullValue()));
         assertThat(buildCause.getMaterialRevisions(), is(given));
@@ -1628,7 +1628,7 @@ public class AutoTriggerDependencyResolutionTest {
         });
 
         AutoBuild autoBuild = new AutoBuild(goConfigService, pipelineService, p2.config.name().toString(), systemEnvironment, materialChecker);
-        pipelineTimeline.update();
+        pipelineTimeline.update(p2.config.name().toString());
         BuildCause buildCause = autoBuild.onModifications(given, false, previousRevisions);
         assertThat(buildCause, is(nullValue()));
     }
@@ -1793,7 +1793,7 @@ public class AutoTriggerDependencyResolutionTest {
                 u.mr(p5, false, p5_1));
 
         AutoBuild autoBuild = new AutoBuild(goConfigService, pipelineService, p6.config.name().toString(), env, materialChecker);
-        pipelineTimeline.update();
+        pipelineTimeline.update(p6.config.name().toString());
 
         BuildCause buildCause = autoBuild.onModifications(given, false, null);
 
@@ -1838,7 +1838,7 @@ public class AutoTriggerDependencyResolutionTest {
         });
 
         AutoBuild autoBuild = new AutoBuild(goConfigService, pipelineService, p2.config.name().toString(), env, materialChecker);
-        pipelineTimeline.update();
+        pipelineTimeline.update(p2.config.name().toString());
         BuildCause buildCause = autoBuild.onModifications(given, false, previousRevisions);
         assertThat(buildCause, is(nullValue()));
     }
@@ -1880,7 +1880,7 @@ public class AutoTriggerDependencyResolutionTest {
         });
 
         AutoBuild autoBuild = new AutoBuild(goConfigService, pipelineService, p2.config.name().toString(), env, materialChecker);
-        pipelineTimeline.update();
+        pipelineTimeline.update(p2.config.name().toString());
         BuildCause buildCause = autoBuild.onModifications(given, false, previousRevisions);
         assertThat(buildCause, is(nullValue()));
     }
@@ -1921,7 +1921,7 @@ public class AutoTriggerDependencyResolutionTest {
         });
 
         AutoBuild autoBuild = new AutoBuild(goConfigService, pipelineService, p2.config.name().toString(), env, materialChecker);
-        pipelineTimeline.update();
+        pipelineTimeline.update(p2.config.name().toString());
         BuildCause buildCause = autoBuild.onModifications(given, true, previousRevisions);
         assertThat(buildCause, is(notNullValue()));
         assertThat(buildCause.getMaterialRevisions(), is(given));
@@ -1958,7 +1958,7 @@ public class AutoTriggerDependencyResolutionTest {
         });
 
         AutoBuild autoBuild = new AutoBuild(goConfigService, pipelineService, p2.config.name().toString(), env, materialChecker);
-        pipelineTimeline.update();
+        pipelineTimeline.update(p2.config.name().toString());
         BuildCause buildCause = autoBuild.onModifications(given, true, previousRevisions);
         assertThat(buildCause, is(notNullValue()));
         assertThat(buildCause.getMaterialRevisions(), is(given));

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/BuildCauseProducerServiceConfigRepoIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/BuildCauseProducerServiceConfigRepoIntegrationTest.java
@@ -293,7 +293,7 @@ public class BuildCauseProducerServiceConfigRepoIntegrationTest {
         materialUpdateService.updateMaterial(material);
         materialUpdateService.updateMaterial(dependencyMaterial);
         waitForMaterialNotInProgress();
-        pipelineTimeline.update();
+        pipelineTimeline.update(x.getName());
 
         configTestRepo.addCodeToRepositoryAndPush("a.java", "added code file", "some java code");
 

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/BuildCauseProducerServiceDependencyIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/BuildCauseProducerServiceDependencyIntegrationTest.java
@@ -262,7 +262,7 @@ public class BuildCauseProducerServiceDependencyIntegrationTest {
         //trigger pipeline
         MaterialRevisions newRevs = checkinFile(svnMaterial, "bar.c", svnRepository);
         minglePipeline.runAndPassWith(newRevs);
-        pipelineTimeline.update();
+        pipelineTimeline.update(MINGLE_PIPELINE_NAME);
         scheduleHelper.autoSchedulePipelinesWithRealMaterials(mingleDownstreamPipelineName);
         assertThat(pipelineScheduleQueue.toBeScheduled().keySet()).doesNotContain(new CaseInsensitiveString(mingleDownstreamPipelineName));
     }
@@ -299,7 +299,8 @@ public class BuildCauseProducerServiceDependencyIntegrationTest {
         MaterialRevisions newRevs = checkinFile(svnMaterial, "bar.c", svnRepository);
         minglePipeline.runAndPassWith(newRevs);
         goPipeline.runAndPassWith(newRevs);
-        pipelineTimeline.update();
+        pipelineTimeline.update(MINGLE_PIPELINE_NAME);
+        pipelineTimeline.update(goPipeline.config.getName().toLower());
         scheduleHelper.autoSchedulePipelinesWithRealMaterials(downstreamPipelineName);
         assertThat(pipelineScheduleQueue.toBeScheduled().keySet()).doesNotContain(new CaseInsensitiveString(downstreamPipelineName));
     }
@@ -336,7 +337,8 @@ public class BuildCauseProducerServiceDependencyIntegrationTest {
         MaterialRevisions newRevs = checkinFile(svnMaterial, "bar.c", svnRepository);
         minglePipeline.runAndPassWith(newRevs);
         goPipeline.runAndPassWith(newRevs);
-        pipelineTimeline.update();
+        pipelineTimeline.update(MINGLE_PIPELINE_NAME);
+        pipelineTimeline.update(goPipeline.config.getName().toLower());
         scheduleHelper.autoSchedulePipelinesWithRealMaterials(downstreamPipelineName);
         assertThat(pipelineScheduleQueue.toBeScheduled().keySet()).contains(new CaseInsensitiveString(downstreamPipelineName));
     }
@@ -368,7 +370,7 @@ public class BuildCauseProducerServiceDependencyIntegrationTest {
         dbHelper.saveRevs(gitMaterialRevisions);
 
         //schedule the pipeline
-        pipelineTimeline.update();
+        pipelineTimeline.update(downstreamPipelineName);
         scheduleHelper.autoSchedulePipelinesWithRealMaterials(downstreamPipelineName);
         assertThat(pipelineScheduleQueue.toBeScheduled().keySet()).contains(new CaseInsensitiveString(downstreamPipelineName));
     }
@@ -396,7 +398,7 @@ public class BuildCauseProducerServiceDependencyIntegrationTest {
         //trigger upstream pipelines
         MaterialRevisions newRevs = checkinFile(svnMaterial, "bar.c", svnRepository);
         minglePipeline.runAndPassWith(newRevs);
-        pipelineTimeline.update();
+        pipelineTimeline.update(MINGLE_PIPELINE_NAME);
         scheduleHelper.autoSchedulePipelinesWithRealMaterials(downstreamPipelineName);
         assertThat(pipelineScheduleQueue.toBeScheduled().keySet()).doesNotContain(new CaseInsensitiveString(downstreamPipelineName));
     }

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/BuildCauseProducerServiceIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/BuildCauseProducerServiceIntegrationTest.java
@@ -317,7 +317,7 @@ public class BuildCauseProducerServiceIntegrationTest {
 
         configHelper.addPipeline(mingleDownstreamPipelineName, STAGE_NAME, new MaterialConfigs(svn.config(), mingleMaterialConfig), "unit");
 
-        pipelineTimeline.update();
+        pipelineTimeline.update(mingleDownstreamPipelineName);
         scheduleHelper.autoSchedulePipelinesWithRealMaterials(mingleDownstreamPipelineName);
 
         assertThat(pipelineScheduleQueue.toBeScheduled().keySet(), hasItem(new CaseInsensitiveString(mingleDownstreamPipelineName)));

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/BuildCauseProducerServiceIntegrationTimerTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/BuildCauseProducerServiceIntegrationTimerTest.java
@@ -122,7 +122,7 @@ public class BuildCauseProducerServiceIntegrationTimerTest {
         u.runAndPassWithGivenMDUTimestampAndRevisionStrings(p1, mduTimeForG11, "g11");
         u.runAndPassWithGivenMDUTimestampAndRevisionStrings(p1, u.d(i++), "g12");
         u.runAndPassWithGivenMDUTimestampAndRevisionStrings(p1, mduTimeForG11, "g11");
-        pipelineTimeline.update();
+        pipelineTimeline.update(pipelineName);
 
         buildCauseProducerService.timerSchedulePipeline(p1.config, new ServerHealthStateOperationResult());
 
@@ -141,7 +141,7 @@ public class BuildCauseProducerServiceIntegrationTimerTest {
 
         u.checkinFile(git1, "g11", temporaryFolder.newFile("blah_g11"), ModifiedAction.added);
         String up1_1 = u.runAndPassWithGivenMDUTimestampAndRevisionStrings(up1, u.d(i++), "g11");
-        pipelineTimeline.update();
+        pipelineTimeline.update(pipelineName);
 
         // Run once with latest, when pipeline schedules due to timer.
         buildCauseProducerService.timerSchedulePipeline(p1.config, new ServerHealthStateOperationResult());
@@ -207,7 +207,7 @@ public class BuildCauseProducerServiceIntegrationTimerTest {
         u.checkinFile(git2, "g21", temporaryFolder.newFile("blah_g21"), ModifiedAction.added);
         Date mduTimeOfG11 = u.d(i++);
         String p1_1 = u.runAndPassWithGivenMDUTimestampAndRevisionStrings(p1, mduTimeOfG11, "g11");
-        pipelineTimeline.update();
+        pipelineTimeline.update(pipelineName);
 
         // Run once with latest, when pipeline schedules due to timer.
         buildCauseProducerService.timerSchedulePipeline(p2.config, new ServerHealthStateOperationResult());
@@ -222,7 +222,7 @@ public class BuildCauseProducerServiceIntegrationTimerTest {
         // Check in to git2 and run pipeline P1 once before the timer time. Then, timer happens. Shows those two materials in "yellow" (changed), on the UI.
         u.checkinFile(git2, "g22", temporaryFolder.newFile("blah_g22"), ModifiedAction.added);
         String p1_2 = u.runAndPassWithGivenMDUTimestampAndRevisionStrings(p1, mduTimeOfG11, "g11");
-        pipelineTimeline.update();
+        pipelineTimeline.update(pipelineName);
         try (LogFixture logFixture = logFixtureFor(TimedBuild.class, Level.INFO)) {
             buildCauseProducerService.timerSchedulePipeline(p2.config, new ServerHealthStateOperationResult());
 

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/FanInPerformanceTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/FanInPerformanceTest.java
@@ -122,7 +122,7 @@ public class FanInPerformanceTest {
     }
 
     private MaterialRevisions getRevisionsBasedOnDependencies(CaseInsensitiveString pipeline, CruiseConfig cruiseConfig, MaterialRevisions given) {
-        pipelineTimeline.update();
+        pipelineTimeline.update(pipeline.toString());
         return pipelineService.getRevisionsBasedOnDependencies(given, cruiseConfig, pipeline);
     }
 }

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/FaninDependencyResolutionTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/FaninDependencyResolutionTest.java
@@ -191,6 +191,7 @@ public class FaninDependencyResolutionTest {
         assertThat(getRevisionsBasedOnDependencies(regression, cruiseConfig, given), is(expected));
 
         String a_2 = u.runAndPass(acceptance, b_2);
+        pipelineTimeline.update(acceptance.config.name().toString());
 
         given = u.mrs(
                 u.mr(build, true, b_2),
@@ -202,6 +203,7 @@ public class FaninDependencyResolutionTest {
 
         String r_2 = u.runAndPass(regression, b_2, a_2);
         String r_3 = u.runAndPass(regression, b_1, a_2);
+        pipelineTimeline.update(regression.config.name().toString());
 
         given = u.mrs(
                 u.mr(acceptance, true, a_2),
@@ -213,6 +215,7 @@ public class FaninDependencyResolutionTest {
 
         String s_2 = u.runAndPass(staging, a_2, r_2);
         String s_3 = u.runAndPass(staging, a_2, r_3);
+        pipelineTimeline.update(staging.config.name().toString());
 
         given = u.mrs(u.mr(staging, true, s_3));
         expected = u.mrs(u.mr(staging, true, s_2));
@@ -224,6 +227,10 @@ public class FaninDependencyResolutionTest {
         String r_4 = u.runAndPass(regression, b_3, a_3);
         String s_4 = u.runAndPass(staging, a_3, r_1);
         String s_5 = u.runAndPass(staging, a_1, r_4);
+        pipelineTimeline.update(build.config.name().toString());
+        pipelineTimeline.update(acceptance.config.name().toString());
+        pipelineTimeline.update(regression.config.name().toString());
+        pipelineTimeline.update(staging.config.name().toString());
 
         given = u.mrs(
                 u.mr(acceptance, true, a_3),
@@ -238,6 +245,7 @@ public class FaninDependencyResolutionTest {
 //        assertThat(getBuildCause(staging,given,previousMaterialRevisions), is(not(nullValue()))); //TODO: *************** Bug where pipeline should be triggered <Sara>
 
         String r_5 = u.runAndPass(regression, b_3, a_3);
+        pipelineTimeline.update(regression.config.name().toString());
 
         given = u.mrs(
                 u.mr(acceptance, true, a_3),

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/FaninDependencyResolutionTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/FaninDependencyResolutionTest.java
@@ -853,12 +853,12 @@ public class FaninDependencyResolutionTest {
 
     private BuildCause getBuildCause(ScheduleTestUtil.AddedPipeline staging, MaterialRevisions given, MaterialRevisions previous) {
         AutoBuild autoBuild = new AutoBuild(goConfigService, pipelineService, staging.config.name().toString(), systemEnvironment, materialChecker);
-        pipelineTimeline.update();
+        pipelineTimeline.update(staging.config.name().toString());
         return autoBuild.onModifications(given, false, previous);
     }
 
     private MaterialRevisions getRevisionsBasedOnDependencies(ScheduleTestUtil.AddedPipeline pipeline, CruiseConfig cruiseConfig, MaterialRevisions given) {
-        pipelineTimeline.update();
+        pipelineTimeline.update(pipeline.config.name().toString());
         return pipelineService.getRevisionsBasedOnDependencies(given, cruiseConfig, pipeline.config.name());
     }
 

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/PipelineHistoryServiceIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/PipelineHistoryServiceIntegrationTest.java
@@ -161,7 +161,7 @@ public class PipelineHistoryServiceIntegrationTest {
         pipelineTwo.createPipelineWithFirstStagePassedAndSecondStageHasNotStarted();
         dbHelper.updateNaturalOrder(toRerun.getId(), 3);
         dbHelper.scheduleStage(toRerun, pipelineTwo.devStage());
-        pipelineRepository.updatePipelineTimeline(pipelineTimeline, new ArrayList<>());
+        pipelineRepository.updatePipelineTimeline(pipelineTimeline, new ArrayList<>(), pipelineOne.pipelineName);
 
         List<PipelineGroupModel> groupModels = pipelineHistoryService.allActivePipelineInstances(new Username(new CaseInsensitiveString("jez")), PipelineSelections.ALL);
         assertThat(groupModels.size(), is(2));

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/PipelineServiceTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/PipelineServiceTest.java
@@ -106,7 +106,7 @@ public class PipelineServiceTest {
         when(pipelineDao.save(pipeline)).thenReturn(pipeline);
         when(materialRepository.findMaterialRevisionsForPipeline(9L)).thenReturn(MaterialRevisions.EMPTY);
         service.save(pipeline);
-        Mockito.verify(pipelineTimeline).update();
+        Mockito.verify(pipelineTimeline).update(pipeline.getName());
     }
 
     @Test
@@ -114,7 +114,7 @@ public class PipelineServiceTest {
         StageStatusListener stageStatusListener = mock(StageStatusListener.class);
         JobStatusListener jobStatusListener = mock(JobStatusListener.class);
         Pipeline pipeline = stubPipelineSaveForStatusListener(stageStatusListener, jobStatusListener);
-        Mockito.doThrow(new RuntimeException()).when(pipelineTimeline).update();
+        Mockito.doThrow(new RuntimeException()).when(pipelineTimeline).update(anyString());
 
         try {
             service.save(pipeline);

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/PipelineServiceTriangleDependencyTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/PipelineServiceTriangleDependencyTest.java
@@ -135,7 +135,7 @@ public class PipelineServiceTriangleDependencyTest {
         when(pipelineDao.save(pipeline)).thenReturn(pipeline);
         when(materialRepository.findMaterialRevisionsForPipeline(9L)).thenReturn(MaterialRevisions.EMPTY);
         service.save(pipeline);
-        Mockito.verify(pipelineTimeline).update();
+        Mockito.verify(pipelineTimeline).update(pipeline.getName());
     }
 
     @Test
@@ -143,7 +143,7 @@ public class PipelineServiceTriangleDependencyTest {
         StageStatusListener stageStatusListener = mock(StageStatusListener.class);
         JobStatusListener jobStatusListener = mock(JobStatusListener.class);
         Pipeline pipeline = stubPipelineSaveForStatusListener(stageStatusListener, jobStatusListener);
-        Mockito.doThrow(new RuntimeException()).when(pipelineTimeline).update();
+        Mockito.doThrow(new RuntimeException()).when(pipelineTimeline).update(any());
 
         try {
             service.save(pipeline);


### PR DESCRIPTION
* This is done so that all PTEs (PipelineTimelineEntries) need not be unnecessarily loaded in memory at startup.
* Earlier, PTEs for even deleted pipelines would be loaded from the db.
* This loads PTEs for specified pipeline on demand.

To test:

- [ ] Server startup time
- [ ] Performance of the new query (pg and h2)
- [ ] Performance while scheduling a pipeline with loads of for the first time (pg and h2)
- [ ] Memory profile (is eviction needed ?)
- [ ] Does this break fan-in? (shouldn't as this is mainly refactoring)
- [ ]  Ask @arvindsv what else to test for 

