### PR TITLE
Do not build fedora-28 based docker gocd agent image

### DIFF
--- a/buildSrc/src/main/groovy/com/thoughtworks/go/build/docker/Distro.groovy
+++ b/buildSrc/src/main/groovy/com/thoughtworks/go/build/docker/Distro.groovy
@@ -103,7 +103,6 @@ enum Distro implements DistroBehavior {
     List<DistroVersion> getSupportedVersions() {
       // Fedora has 13 months for EOL
       return [
-        new DistroVersion(version: '28', releaseName: '28', eolDate: parseDate('2019-06-01'), continueToBuild: true),
         // approximate date - 1 year from release date, check when the build fails
         new DistroVersion(version: '29', releaseName: '29', eolDate: parseDate('2019-11-30')),
         new DistroVersion(version: '30', releaseName: '30', eolDate: parseDate('2020-06-01')),


### PR DESCRIPTION
* Fedora 28 will be reaching EOL on 2019-05-31.
* Fedora 28 based docker gocd agent image will not be build from upcoming releases

Links:
* https://forums.fedoraforum.org/showthread.php?321243-CRITICAL-31st-May-2019-Fedora-28-End-Of-Life