### PR TITLE
Use `urlForCommandLine` to build HgCommand

### DIFF
--- a/common/src/test/java/com/thoughtworks/go/config/materials/mercurial/HgMaterialTest.java
+++ b/common/src/test/java/com/thoughtworks/go/config/materials/mercurial/HgMaterialTest.java
@@ -68,7 +68,6 @@ public class HgMaterialTest {
     private static final String REVISION_1 = "35ff2159f303ecf986b3650fc4299a6ffe5a14e1";
     private static final String REVISION_2 = "ca3ebb67f527c0ad7ed26b789056823d8b9af23f";
 
-
     @Nested
     class SlowOldTestWhichUsesHgCheckout {
         private HgMaterial hgMaterial;

--- a/domain/src/main/java/com/thoughtworks/go/config/materials/mercurial/HgMaterial.java
+++ b/domain/src/main/java/com/thoughtworks/go/config/materials/mercurial/HgMaterial.java
@@ -206,14 +206,15 @@ public class HgMaterial extends ScmMaterial {
 
 
     private HgCommand hg(File workingFolder, ConsoleOutputStreamConsumer outputStreamConsumer) throws Exception {
-        HgCommand hgCommand = new HgCommand(getFingerprint(), workingFolder, getBranch(), getUrl(), secrets());
+        UrlArgument urlArgument = new UrlArgument(urlForCommandLine());
+        HgCommand hgCommand = new HgCommand(getFingerprint(), workingFolder, getBranch(), urlArgument.forCommandLine(), secrets());
         if (!isHgRepository(workingFolder) || isRepositoryChanged(hgCommand)) {
             LOGGER.debug("Invalid hg working copy or repository changed. Delete folder: {}", workingFolder);
             FileUtils.deleteQuietly(workingFolder);
         }
         if (!workingFolder.exists()) {
             createParentFolderIfNotExist(workingFolder);
-            int returnValue = hgCommand.clone(outputStreamConsumer, url);
+            int returnValue = hgCommand.clone(outputStreamConsumer, urlArgument);
             bombIfFailedToRunCommandLine(returnValue, "Failed to run hg clone command");
         }
         return hgCommand;


### PR DESCRIPTION
EPIC #6298

- With the username and password attribute support, `HgCommand` needs to be created
  with the credentials in URL.