### PR TITLE
Modify table component to have draggable rows

### DIFF
--- a/server/webapp/WEB-INF/rails/webpack/views/components/table/index.scss
+++ b/server/webapp/WEB-INF/rails/webpack/views/components/table/index.scss
@@ -19,6 +19,7 @@ $table-border-color: $line-color;
 $table-header-bg: $secondary-bg;
 $table_background_color: #fff;
 $icon_disable_color: #ccc;
+$draggable-row-color: #e2f7fa;
 
 .table {
   $table-border-top-color: #dee2e6;
@@ -103,5 +104,5 @@ $icon_disable_color: #ccc;
 }
 
 .draggable-over {
-  background-color: $icon_disable_color;
+  background-color: $draggable-row-color;
 }

--- a/server/webapp/WEB-INF/rails/webpack/views/components/table/index.scss
+++ b/server/webapp/WEB-INF/rails/webpack/views/components/table/index.scss
@@ -70,4 +70,38 @@ $icon_disable_color: #ccc;
   color: $icon_disable_color;
 }
 
+.drag-icon {
+  @include sort-cursor;
+  @include grip-icon;
 
+  font-size: 12px;
+  color:     $icon-drag;
+  margin:    10px;
+
+  &:active {
+    @include sort-cursor-active;
+  }
+}
+
+.draggable {
+
+  tbody, tr {
+    outline: none;
+  }
+
+  th {
+    &:nth-child(1) {
+      width: 6%;
+    }
+  }
+
+  td {
+    &:nth-child(1) {
+      width: 6%;
+    }
+  }
+}
+
+.draggable-over {
+  background-color: $icon_disable_color;
+}

--- a/server/webapp/WEB-INF/rails/webpack/views/components/table/index.scss.d.ts
+++ b/server/webapp/WEB-INF/rails/webpack/views/components/table/index.scss.d.ts
@@ -4,3 +4,6 @@ export const table: string;
 export const sortableColumn: string;
 export const sortButton: string;
 export const inActive: string;
+export const dragIcon: string;
+export const draggable: string;
+export const draggableOver: string;

