### PR TITLE
#5427 - Change TFS workspace default to be SERVER rather than null

### DIFF
--- a/tfs-impl/tfs-impl-14/src/main/java/com/thoughtworks/go/tfssdk14/wrapper/GoTfsVersionControlClient.java
+++ b/tfs-impl/tfs-impl-14/src/main/java/com/thoughtworks/go/tfssdk14/wrapper/GoTfsVersionControlClient.java
@@ -61,7 +61,7 @@ public class GoTfsVersionControlClient {
     }
 
     public GoTfsWorkspace createWorkspace(String workspace) {
-        WorkspaceLocation workspaceLocation = "Y".equalsIgnoreCase(getProperty("toggle.agent.tfs.use.server.workspace.location", "N")) ? SERVER : null;
+        WorkspaceLocation workspaceLocation = "Y".equalsIgnoreCase(getProperty("toggle.agent.tfs.use.server.workspace.location", "Y")) ? SERVER : null;
         return new GoTfsWorkspace(client.createWorkspace(null, workspace, null, workspaceLocation, null, null));
     }
 


### PR DESCRIPTION
See: https://github.com/gocd/gocd/issues/5427#issuecomment-468120891

For #5427, the plan was to change the default value of the workspace location to be SERVER, after a while. This change does that.