### PR TITLE
Prefix material attributes classes with material name on create pipeline

### DIFF
--- a/server/webapp/WEB-INF/rails/app/presenters/api_v1/admin/pipelines/materials/git_material_representer.rb
+++ b/server/webapp/WEB-INF/rails/app/presenters/api_v1/admin/pipelines/materials/git_material_representer.rb
@@ -31,7 +31,7 @@ module ApiV1
                    }
           property :submodule_folder
           property :shallow_clone
-          property :user_name, as: :username, skip_nil: true
+          property :user_name, as: :username, skip_nil: true, skip_parse: SkipParseOnBlank
           property :password,
                    skip_render: true,
                    skip_nil: true,

--- a/server/webapp/WEB-INF/rails/app/presenters/api_v1/admin/pipelines/materials/hg_material_representer.rb
+++ b/server/webapp/WEB-INF/rails/app/presenters/api_v1/admin/pipelines/materials/hg_material_representer.rb
@@ -21,12 +21,12 @@ module ApiV1
         class HgMaterialRepresenter < ScmMaterialRepresenter
           include EncryptedPasswordSupport
 
-          property :user_name, as: :username, skip_nil: true
+          property :user_name, as: :username, skip_nil: true, skip_parse: SkipParseOnBlank
           property :password,
                    skip_render: true,
                    skip_nil: true,
                    skip_parse: true
-          property :branch, skip_nil: true,
+          property :branch, skip_nil: true, skip_parse: SkipParseOnBlank,
                    getter: lambda {|args|
                      self.getBranchAttribute
                    },

--- a/server/webapp/WEB-INF/rails/app/views/admin/pipelines/materials/_git_form.html.erb
+++ b/server/webapp/WEB-INF/rails/app/views/admin/pipelines/materials/_git_form.html.erb
@@ -12,7 +12,7 @@
 <%= render :partial => 'admin/materials/shared/plain_password', :locals => {:scope => {:form => scope[:form], :password_class => 'git_password'}} %>
 <div class="form_item_block">
   <label>Branch</label>
-  <%= scope[:form].text_field com.thoughtworks.go.config.materials.git.GitMaterialConfig::BRANCH, {:class => "form_input branch", :id => nil} -%>
+  <%= scope[:form].text_field com.thoughtworks.go.config.materials.git.GitMaterialConfig::BRANCH, {:class => "form_input git_branch", :id => nil} -%>
   <%= error_message_on(scope[:material], com.thoughtworks.go.config.materials.git.GitMaterialConfig::BRANCH, :css_class => "form_error") %>
 </div>
 
@@ -31,7 +31,7 @@
 <%= render :partial => 'admin/materials/shared/check_connection', :locals => {:scope =>
                                                                                 {:url => ".git_url",
                                                                                  :type => "git",
-                                                                                 :branch => ".branch",
+                                                                                 :branch => ".git_branch",
                                                                                  :username => ".git_username",
                                                                                  :password => ".git_password",
                                                                                  :encrypted_password => "false"}} %>

--- a/server/webapp/WEB-INF/rails/app/views/admin/pipelines/materials/_hg_form.html.erb
+++ b/server/webapp/WEB-INF/rails/app/views/admin/pipelines/materials/_hg_form.html.erb
@@ -12,7 +12,7 @@
 <%= render :partial => 'admin/materials/shared/plain_password', :locals => {:scope => {:form => scope[:form], :password_class => 'hg_password'}} %>
 <div class="form_item_block">
   <label>Branch</label>
-  <%= scope[:form].text_field com.thoughtworks.go.config.materials.mercurial.HgMaterialConfig::BRANCH, {:class => "form_input branch", :id => nil} -%>
+  <%= scope[:form].text_field com.thoughtworks.go.config.materials.mercurial.HgMaterialConfig::BRANCH, {:class => "form_input hg_branch", :id => nil} -%>
   <%= error_message_on(scope[:material], com.thoughtworks.go.config.materials.mercurial.HgMaterialConfig::BRANCH, :css_class => "form_error") %>
 </div>
 
@@ -21,7 +21,7 @@
 <%= render :partial => "admin/materials/shared/filter", :locals => {:scope => {:form => scope[:form]}} %>
 <%= render :partial => 'admin/materials/shared/check_connection', :locals => {:scope => {:url => ".hg_url",
                                                                                          :type => "hg",
-                                                                                         :branch => ".branch",
+                                                                                         :branch => ".hg_branch",
                                                                                          :username => ".hg_username",
                                                                                          :password => ".hg_password",
                                                                                          :encrypted_password => "false"}} %>


### PR DESCRIPTION
EPIC: #6298 

- This is done to avoid class name conflict in create new pipeline flow
  as view is rendered using all materials form and having same class names
  will lead to conflict