--- a/server/webapp/WEB-INF/rails/webpack/views/components/table/index.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/components/table/index.tsx
@@ -108,7 +108,6 @@ export class Table extends MithrilComponent<Attrs, State> {
     }
 
     vnode.state.dragStart = (e) => {
-      // vnode.state.time             = new Date().getTime();
       vnode.state.dragged          = Number(e.currentTarget.dataset.id);
       vnode.state.dragging         = vnode.state.dragged;
       e.dataTransfer.effectAllowed = "move";
@@ -171,7 +170,8 @@ export class Table extends MithrilComponent<Attrs, State> {
                 class={dragging}
                 data-test-id="table-row">
               {vnode.attrs.draggable ?
-                <td draggable={true} data-id={index}
+                <td draggable={true}
+                    data-id={index}
                     onmouseover={Table.disable.bind(this)}
                     ondragstart={vnode.state.dragStart.bind(this)}
                     ondragover={vnode.state.dragOver.bind(this)}

--- a/server/webapp/WEB-INF/rails/webpack/views/components/table/index.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/components/table/index.tsx
@@ -125,7 +125,10 @@ export class Table extends MithrilComponent<Attrs, State> {
         return;
       }
 
-      vnode.attrs.data.splice(newPosition, 0, vnode.attrs.data.splice(updatedPositionWhileDragging, 1)[0]);
+      // deleting the dragged element from the old position
+      const draggedElement = vnode.attrs.data.splice(updatedPositionWhileDragging, 1)[0];
+      // moving the element to new position
+      vnode.attrs.data.splice(newPosition, 0, draggedElement);
       vnode.state.dragging = newPosition;
       if (vnode.attrs.dragHandler) {
         vnode.attrs.dragHandler(updatedPositionWhileDragging, newPosition);
@@ -172,7 +175,7 @@ export class Table extends MithrilComponent<Attrs, State> {
               {vnode.attrs.draggable ?
                 <td draggable={true}
                     data-id={index}
-                    onmouseover={Table.disable.bind(this)}
+                    onmouseover={Table.disableEvent.bind(this)}
                     ondragstart={vnode.state.dragStart.bind(this)}
                     ondragover={vnode.state.dragOver.bind(this)}
                     ondragend={vnode.state.dragEnd.bind(this)}>
@@ -209,7 +212,7 @@ export class Table extends MithrilComponent<Attrs, State> {
     return ("");
   }
 
-  private static disable(e: MouseEvent) {
+  private static disableEvent(e: MouseEvent) {
     e.preventDefault();
     e.stopPropagation();
   }

--- a/server/webapp/WEB-INF/rails/webpack/views/components/table/index.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/components/table/index.tsx
@@ -117,7 +117,7 @@ export class Table extends MithrilComponent<Attrs, State> {
     vnode.state.dragOver = (e) => {
       e.preventDefault();
 
-      const toBeReplaced                 = e.target;
+      const toBeReplaced                 = e.currentTarget;
       const updatedPositionWhileDragging = vnode.state.dragging;
       const newPosition                  = Number(toBeReplaced.dataset.id);
 
@@ -182,8 +182,7 @@ export class Table extends MithrilComponent<Attrs, State> {
                   onmouseover={Table.disableEvent.bind(this)}>
                   <i className={styles.dragIcon}></i>
                 </td> : null}
-              {_.map(rows,
-                     ((row) => <td>{Table.renderedValue(row)}</td>))}
+              {_.map(rows, ((row) => <td>{Table.renderedValue(row)}</td>))}
             </tr>
           );
         }))

--- a/server/webapp/WEB-INF/rails/webpack/views/components/table/index.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/components/table/index.tsx
@@ -59,8 +59,8 @@ interface HeaderAttrs {
 
 interface State {
   dragging: number;
-  dragStart: (e: any) => void;
-  dragOver: (e: any) => void;
+  dragStart: (e: DragEvent) => void;
+  dragOver: (e: DragEvent) => void;
   dragEnd: () => void;
   dragged: number;
 }
@@ -107,17 +107,17 @@ export class Table extends MithrilComponent<Attrs, State> {
       return;
     }
 
-    vnode.state.dragStart = (e) => {
-      vnode.state.dragged          = Number(e.currentTarget.dataset.id);
-      vnode.state.dragging         = vnode.state.dragged;
-      e.dataTransfer.effectAllowed = "move";
-      e.dataTransfer.setData("text/html", null);
+    vnode.state.dragStart = (e: DragEvent) => {
+      vnode.state.dragged           = Number((e.currentTarget as HTMLElement).dataset.id);
+      vnode.state.dragging          = vnode.state.dragged;
+      e.dataTransfer!.effectAllowed = "move";
+      e.dataTransfer!.setData("text/html", "");
     };
 
-    vnode.state.dragOver = (e) => {
+    vnode.state.dragOver = (e: DragEvent) => {
       e.preventDefault();
 
-      const toBeReplaced                 = e.currentTarget;
+      const toBeReplaced                 = e.currentTarget as HTMLElement;
       const updatedPositionWhileDragging = vnode.state.dragging;
       const newPosition                  = Number(toBeReplaced.dataset.id);
 

--- a/server/webapp/WEB-INF/rails/webpack/views/components/table/index.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/components/table/index.tsx
@@ -119,7 +119,7 @@ export class Table extends MithrilComponent<Attrs, State> {
 
       const toBeReplaced                 = e.target;
       const updatedPositionWhileDragging = vnode.state.dragging;
-      const newPosition                  = Number(toBeReplaced.dataset.id) || updatedPositionWhileDragging;
+      const newPosition                  = Number(toBeReplaced.dataset.id);
 
       if (updatedPositionWhileDragging === newPosition) {
         return;
@@ -171,17 +171,19 @@ export class Table extends MithrilComponent<Attrs, State> {
             <tr key={index.toString()}
                 data-id={index}
                 class={dragging}
+                draggable={true}
+                ondragstart={vnode.attrs.draggable ? vnode.state.dragStart.bind(this) : Table.disableEvent.bind(this)}
+                ondragover={vnode.attrs.draggable ? vnode.state.dragOver.bind(this) : Table.disableEvent.bind(this)}
+                ondragend={vnode.attrs.draggable ? vnode.state.dragEnd.bind(this) : Table.disableEvent.bind(this)}
                 data-test-id="table-row">
               {vnode.attrs.draggable ?
-                <td draggable={true}
-                    data-id={index}
-                    onmouseover={Table.disableEvent.bind(this)}
-                    ondragstart={vnode.state.dragStart.bind(this)}
-                    ondragover={vnode.state.dragOver.bind(this)}
-                    ondragend={vnode.state.dragEnd.bind(this)}>
+                <td
+                  data-id={index}
+                  onmouseover={Table.disableEvent.bind(this)}>
                   <i className={styles.dragIcon}></i>
                 </td> : null}
-              {_.map(rows, ((row) => <td>{Table.renderedValue(row)}</td>))}
+              {_.map(rows,
+                     ((row) => <td>{Table.renderedValue(row)}</td>))}
             </tr>
           );
         }))
@@ -212,8 +214,10 @@ export class Table extends MithrilComponent<Attrs, State> {
     return ("");
   }
 
-  private static disableEvent(e: MouseEvent) {
+  private static disableEvent(e: Event) {
     e.preventDefault();
     e.stopPropagation();
+    e.stopImmediatePropagation();
+    return false;
   }
 }

--- a/server/webapp/WEB-INF/rails/webpack/views/components/table/spec/index_spec.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/components/table/spec/index_spec.tsx
@@ -130,6 +130,10 @@ describe("TableComponent", () => {
     });
 
     it("should give a callback on dragover", () => {
+      if (/(MSIE|Trident|Edge)/i.test(navigator.userAgent)) {
+        return;
+      }
+
       const spy = jasmine.createSpy();
       helper.mount(() => <Table headers={headers} data={testdata()} draggable={true} dragHandler={spy}/>);
 
@@ -143,20 +147,20 @@ describe("TableComponent", () => {
       dataTransfer.effectAllowed = "move";
       rowFirst.dispatchEvent(new DragEvent("dragstart", {
         dataTransfer
-      } as DragEventInit));
+      }));
       m.redraw();
-      rowSecond.dispatchEvent(new DragEvent("dragover", {} as DragEventInit));
+      rowSecond.dispatchEvent(new DragEvent("dragover"));
       m.redraw();
 
       expect(spy).toHaveBeenCalledTimes(1);
+      expect(spy).toHaveBeenCalledWith(0, 1);
       expect(helper.find(`.${styles.draggableOver}`)).toBeInDOM();
 
-      rowFirst.dispatchEvent(new DragEvent("dragend", {} as DragEventInit));
+      rowFirst.dispatchEvent(new DragEvent("dragend"));
       m.redraw();
 
       expect(rowFirst.textContent).toBe("CXN");
       expect(rowSecond.textContent).toBe("AZM");
-
     });
 
   });

--- a/server/webapp/WEB-INF/rails/webpack/views/components/table/spec/index_spec.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/components/table/spec/index_spec.tsx
@@ -130,12 +130,12 @@ describe("TableComponent", () => {
     });
 
     it("should give a callback on dragover", () => {
+      const spy = jasmine.createSpy();
+      helper.mount(() => <Table headers={headers} data={testdata()} draggable={true} dragHandler={spy}/>);
+
       if (/(MSIE|Trident|Edge)/i.test(navigator.userAgent)) {
         return;
       }
-
-      const spy = jasmine.createSpy();
-      helper.mount(() => <Table headers={headers} data={testdata()} draggable={true} dragHandler={spy}/>);
 
       const rowFirst  = helper.find("tr[data-id=\"0\"]").get(0);
       const rowSecond = helper.find("tr[data-id=\"1\"]").get(0);

--- a/server/webapp/WEB-INF/rails/webpack/views/components/table/spec/index_spec.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/components/table/spec/index_spec.tsx
@@ -133,29 +133,29 @@ describe("TableComponent", () => {
       const spy = jasmine.createSpy();
       helper.mount(() => <Table headers={headers} data={testdata()} draggable={true} dragHandler={spy}/>);
 
-      const dragIconFirst  = helper.find(`.${styles.dragIcon}`).eq(0).parent().get(0);
-      const dragIconSecond = helper.find(`.${styles.dragIcon}`).eq(1).parent().get(0);
+      const rowFirst  = helper.find("tr[data-id=\"0\"]").get(0);
+      const rowSecond = helper.find("tr[data-id=\"1\"]").get(0);
 
-      expect(helper.find("tr[data-id=\"0\"]").text()).toBe("AZM");
-      expect(helper.find("tr[data-id=\"1\"]").text()).toBe("CXN");
+      expect(rowFirst.textContent).toBe("AZM");
+      expect(rowSecond.textContent).toBe("CXN");
 
       const dataTransfer         = new DataTransfer();
       dataTransfer.effectAllowed = "move";
-      dragIconFirst.dispatchEvent(new DragEvent("dragstart", {
+      rowFirst.dispatchEvent(new DragEvent("dragstart", {
         dataTransfer
       } as DragEventInit));
       m.redraw();
-      dragIconSecond.dispatchEvent(new DragEvent("dragover", {} as DragEventInit));
+      rowSecond.dispatchEvent(new DragEvent("dragover", {} as DragEventInit));
       m.redraw();
 
       expect(spy).toHaveBeenCalledTimes(1);
       expect(helper.find(`.${styles.draggableOver}`)).toBeInDOM();
 
-      dragIconFirst.dispatchEvent(new DragEvent("dragend", {} as DragEventInit));
+      rowFirst.dispatchEvent(new DragEvent("dragend", {} as DragEventInit));
       m.redraw();
 
-      expect(helper.find("tr[data-id=\"0\"]").text()).toBe("CXN");
-      expect(helper.find("tr[data-id=\"1\"]").text()).toBe("AZM");
+      expect(rowFirst.textContent).toBe("CXN");
+      expect(rowSecond.textContent).toBe("AZM");
 
     });
 

--- a/server/webapp/WEB-INF/rails/webpack/views/global/_mixins.scss
+++ b/server/webapp/WEB-INF/rails/webpack/views/global/_mixins.scss
@@ -86,3 +86,49 @@ $spinner-wrapper-height: 175px;
   -ms-user-select: none;
   user-select: none;
 }
+
+@mixin sort-cursor {
+  //sass-lint:disable no-duplicate-properties
+  cursor: move;
+  cursor: grab;
+  cursor: -moz-grab;
+  cursor: -webkit-grab;
+}
+
+@mixin sort-cursor-active {
+  //sass-lint:disable no-duplicate-properties
+  cursor: move;
+  cursor: grabbing;
+  cursor: -moz-grabbing;
+  cursor: -webkit-grabbing;
+}
+
+@mixin grip-icon($color: #ccc, $shadow-color: #333) {
+  @include unselectable;
+
+  display:        inline-block;
+
+  width:          1em;
+  height:         2.2em;
+  line-height:    0.45em;
+  letter-spacing: 0.15em;
+  color:          $icon-drag;
+
+  vertical-align: middle;
+  text-align:     center;
+  font-family:    sans-serif;
+  overflow:       hidden;
+  white-space:    normal;
+
+  &:after {
+    content: ".. .. .. ..";
+  }
+}
+
+@mixin unselectable {
+  //sass-lint:disable no-duplicate-properties no-important
+  -webkit-user-select: none !important;
+  -moz-user-select:    none !important;
+  -ms-user-select:     none !important;
+  user-select:         none !important;
+}

--- a/server/webapp/WEB-INF/rails/webpack/views/global/_variables.scss
+++ b/server/webapp/WEB-INF/rails/webpack/views/global/_variables.scss
@@ -103,4 +103,4 @@ $btn-secondary: $go-secondary;
 $btn-text-color: #fff;
 $btn-reset: #666;
 $btn-danger: $go-danger;
-
+$icon-drag: #9b9b9b;

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/kitchen_sink.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/kitchen_sink.tsx
@@ -338,7 +338,6 @@ const pipelineData = stream(pipelines().map((e, i) => e.tableData()));
 
 function updateModel(oldIndex: number, newIndex: number) {
   pipelines().splice(newIndex, 0, pipelines().splice(oldIndex, 1)[0]);
-  // m.redraw();
 }
 
 class DummyTableSortHandler extends TableSortHandler {

--- a/server/webapp/WEB-INF/rails/webpack/views/pages/kitchen_sink.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/kitchen_sink.tsx
@@ -262,14 +262,6 @@ export class KitchenSink extends MithrilViewComponent<null> {
         <CopyField property={formValue} buttonDisableReason={"Add text to enable quick add"}/>
 
         <SearchFieldWithButton property={formValue} buttonDisableReason={"Add text to enable search"}/>
-
-        <h3>Table</h3>
-        <Table headers={["Pipeline", "Stage", "Job", "Action"]}
-               data={[
-                 ["WindowsPR", <label>test</label>, "jasmine", <a href="#!">Go to report</a>],
-                 ["LinuxPR", "build", "clean", "Foo"]
-               ]}/>
-
         <br/>
         <h3>Sortable Table</h3>
         <Table data={pipelineData()} headers={["Pipeline", "Stage", "Job"]}
@@ -291,6 +283,12 @@ export class KitchenSink extends MithrilViewComponent<null> {
         <AutocompleteField label="Dynamic" property={model} provider={this.provider}/>
 
         <Buttons.Primary onclick={this.toggleType.bind(this)}>Click to change type!</Buttons.Primary>
+
+        <br/>
+        <h3>Draggable Table</h3>
+        <Table draggable={true} headers={["Pipeline", "Stage", "Job"]} data={pipelineData()}
+               dragHandler={updateModel.bind(this)}/>
+        <p>Model: {JSON.stringify(pipelines())}</p>
       </div>
     );
   }
@@ -310,15 +308,38 @@ export class KitchenSink extends MithrilViewComponent<null> {
   }
 }
 
-const pipelineData = stream(
-  [
-    ["WindowsPR", "test", "jasmine"],
-    ["WindowsPR", "build", "installer"],
-    ["WindowsPR", "upload", "upload"],
-    ["LinuxPR", "build", "clean"],
-    ["LinuxPR", "test", "clean"],
-    ["LinuxPR", "build", "clean"]
-  ]);
+class Pipeline {
+  private pipeline: string;
+  private stage: string;
+  private job: string;
+
+  constructor(pipeline: string, stage: string, job: string) {
+    this.pipeline = pipeline;
+    this.stage    = stage;
+    this.job      = job;
+
+  }
+
+  tableData() {
+    return [this.pipeline, this.stage, this.job];
+  }
+}
+
+const pipelines = stream([
+                           new Pipeline("WindowsPR", "test", "jasmine"),
+                           new Pipeline("WindowsPR", "build", "installer"),
+                           new Pipeline("WindowsPR", "upload", "upload"),
+                           new Pipeline("LinuxPR", "build", "clean"),
+                           new Pipeline("LinuxPR", "test", "clean"),
+                           new Pipeline("LinuxPR", "build", "clean")
+                         ]);
+
+const pipelineData = stream(pipelines().map((e, i) => e.tableData()));
+
+function updateModel(oldIndex: number, newIndex: number) {
+  pipelines().splice(newIndex, 0, pipelines().splice(oldIndex, 1)[0]);
+  // m.redraw();
+}
 
 class DummyTableSortHandler extends TableSortHandler {
   private sortOrders = new Map();


### PR DESCRIPTION
- table component will take in an additional attribute `draggable`
- when set to `true`, a drag icon will allow the user to drag and drop the rows

Note: The `drag-icon` column has a disabled mouse-over event as the same tends to disrupt the draggable flow.
 - `onmouseover` takes precedence over `ondragover` - hence while dragging, it creates an unwanted disruption