### PR TITLE
Allow the ability to programmatically change autocomplete suggestions in AutocompleteField

### DIFF
--- a/server/webapp/WEB-INF/rails/webpack/rails-shared/xhr_promise.js
+++ b/server/webapp/WEB-INF/rails/webpack/rails-shared/xhr_promise.js
@@ -43,7 +43,7 @@
     // are some differences from the native `finally()`. See here:
     // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/finally#Description
     Promise.prototype.finally = function(callback) {
-      function invokeIgnoringArgs() { callback(); }
+      function invokeIgnoringArgs() { if ("function" === typeof callback) { callback(); } }
       return this.then(invokeIgnoringArgs, invokeIgnoringArgs);
     };
   }

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/pipelines/non_scm_material_fields.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/pipelines/non_scm_material_fields.tsx
@@ -21,7 +21,7 @@ import {Stream} from "mithril/stream";
 import * as stream from "mithril/stream";
 import {DependencyMaterialAutocomplete, PipelineNameCache} from "models/materials/dependency_autocomplete_cache";
 import {DependencyMaterialAttributes, Material, MaterialAttributes} from "models/materials/types";
-import {AutocompleteField, SuggestionProvider, SuggestionWriter} from "views/components/forms/autocomplete";
+import {AutocompleteField, SuggestionProvider} from "views/components/forms/autocomplete";
 import {Option, SelectField, SelectFieldOptions, TextField} from "views/components/forms/input_fields";
 import {AdvancedSettings} from "views/pages/pipelines/advanced_settings";
 import * as css from "./components.scss";
@@ -48,14 +48,19 @@ class DependencySuggestionProvider extends SuggestionProvider {
     this.cache = cache;
   }
 
-  getData(setData: SuggestionWriter): void {
-    if (!this.cache.ready()) {
-      this.cache.prime(() => {
-        setData(this.cache.pipelines());
-      });
-    } else {
-      setData(this.cache.pipelines());
-    }
+  getData(): Promise<Awesomplete.Suggestion[]> {
+    const self = this;
+    return new Promise<Awesomplete.Suggestion[]>((resolve, reject) => {
+      if (!self.cache.ready()) {
+        self.cache.prime(() => {
+          resolve(self.cache.pipelines());
+        }, () => {
+          reject(self.cache.failureReason());
+        });
+      } else {
+        resolve(self.cache.pipelines());
+      }
+    });
   }
 }
 


### PR DESCRIPTION
SuggestionProvider now allows a programmatic update/refresh of autocomplete suggestions

  - Changed getData() signature to return a promise
  - AutocompleteField registers handlers on provider
  - SuggestionProvider implementations expose an `update()` method that will invoke `getData()`
    perform updates to the suggestion list when used in AutocompleteField. As long as one has
    a handle on the provider object, one can trigger `update()` from, say, an event handler or
    timer