### PR TITLE
Made Git and Hg material and material config PasswordAwareMaterial

### DIFF
--- a/common/src/test/java/com/thoughtworks/go/config/materials/mercurial/HgMaterialTest.java
+++ b/common/src/test/java/com/thoughtworks/go/config/materials/mercurial/HgMaterialTest.java
@@ -18,12 +18,14 @@ package com.thoughtworks.go.config.materials.mercurial;
 
 import com.thoughtworks.go.config.CaseInsensitiveString;
 import com.thoughtworks.go.config.materials.Filter;
+import com.thoughtworks.go.config.materials.PasswordAwareMaterial;
 import com.thoughtworks.go.domain.MaterialInstance;
 import com.thoughtworks.go.domain.materials.*;
 import com.thoughtworks.go.domain.materials.mercurial.HgCommand;
 import com.thoughtworks.go.domain.materials.mercurial.HgVersion;
 import com.thoughtworks.go.domain.materials.mercurial.StringRevision;
 import com.thoughtworks.go.helper.HgTestRepo;
+import com.thoughtworks.go.helper.MaterialConfigsMother;
 import com.thoughtworks.go.helper.MaterialsMother;
 import com.thoughtworks.go.helper.TestRepo;
 import com.thoughtworks.go.util.JsonValue;
