### PR TITLE
Check if material has secret params before using them.

### DIFF
--- a/server/src/main/java/com/thoughtworks/go/server/service/BuildAssignmentService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/BuildAssignmentService.java
@@ -394,6 +394,7 @@ public class BuildAssignmentService implements ConfigChangedListener {
 
         return materials.stream()
                 .filter(material -> material instanceof SecretParamAware)
+                .filter(material -> ((SecretParamAware) material).hasSecretParams())
                 .map(material -> ((SecretParamAware) material).getSecretParams())
                 .collect(SecretParams.toFlatSecretParams());
     }


### PR DESCRIPTION
- This is done as SecretParams object on the material can be null.
  `material.hasSecretParams()` will make sure that collected object
   is not null and has secret params in it

### issue

Build assignment was failing with 

```log
2019-05-20 13:45:47,451 ERROR [104@MessageListener for WorkFinder] JMSMessageListenerAdapter:90 - Exception thrown in message handling by listener com.thoughtworks.go.server.messaging.scheduling.WorkFinder@5c0bacaa
java.lang.NullPointerException: null
    at java.base/java.util.ArrayList.addAll(ArrayList.java:596)
    at java.base/java.util.stream.ReduceOps$3ReducingSink.accept(ReduceOps.java:169)
    at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:195)
    at java.base/java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:177)
    at java.base/java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1492)
    at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:484)
    at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:474)
    at java.base/java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:913)
    at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
    at java.base/java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:578)
    at com.thoughtworks.go.server.service.BuildAssignmentService.secretParamsInMaterials(BuildAssignmentService.java:398)
    at com.thoughtworks.go.server.service.BuildAssignmentService.resolveSecretParams(BuildAssignmentService.java:380)
    at com.thoughtworks.go.server.service.BuildAssignmentService.lambda$createWork$2(BuildAssignmentService.java:350)
    at com.thoughtworks.go.server.transaction.TransactionTemplate.lambda$execute$1(TransactionTemplate.java:32)
    at org.springframework.transaction.support.TransactionTemplate.execute(TransactionTemplate.java:133)
    at com.thoughtworks.go.server.transaction.TransactionTemplate.execute(TransactionTemplate.java:29)
    at com.thoughtworks.go.server.service.BuildAssignmentService.lambda$createWork$3(BuildAssignmentService.java:340)
    at com.thoughtworks.go.server.transaction.TransactionTemplate.transactionSurrounding(TransactionTemplate.java:61)
    at com.thoughtworks.go.server.service.BuildAssignmentService.createWork(BuildAssignmentService.java:326)
    at com.thoughtworks.go.server.service.BuildAssignmentService.assignWorkToAgent(BuildAssignmentService.java:187)
    at com.thoughtworks.go.server.service.BuildAssignmentService.assignWorkToAgent(BuildAssignmentService.java:166)
    at com.thoughtworks.go.server.messaging.scheduling.WorkFinder.onMessage(WorkFinder.java:60)
    at com.thoughtworks.go.server.messaging.scheduling.WorkFinder.onMessage(WorkFinder.java:33)
    at com.thoughtworks.go.server.messaging.activemq.JMSMessageListenerAdapter.runImpl(JMSMessageListenerAdapter.java:86)
    at com.thoughtworks.go.server.messaging.activemq.JMSMessageListenerAdapter.run(JMSMessageListenerAdapter.java:66)
    at java.base/java.lang.Thread.run(Thread.java:844)

```

This will happen if the material has no secret params defined, to resolve the issue added check if the material has any secret params defined.