### PR TITLE
Complete test coverage for add pipeline components

### DIFF
--- a/server/webapp/WEB-INF/rails/webpack/views/components/forms/input_fields.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/components/forms/input_fields.tsx
@@ -159,10 +159,29 @@ class Label extends MithrilViewComponent<LabelComponentAttrs> {
     }
   }
 
+  static labelToId(label: m.Children): string {
+    if ("string" === typeof label) {
+      return label;
+    }
+
+    if (label instanceof Array) { // best guess, only consider top-level and don't recurse
+      let text = "";
+      for (const child of label) {
+        if ("string" === typeof child) {
+          text += child;
+        } else if (!(child instanceof Array)) {
+          text += (child as m.Vnode).text || "";
+        }
+      }
+      return text;
+    }
+    return "";
+  }
+
   view(vnode: m.Vnode<LabelComponentAttrs>) {
     if (Label.hasLabelText(vnode.attrs)) {
       return <label for={vnode.attrs.fieldId}
-                    data-test-id={`form-field-label-${s.slugify(vnode.attrs.label as string)}`}
+                    data-test-id={`form-field-label-${s.slugify(Label.labelToId(vnode.attrs.label))}`}
                     className={classnames(styles.formLabel)}>
         {vnode.attrs.label}
         <RequiredLabel {...vnode.attrs} />
@@ -252,7 +271,7 @@ function defaultAttributes<T, V>(attrs: BaseAttrs<T> & V,
     "disabled": !!(attrs.readonly),
     "required": !!required,
     "id": id,
-    "data-test-id": `form-field-input-${s.slugify(attrs.label as string)}`
+    "data-test-id": `form-field-input-${s.slugify(Label.labelToId(attrs.label))}`
   };
 
   if (attrs.dataTestId) {

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/pipelines/material_editor.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/pipelines/material_editor.tsx
@@ -39,7 +39,7 @@ export class MaterialEditor extends MithrilViewComponent<Attrs> {
 
   view(vnode: m.Vnode<Attrs>) {
     return <FormBody>
-      <SelectField label="Material Type"property={vnode.attrs.material.type} required={true}>
+      <SelectField label="Material Type" property={vnode.attrs.material.type} required={true}>
         <SelectFieldOptions selected={vnode.attrs.material.type()} items={this.supportedMaterials()}/>
       </SelectField>
 

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/pipelines/non_scm_material_fields.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/pipelines/non_scm_material_fields.tsx
@@ -31,7 +31,7 @@ interface Attrs {
   cache: SuggestionCache;
 }
 
-//tslint:disable-next-line
+// tslint:disable-next-line
 export interface SuggestionCache extends PipelineNameCache<Awesomplete.Suggestion, Option> {}
 
 export class DefaultCache extends DependencyMaterialAutocomplete<Awesomplete.Suggestion, Option> implements SuggestionCache {

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/pipelines/spec/advanced_settings_spec.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/pipelines/spec/advanced_settings_spec.tsx
@@ -16,7 +16,6 @@
 
 import asSelector from "helpers/selector_proxy";
 import * as m from "mithril";
-import * as events from "simulate-event";
 import {TestHelper} from "views/pages/spec/test_helper";
 import {AdvancedSettings} from "../advanced_settings";
 import * as css from "../components.scss";
@@ -51,11 +50,11 @@ describe("AddPipeline: AdvancedSettings", () => {
     expect(top.classList.contains(css.open)).toBe(false);
     expect(window.getComputedStyle(helper.q(sel.details, top)).display).toBe("none");
 
-    events.simulate(helper.q(sel.summary, top), "click");
+    helper.click(sel.summary, top);
     expect(top.classList.contains(css.open)).toBe(true);
     expect(window.getComputedStyle(helper.q(sel.details, top)).display).toBe("block");
 
-    events.simulate(helper.q(sel.summary, top), "click");
+    helper.click(sel.summary, top);
     expect(top.classList.contains(css.open)).toBe(false);
     expect(window.getComputedStyle(helper.q(sel.details, top)).display).toBe("none");
   });

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/pipelines/spec/advanced_settings_spec.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/pipelines/spec/advanced_settings_spec.tsx
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import asSelector from "helpers/selector_proxy";
 import * as m from "mithril";
 import * as events from "simulate-event";
 import {TestHelper} from "views/pages/spec/test_helper";
@@ -21,6 +22,7 @@ import {AdvancedSettings} from "../advanced_settings";
 import * as css from "../components.scss";
 
 describe("AddPipeline: AdvancedSettings", () => {
+  const sel = asSelector<typeof css>(css);
   const helper = new TestHelper();
 
   beforeEach(() => {
@@ -34,27 +36,27 @@ describe("AddPipeline: AdvancedSettings", () => {
   afterEach(helper.unmount.bind(helper));
 
   it("Generates element hierarchy and child elements", () => {
-    const top = helper.find(`.${css.advancedSettings}`)[0];
+    const top = helper.q(sel.advancedSettings);
     expect(top).toBeTruthy();
-    expect(top.querySelector(`.${css.summary}`)).toBeTruthy();
-    expect(top.querySelector(`.${css.summary}`)!.textContent).toBe("Advanced Settings");
+    expect(helper.q(sel.summary, top)).toBeTruthy();
+    expect(helper.text(sel.summary, top)).toBe("Advanced Settings");
 
-    expect(top.querySelector(`.${css.details}`)).toBeTruthy();
-    expect(top.querySelector(`.${css.details} .foo`)).toBeTruthy();
-    expect(top.querySelector(`.${css.details} .foo`)!.textContent).toBe("Some content");
+    expect(helper.q(sel.details, top)).toBeTruthy();
+    expect(helper.q(`${sel.details} .foo`, top)).toBeTruthy();
+    expect(helper.text(`${sel.details} .foo`, top)).toBe("Some content");
   });
 
   it("Clicking toggles the open class", () => {
-    const top = helper.find(`.${css.advancedSettings}`)[0];
+    const top = helper.q(sel.advancedSettings);
     expect(top.classList.contains(css.open)).toBe(false);
-    expect(window.getComputedStyle(top.querySelector(`.${css.details}`)!).display).toBe("none");
+    expect(window.getComputedStyle(helper.q(sel.details, top)).display).toBe("none");
 
-    events.simulate(top.querySelector(`.${css.summary}`)!, "click");
+    events.simulate(helper.q(sel.summary, top), "click");
     expect(top.classList.contains(css.open)).toBe(true);
-    expect(window.getComputedStyle(top.querySelector(`.${css.details}`)!).display).toBe("block");
+    expect(window.getComputedStyle(helper.q(sel.details, top)).display).toBe("block");
 
-    events.simulate(top.querySelector(`.${css.summary}`)!, "click");
+    events.simulate(helper.q(sel.summary, top), "click");
     expect(top.classList.contains(css.open)).toBe(false);
-    expect(window.getComputedStyle(top.querySelector(`.${css.details}`)!).display).toBe("none");
+    expect(window.getComputedStyle(helper.q(sel.details, top)).display).toBe("none");
   });
 });

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/pipelines/spec/concept_diagram_spec.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/pipelines/spec/concept_diagram_spec.tsx
@@ -29,14 +29,14 @@ describe("AddPipeline: ConceptDiagram", () => {
   afterEach(helper.unmount.bind(helper));
 
   it("Renders the concept diagram SVG", () => {
-    const img = helper.find(`object[type="image/svg+xml"]`)[0];
+    const img = helper.q(`object[type="image/svg+xml"]`);
     expect(img).toBeTruthy();
     expect(img.getAttribute("data")).toBe(image);
   });
 
   it("Renders the concept diagram caption", () => {
-    expect(helper.find("figure figcaption")[0].textContent).toBe("A simple explanation");
+    expect(helper.q("figure figcaption").textContent).toBe("A simple explanation");
     // preserves formatting
-    expect(helper.find("figure figcaption strong")[0].textContent).toBe("simple");
+    expect(helper.q("figure figcaption strong").textContent).toBe("simple");
   });
 });

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/pipelines/spec/fillable_section_spec.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/pipelines/spec/fillable_section_spec.tsx
@@ -14,12 +14,14 @@
  * limitations under the License.
  */
 
+import asSelector from "helpers/selector_proxy";
 import * as m from "mithril";
 import {TestHelper} from "views/pages/spec/test_helper";
 import * as css from "../components.scss";
 import {FillableSection} from "../fillable_section";
 
 describe("AddPipeline: FillableSection", () => {
+  const sel = asSelector<typeof css>(css);
   const helper = new TestHelper();
 
   beforeEach(() => {
@@ -33,12 +35,12 @@ describe("AddPipeline: FillableSection", () => {
   afterEach(helper.unmount.bind(helper));
 
   it("Generates structure", () => {
-    const top = helper.find(`.${css.fillable}`)[0];
+    const top = helper.q(sel.fillable);
     expect(top).toBeTruthy();
   });
 
   it("Renders child elements", () => {
-    const top = helper.find(`.${css.fillable}`)[0];
+    const top = helper.q(sel.fillable);
     expect(top.querySelector(".foo")).toBeTruthy();
     expect(top.querySelector(".foo")!.textContent).toBe("Some content");
   });

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/pipelines/spec/job_editor_spec.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/pipelines/spec/job_editor_spec.tsx
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as m from "mithril";
+import {Job} from "models/pipeline_configs/job";
+import {TestHelper} from "views/pages/spec/test_helper";
+import {JobEditor} from "../job_editor";
+
+describe("AddPipeline: JobEditor", () => {
+  const helper = new TestHelper();
+  let job: Job;
+
+  beforeEach(() => {
+    job = new Job("", []);
+    helper.mount(() => <JobEditor job={job}/>);
+  });
+
+  afterEach(helper.unmount.bind(helper));
+
+  it("Generates structure", () => {
+    expect(helper.byTestId("form-field-label-job-name")).toBeTruthy();
+    expect(helper.byTestId("form-field-label-job-name").textContent).toBe("Job Name*");
+
+    expect(helper.byTestId("form-field-input-job-name")).toBeTruthy();
+  });
+
+  it("Binds to model", () => {
+    expect(job.name()).toBe("");
+
+    helper.oninput(helper.byTestId("form-field-input-job-name"), "my-job");
+    expect(job.name()).toBe("my-job");
+  });
+});

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/pipelines/spec/material_editor_spec.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/pipelines/spec/material_editor_spec.tsx
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// import asSelector from "helpers/selector_proxy";
+import * as m from "mithril";
+import {Material} from "models/materials/types";
+import {TestHelper} from "views/pages/spec/test_helper";
+// import * as css from "../components.scss";
+import {MaterialEditor} from "../material_editor";
+
+describe("AddPipeline: Material Editor", () => {
+  // const sel = asSelector<typeof css>(css);
+  const helper = new TestHelper();
+  let material: Material;
+
+  beforeEach(() => {
+    material = new Material();
+
+    helper.mount(() => {
+      return <MaterialEditor material={material}/>;
+    });
+  });
+
+  afterEach(helper.unmount.bind(helper));
+
+  it("Generates structure", () => {
+    expect(helper.q("select")).toBeTruthy();
+    expect(helper.q("label")).toBeTruthy();
+    expect(helper.q("label").textContent).toBe("Material Type*");
+    expect(helper.textAll("option")).toEqual(["Git", "Mercurial", "Subversion", "Perforce", "Team Foundation Server", "Another Pipeline"]);
+  });
+
+  it("Selecting a material updates the model type", () => {
+    expect(material.type()).toBeUndefined();
+
+    helper.onchange("select", "p4");
+    expect(material.type()).toBe("p4");
+    expect(helper.byTestId("form-field-label-repository-url")).toBeFalsy();
+    expect(helper.byTestId("form-field-label-p4-view")).toBeTruthy();
+    expect(helper.byTestId("form-field-label-p4-view").textContent).toBe("P4 View*");
+
+    helper.onchange("select", "git");
+    expect(material.type()).toBe("git");
+    expect(helper.byTestId("form-field-label-p4-view")).toBeFalsy();
+    expect(helper.byTestId("form-field-label-repository-url")).toBeTruthy();
+    expect(helper.byTestId("form-field-label-repository-url").textContent).toBe("Repository URL*");
+  });
+});

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/pipelines/spec/material_editor_spec.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/pipelines/spec/material_editor_spec.tsx
@@ -14,15 +14,12 @@
  * limitations under the License.
  */
 
-// import asSelector from "helpers/selector_proxy";
 import * as m from "mithril";
-import {Material} from "models/materials/types";
+import {GitMaterialAttributes, Material, P4MaterialAttributes} from "models/materials/types";
 import {TestHelper} from "views/pages/spec/test_helper";
-// import * as css from "../components.scss";
 import {MaterialEditor} from "../material_editor";
 
 describe("AddPipeline: Material Editor", () => {
-  // const sel = asSelector<typeof css>(css);
   const helper = new TestHelper();
   let material: Material;
 
@@ -45,15 +42,18 @@ describe("AddPipeline: Material Editor", () => {
 
   it("Selecting a material updates the model type", () => {
     expect(material.type()).toBeUndefined();
+    expect(material.attributes()).toBeUndefined();
 
     helper.onchange("select", "p4");
     expect(material.type()).toBe("p4");
+    expect(material.attributes() instanceof P4MaterialAttributes).toBe(true);
     expect(helper.byTestId("form-field-label-repository-url")).toBeFalsy();
     expect(helper.byTestId("form-field-label-p4-view")).toBeTruthy();
     expect(helper.byTestId("form-field-label-p4-view").textContent).toBe("P4 View*");
 
     helper.onchange("select", "git");
     expect(material.type()).toBe("git");
+    expect(material.attributes() instanceof GitMaterialAttributes).toBe(true);
     expect(helper.byTestId("form-field-label-p4-view")).toBeFalsy();
     expect(helper.byTestId("form-field-label-repository-url")).toBeTruthy();
     expect(helper.byTestId("form-field-label-repository-url").textContent).toBe("Repository URL*");

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/pipelines/spec/non_scm_material_fields_spec.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/pipelines/spec/non_scm_material_fields_spec.tsx
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as m from "mithril";
+import {DependencyMaterialAttributes, Material} from "models/materials/types";
+import {TestHelper} from "views/pages/spec/test_helper";
+import {DependencyFields, SuggestionCache} from "../non_scm_material_fields";
+
+describe("AddPipeline: Non-SCM Material Fields", () => {
+  const helper = new TestHelper();
+
+  afterEach(helper.unmount.bind(helper));
+
+  it("DependencyFields structure", () => {
+    const material = new Material("dependency", new DependencyMaterialAttributes());
+    helper.mount(() => <DependencyFields material={material} cache={new DummyCache()}/>);
+
+    assertLabelledInputsPresent({
+      "upstream-pipeline": "Upstream Pipeline*",
+      "upstream-stage":    "Upstream Stage*",
+      "material-name":     "Material Name",
+    });
+  });
+
+  function assertLabelledInputsPresent(idsToLabels: {[key: string]: string}) {
+    const keys = Object.keys(idsToLabels);
+    expect(keys.length > 0).toBe(true);
+
+    for (const id of keys) {
+      expect(helper.byTestId(`form-field-label-${id}`)).toBeTruthy();
+      expect(helper.byTestId(`form-field-label-${id}`).textContent!.startsWith(idsToLabels[id])).toBe(true);
+      expect(helper.byTestId(`form-field-input-${id}`)).toBeTruthy();
+    }
+  }
+});
+
+class DummyCache implements SuggestionCache {
+  ready() { return true; }
+  // tslint:disable-next-line
+  prime(onSuccess: () => void, onError?: () => void) {}
+  pipelines() { return []; }
+  stages(pipeline: string) { return []; }
+  failureReason() { return undefined; }
+  failed() { return false; }
+}

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/pipelines/spec/pipeline_info_editor_spec.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/pipelines/spec/pipeline_info_editor_spec.tsx
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as m from "mithril";
+import {PipelineConfig} from "models/pipeline_configs/pipeline_config";
+import {TestHelper} from "views/pages/spec/test_helper";
+import {PipelineInfoEditor} from "../pipeline_info_editor";
+
+describe("AddPipeline: PipelineInfoEditor", () => {
+  const helper = new TestHelper();
+  let config: PipelineConfig;
+
+  beforeEach(() => {
+    config = new PipelineConfig("", [], []);
+    helper.mount(() => <PipelineInfoEditor pipelineConfig={config}/>);
+  });
+
+  afterEach(helper.unmount.bind(helper));
+
+  it("Generates structure", () => {
+    expect(helper.byTestId("form-field-label-pipeline-name")).toBeTruthy();
+    expect(helper.byTestId("form-field-label-pipeline-name").textContent).toBe("Pipeline Name*");
+
+    expect(helper.byTestId("form-field-input-pipeline-name")).toBeTruthy();
+  });
+
+  it("Binds to model", () => {
+    expect(config.name()).toBe("");
+
+    helper.oninput(helper.byTestId("form-field-input-pipeline-name"), "my-pipeline");
+    expect(config.name()).toBe("my-pipeline");
+  });
+});

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/pipelines/spec/scm_material_fields_spec.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/pipelines/spec/scm_material_fields_spec.tsx
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as m from "mithril";
+import {
+  GitMaterialAttributes,
+  HgMaterialAttributes,
+  Material,
+  P4MaterialAttributes,
+  SvnMaterialAttributes,
+  TfsMaterialAttributes,
+} from "models/materials/types";
+import {TestHelper} from "views/pages/spec/test_helper";
+import {GitFields, HgFields, P4Fields, SvnFields, TfsFields} from "../scm_material_fields";
+
+describe("AddPipeline: SCM Material Fields", () => {
+  const helper = new TestHelper();
+
+  afterEach(helper.unmount.bind(helper));
+
+  it("GitFields structure", () => {
+    const material = new Material("git", new GitMaterialAttributes());
+    helper.mount(() => <GitFields material={material}/>);
+
+    assertLabelledInputsPresent({
+      "repository-url":          "Repository URL*",
+      "repository-branch":       "Repository Branch",
+      "username":                "Username",
+      "password":                "Password",
+      "alternate-checkout-path": "Alternate Checkout Path",
+      "material-name":           "Material Name",
+    });
+
+    expect(helper.byTestId("test-connection-button")).toBeTruthy();
+  });
+
+  it("HgFields structure", () => {
+    const material = new Material("hg", new HgMaterialAttributes());
+    helper.mount(() => <HgFields material={material}/>);
+
+    assertLabelledInputsPresent({
+      "repository-url":          "Repository URL*",
+      "username":                "Username",
+      "password":                "Password",
+      "alternate-checkout-path": "Alternate Checkout Path",
+      "material-name":           "Material Name",
+    });
+
+    expect(helper.byTestId("test-connection-button")).toBeTruthy();
+  });
+
+  it("SvnFields structure", () => {
+    const material = new Material("svn", new SvnMaterialAttributes());
+    helper.mount(() => <SvnFields material={material}/>);
+
+    assertLabelledInputsPresent({
+      "repository-url":          "Repository URL*",
+      "check-externals":         "Check Externals",
+      "username":                "Username",
+      "password":                "Password",
+      "alternate-checkout-path": "Alternate Checkout Path",
+      "material-name":           "Material Name",
+    });
+
+    expect(helper.byTestId("test-connection-button")).toBeTruthy();
+  });
+
+  it("P4Fields structure", () => {
+    const material = new Material("p4", new P4MaterialAttributes());
+    helper.mount(() => <P4Fields material={material}/>);
+
+    assertLabelledInputsPresent({
+      "p4-protocol-host-port":     "P4 [Protocol:][Host:]Port*",
+      "p4-view":                   "P4 View*",
+      "use-ticket-authentication": "Use Ticket Authentication",
+      "username":                  "Username",
+      "password":                  "Password",
+      "alternate-checkout-path":   "Alternate Checkout Path",
+      "material-name":             "Material Name",
+    });
+
+    expect(helper.byTestId("test-connection-button")).toBeTruthy();
+  });
+
+  it("TfsFields structure", () => {
+    const material = new Material("tfs", new TfsMaterialAttributes());
+    helper.mount(() => <TfsFields material={material}/>);
+
+    assertLabelledInputsPresent({
+      "repository-url":          "Repository URL*",
+      "project-path":            "Project Path*",
+      "domain":                  "Domain",
+      "username":                "Username*",
+      "password":                "Password*",
+      "alternate-checkout-path": "Alternate Checkout Path",
+      "material-name":           "Material Name",
+    });
+
+    expect(helper.byTestId("test-connection-button")).toBeTruthy();
+  });
+
+  function assertLabelledInputsPresent(idsToLabels: {[key: string]: string}) {
+    const keys = Object.keys(idsToLabels);
+    expect(keys.length > 0).toBe(true);
+
+    for (const id of keys) {
+      expect(helper.byTestId(`form-field-label-${id}`)).toBeTruthy();
+      expect(helper.byTestId(`form-field-label-${id}`).textContent!.startsWith(idsToLabels[id])).toBe(true);
+      expect(helper.byTestId(`form-field-input-${id}`)).toBeTruthy();
+    }
+  }
+});

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/pipelines/spec/stage_editor_spec.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/pipelines/spec/stage_editor_spec.tsx
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import asSelector from "helpers/selector_proxy";
+import * as m from "mithril";
+import {Stage} from "models/pipeline_configs/stage";
+import {TestHelper} from "views/pages/spec/test_helper";
+import * as css from "../components.scss";
+import {StageEditor} from "../stage_editor";
+
+describe("AddPipeline: StageEditor", () => {
+  const sel = asSelector<typeof css>(css);
+  const helper = new TestHelper();
+  let stage: Stage;
+
+  beforeEach(() => {
+    stage = new Stage("", []);
+    helper.mount(() => <StageEditor stage={stage}/>);
+  });
+
+  afterEach(helper.unmount.bind(helper));
+
+  it("Generates structure", () => {
+    expect(helper.byTestId("form-field-label-stage-name")).toBeTruthy();
+    expect(helper.byTestId("form-field-label-stage-name").textContent).toBe("Stage Name*");
+
+    expect(helper.byTestId("form-field-input-stage-name")).toBeTruthy();
+
+    expect(helper.q(sel.switchLabelText)).toBeTruthy();
+    expect(helper.byTestId("switch-label")).toBeTruthy();
+    expect(helper.byTestId("switch-label").textContent!.startsWith("Automatically run this stage on upstream changes")).toBe(true);
+    expect(helper.byTestId("switch-paddle")).toBeTruthy();
+    expect(helper.byTestId("switch-checkbox")).toBeTruthy();
+  });
+
+  it("Binds to model", () => {
+    expect(stage.name()).toBe("");
+
+    helper.oninput(helper.byTestId("form-field-input-stage-name"), "my-stage");
+    expect(stage.name()).toBe("my-stage");
+
+    expect(stage.approval().type()).toBe("success");
+
+    helper.click(helper.byTestId("switch-paddle"));
+    expect(stage.approval().type()).toBe("manual");
+  });
+});

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/pipelines/spec/user_input_pane_spec.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/pipelines/spec/user_input_pane_spec.tsx
@@ -14,15 +14,15 @@
  * limitations under the License.
  */
 
-import {bind} from "classnames/bind";
+import asSelector from "helpers/selector_proxy";
 import * as m from "mithril";
 import {TestHelper} from "views/pages/spec/test_helper";
-import * as styles from "../components.scss";
+import * as css from "../components.scss";
 import {UserInputPane} from "../user_input_pane";
 
 describe("AddPipeline: UserInputPane", () => {
+  const sel = asSelector<typeof css>(css);
   const helper = new TestHelper();
-  const cls = bind(styles);
 
   beforeEach(() => {
     helper.mount(() => {
@@ -35,21 +35,19 @@ describe("AddPipeline: UserInputPane", () => {
   afterEach(helper.unmount.bind(helper));
 
   it("Generates structure with heading", () => {
-    const top = helper.find(`.${cls(styles.userInput)}`)[0];
+    const top = helper.q(sel.userInput);
     expect(top).toBeTruthy();
 
-    const heading = top!.querySelector(`.${cls(styles.sectionHeading)}`);
-    expect(heading).not.toBeNull();
-    expect(heading!.textContent).toBe("Episode IV: A New Hope");
+    expect(helper.q(sel.sectionHeading, top)).toBeTruthy();
+    expect(helper.text(sel.sectionHeading, top)).toBe("Episode IV: A New Hope");
 
-    const note = top.querySelector(`.${cls(styles.sectionNote)}`);
-    expect(note).not.toBeNull();
-    expect(note!.textContent).toBe("* denotes a required field");
+    expect(helper.q(sel.sectionNote, top)).toBeTruthy();
+    expect(helper.text(sel.sectionNote, top)).toBe("* denotes a required field");
   });
 
   it("Renders child elements", () => {
-    const top = helper.find(`.${cls(styles.userInput)}`)[0];
-    expect(top.querySelector("p.nerd-alert")).toBeTruthy();
-    expect(top.querySelector("p.nerd-alert")!.textContent).toBe("A long time ago in a galaxy far, far away...");
+    const top = helper.q(sel.userInput);
+    expect(helper.q("p.nerd-alert", top)).toBeTruthy();
+    expect(helper.text("p.nerd-alert", top)).toBe("A long time ago in a galaxy far, far away...");
   });
 });

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/pipelines/task_editor.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/pipelines/task_editor.tsx
@@ -52,7 +52,7 @@ export class TaskEditor extends MithrilViewComponent<Attrs> {
         <span>Caveats</span>
         <p>This is not a real shell:</p>
         <p>- Pipes, loops, and conditionals will NOT work</p>
-        <p>- Use <strong>&lt;shift&gt;-&lt;enter&gt;</strong> for multiline, not <strong>`\`</strong></p>
+        <p>- <strong>&lt;shift&gt;-&lt;enter&gt;</strong> for newlines, <strong>`\`</strong> is optional</p>
         <p>- Commands are not stateful; e.g., `cd foo` will NOT change cwd for subsequent commands</p>
       </div>
       <p class={css.comment}># Type your commands; press <strong>&lt;enter&gt;</strong> to save</p>
@@ -140,7 +140,7 @@ export class TaskEditor extends MithrilViewComponent<Attrs> {
   private static parseCLI(raw: string): ParsedCommand {
     let rawCmd = raw, rawArgs = ""; // rawCmd/Args preserve the exact formatting of the user's input
     let extractedCommand = false; // flag to ensure we only set these once
-    const args = Shellwords.split(raw, (token: string) => {
+    const args = _.filter(Shellwords.split(raw, (token: string) => {
       if (!extractedCommand) {
         // get the raw cmd string and argStr to
         // preserve exactly what the user typed, so as
@@ -149,8 +149,10 @@ export class TaskEditor extends MithrilViewComponent<Attrs> {
         rawArgs = raw.slice(token.length).trim();
         extractedCommand = true;
       }
-    });
+    }), (s) => "\\" !== s.trim());
+
     const cmd = args.shift()!;
+
     return { cmd, args, rawCmd, rawArgs };
   }
 

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/spec/test_helper.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/spec/test_helper.tsx
@@ -97,22 +97,22 @@ export class TestHelper {
     return result;
   }
 
-  onchange(selector: string, value: string) {
-    const input: ElementWithValue = this.q(selector) as ElementWithValue;
+  onchange(selector: string | Element, value: string, context?: Element) {
+    const input: ElementWithValue = this._el(selector, context) as ElementWithValue;
     input.value = value;
     simulateEvent.simulate(input, "change");
     this.redraw();
   }
 
-  oninput(selector: string, value: string) {
-    const input: ElementWithInput = this.q(selector) as ElementWithInput;
+  oninput(selector: string | Element, value: string, context?: Element) {
+    const input: ElementWithInput = this._el(selector, context) as ElementWithInput;
     input.value = value;
     simulateEvent.simulate(input, "input");
     this.redraw();
   }
 
-  click(selector: string) {
-    const element = this.q(selector);
+  click(selector: string | Element, context?: Element) {
+    const element = this._el(selector, context);
     if (!element) {
       throw new Error(`Unable to find element with selector ${selector}`);
     }
@@ -157,6 +157,10 @@ export class TestHelper {
 
   findIn(elem: any, id: string) {
     return $(elem).find(this.dataTestIdSelector(id));
+  }
+
+  private _el(selector: string | Element, context?: Element): Element {
+    return "string" === typeof selector ? this.q(selector, context) : selector;
   }
 
   private initialize() {

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/spec/test_helper.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/spec/test_helper.tsx
@@ -20,6 +20,8 @@ import * as simulateEvent from "simulate-event";
 import {Page} from "views/pages/page";
 
 let mounted = false;
+type ElementWithInput = HTMLInputElement | HTMLTextAreaElement;
+type ElementWithValue = ElementWithInput | HTMLSelectElement;
 
 export class TestHelper {
   root?: HTMLElement;
@@ -80,17 +82,33 @@ export class TestHelper {
     return (context || this.root!).querySelectorAll(selector);
   }
 
-  // jQuery implementations
-  findByDataTestId(id: string) {
-    return $(this.root!).find(`[data-test-id='${id}']`);
+  text(selector: string, context?: Element): string {
+    return (this.q(selector, context).textContent || "").trim();
   }
 
-  find(selector: string) {
-    return $(this.root!).find(selector);
+  textAll(selector: string, context?: Element): string[] {
+    const result: string[] = [];
+    const elements = Array.from(this.qa(selector, context));
+
+    for (const el of elements) {
+      result.push((el.textContent || "").trim());
+    }
+
+    return result;
   }
 
-  findIn(elem: any, id: string) {
-    return $(elem).find(this.dataTestIdSelector(id));
+  onchange(selector: string, value: string) {
+    const input: ElementWithValue = this.q(selector) as ElementWithValue;
+    input.value = value;
+    simulateEvent.simulate(input, "change");
+    this.redraw();
+  }
+
+  oninput(selector: string, value: string) {
+    const input: ElementWithInput = this.q(selector) as ElementWithInput;
+    input.value = value;
+    simulateEvent.simulate(input, "input");
+    this.redraw();
   }
 
   click(selector: string) {
@@ -126,6 +144,19 @@ export class TestHelper {
 
   findByClass(className: string) {
     return this.root!.getElementsByClassName(className);
+  }
+
+  // jQuery implementations
+  findByDataTestId(id: string) {
+    return $(this.root!).find(`[data-test-id='${id}']`);
+  }
+
+  find(selector: string) {
+    return $(this.root!).find(selector);
+  }
+
+  findIn(elem: any, id: string) {
+    return $(elem).find(this.dataTestIdSelector(id));
   }
 
   private initialize() {


### PR DESCRIPTION
Also adds a minor enhancement to the task entry terminal.

For multiline commands, we ignore trailing `\` that are common, which makes it optional.

In other words:

```bash
find . \
  -type f \
  -name package.json
```

parses the same way as:

```bash
find .
  -type f
  -name package.json
```

and

```bash
find . -type f -name package.json
```