### PR TITLE
Fixing check connection error when secret config is refered

### DIFF
--- a/common/src/test/java/com/thoughtworks/go/config/materials/mercurial/HgMaterialTest.java
+++ b/common/src/test/java/com/thoughtworks/go/config/materials/mercurial/HgMaterialTest.java
@@ -17,6 +17,7 @@
 package com.thoughtworks.go.config.materials.mercurial;
 
 import com.thoughtworks.go.config.CaseInsensitiveString;
+import com.thoughtworks.go.config.SecretParam;
 import com.thoughtworks.go.config.materials.Filter;
 import com.thoughtworks.go.config.materials.PasswordAwareMaterial;
 import com.thoughtworks.go.domain.MaterialInstance;
@@ -25,12 +26,14 @@ import com.thoughtworks.go.domain.materials.mercurial.HgCommand;
 import com.thoughtworks.go.domain.materials.mercurial.HgVersion;
 import com.thoughtworks.go.domain.materials.mercurial.StringRevision;
 import com.thoughtworks.go.helper.HgTestRepo;
-import com.thoughtworks.go.helper.MaterialConfigsMother;
 import com.thoughtworks.go.helper.MaterialsMother;
 import com.thoughtworks.go.helper.TestRepo;
 import com.thoughtworks.go.util.JsonValue;
 import com.thoughtworks.go.util.ReflectionUtil;
-import com.thoughtworks.go.util.command.*;
+import com.thoughtworks.go.util.command.ConsoleResult;
+import com.thoughtworks.go.util.command.HgUrlArgument;
+import com.thoughtworks.go.util.command.InMemoryStreamConsumer;
+import com.thoughtworks.go.util.command.UrlArgument;
 import org.apache.commons.io.FileUtils;
 import org.junit.Rule;
 import org.junit.jupiter.api.AfterEach;
@@ -623,6 +626,19 @@ public class HgMaterialTest {
             hgMaterial.setPassword("p@ssw:rd");
 
             assertThat(hgMaterial.urlForCommandLine()).isEqualTo("http://bob%40example.com:p%40ssw:rd@exampele.com");
+        }
+
+        @Test
+        void shouldHaveResolvedUserInfoIfSecretParamsIsPresent() {
+            final HgMaterial gitMaterial = new HgMaterial("http://exampele.com", "destination");
+            gitMaterial.setUserName("bob@example.com");
+            String password = "{{SECRET:[test][id]}}";
+            gitMaterial.setPassword(password);
+
+            SecretParam secretParam = gitMaterial.getSecretParams().get(0);
+            secretParam.setValue("p@ssw:rd");
+
+            assertThat(gitMaterial.urlForCommandLine()).isEqualTo("http://bob%40example.com:p%40ssw:rd@exampele.com");
         }
     }
 

--- a/domain/src/main/java/com/thoughtworks/go/config/materials/git/GitMaterial.java
+++ b/domain/src/main/java/com/thoughtworks/go/config/materials/git/GitMaterial.java
@@ -302,7 +302,7 @@ public class GitMaterial extends ScmMaterial implements PasswordAwareMaterial {
             }
 
             return new URIBuilder(this.url.originalArgument())
-                    .setUserInfo(new UrlUserInfo(this.userName, this.getPassword()).asString())
+                    .setUserInfo(new UrlUserInfo(this.userName, this.passwordForCommandLine()).asString())
                     .build().toString();
 
         } catch (URISyntaxException e) {

--- a/domain/src/main/java/com/thoughtworks/go/config/materials/mercurial/HgMaterial.java
+++ b/domain/src/main/java/com/thoughtworks/go/config/materials/mercurial/HgMaterial.java
@@ -262,7 +262,7 @@ public class HgMaterial extends ScmMaterial implements PasswordAwareMaterial {
             }
 
             return new URIBuilder(this.url.originalArgument())
-                    .setUserInfo(new UrlUserInfo(this.userName, this.getPassword()).asString())
+                    .setUserInfo(new UrlUserInfo(this.userName, this.passwordForCommandLine()).asString())
                     .build().toString();
 
         } catch (URISyntaxException e) {

--- a/domain/src/main/java/com/thoughtworks/go/config/materials/perforce/P4Material.java
+++ b/domain/src/main/java/com/thoughtworks/go/config/materials/perforce/P4Material.java
@@ -220,7 +220,7 @@ public class P4Material extends ScmMaterial implements PasswordEncrypter, Passwo
      */
     P4Client _p4(File workDir, ConsoleOutputStreamConsumer consumer, boolean failOnError) throws Exception {
         String clientName = clientName(workDir);
-        return P4Client.fromServerAndPort(getFingerprint(), serverAndPort, userName, getPassword(), clientName, this.useTickets, workDir, p4view(clientName), consumer, failOnError);
+        return P4Client.fromServerAndPort(getFingerprint(), serverAndPort, userName, passwordForCommandLine(), clientName, this.useTickets, workDir, p4view(clientName), consumer, failOnError);
     }
 
     public void populateAgentSideEnvironmentContext(EnvironmentVariableContext environmentVariableContext, File baseDir) {

--- a/server/webapp/WEB-INF/rails/app/controllers/api_v1/admin/internal/material_test_controller.rb
+++ b/server/webapp/WEB-INF/rails/app/controllers/api_v1/admin/internal/material_test_controller.rb
@@ -26,7 +26,8 @@ module ApiV1
 
         def test
           material_config = ApiV1::Admin::Pipelines::Materials::MaterialRepresenter.new(ApiV1::Admin::Pipelines::Materials::MaterialRepresenter.get_material_type(params[:type]).new).from_hash(params)
-          material_config.validateConcreteScmMaterial(PipelineConfigSaveValidationContext.forChain(false, "group", go_config_service.cruise_config(), material_config))
+          group_name = go_config_service.findGroupNameByPipeline(CaseInsensitiveString.new(params[:pipeline_name]))
+          material_config.validateConcreteScmMaterial(PipelineConfigSaveValidationContext.forChain(false, group_name, go_config_service.cruise_config(), material_config))
           if material_config.errors.any?
             json = ApiV1::Admin::Pipelines::Materials::MaterialRepresenter.new(material_config).to_hash(url_builder: self)
             return render_message(validation_errors_as_error_message(material_config.errors), 422, {data: json})


### PR DESCRIPTION
Issue: #6369
 - Passing in the pipeline group name while validating scm material config in material_test controller
 - In check_connection command, utilizing resolved password i.e. secret resolved.
    - did for `git`, `hg`
    - need to test for `p4`