### PR TITLE
Upgrade filesize library from v3.5.10 to v4.1.2

### DIFF
--- a/server/webapp/WEB-INF/rails/package.json
+++ b/server/webapp/WEB-INF/rails/package.json
@@ -26,7 +26,7 @@
     "classnames": "^2.2.6",
     "clipboard-polyfill": "^2.7.0",
     "details-element-polyfill": "^2.3.1",
-    "filesize": "^3.5.10",
+    "filesize": "^4.1.2",
     "font-awesome": "^4.7.0",
     "foundation-sites": "^6.2.3",
     "jquery": "^2.2.0",

--- a/server/webapp/WEB-INF/rails/yarn.lock
+++ b/server/webapp/WEB-INF/rails/yarn.lock
@@ -3637,10 +3637,10 @@ file-uri-to-path@1:
   resolved "https://registry.yarnpkg.com/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz#553a7b8446ff6f684359c445f1e37a05dacc33dd"
   integrity sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==
 
-filesize@^3.5.10:
-  version "3.6.1"
-  resolved "https://registry.yarnpkg.com/filesize/-/filesize-3.6.1.tgz#090bb3ee01b6f801a8a8be99d31710b3422bb317"
-  integrity sha512-7KjR1vv6qnicaPMi1iiTcI85CyYwRO/PSFCu6SvqL8jN2Wjt/NIYQTFtFs7fSDCYOstUkEWIQGFUg5YZQfjlcg==
+filesize@^4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/filesize/-/filesize-4.1.2.tgz#fcd570af1353cea97897be64f56183adb995994b"
+  integrity sha512-iSWteWtfNcrWQTkQw8ble2bnonSl7YJImsn9OZKpE2E4IHhXI78eASpDYUljXZZdYj36QsEKjOs/CsiDqmKMJw==
 
 fill-range@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
Filesize library is used to convert filesize from a number to a human-readable format.

To Verify the upgrade:
1. On agents SPA, check agents `Free Space` is appropriately shown.
2. On /go/about page, check `Usable space in artifacts repository` is appropriately shown.