### PR TITLE
Better logging for access token requests (#5923)

### DIFF
--- a/server/src/main/java/com/thoughtworks/go/domain/AccessToken.java
+++ b/server/src/main/java/com/thoughtworks/go/domain/AccessToken.java
@@ -23,6 +23,8 @@ import lombok.*;
 import lombok.experimental.Accessors;
 import org.apache.commons.codec.binary.Hex;
 import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.crypto.SecretKey;
 import javax.crypto.SecretKeyFactory;
@@ -32,7 +34,6 @@ import java.security.SecureRandom;
 import java.security.spec.InvalidKeySpecException;
 import java.sql.Timestamp;
 
-import static com.thoughtworks.go.server.service.AccessTokenService.LOGGER;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 
 @EqualsAndHashCode(callSuper = true, doNotUseGetters = true)
@@ -49,6 +50,7 @@ public class AccessToken extends PersistentObject implements Validatable {
     private static final int SALT_LENGTH = 32;
     private static final String KEY_ALGORITHM = "PBKDF2WithHmacSHA256";
     private static SecureRandom SECURE_RANDOM;
+    private static final Logger ACCESS_TOKEN_LOGGER = LoggerFactory.getLogger(AccessToken.class);
 
     static {
         SECURE_RANDOM = new SecureRandom();
@@ -73,17 +75,17 @@ public class AccessToken extends PersistentObject implements Validatable {
     private transient ConfigErrors errors = new ConfigErrors();
 
     public static AccessTokenWithDisplayValue create(String description, String username, String authConfigId, Clock clock) {
-        LOGGER.debug("[Access Token] Creating new access token for user '{}' description '{}' using auth config '{}'.", username, description, authConfigId);
-        LOGGER.debug("[Access Token] Generating Secure Random String of length 16 bytes for original token.");
+        ACCESS_TOKEN_LOGGER.debug("[Access Token] Creating new access token for user '{}' description '{}' using auth config '{}'.", username, description, authConfigId);
+        ACCESS_TOKEN_LOGGER.debug("[Access Token] Generating Secure Random String of length 16 bytes for original token.");
         String originalToken = generateSecureRandomString(16);
-        LOGGER.debug("[Access Token] Generating Secure Random String of length 4 bytes for salt id.");
+        ACCESS_TOKEN_LOGGER.debug("[Access Token] Generating Secure Random String of length 4 bytes for salt id.");
         String saltId = generateSecureRandomString(4);
-        LOGGER.debug("[Access Token] Generating Secure Random String of length {} bytes for salt value.", SALT_LENGTH);
+        ACCESS_TOKEN_LOGGER.debug("[Access Token] Generating Secure Random String of length {} bytes for salt value.", SALT_LENGTH);
         String saltValue = generateSecureRandomString(SALT_LENGTH);
-        LOGGER.debug("[Access Token] Generating hashed token from original token and salt value.");
+        ACCESS_TOKEN_LOGGER.debug("[Access Token] Generating hashed token from original token and salt value.");
         String hashedToken = digestToken(originalToken, saltValue);
         String finalTokenValue = String.format("%s%s", saltId, originalToken);
-        LOGGER.debug("[Access Token] Done creating new access token for user '{}' description '{}' using auth config '{}'.", username, description, authConfigId);
+        ACCESS_TOKEN_LOGGER.debug("[Access Token] Done creating new access token for user '{}' description '{}' using auth config '{}'.", username, description, authConfigId);
 
         return (AccessTokenWithDisplayValue) new AccessTokenWithDisplayValue()
                 .setDisplayValue(finalTokenValue)
@@ -104,7 +106,7 @@ public class AccessToken extends PersistentObject implements Validatable {
 
     static String digestToken(String originalToken, String salt) {
         try {
-            LOGGER.debug("Generating secret using algorithm: {} with spec: DEFAULT_ITERATIONS: {}, DESIRED_KEY_LENGTH: {}", KEY_ALGORITHM, DEFAULT_ITERATIONS, DESIRED_KEY_LENGTH);
+            ACCESS_TOKEN_LOGGER.debug("Generating secret using algorithm: {} with spec: DEFAULT_ITERATIONS: {}, DESIRED_KEY_LENGTH: {}", KEY_ALGORITHM, DEFAULT_ITERATIONS, DESIRED_KEY_LENGTH);
             SecretKeyFactory factory = SecretKeyFactory.getInstance(KEY_ALGORITHM);
             SecretKey key = factory.generateSecret(new PBEKeySpec(originalToken.toCharArray(), salt.getBytes(), DEFAULT_ITERATIONS, DESIRED_KEY_LENGTH));
             return Hex.encodeHexString(key.getEncoded());

--- a/server/src/main/java/com/thoughtworks/go/server/newsecurity/filters/AccessTokenAuthenticationFilter.java
+++ b/server/src/main/java/com/thoughtworks/go/server/newsecurity/filters/AccessTokenAuthenticationFilter.java
@@ -50,6 +50,7 @@ import static org.apache.http.HttpStatus.SC_UNAUTHORIZED;
 @Component
 public class AccessTokenAuthenticationFilter extends OncePerRequestFilter {
     protected final Logger LOGGER = LoggerFactory.getLogger(getClass());
+    protected final Logger ACCESS_TOKEN_LOGGER = LoggerFactory.getLogger(AccessToken.class);
     private static final String BAD_CREDENTIALS_MSG = "Invalid Personal Access Token.";
     protected final SecurityService securityService;
     private SecurityAuthConfigService securityAuthConfigService;
@@ -126,12 +127,12 @@ public class AccessTokenAuthenticationFilter extends OncePerRequestFilter {
             filterChain.doFilter(request, response);
         } else {
             accessTokenService.updateLastUsedCacheWith(accessTokenCredential.getAccessToken());
-            LOGGER.debug("[Bearer Token Authentication] Authenticating bearer token for: " +
-                            "\n GoCD User:             '{}'." +
-                            "\n GoCD API endpoint:     '{}'," +
-                            "\n API Client:            '{}'," +
-                            "\n Is Admin Scoped Token: '{}'," +
-                            "\n Current Time:          '{}'"
+            ACCESS_TOKEN_LOGGER.debug("[Bearer Token Authentication] Authenticating bearer token for: " +
+                            "GoCD User: '{}'. " +
+                            "GoCD API endpoint: '{}', " +
+                            "API Client: '{}', " +
+                            "Is Admin Scoped Token: '{}', " +
+                            "Current Time: '{}'."
                     , accessTokenCredential.getAccessToken().getUsername()
                     , request.getRequestURI()
                     , request.getHeader("User-Agent")

--- a/server/src/main/java/com/thoughtworks/go/server/service/AccessTokenService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/AccessTokenService.java
@@ -40,7 +40,7 @@ import java.util.concurrent.ConcurrentMap;
 
 @Service
 public class AccessTokenService {
-    private static final Logger LOGGER = LoggerFactory.getLogger(AccessTokenService.class);
+    public static final Logger LOGGER = LoggerFactory.getLogger(AccessTokenService.class);
     private final Clock timeProvider;
 
     private final AccessTokenDao accessTokenDao;
@@ -110,9 +110,11 @@ public class AccessTokenService {
             throw new ConflictException("Access token has already been revoked!");
         }
 
+        LOGGER.debug("[Access Token] Revoking access token with id: '{}' for user '{}' with revoked cause '{}'.", id, username, revokeCause);
         fetchedAccessToken.revoke(username, revokeCause, timeProvider.currentTimestamp());
-
         accessTokenDao.saveOrUpdate(fetchedAccessToken);
+
+        LOGGER.debug("[Access Token] Done revoking access token with id: '{}' for user '{}' with revoked cause '{}'.", id, username, revokeCause);
 
         return fetchedAccessToken;
     }

--- a/server/src/main/java/com/thoughtworks/go/server/service/AccessTokenService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/AccessTokenService.java
@@ -40,7 +40,8 @@ import java.util.concurrent.ConcurrentMap;
 
 @Service
 public class AccessTokenService {
-    public static final Logger LOGGER = LoggerFactory.getLogger(AccessTokenService.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(AccessTokenService.class);
+    private static final Logger ACCESS_TOKEN_LOGGER = LoggerFactory.getLogger(AccessToken.class);
     private final Clock timeProvider;
 
     private final AccessTokenDao accessTokenDao;
@@ -110,11 +111,11 @@ public class AccessTokenService {
             throw new ConflictException("Access token has already been revoked!");
         }
 
-        LOGGER.debug("[Access Token] Revoking access token with id: '{}' for user '{}' with revoked cause '{}'.", id, username, revokeCause);
+        ACCESS_TOKEN_LOGGER.debug("[Access Token] Revoking access token with id: '{}' for user '{}' with revoked cause '{}'.", id, username, revokeCause);
         fetchedAccessToken.revoke(username, revokeCause, timeProvider.currentTimestamp());
         accessTokenDao.saveOrUpdate(fetchedAccessToken);
 
-        LOGGER.debug("[Access Token] Done revoking access token with id: '{}' for user '{}' with revoked cause '{}'.", id, username, revokeCause);
+        ACCESS_TOKEN_LOGGER.debug("[Access Token] Done revoking access token with id: '{}' for user '{}' with revoked cause '{}'.", id, username, revokeCause);
 
         return fetchedAccessToken;
     }

--- a/server/src/main/resources/config/logback.xml
+++ b/server/src/main/resources/config/logback.xml
@@ -79,6 +79,7 @@
 
   <logger name="com.thoughtworks.go" level="INFO"/>
   <logger name="com.thoughtworks.go.server.Rails" level="WARN"/>
+  <logger name="com.thoughtworks.go.domain.AccessToken" level="DEBUG"/>
 
   <!-- make sure this is the last line in the config -->
   <include optional="true" file="${cruise.config.dir:-config}/logback-include.xml"/>


### PR DESCRIPTION
#### Debug Logs when a personal access token is generated:
```
019-05-07 11:50:59,448 DEBUG [qtp1412601264-33] AccessTokenService:76 - [Access Token] Creating new access token for user 'admin' description 'for APIs' using auth config '9cad79b0-4d9e-4a62-829c-eb4d9488062f'.
2019-05-07 11:50:59,449 DEBUG [qtp1412601264-33] AccessTokenService:77 - [Access Token] Generating Secure Random String of length 16 bytes for original token.
2019-05-07 11:50:59,449 DEBUG [qtp1412601264-33] AccessTokenService:79 - [Access Token] Generating Secure Random String of length 4 bytes for salt id.
2019-05-07 11:50:59,449 DEBUG [qtp1412601264-33] AccessTokenService:81 - [Access Token] Generating Secure Random String of length 32 bytes for salt value.
2019-05-07 11:50:59,450 DEBUG [qtp1412601264-33] AccessTokenService:83 - [Access Token] Generating hashed token from original token and salt value.
2019-05-07 11:50:59,450 DEBUG [qtp1412601264-33] AccessTokenService:107 - Generating secret using algorithm: PBKDF2WithHmacSHA256 with spec: DEFAULT_ITERATIONS: 4096, DESIRED_KEY_LENGTH: 256
```

#### Debug Logs when a personal access token is revoked:
```
2019-05-07 11:51:38,652 DEBUG [qtp1412601264-30] AccessTokenService:113 - [Access Token] Revoking access token with id: '65' for user 'admin' with revoked cause 'i dont use it anymore'.
2019-05-07 11:51:38,671 DEBUG [qtp1412601264-30] AccessTokenService:117 - [Access Token] Done revoking access token with id: '65' for user 'admin' with revoked cause 'i dont use it anymore'.
```

#### Debug Logs when a personal access token is used:
```
2019-05-07 13:26:51,100 DEBUG  [qtp1412601264-28] AccessTokenAuthenticationFilter:129 - [Bearer Token Authentication] Authenticating bearer token for:
 GoCD User:             'admin'.
 GoCD API endpoint:     '/go/api/current_user',
 API Client:            'curl/7.54.0',
 Is Admin Scoped Token: 'true',
 Current Time:          '2019-05-07 13:26:51.1'
```