### PR TITLE
Remove obsolete `Validatable` JS class

### DIFF
--- a/server/webapp/WEB-INF/rails/webpack/models/maintenance_mode/material.ts
+++ b/server/webapp/WEB-INF/rails/webpack/models/maintenance_mode/material.ts
@@ -16,10 +16,10 @@
 import * as _ from "lodash";
 import {Stream} from "mithril/stream";
 import * as stream from "mithril/stream";
+import {ErrorMessages} from "models/mixins/error_messages";
 import {Errors, ErrorsJSON} from "models/mixins/errors";
 import {applyMixins} from "models/mixins/mixins";
 import {ValidatableMixin} from "models/mixins/new_validatable_mixin";
-import {ErrorMessages} from "models/mixins/validatable";
 import {EncryptedValue} from "views/components/forms/encrypted_value";
 
 const s             = require("helpers/string-plus");

--- a/server/webapp/WEB-INF/rails/webpack/models/materials/types.ts
+++ b/server/webapp/WEB-INF/rails/webpack/models/materials/types.ts
@@ -30,10 +30,10 @@ import {
   SvnMaterialAttributesJSON,
   TfsMaterialAttributesJSON,
 } from "models/materials/serialization";
+import {ErrorMessages} from "models/mixins/error_messages";
 import {Errors} from "models/mixins/errors";
 import {applyMixins} from "models/mixins/mixins";
 import {ValidatableMixin, Validator} from "models/mixins/new_validatable_mixin";
-import {ErrorMessages} from "models/mixins/validatable";
 import {EncryptedValue} from "views/components/forms/encrypted_value";
 
 const s        = require("helpers/string-plus");

--- a/server/webapp/WEB-INF/rails/webpack/models/mixins/error_messages.ts
+++ b/server/webapp/WEB-INF/rails/webpack/models/mixins/error_messages.ts
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import * as s from "underscore.string";
 
 export namespace ErrorMessages {
@@ -43,19 +44,4 @@ export namespace ErrorMessages {
   function humanize(str: string) {
     return s.capitalize(s.trim(s.underscored(str).replace(/_/g, " ")));
   }
-}
-
-export class Validatable {
-  errors: string[];
-
-  constructor() {
-    this.errors = [];
-  }
-
-  validatePresenceOf(attribute: string, message?: string) {
-    if (s.isBlank(attribute)) {
-      this.errors.push(attribute, message || ErrorMessages.mustBePresent(attribute));
-    }
-  }
-
 }

--- a/server/webapp/WEB-INF/rails/webpack/models/mixins/new_validatable_mixin.ts
+++ b/server/webapp/WEB-INF/rails/webpack/models/mixins/new_validatable_mixin.ts
@@ -15,8 +15,8 @@
  */
 import * as _ from "lodash";
 import * as stream from "mithril/stream";
+import {ErrorMessages} from "models/mixins/error_messages";
 import {Errors} from "models/mixins/errors";
-import {ErrorMessages} from "models/mixins/validatable";
 import * as s from "underscore.string";
 
 export interface ValidatorOptions {

--- a/server/webapp/WEB-INF/rails/webpack/models/mixins/new_validatable_mixin_spec.ts
+++ b/server/webapp/WEB-INF/rails/webpack/models/mixins/new_validatable_mixin_spec.ts
@@ -16,9 +16,9 @@
 import * as _ from "lodash";
 import * as stream from "mithril/stream";
 import {Stream} from "mithril/stream";
+import {ErrorMessages} from "models/mixins/error_messages";
 import {applyMixins} from "models/mixins/mixins";
 import {ValidatableMixin, Validator, ValidatorOptions} from "models/mixins/new_validatable_mixin";
-import {ErrorMessages} from "models/mixins/validatable";
 import * as s from "underscore.string";
 
 describe("Validatable", () => {

--- a/server/webapp/WEB-INF/rails/webpack/models/shared/plugin_infos_new/plugin_settings/plugin_settings.ts
+++ b/server/webapp/WEB-INF/rails/webpack/models/shared/plugin_infos_new/plugin_settings/plugin_settings.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 import * as _ from "lodash";
-import {Validatable} from "models/mixins/validatable";
 
 export interface ConfigValue {
   getValue(): string;
@@ -120,13 +119,12 @@ export class Configuration {
   }
 }
 
-export class PluginSettings extends Validatable {
+export class PluginSettings {
   public static readonly API_VERSION: string = "v1";
   readonly plugin_id: string;
   configuration: Configuration[];
 
   constructor(plugin_id: string, configuration?: Configuration[]) {
-    super();
     this.plugin_id     = plugin_id;
     this.configuration = configuration || [];
   }


### PR DESCRIPTION
## Context

`models/mixins/validatable.ts` is mostly used for `ErrorMessages`, despite the name.

There is a teeny, tiny class called `Validatable` which really has 1 method: `validatePresenceOf()` and is unused. The only class to use `Validatable` is `PluginSettings`, which doesn't even use any of the inherited attributes or methods of `Validatable`. Thus, this is likely some early (and cheap) implementation of `ValidatableMixin` that was long forgotten and not removed when `new_validatable_mixin` was written.

## Changes

This PR removes the class `Validatable` and renames the file to `models/mixins/error_messages.ts`. All other changes are modifications to accommodate this change.