### PR TITLE
Fix Weak Etag issue for rails based index APIs (#6278)

### DIFF
--- a/api/api-pipeline-groups-v1/src/test/groovy/com/thoughtworks/go/apiv1/admin/pipelinegroups/PipelineGroupsControllerV1Test.groovy
+++ b/api/api-pipeline-groups-v1/src/test/groovy/com/thoughtworks/go/apiv1/admin/pipelinegroups/PipelineGroupsControllerV1Test.groovy
@@ -92,7 +92,7 @@ class PipelineGroupsControllerV1Test implements SecurityServiceTrait, Controller
       void 'should list all pipeline groups'() {
         def configs = new BasicPipelineConfigs(PipelineConfigMother.pipelineConfig('pipeline1'))
         configs.setGroup("group")
-        def expectedPipelineGroups = new PipelineGroups(configs)
+        def expectedPipelineGroups = new PipelineGroups([configs])
         when(entityHashingService.md5ForEntity(expectedPipelineGroups)).thenReturn("some-etag")
         when(pipelineConfigsService.getGroupsForUser(currentUserLoginName().toString())).thenReturn(expectedPipelineGroups)
 
@@ -109,7 +109,7 @@ class PipelineGroupsControllerV1Test implements SecurityServiceTrait, Controller
       void 'should render 304 if etag matches'() {
         def configs = new BasicPipelineConfigs(PipelineConfigMother.pipelineConfig('pipeline1'))
         configs.setGroup("group")
-        def expectedPipelineGroups = new PipelineGroups(configs)
+        def expectedPipelineGroups = new PipelineGroups([configs])
 
         when(entityHashingService.md5ForEntity(expectedPipelineGroups)).thenReturn("some-etag")
         when(pipelineConfigsService.getGroupsForUser(currentUserLoginName().toString())).thenReturn(expectedPipelineGroups)
@@ -229,7 +229,7 @@ class PipelineGroupsControllerV1Test implements SecurityServiceTrait, Controller
       void 'should show pipeline config for an admin'() {
         def group = new BasicPipelineConfigs(PipelineConfigMother.pipelineConfig('pipeline1'))
         group.setGroup("group")
-        def pipelineGroups = new PipelineGroups(group)
+        def pipelineGroups = new PipelineGroups([group])
         def group_md5 = 'md5_for_group'
 
         when(pipelineConfigsService.getGroupsForUser(currentUserLoginName().toString())).thenReturn(pipelineGroups)
@@ -247,7 +247,7 @@ class PipelineGroupsControllerV1Test implements SecurityServiceTrait, Controller
       void "should return 304 for show pipeline config if etag sent in request is fresh"() {
         def group = new BasicPipelineConfigs(PipelineConfigMother.pipelineConfig('pipeline1'))
         group.setGroup("group")
-        def pipelineGroups = new PipelineGroups(group)
+        def pipelineGroups = new PipelineGroups([group])
         def group_md5 = 'md5_for_group'
 
         when(pipelineConfigsService.getGroupsForUser(currentUserLoginName().toString())).thenReturn(pipelineGroups)
@@ -276,7 +276,7 @@ class PipelineGroupsControllerV1Test implements SecurityServiceTrait, Controller
       void "should show pipeline config if etag sent in request is stale"() {
         def group = new BasicPipelineConfigs(PipelineConfigMother.pipelineConfig('pipeline1'))
         group.setGroup("group")
-        def pipelineGroups = new PipelineGroups(group)
+        def pipelineGroups = new PipelineGroups([group])
         def group_md5 = 'md5_for_group'
 
         when(pipelineConfigsService.getGroupsForUser(currentUserLoginName().toString())).thenReturn(pipelineGroups)
@@ -330,7 +330,7 @@ class PipelineGroupsControllerV1Test implements SecurityServiceTrait, Controller
         def group = new BasicPipelineConfigs(PipelineConfigMother.pipelineConfig("pipeline1"))
         group.setGroup("group1")
         when(entityHashingService.md5ForEntity(group)).thenReturn('md5')
-        when(pipelineConfigsService.getGroupsForUser(currentUserLoginName().toString())).thenReturn(new PipelineGroups(group))
+        when(pipelineConfigsService.getGroupsForUser(currentUserLoginName().toString())).thenReturn(new PipelineGroups([group]))
         when(pipelineConfigsService.updateGroupAuthorization(any(), any(), any(), any(), any(), any())).thenReturn(group)
 
         def headers = [
@@ -350,7 +350,7 @@ class PipelineGroupsControllerV1Test implements SecurityServiceTrait, Controller
       void "should not update group if etag passed does not match the one on server"() {
         def group = new BasicPipelineConfigs(PipelineConfigMother.pipelineConfig("pipeline1"))
         group.setGroup("group1")
-        when(pipelineConfigsService.getGroupsForUser(currentUserLoginName().toString())).thenReturn(new PipelineGroups(group))
+        when(pipelineConfigsService.getGroupsForUser(currentUserLoginName().toString())).thenReturn(new PipelineGroups([group]))
 
         def headers = [
           'If-Match': 'old-etag',
@@ -369,7 +369,7 @@ class PipelineGroupsControllerV1Test implements SecurityServiceTrait, Controller
       void "should not update group if no etag is passed"() {
         def group = new BasicPipelineConfigs(PipelineConfigMother.pipelineConfig("pipeline1"))
         group.setGroup("group1")
-        when(pipelineConfigsService.getGroupsForUser(currentUserLoginName().toString())).thenReturn(new PipelineGroups(group))
+        when(pipelineConfigsService.getGroupsForUser(currentUserLoginName().toString())).thenReturn(new PipelineGroups([group]))
 
         putWithApiHeader(controller.controllerPath("/group1"), toObjectString({
           PipelineGroupRepresenter.toJSON(it, group)
@@ -386,7 +386,7 @@ class PipelineGroupsControllerV1Test implements SecurityServiceTrait, Controller
         def group = new BasicPipelineConfigs(PipelineConfigMother.pipelineConfig("pipeline1"))
         group.setGroup("group1")
         when(entityHashingService.md5ForEntity(group)).thenReturn('md5')
-        when(pipelineConfigsService.getGroupsForUser(currentUserLoginName().toString())).thenReturn(new PipelineGroups(group))
+        when(pipelineConfigsService.getGroupsForUser(currentUserLoginName().toString())).thenReturn(new PipelineGroups([group]))
 
         group.addError("authorization", "Invalid authorization")
 
@@ -428,7 +428,7 @@ class PipelineGroupsControllerV1Test implements SecurityServiceTrait, Controller
       void "should not allow renaming a pipeline"() {
         def group = new BasicPipelineConfigs(PipelineConfigMother.pipelineConfig("pipeline1"))
         group.setGroup("group1")
-        when(pipelineConfigsService.getGroupsForUser(currentUserLoginName().toString())).thenReturn(new PipelineGroups(group))
+        when(pipelineConfigsService.getGroupsForUser(currentUserLoginName().toString())).thenReturn(new PipelineGroups([group]))
 
         def headers = [
           'If-Match': 'md5',
@@ -475,7 +475,7 @@ class PipelineGroupsControllerV1Test implements SecurityServiceTrait, Controller
       @Test
       void "should delete empty pipeline group for an admin"() {
         def group = new BasicPipelineConfigs("group1", new Authorization())
-        when(pipelineConfigsService.getGroupsForUser(currentUserLoginName().toString())).thenReturn(new PipelineGroups(group))
+        when(pipelineConfigsService.getGroupsForUser(currentUserLoginName().toString())).thenReturn(new PipelineGroups([group]))
 
         doAnswer({ InvocationOnMock invocation ->
           HttpLocalizedOperationResult result = invocation.arguments.last()
@@ -504,7 +504,7 @@ class PipelineGroupsControllerV1Test implements SecurityServiceTrait, Controller
       @Test
       void "should not delete pipeline group when the group is not empty"() {
         def group = new BasicPipelineConfigs("group1", new Authorization(), PipelineConfigMother.pipelineConfig("pipeline1"))
-        when(pipelineConfigsService.getGroupsForUser(currentUserLoginName().toString())).thenReturn(new PipelineGroups(group))
+        when(pipelineConfigsService.getGroupsForUser(currentUserLoginName().toString())).thenReturn(new PipelineGroups([group]))
 
         doAnswer({ InvocationOnMock invocation ->
           HttpLocalizedOperationResult result = invocation.arguments.last()

--- a/config/config-api/src/main/java/com/thoughtworks/go/domain/PipelineGroups.java
+++ b/config/config-api/src/main/java/com/thoughtworks/go/domain/PipelineGroups.java
@@ -40,7 +40,15 @@ public class PipelineGroups extends BaseCollection<PipelineConfigs> implements V
     public PipelineGroups() {
     }
 
+    public PipelineGroups(List<PipelineConfigs> pipelineConfigs) {
+        addPipelineConfigs(pipelineConfigs);
+    }
+
     public PipelineGroups(PipelineConfigs... configses) {
+        addPipelineConfigs(Arrays.asList(configses));
+    }
+
+    private void addPipelineConfigs(List<PipelineConfigs> configses) {
         for (PipelineConfigs configs : configses) {
             this.add(configs);
         }

--- a/server/src/main/java/com/thoughtworks/go/server/service/EntityHashingService.java
+++ b/server/src/main/java/com/thoughtworks/go/server/service/EntityHashingService.java
@@ -140,6 +140,14 @@ public class EntityHashingService implements ConfigChangedListener, Initializer 
         return getDomainEntityMd5FromCache(config, cacheKey);
     }
 
+    public String md5ForEntity(SecurityAuthConfigs authConfigs) {
+        List<String> md5s = new ArrayList<>();
+        for (SecurityAuthConfig authConfig : authConfigs) {
+            md5s.add(md5ForEntity(authConfig));
+        }
+        return CachedDigestUtils.md5Hex(StringUtils.join(md5s, "/"));
+    }
+
     public String md5ForEntity(Role config) {
         String cacheKey = cacheKey(config, config.getName());
         return getDomainEntityMd5FromCache(config, cacheKey);

--- a/server/webapp/WEB-INF/rails/app/controllers/api_v1/admin/internal/command_snippets_controller.rb
+++ b/server/webapp/WEB-INF/rails/app/controllers/api_v1/admin/internal/command_snippets_controller.rb
@@ -23,7 +23,8 @@ module ApiV1
         def index
           command_snippets = command_repository_service.lookupCommand(params[:prefix])
 
-          render DEFAULT_FORMAT => CommandSnippetsRepresenter.new(command_snippets.to_a).to_hash(url_builder: self, prefix: params[:prefix])
+          json = CommandSnippetsRepresenter.new(command_snippets.to_a).to_hash(url_builder: self, prefix: params[:prefix])
+          render DEFAULT_FORMAT => json if (stale?(strong_etag: etag_for(command_snippets)))
         end
       end
     end

--- a/server/webapp/WEB-INF/rails/app/controllers/api_v1/admin/internal/pipelines_controller.rb
+++ b/server/webapp/WEB-INF/rails/app/controllers/api_v1/admin/internal/pipelines_controller.rb
@@ -24,8 +24,7 @@ module ApiV1
           pipelines = pipeline_config_service.viewableOrOperatableGroupsFor(current_user)
 
           json = ApiV1::Config::PipelineConfigsWithMinimalAttributesRepresenter.new(pipelines).to_hash(url_builder: self)
-
-          render json_hal_v1: json
+          render json_hal_v1: json if(stale?(strong_etag: etag_for(PipelineGroups.new pipelines)))
         end
       end
     end

--- a/server/webapp/WEB-INF/rails/app/controllers/api_v1/admin/packages_controller.rb
+++ b/server/webapp/WEB-INF/rails/app/controllers/api_v1/admin/packages_controller.rb
@@ -23,7 +23,9 @@ module ApiV1
       before_action :check_for_repository, only: [:create, :update]
 
       def index
-        render DEFAULT_FORMAT => ApiV1::Config::PackagesRepresenter.new(package_definition_service.getPackages).to_hash(url_builder: self)
+        packages = package_definition_service.getPackages
+        json = ApiV1::Config::PackagesRepresenter.new(packages).to_hash(url_builder: self)
+        render DEFAULT_FORMAT => json if(stale?(strong_etag: etag_for(packages)))
       end
 
       def show

--- a/server/webapp/WEB-INF/rails/app/controllers/api_v1/admin/pluggable_scms_controller.rb
+++ b/server/webapp/WEB-INF/rails/app/controllers/api_v1/admin/pluggable_scms_controller.rb
@@ -23,7 +23,8 @@ module ApiV1
 
       def index
         scms = pluggable_scm_service.listAllScms
-        render DEFAULT_FORMAT => ApiV1::Scms::PluggableScmsRepresenter.new(scms).to_hash(url_builder: self)
+        json = ApiV1::Scms::PluggableScmsRepresenter.new(scms).to_hash(url_builder: self)
+        render DEFAULT_FORMAT => json if (stale?(strong_etag: etag_for(scms)))
       end
 
       def show

--- a/server/webapp/WEB-INF/rails/app/controllers/api_v1/admin/repositories_controller.rb
+++ b/server/webapp/WEB-INF/rails/app/controllers/api_v1/admin/repositories_controller.rb
@@ -27,7 +27,9 @@ module ApiV1
       end
 
       def index
-        render DEFAULT_FORMAT => ApiV1::Config::PackageRepositoriesRepresenter.new(package_repository_service.getPackageRepositories()).to_hash(url_builder: self)
+        package_repositories = package_repository_service.getPackageRepositories()
+        json = ApiV1::Config::PackageRepositoriesRepresenter.new(package_repositories).to_hash(url_builder: self)
+        render DEFAULT_FORMAT => json if stale?(strong_etag: etag_for(package_repositories))
       end
 
       def create

--- a/server/webapp/WEB-INF/rails/app/controllers/api_v1/admin/security/auth_configs_controller.rb
+++ b/server/webapp/WEB-INF/rails/app/controllers/api_v1/admin/security/auth_configs_controller.rb
@@ -64,6 +64,10 @@ module ApiV1
           SecurityAuthConfig.new
         end
 
+        def load_all_entities_from_config
+          security_auth_config_service.getPluginProfiles
+        end
+
         def load_entity_from_config
           security_auth_config_service.findProfile(params[:auth_config_id]) || (raise RecordNotFound)
         end

--- a/server/webapp/WEB-INF/rails/app/controllers/api_v4/admin/plugin_infos_controller.rb
+++ b/server/webapp/WEB-INF/rails/app/controllers/api_v4/admin/plugin_infos_controller.rb
@@ -40,7 +40,8 @@ module ApiV4
         if params[:include_bad].to_bool
           plugin_infos += default_plugin_manager.plugins().find_all(&:isInvalid).collect {|descriptor| BadPluginInfo.new(descriptor)}
         end
-        render DEFAULT_FORMAT => Plugin::PluginInfosRepresenter.new(plugin_infos).to_hash(url_builder: self)
+        json = Plugin::PluginInfosRepresenter.new(plugin_infos).to_hash(url_builder: self)
+        render DEFAULT_FORMAT => json if stale?(strong_etag: etag_for(plugin_infos))
       rescue InvalidPluginTypeException
         raise UnprocessableEntity, "Invalid plugins type - `#{params[:type]}` !"
       end

--- a/server/webapp/WEB-INF/rails/app/helpers/api_v1/profiles_controller_actions.rb
+++ b/server/webapp/WEB-INF/rails/app/helpers/api_v1/profiles_controller_actions.rb
@@ -17,9 +17,11 @@
 module ApiV1
   module ProfilesControllerActions
     include JavaImports
+
     def index
-      all_entities_from_config = service.listAll.values.to_a
-      render BaseController::DEFAULT_FORMAT => all_entities_representer.new(all_entities_from_config.to_a).to_hash(url_builder: self)
+      all_entities_from_config = load_all_entities_from_config
+      json = all_entities_representer.new(all_entities_from_config.to_a).to_hash(url_builder: self)
+      render BaseController::DEFAULT_FORMAT => json if stale?(strong_etag: etag_for(all_entities_from_config))
     end
 
     def show

--- a/server/webapp/WEB-INF/rails/spec/controllers/api_v1/admin/internal/command_snippets_controller_spec.rb
+++ b/server/webapp/WEB-INF/rails/spec/controllers/api_v1/admin/internal/command_snippets_controller_spec.rb
@@ -22,6 +22,7 @@ describe ApiV1::Admin::Internal::CommandSnippetsController do
 
   before :each do
     allow(controller).to receive(:command_repository_service).and_return(@command_repository_service = double('command_repository_service'))
+    allow(controller).to receive(:entity_hashing_service).and_return(@entity_hashing_service = double('entity_hashing_service'))
   end
 
   describe "index" do
@@ -63,10 +64,12 @@ describe ApiV1::Admin::Internal::CommandSnippetsController do
         snippet_hash = presenter.to_hash(url_builder: controller, prefix: 'rake')
 
         expect(@command_repository_service).to receive(:lookupCommand).with('rake').and_return([snippet])
+        expect(@entity_hashing_service).to receive(:md5ForEntity).and_return("md5")
 
         get_with_api_header :index, params:{prefix: 'rake'}
 
         expect(response).to be_ok
+        expect(response.headers["ETag"]).not_to include('W/')
         expect(actual_response).to eq(JSON.parse(snippet_hash.to_json).deep_symbolize_keys)
       end
     end

--- a/server/webapp/WEB-INF/rails/spec/controllers/api_v1/admin/internal/pipelines_controller_spec.rb
+++ b/server/webapp/WEB-INF/rails/spec/controllers/api_v1/admin/internal/pipelines_controller_spec.rb
@@ -22,7 +22,9 @@ describe ApiV1::Admin::Internal::PipelinesController do
 
   before(:each) do
     @pipeline_config_service = double('pipeline_config_service')
+    @entity_hashing_service = double('entity_hashing_service')
     allow(controller).to receive('pipeline_config_service').and_return(@pipeline_config_service)
+    allow(controller).to receive('entity_hashing_service').and_return(@entity_hashing_service)
   end
 
   describe "security" do
@@ -66,10 +68,12 @@ describe ApiV1::Admin::Internal::PipelinesController do
         pipeline_configs_list = Arrays.asList(pipeline_configs)
 
         expect(@pipeline_config_service).to receive(:viewableOrOperatableGroupsFor).with(controller.current_user).and_return(pipeline_configs_list)
+        expect(@entity_hashing_service).to receive(:md5ForEntity).and_return("md5")
 
         get_with_api_header :index
 
         expect(response).to be_ok
+        expect(response.headers["ETag"]).not_to include('W/')
         expected_response = expected_response(pipeline_configs_list, ApiV1::Config::PipelineConfigsWithMinimalAttributesRepresenter)
         expect(actual_response).to eq(expected_response)
       end

--- a/server/webapp/WEB-INF/rails/spec/controllers/api_v1/admin/packages_controller_spec.rb
+++ b/server/webapp/WEB-INF/rails/spec/controllers/api_v1/admin/packages_controller_spec.rb
@@ -31,7 +31,10 @@ describe ApiV1::Admin::PackagesController do
     @package.setRepository(@package_repository)
 
     @package_definition_service = double('package-definition-service')
+    @entity_hashing_service = double('entity_hashing_service')
     allow(controller).to receive(:package_definition_service).and_return(@package_definition_service)
+    allow(controller).to receive(:entity_hashing_service).and_return(@entity_hashing_service)
+    allow(@entity_hashing_service).to receive(:md5ForEntity).and_return("md5")
   end
 
   describe "index" do
@@ -50,6 +53,7 @@ describe ApiV1::Admin::PackagesController do
 
         get_with_api_header :index
         expect(response).to be_ok
+        expect(response.headers["ETag"]).not_to include('W/')
         expect(actual_response).to eq(expected_response(packages, ApiV1::Config::PackagesRepresenter))
       end
     end

--- a/server/webapp/WEB-INF/rails/spec/controllers/api_v1/admin/pluggable_scms_controller_spec.rb
+++ b/server/webapp/WEB-INF/rails/spec/controllers/api_v1/admin/pluggable_scms_controller_spec.rb
@@ -70,10 +70,12 @@ describe ApiV1::Admin::PluggableScmsController do
         login_as_admin
 
         expect(@pluggable_scm_service).to receive(:listAllScms).and_return([@scm])
+        expect(@entity_hashing_service).to receive(:md5ForEntity).and_return("md5")
 
         get_with_api_header :index
 
         expect(response).to be_ok
+        expect(response.headers["ETag"]).not_to include('W/')
         expect(actual_response).to eq(expected_response([@scm], ApiV1::Scms::PluggableScmsRepresenter))
       end
     end

--- a/server/webapp/WEB-INF/rails/spec/controllers/api_v1/admin/repositories_controller_spec.rb
+++ b/server/webapp/WEB-INF/rails/spec/controllers/api_v1/admin/repositories_controller_spec.rb
@@ -23,7 +23,10 @@ describe ApiV1::Admin::RepositoriesController do
   before :each do
     @repo_id = 'npm'
     @package_repository_service = double('package-repository-service')
+    @entity_hashing_service = double('entity_hashing_service')
     allow(controller).to receive(:package_repository_service).and_return(@package_repository_service)
+    allow(controller).to receive(:entity_hashing_service).and_return(@entity_hashing_service)
+    allow(@entity_hashing_service).to receive(:md5ForEntity).and_return("md5")
   end
 
   describe "index" do
@@ -38,6 +41,7 @@ describe ApiV1::Admin::RepositoriesController do
 
         get_with_api_header :index
         expect(response).to be_ok
+        expect(response.headers["ETag"]).not_to include('W/')
         expect(actual_response).to eq(expected_response(all_repos, ApiV1::Config::PackageRepositoriesRepresenter))
       end
     end

--- a/server/webapp/WEB-INF/rails/spec/controllers/api_v1/security/auth_configs_controller_spec.rb
+++ b/server/webapp/WEB-INF/rails/spec/controllers/api_v1/security/auth_configs_controller_spec.rb
@@ -67,11 +67,13 @@ describe ApiV1::Admin::Security::AuthConfigsController do
         login_as_admin
 
         auth_config = SecurityAuthConfig.new('foo', 'cd.go.ldap')
-        expect(@security_auth_config_service).to receive(:listAll).and_return({'foo' => auth_config})
+        expect(@security_auth_config_service).to receive(:getPluginProfiles).and_return([auth_config])
+        expect(@entity_hashing_service).to receive(:md5ForEntity).and_return("md5")
 
         get_with_api_header :index
 
         expect(response).to be_ok
+        expect(response.headers["ETag"]).not_to include('W/')
         expect(actual_response).to eq(expected_response([auth_config], ApiV1::Security::AuthConfigsRepresenter))
       end
     end

--- a/server/webapp/WEB-INF/rails/spec/controllers/api_v4/admin/plugin_infos_controller_spec.rb
+++ b/server/webapp/WEB-INF/rails/spec/controllers/api_v4/admin/plugin_infos_controller_spec.rb
@@ -22,7 +22,9 @@ describe ApiV4::Admin::PluginInfosController do
 
   before(:each) do
     @default_plugin_info_finder = double('default_plugin_info_finder')
+    @entity_hashing_service = double('entity_hashing_service')
     allow(controller).to receive('default_plugin_info_finder').and_return(@default_plugin_info_finder)
+    allow(controller).to receive('entity_hashing_service').and_return(@entity_hashing_service)
 
     @default_plugin_manager = double('default_plugin_manager')
     allow(controller).to receive('default_plugin_manager').and_return(@default_plugin_manager)
@@ -30,6 +32,7 @@ describe ApiV4::Admin::PluginInfosController do
     metadata = com.thoughtworks.go.plugin.domain.common.Metadata.new(true, false)
     @plugin_settings = com.thoughtworks.go.plugin.domain.common.PluggableInstanceSettings.new([com.thoughtworks.go.plugin.domain.common.PluginConfiguration.new('memberOf', metadata)], notification_view)
 
+    allow(@entity_hashing_service).to receive(:md5ForEntity).and_return("md5")
   end
 
   describe "security" do
@@ -101,6 +104,7 @@ describe ApiV4::Admin::PluginInfosController do
       get_with_api_header :index
 
       expect(response).to be_ok
+      expect(response.headers["ETag"]).not_to include('W/')
       expect(actual_response).to eq(expected_response([plugin_info], ApiV4::Plugin::PluginInfosRepresenter))
     end
 


### PR DESCRIPTION
* Fix weak etag issue for following rails based APIs:
  - /go/api/admin/internal/command_snippets?prefix=foo
  - /go/api/admin/internal/pipelines
  - /go/api/admin/packages
  - /go/api/admin/scms
  - /go/api/admin/repositories
  - /go/api/admin/security/auth_configs
  - /go/api/admin/plugin_info

* Use entity hashing service to compute md5s of cruise config
  entities.