### PR TITLE
Make the newApi task play well with docker subprojects

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1162,9 +1162,11 @@ task newApi {
       out.println("")
       out.println("rootProject.name = 'gocd'")
       out.println("")
-      def existingProjects = rootProject.allprojects.findAll { prj -> prj.childProjects.isEmpty() }.collect { it.path }
+      def existingProjects = rootProject.allprojects.findAll { prj -> prj.childProjects.isEmpty() && !prj.path.startsWith(":docker") }.collect { it.path }
       def newProjects = existingProjects + [":api:${newProjectName}"]
       newProjects.sort().unique().each { out.println "include '${it}'" }
+      out.println("")
+      out.println("apply from: 'settings-docker.gradle'")
     }
 
     file('.gitignore').withWriterAppend { out ->

--- a/settings-docker.gradle
+++ b/settings-docker.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import com.thoughtworks.go.build.docker.Distro
+import com.thoughtworks.go.build.docker.DistroVersion
+
+Distro.values().each { Distro distro ->
+  distro.supportedVersions.each { DistroVersion version ->
+    include ":docker:gocd-agent:${distro.projectName(version)}"
+  }
+}
+
+include ":docker:gocd-server:${Distro.centos.projectName(Distro.centos.getVersion('7'))}"
+include ":docker:gocd-server:${Distro.alpine.projectName(Distro.alpine.getVersion('3.9'))}"

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,6 +1,3 @@
-import com.thoughtworks.go.build.docker.Distro
-import com.thoughtworks.go.build.docker.DistroVersion
-
 /*
  * Copyright 2019 ThoughtWorks, Inc.
  *
@@ -112,11 +109,4 @@ include ':tfs-impl:tfs-impl-14'
 include ':tw-go-plugins'
 include ':util'
 
-Distro.values().each { Distro distro ->
-  distro.supportedVersions.each { DistroVersion version ->
-    include ":docker:gocd-agent:${distro.projectName(version)}"
-  }
-}
-
-include ":docker:gocd-server:${Distro.centos.projectName(Distro.centos.getVersion('7'))}"
-include ":docker:gocd-server:${Distro.alpine.projectName(Distro.alpine.getVersion('3.9'))}"
+apply from: 'settings-docker.gradle'


### PR DESCRIPTION
The newApi task would remove the `Distro.values().each ...` section from `settings.gradle` and add all projects directly. I have pulled out that section into a separate file and included it in the template used by newApi