### PR TITLE
Introduce ConsoleLogRequestProcessor

### DIFF
--- a/domain/src/main/java/com/thoughtworks/go/domain/JobIdentifier.java
+++ b/domain/src/main/java/com/thoughtworks/go/domain/JobIdentifier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 ThoughtWorks, Inc.
+ * Copyright 2019 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -62,8 +62,8 @@ public class JobIdentifier implements Serializable, LocatableEntity {
                 stage.getStageCounter(), jobName, jobId);
     }
 
-    public JobIdentifier(String pipelineName, int pipelineCounter, String pipelineLabel, String staqeName, String stageCounter, String jobName) {
-        this(pipelineName, pipelineCounter, pipelineLabel, staqeName, stageCounter, jobName, -1L);
+    public JobIdentifier(String pipelineName, int pipelineCounter, String pipelineLabel, String stageName, String stageCounter, String jobName) {
+        this(pipelineName, pipelineCounter, pipelineLabel, stageName, stageCounter, jobName, -1L);
     }
 
     public static JobIdentifier invalidIdentifier(String pipelineName, String pipelineLabel, String stageName,

--- a/server/src/main/java/com/thoughtworks/go/server/service/plugins/processor/console/ConsoleLogAppendRequest.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/plugins/processor/console/ConsoleLogAppendRequest.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.server.service.plugins.processor.console;
+
+import com.thoughtworks.go.domain.JobIdentifier;
+
+public interface ConsoleLogAppendRequest {
+    JobIdentifier jobIdentifier();
+
+    String text();
+}

--- a/server/src/main/java/com/thoughtworks/go/server/service/plugins/processor/console/ConsoleLogRequestProcessor.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/plugins/processor/console/ConsoleLogRequestProcessor.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.server.service.plugins.processor.console;
+
+import com.thoughtworks.go.plugin.api.request.GoApiRequest;
+import com.thoughtworks.go.plugin.api.response.DefaultGoApiResponse;
+import com.thoughtworks.go.plugin.api.response.GoApiResponse;
+import com.thoughtworks.go.plugin.infra.GoPluginApiRequestProcessor;
+import com.thoughtworks.go.plugin.infra.PluginRequestProcessorRegistry;
+import com.thoughtworks.go.plugin.infra.plugininfo.GoPluginDescriptor;
+import com.thoughtworks.go.server.service.ConsoleService;
+import com.thoughtworks.go.server.service.plugins.processor.console.v1.MessageHandlerForConsoleLogRequestProcessorImpl1_0;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static java.text.MessageFormat.format;
+import static java.util.Collections.singletonList;
+
+@Component
+public class ConsoleLogRequestProcessor implements GoPluginApiRequestProcessor {
+    private static final Logger LOGGER = LoggerFactory.getLogger(ConsoleLogRequestProcessor.class);
+
+    public static final String APPEND_TO_CONSOLE_LOG = "go.processor.console-log.append";
+
+    public static final String VERSION_1 = "1.0";
+    private static final List<String> supportedVersions = singletonList(VERSION_1);
+
+    private Map<String, MessageHandlerForConsoleLogRequestProcessor> versionToMessageHandlerMap;
+    private ConsoleService consoleService;
+
+    @Autowired
+    public ConsoleLogRequestProcessor(PluginRequestProcessorRegistry registry, ConsoleService consoleService) {
+        this.consoleService = consoleService;
+        versionToMessageHandlerMap = new HashMap<>();
+        versionToMessageHandlerMap.put(VERSION_1, new MessageHandlerForConsoleLogRequestProcessorImpl1_0());
+
+        registry.registerProcessorFor(APPEND_TO_CONSOLE_LOG, this);
+    }
+
+    @Override
+    public GoApiResponse process(GoPluginDescriptor pluginDescriptor, GoApiRequest request) {
+        try {
+            validatePluginRequest(request);
+
+            final MessageHandlerForConsoleLogRequestProcessor handler = versionToMessageHandlerMap.get(request.apiVersion());
+            final ConsoleLogAppendRequest logUpdateRequest = handler.deserializeConsoleLogAppendRequest(request.requestBody());
+            consoleService.appendToConsoleLog(logUpdateRequest.jobIdentifier(), logUpdateRequest.text());
+        } catch (Exception e) {
+            DefaultGoApiResponse response = new DefaultGoApiResponse(DefaultGoApiResponse.INTERNAL_ERROR);
+            response.setResponseBody(format("'{' \"message\": \"Error: {0}\" '}'", e.getMessage()));
+            LOGGER.warn("Failed to handle message from plugin {}: {}", pluginDescriptor.id(), request.requestBody(), e);
+            return response;
+        }
+
+        return new DefaultGoApiResponse(DefaultGoApiResponse.SUCCESS_RESPONSE_CODE);
+    }
+
+    private void validatePluginRequest(GoApiRequest goPluginApiRequest) {
+        if (!supportedVersions.contains(goPluginApiRequest.apiVersion())) {
+            throw new RuntimeException(String.format("Unsupported '%s' API version: %s. Supported versions: %s",
+                    goPluginApiRequest.api(), goPluginApiRequest.apiVersion(), supportedVersions));
+        }
+    }
+}

--- a/server/src/main/java/com/thoughtworks/go/server/service/plugins/processor/console/MessageHandlerForConsoleLogRequestProcessor.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/plugins/processor/console/MessageHandlerForConsoleLogRequestProcessor.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.server.service.plugins.processor.console;
+
+public interface MessageHandlerForConsoleLogRequestProcessor {
+    ConsoleLogAppendRequest deserializeConsoleLogAppendRequest(String requestBody);
+}

--- a/server/src/main/java/com/thoughtworks/go/server/service/plugins/processor/console/v1/ConsoleLogAppendRequest1_0.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/plugins/processor/console/v1/ConsoleLogAppendRequest1_0.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.server.service.plugins.processor.console.v1;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.annotations.Expose;
+import com.thoughtworks.go.domain.JobIdentifier;
+import com.thoughtworks.go.server.service.plugins.processor.console.ConsoleLogAppendRequest;
+
+public class ConsoleLogAppendRequest1_0 implements ConsoleLogAppendRequest {
+    private static final Gson GSON = new GsonBuilder().excludeFieldsWithoutExposeAnnotation().create();
+
+    @Expose
+    private String pipelineName;
+
+    @Expose
+    private Integer pipelineCounter;
+
+    @Expose
+    private String pipelineLabel;
+
+    @Expose
+    private String stageName;
+
+    @Expose
+    private String stageCounter;
+
+    @Expose
+    private String jobName;
+
+    @Expose
+    private String text;
+
+    public static ConsoleLogAppendRequest1_0 fromJSON(String json) {
+        return GSON.fromJson(json, ConsoleLogAppendRequest1_0.class);
+    }
+
+    @Override
+    public JobIdentifier jobIdentifier() {
+        return new JobIdentifier(pipelineName, pipelineCounter, pipelineLabel, stageName, stageCounter, jobName);
+    }
+
+    @Override
+    public String text() {
+        return text;
+    }
+}

--- a/server/src/main/java/com/thoughtworks/go/server/service/plugins/processor/console/v1/MessageHandlerForConsoleLogRequestProcessorImpl1_0.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/plugins/processor/console/v1/MessageHandlerForConsoleLogRequestProcessorImpl1_0.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.server.service.plugins.processor.console.v1;
+
+import com.thoughtworks.go.server.service.plugins.processor.console.MessageHandlerForConsoleLogRequestProcessor;
+
+public class MessageHandlerForConsoleLogRequestProcessorImpl1_0 implements MessageHandlerForConsoleLogRequestProcessor {
+    @Override
+    public ConsoleLogAppendRequest1_0 deserializeConsoleLogAppendRequest(String requestBody) {
+        return ConsoleLogAppendRequest1_0.fromJSON(requestBody);
+    }
+}

--- a/server/src/test-fast/java/com/thoughtworks/go/server/service/plugins/processor/console/v1/ConsoleLogRequestProcessorTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/service/plugins/processor/console/v1/ConsoleLogRequestProcessorTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.server.service.plugins.processor.console.v1;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.thoughtworks.go.domain.JobIdentifier;
+import com.thoughtworks.go.domain.exception.IllegalArtifactLocationException;
+import com.thoughtworks.go.plugin.api.request.DefaultGoApiRequest;
+import com.thoughtworks.go.plugin.api.response.DefaultGoApiResponse;
+import com.thoughtworks.go.plugin.api.response.GoApiResponse;
+import com.thoughtworks.go.plugin.infra.PluginRequestProcessorRegistry;
+import com.thoughtworks.go.plugin.infra.plugininfo.GoPluginDescriptor;
+import com.thoughtworks.go.server.service.ConsoleService;
+import com.thoughtworks.go.server.service.plugins.processor.console.ConsoleLogRequestProcessor;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import static com.thoughtworks.go.server.service.plugins.processor.console.ConsoleLogRequestProcessor.APPEND_TO_CONSOLE_LOG;
+import static com.thoughtworks.go.server.service.plugins.processor.console.ConsoleLogRequestProcessor.VERSION_1;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.StringContains.containsString;
+import static org.mockito.Mockito.verify;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+public class ConsoleLogRequestProcessorTest {
+    @Mock
+    private PluginRequestProcessorRegistry pluginRequestProcessorRegistry;
+    @Mock
+    private ConsoleService consoleService;
+    @Mock
+    private GoPluginDescriptor pluginDescriptor;
+
+    @BeforeEach
+    void setUp() {
+        initMocks(this);
+    }
+
+    @Test
+    void shouldRouteMessageToConsoleService() throws IOException, IllegalArtifactLocationException {
+        Map<String, String> requestMap = new HashMap<>();
+        requestMap.put("pipelineName", "p1");
+        requestMap.put("pipelineCounter", "1");
+        requestMap.put("pipelineLabel", "label1");
+        requestMap.put("stageName", "s1");
+        requestMap.put("stageCounter", "2");
+        requestMap.put("jobName", "j1");
+        requestMap.put("text", "message1");
+
+        DefaultGoApiRequest goApiRequest = new DefaultGoApiRequest(APPEND_TO_CONSOLE_LOG, VERSION_1, null);
+        goApiRequest.setRequestBody(new GsonBuilder().create().toJson(requestMap));
+
+        final ConsoleLogRequestProcessor processor = new ConsoleLogRequestProcessor(pluginRequestProcessorRegistry, consoleService);
+        final GoApiResponse response = processor.process(pluginDescriptor, goApiRequest);
+
+        assertThat(response.responseCode(), is(DefaultGoApiResponse.SUCCESS_RESPONSE_CODE));
+
+        final JobIdentifier jobIdentifier = new JobIdentifier("p1", 1, "label1", "s1", "2", "j1");
+        verify(consoleService).appendToConsoleLog(jobIdentifier, "message1");
+    }
+
+    @Test
+    void shouldRespondWithAMessageIfSomethingGoesWrong() {
+        DefaultGoApiRequest goApiRequest = new DefaultGoApiRequest(APPEND_TO_CONSOLE_LOG, VERSION_1, null);
+        goApiRequest.setRequestBody("this_is_invalid_JSON");
+
+        final ConsoleLogRequestProcessor processor = new ConsoleLogRequestProcessor(pluginRequestProcessorRegistry, consoleService);
+        final GoApiResponse response = processor.process(pluginDescriptor, goApiRequest);
+
+        assertThat(response.responseCode(), is(DefaultGoApiResponse.INTERNAL_ERROR));
+
+        final Map responseContents = new Gson().fromJson(response.responseBody(), Map.class);
+        assertThat((String) responseContents.get("message"), containsString("Error:"));
+    }
+}


### PR DESCRIPTION
Mainly for use by plugins to write information to the job console log. This is helpful to understand what's going on when an elastic agent is being brought up by a plugin.

### Todo:

- [ ] Update functional tests? Will check to see if any of them test messages.
- [ ] Update [next release notes branch](https://github.com/gocd/www.go.cd/tree/release-notes-19.4).
- [ ] Update plugin-api documentation.

### Testing / trying this out:

1. You'll need code from this PR with something like this in your config:

<details>
<summary>Part of GoCD config</summary>

```
  <elastic>
    <agentProfiles>
      <agentProfile id="mydocker" clusterProfileId="localdocker">
        <property>
          <key>Hosts</key>
          <value />
        </property>
        <property>
          <key>Mounts</key>
          <value />
        </property>
        <property>
          <key>Command</key>
          <value />
        </property>
        <property>
          <key>Privileged</key>
          <value />
        </property>
        <property>
          <key>ReservedMemory</key>
          <value />
        </property>
        <property>
          <key>Environment</key>
          <value />
        </property>
        <property>
          <key>Cpus</key>
          <value />
        </property>
        <property>
          <key>Image</key>
          <value>gocd/gocd-agent-alpine-3.9:v19.3.0</value>
        </property>
        <property>
          <key>MaxMemory</key>
          <value />
        </property>
      </agentProfile>
    </agentProfiles>
    <clusterProfiles>
      <clusterProfile id="localdocker" pluginId="cd.go.contrib.elastic-agent.docker">
        <property>
          <key>go_server_url</key>
          <value>https://192.168.0.100:8154/go</value>
        </property>
        <property>
          <key>environment_variables</key>
          <value />
        </property>
        <property>
          <key>max_docker_containers</key>
          <value>1</value>
        </property>
        <property>
          <key>docker_uri</key>
          <value>unix:///var/run/docker.sock</value>
        </property>
        <property>
          <key>auto_register_timeout</key>
          <value>3</value>
        </property>
        <property>
          <key>docker_ca_cert</key>
          <value />
        </property>
        <property>
          <key>docker_client_cert</key>
          <value />
        </property>
        <property>
          <key>docker_client_key</key>
          <value />
        </property>
        <property>
          <key>private_registry_server</key>
          <value />
        </property>
        <property>
          <key>private_registry_username</key>
          <value />
        </property>
        <property>
          <key>private_registry_password</key>
          <encryptedValue />
        </property>
        <property>
          <key>enable_private_registry_authentication</key>
          <value>false</value>
        </property>
        <property>
          <key>private_registry_custom_credentials</key>
          <value>true</value>
        </property>
        <property>
          <key>pull_on_container_create</key>
          <value>false</value>
        </property>
      </clusterProfile>
    </clusterProfiles>
  </elastic>
  <pipelines group="defaultGroup">
    <pipeline name="Test">
      <materials>
        <git url="https://github.com/arvindsv/faketime.git" />
      </materials>
      <stage name="defaultStage">
        <jobs>
          <job name="defaultJob" elasticProfileId="mydocker">
            <tasks>
              <exec command="ls" />
            </tasks>
          </job>
          <job name="defaultJob2" elasticProfileId="mydocker">
            <tasks>
              <exec command="ls" />
            </tasks>
          </job>
        </jobs>
      </stage>
    </pipeline>
  </pipelines>
```

</details>

2. A plugin which logs these messages will be needed. For now, https://github.com/gocd-contrib/docker-elastic-agents/issues/119 can be used.


### How does it look?

Something like this:

<img width="1440" alt="2019_05_16_21-30-48" src="https://user-images.githubusercontent.com/172235/57899210-266abe00-782a-11e9-89ab-2b4b87f63a39.png">

### Review:

It's not a big change. `ConsoleLogRequestProcessor` is the main change. Everything else just supports it.

### Questions people have asked:

1. Should we have a time window in which the plugin is allowed to append to console log?
2. Should we restrict which plugins can log?

My answer has been: Decided not to restrict. The plugins need to know the job identifier to write to their console log. It’s unlikely they’ll write to the wrong job, since they’ll be using a job identifier provided to them. If there’s a malicious plugin, then it has full access to the filesystem, you don’t really need this processor API to do anything.