### PR TITLE
Add Pipeline Page: Make sure users know about validation errors that may be obstructed from their view

### DIFF
--- a/server/webapp/WEB-INF/rails/webpack/views/pages/pipelines/actions.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/pipelines/actions.tsx
@@ -15,11 +15,14 @@
  */
 
 import * as Routes from "gen/ts-routes";
+import asSelector from "helpers/selector_proxy";
 import {MithrilViewComponent} from "jsx/mithril-component";
 import * as m from "mithril";
 import {PipelineConfig} from "models/pipeline_configs/pipeline_config";
 import * as Buttons from "views/components/buttons";
 import * as css from "./components.scss";
+
+const sel = asSelector<typeof css>(css);
 
 interface Attrs {
   pipelineConfig: PipelineConfig;
@@ -82,11 +85,13 @@ export class PipelineActions extends MithrilViewComponent<Attrs> {
       }).catch((reason) => {
         this.setError(reason);
       });
+    } else {
+      this.setError("Please fix the validation errors above before proceeding.");
     }
   }
 
   private clearError(): Node {
-    return empty(document.querySelector(`.${css.errorResponse}`)!);
+    return empty(document.querySelector(sel.errorResponse)!);
   }
 
   private setError(text: string) {

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/pipelines/advanced_settings.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/pipelines/advanced_settings.tsx
@@ -14,20 +14,35 @@
  * limitations under the License.
  */
 
+import {bind} from "classnames/bind";
 import {MithrilViewComponent} from "jsx/mithril-component";
 import * as m from "mithril";
 import * as css from "./components.scss";
 
-export class AdvancedSettings extends MithrilViewComponent {
-  oncreate(vnode: m.VnodeDOM) {
+const cls = bind(css);
+
+interface Attrs {
+  forceOpen?: boolean;
+}
+
+export class AdvancedSettings extends MithrilViewComponent<Attrs> {
+  oncreate(vnode: m.VnodeDOM<Attrs, {}>) {
     const el = vnode.dom;
     el!.querySelector("dt")!.addEventListener("click", () => {
-      el.classList.toggle(css.open);
+      if (!vnode.attrs.forceOpen) {
+        el.classList.toggle(css.open);
+      }
     });
   }
 
-  view(vnode: m.Vnode): m.Children | void | null {
-    return <dl class={css.advancedSettings}>
+  onupdate(vnode: m.VnodeDOM<Attrs, {}>) {
+    if (vnode.attrs.forceOpen) {
+      vnode.dom.classList.remove(css.open);
+    }
+  }
+
+  view(vnode: m.Vnode<Attrs>): m.Children | void | null {
+    return <dl class={cls(css.advancedSettings, {[css.lockOpen]: vnode.attrs.forceOpen})}>
       <dt class={css.summary}>Advanced Settings</dt>
       <dd class={css.details}>{vnode.children}</dd>
     </dl>;

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/pipelines/components.scss
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/pipelines/components.scss
@@ -39,6 +39,10 @@ $diagram-width: 485px;
   .error-response {
     margin-right: 2ex;
     color: $go-danger;
+
+    &:empty {
+      margin-right: 0;
+    }
   }
 }
 
@@ -158,7 +162,7 @@ $diagram-width: 485px;
     display: none;
   }
 
-  &.open {
+  &.open, &.lock-open {
     .summary {
       margin-bottom: 15px;
 
@@ -168,6 +172,14 @@ $diagram-width: 485px;
     }
 
     .details { display: block; }
+  }
+
+  &.lock-open .summary {
+    cursor: not-allowed;
+
+    &:before {
+      color: lighten($text-color, 50%);
+    }
   }
 }
 

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/pipelines/components.scss.d.ts
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/pipelines/components.scss.d.ts
@@ -43,4 +43,5 @@ export const approvalTypeSelectors: string;
 export const approvalTypeSelector: string;
 export const summary: string;
 export const details: string;
+export const lockOpen: string;
 export const switchLabelText: string;

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/pipelines/non_scm_material_fields.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/pipelines/non_scm_material_fields.tsx
@@ -88,7 +88,7 @@ export class DependencyFields extends MithrilViewComponent<Attrs> {
       <SelectField label="Upstream Stage" property={mat.stage} errorText={this.errs(mat, "stage")} required={true}>
         <SelectFieldOptions selected={mat.stage()} items={this.stages()}/>
       </SelectField>,
-      <AdvancedSettings>
+      <AdvancedSettings forceOpen={mat.errors().hasErrors("name")}>
         <TextField label="Material Name" helpText={IDENTIFIER_FORMAT_HELP_MESSAGE} placeholder="A human-friendly label for this material" property={mat.name}/>
       </AdvancedSettings>
     ];

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/pipelines/scm_material_fields.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/pipelines/scm_material_fields.tsx
@@ -46,7 +46,7 @@ abstract class ScmFields extends MithrilViewComponent<Attrs> {
     return [
       this.requiredFields(mattrs),
       <TestConnection material={vnode.attrs.material}/>,
-      <AdvancedSettings>
+      <AdvancedSettings forceOpen={mattrs.errors().hasErrors("name")}>
         {this.extraFields(mattrs)}
         <TextField label={[
           "Alternate Checkout Path",

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/pipelines/spec/actions_spec.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/pipelines/spec/actions_spec.tsx
@@ -84,6 +84,7 @@ describe("AddPipeline: Actions Section", () => {
 
     expect(config.isValid).toHaveBeenCalled();
     expect(config.create).not.toHaveBeenCalled();
+    expect(helper.text(sel.errorResponse)).toBe("Please fix the validation errors above before proceeding.");
   });
 
   it("Cancel goes to the dashboard but does not create", () => {

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/pipelines/spec/advanced_settings_spec.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/pipelines/spec/advanced_settings_spec.tsx
@@ -48,14 +48,36 @@ describe("AddPipeline: AdvancedSettings", () => {
   it("Clicking toggles the open class", () => {
     const top = helper.q(sel.advancedSettings);
     expect(top.classList.contains(css.open)).toBe(false);
+    expect(top.classList.contains(css.lockOpen)).toBe(false);
     expect(window.getComputedStyle(helper.q(sel.details, top)).display).toBe("none");
 
     helper.click(sel.summary, top);
     expect(top.classList.contains(css.open)).toBe(true);
+    expect(top.classList.contains(css.lockOpen)).toBe(false);
     expect(window.getComputedStyle(helper.q(sel.details, top)).display).toBe("block");
 
     helper.click(sel.summary, top);
     expect(top.classList.contains(css.open)).toBe(false);
+    expect(top.classList.contains(css.lockOpen)).toBe(false);
     expect(window.getComputedStyle(helper.q(sel.details, top)).display).toBe("none");
+  });
+
+  it("Can be locked in an open state with forceOpen attribute", () => {
+    helper.unmount();
+    helper.mount(() => {
+      return <AdvancedSettings forceOpen={true}>
+        <span class="foo">Some content</span>
+      </AdvancedSettings>;
+    });
+
+    const top = helper.q(sel.advancedSettings);
+
+    expect(top.classList.contains(css.lockOpen)).toBe(true);
+    expect(top.classList.contains(css.open)).toBe(false);
+    expect(window.getComputedStyle(helper.q(sel.details, top)).display).toBe("block");
+
+    helper.click(sel.summary, top); // click has no effect
+    expect(top.classList.contains(css.open)).toBe(false);
+    expect(window.getComputedStyle(helper.q(sel.details, top)).display).toBe("block");
   });
 });


### PR DESCRIPTION
  - Displays a validation message near the save button instructing the user to fix validation that may
    above window.scrollTop
  - If material name has a validation error, force the enclosing advanced settings section open