### PR TITLE
Changes to HgMaterial secrets should consider #6298

### DIFF
--- a/common/src/test/java/com/thoughtworks/go/config/materials/mercurial/HgMaterialUpdaterTest.java
+++ b/common/src/test/java/com/thoughtworks/go/config/materials/mercurial/HgMaterialUpdaterTest.java
@@ -90,6 +90,16 @@ class HgMaterialUpdaterTest extends BuildSessionBasedTestCase {
     }
 
     @Test
+    void failureCommandShouldNotLeakPasswordOnUrlWhenCredentialConfiguredThroughAttributes() {
+        HgMaterial material = MaterialsMother.hgMaterial("https://this.is.absolute.not.exists");
+        material.setUserName("foo");
+        material.setPassword("foopassword");
+        updateTo(material, new RevisionContext(REVISION_1), JobResult.Failed);
+        assertThat(console.output()).contains("https://this.is.absolute.not.exists");
+        assertThat(console.output()).doesNotContain("foopassword");
+    }
+
+    @Test
     void shouldCreateBuildCommandUpdateToSpecificRevision() {
         File newFile = new File(workingFolder, "end2end/revision2.txt");
         updateTo(hgMaterial, new RevisionContext(REVISION_0), JobResult.Passed);

--- a/domain/src/main/java/com/thoughtworks/go/config/materials/mercurial/HgMaterial.java
+++ b/domain/src/main/java/com/thoughtworks/go/config/materials/mercurial/HgMaterial.java
@@ -179,7 +179,7 @@ public class HgMaterial extends ScmMaterial implements PasswordAwareMaterial {
     public ValidationBean checkConnection(final SubprocessExecutionContext execCtx) {
         HgCommand hgCommand = new HgCommand(null, null, null, null, secrets());
         try {
-            hgCommand.checkConnection(new UrlArgument(urlForCommandLine()));
+            hgCommand.checkConnection(new HgUrlArgument(urlForCommandLine()));
             return ValidationBean.valid();
         } catch (Exception e) {
             try {
@@ -207,7 +207,7 @@ public class HgMaterial extends ScmMaterial implements PasswordAwareMaterial {
 
 
     private HgCommand hg(File workingFolder, ConsoleOutputStreamConsumer outputStreamConsumer) throws Exception {
-        UrlArgument urlArgument = new UrlArgument(urlForCommandLine());
+        UrlArgument urlArgument = new HgUrlArgument(urlForCommandLine());
         HgCommand hgCommand = new HgCommand(getFingerprint(), workingFolder, getBranch(), urlArgument.forCommandLine(), secrets());
         if (!isHgRepository(workingFolder) || isRepositoryChanged(hgCommand)) {
             LOGGER.debug("Invalid hg working copy or repository changed. Delete folder: {}", workingFolder);
@@ -221,8 +221,8 @@ public class HgMaterial extends ScmMaterial implements PasswordAwareMaterial {
         return hgCommand;
     }
 
-    private List<SecretString> secrets() {
-        SecretString secretSubstitution = line -> line.replace(url.forCommandLine(), url.forDisplay());
+    protected List<SecretString> secrets() {
+        SecretString secretSubstitution = line -> line.replace(urlForCommandLine(), getUriForDisplay());
         return Collections.singletonList(secretSubstitution);
     }
 

--- a/domain/src/main/java/com/thoughtworks/go/domain/materials/mercurial/HgMaterialUpdater.java
+++ b/domain/src/main/java/com/thoughtworks/go/domain/materials/mercurial/HgMaterialUpdater.java
@@ -39,7 +39,7 @@ public class HgMaterialUpdater {
         String workingDir = material.workingdir(new File(baseDir)).getPath();
         UrlArgument url = material.getUrlArgument();
         return compose(
-                secret(url.forCommandLine(), url.forDisplay()),
+                secret(material.urlForCommandLine(), material.getUriForDisplay()),
                 echoWithPrefix("Start updating %s at revision %s from %s", material.updatingTarget(), revision.getRevision(), url.forDisplay()),
                 cloneIfNeeded(workingDir),
                 pull(workingDir),


### PR DESCRIPTION
Part of #6298 

* HgMaterial secrets resolution should replace HgMaterial#urlForCommandLine
  with urlForDisplay. This is required if credentials are specified as attributes,
  the HgMaterial#urlForCommandLine would return an URL with credentials, whereas
  the HgUrlArgument#forCommandLine would return url without credentials.