@@ -67,6 +69,30 @@ public class HgMaterialTest {
     private static final String REVISION_0 = "b61d12de515d82d3a377ae3aae6e8abe516a2651";
     private static final String REVISION_1 = "35ff2159f303ecf986b3650fc4299a6ffe5a14e1";
     private static final String REVISION_2 = "ca3ebb67f527c0ad7ed26b789056823d8b9af23f";
+
+    @Nested
+    class PasswordAware {
+        private HgMaterial material;
+
+        @BeforeEach
+        void setUp() {
+            material = new HgMaterial("some-url", null);
+        }
+
+        @Test
+        void shouldBePasswordAwareMaterial() {
+            assertThat(material).isInstanceOf(PasswordAwareMaterial.class);
+        }
+
+        @Test
+        void shouldUpdatePasswordFromConfig() {
+            assertThat(material.getPassword()).isNull();
+
+            material.updateFromConfig(MaterialConfigsMother.hg("some-url", "bob", "badger"));
+
+            assertThat(material.getPassword()).isEqualTo("badger");
+        }
+    }
 
     @Nested
     class SlowOldTestWhichUsesHgCheckout {

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/materials/git/GitMaterialConfig.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/materials/git/GitMaterialConfig.java
@@ -21,6 +21,7 @@ import com.thoughtworks.go.config.ConfigAttribute;
 import com.thoughtworks.go.config.ConfigTag;
 import com.thoughtworks.go.config.ValidationContext;
 import com.thoughtworks.go.config.materials.Filter;
+import com.thoughtworks.go.config.materials.PasswordAwareMaterial;
 import com.thoughtworks.go.config.materials.ScmMaterialConfig;
 import com.thoughtworks.go.domain.ConfigErrors;
 import com.thoughtworks.go.util.command.UrlArgument;
@@ -29,7 +30,7 @@ import org.apache.commons.lang3.StringUtils;
 import java.util.Map;
 
 @ConfigTag("git")
-public class GitMaterialConfig extends ScmMaterialConfig {
+public class GitMaterialConfig extends ScmMaterialConfig implements PasswordAwareMaterial {
     @ConfigAttribute(value = "url")
     private UrlArgument url;
 

--- a/config/config-api/src/main/java/com/thoughtworks/go/config/materials/mercurial/HgMaterialConfig.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/config/materials/mercurial/HgMaterialConfig.java
@@ -18,6 +18,7 @@ package com.thoughtworks.go.config.materials.mercurial;
 
 import com.thoughtworks.go.config.*;
 import com.thoughtworks.go.config.materials.Filter;
+import com.thoughtworks.go.config.materials.PasswordAwareMaterial;
 import com.thoughtworks.go.config.materials.ScmMaterialConfig;
 import com.thoughtworks.go.domain.ConfigErrors;
 import com.thoughtworks.go.util.command.HgUrlArgument;
@@ -28,7 +29,7 @@ import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.apache.commons.lang3.StringUtils.split;
 
 @ConfigTag(value = "hg", label = "Mercurial")
-public class HgMaterialConfig extends ScmMaterialConfig implements ParamsAttributeAware {
+public class HgMaterialConfig extends ScmMaterialConfig implements ParamsAttributeAware, PasswordAwareMaterial {
     @ConfigAttribute(value = "url")
     private HgUrlArgument url;
 

--- a/config/config-api/src/test/java/com/thoughtworks/go/config/materials/git/GitMaterialConfigTest.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/config/materials/git/GitMaterialConfigTest.java
@@ -18,10 +18,7 @@ package com.thoughtworks.go.config.materials.git;
 
 import com.thoughtworks.go.config.CaseInsensitiveString;
 import com.thoughtworks.go.config.ConfigSaveValidationContext;
-import com.thoughtworks.go.config.materials.AbstractMaterialConfig;
-import com.thoughtworks.go.config.materials.Filter;
-import com.thoughtworks.go.config.materials.IgnoredFiles;
-import com.thoughtworks.go.config.materials.ScmMaterialConfig;
+import com.thoughtworks.go.config.materials.*;
 import com.thoughtworks.go.security.GoCipher;
 import com.thoughtworks.go.util.ReflectionUtil;
 import com.thoughtworks.go.util.command.UrlArgument;
@@ -35,6 +32,11 @@ import java.util.Map;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class GitMaterialConfigTest {
+    @Test
+    void shouldBePasswordAwareMaterial() {
+        assertThat(new GitMaterialConfig()).isInstanceOf(PasswordAwareMaterial.class);
+    }
+
     @Test
     void shouldSetConfigAttributes() {
         GitMaterialConfig gitMaterialConfig = new GitMaterialConfig("");

--- a/config/config-api/src/test/java/com/thoughtworks/go/config/materials/mercurial/HgMaterialConfigTest.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/config/materials/mercurial/HgMaterialConfigTest.java
@@ -18,10 +18,7 @@ package com.thoughtworks.go.config.materials.mercurial;
 
 import com.thoughtworks.go.config.CaseInsensitiveString;
 import com.thoughtworks.go.config.ConfigSaveValidationContext;
-import com.thoughtworks.go.config.materials.AbstractMaterialConfig;
-import com.thoughtworks.go.config.materials.Filter;
-import com.thoughtworks.go.config.materials.IgnoredFiles;
-import com.thoughtworks.go.config.materials.ScmMaterialConfig;
+import com.thoughtworks.go.config.materials.*;
 import com.thoughtworks.go.security.GoCipher;
 import com.thoughtworks.go.util.ReflectionUtil;
 import org.junit.jupiter.api.BeforeEach;
@@ -43,6 +40,11 @@ class HgMaterialConfigTest {
     @BeforeEach
     void setUp() {
         hgMaterialConfig = new HgMaterialConfig("", null);
+    }
+
+    @Test
+    void shouldBePasswordAwareMaterial() {
+        assertThat(hgMaterialConfig).isInstanceOf(PasswordAwareMaterial.class);
     }
 
     @Test

--- a/config/config-api/src/test/java/com/thoughtworks/go/helper/MaterialConfigsMother.java
+++ b/config/config-api/src/test/java/com/thoughtworks/go/helper/MaterialConfigsMother.java
@@ -206,4 +206,18 @@ public class MaterialConfigsMother {
         return tfsMaterialConfig;
 
     }
+
+    public static GitMaterialConfig git(String url, String username, String password) {
+        GitMaterialConfig gitMaterialConfig = new GitMaterialConfig(url);
+        gitMaterialConfig.setUserName(username);
+        gitMaterialConfig.setPassword(password);
+        return gitMaterialConfig;
+    }
+
+    public static HgMaterialConfig hg(String url, String username, String password) {
+        HgMaterialConfig materialConfig = new HgMaterialConfig(url, null);
+        materialConfig.setUserName(username);
+        materialConfig.setPassword(password);
+        return materialConfig;
+    }
 }

--- a/domain/src/main/java/com/thoughtworks/go/config/materials/git/GitMaterial.java
+++ b/domain/src/main/java/com/thoughtworks/go/config/materials/git/GitMaterial.java
@@ -16,6 +16,7 @@
 
 package com.thoughtworks.go.config.materials.git;
 
+import com.thoughtworks.go.config.materials.PasswordAwareMaterial;
 import com.thoughtworks.go.config.materials.ScmMaterial;
 import com.thoughtworks.go.config.materials.ScmMaterialConfig;
 import com.thoughtworks.go.config.materials.SubprocessExecutionContext;
@@ -46,9 +47,10 @@ import static com.thoughtworks.go.util.FileUtil.createParentFolderIfNotExist;
 import static com.thoughtworks.go.util.FileUtil.deleteDirectoryNoisily;
 import static com.thoughtworks.go.util.command.ProcessOutputStreamConsumer.inMemoryConsumer;
 import static java.lang.String.format;
-import static org.apache.commons.lang3.StringUtils.*;
+import static org.apache.commons.lang3.StringUtils.isAllBlank;
+import static org.apache.commons.lang3.StringUtils.isBlank;
 
-public class GitMaterial extends ScmMaterial {
+public class GitMaterial extends ScmMaterial implements PasswordAwareMaterial {
     private static final Logger LOG = LoggerFactory.getLogger(GitMaterial.class);
     public static final int UNSHALLOW_TRYOUT_STEP = 100;
     public static final int DEFAULT_SHALLOW_CLONE_DEPTH = 2;

--- a/domain/src/main/java/com/thoughtworks/go/config/materials/mercurial/HgMaterial.java
+++ b/domain/src/main/java/com/thoughtworks/go/config/materials/mercurial/HgMaterial.java
@@ -16,6 +16,7 @@
 
 package com.thoughtworks.go.config.materials.mercurial;
 
+import com.thoughtworks.go.config.materials.PasswordAwareMaterial;
 import com.thoughtworks.go.config.materials.ScmMaterial;
 import com.thoughtworks.go.config.materials.ScmMaterialConfig;
 import com.thoughtworks.go.config.materials.SubprocessExecutionContext;
@@ -51,7 +52,7 @@ import static org.apache.commons.lang3.StringUtils.isNotBlank;
 /**
  * @understands configuration for mercurial version control
  */
-public class HgMaterial extends ScmMaterial {
+public class HgMaterial extends ScmMaterial implements PasswordAwareMaterial {
     private static final Pattern HG_VERSION_PATTERN = Pattern.compile(".*\\(.*\\s+(\\d(\\.\\d)+.*)\\)");
     private static final Logger LOGGER = LoggerFactory.getLogger(HgMaterial.class);
     private HgUrlArgument url;


### PR DESCRIPTION
EPIC #6298

- This is done as password attributes need to be serialized to the agent as it is not stored in DB.