### PR TITLE
Use a `ProcessTag` marker interface to tag processes

### DIFF
--- a/commandline/build.gradle
+++ b/commandline/build.gradle
@@ -19,6 +19,9 @@ description = 'GoCD commandline Module'
 dependencies {
   compile project(':base')
   compile project(':config:config-api')
+  compileOnly group: 'org.projectlombok', name: 'lombok', version: project.versions.lombok
+  annotationProcessor group: 'org.projectlombok', name: 'lombok', version: project.versions.lombok
+
   testCompile project(':test:test-utils')
   testCompile group: 'com.googlecode', name: 'junit-ext', version: '1.0'
   testCompileOnly group: 'junit', name: 'junit', version: project.versions.junit

--- a/commandline/src/main/java/com/thoughtworks/go/util/MaterialFingerprintTag.java
+++ b/commandline/src/main/java/com/thoughtworks/go/util/MaterialFingerprintTag.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.util;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+
+@EqualsAndHashCode
+@Getter
+public class MaterialFingerprintTag implements ProcessTag {
+    private final String materialFingerprint;
+
+    public MaterialFingerprintTag(String materialFingerprint) {
+        this.materialFingerprint = materialFingerprint;
+    }
+}

--- a/commandline/src/main/java/com/thoughtworks/go/util/NamedProcessTag.java
+++ b/commandline/src/main/java/com/thoughtworks/go/util/NamedProcessTag.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.util;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+
+@EqualsAndHashCode
+@Getter
+public class NamedProcessTag implements ProcessTag {
+    private final String tag;
+
+    public NamedProcessTag(String tag) {
+        this.tag = tag;
+    }
+}

--- a/commandline/src/main/java/com/thoughtworks/go/util/ProcessManager.java
+++ b/commandline/src/main/java/com/thoughtworks/go/util/ProcessManager.java
@@ -30,8 +30,6 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
-import static org.apache.commons.lang3.StringUtils.isEmpty;
-
 public class ProcessManager {
 
     private static final Logger LOG = LoggerFactory.getLogger(ProcessManager.class);
@@ -47,7 +45,7 @@ public class ProcessManager {
     }
 
     public ProcessWrapper createProcess(String[] commandLine, String commandLineForDisplay, File workingDir, Map<String, String> envMap, EnvironmentVariableContext environmentVariableContext,
-                                        ConsoleOutputStreamConsumer consumer, String processTag, String encoding, String errorPrefix) {
+                                        ConsoleOutputStreamConsumer consumer, ProcessTag processTag, String encoding, String errorPrefix) {
         ProcessBuilder processBuilder = new ProcessBuilder(commandLine);
         LOG.debug("Executing: {}", commandLineForDisplay);
         if (workingDir != null) {
@@ -70,10 +68,10 @@ public class ProcessManager {
         }
     }
 
-    public long getIdleTimeFor(String processTag) {
+    public long getIdleTimeFor(ProcessTag processTag) {
         for (ProcessWrapper processWrapper : processMap.values()) {
-            String tag = processWrapper.getProcessTag();
-            if (!isEmpty(tag) && tag.equalsIgnoreCase(processTag)) {
+            ProcessTag tag = processWrapper.getProcessTag();
+            if (processTag.equals(tag)) {
                 return processWrapper.getIdleTime();
             }
         }

--- a/commandline/src/main/java/com/thoughtworks/go/util/ProcessTag.java
+++ b/commandline/src/main/java/com/thoughtworks/go/util/ProcessTag.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thoughtworks.go.util;
+
+public interface ProcessTag {
+}

--- a/commandline/src/main/java/com/thoughtworks/go/util/ProcessWrapper.java
+++ b/commandline/src/main/java/com/thoughtworks/go/util/ProcessWrapper.java
@@ -35,11 +35,11 @@ public class ProcessWrapper {
     private StreamPumper processErrorStream;
     private PrintWriter processInputStream;
     private long startTime;
-    private String processTag;
+    private ProcessTag processTag;
     private String command;
     private static final Logger LOGGER = LoggerFactory.getLogger(ProcessWrapper.class);
 
-    ProcessWrapper(Process process, String processTag, String command, ConsoleOutputStreamConsumer consumer, String encoding, String errorPrefix) {
+    ProcessWrapper(Process process, ProcessTag processTag, String command, ConsoleOutputStreamConsumer consumer, String encoding, String errorPrefix) {
         this.process = process;
         this.processTag = processTag;
         this.command = command;
@@ -108,7 +108,7 @@ public class ProcessWrapper {
         return new SimpleDateFormat("dd/MM/yy - H:mm:ss:S").format(new Date(startTime));
     }
 
-    public String getProcessTag() {
+    public ProcessTag getProcessTag() {
         return processTag;
     }
 

--- a/commandline/src/main/java/com/thoughtworks/go/util/command/CommandLine.java
+++ b/commandline/src/main/java/com/thoughtworks/go/util/command/CommandLine.java
@@ -18,6 +18,7 @@ package com.thoughtworks.go.util.command;
 
 import com.thoughtworks.go.util.ExceptionUtils;
 import com.thoughtworks.go.util.ProcessManager;
+import com.thoughtworks.go.util.ProcessTag;
 import com.thoughtworks.go.util.ProcessWrapper;
 import com.thoughtworks.go.utils.CommandUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -268,14 +269,14 @@ public class CommandLine {
      * @deprecated this should not be used outside of this CommandLine(in production code), as using it directly can bypass smudging of sensitive data
      * this is used only in tests
      */
-    public ProcessWrapper execute(ConsoleOutputStreamConsumer outputStreamConsumer, EnvironmentVariableContext environmentVariableContext, String processTag) {
+    public ProcessWrapper execute(ConsoleOutputStreamConsumer outputStreamConsumer, EnvironmentVariableContext environmentVariableContext, ProcessTag processTag) {
         ProcessWrapper process = createProcess(environmentVariableContext, outputStreamConsumer, processTag, ERROR_STREAM_PREFIX_FOR_CMDS);
         process.typeInputToConsole(inputs);
         return process;
     }
 
 
-    private ProcessWrapper createProcess(EnvironmentVariableContext environmentVariableContext, ConsoleOutputStreamConsumer consumer, String processTag, String errorPrefix) {
+    private ProcessWrapper createProcess(EnvironmentVariableContext environmentVariableContext, ConsoleOutputStreamConsumer consumer, ProcessTag processTag, String errorPrefix) {
         return ProcessManager.getInstance().createProcess(getCommandLine(), toString(getCommandLineForDisplay(), true), workingDir, env, environmentVariableContext, consumer, processTag, encoding,
                 errorPrefix);
     }
@@ -366,7 +367,7 @@ public class CommandLine {
     }
 
     public void runScript(Script script, StreamConsumer buildOutputConsumer,
-                          EnvironmentVariableContext environmentVariableContext, String processTag) throws CheckedCommandLineException {
+                          EnvironmentVariableContext environmentVariableContext, ProcessTag processTag) throws CheckedCommandLineException {
         LOG.info("Running command: {}", toStringForDisplay());
 
         CompositeConsumer errorStreamConsumer = new CompositeConsumer(CompositeConsumer.ERR, StreamLogger.getWarnLogger(LOG), buildOutputConsumer);
@@ -399,7 +400,7 @@ public class CommandLine {
         script.setExitCode(exitCode);
     }
 
-    public ConsoleResult runOrBomb(boolean failOnNonZeroReturn, String processTag, String... input) {
+    public ConsoleResult runOrBomb(boolean failOnNonZeroReturn, ProcessTag processTag, String... input) {
         LOG.debug("Running {}", this);
         addInput(input);
         InMemoryStreamConsumer output = ProcessOutputStreamConsumer.inMemoryConsumer();
@@ -417,14 +418,14 @@ public class CommandLine {
         return result;
     }
 
-    private ProcessWrapper startProcess(EnvironmentVariableContext environmentVariableContext, ConsoleOutputStreamConsumer consumer, String processTag) throws IOException {
+    private ProcessWrapper startProcess(EnvironmentVariableContext environmentVariableContext, ConsoleOutputStreamConsumer consumer, ProcessTag processTag) throws IOException {
         ProcessWrapper process = createProcess(environmentVariableContext, consumer, processTag, ERROR_STREAM_PREFIX_FOR_SCRIPTS);
         process.closeOutputStream();
         return process;
     }
 
 
-    public int run(ConsoleOutputStreamConsumer outputStreamConsumer, String processTag, String... input) {
+    public int run(ConsoleOutputStreamConsumer outputStreamConsumer, ProcessTag processTag, String... input) {
         LOG.debug("Running {}", this);
         addInput(input);
         SafeOutputStreamConsumer safeStreamConsumer = new SafeOutputStreamConsumer(outputStreamConsumer);
@@ -434,7 +435,7 @@ public class CommandLine {
         return process.waitForExit();
     }
 
-    public ConsoleResult runOrBomb(String processTag, String... input) {
+    public ConsoleResult runOrBomb(ProcessTag processTag, String... input) {
         return runOrBomb(true, processTag, input);
     }
 }

--- a/commandline/src/test/java/com/thoughtworks/go/util/ProcessManagerTest.java
+++ b/commandline/src/test/java/com/thoughtworks/go/util/ProcessManagerTest.java
@@ -39,6 +39,8 @@ class ProcessManagerTest {
     private ProcessWrapper wrapperForProcessOne;
     private ProcessWrapper wrapperForProcessTwo;
     private Process processStartedByManager;
+    private ProcessTag tag1;
+    private ProcessTag tag2;
 
     @BeforeEach
     void setUp() {
@@ -63,15 +65,17 @@ class ProcessManagerTest {
         when(processTwo.getErrorStream()).thenReturn(mock(InputStream.class));
         when(processTwo.getOutputStream()).thenReturn(mock(OutputStream.class));
         ConcurrentMap<Process, ProcessWrapper> processMap = processManager.getProcessMap();
-        wrapperForProcessOne = new ProcessWrapper(processOne, "tag1", null, inMemoryConsumer(), "utf-8", "ERROR: ");
+        tag1 = mock(ProcessTag.class);
+        wrapperForProcessOne = new ProcessWrapper(processOne, tag1, null, inMemoryConsumer(), "utf-8", "ERROR: ");
         processMap.put(processOne, wrapperForProcessOne);
-        wrapperForProcessTwo = new ProcessWrapper(processTwo, "tag2", null, inMemoryConsumer(), "utf-8", "ERROR: ");
+        tag2 = mock(ProcessTag.class);
+        wrapperForProcessTwo = new ProcessWrapper(processTwo, tag2, null, inMemoryConsumer(), "utf-8", "ERROR: ");
         processMap.put(processTwo, wrapperForProcessTwo);
     }
 
     @Test
     void shouldAddToProcessListWhenNewProcessCreated() {
-        processManager.createProcess(new String[]{"echo", "message"}, "echo 'message'", null, new HashMap<>(), new EnvironmentVariableContext(), inMemoryConsumer(), "test-tag", "utf-8",
+        processManager.createProcess(new String[]{"echo", "message"}, "echo 'message'", null, new HashMap<>(), new EnvironmentVariableContext(), inMemoryConsumer(), null, "utf-8",
                 "ERROR: ");
         assertThat(processManager.getProcessMap().size()).isEqualTo(3);
     }
@@ -94,12 +98,12 @@ class ProcessManagerTest {
         processMap.put(processOne, processWrapperOne);
         processMap.put(processTwo, processWrapperTwo);
 
-        when(processWrapperOne.getProcessTag()).thenReturn("tag1");
+        when(processWrapperOne.getProcessTag()).thenReturn(tag1);
         when(processWrapperOne.getIdleTime()).thenReturn(200L);
-        when(processWrapperTwo.getProcessTag()).thenReturn("tag2");
+        when(processWrapperTwo.getProcessTag()).thenReturn(tag2);
         when(processWrapperTwo.getIdleTime()).thenReturn(100L);
 
-        long timeout = processManager.getIdleTimeFor("tag2");
+        long timeout = processManager.getIdleTimeFor(tag2);
         assertThat(timeout).isEqualTo(100L);
     }
 

--- a/commandline/src/test/java/com/thoughtworks/go/util/ProcessWrapperTest.java
+++ b/commandline/src/test/java/com/thoughtworks/go/util/ProcessWrapperTest.java
@@ -37,7 +37,7 @@ class ProcessWrapperTest {
     void shouldReturnTrueWhenAProcessIsRunning() {
         Process process = getMockedProcess(mock(OutputStream.class));
         when(process.exitValue()).thenThrow(new IllegalThreadStateException());
-        ProcessWrapper processWrapper = new ProcessWrapper(process, "", "", inMemoryConsumer(), "utf-8", null);
+        ProcessWrapper processWrapper = new ProcessWrapper(process, null, "", inMemoryConsumer(), "utf-8", null);
         assertThat(processWrapper.isRunning()).isTrue();
     }
 
@@ -45,7 +45,7 @@ class ProcessWrapperTest {
     void shouldReturnFalseWhenAProcessHasExited() {
         Process process = getMockedProcess(mock(OutputStream.class));
         when(process.exitValue()).thenReturn(1);
-        ProcessWrapper processWrapper = new ProcessWrapper(process, "", "", inMemoryConsumer(), "utf-8", null);
+        ProcessWrapper processWrapper = new ProcessWrapper(process, null, "", inMemoryConsumer(), "utf-8", null);
         assertThat(processWrapper.isRunning()).isFalse();
     }
 
@@ -53,7 +53,7 @@ class ProcessWrapperTest {
     void shouldTypeInputToConsole() {
         OutputStream processInputStream = new ByteArrayOutputStream();// mock(OutputStream.class);
         Process process = getMockedProcess(processInputStream);
-        ProcessWrapper processWrapper = new ProcessWrapper(process, "", "", inMemoryConsumer(), "utf-8", null);
+        ProcessWrapper processWrapper = new ProcessWrapper(process, null, "", inMemoryConsumer(), "utf-8", null);
         ArrayList<String> inputs = new ArrayList<>();
         inputs.add("input1");
         inputs.add("input2");

--- a/common/src/test/java/com/thoughtworks/go/config/materials/git/GitMaterialUpdaterTest.java
+++ b/common/src/test/java/com/thoughtworks/go/config/materials/git/GitMaterialUpdaterTest.java
@@ -144,14 +144,14 @@ class GitMaterialUpdaterTest extends BuildSessionBasedTestCase {
         GitMaterial material = new GitMaterial(repoWithBranch.projectRepositoryUrl(), true);
         updateTo(material, new RevisionContext(new StringRevision("origin/master")), JobResult.Passed);
         InMemoryStreamConsumer output = inMemoryConsumer();
-        CommandLine.createCommandLine("git").withEncoding("UTF-8").withArg("branch").withWorkingDir(workingDir).run(output, "");
+        CommandLine.createCommandLine("git").withEncoding("UTF-8").withArg("branch").withWorkingDir(workingDir).run(output, null);
         assertThat(output.getStdOut()).isEqualTo("* master");
 
         GitMaterial material1 = new GitMaterial(repoWithBranch.projectRepositoryUrl(), "foo", null, true);
         updateTo(material1, new RevisionContext(new StringRevision("origin/foo")), JobResult.Passed);
 
         output = inMemoryConsumer();
-        CommandLine.createCommandLine("git").withEncoding("UTF-8").withArg("branch").withWorkingDir(workingDir).run(output, "");
+        CommandLine.createCommandLine("git").withEncoding("UTF-8").withArg("branch").withWorkingDir(workingDir).run(output, null);
         assertThat(output.getStdOut()).isEqualTo("* foo");
     }
 

--- a/common/src/test/java/com/thoughtworks/go/domain/materials/git/GitCommandTest.java
+++ b/common/src/test/java/com/thoughtworks/go/domain/materials/git/GitCommandTest.java
@@ -121,7 +121,7 @@ public class GitCommandTest {
         InMemoryStreamConsumer output = inMemoryConsumer();
         git.clone(output, repoUrl);
         CommandLine commandLine = CommandLine.createCommandLine("git").withEncoding("UTF-8").withArg("branch").withWorkingDir(gitLocalRepoDir);
-        commandLine.run(output, "");
+        commandLine.run(output, null);
         assertThat(output.getStdOut()).isEqualTo("* master");
     }
 
@@ -192,7 +192,7 @@ public class GitCommandTest {
         GitCommand branchedGit = new GitCommand(null, gitLocalRepoDir, BRANCH, false, new HashMap<>(), null);
         branchedGit.clone(inMemoryConsumer(), gitFooBranchBundle.projectRepositoryUrl());
         InMemoryStreamConsumer output = inMemoryConsumer();
-        CommandLine.createCommandLine("git").withEncoding("UTF-8").withArg("branch").withWorkingDir(gitLocalRepoDir).run(output, "");
+        CommandLine.createCommandLine("git").withEncoding("UTF-8").withArg("branch").withWorkingDir(gitLocalRepoDir).run(output, null);
         assertThat(output.getStdOut()).isEqualTo("* foo");
     }
 
@@ -201,7 +201,7 @@ public class GitCommandTest {
         gitLocalRepoDir = createTempWorkingDirectory();
         CommandLine gitCloneCommand = CommandLine.createCommandLine("git").withEncoding("UTF-8").withArg("clone");
         gitCloneCommand.withArg("--branch=" + BRANCH).withArg(new UrlArgument(gitFooBranchBundle.projectRepositoryUrl())).withArg(gitLocalRepoDir.getAbsolutePath());
-        gitCloneCommand.run(inMemoryConsumer(), "");
+        gitCloneCommand.run(inMemoryConsumer(), null);
         git = new GitCommand(null, gitLocalRepoDir, BRANCH, false, new HashMap<>(), null);
         assertThat(git.getCurrentBranch()).isEqualTo(BRANCH);
     }

--- a/common/src/test/java/com/thoughtworks/go/domain/materials/perforce/P4CommandTestBase.java
+++ b/common/src/test/java/com/thoughtworks/go/domain/materials/perforce/P4CommandTestBase.java
@@ -20,6 +20,7 @@ import com.thoughtworks.go.config.materials.perforce.P4Material;
 import com.thoughtworks.go.domain.materials.Modification;
 import com.thoughtworks.go.domain.materials.TestSubprocessExecutionContext;
 import com.thoughtworks.go.domain.materials.mercurial.StringRevision;
+import com.thoughtworks.go.util.MaterialFingerprintTag;
 import com.thoughtworks.go.util.command.CommandLine;
 import com.thoughtworks.go.util.command.ConsoleResult;
 import com.thoughtworks.go.util.command.InMemoryStreamConsumer;
@@ -111,13 +112,13 @@ abstract class P4CommandTestBase extends PerforceFixture {
     void shouldBombForNonZeroReturnCode() {
         ProcessOutputStreamConsumer outputStreamConsumer = Mockito.mock(ProcessOutputStreamConsumer.class);
         CommandLine line = Mockito.mock(CommandLine.class);
-        when(line.run(outputStreamConsumer, null, "foo")).thenReturn(1);
+        when(line.run(outputStreamConsumer, new MaterialFingerprintTag(null), "foo")).thenReturn(1);
         try {
             p4.execute(line, "foo", outputStreamConsumer, true);
             fail("did't bomb for non zero return code");
         } catch (Exception ignored) {
         }
-        verify(line).run(outputStreamConsumer, null, "foo");
+        verify(line).run(outputStreamConsumer, new MaterialFingerprintTag(null), "foo");
     }
 
     @Test

--- a/domain/src/main/java/com/thoughtworks/go/domain/materials/SCMCommand.java
+++ b/domain/src/main/java/com/thoughtworks/go/domain/materials/SCMCommand.java
@@ -16,6 +16,7 @@
 
 package com.thoughtworks.go.domain.materials;
 
+import com.thoughtworks.go.util.MaterialFingerprintTag;
 import com.thoughtworks.go.util.command.CommandLine;
 import com.thoughtworks.go.util.command.ConsoleOutputStreamConsumer;
 import com.thoughtworks.go.util.command.ConsoleResult;
@@ -31,14 +32,14 @@ public abstract class SCMCommand {
     }
 
     protected int run(CommandLine commandLine, ConsoleOutputStreamConsumer outputStreamConsumer, String... input) {
-        return commandLine.run(outputStreamConsumer, materialFingerprint, input);
+        return commandLine.run(outputStreamConsumer, new MaterialFingerprintTag(materialFingerprint), input);
     }
 
     public ConsoleResult runOrBomb(CommandLine commandLine, boolean failOnNonZeroReturn, String... input) {
-        return commandLine.runOrBomb(failOnNonZeroReturn, materialFingerprint, input);
+        return commandLine.runOrBomb(failOnNonZeroReturn, new MaterialFingerprintTag(materialFingerprint), input);
     }
 
     public ConsoleResult runOrBomb(CommandLine commandLine, String... input) {
-        return commandLine.runOrBomb(materialFingerprint, input);
+        return commandLine.runOrBomb(new MaterialFingerprintTag(materialFingerprint), input);
     }
 }

--- a/domain/src/main/java/com/thoughtworks/go/domain/materials/git/GitCommand.java
+++ b/domain/src/main/java/com/thoughtworks/go/domain/materials/git/GitCommand.java
@@ -16,12 +16,12 @@
 
 package com.thoughtworks.go.domain.materials.git;
 
-import com.thoughtworks.go.config.materials.git.GitMaterial;
 import com.thoughtworks.go.config.materials.git.GitMaterialConfig;
 import com.thoughtworks.go.domain.materials.Modification;
 import com.thoughtworks.go.domain.materials.Revision;
 import com.thoughtworks.go.domain.materials.SCMCommand;
 import com.thoughtworks.go.domain.materials.mercurial.StringRevision;
+import com.thoughtworks.go.util.NamedProcessTag;
 import com.thoughtworks.go.util.command.*;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -311,7 +311,7 @@ public class GitCommand extends SCMCommand {
 
     public void checkConnection(UrlArgument repoUrl, String branch, Map<String, String> environment) {
         CommandLine commandLine = git(environment).withArgs("ls-remote").withArg(repoUrl).withArg("refs/heads/" + branch);
-        ConsoleResult result = commandLine.runOrBomb(repoUrl.forDisplay());
+        ConsoleResult result = commandLine.runOrBomb(new NamedProcessTag(repoUrl.forDisplay()));
         if (!hasOnlyOneMatchingBranch(result)) {
             throw new CommandLineException(String.format("The branch %s could not be found.", branch));
         }
@@ -324,7 +324,7 @@ public class GitCommand extends SCMCommand {
     public GitVersion version(Map<String, String> map) {
         CommandLine gitLsRemote = git(map).withArgs("version");
 
-        String gitVersionString = gitLsRemote.runOrBomb("git version check").outputAsString();
+        String gitVersionString = gitLsRemote.runOrBomb(new NamedProcessTag("git version check")).outputAsString();
         return GitVersion.parse(gitVersionString);
     }
 

--- a/domain/src/main/java/com/thoughtworks/go/domain/materials/mercurial/HgCommand.java
+++ b/domain/src/main/java/com/thoughtworks/go/domain/materials/mercurial/HgCommand.java
@@ -19,6 +19,7 @@ package com.thoughtworks.go.domain.materials.mercurial;
 import com.thoughtworks.go.domain.materials.Modification;
 import com.thoughtworks.go.domain.materials.Revision;
 import com.thoughtworks.go.domain.materials.SCMCommand;
+import com.thoughtworks.go.util.NamedProcessTag;
 import com.thoughtworks.go.util.command.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -60,7 +61,7 @@ public class HgCommand extends SCMCommand {
 
     public HgVersion version() {
         CommandLine hg = createCommandLine("hg").withArgs("version").withEncoding("utf-8");
-        String hgOut = execute(hg, "hg version check").outputAsString();
+        String hgOut = execute(hg, new NamedProcessTag("hg version check")).outputAsString();
         return HgVersion.parse(hgOut);
     }
 
@@ -72,7 +73,7 @@ public class HgCommand extends SCMCommand {
     }
 
     public void checkConnection(UrlArgument repositoryURL) {
-        execute(createCommandLine("hg").withArgs("id", "--id").withArg(repositoryURL).withNonArgSecrets(secrets).withEncoding("utf-8"), repositoryURL.forDisplay());
+        execute(createCommandLine("hg").withArgs("id", "--id").withArg(repositoryURL).withNonArgSecrets(secrets).withEncoding("utf-8"), new NamedProcessTag(repositoryURL.forDisplay()));
     }
 
     public void updateTo(Revision revision, ConsoleOutputStreamConsumer outputStreamConsumer) {
@@ -148,7 +149,7 @@ public class HgCommand extends SCMCommand {
         return createCommandLine("hg").withArgs(arguments).withNonArgSecrets(secrets).withWorkingDir(workingDir).withEncoding("UTF-8");
     }
 
-    private static ConsoleResult execute(CommandLine hgCmd, String processTag) {
+    private static ConsoleResult execute(CommandLine hgCmd, NamedProcessTag processTag) {
         return hgCmd.runOrBomb(processTag);
     }
 

--- a/domain/src/test/java/com/thoughtworks/go/config/materials/git/GitMaterialTest.java
+++ b/domain/src/test/java/com/thoughtworks/go/config/materials/git/GitMaterialTest.java
@@ -284,13 +284,13 @@ public class GitMaterialTest {
         git = new GitMaterial(gitFooBranchBundle.projectRepositoryUrl());
         git.latestModification(workingDir, new TestSubprocessExecutionContext());
         InMemoryStreamConsumer output = inMemoryConsumer();
-        CommandLine.createCommandLine("git").withEncoding("UTF-8").withArg("branch").withWorkingDir(workingDir).run(output, "");
+        CommandLine.createCommandLine("git").withEncoding("UTF-8").withArg("branch").withWorkingDir(workingDir).run(output, null);
         assertThat(output.getStdOut()).isEqualTo("* master");
 
         git = new GitMaterial(gitFooBranchBundle.projectRepositoryUrl(), "foo");
         git.latestModification(workingDir, new TestSubprocessExecutionContext());
         output = inMemoryConsumer();
-        CommandLine.createCommandLine("git").withEncoding("UTF-8").withArg("branch").withWorkingDir(workingDir).run(output, "");
+        CommandLine.createCommandLine("git").withEncoding("UTF-8").withArg("branch").withWorkingDir(workingDir).run(output, null);
         assertThat(output.getStdOut()).isEqualTo("* foo");
     }
 

--- a/domain/src/test/java/com/thoughtworks/go/domain/materials/git/GitTestRepo.java
+++ b/domain/src/test/java/com/thoughtworks/go/domain/materials/git/GitTestRepo.java
@@ -24,6 +24,7 @@ import com.thoughtworks.go.domain.materials.TestSubprocessExecutionContext;
 import com.thoughtworks.go.domain.materials.mercurial.StringRevision;
 import com.thoughtworks.go.helper.TestRepo;
 import com.thoughtworks.go.util.FileUtil;
+import com.thoughtworks.go.util.NamedProcessTag;
 import com.thoughtworks.go.util.command.CommandLine;
 import com.thoughtworks.go.util.command.InMemoryStreamConsumer;
 import org.junit.rules.TemporaryFolder;
@@ -107,9 +108,9 @@ public class GitTestRepo extends TestRepo {
             throw new RuntimeException(String.format("[ERROR] Failed to clone. URL [%s] exit value [%d] output [%s]", from.getAbsolutePath(), returnValue, outputStreamConsumer.getAllOutput()));
         }
 
-        createCommandLine("git").withEncoding("UTF-8").withWorkingDir(workingDir).withArgs("config", "user.name", "go_test").runOrBomb(true, "git_config");
-        createCommandLine("git").withEncoding("UTF-8").withWorkingDir(workingDir).withArgs("config", "user.email", "go_test@go_test.me").runOrBomb(true, "git_config");
-        createCommandLine("git").withEncoding("UTF-8").withWorkingDir(workingDir).withArgs("config", "commit.gpgSign", "false").runOrBomb(true, "git_config");
+        createCommandLine("git").withEncoding("UTF-8").withWorkingDir(workingDir).withArgs("config", "user.name", "go_test").runOrBomb(true, new NamedProcessTag("git_config"));
+        createCommandLine("git").withEncoding("UTF-8").withWorkingDir(workingDir).withArgs("config", "user.email", "go_test@go_test.me").runOrBomb(true, new NamedProcessTag("git_config"));
+        createCommandLine("git").withEncoding("UTF-8").withWorkingDir(workingDir).withArgs("config", "commit.gpgSign", "false").runOrBomb(true, new NamedProcessTag("git_config"));
 
         git.fetchAndResetToHead(outputStreamConsumer);
     }

--- a/domain/src/test/java/com/thoughtworks/go/helper/GitRepoContainingSubmodule.java
+++ b/domain/src/test/java/com/thoughtworks/go/helper/GitRepoContainingSubmodule.java
@@ -23,6 +23,7 @@ import com.thoughtworks.go.domain.materials.TestSubprocessExecutionContext;
 import com.thoughtworks.go.domain.materials.git.GitCommand;
 import com.thoughtworks.go.domain.materials.mercurial.StringRevision;
 import com.thoughtworks.go.util.FileUtil;
+import com.thoughtworks.go.util.NamedProcessTag;
 import org.apache.commons.io.FileUtils;
 import org.junit.rules.TemporaryFolder;
 
@@ -82,9 +83,9 @@ public class GitRepoContainingSubmodule extends TestRepo {
         File withSubmodules = new File(workingDir, repoName);
         withSubmodules.mkdirs();
         git(withSubmodules).init();
-        createCommandLine("git").withEncoding("UTF-8").withWorkingDir(withSubmodules).withArgs("config", "user.name", "go_test").runOrBomb(true, "git_config");
-        createCommandLine("git").withEncoding("UTF-8").withWorkingDir(withSubmodules).withArgs("config", "user.email", "go_test@go_test.me").runOrBomb(true, "git_config");
-        createCommandLine("git").withEncoding("UTF-8").withWorkingDir(withSubmodules).withArgs("config", "commit.gpgSign", "false").runOrBomb(true, "git_config");
+        createCommandLine("git").withEncoding("UTF-8").withWorkingDir(withSubmodules).withArgs("config", "user.name", "go_test").runOrBomb(true, new NamedProcessTag("git_config"));
+        createCommandLine("git").withEncoding("UTF-8").withWorkingDir(withSubmodules).withArgs("config", "user.email", "go_test@go_test.me").runOrBomb(true, new NamedProcessTag("git_config"));
+        createCommandLine("git").withEncoding("UTF-8").withWorkingDir(withSubmodules).withArgs("config", "commit.gpgSign", "false").runOrBomb(true, new NamedProcessTag("git_config"));
 
         String fileName = "file-" + System.currentTimeMillis();
         addAndCommitNewFile(withSubmodules, fileName, "Added " + fileName);

--- a/server/src/main/java/com/thoughtworks/go/server/domain/PostBackupScript.java
+++ b/server/src/main/java/com/thoughtworks/go/server/domain/PostBackupScript.java
@@ -19,6 +19,7 @@ package com.thoughtworks.go.server.domain;
 import com.google.common.collect.ImmutableMap;
 import com.google.gson.internal.bind.util.ISO8601Utils;
 import com.thoughtworks.go.server.service.BackupService;
+import com.thoughtworks.go.util.NamedProcessTag;
 import com.thoughtworks.go.util.command.CommandLine;
 import com.thoughtworks.go.util.command.CommandLineException;
 import org.slf4j.Logger;
@@ -52,7 +53,7 @@ public class PostBackupScript {
 
     public boolean execute() {
         try {
-            commandLine().runOrBomb("Post Backup Script");
+            commandLine().runOrBomb(new NamedProcessTag("Post Backup Script"));
             return true;
         } catch (CommandLineException e) {
             LOG.error("Failed to execute post backup script.\n{}", e.getResult().describe(), e);

--- a/server/src/main/java/com/thoughtworks/go/server/materials/MaterialUpdateService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/materials/MaterialUpdateService.java
@@ -39,6 +39,7 @@ import com.thoughtworks.go.serverhealth.HealthStateScope;
 import com.thoughtworks.go.serverhealth.HealthStateType;
 import com.thoughtworks.go.serverhealth.ServerHealthService;
 import com.thoughtworks.go.serverhealth.ServerHealthState;
+import com.thoughtworks.go.util.MaterialFingerprintTag;
 import com.thoughtworks.go.util.ProcessManager;
 import com.thoughtworks.go.util.SystemEnvironment;
 import org.slf4j.Logger;
@@ -185,7 +186,7 @@ public class MaterialUpdateService implements GoMessageListener<MaterialUpdateCo
             }
         } else {
             LOGGER.warn("[Material Update] Skipping update of material {} which has been in-progress since {}", material, inProgressSince);
-            long idleTime = getProcessManager().getIdleTimeFor(material.getFingerprint());
+            long idleTime = getProcessManager().getIdleTimeFor(new MaterialFingerprintTag(material.getFingerprint()));
             if (idleTime > getMaterialUpdateInActiveTimeoutInMillis()) {
                 HealthStateScope scope = HealthStateScope.forMaterialUpdate(material);
                 serverHealthService.removeByScope(scope);

--- a/server/src/test-fast/java/com/thoughtworks/go/server/materials/MaterialUpdateServiceTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/materials/MaterialUpdateServiceTest.java
@@ -41,6 +41,7 @@ import com.thoughtworks.go.serverhealth.HealthStateScope;
 import com.thoughtworks.go.serverhealth.HealthStateType;
 import com.thoughtworks.go.serverhealth.ServerHealthService;
 import com.thoughtworks.go.serverhealth.ServerHealthState;
+import com.thoughtworks.go.util.MaterialFingerprintTag;
 import com.thoughtworks.go.util.ProcessManager;
 import com.thoughtworks.go.util.ReflectionUtil;
 import com.thoughtworks.go.util.SystemEnvironment;
@@ -388,7 +389,7 @@ public class MaterialUpdateServiceTest {
         when(material.getUriForDisplay()).thenReturn("uri");
         when(material.getLongDescription()).thenReturn("details to uniquely identify a material");
         when(material.isAutoUpdate()).thenReturn(true);
-        when(processManager.getIdleTimeFor("fingerprint")).thenReturn(60010L);
+        when(processManager.getIdleTimeFor(new MaterialFingerprintTag("fingerprint"))).thenReturn(60010L);
 
         //when
         service.updateMaterial(material);
@@ -412,7 +413,7 @@ public class MaterialUpdateServiceTest {
         service.updateMaterial(material);
         when(service.getProcessManager()).thenReturn(processManager);
         when(material.getFingerprint()).thenReturn("fingerprint");
-        when(processManager.getIdleTimeFor("fingerprint")).thenReturn(60010L);
+        when(processManager.getIdleTimeFor(new MaterialFingerprintTag("fingerprint"))).thenReturn(60010L);
 
         //when
         service.updateMaterial(material);

--- a/server/src/test-integration/java/com/thoughtworks/go/config/CachedGoConfigIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/config/CachedGoConfigIntegrationTest.java
@@ -1292,10 +1292,10 @@ public class CachedGoConfigIntegrationTest {
     private Modification setupExternalConfigRepo(File configRepo, String configRepoTestResource) throws IOException {
         ClassPathResource resource = new ClassPathResource(configRepoTestResource);
         FileUtils.copyDirectory(resource.getFile(), configRepo);
-        CommandLine.createCommandLine("git").withEncoding("utf-8").withArg("init").withArg(configRepo.getAbsolutePath()).runOrBomb("");
-        CommandLine.createCommandLine("git").withEncoding("utf-8").withArgs("config", "commit.gpgSign", "false").withWorkingDir(configRepo.getAbsoluteFile()).runOrBomb("");
+        CommandLine.createCommandLine("git").withEncoding("utf-8").withArg("init").withArg(configRepo.getAbsolutePath()).runOrBomb(null);
+        CommandLine.createCommandLine("git").withEncoding("utf-8").withArgs("config", "commit.gpgSign", "false").withWorkingDir(configRepo.getAbsoluteFile()).runOrBomb(null);
         gitAddDotAndCommit(configRepo);
-        ConsoleResult consoleResult = CommandLine.createCommandLine("git").withEncoding("utf-8").withArg("log").withArg("-1").withArg("--pretty=format:%h").withWorkingDir(configRepo).runOrBomb("");
+        ConsoleResult consoleResult = CommandLine.createCommandLine("git").withEncoding("utf-8").withArg("log").withArg("-1").withArg("--pretty=format:%h").withWorkingDir(configRepo).runOrBomb(null);
 
         Modification modification = new Modification();
         modification.setRevision(consoleResult.outputAsString());
@@ -1303,9 +1303,9 @@ public class CachedGoConfigIntegrationTest {
     }
 
     private void gitAddDotAndCommit(File configRepo) {
-        CommandLine.createCommandLine("git").withEncoding("utf-8").withArg("add").withArg("-A").withArg(".").withWorkingDir(configRepo).runOrBomb("");
-        CommandLine.createCommandLine("git").withEncoding("utf-8").withArg("config").withArg("user.email").withArg("go_test@go_test.me").withWorkingDir(configRepo).runOrBomb("");
-        CommandLine.createCommandLine("git").withEncoding("utf-8").withArg("config").withArg("user.name").withArg("user").withWorkingDir(configRepo).runOrBomb("");
-        CommandLine.createCommandLine("git").withEncoding("utf-8").withArg("commit").withArg("-m").withArg("initial commit").withWorkingDir(configRepo).runOrBomb("");
+        CommandLine.createCommandLine("git").withEncoding("utf-8").withArg("add").withArg("-A").withArg(".").withWorkingDir(configRepo).runOrBomb(null);
+        CommandLine.createCommandLine("git").withEncoding("utf-8").withArg("config").withArg("user.email").withArg("go_test@go_test.me").withWorkingDir(configRepo).runOrBomb(null);
+        CommandLine.createCommandLine("git").withEncoding("utf-8").withArg("config").withArg("user.name").withArg("user").withWorkingDir(configRepo).runOrBomb(null);
+        CommandLine.createCommandLine("git").withEncoding("utf-8").withArg("commit").withArg("-m").withArg("initial commit").withWorkingDir(configRepo).runOrBomb(null);
     }
 }

--- a/server/src/test-integration/java/com/thoughtworks/go/config/GoRepoConfigDataSourceIntegrationTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/config/GoRepoConfigDataSourceIntegrationTest.java
@@ -127,19 +127,19 @@ public class GoRepoConfigDataSourceIntegrationTest {
     private String setupExternalConfigRepo(File configRepo, String configRepoTestResource) throws IOException {
         ClassPathResource resource = new ClassPathResource(configRepoTestResource);
         FileUtils.copyDirectory(resource.getFile(), configRepo);
-        CommandLine.createCommandLine("git").withEncoding("utf-8").withArg("init").withArg(configRepo.getAbsolutePath()).runOrBomb("");
-        CommandLine.createCommandLine("git").withEncoding("utf-8").withArgs("config", "commit.gpgSign", "false").withWorkingDir(configRepo.getAbsoluteFile()).runOrBomb("");
+        CommandLine.createCommandLine("git").withEncoding("utf-8").withArg("init").withArg(configRepo.getAbsolutePath()).runOrBomb(null);
+        CommandLine.createCommandLine("git").withEncoding("utf-8").withArgs("config", "commit.gpgSign", "false").withWorkingDir(configRepo.getAbsoluteFile()).runOrBomb(null);
         gitAddDotAndCommit(configRepo);
-        ConsoleResult consoleResult = CommandLine.createCommandLine("git").withEncoding("utf-8").withArg("log").withArg("-1").withArg("--pretty=format:%h").withWorkingDir(configRepo).runOrBomb("");
+        ConsoleResult consoleResult = CommandLine.createCommandLine("git").withEncoding("utf-8").withArg("log").withArg("-1").withArg("--pretty=format:%h").withWorkingDir(configRepo).runOrBomb(null);
 
         return consoleResult.outputAsString();
     }
 
     private void gitAddDotAndCommit(File configRepo) {
-        CommandLine.createCommandLine("git").withEncoding("utf-8").withArg("add").withArg("-A").withArg(".").withWorkingDir(configRepo).runOrBomb("");
-        CommandLine.createCommandLine("git").withEncoding("utf-8").withArg("config").withArg("user.email").withArg("go_test@go_test.me").withWorkingDir(configRepo).runOrBomb("");
-        CommandLine.createCommandLine("git").withEncoding("utf-8").withArg("config").withArg("user.name").withArg("user").withWorkingDir(configRepo).runOrBomb("");
-        CommandLine.createCommandLine("git").withEncoding("utf-8").withArg("commit").withArg("-m").withArg("initial commit").withWorkingDir(configRepo).runOrBomb("");
+        CommandLine.createCommandLine("git").withEncoding("utf-8").withArg("add").withArg("-A").withArg(".").withWorkingDir(configRepo).runOrBomb(null);
+        CommandLine.createCommandLine("git").withEncoding("utf-8").withArg("config").withArg("user.email").withArg("go_test@go_test.me").withWorkingDir(configRepo).runOrBomb(null);
+        CommandLine.createCommandLine("git").withEncoding("utf-8").withArg("config").withArg("user.name").withArg("user").withWorkingDir(configRepo).runOrBomb(null);
+        CommandLine.createCommandLine("git").withEncoding("utf-8").withArg("commit").withArg("-m").withArg("initial commit").withWorkingDir(configRepo).runOrBomb(null);
     }
 
 }

--- a/server/src/test-integration/java/com/thoughtworks/go/server/service/PipelineConfigServicePerformanceTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/service/PipelineConfigServicePerformanceTest.java
@@ -209,7 +209,7 @@ public class PipelineConfigServicePerformanceTest {
         InMemoryStreamConsumer outputStreamConsumer = inMemoryConsumer();
         CommandLine commandLine = CommandLine.createCommandLine("jmap").withArgs("-J-d64", String.format("-dump:format=b,file=%s/%s.hprof", dumpDir.getAbsoluteFile(), i), ManagementFactory.getRuntimeMXBean().getName().split("@")[0]);
         LOGGER.info(commandLine.describe());
-        int exitCode = commandLine.run(outputStreamConsumer, "thread" + i);
+        int exitCode = commandLine.run(outputStreamConsumer, new NamedProcessTag("thread" + i));
         LOGGER.info(outputStreamConsumer.getAllOutput());
         assertThat(exitCode, is(0));
         LOGGER.info("Heap dump available at " + dumpDir.getAbsolutePath());


### PR DESCRIPTION
String based process tags did not really clarify what the process was
being spun up for.