### PR TITLE
Added onError to secret config state

### DIFF
--- a/server/webapp/WEB-INF/rails/webpack/views/pages/secret_configs.tsx
+++ b/server/webapp/WEB-INF/rails/webpack/views/pages/secret_configs.tsx
@@ -113,6 +113,10 @@ export class SecretConfigsPage extends Page<null, State> {
     vnode.state.onSuccessfulSave = (msg: m.Children) => {
       this.flashMessage.setMessage(MessageType.success, msg);
     };
+
+    vnode.state.onError = (msg: m.Children) => {
+      this.flashMessage.setMessage(MessageType.alert, msg);
+    };
   }
 
   componentToDisplay(vnode: m.Vnode<null, State>): m.Children {


### PR DESCRIPTION
Whenever we try to delete a secret config that is referenced, the error was not shown and the UI seemed to freeze.
This was because the `onError` was not set.