### PR TITLE
Use '\n' instead of '<br/>' in MDU error messages.

### DIFF
--- a/server/src/main/java/com/thoughtworks/go/server/materials/MaterialDatabaseUpdater.java
+++ b/server/src/main/java/com/thoughtworks/go/server/materials/MaterialDatabaseUpdater.java
@@ -118,9 +118,9 @@ public class MaterialDatabaseUpdater {
             String message = escapeHtml4("Modification check failed for material: " + material.getLongDescription());
             String affectedPipelinesMessage = "";
             if (pipelineNames.isEmpty()) {
-                affectedPipelinesMessage = (" <br/> No pipelines are affected by this material, perhaps this material is unused.");
+                affectedPipelinesMessage = ("\nNo pipelines are affected by this material, perhaps this material is unused.");
             } else {
-                affectedPipelinesMessage = (" <br/> Affected pipelines are " + StringUtils.join(pipelineNames, ", ") + ".");
+                affectedPipelinesMessage = ("\nAffected pipelines are " + StringUtils.join(pipelineNames, ", ") + ".");
             }
             String finalMessage = message + affectedPipelinesMessage;
             String errorDescription = e.getMessage() == null ? "Unknown error" : escapeHtml4(e.getMessage());

--- a/server/src/test-fast/java/com/thoughtworks/go/server/materials/MaterialDatabaseUpdaterTest.java
+++ b/server/src/test-fast/java/com/thoughtworks/go/server/materials/MaterialDatabaseUpdaterTest.java
@@ -65,7 +65,7 @@ public class MaterialDatabaseUpdaterTest {
     public void shouldThrowExceptionWithLongDescriptionOfMaterialWhenUpdateFails() throws Exception {
         Material material = new GitMaterial("url", "branch");
         Exception exception = new RuntimeException("failed");
-        String message = "Modification check failed for material: " + material.getLongDescription() + " <br/> Affected pipelines are blah.";
+        String message = "Modification check failed for material: " + material.getLongDescription() + "\nAffected pipelines are blah.";
         when(goConfigService.pipelinesWithMaterial(material.config().getFingerprint())).thenReturn(Collections.singletonList(new CaseInsensitiveString("blah")));
         ServerHealthState error = ServerHealthState.errorWithHtml(message, exception.getMessage(), HealthStateType.general(HealthStateScope.forMaterial(material)));
         when(materialRepository.findMaterialInstance(material)).thenThrow(exception);
@@ -90,7 +90,7 @@ public class MaterialDatabaseUpdaterTest {
     public void shouldFailWithAReasonableMessageWhenExceptionMessageIsNull() throws Exception {
         Material material = new GitMaterial("url", "branch");
         Exception exceptionWithNullMessage = new RuntimeException(null, new RuntimeException("Inner exception has non-null message"));
-        String message = "Modification check failed for material: " + material.getLongDescription() + " <br/> No pipelines are affected by this material, perhaps this material is unused.";
+        String message = "Modification check failed for material: " + material.getLongDescription() + "\nNo pipelines are affected by this material, perhaps this material is unused.";
         when(goConfigService.pipelinesWithMaterial(material.config().getFingerprint())).thenReturn(Collections.emptyList());
 
         when(materialRepository.findMaterialInstance(material)).thenThrow(exceptionWithNullMessage);

--- a/server/src/test-integration/java/com/thoughtworks/go/server/materials/MaterialDatabaseDependencyUpdaterTest.java
+++ b/server/src/test-integration/java/com/thoughtworks/go/server/materials/MaterialDatabaseDependencyUpdaterTest.java
@@ -133,7 +133,7 @@ public class MaterialDatabaseDependencyUpdaterTest {
         }
 
         HealthStateType scope = HealthStateType.general(HealthStateScope.forMaterial(dependencyMaterial));
-        ServerHealthState state = ServerHealthState.errorWithHtml("Modification check failed for material: pipeline-name <br/> No pipelines are affected by this material, perhaps this material is unused.", "Description of error", scope);
+        ServerHealthState state = ServerHealthState.errorWithHtml("Modification check failed for material: pipeline-name\nNo pipelines are affected by this material, perhaps this material is unused.", "Description of error", scope);
         Mockito.verify(healthService).update(state);
     }
 

--- a/server/webapp/WEB-INF/rails/webpack/views/components/server_health_summary/server_health_messages_count_widget.scss
+++ b/server/webapp/WEB-INF/rails/webpack/views/components/server_health_summary/server_health_messages_count_widget.scss
@@ -39,6 +39,7 @@
   .message {
     display:     inline-block;
     font-weight: 600;
+    white-space: pre-line;
   }
 
   .timestamp {


### PR DESCRIPTION
Related to #6295. This ensures that line breaks are displayed properly in the Config Repo error messages and the Server Health Messages modal.